### PR TITLE
Add -ate Clause

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -603,7 +603,7 @@ exports.Formats = [
 		name: "Balanced Hackmons",
 		section: "Other Metagames",
 
-		ruleset: ['Pokemon', 'Ability Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Team Preview', 'HP Percentage Mod'],
+		ruleset: ['Pokemon', 'Ability Clause', '-ate Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Team Preview', 'HP Percentage Mod'],
 		banlist: ['Arena Trap', 'Huge Power', 'Parental Bond', 'Pure Power', 'Shadow Tag', 'Wonder Guard']
 	},
 	{

--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -381,6 +381,22 @@ exports.BattleFormats = {
 			}
 		}
 	},
+	ateclause: {
+		effectType: 'Rule',
+		onStart: function () {
+			this.add('rule', '-ate Clause: Limit one of Aerilate/Refrigerate/Pixilate');
+		},
+		validateTeam: function (team, format) {
+			var ateAbility = false;
+			for (var i = 0; i < team.length; i++) {
+				var ability = toId(team[i].ability);
+				if (ability === 'refrigerate' || ability === 'pixilate' || ability === 'aerilate') {
+					if (ateAbility) return ["You have more than one of Aerilate/Refrigerate/Pixilate, which is banned by -ate Clause."];
+					ateAbility = true;
+				}
+			}
+		}
+	},
 	ohkoclause: {
 		effectType: 'Rule',
 		onStart: function () {


### PR DESCRIPTION
http://www.smogon.com/forums/threads/balanced-hackmons.3489849/page-93#post-5908613

-ate abilities are only limited to 1 per team, total (so no Aerilate + Pixilate or double Aerilate). I believe I did what you asked me to do to make the code look nicer in a later post, @Slayer95. 

I've tested this by setting up: A Pixilate and an Aerilate Pokemon, 2 Aerilate Pokemon, 3 Aerilate Pokemon, and An Aerilate + Magic Bounce Pokemon. The last one was the only one without any errors (as in illegality issues, not actual js errors), and the rule dialog popped up as it should at the start of the battle for the last one as well (with all the others). 
