### PR TITLE
Improve Dragon Darts

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -4121,9 +4121,6 @@ let BattleMovedex = {
 			// We need to do this before targeting is calculated.
 			pokemon.addVolatile('smarttarget');
 		},
-		onModifyMove(move, pokemon, target) {
-			if (target.side.active.length === 2) move.spreadModifier = 1;
-		},
 		target: "normal",
 		type: "Dragon",
 		gmaxPower: 130,

--- a/data/moves.js
+++ b/data/moves.js
@@ -4116,20 +4116,13 @@ let BattleMovedex = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		multihit: 2,
 		secondary: null,
+		beforeMoveCallback(pokemon) {
+			// We need to do this before targeting is calculated.
+			pokemon.addVolatile('smarttarget');
+		},
 		onModifyMove(move, pokemon, target) {
-			if (target.side.active.length === 2) {
-				move.multihit = 1;
-				move.spreadModifier = 1;
-				move.target = "allAdjacentFoes";
-				for (const currentTarget of target.side.active) {
-					if (currentTarget.volatiles['protect'] || !currentTarget.runImmunity('Dragon') || currentTarget.fainted) {
-						move.multihit = 2;
-						break;
-					}
-				}
-			}
+			if (target.side.active.length === 2) move.spreadModifier = 1;
 		},
 		target: "normal",
 		type: "Dragon",

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -462,6 +462,30 @@ let BattleStatuses = {
 			return this.chainModify([0x14CD, 0x1000]);
 		},
 	},
+	smarttarget: {
+		name: 'smarttarget',
+		id: 'smarttarget',
+		num: 0,
+		duration: 1,
+		onRedirectTargetPriority: -1,
+		onRedirectTarget(target, source, source2, move) {
+			// Calculate smart targeting, goes last to allow redirection moves to override smart targeting
+			let targets = source.nearbyFoes();
+			// Handle singles/empty slots in doubles
+			if (targets.length === 1) targets.push(targets[0]);
+			// Smart target moves like Dragon Darts will avoid hitting pokemon that would not be damaged (if not force redirected)
+			for (let i = 0; i < targets.length; i++) {
+				const potentialTarget = targets[i];
+				if (potentialTarget.volatiles['protect'] || !potentialTarget.runImmunity(move.type) || potentialTarget.fainted) {
+					// Target the other pokemon twice
+					targets.splice(i, 1);
+					targets.push(targets[0]);
+					break;
+				}
+			}
+			return targets;
+		},
+	},
 
 	// weather is implemented here since it's so important to the game
 

