### PR TITLE
Update aliases

### DIFF
--- a/data/aliases.js
+++ b/data/aliases.js
@@ -187,7 +187,7 @@ exports.BattleAliases = {
 	"flightgem": "Flying Gem",
 	"goggles": "Safety Goggles",
 	"lefties": "Leftovers",
-	"leppa": "Leppa berry"
+	"leppa": "Leppa Berry",
 	"lo": "Life Orb",
 	"lum": "Lum Berry",
 	"occa": "Occa Berry",


### PR DESCRIPTION
Adding BP for Baton Pass, Obama for Abomasnow (including its Mega), Sitrus for Sitrus berry and Leppa for Leppa Berry;
Moved sash's location for alphabetic consistency
