### PR TITLE
Do not give Clangorous Soul boost below 33%

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -2556,18 +2556,12 @@ let BattleMovedex = {
 		pp: 5,
 		priority: 0,
 		flags: {snatch: 1, sound: 1, dance: 1},
-		onHit(target) {
+		onHit(target, source, move) {
 			if (target.hp <= target.maxhp / 3 || target.boosts.atk >= 6 || target.boosts.def >= 6 || target.boosts.spa >= 6 || target.boosts.spd >= 6 || target.boosts.spe >= 6 || target.maxhp === 1) { // Shedinja clause
 				return false;
 			}
+			this.boost({atk: 1, def: 1, spa: 1, spd: 1, spe: 1}, target, target, move);
 			this.directDamage(target.maxhp / 3);
-		},
-		boosts: {
-			atk: 1,
-			def: 1,
-			spa: 1,
-			spd: 1,
-			spe: 1,
 		},
 		secondary: null,
 		target: "self",


### PR DESCRIPTION
Clangorous Soul is supposed to fail when used below 1/3 max HP but doesn't. Sorry - I'm not sure this fixes it; I'm unable to test.

https://replay.pokemonshowdown.com/gen8customgame-1016802018