### PR TITLE
NEXT: Nerf armor and buff Cute Charm

### DIFF
--- a/mods/gennext/abilities.js
+++ b/mods/gennext/abilities.js
@@ -333,7 +333,7 @@ exports.BattleAbilities = {
 		onDamage: function (damage, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
 				this.add('-message', "Its damage was reduced by Shell Armor!");
-				damage -= target.maxhp / 16;
+				damage -= target.maxhp / 10;
 				if (damage < 0) damage = 0;
 				return damage;
 			}
@@ -349,7 +349,7 @@ exports.BattleAbilities = {
 		onDamage: function (damage, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
 				this.add('-message', "Its damage was reduced by Battle Armor!");
-				damage -= target.maxhp / 16;
+				damage -= target.maxhp / 10;
 				if (damage < 0) damage = 0;
 				return damage;
 			}
@@ -359,7 +359,7 @@ exports.BattleAbilities = {
 		onDamage: function (damage, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
 				this.add('-message', "Its damage was reduced by Weak Armor!");
-				damage -= target.maxhp / 16;
+				damage -= target.maxhp / 10;
 				if (damage < 0) damage = 0;
 				target.setAbility('');
 				this.boost({spe: 1});
@@ -376,7 +376,7 @@ exports.BattleAbilities = {
 		},
 		onDamage: function (damage, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
-				damage -= target.maxhp / 16;
+				damage -= target.maxhp / 10;
 				if (damage < 0) damage = 0;
 				if (effect.type === 'Ice' || effect.type === 'Water') {
 					this.add('-activate', target, 'ability: Magma Armor');


### PR DESCRIPTION
Cute charm buffed to always activate from this commit (https://github.com/Zarel/Pokemon-Showdown/pull/980) for consistency reasons. 
Extra comma removed in poison point.
Armor nerfed to 1/16 because blocking 1/8 per hit is almost the equivalent of poison heal, in addition to blocking critical hits and neutralizing multi hit moves.
