### PR TITLE
Prevent user identity updates from sending leave messages for guests

### DIFF
--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1345,8 +1345,6 @@ export class BasicChatRoom extends BasicRoom {
 			if (!this.users[user.id]) return false;
 			if (user.named) {
 				this.reportJoin('n', user.getIdentityWithStatus(this.roomid) + '|' + user.id, user);
-			} else {
-				this.reportJoin('l', user.id, user);
 			}
 		}
 		return true;


### PR DESCRIPTION
Guests usually don't appear in join/leave/rename messages, but it's
possible for a bot to /trn to a guest nick with an assertion from the
login server and trigger a leave message for a guest nick to get sent.
This shouldn't have any consequences for the official client, but can
crash bots that keep state for users.