### PR TITLE
Fix event validator for RBY Tradebacks

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1457,6 +1457,7 @@ export class TeamValidator {
 		const dex = this.dex;
 		let name = set.species;
 		const species = dex.getSpecies(set.species);
+		const maxSourceGen = this.ruleTable.has('allowtradeback') ? 2 : dex.gen;
 		if (!eventSpecies) eventSpecies = species;
 		if (set.name && set.species !== set.name && species.baseSpecies !== set.name) name = `${set.name} (${set.species})`;
 
@@ -1470,7 +1471,7 @@ export class TeamValidator {
 			if (fastReturn) return true;
 			problems.push(`This format requires Pokemon from gen ${this.minSourceGen} or later and ${name} is from gen ${eventData.generation}${etc}.`);
 		}
-		if (this.maxSourceGen < eventData.generation) {
+		if (maxSourceGen < eventData.generation) {
 			if (fastReturn) return true;
 			problems.push(`This format is in gen ${dex.gen} and ${name} is from gen ${eventData.generation}${etc}.`);
 		}

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1470,7 +1470,7 @@ export class TeamValidator {
 			if (fastReturn) return true;
 			problems.push(`This format requires Pokemon from gen ${this.minSourceGen} or later and ${name} is from gen ${eventData.generation}${etc}.`);
 		}
-		if (dex.gen < eventData.generation) {
+		if (this.maxSourceGen < eventData.generation) {
 			if (fastReturn) return true;
 			problems.push(`This format is in gen ${dex.gen} and ${name} is from gen ${eventData.generation}${etc}.`);
 		}


### PR DESCRIPTION
If you attempt to challenge an opponent to Tradebacks, it will reject Pokemon with NYPC moves even though they should be legal. For example, attempting to use Lovely Kiss Snorlax in RBY Tradebacks:

"Your team was rejected for the following reasons:

- Snorlax has an event-exclusive move that it doesn't qualify for (only one of several ways to get the move will be listed):
- This format is in gen 1 and Snorlax is from gen 2 because it has a move only available from an event."


By changing dex.gen to this.maxSourceGen in the validator for event moves, NYPC moves work as they should in Tradebacks.