### PR TITLE
Add /showtier to show what tier a Pokemon is in

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -633,8 +633,7 @@ var commands = exports.commands = {
 		this.sendReplyBox("" + atkName + " is " + factor + "x effective against " + defName + ".");
 	},
 	
-	st: 'showtier',
-	showtier: function(target, room, user) {
+	tier: function(target, room, user) {
         	if (!this.canBroadcast()) return;
         	var targetId = toId(target);
         	var newTargets = Tools.dataSearch(target);
@@ -931,7 +930,6 @@ var commands = exports.commands = {
 	},
 
 	banlists: 'tiers',
-	tier: 'tiers',
 	tiers: function (target, room, user) {
 		if (!this.canBroadcast()) return;
 		target = toId(target);


### PR DESCRIPTION
Named /showtier so it doesn't conflict with the existing /tier command
