### PR TITLE
Add more move target types to /details

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -738,6 +738,9 @@ export const commands: ChatCommands = {
 						allAdjacent: "All Adjacent Pok\u00e9mon",
 						any: "Any Pok\u00e9mon",
 						all: "All Pok\u00e9mon",
+						scripted: "Opposing Pok\u00e9mon that last dealt damage to the user",
+						randomNormal: "Random Opposing Pok\u00e9mon",
+						allies: "User and Allies",
 					};
 					details["Target"] = targetTypes[move.target] || "Unknown";
 

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -739,7 +739,7 @@ export const commands: ChatCommands = {
 						any: "Any Pok\u00e9mon",
 						all: "All Pok\u00e9mon",
 						scripted: "Opposing Pok\u00e9mon that last dealt damage to the user",
-						randomNormal: "Random Opposing Pok\u00e9mon",
+						randomNormal: "Random Adjacent Opposing Pok\u00e9mon",
 						allies: "User and Allies",
 					};
 					details["Target"] = targetTypes[move.target] || "Unknown";

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -738,7 +738,7 @@ export const commands: ChatCommands = {
 						allAdjacent: "All Adjacent Pok\u00e9mon",
 						any: "Any Pok\u00e9mon",
 						all: "All Pok\u00e9mon",
-						scripted: "Opposing Pok\u00e9mon that last dealt damage to the user",
+						scripted: "Chosen Automatically",
 						randomNormal: "Random Adjacent Opposing Pok\u00e9mon",
 						allies: "User and Allies",
 					};


### PR DESCRIPTION
This is a pretty minor issue but I stumbled upon it while adding searching by target to `/movesearch` so I figured I'd just open a PR fixing it.