### PR TITLE
Add Stealth Rockless OU format

### DIFF
--- a/data/formats.js
+++ b/data/formats.js
@@ -65,6 +65,19 @@ exports.BattleFormats = {
 		ruleset: ['Pokemon', 'Standard', 'Evasion Abilities Clause', 'Team Preview'],
 		banlist: ['Uber', 'Drizzle ++ Swift Swim', 'Soul Dew', 'Landorus']
 	},
+	ounostealthrock: {
+		name: "OU (no Stealth Rock)",
+		section: "Singles,"
+
+		effectType: 'Format',
+		challengeDefault: true,
+		rated: true,
+		challengeShow: true,
+		searchShow: true,
+		isTeambuilderFormat: true,
+		ruleset: ['Pokemon', 'Standard', 'Evasion Abilities Clause', 'Team Preview'],
+		banlist: ['Uber', 'Drizzle ++ Swift Swim', 'Soul Dew', 'Stealth Rock']
+	},
 	ubers: {
 		name: "Ubers",
 		section: "Singles",


### PR DESCRIPTION
The OU council needs an OU format with no Stealth Rock to study the impact on the metagame this change would have, to be able to decide on a Stealth Rock ban in gen 6, which will shape the gen 6 OU metagame.
This metagame is not the same as a suspect test, so it cohabitates with regular OU and any ongoing suspect.
More info: http://www.smogon.com/forums/showpost.php?p=4725140&postcount=196
