### PR TITLE
Fix gem interaction with selfdestruct moves

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -1047,7 +1047,7 @@ var BattlePokemon = (function() {
 	};
 	BattlePokemon.prototype.addVolatile = function(status, source, sourceEffect) {
 		var result;
-		if (!this.hp) return false;
+		if (this.fainted) return false;
 		status = this.battle.getEffect(status);
 		if (this.battle.event) {
 			if (!source) source = this.battle.event.source;


### PR DESCRIPTION
Currently gems don't boost selfdestruct moves because the pokemon's HP is reduced to 0 before `addVolatile` is called, which happens before the pokemon is considered to have fainted, and so the gem boost can never occur because `volatiles['gem']` doesn't get added. Checking if the pokemon has actually fainted fixes this, since the fainting happens after the move is completed.
