### PR TITLE
Calculate fractional priority once per turn

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -3774,7 +3774,7 @@ let BattleAbilities = {
 	},
 	"stall": {
 		shortDesc: "This Pokemon moves last among Pokemon using the same or greater priority moves.",
-		onModifyPriority(priority) {
+		onFractionalPriority(priority) {
 			return Math.round(priority) - 0.1;
 		},
 		id: "stall",

--- a/data/items.js
+++ b/data/items.js
@@ -1133,23 +1133,16 @@ let BattleItems = {
 			basePower: 100,
 			type: "Ghost",
 		},
-		onBeforeTurn(pokemon) {
-			if (!this.willMove(pokemon)) return;
+		onFractionalPriorityPriority: -1,
+		onFractionalPriority(priority, pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
 				if (pokemon.eatItem()) {
 					this.add('-activate', pokemon, 'item: Custap Berry', '[consumed]');
-					pokemon.addVolatile('custapberry');
+					return Math.round(priority) + 0.1;
 				}
 			}
 		},
 		onEat() { },
-		effect: {
-			onModifyPriorityPriority: -1,
-			onModifyPriority(priority, pokemon) {
-				return Math.round(priority) + 0.1;
-			},
-			duration: 1,
-		},
 		num: 210,
 		gen: 4,
 		desc: "Holder moves first in its priority bracket when at 1/4 max HP or less. Single use.",
@@ -4849,19 +4842,12 @@ let BattleItems = {
 	},
 	"quickclaw": {
 		id: "quickclaw",
-		onBeforeTurn(pokemon) {
-			if (!this.willMove(pokemon)) return;
+		onFractionalPriorityPriority: -1,
+		onFractionalPriority(priority, pokemon) {
 			if (this.randomChance(1, 5)) {
 				this.add('-activate', pokemon, 'item: Quick Claw');
-				pokemon.addVolatile('quickclaw');
-			}
-		},
-		effect: {
-			onModifyPriorityPriority: -1,
-			onModifyPriority(priority, pokemon) {
 				return Math.round(priority) + 0.1;
-			},
-			duration: 1,
+			}
 		},
 		name: "Quick Claw",
 		spritenum: 373,

--- a/data/mods/gen7/items.js
+++ b/data/mods/gen7/items.js
@@ -88,30 +88,6 @@ let BattleItems = {
 		inherit: true,
 		isNonstandard: null,
 	},
-	custapberry: {
-		id: "custapberry",
-		name: "Custap Berry",
-		spritenum: 86,
-		isBerry: true,
-		naturalGift: {
-			basePower: 100,
-			type: "Ghost",
-		},
-		onModifyPriorityPriority: -1,
-		onModifyPriority(priority, pokemon) {
-			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
-				if (pokemon.eatItem()) {
-					this.add('-activate', pokemon, 'item: Custap Berry', '[consumed]');
-					pokemon.removeVolatile('custapberry');
-					return Math.round(priority) + 0.1;
-				}
-			}
-		},
-		onEat() { },
-		num: 210,
-		gen: 4,
-		desc: "Holder moves first in its priority bracket when at 1/4 max HP or less. Single use.",
-	},
 	darkgem: {
 		inherit: true,
 		isNonstandard: null,
@@ -414,24 +390,6 @@ let BattleItems = {
 	psychiumz: {
 		inherit: true,
 		isNonstandard: null,
-	},
-	quickclaw: {
-		id: "quickclaw",
-		onModifyPriorityPriority: -1,
-		onModifyPriority(priority, pokemon) {
-			if (this.randomChance(1, 5)) {
-				this.add('-activate', pokemon, 'item: Quick Claw');
-				return Math.round(priority) + 0.1;
-			}
-		},
-		name: "Quick Claw",
-		spritenum: 373,
-		fling: {
-			basePower: 80,
-		},
-		num: 217,
-		gen: 2,
-		desc: "Each turn, holder has a 20% chance to move first in its priority bracket.",
 	},
 	redorb: {
 		inherit: true,

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2394,6 +2394,7 @@ export class Battle {
 						pokemon: action.pokemon,
 					});
 				}
+				action.fractionalPriority = this.runEvent('FractionalPriority', action.pokemon, null, action.move, 0);
 			} else if (['switch', 'instaswitch'].includes(action.choice)) {
 				if (typeof action.pokemon.switchFlag === 'string') {
 					action.sourceEffect = this.dex.getMove(action.pokemon.switchFlag as ID) as any;
@@ -2442,7 +2443,7 @@ export class Battle {
 			// (instead of compounding every time `getActionSpeed` is called)
 			let priority = this.dex.getMove(move.id).priority;
 			priority = this.runEvent('ModifyPriority', action.pokemon, null, move, priority);
-			action.priority = priority;
+			action.priority = priority + action.fractionalPriority;
 			// In Gen 6, Quick Guard blocks moves with artificially enhanced priority.
 			if (this.gen > 5) action.move.priority = priority;
 		}

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -207,6 +207,7 @@ interface EventMethods {
 	onEffectiveness?: MoveEventMethods['onEffectiveness']
 	onFaint?: CommonHandlers['VoidEffect']
 	onFlinch?: ((this: Battle, pokemon: Pokemon) => boolean | void) | boolean
+	onFractionalPriority?: CommonHandlers['ModifierSourceMove']
 	onHit?: MoveEventMethods['onHit']
 	onImmunity?: (this: Battle, type: string, pokemon: Pokemon) => void
 	onLockMove?: string | ((this: Battle, pokemon: Pokemon) => void | string)
@@ -625,6 +626,7 @@ interface EventMethods {
 	onFoeModifyDefPriority?: number
 	onFoeRedirectTargetPriority?: number
 	onFoeTrapPokemonPriority?: number
+	onFractionalPriorityPriority?: number
 	onHitPriority?: number
 	onModifyAccuracyPriority?: number
 	onModifyAtkPriority?: number
@@ -1191,6 +1193,8 @@ namespace Actions {
 		order: 3 | 5 | 200 | 201 | 199;
 		/** priority of the action (lower first) */
 		priority: number;
+		/** fractional priority of the action (lower first) */
+		fractionalPriority: number;
 		/** speed of pokemon using move (higher first if priority tie) */
 		speed: number;
 		/** the pokemon doing the move */


### PR DESCRIPTION
This fixes Custap Berry, Quick Claw and Stall for Gen 8.
In particular, Skill Swap on Stall doesn't affect turn order this turn.