### PR TITLE
G-Max moves should run their effects against a substitute

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -6818,17 +6818,19 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Butterfree",
-		onHit(target, source) {
-			for (let pokemon of target.side.active) {
-				let result = this.random(3);
-				if (result === 0) {
-					pokemon.trySetStatus('slp', source);
-				} else if (result === 1) {
-					pokemon.trySetStatus('par', source);
-				} else {
-					pokemon.trySetStatus('psn', source);
+		self: {
+			onHit(source) {
+				for (let pokemon of source.side.foe.active) {
+					let result = this.random(3);
+					if (result === 0) {
+						pokemon.trySetStatus('slp', source);
+					} else if (result === 1) {
+						pokemon.trySetStatus('par', source);
+					} else {
+						pokemon.trySetStatus('psn', source);
+					}
 				}
-			}
+			},
 		},
 		target: "adjacentFoe",
 		type: "Bug",
@@ -6848,10 +6850,12 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Centiskorch",
-		onHit(target, source) {
-			for (let pokemon of target.side.active) {
-				pokemon.addVolatile('partiallytrapped');
-			}
+		self: {
+			onHit(source) {
+				for (let pokemon of source.side.foe.active) {
+					pokemon.addVolatile('partiallytrapped');
+				}
+			},
 		},
 		secondary: null,
 		target: "adjacentFoe",
@@ -6873,7 +6877,7 @@ let BattleMovedex = {
 		flags: {},
 		isMax: "Machamp",
 		self: {
-			onHit(target, source) {
+			onHit(source) {
 				for (let pokemon of source.side.active) {
 					pokemon.addVolatile('focusenergy');
 				}
@@ -6897,10 +6901,12 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Eevee",
-		onHit(target, source) {
-			for (let pokemon of target.side.active) {
-				pokemon.addVolatile('attract');
-			}
+		self: {
+			onHit(source) {
+				for (let pokemon of source.side.foe.active) {
+					pokemon.addVolatile('attract');
+				}
+			},
 		},
 		secondary: null,
 		target: "adjacentFoe",
@@ -6921,18 +6927,20 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Duraludon",
-		onAfterHit(target, source) {
-			for (let pokemon of target.side.active) {
-				const move = pokemon.lastMove;
-				if (move && !move.isZ && !move.isMax) {
-					let ppDeducted = pokemon.deductPP(move.id, 4);
-					if (ppDeducted) {
-						this.add("-activate", pokemon, 'move: Max Depletion', move.name, ppDeducted);
-						return;
+		self: {
+			onAfterHit(source) {
+				for (let pokemon of source.side.foe.active) {
+					const move = pokemon.lastMove;
+					if (move && !move.isZ && !move.isMax) {
+						let ppDeducted = pokemon.deductPP(move.id, 4);
+						if (ppDeducted) {
+							this.add("-activate", pokemon, 'move: Max Depletion', move.name, ppDeducted);
+							return;
+						}
 					}
+					return false;
 				}
-				return false;
-			}
+			},
 		},
 		secondary: null,
 		target: "adjacentFoe",
@@ -6953,7 +6961,7 @@ let BattleMovedex = {
 		flags: {},
 		isMax: "Alcremie",
 		self: {
-			onAfterHit(target, source) {
+			onAfterHit(source) {
 				for (let pokemon of source.side.active) {
 					this.heal(pokemon.maxhp / 6, pokemon, source);
 				}
@@ -6977,10 +6985,12 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Kingler",
-		onHit(target, source, move) {
-			for (let pokemon of target.side.active) {
-				this.boost({spe: -2}, pokemon, source, move);
-			}
+		self: {
+			onHit(source) {
+				for (let pokemon of source.side.foe.active) {
+					this.boost({spe: -2}, pokemon);
+				}
+			},
 		},
 		secondary: null,
 		target: "adjacentFoe",
@@ -7000,10 +7010,12 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Meowth",
-		onHit(target, source) {
-			for (let pokemon of target.side.active) {
-				pokemon.addVolatile('confusion');
-			}
+		self: {
+			onHit(source) {
+				for (let pokemon of source.side.foe.active) {
+					pokemon.addVolatile('confusion');
+				}
+			},
 		},
 		secondary: null,
 		target: "adjacentFoe",
@@ -7024,9 +7036,7 @@ let BattleMovedex = {
 		flags: {},
 		isMax: "Orbeetle",
 		self: {
-			onHit(target, source, move) {
-				this.field.addPseudoWeather('gravity');
-			},
+			pseudoWeather: 'gravity',
 		},
 		target: "adjacentFoe",
 		type: "Psychic",
@@ -7045,10 +7055,12 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Garbodor",
-		onHit(target, source) {
-			for (let pokemon of target.side.active) {
-				pokemon.trySetStatus('psn', source);
-			}
+		self: {
+			onHit(source) {
+				for (let pokemon of source.side.foe.active) {
+					pokemon.trySetStatus('psn', source);
+				}
+			},
 		},
 		target: "adjacentFoe",
 		type: "Poison",
@@ -7067,10 +7079,12 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Melmetal",
-		onHit(target, source) {
-			for (let pokemon of target.side.active) {
-				pokemon.addVolatile('torment');
-			}
+		self: {
+			onHit(source) {
+				for (let pokemon of source.side.foe.active) {
+					pokemon.addVolatile('torment');
+				}
+			},
 		},
 		secondary: null,
 		target: "adjacentFoe",
@@ -7091,8 +7105,8 @@ let BattleMovedex = {
 		flags: {},
 		isMax: "Snorlax",
 		self: {
-			onHit(target, source) {
-				for (let pokemon of target.side.active) {
+			onHit(source) {
+				for (let pokemon of source.side.active) {
 					if (!pokemon.item && pokemon.lastItem && this.dex.getItem(pokemon.lastItem).isBerry) {
 						let item = pokemon.lastItem;
 						pokemon.lastItem = '';
@@ -7121,9 +7135,7 @@ let BattleMovedex = {
 		flags: {},
 		isMax: "Lapras",
 		self: {
-			onHit(target, source, move) {
-				source.side.addSideCondition('auroraveil');
-			},
+			sideCondition: 'auroraveil',
 		},
 		secondary: null,
 		target: "adjacentFoe",
@@ -7143,10 +7155,14 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Sandaconda",
-		onHit(target, source) {
-			for (let pokemon of target.side.active) {
-				pokemon.addVolatile('partiallytrapped');
-			}
+		self: {
+			onHit(source) {
+				for (let pokemon of source.side.foe.active) {
+					if (!pokemon.volatiles['substitute']) {
+						pokemon.addVolatile('partiallytrapped', source, this.dex.getActiveMove('Sand Tomb'), 'trapper');
+					}
+				}
+			},
 		},
 		secondary: null,
 		target: "adjacentFoe",
@@ -7166,10 +7182,12 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Hatterene",
-		onHit(target, source, move) {
-			for (let pokemon of target.side.active) {
-				pokemon.addVolatile('confusion', source, move);
-			}
+		self: {
+			onHit(source) {
+				for (let pokemon of source.side.foe.active) {
+					pokemon.addVolatile('confusion', source);
+				}
+			},
 		},
 		secondary: null,
 		target: "adjacentFoe",
@@ -7189,12 +7207,14 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Grimmsnarl",
-		onHit(target, source) {
-			for (let pokemon of target.side.active) {
-				if (!target.status && target.runStatusImmunity('slp')) {
-					pokemon.addVolatile('yawn');
+		self: {
+			onHit(source) {
+				for (let pokemon of source.side.foe.active) {
+					if (!pokemon.status && pokemon.runStatusImmunity('slp')) {
+						pokemon.addVolatile('yawn');
+					}
 				}
-			}
+			},
 		},
 		secondary: null,
 		target: "adjacentFoe",
@@ -7214,8 +7234,10 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Copperajah",
-		onHit(target, source, move) {
-			target.side.addSideCondition('gmaxsteelsurge');
+		self: {
+			onHit(source) {
+				source.side.foe.addSideCondition('gmaxsteelsurge');
+			},
 		},
 		effect: {
 			onStart(side) {
@@ -7245,8 +7267,10 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Drednaw",
-		onHit(target, source, move) {
-			target.side.addSideCondition('stealthrock');
+		self: {
+			onHit(source) {
+				source.side.foe.addSideCondition('stealthrock');
+			},
 		},
 		secondary: null,
 		target: "adjacentFoe",
@@ -7266,15 +7290,17 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Toxtricity",
-		onHit(target, source) {
-			for (let pokemon of target.side.active) {
-				let result = this.random(2);
-				if (result === 0) {
-					pokemon.trySetStatus('par', source);
-				} else {
-					pokemon.trySetStatus('psn', source);
+		self: {
+			onHit(source) {
+				for (let pokemon of source.side.foe.active) {
+					let result = this.random(2);
+					if (result === 0) {
+						pokemon.trySetStatus('par', source);
+					} else {
+						pokemon.trySetStatus('psn', source);
+					}
 				}
-			}
+			},
 		},
 		secondary: null,
 		target: "adjacentFoe",
@@ -7294,18 +7320,18 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Appletun",
-		onHit(target, source, move) {
-			this.add('-activate', source, 'move: G-Max Sweetness');
-			let success = false;
-			for (const ally of source.side.pokemon) {
-				// TODO: test move's interaction with sap sipper and Substitute
-				if (ally !== source && ((ally.hasAbility('sapsipper')) ||
-						(ally.volatiles['substitute'] && !move.infiltrates))) {
-					continue;
+		self: {
+			onHit(source, pokemon, move) {
+				this.add('-activate', source, 'move: G-Max Sweetness');
+				for (const ally of source.side.pokemon) {
+					// TODO: test move's interaction with sap sipper and Substitute
+					if (ally !== source && ((ally.hasAbility('sapsipper')) ||
+							(ally.volatiles['substitute'] && !move.infiltrates))) {
+						continue;
+					}
+					ally.cureStatus();
 				}
-				if (ally.cureStatus()) success = true;
-			}
-			return success;
+			},
 		},
 		secondary: null,
 		target: "adjacentFoe",
@@ -7325,10 +7351,12 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Gengar",
-		onHit(target, source, move) {
-			for (const pokemon of target.side.active) {
-				pokemon.addVolatile('trapped', source, move, 'trapper');
-			}
+		self: {
+			onHit(source) {
+				for (const pokemon of source.side.foe.active) {
+					pokemon.addVolatile('trapped', source, null, 'trapper');
+				}
+			},
 		},
 		secondary: null,
 		target: "adjacentFoe",
@@ -7348,10 +7376,12 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Flapple",
-		onHit(target, source, move) {
-			for (const pokemon of target.side.active) {
-				this.boost({evasion: -1}, pokemon, source, move);
-			}
+		self: {
+			onHit(source) {
+				for (const pokemon of source.side.foe.active) {
+					this.boost({evasion: -1}, pokemon);
+				}
+			},
 		},
 		secondary: null,
 		target: "adjacentFoe",
@@ -7372,8 +7402,10 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Coalossal",
-		onHit(target, source, move) {
-			target.side.addSideCondition('gmaxvolcalith');
+		self: {
+			onHit(source) {
+				source.side.foe.addSideCondition('gmaxvolcalith');
+			},
 		},
 		effect: {
 			duration: 4,
@@ -7407,10 +7439,12 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Pikachu",
-		onHit(target, source, move) {
-			for (const pokemon of target.side.active) {
-				pokemon.trySetStatus('par', source, move);
-			}
+		self: {
+			onHit(source) {
+				for (const pokemon of source.side.foe.active) {
+					pokemon.trySetStatus('par', source);
+				}
+			},
 		},
 		secondary: null,
 		target: "adjacentFoe",
@@ -7431,8 +7465,10 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Charizard",
-		onHit(target, source, move) {
-			target.side.addSideCondition('gmaxwildfire');
+		self: {
+			onHit(source) {
+				source.side.foe.addSideCondition('gmaxwildfire');
+			},
 		},
 		effect: {
 			duration: 4,
@@ -7468,25 +7504,27 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: "Corviknight",
-		onHit(target, source, move) {
-			let success = false;
-			let removeTarget = ['reflect', 'lightscreen', 'auroraveil', 'safeguard', 'mist', 'spikes', 'toxicspikes', 'stealthrock', 'stickyweb'];
-			let removeAll = ['spikes', 'toxicspikes', 'stealthrock', 'stickyweb', 'gmaxsteelsurge'];
-			for (const targetCondition of removeTarget) {
-				if (target.side.removeSideCondition(targetCondition)) {
-					if (!removeAll.includes(targetCondition)) continue;
-					this.add('-sideend', target.side, this.dex.getEffect(targetCondition).name, '[from] move: Defog', '[of] ' + source);
-					success = true;
+		self: {
+			onHit(source) {
+				let success = false;
+				let removeTarget = ['reflect', 'lightscreen', 'auroraveil', 'safeguard', 'mist', 'spikes', 'toxicspikes', 'stealthrock', 'stickyweb'];
+				let removeAll = ['spikes', 'toxicspikes', 'stealthrock', 'stickyweb', 'gmaxsteelsurge'];
+				for (const targetCondition of removeTarget) {
+					if (source.side.foe.removeSideCondition(targetCondition)) {
+						if (!removeAll.includes(targetCondition)) continue;
+						this.add('-sideend', source.side.foe, this.dex.getEffect(targetCondition).name, '[from] move: G-Max Wind Rage', '[of] ' + source);
+						success = true;
+					}
 				}
-			}
-			for (const sideCondition of removeAll) {
-				if (source.side.removeSideCondition(sideCondition)) {
-					this.add('-sideend', source.side, this.dex.getEffect(sideCondition).name, '[from] move: Defog', '[of] ' + source);
-					success = true;
+				for (const sideCondition of removeAll) {
+					if (source.side.removeSideCondition(sideCondition)) {
+						this.add('-sideend', source.side, this.dex.getEffect(sideCondition).name, '[from] move: G-Max Wind Rage', '[of] ' + source);
+						success = true;
+					}
 				}
-			}
-			this.field.clearTerrain();
-			return success;
+				this.field.clearTerrain();
+				return success;
+			},
 		},
 		secondary: null,
 		target: "adjacentFoe",
@@ -11183,10 +11221,10 @@ let BattleMovedex = {
 		flags: {},
 		isMax: true,
 		self: {
-			onHit(target, source, move) {
+			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
 				for (let pokemon of source.side.active) {
-					this.boost({spe: 1}, pokemon, source, move);
+					this.boost({spe: 1}, pokemon);
 				}
 			},
 		},
@@ -11208,11 +11246,13 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: true,
-		onHit(target, source, move) {
-			if (!source.volatiles['dynamax']) return;
-			for (let pokemon of target.side.active) {
-				this.boost({spd: -1}, pokemon, source, move);
-			}
+		self: {
+			onHit(source) {
+				if (!source.volatiles['dynamax']) return;
+				for (let pokemon of source.side.foe.active) {
+					this.boost({spd: -1}, pokemon);
+				}
+			},
 		},
 		target: "adjacentFoe",
 		type: "Dark",
@@ -11233,7 +11273,7 @@ let BattleMovedex = {
 		flags: {},
 		isMax: true,
 		self: {
-			onHit(target, source, move) {
+			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
 				this.field.setWeather('sunnyday');
 			},
@@ -11256,11 +11296,13 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: true,
-		onHit(target, source, move) {
-			if (!source.volatiles['dynamax']) return;
-			for (let pokemon of target.side.active) {
-				this.boost({spa: -1}, pokemon, source, move);
-			}
+		self: {
+			onHit(source) {
+				if (!source.volatiles['dynamax']) return;
+				for (let pokemon of source.side.foe.active) {
+					this.boost({spa: -1}, pokemon);
+				}
+			},
 		},
 		target: "adjacentFoe",
 		type: "Bug",
@@ -11281,7 +11323,7 @@ let BattleMovedex = {
 		flags: {},
 		isMax: true,
 		self: {
-			onHit(target, source, move) {
+			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
 				this.field.setWeather('raindance');
 			},
@@ -11350,7 +11392,7 @@ let BattleMovedex = {
 		flags: {},
 		isMax: true,
 		self: {
-			onHit(target, source, move) {
+			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
 				this.field.setWeather('hail');
 			},
@@ -11374,10 +11416,10 @@ let BattleMovedex = {
 		flags: {},
 		isMax: true,
 		self: {
-			onHit(target, source, move) {
+			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
 				for (let pokemon of source.side.active) {
-					this.boost({atk: 1}, pokemon, source, move);
+					this.boost({atk: 1}, pokemon);
 				}
 			},
 		},
@@ -11400,7 +11442,7 @@ let BattleMovedex = {
 		flags: {},
 		isMax: true,
 		self: {
-			onHit(target, source, move) {
+			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
 				this.field.setTerrain('electricterrain');
 			},
@@ -11424,7 +11466,7 @@ let BattleMovedex = {
 		flags: {},
 		isMax: true,
 		self: {
-			onHit(target, source, move) {
+			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
 				this.field.setTerrain('psychicterrain');
 			},
@@ -11448,10 +11490,10 @@ let BattleMovedex = {
 		flags: {},
 		isMax: true,
 		self: {
-			onHit(target, source, move) {
+			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
 				for (let pokemon of source.side.active) {
-					this.boost({spa: 1}, pokemon, source, move);
+					this.boost({spa: 1}, pokemon);
 				}
 			},
 		},
@@ -11474,7 +11516,7 @@ let BattleMovedex = {
 		flags: {},
 		isMax: true,
 		self: {
-			onHit(target, source, move) {
+			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
 				this.field.setTerrain('grassyterrain');
 			},
@@ -11497,11 +11539,13 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: true,
-		onHit(target, source, move) {
-			if (!source.volatiles['dynamax']) return;
-			for (let pokemon of target.side.active) {
-				this.boost({def: -1}, pokemon, source, move);
-			}
+		self: {
+			onHit(source) {
+				if (!source.volatiles['dynamax']) return;
+				for (let pokemon of source.side.foe.active) {
+					this.boost({def: -1}, pokemon);
+				}
+			},
 		},
 		target: "adjacentFoe",
 		type: "Ghost",
@@ -11522,10 +11566,10 @@ let BattleMovedex = {
 		flags: {},
 		isMax: true,
 		self: {
-			onHit(target, source, move) {
+			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
 				for (let pokemon of source.side.active) {
-					this.boost({spd: 1}, pokemon, source, move);
+					this.boost({spd: 1}, pokemon);
 				}
 			},
 		},
@@ -11548,7 +11592,7 @@ let BattleMovedex = {
 		flags: {},
 		isMax: true,
 		self: {
-			onHit(target, source, move) {
+			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
 				this.field.setWeather('sandstorm');
 			},
@@ -11572,7 +11616,7 @@ let BattleMovedex = {
 		flags: {},
 		isMax: true,
 		self: {
-			onHit(target, source, move) {
+			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
 				this.field.setTerrain('mistyterrain');
 			},
@@ -11596,10 +11640,10 @@ let BattleMovedex = {
 		flags: {},
 		isMax: true,
 		self: {
-			onHit(target, source, move) {
+			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
 				for (let pokemon of source.side.active) {
-					this.boost({def: 1}, pokemon, source, move);
+					this.boost({def: 1}, pokemon);
 				}
 			},
 		},
@@ -11621,11 +11665,13 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: true,
-		onHit(target, source, move) {
-			if (!source.volatiles['dynamax']) return;
-			for (let pokemon of target.side.active) {
-				this.boost({spe: -1}, pokemon, source, move);
-			}
+		self: {
+			onHit(source) {
+				if (!source.volatiles['dynamax']) return;
+				for (let pokemon of source.side.foe.active) {
+					this.boost({spe: -1}, pokemon);
+				}
+			},
 		},
 		target: "adjacentFoe",
 		type: "Normal",
@@ -11645,11 +11691,13 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {},
 		isMax: true,
-		onHit(target, source, move) {
-			if (!source.volatiles['dynamax']) return;
-			for (let pokemon of target.side.active) {
-				this.boost({atk: -1}, pokemon, source, move);
-			}
+		self: {
+			onHit(source) {
+				if (!source.volatiles['dynamax']) return;
+				for (let pokemon of source.side.foe.active) {
+					this.boost({atk: -1}, pokemon);
+				}
+			},
 		},
 		target: "adjacentFoe",
 		type: "Dragon",


### PR DESCRIPTION
Reported here: https://www.smogon.com/forums/posts/8297191 and other places.

All (G-)Max effects need to run as `self` so that they're unaffected by the target's Substitute.

Since self effects don't identify the target, this means that anything that effects the foes has to explicitly use `source.side.foe`. To make this clearer, I've updated all of the effects for all (G-)Max moves to only use a single `source` parameter, as I'm concerned that someone might subsequently try to use `target` by mistake.

Sandaconda's G-Max move appears not to match its description; Anubis has it on his to-do list of things to check. In the mean time I changed it so something nearer its description.

I also changed G-Max Wind Rage to use itself as the effect that's removing hazards, as that seemed wrong to me.

Let me know if you want any of those changes reverted.