### PR TITLE
Fix displayed target of move-specific immunity in Gen 1 and 2

### DIFF
--- a/data/mods/gen1/scripts.js
+++ b/data/mods/gen1/scripts.js
@@ -273,7 +273,7 @@ let BattleScripts = {
 		}
 		hitResult = this.singleEvent('TryImmunity', move, null, target, pokemon, move);
 		if (hitResult === false) {
-			this.add('-immune', pokemon);
+			this.add('-immune', target);
 			return false;
 		}
 

--- a/data/mods/gen2/scripts.js
+++ b/data/mods/gen2/scripts.js
@@ -184,7 +184,7 @@ let BattleScripts = {
 
 		hitResult = this.singleEvent('TryImmunity', move, {}, target, pokemon, move);
 		if (hitResult === false) {
-			this.add('-immune', pokemon);
+			this.add('-immune', target);
 			return false;
 		}
 


### PR DESCRIPTION
Followup to #5904; Leech Seed into a Grass type and Dream Eater into anything awake are calculating the immunity correctly but then erroneously crediting it to the attacker instead of the defender.