### PR TITLE
Add Mirror Armor Parting Shot test

### DIFF
--- a/test/sim/abilities/mirrorarmor.js
+++ b/test/sim/abilities/mirrorarmor.js
@@ -29,15 +29,13 @@ describe("Mirror Armor", function () {
 	});
 
 	it.skip("should reflect Parting Shot's stat drops, then the Parting Shot user should switch", function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [
+		battle = common.createBattle([[
 			{species: 'Corviknight', ability: 'mirrorarmor', moves: ['sleeptalk']},
-		]});
-		battle.setPlayer('p2', {team: [
+		], [
 			{species: 'Drapion', moves: ['partingshot']},
 			{species: 'Pangoro', moves: ['sleeptalk']},
-		]});
-		battle.makeChoices('auto', 'auto');
+		]]);
+		battle.makeChoices();
 		const corv = battle.p1.active[0];
 		const drapion = battle.p2.active[0];
 		assert.statStage(corv, 'atk', 0);

--- a/test/sim/abilities/mirrorarmor.js
+++ b/test/sim/abilities/mirrorarmor.js
@@ -27,4 +27,23 @@ describe("Mirror Armor", function () {
 		assert.statStage(corv, 'def', 0);
 		assert.statStage(machop, 'def', -1);
 	});
+
+	it("should reflect Parting Shot's stat drops, then the Parting Shot user should switch", function () {
+		battle = common.createBattle();
+		battle.setPlayer('p1', {team: [
+			{species: 'Corviknight', ability: 'mirrorarmor', moves: ['sleeptalk']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Drapion', moves: ['partingshot']},
+			{species: 'Pangoro', moves: ['sleeptalk']},
+		]});
+		battle.makeChoices('auto', 'auto');
+		const corv = battle.p1.active[0];
+		const drapion = battle.p2.active[0];
+		assert.statStage(corv, 'atk', 0);
+		assert.statStage(corv, 'spa', 0);
+		assert.statStage(drapion, 'atk', -1);
+		assert.statStage(drapion, 'spa', -1);
+		assert.equal(battle.requestState, 'switch');
+	});
 });

--- a/test/sim/abilities/mirrorarmor.js
+++ b/test/sim/abilities/mirrorarmor.js
@@ -28,7 +28,7 @@ describe("Mirror Armor", function () {
 		assert.statStage(machop, 'def', -1);
 	});
 
-	it("should reflect Parting Shot's stat drops, then the Parting Shot user should switch", function () {
+	it.skip("should reflect Parting Shot's stat drops, then the Parting Shot user should switch", function () {
 		battle = common.createBattle();
 		battle.setPlayer('p1', {team: [
 			{species: 'Corviknight', ability: 'mirrorarmor', moves: ['sleeptalk']},


### PR DESCRIPTION
Currently fails on sim (this test currently fails). Sequence of events should be:

1. Parting Shot used into Mirror Armor.
2. Mirror Armor triggers.
3. Mirror Armor lowers the Attack of the Parting Shot user.
4. Mirror Armor triggers.
5. Mirror Armor lowers the Sp. Atk of the Parting Shot user.
6. The Parting Shot user switches out.

In-game behavior: (same as steps above): https://streamable.com/s2ewv
Showdown behavior (Mirror Armor only triggers once and does not let the user switch out): https://replay.pokemonshowdown.com/gen8ou-1067733088