### PR TITLE
Fix room desynch bug

### DIFF
--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1377,6 +1377,9 @@ export class BasicChatRoom extends BasicRoom {
 		}
 		this.active = false;
 
+		// Ensure there aren't any pending messages that could restart the expire timer
+		this.update();
+
 		// Clear any active timers for the room
 		if (this.muteTimer) {
 			clearTimeout(this.muteTimer);


### PR DESCRIPTION
As far as I can tell, the desynch here consists of:

- A tournament is created inside a groupchat.

- The groupchat is manually deleted, destroying the room.

- The tour's end message restarts the room's expire timer after the room has been deleted.

- A new groupchat with the same name is created. 

- The expire timer from the deleted groupchat fires, removing the room's entry in the `Rooms.rooms` map, which now points at the new groupchat.

- The new groupchat now exists without being in the `Rooms.rooms` map. Calamity ensues.

This flushes the groupchat's broadcast buffer when it is deleted, preventing the expire timer from being poked and thus preventing the room being deleted twice.