### PR TITLE
Update for Sneasel ban

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -29,7 +29,7 @@ exports.Formats = [
 		maxLevel: 5,
 		ruleset: ['Pokemon', 'Standard', 'Team Preview', 'Little Cup'],
 		noPokebank: true,
-		banlist: ['Sonicboom', 'Dragon Rage', 'Scyther']
+		banlist: ['Sonicboom', 'Dragon Rage', 'Scyther', 'Sneasel']
 	},
 	{
 		name: "XY Battle Spot Singles (beta)",


### PR DESCRIPTION
As per http://www.smogon.com/forums/threads/sneasel-has-been-banned.3493202/page-5#post-5011892, Sneasel is now banned in LC (LC (beta) being the official Little Cup metagame for XY).
