### PR TITLE
Add tests for Pledge moves modified by Z/Dynamax

### DIFF
--- a/test/sim/misc/pledgemoves.js
+++ b/test/sim/misc/pledgemoves.js
@@ -27,4 +27,30 @@ describe('Pledge Moves', function () {
 		assert(!battle.p2.active[0].side.sideConditions['firepledge'], "Fire Pledge should not be active on the opponent's side of the field.");
 		assert(!battle.p1.active[1].moveThisTurn, "Charizard should not have moved this turn.");
 	});
+
+	it.skip("should not start a Pledge combo for Z-moves", function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Weedle', ability: 'sapsipper', moves: ['sleeptalk']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		], [
+			{species: 'Venusaur', moves: ['grasspledge']},
+			{species: 'Charizard', level: 1, item: 'firiumz', moves: ['firepledge']},
+		]]);
+		battle.makeChoices('auto', 'move grasspledge +1, move firepledge +1 zmove');
+		const weedle = battle.p1.active[0];
+		assert.statStage(weedle, 'atk', +1);
+	});
+
+	it.skip("should not start a Pledge combo for Max Moves", function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Weedle', ability: 'sapsipper', moves: ['sleeptalk']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		], [
+			{species: 'Venusaur', moves: ['grasspledge']},
+			{species: 'Charizard-Gmax', level: 1, moves: ['firepledge']},
+		]]);
+		battle.makeChoices('auto', 'move grasspledge +1, move firepledge +1 dynamax');
+		const weedle = battle.p1.active[0];
+		assert.statStage(weedle, 'atk', +1);
+	});
 });

--- a/test/sim/misc/pledgemoves.js
+++ b/test/sim/misc/pledgemoves.js
@@ -29,7 +29,7 @@ describe('Pledge Moves', function () {
 	});
 
 	it.skip("should not start a Pledge combo for Z-moves", function () {
-		battle = common.createBattle({gameType: 'doubles'}, [[
+		battle = common.gen(7).createBattle({gameType: 'doubles'}, [[
 			{species: 'Weedle', ability: 'sapsipper', moves: ['sleeptalk']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
 		], [


### PR DESCRIPTION
Currently, when you Dynamax/Z-move with a Pledge attack going second, it interrupts the initial Pledge move for a Pledge combo and sets the base power to 150. It should not be starting a Pledge combo at all; Z-moves / Max Moves do not retain Pledge properties. This commits failing skipped tests for those interactions.

Showdown replays (incorrect):
Dynamax: https://replay.pokemonshowdown.com/gen8doublescustomgame-1085419852
Z-move: https://replay.pokemonshowdown.com/gen7doublescustomgame-1085424282