### PR TITLE
Players can mute in battle rooms

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -226,6 +226,8 @@ exports.groups = {
 		id: "player",
 		name: "Player",
 		inherit: '+',
+		jurisdiction: 'u',
+		mute: true,
 		roomvoice: true,
 		modchat: true,
 		roomonly: true,


### PR DESCRIPTION
merged commands /mute and /hourmute
Players can now mute in battle rooms, excluding other users who can mute
(i.e. %, @).

Players should be able to control their spectator audience as long as they aren't interfering with other moderation actions. Modchat + can already silence all (non-auth) spectators, but frequently that is overkill if there is only one bad spectator chat presence. Voices can also be muted as voices causing problems spectating in matches has been an issue in the past.

It's very possible I made an oversight somewhere in here due to the frustrating nature of testings mutes, but I made considerable effort to test all arrangements of ranks muting other ranks in battle rooms to ensure I did not change something else by accident. 
