### PR TITLE
Aegislash's Stance Change Ability correction

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2324,7 +2324,9 @@ exports.BattleAbilities = {
 		shortDesc: "The Pokemon changes form depending on how it battles.",
 		onBeforeMove: function(attacker, defender, move) {
 			if (attacker.template.baseSpecies !== 'Aegislash') return;
-			var targetSpecies = (move.category === 'Status'?'Aegislash':'Aegislash-Blade');
+			if (move.category !== 'Status') var targetSpecies = 'Aegislash-Blade';
+			else if (move.name === "King's Shield") var targetSpecies = 'Aegislash';
+			else return;
 			this.debug('target: '+targetSpecies+', current: '+attacker.template.species);
 			if (attacker.template.species !== targetSpecies && attacker.formeChange(targetSpecies)) {
 				this.add('-formechange', attacker, targetSpecies);


### PR DESCRIPTION
http://www.smogon.com/forums/threads/pok%C3%A9mon-battle-mechanics-research.3489239/page-6#post-4882411

“Non-damaging moves (besides King's Shield) will not change Forme. Test with Confide, Power Trick, Iron Defense, Autotomize, Swords Dance, and Protect do not change Formes. It will remain in whatever is was on. Tested on both Shield and Blade Formes.”
