### PR TITLE
Allowed level >100 pokes in gen 6 custom game

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -104,7 +104,7 @@ exports.Formats = [
 		searchShow: false,
 		canUseRandomTeam: true,
 		debug: true,
-		maxLevel: 1000,
+		maxLevel: 9999,
 		defaultLevel: 100,
 		// no restrictions, for serious (other than team preview)
 		ruleset: ['Team Preview']
@@ -225,7 +225,7 @@ exports.Formats = [
 		searchShow: false,
 		canUseRandomTeam: true,
 		debug: true,
-		maxLevel: 1000,
+		maxLevel: 9999,
 		defaultLevel: 100,
 		// no restrictions, for serious (other than team preview)
 		ruleset: ['Team Preview']
@@ -344,6 +344,8 @@ exports.Formats = [
 		gameType: 'doubles',
 		searchShow: false,
 		canUseRandomTeam: true,
+		maxLevel: 9999,
+		defaultLevel: 100,
 		debug: true,
 		ruleset: ['Team Preview']
 	},
@@ -428,7 +430,7 @@ exports.Formats = [
 		searchShow: false,
 		canUseRandomTeam: true,
 		debug: true,
-		maxLevel: 1000,
+		maxLevel: 9999,
 		defaultLevel: 100,
 		// no restrictions, for serious (other than team preview)
 		ruleset: ['Team Preview']


### PR DESCRIPTION
This would be good for non-serious formats, that require level >100 pokes. I also bumped the max to 9999, because that also allows for some new fun ways to play.
