### PR TITLE
Change Clangorous Soul self damage from 1/3 -> 33%

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2479,8 +2479,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		accuracy: true,
 		basePower: 0,
 		category: "Status",
-		desc: "Raises the user's Attack, Defense, Special Attack, Special Defense, and Speed by 1 stage in exchange for the user losing 1/3 of its maximum HP, rounded down. Fails if the user would faint or if its Attack, Defense, Special Attack, Special Defense, and Speed stat stages would not change.",
-		shortDesc: "User loses 1/3 its max HP. Raises all stats by 1.",
+		desc: "Raises the user's Attack, Defense, Special Attack, Special Defense, and Speed by 1 stage in exchange for the user losing 33% of its maximum HP, rounded down. Fails if the user would faint or if its Attack, Defense, Special Attack, Special Defense, and Speed stat stages would not change.",
+		shortDesc: "User loses 33% if its max HP. Raises all stats by 1.",
 		id: "clangoroussoul",
 		isViable: true,
 		name: "Clangorous Soul",
@@ -2488,14 +2488,14 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {snatch: 1, sound: 1, dance: 1},
 		onTryHit(pokemon, target, move) {
-			if (pokemon.hp <= pokemon.maxhp / 3 || pokemon.maxhp === 1) {
+			if (pokemon.hp <= (pokemon.maxhp * 33 / 100) || pokemon.maxhp === 1) {
 				return false;
 			}
 			if (!this.boost(move.boosts as SparseBoostsTable)) return null;
 			delete move.boosts;
 		},
 		onHit(pokemon) {
-			this.directDamage(pokemon.maxhp / 3);
+			this.directDamage(pokemon.maxhp * 33 / 100);
 		},
 		boosts: {
 			atk: 1,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2480,7 +2480,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		basePower: 0,
 		category: "Status",
 		desc: "Raises the user's Attack, Defense, Special Attack, Special Defense, and Speed by 1 stage in exchange for the user losing 33% of its maximum HP, rounded down. Fails if the user would faint or if its Attack, Defense, Special Attack, Special Defense, and Speed stat stages would not change.",
-		shortDesc: "User loses 33% if its max HP. Raises all stats by 1.",
+		shortDesc: "User loses 33% of its max HP. +1 to all stats.",
 		id: "clangoroussoul",
 		isViable: true,
 		name: "Clangorous Soul",


### PR DESCRIPTION
Per SadisticMystic:

"https://docs.google.com/spreadsheets/d/15r_-iUngMDoA9ux7tCkUJLJVBeQhpIzEH7rju9fgWOQ/edit
the "Moves" tab is a dump of move data from the game, CS has a "-33"
listed under the Heal% field, just like Double-Edge has under
Drain%"