### PR TITLE
Refactor inheritsFrom to changesFrom

### DIFF
--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -527,6 +527,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 6,
 		color: "Yellow",
 		eggGroups: ["Undiscovered"],
+		changesFrom: "Pikachu-Cosplay",
 		gen: 6,
 	},
 	pikachubelle: {
@@ -542,6 +543,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 6,
 		color: "Yellow",
 		eggGroups: ["Undiscovered"],
+		changesFrom: "Pikachu-Cosplay",
 		gen: 6,
 	},
 	pikachupopstar: {
@@ -557,6 +559,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 6,
 		color: "Yellow",
 		eggGroups: ["Undiscovered"],
+		changesFrom: "Pikachu-Cosplay",
 		gen: 6,
 	},
 	pikachuphd: {
@@ -572,6 +575,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 6,
 		color: "Yellow",
 		eggGroups: ["Undiscovered"],
+		changesFrom: "Pikachu-Cosplay",
 		gen: 6,
 	},
 	pikachulibre: {
@@ -587,6 +591,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 6,
 		color: "Yellow",
 		eggGroups: ["Undiscovered"],
+		changesFrom: "Pikachu-Cosplay",
 		gen: 6,
 	},
 	pikachuoriginal: {
@@ -6591,7 +6596,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 60.8,
 		color: "Red",
 		eggGroups: ["Undiscovered"],
-		inheritsFrom: "deoxys",
+		changesFrom: "Deoxys",
 	},
 	deoxysdefense: {
 		num: 386,
@@ -6606,7 +6611,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 60.8,
 		color: "Red",
 		eggGroups: ["Undiscovered"],
-		inheritsFrom: "deoxys",
+		changesFrom: "Deoxys",
 	},
 	deoxysspeed: {
 		num: 386,
@@ -6621,7 +6626,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 60.8,
 		color: "Red",
 		eggGroups: ["Undiscovered"],
-		inheritsFrom: "deoxys",
+		changesFrom: "Deoxys",
 	},
 	turtwig: {
 		num: 387,
@@ -8012,7 +8017,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 0.3,
 		color: "Red",
 		eggGroups: ["Amorphous"],
-		inheritsFrom: "rotom",
+		changesFrom: "Rotom",
 	},
 	rotomwash: {
 		num: 479,
@@ -8027,7 +8032,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 0.3,
 		color: "Red",
 		eggGroups: ["Amorphous"],
-		inheritsFrom: "rotom",
+		changesFrom: "Rotom",
 	},
 	rotomfrost: {
 		num: 479,
@@ -8042,7 +8047,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 0.3,
 		color: "Red",
 		eggGroups: ["Amorphous"],
-		inheritsFrom: "rotom",
+		changesFrom: "Rotom",
 	},
 	rotomfan: {
 		num: 479,
@@ -8057,7 +8062,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 0.3,
 		color: "Red",
 		eggGroups: ["Amorphous"],
-		inheritsFrom: "rotom",
+		changesFrom: "Rotom",
 	},
 	rotommow: {
 		num: 479,
@@ -8072,7 +8077,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 0.3,
 		color: "Red",
 		eggGroups: ["Amorphous"],
-		inheritsFrom: "rotom",
+		changesFrom: "Rotom",
 	},
 	uxie: {
 		num: 480,
@@ -8184,6 +8189,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 650,
 		color: "Black",
 		eggGroups: ["Undiscovered"],
+		changesFrom: "Giratina",
 		requiredItem: "Griseous Orb",
 	},
 	cresselia: {
@@ -8262,6 +8268,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 5.2,
 		color: "Green",
 		eggGroups: ["Undiscovered"],
+		changesFrom: "Shaymin",
 	},
 	arceus: {
 		num: 493,
@@ -8291,6 +8298,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Gray",
 		eggGroups: ["Undiscovered"],
 		requiredItems: ["Insect Plate", "Buginium Z"],
+		changesFrom: "Arceus",
 	},
 	arceusdark: {
 		num: 493,
@@ -8306,6 +8314,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Gray",
 		eggGroups: ["Undiscovered"],
 		requiredItems: ["Dread Plate", "Darkinium Z"],
+		changesFrom: "Arceus",
 	},
 	arceusdragon: {
 		num: 493,
@@ -8321,6 +8330,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Gray",
 		eggGroups: ["Undiscovered"],
 		requiredItems: ["Draco Plate", "Dragonium Z"],
+		changesFrom: "Arceus",
 	},
 	arceuselectric: {
 		num: 493,
@@ -8336,6 +8346,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Gray",
 		eggGroups: ["Undiscovered"],
 		requiredItems: ["Zap Plate", "Electrium Z"],
+		changesFrom: "Arceus",
 	},
 	arceusfairy: {
 		num: 493,
@@ -8352,6 +8363,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		eggGroups: ["Undiscovered"],
 		gen: 6,
 		requiredItems: ["Pixie Plate", "Fairium Z"],
+		changesFrom: "Arceus",
 	},
 	arceusfighting: {
 		num: 493,
@@ -8367,6 +8379,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Gray",
 		eggGroups: ["Undiscovered"],
 		requiredItems: ["Fist Plate", "Fightinium Z"],
+		changesFrom: "Arceus",
 	},
 	arceusfire: {
 		num: 493,
@@ -8382,6 +8395,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Gray",
 		eggGroups: ["Undiscovered"],
 		requiredItems: ["Flame Plate", "Firium Z"],
+		changesFrom: "Arceus",
 	},
 	arceusflying: {
 		num: 493,
@@ -8397,6 +8411,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Gray",
 		eggGroups: ["Undiscovered"],
 		requiredItems: ["Sky Plate", "Flyinium Z"],
+		changesFrom: "Arceus",
 	},
 	arceusghost: {
 		num: 493,
@@ -8412,6 +8427,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Gray",
 		eggGroups: ["Undiscovered"],
 		requiredItems: ["Spooky Plate", "Ghostium Z"],
+		changesFrom: "Arceus",
 	},
 	arceusgrass: {
 		num: 493,
@@ -8427,6 +8443,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Gray",
 		eggGroups: ["Undiscovered"],
 		requiredItems: ["Meadow Plate", "Grassium Z"],
+		changesFrom: "Arceus",
 	},
 	arceusground: {
 		num: 493,
@@ -8442,6 +8459,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Gray",
 		eggGroups: ["Undiscovered"],
 		requiredItems: ["Earth Plate", "Groundium Z"],
+		changesFrom: "Arceus",
 	},
 	arceusice: {
 		num: 493,
@@ -8457,6 +8475,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Gray",
 		eggGroups: ["Undiscovered"],
 		requiredItems: ["Icicle Plate", "Icium Z"],
+		changesFrom: "Arceus",
 	},
 	arceuspoison: {
 		num: 493,
@@ -8472,6 +8491,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Gray",
 		eggGroups: ["Undiscovered"],
 		requiredItems: ["Toxic Plate", "Poisonium Z"],
+		changesFrom: "Arceus",
 	},
 	arceuspsychic: {
 		num: 493,
@@ -8487,6 +8507,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Gray",
 		eggGroups: ["Undiscovered"],
 		requiredItems: ["Mind Plate", "Psychium Z"],
+		changesFrom: "Arceus",
 	},
 	arceusrock: {
 		num: 493,
@@ -8502,6 +8523,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Gray",
 		eggGroups: ["Undiscovered"],
 		requiredItems: ["Stone Plate", "Rockium Z"],
+		changesFrom: "Arceus",
 	},
 	arceussteel: {
 		num: 493,
@@ -8517,6 +8539,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Gray",
 		eggGroups: ["Undiscovered"],
 		requiredItems: ["Iron Plate", "Steelium Z"],
+		changesFrom: "Arceus",
 	},
 	arceuswater: {
 		num: 493,
@@ -8532,6 +8555,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Gray",
 		eggGroups: ["Undiscovered"],
 		requiredItems: ["Splash Plate", "Waterium Z"],
+		changesFrom: "Arceus",
 	},
 	victini: {
 		num: 494,
@@ -10603,6 +10627,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 63,
 		color: "Green",
 		eggGroups: ["Undiscovered"],
+		changesFrom: "Tornadus",
 	},
 	thundurus: {
 		num: 642,
@@ -10631,6 +10656,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 61,
 		color: "Blue",
 		eggGroups: ["Undiscovered"],
+		changesFrom: "Thundurus",
 	},
 	reshiram: {
 		num: 643,
@@ -10683,6 +10709,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 68,
 		color: "Brown",
 		eggGroups: ["Undiscovered"],
+		changesFrom: "Landorus",
 	},
 	kyurem: {
 		num: 646,
@@ -10710,6 +10737,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 325,
 		color: "Gray",
 		eggGroups: ["Undiscovered"],
+		changesFrom: "Kyurem",
 	},
 	kyuremwhite: {
 		num: 646,
@@ -10724,6 +10752,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 325,
 		color: "Gray",
 		eggGroups: ["Undiscovered"],
+		changesFrom: "Kyurem",
 	},
 	keldeo: {
 		num: 647,
@@ -10738,6 +10767,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Yellow",
 		eggGroups: ["Undiscovered"],
 		otherFormes: ["keldeoresolute"],
+		changesFrom: "Keldeo",
 	},
 	keldeoresolute: {
 		num: 647,
@@ -10811,6 +10841,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Purple",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Douse Drive",
+		changesFrom: "Genesect",
 	},
 	genesectshock: {
 		num: 649,
@@ -10826,6 +10857,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Purple",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Shock Drive",
+		changesFrom: "Genesect",
 	},
 	genesectburn: {
 		num: 649,
@@ -10841,6 +10873,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Purple",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Burn Drive",
+		changesFrom: "Genesect",
 	},
 	genesectchill: {
 		num: 649,
@@ -10856,6 +10889,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Purple",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Chill Drive",
+		changesFrom: "Genesect",
 	},
 	chespin: {
 		num: 650,
@@ -11963,6 +11997,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Green",
 		eggGroups: ["Undiscovered"],
 		gen: 7,
+		changesFrom: "Zygarde",
 	},
 	zygardecomplete: {
 		num: 718,
@@ -12036,6 +12071,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 490,
 		color: "Purple",
 		eggGroups: ["Undiscovered"],
+		changesFrom: "Hoopa",
 	},
 	volcanion: {
 		num: 721,
@@ -12360,6 +12396,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 3.4,
 		color: "Yellow",
 		eggGroups: ["Flying"],
+		changesFrom: "Oricorio",
 	},
 	oricoriopau: {
 		num: 741,
@@ -12374,6 +12411,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 3.4,
 		color: "Pink",
 		eggGroups: ["Flying"],
+		changesFrom: "Oricorio",
 	},
 	oricoriosensu: {
 		num: 741,
@@ -12388,6 +12426,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 3.4,
 		color: "Purple",
 		eggGroups: ["Flying"],
+		changesFrom: "Oricorio",
 	},
 	cutiefly: {
 		num: 742,
@@ -12916,6 +12955,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		evoType: "levelFriendship",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Bug Memory",
+		changesFrom: "Silvally",
 	},
 	silvallydark: {
 		num: 773,
@@ -12933,6 +12973,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		evoType: "levelFriendship",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Dark Memory",
+		changesFrom: "Silvally",
 	},
 	silvallydragon: {
 		num: 773,
@@ -12950,6 +12991,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		evoType: "levelFriendship",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Dragon Memory",
+		changesFrom: "Silvally",
 	},
 	silvallyelectric: {
 		num: 773,
@@ -12967,6 +13009,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		evoType: "levelFriendship",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Electric Memory",
+		changesFrom: "Silvally",
 	},
 	silvallyfairy: {
 		num: 773,
@@ -12984,6 +13027,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		evoType: "levelFriendship",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Fairy Memory",
+		changesFrom: "Silvally",
 	},
 	silvallyfighting: {
 		num: 773,
@@ -13001,6 +13045,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		evoType: "levelFriendship",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Fighting Memory",
+		changesFrom: "Silvally",
 	},
 	silvallyfire: {
 		num: 773,
@@ -13018,6 +13063,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		evoType: "levelFriendship",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Fire Memory",
+		changesFrom: "Silvally",
 	},
 	silvallyflying: {
 		num: 773,
@@ -13035,6 +13081,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		evoType: "levelFriendship",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Flying Memory",
+		changesFrom: "Silvally",
 	},
 	silvallyghost: {
 		num: 773,
@@ -13052,6 +13099,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		evoType: "levelFriendship",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Ghost Memory",
+		changesFrom: "Silvally",
 	},
 	silvallygrass: {
 		num: 773,
@@ -13069,6 +13117,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		evoType: "levelFriendship",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Grass Memory",
+		changesFrom: "Silvally",
 	},
 	silvallyground: {
 		num: 773,
@@ -13086,6 +13135,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		evoType: "levelFriendship",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Ground Memory",
+		changesFrom: "Silvally",
 	},
 	silvallyice: {
 		num: 773,
@@ -13103,6 +13153,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		evoType: "levelFriendship",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Ice Memory",
+		changesFrom: "Silvally",
 	},
 	silvallypoison: {
 		num: 773,
@@ -13120,6 +13171,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		evoType: "levelFriendship",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Poison Memory",
+		changesFrom: "Silvally",
 	},
 	silvallypsychic: {
 		num: 773,
@@ -13137,6 +13189,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		evoType: "levelFriendship",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Psychic Memory",
+		changesFrom: "Silvally",
 	},
 	silvallyrock: {
 		num: 773,
@@ -13154,6 +13207,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		evoType: "levelFriendship",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Rock Memory",
+		changesFrom: "Silvally",
 	},
 	silvallysteel: {
 		num: 773,
@@ -13171,6 +13225,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		evoType: "levelFriendship",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Steel Memory",
+		changesFrom: "Silvally",
 	},
 	silvallywater: {
 		num: 773,
@@ -13188,6 +13243,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		evoType: "levelFriendship",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Water Memory",
+		changesFrom: "Silvally",
 	},
 	minior: {
 		num: 774,
@@ -13623,7 +13679,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 460,
 		color: "Yellow",
 		eggGroups: ["Undiscovered"],
-		inheritsFrom: "necrozma",
+		changesFrom: "Necrozma",
 	},
 	necrozmadawnwings: {
 		num: 800,
@@ -13638,7 +13694,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 350,
 		color: "Blue",
 		eggGroups: ["Undiscovered"],
-		inheritsFrom: "necrozma",
+		changesFrom: "Necrozma",
 	},
 	necrozmaultra: {
 		num: 800,
@@ -15197,7 +15253,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Blue",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Rusted Sword",
-		inheritsFrom: "zacian",
+		changesFrom: "Zacian",
 	},
 	zamazenta: {
 		num: 889,
@@ -15226,7 +15282,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Red",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Rusted Shield",
-		inheritsFrom: "zamazenta",
+		changesFrom: "Zamazenta",
 	},
 	eternatus: {
 		num: 890,

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -171,8 +171,8 @@ export class RandomTeams {
 						moveid => learnset![moveid].find(learned => learned.startsWith(String(this.gen)))
 					);
 				}
