### PR TITLE
Send 'trapped' flag in requests for pokémon that are known trapped

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -158,7 +158,7 @@ exports.BattleAbilities = {
 			if (!this.isAdjacent(pokemon, this.effectData.target)) return;
 			if (!pokemon.runImmunity('Ground', false)) return;
 			if (!pokemon.hasType('Flying') || pokemon.hasType('ironball') || this.getPseudoWeather('gravity') || pokemon.volatiles['ingrain']) {
-				pokemon.tryTrap();
+				pokemon.tryTrap(true);
 			}
 		},
 		onFoeMaybeTrapPokemon: function (pokemon, source) {
@@ -1503,7 +1503,7 @@ exports.BattleAbilities = {
 		shortDesc: "Prevents Steel-type foes from switching out normally.",
 		onFoeModifyPokemon: function (pokemon) {
 			if (pokemon.hasType('Steel') && this.isAdjacent(pokemon, this.effectData.target)) {
-				pokemon.tryTrap();
+				pokemon.tryTrap(true);
 			}
 		},
 		onFoeMaybeTrapPokemon: function (pokemon, source) {
@@ -2299,7 +2299,7 @@ exports.BattleAbilities = {
 		shortDesc: "Prevents foes from switching out normally unless they also have this Ability.",
 		onFoeModifyPokemon: function (pokemon) {
 			if (!pokemon.hasAbility('shadowtag') && this.isAdjacent(pokemon, this.effectData.target)) {
-				pokemon.tryTrap();
+				pokemon.tryTrap(true);
 			}
 		},
 		onFoeMaybeTrapPokemon: function (pokemon, source) {

--- a/mods/gennext/abilities.js
+++ b/mods/gennext/abilities.js
@@ -570,15 +570,16 @@ exports.BattleAbilities = {
 		effect: {
 			onFoeModifyPokemon: function (pokemon) {
 				if (pokemon.ability !== 'shadowtag') {
-					pokemon.tryTrap();
+					pokemon.tryTrap(true);
 				}
 			}
 		},
 		onBeforeMove: function (pokemon) {
 			pokemon.removeVolatile('shadowtag');
 		},
-		onFoeMaybeTrapPokemon: function (pokemon) {
-			if (pokemon.ability !== 'shadowtag') {
+		onFoeMaybeTrapPokemon: function (pokemon, source) {
+			if (!source) source = this.effectData.target;
+			if (pokemon.ability !== 'shadowtag' && !source.lastMove) {
 				pokemon.maybeTrapped = true;
 			}
 		}


### PR DESCRIPTION
- BattlePokemon#isLastChoice now checks whether this is the last non-fainted active pokémon in a team.
- BattlePokemon#tryTrap now accepts an argument that, if true, will hide the fact that a pokémon is trapped.
- This should revert an small (annoying) change in the UI for locked moves introduced as a secondary effect in 8afc588e4.
- NEXT: Shadow Tag shouldn't activate the 'maybeTrapped' flag after the suspected Shadow Tagger has made a move.
