### PR TITLE
Fix autostart timer bug with less than 2 players

### DIFF
--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -594,6 +594,7 @@ export class Tournament extends Rooms.RoomGame {
 			if (output.target.startsWith('autostart')) {
 				this.room.send('|tournament|error|NotEnoughUsers');
 				this.forceEnd();
+				this.room.update();
 				output.modlog('TOUR END');
 			} else { // manual tour start without enough users
 				output.sendReply('|tournament|error|NotEnoughUsers');

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -591,7 +591,13 @@ export class Tournament extends Rooms.RoomGame {
 		}
 
 		if (this.players.length < 2) {
-			output.sendReply('|tournament|error|NotEnoughUsers');
+			if (output.target.startsWith('autostart')) {
+				this.room.send('|tournament|error|NotEnoughUsers');
+				this.forceEnd();
+				output.modlog('TOUR END');
+			} else { // manual tour start without enough users
+				output.sendReply('|tournament|error|NotEnoughUsers');
+			}
 			return false;
 		}
 


### PR DESCRIPTION
Currently, if a tournament has autostart on and less than 2 players exist in the tournament when the autostart timer hits 0, the autostart timer basically never resolves and the tournament never starts. VGC's had this happen a couple times, and other rooms have had the problem too. I thought of three potential solutions to this:

If autostart timer is 0 and there are less than two players:
1. End the tournament
2. Restart the autostart timer with an additional 30 seconds
3. Wait until the tournament reaches 2 players and automatically start

Neither 2) nor 3) are ever guaranteed to make anything happen, so I picked solution 1) for this PR (it was also simplest).

See [bug reports post](https://www.smogon.com/forums/threads/bug-reports-v3-read-original-post-before-posting.3634749/post-8212361), [2](https://www.smogon.com/forums/threads/bug-reports-v3-read-original-post-before-posting.3634749/post-8388073). Sample of what would be sent to the client:
![image](https://user-images.githubusercontent.com/23667022/76581193-8d83ee00-64a0-11ea-9246-e3c173a1fee5.png)
