### PR TITLE
Fix Clangorous Soul not showing up in /ms

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -2561,7 +2561,13 @@ let BattleMovedex = {
 				return false;
 			}
 			this.directDamage(target.maxhp / 3);
-			this.boost({atk: 1, def: 1, spa: 1, spd: 1, spe: 1}, target);
+		},
+		boosts: {
+			atk: 1,
+			def: 1,
+			spa: 1,
+			spd: 1,
+			spe: 1,
 		},
 		secondary: null,
 		target: "self",


### PR DESCRIPTION
Fixes `/ms boosts atk, boosts def, boosts spa, boosts spd, boosts spe` not showing Clangorous Soul.