### PR TITLE
Validate sets after, rather than before, legality enforcement is perform...

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -183,7 +183,7 @@ exports.Formats = [
 		gameType: 'doubles',
 		ruleset: ['Pokemon', 'Standard', 'Evasion Abilities Clause', 'Team Preview'],
 		banlist: ['Dark Void', 'Soul Dew',
-			'Mewtwo', 'Mewtwo-Mega-X', 'Mewtwo-Mega-Y',
+			'Mewtwo',
 			'Lugia',
 			'Ho-Oh',
 			'Kyogre',
@@ -208,7 +208,7 @@ exports.Formats = [
 		gameType: 'doubles',
 		ruleset: ['Pokemon', 'Standard', 'Evasion Abilities Clause', 'Team Preview'],
 		banlist: ['Dark Void', 'Soul Dew',
-			'Mewtwo', 'Mewtwo-Mega-X', 'Mewtwo-Mega-Y',
+			'Mewtwo',
 			'Lugia',
 			'Ho-Oh',
 			'Kyogre',
@@ -747,7 +747,7 @@ exports.Formats = [
 			'Ho-Oh',
 			'Kangaskhanite',
 			'Arceus', 'Arceus-Bug', 'Arceus-Dark', 'Arceus-Dragon', 'Arceus-Electric', 'Arceus-Fairy', 'Arceus-Fighting', 'Arceus-Fire', 'Arceus-Flying', 'Arceus-Ghost', 'Arceus-Grass', 'Arceus-Ground', 'Arceus-Ice', 'Arceus-Poison', 'Arceus-Psychic', 'Arceus-Rock', 'Arceus-Steel', 'Arceus-Water',
-			'Mewtwo', 'Mewtwo-Mega-X', 'Mewtwo-Mega-Y',
+			'Mewtwo',
 			'Yveltal',
 			'Xerneas'
 		]

--- a/data/formats.js
+++ b/data/formats.js
@@ -25,7 +25,7 @@ exports.BattleFormats = {
 		effectType: 'Banlist',
 		ruleset: ['Species Clause', 'Item Clause'],
 		banlist: ['Unreleased', 'Illegal', 'Soul Dew',
-			'Mewtwo', 'Mewtwo-Mega-X', 'Mewtwo-Mega-Y',
+			'Mewtwo',
 			'Lugia',
 			'Ho-Oh',
 			'Kyogre',

--- a/tools.js
+++ b/tools.js
@@ -828,6 +828,19 @@ module.exports = (function () {
 		var nameTemplate = this.getTemplate(set.name);
 		if (nameTemplate.exists && nameTemplate.name.toLowerCase() === set.name.toLowerCase()) set.name = null;
 		set.species = set.species;
+
+		if (format.ruleset) {
+			for (var i=0; i<format.ruleset.length; i++) {
+				var subformat = this.getFormat(format.ruleset[i]);
+				if (subformat.validateSet) {
+					problems = problems.concat(subformat.validateSet.call(this, set, format)||[]);
+				}
+			}
+		}
+		if (format.validateSet) {
+			problems = problems.concat(format.validateSet.call(this, set, format)||[]);
+		}
+
 		set.name = set.name || set.species;
 		var name = set.species;
 		if (set.species !== set.name) name = set.name + " ("+set.species+")";
@@ -1046,18 +1059,6 @@ module.exports = (function () {
 				clause = format.name ? " by "+format.name : '';
 				problems.push(name+" has the combination of "+bannedCombo+", which is banned"+clause+".");
 			}
-		}
-
-		if (format.ruleset) {
-			for (var i=0; i<format.ruleset.length; i++) {
-				var subformat = this.getFormat(format.ruleset[i]);
-				if (subformat.validateSet) {
-					problems = problems.concat(subformat.validateSet.call(this, set, format)||[]);
-				}
-			}
-		}
-		if (format.validateSet) {
-			problems = problems.concat(format.validateSet.call(this, set, format)||[]);
 		}
 
 		if (!problems.length) return false;


### PR DESCRIPTION
...ed.

This gets rid of the need of listing all the mega-evos as well when banning a pokémon.
It also prevents the use of Meloetta in GBU formats by crafting a Meloetta-Pirouette (not specifically banned) with Relic Song, which used to be changed to the base forme, thus by-passing the ban.
