### PR TITLE
Set random battle levels by species

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -1,5254 +1,5587 @@
 export const BattleFormatsData: {[k: string]: SpeciesFormatsData} = {
-	bulbasaur: {
-		tier: "LC",
-	},
-	ivysaur: {
-		tier: "NFE",
-	},
-	venusaur: {
-		randomBattleMoves: ["gigadrain", "leechseed", "sleeppowder", "sludgebomb", "substitute"],
-		randomDoubleBattleMoves: ["earthpower", "gigadrain", "leechseed", "protect", "sleeppowder", "sludgebomb"],
-		tier: "UUBL",
-		doublesTier: "DOU",
-	},
-	venusaurmega: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	charmander: {
-		tier: "LC",
-	},
-	charmeleon: {
-		tier: "NFE",
-	},
-	charizard: {
-		randomBattleMoves: ["airslash", "earthquake", "fireblast", "focusblast", "roost"],
-		randomDoubleBattleMoves: ["airslash", "dragonpulse", "heatwave", "overheat", "protect", "tailwind"],
-		tier: "RU",
-		doublesTier: "DOU",
-	},
-	charizardmegax: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	charizardmegay: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	charizardgmax: {
-		randomDoubleBattleMoves: ["earthquake", "focusblast", "heatwave", "hurricane", "protect", "tailwind"],
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	squirtle: {
-		tier: "LC",
-	},
-	wartortle: {
-		tier: "NFE",
-	},
-	blastoise: {
-		randomBattleMoves: ["earthquake", "hydropump", "icebeam", "rapidspin", "scald", "shellsmash"],
-		randomDoubleBattleMoves: ["fakeout", "followme", "icywind", "lifedew", "muddywater", "protect", "scald"],
-		tier: "UU",
-		doublesTier: "DOU",
-	},
-	blastoisemega: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	caterpie: {
-		tier: "LC",
-	},
-	metapod: {
-		tier: "NFE",
-	},
-	butterfree: {
-		randomBattleMoves: ["energyball", "hurricane", "quiverdance", "sleeppowder"],
-		randomDoubleBattleMoves: ["hurricane", "pollenpuff", "protect", "quiverdance", "ragepowder", "sleeppowder", "tailwind"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	butterfreegmax: {
-		randomBattleMoves: ["airslash", "bugbuzz", "quiverdance", "sleeppowder"],
-		randomDoubleBattleMoves: ["hurricane", "pollenpuff", "protect", "quiverdance", "ragepowder", "sleeppowder", "tailwind"],
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	weedle: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	kakuna: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	beedrill: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	beedrillmega: {
-		isNonstandard: "Past",
-	},
-	pidgey: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pidgeotto: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pidgeot: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pidgeotmega: {
-		isNonstandard: "Past",
-	},
-	rattata: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	rattataalola: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	raticate: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	raticatealola: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	raticatealolatotem: {
-		isNonstandard: "Past",
-	},
-	spearow: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	fearow: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	ekans: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	arbok: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pichu: {
-		tier: "LC",
-	},
-	pichuspikyeared: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pikachu: {
-		randomBattleMoves: ["irontail", "knockoff", "surf", "voltswitch", "volttackle"],
-		randomDoubleBattleMoves: ["extremespeed", "fakeout", "knockoff", "surf", "volttackle"],
-		tier: "PU",
-		doublesTier: "NFE",
-	},
-	pikachucosplay: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pikachurockstar: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pikachubelle: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pikachupopstar: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pikachuphd: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pikachulibre: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pikachuoriginal: {
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	pikachuhoenn: {
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	pikachusinnoh: {
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	pikachuunova: {
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	pikachukalos: {
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	pikachualola: {
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	pikachupartner: {
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	pikachustarter: {
-		isNonstandard: "LGPE",
-		tier: "Illegal",
-	},
-	pikachugmax: {
-		randomDoubleBattleMoves: ["extremespeed", "fakeout", "knockoff", "surf", "volttackle"],
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	raichu: {
-		randomBattleMoves: ["encore", "focusblast", "grassknot", "nastyplot", "thunderbolt", "voltswitch"],
-		randomDoubleBattleMoves: ["fakeout", "followme", "grassknot", "nuzzle", "protect", "thunderbolt"],
-		tier: "PU",
-		doublesTier: "DUU",
-	},
-	raichualola: {
-		randomBattleMoves: ["focusblast", "grassknot", "nastyplot", "psyshock", "thunderbolt", "voltswitch"],
-		randomDoubleBattleMoves: ["focusblast", "nastyplot", "protect", "psychic", "psyshock", "surf", "thunderbolt"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	sandshrew: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	sandshrewalola: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	sandslash: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	sandslashalola: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	nidoranf: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	nidorina: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	nidoqueen: {
-		randomBattleMoves: ["earthpower", "icebeam", "sludgewave", "stealthrock", "toxicspikes"],
-		randomDoubleBattleMoves: ["earthpower", "fireblast", "icebeam", "sludgebomb", "stealthrock"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	nidoranm: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	nidorino: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	nidoking: {
-		randomBattleMoves: ["earthpower", "icebeam", "sludgewave", "substitute", "superpower"],
-		randomDoubleBattleMoves: ["earthpower", "fireblast", "icebeam", "protect", "sludgebomb", "superpower"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	cleffa: {
-		tier: "LC",
-	},
-	clefairy: {
-		tier: "NU",
-		doublesTier: "DUU",
-	},
-	clefable: {
-		randomBattleMoves: ["calmmind", "fireblast", "moonblast", "softboiled", "stealthrock", "thunderwave"],
-		randomDoubleBattleMoves: ["fireblast", "followme", "healpulse", "helpinghand", "moonblast", "protect", "thunderwave"],
-		tier: "OU",
-		doublesTier: "(DUU)",
-	},
-	vulpix: {
-		tier: "LC Uber",
-	},
-	vulpixalola: {
-		tier: "LC Uber",
-	},
-	ninetales: {
-		randomBattleMoves: ["fireblast", "nastyplot", "solarbeam", "substitute", "willowisp"],
-		randomDoubleBattleMoves: ["encore", "heatwave", "nastyplot", "protect", "solarbeam"],
-		tier: "RU",
-		doublesTier: "DUU",
-	},
-	ninetalesalola: {
-		randomBattleMoves: ["auroraveil", "blizzard", "freezedry", "moonblast", "nastyplot", "substitute"],
-		randomDoubleBattleMoves: ["auroraveil", "blizzard", "encore", "freezedry", "moonblast", "protect"],
-		tier: "UUBL",
-		doublesTier: "DUU",
-	},
-	igglybuff: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	jigglypuff: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	wigglytuff: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	zubat: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	golbat: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	crobat: {
-		randomBattleMoves: ["bravebird", "defog", "roost", "superfang", "taunt", "toxic", "uturn"],
-		randomDoubleBattleMoves: ["bravebird", "defog", "roost", "superfang", "tailwind", "taunt"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	oddish: {
-		tier: "LC",
-	},
-	gloom: {
-		tier: "NFE",
-	},
-	vileplume: {
-		randomBattleMoves: ["aromatherapy", "gigadrain", "sleeppowder", "sludgebomb", "strengthsap"],
-		randomDoubleBattleMoves: ["aromatherapy", "gigadrain", "pollenpuff", "sleeppowder", "sludgebomb", "strengthsap"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	bellossom: {
-		randomBattleMoves: ["gigadrain", "moonblast", "quiverdance", "sleeppowder", "strengthsap"],
-		randomDoubleBattleMoves: ["gigadrain", "moonblast", "quiverdance", "sleeppowder", "strengthsap"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	paras: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	parasect: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	venonat: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	venomoth: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	diglett: {
-		tier: "LC",
-	},
-	diglettalola: {
-		tier: "LC",
-	},
-	dugtrio: {
-		randomBattleMoves: ["earthquake", "memento", "reversal", "stealthrock", "stoneedge", "substitute"],
-		randomDoubleBattleMoves: ["highhorsepower", "memento", "protect", "rockslide", "substitute", "suckerpunch"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	dugtrioalola: {
-		randomBattleMoves: ["earthquake", "ironhead", "memento", "stoneedge", "suckerpunch"],
-		randomDoubleBattleMoves: ["highhorsepower", "ironhead", "memento", "protect", "rockslide", "suckerpunch"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	meowth: {
-		tier: "LC",
-	},
-	meowthalola: {
-		tier: "LC",
-	},
-	meowthgalar: {
-		tier: "LC",
-	},
-	meowthgmax: {
-		unreleasedHidden: true,
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	persian: {
-		randomBattleMoves: ["doubleedge", "fakeout", "knockoff", "playrough", "uturn"],
-		randomDoubleBattleMoves: ["doubleedge", "fakeout", "foulplay", "hypnosis", "icywind", "taunt"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	persianalola: {
-		randomBattleMoves: ["darkpulse", "hypnosis", "nastyplot", "powergem", "thunderbolt"],
-		randomDoubleBattleMoves: ["fakeout", "foulplay", "icywind", "partingshot", "protect", "snarl", "taunt"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	perrserker: {
-		randomBattleMoves: ["closecombat", "crunch", "fakeout", "ironhead", "swordsdance", "uturn"],
-		randomDoubleBattleMoves: ["closecombat", "crunch", "fakeout", "ironhead", "seedbomb", "swordsdance", "uturn"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	psyduck: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	golduck: {
-		randomBattleMoves: ["calmmind", "focusblast", "icebeam", "psyshock", "scald", "substitute"],
-		randomDoubleBattleMoves: ["calmmind", "encore", "icebeam", "muddywater", "protect", "psyshock"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	mankey: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	primeape: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	growlithe: {
-		tier: "LC",
-	},
-	arcanine: {
-		randomBattleMoves: ["closecombat", "crunch", "extremespeed", "flareblitz", "morningsun", "roar", "wildcharge", "willowisp"],
-		randomDoubleBattleMoves: ["closecombat", "extremespeed", "flareblitz", "morningsun", "protect", "snarl", "willowisp"],
-		tier: "UU",
-		doublesTier: "DOU",
-	},
-	poliwag: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	poliwhirl: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	poliwrath: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	politoed: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	abra: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	kadabra: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	alakazam: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	alakazammega: {
-		isNonstandard: "Past",
-	},
-	machop: {
-		tier: "LC",
-	},
-	machoke: {
-		tier: "NFE",
-	},
-	machamp: {
-		randomBattleMoves: ["bulletpunch", "closecombat", "dynamicpunch", "facade", "knockoff", "stoneedge"],
-		randomDoubleBattleMoves: ["bulletpunch", "closecombat", "facade", "knockoff", "poisonjab", "protect"],
-		tier: "UU",
-		doublesTier: "DUU",
-	},
-	machampgmax: {
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	bellsprout: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	weepinbell: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	victreebel: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	tentacool: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	tentacruel: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	geodude: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	geodudealola: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	graveler: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	graveleralola: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	golem: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	golemalola: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	ponyta: {
-		tier: "LC",
-	},
-	ponytagalar: {
-		tier: "LC",
-	},
-	rapidash: {
-		randomBattleMoves: ["flareblitz", "highhorsepower", "morningsun", "swordsdance", "wildcharge", "willowisp"],
-		randomDoubleBattleMoves: ["flareblitz", "highhorsepower", "morningsun", "protect", "swordsdance", "wildcharge"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	rapidashgalar: {
-		randomBattleMoves: ["highhorsepower", "morningsun", "playrough", "swordsdance", "zenheadbutt"],
-		randomDoubleBattleMoves: ["highhorsepower", "playrough", "protect", "swordsdance", "zenheadbutt"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	slowpoke: {
-		isNonstandard: "Unobtainable",
-		tier: "Unreleased",
-	},
-	slowpokegalar: {
-		unreleasedHidden: true,
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	slowbro: {
-		randomBattleMoves: ["calmmind", "icebeam", "psyshock", "scald", "slackoff", "teleport"],
-		randomDoubleBattleMoves: ["calmmind", "fireblast", "icebeam", "psychic", "psyshock", "scald", "slackoff", "trickroom"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	slowbromega: {
-		isNonstandard: "Past",
-	},
-	slowking: {
-		randomBattleMoves: ["dragontail", "fireblast", "icebeam", "psyshock", "scald", "slackoff", "toxic", "trickroom"],
-		randomDoubleBattleMoves: ["fireblast", "icebeam", "nastyplot", "psychic", "psyshock", "scald", "slackoff", "trickroom"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	magnemite: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	magneton: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	magnezone: {
-		randomBattleMoves: ["bodypress", "flashcannon", "mirrorcoat", "thunderbolt", "voltswitch"],
-		randomDoubleBattleMoves: ["allyswitch", "bodypress", "flashcannon", "protect", "thunderbolt", "voltswitch"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	farfetchd: {
-		randomBattleMoves: ["bravebird", "closecombat", "knockoff", "leafblade", "slash", "swordsdance"],
-		randomDoubleBattleMoves: ["bravebird", "closecombat", "leafblade", "protect", "quickattack", "slash", "swordsdance"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	farfetchdgalar: {
-		tier: "LC",
-	},
-	sirfetchd: {
-		randomBattleMoves: ["bravebird", "closecombat", "firstimpression", "knockoff", "swordsdance"],
-		randomDoubleBattleMoves: ["bravebird", "closecombat", "firstimpression", "knockoff", "poisonjab", "protect", "swordsdance"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	doduo: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	dodrio: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	seel: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	dewgong: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	grimer: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	grimeralola: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	muk: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	mukalola: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	shellder: {
-		tier: "LC",
-	},
-	cloyster: {
-		randomBattleMoves: ["explosion", "hydropump", "iciclespear", "rockblast", "shellsmash"],
-		randomDoubleBattleMoves: ["iceshard", "iciclespear", "liquidation", "protect", "rockblast", "shellsmash"],
-		tier: "OU",
-		doublesTier: "(DUU)",
-	},
-	gastly: {
-		tier: "LC Uber",
-	},
-	haunter: {
-		tier: "NUBL",
-		doublesTier: "NFE",
-	},
-	gengar: {
-		randomDoubleBattleMoves: ["focusblast", "nastyplot", "protect", "shadowball", "sludgebomb", "thunderbolt", "trick", "willowisp"],
-		tier: "OU",
-		doublesTier: "DUU",
-	},
-	gengarmega: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	gengargmax: {
-		randomBattleMoves: ["focusblast", "nastyplot", "shadowball", "sludgewave", "trick"],
-		randomDoubleBattleMoves: ["focusblast", "nastyplot", "protect", "shadowball", "sludgebomb", "thunderbolt", "willowisp"],
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	onix: {
-		tier: "LC",
-	},
-	steelix: {
-		randomBattleMoves: ["dragondance", "earthquake", "headsmash", "heavyslam", "stealthrock"],
-		randomDoubleBattleMoves: ["earthquake", "headsmash", "heavyslam", "protect", "rockpolish", "wideguard"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	steelixmega: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	drowzee: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	hypno: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	krabby: {
-		tier: "LC",
-	},
-	kingler: {
-		randomBattleMoves: ["agility", "liquidation", "rockslide", "superpower", "swordsdance", "xscissor"],
-		randomDoubleBattleMoves: ["agility", "knockoff", "liquidation", "protect", "superpower", "xscissor"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	kinglergmax: {
-		randomDoubleBattleMoves: ["knockoff", "liquidation", "protect", "superpower", "xscissor"],
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	voltorb: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	electrode: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	exeggcute: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	exeggutor: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	exeggutoralola: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	cubone: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	marowak: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	marowakalola: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	marowakalolatotem: {
-		isNonstandard: "Past",
-	},
-	tyrogue: {
-		tier: "LC",
-	},
-	hitmonlee: {
-		randomBattleMoves: ["fakeout", "highjumpkick", "knockoff", "machpunch", "poisonjab", "rapidspin", "stoneedge"],
-		randomDoubleBattleMoves: ["closecombat", "fakeout", "poisonjab", "protect", "rockslide", "throatchop"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	hitmonchan: {
-		randomBattleMoves: ["bulkup", "drainpunch", "icepunch", "machpunch", "rapidspin", "stoneedge"],
-		randomDoubleBattleMoves: ["drainpunch", "feint", "firepunch", "icepunch", "machpunch", "protect"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	hitmontop: {
-		randomBattleMoves: ["closecombat", "machpunch", "rapidspin", "stoneedge", "suckerpunch", "toxic"],
-		randomDoubleBattleMoves: ["closecombat", "fakeout", "feint", "helpinghand", "suckerpunch", "wideguard"],
-		tier: "PU",
-		doublesTier: "DUU",
-	},
-	lickitung: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	lickilicky: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	koffing: {
-		tier: "LC",
-	},
-	weezing: {
-		randomBattleMoves: ["fireblast", "painsplit", "sludgebomb", "toxicspikes", "willowisp"],
-		randomDoubleBattleMoves: ["clearsmog", "fireblast", "painsplit", "sludgebomb", "willowisp"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	weezinggalar: {
-		randomBattleMoves: ["defog", "fireblast", "painsplit", "sludgebomb", "strangesteam", "toxicspikes", "willowisp"],
-		randomDoubleBattleMoves: ["clearsmog", "fireblast", "painsplit", "strangesteam", "willowisp"],
-		tier: "UU",
-		doublesTier: "DUU",
-	},
-	rhyhorn: {
-		tier: "LC",
-	},
-	rhydon: {
-		tier: "RU",
-		doublesTier: "NFE",
-	},
-	rhyperior: {
-		randomBattleMoves: ["earthquake", "firepunch", "megahorn", "rockblast", "rockpolish", "stealthrock", "stoneedge"],
-		randomDoubleBattleMoves: ["highhorsepower", "icepunch", "megahorn", "protect", "rockslide", "stoneedge"],
-		tier: "UU",
-		doublesTier: "DOU",
-	},
-	happiny: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	chansey: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	blissey: {
-		randomBattleMoves: ["healbell", "seismictoss", "softboiled", "stealthrock", "toxic"],
-		randomDoubleBattleMoves: ["allyswitch", "healbell", "protect", "seismictoss", "softboiled", "thunderwave", "toxic"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	tangela: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	tangrowth: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	kangaskhan: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	kangaskhanmega: {
-		isNonstandard: "Past",
-	},
-	horsea: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	seadra: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	kingdra: {
-		randomBattleMoves: ["dracometeor", "hurricane", "hydropump", "icebeam", "toxic"],
-		randomDoubleBattleMoves: ["dragonpulse", "hurricane", "hydropump", "icebeam", "muddywater", "raindance"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	goldeen: {
-		tier: "LC",
-	},
-	seaking: {
-		randomBattleMoves: ["drillrun", "knockoff", "megahorn", "swordsdance", "waterfall"],
-		randomDoubleBattleMoves: ["drillrun", "knockoff", "megahorn", "protect", "swordsdance", "waterfall"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	staryu: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	starmie: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	mimejr: {
-		tier: "LC",
-	},
-	mrmime: {
-		randomBattleMoves: ["dazzlinggleam", "focusblast", "healingwish", "nastyplot", "psychic"],
-		randomDoubleBattleMoves: ["dazzlinggleam", "fakeout", "icywind", "lightscreen", "psychic", "psyshock", "reflect"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	mrmimegalar: {
-		randomBattleMoves: ["focusblast", "freezedry", "nastyplot", "psychic", "rapidspin"],
-		randomDoubleBattleMoves: ["fakeout", "focusblast", "freezedry", "nastyplot", "protect", "psychic", "psyshock"],
-		tier: "NU",
-		doublesTier: "NFE",
-	},
-	mrrime: {
-		randomBattleMoves: ["focusblast", "freezedry", "psychic", "rapidspin", "slackoff", "trick"],
-		randomDoubleBattleMoves: ["fakeout", "focusblast", "freezedry", "icywind", "protect", "psychic", "psyshock", "rapidspin"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	scyther: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	scizor: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	scizormega: {
-		isNonstandard: "Past",
-	},
-	smoochum: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	jynx: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	elekid: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	electabuzz: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	electivire: {
-		randomBattleMoves: ["crosschop", "earthquake", "flamethrower", "icepunch", "voltswitch", "wildcharge"],
-		randomDoubleBattleMoves: ["crosschop", "earthquake", "flamethrower", "icepunch", "wildcharge"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	magby: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	magmar: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	magmortar: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pinsir: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pinsirmega: {
-		isNonstandard: "Past",
-	},
-	tauros: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	magikarp: {
-		tier: "LC",
-	},
-	gyarados: {
-		randomBattleMoves: ["bounce", "dragondance", "earthquake", "powerwhip", "waterfall"],
-		randomDoubleBattleMoves: ["dragondance", "earthquake", "icefang", "powerwhip", "protect", "waterfall"],
-		tier: "UUBL",
-		doublesTier: "DUU",
-	},
-	gyaradosmega: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	lapras: {
-		tier: "PU",
-		doublesTier: "DUU",
-	},
-	laprasgmax: {
-		randomBattleMoves: ["freezedry", "icebeam", "sparklingaria", "substitute", "thunderbolt", "toxic"],
-		randomDoubleBattleMoves: ["freezedry", "helpinghand", "hydropump", "protect", "scald"],
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	ditto: {
-		randomBattleMoves: ["transform"],
-		randomDoubleBattleMoves: ["transform"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	eevee: {
-		tier: "LC",
-	},
-	eeveestarter: {
-		isNonstandard: "LGPE",
-		tier: "Illegal",
-	},
-	eeveegmax: {
-		unreleasedHidden: true,
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	vaporeon: {
-		randomBattleMoves: ["healbell", "icebeam", "protect", "scald", "toxic", "wish"],
-		randomDoubleBattleMoves: ["healbell", "icywind", "protect", "scald", "toxic", "wish"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	jolteon: {
-		randomBattleMoves: ["hypervoice", "shadowball", "thunderbolt", "voltswitch"],
-		randomDoubleBattleMoves: ["faketears", "protect", "shadowball", "thunderbolt", "thunderwave", "voltswitch"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	flareon: {
-		randomBattleMoves: ["facade", "flamecharge", "flareblitz", "quickattack", "superpower"],
-		randomDoubleBattleMoves: ["facade", "flamecharge", "flareblitz", "protect", "quickattack", "superpower"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	espeon: {
-		randomBattleMoves: ["calmmind", "dazzlinggleam", "morningsun", "psychic", "shadowball"],
-		randomDoubleBattleMoves: ["calmmind", "dazzlinggleam", "morningsun", "protect", "psychic", "psyshock", "shadowball"],
-		tier: "UU",
-		doublesTier: "DUU",
-	},
-	umbreon: {
-		randomBattleMoves: ["foulplay", "protect", "toxic", "wish", "yawn"],
-		randomDoubleBattleMoves: ["foulplay", "helpinghand", "moonlight", "snarl", "toxic", "yawn"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	leafeon: {
-		randomBattleMoves: ["doubleedge", "knockoff", "leafblade", "swordsdance", "synthesis", "xscissor"],
-		randomDoubleBattleMoves: ["doubleedge", "knockoff", "leafblade", "protect", "swordsdance"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	glaceon: {
-		randomBattleMoves: ["freezedry", "protect", "shadowball", "toxic", "wish"],
-		randomDoubleBattleMoves: ["blizzard", "freezedry", "helpinghand", "protect", "shadowball", "wish"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	sylveon: {
-		randomBattleMoves: ["calmmind", "hypervoice", "mysticalfire", "protect", "psyshock", "shadowball", "wish"],
-		randomDoubleBattleMoves: ["calmmind", "hypervoice", "mysticalfire", "protect", "psyshock", "wish"],
-		tier: "UU",
-		doublesTier: "DOU",
-	},
-	porygon: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	porygon2: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	porygonz: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	omanyte: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	omastar: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	kabuto: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	kabutops: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	aerodactyl: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	aerodactylmega: {
-		isNonstandard: "Past",
-	},
-	munchlax: {
-		tier: "LC",
-	},
-	snorlax: {
-		randomBattleMoves: ["darkestlariat", "doubleedge", "earthquake", "facade", "heatcrash"],
-		tier: "RU",
-		doublesTier: "DUU",
-	},
-	snorlaxgmax: {
-		randomBattleMoves: ["bodyslam", "curse", "darkestlariat", "earthquake", "rest"],
-		randomDoubleBattleMoves: ["bodyslam", "curse", "darkestlariat", "highhorsepower", "recycle"],
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	articuno: {
-		randomBattleMoves: ["defog", "freezedry", "healbell", "roost", "toxic"],
-		randomDoubleBattleMoves: ["freezedry", "healbell", "hurricane", "icebeam", "roost", "toxic"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	zapdos: {
-		randomBattleMoves: ["defog", "discharge", "heatwave", "hurricane", "roost"],
-		randomDoubleBattleMoves: ["heatwave", "hurricane", "roost", "tailwind", "thunderbolt", "voltswitch"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	moltres: {
-		randomBattleMoves: ["airslash", "defog", "fireblast", "roost", "uturn"],
-		randomDoubleBattleMoves: ["fireblast", "heatwave", "hurricane", "protect", "roost", "tailwind"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	dratini: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	dragonair: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	dragonite: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	mewtwo: {
-		randomBattleMoves: ["aurasphere", "icebeam", "nastyplot", "psystrike", "recover"],
-		randomDoubleBattleMoves: ["aurasphere", "calmmind", "icebeam", "psystrike", "recover"],
-		tier: "Uber",
-		doublesTier: "DUber",
-	},
-	mewtwomegax: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	mewtwomegay: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	mew: {
-		randomBattleMoves: ["bravebird", "closecombat", "flareblitz", "psychicfangs", "swordsdance"],
-		randomDoubleBattleMoves: ["imprison", "protect", "psychic", "transform"],
-		tier: "OU",
-		doublesTier: "DOU",
-	},
-	chikorita: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	bayleef: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	meganium: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	cyndaquil: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	quilava: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	typhlosion: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	totodile: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	croconaw: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	feraligatr: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	sentret: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	furret: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	hoothoot: {
-		tier: "LC",
-	},
-	noctowl: {
-		randomBattleMoves: ["airslash", "defog", "heatwave", "hurricane", "nastyplot", "roost"],
-		randomDoubleBattleMoves: ["heatwave", "hurricane", "hypervoice", "nastyplot", "roost", "tailwind"],
-		tier: "PUBL",
-		doublesTier: "(DUU)",
-	},
-	ledyba: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	ledian: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	spinarak: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	ariados: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	chinchou: {
-		tier: "LC",
-	},
-	lanturn: {
-		randomBattleMoves: ["healbell", "icebeam", "scald", "thunderbolt", "toxic", "voltswitch"],
-		randomDoubleBattleMoves: ["healbell", "icebeam", "protect", "scald", "thunderbolt", "thunderwave"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	togepi: {
-		tier: "LC",
-	},
-	togetic: {
-		tier: "NFE",
-		doublesTier: "DUU",
-	},
-	togekiss: {
-		randomBattleMoves: ["airslash", "aurasphere", "fireblast", "nastyplot", "roost", "thunderwave", "trick"],
-		randomDoubleBattleMoves: ["airslash", "followme", "heatwave", "protect", "roost", "tailwind", "thunderwave"],
-		tier: "OU",
-		doublesTier: "DOU",
-	},
-	natu: {
-		tier: "LC",
-	},
-	xatu: {
-		randomBattleMoves: ["heatwave", "lightscreen", "psychic", "reflect", "roost", "teleport"],
-		randomDoubleBattleMoves: ["airslash", "heatwave", "lightscreen", "psychic", "psyshock", "reflect", "roost", "tailwind"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	mareep: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	flaaffy: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	ampharos: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	ampharosmega: {
-		isNonstandard: "Past",
-	},
-	azurill: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	marill: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	azumarill: {
-		randomBattleMoves: ["aquajet", "bellydrum", "knockoff", "liquidation", "playrough", "superpower"],
-		randomDoubleBattleMoves: ["aquajet", "icepunch", "knockoff", "liquidation", "playrough", "protect", "superpower"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	bonsly: {
-		tier: "LC",
-	},
-	sudowoodo: {
-		randomBattleMoves: ["earthquake", "headsmash", "stealthrock", "suckerpunch", "woodhammer"],
-		randomDoubleBattleMoves: ["bodypress", "firepunch", "headsmash", "protect", "suckerpunch", "woodhammer"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	hoppip: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	skiploom: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	jumpluff: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	aipom: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	ambipom: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	sunkern: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	sunflora: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	yanma: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	yanmega: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	wooper: {
-		tier: "LC",
-	},
-	quagsire: {
-		randomBattleMoves: ["earthquake", "encore", "icebeam", "recover", "scald", "toxic"],
-		randomDoubleBattleMoves: ["highhorsepower", "protect", "recover", "scald", "toxic"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	murkrow: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	honchkrow: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	misdreavus: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	mismagius: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	unown: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	wynaut: {
-		tier: "LC",
-	},
-	wobbuffet: {
-		randomBattleMoves: ["counter", "destinybond", "encore", "mirrorcoat"],
-		randomDoubleBattleMoves: ["charm", "counter", "encore", "mirrorcoat"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	girafarig: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pineco: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	forretress: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	dunsparce: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	gligar: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	gliscor: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	snubbull: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	granbull: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	qwilfish: {
-		randomBattleMoves: ["destinybond", "spikes", "taunt", "thunderwave", "toxicspikes", "waterfall"],
-		randomDoubleBattleMoves: ["liquidation", "poisonjab", "protect", "swordsdance", "taunt", "thunderwave"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	shuckle: {
-		randomBattleMoves: ["encore", "infestation", "knockoff", "stealthrock", "stickyweb", "toxic"],
-		randomDoubleBattleMoves: ["acupressure", "guardsplit", "helpinghand", "infestation", "knockoff", "stealthrock", "stickyweb", "toxic"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	heracross: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	heracrossmega: {
-		isNonstandard: "Past",
-	},
-	sneasel: {
-		tier: "NUBL",
-		doublesTier: "LC Uber",
-	},
-	weavile: {
-		randomBattleMoves: ["iceshard", "iciclecrash", "knockoff", "lowkick", "swordsdance"],
-		randomDoubleBattleMoves: ["fakeout", "iceshard", "iciclecrash", "knockoff", "lowkick", "protect", "swordsdance"],
-		tier: "UUBL",
-		doublesTier: "DUU",
-	},
-	teddiursa: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	ursaring: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	slugma: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	magcargo: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	swinub: {
-		tier: "LC",
-	},
-	piloswine: {
-		tier: "NU",
-		doublesTier: "NFE",
-	},
-	mamoswine: {
-		randomBattleMoves: ["earthquake", "iceshard", "iciclecrash", "knockoff", "stealthrock", "superpower"],
-		randomDoubleBattleMoves: ["highhorsepower", "iceshard", "iciclecrash", "protect", "rockslide"],
-		tier: "UUBL",
-		doublesTier: "DUU",
-	},
-	corsola: {
-		randomBattleMoves: ["powergem", "recover", "scald", "stealthrock", "toxic"],
-		randomDoubleBattleMoves: ["icywind", "lifedew", "lightscreen", "recover", "reflect", "scald"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	corsolagalar: {
-		randomBattleMoves: ["haze", "nightshade", "stealthrock", "strengthsap", "willowisp"],
-		randomDoubleBattleMoves: ["haze", "lightscreen", "nightshade", "reflect", "strengthsap", "willowisp"],
-		tier: "UU",
-		doublesTier: "LC Uber",
-	},
-	cursola: {
-		randomBattleMoves: ["earthpower", "hydropump", "icebeam", "shadowball", "stealthrock", "strengthsap"],
-		randomDoubleBattleMoves: ["earthpower", "hydropump", "icebeam", "protect", "shadowball", "strengthsap"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	remoraid: {
-		tier: "LC",
-	},
-	octillery: {
-		randomBattleMoves: ["energyball", "fireblast", "gunkshot", "hydropump", "icebeam"],
-		randomDoubleBattleMoves: ["fireblast", "gunkshot", "hydropump", "icebeam", "protect", "substitute"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	delibird: {
-		randomBattleMoves: ["freezedry", "memento", "rapidspin", "spikes"],
-		randomDoubleBattleMoves: ["bravebird", "fakeout", "helpinghand", "icebeam", "memento", "tailwind"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	mantyke: {
-		tier: "LC",
-	},
-	mantine: {
-		randomBattleMoves: ["defog", "hurricane", "icebeam", "roost", "scald", "toxic"],
-		randomDoubleBattleMoves: ["haze", "helpinghand", "hurricane", "roost", "scald", "tailwind"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	skarmory: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	houndour: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	houndoom: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	houndoommega: {
-		isNonstandard: "Past",
-	},
-	phanpy: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	donphan: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	stantler: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	smeargle: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	miltank: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	raikou: {
-		randomBattleMoves: ["aurasphere", "calmmind", "scald", "substitute", "thunderbolt", "voltswitch"],
-		randomDoubleBattleMoves: ["aurasphere", "calmmind", "protect", "scald", "snarl", "thunderbolt", "voltswitch"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	entei: {
-		randomBattleMoves: ["extremespeed", "flareblitz", "stompingtantrum", "stoneedge"],
-		randomDoubleBattleMoves: ["extremespeed", "flareblitz", "protect", "snarl", "stompingtantrum", "stoneedge"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	suicune: {
-		randomBattleMoves: ["airslash", "calmmind", "icebeam", "rest", "scald", "sleeptalk"],
-		randomDoubleBattleMoves: ["airslash", "calmmind", "icebeam", "rest", "scald", "sleeptalk"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	larvitar: {
-		tier: "LC",
-	},
-	pupitar: {
-		tier: "NFE",
-	},
-	tyranitar: {
-		randomBattleMoves: ["crunch", "dragondance", "earthquake", "firepunch", "stealthrock", "stoneedge"],
-		randomDoubleBattleMoves: ["crunch", "dragondance", "firepunch", "highhorsepower", "protect", "rockslide", "stoneedge"],
-		tier: "OU",
-		doublesTier: "DOU",
-	},
-	tyranitarmega: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	lugia: {
-		randomBattleMoves: ["airslash", "calmmind", "earthquake", "psyshock", "roost", "substitute", "toxic"],
-		randomDoubleBattleMoves: ["airslash", "calmmind", "psychic", "roost", "toxic"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	hooh: {
-		randomBattleMoves: ["bravebird", "defog", "earthquake", "flareblitz", "roost", "toxic"],
-		randomDoubleBattleMoves: ["bravebird", "earthpower", "flareblitz", "protect", "roost", "tailwind", "willowisp"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	celebi: {
-		randomBattleMoves: ["earthpower", "gigadrain", "leafstorm", "nastyplot", "psychic", "recover", "stealthrock", "uturn"],
-		randomDoubleBattleMoves: ["calmmind", "earthpower", "gigadrain", "leafstorm", "protect", "psychic", "recover"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	treecko: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	grovyle: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	sceptile: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	sceptilemega: {
-		isNonstandard: "Past",
-	},
-	torchic: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	combusken: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	blaziken: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	blazikenmega: {
-		isNonstandard: "Past",
-	},
-	mudkip: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	marshtomp: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	swampert: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	swampertmega: {
-		isNonstandard: "Past",
-	},
-	poochyena: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	mightyena: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	zigzagoon: {
-		tier: "LC",
-	},
-	zigzagoongalar: {
-		tier: "LC",
-	},
-	linoone: {
-		randomBattleMoves: ["bellydrum", "extremespeed", "stompingtantrum", "throatchop"],
-		randomDoubleBattleMoves: ["bellydrum", "extremespeed", "protect", "throatchop"],
-		tier: "NUBL",
-		doublesTier: "(DUU)",
-	},
-	linoonegalar: {
-		tier: "NFE",
-	},
-	obstagoon: {
-		randomBattleMoves: ["bulkup", "closecombat", "facade", "knockoff", "partingshot"],
-		randomDoubleBattleMoves: ["closecombat", "facade", "knockoff", "obstruct", "partingshot", "taunt"],
-		tier: "UUBL",
-		doublesTier: "(DUU)",
-	},
-	wurmple: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	silcoon: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	beautifly: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	cascoon: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	dustox: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	lotad: {
-		tier: "LC",
-	},
-	lombre: {
-		tier: "NFE",
-	},
-	ludicolo: {
-		randomBattleMoves: ["gigadrain", "hydropump", "icebeam", "raindance", "scald"],
-		randomDoubleBattleMoves: ["fakeout", "gigadrain", "hydropump", "icebeam", "raindance"],
-		tier: "PU",
-		doublesTier: "DOU",
-	},
-	seedot: {
-		tier: "LC",
-	},
-	nuzleaf: {
-		tier: "NFE",
-	},
-	shiftry: {
-		randomBattleMoves: ["darkpulse", "defog", "heatwave", "leafstorm", "nastyplot", "suckerpunch"],
-		randomDoubleBattleMoves: ["fakeout", "knockoff", "leafblade", "suckerpunch", "swordsdance", "tailwind"],
-		tier: "RUBL",
-		doublesTier: "(DUU)",
-	},
-	taillow: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	swellow: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	wingull: {
-		tier: "LC",
-	},
-	pelipper: {
-		randomBattleMoves: ["defog", "hurricane", "hydropump", "roost", "scald", "uturn"],
-		randomDoubleBattleMoves: ["hurricane", "hydropump", "protect", "roost", "tailwind", "wideguard"],
-		tier: "OU",
-		doublesTier: "DOU",
-	},
-	ralts: {
-		tier: "LC",
-	},
-	kirlia: {
-		tier: "NFE",
-	},
-	gardevoir: {
-		randomBattleMoves: ["calmmind", "moonblast", "mysticalfire", "psyshock", "substitute", "trick", "willowisp"],
-		randomDoubleBattleMoves: ["calmmind", "dazzlinggleam", "focusblast", "moonblast", "mysticalfire", "protect", "psychic", "shadowball", "thunderbolt", "trick"],
-		tier: "UU",
-		doublesTier: "DUU",
-	},
-	gardevoirmega: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	gallade: {
-		randomBattleMoves: ["closecombat", "knockoff", "shadowsneak", "swordsdance", "trick", "zenheadbutt"],
-		randomDoubleBattleMoves: ["closecombat", "feint", "knockoff", "leafblade", "protect", "rockslide", "swordsdance", "zenheadbutt"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	gallademega: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	surskit: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	masquerain: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	shroomish: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	breloom: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	slakoth: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	vigoroth: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	slaking: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	nincada: {
-		tier: "LC",
-	},
-	ninjask: {
-		randomBattleMoves: ["acrobatics", "leechlife", "nightslash", "swordsdance"],
-		randomDoubleBattleMoves: ["acrobatics", "defog", "leechlife", "protect", "swordsdance"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	shedinja: {
-		randomBattleMoves: ["shadowclaw", "shadowsneak", "swordsdance", "willowisp", "xscissor"],
-		randomDoubleBattleMoves: ["allyswitch", "protect", "shadowsneak", "swordsdance", "willowisp", "xscissor"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	whismur: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	loudred: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	exploud: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	makuhita: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	hariyama: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	nosepass: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	probopass: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	skitty: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	delcatty: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	sableye: {
-		randomBattleMoves: ["encore", "foulplay", "knockoff", "recover", "taunt", "willowisp"],
-		randomDoubleBattleMoves: ["disable", "encore", "fakeout", "foulplay", "knockoff", "recover", "willowisp"],
-		tier: "RU",
-		doublesTier: "DUU",
-	},
-	sableyemega: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	mawile: {
-		randomBattleMoves: ["ironhead", "playrough", "stealthrock", "suckerpunch", "swordsdance"],
-		randomDoubleBattleMoves: ["firefang", "ironhead", "playrough", "protect", "suckerpunch", "swordsdance"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	mawilemega: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	aron: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	lairon: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	aggron: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	aggronmega: {
-		isNonstandard: "Past",
-	},
-	meditite: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	medicham: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	medichammega: {
-		isNonstandard: "Past",
-	},
-	electrike: {
-		tier: "LC",
-	},
-	manectric: {
-		randomBattleMoves: ["flamethrower", "overheat", "switcheroo", "thunderbolt", "voltswitch"],
-		randomDoubleBattleMoves: ["overheat", "protect", "snarl", "thunderbolt", "voltswitch"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	manectricmega: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	plusle: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	minun: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	volbeat: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	illumise: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	budew: {
-		tier: "LC",
-	},
-	roselia: {
-		tier: "PU",
-		doublesTier: "NFE",
-	},
-	roserade: {
-		randomBattleMoves: ["leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"],
-		randomDoubleBattleMoves: ["gigadrain", "leafstorm", "protect", "sleeppowder", "sludgebomb"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	gulpin: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	swalot: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	carvanha: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	sharpedo: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	sharpedomega: {
-		isNonstandard: "Past",
-	},
-	wailmer: {
-		tier: "LC",
-	},
-	wailord: {
-		randomBattleMoves: ["hydropump", "hypervoice", "icebeam", "waterspout"],
-		randomDoubleBattleMoves: ["hydropump", "icebeam", "earthquake", "waterspout"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	numel: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	camerupt: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	cameruptmega: {
-		isNonstandard: "Past",
-	},
-	torkoal: {
-		randomBattleMoves: ["earthquake", "lavaplume", "rapidspin", "solarbeam", "stealthrock"],
-		randomDoubleBattleMoves: ["bodypress", "earthpower", "fireblast", "lavaplume", "protect", "solarbeam", "willowisp"],
-		tier: "UU",
-		doublesTier: "DOU",
-	},
-	spoink: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	grumpig: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	spinda: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	trapinch: {
-		tier: "LC",
-	},
-	vibrava: {
-		tier: "PU",
-		doublesTier: "NFE",
-	},
-	flygon: {
-		randomBattleMoves: ["defog", "dragondance", "earthquake", "firepunch", "outrage", "uturn"],
-		randomDoubleBattleMoves: ["dragonclaw", "dragondance", "earthquake", "firepunch", "firstimpression", "protect", "rockslide", "tailwind"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	cacnea: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	cacturne: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	swablu: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	altaria: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	altariamega: {
-		isNonstandard: "Past",
-	},
-	zangoose: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	seviper: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	lunatone: {
-		randomBattleMoves: ["earthpower", "icebeam", "nastyplot", "powergem", "psychic", "rockpolish", "stealthrock"],
-		randomDoubleBattleMoves: ["earthpower", "icebeam", "powergem", "protect", "psychic", "psyshock", "trickroom"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	solrock: {
-		randomBattleMoves: ["earthquake", "explosion", "morningsun", "rockslide", "stealthrock", "swordsdance", "willowisp", "zenheadbutt"],
-		randomDoubleBattleMoves: ["allyswitch", "flareblitz", "helpinghand", "stoneedge", "willowisp", "zenheadbutt"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	barboach: {
-		tier: "LC",
-	},
-	whiscash: {
-		randomBattleMoves: ["dragondance", "earthquake", "liquidation", "stoneedge", "zenheadbutt"],
-		randomDoubleBattleMoves: ["dragondance", "earthquake", "protect", "stoneedge", "waterfall"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	corphish: {
-		tier: "LC",
-	},
-	crawdaunt: {
-		randomBattleMoves: ["aquajet", "closecombat", "crabhammer", "dragondance", "knockoff", "swordsdance"],
-		randomDoubleBattleMoves: ["aquajet", "closecombat", "crabhammer", "knockoff", "protect", "swordsdance"],
-		tier: "UUBL",
-		doublesTier: "(DUU)",
-	},
-	baltoy: {
-		tier: "LC",
-	},
-	claydol: {
-		randomBattleMoves: ["earthquake", "icebeam", "psychic", "rapidspin", "stealthrock", "toxic"],
-		randomDoubleBattleMoves: ["allyswitch", "earthpower", "icebeam", "lightscreen", "protect", "psychic", "reflect"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	lileep: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	cradily: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	anorith: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	armaldo: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	feebas: {
-		tier: "LC",
-	},
-	milotic: {
-		randomBattleMoves: ["dragontail", "icebeam", "recover", "rest", "scald", "sleeptalk"],
-		randomDoubleBattleMoves: ["dragontail", "icebeam", "icywind", "protect", "recover", "scald"],
-		tier: "UU",
-		doublesTier: "DOU",
-	},
-	castform: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	castformsunny: {
-		isNonstandard: "Past",
-	},
-	castformrainy: {
-		isNonstandard: "Past",
-	},
-	castformsnowy: {
-		isNonstandard: "Past",
-	},
-	kecleon: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	shuppet: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	banette: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	banettemega: {
-		isNonstandard: "Past",
-	},
-	duskull: {
-		tier: "LC",
-	},
-	dusclops: {
-		randomDoubleBattleMoves: ["allyswitch", "haze", "helpinghand", "nightshade", "painsplit", "trickroom", "willowisp"],
-		tier: "NFE",
-		doublesTier: "DOU",
-	},
-	dusknoir: {
-		randomBattleMoves: ["earthquake", "icepunch", "painsplit", "shadowpunch", "shadowsneak", "substitute", "trick", "willowisp"],
-		randomDoubleBattleMoves: ["allyswitch", "earthquake", "haze", "icepunch", "painsplit", "shadowsneak", "trickroom", "willowisp"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	tropius: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	chingling: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	chimecho: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	absol: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	absolmega: {
-		isNonstandard: "Past",
-	},
-	snorunt: {
-		tier: "LC",
-	},
-	glalie: {
-		randomBattleMoves: ["disable", "earthquake", "freezedry", "protect", "substitute"],
-		randomDoubleBattleMoves: ["disable", "earthquake", "freezedry", "protect", "substitute"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	glaliemega: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	froslass: {
-		randomBattleMoves: ["destinybond", "icebeam", "shadowball", "spikes", "taunt", "willowisp"],
-		randomDoubleBattleMoves: ["destinybond", "icebeam", "icywind", "protect", "shadowball", "willowisp"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	spheal: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	sealeo: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	walrein: {
-		randomBattleMoves: ["icebeam", "protect", "surf", "toxic"],
-		randomDoubleBattleMoves: ["brine", "icebeam", "icywind", "superfang"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	clamperl: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	huntail: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	gorebyss: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	relicanth: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	luvdisc: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	bagon: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	shelgon: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	salamence: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	salamencemega: {
-		isNonstandard: "Past",
-	},
-	beldum: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	metang: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	metagross: {
-		randomBattleMoves: ["agility", "bulletpunch", "earthquake", "explosion", "meteormash", "stealthrock", "thunderpunch"],
-		randomDoubleBattleMoves: ["agility", "bulletpunch", "earthquake", "icepunch", "meteormash", "trick", "zenheadbutt"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	metagrossmega: {
-		isNonstandard: "Past",
-	},
-	regirock: {
-		randomBattleMoves: ["bodypress", "curse", "earthquake", "explosion", "rest", "rockslide", "stoneedge"],
-		randomDoubleBattleMoves: ["bodypress", "curse", "rest", "stoneedge"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	regice: {
-		randomBattleMoves: ["focusblast", "icebeam", "rest", "rockpolish", "sleeptalk", "thunderbolt"],
-		randomDoubleBattleMoves: ["focusblast", "icebeam", "rockpolish", "thunderbolt", "thunderwave"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	registeel: {
-		randomBattleMoves: ["bodypress", "protect", "stealthrock", "toxic"],
-		randomDoubleBattleMoves: ["bodypress", "curse", "ironhead", "rest", "toxic"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	latias: {
-		randomBattleMoves: ["aurasphere", "calmmind", "dracometeor", "healingwish", "psychic", "roost"],
-		randomDoubleBattleMoves: ["aurasphere", "calmmind", "dracometeor", "healpulse", "psychic", "psyshock", "roost", "tailwind"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	latiasmega: {
-		isNonstandard: "Past",
-	},
-	latios: {
-		randomBattleMoves: ["aurasphere", "defog", "dracometeor", "psyshock", "roost", "trick"],
-		randomDoubleBattleMoves: ["aurasphere", "dracometeor", "dragonpulse", "psychic", "psyshock", "roost", "trick"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	latiosmega: {
-		isNonstandard: "Past",
-	},
-	kyogre: {
-		randomBattleMoves: ["calmmind", "icebeam", "surf", "thunder", "waterspout"],
-		randomDoubleBattleMoves: ["hydropump", "icebeam", "protect", "thunder", "waterspout"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	kyogreprimal: {
-		isNonstandard: "Past",
-	},
-	groudon: {
-		randomBattleMoves: ["earthquake", "heatcrash", "heavyslam", "stealthrock", "stoneedge", "swordsdance", "thunderwave"],
-		randomDoubleBattleMoves: ["heatcrash", "highhorsepower", "rockpolish", "solarbeam", "stoneedge", "swordsdance"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	groudonprimal: {
-		isNonstandard: "Past",
-	},
-	rayquaza: {
-		randomBattleMoves: ["dragondance", "earthquake", "extremespeed", "outrage", "vcreate"],
-		randomDoubleBattleMoves: ["airslash", "dracometeor", "dragonclaw", "earthpower", "energyball", "extremespeed", "hydropump", "protect", "thunderbolt", "vcreate"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	rayquazamega: {
-		isNonstandard: "Past",
-	},
-	jirachi: {
-		randomBattleMoves: ["bodyslam", "firepunch", "ironhead", "stealthrock", "toxic", "trick", "uturn"],
-		randomDoubleBattleMoves: ["firepunch", "followme", "ironhead", "lifedew", "protect", "thunderwave"],
-		tier: "OU",
-		doublesTier: "DUber",
-	},
-	deoxys: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	deoxysattack: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	deoxysdefense: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	deoxysspeed: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	turtwig: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	grotle: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	torterra: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	chimchar: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	monferno: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	infernape: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	piplup: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	prinplup: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	empoleon: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	starly: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	staravia: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	staraptor: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	bidoof: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	bibarel: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	kricketot: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	kricketune: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	shinx: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	luxio: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	luxray: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	cranidos: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	rampardos: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	shieldon: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	bastiodon: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	burmy: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	wormadam: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	wormadamsandy: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	wormadamtrash: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	mothim: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	combee: {
-		tier: "LC",
-	},
-	vespiquen: {
-		randomBattleMoves: ["airslash", "defog", "roost", "toxic", "uturn"],
-		randomDoubleBattleMoves: ["defendorder", "infestation", "roost", "toxic"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	pachirisu: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	buizel: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	floatzel: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	cherubi: {
-		tier: "LC",
-	},
-	cherrim: {
-		randomBattleMoves: ["dazzlinggleam", "energyball", "healingwish", "leechseed", "substitute"],
-		randomDoubleBattleMoves: ["aromatherapy", "energyball", "helpinghand", "pollenpuff", "protect"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	cherrimsunshine: {
-		randomBattleMoves: ["playrough", "solarblade", "sunnyday", "weatherball"],
-		randomDoubleBattleMoves: ["playrough", "solarblade", "sunnyday", "weatherball"],
-	},
-	shellos: {
-		tier: "LC",
-	},
-	gastrodon: {
-		randomBattleMoves: ["clearsmog", "earthquake", "icebeam", "recover", "scald", "toxic"],
-		randomDoubleBattleMoves: ["clearsmog", "earthpower", "icywind", "protect", "recover", "scald", "yawn"],
-		tier: "RU",
-		doublesTier: "DOU",
-	},
-	drifloon: {
-		tier: "LC Uber",
-	},
-	drifblim: {
-		randomBattleMoves: ["calmmind", "shadowball", "strengthsap", "thunderbolt"],
-		randomDoubleBattleMoves: ["destinybond", "hex", "shadowball", "tailwind", "thunderwave", "willowisp"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	buneary: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	lopunny: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	lopunnymega: {
-		isNonstandard: "Past",
-	},
-	glameow: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	purugly: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	stunky: {
-		tier: "LC",
-	},
-	skuntank: {
-		randomBattleMoves: ["crunch", "defog", "fireblast", "poisonjab", "suckerpunch", "toxic"],
-		randomDoubleBattleMoves: ["crunch", "fireblast", "haze", "poisonjab", "suckerpunch", "taunt"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	bronzor: {
-		tier: "LC",
-	},
-	bronzong: {
-		randomBattleMoves: ["earthquake", "ironhead", "protect", "stealthrock", "toxic"],
-		randomDoubleBattleMoves: ["allyswitch", "bodypress", "explosion", "ironhead", "lightscreen", "reflect", "trickroom"],
-		tier: "UU",
-		doublesTier: "DUU",
-	},
-	chatot: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	spiritomb: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	gible: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	gabite: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	garchomp: {
-		randomBattleMoves: ["earthquake", "fireblast", "firefang", "outrage", "stealthrock", "stoneedge", "swordsdance"],
-		randomDoubleBattleMoves: ["dragonclaw", "earthquake", "fireblast", "protect", "stoneedge", "swordsdance"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	garchompmega: {
-		isNonstandard: "Past",
-	},
-	riolu: {
-		tier: "LC",
-	},
-	lucario: {
-		randomBattleMoves: ["closecombat", "extremespeed", "icepunch", "meteormash", "swordsdance"],
-		randomDoubleBattleMoves: ["aurasphere", "bulletpunch", "closecombat", "darkpulse", "extremespeed", "flashcannon", "icepunch", "meteormash", "nastyplot", "protect"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	lucariomega: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	hippopotas: {
-		tier: "LC",
-	},
-	hippowdon: {
-		randomBattleMoves: ["earthquake", "slackoff", "stealthrock", "stoneedge", "toxic", "whirlwind"],
-		randomDoubleBattleMoves: ["highhorsepower", "protect", "rockslide", "slackoff", "stealthrock", "whirlwind", "yawn"],
-		tier: "OU",
-		doublesTier: "(DUU)",
-	},
-	skorupi: {
-		tier: "LC",
-	},
-	drapion: {
-		randomBattleMoves: ["earthquake", "knockoff", "poisonjab", "swordsdance", "taunt", "toxicspikes"],
-		randomDoubleBattleMoves: ["acupressure", "knockoff", "poisonjab", "protect", "rockslide", "taunt"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	croagunk: {
-		tier: "LC",
-	},
-	toxicroak: {
-		randomBattleMoves: ["drainpunch", "gunkshot", "icepunch", "substitute", "suckerpunch", "swordsdance"],
-		randomDoubleBattleMoves: ["drainpunch", "fakeout", "gunkshot", "icepunch", "protect", "suckerpunch", "swordsdance", "taunt"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	carnivine: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	finneon: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	lumineon: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	snover: {
-		tier: "LC",
-	},
-	abomasnow: {
-		randomBattleMoves: ["auroraveil", "blizzard", "earthquake", "iceshard", "woodhammer"],
-		randomDoubleBattleMoves: ["auroraveil", "blizzard", "focusblast", "iceshard", "protect", "woodhammer"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	abomasnowmega: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	rotom: {
-		randomBattleMoves: ["nastyplot", "shadowball", "thunderbolt", "voltswitch", "willowisp"],
-		randomDoubleBattleMoves: ["allyswitch", "electroweb", "protect", "shadowball", "thunderbolt", "voltswitch", "willowisp"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	rotomheat: {
-		randomBattleMoves: ["defog", "nastyplot", "overheat", "thunderbolt", "voltswitch", "willowisp"],
-		randomDoubleBattleMoves: ["electroweb", "overheat", "protect", "thunderbolt", "voltswitch", "willowisp"],
-		tier: "OU",
-		doublesTier: "DUU",
-	},
-	rotomwash: {
-		randomBattleMoves: ["hydropump", "thunderbolt", "trick", "voltswitch", "willowisp"],
-		randomDoubleBattleMoves: ["allyswitch", "hydropump", "protect", "thunderbolt", "thunderwave", "voltswitch", "willowisp"],
-		tier: "UU",
-		doublesTier: "DOU",
-	},
-	rotomfrost: {
-		randomBattleMoves: ["blizzard", "nastyplot", "thunderbolt", "voltswitch", "willowisp"],
-		randomDoubleBattleMoves: ["blizzard", "nastyplot", "protect", "thunderbolt", "willowisp"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	rotomfan: {
-		randomBattleMoves: ["airslash", "nastyplot", "thunderbolt", "voltswitch", "willowisp"],
-		randomDoubleBattleMoves: ["airslash", "darkpulse", "nastyplot", "protect", "thunderbolt"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	rotommow: {
-		randomBattleMoves: ["leafstorm", "thunderbolt", "trick", "voltswitch", "willowisp"],
-		randomDoubleBattleMoves: ["electroweb", "leafstorm", "protect", "thunderbolt", "voltswitch", "willowisp"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	uxie: {
-		randomBattleMoves: ["healbell", "knockoff", "psychic", "stealthrock", "uturn", "yawn"],
-		randomDoubleBattleMoves: ["knockoff", "lightscreen", "psychic", "reflect", "thunderwave", "yawn"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	mesprit: {
-		randomBattleMoves: ["energyball", "healingwish", "icebeam", "nastyplot", "psychic", "stealthrock", "thunderwave", "uturn"],
-		randomDoubleBattleMoves: ["energyball", "healingwish", "icebeam", "nastyplot", "psychic", "thunderbolt"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	azelf: {
-		randomBattleMoves: ["dazzlinggleam", "fireblast", "nastyplot", "psychic", "stealthrock", "taunt", "uturn"],
-		randomDoubleBattleMoves: ["energyball", "fireblast", "nastyplot", "psychic", "psyshock", "shadowball", "uturn"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	dialga: {
-		randomBattleMoves: ["dracometeor", "dragontail", "fireblast", "flashcannon", "stealthrock", "thunderbolt", "toxic"],
-		randomDoubleBattleMoves: ["dracometeor", "earthpower", "flashcannon", "protect", "thunderbolt", "thunderwave"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	palkia: {
-		randomBattleMoves: ["dracometeor", "dragonpulse", "fireblast", "hydropump", "thunderwave"],
-		randomDoubleBattleMoves: ["dracometeor", "earthpower", "fireblast", "hydropump", "protect", "thunderwave"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	heatran: {
-		randomBattleMoves: ["earthpower", "flashcannon", "lavaplume", "protect", "stealthrock", "taunt", "toxic"],
-		randomDoubleBattleMoves: ["earthpower", "eruption", "fireblast", "flashcannon", "protect"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	regigigas: {
-		randomBattleMoves: ["bodyslam", "protect", "substitute", "toxic"],
-		randomDoubleBattleMoves: ["bodyslam", "knockoff", "protect", "substitute"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	giratina: {
-		randomBattleMoves: ["aurasphere", "calmmind", "dracometeor", "rest", "shadowball", "sleeptalk", "willowisp"],
-		randomDoubleBattleMoves: ["calmmind", "dragonpulse", "rest", "shadowball", "willowisp"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	giratinaorigin: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	cresselia: {
-		randomBattleMoves: ["calmmind", "moonblast", "moonlight", "psyshock", "thunderwave", "toxic"],
-		randomDoubleBattleMoves: ["allyswitch", "helpinghand", "icywind", "magiccoat", "moonlight", "psychic"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	phione: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	manaphy: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	darkrai: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	shaymin: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	shayminsky: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	arceus: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	arceusbug: {
-		isNonstandard: "Past",
-	},
-	arceusdark: {
-		isNonstandard: "Past",
-	},
-	arceusdragon: {
-		isNonstandard: "Past",
-	},
-	arceuselectric: {
-		isNonstandard: "Past",
-	},
-	arceusfairy: {
-		isNonstandard: "Past",
-	},
-	arceusfighting: {
-		isNonstandard: "Past",
-	},
-	arceusfire: {
-		isNonstandard: "Past",
-	},
-	arceusflying: {
-		isNonstandard: "Past",
-	},
-	arceusghost: {
-		isNonstandard: "Past",
-	},
-	arceusgrass: {
-		isNonstandard: "Past",
-	},
-	arceusground: {
-		isNonstandard: "Past",
-	},
-	arceusice: {
-		isNonstandard: "Past",
-	},
-	arceuspoison: {
-		isNonstandard: "Past",
-	},
-	arceuspsychic: {
-		isNonstandard: "Past",
-	},
-	arceusrock: {
-		isNonstandard: "Past",
-	},
-	arceussteel: {
-		isNonstandard: "Past",
-	},
-	arceuswater: {
-		isNonstandard: "Past",
-	},
-	victini: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	snivy: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	servine: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	serperior: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	tepig: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pignite: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	emboar: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	oshawott: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	dewott: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	samurott: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	patrat: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	watchog: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	lillipup: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	herdier: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	stoutland: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	purrloin: {
-		tier: "LC",
-	},
-	liepard: {
-		randomBattleMoves: ["copycat", "encore", "knockoff", "playrough", "thunderwave", "uturn"],
-		randomDoubleBattleMoves: ["copycat", "encore", "fakeout", "foulplay", "snarl", "taunt", "thunderwave"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	pansage: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	simisage: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pansear: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	simisear: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	panpour: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	simipour: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	munna: {
-		tier: "LC",
-	},
-	musharna: {
-		randomBattleMoves: ["calmmind", "moonblast", "moonlight", "psychic", "thunderwave"],
-		randomDoubleBattleMoves: ["healingwish", "hypnosis", "moonblast", "protect", "psychic", "trickroom"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	pidove: {
-		tier: "LC",
-	},
-	tranquill: {
-		tier: "NFE",
-	},
-	unfezant: {
-		randomBattleMoves: ["bravebird", "defog", "nightslash", "roost", "uturn"],
-		randomDoubleBattleMoves: ["bravebird", "facade", "nightslash", "quickattack", "roost", "tailwind"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	blitzle: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	zebstrika: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	roggenrola: {
-		tier: "LC",
-	},
-	boldore: {
-		tier: "NFE",
-	},
-	gigalith: {
-		randomBattleMoves: ["earthquake", "explosion", "rockblast", "stealthrock", "stoneedge", "superpower"],
-		randomDoubleBattleMoves: ["bodypress", "earthquake", "explosion", "heavyslam", "protect", "stealthrock", "stoneedge", "wideguard"],
-		tier: "UU",
-		doublesTier: "DUU",
-	},
-	woobat: {
-		tier: "LC",
-	},
-	swoobat: {
-		randomBattleMoves: ["airslash", "heatwave", "nastyplot", "psyshock", "roost"],
-		randomDoubleBattleMoves: ["airslash", "calmmind", "gigadrain", "heatwave", "protect", "psychic", "psyshock"],
-		tier: "PUBL",
-		doublesTier: "(DUU)",
-	},
-	drilbur: {
-		tier: "LC",
-	},
-	excadrill: {
-		randomBattleMoves: ["earthquake", "ironhead", "rapidspin", "rockslide", "swordsdance"],
-		randomDoubleBattleMoves: ["highhorsepower", "ironhead", "protect", "rapidspin", "rockslide", "swordsdance"],
-		tier: "OU",
-		doublesTier: "DOU",
-	},
-	audino: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	audinomega: {
-		isNonstandard: "Past",
-	},
-	timburr: {
-		tier: "LC",
-	},
-	gurdurr: {
-		tier: "RU",
-	},
-	conkeldurr: {
-		randomBattleMoves: ["bulkup", "drainpunch", "facade", "knockoff", "machpunch"],
-		randomDoubleBattleMoves: ["closecombat", "drainpunch", "highhorsepower", "icepunch", "knockoff", "machpunch", "protect", "stoneedge"],
-		tier: "OU",
-		doublesTier: "DOU",
-	},
-	tympole: {
-		tier: "LC",
-	},
-	palpitoad: {
-		tier: "PU",
-		doublesTier: "NFE",
-	},
-	seismitoad: {
-		randomBattleMoves: ["earthquake", "liquidation", "raindance", "sludgebomb", "stealthrock"],
-		randomDoubleBattleMoves: ["earthpower", "earthquake", "knockoff", "liquidation", "powerwhip", "protect"],
-		tier: "OU",
-		doublesTier: "(DUU)",
-	},
-	throh: {
-		randomBattleMoves: ["bulkup", "circlethrow", "icepunch", "knockoff", "rest", "sleeptalk", "stormthrow"],
-		randomDoubleBattleMoves: ["facade", "knockoff", "poisonjab", "protect", "stoneedge", "stormthrow", "wideguard"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	sawk: {
-		randomBattleMoves: ["bulkup", "closecombat", "knockoff", "poisonjab", "stoneedge"],
-		randomDoubleBattleMoves: ["closecombat", "helpinghand", "knockoff", "poisonjab", "protect", "rockslide"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	sewaddle: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	swadloon: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	leavanny: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	venipede: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	whirlipede: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	scolipede: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	cottonee: {
-		tier: "LC",
-	},
-	whimsicott: {
-		randomBattleMoves: ["defog", "energyball", "leechseed", "moonblast", "stunspore", "taunt", "uturn"],
-		randomDoubleBattleMoves: ["encore", "energyball", "helpinghand", "moonblast", "tailwind", "taunt"],
-		tier: "RU",
-		doublesTier: "DOU",
-	},
-	petilil: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	lilligant: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	basculin: {
-		randomBattleMoves: ["aquajet", "crunch", "headsmash", "liquidation", "psychicfangs"],
-		randomDoubleBattleMoves: ["aquajet", "crunch", "headsmash", "liquidation", "muddywater", "psychicfangs", "superpower"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	basculinbluestriped: {
-		randomBattleMoves: ["aquajet", "crunch", "headsmash", "liquidation", "psychicfangs"],
-		randomDoubleBattleMoves: ["aquajet", "crunch", "headsmash", "liquidation", "muddywater", "psychicfangs", "superpower"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	sandile: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	krokorok: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	krookodile: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	darumaka: {
-		tier: "LC",
-	},
-	darumakagalar: {
-		tier: "LC",
-	},
-	darmanitan: {
-		randomBattleMoves: ["earthquake", "flareblitz", "rockslide", "superpower", "uturn"],
-		randomDoubleBattleMoves: ["earthquake", "flareblitz", "ironhead", "rockslide", "superpower", "uturn"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	darmanitangalar: {
-		randomBattleMoves: ["earthquake", "flareblitz", "iciclecrash", "superpower", "uturn"],
-		randomDoubleBattleMoves: ["earthquake", "flareblitz", "iciclecrash", "rockslide", "superpower", "uturn"],
-		tier: "Uber",
-		doublesTier: "DOU",
-	},
-	darmanitangalarzen: {
-		randomBattleMoves: ["earthquake", "flareblitz", "iciclecrash", "superpower", "uturn"],
-	},
-	maractus: {
-		randomBattleMoves: ["drainpunch", "energyball", "leechseed", "spikes", "spikyshield", "toxic"],
-		randomDoubleBattleMoves: ["acupressure", "drainpunch", "helpinghand", "leafstorm", "spikyshield", "suckerpunch"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	dwebble: {
-		tier: "LC",
-	},
-	crustle: {
-		randomBattleMoves: ["earthquake", "shellsmash", "spikes", "stealthrock", "stoneedge", "xscissor"],
-		randomDoubleBattleMoves: ["earthquake", "knockoff", "protect", "rockslide", "shellsmash", "xscissor"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	scraggy: {
-		tier: "LC",
-	},
-	scrafty: {
-		randomBattleMoves: ["closecombat", "dragondance", "icepunch", "knockoff", "poisonjab"],
-		randomDoubleBattleMoves: ["closecombat", "dragondance", "drainpunch", "fakeout", "icepunch", "knockoff"],
-		tier: "RU",
-		doublesTier: "DUU",
-	},
-	sigilyph: {
-		randomBattleMoves: ["airslash", "defog", "energyball", "heatwave", "psychic"],
-		randomDoubleBattleMoves: ["airslash", "calmmind", "energyball", "heatwave", "icebeam", "psychic", "psyshock", "roost"],
-		tier: "RUBL",
-		doublesTier: "(DUU)",
-	},
-	yamask: {
-		tier: "LC",
-	},
-	yamaskgalar: {
-		tier: "LC",
-	},
-	cofagrigus: {
-		randomBattleMoves: ["bodypress", "memento", "shadowball", "toxicspikes", "willowisp"],
-		randomDoubleBattleMoves: ["allyswitch", "bodypress", "painsplit", "shadowball", "trickroom", "willowisp"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	runerigus: {
-		randomBattleMoves: ["earthquake", "haze", "shadowclaw", "stealthrock", "toxicspikes", "willowisp"],
-		randomDoubleBattleMoves: ["allyswitch", "earthquake", "nightshade", "protect", "trickroom", "willowisp"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	tirtouga: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	carracosta: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	archen: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	archeops: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	trubbish: {
-		tier: "LC",
-	},
-	garbodor: {
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	garbodorgmax: {
-		randomBattleMoves: ["drainpunch", "explosion", "gunkshot", "painsplit", "spikes", "toxicspikes"],
-		randomDoubleBattleMoves: ["bodyslam", "drainpunch", "explosion", "gunkshot", "protect", "seedbomb"],
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	zorua: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	zoroark: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	minccino: {
-		tier: "LC",
-	},
-	cinccino: {
-		randomBattleMoves: ["bulletseed", "knockoff", "rockblast", "tailslap", "uturn"],
-		randomDoubleBattleMoves: ["aquatail", "bulletseed", "encore", "gunkshot", "knockoff", "rockblast", "tailslap"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	gothita: {
-		tier: "LC Uber",
-	},
-	gothorita: {
-		tier: "NFE",
-	},
-	gothitelle: {
-		randomBattleMoves: ["nastyplot", "psychic", "shadowball", "thunderbolt", "trick"],
-		randomDoubleBattleMoves: ["allyswitch", "fakeout", "healpulse", "helpinghand", "hypnosis", "psychic", "psyshock", "shadowball", "trickroom"],
-		tier: "PU",
-		doublesTier: "DOU",
-	},
-	solosis: {
-		tier: "LC",
-	},
-	duosion: {
-		tier: "NFE",
-	},
-	reuniclus: {
-		randomBattleMoves: ["calmmind", "focusblast", "psychic", "recover", "shadowball", "trickroom"],
-		randomDoubleBattleMoves: ["energyball", "focusblast", "psychic", "psyshock", "recover", "shadowball", "trick", "trickroom"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	ducklett: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	swanna: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	vanillite: {
-		tier: "LC",
-	},
-	vanillish: {
-		tier: "NFE",
-	},
-	vanilluxe: {
-		randomBattleMoves: ["auroraveil", "blizzard", "explosion", "flashcannon", "freezedry"],
-		randomDoubleBattleMoves: ["auroraveil", "blizzard", "flashcannon", "freezedry", "iceshard"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	deerling: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	sawsbuck: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	emolga: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	karrablast: {
-		tier: "LC",
-	},
-	escavalier: {
-		randomBattleMoves: ["closecombat", "drillrun", "ironhead", "knockoff", "megahorn", "swordsdance"],
-		randomDoubleBattleMoves: ["closecombat", "drillrun", "ironhead", "knockoff", "megahorn", "protect", "swordsdance"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	foongus: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	amoonguss: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	frillish: {
-		tier: "LC",
-	},
-	jellicent: {
-		randomBattleMoves: ["icebeam", "recover", "scald", "shadowball", "willowisp"],
-		randomDoubleBattleMoves: ["protect", "recover", "scald", "shadowball", "trickroom", "willowisp"],
-		tier: "RU",
-		doublesTier: "DUU",
-	},
-	alomomola: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	joltik: {
-		tier: "LC",
-	},
-	galvantula: {
-		randomBattleMoves: ["bugbuzz", "gigadrain", "stickyweb", "thunder", "voltswitch"],
-		randomDoubleBattleMoves: ["bugbuzz", "electroweb", "energyball", "protect", "stickyweb", "thunder"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	ferroseed: {
-		tier: "NU",
-		doublesTier: "LC",
-	},
-	ferrothorn: {
-		randomBattleMoves: ["leechseed", "gyroball", "powerwhip", "protect", "spikes", "stealthrock"],
-		randomDoubleBattleMoves: ["bodypress", "gyroball", "knockoff", "leechseed", "powerwhip", "protect", "thunderwave"],
-		tier: "OU",
-		doublesTier: "DOU",
-	},
-	klink: {
-		tier: "LC",
-	},
-	klang: {
-		tier: "NFE",
-	},
-	klinklang: {
-		randomBattleMoves: ["geargrind", "shiftgear", "substitute", "wildcharge"],
-		randomDoubleBattleMoves: ["assurance", "geargrind", "protect", "shiftgear", "wildcharge"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	tynamo: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	eelektrik: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	eelektross: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	elgyem: {
-		tier: "LC",
-	},
-	beheeyem: {
-		randomBattleMoves: ["psychic", "shadowball", "thunderbolt", "trick", "trickroom"],
-		randomDoubleBattleMoves: ["nastyplot", "protect", "psychic", "shadowball", "thunderbolt", "trickroom"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	litwick: {
-		tier: "LC",
-	},
-	lampent: {
-		tier: "NFE",
-	},
-	chandelure: {
-		randomBattleMoves: ["calmmind", "energyball", "fireblast", "shadowball", "substitute", "trick"],
-		randomDoubleBattleMoves: ["calmmind", "energyball", "heatwave", "overheat", "protect", "shadowball", "trick"],
-		tier: "UU",
-		doublesTier: "DOU",
-	},
-	axew: {
-		tier: "LC",
-	},
-	fraxure: {
-		tier: "PU",
-		doublesTier: "NFE",
-	},
-	haxorus: {
-		randomBattleMoves: ["closecombat", "dragondance", "earthquake", "outrage", "poisonjab", "taunt"],
-		randomDoubleBattleMoves: ["closecombat", "dragonclaw", "dragondance", "earthquake", "poisonjab", "substitute"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	cubchoo: {
-		tier: "LC",
-	},
-	beartic: {
-		randomBattleMoves: ["aquajet", "iciclecrash", "superpower", "swordsdance", "throatchop"],
-		randomDoubleBattleMoves: ["aquajet", "iciclecrash", "protect", "rockslide", "superpower", "swordsdance", "throatchop"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	cryogonal: {
-		randomBattleMoves: ["freezedry", "haze", "rapidspin", "recover", "toxic"],
-		randomDoubleBattleMoves: ["freezedry", "icebeam", "lightscreen", "rapidspin", "recover", "reflect"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	shelmet: {
-		tier: "LC",
-	},
-	accelgor: {
-		randomBattleMoves: ["bugbuzz", "energyball", "focusblast", "spikes", "toxic", "yawn"],
-		randomDoubleBattleMoves: ["acidspray", "bugbuzz", "encore", "energyball", "focusblast"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	stunfisk: {
-		randomBattleMoves: ["discharge", "earthpower", "foulplay", "scald", "stealthrock"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	stunfiskgalar: {
-		randomBattleMoves: ["curse", "earthquake", "painsplit", "rockslide", "stealthrock"],
-		randomDoubleBattleMoves: ["counter", "earthquake", "foulplay", "stealthrock", "stoneedge", "thunderwave"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	mienfoo: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	mienshao: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	druddigon: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	golett: {
-		tier: "LC",
-	},
-	golurk: {
-		randomBattleMoves: ["drainpunch", "earthquake", "icepunch", "rockpolish", "shadowpunch"],
-		randomDoubleBattleMoves: ["closecombat", "earthquake", "highhorsepower", "icepunch", "protect", "rockpolish", "shadowpunch"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	pawniard: {
-		tier: "PU",
-		doublesTier: "LC",
-	},
-	bisharp: {
-		randomBattleMoves: ["ironhead", "knockoff", "stealthrock", "suckerpunch", "swordsdance"],
-		randomDoubleBattleMoves: ["brickbreak", "ironhead", "knockoff", "protect", "suckerpunch", "swordsdance"],
-		tier: "OU",
-		doublesTier: "(DUU)",
-	},
-	bouffalant: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	rufflet: {
-		tier: "LC Uber",
-	},
-	braviary: {
-		randomBattleMoves: ["bravebird", "bulkup", "closecombat", "facade", "roost", "uturn"],
-		randomDoubleBattleMoves: ["bravebird", "closecombat", "protect", "roost", "tailwind"],
-		tier: "RU",
-		doublesTier: "DUU",
-	},
-	vullaby: {
-		tier: "LC",
-	},
-	mandibuzz: {
-		randomBattleMoves: ["defog", "foulplay", "roost", "taunt", "toxic", "uturn"],
-		randomDoubleBattleMoves: ["foulplay", "roost", "snarl", "tailwind", "taunt"],
-		tier: "OU",
-		doublesTier: "(DUU)",
-	},
-	heatmor: {
-		randomBattleMoves: ["firelash", "gigadrain", "knockoff", "substitute", "suckerpunch", "superpower"],
-		randomDoubleBattleMoves: ["firelash", "gigadrain", "incinerate", "protect", "rocktomb", "suckerpunch", "superpower", "willowisp"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	durant: {
-		randomBattleMoves: ["firstimpression", "honeclaws", "ironhead", "rockslide", "superpower"],
-		randomDoubleBattleMoves: ["firstimpression", "ironhead", "protect", "rockslide", "superpower", "xscissor"],
-		tier: "UUBL",
-		doublesTier: "DUU",
-	},
-	deino: {
-		tier: "LC",
-	},
-	zweilous: {
-		tier: "NFE",
-	},
-	hydreigon: {
-		randomBattleMoves: ["darkpulse", "dracometeor", "fireblast", "flashcannon", "nastyplot", "roost", "uturn"],
-		randomDoubleBattleMoves: ["darkpulse", "dracometeor", "dragonpulse", "earthpower", "fireblast", "nastyplot", "protect", "tailwind"],
-		tier: "OU",
-		doublesTier: "DUU",
-	},
-	larvesta: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	volcarona: {
-		randomBattleMoves: ["bugbuzz", "fireblast", "gigadrain", "quiverdance", "roost"],
-		randomDoubleBattleMoves: ["bugbuzz", "gigadrain", "heatwave", "hurricane", "quiverdance", "roost"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	cobalion: {
-		randomBattleMoves: ["closecombat", "ironhead", "stealthrock", "stoneedge", "swordsdance", "voltswitch"],
-		randomDoubleBattleMoves: ["ironhead", "protect", "sacredsword", "stoneedge", "swordsdance", "thunderwave"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	terrakion: {
-		randomBattleMoves: ["closecombat", "earthquake", "quickattack", "stoneedge", "swordsdance"],
-		randomDoubleBattleMoves: ["closecombat", "ironhead", "protect", "rockslide", "stoneedge", "swordsdance"],
-		tier: "OU",
-		doublesTier: "DOU",
-	},
-	virizion: {
-		randomBattleMoves: ["closecombat", "leafblade", "stoneedge", "swordsdance", "taunt"],
-		randomDoubleBattleMoves: ["closecombat", "leafblade", "stoneedge", "substitute", "swordsdance", "taunt"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	tornadus: {
-		randomBattleMoves: ["defog", "grassknot", "heatwave", "hurricane", "nastyplot"],
-		randomDoubleBattleMoves: ["heatwave", "hurricane", "nastyplot", "superpower", "tailwind", "taunt"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	tornadustherian: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	thundurus: {
-		randomBattleMoves: ["focusblast", "grassknot", "knockoff", "nastyplot", "superpower", "thunderbolt", "thunderwave", "uturn"],
-		randomDoubleBattleMoves: ["grassknot", "nastyplot", "sludgebomb", "substitute", "thunderbolt"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	thundurustherian: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	reshiram: {
-		randomBattleMoves: ["blueflare", "dracometeor", "dragonpulse", "earthpower", "roost", "stoneedge"],
-		randomDoubleBattleMoves: ["blueflare", "dracometeor", "earthpower", "heatwave", "roost", "tailwind"],
-		tier: "Uber",
-		doublesTier: "DUber",
-	},
-	zekrom: {
-		randomBattleMoves: ["boltstrike", "dragondance", "outrage", "substitute"],
-		randomDoubleBattleMoves: ["boltstrike", "dragonclaw", "dragondance", "roost", "substitute"],
-		tier: "Uber",
-		doublesTier: "DUber",
-	},
-	landorus: {
-		randomBattleMoves: ["earthpower", "focusblast", "knockoff", "rockpolish", "rockslide", "sludgewave", "stealthrock"],
-		randomDoubleBattleMoves: ["calmmind", "earthpower", "focusblast", "protect", "psychic", "sludgebomb"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	landorustherian: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	kyurem: {
-		randomBattleMoves: ["dracometeor", "earthpower", "focusblast", "freezedry", "icebeam", "outrage"],
-		randomDoubleBattleMoves: ["dracometeor", "earthpower", "freezedry", "glaciate", "protect", "roost", "substitute"],
-		tier: "OU",
-		doublesTier: "DUU",
-	},
-	kyuremblack: {
-		randomBattleMoves: ["dragondance", "fusionbolt", "iciclespear", "outrage"],
-		randomDoubleBattleMoves: ["dragonclaw", "dragondance", "fusionbolt", "iciclespear", "protect", "roost"],
-		tier: "Uber",
-		doublesTier: "DUber",
-	},
-	kyuremwhite: {
-		randomBattleMoves: ["dracometeor", "earthpower", "freezedry", "fusionflare", "icebeam"],
-		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "earthpower", "freezedry", "fusionflare", "icebeam", "protect", "roost"],
-		tier: "Uber",
-		doublesTier: "DUber",
-	},
-	keldeo: {
-		randomDoubleBattleMoves: ["calmmind", "hydropump", "icywind", "protect", "scald", "secretsword"],
-		tier: "OU",
-		doublesTier: "DUU",
-	},
-	keldeoresolute: {
-		randomBattleMoves: ["airslash", "calmmind", "hydropump", "icywind", "scald", "secretsword", "substitute"],
-	},
-	meloetta: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	meloettapirouette: {
-		isNonstandard: "Past",
-	},
-	genesect: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	genesectburn: {
-		isNonstandard: "Past",
-	},
-	genesectchill: {
-		isNonstandard: "Past",
-	},
-	genesectdouse: {
-		isNonstandard: "Past",
-	},
-	genesectshock: {
-		isNonstandard: "Past",
-	},
-	chespin: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	quilladin: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	chesnaught: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	fennekin: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	braixen: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	delphox: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	froakie: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	frogadier: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	greninja: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	greninjaash: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	bunnelby: {
-		tier: "LC",
-	},
-	diggersby: {
-		randomBattleMoves: ["bodyslam", "earthquake", "knockoff", "quickattack", "swordsdance", "uturn"],
-		randomDoubleBattleMoves: ["bodyslam", "highhorsepower", "knockoff", "quickattack", "stoneedge", "superpower", "swordsdance"],
-		tier: "UUBL",
-		doublesTier: "(DUU)",
-	},
-	fletchling: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	fletchinder: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	talonflame: {
-		randomBattleMoves: ["bravebird", "defog", "flareblitz", "roost", "swordsdance", "uturn"],
-		randomDoubleBattleMoves: ["bravebird", "defog", "flareblitz", "overheat", "roost", "tailwind", "willowisp"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	scatterbug: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	spewpa: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	vivillon: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	vivillonfancy: {
-		isNonstandard: "Past",
-	},
-	vivillonpokeball: {
-		isNonstandard: "Past",
-	},
-	litleo: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pyroar: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	flabebe: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	floette: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	floetteeternal: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	florges: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	skiddo: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	gogoat: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pancham: {
-		tier: "LC",
-	},
-	pangoro: {
-		randomBattleMoves: ["closecombat", "darkestlariat", "gunkshot", "icepunch", "partingshot"],
-		randomDoubleBattleMoves: ["bulletpunch", "closecombat", "drainpunch", "gunkshot", "icepunch", "knockoff", "protect"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	furfrou: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	espurr: {
-		tier: "LC",
-	},
-	meowstic: {
-		randomBattleMoves: ["lightscreen", "psychic", "reflect", "thunderwave", "yawn"],
-		randomDoubleBattleMoves: ["fakeout", "foulplay", "lightscreen", "reflect", "thunderwave"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	meowsticf: {
-		randomBattleMoves: ["energyball", "nastyplot", "psychic", "shadowball", "thunderbolt"],
-		randomDoubleBattleMoves: ["fakeout", "nastyplot", "psychic", "shadowball", "thunderbolt"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	honedge: {
-		tier: "LC",
-	},
-	doublade: {
-		randomBattleMoves: ["ironhead", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"],
-		randomDoubleBattleMoves: ["ironhead", "protect", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"],
-		tier: "UU",
-		doublesTier: "NFE",
-	},
-	aegislash: {
-		randomBattleMoves: ["closecombat", "flashcannon", "kingsshield", "shadowball", "shadowsneak", "substitute", "toxic"],
-		randomDoubleBattleMoves: ["flashcannon", "kingsshield", "shadowball", "shadowsneak"],
-		tier: "OU",
-		doublesTier: "DUU",
-	},
-	aegislashblade: {
-		randomBattleMoves: ["closecombat", "ironhead", "shadowclaw", "shadowsneak", "swordsdance"],
-		randomDoubleBattleMoves: ["closecombat", "ironhead", "kingsshield", "shadowclaw", "shadowsneak", "swordsdance"],
-	},
-	spritzee: {
-		tier: "LC",
-	},
-	aromatisse: {
-		randomBattleMoves: ["calmmind", "moonblast", "protect", "toxic", "wish"],
-		randomDoubleBattleMoves: ["healpulse", "moonblast", "protect", "thunderbolt", "trickroom", "wish"],
-		tier: "RU",
-		doublesTier: "DUU",
-	},
-	swirlix: {
-		tier: "LC Uber",
-	},
-	slurpuff: {
-		randomBattleMoves: ["bellydrum", "drainpunch", "facade", "playrough"],
-		randomDoubleBattleMoves: ["faketears", "flamethrower", "helpinghand", "playrough", "stickyweb"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	inkay: {
-		tier: "LC",
-	},
-	malamar: {
-		randomBattleMoves: ["knockoff", "psychocut", "rest", "sleeptalk", "substitute", "superpower"],
-		randomDoubleBattleMoves: ["knockoff", "psychocut", "rest", "superpower"],
-		tier: "NU",
-		doublesTier: "DUU",
-	},
-	binacle: {
-		tier: "LC",
-	},
-	barbaracle: {
-		randomBattleMoves: ["crosschop", "earthquake", "liquidation", "shellsmash", "stoneedge"],
-		randomDoubleBattleMoves: ["liquidation", "poisonjab", "protect", "rockslide", "shellsmash", "superpower"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	skrelp: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	dragalge: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	clauncher: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	clawitzer: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	helioptile: {
-		tier: "LC",
-	},
-	heliolisk: {
-		randomBattleMoves: ["focusblast", "grassknot", "hypervoice", "surf", "thunderbolt", "voltswitch"],
-		randomDoubleBattleMoves: ["electroweb", "focusblast", "grassknot", "hypervoice", "protect", "surf", "thunderbolt", "voltswitch"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	tyrunt: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	tyrantrum: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	amaura: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	aurorus: {
-		randomBattleMoves: ["ancientpower", "blizzard", "earthpower", "freezedry", "hypervoice", "stealthrock", "thunderwave"],
-		randomDoubleBattleMoves: ["earthpower", "freezedry", "hypervoice", "protect", "thunderwave"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	hawlucha: {
-		randomBattleMoves: ["bravebird", "closecombat", "roost", "stoneedge", "swordsdance", "throatchop"],
-		randomDoubleBattleMoves: ["bravebird", "closecombat", "protect", "stoneedge", "swordsdance", "throatchop"],
-		tier: "OU",
-		doublesTier: "DUU",
-	},
-	dedenne: {
-		randomBattleMoves: ["protect", "recycle", "thunderbolt", "toxic"],
-		randomDoubleBattleMoves: ["eerieimpulse", "helpinghand", "nuzzle", "recycle", "superfang", "thunderbolt"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	carbink: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	goomy: {
-		tier: "LC",
-	},
-	sliggoo: {
-		tier: "NFE",
-	},
-	goodra: {
-		randomBattleMoves: ["dracometeor", "earthquake", "fireblast", "powerwhip", "sludgebomb", "thunderbolt"],
-		randomDoubleBattleMoves: ["breakingswipe", "dracometeor", "fireblast", "muddywater", "powerwhip", "protect", "sludgebomb", "thunderbolt"],
-		tier: "RUBL",
-		doublesTier: "(DUU)",
-	},
-	klefki: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	phantump: {
-		tier: "LC",
-	},
-	trevenant: {
-		randomBattleMoves: ["earthquake", "hornleech", "rockslide", "shadowclaw", "trickroom", "woodhammer"],
-		randomDoubleBattleMoves: ["allyswitch", "rockslide", "shadowclaw", "trickroom", "willowisp", "woodhammer"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	pumpkaboo: {
-		tier: "LC",
-	},
-	pumpkaboosmall: {
-		unreleasedHidden: true,
-		tier: "LC",
-	},
-	pumpkaboolarge: {
-		unreleasedHidden: true,
-		tier: "LC",
-	},
-	pumpkaboosuper: {
-		tier: "LC",
-	},
-	gourgeist: {
-		randomBattleMoves: ["leechseed", "powerwhip", "shadowsneak", "substitute", "willowisp"],
-		randomDoubleBattleMoves: ["destinybond", "disable", "foulplay", "leechseed", "painsplit", "powerwhip", "willowisp"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	gourgeistsmall: {
-		randomBattleMoves: ["leechseed", "powerwhip", "shadowsneak", "substitute", "willowisp"],
-		randomDoubleBattleMoves: ["destinybond", "disable", "foulplay", "leechseed", "painsplit", "powerwhip", "willowisp"],
-		unreleasedHidden: true,
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	gourgeistlarge: {
-		randomBattleMoves: ["leechseed", "powerwhip", "shadowsneak", "substitute", "willowisp"],
-		randomDoubleBattleMoves: ["powerwhip", "protect", "shadowclaw", "shadowsneak", "synthesis", "trickroom"],
-		unreleasedHidden: true,
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	gourgeistsuper: {
-		randomBattleMoves: ["explosion", "foulplay", "powerwhip", "rockslide", "shadowsneak", "trick"],
-		randomDoubleBattleMoves: ["powerwhip", "protect", "shadowclaw", "shadowsneak", "synthesis", "trickroom"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	bergmite: {
-		tier: "LC",
-	},
-	avalugg: {
-		randomBattleMoves: ["avalanche", "bodypress", "curse", "rapidspin", "recover"],
-		randomDoubleBattleMoves: ["avalanche", "bodypress", "curse", "highhorsepower", "protect", "recover"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	noibat: {
-		tier: "LC",
-	},
-	noivern: {
-		randomBattleMoves: ["boomburst", "dracometeor", "flamethrower", "hurricane", "roost", "uturn"],
-		randomDoubleBattleMoves: ["boomburst", "dracometeor", "flamethrower", "hurricane", "protect", "tailwind"],
-		tier: "UU",
-		doublesTier: "DUU",
-	},
-	xerneas: {
-		randomBattleMoves: ["calmmind", "focusblast", "moonblast", "psyshock", "thunderbolt"],
-		randomDoubleBattleMoves: ["calmmind", "closecombat", "dazzlinggleam", "healpulse", "moonblast", "protect", "psyshock", "thunderbolt"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	xerneasneutral: {
-		isNonstandard: "Custom", // can't be used in battle
-		tier: "Illegal",
-	},
-	yveltal: {
-		randomBattleMoves: ["defog", "heatwave", "hurricane", "knockoff", "roost", "suckerpunch"],
-		randomDoubleBattleMoves: ["darkpulse", "heatwave", "hurricane", "knockoff", "roost", "suckerpunch", "tailwind", "uturn"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	zygarde: {
-		randomBattleMoves: ["dragondance", "earthquake", "extremespeed", "outrage", "stoneedge"],
-		randomDoubleBattleMoves: ["coil", "earthquake", "extremespeed", "glare", "irontail", "protect", "stoneedge"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	zygarde10: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	zygardecomplete: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	diancie: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	dianciemega: {
-		isNonstandard: "Past",
-	},
-	hoopa: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	hoopaunbound: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	volcanion: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	rowlet: {
-		tier: "LC",
-	},
-	dartrix: {
-		tier: "NFE",
-	},
-	decidueye: {
-		randomBattleMoves: ["bravebird", "leafblade", "roost", "shadowsneak", "spiritshackle", "swordsdance"],
-		randomDoubleBattleMoves: ["bravebird", "leafblade", "protect", "shadowsneak", "spiritshackle", "swordsdance"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	litten: {
-		tier: "LC",
-	},
-	torracat: {
-		tier: "NFE",
-		doublesTier: "DUU",
-	},
-	incineroar: {
-		randomBattleMoves: ["earthquake", "flareblitz", "knockoff", "partingshot", "uturn", "willowisp"],
-		randomDoubleBattleMoves: ["fakeout", "flareblitz", "knockoff", "partingshot", "protect", "snarl"],
-		tier: "UU",
-		doublesTier: "DOU",
-	},
-	popplio: {
-		tier: "LC",
-	},
-	brionne: {
-		tier: "NFE",
-	},
-	primarina: {
-		randomBattleMoves: ["energyball", "hydropump", "moonblast", "psychic", "sparklingaria"],
-		randomDoubleBattleMoves: ["energyball", "hydropump", "icebeam", "moonblast", "protect", "psychic"],
-		tier: "UUBL",
-		doublesTier: "DUU",
-	},
-	pikipek: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	trumbeak: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	toucannon: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	yungoos: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	gumshoos: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	gumshoostotem: {
-		isNonstandard: "Past",
-	},
-	grubbin: {
-		tier: "LC",
-	},
-	charjabug: {
-		tier: "NFE",
-	},
-	vikavolt: {
-		randomBattleMoves: ["agility", "bugbuzz", "energyball", "stickyweb", "thunderbolt", "voltswitch"],
-		randomDoubleBattleMoves: ["bugbuzz", "energyball", "protect", "stickyweb", "thunderbolt", "voltswitch"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	vikavolttotem: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	crabrawler: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	crabominable: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	oricorio: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	oricoriopompom: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	oricoriopau: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	oricoriosensu: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	cutiefly: {
-		tier: "LC Uber",
-	},
-	ribombee: {
-		randomBattleMoves: ["bugbuzz", "moonblast", "stickyweb", "stunspore", "uturn"],
-		randomDoubleBattleMoves: ["helpinghand", "moonblast", "pollenpuff", "protect", "stickyweb", "tailwind"],
-		tier: "UU",
-		doublesTier: "DUU",
-	},
-	ribombeetotem: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	rockruff: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	rockruffdusk: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	lycanroc: {
-		randomBattleMoves: ["accelerock", "closecombat", "psychicfangs", "stoneedge", "swordsdance"],
-		randomDoubleBattleMoves: ["accelerock", "closecombat", "crunch", "protect", "psychicfangs", "stoneedge", "swordsdance"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	lycanrocmidnight: {
-		randomBattleMoves: ["closecombat", "irontail", "stealthrock", "stoneedge", "suckerpunch"],
-		randomDoubleBattleMoves: ["closecombat", "irontail", "protect", "stoneedge", "suckerpunch", "swordsdance"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	lycanrocdusk: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	wishiwashi: {
-		randomDoubleBattleMoves: ["earthquake", "helpinghand", "hydropump", "icebeam", "muddywater", "protect"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	wishiwashischool: {
-		randomBattleMoves: ["earthquake", "hydropump", "icebeam", "scald", "uturn"],
-	},
-	mareanie: {
-		tier: "LC",
-	},
-	toxapex: {
-		randomBattleMoves: ["banefulbunker", "haze", "recover", "scald", "toxic", "toxicspikes"],
-		randomDoubleBattleMoves: ["banefulbunker", "haze", "infestation", "recover", "scald", "toxic"],
-		tier: "OU",
-		doublesTier: "(DUU)",
-	},
-	mudbray: {
-		tier: "LC",
-	},
-	mudsdale: {
-		randomBattleMoves: ["bodypress", "earthquake", "heavyslam", "rockslide", "stealthrock"],
-		randomDoubleBattleMoves: ["bodypress", "heavyslam", "highhorsepower", "protect", "rest", "rocktomb"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	dewpider: {
-		tier: "LC",
-	},
-	araquanid: {
-		randomBattleMoves: ["liquidation", "leechlife", "mirrorcoat", "stickyweb", "toxic"],
-		randomDoubleBattleMoves: ["leechlife", "liquidation", "lunge", "protect", "stickyweb", "wideguard"],
-		tier: "UU",
-		doublesTier: "DUU",
-	},
-	araquanidtotem: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	fomantis: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	lurantis: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	lurantistotem: {
-		isNonstandard: "Past",
-	},
-	morelull: {
-		tier: "LC",
-	},
-	shiinotic: {
-		randomBattleMoves: ["energyball", "leechseed", "moonblast", "spore", "strengthsap"],
-		randomDoubleBattleMoves: ["energyball", "moonblast", "protect", "spore", "strengthsap"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	salandit: {
-		tier: "LC",
-	},
-	salazzle: {
-		randomBattleMoves: ["flamethrower", "protect", "substitute", "toxic"],
-		randomDoubleBattleMoves: ["encore", "fakeout", "fireblast", "nastyplot", "protect", "sludgebomb"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	salazzletotem: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	stufful: {
-		tier: "LC",
-	},
-	bewear: {
-		randomBattleMoves: ["closecombat", "darkestlariat", "doubleedge", "icepunch", "swordsdance"],
-		randomDoubleBattleMoves: ["closecombat", "darkestlariat", "doubleedge", "drainpunch", "highhorsepower", "icepunch", "protect", "wideguard"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	bounsweet: {
-		tier: "LC",
-	},
-	steenee: {
-		tier: "NFE",
-	},
-	tsareena: {
-		randomBattleMoves: ["highjumpkick", "knockoff", "playrough", "powerwhip", "rapidspin", "synthesis", "uturn"],
-		randomDoubleBattleMoves: ["highjumpkick", "knockoff", "playrough", "powerwhip", "rapidspin", "uturn"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	comfey: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	oranguru: {
-		randomBattleMoves: ["focusblast", "nastyplot", "psychic", "thunderbolt", "trickroom"],
-		randomDoubleBattleMoves: ["allyswitch", "focusblast", "instruct", "protect", "psychic", "trickroom"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	passimian: {
-		randomBattleMoves: ["closecombat", "earthquake", "gunkshot", "knockoff", "rockslide", "uturn"],
-		randomDoubleBattleMoves: ["closecombat", "gunkshot", "knockoff", "rockslide", "uturn"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	wimpod: {
-		tier: "LC",
-	},
-	golisopod: {
-		randomBattleMoves: ["aquajet", "closecombat", "firstimpression", "liquidation", "spikes"],
-		randomDoubleBattleMoves: ["aquajet", "closecombat", "firstimpression", "knockoff", "leechlife", "liquidation", "protect", "wideguard"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	sandygast: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	palossand: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pyukumuku: {
-		randomBattleMoves: ["counter", "mirrorcoat", "recover", "toxic"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	typenull: {
-		randomBattleMoves: ["crushclaw", "payback", "rest", "sleeptalk", "swordsdance"],
-		randomDoubleBattleMoves: ["doubleedge", "flamecharge", "shadowclaw", "swordsdance", "thunderwave"],
-		tier: "PU",
-		doublesTier: "NFE",
-	},
-	silvally: {
-		randomBattleMoves: ["crunch", "explosion", "flamecharge", "flamethrower", "multiattack", "swordsdance", "uturn"],
-		randomDoubleBattleMoves: ["crunch", "explosion", "flamethrower", "multiattack", "protect", "tailwind"],
-		tier: "PUBL",
-		doublesTier: "(DUU)",
-	},
-	silvallybug: {
-		randomBattleMoves: ["flamethrower", "multiattack", "partingshot", "psychicfangs", "thunderbolt"],
-		randomDoubleBattleMoves: ["flamethrower", "multiattack", "psychicfangs", "tailwind", "uturn"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	silvallydark: {
-		randomBattleMoves: ["ironhead", "multiattack", "partingshot", "psychicfangs", "swordsdance"],
-		randomDoubleBattleMoves: ["ironhead", "multiattack", "psychicfangs", "swordsdance", "tailwind"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	silvallydragon: {
-		randomBattleMoves: ["firefang", "ironhead", "multiattack", "partingshot", "swordsdance"],
-		randomDoubleBattleMoves: ["firefang", "ironhead", "multiattack", "swordsdance", "tailwind"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	silvallyelectric: {
-		randomBattleMoves: ["flamethrower", "icebeam", "multiattack", "partingshot", "toxic"],
-		randomDoubleBattleMoves: ["flamethrower", "grasspledge", "icebeam", "multiattack", "tailwind"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	silvallyfairy: {
-		randomBattleMoves: ["firefang", "multiattack", "psychicfangs", "swordsdance"],
-		randomDoubleBattleMoves: ["flamethrower", "multiattack", "partingshot", "tailwind"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	silvallyfighting: {
-		randomBattleMoves: ["crunch", "ironhead", "multiattack", "swordsdance", "uturn"],
-		randomDoubleBattleMoves: ["crunch", "multiattack", "rockslide", "swordsdance", "tailwind"],
-		tier: "PUBL",
-		doublesTier: "(DUU)",
-	},
-	silvallyfire: {
-		randomBattleMoves: ["crunch", "ironhead", "multiattack", "swordsdance"],
-		randomDoubleBattleMoves: ["heatwave", "icebeam", "multiattack", "tailwind", "thunderbolt"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	silvallyflying: {
-		randomBattleMoves: ["firefang", "ironhead", "multiattack", "rockslide", "swordsdance"],
-		randomDoubleBattleMoves: ["firefang", "ironhead", "multiattack", "swordsdance", "tailwind"],
-		tier: "PUBL",
-		doublesTier: "(DUU)",
-	},
-	silvallyghost: {
-		randomBattleMoves: ["multiattack", "partingshot", "swordsdance", "xscissor"],
-		randomDoubleBattleMoves: ["multiattack", "swordsdance", "tailwind", "xscissor"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	silvallygrass: {
-		randomBattleMoves: ["defog", "flamethrower", "icebeam", "multiattack", "partingshot"],
-		randomDoubleBattleMoves: ["flamethrower", "icebeam", "multiattack", "partingshot", "tailwind"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	silvallyground: {
-		randomBattleMoves: ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic"],
-		randomDoubleBattleMoves: ["multiattack", "rockslide", "swordsdance", "tailwind"],
-		tier: "PUBL",
-		doublesTier: "(DUU)",
-	},
-	silvallyice: {
-		randomBattleMoves: ["firefang", "multiattack", "psychicfangs", "swordsdance"],
-		randomDoubleBattleMoves: ["flamethrower", "multiattack", "partingshot", "tailwind", "thunderbolt"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	silvallypoison: {
-		randomBattleMoves: ["defog", "flamethrower", "grasspledge", "multiattack", "partingshot", "toxic"],
-		randomDoubleBattleMoves: ["flamethrower", "grasspledge", "multiattack", "partingshot", "snarl", "tailwind"],
-		tier: "PUBL",
-		doublesTier: "(DUU)",
-	},
-	silvallypsychic: {
-		randomBattleMoves: ["crunch", "multiattack", "swordsdance", "uturn"],
-		randomDoubleBattleMoves: ["flamethrower", "multiattack", "partingshot", "tailwind", "xscissor"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	silvallyrock: {
-		randomBattleMoves: ["firefang", "multiattack", "partingshot", "psychicfangs", "swordsdance"],
-		randomDoubleBattleMoves: ["flamethrower", "multiattack", "partingshot", "psychicfangs", "tailwind"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	silvallysteel: {
-		randomBattleMoves: ["defog", "flamethrower", "multiattack", "partingshot", "thunderbolt", "toxic"],
-		randomDoubleBattleMoves: ["flamethrower", "multiattack", "partingshot", "tailwind", "thunderbolt"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	silvallywater: {
-		randomBattleMoves: ["defog", "icebeam", "multiattack", "partingshot", "thunderbolt", "toxic"],
-		randomDoubleBattleMoves: ["icebeam", "multiattack", "partingshot", "tailwind", "thunderbolt"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	minior: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	miniormeteor: {
-		isNonstandard: "Past",
-	},
-	komala: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	turtonator: {
-		randomBattleMoves: ["bodypress", "dracometeor", "earthquake", "fireblast", "rapidspin", "shellsmash", "willowisp"],
-		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "fireblast", "protect", "shellsmash"],
-		tier: "NUBL",
-		doublesTier: "(DUU)",
-	},
-	togedemaru: {
-		randomBattleMoves: ["ironhead", "nuzzle", "spikyshield", "uturn", "wish", "zingzap"],
-		randomDoubleBattleMoves: ["encore", "fakeout", "ironhead", "nuzzle", "spikyshield", "zingzap"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	togedemarutotem: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	mimikyu: {
-		randomBattleMoves: ["playrough", "shadowclaw", "shadowsneak", "swordsdance", "taunt"],
-		randomDoubleBattleMoves: ["playrough", "protect", "shadowclaw", "shadowsneak", "swordsdance", "woodhammer"],
-		tier: "OU",
-		doublesTier: "DUU",
-	},
-	mimikyutotem: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	mimikyubustedtotem: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	bruxish: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	drampa: {
-		randomBattleMoves: ["dracometeor", "fireblast", "glare", "hypervoice", "roost", "thunderbolt"],
-		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "energyball", "glare", "heatwave", "hypervoice", "protect", "roost", "thunderbolt"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	dhelmise: {
-		randomBattleMoves: ["anchorshot", "earthquake", "knockoff", "powerwhip", "rapidspin", "swordsdance"],
-		randomDoubleBattleMoves: ["anchorshot", "knockoff", "liquidation", "powerwhip", "shadowclaw", "synthesis"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	jangmoo: {
-		tier: "LC",
-	},
-	hakamoo: {
-		tier: "NFE",
-	},
-	kommoo: {
-		randomBattleMoves: ["clangingscales", "clangoroussoul", "closecombat", "poisonjab", "stealthrock"],
-		randomDoubleBattleMoves: ["bodypress", "dracometeor", "irondefense", "protect"],
-		tier: "OU",
-		doublesTier: "DUU",
-	},
-	kommoototem: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	tapukoko: {
-		randomBattleMoves: ["bravebird", "closecombat", "playrough", "uturn", "wildcharge"],
-		randomDoubleBattleMoves: ["bravebird", "closecombat", "playrough", "uturn", "wildcharge"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	tapulele: {
-		randomBattleMoves: ["calmmind", "focusblast", "moonblast", "psychic", "psyshock", "taunt"],
-		randomDoubleBattleMoves: ["focusblast", "moonblast", "protect", "psychic", "psyshock", "taunt"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	tapubulu: {
-		randomBattleMoves: ["bulkup", "closecombat", "hornleech", "playrough", "stoneedge", "woodhammer"],
-		randomDoubleBattleMoves: ["closecombat", "hornleech", "playrough", "protect", "stoneedge", "synthesis", "woodhammer"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	tapufini: {
-		randomBattleMoves: ["calmmind", "defog", "moonblast", "surf", "taunt"],
-		randomDoubleBattleMoves: ["healpulse", "hydropump", "icywind", "moonblast", "muddywater", "naturesmadness", "swagger"],
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	cosmog: {
-		tier: "LC",
-	},
-	cosmoem: {
-		tier: "NFE",
-	},
-	solgaleo: {
-		randomBattleMoves: ["closecombat", "flamecharge", "morningsun", "psychicfangs", "stoneedge", "sunsteelstrike"],
-		randomDoubleBattleMoves: ["closecombat", "flareblitz", "morningsun", "protect", "psychicfangs", "stoneedge", "sunsteelstrike"],
-		tier: "Uber",
-		doublesTier: "DUber",
-	},
-	lunala: {
-		randomBattleMoves: ["calmmind", "moonblast", "moongeistbeam", "psyshock", "roost"],
-		randomDoubleBattleMoves: ["calmmind", "moonblast", "moongeistbeam", "moonlight", "protect", "psychic", "psyshock"],
-		tier: "Uber",
-		doublesTier: "DUber",
-	},
-	nihilego: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	buzzwole: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	pheromosa: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	xurkitree: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	celesteela: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	kartana: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	guzzlord: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	necrozma: {
-		randomBattleMoves: ["calmmind", "heatwave", "moonlight", "photongeyser", "stealthrock"],
-		randomDoubleBattleMoves: ["calmmind", "earthpower", "moonlight", "photongeyser", "powergem"],
-		tier: "UU",
-		doublesTier: "DOU",
-	},
-	necrozmaduskmane: {
-		randomBattleMoves: ["dragondance", "earthquake", "morningsun", "photongeyser", "sunsteelstrike"],
-		randomDoubleBattleMoves: ["dragondance", "morningsun", "photongeyser", "protect", "sunsteelstrike"],
-		tier: "Uber",
-		doublesTier: "DUber",
-	},
-	necrozmadawnwings: {
-		randomBattleMoves: ["autotomize", "calmmind", "heatwave", "moongeistbeam", "photongeyser"],
-		randomDoubleBattleMoves: ["earthpower", "heatwave", "moonblast", "moongeistbeam", "photongeyser", "protect"],
-		tier: "Uber",
-		doublesTier: "DUber",
-	},
-	necrozmaultra: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	magearna: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	magearnaoriginal: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	marshadow: {
-		randomBattleMoves: ["bulkup", "closecombat", "icepunch", "rocktomb", "shadowsneak", "spectralthief"],
-		randomDoubleBattleMoves: ["closecombat", "protect", "rocktomb", "shadowsneak", "spectralthief"],
-		tier: "Uber",
-		doublesTier: "DUber",
-	},
-	poipole: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	naganadel: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	stakataka: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	blacephalon: {
-		isNonstandard: "Past",
-		tier: "Illegal",
-	},
-	zeraora: {
-		randomBattleMoves: ["bulkup", "closecombat", "grassknot", "knockoff", "plasmafists", "playrough", "voltswitch"],
-		randomDoubleBattleMoves: ["closecombat", "fakeout", "grassknot", "knockoff", "plasmafists", "playrough"],
-		tier: "OU",
-		doublesTier: "DOU",
-	},
-	meltan: {
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	melmetal: {
-		randomBattleMoves: ["doubleironbash", "earthquake", "substitute", "superpower", "thunderpunch"],
-		randomDoubleBattleMoves: ["bodypress", "doubleironbash", "highhorsepower", "icepunch", "thunderpunch", "thunderwave"],
-		tier: "Uber",
-		doublesTier: "DOU",
-	},
-	melmetalgmax: {
-		isNonstandard: "Unobtainable",
-		tier: "Unreleased",
-	},
-	grookey: {
-		unreleasedHidden: true,
-		tier: "LC",
-	},
-	thwackey: {
-		unreleasedHidden: true,
-		tier: "NFE",
-	},
-	rillaboom: {
-		randomBattleMoves: ["bulkup", "drumbeating", "highhorsepower", "knockoff", "substitute", "uturn", "woodhammer"],
-		randomDoubleBattleMoves: ["drumbeating", "fakeout", "highhorsepower", "superpower", "swordsdance", "uturn"],
-		unreleasedHidden: true,
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	scorbunny: {
-		unreleasedHidden: true,
-		tier: "LC",
-	},
-	raboot: {
-		unreleasedHidden: true,
-		tier: "NFE",
-	},
-	cinderace: {
-		randomBattleMoves: ["courtchange", "gunkshot", "highjumpkick", "pyroball", "uturn", "zenheadbutt"],
-		randomDoubleBattleMoves: ["courtchange", "gunkshot", "highjumpkick", "ironhead", "protect", "pyroball", "uturn", "zenheadbutt"],
-		unreleasedHidden: true,
-		tier: "OU",
-		doublesTier: "DUU",
-	},
-	sobble: {
-		unreleasedHidden: true,
-		tier: "LC",
-	},
-	drizzile: {
-		unreleasedHidden: true,
-		tier: "NFE",
-	},
-	inteleon: {
-		randomBattleMoves: ["airslash", "darkpulse", "hydropump", "icebeam", "scald", "uturn"],
-		randomDoubleBattleMoves: ["airslash", "hydropump", "icebeam", "muddywater", "shadowball", "uturn"],
-		unreleasedHidden: true,
-		tier: "RU",
-		doublesTier: "DUU",
-	},
-	skwovet: {
-		unreleasedHidden: true,
-		tier: "LC",
-	},
-	greedent: {
-		randomBattleMoves: ["bodyslam", "earthquake", "firefang", "payback", "swordsdance"],
-		randomDoubleBattleMoves: ["bodyslam", "crunch", "earthquake", "gyroball", "protect", "swordsdance"],
-		unreleasedHidden: true,
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	rookidee: {
-		tier: "LC",
-	},
-	corvisquire: {
-		tier: "NFE",
-	},
-	corviknight: {
-		randomBattleMoves: ["bodypress", "bravebird", "bulkup", "defog", "roost"],
-		randomDoubleBattleMoves: ["bodypress", "bravebird", "bulkup", "ironhead", "roost", "tailwind"],
-		tier: "OU",
-		doublesTier: "DOU",
-	},
-	corviknightgmax: {
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	blipbug: {
-		tier: "LC",
-	},
-	dottler: {
-		tier: "NFE",
-	},
-	orbeetle: {
-		randomBattleMoves: ["bodypress", "hypnosis", "psychic", "recover", "stickyweb", "uturn"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	orbeetlegmax: {
-		randomDoubleBattleMoves: ["helpinghand", "hypnosis", "lightscreen", "psychic", "reflect", "stickyweb", "strugglebug"],
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	nickit: {
-		unreleasedHidden: true,
-		tier: "LC",
-	},
-	thievul: {
-		randomBattleMoves: ["darkpulse", "foulplay", "grassknot", "nastyplot", "partingshot", "psychic"],
-		randomDoubleBattleMoves: ["faketears", "foulplay", "partingshot", "snarl", "taunt"],
-		unreleasedHidden: true,
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	gossifleur: {
-		tier: "LC",
-	},
-	eldegoss: {
-		randomBattleMoves: ["charm", "energyball", "leechseed", "pollenpuff", "rapidspin", "sleeppowder"],
-		randomDoubleBattleMoves: ["gigadrain", "helpinghand", "leechseed", "pollenpuff", "protect", "sleeppowder", "synthesis"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	wooloo: {
-		unreleasedHidden: true,
-		tier: "LC",
-	},
-	dubwool: {
-		randomBattleMoves: ["bodypress", "cottonguard", "rest", "sleeptalk"],
-		randomDoubleBattleMoves: ["doubleedge", "protect", "swordsdance", "thunderwave", "wildcharge", "zenheadbutt"],
-		unreleasedHidden: true,
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	chewtle: {
-		tier: "LC",
-	},
-	drednaw: {
-		randomBattleMoves: ["liquidation", "stealthrock", "stoneedge", "superpower", "swordsdance"],
-		randomDoubleBattleMoves: ["highhorsepower", "liquidation", "protect", "rockslide", "superpower", "swordsdance"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	drednawgmax: {
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	yamper: {
-		unreleasedHidden: true,
-		tier: "LC",
-	},
-	boltund: {
-		randomBattleMoves: ["bulkup", "crunch", "firefang", "playrough", "psychicfangs", "thunderfang", "voltswitch"],
-		randomDoubleBattleMoves: ["crunch", "firefang", "nuzzle", "playrough", "protect", "psychicfangs", "snarl", "thunderfang"],
-		unreleasedHidden: true,
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	rolycoly: {
-		tier: "LC",
-	},
-	carkol: {
-		tier: "PU",
-		doublesTier: "NFE",
-	},
-	coalossal: {
-		tier: "RU",
-		doublesTier: "DUU",
-	},
-	coalossalgmax: {
-		randomBattleMoves: ["overheat", "rapidspin", "spikes", "stealthrock", "stoneedge", "willowisp"],
-		randomDoubleBattleMoves: ["fireblast", "incinerate", "protect", "stealthrock", "stoneedge", "willowisp"],
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	applin: {
-		tier: "LC",
-	},
-	flapple: {
-		randomBattleMoves: ["dragondance", "gravapple", "outrage", "suckerpunch", "uturn"],
-		randomDoubleBattleMoves: ["acrobatics", "dragondance", "dragonrush", "gravapple", "protect"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	flapplegmax: {
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	appletun: {
-		randomBattleMoves: ["appleacid", "dragonpulse", "leechseed", "recover"],
-		randomDoubleBattleMoves: ["appleacid", "dracometeor", "dragonpulse", "leechseed", "protect", "recover"],
-		tier: "PUBL",
-		doublesTier: "(DUU)",
-	},
-	appletungmax: {
-		randomBattleMoves: ["appleacid", "dracometeor", "leechseed", "recover"],
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	silicobra: {
-		tier: "LC",
-	},
-	sandaconda: {
-		randomBattleMoves: ["coil", "earthquake", "glare", "stealthrock", "stoneedge", "rest"],
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	sandacondagmax: {
-		randomDoubleBattleMoves: ["coil", "glare", "highhorsepower", "protect", "stoneedge"],
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	cramorant: {
-		randomBattleMoves: ["bravebird", "defog", "roost", "superpower", "surf"],
-		randomDoubleBattleMoves: ["hurricane", "icebeam", "protect", "roost", "surf", "tailwind"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	arrokuda: {
-		tier: "LC",
-	},
-	barraskewda: {
-		randomBattleMoves: ["closecombat", "crunch", "drillrun", "liquidation", "poisonjab"],
-		randomDoubleBattleMoves: ["closecombat", "crunch", "drillrun", "liquidation", "poisonjab", "psychicfangs"],
-		tier: "RUBL",
-		doublesTier: "DUU",
-	},
-	toxel: {
-		tier: "LC",
-	},
-	toxtricity: {
-		randomBattleMoves: ["boomburst", "overdrive", "shiftgear", "sludgewave", "voltswitch"],
-		tier: "UU",
-		doublesTier: "DUU",
-	},
-	toxtricitylowkey: {
-		randomBattleMoves: ["boomburst", "overdrive", "sludgewave", "voltswitch"],
-		tier: "UU",
-		doublesTier: "DUU",
-	},
-	toxtricitygmax: {
-		randomDoubleBattleMoves: ["boomburst", "overdrive", "shiftgear", "sludgebomb", "snarl", "voltswitch"],
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	toxtricitylowkeygmax: {
-		randomDoubleBattleMoves: ["boomburst", "overdrive", "sludgebomb", "snarl", "voltswitch"],
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	sizzlipede: {
-		tier: "LC",
-	},
-	centiskorch: {
-		randomBattleMoves: ["coil", "firelash", "knockoff", "leechlife", "powerwhip"],
-		randomDoubleBattleMoves: ["coil", "firelash", "knockoff", "leechlife", "powerwhip", "protect"],
-		tier: "RUBL",
-		doublesTier: "DUU",
-	},
-	centiskorchgmax: {
-		randomDoubleBattleMoves: ["coil", "firelash", "knockoff", "leechlife", "powerwhip", "protect"],
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	clobbopus: {
-		tier: "LC",
-	},
-	grapploct: {
-		randomBattleMoves: ["brutalswing", "circlethrow", "drainpunch", "icepunch", "suckerpunch"],
-		randomDoubleBattleMoves: ["closecombat", "drainpunch", "icepunch", "octolock", "payback", "protect"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	sinistea: {
-		tier: "LC",
-	},
-	sinisteaantique: {
-		unreleasedHidden: true,
-		tier: "LC",
-	},
-	polteageist: {
-		randomBattleMoves: ["gigadrain", "shadowball", "shellsmash", "storedpower", "strengthsap"],
-		randomDoubleBattleMoves: ["gigadrain", "protect", "shadowball", "shellsmash", "storedpower"],
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	polteageistantique: {
-		unreleasedHidden: true,
-		tier: "UU",
-		doublesTier: "(DUU)",
-	},
-	hatenna: {
-		tier: "LC",
-	},
-	hattrem: {
-		tier: "NU",
-		doublesTier: "NFE",
-	},
-	hatterene: {
-		tier: "OU",
-		doublesTier: "DOU",
-	},
-	hatterenegmax: {
-		randomBattleMoves: ["calmmind", "darkpulse", "dazzlinggleam", "mysticalfire", "psychic", "trickroom"],
-		randomDoubleBattleMoves: ["dazzlinggleam", "mysticalfire", "protect", "psychic", "psyshock", "trickroom"],
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	impidimp: {
-		tier: "LC",
-	},
-	morgrem: {
-		tier: "NFE",
-	},
-	grimmsnarl: {
-		randomBattleMoves: ["lightscreen", "reflect", "spiritbreak", "taunt", "thunderwave"],
-		tier: "OU",
-		doublesTier: "DOU",
-	},
-	grimmsnarlgmax: {
-		randomBattleMoves: ["bulkup", "darkestlariat", "playrough", "substitute", "suckerpunch", "trick"],
-		randomDoubleBattleMoves: ["darkestlariat", "fakeout", "lightscreen", "reflect", "spiritbreak", "taunt", "thunderwave"],
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	milcery: {
-		tier: "LC",
-	},
-	alcremie: {
-		tier: "NU",
-		doublesTier: "DUU",
-	},
-	alcremiegmax: {
-		randomBattleMoves: ["calmmind", "dazzlinggleam", "mysticalfire", "psychic", "recover"],
-		randomDoubleBattleMoves: ["dazzlinggleam", "decorate", "mysticalfire", "protect", "recover"],
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	falinks: {
-		randomBattleMoves: ["closecombat", "noretreat", "poisonjab", "rockslide", "throatchop"],
-		randomDoubleBattleMoves: ["closecombat", "noretreat", "poisonjab", "rockslide", "throatchop"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	pincurchin: {
-		randomBattleMoves: ["discharge", "recover", "selfdestruct", "spikes", "suckerpunch", "toxicspikes"],
-		randomDoubleBattleMoves: ["acupressure", "protect", "recover", "scald", "suckerpunch", "thunderbolt", "thunderwave"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	snom: {
-		tier: "LC",
-	},
-	frosmoth: {
-		randomBattleMoves: ["bugbuzz", "gigadrain", "hurricane", "icebeam", "quiverdance"],
-		randomDoubleBattleMoves: ["bugbuzz", "gigadrain", "hurricane", "icebeam", "quiverdance", "wideguard"],
-		tier: "RU",
-		doublesTier: "DUU",
-	},
-	stonjourner: {
-		randomBattleMoves: ["earthquake", "heatcrash", "rockpolish", "stealthrock", "stoneedge"],
-		randomDoubleBattleMoves: ["bodypress", "heatcrash", "heavyslam", "protect", "rockpolish", "stoneedge", "wideguard"],
-		tier: "PU",
-		doublesTier: "(DUU)",
-	},
-	eiscue: {
-		randomBattleMoves: ["bellydrum", "iciclecrash", "liquidation", "substitute", "zenheadbutt"],
-		randomDoubleBattleMoves: ["bellydrum", "iciclecrash", "liquidation", "protect", "zenheadbutt"],
-		tier: "(PU)",
-		doublesTier: "(DUU)",
-	},
-	indeedee: {
-		randomBattleMoves: ["calmmind", "hypervoice", "mysticalfire", "psyshock", "trick"],
-		randomDoubleBattleMoves: ["encore", "hypervoice", "mysticalfire", "protect", "psychic", "psyshock", "trick"],
-		tier: "RU",
-		doublesTier: "DUU",
-	},
-	indeedeef: {
-		randomBattleMoves: ["calmmind", "healingwish", "hypervoice", "mysticalfire", "psychic"],
-		randomDoubleBattleMoves: ["allyswitch", "followme", "healpulse", "helpinghand", "protect", "psychic", "psyshock"],
-		tier: "NU",
-		doublesTier: "DOU",
-	},
-	morpeko: {
-		randomBattleMoves: ["aurawheel", "foulplay", "partingshot", "protect", "psychicfangs", "rapidspin"],
-		randomDoubleBattleMoves: ["aurawheel", "fakeout", "partingshot", "protect", "rapidspin", "superfang"],
-		tier: "RU",
-		doublesTier: "(DUU)",
-	},
-	cufant: {
-		tier: "LC",
-	},
-	copperajah: {
-		randomBattleMoves: ["earthquake", "ironhead", "playrough", "rockslide", "stealthrock"],
-		randomDoubleBattleMoves: ["heatcrash", "highhorsepower", "ironhead", "playrough", "powerwhip", "protect", "stoneedge"],
-		tier: "RU",
-		doublesTier: "DUU",
-	},
-	copperajahgmax: {
-		randomBattleMoves: ["earthquake", "heatcrash", "heavyslam", "powerwhip", "stoneedge"],
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	dracozolt: {
-		randomBattleMoves: ["aerialace", "boltbeak", "earthquake", "lowkick", "outrage"],
-		randomDoubleBattleMoves: ["aerialace", "boltbeak", "dragonclaw", "highhorsepower", "rockslide"],
-		unreleasedHidden: true,
-		tier: "UUBL",
-		doublesTier: "(DUU)",
-	},
-	arctozolt: {
-		randomBattleMoves: ["bodyslam", "boltbeak", "freezedry", "iciclecrash", "lowkick"],
-		randomDoubleBattleMoves: ["blizzard", "boltbeak", "iciclecrash", "lowkick", "protect"],
-		unreleasedHidden: true,
-		tier: "PUBL",
-		doublesTier: "(DUU)",
-	},
-	dracovish: {
-		randomBattleMoves: ["crunch", "fishiousrend", "icefang", "lowkick", "psychicfangs"],
-		randomDoubleBattleMoves: ["crunch", "dragonrush", "fishiousrend", "icefang", "psychicfangs"],
-		unreleasedHidden: true,
-		tier: "OU",
-		doublesTier: "DOU",
-	},
-	arctovish: {
-		randomBattleMoves: ["bodyslam", "fishiousrend", "freezedry", "iciclecrash", "psychicfangs"],
-		randomDoubleBattleMoves: ["blizzard", "bodyslam", "fishiousrend", "iciclecrash", "protect", "psychicfangs"],
-		unreleasedHidden: true,
-		tier: "NU",
-		doublesTier: "(DUU)",
-	},
-	duraludon: {
-		randomBattleMoves: ["bodypress", "dracometeor", "flashcannon", "stealthrock", "thunderbolt"],
-		randomDoubleBattleMoves: ["bodypress", "dracometeor", "dragonpulse", "flashcannon", "protect", "snarl", "thunderbolt"],
-		tier: "RU",
-		doublesTier: "DUU",
-	},
-	duraludongmax: {
-		tier: "(Uber)",
-		doublesTier: "(DUber)",
-	},
-	dreepy: {
-		tier: "LC",
-	},
-	drakloak: {
-		tier: "NFE",
-	},
-	dragapult: {
-		randomBattleMoves: ["dracometeor", "fireblast", "shadowball", "thunderbolt", "uturn"],
-		randomDoubleBattleMoves: ["disable", "dragondarts", "fireblast", "phantomforce", "protect", "thunderbolt", "willowisp"],
-		tier: "OU",
-		doublesTier: "DOU",
-	},
-	zacian: {
-		randomBattleMoves: ["closecombat", "crunch", "playrough", "psychicfangs", "swordsdance"],
-		randomDoubleBattleMoves: ["closecombat", "crunch", "playrough", "protect", "psychicfangs", "swordsdance"],
-		tier: "Uber",
-		doublesTier: "DUber",
-	},
-	zaciancrowned: {
-		randomBattleMoves: ["behemothblade", "closecombat", "crunch", "playrough", "psychicfangs", "swordsdance"],
-		randomDoubleBattleMoves: ["behemothblade", "closecombat", "playrough", "protect", "psychicfangs", "swordsdance"],
-		tier: "Uber",
-		doublesTier: "DUber",
-	},
-	zamazenta: {
-		randomBattleMoves: ["closecombat", "crunch", "psychicfangs", "wildcharge"],
-		randomDoubleBattleMoves: ["closecombat", "crunch", "playrough", "protect", "psychicfangs"],
-		tier: "Uber",
-		doublesTier: "DUber",
-	},
-	zamazentacrowned: {
-		randomBattleMoves: ["behemothbash", "closecombat", "crunch", "psychicfangs"],
-		randomDoubleBattleMoves: ["behemothbash", "closecombat", "crunch", "playrough", "protect", "psychicfangs"],
-		tier: "Uber",
-		doublesTier: "DUber",
-	},
-	eternatus: {
-		randomBattleMoves: ["dynamaxcannon", "flamethrower", "recover", "sludgewave", "toxic"],
-		randomDoubleBattleMoves: ["cosmicpower", "dynamaxcannon", "flamethrower", "recover"],
-		tier: "Uber",
-		doublesTier: "DUber",
-	},
-	eternatuseternamax: {
-		isNonstandard: "Unobtainable",
-		tier: "Illegal",
-	},
-	missingno: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
-	syclar: {
-		isNonstandard: "CAP",
-		tier: "CAP LC",
-	},
-	syclant: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	revenankh: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	embirch: {
-		isNonstandard: "CAP",
-		tier: "CAP LC",
-	},
-	flarelm: {
-		isNonstandard: "CAP",
-		tier: "CAP NFE",
-	},
-	pyroak: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	breezi: {
-		isNonstandard: "CAP",
-		tier: "CAP LC",
-	},
-	fidgit: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	rebble: {
-		isNonstandard: "CAP",
-		tier: "CAP LC",
-	},
-	tactite: {
-		isNonstandard: "CAP",
-		tier: "CAP NFE",
-	},
-	stratagem: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	privatyke: {
-		isNonstandard: "CAP",
-		tier: "CAP LC",
-	},
-	arghonaut: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	kitsunoh: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	cyclohm: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	colossoil: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	krilowatt: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	voodoll: {
-		isNonstandard: "CAP",
-		tier: "CAP LC",
-	},
-	voodoom: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	scratchet: {
-		isNonstandard: "CAP",
-		tier: "CAP LC",
-	},
-	tomohawk: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	necturine: {
-		isNonstandard: "CAP",
-		tier: "CAP LC",
-	},
-	necturna: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	mollux: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	cupra: {
-		isNonstandard: "CAP",
-		tier: "CAP LC",
-	},
-	argalis: {
-		isNonstandard: "CAP",
-		tier: "CAP NFE",
-	},
-	aurumoth: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	brattler: {
-		isNonstandard: "CAP",
-		tier: "CAP LC",
-	},
-	malaconda: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	cawdet: {
-		isNonstandard: "CAP",
-		tier: "CAP LC",
-	},
-	cawmodore: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	volkritter: {
-		isNonstandard: "CAP",
-		tier: "CAP LC",
-	},
-	volkraken: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	snugglow: {
-		isNonstandard: "CAP",
-		tier: "CAP LC",
-	},
-	plasmanta: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	floatoy: {
-		isNonstandard: "CAP",
-		tier: "CAP LC",
-	},
-	caimanoe: {
-		isNonstandard: "CAP",
-		tier: "CAP NFE",
-	},
-	naviathan: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	crucibelle: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	crucibellemega: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	pluffle: {
-		isNonstandard: "CAP",
-		tier: "CAP LC",
-	},
-	kerfluffle: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	pajantom: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	mumbao: {
-		isNonstandard: "CAP",
-		tier: "CAP LC",
-	},
-	jumbao: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	fawnifer: {
-		isNonstandard: "CAP",
-		tier: "CAP LC",
-	},
-	electrelk: {
-		isNonstandard: "CAP",
-		tier: "CAP NFE",
-	},
-	caribolt: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	smogecko: {
-		isNonstandard: "CAP",
-		tier: "CAP LC",
-	},
-	smoguana: {
-		isNonstandard: "CAP",
-		tier: "CAP NFE",
-	},
-	smokomodo: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	swirlpool: {
-		isNonstandard: "CAP",
-		tier: "CAP LC",
-	},
-	coribalis: {
-		isNonstandard: "CAP",
-		tier: "CAP NFE",
-	},
-	snaelstrom: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	equilibra: {
-		isNonstandard: "CAP",
-		tier: "CAP",
-	},
-	pokestarsmeargle: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
-	pokestarufo: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
-	pokestarufo2: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
-	pokestarbrycenman: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
-	pokestarmt: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
-	pokestarmt2: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
-	pokestartransport: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
-	pokestargiant: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
-	pokestargiant2: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
-	pokestarhumanoid: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
-	pokestarmonster: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
-	pokestarf00: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
-	pokestarf002: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
-	pokestarspirit: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
-	pokestarblackdoor: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
-	pokestarwhitedoor: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
-	pokestarblackbelt: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
-	pokestargiantpropo2: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
-	pokestarufopropu2: {
-		isNonstandard: "Custom",
-		tier: "Illegal",
-	},
+    bulbasaur: {
+        tier: "LC",
+    },
+    ivysaur: {
+        tier: "NFE",
+    },
+    venusaur: {
+        randomBattleMoves: [ "gigadrain", "leechseed", "sleeppowder", "sludgebomb", "substitute" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "earthpower", "gigadrain", "leechseed", "protect", "sleeppowder", "sludgebomb" ],
+        tier: "UUBL",
+        doublesTier: "DOU",
+    },
+    venusaurmega: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    charmander: {
+        tier: "LC",
+    },
+    charmeleon: {
+        tier: "NFE",
+    },
+    charizard: {
+        randomBattleMoves: [ "airslash", "earthquake", "fireblast", "focusblast", "roost" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "airslash", "dragonpulse", "heatwave", "overheat", "protect", "tailwind" ],
+        tier: "RU",
+        doublesTier: "DOU",
+    },
+    charizardmegax: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    charizardmegay: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    charizardgmax: {
+        randomDoubleBattleMoves: [ "earthquake", "focusblast", "heatwave", "hurricane", "protect", "tailwind" ],
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    squirtle: {
+        tier: "LC",
+    },
+    wartortle: {
+        tier: "NFE",
+    },
+    blastoise: {
+        randomBattleMoves: [ "earthquake", "hydropump", "icebeam", "rapidspin", "scald", "shellsmash" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "fakeout", "followme", "icywind", "lifedew", "muddywater", "protect", "scald" ],
+        tier: "UU",
+        doublesTier: "DOU",
+    },
+    blastoisemega: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    caterpie: {
+        tier: "LC",
+    },
+    metapod: {
+        tier: "NFE",
+    },
+    butterfree: {
+        randomBattleMoves: [ "energyball", "hurricane", "quiverdance", "sleeppowder" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "hurricane", "pollenpuff", "protect", "quiverdance", "ragepowder", "sleeppowder", "tailwind" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    butterfreegmax: {
+        randomBattleMoves: [ "airslash", "bugbuzz", "quiverdance", "sleeppowder" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "hurricane", "pollenpuff", "protect", "quiverdance", "ragepowder", "sleeppowder", "tailwind" ],
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    weedle: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    kakuna: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    beedrill: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    beedrillmega: {
+        isNonstandard: "Past",
+    },
+    pidgey: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pidgeotto: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pidgeot: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pidgeotmega: {
+        isNonstandard: "Past",
+    },
+    rattata: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    rattataalola: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    raticate: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    raticatealola: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    raticatealolatotem: {
+        isNonstandard: "Past",
+    },
+    spearow: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    fearow: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    ekans: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    arbok: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pichu: {
+        tier: "LC",
+    },
+    pichuspikyeared: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pikachu: {
+        randomBattleMoves: [ "irontail", "knockoff", "surf", "voltswitch", "volttackle" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "extremespeed", "fakeout", "knockoff", "surf", "volttackle" ],
+        tier: "PU",
+        doublesTier: "NFE",
+    },
+    pikachucosplay: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pikachurockstar: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pikachubelle: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pikachupopstar: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pikachuphd: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pikachulibre: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pikachuoriginal: {
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    pikachuhoenn: {
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    pikachusinnoh: {
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    pikachuunova: {
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    pikachukalos: {
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    pikachualola: {
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    pikachupartner: {
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    pikachustarter: {
+        isNonstandard: "LGPE",
+        tier: "Illegal",
+    },
+    pikachugmax: {
+        randomDoubleBattleMoves: [ "extremespeed", "fakeout", "knockoff", "surf", "volttackle" ],
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    raichu: {
+        randomBattleMoves: [ "encore", "focusblast", "grassknot", "nastyplot", "thunderbolt", "voltswitch" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "fakeout", "followme", "grassknot", "nuzzle", "protect", "thunderbolt" ],
+        tier: "PU",
+        doublesTier: "DUU",
+    },
+    raichualola: {
+        randomBattleMoves: [ "focusblast", "grassknot", "nastyplot", "psyshock", "thunderbolt", "voltswitch" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "focusblast", "nastyplot", "protect", "psychic", "psyshock", "surf", "thunderbolt" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    sandshrew: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    sandshrewalola: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    sandslash: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    sandslashalola: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    nidoranf: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    nidorina: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    nidoqueen: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "earthpower", "icebeam", "sludgewave", "stealthrock", "toxicspikes" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "earthpower", "fireblast", "icebeam", "sludgebomb", "stealthrock" ],
+        tier: "Illegal",
+    },
+    nidoranm: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    nidorino: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    nidoking: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "earthpower", "icebeam", "sludgewave", "substitute", "superpower" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "earthpower", "fireblast", "icebeam", "protect", "sludgebomb", "superpower" ],
+        tier: "Illegal",
+    },
+    cleffa: {
+        tier: "LC",
+    },
+    clefairy: {
+        tier: "NU",
+        doublesTier: "DUU",
+    },
+    clefable: {
+        randomBattleMoves: [ "calmmind", "fireblast", "moonblast", "softboiled", "stealthrock", "thunderwave" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "fireblast", "followme", "healpulse", "helpinghand", "moonblast", "protect", "thunderwave" ],
+        tier: "OU",
+        doublesTier: "(DUU)",
+    },
+    vulpix: {
+        tier: "LC Uber",
+    },
+    vulpixalola: {
+        tier: "LC Uber",
+    },
+    ninetales: {
+        randomBattleMoves: [ "fireblast", "nastyplot", "solarbeam", "substitute", "willowisp" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "encore", "heatwave", "nastyplot", "protect", "solarbeam" ],
+        tier: "RU",
+        doublesTier: "DUU",
+    },
+    ninetalesalola: {
+        randomBattleMoves: [ "auroraveil", "blizzard", "freezedry", "moonblast", "nastyplot", "substitute" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "auroraveil", "blizzard", "encore", "freezedry", "moonblast", "protect" ],
+        tier: "UUBL",
+        doublesTier: "DUU",
+    },
+    igglybuff: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    jigglypuff: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    wigglytuff: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    zubat: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    golbat: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    crobat: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "bravebird", "defog", "roost", "superfang", "taunt", "toxic", "uturn" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "bravebird", "defog", "roost", "superfang", "tailwind", "taunt" ],
+        tier: "Illegal",
+    },
+    oddish: {
+        tier: "LC",
+    },
+    gloom: {
+        tier: "NFE",
+    },
+    vileplume: {
+        randomBattleMoves: [ "aromatherapy", "gigadrain", "sleeppowder", "sludgebomb", "strengthsap" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "aromatherapy", "gigadrain", "pollenpuff", "sleeppowder", "sludgebomb", "strengthsap" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    bellossom: {
+        randomBattleMoves: [ "gigadrain", "moonblast", "quiverdance", "sleeppowder", "strengthsap" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "gigadrain", "moonblast", "quiverdance", "sleeppowder", "strengthsap" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    paras: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    parasect: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    venonat: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    venomoth: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    diglett: {
+        tier: "LC",
+    },
+    diglettalola: {
+        tier: "LC",
+    },
+    dugtrio: {
+        randomBattleMoves: [ "earthquake", "memento", "reversal", "stealthrock", "stoneedge", "substitute" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "highhorsepower", "memento", "protect", "rockslide", "substitute", "suckerpunch" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    dugtrioalola: {
+        randomBattleMoves: [ "earthquake", "ironhead", "memento", "stoneedge", "suckerpunch" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "highhorsepower", "ironhead", "memento", "protect", "rockslide", "suckerpunch" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    meowth: {
+        tier: "LC",
+    },
+    meowthalola: {
+        tier: "LC",
+    },
+    meowthgalar: {
+        tier: "LC",
+    },
+    meowthgmax: {
+        unreleasedHidden: true,
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    persian: {
+        randomBattleMoves: [ "doubleedge", "fakeout", "knockoff", "playrough", "uturn" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "doubleedge", "fakeout", "foulplay", "hypnosis", "icywind", "taunt" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    persianalola: {
+        randomBattleMoves: [ "darkpulse", "hypnosis", "nastyplot", "powergem", "thunderbolt" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "fakeout", "foulplay", "icywind", "partingshot", "protect", "snarl", "taunt" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    perrserker: {
+        randomBattleMoves: [ "closecombat", "crunch", "fakeout", "ironhead", "swordsdance", "uturn" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "closecombat", "crunch", "fakeout", "ironhead", "seedbomb", "swordsdance", "uturn" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    psyduck: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    golduck: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "calmmind", "focusblast", "icebeam", "psyshock", "scald", "substitute" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "calmmind", "encore", "icebeam", "muddywater", "protect", "psyshock" ],
+        tier: "Illegal",
+    },
+    mankey: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    primeape: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    growlithe: {
+        tier: "LC",
+    },
+    arcanine: {
+        randomBattleMoves: [ "closecombat", "crunch", "extremespeed", "flareblitz", "morningsun", "roar", "wildcharge", "willowisp" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "closecombat", "extremespeed", "flareblitz", "morningsun", "protect", "snarl", "willowisp" ],
+        tier: "UU",
+        doublesTier: "DOU",
+    },
+    poliwag: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    poliwhirl: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    poliwrath: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    politoed: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    abra: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    kadabra: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    alakazam: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    alakazammega: {
+        isNonstandard: "Past",
+    },
+    machop: {
+        tier: "LC",
+    },
+    machoke: {
+        tier: "NFE",
+    },
+    machamp: {
+        randomBattleMoves: [ "bulletpunch", "closecombat", "dynamicpunch", "facade", "knockoff", "stoneedge" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "bulletpunch", "closecombat", "facade", "knockoff", "poisonjab", "protect" ],
+        tier: "UU",
+        doublesTier: "DUU",
+    },
+    machampgmax: {
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    bellsprout: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    weepinbell: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    victreebel: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    tentacool: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    tentacruel: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    geodude: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    geodudealola: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    graveler: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    graveleralola: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    golem: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    golemalola: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    ponyta: {
+        tier: "LC",
+    },
+    ponytagalar: {
+        tier: "LC",
+    },
+    rapidash: {
+        randomBattleMoves: [ "flareblitz", "highhorsepower", "morningsun", "swordsdance", "wildcharge", "willowisp" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "flareblitz", "highhorsepower", "morningsun", "protect", "swordsdance", "wildcharge" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    rapidashgalar: {
+        randomBattleMoves: [ "highhorsepower", "morningsun", "playrough", "swordsdance", "zenheadbutt" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "highhorsepower", "playrough", "protect", "swordsdance", "zenheadbutt" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    slowpoke: {
+        isNonstandard: "Unobtainable",
+        tier: "Unreleased",
+    },
+    slowpokegalar: {
+        unreleasedHidden: true,
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    slowbro: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "calmmind", "icebeam", "psyshock", "scald", "slackoff", "teleport" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "calmmind", "fireblast", "icebeam", "psychic", "psyshock", "scald", "slackoff", "trickroom" ],
+        tier: "Illegal",
+    },
+    slowbromega: {
+        isNonstandard: "Past",
+    },
+    slowking: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "dragontail", "fireblast", "icebeam", "psyshock", "scald", "slackoff", "toxic", "trickroom" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "fireblast", "icebeam", "nastyplot", "psychic", "psyshock", "scald", "slackoff", "trickroom" ],
+        tier: "Illegal",
+    },
+    magnemite: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    magneton: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    magnezone: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "bodypress", "flashcannon", "mirrorcoat", "thunderbolt", "voltswitch" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "allyswitch", "bodypress", "flashcannon", "protect", "thunderbolt", "voltswitch" ],
+        tier: "Illegal",
+    },
+    farfetchd: {
+        randomBattleMoves: [ "bravebird", "closecombat", "knockoff", "leafblade", "slash", "swordsdance" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "bravebird", "closecombat", "leafblade", "protect", "quickattack", "slash", "swordsdance" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    farfetchdgalar: {
+        tier: "LC",
+    },
+    sirfetchd: {
+        randomBattleMoves: [ "bravebird", "closecombat", "firstimpression", "knockoff", "swordsdance" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "bravebird", "closecombat", "firstimpression", "knockoff", "poisonjab", "protect", "swordsdance" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    doduo: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    dodrio: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    seel: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    dewgong: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    grimer: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    grimeralola: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    muk: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    mukalola: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    shellder: {
+        tier: "LC",
+    },
+    cloyster: {
+        randomBattleMoves: [ "explosion", "hydropump", "iciclespear", "rockblast", "shellsmash" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "iceshard", "iciclespear", "liquidation", "protect", "rockblast", "shellsmash" ],
+        tier: "OU",
+        doublesTier: "(DUU)",
+    },
+    gastly: {
+        tier: "LC Uber",
+    },
+    haunter: {
+        tier: "NUBL",
+        doublesTier: "NFE",
+    },
+    gengar: {
+        randomDoubleBattleMoves: [ "focusblast", "nastyplot", "protect", "shadowball", "sludgebomb", "thunderbolt", "trick", "willowisp" ],
+        tier: "OU",
+        doublesTier: "DUU",
+    },
+    gengarmega: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    gengargmax: {
+        randomBattleMoves: [ "focusblast", "nastyplot", "shadowball", "sludgewave", "trick" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "focusblast", "nastyplot", "protect", "shadowball", "sludgebomb", "thunderbolt", "willowisp" ],
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    onix: {
+        tier: "LC",
+    },
+    steelix: {
+        randomBattleMoves: [ "dragondance", "earthquake", "headsmash", "heavyslam", "stealthrock" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "earthquake", "headsmash", "heavyslam", "protect", "rockpolish", "wideguard" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    steelixmega: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    drowzee: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    hypno: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    krabby: {
+        tier: "LC",
+    },
+    kingler: {
+        randomBattleMoves: [ "agility", "liquidation", "rockslide", "superpower", "swordsdance", "xscissor" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "agility", "knockoff", "liquidation", "protect", "superpower", "xscissor" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    kinglergmax: {
+        randomDoubleBattleMoves: [ "knockoff", "liquidation", "protect", "superpower", "xscissor" ],
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    voltorb: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    electrode: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    exeggcute: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    exeggutor: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    exeggutoralola: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    cubone: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    marowak: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    marowakalola: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    marowakalolatotem: {
+        isNonstandard: "Past",
+    },
+    tyrogue: {
+        tier: "LC",
+    },
+    hitmonlee: {
+        randomBattleMoves: [ "fakeout", "highjumpkick", "knockoff", "machpunch", "poisonjab", "rapidspin", "stoneedge" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "closecombat", "fakeout", "poisonjab", "protect", "rockslide", "throatchop" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    hitmonchan: {
+        randomBattleMoves: [ "bulkup", "drainpunch", "icepunch", "machpunch", "rapidspin", "stoneedge" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "drainpunch", "feint", "firepunch", "icepunch", "machpunch", "protect" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    hitmontop: {
+        randomBattleMoves: [ "closecombat", "machpunch", "rapidspin", "stoneedge", "suckerpunch", "toxic" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "closecombat", "fakeout", "feint", "helpinghand", "suckerpunch", "wideguard" ],
+        tier: "PU",
+        doublesTier: "DUU",
+    },
+    lickitung: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    lickilicky: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    koffing: {
+        tier: "LC",
+    },
+    weezing: {
+        randomBattleMoves: [ "fireblast", "painsplit", "sludgebomb", "toxicspikes", "willowisp" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "clearsmog", "fireblast", "painsplit", "sludgebomb", "willowisp" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    weezinggalar: {
+        randomBattleMoves: [ "defog", "fireblast", "painsplit", "sludgebomb", "strangesteam", "toxicspikes", "willowisp" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "clearsmog", "fireblast", "painsplit", "strangesteam", "willowisp" ],
+        tier: "UU",
+        doublesTier: "DUU",
+    },
+    rhyhorn: {
+        tier: "LC",
+    },
+    rhydon: {
+        tier: "RU",
+        doublesTier: "NFE",
+    },
+    rhyperior: {
+        randomBattleMoves: [ "earthquake", "firepunch", "megahorn", "rockblast", "rockpolish", "stealthrock", "stoneedge" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "highhorsepower", "icepunch", "megahorn", "protect", "rockslide", "stoneedge" ],
+        tier: "UU",
+        doublesTier: "DOU",
+    },
+    happiny: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    chansey: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    blissey: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "healbell", "seismictoss", "softboiled", "stealthrock", "toxic" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "allyswitch", "healbell", "protect", "seismictoss", "softboiled", "thunderwave", "toxic" ],
+        tier: "Illegal",
+    },
+    tangela: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    tangrowth: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    kangaskhan: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    kangaskhanmega: {
+        isNonstandard: "Past",
+    },
+    horsea: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    seadra: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    kingdra: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "dracometeor", "hurricane", "hydropump", "icebeam", "toxic" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "dragonpulse", "hurricane", "hydropump", "icebeam", "muddywater", "raindance" ],
+        tier: "Illegal",
+    },
+    goldeen: {
+        tier: "LC",
+    },
+    seaking: {
+        randomBattleMoves: [ "drillrun", "knockoff", "megahorn", "swordsdance", "waterfall" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "drillrun", "knockoff", "megahorn", "protect", "swordsdance", "waterfall" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    staryu: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    starmie: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    mimejr: {
+        tier: "LC",
+    },
+    mrmime: {
+        randomBattleMoves: [ "dazzlinggleam", "focusblast", "healingwish", "nastyplot", "psychic" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "dazzlinggleam", "fakeout", "icywind", "lightscreen", "psychic", "psyshock", "reflect" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    mrmimegalar: {
+        randomBattleMoves: [ "focusblast", "freezedry", "nastyplot", "psychic", "rapidspin" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "fakeout", "focusblast", "freezedry", "nastyplot", "protect", "psychic", "psyshock" ],
+        tier: "NU",
+        doublesTier: "NFE",
+    },
+    mrrime: {
+        randomBattleMoves: [ "focusblast", "freezedry", "psychic", "rapidspin", "slackoff", "trick" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "fakeout", "focusblast", "freezedry", "icywind", "protect", "psychic", "psyshock", "rapidspin" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    scyther: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    scizor: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    scizormega: {
+        isNonstandard: "Past",
+    },
+    smoochum: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    jynx: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    elekid: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    electabuzz: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    electivire: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "crosschop", "earthquake", "flamethrower", "icepunch", "voltswitch", "wildcharge" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "crosschop", "earthquake", "flamethrower", "icepunch", "wildcharge" ],
+        tier: "Illegal",
+    },
+    magby: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    magmar: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    magmortar: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pinsir: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pinsirmega: {
+        isNonstandard: "Past",
+    },
+    tauros: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    magikarp: {
+        tier: "LC",
+    },
+    gyarados: {
+        randomBattleMoves: [ "bounce", "dragondance", "earthquake", "powerwhip", "waterfall" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "dragondance", "earthquake", "icefang", "powerwhip", "protect", "waterfall" ],
+        tier: "UUBL",
+        doublesTier: "DUU",
+    },
+    gyaradosmega: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    lapras: {
+        tier: "PU",
+        doublesTier: "DUU",
+    },
+    laprasgmax: {
+        randomBattleMoves: [ "freezedry", "icebeam", "sparklingaria", "substitute", "thunderbolt", "toxic" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "freezedry", "helpinghand", "hydropump", "protect", "scald" ],
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    ditto: {
+        randomBattleMoves: [ "transform" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "transform" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    eevee: {
+        tier: "LC",
+    },
+    eeveestarter: {
+        isNonstandard: "LGPE",
+        tier: "Illegal",
+    },
+    eeveegmax: {
+        unreleasedHidden: true,
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    vaporeon: {
+        randomBattleMoves: [ "healbell", "icebeam", "protect", "scald", "toxic", "wish" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "healbell", "icywind", "protect", "scald", "toxic", "wish" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    jolteon: {
+        randomBattleMoves: [ "hypervoice", "shadowball", "thunderbolt", "voltswitch" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "faketears", "protect", "shadowball", "thunderbolt", "thunderwave", "voltswitch" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    flareon: {
+        randomBattleMoves: [ "facade", "flamecharge", "flareblitz", "quickattack", "superpower" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "facade", "flamecharge", "flareblitz", "protect", "quickattack", "superpower" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    espeon: {
+        randomBattleMoves: [ "calmmind", "dazzlinggleam", "morningsun", "psychic", "shadowball" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "calmmind", "dazzlinggleam", "morningsun", "protect", "psychic", "psyshock", "shadowball" ],
+        tier: "UU",
+        doublesTier: "DUU",
+    },
+    umbreon: {
+        randomBattleMoves: [ "foulplay", "protect", "toxic", "wish", "yawn" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "foulplay", "helpinghand", "moonlight", "snarl", "toxic", "yawn" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    leafeon: {
+        randomBattleMoves: [ "doubleedge", "knockoff", "leafblade", "swordsdance", "synthesis", "xscissor" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "doubleedge", "knockoff", "leafblade", "protect", "swordsdance" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    glaceon: {
+        randomBattleMoves: [ "freezedry", "protect", "shadowball", "toxic", "wish" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "blizzard", "freezedry", "helpinghand", "protect", "shadowball", "wish" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    sylveon: {
+        randomBattleMoves: [ "calmmind", "hypervoice", "mysticalfire", "protect", "psyshock", "shadowball", "wish" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "calmmind", "hypervoice", "mysticalfire", "protect", "psyshock", "wish" ],
+        tier: "UU",
+        doublesTier: "DOU",
+    },
+    porygon: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    porygon2: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    porygonz: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    omanyte: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    omastar: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    kabuto: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    kabutops: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    aerodactyl: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    aerodactylmega: {
+        isNonstandard: "Past",
+    },
+    munchlax: {
+        tier: "LC",
+    },
+    snorlax: {
+        randomBattleMoves: [ "darkestlariat", "doubleedge", "earthquake", "facade", "heatcrash" ],
+        randomBattleLevel: 84,
+        tier: "RU",
+        doublesTier: "DUU",
+    },
+    snorlaxgmax: {
+        randomBattleMoves: [ "bodyslam", "curse", "darkestlariat", "earthquake", "rest" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "bodyslam", "curse", "darkestlariat", "highhorsepower", "recycle" ],
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    articuno: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "defog", "freezedry", "healbell", "roost", "toxic" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "freezedry", "healbell", "hurricane", "icebeam", "roost", "toxic" ],
+        tier: "Illegal",
+    },
+    zapdos: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "defog", "discharge", "heatwave", "hurricane", "roost" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "heatwave", "hurricane", "roost", "tailwind", "thunderbolt", "voltswitch" ],
+        tier: "Illegal",
+    },
+    moltres: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "airslash", "defog", "fireblast", "roost", "uturn" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "fireblast", "heatwave", "hurricane", "protect", "roost", "tailwind" ],
+        tier: "Illegal",
+    },
+    dratini: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    dragonair: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    dragonite: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    mewtwo: {
+        randomBattleMoves: [ "aurasphere", "icebeam", "nastyplot", "psystrike", "recover" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "aurasphere", "calmmind", "icebeam", "psystrike", "recover" ],
+        tier: "Uber",
+        doublesTier: "DUber",
+    },
+    mewtwomegax: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    mewtwomegay: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    mew: {
+        randomBattleMoves: [ "bravebird", "closecombat", "flareblitz", "psychicfangs", "swordsdance" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "imprison", "protect", "psychic", "transform" ],
+        tier: "OU",
+        doublesTier: "DOU",
+    },
+    chikorita: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    bayleef: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    meganium: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    cyndaquil: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    quilava: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    typhlosion: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    totodile: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    croconaw: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    feraligatr: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    sentret: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    furret: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    hoothoot: {
+        tier: "LC",
+    },
+    noctowl: {
+        randomBattleMoves: [ "airslash", "defog", "heatwave", "hurricane", "nastyplot", "roost" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "heatwave", "hurricane", "hypervoice", "nastyplot", "roost", "tailwind" ],
+        tier: "PUBL",
+        doublesTier: "(DUU)",
+    },
+    ledyba: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    ledian: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    spinarak: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    ariados: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    chinchou: {
+        tier: "LC",
+    },
+    lanturn: {
+        randomBattleMoves: [ "healbell", "icebeam", "scald", "thunderbolt", "toxic", "voltswitch" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "healbell", "icebeam", "protect", "scald", "thunderbolt", "thunderwave" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    togepi: {
+        tier: "LC",
+    },
+    togetic: {
+        tier: "NFE",
+        doublesTier: "DUU",
+    },
+    togekiss: {
+        randomBattleMoves: [ "airslash", "aurasphere", "fireblast", "nastyplot", "roost", "thunderwave", "trick" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "airslash", "followme", "heatwave", "protect", "roost", "tailwind", "thunderwave" ],
+        tier: "OU",
+        doublesTier: "DOU",
+    },
+    natu: {
+        tier: "LC",
+    },
+    xatu: {
+        randomBattleMoves: [ "heatwave", "lightscreen", "psychic", "reflect", "roost", "teleport" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "airslash", "heatwave", "lightscreen", "psychic", "psyshock", "reflect", "roost", "tailwind" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    mareep: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    flaaffy: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    ampharos: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    ampharosmega: {
+        isNonstandard: "Past",
+    },
+    azurill: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    marill: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    azumarill: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "aquajet", "bellydrum", "knockoff", "liquidation", "playrough", "superpower" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "aquajet", "icepunch", "knockoff", "liquidation", "playrough", "protect", "superpower" ],
+        tier: "Illegal",
+    },
+    bonsly: {
+        tier: "LC",
+    },
+    sudowoodo: {
+        randomBattleMoves: [ "earthquake", "headsmash", "stealthrock", "suckerpunch", "woodhammer" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "bodypress", "firepunch", "headsmash", "protect", "suckerpunch", "woodhammer" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    hoppip: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    skiploom: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    jumpluff: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    aipom: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    ambipom: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    sunkern: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    sunflora: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    yanma: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    yanmega: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    wooper: {
+        tier: "LC",
+    },
+    quagsire: {
+        randomBattleMoves: [ "earthquake", "encore", "icebeam", "recover", "scald", "toxic" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "highhorsepower", "protect", "recover", "scald", "toxic" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    murkrow: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    honchkrow: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    misdreavus: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    mismagius: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    unown: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    wynaut: {
+        tier: "LC",
+    },
+    wobbuffet: {
+        randomBattleMoves: [ "counter", "destinybond", "encore", "mirrorcoat" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "charm", "counter", "encore", "mirrorcoat" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    girafarig: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pineco: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    forretress: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    dunsparce: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    gligar: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    gliscor: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    snubbull: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    granbull: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    qwilfish: {
+        randomBattleMoves: [ "destinybond", "spikes", "taunt", "thunderwave", "toxicspikes", "waterfall" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "liquidation", "poisonjab", "protect", "swordsdance", "taunt", "thunderwave" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    shuckle: {
+        randomBattleMoves: [ "encore", "infestation", "knockoff", "stealthrock", "stickyweb", "toxic" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "acupressure", "guardsplit", "helpinghand", "infestation", "knockoff", "stealthrock", "stickyweb", "toxic" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    heracross: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    heracrossmega: {
+        isNonstandard: "Past",
+    },
+    sneasel: {
+        tier: "NUBL",
+        doublesTier: "LC Uber",
+    },
+    weavile: {
+        randomBattleMoves: [ "iceshard", "iciclecrash", "knockoff", "lowkick", "swordsdance" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "fakeout", "iceshard", "iciclecrash", "knockoff", "lowkick", "protect", "swordsdance" ],
+        tier: "UUBL",
+        doublesTier: "DUU",
+    },
+    teddiursa: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    ursaring: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    slugma: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    magcargo: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    swinub: {
+        tier: "LC",
+    },
+    piloswine: {
+        tier: "NU",
+        doublesTier: "NFE",
+    },
+    mamoswine: {
+        randomBattleMoves: [ "earthquake", "iceshard", "iciclecrash", "knockoff", "stealthrock", "superpower" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "highhorsepower", "iceshard", "iciclecrash", "protect", "rockslide" ],
+        tier: "UUBL",
+        doublesTier: "DUU",
+    },
+    corsola: {
+        randomBattleMoves: [ "powergem", "recover", "scald", "stealthrock", "toxic" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "icywind", "lifedew", "lightscreen", "recover", "reflect", "scald" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    corsolagalar: {
+        randomBattleMoves: [ "haze", "nightshade", "stealthrock", "strengthsap", "willowisp" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "haze", "lightscreen", "nightshade", "reflect", "strengthsap", "willowisp" ],
+        tier: "UU",
+        doublesTier: "LC Uber",
+    },
+    cursola: {
+        randomBattleMoves: [ "earthpower", "hydropump", "icebeam", "shadowball", "stealthrock", "strengthsap" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "earthpower", "hydropump", "icebeam", "protect", "shadowball", "strengthsap" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    remoraid: {
+        tier: "LC",
+    },
+    octillery: {
+        randomBattleMoves: [ "energyball", "fireblast", "gunkshot", "hydropump", "icebeam" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "fireblast", "gunkshot", "hydropump", "icebeam", "protect", "substitute" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    delibird: {
+        randomBattleMoves: [ "freezedry", "memento", "rapidspin", "spikes" ],
+        randomBattleLevel: 100,
+        randomDoubleBattleMoves: [ "bravebird", "fakeout", "helpinghand", "icebeam", "memento", "tailwind" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    mantyke: {
+        tier: "LC",
+    },
+    mantine: {
+        randomBattleMoves: [ "defog", "hurricane", "icebeam", "roost", "scald", "toxic" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "haze", "helpinghand", "hurricane", "roost", "scald", "tailwind" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    skarmory: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    houndour: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    houndoom: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    houndoommega: {
+        isNonstandard: "Past",
+    },
+    phanpy: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    donphan: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    stantler: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    smeargle: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    miltank: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    raikou: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "aurasphere", "calmmind", "scald", "substitute", "thunderbolt", "voltswitch" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "aurasphere", "calmmind", "protect", "scald", "snarl", "thunderbolt", "voltswitch" ],
+        tier: "Illegal",
+    },
+    entei: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "extremespeed", "flareblitz", "stompingtantrum", "stoneedge" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "extremespeed", "flareblitz", "protect", "snarl", "stompingtantrum", "stoneedge" ],
+        tier: "Illegal",
+    },
+    suicune: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "airslash", "calmmind", "icebeam", "rest", "scald", "sleeptalk" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "airslash", "calmmind", "icebeam", "rest", "scald", "sleeptalk" ],
+        tier: "Illegal",
+    },
+    larvitar: {
+        tier: "LC",
+    },
+    pupitar: {
+        tier: "NFE",
+    },
+    tyranitar: {
+        randomBattleMoves: [ "crunch", "dragondance", "earthquake", "firepunch", "stealthrock", "stoneedge" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "crunch", "dragondance", "firepunch", "highhorsepower", "protect", "rockslide", "stoneedge" ],
+        tier: "OU",
+        doublesTier: "DOU",
+    },
+    tyranitarmega: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    lugia: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "airslash", "calmmind", "earthquake", "psyshock", "roost", "substitute", "toxic" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "airslash", "calmmind", "psychic", "roost", "toxic" ],
+        tier: "Illegal",
+    },
+    hooh: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "bravebird", "defog", "earthquake", "flareblitz", "roost", "toxic" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "bravebird", "earthpower", "flareblitz", "protect", "roost", "tailwind", "willowisp" ],
+        tier: "Illegal",
+    },
+    celebi: {
+        randomBattleMoves: [ "earthpower", "gigadrain", "leafstorm", "nastyplot", "psychic", "recover", "stealthrock", "uturn" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "calmmind", "earthpower", "gigadrain", "leafstorm", "protect", "psychic", "recover" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    treecko: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    grovyle: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    sceptile: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    sceptilemega: {
+        isNonstandard: "Past",
+    },
+    torchic: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    combusken: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    blaziken: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    blazikenmega: {
+        isNonstandard: "Past",
+    },
+    mudkip: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    marshtomp: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    swampert: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    swampertmega: {
+        isNonstandard: "Past",
+    },
+    poochyena: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    mightyena: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    zigzagoon: {
+        tier: "LC",
+    },
+    zigzagoongalar: {
+        tier: "LC",
+    },
+    linoone: {
+        randomBattleMoves: [ "bellydrum", "extremespeed", "stompingtantrum", "throatchop" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "bellydrum", "extremespeed", "protect", "throatchop" ],
+        tier: "NUBL",
+        doublesTier: "(DUU)",
+    },
+    linoonegalar: {
+        tier: "NFE",
+    },
+    obstagoon: {
+        randomBattleMoves: [ "bulkup", "closecombat", "facade", "knockoff", "partingshot" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "closecombat", "facade", "knockoff", "obstruct", "partingshot", "taunt" ],
+        tier: "UUBL",
+        doublesTier: "(DUU)",
+    },
+    wurmple: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    silcoon: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    beautifly: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    cascoon: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    dustox: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    lotad: {
+        tier: "LC",
+    },
+    lombre: {
+        tier: "NFE",
+    },
+    ludicolo: {
+        randomBattleMoves: [ "gigadrain", "hydropump", "icebeam", "raindance", "scald" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "fakeout", "gigadrain", "hydropump", "icebeam", "raindance" ],
+        tier: "PU",
+        doublesTier: "DOU",
+    },
+    seedot: {
+        tier: "LC",
+    },
+    nuzleaf: {
+        tier: "NFE",
+    },
+    shiftry: {
+        randomBattleMoves: [ "darkpulse", "defog", "heatwave", "leafstorm", "nastyplot", "suckerpunch" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "fakeout", "knockoff", "leafblade", "suckerpunch", "swordsdance", "tailwind" ],
+        tier: "RUBL",
+        doublesTier: "(DUU)",
+    },
+    taillow: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    swellow: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    wingull: {
+        tier: "LC",
+    },
+    pelipper: {
+        randomBattleMoves: [ "defog", "hurricane", "hydropump", "roost", "scald", "uturn" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "hurricane", "hydropump", "protect", "roost", "tailwind", "wideguard" ],
+        tier: "OU",
+        doublesTier: "DOU",
+    },
+    ralts: {
+        tier: "LC",
+    },
+    kirlia: {
+        tier: "NFE",
+    },
+    gardevoir: {
+        randomBattleMoves: [ "calmmind", "moonblast", "mysticalfire", "psyshock", "substitute", "trick", "willowisp" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "calmmind", "dazzlinggleam", "focusblast", "moonblast", "mysticalfire", "protect", "psychic", "shadowball", "thunderbolt", "trick" ],
+        tier: "UU",
+        doublesTier: "DUU",
+    },
+    gardevoirmega: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    gallade: {
+        randomBattleMoves: [ "closecombat", "knockoff", "shadowsneak", "swordsdance", "trick", "zenheadbutt" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "closecombat", "feint", "knockoff", "leafblade", "protect", "rockslide", "swordsdance", "zenheadbutt" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    gallademega: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    surskit: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    masquerain: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    shroomish: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    breloom: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    slakoth: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    vigoroth: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    slaking: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    nincada: {
+        tier: "LC",
+    },
+    ninjask: {
+        randomBattleMoves: [ "acrobatics", "leechlife", "nightslash", "swordsdance" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "acrobatics", "defog", "leechlife", "protect", "swordsdance" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    shedinja: {
+        randomBattleMoves: [ "shadowclaw", "shadowsneak", "swordsdance", "willowisp", "xscissor" ],
+        randomBattleLevel: 100,
+        randomDoubleBattleMoves: [ "allyswitch", "protect", "shadowsneak", "swordsdance", "willowisp", "xscissor" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    whismur: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    loudred: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    exploud: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    makuhita: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    hariyama: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    nosepass: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    probopass: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    skitty: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    delcatty: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    sableye: {
+        randomBattleMoves: [ "encore", "foulplay", "knockoff", "recover", "taunt", "willowisp" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "disable", "encore", "fakeout", "foulplay", "knockoff", "recover", "willowisp" ],
+        tier: "RU",
+        doublesTier: "DUU",
+    },
+    sableyemega: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    mawile: {
+        randomBattleMoves: [ "ironhead", "playrough", "stealthrock", "suckerpunch", "swordsdance" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "firefang", "ironhead", "playrough", "protect", "suckerpunch", "swordsdance" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    mawilemega: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    aron: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    lairon: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    aggron: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    aggronmega: {
+        isNonstandard: "Past",
+    },
+    meditite: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    medicham: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    medichammega: {
+        isNonstandard: "Past",
+    },
+    electrike: {
+        tier: "LC",
+    },
+    manectric: {
+        randomBattleMoves: [ "flamethrower", "overheat", "switcheroo", "thunderbolt", "voltswitch" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "overheat", "protect", "snarl", "thunderbolt", "voltswitch" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    manectricmega: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    plusle: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    minun: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    volbeat: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    illumise: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    budew: {
+        tier: "LC",
+    },
+    roselia: {
+        tier: "PU",
+        doublesTier: "NFE",
+    },
+    roserade: {
+        randomBattleMoves: [ "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "gigadrain", "leafstorm", "protect", "sleeppowder", "sludgebomb" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    gulpin: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    swalot: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    carvanha: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    sharpedo: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    sharpedomega: {
+        isNonstandard: "Past",
+    },
+    wailmer: {
+        tier: "LC",
+    },
+    wailord: {
+        randomBattleMoves: [ "hydropump", "hypervoice", "icebeam", "waterspout" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "hydropump", "icebeam", "earthquake", "waterspout" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    numel: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    camerupt: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    cameruptmega: {
+        isNonstandard: "Past",
+    },
+    torkoal: {
+        randomBattleMoves: [ "earthquake", "lavaplume", "rapidspin", "solarbeam", "stealthrock" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "bodypress", "earthpower", "fireblast", "lavaplume", "protect", "solarbeam", "willowisp" ],
+        tier: "UU",
+        doublesTier: "DOU",
+    },
+    spoink: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    grumpig: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    spinda: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    trapinch: {
+        tier: "LC",
+    },
+    vibrava: {
+        tier: "PU",
+        doublesTier: "NFE",
+    },
+    flygon: {
+        randomBattleMoves: [ "defog", "dragondance", "earthquake", "firepunch", "outrage", "uturn" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "dragonclaw", "dragondance", "earthquake", "firepunch", "firstimpression", "protect", "rockslide", "tailwind" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    cacnea: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    cacturne: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    swablu: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    altaria: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    altariamega: {
+        isNonstandard: "Past",
+    },
+    zangoose: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    seviper: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    lunatone: {
+        randomBattleMoves: [ "earthpower", "icebeam", "nastyplot", "powergem", "psychic", "rockpolish", "stealthrock" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "earthpower", "icebeam", "powergem", "protect", "psychic", "psyshock", "trickroom" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    solrock: {
+        randomBattleMoves: [ "earthquake", "explosion", "morningsun", "rockslide", "stealthrock", "swordsdance", "willowisp", "zenheadbutt" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "allyswitch", "flareblitz", "helpinghand", "stoneedge", "willowisp", "zenheadbutt" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    barboach: {
+        tier: "LC",
+    },
+    whiscash: {
+        randomBattleMoves: [ "dragondance", "earthquake", "liquidation", "stoneedge", "zenheadbutt" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "dragondance", "earthquake", "protect", "stoneedge", "waterfall" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    corphish: {
+        tier: "LC",
+    },
+    crawdaunt: {
+        randomBattleMoves: [ "aquajet", "closecombat", "crabhammer", "dragondance", "knockoff", "swordsdance" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "aquajet", "closecombat", "crabhammer", "knockoff", "protect", "swordsdance" ],
+        tier: "UUBL",
+        doublesTier: "(DUU)",
+    },
+    baltoy: {
+        tier: "LC",
+    },
+    claydol: {
+        randomBattleMoves: [ "earthquake", "icebeam", "psychic", "rapidspin", "stealthrock", "toxic" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "allyswitch", "earthpower", "icebeam", "lightscreen", "protect", "psychic", "reflect" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    lileep: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    cradily: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    anorith: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    armaldo: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    feebas: {
+        tier: "LC",
+    },
+    milotic: {
+        randomBattleMoves: [ "dragontail", "icebeam", "recover", "rest", "scald", "sleeptalk" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "dragontail", "icebeam", "icywind", "protect", "recover", "scald" ],
+        tier: "UU",
+        doublesTier: "DOU",
+    },
+    castform: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    castformsunny: {
+        isNonstandard: "Past",
+    },
+    castformrainy: {
+        isNonstandard: "Past",
+    },
+    castformsnowy: {
+        isNonstandard: "Past",
+    },
+    kecleon: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    shuppet: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    banette: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    banettemega: {
+        isNonstandard: "Past",
+    },
+    duskull: {
+        tier: "LC",
+    },
+    dusclops: {
+        randomDoubleBattleMoves: [ "allyswitch", "haze", "helpinghand", "nightshade", "painsplit", "trickroom", "willowisp" ],
+        tier: "NFE",
+        doublesTier: "DOU",
+    },
+    dusknoir: {
+        randomBattleMoves: [ "earthquake", "icepunch", "painsplit", "shadowpunch", "shadowsneak", "substitute", "trick", "willowisp" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "allyswitch", "earthquake", "haze", "icepunch", "painsplit", "shadowsneak", "trickroom", "willowisp" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    tropius: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    chingling: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    chimecho: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    absol: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    absolmega: {
+        isNonstandard: "Past",
+    },
+    snorunt: {
+        tier: "LC",
+    },
+    glalie: {
+        randomBattleMoves: [ "disable", "earthquake", "freezedry", "protect", "substitute" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "disable", "earthquake", "freezedry", "protect", "substitute" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    glaliemega: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    froslass: {
+        randomBattleMoves: [ "destinybond", "icebeam", "shadowball", "spikes", "taunt", "willowisp" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "destinybond", "icebeam", "icywind", "protect", "shadowball", "willowisp" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    spheal: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    sealeo: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    walrein: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "icebeam", "protect", "surf", "toxic" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "brine", "icebeam", "icywind", "superfang" ],
+        tier: "Illegal",
+    },
+    clamperl: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    huntail: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    gorebyss: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    relicanth: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    luvdisc: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    bagon: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    shelgon: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    salamence: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    salamencemega: {
+        isNonstandard: "Past",
+    },
+    beldum: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    metang: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    metagross: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "agility", "bulletpunch", "earthquake", "explosion", "meteormash", "stealthrock", "thunderpunch" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "agility", "bulletpunch", "earthquake", "icepunch", "meteormash", "trick", "zenheadbutt" ],
+        tier: "Illegal",
+    },
+    metagrossmega: {
+        isNonstandard: "Past",
+    },
+    regirock: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "bodypress", "curse", "earthquake", "explosion", "rest", "rockslide", "stoneedge" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "bodypress", "curse", "rest", "stoneedge" ],
+        tier: "Illegal",
+    },
+    regice: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "focusblast", "icebeam", "rest", "rockpolish", "sleeptalk", "thunderbolt" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "focusblast", "icebeam", "rockpolish", "thunderbolt", "thunderwave" ],
+        tier: "Illegal",
+    },
+    registeel: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "bodypress", "protect", "stealthrock", "toxic" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "bodypress", "curse", "ironhead", "rest", "toxic" ],
+        tier: "Illegal",
+    },
+    latias: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "aurasphere", "calmmind", "dracometeor", "healingwish", "psychic", "roost" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "aurasphere", "calmmind", "dracometeor", "healpulse", "psychic", "psyshock", "roost", "tailwind" ],
+        tier: "Illegal",
+    },
+    latiasmega: {
+        isNonstandard: "Past",
+    },
+    latios: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "aurasphere", "defog", "dracometeor", "psyshock", "roost", "trick" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "aurasphere", "dracometeor", "dragonpulse", "psychic", "psyshock", "roost", "trick" ],
+        tier: "Illegal",
+    },
+    latiosmega: {
+        isNonstandard: "Past",
+    },
+    kyogre: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "calmmind", "icebeam", "surf", "thunder", "waterspout" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "hydropump", "icebeam", "protect", "thunder", "waterspout" ],
+        tier: "Illegal",
+    },
+    kyogreprimal: {
+        isNonstandard: "Past",
+    },
+    groudon: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "earthquake", "heatcrash", "heavyslam", "stealthrock", "stoneedge", "swordsdance", "thunderwave" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "heatcrash", "highhorsepower", "rockpolish", "solarbeam", "stoneedge", "swordsdance" ],
+        tier: "Illegal",
+    },
+    groudonprimal: {
+        isNonstandard: "Past",
+    },
+    rayquaza: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "dragondance", "earthquake", "extremespeed", "outrage", "vcreate" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "airslash", "dracometeor", "dragonclaw", "earthpower", "energyball", "extremespeed", "hydropump", "protect", "thunderbolt", "vcreate" ],
+        tier: "Illegal",
+    },
+    rayquazamega: {
+        isNonstandard: "Past",
+    },
+    jirachi: {
+        randomBattleMoves: [ "bodyslam", "firepunch", "ironhead", "stealthrock", "toxic", "trick", "uturn" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "firepunch", "followme", "ironhead", "lifedew", "protect", "thunderwave" ],
+        tier: "OU",
+        doublesTier: "DUber",
+    },
+    deoxys: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    deoxysattack: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    deoxysdefense: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    deoxysspeed: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    turtwig: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    grotle: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    torterra: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    chimchar: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    monferno: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    infernape: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    piplup: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    prinplup: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    empoleon: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    starly: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    staravia: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    staraptor: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    bidoof: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    bibarel: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    kricketot: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    kricketune: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    shinx: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    luxio: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    luxray: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    cranidos: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    rampardos: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    shieldon: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    bastiodon: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    burmy: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    wormadam: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    wormadamsandy: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    wormadamtrash: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    mothim: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    combee: {
+        tier: "LC",
+    },
+    vespiquen: {
+        randomBattleMoves: [ "airslash", "defog", "roost", "toxic", "uturn" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "defendorder", "infestation", "roost", "toxic" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    pachirisu: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    buizel: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    floatzel: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    cherubi: {
+        tier: "LC",
+    },
+    cherrim: {
+        randomBattleMoves: [ "dazzlinggleam", "energyball", "healingwish", "leechseed", "substitute" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "aromatherapy", "energyball", "helpinghand", "pollenpuff", "protect" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    cherrimsunshine: {
+        randomBattleMoves: [ "playrough", "solarblade", "sunnyday", "weatherball" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "playrough", "solarblade", "sunnyday", "weatherball" ]
+    },
+    shellos: {
+        tier: "LC",
+    },
+    gastrodon: {
+        randomBattleMoves: [ "clearsmog", "earthquake", "icebeam", "recover", "scald", "toxic" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "clearsmog", "earthpower", "icywind", "protect", "recover", "scald", "yawn" ],
+        tier: "RU",
+        doublesTier: "DOU",
+    },
+    drifloon: {
+        tier: "LC Uber",
+    },
+    drifblim: {
+        randomBattleMoves: [ "calmmind", "shadowball", "strengthsap", "thunderbolt" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "destinybond", "hex", "shadowball", "tailwind", "thunderwave", "willowisp" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    buneary: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    lopunny: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    lopunnymega: {
+        isNonstandard: "Past",
+    },
+    glameow: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    purugly: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    stunky: {
+        tier: "LC",
+    },
+    skuntank: {
+        randomBattleMoves: [ "crunch", "defog", "fireblast", "poisonjab", "suckerpunch", "toxic" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "crunch", "fireblast", "haze", "poisonjab", "suckerpunch", "taunt" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    bronzor: {
+        tier: "LC",
+    },
+    bronzong: {
+        randomBattleMoves: [ "earthquake", "ironhead", "protect", "stealthrock", "toxic" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "allyswitch", "bodypress", "explosion", "ironhead", "lightscreen", "reflect", "trickroom" ],
+        tier: "UU",
+        doublesTier: "DUU",
+    },
+    chatot: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    spiritomb: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    gible: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    gabite: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    garchomp: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "earthquake", "fireblast", "firefang", "outrage", "stealthrock", "stoneedge", "swordsdance" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "dragonclaw", "earthquake", "fireblast", "protect", "stoneedge", "swordsdance" ],
+        tier: "Illegal",
+    },
+    garchompmega: {
+        isNonstandard: "Past",
+    },
+    riolu: {
+        tier: "LC",
+    },
+    lucario: {
+        randomBattleMoves: [ "closecombat", "extremespeed", "icepunch", "meteormash", "swordsdance" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "aurasphere", "bulletpunch", "closecombat", "darkpulse", "extremespeed", "flashcannon", "icepunch", "meteormash", "nastyplot", "protect" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    lucariomega: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    hippopotas: {
+        tier: "LC",
+    },
+    hippowdon: {
+        randomBattleMoves: [ "earthquake", "slackoff", "stealthrock", "stoneedge", "toxic", "whirlwind" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "highhorsepower", "protect", "rockslide", "slackoff", "stealthrock", "whirlwind", "yawn" ],
+        tier: "OU",
+        doublesTier: "(DUU)",
+    },
+    skorupi: {
+        tier: "LC",
+    },
+    drapion: {
+        randomBattleMoves: [ "earthquake", "knockoff", "poisonjab", "swordsdance", "taunt", "toxicspikes" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "acupressure", "knockoff", "poisonjab", "protect", "rockslide", "taunt" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    croagunk: {
+        tier: "LC",
+    },
+    toxicroak: {
+        randomBattleMoves: [ "drainpunch", "gunkshot", "icepunch", "substitute", "suckerpunch", "swordsdance" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "drainpunch", "fakeout", "gunkshot", "icepunch", "protect", "suckerpunch", "swordsdance", "taunt" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    carnivine: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    finneon: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    lumineon: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    snover: {
+        tier: "LC",
+    },
+    abomasnow: {
+        randomBattleMoves: [ "auroraveil", "blizzard", "earthquake", "iceshard", "woodhammer" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "auroraveil", "blizzard", "focusblast", "iceshard", "protect", "woodhammer" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    abomasnowmega: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    rotom: {
+        randomBattleMoves: [ "nastyplot", "shadowball", "thunderbolt", "voltswitch", "willowisp" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "allyswitch", "electroweb", "protect", "shadowball", "thunderbolt", "voltswitch", "willowisp" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    rotomheat: {
+        randomBattleMoves: [ "defog", "nastyplot", "overheat", "thunderbolt", "voltswitch", "willowisp" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "electroweb", "overheat", "protect", "thunderbolt", "voltswitch", "willowisp" ],
+        tier: "OU",
+        doublesTier: "DUU",
+    },
+    rotomwash: {
+        randomBattleMoves: [ "hydropump", "thunderbolt", "trick", "voltswitch", "willowisp" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "allyswitch", "hydropump", "protect", "thunderbolt", "thunderwave", "voltswitch", "willowisp" ],
+        tier: "UU",
+        doublesTier: "DOU",
+    },
+    rotomfrost: {
+        randomBattleMoves: [ "blizzard", "nastyplot", "thunderbolt", "voltswitch", "willowisp" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "blizzard", "nastyplot", "protect", "thunderbolt", "willowisp" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    rotomfan: {
+        randomBattleMoves: [ "airslash", "nastyplot", "thunderbolt", "voltswitch", "willowisp" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "airslash", "darkpulse", "nastyplot", "protect", "thunderbolt" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    rotommow: {
+        randomBattleMoves: [ "leafstorm", "thunderbolt", "trick", "voltswitch", "willowisp" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "electroweb", "leafstorm", "protect", "thunderbolt", "voltswitch", "willowisp" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    uxie: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "healbell", "knockoff", "psychic", "stealthrock", "uturn", "yawn" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "knockoff", "lightscreen", "psychic", "reflect", "thunderwave", "yawn" ],
+        tier: "Illegal",
+    },
+    mesprit: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "energyball", "healingwish", "icebeam", "nastyplot", "psychic", "stealthrock", "thunderwave", "uturn" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "energyball", "healingwish", "icebeam", "nastyplot", "psychic", "thunderbolt" ],
+        tier: "Illegal",
+    },
+    azelf: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "dazzlinggleam", "fireblast", "nastyplot", "psychic", "stealthrock", "taunt", "uturn" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "energyball", "fireblast", "nastyplot", "psychic", "psyshock", "shadowball", "uturn" ],
+        tier: "Illegal",
+    },
+    dialga: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "dracometeor", "dragontail", "fireblast", "flashcannon", "stealthrock", "thunderbolt", "toxic" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "dracometeor", "earthpower", "flashcannon", "protect", "thunderbolt", "thunderwave" ],
+        tier: "Illegal",
+    },
+    palkia: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "dracometeor", "dragonpulse", "fireblast", "hydropump", "thunderwave" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "dracometeor", "earthpower", "fireblast", "hydropump", "protect", "thunderwave" ],
+        tier: "Illegal",
+    },
+    heatran: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "earthpower", "flashcannon", "lavaplume", "protect", "stealthrock", "taunt", "toxic" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "earthpower", "eruption", "fireblast", "flashcannon", "protect" ],
+        tier: "Illegal",
+    },
+    regigigas: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "bodyslam", "protect", "substitute", "toxic" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "bodyslam", "knockoff", "protect", "substitute" ],
+        tier: "Illegal",
+    },
+    giratina: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "aurasphere", "calmmind", "dracometeor", "rest", "shadowball", "sleeptalk", "willowisp" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "calmmind", "dragonpulse", "rest", "shadowball", "willowisp" ],
+        tier: "Illegal",
+    },
+    giratinaorigin: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    cresselia: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "calmmind", "moonblast", "moonlight", "psyshock", "thunderwave", "toxic" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "allyswitch", "helpinghand", "icywind", "magiccoat", "moonlight", "psychic" ],
+        tier: "Illegal",
+    },
+    phione: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    manaphy: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    darkrai: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    shaymin: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    shayminsky: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    arceus: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    arceusbug: {
+        isNonstandard: "Past",
+    },
+    arceusdark: {
+        isNonstandard: "Past",
+    },
+    arceusdragon: {
+        isNonstandard: "Past",
+    },
+    arceuselectric: {
+        isNonstandard: "Past",
+    },
+    arceusfairy: {
+        isNonstandard: "Past",
+    },
+    arceusfighting: {
+        isNonstandard: "Past",
+    },
+    arceusfire: {
+        isNonstandard: "Past",
+    },
+    arceusflying: {
+        isNonstandard: "Past",
+    },
+    arceusghost: {
+        isNonstandard: "Past",
+    },
+    arceusgrass: {
+        isNonstandard: "Past",
+    },
+    arceusground: {
+        isNonstandard: "Past",
+    },
+    arceusice: {
+        isNonstandard: "Past",
+    },
+    arceuspoison: {
+        isNonstandard: "Past",
+    },
+    arceuspsychic: {
+        isNonstandard: "Past",
+    },
+    arceusrock: {
+        isNonstandard: "Past",
+    },
+    arceussteel: {
+        isNonstandard: "Past",
+    },
+    arceuswater: {
+        isNonstandard: "Past",
+    },
+    victini: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    snivy: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    servine: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    serperior: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    tepig: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pignite: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    emboar: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    oshawott: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    dewott: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    samurott: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    patrat: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    watchog: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    lillipup: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    herdier: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    stoutland: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    purrloin: {
+        tier: "LC",
+    },
+    liepard: {
+        randomBattleMoves: [ "copycat", "encore", "knockoff", "playrough", "thunderwave", "uturn" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "copycat", "encore", "fakeout", "foulplay", "snarl", "taunt", "thunderwave" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    pansage: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    simisage: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pansear: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    simisear: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    panpour: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    simipour: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    munna: {
+        tier: "LC",
+    },
+    musharna: {
+        randomBattleMoves: [ "calmmind", "moonblast", "moonlight", "psychic", "thunderwave" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "healingwish", "hypnosis", "moonblast", "protect", "psychic", "trickroom" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    pidove: {
+        tier: "LC",
+    },
+    tranquill: {
+        tier: "NFE",
+    },
+    unfezant: {
+        randomBattleMoves: [ "bravebird", "defog", "nightslash", "roost", "uturn" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "bravebird", "facade", "nightslash", "quickattack", "roost", "tailwind" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    blitzle: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    zebstrika: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    roggenrola: {
+        tier: "LC",
+    },
+    boldore: {
+        tier: "NFE",
+    },
+    gigalith: {
+        randomBattleMoves: [ "earthquake", "explosion", "rockblast", "stealthrock", "stoneedge", "superpower" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "bodypress", "earthquake", "explosion", "heavyslam", "protect", "stealthrock", "stoneedge", "wideguard" ],
+        tier: "UU",
+        doublesTier: "DUU",
+    },
+    woobat: {
+        tier: "LC",
+    },
+    swoobat: {
+        randomBattleMoves: [ "airslash", "heatwave", "nastyplot", "psyshock", "roost" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "airslash", "calmmind", "gigadrain", "heatwave", "protect", "psychic", "psyshock" ],
+        tier: "PUBL",
+        doublesTier: "(DUU)",
+    },
+    drilbur: {
+        tier: "LC",
+    },
+    excadrill: {
+        randomBattleMoves: [ "earthquake", "ironhead", "rapidspin", "rockslide", "swordsdance" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "highhorsepower", "ironhead", "protect", "rapidspin", "rockslide", "swordsdance" ],
+        tier: "OU",
+        doublesTier: "DOU",
+    },
+    audino: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    audinomega: {
+        isNonstandard: "Past",
+    },
+    timburr: {
+        tier: "LC",
+    },
+    gurdurr: {
+        tier: "RU",
+    },
+    conkeldurr: {
+        randomBattleMoves: [ "bulkup", "drainpunch", "facade", "knockoff", "machpunch" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "closecombat", "drainpunch", "highhorsepower", "icepunch", "knockoff", "machpunch", "protect", "stoneedge" ],
+        tier: "OU",
+        doublesTier: "DOU",
+    },
+    tympole: {
+        tier: "LC",
+    },
+    palpitoad: {
+        tier: "PU",
+        doublesTier: "NFE",
+    },
+    seismitoad: {
+        randomBattleMoves: [ "earthquake", "liquidation", "raindance", "sludgebomb", "stealthrock" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "earthpower", "earthquake", "knockoff", "liquidation", "powerwhip", "protect" ],
+        tier: "OU",
+        doublesTier: "(DUU)",
+    },
+    throh: {
+        randomBattleMoves: [ "bulkup", "circlethrow", "icepunch", "knockoff", "rest", "sleeptalk", "stormthrow" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "facade", "knockoff", "poisonjab", "protect", "stoneedge", "stormthrow", "wideguard" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    sawk: {
+        randomBattleMoves: [ "bulkup", "closecombat", "knockoff", "poisonjab", "stoneedge" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "closecombat", "helpinghand", "knockoff", "poisonjab", "protect", "rockslide" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    sewaddle: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    swadloon: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    leavanny: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    venipede: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    whirlipede: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    scolipede: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    cottonee: {
+        tier: "LC",
+    },
+    whimsicott: {
+        randomBattleMoves: [ "defog", "energyball", "leechseed", "moonblast", "stunspore", "taunt", "uturn" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "encore", "energyball", "helpinghand", "moonblast", "tailwind", "taunt" ],
+        tier: "RU",
+        doublesTier: "DOU",
+    },
+    petilil: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    lilligant: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    basculin: {
+        randomBattleMoves: [ "aquajet", "crunch", "headsmash", "liquidation", "psychicfangs" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "aquajet", "crunch", "headsmash", "liquidation", "muddywater", "psychicfangs", "superpower" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    basculinbluestriped: {
+        randomBattleMoves: [ "aquajet", "crunch", "headsmash", "liquidation", "psychicfangs" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "aquajet", "crunch", "headsmash", "liquidation", "muddywater", "psychicfangs", "superpower" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    sandile: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    krokorok: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    krookodile: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    darumaka: {
+        tier: "LC",
+    },
+    darumakagalar: {
+        tier: "LC",
+    },
+    darmanitan: {
+        randomBattleMoves: [ "earthquake", "flareblitz", "rockslide", "superpower", "uturn" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "earthquake", "flareblitz", "ironhead", "rockslide", "superpower", "uturn" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    darmanitangalar: {
+        randomBattleMoves: [ "earthquake", "flareblitz", "iciclecrash", "superpower", "uturn" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "earthquake", "flareblitz", "iciclecrash", "rockslide", "superpower", "uturn" ],
+        tier: "Uber",
+        doublesTier: "DOU",
+    },
+    darmanitangalarzen: {
+        randomBattleMoves: [ "earthquake", "flareblitz", "iciclecrash", "superpower", "uturn" ],
+        randomBattleLevel: 80
+    },
+    maractus: {
+        randomBattleMoves: [ "drainpunch", "energyball", "leechseed", "spikes", "spikyshield", "toxic" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "acupressure", "drainpunch", "helpinghand", "leafstorm", "spikyshield", "suckerpunch" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    dwebble: {
+        tier: "LC",
+    },
+    crustle: {
+        randomBattleMoves: [ "earthquake", "shellsmash", "spikes", "stealthrock", "stoneedge", "xscissor" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "earthquake", "knockoff", "protect", "rockslide", "shellsmash", "xscissor" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    scraggy: {
+        tier: "LC",
+    },
+    scrafty: {
+        randomBattleMoves: [ "closecombat", "dragondance", "icepunch", "knockoff", "poisonjab" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "closecombat", "dragondance", "drainpunch", "fakeout", "icepunch", "knockoff" ],
+        tier: "RU",
+        doublesTier: "DUU",
+    },
+    sigilyph: {
+        randomBattleMoves: [ "airslash", "defog", "energyball", "heatwave", "psychic" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "airslash", "calmmind", "energyball", "heatwave", "icebeam", "psychic", "psyshock", "roost" ],
+        tier: "RUBL",
+        doublesTier: "(DUU)",
+    },
+    yamask: {
+        tier: "LC",
+    },
+    yamaskgalar: {
+        tier: "LC",
+    },
+    cofagrigus: {
+        randomBattleMoves: [ "bodypress", "memento", "shadowball", "toxicspikes", "willowisp" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "allyswitch", "bodypress", "painsplit", "shadowball", "trickroom", "willowisp" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    runerigus: {
+        randomBattleMoves: [ "earthquake", "haze", "shadowclaw", "stealthrock", "toxicspikes", "willowisp" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "allyswitch", "earthquake", "nightshade", "protect", "trickroom", "willowisp" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    tirtouga: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    carracosta: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    archen: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    archeops: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    trubbish: {
+        tier: "LC",
+    },
+    garbodor: {
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    garbodorgmax: {
+        randomBattleMoves: [ "drainpunch", "explosion", "gunkshot", "painsplit", "spikes", "toxicspikes" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "bodyslam", "drainpunch", "explosion", "gunkshot", "protect", "seedbomb" ],
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    zorua: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    zoroark: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    minccino: {
+        tier: "LC",
+    },
+    cinccino: {
+        randomBattleMoves: [ "bulletseed", "knockoff", "rockblast", "tailslap", "uturn" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "aquatail", "bulletseed", "encore", "gunkshot", "knockoff", "rockblast", "tailslap" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    gothita: {
+        tier: "LC Uber",
+    },
+    gothorita: {
+        tier: "NFE",
+    },
+    gothitelle: {
+        randomBattleMoves: [ "nastyplot", "psychic", "shadowball", "thunderbolt", "trick" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "allyswitch", "fakeout", "healpulse", "helpinghand", "hypnosis", "psychic", "psyshock", "shadowball", "trickroom" ],
+        tier: "PU",
+        doublesTier: "DOU",
+    },
+    solosis: {
+        tier: "LC",
+    },
+    duosion: {
+        tier: "NFE",
+    },
+    reuniclus: {
+        randomBattleMoves: [ "calmmind", "focusblast", "psychic", "recover", "shadowball", "trickroom" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "energyball", "focusblast", "psychic", "psyshock", "recover", "shadowball", "trick", "trickroom" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    ducklett: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    swanna: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    vanillite: {
+        tier: "LC",
+    },
+    vanillish: {
+        tier: "NFE",
+    },
+    vanilluxe: {
+        randomBattleMoves: [ "auroraveil", "blizzard", "explosion", "flashcannon", "freezedry" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "auroraveil", "blizzard", "flashcannon", "freezedry", "iceshard" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    deerling: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    sawsbuck: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    emolga: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    karrablast: {
+        tier: "LC",
+    },
+    escavalier: {
+        randomBattleMoves: [ "closecombat", "drillrun", "ironhead", "knockoff", "megahorn", "swordsdance" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "closecombat", "drillrun", "ironhead", "knockoff", "megahorn", "protect", "swordsdance" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    foongus: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    amoonguss: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    frillish: {
+        tier: "LC",
+    },
+    jellicent: {
+        randomBattleMoves: [ "icebeam", "recover", "scald", "shadowball", "willowisp" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "protect", "recover", "scald", "shadowball", "trickroom", "willowisp" ],
+        tier: "RU",
+        doublesTier: "DUU",
+    },
+    alomomola: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    joltik: {
+        tier: "LC",
+    },
+    galvantula: {
+        randomBattleMoves: [ "bugbuzz", "gigadrain", "stickyweb", "thunder", "voltswitch" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "bugbuzz", "electroweb", "energyball", "protect", "stickyweb", "thunder" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    ferroseed: {
+        tier: "NU",
+        doublesTier: "LC",
+    },
+    ferrothorn: {
+        randomBattleMoves: [ "leechseed", "gyroball", "powerwhip", "protect", "spikes", "stealthrock" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "bodypress", "gyroball", "knockoff", "leechseed", "powerwhip", "protect", "thunderwave" ],
+        tier: "OU",
+        doublesTier: "DOU",
+    },
+    klink: {
+        tier: "LC",
+    },
+    klang: {
+        tier: "NFE",
+    },
+    klinklang: {
+        randomBattleMoves: [ "geargrind", "shiftgear", "substitute", "wildcharge" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "assurance", "geargrind", "protect", "shiftgear", "wildcharge" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    tynamo: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    eelektrik: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    eelektross: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    elgyem: {
+        tier: "LC",
+    },
+    beheeyem: {
+        randomBattleMoves: [ "psychic", "shadowball", "thunderbolt", "trick", "trickroom" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "nastyplot", "protect", "psychic", "shadowball", "thunderbolt", "trickroom" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    litwick: {
+        tier: "LC",
+    },
+    lampent: {
+        tier: "NFE",
+    },
+    chandelure: {
+        randomBattleMoves: [ "calmmind", "energyball", "fireblast", "shadowball", "substitute", "trick" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "calmmind", "energyball", "heatwave", "overheat", "protect", "shadowball", "trick" ],
+        tier: "UU",
+        doublesTier: "DOU",
+    },
+    axew: {
+        tier: "LC",
+    },
+    fraxure: {
+        tier: "PU",
+        doublesTier: "NFE",
+    },
+    haxorus: {
+        randomBattleMoves: [ "closecombat", "dragondance", "earthquake", "outrage", "poisonjab", "taunt" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "closecombat", "dragonclaw", "dragondance", "earthquake", "poisonjab", "substitute" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    cubchoo: {
+        tier: "LC",
+    },
+    beartic: {
+        randomBattleMoves: [ "aquajet", "iciclecrash", "superpower", "swordsdance", "throatchop" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "aquajet", "iciclecrash", "protect", "rockslide", "superpower", "swordsdance", "throatchop" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    cryogonal: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "freezedry", "haze", "rapidspin", "recover", "toxic" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "freezedry", "icebeam", "lightscreen", "rapidspin", "recover", "reflect" ],
+        tier: "Illegal",
+    },
+    shelmet: {
+        tier: "LC",
+    },
+    accelgor: {
+        randomBattleMoves: [ "bugbuzz", "energyball", "focusblast", "spikes", "toxic", "yawn" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "acidspray", "bugbuzz", "encore", "energyball", "focusblast" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    stunfisk: {
+        randomBattleMoves: [ "discharge", "earthpower", "foulplay", "scald", "stealthrock" ],
+        randomBattleLevel: 86,
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    stunfiskgalar: {
+        randomBattleMoves: [ "curse", "earthquake", "painsplit", "rockslide", "stealthrock" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "counter", "earthquake", "foulplay", "stealthrock", "stoneedge", "thunderwave" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    mienfoo: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    mienshao: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    druddigon: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    golett: {
+        tier: "LC",
+    },
+    golurk: {
+        randomBattleMoves: [ "drainpunch", "earthquake", "icepunch", "rockpolish", "shadowpunch" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "closecombat", "earthquake", "highhorsepower", "icepunch", "protect", "rockpolish", "shadowpunch" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    pawniard: {
+        tier: "PU",
+        doublesTier: "LC",
+    },
+    bisharp: {
+        randomBattleMoves: [ "ironhead", "knockoff", "stealthrock", "suckerpunch", "swordsdance" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "brickbreak", "ironhead", "knockoff", "protect", "suckerpunch", "swordsdance" ],
+        tier: "OU",
+        doublesTier: "(DUU)",
+    },
+    bouffalant: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    rufflet: {
+        tier: "LC Uber",
+    },
+    braviary: {
+        randomBattleMoves: [ "bravebird", "bulkup", "closecombat", "facade", "roost", "uturn" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "bravebird", "closecombat", "protect", "roost", "tailwind" ],
+        tier: "RU",
+        doublesTier: "DUU",
+    },
+    vullaby: {
+        tier: "LC",
+    },
+    mandibuzz: {
+        randomBattleMoves: [ "defog", "foulplay", "roost", "taunt", "toxic", "uturn" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "foulplay", "roost", "snarl", "tailwind", "taunt" ],
+        tier: "OU",
+        doublesTier: "(DUU)",
+    },
+    heatmor: {
+        randomBattleMoves: [ "firelash", "gigadrain", "knockoff", "substitute", "suckerpunch", "superpower" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "firelash", "gigadrain", "incinerate", "protect", "rocktomb", "suckerpunch", "superpower", "willowisp" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    durant: {
+        randomBattleMoves: [ "firstimpression", "honeclaws", "ironhead", "rockslide", "superpower" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "firstimpression", "ironhead", "protect", "rockslide", "superpower", "xscissor" ],
+        tier: "UUBL",
+        doublesTier: "DUU",
+    },
+    deino: {
+        tier: "LC",
+    },
+    zweilous: {
+        tier: "NFE",
+    },
+    hydreigon: {
+        randomBattleMoves: [ "darkpulse", "dracometeor", "fireblast", "flashcannon", "nastyplot", "roost", "uturn" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "darkpulse", "dracometeor", "dragonpulse", "earthpower", "fireblast", "nastyplot", "protect", "tailwind" ],
+        tier: "OU",
+        doublesTier: "DUU",
+    },
+    larvesta: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    volcarona: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "bugbuzz", "fireblast", "gigadrain", "quiverdance", "roost" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "bugbuzz", "gigadrain", "heatwave", "hurricane", "quiverdance", "roost" ],
+        tier: "Illegal",
+    },
+    cobalion: {
+        randomBattleMoves: [ "closecombat", "ironhead", "stealthrock", "stoneedge", "swordsdance", "voltswitch" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "ironhead", "protect", "sacredsword", "stoneedge", "swordsdance", "thunderwave" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    terrakion: {
+        randomBattleMoves: [ "closecombat", "earthquake", "quickattack", "stoneedge", "swordsdance" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "closecombat", "ironhead", "protect", "rockslide", "stoneedge", "swordsdance" ],
+        tier: "OU",
+        doublesTier: "DOU",
+    },
+    virizion: {
+        randomBattleMoves: [ "closecombat", "leafblade", "stoneedge", "swordsdance", "taunt" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "closecombat", "leafblade", "stoneedge", "substitute", "swordsdance", "taunt" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    tornadus: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "defog", "grassknot", "heatwave", "hurricane", "nastyplot" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "heatwave", "hurricane", "nastyplot", "superpower", "tailwind", "taunt" ],
+        tier: "Illegal",
+    },
+    tornadustherian: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    thundurus: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "focusblast", "grassknot", "knockoff", "nastyplot", "superpower", "thunderbolt", "thunderwave", "uturn" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "grassknot", "nastyplot", "sludgebomb", "substitute", "thunderbolt" ],
+        tier: "Illegal",
+    },
+    thundurustherian: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    reshiram: {
+        randomBattleMoves: [ "blueflare", "dracometeor", "dragonpulse", "earthpower", "roost", "stoneedge" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "blueflare", "dracometeor", "earthpower", "heatwave", "roost", "tailwind" ],
+        tier: "Uber",
+        doublesTier: "DUber",
+    },
+    zekrom: {
+        randomBattleMoves: [ "boltstrike", "dragondance", "outrage", "substitute" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "boltstrike", "dragonclaw", "dragondance", "roost", "substitute" ],
+        tier: "Uber",
+        doublesTier: "DUber",
+    },
+    landorus: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "earthpower", "focusblast", "knockoff", "rockpolish", "rockslide", "sludgewave", "stealthrock" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "calmmind", "earthpower", "focusblast", "protect", "psychic", "sludgebomb" ],
+        tier: "Illegal",
+    },
+    landorustherian: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    kyurem: {
+        randomBattleMoves: [ "dracometeor", "earthpower", "focusblast", "freezedry", "icebeam", "outrage" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "dracometeor", "earthpower", "freezedry", "glaciate", "protect", "roost", "substitute" ],
+        tier: "OU",
+        doublesTier: "DUU",
+    },
+    kyuremblack: {
+        randomBattleMoves: [ "dragondance", "fusionbolt", "iciclespear", "outrage" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "dragonclaw", "dragondance", "fusionbolt", "iciclespear", "protect", "roost" ],
+        tier: "Uber",
+        doublesTier: "DUber",
+    },
+    kyuremwhite: {
+        randomBattleMoves: [ "dracometeor", "earthpower", "freezedry", "fusionflare", "icebeam" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "dracometeor", "dragonpulse", "earthpower", "freezedry", "fusionflare", "icebeam", "protect", "roost" ],
+        tier: "Uber",
+        doublesTier: "DUber",
+    },
+    keldeo: {
+        randomDoubleBattleMoves: [ "calmmind", "hydropump", "icywind", "protect", "scald", "secretsword" ],
+        tier: "OU",
+        doublesTier: "DUU",
+    },
+    keldeoresolute: {
+        randomBattleMoves: [ "airslash", "calmmind", "hydropump", "icywind", "scald", "secretsword", "substitute" ],
+        randomBattleLevel: 80
+    },
+    meloetta: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    meloettapirouette: {
+        isNonstandard: "Past",
+    },
+    genesect: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    genesectburn: {
+        isNonstandard: "Past",
+    },
+    genesectchill: {
+        isNonstandard: "Past",
+    },
+    genesectdouse: {
+        isNonstandard: "Past",
+    },
+    genesectshock: {
+        isNonstandard: "Past",
+    },
+    chespin: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    quilladin: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    chesnaught: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    fennekin: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    braixen: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    delphox: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    froakie: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    frogadier: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    greninja: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    greninjaash: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    bunnelby: {
+        tier: "LC",
+    },
+    diggersby: {
+        randomBattleMoves: [ "bodyslam", "earthquake", "knockoff", "quickattack", "swordsdance", "uturn" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "bodyslam", "highhorsepower", "knockoff", "quickattack", "stoneedge", "superpower", "swordsdance" ],
+        tier: "UUBL",
+        doublesTier: "(DUU)",
+    },
+    fletchling: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    fletchinder: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    talonflame: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "bravebird", "defog", "flareblitz", "roost", "swordsdance", "uturn" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "bravebird", "defog", "flareblitz", "overheat", "roost", "tailwind", "willowisp" ],
+        tier: "Illegal",
+    },
+    scatterbug: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    spewpa: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    vivillon: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    vivillonfancy: {
+        isNonstandard: "Past",
+    },
+    vivillonpokeball: {
+        isNonstandard: "Past",
+    },
+    litleo: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pyroar: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    flabebe: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    floette: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    floetteeternal: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    florges: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    skiddo: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    gogoat: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pancham: {
+        tier: "LC",
+    },
+    pangoro: {
+        randomBattleMoves: [ "closecombat", "darkestlariat", "gunkshot", "icepunch", "partingshot" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "bulletpunch", "closecombat", "drainpunch", "gunkshot", "icepunch", "knockoff", "protect" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    furfrou: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    espurr: {
+        tier: "LC",
+    },
+    meowstic: {
+        randomBattleMoves: [ "lightscreen", "psychic", "reflect", "thunderwave", "yawn" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "fakeout", "foulplay", "lightscreen", "reflect", "thunderwave" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    meowsticf: {
+        randomBattleMoves: [ "energyball", "nastyplot", "psychic", "shadowball", "thunderbolt" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "fakeout", "nastyplot", "psychic", "shadowball", "thunderbolt" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    honedge: {
+        tier: "LC",
+    },
+    doublade: {
+        randomBattleMoves: [ "ironhead", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "ironhead", "protect", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance" ],
+        tier: "UU",
+        doublesTier: "NFE",
+    },
+    aegislash: {
+        randomBattleMoves: [ "closecombat", "flashcannon", "kingsshield", "shadowball", "shadowsneak", "substitute", "toxic" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "flashcannon", "kingsshield", "shadowball", "shadowsneak" ],
+        tier: "OU",
+        doublesTier: "DUU",
+    },
+    aegislashblade: {
+        randomBattleMoves: [ "closecombat", "ironhead", "shadowclaw", "shadowsneak", "swordsdance" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "closecombat", "ironhead", "kingsshield", "shadowclaw", "shadowsneak", "swordsdance" ]
+    },
+    spritzee: {
+        tier: "LC",
+    },
+    aromatisse: {
+        randomBattleMoves: [ "calmmind", "moonblast", "protect", "toxic", "wish" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "healpulse", "moonblast", "protect", "thunderbolt", "trickroom", "wish" ],
+        tier: "RU",
+        doublesTier: "DUU",
+    },
+    swirlix: {
+        tier: "LC Uber",
+    },
+    slurpuff: {
+        randomBattleMoves: [ "bellydrum", "drainpunch", "facade", "playrough" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "faketears", "flamethrower", "helpinghand", "playrough", "stickyweb" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    inkay: {
+        tier: "LC",
+    },
+    malamar: {
+        randomBattleMoves: [ "knockoff", "psychocut", "rest", "sleeptalk", "substitute", "superpower" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "knockoff", "psychocut", "rest", "superpower" ],
+        tier: "NU",
+        doublesTier: "DUU",
+    },
+    binacle: {
+        tier: "LC",
+    },
+    barbaracle: {
+        randomBattleMoves: [ "crosschop", "earthquake", "liquidation", "shellsmash", "stoneedge" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "liquidation", "poisonjab", "protect", "rockslide", "shellsmash", "superpower" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    skrelp: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    dragalge: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    clauncher: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    clawitzer: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    helioptile: {
+        tier: "LC",
+    },
+    heliolisk: {
+        randomBattleMoves: [ "focusblast", "grassknot", "hypervoice", "surf", "thunderbolt", "voltswitch" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "electroweb", "focusblast", "grassknot", "hypervoice", "protect", "surf", "thunderbolt", "voltswitch" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    tyrunt: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    tyrantrum: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    amaura: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    aurorus: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "ancientpower", "blizzard", "earthpower", "freezedry", "hypervoice", "stealthrock", "thunderwave" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "earthpower", "freezedry", "hypervoice", "protect", "thunderwave" ],
+        tier: "Illegal",
+    },
+    hawlucha: {
+        randomBattleMoves: [ "bravebird", "closecombat", "roost", "stoneedge", "swordsdance", "throatchop" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "bravebird", "closecombat", "protect", "stoneedge", "swordsdance", "throatchop" ],
+        tier: "OU",
+        doublesTier: "DUU",
+    },
+    dedenne: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "protect", "recycle", "thunderbolt", "toxic" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "eerieimpulse", "helpinghand", "nuzzle", "recycle", "superfang", "thunderbolt" ],
+        tier: "Illegal",
+    },
+    carbink: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    goomy: {
+        tier: "LC",
+    },
+    sliggoo: {
+        tier: "NFE",
+    },
+    goodra: {
+        randomBattleMoves: [ "dracometeor", "earthquake", "fireblast", "powerwhip", "sludgebomb", "thunderbolt" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "breakingswipe", "dracometeor", "fireblast", "muddywater", "powerwhip", "protect", "sludgebomb", "thunderbolt" ],
+        tier: "RUBL",
+        doublesTier: "(DUU)",
+    },
+    klefki: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    phantump: {
+        tier: "LC",
+    },
+    trevenant: {
+        randomBattleMoves: [ "earthquake", "hornleech", "rockslide", "shadowclaw", "trickroom", "woodhammer" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "allyswitch", "rockslide", "shadowclaw", "trickroom", "willowisp", "woodhammer" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    pumpkaboo: {
+        tier: "LC",
+    },
+    pumpkaboosmall: {
+        unreleasedHidden: true,
+        tier: "LC",
+    },
+    pumpkaboolarge: {
+        unreleasedHidden: true,
+        tier: "LC",
+    },
+    pumpkaboosuper: {
+        tier: "LC",
+    },
+    gourgeist: {
+        randomBattleMoves: [ "leechseed", "powerwhip", "shadowsneak", "substitute", "willowisp" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "destinybond", "disable", "foulplay", "leechseed", "painsplit", "powerwhip", "willowisp" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    gourgeistsmall: {
+        randomBattleMoves: [ "leechseed", "powerwhip", "shadowsneak", "substitute", "willowisp" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "destinybond", "disable", "foulplay", "leechseed", "painsplit", "powerwhip", "willowisp" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    gourgeistlarge: {
+        randomBattleMoves: [ "leechseed", "powerwhip", "shadowsneak", "substitute", "willowisp" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "powerwhip", "protect", "shadowclaw", "shadowsneak", "synthesis", "trickroom" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    gourgeistsuper: {
+        randomBattleMoves: [ "explosion", "foulplay", "powerwhip", "rockslide", "shadowsneak", "trick" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "powerwhip", "protect", "shadowclaw", "shadowsneak", "synthesis", "trickroom" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    bergmite: {
+        tier: "LC",
+    },
+    avalugg: {
+        randomBattleMoves: [ "avalanche", "bodypress", "curse", "rapidspin", "recover" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "avalanche", "bodypress", "curse", "highhorsepower", "protect", "recover" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    noibat: {
+        tier: "LC",
+    },
+    noivern: {
+        randomBattleMoves: [ "boomburst", "dracometeor", "flamethrower", "hurricane", "roost", "uturn" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "boomburst", "dracometeor", "flamethrower", "hurricane", "protect", "tailwind" ],
+        tier: "UU",
+        doublesTier: "DUU",
+    },
+    xerneas: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "calmmind", "focusblast", "moonblast", "psyshock", "thunderbolt" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "calmmind", "closecombat", "dazzlinggleam", "healpulse", "moonblast", "protect", "psyshock", "thunderbolt" ],
+        tier: "Illegal",
+    },
+    xerneasneutral: {
+        isNonstandard: "Unobtainable",
+        tier: "Illegal",
+    },
+    yveltal: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "defog", "heatwave", "hurricane", "knockoff", "roost", "suckerpunch" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "darkpulse", "heatwave", "hurricane", "knockoff", "roost", "suckerpunch", "tailwind", "uturn" ],
+        tier: "Illegal",
+    },
+    zygarde: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "dragondance", "earthquake", "extremespeed", "outrage", "stoneedge" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "coil", "earthquake", "extremespeed", "glare", "irontail", "protect", "stoneedge" ],
+        tier: "Illegal",
+    },
+    zygarde10: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    zygardecomplete: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    diancie: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    dianciemega: {
+        isNonstandard: "Past",
+    },
+    hoopa: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    hoopaunbound: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    volcanion: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    rowlet: {
+        tier: "LC",
+    },
+    dartrix: {
+        tier: "NFE",
+    },
+    decidueye: {
+        randomBattleMoves: [ "bravebird", "leafblade", "roost", "shadowsneak", "spiritshackle", "swordsdance" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "bravebird", "leafblade", "protect", "shadowsneak", "spiritshackle", "swordsdance" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    litten: {
+        tier: "LC",
+    },
+    torracat: {
+        tier: "NFE",
+        doublesTier: "DUU",
+    },
+    incineroar: {
+        randomBattleMoves: [ "earthquake", "flareblitz", "knockoff", "partingshot", "uturn", "willowisp" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "fakeout", "flareblitz", "knockoff", "partingshot", "protect", "snarl" ],
+        tier: "UU",
+        doublesTier: "DOU",
+    },
+    popplio: {
+        tier: "LC",
+    },
+    brionne: {
+        tier: "NFE",
+    },
+    primarina: {
+        randomBattleMoves: [ "energyball", "hydropump", "moonblast", "psychic", "sparklingaria" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "energyball", "hydropump", "icebeam", "moonblast", "protect", "psychic" ],
+        tier: "UUBL",
+        doublesTier: "DUU",
+    },
+    pikipek: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    trumbeak: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    toucannon: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    yungoos: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    gumshoos: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    gumshoostotem: {
+        isNonstandard: "Past",
+    },
+    grubbin: {
+        tier: "LC",
+    },
+    charjabug: {
+        tier: "NFE",
+    },
+    vikavolt: {
+        randomBattleMoves: [ "agility", "bugbuzz", "energyball", "stickyweb", "thunderbolt", "voltswitch" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "bugbuzz", "energyball", "protect", "stickyweb", "thunderbolt", "voltswitch" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    vikavolttotem: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    crabrawler: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    crabominable: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    oricorio: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    oricoriopompom: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    oricoriopau: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    oricoriosensu: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    cutiefly: {
+        tier: "LC Uber",
+    },
+    ribombee: {
+        randomBattleMoves: [ "bugbuzz", "moonblast", "stickyweb", "stunspore", "uturn" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "helpinghand", "moonblast", "pollenpuff", "protect", "stickyweb", "tailwind" ],
+        tier: "UU",
+        doublesTier: "DUU",
+    },
+    ribombeetotem: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    rockruff: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    rockruffdusk: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    lycanroc: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "accelerock", "closecombat", "psychicfangs", "stoneedge", "swordsdance" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "accelerock", "closecombat", "crunch", "protect", "psychicfangs", "stoneedge", "swordsdance" ],
+        tier: "Illegal",
+    },
+    lycanrocmidnight: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "closecombat", "irontail", "stealthrock", "stoneedge", "suckerpunch" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "closecombat", "irontail", "protect", "stoneedge", "suckerpunch", "swordsdance" ],
+        tier: "Illegal",
+    },
+    lycanrocdusk: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    wishiwashi: {
+        randomDoubleBattleMoves: [ "earthquake", "helpinghand", "hydropump", "icebeam", "muddywater", "protect" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    wishiwashischool: {
+        randomBattleMoves: [ "earthquake", "hydropump", "icebeam", "scald", "uturn" ],
+        randomBattleLevel: 88
+    },
+    mareanie: {
+        tier: "LC",
+    },
+    toxapex: {
+        randomBattleMoves: [ "banefulbunker", "haze", "recover", "scald", "toxic", "toxicspikes" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "banefulbunker", "haze", "infestation", "recover", "scald", "toxic" ],
+        tier: "OU",
+        doublesTier: "(DUU)",
+    },
+    mudbray: {
+        tier: "LC",
+    },
+    mudsdale: {
+        randomBattleMoves: [ "bodypress", "earthquake", "heavyslam", "rockslide", "stealthrock" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "bodypress", "heavyslam", "highhorsepower", "protect", "rest", "rocktomb" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    dewpider: {
+        tier: "LC",
+    },
+    araquanid: {
+        randomBattleMoves: [ "liquidation", "leechlife", "mirrorcoat", "stickyweb", "toxic" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "leechlife", "liquidation", "lunge", "protect", "stickyweb", "wideguard" ],
+        tier: "UU",
+        doublesTier: "DUU",
+    },
+    araquanidtotem: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    fomantis: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    lurantis: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    lurantistotem: {
+        isNonstandard: "Past",
+    },
+    morelull: {
+        tier: "LC",
+    },
+    shiinotic: {
+        randomBattleMoves: [ "energyball", "leechseed", "moonblast", "spore", "strengthsap" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "energyball", "moonblast", "protect", "spore", "strengthsap" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    salandit: {
+        tier: "LC",
+    },
+    salazzle: {
+        randomBattleMoves: [ "flamethrower", "protect", "substitute", "toxic" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "encore", "fakeout", "fireblast", "nastyplot", "protect", "sludgebomb" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    salazzletotem: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    stufful: {
+        tier: "LC",
+    },
+    bewear: {
+        randomBattleMoves: [ "closecombat", "darkestlariat", "doubleedge", "icepunch", "swordsdance" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "closecombat", "darkestlariat", "doubleedge", "drainpunch", "highhorsepower", "icepunch", "protect", "wideguard" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    bounsweet: {
+        tier: "LC",
+    },
+    steenee: {
+        tier: "NFE",
+    },
+    tsareena: {
+        randomBattleMoves: [ "highjumpkick", "knockoff", "playrough", "powerwhip", "rapidspin", "synthesis", "uturn" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "highjumpkick", "knockoff", "playrough", "powerwhip", "rapidspin", "uturn" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    comfey: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    oranguru: {
+        randomBattleMoves: [ "focusblast", "nastyplot", "psychic", "thunderbolt", "trickroom" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "allyswitch", "focusblast", "instruct", "protect", "psychic", "trickroom" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    passimian: {
+        randomBattleMoves: [ "closecombat", "earthquake", "gunkshot", "knockoff", "rockslide", "uturn" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "closecombat", "gunkshot", "knockoff", "rockslide", "uturn" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    wimpod: {
+        tier: "LC",
+    },
+    golisopod: {
+        randomBattleMoves: [ "aquajet", "closecombat", "firstimpression", "liquidation", "spikes" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "aquajet", "closecombat", "firstimpression", "knockoff", "leechlife", "liquidation", "protect", "wideguard" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    sandygast: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    palossand: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pyukumuku: {
+        randomBattleMoves: [ "counter", "mirrorcoat", "recover", "toxic" ],
+        randomBattleLevel: 88,
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    typenull: {
+        randomBattleMoves: [ "crushclaw", "payback", "rest", "sleeptalk", "swordsdance" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "doubleedge", "flamecharge", "shadowclaw", "swordsdance", "thunderwave" ],
+        tier: "PU",
+        doublesTier: "NFE",
+    },
+    silvally: {
+        randomBattleMoves: [ "crunch", "explosion", "flamecharge", "flamethrower", "multiattack", "swordsdance", "uturn" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "crunch", "explosion", "flamethrower", "multiattack", "protect", "tailwind" ],
+        tier: "PUBL",
+        doublesTier: "(DUU)",
+    },
+    silvallybug: {
+        randomBattleMoves: [ "flamethrower", "multiattack", "partingshot", "psychicfangs", "thunderbolt" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "flamethrower", "multiattack", "psychicfangs", "tailwind", "uturn" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    silvallydark: {
+        randomBattleMoves: [ "ironhead", "multiattack", "partingshot", "psychicfangs", "swordsdance" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "ironhead", "multiattack", "psychicfangs", "swordsdance", "tailwind" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    silvallydragon: {
+        randomBattleMoves: [ "firefang", "ironhead", "multiattack", "partingshot", "swordsdance" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "firefang", "ironhead", "multiattack", "swordsdance", "tailwind" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    silvallyelectric: {
+        randomBattleMoves: [ "flamethrower", "icebeam", "multiattack", "partingshot", "toxic" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "flamethrower", "grasspledge", "icebeam", "multiattack", "tailwind" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    silvallyfairy: {
+        randomBattleMoves: [ "firefang", "multiattack", "psychicfangs", "swordsdance" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "flamethrower", "multiattack", "partingshot", "tailwind" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    silvallyfighting: {
+        randomBattleMoves: [ "crunch", "ironhead", "multiattack", "swordsdance", "uturn" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "crunch", "multiattack", "rockslide", "swordsdance", "tailwind" ],
+        tier: "PUBL",
+        doublesTier: "(DUU)",
+    },
+    silvallyfire: {
+        randomBattleMoves: [ "crunch", "ironhead", "multiattack", "swordsdance" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "heatwave", "icebeam", "multiattack", "tailwind", "thunderbolt" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    silvallyflying: {
+        randomBattleMoves: [ "firefang", "ironhead", "multiattack", "rockslide", "swordsdance" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "firefang", "ironhead", "multiattack", "swordsdance", "tailwind" ],
+        tier: "PUBL",
+        doublesTier: "(DUU)",
+    },
+    silvallyghost: {
+        randomBattleMoves: [ "multiattack", "partingshot", "swordsdance", "xscissor" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "multiattack", "swordsdance", "tailwind", "xscissor" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    silvallygrass: {
+        randomBattleMoves: [ "defog", "flamethrower", "icebeam", "multiattack", "partingshot" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "flamethrower", "icebeam", "multiattack", "partingshot", "tailwind" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    silvallyground: {
+        randomBattleMoves: [ "defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "multiattack", "rockslide", "swordsdance", "tailwind" ],
+        tier: "PUBL",
+        doublesTier: "(DUU)",
+    },
+    silvallyice: {
+        randomBattleMoves: [ "firefang", "multiattack", "psychicfangs", "swordsdance" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "flamethrower", "multiattack", "partingshot", "tailwind", "thunderbolt" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    silvallypoison: {
+        randomBattleMoves: [ "defog", "flamethrower", "grasspledge", "multiattack", "partingshot", "toxic" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "flamethrower", "grasspledge", "multiattack", "partingshot", "snarl", "tailwind" ],
+        tier: "PUBL",
+        doublesTier: "(DUU)",
+    },
+    silvallypsychic: {
+        randomBattleMoves: [ "crunch", "multiattack", "swordsdance", "uturn" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "flamethrower", "multiattack", "partingshot", "tailwind", "xscissor" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    silvallyrock: {
+        randomBattleMoves: [ "firefang", "multiattack", "partingshot", "psychicfangs", "swordsdance" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "flamethrower", "multiattack", "partingshot", "psychicfangs", "tailwind" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    silvallysteel: {
+        randomBattleMoves: [ "defog", "flamethrower", "multiattack", "partingshot", "thunderbolt", "toxic" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "flamethrower", "multiattack", "partingshot", "tailwind", "thunderbolt" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    silvallywater: {
+        randomBattleMoves: [ "defog", "icebeam", "multiattack", "partingshot", "thunderbolt", "toxic" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "icebeam", "multiattack", "partingshot", "tailwind", "thunderbolt" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    minior: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    miniormeteor: {
+        isNonstandard: "Past",
+    },
+    komala: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    turtonator: {
+        randomBattleMoves: [ "bodypress", "dracometeor", "earthquake", "fireblast", "rapidspin", "shellsmash", "willowisp" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "dracometeor", "dragonpulse", "fireblast", "protect", "shellsmash" ],
+        tier: "NUBL",
+        doublesTier: "(DUU)",
+    },
+    togedemaru: {
+        randomBattleMoves: [ "ironhead", "nuzzle", "spikyshield", "uturn", "wish", "zingzap" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "encore", "fakeout", "ironhead", "nuzzle", "spikyshield", "zingzap" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    togedemarutotem: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    mimikyu: {
+        randomBattleMoves: [ "playrough", "shadowclaw", "shadowsneak", "swordsdance", "taunt" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "playrough", "protect", "shadowclaw", "shadowsneak", "swordsdance", "woodhammer" ],
+        tier: "OU",
+        doublesTier: "DUU",
+    },
+    mimikyutotem: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    mimikyubustedtotem: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    bruxish: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    drampa: {
+        randomBattleMoves: [ "dracometeor", "fireblast", "glare", "hypervoice", "roost", "thunderbolt" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "dracometeor", "dragonpulse", "energyball", "glare", "heatwave", "hypervoice", "protect", "roost", "thunderbolt" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    dhelmise: {
+        randomBattleMoves: [ "anchorshot", "earthquake", "knockoff", "powerwhip", "rapidspin", "swordsdance" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "anchorshot", "knockoff", "liquidation", "powerwhip", "shadowclaw", "synthesis" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    jangmoo: {
+        tier: "LC",
+    },
+    hakamoo: {
+        tier: "NFE",
+    },
+    kommoo: {
+        randomBattleMoves: [ "clangingscales", "clangoroussoul", "closecombat", "poisonjab", "stealthrock" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "bodypress", "dracometeor", "irondefense", "protect" ],
+        tier: "OU",
+        doublesTier: "DUU",
+    },
+    kommoototem: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    tapukoko: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "bravebird", "closecombat", "playrough", "uturn", "wildcharge" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "bravebird", "closecombat", "playrough", "uturn", "wildcharge" ],
+        tier: "Illegal",
+    },
+    tapulele: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "calmmind", "focusblast", "moonblast", "psychic", "psyshock", "taunt" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "focusblast", "moonblast", "protect", "psychic", "psyshock", "taunt" ],
+        tier: "Illegal",
+    },
+    tapubulu: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "bulkup", "closecombat", "hornleech", "playrough", "stoneedge", "woodhammer" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "closecombat", "hornleech", "playrough", "protect", "stoneedge", "synthesis", "woodhammer" ],
+        tier: "Illegal",
+    },
+    tapufini: {
+        isNonstandard: "Past",
+        randomBattleMoves: [ "calmmind", "defog", "moonblast", "surf", "taunt" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "healpulse", "hydropump", "icywind", "moonblast", "muddywater", "naturesmadness", "swagger" ],
+        tier: "Illegal",
+    },
+    cosmog: {
+        tier: "LC",
+    },
+    cosmoem: {
+        tier: "NFE",
+    },
+    solgaleo: {
+        randomBattleMoves: [ "closecombat", "flamecharge", "morningsun", "psychicfangs", "stoneedge", "sunsteelstrike" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "closecombat", "flareblitz", "morningsun", "protect", "psychicfangs", "stoneedge", "sunsteelstrike" ],
+        tier: "Uber",
+        doublesTier: "DUber",
+    },
+    lunala: {
+        randomBattleMoves: [ "calmmind", "moonblast", "moongeistbeam", "psyshock", "roost" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "calmmind", "moonblast", "moongeistbeam", "moonlight", "protect", "psychic", "psyshock" ],
+        tier: "Uber",
+        doublesTier: "DUber",
+    },
+    nihilego: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    buzzwole: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    pheromosa: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    xurkitree: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    celesteela: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    kartana: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    guzzlord: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    necrozma: {
+        randomBattleMoves: [ "calmmind", "heatwave", "moonlight", "photongeyser", "stealthrock" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "calmmind", "earthpower", "moonlight", "photongeyser", "powergem" ],
+        tier: "UU",
+        doublesTier: "DOU",
+    },
+    necrozmaduskmane: {
+        randomBattleMoves: [ "dragondance", "earthquake", "morningsun", "photongeyser", "sunsteelstrike" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "dragondance", "morningsun", "photongeyser", "protect", "sunsteelstrike" ],
+        tier: "Uber",
+        doublesTier: "DUber",
+    },
+    necrozmadawnwings: {
+        randomBattleMoves: [ "autotomize", "calmmind", "heatwave", "moongeistbeam", "photongeyser" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "earthpower", "heatwave", "moonblast", "moongeistbeam", "photongeyser", "protect" ],
+        tier: "Uber",
+        doublesTier: "DUber",
+    },
+    necrozmaultra: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    magearna: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    magearnaoriginal: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    marshadow: {
+        randomBattleMoves: [ "bulkup", "closecombat", "icepunch", "rocktomb", "shadowsneak", "spectralthief" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "closecombat", "protect", "rocktomb", "shadowsneak", "spectralthief" ],
+        tier: "Uber",
+        doublesTier: "DUber",
+    },
+    poipole: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    naganadel: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    stakataka: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    blacephalon: {
+        isNonstandard: "Past",
+        tier: "Illegal",
+    },
+    zeraora: {
+        randomBattleMoves: [ "bulkup", "closecombat", "grassknot", "knockoff", "plasmafists", "playrough", "voltswitch" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "closecombat", "fakeout", "grassknot", "knockoff", "plasmafists", "playrough" ],
+        tier: "OU",
+        doublesTier: "DOU",
+    },
+    meltan: {
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    melmetal: {
+        randomBattleMoves: [ "doubleironbash", "earthquake", "substitute", "superpower", "thunderpunch" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "bodypress", "doubleironbash", "highhorsepower", "icepunch", "thunderpunch", "thunderwave" ],
+        tier: "Uber",
+        doublesTier: "DOU",
+    },
+    melmetalgmax: {
+        isNonstandard: "Unobtainable",
+        tier: "Unreleased",
+    },
+    grookey: {
+        unreleasedHidden: true,
+        tier: "LC",
+    },
+    thwackey: {
+        unreleasedHidden: true,
+        tier: "NFE",
+    },
+    rillaboom: {
+        randomBattleMoves: [ "bulkup", "drumbeating", "highhorsepower", "knockoff", "substitute", "uturn", "woodhammer" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "drumbeating", "fakeout", "highhorsepower", "superpower", "swordsdance", "uturn" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    scorbunny: {
+        unreleasedHidden: true,
+        tier: "LC",
+    },
+    raboot: {
+        unreleasedHidden: true,
+        tier: "NFE",
+    },
+    cinderace: {
+        randomBattleMoves: [ "courtchange", "gunkshot", "highjumpkick", "pyroball", "uturn", "zenheadbutt" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "courtchange", "gunkshot", "highjumpkick", "ironhead", "protect", "pyroball", "uturn", "zenheadbutt" ],
+        tier: "OU",
+        doublesTier: "DUU",
+    },
+    sobble: {
+        unreleasedHidden: true,
+        tier: "LC",
+    },
+    drizzile: {
+        unreleasedHidden: true,
+        tier: "NFE",
+    },
+    inteleon: {
+        randomBattleMoves: [ "airslash", "darkpulse", "hydropump", "icebeam", "scald", "uturn" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "airslash", "hydropump", "icebeam", "muddywater", "shadowball", "uturn" ],
+        tier: "RU",
+        doublesTier: "DUU",
+    },
+    skwovet: {
+        unreleasedHidden: true,
+        tier: "LC",
+    },
+    greedent: {
+        randomBattleMoves: [ "bodyslam", "earthquake", "firefang", "payback", "swordsdance" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "bodyslam", "crunch", "earthquake", "gyroball", "protect", "swordsdance" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    rookidee: {
+        tier: "LC",
+    },
+    corvisquire: {
+        tier: "NFE",
+    },
+    corviknight: {
+        randomBattleMoves: [ "bodypress", "bravebird", "bulkup", "defog", "roost" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "bodypress", "bravebird", "bulkup", "ironhead", "roost", "tailwind" ],
+        tier: "OU",
+        doublesTier: "DOU",
+    },
+    corviknightgmax: {
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    blipbug: {
+        tier: "LC",
+    },
+    dottler: {
+        tier: "NFE",
+    },
+    orbeetle: {
+        randomBattleMoves: [ "bodypress", "hypnosis", "psychic", "recover", "stickyweb", "uturn" ],
+        randomBattleLevel: 86,
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    orbeetlegmax: {
+        randomDoubleBattleMoves: [ "helpinghand", "hypnosis", "lightscreen", "psychic", "reflect", "stickyweb", "strugglebug" ],
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    nickit: {
+        unreleasedHidden: true,
+        tier: "LC",
+    },
+    thievul: {
+        randomBattleMoves: [ "darkpulse", "foulplay", "grassknot", "nastyplot", "partingshot", "psychic" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "faketears", "foulplay", "partingshot", "snarl", "taunt" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    gossifleur: {
+        tier: "LC",
+    },
+    eldegoss: {
+        randomBattleMoves: [ "charm", "energyball", "leechseed", "pollenpuff", "rapidspin", "sleeppowder" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "gigadrain", "helpinghand", "leechseed", "pollenpuff", "protect", "sleeppowder", "synthesis" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    wooloo: {
+        unreleasedHidden: true,
+        tier: "LC",
+    },
+    dubwool: {
+        randomBattleMoves: [ "bodypress", "cottonguard", "rest", "sleeptalk" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "doubleedge", "protect", "swordsdance", "thunderwave", "wildcharge", "zenheadbutt" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    chewtle: {
+        tier: "LC",
+    },
+    drednaw: {
+        randomBattleMoves: [ "liquidation", "stealthrock", "stoneedge", "superpower", "swordsdance" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "highhorsepower", "liquidation", "protect", "rockslide", "superpower", "swordsdance" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    drednawgmax: {
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    yamper: {
+        unreleasedHidden: true,
+        tier: "LC",
+    },
+    boltund: {
+        randomBattleMoves: [ "bulkup", "crunch", "firefang", "playrough", "psychicfangs", "thunderfang", "voltswitch" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "crunch", "firefang", "nuzzle", "playrough", "protect", "psychicfangs", "snarl", "thunderfang" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    rolycoly: {
+        tier: "LC",
+    },
+    carkol: {
+        tier: "PU",
+        doublesTier: "NFE",
+    },
+    coalossal: {
+        tier: "RU",
+        doublesTier: "DUU",
+    },
+    coalossalgmax: {
+        randomBattleMoves: [ "overheat", "rapidspin", "spikes", "stealthrock", "stoneedge", "willowisp" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "fireblast", "incinerate", "protect", "stealthrock", "stoneedge", "willowisp" ],
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    applin: {
+        tier: "LC",
+    },
+    flapple: {
+        randomBattleMoves: [ "dragondance", "gravapple", "outrage", "suckerpunch", "uturn" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "acrobatics", "dragondance", "dragonrush", "gravapple", "protect" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    flapplegmax: {
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    appletun: {
+        randomBattleMoves: [ "appleacid", "dragonpulse", "leechseed", "recover" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "appleacid", "dracometeor", "dragonpulse", "leechseed", "protect", "recover" ],
+        tier: "PUBL",
+        doublesTier: "(DUU)",
+    },
+    appletungmax: {
+        randomBattleMoves: [ "appleacid", "dracometeor", "leechseed", "recover" ],
+        randomBattleLevel: 88,
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    silicobra: {
+        tier: "LC",
+    },
+    sandaconda: {
+        randomBattleMoves: [ "coil", "earthquake", "glare", "stealthrock", "stoneedge", "rest" ],
+        randomBattleLevel: 86,
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    sandacondagmax: {
+        randomDoubleBattleMoves: [ "coil", "glare", "highhorsepower", "protect", "stoneedge" ],
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    cramorant: {
+        randomBattleMoves: [ "bravebird", "defog", "roost", "superpower", "surf" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "hurricane", "icebeam", "protect", "roost", "surf", "tailwind" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    arrokuda: {
+        tier: "LC",
+    },
+    barraskewda: {
+        randomBattleMoves: [ "closecombat", "crunch", "drillrun", "liquidation", "poisonjab" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "closecombat", "crunch", "drillrun", "liquidation", "poisonjab", "psychicfangs" ],
+        tier: "RUBL",
+        doublesTier: "DUU",
+    },
+    toxel: {
+        tier: "LC",
+    },
+    toxtricity: {
+        randomBattleMoves: [ "boomburst", "overdrive", "shiftgear", "sludgewave", "voltswitch" ],
+        randomBattleLevel: 82,
+        tier: "UU",
+        doublesTier: "DUU",
+    },
+    toxtricitylowkey: {
+        randomBattleMoves: [ "boomburst", "overdrive", "sludgewave", "voltswitch" ],
+        randomBattleLevel: 82,
+        tier: "UU",
+        doublesTier: "DUU",
+    },
+    toxtricitygmax: {
+        randomDoubleBattleMoves: [ "boomburst", "overdrive", "shiftgear", "sludgebomb", "snarl", "voltswitch" ],
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    toxtricitylowkeygmax: {
+        randomDoubleBattleMoves: [ "boomburst", "overdrive", "sludgebomb", "snarl", "voltswitch" ],
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    sizzlipede: {
+        tier: "LC",
+    },
+    centiskorch: {
+        randomBattleMoves: [ "coil", "firelash", "knockoff", "leechlife", "powerwhip" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "coil", "firelash", "knockoff", "leechlife", "powerwhip", "protect" ],
+        tier: "RUBL",
+        doublesTier: "DUU",
+    },
+    centiskorchgmax: {
+        randomDoubleBattleMoves: [ "coil", "firelash", "knockoff", "leechlife", "powerwhip", "protect" ],
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    clobbopus: {
+        tier: "LC",
+    },
+    grapploct: {
+        randomBattleMoves: [ "brutalswing", "circlethrow", "drainpunch", "icepunch", "suckerpunch" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "closecombat", "drainpunch", "icepunch", "octolock", "payback", "protect" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    sinistea: {
+        tier: "LC",
+    },
+    sinisteaantique: {
+        unreleasedHidden: true,
+        tier: "LC",
+    },
+    polteageist: {
+        randomBattleMoves: [ "gigadrain", "shadowball", "shellsmash", "storedpower", "strengthsap" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "gigadrain", "protect", "shadowball", "shellsmash", "storedpower" ],
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    polteageistantique: {
+        unreleasedHidden: true,
+        tier: "UU",
+        doublesTier: "(DUU)",
+    },
+    hatenna: {
+        tier: "LC",
+    },
+    hattrem: {
+        tier: "NU",
+        doublesTier: "NFE",
+    },
+    hatterene: {
+        tier: "OU",
+        doublesTier: "DOU",
+    },
+    hatterenegmax: {
+        randomBattleMoves: [ "calmmind", "darkpulse", "dazzlinggleam", "mysticalfire", "psychic", "trickroom" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "dazzlinggleam", "mysticalfire", "protect", "psychic", "psyshock", "trickroom" ],
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    impidimp: {
+        tier: "LC",
+    },
+    morgrem: {
+        tier: "NFE",
+    },
+    grimmsnarl: {
+        randomBattleMoves: [ "lightscreen", "reflect", "spiritbreak", "taunt", "thunderwave" ],
+        randomBattleLevel: 80,
+        tier: "OU",
+        doublesTier: "DOU",
+    },
+    grimmsnarlgmax: {
+        randomBattleMoves: [ "bulkup", "darkestlariat", "playrough", "substitute", "suckerpunch", "trick" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "darkestlariat", "fakeout", "lightscreen", "reflect", "spiritbreak", "taunt", "thunderwave" ],
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    milcery: {
+        tier: "LC",
+    },
+    alcremie: {
+        tier: "NU",
+        doublesTier: "DUU",
+    },
+    alcremiegmax: {
+        randomBattleMoves: [ "calmmind", "dazzlinggleam", "mysticalfire", "psychic", "recover" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "dazzlinggleam", "decorate", "mysticalfire", "protect", "recover" ],
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    falinks: {
+        randomBattleMoves: [ "closecombat", "noretreat", "poisonjab", "rockslide", "throatchop" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "closecombat", "noretreat", "poisonjab", "rockslide", "throatchop" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    pincurchin: {
+        randomBattleMoves: [ "discharge", "recover", "selfdestruct", "spikes", "suckerpunch", "toxicspikes" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "acupressure", "protect", "recover", "scald", "suckerpunch", "thunderbolt", "thunderwave" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    snom: {
+        tier: "LC",
+    },
+    frosmoth: {
+        randomBattleMoves: [ "bugbuzz", "gigadrain", "hurricane", "icebeam", "quiverdance" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "bugbuzz", "gigadrain", "hurricane", "icebeam", "quiverdance", "wideguard" ],
+        tier: "RU",
+        doublesTier: "DUU",
+    },
+    stonjourner: {
+        randomBattleMoves: [ "earthquake", "heatcrash", "rockpolish", "stealthrock", "stoneedge" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "bodypress", "heatcrash", "heavyslam", "protect", "rockpolish", "stoneedge", "wideguard" ],
+        tier: "PU",
+        doublesTier: "(DUU)",
+    },
+    eiscue: {
+        randomBattleMoves: [ "bellydrum", "iciclecrash", "liquidation", "substitute", "zenheadbutt" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "bellydrum", "iciclecrash", "liquidation", "protect", "zenheadbutt" ],
+        tier: "(PU)",
+        doublesTier: "(DUU)",
+    },
+    indeedee: {
+        randomBattleMoves: [ "calmmind", "hypervoice", "mysticalfire", "psyshock", "trick" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "encore", "hypervoice", "mysticalfire", "protect", "psychic", "psyshock", "trick" ],
+        tier: "RU",
+        doublesTier: "DUU",
+    },
+    indeedeef: {
+        randomBattleMoves: [ "calmmind", "healingwish", "hypervoice", "mysticalfire", "psychic" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "allyswitch", "followme", "healpulse", "helpinghand", "protect", "psychic", "psyshock" ],
+        tier: "NU",
+        doublesTier: "DOU",
+    },
+    morpeko: {
+        randomBattleMoves: [ "aurawheel", "foulplay", "partingshot", "protect", "psychicfangs", "rapidspin" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "aurawheel", "fakeout", "partingshot", "protect", "rapidspin", "superfang" ],
+        tier: "RU",
+        doublesTier: "(DUU)",
+    },
+    cufant: {
+        tier: "LC",
+    },
+    copperajah: {
+        randomBattleMoves: [ "earthquake", "ironhead", "playrough", "rockslide", "stealthrock" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "heatcrash", "highhorsepower", "ironhead", "playrough", "powerwhip", "protect", "stoneedge" ],
+        tier: "RU",
+        doublesTier: "DUU",
+    },
+    copperajahgmax: {
+        randomBattleMoves: [ "earthquake", "heatcrash", "heavyslam", "powerwhip", "stoneedge" ],
+        randomBattleLevel: 84,
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    dracozolt: {
+        randomBattleMoves: [ "aerialace", "boltbeak", "earthquake", "lowkick", "outrage" ],
+        randomBattleLevel: 82,
+        randomDoubleBattleMoves: [ "aerialace", "boltbeak", "dragonclaw", "highhorsepower", "rockslide" ],
+        tier: "UUBL",
+        doublesTier: "(DUU)",
+    },
+    arctozolt: {
+        randomBattleMoves: [ "bodyslam", "boltbeak", "freezedry", "iciclecrash", "lowkick" ],
+        randomBattleLevel: 88,
+        randomDoubleBattleMoves: [ "blizzard", "boltbeak", "iciclecrash", "lowkick", "protect" ],
+        tier: "PUBL",
+        doublesTier: "(DUU)",
+    },
+    dracovish: {
+        randomBattleMoves: [ "crunch", "fishiousrend", "icefang", "lowkick", "psychicfangs" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "crunch", "dragonrush", "fishiousrend", "icefang", "psychicfangs" ],
+        tier: "OU",
+        doublesTier: "DOU",
+    },
+    arctovish: {
+        randomBattleMoves: [ "bodyslam", "fishiousrend", "freezedry", "iciclecrash", "psychicfangs" ],
+        randomBattleLevel: 86,
+        randomDoubleBattleMoves: [ "blizzard", "bodyslam", "fishiousrend", "iciclecrash", "protect", "psychicfangs" ],
+        tier: "NU",
+        doublesTier: "(DUU)",
+    },
+    duraludon: {
+        randomBattleMoves: [ "bodypress", "dracometeor", "flashcannon", "stealthrock", "thunderbolt" ],
+        randomBattleLevel: 84,
+        randomDoubleBattleMoves: [ "bodypress", "dracometeor", "dragonpulse", "flashcannon", "protect", "snarl", "thunderbolt" ],
+        tier: "RU",
+        doublesTier: "DUU",
+    },
+    duraludongmax: {
+        tier: "(Uber)",
+        doublesTier: "(DUber)",
+    },
+    dreepy: {
+        tier: "LC",
+    },
+    drakloak: {
+        tier: "NFE",
+    },
+    dragapult: {
+        randomBattleMoves: [ "dracometeor", "fireblast", "shadowball", "thunderbolt", "uturn" ],
+        randomBattleLevel: 80,
+        randomDoubleBattleMoves: [ "disable", "dragondarts", "fireblast", "phantomforce", "protect", "thunderbolt", "willowisp" ],
+        tier: "OU",
+        doublesTier: "DOU",
+    },
+    zacian: {
+        randomBattleMoves: [ "closecombat", "crunch", "playrough", "psychicfangs", "swordsdance" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "closecombat", "crunch", "playrough", "protect", "psychicfangs", "swordsdance" ],
+        tier: "Uber",
+        doublesTier: "DUber",
+    },
+    zaciancrowned: {
+        randomBattleMoves: [ "behemothblade", "closecombat", "crunch", "playrough", "psychicfangs", "swordsdance" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "behemothblade", "closecombat", "playrough", "protect", "psychicfangs", "swordsdance" ],
+        tier: "Uber",
+        doublesTier: "DUber",
+    },
+    zamazenta: {
+        randomBattleMoves: [ "closecombat", "crunch", "psychicfangs", "wildcharge" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "closecombat", "crunch", "playrough", "protect", "psychicfangs" ],
+        tier: "Uber",
+        doublesTier: "DUber",
+    },
+    zamazentacrowned: {
+        randomBattleMoves: [ "behemothbash", "closecombat", "crunch", "psychicfangs" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "behemothbash", "closecombat", "crunch", "playrough", "protect", "psychicfangs" ],
+        tier: "Uber",
+        doublesTier: "DUber",
+    },
+    eternatus: {
+        randomBattleMoves: [ "dynamaxcannon", "flamethrower", "recover", "sludgewave", "toxic" ],
+        randomBattleLevel: 72,
+        randomDoubleBattleMoves: [ "cosmicpower", "dynamaxcannon", "flamethrower", "recover" ],
+        tier: "Uber",
+        doublesTier: "DUber",
+    },
+    eternatuseternamax: {
+        isNonstandard: "Unobtainable",
+        tier: "Illegal",
+    },
+    missingno: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
+    syclar: {
+        isNonstandard: "CAP",
+        tier: "CAP LC",
+    },
+    syclant: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    revenankh: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    embirch: {
+        isNonstandard: "CAP",
+        tier: "CAP LC",
+    },
+    flarelm: {
+        isNonstandard: "CAP",
+        tier: "CAP NFE",
+    },
+    pyroak: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    breezi: {
+        isNonstandard: "CAP",
+        tier: "CAP LC",
+    },
+    fidgit: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    rebble: {
+        isNonstandard: "CAP",
+        tier: "CAP LC",
+    },
+    tactite: {
+        isNonstandard: "CAP",
+        tier: "CAP NFE",
+    },
+    stratagem: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    privatyke: {
+        isNonstandard: "CAP",
+        tier: "CAP LC",
+    },
+    arghonaut: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    kitsunoh: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    cyclohm: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    colossoil: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    krilowatt: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    voodoll: {
+        isNonstandard: "CAP",
+        tier: "CAP LC",
+    },
+    voodoom: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    scratchet: {
+        isNonstandard: "CAP",
+        tier: "CAP LC",
+    },
+    tomohawk: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    necturine: {
+        isNonstandard: "CAP",
+        tier: "CAP LC",
+    },
+    necturna: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    mollux: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    cupra: {
+        isNonstandard: "CAP",
+        tier: "CAP LC",
+    },
+    argalis: {
+        isNonstandard: "CAP",
+        tier: "CAP NFE",
+    },
+    aurumoth: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    brattler: {
+        isNonstandard: "CAP",
+        tier: "CAP LC",
+    },
+    malaconda: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    cawdet: {
+        isNonstandard: "CAP",
+        tier: "CAP LC",
+    },
+    cawmodore: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    volkritter: {
+        isNonstandard: "CAP",
+        tier: "CAP LC",
+    },
+    volkraken: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    snugglow: {
+        isNonstandard: "CAP",
+        tier: "CAP LC",
+    },
+    plasmanta: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    floatoy: {
+        isNonstandard: "CAP",
+        tier: "CAP LC",
+    },
+    caimanoe: {
+        isNonstandard: "CAP",
+        tier: "CAP NFE",
+    },
+    naviathan: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    crucibelle: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    crucibellemega: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    pluffle: {
+        isNonstandard: "CAP",
+        tier: "CAP LC",
+    },
+    kerfluffle: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    pajantom: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    mumbao: {
+        isNonstandard: "CAP",
+        tier: "CAP LC",
+    },
+    jumbao: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    fawnifer: {
+        isNonstandard: "CAP",
+        tier: "CAP LC",
+    },
+    electrelk: {
+        isNonstandard: "CAP",
+        tier: "CAP NFE",
+    },
+    caribolt: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    smogecko: {
+        isNonstandard: "CAP",
+        tier: "CAP LC",
+    },
+    smoguana: {
+        isNonstandard: "CAP",
+        tier: "CAP NFE",
+    },
+    smokomodo: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    swirlpool: {
+        isNonstandard: "CAP",
+        tier: "CAP LC",
+    },
+    coribalis: {
+        isNonstandard: "CAP",
+        tier: "CAP NFE",
+    },
+    snaelstrom: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    equilibra: {
+        isNonstandard: "CAP",
+        tier: "CAP",
+    },
+    pokestarsmeargle: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
+    pokestarufo: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
+    pokestarufo2: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
+    pokestarbrycenman: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
+    pokestarmt: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
+    pokestarmt2: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
+    pokestartransport: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
+    pokestargiant: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
+    pokestargiant2: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
+    pokestarhumanoid: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
+    pokestarmonster: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
+    pokestarf00: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
+    pokestarf002: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
+    pokestarspirit: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
+    pokestarblackdoor: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
+    pokestarwhitedoor: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
+    pokestarblackbelt: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
+    pokestargiantpropo2: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
+    pokestarufopropu2: {
+        isNonstandard: "Custom",
+        tier: "Illegal",
+    },
 };

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1271,31 +1271,7 @@ export class RandomTeams {
 		let level: number;
 
 		if (!isDoubles) {
-			const levelScale: {[tier: string]: number} = {
-				uber: 72, ou: 80, uu: 82, ru: 84, nu: 86, pu: 88,
-			};
-			const customScale: {[species: string]: number} = {
-				Glalie: 72, 'Darmanitan-Galar-Zen': 80, Wobbuffet: 80, Zygarde: 80,
-				Delibird: 100, Shedinja: 100,
-			};
-			let tier = toID((species.isGigantamax ? this.dex.getSpecies(species.baseSpecies) : species).tier).replace('bl', '');
-			// For future DLC Pokemon
-			if (tier === 'illegal') {
-				tier = toID(this.dex.mod('gen7').getSpecies(species.name).tier);
-				switch (tier) {
-				case 'uubl': case 'uu':
-					tier = 'ou';
-					break;
-				case 'rubl': case 'ru':
-					tier = 'uu';
-					break;
-				case 'nubl': case 'nu': case 'publ': case 'pu':
-					tier = 'ru';
-					break;
-				}
-			}
-			level = levelScale[tier] || (species.nfe ? 90 : 80);
-			if (customScale[species.name]) level = customScale[species.name];
+			level = species.randomBattleLevel; 
 		} else {
 			// We choose level based on BST. Min level is 70, max level is 100. 640+ BST is 70, 330 or lower is 100. Calculate with those values.
 			// Every 10.3 BST adds a level from 70 up to 100. Results are floored.

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -672,6 +672,7 @@ export class Species extends BasicEffect implements Readonly<BasicEffect & Speci
 	 */
 	readonly doublesTier: string;
 	readonly randomBattleMoves?: readonly ID[];
+	readonly randomBattleLevel?: number;
 	readonly randomDoubleBattleMoves?: readonly ID[];
 	readonly exclusiveMoves?: readonly ID[];
 	readonly comboMoves?: readonly ID[];


### PR DESCRIPTION
This request is in preparation for a level scaling system of Random Battles Pokemon that does not depend on tier.
1. Add a randomBattleLevel field to SpeciesFormatData in dex-data.ts,
2. instantiate the random battle levels for each species in
formats-data.ts (according to current tiering + custom level scales),
3. access this level in random-teams.ts