### PR TITLE
Dynamax Draft

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -81,6 +81,7 @@ let BattleFormatsData = {
 		tier: "Illegal",
 	},
 	charizardgmax: {
+		isGigantamax: "G-Max Wildfire",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -149,6 +150,7 @@ let BattleFormatsData = {
 		doublesTier: "New",
 	},
 	butterfreegmax: {
+		isGigantamax: "G-Max Befuddle",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -514,6 +516,7 @@ let BattleFormatsData = {
 		tier: "Illegal",
 	},
 	pikachugmax: {
+		isGigantamax: "G-Max Volt Crash",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -819,6 +822,7 @@ let BattleFormatsData = {
 		eventPokemon: [
 			{"generation": 8, "level": 5, "shiny": false, "moves": ["fakeout", "growl", "slash", "payday"], "pokeball": "cherishball"},
 		],
+		isGigantamax: "G-Max Gold Rush",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -1001,6 +1005,7 @@ let BattleFormatsData = {
 		doublesTier: "New",
 	},
 	machampgmax: {
+		isGigantamax: "G-Max Chi Strike",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -1323,6 +1328,7 @@ let BattleFormatsData = {
 		tier: "Illegal",
 	},
 	gengargmax: {
+		isGigantamax: "G-Max Terror",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -1380,6 +1386,7 @@ let BattleFormatsData = {
 		doublesTier: "New",
 	},
 	kinglergmax: {
+		isGigantamax: "G-Max Foam Burst",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -1885,6 +1892,7 @@ let BattleFormatsData = {
 		doublesTier: "New",
 	},
 	laprasgmax: {
+		isGigantamax: "G-Max Resonance",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -1928,6 +1936,7 @@ let BattleFormatsData = {
 		tier: "Illegal",
 	},
 	eeveegmax: {
+		isGigantamax: "G-Max Cuddle",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -2095,6 +2104,7 @@ let BattleFormatsData = {
 		doublesTier: "New",
 	},
 	snorlaxgmax: {
+		isGigantamax: "G-Max Replenish",
 		isUnreleased: true,
 		tier: "Unreleased",
 	},
@@ -5415,6 +5425,7 @@ let BattleFormatsData = {
 		doublesTier: "New",
 	},
 	garbodorgmax: {
+		isGigantamax: "G-Max Maloder",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -7301,6 +7312,7 @@ let BattleFormatsData = {
 		tier: "Unreleased",
 	},
 	melmetalgmax: {
+		isGigantamax: "G-Max Meltdown",
 		isUnreleased: true,
 		tier: "Unreleased",
 	},
@@ -7361,6 +7373,7 @@ let BattleFormatsData = {
 	},
 	corviknight: {
 		randomBattleMoves: ["bodypress", "bravebird", "bulkup", "defog", "ironhead", "roost", "uturn"],
+		isGigantamax: "G-Max Wind Rage",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -7380,6 +7393,7 @@ let BattleFormatsData = {
 		doublesTier: "New",
 	},
 	orbeetlegmax: {
+		isGigantamax: "G-Max Gravitas",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -7416,6 +7430,7 @@ let BattleFormatsData = {
 		doublesTier: "New",
 	},
 	drednawgmax: {
+		isGigantamax: "G-Max Stonesurge",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -7439,6 +7454,7 @@ let BattleFormatsData = {
 		doublesTier: "New",
 	},
 	coalossalgmax: {
+		isGigantamax: "G-Max Volcalith",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -7451,6 +7467,7 @@ let BattleFormatsData = {
 		doublesTier: "New",
 	},
 	flapplegmax: {
+		isGigantamax: "G-Max Tartness",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -7460,6 +7477,7 @@ let BattleFormatsData = {
 		doublesTier: "New",
 	},
 	appletungmax: {
+		isGigantamax: "G-Max Sweetness",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -7472,6 +7490,7 @@ let BattleFormatsData = {
 		doublesTier: "New",
 	},
 	sandacondagmax: {
+		isGigantamax: "G-Max Sandblast",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -7508,6 +7527,7 @@ let BattleFormatsData = {
 		doublesTier: "New",
 	},
 	toxtricitygmax: {
+		isGigantamax: "G-Max Stun Shock",
 		isUnreleased: true,
 		tier: "Unreleased",
 	},
@@ -7516,6 +7536,7 @@ let BattleFormatsData = {
 	},
 	centiskorch: {
 		randomBattleMoves: ["coil", "firelash", "knockoff", "leechlife", "powerwhip"],
+		isGigantamax: "G-Max Centiferno",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -7551,6 +7572,7 @@ let BattleFormatsData = {
 		doublesTier: "New",
 	},
 	hatterenegmax: {
+		isGigantamax: "G-Max Smite",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -7562,6 +7584,7 @@ let BattleFormatsData = {
 	},
 	grimmsnarl: {
 		randomBattleMoves: ["bulkup", "drainpunch", "falsesurrender", "playrough", "spiritbreak", "suckerpunch", "superpower", "thunderwave", "taunt"],
+		isGigantamax: "G-Max Snooze",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -7578,6 +7601,7 @@ let BattleFormatsData = {
 		doublesTier: "New",
 	},
 	alcremiegmax: {
+		isGigantamax: "G-Max Finale",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -7635,6 +7659,7 @@ let BattleFormatsData = {
 	},
 	copperajah: {
 		randomBattleMoves: ["curse", "earthquake", "heavyslam", "ironhead", "powerwhip", "playrough", "rockslide", "stealthrock"],
+		isGigantamax: "G-Max Steelsurge",
 		tier: "New",
 		doublesTier: "New",
 	},
@@ -7672,6 +7697,7 @@ let BattleFormatsData = {
 		doublesTier: "New",
 	},
 	duraludongmax: {
+		isGigantamax: "G-Max Depletion",
 		tier: "New",
 		doublesTier: "New",
 	},

--- a/data/mods/ssb/scripts.js
+++ b/data/mods/ssb/scripts.js
@@ -206,7 +206,7 @@ let BattleScripts = {
 		if (!item.zMove) return;
 		if (item.zMoveUser && !item.zMoveUser.includes(pokemon.template.species)) return;
 		let atLeastOne = false;
-		/**@type {AnyObject?[]} */
+		/**@type {ZMoveOptions} */
 		let zMoves = [];
 		for (const moveSlot of pokemon.moveSlots) {
 			if (moveSlot.pp <= 0) {

--- a/data/moves.js
+++ b/data/moves.js
@@ -11123,7 +11123,7 @@ let BattleMovedex = {
 		isViable: true,
 		name: "Max Guard",
 		pp: 5,
-		priority: 0,
+		priority: 4,
 		flags: {},
 		isMax: true,
 		stallingMove: true,

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1203,8 +1203,7 @@ let BattleScripts = {
 			if (gMaxMove.exists && gMaxMove.type === move.type) maxMove = gMaxMove;
 		}
 		// @ts-ignore
-		// maxMove.basePower = move.maxPower; // TODO define this in all moves
-		// TODO actually modify max moves when they are coded & other moves have support for max moves
+		maxMove.basePower = move.zMovePower; // TODO defined a Max Move Power in all moves and use that
 		maxMove.maxPowered = true;
 		return maxMove;
 	},

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -16,8 +16,8 @@ let BattleScripts = {
 	 * externalMove skips LockMove and PP deduction, mostly for use by
 	 * Dancer.
 	 */
-	runMove(moveOrMoveName, pokemon, targetLoc, sourceEffect, zMove, externalMove) {
-		let target = this.getTarget(pokemon, zMove || moveOrMoveName, targetLoc);
+	runMove(moveOrMoveName, pokemon, targetLoc, sourceEffect, zMove, externalMove, maxMove) {
+		let target = this.getTarget(pokemon, maxMove || zMove || moveOrMoveName, targetLoc);
 		let baseMove = this.dex.getActiveMove(moveOrMoveName);
 		const pranksterBoosted = baseMove.pranksterBoosted;
 		if (baseMove.id !== 'struggle' && !zMove && !externalMove) {
@@ -28,7 +28,12 @@ let BattleScripts = {
 				target = this.resolveTarget(pokemon, baseMove);
 			}
 		}
-		let move = zMove ? this.getActiveZMove(baseMove, pokemon) : baseMove;
+		let move = baseMove;
+		if (zMove) {
+			move = this.getActiveZMove(baseMove, pokemon);
+		} else if (maxMove) {
+			move = this.getActiveMaxMove(baseMove, pokemon);
+		}
 
 		move.isExternal = externalMove;
 
@@ -90,7 +95,7 @@ let BattleScripts = {
 			this.add('-zpower', pokemon);
 			pokemon.side.zMoveUsed = true;
 		}
-		let moveDidSomething = this.useMove(baseMove, pokemon, target, sourceEffect, zMove);
+		let moveDidSomething = this.useMove(baseMove, pokemon, target, sourceEffect, zMove, maxMove);
 		if (this.activeMove) move = this.activeMove;
 		this.singleEvent('AfterMove', move, null, pokemon, target, move);
 		this.runEvent('AfterMove', pokemon, target, move);
@@ -134,15 +139,15 @@ let BattleScripts = {
 	 * The only ones that use runMove are Instruct, Pursuit, and
 	 * Dancer.
 	 */
-	useMove(move, pokemon, target, sourceEffect, zMove) {
+	useMove(move, pokemon, target, sourceEffect, zMove, maxMove) {
 		pokemon.moveThisTurnResult = undefined;
 		/** @type {boolean? | undefined} */ // Typescript bug
 		let oldMoveResult = pokemon.moveThisTurnResult;
-		let moveResult = this.useMoveInner(move, pokemon, target, sourceEffect, zMove);
+		let moveResult = this.useMoveInner(move, pokemon, target, sourceEffect, zMove, maxMove);
 		if (oldMoveResult === pokemon.moveThisTurnResult) pokemon.moveThisTurnResult = moveResult;
 		return moveResult;
 	},
-	useMoveInner(moveOrMoveName, pokemon, target, sourceEffect, zMove) {
+	useMoveInner(moveOrMoveName, pokemon, target, sourceEffect, zMove, maxMove) {
 		if (!sourceEffect && this.effect.id) sourceEffect = this.effect;
 		if (sourceEffect && ['instruct', 'custapberry'].includes(sourceEffect.id)) sourceEffect = null;
 
@@ -155,6 +160,9 @@ let BattleScripts = {
 		}
 		if (zMove || (move.category !== 'Status' && sourceEffect && /** @type {ActiveMove} */(sourceEffect).isZ)) {
 			move = this.getActiveZMove(move, pokemon);
+		}
+		if (maxMove || (move.category !== 'Status' && sourceEffect && /** @type {ActiveMove} */(sourceEffect).isMax)) {
+			move = this.getActiveMaxMove(move, pokemon);
 		}
 
 		if (this.activeMove) {
@@ -1094,7 +1102,7 @@ let BattleScripts = {
 		if (item.zMoveUser && !item.zMoveUser.includes(pokemon.template.species)) return;
 		let atLeastOne = false;
 		let mustStruggle = true;
-		/**@type {AnyObject?[]} */
+		/**@type {ZMoveOptions} */
 		let zMoves = [];
 		for (const moveSlot of pokemon.moveSlots) {
 			if (moveSlot.pp <= 0) {
@@ -1134,6 +1142,60 @@ let BattleScripts = {
 			return "Necrozma-Ultra";
 		}
 		return null;
+	},
+
+	maxMoveTable: {
+		Flying: 'Max Airstream',
+		Dark: 'Max Darkness',
+		Fire: 'Max Flare',
+		Bug: 'Max Flutterby',
+		Water: 'Max Geyser',
+		Status: 'Max Guard',
+		Ice: 'Max Hailstorm',
+		Fighting: 'Max Knuckle',
+		Electric: 'Max Lightning',
+		Psychic: 'Max Mindstorm',
+		Poison: 'Max Ooze',
+		Grass: 'Max Overgrowth',
+		Ghost: 'Max Phantasm',
+		Ground: 'Max Quake',
+		Rock: 'Max Rockfall',
+		Fairy: 'Max Starfall',
+		Steel: 'Max Steelspike',
+		Normal: 'Max Strike',
+		Dragon: 'Max Wyrmwind',
+	},
+
+	canDynamax(pokemon, skipChecks) {
+		// {gigantimax?: string, maxMoves: {[k: string]: string} | null}[]
+		if (!skipChecks) {
+			if (!pokemon.canDynamax) return;
+		}
+		/** @type {DynamaxOptions} */
+		let result = {maxMoves: []};
+		for (let moveSlot of pokemon.moveSlots) {
+			let move = this.dex.getMove(moveSlot.id);
+			let maxMove = this.getMaxMove(move, pokemon);
+			if (maxMove) result.maxMoves.push({move: maxMove.id, target: maxMove.target});
+		}
+		// TODO gigantimax
+		return result;
+	},
+
+	getMaxMove(move, pokemon) {
+		// TODO Gigantimax
+		if (move.isMax) return move;
+		return this.dex.getMove(this.maxMoveTable[move.category === 'Status' ? move.category : move.type]);
+	},
+
+	getActiveMaxMove(move, pokemon) {
+		let maxMove = this.dex.getActiveMove(this.maxMoveTable[move.category === 'Status' ? move.category : move.type]);
+		// @ts-ignore
+		//maxMove.basePower = move.maxPower; // TODO define this in all moves
+		// TODO actually modify max moves when they are coded & other moves have support for max moves
+		// TODO get gigantimax moves as approriate
+		maxMove.isMaxPowered = true;
+		return maxMove;
 	},
 
 	runMegaEvo(pokemon) {

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -716,11 +716,13 @@ let BattleStatuses = {
 		duration: 3,
 		onStart(pokemon) {
 			this.add('-dynamax', pokemon);
+			this.debug(`Dynamax Start: ${pokemon} (${pokemon.side.name})`);
+			if (pokemon.canGigantamax) pokemon.formeChange(pokemon.canGigantamax);
 			let ratio = (2 / 3); // Changes based on dynamax level, static (LVL 0) until we know the levels
 			pokemon.maxhp = Math.floor(pokemon.maxhp / ratio);
 			pokemon.hp = Math.floor(pokemon.hp / ratio);
 			// TODO work on display for healing
-			this.add('-heal', pokemon, pokemon.getHealth, '[silent]');
+			this.add('-heal', pokemon, pokemon.getHealth, '[from] Dynamax');
 		},
 		onFlinch: false,
 		onSwitchOut(pokemon) {
@@ -731,11 +733,13 @@ let BattleStatuses = {
 			// Play animation
 			// Modify HP - Work with LVL 0 for now
 			this.add('-undynamax', pokemon);
+			this.debug(`Dynamax End: ${pokemon} (${pokemon.side.name})`);
+			if (pokemon.canGigantamax) pokemon.formeChange(pokemon.baseTemplate.species);
 			let ratio = (2 / 3); // Changes based on dynamax level, static (LVL 0) until we know the levels
 			pokemon.maxhp = Math.floor(pokemon.maxhp * ratio); // TODO prevent maxhp loss
 			pokemon.hp = Math.floor(pokemon.hp * ratio);
 			// TODO work on display for healing
-			this.add('-heal', pokemon, pokemon.getHealth, '[silent]');
+			this.add('-heal', pokemon, pokemon.getHealth, '[from] Dynamax');
 		},
 	},
 

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -709,6 +709,36 @@ let BattleStatuses = {
 		},
 	},
 
+	dynamax: {
+		name: 'Dynamax',
+		id: 'dynamax',
+		num: 0,
+		duration: 3,
+		onStart(pokemon) {
+			this.add('-dynamax', pokemon);
+			let ratio = (2 / 3); // Changes based on dynamax level, static (LVL 0) until we know the levels
+			pokemon.maxhp = Math.floor(pokemon.maxhp / ratio);
+			pokemon.hp = Math.floor(pokemon.hp / ratio);
+			// TODO work on display for healing
+			this.add('-heal', pokemon, pokemon.getHealth, '[silent]');
+		},
+		onFlinch: false,
+		onSwitchOut(pokemon) {
+			// Run the end event
+			pokemon.volatiles.dynamax.onEnd(pokemon);
+		},
+		onEnd(pokemon) {
+			// Play animation
+			// Modify HP - Work with LVL 0 for now
+			this.add('-undynamax', pokemon);
+			let ratio = (2 / 3); // Changes based on dynamax level, static (LVL 0) until we know the levels
+			pokemon.maxhp = Math.floor(pokemon.maxhp * ratio); // TODO prevent maxhp loss
+			pokemon.hp = Math.floor(pokemon.hp * ratio);
+			// TODO work on display for healing
+			this.add('-heal', pokemon, pokemon.getHealth, '[silent]');
+		},
+	},
+
 	// Arceus and Silvally's actual typing is implemented here.
 	// Their true typing for all their formes is Normal, and it's only
 	// Multitype and RKS System, respectively, that changes their type,

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2394,6 +2394,15 @@ export class Battle {
 						}
 					}
 				}
+				if (action.maxMove) {
+					const maxMoveName = this.getMaxMove(action.maxMove, action.pokemon);
+					if (maxMoveName) {
+						const maxMove = this.getActiveMaxMove(action.move, action.pokemon);
+						if (maxMove.exists && maxMove.isMax) {
+							move = maxMove;
+						}
+					}
+				}
 				const priority = this.runEvent('ModifyPriority', action.pokemon, target, move, move.priority);
 				action.priority = priority;
 				// In Gen 6, Quick Guard blocks moves with artificially enhanced priority.
@@ -2551,14 +2560,15 @@ export class Battle {
 		case 'move':
 			if (!action.pokemon.isActive) return false;
 			if (action.pokemon.fainted) return false;
-			this.runMove(action.move, action.pokemon, action.targetLoc, action.sourceEffect, action.zmove, undefined, action.maxMove);
+			this.runMove(action.move, action.pokemon, action.targetLoc, action.sourceEffect,
+				action.zmove, undefined, action.maxMove);
 			break;
 		case 'megaEvo':
 			this.runMegaEvo(action.pokemon);
 			break;
 		case 'runDynamax':
 			action.pokemon.addVolatile('dynamax');
-			for (let pokemon of action.pokemon.side.pokemon) {
+			for (const pokemon of action.pokemon.side.pokemon) {
 				pokemon.canDynamax = null;
 			}
 			break;
@@ -3117,8 +3127,7 @@ export class Battle {
 		throw new UnimplementedError('canZMove');
 	}
 
-	// FIXME determine how to both return dyna moves and giga form if needed
-	canDynamax(pokemon: Pokemon): DynamaxOptions | undefined {
+	canDynamax(pokemon: Pokemon, skipChecks?: boolean): DynamaxOptions | undefined {
 		throw new UnimplementedError('canDynamax');
 	}
 

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -587,7 +587,7 @@ export class Template extends BasicEffect implements Readonly<BasicEffect & Temp
 	/** True if a pokemon is primal. */
 	readonly isPrimal?: boolean;
 	/** True if a pokemon is gigantamax. */
-	readonly isGigantamax?: boolean;
+	readonly isGigantamax?: string;
 	/** True if a pokemon is a forme that is only accessible in battle. */
 	readonly battleOnly?: boolean;
 	/** Required item. Do not use this directly; see requiredItems. */
@@ -676,7 +676,7 @@ export class Template extends BasicEffect implements Readonly<BasicEffect & Temp
 		this.eventOnly = !!data.eventOnly;
 		this.eventPokemon = data.eventPokemon || undefined;
 		this.isMega = !!(this.forme && ['Mega', 'Mega-X', 'Mega-Y'].includes(this.forme)) || undefined;
-		this.isGigantamax = !!(this.forme && this.forme.endsWith('Gigantamax')) || undefined;
+		this.isGigantamax = data.isGigantamax || undefined;
 		this.battleOnly = !!data.battleOnly || !!this.isMega || !!this.isGigantamax || undefined;
 
 		if (!this.gen && this.num >= 1) {

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -659,6 +659,11 @@ interface EffectData {
 	 * Sparksurfer.
 	 */
 	isZ?: boolean | string
+	/**
+	 * `true` for Max moves like Max Airstream. If its a G-Max moves, this is
+	 * the species ID of the giganimax pokemon that can use this G-Max move.
+	 */
+	isMax?: boolean | string
 	noCopy?: boolean
 	recoil?: [number, number]
 	secondary?: SecondaryEffect | null
@@ -878,6 +883,11 @@ interface ActiveMove extends BasicEffect, MoveData {
 	 * truthy.
 	 */
 	isZPowered?: boolean
+	/**
+	 * Same idea has isZPowered. (Is only blocked by protect if its)
+	 * maxPowered. Update/remove this when this is confirmed.
+	 */
+	maxPowered?: boolean
 }
 
 type TemplateAbility = {0: string, 1?: string, H?: string, S?: string}
@@ -1032,17 +1042,23 @@ interface Format extends Readonly<BasicEffect & FormatsData> {
 
 type SpreadMoveTargets = (Pokemon | false | null)[]
 type SpreadMoveDamage = (number | boolean | undefined)[]
+type ZMoveOptions = ({move: string, target: string} | null)[]
+type DynamaxOptions = {maxMoves: ({move: string, target: string} | null)[], gigantimax?: string}
 
 interface BattleScriptsData {
 	gen: number
 	zMoveTable?: {[k: string]: string}
+	maxMoveTable?: {[k: string]: string}
 	afterMoveSecondaryEvent?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => undefined
 	calcRecoilDamage?: (this: Battle, damageDealt: number, move: Move) => number
 	canMegaEvo?: (this: Battle, pokemon: Pokemon) => string | undefined | null
 	canUltraBurst?: (this: Battle, pokemon: Pokemon) => string | null
-	canZMove?: (this: Battle, pokemon: Pokemon) => (AnyObject | null)[] | void
+	canZMove?: (this: Battle, pokemon: Pokemon) => ZMoveOptions | void
+	canDynamax?: (this: Battle, pokemon: Pokemon, skipChecks?: boolean) => DynamaxOptions | void
 	forceSwitch?: (this: Battle, damage: SpreadMoveDamage, targets: SpreadMoveTargets, source: Pokemon, move: ActiveMove, moveData: ActiveMove, isSecondary?: boolean, isSelf?: boolean) => SpreadMoveDamage
+	getActiveMaxMove?: (this: Battle, move: Move, pokemon: Pokemon) => ActiveMove
 	getActiveZMove?: (this: Battle, move: Move, pokemon: Pokemon) => ActiveMove
+	getMaxMove?: (this: Battle, move: Move, pokemon: Pokemon) => Move | undefined
 	getSpreadDamage?: (this: Battle, damage: SpreadMoveDamage, targets: SpreadMoveTargets, source: Pokemon, move: ActiveMove, moveData: ActiveMove, isSecondary?: boolean, isSelf?: boolean) => SpreadMoveDamage
 	getZMove?: (this: Battle, move: Move, pokemon: Pokemon, skipChecks?: boolean) => string | undefined
 	hitStepAccuracy?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => boolean[]
@@ -1058,7 +1074,7 @@ interface BattleScriptsData {
 	resolveAction?: (this: Battle, action: AnyObject, midTurn?: boolean) => Actions.Action
 	runAction?: (this: Battle, action: Actions.Action) => void
 	runMegaEvo?: (this: Battle, pokemon: Pokemon) => boolean
-	runMove?: (this: Battle, moveOrMoveName: Move | string, pokemon: Pokemon, targetLoc: number, sourceEffect?: Effect | null, zMove?: string, externalMove?: boolean) => void
+	runMove?: (this: Battle, moveOrMoveName: Move | string, pokemon: Pokemon, targetLoc: number, sourceEffect?: Effect | null, zMove?: string, externalMove?: boolean, maxMove?: string) => void
 	runMoveEffects?: (this: Battle, damage: SpreadMoveDamage, targets: SpreadMoveTargets, source: Pokemon, move: ActiveMove, moveData: ActiveMove, isSecondary?: boolean, isSelf?: boolean) => SpreadMoveDamage
 	runZPower?: (this: Battle, move: ActiveMove, pokemon: Pokemon) => void
 	secondaries?: (this: Battle, targets: SpreadMoveTargets, source: Pokemon, move: ActiveMove, moveData: ActiveMove, isSelf?: boolean) => void
@@ -1068,8 +1084,8 @@ interface BattleScriptsData {
 	tryMoveHit?: (this: Battle, target: Pokemon, pokemon: Pokemon, move: ActiveMove) => number | undefined | false | ''
 	tryPrimaryHitEvent?: (this: Battle, damage: SpreadMoveDamage, targets: SpreadMoveTargets, pokemon: Pokemon, move: ActiveMove, moveData: ActiveMove, isSecondary?: boolean) => SpreadMoveDamage
 	trySpreadMoveHit?: (this: Battle, targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) => boolean
-	useMove?: (this: Battle, move: Move, pokemon: Pokemon, target?: Pokemon | null, sourceEffect?: Effect | null, zMove?: string) => boolean
-	useMoveInner?: (this: Battle, move: Move, pokemon: Pokemon, target?: Pokemon | null, sourceEffect?: Effect | null, zMove?: string) => boolean
+	useMove?: (this: Battle, move: Move, pokemon: Pokemon, target?: Pokemon | null, sourceEffect?: Effect | null, zMove?: string, maxMove?: string) => boolean
+	useMoveInner?: (this: Battle, move: Move, pokemon: Pokemon, target?: Pokemon | null, sourceEffect?: Effect | null, zMove?: string, maxMove?: string) => boolean
 }
 
 interface ModdedBattleSide {
@@ -1081,7 +1097,7 @@ interface ModdedBattlePokemon {
 	boostBy?: (this: Pokemon, boost: SparseBoostsTable) => boolean | number
 	calculateStat?: (this: Pokemon, statName: StatNameExceptHP, boost: number, modifier?: number) => number
 	getActionSpeed?: (this: Pokemon) => number
-	getRequestData?: (this: Pokemon) => {moves: {move: string, id: ID, target?: string, disabled?: boolean}[], maybeDisabled?: boolean, trapped?: boolean, maybeTrapped?: boolean, canMegaEvo?: boolean, canUltraBurst?: boolean, canZMove?: AnyObject | null}
+	getRequestData?: (this: Pokemon) => {moves: {move: string, id: ID, target?: string, disabled?: boolean}[], maybeDisabled?: boolean, trapped?: boolean, maybeTrapped?: boolean, canMegaEvo?: boolean, canUltraBurst?: boolean, canZMove?: ZMoveOptions}
 	getStat?: (this: Pokemon, statName: StatNameExceptHP, unboosted?: boolean, unmodified?: boolean, fastReturn?: boolean) => number
 	getWeight?: (this: Pokemon) => number
 	hasAbility?: (this: Pokemon, ability: string | string[]) => boolean
@@ -1117,7 +1133,7 @@ interface ModdedBattleScriptsData extends Partial<BattleScriptsData> {
 	getAbility?: (this: Battle, name: string | Ability ) => Ability
 	getZMove?: (this: Battle, move: Move, pokemon: Pokemon, skipChecks?: boolean) => string | undefined
 	getActiveZMove?: (this: Battle, move: Move, pokemon: Pokemon) => ActiveMove
-	canZMove?: (this: Battle, pokemon: Pokemon) => (AnyObject | null)[] | void
+	canZMove?: (this: Battle, pokemon: Pokemon) => ZMoveOptions | void
 }
 
 interface TypeData {
@@ -1170,6 +1186,8 @@ namespace Actions {
 		mega: boolean | 'done';
 		/** if zmoving, the name of the zmove */
 		zmove?: string;
+		/** if dynamaxed, the name of the max move */
+		maxMove?: string;
 		/** effect that called the move (eg Instruct) if any */
 		sourceEffect?: Effect | null;
 	}
@@ -1219,7 +1237,7 @@ namespace Actions {
 	/** A generic action done by a single pokemon */
 	export interface PokemonAction {
 		/** action type */
-		choice: 'megaEvo' | 'shift' | 'runPrimal' | 'runSwitch' | 'event' | 'runUnnerve';
+		choice: 'megaEvo' | 'shift' | 'runPrimal' | 'runSwitch' | 'event' | 'runUnnerve' | 'runDynamax';
 		/** priority of the action (lower first) */
 		priority: number;
 		/** speed of pokemon doing action (higher first if priority tie) */

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -935,6 +935,7 @@ interface TemplateFormatsData {
 	eventPokemon?: EventInfo[]
 	exclusiveMoves?: readonly string[]
 	gen?: number
+	isGigantamax?: string
 	isNonstandard?: Nonstandard | null
 	isUnreleased?: boolean
 	maleOnlyHidden?: boolean
@@ -1043,7 +1044,7 @@ interface Format extends Readonly<BasicEffect & FormatsData> {
 type SpreadMoveTargets = (Pokemon | false | null)[]
 type SpreadMoveDamage = (number | boolean | undefined)[]
 type ZMoveOptions = ({move: string, target: string} | null)[]
-type DynamaxOptions = {maxMoves: ({move: string, target: string} | null)[], gigantimax?: string}
+type DynamaxOptions = {maxMoves: ({move: string, target: string})[], gigantamax?: string}
 
 interface BattleScriptsData {
 	gen: number

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -225,13 +225,6 @@ export class Pokemon {
 		if (!this.baseTemplate.exists) {
 			throw new Error(`Unidentified species: ${this.baseTemplate.name}`);
 		}
-		// FIXME This is probably a bad way to go about this and dosen't work anyways.
-		let gMax = '';
-		if (this.baseTemplate.forme === 'Gmax') {
-			// Use the base species, not gigantamax species.
-			gMax = this.baseTemplate.name;
-			this.baseTemplate = this.battle.dex.getTemplate(this.baseTemplate.baseSpecies);
-		}
 		this.template = this.baseTemplate;
 		this.species = this.battle.dex.getSpecies(set.species);
 		this.speciesid = toID(this.species);
@@ -376,7 +369,7 @@ export class Pokemon {
 		this.canDynamax = true; // (this.battle.gen >= 8);
 		const canDynamax = this.battle.canDynamax(this);
 		this.canDynamax = canDynamax && canDynamax.gigantamax ? canDynamax.gigantamax : !!canDynamax;
-		this.canGigantamax = gMax || null;
+		this.canGigantamax = null; // TODO Gmax support
 
 		// This is used in gen 1 only, here to avoid code repetition.
 		// Only declared if gen 1 to avoid declaring an object we aren't going to need.

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -198,6 +198,7 @@ export class Pokemon {
 
 	canMegaEvo: string | null | undefined;
 	canUltraBurst: string | null | undefined;
+	canDynamax: string | boolean | null | undefined;
 
 	staleness?: 'internal' | 'external';
 	pendingStaleness?: 'internal' | 'external';
@@ -363,6 +364,8 @@ export class Pokemon {
 
 		this.canMegaEvo = this.battle.canMegaEvo(this);
 		this.canUltraBurst = this.battle.canUltraBurst(this);
+		let canDynamax = this.battle.canDynamax(this);
+		this.canDynamax = canDynamax && canDynamax.gigantimax ? canDynamax.gigantimax : !!canDynamax;
 
 		// This is used in gen 1 only, here to avoid code repetition.
 		// Only declared if gen 1 to avoid declaring an object we aren't going to need.

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -20,6 +20,7 @@ interface ChosenAction {
 	side?: Side; // the action's side
 	mega?: boolean | null; // true if megaing or ultra bursting
 	zmove?: string; // if zmoving, the name of the zmove
+	maxMove?: string; // if dynamaxed, the name of the max move
 	priority?: number; // priority of the action
 }
 
@@ -34,6 +35,7 @@ export interface Choice {
 	zMove: boolean; // true if a Z-move has already been selected
 	mega: boolean; // true if a mega evolution has already been selected
 	ultra: boolean; // true if an ultra burst has already been selected
+	dynamax: boolean; // true if a dynamax has already been selected
 }
 
 export class Side {
@@ -117,6 +119,7 @@ export class Side {
 			zMove: false,
 			mega: false,
 			ultra: false,
+			dynamax: false,
 		};
 
 		// old-gens
@@ -352,7 +355,7 @@ export class Side {
 		return this.choice.actions.length >= this.active.length;
 	}
 
-	chooseMove(moveText?: string | number, targetLoc?: number, megaOrZ?: boolean | string) {
+	chooseMove(moveText?: string | number, targetLoc?: number, megaDynaOrZ?: boolean | string) {
 		if (this.requestState !== 'move') {
 			return this.emitChoiceError(`Can't move: You need a ${this.requestState} response`);
 		}
@@ -363,7 +366,7 @@ export class Side {
 		const autoChoose = !moveText;
 		const pokemon: Pokemon = this.active[index];
 
-		if (megaOrZ === true) megaOrZ = 'mega';
+		if (megaDynaOrZ === true) megaDynaOrZ = 'mega';
 		if (!targetLoc) targetLoc = 0;
 
 		// Parse moveText (name or index)
@@ -412,8 +415,8 @@ export class Side {
 
 		// Z-move
 
-		const zMove = megaOrZ === 'zmove' ? this.battle.getZMove(move, pokemon) : undefined;
-		if (megaOrZ === 'zmove' && !zMove) {
+		const zMove = megaDynaOrZ === 'zmove' ? this.battle.getZMove(move, pokemon) : undefined;
+		if (megaDynaOrZ === 'zmove' && !zMove) {
 			return this.emitChoiceError(`Can't move: ${pokemon.name} can't use ${move.name} as a Z-move`);
 		}
 		if (zMove && this.choice.zMove) {
@@ -421,6 +424,14 @@ export class Side {
 		}
 
 		if (zMove) targetType = this.battle.dex.getMove(zMove).target;
+
+		// Dynamax
+		// TODO getMaxMove
+		// Is dynamaxed or will dynamax this turn.
+		const maxMove = (megaDynaOrZ === 'dynamax' || pokemon.volatiles['dynamax']) ? this.battle.getMaxMove(move, pokemon) : undefined;
+		if (megaDynaOrZ === 'dynamax' && !maxMove) {
+			return this.emitChoiceError(`Can't move: ${pokemon.name} can't use ${move.name} as a Max Move`);
+		}
 
 		// Validate targetting
 
@@ -496,21 +507,26 @@ export class Side {
 
 		// Mega evolution
 
-		const mega = (megaOrZ === 'mega');
+		const mega = (megaDynaOrZ === 'mega');
 		if (mega && !pokemon.canMegaEvo) {
 			return this.emitChoiceError(`Can't move: ${pokemon.name} can't mega evolve`);
 		}
 		if (mega && this.choice.mega) {
 			return this.emitChoiceError(`Can't move: You can only mega-evolve once per battle`);
 		}
-		const ultra = (megaOrZ === 'ultra');
+		const ultra = (megaDynaOrZ === 'ultra');
 		if (ultra && !pokemon.canUltraBurst) {
-			return this.emitChoiceError(`Can't move: ${pokemon.name} can't mega evolve`);
+			return this.emitChoiceError(`Can't move: ${pokemon.name} can't ultra burst`);
 		}
 		if (ultra && this.choice.ultra) {
 			return this.emitChoiceError(`Can't move: You can only ultra burst once per battle`);
 		}
+		const dynamax = (megaDynaOrZ === 'dynamax');
+		if (dynamax && this.choice.dynamax) {
+			return this.emitChoiceError(`Can't move: You can only Dynamax once per battle.`);
+		}
 
+		this.battle.debug(`Pushing choice: maxMove: ${maxMove}`);
 		this.choice.actions.push({
 			choice: 'move',
 			pokemon,
@@ -518,6 +534,7 @@ export class Side {
 			moveid,
 			mega: mega || ultra,
 			zmove: zMove,
+			maxMove: maxMove ? maxMove.id : undefined, // TODO dynamax: "maxMoveid"
 		});
 
 		if (pokemon.maybeDisabled) {
@@ -527,6 +544,7 @@ export class Side {
 		if (mega) this.choice.mega = true;
 		if (ultra) this.choice.ultra = true;
 		if (zMove) this.choice.zMove = true;
+		if (dynamax) this.choice.dynamax = true;
 
 		return true;
 	}
@@ -717,6 +735,7 @@ export class Side {
 			zMove: false,
 			mega: false,
 			ultra: false,
+			dynamax: false,
 		};
 	}
 
@@ -758,7 +777,7 @@ export class Side {
 				const original = data;
 				const error = () => this.emitChoiceError(`Conflicting arguments for "move": ${original}`);
 				let targetLoc: number | undefined;
-				let megaOrZ = '';
+				let megaDynaOrZ = '';
 				while (true) {
 					// If data ends with a number, treat it as a target location.
 					// We need to special case 'Conversion 2' so it doesn't get
@@ -769,22 +788,26 @@ export class Side {
 						targetLoc = parseInt(data.slice(-2), 10);
 						data = data.slice(0, -2).trim();
 					} else if (data.endsWith(' mega')) {
-						if (megaOrZ) return error();
-						megaOrZ = 'mega';
+						if (megaDynaOrZ) return error();
+						megaDynaOrZ = 'mega';
 						data = data.slice(0, -5);
 					} else if (data.endsWith(' zmove')) {
-						if (megaOrZ) return error();
-						megaOrZ = 'zmove';
+						if (megaDynaOrZ) return error();
+						megaDynaOrZ = 'zmove';
 						data = data.slice(0, -6);
 					} else if (data.endsWith(' ultra')) {
-						if (megaOrZ) return error();
-						megaOrZ = 'ultra';
+						if (megaDynaOrZ) return error();
+						megaDynaOrZ = 'ultra';
 						data = data.slice(0, -6);
+					} else if (data.endsWith(' dynamax')) {
+						if (megaDynaOrZ) return error();
+						megaDynaOrZ = 'dynamax';
+						data = data.slice(0, -8);
 					} else {
 						break;
 					}
 				}
-				if (!this.chooseMove(data, targetLoc, megaOrZ)) return false;
+				if (!this.chooseMove(data, targetLoc, megaDynaOrZ)) return false;
 				break;
 			case 'switch':
 				this.chooseSwitch(data);

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -426,9 +426,9 @@ export class Side {
 		if (zMove) targetType = this.battle.dex.getMove(zMove).target;
 
 		// Dynamax
-		// TODO getMaxMove
 		// Is dynamaxed or will dynamax this turn.
-		const maxMove = (megaDynaOrZ === 'dynamax' || pokemon.volatiles['dynamax']) ? this.battle.getMaxMove(move, pokemon) : undefined;
+		const maxMove = (megaDynaOrZ === 'dynamax' || pokemon.volatiles['dynamax']) ?
+			this.battle.getMaxMove(move, pokemon) : undefined;
 		if (megaDynaOrZ === 'dynamax' && !maxMove) {
 			return this.emitChoiceError(`Can't move: ${pokemon.name} can't use ${move.name} as a Max Move`);
 		}
@@ -522,7 +522,7 @@ export class Side {
 			return this.emitChoiceError(`Can't move: You can only ultra burst once per battle`);
 		}
 		const dynamax = (megaDynaOrZ === 'dynamax');
-		if (dynamax && this.choice.dynamax) {
+		if (dynamax && (this.choice.dynamax || !this.battle.canDynamax(pokemon))) {
 			return this.emitChoiceError(`Can't move: You can only Dynamax once per battle.`);
 		}
 
@@ -534,7 +534,7 @@ export class Side {
 			moveid,
 			mega: mega || ultra,
 			zmove: zMove,
-			maxMove: maxMove ? maxMove.id : undefined, // TODO dynamax: "maxMoveid"
+			maxMove: maxMove ? maxMove.id : undefined,
 		});
 
 		if (pokemon.maybeDisabled) {

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -526,7 +526,6 @@ export class Side {
 			return this.emitChoiceError(`Can't move: You can only Dynamax once per battle.`);
 		}
 
-		this.battle.debug(`Pushing choice: maxMove: ${maxMove}`);
 		this.choice.actions.push({
 			choice: 'move',
 			pokemon,

--- a/sim/state.ts
+++ b/sim/state.ts
@@ -37,7 +37,7 @@ type Referable = Battle | Field | Side | Pokemon | PureEffect | Ability | Item |
 const BATTLE = new Set([
 	'dex', 'gen', 'ruleTable', 'id', 'log', 'inherit', 'format',
 	'zMoveTable', 'teamGenerator', 'NOT_FAIL', 'FAIL', 'SILENT_FAIL',
-	'field', 'sides', 'prng', 'hints', 'deserialized',
+	'field', 'sides', 'prng', 'hints', 'deserialized', 'maxMoveTable',
 ]);
 const FIELD = new Set(['id', 'battle']);
 const SIDE = new Set(['battle', 'team', 'pokemon', 'choice', 'activeRequest']);


### PR DESCRIPTION
Paired with https://github.com/smogon/pokemon-showdown-client/pull/1394

This is a draft of dynamaxing. Feedback is appreciated, I will be debugging and improving the code today myself too. 

TODO:
- [x] Actually test this to find & fix bugs.
- [x] Add gigantamax support
- [x] Client support is not done, someone else can take that.

Client support details:
the `|request|` protocal object will soon also send two new properties on an active pokemon. `canDynamax` is a boolean indicating if the dynamax checkbox should be enabled. `maxMoves` is an array of objects setup in the same way as Z-Moves. `maxMoves` will be defined if `canDynamax` is or if the pokemon is already dynamaxed. Be sure to show the max moves when the checkbox is clicked/by default when `maxMoves` is defined but `canDynamax` isn't.

Start and end minor messages currently are `-dynamax|POKEMON` and `-undynamax|POKEMON`, feel free to have those changed its an easy swap, and we may need additional info anyways for things like gigantimax.