### PR TITLE
(gen 7) Properly resolve speed ties on the turn of Mega Evolution

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2531,7 +2531,8 @@ export class Battle {
 			chosenAction.pokemon.updateSpeed();
 		}
 		const action = this.resolveAction(chosenAction, midTurn);
-		let tieStart = -1, tieEnd = this.queue.length;
+		let tieStart = -1;
+		let tieEnd = this.queue.length;
 		for (const [i, curAction] of this.queue.entries()) {
 			const delta = this.comparePriority(action, curAction);
 			if (delta === 0 && tieStart === -1) {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2531,13 +2531,27 @@ export class Battle {
 			chosenAction.pokemon.updateSpeed();
 		}
 		const action = this.resolveAction(chosenAction, midTurn);
+		let tieStart = -1, tieEnd = this.queue.length;
 		for (const [i, curAction] of this.queue.entries()) {
-			if (this.comparePriority(action, curAction) < 0) {
-				this.queue.splice(i, 0, action);
-				return;
+			const delta = this.comparePriority(action, curAction);
+			if (delta === 0 && tieStart === -1) {
+				tieStart = i; // Mark the index where the first tie occurs
+			} else if (delta < 0) {
+				if (tieStart === -1) {
+					this.queue.splice(i, 0, action);
+					return;
+				}
+				tieEnd = i; // Mark the index after the last tie occurs
+				break;
 			}
 		}
-		this.queue.push(action);
+		if (tieStart !== -1) {
+			// Shuffle all of the tied actions
+			this.queue.splice(tieStart, 0, action);
+			this.prng.shuffle(this.queue, tieStart, tieEnd + 1);
+		} else {
+			this.queue.push(action);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Original bug reported here: https://www.smogon.com/forums/threads/bug-reports-v3-read-original-post-before-posting.3634749/page-107#post-8345248

Currently, in gen 7, any Pokemon that speed ties with the opponent but has to mega evolve on that turn always goes last. This PR fixes that by adding logic to check/account for speed ties.

Example replay demonstrating the fix working https://pastebin.com/7P1B1wGs
