### PR TITLE
Add various mechanics tests

### DIFF
--- a/test/sim/abilities/steelyspirit.js
+++ b/test/sim/abilities/steelyspirit.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Steely Spirit', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should boost Steel-type moves for its ally and itself', function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'aron', ability: 'steelyspirit', moves: ['ironhead']},
+			{species: 'aron', moves: ['ironhead']},
+		], [
+			{species: 'wynaut', moves: ['sleeptalk']},
+			{species: 'wynaut', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move ironhead 1, move ironhead 2', 'auto');
+		const wynautLeft = battle.p2.active[0];
+		let damage = wynautLeft.maxhp - wynautLeft.hp;
+		assert.bounded(damage, [172, 204]);
+
+		const wynautRight = battle.p2.active[1];
+		damage = wynautRight.maxhp - wynautRight.hp;
+		assert.bounded(damage, [172, 204]);
+	});
+
+	it('should stack with itself', function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'aron', ability: 'steelyspirit', moves: ['ironhead']},
+			{species: 'aron', ability: 'steelyspirit', moves: ['ironhead']},
+		], [
+			{species: 'wynaut', moves: ['sleeptalk']},
+			{species: 'wynaut', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move ironhead 1, move ironhead 2', 'auto');
+		const wynautLeft = battle.p2.active[0];
+		let damage = wynautLeft.maxhp - wynautLeft.hp;
+		assert.bounded(damage, [258, 304]);
+
+		const wynautRight = battle.p2.active[1];
+		damage = wynautRight.maxhp - wynautRight.hp;
+		assert.bounded(damage, [258, 304]);
+	});
+});

--- a/test/sim/abilities/symbiosis.js
+++ b/test/sim/abilities/symbiosis.js
@@ -29,4 +29,65 @@ describe('Symbiosis', function () {
 		assert.equal(battle.p1.active[0].item, 'latiasite');
 		assert.equal(battle.p1.active[1].item, '');
 	});
+
+	it.skip('should not trigger on an ally losing their Eject Button in Generation 7 or later', function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'oranguru', ability: 'symbiosis', item: 'leftovers', moves: ['sleeptalk']},
+			{species: 'wynaut', item: 'ejectbutton', moves: ['sleeptalk']},
+			{species: 'corphish', moves: ['sleeptalk']},
+		], [
+			{species: 'wynaut', moves: ['tackle']},
+			{species: 'wynaut', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices('auto', 'move tackle 2, move sleeptalk');
+
+		assert.equal(battle.p1.active[0].item, 'leftovers');
+		assert.equal(battle.p1.active[1].item, '');
+	});
+
+	// See Marty's research for many more examples: https://www.smogon.com/forums/threads/battle-mechanics-research.3489239/post-6401506
+	describe.skip('Symbiosis Eject Button Glitch (Gen 6 only)', function () {
+		it('should cause Leftovers to restore HP 4 times', function () {
+			battle = common.gen(6).createBattle({gameType: 'doubles'}, [[
+				{species: 'florges', ability: 'symbiosis', item: 'leftovers', moves: ['sleeptalk']},
+				{species: 'roggenrola', level: 50, ability: 'sturdy', item: 'ejectbutton', moves: ['sleeptalk']},
+				{species: 'corphish', moves: ['sleeptalk']},
+			], [
+				{species: 'wynaut', moves: ['sleeptalk', 'closecombat']},
+				{species: 'wynaut', moves: ['sleeptalk']},
+			]]);
+
+			battle.makeChoices('auto', 'move closecombat 2, move sleeptalk');
+			assert.equal(battle.p1.active[0].item, '');
+			assert.equal(battle.p1.active[1].item, 'leftovers');
+			battle.makeChoices('switch 3');
+			battle.makeChoices('move sleeptalk, switch 3', 'auto');
+
+			// Close Combat brought Roggenrola down to Sturdy = 1 HP
+			const roggenrola = battle.p1.active[1];
+			const targetHP = 1 + (Math.floor(roggenrola.maxhp / 16) * 4);
+			assert.equal(targetHP, roggenrola.hp);
+		});
+
+		it('should cause Choice items to apply 2 times', function () {
+			battle = common.gen(6).createBattle({gameType: 'doubles'}, [[
+				{species: 'florges', ability: 'symbiosis', item: 'choiceband', moves: ['sleeptalk']},
+				{species: 'roggenrola', evs: {atk: 8}, item: 'ejectbutton', moves: ['smackdown']},
+				{species: 'corphish', moves: ['sleeptalk']},
+			], [
+				{species: 'wynaut', moves: ['sleeptalk', 'tackle']},
+				{species: 'torkoal', moves: ['sleeptalk']},
+			]]);
+
+			battle.makeChoices('auto', 'move tackle 2, move sleeptalk');
+			battle.makeChoices('switch 3');
+			battle.makeChoices('move sleeptalk, switch 3', 'auto');
+			battle.makeChoices('move sleeptalk, move smackdown 1', 'auto');
+
+			// Choice Band applied twice, effectively making Roggenrola's Attack 423
+			const wynaut = battle.p2.active[0];
+			const damage = wynaut.maxhp - wynaut.hp;
+			assert.bounded(damage, [172, 204]);
+		});
+	});
 });

