### PR TITLE
Added bullet/pulse detection to /details

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -305,7 +305,7 @@ var commands = exports.commands = {
 					"Egg Group(s)": pokemon.eggGroups.join(", ")
 				};
 				if (!pokemon.evos.length) {
-					details["Evolution"] = "<font color=#585858>Does Not Evolve</font>";
+					details["<font color=#585858>Does Not Evolve</font>"] = "";
 				} else {
 					details["Evolution"] = pokemon.evos.map(function (evo) {
 						var evo = Tools.getTemplate(evo);
@@ -321,6 +321,8 @@ var commands = exports.commands = {
 				
 				if (move.secondary || move.secondaries) details["<font color=black>&#10003; Secondary Effect</font>"] = "";	
 				if (move.isContact) details["<font color=black>&#10003; Contact</font>"] = "";
+				if (move.isBullet) details["<font color=black>&#10003; Bullet</font>"] = "";
+				if (move.isPulseMove) details["<font color=black>&#10003; Pulse</font>"] = "";
 
 				details["Target"] = {
 					'normal': "Adjacent Pokemon",


### PR DESCRIPTION
Removed redundant use of "Evolution:"
Added return for pulse and bullet moves.

With how many parts to this command there are to manage, I was bound to miss a few. CAP Pokemon are still missing dex colors, and I'm considering removing the "Does Not Evolve" phrase entirely. The only reason I haven't is because all other parts of the pokemon details return 100% of the time, so removing just one element removes some consistency of how you look at the line while just glancing over it.

Either way this is still a minor improvement, and I'll wait a bit to get some more feedback before changing anything else. 
