### PR TITLE
Implement Array.prototype.shuffle to deprecate .randomize from sugar

### DIFF
--- a/app.js
+++ b/app.js
@@ -84,6 +84,17 @@ if (!fs.existsSync('./config/config.js')) {
 	);
 }
 
+// Implement Fisher-Yates shuffle on Array prototype so it's available for all arrays on the application
+Array.prototype.shuffle = function() {
+	for (var i = this.length - 1; i > 0; i--) {
+		var j = Math.floor(Math.random() * (i + 1));
+		var temp = this[i];
+		this[i] = this[j];
+		this[j] = temp;
+	}
+	return this;
+}
+
 /*********************************************************
  * Load configuration
  *********************************************************/

--- a/config/formats.js
+++ b/config/formats.js
@@ -394,7 +394,7 @@ exports.Formats = [
 						this.add('-message', 'Treat: Uhm, these candy taste weird...');
 					};
 					var boosts = {};
-					var possibleBoosts = ['atk','def','spa','spd','spe','accuracy','evasion'].randomize();
+					var possibleBoosts = ['atk','def','spa','spd','spe','accuracy','evasion'].shuffle();
 					boosts[possibleBoosts[0]] = 2;
 					boosts[possibleBoosts[1]] = -1;
 					boosts[possibleBoosts[2]] = -1;

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -703,7 +703,7 @@ exports.BattleScripts = {
 			require('../crashlogger.js')(fakeErr, 'The randbat set generator');
 		}
 
-		var moveKeys = Object.keys(template.viableMoves || template.learnset).randomize();
+		var moveKeys = Object.keys(template.viableMoves || template.learnset).shuffle();
 		var moves = [];
 		var ability = '';
 		var item = '';
@@ -1358,9 +1358,9 @@ exports.BattleScripts = {
 				item = 'Life Orb';
 			} else if (ability === 'Unburden' && (counter['Physical'] || counter['Special'])) {
 				// Give Unburden mons a random Gem of the type of one of their damaging moves
-				var shuffledMoves = moves.randomize();
-				for (var m in shuffledMoves) {
-					var move = this.getMove(shuffledMoves[m]);
+				moves.shuffle();
+				for (var m in moves) {
+					var move = this.getMove(moves[m]);
 					if (move.basePower || move.basePowerCallback) {
 						item = move.type + ' Gem';
 						break;
@@ -1403,9 +1403,9 @@ exports.BattleScripts = {
 			} else if ((hasMove['eruption'] || hasMove['waterspout']) && !counter['Status']) {
 				item = 'Choice Scarf';
 			} else if (hasMove['substitute'] && hasMove['reversal']) {
-				var shuffledMoves = moves.randomize();
-				for (var m in shuffledMoves) {
-					var move = this.getMove(shuffledMoves[m]);
+				moves.shuffle();
+				for (var m in moves) {
+					var move = this.getMove(moves[m]);
 					if (move.basePower || move.basePowerCallback) {
 						item = move.type + ' Gem';
 						break;
@@ -1515,7 +1515,7 @@ exports.BattleScripts = {
 				keys.push(i);
 			}
 		}
-		keys = keys.randomize();
+		keys.shuffle();
 
 		// PotD stuff
 		var potd = {};
@@ -1618,7 +1618,7 @@ exports.BattleScripts = {
 			'shiftry', 'shuppet', 'skuntank', 'sneasel', 'snorlax', 'spiritomb', 'stunky', 'throh', 'toxicroak', 'tyranitar', 'umbreon',
 			'vullaby', 'weavile', 'wobbuffet', 'yamask', 'zoroark', 'zorua', 'zweilous'
 		];
-		seasonalPokemonList = seasonalPokemonList.randomize();
+		seasonalPokemonList.shuffle();
 		var team = [];
 
 		for (var i=0; i<6; i++) {

--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -326,7 +326,7 @@ exports.BattleMovedex = {
 					this.effectData.duration++;
 				}
 				var moves = pokemon.moves;
-				moves = moves.randomize();
+				moves.shuffle();
 				var move = this.getMove(moves[0]);
 				this.add('-start', pokemon, 'Disable', move.name);
 				this.effectData.move = move.id;

--- a/mods/gen1/scripts.js
+++ b/mods/gen1/scripts.js
@@ -949,7 +949,7 @@ exports.BattleScripts = {
 				keys.push(i);
 			//}
 		}
-		keys = keys.randomize();
+		keys.shuffle();
 
 		var ruleset = this.getFormat().ruleset;
 
@@ -969,7 +969,7 @@ exports.BattleScripts = {
 		template = this.getTemplate(template);
 		if (!template.exists) template = this.getTemplate('pikachu'); // Because Gen 1
 
-		var moveKeys = Object.keys(template.viableMoves || template.learnset).randomize();
+		var moveKeys = Object.keys(template.viableMoves || template.learnset).shuffle();
 		var moves = [];
 		var hasType = {};
 		hasType[template.types[0]] = true;


### PR DESCRIPTION
In order to take further steps in fully deprecating and stop using
sugar, implement the Fisher-Yates algorithm for random sorting as
a prototype of the Array object.
