### PR TITLE
Fix handling of locked and proxy connections

### DIFF
--- a/server/chat-plugins/helptickets.js
+++ b/server/chat-plugins/helptickets.js
@@ -671,10 +671,10 @@ const pages = {
 								buf += `<p><Button>lock</Button></p>`;
 							}
 						}
-						if (user.locked === '#hostfilter' || isStaff) {
+						if (user.locked === '#hostfilter' || (user.latestHostType === 'proxy' && user.locked !== user.id) || isStaff) {
 							buf += `<p><Button>hostfilter</Button></p>`;
 						}
-						if ((user.locked !== user.id && user.locked !== '#hostfilter') || isStaff) {
+						if ((user.locked !== '#hostfilter' && user.latestHostType !== 'proxy' && user.locked !== user.id) || isStaff) {
 							buf += `<p><Button>ip</Button></p>`;
 						}
 					}
@@ -699,7 +699,7 @@ const pages = {
 					buf += `<p><Button>confirmipappeal</Button></p>`;
 					break;
 				case 'hostfilter':
-					buf += `<p>If you are locked with the message: "Due to spam, you can't chat using a proxy," it means you are connected to Pokemon Showdown with a proxy or VPN. We automatically lock these to prevent evasion of punishments. To get unlocked, you need to disable your proxy or VPN, and then type the <code>/logout</code> command in any chatroom.</p>`;
+					buf += `<p>We automatically lock proxies and VPNs to prevent evasion of punishments and other attacks on our server. To get unlocked, you need to disable your proxy or VPN.</p>`;
 					break;
 				case 'semilock':
 					buf += `<p>Do you have an autoconfirmed account? An account is autoconfirmed when it has won at least one rated battle and has been registered for one week or longer.</p>`;

--- a/server/chat-plugins/info.js
+++ b/server/chat-plugins/info.js
@@ -123,10 +123,7 @@ const commands = {
 			} else if (targetUser.locked) {
 				buf += `<br />LOCKED: ${targetUser.locked}`;
 				switch (targetUser.locked) {
-				case '#dnsbl':
-					buf += ` - IP is in a DNS-based blacklist`;
-					break;
-				case '#range':
+				case '#rangelock':
 					buf += ` - IP or host is in a temporary range-lock`;
 					break;
 				case '#hostfilter':

--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -1122,10 +1122,10 @@ export const Punishments = new class {
 			user.resetName();
 			user.updateIdentity();
 		} else {
-			if (punishUserid === '#hostfilter') {
-				user.popup(`Due to spam, you can't chat using a proxy. (Your IP ${user.latestIp} appears to be a proxy.)`);
-			} else if (punishUserid === '#ipban') {
-				user.popup(`Your IP (${user.latestIp}) is not allowed to chat on PS, because it has been used to spam, hack, or otherwise attack our server. Make sure you are not using any proxies to connect to PS.`);
+			if (punishUserid === '#hostfilter' || punishUserid === '#ipban') {
+				user.send(`|popup||html|Your IP (${user.latestIp}) is currently locked due to being a proxy. We automatically lock these connections since they are used to spam, hack, or otherwise attack our server. Disable any proxies you are using to connect to PS.\n\n<a href="view-help-request--appeal"><button class="button">Help me with a lock from a proxy</button></a>`);
+			} else if (user.latestHostType === 'proxy' && user.locked !== user.id) {
+				user.send(`|popup||html|You are locked${bannedUnder} on the IP (${user.latestIp}), which is a proxy. We automatically lock these connections since they are used to spam, hack, or otherwise attack our server. Disable any proxies you are using to connect to PS.\n\n<a href="view-help-request--appeal"><button class="button">Help me with a lock from a proxy</button></a>`);
 			} else if (!user.lockNotified) {
 				user.send(`|popup||html|You are locked${bannedUnder}. ${user.permalocked ? `This lock is permanent.` : `Your lock will expire in a few days.`}${reason}${appeal}`);
 			}
@@ -1158,7 +1158,6 @@ export const Punishments = new class {
 
 		return IPTools.lookup(ip).then(({dnsbl, host, hostType}) => {
 			user = connection.user || user;
-			if (user.locked === '#hostfilter') user.locked = null;
 
 			if (hostType === 'proxy' && !user.trusted && !user.locked) {
 				user.locked = '#hostfilter';


### PR DESCRIPTION
A few changes to the popup for users on a proxy:
1) Link a user on a proxy to information on disabling it within the help ticket system.
2) Handles the case where a user turns off the proxy but doesn't log out by telling them they need to log out fully.  These people frequently end up in help tickets.  Ideally, I'd like to have a "Log out" button here but I can't get it to do anything right now.

Adds the case in help ticket appeals where a user on a "[proxy]" IP that is locked as another user is directed to how to turn off their proxy rather than to IP-appeals, where they would normally get the IP markshared or unlocked. Proxy IPs should remain locked by default, even if another user has a punishment on it.