### PR TITLE
Fix minor /hidetext bug

### DIFF
--- a/server/chat-commands/moderation.js
+++ b/server/chat-commands/moderation.js
@@ -1409,7 +1409,7 @@ exports.commands = {
 
 		if (!this.can('mute', null, room)) return;
 		if (targetUser && targetUser.trusted && targetUser !== user && !cmd.includes('force')) {
-			return this.errorReply(`${target} is a trusted user, are you sure you want to hide their messages? Use /forcehidetext if you're sure.`);
+			return this.errorReply(`${name} is a trusted user, are you sure you want to hide their messages? Use /forcehidetext if you're sure.`);
 		}
 
 		if (targetUser && cmd.includes('alt')) {


### PR DESCRIPTION
If /hidetext is used with a linecount parameter on a trusted user, it currently says "USER, 4 is a trusted user, are you sure you want to hide their messages? Use /forcehidetext if you're sure." This change hides the additional linecount parameter from the message.