### PR TITLE
Make Max moves deal 25% through Obstruct

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -13013,7 +13013,10 @@ let BattleMovedex = {
 			},
 			onTryHitPriority: 3,
 			onTryHit(target, source, move) {
-				if (!move.flags['protect']) return;
+				if (!move.flags['protect']) {
+					if (move.isZ || move.isMax) target.getMoveHitData(move).zBrokeProtect = true;
+					return;
+				}
 				this.add('-activate', target, 'move: Protect');
 				let lockedmove = source.getVolatile('lockedmove');
 				if (lockedmove) {


### PR DESCRIPTION
Couldn't find any sources on the matter, but Obstruct should behave like the other protection moves. Can someone verify?

EDIT: Current behaviour: Obstruct is broken, regular damage is dealt without being quartered.