### PR TITLE
Make Thousand Arrows only ignore Ground immunities

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -13825,7 +13825,12 @@ exports.BattleMovedex = {
 		pp: 10,
 		priority: 0,
 		isUnreleased: true,
-		affectedByImmunities: false,
+		onModifyMovePriority: -5,
+		onModifyMove: function (move) {
+			if (move.type === 'Ground') {
+				move.affectedByImmunities = false;
+			}
+		},
 		volatileStatus: 'smackdown',
 		secondary: false,
 		target: "normal",


### PR DESCRIPTION
Imitated Scrappy's syntax for letting certain types of moves to ignore
immunities instead of letting all immunities go through.

With regards to #1272.
