### PR TITLE
Group zMove and maxMove attributes

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -1247,7 +1247,7 @@ export const BattleAbilities: {[abilityid: string]: AbilityData} = {
 			pokemon.abilityData.choiceLock = "";
 		},
 		onBeforeMove(pokemon, target, move) {
-			if (move.isZPowered || move.isMaxPowered || move.id === 'struggle') return;
+			if (move.isZOrMaxPowered || move.isZOrMaxPowered || move.id === 'struggle') return;
 			if (pokemon.abilityData.choiceLock && pokemon.abilityData.choiceLock !== move.id) {
 				// Fails unless ability is being ignored (these events will not run), no PP lost.
 				this.addMove('move', pokemon, move.name);
@@ -1258,7 +1258,7 @@ export const BattleAbilities: {[abilityid: string]: AbilityData} = {
 			}
 		},
 		onModifyMove(move, pokemon) {
-			if (pokemon.abilityData.choiceLock || move.isZPowered || move.isMaxPowered || move.id === 'struggle') return;
+			if (pokemon.abilityData.choiceLock || move.isZOrMaxPowered || move.isZOrMaxPowered || move.id === 'struggle') return;
 			pokemon.abilityData.choiceLock = move.id;
 		},
 		onModifyAtkPriority: 1,

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -1247,7 +1247,7 @@ export const BattleAbilities: {[abilityid: string]: AbilityData} = {
 			pokemon.abilityData.choiceLock = "";
 		},
 		onBeforeMove(pokemon, target, move) {
-			if (move.isZPowered || move.maxPowered || move.id === 'struggle') return;
+			if (move.isZPowered || move.isMaxPowered || move.id === 'struggle') return;
 			if (pokemon.abilityData.choiceLock && pokemon.abilityData.choiceLock !== move.id) {
 				// Fails unless ability is being ignored (these events will not run), no PP lost.
 				this.addMove('move', pokemon, move.name);
@@ -1258,7 +1258,7 @@ export const BattleAbilities: {[abilityid: string]: AbilityData} = {
 			}
 		},
 		onModifyMove(move, pokemon) {
-			if (pokemon.abilityData.choiceLock || move.isZPowered || move.maxPowered || move.id === 'struggle') return;
+			if (pokemon.abilityData.choiceLock || move.isZPowered || move.isMaxPowered || move.id === 'struggle') return;
 			pokemon.abilityData.choiceLock = move.id;
 		},
 		onModifyAtkPriority: 1,

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -1247,7 +1247,7 @@ export const BattleAbilities: {[abilityid: string]: AbilityData} = {
 			pokemon.abilityData.choiceLock = "";
 		},
 		onBeforeMove(pokemon, target, move) {
-			if (move.isZOrMaxPowered || move.isZOrMaxPowered || move.id === 'struggle') return;
+			if (move.isZOrMaxPowered || move.id === 'struggle') return;
 			if (pokemon.abilityData.choiceLock && pokemon.abilityData.choiceLock !== move.id) {
 				// Fails unless ability is being ignored (these events will not run), no PP lost.
 				this.addMove('move', pokemon, move.name);
@@ -1258,7 +1258,7 @@ export const BattleAbilities: {[abilityid: string]: AbilityData} = {
 			}
 		},
 		onModifyMove(move, pokemon) {
-			if (pokemon.abilityData.choiceLock || move.isZOrMaxPowered || move.isZOrMaxPowered || move.id === 'struggle') return;
+			if (pokemon.abilityData.choiceLock || move.isZOrMaxPowered || move.id === 'struggle') return;
 			pokemon.abilityData.choiceLock = move.id;
 		},
 		onModifyAtkPriority: 1,

--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -616,7 +616,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 				return this.NOT_FAIL;
 			},
 			onHit(target, source, move) {
-				if (move.isZPowered && move.flags['contact']) {
+				if (move.isZOrMaxPowered && move.flags['contact']) {
 					this.boost({atk: -2}, source, target, this.dex.getActiveMove("King's Shield"));
 				}
 			},

--- a/data/mods/ssb/moves.ts
+++ b/data/mods/ssb/moves.ts
@@ -3456,7 +3456,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 				return null;
 			},
 			onHit(target, source, move) {
-				if (move.isZPowered && move.flags['contact']) {
+				if (move.isZOrMaxPowered && move.flags['contact']) {
 					this.heal(target.baseMaxhp / 4, target, target);
 				}
 			},

--- a/data/mods/ssb/moves.ts
+++ b/data/mods/ssb/moves.ts
@@ -25,8 +25,8 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		// Other useful things
 		noPPBoosts: true, // add this to not boost the PP of a move, not needed for Z moves, dont include it otherwise
 		isZ: "crystalname", // marks a move as a z move, list the crystal name inside
-		zMoveEffect: '', // for status moves, what happens when this is used as a Z move? check data/moves.js for examples
-		zMoveBoost: {atk: 2}, // for status moves, stat boost given when used as a z move
+		zMove: {effect: '', // for status moves}, what happens when this is used as a Z move? check data/moves.js for examples
+		zMove: {boost: {atk: 2}, // for status moves}, stat boost given when used as a z move
 		critRatio: 2, // The higher the number (above 1) the higher the ratio, lowering it lowers the crit ratio
 		drain: [1, 2], // recover first num / second num % of the damage dealt
 		heal: [1, 2], // recover first num / second num % of the target's HP
@@ -132,7 +132,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		},
 		target: "normal",
 		type: "Electric",
-		zMovePower: 200,
+		zMove: {basePower: 200},
 	},
 	// Aeonic
 	shitpost: {
@@ -1372,7 +1372,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Ground",
-		zMoveEffect: 'healhalf',
+		zMove: {effect: 'healhalf'},
 	},
 	// E4 Flint
 	fangofthefireking: {
@@ -1471,7 +1471,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Fighting",
-		zMovePower: 175,
+		zMove: {basePower: 175},
 	},
 	// eternally
 	quack: {
@@ -1952,7 +1952,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		secondary: null,
 		target: "foeSide",
 		type: "Normal",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 	},
 	// HoeenHero
 	scriptedterrain: {
@@ -2641,7 +2641,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		},
 		target: "normal",
 		type: "Fire",
-		zMovePower: 160,
+		zMove: {basePower: 160},
 	},
 	// MacChaeger
 	naptime: {
@@ -2697,7 +2697,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		},
 		target: "self",
 		type: "Fairy",
-		zMoveEffect: 'clearnegativeboosts',
+		zMove: {effect: 'clearnegativeboosts'},
 	},
 	// Mad Monty ¾°
 	llamacide: {
@@ -2894,7 +2894,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveEffect: 'heal',
+		zMove: {effect: 'heal'},
 	},
 	// Meicoo
 	scavengesu: {
@@ -3126,7 +3126,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Water",
-		zMoveEffect: "boostreplacement",
+		zMove: {effect: "boostreplacement"},
 	},
 	// OM
 	omboom: {
@@ -4256,7 +4256,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Steel",
-		zMovePower: 160,
+		zMove: {basePower: 160},
 		contestType: "Cool",
 	},
 	// Tony
@@ -4475,7 +4475,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 				status: 'par',
 			},
 		],
-		zMovePower: 175,
+		zMove: {basePower: 175},
 		target: "normal",
 		type: "Flying",
 	},

--- a/data/mods/ssb/moves.ts
+++ b/data/mods/ssb/moves.ts
@@ -25,8 +25,8 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		// Other useful things
 		noPPBoosts: true, // add this to not boost the PP of a move, not needed for Z moves, dont include it otherwise
 		isZ: "crystalname", // marks a move as a z move, list the crystal name inside
