### PR TITLE
Primal Reversion occurs before ability messages activate

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -2440,7 +2440,6 @@ Battle = (function () {
 		}
 		this.add('switch', pokemon, pokemon.getDetails);
 		pokemon.update();
-		this.runEvent('SwitchIn', pokemon);
 		this.addQueue({pokemon: pokemon, choice: 'runSwitch'});
 	};
 	Battle.prototype.canSwitch = function (side) {
@@ -2498,7 +2497,6 @@ Battle = (function () {
 		}
 		this.add('drag', pokemon, pokemon.getDetails);
 		pokemon.update();
-		this.runEvent('SwitchIn', pokemon);
 		this.addQueue({pokemon: pokemon, choice: 'runSwitch'});
 		return true;
 	};
@@ -3385,6 +3383,7 @@ Battle = (function () {
 			this.switchIn(decision.target, decision.pokemon.position);
 			break;
 		case 'runSwitch':
+			this.runEvent('SwitchIn', decision.pokemon);
 			decision.pokemon.isStarted = true;
 			if (!decision.pokemon.fainted) {
 				this.singleEvent('Start', decision.pokemon.getAbility(), decision.pokemon.abilityData, decision.pokemon);

--- a/data/items.js
+++ b/data/items.js
@@ -474,7 +474,8 @@ exports.BattleItems = {
 		id: "blueorb",
 		name: "Blue Orb",
 		spritenum: 41,
-		onStart: function (pokemon) {
+		onSwitchInPriority: -6,
+		onSwitchIn: function (pokemon) {
 			if (pokemon.isActive && pokemon.baseTemplate.species === 'Kyogre') {
 				var template = this.getTemplate('Kyogre-Primal');
 				pokemon.formeChange(template);
@@ -3598,7 +3599,8 @@ exports.BattleItems = {
 		id: "redorb",
 		name: "Red Orb",
 		spritenum: 390,
-		onStart: function (pokemon) {
+		onSwitchInPriority: -6,
+		onSwitchIn: function (pokemon) {
 			if (pokemon.isActive && pokemon.baseTemplate.species === 'Groudon') {
 				var template = this.getTemplate('Groudon-Primal');
 				pokemon.formeChange(template);


### PR DESCRIPTION
Shifted up the event for Red and Blue Orbs to `onSwitchIn` instead of
`onStart` to let them activate before ability activation messages.
