### PR TITLE
Simple algorithm to easily mute a user that just talked.

### DIFF
--- a/command-parser.js
+++ b/command-parser.js
@@ -222,6 +222,11 @@ var parse = exports.parse = function(message, room, user, connection, levelsDeep
 	message = canTalk(user, room, connection, message);
 	if (!message) return false;
 
+	if (room.type === 'chat') {
+		if (room.recentlytalked.indexOf(user.userid) === -1) room.recentlytalked.push(user.userid);
+		if (room.recentlytalked.length > 5) room.recentlytalked.splice(0, 1);
+	}
+
 	return message;
 };
 

--- a/commands.js
+++ b/commands.js
@@ -488,11 +488,28 @@ var commands = exports.commands = {
 	m: 'mute',
 	mute: function(target, room, user) {
 		if (!target) return this.parse('/help mute');
-
-		target = this.splitTarget(target);
-		var targetUser = this.targetUser;
+		var commaIndex = target.indexOf(',');
+		if (commaIndex < 0) {
+			var targetOne = target;
+			target = '';
+		} else {
+			var targetOne = target.substr(0, commaIndex);
+			target = target.substr(commaIndex+1).trim();
+		}
+		targetUser = Users.get(targetOne);
+		if (!targetUser && room.recentlytalked) {
+			targetOne = toId(targetOne);
+			for (var i = room.recentlytalked.length - 1; i >= 0; i--) {
+				var loopid = room.recentlytalked[i];
+				if (targetOne === loopid.substr(0, targetOne.length)) {
+					targetOne = room.recentlytalked[i];
+					break;
+				}
+			}
+			targetUser = Users.get(targetOne);
+		}
 		if (!targetUser) {
-			return this.sendReply('User '+this.targetUsername+' not found.');
+			return this.sendReply('User '+ targetOne +' not found.');
 		}
 		if (!this.can('mute', targetUser, room)) return false;
 		if (targetUser.mutedRooms[room.id] || targetUser.locked || !targetUser.connected) {

--- a/rooms.js
+++ b/rooms.js
@@ -1147,6 +1147,7 @@ var ChatRoom = (function() {
 		this.destroyingLog = false;
 		this.bannedUsers = {};
 		this.bannedIps = {};
+		this.recentlytalked = [];
 
 		// `config.loglobby` is a legacy name
 		if (config.logchat || config.loglobby) {


### PR DESCRIPTION
The IDs of the last 5 users that talked in a chat room are stored, so that when Users.get fails, the first few letters of the stored IDs are compared with the argument of /mute.
