### PR TITLE
Future Moves Bug Fix (Issue 567)

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -3125,7 +3125,7 @@ exports.BattleAbilities = {
 		desc: "This Pokemon only receives damage from attacks belonging to types that cause Super Effective to this Pokemon. Wonder Guard does not protect a Pokemon from status ailments (burn, freeze, paralysis, poison, sleep, Toxic or any of their side effects or damage), recoil damage nor the moves Beat Up, Bide, Doom Desire, Fire Fang, Future Sight, Hail, Leech Seed, Sandstorm, Spikes, Stealth Rock and Struggle. Wonder Guard cannot be Skill Swapped nor Role Played. Trace, however, does copy Wonder Guard.",
 		shortDesc: "This Pokemon can only be damaged by super effective moves and indirect damage.",
 		onTryHit: function (target, source, move) {
-			if (target === source || move.category === 'Status' || move.type === '???' || move.id === 'struggle') return;
+			if (target === source || move.category === 'Status' || move.type === '???' || move.id === 'struggle' || move.isFutureMove) return;
 			this.debug('Wonder Guard immunity: ' + move.id);
 			if (this.getEffectiveness(move, target) <= 0) {
 				this.add('-activate', target, 'ability: Wonder Guard');

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -314,6 +314,15 @@ exports.BattleStatuses = {
 				if (typeof posData.moveData.affectedByImmunities === 'undefined') {
 					posData.moveData.affectedByImmunities = true;
 				}
+				
+				if (target.hasAbility('wonderguard') && this.gen > 5) {
+					this.debug('Wonder Guard immunity: ' + move.id);
+					if (this.getEffectiveness(move, target) <= 0) {
+						this.add('-activate', target, 'ability: Wonder Guard');
+						this.effectData.positions[i] = null;
+						return null;
+					}
+				}
 
 				this.moveHit(target, posData.source, move, posData.moveData);
 


### PR DESCRIPTION
Future moves (Future Sight and Doom Desire) fail to activate if the opponent has Wonder Guard, and
deals damage if it activated beforehand to a Wonder Guard Pokemon that
is not weak to them. This commit fixes both of those issues.

https://github.com/Zarel/Pokemon-Showdown/issues/567
See this link for the original issue. And yes, I have tested this beforehand by activating said moves against a Wonder Guard Azumarill and Bergmite (yes the choices are random but functional).
