### PR TITLE
Fix ADV Explosion mechanics

### DIFF
--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -261,6 +261,10 @@ exports.BattleMovedex = {
 	},
 	explosion: {
 		inherit: true,
+		onHit: function(target) {
+			if (!target) return;
+			this.cancelMove(target);
+		},
 		basePower: 500
 	},
 	extrasensory: {
@@ -546,6 +550,10 @@ exports.BattleMovedex = {
 	},
 	selfdestruct: {
 		inherit: true,
+		onHit: function(target) {
+			if (!target) return;
+			this.cancelMove(target);
+		},
 		basePower: 400
 	},
 	skillswap: {


### PR DESCRIPTION
In ADV, Self Destruct and Explosion should prevent the target from moving if used by a faster mon. This is a pretty crucial bug, since it gives set-up sweepers like Suicune a free turn to Rest, which can be game changing.

http://www.smogon.com/forums/threads/implementing-all-old-gens-in-ps-testers-required.3483261/page-6#post-5438890
http://puu.sh/8J6E5.png
