### PR TITLE
Add additional Eject Pack tests

### DIFF
--- a/test/sim/items/ejectpack.js
+++ b/test/sim/items/ejectpack.js
@@ -37,53 +37,45 @@ describe('Eject Pack', function () {
 	});
 
 	it.skip("should not trigger until after all entrance abilities have resolved during simultaneous switches", function () {
-		battle = common.createBattle({gameType: 'doubles'});
-		battle.setPlayer('p1', {team: [
+		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: 'Hydreigon', ability: 'intimidate', moves: ['sleeptalk']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
-		]});
-		battle.setPlayer('p2', {team: [
+		], [
 			{species: 'Morelull', ability: 'drought', item: 'ejectpack', moves: ['sleeptalk']},
 			{species: 'Mew', level: 1, ability: 'electricsurge', moves: ['sleeptalk']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
-		]});
+		]]);
 		battle.makeChoices();
-		assert.ok(battle.field.isWeather('sunnyday'));
-		assert.ok(battle.field.isTerrain('electricterrain'));
+		assert(battle.field.isWeather('sunnyday'));
+		assert(battle.field.isTerrain('electricterrain'));
 		assert.equal(battle.p2.requestState, 'switch');
 	});
 
 	it.skip("should only trigger the fastest Eject Pack when multiple targets with Eject Pack have stats lowered", function () {
-		battle = common.createBattle({gameType: 'doubles'});
-		battle.setPlayer('p1', {team: [
+		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: 'Hydreigon', moves: ['leer']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
-		]});
-		battle.setPlayer('p2', {team: [
+		], [
 			{species: 'Morelull', item: 'ejectpack', moves: ['sleeptalk']},
 			{species: 'Mew', item: 'ejectpack', moves: ['sleeptalk']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
-		]});
+		]]);
 		battle.makeChoices('move leer, move sleeptalk', 'move sleeptalk, move sleeptalk');
 		battle.makeChoices();
-		console.log(battle.getDebugLog());
-		console.log(battle.p2.active[0].species);
 		assert.equal(battle.p2.active[0].species, "Morelull");
 		assert.equal(battle.p2.active[1].species, "Wynaut");
 	});
 
 	it("should cause Pokemon to switch out during the semi-invulernable state", function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [
+		battle = common.createBattle([[
 			{species: 'Charmeleon', item: 'ejectpack', moves: ['phantomforce']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
-		]});
-		battle.setPlayer('p2', {team: [
+		], [
 			{species: 'Wynaut', moves: ['sleeptalk']},
 			{species: 'Arcanine', ability: 'intimidate', moves: ['sleeptalk']},
-		]});
+		]]);
 		battle.makeChoices('move phantomforce', 'move sleeptalk');
 		battle.makeChoices('move phantomforce', 'switch 2');
 		assert.equal(battle.p1.requestState, 'switch');

--- a/test/sim/items/ejectpack.js
+++ b/test/sim/items/ejectpack.js
@@ -36,7 +36,7 @@ describe('Eject Pack', function () {
 		assert.equal(battle.p2.requestState, 'switch');
 	});
 
