### PR TITLE
Mentorship intro command

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -656,7 +656,7 @@ var commands = exports.commands = {
 	smogintro: function(target, room, user) {
 		if (!this.canBroadcast()) return;
 		this.sendReplyBox('Welcome to Smogon\'s Official Pokémon Showdown server!<br /><br />' + 
-			'Here are some useful links to Smogon\'s Mentorship Program to help integrate you into Smogon\'s community:<br />' +
+			'Here are some useful links to Smogon\'s Mentorship Program to help you get integrated into the community:<br />' +
 			'- <a href="http://www.smogon.com/mentorship/primer">Smogon Primer: A brief introduction to Smogon\'s subcommunities</a><br />' +
 			'- <a href="http://www.smogon.com/mentorship/introductions">Introduce yourself to Smogon!</a><br />' +
 			'- <a href="http://www.smogon.com/mentorship/profiles">Profiles of current Smogon Mentors</a><br />' +


### PR DESCRIPTION
As requested by user: Redew

[18:25:54] <Redew>  we have an !intro command, but could we have a !smogonintro one too? one that links to the primer and the mentorship hub/forum?
[18:26:00] <Redew> zarel said to talk to you about it
