### PR TITLE
Fix modchat in unofficial rooms

### DIFF
--- a/command-parser.js
+++ b/command-parser.js
@@ -262,10 +262,9 @@ function canTalk(user, room, connection, message) {
 		} else {
 			var userGroup = user.group;
 			if (room.auth) {
-				if (room.auth[user.userid]) {
-					userGroup = room.auth[user.userid];
-				} else if (userGroup !== ' ') {
-					userGroup = '+';
+				var localauth = room.auth[user.userid];
+				if (localauth && config.groupsranking.indexOf(localauth) > config.groupsranking.indexOf(userGroup)) {
+					userGroup = localauth;
 				}
 			}
 			if (!user.authenticated && room.modchat === true) {


### PR DESCRIPTION
For canTalk, properly inherit user group from official rooms, in agreement with commit a153f2f51e2139f56b2ca11ed3d0c1c504be4fef

This fixes issues with modchat of level & and ~ in unofficial chat rooms: absolutely nobody was able to talk if they were set, and they could not be turned off.

Also, modchat % and + will now be removable by global moderators.
