### PR TITLE
Fixes for type change

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -233,7 +233,17 @@ var BattlePokemon = (function() {
 		this.itemData = {id: this.item};
 		this.speciesData = {id: this.speciesid};
 
-		this.types = this.baseTemplate.types;
+		this.types = [];
+		this.typesData = [];
+
+		for (var i=0, l=this.baseTemplate.types.length; i<l; i++) {
+			this.types.push(this.baseTemplate.types[i]);
+			this.typesData.push({
+				type: this.baseTemplate.types[i],
+				suppressed: false,
+				isAdded: false
+			});
+		}
 
 		if (this.set.moves) {
 			for (var i=0; i<this.set.moves.length; i++) {
@@ -646,7 +656,15 @@ var BattlePokemon = (function() {
 			return false;
 		}
 		this.transformed = true;
-		this.types = pokemon.types;
+		this.typesData = new Array();
+		for (var i=0, l=pokemon.typesData.length; i<l; i++) {
+			this.typesData.push({
+				type: pokemon.typesData[i].type,
+				suppressed: false,
+				isAdded: pokemon.typesData[i].isAdded
+			});
+		}
+		this.types = this.getTypes();
 		for (var statName in this.stats) {
 			this.stats[statName] = pokemon.stats[statName];
 		}
@@ -686,6 +704,14 @@ var BattlePokemon = (function() {
 		if (!template.abilities) return false;
 		this.template = template;
 		this.types = this.template.types;
+		this.typesData = new Array();
+		for (var i=0, l=this.types.length; i<l; i++) {
+			this.typesData.push({
+				type: this.types[i],
+				suppressed: false,
+				isAdded: false
+			});
+		}
 		if (!dontRecalculateStats) {
 			for (var statName in this.stats) {
 				var stat = this.template.baseStats[statName];
@@ -754,9 +780,7 @@ var BattlePokemon = (function() {
 				if (this.hasType(type[i])) return true;
 			}
 		} else {
-			for (var i=0; i<this.types.length; i++) {
-				if (this.types[i] === type) return true;
-			}
+			if (this.getTypes().indexOf(type) > -1) return true;
 		}
 		return false;
 	};
@@ -1106,6 +1130,17 @@ var BattlePokemon = (function() {
 		}
 		if (this.status) hpstring += ' ' + this.status;
 		return hpstring;
+	};
+	BattlePokemon.prototype.getTypes = function(getAll) {
+		var types = new Array();
+		for (var i=0, l=this.typesData.length; i<l; i++) {
+			if (getAll || !this.typesData[i].suppressed) {
+				types.push(this.typesData[i].type);
+			}
+		}
+		if (types.length) return types;
+		if (this.battle.gen >= 5) return ['Normal'];
+		return [undefined];
 	};
 	BattlePokemon.prototype.runImmunity = function(type, message) {
 		if (this.fainted) {

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -342,7 +342,14 @@ exports.BattleAbilities = {
 			if (target.isActive && move && move.effectType === 'Move' && move.category !== 'Status') {
 				if (!target.hasType(move.type)) {
 					this.add('-start', target, 'typechange', move.type, '[from] Color Change');
-					target.types = [move.type];
+					target.typesData = [{
+						type: move.type,
+						suppressed: false,
+						isAdded: false
+					}];					
+					// target.types = target.getTypes();
+
+					target.update();
 				}
 			}
 		},
@@ -1992,9 +1999,14 @@ exports.BattleAbilities = {
 		onBeforeMove: function(pokemon, target, move) {
 			if (!move) return;
 			var moveType = (move.id === 'hiddenpower' ? pokemon.hpType : move.type);
-			if (pokemon.types.join() !== moveType) {
+			if (pokemon.getTypes().join() !== moveType) {
 				this.add('-start', pokemon, 'typechange', moveType, '[from] Protean');
-				pokemon.types = [moveType];
+				pokemon.typesData = [{
+					type: moveType,
+					suppressed: false,
+					isAdded: false
+				}];
+				// pokemon.types = pokemon.getTypes();
 			}
 		},
 		id: "protean",

--- a/data/moves.js
+++ b/data/moves.js
@@ -1505,7 +1505,12 @@ exports.BattleMovedex = {
 			else if (this.isTerrain('mistyterrain')) newType = 'Fairy';
 
 			this.add('-start', target, 'typechange', newType);
-			target.types = [newType];
+			target.typesData = [{
+				type: newType,
+				suppressed: false,
+				isAdded: false
+			}];
+			// target.types = target.getTypes();
 		},
 		secondary: false,
 		target: "self",
@@ -1888,7 +1893,12 @@ exports.BattleMovedex = {
 			}
 			var type = possibleTypes[this.random(possibleTypes.length)];
 			this.add('-start', target, 'typechange', type);
-			target.types = [type];
+			target.typesData = [{
+				type: type,
+				suppressed: false,
+				isAdded: false
+			}];
+			// target.types = target.getTypes();
 		},
 		secondary: false,
 		target: "self",
@@ -1924,7 +1934,12 @@ exports.BattleMovedex = {
 			}
 			var type = possibleTypes[this.random(possibleTypes.length)];
 			this.add('-start', source, 'typechange', type);
-			source.types = [type];
+			source.typesData = [{
+				type: type,
+				suppressed: false,
+				isAdded: false
+			}];
+			// source.types = source.getTypes();
 		},
 		secondary: false,
 		target: "normal",
@@ -4540,9 +4555,16 @@ exports.BattleMovedex = {
 		priority: 0,
 		isBounceable: true,
 		onHit: function(target) {
-			if (target.hasType("Grass")) return false;
-			target.types = target.types.slice(0,2).concat(["Grass"]);
-			this.add("-start", target, "typechange", target.types.join("/"), "[from] move: Forest's Curse");
+			if (target.hasType('Grass')) return false;
+			target.typesData = target.typesData.filter(function(typeData) {
+				return !typeData.isAdded;
+			}).concat([{
+				type: 'Grass',
+				suppressed: false,
+				isAdded: true
+			}]);
+			// target.types = target.getTypes();
+			this.add('-start', target, 'typechange', target.getTypes(true).join('/'), '[from] move: Forest\'s Curse');
 		},
 		secondary: false,
 		target: "normal",
@@ -4580,15 +4602,14 @@ exports.BattleMovedex = {
 		getEffectiveness: function(source, target, pokemon) {
 			var type = source.type || source;
 			var totalTypeMod = 0;
-			var tarType = '';
-			for (var i=0; i<target.types.length; i++) {
-				tarType = target.types[i];
-				if (!this.data.TypeChart[tarType]) continue;
-				if (tarType === 'Water') {
+			var types = target.getTypes();
+			for (var i=0; i<types.length; i++) {
+				if (!this.data.TypeChart[types[i]]) continue;
+				if (types[i] === 'Water') {
 					totalTypeMod++;
 					continue;
 				}
-				var typeMod = this.data.TypeChart[tarType].damageTaken[type];
+				var typeMod = this.data.TypeChart[types[i]].damageTaken[type];
 				if (typeMod === 1) { // super-effective
 					totalTypeMod++;
 				}
@@ -10336,8 +10357,17 @@ exports.BattleMovedex = {
 		pp: 15,
 		priority: 0,
 		onHit: function(target, source) {
-			this.add('-start', source, 'typechange', target.types.join('/'), '[from] move: Reflect Type', '[of] '+target);
-			source.types = target.types;
+			this.add('-start', source, 'typechange', target.getTypes(true).join('/'), '[from] move: Reflect Type', '[of] '+target);
+			source.typesData = new Array();
+			for (var i=0, l=target.typesData; i<l; i++) {
+				if (target.typesData[i].suppressed) continue;
+				source.typesData.push({
+					type: target.typesData[i].type,
+					suppressed: false,
+					isAdded: target.typesData[i].isAdded
+				});
+			}
+			// source.types = source.getTypes();
 		},
 		secondary: false,
 		target: "normal",
@@ -10828,33 +10858,31 @@ exports.BattleMovedex = {
 		effect: {
 			duration: 1,
 			onStart: function(pokemon) {
-				// This is not how Roost "should" be implemented, but is rather
-				// a simplification.
-
-				// This implementation has the advantage of not requiring a separate
-				// event just for Roost, and the only difference would come up in
-				// Doubles Hackmons. If we ever introduce Doubles Hackmons and
-				// Color Change Roost becomes popular; I might need to revisit this
-				// implementation. :P
-
-				if (pokemon.hasType('Flying')) {
-					// don't just delete the type; since
-					// the types array may be a pointer to the
-					// types array in the Pokedex.
-					this.effectData.oldTypes = pokemon.types;
-					if (pokemon.types[0] === 'Flying') {
-						pokemon.types = [pokemon.types[1] || 'Normal'];
-					} else {
-						pokemon.types = [pokemon.types[0]];
+				for (var i=0, l=pokemon.typesData.length; i<l; i++) {
+					if (pokemon.typesData[i].type === 'Flying') {
+						pokemon.typesData[i].suppressed = true;
+						break;
 					}
-					this.effectData.roostTypeString = pokemon.types.join(',');
 				}
-				//pokemon.negateImmunity['Ground'] = 1;
+				// pokemon.types = pokemon.getTypes();
+			},
+			onModifyPokemon: function(pokemon) {
+				for (var i=0, l=pokemon.typesData.length; i<l; i++) {
+					if (pokemon.typesData[i].type === 'Flying') {
+						pokemon.typesData[i].suppressed = true;
+						break;
+					}
+				}
+				// pokemon.types = pokemon.getTypes();
 			},
 			onEnd: function(pokemon) {
-				if (this.effectData.roostTypeString === pokemon.types.join(',')) {
-					pokemon.types = this.effectData.oldTypes;
+				for (var i=0, l=pokemon.typesData.length; i<l; i++) {
+					if (pokemon.typesData[i].type === 'Flying') {
+						pokemon.typesData[i].suppressed = false;
+						break;
+					}
 				}
+				// pokemon.types = pokemon.getTypes();
 			}
 		},
 		secondary: false,
@@ -12217,7 +12245,12 @@ exports.BattleMovedex = {
 		isBounceable: true,
 		onHit: function(target) {
 			this.add('-start', target, 'typechange', 'Water');
-			target.types = ['Water'];
+			target.typesData = [{
+				type: 'Water',
+				suppressed: false,
+				isAdded: false
+			}];
+			// target.types = target.getTypes();
 		},
 		secondary: false,
 		target: "normal",
@@ -13194,7 +13227,7 @@ exports.BattleMovedex = {
 		pp: 15,
 		priority: 0,
 		onTryHit: function(target, source) {
-			return target.hasType(source.types);
+			return target.hasType(source.getTypes());
 		},
 		secondary: false,
 		target: "allAdjacent",
@@ -13891,8 +13924,15 @@ exports.BattleMovedex = {
 		isBounceable: true,
 		onHit: function(target) {
 			if (target.hasType('Ghost')) return false;
-			target.types = target.types.slice(0,2).concat(['Ghost']);
-			this.add('-start', target, 'typechange', target.types.join('/'), '[from] move: Trick-or-Treat');
+			target.typesData = target.typesData.filter(function(typeData) {
+				return !typeData.isAdded;
+			}).concat([{
+				type: 'Ghost',
+				suppressed: false,
+				isAdded: true
+			}]);
+			// target.types = target.getTypes();
+			this.add('-start', target, 'typechange', target.getTypes(true).join('/'), '[from] move: Trick-or-Treat');
 		},
 		secondary: false,
 		target: "normal",

--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -247,15 +247,22 @@ exports.BattleMovedex = {
 		effect: {
 			noCopy: true,
 			onStart: function(target, source) {
-				this.effectData.types = target.types;
-				this.add('-start', source, 'typechange', target.types.join(', '), '[from] move: Conversion', '[of] '+target);
+				this.effectData.typesData = new Array();
+				for (var i=0, l=target.typesData.length; i<l; i++) {
+					this.effectData.typesData.push(Object.clone(target.typesData[i]));
+				}
+				this.add('-start', source, 'typechange', target.getTypes(true).join(', '), '[from] move: Conversion', '[of] '+target);
 			},
 			onRestart: function(target, source) {
-				this.effectData.types = target.types;
-				this.add('-start', source, 'typechange', target.types.join(', '), '[from] move: Conversion', '[of] '+target);
+				this.effectData.typesData = new Array();
+				for (var i=0, l=target.typesData.length; i<l; i++) {
+					this.effectData.typesData.push(Object.clone(target.typesData[i]));
+				}
+				this.add('-start', source, 'typechange', target.getTypes(true).join(', '), '[from] move: Conversion', '[of] '+target);
 			},
 			onModifyPokemon: function(pokemon) {
-				pokemon.types = this.effectData.types;
+				pokemon.typesData = this.effectData.typesData;
+				// pokemon.types = pokemon.getTypes();
 			}
 		}
 	},

--- a/mods/gen4/moves.js
+++ b/mods/gen4/moves.js
@@ -742,42 +742,6 @@ exports.BattleMovedex = {
 		inherit: true,
 		accuracy: 80
 	},
-	roost: {
-		inherit: true,
-		effect: {
-			duration: 1,
-			onStart: function(pokemon) {
-				// This is not how Roost "should" be implemented, but is rather
-				// a simplification.
-
-				// This implementation has the advantage of not requiring a separate
-				// event just for Roost, and the only difference would come up in
-				// Doubles Hackmons. If we ever introduce Doubles Hackmons and
-				// Color Change Roost becomes popular; I might need to revisit this
-				// implementation. :P
-
-				if (pokemon.hasType('Flying')) {
-					// don't just delete the type; since
-					// the types array may be a pointer to the
-					// types array in the Pokedex.
-					this.effectData.oldTypes = pokemon.types;
-					if (pokemon.types[0] === 'Flying') {
-						// Pure Flying-types become ???-type
-						pokemon.types = [pokemon.types[1]];
-					} else {
-						pokemon.types = [pokemon.types[0]];
-					}
-					this.effectData.roostTypeString = pokemon.types.join(',');
-				}
-				//pokemon.negateImmunity['Ground'] = 1;
-			},
-			onEnd: function(pokemon) {
-				if (this.effectData.roostTypeString === pokemon.types.join(',')) {
-					pokemon.types = this.effectData.oldTypes;
-				}
-			}
-		}
-	},
 	sandtomb: {
 		inherit: true,
 		accuracy: 70,

--- a/mods/gen5/moves.js
+++ b/mods/gen5/moves.js
@@ -70,7 +70,12 @@ exports.BattleMovedex = {
 		shortDesc: "Changes user's type based on terrain. (Ground)",
 		onHit: function(target) {
 			this.add('-start', target, 'typechange', 'Ground');
-			target.types = ['Ground'];
+			target.typesData = [{
+				type: 'Ground',
+				suppressed: false,
+				isAdded: false
+			}];
+			// target.types = target.getTypes();
 		}
 	},
 	charm: {

--- a/mods/gennext/items.js
+++ b/mods/gennext/items.js
@@ -131,7 +131,7 @@ exports.BattleItems = {
 		onResidualSubOrder: 2,
 		onResidual: function(pokemon) {
 			if (pokemon.hasType('Poison')) {
-				this.heal(pokemon.maxhp/(pokemon.types.length===1 ? 8 : 16));
+				this.heal(pokemon.maxhp/(pokemon.getTypes().length===1 ? 8 : 16));
 			} else {
 				this.damage(pokemon.maxhp/8);
 			}
@@ -145,7 +145,8 @@ exports.BattleItems = {
 			basePower: 10
 		},
 		onDamage: function(damage, target, source, effect) {
-			if (target.types.length === 1 && target.types[0] === 'Fighting' &&
+			var types = target.getTypes();
+			if (types.length === 1 && types[0] === 'Fighting' &&
 					effect && effect.effectType === 'Move' &&
 					target.useItem()) {
 				if (damage >= target.hp) {
@@ -164,7 +165,8 @@ exports.BattleItems = {
 		inherit: true,
 		onBasePower: function(basePower, user, target, move) {
 			if (move.category === 'Special') {
-				if (user.types.length === 1 && user.types[0] === 'Psychic') {
+				var types = user.getTypes();
+				if (types.length === 1 && types[0] === 'Psychic') {
 					return basePower * 1.2;
 				}
 				return basePower * 1.1;
@@ -175,7 +177,8 @@ exports.BattleItems = {
 		inherit: true,
 		onBasePower: function(basePower, user, target, move) {
 			if (move.category === 'Physical') {
-				if (user.types.length === 1 && user.types[0] === 'Fighting') {
+				var types = user.getTypes();
+				if (types.length === 1 && types[0] === 'Fighting') {
 					return basePower * 1.2;
 				}
 				return basePower * 1.1;

--- a/tools.js
+++ b/tools.js
@@ -120,8 +120,9 @@ module.exports = (function () {
 		return this.name;
 	};
 	Tools.prototype.getImmunity = function(type, target) {
-		for (var i=0; i<target.types.length; i++) {
-			if (this.data.TypeChart[target.types[i]] && this.data.TypeChart[target.types[i]].damageTaken && this.data.TypeChart[target.types[i]].damageTaken[type] === 3) {
+		var types = target.getTypes && target.getTypes() || target.types;
+		for (var i=0; i<types.length; i++) {
+			if (this.data.TypeChart[types[i]] && this.data.TypeChart[types[i]].damageTaken && this.data.TypeChart[types[i]].damageTaken[type] === 3) {
 				return false;
 			}
 		}
@@ -133,9 +134,10 @@ module.exports = (function () {
 		}
 		var type = source.type || source;
 		var totalTypeMod = 0;
-		for (var i=0; i<target.types.length; i++) {
-			if (!this.data.TypeChart[target.types[i]]) continue;
-			var typeMod = this.data.TypeChart[target.types[i]].damageTaken[type];
+		var targetTypes = target.getTypes && target.getTypes() || target.types;
+		for (var i=0; i<targetTypes.length; i++) {
+			if (!this.data.TypeChart[targetTypes[i]]) continue;
+			var typeMod = this.data.TypeChart[targetTypes[i]].damageTaken[type];
 			if (typeMod === 1) { // super-effective
 				totalTypeMod++;
 			}


### PR DESCRIPTION
Fixes Trick-or-Treat and Forest´s Curse stacking.
Fixes Roost overriding other type changes when it ends.
Fixes Roost not suppressing Flying type adquired afterwards in the turn.
Fixes mons not adquiring Flying type when transforming into a roosted pokemon.
Fixes nature of types (added by Trick-or-Treat or Forest´s Curse) not being passed on use of Reflect Type or Transform.
