### PR TITLE
Sort battle actions by order instead of priority

### DIFF
--- a/data/mods/gen7/moves.js
+++ b/data/mods/gen7/moves.js
@@ -605,6 +605,24 @@ let BattleMovedex = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	quash: {
+		inherit: true,
+		onHit(target) {
+			if (target.side.active.length < 2) return false; // fails in singles
+			let action = this.willMove(target);
+			if (!action) return false;
+
+			action.priority = -7.1;
+			this.cancelMove(target);
+			for (let i = this.queue.length - 1; i >= 0; i--) {
+				if (this.queue[i].choice === 'residual') {
+					this.queue.splice(i, 0, action);
+					break;
+				}
+			}
+			this.add('-activate', target, 'move: Quash');
+		},
+	},
 	rage: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/moves.js
+++ b/data/moves.js
@@ -14760,19 +14760,10 @@ let BattleMovedex = {
 		onHit(target) {
 			if (target.side.active.length < 2) return false; // fails in singles
 			let action = this.willMove(target);
-			if (action) {
-				action.priority = -7.1;
-				this.cancelMove(target);
-				for (let i = this.queue.length - 1; i >= 0; i--) {
-					if (this.queue[i].choice === 'residual') {
-						this.queue.splice(i, 0, action);
-						break;
-					}
-				}
-				this.add('-activate', target, 'move: Quash');
-			} else {
-				return false;
-			}
+			if (!action) return false;
+
+			action.order = 201;
+			this.add('-activate', target, 'move: Quash');
 		},
 		secondary: null,
 		target: "normal",

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2338,24 +2338,34 @@ export class Battle {
 		if (!action.side && action.pokemon) action.side = action.pokemon.side;
 		if (!action.move && action.moveid) action.move = this.dex.getActiveMove(action.moveid);
 		if (!action.choice && action.move) action.choice = 'move';
-		if (!action.priority && action.priority !== 0) {
-			const priorities = {
-				beforeTurn: 100,
-				beforeTurnMove: 99,
-				switch: 7,
-				runUnnerve: 7.3,
-				runSwitch: 7.2,
-				runPrimal: 7.1,
-				instaswitch: 101,
-				megaEvo: 6.9,
-				runDynamax: 6.8,
-				residual: -100,
-				team: 102,
-				start: 101,
+		if (!action.order) {
+			const orders: {[choice: string]: number} = {
+				team: 1,
+				start: 2,
+				instaswitch: 3,
+				beforeTurn: 4,
+				beforeTurnMove: 5,
+
+				runUnnerve: 100,
+				runSwitch: 101,
+				runPrimal: 102,
+				switch: 103,
+				megaEvo: 104,
+				runDynamax: 105,
+
+				shift: 106,
+
+				// default is 200 (for moves)
+
+				residual: 300,
 			};
-			if (action.choice in priorities) {
-				// @ts-ignore - Typescript being dumb about index signatures
-				action.priority = priorities[action.choice];
+			if (action.choice in orders) {
+				action.order = orders[action.choice];
+			} else {
+				action.order = 200;
+				if (!['move', 'event'].includes(action.choice)) {
+					throw new Error(`Unexpected orderless action ${action.choice}`);
+				}
 			}
 		}
 		if (!midTurn) {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2516,7 +2516,7 @@ export class Battle {
 			}
 		}
 		action.sourceEffect = sourceEffect;
-		action.priority = 10;
+		action.order = 3;
 		this.queue.unshift(action);
 	}
 

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -1180,6 +1180,7 @@ namespace Actions {
 	export interface MoveAction {
 		/** action type */
 		choice: 'move' | 'beforeTurnMove';
+		order: 3 | 5 | 200 | 201 | 199;
 		/** priority of the action (lower first) */
 		priority: number;
 		/** speed of pokemon using move (higher first if priority tie) */
@@ -1206,6 +1207,7 @@ namespace Actions {
 	export interface SwitchAction {
 		/** action type */
 		choice: 'switch' | 'instaswitch';
+		order: 3 | 103;
 		/** priority of the action (lower first) */
 		priority: number;
 		/** speed of pokemon switching (higher first if priority tie) */


### PR DESCRIPTION
This fixes the issues with priority moves in gen 8.