### PR TITLE
National Dex: Ban Gengarite

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -402,7 +402,7 @@ const Formats = [
 			'Gengar-Mega', 'Giratina', 'Groudon', 'Ho-Oh', 'Kangaskhan-Mega', 'Kyogre', 'Kyurem-Black', 'Kyurem-White', 'Landorus-Base', 'Lucario-Mega',
 			'Lugia', 'Lunala', 'Marshadow', 'Mewtwo', 'Naganadel', 'Necrozma-Dawn-Wings', 'Necrozma-Dusk-Mane', 'Palkia', 'Pheromosa', 'Rayquaza',
 			'Reshiram', 'Salamence-Mega', 'Shaymin-Sky', 'Solgaleo', 'Xerneas', 'Yveltal', 'Zacian', 'Zamazenta', 'Zekrom', 'Zygarde-Base',
-			'Arena Trap', 'Moody', 'Power Construct', 'Shadow Tag', 'Baton Pass',
+			'Arena Trap', 'Moody', 'Power Construct', 'Shadow Tag', 'Gengarite', 'Baton Pass',
 		],
 		onBegin() {
 			if (this.rated && this.format.id === 'gen8nationaldex') {


### PR DESCRIPTION
There is currently an exploit where if you put Gengarite on Gengar-Gmax in a National Dex team, you will be able to bring Gengar @ Gengarite to battle. This only happens because of dynamax clause existing, preventing the dynamax button from appearing.

I will find a real fix to this soon, but this is very high priority that it gets patched in some way for now.