### PR TITLE
Change moveset validation to ignore nature restrictions in gen 8

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1367,7 +1367,7 @@ export class TeamValidator {
 				problems.push(`${name}'s gender must be ${eventData.gender}${etc}.`);
 			}
 		}
-		const canMint = dex.gen > 7
+		let canMint = dex.gen > 7;
 		if (eventData.nature && eventData.nature !== set.nature && !canMint) {
 			if (fastReturn) return true;
 			problems.push(`${name} must have a ${eventData.nature} nature${etc} - Mints are only available starting gen 8.`);

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1367,9 +1367,10 @@ export class TeamValidator {
 				problems.push(`${name}'s gender must be ${eventData.gender}${etc}.`);
 			}
 		}
-		if (eventData.nature && eventData.nature !== set.nature) {
+		const canMint = dex.gen > 7
+		if (eventData.nature && eventData.nature !== set.nature && !canMint) {
 			if (fastReturn) return true;
-			problems.push(`${name} must have a ${eventData.nature} nature${etc}.`);
+			problems.push(`${name} must have a ${eventData.nature} nature${etc} - Mints are only available starting gen 8.`);
 		}
 		let requiredIVs = 0;
 		if (eventData.ivs) {


### PR DESCRIPTION
Removed nature lock from certain events in gen 8 formats as mints allow for editing natures.