### PR TITLE
Add ofe as an opt-in dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "nodemailer": "0.4.1",
     "http-proxy": "0.10.0"
   },
+  "nonDefaultDependencies": {
+    "ofe": "0.1.2"
+  },
   "engines": {
     "node": "> 0.10.1"
   },


### PR DESCRIPTION
The ´nonDefaultDependencies´ field in package.json is not used by NPM, but allows us to keep track of them.

Follow-up of #541
