### PR TITLE
update musharna's tiering

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -3996,7 +3996,7 @@ exports.BattleFormatsData = {
 		eventPokemon: [
 			{"generation":5,"level":50,"isHidden":true,"moves":["defensecurl","luckychant","psybeam","hypnosis"]}
 		],
-		tier: "PU"
+		tier: "NU"
 	},
 	pidove: {
 		randomBattleMoves: ["pluck","uturn","return","detect","roost","wish"],


### PR DESCRIPTION
technically Musharna is now BL4, but because there isn't a BL4, I listed it as NU. as far as legality in NU and PU is concerned, this is accurate for the teambuilder and seems to be the best way to handle it.
