### PR TITLE
Fix useSourceDefensive

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2017,9 +2017,9 @@ export class Battle {
 		}
 
 		if (move.useSourceDefensive) {
-			defense = attacker.calculateStat(defenseStat, defBoosts);
+			attack = attacker.calculateStat(defenseStat, defBoosts);
 		} else {
-			defense = defender.calculateStat(defenseStat, defBoosts);
+			attack = attacker.calculateStat(attackStat, atkBoosts);
 		}
 
 		// Apply Stat Modifiers


### PR DESCRIPTION
Explanation:

This move was supposed to use the User’s Defense stat in place of the Attack Stat, but instead replaces the Target’s Defense stat with the user’s, having the opposite effect.

The original code just gives it the exact opposite effect of `useTargetOffensive`:

useTargetOffensive replaces the user’s attack with the target’s
useSourceDefensive replaces the target’s defense with the user’s.

I changed it so the target replaces it’s own attack with it’s own defense (and otherwise has a normal effect when it’s `false`).