### PR TITLE
Support custom Max Level and Team Length in tours

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2515,10 +2515,11 @@ export class Battle {
 				side.pokemon = side.pokemon.slice(0, side.pokemonLeft);
 			}
 
-			if (format.teamLength && format.teamLength.battle) {
+			const teamLength = this.ruleTable.teamLength || format.teamLength 
+			if (teamLength && teamLength.battle) {
 				// Trim the team: not all of the Pokémon brought to Preview will battle.
 				for (const side of this.sides) {
-					side.pokemon = side.pokemon.slice(0, format.teamLength.battle);
+					side.pokemon = side.pokemon.slice(0, teamLength.battle);
 					side.pokemonLeft = side.pokemon.length;
 				}
 			}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2515,7 +2515,7 @@ export class Battle {
 				side.pokemon = side.pokemon.slice(0, side.pokemonLeft);
 			}
 
-			const teamLength = this.ruleTable.teamLength || format.teamLength 
+			const teamLength = this.ruleTable.teamLength || format.teamLength;
 			if (teamLength && teamLength.battle) {
 				// Trim the team: not all of the Pokémon brought to Preview will battle.
 				for (const side of this.sides) {

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -169,13 +169,19 @@ export class RuleTable extends Map<string, string> {
 	// tslint:disable-next-line:ban-types
 	checkLearnset: [Function, string] | null;
 	timer: [Partial<GameTimerSettings>, string] | null;
-
+	teamLength: {battle: number, validate: [number, number]} | null;
+	maxLevel: number | null;
+	maxForcedLevel: number | null;
+	
 	constructor() {
 		super();
 		this.complexBans = [];
 		this.complexTeamBans = [];
 		this.checkLearnset = null;
 		this.timer = null;
+		this.teamLength = null;
+		this.maxLevel = null;
+		this.maxForcedLevel = null;
 	}
 
 	isBanned(thing: string) {

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -172,7 +172,7 @@ export class RuleTable extends Map<string, string> {
 	teamLength: {battle: number, validate: [number, number]} | null;
 	maxLevel: number | null;
 	maxForcedLevel: number | null;
-	
+
 	constructor() {
 		super();
 		this.complexBans = [];

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -76,40 +76,40 @@ const DATA_FILES = {
 };
 
 interface BasicRule {
-	ruleType: 'basicRule',
-	rule: string,
+	ruleType: 'basicRule';
+	rule: string;
 }
 
 interface ComplexTeamRule {
-	ruleType: 'complexTeamRule',
-	innerRule: number,
-	source: number,
-	limit: string,
-	bans: string[],
+	ruleType: 'complexTeamRule';
+	innerRule: number;
+	source: number;
+	limit: string;
+	bans: string[];
 }
 
 interface ComplexRule {
-	ruleType: 'complexRule',
-	innerRule: number,
-	source: number,
-	limit: string,
-	bans: string[],
+	ruleType: 'complexRule';
+	innerRule: number;
+	source: number;
+	limit: string;
+	bans: string[];
 }
 
 interface BanRule {
-	ruleType: 'banRule',
-	ban: string,
+	ruleType: 'banRule';
+	ban: string;
 }
 
 interface TeamLengthRule {
-	ruleType: 'teamLengthRule',
-	onBattle: number,
+	ruleType: 'teamLengthRule';
+	onBattle: number;
 	onValidate: number,
 }
 
 interface LevelRule {
-	ruleType: 'levelRule',
-	level: number,
+	ruleType: 'levelRule';
+	level: number;
 }
 
 type ValidatedRule = BasicRule | ComplexTeamRule | ComplexRule | BanRule | TeamLengthRule | LevelRule;
@@ -847,6 +847,7 @@ export class ModdedDex {
 			if (rule.startsWith('!')) continue;
 
 			const ruleSpec = this.validateRule(rule, format);
+
 			switch(ruleSpec.ruleType) {
 				case 'complexTeamRule':
 					const complexTeamBan: Data.ComplexTeamBan = [ruleSpec.innerRule, ruleSpec.source, ruleSpec.limit, ruleSpec.bans] as Data.ComplexTeamBan;
@@ -935,19 +936,19 @@ export class ModdedDex {
 				if (checkTeam) {
 					return {
 						ruleType: 'complexTeamBan'
-						innerRule: innerRule,
+						innerRule,
 						source: '',
-						limit: limit,
-						bans: bans,
+						limit,
+						bans,
 					};
 				}
 				if (bans.length > 1 || limit > 0) {
 					return {
 						ruleType: 'complexBan'
-						innerRule: innerRule,
+						innerRule,
 						source: '',
-						limit: limit,
-						bans: bans,
+						limit,
+						bans,
 					};
 				}
 				throw new Error(`Confusing rule ${rule}`);
@@ -974,8 +975,8 @@ export class ModdedDex {
 						}
 						return {
 							ruleType: 'teamLengthRule',
-							onBattle: onBattle,
-							onValidate: onValidate,
+							onBattle,
+							onValidate,
 						};
 					}
 				} else if (type === "level" || type === "maxlevel") {
@@ -983,7 +984,7 @@ export class ModdedDex {
 					if (!isNaN(level)) {
 						return {
 							ruleType: 'levelRule'
-							level: level
+							level,
 						};
 					}
 				}

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -832,12 +832,12 @@ export class ModdedDex {
 					const vals = ruleValue.split('-');
 					const onValidate = parseInt(vals[1]);
 					const onBattle = parseInt(vals[0]);
-					format.teamLength = {
+					ruleTable.teamLength = {
 						validate: [onBattle, onValidate],
 						battle: onBattle,
 					};
 				} else if (ruleName === 'level') {
-					format.maxLevel = parseInt(ruleValue);
+					ruleTable.maxLevel = parseInt(ruleValue);
 				}
 				continue;
 			}

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -982,7 +982,7 @@ export class ModdedDex {
 					const level = parseInt(parts[1]);
 					if (!isNaN(level)) {
 						return {
-							ruleType: 'levelRule'
+							ruleType: 'levelRule',
 							level,
 						};
 					}

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -104,7 +104,7 @@ interface BanRule {
 interface TeamLengthRule {
 	ruleType: 'teamLengthRule';
 	onBattle: number;
-	onValidate: number,
+	onValidate: number;
 }
 
 interface LevelRule {
@@ -847,8 +847,7 @@ export class ModdedDex {
 			if (rule.startsWith('!')) continue;
 
 			const ruleSpec = this.validateRule(rule, format);
-
-			switch(ruleSpec.ruleType) {
+			switch (ruleSpec.ruleType) {
 				case 'complexTeamRule':
 					const complexTeamBan: Data.ComplexTeamBan = [ruleSpec.innerRule, ruleSpec.source, ruleSpec.limit, ruleSpec.bans] as Data.ComplexTeamBan;
 					ruleTable.addComplexTeamBan(complexTeamBan[0], complexTeamBan[1], complexTeamBan[2], complexTeamBan[3]);

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -815,6 +815,15 @@ export class ModdedDex {
 				} else if (ruleSpec[0] === 'complexBan') {
 					const complexBan: Data.ComplexBan = ruleSpec.slice(1) as Data.ComplexBan;
 					ruleTable.addComplexBan(complexBan[0], complexBan[1], complexBan[2], complexBan[3]);
+				} else if (ruleSpec[0] === 'teamlength') {
+					const onValidate = parseInt(ruleSpec[2]);
+					const onBattle = parseInt(ruleSpec[1]);
+					ruleTable.teamLength = {
+						validate: [onBattle, onValidate],
+						battle: onBattle,
+					};
+				} else if (ruleSpec[0] === 'level') {
+					ruleTable.maxLevel = parseInt(ruleSpec[1]);
 				} else {
 					throw new Error(`Unrecognized rule spec ${ruleSpec}`);
 				}
@@ -824,21 +833,6 @@ export class ModdedDex {
 				if (ruleSpec.startsWith('+')) ruleTable.delete('-' + ruleSpec.slice(1));
 				if (ruleSpec.startsWith('-')) ruleTable.delete('+' + ruleSpec.slice(1));
 				ruleTable.set(ruleSpec, '');
-				continue;
-			}
-			if (ruleSpec.includes(":")) {
-				const [ruleName, ruleValue] = ruleSpec.split(":");
-				if (ruleName === 'teamlength') {
-					const vals = ruleValue.split('-');
-					const onValidate = parseInt(vals[1]);
-					const onBattle = parseInt(vals[0]);
-					ruleTable.teamLength = {
-						validate: [onBattle, onValidate],
-						battle: onBattle,
-					};
-				} else if (ruleName === 'level') {
-					ruleTable.maxLevel = parseInt(ruleValue);
-				}
 				continue;
 			}
 			const subformat = this.getFormat(ruleSpec);

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -916,7 +916,7 @@ export class ModdedDex {
 			if (parts.length > 1) {
 				const type = toID(parts[0]);
 				if (type === "teamlength" || type === "teamcap") {
-					let onValidate = parts[1].split('-');
+					let options = parts[1].split('-');
 					const onValidate = parseInt(options[0]);
 					let onBattle = parseInt(options[1]);
 					if (options.length === 1) onBattle = onValidate;

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -816,14 +816,15 @@ export class ModdedDex {
 					const complexBan: Data.ComplexBan = ruleSpec.slice(1) as Data.ComplexBan;
 					ruleTable.addComplexBan(complexBan[0], complexBan[1], complexBan[2], complexBan[3]);
 				} else if (ruleSpec[0] === 'teamlength') {
-					const onValidate = ruleSpec[2];
-					const onBattle = ruleSpec[1];
+					const onValidate: number = ruleSpec[2];
+					const onBattle: number = ruleSpec[1];
 					ruleTable.teamLength = {
 						validate: [onBattle, onValidate],
 						battle: onBattle,
 					};
 				} else if (ruleSpec[0] === 'level') {
-					ruleTable.maxLevel = ruleSpec[1];
+					const maxLevel: number = ruleSpec[1];
+					ruleTable.maxLevel = maxLevel;
 				} else {
 					throw new Error(`Unrecognized rule spec ${ruleSpec}`);
 				}

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -934,7 +934,7 @@ export class ModdedDex {
 
 				if (checkTeam) {
 					return {
-						ruleType: 'complexTeamBan'
+						ruleType: 'complexTeamBan',
 						innerRule,
 						source: '',
 						limit,
@@ -943,7 +943,7 @@ export class ModdedDex {
 				}
 				if (bans.length > 1 || limit > 0) {
 					return {
-						ruleType: 'complexBan'
+						ruleType: 'complexBan',
 						innerRule,
 						source: '',
 						limit,

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -82,17 +82,17 @@ interface BasicRule {
 
 interface ComplexTeamRule {
 	ruleType: 'complexTeamRule';
-	innerRule: number;
-	source: number;
-	limit: string;
+	innerRule: string;
+	source: string;
+	limit: number;
 	bans: string[];
 }
 
 interface ComplexRule {
 	ruleType: 'complexRule';
-	innerRule: number;
-	source: number;
-	limit: string;
+	innerRule: string;
+	source: string;
+	limit: number;
 	bans: string[];
 }
 
@@ -838,7 +838,7 @@ export class ModdedDex {
 		// apply rule repeals before other rules
 		for (const rule of ruleset) {
 			if (rule.startsWith('!')) {
-				const ruleSpec = this.validateRule(rule, format);
+				const ruleSpec = this.validateRule(rule, format) as BasicRule;
 				ruleTable.set(ruleSpec.rule, '');
 			}
 		}
@@ -849,11 +849,11 @@ export class ModdedDex {
 			const ruleSpec = this.validateRule(rule, format);
 			switch (ruleSpec.ruleType) {
 				case 'complexTeamRule':
-					const complexTeamBan: Data.ComplexTeamBan = [ruleSpec.innerRule, ruleSpec.limit, ruleSpec.source, ruleSpec.bans] as Data.ComplexTeamBan;
+					const complexTeamBan: Data.ComplexTeamBan = [ruleSpec.innerRule, ruleSpec.source, ruleSpec.limit, ruleSpec.bans] as Data.ComplexTeamBan;
 					ruleTable.addComplexTeamBan(complexTeamBan[0], complexTeamBan[1], complexTeamBan[2], complexTeamBan[3]);
 					continue;
 				case 'complexRule':
-					const complexBan: Data.ComplexBan = [ruleSpec.innerRule, ruleSpec.limit, ruleSpec.source, ruleSpec.bans] as Data.ComplexBan;
+					const complexBan: Data.ComplexBan = [ruleSpec.innerRule, ruleSpec.source, ruleSpec.limit, ruleSpec.bans] as Data.ComplexBan;
 					ruleTable.addComplexBan(complexBan[0], complexBan[1], complexBan[2], complexBan[3]);
 					continue;
 				case 'teamLengthRule':

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -826,7 +826,7 @@ export class ModdedDex {
 				ruleTable.set(ruleSpec, '');
 				continue;
 			}
-			if (ruleSpec.split(":").length > 1) {
+			if (ruleSpec.includes(":")) {
 				const parts = ruleSpec.split(":");
 				if (parts[0] === 'teamlength') {
 					const vals = ruleSpec.split(":")[1].split('-');
@@ -834,10 +834,9 @@ export class ModdedDex {
 					const onBattle = parseInt(vals[0]);
 					format.teamLength = {
 						validate: [onBattle, onValidate],
-						battle: onBattle
-					}
-				}
-				else if (parts[0] === 'level') {
+						battle: onBattle,
+					};
+				} else if (parts[0] === 'level') {
 					format.maxLevel = parseInt(parts[1]);
 				}
 				continue;
@@ -915,10 +914,10 @@ export class ModdedDex {
 			const id = toID(rule);
 			const parts = rule.replace('=', ':').split(":");
 			if (parts.length > 1) {
-				let type = toID(parts[0])
+				const type = toID(parts[0]);
 				if (type === "teamlength" || type === "teamcap") {
-					let options = parts[1].split('-')
-					let onValidate = parseInt(options[0]);
+					const options = parts[1].split('-');
+					const onValidate = parseInt(options[0]);
 					let onBattle = parseInt(options[1]);
 					if (options.length === 1) onBattle = onValidate;
 					if (!isNaN(onValidate) && !isNaN(onBattle)) {
@@ -930,16 +929,14 @@ export class ModdedDex {
 						}
 						return `teamlength:${onBattle}-${onValidate}`;
 					}
-				}
-				else if (type === "level" || type === "maxlevel") {
-					let level = parseInt(parts[1]);
+				} else if (type === "level" || type === "maxlevel") {
+					const level = parseInt(parts[1]);
 					if (!isNaN(level)) {
 						return `level:${level}`;
 					}
 				}
 				throw new Error(`Unrecognized rule "${rule}"`);
-			}
-			else if (!this.data.Formats.hasOwnProperty(id)) {
+			} else if (!this.data.Formats.hasOwnProperty(id)) {
 				throw new Error(`Unrecognized rule "${rule}"`);
 			}
 			if (rule.charAt(0) === '!') return `!${id}`;

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -838,7 +838,7 @@ export class ModdedDex {
 		// apply rule repeals before other rules
 		for (const rule of ruleset) {
 			if (rule.startsWith('!')) {
-				const ruleSpec = this.validateRule(rule, format) as string;
+				const ruleSpec = this.validateRule(rule, format);
 				ruleTable.set(ruleSpec.rule, '');
 			}
 		}
@@ -849,11 +849,11 @@ export class ModdedDex {
 			const ruleSpec = this.validateRule(rule, format);
 			switch (ruleSpec.ruleType) {
 				case 'complexTeamRule':
-					const complexTeamBan: Data.ComplexTeamBan = [ruleSpec.innerRule, ruleSpec.source, ruleSpec.limit, ruleSpec.bans] as Data.ComplexTeamBan;
+					const complexTeamBan: Data.ComplexTeamBan = [ruleSpec.innerRule, ruleSpec.limit, ruleSpec.source, ruleSpec.bans] as Data.ComplexTeamBan;
 					ruleTable.addComplexTeamBan(complexTeamBan[0], complexTeamBan[1], complexTeamBan[2], complexTeamBan[3]);
 					continue;
 				case 'complexRule':
-					const complexBan: Data.ComplexBan = [ruleSpec.innerRule, ruleSpec.source, ruleSpec.limit, ruleSpec.bans] as Data.ComplexBan;
+					const complexBan: Data.ComplexBan = [ruleSpec.innerRule, ruleSpec.limit, ruleSpec.source, ruleSpec.bans] as Data.ComplexBan;
 					ruleTable.addComplexBan(complexBan[0], complexBan[1], complexBan[2], complexBan[3]);
 					continue;
 				case 'teamLengthRule':
@@ -934,7 +934,7 @@ export class ModdedDex {
 
 				if (checkTeam) {
 					return {
-						ruleType: 'complexTeamBan',
+						ruleType: 'complexTeamRule',
 						innerRule,
 						source: '',
 						limit,
@@ -943,7 +943,7 @@ export class ModdedDex {
 				}
 				if (bans.length > 1 || limit > 0) {
 					return {
-						ruleType: 'complexBan',
+						ruleType: 'complexRule',
 						innerRule,
 						source: '',
 						limit,

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -953,7 +953,7 @@ export class ModdedDex {
 				}
 				throw new Error(`Confusing rule ${rule}`);
 			}
-			let banRule = this.validateBanRule(rule);
+			const banRule = this.validateBanRule(rule);
 			if (rule.charAt(0) === '-') banRule.ban = '-' + banRule.ban;
 			return banRule;
 		default:
@@ -962,7 +962,7 @@ export class ModdedDex {
 			if (parts.length > 1) {
 				const type = toID(parts[0]);
 				if (type === "teamlength" || type === "teamcap") {
-					let options = parts[1].split('-');
+					const options = parts[1].split('-');
 					const onValidate = parseInt(options[0]);
 					let onBattle = parseInt(options[1]);
 					if (options.length === 1) onBattle = onValidate;

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -816,14 +816,14 @@ export class ModdedDex {
 					const complexBan: Data.ComplexBan = ruleSpec.slice(1) as Data.ComplexBan;
 					ruleTable.addComplexBan(complexBan[0], complexBan[1], complexBan[2], complexBan[3]);
 				} else if (ruleSpec[0] === 'teamlength') {
-					const onValidate = parseInt(ruleSpec[2]);
-					const onBattle = parseInt(ruleSpec[1]);
+					const onValidate = ruleSpec[2];
+					const onBattle = ruleSpec[1];
 					ruleTable.teamLength = {
 						validate: [onBattle, onValidate],
 						battle: onBattle,
 					};
 				} else if (ruleSpec[0] === 'level') {
-					ruleTable.maxLevel = parseInt(ruleSpec[1]);
+					ruleTable.maxLevel = ruleSpec[1];
 				} else {
 					throw new Error(`Unrecognized rule spec ${ruleSpec}`);
 				}

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -816,14 +816,14 @@ export class ModdedDex {
 					const complexBan: Data.ComplexBan = ruleSpec.slice(1) as Data.ComplexBan;
 					ruleTable.addComplexBan(complexBan[0], complexBan[1], complexBan[2], complexBan[3]);
 				} else if (ruleSpec[0] === 'teamlength') {
-					const onValidate: number = ruleSpec[2];
-					const onBattle: number = ruleSpec[1];
+					const onValidate = ruleSpec[2] as number;
+					const onBattle = ruleSpec[1] as number;
 					ruleTable.teamLength = {
 						validate: [onBattle, onValidate],
 						battle: onBattle,
 					};
 				} else if (ruleSpec[0] === 'level') {
-					const maxLevel: number = ruleSpec[1];
+					const maxLevel = ruleSpec[1] as number;
 					ruleTable.maxLevel = maxLevel;
 				} else {
 					throw new Error(`Unrecognized rule spec ${ruleSpec}`);

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -922,12 +922,12 @@ export class ModdedDex {
 						if (onValidate > 24) {
 							throw new Error("You may not have more than 24 Pokémon on a team");
 						}
-						return `teamlength:${onBattle}-${onValidate}`;
+						return ['teamlength', onBattle, onValidate];
 					}
 				} else if (type === "level" || type === "maxlevel") {
 					const level = parseInt(parts[1]);
 					if (!isNaN(level)) {
-						return `level:${level}`;
+						return ['level', level];
 					}
 				}
 				throw new Error(`Unrecognized rule "${rule}"`);

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -827,17 +827,17 @@ export class ModdedDex {
 				continue;
 			}
 			if (ruleSpec.includes(":")) {
-				const parts = ruleSpec.split(":");
-				if (parts[0] === 'teamlength') {
-					const vals = ruleSpec.split(":")[1].split('-');
+				const [ruleName, ruleValue] = ruleSpec.split(":");
+				if (ruleName === 'teamlength') {
+					const vals = ruleValue.split('-');
 					const onValidate = parseInt(vals[1]);
 					const onBattle = parseInt(vals[0]);
 					format.teamLength = {
 						validate: [onBattle, onValidate],
 						battle: onBattle,
 					};
-				} else if (parts[0] === 'level') {
-					format.maxLevel = parseInt(parts[1]);
+				} else if (ruleName === 'level') {
+					format.maxLevel = parseInt(ruleValue);
 				}
 				continue;
 			}
@@ -916,7 +916,7 @@ export class ModdedDex {
 			if (parts.length > 1) {
 				const type = toID(parts[0]);
 				if (type === "teamlength" || type === "teamcap") {
-					const options = parts[1].split('-');
+					let onValidate = parts[1].split('-');
 					const onValidate = parseInt(options[0]);
 					let onBattle = parseInt(options[1]);
 					if (options.length === 1) onBattle = onValidate;
@@ -924,7 +924,7 @@ export class ModdedDex {
 						if (onValidate < onBattle) {
 							throw new Error("You can't bring more Pokémon to a battle than the maximum team length");
 						}
-						if (preview > 24) {
+						if (onValidate > 24) {
 							throw new Error("You may not have more than 24 Pokémon on a team");
 						}
 						return `teamlength:${onBattle}-${onValidate}`;

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -216,7 +216,7 @@ export class TeamValidator {
 			return [`You sent invalid team data. If you're not using a custom client, please report this as a bug.`];
 		}
 
-		let [minSize, maxSize] = format.teamLength && format.teamLength.validate || [1, 6];
+		let [minSize, maxSize] = this.ruleTable.teamLength && this.ruleTable.teamLength.validate || format.teamLength && format.teamLength.validate || [1, 6];
 		if (format.gameType === 'doubles' && minSize < 2) minSize = 2;
 		if (['triples', 'rotation'].includes(format.gameType as 'triples') && minSize < 3) minSize = 3;
 
@@ -309,8 +309,8 @@ export class TeamValidator {
 		set.nature = dex.getNature(Dex.getString(set.nature)).name;
 		if (!Array.isArray(set.moves)) set.moves = [];
 
-		const maxLevel = format.maxLevel || 100;
-		const maxForcedLevel = format.maxForcedLevel || maxLevel;
+		const maxLevel = this.ruleTable.maxLevel || format.maxLevel || 100;
+		const maxForcedLevel = this.ruleTable.maxForcedLevel || format.maxForcedLevel || maxLevel;
 		let forcedLevel: number | null = null;
 		if (!set.level) {
 			set.level = (format.defaultLevel || maxLevel);


### PR DESCRIPTION
I tried my absolute best to keep code standards good, but truth is I'm just really not good at things like variable naming. Adjustments will most likely need to be made by someone who's actually good at those things

I do know however that this code does what it needs to (`/tour rules Max Level:5` sets max level to 5, and `/tour rules Team Length:3-1` sets the teamLength to set max team length to 3, and allow one of those to be picked into battle)
As far as I can tell the syntax I used does not interfere with anything already in place, and shouldn't interfere with anything that could be added in the future