### PR TITLE
Fix bug caused by #6149

### DIFF
--- a/data/statuses.js
+++ b/data/statuses.js
@@ -740,15 +740,14 @@ let BattleStatuses = {
 			pokemon.hp = Math.floor(pokemon.hp * ratio);
 			this.add('-heal', pokemon, pokemon.getHealth, '[silent]');
 		},
-		onSwitchIn(pokemon) { // Putting Eternamax in onSwitchIn so it shows up everytime Eternatus switches in.
-			if (pokemon.species !== 'Eternatus-Eternamax') return; // Special for Eternatus' Eternamax forme
+		onSwitchIn(pokemon) { // Special for Eternatus-Eternamax
+			if (pokemon.species !== 'Eternatus-Eternamax') return;
 			pokemon.removeVolatile('substitute');
-			//this.add('-start', pokemon, 'Eternamax');
 			this.effectData.duration = 0;
 		},
 		onFlinch: false,
 		onBeforeSwitchOut(pokemon) {
-			if(pokemon.species !== 'Eternatus-Eternamax') pokemon.removeVolatile('dynamax');
+			if (pokemon.species !== 'Eternatus-Eternamax') pokemon.removeVolatile('dynamax');
 		},
 		onDragOutPriority: 2,
 		onDragOut(pokemon) {
@@ -771,17 +770,6 @@ let BattleStatuses = {
 	// but their formes are specified to be their corresponding type
 	// in the Pokedex, so that needs to be overridden.
 	// This is mainly relevant for Hackmons Cup and Balanced Hackmons.
-	eternatuseternamax: {
-		name: 'Eternatus-Eternamax',
-		id: 'eternatuseternamax',
-		num: 890,
-		onStart(pokemon) {
-			if (pokemon.transformed) return;
-			pokemon.addVolatile('dynamax');
-			pokemon.maxhp = Math.floor(pokemon.maxhp * 2);
-			pokemon.hp = Math.floor(pokemon.hp * 2);
-		},
-	},
 	arceus: {
 		name: 'Arceus',
 		id: 'arceus',
@@ -816,6 +804,17 @@ let BattleStatuses = {
 				}
 			}
 			return [type];
+		},
+	},
+	eternatuseternamax: {
+		name: 'Eternatus-Eternamax',
+		id: 'eternatuseternamax',
+		num: 890,
+		onStart(pokemon) {
+			if (pokemon.transformed) return;
+			pokemon.addVolatile('dynamax');
+			pokemon.maxhp = Math.floor(pokemon.maxhp * 2);
+			pokemon.hp = Math.floor(pokemon.hp * 2);
 		},
 	},
 };

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -740,7 +740,8 @@ let BattleStatuses = {
 			pokemon.hp = Math.floor(pokemon.hp * ratio);
 			this.add('-heal', pokemon, pokemon.getHealth, '[silent]');
 		},
-		onSwitchIn(pokemon) { // Special for Eternatus-Eternamax
+		onSwitchIn(pokemon) {
+			// Special case for Eternamax
 			if (pokemon.species !== 'Eternatus-Eternamax') return;
 			pokemon.removeVolatile('substitute');
 			this.effectData.duration = 0;

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -743,15 +743,12 @@ let BattleStatuses = {
 		onSwitchIn(pokemon) { // Putting Eternamax in onSwitchIn so it shows up everytime Eternatus switches in.
 			if (pokemon.species !== 'Eternatus-Eternamax') return; // Special for Eternatus' Eternamax forme
 			pokemon.removeVolatile('substitute');
-			this.add('-start', pokemon, 'Eternamax');
+			//this.add('-start', pokemon, 'Eternamax');
 			this.effectData.duration = 0;
-			pokemon.maxhp = Math.floor(pokemon.maxhp * 2);
-			pokemon.hp = Math.floor(pokemon.hp * 2);
-			this.add('-heal', pokemon, pokemon.getHealth, '[silent]');
 		},
 		onFlinch: false,
 		onBeforeSwitchOut(pokemon) {
-			pokemon.removeVolatile('dynamax');
+			if(pokemon.species !== 'Eternatus-Eternamax') pokemon.removeVolatile('dynamax');
 		},
 		onDragOutPriority: 2,
 		onDragOut(pokemon) {
@@ -759,7 +756,7 @@ let BattleStatuses = {
 			return null;
 		},
 		onEnd(pokemon) {
-			if (pokemon.species !== 'Eternatus-Eternamax') this.add('-end', pokemon, 'Dynamax');
+			this.add('-end', pokemon, 'Dynamax');
 			if (pokemon.canGigantamax) pokemon.formeChange(pokemon.baseTemplate.species);
 			if (pokemon.species === 'Shedinja') return;
 			pokemon.hp = pokemon.getUndynamaxedHP();
@@ -781,6 +778,8 @@ let BattleStatuses = {
 		onStart(pokemon) {
 			if (pokemon.transformed) return;
 			pokemon.addVolatile('dynamax');
+			pokemon.maxhp = Math.floor(pokemon.maxhp * 2);
+			pokemon.hp = Math.floor(pokemon.hp * 2);
 		},
 	},
 	arceus: {


### PR DESCRIPTION
Eternamax was losing dynamax benefits after switching out once. This changes the way eternatus-eternamax interacts with the volatile to completely remove health-related matters from the dynamax volatile, instead being handled by the eternamax volatile right at the beginning. 
I've reviewed videos, and none of them have an indicator of any such thing as "eternamax" starting, so a silent start is the most accurate here. It's intrinsic to the mon itself, except weirdly without an accompanying ability.