### PR TITLE
Treat Mega formes as Gen 6 mons

### DIFF
--- a/tools.js
+++ b/tools.js
@@ -181,7 +181,7 @@ module.exports = (function () {
 			if (!template.genderRatio) template.genderRatio = {M:0.5,F:0.5};
 			if (!template.tier) template.tier = 'Illegal';
 			if (!template.gen) {
-				if (template.num >= 650 || template.forme === 'Mega') template.gen = 6;
+				if (template.num >= 650 || template.forme.substr(0,4) === 'Mega') template.gen = 6;
 				else if (template.num >= 494) template.gen = 5;
 				else if (template.num >= 387) template.gen = 4;
 				else if (template.num >= 252) template.gen = 3;


### PR DESCRIPTION
This fixes Mega formes being allowed in gen 5 BH by ignoring their position in the pokedex and just checking their forme to determine if they are gen 6, instead of being in the same gen as their standard forme.
