### PR TITLE
Tweak modchat message (talk and set)

### DIFF
--- a/command-parser.js
+++ b/command-parser.js
@@ -283,8 +283,7 @@ function canTalk(user, room, connection, message) {
 			} else if (config.groupsranking.indexOf(userGroup) < config.groupsranking.indexOf(room.modchat)) {
 				var groupName = config.groups[room.modchat].name;
 				if (!groupName) groupName = room.modchat;
-				if (groupName === 'Administrator') connection.sendTo(room, 'Because moderated chat is set, you must be of rank ' + groupName +' to speak in '+room.id+' chat.');
-				else connection.sendTo(room, 'Because moderated chat is set, you must be of rank ' + groupName +' or higher to speak in '+room.id+' chat.');
+				connection.sendTo(room, 'Because moderated chat is set, you must be of rank ' + groupName +' or higher to speak in '+room.id+' chat.');
 				return false;
 			}
 		}

--- a/commands.js
+++ b/commands.js
@@ -779,9 +779,7 @@ var commands = exports.commands = {
 			this.add('|raw|<div class="broadcast-red"><b>Moderated chat was enabled!</b><br />Only registered users can talk.</div>');
 		} else if (!room.modchat) {
 			this.add('|raw|<div class="broadcast-blue"><b>Moderated chat was disabled!</b><br />Anyone may talk now.</div>');
-		} else if (sanitize(room.modchat) === '~') {
-         	this.add('|raw|<div class="broadcast-red"><b>Moderated chat was set to ~!</b><br />Only users of the rank ~ can talk.</div>');
-      	} else {
+		} else {
          	var modchat = sanitize(room.modchat);
          	this.add('|raw|<div class="broadcast-red"><b>Moderated chat was set to '+modchat+'!</b><br />Only users of rank '+modchat+' and higher can talk.</div>');
       	}


### PR DESCRIPTION
Change the message that is shown when Modchat is set to Administrator
when modchat is set, and someone talks in it.

Adding the room name itself to the modchat message when someone talks.
