### PR TITLE
Two-turn moves exploit fixed

### DIFF
--- a/movedex.js
+++ b/movedex.js
@@ -1066,13 +1066,7 @@ exports.BattleMovedex = {
 		effect: {
 			duration: 2,
 			onModifyPokemon: function(pokemon) {
-				if (pokemon.getVolatile('transformMove')) {
-					//If this was a transformed move, we actually want to lock into the transforming move
-					pokemon.lockMove(pokemon.transformMove);
-				} else {
-					//If this wasn't a transformed move, lock as normal
-					pokemon.lockMove('bounce');
-				}
+				pokemon.lockMove('bounce');
 			},
 			onSourceModifyMove: function(move) {
 
@@ -2293,13 +2287,7 @@ exports.BattleMovedex = {
 		effect: {
 			duration: 2,
 			onModifyPokemon: function(pokemon) {
-				if (pokemon.getVolatile('transformMove')) {
-					//If this was a transformed move, we actually want to lock into the transforming move
-					pokemon.lockMove(pokemon.transformMove);
-				} else {
-					//If this wasn't a transformed move, lock as normal
-					pokemon.lockMove('dig');
-				}
+				pokemon.lockMove('dig');
 			},
 			onSourceModifyMove: function(move) {
 				if (move.target === 'foeSide') return;
@@ -2423,13 +2411,7 @@ exports.BattleMovedex = {
 		effect: {
 			duration: 2,
 			onModifyPokemon: function(pokemon) {
-				if (pokemon.getVolatile('transformMove')) {
-					//If this was a transformed move, we actually want to lock into the transforming move
-					pokemon.lockMove(pokemon.transformMove);
-				} else {
-					//If this wasn't a transformed move, lock as normal
-					pokemon.lockMove('dive');
-				}
+				pokemon.lockMove('dive');
 			},
 			onSourceModifyMove: function(move) {
 				if (move.target === 'foeSide') return;
@@ -3826,13 +3808,7 @@ exports.BattleMovedex = {
 		effect: {
 			duration: 2,
 			onModifyPokemon: function(pokemon) {
-				if (pokemon.getVolatile('transformMove')) {
-					//If this was a transformed move, we actually want to lock into the transforming move
-					pokemon.lockMove(pokemon.transformMove);
-				} else {
-					//If this wasn't a transformed move, lock as normal
-					pokemon.lockMove('fly');
-				}
+				pokemon.lockMove('fly');
 			},
 			onSourceModifyMove: function(move) {
 
@@ -4039,13 +4015,7 @@ exports.BattleMovedex = {
 		effect: {
 			duration: 2,
 			onModifyPokemon: function(pokemon) {
-				if (pokemon.getVolatile('transformMove')) {
-					//If this was a transformed move, we actually want to lock into the transforming move
-					pokemon.lockMove(pokemon.transformMove);
-				} else {
-					//If this wasn't a transformed move, lock as normal
-					pokemon.lockMove('freezeshock');
-				}
+				pokemon.lockMove('freezeshock');
 			}
 		},
 		secondary: {
@@ -5705,13 +5675,7 @@ exports.BattleMovedex = {
 		effect: {
 			duration: 2,
 			onModifyPokemon: function(pokemon) {
-				if (pokemon.getVolatile('transformMove')) {
-					//If this was a transformed move, we actually want to lock into the transforming move
-					pokemon.lockMove(pokemon.transformMove);
-				} else {
-					//If this wasn't a transformed move, lock as normal
-					pokemon.lockMove('iceburn');
-				}
+				pokemon.lockMove('iceburn');
 			}
 		},
 		secondary: {
@@ -8734,13 +8698,7 @@ exports.BattleMovedex = {
 		effect: {
 			duration: 2,
 			onModifyPokemon: function(pokemon) {
-				if (pokemon.getVolatile('transformMove')) {
-					//If this was a transformed move, we actually want to lock into the transforming move
-					pokemon.lockMove(pokemon.transformMove);
-				} else {
-					//If this wasn't a transformed move, lock as normal
-					pokemon.lockMove('razorwind');
-				}
+				pokemon.lockMove('razorwind');
 			}
 		},
 		critRatio: 2,
@@ -9758,13 +9716,7 @@ exports.BattleMovedex = {
 		effect: {
 			duration: 2,
 			onModifyPokemon: function(pokemon) {
-				if (pokemon.getVolatile('transformMove')) {
-					//If this was a transformed move, we actually want to lock into the transforming move
-					pokemon.lockMove(pokemon.transformMove);
-				} else {
-					//If this wasn't a transformed move, lock as normal
-					pokemon.lockMove('shadowforce');
-				}
+				pokemon.lockMove('shadowforce');
 			},
 			onSourceModifyMove: function(move) {
 				if (move.target === 'foeSide') return;
@@ -10065,13 +10017,7 @@ exports.BattleMovedex = {
 				this.boost({def:1}, pokemon, pokemon, this.getMove('skullbash'));
 			},
 			onModifyPokemon: function(pokemon) {
-				if (pokemon.getVolatile('transformMove')) {
-					//If this was a transformed move, we actually want to lock into the transforming move
-					pokemon.lockMove(pokemon.transformMove);
-				} else {
-					//If this wasn't a transformed move, lock as normal
-					pokemon.lockMove('skullbash');
-				}
+				pokemon.lockMove('skullbash');
 			}
 		},
 		secondary: false,
@@ -10099,13 +10045,7 @@ exports.BattleMovedex = {
 		effect: {
 			duration: 2,
 			onModifyPokemon: function(pokemon) {
-				if (pokemon.getVolatile('transformMove')) {
-					//If this was a transformed move, we actually want to lock into the transforming move
-					pokemon.lockMove(pokemon.transformMove);
-				} else {
-					//If this wasn't a transformed move, lock as normal
-					pokemon.lockMove('skyattack');
-				}
+				pokemon.lockMove('skyattack');
 			}
 		},
 		secondary: {
@@ -10137,13 +10077,7 @@ exports.BattleMovedex = {
 		effect: {
 			duration: 2,
 			onModifyPokemon: function(pokemon) {
-				if (pokemon.getVolatile('transformMove')) {
-					//If this was a transformed move, we actually want to lock into the transforming move
-					pokemon.lockMove(pokemon.transformMove);
-				} else {
-					//If this wasn't a transformed move, lock as normal
-					pokemon.lockMove('skydrop');
-				}
+				pokemon.lockMove('skydrop');
 			},
 			onSourceModifyPokemon: function(pokemon) {
 				pokemon.lockMove('recharge');
@@ -10574,13 +10508,7 @@ exports.BattleMovedex = {
 		effect: {
 			duration: 2,
 			onModifyPokemon: function(pokemon) {
-				if (pokemon.getVolatile('transformMove')) {
-					//If this was a transformed move, we actually want to lock into the transforming move
-					pokemon.lockMove(pokemon.transformMove);
-				} else {
-					//If this wasn't a transformed move, lock as normal
-					pokemon.lockMove('solarbeam');
-				}
+				pokemon.lockMove('solarbeam');
 			}
 		},
 		secondary: false,

--- a/simulator.js
+++ b/simulator.js
@@ -791,6 +791,8 @@ function BattlePokemon(set, side) {
 		// actually, you can do nearly everything in effect script
 		if (!moveid || (!selfP.hasMove(moveid) && moveid !== 'recharge')) return;
 		if (moveid === 'recharge') selfP.disabledMoves['recharge'] = false;
+		//If this was a transformed move, we actually want to lock into the transforming move
+		if (selfP.getVolatile('transformMove')) moveid = selfP.transformMove;
 		var moves = selfP.moveset;
 		for (var i=0; i<moves.length; i++) {
 			if (moves[i].id !== moveid) {


### PR DESCRIPTION
bmelts told me that I shouldn't work on this only after I finished working on it, but either way I am submitting it because there is a major Prankster Copycat/Assist + Sky Attack Rayquaza team-style being exploited in (Balanced) Hackmons right now, and the metagame has become unplayable because of it. This, at the very least, fixes that metagame-relevant bug now even if bmelts / aeo want to completely redo two-turn moves in the future.

I don't consider my solution that bad, either. It's isolated to movedex.js and has appropriate behavior for locking the Pokemon into the two-turn move even when the two-turn move isn't present on your set (ie. Assist + Sky Attack). It has a few quirks, though, such as saying "XXXX used Assist!" twice in two turns instead of saying it only once on the first turn, and it accosts Assist etc. 2 PP instead of 1. I'm not sure how to fix those right now, but they are much smaller bugs than the bug this addresses. I'm open to further discussion on the matter either way, though.
