### PR TITLE
Make /rules support room rules

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -755,6 +755,7 @@ var commands = exports.commands = {
 			'<br />' +
 			'Room owners (#) can also use:<br />' +
 			'- /roomdesc <em>description</em>: set the room description on the room join page<br />' +
+			'- /rules <em>rules link</em>: set the room rules link seen when using /rules<br />' +
 			'- /roommod, /roomdriver <em>username</em>: appoint a room moderator/driver<br />' +
 			'- /roomdemod, /roomdedriver <em>username</em>: remove a room moderator/driver<br />' +
 			'- /modchat <em>[%/@/#]</em>: set modchat level<br />' +
@@ -775,10 +776,30 @@ var commands = exports.commands = {
 
 	rule: 'rules',
 	rules: function(target, room, user) {
-		if (!this.canBroadcast()) return;
-		this.sendReplyBox('Please follow the rules:<br />' +
+		if (!target) {
+			if (!this.canBroadcast()) return;
+			var re = /(https?:\/\/(([-\w\.]+)+(:\d+)?(\/([\w/_\.]*(\?\S+)?)?)?))/g;
+			if (!room.rules) return this.sendReplyBox('Please follow the rules:<br />' +
 			'- <a href="http://pokemonshowdown.com/rules">Rules</a><br />' +
 			'</div>');
+			this.sendReplyBox('Please follow the rules:<br />' +
+			'- <a href="http://pokemonshowdown.com/rules">Rules</a><br />' +
+			'- ' + room.rules.replace(re, "<a href=\"$1\">$1</a>") + ' ' + room.title + ' room rules</a><br />' +
+			'</div>');
+			return;
+		}
+		if (!this.can('roommod', null, room)) return false;
+		if (target.length > 40) {
+			return this.sendReply('Error: Room rules link is too long (must be under 40 characters). You can use a URL shortener to shorten the link.');
+		}
+
+		room.rules = target;
+		this.sendReply('(The room rules link is now: '+target+')');
+
+		if (room.chatRoomData) {
+			room.chatRoomData.rules = room.rules;
+			Rooms.global.writeChatRoomData();
+		}
 	},
 
 	faq: function(target, room, user) {


### PR DESCRIPTION
Similar to /roomdesc, a Room Owner or Admin can set a rules link for a room which appears beneath the global rules link on /rules. This would be used purely as a convenience to have global and room rules under the same command.
