### PR TITLE
Sim: Implement Gen 7 forced slot switching

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1032,8 +1032,9 @@ export class Battle extends Dex.ModdedDex {
 				for (const pokemon of side.active) {
 					switchTable.push(!!(pokemon && pokemon.switchFlag));
 				}
+
 				if (switchTable.some(flag => flag === true)) {
-					requests[i] = {forceSwitch: switchTable, side: side.getRequestData()};
+					requests[i] = {forceSwitch: switchTable, forcedSwitchLocations: this.gen >= 7, side: side.getRequestData()};
 				}
 			}
 			break;

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -805,6 +805,9 @@ export class Side {
 				if (!this.choice.forcedPassesLeft) {
 					return this.emitChoiceError(`Can't pass: You need to switch in a Pokémon to replace ${pokemon.name}`);
 				}
+				if (this.battle.gen >= 7 && this.choice.forcedSwitchesLeft) {
+					return this.emitChoiceError(`Can't pass: You need to switch in a Pokémon on the left`);
+				}
 				this.choice.forcedPassesLeft--;
 			}
 			break;


### PR DESCRIPTION
In SM Doubles switch requests, if the player team is all fainted except for one Pokémon, it must switch on the left side.

https://www.youtube.com/watch?v=x4Xgc3JNUz0&feature=youtu.be&t=23m8s