### PR TITLE
Shell Trap should not power up if hit by a Z- or Max move

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -16695,7 +16695,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 					pokemon.volatiles['shelltrap'].gotHit = true;
 					const action = this.queue.willMove(pokemon);
 					if (action) {
-						this.queue.prioritizeAction(action, move);
+						this.queue.prioritizeAction(action);
 					}
 				}
 			},

--- a/test/sim/moves/shelltrap.js
+++ b/test/sim/moves/shelltrap.js
@@ -32,4 +32,22 @@ describe('Shell Trap', function () {
 		battle.makeChoices('move shelltrap, move splash', 'move tackle, move splash');
 		assert.equal(move.pp, move.maxpp - 2);
 	});
+
+	it('should not Z-power if hit by a Z-move', function () {
+		battle = common.createBattle({}, [
+			[{species: 'Turtonator', moves: ['shelltrap']}],
+			[{species: 'Magikarp', item: 'normaliumz', moves: ['flail']}],
+		]);
+		battle.makeChoices('move shelltrap', 'move flail zmove');
+		assert(battle.log.some(line => line.includes('|Shell Trap|')));
+	});
+
+	it('should not Max if hit by a Max move', function () {
+		battle = common.createBattle({}, [
+			[{species: 'Turtonator', moves: ['shelltrap']}],
+			[{species: 'Magikarp', moves: ['flail']}],
+		]);
+		battle.makeChoices('move shelltrap', 'move flail dynamax');
+		assert(battle.log.some(line => line.includes('|Shell Trap|')));
+	});
 });


### PR DESCRIPTION
Error introduced as part of the fix for PR #6231.

Reported here: https://www.smogon.com/forums/posts/8438387

Relevant replay in the post: https://replay.pokemonshowdown.com/gen8hackmonscup-1101486710 turn 47