### PR TITLE
Allow room owners to read their modlogs

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -219,7 +219,6 @@ exports.groups = {
 		roomdriver: true,
 		declare: true,
 		modchatall: true,
-		modlog: true,
 		roomonly: true,
 		rank: 5
 	},


### PR DESCRIPTION
Also fix the feature to check any single modlog without being in that room, including the battle modlog.
