### PR TITLE
Fix Pickpocket Eject Button Interaction

### DIFF
--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1446,6 +1446,7 @@ export class Pokemon {
 			if (source && toID(source.ability) === 'multitype') return false;
 		}
 		const item = this.getItem();
+		if (source.ability === 'pickpocket' && item && item === 'ejectbutton') return false;
 		if (this.battle.runEvent('TakeItem', this, source, null, item)) {
 			this.item = '';
 			this.itemData = {id: '', target: this};


### PR DESCRIPTION
Fix of mechanic bug: https://github.com/smogon/pokemon-showdown/projects/3#card-25870242
If a Pokemon with Pickpocket and Eject Button is hit by a contact move, Pickpocket should not resolve to steal the opponent's item.