### PR TITLE
Gorilla Tactics should only lock into the first successful move

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1303,7 +1303,7 @@ let BattleAbilities = {
 			}
 		},
 		onModifyMove(move, pokemon) {
-			if (move.isZPowered || move.maxPowered || move.id === 'struggle') return;
+			if (pokemon.abilityData.choiceLock || move.isZPowered || move.maxPowered || move.id === 'struggle') return;
 			pokemon.abilityData.choiceLock = move.id;
 		},
 		onModifyAtkPriority: 1,


### PR DESCRIPTION
Normal Choice items work by setting the choice volatile once a move starts to execute. Since a volatile can only be started once, this means that when you lock into a move that calls another move the lock has already been taken and the second move is ignored.

This emulates that behaviour for Gorilla Tactics by checking that we aren't already locked into a move.