### PR TITLE
Add Snow Cloak to gen4ou bans

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -1213,7 +1213,7 @@ let Formats = [
 
 		mod: 'gen4',
 		ruleset: ['Standard', 'Baton Pass Clause'],
-		banlist: ['Uber', 'Sand Veil', 'Soul Dew'],
+		banlist: ['Uber', 'Mamoswine ++ Snow Cloak', 'Piloswine ++ Snow Cloak', 'Sand Veil', 'Soul Dew', 'Swinub ++ Snow Cloak'],
 	},
 	{
 		name: "[Gen 3] OU",

--- a/config/formats.js
+++ b/config/formats.js
@@ -1213,7 +1213,7 @@ let Formats = [
 
 		mod: 'gen4',
 		ruleset: ['Standard', 'Baton Pass Clause'],
-		banlist: ['Uber', 'Mamoswine ++ Snow Cloak', 'Piloswine ++ Snow Cloak', 'Sand Veil', 'Soul Dew', 'Swinub ++ Snow Cloak'],
+		banlist: ['Uber', 'Sand Veil', 'Soul Dew', 'Swinub ++ Snow Cloak', 'Piloswine ++ Snow Cloak', 'Mamoswine ++ Snow Cloak'],
 	},
 	{
 		name: "[Gen 3] OU",


### PR DESCRIPTION
Bans for Mamoswine familly. Glaceon and Frostlass have only 1 ability.
[https://www.smogon.com/forums/threads/bug-reports-v3-read-original-post-before-posting.3634749/post-8395762](url)