### PR TITLE
Fix Sky Drop Wonder Guard interaction

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -4659,6 +4659,7 @@ let BattleAbilities = {
 		shortDesc: "This Pokemon can only be damaged by supereffective moves and indirect damage.",
 		onTryHit(target, source, move) {
 			if (target === source || move.category === 'Status' || move.type === '???' || move.id === 'struggle') return;
+			if (move.id === 'skydrop' && !source.volatiles['skydrop']) return;
 			this.debug('Wonder Guard immunity: ' + move.id);
 			if (target.runEffectiveness(move) <= 0) {
 				if (move.smartTarget) {

--- a/data/moves.js
+++ b/data/moves.js
@@ -17060,9 +17060,7 @@ let BattleMovedex = {
 			}
 		},
 		onHit(target, source) {
-			if (target.hp > 0) {
-				this.add('-end', target, 'Sky Drop');
-			}
+			if (target.hp) this.add('-end', target, 'Sky Drop');
 		},
 		effect: {
 			duration: 2,

--- a/data/moves.js
+++ b/data/moves.js
@@ -17060,7 +17060,9 @@ let BattleMovedex = {
 			}
 		},
 		onHit(target, source) {
-			this.add('-end', target, 'Sky Drop');
+			if (target.hp > 0) {
+				this.add('-end', target, 'Sky Drop');
+			}
 		},
 		effect: {
 			duration: 2,

--- a/test/sim/moves/skydrop.js
+++ b/test/sim/moves/skydrop.js
@@ -93,6 +93,21 @@ describe('Sky Drop', function () {
 		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
+	it('should pick up non-Flying weak Wonder Guard Pokemon but do no damage', function () {
+		battle = common.createBattle([
+			[{species: "Braviary", ability: 'keeneye', moves: ['skydrop']}],
+			[{species: "Shuckle", ability: 'wonderguard', moves: ['tackle']},
+			 {species: "Shedinja", ability: 'wonderguard', moves: ['sleeptalk']},
+			],
+		]);
+		battle.makeChoices('move skydrop', 'move tackle');
+		assert.equal(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		battle.makeChoices('move skydrop', 'move tackle');
+		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		battle.makeChoices('move skydrop', 'switch 2');
+		assert.hurts(battle.p2.active[0], () => battle.makeChoices('move skydrop', 'move sleeptalk'));
+	});
+
 	it('should only make contact on the way down', function () {
 		battle = common.createBattle([[
 			{species: "Aerodactyl", moves: ['skydrop']},


### PR DESCRIPTION
https://github.com/smogon/pokemon-showdown/projects/3#card-25870318

Sky Drop should affect every Wonder Guard Pokemon on the first turn, effectively taking them in the sky. Then Wonder Guard would activate on the second turn, when the attack actually happens. This should now be the case. Additionally, Sky Drop still affects Flying-weak Wonder Guard Pokemon.

I noticed the message "[Pokemon] is freed from the Sky Drop" still displays even if the Pokemon faints. I don't know if it should be the case or if it should be omitted.