### PR TITLE
Pikachu-Alola is not an Alola form for dex search

### DIFF
--- a/chat-plugins/datasearch.js
+++ b/chat-plugins/datasearch.js
@@ -722,7 +722,8 @@ function runDexsearch(target, cmd, canAll, message) {
 	}
 	let results = [];
 	for (const mon of Object.keys(dex).sort()) {
-		if (dex[mon].forme !== "Alola" && dex[mon].baseSpecies && results.includes(dex[mon].baseSpecies)) continue;
+		const isAlola = dex[mon].forme === "Alola" && dex[mon].species !== "Pikachu-Alola";
+		if (!isAlola && dex[mon].baseSpecies && results.includes(dex[mon].baseSpecies)) continue;
 		results.push(dex[mon].species);
 	}
 


### PR DESCRIPTION
The intent of a recent dexsearch change was to display Alola formes separately as they are very different. However, this also meant showing Pikachu-Alola which is not an Alola form despite having "Alola" as a forme name.