### PR TITLE
Fix server crash from overlength posts

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -388,8 +388,7 @@ export class CommandContext extends MessageContext {
 		}
 
 		// Output the message
-
-		if (typeof message.then === 'function') {
+		if (message && typeof message.then === 'function') {
 			message.then(() => this.update());
 		} else if (message && message !== true) {
 			if (this.pmTarget) {


### PR DESCRIPTION
- server will crash and be unable to handle any further inputs from users.   Got this error when i accidentally posted a super long HTML post that exploited /requestshow

Byproduct of https://github.com/smogon/pokemon-showdown/pull/6745