### PR TITLE
Improve type change

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -233,13 +233,12 @@ var BattlePokemon = (function() {
 		this.itemData = {id: this.item};
 		this.speciesData = {id: this.speciesid};
 
-		this.types = [];
+		this.types = this.baseTemplate.types;
 		this.typesData = [];
 
-		for (var i=0, l=this.baseTemplate.types.length; i<l; i++) {
-			this.types.push(this.baseTemplate.types[i]);
+		for (var i=0, l=this.types.length; i<l; i++) {
 			this.typesData.push({
-				type: this.baseTemplate.types[i],
+				type: this.types[i],
 				suppressed: false,
 				isAdded: false
 			});
@@ -656,7 +655,7 @@ var BattlePokemon = (function() {
 			return false;
 		}
 		this.transformed = true;
-		this.typesData = new Array();
+		this.typesData = [];
 		for (var i=0, l=pokemon.typesData.length; i<l; i++) {
 			this.typesData.push({
 				type: pokemon.typesData[i].type,
@@ -664,7 +663,6 @@ var BattlePokemon = (function() {
 				isAdded: pokemon.typesData[i].isAdded
 			});
 		}
-		this.types = this.getTypes();
 		for (var statName in this.stats) {
 			this.stats[statName] = pokemon.stats[statName];
 		}
@@ -703,8 +701,7 @@ var BattlePokemon = (function() {
 
 		if (!template.abilities) return false;
 		this.template = template;
-		this.types = this.template.types;
-		this.typesData = new Array();
+		this.typesData = [];
 		for (var i=0, l=this.types.length; i<l; i++) {
 			this.typesData.push({
 				type: this.types[i],
@@ -1131,8 +1128,27 @@ var BattlePokemon = (function() {
 		if (this.status) hpstring += ' ' + this.status;
 		return hpstring;
 	};
+	BattlePokemon.prototype.setType = function() {
+		this.typesData = Array.prototype.map.call(arguments, function(type) {
+			return {
+				type: type,
+				suppressed: false,
+				isAdded: false
+			}
+		});
+	};
+	BattlePokemon.prototype.addType = function(newType) {
+		// removes any types added previously and adds another one
+		this.typesData = this.typesData.filter(function(typeData) {
+			return !typeData.isAdded;
+		}).concat([{
+			type: newType,
+			suppressed: false,
+			isAdded: true
+		}]);
+	};
 	BattlePokemon.prototype.getTypes = function(getAll) {
-		var types = new Array();
+		var types = [];
 		for (var i=0, l=this.typesData.length; i<l; i++) {
 			if (getAll || !this.typesData[i].suppressed) {
 				types.push(this.typesData[i].type);
@@ -1140,7 +1156,7 @@ var BattlePokemon = (function() {
 		}
 		if (types.length) return types;
 		if (this.battle.gen >= 5) return ['Normal'];
-		return [undefined];
+		return ['???'];
 	};
 	BattlePokemon.prototype.runImmunity = function(type, message) {
 		if (this.fainted) {

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -342,13 +342,7 @@ exports.BattleAbilities = {
 			if (target.isActive && move && move.effectType === 'Move' && move.category !== 'Status') {
 				if (!target.hasType(move.type)) {
 					this.add('-start', target, 'typechange', move.type, '[from] Color Change');
-					target.typesData = [{
-						type: move.type,
-						suppressed: false,
-						isAdded: false
-					}];					
-					// target.types = target.getTypes();
-
+					target.setType(move.type);
 					target.update();
 				}
 			}
@@ -2001,12 +1995,7 @@ exports.BattleAbilities = {
 			var moveType = (move.id === 'hiddenpower' ? pokemon.hpType : move.type);
 			if (pokemon.getTypes().join() !== moveType) {
 				this.add('-start', pokemon, 'typechange', moveType, '[from] Protean');
-				pokemon.typesData = [{
-					type: moveType,
-					suppressed: false,
-					isAdded: false
-				}];
-				// pokemon.types = pokemon.getTypes();
+				pokemon.setType(moveType);
 			}
 		},
 		id: "protean",

--- a/data/moves.js
+++ b/data/moves.js
@@ -1505,12 +1505,7 @@ exports.BattleMovedex = {
 			else if (this.isTerrain('mistyterrain')) newType = 'Fairy';
 
 			this.add('-start', target, 'typechange', newType);
-			target.typesData = [{
-				type: newType,
-				suppressed: false,
-				isAdded: false
-			}];
-			// target.types = target.getTypes();
+			target.setType(newType);
 		},
 		secondary: false,
 		target: "self",
@@ -1893,12 +1888,7 @@ exports.BattleMovedex = {
 			}
 			var type = possibleTypes[this.random(possibleTypes.length)];
 			this.add('-start', target, 'typechange', type);
-			target.typesData = [{
-				type: type,
-				suppressed: false,
-				isAdded: false
-			}];
-			// target.types = target.getTypes();
+			target.setType(type);
 		},
 		secondary: false,
 		target: "self",
@@ -1934,12 +1924,7 @@ exports.BattleMovedex = {
 			}
 			var type = possibleTypes[this.random(possibleTypes.length)];
 			this.add('-start', source, 'typechange', type);
-			source.typesData = [{
-				type: type,
-				suppressed: false,
-				isAdded: false
-			}];
-			// source.types = source.getTypes();
+			source.setType(type);
 		},
 		secondary: false,
 		target: "normal",
@@ -4558,14 +4543,7 @@ exports.BattleMovedex = {
 		isBounceable: true,
 		onHit: function(target) {
 			if (target.hasType('Grass')) return false;
-			target.typesData = target.typesData.filter(function(typeData) {
-				return !typeData.isAdded;
-			}).concat([{
-				type: 'Grass',
-				suppressed: false,
-				isAdded: true
-			}]);
-			// target.types = target.getTypes();
+			target.addType('Grass');
 			this.add('-start', target, 'typechange', target.getTypes(true).join('/'), '[from] move: Forest\'s Curse');
 		},
 		secondary: false,
@@ -10361,7 +10339,7 @@ exports.BattleMovedex = {
 		priority: 0,
 		onHit: function(target, source) {
 			this.add('-start', source, 'typechange', target.getTypes(true).join('/'), '[from] move: Reflect Type', '[of] '+target);
-			source.typesData = new Array();
+			source.typesData = [];
 			for (var i=0, l=target.typesData; i<l; i++) {
 				if (target.typesData[i].suppressed) continue;
 				source.typesData.push({
@@ -10370,7 +10348,6 @@ exports.BattleMovedex = {
 					isAdded: target.typesData[i].isAdded
 				});
 			}
-			// source.types = source.getTypes();
 		},
 		secondary: false,
 		target: "normal",
@@ -10867,7 +10844,6 @@ exports.BattleMovedex = {
 						break;
 					}
 				}
-				// pokemon.types = pokemon.getTypes();
 			},
 			onModifyPokemon: function(pokemon) {
 				for (var i=0, l=pokemon.typesData.length; i<l; i++) {
@@ -10876,7 +10852,6 @@ exports.BattleMovedex = {
 						break;
 					}
 				}
-				// pokemon.types = pokemon.getTypes();
 			},
 			onEnd: function(pokemon) {
 				for (var i=0, l=pokemon.typesData.length; i<l; i++) {
@@ -10885,7 +10860,6 @@ exports.BattleMovedex = {
 						break;
 					}
 				}
-				// pokemon.types = pokemon.getTypes();
 			}
 		},
 		secondary: false,
@@ -12248,12 +12222,7 @@ exports.BattleMovedex = {
 		isBounceable: true,
 		onHit: function(target) {
 			this.add('-start', target, 'typechange', 'Water');
-			target.typesData = [{
-				type: 'Water',
-				suppressed: false,
-				isAdded: false
-			}];
-			// target.types = target.getTypes();
+			target.setType('Water');
 		},
 		secondary: false,
 		target: "normal",
@@ -13927,14 +13896,7 @@ exports.BattleMovedex = {
 		isBounceable: true,
 		onHit: function(target) {
 			if (target.hasType('Ghost')) return false;
-			target.typesData = target.typesData.filter(function(typeData) {
-				return !typeData.isAdded;
-			}).concat([{
-				type: 'Ghost',
-				suppressed: false,
-				isAdded: true
-			}]);
-			// target.types = target.getTypes();
+			target.addType('Ghost');
 			this.add('-start', target, 'typechange', target.getTypes(true).join('/'), '[from] move: Trick-or-Treat');
 		},
 		secondary: false,

--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -247,14 +247,14 @@ exports.BattleMovedex = {
 		effect: {
 			noCopy: true,
 			onStart: function(target, source) {
-				this.effectData.typesData = new Array();
+				this.effectData.typesData = [];
 				for (var i=0, l=target.typesData.length; i<l; i++) {
 					this.effectData.typesData.push(Object.clone(target.typesData[i]));
 				}
 				this.add('-start', source, 'typechange', target.getTypes(true).join(', '), '[from] move: Conversion', '[of] '+target);
 			},
 			onRestart: function(target, source) {
-				this.effectData.typesData = new Array();
+				this.effectData.typesData = [];
 				for (var i=0, l=target.typesData.length; i<l; i++) {
 					this.effectData.typesData.push(Object.clone(target.typesData[i]));
 				}
@@ -262,7 +262,6 @@ exports.BattleMovedex = {
 			},
 			onModifyPokemon: function(pokemon) {
 				pokemon.typesData = this.effectData.typesData;
-				// pokemon.types = pokemon.getTypes();
 			}
 		}
 	},


### PR DESCRIPTION
Change back pokemon.types to a pointer to the types in the dex entry.
A typeless mon now defaults to ??? rather than undefined in pokemon.getTypes()
Implement methods pokemon.setType and pokemon.addType
'setType' accepts as parameters any amount of types, with the default attributes.
'addType' accepts as parameter a single type, which will have the flag 'isAdded'.
