### PR TITLE
Dynamax Cannon now targets both foes instead of just one in doubles

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -4369,7 +4369,7 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {protect: 1},
 		secondary: null,
-		target: "normal",
+		target: "allAdjacentFoes",
 		type: "Dragon",
 	},
 	"dynamicpunch": {

--- a/test/sim/moves/dynamaxcannon.js
+++ b/test/sim/moves/dynamaxcannon.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Dynamax Cannon', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should hit all enemy targets in doubles', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [
+			{species: 'Eternatus', ability: 'pressure', moves: ['dynamaxcannon']},
+			{species: 'Clefairy', ability: 'pressure', moves: ['softboiled']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Perrserker', ability: 'battlearmor', moves: ['honeclaws']},
+			{species: 'Perrserker', ability: 'battlearmor', moves: ['honeclaws']},
+		]});
+		battle.makeChoices('move dynamaxcannon, move softboiled', 'move honeclaws, move honeclaws');
+		assert.false.fullHP(battle.p2.active[0]);
+		assert.false.fullHP(battle.p2.active[1]);
+	});
+});


### PR DESCRIPTION
This fixes https://github.com/smogon/pokemon-showdown/projects/3#card-29789538