### PR TITLE
Set old moves' categories on data load

### DIFF
--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -11,7 +11,6 @@ function clampIntRange(num, min, max) {
 exports.BattleMovedex = {
 	acid: {
 		inherit: true,
-		category: "Physical",
 		target: "normal"
 	},
 	amnesia: {
@@ -155,7 +154,6 @@ exports.BattleMovedex = {
 	clamp: {
 		inherit: true,
 		accuracy: 75,
-		category: "Special",
 		pp: 10,
 		volatileStatus: 'partiallytrapped',
 		self: {
@@ -218,10 +216,6 @@ exports.BattleMovedex = {
 			this.add('-fail', pokemon);
 			return false;
 		}
-	},
-	crabhammer: {
-		inherit: true,
-		category: "Special"
 	},
 	dig: {
 		inherit: true,
@@ -323,10 +317,6 @@ exports.BattleMovedex = {
 			status: 'brn'
 		}
 	},
-	firepunch: {
-		inherit: true,
-		category: "Special"
-	},
 	firespin: {
 		inherit: true,
 		accuracy: 70,
@@ -412,7 +402,6 @@ exports.BattleMovedex = {
 	},
 	gust: {
 		inherit: true,
-		category: "Physical",
 		type: "Normal"
 	},
 	haze: {
@@ -455,13 +444,8 @@ exports.BattleMovedex = {
 	},
 	hyperbeam: {
 		inherit: true,
-		category: "Physical",
 		desc: "Deals damage to a target. If this move is successful, the user must recharge on the following turn and cannot make a move, unless the opponent faints or a Substitute is destroyed.",
 		shortDesc: "User cannot move next turn unless target or substitute faints."
-	},
-	icepunch: {
-		inherit: true,
-		category: "Special"
 	},
 	jumpkick: {
 		inherit: true,
@@ -664,7 +648,6 @@ exports.BattleMovedex = {
 	},
 	razorleaf: {
 		inherit: true,
-		category: "Special",
 		target: "normal"
 	},
 	razorwind: {
@@ -786,10 +769,6 @@ exports.BattleMovedex = {
 		inherit: true,
 		critRatio: 1
 	},
-	sludge: {
-		inherit: true,
-		category: "Physical"
-	},
 	softboiled: {
 		inherit: true,
 		heal: null,
@@ -800,10 +779,6 @@ exports.BattleMovedex = {
 			}
 			this.heal(Math.floor(target.maxhp / 2), target, target);
 		}
-	},
-	sonicboom: {
-		inherit: true,
-		category: "Physical"
 	},
 	struggle: {
 		num: 165,
@@ -918,20 +893,12 @@ exports.BattleMovedex = {
 		target: "self",
 		type: "Normal"
 	},
-	swift: {
-		inherit: true,
-		category: "Physical"
-	},
 	thunder: {
 		inherit: true,
 		secondary: {
 			chance: 10,
 			status: 'par'
 		}
-	},
-	thunderpunch: {
-		inherit: true,
-		category: "Special"
 	},
 	thunderwave: {
 		inherit: true,
@@ -945,16 +912,7 @@ exports.BattleMovedex = {
 	},
 	triattack: {
 		inherit: true,
-		category: "Physical",
 		secondary: false
-	},
-	vinewhip: {
-		inherit: true,
-		category: "Special"
-	},
-	waterfall: {
-		inherit: true,
-		category: "Special"
 	},
 	whirlwind: {
 		inherit: true,

--- a/mods/gen2/scripts.js
+++ b/mods/gen2/scripts.js
@@ -4,12 +4,7 @@
 exports.BattleScripts = {
 	inherit: 'gen3',
 	gen: 2,
-	getCategory: function(move) {
-		move = this.getMove(move);
-		var specialTypes = {Fire:1, Water:1, Grass:1, Ice:1, Electric:1, Dark:1, Psychic:1, Dragon:1};
-		if (move.category === 'Status') return 'Status';
-		return specialTypes[move.type]?'Special':'Physical';
-	},
+	init: function() { },
 	getStatCallback: function (stat, statName, pokemon) {
 		// Gen 2 caps stats at 999 and min is 1. Stats over 1023 with items roll over (Marowak, Pikachu)
 		if (pokemon.species === 'Marowak' && pokemon.item === 'thickclub' && statName === 'atk' && stat > 1023) {

--- a/mods/gen3/scripts.js
+++ b/mods/gen3/scripts.js
@@ -5,12 +5,14 @@ exports.BattleScripts = {
 		for (var i in this.data.Pokedex) {
 			delete this.data.Pokedex[i].abilities['H'];
 		}
-	},
-	getCategory: function(move) {
-		move = this.getMove(move);
-		if (!(move.category in {'Special':1,'Physical':1})) return move.category;
-		// overwrite categories
 		var specialTypes = {Fire:1, Water:1, Grass:1, Ice:1, Electric:1, Dark:1, Psychic:1, Dragon:1};
-		return specialTypes[move.type]? 'Special' : 'Physical';
+		var newCategory = '';
+		for (var i in this.data.Movedex) {
+			if (this.data.Movedex[i].category === 'Status') continue;
+			newCategory = specialTypes[this.data.Movedex[i].type]? 'Special' : 'Physical';
+			if (newCategory !== this.data.Movedex[i].category) {
+				this.modData('Movedex', i).category = newCategory;
+			}
+		}
 	}
 };


### PR DESCRIPTION
Rather than figuring them out each time it's needed. This is only performed for Gen 3, as the data is passed down to older gens.
