### PR TITLE
Fix tier counting in Gen 5 randbats

### DIFF
--- a/data/mods/gen5/random-teams.js
+++ b/data/mods/gen5/random-teams.js
@@ -709,9 +709,7 @@ class RandomGen5Teams extends RandomGen6Teams {
 			let tier = template.tier;
 
 			// Limit two Pokemon per tier
-			if (!tierCount[tier]) {
-				tierCount[tier] = 1;
-			} else if (tierCount[tier] > 1 && this.gen === 5) {
+			if (tierCount[tier] > 1 && this.gen === 5) {
 				continue;
 			}
 
@@ -754,7 +752,13 @@ class RandomGen5Teams extends RandomGen6Teams {
 
 			// Now that our Pokemon has passed all checks, we can increment our counters
 			baseFormes[template.baseSpecies] = 1;
-			tierCount[tier]++;
+
+			// Increment tier counter
+			if (tierCount[tier]) {
+				tierCount[tier]++;
+			} else {
+				tierCount[tier] = 1;
+			}
 
 			// Increment type counters
 			for (const type of types) {


### PR DESCRIPTION
The first Pokémon in any tier is getting counted twice, which is a shame when you're trying to limit to 2 per tier, as you then end up with 1 per tier. The Gen 2 code for counting tiers seems to be appropriate here. A fix may be needed for later gens but I don't understand what the code there is trying to do.