### PR TITLE
Add test for Unaware & spread moves

### DIFF
--- a/test/sim/abilities/unaware.js
+++ b/test/sim/abilities/unaware.js
@@ -78,4 +78,18 @@ describe('Unaware', function () {
 		battle.makeChoices('move splash', 'move shadowsneak');
 		assert.notStrictEqual(pokemon.maxhp - pokemon.hp, damage);
 	});
+	it.skip('should only apply to targets with Unaware in battles with multiple Pokemon', function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'manaphy', moves: ['tailglow', 'surf']},
+			{species: 'slowbro', ability: 'unaware', moves: ['sleeptalk']},
+		], [
+			{species: 'clobbopus', ability: 'sturdy', moves: ['sleeptalk']},
+			{species: 'clobbopus', ability: 'sturdy', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices('move tailglow, auto', 'auto');
+		battle.makeChoices('move surf, auto', 'auto');
+		console.log(battle.getDebugLog());
+		assert.equal(battle.p2.active[0].hp, 1);
+		assert.equal(battle.p2.active[1].hp, 1);
+	});
 });

--- a/test/sim/abilities/unaware.js
+++ b/test/sim/abilities/unaware.js
@@ -88,7 +88,6 @@ describe('Unaware', function () {
 		]]);
 		battle.makeChoices('move tailglow, auto', 'auto');
 		battle.makeChoices('move surf, auto', 'auto');
-		console.log(battle.getDebugLog());
 		assert.equal(battle.p2.active[0].hp, 1);
 		assert.equal(battle.p2.active[1].hp, 1);
 	});


### PR DESCRIPTION
Currently, Unaware is somehow setting the its flag for multiple targets. In this test, a +3 Surf is used into an Unaware ally and two opposing Sturdy Pokemon - it should always deal enough damage to trigger Sturdy (and never enough on a crit), but it does not because Unaware is getting applied to the Sturdy Pokemon.

Showdown replay example (incorrect, turn 4) (this was actually from me laddering for a DOU suspect!): https://replay.pokemonshowdown.com/gen8doublesou-1088725658-xrpimtcqyp07fmz994elc0rwer26vf6pw