### PR TITLE
NEXT: Signature Slash/Buffs

### DIFF
--- a/mods/gennext/moves.js
+++ b/mods/gennext/moves.js
@@ -1239,6 +1239,19 @@ exports.BattleMovedex = {
 			status: 'tox'
 		}
 	},
+	slash: {
+		inherit: true,
+		basePower: 60,
+		onBasePower: function (power, user) {
+			if (user.template.id === 'persian') return power * 1.5;
+		},
+		secondary: {
+			chance: 30,
+			boosts: {
+				def: -1
+			}
+		}
+	},
 	sludge: {
 		inherit: true,
 		basePower: 60,


### PR DESCRIPTION
Put slash down 10bp to 60 so Persian gets technician boost (otherwise it still wouldn't be usable) with the signature bonus.
Added 30% -1 defense chance to make it harder to stay on any Slash user (between crit RNG and defense RNG most would find it difficult/risky)
