### PR TITLE
Fixed bug in ban ninja thing

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -290,7 +290,7 @@ var commands = exports.commands = {
 		}
 		if (!this.can('ban', targetUser)) return false;
 
-		if (Users.checkBanned(Object.keys(targetUser.ips)[0]) && !target) {
+		if (Users.checkBanned(Object.keys(targetUser.ips)[targetUser.ips.length()-1]) && !target) {
 			var problem = ' but was already banned';
 			return this.privateModCommand('('+targetUser.name+' would be banned by '+user.name+problem+'.)');
 		}


### PR DESCRIPTION
currently if a user ban evades and keeps the same name, you cannot re-ban him as it checks the first IP in the list. This changes it such that the command chooses the latest IP circumventing this issue.

Approved by Joim
