### PR TITLE
Update Doubles Ubers

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -278,11 +278,13 @@ let Formats = [
 	},
 	{
 		name: "[Gen 8] Doubles Ubers",
-
+		threads: [
+			`&bullet; <a href="https://www.smogon.com/forums/threads/3661142/">Doubles Ubers Metagame Discussion</a>`,
+		],
 		mod: 'gen8',
 		gameType: 'doubles',
-		searchShow: false,
-		ruleset: ['Standard Doubles'],
+		searchShow: true,
+		ruleset: ['Standard Doubles', '!Gravity Sleep Clause'],
 		banlist: [],
 	},
 	{

--- a/config/formats.js
+++ b/config/formats.js
@@ -281,9 +281,9 @@ let Formats = [
 		threads: [
 			`&bullet; <a href="https://www.smogon.com/forums/threads/3661142/">Doubles Ubers Metagame Discussion</a>`,
 		],
+
 		mod: 'gen8',
 		gameType: 'doubles',
-		searchShow: true,
 		ruleset: ['Standard Doubles', '!Gravity Sleep Clause'],
 		banlist: [],
 	},


### PR DESCRIPTION
Does the following:

- Removes Gravity Sleep Clause (approved by DOU tier leader talkingtree and myself, I'm the one taking over the thread)
- Adds the DUbers thread
- Allows DUbers live on the ladder