### PR TITLE
Add test for when Dynamax should revert

### DIFF
--- a/test/sim/misc/dynamax.js
+++ b/test/sim/misc/dynamax.js
@@ -85,7 +85,7 @@ describe("Dynamax", function () {
 		assert.equal(pokemon.maxhp - pokemon.hp, expectedDamage, `${pokemon.name} should take ${expectedPercent * 100}%`);
 	});
 
-	it('should revert before the start of the 4th turn, not as an end-of-turn effect on the 3rd turn', function () {
+	it.skip('should revert before the start of the 4th turn, not as an end-of-turn effect on the 3rd turn', function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', moves: ['sleeptalk', 'psychic']},
 		], [

--- a/test/sim/misc/dynamax.js
+++ b/test/sim/misc/dynamax.js
@@ -84,4 +84,19 @@ describe("Dynamax", function () {
 		const expectedDamage = Math.floor(pokemon.maxhp * expectedPercent);
 		assert.equal(pokemon.maxhp - pokemon.hp, expectedDamage, `${pokemon.name} should take ${expectedPercent * 100}%`);
 	});
+
+	it('should revert before the start of the 4th turn, not as an end-of-turn effect on the 3rd turn', function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', moves: ['sleeptalk', 'psychic']},
+		], [
+			{species: 'weedle', level: 1, moves: ['sleeptalk']},
+			{species: 'weedle', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices('move sleep talk dynamax');
+		const dynamaxedHP = battle.p1.active[0].hp;
+		battle.makeChoices();
+		battle.makeChoices('move psychic');
+		assert.equal(battle.requestState, 'switch');
+		assert.equal(battle.p1.active[0].hp, dynamaxedHP);
+	});
 });


### PR DESCRIPTION
Currently, Dynamax reversion is treated as an end-of-turn effect (and a very early one, I might add). It should be the last thing to occur before the start of the 4th turn, after switches have resolved. Because of the improper timing, things like Wishiwashi's transformation, various chip damage (e.g. G-Max Wildfire, Sticky Barb), etc. can all result in slightly different amounts of HP. This commits a skipped failing test for the interaction that gets as close to it as I can think of.

Cartridge interaction: https://youtu.be/5C6JfhhXn2w?t=1017
Sample replay showcasing why this matters, e.g. with G-Max Wildfire: https://replay.pokemonshowdown.com/gen8doublescustomgame-1087718887

A bandaid fix would be to just set Dynamax reversion as the last effect to happen in the end-turn resolution order.