### PR TITLE
Fix Lottery Help

### DIFF
--- a/server/chat-plugins/lottery.ts
+++ b/server/chat-plugins/lottery.ts
@@ -248,7 +248,7 @@ export const commands: ChatCommands = {
 		`/lottery create max winners, name, html - creates a new lottery with [name] as the header and [html] as body. Max winners is the amount of people that will win the lottery. Requires # & ~`,
 		`/lottery delete - deletes the current lottery without declaring a winner. Requires # & ~`,
 		`/lottery end - ends the current lottery, declaring a random participant as the winner. Requires # & ~`,
-		`/lottery edit max winners, name, html - edits the lottery markup with the provided HTML. Requires # & ~`,
+		`/lottery edit max winners, name, html - edits the lottery with the provided parameters. Requires # & ~`,
 		`/lottery join - joins the current lottery, if it exists, you need to be not currently punished in any public room, not locked and be autoconfirmed.`,
 		`/lottery leave - leaves the current lottery, if it exists.`,
 		`/lottery participants - shows the current participants in the lottery.`,

--- a/server/chat-plugins/lottery.ts
+++ b/server/chat-plugins/lottery.ts
@@ -248,7 +248,7 @@ export const commands: ChatCommands = {
 		`/lottery create max winners, name, html - creates a new lottery with [name] as the header and [html] as body. Max winners is the amount of people that will win the lottery. Requires # & ~`,
 		`/lottery delete - deletes the current lottery without declaring a winner. Requires # & ~`,
 		`/lottery end - ends the current lottery, declaring a random participant as the winner. Requires # & ~`,
-		`/lottery editmarkup html - edits the lottery markup with the provided HTML. Requires # & ~`,
+		`/lottery edit max winners, name, html - edits the lottery markup with the provided HTML. Requires # & ~`,
 		`/lottery join - joins the current lottery, if it exists, you need to be not currently punished in any public room, not locked and be autoconfirmed.`,
 		`/lottery leave - leaves the current lottery, if it exists.`,
 		`/lottery participants - shows the current participants in the lottery.`,


### PR DESCRIPTION
There is no lottery editmarkup command. The proper use is to use /lottery edit, which allows you to edit the number of max winners, the name of the lottery, and the HTML, but also requires all three parameters be included.