### PR TITLE
Youtube: fix ID crash 

### DIFF
--- a/server/chat-plugins/youtube.ts
+++ b/server/chat-plugins/youtube.ts
@@ -114,8 +114,8 @@ export class YoutubeInterface {
 		} else {
 			id = link.split('channel/')[1];
 		}
-		if (id.includes('&')) id = id.split('&')[0];
-		if (id.includes('?')) id = id.split('?')[0];
+		if (id?.includes('&')) id = id.split('&')[0];
+		if (id?.includes('?')) id = id.split('?')[0];
 		return id;
 	}
 	async generateVideoDisplay(link: string) {

--- a/server/chat-plugins/youtube.ts
+++ b/server/chat-plugins/youtube.ts
@@ -114,8 +114,8 @@ export class YoutubeInterface {
 		} else {
 			id = link.split('channel/')[1] || '';
 		}
-		if (id.includes('&')) id = id.split('&')[0] || '';
-		if (id.includes('?')) id = id.split('?')[0] || '';
+		if (id.includes('&')) id = id.split('&')[0];
+		if (id.includes('?')) id = id.split('?')[0];
 		return id;
 	}
 	async generateVideoDisplay(link: string) {

--- a/server/chat-plugins/youtube.ts
+++ b/server/chat-plugins/youtube.ts
@@ -105,17 +105,17 @@ export class YoutubeInterface {
 		if (channelData[link]) return link;
 		if (!link.includes('channel')) {
 			if (link.includes('youtube')) {
-				id = link.split('v=')[1];
+				id = (link.split('v=')[1] || '');
 			} else if (link.includes('youtu.be')) {
-				id = link.split('/')[3];
+				id = (link.split('/')[3] || '');
 			} else {
 				return null;
 			}
 		} else {
-			id = link.split('channel/')[1];
+			id = (link.split('channel/')[1] || '');
 		}
-		if (id?.includes('&')) id = id.split('&')[0];
-		if (id?.includes('?')) id = id.split('?')[0];
+		if (id?.includes('&')) id = (id.split('&')[0] || '');
+		if (id?.includes('?')) id = (id.split('?')[0] || '');
 		return id;
 	}
 	async generateVideoDisplay(link: string) {

--- a/server/chat-plugins/youtube.ts
+++ b/server/chat-plugins/youtube.ts
@@ -105,17 +105,17 @@ export class YoutubeInterface {
 		if (channelData[link]) return link;
 		if (!link.includes('channel')) {
 			if (link.includes('youtube')) {
-				id = (link.split('v=')[1] || '');
+				id = link.split('v=')[1] || '';
 			} else if (link.includes('youtu.be')) {
-				id = (link.split('/')[3] || '');
+				id = link.split('/')[3] || '';
 			} else {
 				return null;
 			}
 		} else {
-			id = (link.split('channel/')[1] || '');
+			id = link.split('channel/')[1] || '';
 		}
-		if (id?.includes('&')) id = (id.split('&')[0] || '');
-		if (id?.includes('?')) id = (id.split('?')[0] || '');
+		if (id.includes('&')) id = id.split('&')[0] || '';
+		if (id.includes('?')) id = id.split('?')[0] || '';
 		return id;
 	}
 	async generateVideoDisplay(link: string) {


### PR DESCRIPTION
This ensures ID exists when checking if it includes. It already handles if this returns undefined, so no other changes should need to be made.