### PR TITLE
Adding Smogon Doubles to /om

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -1041,6 +1041,7 @@ function parseCommandLocal(user, cmd, target, room, socket, message) {
 			'- <a href="http://www.smogon.com/forums/showthread.php?t=3471810" target="_blank">Dream World OU</a><br />' +
 			'- <a href="http://www.smogon.com/forums/showthread.php?t=3467120" target="_blank">Glitchmons</a><br />' +
 			'- <a href="http://www.smogon.com/forums/showthread.php?t=3476006" target="_blank">Seasonal: Winter Wonderland</a>' +
+			'- <a href="http://www.smogon.com/forums/showthread.php?t=3476469" target="_blank">Smogon Doubles</a>' +
 			'</div>');
 		return false;
 		break;


### PR DESCRIPTION
Added a link to Other Metagames forum thread on Smogon Doubles to the /om !om command.
