### PR TITLE
VGC 2020 Validator - Charizard-GMax Fix

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -252,7 +252,7 @@ let Formats = [
 		},
 		ruleset: ['Standard GBU', 'VGC Timer'],
 		banlist: [
-			'Alcremie-Gmax', 'Appletun-Gmax', 'Charizard-Gmax ++ Solar Power', 'Coalossal-Gmax', 'Copperajah-Gmax',
+			'Alcremie-Gmax', 'Appletun-Gmax', 'Charizard-Gmax + Solar Power', 'Coalossal-Gmax', 'Copperajah-Gmax',
 			'Duraludon-Gmax', 'Flapple-Gmax', 'Garbodor-Gmax', 'Gengar-Gmax', 'Grimmsnarl-Gmax', 'Hatterene-Gmax',
 			'Kingler-Gmax', 'Lapras-Gmax', 'Machamp-Gmax', 'Melmetal-Gmax', 'Orbeetle-Gmax', 'Slowpoke-Galar',
 			'Toxtricity-Gmax',


### PR DESCRIPTION
Only Charizard with Solar Power is banned, not the combination of Charizard and another Pokemon with Solar Power.