### PR TITLE
Sunflora Gen 2 move legality

### DIFF
--- a/data/mods/gen2/rulesets.js
+++ b/data/mods/gen2/rulesets.js
@@ -17,7 +17,7 @@ let BattleFormats = {
 			'Vaporeon + Tackle + Growl',
 			'Jolteon + Tackle + Growl', 'Jolteon + Focus Energy + Thunder Shock',
 			'Flareon + Tackle + Growl', 'Flareon + Focus Energy + Ember',
-			
+
 			'Sunflora + Razor Leaf + Synthesis',
 		],
 	},

--- a/data/mods/gen2/rulesets.js
+++ b/data/mods/gen2/rulesets.js
@@ -17,6 +17,8 @@ let BattleFormats = {
 			'Vaporeon + Tackle + Growl',
 			'Jolteon + Tackle + Growl', 'Jolteon + Focus Energy + Thunder Shock',
 			'Flareon + Tackle + Growl', 'Flareon + Focus Energy + Ember',
+			
+			'Sunflora + Razor Leaf + Synthesis',
 		],
 	},
 	standard: {


### PR DESCRIPTION
Sunflora can only learn Razor Leaf at Level 10, after it evolves. It can only learn Synthesis at Level 31, before it evolves. So it can't have both.