### PR TITLE
Security tweaks related to autoconfirmed users

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -1517,7 +1517,7 @@ var commands = exports.commands = {
 	cmd: 'query',
 	query: function(target, room, user, connection) {
 		// Avoid guest users to use the cmd errors to ease the app-layer attacks in emergency mode
-		var trustable = (!config.emergency || (user.named && user.authenticated));
+		var trustable = (!config.emergency || (user.named && user.autoconfirmed));
 		if (config.emergency && ResourceMonitor.countCmd(connection.ip, user.name)) return false;
 		var spaceIndex = target.indexOf(' ');
 		var cmd = target;

--- a/users.js
+++ b/users.js
@@ -388,6 +388,7 @@ var User = (function () {
 		this.userid = userid;
 		users[this.userid] = this;
 		this.authenticated = !!authenticated;
+		this.autoconfirmed = this.authenticated && this.autoconfirmed;
 		this.forceRenamed = !!forcible;
 
 		for (var i=0; i<this.connections.length; i++) {


### PR DESCRIPTION
In emergency mode, users now require to be not only authenticated but also autoconfirmed in order to be /cmd trustable. If they are forcibly renamed, users now get unconfirmed in much the same way as they get unauthenticated.
