### PR TITLE
Minor adjustments to random set logic, minor cleanup of code from previous commit

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -888,9 +888,9 @@ exports.BattleScripts = {
 				case 'trick': case 'switcheroo':
 					if (setupType || (hasMove['rest'] && hasMove['sleeptalk']) || hasMove['trickroom'] || hasMove['reflect'] || hasMove['lightscreen'] || hasMove['batonpass']) rejected = true;
 					break;
-				case 'dragontail':
+				case 'dragontail': case 'circlethrow':
 					if (hasMove['agility'] || hasMove['rockpolish']) rejected = true;
-					if (hasMove['whirlwind']) rejected = true;
+					if (hasMove['whirlwind'] || hasMove['roar'] || hasMove['encore']) rejected = true;
 					break;
 
 				// bit redundant to have both
@@ -995,7 +995,7 @@ exports.BattleScripts = {
 					break;
 				case 'roar':
 					// Whirlwind outclasses Roar because Soundproof
-					if (hasMove['whirlwind'] || hasMove['dragontail'] || hasMove['haze']) rejected = true;
+					if (hasMove['whirlwind'] || hasMove['dragontail'] || hasMove['haze'] || hasMove['circlethrow']) rejected = true;
 					break;
 				case 'substitute':
 					if (hasMove['uturn'] || hasMove['voltswitch'] || hasMove['pursuit']) rejected = true;
@@ -1003,7 +1003,11 @@ exports.BattleScripts = {
 				case 'fakeout':
 					if (hasMove['trick'] || hasMove['switcheroo']) rejected = true;
 					break;
-				case 'encore': case 'suckerpunch':
+				case 'encore':
+					if (hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (hasMove['whirlwind'] || hasMove['dragontail'] || hasMove['roar'] || hasMove['circlethrow']) rejected = true;
+					break;
+				case 'suckerpunch':
 					if (hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
 					break;
 				case 'cottonguard':


### PR DESCRIPTION
Changes to random set logic:
- Fixed case where Pokemon could receive Baton Pass without having anything to pass
- Focus Sash is no longer a viable item for Pokemon in the first slot if the holder has a recoil move
- If you have 3 attacking moves from the same category and Trick/Switcheroo, you will recieve Choice Band or Choice Specs instead of Choice Scarf
