### PR TITLE
Dancer should not activate if the holder fainted

### DIFF
--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -118,6 +118,7 @@ export const BattleScripts: BattleScriptsData = {
 			);
 			for (const dancer of dancers) {
 				if (this.faintMessages()) break;
+				if (dancer.fainted) continue;
 				this.add('-activate', dancer, 'ability: Dancer');
 				// @ts-ignore - the Dancer ability can't trigger on a move where target is null because it does not copy failed moves.
 				const dancersTarget = target.side !== dancer.side && pokemon.side === dancer.side ? target : pokemon;

--- a/test/sim/abilities/dancer.js
+++ b/test/sim/abilities/dancer.js
@@ -109,6 +109,14 @@ describe('Dancer', function () {
 		assert.hurts(dancer, () => battle.makeChoices('move fierydance', 'move meanlook'));
 	});
 
+	it('should not activate if the holder fainted', function () {
+		battle = common.createBattle();
+		battle.setPlayer('p1', {team: [{species: 'Oricoriopompom', ability: 'dancer', moves: ['revelationdance']}]});
+		battle.setPlayer('p2', {team: [{species: 'oricorio', ability: 'dancer', level: 1, moves: ['sleeptalk']}, {species: 'oricorio', ability: 'dancer', level: 1, moves: ['sleeptalk']}]});
+		battle.makeChoices();
+		assert.ok(!battle.log.includes('|-activate|p2: Oricorio|ability: Dancer'));
+	});
+
 	it('should target the user of a Dance move unless it was an ally attacking an opponent', function () {
 		battle = common.createBattle({gameType: 'doubles'});
 		battle.setPlayer('p1', {team: [


### PR DESCRIPTION
If the holder has no more allies then the battle simply ends, but if you KO a Dancer with a Dance move then you get a presumably spurious activation message. (The Dancer doesn't actually copy the Dance move; this is just an ability activation display error.)