### PR TITLE
Properly override onFractionalPriority in past gens

### DIFF
--- a/data/mods/gen2/items.js
+++ b/data/mods/gen2/items.js
@@ -80,7 +80,7 @@ let BattleItems = {
 	quickclaw: {
 		inherit: true,
 		desc: "Each turn, holder has a ~23.4% chance to move first in its priority bracket.",
-		onModifyPriority(priority, pokemon) {
+		onFractionalPriority(priority, pokemon) {
 			if (this.randomChance(60, 256)) {
 				return Math.round(priority) + 0.1;
 			}

--- a/data/mods/gen3/items.js
+++ b/data/mods/gen3/items.js
@@ -253,7 +253,7 @@ let BattleItems = {
 	},
 	quickclaw: {
 		inherit: true,
-		onModifyPriority(priority, pokemon) {
+		onFractionalPriority(priority, pokemon) {
 			if (this.randomChance(1, 5)) {
 				return Math.round(priority) + 0.1;
 			}

--- a/data/mods/gen3/items.js
+++ b/data/mods/gen3/items.js
@@ -252,20 +252,12 @@ let BattleItems = {
 		},
 	},
 	quickclaw: {
-		id: "quickclaw",
+		inherit: true,
 		onModifyPriority(priority, pokemon) {
 			if (this.randomChance(1, 5)) {
 				return Math.round(priority) + 0.1;
 			}
 		},
-		name: "Quick Claw",
-		spritenum: 373,
-		fling: {
-			basePower: 80,
-		},
-		num: 217,
-		gen: 2,
-		desc: "Each turn, holder has a 20% chance to move first in its priority bracket (no message).",
 	},
 	salacberry: {
 		inherit: true,

--- a/data/mods/gen4/items.js
+++ b/data/mods/gen4/items.js
@@ -47,7 +47,7 @@ let BattleItems = {
 	},
 	custapberry: {
 		inherit: true,
-		onModifyPriority() {},
+		onFractionalPriority() {},
 		onBeforeTurn(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.ability === 'gluttony')) {
 				let action = this.queue.willMove(pokemon);


### PR DESCRIPTION
72976d1 sort of fixed Quick Claw for past gens, but while simplifying it I noticed that Custap Berry also needed a fix.