### PR TITLE
Fix bug in modlog, allow to search names that begin with numbers

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -514,8 +514,11 @@ var commands = exports.commands = {
 
 	modlog: function(target, room, user, connection) {
 		if (!this.can('modlog')) return false;
-		var lines = parseInt(target || 15, 10);
-		if (lines > 100) lines = 100;
+		var lines = 0;
+		if (!target.match('[^0-9]')) { 
+			lines = parseInt(target || 15, 10);
+			if (lines > 100) lines = 100;
+		}
 		var filename = 'logs/modlog.txt';
 		var command = 'tail -'+lines+' '+filename;
 		var grepLimit = 100;


### PR DESCRIPTION
If you search a name that begins with a number, like 10asdf, parseInt will return 10 and modlog thinks you are looking for a number of lines. Fix this testing target to see if it has a non-numerical character.
