### PR TITLE
Fix two issues with Magic Powder

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -10855,14 +10855,9 @@ let BattleMovedex = {
 		name: "Magic Powder",
 		pp: 20,
 		priority: 0,
-		flags: {protect: 1, reflectable: 1, mirror: 1, mystery: 1},
+		flags: {powder: 1, protect: 1, reflectable: 1, mirror: 1, mystery: 1},
 		onHit(target) {
-			if (target.getTypes().join() === 'Psychic' || !target.setType('Psychic')) {
-				// Soak should animate even when it fails.
-				// Returning false would suppress the animation.
-				this.add('-fail', target);
-				return null;
-			}
+			if (target.getTypes().join() === 'Psychic' || !target.setType('Psychic')) return false;
 			this.add('-start', target, 'typechange', 'Psychic');
 		},
 		secondary: null,


### PR DESCRIPTION
Confirmed by Anubis but also mentioned on the forums.
- Magic Powder is a Powder move, and doesn't affect e.g. Grass types.
- Magic Powder just fails, unlike Soak.