### PR TITLE
Pass the Transform or Imposter effect to onModifySpecies

### DIFF
--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1014,7 +1014,7 @@ export class Pokemon {
 		}
 	}
 
-	transformInto(pokemon: Pokemon, effect: Effect | null = null) {
+	transformInto(pokemon: Pokemon, effect?: Effect) {
 		const species = pokemon.species;
 		if (pokemon.fainted || pokemon.illusion || (pokemon.volatiles['substitute'] && this.battle.gen >= 5) ||
 			(pokemon.transformed && this.battle.gen >= 2) || (this.transformed && this.battle.gen >= 5) ||
@@ -1022,7 +1022,7 @@ export class Pokemon {
 			return false;
 		}
 
-		if (!this.setSpecies(species, null, true)) return false;
+		if (!this.setSpecies(species, effect, true)) return false;
 
 		this.transformed = true;
 		this.weighthg = pokemon.weighthg;


### PR DESCRIPTION
As discussed here: https://github.com/smogon/pokemon-showdown/commit/9b943fb#r38273770

`onModifySpecies`, or as it was called back then `onModifyTemplate`, always used to be passed the effect that was setting the template. Commit 9b943fb changed that to always pass `null` for Transform and Imposter. Although I don't mind either way, commit history suggests that it's preferred to pass the effect in all cases. (Note that `Transform` doesn't actually pass the effect to `transformInfo` but because the effect is missing rather than null this means that `setSpecies` is able to look up the effect by default anyway.) In particular Camomons is currently checking for the two specific effects to avoid modifying a Transformed template.