### PR TITLE
Moxie and Beast Boost should have one combined boost for all fainted Pokémon.

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -264,7 +264,7 @@ export const BattleAbilities: {[abilityid: string]: AbilityData} = {
 	battlebond: {
 		desc: "If this Pokemon is a Greninja, it transforms into Ash-Greninja after knocking out a Pokemon. As Ash-Greninja, its Water Shuriken has 20 base power and always hits 3 times.",
 		shortDesc: "After KOing a Pokemon: becomes Ash-Greninja, Water Shuriken: 20 power, hits 3x.",
-		onSourceFaint(target, source, effect) {
+		onSourceAfterFaint(length, target, source, effect) {
 			if (effect?.effectType !== 'Move') {
 				return;
 			}
@@ -287,7 +287,7 @@ export const BattleAbilities: {[abilityid: string]: AbilityData} = {
 	beastboost: {
 		desc: "This Pokemon's highest stat is raised by 1 stage if it attacks and knocks out another Pokemon.",
 		shortDesc: "This Pokemon's highest stat is raised by 1 if it attacks and KOes another Pokemon.",
-		onSourceFaint(target, source, effect) {
+		onSourceAfterFaint(length, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
 				let statName = 'atk';
 				let bestStat = 0;
@@ -298,7 +298,7 @@ export const BattleAbilities: {[abilityid: string]: AbilityData} = {
 						bestStat = source.storedStats[s];
 					}
 				}
-				this.boost({[statName]: 1}, source);
+				this.boost({[statName]: length}, source);
 			}
 		},
 		id: "beastboost",
@@ -2364,9 +2364,9 @@ export const BattleAbilities: {[abilityid: string]: AbilityData} = {
 	moxie: {
 		desc: "This Pokemon's Attack is raised by 1 stage if it attacks and knocks out another Pokemon.",
 		shortDesc: "This Pokemon's Attack is raised by 1 stage if it attacks and KOes another Pokemon.",
-		onSourceFaint(target, source, effect) {
+		onSourceAfterFaint(length, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
-				this.boost({atk: 1}, source);
+				this.boost({atk: length}, source);
 			}
 		},
 		id: "moxie",

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2358,7 +2358,8 @@ export class Battle {
 
 	faintMessages(lastFirst = false) {
 		if (this.ended) return;
-		if (!this.faintQueue.length) return false;
+		const length = this.faintQueue.length;
+		if (!length) return false;
 		if (lastFirst) {
 			this.faintQueue.unshift(this.faintQueue[this.faintQueue.length - 1]);
 			this.faintQueue.pop();
@@ -2426,6 +2427,10 @@ export class Battle {
 		if (!team1PokemonLeft && !team2PokemonLeft && !team3PokemonLeft) {
 			this.win(this.sides[3]);
 			return true;
+		}
+
+		if (faintData) {
+			this.runEvent('AfterFaint', faintData.target, faintData.source, faintData.effect, length);
 		}
 		return false;
 	}

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -204,6 +204,7 @@ interface EventMethods {
 	onAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void;
 	onAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void;
+	onAfterFaint?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onAfterMoveSecondarySelf?: MoveEventMethods['onAfterMoveSecondarySelf'];
 	onAfterMoveSecondary?: MoveEventMethods['onAfterMoveSecondary'];
 	onAfterMove?: MoveEventMethods['onAfterMove'];
@@ -305,6 +306,7 @@ interface EventMethods {
 	onAllyAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void;
 	onAllyAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onAllyAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void;
+	onAllyAfterFaint?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onAllyAfterMoveSecondarySelf?: MoveEventMethods['onAfterMoveSecondarySelf'];
 	onAllyAfterMoveSecondary?: MoveEventMethods['onAfterMoveSecondary'];
 	onAllyAfterMove?: MoveEventMethods['onAfterMove'];
@@ -406,6 +408,7 @@ interface EventMethods {
 	onFoeAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void;
 	onFoeAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onFoeAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void;
+	onFoeAfterFaint?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onFoeAfterMoveSecondarySelf?: MoveEventMethods['onAfterMoveSecondarySelf'];
 	onFoeAfterMoveSecondary?: MoveEventMethods['onAfterMoveSecondary'];
 	onFoeAfterMove?: MoveEventMethods['onAfterMove'];
@@ -507,6 +510,7 @@ interface EventMethods {
 	onSourceAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void;
 	onSourceAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onSourceAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void;
+	onSourceAfterFaint?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onSourceAfterMoveSecondarySelf?: MoveEventMethods['onAfterMoveSecondarySelf'];
 	onSourceAfterMoveSecondary?: MoveEventMethods['onAfterMoveSecondary'];
 	onSourceAfterMove?: MoveEventMethods['onAfterMove'];
@@ -610,6 +614,7 @@ interface EventMethods {
 	onAnyAfterSwitchInSelf?: (this: Battle, pokemon: Pokemon) => void;
 	onAnyAfterUseItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onAnyAfterBoost?: (this: Battle, boost: SparseBoostsTable, target: Pokemon, source: Pokemon, effect: Effect) => void;
+	onAnyAfterFaint?: (this: Battle, length: number, target: Pokemon, source: Pokemon, effect: Effect) => void;
 	onAnyAfterMoveSecondarySelf?: MoveEventMethods['onAfterMoveSecondarySelf'];
 	onAnyAfterMoveSecondary?: MoveEventMethods['onAfterMoveSecondary'];
 	onAnyAfterMove?: MoveEventMethods['onAfterMove'];

--- a/test/sim/abilities/moxie.js
+++ b/test/sim/abilities/moxie.js
@@ -17,4 +17,20 @@ describe('Moxie', function () {
 		battle.makeChoices('move crunch', 'move sleeptalk');
 		assert.statStage(battle.p1.active[0], 'atk', 1);
 	});
+
+	it('should not boost Attack when its user KOs the last Pokemon', function () {
+		battle = common.createBattle();
+		battle.setPlayer('p1', {team: [{species: "Krookodile", ability: 'moxie', moves: ['crunch']}]});
+		battle.setPlayer('p2', {team: [{species: "Shedinja", moves: ['sleeptalk']}]});
+		battle.makeChoices('move crunch', 'move sleeptalk');
+		assert.statStage(battle.p1.active[0], 'atk', 0);
+	});
+
+	it('should not boost Attack when its user KOs several last Pokemon', function () {
+		battle = common.createBattle({gameType: "doubles"});
+		battle.setPlayer('p1', {team: [{species: "Krookodile", ability: 'moxie', moves: ['earthquake']}, {species: "Shedinja", moves: ['sleeptalk']}]});
+		battle.setPlayer('p2', {team: [{species: "Shedinja", moves: ['sleeptalk']}, {species: "Shedinja", moves: ['sleeptalk']}]});
+		battle.makeChoices('move earthquake, move sleeptalk', 'move sleeptalk, move sleeptalk');
+		assert.statStage(battle.p1.active[0], 'atk', 0);
+	});
 });


### PR DESCRIPTION
In addition, they should not activate for a spread move that ends the game.
(This contrasts with Soul-Heart, which will activate until the last target.)

This behaviour is on one of @DaWoblefet's lists somewhere.

(Given my recent luck, this is probably not the best way to implement this.)