### PR TITLE
Fix Forretress not showing up in gen 2 randbats

### DIFF
--- a/data/mods/gen2/formats-data.js
+++ b/data/mods/gen2/formats-data.js
@@ -3081,7 +3081,7 @@ let BattleFormatsData = {
 		tier: "LC",
 	},
 	forretress: { // Spikes
-		randomSet3: {
+		randomSet1: {
 			chance: 16,
 			item: ["leftovers"],
 			baseMove1: "spikes", baseMove2: "explosion",


### PR DESCRIPTION
Team generation requires a randomSet1 property on the mon, which this didn't have, I assume because at some point there were multiple sets and they were collapsed into one.