### PR TITLE
Fix more bugs with Protean

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1988,8 +1988,7 @@ exports.BattleAbilities = {
 	"protean": {
 		desc: "Right before this Pokemon uses a move, it changes its type to match that move. Hidden Power is interpreted as its Hidden Power type, rather than Normal.",
 		shortDesc: "Right before this Pokemon uses a move, it changes its type to match that move.",
-		onSourceTryPrimaryHit: function (target, source, move) {
-			if (!move || source.volatiles.mustrecharge) return;
+		onPrepareHit: function (source, target, move) {
 			if (source.getTypes().join() !== move.type) {
 				if (!source.setType(move.type)) return;
 				this.add('-start', source, 'typechange', move.type, '[from] Protean');

--- a/data/moves.js
+++ b/data/moves.js
@@ -2494,7 +2494,7 @@ exports.BattleMovedex = {
 		priority: 4,
 		stallingMove: true, // Note: stallingMove is not used anywhere.
 		volatileStatus: 'protect',
-		onTryHit: function (pokemon) {
+		onPrepareHit: function (pokemon) {
 			return !!this.willAct() && this.runEvent('StallMove', pokemon);
 		},
 		onHit: function (pokemon) {
@@ -3982,7 +3982,7 @@ exports.BattleMovedex = {
 		name: "Fire Pledge",
 		pp: 10,
 		priority: 0,
-		onTryHit: function (target, source, move) {
+		onPrepareHit: function (target, source, move) {
 			for (var i = 0; i < this.queue.length; i++) {
 				var decision = this.queue[i];
 				if (!decision.pokemon || !decision.move) continue;
@@ -4309,7 +4309,7 @@ exports.BattleMovedex = {
 				pokemon.setItem('');
 			}
 		},
-		onTryHit: function (target, source, move) {
+		onPrepareHit: function (target, source, move) {
 			if (!source.volatiles['fling']) return false;
 			var item = this.getItem(source.volatiles['fling'].item);
 			this.add("-enditem", source, item.name, '[from] move: Fling');
@@ -5140,7 +5140,7 @@ exports.BattleMovedex = {
 		name: "Grass Pledge",
 		pp: 10,
 		priority: 0,
-		onTryHit: function (target, source, move) {
+		onPrepareHit: function (target, source, move) {
 			for (var i = 0; i < this.queue.length; i++) {
 				var decision = this.queue[i];
 				if (!decision.pokemon || !decision.move) continue;
@@ -8834,7 +8834,7 @@ exports.BattleMovedex = {
 				pokemon.setItem('');
 			}
 		},
-		onTryHit: function (target, source) {
+		onPrepareHit: function (target, source) {
 			if (!source.volatiles['naturalgift']) return false;
 		},
 		onModifyMove: function (move, pokemon) {
@@ -9847,7 +9847,7 @@ exports.BattleMovedex = {
 		priority: 4,
 		stallingMove: true, // Note: stallingMove is not used anywhere.
 		volatileStatus: 'protect',
-		onTryHit: function (pokemon) {
+		onPrepareHit: function (pokemon) {
 			return !!this.willAct() && this.runEvent('StallMove', pokemon);
 		},
 		onHit: function (pokemon) {
@@ -14587,7 +14587,7 @@ exports.BattleMovedex = {
 		name: "Water Pledge",
 		pp: 10,
 		priority: 0,
-		onTryHit: function (target, source, move) {
+		onPrepareHit: function (target, source, move) {
 			for (var i = 0; i < this.queue.length; i++) {
 				var decision = this.queue[i];
 				if (!decision.pokemon || !decision.move) continue;

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -193,12 +193,20 @@ exports.BattleScripts = {
 			pokemon.hp = 0;
 		}
 
-		if ((move.affectedByImmunities && !target.runImmunity(move.type, true)) || (move.isSoundBased && (pokemon !== target || this.gen <= 4) && !target.runImmunity('sound', true))) {
+		this.setActiveMove(move, pokemon, target);
+		var hitResult = true;
+
+		hitResult = this.singleEvent('PrepareHit', move, {}, target, pokemon, move);
+		if (!hitResult) {
+			if (hitResult === false) this.add('-fail', target);
 			return false;
 		}
 
-		this.setActiveMove(move, pokemon, target);
-		var hitResult = true;
+		this.runEvent('PrepareHit', pokemon, target, move);
+
+		if ((move.affectedByImmunities && !target.runImmunity(move.type, true)) || (move.isSoundBased && (pokemon !== target || this.gen <= 4) && !target.runImmunity('sound', true))) {
+			return false;
+		}
 
 		if (typeof move.affectedByImmunities === 'undefined') {
 			move.affectedByImmunities = (move.category !== 'Status');


### PR DESCRIPTION
- Fix an issue introduced in 6539521adc, where Protean didn't activate if the target was immune to the move.
- Protean should not activate if the user fails a Detect/Protect, or the move is Fling or Natural Gift and the user has no item.
- Protean should not activate on the first turn of a Pledge Combo. Aditionally, fix Flash Fire/Storm Drain, etc being activated by the first move in the combo.
- Introduce event 'PrepareHit', which is ran after any move target is resolved but before immunity is checked.
