### PR TITLE
NEXT: Gen 6 starters get new abilities

### DIFF
--- a/mods/gennext/scripts.js
+++ b/mods/gennext/scripts.js
@@ -92,6 +92,12 @@ exports.BattleScripts = {
 		this.modData('Pokedex', 'emboar').abilities['1'] = 'Sheer Force';
 		// Samurott
 		this.modData('Pokedex', 'samurott').abilities['1'] = 'Technician';
+		// Chesnaught
+		this.modData('Pokedex', 'chesnaught').abilities['1'] = 'Battle Armor';
+		// Delphox
+		this.modData('Pokedex', 'delphox').abilities['1'] = 'Magic Guard';
+		// Greninja
+		this.modData('Pokedex', 'greninja').abilities['1'] = 'Pickpocket';
 
 		// Levitate mons
 		this.modData('Pokedex', 'unown').abilities['1'] = 'Shadow Tag';


### PR DESCRIPTION
Greninja justification: Flavor purposes, a ninja is sneaky and it allows other options for Greninja.
Delphox justification: Magic guard makes sense on a magician, allowing sash and LO to be better on Delphox.
Chesnaught justification: Large armor for flavor and better defenses. Not Shell Armor since Blastoise also gets Shell Armor as a NEXT ability.
