### PR TITLE
Pass target location to ´beforeTurnCallback´

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -3115,7 +3115,7 @@ var Battle = (function () {
 			}
 			if (decision.choice === 'move') {
 				if (this.getMove(decision.move).beforeTurnCallback) {
-					this.addQueue({choice: 'beforeTurnMove', pokemon: decision.pokemon, move: decision.move}, true);
+					this.addQueue({choice: 'beforeTurnMove', pokemon: decision.pokemon, move: decision.move, targetLoc: decision.targetLoc}, true);
 				}
 			} else if (decision.choice === 'switch') {
 				if (decision.pokemon.switchFlag && decision.pokemon.switchFlag !== true) {

--- a/mods/gen2/scripts.js
+++ b/mods/gen2/scripts.js
@@ -275,7 +275,7 @@ exports.BattleScripts = {
 			}
 			if (decision.choice === 'move') {
 				if (this.getMove(decision.move).beforeTurnCallback) {
-					this.addQueue({choice: 'beforeTurnMove', pokemon: decision.pokemon, move: decision.move}, true);
+					this.addQueue({choice: 'beforeTurnMove', pokemon: decision.pokemon, move: decision.move, targetLoc: decision.targetLoc}, true);
 				}
 			} else if (decision.choice === 'switch') {
 				if (decision.pokemon.switchFlag && decision.pokemon.switchFlag !== true) {


### PR DESCRIPTION
This fixes Assurance sometimes failing to track damage dealt in the turn.
