### PR TITLE
Simplify handling of `trunc` for custom battles

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -225,7 +225,7 @@ const Formats = [
 		searchShow: false,
 		debug: true,
 		maxLevel: 9999,
-		trunc(n) { return Math.trunc(n); },
+		battle: {trunc: Math.trunc},
 		defaultLevel: 100,
 		teamLength: {
 			validate: [1, 24],
@@ -386,7 +386,7 @@ const Formats = [
 		gameType: 'doubles',
 		searchShow: false,
 		maxLevel: 9999,
-		trunc(n) { return Math.trunc(n); },
+		battle: {trunc: Math.trunc},
 		defaultLevel: 100,
 		debug: true,
 		teamLength: {
@@ -1372,7 +1372,7 @@ const Formats = [
 		searchShow: false,
 		debug: true,
 		maxLevel: 9999,
-		trunc(n) { return Math.trunc(n); },
+		battle: {trunc: Math.trunc},
 		defaultLevel: 100,
 		teamLength: {
 			validate: [1, 24],
@@ -1512,7 +1512,7 @@ const Formats = [
 		gameType: 'doubles',
 		searchShow: false,
 		maxLevel: 9999,
-		trunc(n) { return Math.trunc(n); },
+		battle: {trunc: Math.trunc},
 		defaultLevel: 100,
 		debug: true,
 		teamLength: {
@@ -1678,7 +1678,7 @@ const Formats = [
 		searchShow: false,
 		debug: true,
 		maxLevel: 9999,
-		trunc(n) { return Math.trunc(n); },
+		battle: {trunc: Math.trunc},
 		defaultLevel: 100,
 		// no restrictions, for serious (other than team preview)
 		ruleset: ['Team Preview', 'Cancel Mod'],
@@ -1761,7 +1761,7 @@ const Formats = [
 		gameType: 'doubles',
 		searchShow: false,
 		maxLevel: 9999,
-		trunc(n) { return Math.trunc(n); },
+		battle: {trunc: Math.trunc},
 		defaultLevel: 100,
 		debug: true,
 		// no restrictions, for serious (other than team preview)
@@ -1791,7 +1791,7 @@ const Formats = [
 		gameType: 'triples',
 		searchShow: false,
 		maxLevel: 9999,
-		trunc(n) { return Math.trunc(n); },
+		battle: {trunc: Math.trunc},
 		defaultLevel: 100,
 		debug: true,
 		// no restrictions, for serious (other than team preview)
@@ -1916,7 +1916,7 @@ const Formats = [
 		searchShow: false,
 		debug: true,
 		maxLevel: 9999,
-		trunc(n) { return Math.trunc(n); },
+		battle: {trunc: Math.trunc},
 		defaultLevel: 100,
 		// no restrictions, for serious (other than team preview)
 		ruleset: ['Team Preview', 'Cancel Mod'],
@@ -1965,7 +1965,7 @@ const Formats = [
 		searchShow: false,
 		debug: true,
 		maxLevel: 9999,
-		trunc(n) { return Math.trunc(n); },
+		battle: {trunc: Math.trunc},
 		defaultLevel: 100,
 		// no restrictions, for serious (other than team preview)
 		ruleset: ['Team Preview', 'Cancel Mod'],
@@ -1978,7 +1978,7 @@ const Formats = [
 		searchShow: false,
 		debug: true,
 		maxLevel: 9999,
-		trunc(n) { return Math.trunc(n); },
+		battle: {trunc: Math.trunc},
 		defaultLevel: 100,
 		// no restrictions, for serious (other than team preview)
 		ruleset: ['Team Preview', 'Cancel Mod'],
@@ -2083,7 +2083,7 @@ const Formats = [
 		searchShow: false,
 		debug: true,
 		maxLevel: 9999,
-		trunc(n) { return Math.trunc(n); },
+		battle: {trunc: Math.trunc},
 		defaultLevel: 100,
 		// no restrictions
 		ruleset: ['Cancel Mod'],
@@ -2115,7 +2115,7 @@ const Formats = [
 		searchShow: false,
 		debug: true,
 		maxLevel: 9999,
-		trunc(n) { return Math.trunc(n); },
+		battle: {trunc: Math.trunc},
 		defaultLevel: 100,
 		// no restrictions
 		ruleset: ['Cancel Mod'],
@@ -2186,7 +2186,7 @@ const Formats = [
 		searchShow: false,
 		debug: true,
 		maxLevel: 9999,
-		trunc(n) { return Math.trunc(n); },
+		battle: {trunc: Math.trunc},
 		defaultLevel: 100,
 		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
 	},
@@ -2234,7 +2234,7 @@ const Formats = [
 		searchShow: false,
 		debug: true,
 		maxLevel: 9999,
-		trunc(n) { return Math.trunc(n); },
+		battle: {trunc: Math.trunc},
 		defaultLevel: 100,
 		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
 	},
@@ -2293,7 +2293,7 @@ const Formats = [
 		searchShow: false,
 		debug: true,
 		maxLevel: 9999,
-		trunc(n) { return Math.trunc(n); },
+		battle: {trunc: Math.trunc},
 		defaultLevel: 100,
 		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
 	},

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -147,6 +147,7 @@ export class Battle {
 
 		this.zMoveTable = {};
 		this.maxMoveTable = {};
+		this.trunc = this.dex.trunc;
 		Object.assign(this, this.dex.data.Scripts);
 		if (format.battle) Object.assign(this, format.battle);
 
@@ -210,7 +211,6 @@ export class Battle {
 		this.SILENT_FAIL = null;
 
 		this.send = options.send || (() => {});
-		this.trunc = this.dex.trunc;
 
 		// bound function for faster speedSort
 		// (so speedSort doesn't need to bind before use)
@@ -1611,7 +1611,6 @@ export class Battle {
 		}
 
 		if (format.onBegin) format.onBegin.call(this);
-		if (format.trunc) this.trunc = format.trunc;
 		for (const rule of this.ruleTable.keys()) {
 			if (rule.startsWith('+') || rule.startsWith('-') || rule.startsWith('!')) continue;
 			const subFormat = this.dex.getFormat(rule);
@@ -1637,8 +1636,6 @@ export class Battle {
 
 	restart(send?: (type: string, data: string | string[]) => void) {
 		if (!this.deserialized) throw new Error('Attempt to restart a battle which has not been deserialized');
-
-		if (this.format.trunc) this.trunc = this.format.trunc;
 
 		// @ts-ignore - readonly
 		this.send = send;

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -1229,7 +1229,6 @@ interface FormatsData extends EventMethods {
 		removeNicknames?: boolean,
 		skipSets?: {[name: string]: {[key: string]: boolean}},
 	}) => string[] | void;
-	trunc?: (n: number) => number;
 	section?: string;
 	column?: number;
 }
@@ -1394,6 +1393,7 @@ interface ModdedBattleScriptsData extends Partial<BattleScriptsData> {
 	natureModify?: (this: Battle, stats: StatsTable, set: PokemonSet) => StatsTable;
 	spreadModify?: (this: Battle, baseStats: StatsTable, set: PokemonSet) => StatsTable;
 	suppressingWeather?: (this: Battle) => boolean;
+	trunc?: (n: number) => number;
 
 	// oms
 	doGetMixedSpecies?: (this: Battle, species: Species, deltas: AnyObject) => Species;


### PR DESCRIPTION
Making it a `battle` property means that it doesn't have to be explicitly copied when starting or deserialising battles.