### PR TITLE
Fix various Stadium issues

### DIFF
--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -21,6 +21,12 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 			}
 		},
 	},
+	hyperbeam: {
+		inherit: true,
+		onMoveFail(target, source, move) {
+			source.addVolatile('mustrecharge', target, move, 'trapper');
+		},
+	},
 	jumpkick: {
 		inherit: true,
 		desc: "If this attack misses the target, the user 1HP of damage.",

--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -24,7 +24,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 	hyperbeam: {
 		inherit: true,
 		onMoveFail(target, source, move) {
-			source.addVolatile('mustrecharge', target, move, 'trapper');
+			source.addVolatile('mustrecharge');
 		},
 	},
 	jumpkick: {

--- a/data/mods/stadium/scripts.ts
+++ b/data/mods/stadium/scripts.ts
@@ -132,7 +132,7 @@ export const BattleScripts: ModdedBattleScriptsData = {
 			return false;
 		}
 
-		// Then, check if the PokÃ©mon is immune to this move.
+		// Then, check if the Pokemon is immune to this move.
 		if (
 			(!move.ignoreImmunity || (move.ignoreImmunity !== true && !move.ignoreImmunity[move.type])) &&
 			!target.runImmunity(move.type, true)

--- a/data/mods/stadium/scripts.ts
+++ b/data/mods/stadium/scripts.ts
@@ -97,7 +97,7 @@ export const BattleScripts: ModdedBattleScriptsData = {
 		this.useMove(move, pokemon, target, sourceEffect);
 		this.singleEvent('AfterMove', move, null, pokemon, target, move);
 
-		// If rival fainted
+		// If target fainted
 		if (target && target.hp <= 0) {
 			// We remove screens
 			target.side.removeSideCondition('reflect');
@@ -105,6 +105,7 @@ export const BattleScripts: ModdedBattleScriptsData = {
 		} else {
 			this.runEvent('AfterMoveSelf', pokemon, target, move);
 		}
+		if (pokemon.volatiles['mustrecharge']) this.add('-mustrecharge', pokemon);
 
 		// For partial trapping moves, we are saving the target.
 		if (move.volatileStatus === 'partiallytrapped' && target && target.hp > 0) {
@@ -121,10 +122,17 @@ export const BattleScripts: ModdedBattleScriptsData = {
 		}
 	},
 	tryMoveHit(target, pokemon, move) {
-		let doSelfDestruct = true;
 		let damage: number | false | undefined = 0;
 
-		// First, check if the Pokémon is immune to this move.
+		// First, check if the target is semi-invulnerable
+		let hitResult = this.runEvent('Invulnerability', target, pokemon, move);
+		if (hitResult === false) {
+			if (!move.spreadHit) this.attrLastMove('[miss]');
+			this.add('-miss', pokemon);
+			return false;
+		}
+
+		// Then, check if the PokÃ©mon is immune to this move.
 		if (
 			(!move.ignoreImmunity || (move.ignoreImmunity !== true && !move.ignoreImmunity[move.type])) &&
 			!target.runImmunity(move.type, true)
@@ -132,6 +140,11 @@ export const BattleScripts: ModdedBattleScriptsData = {
 			if (move.selfdestruct) {
 				this.faint(pokemon, pokemon, move);
 			}
+			return false;
+		}
+		hitResult = this.singleEvent('TryImmunity', move, null, target, pokemon, move);
+		if (hitResult === false) {
+			this.add('-immune', target);
 			return false;
 		}
 
@@ -219,9 +232,7 @@ export const BattleScripts: ModdedBattleScriptsData = {
 
 		if (move.category !== 'Status') target.gotAttacked(move, damage, pokemon);
 
-		// Checking if substitute fainted
-		if (target.subFainted) doSelfDestruct = false;
-		if (move.selfdestruct && doSelfDestruct) {
+		if (move.selfdestruct) {
 			this.faint(pokemon, pokemon, move);
 		}
 

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1800,8 +1800,10 @@ export class Battle {
 
 			if (targetDamage && effect.effectType === 'Move') {
 				if (this.gen <= 1 && effect.recoil && source) {
-					const amount = this.clampIntRange(Math.floor(targetDamage * effect.recoil[0] / effect.recoil[1]), 1);
-					this.damage(amount, source, target, 'recoil');
+					if (this.dex.currentMod !== 'stadium' || target.hp > 0) {
+						const amount = this.clampIntRange(Math.floor(targetDamage * effect.recoil[0] / effect.recoil[1]), 1);
+						this.damage(amount, source, target, 'recoil');
+					}
 				}
 				if (this.gen <= 4 && effect.drain && source) {
 					const amount = this.clampIntRange(Math.floor(targetDamage * effect.drain[0] / effect.drain[1]), 1);


### PR DESCRIPTION
Fixed the following issues with Stadium:
-Must Recharge did not display after using Hyper Beam
-Hyper Beam did not require recharging after missing
-Self-destruct and Explosion did not cause the user to faint if it broke a Substitute
-All moves ignored the semi-invulnerability from Dig/Fly
-Dream Eater hit Pokemon that were not asleep
-Recoil moves inflicted recoil when the opponent was KO'd

Based fixes on research done by Plague von Karma and Beelzemon 2003
https://www.smogon.com/forums/threads/stadium-format-is-now-available-on-ps.3526616/page-2#post-8502629