### PR TITLE
Gen 4: Fix baton pass trapping.

### DIFF
--- a/mods/gen4/statuses.js
+++ b/mods/gen4/statuses.js
@@ -45,5 +45,9 @@ exports.BattleStatuses = {
 		// See http://upokecenter.dreamhosters.com/dex/?lang=en&move=182
 		inherit: true,
 		counterMax: 8
+	},
+	trapped: {
+		inherit: true,
+		noCopy: false
 	}
 };


### PR DESCRIPTION
Trapping volatile (Mean Look, Spider Web) can be passed through Baton Pass in Gen 4.
