### PR TITLE
Oblivious Pokemon are immune to Captivate, and Captivate only works on opposite-gendered foes.

### DIFF
--- a/abilities.js
+++ b/abilities.js
@@ -1245,6 +1245,12 @@ exports.BattleAbilities = {
 				return false;
 			}
 		},
+		onTryHit: function(pokemon, target, move) {
+			if (move.id === 'captivate') {
+				this.add('-message', 'It doesn\'t affect '+pokemon.name+'... (placeholder)');
+				return null;
+			}
+		},
 		id: "oblivious",
 		name: "Oblivious",
 		rating: 0.5,

--- a/movedex.js
+++ b/movedex.js
@@ -1350,6 +1350,10 @@ exports.BattleMovedex = {
 		name: "Captivate",
 		pp: 20,
 		priority: 0,
+		onTryHit: function(pokemon, source) {
+			if ((pokemon.gender === 'M' && source.gender === 'F') || (pokemon.gender === 'F' && source.gender === 'M')) return;
+			else return false;
+		},
 		boosts: {
 			spa: -2
 		},


### PR DESCRIPTION
Changed Captivate to use onTryHit instead, works even better than before!
