### PR TITLE
Disguise breaking prevents critical hits

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -738,6 +738,17 @@ export const BattleAbilities: {[abilityid: string]: AbilityData} = {
 				return 0;
 			}
 		},
+		onCriticalHit(target, source, move) {
+			if (!target) return;
+			if (!['mimikyu', 'mimikyutotem'].includes(target.species.id) || target.transformed) {
+				return;
+			}
+			const hitSub = target.volatiles['substitute'] && !move.flags['authentic'] && !(move.infiltrates && this.gen >= 6);
+			if (hitSub) return;
+
+			if (!target.runImmunity(move.type)) return;
+			return false;
+		},
 		onEffectiveness(typeMod, target, type, move) {
 			if (!target) return;
 			if (!['mimikyu', 'mimikyutotem'].includes(target.species.id) || target.transformed) {
@@ -1534,6 +1545,13 @@ export const BattleAbilities: {[abilityid: string]: AbilityData} = {
 				this.effectData.busted = true;
 				return 0;
 			}
+		},
+		onCriticalHit(target, type, move) {
+			if (!target) return;
+			if (move.category !== 'Physical' || target.species.id !== 'eiscue' || target.transformed) return;
+			if (target.volatiles['substitute'] && !(move.flags['authentic'] || move.infiltrates)) return;
+			if (!target.runImmunity(move.type)) return;
+			return false;
 		},
 		onEffectiveness(typeMod, target, type, move) {
 			if (!target) return;

--- a/test/sim/abilities/disguise.js
+++ b/test/sim/abilities/disguise.js
@@ -75,7 +75,7 @@ describe('Disguise', function () {
 		assert.hurtsBy(battle.p2.active[0], 1, () => battle.makeChoices());
 	});
 
-	it.skip('should not trigger critical hits while active', function () {
+	it('should not trigger critical hits while active', function () {
 		battle = common.createBattle([[
 			{species: 'Mimikyu', ability: 'disguise', moves: ['sleeptalk']},
 		], [


### PR DESCRIPTION
Basically in the same way that effectiveness is ignored.

Also enabling the test, of course.