### PR TITLE
Correct Self-Destruct and Explosion base power

### DIFF
--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -289,8 +289,6 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 	explosion: {
 		inherit: true,
 		desc: "The user faints after using this move. The target's Defense is halved during damage calculation.",
-		shortDesc: "The user faints.",
-		basePower: 250,
 		noSketch: true,
 	},
 	fissure: {
@@ -738,8 +736,6 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 	selfdestruct: {
 		inherit: true,
 		desc: "The user faints after using this move. The target's Defense is halved during damage calculation.",
-		shortDesc: "The user faints.",
-		basePower: 200,
 		noSketch: true,
 	},
 	sketch: {

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -570,7 +570,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 	explosion: {
 		inherit: true,
 		desc: "The user faints after using this move, unless this move has no target. The target's Defense is halved during damage calculation. This move is prevented from executing if any active Pokemon has the Damp Ability.",
-		basePower: 500,
+		shortDesc: "Deals double damage. The user faints.",
 	},
 	extremespeed: {
 		inherit: true,
@@ -1386,7 +1386,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 	selfdestruct: {
 		inherit: true,
 		desc: "The user faints after using this move, unless this move has no target. The target's Defense is halved during damage calculation. This move is prevented from executing if any active Pokemon has the Damp Ability.",
-		basePower: 400,
+		shortDesc: "Deals double damage. The user faints.",
 	},
 	sketch: {
 		inherit: true,

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2124,6 +2124,11 @@ export class Battle {
 		attack = this.runEvent('Modify' + statTable[attackStat], attacker, defender, move, attack);
 		defense = this.runEvent('Modify' + statTable[defenseStat], defender, attacker, move, defense);
 
+		if (this.gen <= 4 && ['explosion', 'selfdestruct'].includes(move.id) &&
+				move.defensiveCategory === 'Physical') {
+			defense = this.dex.clampIntRange(Math.floor(defense / 2), 1);
+		}
+
 		const tr = this.trunc;
 
 		// int(int(int(2 * L / 5 + 2) * A * P / D) / 50);


### PR DESCRIPTION
As confirmed by SadisticMystic, base power cannot be above 255, so
this move data is clearly incorrect and results in downstream users
of the data files such as the Smogon or PS dex or the tooltips
displaying misleading information.