### PR TITLE
Add joim as an alias of join

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -597,6 +597,7 @@ var commands = exports.commands = {
 		Rooms.global.autojoinRooms(user, connection);
 	},
 
+	joim: 'join',
 	join: function (target, room, user, connection) {
 		if (!target) return false;
 		var targetRoom = Rooms.search(target);


### PR DESCRIPTION
In recognition of your outstanding accomplishments in the field of Pokémon sciences, we hereby award you the highest of honors; a commemorative alias.

Identical to #1018 and #1045, both of which were closed due to incorrect commit messages.
