### PR TITLE
Add a skipSets parameter to validateTeam

### DIFF
--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -1182,7 +1182,7 @@ interface FormatsData extends EventMethods {
 	) => string[] | void
 	onValidateTeam?: (this: TeamValidator, team: PokemonSet[], format: Format, teamHas: AnyObject) => string[] | void
 	validateSet?: (this: TeamValidator, set: PokemonSet, teamHas: AnyObject) => string[] | null
-	validateTeam?: (this: TeamValidator, team: PokemonSet[], removeNicknames: boolean) => string[] | void,
+	validateTeam?: (this: TeamValidator, team: PokemonSet[], removeNicknames: boolean, skipSets: boolean) => string[] | void,
 	trunc?: (n: number) => number;
 	section?: string,
 	column?: number

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -1182,7 +1182,10 @@ interface FormatsData extends EventMethods {
 	) => string[] | void
 	onValidateTeam?: (this: TeamValidator, team: PokemonSet[], format: Format, teamHas: AnyObject) => string[] | void
 	validateSet?: (this: TeamValidator, set: PokemonSet, teamHas: AnyObject) => string[] | null
-	validateTeam?: (this: TeamValidator, team: PokemonSet[], removeNicknames: boolean, skipSets: Record<string, Record<string, boolean>>) => string[] | void,
+	validateTeam?: (this: TeamValidator, team: PokemonSet[], options?: {
+		removeNicknames?: boolean,
+		skipSets?: {[name: string]: {[key: string]: boolean}},
+	}) => string[] | void,
 	trunc?: (n: number) => number;
 	section?: string,
 	column?: number

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -1182,7 +1182,7 @@ interface FormatsData extends EventMethods {
 	) => string[] | void
 	onValidateTeam?: (this: TeamValidator, team: PokemonSet[], format: Format, teamHas: AnyObject) => string[] | void
 	validateSet?: (this: TeamValidator, set: PokemonSet, teamHas: AnyObject) => string[] | null
