### PR TITLE
Modlog: prevent non-gstaff from searching for IPs

### DIFF
--- a/server/chat-plugins/modlog.ts
+++ b/server/chat-plugins/modlog.ts
@@ -309,7 +309,7 @@ async function getModlog(
 	const addModlogLinks = !!(
 		Config.modloglink && (user.group !== ' ' || (targetRoom && targetRoom.settings.isPrivate !== true))
 	);
-	if (hideIps && /^[0-9.*]+$/.test(searchString)) {
+	if (hideIps && /^\[?[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\]?$/.test(searchString)) {
 		connection.popup(`You cannot search for IPs.`);
 		return;
 	}

--- a/server/chat-plugins/modlog.ts
+++ b/server/chat-plugins/modlog.ts
@@ -309,7 +309,10 @@ async function getModlog(
 	const addModlogLinks = !!(
 		Config.modloglink && (user.group !== ' ' || (targetRoom && targetRoom.settings.isPrivate !== true))
 	);
-
+	if (hideIps && /^[0-9.*]+$/.test(searchString)) {
+		connection.popup(`You cannot search for IPs.`);
+		return;
+	}
 	if (searchString.length > MAX_QUERY_LENGTH) {
 		connection.popup(`Your search query must be shorter than ${MAX_QUERY_LENGTH} characters.`);
 		return;


### PR DESCRIPTION
Currently, if you /modlog [ip] (as a non-gstaff user) it will show actions with that IP,  even though the IP is removed. EG: https://prnt.sc/t10k1r
This prevents anyone who isn't gstaff from searching _just_ numbers, since without it it will include IP results.
I'm not sure if there's a better way to do this with regex but this blocks all cases i can think of and doesn't hurt functionality.