### PR TITLE
Fix movesearch with max flag

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1463,7 +1463,7 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 						break;
 					}
 				} else if (flag === 'maxmove') {
-					if (!(typeof dex[move].isMax === 'boolean') === !alts.flags[flag]) {
+					if (!(typeof dex[move].isMax === 'boolean' && dex[move].isMax) === !alts.flags[flag]) {
 						matched = true;
 						break;
 					}


### PR DESCRIPTION
Returns this now:
![image](https://user-images.githubusercontent.com/23667022/81463110-97625e80-917c-11ea-9fdb-65b91027319d.png)

instead of this:
![image](https://user-images.githubusercontent.com/23667022/81463135-cbd61a80-917c-11ea-9528-d9c7078c82a2.png)

I didn't make it return G-Max moves since there's a separate flag already for them.