### PR TITLE
Add recovery paramater to /dexsearch

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -377,6 +377,7 @@ var commands = exports.commands = {
 		var showAll = false;
 		var megaSearch = null;
 		var feSearch = null; // search for fully evolved pokemon only
+		var recoverySearch = null;
 		var output = 10;
 
 		for (var i in targets) {
@@ -438,6 +439,13 @@ var commands = exports.commands = {
 				feSearch = !isNotSearch;
 				continue;
 			}
+			
+			if (target === 'recovery') {
+				if ((recoverySearch && isNotSearch) || (recoverySearch === false && !isNotSearch)) return this.sendReplyBox('A search cannot both exclude and recovery moves.');
+				if (!searches['recovery']) searches['recovery'] = {};
+				recoverySearch = !isNotSearch;
+				continue;
+			}	
 
 			var targetMove = Tools.getMove(target);
 			if (targetMove.exists) {
@@ -474,7 +482,7 @@ var commands = exports.commands = {
 			}
 		}
 
-		for (var search in {'moves':1, 'types':1, 'ability':1, 'tier':1, 'gen':1, 'color':1}) {
+		for (var search in {'moves':1, 'recovery':1, 'types':1, 'ability':1, 'tier':1, 'gen':1, 'color':1}) {
 			if (!searches[search]) continue;
 			switch (search) {
 				case 'types':
@@ -541,6 +549,24 @@ var commands = exports.commands = {
 							var canLearn = (prevoTemp.learnset.sketch && !(move.id in {'chatter':1, 'struggle':1, 'magikarpsrevenge':1})) || prevoTemp.learnset[move.id];
 							if ((!canLearn && searches[search][i]) || (searches[search][i] === false && canLearn)) delete dex[mon];
 						}
+					}
+					break;
+
+				case 'recovery':
+					for (var mon in dex) {
+						var template = Tools.getTemplate(dex[mon].id);
+						if (!template.learnset) template = Tools.getTemplate(template.baseSpecies);
+						if (!template.learnset) continue;
+						var recoveryMoves = ["recover", "roost", "moonlight", "morningsun", "synthesis", "milkdrink", "slackoff", "softboiled", "wish", "healorder"];
+						for (var i = 0; i < recoveryMoves.length; i++) {
+							var prevoTemp = Tools.getTemplate(template.id);
+							while (prevoTemp.prevo && prevoTemp.learnset && !(prevoTemp.learnset[recoveryMoves[i]])) {
+								prevoTemp = Tools.getTemplate(prevoTemp.prevo);
+							}
+							var canLearn = (prevoTemp.learnset.sketch) || prevoTemp.learnset[recoveryMoves[i]];
+							if (canLearn) break;
+						}
+						if ((!canLearn && searches[search]) || (searches[search] === false && canLearn)) delete dex[mon];
 					}
 					break;
 


### PR DESCRIPTION
returns all Pokemon whom learn a recovery move (excluding rest)

Since often one does not care about which particular recovery move they use, dexsearching recovery moves in general is advantageous. 

an array was used to label the recovery moves instead of a map as it was difficult to check prevo move sets otherwise.
Slayer95 also suggested this as a possibility:  http://pastebin.com/hWdw75YH
However it seems to make the command mildly lag which does not seem like a good trade for reducing LoC.

![ss 2014-07-01 at 01 02 57](https://cloud.githubusercontent.com/assets/7889474/3440370/43679d30-00f6-11e4-8ff9-4af9a9e1c1ee.png)
