### PR TITLE
Improve /showimage to include a default size for the image

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -1087,12 +1087,16 @@ var commands = exports.commands = {
 
 		if (!this.canTalk()) return;
 
-		targets = target.split(', ');
-		if (targets.length != 3) {
+		var targets = target.split(', ');
+		if (targets.length != 1 && targets.length != 3) {
 			return this.parse('/help showimage');
 		}
-
-		this.add('|raw|'+sanitize(user.name)+' shows:<br /><img src="'+sanitize(targets[0])+'" alt="" width="'+toId(targets[1])+'" height="'+toId(targets[2])+'" />');
+		
+		if (typeof targets[1] === "undefined") targets[1] = '';
+		if (typeof targets[2] === "undefined") targets[2] = '';
+		
+		var image = '<img src="'+sanitize(targets[0])+'" alt="" width="'+toId(targets[1])+'" height="'+toId(targets[2])+'" max-width="400px" />'
+		this.add('|raw|'+sanitize(user.name)+' shows:<br />' + image);
 	},
 
 	a: function(target, room, user) {


### PR DESCRIPTION
If no width/height are passed, it uses a default width of 400 pixels and scales the image to match this. I don't know if there's any way to get the width of the user's chat window but on my smallish laptop 400 pixels is almost the whole width.

Also fixed a problem with variable scope. ('targets' should be locally scoped, not global)
