### PR TITLE
Fixed heroku crash (port)

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -1,4 +1,7 @@
-// The server port - the port to run Pokemon Showdown under
+/* The server port - the port to run Pokemon Showdown under.
+ * Note: you must replace this line by "exports.port = process.env.PORT || 8000;"
+ * if you use a heroku hosting.
+ */
 exports.port = 8000;
 
 // proxyip - proxy IPs with trusted X-Forwarded-For headers


### PR DESCRIPTION
Doc: the application crashes in heroku if you don't use "process.env.PORT" to define your port.
