### PR TITLE
updated LC auto-leveling

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -186,6 +186,7 @@ exports.Formats = [
 
 		mod: 'gen5',
 		maxLevel: 5,
+		defaultLevel: 5,
 		ruleset: ['Pokemon', 'Standard', 'Team Preview', 'Little Cup'],
 		banlist: ['Sonicboom', 'Dragon Rage', 'Berry Juice', 'Carvanha', 'Meditite', 'Gligar', 'Scyther', 'Sneasel', 'Tangela', 'Vulpix', 'Yanma', 'Soul Dew']
 	},


### PR DESCRIPTION
Allows Little Cup pokémon to be autoset at level 5 when building a team if you selected LC or Pokebank LC as the tier choice, instead of manually editing it for right shown stats.
