### PR TITLE
Make /warn break links

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -474,6 +474,7 @@ var commands = exports.commands = {
 
 		this.addModCommand(''+targetUser.name+' was warned by '+user.name+'.' + (target ? " (" + target + ")" : ""));
 		targetUser.send('|c|~|/warn '+target);
+		this.add('|unlink|' + targetUser.userid);
 	},
 
 	redirect: 'redir',


### PR DESCRIPTION
After creating a dedicated /linkbreak command, Zarel recommended that instead I focus on making /warn break links instead. I did that and with this addition /warn breaks links, making them unclickable.