-	validateTeam?: (this: TeamValidator, team: PokemonSet[], removeNicknames: boolean, skipSets: boolean) => string[] | void,
+	validateTeam?: (this: TeamValidator, team: PokemonSet[], removeNicknames: boolean, skipSets: Record<string, Record<string, boolean>>) => string[] | void,
 	trunc?: (n: number) => number;
 	section?: string,
 	column?: number

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -202,19 +202,23 @@ export class TeamValidator {
 
 	validateTeam(
 		team: PokemonSet[] | null,
-		removeNicknames = false,
-		skipSets: Record<string, Record<string, boolean>> = {}
+		options: {
+			removeNicknames?: boolean,
+			skipSets?: {[name: string]: {[key: string]: boolean}},
+		} = {}
 	): string[] | null {
 		if (team && this.format.validateTeam) {
-			return this.format.validateTeam.call(this, team, removeNicknames, skipSets) || null;
+			return this.format.validateTeam.call(this, team, options) || null;
 		}
-		return this.baseValidateTeam(team, removeNicknames, skipSets);
+		return this.baseValidateTeam(team, options);
 	}
 
 	baseValidateTeam(
 		team: PokemonSet[] | null,
-		removeNicknames = false,
-		skipSets: Record<string, Record<string, boolean>> = {}
+		options: {
+			removeNicknames?: boolean,
+			skipSets?: {[name: string]: {[key: string]: boolean}},
+		} = {}
 	): string[] | null {
 		const format = this.format;
 		const dex = this.dex;
@@ -253,8 +257,8 @@ export class TeamValidator {
 			if (!set) return [`You sent invalid team data. If you're not using a custom client, please report this as a bug.`];
 
 			let setProblems: string[] | null = null;
-			if (skipSets[set.name]) {
-				for (const i in skipSets[set.name]) {
+			if (options.skipSets && options.skipSets[set.name]) {
+				for (const i in options.skipSets[set.name]) {
 					teamHas[i] = (teamHas[i] || 0) + 1;
 				}
 			} else {
@@ -270,7 +274,7 @@ export class TeamValidator {
 			if (setProblems) {
 				problems = problems.concat(setProblems);
 			}
-			if (removeNicknames) {
+			if (options.removeNicknames) {
 				let crossTemplate: Template;
 				if (format.name === '[Gen 7] Cross Evolution' && (crossTemplate = dex.getTemplate(set.name)).exists) {
 					set.name = crossTemplate.species;

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -200,14 +200,14 @@ export class TeamValidator {
 			this.ruleTable.minSourceGen[0] : 1;
 	}
 
-	validateTeam(team: PokemonSet[] | null, removeNicknames = false): string[] | null {
+	validateTeam(team: PokemonSet[] | null, removeNicknames = false, skipSets = false): string[] | null {
 		if (team && this.format.validateTeam) {
-			return this.format.validateTeam.call(this, team, removeNicknames) || null;
+			return this.format.validateTeam.call(this, team, removeNicknames, skipSets) || null;
 		}
-		return this.baseValidateTeam(team, removeNicknames);
+		return this.baseValidateTeam(team, removeNicknames, skipSets);
 	}
 
-	baseValidateTeam(team: PokemonSet[] | null, removeNicknames = false): string[] | null {
+	baseValidateTeam(team: PokemonSet[] | null, removeNicknames = false, skipSets = false): string[] | null {
 		const format = this.format;
 		const dex = this.dex;
 
@@ -243,7 +243,7 @@ export class TeamValidator {
 		let lgpeStarterCount = 0;
 		for (const set of team) {
 			if (!set) return [`You sent invalid team data. If you're not using a custom client, please report this as a bug.`];
-			const setProblems = (format.validateSet || this.validateSet).call(this, set, teamHas);
+			const setProblems = skipSets ? null : (format.validateSet || this.validateSet).call(this, set, teamHas);
 			if (set.species === 'Pikachu-Starter' || set.species === 'Eevee-Starter') {
 				lgpeStarterCount++;
 				if (lgpeStarterCount === 2 && ruleTable.isBanned('nonexistent')) {

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -200,14 +200,22 @@ export class TeamValidator {
 			this.ruleTable.minSourceGen[0] : 1;
 	}
 
-	validateTeam(team: PokemonSet[] | null, removeNicknames = false, skipSets = false): string[] | null {
+	validateTeam(
+		team: PokemonSet[] | null,
+		removeNicknames = false,
+		skipSets: Record<string, Record<string, boolean>> = {}
+	): string[] | null {
 		if (team && this.format.validateTeam) {
 			return this.format.validateTeam.call(this, team, removeNicknames, skipSets) || null;
 		}
 		return this.baseValidateTeam(team, removeNicknames, skipSets);
 	}
 
-	baseValidateTeam(team: PokemonSet[] | null, removeNicknames = false, skipSets = false): string[] | null {
+	baseValidateTeam(
+		team: PokemonSet[] | null,
+		removeNicknames = false,
+		skipSets: Record<string, Record<string, boolean>> = {}
+	): string[] | null {
 		const format = this.format;
 		const dex = this.dex;
 
@@ -243,7 +251,16 @@ export class TeamValidator {
 		let lgpeStarterCount = 0;
 		for (const set of team) {
 			if (!set) return [`You sent invalid team data. If you're not using a custom client, please report this as a bug.`];
-			const setProblems = skipSets ? null : (format.validateSet || this.validateSet).call(this, set, teamHas);
+
+			let setProblems: string[] | null = null;
+			if (skipSets[set.name]) {
+				for (const i in skipSets[set.name]) {
+					teamHas[i] = (teamHas[i] || 0) + 1;
+				}
+			} else {
+				setProblems = (format.validateSet || this.validateSet).call(this, set, teamHas);
+			}
+
 			if (set.species === 'Pikachu-Starter' || set.species === 'Eevee-Starter') {
 				lgpeStarterCount++;
 				if (lgpeStarterCount === 2 && ruleTable.isBanned('nonexistent')) {


### PR DESCRIPTION
This option allows for decoupling intra-set validation from the inter-set team validations which is useful for the team validator to be used incrementally more efficiently in a generative context (i.e. each time a new set is added to a team the team can be validated and then *just* the new set, ie. N set validations instead of N!)