### PR TITLE
Wide/Quick Guard should increment the StallMove counter

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -10100,6 +10100,9 @@ exports.BattleMovedex = {
 		onTryHitSide: function (side, source) {
 			return this.willAct();
 		},
+		onHitSide: function (side, source) {
+			source.addVolatile('stall');
+		},
 		effect: {
 			duration: 1,
 			onStart: function (target, source) {
@@ -14736,6 +14739,9 @@ exports.BattleMovedex = {
 		sideCondition: 'wideguard',
 		onTryHitSide: function (side, source) {
 			return this.willAct();
+		},
+		onHitSide: function (side, source) {
+			source.addVolatile('stall');
 		},
 		effect: {
 			duration: 1,


### PR DESCRIPTION
Wide Guard and Quick Guard can be used indefinitely without chance of failure; however, using Protect/Detect etc after using Quick Guard or Wide Guard should have the same chance of failure as they would if they were used after a chain of themselves.

http://www.smogon.com/forums/threads/battle-mechanics-research.3489239/page-36#post-4941980
