### PR TITLE
Unlink most recent name of guests, not userid

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -488,7 +488,8 @@ var commands = exports.commands = {
 
 		this.addModCommand("" + targetUser.name + " was warned by " + user.name + "." + (target ? " (" + target + ")" : ""));
 		targetUser.send('|c|~|/warn ' + target);
-		var nickToUnlink = targetUser.named ? targetUser.userid : (Object.keys(targetUser.prevNames)[Object.keys(targetUser.prevNames).length - 1] || targetUser.userid);
+		var prevUserids = Object.keys(targetUser.prevNames);
+		var nickToUnlink = targetUser.named ? targetUser.userid : (prevUserids[prevUserids.length - 1] || targetUser.userid);
 		this.add('|unlink|' + nickToUnlink);
 	},
 
@@ -542,7 +543,8 @@ var commands = exports.commands = {
 		this.addModCommand("" + targetUser.name + " was muted by " + user.name + " for 7 minutes." + (target ? " (" + target + ")" : ""));
 		var alts = targetUser.getAlts();
 		if (alts.length) this.addModCommand("" + targetUser.name + "'s alts were also muted: " + alts.join(", "));
-		var nickToUnlink = targetUser.named ? targetUser.userid : (Object.keys(targetUser.prevNames)[Object.keys(targetUser.prevNames).length - 1] || targetUser.userid);
+		var prevUserids = Object.keys(targetUser.prevNames);
+		var nickToUnlink = targetUser.named ? targetUser.userid : (prevUserids[prevUserids.length - 1] || targetUser.userid);
 		this.add('|unlink|' + nickToUnlink);
 
 		targetUser.mute(room.id, 7 * 60 * 1000);
@@ -571,7 +573,8 @@ var commands = exports.commands = {
 		this.addModCommand("" + targetUser.name + " was muted by " + user.name + " for 60 minutes." + (target ? " (" + target + ")" : ""));
 		var alts = targetUser.getAlts();
 		if (alts.length) this.addModCommand("" + targetUser.name + "'s alts were also muted: " + alts.join(", "));
-		var nickToUnlink = targetUser.named ? targetUser.userid : (Object.keys(targetUser.prevNames)[Object.keys(targetUser.prevNames).length - 1] || targetUser.userid);
+		var prevUserids = Object.keys(targetUser.prevNames);
+		var nickToUnlink = targetUser.named ? targetUser.userid : (prevUserids[prevUserids.length - 1] || targetUser.userid);
 		this.add('|unlink|' + nickToUnlink);
 
 		targetUser.mute(room.id, 60 * 60 * 1000, true);
@@ -620,7 +623,8 @@ var commands = exports.commands = {
 		this.addModCommand("" + targetUser.name + " was locked from talking by " + user.name + "." + (target ? " (" + target + ")" : ""));
 		var alts = targetUser.getAlts();
 		if (alts.length) this.addModCommand("" + targetUser.name + "'s alts were also locked: " + alts.join(", "));
-		var nickToUnlink = targetUser.named ? targetUser.userid : (Object.keys(targetUser.prevNames)[Object.keys(targetUser.prevNames).length - 1] || targetUser.userid);
+		var prevUserids = Object.keys(targetUser.prevNames);
+		var nickToUnlink = targetUser.named ? targetUser.userid : (prevUserids[prevUserids.length - 1] || targetUser.userid);
 		this.add('|unlink|' + nickToUnlink);
 
 		targetUser.lock();
@@ -672,7 +676,8 @@ var commands = exports.commands = {
 			}
 		}
 
-		var nickToUnlink = targetUser.named ? targetUser.userid : (Object.keys(targetUser.prevNames)[Object.keys(targetUser.prevNames).length - 1] || targetUser.userid);
+		var prevUserids = Object.keys(targetUser.prevNames);
+		var nickToUnlink = targetUser.named ? targetUser.userid : (prevUserids[prevUserids.length - 1] || targetUser.userid);
 		this.add('|unlink|' + nickToUnlink);
 		targetUser.ban();
 	},


### PR DESCRIPTION
Currently a user can send a link and log out quickly, resulting in the `|unlink|` never unlinking their message (instead it unlinks the guest### messages, which don't exist). This unlinks the current name of a user, or their most recent one if they aren't named
