### PR TITLE
Fix Ditto from Dynamaxing as a Mega/Primal etc

### DIFF
--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -733,16 +733,6 @@ let BattleFormats = {
 				return [`${set.name}'s item ${item.name} does not exist in Gen ${this.dex.gen}.`];
 			}
 		},
-		onBegin() {
-			// if you have a mega/primal or z, you can't dynamax
-			for (const pokemon of this.getAllPokemon()) {
-				const item = pokemon.getItem();
-				// this.canMegaEvo check is for Rayquaza.
-				if (item.megaStone || this.canMegaEvo(pokemon) || item.onPrimal || item.zMove) {
-					pokemon.canDynamax = false;
-				}
-			}
-		},
 	},
 	ignoreillegalabilities: {
 		effectType: 'ValidatorRule',

--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -738,7 +738,7 @@ let BattleFormats = {
 			for (const pokemon of this.getAllPokemon()) {
 				const item = pokemon.getItem();
 				// this.canMegaEvo check is for Rayquaza.
-				if (item.megaStone || this.canMegaEvo(pokemon) || item.onPrimal || item.zMove || (pokemon.transformed && (pokemon.template.isMega || pokemon.template.isPrimal || pokemon.template.forme === "Ultra"))) {
+				if (item.megaStone || this.canMegaEvo(pokemon) || item.onPrimal || item.zMove) {
 					pokemon.canDynamax = false;
 				}
 			}

--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -738,7 +738,7 @@ let BattleFormats = {
 			for (const pokemon of this.getAllPokemon()) {
 				const item = pokemon.getItem();
 				// this.canMegaEvo check is for Rayquaza.
-				if (item.megaStone || this.canMegaEvo(pokemon) || item.onPrimal || item.zMove) {
+				if (item.megaStone || this.canMegaEvo(pokemon) || item.onPrimal || item.zMove  || (pokemon.transformed && (pokemon.template.isMega || pokemon.template.isPrimal || pokemon.template.forme === "Ultra" || pokemon.template === 'zacian'|| pokemon.template === 'zamazenta' || pokemon.template === 'eternatus'))) {
 					pokemon.canDynamax = false;
 				}
 			}

--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -738,7 +738,7 @@ let BattleFormats = {
 			for (const pokemon of this.getAllPokemon()) {
 				const item = pokemon.getItem();
 				// this.canMegaEvo check is for Rayquaza.
-				if (item.megaStone || this.canMegaEvo(pokemon) || item.onPrimal || item.zMove  || (pokemon.transformed && (pokemon.template.isMega || pokemon.template.isPrimal || pokemon.template.forme === "Ultra" || pokemon.template === 'zacian'|| pokemon.template === 'zamazenta' || pokemon.template === 'eternatus'))) {
+				if (item.megaStone || this.canMegaEvo(pokemon) || item.onPrimal || item.zMove || (pokemon.transformed && (pokemon.template.isMega || pokemon.template.isPrimal || pokemon.template.forme === "Ultra" || pokemon.template === 'zacian' || pokemon.template === 'zamazenta' || pokemon.template === 'eternatus'))) {
 					pokemon.canDynamax = false;
 				}
 			}

--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -738,7 +738,7 @@ let BattleFormats = {
 			for (const pokemon of this.getAllPokemon()) {
 				const item = pokemon.getItem();
 				// this.canMegaEvo check is for Rayquaza.
-				if (item.megaStone || this.canMegaEvo(pokemon) || item.onPrimal || item.zMove || (pokemon.transformed && (pokemon.template.isMega || pokemon.template.isPrimal || pokemon.template.forme === "Ultra" || pokemon.template === 'zacian' || pokemon.template === 'zamazenta' || pokemon.template === 'eternatus'))) {
+				if (item.megaStone || this.canMegaEvo(pokemon) || item.onPrimal || item.zMove || (pokemon.transformed && (pokemon.template.isMega || pokemon.template.isPrimal || pokemon.template.forme === "Ultra"))) {
 					pokemon.canDynamax = false;
 				}
 			}

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1170,7 +1170,9 @@ let BattleScripts = {
 		// {gigantamax?: string, maxMoves: {[k: string]: string} | null}[]
 		if (!skipChecks) {
 			if (!pokemon.canDynamax) return;
-			if (pokemon.transformed && (pokemon.template.baseSpecies === 'zacian' || pokemon.template.baseSpecies === 'zamazenta' || pokemon.template.baseSpecies === 'eternatus' || pokemon.template.isMega || pokemon.template.isPrimal || pokemon.template.forme === "Ultra")) return;
+			if (['zacian', 'zamazenta', 'eternatus'].includes(pokemon.template.baseSpecies) || pokemon.template.isMega || pokemon.template.isPrimal || pokemon.template.forme === "Ultra") {
+				return;
+			}
 			// Some pokemon species are unable to dynamax
 			const cannotDynamax = ['zacian', 'zamazenta', 'eternatus'];
 			if (cannotDynamax.includes(toID(pokemon.template.baseSpecies))) {

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1170,7 +1170,7 @@ let BattleScripts = {
 		// {gigantamax?: string, maxMoves: {[k: string]: string} | null}[]
 		if (!skipChecks) {
 			if (!pokemon.canDynamax) return;
-			if (pokemon.transformed && (pokemon.template.isMega || pokemon.template.isPrimal || pokemon.template.forme === "Ultra")) {
+			if (pokemon.template.isMega || pokemon.template.isPrimal || pokemon.template.forme === "Ultra") {
 				return;
 			}
 			// Some pokemon species are unable to dynamax

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1170,7 +1170,7 @@ let BattleScripts = {
 		// {gigantamax?: string, maxMoves: {[k: string]: string} | null}[]
 		if (!skipChecks) {
 			if (!pokemon.canDynamax) return;
-			if (pokemon.template.isMega || pokemon.template.isPrimal || pokemon.template.forme === "Ultra") {
+			if (pokemon.template.isMega || pokemon.template.isPrimal || pokemon.template.forme === "Ultra" || pokemon.getItem().zMove || this.canMegaEvo(pokemon)) {
 				return;
 			}
 			// Some pokemon species are unable to dynamax

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1170,7 +1170,7 @@ let BattleScripts = {
 		// {gigantamax?: string, maxMoves: {[k: string]: string} | null}[]
 		if (!skipChecks) {
 			if (!pokemon.canDynamax) return;
-			if (pokemon.transformed && (pokemon.baseSpecies === 'zacian' || pokemon.baseSpecies === 'zamazenta' || pokemon.baseSpecies === 'eternatus')) return;
+			if (pokemon.transformed && (pokemon.template.baseSpecies === 'zacian' || pokemon.template.baseSpecies === 'zamazenta' || pokemon.template.baseSpecies === 'eternatus')) return;
 			// Some pokemon species are unable to dynamax
 			const cannotDynamax = ['zacian', 'zamazenta', 'eternatus'];
 			if (cannotDynamax.includes(toID(pokemon.template.baseSpecies))) {

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1170,6 +1170,7 @@ let BattleScripts = {
 		// {gigantamax?: string, maxMoves: {[k: string]: string} | null}[]
 		if (!skipChecks) {
 			if (!pokemon.canDynamax) return;
+			if (pokemon.transformed && (pokemon.baseSpecies === 'zacian' || pokemon.baseSpecies === 'zamazenta' || pokemon.baseSpecies === 'eternatus')) return;
 			// Some pokemon species are unable to dynamax
 			const cannotDynamax = ['zacian', 'zamazenta', 'eternatus'];
 			if (cannotDynamax.includes(toID(pokemon.template.baseSpecies))) {

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1170,7 +1170,7 @@ let BattleScripts = {
 		// {gigantamax?: string, maxMoves: {[k: string]: string} | null}[]
 		if (!skipChecks) {
 			if (!pokemon.canDynamax) return;
-			if (pokemon.transformed && (pokemon.template.baseSpecies === 'zacian' || pokemon.template.baseSpecies === 'zamazenta' || pokemon.template.baseSpecies === 'eternatus')) return;
+			if (pokemon.transformed && (pokemon.template.baseSpecies === 'zacian' || pokemon.template.baseSpecies === 'zamazenta' || pokemon.template.baseSpecies === 'eternatus' || pokemon.template.isMega || pokemon.template.isPrimal || pokemon.template.forme === "Ultra")) return;
 			// Some pokemon species are unable to dynamax
 			const cannotDynamax = ['zacian', 'zamazenta', 'eternatus'];
 			if (cannotDynamax.includes(toID(pokemon.template.baseSpecies))) {

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -1170,7 +1170,7 @@ let BattleScripts = {
 		// {gigantamax?: string, maxMoves: {[k: string]: string} | null}[]
 		if (!skipChecks) {
 			if (!pokemon.canDynamax) return;
-			if (['zacian', 'zamazenta', 'eternatus'].includes(pokemon.template.baseSpecies) || pokemon.template.isMega || pokemon.template.isPrimal || pokemon.template.forme === "Ultra") {
+			if (pokemon.transformed && (pokemon.template.isMega || pokemon.template.isPrimal || pokemon.template.forme === "Ultra")) {
 				return;
 			}
 			// Some pokemon species are unable to dynamax


### PR DESCRIPTION
Ditto is still able to Dynamax while transformed as a Megas, Primals, and Ultra Necrozma.  Since Ditto cannot Dynamax as Zacian, Zamazenta, and Eternatus, Megazard has asked me to fix this for more Balance within the National Dex formats.