### PR TITLE
Fix IP range checking and check ids too

### DIFF
--- a/users.js
+++ b/users.js
@@ -1016,7 +1016,7 @@ var Connection = (function () {
 			this.ip = socket.remoteAddress;
 		}
 
-		if (ipSearch(this.useip, bannedIps) || useridSearch(user.userid, bannedIps)) {
+		if (ipSearch(this.ip, bannedIps) || useridSearch(user.userid, bannedIps)) {
 			// gonna kill this
 			this.banned = true;
 			this.user = null;


### PR DESCRIPTION
Until now, the IP range checking was not working. Banned and muted users could simply get a new dynamic IP to go back on the same account to keep their miss behaviour. With this fix, all IPs within the same range are found.
Also added utility to check userid on bans.
