### PR TITLE
Fix Octoberfest set builder

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1602,7 +1602,6 @@ exports.BattleScripts = {
 			var pokemon = seasonalPokemonList[i];
 			var template = this.getTemplate(pokemon);
 			var set = this.randomSet(template, i);
-			var hasMoves = {};
 			var trickindex = -1;
 			for (var j=0, l=set.moves.length; j<l; j++) {
 				if (set.moves[j].toLowerCase() === 'trick') {


### PR DESCRIPTION
Pokémon could lack Trick if they would have gotten it as their third movement from <i>randomSet</i>. This is now properly dealt with. (Note that no OF-pokémon gets Present from randomSet.)
