### PR TITLE
Add ADV UU NFE Clause

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -1022,7 +1022,7 @@ let Formats = [
 
 		mod: 'gen3',
 		// searchShow: false,
-		ruleset: ['Standard'],
+		ruleset: ['Standard', 'UU NFE Clause'],
 		banlist: ['Uber', 'OU', 'UUBL', 'Smeargle + Ingrain'],
 	},
 	{
@@ -2139,7 +2139,7 @@ let Formats = [
 
 		mod: 'gen3',
 		searchShow: false,
-		ruleset: ['[Gen 3] UU'],
+		ruleset: ['[Gen 3] UU', '!UU NFE Clause'],
 		banlist: ['UU'],
 	},
 	{

--- a/data/mods/gen3/rulesets.js
+++ b/data/mods/gen3/rulesets.js
@@ -8,6 +8,28 @@ let BattleFormats = {
 		desc: "The standard ruleset for all offical Smogon singles tiers (Ubers, OU, etc.)",
 		ruleset: ['Obtainable', 'Sleep Clause Mod', 'Switch Priority Clause Mod', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Moody Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],
 	},
+	uunfeclause: {
+		effectType: 'ValidatorRule',
+		name: 'UU NFE Clause',
+		desc: "Bans all NFE Pokemon, except Scyther.",
+		banlist: [
+			"Abra", "Anorith", "Aron", "Azurill", "Bagon", "Baltoy", "Barboach", "Bayleef", "Beldum", "Bellsprout", "Bulbasaur","Cacnea",
+			"Carvanha", "Cascoon", "Caterpie", "Charmander", "Charmeleon", "Chikorita", "Chinchou", "Clamperl", "Clefairy", "Cleffa",
+			"Combusken", "Corphish", "Croconaw", "Cubone", "Cyndaquil", "Diglett", "Doduo", "Dragonair", "Dratini", "Drowzee", "Duskull",
+			"Eevee", "Ekans", "Electrike", "Elekid", "Exeggcute", "Feebas", "Flaaffy", "Gastly", "Geodude", "Gloom", "Goldeen", "Grimer",
+			"Grovyle", "Growlithe", "Gulpin", "Hoothoot", "Hoppip", "Horsea", "Houndour", "Igglybuff", "Ivysaur", "Jigglypuff", "Kabuto",
+			"Kakuna", "Kirlia", "Koffing", "Krabby", "Lairon", "Larvitar", "Ledyba", "Lileep", "Lombre", "Lotad", "Loudred", "Machoke",
+			"Machop", "Magby", "Magikarp", "Magnemite", "Makuhita", "Mankey", "Mareep", "Marill", "Marshtomp", "Meditite", "Meowth", "Metang",
+			"Metapod", "Mudkip", "Natu", "Nidoran-F", "Nidoran-M", "Nidorina", "Nidorino", "Nincada", "Numel", "Nuzleaf", "Oddish", "Omanyte",
+			"Onix", "Paras", "Phanpy", "Pichu", "Pidgeotto", "Pidgey", "Pikachu", "Pineco", "Poliwag", "Poliwhirl", "Ponyta", "Poochyena",
+			"Porygon", "Psyduck", "Pupitar", "Quilava", "Ralts", "Rattata", "Remoraid", "Rhyhorn", "Sandshrew", "Scyther", "Seadra", "Sealeo",
+			"Seedot", "Seel", "Sentret", "Shelgon", "Shellder", "Shroomish", "Shuppet", "Silcoon", "Skiploom", "Skitty", "Slakoth", "Slowpoke",
+			"Slugma", "Smoochum", "Snorunt", "Snubbull", "Spearow", "Spheal", "Spinarak", "Spoink", "Squirtle", "Staryu", "Sunkern", "Surskit",
+			"Swablu", "Swinub", "Taillow", "Teddiursa", "Tentacool", "Togepi", "Torchic", "Totodile", "Trapinch", "Treecko", "Tyrogue", "Venonat",
+			"Vibrava", "Vigoroth", "Voltorb", "Vulpix", "Wailmer", "Wartortle", "Weedle", "Weepinbell", "Whismur", "Wingull", "Wooper", "Wurmple",
+			"Zigzagoon", "Zubat",
+		],
+	},
 };
 
 exports.BattleFormats = BattleFormats;

--- a/data/mods/gen3/rulesets.js
+++ b/data/mods/gen3/rulesets.js
@@ -13,7 +13,7 @@ let BattleFormats = {
 		name: 'UU NFE Clause',
 		desc: "Bans all NFE Pokemon, except Scyther.",
 		banlist: [
-			"Abra", "Anorith", "Aron", "Azurill", "Bagon", "Baltoy", "Barboach", "Bayleef", "Beldum", "Bellsprout", "Bulbasaur","Cacnea",
+			"Abra", "Anorith", "Aron", "Azurill", "Bagon", "Baltoy", "Barboach", "Bayleef", "Beldum", "Bellsprout", "Bulbasaur", "Cacnea",
 			"Carvanha", "Cascoon", "Caterpie", "Charmander", "Charmeleon", "Chikorita", "Chinchou", "Clamperl", "Clefairy", "Cleffa",
 			"Combusken", "Corphish", "Croconaw", "Cubone", "Cyndaquil", "Diglett", "Doduo", "Dragonair", "Dratini", "Drowzee", "Duskull",
 			"Eevee", "Ekans", "Electrike", "Elekid", "Exeggcute", "Feebas", "Flaaffy", "Gastly", "Geodude", "Gloom", "Goldeen", "Grimer",

--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -835,7 +835,13 @@ let BattleFormats = {
 		effectType: 'ValidatorRule',
 		name: 'Standard Pet Mod',
 		desc: "Holds all custom Pet Mod ruleset validation",
-		// Implemented in mods/petmod/rulesets.js
+		// Implemented in mods/[petmod]/rulesets.js
+	},
+	uunfeclause: {
+		effectType: 'ValidatorRule',
+		name: 'UU NFE Clause',
+		desc: "Bans all NFE Pokemon, except Scyther, from [Gen 3] UU.",
+		// Implemented in mods/gen3/rulesets.js
 	},
 };
 


### PR DESCRIPTION
Even though there is discussion about its existence, I was asked by hogg to implement it for the time being so that ADV UU is being accurately simulated.

I originally did this with ``onValidateSet`` and ``template.nfe``, but the ``template.nfe`` check isnt supported in previous generations.