### PR TITLE
Chatlog: fix a bug with dates

### DIFF
--- a/server/chat-plugins/chatlog.ts
+++ b/server/chat-plugins/chatlog.ts
@@ -363,12 +363,14 @@ export const pages: PageTable = {
 			const parsedDate = new Date(date);
 			// this is apparently the best way to tell if a date is invalid
 			if (isNaN(parsedDate.getTime())) return LogViewer.error(`Invalid date.`);
-			return LogViewer.day(roomid, Chat.toTimestamp(parsedDate).slice(0, 10), opts);
+			// is a valid date, return logs
+			return LogViewer.day(roomid, date, opts);
 		}
 		if (date) {
 			const parsedDate = new Date(date);
 			if (isNaN(parsedDate.getTime())) return LogViewer.error(`Invalid date.`);
-			return LogViewer.month(roomid, Chat.toTimestamp(parsedDate).slice(0, 7));
+			// date is valid, return logs
+			return LogViewer.month(roomid, date);
 		}
 		return LogViewer.room(roomid);
 	},


### PR DESCRIPTION
peach's fix for the crash was causing an error; `parsedDate` would return a date one day behind the given date, so going backwards / forwards would go to the wrong date (eg: 04-04 log's back a day button to 04-03 would skip you to 04-02, and forwards a day would take you from 04-04 to 04-06.) 
So if date's not valid, return error, else just take it as normal.