### PR TITLE
Fix a massive exploit in /requestshow

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2440,11 +2440,12 @@ export const commands: ChatCommands = {
 		if (!room.settings.requestShowEnabled) {
 			return this.errorReply(`Media approvals are disabled in this room.`);
 		}
-		if (this.can('showmedia', null, room)) return this.errorReply(`Use !show instead.`);
+		if (user.can('showmedia', null, room)) return this.errorReply(`Use !show instead.`);
 		if (room.pendingApprovals?.has(user.id)) return this.errorReply('You have a request pending already.');
 		if (!toID(target)) return this.parse(`/help requestshow`);
 
-		if (!/^https?:\/\//.test(target)) target = `https://${Utils.escapeHTML(target)}`;
+		if (!/^https?:\/\//.test(target)) target = `https://${target}`;
+		target = Utils.escapeHTML(target);
 
 		if (!room.pendingApprovals) room.pendingApprovals = new Map();
 		room.pendingApprovals.set(user.id, target);
@@ -2482,7 +2483,7 @@ export const commands: ChatCommands = {
 			const [width, height] = await Chat.fitImage(link);
 			buf = Utils.html`<img src="${link}" style="width:${width}px;height:${height}px" />`;
 		}
-		buf += Utils.html`<br /><p style="margin-left:5px;font-size:9pt;color:white"><small>(Requested by ${user.name})</small></p>`;
+		buf += Utils.html`<br /><p style="margin-left:5px;font-size:9pt;color:white"><small>(Requested by ${userid})</small></p>`;
 		this.addBox(buf);
 		room.update();
 	},

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2445,13 +2445,12 @@ export const commands: ChatCommands = {
 		if (!toID(target)) return this.parse(`/help requestshow`);
 
 		if (!/^https?:\/\//.test(target)) target = `https://${target}`;
-		target = Utils.escapeHTML(target);
 
 		if (!room.pendingApprovals) room.pendingApprovals = new Map();
 		room.pendingApprovals.set(user.id, target);
 		this.sendReply(`You have requested to show the link: ${target}`);
 		room.sendMods(
-			`|uhtml|request-${user.id}|<div class="infobox">${user.name} wants to show <a href="${target}">${target}</a><br>` +
+			Utils.html`|uhtml|request-${user.id}|<div class="infobox">${user.name} wants to show <a href="${target}">${target}</a><br>` +
 			`<button class="button" name="send" value="/approveshow ${user.id}">Approve</button><br>` +
 			`<button class="button" name="send" value="/denyshow ${user.id}">Deny</button></div>`
 		);


### PR DESCRIPTION
![bad kitten](https://i.imgur.com/Zkv4fLt.png)

This would be really really horrible to have on the server because it would allow people to actually target staff.

1. they could inject something malicious there and make your computer download malicious files
2. they can grab the IPs of all the staff on within a room by using an image hosted on a server they own. (sounds like the perfect revenge story)

Also fixes the "access denied" message that would show when you use this.can instead of user.can whenever the user doesn't have the permission, as well as approve showing the approver's name, instead of the requester's name