### PR TITLE
Fix Pomeg Glitch for certain evolutions

### DIFF
--- a/sim/team-validator.js
+++ b/sim/team-validator.js
@@ -1052,7 +1052,7 @@ class Validator {
 							// we're past the required level to learn it
 							// (gen 7 level-up moves can be relearnered at any level)
 							// falls through to LMT check below
-						} else if (level >= 5 && learnedGen === 3 && template.eggGroups && template.eggGroups[0] !== 'Undiscovered') {
+						} else if (level >= 5 && learnedGen === 3 && template.eggGroups && (template.eggGroups[0] !== 'Undiscovered' || dex.getTemplate(template.evos[0]).eggGroups[0] !== 'Undiscovered')) {
 							// Pomeg Glitch
 						} else if ((!template.gender || template.gender === 'F') && learnedGen >= 2) {
 							// available as egg move


### PR DESCRIPTION
This should fix the Wynaut glitch.
Basically, Wynaut is Undiscovered, but Pomeg glitch still applies because its evolution can breed. Nidoran-F is the opposite (it is not undiscovered, but its evolutions are), so I think the double check is necessary.

This line gets long and convoluted, but I'm not sure what a better version would be.