### PR TITLE
Add bl as an alias for blacklist

### DIFF
--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -1489,6 +1489,7 @@ export const commands: ChatCommands = {
 	],
 
 	ab: 'blacklist',
+	bl: 'blacklist',
 	blacklist(target, room, user) {
 		if (!target) return this.parse('/help blacklist');
 		if (!this.canTalk()) return;


### PR DESCRIPTION
This is a more common alias for blacklist than ab, which was implemented because that's what bots at the time used