### PR TITLE
Allow for presetting settings after a rename with /trn

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -231,6 +231,8 @@ represented by a space), and the rest of the string being their username.
 >
 > Finish logging in (or renaming) by sending: `/trn USERNAME,0,ASSERTION`
 > where `USERNAME` is your desired username and `ASSERTION` is `data.assertion`.
+> A fourth, optional `SETTINGS` parameter can be passed after the `ASSERTION` to
+> preset a user's settings.
 
 `|updateuser|USER@STATUS|NAMED|AVATAR|SETTINGS`
 

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -4488,6 +4488,7 @@ const commands = {
 		let targetName = target;
 		let targetRegistered = false;
 		let targetToken = '';
+		let settings = {};
 		if (commaIndex >= 0) {
 			targetName = target.substr(0, commaIndex);
 			target = target.substr(commaIndex + 1);
@@ -4495,10 +4496,16 @@ const commands = {
 			targetRegistered = target;
 			if (commaIndex >= 0) {
 				targetRegistered = !!parseInt(target.substr(0, commaIndex));
-				targetToken = target.substr(commaIndex + 1);
+				target = target.substr(commaIndex + 1);
+				commaIndex = target.indexOf(',');
+				targetToken = target;
+				if (commaIndex >= 0) {
+					targetToken = target.substr(0, commaIndex);
+					settings = JSON.parse(target.substr(commaIndex + 1));
+				}
 			}
 		}
-		user.rename(targetName, targetToken, targetRegistered, connection);
+		user.rename(targetName, targetToken, targetRegistered, connection, settings);
 	},
 
 	a(target, room, user) {

--- a/server/users.js
+++ b/server/users.js
@@ -546,7 +546,7 @@ class User extends Chat.MessageContext {
 	}
 
 	/**
-	 * @param {UserSettings} [settings]
+	 * @param {UserSettings?}
 	 */
 	applySettings(settings) {
 		if (!settings) return;


### PR DESCRIPTION
Required for Zarel/Pokemon-Showdown-Client#1271