### PR TITLE
More consistent and accurate results for /dexsearch

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -362,6 +362,15 @@ var commands = exports.commands = {
 					break;
 
 				case 'tier':
+					for (var mon in dex) {
+						// some LC legal Pokemon are stored in other tiers (Ferroseed/Murkrow etc)
+						// this checks for LC legality using the going criteria, instead of dex[mon].tier
+						if ('lc' in searches[search]) {
+							if ((dex[mon].evos && dex[mon].evos.length === 0) || dex[mon].prevo || Tools.data.Formats['lc'].banlist.indexOf(dex[mon].species) > -1) delete dex[mon];
+						} else if (!(String(dex[mon][search]).toLowerCase() in searches[search])) delete dex[mon];
+					}
+					break;
+
 				case 'gen':
 				case 'color':
 					for (var mon in dex) {


### PR DESCRIPTION
The current version gives different results based on the order of the search terms
![](http://puu.sh/6AWGi)
This fixes that and also makes LC searches more accurate by including mons such as Ferroseed and Misdreavus which have a different tier in formats-data.js (they're both Limbo)
