### PR TITLE
More trivial updates - /dexsearch and /intro

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -343,7 +343,7 @@ var commands = exports.commands = {
 		var dex = {};
 		for (var pokemon in Tools.data.Pokedex) {
 			var template = Tools.getTemplate(pokemon);
-			if (template.tier !== 'Illegal' && (template.tier !== 'CAP' || (searches['tier'] && 'cap' in searches['tier'])) && (!megasOnly || template.forme in {'Mega':1,'Mega-X':1,'Mega-Y':1})) {
+			if (template.tier !== 'Illegal' && (template.tier !== 'CAP' || (searches['tier'] && 'cap' in searches['tier'])) && (!megasOnly || template.isMega)) {
 				dex[pokemon] = template;
 			}
 		}
@@ -401,17 +401,16 @@ var commands = exports.commands = {
 			}
 		}
 
-		var results = Object.keys(dex).map(function(speciesid) {return dex[speciesid].species});
+		var results = [];
+		// While a direct map would be faster, this ensures the results are printed in Pokedex order
+		for (var mon in Tools.data.Pokedex) if (mon in dex) results.push(dex[mon].species);
 		var resultsStr = '';
 		if (results.length > 0) {
 			if (showAll || results.length <= output) {
 				resultsStr = results.join(', ');
 			} else {
-				var hidden = string(results.length - output);
 				results.sort(function(a,b) {return Math.round(Math.random());});
-				var shown = results.slice(0, 10);
-				resultsStr = shown.join(', ');
-				resultsStr += ', and ' + hidden + ' more. Redo the search with "all" as a search parameter to show all results.';
+				resultsStr = results.slice(0, 10).join(', ') + ', and ' + string(results.length - output) + ' more. Redo the search with "all" as a search parameter to show all results.';
 			}
 		} else {
 			resultsStr = 'No Pokémon found.';


### PR DESCRIPTION
@Slayer95 jsyk I'm reverting part of your dexsearch optimisation because, while your update was correct and slightly faster, this way ensures accuracy at the cost of minimal speed (it prints the results in pokedex order instead of the order they were in the dex object, which has an effect where movepool problems occur, such as /dexsearch dragon rage, blast burn - your way has Charmeleon last (after Zard/Zard-X/Zard-Y/Smeargle) where it should be between Charmander and Charizard, as this method places it). Perhaps the accuracy is not /that/ important but I'm somewhat of a pedant
