### PR TITLE
Enforcing the 510 EV limit in Balanced Hackmons

### DIFF
--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -67,6 +67,7 @@ exports.BattleFormats = {
 			var item = this.getItem(set.item);
 			var template = this.getTemplate(set.species);
 			var problems = [];
+			var totalEV = 0;
 
 			if (set.species === set.name) delete set.name;
 			if (template.gen > this.gen) {
@@ -108,6 +109,22 @@ exports.BattleFormats = {
 				}
 				if (item.isNonstandard) {
 					problems.push(item.name + ' is not a real item.');
+				}
+			}
+			for (var k in set.evs) {
+				if (typeof set.evs[k] !== 'number' || set.evs[k] < 0) {
+					set.evs[k] = 0;
+				}
+				totalEV += set.evs[k];
+			}
+			// In gen 6, it is impossible to battle other players with pokemon that break the EV limit
+			if (totalEV > 510 && this.gen >= 6) {
+				problems.push((set.name || set.species) + " has more than 510 total EVs.");
+			}
+			if (format.banlistTable['illegal']) {
+				// In gen 1 and 2, it was possible to max out all EVs
+				if (this.gen >= 3 && this.gen < 6 && totalEV > 510) {
+					problems.push((set.name || set.species) + " has more than 510 total EVs.");
 				}
 			}
 

--- a/team-validator.js
+++ b/team-validator.js
@@ -362,23 +362,7 @@ Validator = (function () {
 			}
 		}
 		setHas[toId(set.ability)] = true;
-		var totalEV = 0;
-		for (var k in set.evs) {
-			if (typeof set.evs[k] !== 'number' || set.evs[k] < 0) {
-				set.evs[k] = 0;
-			}
-			totalEV += set.evs[k];
-		}
-		// In gen 6, it is impossible to battle other players with pokemon that break the EV limit
-		if (totalEV > 510 && this.gen >= 6) {
-			problems.push(name + " has more than 510 total EVs.");
-		}
 		if (banlistTable['illegal']) {
-			// In gen 1 and 2, it was possible to max out all EVs
-			if (tools.gen >= 3 && totalEV > 510) {
-				problems.push(name + " has more than 510 total EVs.");
-			}
-
 			// Don't check abilities for metagames with All Abilities
 			if (tools.gen <= 2) {
 				set.ability = 'None';


### PR DESCRIPTION
I have tested this in several formats (Including Balanced Hackmons and Custom Game), and it works without any issue. I've even fixed the bug where the 510 ev message displays twice!

I've moved the EV block from team-validator.js to rulesets.js, and changed said block a bit to prevent it from throwing any errors or resulting in any bugs. This pull request and commit is effectively that. 
