### PR TITLE
Fix data loading for 'generate-team'

### DIFF
--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -222,7 +222,7 @@ export class ModdedDex {
 	forFormat(format: Format | string): ModdedDex {
 		if (!this.modsLoaded) this.includeMods();
 		const mod = this.getFormat(format).mod;
-		return dexes[mod || 'gen7'].includeData();
+		return dexes[mod || 'gen8'].includeData();
 	}
 
 	modData(dataType: DataType, id: string) {


### PR DESCRIPTION
Since the data files are only loaded in the getter for Dex.data, which RandomTeam does not actually access, Dex.gen was 0, which led to an empty pokemon pool for random team generation.
This way, Dex.forFormat loads the data required for that format on its own.