-				if (species.inheritsFrom) {
-					learnset = this.dex.data.Learnsets[species.inheritsFrom].learnset;
+				if (species.changesFrom) {
+					learnset = this.dex.data.Learnsets[toID(species.changesFrom)].learnset;
 					const basePool = Object.keys(learnset!).filter(
 						moveid => learnset![moveid].find(learned => learned.startsWith(String(this.gen)))
 					);

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -862,11 +862,8 @@ export const BattleFormats: {[k: string]: FormatsData} = {
 				if (baseSpecies.otherFormes) {
 					for (const formeid of baseSpecies.otherFormes) {
 						const forme = dex.getSpecies(formeid);
-						if (!forme.battleOnly) {
-							if (!forme.forme.includes('Alola') && forme.forme !== 'Galar' && forme.baseSpecies !== 'Wormadam') {
-								types = types.concat(forme.types).concat(baseSpecies.types);
-							}
-						}
+						if (!forme.changesFrom) continue;
+						types = types.concat(forme.types).concat(baseSpecies.types);
 					}
 				}
 				if (types.includes(move.type)) return null;

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -849,22 +849,30 @@ export const BattleFormats: {[k: string]: FormatsData} = {
 		desc: "Allows Pok&eacute;mon to use any move that they or a previous evolution/out-of-battle forme share a type with",
 		checkLearnset(move, species, setSources, set) {
 			const restrictedMoves = this.format.restricted || [];
-			if (!restrictedMoves.includes(move.name) && !move.isNonstandard && !move.isMax) {
+			if (!restrictedMoves.includes(move.name) && !move.isNonstandard && !move.isZ && !move.isMax) {
 				const dex = this.dex;
-				let types = species.types;
-				const baseSpecies = dex.getSpecies(species.baseSpecies);
+				let types: string[];
+				if (species.forme || species.otherFormes) {
+					const baseSpecies = dex.getSpecies(species.baseSpecies);
+					const originalForme = dex.getSpecies(species.changesFrom || species.name);
+					types = originalForme.types;
+					if (baseSpecies.otherFormes) {
+						for (const formeid of baseSpecies.otherFormes) {
+							const forme = dex.getSpecies(formeid);
+							if (forme.changesFrom === originalForme.name) {
+								types = types.concat(forme.types);
+							}
+						}
+					}
+				} else {
+					types = species.types;
+				}
+
 				let prevo = species.prevo;
 				while (prevo) {
 					const prevoSpecies = dex.getSpecies(prevo);
 					types = types.concat(prevoSpecies.types);
 					prevo = prevoSpecies.prevo;
-				}
-				if (baseSpecies.otherFormes) {
-					for (const formeid of baseSpecies.otherFormes) {
-						const forme = dex.getSpecies(formeid);
-						if (!forme.changesFrom) continue;
-						types = types.concat(forme.types).concat(baseSpecies.types);
-					}
 				}
 				if (types.includes(move.type)) return null;
 			}

--- a/server/chat-commands/info.js
+++ b/server/chat-commands/info.js
@@ -1988,7 +1988,7 @@ const commands = {
 			}
 
 			if ((pokemon.battleOnly && pokemon.baseSpecies !== 'Greninja') || ['Keldeo', 'Genesect'].includes(pokemon.baseSpecies)) {
-				pokemon = Dex.getSpecies(pokemon.inheritsFrom || pokemon.baseSpecies);
+				pokemon = Dex.getSpecies(pokemon.changesFrom || pokemon.baseSpecies);
 			}
 
 			let formatName = extraFormat.name;

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -530,7 +530,7 @@ export class Species extends BasicEffect implements Readonly<BasicEffect & Speci
 	 * Base species. Species, but without the forme name.
 	 *
 	 * DO NOT ASSUME A POKEMON CAN TRANSFORM FROM `baseSpecies` TO
-	 * `species`. USE `inheritsFrom` FOR THAT.
+	 * `species`. USE `changesFrom` FOR THAT.
 	 */
 	readonly baseSpecies: string;
 	/**
@@ -640,7 +640,7 @@ export class Species extends BasicEffect implements Readonly<BasicEffect & Speci
 	 * Not filled out for megas/primals - fall back to baseSpecies
 	 * for in-battle formes.
 	 */
-	readonly inheritsFrom: ID;
+	readonly changesFrom?: string;
 
 	/**
 	 * Singles Tier. The Pokemon's location in the Smogon tier system.
@@ -704,7 +704,7 @@ export class Species extends BasicEffect implements Readonly<BasicEffect & Speci
 		this.isMega = !!(this.forme && ['Mega', 'Mega-X', 'Mega-Y'].includes(this.forme)) || undefined;
 		this.isGigantamax = data.isGigantamax || undefined;
 		this.battleOnly = data.battleOnly || (this.isMega || this.isGigantamax ? this.baseSpecies : undefined);
-		this.inheritsFrom = data.inheritsFrom || (this.isGigantamax ? toID(this.baseSpecies) : undefined);
+		this.changesFrom = data.changesFrom || (this.isGigantamax ? this.baseSpecies : undefined);
 
 		if (!this.gen && this.num >= 1) {
 			if (this.num >= 810 || ['Gmax', 'Galar', 'Galar-Zen'].includes(this.forme)) {

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -459,7 +459,7 @@ export class ModdedDex {
 
 	getOutOfBattleSpecies(species: Species) {
 		return !species.battleOnly ? species.name :
-			species.inheritsFrom ? this.getSpecies(species.inheritsFrom).name :
+			species.changesFrom ? this.getSpecies(species.changesFrom).name :
 			species.baseSpecies;
 	}
 

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -1088,7 +1088,7 @@ interface SpeciesData {
 	requiredMove?: string;
 	battleOnly?: string | string[];
 	isGigantamax?: string;
-	inheritsFrom?: string;
+	changesFrom?: string;
 }
 
 interface ModdedSpeciesData extends Partial<SpeciesData> {

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1711,15 +1711,15 @@ export class TeamValidator {
 			if (dex.gen <= 2 && species.gen === 1) tradebackEligible = true;
 			const lsetData = dex.getLearnsetData(species.id);
 			if (!lsetData.learnset) {
-				if (species.baseSpecies !== species.name) {
+				if ((species.changesFrom || species.baseSpecies) !== species.name) {
 					// forme without its own learnset
-					species = dex.getSpecies(species.baseSpecies);
+					species = dex.getSpecies(species.changesFrom || species.baseSpecies);
 					// warning: formes with their own learnset, like Wormadam, should NOT
 					// inherit from their base forme unless they're freely switchable
 					continue;
 				}
 				// should never happen
-				break;
+				throw new Error(`Species with no learnset data: ${species.id}`);
 			}
 			const checkingPrevo = species.baseSpecies !== s.baseSpecies;
 			if (checkingPrevo && !moveSources.size()) {

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1938,9 +1938,9 @@ export class TeamValidator {
 			species = this.dex.getSpecies(species.prevo);
 			if (species.gen > Math.max(2, this.dex.gen)) return null;
 			return species;
-		} else if (species.inheritsFrom) {
+		} else if (species.changesFrom) {
 			// For Pokemon like Rotom, Necrozma, and Gmax formes whose movesets are extensions are their base formes
-			return this.dex.getSpecies(species.inheritsFrom);
+			return this.dex.getSpecies(species.changesFrom);
 		}
 		return null;
 	}


### PR DESCRIPTION
I renamed it from `inheritsFrom` to `changesFrom`, and it is no longer an `ID` to be consistent with upcoming changes to `otherFormes` and `cosmeticFormes`