### PR TITLE
Fix lockedmove volatile interaction with Max moves

### DIFF
--- a/data/statuses.js
+++ b/data/statuses.js
@@ -291,6 +291,7 @@ let BattleStatuses = {
 			target.addVolatile('confusion');
 		},
 		onLockMove(pokemon) {
+			if (pokemon.volatiles['dynamax']) return;
 			return this.effectData.move;
 		},
 	},


### PR DESCRIPTION
Currently, moves that cause fatigue such as Thrash and Outrage will cause the battle to pause after the first turn of dynamaxing. in [this battle](https://replay.pokemonshowdown.com/gen8doublesou-1014430299), n10sit uses Max Wyrmwind based off of Outrage to attack, and it works fine the first turn. However, the battle falsely emits an Invalid choice on the following turn.