### PR TITLE
NEXT: Update moves

### DIFF
--- a/mods/gennext/moves.js
+++ b/mods/gennext/moves.js
@@ -944,12 +944,8 @@ exports.BattleMovedex = {
 		inherit: true,
 		accuracy: true
 	},
-	twineedle: {
-		inherit: true
-		accuracy: true
-	},
 	watershuriken: {
-		inherit: true
+		inherit: true,
 		accuracy: true
 	},
 	/******************************************************************
@@ -1629,6 +1625,7 @@ exports.BattleMovedex = {
 	******************************************************************/
 	twineedle: {
 		inherit: true,
+		accuracy: true,
 		basePower: 50
 	},
 	drillpeck: {


### PR DESCRIPTION
Triple kick, twineedle, and water shuriken now have perfect accuracy in keeping with the precedent set by other multi-hit moves.
Clear smog is a never miss move and now has 90 base power, allowing for a safer option over sludge bomb.
Quiver dance does not need any NEXT modifications because it will work the same as in OU as discussed in a previous pull request. Gossamer Wing will be changed later.
