### PR TITLE
Fix Pickpocket Eject Button Interaction

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -604,6 +604,10 @@ export class Battle {
 		if (!target) target = this;
 		let effectSource = null;
 		if (source instanceof Pokemon) effectSource = source;
+		if (eventid === 'TakeItem' && source && source.ability === 'pickpocket' && !source.item && target && target.item && target.item === 'ejectbutton') {
+			// fail pickpocket against ejectbutton
+			return false;
+		}
 		const handlers = this.findEventHandlers(target, eventid, effectSource);
 		if (eventid === 'Invulnerability' || eventid === 'TryHit' || eventid === 'AfterDamage') {
 			handlers.sort(Battle.compareLeftToRightOrder);


### PR DESCRIPTION
Fix of mechanic bug: https://github.com/smogon/pokemon-showdown/projects/3#card-25870242
If a Pokemon with Pickpocket and Eject Button is hit by a contact move, Pickpocket should not resolve to steal the opponent's item.