### PR TITLE
Fixed roost mechanics

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -9661,6 +9661,12 @@ exports.BattleMovedex = {
 				}
 			}
 		},
+		onTry: function(pokemon) {
+			if (pokemon.hp === pokemon.maxhp) {
+				this.add('-fail', pokemon, 'move: Roost');
+				return false;
+			}
+		},
 		secondary: false,
 		target: "self",
 		type: "Flying"


### PR DESCRIPTION
If the user of Roost is already at full HP, its Flying type shouldn't be removed.

Instead, the move will fail.
