### PR TITLE
Return correct command when using /demote

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -613,7 +613,7 @@ var commands = exports.commands = {
 			return this.sendReply('Group \'' + nextGroup + '\' does not exist.');
 		}
 		if (!user.checkPromotePermission(currentGroup, nextGroup)) {
-			return this.sendReply('/promote - Access denied.');
+			return this.sendReply('/' + cmd + ' - Access denied.');
 		}
 
 		var isDemotion = (config.groups[nextGroup].rank < config.groups[currentGroup].rank);


### PR DESCRIPTION
Previously if you used /demote and didn't have permission to it would return /promote - Access denied.
