### PR TITLE
Added Dockerfile for containerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # Dockerfile for Pokemon Showdown Server
-FROM node:10
+FROM node:13
 
 # Create app directory
 WORKDIR /usr/src/app
 
-# Copy pacakge and cache things
+# Copy package and cache things
 COPY package*.json ./
 RUN npm install
 
@@ -15,4 +15,4 @@ COPY . .
 EXPOSE 8000
 
 # Start the server
-CMD ["node", "pokemon-showdown"]
+CMD ["pokemon-showdown"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Dockerfile for Pokemon Showdown Server
+FROM node:10
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Copy pacakge and cache things
+COPY package*.json ./
+RUN npm install
+
+# Copy the application into the docker image
+COPY . .
+
+# Expose the server on port 8000
+EXPOSE 8000
+
+# Start the server
+CMD ["node", "pokemon-showdown"]


### PR DESCRIPTION
You can use this to run Pokemon Showdown in Docker easily. I use this for running a personal server with a custom config on my server easily -- without needing to worry about versioning of Node etc for other software. 

You can use the following to test it out:

```
docker image build -t pokemon-showdown-server:latest .
docker container run --network host pokemon-showdown-server
```

I run this in my own branch right now -- wondering if we could get this upstream? I would be fine to maintain this. 