### PR TITLE
Fairy Face-Off bans

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -133,6 +133,7 @@ exports.Formats = [
 		},
 		forcedLevel: 30,
 		ruleset: ['Pokemon', 'Standard GBU', 'Team Preview GBU'],
+		banlist: ['Diancie', 'Xerneas'],
 		requirePentagon: true,
 		validateTeam: function (team) {
 			var problems = [];


### PR DESCRIPTION
Arceus-Fairy, Diancie and Xerneas are banned. Didn't add Arceus because it isn't a Fairy-type and you can't run an Arceus-Fairy without using an Arceus and giving it Fairy Plate.
