### PR TITLE
Fix error when searching for type, and change isShowAll to showAll

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Commands
  * Pokemon Showdown - http://pokemonshowdown.com/
  *


### PR DESCRIPTION
Previously when searching for Pokemon by type, any sequence of 3 or 4 characters following a type would allow for a valid search for that type, resulting to it being exploited as shown here.

![dexsearch error](http://puu.sh/4or8I.png)
