### PR TITLE
Fix /statcalc without pokemon argument

### DIFF
--- a/server/chat-commands/info.js
+++ b/server/chat-commands/info.js
@@ -1273,7 +1273,7 @@ const commands = {
 
 			if (!pokemon) {
 				let testPoke = Dex.getTemplate(arg);
-				if (testPoke.exists && testPoke.baseStats) {
+				if (testPoke.exists) {
 					pokemon = testPoke.baseStats;
 					baseSet = true;
 					continue;

--- a/server/chat-commands/info.js
+++ b/server/chat-commands/info.js
@@ -1273,7 +1273,7 @@ const commands = {
 
 			if (!pokemon) {
 				let testPoke = Dex.getTemplate(arg);
-				if (testPoke.baseStats) {
+				if (testPoke.exists && testPoke.baseStats) {
 					pokemon = testPoke.baseStats;
 					baseSet = true;
 					continue;


### PR DESCRIPTION
Non-existant templates have a base stat object now (with every stat at 0), so just checking whether there is a base stat object isn't enough to filter out nonexistent templates.