### PR TITLE
Fix crash when room doesn't exist in getIdentity()

### DIFF
--- a/users.js
+++ b/users.js
@@ -346,7 +346,7 @@ var User = (function () {
 			return '!' + this.name;
 		}
 		var room = Rooms.rooms[roomid];
-		if (room.auth) {
+		if (room && room.auth) {
 			if (room.auth[this.userid]) {
 				return room.auth[this.userid] + this.name;
 			}


### PR DESCRIPTION
(It happens when you try to PM in a server without lobby)
