### PR TITLE
Fix Sky Drop bug

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -11797,7 +11797,7 @@ exports.BattleMovedex = {
 				this.add('-activate', defender, 'Protect');
 				return null;
 			}
-			if (defender.volatiles['bounce'] || defender.volatiles['dig'] || defender.volatiles['dive'] || defender.volatiles['fly'] || defender.volatiles['shadowforce']) {
+			if (defender.volatiles['bounce'] || defender.volatiles['dig'] || defender.volatiles['dive'] || defender.volatiles['fly'] || defender.volatiles['shadowforce'] || defender.volatiles['skydrop']) {
 				this.add('-miss', attacker, defender);
 				return null;
 			}


### PR DESCRIPTION
Sky Drop should fail if the opponent used Sky Drop the previous turn, similar to Fly or Bounce.
