### PR TITLE
Galar Beginnings: Allow Snorlax-Gmax

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -170,6 +170,7 @@ let Formats = [
 			battle: 3,
 		},
 		ruleset: ['Obtainable', 'Standard GBU'],
+		unbanlist: ['Snorlax-Gmax'],
 		minSourceGen: 8,
 	},
 	{


### PR DESCRIPTION
Snorlax-Gmax will be released before the competition starts on cartridge and therefore allowed in the competition, so it'd be great if we could get it unbanned here for testing before the comp starts.