### PR TITLE
Call validateTeam only once for a valid team

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -1044,6 +1044,10 @@ var commands = exports.commands = {
 				Simulator.SimulatorProcess.respawn();
 				// broadcast the new formats list to clients
 				Rooms.global.send(Rooms.global.formatListText);
+				// users must have their teams validated
+				for (var uid in Users.users) {
+					Users.users[uid].validTeam = false;
+				}
 
 				return this.sendReply('Formats have been hotpatched.');
 			} catch (e) {
@@ -1585,7 +1589,10 @@ var commands = exports.commands = {
 			}
 		}
 		user.prepBattle(target, 'challenge', connection, function (result) {
-			if (result) user.makeChallenge(targetUser, target);
+			if (result) {
+				user.validTeam = target;
+				user.makeChallenge(targetUser, target);
+			}
 		});
 	},
 
@@ -1616,7 +1623,10 @@ var commands = exports.commands = {
 			return false;
 		}
 		user.prepBattle(format, 'challenge', connection, function (result) {
-			if (result) user.acceptChallengeFrom(userid);
+			if (result) {
+				user.validTeam = format;
+				user.acceptChallengeFrom(userid);
+			}
 		});
 	},
 
@@ -1627,7 +1637,10 @@ var commands = exports.commands = {
 	saveteam: 'useteam',
 	utm: 'useteam',
 	useteam: function(target, room, user) {
-		user.team = target;
+		if (user.team !== target) {
+			user.validTeam = false;
+			user.team = target;
+		}
 	},
 
 	/*********************************************************

--- a/config/formats.js
+++ b/config/formats.js
@@ -613,7 +613,7 @@ exports.Formats = [
 
 		mod: 'gen5',
 		validateSet: function(set) {
-			if (!set.level || set.level >= 50) set.forcedLevel = 50;
+			if (!set.level || set.level > 50) set.forcedLevel = 50;
 			return [];
 		},
 		onBegin: function() {

--- a/rooms.js
+++ b/rooms.js
@@ -249,6 +249,9 @@ var GlobalRoom = (function() {
 	GlobalRoom.prototype.finishSearchBattle = function(user, formatid, result) {
 		if (!result) return;
 
+		// cache the validation
+		user.validTeam = formatid;
+
 		// tell the user they've started searching
 		var newSearchData = {
 			format: formatid

--- a/team-validator.js
+++ b/team-validator.js
@@ -277,10 +277,10 @@ var Validator = (function() {
 		}
 		if (format.forcedLevel) {
 			set.forcedLevel = format.forcedLevel;
-		} else if (set.level >= maxForcedLevel) {
+		} else if (set.level > maxForcedLevel) {
 			set.forcedLevel = maxForcedLevel;
 		}
-		if (set.level > maxLevel || set.level == set.forcedLevel || set.level == set.maxForcedLevel) {
+		if (set.level > maxLevel || set.level == set.forcedLevel || set.level == maxForcedLevel) {
 			set.level = maxLevel;
 		}
 

--- a/users.js
+++ b/users.js
@@ -1130,7 +1130,12 @@ var User = (function () {
 			setImmediate(callback.bind(null, false));
 			return;
 		}
-		TeamValidator.validateTeam(formatid, this.team, this.finishPrepBattle.bind(this, connection, callback));
+		if (this.validTeam === formatid) {
+			// add exception for custom games when they become "really custom"
+			this.finishPrepBattle(connection, callback, true, this.team);
+		} else {
+			TeamValidator.validateTeam(formatid, this.team, this.finishPrepBattle.bind(this, connection, callback));
+		}
 	};
 	User.prototype.finishPrepBattle = function(connection, callback, success, details) {
 		if (!success) {


### PR DESCRIPTION
If the result of a validation for a format is positive, it will be saved to avoid the repetition of the task for the next battle.
This optimization is based on the assumption that the majority of the userbase battles in a single format and with a single team.
