### PR TITLE
Last Pokemon to faint wins

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -2921,8 +2921,9 @@ var Battle = (function() {
 		var p2fainted = this.p2.active.map(isFainted);
 	};
 	Battle.prototype.faintMessages = function() {
+		var faintData;
 		while (this.faintQueue.length) {
-			var faintData = this.faintQueue.shift();
+			faintData = this.faintQueue.shift();
 			if (!faintData.target.fainted) {
 				this.add('faint', faintData.target);
 				this.runEvent('Faint', faintData.target, faintData.source, faintData.effect);
@@ -2934,7 +2935,8 @@ var Battle = (function() {
 			}
 		}
 		if (!this.p1.pokemonLeft && !this.p2.pokemonLeft) {
-			this.win();
+			// If both players have no Pokemon left, the player whose Pokemon fainted last wins.
+			this.win(faintData.target.side);
 			return true;
 		}
 		if (!this.p1.pokemonLeft) {


### PR DESCRIPTION
In the event that both players have no Pokemon left at the end of the
turn, the player whose pokemon fainted last wins. It does not end in a
tie.
