### PR TITLE
Fixes for item removal

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -131,7 +131,7 @@ exports.BattleAbilities = {
 		num: 83
 	},
 	"anticipation": {
-		desc: "A warning is displayed if an opposing Pokemon has the moves Fissure, Guillotine, Horn Drill, Sheer Cold, or any attacking move from a type that is considered super effective against this Pokemon (including Counter, Mirror Coat, and Metal Burst). Hidden Power, Judgment, Natural Gift and Weather Ball are considered Normal-type moves.",
+		desc: "A warning is displayed if an opposing Pokemon has the moves Fissure, Guillotine, Horn Drill, Sheer Cold, or any attacking move from a type that is considered super effective against this Pokemon (including Counter, Mirror Coat, and Metal Burst). Hidden Power, Judgment, Natural Gift and Weather Ball are considered Normal-type moves. Flying Press is considered a Fighting-type move.",
 		shortDesc: "On switch-in, this Pokemon shudders if any foe has a super effective or OHKO move.",
 		onStart: function(pokemon) {
 			var targets = pokemon.side.foe.active;
@@ -139,7 +139,7 @@ exports.BattleAbilities = {
 				if (targets[i].fainted) continue;
 				for (var j=0; j<targets[i].moveset.length; j++) {
 					var move = this.getMove(targets[i].moveset[j].move);
-					if (move.category !== 'Status' && (this.getImmunity(move.type, pokemon) && this.getEffectiveness(move, pokemon) > 0 || move.ohko)) {
+					if (move.category !== 'Status' && (this.getImmunity(move.type, pokemon) && this.getEffectiveness(move.type, pokemon) > 0 || move.ohko)) {
 						this.add('-message', pokemon.name+' shuddered! (placeholder)');
 						return;
 					}


### PR DESCRIPTION
Neither Fling nor Natural Gift triggered Unburden.
Mails removed by Knock Off were recyclable and did not trigger Unburden either.
Flinged Air Balloons and Eject Buttons were unaffected by Pick Up.
Implemented function pokemon.tossItem, for removing items that would be affected by Recycle and Pick Up, while detecting the removal and triggering a TossItem event.
Replaced the boolean pokemon.usedItemThisTurn by the object pokemon.lastItemTurnData to track the way in which the item was removed.
