### PR TITLE
Typos and complete list of in-battle formes

### DIFF
--- a/data/FORMES.md
+++ b/data/FORMES.md
@@ -97,7 +97,7 @@ Some Pokémon can change forme out-of-battle. These include:
 
 If a held item is required for a Pokémon to start battle with that forme, the `requiredItem` property will track this.
 
-`{name: "Giratina-Origin", forme: "Origin", baseSpecies: "Wormadam", requiredItem: "Griseous Orb"}`
+`{name: "Giratina-Origin", forme: "Origin", baseSpecies: "Giratina", requiredItem: "Griseous Orb"}`
 
 Some changeable formes (like Arceus) are visual formes. See "Visual formes" above for more information.
 
@@ -107,12 +107,27 @@ Changeable formes are otherwise treated identically to regular formes.
 In-battle formes
 ----------------
 
-Some Pokémon change forme in the middle of a battle. These include:
+Some Pokémon change forme in the middle of a battle. These forme changes do reset stats and type.
 
-- Meloetta (Pirouette forme)
+List of all in-battle forme changes:
+
+- Ash Greninja (Battle Bond)
+- Mimikyu (Disguise)
+- Cherrim (Flower Gift)
+- Castform (Forecast)
+- Cramorant (Gulp Missile)
+- Morpeko (Hunger Switch)
+- Eiscue (Ice Face)
+- Zygarde (Power Construct)
+- Wishiwashi (Schooling)
+- Minior (Shields Down)
+- Aegislash (Stance Change)
 - Darmanitan (Zen Mode)
-- Eiscue
-- all Mega evolutions, Primal reversion, Ultra Burst
+- Meloetta (Relic Song)
+- Shaymin-Sky (Frozen status)
+- Mega evolutions
+- Primal reversions
+- Ultra Burst
 
 PS treats these identically to regular formes, but gives them a `battleOnly` property noting what forme they would be in at the start of battle:
 
@@ -136,7 +151,7 @@ PS treats these like regular in-battle formes.
 "Fake" visual in-battle formes
 ------------------------------
 
-Dynamax/Gigantamax can be thought of as visual in-battle formes, but they're different in one major way: They're not considered "real" forme changes, so the change doesn't reset types and stats changed by Reflect Type, Power Swap, etc.
+Dynamax/Gigantamax can be thought of as visual in-battle formes, but they're different in one major way: They're not considered "real" forme changes, so the change doesn't reset types and stats changed by Reflect Type, Power Split, Power Trick, etc.
 
 These include:
 

--- a/data/FORMES.md
+++ b/data/FORMES.md
@@ -172,6 +172,10 @@ These include:
 - Zygarde (10% Forme) (with Power Construct)
 - Zygarde (50% Forme) (with Power Construct)
 
+Greninja in the game code has three formes: regular, Battle Bond, and Ash-Greninja. Battle Bond is an event-only ability forme, and Ash-Greninja is an in-battle forme of the the event-only ability forme.
+
+Zygarde works the same way, with five formes: regular 50% Zygarde, event-only Power Construct 50% Zygarde, regular 10% Zygarde, event-only Power Construct 10% Zygarde, Zygarde Complete being an in-battle only forme of either event-only Power Construct 10% Zygarde or event-only Power Construct 50% Zygarde.
+
 PS's current implementation of this is weird and will be changed in a few days; do not rely on its current implementation.
 
 


### PR DESCRIPTION
Follow-up to the discussion between @Zarel and @urkerab in b9e25acbbf30cdcaaed1439882b45146224d18c2 and 7c0a6a9c603e8fb2488472bb50e3ce80eb4cafbf

I'd like a few comments on:

- Shaymin-Sky that was in @urkerab's list does not actually have `battleOnly`, so even though I understand that due to the reversion when frozen during battle it has a special treatment, does it fit in that list?

- Megas and Primals also do not have `battleOnly`, so should they stay in that list? Or should the text below be rewritten to exclude these specific cases?

- Ash-Greninja is now in the "In-battle formes" list and also in the "Event-only Ability formes" list, and again I understand why with its distribution, but should it stay this way? I was leaning towards yes so I left it so far.

- There was an explanation for "In-Battle form"s in the comment that I left out as I found it confusing, it went:
"all of these forme changes do reset stats and type, _especially those whose forms have different base stats_." I felt like the "_especially_" was misleading since they all get the reset, so I left the part in italic out. Then the comment continued:
_"Since most of them rely on the current Ability being the one that they would have after the forme change anyway, it's not possible to observe a change in Ability in those cases._" I think I understand what was implied, but that sounded confusing so I left it out. Let me know what you think.