### PR TITLE
Properly load banlist tables for modded formats

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1639,7 +1639,7 @@ exports.BattleScripts = {
 
 		// PotD stuff
 		var potd = {};
-		if ('Rule:potd' in this.getFormat().banlistTable) {
+		if ('Rule:potd' in this.getBanlistTable(this.getFormat())) {
 			potd = this.getTemplate(Config.potd);
 		}
 
@@ -1758,7 +1758,7 @@ exports.BattleScripts = {
 
 		// PotD stuff
 		var potd = {};
-		if ('Rule:potd' in this.getFormat().banlistTable) {
+		if ('Rule:potd' in this.getBanlistTable(this.getFormat())) {
 			potd = this.getTemplate(Config.potd);
 		}
 

--- a/mods/gen2/rulesets.js
+++ b/mods/gen2/rulesets.js
@@ -106,8 +106,8 @@ exports.BattleFormats = {
 	},
 	standard: {
 		effectType: 'Banlist',
-		ruleset: ['Sleep Clause', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause'],
-		banlist: ['Unreleased', 'Illegal', 'Ignore Illegal Abilities'],
+		ruleset: ['Sleep Clause Mod', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause'],
+		banlist: ['Unreleased', 'Illegal'],
 		validateSet: function (set) {
 			// limit one of each move in Standard
 			var moves = [];

--- a/mods/gen5/scripts.js
+++ b/mods/gen5/scripts.js
@@ -830,7 +830,7 @@ exports.BattleScripts = {
 
 		// PotD stuff
 		var potd = {};
-		if ('Rule:potd' in this.getFormat().banlistTable) {
+		if ('Rule:potd' in this.getBanlistTable(this.getFormat())) {
 			potd = this.getTemplate(Config.potd);
 		}
 

--- a/tools.js
+++ b/tools.js
@@ -388,7 +388,6 @@ module.exports = (function () {
 			effect.toString = this.effectToString;
 			if (!effect.category) effect.category = 'Effect';
 			if (!effect.effectType) effect.effectType = 'Effect';
-			this.getBanlistTable(effect);
 		}
 		return effect;
 	};


### PR DESCRIPTION
They are no longer loaded in Tools.getFormat, which could be called from any modded tools and cached the bans.

Apparently this got broken in some point before 0.9.1, and the related Gen 2 code never actually worked.
