### PR TITLE
Update moves.js

### DIFF
--- a/mods/gennext/moves.js
+++ b/mods/gennext/moves.js
@@ -711,7 +711,7 @@ exports.BattleMovedex = {
 			accuracy: 1
 		},
 		onModifyMove: function(move, user) {
-			var GossamerWingUsers = {"Butterfree":1, "Masquerain":1, "Beautifly":1, "Mothim":1, "Lilligant":1};
+			var GossamerWingUsers = {"Butterfree":1, "Masquerain":1, "Beautifly":1, "Mothim":1, "Lilligant":1, "Vivillon":1};
 			if (user.item === 'stick' && GossamerWingUsers[user.template.species]) {
 				move.boosts = {
 					spa: 1,


### PR DESCRIPTION
Vivillon should QD as well. On another note, Vivillon doesn't exactly totally eclipse Butterfree because Vivillon doesn't have tinted lens.
