### PR TITLE
Remove randbats allowing sets with no damaging moves

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1142,8 +1142,8 @@ exports.BattleScripts = {
 			if (j<moveKeys.length && moves.length === 4) {
 				// Move post-processing:
 				if (damagingMoves.length===0) {
-					// Have a 60% chance of rejecting one move at random:
-					if (Math.random()*1.66<1) moves.splice(Math.floor(Math.random()*moves.length),1);
+					// A set shouldn't have no attacking moves
+					moves.splice(Math.floor(Math.random()*moves.length),1);
 				} else if (damagingMoves.length===1) {
 					// Night Shade, Seismic Toss, etc. don't count:
 					if (!damagingMoves[0].damage) {


### PR DESCRIPTION
[20:25:52] <%Texas> so can we
[20:25:53] <%Texas> fix
[20:25:56] <%Texas> no attacking moves mons
[20:26:00] <%Texas> in randbats
[20:31:42] <%Coronis> ^^^^^
[20:32:49] <@ Treecko> !msg joim [01:25] <%Texas> so can we [01:25] <%Texas> fix [01:25] <%Texas> no attacking moves mons [01:25] <%Texas> in randbats

I'm not really sure why it was allowed in the first place? I'll close this if there was a reason for it, but as it stands I feel like it should be changed since we get things like:
[20:34:47] <%Texas> someone reported a hoh
[20:34:49] <%Texas> hooh
[20:34:54] <%Texas> Tailwind/Roost/Sub/Wow Ho-oh
which are just terrible sets tbh
