### PR TITLE
Add "seejong" as an alias for Sealeo

### DIFF
--- a/data/aliases.js
+++ b/data/aliases.js
@@ -708,6 +708,7 @@ let BattleAliases = {
 	"sable": "Sableye",
 	"scept": "Sceptile",
 	"scoli": "Scolipede",
+	"seejong": "Sealeo",
 	"serp": "Serperior",
 	"shao": "Mienshao",
 	"skarm": "Skarmory",


### PR DESCRIPTION
The entire Pokemon Games room refers to Sealeo as Seejong and it has significant meme value. Additionally, Seejong is Sealeo's German name.