### PR TITLE
Battle Stadium: Allow Season 2 Gmaxes

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -183,8 +183,12 @@ let Formats = [
 		ruleset: ['Obtainable', 'Standard GBU'],
 		minSourceGen: 8,
 		onBegin() {
+			const allowedGigantamaxes = [
+				"Charizard", "Butterfree", "Pikachu", "Meowth", "Eevee", "Snorlax",
+				"Corviknight", "Dreadnaw", "Sandaconda", "Centiscorch",
+			];
 			for (const pokemon of this.getAllPokemon()) {
-				pokemon.canGigantamax = null;
+				if (allowedGigantamaxes.indexOf(pokemon.species) === -1) pokemon.canGigantamax = null;
 			}
 		},
 	},
@@ -278,8 +282,12 @@ let Formats = [
 		ruleset: ['Obtainable', 'Standard GBU'],
 		minSourceGen: 8,
 		onBegin() {
+			const allowedGigantamaxes = [
+				"Charizard", "Butterfree", "Pikachu", "Meowth", "Eevee", "Snorlax",
+				"Corviknight", "Dreadnaw", "Sandaconda", "Centiscorch",
+			];
 			for (const pokemon of this.getAllPokemon()) {
-				pokemon.canGigantamax = null;
+				if (allowedGigantamaxes.indexOf(pokemon.species) === -1) pokemon.canGigantamax = null;
 			}
 		},
 	},

--- a/config/formats.js
+++ b/config/formats.js
@@ -188,7 +188,7 @@ let Formats = [
 				"Corviknight", "Dreadnaw", "Sandaconda", "Centiscorch",
 			];
 			for (const pokemon of this.getAllPokemon()) {
-				if (allowedGigantamaxes.indexOf(pokemon.species) === -1) pokemon.canGigantamax = null;
+				if (!allowedGigantamaxes.includes(pokemon.species)) pokemon.canGigantamax = null;
 			}
 		},
 	},
@@ -287,7 +287,7 @@ let Formats = [
 				"Corviknight", "Dreadnaw", "Sandaconda", "Centiscorch",
 			];
 			for (const pokemon of this.getAllPokemon()) {
-				if (allowedGigantamaxes.indexOf(pokemon.species) === -1) pokemon.canGigantamax = null;
+				if (!allowedGigantamaxes.includes(pokemon.species)) pokemon.canGigantamax = null;
 			}
 		},
 	},

--- a/config/formats.js
+++ b/config/formats.js
@@ -184,8 +184,8 @@ let Formats = [
 		minSourceGen: 8,
 		onBegin() {
 			const allowedGigantamaxes = [
-				"Charizard", "Butterfree", "Pikachu", "Meowth", "Eevee", "Snorlax",
-				"Corviknight", "Dreadnaw", "Sandaconda", "Centiscorch",
+				"Charizard-Gmax", "Butterfree-Gmax", "Pikachu-Gmax", "Meowth-Gmax", "Eevee-Gmax", "Snorlax-Gmax",
+				"Corviknight-Gmax", "Dreadnaw-Gmax", "Sandaconda-Gmax", "Centiskorch-Gmax",
 			];
 			for (const pokemon of this.getAllPokemon()) {
 				if (!allowedGigantamaxes.includes(pokemon.species)) pokemon.canGigantamax = null;
@@ -283,8 +283,8 @@ let Formats = [
 		minSourceGen: 8,
 		onBegin() {
 			const allowedGigantamaxes = [
-				"Charizard", "Butterfree", "Pikachu", "Meowth", "Eevee", "Snorlax",
-				"Corviknight", "Dreadnaw", "Sandaconda", "Centiscorch",
+				"Charizard-Gmax", "Butterfree-Gmax", "Pikachu-Gmax", "Meowth-Gmax", "Eevee-Gmax", "Snorlax-Gmax",
+				"Corviknight-Gmax", "Dreadnaw-Gmax", "Sandaconda-Gmax", "Centiskorch-Gmax",
 			];
 			for (const pokemon of this.getAllPokemon()) {
 				if (!allowedGigantamaxes.includes(pokemon.species)) pokemon.canGigantamax = null;


### PR DESCRIPTION
Season 2 of on-cart Battle Stadium unbans select Gmaxes, as per https://www.pokemon.com/us/pokemon-news/clash-with-gigantamax-pokemon-for-great-prizes-in-ranked-battles-january-season/