### PR TITLE
Grammatical mistake

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -1350,7 +1350,7 @@ var commands = exports.commands = {
 		}
 		if (target === "%" || target === 'kickbattle ') {
 			matched = true;
-			this.sendReply("/kickbattle [username], [reason] - Kicks an user from a battle with reason. Requires: % @ & ~");
+			this.sendReply("/kickbattle [username], [reason] - Kicks a user from a battle with reason. Requires: % @ & ~");
 		}
 		if (target === "%" || target === 'warn' || target === 'k') {
 			matched = true;


### PR DESCRIPTION
The term "an" is only used when the word in-front is a 'consonant', any letter that is not a 'vowel' (a, e, i, o, u) whereas in this case, the term "an" is used/preferred over the term "a" although seeing examples above and below it is seemingly a mistake. This pull request is to fix that.
