### PR TITLE
NEXT: Upgraded move accuracy

### DIFF
--- a/mods/gennext/moves.js
+++ b/mods/gennext/moves.js
@@ -71,6 +71,7 @@ exports.BattleMovedex = {
 	},
 	cut: {
 		inherit: true,
+		accuracy: 100,
 		secondary: {
 			chance: 100,
 			boosts: {
@@ -1467,6 +1468,10 @@ exports.BattleMovedex = {
 		inherit: true,
 		accuracy: 100
 	},
+	flyingpress: {
+		inherit: true,
+		accuracy: 100
+	},
 	crushclaw: {
 		inherit: true,
 		accuracy: 100
@@ -1484,6 +1489,10 @@ exports.BattleMovedex = {
 		accuracy: 100
 	},
 	diamondstorm: {
+		inherit: true,
+		accuracy: 100
+	},
+	steameruption: {
 		inherit: true,
 		accuracy: 100
 	},
@@ -1523,6 +1532,14 @@ exports.BattleMovedex = {
 			status: 'brn'
 		}
 	},
+	dragonrush: {
+		inherit: true,
+		accuracy: 80
+	},
+	rocktomb: {
+		inherit: true,
+		accuracy: 100
+	},
 	fireblast: {
 		inherit: true,
 		accuracy: 80,
@@ -1531,9 +1548,21 @@ exports.BattleMovedex = {
 			status: 'brn'
 		}
 	},
+	irontail: {
+		inherit: true,
+		accuracy: 80
+	},
 	magmastorm: {
 		inherit: true,
 		accuracy: 80
+	},
+	megahorn: {
+		inherit: true,
+		accuracy: 90
+	},
+	megapunch: {
+		inherit: true,
+		accuracy: 90
 	},
 	megakick: {
 		inherit: true,
@@ -1551,9 +1580,17 @@ exports.BattleMovedex = {
 		inherit: true,
 		accuracy: 80
 	},
+	sweetkiss: {
+		inherit: true,
+		accuracy: 80
+	},
 	lovelykiss: {
 		inherit: true,
 		accuracy: 80
+	},
+	whirlpool: {
+		inherit: true,
+		accuracy: 90
 	},
 	eggbomb: {
 		inherit: true,


### PR DESCRIPTION
Justification:
all moves' accuracy is rounded up to the nearest multiple of 10%

95 -> 100% = Cut, Steam Eruption, Rock Tomb, Flying Press
85 -> 90% = Mega Horn, Mega Punch, Whirlpool
75 -> 80% = Dragon Rush, Iron Tail, Sweet Kiss
