### PR TITLE
Require a break on either side of evaded words

### DIFF
--- a/server/chat-plugins/chat-monitor.js
+++ b/server/chat-plugins/chat-monitor.js
@@ -137,16 +137,18 @@ Chat.registerMonitor('evasion', {
 	punishment: 'EVASION',
 	label: 'Filter Evasion Detection',
 	monitor(line, room, user, message, lcMessage, isStaff) {
+		let [regex, word, reason] = line;
+
 		// Many codepoints used in filter evasion detection can be decomposed
 		// into multiple codepoints that are canonically equivalent to the
 		// original. Perform a canonical composition on the message to detect
 		// when people attempt to evade by abusing this behaviour of Unicode.
-		lcMessage = lcMessage.normalize('NFKC');
+		let normalizedMessage = lcMessage.normalize('NFKC');
 
-		let [regex, word, reason] = line;
-		// Normalise spaces and other common evasion characters to a period
-		lcMessage = lcMessage.replace(/[\s-_,.]+/g, '.');
-		const match = lcMessage.match(regex);
+		// Normalize spaces and other common evasion characters to a period
+		normalizedMessage = normalizedMessage.replace(/[\s-_,.]+/g, '.');
+
+		const match = normalizedMessage.match(regex);
 		if (match) {
 			// Don't lock someone iff the word itself is used, and whitespace wasn't used to evade the filter,
 			// in which case message (which doesn't have whitespace stripped) should also match the regex.

--- a/server/chat-plugins/chat-monitor.js
+++ b/server/chat-plugins/chat-monitor.js
@@ -51,16 +51,9 @@ let filterWords = Chat.filterWords;
  * @param {string} str
  */
 function constructEvasionRegex(str) {
-	let buf = '';
-	// substitutions
-	for (let i = 0; i < str.length; i++) {
-		buf += EVASION_DETECTION_SUB_STRINGS[str[i]] || str[i];
-		// Check any number of repeating letters
-		// The first and last letters aren't repeated, as there's too many
-		// false positives with the end / start of the previous / next word
-		if (i !== 0 && i !== str.length - 1) buf += '+';
-	}
-
+	const buf = "\\b" +
+		str.split('').map(letter => (EVASION_DETECTION_SUB_STRINGS[letter] || letter) + '+').join('\\.?') +
+		"\\b";
 	return new RegExp(buf, 'i');
 }
 
@@ -151,8 +144,8 @@ Chat.registerMonitor('evasion', {
 		lcMessage = lcMessage.normalize('NFKC');
 
 		let [regex, word, reason] = line;
-		// Remove spaces and obvious false positives
-		lcMessage = lcMessage.replace(/[\s-_,.]/g, '');
+		// Normalise spaces and other common evasion characters to a period
+		lcMessage = lcMessage.replace(/[\s-_,.]+/g, '.');
 		const match = lcMessage.match(regex);
 		if (match) {
 			// Don't lock someone iff the word itself is used, and whitespace wasn't used to evade the filter,


### PR DESCRIPTION
This doesn't exactly feel like a /good/ way to do this to me, but I can't think of any better way.