### PR TITLE
Fix display of Gen 8 Nursery Mechanics in `/learn`

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1860,13 +1860,11 @@ export class TeamValidator {
 					}
 
 					// Gen 8 egg moves can be taught to any pokemon from any source
-					if (learned === '8E') learned = '8T';
-
-					if ('LMTR'.includes(learned.charAt(1))) {
+					if (learned === '8E' || 'LMTR'.includes(learned.charAt(1))) {
 						if (learnedGen === dex.gen && learned.charAt(1) !== 'R') {
 							// current-gen level-up, TM or tutor moves:
 							//   always available
-							if (babyOnly) setSources.babyOnly = babyOnly;
+							if (learned !== '8E' && babyOnly) setSources.babyOnly = babyOnly;
 							if (!moveSources.moveEvoCarryCount) return null;
 						}
 						// past-gen level-up, TM, or tutor moves:


### PR DESCRIPTION
If you write `/learn clefable, wish` it says:

In Gen 8, Clefairy can learn Wish from:
- anywhere (move is level-up/tutor/TM/HM/egg in Gen 8)
- must be obtained as Cleffa

The latter is not true, as you can breed a second Cleffa with Wish, evolve it into Clefairy, and then transfer Wish in the Nursery.

I couldn't work out why `/learn clefable, wish, teleport` works even without this though, so maybe there's a special case somewhere else that is no longer necessary.