### PR TITLE
Add /dexsearch command

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -344,6 +344,8 @@ var commands = exports.commands = {
                         };
                 };
  
+ 		if (all && count === 0) return this.sendReply('No search parameters other than "all" were found.\nTry "/help dexsearch" for more information on this command.');
+ 
                 while (count > 0) {
                         --count;
                         var tempResults = [];


### PR DESCRIPTION
/dexsearch is a command reminiscent of TIBot's !search on IRC. It searches the Pokedex based on a set of given parameters, which can include any and/or all of the following:
- gen, which is entered as a number, e.g., "/dexsearch 1" would search for first generation Pokemon
- tier, which is drawn from the tiers in the pokedex; illegal is included, but results from it are not shown unless it is specified in the search
- type, which can be either one or two types, e.g., "/dexsearch dragon type, ground type" would search for all Pokemon with the dual-type Dragon/Ground, while "/dexsearch dragon type" would search for all Pokemon with either only Dragon-type, or with a dual-typing including Dragon-type
- moves; up to 4 moves can be given. These are checked using checkLearnset
- colour, which are drawn from the Pokedex
- ability; only one ability will be accepted. This includes unreleased abilities

and returns a list of the Pokemon that meet all of the given parameters. If 10 or less Pokemon are found, a list on Pokedex order is returned; otherwise, 10 random results are returned, as well as the number of hidden results. The rest can be shown by adding "all" as a search parameter; this cannot be broadcast, since some searches such as "/dexsearch substitute, all" return in excess of 600 results.

As an example, "/dexsearch ou, uu, earthquake, stone edge" would give
![/dexsearch ou, uu, earthquake, stone edge](http://puu.sh/3JIny.png)
while "/dexsearch ou, uu, earthquake, stone edge, all" would give
![/dexsearch ou, uu, earthquake, stone edge, all](http://puu.sh/3JIoW.png)
