### PR TITLE
Make /addline require console access

### DIFF
--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -126,8 +126,10 @@ export const commands: ChatCommands = {
 		`/changerankuhtml [rank], [name], [message] - Changes the message previously shown with /addrankuhtml [rank], [name]. Requires: * & ~`,
 	],
 
-	addline(target, room, user) {
-		if (!this.can('rawpacket')) return false;
+	addline(target, room, user, connection) {
+		if (!user.hasConsoleAccess(connection)) {
+			return this.errorReply("/addline - Access denied.");
+		}
 		// secret sysop command
 		room.add(target);
 	},


### PR DESCRIPTION
Honestly why isn't this limited to those with console access. Its extremely powerful still, being the (literal) equivalent of `/eval room.add(target);`.

This becomes more important with the proposed flattening.