### PR TITLE
Prevent voices from entering tournament battles as a battler

### DIFF
--- a/rooms.js
+++ b/rooms.js
@@ -395,7 +395,7 @@ var GlobalRoom = (function () {
 				this.cancelSearch(user, true);
 				this.cancelSearch(searchUser, true);
 				user.send('|updatesearch|' + JSON.stringify({searching: false}));
-				this.startBattle(searchUser, user, search.formatid, true, search.team, newSearch.team);
+				this.startBattle(searchUser, user, search.formatid, search.team, newSearch.team, {rated: true});
 				return;
 			}
 		}
@@ -520,7 +520,7 @@ var GlobalRoom = (function () {
 		--this.userCount;
 		this.cancelSearch(user, true);
 	};
-	GlobalRoom.prototype.startBattle = function (p1, p2, format, rated, p1team, p2team) {
+	GlobalRoom.prototype.startBattle = function (p1, p2, format, p1team, p2team, options) {
 		var newRoom;
 		p1 = Users.get(p1);
 		p2 = Users.get(p2);
@@ -554,7 +554,7 @@ var GlobalRoom = (function () {
 		}
 		this.lastBattle = i;
 		rooms.global.writeNumRooms();
-		newRoom = this.addRoom('battle-' + formaturlid + '-' + i, format, p1, p2, this.id, rated);
+		newRoom = this.addRoom('battle-' + formaturlid + '-' + i, format, p1, p2, options);
 		p1.joinRoom(newRoom);
 		p2.joinRoom(newRoom);
 		newRoom.joinBattle(p1, p1team);
@@ -564,7 +564,7 @@ var GlobalRoom = (function () {
 		if (Config.reportbattles && rooms.lobby) {
 			rooms.lobby.add('|b|' + newRoom.id + '|' + p1.getIdentity() + '|' + p2.getIdentity());
 		}
-		if (Config.logladderip && rated) {
+		if (Config.logladderip && options.rated) {
 			if (!this.ladderIpLog) {
 				this.ladderIpLog = fs.createWriteStream('logs/ladderip/ladderip.txt', {flags: 'a'});
 			}
@@ -573,8 +573,8 @@ var GlobalRoom = (function () {
 		}
 		return newRoom;
 	};
-	GlobalRoom.prototype.addRoom = function (room, format, p1, p2, parent, rated) {
-		room = Rooms.createBattle(room, format, p1, p2, parent, rated);
+	GlobalRoom.prototype.addRoom = function (room, format, p1, p2, options) {
+		room = Rooms.createBattle(room, format, p1, p2, options);
 		return room;
 	};
 	GlobalRoom.prototype.chat = function (user, message, connection) {
@@ -588,7 +588,7 @@ var GlobalRoom = (function () {
 })();
 
 var BattleRoom = (function () {
-	function BattleRoom(roomid, format, p1, p2, parentid, rated) {
+	function BattleRoom(roomid, format, p1, p2, options) {
 		Room.call(this, roomid, "" + p1.name + " vs. " + p2.name);
 		this.modchat = (Config.battlemodchat || false);
 
@@ -600,7 +600,13 @@ var BattleRoom = (function () {
 
 		var formatid = toId(format);
 
-		if (rated && Tools.getFormat(formatid).rated !== false) {
+		// Sometimes we might allow BattleRooms to have no options
+		if (!options) {
+			options = {};
+		}
+
+		var rated;
+		if (options.rated && Tools.getFormat(formatid).rated !== false) {
 			rated = {
 				p1: p1.userid,
 				p2: p2.userid,
@@ -610,10 +616,20 @@ var BattleRoom = (function () {
 			rated = false;
 		}
 
+		if (options.tour) {
+			this.tour = {
+				p1: p1.userid,
+				p2: p2.userid,
+				format: format,
+				tour: options.tour
+			};
+		} else {
+			this.tour = false;
+		}
+
 		this.rated = rated;
 		this.battle = Simulator.create(this.id, format, rated, this);
 
-		this.parentid = parentid || '';
 		this.p1 = p1 || '';
 		this.p2 = p2 || '';
 
@@ -723,6 +739,10 @@ var BattleRoom = (function () {
 					}
 				});
 			}
+		}
+		if (this.tour) {
+			var tour = this.tour.tour;
+			tour.onBattleWin(this, winner);
 		}
 		rooms.global.battleCount += 0 - (this.active ? 1 : 0);
 		this.active = false;
@@ -1098,6 +1118,17 @@ var BattleRoom = (function () {
 			}
 		}
 
+		if (this.tour) {
+			if (this.tour.p1 === user.userid) {
+				slot = 0;
+			} else if (this.tour.p2 === user.userid) {
+				slot = 1;
+			} else {
+				user.popup("This is a tournament battle; your username must be " + this.tour.p1 + " or " + this.tour.p2 + " to join.");
+				return false;
+			}
+		}
+
 		if (this.battle.active) {
 			user.popup("This battle already has two players.");
 			return false;
@@ -1464,7 +1495,7 @@ Rooms.search = function (name, fallback) {
 	return getRoom(name) || getRoom(toId(name)) || Rooms.aliases[toId(name)] || (fallback ? rooms.global : undefined);
 };
 
-Rooms.createBattle = function (roomid, format, p1, p2, parent, rated) {
+Rooms.createBattle = function (roomid, format, p1, p2, options) {
 	if (roomid && roomid.id) return roomid;
 	if (!p1 || !p2) return false;
 	if (!roomid) roomid = 'default';
@@ -1472,7 +1503,7 @@ Rooms.createBattle = function (roomid, format, p1, p2, parent, rated) {
 		// console.log("NEW BATTLE ROOM: " + roomid);
 		ResourceMonitor.countBattle(p1.latestIp, p1.name);
 		ResourceMonitor.countBattle(p2.latestIp, p2.name);
-		rooms[roomid] = new BattleRoom(roomid, format, p1, p2, parent, rated);
+		rooms[roomid] = new BattleRoom(roomid, format, p1, p2, options);
 	}
 	return rooms[roomid];
 };

--- a/tournaments/index.js
+++ b/tournaments/index.js
@@ -630,7 +630,7 @@ Tournament = (function () {
 		if (!this.pendingChallenges.get(challenge.from)) return;
 		if (!this.pendingChallenges.get(user)) return;
 
-		var room = Rooms.global.startBattle(challenge.from, user, this.format, this.isRated, challenge.team, user.team);
+		var room = Rooms.global.startBattle(challenge.from, user, this.format, challenge.team, user.team, {rated: this.isRated, tour: this});
 		if (!room) return;
 
 		this.pendingChallenges.set(challenge.from, null);
@@ -644,12 +644,6 @@ Tournament = (function () {
 		this.isBracketInvalidated = true;
 		this.runAutoDisqualify();
 		this.update();
-
-		var self = this;
-		room.win = function (winner) {
-			self.onBattleWin(this, Users.get(winner));
-			return Object.getPrototypeOf(this).win.call(this, winner);
-		};
 	};
 	Tournament.prototype.onBattleWin = function (room, winner) {
 		var from = Users.get(room.p1);

--- a/users.js
+++ b/users.js
@@ -1460,7 +1460,7 @@ User = (function () {
 			}
 			return false;
 		}
-		Rooms.global.startBattle(this, user, user.challengeTo.format, false, this.team, user.challengeTo.team);
+		Rooms.global.startBattle(this, user, user.challengeTo.format, this.team, user.challengeTo.team, {rated: false});
 		delete this.challengesFrom[user.userid];
 		user.challengeTo = null;
 		this.updateChallenges();


### PR DESCRIPTION
~~Sets a variable inside battle rooms that should only be enabled when the
tournament script calls it. This variable prevents roomvoices from joining
the same way they are prevented in rated battles.~~

To mark battles as tournament battles, refactored battle room constructors 
to accept more generalized details. Said details currently process whether 
the battle is rated and whether it is a tournament, but can be expanded to 
check for more parameters.
