### PR TITLE
Ability refactor - Abilities now receive End events properly

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -1033,6 +1033,7 @@ BattlePokemon = (function () {
 		}
 		if (ability.id in {illusion:1, multitype:1, stancechange:1}) return false;
 		if (oldAbility in {multitype:1, stancechange:1}) return false;
+		this.battle.singleEvent('End', this.battle.getAbility(oldAbility), this.abilityData, this, source, effect);
 		this.ability = ability.id;
 		this.abilityData = {id: ability.id, target: this};
 		if (ability.id && this.battle.gen > 3) {
@@ -1858,7 +1859,7 @@ Battle = (function () {
 			// it's changed; call it off
 			return relayVar;
 		}
-		if (target.ignore && target.ignore[effect.effectType]) {
+		if (target.ignore && target.ignore[effect.effectType] && target.ignore[effect.effectType] !== 'A') {
 			this.debug(eventid + ' handler suppressed by Gastro Acid, Klutz or Magic Room');
 			return relayVar;
 		}
@@ -2482,6 +2483,7 @@ Battle = (function () {
 				return false;
 			}
 			this.runEvent('SwitchOut', oldActive);
+			this.singleEvent('End', this.getAbility(oldActive.ability), oldActive.abilityData, oldActive);
 			oldActive.isActive = false;
 			oldActive.isStarted = false;
 			oldActive.position = pokemon.position;
@@ -3111,6 +3113,7 @@ Battle = (function () {
 			if (!faintData.target.fainted) {
 				this.add('faint', faintData.target);
 				this.runEvent('Faint', faintData.target, faintData.source, faintData.effect);
+				this.singleEvent('End', this.getAbility(faintData.target.ability), faintData.target.abilityData, faintData.target);
 				faintData.target.fainted = true;
 				faintData.target.isActive = false;
 				faintData.target.isStarted = false;
@@ -3364,6 +3367,7 @@ Battle = (function () {
 					// a switch-out.
 					break;
 				}
+				this.singleEvent('End', this.getAbility(decision.pokemon.ability), decision.pokemon.abilityData, decision.pokemon);
 			}
 			if (decision.pokemon && !decision.pokemon.hp && !decision.pokemon.fainted) {
 				// a pokemon fainted from Pursuit before it could switch

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -527,6 +527,20 @@ exports.BattleAbilities = {
 		onStart: function (source) {
 			this.setWeather('deltastream');
 		},
+		onEnd: function (pokemon) {
+			if (this.weatherData.source !== pokemon) return;
+			for (var i = 0; i < this.sides.length; i++) {
+				for (var j = 0; j < this.sides[i].active.length; j++) {
+					var target = this.sides[i].active[j];
+					if (target === pokemon) continue;
+					if (target && target.hp && target.ability === 'deltastream' && target.ignore['Ability'] !== true) {
+						this.weatherData.source = target;
+						return;
+					}
+				}
+			}
+			this.clearWeather();
+		},
 		id: "deltastream",
 		name: "Delta Stream",
 		rating: 5,
@@ -537,6 +551,20 @@ exports.BattleAbilities = {
 		shortDesc: "The weather becomes harsh sun until this Pokemon leaves battle.",
 		onStart: function (source) {
 			this.setWeather('desolateland');
+		},
+		onEnd: function (pokemon) {
+			if (this.weatherData.source !== pokemon) return;
+			for (var i = 0; i < this.sides.length; i++) {
+				for (var j = 0; j < this.sides[i].active.length; j++) {
+					var target = this.sides[i].active[j];
+					if (target === pokemon) continue;
+					if (target && target.hp && target.ability === 'desolateland' && target.ignore['Ability'] !== true) {
+						this.weatherData.source = target;
+						return;
+					}
+				}
+			}
+			this.clearWeather();
 		},
 		id: "desolateland",
 		name: "Desolate Land",
@@ -2004,6 +2032,20 @@ exports.BattleAbilities = {
 		shortDesc: "The weather becomes heavy rain until this Pokemon leaves battle.",
 		onStart: function (source) {
 			this.setWeather('primordialsea');
+		},
+		onEnd: function (pokemon) {
+			if (this.weatherData.source !== pokemon) return;
+			for (var i = 0; i < this.sides.length; i++) {
+				for (var j = 0; j < this.sides[i].active.length; j++) {
+					var target = this.sides[i].active[j];
+					if (target === pokemon) continue;
+					if (target && target.hp && target.ability === 'primordialsea' && target.ignore['Ability'] !== true) {
+						this.weatherData.source = target;
+						return;
+					}
+				}
+			}
+			this.clearWeather();
 		},
 		id: "primordialsea",
 		name: "Primordial Sea",

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -567,7 +567,6 @@ exports.BattleScripts = {
 		var oldAbility = pokemon.ability;
 		pokemon.setAbility(template.abilities['0']);
 		pokemon.baseAbility = pokemon.ability;
-		this.runEvent('EndAbility', pokemon, oldAbility);
 
 		side.megaEvo = 1;
 		for (var i = 0; i < side.pokemon.length; i++) side.pokemon[i].canMegaEvo = false;

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -440,23 +440,6 @@ exports.BattleStatuses = {
 			this.add('-weather', 'PrimordialSea', '[upkeep]');
 			this.eachEvent('Weather');
 		},
-		onEndAbility: function (pokemon, oldability) {
-			if (this.weatherData.source !== pokemon) return;
-			if (oldability !== 'primordialsea') return;
-			this.clearWeather();
-		},
-		onFaint: function (pokemon) {
-			if (this.weatherData.source !== pokemon) return;
-			this.clearWeather();
-		},
-		onDragOut: function (pokemon) {
-			if (this.weatherData.source !== pokemon) return;
-			this.clearWeather();
-		},
-		onSwitchOut: function (pokemon) {
-			if (this.weatherData.source !== pokemon) return;
-			this.clearWeather();
-		},
 		onEnd: function () {
 			this.add('-weather', 'none');
 		}
@@ -526,23 +509,6 @@ exports.BattleStatuses = {
 		onResidual: function () {
 			this.add('-weather', 'DesolateLand', '[upkeep]');
 			this.eachEvent('Weather');
-		},
-		onEndAbility: function (pokemon, oldability) {
-			if (this.weatherData.source !== pokemon) return;
-			if (oldability !== 'desolateland') return;
-			this.clearWeather();
-		},
-		onFaint: function (pokemon) {
-			if (this.weatherData.source !== pokemon) return;
-			this.clearWeather();
-		},
-		onDragOut: function (pokemon) {
-			if (this.weatherData.source !== pokemon) return;
-			this.clearWeather();
-		},
-		onSwitchOut: function (pokemon) {
-			if (this.weatherData.source !== pokemon) return;
-			this.clearWeather();
 		},
 		onEnd: function () {
 			this.add('-weather', 'none');
@@ -631,23 +597,6 @@ exports.BattleStatuses = {
 		onResidual: function () {
 			this.add('-weather', 'DeltaStream', '[upkeep]');
 			this.eachEvent('Weather');
-		},
-		onEndAbility: function (pokemon, oldability) {
-			if (this.weatherData.source !== pokemon) return;
-			if (oldability !== 'deltastream') return;
-			this.clearWeather();
-		},
-		onFaint: function (pokemon) {
-			if (this.weatherData.source !== pokemon) return;
-			this.clearWeather();
-		},
-		onDragOut: function (pokemon) {
-			if (this.weatherData.source !== pokemon) return;
-			this.clearWeather();
-		},
-		onSwitchOut: function (pokemon) {
-			if (this.weatherData.source !== pokemon) return;
-			this.clearWeather();
 		},
 		onEnd: function () {
 			this.add('-weather', 'none');

--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -567,14 +567,14 @@ exports.BattleMovedex = {
 	skillswap: {
 		inherit: true,
 		onHit: function (target, source) {
-			var targetAbility = target.ability;
-			var sourceAbility = source.ability;
-			if (!target.setAbility(sourceAbility) || !source.setAbility(targetAbility)) {
-				target.ability = targetAbility;
-				source.ability = sourceAbility;
+			var targetAbility = this.getAbility(target.ability);
+			var sourceAbility = this.getAbility(source.ability);
+			if (targetAbility.id === sourceAbility.id) {
 				return false;
 			}
 			this.add('-activate', source, 'move: Skill Swap');
+			source.setAbility(targetAbility);
+			target.setAbility(sourceAbility);
 		}
 	},
 	spikes: {

--- a/mods/gen4/moves.js
+++ b/mods/gen4/moves.js
@@ -838,12 +838,12 @@ exports.BattleMovedex = {
 		onHit: function (target, source) {
 			var targetAbility = target.ability;
 			var sourceAbility = source.ability;
-			if (!target.setAbility(sourceAbility) || !source.setAbility(targetAbility)) {
-				target.ability = targetAbility;
-				source.ability = sourceAbility;
+			if (targetAbility === sourceAbility) {
 				return false;
 			}
 			this.add('-activate', source, 'move: Skill Swap');
+			source.setAbility(targetAbility);
+			target.setAbility(sourceAbility);
 		}
 	},
 	spikes: {

--- a/mods/gen5/moves.js
+++ b/mods/gen5/moves.js
@@ -659,6 +659,19 @@ exports.BattleMovedex = {
 			}
 		}
 	},
+	skillswap: {
+		inherit: true,
+		onHit: function (target, source) {
+			var targetAbility = target.ability;
+			var sourceAbility = source.ability;
+			if (targetAbility === sourceAbility) {
+				return false;
+			}
+			this.add('-activate', source, 'move: Skill Swap', targetAbility, sourceAbility, '[of] ' + target);
+			source.setAbility(targetAbility);
+			target.setAbility(sourceAbility);
+		}
+	},
 	skullbash: {
 		inherit: true,
 		basePower: 100,


### PR DESCRIPTION
Fixed up setAbility to send End events to abilities, ~~and added a new
function canSetAbility so Skill Swap and other moves can properly check if
an ability can be set without resorting to purposefully getting false on
setAbility (especially for Skill Swap).~~

Fixed up the order of events fired off in Skill Swap to the correct order,
first firing off both End events, then both Start events, with the Pokemon
that used Skill Swap activating its ability first.

Fixed up the primal weathers to properly use the new End events.

Moved checks on switching and fainting from the weather into the ability
so that they can properly interact with Air Lock and Cloud Nine.
