### PR TITLE
Add forme-exclusive move validator tests

### DIFF
--- a/test/sim/team-validator.js
+++ b/test/sim/team-validator.js
@@ -512,6 +512,34 @@ describe('Team Validator', function () {
 		assert(illegal);
 	});
 
+	it('should reject Pokemon that cannot obtain moves in a particular forme', function () {
+		let team = [
+			{species: 'toxicrity', ability: 'punkrock', moves: ['venomdrench, magneticflux'], evs: {hp: 1}},
+			{species: 'toxicrity-low-key', ability: 'punkrock', moves: ['venoshock, shiftgear'], evs: {hp: 1}},
+		];
+		let illegal = TeamValidator.get('gen8anythinggoes').validateTeam(team);
+		assert(illegal);
+
+		team = [
+			{species: 'rotom-wash', ability: 'levitate', moves: ['overheat'], evs: {hp: 1}},
+		];
+		illegal = TeamValidator.get('gen8anythinggoes').validateTeam(team);
+		assert(illegal);
+
+		team = [
+			{species: 'kyurem-black', ability: 'teravolt', moves: ['glaciate'], evs: {hp: 1}},
+		];
+		illegal = TeamValidator.get('gen8anythinggoes').validateTeam(team);
+		assert(illegal);
+
+		// Scary Face is a TM in Gen 8, so use Gen 7 to test
+		team = [
+			{species: 'kyurem-white', ability: 'turboblaze', moves: ['scaryface'], evs: {hp: 1}},
+		];
+		illegal = TeamValidator.get('gen7anythinggoes').validateTeam(team);
+		assert(illegal);
+	});
+
 	/*********************************************************
  	* Custom rules
  	*********************************************************/

--- a/test/sim/team-validator.js
+++ b/test/sim/team-validator.js
@@ -512,7 +512,7 @@ describe('Team Validator', function () {
 		assert(illegal);
 	});
 
-	it('should reject Pokemon that cannot obtain moves in a particular forme', function () {
+	it.skip('should reject Pokemon that cannot obtain moves in a particular forme', function () {
 		let team = [
 			{species: 'toxicrity', ability: 'punkrock', moves: ['venomdrench, magneticflux'], evs: {hp: 1}},
 			{species: 'toxicrity-low-key', ability: 'punkrock', moves: ['venoshock, shiftgear'], evs: {hp: 1}},


### PR DESCRIPTION
Kyurem-B and Kyurem-W should not have access to Glaciate (all gens) or Scary Face (pre-Gen 8, since it was made a TM in Gen 8). It also adds cases for Toxicrity and Rotom, which pass.