### PR TITLE
Fix G-Max Chi Strike's effect on Crit Ratio

### DIFF
--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -190,7 +190,7 @@ interface PureEffectEventMethods {
 	durationCallback?: (this: Battle, target: Pokemon, source: Pokemon, effect: Effect | null) => number;
 	onCopy?: (this: Battle, pokemon: Pokemon) => void;
 	onEnd?: (this: Battle, target: Pokemon & Side & Field) => void;
-	onRestart?: (this: Battle, target: Pokemon & Side & Field, source: Pokemon) => void;
+	onRestart?: (this: Battle, target: Pokemon & Side & Field, source: Pokemon, sourceEffect: Effect) => void;
 	onStart?: (this: Battle, target: Pokemon & Side & Field, source: Pokemon, sourceEffect: Effect) => void;
 }
 
@@ -770,8 +770,6 @@ interface EffectData {
 	infiltrates?: boolean;
 	isNonstandard?: Nonstandard | null;
 	shortDesc?: string;
-
-	onRestart?: (this: Battle, target: Pokemon & Side & Field, source: Pokemon) => void;
 }
 
 type ModdedEffectData = EffectData | Partial<EffectData> & {inherit: true};

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1099,10 +1099,11 @@ export class Pokemon {
 			this.boosts[boostName] = pokemon.boosts[boostName]!;
 		}
 		if (this.battle.gen >= 6) {
-			const volatilesToCopy = ['focusenergy', 'laserfocus'];
+			const volatilesToCopy = ['focusenergy', 'gmaxchistrike', 'laserfocus'];
 			for (const volatile of volatilesToCopy) {
 				if (pokemon.volatiles[volatile]) {
 					this.addVolatile(volatile);
+					if (volatile === 'gmaxchistrike') this.volatiles[volatile].layers = pokemon.volatiles[volatile].layers;
 				} else {
 					this.removeVolatile(volatile);
 				}


### PR DESCRIPTION
As researched by @DaWoblefet: https://www.smogon.com/forums/posts/8440929

- Each use of G-Max Chi Strike increases team's crit ratio by 1
- This increase stacks up to 3 layers
- Can be copied by Psych Up, Imposter and Transform but not Baton Pass

I don't know why `global-types.ts` had two copies of `onRestart`; it seems to compile fine with just the one.