### PR TITLE
Leech Seed + Toxic is not fixed in Stadium

### DIFF
--- a/mods/stadium/moves.js
+++ b/mods/stadium/moves.js
@@ -45,6 +45,12 @@ exports.BattleMovedex = {
 					this.debug('Nothing to leech into');
 					return;
 				}
+				// We check if leeched Pokémon has Toxic to increase leeched damage.
+				let toxicCounter = 1;
+				if (pokemon.volatiles['residualdmg']) {
+					pokemon.volatiles['residualdmg'].counter++;
+					toxicCounter = pokemon.volatiles['residualdmg'].counter;
+				}
 				let toLeech = this.clampIntRange(Math.floor(pokemon.maxhp / 16), 1);
 				let damage = this.damage(toLeech, pokemon, leecher);
 				if (damage) this.heal(damage, leecher, pokemon);


### PR DESCRIPTION
Appropriate battle log: https://replay.pokemonshowdown.com/gen1stadium-709623169

Leech Seed should increment Toxic counter, and have the HP drained accordingly.
The HP drained shouldn't be higher than the target's remaining HP,