### PR TITLE
Remove erroneous autolink escape formatting

### DIFF
--- a/server/chat-plugins/chat-monitor.js
+++ b/server/chat-plugins/chat-monitor.js
@@ -159,7 +159,6 @@ Chat.registerMonitor('evasion', {
 			}
 			if (isStaff) return `${message} __[would be locked for filter evading: ${match[0]} (${word})]__`;
 			message = message.replace(/(https?):\/\//g, '$1__:__//');
-			message = message.replace(/\./g, '__.__');
 			if (room) {
 				Punishments.autolock(user, room, 'FilterEvasionMonitor', `Evading filter: ${message} (${match[0]} => ${word})`, `<${room.roomid}> ${user.name}: \`\`${message}\`\` __(${match[0]} => ${word})__`);
 			} else {


### PR DESCRIPTION
The "."->"__.__" is copy-pasted from elsewhere, but here, the match is put in code formatting, so there's no need for it and it adds more clutter.