### PR TITLE
Mons with no movesets removed from dexsearch results

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -343,7 +343,7 @@ var commands = exports.commands = {
 				searches['moves'][targetMove.name] = !isNotSearch;
 				continue;
 			} else {
-				return this.sendReply('"' + target + '" could not be found in any of the search categories.');
+				if (target.length) return this.sendReply('"' + target + '" could not be found in any of the search categories.');
 			}
 		}
 
@@ -413,13 +413,11 @@ var commands = exports.commands = {
 				case 'moves':
 					for (var mon in dex) {
 						var template = Tools.getTemplate(dex[mon].id);
-						if (!template.learnset) {
-							if (megaSearch && template.isMega) {
-								template = Tools.getTemplate(template.baseSpecies);
-							} else {
-								delete dex[mon];
-								continue;
-							}
+						if (mon !== toId(template.baseSpecies) && toId(template.baseSpecies) in dex) {
+							delete dex[mon];
+							continue;
+						} else {
+							template = Tools.getTemplate(template.baseSpecies);
 						}
 						if (!template.learnset) continue;
 						for (var i in searches[search]) {


### PR DESCRIPTION
[19:59:14] <&bmelts> Zarel you should fix this at some point http://i.imgur.com/Im0pDPK.png
[19:59:35] <&bmelts> formes without different movesets have no need to be listed separately
[20:01:16] <+rileydelete> I'd be willing to fix it. 
[20:01:18] <~Zarel> bmelts, dexsearch is 100% TTT
[20:01:36] <~Zarel> ask him why he's listing pokemon with no learnsets

You can still search for megas by move using /dexsearch mega, move, ..., but otherwise all formes without a unique moveset are ignored.
