### PR TITLE
Randbats: Isolated type weakness change.

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1539,10 +1539,10 @@ exports.BattleScripts = {
 			var setAbility = set.ability;
 			// Limit 1 of any type combination
 			var typeCombo = types.join();
-			if (set.ability === 'Drought' || set.ability === 'Drizzle') {
-				// Drought and Drizzle don't count towards the type combo limit
+			if (setAbility === 'Drought' || setAbility === 'Drizzle' || setAbility === 'Sand Stream' || setAbility === 'Snow Warning') {
+				// Weather doesn't count towards any limits on type combinations
 				typeCombo = setAbility;
-			}
+		   }
 			if (typeCombo in typeComboCount) continue;
 
 			// Limit number of Pokemon weak to any one type.


### PR DESCRIPTION
Isolated the change to the team generation to reject a team if it is too weak to any one type.
Basically, team generation now looks for weaknesses to any one particular type.
How strict it is about removing Pokemon is determined by `if (typeWeaknesses[t] > i)`, where `i` is the maximum number of Pokemon that are allowed to be weak to that type. Typically, 0 is too strict and 2 rejects only the worst cases. It's currently set to 1; feel free to adjust it as you see fit.
- Perhaps there should be a chance to keep the Pokemon anyway, even if it makes us weak to a type? I don't _see_ any real reduction in randomness (if `i` is 1 we usually reject about 4-7 Pokemon per side; if `i` is 2 we usually reject 0-3), but considering how we have a small chance to keep Pokemon elsewhere even if they cause issues, perhaps there should be a check included here as well.
