### PR TITLE
Remove Tornadus-Therian level exception from Random Battle (74 → 70)

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1477,7 +1477,7 @@ exports.BattleScripts = {
 			Dusclops: 84, Porygon2: 82, Chansey: 78,
 
 			// Weather or teammate dependent
-			Snover: 95, Vulpix: 95, Excadrill: 78, Ninetales: 78, Tentacruel: 78, Toxicroak: 78, Venusaur: 78, "Tornadus-Therian": 74,
+			Snover: 95, Vulpix: 95, Excadrill: 78, Ninetales: 78, Tentacruel: 78, Toxicroak: 78, Venusaur: 78,
 
 			// Holistic judgment
 			Carvanha: 90, Blaziken: 74, "Deoxys-Defense": 74, "Deoxys-Speed": 74, Garchomp: 74, Thundurus: 74


### PR DESCRIPTION
Being an avid Random Battle player, I don’t believe that T-T requires weather to be good. What, Rain so its Heat Wave is weaker? It can get Air Slash instead of Hurricane, and Hurricane still has decent 70% accuracy without Rain. U-turn Regenerator and its monstrous speed are ridiculous (it outspeeds base 100 NU Pokémon like Charizard); the only thing not so good about it is its power, 109 SpA for a level 74 isn’t that good, but it can still OHKO if it gets a SE hit in; and it’s a fantastic late-game sweeper. Either way, I don’t see the reason for the exception in the first place, regardless of how good the Pokémon is, it’s not weather/teammates dependent, so I think the exception should be removed.

Regarding my Random Battle ability, I’ve been in the top 70 a year ago, and was somewhere inside/around top 100 before the latest reset, without account spamming. My current rating is terrible, because I haven’t played much and the little I played I lost many matches to bad luck.
