### PR TITLE
Body Press uses SpD boosts under Wonder Room

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2006,7 +2006,19 @@ export class Battle {
 		const defender = target;
 		let attackStat: StatNameExceptHP = category === 'Physical' ? 'atk' : 'spa';
 		const defenseStat: StatNameExceptHP = defensiveCategory === 'Physical' ? 'def' : 'spd';
-		if (move.useSourceDefensiveAsOffensive) attackStat = defenseStat;
+		if (move.useSourceDefensiveAsOffensive) {
+			attackStat = defenseStat;
+			// Body press really wants to use the def stat,
+			// so it switches stats to compensate for Wonder Room.
+			// Of course, the game thus miscalculates the boosts...
+			if ('wonderroom' in this.field.pseudoWeather) {
+				if (attackStat === 'def') {
+					attackStat = 'spd';
+				} else if (attackStat === 'spd') {
+					attackStat = 'def';
+				}
+			}
+		}
 
 		const statTable = {atk: 'Atk', def: 'Def', spa: 'SpA', spd: 'SpD', spe: 'Spe'};
 		let attack;

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2017,6 +2017,7 @@ export class Battle {
 				} else if (attackStat === 'spd') {
 					attackStat = 'def';
 				}
+				if (attacker.boosts[attackStat]) this.hint("Body Press uses Sp. Def boosts when Wonder Room is active.");
 			}
 		}
 


### PR DESCRIPTION
Body Press tries really hard to use the attacker's Def, and it's almost clever enough to compensate for Wonder Room, but it turns out that it then goes on to use the attacker's SpD boosts.

Sorry, but I can't remember which researcher discovered this quirk.