### PR TITLE
Correctly set hp and maxhp fields if Zygarde transforms while Dynamaxed

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2832,9 +2832,10 @@ let BattleAbilities = {
 			if (pokemon.template.speciesid === 'zygardecomplete' || pokemon.hp > pokemon.maxhp / 2) return;
 			this.add('-activate', pokemon, 'ability: Power Construct');
 			pokemon.formeChange('Zygarde-Complete', this.effect, true);
-			let newHP = Math.floor(Math.floor(2 * pokemon.template.baseStats['hp'] + pokemon.set.ivs['hp'] + Math.floor(pokemon.set.evs['hp'] / 4) + 100) * pokemon.level / 100 + 10);
-			pokemon.hp = newHP - (pokemon.maxhp - pokemon.hp);
-			pokemon.maxhp = pokemon.baseMaxhp = newHP;
+			pokemon.baseMaxhp = Math.floor(Math.floor(2 * pokemon.template.baseStats['hp'] + pokemon.set.ivs['hp'] + Math.floor(pokemon.set.evs['hp'] / 4) + 100) * pokemon.level / 100 + 10);
+			let newMaxHP = pokemon.volatiles['dynamax'] ? (2 * pokemon.baseMaxhp) : pokemon.baseMaxhp;
+			pokemon.hp = newMaxHP - (pokemon.maxhp - pokemon.hp);
+			pokemon.maxhp = newMaxHP;
 			this.add('-heal', pokemon, pokemon.getHealth, '[silent]');
 		},
 		id: "powerconstruct",


### PR DESCRIPTION
Currently, Zygarde can have 0% or even negative HP if the Power Construct transformation takes place while it's Dynamaxed (ie. as shown in [this](https://replay.pokemonshowdown.com/gen8nationaldexag-1043549787) replay on turn 9). This PR fixes that.