### PR TITLE
Implement Stadium Sleep Clause

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2273,7 +2273,7 @@ export const Formats: (FormatsData | {section: string, column?: number})[] = [
 
 		mod: 'stadium',
 		searchShow: false,
-		ruleset: ['Obtainable', 'Team Preview', 'Stadium Sleep Clause Mod', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],
+		ruleset: ['Standard', 'Team Preview', '!Sleep Clause Mod', 'Stadium Sleep Clause Mod'],
 		banlist: ['Uber',
 			'Nidoking + Fury Attack + Thrash', 'Exeggutor + Poison Powder + Stomp', 'Exeggutor + Sleep Powder + Stomp',
 			'Exeggutor + Stun Spore + Stomp', 'Jolteon + Focus Energy + Thunder Shock', 'Flareon + Focus Energy + Ember',

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2273,7 +2273,7 @@ export const Formats: (FormatsData | {section: string, column?: number})[] = [
 
 		mod: 'stadium',
 		searchShow: false,
-		ruleset: ['Obtainable', 'Team Preview', 'Stadium Sleep Clause Mod', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod',],
+		ruleset: ['Obtainable', 'Team Preview', 'Stadium Sleep Clause Mod', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],
 		banlist: ['Uber',
 			'Nidoking + Fury Attack + Thrash', 'Exeggutor + Poison Powder + Stomp', 'Exeggutor + Sleep Powder + Stomp',
 			'Exeggutor + Stun Spore + Stomp', 'Jolteon + Focus Energy + Thunder Shock', 'Flareon + Focus Energy + Ember',

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2273,7 +2273,7 @@ export const Formats: (FormatsData | {section: string, column?: number})[] = [
 
 		mod: 'stadium',
 		searchShow: false,
-		ruleset: ['Standard', 'Team Preview'],
+		ruleset: ['Obtainable', 'Team Preview', 'Stadium Sleep Clause Mod', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod',],
 		banlist: ['Uber',
 			'Nidoking + Fury Attack + Thrash', 'Exeggutor + Poison Powder + Stomp', 'Exeggutor + Sleep Powder + Stomp',
 			'Exeggutor + Stun Spore + Stomp', 'Jolteon + Focus Energy + Thunder Shock', 'Flareon + Focus Energy + Ember',

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2273,7 +2273,7 @@ export const Formats: (FormatsData | {section: string, column?: number})[] = [
 
 		mod: 'stadium',
 		searchShow: false,
-		ruleset: ['Standard', 'Team Preview', '!Sleep Clause Mod', 'Stadium Sleep Clause Mod'],
+		ruleset: ['Standard', 'Team Preview', '!Sleep Clause Mod', 'Stadium Sleep Clause'],
 		banlist: ['Uber',
 			'Nidoking + Fury Attack + Thrash', 'Exeggutor + Poison Powder + Stomp', 'Exeggutor + Sleep Powder + Stomp',
 			'Exeggutor + Stun Spore + Stomp', 'Jolteon + Focus Energy + Thunder Shock', 'Flareon + Focus Energy + Ember',

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -735,6 +735,27 @@ export const BattleFormats: {[k: string]: FormatsData} = {
 			}
 		},
 	},
+	stadiumsleepclausemod: {
+		effectType: 'Rule',
+		name: 'Stadium Sleep Clause Mod',
+		desc: "Prevents players from putting one of their opponent's Pok&eacute;mon to sleep if any of the opponent's other Pok&eacute;mon are asleep",
+		onBegin() {
+			this.add('rule', 'Stadium Sleep Clause Mod: Limit one foe put to sleep');
+		},
+		onSetStatus(status, target, source) {
+			if (source && source.side === target.side) {
+				return;
+			}
+			if (status.id === 'slp') {
+				for (const pokemon of target.side.pokemon) {
+					if (pokemon.hp && pokemon.status === 'slp') {
+						this.add('-message', "Sleep Clause Mod activated. (In Stadium, Sleep Clause activates if any of the opponent's Pokemon are asleep, even if self-inflicted from Rest)");
+						return false;
+					}
+				}
+			}
+		},
+	},
 	switchpriorityclausemod: {
 		effectType: 'Rule',
 		name: 'Switch Priority Clause Mod',

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -735,12 +735,12 @@ export const BattleFormats: {[k: string]: FormatsData} = {
 			}
 		},
 	},
-	stadiumsleepclausemod: {
+	stadiumsleepclause: {
 		effectType: 'Rule',
-		name: 'Stadium Sleep Clause Mod',
+		name: 'Stadium Sleep Clause',
 		desc: "Prevents players from putting one of their opponent's Pok&eacute;mon to sleep if any of the opponent's other Pok&eacute;mon are asleep",
 		onBegin() {
-			this.add('rule', 'Stadium Sleep Clause Mod: Limit one foe put to sleep');
+			this.add('rule', 'Stadium Sleep Clause: Limit one foe put to sleep');
 		},
 		onSetStatus(status, target, source) {
 			if (source && source.side === target.side) {
@@ -749,7 +749,7 @@ export const BattleFormats: {[k: string]: FormatsData} = {
 			if (status.id === 'slp') {
 				for (const pokemon of target.side.pokemon) {
 					if (pokemon.hp && pokemon.status === 'slp') {
-						this.add('-message', "Sleep Clause Mod activated. (In Stadium, Sleep Clause activates if any of the opponent's Pokemon are asleep, even if self-inflicted from Rest)");
+						this.add('-message', "Sleep Clause activated. (In Stadium, Sleep Clause activates if any of the opponent's Pokemon are asleep, even if self-inflicted from Rest)");
 						return false;
 					}
 				}

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -738,7 +738,7 @@ export const BattleFormats: {[k: string]: FormatsData} = {
 	stadiumsleepclause: {
 		effectType: 'Rule',
 		name: 'Stadium Sleep Clause',
-		desc: "Prevents players from putting one of their opponent's Pok&eacute;mon to sleep if any of the opponent's other Pok&eacute;mon are asleep",
+		desc: "Prevents players from putting one of their opponent's Pok\u00E9mon to sleep if any of the opponent's other Pok\u00E9mon are asleep (different from Sleep Clause Mod because putting your own Pok\u00E9mon to sleep is enough to prevent opponents from putting your others to sleep).",
 		onBegin() {
 			this.add('rule', 'Stadium Sleep Clause: Limit one foe put to sleep');
 		},


### PR DESCRIPTION
Adds Stadium's Sleep Clause to [Gen 1] Stadium OU.

In Pokemon Stadium, Sleep Clause only checks whether any Pokemon on the opposing side is asleep to activate, and does not check the source of sleep.

This means if a player's Pokemon uses Rest, Sleep Clause is activated for their side and is protected from Sleep moves, even though the sleep was self-inflicted from Rest.

Proof:
https://www.smogon.com/forums/threads/gen-1-and-tradebacks-dev-post-bugs-here.3524844/page-14#post-8502315