### PR TITLE
Inheritance: Add basic move validation support

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -480,6 +480,8 @@ let Formats = [
 			/** @type {{[k: string]: string[]}} */
 			const abilityMap = Object.create(null);
 
+			const moves = set.moves.map(toID);
+
 			const donorBanlist = this.format.restricted || [];
 			for (const speciesid of Object.keys(dex.data.Pokedex)) {
 				const pokemon = dex.getTemplate(speciesid);
@@ -487,6 +489,15 @@ let Formats = [
 				if (pokemon.isUnreleased || pokemon.isNonstandard) continue;
 				if (pokemon.requiredItem || pokemon.requiredMove) continue;
 				if (pokemon.isGigantamax) continue;
+				/** @type {AnyObject | null} */
+				let learnset = null;
+				if (pokemon.learnset) learnset = pokemon.learnset;
+				if (!pokemon.learnset && dex.getLearnset(pokemon.baseSpecies)) learnset = dex.getLearnset(pokemon.baseSpecies);
+				if (!learnset) continue;
+				let learnsMove = true;
+				// @ts-ignore
+				if (learnset && !moves.some(move => !!Object.keys(learnset).map(toID).includes(move))) learnsMove = false;
+				if (!learnsMove) continue;
 				for (const key of Object.values(pokemon.abilities)) {
 					const abilityId = toID(key);
 					if (abilityMap[abilityId]) {


### PR DESCRIPTION
This fixes some some legal sets not being able to validate, such as a normal Abomasnow set not validating because it thinks the set is Vanillish.