### PR TITLE
Remove ´watchFile´ global

### DIFF
--- a/app.js
+++ b/app.js
@@ -92,16 +92,8 @@ if (!fs.existsSync('./config/config.js')) {
 
 global.Config = require('./config/config.js');
 
-var watchFile = global.watchFile = function () {
-	try {
-		return fs.watchFile.apply(fs, arguments);
-	} catch (e) {
-		console.log('Your version of node does not support `fs.watchFile`');
-	}
-};
-
 if (Config.watchconfig) {
-	watchFile('./config/config.js', function (curr, prev) {
+	fs.watchFile('./config/config.js', function (curr, prev) {
 		if (curr.mtime <= prev.mtime) return;
 		try {
 			delete require.cache[require.resolve('./config/config.js')];

--- a/loginserver.js
+++ b/loginserver.js
@@ -227,7 +227,7 @@ var LoginServer = module.exports = (function () {
 	return LoginServer;
 })();
 
-watchFile('./config/custom.css', function (curr, prev) {
+require('fs').watchFile('./config/custom.css', function (curr, prev) {
 	LoginServer.request('invalidatecss', {}, function () {});
 });
 LoginServer.request('invalidatecss', {}, function () {});


### PR DESCRIPTION
Also, calls to ´fs.watchFile´ are no longer embedded in try-catch blocks, as its call would only crash in some platforms (Windows) in versions of Node.js no longer supported (before Node v0.8.0).
