### PR TITLE
Fixing Gen 3 Wish

### DIFF
--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -694,6 +694,23 @@ exports.BattleMovedex = {
 					var source = this.effectData.source;
 					var damage = this.heal(target.maxhp / 2, target, target);
 					if (damage) this.add('-heal', target, target.getHealth, '[from] move: Wish', '[wisher] ' + source.name);
+				} else {
+					int didFaint = 1;
+					onSwitchInPriority: -1,
+					onSwitchIn: function (target) {
+						while (didFaint != 0) {
+							if (target.position != this.effectData.sourcePosition) {
+								return;
+							}
+							if (!target.fainted) {
+								var source = this.effectData.source;
+								var damage = target.heal(target.maxhp / 2);
+								this.add('-heal', target, target.getHealth, '[from] move: Wish');
+								target.side.removeSideCondition('Wish');
+								didFaint = 0;
+							}
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Wish would not work if a Pokemon faints. This added code essentially allows Wish to constantly check if a Pokemon faints. If it does, it heals the new Pokemon. If even that Pokemon faints [due to spikes damage], it will keep going until a Pokemon doesn't faint.
