### PR TITLE
Fix Life Orb

### DIFF
--- a/data/items.js
+++ b/data/items.js
@@ -1803,9 +1803,9 @@ exports.BattleItems = {
 		fling: {
 			basePower: 30
 		},
-		onBasePower: function(basePower, user) {
-			user.addVolatile('lifeorb');
-			return basePower * 1.3;
+		onDamage: function(damage, target, source, effect) {
+			source.addVolatile('lifeorb');
+			return Math.round(damage * (0x14CC / 0x1000));
 		},
 		effect: {
 			duration: 1,


### PR DESCRIPTION
Life Orb is a damage modifier that is applied at the damage, not at the base power. The game computes it as damage \* (0X14CC / 0x1000) and then rounds it with round, >=.5 up, otherwise down. This is a main difference with current mechanics, so it's a serious bug since 1 HP difference in an attack may be the cause of a victory or defeat.

Math.round is here pending a BattlePokemon.prototype.damage revamp on this situations.
