### PR TITLE
Implement XY Battle Spot Doubles

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -241,6 +241,27 @@ exports.Formats = [
 		]
 	},
 	{
+		name: "XY Battle Spot Doubles (beta)",
+		section: "XY Doubles",
+		column: 2,
+
+		gameType: 'doubles',
+		onBegin: function() {
+			this.debug('cutting down to 4');
+			this.p1.pokemon = this.p1.pokemon.slice(0,4);
+			this.p1.pokemonLeft = this.p1.pokemon.length;
+			this.p2.pokemon = this.p2.pokemon.slice(0,4);
+			this.p2.pokemonLeft = this.p2.pokemon.length;
+		},
+		maxForcedLevel: 50,
+		ruleset: ['Pokemon', 'Standard GBU', 'Team Preview VGC'],
+		noPokebank: true,
+		banlist: [], // The neccessary bans are in Standard GBU
+		validateTeam: function(team, format) {
+			if (team.length < 4) return ['You must bring at least 4 Pokemon.'];
+		}
+	},
+	{
 		name: "Doubles Challenge Cup",
 		section: 'XY Doubles',
 

--- a/data/formats.js
+++ b/data/formats.js
@@ -31,6 +31,28 @@ exports.BattleFormats = {
 		ruleset: ['Sleep Clause Mod', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause', 'HP Percentage Mod'],
 		banlist: ['Illegal', 'Moody']
 	},
+	standardgbu: {
+		effectType: 'Banlist',
+		ruleset: ['Species Clause', 'Item Clause'],
+		banlist: ['Unreleased', 'Illegal', 'Dark Void', 'Soul Dew',
+			'Mewtwo',
+			'Lugia',
+			'Ho-Oh',
+			'Kyogre',
+			'Groudon',
+			'Rayquaza',
+			'Dialga',
+			'Palkia',
+			'Giratina', 'Giratina-Origin',
+			'Arceus', 'Arceus-Bug', 'Arceus-Dark', 'Arceus-Dragon', 'Arceus-Electric', 'Arceus-Fairy', 'Arceus-Fighting', 'Arceus-Fire', 'Arceus-Flying', 'Arceus-Ghost', 'Arceus-Grass', 'Arceus-Ground', 'Arceus-Ice', 'Arceus-Poison', 'Arceus-Psychic', 'Arceus-Rock', 'Arceus-Steel', 'Arceus-Water',
+			'Reshiram',
+			'Zekrom',
+			'Kyurem-White',
+			'Xerneas',
+			'Yveltal',
+			'Zygarde'
+		]
+	},
 	pokemon: {
 		effectType: 'Banlist',
 		validateSet: function(set, format) {


### PR DESCRIPTION
This commit also introduces the 'Standard GBU' ruleset, which bans Dark
Void, Soul Dew, and the many banned legends in VGC and GBU
