### PR TITLE
Shorten Ice Scales shortDesc

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1597,7 +1597,7 @@ let BattleAbilities = {
 		num: 248,
 	},
 	"icescales": {
-		shortDesc: "This Pokémon's Sp. Defense is doubled.",
+		shortDesc: "This Pokémon's Special Defense is doubled.",
 		// TODO verify this is the correct way to implement this
 		onModifySpD(spd) {
 			return this.chainModify(2);

--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1597,7 +1597,7 @@ let BattleAbilities = {
 		num: 248,
 	},
 	"icescales": {
-		shortDesc: "The Pokémon is protected by ice scales, which halve the damage taken from special moves.",
+		shortDesc: "This Pokémon's Sp. Defense is doubled.",
 		// TODO verify this is the correct way to implement this
 		onModifySpD(spd) {
 			return this.chainModify(2);


### PR DESCRIPTION
Overflowing at the moment. 

Also, what's the policy on descriptive abilities?
(stuff like ``This Pokemon is protected by ice scales, which`` which provide a description and can be removed without leaving the effects out of context)