### PR TITLE
Fix /tour autodq off

### DIFF
--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -774,7 +774,7 @@ export class Tournament extends Rooms.RoomGame {
 	}
 
 	setAutoDisqualifyTimeout(timeout: number, output: CommandContext) {
-		if (timeout < AUTO_DISQUALIFY_WARNING_TIMEOUT || timeout > MAX_AUTO_DISQUALIFY_TIMEOUT || isNaN(timeout)) {
+		if (timeout < AUTO_DISQUALIFY_WARNING_TIMEOUT || timeout > MAX_AUTO_DISQUALIFY_TIMEOUT && timeout !== Infinity || isNaN(timeout)) {
 			output.sendReply('|tournament|error|InvalidAutoDisqualifyTimeout');
 			return false;
 		}


### PR DESCRIPTION
The most recent change to this file prevents "/tour autodq off" from working and sends a "That isn't a valid timeout value." error to the client. This is because it checks for a condition where timeout is greater than 1 hour, but when turning autodq off, the timeout variable is set to Infinity.

This proposed change adds a check in the condition for if the timeout value is Infinity and does not send the error if that is the case (but if timeout is a numeric value greater than 1 hour, it still will fail).