### PR TITLE
Add command cooldown

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -50,7 +50,6 @@ var cooldown = {
 		}
 	}
 };
-var doCooldown = setInterval(cooldown.pruneUsedCmds, 5000);
 
 function logCommand(command, target) {
 	if (target.indexOf(',') > -1) {
@@ -67,6 +66,7 @@ function usedRecently(command, target) {
 			var targets = splitTarget(target);
 			target = targets[0];
 		}
+		cooldown.pruneUsedCmds();
 		return (command + '-' + target in cooldown.lastCommands);
 	} else {
 		return false;


### PR DESCRIPTION
All ! commands, warn, mute, and ban are subject to command cooldown. Command cooldown avoids the same command with the same target to be used twice in a row for 5 seconds.
