### PR TITLE
Fix wrong default path in repl.js

### DIFF
--- a/repl.js
+++ b/repl.js
@@ -6,7 +6,7 @@ var clearedPrefixes = {};
 exports.start = function (prefix, suffix, evalFunction) {
 	if (process.platform === 'win32') return; // Windows doesn't support sockets mounted in the filesystem
 
-	prefix = (Config.replsocketprefix || './repl/') + prefix;
+	prefix = (Config.replsocketprefix || './logs/repl/') + prefix;
 	if (!evalFunction) {
 		evalFunction = suffix;
 		suffix = "";


### PR DESCRIPTION
shouma already had some problems after pulling a server update:

```
CRASH: Error: ENOENT, no such file or directory './repl'
    at Object.fs.readdirSync (fs.js:665:18)
    at Object.exports.start (/home/shouma/showdown/Pokemon-Showdown/repl.js:20:6)
    at Object.<anonymous> (/home/shouma/showdown/Pokemon-Showdown/team-validator.js:156:23)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
```
