### PR TITLE
Support /hidetext [line count]

### DIFF
--- a/server/chat-commands/moderation.js
+++ b/server/chat-commands/moderation.js
@@ -1413,7 +1413,7 @@ exports.commands = {
 				userid,
 				...Object.keys(targetUser.prevNames),
 				...targetUser.getAltUsers(true).map(user => user.getLastId()),
-			], lineCount);
+			]);
 		} else {
 			room.send(`|c|~|${name}'s messages were cleared from ${room.title} by ${user.name}.`);
 			this.modlog('HIDETEXT', targetUser || userid, null, {noip: 1, noalts: 1});

--- a/server/chat-commands/moderation.js
+++ b/server/chat-commands/moderation.js
@@ -1393,7 +1393,7 @@ exports.commands = {
 	hidetext(target, room, user, connection, cmd) {
 		if (!target) return this.parse(`/help hidetext`);
 
-		this.splitTarget(target);
+		const lineCount = parseInt(this.splitTarget(target)) || 0;
 		let targetUser = this.targetUser;
 		let name = this.targetUsername;
 		if (!targetUser && !room.log.hasUsername(name)) {

--- a/server/chat-commands/moderation.js
+++ b/server/chat-commands/moderation.js
@@ -1415,7 +1415,11 @@ exports.commands = {
 				...targetUser.getAltUsers(true).map(user => user.getLastId()),
 			]);
 		} else {
-			room.send(`|c|~|${name}'s messages were cleared from ${room.title} by ${user.name}.`);
+			if (lineCount > 0) {
+				room.send(`|c|~|${lineCount} of ${name}'s messages were cleared from ${room.title} by ${user.name}.`);
+			} else {
+				room.send(`|c|~|${name}'s messages were cleared from ${room.title} by ${user.name}.`);
+			}
 			this.modlog('HIDETEXT', targetUser || userid, null, {noip: 1, noalts: 1});
 			room.hideText([userid], lineCount);
 		}

--- a/server/chat-commands/moderation.js
+++ b/server/chat-commands/moderation.js
@@ -1399,6 +1399,9 @@ exports.commands = {
 		if (!targetUser && !room.log.hasUsername(name)) {
 			return this.errorReply(`User ${name} not found or has no roomlogs.`);
 		}
+		if (lineCount && cmd.includes('alt')) {
+			return this.errorReply(`You can't specify a line count when using /hidealtstext.`);
+		}
 		let userid = toID(this.inputUsername);
 
 		if (!this.can('mute', null, room)) return;

--- a/server/chat-commands/moderation.js
+++ b/server/chat-commands/moderation.js
@@ -1397,7 +1397,7 @@ exports.commands = {
 		let targetUser = this.targetUser;
 		let name = this.targetUsername;
 		let lineCount = 0;
-		if (target.includes(',')) lineCount = Number(target.split(',')[1]);
+		if (target.includes(',')) lineCount = Math.abs(parseInt(target.split(',')[1]));
 		if (!targetUser && !room.log.hasUsername(target)) return this.errorReply(`User ${name} not found or has no roomlogs.`);
 		let userid = toID(this.inputUsername);
 

--- a/server/chat-commands/moderation.js
+++ b/server/chat-commands/moderation.js
@@ -1396,8 +1396,6 @@ exports.commands = {
 		this.splitTarget(target);
 		let targetUser = this.targetUser;
 		let name = this.targetUsername;
-		let lineCount = 0;
-		if (target.includes(',')) lineCount = Math.abs(parseInt(target.split(',')[1]));
 		if (!targetUser && !room.log.hasUsername(name)) {
 			return this.errorReply(`User ${name} not found or has no roomlogs.`);
 		}

--- a/server/chat-commands/moderation.js
+++ b/server/chat-commands/moderation.js
@@ -1396,7 +1396,9 @@ exports.commands = {
 		this.splitTarget(target);
 		let targetUser = this.targetUser;
 		let name = this.targetUsername;
-		if (!targetUser && !room.log.hasUsername(target)) return this.errorReply(`User ${target} not found or has no roomlogs.`);
+		let lineCount = 0;
+		if (target.includes(',')) lineCount = Number(target.split(',')[1]);
+		if (!targetUser && !room.log.hasUsername(target)) return this.errorReply(`User ${name} not found or has no roomlogs.`);
 		let userid = toID(this.inputUsername);
 
 		if (!this.can('mute', null, room)) return;
@@ -1411,11 +1413,11 @@ exports.commands = {
 				userid,
 				...Object.keys(targetUser.prevNames),
 				...targetUser.getAltUsers(true).map(user => user.getLastId()),
-			]);
+			], lineCount);
 		} else {
 			room.send(`|c|~|${name}'s messages were cleared from ${room.title} by ${user.name}.`);
 			this.modlog('HIDETEXT', targetUser || userid, null, {noip: 1, noalts: 1});
-			room.hideText([userid]);
+			room.hideText([userid], lineCount);
 		}
 	},
 	hidetexthelp: [

--- a/server/chat-commands/moderation.js
+++ b/server/chat-commands/moderation.js
@@ -1398,7 +1398,9 @@ exports.commands = {
 		let name = this.targetUsername;
 		let lineCount = 0;
 		if (target.includes(',')) lineCount = Math.abs(parseInt(target.split(',')[1]));
-		if (!targetUser && !room.log.hasUsername(target)) return this.errorReply(`User ${name} not found or has no roomlogs.`);
+		if (!targetUser && !room.log.hasUsername(name)) {
+			return this.errorReply(`User ${name} not found or has no roomlogs.`);
+		}
 		let userid = toID(this.inputUsername);
 
 		if (!this.can('mute', null, room)) return;

--- a/server/roomlogs.ts
+++ b/server/roomlogs.ts
@@ -199,8 +199,7 @@ export class Roomlog {
 				}
 			}
 			return true;
-		});
-		this.log = this.log.reverse();
+		}).reverse();
 		return cleared;
 	}
 	uhtmlchange(message: string) {

--- a/server/roomlogs.ts
+++ b/server/roomlogs.ts
@@ -182,7 +182,7 @@ export class Roomlog {
 		const messageStart = this.logTimes ? '|c:|' : '|c|';
 		const section = this.logTimes ? 4 : 3; // ['', 'c' timestamp?, author, message]
 		const cleared: ID[] = [];
-		const clearAll = (lineCount === 0 ? true : false);
+		const clearAll = (lineCount === 0);
 		this.log = this.log.reverse().filter(line => {
 			if (line.startsWith(messageStart)) {
 				const parts = Chat.splitFirst(line, '|', section);

--- a/server/roomlogs.ts
+++ b/server/roomlogs.ts
@@ -178,22 +178,29 @@ export class Roomlog {
 		}
 		return false;
 	}
-	clearText(userids: ID[]) {
+	clearText(userids: ID[], lineCount = 0) {
 		const messageStart = this.logTimes ? '|c:|' : '|c|';
 		const section = this.logTimes ? 4 : 3; // ['', 'c' timestamp?, author, message]
 		const cleared: ID[] = [];
-		this.log = this.log.filter(line => {
+		const clearAll = (lineCount === 0 ? true : false);
+		this.log = this.log.reverse().filter(line => {
 			if (line.startsWith(messageStart)) {
 				const parts = Chat.splitFirst(line, '|', section);
 				const userid = toID(parts[section - 1]);
 				if (userids.includes(userid)) {
 					if (!cleared.includes(userid)) cleared.push(userid);
 					if (this.roomid.startsWith('battle-')) return true; // Don't remove messages in battle rooms to preserve evidence
-					return false;
+					if (clearAll) return false;
+					if (lineCount > 0) {
+						lineCount--;
+						return false;
+					}
+					return true;
 				}
 			}
 			return true;
 		});
+		this.log = this.log.reverse();
 		return cleared;
 	}
 	uhtmlchange(message: string) {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1159,10 +1159,10 @@ export class BasicChatRoom extends BasicRoom {
 		this.log.modlog(message);
 		return this;
 	}
-	hideText(userids: ID[]) {
+	hideText(userids: ID[], lineCount: number = 0) {
 		const cleared = this.log.clearText(userids);
 		for (const userid of cleared) {
-			this.send(`|unlink|hide|${userid}`);
+			this.send(`|unlink|hide|${userid}|${lineCount}`);
 		}
 		this.update();
 	}

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1160,7 +1160,7 @@ export class BasicChatRoom extends BasicRoom {
 		return this;
 	}
 	hideText(userids: ID[], lineCount = 0) {
-		const cleared = this.log.clearText(userids);
+		const cleared = this.log.clearText(userids, lineCount);
 		for (const userid of cleared) {
 			this.send(`|unlink|hide|${userid}|${lineCount}`);
 		}

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1159,7 +1159,7 @@ export class BasicChatRoom extends BasicRoom {
 		this.log.modlog(message);
 		return this;
 	}
-	hideText(userids: ID[], lineCount: number = 0) {
+	hideText(userids: ID[], lineCount = 0) {
 		const cleared = this.log.clearText(userids);
 		for (const userid of cleared) {
 			this.send(`|unlink|hide|${userid}|${lineCount}`);


### PR DESCRIPTION
This patch (coupled with its accompanying client-side patch) amends the /hidetext command to accept an integer that represents the number of lines that should be hidden.

Sometimes not all lines need to be cleared and several staff (room and global) have suggested that the option to hide just some lines would be useful.