### PR TITLE
Hide stacktraces for private code

### DIFF
--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -987,7 +987,7 @@ export class GlobalRoom extends BasicRoom {
 		}
 		const stack = stackLines.slice(0, 2).join(`<br />`);
 		let crashMessage;
-		if (/private|chat-plugins&#x2f;_/.test(stack)) {
+		if (/private/.test(stack)) {
 			crashMessage = `|html|<div class="broadcast-red"><b>${crasher} has crashed in private code</b></div>`;
 		} else {
 			crashMessage = `|html|<div class="broadcast-red"><b>${crasher} has crashed:</b> ${stack}</div>`;

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -986,7 +986,12 @@ export class GlobalRoom extends BasicRoom {
 			}
 		}
 		const stack = stackLines.slice(0, 2).join(`<br />`);
-		const crashMessage = `|html|<div class="broadcast-red"><b>${crasher} has crashed:</b> ${stack}</div>`;
+		let crashMessage;
+		if (/private|chat-plugins&#x2f;_/.test(stack)) {
+			crashMessage = `|html|<div class="broadcast-red"><b>${crasher} has crashed in private code</b></div>`;
+		} else {
+			crashMessage = `|html|<div class="broadcast-red"><b>${crasher} has crashed:</b> ${stack}</div>`;
+		}
 		const devRoom = Rooms.get('development');
 		if (devRoom) {
 			devRoom.add(crashMessage).update();


### PR DESCRIPTION
Errors in private code aren't actionable for Showdown contributors without access to private code, so no need to show them the details of those, only for them to realize those files aren't in the repo. This unnecessarily wastes time.