### PR TITLE
Muted / locked users cannot warn

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -458,6 +458,7 @@ var commands = exports.commands = {
 	k: 'warn',
 	warn: function(target, room, user) {
 		if (!target) return this.parse('/help warn');
+		if (!this.canTalk()) return;
 
 		target = this.splitTarget(target);
 		var targetUser = this.targetUser;


### PR DESCRIPTION
Often times when someone is locked or muted and has an auth rank somewhere, they will tend to continue to talk through warns- which defeats the purpose of a lock or mute.
