### PR TITLE
feat: Make alts configurable on a per server basis for tournaments

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -372,6 +372,7 @@ exports.customavatars = {
  * tourroom - specify a room to receive tournament announcements (defaults to
  * the room 'tournaments').
  * tourannouncements - announcements are only allowed in these rooms
+ * touralts - whether or not alts are allowed in a tournament
  * tourdefaultplayercap - a set cap of how many players can be in a tournament
  * ratedtours - toggles tournaments being ladder rated (true) or not (false)
  */
@@ -379,6 +380,7 @@ exports.tourroom = '';
 /** @type {string[]} */
 exports.tourannouncements = [/* roomids */];
 exports.tourdefaultplayercap = 0;
+exports.touralts = false;
 exports.ratedtours = false;
 
 /**

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -16,7 +16,6 @@ const AUTO_START_MINIMUM_TIMEOUT = 30 * 1000;
 const MAX_REASON_LENGTH = 300;
 const MAX_CUSTOM_NAME_LENGTH = 100;
 const TOURBAN_DURATION = 14 * 24 * 60 * 60 * 1000;
-const ALLOW_ALTS = false;
 
 Punishments.roomPunishmentTypes.set('TOURBAN', 'banned from tournaments');
 
@@ -380,7 +379,7 @@ export class Tournament extends Rooms.RoomGame {
 			return;
 		}
 
-		if (!ALLOW_ALTS) {
+		if (!Config.touralts) {
 			for (const otherPlayer of this.players) {
 				if (!otherPlayer) continue;
 				const otherUser = Users.get(otherPlayer.id);
@@ -460,7 +459,7 @@ export class Tournament extends Rooms.RoomGame {
 			output.errorReply(`${replacementUser.name} is banned from joining tournaments.`);
 			return;
 		}
-		if (!ALLOW_ALTS) {
+		if (!Config.touralts) {
 			for (const otherPlayer of this.players) {
 				if (!otherPlayer) continue;
 				const otherUser = Users.get(otherPlayer.id);


### PR DESCRIPTION
A server I use has to have this off because we often having people playing from the same household. It's not a large server (< 10 people) so it's fine for our use case.

Are there objections to making this configurable? 