### PR TITLE
Gen I: Rest fix. One turn less

### DIFF
--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -870,8 +870,8 @@ exports.BattleMovedex = {
 			if (!target.setStatus('slp')) return false;
 			// Fail glitch when hp is 255/511 less than max
 			if (target.hp === (target.maxhp - 255) || target.hp === (target.maxhp - 511)) return false;
-			target.statusData.time = 3;
-			target.statusData.startTime = 3;
+			target.statusData.time = 2;
+			target.statusData.startTime = 2;
 			this.heal(target.maxhp); // Aeshetic only as the healing happens after you fall asleep in-game
 			this.add('-status', target, 'slp', '[from] move: Rest');
 		}


### PR DESCRIPTION
In gen 1, Rest just lasts two turns asleep, the turn of cast, 
and the next one, as in the next turn it will be awake at 
the end of the turn.
