### PR TITLE
Refactor `AfterDamage` to `DamagingHit`

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -891,17 +891,15 @@ let BattleAbilities = {
 	"emergencyexit": {
 		desc: "When this Pokemon has more than 1/2 its maximum HP and takes damage bringing it to 1/2 or less of its maximum HP, it immediately switches out to a chosen ally. This effect applies after all hits from a multi-hit move; Sheer Force prevents it from activating if the move has a secondary effect. This effect applies to both direct and indirect damage, except Curse and Substitute on use, Belly Drum, Pain Split, and confusion damage.",
 		shortDesc: "This Pokemon switches out when it reaches 1/2 or less of its maximum HP.",
-		onAfterMoveSecondary(target, source, move) {
-			if (!source || source === target || !target.hp || !move.totalDamage) return;
-			const lastAttackedBy = target.getLastAttackedBy();
-			if (!lastAttackedBy) return;
-			const damage = move.multihit ? move.totalDamage : lastAttackedBy.damage;
-			if (target.hp <= target.maxhp / 2 && target.hp + damage > target.maxhp / 2) {
-				if (!this.canSwitch(target.side) || target.forceSwitchFlag || target.switchFlag) return;
-				target.switchFlag = true;
-				source.switchFlag = false;
-				this.add('-activate', target, 'ability: Emergency Exit');
+		onEmergencyExit(target) {
+			if (!this.canSwitch(target.side) || target.forceSwitchFlag || target.switchFlag) return;
+			for (const side of this.sides) {
+				for (const active of side.active) {
+					active.switchFlag = false;
+				}
 			}
+			target.switchFlag = true;
+			this.add('-activate', target, 'ability: Emergency Exit');
 		},
 		id: "emergencyexit",
 		name: "Emergency Exit",
@@ -4589,17 +4587,15 @@ let BattleAbilities = {
 	"wimpout": {
 		desc: "When this Pokemon has more than 1/2 its maximum HP and takes damage bringing it to 1/2 or less of its maximum HP, it immediately switches out to a chosen ally. This effect applies after all hits from a multi-hit move; Sheer Force prevents it from activating if the move has a secondary effect. This effect applies to both direct and indirect damage, except Curse and Substitute on use, Belly Drum, Pain Split, and confusion damage.",
 		shortDesc: "This Pokemon switches out when it reaches 1/2 or less of its maximum HP.",
-		onAfterMoveSecondary(target, source, move) {
-			if (!source || source === target || !target.hp || !move.totalDamage) return;
-			const lastAttackedBy = target.getLastAttackedBy();
-			if (!lastAttackedBy) return;
-			const damage = move.multihit ? move.totalDamage : lastAttackedBy.damage;
-			if (target.hp <= target.maxhp / 2 && target.hp + damage > target.maxhp / 2) {
-				if (!this.canSwitch(target.side) || target.forceSwitchFlag || target.switchFlag) return;
-				target.switchFlag = true;
-				source.switchFlag = false;
-				this.add('-activate', target, 'ability: Wimp Out');
+		onEmergencyExit(target) {
+			if (!this.canSwitch(target.side) || target.forceSwitchFlag || target.switchFlag) return;
+			for (const side of this.sides) {
+				for (const active of side.active) {
+					active.switchFlag = false;
+				}
 			}
+			target.switchFlag = true;
+			this.add('-activate', target, 'ability: Wimp Out');
 		},
 		id: "wimpout",
 		name: "Wimp Out",

--- a/data/items.js
+++ b/data/items.js
@@ -41,7 +41,7 @@ let BattleItems = {
 		fling: {
 			basePower: 30,
 		},
-		onAfterDamage(damage, target, source, move) {
+		onDamagingHit(damage, target, source, move) {
 			if (move.type === 'Water') {
 				target.useItem();
 			}
@@ -162,18 +162,15 @@ let BattleItems = {
 			}
 		},
 		// airborneness implemented in sim/pokemon.js:Pokemon#isGrounded
-		onAfterDamage(damage, target, source, effect) {
-			this.debug('effect: ' + effect.id);
-			if (effect.effectType === 'Move' && effect.id !== 'confused') {
-				this.add('-enditem', target, 'Air Balloon');
-				target.item = '';
-				target.itemData = {id: '', target};
-				this.runEvent('AfterUseItem', target, null, null, this.dex.getItem('airballoon'));
-			}
+		onDamagingHit(damage, target, source, move) {
+			this.add('-enditem', target, 'Air Balloon');
+			target.item = '';
+			target.itemData = {id: '', target};
+			this.runEvent('AfterUseItem', target, null, null, this.dex.getItem('airballoon'));
 		},
 		onAfterSubDamage(damage, target, source, effect) {
 			this.debug('effect: ' + effect.id);
-			if (effect.effectType === 'Move' && effect.id !== 'confused') {
+			if (effect.effectType === 'Move') {
 				this.add('-enditem', target, 'Air Balloon');
 				target.item = '';
 				target.itemData = {id: '', target};
@@ -736,7 +733,7 @@ let BattleItems = {
 		fling: {
 			basePower: 30,
 		},
-		onAfterDamage(damage, target, source, move) {
+		onDamagingHit(damage, target, source, move) {
 			if (move.type === 'Electric') {
 				target.useItem();
 			}
@@ -2900,8 +2897,8 @@ let BattleItems = {
 			basePower: 100,
 			type: "Dragon",
 		},
-		onAfterDamage(damage, target, source, move) {
-			if (source && source.hp && source !== target && move && move.category === 'Physical') {
+		onDamagingHit(damage, target, source, move) {
+			if (move.category === 'Physical') {
 				if (target.eatItem()) {
 					this.damage(source.baseMaxhp / 8, source, target);
 				}
@@ -3404,7 +3401,7 @@ let BattleItems = {
 		fling: {
 			basePower: 30,
 		},
-		onAfterDamage(damage, target, source, move) {
+		onDamagingHit(damage, target, source, move) {
 			if (move.type === 'Water') {
 				target.useItem();
 			}
@@ -5151,9 +5148,9 @@ let BattleItems = {
 		fling: {
 			basePower: 60,
 		},
-		onAfterDamageOrder: 2,
-		onAfterDamage(damage, target, source, move) {
-			if (source && source !== target && move && move.flags['contact']) {
+		onDamagingHitOrder: 2,
+		onDamagingHit(damage, target, source, move) {
+			if (move.flags['contact']) {
 				this.damage(source.baseMaxhp / 6, source, target);
 			}
 		},
@@ -5242,8 +5239,8 @@ let BattleItems = {
 			basePower: 100,
 			type: "Dark",
 		},
-		onAfterDamage(damage, target, source, move) {
-			if (source && source.hp && source !== target && move && move.category === 'Special') {
+		onDamagingHit(damage, target, source, move) {
+			if (move.category === 'Special') {
 				if (target.eatItem()) {
 					this.damage(source.baseMaxhp / 8, source, target);
 				}
@@ -5711,7 +5708,7 @@ let BattleItems = {
 		fling: {
 			basePower: 30,
 		},
-		onAfterDamage(damage, target, source, move) {
+		onDamagingHit(damage, target, source, move) {
 			if (move.type === 'Ice') {
 				target.useItem();
 			}

--- a/data/mods/gen2/moves.js
+++ b/data/mods/gen2/moves.js
@@ -956,7 +956,7 @@ let BattleMovedex = {
 		onAfterHit() {},
 		secondary: {
 			chance: 100,
-			onAfterHit(target, source) {
+			onHit(target, source) {
 				if (source.item || source.volatiles['gem']) {
 					return;
 				}

--- a/data/mods/gen3/abilities.js
+++ b/data/mods/gen3/abilities.js
@@ -6,8 +6,8 @@ let BattleAbilities = {
 		inherit: true,
 		desc: "There is a 1/3 chance a Pokemon making contact with this Pokemon will become infatuated if it is of the opposite gender.",
 		shortDesc: "1/3 chance of infatuating Pokemon of the opposite gender if they make contact.",
-		onAfterDamage(damage, target, source, move) {
-			if (move && move.flags['contact']) {
+		onDamagingHit(damage, target, source, move) {
+			if (move.flags['contact']) {
 				if (this.randomChance(1, 3)) {
 					source.addVolatile('attract', target);
 				}
@@ -18,8 +18,8 @@ let BattleAbilities = {
 		inherit: true,
 		desc: "10% chance a Pokemon making contact with this Pokemon will be poisoned, paralyzed, or fall asleep.",
 		shortDesc: "10% chance of poison/paralysis/sleep on others making contact with this Pokemon.",
-		onAfterDamage(damage, target, source, move) {
-			if (move && move.flags['contact'] && !source.status) {
+		onDamagingHit(damage, target, source, move) {
+			if (move.flags['contact'] && !source.status) {
 				let r = this.random(300);
 				if (r < 10) {
 					source.setStatus('slp', target);
@@ -34,8 +34,8 @@ let BattleAbilities = {
 	"flamebody": {
 		inherit: true,
 		shortDesc: "1/3 chance a Pokemon making contact with this Pokemon will be burned.",
-		onAfterDamage(damage, target, source, move) {
-			if (move && move.flags['contact']) {
+		onDamagingHit(damage, target, source, move) {
+			if (move.flags['contact']) {
 				if (this.randomChance(1, 3)) {
 					source.trySetStatus('brn', target);
 				}
@@ -129,8 +129,8 @@ let BattleAbilities = {
 	"poisonpoint": {
 		inherit: true,
 		shortDesc: "1/3 chance a Pokemon making contact with this Pokemon will be poisoned.",
-		onAfterDamage(damage, target, source, move) {
-			if (move && move.flags['contact']) {
+		onDamagingHit(damage, target, source, move) {
+			if (move.flags['contact']) {
 				if (this.randomChance(1, 3)) {
 					source.trySetStatus('psn', target);
 				}
@@ -147,8 +147,8 @@ let BattleAbilities = {
 		inherit: true,
 		desc: "Pokemon making contact with this Pokemon lose 1/16 of their maximum HP, rounded down.",
 		shortDesc: "Pokemon making contact with this Pokemon lose 1/16 of their max HP.",
-		onAfterDamage(damage, target, source, move) {
-			if (source && source !== target && move && move.flags['contact']) {
+		onDamagingHit(damage, target, source, move) {
+			if (move.flags['contact']) {
 				this.damage(source.baseMaxhp / 16, source, target);
 			}
 		},
@@ -164,8 +164,8 @@ let BattleAbilities = {
 	"static": {
 		inherit: true,
 		shortDesc: "1/3 chance a Pokemon making contact with this Pokemon will be paralyzed.",
-		onAfterDamage(damage, target, source, effect) {
-			if (effect && effect.flags['contact']) {
+		onDamagingHit(damage, target, source, move) {
+			if (move.flags['contact']) {
 				if (this.randomChance(1, 3)) {
 					source.trySetStatus('par', target);
 				}

--- a/data/mods/gen4/abilities.js
+++ b/data/mods/gen4/abilities.js
@@ -33,10 +33,10 @@ let BattleAbilities = {
 	"colorchange": {
 		inherit: true,
 		desc: "This Pokemon's type changes to match the type of the last move that hit it, unless that type is already one of its types. This effect applies after each hit from a multi-hit move.",
-		onAfterDamage(damage, target, source, move) {
+		onDamagingHit(damage, target, source, move) {
 			if (!target.hp) return;
 			let type = move.type;
-			if (target.isActive && move.effectType === 'Move' && move.category !== 'Status' && type !== '???' && !target.hasType(type)) {
+			if (target.isActive && move.category !== 'Status' && type !== '???' && !target.hasType(type)) {
 				if (!target.setType(type)) return false;
 				this.add('-start', target, 'typechange', type, '[from] ability: Color Change');
 			}
@@ -45,8 +45,8 @@ let BattleAbilities = {
 	},
 	"effectspore": {
 		inherit: true,
-		onAfterDamage(damage, target, source, move) {
-			if (move && move.flags['contact'] && !source.status) {
+		onDamagingHit(damage, target, source, move) {
+			if (move.flags['contact'] && !source.status) {
 				let r = this.random(100);
 				if (r < 10) {
 					source.setStatus('slp', target);

--- a/data/mods/gen4/items.js
+++ b/data/mods/gen4/items.js
@@ -125,17 +125,6 @@ let BattleItems = {
 		onEffectiveness() {},
 		desc: "Holder's Speed is halved and it becomes grounded.",
 	},
-	"jabocaberry": {
-		inherit: true,
-		onAfterDamage() {},
-		onAfterMoveSecondary(target, source, move) {
-			if (source && source !== target && move && move.category === 'Physical') {
-				if (target.eatItem()) {
-					this.damage(source.baseMaxhp / 8, source, target, null, true);
-				}
-			}
-		},
-	},
 	"kingsrock": {
 		inherit: true,
 		onModifyMove(move) {
@@ -255,17 +244,6 @@ let BattleItems = {
 					chance: 10,
 					volatileStatus: 'flinch',
 				});
-			}
-		},
-	},
-	"rowapberry": {
-		inherit: true,
-		onAfterDamage() {},
-		onAfterMoveSecondary(target, source, move) {
-			if (source && source !== target && move && move.category === 'Special') {
-				if (target.eatItem()) {
-					this.damage(source.baseMaxhp / 8, source, target, null, true);
-				}
 			}
 		},
 	},

--- a/data/mods/gen6/abilities.js
+++ b/data/mods/gen6/abilities.js
@@ -13,8 +13,8 @@ let BattleAbilities = {
 	},
 	"aftermath": {
 		inherit: true,
-		onAfterDamage(damage, target, source, move) {
-			if (source && source !== target && move && move.flags['contact'] && !target.hp) {
+		onDamagingHit(damage, target, source, move) {
+			if (move.flags['contact'] && !target.hp) {
 				this.damage(source.baseMaxhp / 4, source, target, null, true);
 			}
 		},
@@ -47,8 +47,8 @@ let BattleAbilities = {
 	},
 	"ironbarbs": {
 		inherit: true,
-		onAfterDamage(damage, target, source, move) {
-			if (source && source !== target && move && move.flags['contact']) {
+		onDamagingHit(damage, target, source, move) {
+			if (move.flags['contact']) {
 				this.damage(source.baseMaxhp / 8, source, target, null, true);
 			}
 		},
@@ -124,8 +124,8 @@ let BattleAbilities = {
 	},
 	"roughskin": {
 		inherit: true,
-		onAfterDamage(damage, target, source, move) {
-			if (source && source !== target && move && move.flags['contact']) {
+		onDamagingHit(damage, target, source, move) {
+			if (move.flags['contact']) {
 				this.damage(source.baseMaxhp / 8, source, target, null, true);
 			}
 		},
@@ -142,7 +142,7 @@ let BattleAbilities = {
 		inherit: true,
 		desc: "If a physical attack hits this Pokemon, its Defense is lowered by 1 stage and its Speed is raised by 1 stage.",
 		shortDesc: "If a physical attack hits this Pokemon, Defense is lowered by 1, Speed is raised by 1.",
-		onAfterDamage(damage, target, source, move) {
+		onDamagingHit(damage, target, source, move) {
 			if (move.category === 'Physical') {
 				this.boost({def: -1, spe: 1}, target, target);
 			}

--- a/data/mods/gen6/items.js
+++ b/data/mods/gen6/items.js
@@ -76,8 +76,8 @@ let BattleItems = {
 	},
 	jabocaberry: {
 		inherit: true,
-		onAfterDamage(damage, target, source, move) {
-			if (source && source !== target && move && move.category === 'Physical') {
+		onDamagingHit(damage, target, source, move) {
+			if (move.category === 'Physical') {
 				if (target.eatItem()) {
 					this.damage(source.baseMaxhp / 8, source, target, null, true);
 				}
@@ -145,16 +145,16 @@ let BattleItems = {
 	},
 	rockyhelmet: {
 		inherit: true,
-		onAfterDamage(damage, target, source, move) {
-			if (source && source !== target && move && move.flags['contact']) {
+		onDamagingHit(damage, target, source, move) {
+			if (move.flags['contact']) {
 				this.damage(source.baseMaxhp / 6, source, target, null, true);
 			}
 		},
 	},
 	rowapberry: {
 		inherit: true,
-		onAfterDamage(damage, target, source, move) {
-			if (source && source !== target && move && move.category === 'Special') {
+		onDamagingHit(damage, target, source, move) {
+			if (move.category === 'Special') {
 				if (target.eatItem()) {
 					this.damage(source.baseMaxhp / 8, source, target, null, true);
 				}

--- a/data/mods/gen7/abilities.js
+++ b/data/mods/gen7/abilities.js
@@ -110,8 +110,8 @@ let BattleAbilities = {
 	"rattled": {
 		desc: "This Pokemon's Speed is raised by 1 stage if hit by a Bug-, Dark-, or Ghost-type attack.",
 		shortDesc: "This Pokemon's Speed is raised 1 stage if hit by a Bug-, Dark-, or Ghost-type attack.",
-		onAfterDamage(damage, target, source, effect) {
-			if (effect && (effect.type === 'Dark' || effect.type === 'Bug' || effect.type === 'Ghost')) {
+		onDamagingHit(damage, target, source, move) {
+			if (['Dark', 'Bug', 'Ghost'].includes(move.type)) {
 				this.boost({spe: 1});
 			}
 		},

--- a/data/mods/gennext/abilities.js
+++ b/data/mods/gennext/abilities.js
@@ -123,8 +123,8 @@ let BattleAbilities = {
 		onResidual(target, source, effect) {
 			this.heal(target.baseMaxhp / 16);
 		},
-		onAfterDamage(damage, target, source, move) {
-			if (move && move.flags['contact'] && this.field.isWeather('hail')) {
+		onDamagingHit(damage, target, source, move) {
+			if (move.flags['contact'] && this.field.isWeather('hail')) {
 				if (this.randomChance(3, 10)) {
 					source.trySetStatus('frz', target);
 				}
@@ -141,8 +141,8 @@ let BattleAbilities = {
 	},
 	"static": {
 		inherit: true,
-		onAfterDamage(damage, target, source, move) {
-			if (move && move.flags['contact']) {
+		onDamagingHit(damage, target, source, move) {
+			if (move.flags['contact']) {
 				source.trySetStatus('par', target);
 			}
 		},
@@ -150,8 +150,8 @@ let BattleAbilities = {
 	},
 	"cutecharm": {
 		inherit: true,
-		onAfterDamage(damage, target, source, move) {
-			if (move && move.flags['contact']) {
+		onDamagingHit(damage, target, source, move) {
+			if (move.flags['contact']) {
 				source.addVolatile('Attract', target);
 			}
 		},
@@ -160,8 +160,8 @@ let BattleAbilities = {
 	},
 	"poisonpoint": {
 		inherit: true,
-		onAfterDamage(damage, target, source, move) {
-			if (move && move.flags['contact']) {
+		onDamagingHit(damage, target, source, move) {
+			if (move.flags['contact']) {
 				source.trySetStatus('psn', target);
 			}
 		},
@@ -416,7 +416,7 @@ let BattleAbilities = {
 				return damage;
 			}
 		},
-		onAfterDamage() {},
+		onDamagingHit() {},
 		desc: "This ability reduces incoming move damage by 1/10 of the user's max HP and increases the user's Speed for the first hit after switch-in (and does not activate again until the next switch-in).",
 		shortDesc: "Reduces incoming move damage by 1/10 of the user's max HP and increases the user's Spe for the 1st hit after switch-in (doesn't activate until next switch-in).",
 	},
@@ -482,8 +482,8 @@ let BattleAbilities = {
 	},
 	"aftermath": {
 		inherit: true,
-		onAfterDamage(damage, target, source, move) {
-			if (source && source !== target && move && !target.hp) {
+		onDamagingHit(damage, target, source, move) {
+			if (!target.hp) {
 				this.damage(source.baseMaxhp / 3, source, target, null, true);
 			}
 		},

--- a/data/mods/ssb/abilities.js
+++ b/data/mods/ssb/abilities.js
@@ -278,9 +278,8 @@ let BattleAbilities = {
 			if ((target === source || move.category === 'Status') && target.template.speciesid !== 'shayminsky' && target.transformed) return;
 			target.formeChange('Shaymin', this.effect);
 		},
-		onAfterDamage(damage, target, source, effect) {
-			if (source === target) return;
-			if (target && target.template.speciesid === 'shaymin') {
+		onDamagingHit(damage, target, source, move) {
+			if (target.template.speciesid === 'shaymin') {
 				target.formeChange('Shaymin-Sky', this.effect);
 			}
 		},
@@ -333,9 +332,9 @@ let BattleAbilities = {
 				pokemon.maybeTrapped = true;
 			}
 		},
-		onAfterDamageOrder: 1,
-		onAfterDamage(damage, target, source, move) {
-			if (source && source !== target && move && move.effectType === 'Move' && !target.hp) {
+		onDamagingHitOrder: 1,
+		onDamagingHit(damage, target, source, move) {
+			if (!target.hp) {
 				this.damage(damage, source, target);
 			}
 		},
@@ -407,8 +406,8 @@ let BattleAbilities = {
 	giblovepls: {
 		desc: "After being damaged by a contact move, this Pokemon is healed by 20% of its maximum HP and has its Defense raised by one stage.",
 		shortDesc: "Defense +1 and heal 20% after hit by contact move.",
-		onAfterDamage(damage, target, source, effect) {
-			if (effect && effect.flags['contact']) {
+		onDamagingHit(damage, target, source, move) {
+			if (move.flags['contact']) {
 				this.boost({def: 1}, target);
 				this.heal(target.baseMaxhp / 5, target);
 			}
@@ -452,10 +451,10 @@ let BattleAbilities = {
 			if (pokemon === pokemon.side.pokemon[i]) return;
 			pokemon.illusion = pokemon.side.pokemon[i];
 		},
-		onAfterDamage(damage, target, source, effect) {
+		onDamagingHit(damage, target, source, move) {
 			// Illusion that only breaks when hit with a move that is super effective VS dark
-			if (target.illusion && effect && effect.effectType === 'Move' && effect.id !== 'confused' && this.dex.getEffectiveness(effect.type, target.getTypes()) > 0) {
-				this.singleEvent('End', this.dex.getAbility('Illusion'), target.abilityData, target, source, effect);
+			if (target.illusion && this.dex.getEffectiveness(move.type, target.getTypes()) > 0) {
+				this.singleEvent('End', this.dex.getAbility('Illusion'), target.abilityData, target, source, move);
 			}
 		},
 		onEnd(pokemon) {
@@ -632,8 +631,8 @@ let BattleAbilities = {
 				return this.chainModify([0x1333, 0x1000]);
 			}
 		},
-		onAfterDamage(damage, target, source, effect) {
-			if (effect && effect.effectType === 'Move' && effect.flags.contact && effect.id !== 'confused') {
+		onDamagingHit(damage, target, source, move) {
+			if (move.flags['contact']) {
 				this.boost({spe: 1});
 			}
 		},
@@ -917,7 +916,7 @@ let BattleAbilities = {
 				return false;
 			}
 		},
-		onAfterDamage(damage, target, source, move) {
+		onDamagingHit(damage, target, source, move) {
 			if (target.getMoveHitData(move).typeMod > 0) {
 				if (target.m.heavilydamaged && !target.m.quoteplayed) {
 					this.add(`c|@Ransei|Yo really? Why do you keep hitting me with super effective moves?`);

--- a/data/mods/ssb/statuses.js
+++ b/data/mods/ssb/statuses.js
@@ -1404,7 +1404,7 @@ let BattleStatuses = {
 			// Prevent Snaquaza from fainting while using a fake claim to prevent visual bug
 			if (pokemon.hp - damage <= 0) return (pokemon.hp - 1);
 		},
-		onAfterDamage(damage, pokemon) {
+		onDamagingHit(damage, pokemon) {
 			// Hack for Snaquaza's Z move
 			if (!pokemon.m.claimHP || pokemon.hp > 1) return;
 			// Now we handle the fake claim "fainting"

--- a/data/moves.js
+++ b/data/moves.js
@@ -2974,8 +2974,8 @@ let BattleMovedex = {
 				if (source !== this.effectData.target) return;
 				return source.side.foe.active[this.effectData.position];
 			},
-			onAfterDamage(damage, target, source, effect) {
-				if (effect && effect.effectType === 'Move' && source.side !== target.side && this.getCategory(effect) === 'Physical') {
+			onDamagingHit(damage, target, source, move) {
+				if (source.side !== target.side && this.getCategory(move) === 'Physical') {
 					this.effectData.position = source.position;
 					this.effectData.damage = 2 * damage;
 				}
@@ -6941,7 +6941,7 @@ let BattleMovedex = {
 		flags: {},
 		isMax: "Duraludon",
 		self: {
-			onAfterHit(source) {
+			onHit(source) {
 				for (let pokemon of source.side.foe.active) {
 					const move = pokemon.lastMove;
 					if (move && !move.isZ && !move.isMax) {
@@ -6975,7 +6975,7 @@ let BattleMovedex = {
 		flags: {},
 		isMax: "Alcremie",
 		self: {
-			onAfterHit(target, source, move) {
+			onHit(target, source, move) {
 				for (let pokemon of source.side.active) {
 					this.heal(pokemon.maxhp / 6, pokemon, source, move);
 				}
@@ -11944,8 +11944,8 @@ let BattleMovedex = {
 				if (source !== this.effectData.target) return;
 				return source.side.foe.active[this.effectData.position];
 			},
-			onAfterDamage(damage, target, source, effect) {
-				if (effect && effect.effectType === 'Move' && source.side !== target.side) {
+			onDamagingHit(damage, target, source, effect) {
+				if (source.side !== target.side) {
 					this.effectData.position = source.position;
 					this.effectData.damage = 1.5 * damage;
 				}
@@ -12301,8 +12301,8 @@ let BattleMovedex = {
 				if (source !== this.effectData.target) return;
 				return source.side.foe.active[this.effectData.position];
 			},
-			onAfterDamage(damage, target, source, effect) {
-				if (effect && effect.effectType === 'Move' && source.side !== target.side && this.getCategory(effect) === 'Special') {
+			onDamagingHit(damage, target, source, move) {
+				if (source.side !== target.side && this.getCategory(move) === 'Special') {
 					this.effectData.position = source.position;
 					this.effectData.damage = 2 * damage;
 				}

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -708,6 +708,15 @@ let BattleScripts = {
 		// @ts-ignore
 		this.afterMoveSecondaryEvent(targetsCopy.filter(val => !!val), pokemon, move);
 
+		if (!move.negateSecondary && !(move.hasSheerForce && pokemon.hasAbility('sheerforce'))) {
+			for (let i = 0; i < damage.length; i++) {
+				const curDamage = damage[i];
+				if (typeof curDamage === 'number' && targets[i].hp <= targets[i].maxhp / 2 && targets[i].hp + curDamage > targets[i].maxhp / 2) {
+					this.runEvent('EmergencyExit', targets[i], pokemon);
+				}
+			}
+		}
+
 		return damage;
 	},
 	spreadMoveHit(targets, pokemon, moveOrMoveName, moveData, isSecondary, isSelf) {
@@ -801,12 +810,16 @@ let BattleScripts = {
 				damagedDamage.push(damage[i]);
 			}
 		}
+		const pokemonOriginalHP = pokemon.hp;
 		if (damagedDamage.length) {
 			this.runEvent('DamagingHit', damagedTargets, pokemon, move, damagedDamage);
 			if (moveData.onAfterHit) {
 				for (const target of damagedTargets) {
 					this.singleEvent('AfterHit', moveData, {}, target, pokemon, move);
 				}
+			}
+			if (pokemon.hp <= pokemon.maxhp / 2 && pokemonOriginalHP > pokemon.maxhp / 2) {
+				this.runEvent('EmergencyExit', pokemon);
 			}
 		}
 

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -416,7 +416,8 @@ export class Battle {
 	singleEvent(
 		eventid: string, effect: Effect, effectData: AnyObject | null,
 		target: string | Pokemon | Side | Field | Battle | null, source?: string | Pokemon | Effect | false | null,
-		sourceEffect?: Effect | string | null, relayVar?: any) {
+		sourceEffect?: Effect | string | null, relayVar?: any
+	) {
 		if (this.eventDepth >= 8) {
 			// oh fuck
 			this.add('message', 'STACK LIMIT EXCEEDED');
@@ -588,7 +589,8 @@ export class Battle {
 	 */
 	runEvent(
 		eventid: string, target?: Pokemon | Pokemon[] | Side | Battle | null, source?: string | Pokemon | false | null,
-		effect?: Effect | null, relayVar?: any, onEffect?: boolean, fastExit?: boolean) {
+		effect?: Effect | null, relayVar?: any, onEffect?: boolean, fastExit?: boolean
+	) {
 		// if (Battle.eventCounter) {
 		// 	if (!Battle.eventCounter[eventid]) Battle.eventCounter[eventid] = 0;
 		// 	Battle.eventCounter[eventid]++;
@@ -605,7 +607,7 @@ export class Battle {
 		let effectSource = null;
 		if (source instanceof Pokemon) effectSource = source;
 		const handlers = this.findEventHandlers(target, eventid, effectSource);
-		if (eventid === 'Invulnerability' || eventid === 'TryHit' || eventid === 'AfterDamage') {
+		if (eventid === 'Invulnerability' || eventid === 'TryHit' || eventid === 'DamagingHit') {
 			handlers.sort(Battle.compareLeftToRightOrder);
 		} else if (fastExit) {
 			handlers.sort(Battle.compareRedirectOrder);
@@ -650,7 +652,7 @@ export class Battle {
 			if (handler.index !== undefined) {
 				// TODO: find a better way to do this
 				if (!targetRelayVars[handler.index] && !(targetRelayVars[handler.index] === 0 &&
-					eventid === 'AfterDamage')) continue;
+					eventid === 'DamagingHit')) continue;
 				if (handler.target) {
 					args[hasRelayVar] = handler.target;
 					this.event.target = handler.target;
@@ -763,7 +765,8 @@ export class Battle {
 	 */
 	priorityEvent(
 		eventid: string, target: Pokemon | Side | Battle, source?: Pokemon | null,
-		effect?: Effect, relayVar?: any, onEffect?: boolean): any {
+		effect?: Effect, relayVar?: any, onEffect?: boolean
+	): any {
 		return this.runEvent(eventid, target, source, effect, relayVar, onEffect, true);
 	}
 
@@ -1750,8 +1753,6 @@ export class Battle {
 			}
 		}
 
-		// @ts-ignore - FIXME AfterDamage passes an Effect, not an ActiveMove
-		if (!effect.flags) effect.flags = {};
 		if (instafaint) {
 			for (const [i, target] of targetArray.entries()) {
 				if (!retVals[i] || !target) continue;
@@ -1766,7 +1767,6 @@ export class Battle {
 				}
 			}
 		}
-		retVals = this.runEvent('AfterDamage', (targetArray.filter(val => !!val)) as Pokemon[], source, effect, retVals);
 
 		return retVals;
 	}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2608,6 +2608,7 @@ export class Battle {
 	}
 
 	runAction(action: Actions.Action) {
+		const pokemonOriginalHP = action.pokemon?.hp;
 		// returns whether or not we ended in a callback
 		switch (action.choice) {
 		case 'start': {
@@ -2835,6 +2836,13 @@ export class Battle {
 		}
 
 		this.eachEvent('Update');
+
+		if (action.choice === 'runSwitch') {
+			if (action.pokemon.hp <= action.pokemon.maxhp / 2 && pokemonOriginalHP! > action.pokemon.maxhp / 2) {
+				this.runEvent('EmergencyExit', action.pokemon);
+			}
+		}
+
 		if (this.gen >= 8 && this.queue.length && this.queue[0].choice === 'move') {
 			// In gen 8, speed is updated dynamically so update the queue's speed properties and sort it.
 			this.updateSpeed();

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -195,6 +195,7 @@ interface PureEffectEventMethods {
 
 interface EventMethods {
 	onDamagingHit?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void
+	onEmergencyExit?: (this: Battle, pokemon: Pokemon) => void
 	onAfterEachBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon) => void
 	onAfterHit?: MoveEventMethods['onAfterHit']
 	onAfterSetStatus?: (this: Battle, status: PureEffect, target: Pokemon, source: Pokemon, effect: Effect) => void

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -109,7 +109,6 @@ interface SelfEffect {
 	terrain?: string
 	volatileStatus?: string
 	weather?: string
-	onAfterHit?: MoveEventMethods['onAfterHit']
 	onHit?: MoveEventMethods['onHit']
 }
 
@@ -122,7 +121,6 @@ interface SecondaryEffect {
 	self?: SelfEffect
 	status?: string
 	volatileStatus?: string
-	onAfterHit?: MoveEventMethods['onAfterHit']
 	onHit?: MoveEventMethods['onHit']
 }
 
@@ -196,7 +194,7 @@ interface PureEffectEventMethods {
 }
 
 interface EventMethods {
-	onAfterDamage?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void
+	onDamagingHit?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void
 	onAfterEachBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon) => void
 	onAfterHit?: MoveEventMethods['onAfterHit']
 	onAfterSetStatus?: (this: Battle, status: PureEffect, target: Pokemon, source: Pokemon, effect: Effect) => void
@@ -283,7 +281,7 @@ interface EventMethods {
 	onWeatherModifyDamage?: CommonHandlers['ModifierSourceMove']
 	onModifyDamagePhase1?: CommonHandlers['ModifierSourceMove']
 	onModifyDamagePhase2?: CommonHandlers['ModifierSourceMove']
-	onAllyAfterDamage?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void
+	onAllyDamagingHit?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void
 	onAllyAfterEachBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon) => void
 	onAllyAfterHit?: MoveEventMethods['onAfterHit']
 	onAllyAfterSetStatus?: (this: Battle, status: PureEffect, target: Pokemon, source: Pokemon, effect: Effect) => void
@@ -368,7 +366,7 @@ interface EventMethods {
 	onAllyWeatherModifyDamage?: CommonHandlers['ModifierSourceMove']
 	onAllyModifyDamagePhase1?: CommonHandlers['ModifierSourceMove']
 	onAllyModifyDamagePhase2?: CommonHandlers['ModifierSourceMove']
-	onFoeAfterDamage?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void
+	onFoeDamagingHit?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void
 	onFoeAfterEachBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon) => void
 	onFoeAfterHit?: MoveEventMethods['onAfterHit']
 	onFoeAfterSetStatus?: (this: Battle, status: PureEffect, target: Pokemon, source: Pokemon, effect: Effect) => void
@@ -453,7 +451,7 @@ interface EventMethods {
 	onFoeWeatherModifyDamage?: CommonHandlers['ModifierSourceMove']
 	onFoeModifyDamagePhase1?: CommonHandlers['ModifierSourceMove']
 	onFoeModifyDamagePhase2?: CommonHandlers['ModifierSourceMove']
-	onSourceAfterDamage?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void
+	onSourceDamagingHit?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void
 	onSourceAfterEachBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon) => void
 	onSourceAfterHit?: MoveEventMethods['onAfterHit']
 	onSourceAfterSetStatus?: (this: Battle, status: PureEffect, target: Pokemon, source: Pokemon, effect: Effect) => void
@@ -538,7 +536,7 @@ interface EventMethods {
 	onSourceWeatherModifyDamage?: CommonHandlers['ModifierSourceMove']
 	onSourceModifyDamagePhase1?: CommonHandlers['ModifierSourceMove']
 	onSourceModifyDamagePhase2?: CommonHandlers['ModifierSourceMove']
-	onAnyAfterDamage?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void
+	onAnyDamagingHit?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void
 	onAnyAfterEachBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon) => void
 	onAnyAfterHit?: MoveEventMethods['onAfterHit']
 	onAnyAfterSetStatus?: (this: Battle, status: PureEffect, target: Pokemon, source: Pokemon, effect: Effect) => void
@@ -626,7 +624,7 @@ interface EventMethods {
 
 	// Priorities (incomplete list)
 	onAccuracyPriority?: number
-	onAfterDamageOrder?: number
+	onDamagingHitOrder?: number
 	onAfterMoveSecondaryPriority?: number
 	onAfterMoveSecondarySelfPriority?: number
 	onAfterMoveSelfPriority?: number

--- a/simulator-doc.txt
+++ b/simulator-doc.txt
@@ -82,13 +82,11 @@ runAction() - runs runSwitch, runAfterSwitch, and runMove in priority order, the
 					[Damage] (A,U)
 					-> false => exit damage()
 					damage
-					[AfterDamage] (U)
 				}
 				heal() {
 					[Heal] (A)
 					-> false => exit heal()
 					heal
-					[AfterHeal]
 				}
 				status() (U) {
 					[Status] (A)

--- a/test/sim/abilities/emergencyexit.js
+++ b/test/sim/abilities/emergencyexit.js
@@ -23,12 +23,26 @@ describe(`Emergency Exit`, function () {
 		assert.strictEqual(battle.requestState, 'switch');
 	});
 
-	it(`should not request switch-out if first healed by berry`, function () {
+	it(`should not request switch-out if attacked and healed by berry`, function () {
 		battle = common.createBattle([
 			[{species: "Golisopod", ability: 'emergencyexit', moves: ['sleeptalk'], item: 'sitrusberry', ivs: EMPTY_IVS}, {species: "Clefable", ability: 'Unaware', moves: ['metronome']}],
 			[{species: "Raticate", ability: 'guts', moves: ['superfang']}],
 		]);
 		battle.makeChoices('move sleeptalk', 'move superfang');
+		assert.strictEqual(battle.requestState, 'move');
+	});
+
+	it(`should not request switch-out after taking residual damage and getting healed by berry`, function () {
+		battle = common.createBattle([
+			[{species: "Golisopod", ability: 'emergencyexit', moves: ['uturn', 'sleeptalk'], item: 'sitrusberry'}, {species: "Magikarp", ability: 'swiftswim', moves: ['splash']}],
+			[{species: "Ferrothorn", ability: 'ironbarbs', moves: ['stealthrock', 'spikes', 'protect']}],
+		]);
+		battle.makeChoices('move uturn', 'move stealthrock');
+		battle.makeChoices('switch 2', '');
+		battle.makeChoices('move splash', 'move spikes');
+		battle.makeChoices('move splash', 'move spikes');
+		battle.makeChoices('move splash', 'move spikes');
+		battle.makeChoices('switch 2', 'move protect');
 		assert.strictEqual(battle.requestState, 'move');
 	});
 


### PR DESCRIPTION
Fixes #6346

#6346 reports that all existing `AfterDamage` handlers should happen after secondaries.

This does that:

- The `AfterDamage` event has been replaced with `DamagingHit`, which which happens for damaging moves after secondaries.

- The `AfterHit` event has also been moved after `DamagingHit`, to make sure Knock Off still procs after Rocky Helmet.

- `AfterHit` is no longer a valid event on `secondary` and `self` blocks, because it's meaningless in those blocks, anyway. All `self.onAfterHit` and `secondary.onAfterHit` handlers have been moved to `onHit`, which should have the same timing in practice.