### PR TITLE
Rename data tables from Battle[foo] to Dex[foo]

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -32,7 +32,7 @@ Ratings and how they work:
 
 */
 
-export const BattleAbilities: {[abilityid: string]: AbilityData} = {
+export const DexAbilities: {[abilityid: string]: AbilityData} = {
 	noability: {
 		shortDesc: "Does nothing.",
 		isNonstandard: "Past",

--- a/data/aliases.ts
+++ b/data/aliases.ts
@@ -1,4 +1,4 @@
-export const BattleAliases: {[alias: string]: string} = {
+export const DexAliases: {[alias: string]: string} = {
 	// formats
 	randbats: "[Gen 8] Random Battle",
 	uber: "[Gen 8] Ubers",

--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: SpeciesFormatsData} = {
+export const DexFormatsData: {[k: string]: SpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/items.ts
+++ b/data/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[itemid: string]: ItemData} = {
+export const DexItems: {[itemid: string]: ItemData} = {
 	abomasite: {
 		name: "Abomasite",
 		spritenum: 575,

--- a/data/learnsets.ts
+++ b/data/learnsets.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 
-export const BattleLearnsets: {[speciesid: string]: LearnsetData} = {
+export const DexLearnsets: {[speciesid: string]: LearnsetData} = {
 	missingno: {
 		learnset: {
 			blizzard: ["3L1"],

--- a/data/mods/gen1/formats-data.ts
+++ b/data/mods/gen1/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const DexFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		randomBattleMoves: ["sleeppowder", "bodyslam"],
 		essentialMove: "razorleaf",

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -3,7 +3,7 @@
  * Some moves have had major changes, such as Bite's typing.
  */
 
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const DexMoves: {[k: string]: ModdedMoveData} = {
 	absorb: {
 		inherit: true,
 		desc: "The user recovers 1/2 the HP lost by the target, rounded down. If this move breaks the target's substitute, the user does not recover any HP.",

--- a/data/mods/gen1/pokedex.ts
+++ b/data/mods/gen1/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const DexPokedex: {[k: string]: ModdedSpeciesData} = {
 	missingno: {
 		inherit: true,
 		baseStats: {hp: 33, atk: 136, def: 0, spa: 6, spd: 6, spe: 29},

--- a/data/mods/gen1/rulesets.ts
+++ b/data/mods/gen1/rulesets.ts
@@ -1,4 +1,4 @@
-export const BattleFormats: {[k: string]: ModdedFormatsData} = {
+export const DexFormats: {[k: string]: ModdedFormatsData} = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -4,7 +4,7 @@
  * This generation inherits all the changes from older generations, that must be taken into account when editing code.
  */
 
-export const BattleScripts: ModdedBattleScriptsData = {
+export const DexScripts: ModdedBattleScriptsData = {
 	inherit: 'gen2',
 	gen: 1,
 	init() {
@@ -865,4 +865,4 @@ export const BattleScripts: ModdedBattleScriptsData = {
 	},
 };
 
-exports.BattleScripts = BattleScripts;
+exports.DexScripts = DexScripts;

--- a/data/mods/gen1/statuses.ts
+++ b/data/mods/gen1/statuses.ts
@@ -8,7 +8,7 @@
  * under certain conditions and re-applied under other conditions.
  */
 
-export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
+export const DexStatuses: {[k: string]: ModdedPureEffectData} = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',
@@ -258,4 +258,4 @@ export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
 	},
 };
 
-exports.BattleStatuses = BattleStatuses;
+exports.DexStatuses = DexStatuses;

--- a/data/mods/gen1/typechart.ts
+++ b/data/mods/gen1/typechart.ts
@@ -6,7 +6,7 @@
  * Psychic was immune to ghost
  */
 
-export const BattleTypeChart: {[k: string]: ModdedTypeData | null} = {
+export const DexTypes: {[k: string]: ModdedTypeData | null} = {
 	Bug: {
 		damageTaken: {
 			Bug: 0,

--- a/data/mods/gen2/formats-data.ts
+++ b/data/mods/gen2/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const DexFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen2/items.ts
+++ b/data/mods/gen2/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const DexItems: {[k: string]: ModdedItemData} = {
 	berryjuice: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/gen2/learnsets.ts
+++ b/data/mods/gen2/learnsets.ts
@@ -1,4 +1,4 @@
-export const BattleLearnsets: {[k: string]: ModdedLearnsetData} = {
+export const DexLearnsets: {[k: string]: ModdedLearnsetData} = {
 	missingno: {
 		learnset: {
 			blizzard: ["1M"],

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -2,7 +2,7 @@
  * Gen 2 moves
  */
 
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const DexMoves: {[k: string]: ModdedMoveData} = {
 	absorb: {
 		inherit: true,
 		desc: "The user recovers 1/2 the HP lost by the target, rounded down. If the target has a substitute, this move misses.",

--- a/data/mods/gen2/rulesets.ts
+++ b/data/mods/gen2/rulesets.ts
@@ -1,4 +1,4 @@
-export const BattleFormats: {[k: string]: ModdedFormatsData} = {
+export const DexFormats: {[k: string]: ModdedFormatsData} = {
 	obtainablemoves: {
 		inherit: true,
 		banlist: [

--- a/data/mods/gen2/scripts.ts
+++ b/data/mods/gen2/scripts.ts
@@ -2,7 +2,7 @@
  * Gen 2 scripts.
  */
 
-export const BattleScripts: ModdedBattleScriptsData = {
+export const DexScripts: ModdedBattleScriptsData = {
 	inherit: 'gen3',
 	gen: 2,
 	// BattlePokemon scripts.

--- a/data/mods/gen2/statuses.ts
+++ b/data/mods/gen2/statuses.ts
@@ -1,4 +1,4 @@
-export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
+export const DexStatuses: {[k: string]: ModdedPureEffectData} = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',
@@ -238,4 +238,4 @@ function residualdmg(battle: Battle, pokemon: Pokemon) {
 	}
 }
 
-exports.BattleStatuses = BattleStatuses;
+exports.DexStatuses = DexStatuses;

--- a/data/mods/gen2/typechart.ts
+++ b/data/mods/gen2/typechart.ts
@@ -1,4 +1,4 @@
-export const BattleTypeChart: {[k: string]: ModdedTypeData} = {
+export const DexTypes: {[k: string]: ModdedTypeData} = {
 	Fire: {
 		inherit: true,
 		damageTaken: {

--- a/data/mods/gen3/abilities.ts
+++ b/data/mods/gen3/abilities.ts
@@ -1,4 +1,4 @@
-export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
+export const DexAbilities: {[k: string]: ModdedAbilityData} = {
 	cutecharm: {
 		inherit: true,
 		desc: "There is a 1/3 chance a Pokemon making contact with this Pokemon will become infatuated if it is of the opposite gender.",

--- a/data/mods/gen3/formats-data.ts
+++ b/data/mods/gen3/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const DexFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen3/items.ts
+++ b/data/mods/gen3/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const DexItems: {[k: string]: ModdedItemData} = {
 	aguavberry: {
 		inherit: true,
 		onUpdate() {},

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -2,7 +2,7 @@
  * Gen 3 moves
  */
 
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const DexMoves: {[k: string]: ModdedMoveData} = {
 	absorb: {
 		inherit: true,
 		desc: "The user recovers 1/2 the HP lost by the target, rounded down.",
@@ -964,4 +964,4 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 	},
 };
 
-exports.BattleMovedex = BattleMovedex;
+exports.DexMoves = DexMoves;

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -421,7 +421,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			item = 'Petaya Berry';
 		} else if (counter.Physical >= 4) {
 			item = 'Choice Band';
-		} else if (counter.Physical >= 3 && (hasMove['firepunch'] || hasMove['icebeam'] || hasMove['overheat'] || moves.filter(m => this.dex.data.Movedex[m].category === 'Special' && hasType[this.dex.data.Movedex[m].type]).length)) {
+		} else if (counter.Physical >= 3 && (hasMove['firepunch'] || hasMove['icebeam'] || hasMove['overheat'] || moves.filter(m => this.dex.data.Moves[m].category === 'Special' && hasType[this.dex.data.Moves[m].type]).length)) {
 			item = 'Choice Band';
 
 		// Default to Leftovers

--- a/data/mods/gen3/rulesets.ts
+++ b/data/mods/gen3/rulesets.ts
@@ -1,4 +1,4 @@
-export const BattleFormats: {[k: string]: ModdedFormatsData} = {
+export const DexFormats: {[k: string]: ModdedFormatsData} = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',

--- a/data/mods/gen3/scripts.ts
+++ b/data/mods/gen3/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const DexScripts: ModdedBattleScriptsData = {
 	inherit: 'gen4',
 	gen: 3,
 	init() {
@@ -7,12 +7,12 @@ export const BattleScripts: ModdedBattleScriptsData = {
 		}
 		const specialTypes = ['Fire', 'Water', 'Grass', 'Ice', 'Electric', 'Dark', 'Psychic', 'Dragon'];
 		let newCategory = '';
-		for (const i in this.data.Movedex) {
-			if (!this.data.Movedex[i]) console.log(i);
-			if (this.data.Movedex[i].category === 'Status') continue;
-			newCategory = specialTypes.includes(this.data.Movedex[i].type) ? 'Special' : 'Physical';
-			if (newCategory !== this.data.Movedex[i].category) {
-				this.modData('Movedex', i).category = newCategory;
+		for (const i in this.data.Moves) {
+			if (!this.data.Moves[i]) console.log(i);
+			if (this.data.Moves[i].category === 'Status') continue;
+			newCategory = specialTypes.includes(this.data.Moves[i].type) ? 'Special' : 'Physical';
+			if (newCategory !== this.data.Moves[i].category) {
+				this.modData('Moves', i).category = newCategory;
 			}
 		}
 	},

--- a/data/mods/gen3/statuses.ts
+++ b/data/mods/gen3/statuses.ts
@@ -1,4 +1,4 @@
-export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
+export const DexStatuses: {[k: string]: ModdedPureEffectData} = {
 	slp: {
 		name: 'slp',
 		effectType: 'Status',

--- a/data/mods/gen4/abilities.ts
+++ b/data/mods/gen4/abilities.ts
@@ -1,4 +1,4 @@
-export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
+export const DexAbilities: {[k: string]: ModdedAbilityData} = {
 	angerpoint: {
 		inherit: true,
 		desc: "If this Pokemon, or its substitute, is struck by a critical hit, its Attack is raised by 12 stages.",

--- a/data/mods/gen4/formats-data.ts
+++ b/data/mods/gen4/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const DexFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen4/items.ts
+++ b/data/mods/gen4/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const DexItems: {[k: string]: ModdedItemData} = {
 	adamantorb: {
 		inherit: true,
 		onBasePower(basePower, user, target, move) {

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -1,4 +1,4 @@
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const DexMoves: {[k: string]: ModdedMoveData} = {
 	absorb: {
 		inherit: true,
 		desc: "The user recovers 1/2 the HP lost by the target, rounded down. If Big Root is held by the user, the HP recovered is 1.3x normal, rounded down.",

--- a/data/mods/gen4/pokedex.ts
+++ b/data/mods/gen4/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const DexPokedex: {[k: string]: ModdedSpeciesData} = {
 	milotic: {
 		inherit: true,
 		evoType: 'levelExtra',

--- a/data/mods/gen4/rulesets.ts
+++ b/data/mods/gen4/rulesets.ts
@@ -1,4 +1,4 @@
-export const BattleFormats: {[k: string]: ModdedFormatsData} = {
+export const DexFormats: {[k: string]: ModdedFormatsData} = {
 	standard: {
 		inherit: true,
 		ruleset: ['Obtainable', 'Sleep Clause Mod', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],

--- a/data/mods/gen4/scripts.ts
+++ b/data/mods/gen4/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const DexScripts: ModdedBattleScriptsData = {
 	inherit: 'gen5',
 	gen: 4,
 	init() {

--- a/data/mods/gen4/statuses.ts
+++ b/data/mods/gen4/statuses.ts
@@ -1,4 +1,4 @@
-export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
+export const DexStatuses: {[k: string]: ModdedPureEffectData} = {
 	par: {
 		inherit: true,
 		onBeforeMove(pokemon) {

--- a/data/mods/gen5/abilities.ts
+++ b/data/mods/gen5/abilities.ts
@@ -1,4 +1,4 @@
-export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
+export const DexAbilities: {[k: string]: ModdedAbilityData} = {
 	anticipation: {
 		inherit: true,
 		desc: "On switch-in, this Pokemon is alerted if any opposing Pokemon has an attack that is super effective on this Pokemon, or an OHKO move. Counter, Metal Burst, and Mirror Coat count as attacking moves of their respective types, while Hidden Power, Judgment, Natural Gift, Techno Blast, and Weather Ball are considered Normal-type moves.",

--- a/data/mods/gen5/formats-data.ts
+++ b/data/mods/gen5/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const DexFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		maleOnlyHidden: true,
 		tier: "LC",

--- a/data/mods/gen5/items.ts
+++ b/data/mods/gen5/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const DexItems: {[k: string]: ModdedItemData} = {
 	aguavberry: {
 		inherit: true,
 		naturalGift: {

--- a/data/mods/gen5/moves.ts
+++ b/data/mods/gen5/moves.ts
@@ -1,4 +1,4 @@
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const DexMoves: {[k: string]: ModdedMoveData} = {
 	absorb: {
 		inherit: true,
 		flags: {protect: 1, mirror: 1},

--- a/data/mods/gen5/pokedex.ts
+++ b/data/mods/gen5/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const DexPokedex: {[k: string]: ModdedSpeciesData} = {
 	butterfree: {
 		inherit: true,
 		baseStats: {hp: 60, atk: 45, def: 50, spa: 80, spd: 80, spe: 70},

--- a/data/mods/gen5/rulesets.ts
+++ b/data/mods/gen5/rulesets.ts
@@ -1,4 +1,4 @@
-export const BattleFormats: {[k: string]: ModdedFormatsData} = {
+export const DexFormats: {[k: string]: ModdedFormatsData} = {
 	standard: {
 		inherit: true,
 		ruleset: [

--- a/data/mods/gen5/scripts.ts
+++ b/data/mods/gen5/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const DexScripts: ModdedBattleScriptsData = {
 	inherit: 'gen6',
 	gen: 5,
 };

--- a/data/mods/gen5/statuses.ts
+++ b/data/mods/gen5/statuses.ts
@@ -1,4 +1,4 @@
-export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
+export const DexStatuses: {[k: string]: ModdedPureEffectData} = {
 	slp: {
 		inherit: true,
 		onSwitchIn(target) {

--- a/data/mods/gen5/typechart.ts
+++ b/data/mods/gen5/typechart.ts
@@ -1,4 +1,4 @@
-export const BattleTypeChart: {[k: string]: ModdedTypeData | null} = {
+export const DexTypes: {[k: string]: ModdedTypeData | null} = {
 	Electric: {
 		inherit: true,
 		damageTaken: {

--- a/data/mods/gen6/abilities.ts
+++ b/data/mods/gen6/abilities.ts
@@ -1,4 +1,4 @@
-export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
+export const DexAbilities: {[k: string]: ModdedAbilityData} = {
 	aerilate: {
 		inherit: true,
 		desc: "This Pokemon's Normal-type moves become Flying-type moves and have their power multiplied by 1.3. This effect comes after other effects that change a move's type, but before Ion Deluge and Electrify's effects.",

--- a/data/mods/gen6/formats-data.ts
+++ b/data/mods/gen6/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const DexFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen6/items.ts
+++ b/data/mods/gen6/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const DexItems: {[k: string]: ModdedItemData} = {
 	aguavberry: {
 		inherit: true,
 		desc: "Restores 1/8 max HP at 1/2 max HP or less; confuses if -SpD Nature. Single use.",
@@ -203,4 +203,4 @@ export const BattleItems: {[k: string]: ModdedItemData} = {
 	},
 };
 
-exports.BattleItems = BattleItems;
+exports.DexItems = DexItems;

--- a/data/mods/gen6/learnsets.ts
+++ b/data/mods/gen6/learnsets.ts
@@ -1,4 +1,4 @@
-export const BattleLearnsets: {[k: string]: ModdedLearnsetData} = {
+export const DexLearnsets: {[k: string]: ModdedLearnsetData} = {
 	tomohawk: {
 		inherit: true,
 		learnset: {

--- a/data/mods/gen6/moves.ts
+++ b/data/mods/gen6/moves.ts
@@ -1,4 +1,4 @@
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const DexMoves: {[k: string]: ModdedMoveData} = {
 	allyswitch: {
 		inherit: true,
 		desc: "The user swaps positions with its ally on the opposite side of the field. Fails if there is no Pokemon at that position, if the user is the only Pokemon on its side, or if the user is in the middle.",

--- a/data/mods/gen6/pokedex.ts
+++ b/data/mods/gen6/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const DexPokedex: {[k: string]: ModdedSpeciesData} = {
 	charizardmegax: {
 		inherit: true,
 		color: "Red",

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -1078,7 +1078,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 				}
 			}
 
-			for (const typeName in this.dex.data.TypeChart) {
+			for (const typeName in this.dex.data.Types) {
 				// Cover any major weakness (3+) with at least one resistance
 				if (teamData.resistances[typeName] >= 1) continue;
 				if (resistanceAbilities[abilityData.id] && resistanceAbilities[abilityData.id].includes(typeName) || !this.dex.getImmunity(typeName, types)) {

--- a/data/mods/gen6/scripts.ts
+++ b/data/mods/gen6/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const DexScripts: ModdedBattleScriptsData = {
 	inherit: 'gen7',
 	gen: 6,
 };

--- a/data/mods/gen6/statuses.ts
+++ b/data/mods/gen6/statuses.ts
@@ -1,4 +1,4 @@
-export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
+export const DexStatuses: {[k: string]: ModdedPureEffectData} = {
 	brn: {
 		inherit: true,
 		onResidual(pokemon) {

--- a/data/mods/gen6/typechart.ts
+++ b/data/mods/gen6/typechart.ts
@@ -1,4 +1,4 @@
-export const BattleTypeChart: {[k: string]: ModdedTypeData} = {
+export const DexTypes: {[k: string]: ModdedTypeData} = {
 	Dark: {
 		inherit: true,
 		damageTaken: {

--- a/data/mods/gen7/abilities.ts
+++ b/data/mods/gen7/abilities.ts
@@ -1,4 +1,4 @@
-export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
+export const DexAbilities: {[k: string]: ModdedAbilityData} = {
 	chlorophyll: {
 		inherit: true,
 		desc: "If Sunny Day is active, this Pokemon's Speed is doubled.",

--- a/data/mods/gen7/formats-data.ts
+++ b/data/mods/gen7/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const DexFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen7/items.ts
+++ b/data/mods/gen7/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const DexItems: {[k: string]: ModdedItemData} = {
 	abomasite: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -1,4 +1,4 @@
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const DexMoves: {[k: string]: ModdedMoveData} = {
 	"10000000voltthunderbolt": {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/gen7/pokedex.ts
+++ b/data/mods/gen7/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const DexPokedex: {[k: string]: ModdedSpeciesData} = {
 	pikachuoriginal: {
 		inherit: true,
 		abilities: {0: "Static"},

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1162,7 +1162,7 @@ export class RandomGen7Teams extends RandomTeams {
 		const pokemon = [];
 		const pokemonPool = Object.keys(this.randomFactorySets[chosenTier]);
 
-		const typePool = Object.keys(this.dex.data.TypeChart);
+		const typePool = Object.keys(this.dex.data.Types);
 		const type = this.sample(typePool);
 
 		const teamData: TeamData = {
@@ -1296,7 +1296,7 @@ export class RandomGen7Teams extends RandomTeams {
 				}
 			}
 
-			for (const typeName in this.dex.data.TypeChart) {
+			for (const typeName in this.dex.data.Types) {
 				// Cover any major weakness (3+) with at least one resistance
 				if (teamData.resistances[typeName] >= 1) continue;
 				if (
@@ -1529,7 +1529,7 @@ export class RandomGen7Teams extends RandomTeams {
 				}
 			}
 
-			for (const typeName in this.dex.data.TypeChart) {
+			for (const typeName in this.dex.data.Types) {
 				// Cover any major weakness (3+) with at least one resistance
 				if (teamData.resistances[typeName] >= 1) continue;
 				if (

--- a/data/mods/gen7/rulesets.ts
+++ b/data/mods/gen7/rulesets.ts
@@ -1,4 +1,4 @@
-export const BattleFormats: {[k: string]: ModdedFormatsData} = {
+export const DexFormats: {[k: string]: ModdedFormatsData} = {
 	standard: {
 		inherit: true,
 		ruleset: ['Obtainable', 'Team Preview', 'Sleep Clause Mod', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Moody Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],

--- a/data/mods/gen7/scripts.ts
+++ b/data/mods/gen7/scripts.ts
@@ -1,3 +1,3 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const DexScripts: ModdedBattleScriptsData = {
 	gen: 7,
 };

--- a/data/mods/gennext/abilities.ts
+++ b/data/mods/gennext/abilities.ts
@@ -1,4 +1,4 @@
-export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
+export const DexAbilities: {[k: string]: ModdedAbilityData} = {
 	swiftswim: {
 		inherit: true,
 		onModifySpe(spe, pokemon) {
@@ -685,4 +685,4 @@ export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
 	},
 };
 
-exports.BattleAbilities = BattleAbilities;
+exports.DexAbilities = DexAbilities;

--- a/data/mods/gennext/formats-data.ts
+++ b/data/mods/gennext/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const DexFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	aegislash: {
 		inherit: true,
 		tier: "OU",

--- a/data/mods/gennext/items.ts
+++ b/data/mods/gennext/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const DexItems: {[k: string]: ModdedItemData} = {
 	burndrive: {
 		inherit: true,
 		onBasePower(basePower, user, target, move) {},

--- a/data/mods/gennext/moves.ts
+++ b/data/mods/gennext/moves.ts
@@ -1,4 +1,4 @@
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const DexMoves: {[k: string]: ModdedMoveData} = {
 	/******************************************************************
 	Perfect accuracy moves:
 	- base power increased to 90
@@ -2077,4 +2077,4 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 	},
 };
 
-exports.BattleMovedex = BattleMovedex;
+exports.DexMoves = DexMoves;

--- a/data/mods/gennext/pokedex.ts
+++ b/data/mods/gennext/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const DexPokedex: {[k: string]: ModdedSpeciesData} = {
 	genesectdouse: {
 		inherit: true,
 		types: ["Bug", "Water"],

--- a/data/mods/gennext/scripts.ts
+++ b/data/mods/gennext/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const DexScripts: ModdedBattleScriptsData = {
 	inherit: 'gen6',
 	init() {
 		this.modData('Pokedex', 'cherrimsunshine').types = ['Grass', 'Fire'];

--- a/data/mods/gennext/statuses.ts
+++ b/data/mods/gennext/statuses.ts
@@ -1,4 +1,4 @@
-export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
+export const DexStatuses: {[k: string]: ModdedPureEffectData} = {
 	frz: {
 		name: 'frz',
 		effectType: 'Status',

--- a/data/mods/letsgo/formats-data.ts
+++ b/data/mods/letsgo/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const DexFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		inherit: true,
 		tier: "LC",

--- a/data/mods/letsgo/learnsets.ts
+++ b/data/mods/letsgo/learnsets.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 
-export const BattleLearnsets: {[k: string]: ModdedLearnsetData} = {
+export const DexLearnsets: {[k: string]: ModdedLearnsetData} = {
 	bulbasaur: {
 		learnset: {
 			doubleedge: ["7L32"],

--- a/data/mods/letsgo/moves.ts
+++ b/data/mods/letsgo/moves.ts
@@ -1,4 +1,4 @@
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const DexMoves: {[k: string]: ModdedMoveData} = {
 	absorb: {
 		inherit: true,
 		basePower: 40,
@@ -41,7 +41,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		onHit(target, source, effect) {
 			const moves = [];
-			for (const id in exports.BattleMovedex) {
+			for (const id in exports.DexMoves) {
 				const move = this.dex.getMove(id);
 				if (move.realMove) continue;
 				if (move.gen !== 1) continue;

--- a/data/mods/letsgo/pokedex.ts
+++ b/data/mods/letsgo/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const DexPokedex: {[k: string]: ModdedSpeciesData} = {
 	pichu: {
 		inherit: true,
 		evos: [],

--- a/data/mods/letsgo/rulesets.ts
+++ b/data/mods/letsgo/rulesets.ts
@@ -1,4 +1,4 @@
-export const BattleFormats: {[k: string]: ModdedFormatsData} = {
+export const DexFormats: {[k: string]: ModdedFormatsData} = {
 	allowavs: {
 		effectType: 'ValidatorRule',
 		name: 'Allow AVs',

--- a/data/mods/letsgo/scripts.ts
+++ b/data/mods/letsgo/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const DexScripts: ModdedBattleScriptsData = {
 	inherit: 'gen7',
 	init() {
 		this.modData('Abilities', 'noability').isNonstandard = null;
@@ -55,4 +55,4 @@ export const BattleScripts: ModdedBattleScriptsData = {
 	},
 };
 
-exports.BattleScripts = BattleScripts;
+exports.DexScripts = DexScripts;

--- a/data/mods/mixandmega/items.ts
+++ b/data/mods/mixandmega/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const DexItems: {[k: string]: ModdedItemData} = {
 	abomasite: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/mixandmega/scripts.ts
+++ b/data/mods/mixandmega/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const DexScripts: ModdedBattleScriptsData = {
 	init() {
 		for (const i in this.data.Items) {
 			if (!this.data.Items[i].megaStone) continue;

--- a/data/mods/roulettemons/formats-data.ts
+++ b/data/mods/roulettemons/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const DexFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	koatric: {
 		tier: "OU",
 		doublesTier: "DOU",

--- a/data/mods/roulettemons/items.ts
+++ b/data/mods/roulettemons/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const DexItems: {[k: string]: ModdedItemData} = {
 	chillytite: {
 		name: "Chillytite",
 		spritenum: 594,

--- a/data/mods/roulettemons/learnsets.ts
+++ b/data/mods/roulettemons/learnsets.ts
@@ -1,4 +1,4 @@
-export const BattleLearnsets: {[k: string]: ModdedLearnsetData} = {
+export const DexLearnsets: {[k: string]: ModdedLearnsetData} = {
 	koatric: {
 		learnset: {
 			barrage: ["7L1"],

--- a/data/mods/roulettemons/pokedex.ts
+++ b/data/mods/roulettemons/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const DexPokedex: {[k: string]: ModdedSpeciesData} = {
 	koatric: {
 		num: 1.5,
 		name: "Koatric",

--- a/data/mods/ssb/abilities.ts
+++ b/data/mods/ssb/abilities.ts
@@ -1,4 +1,4 @@
-export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
+export const DexAbilities: {[k: string]: ModdedAbilityData} = {
 	/*
 	// Example
 	"abilityid": {

--- a/data/mods/ssb/items.ts
+++ b/data/mods/ssb/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const DexItems: {[k: string]: ModdedItemData} = {
 	// Aeonic
 	noseiumz: {
 		name: "Noseium Z",
@@ -146,4 +146,4 @@ export const BattleItems: {[k: string]: ModdedItemData} = {
 	},
 };
 
-exports.BattleItems = BattleItems;
+exports.DexItems = DexItems;

--- a/data/mods/ssb/moves.ts
+++ b/data/mods/ssb/moves.ts
@@ -2,7 +2,7 @@
 import {RandomStaffBrosTeams} from './random-teams';
 import {Pokemon, EffectState} from '../../../sim/pokemon';
 
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const DexMoves: {[k: string]: ModdedMoveData} = {
 	/*
 	// Example
 	"moveid": {
@@ -2018,7 +2018,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 					this.add('message', `${pokemon.name} was corrupted by a bug in the Scripted Terrain!`);
 					// generate a movepool
 					const moves = [];
-					const pool = this.dex.shuffle(Object.keys(this.dex.data.Movedex));
+					const pool = this.dex.shuffle(Object.keys(this.dex.data.Moves));
 					const metronome = this.dex.getMove('metronome');
 					for (const id of pool) {
 						const move = this.dex.getMove(id);
@@ -2085,8 +2085,8 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		},
 		onHit(target, source, effect) {
 			const moves = [];
-			for (const id in this.dex.data.Movedex) {
-				const move = this.dex.data.Movedex[id];
+			for (const id in this.dex.data.Moves) {
+				const move = this.dex.data.Moves[id];
 				if (move.realMove) continue;
 				if (move.isZ || move.isNonstandard) continue;
 				if (effect.noMetronome && effect.noMetronome.includes(move.name)) continue;
@@ -2875,7 +2875,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 				}
 			}
 			const weaknesses = [];
-			for (const type in this.dex.data.TypeChart) {
+			for (const type in this.dex.data.Types) {
 				const typeMod = this.dex.getEffectiveness(type, targetTypes);
 				if (typeMod > 0 && this.dex.getImmunity(type, target)) weaknesses.push(type);
 			}
@@ -3248,7 +3248,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		onPrepareHit(target, source) {
 			this.add('-anim', source, "Toxic", target);
 		},
-		// Innate corrosive implemented in BattleScripts#setStatus
+		// Innate corrosive implemented in DexScripts#setStatus
 		status: 'tox',
 		secondary: null,
 		target: "normal",
@@ -4505,8 +4505,8 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		},
 		onHit(target, source, effect) {
 			const moves = [];
-			for (const id in exports.BattleMovedex) {
-				const move = exports.BattleMovedex[id];
+			for (const id in exports.DexMoves) {
+				const move = exports.DexMoves[id];
 				if (move.realMove || move.id === 'glitzerpopping') continue;
 				// Calling 1 BP move is somewhat lame and disappointing. However,
 				// signature Z moves are fine, as they actually have a base power.

--- a/data/mods/ssb/pokedex.ts
+++ b/data/mods/ssb/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const DexPokedex: {[k: string]: ModdedSpeciesData} = {
 	/*
 	// Example
 	id: {

--- a/data/mods/ssb/scripts.ts
+++ b/data/mods/ssb/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const DexScripts: ModdedBattleScriptsData = {
 	inherit: 'gen7',
 	runMove(moveOrMoveName, pokemon, targetLoc, sourceEffect, zMove, externalMove) {
 		pokemon.activeMoveActions++;

--- a/data/mods/ssb/statuses.ts
+++ b/data/mods/ssb/statuses.ts
@@ -1,4 +1,4 @@
-export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
+export const DexStatuses: {[k: string]: ModdedPureEffectData} = {
 	/*
 	// Example:
 	userid: {

--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -1,4 +1,4 @@
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const DexMoves: {[k: string]: ModdedMoveData} = {
 	bind: {
 		inherit: true,
 		// FIXME: onBeforeMove() {},

--- a/data/mods/stadium/rulesets.ts
+++ b/data/mods/stadium/rulesets.ts
@@ -1,4 +1,4 @@
-export const BattleFormats: {[k: string]: ModdedFormatsData} = {
+export const DexFormats: {[k: string]: ModdedFormatsData} = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',

--- a/data/mods/stadium/scripts.ts
+++ b/data/mods/stadium/scripts.ts
@@ -1,7 +1,7 @@
 /**
  * Stadium mechanics inherit from gen 1 mechanics, but fixes some stuff.
  */
-export const BattleScripts: ModdedBattleScriptsData = {
+export const DexScripts: ModdedBattleScriptsData = {
 	inherit: 'gen1',
 	gen: 1,
 	// BattlePokemon scripts. Stadium shares gen 1 code but it fixes some problems with it.

--- a/data/mods/stadium/statuses.ts
+++ b/data/mods/stadium/statuses.ts
@@ -1,4 +1,4 @@
-export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
+export const DexStatuses: {[k: string]: ModdedPureEffectData} = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',

--- a/data/mods/vgc17/formats-data.ts
+++ b/data/mods/vgc17/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const DexFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	pikachupartner: {
 		inherit: true,
 		isNonstandard: "Unobtainable",

--- a/data/mods/vgc17/items.ts
+++ b/data/mods/vgc17/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const DexItems: {[k: string]: ModdedItemData} = {
 	kommoniumz: {
 		inherit: true,
 		isNonstandard: "Unobtainable",

--- a/data/mods/vgc17/learnsets.ts
+++ b/data/mods/vgc17/learnsets.ts
@@ -1,4 +1,4 @@
-export const BattleLearnsets: {[k: string]: ModdedLearnsetData} = {
+export const DexLearnsets: {[k: string]: ModdedLearnsetData} = {
 	missingno: {inherit: true, learnset: {
 		blizzard: ["5L1"],
 		bubblebeam: ["5L1"],

--- a/data/mods/vgc17/rulesets.ts
+++ b/data/mods/vgc17/rulesets.ts
@@ -1,4 +1,4 @@
-export const BattleFormats: {[k: string]: ModdedFormatsData} = {
+export const DexFormats: {[k: string]: ModdedFormatsData} = {
 	alolapokedex: {
 		effectType: 'ValidatorRule',
 		name: 'Alola Pokedex',

--- a/data/mods/vgc17/scripts.ts
+++ b/data/mods/vgc17/scripts.ts
@@ -1,3 +1,3 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const DexScripts: ModdedBattleScriptsData = {
 	inherit: 'gen7',
 };

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -26,7 +26,7 @@ sound: Has no effect on Pokemon with the Soundproof Ability.
 
 */
 
-export const BattleMovedex: {[moveid: string]: MoveData} = {
+export const DexMoves: {[moveid: string]: MoveData} = {
 	"10000000voltthunderbolt": {
 		num: 719,
 		accuracy: true,
@@ -2610,9 +2610,9 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 			}
 			const possibleTypes = [];
 			const attackType = target.lastMove.type;
-			for (const type in this.dex.data.TypeChart) {
+			for (const type in this.dex.data.Types) {
 				if (source.hasType(type)) continue;
-				const typeCheck = this.dex.data.TypeChart[type].damageTaken[attackType];
+				const typeCheck = this.dex.data.Types[type].damageTaken[attackType];
 				if (typeCheck === 2 || typeCheck === 3) {
 					possibleTypes.push(type);
 				}
@@ -11481,8 +11481,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		],
 		onHit(target, source, effect) {
 			const moves: MoveData[] = [];
-			for (const id in BattleMovedex) {
-				const move = BattleMovedex[id];
+			for (const id in DexMoves) {
+				const move = DexMoves[id];
 				if (move.realMove) continue;
 				if (move.isZ || move.isMax || move.isNonstandard) continue;
 				if (effect.noMetronome!.includes(move.name)) continue;
@@ -19064,7 +19064,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1},
-		// No Guard-like effect for Poison-type users implemented in BattleScripts#tryMoveHit
+		// No Guard-like effect for Poison-type users implemented in DexScripts#tryMoveHit
 		status: 'tox',
 		secondary: null,
 		target: "normal",

--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
+export const DexPokedex: {[speciesid: string]: SpeciesData} = {
 	bulbasaur: {
 		num: 1,
 		name: "Bulbasaur",

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -161,8 +161,8 @@ export class RandomTeams {
 			let moves;
 			let pool = ['struggle'];
 			if (forme === 'Smeargle') {
-				pool = Object.keys(this.dex.data.Movedex).filter(
-					moveid => !(this.dex.data.Movedex[moveid].isNonstandard || this.dex.data.Movedex[moveid].isZ || moveid.startsWith('hiddenpower') && moveid !== 'hiddenpower')
+				pool = Object.keys(this.dex.data.Moves).filter(
+					moveid => !(this.dex.data.Moves[moveid].isNonstandard || this.dex.data.Moves[moveid].isZ || moveid.startsWith('hiddenpower') && moveid !== 'hiddenpower')
 				);
 			} else {
 				let learnset = this.dex.data.Learnsets[species.id] && this.dex.data.Learnsets[species.id].learnset ?
@@ -303,7 +303,7 @@ export class RandomTeams {
 
 		const itemPool = Object.keys(this.dex.data.Items);
 		const abilityPool = Object.keys(this.dex.data.Abilities);
-		const movePool = Object.keys(this.dex.data.Movedex);
+		const movePool = Object.keys(this.dex.data.Moves);
 		const naturePool = Object.keys(this.dex.data.Natures);
 
 		const random6 = this.random6Pokemon();
@@ -428,7 +428,7 @@ export class RandomTeams {
 		};
 
 		let typeDef: string;
-		for (typeDef in this.dex.data.TypeChart) {
+		for (typeDef in this.dex.data.Types) {
 			counter[typeDef] = 0;
 		}
 
@@ -1391,7 +1391,7 @@ export class RandomTeams {
 
 		// For Monotype
 		const isMonotype = ruleTable.has('sametypeclause');
-		const typePool = Object.keys(this.dex.data.TypeChart);
+		const typePool = Object.keys(this.dex.data.Types);
 		const type = this.sample(typePool);
 
 		// PotD stuff

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1,7 +1,7 @@
 // Note: These are the rules that formats use
 // The list of formats is stored in config/formats.js
 
-export const BattleFormats: {[k: string]: FormatsData} = {
+export const DexFormats: {[k: string]: FormatsData} = {
 
 	// Rulesets
 	///////////////////////////////////////////////////////////////////

--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -1,6 +1,6 @@
 const CHOOSABLE_TARGETS = new Set(['normal', 'any', 'adjacentAlly', 'adjacentAllyOrSelf', 'adjacentFoe']);
 
-export const BattleScripts: BattleScriptsData = {
+export const DexScripts: BattleScriptsData = {
 	gen: 8,
 	/**
 	 * runMove is the "outside" move caller. It handles deducting PP,

--- a/data/statuses.ts
+++ b/data/statuses.ts
@@ -1,4 +1,4 @@
-export const BattleStatuses: {[k: string]: PureEffectData} = {
+export const DexStatuses: {[k: string]: PureEffectData} = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',

--- a/data/typechart.ts
+++ b/data/typechart.ts
@@ -1,4 +1,4 @@
-export const BattleTypeChart: {[k: string]: TypeData} = {
+export const DexTypes: {[k: string]: TypeData} = {
 	Bug: {
 		damageTaken: {
 			Bug: 0,

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -462,7 +462,7 @@ export const commands: ChatCommands = {
 	async savelearnsets(target, room, user) {
 		if (!this.can('hotpatch')) return false;
 		this.sendReply("saving...");
-		await FS('data/learnsets.js').write(`'use strict';\n\nexports.BattleLearnsets = {\n` +
+		await FS('data/learnsets.js').write(`'use strict';\n\nexports.DexLearnsets = {\n` +
 			Object.entries(Dex.data.Learnsets).map(([id, entry]) => (
 				`\t${id}: {learnset: {\n` +
 				Object.entries(Dex.getLearnsetData(id as ID)).sort(

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -837,7 +837,7 @@ export const commands: ChatCommands = {
 		const weaknesses = [];
 		const resistances = [];
 		const immunities = [];
-		for (const type in mod.data.TypeChart) {
+		for (const type in mod.data.Types) {
 			const notImmune = mod.getImmunity(type, species);
 			if (notImmune) {
 				const typeMod = mod.getEffectiveness(type, species);
@@ -975,7 +975,7 @@ export const commands: ChatCommands = {
 		const bestCoverage: {[k: string]: number} = {};
 		let hasThousandArrows = false;
 
-		for (const type in dex.data.TypeChart) {
+		for (const type in dex.data.Types) {
 			// This command uses -5 to designate immunity
 			bestCoverage[type] = -5;
 		}
@@ -996,7 +996,7 @@ export const commands: ChatCommands = {
 			// arg is a type?
 			const argType = arg.charAt(0).toUpperCase() + arg.slice(1);
 			let eff;
-			if (argType in dex.data.TypeChart) {
+			if (argType in dex.data.Types) {
 				sources.push(argType);
 				for (const type in bestCoverage) {
 					if (!dex.getImmunity(argType, type)) continue;
@@ -1077,16 +1077,16 @@ export const commands: ChatCommands = {
 		} else {
 			let buffer = '<div class="scrollable"><table cellpadding="1" width="100%"><tr><th></th>';
 			const icon: {[k: string]: string} = {};
-			for (const type in dex.data.TypeChart) {
+			for (const type in dex.data.Types) {
 				icon[type] = `<img src="https://${Config.routes.client}/sprites/types/${type}.png" width="32" height="14">`;
 				// row of icons at top
 				buffer += `<th>${icon[type]}</th>`;
 			}
 			buffer += '</tr>';
-			for (const type1 in dex.data.TypeChart) {
+			for (const type1 in dex.data.Types) {
 				// assembles the rest of the rows
 				buffer += `<tr><th>${icon[type1]}</th>`;
-				for (const type2 in dex.data.TypeChart) {
+				for (const type2 in dex.data.Types) {
 					let typing: string;
 					let cell = '<th ';
 					let bestEff = -5;

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -290,7 +290,7 @@ export const commands: ChatCommands = {
 		`Parameters separated with '|' will be searched as alternatives for each other, e.g., 'fire | water' searches for all moves that are either Fire type or Water type.`,
 		`If a Pok\u00e9mon is included as a parameter, moves will be searched from its movepool.`,
 		`You can search for info in a specific generation by appending the generation to ms, e.g. '/ms1 normal' searches for all moves that were normal type in Generation I.`,
-		`/ms will search the Galar Movedex; You can search the National Movedex by using '/nms' or by adding 'natdex' as a parameter.`,
+		`/ms will search the Galar Moves; You can search the National Moves by using '/nms' or by adding 'natdex' as a parameter.`,
 		`The order of the parameters does not matter.`,
 	],
 
@@ -387,7 +387,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		doublesnu: '(DUU)', dnu: '(DUU)',
 	});
 	const allTypes = Object.create(null);
-	for (const i in Dex.data.TypeChart) {
+	for (const i in Dex.data.Types) {
 		allTypes[toID(i)] = i;
 	}
 	const allColors = ['green', 'red', 'blue', 'white', 'brown', 'yellow', 'purple', 'pink', 'gray', 'black'];
@@ -661,7 +661,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 
 			if (target === 'priority') {
 				if (parameters.length > 1) return {error: "The parameter 'priority' cannot have alternative parameters"};
-				for (const move in Dex.data.Movedex) {
+				for (const move in Dex.data.Moves) {
 					const moveData = Dex.getMove(move);
 					if (moveData.category === "Status" || moveData.id === "bide") continue;
 					if (moveData.priority > 0) {
@@ -682,7 +682,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 
 			if (target.substr(0, 8) === 'resists ') {
 				const targetResist = target.substr(8, 1).toUpperCase() + target.substr(9);
-				if (targetResist in Dex.data.TypeChart) {
+				if (targetResist in Dex.data.Types) {
 					const invalid = validParameter("resists", targetResist, isNotSearch, target);
 					if (invalid) return {error: invalid};
 					orGroup.resists[targetResist] = !isNotSearch;
@@ -694,7 +694,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 
 			if (target.substr(0, 5) === 'weak ') {
 				const targetWeak = target.substr(5, 1).toUpperCase() + target.substr(6);
-				if (targetWeak in Dex.data.TypeChart) {
+				if (targetWeak in Dex.data.Types) {
 					const invalid = validParameter("weak", targetWeak, isNotSearch, target);
 					if (invalid) return {error: invalid};
 					orGroup.weak[targetWeak] = !isNotSearch;
@@ -1027,7 +1027,7 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 	const allVolatileStatus = ['flinch', 'confusion', 'partiallytrapped'];
 	const allBoosts = ['hp', 'atk', 'def', 'spa', 'spd', 'spe', 'accuracy', 'evasion'];
 	const allTypes: {[k: string]: string} = Object.create(null);
-	for (const i in Dex.data.TypeChart) {
+	for (const i in Dex.data.Types) {
 		allTypes[toID(i)] = i;
 	}
 	let showAll = false;
@@ -1390,7 +1390,7 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 
 	// Since we assume we have no target mons at first
 	// then the valid moveset we can search is the set of all moves.
-	const validMoves = new Set(Object.keys(Dex.data.Movedex));
+	const validMoves = new Set(Object.keys(Dex.data.Moves));
 	validMoves.delete('magikarpsrevenge');
 	for (const mon of targetMons) {
 		const species = mod.getSpecies(mon.name);
@@ -1803,7 +1803,7 @@ function runItemsearch(target: string, cmd: string, canAll: boolean, message: st
 
 		for (let word of searchedWords) {
 			word = word.charAt(0).toUpperCase() + word.slice(1);
-			if (word in Dex.data.TypeChart) {
+			if (word in Dex.data.Types) {
 				if (type) return {error: "Only specify natural gift type once."};
 				type = word;
 			} else {

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1885,7 +1885,7 @@ export class Pokemon {
 	/** false = immune, true = not immune */
 	runImmunity(type: string, message?: string | boolean) {
 		if (!type || type === '???') return true;
-		if (!(type in this.battle.dex.data.TypeChart)) {
+		if (!(type in this.battle.dex.data.Types)) {
 			if (type === 'Fairy' || type === 'Dark' || type === 'Steel') return true;
 			throw new Error("Use runStatusImmunity for " + type);
 		}

--- a/sim/tools/exhaustive-runner.ts
+++ b/sim/tools/exhaustive-runner.ts
@@ -115,7 +115,7 @@ export class ExhaustiveRunner {
 				(_, p) => (p.name !== 'Pichu-Spiky-eared' && p.name.substr(0, 8) !== 'Pikachu-')), this.prng),
 			items: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Items, i => dex.getItem(i)), this.prng),
 			abilities: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Abilities, a => dex.getAbility(a)), this.prng),
-			moves: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Movedex, m => dex.getMove(m),
+			moves: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Moves, m => dex.getMove(m),
 				m => (m !== 'struggle' && (m === 'hiddenpower' || m.substr(0, 11) !== 'hiddenpower'))), this.prng),
 		};
 	}

--- a/test/sim/data.js
+++ b/test/sim/data.js
@@ -111,10 +111,10 @@ describe('Dex data', function () {
 		}
 	});
 
-	it('should have valid Movedex entries', function () {
-		const Movedex = Dex.data.Movedex;
-		for (const moveid in Movedex) {
-			const entry = Movedex[moveid];
+	it('should have valid Moves entries', function () {
+		const Moves = Dex.data.Moves;
+		for (const moveid in Moves) {
+			const entry = Moves[moveid];
 			assert.equal(toID(entry.name), moveid, `Mismatched Move key "${moveid}" of "${entry.name}"`);
 			assert.equal(typeof entry.num, 'number', `Move ${entry.name} should have a number`);
 			assert.false(entry.infiltrates, `Move ${entry.name} should not have an 'infiltrates' property (no real move has it)`);


### PR DESCRIPTION
Files in `data/` now export `Dex...` instead of `Battle...`.

- `BattlePokedex` -> `DexPokedex`, etc

In addition, this is a good time to rename `Movedex` to `Moves` and `TypeChart` to `Types`.