### PR TITLE
NEXT: Fix Rock Wrecker and Roar of Time

### DIFF
--- a/mods/gennext/moves.js
+++ b/mods/gennext/moves.js
@@ -491,6 +491,30 @@ exports.BattleMovedex = {
 			}
 		}
 	},
+	rockwrecker: {
+		inherit: true,
+		accuracy: true,
+		basePower: 75,
+		willCrit: true,
+		self: null,
+		onHit: function(target, source) {
+			if (!target.hp) {
+				source.addVolatile('mustrecharge');
+			}
+		}
+	},
+	roaroftime: {
+		inherit: true,
+		accuracy: true,
+		basePower: 75,
+		willCrit: true,
+		self: null,
+		onHit: function(target, source) {
+			if (!target.hp) {
+				source.addVolatile('mustrecharge');
+			}
+		}
+	},
 	bide: {
 		inherit: true,
 		effect: {


### PR DESCRIPTION
This should alter Rock Wrecker and Roar of Time so that they match the other NEXT recharge moves. It also brings them in line with NEXT's current readme description.

"Recharge moves are similarly buffed. They have 75 base power, always crit, and they only recharge if they KO. Be careful - in return for a KO, they still give the foe a free switch-in and a turn to set up."
