### PR TITLE
slight tweak to random doubles set

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -3503,7 +3503,7 @@ exports.BattleFormatsData = {
 	},
 	uxie: {
 		randomBattleMoves: ["uturn","psyshock","yawn","healbell","stealthrock","toxic","thunderbolt","substitute","calmmind"],
-		randomDoubleBattleMoves: ["uturn","psyshock","yawn","healbell","stealthrock","thunderbolt","protect","helpinghand","thunderwave"],
+		randomDoubleBattleMoves: ["uturn","psyshock","yawn","healbell","stealthrock","thunderbolt","protect","helpinghand","thunderwave","skillswap"],
 		tier: "NU"
 	},
 	mesprit: {


### PR DESCRIPTION
Apparently since Joim put Facade in Kangaskhan's movepool it was causing people to get Toxic Orb on their Kangaskhans if it wasn't Mega Kangaskhan (lol). Anyways fixed this and added Protect to its movepool.
