### PR TITLE
Gen 1: Several move bug fixes

### DIFF
--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -533,8 +533,14 @@ exports.BattleMovedex = {
 					}
 					this.sides[i].removeSideCondition('lightscreen');
 					this.sides[i].removeSideCondition('reflect');
-					if (hasTox) this.sides[i].active[j].setStatus('psn');
-					this.sides[i].active[j].clearVolatile();
+					// Turns toxic to poison for user
+					if (hasTox && this.sides[i].active[j].id === source.id) {
+						this.sides[i].active[j].setStatus('psn');
+					}
+					// Clears volatile only from user
+					if (this.sides[i].active[j].id === source.id) {
+						this.sides[i].active[j].clearVolatile();
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Substitute: Pokemon couldn't use boost moves on themselves.
Draining a Substitute and breaking crashed.
Speed boosting and Attack boosting moves need to boost beside 
negating paralyze and burn respective drops.
Counter does not counter seismic toss.
Attack and speed dropping attacks reinstante paralysis' and burn's
respective drops.
