### PR TITLE
Make hosts like heroku recognise $port

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -1,5 +1,6 @@
 // The server port - the port to run Pokemon Showdown under
-exports.port = 8000;
+var port = process.env.PORT || 8000;
+exports.port = port;
 
 // proxyip - proxy IPs with trusted X-Forwarded-For headers
 //   This can be either false (meaning not to trust any proxies) or an array


### PR DESCRIPTION
The above command line 'var port = process.env.PORT || 8000;', makes heroku to respond or it just returns with a timeout.
