### PR TITLE
Making JSHint actually look helpful, and explicitly ignoring eqeqeq errors

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,9 +1,11 @@
 var gulp = require('gulp'),
+	jshintStylish = require('jshint-stylish'),
 	gutil = require('gulp-util'),// Currently unused, but gulp strongly suggested I install...
 	jshint = require('gulp-jshint'),
 	jsHintIgnore = {
 		"sub": true,
-		"smarttabs": true
+		"smarttabs": true,
+		"eqeqeq": false
 	};
 
 gulp.task('lint', function() {
@@ -13,7 +15,7 @@ gulp.task('lint', function() {
 	for(var dir in directories) {
 		gulp.src(directories[dir])
 			.pipe(jshint(jsHintIgnore))
-			.pipe(jshint.reporter('default'));
+			.pipe(jshint.reporter(jshintStylish));
 	}
 });
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "gulp-util": "~2.2.14",
     "gulp": "~3.5.2",
-    "gulp-jshint": "~1.4.0"
+    "gulp-jshint": "~1.4.0",
+    "jshint-stylish": "~0.1.5"
   }
 }


### PR DESCRIPTION
JSHint errors now look like:

``` javascript

/Users/TheIronDeveloper/workspace/Pokemon-Showdown/data/items.js
  line 1838  col 41  A leading decimal point can be confused with a dot: '.5'.
  line 2409  col 33  Missing semicolon.
  line 3903  col 23  'i' is already defined.

✖ 3 problems

```
