### PR TITLE
Allow leaders+ to exportinputlog directly

### DIFF
--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -815,7 +815,15 @@ export const commands: ChatCommands = {
 			return;
 		}
 		if (!this.can('exportinputlog', null, room)) return;
-		if (!battle.allowExtraction[user.id]) {
+		if (user.can('forcewin')) {
+			if (!battle.inputLog) return this.errorReply('No input log found.');
+			this.addModAction(`${user.name} has extracted the battle input log.`);
+			const inputLog = battle.inputLog.map(Chat.escapeHTML).join(`<br />`);
+			user.sendTo(
+				room,
+				`|html|<div class="chat"><code style="white-space: pre-wrap; overflow-wrap: break-word; display: block">${inputLog}</code></div>`,
+			);
+		} else if (!battle.allowExtraction[user.id]) {
 			battle.allowExtraction[user.id] = new Set();
 			for (const player of battle.players) {
 				const playerUser = player.getUser();


### PR DESCRIPTION
@asgdf  brought this up recently to me. This is purely a convenience command so it doesn't have to be done via replays and can instead grab the inputlog natively within Showdown. I'm not sure if this needs policy hashed out or anything, but the only difference I'm seeing is that it's being done through Showdown and not through replays. Leaders still have access either way. Players still have to explicitly request permission to obtain the inputlog from a battle, even if a leader+ grabbed the inputlog first. As a sanity check, it also still logs to the battle that the leader+ exported the input log.