### PR TITLE
Force timer if blitz mod is in effect

### DIFF
--- a/data/rulesets.js
+++ b/data/rulesets.js
@@ -307,7 +307,7 @@ let BattleFormats = {
 		onBegin() {
 			this.add('rule', 'Blitz: Super-fast timer');
 		},
-		timer: {starting: 15, addPerTurn: 5, maxPerTurn: 15, maxFirstTurn: 30, grace: 30},
+		timer: {starting: 15, addPerTurn: 5, maxPerTurn: 15, maxFirstTurn: 40, grace: 30},
 	},
 	vgctimer: {
 		effectType: 'Rule',

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -567,11 +567,7 @@ export class RoomBattle extends RoomGames.RoomGame {
 			this.addPlayer(options.p4, options.p4team || '', options.p4rating);
 		}
 		this.timer = new RoomBattleTimer(this);
-		if (Config.forcetimer) {
-			this.timer.start();
-		} else if (this.format.includes('blitz')) {
-			this.timer.start();
-		}
+		if (Config.forcetimer || this.format.includes('blitz')) this.timer.start();
 		this.start();
 	}
 

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -568,6 +568,7 @@ export class RoomBattle extends RoomGames.RoomGame {
 		}
 		this.timer = new RoomBattleTimer(this);
 		if (Config.forcetimer) this.timer.start();
+		if (this.format.includes('blitz')) this.timer.start();
 		this.start();
 	}
 

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -567,8 +567,11 @@ export class RoomBattle extends RoomGames.RoomGame {
 			this.addPlayer(options.p4, options.p4team || '', options.p4rating);
 		}
 		this.timer = new RoomBattleTimer(this);
-		if (Config.forcetimer) this.timer.start();
-		if (this.format.includes('blitz')) this.timer.start();
+		if (Config.forcetimer) {
+			this.timer.start();
+		} else if (this.format.includes('blitz')) {
+			this.timer.start();
+		}
 		this.start();
 	}
 


### PR DESCRIPTION
This should work for both the format (when it's back) and tours (when the mod is applied). 
Let me know if there's a way to do this better, but this seemed optimal, since it gets `@@@blitz` too.
from: https://www.smogon.com/forums/threads/enforce-timer-when-blitz-is-added.3655991/