### PR TITLE
Explosion and Self-Destruct bug-fix

### DIFF
--- a/battle-engine.js
+++ b/battle-engine.js
@@ -782,7 +782,6 @@ BattlePokemon = (function () {
 		var d = this.hp;
 		this.hp = 0;
 		this.switchFlag = false;
-		this.status = 'fnt';
 		this.battle.faintQueue.push({
 			target: this,
 			source: source,
@@ -2431,6 +2430,7 @@ Battle = (function () {
 			pokemon.position = pos;
 			side.pokemon[pokemon.position] = pokemon;
 			side.pokemon[oldActive.position] = oldActive;
+			if (oldActive.fainted) oldActive.status = 'fnt';
 			this.cancelMove(oldActive);
 			oldActive.clearVolatile();
 		}


### PR DESCRIPTION
https://github.com/Zarel/Pokemon-Showdown/issues/1287
Explosion and Self-Destruct were not affected by burn before, as shown in the above issue. This
commit effectively fixes that bug.

moves.js is not the place to put this check, due to the basePowerCallback being processed after scripts.js blows the pokemon up (I tested it this way initially). I placed this before the fainting action so that way burn can be checked, as placing it after would do nothing. I only needed two of these; the third one is simply where the HP is set to 0, and is after the first two have the possibility to be triggered (only one triggers due to the logic). This code has been tested and confirmed to work with no issues (32% unburned as opposed to 19% burned, with an 85 Attack EV Electrode Explosion versus a 85 HP and Defense EV Ho-Oh for each test).

In the future, if there is another physical self-destruct move, this code will also work for that without any modifications. Special/Status self-destruct moves are unaffected, regardless of burn.
