### PR TITLE
Fix Fell Stinger after redirection

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -226,6 +226,9 @@ let BattleScripts = {
 		}
 
 		const {targets, pressureTargets} = pokemon.getMoveTargets(move, target);
+		if (targets.length) {
+			target = targets[targets.length - 1]; // in case of redirection
+		}
 
 		if (!sourceEffect || sourceEffect.id === 'pursuit') {
 			let extraPP = 0;

--- a/test/sim/moves/fellstinger.js
+++ b/test/sim/moves/fellstinger.js
@@ -10,7 +10,7 @@ describe('Fell Stringer', function () {
 		battle.destroy();
 	});
 
-	it.skip('should get a boost when KOing a Pokemon after redirection', function () {
+	it('should get a boost when KOing a Pokemon after redirection', function () {
 		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: 'joltik', moves: ['fellstinger']},
 			{species: 'wynaut', moves: ['sleeptalk']},


### PR DESCRIPTION
This also fixes a bug whereby if you target your own ally with Aqua Jet, but your opponent switches in Gastrodon and Bruxish, then Dazzling should prevent the move from executing.

I take the last target because Dazzling still needs to be able to block Prankster Copycat Earthquake. If you prefer I could probably change the test to `targets.length === 1` since there can only be one target for a redirect.