### PR TITLE
Fix Mandibuzz's Gen 5 tier

### DIFF
--- a/data/mods/gen5/formats-data.ts
+++ b/data/mods/gen5/formats-data.ts
@@ -2728,7 +2728,7 @@ export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mandibuzz: {
 		randomBattleMoves: ["bravebird", "foulplay", "roost", "taunt", "toxic", "uturn", "whirlwind"],
-		tier: "(NU)",
+		tier: "NU",
 		doublesTier: "DUU",
 	},
 	heatmor: {


### PR DESCRIPTION
https://www.smogon.com/forums/threads/official-smogon-university-simulator-statistics-%E2%80%94-august-2013.3487934/ It very clearly has 7% usage in the last tier shift of gen 5, i just accidentally changed its tier when implementing Gen 5's Below NU support