### PR TITLE
Rework special scavenger modes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-server/chat-plugins/scavenger*.js @xfix
+server/chat-plugins/scavenger*.js @xfix @sparkychildcharlie
 server/chat-plugins/trivia.js @xfix
 server/chat-plugins/mafia*.js @HoeenCoder @whalemer
 data/mods/ssb/ @HoeenCoder

--- a/server/chat-plugins/scavenger-games.js
+++ b/server/chat-plugins/scavenger-games.js
@@ -71,509 +71,310 @@ class Leaderboard {
 	}
 }
 
-class ScavGame extends Rooms.RoomGame {
-	constructor(room, gameType = "Scavenger Game") {
-		super(room);
+const TWISTS = {
+	'perfectscore': {
+		name: 'Perfect Score',
+		id: 'perfectscore',
 
-		this.title = gameType;
-		this.gameid = toID(gameType);
+		onLeave(player) {
+			if (!this.leftGame) this.leftGame = [];
+			this.leftGame.push(player.id);
+		},
 
-		this.childGame = null;
-		this.playerCap = Infinity;
+		onSubmitPriority: 1,
+		onSubmit(player, value) {
+			let currentQuestion = player.currentQuestion;
 
-		this.leaderboard = null;
+			if (!player.answers) player.answers = {};
+			if (!player.answers[currentQuestion]) player.answers[currentQuestion] = [];
 
-		this.round = 0;
+			if (player.answers[currentQuestion].includes(value)) return;
 
-		// identify this as a scav game.
-		this.scavParentGame = true;
-		this.scavGame = true;
-	}
+			player.answers[currentQuestion].push(value);
+		},
 
-	canJoinGame(user) {
-		/**
-		 * Placeholder function that checks whether or not a player can join the current round of a scavenger game
-		 * Used in elimination based games, where players may not be able to join in subsequent rounds.
-		 */
-		return true;
-	}
-
-	joinGame(user) {
-		if (!this.childGame) return user.sendTo(this.room, "There is no hunt to join yet.");
-		if (!this.canJoinGame(user)) return user.sendTo(this.room, "You are not allowed to join this hunt.");
-		if ((user.id in this.playerTable) || this._joinGame(user)) { // if user is already in this parent game, or if the user is able to join this parent game
-			if (this.childGame && this.childGame.joinGame) return this.childGame.joinGame(user);
-		}
-	}
-
-	// joining the parent game
-	_joinGame(user) {
-		let success = this.addPlayer(user);
-		if (success) user.sendTo(this.room, `You have joined the Scavenger Game - ${this.title}.`);
-		return success;
-	}
-
-	// renaming in the parent game
-	onRename(user, oldUserid, isJoining, isForceRenamed) {
-		if (!this.allowRenames || (!user.named && !isForceRenamed)) {
-			if (!(user.id in this.playerTable)) {
-				user.games.delete(this.roomid);
-				user.updateSearch();
+		onAfterEndPriority: 1,
+		onAfterEnd() {
+			for (const player of this.players) {
+				if (!player.answers || (this.leftGame && this.leftGame.includes(player.id))) continue; // didn't guess at all!
+				let isPerfect = Object.keys(player.answers).map(q => player.answers[q].length).every(attempts => attempts <= 1);
+				if (isPerfect) this.announce(player.name + ' has completed the hunt without a single wrong answer!');
 			}
-			return;
-		}
-		if (!(oldUserid in this.playerTable)) return;
-		this.renamePlayer(user, oldUserid);
-		if (this.childGame && this.childGame.onRename) this.childGame.onRename(user, oldUserid, isJoining, isForceRenamed);
+		},
+	},
+
+	'incognito': {
+		name: 'Incognito',
+		id: 'incognito',
+
+		onCorrectAnswer(player, value) {
+			if (player.currentQuestion + 1 >= this.questions.length) {
+				this.runEvent('PreComplete', player);
+
+				player.sendRoom(`Congratulations! You have gotten the correct answer.`);
+				player.sendRoom(`This is a special style where finishes aren't announced! To see your placement, wait for the hunt to end. Until then, it's your secret that you finished!`);
+				return false;
+			}
+		},
+
+		onPreComplete(player) {
+			let now = Date.now();
+			let time = Chat.toDurationString(now - this.startTime, {hhmmss: true});
+
+			this.preCompleted = this.preCompleted ? [...this.preCompleted, {name: player.name, time}] : [{name: player.name, time}];
+			player.completed = true;
+		},
+
+		onEnd() {
+			this.completed = this.preCompleted || [];
+		},
+	},
+
+	'blindincognito': {
+		name: 'Blind Incognito',
+		id: 'blindincognito',
+
+		onAnySubmit(player, value) {
+			if (player.completed) {
+				player.sendRoom(`That may or may not be the right answer - if you aren't confident, you can try again!`);
+				return true;
+			}
+		},
+
+		onCorrectAnswer(player, value) {
+			if (player.currentQuestion + 1 >= this.questions.length) {
+				this.runEvent('PreComplete', player);
+
+				player.sendRoom(`That may or may not be the right answer - if you aren't confident, you can try again!`);
+				return false;
+			}
+		},
+
+		onIncorrectAnswer(player, value) {
+			if (player.currentQuestion + 2 >= this.questions.length) {
+				player.sendRoom(`That may or may not be the right answer - if you aren't confident, you can try again!`);
+				return false;
+			}
+		},
+
+		onPreComplete(player) {
+			let now = Date.now();
+			let time = Chat.toDurationString(now - this.startTime, {hhmmss: true});
+
+			this.preCompleted = this.preCompleted ? [...this.preCompleted, {name: player.name, time}] : [{name: player.name, time}];
+			player.completed = true;
+		},
+
+		onEnd() {
+			this.completed = this.preCompleted || [];
+		},
+	},
+};
+
+const MODES = {
+	'scav': 'scavengergames',
+	'scavgames': 'scavengergames',
+	scavengergames: {
+		name: 'Scavenger Games',
+		id: 'scavengergames',
+
+		mod: {
+			name: 'Scavenger Games',
+			id: 'scavengergames',
+
+			onLoad() {
+				this.allowRenames = false; // don't let people change their name in the middle of the hunt.
+			},
+
+			onJoin(user) {
+				if (this.room.scavgame.playerlist && !this.room.scavgame.playerlist.includes(user.id)) {
+					user.sendTo(this.room, 'You are not allowed to join this scavenger hunt.');
+					return true;
+				}
+			},
+
+			onAfterEnd() {
+				if (!this.completed.length) {
+					this.announce('No one has completd the hunt - the round has been void.');
+					return;
+				}
+
+				this.room.scavgame.round++;
+
+				// elimination
+				if (!this.room.scavgame.playerlist) {
+					this.room.scavgame.playerlist = this.completed.map(entry => toID(entry.name));
+					this.announce(`Round ${this.room.scavgame.round} - ${Chat.toListString(this.players.map(p => `<em>${p.name}</em>`))} have successfully completed the last hunt and have moved on to the next round!`);
+				} else {
+					let eliminated = [];
+					let completed = this.completed.map(entry => toID(entry.name));
+					if (completed.length === this.room.scavgame.playerlist.length) {
+						eliminated.push(completed.pop()); // eliminate one
+						this.room.scavgame.playerlist = this.room.scavgame.playerlist.filter(userid => completed.includes(userid));
+					} else {
+						eliminated = this.room.scavgame.playerlist.filter(userid => !completed.includes(userid));
+						for (const username of eliminated) {
+							let userid = toID(username);
+							this.room.scavgame.playerlist = this.room.scavgame.playerlist.filter(pid => pid !== userid);
+						}
+					}
+
+					this.announce(`Round ${this.room.scavgame.round} - ${Chat.toListString(eliminated.map(n => `<em>${n}</em>`))} ${Chat.plural(eliminated, 'have', 'has')} been eliminated! ${Chat.toListString(this.room.scavgame.playerlist.map(p => `<em>${this.playerTable[p].name}</em>`))} have successfully completed the last hunt and have moved on to the next round!`);
+				}
+
+				// process end of game
+				if (this.room.scavgame.playerlist.length === 1) {
+					let winner = Users.get(this.room.scavgame.playerlist[0]);
+					winner = winner ? winner.name : this.room.scavgame.playerlist[0];
+
+					this.announce(`Congratulations to the winner - ${winner}!`);
+					this.room.scavgame.destroy();
+				} else if (!this.room.scavgame.playerlist.length) {
+					this.announce('Everyone has been eliminated!  Better luck next time!');
+					this.room.scavgame.destroy();
+				}
+			},
+		},
+
+		round: 0,
+		playerlist: null,
+	},
+
+	'ko': 'kogames',
+	kogames: {
+		name: 'KO Games',
+		id: 'kogames',
+
+		mod: {
+			name: 'KO Games',
+			id: 'kogames',
+
+			onLoad() {
+				this.allowRenames = false; // don't let people change their name in the middle of the hunt.
+				this.setTimer(1);
+			},
+
+			onJoin(user) {
+				if (this.room.scavgame.playerlist && !this.room.scavgame.playerlist.includes(user.id)) {
+					user.sendTo(this.room, 'You are not allowed to join this scavenger hunt.');
+					return true;
+				}
+			},
+
+			onAfterEnd() {
+				if (!this.completed.length) {
+					this.announce('No one has completed the hunt - the round has been void.');
+					return;
+				}
+				this.room.scavgame.round++;
+
+				let eliminated = [];
+				if (!this.room.scavgame.playerlist) {
+					this.room.scavgame.playerlist = this.completed.map(entry => toID(entry.name));
+				} else {
+					let completed = this.completed.map(entry => toID(entry.name));
+					eliminated = this.room.scavgame.playerlist.filter(userid => !completed.includes(userid));
+					for (const username of eliminated) {
+						let userid = toID(username);
+						this.room.scavgame.playerlist = this.room.scavgame.playerlist.filter(pid => pid !== userid);
+					}
+				}
+
+				this.announce(`Round ${this.room.scavgame.round} - ${Chat.toListString(eliminated.map(n => `<em>${n}</em>`))} ${eliminated.length ? `${Chat.plural(eliminated, 'have', 'has')} been eliminated!` : ''} ${Chat.toListString(this.room.scavgame.playerlist.map(p => `<em>${this.playerTable[p].name}</em>`))} have successfully completed the last hunt and have moved on to the next round!`);
+
+				// process end of game
+				if (this.room.scavgame.playerlist.length === 1) {
+					let winner = Users.get(this.room.scavgame.playerlist[0]);
+					winner = winner ? winner.name : this.room.scavgame.playerlist[0];
+
+					this.announce(`Congratulations to the winner - ${winner}!`);
+					this.room.scavgame.destroy();
+				} else if (!this.room.scavgame.playerlist.length) {
+					this.announce('Everyone has been eliminated!  Better luck next time!');
+					this.room.scavgame.destroy();
+				}
+			},
+		},
+
+		round: 0,
+		playerlist: null,
+	},
+
+	pointrally: {
+		name: 'Point Rally',
+		id: 'pointrally',
+
+		pointDistribution: [50, 40, 32, 25, 20, 15, 10],
+
+		mod: {
+			name: 'Point Rally',
+			id: 'pointrally',
+
+			onLoad() {
+				this.announce(`Round ${++this.room.scavgame.round}`);
+			},
+
+			onAfterEnd() {
+				for (const [i, completed] of this.completed.map(e => e.name).entries()) {
+					let points = this.room.scavgame.pointDistribution[i] || this.room.scavgame.pointDistribution[this.room.scavgame.pointDistribution.length - 1];
+					this.room.scavgame.leaderboard.addPoints(completed, 'points', points);
+				}
+				// post leaderboard
+				let room = this.room;
+				this.room.scavgame.leaderboard.htmlLadder().then(html => {
+					room.add(`|raw|${html}`).update();
+					room = null;
+				});
+			},
+		},
+		round: 0,
+		leaderboard: true,
+	},
+};
+
+class GameTemplate {
+	constructor(room) {
+		this.room = room;
+		this.playerlist = null;
 	}
 
-	// get rid of childgame
-	destroy() {
-		if (this.childGame && this.childGame.destroy) this.childGame.destroy();
-		if (this.timer) {
-			clearTimeout(this.timer);
-			this.timer = null;
-		}
-		this.room.game = null;
-		this.room = null;
-		for (let i in this.playerTable) {
-			this.playerTable[i].destroy();
-		}
+	destroy(force) {
+		if (this.timer) clearTimeout(this.timer);
+		if (force && this.room.game && this.room.game.gameid === 'scavengerhunt') this.room.game.onEnd(null);
+		delete this.room.scavgame;
 	}
 
-	/**
-	 * Carry forward roomgame properties of scavenger hunts
-	 */
-	onSubmit(...args) {
-		if (this.childGame && this.childGame.onSubmit) this.childGame.onSubmit(...args);
-	}
-	onConnect(...args) {
-		if (this.childGame && this.childGame.onConnect) this.childGame.onConnect(...args);
-	}
-	leaveGame(...args) {
-		if (this.childGame && this.childGame.leaveGame) this.childGame.leaveGame(...args);
-	}
-	setTimer(...args) {
-		if (this.childGame && this.childGame.setTimer) return this.childGame.setTimer(...args);
-	}
-	onSendQuestion(...args) {
-		if (this.childGame && this.childGame.onSendQuestion) return this.childGame.onSendQuestion(...args);
-	}
-	onEnd(...args) {
-		if (this.childGame && this.childGame.onEnd) this.childGame.onEnd(...args);
-	}
-	onChatMessage(msg) {
-		if (this.childGame && this.childGame.onChatMessage) return this.childGame.onChatMessage(msg);
-	}
-	onUpdateConnection() {}
+	eliminate(userid) {
+		if (!this.playerlist || !this.playerlist.includes(userid)) return false;
+		this.playerlist = this.playerlist.filter(pid => pid !== userid);
 
-	/**
-	 * Functions for the child hunt to call once a certain condition is met
-	 * in the child roomgame
-	 */
-	onStartEvent() {
-		this.round++;
-	}
-	onCompleteEvent(player) {}
-	onEndEvent() {}
-	onBeforeEndHunt() {}
-	onAfterEndHunt() {}
-	onDestroyEvent() {
-		this.childGame = null;
-	}
-
-	/**
-	 * General Game functions.
-	 */
-	createHunt(room, staffHost, host, gameType, questions) {
-		if (this.childGame) return staffHost.sendTo(this.room, "There is already a scavenger hunt in progress.");
-		this.onStartEvent();
-		this.childGame = new Rooms.ScavengerHunt(room, staffHost, host, gameType, questions, this);
+		if (this.leaderboard) delete this.leaderboard.data[userid];
 		return true;
 	}
 
 	announce(msg) {
-		this.room.add(`|raw|<div class="broadcast-green"><strong>${msg}</strong></div>`).update();
-	}
-
-	eliminate(userid) {
-		if (!(userid in this.playerTable)) return false;
-		let name = this.playerTable[userid].name;
-
-		this.playerTable[userid].destroy();
-		if (this.childGame && this.childGame.eliminate) this.childGame.eliminate(userid);
-
-		delete this.playerTable[userid];
-		this.playerCount--;
-
-		if (this.leaderboard) {
-			delete this.leaderboard.data[userid]; // remove their points in the leaderboard
-		}
-
-		return name;
+		this.room.add(`|raw|<div class="broadcast-blue"><strong>${msg}</strong></div>`).update();
 	}
 }
 
-/**
- * Knockout games - slowest user, or non finishers will be eliminated.
- */
-class KOGame extends ScavGame {
-	constructor(room) {
-		super(room, "Knockout Games");
+const LoadGame = function (room, gameid) {
+	let game = MODES[gameid];
+	if (!game) return false; // invalid id
+	if (typeof game === 'string') game = MODES[game];
+
+	let base = new GameTemplate(room);
+
+	let scavgame = Object.assign(base, game);
+
+	// initialize leaderboard if required
+	if (scavgame.leaderboard) {
+		scavgame.leaderboard = new Leaderboard();
 	}
-
-	canJoinGame(user) {
-		return this.round === 1 || (user.id in this.playerTable);
-	}
-
-	onStartEvent() {
-		this.round++;
-		if (this.round === 1) {
-			this.announce(`Knockout Games - Round 1.  Everyone is welcome to join!`);
-		} else {
-			let participants = Object.keys(this.playerTable).map(p => this.playerTable[p].name);
-			this.announce(`Knockout Games - Round ${this.round}. Only the following ${participants.length} players are allowed to join: ${participants.join(', ')}.`);
-		}
-	}
-
-	onEndEvent() {
-		let completed = this.childGame.completed.map(u => toID(u.name)); // list of userids
-		if (!completed.length) {
-			this.announce(`No one has completed the hunt! This round has been void!`);
-			this.round--;
-
-			return;
-		}
-
-		if (this.round === 1) {
-			// prune the players that havent finished
-			for (let i in this.playerTable) {
-				if (!(i in this.childGame.playerTable) || !this.childGame.playerTable[i].completed) this.eliminate(i); // user hasnt finished.
-			}
-			this.announce(`Congratulations to ${Chat.toListString(Object.keys(this.playerTable).map(i => this.playerTable[i].name))}! They have completed the first round, and have moved on to the next round!`);
-			return;
-		}
-
-		let unfinished = Object.keys(this.playerTable).filter(id => !completed.includes(id));
-
-		if (!unfinished.length) {
-			unfinished = completed.slice(-1);
-		}
-
-		let eliminated = unfinished.map(id => this.eliminate(id)).filter(n => n); // this.eliminate() returns the players name.
-
-		if (Object.keys(this.playerTable).length <= 1) {
-			// game over
-			let winner = this.playerTable[Object.keys(this.playerTable)[0]];
-
-			if (winner) {
-				this.announce(`Congratulations to ${winner.name} for winning the Knockout Games!`);
-			} else {
-				this.announce(`Sorry, no winners this time!`); // a catch - this should not realistically happen.
-			}
-			setImmediate(() => this.destroy()); // destroy the parent game after the child game finishes running their destroy functions.
-			return;
-		}
-
-		this.announce(`${Chat.toListString(eliminated.map(n => `<em>${n}</em>`))} ${Chat.plural(eliminated, 'have', 'has')} been eliminated! ${Chat.toListString(Object.keys(this.playerTable).map(p => `<em>${this.playerTable[p].name}</em>`))} have successfully completed the last hunt and have moved on to the next round!`);
-	}
-}
-
-class ScavengerGames extends ScavGame {
-	constructor(room) {
-		super(room, "Scavenger Games");
-	}
-
-	canJoinGame(user) {
-		return this.round === 1 || (user.id in this.playerTable);
-	}
-
-	onStartEvent() {
-		this.round++;
-		if (this.round === 1) {
-			this.announce(`Scavenger Games - Round 1.  Everyone is welcome to join!`);
-		} else {
-			let participants = Object.keys(this.playerTable).map(p => this.playerTable[p].name);
-			this.announce(`Scavenger Games - Round ${this.round}. Only the following ${participants.length} players are allowed to join: ${participants.join(', ')}. You have one minute to complete the hunt!`);
-			setImmediate(() => this.childGame.setTimer(1));
-		}
-	}
-
-	onEndEvent() {
-		let completed = this.childGame.completed.map(u => toID(u.name)); // list of userids
-		if (!completed.length) {
-			this.announce(`No one has completed the hunt! This round has been voided!`);
-			this.round--;
-
-			return;
-		}
-
-		if (this.round === 1) {
-			// prune the players that havent finished
-			for (let i in this.playerTable) {
-				if (!(i in this.childGame.playerTable) || !this.childGame.playerTable[i].completed) this.eliminate(i); // user hasnt finished.
-			}
-			this.announce(`Congratulations to ${Chat.toListString(Object.keys(this.playerTable).map(i => this.playerTable[i].name))}! They have completed the first round, and have moved on to the next round!`);
-			return;
-		}
-
-		let unfinished = Object.keys(this.playerTable).filter(id => !completed.includes(id));
-
-		let eliminated = unfinished.map(id => this.eliminate(id)).filter(n => n); // this.eliminate() returns the players name.
-
-		if (Object.keys(this.playerTable).length <= 1) {
-			// game over
-			let winner = this.playerTable[Object.keys(this.playerTable)[0]];
-
-			if (winner) {
-				this.announce(`Congratulations to ${winner.name} for winning the Knockout Games!`);
-			} else {
-				this.announce(`Sorry, no winners this time!`); // a catch - this should not realistically happen.
-			}
-			setImmediate(() => this.destroy()); // destroy the parent game after the child game finishes running their destroy functions.
-			return;
-		}
-
-		this.announce(`${Chat.toListString(eliminated.map(n => `<em>${n}</em>`))} ${Chat.plural(eliminated, 'have', 'has')} been eliminated! ${Chat.toListString(Object.keys(this.playerTable).map(p => `<em>${this.playerTable[p].name}</em>`))} have successfully completed the last hunt and have moved on to the next round!`);
-	}
-}
-
-class JumpStart extends ScavGame {
-	constructor(room) {
-		super(room, "Jump Start");
-
-		// the place to store both hunts
-		this.hunts = [];
-		this.completed = [];
-	}
-
-	// alter the create hunt function so that both hunts are entered before the actual hunt starts
-	createHunt(room, staffHost, host, gameType, questions) {
-		if (this.hunts.length === 0) {
-			this.hunts.push([room, staffHost, host, gameType, questions]);
-			staffHost.sendTo(this.room, "The first hunt has been set. Please use /starthunt again to add the second hunt.");
-		} else if (this.hunts.length === 1) {
-			this.hunts.push([room, staffHost, host, gameType, questions]);
-			staffHost.sendTo(this.room, "The second hunt has been set. Please use /scav game jumpstart set [seconds], [seconds]... to set how many seconds early the hints should be automatically given out.");
-		} else {
-			staffHost.sendTo(this.room, "There are already 2 hunts set for this scavenger game.");
-		}
-		return false;
-	}
-
-	setJumpStart(timesArray) {
-		if (this.jumpStartTimes) return "The times for the jump start has already been set.";
-
-		timesArray = timesArray.map(t => Number(t));
-		this.jumpStartTimes = [];
-
-		const MIN_WAIT_TIME = 60; // seconds
-		let prevDiff;
-		for (const diff of timesArray) {
-			if (!diff || diff < 0) {
-				delete this.jumpStartTimes;
-				return "The times must be numbers greater than 0 in seconds.";
-			}
-			if (prevDiff) {
-				this.jumpStartTimes.push(prevDiff - diff); // make the timer call itself as one runs out
-			} else {
-				this.jumpStartTimes.push(MIN_WAIT_TIME); // the first one is always 0 + the minimum wait
-			}
-			prevDiff = diff;
-		}
-		this.huntWait = prevDiff; // the last wait time
-
-		if (this.jumpStartTimes.some(t => t < 0)) {
-			this.jumpStartTimes = null;
-			return "Invalid ordering of times.";
-		}
-		this.earlyTimes = timesArray;
-		// start the hunt
-		this.onStartEvent();
-		this.childGame = new Rooms.ScavengerHunt(...this.hunts[0], this);
-	}
-
-	runJumpStartTimer() {
-		if (this.jumpStartTimes.length) {
-			let targetUserId = this.completed.shift();
-
-			// if there are no more to distribute - set one timer with all of the remaining times together
-			if (!targetUserId) {
-				this.timer = setTimeout(() => {
-					this.onStartEvent();
-					this.childGame = new Rooms.ScavengerHunt(...this.hunts[1], this); // start it after the last hunt object has been destroyed
-				}, this.huntWait * 1000 + (this.jumpStartTimes.reduce((a, b) => a + b) * 1000));
-				return;
-			}
-
-			// set the (recursive) timer to give out hints.
-			let duration = this.jumpStartTimes.shift() * 1000;
-			this.timer = setTimeout(() => {
-				let targetUser = Users.get(targetUserId);
-				if (targetUser) {
-					this.announce('sending hint to ' + targetUser.name + " " + new Date());
-					targetUser.sendTo(this.room, `|raw|<strong>The first hint to the next hunt is:</strong> ${Chat.formatText(this.hunts[1][4][0])}`);
-					targetUser.sendTo(this.room, `|notify|Early Hint|The first hint to the next hunt is: ${this.hunts[1][4][0]}`);
-				}
-				this.runJumpStartTimer();
-			}, duration);
-		} else {
-			// there are no more slots for early delivery - start the new hunt
-			this.timer = setTimeout(() => {
-				this.announce('starting second hunt ' + new Date());
-				this.onStartEvent();
-				this.childGame = new Rooms.ScavengerHunt(...this.hunts[1], this);
-				this.room.add(`|c|~|[ScavengerManager] A scavenger hunt by ${Chat.toListString(this.childGame.hosts.map(h => h.name))} has been automatically started.`).update(); // highlight the users with "hunt by"
-			}, this.huntWait * 1000);
-		}
-	}
-
-	onCompleteEvent(player) {
-		if (this.round === 1 && this.completed.length < this.jumpStartTimes.length) {
-			player.sendRoom(`You will receive your hint ${this.earlyTimes.shift()} seconds ahead of time!`);
-			this.completed.push(player.id);
-		}
-	}
-
-	onEndEvent() {
-		let completed = this.childGame.completed.map(u => toID(u.name)); // list of userids
-		if (!completed.length) {
-			this.announce(`No one has completed the hunt! Better luck next time!`);
-
-			setImmediate(() => this.destroy());
-			return;
-		}
-		if (this.round === 1) {
-			// prune the players that havent finished
-			for (let i in this.playerTable) {
-				if (!(i in this.childGame.playerTable) || !this.childGame.playerTable[i].completed) this.eliminate(i); // user hasnt finished.
-			}
-			this.announce(`The early distribution of hints will start in one minute!`);
-
-			if (this.hunts.length === 2) {
-				this.runJumpStartTimer();
-			} else {
-				// technically should never happen
-				this.announce("ERROR: The scavenger game has been abruptly ended due to the lack of a second game.");
-				setImmediate(() => this.destroy());
-			}
-		} else {
-			this.announce(`Congratulations to the winners of the Jump Start game!`);
-			setImmediate(() => this.destroy());
-		}
-	}
-}
-
-class PointRally extends ScavGame {
-	constructor(room) {
-		super(room, "Point Rally");
-
-		this.pointDistribution = [50, 40, 32, 25, 20, 15, 10];
-
-		this.leaderboard = new Leaderboard(this);
-	}
-
-	getPoints(place) {
-		return this.pointDistribution[place] || this.pointDistribution[this.pointDistribution.length - 1];
-	}
-
-	onStartEvent() {
-		this.round++;
-		this.announce(`Hunt #${this.round}`);
-	}
-
-	onEndEvent() {
-		// give points
-		for (const [i, completed] of this.childGame.completed.map(e => e.name).entries()) {
-			this.leaderboard.addPoints(completed, 'points', this.getPoints(i));
-		}
-
-		// post leaderboard
-		this.leaderboard.htmlLadder().then(html => {
-			this.room.add(`|raw|${html}`).update();
-		});
-	}
-
-	destroy() {
-		if (this.childGame && this.childGame.destroy) this.childGame.destroy();
-		this.room.game = null;
-		this.room = null;
-		for (let i in this.playerTable) {
-			this.playerTable[i].destroy();
-		}
-	}
-}
-
-class Incognito extends ScavGame {
-	constructor(room, blind, gameType, staffHost, hosts, hunt) {
-		super(room, 'Incognito');
-
-		this.blind = blind;
-		this.hunt = hunt;
-		this.gameType = gameType;
-
-		this.announce(`A new ${blind ? 'Blind' : ''} Incognito game has been started!`);
-		this.createHunt(room, staffHost, hosts, this.gameType, hunt);
-		this.childGame.preCompleted = [];
-	}
-
-	onSubmit(user, value) {
-		if (this.childGame && this.childGame.onSubmit) {
-			// intercept handling of the last question
-			if (user.id in this.childGame.playerTable && this.childGame.playerTable[user.id].currentQuestion + 1 >= this.childGame.questions.length) {
-				let hunt = this.childGame;
-
-				value = toID(value);
-
-				let player = hunt.playerTable[user.id];
-				if (player.completed) {
-					if (!this.blind) return;
-					return player.sendRoom(`That may or may not be the right answer - if you aren't confident, you can try again!`);
-				}
-
-				hunt.validatePlayer(player);
-
-				if (player.verifyAnswer(value)) {
-					this.markComplete(player);
-					if (this.blind) return player.sendRoom(`That may or may not be the right answer - if you aren't confident, you can try again!`);
-					player.sendRoom(`Congratulations! You have gotten the correct answer.`);
-					player.sendRoom(`This is a special style where finishes aren't announced! To see your placement, wait for the hunt to end. Until then, it's your secret that you finished!`);
-				} else {
-					if (this.blind) return player.sendRoom(`That may or may not be the right answer - if you aren't confident, you can try again!`);
-					player.sendRoom(`That is not the answer - try again!`);
-				}
-			} else {
-				this.childGame.onSubmit(user, value);
-			}
-		}
-	}
-
-	markComplete(player) {
-		if (player.completed) return false;
-
-		if (this.childGame.preCompleted.find(p => toID(p.name) === player.id)) return false;
-
-		let now = Date.now();
-		let time = Chat.toDurationString(now - this.childGame.startTime, {hhmmss: true});
-
-		player.completed = true;
-		this.childGame.preCompleted.push({name: player.name, time: time});
-	}
-
-	onBeforeEndHunt() {
-		this.childGame.completed = this.childGame.preCompleted;
-	}
-
-	onAfterEndHunt() {
-		setImmediate(() => this.destroy());
-	}
-}
-
+	return scavgame;
+};
 
 module.exports = {
-	KOGame,
-	JumpStart,
-	PointRally,
-	ScavengerGames,
-	Incognito,
+	LoadGame,
+	twists: TWISTS,
+	modes: MODES,
 };

--- a/server/chat-plugins/scavengers.js
+++ b/server/chat-plugins/scavengers.js
@@ -22,7 +22,7 @@ const DEFAULT_BLITZ_POINTS = {
 const DEFAULT_HOST_POINTS = 4;
 const DEFAULT_TIMER_DURATION = 120;
 
-const DATA_FILE = 'config/chat-plugins/scavdata.json';
+const DATA_FILE = 'config/chat-plugins/ScavMods.json';
 const HOST_DATA_FILE = 'config/chat-plugins/scavhostdata.json';
 const PLAYER_DATA_FILE = 'config/chat-plugins/scavplayerdata.json';
 const DATABASE_FILE = 'config/chat-plugins/scavhunts.json';
@@ -32,7 +32,7 @@ const FILTER_LENIENCY = 7;
 
 const HISTORY_PERIOD = 6; // months
 
-const ScavengerGames = require("./scavenger-games");
+const ScavMods = require('./scavenger-games.js');
 
 const databaseContentsJSON = FS(DATABASE_FILE).readIfExistsSync();
 const scavengersData = databaseContentsJSON ? JSON.parse(databaseContentsJSON) : {recycledHunts: []};
@@ -193,10 +193,10 @@ function formatQueue(queue = [], viewer, room, broadcasting) {
 			const queuedBy = item.hosts.every(h => h.id !== item.staffHostId) ? ` / ${item.staffHostId}` : '';
 			let questions;
 			if (!broadcasting && (item.hosts.some(h => h.id === viewer.id) || viewer.id === item.staffHostId)) {
-				questions = item.questions.map(
-					(q, i) => i % 2 ?
-						Chat.html`<span style="color: green"><em>[${q.join(' / ')}]</em></span><br />` :
-						Chat.escapeHTML(q)
+				questions = item.questions.map((q, i) => i % 2 ?
+					Chat.html`<span style="color: green"><em>[${q.join(' / ')}]</em></span><br />`
+					: // eslint-disable-line operator-linebreak
+					Chat.escapeHTML(q)
 				).join(" ");
 			} else {
 				questions = `[${item.questions.length / 2} hidden questions]`;
@@ -292,7 +292,7 @@ class ScavengerHuntDatabase {
 	}
 }
 class ScavengerHunt extends Rooms.RoomGame {
-	constructor(room, staffHost, hosts, gameType, questions, parentGame) {
+	constructor(room, staffHost, hosts, gameType, questions, mod) {
 		super(room);
 
 		this.allowRenames = true;
@@ -308,9 +308,9 @@ class ScavengerHunt extends Rooms.RoomGame {
 
 		this.leftHunt = {};
 
-		this.parentGame = parentGame || null;
-
 		this.hosts = hosts;
+
+		this.mods = {};
 
 		this.staffHostId = staffHost.id;
 		this.staffHostName = staffHost.name;
@@ -320,18 +320,52 @@ class ScavengerHunt extends Rooms.RoomGame {
 		this.title = 'Scavenger Hunt';
 		this.scavGame = true;
 
+		if (this.room.scavgame) {
+			this.loadMod(this.room.scavgame.mod);
+		} else if (this.gameType === 'official' && this.room.officialtwist) {
+			this.loadMod(this.room.officialtwist);
+		}
+		if (mod) {
+			this.loadMod(mod);
+		}
+		this.runEvent('Load');
 		this.onLoad(questions);
+	}
+
+	loadMod(modId) {
+		let twist;
+		if (typeof modId === 'string') {
+			modId = toID(modId);
+			if (!ScavMods.twists[modId]) return this.announce(`Invalid mod. Starting the hunt without the mod ${modId}.`);
+
+			twist = ScavMods.twists[modId];
+		} else {
+			twist = modId;
+		}
+		for (let key in twist) {
+			if (!key.startsWith('on')) continue;
+			let priority = twist[key + 'Priority'] || 0;
+			if (!this.mods[key]) this.mods[key] = [];
+			this.mods[key].push({exec: twist[key], priority});
+		}
+		this.announce(`This hunt uses the twist ${twist.name}.`);
 	}
 
 	// alert new users that are joining the room about the current hunt.
 	onConnect(user, connection) {
 		// send the fact that a hunt is currently going on.
-		connection.sendTo(this.room, `|raw|<div class="broadcast-blue"><strong>${['official', 'unrated'].includes(this.gameType) ? 'An' : 'A'} ${this.gameType} Scavenger Hunt by <em>${Chat.escapeHTML(Chat.toListString(this.hosts.map(h => h.name)))}</em> has been started${(this.hosts.some(h => h.id === this.staffHostId) ? '' : ` by <em>${Chat.escapeHTML(this.staffHostName)}</em>`)}.<br />The first hint is: ${Chat.formatText(this.questions[0].hint)}</strong></div>`);
+		connection.sendTo(this.room, this.getCreationMessage());
+	}
+
+	getCreationMessage() {
+		let message = this.runEvent('CreateCallback');
+		return message || `|raw|<div class="broadcast-blue"><strong>${['official', 'unrated'].includes(this.gameType) ? 'An' : 'A'} ${this.gameType} Scavenger Hunt by <em>${Chat.escapeHTML(Chat.toListString(this.hosts.map(h => h.name)))}</em> has been started${(this.hosts.some(h => h.id === this.staffHostId) ? '' : ` by <em>${Chat.escapeHTML(this.staffHostName)}</em>`)}.<br />The first hint is: ${Chat.formatText(this.questions[0].hint)}</strong></div>`;
 	}
 
 	joinGame(user) {
 		if (this.hosts.some(h => h.id === user.id) || user.id === this.staffHostId) return user.sendTo(this.room, "You cannot join your own hunt! If you wish to view your questions, use /viewhunt instead!");
 		if (Object.keys(user.ips).some(ip => this.joinedIps.includes(ip))) return user.sendTo(this.room, "You already have one alt in the hunt.");
+		if (this.runEvent('Join', user)) return false;
 		if (this.addPlayer(user)) {
 			this.cacheUserIps(user);
 			delete this.leftHunt[user.id];
@@ -356,7 +390,7 @@ class ScavengerHunt extends Rooms.RoomGame {
 
 		if (!player) return user.sendTo(this.room, "You have not joined the scavenger hunt.");
 		if (player.completed) return user.sendTo(this.room, "You have already completed this scavenger hunt.");
-
+		this.runEvent('Leave', player);
 		this.joinedIps = this.joinedIps.filter(ip => !player.joinIps.includes(ip));
 		this.removePlayer(user);
 		this.leftHunt[user.id] = 1;
@@ -377,6 +411,24 @@ class ScavengerHunt extends Rooms.RoomGame {
 		}
 
 		this.announce(`A new ${this.gameType} Scavenger Hunt by <em>${Chat.escapeHTML(Chat.toListString(this.hosts.map(h => h.name)))}</em> has been started${(this.hosts.some(h => h.id === this.staffHostId) ? '' : ` by <em>${Chat.escapeHTML(this.staffHostName)}</em>`)}.<br />The first hint is: ${Chat.formatText(this.questions[0].hint)}`);
+	}
+
+	runEvent(event_id, ...args) {
+		let events = this.mods['on' + event_id];
+		if (!events) return;
+
+		events = events.sort((a, b) => b.priority - a.priority);
+		let result = undefined;
+
+		if (events) {
+			for (let event of events) {
+				let subResult = event.exec.call(this, ...args);
+				if (subResult === true) return true;
+				result = subResult;
+			}
+		}
+
+		return result === false ? true : result;
 	}
 
 	onEditQuestion(number, question_answer, value) {
@@ -421,18 +473,22 @@ class ScavengerHunt extends Rooms.RoomGame {
 
 	onSubmit(user, value) {
 		if (!(user.id in this.playerTable)) {
-			if (!this.parentGame && !this.joinGame(user)) return false;
-			if (this.parentGame && !this.parentGame.joinGame(user)) return false;
+			if (!this.joinGame(user)) return false;
 		}
 		value = toID(value);
 
 		let player = this.playerTable[user.id];
+
+		if (this.runEvent('AnySubmit', player, value)) return;
 		if (player.completed) return false;
 
 		this.validatePlayer(player);
 		player.lastGuess = Date.now();
 
+		if (this.runEvent('Submit', player, value)) return false;
+
 		if (player.verifyAnswer(value)) {
+			if (this.runEvent('CorrectAnswer', player, value)) return;
 			player.sendRoom("Congratulations! You have gotten the correct answer.");
 			player.currentQuestion++;
 			if (player.currentQuestion === this.questions.length) {
@@ -441,6 +497,7 @@ class ScavengerHunt extends Rooms.RoomGame {
 				this.onSendQuestion(user);
 			}
 		} else {
+			if (this.runEvent('IncorrectAnswer', player, value)) return;
 			player.sendRoom("That is not the answer - try again!");
 		}
 	}
@@ -451,6 +508,8 @@ class ScavengerHunt extends Rooms.RoomGame {
 		let player = this.playerTable[user.id];
 		if (player.completed) return false;
 
+		if (this.runEvent('SendQuestion', player, showHints)) return;
+
 		let current = player.getCurrentQuestion();
 
 		player.sendRoom(`|raw|You are on ${(current.number === this.questions.length ? "final " : "")}hint #${current.number}: ${Chat.formatText(current.question.hint)}${showHints && current.question.spoilers.length ? `<details><summary>Extra Hints:</summary>${current.question.spoilers.map(p => `- ${p}`).join('<br />')}</details>` : ''}`);
@@ -458,6 +517,8 @@ class ScavengerHunt extends Rooms.RoomGame {
 	}
 
 	onViewHunt(user) {
+		if (this.runEvent('onViewHunt', user)) return;
+
 		let qLimit = 1;
 		if (this.hosts.some(h => h.id === user.id) || user.id === this.staffHostId)	{
 			qLimit = this.questions.length + 1;
@@ -478,20 +539,22 @@ class ScavengerHunt extends Rooms.RoomGame {
 		let blitz = (((this.room.blitzPoints && this.room.blitzPoints[this.gameType]) || DEFAULT_BLITZ_POINTS[this.gameType]) && now - this.startTime <= 60000);
 
 		player.completed = true;
-		this.completed.push({name: player.name, time: time, blitz: blitz});
+		let result = this.runEvent('Complete', player);
+		if (result === false) return;
+		result = result || {name: player.name, time: time, blitz: blitz};
+		this.completed.push(result);
 		let place = formatOrder(this.completed.length);
 
 		this.announce(Chat.html`<em>${player.name}</em> has finished the hunt in ${place} place! (${time}${(blitz ? " - BLITZ" : "")})`);
-		if (this.parentGame) this.parentGame.onCompleteEvent(player);
 		player.destroy(); // remove from user.games;
 	}
 
 	onEnd(reset, endedBy) {
-		if (this.parentGame) this.parentGame.onBeforeEndHunt();
 		if (!endedBy && (this.preCompleted ? this.preCompleted.length : this.completed.length) === 0) {
 			reset = true;
 		}
 
+		this.runEvent('End');
 		if (!ScavengerHuntDatabase.isEmpty() && this.room.addRecycledHuntsToQueueAutomatically) {
 			if (!this.room.scavQueue) {
 				this.room.scavQueue = [];
@@ -507,7 +570,6 @@ class ScavengerHunt extends Rooms.RoomGame {
 				gameType: 'unrated',
 			});
 		}
-
 		if (!reset) {
 			let sliceIndex = this.gameType === 'official' ? 5 : 3;
 
@@ -518,37 +580,36 @@ class ScavengerHunt extends Rooms.RoomGame {
 			);
 
 			// give points for winning and blitzes in official games
-
-			const winPoints = (this.room.winPoints && this.room.winPoints[this.gameType]) || DEFAULT_POINTS[this.gameType];
-			const blitzPoints = (this.room.blitzPoints && this.room.blitzPoints[this.gameType]) || DEFAULT_BLITZ_POINTS[this.gameType];
-			// only regular hunts give host points
-			let hostPoints;
-			if (this.gameType === 'regular') {
-				hostPoints = Object.hasOwnProperty.call(this.room, 'hostPoints') ? this.room.hostPoints : DEFAULT_HOST_POINTS;
-			}
-
-			let didSomething = false;
-			if (winPoints || blitzPoints) {
-				for (const [i, completed] of this.completed.entries()) {
-					if (!completed.blitz && i >= winPoints.length) break; // there won't be any more need to keep going
-					let name = completed.name;
-					if (winPoints[i]) Leaderboard.addPoints(name, 'points', winPoints[i]);
-					if (blitzPoints && completed.blitz) Leaderboard.addPoints(name, 'points', blitzPoints);
+			if (this.runEvent('GivePoints')) {
+				const winPoints = (this.room.winPoints && this.room.winPoints[this.gameType]) || DEFAULT_POINTS[this.gameType];
+				const blitzPoints = (this.room.blitzPoints && this.room.blitzPoints[this.gameType]) || DEFAULT_BLITZ_POINTS[this.gameType];
+				// only regular hunts give host points
+				let hostPoints;
+				if (this.gameType === 'regular') {
+					hostPoints = Object.hasOwnProperty.call(this.room, 'hostPoints') ? this.room.hostPoints : DEFAULT_HOST_POINTS;
 				}
-				didSomething = true;
-			}
-			if (hostPoints) {
-				if (this.hosts.length === 1) {
-					Leaderboard.addPoints(this.hosts[0].name, 'points', hostPoints, this.hosts[0].noUpdate);
+
+				let didSomething = false;
+				if (winPoints || blitzPoints) {
+					for (const [i, completed] of this.completed.entries()) {
+						if (!completed.blitz && i >= winPoints.length) break; // there won't be any more need to keep going
+						let name = completed.name;
+						if (winPoints[i]) Leaderboard.addPoints(name, 'points', winPoints[i]);
+						if (blitzPoints && completed.blitz) Leaderboard.addPoints(name, 'points', blitzPoints);
+					}
 					didSomething = true;
-				} else {
-					this.room.sendMods('|notify|A scavenger hunt with multiple hosts needs points!');
-					this.room.sendMods('(A scavenger hunt with multiple hosts has ended.)');
 				}
+				if (hostPoints) {
+					if (this.hosts.length === 1) {
+						Leaderboard.addPoints(this.hosts[0].name, 'points', hostPoints, this.hosts[0].noUpdate);
+						didSomething = true;
+					} else {
+						this.room.sendMods('|notify|A scavenger hunt with multiple hosts needs points!');
+						this.room.sendMods('(A scavenger hunt with multiple hosts has ended.)');
+					}
+				}
+				if (didSomething) Leaderboard.write();
 			}
-			if (didSomething) Leaderboard.write();
-
-			if (this.parentGame) this.parentGame.onEndEvent();
 
 			this.onTallyLeaderboard();
 
@@ -557,10 +618,9 @@ class ScavengerHunt extends Rooms.RoomGame {
 			this.announce(`The scavenger hunt has been reset by ${endedBy.name}.`);
 		} else {
 			this.announce("The hunt has been reset automatically, due to the lack of finishers.");
-			if (this.parentGame) this.parentGame.onEndEvent();
 			this.tryRunQueue(this.room.roomid);
 		}
-		if (this.parentGame) this.parentGame.onAfterEndHunt();
+		this.runEvent('AfterEnd');
 		this.destroy();
 	}
 
@@ -585,7 +645,7 @@ class ScavengerHunt extends Rooms.RoomGame {
 	}
 
 	tryRunQueue(roomid) {
-		if (this.parentGame || this.room.scavQueueDisabled) return; // don't run the queue for child games.
+		if (this.room.scavgame || this.room.scavQueueDisabled) return; // don't run the queue for child games.
 		// prepare the next queue'd game
 		if (this.room.scavQueue && this.room.scavQueue.length) {
 			setTimeout(() => {
@@ -617,12 +677,9 @@ class ScavengerHunt extends Rooms.RoomGame {
 			this.playerTable[i].destroy();
 		}
 		// destroy this game
-		if (this.parentGame) {
-			this.parentGame.onDestroyEvent();
-		} else {
-			delete this.room.game;
-			this.room = null;
-		}
+
+		delete this.room.game;
+		this.room = null;
 	}
 
 	announce(msg) {
@@ -764,6 +821,7 @@ class ScavengerHuntPlayer extends Rooms.RoomGamePlayer {
 	}
 
 	onNotifyChange(num) {
+		this.game.runEvent('NotifyChange', this, num);
 		if (num === this.currentQuestion) {
 			this.sendRoom(`|raw|<strong>The hint has been changed to:</strong> ${Chat.formatText(this.game.questions[num].hint)}`);
 		}
@@ -771,7 +829,7 @@ class ScavengerHuntPlayer extends Rooms.RoomGamePlayer {
 
 	destroy() {
 		let user = Users.getExact(this.id);
-		if (user && !this.game.parentGame) {
+		if (user) {
 			user.games.delete(this.game.roomid);
 			user.updateSearch();
 		}
@@ -812,101 +870,41 @@ let commands = {
 	 */
 	game: 'games',
 	games: {
-		knockoutgames: 'kogames',
-		kogames(target, room, user) {
-			if (room.roomid !== 'scavengers' && !(room.parent && room.parent.roomid === 'scavengers')) return this.errorReply("Scavenger games can only be created in the scavengers room.");
-			if (!this.can('mute', null, room)) return false;
-			if (room.game) return this.errorReply(`There is already a game in this room - ${room.game.title}.`);
-
-			room.game = new ScavengerGames.KOGame(room);
-			room.game.announce("A new Knockout Games has been started!");
-		},
-
-		jumpstart: {
-			""(target, room, user) {
-				if (room.roomid !== 'scavengers' && !(room.parent && room.parent.roomid === 'scavengers')) return this.errorReply("Scavenger games can only be created in the scavengers room.");
-				if (!this.can('mute', null, room)) return false;
-				if (room.game) return this.errorReply(`There is already a game in this room - ${room.game.title}.`);
-
-				room.game = new ScavengerGames.JumpStart(room);
-				room.game.announce("A new Jump Start game has been started!");
-				this.sendReply('Please use /starthunt to set the first hunt.');
-			},
-
-			set(target, room, user) {
-				if (!this.can('mute', null, room)) return false;
-				if (!room.game || room.game.gameid !== "jumpstart") return this.errorReply("There is no Jump Start game currently running.");
-
-				let error = room.game.setJumpStart(target.split(','));
-				if (error) return this.errorReply(error);
-			},
-		},
-
-		scav: 'scavengergames',
-		scavengergames(target, room, user) {
-			if (room.roomid !== 'scavengers' && !(room.parent && room.parent.roomid === 'scavengers')) return this.errorReply("Scavenger games can only be created in the scavengers room.");
-			if (!this.can('mute', null, room)) return false;
-			if (room.game) return this.errorReply(`There is already a game in this room - ${room.game.title}.`);
-
-			room.game = new ScavengerGames.ScavengerGames(room);
-			room.game.announce("A new Scavenger Games has been started!");
-		},
-
-		pointrally(target, room, user) {
-			if (room.roomid !== 'scavengers' && !(room.parent && room.parent.roomid === 'scavengers')) return this.errorReply("Scavenger games can only be created in the scavengers room.");
-			if (!this.can('mute', null, room)) return false;
-			if (room.game) return this.errorReply(`There is already a game in this room - ${room.game.title}.`);
-
-			room.game = new ScavengerGames.PointRally(room);
-			room.game.announce("A new Point Rally game has been started!");
-		},
-
-		incog: 'incognito',
-		incognitomode: 'incognito',
-		incognito(target, room, user) {
-			if (room.roomid !== 'scavengers' && !(room.parent && room.parent.roomid === 'scavengers')) return this.errorReply("Scavenger games can only be created in the scavengers room.");
-			if (!this.can('mute', null, room)) return false;
-			if (room.game) return this.errorReply(`There is already a game in this room - ${room.game.title}.`);
-
-			let [details, hostsArray, ...params] = target.split('|'), blind, official;
-			details = details.split(' ').map(toID);
-			if (details.includes('blind')) blind = true;
-			let gameType = 'regular';
-			if (details.includes('official')) {
-				gameType = 'official';
-			} else if (details.includes('mini')) {
-				gameType = 'mini';
-			}
-
-			if (gameType === 'regular' && !blind) {
-				params = [hostsArray, ...params];
-				hostsArray = details.join(' ');
-			}
-			if (!hostsArray) return this.errorReply("The user(s) you specified as the host is not online, or is not in the room.");
-			let hosts = ScavengerHunt.parseHosts(hostsArray.split(/[,;]/), room, official);
-			if (!hosts) return this.errorReply("The user(s) you specified as the host is not online, or is not in the room.");
-
-			params = ScavengerHunt.parseQuestions(params);
-			if (params.err) return this.errorReply(params.err);
-
-			room.game = new ScavengerGames.Incognito(room, blind, gameType, user, hosts, params.result);
-		},
 		/**
 		 * General game commands
 		 */
+		create: 'start',
+		new: 'start',
+		start(target, room, user) {
+			if (!this.can('mute', null, room)) return false;
+			if (room.scavgame) return this.errorReply('There is already a scavenger game running.');
+
+			target = toID(target);
+			let game = ScavMods.LoadGame(room, target);
+
+			if (!game) return this.errorReply('Invalid game mode.');
+
+			room.scavgame = game;
+
+			this.privateModAction(`(A ${room.scavgame.name} has been created by ${user.name}.)`);
+			this.modlog('SCAVENGER', null, 'ended the scavenger game');
+
+			room.scavgame.announce(`A game of ${room.scavgame.name} has been started!`);
+		},
+
 		end(target, room, user) {
 			if (!this.can('mute', null, room)) return false;
-			if (!room.game || !room.game.scavParentGame) return this.errorReply(`There is no scavenger game currently running.`);
+			if (!room.scavgame) return this.errorReply(`There is no scavenger game currently running.`);
 
-			this.privateModAction(`The ${room.game.title} has been forcibly ended by ${user.name}.`);
-			this.modlog('SCAVENGER', null, 'ended the hunt');
-			room.game.announce(`The ${room.game.title} has been forcibly ended.`);
-			room.game.destroy();
+			this.privateModAction(`(The ${room.scavgame.name} has been forcibly ended by ${user.name}.)`);
+			this.modlog('SCAVENGER', null, 'ended the scavenger game');
+			room.scavgame.announce(`The ${room.scavgame.name} has been forcibly ended.`);
+			room.scavgame.destroy(true);
 		},
 
 		kick(target, room, user) {
 			if (!this.can('mute', null, room)) return false;
-			if (!room.game || !room.game.scavParentGame) return this.errorReply(`There is no scavenger game currently running.`);
+			if (!room.scavgame) return this.errorReply(`There is no scavenger game currently running.`);
 
 			let targetId = toID(target);
 			if (targetId === 'constructor' || !targetId) return this.errorReply("Invalid player.");
@@ -924,24 +922,24 @@ let commands = {
 		score: 'leaderboard',
 		scoreboard: 'leaderboard',
 		leaderboard(target, room, user) {
-			if (!room.game || !room.game.scavParentGame) return this.errorReply(`There is no scavenger game currently running.`);
-			if (!room.game.leaderboard) return this.errorReply("This scavenger game does not have a leaderboard.");
+			if (!room.scavgame) return this.errorReply(`There is no scavenger game currently running.`);
+			if (!room.scavgame.leaderboard) return this.errorReply("This scavenger game does not have a leaderboard.");
 			if (!this.runBroadcast()) return false;
 
-			room.game.leaderboard.htmlLadder().then(html => {
+			room.scavgame.leaderboard.htmlLadder().then(html => {
 				this.sendReply(`|raw|${html}`);
 				if (this.broadcasting) setImmediate(() => room.update()); // make sure the room updates for broadcasting since this is async.
 			});
 		},
 
 		rank(target, room, user) {
-			if (!room.game || !room.game.scavParentGame) return this.errorReply(`There is no scavenger game currently running.`);
-			if (!room.game.leaderboard) return this.errorReply("This scavenger game does not have a leaderboard.");
+			if (!room.scavgame) return this.errorReply(`There is no scavenger game currently running.`);
+			if (!room.scavgame.leaderboard) return this.errorReply("This scavenger game does not have a leaderboard.");
 			if (!this.runBroadcast()) return false;
 
 			let targetId = toID(target) || user.id;
 
-			room.game.leaderboard.visualize('points', targetId).then(rank => {
+			room.scavgame.leaderboard.visualize('points', targetId).then(rank => {
 				if (!rank) return this.sendReplyBox(`User '${targetId}' does not have any points on the scavenger games leaderboard.`);
 
 				this.sendReplyBox(Chat.html`User '${rank.name}' is #${rank.rank} on the scavenger games leaderboard with ${rank.points} points.`);
@@ -952,6 +950,7 @@ let commands = {
 	/**
 	 * Creation / Moderation commands
 	 */
+	createtwist: 'create',
 	createpractice: 'create',
 	createofficial: 'create',
 	createunrated: 'create',
@@ -962,7 +961,7 @@ let commands = {
 	create(target, room, user, connection, cmd) {
 		if (room.roomid !== 'scavengers' && !(room.parent && room.parent.roomid === 'scavengers')) return this.errorReply("Scavenger hunts can only be created in the scavengers room.");
 		if (!this.can('mute', null, room)) return false;
-		if (room.game && !room.game.scavParentGame) return this.errorReply(`There is already a game in this room - ${room.game.title}.`);
+		if (room.game) return this.errorReply(`There is already a game in this room - ${room.game.title}.`);
 		let gameType = 'regular';
 		if (cmd.includes('practice')) {
 			gameType = 'practice';
@@ -976,8 +975,14 @@ let commands = {
 			gameType = 'recycled';
 		}
 
+		let mod = null;
+		if (cmd.includes('twist')) {
+			[mod, ...target] = target.split('|');
+			target = target.join('|');
+		}
+
 		// mini and officials can be started anytime
-		if (!cmd.includes('force') && ['regular', 'unrated', 'recycled'].includes(gameType) && room.scavQueue && room.scavQueue.length && !(room.game && room.game.scavParentGame)) return this.errorReply(`There are currently hunts in the queue! If you would like to start the hunt anyways, use /forcestart${gameType === 'regular' ? 'hunt' : gameType}.`);
+		if (!cmd.includes('force') && ['regular', 'unrated', 'recycled'].includes(gameType) && room.scavQueue && room.scavQueue.length && !room.scavgame) return this.errorReply(`There are currently hunts in the queue! If you would like to start the hunt anyways, use /forcestart${gameType === 'regular' ? 'hunt' : gameType}.`);
 
 		if (gameType === 'recycled') {
 			if (ScavengerHuntDatabase.isEmpty()) {
@@ -1007,12 +1012,8 @@ let commands = {
 		params = ScavengerHunt.parseQuestions(params);
 		if (params.err) return this.errorReply(params.err);
 
-		if (room.game && room.game.scavParentGame) {
-			let success = room.game.createHunt(room, user, hosts, gameType, params.result);
-			if (!success) return;
-		} else {
-			room.game = new ScavengerHunt(room, user, hosts, gameType, params.result);
-		}
+		room.game = new ScavengerHunt(room, user, hosts, gameType, params.result, mod);
+
 		this.privateModAction(`(A new scavenger hunt was created by ${user.name}.)`);
 		this.modlog('SCAV NEW', null, `${gameType.toUpperCase()}: creators - ${hosts.map(h => h.id)}`);
 	},
@@ -1020,7 +1021,7 @@ let commands = {
 	status(target, room, user) {
 		if (!room.game || !room.game.scavGame) return this.errorReply(`There is no scavenger game currently running.`);
 
-		let game = room.game.childGame || room.game;
+		let game = room.game;
 		if (!('questions' in game)) return this.errorReply('There is currently no hunt going on.');
 
 		const elapsedMsg = Chat.toDurationString(Date.now() - game.startTime, {hhmmss: true});
@@ -1039,10 +1040,10 @@ let commands = {
 					str += `<tr><td>${questionNum}</td><td>None</td>`;
 				} else {
 					str += `<tr><td>${questionNum}</td><td>`;
-					str += players.map(
-						pl => pl.lastGuess > Date.now() - 1000 * 300 ?
-							Chat.html`<strong>${pl.name}</strong>` :
-							Chat.escapeHTML(pl.name)
+					str += players.map(pl => pl.lastGuess > Date.now() - 1000 * 300 ?
+						Chat.html`<strong>${pl.name}</strong>`
+						: // eslint-disable-line operator-linebreak
+						Chat.escapeHTML(pl.name)
 					).join(", ");
 				}
 			}
@@ -1074,7 +1075,7 @@ let commands = {
 		if (!this.can('mute', null, room)) return false;
 		if (!room.game || !room.game.scavGame) return this.errorReply(`There is no scavenger game currently running.`);
 
-		let game = room.game.childGame || room.game;
+		let game = room.game;
 		if (!('questions' in game)) return this.errorReply('There is currently no hunt going on.');
 
 		if (game.staffHostId === user.id) return this.errorReply('You already have staff permissions for this hunt.');
@@ -1102,10 +1103,10 @@ let commands = {
 	forceend: 'end',
 	end(target, room, user) {
 		if (!this.can('mute', null, room)) return false;
+		if (!room.game && room.scavgame) return this.parse('/scav games end');
 		if (!room.game || !room.game.scavGame) return this.errorReply(`There is no scavenger game currently running.`);
-		if (room.game.scavParentGame && !room.game.childGame) return this.parse('/scav games end');
 
-		let game = room.game.childGame || room.game;
+		let game = room.game;
 		let completed = game.preCompleted ? game.preCompleted : game.completed;
 
 		if (!this.cmd.includes('force')) {
@@ -1124,7 +1125,7 @@ let commands = {
 	viewhunt(target, room, user) {
 		if (!room.game || !room.game.scavGame) return this.errorReply(`There is no scavenger game currently running.`);
 
-		let game = room.game.childGame || room.game;
+		let game = room.game;
 		if (!('onViewHunt' in game)) return this.errorReply('There is currently no hunt to be viewed.');
 
 		game.onViewHunt(user);
@@ -1132,7 +1133,7 @@ let commands = {
 
 	edithunt(target, room, user) {
 		if (!room.game || !room.game.scavGame) return this.errorReply(`There is no scavenger game currently running.`);
-		let game = room.game.childGame || room.game;
+		let game = room.game;
 		if ((!game.hosts.some(h => h.id === user.id) || !user.can('broadcast', null, room)) && game.staffHostId !== user.id) return this.errorReply("You cannot edit the hints and answers if you are not the host.");
 
 		let [question, type, ...value] = target.split(',');
@@ -1144,7 +1145,7 @@ let commands = {
 	addhint: 'spoiler',
 	spoiler(target, room, user) {
 		if (!room.game || !room.game.scavGame) return this.errorReply(`There is no scavenger game currently running.`);
-		let game = room.game.childGame || room.game;
+		let game = room.game;
 		if ((!game.hosts.some(h => h.id === user.id) || !user.can('broadcast', null, room)) && game.staffHostId !== user.id) return this.errorReply("You cannot add more hints if you are not the host.");
 
 		let elapsedTime = Date.now() - game.startTime;
@@ -1168,7 +1169,7 @@ let commands = {
 		let targetId = toID(target);
 		if (targetId === 'constructor' || !targetId) return this.errorReply("Invalid player.");
 
-		let game = room.game.childGame || room.game;
+		let game = room.game;
 		let success = game.eliminate(null, targetId);
 		if (success) {
 			this.modlog('SCAV KICK', targetId);
@@ -1503,6 +1504,47 @@ let commands = {
 			scavsRoom.roomlog(`(${user.name} has set the points awarded for winning ${type} scavenger hunts to - ${pointsDisplay} in <<${room.roomid}>>)`);
 		}
 	},
+	resettwist: 'settwist',
+	twist: 'settwist',
+	settwist(target, room, user) {
+		if (room.roomid !== 'scavengers' && !(room.parent && room.parent.roomid === 'scavengers')) return this.errorReply("This command can only be used in the scavengers room.");
+		if (this.cmd.includes('reset')) target = 'RESET';
+		if (!target) {
+			let twist = room.officialtwist || 'none';
+			return this.sendReplyBox(`The current official twist is: ${twist}`);
+		}
+		if (!this.can('declare', null, room)) return false;
+		if (target === 'RESET') {
+			room.officialtwist = null;
+		} else {
+			let twist = toID(target);
+			if (!ScavMods.twists[twist] || twist === 'constructor') return this.errorReply('Invalid twist.');
+
+			room.officialtwist = twist;
+			if (room.chatRoomData) {
+				room.chatRoomData.twist = room.officialtwist;
+				Rooms.global.writeChatRoomData();
+			}
+		}
+		if (room.officialtwist) {
+			this.privateModAction(`(${user.name} has set the official twist to ${room.officialtwist})`);
+		} else {
+			this.privateModAction(`(${user.name} has removed the official twist.`);
+		}
+		this.modlog('SCAV TWIST', null, room.officialtwist);
+
+		// double modnote in scavs room if it is a subroomgroupchat
+		if (room.parent && !room.chatRoomData) {
+			if (room.officialtwist) {
+				scavsRoom.modlog(`(scavengers) SCAV TWIST: [room: ${room.roomid}] by ${user.id}: ${room.officialtwist}`);
+				scavsRoom.sendMods(`(${user.name} has set the official twist to - ${room.officialtwist} in <<${room.roomid}>>)`);
+				scavsRoom.roomlog(`(${user.name} has set the official twist to  - ${room.officialtwist} in <<${room.roomid}>>)`);
+			} else {
+				scavsRoom.sendMods(`(${user.name} has reset the official twist in <<${room.roomid}>>)`);
+				scavsRoom.roomlog(`(${user.name} has reset the official twist in <<${room.roomid}>>)`);
+			}
+		}
+	},
 
 	/**
 	 * Scavenger statistic tracking
@@ -1823,6 +1865,7 @@ exports.commands = {
 	startminihunt: 'starthunt',
 	startunratedhunt: 'starthunt',
 	startrecycledhunt: 'starthunt',
+	starttwisthunt: 'starthunt',
 
 	forcestarthunt: 'starthunt',
 	forcestartunrated: 'starthunt',

--- a/server/chat-plugins/scavengers.js
+++ b/server/chat-plugins/scavengers.js
@@ -22,7 +22,7 @@ const DEFAULT_BLITZ_POINTS = {
 const DEFAULT_HOST_POINTS = 4;
 const DEFAULT_TIMER_DURATION = 120;
 
-const DATA_FILE = 'config/chat-plugins/scavdata.json';
+const DATA_FILE = 'config/chat-plugins/ScavMods.json';
 const HOST_DATA_FILE = 'config/chat-plugins/scavhostdata.json';
 const PLAYER_DATA_FILE = 'config/chat-plugins/scavplayerdata.json';
 const DATABASE_FILE = 'config/chat-plugins/scavhunts.json';
@@ -193,10 +193,10 @@ function formatQueue(queue = [], viewer, room, broadcasting) {
 			const queuedBy = item.hosts.every(h => h.id !== item.staffHostId) ? ` / ${item.staffHostId}` : '';
 			let questions;
 			if (!broadcasting && (item.hosts.some(h => h.id === viewer.id) || viewer.id === item.staffHostId)) {
-				questions = item.questions.map((q, i) => i % 2 ?
-					Chat.html`<span style="color: green"><em>[${q.join(' / ')}]</em></span><br />`
-					: // eslint-disable-line operator-linebreak
-					Chat.escapeHTML(q)
+				questions = item.questions.map(
+					(q, i) => i % 2 ?
+						Chat.html`<span style="color: green"><em>[${q.join(' / ')}]</em></span><br />` :
+						Chat.escapeHTML(q)
 				).join(" ");
 			} else {
 				questions = `[${item.questions.length / 2} hidden questions]`;
@@ -1040,10 +1040,10 @@ let commands = {
 					str += `<tr><td>${questionNum}</td><td>None</td>`;
 				} else {
 					str += `<tr><td>${questionNum}</td><td>`;
-					str += players.map(pl => pl.lastGuess > Date.now() - 1000 * 300 ?
-						Chat.html`<strong>${pl.name}</strong>`
-						: // eslint-disable-line operator-linebreak
-						Chat.escapeHTML(pl.name)
+					str += players.map(
+						pl => pl.lastGuess > Date.now() - 1000 * 300 ?
+							Chat.html`<strong>${pl.name}</strong>` :
+							Chat.escapeHTML(pl.name)
 					).join(", ");
 				}
 			}

--- a/server/chat-plugins/scavengers.js
+++ b/server/chat-plugins/scavengers.js
@@ -22,7 +22,7 @@ const DEFAULT_BLITZ_POINTS = {
 const DEFAULT_HOST_POINTS = 4;
 const DEFAULT_TIMER_DURATION = 120;
 
-const DATA_FILE = 'config/chat-plugins/ScavMods.json';
+const DATA_FILE = 'config/chat-plugins/scavdata.json';
 const HOST_DATA_FILE = 'config/chat-plugins/scavhostdata.json';
 const PLAYER_DATA_FILE = 'config/chat-plugins/scavplayerdata.json';
 const DATABASE_FILE = 'config/chat-plugins/scavhunts.json';


### PR DESCRIPTION
- apply them as "formats"/"mods" instead of a large parent game with another room game nested inside
- the parent game is attached to ``room.scavgame`` as an independent object instead.
- add a command to set the twist (/scav settwist) and reset the twist (/scav resettwist) for scripted formats
     - this means that scavenger-games.js might be updated once per month as new twists are created.
- add a command to start a regular hunt with twists

More than one twist can be loaded into a single scavenger hunt (from scavenger game mode + /scav createtwist)

And as usual, this has Meicoo's seal of approval.