### PR TITLE
Movesearch: fix search for stat boosts

### DIFF
--- a/server/chat-plugins/datasearch.js
+++ b/server/chat-plugins/datasearch.js
@@ -1224,6 +1224,16 @@ function runMovesearch(target, cmd, canAll, message) {
 						matched = true;
 						break;
 					}
+				} else if (dex[move].self && dex[move].self.boosts) {
+					if ((dex[move].self.boosts[boost] > 0) === alts.boost[boost]) {
+						matched = true;
+						break;
+					}
+				} else if (dex[move].secondary && dex[move].secondary.boosts) {
+					if ((dex[move].secondary.boosts[boost] > 0) === alts.boost[boost]) {
+						matched = true;
+						break;
+					}
 				} else if (dex[move].secondary && dex[move].secondary.self && dex[move].secondary.self.boosts) {
 					if ((dex[move].secondary.self.boosts[boost] > 0) === alts.boost[boost]) {
 						matched = true;
@@ -1238,8 +1248,18 @@ function runMovesearch(target, cmd, canAll, message) {
 						matched = true;
 						break;
 					}
+				} else if (dex[move].self && dex[move].self.boosts) {
+					if ((dex[move].self.boosts[lower] < 0) === alts.lower[lower]) {
+						matched = true;
+						break;
+					}
+				} else if (dex[move].secondary && dex[move].secondary.boosts) {
+					if ((dex[move].secondary.boosts[lower] < 0) === alts.lower[lower]) {
+						matched = true;
+						break;
+					}
 				} else if (dex[move].secondary && dex[move].secondary.self && dex[move].secondary.self.boosts) {
-					if ((dex[move].secondary.self.boosts[lower] < 0) === alts.boost[lower]) {
+					if ((dex[move].secondary.self.boosts[lower] < 0) === alts.lower[lower]) {
 						matched = true;
 						break;
 					}


### PR DESCRIPTION
E.g. Close Combat is now shown for `/ms lowers def, lowers spd` and
Mud-Slap for `/ms lowers accuracy`