### PR TITLE
Gen I: Add HP hint for Rest

### DIFF
--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -769,11 +769,12 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		desc: "The user falls asleep for the next two turns and restores all of its HP, curing itself of any major status condition in the process. This does not remove the user's stat penalty for burn or paralysis. Fails if the user has full HP.",
 		onTryMove() {},
 		onHit(target, source, move) {
-			// Fails if the difference between
-			// max HP and current HP is 0, 255, or 511
-			if (target.hp >= target.maxhp ||
-			target.hp === (target.maxhp - 255) ||
-			target.hp === (target.maxhp - 511)) return false;
+			if (target.hp === target.maxhp) return false;
+			// Fail when health is 255 or 511 less than max
+			if (target.hp === (target.maxhp - 255) || target.hp === (target.maxhp - 511)) {
+				this.hint("In Gen 1, recovery moves fail if (user's maximum HP - user's current HP + 1) is divisible by 256.");
+				return false;
+			}
 			if (!target.setStatus('slp', source, move)) return false;
 			target.statusData.time = 2;
 			target.statusData.startTime = 2;


### PR DESCRIPTION
By the way, this pull request assumes there is no other way for Rest to fail, otherwise such a message could be an information leak. Is this the case for Gen1 games? I don't think there is a way to prevent sleep, but maybe I did miss something.