### PR TITLE
Allow safer and exact type retrieval of Room#game

### DIFF
--- a/server/chat-plugins/hangman.ts
+++ b/server/chat-plugins/hangman.ts
@@ -7,7 +7,7 @@
 
 const maxMistakes = 6;
 
-class Hangman extends Rooms.RoomGame {
+export class Hangman extends Rooms.RoomGame {
 	gameNumber: number;
 	creator: ID;
 	word: string;

--- a/server/chat-plugins/hangman.ts
+++ b/server/chat-plugins/hangman.ts
@@ -240,7 +240,7 @@ export const commands: ChatCommands = {
 
 		guess(target, room, user) {
 			if (!target) return this.parse('/help guess');
-			const game = room.getGame<Hangman>(Hangman);
+			const game = room.getGame(Hangman);
 			if (!game) return this.errorReply("There is no game of hangman running in this room.");
 			if (!this.canTalk()) return;
 
@@ -255,7 +255,7 @@ export const commands: ChatCommands = {
 		end(target, room, user) {
 			if (!this.can('minigame', null, room)) return false;
 			if (!this.canTalk()) return;
-			const game = room.getGame<Hangman>(Hangman);
+			const game = room.getGame(Hangman);
 			if (!game) return this.errorReply("There is no game of hangman running in this room.");
 			game.end();
 			this.modlog('ENDHANGMAN');
@@ -290,7 +290,7 @@ export const commands: ChatCommands = {
 		},
 
 		display(target, room, user) {
-			const game = room.getGame<Hangman>(Hangman);
+			const game = room.getGame(Hangman);
 			if (!game) return this.errorReply("There is no game of hangman running in this room.");
 			if (!this.runBroadcast()) return;
 			room.update();
@@ -315,7 +315,7 @@ export const commands: ChatCommands = {
 	],
 
 	guess(target, room, user) {
-		const game = room.getGame<Hangman>(Hangman);
+		const game = room.getGame(Hangman);
 		if (!game) return this.errorReply("There is no game of hangman running in this room.");
 		if (!this.canTalk()) return;
 

--- a/server/chat-plugins/hangman.ts
+++ b/server/chat-plugins/hangman.ts
@@ -240,10 +240,10 @@ export const commands: ChatCommands = {
 
 		guess(target, room, user) {
 			if (!target) return this.parse('/help guess');
-			if (!room.game || room.game.gameid !== 'hangman') return this.errorReply("There is no game of hangman running in this room.");
+			const game = room.getGame<Hangman>(Hangman);
+			if (!game) return this.errorReply("There is no game of hangman running in this room.");
 			if (!this.canTalk()) return;
 
-			const game = room.game as Hangman;
 			game.guess(target, user);
 		},
 		guesshelp: [
@@ -255,9 +255,8 @@ export const commands: ChatCommands = {
 		end(target, room, user) {
 			if (!this.can('minigame', null, room)) return false;
 			if (!this.canTalk()) return;
-			if (!room.game || room.game.gameid !== 'hangman') return this.errorReply("There is no game of hangman running in this room.");
-
-			const game = room.game as Hangman;
+			const game = room.getGame<Hangman>(Hangman);
+			if (!game) return this.errorReply("There is no game of hangman running in this room.");
 			game.end();
 			this.modlog('ENDHANGMAN');
 			return this.privateModAction(`(The game of hangman was ended by ${user.name}.)`);
@@ -291,11 +290,11 @@ export const commands: ChatCommands = {
 		},
 
 		display(target, room, user) {
-			if (!room.game || room.game.title !== 'Hangman') return this.errorReply("There is no game of hangman running in this room.");
+			const game = room.getGame<Hangman>(Hangman);
+			if (!game) return this.errorReply("There is no game of hangman running in this room.");
 			if (!this.runBroadcast()) return;
 			room.update();
 
-			const game = room.game as Hangman;
 			game.display(user, this.broadcasting);
 		},
 
@@ -316,11 +315,11 @@ export const commands: ChatCommands = {
 	],
 
 	guess(target, room, user) {
-		if (!room.game) return this.errorReply("There is no game running in this room.");
+		const game = room.getGame<Hangman>(Hangman);
+		if (!game) return this.errorReply("There is no game of hangman running in this room.");
 		if (!this.canTalk()) return;
-		if (!(room.game as Hangman).guess) return this.errorReply("You can't guess anything in this game.");
 
-		(room.game as Hangman).guess(target, user);
+		game.guess(target, user);
 	},
 	guesshelp: [
 		`/guess - Shortcut for /hangman guess.`,

--- a/server/chat-plugins/hangman.ts
+++ b/server/chat-plugins/hangman.ts
@@ -257,6 +257,7 @@ export const commands: ChatCommands = {
 			if (!this.canTalk()) return;
 			const game = room.getGame(Hangman);
 			if (!game) return this.errorReply("There is no game of hangman running in this room.");
+
 			game.end();
 			this.modlog('ENDHANGMAN');
 			return this.privateModAction(`(The game of hangman was ended by ${user.name}.)`);

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -1595,7 +1595,7 @@ export const pages: PageTable = {
 		let roomid = query.shift();
 		if (roomid === 'groupchat') roomid += `-${query.shift()}-${query.shift()}`;
 		const room = Rooms.get(roomid);
-		const game = room && room.getGame<MafiaTracker>(MafiaTracker);
+		const game = room && room.getGame(MafiaTracker);
 		if (!room || !room.users[user.id] || !game || game.ended) {
 			return this.close();
 		}
@@ -1812,7 +1812,7 @@ export const pages: PageTable = {
 export const commands: ChatCommands = {
 	mafia: {
 		''(target, room, user) {
-			const game = room.getGame<MafiaTracker>(MafiaTracker);
+			const game = room.getGame(MafiaTracker);
 			if (game) {
 				if (!this.runBroadcast()) return;
 				return this.sendReply(`|html|${game.roomWindow()}`);
@@ -1945,7 +1945,7 @@ export const commands: ChatCommands = {
 				if (!room || room.type !== 'chat') return this.errorReply(`This command is only meant to be used in chat rooms.`);
 				targetRoom = room;
 			}
-			const game = targetRoom.getGame<MafiaTracker>(MafiaTracker);
+			const game = targetRoom.getGame(MafiaTracker);
 			if (!game) return user.sendTo(targetRoom, `|error|There is no game of mafia running in this room.`);
 
 			if (!this.canTalk(null, targetRoom)) return;
@@ -1960,14 +1960,14 @@ export const commands: ChatCommands = {
 				if (!room || room.type !== 'chat') return this.errorReply(`This command is only meant to be used in chat rooms.`);
 				targetRoom = room;
 			}
-			const game = targetRoom.getGame<MafiaTracker>(MafiaTracker);
+			const game = targetRoom.getGame(MafiaTracker);
 			if (!game) return user.sendTo(targetRoom, `|error|There is no game of mafia running in this room.`);
 			game.leave(user);
 		},
 		leavehelp: [`/mafia leave - Leave the game. Can only be done while signups are open.`],
 
 		playercap(target, room, user) {
-			const game = room.getGame<MafiaTracker>(MafiaTracker);
+			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
 			if (game.phase !== 'signups') return this.errorReply(`Signups are already closed.`);
@@ -1988,7 +1988,7 @@ export const commands: ChatCommands = {
 				if (!room || room.type !== 'chat') return this.errorReply(`This command is only meant to be used in chat rooms.`);
 				targetRoom = room;
 			}
-			const game = targetRoom.getGame<MafiaTracker>(MafiaTracker);
+			const game = targetRoom.getGame(MafiaTracker);
 			if (!game) return user.sendTo(targetRoom, `|error|There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
 			if (game.phase !== 'signups') return user.sendTo(targetRoom, `|error|Signups are already closed.`);
@@ -2010,7 +2010,7 @@ export const commands: ChatCommands = {
 			} else {
 				args.shift();
 			}
-			const game = targetRoom.getGame<MafiaTracker>(MafiaTracker);
+			const game = targetRoom.getGame(MafiaTracker);
 			if (!game) return user.sendTo(targetRoom, `|error|There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
 			const action = toID(args.join(''));
@@ -2032,7 +2032,7 @@ export const commands: ChatCommands = {
 			} else {
 				args.shift();
 			}
-			const game = targetRoom.getGame<MafiaTracker>(MafiaTracker);
+			const game = targetRoom.getGame(MafiaTracker);
 			if (!game) return user.sendTo(targetRoom, `|error|There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
 			const action = toID(args.join(''));
@@ -2048,7 +2048,7 @@ export const commands: ChatCommands = {
 		forceresetroles: 'setroles',
 		forcesetroles: 'setroles',
 		setroles(target, room, user, connection, cmd) {
-			const game = room.getGame<MafiaTracker>(MafiaTracker);
+			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
 			const reset = cmd.includes('reset');
@@ -2068,7 +2068,7 @@ export const commands: ChatCommands = {
 		],
 
 		idea(target, room, user) {
-			const game = room.getGame<MafiaTracker>(MafiaTracker);
+			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (!this.can('broadcast', null, room)) return;
 			if (!user.can('mute', null, room) && game.hostid !== user.id && !game.cohosts.includes(user.id)) {
@@ -2087,7 +2087,7 @@ export const commands: ChatCommands = {
 
 		customidea(target, room, user) {
 			if (!this.can('mute', null, room)) return;
-			const game = room.getGame<MafiaTracker>(MafiaTracker);
+			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.started) return this.errorReply(`You cannot start an IDEA after the game has started.`);
 			if (game.phase !== 'locked' && game.phase !== 'IDEAlocked') return this.errorReply(`You need to close the signups first.`);
@@ -2115,7 +2115,7 @@ export const commands: ChatCommands = {
 			} else {
 				args.shift();
 			}
-			const game = targetRoom.getGame<MafiaTracker>(MafiaTracker);
+			const game = targetRoom.getGame(MafiaTracker);
 			if (!game) {
 				return user.sendTo(targetRoom, `|error|There is no game of mafia running in this room.`);
 			}
@@ -2135,7 +2135,7 @@ export const commands: ChatCommands = {
 				if (!room || room.type !== 'chat') return this.errorReply(`This command is only meant to be used in chat rooms.`);
 				targetRoom = room;
 			}
-			const game = targetRoom.getGame<MafiaTracker>(MafiaTracker);
+			const game = targetRoom.getGame(MafiaTracker);
 			if (!game) return user.sendTo(targetRoom, `|error|There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
 			game.ideaDistributeRoles(user);
@@ -2144,7 +2144,7 @@ export const commands: ChatCommands = {
 
 		discards: 'ideadiscards',
 		ideadiscards(target, room, user) {
-			const game = room.getGame<MafiaTracker>(MafiaTracker);
+			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (!game.IDEA.data) return this.errorReply(`There is no IDEA module in the mafia game.`);
 			if (target) {
@@ -2181,7 +2181,7 @@ export const commands: ChatCommands = {
 			} else {
 				target = '';
 			}
-			const game = targetRoom.getGame<MafiaTracker>(MafiaTracker);
+			const game = targetRoom.getGame(MafiaTracker);
 			if (!game) return user.sendTo(targetRoom, `|error|There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
 			if (target) {
@@ -2206,7 +2206,7 @@ export const commands: ChatCommands = {
 			} else {
 				args.shift();
 			}
-			const game = targetRoom.getGame<MafiaTracker>(MafiaTracker);
+			const game = targetRoom.getGame(MafiaTracker);
 			if (!game) return user.sendTo(targetRoom, `|error|There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
 			if (cmd === 'night') {
@@ -2239,7 +2239,7 @@ export const commands: ChatCommands = {
 			} else {
 				args.shift();
 			}
-			const game = targetRoom.getGame<MafiaTracker>(MafiaTracker);
+			const game = targetRoom.getGame(MafiaTracker);
 			if (!game) return user.sendTo(targetRoom, `|error|There is no game of mafia running in this room.`);
 			if (!this.canTalk(null, targetRoom)) return;
 			if (!(user.id in game.playerTable) &&
@@ -2260,7 +2260,7 @@ export const commands: ChatCommands = {
 				if (!room || room.type !== 'chat') return this.errorReply(`This command is only meant to be used in chat rooms.`);
 				targetRoom = room;
 			}
-			const game = targetRoom.getGame<MafiaTracker>(MafiaTracker);
+			const game = targetRoom.getGame(MafiaTracker);
 			if (!game) return user.sendTo(targetRoom, `|error|There is no game of mafia running in this room.`);
 			if (!this.canTalk(null, targetRoom)) return;
 			if (!(user.id in game.playerTable) &&
@@ -2287,7 +2287,7 @@ export const commands: ChatCommands = {
 			} else {
 				args.shift();
 			}
-			const game = targetRoom.getGame<MafiaTracker>(MafiaTracker);
+			const game = targetRoom.getGame(MafiaTracker);
 			if (!game) return user.sendTo(targetRoom, `|error|There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
 			const action = toID(args.shift());
@@ -2318,7 +2318,7 @@ export const commands: ChatCommands = {
 			} else {
 				args.shift();
 			}
-			const game = targetRoom.getGame<MafiaTracker>(MafiaTracker);
+			const game = targetRoom.getGame(MafiaTracker);
 			if (!game) return user.sendTo(targetRoom, `|error|There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
 			const player = game.playerTable[toID(args.join(''))];
@@ -2345,7 +2345,7 @@ export const commands: ChatCommands = {
 			} else {
 				args.shift();
 			}
-			const game = targetRoom.getGame<MafiaTracker>(MafiaTracker);
+			const game = targetRoom.getGame(MafiaTracker);
 			if (!game) return user.sendTo(targetRoom, `|error|There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
 			if (!toID(args.join(''))) return this.parse('/help mafia revive');
@@ -2357,7 +2357,7 @@ export const commands: ChatCommands = {
 
 		dl: 'deadline',
 		deadline(target, room, user) {
-			const game = room.getGame<MafiaTracker>(MafiaTracker);
+			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			target = toID(target);
 			if (target && game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
@@ -2386,7 +2386,7 @@ export const commands: ChatCommands = {
 
 		applylynchmodifier: 'applyhammermodifier',
 		applyhammermodifier(target, room, user, connection, cmd) {
-			const game = room.getGame<MafiaTracker>(MafiaTracker);
+			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
 			if (!game.started) return this.errorReply(`The game has not started yet.`);
@@ -2399,7 +2399,7 @@ export const commands: ChatCommands = {
 		},
 		clearlynchmodifiers: 'clearhammermodifiers',
 		clearhammermodifiers(target, room, user, connection, cmd) {
-			const game = room.getGame<MafiaTracker>(MafiaTracker);
+			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
 			if (!game.started) return this.errorReply(`The game has not started yet.`);
@@ -2452,7 +2452,7 @@ export const commands: ChatCommands = {
 
 		unsilence: 'silence',
 		silence(target, room, user, connection, cmd) {
-			const game = room.getGame<MafiaTracker>(MafiaTracker);
+			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
 			if (!game.started) return this.errorReply(`The game has not started yet.`);
@@ -2531,7 +2531,7 @@ export const commands: ChatCommands = {
 		shifthammer: 'hammer',
 		resethammer: 'hammer',
 		hammer(target, room, user, connection, cmd) {
-			const game = room.getGame<MafiaTracker>(MafiaTracker);
+			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
 			if (!game.started) return this.errorReply(`The game has not started yet.`);
@@ -2564,7 +2564,7 @@ export const commands: ChatCommands = {
 				if (!room || room.type !== 'chat') return this.errorReply(`This command is only meant to be used in chat rooms.`);
 				targetRoom = room;
 			}
-			const game = targetRoom.getGame<MafiaTracker>(MafiaTracker);
+			const game = targetRoom.getGame(MafiaTracker);
 			if (!game) return user.sendTo(targetRoom, `|error|There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
 			if (cmd === 'enablenl') {
@@ -2576,7 +2576,7 @@ export const commands: ChatCommands = {
 		enablenlhelp: [`/mafia [enablenl|disablenl] - Allows or disallows players abstain from lynching. Requires host % @ # & ~`],
 
 		forcelynch(target, room, user) {
-			const game = room.getGame<MafiaTracker>(MafiaTracker);
+			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
 			target = toID(target);
@@ -2596,7 +2596,7 @@ export const commands: ChatCommands = {
 		forcelynchhelp: [`/mafia forcelynch [yes/no] - Forces player's lynches onto themselves, and prevents unlynching. Requires host % @ # & ~`],
 
 		lynches(target, room, user) {
-			const game = room.getGame<MafiaTracker>(MafiaTracker);
+			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (!game.started) return this.errorReply(`The game of mafia has not started yet.`);
 
@@ -2611,7 +2611,7 @@ export const commands: ChatCommands = {
 
 		pl: 'players',
 		players(target, room, user) {
-			const game = room.getGame<MafiaTracker>(MafiaTracker);
+			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 
 			// hack to let hosts broadcast
@@ -2631,7 +2631,7 @@ export const commands: ChatCommands = {
 		orl: 'rolelist',
 		rl: 'rolelist',
 		rolelist(target, room, user, connection, cmd) {
-			const game = room.getGame<MafiaTracker>(MafiaTracker);
+			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.closedSetup) return this.errorReply(`You cannot show roles in a closed setup.`);
 			if (!this.runBroadcast()) return false;
@@ -2650,7 +2650,7 @@ export const commands: ChatCommands = {
 		},
 
 		playerroles(target, room, user) {
-			const game = room.getGame<MafiaTracker>(MafiaTracker);
+			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id)) return this.errorReply(`Only the host can view roles.`);
 			if (!game.started) return this.errorReply(`The game has not started.`);
@@ -2673,7 +2673,7 @@ export const commands: ChatCommands = {
 				if (!room || room.type !== 'chat') return this.errorReply(`This command is only meant to be used in chat rooms.`);
 				targetRoom = room;
 			}
-			const game = targetRoom.getGame<MafiaTracker>(MafiaTracker);
+			const game = targetRoom.getGame(MafiaTracker);
 			if (!game) return user.sendTo(targetRoom, `|error|There is no game of mafia running in this room.`);
 			const lynches = game.lynchBoxFor(user.id);
 			user.send(`>view-mafia-${game.room.roomid}\n|selectorhtml|#mafia-lynches|` + lynches);
@@ -2689,7 +2689,7 @@ export const commands: ChatCommands = {
 			} else {
 				args.shift();
 			}
-			const game = targetRoom.getGame<MafiaTracker>(MafiaTracker);
+			const game = targetRoom.getGame(MafiaTracker);
 			if (!game) return user.sendTo(targetRoom, `|error|There is no game of mafia running in this room.`);
 			const action = toID(args.shift());
 			switch (action) {
@@ -2806,7 +2806,7 @@ export const commands: ChatCommands = {
 			} else {
 				args.shift();
 			}
-			const game = targetRoom.getGame<MafiaTracker>(MafiaTracker);
+			const game = targetRoom.getGame(MafiaTracker);
 			if (!game) return user.sendTo(targetRoom, `|error|There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
 			if (this.meansYes(toID(args.join('')))) {
@@ -2828,7 +2828,7 @@ export const commands: ChatCommands = {
 		forcecohost: 'subhost',
 		forcesubhost: 'subhost',
 		subhost(target, room, user, connection, cmd) {
-			const game = room.getGame<MafiaTracker>(MafiaTracker);
+			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (!this.canTalk()) return;
 			if (!target) return this.parse(`/help mafia ${cmd}`);
@@ -2876,7 +2876,7 @@ export const commands: ChatCommands = {
 
 		uncohost: 'removecohost',
 		removecohost(target, room, user) {
-			const game = room.getGame<MafiaTracker>(MafiaTracker);
+			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (!this.canTalk()) return;
 			if (!target) return this.parse('/help mafia subhost');
@@ -2900,7 +2900,7 @@ export const commands: ChatCommands = {
 				if (!room || room.type !== 'chat') return this.errorReply(`This command is only meant to be used in chat rooms.`);
 				targetRoom = room;
 			}
-			const game = targetRoom.getGame<MafiaTracker>(MafiaTracker);
+			const game = targetRoom.getGame(MafiaTracker);
 			if (!game) return user.sendTo(targetRoom, `|error|There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('broadcast', null, room)) return;
 			game.end();
@@ -2920,7 +2920,11 @@ export const commands: ChatCommands = {
 			if (cmd === 'role' && !target && room) {
 				// Support /mafia role showing your current role if you're in a game
 				const game = room.getGame(MafiaTracker);
+<<<<<<< HEAD
 				if (!game) return this.errorReply(`There is no game of mafia running in this room. If you meant to display information about a role, use /mafia role [role name]`);
+=======
+				if (!game || game.roomid !== 'mafia') return this.errorReply(`There is no game of mafia running in this room. If you meant to display information about a role, use /mafia role [role name]`);
+>>>>>>> TypeScript can infer template type
 				if (!(user.id in game.playerTable)) return this.errorReply(`You are not in the game of ${game.title}.`);
 				const role = game.playerTable[user.id].role;
 				if (!role) return this.errorReply(`You do not have a role yet.`);
@@ -2928,7 +2932,7 @@ export const commands: ChatCommands = {
 			}
 
 			// hack to let hosts broadcast
-			const game = room && room.getGame<MafiaTracker>(MafiaTracker);
+			const game = room && room.getGame(MafiaTracker);
 			if (game && (game.hostid === user.id || game.cohosts.includes(user.id))) {
 				this.broadcastMessage = this.message.toLowerCase().replace(/[^a-z0-9\s!,]/g, '');
 			}
@@ -3010,7 +3014,7 @@ export const commands: ChatCommands = {
 			let toGiveTo = [];
 			let buf = `${points} point${Chat.plural(points, 's were', ' was')} awarded to: `;
 			if (cmd === 'winfaction') {
-				const game = room.getGame<MafiaTracker>(MafiaTracker)!;
+				const game = room.getGame(MafiaTracker)!;
 				for (let faction of args) {
 					faction = toID(faction);
 					const inFaction = [];

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -1813,7 +1813,7 @@ export const commands: ChatCommands = {
 	mafia: {
 		''(target, room, user) {
 			const game = room.getGame<MafiaTracker>(MafiaTracker);
-			if (game && game.gameid === 'mafia') {
+			if (game) {
 				if (!this.runBroadcast()) return;
 				return this.sendReply(`|html|${game.roomWindow()}`);
 			}
@@ -2928,7 +2928,7 @@ export const commands: ChatCommands = {
 			}
 
 			// hack to let hosts broadcast
-			const game = room && room.game && room.game.gameid === 'mafia' ? room.getGame<MafiaTracker>(MafiaTracker) : null;
+			const game = room && room.getGame<MafiaTracker>(MafiaTracker);
 			if (game && (game.hostid === user.id || game.cohosts.includes(user.id))) {
 				this.broadcastMessage = this.message.toLowerCase().replace(/[^a-z0-9\s!,]/g, '');
 			}

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -2920,11 +2920,7 @@ export const commands: ChatCommands = {
 			if (cmd === 'role' && !target && room) {
 				// Support /mafia role showing your current role if you're in a game
 				const game = room.getGame(MafiaTracker);
-<<<<<<< HEAD
 				if (!game) return this.errorReply(`There is no game of mafia running in this room. If you meant to display information about a role, use /mafia role [role name]`);
-=======
-				if (!game || game.roomid !== 'mafia') return this.errorReply(`There is no game of mafia running in this room. If you meant to display information about a role, use /mafia role [role name]`);
->>>>>>> TypeScript can infer template type
 				if (!(user.id in game.playerTable)) return this.errorReply(`You are not in the game of ${game.title}.`);
 				const role = game.playerTable[user.id].role;
 				if (!role) return this.errorReply(`You do not have a role yet.`);

--- a/server/chat-plugins/uno.ts
+++ b/server/chat-plugins/uno.ts
@@ -811,7 +811,7 @@ export const commands: ChatCommands = {
 
 		color(target, room, user) {
 			const game = room.getGame<UnoGame>(UnoGame);
-			if (!game || game.gameid !== 'uno') return false;
+			if (!game) return false;
 			const player: UnoGamePlayer | undefined = game.playerTable[user.id];
 			if (!player) return this.errorReply(`You are not in the game of UNO.`);
 			let color: Color;
@@ -825,7 +825,7 @@ export const commands: ChatCommands = {
 
 		uno(target, room, user) {
 			const game = room.getGame<UnoGame>(UnoGame);
-			if (!game || game.gameid !== 'uno') return false;
+			if (!game) return false;
 			const player: UnoGamePlayer | undefined = game.playerTable[user.id];
 			if (!player) return this.errorReply(`You are not in the game of UNO.`);
 			game.onUno(player, toID(target));
@@ -835,7 +835,7 @@ export const commands: ChatCommands = {
 		'': 'hand',
 		hand(target, room, user) {
 			const game = room.getGame<UnoGame>(UnoGame);
-			if (!game || game.gameid !== 'uno') return this.parse("/help uno");
+			if (!game) return this.parse("/help uno");
 			game.onSendHand(user);
 		},
 

--- a/server/chat-plugins/uno.ts
+++ b/server/chat-plugins/uno.ts
@@ -80,7 +80,7 @@ function createDeck() {
 	]; // 108 cards
 }
 
-class UnoGame extends Rooms.RoomGame {
+export class UnoGame extends Rooms.RoomGame {
 	playerTable: {[userid: string]: UnoGamePlayer};
 	players: UnoGamePlayer[];
 	playerCap: number;

--- a/server/chat-plugins/uno.ts
+++ b/server/chat-plugins/uno.ts
@@ -686,8 +686,8 @@ export const commands: ChatCommands = {
 
 		start(target, room, user) {
 			if (!this.can('minigame', null, room)) return;
-			const game = room.game as UnoGame;
-			if (!game || game.gameid !== 'uno' || game.state !== 'signups') {
+			const game = room.getGame<UnoGame>(UnoGame);
+			if (!game || game.state !== 'signups') {
 				return this.errorReply("There is no UNO game in signups phase in this room.");
 			}
 			if (game.onStart()) {
@@ -708,8 +708,8 @@ export const commands: ChatCommands = {
 
 		timer(target, room, user) {
 			if (!this.can('minigame', null, room)) return;
-			const game = room.game as UnoGame;
-			if (!game || game.gameid !== 'uno') return this.errorReply("There is no UNO game going on in this room.");
+			const game = room.getGame<UnoGame>(UnoGame);
+			if (!game) return this.errorReply("There is no UNO game going on in this room.");
 			const amount = parseInt(target);
 			if (!amount || amount < 5 || amount > 300) return this.errorReply("The amount must be a number between 5 and 300.");
 
@@ -724,8 +724,8 @@ export const commands: ChatCommands = {
 
 		autostart(target, room, user) {
 			if (!this.can('minigame', null, room)) return;
-			const game = room.game as UnoGame;
-			if (!game || game.gameid !== 'uno') return this.errorReply("There is no UNO game going on in this room right now.");
+			const game = room.getGame<UnoGame>(UnoGame);
+			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			if (toID(target) === 'off') {
 				if (!game.autostartTimer) return this.errorReply("There is no autostart timer running on.");
 				this.addModAction(`${user.name} has turned off the UNO autostart timer.`);
@@ -747,8 +747,8 @@ export const commands: ChatCommands = {
 		dq: 'disqualify',
 		disqualify(target, room, user) {
 			if (!this.can('minigame', null, room)) return;
-			const game = room.game as UnoGame;
-			if (!game || game.gameid !== 'uno') return this.errorReply("There is no UNO game going on in this room right now.");
+			const game = room.getGame<UnoGame>(UnoGame);
+			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 
 			const disqualified = game.eliminate(toID(target));
 			if (disqualified === false) return this.errorReply(`Unable to disqualify ${target}.`);
@@ -762,8 +762,8 @@ export const commands: ChatCommands = {
 		// TypeScript doesn't like 'join' being defined as a function
 		join: 'unojoin',
 		unojoin(target, room, user) {
-			const game = room.game as UnoGame;
-			if (!game || game.gameid !== 'uno') return this.errorReply("There is no UNO game going on in this room right now.");
+			const game = room.getGame<UnoGame>(UnoGame);
+			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			if (!this.canTalk()) return false;
 			if (!game.joinGame(user)) return this.errorReply("Unable to join the game.");
 
@@ -772,15 +772,15 @@ export const commands: ChatCommands = {
 
 		l: 'leave',
 		leave(target, room, user) {
-			const game = room.game as UnoGame;
-			if (!game || game.gameid !== 'uno') return this.errorReply("There is no UNO game going on in this room right now.");
+			const game = room.getGame<UnoGame>(UnoGame);
+			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			if (!game.leaveGame(user)) return this.errorReply("Unable to leave the game.");
 			return this.sendReply("You have left the game of UNO.");
 		},
 
 		play(target, room, user) {
-			const game = room.game as UnoGame;
-			if (!game || game.gameid !== 'uno') return this.errorReply("There is no UNO game going on in this room right now.");
+			const game = room.getGame<UnoGame>(UnoGame);
+			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			const player: UnoGamePlayer | undefined = game.playerTable[user.id];
 			if (!player) return this.errorReply(`You are not in the game of UNO.`);
 			const error = game.onPlay(player, target);
@@ -788,8 +788,8 @@ export const commands: ChatCommands = {
 		},
 
 		draw(target, room, user) {
-			const game = room.game as UnoGame;
-			if (!game || game.gameid !== 'uno') return this.errorReply("There is no UNO game going on in this room right now.");
+			const game = room.getGame<UnoGame>(UnoGame);
+			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			const player: UnoGamePlayer | undefined = game.playerTable[user.id];
 			if (!player) return this.errorReply(`You are not in the game of UNO.`);
 			const error = game.onDraw(player);
@@ -797,8 +797,8 @@ export const commands: ChatCommands = {
 		},
 
 		pass(target, room, user) {
-			const game = room.game as UnoGame;
-			if (!game || game.gameid !== 'uno') return this.errorReply("There is no UNO game going on in this room right now.");
+			const game = room.getGame<UnoGame>(UnoGame);
+			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			if (game.currentPlayerid !== user.id) return this.errorReply("It is currently not your turn.");
 			const player: UnoGamePlayer | undefined = game.playerTable[user.id];
 			if (!player) return this.errorReply(`You are not in the game of UNO.`);
@@ -810,7 +810,7 @@ export const commands: ChatCommands = {
 		},
 
 		color(target, room, user) {
-			const game = room.game as UnoGame;
+			const game = room.getGame<UnoGame>(UnoGame);
 			if (!game || game.gameid !== 'uno') return false;
 			const player: UnoGamePlayer | undefined = game.playerTable[user.id];
 			if (!player) return this.errorReply(`You are not in the game of UNO.`);
@@ -824,7 +824,7 @@ export const commands: ChatCommands = {
 		},
 
 		uno(target, room, user) {
-			const game = room.game as UnoGame;
+			const game = room.getGame<UnoGame>(UnoGame);
 			if (!game || game.gameid !== 'uno') return false;
 			const player: UnoGamePlayer | undefined = game.playerTable[user.id];
 			if (!player) return this.errorReply(`You are not in the game of UNO.`);
@@ -834,7 +834,7 @@ export const commands: ChatCommands = {
 		// information commands
 		'': 'hand',
 		hand(target, room, user) {
-			const game = room.game as UnoGame;
+			const game = room.getGame<UnoGame>(UnoGame);
 			if (!game || game.gameid !== 'uno') return this.parse("/help uno");
 			game.onSendHand(user);
 		},
@@ -843,8 +843,8 @@ export const commands: ChatCommands = {
 		users: 'getusers',
 		getplayers: 'getusers',
 		getusers(target, room, user) {
-			const game = room.game as UnoGame;
-			if (!game || game.gameid !== 'uno') return this.errorReply("There is no UNO game going on in this room right now.");
+			const game = room.getGame<UnoGame>(UnoGame);
+			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			if (!this.runBroadcast()) return false;
 			this.sendReplyBox(`<strong>Players (${game.playerCount})</strong>:<br />${game.getPlayers().join(', ')}`);
 		},
@@ -855,8 +855,8 @@ export const commands: ChatCommands = {
 
 		// suppression commands
 		suppress(target, room, user) {
-			const game = room.game as UnoGame;
-			if (!game || game.gameid !== 'uno') return this.errorReply("There is no UNO game going on in this room right now.");
+			const game = room.getGame<UnoGame>(UnoGame);
+			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			if (!this.can('minigame', null, room)) return;
 
 			target = toID(target);
@@ -876,8 +876,8 @@ export const commands: ChatCommands = {
 		},
 
 		spectate(target, room, user) {
-			const game = room.game as UnoGame;
-			if (!game || game.gameid !== 'uno') return this.errorReply("There is no UNO game going on in this room right now.");
+			const game = room.getGame<UnoGame>(UnoGame);
+			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 
 			if (!game.suppressMessages) return this.errorReply("The current UNO game is not suppressing messages.");
 			if (user.id in game.spectators) return this.errorReply("You are already spectating this game.");
@@ -887,8 +887,8 @@ export const commands: ChatCommands = {
 		},
 
 		unspectate(target, room, user) {
-			const game = room.game as UnoGame;
-			if (!game || game.gameid !== 'uno') return this.errorReply("There is no UNO game going on in this room right now.");
+			const game = room.getGame<UnoGame>(UnoGame);
+			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 
 			if (!game.suppressMessages) return this.errorReply("The current UNO game is not suppressing messages.");
 			if (!(user.id in game.spectators)) return this.errorReply("You are currently not spectating this game.");

--- a/server/chat-plugins/uno.ts
+++ b/server/chat-plugins/uno.ts
@@ -686,7 +686,7 @@ export const commands: ChatCommands = {
 
 		start(target, room, user) {
 			if (!this.can('minigame', null, room)) return;
-			const game = room.getGame<UnoGame>(UnoGame);
+			const game = room.getGame(UnoGame);
 			if (!game || game.state !== 'signups') {
 				return this.errorReply("There is no UNO game in signups phase in this room.");
 			}
@@ -708,7 +708,7 @@ export const commands: ChatCommands = {
 
 		timer(target, room, user) {
 			if (!this.can('minigame', null, room)) return;
-			const game = room.getGame<UnoGame>(UnoGame);
+			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room.");
 			const amount = parseInt(target);
 			if (!amount || amount < 5 || amount > 300) return this.errorReply("The amount must be a number between 5 and 300.");
@@ -724,7 +724,7 @@ export const commands: ChatCommands = {
 
 		autostart(target, room, user) {
 			if (!this.can('minigame', null, room)) return;
-			const game = room.getGame<UnoGame>(UnoGame);
+			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			if (toID(target) === 'off') {
 				if (!game.autostartTimer) return this.errorReply("There is no autostart timer running on.");
@@ -747,7 +747,7 @@ export const commands: ChatCommands = {
 		dq: 'disqualify',
 		disqualify(target, room, user) {
 			if (!this.can('minigame', null, room)) return;
-			const game = room.getGame<UnoGame>(UnoGame);
+			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 
 			const disqualified = game.eliminate(toID(target));
@@ -762,7 +762,7 @@ export const commands: ChatCommands = {
 		// TypeScript doesn't like 'join' being defined as a function
 		join: 'unojoin',
 		unojoin(target, room, user) {
-			const game = room.getGame<UnoGame>(UnoGame);
+			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			if (!this.canTalk()) return false;
 			if (!game.joinGame(user)) return this.errorReply("Unable to join the game.");
@@ -772,14 +772,14 @@ export const commands: ChatCommands = {
 
 		l: 'leave',
 		leave(target, room, user) {
-			const game = room.getGame<UnoGame>(UnoGame);
+			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			if (!game.leaveGame(user)) return this.errorReply("Unable to leave the game.");
 			return this.sendReply("You have left the game of UNO.");
 		},
 
 		play(target, room, user) {
-			const game = room.getGame<UnoGame>(UnoGame);
+			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			const player: UnoGamePlayer | undefined = game.playerTable[user.id];
 			if (!player) return this.errorReply(`You are not in the game of UNO.`);
@@ -788,7 +788,7 @@ export const commands: ChatCommands = {
 		},
 
 		draw(target, room, user) {
-			const game = room.getGame<UnoGame>(UnoGame);
+			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			const player: UnoGamePlayer | undefined = game.playerTable[user.id];
 			if (!player) return this.errorReply(`You are not in the game of UNO.`);
@@ -797,7 +797,7 @@ export const commands: ChatCommands = {
 		},
 
 		pass(target, room, user) {
-			const game = room.getGame<UnoGame>(UnoGame);
+			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			if (game.currentPlayerid !== user.id) return this.errorReply("It is currently not your turn.");
 			const player: UnoGamePlayer | undefined = game.playerTable[user.id];
@@ -810,7 +810,7 @@ export const commands: ChatCommands = {
 		},
 
 		color(target, room, user) {
-			const game = room.getGame<UnoGame>(UnoGame);
+			const game = room.getGame(UnoGame);
 			if (!game) return false;
 			const player: UnoGamePlayer | undefined = game.playerTable[user.id];
 			if (!player) return this.errorReply(`You are not in the game of UNO.`);
@@ -824,7 +824,7 @@ export const commands: ChatCommands = {
 		},
 
 		uno(target, room, user) {
-			const game = room.getGame<UnoGame>(UnoGame);
+			const game = room.getGame(UnoGame);
 			if (!game) return false;
 			const player: UnoGamePlayer | undefined = game.playerTable[user.id];
 			if (!player) return this.errorReply(`You are not in the game of UNO.`);
@@ -834,7 +834,7 @@ export const commands: ChatCommands = {
 		// information commands
 		'': 'hand',
 		hand(target, room, user) {
-			const game = room.getGame<UnoGame>(UnoGame);
+			const game = room.getGame(UnoGame);
 			if (!game) return this.parse("/help uno");
 			game.onSendHand(user);
 		},
@@ -843,7 +843,7 @@ export const commands: ChatCommands = {
 		users: 'getusers',
 		getplayers: 'getusers',
 		getusers(target, room, user) {
-			const game = room.getGame<UnoGame>(UnoGame);
+			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			if (!this.runBroadcast()) return false;
 			this.sendReplyBox(`<strong>Players (${game.playerCount})</strong>:<br />${game.getPlayers().join(', ')}`);
@@ -855,7 +855,7 @@ export const commands: ChatCommands = {
 
 		// suppression commands
 		suppress(target, room, user) {
-			const game = room.getGame<UnoGame>(UnoGame);
+			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			if (!this.can('minigame', null, room)) return;
 
@@ -876,7 +876,7 @@ export const commands: ChatCommands = {
 		},
 
 		spectate(target, room, user) {
-			const game = room.getGame<UnoGame>(UnoGame);
+			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 
 			if (!game.suppressMessages) return this.errorReply("The current UNO game is not suppressing messages.");
@@ -887,7 +887,7 @@ export const commands: ChatCommands = {
 		},
 
 		unspectate(target, room, user) {
-			const game = room.getGame<UnoGame>(UnoGame);
+			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 
 			if (!game.suppressMessages) return this.errorReply("The current UNO game is not suppressing messages.");

--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -13,8 +13,6 @@
 
 import {FS} from '../lib/fs';
 
-type TournamentType = import('./tournaments').Tournament;
-
 const PUNISHMENT_FILE = 'config/punishments.tsv';
 const ROOM_PUNISHMENT_FILE = 'config/room-punishments.tsv';
 const SHAREDIPS_FILE = 'config/sharedips.tsv';
@@ -771,7 +769,7 @@ export const Punishments = new class {
 
 		// Handle tournaments the user was in before being battle banned
 		for (const games of user.games.keys()) {
-			const game = Rooms.get(games)!.getGame<TournamentType>(Tournaments.Tournament);
+			const game = Rooms.get(games)!.getGame(Tournaments.Tournament);
 			if (!game) continue; // this should never happen
 			if (game.isTournamentStarted) {
 				game.disqualifyUser(id, null, null);

--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -13,7 +13,7 @@
 
 import {FS} from '../lib/fs';
 
-type Tournament = import('./tournaments').Tournament;
+type TournamentType = import('./tournaments').Tournament;
 
 const PUNISHMENT_FILE = 'config/punishments.tsv';
 const ROOM_PUNISHMENT_FILE = 'config/room-punishments.tsv';
@@ -771,14 +771,12 @@ export const Punishments = new class {
 
 		// Handle tournaments the user was in before being battle banned
 		for (const games of user.games.keys()) {
-			const game = Rooms.get(games)!.game;
+			const game = Rooms.get(games)!.getGame<TournamentType>(Tournaments.Tournament);
 			if (!game) continue; // this should never happen
-			if ((game as Tournament).isTournament) {
-				if ((game as Tournament).isTournamentStarted) {
-					(game as Tournament).disqualifyUser(id, null, null);
-				} else if (!(game as Tournament).isTournamentStarted) {
-					(game as Tournament).removeUser(user.id);
-				}
+			if (game.isTournamentStarted) {
+				game.disqualifyUser(id, null, null);
+			} else if (!game.isTournamentStarted) {
+				game.removeUser(user.id);
 			}
 		}
 

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -305,6 +305,10 @@ export abstract class BasicRoom {
 		}
 		if (this.parent) return this.parent.getMuteTime(user);
 	}
+	getGame<T extends RoomGame>(constructor: new (...args: any[]) => T): T | null {
+		if (this.game && this.game.constructor.prototype.gameid === constructor.prototype.gameid) return this.game as T;
+		return null;
+	}
 	/**
 	 * Gets the group symbol of a user in the room.
 	 */

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -306,7 +306,8 @@ export abstract class BasicRoom {
 		if (this.parent) return this.parent.getMuteTime(user);
 	}
 	getGame<T extends RoomGame>(constructor: new (...args: any[]) => T): T | null {
-		if (this.game && this.game.constructor.prototype.gameid === constructor.prototype.gameid) return this.game as T;
+		// TODO: switch to `static readonly gameid` when all game files are TypeScripted
+		if (this.game && this.game.constructor.name === constructor.name) return this.game as T;
 		return null;
 	}
 	/**

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -1588,9 +1588,9 @@ export const commands: ChatCommands = {
 			if (!this.runBroadcast()) return;
 			const update = [];
 			for (const tourRoom of Rooms.rooms.values()) {
-				if (!tourRoom.game || tourRoom.game.gameid !== 'tournament') continue;
+				const tournament = tourRoom.getGame<Tournament>(Tournament);
+				if (!tournament) continue;
 				if (tourRoom.isPrivate || tourRoom.isPersonal || tourRoom.staffRoom) continue;
-				const tournament = tourRoom.game as Tournament;
 				update.push({
 					room: tourRoom.roomid, title: room.title, format: tournament.name,
 					generator: tournament.generator.name, isStarted: tournament.isTournamentStarted,
@@ -1696,7 +1696,7 @@ export const commands: ChatCommands = {
 				}
 			}
 		} else {
-			const tournament = (room.game && room.game.gameid === 'tournament') ? room.game as Tournament : null;
+			const tournament = room.getGame<Tournament>(Tournament);
 			if (!tournament) {
 				return this.sendReply("There is currently no tournament running in this room.");
 			}

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -1588,7 +1588,7 @@ export const commands: ChatCommands = {
 			if (!this.runBroadcast()) return;
 			const update = [];
 			for (const tourRoom of Rooms.rooms.values()) {
-				const tournament = tourRoom.getGame<Tournament>(Tournament);
+				const tournament = tourRoom.getGame(Tournament);
 				if (!tournament) continue;
 				if (tourRoom.isPrivate || tourRoom.isPersonal || tourRoom.staffRoom) continue;
 				update.push({
@@ -1696,7 +1696,7 @@ export const commands: ChatCommands = {
 				}
 			}
 		} else {
-			const tournament = room.getGame<Tournament>(Tournament);
+			const tournament = room.getGame(Tournament);
 			if (!tournament) {
 				return this.sendReply("There is currently no tournament running in this room.");
 			}

--- a/test/server/rooms.js
+++ b/test/server/rooms.js
@@ -18,6 +18,20 @@ describe('Rooms features', function () {
 		});
 	});
 
+	describe('BasicRoom', function () {
+		describe('getGame', function () {
+			it('should return the game only when the gameids match', function () {
+				const Hangman = require('../../.server-dist/chat-plugins/hangman').Hangman;
+				const Uno = require('../../.server-dist/chat-plugins/uno').UnoGame;
+				const room = Rooms.createChatRoom('r/relationshipadvice');
+				const game = new Hangman(room, new User(), 'There\'s a lot of red flags here');
+				room.game = game;
+				assert.strictEqual(room.getGame(Hangman), game);
+				assert.strictEqual(room.getGame(Uno), null);
+			});
+		});
+	});
+
 	describe('GameRoom', function () {
 		const packedTeam = 'Weavile||lifeorb||swordsdance,knockoff,iceshard,iciclecrash|Jolly|,252,,,4,252|||||';
 


### PR DESCRIPTION
By adding a `getGame` function of type:

```typescript
// null is returned if the gameids don't match
// or the game doesn't exist
getGame<T extends RoomGame>(constructor: new (...args: any[]) => T) => T | null
```
(Credits @urkerab and @whalemer for the function signature.)

It allows refactoring previous code of:

```typescript
if (room.game && room.game.gameid !== 'hangman') return;
const game = room.game as Hangman;
```

to:

```typescript
const game = room.getGame<Hangman>(Hangman);
if (!game) return;
```

This has a couple of advantages:
- TypeScript will throw an error if the if condition is not present.

- In the new code, the template must extends `RoomGame` and be assignable to the same ID, so it's 100% typesafe