### PR TITLE
Add Emergency Exit tests for new bugged behavior

### DIFF
--- a/test/sim/abilities/emergencyexit.js
+++ b/test/sim/abilities/emergencyexit.js
@@ -217,4 +217,36 @@ describe(`Emergency Exit`, function () {
 		assert.atMost(eePokemon.hp, eePokemon.maxhp / 2);
 		assert.equal(battle.requestState, 'move');
 	});
+
+	it.skip('should not request switchout if its HP is already below 50%', function () {
+		battle = common.createBattle([[
+			{species: "Golisopod", evs: {hp: 4}, ability: 'emergencyexit', moves: ['sleeptalk', 'tackle']},
+			{species: "Wynaut", moves: ['sleeptalk']},
+		], [
+			{species: "stufful", ability: 'compoundeyes', moves: ['superfang', 'sleeptalk']},
+		]]);
+		battle.makeChoices();
+		battle.makeChoices('switch 2');
+
+		// Switch Goliosopod back in
+		battle.makeChoices('switch 2', 'auto');
+		battle.makeChoices('move tackle', 'move sleeptalk');
+		assert.equal(battle.requestState, 'move');
+	});
+
+	it('should request switchout if its HP was restored to above 50% and brought down again', function () {
+		battle = common.createBattle([[
+			{species: "Golisopod", evs: {hp: 4}, ability: 'emergencyexit', moves: ['sleeptalk']},
+			{species: "Wynaut", moves: ['sleeptalk']},
+		], [
+			{species: "stufful", ability: 'compoundeyes', moves: ['superfang', 'healpulse']},
+		]]);
+		battle.makeChoices();
+		battle.makeChoices('switch 2');
+
+		// Switch Goliosopod back in and heal it before switching it back out again
+		battle.makeChoices('switch 2', 'move healpulse');
+		battle.makeChoices('auto', 'move superfang');
+		assert.equal(battle.requestState, 'switch');
+	});
 });


### PR DESCRIPTION
fart's change in https://github.com/smogon/pokemon-showdown/pull/6738 unfortunately broke Emergency Exit in another way; it's requesting switchout if its HP is already below 50%, see bugged behavior turn 17: https://replay.pokemonshowdown.com/gen8randombattle-1122012552

Adds skipped test (what's failing) and passing test for if Emergency Exit heals HP above 50% and gets brought back down again (currently passing)