### PR TITLE
fixed an error and added new doubles randbats moves

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -1620,7 +1620,7 @@ exports.BattleFormatsData = {
 	},
 	ambipom: {
 		randomBattleMoves: ["fakeout","return","knockoff","uturn","switcheroo","seedbomb","icepunch","lowkick"],
-		randomDoubleBattleMoves: ["Doublesfakeout","return","knockoff","uturn","switcheroo","seedbomb","icepunch","lowkick","protect"],
+		randomDoubleBattleMoves: ["fakeout","return","knockoff","uturn","switcheroo","seedbomb","icepunch","lowkick","protect"],
 		tier: "RU"
 	},
 	sunkern: {


### PR DESCRIPTION
I mistyped something in Ambipom's moveset so Fake Out was made unusable. Thankfully someone notified me and I fixed it now. Also, added movesets for a few new mons
