### PR TITLE
Fix the rename command to log the new room & require a target

### DIFF
--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -822,8 +822,6 @@ export const commands: ChatCommands = {
 			return this.errorReply(`An error occured while renaming the room.`);
 		}
 		this.modlog(`RENAMEROOM`, null, `from ${oldTitle}`);
-		room.log.roomlogFilename = "";
-		await room.log.setupRoomlogStream(true);
 		const privacy = room.isPrivate === true ? "Private" :
 			room.isPrivate === false ? "Public" :
 			`${room.isPrivate.charAt(0).toUpperCase()}${room.isPrivate.slice(1)}`;

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -809,6 +809,7 @@ export const commands: ChatCommands = {
 		const oldTitle = room.title;
 		const roomid = toID(target) as RoomID;
 		const roomtitle = target;
+		if (!roomid.length) return this.errorReply("The new room needs a title.");
 		// `,` is a delimiter used by a lot of /commands
 		// `|` and `[` are delimiters used by the protocol
 		// `-` has special meaning in roomids
@@ -821,6 +822,8 @@ export const commands: ChatCommands = {
 			return this.errorReply(`An error occured while renaming the room.`);
 		}
 		this.modlog(`RENAMEROOM`, null, `from ${oldTitle}`);
+		room.log.roomlogFilename = "";
+		room.log.setupRoomlogStream(true);
 		const privacy = room.isPrivate === true ? "Private" :
 			room.isPrivate === false ? "Public" :
 			`${room.isPrivate.charAt(0).toUpperCase()}${room.isPrivate.slice(1)}`;

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -823,7 +823,7 @@ export const commands: ChatCommands = {
 		}
 		this.modlog(`RENAMEROOM`, null, `from ${oldTitle}`);
 		room.log.roomlogFilename = "";
-		room.log.setupRoomlogStream(true);
+		await room.log.setupRoomlogStream(true);
 		const privacy = room.isPrivate === true ? "Private" :
 			room.isPrivate === false ? "Public" :
 			`${room.isPrivate.charAt(0).toUpperCase()}${room.isPrivate.slice(1)}`;

--- a/server/roomlogs.ts
+++ b/server/roomlogs.ts
@@ -274,6 +274,7 @@ export class Roomlog {
 		}
 		if (roomlogStreamExisted) {
 			this.roomlogStream = undefined;
+			this.roomlogFilename = "";
 			await this.setupRoomlogStream(true);
 		}
 		return true;


### PR DESCRIPTION
If someone were to type ``/rename `` it would then glitch any server that has the autojoin for lobby enabled. Also for whatever reason it just didn't log the newly named room in chat logs.