### PR TITLE
Life Orb/Shell Bell should take effect before Pickpocket

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -297,6 +297,7 @@ let BattleAbilities = {
 	"berserk": {
 		desc: "When this Pokemon has more than 1/2 its maximum HP and takes damage from an attack bringing it to 1/2 or less of its maximum HP, its Special Attack is raised by 1 stage. This effect applies after all hits from a multi-hit move; Sheer Force prevents it from activating if the move has a secondary effect.",
 		shortDesc: "This Pokemon's Sp. Atk is raised by 1 when it reaches 1/2 or less of its max HP.",
+		onAfterMoveSecondaryPriority: 4,
 		onAfterMoveSecondary(target, source, move) {
 			if (!source || source === target || !target.hp || !move.totalDamage) return;
 			const lastAttackedBy = target.getLastAttackedBy();
@@ -422,6 +423,7 @@ let BattleAbilities = {
 	"colorchange": {
 		desc: "This Pokemon's type changes to match the type of the last move that hit it, unless that type is already one of its types. This effect applies after all hits from a multi-hit move; Sheer Force prevents it from activating if the move has a secondary effect.",
 		shortDesc: "This Pokemon's type changes to the type of a move it's hit by, unless it has the type.",
+		onAfterMoveSecondaryPriority: 4,
 		onAfterMoveSecondary(target, source, move) {
 			if (!target.hp) return;
 			let type = move.type;
@@ -2323,6 +2325,7 @@ let BattleAbilities = {
 	"pickpocket": {
 		desc: "If this Pokemon has no item, it steals the item off a Pokemon that makes contact with it. This effect applies after all hits from a multi-hit move; Sheer Force prevents it from activating if the move has a secondary effect.",
 		shortDesc: "If this Pokemon has no item, it steals the item off a Pokemon making contact with it.",
+		onAfterMoveSecondaryPriority: -1,
 		onAfterMoveSecondary(target, source, move) {
 			if (source && source !== target && move && move.flags['contact']) {
 				if (target.item) {

--- a/data/items.js
+++ b/data/items.js
@@ -2742,6 +2742,7 @@ let BattleItems = {
 			basePower: 100,
 			type: "Fairy",
 		},
+		onAfterMoveSecondaryPriority: 3,
 		onAfterMoveSecondary(target, source, move) {
 			if (move.category === 'Physical') {
 				target.eatItem();
@@ -2999,6 +3000,7 @@ let BattleItems = {
 		onModifyDamage(damage, source, target, move) {
 			return this.chainModify([0x14CC, 0x1000]);
 		},
+		onSourceAfterMoveSecondaryPriority: 1,
 		onSourceAfterMoveSecondary(target, source, move) {
 			if (source && source !== target && move && move.category !== 'Status') {
 				this.damage(source.maxhp / 10, source, source, this.dex.getItem('lifeorb'));
@@ -3316,6 +3318,7 @@ let BattleItems = {
 			basePower: 100,
 			type: "Dark",
 		},
+		onAfterMoveSecondaryPriority: 3,
 		onAfterMoveSecondary(target, source, move) {
 			if (move.category === 'Special') {
 				target.eatItem();
@@ -4675,6 +4678,7 @@ let BattleItems = {
 		fling: {
 			basePower: 10,
 		},
+		onAfterMoveSecondaryPriority: 2,
 		onAfterMoveSecondary(target, source, move) {
 			if (source && source !== target && source.hp && target.hp && move && move.category !== 'Status') {
 				if (!source.isActive || !this.canSwitch(source.side) || source.forceSwitchFlag || target.forceSwitchFlag) return;
@@ -5119,6 +5123,7 @@ let BattleItems = {
 		fling: {
 			basePower: 30,
 		},
+		onSourceAfterMoveSecondaryPriority: 1,
 		onSourceAfterMoveSecondary(target, pokemon, move) {
 			if (move.category !== 'Status') {
 				this.heal(pokemon.lastDamage / 8, pokemon);

--- a/data/items.js
+++ b/data/items.js
@@ -2999,7 +2999,7 @@ let BattleItems = {
 		onModifyDamage(damage, source, target, move) {
 			return this.chainModify([0x14CC, 0x1000]);
 		},
-		onAfterMoveSecondarySelf(source, target, move) {
+		onSourceAfterMoveSecondary(target, source, move) {
 			if (source && source !== target && move && move.category !== 'Status') {
 				this.damage(source.maxhp / 10, source, source, this.dex.getItem('lifeorb'));
 			}
@@ -5119,8 +5119,7 @@ let BattleItems = {
 		fling: {
 			basePower: 30,
 		},
-		onAfterMoveSecondarySelfPriority: -1,
-		onAfterMoveSecondarySelf(pokemon, target, move) {
+		onSourceAfterMoveSecondary(target, pokemon, move) {
 			if (move.category !== 'Status') {
 				this.heal(pokemon.lastDamage / 8, pokemon);
 			}

--- a/data/mods/gen1/scripts.js
+++ b/data/mods/gen1/scripts.js
@@ -241,11 +241,6 @@ let BattleScripts = {
 			this.singleEvent('MoveFail', move, null, target, pokemon, move);
 			return true;
 		}
-
-		if (!move.negateSecondary) {
-			this.singleEvent('AfterMoveSecondarySelf', move, null, pokemon, target, move);
-			this.runEvent('AfterMoveSecondarySelf', pokemon, target, move);
-		}
 		return true;
 	},
 	// tryMoveHit can be found on scripts.js

--- a/data/mods/gen2/statuses.js
+++ b/data/mods/gen2/statuses.js
@@ -76,7 +76,7 @@ let BattleStatuses = {
 				target.cureStatus();
 			}
 		},
-		onAfterMoveSecondarySelf(pokemon, target, move) {
+		onSourceAfterMoveSecondary(target, pokemon, move) {
 			if (move.flags['defrost']) pokemon.cureStatus();
 		},
 		onResidual(pokemon) {

--- a/data/mods/gen3/scripts.js
+++ b/data/mods/gen3/scripts.js
@@ -155,11 +155,6 @@ let BattleScripts = {
 			this.singleEvent('MoveFail', move, null, target, pokemon, move);
 			return false;
 		}
-
-		if (!move.negateSecondary && !(move.hasSheerForce && pokemon.hasAbility('sheerforce'))) {
-			this.singleEvent('AfterMoveSecondarySelf', move, null, pokemon, target, move);
-			this.runEvent('AfterMoveSecondarySelf', pokemon, target, move);
-		}
 		return true;
 	},
 	tryMoveHit(target, pokemon, move) {

--- a/data/mods/gen4/items.js
+++ b/data/mods/gen4/items.js
@@ -152,7 +152,7 @@ let BattleItems = {
 	"lifeorb": {
 		inherit: true,
 		onModifyDamage() {},
-		onAfterMoveSecondarySelf() {},
+		onSourceAfterMoveSecondary() {},
 		onBasePower(basePower, user, target) {
 			if (!target.volatiles['substitute']) {
 				user.addVolatile('lifeorb');
@@ -164,7 +164,7 @@ let BattleItems = {
 		},
 		effect: {
 			duration: 1,
-			onAfterMoveSecondarySelf(source, target, move) {
+			onSourceAfterMoveSecondary(target, source, move) {
 				if (move && move.effectType === 'Move' && source && source.volatiles['lifeorb']) {
 					this.damage(source.maxhp / 10, source, source, this.dex.getItem('lifeorb'));
 					source.removeVolatile('lifeorb');

--- a/data/mods/gen4/moves.js
+++ b/data/mods/gen4/moves.js
@@ -931,8 +931,8 @@ let BattleMovedex = {
 		desc: "Until the end of the next turn, the target cannot avoid the user's moves, even if the target is in the middle of a two-turn move. When this effect is started against the target, this and Mind Reader's effects end for every other Pokemon against that target. If the target leaves the field using Baton Pass, the replacement remains under this effect. If the user leaves the field using Baton Pass, this effect is restarted against the same target for the replacement. The effect ends if either the user or the target leaves the field.",
 		effect: {
 			duration: 2,
-			onSourceInvulnerabilityPriority: 1,
-			onSourceInvulnerability(target, source, move) {
+			onAnyInvulnerabilityPriority: 1,
+			onAnyInvulnerability(target, source, move) { // onSourceInvulnerability would only run once
 				if (move && source === this.effectData.target && target === this.effectData.source) return 0;
 			},
 			onSourceAccuracy(accuracy, target, source, move) {

--- a/data/mods/gen5/moves.js
+++ b/data/mods/gen5/moves.js
@@ -913,7 +913,7 @@ let BattleMovedex = {
 		shortDesc: "Effect varies with terrain. (30% chance acc -1)",
 		effect: {
 			duration: 1,
-			onAfterMoveSecondarySelf(source, target, move) {
+			onSourceAfterMoveSecondary(target, source, move) {
 				if (this.randomChance(3, 10)) {
 					this.boost({accuracy: -1}, target, source);
 				}

--- a/data/mods/gen6/items.js
+++ b/data/mods/gen6/items.js
@@ -75,7 +75,7 @@ let BattleItems = {
 	},
 	lifeorb: {
 		inherit: true,
-		onAfterMoveSecondarySelf(source, target, move) {
+		onSourceAfterMoveSecondary(target, source, move) {
 			if (source && source !== target && move && move.category !== 'Status' && !move.ohko) {
 				this.damage(source.maxhp / 10, source, source, this.dex.getItem('lifeorb'));
 			}

--- a/data/mods/gen6/moves.js
+++ b/data/mods/gen6/moves.js
@@ -132,7 +132,7 @@ let BattleMovedex = {
 		desc: "Raises the user's Attack by 2 stages if this move knocks out the target.",
 		shortDesc: "Raises user's Attack by 2 if this KOes the target.",
 		basePower: 30,
-		onAfterMoveSecondarySelf(pokemon, target, move) {
+		onAfterMoveSecondary(target, pokemon, move) {
 			if (!target || target.fainted || target.hp <= 0) this.boost({atk: 2}, pokemon, pokemon, move);
 		},
 	},

--- a/data/mods/gennext/items.js
+++ b/data/mods/gennext/items.js
@@ -43,7 +43,7 @@ let BattleItems = {
 	},
 	"bigroot": {
 		inherit: true,
-		onAfterMoveSecondarySelf(source, target) {
+		onSourceAfterMoveSecondary(target, source) {
 			if (source.hasType('Grass')) {
 				this.heal(source.lastDamage / 8, source);
 			}
@@ -165,7 +165,7 @@ let BattleItems = {
 				}
 			}
 		},
-		onAfterMoveSecondarySelf(source, target, move) {
+		onSourceAfterMoveSecondary(target, source, move) {
 			let GossamerWingUsers = ["Butterfree", "Masquerain", "Beautifly", "Mothim", "Vivillon"];
 			if (move && move.effectType === 'Move' && move.category === 'Status' && GossamerWingUsers.includes(source.template.species)) {
 				this.heal(source.maxhp / 16);

--- a/data/mods/ssb/moves.js
+++ b/data/mods/ssb/moves.js
@@ -198,7 +198,7 @@ let BattleMovedex = {
 			this.add('-anim', source, "Continental Crush", target);
 			this.add('-anim', source, "Giga Impact", target);
 		},
-		onAfterMoveSecondarySelf(pokemon) {
+		onAfterMoveSecondary(target, pokemon) {
 			pokemon.clearBoosts();
 			this.add('-clearboost', pokemon);
 			this.boost({atk: -1, def: -1, spe: -1}, pokemon, pokemon, this.dex.getActiveMove('Cataclysm'));
@@ -1095,7 +1095,7 @@ let BattleMovedex = {
 			this.add('-anim', source, 'Swords Dance', source);
 			this.add('-anim', source, 'Bloom Doom', target);
 		},
-		onAfterMoveSecondarySelf() {
+		onAfterMoveSecondary() {
 			this.field.setTerrain('grassyterrain');
 		},
 		onAfterMove(pokemon) {
@@ -1553,7 +1553,7 @@ let BattleMovedex = {
 			this.add('-anim', source, 'Eruption', target);
 			this.add('-anim', source, 'Sunny Day', source);
 		},
-		onAfterMoveSecondarySelf() {
+		onAfterMoveSecondary() {
 			this.field.setWeather('sunnyday');
 		},
 		secondary: null,
@@ -2270,7 +2270,7 @@ let BattleMovedex = {
 		onPrepareHit(target, source) {
 			this.add('-anim', source, "Draco Meteor", target);
 		},
-		onAfterMoveSecondarySelf(pokemon, target, move) {
+		onAfterMoveSecondary(target, pokemon, move) {
 			this.heal(pokemon.maxhp * 0.15, pokemon, pokemon, move); // 15% health recovered
 		},
 		secondary: null,
@@ -3018,7 +3018,7 @@ let BattleMovedex = {
 			this.add('-anim', source, "Dragon Hammer", target);
 			this.add('-anim', target, "Earthquake", target);
 		},
-		onAfterMoveSecondarySelf(pokemon) {
+		onAfterMoveSecondary(target, pokemon) {
 			let stockpileLayers = 0;
 			if (pokemon.volatiles['stockpile']) stockpileLayers = pokemon.volatiles['stockpile'].layers;
 			let boosts = {};
@@ -4059,7 +4059,7 @@ let BattleMovedex = {
 			this.add('-anim', source, zmove.name, target);
 			this.add('-anim', source, "Transform", source);
 		},
-		onAfterMoveSecondarySelf(pokemon, move) {
+		onAfterMoveSecondary(target, pokemon, move) {
 			/** @type {{[move: string]: string[]}} */
 			let claims = {
 				bravebird: ['Braviary', 'Crobat', 'Decidueye', 'Dodrio', 'Farfetch\'d', 'Golbat', 'Mandibuzz', 'Pidgeot', 'Skarmory', 'Staraptor', 'Swanna', 'Swellow', 'Talonflame', 'Tapu Koko', 'Toucannon'],
@@ -4356,7 +4356,7 @@ let BattleMovedex = {
 		onPrepareHit(target, source) {
 			this.add('-anim', source, "Gyro Ball", target);
 		},
-		onAfterMoveSecondarySelf(pokemon) {
+		onAfterMoveSecondary(target, pokemon) {
 			if (!this.field.pseudoWeather.trickroom) {
 				this.field.addPseudoWeather('trickroom', pokemon);
 			}
@@ -4815,7 +4815,7 @@ let BattleMovedex = {
 		},
 		effect: {
 			duration: 1,
-			onAfterMoveSecondarySelf(pokemon, target, move) {
+			onSourceAfterMoveSecondary(target, pokemon, move) {
 				if (pokemon.template.speciesid === 'meloettapirouette') {
 					pokemon.formeChange('Meloetta');
 				} else {

--- a/data/moves.js
+++ b/data/moves.js
@@ -9442,8 +9442,8 @@ let BattleMovedex = {
 		effect: {
 			noCopy: true, // doesn't get copied by Baton Pass
 			duration: 2,
-			onSourceInvulnerabilityPriority: 1,
-			onSourceInvulnerability(target, source, move) {
+			onAnyInvulnerabilityPriority: 1,
+			onAnyInvulnerability(target, source, move) { // onSourceInvulnerability would only run once
 				if (move && source === this.effectData.target && target === this.effectData.source) return 0;
 			},
 			onSourceAccuracy(accuracy, target, source, move) {

--- a/data/moves.js
+++ b/data/moves.js
@@ -4928,7 +4928,7 @@ let BattleMovedex = {
 		pp: 25,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		onAfterMoveSecondarySelf(pokemon, target, move) {
+		onAfterMoveSecondary(target, pokemon, move) {
 			if (!target || target.fainted || target.hp <= 0) this.boost({atk: 3}, pokemon, pokemon, move);
 		},
 		secondary: null,
@@ -13448,7 +13448,7 @@ let BattleMovedex = {
 				move.willChangeForme = true;
 			}
 		},
-		onAfterMoveSecondarySelf(pokemon, target, move) {
+		onAfterMoveSecondary(target, pokemon, move) {
 			if (move.willChangeForme) {
 				pokemon.formeChange(pokemon.template.speciesid === 'meloettapirouette' ? 'Meloetta' : 'Meloetta-Pirouette', this.effect, false, '[msg]');
 			}

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -267,11 +267,6 @@ let BattleScripts = {
 			return false;
 		}
 
-		if (!move.negateSecondary && !(move.hasSheerForce && pokemon.hasAbility('sheerforce'))) {
-			this.singleEvent('AfterMoveSecondarySelf', move, null, pokemon, target, move);
-			this.runEvent('AfterMoveSecondarySelf', pokemon, target, move);
-		}
-
 		return true;
 	},
 	trySpreadMoveHit(targets, pokemon, move) {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -746,12 +746,15 @@ export class Battle {
 		if (Array.isArray(thing)) {
 			for (const [i, pokemon] of thing.entries()) {
 				// console.log(`Event: ${eventName}, Target: ${'' + pokemon}, ${i}`);
-				const curHandlers = this.findEventHandlers(pokemon, eventName, sourceThing);
+				const curHandlers = this.findEventHandlers(pokemon, eventName);
 				for (const handler of curHandlers) {
 					handler.target = pokemon; // Original "thing"
 					handler.index = i;
 				}
 				handlers = handlers.concat(curHandlers);
+			}
+			if (sourceThing) {
+				handlers.push(...this.findPokemonEventHandlers(sourceThing, `onSource${eventName}`));
 			}
 			return handlers;
 		}

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -139,7 +139,6 @@ interface MoveEventMethods {
 
 	onAfterHit?: CommonHandlers['VoidSourceMove']
 	onAfterSubDamage?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void
-	onAfterMoveSecondarySelf?: CommonHandlers['VoidSourceMove']
 	onAfterMoveSecondary?: CommonHandlers['VoidMove']
 	onAfterMove?: CommonHandlers['VoidSourceMove']
 
@@ -179,7 +178,6 @@ interface EventMethods {
 	onAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void
 	onAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void
 	onAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void
-	onAfterMoveSecondarySelf?: MoveEventMethods['onAfterMoveSecondarySelf']
 	onAfterMoveSecondary?: MoveEventMethods['onAfterMoveSecondary']
 	onAfterMove?: MoveEventMethods['onAfterMove']
 	onAfterMoveSelf?: CommonHandlers['VoidSourceMove']
@@ -262,7 +260,6 @@ interface EventMethods {
 	onAllyAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void
 	onAllyAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void
 	onAllyAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void
-	onAllyAfterMoveSecondarySelf?: MoveEventMethods['onAfterMoveSecondarySelf']
 	onAllyAfterMoveSecondary?: MoveEventMethods['onAfterMoveSecondary']
 	onAllyAfterMove?: MoveEventMethods['onAfterMove']
 	onAllyAfterMoveSelf?: CommonHandlers['VoidSourceMove']
@@ -345,7 +342,6 @@ interface EventMethods {
 	onFoeAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void
 	onFoeAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void
 	onFoeAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void
-	onFoeAfterMoveSecondarySelf?: MoveEventMethods['onAfterMoveSecondarySelf']
 	onFoeAfterMoveSecondary?: MoveEventMethods['onAfterMoveSecondary']
 	onFoeAfterMove?: MoveEventMethods['onAfterMove']
 	onFoeAfterMoveSelf?: CommonHandlers['VoidSourceMove']
@@ -428,7 +424,6 @@ interface EventMethods {
 	onSourceAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void
 	onSourceAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void
 	onSourceAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void
-	onSourceAfterMoveSecondarySelf?: MoveEventMethods['onAfterMoveSecondarySelf']
 	onSourceAfterMoveSecondary?: MoveEventMethods['onAfterMoveSecondary']
 	onSourceAfterMove?: MoveEventMethods['onAfterMove']
 	onSourceAfterMoveSelf?: CommonHandlers['VoidSourceMove']
@@ -511,7 +506,6 @@ interface EventMethods {
 	onAnyAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void
 	onAnyAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void
 	onAnyAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void
-	onAnyAfterMoveSecondarySelf?: MoveEventMethods['onAfterMoveSecondarySelf']
 	onAnyAfterMoveSecondary?: MoveEventMethods['onAfterMoveSecondary']
 	onAnyAfterMove?: MoveEventMethods['onAfterMove']
 	onAnyAfterMoveSelf?: CommonHandlers['VoidSourceMove']
@@ -591,7 +585,6 @@ interface EventMethods {
 	onAccuracyPriority?: number
 	onAfterDamageOrder?: number
 	onAfterMoveSecondaryPriority?: number
-	onAfterMoveSecondarySelfPriority?: number
 	onAfterMoveSelfPriority?: number
 	onAnyBasePowerPriority?: number
 	onAnyInvulnerabilityPriority?: number

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -617,6 +617,7 @@ interface EventMethods {
 	onResidualOrder?: number
 	onResidualPriority?: number
 	onResidualSubOrder?: number
+	onSourceAfterMoveSecondaryPriority?: number
 	onSourceBasePowerPriority?: number
 	onSourceInvulnerabilityPriority?: number
 	onSourceModifyAtkPriority?: number


### PR DESCRIPTION
Thanks to @MacChaeger we can now move AfterMoveSecondarySelf to happen before AfterMoveSecondary and still have it only fire once, although I'm not sure I'm using the right target.

The other effects that use AfterMoveSecondarySelf are Fell Stinger, which doesn't care as its target has been KO'd anyway, and Meloetta's forme change, which seems fairly innocuous to me...