### PR TITLE
Fix pickpocket eject button interaction

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2697,7 +2697,7 @@ let BattleAbilities = {
 					return;
 				}
 				let yourItem = source.takeItem(target);
-				if (!yourItem) {
+				if (!yourItem || yourItem.id === 'ejectbutton') {
 					return;
 				}
 				if (!target.setItem(yourItem)) {


### PR DESCRIPTION
Fix of mechanic bug https://github.com/smogon/pokemon-showdown/projects/3#card-25870242
If a Pokemon with Pickpocket and Eject Button is hit by a contact move, Pickpocket should not resolve to steal the opponent's item.