### PR TITLE
Properly do 891e7aebb6 and extend to Embargo

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -3375,6 +3375,7 @@ exports.BattleMovedex = {
 			},
 			onModifyPokemonPriority: 1,
 			onModifyPokemon: function(pokemon) {
+				if (pokemon.getItem().megaEvolves) return;
 				pokemon.ignore['Item'] = true;
 			}
 		},
@@ -7680,7 +7681,7 @@ exports.BattleMovedex = {
 			},
 			onModifyPokemonPriority: 1,
 			onModifyPokemon: function(pokemon) {
-				if (pokemon.getItem(this.item).megaEvolves) return false;
+				if (pokemon.getItem().megaEvolves) return;
 				pokemon.ignore['Item'] = true;
 			},
 			onResidualOrder: 25,


### PR DESCRIPTION
The previous implementation caused the ModifyPokemon event to be interrupted for a pokemon holding a mega Stone in Magic Room.
