### PR TITLE
Improve getMove and fix Metronomes using future gen moves

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -7991,7 +7991,7 @@ exports.BattleMovedex = {
 		onHit: function(target) {
 			var moves = [];
 			for (var i in exports.BattleMovedex) {
-				var move = exports.BattleMovedex[i];
+				var move = this.getMove(i);
 				if (i !== move.id) continue;
 				if (move.isNonstandard) continue;
 				var noMetronome = {

--- a/tools.js
+++ b/tools.js
@@ -229,6 +229,7 @@ module.exports = (function () {
 				else move.gen = 0;
 			}
 			if (!move.priority) move.priority = 0;
+			if (this.gen && this.gen < move.gen) move.isNonstandard = true;
 		}
 		return move;
 	};


### PR DESCRIPTION
Now, a move is considered non standard if it is available only in future generations.
