### PR TITLE
Remove tightening focus mechanic when used by dynamaxed pokemon

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2390,7 +2390,7 @@ export class Battle {
 		}
 		if (!midTurn) {
 			if (action.choice === 'move') {
-				if (!action.zmove && action.move.beforeTurnCallback) {
+				if (!action.maxMove && !action.zmove && action.move.beforeTurnCallback) {
 					this.addToQueue({
 						choice: 'beforeTurnMove', pokemon: action.pokemon, move: action.move, targetLoc: action.targetLoc,
 					});

--- a/test/sim/moves/focuspunch.js
+++ b/test/sim/moves/focuspunch.js
@@ -86,4 +86,36 @@ describe('Focus Punch', function () {
 		battle.makeChoices('move focuspunch', 'move toxic');
 		assert.strictEqual(move.pp, move.maxpp - 2);
 	});
+
+	it('should not tighten the pokemon\'s focus when Dynamaxing', function () {
+		battle = common.createBattle();
+		battle.setPlayer('p1', {team: [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]});
+		battle.setPlayer('p2', {team: [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf', 'toxic']}]});
+
+		battle.makeChoices('move focuspunch dynamax', 'move magicalleaf');
+		const tighteningFocusMessage = battle.log.filter(str => str === '|-singleturn|p1a: Chansey|move: Focus Punch');
+
+		assert.strictEqual(tighteningFocusMessage.length, 0);
+	});
+
+	it('should not tighten the pokemon\'s focus when already Dynamaxed', function () {
+		battle = common.createBattle();
+		battle.setPlayer('p1', {team: [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]});
+		battle.setPlayer('p2', {team: [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf', 'toxic']}]});
+
+		battle.makeChoices('move focuspunch dynamax', 'move magicalleaf');
+		battle.makeChoices('move focuspunch', 'move magicalleaf');
+		const tighteningFocusMessage = battle.log.filter(str => str === '|-singleturn|p1a: Chansey|move: Focus Punch');
+		assert.strictEqual(tighteningFocusMessage.length, 0);
+	});
+
+	it('should tighten the pokemon\'s focus when not Dynamaxed', function () {
+		battle = common.createBattle();
+		battle.setPlayer('p1', {team: [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]});
+		battle.setPlayer('p2', {team: [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf', 'toxic']}]});
+
+		battle.makeChoices('move focuspunch', 'move magicalleaf');
+		const tighteningFocusMessage = battle.log.filter(str => str === '|-singleturn|p1a: Chansey|move: Focus Punch');
+		assert.strictEqual(tighteningFocusMessage.length, 1);
+	});
 });


### PR DESCRIPTION
PR for https://github.com/smogon/pokemon-showdown/projects/3#card-29862179

~~Check the current turn's queued messages to see if the pokemon in question will be Dynamaxing this turn or not. If it is Dynamaxing, do not tighten the focus. It will be converted into Max Knuckle later.~~ Now checks all moves during resolution, and lets the `runDynamax` mechanic handle move resolution if the move is considered a Max Move.

I've tested it locally of course. If there's anything else, feel free to leave a comment :)