### PR TITLE
Ladders: Delete rating cache if no response.

### DIFF
--- a/server/ladders-remote.ts
+++ b/server/ladders-remote.ts
@@ -67,6 +67,8 @@ export class LadderStore {
 		}
 
 		const formatid = this.formatid;
+		const p1 = Users.getExact(p1name);
+		const p2 = Users.getExact(p2name);
 		room.update();
 		room.send(`||Ladder updating...`);
 		const [data, , error] = await LoginServer.request('ladderupdate', {
@@ -75,35 +77,44 @@ export class LadderStore {
 			score: p1score,
 			format: formatid,
 		});
+		let problem = false;
+
 		if (error) {
 			if (error.message === 'stream interrupt') {
 				room.add(`||Ladder updated, but score could not be retrieved.`);
 			} else {
 				room.add(`||Ladder (probably) updated, but score could not be retrieved (${error.message}).`);
 			}
-			return [p1score, null, null];
+			problem = true;
 		}
 		if (!room.battle) {
 			Monitor.warn(`room expired before ladder update was received`);
-			return [p1score, null, null];
+			problem = true;
 		}
 		if (!data) {
 			room.add(`|error|Unexpected response ${data} from ladder server.`);
 			room.update();
-			return [p1score, null, null];
+			problem = true;
 		}
-		if (data.errorip) {
+		if (data && data.errorip) {
 			room.add(`|error|This server's request IP ${data.errorip} is not a registered server.`);
 			room.add(`|error|You should be using ladders.js and not ladders-remote.js for ladder tracking.`);
 			room.update();
+			problem = true;
+		}
+
+		if (problem) {
+			// Clear mmrCache for the format to get the users updated rating next search
+			if (p1) delete p1.mmrCache[formatid];
+			if (p2) delete p2.mmrCache[formatid];
 			return [p1score, null, null];
 		}
 
 		let p1rating;
 		let p2rating;
 		try {
-			p1rating = data.p1rating;
-			p2rating = data.p2rating;
+			p1rating = data!.p1rating;
+			p2rating = data!.p2rating;
 
 			let oldelo = Math.round(p1rating.oldelo);
 			let elo = Math.round(p1rating.elo);
@@ -122,9 +133,7 @@ export class LadderStore {
 			if (elo < minElo) minElo = elo;
 			room.rated = minElo;
 
-			const p1 = Users.getExact(p1name);
 			if (p1) p1.mmrCache[formatid] = +p1rating.elo;
-			const p2 = Users.getExact(p2name);
 			if (p2) p2.mmrCache[formatid] = +p2rating.elo;
 			room.update();
 		} catch (e) {

--- a/server/ladders.ts
+++ b/server/ladders.ts
@@ -474,8 +474,8 @@ class Ladder extends LadderStore {
 		// search must be within range
 		let searchRange = 100;
 		const elapsed = Date.now() - Math.min(search1.time, search2.time);
-		if (formatid === 'gen7ou' || formatid === 'gen7oucurrent' ||
-				formatid === 'gen7oususpecttest' || formatid === 'gen7randombattle') {
+		if (formatid === 'gen8ou' || formatid === 'gen8oucurrent' ||
+				formatid === 'gen8oususpecttest' || formatid === 'gen8randombattle') {
 			searchRange = 50;
 		}
 


### PR DESCRIPTION
If the remote ladder's update rating method dosen't receive
a response from the login server, it will not change the user's
mmrCache for the format, resulting in future ladder matches using
an outdated ELO until the server receives a response at the end of
a future match.

This is the cause of issues such as users with 1400 ELO being matched
with users with 1000 ELO with a 10 second wait time in current gen OU.

HIGH PRIORITY due to an upcoming OU suspect test. Ideally we merge this and reboot the server tonight.