### PR TITLE
Accuracy Fixes

### DIFF
--- a/movedex.js
+++ b/movedex.js
@@ -995,7 +995,7 @@ exports.BattleMovedex = {
 	},
 	"BoneRush": {
 		num: 198,
-		accuracy: 80,
+		accuracy: 90,
 		basePower: 25,
 		category: "Physical",
 		desc: "Attacks 2-5 times in one turn; if one of these attacks breaks a target's Substitute, the target will take damage for the rest of the hits. This move has a 3/8 chance to hit twice, a 3/8 chance to hit three times, a 1/8 chance to hit four times and a 1/8 chance to hit five times. If the user of this move has Skill Link, this move will always strike five times.",
@@ -7592,7 +7592,7 @@ exports.BattleMovedex = {
 	},
 	"PoisonGas": {
 		num: 139,
-		accuracy: 90,
+		accuracy: 80,
 		basePower: 0,
 		category: "Status",
 		desc: "Poisons the target.",
@@ -9216,7 +9216,7 @@ exports.BattleMovedex = {
 	},
 	"ScaryFace": {
 		num: 184,
-		accuracy: 90,
+		accuracy: 100,
 		basePower: 0,
 		category: "Status",
 		desc: "Lowers the target's Speed by 2 stages.",


### PR DESCRIPTION
Poison Gas (80 now, incorrectly 90 before)
Scary Face (100 now, incorrectly 90 before)
Bone Rush (90 now, incorrectly 80 before)
