### PR TITLE
Random Battle: Enforce Psychic STAB on strong mono-Psychic mons

### DIFF
--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -1155,6 +1155,7 @@ class RandomTeams extends Dex.ModdedDex {
 					(hasType['Ground'] && !counter['Ground'] && !hasMove['rest'] && !hasMove['sleeptalk']) ||
 					(hasType['Ice'] && !counter['Ice'] && !hasAbility['Refrigerate']) ||
 					(hasType['Psychic'] && !!counter['Psychic'] && !hasType['Flying'] && !hasAbility['Pixilate'] && template.types.length > 1 && counter.stab < 2) ||
+					(hasType['Psychic'] && !counter['Psychic'] && template.types.length < 2 && template.baseStats.spa >= 120) ||
 					(((hasType['Steel'] && hasAbility['Technician']) || hasAbility['Steelworker']) && !counter['Steel']) ||
 					(hasType['Water'] && (!counter['Water'] || !counter.stab) && !hasAbility['Protean']) ||
 					// @ts-ignore


### PR DESCRIPTION
Right now, Psychic is one of the few types that does not enforce STAB,
but many powerful mono-Psychic Pokemon still appreciate a Psychic move.

As such, add a check for mono-Psychic to have a Psychic move, but only
if its Special Attack passes a certain threshold. This affects Alakazam
(regular and Mega), Mewtwo (regular and Mega-Y), Deoxys (normal and
Attack), Azelf, and Necrozma (normal).