### PR TITLE
Fix activeMoveActions bug

### DIFF
--- a/data/mods/ssb/scripts.js
+++ b/data/mods/ssb/scripts.js
@@ -4,6 +4,7 @@
 let BattleScripts = {
 	inherit: 'gen7',
 	runMove(moveOrMoveName, pokemon, targetLoc, sourceEffect, zMove, externalMove) {
+		pokemon.activeMoveActions++;
 		let target = this.getTarget(pokemon, zMove || moveOrMoveName, targetLoc);
 		let baseMove = this.dex.getActiveMove(moveOrMoveName);
 		const pranksterBoosted = baseMove.pranksterBoosted;


### PR DESCRIPTION
Bar Fight is supposed to act like Fake Out and only work on turn 1. This line added in this PR was missing from the runMove function, so Bar Fight and Fake Out were usable past turn 1.