### PR TITLE
Fix `Battle#switchIn`

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1256,9 +1256,11 @@ export class Battle {
 		pokemon.isActive = true;
 		this.runEvent('BeforeSwitchIn', pokemon);
 		if (oldActive) {
-			this.runEvent('SwitchOut', oldActive);
-			oldActive.illusion = null;
-			this.singleEvent('End', oldActive.getAbility(), oldActive.abilityData, oldActive);
+			if (isDrag) {
+				this.runEvent('SwitchOut', oldActive);
+				oldActive.illusion = null;
+				this.singleEvent('End', oldActive.getAbility(), oldActive.abilityData, oldActive);
+			}
 			oldActive.isActive = false;
 			oldActive.isStarted = false;
 			oldActive.usedItemThisTurn = false;

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1256,6 +1256,9 @@ export class Battle {
 		pokemon.isActive = true;
 		this.runEvent('BeforeSwitchIn', pokemon);
 		if (oldActive) {
+			this.runEvent('SwitchOut', oldActive);
+			oldActive.illusion = null;
+			this.singleEvent('End', oldActive.getAbility(), oldActive.abilityData, oldActive);
 			oldActive.isActive = false;
 			oldActive.isStarted = false;
 			oldActive.usedItemThisTurn = false;
@@ -1272,6 +1275,7 @@ export class Battle {
 			moveSlot.used = false;
 		}
 		this.add(isDrag ? 'drag' : 'switch', pokemon, pokemon.getDetails);
+		if (isDrag && this.gen === 2) pokemon.draggedIn = this.turn;
 		if (sourceEffect) this.log[this.log.length - 1] += `|[from]${sourceEffect.fullname}`;
 		pokemon.previouslySwitchedIn++;
 

--- a/test/sim/abilities/naturalcure.js
+++ b/test/sim/abilities/naturalcure.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Natural Cure', function () {
+	it('should cure even when phased out by Roar', function () {
+		battle = common.createBattle();
+		battle.setPlayer('p1', {
+			team: [
+				{species: 'Celebi', ability: 'naturalcure', moves: ['leechseed']},
+				{species: 'Swampert', ability: 'torrents', moves: ['surf']},
+			],
+		});
+		battle.setPlayer('p2', {
+			team: [
+				{species: 'Zapdos', ability: 'pressure', moves: ['thunderwave', 'roar']},
+			],
+		});
+		battle.makeChoices('move leechseed', 'move thunderwave');
+		battle.makeChoices('move leechseed', 'move roar');
+		assert.false(battle.p1.pokemon[1].status === 'par');
+	});
+});


### PR DESCRIPTION
Regression caused by: https://github.com/smogon/pokemon-showdown/commit/47b55f96bc5c62e51255012e154ea81a46a2bb90

`Battle#dragIn` used to run the `SwitchOut` event among other functions
but were accidentally left off in the refactor. This commit adds them back.

The main bug caused by this is Natural Cure not curing status aliments when
phased out by Roar.

@Zarel: **please review/merge ASAP** as a major ADV tournament is going on
currently, so Natural Cure being broken is a big deal.