### PR TITLE
Mark Plates (except Pixie Plate) as past gen items

### DIFF
--- a/data/items.js
+++ b/data/items.js
@@ -1368,6 +1368,7 @@ let BattleItems = {
 		forcedForme: "Arceus-Dragon",
 		num: 311,
 		gen: 4,
+		isNonstandard: "Past",
 		desc: "Holder's Dragon-type attacks have 1.2x power. Judgment is Dragon type.",
 	},
 	"dragonfang": {
@@ -1465,6 +1466,7 @@ let BattleItems = {
 		forcedForme: "Arceus-Dark",
 		num: 312,
 		gen: 4,
+		isNonstandard: "Past",
 		desc: "Holder's Dark-type attacks have 1.2x power. Judgment is Dark type.",
 	},
 	"dreamball": {
@@ -1543,6 +1545,7 @@ let BattleItems = {
 		forcedForme: "Arceus-Ground",
 		num: 305,
 		gen: 4,
+		isNonstandard: "Past",
 		desc: "Holder's Ground-type attacks have 1.2x power. Judgment is Ground type.",
 	},
 	"eeviumz": {
@@ -1979,6 +1982,7 @@ let BattleItems = {
 		forcedForme: "Arceus-Fighting",
 		num: 303,
 		gen: 4,
+		isNonstandard: "Past",
 		desc: "Holder's Fighting-type attacks have 1.2x power. Judgment is Fighting type.",
 	},
 	"flameorb": {
@@ -2018,6 +2022,7 @@ let BattleItems = {
 		forcedForme: "Arceus-Fire",
 		num: 298,
 		gen: 4,
+		isNonstandard: "Past",
 		desc: "Holder's Fire-type attacks have 1.2x power. Judgment is Fire type.",
 	},
 	"floatstone": {
@@ -2779,6 +2784,7 @@ let BattleItems = {
 		forcedForme: "Arceus-Ice",
 		num: 302,
 		gen: 4,
+		isNonstandard: "Past",
 		desc: "Holder's Ice-type attacks have 1.2x power. Judgment is Ice type.",
 	},
 	"iciumz": {
@@ -2839,6 +2845,7 @@ let BattleItems = {
 		forcedForme: "Arceus-Bug",
 		num: 308,
 		gen: 4,
+		isNonstandard: "Past",
 		desc: "Holder's Bug-type attacks have 1.2x power. Judgment is Bug type.",
 	},
 	"ironball": {
@@ -2881,6 +2888,7 @@ let BattleItems = {
 		forcedForme: "Arceus-Steel",
 		num: 313,
 		gen: 4,
+		isNonstandard: "Past",
 		desc: "Holder's Steel-type attacks have 1.2x power. Judgment is Steel type.",
 	},
 	"jabocaberry": {
@@ -3668,6 +3676,7 @@ let BattleItems = {
 		forcedForme: "Arceus-Grass",
 		num: 301,
 		gen: 4,
+		isNonstandard: "Past",
 		desc: "Holder's Grass-type attacks have 1.2x power. Judgment is Grass type.",
 	},
 	"medichamite": {
@@ -3926,6 +3935,7 @@ let BattleItems = {
 		forcedForme: "Arceus-Psychic",
 		num: 307,
 		gen: 4,
+		isNonstandard: "Past",
 		desc: "Holder's Psychic-type attacks have 1.2x power. Judgment is Psychic type.",
 	},
 	"miracleseed": {
@@ -5659,6 +5669,7 @@ let BattleItems = {
 		forcedForme: "Arceus-Flying",
 		num: 306,
 		gen: 4,
+		isNonstandard: "Past",
 		desc: "Holder's Flying-type attacks have 1.2x power. Judgment is Flying type.",
 	},
 	"slowbronite": {
@@ -5820,6 +5831,7 @@ let BattleItems = {
 		forcedForme: "Arceus-Water",
 		num: 299,
 		gen: 4,
+		isNonstandard: "Past",
 		desc: "Holder's Water-type attacks have 1.2x power. Judgment is Water type.",
 	},
 	"spookyplate": {
@@ -5842,6 +5854,7 @@ let BattleItems = {
 		forcedForme: "Arceus-Ghost",
 		num: 310,
 		gen: 4,
+		isNonstandard: "Past",
 		desc: "Holder's Ghost-type attacks have 1.2x power. Judgment is Ghost type.",
 	},
 	"sportball": {
@@ -6023,6 +6036,7 @@ let BattleItems = {
 		forcedForme: "Arceus-Rock",
 		num: 309,
 		gen: 4,
+		isNonstandard: "Past",
 		desc: "Holder's Rock-type attacks have 1.2x power. Judgment is Rock type.",
 	},
 	"strawberrysweet": {
@@ -6242,6 +6256,7 @@ let BattleItems = {
 		forcedForme: "Arceus-Poison",
 		num: 304,
 		gen: 4,
+		isNonstandard: "Past",
 		desc: "Holder's Poison-type attacks have 1.2x power. Judgment is Poison type.",
 	},
 	"tr00": {
@@ -7746,6 +7761,7 @@ let BattleItems = {
 		forcedForme: "Arceus-Electric",
 		num: 300,
 		gen: 4,
+		isNonstandard: "Past",
 		desc: "Holder's Electric-type attacks have 1.2x power. Judgment is Electric type.",
 	},
 	"zoomlens": {

--- a/data/mods/gen7/items.js
+++ b/data/mods/gen7/items.js
@@ -137,12 +137,20 @@ let BattleItems = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	dracoplate: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	dragongem: {
 		inherit: true,
 		isNonstandard: null,
 		isUnreleased: true,
 	},
 	dragoniumz: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	dreadplate: {
 		inherit: true,
 		isNonstandard: null,
 	},
@@ -154,6 +162,10 @@ let BattleItems = {
 		gen: 5,
 		isPokeball: true,
 		desc: "A special Poke Ball that appears out of nowhere in a bag at the Entree Forest.",
+	},
+	earthplate: {
+		inherit: true,
+		isNonstandard: null,
 	},
 	eeviumz: {
 		inherit: true,
@@ -202,6 +214,14 @@ let BattleItems = {
 		isUnreleased: true,
 	},
 	firiumz: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	fistplate: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	flameplate: {
 		inherit: true,
 		isNonstandard: null,
 	},
@@ -296,11 +316,23 @@ let BattleItems = {
 		inherit: true,
 		desc: "Evolves Alolan Sandshrew into Alolan Sandslash and Alolan Vulpix into Alolan Ninetales when used.",
 	},
+	icicleplate: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	iciumz: {
 		inherit: true,
 		isNonstandard: null,
 	},
 	inciniumz: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	insectplate: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	ironplate: {
 		inherit: true,
 		isNonstandard: null,
 	},
@@ -379,6 +411,10 @@ let BattleItems = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	meadowplate: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	medichamite: {
 		inherit: true,
 		isNonstandard: null,
@@ -404,6 +440,10 @@ let BattleItems = {
 		isUnreleased: undefined,
 	},
 	mimikiumz: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	mindplate: {
 		inherit: true,
 		isNonstandard: null,
 	},
@@ -506,6 +546,10 @@ let BattleItems = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	skyplate: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	slowbronite: {
 		inherit: true,
 		isNonstandard: null,
@@ -515,6 +559,14 @@ let BattleItems = {
 		isNonstandard: null,
 	},
 	solganiumz: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	splashplate: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	spookyplate: {
 		inherit: true,
 		isNonstandard: null,
 	},
@@ -535,6 +587,10 @@ let BattleItems = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	stoneplate: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	swampertite: {
 		inherit: true,
 		isNonstandard: null,
@@ -546,6 +602,10 @@ let BattleItems = {
 	thunderstone: {
 		inherit: true,
 		desc: "Evolves Pikachu into Raichu or Alolan Raichu, Eevee into Jolteon, and Eelektrik into Eelektross when used.",
+	},
+	toxicplate: {
+		inherit: true,
+		isNonstandard: null,
 	},
 	tyranitarite: {
 		inherit: true,
@@ -578,6 +638,10 @@ let BattleItems = {
 				pokemon.addVolatile('confusion');
 			}
 		},
+	},
+	zapplate: {
+		inherit: true,
+		isNonstandard: null,
 	},
 };
 exports.BattleItems = BattleItems;


### PR DESCRIPTION
You can't obtain Plates, save Pixie Plate, in Sword and Shield.