### PR TITLE
Fix dexsearch giving all pokemon for any move combination

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -428,7 +428,7 @@ var commands = exports.commands = {
 							if (!template.learnset.sketch && !template.learnset[move.id]) break;
 						}
 					}
-					if (!problem) results.add(tempResults[mon]);
+					if (template.learnset[move.id] || template.learnset.sketch) results.add(tempResults[mon]);
 				}
 				moves.count = 0;
 				continue;


### PR DESCRIPTION
Zarel's fix caused dexsearch to give every mon as a result for a move search

[11:22:24] <%Arcticblast> %Kiba Roserade: !dexsearch Boomburst
[11:22:24] <%Arcticblast> Shelgon, Zygarde, Venusaur, Venusaur-Mega, Charmander, Charmeleon, Yveltal, Charizard-Mega-X, Xerneas, Squirtle, and 791 more. Redo the search with "all" as a search parameter to show all results.
