### PR TITLE
NEXT: Move changes

### DIFF
--- a/mods/gennext/moves.js
+++ b/mods/gennext/moves.js
@@ -971,7 +971,7 @@ exports.BattleMovedex = {
 		inherit: true,
 		basePower: 80,
 		onBasePower: function (power, user) {
-			var GossamerWingUsers = {"Butterfree":1, "Venomoth":1, "Masquerain":1, "Dustox":1, "Beautifly":1, "Mothim":1};
+			var GossamerWingUsers = {"Butterfree":1, "Venomoth":1, "Masquerain":1, "Dustox":1, "Beautifly":1, "Mothim":1, "Lilligant":1, "Volcarona":1, "Vivillon":1};
 			if (user.item === 'stick' && GossamerWingUsers[user.template.species]) {
 				return power * 1.5;
 			},


### PR DESCRIPTION
Twister now gets 1.5 times power if the user learns quiver dance and has a stick equipped and is not Smeargle. This is part of reworking gossamer wing (https://github.com/Zarel/Pokemon-Showdown/pull/938)

Steam eruption should work similarly to scald because of thematic and mechanics. Weather will be changed in the future because Volcanion is a powerhouse in both sun and rain, and the prevalence of perma-weather.
