### PR TITLE
Fix residual order for G-Max Volcalith / Wildfire

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -1424,7 +1424,7 @@ let BattleAbilities = {
 		id: "healer",
 		name: "Healer",
 		onResidualOrder: 5,
-		onResidualSubOrder: 1,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			if (pokemon.side.active.length === 1) {
 				return;
@@ -1522,7 +1522,7 @@ let BattleAbilities = {
 		desc: "This Pokemon has its major status condition cured at the end of each turn if Rain Dance is active. If this Pokemon is holding Utility Umbrella, its major status condition will not be cured.",
 		shortDesc: "This Pokemon has its status cured at the end of each turn if Rain Dance is active.",
 		onResidualOrder: 5,
-		onResidualSubOrder: 1,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			if (pokemon.status && ['raindance', 'primordialsea'].includes(pokemon.effectiveWeather())) {
 				this.debug('hydration');
@@ -3471,7 +3471,7 @@ let BattleAbilities = {
 		desc: "This Pokemon has a 33% chance to have its major status condition cured at the end of each turn.",
 		shortDesc: "This Pokemon has a 33% chance to have its status cured at the end of each turn.",
 		onResidualOrder: 5,
-		onResidualSubOrder: 1,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			if (pokemon.hp && pokemon.status && this.randomChance(1, 3)) {
 				this.debug('shed skin');

--- a/data/items.js
+++ b/data/items.js
@@ -501,7 +501,7 @@ let BattleItems = {
 			basePower: 30,
 		},
 		onResidualOrder: 5,
-		onResidualSubOrder: 2,
+		onResidualSubOrder: 5,
 		onResidual(pokemon) {
 			if (this.field.isTerrain('grassyterrain')) return;
 			if (pokemon.hasType('Poison')) {
@@ -3185,7 +3185,7 @@ let BattleItems = {
 			basePower: 10,
 		},
 		onResidualOrder: 5,
-		onResidualSubOrder: 2,
+		onResidualSubOrder: 5,
 		onResidual(pokemon) {
 			if (this.field.isTerrain('grassyterrain')) return;
 			this.heal(pokemon.baseMaxhp / 16);

--- a/data/moves.js
+++ b/data/moves.js
@@ -5424,6 +5424,8 @@ let BattleMovedex = {
 				}
 				this.add('-sideend', targetSide, 'Fire Pledge');
 			},
+			onResidualOrder: 5,
+			onResidualSubOrder: 1,
 			onResidual(side) {
 				for (const pokemon of side.active) {
 					if (pokemon && !pokemon.hasType('Fire')) {
@@ -7428,6 +7430,8 @@ let BattleMovedex = {
 			onStart(targetSide) {
 				this.add('-sidestart', targetSide, 'G-Max Volcalith');
 			},
+			onResidualOrder: 5,
+			onResidualSubOrder: 1,
 			onResidual(targetSide) {
 				for (const pokemon of targetSide.active) {
 					if (!pokemon.hasType('Rock')) this.damage(pokemon.baseMaxhp / 6, pokemon);
@@ -7495,6 +7499,8 @@ let BattleMovedex = {
 			onStart(targetSide) {
 				this.add('-sidestart', targetSide, 'G-Max Wildfire');
 			},
+			onResidualOrder: 5,
+			onResidualSubOrder: 1,
 			onResidual(targetSide) {
 				for (const pokemon of targetSide.active) {
 					if (!pokemon.hasType('Fire')) this.damage(pokemon.baseMaxhp / 6, pokemon);

--- a/data/moves.js
+++ b/data/moves.js
@@ -7431,7 +7431,7 @@ let BattleMovedex = {
 				this.add('-sidestart', targetSide, 'G-Max Volcalith');
 			},
 			onResidualOrder: 5,
-			onResidualSubOrder: 1,
+			onResidualSubOrder: 1.1,
 			onResidual(targetSide) {
 				for (const pokemon of targetSide.active) {
 					if (!pokemon.hasType('Rock')) this.damage(pokemon.baseMaxhp / 6, pokemon);
@@ -7500,7 +7500,7 @@ let BattleMovedex = {
 				this.add('-sidestart', targetSide, 'G-Max Wildfire');
 			},
 			onResidualOrder: 5,
-			onResidualSubOrder: 1,
+			onResidualSubOrder: 1.1,
 			onResidual(targetSide) {
 				for (const pokemon of targetSide.active) {
 					if (!pokemon.hasType('Fire')) this.damage(pokemon.baseMaxhp / 6, pokemon);

--- a/test/sim/moves/gmaxvolcalith.js
+++ b/test/sim/moves/gmaxvolcalith.js
@@ -40,4 +40,34 @@ describe('G-Max Volcalith', function () {
 		battle.makeChoices('move sleeptalk, move sleeptalk', 'move sleeptalk, move sleeptalk');
 		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp - (Math.floor(battle.p2.active[0].maxhp / 6) * 4));
 	});
+
+	it.skip('should deal damage alongside Sea of Fire or G-Max Wildfire in the order those field effects were set', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [
+			{species: 'Coalossal-Gmax', item: 'Eject Button', moves: ['rockthrow', 'sleeptalk']},
+			{species: 'Charmander', moves: ['firepledge', 'sleeptalk']},
+			{species: 'Wynaut', level: 72, moves: ['grasspledge', 'nightshade', 'sleeptalk']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Roggenrola', ability: 'Receiver', item: 'Focus Sash', level: 1, moves: ['sleeptalk', 'tackle']},
+			{species: 'Boldore', ability: 'Receiver', item: 'Sitrus Berry', evs: {hp: 28}, moves: ['sleeptalk']},
+			{species: 'Torracat', ability: 'Cheek Pouch', item: 'Focus Sash', level: 1, moves: ['sleeptalk']},
+		]});
+		//Set up Volcalith first, then Sea of Fire
+		battle.makeChoices('move rockthrow 1 dynamax, move sleeptalk', 'move tackle 1, move sleeptalk');
+		battle.makeChoices('switch 3');
+		battle.makeChoices('move grasspledge 1, move firepledge 1', 'move sleeptalk, move sleeptalk');
+		battle.makeChoices('', 'switch 3');
+
+		//Bring Cheek Pouch down to Sash so it will faint and set Receiver's HP to exactly 5/8 of max
+		battle.makeChoices('move nightshade 2, move firepledge 1', 'move sleeptalk, move sleeptalk');
+		let expectedHP = battle.p2.active[1].maxhp;
+
+		/* TODO: this passes when it shouldn't because Sitrus Berry isn't triggering between Sea of Fire and G-Max Volcalith like it should;
+		 * Sitrus Berry should be able to activate in between those damaging effects. */
+
+		//If Sea of Fire triggered first, Sitrus Berry would activate without Cheek Pouch, missing the timing for extra health
+		//Failure HP should be 216
+		assert.strictEqual(battle.p2.active[1].hp, expectedHP);
+	});
 });

--- a/test/sim/moves/gmaxvolcalith.js
+++ b/test/sim/moves/gmaxvolcalith.js
@@ -42,32 +42,26 @@ describe('G-Max Volcalith', function () {
 	});
 
 	it.skip('should deal damage alongside Sea of Fire or G-Max Wildfire in the order those field effects were set', function () {
-		battle = common.createBattle({gameType: 'doubles'});
-		battle.setPlayer('p1', {team: [
+		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: 'Coalossal-Gmax', item: 'Eject Button', moves: ['rockthrow', 'sleeptalk']},
-			{species: 'Charmander', moves: ['firepledge', 'sleeptalk']},
-			{species: 'Wynaut', level: 72, moves: ['grasspledge', 'nightshade', 'sleeptalk']},
-		]});
-		battle.setPlayer('p2', {team: [
-			{species: 'Roggenrola', ability: 'Receiver', item: 'Focus Sash', level: 1, moves: ['sleeptalk', 'tackle']},
-			{species: 'Boldore', ability: 'Receiver', item: 'Sitrus Berry', evs: {hp: 28}, moves: ['sleeptalk']},
-			{species: 'Torracat', ability: 'Cheek Pouch', item: 'Focus Sash', level: 1, moves: ['sleeptalk']},
-		]});
+			{species: 'Wynaut', moves: ['sleeptalk', 'grasspledge']},
+			{species: 'Wynaut', moves: ['sleeptalk', 'firepledge']},
+		], [
+			{species: 'Blissey', ability: "noguard", moves: ['superfang', 'softboiled']},
+			{species: 'Blissey', ability: "noguard", moves: ['superfang', 'softboiled']},
+			{species: 'Golisopod', moves: ['sleeptalk']},
+		]]);
+
 		// Set up Volcalith first, then Sea of Fire
-		battle.makeChoices('move rockthrow 1 dynamax, move sleeptalk', 'move tackle 1, move sleeptalk');
+		battle.makeChoices('move rockthrow 1 dynamax, move grasspledge -1', 'move softboiled, move softboiled');
 		battle.makeChoices('switch 3');
-		battle.makeChoices('move grasspledge 1, move firepledge 1', 'move sleeptalk, move sleeptalk');
-		battle.makeChoices('', 'switch 3');
+		battle.makeChoices('move firepledge 1, move grasspledge 1', 'move softboiled, move softboiled');
 
-		// Bring Cheek Pouch down to Sash so it will faint and set Receiver's HP to exactly 5/8 of max
-		battle.makeChoices('move nightshade 2, move firepledge 1', 'move sleeptalk, move sleeptalk');
-		let expectedHP = battle.p2.active[1].maxhp;
-
-		/* TODO: this passes when it shouldn't because Sitrus Berry isn't triggering between Sea of Fire and G-Max Volcalith like it should;
-		 * Sitrus Berry should be able to activate in between those damaging effects. */
-
-		// If Sea of Fire triggered first, Sitrus Berry would activate without Cheek Pouch, missing the timing for extra health
-		// Failure HP should be 216
-		assert.strictEqual(battle.p2.active[1].hp, expectedHP);
+		// Switch into Golisopod; Emergency Exit should trigger and only take Volcalith damage then switch, avoiding Sea of Fire
+		// Note that Emergency Exit is also bugged here; it's actually not switching out at all lol, so it takes both Volcalith and Sea of Fire
+		battle.makeChoices('move sleeptalk, move sleeptalk', 'switch 3, move superfang -1');
+		const maxHP = battle.p2.active[0].maxhp;
+		const expectedHP = maxHP - Math.floor(maxHP / 2) - Math.floor(maxHP / 6);
+		assert.strictEqual(battle.p2.active[0].hp, expectedHP);
 	});
 });

--- a/test/sim/moves/gmaxvolcalith.js
+++ b/test/sim/moves/gmaxvolcalith.js
@@ -59,7 +59,7 @@ describe('G-Max Volcalith', function () {
 		battle.makeChoices('move grasspledge 1, move firepledge 1', 'move sleeptalk, move sleeptalk');
 		battle.makeChoices('', 'switch 3');
 
-		//Bring Cheek Pouch down to Sash so it will faint and set Receiver's HP to exactly 5/8 of max
+		// Bring Cheek Pouch down to Sash so it will faint and set Receiver's HP to exactly 5/8 of max
 		battle.makeChoices('move nightshade 2, move firepledge 1', 'move sleeptalk, move sleeptalk');
 		let expectedHP = battle.p2.active[1].maxhp;
 

--- a/test/sim/moves/gmaxvolcalith.js
+++ b/test/sim/moves/gmaxvolcalith.js
@@ -53,7 +53,7 @@ describe('G-Max Volcalith', function () {
 			{species: 'Boldore', ability: 'Receiver', item: 'Sitrus Berry', evs: {hp: 28}, moves: ['sleeptalk']},
 			{species: 'Torracat', ability: 'Cheek Pouch', item: 'Focus Sash', level: 1, moves: ['sleeptalk']},
 		]});
-		//Set up Volcalith first, then Sea of Fire
+		// Set up Volcalith first, then Sea of Fire
 		battle.makeChoices('move rockthrow 1 dynamax, move sleeptalk', 'move tackle 1, move sleeptalk');
 		battle.makeChoices('switch 3');
 		battle.makeChoices('move grasspledge 1, move firepledge 1', 'move sleeptalk, move sleeptalk');
@@ -66,8 +66,8 @@ describe('G-Max Volcalith', function () {
 		/* TODO: this passes when it shouldn't because Sitrus Berry isn't triggering between Sea of Fire and G-Max Volcalith like it should;
 		 * Sitrus Berry should be able to activate in between those damaging effects. */
 
-		//If Sea of Fire triggered first, Sitrus Berry would activate without Cheek Pouch, missing the timing for extra health
-		//Failure HP should be 216
+		// If Sea of Fire triggered first, Sitrus Berry would activate without Cheek Pouch, missing the timing for extra health
+		// Failure HP should be 216
 		assert.strictEqual(battle.p2.active[1].hp, expectedHP);
 	});
 });


### PR DESCRIPTION
Currently, G-Max Volcalith / G-Max Wildfire / Sea of Fire do not have a proper residual order variable, so it runs _after_ the end-of-turn effects which I am sick of dealing with in VGC haha. This fix isn't perfect, though. Sea of Fire / G-Max Volcalith / G-Max Wildfire all definitely have a onResidualOrder of 5 and a suborder of 1, but that suborder of 1 is queue-based; it happens in whatever order the effects were set. So currently, if two of these 3 effects are active, it will be random which one happens first, which can matter but is more niche. My hacky solution is to set the G-Max moves to be suborder 1.1, and then write a skipped test for it, except there's _another_ mechanics bug that doesn't let healing Berries activate in between Sea of Fire and G-Max Volcalith, so my test is passing when it shouldn't be so yeah. I can adjust that however we want to do it. I'll see if I can think of a better test in the meantime.