### PR TITLE
Partial Trapping moves now deal 1/8 of Max HP for residual damage

### DIFF
--- a/data/statuses.js
+++ b/data/statuses.js
@@ -172,9 +172,9 @@ exports.BattleStatuses = {
 				return;
 			}
 			if (this.effectData.source.item === 'bindingband') {
-				this.damage(pokemon.maxhp/8);
+				this.damage(pokemon.maxhp/6);
 			} else {
-				this.damage(pokemon.maxhp/16);
+				this.damage(pokemon.maxhp/8);
 			}
 		},
 		onEnd: function(pokemon) {

--- a/mods/gen5/statuses.js
+++ b/mods/gen5/statuses.js
@@ -5,4 +5,18 @@ exports.BattleStatuses = {
 			this.effectData.time = this.effectData.startTime;
 		}
 	}
+	partiallytrapped: {
+		inherit: true,
+		onResidual: function(pokemon) {
+			if (this.effectData.source && (!this.effectData.source.isActive || this.effectData.source.hp <= 0)) {
+				pokemon.removeVolatile('partiallytrapped');
+				return;
+			}
+			if (this.effectData.source.item === 'bindingband') {
+				this.damage(pokemon.maxhp/8);
+			} else {
+				this.damage(pokemon.maxhp/16);
+			}
+		},
+	}
 };


### PR DESCRIPTION
In Gen 5, partial trapping residual damage was 1/16 Max HP and 1/8 with
Binding Band
In Gen 6, it is now 1/8 Max HP and 1/6 with Binding Band
