### PR TITLE
Fix bugs caused by not specifying effectiveness priority

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -18456,6 +18456,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 			onStart(pokemon) {
 				this.add('-start', pokemon, 'Tar Shot');
 			},
+			onEffectivenessPriority: -2,
 			onEffectiveness(typeMod, target, type, move) {
 				if (move.type !== 'Fire') return;
 				if (!target) return;

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -869,6 +869,7 @@ export const BattleFormats: {[k: string]: FormatsData} = {
 		onBegin() {
 			this.add('rule', 'Inverse Mod: Weaknesses become resistances, while resistances and immunities become weaknesses.');
 		},
+		onEffectivenessPriority: 1,
 		onEffectiveness(typeMod, target, type, move) {
 			// The effectiveness of Freeze Dry on Water isn't reverted
 			if (move && move.id === 'freezedry' && type === 'Water') return;

--- a/data/statuses.ts
+++ b/data/statuses.ts
@@ -644,6 +644,7 @@ export const BattleStatuses: {[k: string]: PureEffectData} = {
 		name: 'DeltaStream',
 		effectType: 'Weather',
 		duration: 0,
+		onEffectivenessPriority: -1,
 		onEffectiveness(typeMod, target, type, move) {
 			if (move && move.effectType === 'Move' && move.category !== 'Status' && type === 'Flying' && typeMod > 0) {
 				this.add('-activate', '', 'deltastream');

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -727,6 +727,7 @@ interface EventMethods {
 	onBoostPriority?: number;
 	onDamagePriority?: number;
 	onDragOutPriority?: number;
+	onEffectivenessPriority?: number;
 	onFoeBasePowerPriority?: number;
 	onFoeBeforeMovePriority?: number;
 	onFoeModifyDefPriority?: number;

--- a/test/sim/misc/inversebattle.js
+++ b/test/sim/misc/inversebattle.js
@@ -54,6 +54,22 @@ describe('Inverse Battle', function () {
 		}
 	});
 
+	it('should affect the resistance of Delta Stream', function () {
+		battle.setPlayer('p1', {team: [{species: "Rayquaza-Mega", ability: 'deltastream', moves: ['hiddenpowerbug']}]});
+		battle.setPlayer('p2', {team: [{species: "Rayquaza-Mega", ability: 'deltastream', moves: ['hiddenpowerbug']}]});
+		battle.makeChoices('move hiddenpower', 'move hiddenpower');
+		battle.makeChoices('move hiddenpower', 'move hiddenpower');
+		assert.ok(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+	});
+
+	it('should make Ghost/Grass types take neutral damage from Flying Press', function () {
+		battle.setPlayer('p1', {team: [{species: "Hawlucha", ability: 'unburden', moves: ['flyingpress']}]});
+		battle.setPlayer('p2', {team: [{species: "Gourgeist", ability: 'insomnia', moves: ['shadowsneak']}]});
+		battle.makeChoices('move flyingpress', 'move shadowsneak');
+		battle.makeChoices('move flyingpress', 'move shadowsneak');
+		assert.ok(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+	});
+
 	it('should not affect ability-based immunities', function () {
 		battle.setPlayer('p1', {team: [{species: "Hariyama", ability: 'guts', moves: ['earthquake']}]});
 		battle.setPlayer('p2', {team: [{species: "Mismagius", ability: 'levitate', moves: ['shadowsneak']}]});

--- a/test/sim/moves/tarshot.js
+++ b/test/sim/moves/tarshot.js
@@ -36,7 +36,7 @@ describe('Tar Shot', function () {
 		assert.statStage(battle.p2.active[0], 'spa', 2);
 	});
 
-	it.skip('should not interact with Delta Stream', function () {
+	it('should not interact with Delta Stream', function () {
 		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: 'wobbuffet', moves: ['tarshot']},
 			{species: 'wynaut', moves: ['fusionflare']},


### PR DESCRIPTION
Inverse Mod needs to go first, to calculate the negated effectiveness.
Disguise goes second, to suppress effectiveness.
Delta Stream goes third, to weaken moves super-effective against Flying types.
Tar Shot goes last, to make its victim weak to Fire type moves.

This allows the existing test for Delta Stream with Tar Shot to pass.
Additionally a new test for Delta Stream with Inverse Mod now passes.
A test for Flying Press with Inverse Mod is also included.