### PR TITLE
Make semi-invulnerability work in Gen 1 again

### DIFF
--- a/data/mods/gen1/moves.js
+++ b/data/mods/gen1/moves.js
@@ -281,7 +281,7 @@ let BattleMovedex = {
 			onInvulnerability(target, source, move) {
 				if (move.id === 'swift') return true;
 				this.add('-message', 'The foe ' + target.name + ' can\'t be hit underground!');
-				return null;
+				return false;
 			},
 			onDamage(damage, target, source, move) {
 				if (!move || move.effectType !== 'Move') return;
@@ -418,7 +418,7 @@ let BattleMovedex = {
 			onInvulnerability(target, source, move) {
 				if (move.id === 'swift') return true;
 				this.add('-message', 'The foe ' + target.name + ' can\'t be hit while flying!');
-				return null;
+				return false;
 			},
 			onDamage(damage, target, source, move) {
 				if (!move || move.effectType !== 'Move') return;


### PR DESCRIPTION
The changes I made to simplify the No Guard checks in later gens mean that this function is assumed to return one of `true`, `false` or `0`, but not `null`, which I overlooked at the time...