### PR TITLE
Fix Scrappy's interaction with Ion Deluge/Electrify

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2271,6 +2271,7 @@ exports.BattleAbilities = {
 	"scrappy": {
 		desc: "This Pokemon has the ability to hit Ghost-type Pokemon with Normal-type and Fighting-type moves. Effectiveness of these moves takes into account the Ghost-type Pokemon's other weaknesses and resistances.",
 		shortDesc: "This Pokemon can hit Ghost-types with Normal- and Fighting-type moves.",
+		onModifyMovePriority: -5,
 		onModifyMove: function (move) {
 			if (move.type in {'Fighting':1, 'Normal':1}) {
 				move.affectedByImmunities = false;


### PR DESCRIPTION
Give Scrappy a negative priority on its onModifyMove action because it was
causing Normal/Fighting moves affected by Electrify to hit Ground types.
