### PR TITLE
Fix Roar failure message

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -728,7 +728,7 @@ let BattleScripts = {
 				didSomething = didSomething || hitResult;
 			}
 			if (moveData.forceSwitch) {
-				hitResult = this.canSwitch(target.side);
+				hitResult = !!this.canSwitch(target.side);
 				didSomething = didSomething || hitResult;
 			}
 			if (moveData.selfSwitch) {


### PR DESCRIPTION
Roar et al. will now properly display "But it failed!" when used on a team's last poke, rather than being silent