### PR TITLE
Add Gen 8 Doubles OU Beta

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -648,6 +648,17 @@ let Formats = [
 		banlist: ['Uber', 'Baton Pass'],
 	},
 	{
+		name: "[Gen 8] Doubles OU (beta)",
+		threads: [
+			`&bullet; <a href="https://www.smogon.com/forums/threads/np-swsh-dou-stage-0-begin-again.3656244/">Doubles OU Metagame Discussion</a>`,
+		],
+
+		mod: 'gen8',
+		gameType: 'doubles',
+		ruleset: ['Obtainable', 'Standard Doubles', 'Team Preview'],
+		banlist: ['DUber', 'Gravity ++ Grass Whistle', 'Gravity ++ Hypnosis', 'Gravity ++ Lovely Kiss', 'Gravity ++ Sing', 'Gravity ++ Sleep Powder'],
+	},
+	{
 		name: "[Gen 8] Custom Game",
 
 		mod: 'gen8',

--- a/config/formats.js
+++ b/config/formats.js
@@ -656,7 +656,7 @@ let Formats = [
 		mod: 'gen8',
 		gameType: 'doubles',
 		ruleset: ['Obtainable', 'Standard Doubles', 'Team Preview'],
-		banlist: ['DUber', 'Gravity ++ Grass Whistle', 'Gravity ++ Hypnosis', 'Gravity ++ Lovely Kiss', 'Gravity ++ Sing', 'Gravity ++ Sleep Powder'],
+		banlist: ['DUber', 'Gravity ++ Hypnosis', 'Gravity ++ Lovely Kiss', 'Gravity ++ Sing', 'Gravity ++ Sleep Powder'],
 	},
 	{
 		name: "[Gen 8] Custom Game",


### PR DESCRIPTION
Bans for Gen 8 Doubles OU, approved from tier leader MajorBowman:

- Zacian
- Zamazenta
- Eternatus
- Gravnosis clause