### PR TITLE
Limit MNM warnings to CAP stones

### DIFF
--- a/server/chat-plugins/othermetas.js
+++ b/server/chat-plugins/othermetas.js
@@ -108,7 +108,7 @@ const commands = {
 		if (template.isNonstandard) {
 			this.errorReply(`Warning: ${template.name} is not a real Pokemon and is therefore not usable in Mix and Mega.`);
 		}
-		if (stone.isNonstandard) {
+		if (stone.isNonstandard === "CAP") {
 			this.errorReply(`Warning: ${stone.name} is a fake mega stone created by the CAP Project and is restricted to the CAP ${stone.megaEvolves}.`);
 		}
 		let baseTemplate = Dex.getTemplate(stone.megaEvolves);


### PR DESCRIPTION
Right now the /mnm command results in warnings that the mega stone is a CAP stone, even when it is not. This is because isNonstandard is now set to "Past" instead of undefined.