### PR TITLE
Allow drivers to modchat by default

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -543,7 +543,6 @@ exports.grouplist = [
 		inherit: '%',
 		jurisdiction: 'u',
 		ban: true,
-		modchat: true,
 		modchatall: true,
 		roomvoice: true,
 		forcerename: true,
@@ -573,6 +572,7 @@ exports.grouplist = [
 		jeopardy: true,
 		joinbattle: true,
 		minigame: true,
+		modchat: true,
 	},
 	{
 		symbol: '\u2606',


### PR DESCRIPTION
As was discussed.
The roomban permission thing is probably not great. There is a ban permission in the config, but it will apply to all drivers (and includes gban for gdrivers), which I don't want. I'm open to other suggestions of how to implement that.