### PR TITLE
fix Toxtricity-Gmax pokedex number

### DIFF
--- a/data/pokedex.js
+++ b/data/pokedex.js
@@ -14394,7 +14394,7 @@ let BattlePokedex = {
 		eggGroups: ["Human-Like"],
 	},
 	toxtricitygmax: {
-		num: 844,
+		num: 849,
 		species: "Toxtricity-Gmax",
 		baseSpecies: "Toxtricity",
 		forme: "Gmax",


### PR DESCRIPTION
Pokedex / National Dex number for Toxtricity-Gmax should be 849 instead of 844. Toxtricity and Toxtricity-Low-Key already use the correct number.