### PR TITLE
Hack: Manually call the timeout callback for connections where the timeout somehow got cancelled

### DIFF
--- a/sockets.js
+++ b/sockets.js
@@ -195,7 +195,7 @@ if (cluster.isMaster) {
 	var sockets = {};
 	var channels = {};
 
-	// Deal with phantom xhr-streaming connections.
+	// Deal with phantom connections.
 	global.sweepClosedSockets = function() {
 		for (var s in sockets) {
 			if (sockets[s].protocol === 'xhr-streaming' &&
@@ -203,6 +203,10 @@ if (cluster.isMaster) {
 				sockets[s]._session.recv) {
 				sockets[s]._session.recv.didClose();
 			}
+
+			// A ghost connection's `_session.to_tref._idleTimeout` property is -1 while a normal timeout value for normal users.
+			// Simply calling `_session.timeout_cb` on those connections kills those connections.
+			// This timeout is the timeout that sockjs sets to wait for users to reconnect within that time to continue their session.
 			if (sockets[s]._session &&
 				sockets[s]._session.to_tref &&
 				sockets[s]._session.to_tref._idleTimeout === -1) {


### PR DESCRIPTION
After looking in to why ghost users occurred and the differences between normal users, I found that the connection's `_session.to_tref._idleTimeout` property was -1 for all ghost users while a normal timeout value for normal users.
Simply calling `_session.timeout_cb` on those connections killed those connections.
This timeout is the timeout that sockjs sets to wait for users to reconnect within that time to continue their session.

I've tested this and it only kills the ghost connections without any collateral damage.
