### PR TITLE
Update VGC and Battle Stadium to Series 4

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -224,7 +224,6 @@ let Formats = [
 			battle: 3,
 		},
 		ruleset: ['Standard GBU'],
-		banlist: ['Copperajah-Gmax', 'Duraludon-Gmax', 'Garbodor-Gmax', 'Gengar-Gmax', 'Machamp-Gmax'],
 		minSourceGen: 8,
 	},
 	{
@@ -309,8 +308,6 @@ let Formats = [
 		},
 		ruleset: ['Standard GBU', 'VGC Timer'],
 		banlist: [
-			// Gigantamax Pokemon
-			'Copperajah-Gmax', 'Duraludon-Gmax', 'Garbodor-Gmax', 'Gengar-Gmax', 'Machamp-Gmax',
 			// Can't obtain in Galar without transferring
 			'Cobalion', 'Raichu-Alola', 'Terrakion', 'Virizion', 'Weezing-Base',
 		],


### PR DESCRIPTION
DO NOT MERGE UNTIL MAY 1

The newest Battle Stadium legalizes all remaining Gigantamax Pokemon. As far as I can tell, it's otherwise identical to series 3.