### PR TITLE
Update SockJS to 0.3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "sugar": "1.3.8",
     "node-static": "0.6.9",
-    "sockjs": "0.3.8",
+    "sockjs": "0.3.9",
     "es6-shim": "0.8.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
And, therefore, faye-websocket to 0.7.2, thus fixing a DoS vulnerability that affected PS some time ago.

(Relevant to non-official servers)
