### PR TITLE
Add an exception in Magic Guard's desc

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1415,7 +1415,7 @@ exports.BattleAbilities = {
 	},
 	"magicguard": {
 		desc: "Prevents all damage except from direct attacks.",
-		shortDesc: "This Pokemon can only be damaged by direct attacks.",
+		shortDesc: "This Pokemon can only be damaged by direct attacks except Belly Drum.",
 		onDamage: function (damage, target, source, effect) {
 			if (effect.effectType !== 'Move') {
 				return false;


### PR DESCRIPTION
Belly Drum takes away the HP of a Pokemon even if it's Magic Guard and adding that as an exception in it's description is better, at least imo.
