### PR TITLE
Fix Battle Substitutions

### DIFF
--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1048,7 +1048,7 @@ export class RoomBattle extends RoomGames.RoomGame {
 			};
 			void this.stream.write(`>player ${slot} ` + JSON.stringify(options));
 
-			for (const battler of this.room.battle.players) {
+			for (const battler of this.room.battle.?players ?? []) {
 				if (battler.id === player.id) battler.id = '';
 			}
 

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1048,7 +1048,7 @@ export class RoomBattle extends RoomGames.RoomGame {
 			};
 			void this.stream.write(`>player ${slot} ` + JSON.stringify(options));
 
-			for (const battler of this.room.battle.?players ?? []) {
+			for (const battler of this.room.battle?.players ?? []) {
 				if (battler.id === player.id) battler.id = '';
 			}
 

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1049,7 +1049,7 @@ export class RoomBattle extends RoomGames.RoomGame {
 			void this.stream.write(`>player ${slot} ` + JSON.stringify(options));
 
 			for (const battler of this.room.battle.players) {
-				if (battler.id === player.id) battler.id = null;
+				if (battler.id === player.id) battler.id = '';
 			}
 
 			this.room.add(`|player|${slot}|`);

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1048,7 +1048,9 @@ export class RoomBattle extends RoomGames.RoomGame {
 			};
 			void this.stream.write(`>player ${slot} ` + JSON.stringify(options));
 
-			for (const battler of this.room.battle?.players ?? []) {
+			if (!this.room.battle) throw new Error(`Battle ${this.roomid} not found`);
+
+			for (const battler of this.room.battle.players) {
 				if (battler.id === player.id) battler.id = '';
 			}
 

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1048,6 +1048,10 @@ export class RoomBattle extends RoomGames.RoomGame {
 			};
 			void this.stream.write(`>player ${slot} ` + JSON.stringify(options));
 
+			for (const battler of this.room.battle.players) {
+				if (battler.id === player.id) battler.id = null;
+			}
+
 			this.room.add(`|player|${slot}|`);
 		}
 	}

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1048,9 +1048,7 @@ export class RoomBattle extends RoomGames.RoomGame {
 			};
 			void this.stream.write(`>player ${slot} ` + JSON.stringify(options));
 
-			if (!this.room.battle) throw new Error(`Battle ${this.roomid} not found`);
-
-			for (const battler of this.room.battle.players) {
+			for (const battler of this.players) {
 				if (battler.id === player.id) battler.id = '';
 			}
 


### PR DESCRIPTION
Right now, it just doesn't detect the slot, and then doesn't sub properly. (The old code, I mean.)

**NOTE:** 
I've tested these changes on a sideserver, where they worked during normal challenge battles. I have not tested on rated battles or tournament battles, but those shouldn't be affected. 
There have been no crashes on renames or multi-substituting until the original players are switched; but I'm not completely sure if that's all that this was meant to handle - are there any cases I'm missing?