### PR TITLE
Ban Hidden Abilities unreleased in VGC17

### DIFF
--- a/data/mods/vgc17/formats-data.js
+++ b/data/mods/vgc17/formats-data.js
@@ -67,6 +67,50 @@ let BattleFormatsData = {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",
 	},
+	litten: {
+		inherit: true,
+		unreleasedHidden: true,
+	},
+	torracat: {
+		inherit: true,
+		unreleasedHidden: true,
+	},
+	incineroar: {
+		inherit: true,
+		unreleasedHidden: true,
+	},
+	rowlet: {
+		inherit: true,
+		unreleasedHidden: true,
+	},
+	dartrix: {
+		inherit: true,
+		unreleasedHidden: true,
+	},
+	decidueye: {
+		inherit: true,
+		unreleasedHidden: true,
+	},
+	popplio: {
+		inherit: true,
+		unreleasedHidden: true,
+	},
+	brionne: {
+		inherit: true,
+		unreleasedHidden: true,
+	},
+	primarina: {
+		inherit: true,
+		unreleasedHidden: true,
+	},
+	passimian: {
+		inherit: true,
+		unreleasedHidden: true,
+	},
+	oranguru: {
+		inherit: true,
+		unreleasedHidden: true,
+	},
 };
 
 exports.BattleFormatsData = BattleFormatsData;


### PR DESCRIPTION
Most old VGC 2017 tournaments just have to gentlemen's agreement not to use these right now; we probably should actually ban them! The Immortal's commit to fix illegal Z-moves in 2017 prompted this.