### PR TITLE
Fix Healing Wish for Gen 8

### DIFF
--- a/data/mods/gen7/moves.js
+++ b/data/mods/gen7/moves.js
@@ -395,6 +395,23 @@ let BattleMovedex = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	"healingwish": {
+		inherit: true,
+		desc: "The user faints and the Pokemon brought out to replace it has its HP fully restored along with having any major status condition cured. The new Pokemon is sent out at the end of the turn, and the healing happens before hazards take effect. Fails if the user is the last unfainted Pokemon in its party.",
+		shortDesc: "User faints. Replacement is fully healed.",
+		effect: {
+			duration: 2,
+			onSwitchInPriority: 1,
+			onSwitchIn(target) {
+				if (!target.fainted) {
+					target.heal(target.maxhp);
+					target.setStatus('');
+					this.add('-heal', target, target.getHealth, '[from] move: Healing Wish');
+					target.side.removeSlotCondition(target, 'healingwish');
+				}
+			},
+		},
+	},
 	healorder: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/moves.js
+++ b/data/moves.js
@@ -8373,8 +8373,8 @@ let BattleMovedex = {
 		accuracy: true,
 		basePower: 0,
 		category: "Status",
-		desc: "The user faints and the Pokemon brought out to replace it has its HP fully restored along with having any major status condition cured. The new Pokemon is sent out at the end of the turn, and the healing happens before hazards take effect. Fails if the user is the last unfainted Pokemon in its party.",
-		shortDesc: "User faints. Replacement is fully healed.",
+		desc: "The user faints and the next injured or statused Pokemon brought in has its HP fully restored along with having any major status condition cured. The healing happens before hazards take effect. Is not consumed if the Pokemon sent out is not injured or statused. Fails if the user is the last unfainted Pokemon in its party.",
+		shortDesc: "User faints. Next hurt Pokemon is fully healed.",
 		id: "healingwish",
 		isViable: true,
 		name: "Healing Wish",
@@ -8390,10 +8390,8 @@ let BattleMovedex = {
 		selfdestruct: "ifHit",
 		slotCondition: 'healingwish',
 		effect: {
-			duration: 2,
-			onSwitchInPriority: 1,
-			onSwitchIn(target) {
-				if (!target.fainted) {
+			onSwap(target) {
+				if (!target.fainted && (target.hp < target.maxhp || target.status)) {
 					target.heal(target.maxhp);
 					target.setStatus('');
 					this.add('-heal', target, target.getHealth, '[from] move: Healing Wish');

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1320,6 +1320,7 @@ export class Battle {
 		this.add('drag', pokemon, pokemon.getDetails);
 		if (this.gen >= 5) {
 			this.singleEvent('PreStart', pokemon.getAbility(), pokemon.abilityData, pokemon);
+			this.runEvent('Swap', pokemon);
 			this.runEvent('SwitchIn', pokemon);
 			if (!pokemon.hp) return true;
 			pokemon.isStarted = true;
@@ -1349,6 +1350,8 @@ export class Battle {
 		side.active[slot] = side.pokemon[slot];
 		if (target) target.position = pokemon.position;
 		pokemon.position = slot;
+		this.runEvent('Swap', target, pokemon);
+		this.runEvent('Swap', pokemon, target);
 		return true;
 	}
 
@@ -2723,6 +2726,7 @@ export class Battle {
 			this.singleEvent('PreStart', action.pokemon.getAbility(), action.pokemon.abilityData, action.pokemon);
 			break;
 		case 'runSwitch':
+			this.runEvent('Swap', action.pokemon);
 			this.runEvent('SwitchIn', action.pokemon);
 			if (this.gen <= 2 && !action.pokemon.side.faintedThisTurn && action.pokemon.draggedIn !== this.turn) {
 				this.runEvent('AfterSwitchInSelf', action.pokemon);

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -258,6 +258,7 @@ interface EventMethods {
 	onStallMove?: (this: Battle, pokemon: Pokemon) => boolean | void
 	onSwitchIn?: (this: Battle, pokemon: Pokemon) => void
 	onSwitchOut?: (this: Battle, pokemon: Pokemon) => void
+	onSwap?: (this: Battle, target: Pokemon, source: Pokemon) => void
 	onTakeItem?: ((this: Battle, item: Item, pokemon: Pokemon, source: Pokemon, move?: ActiveMove) => boolean | void) | boolean
 	onTerrain?: (this: Battle, pokemon: Pokemon) => void
 	onTerrainStart?: (this: Battle, target: Pokemon, source: Pokemon, terrain: PureEffect) => void

--- a/test/sim/moves/healingwish.js
+++ b/test/sim/moves/healingwish.js
@@ -35,6 +35,47 @@ describe('Healing Wish', function () {
 		assert.strictEqual(battle.p1.active[0].moveSlots[0].pp, 63);
 	});
 
+	it('should not be consumed if a switch-in is fully healed already', function () {
+		battle = common.createBattle();
+		battle.setPlayer('p1', {team: [
+			{species: 'Jirachi', ability: 'serenegrace', moves: ['healingwish', 'protect']},
+			{species: 'Caterpie', ability: 'shielddust', moves: ['stringshot']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Tyranitar', ability: 'sandstream', moves: ['seismictoss', 'stealthrock']},
+		]});
+		battle.makeChoices('move Protect', 'move Stealth Rock'); // set up Sand and Stealth Rock
+
+		battle.makeChoices('move Healing Wish', 'move Seismic Toss');
+
+		// sand happens after Jirachi faints and before any switch-in
+		battle.makeChoices('switch Caterpie', ''); // Caterpie does not consume Healing Wish
+		assert(battle.p1.slotConditions[0]['healingwish']);
+	});
+
+	it('should heal an ally fully after Ally Switch', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [
+			{species: 'Jirachi', ability: 'serenegrace', moves: ['healingwish']},
+			{species: 'Caterpie', ability: 'shielddust', moves: ['stringshot']},
+			{species: 'Rotom', ability: 'levitate', moves: ['allyswitch']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Garchomp', ability: 'sandveil', moves: ['sleeptalk']},
+			{species: 'Shedinja', ability: 'wonderguard', moves: ['endeavor', 'protect']},
+		]});
+		// set up Healing Wish, Caterpie is at 1 HP
+		battle.makeChoices('move Healing Wish, move String Shot', 'move Sleep Talk, move Endeavor 2');
+		// Rotom does not consume Healing Wish
+		battle.makeChoices('switch Rotom', '');
+		assert(battle.p1.slotConditions[0]['healingwish']);
+		// Caterpie gets healed by Healing Wish triggered by Ally Switch
+		battle.makeChoices('move Ally Switch, move String Shot', 'move Sleep Talk, move Protect');
+
+		assert.strictEqual(battle.p1.active[0].hp, 231); // Caterpie start in slot 1 -> Ally Switch-ed to slot 0
+		assert.false(battle.p1.slotConditions[0]['healingwish']);
+	});
+
 	it('[Gen 4] should heal a switch-in for full after hazards mid-turn', function () {
 		battle = common.gen(4).createBattle();
 		battle.setPlayer('p1', {team: [


### PR DESCRIPTION
It's been years since I did this last so idk if I did this right.

Reference https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/page-39#post-8341844

- Healing Wish is not consumed if the Pokemon switching in
  has full health and no status condition
- There is no timeout for this effect, it lasts until consumed
- Being statused with full health will consume the Healing Wish
- It does not trigger on damage after switching in
- The effect will be consumed if an injured Pokemon is swapped
  into a slot with an active Healing Wish by Ally Switch