### PR TITLE
Unlink most recent name of guests, not userid

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -488,7 +488,8 @@ var commands = exports.commands = {
 
 		this.addModCommand("" + targetUser.name + " was warned by " + user.name + "." + (target ? " (" + target + ")" : ""));
 		targetUser.send('|c|~|/warn ' + target);
-		this.add('|unlink|' + targetUser.userid);
+		var nickToUnlink = targetUser.named ? targetUser.userid : (Object.keys(targetUser.prevNames).last() || targetUser.userid);
+		this.add('|unlink|' + nickToUnlink);
 	},
 
 	redirect: 'redir',
@@ -541,7 +542,8 @@ var commands = exports.commands = {
 		this.addModCommand("" + targetUser.name + " was muted by " + user.name + " for 7 minutes." + (target ? " (" + target + ")" : ""));
 		var alts = targetUser.getAlts();
 		if (alts.length) this.addModCommand("" + targetUser.name + "'s alts were also muted: " + alts.join(", "));
-		this.add('|unlink|' + targetUser.userid);
+		var nickToUnlink = targetUser.named ? targetUser.userid : (Object.keys(targetUser.prevNames).last() || targetUser.userid);
+		this.add('|unlink|' + nickToUnlink);
 
 		targetUser.mute(room.id, 7 * 60 * 1000);
 	},
@@ -569,7 +571,8 @@ var commands = exports.commands = {
 		this.addModCommand("" + targetUser.name + " was muted by " + user.name + " for 60 minutes." + (target ? " (" + target + ")" : ""));
 		var alts = targetUser.getAlts();
 		if (alts.length) this.addModCommand("" + targetUser.name + "'s alts were also muted: " + alts.join(", "));
-		this.add('|unlink|' + targetUser.userid);
+		var nickToUnlink = targetUser.named ? targetUser.userid : (Object.keys(targetUser.prevNames).last() || targetUser.userid);
+		this.add('|unlink|' + nickToUnlink);
 
 		targetUser.mute(room.id, 60 * 60 * 1000, true);
 	},
@@ -617,7 +620,8 @@ var commands = exports.commands = {
 		this.addModCommand("" + targetUser.name + " was locked from talking by " + user.name + "." + (target ? " (" + target + ")" : ""));
 		var alts = targetUser.getAlts();
 		if (alts.length) this.addModCommand("" + targetUser.name + "'s alts were also locked: " + alts.join(", "));
-		this.add('|unlink|' + targetUser.userid);
+		var nickToUnlink = targetUser.named ? targetUser.userid : (Object.keys(targetUser.prevNames).last() || targetUser.userid);
+		this.add('|unlink|' + nickToUnlink);
 
 		targetUser.lock();
 	},
@@ -668,7 +672,8 @@ var commands = exports.commands = {
 			}
 		}
 
-		this.add('|unlink|' + targetUser.userid);
+		var nickToUnlink = targetUser.named ? targetUser.userid : (Object.keys(targetUser.prevNames).last() || targetUser.userid);
+		this.add('|unlink|' + nickToUnlink);
 		targetUser.ban();
 	},
 


### PR DESCRIPTION
Currently a user can send a link and log out quickly, resulting in the |unlink| never unlinking their message (instead it unlinks the guest### messages, which don't exist). This unlinks the current name of a user, or their most recent one if they aren't named

Corrected
