### PR TITLE
Formats: Update Doubles OU and VGC 2019

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -1325,6 +1325,7 @@ let Formats = [
 
 		mod: 'gen7',
 		gameType: 'doubles',
+		searchShow: false,
 		forcedLevel: 50,
 		teamLength: {
 			validate: [4, 6],

--- a/config/formats.js
+++ b/config/formats.js
@@ -222,7 +222,7 @@ let Formats = [
 
 		mod: 'gen8',
 		gameType: 'doubles',
-		ruleset: ['Standard Doubles'],
+		ruleset: ['Standard Doubles', '!Evasion Abilities Clause'],
 		banlist: ['DUber'],
 	},
 	{

--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -67,7 +67,7 @@ let BattleFormats = {
 		effectType: 'ValidatorRule',
 		name: 'Standard Doubles',
 		desc: "The standard ruleset for all official Smogon doubles tiers",
-		ruleset: ['Obtainable', 'Team Preview', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Evasion Abilities Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],
+		ruleset: ['Obtainable', 'Team Preview', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],
 	},
 	standardnatdex: {
 		effectType: 'ValidatorRule',

--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -67,7 +67,7 @@ let BattleFormats = {
 		effectType: 'ValidatorRule',
 		name: 'Standard Doubles',
 		desc: "The standard ruleset for all official Smogon doubles tiers",
-		ruleset: ['Obtainable', 'Team Preview', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],
+		ruleset: ['Obtainable', 'Team Preview', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Evasion Abilities Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],
 	},
 	standardnatdex: {
 		effectType: 'ValidatorRule',


### PR DESCRIPTION
https://www.smogon.com/forums/threads/sword-and-shield-tiering-announcements.3657492/#post-8335366

[06:56] @ DaWoblefet: oh hey, The Immortal, you can remove Ultra Series as a ladder format whenever you want
[06:56] @ DaWoblefet: all tournaments for it are over

[13:24] +Pokesartoolcay: Hey, Kris
[13:24] +Kris: hi
[13:25] +Pokesartoolcay: 2v2 Doubles is fine with not having evasion abilities clause
[13:25] +Pokesartoolcay: -Resident 2v2 TL