### PR TITLE
Fix setting modchat in battles

### DIFF
--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -67,7 +67,7 @@ export const commands: ChatCommands = {
 		// 'makeroom' lets you set any rank, no limit
 		const threshold = user.can('makeroom') ? Infinity :
 			user.can('modchatall', null, room) ? Config.groupsranking.indexOf(room.auth.get(user.id)) :
-			(Config.groupsranking.indexOf('+') || 2);
+			Math.max(Config.groupsranking.indexOf('+'), 1);
 
 		if (room.settings.modchat &&
 				room.settings.modchat.length <= 1 &&

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -67,7 +67,7 @@ export const commands: ChatCommands = {
 		// 'makeroom' lets you set any rank, no limit
 		const threshold = user.can('makeroom') ? Infinity :
 			user.can('modchatall', null, room) ? Config.groupsranking.indexOf(room.auth.get(user.id)) :
-			Config.groupsranking.indexOf('+');
+			(Config.groupsranking.indexOf('+') || 2);
 
 		if (room.settings.modchat &&
 				room.settings.modchat.length <= 1 &&

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -67,7 +67,7 @@ export const commands: ChatCommands = {
 		// 'makeroom' lets you set any rank, no limit
 		const threshold = user.can('makeroom') ? Infinity :
 			user.can('modchatall', null, room) ? Config.groupsranking.indexOf(room.auth.get(user.id)) :
-			2;
+			Config.groupsranking.indexOf('+');
 
 		if (room.settings.modchat &&
 				room.settings.modchat.length <= 1 &&

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -67,7 +67,7 @@ export const commands: ChatCommands = {
 		// 'makeroom' lets you set any rank, no limit
 		const threshold = user.can('makeroom') ? Infinity :
 			user.can('modchatall', null, room) ? Config.groupsranking.indexOf(room.auth.get(user.id)) :
-			1;
+			2;
 
 		if (room.settings.modchat &&
 				room.settings.modchat.length <= 1 &&


### PR DESCRIPTION
``Config.groupsranking[1]`` is now whitelist, not voice, so this needs to be changed.