### PR TITLE
Gen 1: Bug fix. Allow Bide with Substitute. Add flinch to Low Kick.

### DIFF
--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -654,7 +654,11 @@ exports.BattleMovedex = {
 		inherit: true,
 		accuracy: 90,
 		basePower: 50,
-		basePowerCallback: undefined
+		basePowerCallback: undefined,
+		secondary: {
+			chance: 30,
+			volatileStatus: 'flinch'
+		}
 	},
 	megadrain: {
 		inherit: true,


### PR DESCRIPTION
Allow Bide and other moves that target self with a volatile but 
have no damage to work correctly with Substitute.
Low Kick has a 30% flinch rate.