-		zMove: {effect: '', // for status moves}, what happens when this is used as a Z move? check data/moves.js for examples
-		zMove: {boost: {atk: 2}, // for status moves}, stat boost given when used as a z move
+		zMove: {effect: ''}, // for status moves, what happens when this is used as a Z move? check data/moves.js for examples
+		zMove: {boost: {atk: 2}}, // for status moves, stat boost given when used as a z move
 		critRatio: 2, // The higher the number (above 1) the higher the ratio, lowering it lowers the crit ratio
 		drain: [1, 2], // recover first num / second num % of the damage dealt
 		heal: [1, 2], // recover first num / second num % of the target's HP

--- a/data/mods/ssb/scripts.ts
+++ b/data/mods/ssb/scripts.ts
@@ -190,7 +190,7 @@ export const BattleScripts: ModdedBattleScriptsData = {
 				zMove = this.dex.getActiveMove(item.zMove as string);
 				// Hack for Snaquaza's Z move
 				zMove.baseMove = move.id;
-				zMove.isZPowered = true;
+				zMove.isZOrMaxPowered = true;
 				return zMove;
 			}
 		}
@@ -198,13 +198,13 @@ export const BattleScripts: ModdedBattleScriptsData = {
 		if (move.category === 'Status') {
 			zMove = this.dex.getActiveMove(move);
 			zMove.isZ = true;
-			zMove.isZPowered = true;
+			zMove.isZOrMaxPowered = true;
 			return zMove;
 		}
 		zMove = this.dex.getActiveMove(this.zMoveTable[move.type]);
 		zMove.basePower = move.zMove!.basePower!;
 		zMove.category = move.category;
-		zMove.isZPowered = true;
+		zMove.isZOrMaxPowered = true;
 		return zMove;
 	},
 	// Modded to allow each Pokemon on a team to use a Z move once per battle
@@ -361,7 +361,7 @@ export const BattleScripts: ModdedBattleScriptsData = {
 		// Final modifier. Modifiers that modify damage after min damage check, such as Life Orb.
 		baseDamage = this.runEvent('ModifyDamage', pokemon, target, move, baseDamage);
 
-		if ((move.isZPowered || move.isMax) && target.getMoveHitData(move).zBrokeProtect) {
+		if ((move.isZOrMaxPowered || move.isMax) && target.getMoveHitData(move).zBrokeProtect) {
 			baseDamage = this.modify(baseDamage, 0.25);
 			this.add('-zbroken', target);
 		}

--- a/data/mods/ssb/scripts.ts
+++ b/data/mods/ssb/scripts.ts
@@ -202,7 +202,7 @@ export const BattleScripts: ModdedBattleScriptsData = {
 			return zMove;
 		}
 		zMove = this.dex.getActiveMove(this.zMoveTable[move.type]);
-		zMove.basePower = move.zMove?.basePower;
+		zMove.basePower = move.zMove!.basePower;
 		zMove.category = move.category;
 		zMove.isZPowered = true;
 		return zMove;

--- a/data/mods/ssb/scripts.ts
+++ b/data/mods/ssb/scripts.ts
@@ -202,7 +202,7 @@ export const BattleScripts: ModdedBattleScriptsData = {
 			return zMove;
 		}
 		zMove = this.dex.getActiveMove(this.zMoveTable[move.type]);
-		zMove.basePower = move.zMove!.basePower;
+		zMove.basePower = move.zMove!.basePower!;
 		zMove.category = move.category;
 		zMove.isZPowered = true;
 		return zMove;

--- a/data/mods/ssb/scripts.ts
+++ b/data/mods/ssb/scripts.ts
@@ -175,7 +175,7 @@ export const BattleScripts: ModdedBattleScriptsData = {
 			if (move.type === item.zMoveType) {
 				if (move.category === "Status") {
 					return move.name;
-				} else if (move.zMovePower) {
+				} else if (move.zMove?.basePower) {
 					return this.zMoveTable[move.type];
 				}
 			}
@@ -203,7 +203,7 @@ export const BattleScripts: ModdedBattleScriptsData = {
 		}
 		zMove = this.dex.getActiveMove(this.zMoveTable[move.type]);
 		// @ts-ignore
-		zMove.basePower = move.zMovePower;
+		zMove.basePower = move.zMove?.basePower;
 		zMove.category = move.category;
 		zMove.isZPowered = true;
 		return zMove;
@@ -247,10 +247,10 @@ export const BattleScripts: ModdedBattleScriptsData = {
 		const zPower = this.dex.getEffect('zpower');
 		if (move.category !== 'Status') {
 			this.attrLastMove('[zeffect]');
-		} else if (move.zMoveBoost) {
-			this.boost(move.zMoveBoost, pokemon, pokemon, zPower);
+		} else if (move.zMove?.boost) {
+			this.boost(move.zMove.boost, pokemon, pokemon, zPower);
 		} else {
-			switch (move.zMoveEffect) {
+			switch (move.zMove?.effect) {
 			case 'heal':
 				this.heal(pokemon.maxhp, pokemon, pokemon, zPower);
 				break;

--- a/data/mods/ssb/scripts.ts
+++ b/data/mods/ssb/scripts.ts
@@ -202,7 +202,6 @@ export const BattleScripts: ModdedBattleScriptsData = {
 			return zMove;
 		}
 		zMove = this.dex.getActiveMove(this.zMoveTable[move.type]);
-		// @ts-ignore
 		zMove.basePower = move.zMove?.basePower;
 		zMove.category = move.category;
 		zMove.isZPowered = true;

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -1031,7 +1031,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 				return this.NOT_FAIL;
 			},
 			onHit(target, source, move) {
-				if (move.isZPowered && move.flags['contact']) {
+				if (move.isZOrMaxPowered && move.flags['contact']) {
 					source.trySetStatus('psn', target);
 				}
 			},
@@ -2697,7 +2697,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 			let move: Move | ActiveMove | null = this.lastMove;
 			if (!move) return;
 
-			if ((move as ActiveMove).isMaxPowered) move = this.dex.getMove(move.baseMove);
+			if ((move as ActiveMove).isZOrMaxPowered) move = this.dex.getMove(move.baseMove);
 			if (noCopycat.includes(move.id) || move.isZ || move.isMax) {
 				return false;
 			}
@@ -4550,7 +4550,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 				let move: Move | ActiveMove | null = target.lastMove;
 				if (!move || target.volatiles['dynamax']) return false;
 
-				if ((move as ActiveMove).isMaxPowered) move = this.dex.getMove(move.baseMove);
+				if ((move as ActiveMove).isZOrMaxPowered) move = this.dex.getMove(move.baseMove);
 				const moveIndex = target.moves.indexOf(move.id);
 				if (move.isZ || noEncore.includes(move.id) || !target.moveSlots[moveIndex] || target.moveSlots[moveIndex].pp <= 0) {
 					// it failed
@@ -9743,7 +9743,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 				return this.NOT_FAIL;
 			},
 			onHit(target, source, move) {
-				if (move.isZPowered && move.flags['contact']) {
+				if (move.isZOrMaxPowered && move.flags['contact']) {
 					this.boost({atk: -1}, source, target, this.dex.getActiveMove("King's Shield"));
 				}
 			},
@@ -12737,7 +12737,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 				return this.NOT_FAIL;
 			},
 			onHit(target, source, move) {
-				if (move.isZPowered && move.flags['contact']) {
+				if (move.isZOrMaxPowered && move.flags['contact']) {
 					this.boost({def: -2}, source, target, this.dex.getActiveMove("Obstruct"));
 				}
 			},
@@ -17396,7 +17396,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 				return this.NOT_FAIL;
 			},
 			onHit(target, source, move) {
-				if (move.isZPowered && move.flags['contact']) {
+				if (move.isZOrMaxPowered && move.flags['contact']) {
 					this.damage(source.baseMaxhp / 8, source, target);
 				}
 			},

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -119,7 +119,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Poison",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Tough",
 	},
 	aciddownpour: {
@@ -214,7 +214,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "adjacentAllyOrSelf",
 		type: "Normal",
-		zMoveEffect: 'crit2',
+		zMove: {effect: 'crit2'},
 		contestType: "Tough",
 	},
 	aerialace: {
@@ -276,7 +276,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Cute",
 	},
 	agility: {
@@ -297,7 +297,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Psychic",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Cool",
 	},
 	aircutter: {
@@ -378,7 +378,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Psychic",
-		zMoveBoost: {spe: 2},
+		zMove: {boost: {spe: 2}},
 		contestType: "Clever",
 	},
 	amnesia: {
@@ -398,7 +398,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Psychic",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Cute",
 	},
 	anchorshot: {
@@ -511,7 +511,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Water",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Beautiful",
 	},
 	aquatail: {
@@ -573,7 +573,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		},
 		target: "allyTeam",
 		type: "Grass",
-		zMoveEffect: 'heal',
+		zMove: {effect: 'heal'},
 		contestType: "Clever",
 	},
 	aromaticmist: {
@@ -593,7 +593,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "adjacentAlly",
 		type: "Fairy",
-		zMoveBoost: {spd: 2},
+		zMove: {boost: {spd: 2}},
 		contestType: "Beautiful",
 	},
 	assist: {
@@ -751,7 +751,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Cute",
 	},
 	aurasphere: {
@@ -878,7 +878,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allySide",
 		type: "Ice",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Beautiful",
 	},
 	autotomize: {
@@ -911,7 +911,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Steel",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Beautiful",
 	},
 	avalanche: {
@@ -958,7 +958,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Fairy",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Cute",
 	},
 	baddybad: {
@@ -1039,7 +1039,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Poison",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Tough",
 	},
 	barrage: {
@@ -1078,7 +1078,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Psychic",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Cool",
 	},
 	batonpass: {
@@ -1097,7 +1097,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Cute",
 	},
 	beakblast: {
@@ -1226,7 +1226,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveEffect: 'heal',
+		zMove: {effect: 'heal'},
 		contestType: "Cute",
 	},
 	bestow: {
@@ -1256,7 +1256,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {spe: 2},
+		zMove: {boost: {spe: 2}},
 		contestType: "Cute",
 	},
 	bide: {
@@ -1467,7 +1467,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Cute",
 	},
 	bloomdoom: {
@@ -1625,7 +1625,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Ground",
-		gmaxPower: 130,
+		maxMove: {basePower: 130},
 		contestType: "Tough",
 	},
 	bonerush: {
@@ -1643,8 +1643,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Ground",
-		zMovePower: 140,
-		gmaxPower: 130,
+		zMove: {basePower: 140},
+		maxMove: {basePower: 130},
 		contestType: "Tough",
 	},
 	boomburst: {
@@ -1970,7 +1970,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Fighting",
-		zMoveBoost: {atk: 1},
+		zMove: {boost: {atk: 1}},
 		contestType: "Cool",
 	},
 	bulldoze: {
@@ -2027,8 +2027,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Grass",
-		zMovePower: 140,
-		gmaxPower: 130,
+		zMove: {basePower: 140},
+		maxMove: {basePower: 130},
 		contestType: "Cool",
 	},
 	burnup: {
@@ -2099,7 +2099,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Psychic",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Clever",
 	},
 	camouflage: {
@@ -2132,7 +2132,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveBoost: {evasion: 1},
+		zMove: {boost: {evasion: 1}},
 		contestType: "Clever",
 	},
 	captivate: {
@@ -2156,7 +2156,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allAdjacentFoes",
 		type: "Normal",
-		zMoveBoost: {spd: 2},
+		zMove: {boost: {spd: 2}},
 		contestType: "Cute",
 	},
 	catastropika: {
@@ -2193,7 +2193,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveBoost: {atk: 1, def: 1, spa: 1, spd: 1, spe: 1},
+		zMove: {boost: {atk: 1, def: 1, spa: 1, spd: 1, spe: 1}},
 		contestType: "Cute",
 	},
 	charge: {
@@ -2230,7 +2230,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Electric",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Clever",
 	},
 	chargebeam: {
@@ -2273,7 +2273,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Fairy",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Cute",
 	},
 	chatter: {
@@ -2499,7 +2499,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Poison",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Tough",
 	},
 	cometpunch: {
@@ -2518,7 +2518,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		gmaxPower: 100,
+		maxMove: {basePower: 100},
 		contestType: "Tough",
 	},
 	confide: {
@@ -2538,7 +2538,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Cute",
 	},
 	confuseray: {
@@ -2556,7 +2556,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Ghost",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Clever",
 	},
 	confusion: {
@@ -2637,7 +2637,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveBoost: {atk: 1, def: 1, spa: 1, spd: 1, spe: 1},
+		zMove: {boost: {atk: 1, def: 1, spa: 1, spd: 1, spe: 1}},
 		contestType: "Beautiful",
 	},
 	conversion2: {
@@ -2676,7 +2676,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveEffect: 'heal',
+		zMove: {effect: 'heal'},
 		contestType: "Beautiful",
 	},
 	copycat: {
@@ -2694,10 +2694,10 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 			const noCopycat = [
 				'assist', 'banefulbunker', 'beakblast', 'belch', 'bestow', 'celebrate', 'chatter', 'circlethrow', 'copycat', 'counter', 'covet', 'craftyshield', 'destinybond', 'detect', 'dragontail', 'dynamaxcannon', 'endure', 'feint', 'focuspunch', 'followme', 'helpinghand', 'holdhands', 'kingsshield', 'matblock', 'mefirst', 'metronome', 'mimic', 'mirrorcoat', 'mirrormove', 'naturepower', 'obstruct', 'protect', 'ragepowder', 'roar', 'shelltrap', 'sketch', 'sleeptalk', 'snatch', 'spikyshield', 'spotlight', 'struggle', 'switcheroo', 'thief', 'transform', 'trick', 'whirlwind',
 			];
-			let move = this.lastMove;
+			let move: Move | ActiveMove | null = this.lastMove;
 			if (!move) return;
 
-			if (move.maxPowered) move = this.dex.getMove(move.baseMove);
+			if ((move as ActiveMove).isMaxPowered) move = this.dex.getMove(move.baseMove);
 			if (noCopycat.includes(move.id) || move.isZ || move.isMax) {
 				return false;
 			}
@@ -2706,7 +2706,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveBoost: {accuracy: 1},
+		zMove: {boost: {accuracy: 1}},
 		contestType: "Cute",
 	},
 	coreenforcer: {
@@ -2741,7 +2741,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allAdjacentFoes",
 		type: "Dragon",
-		zMovePower: 140,
+		zMove: {basePower: 140},
 		contestType: "Tough",
 	},
 	corkscrewcrash: {
@@ -2779,7 +2779,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Psychic",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Beautiful",
 	},
 	cottonguard: {
@@ -2800,7 +2800,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Grass",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Cute",
 	},
 	cottonspore: {
@@ -2820,7 +2820,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allAdjacentFoes",
 		type: "Grass",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Beautiful",
 	},
 	counter: {
@@ -2867,7 +2867,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "scripted",
 		type: "Fighting",
-		gmaxPower: 75,
+		maxMove: {basePower: 75},
 		contestType: "Tough",
 	},
 	courtchange: {
@@ -3006,7 +3006,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allySide",
 		type: "Fairy",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Clever",
 	},
 	crosschop: {
@@ -3108,8 +3108,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMovePower: 190,
-		gmaxPower: 140,
+		zMove: {basePower: 190},
+		maxMove: {basePower: 140},
 		contestType: "Tough",
 	},
 	curse: {
@@ -3154,7 +3154,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		target: "normal",
 		nonGhostTarget: "self",
 		type: "Ghost",
-		zMoveEffect: 'curse',
+		zMove: {effect: 'curse'},
 		contestType: "Tough",
 	},
 	cut: {
@@ -3235,7 +3235,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allAdjacentFoes",
 		type: "Dark",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Clever",
 	},
 	dazzlinggleam: {
@@ -3292,7 +3292,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Bug",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Clever",
 	},
 	defensecurl: {
@@ -3316,7 +3316,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveBoost: {accuracy: 1},
+		zMove: {boost: {accuracy: 1}},
 		contestType: "Cute",
 	},
 	defog: {
@@ -3359,7 +3359,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Flying",
-		zMoveBoost: {accuracy: 1},
+		zMove: {boost: {accuracy: 1}},
 		contestType: "Cool",
 	},
 	destinybond: {
@@ -3406,7 +3406,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Ghost",
-		zMoveEffect: 'redirect',
+		zMove: {effect: 'redirect'},
 		contestType: "Clever",
 	},
 	detect: {
@@ -3432,7 +3432,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Fighting",
-		zMoveBoost: {evasion: 1},
+		zMove: {boost: {evasion: 1}},
 		contestType: "Cool",
 	},
 	devastatingdrake: {
@@ -3595,7 +3595,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Clever",
 	},
 	disarmingvoice: {
@@ -3773,8 +3773,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMovePower: 140,
-		gmaxPower: 120,
+		zMove: {basePower: 140},
+		maxMove: {basePower: 120},
 		contestType: "Cool",
 	},
 	doubleironbash: {
@@ -3796,8 +3796,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		},
 		target: "normal",
 		type: "Steel",
-		zMovePower: 180,
-		gmaxPower: 140,
+		zMove: {basePower: 180},
+		maxMove: {basePower: 140},
 		contestType: "Clever",
 	},
 	doublekick: {
@@ -3815,7 +3815,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Fighting",
-		gmaxPower: 80,
+		maxMove: {basePower: 80},
 		contestType: "Cool",
 	},
 	doubleslap: {
@@ -3853,7 +3853,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Cool",
 	},
 	dracometeor: {
@@ -3955,7 +3955,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Dragon",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Cool",
 	},
 	dragondarts: {
@@ -3974,7 +3974,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Dragon",
-		gmaxPower: 130,
+		maxMove: {basePower: 130},
 	},
 	dragonhammer: {
 		num: 692,
@@ -4186,7 +4186,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Dragon",
-		gmaxPower: 130,
+		maxMove: {basePower: 130},
 		contestType: "Tough",
 	},
 	dynamaxcannon: {
@@ -4318,7 +4318,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Electric",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Clever",
 	},
 	eggbomb: {
@@ -4395,7 +4395,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Electric",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Clever",
 	},
 	electrify: {
@@ -4429,7 +4429,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Electric",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Clever",
 	},
 	electroball: {
@@ -4453,8 +4453,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Electric",
-		zMovePower: 160,
-		gmaxPower: 130,
+		zMove: {basePower: 160},
+		maxMove: {basePower: 130},
 		contestType: "Cool",
 	},
 	electroweb: {
@@ -4505,7 +4505,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Dark",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Clever",
 	},
 	ember: {
@@ -4547,10 +4547,10 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 				const noEncore = [
 					'assist', 'copycat', 'encore', 'mefirst', 'metronome', 'mimic', 'mirrormove', 'naturepower', 'sketch', 'sleeptalk', 'struggle', 'transform',
 				];
-				let move = target.lastMove;
+				let move: Move | ActiveMove | null = target.lastMove;
 				if (!move || target.volatiles['dynamax']) return false;
 
-				if (move.maxPowered) move = this.dex.getMove(move.baseMove);
+				if ((move as ActiveMove).isMaxPowered) move = this.dex.getMove(move.baseMove);
 				const moveIndex = target.moves.indexOf(move.id);
 				if (move.isZ || noEncore.includes(move.id) || !target.moveSlots[moveIndex] || target.moveSlots[moveIndex].pp <= 0) {
 					// it failed
@@ -4590,7 +4590,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Cute",
 	},
 	endeavor: {
@@ -4614,8 +4614,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMovePower: 160,
-		gmaxPower: 130,
+		zMove: {basePower: 160},
+		maxMove: {basePower: 130},
 		contestType: "Tough",
 	},
 	endure: {
@@ -4653,7 +4653,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Tough",
 	},
 	energyball: {
@@ -4715,7 +4715,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Cute",
 	},
 	eruption: {
@@ -4883,7 +4883,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Fairy",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Clever",
 	},
 	fairywind: {
@@ -4946,7 +4946,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Dark",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Cute",
 	},
 	falsesurrender: {
@@ -4998,7 +4998,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Flying",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Beautiful",
 	},
 	feint: {
@@ -5099,7 +5099,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Fighting",
-		zMovePower: 180,
+		zMove: {basePower: 180},
 		contestType: "Tough",
 	},
 	fireblast: {
@@ -5347,8 +5347,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Ground",
-		zMovePower: 180,
-		gmaxPower: 130,
+		zMove: {basePower: 180},
+		maxMove: {basePower: 130},
 		contestType: "Tough",
 	},
 	flail: {
@@ -5384,8 +5384,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMovePower: 160,
-		gmaxPower: 130,
+		zMove: {basePower: 160},
+		maxMove: {basePower: 130},
 		contestType: "Cute",
 	},
 	flameburst: {
@@ -5527,7 +5527,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {evasion: 1},
+		zMove: {boost: {evasion: 1}},
 		contestType: "Beautiful",
 	},
 	flashcannon: {
@@ -5570,7 +5570,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Dark",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Clever",
 	},
 	fleurcannon: {
@@ -5690,7 +5690,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Fairy",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Beautiful",
 	},
 	flowershield: {
@@ -5721,7 +5721,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Fairy",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Beautiful",
 	},
 	fly: {
@@ -5782,7 +5782,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "any",
 		type: "Fighting",
-		zMovePower: 170,
+		zMove: {basePower: 170},
 		contestType: "Tough",
 	},
 	focusblast: {
@@ -5836,7 +5836,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveBoost: {accuracy: 1},
+		zMove: {boost: {accuracy: 1}},
 		contestType: "Cool",
 	},
 	focuspunch: {
@@ -5912,7 +5912,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Cute",
 	},
 	forcepalm: {
@@ -5967,7 +5967,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveEffect: 'crit2',
+		zMove: {effect: 'crit2'},
 		contestType: "Clever",
 	},
 	forestscurse: {
@@ -5989,7 +5989,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Grass",
-		zMoveBoost: {atk: 1, def: 1, spa: 1, spd: 1, spe: 1},
+		zMove: {boost: {atk: 1, def: 1, spa: 1, spd: 1, spe: 1}},
 		contestType: "Clever",
 	},
 	foulplay: {
@@ -6142,8 +6142,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMovePower: 160,
-		gmaxPower: 130,
+		zMove: {basePower: 160},
+		maxMove: {basePower: 130},
 		contestType: "Cute",
 	},
 	furyattack: {
@@ -6212,7 +6212,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		gmaxPower: 100,
+		maxMove: {basePower: 100},
 		contestType: "Tough",
 	},
 	fusionbolt: {
@@ -6332,7 +6332,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Poison",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Tough",
 	},
 	geargrind: {
@@ -6351,8 +6351,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Steel",
-		zMovePower: 180,
-		gmaxPower: 130,
+		zMove: {basePower: 180},
+		maxMove: {basePower: 130},
 		contestType: "Clever",
 	},
 	gearup: {
@@ -6383,7 +6383,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allySide",
 		type: "Steel",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Clever",
 	},
 	genesissupernova: {
@@ -6443,7 +6443,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Fairy",
-		zMoveBoost: {atk: 1, def: 1, spa: 1, spd: 1, spe: 1},
+		zMove: {boost: {atk: 1, def: 1, spa: 1, spd: 1, spe: 1}},
 		contestType: "Beautiful",
 	},
 	gigadrain: {
@@ -6537,7 +6537,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Tough",
 	},
 	glitzyglow: {
@@ -7332,8 +7332,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Grass",
-		zMovePower: 160,
-		gmaxPower: 130,
+		zMove: {basePower: 160},
+		maxMove: {basePower: 130},
 		contestType: "Cute",
 	},
 	grasspledge: {
@@ -7417,7 +7417,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Grass",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Clever",
 	},
 	grassyterrain: {
@@ -7478,7 +7478,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Grass",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Beautiful",
 	},
 	gravapple: {
@@ -7584,7 +7584,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Psychic",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Clever",
 	},
 	growl: {
@@ -7604,7 +7604,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allAdjacentFoes",
 		type: "Normal",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Cute",
 	},
 	growth: {
@@ -7628,7 +7628,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Beautiful",
 	},
 	grudge: {
@@ -7667,7 +7667,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Ghost",
-		zMoveEffect: 'redirect',
+		zMove: {effect: 'redirect'},
 		contestType: "Tough",
 	},
 	guardianofalola: {
@@ -7722,7 +7722,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Psychic",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Clever",
 	},
 	guardswap: {
@@ -7754,7 +7754,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Psychic",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Clever",
 	},
 	guillotine: {
@@ -7772,8 +7772,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMovePower: 180,
-		gmaxPower: 130,
+		zMove: {basePower: 180},
+		maxMove: {basePower: 130},
 		contestType: "Cool",
 	},
 	gunkshot: {
@@ -7834,8 +7834,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Steel",
-		zMovePower: 160,
-		gmaxPower: 130,
+		zMove: {basePower: 160},
+		maxMove: {basePower: 130},
 		contestType: "Cool",
 	},
 	hail: {
@@ -7853,7 +7853,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Ice",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Beautiful",
 	},
 	hammerarm: {
@@ -7894,7 +7894,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allySide",
 		type: "Normal",
-		zMoveBoost: {atk: 1, def: 1, spa: 1, spd: 1, spe: 1},
+		zMove: {boost: {atk: 1, def: 1, spa: 1, spd: 1, spe: 1}},
 		contestType: "Cute",
 	},
 	harden: {
@@ -7914,7 +7914,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Tough",
 	},
 	haze: {
@@ -7938,7 +7938,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Ice",
-		zMoveEffect: 'heal',
+		zMove: {effect: 'heal'},
 		contestType: "Beautiful",
 	},
 	headbutt: {
@@ -8021,7 +8021,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		},
 		target: "allyTeam",
 		type: "Normal",
-		zMoveEffect: 'heal',
+		zMove: {effect: 'heal'},
 		contestType: "Beautiful",
 	},
 	healblock: {
@@ -8075,7 +8075,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allAdjacentFoes",
 		type: "Psychic",
-		zMoveBoost: {spa: 2},
+		zMove: {boost: {spa: 2}},
 		contestType: "Clever",
 	},
 	healingwish: {
@@ -8130,7 +8130,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Bug",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Clever",
 	},
 	healpulse: {
@@ -8159,7 +8159,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "any",
 		type: "Psychic",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Beautiful",
 	},
 	heartstamp: {
@@ -8212,7 +8212,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Psychic",
-		zMoveEffect: 'crit2',
+		zMove: {effect: 'crit2'},
 		contestType: "Clever",
 	},
 	heatcrash: {
@@ -8253,8 +8253,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Fire",
-		zMovePower: 160,
-		gmaxPower: 130,
+		zMove: {basePower: 160},
+		maxMove: {basePower: 130},
 		contestType: "Tough",
 	},
 	heatwave: {
@@ -8316,8 +8316,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Steel",
-		zMovePower: 160,
-		gmaxPower: 130,
+		zMove: {basePower: 160},
+		maxMove: {basePower: 130},
 		contestType: "Tough",
 	},
 	helpinghand: {
@@ -8354,7 +8354,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "adjacentAlly",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Clever",
 	},
 	hex: {
@@ -8376,7 +8376,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Ghost",
-		zMovePower: 160,
+		zMove: {basePower: 160},
 		contestType: "Clever",
 	},
 	hiddenpower: {
@@ -8760,7 +8760,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "adjacentAlly",
 		type: "Normal",
-		zMoveBoost: {atk: 1, def: 1, spa: 1, spd: 1, spe: 1},
+		zMove: {boost: {atk: 1, def: 1, spa: 1, spd: 1, spe: 1}},
 		contestType: "Cute",
 	},
 	honeclaws: {
@@ -8782,7 +8782,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Dark",
-		zMoveBoost: {atk: 1},
+		zMove: {boost: {atk: 1}},
 		contestType: "Cute",
 	},
 	hornattack: {
@@ -8815,8 +8815,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMovePower: 180,
-		gmaxPower: 130,
+		zMove: {basePower: 180},
+		maxMove: {basePower: 130},
 		contestType: "Cool",
 	},
 	hornleech: {
@@ -8854,7 +8854,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allies",
 		type: "Normal",
-		zMoveBoost: {atk: 1},
+		zMove: {boost: {atk: 1}},
 		contestType: "Cool",
 	},
 	hurricane: {
@@ -9065,7 +9065,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Psychic",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Clever",
 	},
 	iceball: {
@@ -9287,8 +9287,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Ice",
-		zMovePower: 140,
-		gmaxPower: 130,
+		zMove: {basePower: 140},
+		maxMove: {basePower: 130},
 		contestType: "Beautiful",
 	},
 	icywind: {
@@ -9348,7 +9348,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		pressureTarget: "foeSide",
 		target: "self",
 		type: "Psychic",
-		zMoveBoost: {spd: 2},
+		zMove: {boost: {spd: 2}},
 		contestType: "Clever",
 	},
 	incinerate: {
@@ -9458,7 +9458,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Grass",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Clever",
 	},
 	instruct: {
@@ -9493,7 +9493,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Psychic",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Clever",
 	},
 	iondeluge: {
@@ -9525,7 +9525,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Electric",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Beautiful",
 	},
 	irondefense: {
@@ -9545,7 +9545,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Steel",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Tough",
 	},
 	ironhead: {
@@ -9691,7 +9691,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Psychic",
-		zMoveBoost: {evasion: 1},
+		zMove: {boost: {evasion: 1}},
 		contestType: "Clever",
 	},
 	kingsshield: {
@@ -9751,7 +9751,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Steel",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Cool",
 	},
 	knockoff: {
@@ -9801,7 +9801,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allAdjacentFoes",
 		type: "Ground",
-		zMovePower: 185,
+		zMove: {basePower: 185},
 		contestType: "Beautiful",
 	},
 	laserfocus: {
@@ -9839,7 +9839,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveBoost: {atk: 1},
+		zMove: {boost: {atk: 1}},
 		contestType: "Cool",
 	},
 	lastresort: {
@@ -10020,7 +10020,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Grass",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Clever",
 	},
 	leer: {
@@ -10040,7 +10040,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allAdjacentFoes",
 		type: "Normal",
-		zMoveBoost: {atk: 1},
+		zMove: {boost: {atk: 1}},
 		contestType: "Cool",
 	},
 	letssnuggleforever: {
@@ -10158,7 +10158,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allySide",
 		type: "Psychic",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Beautiful",
 	},
 	lightthatburnsthesky: {
@@ -10237,7 +10237,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Clever",
 	},
 	lovelykiss: {
@@ -10256,7 +10256,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Beautiful",
 	},
 	lowkick: {
@@ -10300,7 +10300,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Fighting",
-		zMovePower: 160,
+		zMove: {basePower: 160},
 		contestType: "Tough",
 	},
 	lowsweep: {
@@ -10352,7 +10352,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allySide",
 		type: "Normal",
-		zMoveBoost: {evasion: 1},
+		zMove: {boost: {evasion: 1}},
 		contestType: "Cute",
 	},
 	lunardance: {
@@ -10535,7 +10535,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Psychic",
-		zMoveBoost: {spd: 2},
+		zMove: {boost: {spd: 2}},
 		contestType: "Beautiful",
 	},
 	magicpowder: {
@@ -10593,7 +10593,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Psychic",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Clever",
 	},
 	magikarpsrevenge: {
@@ -10700,7 +10700,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allySide",
 		type: "Electric",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Clever",
 	},
 	magnetrise: {
@@ -10732,7 +10732,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Electric",
-		zMoveBoost: {evasion: 1},
+		zMove: {boost: {evasion: 1}},
 		contestType: "Clever",
 	},
 	magnitude: {
@@ -10778,8 +10778,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allAdjacent",
 		type: "Ground",
-		zMovePower: 140,
-		gmaxPower: 140,
+		zMove: {basePower: 140},
+		maxMove: {basePower: 140},
 		contestType: "Tough",
 	},
 	maliciousmoonsault: {
@@ -10846,7 +10846,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allySide",
 		type: "Fighting",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Cool",
 	},
 	maxairstream: {
@@ -11339,7 +11339,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Beautiful",
 	},
 	meditate: {
@@ -11360,7 +11360,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Psychic",
-		zMoveBoost: {atk: 1},
+		zMove: {boost: {atk: 1}},
 		contestType: "Beautiful",
 	},
 	mefirst: {
@@ -11400,7 +11400,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "adjacentFoe",
 		type: "Normal",
-		zMoveBoost: {spe: 2},
+		zMove: {boost: {spe: 2}},
 		contestType: "Clever",
 	},
 	megadrain: {
@@ -11418,7 +11418,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Grass",
-		zMovePower: 120,
+		zMove: {basePower: 120},
 		contestType: "Clever",
 	},
 	megahorn: {
@@ -11487,7 +11487,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Dark",
-		zMoveEffect: 'healreplacement',
+		zMove: {effect: 'healreplacement'},
 		contestType: "Tough",
 	},
 	menacingmoonrazemaelstrom: {
@@ -11596,7 +11596,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Steel",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Clever",
 	},
 	meteorassault: {
@@ -11697,7 +11697,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Cute",
 	},
 	mimic: {
@@ -11736,7 +11736,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {accuracy: 1},
+		zMove: {boost: {accuracy: 1}},
 		contestType: "Cute",
 	},
 	mindblown: {
@@ -11784,7 +11784,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Clever",
 	},
 	minimize: {
@@ -11825,7 +11825,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Cute",
 	},
 	miracleeye: {
@@ -11861,7 +11861,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Psychic",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Clever",
 	},
 	mirrorcoat: {
@@ -11933,7 +11933,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Flying",
-		zMoveBoost: {atk: 2},
+		zMove: {boost: {atk: 2}},
 		contestType: "Clever",
 	},
 	mirrorshot: {
@@ -12000,7 +12000,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allySide",
 		type: "Ice",
-		zMoveEffect: 'heal',
+		zMove: {effect: 'heal'},
 		contestType: "Beautiful",
 	},
 	mistball: {
@@ -12082,7 +12082,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Fairy",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Beautiful",
 	},
 	moonblast: {
@@ -12156,7 +12156,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Fairy",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Beautiful",
 	},
 	morningsun: {
@@ -12190,7 +12190,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Beautiful",
 	},
 	mudbomb: {
@@ -12290,7 +12290,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Ground",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Cute",
 	},
 	muddywater: {
@@ -12333,7 +12333,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMovePower: 185,
+		zMove: {basePower: 185},
 		contestType: "Tough",
 	},
 	mysticalfire: {
@@ -12375,7 +12375,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Dark",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Clever",
 	},
 	naturalgift: {
@@ -12409,8 +12409,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMovePower: 160,
-		gmaxPower: 130,
+		zMove: {basePower: 160},
+		maxMove: {basePower: 130},
 		contestType: "Clever",
 	},
 	naturepower: {
@@ -12551,7 +12551,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Ghost",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Clever",
 	},
 	nightshade: {
@@ -12608,7 +12608,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Tough",
 	},
 	noretreat: {
@@ -12841,7 +12841,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {atk: 1},
+		zMove: {boost: {atk: 1}},
 		contestType: "Clever",
 	},
 	ominouswind: {
@@ -12976,7 +12976,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Clever",
 	},
 	paleowave: {
@@ -13041,7 +13041,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Dark",
-		zMoveEffect: 'healreplacement',
+		zMove: {effect: 'healreplacement'},
 		contestType: "Cool",
 	},
 	payback: {
@@ -13148,7 +13148,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Beautiful",
 	},
 	petalblizzard: {
@@ -13281,8 +13281,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Bug",
-		zMovePower: 140,
-		gmaxPower: 130,
+		zMove: {basePower: 140},
+		maxMove: {basePower: 130},
 		contestType: "Cool",
 	},
 	plasmafists: {
@@ -13320,7 +13320,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Cute",
 	},
 	playrough: {
@@ -13406,7 +13406,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allAdjacentFoes",
 		type: "Poison",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Clever",
 	},
 	poisonjab: {
@@ -13444,7 +13444,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Poison",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Clever",
 	},
 	poisonsting: {
@@ -13557,7 +13557,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Bug",
-		zMoveBoost: {spd: 2},
+		zMove: {boost: {spd: 2}},
 		contestType: "Clever",
 	},
 	powdersnow: {
@@ -13618,7 +13618,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Psychic",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Clever",
 	},
 	powerswap: {
@@ -13650,7 +13650,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Psychic",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Clever",
 	},
 	powertrick: {
@@ -13693,7 +13693,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Psychic",
-		zMoveBoost: {atk: 1},
+		zMove: {boost: {atk: 1}},
 		contestType: "Clever",
 	},
 	powertrip: {
@@ -13713,8 +13713,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Dark",
-		zMovePower: 160,
-		gmaxPower: 130,
+		zMove: {basePower: 160},
+		maxMove: {basePower: 130},
 		contestType: "Clever",
 	},
 	poweruppunch: {
@@ -13870,7 +13870,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Cute",
 	},
 	psybeam: {
@@ -13922,7 +13922,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveEffect: 'heal',
+		zMove: {effect: 'heal'},
 		contestType: "Clever",
 	},
 	psychic: {
@@ -14031,7 +14031,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Psychic",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Clever",
 	},
 	psychoboost: {
@@ -14098,7 +14098,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Psychic",
-		zMoveBoost: {spa: 2},
+		zMove: {boost: {spa: 2}},
 		contestType: "Clever",
 	},
 	psyshock: {
@@ -14195,8 +14195,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Dark",
-		zMovePower: 160,
-		gmaxPower: 130,
+		zMove: {basePower: 160},
+		maxMove: {basePower: 130},
 		contestType: "Cool",
 	},
 	purify: {
@@ -14217,7 +14217,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Poison",
-		zMoveBoost: {atk: 1, def: 1, spa: 1, spd: 1, spe: 1},
+		zMove: {boost: {atk: 1, def: 1, spa: 1, spd: 1, spe: 1}},
 		contestType: "Beautiful",
 	},
 	pursuit: {
@@ -14331,7 +14331,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Dark",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Clever",
 	},
 	quickattack: {
@@ -14397,7 +14397,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allySide",
 		type: "Fighting",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Cool",
 	},
 	quiverdance: {
@@ -14420,7 +14420,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Bug",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Beautiful",
 	},
 	rage: {
@@ -14493,7 +14493,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Bug",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Clever",
 	},
 	raindance: {
@@ -14511,7 +14511,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Water",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Beautiful",
 	},
 	rapidspin: {
@@ -14650,7 +14650,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Clever",
 	},
 	recycle: {
@@ -14674,7 +14674,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveBoost: {spe: 2},
+		zMove: {boost: {spe: 2}},
 		contestType: "Clever",
 	},
 	reflect: {
@@ -14718,7 +14718,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allySide",
 		type: "Psychic",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Clever",
 	},
 	reflecttype: {
@@ -14750,7 +14750,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Clever",
 	},
 	refresh: {
@@ -14773,7 +14773,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveEffect: 'heal',
+		zMove: {effect: 'heal'},
 		contestType: "Cute",
 	},
 	relicsong: {
@@ -14838,7 +14838,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Psychic",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Cute",
 	},
 	retaliate: {
@@ -14882,8 +14882,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMovePower: 160,
-		gmaxPower: 130,
+		zMove: {basePower: 160},
+		maxMove: {basePower: 130},
 		contestType: "Cute",
 	},
 	revelationdance: {
@@ -14968,7 +14968,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Fighting",
-		zMovePower: 160,
+		zMove: {basePower: 160},
 		contestType: "Cool",
 	},
 	roar: {
@@ -14987,7 +14987,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Cool",
 	},
 	roaroftime: {
@@ -15026,8 +15026,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Rock",
-		zMovePower: 140,
-		gmaxPower: 130,
+		zMove: {basePower: 140},
+		maxMove: {basePower: 130},
 		contestType: "Tough",
 	},
 	rockclimb: {
@@ -15068,7 +15068,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Rock",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Tough",
 	},
 	rockslide: {
@@ -15202,7 +15202,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Psychic",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Cute",
 	},
 	rollingkick: {
@@ -15303,7 +15303,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Flying",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Clever",
 	},
 	rototiller: {
@@ -15340,7 +15340,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Ground",
-		zMoveBoost: {atk: 1},
+		zMove: {boost: {atk: 1}},
 		contestType: "Tough",
 	},
 	round: {
@@ -15470,7 +15470,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allySide",
 		type: "Normal",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Beautiful",
 	},
 	sandattack: {
@@ -15490,7 +15490,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Ground",
-		zMoveBoost: {evasion: 1},
+		zMove: {boost: {evasion: 1}},
 		contestType: "Cute",
 	},
 	sandstorm: {
@@ -15508,7 +15508,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Rock",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Tough",
 	},
 	sandtomb: {
@@ -15605,7 +15605,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Tough",
 	},
 	scratch: {
@@ -15640,7 +15640,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {atk: 1},
+		zMove: {boost: {atk: 1}},
 		contestType: "Clever",
 	},
 	searingshot: {
@@ -15805,7 +15805,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Fighting",
-		gmaxPower: 75,
+		maxMove: {basePower: 75},
 		contestType: "Tough",
 	},
 	selfdestruct: {
@@ -15996,7 +15996,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveBoost: {atk: 1},
+		zMove: {boost: {atk: 1}},
 		contestType: "Cute",
 	},
 	shatteredpsyche: {
@@ -16031,8 +16031,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		ohko: 'Ice',
 		target: "normal",
 		type: "Ice",
-		zMovePower: 180,
-		gmaxPower: 130,
+		zMove: {basePower: 180},
+		maxMove: {basePower: 130},
 		contestType: "Beautiful",
 	},
 	shellsmash: {
@@ -16057,7 +16057,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Tough",
 	},
 	shelltrap: {
@@ -16120,7 +16120,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Steel",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Clever",
 	},
 	shockwave: {
@@ -16160,7 +16160,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Ground",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Beautiful",
 	},
 	signalbeam: {
@@ -16242,7 +16242,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Cute",
 	},
 	sing: {
@@ -16259,7 +16259,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Cute",
 	},
 	sinisterarrowraid: {
@@ -16337,7 +16337,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {atk: 1, def: 1, spa: 1, spd: 1, spe: 1},
+		zMove: {boost: {atk: 1, def: 1, spa: 1, spd: 1, spe: 1}},
 		contestType: "Clever",
 	},
 	skillswap: {
@@ -16383,7 +16383,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Psychic",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Clever",
 	},
 	skullbash: {
@@ -16587,7 +16587,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Cute",
 	},
 	slam: {
@@ -16637,7 +16637,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Grass",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Clever",
 	},
 	sleeptalk: {
@@ -16680,7 +16680,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveEffect: 'crit2',
+		zMove: {effect: 'crit2'},
 		contestType: "Cute",
 	},
 	sludge: {
@@ -16865,7 +16865,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {evasion: 1},
+		zMove: {boost: {evasion: 1}},
 		contestType: "Clever",
 	},
 	snaptrap: {
@@ -16939,7 +16939,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		pressureTarget: "foeSide",
 		target: "self",
 		type: "Dark",
-		zMoveBoost: {spe: 2},
+		zMove: {boost: {spe: 2}},
 		contestType: "Clever",
 	},
 	snipeshot: {
@@ -17005,7 +17005,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Water",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Cute",
 	},
 	softboiled: {
@@ -17024,7 +17024,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Cute",
 	},
 	solarbeam: {
@@ -17267,7 +17267,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Psychic",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Clever",
 	},
 	spiderweb: {
@@ -17288,7 +17288,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Bug",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Clever",
 	},
 	spikecannon: {
@@ -17307,7 +17307,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		gmaxPower: 120,
+		maxMove: {basePower: 120},
 		contestType: "Cool",
 	},
 	spikes: {
@@ -17344,7 +17344,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "foeSide",
 		type: "Ground",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Clever",
 	},
 	spikyshield: {
@@ -17404,7 +17404,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Grass",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Tough",
 	},
 	spiritbreak: {
@@ -17501,7 +17501,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Ghost",
-		zMoveEffect: 'heal',
+		zMove: {effect: 'heal'},
 		contestType: "Tough",
 	},
 	splash: {
@@ -17520,7 +17520,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveBoost: {atk: 3},
+		zMove: {boost: {atk: 3}},
 		contestType: "Cute",
 	},
 	splinteredstormshards: {
@@ -17581,7 +17581,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Grass",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Beautiful",
 	},
 	spotlight: {
@@ -17615,7 +17615,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Cute",
 	},
 	stealthrock: {
@@ -17645,7 +17645,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "foeSide",
 		type: "Rock",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Cool",
 	},
 	steameruption: {
@@ -17762,7 +17762,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "foeSide",
 		type: "Bug",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Tough",
 	},
 	stockpile: {
@@ -17818,7 +17818,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveEffect: 'heal',
+		zMove: {effect: 'heal'},
 		contestType: "Tough",
 	},
 	stokedsparksurfer: {
@@ -17917,8 +17917,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Psychic",
-		zMovePower: 160,
-		gmaxPower: 130,
+		zMove: {basePower: 160},
+		maxMove: {basePower: 130},
 		contestType: "Clever",
 	},
 	stormthrow: {
@@ -17994,7 +17994,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Grass",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Cute",
 	},
 	stringshot: {
@@ -18014,7 +18014,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allAdjacentFoes",
 		type: "Bug",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Clever",
 	},
 	struggle: {
@@ -18099,7 +18099,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Grass",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Clever",
 	},
 	submission: {
@@ -18196,7 +18196,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Cute",
 	},
 	subzeroslammer: {
@@ -18257,7 +18257,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Fire",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Beautiful",
 	},
 	sunsteelstrike: {
@@ -18334,7 +18334,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Clever",
 	},
 	supersonicskystrike: {
@@ -18389,7 +18389,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Cute",
 	},
 	swallow: {
@@ -18415,7 +18415,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Tough",
 	},
 	sweetkiss: {
@@ -18432,7 +18432,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Fairy",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Cute",
 	},
 	sweetscent: {
@@ -18452,7 +18452,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allAdjacentFoes",
 		type: "Normal",
-		zMoveBoost: {accuracy: 1},
+		zMove: {boost: {accuracy: 1}},
 		contestType: "Cute",
 	},
 	swift: {
@@ -18519,7 +18519,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Dark",
-		zMoveBoost: {spe: 2},
+		zMove: {boost: {spe: 2}},
 		contestType: "Clever",
 	},
 	swordsdance: {
@@ -18540,7 +18540,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Beautiful",
 	},
 	synchronoise: {
@@ -18594,7 +18594,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Grass",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Clever",
 	},
 	tackle: {
@@ -18631,7 +18631,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Bug",
-		zMoveEffect: 'clearnegativeboost',
+		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Beautiful",
 	},
 	tailslap: {
@@ -18650,8 +18650,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMovePower: 140,
-		gmaxPower: 130,
+		zMove: {basePower: 140},
+		maxMove: {basePower: 130},
 		contestType: "Cute",
 	},
 	tailwhip: {
@@ -18671,7 +18671,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allAdjacentFoes",
 		type: "Normal",
-		zMoveBoost: {atk: 1},
+		zMove: {boost: {atk: 1}},
 		contestType: "Cute",
 	},
 	tailwind: {
@@ -18711,7 +18711,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allySide",
 		type: "Flying",
-		zMoveEffect: 'crit2',
+		zMove: {effect: 'crit2'},
 		contestType: "Cool",
 	},
 	takedown: {
@@ -18804,7 +18804,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Dark",
-		zMoveBoost: {atk: 1},
+		zMove: {boost: {atk: 1}},
 		contestType: "Clever",
 	},
 	tearfullook: {
@@ -18825,7 +18825,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Cute",
 	},
 	teatime: {
@@ -18913,7 +18913,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allAdjacent",
 		type: "Normal",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Cute",
 	},
 	telekinesis: {
@@ -18961,7 +18961,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Psychic",
-		zMoveBoost: {spa: 1},
+		zMove: {boost: {spa: 1}},
 		contestType: "Clever",
 	},
 	teleport: {
@@ -18980,7 +18980,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Psychic",
-		zMoveEffect: 'heal',
+		zMove: {effect: 'heal'},
 		contestType: "Cool",
 	},
 	thief: {
@@ -19041,7 +19041,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allAdjacentFoes",
 		type: "Ground",
-		zMovePower: 180,
+		zMove: {basePower: 180},
 		contestType: "Beautiful",
 	},
 	thousandwaves: {
@@ -19267,7 +19267,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Electric",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Cool",
 	},
 	tickle: {
@@ -19288,7 +19288,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Cute",
 	},
 	topsyturvy: {
@@ -19316,7 +19316,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Dark",
-		zMoveBoost: {atk: 1},
+		zMove: {boost: {atk: 1}},
 		contestType: "Clever",
 	},
 	torment: {
@@ -19350,7 +19350,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Dark",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Tough",
 	},
 	toxic: {
@@ -19370,7 +19370,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Poison",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Clever",
 	},
 	toxicspikes: {
@@ -19414,7 +19414,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "foeSide",
 		type: "Poison",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Clever",
 	},
 	toxicthread: {
@@ -19436,7 +19436,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Poison",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Tough",
 	},
 	transform: {
@@ -19458,7 +19458,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveEffect: 'heal',
+		zMove: {effect: 'heal'},
 		contestType: "Clever",
 	},
 	triattack: {
@@ -19538,7 +19538,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Psychic",
-		zMoveBoost: {spe: 2},
+		zMove: {boost: {spe: 2}},
 		contestType: "Clever",
 	},
 	trickortreat: {
@@ -19568,7 +19568,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Ghost",
-		zMoveBoost: {atk: 1, def: 1, spa: 1, spd: 1, spe: 1},
+		zMove: {boost: {atk: 1, def: 1, spa: 1, spd: 1, spe: 1}},
 		contestType: "Cute",
 	},
 	trickroom: {
@@ -19607,7 +19607,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Psychic",
-		zMoveBoost: {accuracy: 1},
+		zMove: {boost: {accuracy: 1}},
 		contestType: "Clever",
 	},
 	triplekick: {
@@ -19629,8 +19629,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Fighting",
-		zMovePower: 120,
-		gmaxPower: 80,
+		zMove: {basePower: 120},
+		maxMove: {basePower: 80},
 		contestType: "Cool",
 	},
 	tropkick: {
@@ -19687,8 +19687,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMovePower: 160,
-		gmaxPower: 130,
+		zMove: {basePower: 160},
+		maxMove: {basePower: 130},
 		contestType: "Cool",
 	},
 	twineedle: {
@@ -19710,7 +19710,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		},
 		target: "normal",
 		type: "Bug",
-		gmaxPower: 100,
+		maxMove: {basePower: 100},
 		contestType: "Cool",
 	},
 	twinkletackle: {
@@ -19858,7 +19858,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Fire",
-		zMovePower: 220,
+		zMove: {basePower: 220},
 		contestType: "Cool",
 	},
 	veeveevolley: {
@@ -19902,7 +19902,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allAdjacentFoes",
 		type: "Poison",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Clever",
 	},
 	venoshock: {
@@ -20216,7 +20216,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Water",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Cute",
 	},
 	waterspout: {
@@ -20289,8 +20289,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMovePower: 160,
-		gmaxPower: 130,
+		zMove: {basePower: 160},
+		maxMove: {basePower: 130},
 		contestType: "Beautiful",
 	},
 	whirlpool: {
@@ -20326,7 +20326,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Clever",
 	},
 	wideguard: {
@@ -20376,7 +20376,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "allySide",
 		type: "Rock",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Tough",
 	},
 	wildcharge: {
@@ -20413,7 +20413,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Fire",
-		zMoveBoost: {atk: 1},
+		zMove: {boost: {atk: 1}},
 		contestType: "Beautiful",
 	},
 	wingattack: {
@@ -20460,7 +20460,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Cute",
 	},
 	withdraw: {
@@ -20480,7 +20480,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Water",
-		zMoveBoost: {def: 1},
+		zMove: {boost: {def: 1}},
 		contestType: "Cute",
 	},
 	wonderroom: {
@@ -20519,7 +20519,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "all",
 		type: "Psychic",
-		zMoveBoost: {spd: 1},
+		zMove: {boost: {spd: 1}},
 		contestType: "Clever",
 	},
 	woodhammer: {
@@ -20558,7 +20558,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "self",
 		type: "Normal",
-		zMoveBoost: {atk: 1},
+		zMove: {boost: {atk: 1}},
 		contestType: "Tough",
 	},
 	worryseed: {
@@ -20594,7 +20594,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Grass",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Clever",
 	},
 	wrap: {
@@ -20632,8 +20632,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMovePower: 190,
-		gmaxPower: 140,
+		zMove: {basePower: 190},
+		maxMove: {basePower: 140},
 		contestType: "Tough",
 	},
 	xscissor: {
@@ -20684,7 +20684,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		secondary: null,
 		target: "normal",
 		type: "Normal",
-		zMoveBoost: {spe: 1},
+		zMove: {boost: {spe: 1}},
 		contestType: "Cute",
 	},
 	zapcannon: {

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -563,8 +563,8 @@ export const BattleFormats: {[k: string]: FormatsData} = {
 					(move.boosts.spa && move.boosts.spa > 0) || (move.boosts.spd && move.boosts.spd > 0))) {
 					nonSpeedBoosted = true;
 				}
-				if (item.zMove && move.type === item.zMoveType && move.zMoveBoost) {
-					const boosts = move.zMoveBoost;
+				if (item.zMove && move.type === item.zMoveType && move.zMove?.boost) {
+					const boosts = move.zMove.boost;
 					if (boosts.spe && boosts.spe > 0) {
 						if (!speedBoosted) speedBoosted = move.name;
 					}

--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -1123,7 +1123,7 @@ export const BattleScripts: BattleScriptsData = {
 			if (move.type === item.zMoveType) {
 				if (move.category === "Status") {
 					return move.name;
-				} else if (move.zMovePower) {
+				} else if (move.zMove?.basePower) {
 					return this.zMoveTable[move.type];
 				}
 			}
@@ -1148,8 +1148,7 @@ export const BattleScripts: BattleScriptsData = {
 			return zMove;
 		}
 		const zMove = this.dex.getActiveMove(this.zMoveTable[move.type]);
-		// @ts-ignore
-		zMove.basePower = move.zMovePower;
+		zMove.basePower = move.zMove!.basePower!;
 		zMove.category = move.category;
 		// copy the priority for Quick Guard
 		zMove.priority = move.priority;
@@ -1258,12 +1257,12 @@ export const BattleScripts: BattleScriptsData = {
 				const gMaxMove = this.dex.getActiveMove(gMaxSpecies.isGigantamax ? gMaxSpecies.isGigantamax : '');
 				if (gMaxMove.exists && gMaxMove.type === move.type) maxMove = gMaxMove;
 			}
-			if (!move.gmaxPower) throw new Error(`${move.name} doesn't have a gmaxPower`);
-			maxMove.basePower = move.gmaxPower;
+			if (!move.maxMove?.basePower) throw new Error(`${move.name} doesn't have a maxMove basePower`);
+			maxMove.basePower = move.maxMove.basePower;
 			maxMove.category = move.category;
 		}
 		maxMove.baseMove = move.id;
-		maxMove.maxPowered = true;
+		maxMove.isMaxPowered = true;
 		return maxMove;
 	},
 
@@ -1299,10 +1298,10 @@ export const BattleScripts: BattleScriptsData = {
 		const zPower = this.dex.getEffect('zpower');
 		if (move.category !== 'Status') {
 			this.attrLastMove('[zeffect]');
-		} else if (move.zMoveBoost) {
-			this.boost(move.zMoveBoost, pokemon, pokemon, zPower);
-		} else {
-			switch (move.zMoveEffect) {
+		} else if (move.zMove?.boost) {
+			this.boost(move.zMove.boost, pokemon, pokemon, zPower);
+		} else if (move.zMove?.effect) {
+			switch (move.zMove.effect) {
 			case 'heal':
 				this.heal(pokemon.maxhp, pokemon, pokemon, zPower);
 				break;

--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -1136,7 +1136,7 @@ export const BattleScripts: BattleScriptsData = {
 			if (move.name === item.zMoveFrom) {
 				// @ts-ignore
 				const zMove = this.dex.getActiveMove(item.zMove);
-				zMove.isZPowered = true;
+				zMove.isZOrMaxPowered = true;
 				return zMove;
 			}
 		}
@@ -1144,7 +1144,7 @@ export const BattleScripts: BattleScriptsData = {
 		if (move.category === 'Status') {
 			const zMove = this.dex.getActiveMove(move);
 			zMove.isZ = true;
-			zMove.isZPowered = true;
+			zMove.isZOrMaxPowered = true;
 			return zMove;
 		}
 		const zMove = this.dex.getActiveMove(this.zMoveTable[move.type]);
@@ -1152,7 +1152,7 @@ export const BattleScripts: BattleScriptsData = {
 		zMove.category = move.category;
 		// copy the priority for Quick Guard
 		zMove.priority = move.priority;
-		zMove.isZPowered = true;
+		zMove.isZOrMaxPowered = true;
 		return zMove;
 	},
 
@@ -1262,7 +1262,7 @@ export const BattleScripts: BattleScriptsData = {
 			maxMove.category = move.category;
 		}
 		maxMove.baseMove = move.id;
-		maxMove.isMaxPowered = true;
+		maxMove.isZOrMaxPowered = true;
 		return maxMove;
 	},
 

--- a/server/chat-commands/info.js
+++ b/server/chat-commands/info.js
@@ -662,9 +662,9 @@ const commands = {
 					if (dex.gen >= 7) {
 						if (move.gen >= 8 && move.isMax) {
 							// Don't display Z-Power for Max/G-Max moves
-						} else if (move.zMovePower) {
-							details["Z-Power"] = move.zMovePower;
-						} else if (move.zMoveEffect) {
+						} else if (move.zMove && move.zMove.basePower) {
+							details["Z-Power"] = move.zMove.basePower;
+						} else if (move.zMove && move.zMove.effect) {
 							details["Z-Effect"] = {
 								'clearnegativeboost': "Restores negative stat stages to 0",
 								'crit2': "Crit ratio +2",
@@ -672,10 +672,10 @@ const commands = {
 								'curse': "Restores HP 100% if user is Ghost type, otherwise Attack +1",
 								'redirect': "Redirects opposing attacks to user",
 								'healreplacement': "Restores replacement's HP 100%",
-							}[move.zMoveEffect];
-						} else if (move.zMoveBoost) {
+							}[move.zMove.effect];
+						} else if (move.zMove && move.zMove.boost) {
 							details["Z-Effect"] = "";
-							const boost = move.zMoveBoost;
+							const boost = move.zMove.boost;
 							const stats = {atk: 'Attack', def: 'Defense', spa: 'Sp. Atk', spd: 'Sp. Def', spe: 'Speed', accuracy: 'Accuracy', evasion: 'Evasiveness'};
 							for (const i in boost) {
 								details["Z-Effect"] += " " + stats[i] + " +" + boost[i];
@@ -696,8 +696,8 @@ const commands = {
 						if (move.isMax) {
 							details["&#10003; Max Move"] = "";
 							if (typeof move.isMax === "string") details["User"] = move.isMax + "-Gmax";
-						} else if (move.gmaxPower) {
-							details["Dynamax Power"] = move.gmaxPower;
+						} else if (move.maxMove && move.maxMove.basePower) {
+							details["Dynamax Power"] = move.maxMove.basePower;
 						}
 					}
 

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1500,7 +1500,7 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 				if (recoveryType === "recovery") {
 					hasRecovery = !!dex[move].drain || !!dex[move].flags.heal;
 				} else if (recoveryType === "zrecovery") {
-					hasRecovery = (dex[move].zMoveEffect === 'heal');
+					hasRecovery = (dex[move].zMove?.effect === 'heal');
 				}
 				if (hasRecovery === alts.recovery[recoveryType]) {
 					matched = true;
@@ -1573,8 +1573,9 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 			}
 			if (matched) continue;
 			for (const boost in alts.zboost) {
-				if (dex[move].zMoveBoost) {
-					if ((dex[move].zMoveBoost![boost as BoostName]! > 0) === alts.zboost[boost]) {
+				const zMove = dex[move].zMove;
+				if (zMove?.boost) {
+					if ((zMove.boost[boost as BoostName]! > 0) === alts.zboost[boost]) {
 						matched = true;
 						break;
 					}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -116,7 +116,7 @@ export class Battle {
 	activePokemon: Pokemon | null;
 	activeTarget: Pokemon | null;
 
-	lastMove: Move | null;
+	lastMove: ActiveMove | null;
 	lastMoveThisTurn: Move | null;
 	lastMoveLine: number;
 	lastDamage: number;
@@ -2206,7 +2206,7 @@ export class Battle {
 		// Final modifier. Modifiers that modify damage after min damage check, such as Life Orb.
 		baseDamage = this.runEvent('ModifyDamage', pokemon, target, move, baseDamage);
 
-		if ((move.isZPowered || move.maxPowered) && target.getMoveHitData(move).zBrokeProtect) {
+		if ((move.isZPowered || move.isMaxPowered) && target.getMoveHitData(move).zBrokeProtect) {
 			baseDamage = this.modify(baseDamage, 0.25);
 			this.add('-zbroken', target);
 		}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2206,7 +2206,7 @@ export class Battle {
 		// Final modifier. Modifiers that modify damage after min damage check, such as Life Orb.
 		baseDamage = this.runEvent('ModifyDamage', pokemon, target, move, baseDamage);
 
-		if ((move.isZPowered || move.isMaxPowered) && target.getMoveHitData(move).zBrokeProtect) {
+		if ((move.isZOrMaxPowered || move.isZOrMaxPowered) && target.getMoveHitData(move).zBrokeProtect) {
 			baseDamage = this.modify(baseDamage, 0.25);
 			this.add('-zbroken', target);
 		}

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -912,7 +912,7 @@ export class Move extends BasicEffect implements Readonly<BasicEffect & MoveData
 		this.volatileStatus = typeof data.volatileStatus === 'string' ? (data.volatileStatus as ID) : undefined;
 
 		if (this.category !== 'Status' && !this.maxMove && this.id !== 'struggle') {
-			this.maxMove = {} as {basePower: number};
+			this.maxMove = {basePower: 1};
 			if (this.isMax || this.isZ) {
 				this.maxMove.basePower = 1;
 			} else if (!this.basePower) {

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -824,16 +824,22 @@ export class Move extends BasicEffect implements Readonly<BasicEffect & MoveData
 	readonly pp: number;
 	/** Whether or not this move can receive PP boosts. */
 	readonly noPPBoosts: boolean;
-	/** Is this move a Z-Move? */
-	readonly isZ: boolean | string;
 	/** How many times does this move hit? */
 	readonly multihit?: number | number[];
+	/** Is this move a Z-Move? */
+	readonly isZ: boolean | string;
+	/* Z-Move fields */
+	readonly zMove?: {
+		basePower?: number,
+		effect?: string,
+		boost?: SparseBoostsTable,
+	};
 	/** Is this move a Max move? */
 	readonly isMax: boolean | string;
-	/** Max/G-Max move power */
-	readonly gmaxPower?: number;
-	/** Z-move power */
-	readonly zMovePower?: number;
+	/** Max/G-Max move fields */
+	readonly maxMove?: {
+		basePower: number,
+	};
 	readonly flags: MoveFlags;
 	/** Whether or not the user must switch after using this move. */
 	readonly selfSwitch?: ID | boolean;
@@ -905,70 +911,72 @@ export class Move extends BasicEffect implements Readonly<BasicEffect & MoveData
 		this.stab = data.stab || undefined;
 		this.volatileStatus = typeof data.volatileStatus === 'string' ? (data.volatileStatus as ID) : undefined;
 
-		if (this.category !== 'Status' && !this.gmaxPower) {
+		if (this.category !== 'Status' && !this.maxMove?.basePower) {
+			this.maxMove = this.maxMove || {} as MoveData['maxMove'];
 			if (this.isMax || this.isZ) {
-				this.gmaxPower = 1;
+				this.maxMove!.basePower = 1;
 			} else if (!this.basePower) {
-				this.gmaxPower = 100;
+				this.maxMove!.basePower = 100;
 			} else if (['Fighting', 'Poison'].includes(this.type)) {
 				if (this.basePower >= 150) {
-					this.gmaxPower = 100;
+					this.maxMove!.basePower = 100;
 				} else if (this.basePower >= 110) {
-					this.gmaxPower = 95;
+					this.maxMove!.basePower = 95;
 				} else if (this.basePower >= 75) {
-					this.gmaxPower = 90;
+					this.maxMove!.basePower = 90;
 				} else if (this.basePower >= 65) {
-					this.gmaxPower = 85;
+					this.maxMove!.basePower = 85;
 				} else if (this.basePower >= 55) {
-					this.gmaxPower = 80;
+					this.maxMove!.basePower = 80;
 				} else if (this.basePower >= 45) {
-					this.gmaxPower = 75;
+					this.maxMove!.basePower = 75;
 				} else {
-					this.gmaxPower = 70;
+					this.maxMove!.basePower = 70;
 				}
 			} else {
 				if (this.basePower >= 150) {
-					this.gmaxPower = 150;
+					this.maxMove!.basePower = 150;
 				} else if (this.basePower >= 110) {
-					this.gmaxPower = 140;
+					this.maxMove!.basePower = 140;
 				} else if (this.basePower >= 75) {
-					this.gmaxPower = 130;
+					this.maxMove!.basePower = 130;
 				} else if (this.basePower >= 65) {
-					this.gmaxPower = 120;
+					this.maxMove!.basePower = 120;
 				} else if (this.basePower >= 55) {
-					this.gmaxPower = 110;
+					this.maxMove!.basePower = 110;
 				} else if (this.basePower >= 45) {
-					this.gmaxPower = 100;
+					this.maxMove!.basePower = 100;
 				} else {
-					this.gmaxPower = 90;
+					this.maxMove!.basePower = 90;
 				}
 			}
 		}
-		if (this.category !== 'Status' && !this.zMovePower && !this.isZ && !this.isMax) {
+		if (this.category !== 'Status' && !this.zMove?.basePower && !this.isZ && !this.isMax) {
 			let basePower = this.basePower;
+			this.zMove = this.zMove || {} as MoveData['zMove'];
 			if (Array.isArray(this.multihit)) basePower *= 3;
 			if (!basePower) {
-				this.zMovePower = 100;
+				this.zMove!.basePower = 100;
 			} else if (basePower >= 140) {
-				this.zMovePower = 200;
+				this.zMove!.basePower = 200;
 			} else if (basePower >= 130) {
-				this.zMovePower = 195;
+				this.zMove!.basePower = 195;
 			} else if (basePower >= 120) {
-				this.zMovePower = 190;
+				this.zMove!.basePower = 190;
 			} else if (basePower >= 110) {
-				this.zMovePower = 185;
+				this.zMove!.basePower = 185;
 			} else if (basePower >= 100) {
-				this.zMovePower = 180;
+				this.zMove!.basePower = 180;
 			} else if (basePower >= 90) {
-				this.zMovePower = 175;
+				this.zMove!.basePower = 175;
 			} else if (basePower >= 80) {
-				this.zMovePower = 160;
+				this.zMove!.basePower = 160;
 			} else if (basePower >= 70) {
-				this.zMovePower = 140;
+				this.zMove!.basePower = 140;
 			} else if (basePower >= 60) {
-				this.zMovePower = 120;
+				this.zMove!.basePower = 120;
 			} else {
-				this.zMovePower = 100;
+				this.zMove!.basePower = 100;
 			}
 		}
 

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -911,72 +911,72 @@ export class Move extends BasicEffect implements Readonly<BasicEffect & MoveData
 		this.stab = data.stab || undefined;
 		this.volatileStatus = typeof data.volatileStatus === 'string' ? (data.volatileStatus as ID) : undefined;
 
-		if (this.category !== 'Status' && !this.maxMove?.basePower) {
-			this.maxMove = this.maxMove || {} as MoveData['maxMove'];
+		if (this.category !== 'Status' && !this.maxMove && this.id !== 'struggle') {
+			this.maxMove = {} as {basePower: number};
 			if (this.isMax || this.isZ) {
-				this.maxMove!.basePower = 1;
+				this.maxMove.basePower = 1;
 			} else if (!this.basePower) {
-				this.maxMove!.basePower = 100;
+				this.maxMove.basePower = 100;
 			} else if (['Fighting', 'Poison'].includes(this.type)) {
 				if (this.basePower >= 150) {
-					this.maxMove!.basePower = 100;
+					this.maxMove.basePower = 100;
 				} else if (this.basePower >= 110) {
-					this.maxMove!.basePower = 95;
+					this.maxMove.basePower = 95;
 				} else if (this.basePower >= 75) {
-					this.maxMove!.basePower = 90;
+					this.maxMove.basePower = 90;
 				} else if (this.basePower >= 65) {
-					this.maxMove!.basePower = 85;
+					this.maxMove.basePower = 85;
 				} else if (this.basePower >= 55) {
-					this.maxMove!.basePower = 80;
+					this.maxMove.basePower = 80;
 				} else if (this.basePower >= 45) {
-					this.maxMove!.basePower = 75;
+					this.maxMove.basePower = 75;
 				} else {
-					this.maxMove!.basePower = 70;
+					this.maxMove.basePower = 70;
 				}
 			} else {
 				if (this.basePower >= 150) {
-					this.maxMove!.basePower = 150;
+					this.maxMove.basePower = 150;
 				} else if (this.basePower >= 110) {
-					this.maxMove!.basePower = 140;
+					this.maxMove.basePower = 140;
 				} else if (this.basePower >= 75) {
-					this.maxMove!.basePower = 130;
+					this.maxMove.basePower = 130;
 				} else if (this.basePower >= 65) {
-					this.maxMove!.basePower = 120;
+					this.maxMove.basePower = 120;
 				} else if (this.basePower >= 55) {
-					this.maxMove!.basePower = 110;
+					this.maxMove.basePower = 110;
 				} else if (this.basePower >= 45) {
-					this.maxMove!.basePower = 100;
+					this.maxMove.basePower = 100;
 				} else {
-					this.maxMove!.basePower = 90;
+					this.maxMove.basePower = 90;
 				}
 			}
 		}
-		if (this.category !== 'Status' && !this.zMove?.basePower && !this.isZ && !this.isMax) {
+		if (this.category !== 'Status' && !this.zMove && !this.isZ && !this.isMax) {
 			let basePower = this.basePower;
-			this.zMove = this.zMove || {} as MoveData['zMove'];
+			this.zMove = {};
 			if (Array.isArray(this.multihit)) basePower *= 3;
 			if (!basePower) {
-				this.zMove!.basePower = 100;
+				this.zMove.basePower = 100;
 			} else if (basePower >= 140) {
-				this.zMove!.basePower = 200;
+				this.zMove.basePower = 200;
 			} else if (basePower >= 130) {
-				this.zMove!.basePower = 195;
+				this.zMove.basePower = 195;
 			} else if (basePower >= 120) {
-				this.zMove!.basePower = 190;
+				this.zMove.basePower = 190;
 			} else if (basePower >= 110) {
-				this.zMove!.basePower = 185;
+				this.zMove.basePower = 185;
 			} else if (basePower >= 100) {
-				this.zMove!.basePower = 180;
+				this.zMove.basePower = 180;
 			} else if (basePower >= 90) {
-				this.zMove!.basePower = 175;
+				this.zMove.basePower = 175;
 			} else if (basePower >= 80) {
-				this.zMove!.basePower = 160;
+				this.zMove.basePower = 160;
 			} else if (basePower >= 70) {
-				this.zMove!.basePower = 140;
+				this.zMove.basePower = 140;
 			} else if (basePower >= 60) {
-				this.zMove!.basePower = 120;
+				this.zMove.basePower = 120;
 			} else {
-				this.zMove!.basePower = 100;
+				this.zMove.basePower = 100;
 			}
 		}
 

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -914,7 +914,7 @@ export class Move extends BasicEffect implements Readonly<BasicEffect & MoveData
 		if (this.category !== 'Status' && !this.maxMove && this.id !== 'struggle') {
 			this.maxMove = {basePower: 1};
 			if (this.isMax || this.isZ) {
-				this.maxMove.basePower = 1;
+				// already initialized to 1
 			} else if (!this.basePower) {
 				this.maxMove.basePower = 100;
 			} else if (['Fighting', 'Poison'].includes(this.type)) {

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -1077,16 +1077,10 @@ interface ActiveMove extends BasicEffect, MoveData {
 	infiltrates?: boolean;
 
 	/**
-	 * Has this move been boosted by a Z-crystal? Usually the same as
-	 * `isZ`, but hacked moves will have this be `false` and `isZ` be
-	 * truthy.
+	 * Has this move been boosted by a Z-crystal or used by a Dynamax Pokemon? Usually the same as
+	 * `isZ` or `isMax`, but hacked moves will have this be `false` and `isZ` / `isMax` be truthy.
 	 */
-	isZPowered?: boolean;
-	/**
-	 * Same idea has `isZPowered`. Hacked Max moves will have this be
-	 * `false` and `isMax` be truthy.
-	 */
-	isMaxPowered?: boolean;
+	isZOrMaxPowered?: boolean;
 }
 
 interface SpeciesAbility {

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -925,29 +925,22 @@ interface MoveData extends EffectData, MoveEventMethods, HitEffect {
 	 * Sparksurfer.
 	 */
 	isZ?: boolean | string;
-	zMovePower?: number;
-	zMoveEffect?: string;
-	zMoveBoost?: SparseBoostsTable;
-	/**
-	 * Has this move been boosted by a Z-crystal? Usually the same as
-	 * `isZ`, but hacked moves will have this be `false` and `isZ` be
-	 * truthy.
-	 */
-	isZPowered?: boolean;
+	zMove?: {
+		basePower?: number,
+		effect?: string,
+		boost?: SparseBoostsTable,
+	};
 
 	// Max move data
 	// -------------
-	gmaxPower?: number;
 	/**
 	 * `true` for Max moves like Max Airstream. If its a G-Max moves, this is
 	 * the species ID of the Gigantamax Pokemon that can use this G-Max move.
 	 */
 	isMax?: boolean | string;
-	/**
-	 * Same idea has `isZPowered`. Hacked Max moves will have this be
-	 * `false` and `isMax` be truthy.
-	 */
-	maxPowered?: boolean;
+	maxMove?: {
+		basePower: number,
+	};
 
 	// Hit effects
 	// -----------
@@ -1082,6 +1075,18 @@ interface ActiveMove extends BasicEffect, MoveData {
 	totalDamage?: number | false;
 	willChangeForme?: boolean;
 	infiltrates?: boolean;
+
+	/**
+	 * Has this move been boosted by a Z-crystal? Usually the same as
+	 * `isZ`, but hacked moves will have this be `false` and `isZ` be
+	 * truthy.
+	 */
+	isZPowered?: boolean;
+	/**
+	 * Same idea has `isZPowered`. Hacked Max moves will have this be
+	 * `false` and `isMax` be truthy.
+	 */
+	isMaxPowered?: boolean;
 }
 
 interface SpeciesAbility {

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -126,7 +126,7 @@ export class Pokemon {
 	newlySwitched: boolean;
 	beingCalledBack: boolean;
 
-	lastMove: Move | null;
+	lastMove: ActiveMove | null;
 	lastMoveTargetLoc?: number;
 	moveThisTurn: string | boolean;
 	/**
@@ -744,7 +744,7 @@ export class Pokemon {
 		return amount;
 	}
 
-	moveUsed(move: Move, targetLoc?: number) {
+	moveUsed(move: ActiveMove, targetLoc?: number) {
 		this.lastMove = move;
 		this.lastMoveTargetLoc = targetLoc;
 		this.moveThisTurn = move.id;


### PR DESCRIPTION
This mostly serves to provide cleaner and more consistent field
naming. maxMove currently doesn't have boosts or effects to group
together but who knows what will be thrown at us via DLC, and being
symmetrical with zMoves is a nice.