### PR TITLE
Fix Pickpocket Eject Button Interaction

### DIFF
--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1445,6 +1445,7 @@ export class Pokemon {
 			if (toID(this.ability) === 'multitype') return false;
 			if (source && toID(source.ability) === 'multitype') return false;
 		}
+		if (source.ability === 'pickpocket' && this.item === 'ejectbutton') return false;
 		const item = this.getItem();
 		if (this.battle.runEvent('TakeItem', this, source, null, item)) {
 			this.item = '';


### PR DESCRIPTION
Fix of mechanic bug: https://github.com/smogon/pokemon-showdown/projects/3#card-25870242
If a Pokemon with Pickpocket and Eject Button is hit by a contact move, Pickpocket should not resolve to steal the opponent's item.