### PR TITLE
Fix doubled effectiveness for victims of Tar Shot

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -18457,10 +18457,10 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 				this.add('-start', pokemon, 'Tar Shot');
 			},
 			onEffectiveness(typeMod, target, type, move) {
+				if (move.type !== 'Fire') return;
 				if (!target) return;
-				if (move.type === 'Fire') {
-					return this.dex.getEffectiveness('Fire', target) + 1;
-				}
+				if (type !== target.getTypes()[0]) return;
+				return typeMod + 1;
 			},
 		},
 		boosts: {

--- a/test/sim/moves/tarshot.js
+++ b/test/sim/moves/tarshot.js
@@ -49,4 +49,25 @@ describe('Tar Shot', function () {
 		const damage = torn.maxhp - torn.hp;
 		assert.bounded(damage, [62, 74]);
 	});
+
+	it('should make the target weaker to fire', function () {
+		battle = common.createBattle();
+		battle.setPlayer('p1', {team: [{species: 'Coalossal', ability: 'steamengine', moves: ['tarshot', 'flamecharge']}]});
+		battle.setPlayer('p2', {team: [{species: 'Snorlax', ability: 'thickfat', item: 'occaberry', moves: ['rest']}]});
+		battle.makeChoices('move tarshot', 'move rest');
+		battle.makeChoices('move flamecharge', 'move rest');
+		assert.equal(battle.p2.active[0].item, '');
+	});
+
+	it('should not make the target over 2x weaker to fire', function () {
+		battle = common.createBattle();
+		battle.setPlayer('p1', {team: [{species: 'Coalossal', ability: 'steamengine', item: 'occaberry', moves: ['tarshot', 'flamecharge']}]});
+		battle.setPlayer('p2', {team: [{species: 'Ferrothorn', ability: 'ironbarbs', moves: ['rest', 'trick']}]});
+		battle.makeChoices('move flamecharge', 'move trick');
+		assert.notStrictEqual(battle.p1.active[0].hp, 0);
+		// Ferrothorn now has the Occa Berry, cancelling out Tar Shot
+		battle.makeChoices('move tarshot', 'move rest');
+		battle.makeChoices('move flamecharge', 'move rest');
+		assert.notStrictEqual(battle.p1.active[0].hp, 0);
+	});
 });


### PR DESCRIPTION
When a Fire type move is used against a dual typed victim of Tar Shot, the resulting effectiveness is applied twice. This is because the Effectiveness event gets called for each type of the target. (Freeze Dry relies on this for instance.)

- For (dual) types that normally dual resist Fire, this means that they still dual resist Fire.
- Types that normally resist Fire are unaffected as they are now neutral to fire anyway.
- For dual types that were neutral to Fire, this means that they are now quad weak to Fire.
- For dual types that were weak to Fire, this means that they are now 16× weak to Fire.
- For (dual) types that were quad weak to Fire, this means that they are now 64× weak to Fire. (The sim clamps the weakness to this level, so you can't go higher using Forest's Curse.)

The test compares the damage by Coalossal's Flame Charge against Ferrothorn with the damage when Ferrothorn is hit by Tar Shot (doubling damage) but holding an Occa Berry (halving damage). Currently the latter cleanly one-shots Ferrothorn when it should only do about the same amount of damage.