### PR TITLE
Fix Snatch interation with Throat Chop and Heal Bell

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -8278,7 +8278,9 @@ let BattleMovedex = {
 		priority: 0,
 		flags: {snatch: 1, sound: 1, distance: 1, authentic: 1},
 		onHit(pokemon, source) {
-			this.add('-activate', source, 'move: Heal Bell');
+			if (!source.volatiles['snatch']) {
+				this.add('-activate', source, 'move: Heal Bell');
+			}
 			let side = pokemon.side;
 			let success = false;
 			for (const ally of side.pokemon) {
@@ -17511,9 +17513,14 @@ let BattleMovedex = {
 				if (!move || move.isZ || move.isMax || !move.flags['snatch'] || move.sourceEffect === 'snatch') {
 					return;
 				}
-				snatchUser.removeVolatile('snatch');
+				if (move.id === 'healbell') this.add('-activate', snatchUser, 'move: Heal Bell');
 				this.add('-activate', snatchUser, 'move: Snatch', '[of] ' + source);
+				if (snatchUser.volatiles['throatchop'] && move.flags['sound']) {
+					this.add('cant', snatchUser, 'move: Throat Chop');
+					return null;
+				}
 				this.useMove(move.id, snatchUser);
+				snatchUser.removeVolatile('snatch');
 				return null;
 			},
 		},

--- a/test/sim/moves/snatch.js
+++ b/test/sim/moves/snatch.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Snatch', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should steal snatchable moves from the opposing Pokemon and prevent them from using them', function () {
+		battle = common.createBattle([
+			[{species: 'Jolteon', ability: 'noguard', moves: ['toxic', 'healbell']}],
+			[{species: 'Weavile', ability: 'pressure', moves: ['snatch', 'toxic']}],
+		]);
+		battle.makeChoices('move toxic', 'move toxic');
+		// also checks that Snatch has priority
+		battle.makeChoices('move healbell', 'move snatch');
+		assert.equal(battle.p1.active[0].status, 'tox');
+		assert.equal(battle.p2.active[0].status, '');
+	});
+
+	it('should not steal sound-based moves when under Throat Chop effect', function () {
+		battle = common.createBattle([
+			[{species: 'Jolteon', ability: 'noguard', moves: ['toxic', 'healbell', 'throatchop']}],
+			[{species: 'Weavile', ability: 'pressure', moves: ['toxic', 'snatch', 'recover']}],
+		]);
+		battle.makeChoices('move toxic', 'move toxic');
+		battle.makeChoices('move throatchop', 'move recover');
+		battle.makeChoices('move healbell', 'move snatch');
+		assert.equal(battle.p2.active[0].status, 'tox');
+		assert.equal(battle.p1.active[0].status, 'tox');
+	});
+});


### PR DESCRIPTION
https://github.com/smogon/pokemon-showdown/projects/3#card-25870296
https://github.com/smogon/pokemon-showdown/projects/3#card-25870288

Snatched sound-based moves should now be disabled when the Snatch user is under the effects of Throat Chop. Additionally, the message "A bell chimed!" is now displayed before the message "[Pokemon] snatched the opponent's move" when Heal Bell is snatched. Tbh there is probably a better way to do that but I wasn't sure how to use the event handlers correctly.