### PR TITLE
Make chat-plugins functionable

### DIFF
--- a/app.js
+++ b/app.js
@@ -428,3 +428,5 @@ fs.readFile('./config/ipbans.txt', function (err, data) {
 	}
 	Users.checkRangeBanned = Cidr.checker(rangebans);
 });
+/* Chat plugins like scavengers*/ 
+global.plugins = require('./chat-plugins.js')


### PR DESCRIPTION
The chat-plugins.js will not be read by app.js if the "global.plugins = require('./chat-plugins.js')" is not present so therefore plugins will not be useable without the above.
