### PR TITLE
Re-add Evasion Abilities Clause to Gen 6/7 DOU

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -1303,7 +1303,7 @@ let Formats = [
 
 		mod: 'gen7',
 		gameType: 'doubles',
-		ruleset: ['Standard Doubles', 'Swagger Clause'],
+		ruleset: ['Standard Doubles', 'Evasion Abilities Clause', 'Swagger Clause'],
 		banlist: ['DUber', 'Power Construct', 'Eevium Z', 'Dark Void', 'Gravity ++ Grass Whistle', 'Gravity ++ Hypnosis', 'Gravity ++ Lovely Kiss', 'Gravity ++ Sing', 'Gravity ++ Sleep Powder'],
 	},
 	{
@@ -1612,7 +1612,7 @@ let Formats = [
 		mod: 'gen6',
 		gameType: 'doubles',
 		searchShow: false,
-		ruleset: ['Standard Doubles', 'Swagger Clause'],
+		ruleset: ['Standard Doubles', 'Evasion Abilities Clause', 'Swagger Clause'],
 		banlist: ['DUber', 'Soul Dew', 'Dark Void', 'Gravity ++ Grass Whistle', 'Gravity ++ Hypnosis', 'Gravity ++ Lovely Kiss', 'Gravity ++ Sing', 'Gravity ++ Sleep Powder'],
 	},
 	{


### PR DESCRIPTION
When @TheImmortal removed Evasion Abilities Clause, it wasn't re-added back to Gen 7 and Gen 6 DOU which should have the clause (Gen 5 already has it). DOU tier leaders confirm it should only be removed from Gen 8. According to Pokesartoolcay, 2v2 Doubles doesn't need Evasion Abilities Clause so I did not re-add it there.
![image](https://user-images.githubusercontent.com/23667022/72033669-96660280-3258-11ea-9070-959c8c8dd70b.png)
