### PR TITLE
Add test for unmatched < or >

### DIFF
--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -86,6 +86,7 @@ export const commands: ChatCommands = {
 		if (!html) return this.parse(`/help ${cmd}`);
 		if (!this.can('addhtml', null, room)) return;
 		html = Chat.collapseLineBreaksHTML(html);
+		if (!/^[^<>]*(?:<[^<>]*?>[^<>]*)*$/.test(html)) return this.errorReply('Found unmatched < or >. If you wish to use them as text, please use `&lt;` or `&gt;` respectively.');
 		if (!user.can('addhtml')) {
 			html += Chat.html`<div style="float:right;color:#888;font-size:8pt">[${user.name}]</div><div style="clear:both"></div>`;
 		}

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -86,7 +86,9 @@ export const commands: ChatCommands = {
 		if (!html) return this.parse(`/help ${cmd}`);
 		if (!this.can('addhtml', null, room)) return;
 		html = Chat.collapseLineBreaksHTML(html);
-		if (!/^[^<>]*(?:<[^<>]*?>[^<>]*)*$/.test(html)) return this.errorReply('Found unmatched < or >. If you wish to use them as text, please use `&lt;` or `&gt;` respectively.');
+		if (!/^[^<>]*(?:<[^<>]*?>[^<>]*)*$/.test(html)) {
+			return this.errorReply('Found unmatched < or >. If you wish to use them, please use `&lt;` or `&gt;`.');
+		}
 		if (!user.can('addhtml')) {
 			html += Chat.html`<div style="float:right;color:#888;font-size:8pt">[${user.name}]</div><div style="clear:both"></div>`;
 		}

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -86,9 +86,6 @@ export const commands: ChatCommands = {
 		if (!html) return this.parse(`/help ${cmd}`);
 		if (!this.can('addhtml', null, room)) return;
 		html = Chat.collapseLineBreaksHTML(html);
-		if (!/^[^<>]*(?:<[^<>]*?>[^<>]*)*$/.test(html)) {
-			return this.errorReply('Found unmatched < or >. If you wish to use them, please use `&lt;` or `&gt;`.');
-		}
 		if (!user.can('addhtml')) {
 			html += Chat.html`<div style="float:right;color:#888;font-size:8pt">[${user.name}]</div><div style="clear:both"></div>`;
 		}

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1076,30 +1076,25 @@ export class CommandContext extends MessageContext {
 			this.errorReply('Do not use "click here"');
 			return null;
 		}
-		if (!/^[^<>]*(?:<[^<>]*?>[^<>]*)*$/.test(htmlContent)) {
-			this.errorReply('Found unmatched < or >. If you wish to use them, please use `&lt;` or `&gt;`.');
-			return null;
-		}
 
 		// check for mismatched tags
 		const tags = htmlContent
-			.toLowerCase()
 			// eslint-ignore-next-line @typescript-eslint/prefer-regexp-exec
-			.match(/<\/?(?:div|a|button|b|strong|em|i|u|center|font|marquee|blink|details|summary|code|table|td|tr|style|script)\b/g);
+			.match(/<\/?[a-z0-9]*/gi);
 		if (tags) {
 			const stack = [];
 			for (const tag of tags) {
 				if (tag.charAt(1) === '/') {
 					if (!stack.length) {
-						this.errorReply("Extraneous </" + tag.substr(2) + "> without an opening tag.");
+						this.errorReply(`Extraneous </${tag.substr(2)}> without an opening tag.`);
 						return null;
 					}
 					if (tag.substr(2) !== stack.pop()) {
-						this.errorReply("Missing </" + tag.substr(2) + "> or it's in the wrong place.");
+						this.errorReply(`Missing </${tag.substr(2)}> or it's in the wrong place.`);
 						return null;
 					}
-				} else {
-					stack.push(tag.substr(1));
+				} else if (/<(?:div|a|button|b|strong|em|i|u|center|font|marquee|blink|details|summary|code|table|td|tr|th|style|script|h\d)\b/.test(tag.toLowerCase())) {
+					this.errorReply(`Unrecognized tag \`${match.slice(1)}\` (often caused by using an unmatched <). If you meant to use the character, use a \`&lt;\` instead.`);
 				}
 			}
 			if (stack.length) {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1094,7 +1094,9 @@ export class CommandContext extends MessageContext {
 						return null;
 					}
 				} else if (/<(?:div|a|button|b|strong|em|i|u|center|font|marquee|blink|details|summary|code|table|td|tr|th|style|script|h\d)\b/.test(tag.toLowerCase())) {
-					this.errorReply(`Unrecognized tag \`${match.slice(1)}\` (often caused by using an unmatched <). If you meant to use the character, use a \`&lt;\` instead.`);
+					stack.push(tag.substr(1));
+				} else if (!["br", "area", "embed", "hr", "img", "link", "source", "track"].includes(tag.slice(1).toLowerCase())) {
+					this.errorReply(`Unrecognized tag \`${tag.slice(1)}\` (often caused by using an unmatched <). If you meant to use the character, use a \`&lt;\` instead.`);
 				}
 			}
 			if (stack.length) {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1094,9 +1094,9 @@ export class CommandContext extends MessageContext {
 						this.errorReply(`Missing </${tag.substr(2)}> or it's in the wrong place.`);
 						return null;
 					}
-				} else if (/<(?:div|a|button|b|strong|em|i|u|center|font|marquee|blink|details|summary|code|table|td|tr|th|style|script|h\d)\b/.test(tag.toLowerCase())) {
+				} else if (/<(?:div|a|button|b|strong|em|i|u|center|font|marquee|blink|details|summary|code|table|td|tr|th|style|script|h\d)\b/.test(tag)) {
 					stack.push(tag.substr(1));
-				} else if (!["br", "area", "embed", "hr", "img", "link", "source", "track"].includes(tag.slice(1).toLowerCase())) {
+				} else if (!["br", "area", "embed", "hr", "img", "link", "source", "track"].includes(tag.slice(1))) {
 					this.errorReply(`Unrecognized tag \`${tag.slice(1)}\` (often caused by using an unmatched <). If you meant to use the character, use a \`&lt;\` instead.`);
 					return null;
 				}

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1076,7 +1076,7 @@ export class CommandContext extends MessageContext {
 			this.errorReply('Do not use "click here"');
 			return null;
 		}
-		if (!/^[^<>]*(?:<[^<>]*?>[^<>]*)*$/.test(html)) {
+		if (!/^[^<>]*(?:<[^<>]*?>[^<>]*)*$/.test(htmlContent)) {
 			this.errorReply('Found unmatched < or >. If you wish to use them, please use `&lt;` or `&gt;`.');
 			return null;
 		}

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1076,6 +1076,10 @@ export class CommandContext extends MessageContext {
 			this.errorReply('Do not use "click here"');
 			return null;
 		}
+		if (!/^[^<>]*(?:<[^<>]*?>[^<>]*)*$/.test(html)) {
+			this.errorReply('Found unmatched < or >. If you wish to use them, please use `&lt;` or `&gt;`.');
+			return null;
+		}
 
 		// check for mismatched tags
 		const tags = htmlContent

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1097,6 +1097,7 @@ export class CommandContext extends MessageContext {
 					stack.push(tag.substr(1));
 				} else if (!["br", "area", "embed", "hr", "img", "link", "source", "track"].includes(tag.slice(1).toLowerCase())) {
 					this.errorReply(`Unrecognized tag \`${tag.slice(1)}\` (often caused by using an unmatched <). If you meant to use the character, use a \`&lt;\` instead.`);
+					return null;
 				}
 			}
 			if (stack.length) {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1079,8 +1079,9 @@ export class CommandContext extends MessageContext {
 
 		// check for mismatched tags
 		const tags = htmlContent
+			.toLowerCase()
 			// eslint-ignore-next-line @typescript-eslint/prefer-regexp-exec
-			.match(/<\/?[a-z0-9]*/gi);
+			.match(/<\/?[a-z0-9]*/g);
 		if (tags) {
 			const stack = [];
 			for (const tag of tags) {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1100,7 +1100,7 @@ export class CommandContext extends MessageContext {
 				}
 			}
 			if (stack.length) {
-				this.errorReply("Missing </" + stack.pop() + ">.");
+				this.errorReply(`Missing </${stack.pop()}>.`);
 				return null;
 			}
 		}


### PR DESCRIPTION
This change prevents using an unmatched < to escape UHTML name tags, but also prevents direct nesting of tags (of the form ``<button value="<..>">`` or similar). However, most of these uses (if they exist) can be covered by escaping them.