### PR TITLE
Dynamic speed updates for Gen 8

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -284,6 +284,7 @@ let BattleMovedex = {
 			let action = this.willMove(target);
 			if (action) {
 				this.cancelMove(target);
+				action.priority = 7.1;
 				this.queue.unshift(action);
 				this.add('-activate', target, 'move: After You');
 			} else {

--- a/data/moves.js
+++ b/data/moves.js
@@ -283,9 +283,7 @@ let BattleMovedex = {
 			if (target.side.active.length < 2) return false; // fails in singles
 			let action = this.willMove(target);
 			if (action) {
-				this.cancelMove(target);
-				action.priority = 7.1;
-				this.queue.unshift(action);
+				this.prioritizeAction(action);
 				this.add('-activate', target, 'move: After You');
 			} else {
 				return false;

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2502,7 +2502,7 @@ export class Battle {
 			}
 		}
 		action.sourceEffect = sourceEffect;
-		action.priority = 7.1;
+		action.priority = 10;
 		this.queue.unshift(action);
 	}
 
@@ -2738,7 +2738,7 @@ export class Battle {
 			// in gen 3 or earlier, switching in fainted pokemon is done after
 			// every move, rather than only at the end of the turn.
 			this.checkFainted();
-		} else if (['megaEvo', 'runDynamax'].includes(action.choice) && this.gen >= 7) {
+		} else if (action.choice === 'megaEvo' && this.gen === 7) {
 			this.eachEvent('Update');
 			// In Gen 7, the action order is recalculated for a Pokémon that mega evolves.
 			const moveIndex = this.queue.findIndex(queuedAction =>
@@ -2778,6 +2778,10 @@ export class Battle {
 		}
 
 		this.eachEvent('Update');
+		if (this.gen >= 8 && this.queue.length && this.queue[0].choice === 'move') {
+			this.updateSpeed();
+			this.sortQueue();
+		}
 
 		return false;
 	}
@@ -2797,12 +2801,6 @@ export class Battle {
 			this.queue.shift();
 			this.runAction(action);
 			if (this.requestState || this.ended) return;
-
-			if (this.gen >= 8 && this.turn > 0) {
-				// Dynamically updated speed mid-turn except during team selection.
-				this.updateSpeed();
-				this.sortQueue();
-			}
 		}
 
 		this.nextTurn();

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -308,13 +308,6 @@ export class Battle {
 		for (const pokemon of this.getAllActive()) {
 			pokemon.updateSpeed();
 		}
-
-		if (this.gen < 8) return;
-
-		// In gen 8, speed is updated dynamically so update the queue's speed properties.
-		for (const action of this.queue) {
-			if (action.pokemon) action.speed = action.pokemon.speed;
-		}
 	}
 
 	comparePriority(a: AnyObject, b: AnyObject) {
@@ -2779,7 +2772,11 @@ export class Battle {
 
 		this.eachEvent('Update');
 		if (this.gen >= 8 && this.queue.length && this.queue[0].choice === 'move') {
+			// In gen 8, speed is updated dynamically so update the queue's speed properties and sort it.
 			this.updateSpeed();
+			for (const queueAction of this.queue) {
+				if (queueAction.pokemon) queueAction.speed = queueAction.pokemon.speed;
+			}
 			this.sortQueue();
 		}
 

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -308,6 +308,13 @@ export class Battle {
 		for (const pokemon of this.getAllActive()) {
 			pokemon.updateSpeed();
 		}
+
+		if (this.gen < 8) return;
+
+		// In gen 8, speed is updated dynamically so update the queue's speed properties.
+		for (const action of this.queue) {
+			if (action.pokemon) action.speed = action.pokemon.speed;
+		}
 	}
 
 	comparePriority(a: AnyObject, b: AnyObject) {
@@ -2374,7 +2381,6 @@ export class Battle {
 					});
 				}
 				if (action.maxMove && !action.pokemon.volatiles['dynamax']) {
-					this.debug(`Adding runDynamax to queue`);
 					this.addToQueue({
 						choice: 'runDynamax',
 						pokemon: action.pokemon,
@@ -2496,6 +2502,7 @@ export class Battle {
 			}
 		}
 		action.sourceEffect = sourceEffect;
+		action.priority = 7.1;
 		this.queue.unshift(action);
 	}
 
@@ -2790,6 +2797,12 @@ export class Battle {
 			this.queue.shift();
 			this.runAction(action);
 			if (this.requestState || this.ended) return;
+
+			if (this.gen >= 8 && this.turn > 0) {
+				// Dynamically updated speed mid-turn except during team selection.
+				this.updateSpeed();
+				this.sortQueue();
+			}
 		}
 
 		this.nextTurn();

--- a/test/sim/misc/target-resolution.js
+++ b/test/sim/misc/target-resolution.js
@@ -13,7 +13,7 @@ describe('Target Resolution', function () {
 	describe(`Targetted Pokémon fainted in-turn`, function () {
 		it(`should redirect 'any' from a fainted foe to a targettable foe`, function () {
 			battle = common.createBattle({gameType: 'doubles'}, [[
-				{species: 'Wailord', item: 'laggingtail', ability: 'pressure', moves: ['waterpulse']},
+				{species: 'Wailord', item: 'laggingtail', ability: 'pressure', moves: ['watergun']},
 				{species: 'Metapod', ability: 'shedskin', moves: ['harden']},
 			], [
 				{species: 'Chansey', ability: 'naturalcure', moves: ['curse']},
@@ -21,12 +21,12 @@ describe('Target Resolution', function () {
 				{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
 			]]);
 			const defender = battle.p2.active[0];
-			assert.hurts(defender, () => battle.makeChoices('move waterpulse 2, auto', 'auto'));
+			assert.hurts(defender, () => battle.makeChoices('move watergun 2, auto', 'auto'));
 		});
 
 		it(`should not redirect 'any' from a fainted ally to another Pokémon by default`, function () {
 			battle = common.createBattle({gameType: 'doubles'}, [[
-				{species: 'Wailord', item: 'laggingtail', ability: 'pressure', moves: ['waterpulse']},
+				{species: 'Wailord', item: 'laggingtail', ability: 'pressure', moves: ['watergun']},
 				{species: 'Latias', ability: 'levitate', moves: ['healingwish']},
 				{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
 			], [
@@ -35,17 +35,17 @@ describe('Target Resolution', function () {
 			]]);
 			const activePokemonList = [battle.p1.active[0], ...battle.p2.active];
 			const prevHps = activePokemonList.map(pokemon => pokemon.hp);
-			battle.makeChoices('move waterpulse -2, auto', 'auto');
+			battle.makeChoices('move watergun -2, auto', 'auto');
 			const newHps = activePokemonList.map(pokemon => pokemon.hp);
 
 			assert.deepStrictEqual(prevHps, newHps);
-			assert(battle.log.includes('|move|p1a: Wailord|Water Pulse|p1: Latias|[notarget]'));
+			assert(battle.log.includes('|move|p1a: Wailord|Water Gun|p1: Latias|[notarget]'));
 			assert(battle.log.includes('|-fail|p1a: Wailord'));
 		});
 
 		it(`should support RedirectTarget event for a fainted foe and type 'any' `, function () {
 			battle = common.createBattle({gameType: 'triples'}, [[
-				{species: 'Wailord', item: 'laggingtail', ability: 'pressure', moves: ['waterpulse']},
+				{species: 'Wailord', item: 'laggingtail', ability: 'pressure', moves: ['waterpulse']}, // Water Pulse over Water Gun due to targeting in triples
 				{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
 				{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
 			], [
@@ -61,7 +61,7 @@ describe('Target Resolution', function () {
 			// Do it again with swapped positions
 			battle.destroy();
 			battle = common.createBattle({gameType: 'triples'}, [[
-				{species: 'Wailord', item: 'laggingtail', ability: 'pressure', moves: ['waterpulse']},
+				{species: 'Wailord', item: 'laggingtail', ability: 'pressure', moves: ['watergun']},
 				{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
 				{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
 			], [
@@ -71,13 +71,13 @@ describe('Target Resolution', function () {
 				{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
 			]]);
 			redirector = battle.p2.active[2];
-			battle.makeChoices('move waterpulse 2, auto', 'auto');
+			battle.makeChoices('move watergun 2, auto', 'auto');
 			assert.statStage(redirector, 'spa', 1);
 		});
 
 		it(`should support RedirectTarget event for a fainted ally and type 'any'`, function () {
 			battle = common.createBattle({gameType: 'doubles'}, [[
-				{species: 'Wailord', item: 'laggingtail', ability: 'pressure', moves: ['waterpulse']},
+				{species: 'Wailord', item: 'laggingtail', ability: 'pressure', moves: ['watergun']},
 				{species: 'Latias', ability: 'levitate', moves: ['healingwish']},
 				{species: 'Magikarp', ability: 'rattled', moves: ['splash']},
 			], [
@@ -85,7 +85,7 @@ describe('Target Resolution', function () {
 				{species: 'Metapod', ability: 'shedskin', moves: ['harden']},
 			]]);
 			const redirector = battle.p2.active[0];
-			battle.makeChoices('move waterpulse -2, auto', 'auto');
+			battle.makeChoices('move watergun -2, auto', 'auto');
 			assert.statStage(redirector, 'spa', 1);
 		});
 	});
@@ -93,10 +93,10 @@ describe('Target Resolution', function () {
 	describe(`Targetted slot is empty`, function () {
 		it(`should redirect 'any' from a fainted foe to a targettable foe`, function () {
 			battle = common.createBattle({gameType: 'doubles'}, [[
-				{species: 'Wailord', ability: 'owntempo', moves: ['waterpulse']},
+				{species: 'Wailord', ability: 'pressure', moves: ['watergun']},
 				{species: 'Shedinja', item: 'flameorb', ability: 'wonderguard', moves: ['agility']},
 			], [
-				{species: 'Wailord', ability: 'owntempo', moves: ['waterpulse']},
+				{species: 'Wailord', ability: 'pressure', moves: ['watergun']},
 				{species: 'Shedinja', item: 'flameorb', ability: 'wonderguard', moves: ['agility']},
 			]]);
 			const attackers = battle.sides.map(side => side.active[0]);
@@ -105,7 +105,7 @@ describe('Target Resolution', function () {
 			battle.makeChoices('auto', 'auto'); // Shedinjas faint
 
 			const prevHps = attackers.map(pokemon => pokemon.hp);
-			battle.makeChoices('move waterpulse 2, pass', 'move waterpulse 2, pass');
+			battle.makeChoices('move watergun 2, pass', 'move watergun 2, pass');
 			const newHps = attackers.map(pokemon => pokemon.hp);
 
 			assert(
@@ -144,7 +144,7 @@ describe('Target Resolution', function () {
 
 		it(`should support RedirectTarget event for a fainted foe and type 'any'`, function () {
 			battle = common.createBattle({gameType: 'doubles'}, [[
-				{species: 'Aurorus', ability: 'snowwarning', moves: ['waterpulse']},
+				{species: 'Aurorus', ability: 'snowwarning', moves: ['watergun']},
 				{species: 'Shedinja', ability: 'wonderguard', moves: ['agility']},
 			], [
 				{species: 'Gastrodon', ability: 'stormdrain', moves: ['curse']},
@@ -153,13 +153,13 @@ describe('Target Resolution', function () {
 			const redirector = battle.p2.active[0];
 
 			battle.makeChoices('auto', 'auto'); // Shedinjas faint
-			battle.makeChoices('move waterpulse 2, pass', 'auto');
+			battle.makeChoices('move watergun 2, pass', 'auto');
 			assert.statStage(redirector, 'spa', 2);
 		});
 
 		it(`should support RedirectTarget event for a fainted ally and type 'any'`, function () {
 			battle = common.createBattle({gameType: 'doubles'}, [[
-				{species: 'Aurorus', ability: 'snowwarning', moves: ['waterpulse']},
+				{species: 'Aurorus', ability: 'snowwarning', moves: ['watergun']},
 				{species: 'Shedinja', ability: 'wonderguard', moves: ['agility']},
 			], [
 				{species: 'Gastrodon', ability: 'stormdrain', moves: ['curse']},
@@ -168,7 +168,7 @@ describe('Target Resolution', function () {
 			const redirector = battle.p2.active[0];
 
 			battle.makeChoices('auto', 'auto'); // Shedinjas faint
-			battle.makeChoices('move waterpulse -2, pass', 'auto');
+			battle.makeChoices('move watergun -2, pass', 'auto');
 			assert.statStage(redirector, 'spa', 2);
 		});
 	});

--- a/test/sim/misc/target-resolution.js
+++ b/test/sim/misc/target-resolution.js
@@ -116,10 +116,10 @@ describe('Target Resolution', function () {
 
 		it(`should not redirect 'any' from a fainted ally to another Pokémon by default`, function () {
 			battle = common.createBattle({gameType: 'doubles'}, [[
-				{species: 'Wailord', ability: 'pressure', moves: ['waterpulse']},
+				{species: 'Wailord', ability: 'pressure', moves: ['watergun']},
 				{species: 'Shedinja', item: 'flameorb', ability: 'wonderguard', moves: ['agility']},
 			], [
-				{species: 'Wailord', ability: 'pressure', moves: ['waterpulse']},
+				{species: 'Wailord', ability: 'pressure', moves: ['watergun']},
 				{species: 'Shedinja', item: 'flameorb', ability: 'wonderguard', moves: ['agility']},
 			]]);
 
@@ -132,13 +132,13 @@ describe('Target Resolution', function () {
 			assert.fainted(faintTargets[1]);
 
 			const prevHps = attackers.map(pokemon => pokemon.hp);
-			battle.makeChoices('move waterpulse -2, pass', 'move waterpulse -2, pass');
+			battle.makeChoices('move watergun -2, pass', 'move watergun -2, pass');
 			const newHps = attackers.map(pokemon => pokemon.hp);
 
 			assert.deepStrictEqual(prevHps, newHps);
-			assert(battle.log.includes('|move|p1a: Wailord|Water Pulse|p1: Shedinja|[notarget]'));
+			assert(battle.log.includes('|move|p1a: Wailord|Water Gun|p1: Shedinja|[notarget]'));
 			assert(battle.log.includes('|-fail|p1a: Wailord'));
-			assert(battle.log.includes('|move|p2a: Wailord|Water Pulse|p2: Shedinja|[notarget]'));
+			assert(battle.log.includes('|move|p2a: Wailord|Water Gun|p2: Shedinja|[notarget]'));
 			assert(battle.log.includes('|-fail|p2a: Wailord'));
 		});
 

--- a/test/sim/misc/turn-order.js
+++ b/test/sim/misc/turn-order.js
@@ -103,3 +103,53 @@ describe('Mega Evolution [Gen 6]', function () {
 		assert.fainted(fastMega);
 	});
 });
+
+describe('Pokemon Speed', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should update dynamically in Gen 8', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		const p1team = [
+			{species: 'Ludicolo', ability: 'swiftswim', moves: ['scald'], evs: {spe: 100}}, // 201 Speed
+			{species: 'Appletun', ability: 'ripen', moves: ['sleeptalk']}, // To be switched out
+			{species: 'Pelipper', ability: 'drizzle', moves: ['sleeptalk']}, // Will set rain on switch in
+		];
+		const p2team = [
+			{species: 'Accelgor', ability: 'hydration', moves: ['bugbuzz'], evs: {spe: 156}, nature: 'Timid'}, // 401 Speed
+			{species: 'Aegislash', ability: 'stancechange', moves: ['sleeptalk']}, // Does nothing but fill a slot
+		];
+		battle.setPlayer('p1', {team: p1team});
+		battle.setPlayer('p2', {team: p2team});
+
+		// Set ludicolo's and accelgor's HP to 1.
+		battle.p1.pokemon[0].sethp(1); // Ludicolo
+		battle.p2.pokemon[0].sethp(1); // Accelgor
+
+		battle.makeChoices('move scald 1, switch 3', 'move bugbuzz 1, auto');
+		assert.fainted(battle.p2.pokemon[0]); // Accelgor should be fainted
+	});
+
+	it('should NOT update dynamically in Gen 7', function () {
+		battle = common.gen(7).createBattle({gameType: 'doubles'});
+		const p1team = [
+			{species: 'Ludicolo', ability: 'swiftswim', moves: ['scald'], evs: {spe: 100}}, // 201 Speed
+			{species: 'Appletun', ability: 'ripen', moves: ['sleeptalk']}, // To be switched out
+			{species: 'Pelipper', ability: 'drizzle', moves: ['sleeptalk']}, // Will set rain on switch in
+		];
+		const p2team = [
+			{species: 'Accelgor', ability: 'hydration', moves: ['bugbuzz'], evs: {spe: 156}, nature: 'Timid'}, // 401 Speed
+			{species: 'Aegislash', ability: 'stancechange', moves: ['sleeptalk']}, // Does nothing but fill a slot
+		];
+		battle.setPlayer('p1', {team: p1team});
+		battle.setPlayer('p2', {team: p2team});
+
+		// Set ludicolo's and accelgor's HP to 1.
+		battle.p1.pokemon[0].sethp(1); // Ludicolo
+		battle.p2.pokemon[0].sethp(1); // Accelgor
+
+		battle.makeChoices('move scald 1, switch 3', 'move bugbuzz 1, auto');
+		assert.fainted(battle.p1.pokemon[0]); // Ludicolo should be fainted
+	});
+});


### PR DESCRIPTION
This makes generation 8 use dynamically updating speed. Specifically speeds are updated after each action in the queue completes. Changes up to this point tested with @DaWoblefet.

TODO:
- [x] Fix failed tests (fusion bolt/flare, redirection in doubles)
- [x] Add tests to ensure dynamic speed works in gen 8 and prior speed system is used in gen 7.
- [x] Figure out whats going on with this line is doing. https://github.com/smogon/pokemon-showdown/blob/master/sim/side.ts#L694 Specifically the priority being lower (<= 0) than start (102) causes problems if the queue is dynamically updated when `battle.turn === 0`. 