### PR TITLE
Add /room

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -345,6 +345,12 @@ var commands = exports.commands = {
 			Rooms.global.writeChatRoomData();
 		}
 	},
+	
+	roomid: 'room',
+	room: function(target, room, user) {
+        	if (!this.canBroadcast()) return;
+        	this.sendReplyBox('You are currently in the room "'+room.id+'".');
+	},
 
 	autojoin: function(target, room, user, connection) {
 		Rooms.global.autojoinRooms(user, connection);


### PR DESCRIPTION
Often times when people join a large sum of rooms, it can be hard to know what room you're in.  Using /room will tell the user what room they're in.
