### PR TITLE
CAP: Volkraken and Volkritter are gen 6

### DIFF
--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -15941,7 +15941,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Red",
 		evos: ["Volkraken"],
 		eggGroups: ["Water 1", "Water 2"],
-		gen: 5,
+		gen: 6,
 	},
 	volkraken: {
 		num: -33,
@@ -15955,7 +15955,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		prevo: "Volkritter",
 		evoLevel: 34,
 		eggGroups: ["Water 1", "Water 2"],
-		gen: 5,
+		gen: 6,
 	},
 	snugglow: {
 		num: -34,


### PR DESCRIPTION
Evidence, if needed:
- https://www.smogon.com/forums/threads/cap-18-final-product.3507516/post-5471155 final product was 2014, well after gen 6 release
- https://www.smogon.com/cap/pokemon/ has it listed under gen 6
- learnsets.js doesn't contain gen 5 data