--- a/test/sim/items/metronome.js
+++ b/test/sim/items/metronome.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Metronome (item)', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should increase the damage of moves that have been used successfully and consecutively', function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', item: 'metronome', moves: ['psystrike']},
+		], [
+			{species: 'cleffa', evs: {hp: 252}, ability: 'shellarmor', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		const cleffa = battle.p2.active[0];
+		const hpAfterOneAttack = cleffa.hp;
+		battle.makeChoices();
+		const damage = hpAfterOneAttack - cleffa.hp;
+		assert.bounded(damage, [115, 137]);
+	});
+
+	it('should reset the multiplier after switching moves', function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', item: 'metronome', moves: ['psystrike', 'sleeptalk']},
+		], [
+			{species: 'cleffa', evs: {hp: 252}, ability: 'shellarmor', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		const cleffa = battle.p2.active[0];
+		const hpAfterOneAttack = cleffa.hp;
+		battle.makeChoices('move sleeptalk', 'auto');
+		battle.makeChoices();
+		const damage = hpAfterOneAttack - cleffa.hp;
+		assert.bounded(damage, [96, 114]);
+	});
+
+	it('should reset the multiplier after hitting Protect', function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', item: 'metronome', moves: ['psystrike']},
+		], [
+			{species: 'cleffa', evs: {hp: 252}, ability: 'shellarmor', moves: ['sleeptalk', 'protect']},
+		]]);
+		battle.makeChoices();
+		const cleffa = battle.p2.active[0];
+		const hpAfterOneAttack = cleffa.hp;
+		battle.makeChoices('auto', 'move protect');
+		battle.makeChoices();
+		const damage = hpAfterOneAttack - cleffa.hp;
+		assert.bounded(damage, [96, 114]);
+	});
+
+	// See research: https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/post-8470799
+	it('should instantly start moves that use a charging turn at Metronome 1 boost level, then increase linearly', function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', item: 'metronome', moves: ['solarbeam']},
+		], [
+			{species: 'cleffa', evs: {hp: 252}, ability: 'shellarmor', moves: ['sleeptalk', 'protect']},
+		]]);
+		battle.makeChoices();
+		battle.makeChoices();
+		const cleffa = battle.p2.active[0];
+		const damage = cleffa.maxhp - cleffa.hp;
+		assert.bounded(damage, [59, 70]);
+	});
+});

--- a/test/sim/items/metronome.js
+++ b/test/sim/items/metronome.js
@@ -55,7 +55,7 @@ describe('Metronome (item)', function () {
 	});
 
 	// See research: https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/post-8470799
-	it('should instantly start moves that use a charging turn at Metronome 1 boost level, then increase linearly', function () {
+	it.skip('should instantly start moves that use a charging turn at Metronome 1 boost level, then increase linearly', function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', item: 'metronome', moves: ['solarbeam']},
 		], [

--- a/test/sim/misc/dynamax.js
+++ b/test/sim/misc/dynamax.js
@@ -118,16 +118,4 @@ describe("Dynamax", function () {
 		battle.makeChoices('move 1', 'auto');
 		assert.cantMove(() => battle.choose('p1', 'move splash dynamax'));
 	});
-
-	it('Max Guard should be disallowed by Taunt', function () {
-		battle = common.createBattle([[
-			{species: "Feebas", moves: ['splash', 'tackle']},
-		], [
-			{species: "Wynaut", moves: ['taunt', 'splash']},
-		]]);
-		battle.makeChoices('move tackle dynamax', 'auto');
-		// battle.makeChoices('move splash', 'auto');
-		// console.log(battle.getDebugLog());
-		assert.cantMove(() => battle.choose('p1', 'move splash'), 'Feebas', 'Max Guard', false);
-	});
 });

--- a/test/sim/misc/target-resolution.js
+++ b/test/sim/misc/target-resolution.js
@@ -198,4 +198,19 @@ describe('Target Resolution', function () {
 			assert.notEqual(battle.p2.active[1].hp, battle.p2.active[1].maxhp);
 		});
 	});
+
+	it.skip('should not force charge moves called by another move to target an ally after Ally Switch', function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'purrloin', ability: 'prankster', moves: ['copycat', 'sleeptalk']},
+			{species: 'wynaut', moves: ['allyswitch', 'solarbeam']},
+		], [
+			{species: 'swablu', moves: ['sleeptalk']},
+			{species: 'swablu', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move sleeptalk, move solarbeam 1', 'auto');
+		battle.makeChoices();
+		battle.makeChoices();
+		assert.fullHP(battle.p1.active[0]);
+	});
 });

