### PR TITLE
Add note command

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -367,13 +367,10 @@ var commands = exports.commands = {
 	 * Moderating: Other
 	 *********************************************************/
 	
-	note: function(target, room, user, connection, cmd) {
+	modnote: function(target, room, user, connection, cmd) {
 		if (!target) return this.parse('/help note');
-		target = this.splitTarget(target);
-		var targetUser = this.targetUser;
-		if (!targetUser) return this.sendReply('User '+this.targetUsername+' not found.');
 		if (!this.can('mute')) return false;
-		return this.privateModCommand('' + targetUser.name + ' has had a note added by ' + user.name + '. (' + target + ')');
+		return this.privateModCommand('(' + user.name + ' notes: ' + target + ')');
 	},
 	
 	demote: 'promote',


### PR DESCRIPTION
Add a note command that adds silently a note to a user's modlog for other auth to read without giving actual punishment and without having the whole chat knowing.
