### PR TITLE
Commands: remove minimum length and newline restrictions on /code

### DIFF
--- a/server/chat-commands/info.js
+++ b/server/chat-commands/info.js
@@ -2398,33 +2398,30 @@ const commands = {
 	code(target, room, user) {
 		if (!target) return this.parse('/help code');
 		if (!this.canTalk()) return;
-		if (target.startsWith('\n')) target = target.slice(1);
+		if (!this.runBroadcast(true, '!code')) return;
 		if (target.length >= 8192) return this.errorReply("Your code must be under 8192 characters long!");
-		const separator = '\n';
-		if (target.includes(separator) || target.length > 150) {
-			const params = target.split(separator);
-			let output = [];
-			let cutoff = 3;
-			for (const param of params) {
-				if (output.length < 2 && param.length > 80) cutoff = 2;
-				output.push(Chat.escapeHTML(param));
-			}
-			let code;
-			if (output.length > cutoff) {
-				code = `<div class="chat"><details class="readmore code" style="white-space: pre-wrap; display: table; tab-size: 3"><summary>${output.slice(0, cutoff).join('<br />')}</summary>${output.slice(cutoff).join('<br />')}</details></div>`;
-			} else {
-				code = `<div class="chat"><code style="white-space: pre-wrap; display: table; tab-size: 3">${output.join('<br />')}</code></div>`;
-			}
 
-			if (!this.canBroadcast(true, '!code')) return;
-			if (this.broadcastMessage && !this.can('broadcast', null, room)) return false;
-
-			if (!this.runBroadcast(true, '!code')) return;
-
-			this.sendReplyBox(code);
-		} else {
-			return this.errorReply("You can simply use ``[code]`` for code messages that are only one line.");
+		const params = target.split('\n');
+		if (!params[0]) params.unshift();
+		if (!params[params.length - 1]) params.pop();
+		if (params.length === 1 && params[0].length < 80 && !target.includes('```') && this.message.startsWith('/')) {
+			return `\`\`\`${params[0]}\`\`\``;
 		}
+		let output = [];
+		let cutoff = 3;
+		for (const param of params) {
+			if (output.length < 3 && param.length > 80) cutoff = 2;
+			output.push(Chat.escapeHTML(param));
+		}
+
+		let code;
+		if (output.length > cutoff) {
+			code = `<div class="chat"><details class="readmore code" style="white-space: pre-wrap; display: table; tab-size: 3"><summary>${output.slice(0, cutoff).join('<br />')}</summary>${output.slice(cutoff).join('<br />')}</details></div>`;
+		} else {
+			code = `<div class="chat"><code style="white-space: pre-wrap; display: table; tab-size: 3">${output.join('<br />')}</code></div>`;
+		}
+
+		this.sendReplyBox(code);
 	},
 	codehelp: [
 		`!code [code] - Broadcasts code to a room. Accepts multi-line arguments. Requires: + % @ & # ~`,


### PR DESCRIPTION
Forcing people to use inline code formatting over restrictions that aren't clearly explained and having the input given be changed on you if it starts with a newline is really annoying. This should make it so /code handles input the same way inline code formatting does, just with the addition of accepting multiline input.