### PR TITLE
If a command is unrecognized, send the error message to the correct room.

### DIFF
--- a/command-parser.js
+++ b/command-parser.js
@@ -215,7 +215,7 @@ var parse = exports.parse = function(message, room, user, connection, levelsDeep
 
 		if (message.substr(0,1) === '/' && cmd) {
 			// To guard against command typos, we now emit an error message
-			return connection.send('The command "/'+cmd+'" was unrecognized. To send a message starting with "/'+cmd+'", type "//'+cmd+'".');
+			return connection.sendTo(room.id, 'The command "/'+cmd+'" was unrecognized. To send a message starting with "/'+cmd+'", type "//'+cmd+'".');
 		}
 	}
 


### PR DESCRIPTION
The error messages used to be redirected to the lobby.
