### PR TITLE
Make !othermetas and !tiers less spammy

### DIFF
--- a/chat-commands.js
+++ b/chat-commands.js
@@ -1167,7 +1167,7 @@ function parseCommandLocal(user, cmd, target, room, socket, message) {
 	case 'tiers':
 	case '!banlists':
 	case '!tiers':
-		target = target.toLowerCase();
+		target = toId(target);
 		var buffer = '<div class="infobox">';
 		var matched = false;
 		if (!target || target === 'all') {


### PR DESCRIPTION
To ease the rapid flooding of text in the Lobby chat, !othermetas and !tiers have been updated in the !faq fashion to only show a specific tier at once or general information unless specified otherwise.