-	it("should not trigger until after all entrance abilities have resolved during simultaneous switches", function () {
+	it.skip("should not trigger until after all entrance abilities have resolved during simultaneous switches", function () {
 		battle = common.createBattle({gameType: 'doubles'});
 		battle.setPlayer('p1', {team: [
 			{species: 'Hydreigon', ability: 'intimidate', moves: ['sleeptalk']},
@@ -54,7 +54,7 @@ describe('Eject Pack', function () {
 		assert.equal(battle.p2.requestState, 'switch');
 	});
 
-	it("should only trigger the fastest Eject Pack when multiple targets with Eject Pack have stats lowered", function () {
+	it.skip("should only trigger the fastest Eject Pack when multiple targets with Eject Pack have stats lowered", function () {
 		battle = common.createBattle({gameType: 'doubles'});
 		battle.setPlayer('p1', {team: [
 			{species: 'Hydreigon', moves: ['leer']},

--- a/test/sim/items/ejectpack.js
+++ b/test/sim/items/ejectpack.js
@@ -35,4 +35,17 @@ describe('Eject Pack', function () {
 		battle.makeChoices();
 		assert.equal(battle.p2.requestState, 'switch');
 	});
+
+	it("should not trigger until after all entrance abilities have resolved", function () {
+		battle = common.createBattle();
+		battle.setPlayer('p1', {team: [
+			{species: 'Hydreigon', ability: 'intimidate', moves: ['sleeptalk']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Morelull', ability: 'drought', item: 'ejectpack', moves: ['sleeptalk']},
+			{species: 'Mew', moves: ['splash']},
+		]});
+		battle.makeChoices();
+		assert.ok(battle.field.isWeather('sunnyday'));
+	});
 });

--- a/test/sim/items/ejectpack.js
+++ b/test/sim/items/ejectpack.js
@@ -36,16 +36,56 @@ describe('Eject Pack', function () {
 		assert.equal(battle.p2.requestState, 'switch');
 	});
 
-	it("should not trigger until after all entrance abilities have resolved", function () {
-		battle = common.createBattle();
+	it("should not trigger until after all entrance abilities have resolved during simultaneous switches", function () {
+		battle = common.createBattle({gameType: 'doubles'});
 		battle.setPlayer('p1', {team: [
 			{species: 'Hydreigon', ability: 'intimidate', moves: ['sleeptalk']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
 		]});
 		battle.setPlayer('p2', {team: [
 			{species: 'Morelull', ability: 'drought', item: 'ejectpack', moves: ['sleeptalk']},
-			{species: 'Mew', moves: ['splash']},
+			{species: 'Mew', level: 1, ability: 'electricsurge', moves: ['sleeptalk']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
 		]});
 		battle.makeChoices();
 		assert.ok(battle.field.isWeather('sunnyday'));
+		assert.ok(battle.field.isTerrain('electricterrain'));
+		assert.equal(battle.p2.requestState, 'switch');
+	});
+
+	it("should only trigger the fastest Eject Pack when multiple targets with Eject Pack have stats lowered", function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [
+			{species: 'Hydreigon', moves: ['leer']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Morelull', item: 'ejectpack', moves: ['sleeptalk']},
+			{species: 'Mew', item: 'ejectpack', moves: ['sleeptalk']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		]});
+		battle.makeChoices('move leer, move sleeptalk', 'move sleeptalk, move sleeptalk');
+		battle.makeChoices();
+		console.log(battle.getDebugLog());
+		console.log(battle.p2.active[0].species);
+		assert.equal(battle.p2.active[0].species, "Morelull");
+		assert.equal(battle.p2.active[1].species, "Wynaut");
+	});
+
+	it("should cause Pokemon to switch out during the semi-invulernable state", function () {
+		battle = common.createBattle();
+		battle.setPlayer('p1', {team: [
+			{species: 'Charmeleon', item: 'ejectpack', moves: ['phantomforce']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Wynaut', moves: ['sleeptalk']},
+			{species: 'Arcanine', ability: 'intimidate', moves: ['sleeptalk']},
+		]});
+		battle.makeChoices('move phantomforce', 'move sleeptalk');
+		battle.makeChoices('move phantomforce', 'switch 2');
+		assert.equal(battle.p1.requestState, 'switch');
 	});
 });


### PR DESCRIPTION
Adds three new Eject Pack tests.

**Test 1** (currently fails on sim): Eject Pack should not trigger until all entrance abilities have been resolved in cases of simultaneous switches (such as at the start of the battle or switching in Pokemon after 2 KOs).

I'm not sure if this test is set up quite correct. I want to verify Sun and Electric Terrain exist on the field, then that player 2 is currently attempting to switch.

In-game behavior: https://www.youtube.com/watch?v=dAY99Y5mABk
Showdown behavior (attempts to resolve the switch instantly): https://replay.pokemonshowdown.com/gen8vgc2020-1074228320-w27uyh1s3ble7k2v1d9bas2895nq8x4pw

**Test 2** (currently fails on sim): If multiple Pokemon have Eject Pack, effects such as Intimidate, Leer, or Icy Wind should cause only the fastest Pokemon (without _any_ Speed modifiers at all) to consume its Eject Pack and switch out.

Showdown behavior is to switch out the leftmost Pokemon. I don't have a replay or cart footage offhand of this one but can provide on request (I did test both).

**Test 3** (currently passes on sim): If a Pokemon is in the semi-invulnerable state and has its stats lowered (e.g. via Intimidate), Eject Pack will activate and switch out the Pokemon.