### PR TITLE
NEXT: Buff Clear Smog, Fix Twineedle

### DIFF
--- a/mods/gennext/moves.js
+++ b/mods/gennext/moves.js
@@ -50,7 +50,7 @@ exports.BattleMovedex = {
 	},
 	clearsmog: {
 		inherit: true,
-		basePowder: 90
+		basePower: 90
 	},
 	/******************************************************************
 	HMs:
@@ -952,10 +952,6 @@ exports.BattleMovedex = {
 		inherit: true,
 		accuracy: true
 	},
-	twineedle: {
-		inherit: true,
-		accuracy: true
-	},
 	/******************************************************************
 	Draining moves:
 	- buff Leech Life
@@ -1583,6 +1579,7 @@ exports.BattleMovedex = {
 	******************************************************************/
 	twineedle: {
 		inherit: true,
+		accuracy: true,
 		basePower: 50
 	},
 	drillpeck: {


### PR DESCRIPTION
Clear Smog is a perfect accuracy move (albeit with a side-effect) that was not given the 90bp damage boost as was the case with all other perfect accuracy moves. This change brings it in line with the other moves.

Twineedle remained at 100% accuracy instead of perfect accuracy unlike all other Multi-Hit moves which were given perfect accuracy. This change brings it in line with the other moves.
