### PR TITLE
Fix bug in Tools.prototype.getEffectiveness

### DIFF
--- a/tools.js
+++ b/tools.js
@@ -109,6 +109,10 @@ module.exports = (function () {
 			if (typeMod === 2) { // resist
 				totalTypeMod--;
 			}
+			if (typeMod === 3) { // immune
+				totalTypeMod = 0;
+				break;
+			}
 			// in case of weird situations like Gravity, immunity is
 			// handled elsewhere
 		}


### PR DESCRIPTION
Tools.prototype.getEffectiveness was not taking into account immunities (modifier 3), so for instance it would return weakness to electric on ground/flying or to fighting on dark/ghost.
