### PR TITLE
Add a few G-Max Chi Strike tests

### DIFF
--- a/test/sim/moves/gmaxchistrike.js
+++ b/test/sim/moves/gmaxchistrike.js
@@ -43,6 +43,7 @@ describe('G-Max Chi Strike', function () {
 	});
 
 	it('should be copied by Psych Up', function () {
+		// hardcoded RNG seed ensures Magikarp will not crit at +0
 		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
 			{species: 'Machamp-Gmax', moves: ['rocksmash', 'sleeptalk']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
@@ -64,6 +65,7 @@ describe('G-Max Chi Strike', function () {
 	});
 
 	it('should not be passed by Baton Pass', function () {
+		// hardcoded RNG seed ensures Magikarp will not crit at +0
 		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
 			{species: 'Machamp-Gmax', moves: ['rocksmash', 'batonpass']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
@@ -80,7 +82,7 @@ describe('G-Max Chi Strike', function () {
 		battle.makeChoices('switch 3');
 		battle.makeChoices('move tackle 2, move sleeptalk', 'auto');
 
-		// Magikarp is only +0 for crit rate, so it probably will not crit
+		// Magikarp is only +0 for crit rate, so it will not crit
 		assert(battle.log.every(line => !line.startsWith('|-crit')));
 	});
 });

--- a/test/sim/moves/gmaxchistrike.js
+++ b/test/sim/moves/gmaxchistrike.js
@@ -87,7 +87,6 @@ describe('G-Max Chi Strike', function () {
 		battle.makeChoices('move batonpass, move sleeptalk', 'auto');
 		battle.makeChoices('switch 3');
 		battle.makeChoices('move tackle 2, move sleeptalk', 'auto');
-		console.log(battle.getDebugLog());
 
 		// Magikarp is only +0 so it probably will not crit
 		assert(battle.log.every(line => !line.startsWith('|-crit')));

--- a/test/sim/moves/gmaxchistrike.js
+++ b/test/sim/moves/gmaxchistrike.js
@@ -10,19 +10,31 @@ describe('G-Max Chi Strike', function () {
 		battle.destroy();
 	});
 
-	it.skip('should provide a crit boost independent of Focus Energy', function () {
+	it('should boost the user and its ally\'s critical hit rate by 1 stage', function () {
 		// hardcoded RNG seed that doesn't roll a crit at +2 crit rate
-		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]});
-		battle.setPlayer('p1', {team: [
+		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
 			{species: 'Machamp-Gmax', moves: ['sleeptalk', 'rocksmash']},
-			{species: 'Wynaut', moves: ['focusenergy', 'tackle']},
-		]});
-		battle.setPlayer('p2', {team: [
+			{species: 'Wynaut', ability: "Super Luck", item: "Scope Lens", moves: ['tackle']},
+		], [
 			{species: 'Wynaut', ability: "Shell Armor", moves: ['sleeptalk']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
-		]});
+		]]);
 
-		battle.resetRNG();
+		// Boosts Wynaut to +3, so this crit is now guaranteed
+		battle.makeChoices('move rocksmash 1 dynamax, move tackle 2', 'auto');
+		assert(battle.log.some(line => line.startsWith('|-crit')));
+	});
+
+	it('should provide a crit boost independent of Focus Energy', function () {
+		// hardcoded RNG seed that doesn't roll a crit at +2 crit rate
+		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
+			{species: 'Machamp-Gmax', moves: ['sleeptalk', 'rocksmash']},
+			{species: 'Wynaut', moves: ['focusenergy', 'tackle']},
+		], [
+			{species: 'Wynaut', ability: "Shell Armor", moves: ['sleeptalk']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		]]);
+
 		battle.makeChoices();
 		battle.makeChoices('move rocksmash 1 dynamax, move tackle 2', 'auto');
 
@@ -30,33 +42,15 @@ describe('G-Max Chi Strike', function () {
 		assert(battle.log.some(line => line.startsWith('|-crit')));
 	});
 
-	it('should boost the user and its ally\'s critical hit rate by 1 stage', function () {
-		battle = common.createBattle({gameType: 'doubles'});
-		battle.setPlayer('p1', {team: [
-			{species: 'Machamp-Gmax', moves: ['rocksmash']},
-			{species: 'Wynaut', item: 'Scope Lens', ability: "Super Luck", moves: ['tackle']},
-		]});
-		battle.setPlayer('p2', {team: [
-			{species: 'Wynaut', ability: "Shell Armor", moves: ['sleeptalk']},
-			{species: 'Wynaut', moves: ['sleeptalk']},
-		]});
-
-		// Boosts Wynaut to +3, so this crit is now guaranteed
-		battle.makeChoices('move rocksmash 1 dynamax, move tackle 2', 'auto');
-		assert(battle.log.some(line => line.startsWith('|-crit')));
-	});
-
-	it.skip('should be copied by Psych Up', function () {
-		battle = common.createBattle({gameType: 'doubles'});
-		battle.setPlayer('p1', {team: [
+	it('should be copied by Psych Up', function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: 'Machamp-Gmax', moves: ['rocksmash', 'sleeptalk']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
 			{species: 'Magikarp', moves: ['psychup', 'tackle']},
-		]});
-		battle.setPlayer('p2', {team: [
+		], [
 			{species: 'Wynaut', ability: "Shell Armor", moves: ['sleeptalk']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
-		]});
+		]]);
 
 		battle.makeChoices('move rocksmash 1 dynamax, move sleeptalk', 'auto');
 		battle.makeChoices('move rocksmash 1, move sleeptalk', 'auto');
@@ -70,16 +64,14 @@ describe('G-Max Chi Strike', function () {
 	});
 
 	it('should not be passed by Baton Pass', function () {
-		battle = common.createBattle({gameType: 'doubles'});
-		battle.setPlayer('p1', {team: [
+		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: 'Machamp-Gmax', moves: ['rocksmash', 'batonpass']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
 			{species: 'Magikarp', moves: ['tackle']},
-		]});
-		battle.setPlayer('p2', {team: [
+		], [
 			{species: 'Wynaut', ability: "Shell Armor", moves: ['sleeptalk']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
-		]});
+		]]);
 
 		battle.makeChoices('move rocksmash 1 dynamax, move sleeptalk', 'auto');
 		battle.makeChoices('move rocksmash 1, move sleeptalk', 'auto');
@@ -88,7 +80,7 @@ describe('G-Max Chi Strike', function () {
 		battle.makeChoices('switch 3');
 		battle.makeChoices('move tackle 2, move sleeptalk', 'auto');
 
-		// Magikarp is only +0 so it probably will not crit
+		// Magikarp is only +0 for crit rate, so it probably will not crit
 		assert(battle.log.every(line => !line.startsWith('|-crit')));
 	});
 });

--- a/test/sim/moves/gmaxchistrike.js
+++ b/test/sim/moves/gmaxchistrike.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('G-Max Chi Strike', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it.skip('should boost the user and its ally\'s critical hit rate by 1 stage', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [
+			{species: 'Machamp-Gmax', moves: ['rocksmash']},
+			{species: 'Wynaut', item: 'Scope Lens', moves: ['tackle']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Wynaut', moves: ['sleeptalk']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		]});
+
+		// Needs an RNG seed that does not produce a crit at current crit stage of +2 from Scope Lens & +1 Chi Strike
+		battle.makeChoices('move rocksmash 1 dynamax, move tackle 2', 'auto');
+		assert(battle.log.every(line => !line.startsWith('|-crit')));
+
+		// Boosts Wynaut to +3, so this crit is now guaranteed
+		battle.makeChoices('move rocksmash 1 dynamax, move tackle 2', 'auto');
+		assert(battle.log.some(line => line.startsWith('|-crit')));
+	});
+
+	it.skip('should provide a crit boost independent of Focus Energy', function () {
+		// hardcoded RNG seed that doesn't roll a crit at +2 crit rate
+		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]});
+		battle.setPlayer('p1', {team: [
+			{species: 'Machamp-Gmax', moves: ['sleeptalk', 'rocksmash']},
+			{species: 'Wynaut', moves: ['focusenergy', 'tackle']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Wynaut', moves: ['sleeptalk']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		]});
+
+		battle.resetRNG();
+		battle.makeChoices();
+		battle.makeChoices('move rocksmash 1 dynamax, move tackle 2', 'auto');
+
+		// This should be a guaranteed crit at +3
+		assert(battle.log.some(line => line.startsWith('|-crit')));
+	});
+});

--- a/test/sim/moves/gmaxchistrike.js
+++ b/test/sim/moves/gmaxchistrike.js
@@ -10,26 +10,6 @@ describe('G-Max Chi Strike', function () {
 		battle.destroy();
 	});
 
-	it.skip('should boost the user and its ally\'s critical hit rate by 1 stage', function () {
-		battle = common.createBattle({gameType: 'doubles'});
-		battle.setPlayer('p1', {team: [
-			{species: 'Machamp-Gmax', moves: ['rocksmash']},
-			{species: 'Wynaut', item: 'Scope Lens', moves: ['tackle']},
-		]});
-		battle.setPlayer('p2', {team: [
-			{species: 'Wynaut', moves: ['sleeptalk']},
-			{species: 'Wynaut', moves: ['sleeptalk']},
-		]});
-
-		// Needs an RNG seed that does not produce a crit at current crit stage of +2 from Scope Lens & +1 Chi Strike
-		battle.makeChoices('move rocksmash 1 dynamax, move tackle 2', 'auto');
-		assert(battle.log.every(line => !line.startsWith('|-crit')));
-
-		// Boosts Wynaut to +3, so this crit is now guaranteed
-		battle.makeChoices('move rocksmash 1 dynamax, move tackle 2', 'auto');
-		assert(battle.log.some(line => line.startsWith('|-crit')));
-	});
-
 	it.skip('should provide a crit boost independent of Focus Energy', function () {
 		// hardcoded RNG seed that doesn't roll a crit at +2 crit rate
 		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]});
@@ -38,7 +18,7 @@ describe('G-Max Chi Strike', function () {
 			{species: 'Wynaut', moves: ['focusenergy', 'tackle']},
 		]});
 		battle.setPlayer('p2', {team: [
-			{species: 'Wynaut', moves: ['sleeptalk']},
+			{species: 'Wynaut', ability: "Shell Armor", moves: ['sleeptalk']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
 		]});
 
@@ -48,5 +28,68 @@ describe('G-Max Chi Strike', function () {
 
 		// This should be a guaranteed crit at +3
 		assert(battle.log.some(line => line.startsWith('|-crit')));
+	});
+
+	it('should boost the user and its ally\'s critical hit rate by 1 stage', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [
+			{species: 'Machamp-Gmax', moves: ['rocksmash']},
+			{species: 'Wynaut', item: 'Scope Lens', ability: "Super Luck", moves: ['tackle']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Wynaut', ability: "Shell Armor", moves: ['sleeptalk']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		]});
+
+		// Boosts Wynaut to +3, so this crit is now guaranteed
+		battle.makeChoices('move rocksmash 1 dynamax, move tackle 2', 'auto');
+		assert(battle.log.some(line => line.startsWith('|-crit')));
+	});
+
+	it.skip('should be copied by Psych Up', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [
+			{species: 'Machamp-Gmax', moves: ['rocksmash', 'sleeptalk']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+			{species: 'Magikarp', moves: ['psychup', 'tackle']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Wynaut', ability: "Shell Armor", moves: ['sleeptalk']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		]});
+
+		battle.makeChoices('move rocksmash 1 dynamax, move sleeptalk', 'auto');
+		battle.makeChoices('move rocksmash 1, move sleeptalk', 'auto');
+		battle.makeChoices('move rocksmash 1, move sleeptalk', 'auto');
+		battle.makeChoices('move sleeptalk, switch 3', 'auto');
+		battle.makeChoices('move sleeptalk, move psychup -1', 'auto');
+		battle.makeChoices('move sleeptalk, move tackle 2', 'auto');
+
+		// Magikarp is +3 after Psych Up, so this crit is now guaranteed
+		assert(battle.log.some(line => line.startsWith('|-crit')));
+	});
+
+	it('should not be passed by Baton Pass', function () {
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [
+			{species: 'Machamp-Gmax', moves: ['rocksmash', 'batonpass']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+			{species: 'Magikarp', moves: ['tackle']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Wynaut', ability: "Shell Armor", moves: ['sleeptalk']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		]});
+
+		battle.makeChoices('move rocksmash 1 dynamax, move sleeptalk', 'auto');
+		battle.makeChoices('move rocksmash 1, move sleeptalk', 'auto');
+		battle.makeChoices('move rocksmash 1, move sleeptalk', 'auto');
+		battle.makeChoices('move batonpass, move sleeptalk', 'auto');
+		battle.makeChoices('switch 3');
+		battle.makeChoices('move tackle 2, move sleeptalk', 'auto');
+		console.log(battle.getDebugLog());
+
+		// Magikarp is only +0 so it probably will not crit
+		assert(battle.log.every(line => !line.startsWith('|-crit')));
 	});
 });

--- a/test/sim/moves/gmaxchistrike.js
+++ b/test/sim/moves/gmaxchistrike.js
@@ -43,7 +43,7 @@ describe('G-Max Chi Strike', function () {
 	});
 
 	it('should be copied by Psych Up', function () {
-		battle = common.createBattle({gameType: 'doubles'}, [[
+		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
 			{species: 'Machamp-Gmax', moves: ['rocksmash', 'sleeptalk']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
 			{species: 'Magikarp', moves: ['psychup', 'tackle']},
@@ -64,7 +64,7 @@ describe('G-Max Chi Strike', function () {
 	});
 
 	it('should not be passed by Baton Pass', function () {
-		battle = common.createBattle({gameType: 'doubles'}, [[
+		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
 			{species: 'Machamp-Gmax', moves: ['rocksmash', 'batonpass']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
 			{species: 'Magikarp', moves: ['tackle']},


### PR DESCRIPTION
G-Max Chi Strike currently sets Focus Energy, when it should actually set an independent stat boost. G-Max Chi Strike boosts crit rate by 1 and is stackable, unlike Focus Energy which boosts by 2 and is not stackable. See research:

https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/post-8440929

My tests here are weird. For one thing, crits are random; normally it'd be easy to test because you'd just give the mon Scope Lens and Super Luck and check if the move crit after a single use since the mon is +3, but since Focus Energy is being set you can't really use that as a test because the old implementation would just reach +4 and you'd crit anyway.

The 1st test checks that it's different from Focus Energy. Some subsequent tests pass when they should not because I'm setting up guaranteed crits. They also might not be accurate at all because these are RNG-based tests and I'm not confident in how to rig the RNG.