### PR TITLE
Remove formes with no learnset from /dexsearch

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -430,6 +430,10 @@ var commands = exports.commands = {
 		}
 
 		var results = Object.keys(dex).map(function (speciesid) {return dex[speciesid].species;});
+		results = results.filter(function (species) {
+			var template = Tools.getTemplate(species);
+			return !(species !== template.baseSpecies && results.indexOf(template.baseSpecies) > -1);
+		});
 		var resultsStr = "";
 		if (results.length > 0) {
 			if (showAll || results.length <= output) {


### PR DESCRIPTION
They'll only be removed if their base forme is present in the results; otherwise, they will appear as normal.

It has to be done this way because searches for moves are evaluated first, so there is no way to know at the start whether the base forme will be eliminated from the results set. Changing the order of evaluation just makes the results less accurate.
