### PR TITLE
Trivia: Fix bug with computing user ranking

### DIFF
--- a/server/chat-plugins/trivia.ts
+++ b/server/chat-plugins/trivia.ts
@@ -235,7 +235,7 @@ class Ladder {
 					if (!ladder[rank]) ladder[rank] = [];
 					ladder[rank].push(leader as unknown as TriviaRank);
 				}
-				ranks[leader].push(rank + 1);
+				ranks[leader][i] = rank + 1;
 			}
 		}
 		return {ladder, ranks};


### PR DESCRIPTION
This is the bug: 
<img width="571" alt="image" src="https://user-images.githubusercontent.com/56906084/84824114-48f27c00-afd4-11ea-9130-2bfe92f55d4b.png">
