### PR TITLE
Fix interaction between Court Change, Sticky Web, and Defiant or Competitive

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -18333,7 +18333,7 @@ let BattleMovedex = {
 				if (!pokemon.isGrounded()) return;
 				if (pokemon.hasItem('heavydutyboots')) return;
 				this.add('-activate', pokemon, 'move: Sticky Web');
-				this.boost({spe: -1}, pokemon, pokemon.side.foe.active[0], this.dex.getActiveMove('stickyweb'));
+				this.boost({spe: -1}, pokemon, this.effectData.source, this.dex.getActiveMove('stickyweb'));
 			},
 		},
 		secondary: null,


### PR DESCRIPTION
As discovered by a Pokétuber, if you use Court Change to move the webs you set on your opponent's side to your side, they're still your webs, so they don't trigger Defiant or Competitive. (Contrary still works of course.)