### PR TITLE
changes to random doubles item generation

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1776,15 +1776,6 @@ exports.BattleScripts = {
 		}
 
 		var moveKeys = (template.randomDoubleBattleMoves || template.randomBattleMoves || Object.keys(template.learnset)).randomize();
-		// Make protect viable for everyone
-		// Delete this once all Pokémon have viable doubles sets
-		var hasProtectingMove = false;
-		for (var i = 0; i < moveKeys.length && !hasProtectingMove; i++) {
-			if (moveKeys[i] in {'protect':1, 'detect':1, 'kingsshield':1, 'spikyshield':1}) hasProtectingMove = true;
-		}
-		if (!hasProtectingMove) {
-			if (template.learnset && 'protect' in template.learnset) moveKeys.push('protect');
-		}
 		var moves = [];
 		var ability = '';
 		var item = '';
@@ -1996,7 +1987,7 @@ exports.BattleScripts = {
 					if (setupType || (hasMove['rest'] && hasMove['sleeptalk'])) rejected = true;
 					break;
 				case 'trick': case 'switcheroo':
-					if (setupType || (hasMove['rest'] && hasMove['sleeptalk']) || hasMove['trickroom'] || hasMove['reflect'] || hasMove['lightscreen'] || hasMove['batonpass']) rejected = true;
+					if (setupType || (hasMove['rest'] && hasMove['sleeptalk']) || hasMove['trickroom'] || hasMove['reflect'] || hasMove['lightscreen'] || hasMove['batonpass'] || item.megaStone) rejected = true;
 					break;
 				case 'dragontail': case 'circlethrow':
 					if (hasMove['agility'] || hasMove['rockpolish']) rejected = true;
@@ -2111,7 +2102,7 @@ exports.BattleScripts = {
 					if (hasMove['uturn'] || hasMove['voltswitch'] || hasMove['pursuit']) rejected = true;
 					break;
 				case 'fakeout':
-					if (hasMove['trick'] || hasMove['switcheroo']) rejected = true;
+					if (hasMove['trick'] || hasMove['switcheroo'] || ability === 'Sheer Force') rejected = true;
 					break;
 				case 'encore':
 					if (hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
@@ -2397,10 +2388,10 @@ exports.BattleScripts = {
 				item = 'Life Orb';
 			} else if (ability === 'Unburden') {
 				item = 'Red Card';
-				// Give Unburden mons a Normal Gem if they have a Normal-type attacking move
+				// Give Unburden mons a Normal Gem if they have Fake Out
 				for (var m in moves) {
 					var move = this.getMove(moves[m]);
-					if (move.type === 'Normal' && (move.basePower || move.basePowerCallback)) {
+					if (hasMove['fakeout']) {
 						item = 'Normal Gem';
 						break;
 					}
@@ -2425,17 +2416,18 @@ exports.BattleScripts = {
 				}
 			} else if (ability === 'Marvel Scale' && hasMove['psychoshift']) {
 				item = 'Flame Orb';
-			} else if (hasMove['reflect'] || hasMove['lightscreen']) {
-				// less priority than if you'd had both
-				item = 'Light Clay';
 			} else if (counter.Physical >= 4 && !hasMove['fakeout'] && !hasMove['suckerpunch'] && !hasMove['flamecharge'] && !hasMove['rapidspin']) {
-				item = 'Expert Belt';
+				item = 'Life Orb';
 			} else if (counter.Special >= 4) {
-				item = 'Expert Belt';
-			} else if (this.getEffectiveness('Ground', template) >= 2 && ability !== 'Levitate' && !hasMove['magnetrise']) {
+				item = 'Life Orb';
+            		} else if (this.getImmunity('Ground', template) && this.getEffectiveness('Ground', template) >= 1 && ability !== 'Levitate' && !hasMove['magnetrise']) {
 				item = 'Shuca Berry';
-			} else if (this.getEffectiveness('Ice', template) >= 1) {
+			} else if (this.getEffectiveness('Ice', template) >= 2) {
 				item = 'Yache Berry';
+            		} else if (this.getEffectiveness('Rock', template) >= 2) {
+				item = 'Charti Berry';
+            		} else if (this.getEffectiveness('Fire', template) >= 2) {
+				item = 'Occa Berry';
 			} else if (this.getImmunity('Fighting', template) && this.getEffectiveness('Fighting', template) >= 1) {
 				item = 'Chople Berry';
 			} else if (hasMove['substitute'] || hasMove['detect'] || hasMove['protect'] || ability === 'Moody') {
@@ -2461,8 +2453,6 @@ exports.BattleScripts = {
 			// this is the "REALLY can't think of a good item" cutoff
 			} else if (counter.Physical + counter.Special >= 2 && template.baseStats.hp + template.baseStats.def + template.baseStats.spd > 315) {
 				item = 'Weakness Policy';
-			} else if (this.getImmunity('Ground', template) && this.getEffectiveness('Ground', template) >= 1 && ability !== 'Levitate' && !hasMove['magnetrise']) {
-				item = 'Shuca Berry';
 			} else if (hasType['Poison']) {
 				item = 'Black Sludge';
 			} else if (counter.Status <= 1) {


### PR DESCRIPTION
- added charti & occa for 4x weaknesses
- made yache only for 4x weaknesses
- made it so you cant have fake out & sheer force 
- changed it so shuca berry and chople berry won't be added to immunities
- changed it so having light screen or reflect doesn't force you to have light clay
- changed it so pokemon with megastones no longer have trick
- unburden mons only have normal gem if they have fake out as opposed to any normal attacking move
- made life orb more common over expert belt
