### PR TITLE
Only in Gen 7 can level-up moves be relearned at any level

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1690,7 +1690,7 @@ export class TeamValidator {
 
 					if (learned.charAt(1) === 'L') {
 						// special checking for level-up moves
-						if (level >= parseInt(learned.substr(2), 10) || learnedGen >= 7) {
+						if (level >= parseInt(learned.substr(2), 10) || learnedGen === 7) {
 							// we're past the required level to learn it
 							// (gen 7 level-up moves can be relearnered at any level)
 							// falls through to LMT check below


### PR DESCRIPTION
Reported here: https://www.smogon.com/forums/posts/8298152

The Gen 8 relearner only allows previously learned moves again.