### PR TITLE
NEXT: Fix Weather affecting Steam Eruption's Base Power

### DIFF
--- a/mods/gennext/statuses.js
+++ b/mods/gennext/statuses.js
@@ -72,7 +72,7 @@ exports.BattleStatuses = {
 	raindance: {
 		inherit: true,
 		onBasePower: function (basePower, attacker, defender, move) {
-			if (move.id === 'scald') {
+			if (move.id === 'scald' || move.id === 'steameruption') {
 				return;
 			}
 			if (move.type === 'Water') {
@@ -88,7 +88,7 @@ exports.BattleStatuses = {
 	sunnyday: {
 		inherit: true,
 		onBasePower: function (basePower, attacker, defender, move) {
-			if (move.id === 'scald') {
+			if (move.id === 'scald' || move.id === 'steameruption') {
 				return;
 			}
 			if (move.type === 'Fire') {


### PR DESCRIPTION
Update weather data to not alter the Base Power of Steam Eruption, similar to Scald.
