### PR TITLE
Fix Howl not raising ally's Atk

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -9159,9 +9159,7 @@ let BattleMovedex = {
 		flags: {snatch: 1},
 		self: {
 			onHit(source) {
-				let ally;
-				if (source.side.active[0] === source) ally = source.side.active[1];
-				else ally = source.side.active[0];
+				const ally = (source.side.active[0] === source ? source.side.active[1] : source.side.active[0]);
 				this.boost({atk: 1}, ally);
 			},
 		},

--- a/data/moves.js
+++ b/data/moves.js
@@ -9157,6 +9157,14 @@ let BattleMovedex = {
 		pp: 40,
 		priority: 0,
 		flags: {snatch: 1},
+		self: {
+			onHit(source) {
+				let ally;
+				if (source.side.active[0] === source) ally = source.side.active[1];
+				else ally = source.side.active[0];
+				this.boost({atk: 1}, ally);
+			},
+		},
 		boosts: {
 			atk: 1,
 		},


### PR DESCRIPTION
Specifically done this way so it is still searchable by ``/movesearch boosts atk``