### PR TITLE
Add Max Move/LightningRod/Storm Drain tests

### DIFF
--- a/test/sim/abilities/lightningrod.js
+++ b/test/sim/abilities/lightningrod.js
@@ -119,4 +119,19 @@ describe('Lightning Rod', function () {
 		assert.false.fullHP(rodPokemon);
 		assert.false.fullHP(ally);
 	});
+
+	it('should redirect Max Lightning from an ally', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [
+			{species: 'Manectric', ability: 'lightningrod', moves: ['sleep talk']},
+			{species: 'Boltund', ability: 'strong jaw', moves: ['thunderbolt']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Igglybuff', ability: 'cute charm', moves: ['sleep talk']},
+			{species: 'Igglybuff', ability: 'cute charm', moves: ['sleep talk']},
+		]});
+		battle.makeChoices('move sleeptalk, move thunderbolt 1 dynamax', 'move sleep talk, move sleep talk');
+		assert.fullHP(battle.p1.active[0]);
+		assert.statStage(battle.p1.active[0], 'spa', 1);
+	});
 });

--- a/test/sim/abilities/stormdrain.js
+++ b/test/sim/abilities/stormdrain.js
@@ -85,4 +85,19 @@ describe('Storm Drain', function () {
 		assert.false.fullHP(stormDrainMon);
 		assert.false.fullHP(ally);
 	});
+
+	it('should redirect Max Geyser from an ally', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [
+			{species: 'Gastrodon', ability: 'stormdrain', moves: ['sleep talk']},
+			{species: 'Manaphy', ability: 'hydration', moves: ['scald']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Igglybuff', ability: 'cute charm', moves: ['sleep talk']},
+			{species: 'Igglybuff', ability: 'cute charm', moves: ['sleep talk']},
+		]});
+		battle.makeChoices('move sleeptalk, move scald 1 dynamax', 'move sleep talk, move sleep talk');
+		assert.fullHP(battle.p1.active[0]);
+		assert.statStage(battle.p1.active[0], 'spa', 1);
+	});
 });


### PR DESCRIPTION
If an ally Pokemon uses a Max Water / Max Electric move when the ally has Storm Drain / Lightning Rod, they should be redirected into that ally and boost the ally's Sp. Atk.