### PR TITLE
Hopefully fixed /dex command for CAP

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -1159,6 +1159,9 @@ function parseCommandLocal(user, cmd, target, room, socket, message) {
 			generation = "rb";
 			genNumber = 1;
 		}
+		else if(template.tier.indexOf("CAP", template.tier.length - 3) !== -1) {
+			generation = "cap";
+		}
 		else {
 			generation = "bw";
 		}


### PR DESCRIPTION
I noticed that for most arguments, the /dex command either returns a correct Smogon analysis URL or displays a "pokemon not found" message.  For CAPs, however, it currently returns an incorrect URL.  I read through the source code for the "/dex" command, along with tools.js and several of the data files, and though I have not tested this code, I don't believe it would break anything (you may add a try-catch to make sure) and I believe it should fix the bug.
