### PR TITLE
Updated dark pranster immunity message for gen 8.

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -409,7 +409,7 @@ let BattleScripts = {
 				hitResults[i] = false;
 			} else if (this.gen >= 7 && move.pranksterBoosted && pokemon.hasAbility('prankster') && targets[i].side !== pokemon.side && !this.dex.getImmunity('prankster', target)) {
 				this.debug('natural prankster immunity');
-				if (!target.illusion) this.hint("In gen 7, Dark is immune to Prankster moves.");
+				if (!target.illusion) this.hint("Since gen 7, Dark is immune to Prankster moves.");
 				this.add('-immune', target);
 				hitResults[i] = false;
 			} else {


### PR DESCRIPTION
"A minor text error in the battle log: when a pokemon with Prankster tries to status a Dark-type, it fails and says "In gen 7, Dark is immune to Prankster moves." Since gen 8 is now out, the sentence should probably implicate gen 8 in its semantics (i.e., "Since gen 7")."

https://www.smogon.com/forums/threads/bug-reports-v3-read-original-post-before-posting.3634749/post-8289288