### PR TITLE
Fix Protean Bug

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2004,8 +2004,7 @@ exports.BattleAbilities = {
 			if (!move) return;
 			var moveType = (move.id === 'hiddenpower' ? pokemon.hpType : move.type);
 			if (pokemon.getTypes().join() !== moveType) {
-				if (!pokemon.setType(moveType)) return false;
-				if (move.volatileStatus === 'mustrecharge') return false;
+				if (!pokemon.setType(moveType) || move.volatileStatus === 'mustrecharge') return false;
 				this.add('-start', pokemon, 'typechange', moveType, '[from] Protean');
 			}
 		},


### PR DESCRIPTION
When recharging from a move such as Hyper Beam, Protean activated and changed the Pokemon's type to an undefined type.
