### PR TITLE
Implement userid based banning and locking

### DIFF
--- a/users.js
+++ b/users.js
@@ -641,8 +641,6 @@ var User = (function () {
 	User.prototype.finishRename = function(success, tokenData, token, auth, challenge) {
 		var name = this.renamePending;
 		var userid = toUserid(name);
-		// Check if the user id is banned
-		
 		var expired = false;
 		var invalidHost = false;
 


### PR DESCRIPTION
With more RAM on the server and the ease of evading bans and locks discovered and known by 
everyone, it's necessary to start keeping track of banned userids so they have to, at least, change 
userids and thus avoid evading modchat autoregistered to spam and do other evil stuff of the sort.
