### PR TITLE
NEXT: Buff Cute Charm

### DIFF
--- a/mods/gennext/abilities.js
+++ b/mods/gennext/abilities.js
@@ -112,6 +112,14 @@ exports.BattleAbilities = {
 			if (type === 'hail') return false;
 		}
 	},
+	"cutecharm": {
+		inherit: true,
+		onAfterDamage: function (damage, target, source, move) {
+			if (move && move.isContact) {
+				source.addVolatile('attract', target);
+			}
+		}
+	},
 	"static": {
 		inherit: true,
 		onAfterDamage: function (damage, target, source, move) {


### PR DESCRIPTION
Cute Charm now has a 100% chance of activating upon contact bringing it in line with Poison Point/Static changes and having the ability be viable.

Justification: other contact abilities were similarly buffed + the ability was garbage and nigh unusable and the mons who can use it won't be overpowered even with this change.
