### PR TITLE
Refactor Dragon Darts

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -4625,7 +4625,11 @@ let BattleAbilities = {
 			if (target === source || move.category === 'Status' || move.type === '???' || move.id === 'struggle') return;
 			this.debug('Wonder Guard immunity: ' + move.id);
 			if (target.runEffectiveness(move) <= 0) {
-				this.add('-immune', target, '[from] ability: Wonder Guard');
+				if (move.smartTarget) {
+					move.smartTarget = false;
+				} else {
+					this.add('-immune', target, '[from] ability: Wonder Guard');
+				}
 				return null;
 			}
 		},

--- a/data/moves.js
+++ b/data/moves.js
@@ -1057,7 +1057,11 @@ let BattleMovedex = {
 					if (move.isZ || move.isMax) target.getMoveHitData(move).zBrokeProtect = true;
 					return;
 				}
-				this.add('-activate', target, 'move: Protect');
+				if (move.smartTarget) {
+					move.smartTarget = false;
+				} else {
+					this.add('-activate', target, 'move: Protect');
+				}
 				let lockedmove = source.getVolatile('lockedmove');
 				if (lockedmove) {
 					// Outrage counter is reset
@@ -10051,7 +10055,11 @@ let BattleMovedex = {
 					if (move.isZ || move.isMax) target.getMoveHitData(move).zBrokeProtect = true;
 					return;
 				}
-				this.add('-activate', target, 'move: Protect');
+				if (move.smartTarget) {
+					move.smartTarget = false;
+				} else {
+					this.add('-activate', target, 'move: Protect');
+				}
 				let lockedmove = source.getVolatile('lockedmove');
 				if (lockedmove) {
 					// Outrage counter is reset
@@ -11367,7 +11375,11 @@ let BattleMovedex = {
 				if (!blockedByMaxGuard) {
 					return;
 				}
-				this.add('-activate', target, 'move: Max Guard');
+				if (move.smartTarget) {
+					move.smartTarget = false;
+				} else {
+					this.add('-activate', target, 'move: Max Guard');
+				}
 				let lockedmove = source.getVolatile('lockedmove');
 				if (lockedmove) {
 					// Outrage counter is reset
@@ -13136,7 +13148,11 @@ let BattleMovedex = {
 					if (move.isZ || move.isMax) target.getMoveHitData(move).zBrokeProtect = true;
 					return;
 				}
-				this.add('-activate', target, 'move: Protect');
+				if (move.smartTarget) {
+					move.smartTarget = false;
+				} else {
+					this.add('-activate', target, 'move: Protect');
+				}
 				let lockedmove = source.getVolatile('lockedmove');
 				if (lockedmove) {
 					// Outrage counter is reset
@@ -14312,7 +14328,11 @@ let BattleMovedex = {
 					if (move.isZ || move.isMax) target.getMoveHitData(move).zBrokeProtect = true;
 					return;
 				}
-				this.add('-activate', target, 'move: Protect');
+				if (move.smartTarget) {
+					move.smartTarget = false;
+				} else {
+					this.add('-activate', target, 'move: Protect');
+				}
 				let lockedmove = source.getVolatile('lockedmove');
 				if (lockedmove) {
 					// Outrage counter is reset
@@ -17943,7 +17963,11 @@ let BattleMovedex = {
 					if (move.isZ || move.isMax) target.getMoveHitData(move).zBrokeProtect = true;
 					return;
 				}
-				this.add('-activate', target, 'move: Protect');
+				if (move.smartTarget) {
+					move.smartTarget = false;
+				} else {
+					this.add('-activate', target, 'move: Protect');
+				}
 				let lockedmove = source.getVolatile('lockedmove');
 				if (lockedmove) {
 					// Outrage counter is reset

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -631,7 +631,13 @@ let BattleScripts = {
 				targetsCopy = targets.slice(0);
 			}
 			let target = targetsCopy[0]; // some relevant-to-single-target-moves-only things are hardcoded
-			if (target && typeof move.smartTarget === 'boolean') this.addMove('-anim', pokemon, move.name, target);
+			if (target && typeof move.smartTarget === 'boolean') {
+				if (hit > 1) {
+					this.addMove('-anim', pokemon, move.name, target);
+				} else {
+					this.retargetLastMove(target);
+				}
+			}
 
 			// like this (Triple Kick)
 			if (target && move.multiaccuracy && hit > 1) {

--- a/data/scripts.js
+++ b/data/scripts.js
@@ -378,8 +378,12 @@ let BattleScripts = {
 		const hitResults = this.runEvent('Invulnerability', targets, pokemon, move);
 		for (const [i, target] of targets.entries()) {
 			if (hitResults[i] === false) {
-				if (!move.spreadHit) this.attrLastMove('[miss]');
-				this.add('-miss', pokemon, target);
+				if (move.smartTarget) {
+					move.smartTarget = false;
+				} else {
+					if (!move.spreadHit) this.attrLastMove('[miss]');
+					this.add('-miss', pokemon, target);
+				}
 			}
 		}
 		return hitResults;
@@ -402,7 +406,8 @@ let BattleScripts = {
 
 		const hitResults = [];
 		for (let i = 0; i < targets.length; i++) {
-			hitResults[i] = (move.ignoreImmunity && (move.ignoreImmunity === true || move.ignoreImmunity[move.type])) || targets[i].runImmunity(move.type, true);
+			hitResults[i] = (move.ignoreImmunity && (move.ignoreImmunity === true || move.ignoreImmunity[move.type])) || targets[i].runImmunity(move.type, !move.smartTarget);
+			if (move.smartTarget && !hitResults[i]) move.smartTarget = false;
 		}
 
 		return hitResults;
@@ -480,9 +485,12 @@ let BattleScripts = {
 				accuracy = this.runEvent('Accuracy', target, pokemon, move, accuracy);
 			}
 			if (accuracy !== true && !this.randomChance(accuracy, 100)) {
-				if (!move.spreadHit) this.attrLastMove('[miss]');
-				const hideFailure = move.smartTarget && (i < targets.length - 1 || hitResults.some(Boolean));
-				if (!hideFailure) this.add('-miss', pokemon, target);
+				if (move.smartTarget) {
+					move.smartTarget = false;
+				} else {
+					if (!move.spreadHit) this.attrLastMove('[miss]');
+					this.add('-miss', pokemon, target);
+				}
 				if (pokemon.hasItem('blunderpolicy') && pokemon.useItem()) this.boost({spe: 2}, pokemon);
 				hitResults[i] = false;
 				continue;
@@ -619,11 +627,11 @@ let BattleScripts = {
 			move.hit = hit;
 			if (move.smartTarget && targets.length > 1) {
 				targetsCopy = [targets[hit - 1]];
-				if (targetsCopy[0] && hit > 1) this.addMove('-anim', pokemon, move.name, targetsCopy[0]);
 			} else {
 				targetsCopy = targets.slice(0);
 			}
 			let target = targetsCopy[0]; // some relevant-to-single-target-moves-only things are hardcoded
+			if (target && typeof move.smartTarget === 'boolean') this.addMove('-anim', pokemon, move.name, target);
 
 			// like this (Triple Kick)
 			if (target && move.multiaccuracy && hit > 1) {

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -602,33 +602,21 @@ export class Pokemon {
 	}
 
 	/** Get targets for Dragon Darts */
-	getSmartTargets(target: Pokemon, move: Move) {
+	getSmartTargets(target: Pokemon, move: ActiveMove) {
+		this.battle.attrLastMove('[still]');
 		const target2 = target.nearbyAllies()[0];
-		if (!target2 || target2 === this || !target2.hp) return [target];
-		if (!target.hp) return [target2];
-
-		if (target.isSemiInvulnerable()) return [target2];
-		if (target2.isSemiInvulnerable()) return [target];
-
-		if (target.isProtected()) return [target2];
-		if (target2.isProtected()) return [target];
-
-		if (target.side.sideConditions['matblock']) return [target2];
-
-		if (target.hasAbility('wonderguard') && this.battle.dex.getEffectiveness(move.type, target) <= 0) {
-			return [target2];
-		}
-		if (target2.hasAbility('wonderguard') && this.battle.dex.getEffectiveness(move.type, target2) <= 0) {
+		if (!target2 || target2 === this || !target2.hp) {
+			move.smartTarget = false;
 			return [target];
 		}
-
-		if (!target.hasItem('ringtarget') && !this.battle.dex.getImmunity(move.type, target)) return [target2];
-		if (!target2.hasItem('ringtarget') && !this.battle.dex.getImmunity(move.type, target2)) return [target];
-
+		if (!target.hp) {
+			move.smartTarget = false;
+			return [target2];
+		}
 		return [target, target2];
 	}
 
-	getMoveTargets(move: Move, target: Pokemon): {targets: Pokemon[], pressureTargets: Pokemon[]} {
+	getMoveTargets(move: ActiveMove, target: Pokemon): {targets: Pokemon[], pressureTargets: Pokemon[]} {
 		let targets: Pokemon[] = [];
 		let pressureTargets;
 
@@ -667,16 +655,15 @@ export class Pokemon {
 				if (!possibleTarget) return {targets: [], pressureTargets: []};
 				target = possibleTarget;
 			}
-			const activeMove = this.battle.dex.getActiveMove(move);
 			if (target.side.active.length > 1 && !move.tracksTarget) {
 				const isCharging = move.flags['charge'] && !this.volatiles['twoturnmove'] &&
 					!(move.id.startsWith('solarb') && this.battle.field.isWeather(['sunnyday', 'desolateland'])) &&
 					!(this.hasItem('powerherb') && move.id !== 'skydrop');
 				if (!isCharging) {
-					target = this.battle.priorityEvent('RedirectTarget', this, this, activeMove, target);
+					target = this.battle.priorityEvent('RedirectTarget', this, this, move, target);
 				}
 			}
-			if (activeMove.smartTarget) {
+			if (move.smartTarget) {
 				targets = this.getSmartTargets(target, move);
 				target = targets[0];
 			} else {

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -603,7 +603,6 @@ export class Pokemon {
 
 	/** Get targets for Dragon Darts */
 	getSmartTargets(target: Pokemon, move: ActiveMove) {
-		this.battle.attrLastMove('[still]');
 		const target2 = target.nearbyAllies()[0];
 		if (!target2 || target2 === this || !target2.hp) {
 			move.smartTarget = false;

--- a/test/sim/moves/dragondarts.js
+++ b/test/sim/moves/dragondarts.js
@@ -126,6 +126,24 @@ describe('Dragon Darts', function () {
 		assert.statStage(battle.p2.active[1], 'def', 0);
 	});
 
+	it('should hit one target twice if the other is protected by an ability', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [
+			{species: "Dragapult", ability: "Clear Body", moves: ["dragondarts"]},
+			{species: "Grimmsnarl", ability: "Prankster", moves: ["electrify"]},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: "Arcanine", ability: "Stamina", moves: ["sleeptalk"]},
+			{species: "Emolga", ability: "Motor Drive", moves: ["sleeptalk"]},
+		]});
+		battle.makeChoices('move dragondarts 2, move electrify -1', 'move sleeptalk, move sleeptalk');
+
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.equal(battle.p2.active[1].hp, battle.p2.active[1].maxhp);
+		assert.statStage(battle.p2.active[0], 'def', 2);
+		assert.statStage(battle.p2.active[1], 'spe', 1);
+	});
+
 	it('should hit one target twice if the other is immunue', function () {
 		battle = common.createBattle({gameType: 'doubles'});
 		battle.setPlayer('p1', {team: [


### PR DESCRIPTION
This makes `move.smartTarget` a three-state. I was considering turning it into an integer though.

If it's `true`, then this means that there are two targets, so that Wonder Guard, Protect, semi-invulnerability, type immunity and evasion should be silent.

However, as soon as one of these effects applies, it then goes and sets it to `false`, which means that further failure messages for the other target will appear normally.

Thus if Dragon Darts misses both targets due to evasion, only the neighbouring ally's miss message will appear, as desired.

Note that `false` still counts as smart targeting from the point of view of the hit step loop.

I also tweaked the early exit condition from the hit step loop so that Dragon Darts can hit both foes even if the first faints.