### PR TITLE
Update Gourgeist / Type: Null Doubles Sets

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -4041,7 +4041,7 @@ export const BattleFormatsData: {[k: string]: SpeciesFormatsData} = {
 	gourgeistlarge: {
 		randomBattleMoves: ["leechseed", "powerwhip", "shadowsneak", "substitute", "willowisp"],
 		randomBattleLevel: 88,
-		randomDoubleBattleMoves: ["powerwhip", "protect", "shadowclaw", "shadowsneak", "synthesis", "trickroom"],
+		randomDoubleBattleMoves: ["powerwhip", "protect", "shadowsneak", "synthesis", "trickroom"],
 		unreleasedHidden: true,
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -4049,7 +4049,7 @@ export const BattleFormatsData: {[k: string]: SpeciesFormatsData} = {
 	gourgeistsuper: {
 		randomBattleMoves: ["explosion", "foulplay", "powerwhip", "rockslide", "shadowsneak", "trick"],
 		randomBattleLevel: 88,
-		randomDoubleBattleMoves: ["powerwhip", "protect", "shadowclaw", "shadowsneak", "synthesis", "trickroom"],
+		randomDoubleBattleMoves: ["powerwhip", "protect", "shadowsneak", "synthesis", "trickroom"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
@@ -4416,7 +4416,6 @@ export const BattleFormatsData: {[k: string]: SpeciesFormatsData} = {
 	typenull: {
 		randomBattleMoves: ["crushclaw", "payback", "rest", "sleeptalk", "swordsdance"],
 		randomBattleLevel: 88,
-		randomDoubleBattleMoves: ["doubleedge", "flamecharge", "shadowclaw", "swordsdance", "thunderwave"],
 		tier: "PU",
 		doublesTier: "NFE",
 	},


### PR DESCRIPTION
(i) Gourgeist can't learn Shadow Claw.
(ii) I was also asked by A Cake Wearing A Hat to remove Type: Null's entry from Doubles.