### PR TITLE
Fix recoil for multihit moves

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -2625,20 +2625,16 @@ var Battle = (function () {
 			break;
 		}
 
-		if (effect.recoil && source) {
-			this.damage(this.clampIntRange(Math.round(damage * effect.recoil[0] / effect.recoil[1]), 1), source, target, 'recoil');
-		}
 		if (effect.drain && source) {
 			this.heal(Math.ceil(damage * effect.drain[0] / effect.drain[1]), source, target, 'drain');
 		}
 
-		if (target.fainted) this.faint(target);
-		else {
+		if (target.fainted) {
+			this.faint(target);
+		} else {
 			damage = this.runEvent('AfterDamage', target, source, effect, damage);
-			if (effect && !effect.negateSecondary) {
-				this.runEvent('Secondary', target, source, effect);
-			}
 		}
+
 		return damage;
 	};
 	Battle.prototype.directDamage = function (damage, target, source, effect) {

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -241,6 +241,7 @@ exports.BattleScripts = {
 			return false;
 		}
 
+		var totalDamage = 0;
 		var damage = 0;
 		pokemon.lastDamage = 0;
 		if (move.multihit) {
@@ -265,6 +266,8 @@ exports.BattleScripts = {
 				// Damage from each hit is individually counted for the
 				// purposes of Counter, Metal Burst, and Mirror Coat.
 				damage = (moveDamage || 0);
+				// Total damage dealt is accumulated for the purposes of recoil (Parental Bond).
+				totalDamage += damage;
 				this.eachEvent('Update');
 			}
 			if (i === 0) return true;
@@ -272,6 +275,11 @@ exports.BattleScripts = {
 			this.add('-hitcount', target, i);
 		} else {
 			damage = this.moveHit(target, pokemon, move);
+			totalDamage = damage;
+		}
+
+		if (move.recoil) {
+			this.damage(this.clampIntRange(Math.round(totalDamage * move.recoil[0] / move.recoil[1]), 1), pokemon, target, 'recoil');
 		}
 
 		if (target && move.category !== 'Status') target.gotAttacked(move, damage, pokemon);

--- a/mods/gen1/scripts.js
+++ b/mods/gen1/scripts.js
@@ -827,13 +827,12 @@ exports.BattleScripts = {
 			this.heal(Math.ceil(damage * effect.drain[0] / effect.drain[1]), source, target, 'drain');
 		}
 
-		if (target.fainted) this.faint(target);
-		else {
+		if (target.fainted) {
+			this.faint(target);
+		} else {
 			damage = this.runEvent('AfterDamage', target, source, effect, damage);
-			if (effect && !effect.negateSecondary) {
-				this.runEvent('Secondary', target, source, effect);
-			}
 		}
+
 		return damage;
 	},
 	// This is random teams making for gen 1


### PR DESCRIPTION
- Recoil for Parental Bond Double Edge, etc should happen after all the hits have finished.
- Also removed the event 'Secondary', currently unused in the codebase.
