### PR TITLE
Remove redundancy in /roompromote

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -314,9 +314,6 @@ var commands = exports.commands = {
 		if (!Config.groups[nextGroup]) {
 			return this.sendReply("Group '" + nextGroup + "' does not exist.");
 		}
-		if (Config.groups[nextGroup].globalonly) {
-			return this.sendReply("The rank of " + Config.groups[nextGroup].name + " is global-only and can't be room-promoted to.");
-		}
 
 		if (Config.groups[nextGroup].globalonly) {
 			return this.sendReply("Group 'room" + Config.groups[nextGroup].id + "' does not exist as a room rank.");
@@ -342,6 +339,8 @@ var commands = exports.commands = {
 		if (Config.groups[nextGroup].rank < Config.groups[currentGroup].rank) {
 			this.privateModCommand("(" + name + " was demoted to Room " + groupName + " by " + user.name + ".)");
 			if (targetUser) targetUser.popup("You were demoted to Room " + groupName + " by " + user.name + ".");
+		} else if (nextGroup === '#') {
+			this.addModCommand("" + name + " was promoted to " + groupName + " by " + user.name + ".");
 		} else {
 			this.addModCommand("" + name + " was promoted to Room " + groupName + " by " + user.name + ".");
 		}


### PR DESCRIPTION
If used to promote a user to room owner, the command displayed: "User was promoted to Room Room Owner". There were also two error messages for trying to promote to global-only ranks, so I kept the newer one from <a href="https://github.com/Zarel/Pokemon-Showdown/commit/4f86a6e849a731f0e3359d1c135ca6d40594702a">this commit.</a>
