### PR TITLE
Merge global type declarations into dex-data

### DIFF
--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -451,6 +451,21 @@ export class Item extends BasicEffect implements Readonly<BasicEffect & ItemData
 	}
 }
 
+interface AbilityEventMethods {
+	onCheckShow?: (this: Battle, pokemon: Pokemon) => void
+	onEnd?: (this: Battle, target: Pokemon & Side & Field) => void
+	onPreStart?: (this: Battle, pokemon: Pokemon) => void
+	onStart?: (this: Battle, target: Pokemon) => void
+}
+
+export interface AbilityData extends EffectData, AbilityEventMethods, EventMethods {
+	rating: number
+	isUnbreakable?: boolean
+	suppressWeather?: boolean
+}
+
+export interface ModdedAbilityData extends Partial<AbilityData>, ModdedEffectData {}
+
 export class Ability extends BasicEffect implements Readonly<BasicEffect & AbilityData> {
 	readonly effectType: 'Ability';
 	/** Represents how useful or detrimental this ability is. */

--- a/sim/globals.ts
+++ b/sim/globals.ts
@@ -6,6 +6,10 @@ type PRNGSeed = import('./prng').PRNGSeed;
 type Side = import('./side').Side
 type Validator = import('./team-validator').Validator
 
+type Ability = import('./dex-data').Ability
+type AbilityData = import('./dex-data').AbilityData
+type ModdedAbilityData = import('./dex-data').ModdedAbilityData
+
 interface AnyObject {[k: string]: any}
 type DexTable<T> = {[key: string]: T}
 
@@ -154,13 +158,6 @@ interface CommonHandlers {
 	ExtResultSourceMove: boolean | ((this: Battle, source: Pokemon, target: Pokemon, move: ActiveMove) => boolean | null | number | "" | void);
 	VoidSourceEffect: (this: Battle, source: Pokemon, target: Pokemon, effect: Effect) => void;
 	VoidSourceMove: (this: Battle, source: Pokemon, target: Pokemon, move: ActiveMove) => void;
-}
-
-interface AbilityEventMethods {
-	onCheckShow?: (this: Battle, pokemon: Pokemon) => void
-	onEnd?: (this: Battle, target: Pokemon & Side & Field) => void
-	onPreStart?: (this: Battle, pokemon: Pokemon) => void
-	onStart?: (this: Battle, target: Pokemon) => void
 }
 
 interface ItemEventMethods {
@@ -730,18 +727,6 @@ interface ModdedPureEffectData extends Partial<PureEffectData>, ModdedEffectData
 
 interface PureEffect extends Readonly<BasicEffect & PureEffectData> {
 	readonly effectType: 'Status' | 'Effect' | 'Weather'
-}
-
-interface AbilityData extends EffectData, AbilityEventMethods, EventMethods {
-	rating: number
-	isUnbreakable?: boolean
-	suppressWeather?: boolean
-}
-
-interface ModdedAbilityData extends Partial<AbilityData>, ModdedEffectData {}
-
-interface Ability extends Readonly<BasicEffect & AbilityData> {
-	readonly effectType: 'Ability'
 }
 
 interface FlingData {


### PR DESCRIPTION
Currently the PR title is purely aspirational, as `tsc` seems to not want this to happen. I've attempted to migrate `Ability` as a strawman, and I run into the [following errors](https://gist.github.com/scheibo/f7b32f535b289643ca9b025928153f53):

```
...
data/abilities.js:321:17 - error TS2339: Property 'secondaries' does not exist on type 'Effect'.
  Property 'secondaries' does not exist on type 'Ability'.

321  			if (!effect.secondaries) this.add("-fail", target, "unboost", "Defense", "[from] ability: Big Pecks", "[of] " + target);
     			            ~~~~~~~~~~~
...
```

I can't figure out why it can't follow `Ability -> AbilityData -> EffectData` or `Ability -> BasicEffect -> EffectData`, but unless we can figure this out, unifying these two files won't happen :(. Any suggestions for what to try to resolve this would be useful, as I'm fairly confident that if we can unify `Ability` we can unify all of the rest.