### PR TITLE
Tournament code no longer overrides BattleRoom.win

### DIFF
--- a/rooms.js
+++ b/rooms.js
@@ -749,12 +749,12 @@ var BattleRoom = (function () {
 				});
 			}
 		}
-		// if (this.tour) {
-		// 	var winnerid = toId(winner);
-		// 	winner = Users.get(winner);
-		// 	var tour = this.tour.tour;
-		// 	tour.onBattleWin(this, winner);
-		// }
+		if (this.tour) {
+			var winnerid = toId(winner);
+			winner = Users.get(winner);
+			var tour = this.tour.tour;
+			tour.onBattleWin(this, winner);
+		}
 		rooms.global.battleCount += 0 - (this.active ? 1 : 0);
 		this.active = false;
 		this.update();

--- a/tournaments/index.js
+++ b/tournaments/index.js
@@ -138,7 +138,7 @@ Tournament = (function () {
 	Tournament.prototype.forceEnd = function () {
 		if (this.isTournamentStarted) {
 			this.inProgressMatches.forEach(function (match) {
-				if (match) delete match.room.win;
+				if (match) delete match.room.tour;
 			});
 		}
 		this.isEnded = true;
@@ -647,12 +647,6 @@ Tournament = (function () {
 		this.isBracketInvalidated = true;
 		this.runAutoDisqualify();
 		this.update();
-
-		var self = this;
-		room.win = function (winner) {
-			self.onBattleWin(this, Users.get(winner));
-			return Object.getPrototypeOf(this).win.call(this, winner);
-		};
 	};
 	Tournament.prototype.onBattleWin = function (room, winner) {
 		var from = Users.get(room.p1);


### PR DESCRIPTION
Since tournament battle rooms already keep track of the room where the
tournament began, it's possible to have the default `BattleRoom.win` submit
the results of the battle instead of having to override the function and
still call the old code.

The initial tournament code refactor had a bug that caused problems if a 
tournament was forcefully ended, leaving the tournament battle's win check 
confused. Adding a line of code to `Tournament.forceEnd` should have fixed this.
