### PR TITLE
Generalize NFE bans into validator rule

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -232,18 +232,12 @@ let Formats = [
 
 		mod: 'gen7',
 		searchShow: false,
-		ruleset: ['[Gen 7] OU'],
+		ruleset: ['[Gen 7] OU', 'NFE Clause'],
 		banlist: [
 			'Chansey', 'Doublade', 'Gligar', 'Golbat', 'Gurdurr', 'Magneton', 'Piloswine',
 			'Porygon2', 'Rhydon', 'Scyther', 'Sneasel', 'Type: Null', 'Vigoroth',
 			'Drought', 'Aurora Veil',
 		],
-		onValidateSet(set) {
-			let template = this.dex.getTemplate(set.species || set.name);
-			if (!template.nfe) {
-				return [set.species + " cannot evolve."];
-			}
-		},
 	},
 	{
 		name: "[Gen 7] CAP",

--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -535,6 +535,20 @@ let BattleFormats = {
 			this.add('rule', 'Z-Move Clause: Z-Moves are banned');
 		},
 	},
+	nfeclause: {
+		effectType: 'ValidatorRule',
+		name: 'NFE Clause',
+		desc: "Bans Pok&eacute;mon that cannot evolve",
+		onValidateSet(set) {
+			const template = this.dex.getTemplate(set.species || set.name);
+			if (!template.nfe) {
+				return [set.species + " cannot evolve."];
+			}
+		},
+		onBegin() {
+			this.add('rule', 'NFE Clause: Fully Evolved Pok&eacute;mon are banned');
+		},
+	},
 	hppercentagemod: {
 		effectType: 'Rule',
 		name: 'HP Percentage Mod',

--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -538,7 +538,7 @@ let BattleFormats = {
 	nfeclause: {
 		effectType: 'ValidatorRule',
 		name: 'NFE Clause',
-		desc: "Bans Pok&eacute;mon that cannot evolve",
+		desc: "Bans Pok&eacute;mon that are fully evolved or can't evolve",
 		onValidateSet(set) {
 			const template = this.dex.getTemplate(set.species || set.name);
 			if (!template.nfe) {


### PR DESCRIPTION
so various NFE tournaments like old generations or Mix & Mega can be played without gentleman's rule or complex banlists. Tried to ask @TheImmortal for permission beforehand but didn't get an answer so figured I'd just propose it and see if it gets approved