### PR TITLE
Consistent return format for /dexsearch + other updates

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -289,22 +289,22 @@ var commands = exports.commands = {
 			var targetAbility = Tools.getAbility(targets[i]);
 			if (targetAbility.exists) {
 				if (!searches['ability']) searches['ability'] = {};
-				if (Object.count(searches['ability'], true) === 1 && !isNotSearch) return this.sendReply('Specify only one ability.');
-				if (searches['ability'][targetAbility.name] && isNotSearch) return this.sendReplyBox('No Pokémon found.');
+				if (Object.count(searches['ability'], true) === 1 && !isNotSearch) return this.sendReplyBox('Specify only one ability.');
+				if ((searches['ability'][targetAbility.name] && isNotSearch) || (searches['ability'][targetAbility.name] === false && !isNotSearch)) return this.sendReplyBox('A search cannot both exclude and include an ability.');
 				searches['ability'][targetAbility.name] = !isNotSearch;
 				continue;
 			}
 
 			if (target in allTiers) {
 				if (!searches['tier']) searches['tier'] = {};
-				if (searches['tier'][target] && isNotSearch) return this.sendReplyBox('No Pokémon found.');
+				if ((searches['tier'][target] && isNotSearch) || (searches['tier'][target] === false && !isNotSearch)) return this.sendReplyBox('A search cannot both exclude and include a tier.');
 				searches['tier'][target] = !isNotSearch;
 				continue;
 			}
 
 			if (target in allColours) {
 				if (!searches['color']) searches['color'] = {};
-				if (searches['color'][target] && isNotSearch) return this.sendReplyBox('No Pokémon found.');
+				if ((searches['color'][target] && isNotSearch) || (searches['color'][target] === false && !isNotSearch)) return this.sendReplyBox('A search cannot both exclude and include a color.');
 				searches['color'][target] = !isNotSearch;
 				continue;
 			}
@@ -312,21 +312,21 @@ var commands = exports.commands = {
 			var targetInt = parseInt(target);
 			if (0 < targetInt && targetInt < 7) {
 				if (!searches['gen']) searches['gen'] = {};
-				if (searches['gen'][target] && isNotSearch) return this.sendReplyBox('No Pokémon found.');
+				if ((searches['gen'][target] && isNotSearch) || (searches['gen'][target] === false && !isNotSearch)) return this.sendReplyBox('A search cannot both exclude and include a generation.');
 				searches['gen'][target] = !isNotSearch;
 				continue;
 			}
 
 			if (target === 'all') {
 				if (this.broadcasting) {
-					return this.sendReply('A search with the parameter "all" cannot be broadcast.');
+					return this.sendReplyBox('A search with the parameter "all" cannot be broadcast.');
 				}
 				showAll = true;
 				continue;
 			}
 
 			if (target === 'megas' || target === 'mega') {
-				if (megaSearch && isNotSearch) return this.sendReplyBox('No Pokémon found.');
+				if ((megaSearch && isNotSearch) || (megaSearch === false && !isNotSearch)) return this.sendReplyBox('A search cannot both exclude and include Mega Evolutions.');
 				megaSearch = !isNotSearch;
 				continue;
 			}
@@ -335,8 +335,8 @@ var commands = exports.commands = {
 				target = target.charAt(0).toUpperCase() + target.slice(1, target.indexOf(' type'));
 				if (target in Tools.data.TypeChart) {
 					if (!searches['types']) searches['types'] = {};
-					if (Object.count(searches['types'], true) === 2 && !isNotSearch) return this.sendReply('Specify a maximum of two types.');
-					if (searches['types'][target] && isNotSearch) return this.sendReplyBox('No Pokémon found.');
+					if (Object.count(searches['types'], true) === 2 && !isNotSearch) return this.sendReplyBox('Specify a maximum of two types.');
+					if ((searches['types'][target] && isNotSearch) || (searches['types'][target] === false && !isNotSearch)) return this.sendReplyBox('A search cannot both exclude and include a type.');
 					searches['types'][target] = !isNotSearch;
 					continue;
 				}
@@ -345,16 +345,16 @@ var commands = exports.commands = {
 			var targetMove = Tools.getMove(target);
 			if (targetMove.exists) {
 				if (!searches['moves']) searches['moves'] = {};
-				if (Object.count(searches['moves'], true) === 4 && !isNotSearch) return this.sendReply('Specify a maximum of 4 moves.');
-				if (searches['moves'][targetMove.name] && isNotSearch) return this.sendReplyBox('No Pokémon found.');
+				if (Object.count(searches['moves'], true) === 4 && !isNotSearch) return this.sendReplyBox('Specify a maximum of 4 moves.');
+				if ((searches['moves'][targetMove.name] && isNotSearch) || (searches['moves'][targetMove.name] === false && !isNotSearch)) return this.sendReplyBox('A search cannot both exclude and include a move.');
 				searches['moves'][targetMove.name] = !isNotSearch;
 				continue;
 			} else {
-				return this.sendReply('"' + target + '" could not be found in any of the search categories.');
+				return this.sendReplyBox('"' + sanitize(target, true) + '" could not be found in any of the search categories.');
 			}
 		}
 
-		if (showAll && Object.size(searches) === 0 && megaSearch === null) return this.sendReply('No search parameters other than "all" were found.\nTry "/help dexsearch" for more information on this command.');
+		if (showAll && Object.size(searches) === 0 && megaSearch === null) return this.sendReplyBox('No search parameters other than "all" were found.\nTry "/help dexsearch" for more information on this command.');
 
 		var dex = {};
 		for (var pokemon in Tools.data.Pokedex) {
@@ -436,7 +436,7 @@ var commands = exports.commands = {
 					break;
 
 				default:
-					return this.sendReply("Something broke! PM TalkTakesTime here or on the Smogon forums with the command you tried.");
+					return this.sendReplyBox("Something broke! PM TalkTakesTime here or on the Smogon forums with the command you tried.");
 			}
 		}
 


### PR DESCRIPTION
Also adds error messages for searches of type "x, !x", instead of just returning a nothing found message, as well as taking care of the case where the order of "x, !x" is reversed, which was not covered by Relados' commit
