### PR TITLE
Add "Past Gens Only" to gen 8 /dt

### DIFF
--- a/server/chat-commands/info.js
+++ b/server/chat-commands/info.js
@@ -636,6 +636,7 @@ const commands = {
 						"Gen": move.gen || 'CAP',
 					};
 
+					if (move.isNonstandard === "Past" && dex.gen >= 8) details["&#10007; Past Gens Only"] = "";
 					if (move.secondary || move.secondaries) details["&#10003; Secondary effect"] = "";
 					if (move.flags['contact']) details["&#10003; Contact"] = "";
 					if (move.flags['sound']) details["&#10003; Sound"] = "";


### PR DESCRIPTION
Now says "Past Gens Only" if and only if the move is gone from swsh and the gen number is 8 or greater.