### PR TITLE
Helptickets: Add a shortcut command for appeals

### DIFF
--- a/chat-plugins/helptickets.js
+++ b/chat-plugins/helptickets.js
@@ -505,6 +505,16 @@ exports.commands = {
 		return this.parse('/join view-help-request--report');
 	},
 
+	'!appeal': true,
+	appeal: function (target, room, user, connection) {
+		if (!this.runBroadcast()) return;
+		if (this.broadcasting) {
+			return this.sendReplyBox('<button name="joinRoom" value="view-help-request--appeal" class="button"><strong>Appeal a punishment</strong></button>');
+		}
+
+		return this.parse('/join view-help-request--appeal');
+	},
+
 	requesthelp: 'helpticket',
 	helprequest: 'helpticket',
 	ht: 'helpticket',


### PR DESCRIPTION
Would of pushed this since its really simple and was already done with `/report`, but this doesn't really qualify as a simple bug fix, or a bug fix at all.

I think this would be a useful addition. Mostly for whenever i need to tell someone who is trying to appeal on forums to get in touch with a staff member on the simulator, or for when I'm really busy and I get a PM appeal (and can't take care of it at that time).