### PR TITLE
Updated commands.js for !smogintro

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -682,7 +682,7 @@ var commands = exports.commands = {
 	smogintro: function (target, room, user) {
 		if (!this.canBroadcast()) return;
 		this.sendReplyBox(
-			"Welcome to Smogon's Official Pokémon Showdown server! The Mentoring room can be found <a href=\"http://play.pokemonshowdown.com/communitymentoring\">here</a> or by using /join communitymentoring.<br /><br />" +
+			"Welcome to Smogon's Official Pokémon Showdown server!<br />" +
 			"Here are some useful links to Smogon\'s Mentorship Program to help you get integrated into the community:<br />" +
 			"- <a href=\"http://www.smogon.com/mentorship/primer\">Smogon Primer: A brief introduction to Smogon's subcommunities</a><br />" +
 			"- <a href=\"http://www.smogon.com/mentorship/introductions\">Introduce yourself to Smogon!</a><br />" +


### PR DESCRIPTION
!smogintro currently still displays the following message:
"The Mentoring room can be found here or by using /join communitymentoring." where 'here' is hyperlinked the play.pokemonshowdown.com/communitymentoring

However the room has been deleted and thus this is only confusing for users to see.
