### PR TITLE
Tiershift: Fix 'LC Uber' Pokemon being unchanged

### DIFF
--- a/mods/tiershift/scripts.js
+++ b/mods/tiershift/scripts.js
@@ -17,6 +17,7 @@ exports.BattleScripts = {
 			case 'BL3':
 			case 'NU':
 			case 'NFE':
+			case 'LC Uber':
 			case 'LC':
 				adjustment = 15;
 			}


### PR DESCRIPTION
Add a case for 'LC Uber', fixing a bug where Pokemon in the LC Uber tier did not receive any stat adjustments.
