### PR TITLE
Magic Bounce and Rebound should not use old protocol messages

### DIFF
--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -208,7 +208,7 @@ export const Scripts: BattleScriptsData = {
 
 		let movename = move.name;
 		if (move.id === 'hiddenpower') movename = 'Hidden Power';
-		if (sourceEffect) attrs += '|[from]' + this.dex.getEffect(sourceEffect);
+		if (sourceEffect) attrs += `|[from]S{sourceEffect.fullname}`;
 		if (zMove && move.isZ === true) {
 			attrs = '|[anim]' + movename + attrs;
 			movename = 'Z-' + movename;


### PR DESCRIPTION
Reported [here](https://www.smogon.com/forums/posts/7995630). This is going to need client-side changes too (both for the [Pokémon's Magic Bounce] text and the ability activation animation) but this will simplify the necessary changes (I think the old code had to special-case Magic Bounce and Rebound to achieve this).