### PR TITLE
Mafia: Use a slightly better hack to allow hosts to broadcast

### DIFF
--- a/server/chat-plugins/mafia.js
+++ b/server/chat-plugins/mafia.js
@@ -2429,19 +2429,12 @@ const commands = {
 			} else {
 				const num = parseInt(target);
 				if (isNaN(num)) {
-					if ((game.hostid === user.id || game.cohosts.includes(user.id)) && this.cmdToken === "!") {
-						const broadcastMessage = this.message.toLowerCase().replace(/[^a-z0-9\s!,]/g, '');
-						if (room.lastBroadcast === broadcastMessage &&
-							room.lastBroadcastTime >= Date.now() - 20 * 1000) {
-							return this.errorReply("You can't broadcast this because it was just broadcasted.");
-						}
-						this.broadcasting = true;
-						this.broadcastMessage = broadcastMessage;
-						this.sendReply('|c|' + this.user.getIdentity(this.room.roomid) + '|' + this.message);
-						room.lastBroadcastTime = Date.now();
-						room.lastBroadcast = broadcastMessage;
+					// hack to let hosts broadcast
+					if (game.hostid === user.id || game.cohosts.includes(user.id)) {
+						this.broadcastMessage = this.message.toLowerCase().replace(/[^a-z0-9\s!,]/g, '');
 					}
 					if (!this.runBroadcast()) return false;
+
 					if ((game.dlAt - Date.now()) > 0) {
 						return this.sendReply(`|raw|<strong>The deadline is in ${Chat.toDurationString(game.dlAt - Date.now()) || '0 seconds'}.</strong>`);
 					} else {
@@ -2611,17 +2604,10 @@ const commands = {
 			if (!room || !room.game || room.game.gameid !== 'mafia') return this.errorReply(`There is no game of mafia running in this room.`);
 			const game = /** @type {MafiaTracker} */ (room.game);
 			if (!game.started) return this.errorReply(`The game of mafia has not started yet.`);
-			if ((game.hostid === user.id || game.cohosts.includes(user.id)) && this.cmdToken === "!") {
-				const broadcastMessage = this.message.toLowerCase().replace(/[^a-z0-9\s!,]/g, '');
-				if (room.lastBroadcast === broadcastMessage &&
-					room.lastBroadcastTime >= Date.now() - 20 * 1000) {
-					return this.errorReply("You can't broadcast this because it was just broadcasted.");
-				}
-				this.broadcasting = true;
-				this.broadcastMessage = broadcastMessage;
-				this.sendReply('|c|' + this.user.getIdentity(this.room.roomid) + '|' + this.message);
-				room.lastBroadcastTime = Date.now();
-				room.lastBroadcast = broadcastMessage;
+
+			// hack to let hosts broadcast
+			if (game.hostid === user.id || game.cohosts.includes(user.id)) {
+				this.broadcastMessage = this.message.toLowerCase().replace(/[^a-z0-9\s!,]/g, '');
 			}
 			if (!this.runBroadcast()) return false;
 
@@ -2632,17 +2618,10 @@ const commands = {
 		players(target, room, user) {
 			if (!room || !room.game || room.game.gameid !== 'mafia') return this.errorReply(`There is no game of mafia running in this room.`);
 			const game = /** @type {MafiaTracker} */ (room.game);
-			if ((game.hostid === user.id || game.cohosts.includes(user.id)) && this.cmdToken === "!") {
-				const broadcastMessage = this.message.toLowerCase().replace(/[^a-z0-9\s!,]/g, '');
-				if (room.lastBroadcast === broadcastMessage &&
-					room.lastBroadcastTime >= Date.now() - 20 * 1000) {
-					return this.errorReply("You can't broadcast this because it was just broadcasted.");
-				}
-				this.broadcasting = true;
-				this.broadcastMessage = broadcastMessage;
-				this.sendReply('|c|' + this.user.getIdentity(this.room.roomid) + '|' + this.message);
-				room.lastBroadcastTime = Date.now();
-				room.lastBroadcast = broadcastMessage;
+
+			// hack to let hosts broadcast
+			if (game.hostid === user.id || game.cohosts.includes(user.id)) {
+				this.broadcastMessage = this.message.toLowerCase().replace(/[^a-z0-9\s!,]/g, '');
 			}
 			if (!this.runBroadcast()) return false;
 
@@ -2944,18 +2923,10 @@ const commands = {
 				return this.sendReplyBox(`Your role is: ${role.safeName}`);
 			}
 
+			// hack to let hosts broadcast
 			const game = room && room.game && room.game.gameid === 'mafia' ? /** @type {MafiaTracker} */(room.game) : null;
-			if (game && (game.hostid === user.id || game.cohosts.includes(user.id)) && this.cmdToken === "!") {
-				const broadcastMessage = this.message.toLowerCase().replace(/[^a-z0-9\s!,]/g, '');
-				if (room.lastBroadcast === broadcastMessage &&
-					room.lastBroadcastTime >= Date.now() - 20 * 1000) {
-					return this.errorReply("You can't broadcast this because it was just broadcasted.");
-				}
-				this.broadcasting = true;
-				this.broadcastMessage = broadcastMessage;
-				this.sendReply('|c|' + this.user.getIdentity(this.room.roomid) + '|' + this.message);
-				room.lastBroadcastTime = Date.now();
-				room.lastBroadcast = broadcastMessage;
+			if (game && (game.hostid === user.id || game.cohosts.includes(user.id))) {
+				this.broadcastMessage = this.message.toLowerCase().replace(/[^a-z0-9\s!,]/g, '');
 			}
 			if (!this.runBroadcast()) return false;
 


### PR DESCRIPTION
`Chat#canBroadcast` sets `broadcastMessage` as an indicator that it's run, so setting it manually lets us bypass `canBroadcast`.