### PR TITLE
Improve sixth gen check in random team builder

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1507,7 +1507,7 @@ exports.BattleScripts = {
 		var pokemonLeft = 0;
 		var pokemon = [];
 		for (var i in this.data.FormatsData) {
-			if (this.data.FormatsData[i].viableMoves && this.data.FormatsData[i].tier !== 'Limbo') {
+			if (this.data.FormatsData[i].viableMoves && this.data.FormatsData[i].num < 650) {
 				keys.push(i);
 			}
 		}


### PR DESCRIPTION
Since tier classification has begun, being in Limbo is not a necessary condition for being in 6th gen anymore.
