### PR TITLE
Prevent Eternamax Max HP Doubling

### DIFF
--- a/data/statuses.js
+++ b/data/statuses.js
@@ -751,9 +751,7 @@ let BattleStatuses = {
 		},
 		onFlinch: false,
 		onBeforeSwitchOut(pokemon) {
-			if (pokemon.species !== 'Eternatus-Eternamax') {
-				pokemon.removeVolatile('dynamax');
-			}
+			pokemon.removeVolatile('dynamax');
 		},
 		onDragOutPriority: 2,
 		onDragOut(pokemon) {


### PR DESCRIPTION
* Removed check that prevented `dynamax` volatile from calling `onEnd` when species is Eternatus-Eternamax.
* Lack of `onEnd` prevented Eternamax's `maxhp` from resetting thanks to the volatile simply being cleared rather than being ended properly. Further switch-ins and switch outs result in further doubling: `maxHp` goes from 700 -> 1400 -> 2800 etc, then is doubled for Dynamax and kept on switch-out, thus causing the bug.

Edit: flaw in initial logic