--- a/test/sim/moves/fling.js
+++ b/test/sim/moves/fling.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Fling', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should consume the user\'s item after being flung', function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', item: 'ironball', moves: ['fling']},
+		], [
+			{species: 'cleffa', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].item, '');
+	});
+
+	it('should apply custom effects when certain items are flung', function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', item: 'flameorb', moves: ['fling']},
+		], [
+			{species: 'cleffa', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		assert.equal(battle.p2.active[0].status, 'brn');
+	});
+
+	it('should not be usuable in Magic Room', function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', item: 'ironball', moves: ['fling']},
+		], [
+			{species: 'cleffa', moves: ['magicroom']},
+		]]);
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].item, 'ironball');
+	});
+
+	it.skip('should use its item to be flung in damage calculations', function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', item: 'lifeorb', moves: ['fling']},
+		], [
+			{species: 'cleffa', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+
+		// Fling's damage should be boosted by Life Orb
+		const cleffa = battle.p2.active[0];
+		const damage = cleffa.maxhp - cleffa.hp;
+		assert.bounded(damage, [13, 16]);
+
+		// Wynaut should not have taken Life Orb recoil
+		assert.fullHP(battle.p1.active[0]);
+	});
+});

--- a/test/sim/moves/maxguard.js
+++ b/test/sim/moves/maxguard.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Max Guard', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should be disallowed by Taunt', function () {
+		battle = common.createBattle([[
+			{species: "Feebas", moves: ['splash', 'tackle']},
+		], [
+			{species: "Wynaut", moves: ['taunt', 'splash']},
+		]]);
+		battle.makeChoices('move tackle dynamax', 'auto');
+		assert.cantMove(() => battle.choose('p1', 'move splash'), 'Feebas', 'Max Guard', false);
+	});
+
+	it('should allow Feint to damage the user, but not break the protection effect', function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'minun', moves: ['sleeptalk']},
+			{species: 'plusle', moves: ['sleeptalk']},
+		], [
+			{species: 'wynaut', ability: 'noguard', moves: ['fissure']},
+			{species: 'wynaut', moves: ['feint']},
+		]]);
+		battle.makeChoices('move sleeptalk dynamax, move sleeptalk', 'move fissure 1, move feint 1');
+
+		const minun = battle.p1.active[0];
+		assert.false.fainted(minun);
+	});
+
+	it.skip('should block certain moves that bypass Protect', function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'minun', ability: 'plus', moves: ['sleeptalk']},
+			{species: 'plusle', moves: ['magneticflux']},
+		], [
+			{species: 'wynaut', item: 'powerherb', moves: ['phantomforce']},
+			{species: 'wynaut', ability: 'intrepidsword', moves: ['psychup']},
+		]]);
+		battle.makeChoices('move sleeptalk dynamax, move magneticflux', 'move phantomforce 1, move psychup 1');
+
+		const minun = battle.p1.active[0];
+		assert.statStage(minun, 'def', 0);
+		assert.statStage(minun, 'spd', 0);
+		assert.fullHP(minun);
+		assert.statStage(battle.p2.active[1], 'atk', 1);
+	});
+});

--- a/test/sim/moves/tarshot.js
+++ b/test/sim/moves/tarshot.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Tar Shot', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should cause subsequent Fire-type attacks to deal 2x damage as a type chart multiplier', function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', moves: ['tarshot', 'fusionflare']},
+		], [
+			{species: 'cleffa', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		battle.makeChoices('move fusionflare', 'auto');
+		const cleffa = battle.p2.active[0];
+		const damage = cleffa.maxhp - cleffa.hp;
+		assert.bounded(damage, [82, 98]);
+	});
+
+	it('should cause Fire-type attacks to trigger Weakness Policy', function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', moves: ['tarshot', 'fusionflare']},
+		], [
+			{species: 'cleffa', item: 'weaknesspolicy', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		battle.makeChoices('move fusionflare', 'auto');
+		assert.equal(battle.p2.active[0].item, '');
+		assert.statStage(battle.p2.active[0], 'atk', 2);
+		assert.statStage(battle.p2.active[0], 'spa', 2);
+	});
+
+	it.skip('should not interact with Delta Stream', function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'wobbuffet', moves: ['tarshot']},
+			{species: 'wynaut', moves: ['fusionflare']},
+		], [
+			{species: 'tornadus', moves: ['sleeptalk']},
+			{species: 'thundurus', ability: 'deltastream', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices('move tarshot 1, move fusionflare 1', 'auto');
+		const torn = battle.p2.active[0];
+		const damage = torn.maxhp - torn.hp;
+		assert.bounded(damage, [62, 74]);
+	});
+});


### PR DESCRIPTION
Specifically, Fling, Tar Shot, Symbiosis, Steely Spirit, the item Metronome, Max Guard, and a bizarre interaction with moves that call other moves + moves that have a charge turn + Ally Switch all have additional tests. There are 8 skipped tests in here to account for the mechanics bugs reported so far in the new bug reports thread (up to post 61) as well as 11 passing tests to complement behavior and hopefully ensure behavior doesn't regress if any of the failing tests are tackled.