### PR TITLE
Add a RoomBattle#challengeType property

### DIFF
--- a/server/chat-plugins/chat-monitor.js
+++ b/server/chat-plugins/chat-monitor.js
@@ -287,7 +287,7 @@ let chatfilter = function (message, user, room) {
 		const {location, condition, monitor} = Chat.monitors[list];
 		if (!monitor) continue;
 		// Ignore challenge games, which are unrated and not part of roomtours.
-		if (location === 'BATTLES' && !(room && room.battle && room.battle.type !== 'challenge')) continue;
+		if (location === 'BATTLES' && !(room && room.battle && room.battle.challengeType !== 'challenge')) continue;
 		if (location === 'PUBLIC' && room && room.isPrivate === true) continue;
 
 		switch (condition) {

--- a/server/chat-plugins/chat-monitor.js
+++ b/server/chat-plugins/chat-monitor.js
@@ -287,7 +287,7 @@ let chatfilter = function (message, user, room) {
 		const {location, condition, monitor} = Chat.monitors[list];
 		if (!monitor) continue;
 		// Ignore challenge games, which are unrated and not part of roomtours.
-		if (location === 'BATTLES' && !(room && room.battle && (room.battle.rated || room.parent))) continue;
+		if (location === 'BATTLES' && !(room && room.battle && room.battle.type !== 'challenge')) continue;
 		if (location === 'PUBLIC' && room && room.isPrivate === true) continue;
 
 		switch (condition) {

--- a/server/ladders.ts
+++ b/server/ladders.ts
@@ -15,6 +15,8 @@ const LadderStore: typeof LadderStoreT = (typeof Config === 'object' && Config.r
 const SECONDS = 1000;
 const PERIODIC_MATCH_INTERVAL = 60 * SECONDS;
 
+type BattleType = import('./room-battle').BattleType;
+
 /**
  * This represents a user's search for a battle under a format.
  */
@@ -23,12 +25,14 @@ class BattleReady {
 	readonly formatid: string;
 	readonly team: string;
 	readonly rating: number;
+	readonly type: BattleType;
 	readonly time: number;
-	constructor(userid: ID, formatid: string, team: string, rating: number = 0) {
+	constructor(userid: ID, formatid: string, team: string, rating: number = 0, type: BattleType) {
 		this.userid = userid;
 		this.formatid = formatid;
 		this.team = team;
 		this.rating = rating;
+		this.type = type;
 		this.time = Date.now();
 	}
 }
@@ -65,7 +69,7 @@ class Ladder extends LadderStore {
 		super(formatid);
 	}
 
-	async prepBattle(connection: Connection, team: string | null = null, isRated = false) {
+	async prepBattle(connection: Connection, type: BattleType, team: string | null = null, isRated = false) {
 		// all validation for a battle goes through here
 		const user = connection.user;
 		const userid = user.id;
@@ -144,7 +148,7 @@ class Ladder extends LadderStore {
 			return null;
 		}
 
-		return new BattleReady(userid, this.formatid, valResult.slice(1), rating);
+		return new BattleReady(userid, this.formatid, valResult.slice(1), rating, type);
 	}
 
 	static cancelChallenging(user: User) {
@@ -205,7 +209,7 @@ class Ladder extends LadderStore {
 			connection.popup(`You challenged less than 10 seconds after your last challenge! It's cancelled in case it's a misclick.`);
 			return false;
 		}
-		const ready = await this.prepBattle(connection);
+		const ready = await this.prepBattle(connection, 'challenge');
 		if (!ready) return false;
 		// If our target is already challenging us in the same format,
 		// simply accept the pending challenge instead of creating a new one.
@@ -233,7 +237,7 @@ class Ladder extends LadderStore {
 			return false;
 		}
 		const ladder = Ladders(chall.formatid);
-		const ready = await ladder.prepBattle(connection);
+		const ready = await ladder.prepBattle(connection, 'challenge');
 		if (!ready) return false;
 		if (Ladder.removeChallenge(chall)) {
 			Ladders.match(chall.ready, ready);
@@ -412,7 +416,7 @@ class Ladder extends LadderStore {
 		}
 
 		const oldUserid = user.id;
-		const search = await this.prepBattle(connection, null, format.rated !== false);
+		const search = await this.prepBattle(connection, format.rated ? 'rated' : 'unrated', null, format.rated !== false);
 
 		if (oldUserid !== user.id) return;
 		if (!search) return;
@@ -573,6 +577,7 @@ class Ladder extends LadderStore {
 			p2team: ready2.team,
 			p2rating: ready2.rating,
 			rated: Math.min(ready1.rating, ready2.rating),
+			type: ready1.type,
 		});
 	}
 }

--- a/server/ladders.ts
+++ b/server/ladders.ts
@@ -15,7 +15,7 @@ const LadderStore: typeof LadderStoreT = (typeof Config === 'object' && Config.r
 const SECONDS = 1000;
 const PERIODIC_MATCH_INTERVAL = 60 * SECONDS;
 
-type BattleType = import('./room-battle').BattleType;
+type ChallengeType = import('./room-battle').ChallengeType;
 
 /**
  * This represents a user's search for a battle under a format.
@@ -25,14 +25,14 @@ class BattleReady {
 	readonly formatid: string;
 	readonly team: string;
 	readonly rating: number;
-	readonly type: BattleType;
+	readonly challengeType: ChallengeType;
 	readonly time: number;
-	constructor(userid: ID, formatid: string, team: string, rating: number = 0, type: BattleType) {
+	constructor(userid: ID, formatid: string, team: string, rating: number = 0, challengeType: ChallengeType) {
 		this.userid = userid;
 		this.formatid = formatid;
 		this.team = team;
 		this.rating = rating;
-		this.type = type;
+		this.challengeType = challengeType;
 		this.time = Date.now();
 	}
 }
@@ -69,7 +69,7 @@ class Ladder extends LadderStore {
 		super(formatid);
 	}
 
-	async prepBattle(connection: Connection, type: BattleType, team: string | null = null, isRated = false) {
+	async prepBattle(connection: Connection, challengeType: ChallengeType, team: string | null = null, isRated = false) {
 		// all validation for a battle goes through here
 		const user = connection.user;
 		const userid = user.id;
@@ -148,7 +148,7 @@ class Ladder extends LadderStore {
 			return null;
 		}
 
-		return new BattleReady(userid, this.formatid, valResult.slice(1), rating, type);
+		return new BattleReady(userid, this.formatid, valResult.slice(1), rating, challengeType);
 	}
 
 	static cancelChallenging(user: User) {
@@ -577,7 +577,7 @@ class Ladder extends LadderStore {
 			p2team: ready2.team,
 			p2rating: ready2.rating,
 			rated: Math.min(ready1.rating, ready2.rating),
-			type: ready1.type,
+			challengeType: ready1.challengeType,
 		});
 	}
 }

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -20,6 +20,7 @@ import * as RoomGames from "./room-game";
 
 type ChannelIndex = 0 | 1 | 2 | 3 | 4;
 type PlayerIndex = 1 | 2 | 3 | 4;
+export type BattleType = 'rated' | 'unrated' | 'challenge' | 'tour';
 
 interface BattleRequestTracker {
 	rqid: number;
@@ -455,6 +456,7 @@ export class RoomBattle extends RoomGames.RoomGame {
 	readonly allowRenames: boolean;
 	readonly format: string;
 	readonly gameType: string | undefined;
+	readonly type: BattleType;
 	/**
 	 * The lower player's rating, for searching purposes.
 	 * 0 for unrated battles. 1 for unknown ratings.
@@ -498,6 +500,7 @@ export class RoomBattle extends RoomGames.RoomGame {
 
 		this.format = formatid;
 		this.gameType = format.gameType;
+		this.type = options.type;
 		this.rated = options.rated || 0;
 		// true when onCreateBattleRoom has been called
 		this.missingBattleStartMessage = !!options.inputLog;

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -20,7 +20,7 @@ import * as RoomGames from "./room-game";
 
 type ChannelIndex = 0 | 1 | 2 | 3 | 4;
 type PlayerIndex = 1 | 2 | 3 | 4;
-export type BattleType = 'rated' | 'unrated' | 'challenge' | 'tour';
+export type ChallengeType = 'rated' | 'unrated' | 'challenge' | 'tour';
 
 interface BattleRequestTracker {
 	rqid: number;
@@ -456,7 +456,7 @@ export class RoomBattle extends RoomGames.RoomGame {
 	readonly allowRenames: boolean;
 	readonly format: string;
 	readonly gameType: string | undefined;
-	readonly type: BattleType;
+	readonly challengeType: ChallengeType;
 	/**
 	 * The lower player's rating, for searching purposes.
 	 * 0 for unrated battles. 1 for unknown ratings.
@@ -500,7 +500,7 @@ export class RoomBattle extends RoomGames.RoomGame {
 
 		this.format = formatid;
 		this.gameType = format.gameType;
-		this.type = options.type;
+		this.challengeType = options.challengeType;
 		this.rated = options.rated || 0;
 		// true when onCreateBattleRoom has been called
 		this.missingBattleStartMessage = !!options.inputLog;

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -868,7 +868,7 @@ export class Tournament extends Rooms.RoomGame {
 		this.isAvailableMatchesInvalidated = true;
 		this.update();
 
-		const ready = await Ladders(this.fullFormat).prepBattle(output.connection);
+		const ready = await Ladders(this.fullFormat).prepBattle(output.connection, 'tour');
 		if (!ready) {
 			from.isBusy = false;
 			to.isBusy = false;
@@ -928,7 +928,7 @@ export class Tournament extends Rooms.RoomGame {
 		const challenge = player.pendingChallenge;
 		if (!challenge || !challenge.from) return;
 
-		const ready = await Ladders(this.fullFormat).prepBattle(output.connection);
+		const ready = await Ladders(this.fullFormat).prepBattle(output.connection, 'tour');
 		if (!ready) return;
 
 		// Prevent battles between offline users from starting
@@ -946,6 +946,7 @@ export class Tournament extends Rooms.RoomGame {
 			p2: user,
 			p2team: ready.team,
 			rated: !Ladders.disabled && this.isRated,
+			type: ready.type,
 			tour: this,
 		});
 		if (!room || !room.battle) throw new Error(`Failed to create battle in ${room}`);

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -946,7 +946,7 @@ export class Tournament extends Rooms.RoomGame {
 			p2: user,
 			p2team: ready.team,
 			rated: !Ladders.disabled && this.isRated,
-			type: ready.type,
+			challengeType: ready.challengeType,
 			tour: this,
 		});
 		if (!room || !room.battle) throw new Error(`Failed to create battle in ${room}`);


### PR DESCRIPTION
This commit adds a `challengeType` property to `RoomBattle` of
type `rated | unrated | challenge | tour`.

Previously, there was no way to programatically differ an unrated
battle from a challenge, which is useful in places like filters.

(This pull request requires a restart.)