### PR TITLE
Introduce /modchatnext command

### DIFF
--- a/server/chat-plugins/roomsettings.js
+++ b/server/chat-plugins/roomsettings.js
@@ -211,6 +211,30 @@ exports.commands = {
 	},
 	roomsettingshelp: [`/roomsettings - Shows current room settings with buttons to change them (if you can).`],
 
+	// TODO: how to indicate this helper method is not a command?
+	targetToModchat(target, threshold = 1) {
+		if (this.meansNo(target)) return false;
+		switch (target) {
+		case 'ac':
+		case 'autoconfirmed':
+			return 'autoconfirmed';
+		case 'trusted':
+			return 'trusted';
+		case 'player':
+			target = Users.PLAYER_SYMBOL;
+			/* falls through */
+		default:
+			if (!Config.groups[target]) {
+				this.errorReply(`The rank '${target}' was unrecognized as a modchat level.`);
+				return this.parse('/help modchat');
+			}
+			if (Config.groupsranking.indexOf(target) > threshold) {
+				return this.errorReply(`/modchat - Access denied for setting higher than ${Config.groupsranking[threshold]}.`);
+			}
+			return target;
+		}
+	},
+
 	modchat(target, room, user) {
 		if (!target) {
 			const modchatSetting = (room.modchat || "OFF");
@@ -240,35 +264,9 @@ exports.commands = {
 		}
 
 		target = target.toLowerCase().trim();
+		if (target === 'next') return this.parse('/modchatnext');
 		const currentModchat = room.modchat;
-		switch (target) {
-		case 'off':
-		case 'false':
-		case 'no':
-		case 'disable':
-			room.modchat = false;
-			break;
-		case 'ac':
-		case 'autoconfirmed':
-			room.modchat = 'autoconfirmed';
-			break;
-		case 'trusted':
-			room.modchat = 'trusted';
-			break;
-		case 'player':
-			target = Users.PLAYER_SYMBOL;
-			/* falls through */
-		default:
-			if (!Config.groups[target]) {
-				this.errorReply(`The rank '${target}' was unrecognized as a modchat level.`);
-				return this.parse('/help modchat');
-			}
-			if (Config.groupsranking.indexOf(target) > threshold) {
-				return this.errorReply(`/modchat - Access denied for setting higher than ${Config.groupsranking[threshold]}.`);
-			}
-			room.modchat = target;
-			break;
-		}
+		room.modchat = this.targetToModchat(target, threshold);
 		if (currentModchat === room.modchat) {
 			return this.errorReply(`Modchat is already set to ${currentModchat}.`);
 		}
@@ -288,6 +286,21 @@ exports.commands = {
 		}
 	},
 	modchathelp: [`/modchat [off/autoconfirmed/+/%/@/*/player/#/&/~] - Set the level of moderated chat. Requires: * @ \u2606 for off/autoconfirmed/+ options, # & ~ for all the options`],
+
+	'!modchatnext': true,
+	mcnext: 'modchatnext',
+	modchatnext(target, room, user) {
+		const groupConfig = Config.groups[Users.PLAYER_SYMBOL];
+		if (!(groupConfig && groupConfig.modchat)) return this.errorReply(`/modchat - Access denied.`);
+		target = this.targetToModchat(target.toLowerCase().trim()); // TODO threshold?
+		user.modchatNextBattle = target;
+		user.update('modchatNextBattle');
+		if (target) {
+			this.sendReply("Your next battle will not begin with modchat turned on.");
+		} else {
+			this.sendReply("Your next battle will begin with modchat turned on.");
+		}
+	},
 
 	ioo(target, room, user) {
 		return this.parse('/modjoin %');

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1548,7 +1548,7 @@ export const Rooms = {
 		return room;
 	},
 	createBattle(formatid: string, options: AnyObject) {
-		const players: (User & {specialNextBattle: boolean})[] =
+		const players: (User & {specialNextBattle?: string })[] =
 			[options.p1, options.p2, options.p3, options.p4].filter(user => user);
 		const gameType = Dex.getFormat(formatid).gameType;
 		if (gameType !== 'multi' && gameType !== 'free-for-all') {
@@ -1571,21 +1571,21 @@ export const Rooms = {
 			return;
 		}
 
-		if (players.some(user => user.specialNextBattle)) {
-			const p1Special = players[0].specialNextBattle;
-			let mismatch = `"${p1Special}"`;
+		const p1Special = players[0].specialNextBattle;
+		let mismatch = `"${p1Special}"`;
+		for (const user of players) {
+			if (user.specialNextBattle !== p1Special) {
+				mismatch += ` vs. "${user.specialNextBattle}"`;
+			}
+			user.specialNextBattle = undefined;
+		}
+
+		if (mismatch !== `"${p1Special}"`) {
 			for (const user of players) {
-				if (user.specialNextBattle !== p1Special) {
-					mismatch += ` vs. "${user.specialNextBattle}"`;
-					break;
-				}
+				user.popup(`Your special battle settings don't match: ${mismatch}`);
 			}
-			if (mismatch !== `"${p1Special}"`) {
-				for (const user of players) {
-					user.popup(`Your special battle settings don't match: ${mismatch}`);
-				}
-				return;
-			}
+			return;
+		} else if (p1Special) {
 			options.ratedMessage = p1Special;
 		}
 
@@ -1611,6 +1611,8 @@ export const Rooms = {
 		const room = Rooms.createGameRoom(roomid, roomTitle, options);
 		const battle = new Rooms.RoomBattle(room, formatid, options);
 		room.game = battle;
+		// Special battles have modchat set to Player from the beginning
+		if (p1Special) room.modchat = '\u2606';
 
 		const inviteOnly = (options.inviteOnly || []);
 		for (const user of players) {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1618,7 +1618,6 @@ export const Rooms = {
 				inviteOnly.push(user.id);
 				user.inviteOnlyNextBattle = false;
 			}
-			// TODO: use most selective of the players choices for modchat?
 		}
 		if (inviteOnly.length) {
 			const prefix = battle.forcedPublic();

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1618,6 +1618,7 @@ export const Rooms = {
 				inviteOnly.push(user.id);
 				user.inviteOnlyNextBattle = false;
 			}
+			// TODO: use most selective of the players choices for modchat?
 		}
 		if (inviteOnly.length) {
 			const prefix = battle.forcedPublic();


### PR DESCRIPTION
The TDs have found that setting the default modchat on smogtours to player is undesirable because a lot more casual games happen there than they anticipated.

```
[14:19]Tony:i was wondering how possible it was for to create a /ionext type of command for modchat on smogtours
[14:20]Tony:as in, one of the two players (or both players) enters /modchaton or something in the lobby or their private messages
[14:20]Tony:and then the game starts with modchat immediately on
[14:20]Tony:and if neither player does, then modchat is off
[17:14]pre:we would need to do it in the main code, because its somewhat tricky to implement a /modchatnext as a private plugin
[17:15]pre:whats the motivation?
[17:16]pre:ionext needs to work the way it does to ensure the battle stays private, but is /modchat at the start of the battle not sufficient already? are we trying to guard against some errant 'first!'s or something
[05:19]Tony:the motivation is that we underestimated how many friendly games are played on smogtours as well
[05:20]Tony:and by changing our stance from opt-out to opt-in we still make it possible to instantly have modchat on for those who want that during their games, especially official tournament games, while also catering to those that use the server more casually and wanna mess around with their friends
[05:21]Tony: "are we trying to guard against some errant 'first!'s or something" = we are essentially. people love spamming battlechats of official games like that until a moderator sets modchat
```

I ran into a lot of questions when writing this draft PR:

1) Does it make sense to try and merge next-battle related settings in some way as opposed to having `modchatNextBattle` and `inviteOnlyNextBattle` (do we expect more in the future? does it make sense to consolidate/generalize)?
2) Do we want to support multiple levels for `modchatNextBattle` instead of just 'on' or 'off'? I was looking into going that route in this change, but it increases complexity quite a bit.
3) Completely alternative solution: some sort of default slowchat-esque period at the start of a battle which would provide players to opportunity to set up this modchat normally

More thoughts appreciated.
