### PR TITLE
Fix in-battle rules list

### DIFF
--- a/config/CUSTOM-RULES.md
+++ b/config/CUSTOM-RULES.md
@@ -189,7 +189,7 @@ In-battle rules
 
 `Freeze Clause Mod` - prevent Pokémon from getting frozen if they have frozen allies
 
-`Cancel Mod` - allow the Cancel button
+`Cancel Mod` - allow players to cancel their moves
 
 `Inverse Mod` - inverse type effectiveness (like in Gen 6 Inverse Battles)
 
@@ -203,9 +203,7 @@ In-battle rules
 
 `HP Percentage Mod` - Show the opposing Pokémon's HP rounded to the nearest percent, as opposed to a range of percentages based upon the health bar's size in-game
 
-`Exact HP Mod` - Show the opposing Pokémon's HP rounded to the nearest tenth of a percent
-
-`Cancel Mod` - allow players to cancel their moves
+`Exact HP Mod` - Show all Pokémon's exact HP in the battle log
 
 `Switch Priority Clause Mod` - make the fastest Pokémon switch first when more than one Pokémon switches out at once, unlike in Emerald link battles, where Player 1's Pokémon would switch first.
 

--- a/config/CUSTOM-RULES.md
+++ b/config/CUSTOM-RULES.md
@@ -189,7 +189,7 @@ In-battle rules
 
 `Freeze Clause Mod` - prevent Pokémon from getting frozen if they have frozen allies
 
-`Cancel Mod` - allow players to cancel their moves
+`Cancel Mod` - show the Cancel button and allow players to cancel their moves
 
 `Inverse Mod` - inverse type effectiveness (like in Gen 6 Inverse Battles)
 

--- a/config/CUSTOM-RULES.md
+++ b/config/CUSTOM-RULES.md
@@ -203,7 +203,7 @@ In-battle rules
 
 `HP Percentage Mod` - Show the opposing Pokémon's HP rounded to the nearest percent, as opposed to a range of percentages based upon the health bar's size in-game
 
-`Exact HP Mod` - Show all Pokémon's exact HP in the battle log
+`Exact HP Mod` - Show all Pokémon's exact HP and max HP in the battle log
 
 `Switch Priority Clause Mod` - make the fastest Pokémon switch first when more than one Pokémon switches out at once, unlike in Emerald link battles, where Player 1's Pokémon would switch first.
 


### PR DESCRIPTION
* Cancel Mod was listed twice
* Exact HP Mod does actually show the exact HP, when you hover over it in the battle log