### PR TITLE
Simplify handling of Encore volatile

### DIFF
--- a/data/mods/gen2/moves.js
+++ b/data/mods/gen2/moves.js
@@ -248,8 +248,7 @@ let BattleMovedex = {
 				if (!target.lastMove || noEncore.includes(target.lastMove.id) || !target.moveSlots[moveIndex] || target.moveSlots[moveIndex].pp <= 0) {
 					// it failed
 					this.add('-fail', target);
-					delete target.volatiles['encore'];
-					return;
+					return false;
 				}
 				this.effectData.move = target.lastMove.id;
 				this.add('-start', target, 'Encore');
@@ -264,8 +263,7 @@ let BattleMovedex = {
 			onResidual(target) {
 				if (target.moves.includes(this.effectData.move) && target.moveSlots[target.moves.indexOf(this.effectData.move)].pp <= 0) {
 					// early termination if you run out of PP
-					delete target.volatiles.encore;
-					this.add('-end', target, 'Encore');
+					target.removeVolatile('encore');
 				}
 			},
 			onEnd(target) {

--- a/data/mods/gen3/moves.js
+++ b/data/mods/gen3/moves.js
@@ -361,8 +361,7 @@ let BattleMovedex = {
 					// it failed
 					this.add('-fail', source);
 					this.attrLastMove('[still]');
-					delete target.volatiles['encore'];
-					return;
+					return false;
 				}
 				this.effectData.move = target.lastMove.id;
 				this.add('-start', target, 'Encore');
@@ -377,8 +376,7 @@ let BattleMovedex = {
 			onResidual(target) {
 				if (target.moves.includes(this.effectData.move) && target.moveSlots[target.moves.indexOf(this.effectData.move)].pp <= 0) {
 					// early termination if you run out of PP
-					delete target.volatiles.encore;
-					this.add('-end', target, 'Encore');
+					target.removeVolatile('encore');
 				}
 			},
 			onEnd(target) {

--- a/data/mods/gen4/moves.js
+++ b/data/mods/gen4/moves.js
@@ -523,8 +523,7 @@ let BattleMovedex = {
 					// it failed
 					this.add('-fail', source);
 					this.attrLastMove('[still]');
-					delete target.volatiles['encore'];
-					return;
+					return false;
 				}
 				this.effectData.move = target.lastMove.id;
 				this.add('-start', target, 'Encore');
@@ -539,8 +538,7 @@ let BattleMovedex = {
 			onResidual(target) {
 				if (target.moves.includes(this.effectData.move) && target.moveSlots[target.moves.indexOf(this.effectData.move)].pp <= 0) {
 					// early termination if you run out of PP
-					delete target.volatiles.encore;
-					this.add('-end', target, 'Encore');
+					target.removeVolatile('encore');
 				}
 			},
 			onEnd(target) {

--- a/data/mods/gen6/moves.js
+++ b/data/mods/gen6/moves.js
@@ -81,7 +81,6 @@ let BattleMovedex = {
 				let moveIndex = target.lastMove ? target.moves.indexOf(target.lastMove.id) : -1;
 				if (!target.lastMove || noEncore.includes(target.lastMove.id) || !target.moveSlots[moveIndex] || target.moveSlots[moveIndex].pp <= 0) {
 					// it failed
-					delete target.volatiles['encore'];
 					return false;
 				}
 				this.effectData.move = target.lastMove.id;
@@ -96,8 +95,7 @@ let BattleMovedex = {
 			onResidualOrder: 13,
 			onResidual(target) {
 				if (target.moves.includes(this.effectData.move) && target.moveSlots[target.moves.indexOf(this.effectData.move)].pp <= 0) { // early termination if you run out of PP
-					delete target.volatiles.encore;
-					this.add('-end', target, 'Encore');
+					target.removeVolatile('encore');
 				}
 			},
 			onEnd(target) {

--- a/data/moves.js
+++ b/data/moves.js
@@ -4745,7 +4745,6 @@ let BattleMovedex = {
 				let moveIndex = move ? target.moves.indexOf(move.id) : -1;
 				if (!move || move.isZ || move.isMax || target.volatiles['dynamax'] || noEncore.includes(move.id) || !target.moveSlots[moveIndex] || target.moveSlots[moveIndex].pp <= 0) {
 					// it failed
-					delete target.volatiles['encore'];
 					return false;
 				}
 				this.effectData.move = move.id;
@@ -4761,8 +4760,7 @@ let BattleMovedex = {
 			onResidual(target) {
 				if (target.moves.includes(this.effectData.move) && target.moveSlots[target.moves.indexOf(this.effectData.move)].pp <= 0) {
 					// early termination if you run out of PP
-					delete target.volatiles.encore;
-					this.add('-end', target, 'Encore');
+					target.removeVolatile('encore');
 				}
 			},
 			onEnd(target) {


### PR DESCRIPTION
- Prior to Gen 6, the Encore volatile's `onStart` handler forcibly removes the volatile if it detects a failure condition. Starting in Gen 6, it also returns `false`, which would automatically cancel the volatile, except that it's still forcibly removed it. All these occurrences have been changed to just return `false`.
- When the Encore needs to be aborted, the current code always forcibly removes the volatile and then manually sends the `-end` message to the client. However, the volatile's `onEnd` handler already sends the message, so the volatile can just be removed normally.