### PR TITLE
Life Orb + Emergency Exit Interaction Fix

### DIFF
--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -285,6 +285,11 @@ export const BattleScripts: BattleScriptsData = {
 		if (!move.negateSecondary && !(move.hasSheerForce && pokemon.hasAbility('sheerforce'))) {
 			this.singleEvent('AfterMoveSecondarySelf', move, null, pokemon, target, move);
 			this.runEvent('AfterMoveSecondarySelf', pokemon, target, move);
+			if (pokemon && pokemon !== target && move && move.category !== 'Status') {
+				if (pokemon.hp <= pokemon.maxhp / 2) {
+					this.runEvent('EmergencyExit', pokemon, pokemon);
+				}
+			}
 		}
 
 		return true;

--- a/test/sim/abilities/emergencyexit.js
+++ b/test/sim/abilities/emergencyexit.js
@@ -108,7 +108,7 @@ describe(`Emergency Exit`, function () {
 		assert.equal(battle.requestState, 'switch');
 	});
 
-	it.skip('should request switch-out after taking Life Orb recoil', function () {
+	it('should request switch-out after taking Life Orb recoil', function () {
 		battle = common.createBattle([[
 			{species: "Golisopod", item: "lifeorb", ability: 'emergencyexit', moves: ['peck']},
 			{species: "Wynaut", moves: ['sleeptalk']},


### PR DESCRIPTION
Life Orb should trigger Emergency Exit.
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/page-2#post-8465511

I apologize if this isn't the cleanest way to do it. I initially had placed the Emergency Exit runEvent inside of Life Orb's code but I know that's not an acceptable way to accomplish this. This passes all tests and I believe should be okay, but if there's tweaks I should make to it, please let me know.