### PR TITLE
Update Magic Room Mechanics

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -7680,6 +7680,7 @@ exports.BattleMovedex = {
 			},
 			onModifyPokemonPriority: 1,
 			onModifyPokemon: function(pokemon) {
+				if (pokemon.getItem(this.item).megaEvolves) return false;
 				pokemon.ignore['Item'] = true;
 			},
 			onResidualOrder: 25,


### PR DESCRIPTION
Magic Room should not affect Mega Stones. Previously, Knock Off worked on Mega Stones when this move was in effect.
