### PR TITLE
Tournaments: escape usernames in /tour getusers

### DIFF
--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -1179,8 +1179,8 @@ const tourCommands: {basic: TourCommands, creation: TourCommands, moderation: To
 			if (!this.runBroadcast()) return;
 			const users = usersToNames(tournament.getRemainingPlayers().sort());
 			this.sendReplyBox(
-				Chat.html`<strong>${users.length}/${tournament.players.length}` +
-				` users remain in this tournament:</strong><br />${users.join(', ')}`
+				`<strong>${users.length}/${tournament.players.length}` +
+				` users remain in this tournament:</strong><br />${Chat.escapeHTML(users.join(', '))}`
 			);
 		},
 		getupdate(tournament, user) {

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -1180,7 +1180,7 @@ const tourCommands: {basic: TourCommands, creation: TourCommands, moderation: To
 			const users = usersToNames(tournament.getRemainingPlayers().sort());
 			this.sendReplyBox(
 				`<strong>${users.length}/${tournament.players.length}` +
-				` users remain in this tournament:</strong><br />${Chat.escapeHTML(users.join(', '))}`
+				Chat.html` users remain in this tournament:</strong><br />${users.join(', ')}`
 			);
 		},
 		getupdate(tournament, user) {


### PR DESCRIPTION
Fixes the bug shown in the attached image.
<img width="273" alt="Skärmavbild 2020-05-29 kl  2 04 14 em" src="https://user-images.githubusercontent.com/56906084/83305526-d1d87d80-a1b5-11ea-97fb-fc774836b70a.png">
