### PR TITLE
Fix "[Pokémon] can't have ." bug for abilities.

### DIFF
--- a/tools.js
+++ b/tools.js
@@ -830,7 +830,7 @@ module.exports = (function () {
 			if (this.gen <= 2) {
 				set.ability = '';
 			}
-			if (!banlistTable['ignoreillegalabilities']) {
+			if (!banlistTable['ignoreillegalabilities'] && this.gen <= 2) {
 				if (ability.name !== template.abilities['0'] &&
 					ability.name !== template.abilities['1'] &&
 					ability.name !== template.abilities['DW']) {


### PR DESCRIPTION
If the user does not use the current Teambuilder, ie. exports an old gen mon team from PO or writes it on Export/Import, the ability check will fail and report that the Pokémon can't have an "" (empty) ability.
