### PR TITLE
Add Dynamax Clause to CC1v1/CC2v2

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -592,7 +592,7 @@ let Formats = [
 		teamLength: {
 			battle: 1,
 		},
-		ruleset: ['Obtainable', 'HP Percentage Mod', 'Cancel Mod', 'Team Preview'],
+		ruleset: ['Obtainable', 'HP Percentage Mod', 'Cancel Mod', 'Team Preview', 'Dynamax Clause'],
 	},
 	{
 		name: "[Gen 8] Challenge Cup 2v2",
@@ -604,7 +604,7 @@ let Formats = [
 			battle: 2,
 		},
 		searchShow: false,
-		ruleset: ['Obtainable', 'HP Percentage Mod', 'Cancel Mod', 'Team Preview'],
+		ruleset: ['Obtainable', 'HP Percentage Mod', 'Cancel Mod', 'Team Preview', 'Dynamax Clause'],
 	},
 	{
 		name: "[Gen 8] Hackmons Cup",


### PR DESCRIPTION
> chaos11/19/2019
> The Immortal i think we should ban dynamax in cc1v1, theres no point to the random moveset when you're just gonna be spamming Max ___
> or maybe you wanna wait until dynamax stuff is settled in other formats, just seems particularly egregious in this one
> 
> The Immortal11/19/2019
> good point

Given that it is banned in regular 1v1 now, seems like the right time