### PR TITLE
Add Venusaur-Gmax's Gmax Move

### DIFF
--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -71,6 +71,7 @@ export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 0,
 		color: "Green",
 		eggGroups: ["Monster", "Grass"],
+		isGigantamax: "G-Max Vine Lash",
 	},
 	charmander: {
 		num: 4,


### PR DESCRIPTION
Right now Venusaur-Gmax isn't considered a Gmax Pokemon because its move hasn't been specified.