### PR TITLE
Fix Technician interaction with Battery/Auras/PowerSpot

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -65,7 +65,7 @@ let BattleAbilities = {
 				move.aerilateBoosted = true;
 			}
 		},
-		onBasePowerPriority: 8,
+		onBasePowerPriority: 7,
 		onBasePower(basePower, pokemon, target, move) {
 			if (move.aerilateBoosted) return this.chainModify([0x1333, 0x1000]);
 		},
@@ -102,7 +102,7 @@ let BattleAbilities = {
 	analytic: {
 		desc: "The power of this Pokemon's move is multiplied by 1.3 if it is the last to move in a turn. Does not affect Doom Desire and Future Sight.",
 		shortDesc: "This Pokemon's attacks have 1.3x power if it is the last to move in a turn.",
-		onBasePowerPriority: 8,
+		onBasePowerPriority: 7,
 		onBasePower(basePower, pokemon) {
 			let boosted = true;
 			for (const target of this.getAllActive()) {
@@ -239,7 +239,7 @@ let BattleAbilities = {
 	},
 	battery: {
 		shortDesc: "This Pokemon's allies have the power of their special attacks multiplied by 1.3.",
-		onAllyBasePowerPriority: 8,
+		onAllyBasePowerPriority: 9,
 		onAllyBasePower(basePower, attacker, defender, move) {
 			if (attacker !== this.effectData.target && move.category === 'Special') {
 				this.debug('Battery boost');
@@ -617,6 +617,7 @@ let BattleAbilities = {
 		onStart(pokemon) {
 			this.add('-ability', pokemon, 'Dark Aura');
 		},
+		onAnyBasePowerPriority: 9,
 		onAnyBasePower(basePower, source, target, move) {
 			if (target === source || move.category === 'Status' || move.type !== 'Dark') return;
 			if (!move.auraBooster) move.auraBooster = this.effectData.target;
@@ -929,6 +930,7 @@ let BattleAbilities = {
 		onStart(pokemon) {
 			this.add('-ability', pokemon, 'Fairy Aura');
 		},
+		onAnyBasePowerPriority: 9,
 		onAnyBasePower(basePower, source, target, move) {
 			if (target === source || move.category === 'Status' || move.type !== 'Fairy') return;
 			if (!move.auraBooster) move.auraBooster = this.effectData.target;
@@ -971,7 +973,7 @@ let BattleAbilities = {
 	flareboost: {
 		desc: "While this Pokemon is burned, the power of its special attacks is multiplied by 1.5.",
 		shortDesc: "While this Pokemon is burned, its special attacks have 1.5x power.",
-		onBasePowerPriority: 8,
+		onBasePowerPriority: 7,
 		onBasePower(basePower, attacker, defender, move) {
 			if (attacker.status === 'brn' && move.category === 'Special') {
 				return this.chainModify(1.5);
@@ -1265,7 +1267,7 @@ let BattleAbilities = {
 				move.galvanizeBoosted = true;
 			}
 		},
-		onBasePowerPriority: 8,
+		onBasePowerPriority: 7,
 		onBasePower(basePower, pokemon, target, move) {
 			if (move.galvanizeBoosted) return this.chainModify([0x1333, 0x1000]);
 		},
@@ -1816,7 +1818,7 @@ let BattleAbilities = {
 	ironfist: {
 		desc: "This Pokemon's punch-based attacks have their power multiplied by 1.2.",
 		shortDesc: "This Pokemon's punch-based attacks have 1.2x power. Sucker Punch is not boosted.",
-		onBasePowerPriority: 8,
+		onBasePowerPriority: 7,
 		onBasePower(basePower, attacker, defender, move) {
 			if (move.flags['punch']) {
 				this.debug('Iron Fist boost');
@@ -2130,7 +2132,7 @@ let BattleAbilities = {
 	megalauncher: {
 		desc: "This Pokemon's pulse moves have their power multiplied by 1.5. Heal Pulse restores 3/4 of a target's maximum HP, rounded half down.",
 		shortDesc: "This Pokemon's pulse moves have 1.5x power. Heal Pulse heals 3/4 target's max HP.",
-		onBasePowerPriority: 8,
+		onBasePowerPriority: 7,
 		onBasePower(basePower, attacker, defender, move) {
 			if (move.flags['pulse']) {
 				return this.chainModify(1.5);
@@ -2531,7 +2533,7 @@ let BattleAbilities = {
 				move.normalizeBoosted = true;
 			}
 		},
-		onBasePowerPriority: 8,
+		onBasePowerPriority: 7,
 		onBasePower(basePower, pokemon, target, move) {
 			if (move.normalizeBoosted) return this.chainModify([0x1333, 0x1000]);
 		},
@@ -2640,7 +2642,7 @@ let BattleAbilities = {
 				move.multihitType = 'parentalbond';
 			}
 		},
-		onBasePowerPriority: 8,
+		onBasePowerPriority: 7,
 		onBasePower(basePower, pokemon, target, move) {
 			if (move.multihitType === 'parentalbond' && move.hit > 1) return this.chainModify(0.25);
 		},
@@ -2775,7 +2777,7 @@ let BattleAbilities = {
 				move.pixilateBoosted = true;
 			}
 		},
-		onBasePowerPriority: 8,
+		onBasePowerPriority: 7,
 		onBasePower(basePower, pokemon, target, move) {
 			if (move.pixilateBoosted) return this.chainModify([0x1333, 0x1000]);
 		},
@@ -2889,7 +2891,7 @@ let BattleAbilities = {
 	},
 	powerspot: {
 		shortDesc: "This Pokemon's allies have the power of their moves multiplied by 1.3.",
-		onAllyBasePowerPriority: 8,
+		onAllyBasePowerPriority: 9,
 		onAllyBasePower(basePower, attacker, defender, move) {
 			if (attacker !== this.effectData.target) {
 				this.debug('Power Spot boost');
@@ -3010,7 +3012,7 @@ let BattleAbilities = {
 	punkrock: {
 		desc: "This Pokemon's sound-based moves have their power multiplied by 1.3. This Pokemon takes halved damage from sound-based moves.",
 		shortDesc: "This Pokemon receives 1/2 damage from sound moves. Its own have 1.3x power.",
-		onBasePowerPriority: 8,
+		onBasePowerPriority: 7,
 		onBasePower(basePower, attacker, defender, move) {
 			if (move.flags['sound']) {
 				this.debug('Punk Rock boost');
@@ -3124,7 +3126,7 @@ let BattleAbilities = {
 	reckless: {
 		desc: "This Pokemon's attacks with recoil or crash damage have their power multiplied by 1.2. Does not affect Struggle.",
 		shortDesc: "This Pokemon's attacks with recoil or crash damage have 1.2x power; not Struggle.",
-		onBasePowerPriority: 8,
+		onBasePowerPriority: 7,
 		onBasePower(basePower, attacker, defender, move) {
 			if (move.recoil || move.hasCustomRecoil) {
 				this.debug('Reckless boost');
@@ -3146,7 +3148,7 @@ let BattleAbilities = {
 				move.refrigerateBoosted = true;
 			}
 		},
-		onBasePowerPriority: 8,
+		onBasePowerPriority: 7,
 		onBasePower(basePower, pokemon, target, move) {
 			if (move.refrigerateBoosted) return this.chainModify([0x1333, 0x1000]);
 		},
@@ -3207,7 +3209,7 @@ let BattleAbilities = {
 	rivalry: {
 		desc: "This Pokemon's attacks have their power multiplied by 1.25 against targets of the same gender or multiplied by 0.75 against targets of the opposite gender. There is no modifier if either this Pokemon or the target is genderless.",
 		shortDesc: "This Pokemon's attacks do 1.25x on same gender targets; 0.75x on opposite gender.",
-		onBasePowerPriority: 8,
+		onBasePowerPriority: 7,
 		onBasePower(basePower, attacker, defender, move) {
 			if (attacker.gender && defender.gender) {
 				if (attacker.gender === defender.gender) {
@@ -3270,7 +3272,7 @@ let BattleAbilities = {
 	sandforce: {
 		desc: "If Sandstorm is active, this Pokemon's Ground-, Rock-, and Steel-type attacks have their power multiplied by 1.3. This Pokemon takes no damage from Sandstorm.",
 		shortDesc: "This Pokemon's Ground/Rock/Steel attacks do 1.3x in Sandstorm; immunity to it.",
-		onBasePowerPriority: 8,
+		onBasePowerPriority: 7,
 		onBasePower(basePower, attacker, defender, move) {
 			if (this.field.isWeather('sandstorm')) {
 				if (move.type === 'Rock' || move.type === 'Ground' || move.type === 'Steel') {
@@ -3522,7 +3524,7 @@ let BattleAbilities = {
 				move.hasSheerForce = true;
 			}
 		},
-		onBasePowerPriority: 8,
+		onBasePowerPriority: 7,
 		onBasePower(basePower, pokemon, target, move) {
 			if (move.hasSheerForce) return this.chainModify([0x14CD, 0x1000]);
 		},
@@ -3914,7 +3916,7 @@ let BattleAbilities = {
 	},
 	steelyspirit: {
 		shortDesc: "This Pokemon and its allies' Steel-type moves have their power multiplied by 1.5.",
-		onAllyBasePowerPriority: 8,
+		onAllyBasePowerPriority: 7,
 		onAllyBasePower(basePower, attacker, defender, move) {
 			if (move.type === 'Steel') {
 				this.debug('Steely Spirit boost');
@@ -3992,7 +3994,7 @@ let BattleAbilities = {
 	strongjaw: {
 		desc: "This Pokemon's bite-based attacks have their power multiplied by 1.5.",
 		shortDesc: "This Pokemon's bite-based attacks have 1.5x power. Bug Bite is not boosted.",
-		onBasePowerPriority: 8,
+		onBasePowerPriority: 7,
 		onBasePower(basePower, attacker, defender, move) {
 			if (move.flags['bite']) {
 				return this.chainModify(1.5);
@@ -4185,7 +4187,9 @@ let BattleAbilities = {
 		shortDesc: "This Pokemon's moves of 60 power or less have 1.5x power. Includes Struggle.",
 		onBasePowerPriority: 8,
 		onBasePower(basePower, attacker, defender, move) {
-			if (basePower <= 60) {
+			let basePowerAfterMultiplier = this.modify(basePower, this.event.modifier);
+			this.debug('Base Power: ' + basePowerAfterMultiplier);
+			if (basePowerAfterMultiplier <= 60) {
 				this.debug('Technician boost');
 				return this.chainModify(1.5);
 			}
@@ -4280,7 +4284,7 @@ let BattleAbilities = {
 	},
 	toughclaws: {
 		shortDesc: "This Pokemon's contact moves have their power multiplied by 1.3.",
-		onBasePowerPriority: 8,
+		onBasePowerPriority: 7,
 		onBasePower(basePower, attacker, defender, move) {
 			if (move.flags['contact']) {
 				return this.chainModify([0x14CD, 0x1000]);
@@ -4294,7 +4298,7 @@ let BattleAbilities = {
 	toxicboost: {
 		desc: "While this Pokemon is poisoned, the power of its physical attacks is multiplied by 1.5.",
 		shortDesc: "While this Pokemon is poisoned, its physical attacks have 1.5x power.",
-		onBasePowerPriority: 8,
+		onBasePowerPriority: 7,
 		onBasePower(basePower, attacker, defender, move) {
 			if ((attacker.status === 'psn' || attacker.status === 'tox') && move.category === 'Physical') {
 				return this.chainModify(1.5);

--- a/test/sim/abilities/technician.js
+++ b/test/sim/abilities/technician.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Technician', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should not apply boost on a move boosted over 60 BP by Battery/Power Spot', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [
+			{species: 'Toxtricity', ability: 'technician', moves: ['shockwave']},
+			{species: 'Charjabug', ability: 'battery', moves: ['sleeptalk']},
+			{species: 'Stonjourner', ability: 'powerspot', moves: ['sleeptalk']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Marshadow', ability: 'technician', moves: ['sleeptalk']},
+			{species: 'Mew', ability: 'synchronize', moves: ['sleeptalk']},
+		]});
+		battle.makeChoices('move shockwave 2, move sleeptalk', 'move sleeptalk, move sleeptalk');
+		const mew = battle.p2.active[1];
+		let damage = mew.maxhp - mew.hp;
+		assert.bounded(damage, [94, 112]);
+		battle.makeChoices('move shockwave 2, switch 3', 'move sleeptalk, move sleeptalk');
+		let damage2 = mew.maxhp - mew.hp - damage;
+		assert.bounded(damage2, [94, 112]);
+	});
+
+	it('should apply boost on a move boosted over 60 BP by Steely Spirit', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [
+			{species: 'Scizor', ability: 'technician', moves: ['metalclaw']},
+			{species: 'Perrserker', ability: 'steelyspirit', moves: ['sleeptalk']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Marshadow', ability: 'technician', moves: ['sleeptalk']},
+			{species: 'Mew', ability: 'synchronize', moves: ['sleeptalk']},
+		]});
+		battle.makeChoices('move metalclaw 2, move sleeptalk', 'move sleeptalk, move sleeptalk');
+		const mew = battle.p2.active[1];
+		let damage = mew.maxhp - mew.hp;
+		assert.bounded(damage, [151, 178]);
+	});
+
+	it("should consider the BP after Aura boosts have been applied", function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [
+			{species: 'Smeargle', ability: 'technician', moves: ['drainingkiss', 'knockoff']},
+			{species: 'Scizor', ability: 'technician', moves: ['thief', 'sleeptalk']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Xerneas', ability: 'fairyaura', moves: ['sleeptalk']},
+			{species: 'Yveltal', ability: 'darkaura', moves: ['sleeptalk']},
+			{species: 'Zygarde', ability: 'aurabreak', moves: ['sleeptalk']},
+		]});
+		// 1st turn: test Fairy Aura and Dark Aura
+		// Scizor attacks Xerneas with Thief, Smeargle attacks Yveltal with Draining Kiss
+		battle.makeChoices('move drainingkiss 2, move thief 1', 'move sleeptalk, move sleeptalk');
+		const yveltal = battle.p2.active[1];
+		const xerneas = battle.p2.active[0];
+		let damage_xern = xerneas.maxhp - xerneas.hp;
+		assert.bounded(damage_xern, [38, 45]);
+		let damage_yvel = yveltal.maxhp - yveltal.hp;
+		assert.bounded(damage_yvel, [34, 40]);
+		// Smeargle attacks Zygarde on the switch with Knock Off, which should be at a <60 BP after Aura Break and thus boosted by Technician.
+		battle.makeChoices('move knockoff 1, move sleeptalk', 'switch 3, move sleeptalk');
+		const zygarde = battle.p2.active[0];
+		let damage_zyg = zygarde.maxhp - zygarde.hp;
+		assert.bounded(damage_zyg, [15, 18]);
+	});
+});


### PR DESCRIPTION
As pointed by @DaWoblefet, the interaction of Technician with some abilities boosting move BPs was faulty; Technician would apply even though the move was boosted over 60 BP. This should now be fixed. The concerned abilities are Fairy Aura, Dark Aura, Aura Break, Battery and Power Spot.

Also, according to [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Technician_(Ability)), this behaviour doesn't apply to Steely Spirit. I'm not sure if I can trust Bulbapedia on this, and seeing as the only concerned move would be Metal Claw, which can only be learned by Scizor and is therefore unavailable in gen 8, this is not really checkable anyway. I coded it so that Technician would apply first.

https://github.com/smogon/pokemon-showdown/projects/3#card-25870312