### PR TITLE
Rooms: save creation time for all rooms

### DIFF
--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -656,7 +656,8 @@ export const commands: ChatCommands = {
 	roomuptime(target, room, user, connection, cmd) {
 		if (!this.runBroadcast()) return;
 		if (!room) return this.errorReply(`Can only be used in a room.`);
-		// legacy handling
+
+		// for hotpatching
 		if (!room.settings.creationTime) room.settings.creationTime = Date.now();
 		const uptime = Chat.toDurationString(Date.now() - room.settings.creationTime);
 		this.sendReplyBox(`Room uptime: <b>${uptime}</b>`);

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -655,6 +655,7 @@ export const commands: ChatCommands = {
 	groupchatuptime: 'roomuptime',
 	roomuptime(target, room, user, connection, cmd) {
 		if (!this.runBroadcast()) return;
+		if (!room) return this.errorReply(`Can only be used in a room.`);
 		// legacy handling
 		if (!room.settings.creationTime) room.settings.creationTime = Date.now();
 		const uptime = Chat.toDurationString(Date.now() - room.settings.creationTime);

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -626,7 +626,7 @@ export const commands: ChatCommands = {
 		const targetRoom = Rooms.createChatRoom(roomid, `[G] ${title}`, {
 			isPersonal: true,
 			isPrivate: 'hidden',
-			creationTime: parent ? null : Date.now(),
+			creationTime: Date.now(),
 			modjoin: parent ? null : '+',
 			parentid: parent,
 			auth: {},
@@ -651,14 +651,16 @@ export const commands: ChatCommands = {
 		`/subroomgroupchat [roomname] - Creates a subroom groupchat of the current room. Can only be used in a public room you have staff in.`,
 	],
 
-	'!groupchatuptime': true,
-	groupchatuptime(target, room, user) {
-		if (!room || !room.creationTime) return this.errorReply("Can only be used in a groupchat.");
+	'!roomuptime': true,
+	groupchatuptime: 'roomuptime',
+	roomuptime(target, room, user, connection, cmd) {
 		if (!this.runBroadcast()) return;
-		const uptime = Chat.toDurationString(Date.now() - room.creationTime);
-		this.sendReplyBox(`Groupchat uptime: <b>${uptime}</b>`);
+		// legacy handling
+		if (!room.settings.creationTime) room.settings.creationTime = Date.now();
+		const uptime = Chat.toDurationString(Date.now() - room.settings.creationTime);
+		this.sendReplyBox(`Room uptime: <b>${uptime}</b>`);
 	},
-	groupchatuptimehelp: [`/groupchatuptime - Displays the uptime if the current room is a groupchat.`],
+	roomuptimehelp: [`/roomuptime - Displays the uptime of the room.`],
 
 	deregisterchatroom(target, room, user) {
 		if (!this.can('makeroom')) return;

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -100,6 +100,7 @@ export interface RoomSettings {
 	staffMessage?: string | null;
 	rulesLink?: string | null;
 	dataCommandTierDisplay?: 'tiers' | 'doubles tiers' | 'numbers';
+	creationTime?: number;
 
 	scavSettings?: AnyObject;
 	scavQueue?: QueuedHunt[];
@@ -201,6 +202,7 @@ export abstract class BasicRoom {
 		this.settings = {
 			title: this.title,
 			auth: Object.create(null),
+			creationTime: Date.now(),
 		};
 		this.persist = false;
 		this.hideReplay = false;
@@ -790,6 +792,7 @@ export class GlobalRoom extends BasicRoom {
 
 		const settings = {
 			title,
+			creationTime: Date.now(),
 		};
 		const room = Rooms.createChatRoom(id, title, settings);
 		if (id === 'lobby') Rooms.lobby = room;
@@ -1081,7 +1084,6 @@ export class GlobalRoom extends BasicRoom {
 export class BasicChatRoom extends BasicRoom {
 	readonly log: Roomlog;
 	/** Only available in groupchats */
-	readonly creationTime: number | null;
 	readonly type: 'chat' | 'battle';
 	minorActivity: Poll | Announcement | null;
 	banwordRegex: RegExp | true | null;
@@ -1110,7 +1112,6 @@ export class BasicChatRoom extends BasicRoom {
 		}
 		this.log = Roomlogs.create(this, options);
 
-		this.creationTime = null;
 		this.type = 'chat';
 		this.banwordRegex = null;
 		this.subRooms = new Map();
@@ -1686,6 +1687,7 @@ export const Rooms = {
 	},
 	createChatRoom(roomid: RoomID, title: string, options: AnyObject) {
 		if (Rooms.rooms.has(roomid)) throw new Error(`Room ${roomid} already exists`);
+		if (!options.creationTime) options.creationTime = Date.now();
 		const room = new BasicChatRoom(roomid, title, options) as ChatRoom;
 		Rooms.rooms.set(roomid, room);
 		return room;

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -100,7 +100,9 @@ export interface RoomSettings {
 	staffMessage?: string | null;
 	rulesLink?: string | null;
 	dataCommandTierDisplay?: 'tiers' | 'doubles tiers' | 'numbers';
-	creationTime?: number;
+	requestShowEnabled?: boolean | null;
+	showEnabled?: GroupSymbol | true;
+	creationTime?: number | null;
 
 	scavSettings?: AnyObject;
 	scavQueue?: QueuedHunt[];
@@ -1117,6 +1119,7 @@ export class BasicChatRoom extends BasicRoom {
 		this.subRooms = new Map();
 
 		this.settings = options as RoomSettings;
+		if (!this.settings.creationTime) this.settings.creationTime = Date.now();
 		this.auth.load();
 
 		if (!options.isPersonal) this.persist = true;
@@ -1687,7 +1690,6 @@ export const Rooms = {
 	},
 	createChatRoom(roomid: RoomID, title: string, options: AnyObject) {
 		if (Rooms.rooms.has(roomid)) throw new Error(`Room ${roomid} already exists`);
-		if (!options.creationTime) options.creationTime = Date.now();
 		const room = new BasicChatRoom(roomid, title, options) as ChatRoom;
 		Rooms.rooms.set(roomid, room);
 		return room;

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -68,6 +68,7 @@ interface UserTable {
 export interface RoomSettings {
 	title: string;
 	auth: {[userid: string]: GroupSymbol};
+	creationTime: number;
 
 	readonly staffAutojoin?: string | boolean;
 	readonly autojoin?: boolean;
@@ -102,7 +103,6 @@ export interface RoomSettings {
 	dataCommandTierDisplay?: 'tiers' | 'doubles tiers' | 'numbers';
 	requestShowEnabled?: boolean | null;
 	showEnabled?: GroupSymbol | true;
-	creationTime?: number | null;
 
 	scavSettings?: AnyObject;
 	scavQueue?: QueuedHunt[];


### PR DESCRIPTION
Creation time is set on creation of the room - eg restart / command creation. 
All rooms have uptime regardless now, and uptime is saved on settings for perm rooms.