### PR TITLE
Add Dynamax Struggle tests

### DIFF
--- a/test/sim/misc/dynamax.js
+++ b/test/sim/misc/dynamax.js
@@ -120,11 +120,11 @@ describe("Dynamax", function () {
 
 	it('Max Guard should be disallowed by Taunt', function () {
 		battle = common.createBattle([[
-			{species: "Feebas", moves: ['splash']},
+			{species: "Feebas", moves: ['splash', 'tackle']},
 		], [
 			{species: "Wynaut", moves: ['taunt', 'splash']},
 		]]);
-		battle.makeChoices('move splash dynamax', 'auto');
+		battle.makeChoices('move tackle dynamax', 'auto');
 		assert.cantMove(() => battle.choose('p1', 'move splash'), 'Feebas', 'Max Guard', true);
 	});
 });

--- a/test/sim/misc/dynamax.js
+++ b/test/sim/misc/dynamax.js
@@ -99,4 +99,32 @@ describe("Dynamax", function () {
 		assert.equal(battle.requestState, 'switch');
 		assert.equal(battle.p1.active[0].hp, dynamaxedHP);
 	});
+
+	it('should be impossible to Dynamax when all the base moves are disabled', function () {
+		battle = common.createBattle([[
+			{species: "Feebas", moves: ['splash']},
+		], [
+			{species: "Wynaut", moves: ['taunt', 'splash']},
+		]]);
+		battle.makeChoices();
+		assert.cantMove(() => battle.choose('p1', 'move splash dynamax'), 'Feebas', 'Max Guard', true);
+
+		battle = common.createBattle([[
+			{species: "Feebas", moves: ['splash']},
+		], [
+			{species: "Wynaut", moves: ['imprison', 'splash']},
+		]]);
+		battle.makeChoices();
+		assert.cantMove(() => battle.choose('p1', 'move splash dynamax'), 'Feebas', 'Max Guard', true);
+	});
+
+	it('Max Guard should be disallowed by Taunt', function () {
+		battle = common.createBattle([[
+			{species: "Feebas", moves: ['splash']},
+		], [
+			{species: "Wynaut", moves: ['taunt', 'splash']},
+		]]);
+		battle.makeChoices('move splash dynamax', 'auto');
+		assert.cantMove(() => battle.choose('p1', 'move splash'), 'Feebas', 'Max Guard', true);
+	});
 });


### PR DESCRIPTION
DO NOT MERGE

OK so these tests are failing but presumably not for the right reasons. On sim right now Taunting into a Pokemon with _only_ status moves should prevent that Pokemon from Dynamaxing. My test fails for that case.

The situation I care more about is Dynamax being able to bypass Imprison, and Taunt not stopping Max Guard. The former can cause really ugly and wrong error messages when the target should Struggle (see https://replay.pokemonshowdown.com/gen8customgame-1103346271). The latter can lead to virtual softlocks in Metronome battles. It's partially the client's fault too, I think, since Max Guard Taunt isn't actually disabled in the client.
https://replay.pokemonshowdown.com/gen8metronomebattle-1102183415 (turn 6)

