### PR TITLE
Correct level implementation for Gen 8 cartridge formats

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -154,7 +154,7 @@ let Formats = [
 		],
 
 		mod: 'gen8',
-		maxForcedLevel: 50,
+		forcedLevel: 50,
 		teamLength: {
 			validate: [3, 6],
 			battle: 3,
@@ -218,7 +218,7 @@ let Formats = [
 
 		mod: 'gen8',
 		gameType: 'doubles',
-		maxForcedLevel: 50,
+		forcedLevel: 50,
 		teamLength: {
 			validate: [4, 6],
 			battle: 4,
@@ -232,7 +232,7 @@ let Formats = [
 
 		mod: 'gen8',
 		gameType: 'doubles',
-		maxForcedLevel: 50,
+		forcedLevel: 50,
 		teamLength: {
 			validate: [4, 6],
 			battle: 4,


### PR DESCRIPTION
VGC 2020, Battle Stadium Doubles, and Battle Stadium Singles all take Pokemon below level 50 and force them to be level 50 (this was my error when I added Battle Stadium Doubles / VGC 2020 originally). VGC 2020 technically doesn't have a released ruleset in-game yet, but the format announcement confirms it will be autolevel up. https://www.pokemon.com/us/pokemon-news/2020-pokemon-video-game-championships-vgc-format-rules/