### PR TITLE
NEXT: Possible CompoundEyes fix in abilities.js

### DIFF
--- a/mods/gennext/abilities.js
+++ b/mods/gennext/abilities.js
@@ -216,7 +216,7 @@ exports.BattleAbilities = {
 		id: "keeneye",
 		name: "Keen Eye",
 		rating: 3.5,
-		num: 14
+		num: 51
 	},
 	"solidrock": {
 		inherit: true,


### PR DESCRIPTION
In normal abilities.js Compound Eyes is number 14 and Keen Eyes in 51. However here in NEXT both are 14, perhaps causing the incompatibility issues that come up when trying to use compound.
