### PR TITLE
Fixed Power Swap message

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -8403,7 +8403,7 @@ exports.BattleMovedex = {
 			source.setBoost(targetBoosts);
 			target.setBoost(sourceBoosts);
 
-			this.add('-swapboost', target, source, 'atk, spa', '[from] move: Power Swap');
+			this.add('-swapboost', source, target, 'atk, spa', '[from] move: Power Swap');
 		},
 		secondary: false,
 		target: "normal",


### PR DESCRIPTION
Fixes the Power Swap message to correctly say "<user> switched all changes to its Attack and Sp. Atk with the target!" instead of "<target> switched all changes to its Attack and Sp. Atk with the target!"
