### PR TITLE
Quick Guard blocks all priority moves

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -2999,6 +2999,8 @@ var Battle = (function() {
 					var priority = decision.move.priority;
 					priority = this.runEvent('ModifyPriority', decision.pokemon, target, decision.move, priority);
 					decision.priority = priority;
+					// In Gen 6, Quick Guard blocks moves with artificially enhanced priority.
+					if (this.format.gen > 5) decision.move.priority = priority;
 				}
 			}
 			if (!decision.pokemon && !decision.speed) decision.speed = 1;

--- a/data/moves.js
+++ b/data/moves.js
@@ -10012,7 +10012,6 @@ exports.BattleMovedex = {
 			onTryHit: function(target, source, effect) {
 				// Quick Guard blocks moves with positive priority, even those given increased priority by Prankster or Gale Wings.
 				// (e.g. it blocks 0 priority moves boosted by Prankster or Gale Wings)
-				// TODO: Make Quick Guard block moves with artificially enhanced priority.
 				if (effect && (effect.id === 'Feint' || this.getMove(effect.id).priority <= 0)) {
 					return;
 				}


### PR DESCRIPTION
Even ones with artificially enhanced priority

Did not expect to find the solution to this so quickly. bmelts is a champ
