### PR TITLE
Allow global staff to find private battles with /whois

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -210,7 +210,7 @@ var commands = exports.commands = {
 		var canMute = user.can('mute', targetUser); // Don't perform this check on every room
 		for (var i in targetUser.roomCount) {
 			var targetRoom = Rooms.get(i);
-			if (i === 'global' || targetRoom.isPrivate && !canMute && targetRoom.type != "battle") continue;
+			if (i === 'global' || targetRoom.isPrivate && !canMute && targetRoom.type !== "battle") continue;
 			if (!first) output += " | ";
 			first = false;
 


### PR DESCRIPTION
Private battles are marked with a superscript P. Chatrooms will stay private.

/query remains unchanged, as it requires a client modification.

See #1306 
