### PR TITLE
NEXT: White smoke buffed

### DIFF
--- a/mods/gennext/abilities.js
+++ b/mods/gennext/abilities.js
@@ -265,6 +265,17 @@ exports.BattleAbilities = {
 			}
 		}
 	},
+	"whitesmoke": {
+		inherit: true,
+		onBoost: function (boost, target, source) {
+			for (var i in boost) {
+				if (boost[i]] < 0) {
+					delete boost[i];
+					this.add("-message", target.name + "'s stats were not lowered! (placeholder)");
+				}
+			}
+		}
+	},
 	"rockhead": {
 		inherit: true,
 		onModifyMove: function (move) {


### PR DESCRIPTION
For consistency, white smoke now works the same way that clear body does. Self inflicted stat drops are ignored.
