### PR TITLE
Fix Max Move base move source from leaking

### DIFF
--- a/data/scripts.js
+++ b/data/scripts.js
@@ -161,11 +161,9 @@ let BattleScripts = {
 			move = this.getActiveZMove(move, pokemon);
 		}
 		if (maxMove && move.category !== 'Status') {
-			let moveType = move.type;
 			// Max move outcome is dependent on the move type after type modifications from ability and the move itself
 			this.singleEvent('ModifyType', move, null, pokemon, target, move, move);
 			this.runEvent('ModifyType', pokemon, target, move, move);
-			if (move.type !== moveType) sourceEffect = move;
 		}
 		if (maxMove || (move.category !== 'Status' && sourceEffect && /** @type {ActiveMove} */(sourceEffect).isMax)) {
 			move = this.getActiveMaxMove(move, pokemon);


### PR DESCRIPTION
Currently, Max Moves are sending `sourceEffect` of their base move when the original move type isn't identical to source move type. This results in the server leaking which base move was used. For example:

|move|p2a: Nine lives|Max Flare|p1a: Smeargle|[from]Weather Ball
|move|p1a: Silvally|Max Flutterby|p2a: Necrozma|[from]Multi-Attack

It's more apparent with Weather Ball because it has a custom string attached to its Z-move transformation, but it's getting sent with any Max Move that dynamically changes typing, e.g. https://replay.pokemonshowdown.com/gen8doublescustomgame-1099210961.