--- a/data/statuses.js
+++ b/data/statuses.js
@@ -476,7 +476,8 @@ let BattleStatuses = {
 			// Smart target moves like Dragon Darts will avoid hitting pokemon that would not be damaged (if not force redirected)
 			for (let i = 0; i < targets.length; i++) {
 				const potentialTarget = targets[i];
-				if (potentialTarget.volatiles['protect'] || !potentialTarget.runImmunity(move.type) || potentialTarget.fainted) {
+				let invulrabilities = this.runEvent('Invulnerability', [potentialTarget], source, move).includes(false);
+				if (potentialTarget.volatiles['protect'] || invulrabilities || !potentialTarget.runImmunity(move.type) || potentialTarget.fainted) {
 					// Target the other pokemon twice
 					targets.splice(i, 1);
 					targets.push(targets[0]);

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -250,7 +250,7 @@ interface EventMethods {
 	onNegateImmunity?: ((this: Battle, pokemon: Pokemon, type: string) => boolean | void) | boolean
 	onOverrideAction?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => string | void
 	onPrepareHit?: CommonHandlers['ResultSourceMove']
-	onRedirectTarget?: (this: Battle, target: Pokemon, source: Pokemon, source2: Effect, move: ActiveMove) => Pokemon | void
+	onRedirectTarget?: (this: Battle, target: Pokemon, source: Pokemon, source2: Effect, move: ActiveMove) => Pokemon | Pokemon[] | void
 	onResidual?: (this: Battle, target: Pokemon & Side, source: Pokemon, effect: Effect) => void
 	onSetAbility?: (this: Battle, ability: string, target: Pokemon, source: Pokemon, effect: Effect) => boolean | void
 	onSetStatus?: (this: Battle, status: PureEffect, target: Pokemon, source: Pokemon, effect: Effect) => boolean | null | void

--- a/test/sim/moves/dragondarts.js
+++ b/test/sim/moves/dragondarts.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Dragon Darts', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should hit both foes in doubles if they would take damage', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [{species: "Dragapult", ability: "Clear Body", moves: ["dragondarts"]}, {species: "Ludicolo", ability: "Dancer", moves: ["sleeptalk"]}]});
+		battle.setPlayer('p2', {team: [{species: "Arcanine", ability: "Flash Fire", moves: ["sleeptalk"]}, {species: "Appletun", ability: "Ripen", moves: ["sleeptalk"]}]});
+		battle.makeChoices('move dragondarts 1, move sleeptalk', 'move sleeptalk, move sleeptalk');
+
+		assert.strictEqual(battle.p2.pokemon[0].hp !== battle.p2.pokemon[0].maxhp, true);
+		assert.strictEqual(battle.p2.pokemon[1].hp !== battle.p2.pokemon[1].maxhp, true);
+	});
+
+	it('should hit one target twice if the other is immunue', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [{species: "Dragapult", ability: "Clear Body", moves: ["dragondarts"]}, {species: "Ludicolo", ability: "Dancer", moves: ["sleeptalk"]}]});
+		battle.setPlayer('p2', {team: [{species: "Arcanine", ability: "Flash Fire", moves: ["sleeptalk"]}, {species: "Clefairy", ability: "Ripen", moves: ["sleeptalk"]}]});
+		battle.makeChoices('move dragondarts 2, move sleeptalk', 'move sleeptalk, move sleeptalk');
+
+		assert.strictEqual(battle.p2.pokemon[0].hp !== battle.p2.pokemon[0].maxhp, true);
+		assert.strictEqual(battle.p2.pokemon[1].hp !== battle.p2.pokemon[1].maxhp, false);
+	});
+
+	it('should hit one target twice if the other is using a protect like move', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [{species: "Dragapult", ability: "Clear Body", moves: ["dragondarts"]}, {species: "Ludicolo", ability: "Dancer", moves: ["sleeptalk"]}]});
+		battle.setPlayer('p2', {team: [{species: "Arcanine", ability: "Flash Fire", moves: ["sleeptalk"]}, {species: "Porygon2", ability: "Ripen", moves: ["protect"]}]});
+		battle.makeChoices('move dragondarts 2, move sleeptalk', 'move sleeptalk, move protect');
+
+		assert.strictEqual(battle.p2.pokemon[0].hp !== battle.p2.pokemon[0].maxhp, true);
+		assert.strictEqual(battle.p2.pokemon[1].hp !== battle.p2.pokemon[1].maxhp, false);
+	});
+
+	it('should hit one target twice if the other is semi-invulnrable', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [{species: "Dragapult", item: "Lagging Tail", ability: "Clear Body", moves: ["dragondarts"]}, {species: "Ludicolo", ability: "Dancer", moves: ["sleeptalk"]}]});
+		battle.setPlayer('p2', {team: [{species: "Arcanine", ability: "Flash Fire", moves: ["sleeptalk"]}, {species: "Golurk", ability: "Ripen", moves: ["phantomforce"]}]});
+		battle.makeChoices('move dragondarts 2, move sleeptalk', 'move sleeptalk, move phantomforce 1');
+
+		assert.strictEqual(battle.p2.pokemon[0].hp !== battle.p2.pokemon[0].maxhp, true);
+		assert.strictEqual(battle.p2.pokemon[1].hp !== battle.p2.pokemon[1].maxhp, false);
+	});
+
+	it('should hit one target twice if the other is fainted', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [{species: "Dragapult", ability: "Clear Body", moves: ["dragondarts"]}, {species: "Ludicolo", ability: "Dancer", moves: ["sleeptalk"]}]});
+		battle.setPlayer('p2', {team: [{species: "Arcanine", ability: "Flash Fire", moves: ["sleeptalk"]}, {species: "Snom", ability: "Ripen", moves: ["sleeptalk"]}]});
+
+		battle.p2.pokemon[1].faint();
+		battle.makeChoices('move dragondarts 2, move sleeptalk', 'move sleeptalk, move sleeptalk');
+
+		assert.strictEqual(battle.p2.pokemon[0].hp !== battle.p2.pokemon[0].maxhp, true);
+		assert.strictEqual(battle.p2.pokemon[1].hp !== 0, false);
+	});
+
+	it('when redirected should hit the target it was redirected to twice', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [{species: "Dragapult", ability: "Clear Body", moves: ["dragondarts"]}, {species: "Ludicolo", ability: "Dancer", moves: ["sleeptalk"]}]});
+		battle.setPlayer('p2', {team: [{species: "Arcanine", ability: "Flash Fire", moves: ["sleeptalk"]}, {species: "Cacturne", ability: "Ripen", moves: ["followme"]}]});
+		battle.makeChoices('move dragondarts 1, move sleeptalk', 'move sleeptalk, move followme');
+
+		assert.strictEqual(battle.p2.pokemon[0].hp !== battle.p2.pokemon[0].maxhp, false);
+		assert.strictEqual(battle.p2.pokemon[1].hp !== battle.p2.pokemon[1].maxhp, true);
+	});
+
+	it('should fail if both targets are fainted', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [{species: "Dragapult", ability: "Clear Body", moves: ["dragondarts"]}, {species: "Ludicolo", ability: "Dancer", moves: ["celebrate"]}]});
+		battle.setPlayer('p2', {team: [{species: "Arcanine", ability: "Flash Fire", moves: ["celebrate"]}, {species: "Arcanine", ability: "Flash Fire", moves: ["celebrate"]}, {species: "Arcanine", ability: "Flash Fire", moves: ["celebrate"]}]});
+
+		battle.p2.pokemon[0].faint();
+		battle.p2.pokemon[1].faint();
+		battle.makeChoices('move dragondarts 1, move celebrate', 'move celebrate, move celebrate');
+
+		assert.strictEqual(battle.log.includes(`|-fail|p1a: Dragapult`), true);
+	});
+
+	it('should hit the target twice in singles', function () {
+		battle = common.createBattle();
+		battle.setPlayer('p1', {team: [{species: "Dragapult", ability: "Clear Body", moves: ["dragondarts"]}]});
+		battle.setPlayer('p2', {team: [{species: "Arcanine", ability: "Flash Fire", moves: ["sleeptalk"]}]});
+		battle.makeChoices('move dragondarts', 'move sleeptalk');
+
+		assert.strictEqual(battle.p2.pokemon[0].hp !== battle.p2.pokemon[0].maxhp, true);
+	});
+});


### PR DESCRIPTION
This moves most of dragon dart's logic to `Pokemon.getMovetargets` by giving a new move target type called `allFoesSmart` (Feel free to bikeshed about the name, I'm not too attatched).

Put this up as a draft since I need to do something about being unable to tell if a move's target was forcibly changed during a `RedirectTarget` event. Looking for feedback/assistance on this.