### PR TITLE
Correcting Hyperspace Fury's Category

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -6559,7 +6559,7 @@ exports.BattleMovedex = {
 		num: 621,
 		accuracy: true,
 		basePower: 100,
-		category: "Special",
+		category: "Physical",
 		desc: "Deals damage to one adjacent target and breaks through Protect and Detect for this turn, allowing other Pokemon to attack the target normally. Lowers the user's Defense by 1 stage. Makes contact.",
 		shortDesc: "Breaks protect and lowers user's Def. by 1.",
 		id: "hyperspacefury",


### PR DESCRIPTION
As shown in the below video (I also put the time in there for convenience), Hyperspace Fury is, in fact, a physical move and not a special move. Whether it still has its substitute-bypassing effects is unknown at this time, so I didn't touch those. No wonder Hoopa-U got that physical attack boost :P

http://youtu.be/NWB-oQQjHkw?t=1m35s
