### PR TITLE
Fix Gen 1 bug, Sub being attacked on first turn

### DIFF
--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -1031,6 +1031,7 @@ exports.BattleMovedex = {
 				}
 				this.runEvent('AfterSubDamage', target, source, move, damage);
 				// Add here counter damage
+				if (!target.lastAttackedBy) target.lastAttackedBy = {pokemon: source, thisTurn: true};
 				target.lastAttackedBy.move = move.id;
 				target.lastAttackedBy.damage = damage;
 				return 0; // hit


### PR DESCRIPTION
Fix Substitute being attacked on the first turn, lastAttackedBy 
object of BattlePokemon was not set yet and crashed.
