### PR TITLE
eval: Log in dev room and broadcast 

### DIFF
--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -931,7 +931,12 @@ export const commands: ChatCommands = {
 		if (!this.runBroadcast(true)) return;
 		const logRoom = Rooms.get('development');
 
-		room.add(`||>> ${target}`).update();
+		const show = this.message.startsWith('>>');
+		if (show) {
+			room.add(`||>> ${target}`).update();
+		} else {
+			this.sendReply(`||>> ${target}`);
+		}
 		logRoom?.roomlog(`>> ${target}`);
 		try {
 			/* eslint-disable no-eval, @typescript-eslint/no-unused-vars */
@@ -945,20 +950,29 @@ export const commands: ChatCommands = {
 			} else {
 				result = Utils.visualize(result);
 			}
-			result = result.length > 200 ? Chat.collapseLineBreaksHTML(`<details class="readmore code" style="white-space: ` +
+			result = show && result.length > 200 ? Chat.collapseLineBreaksHTML(
+				`<details class="readmore code" style="white-space: ` +
 				`pre-wrap; display: table; tab-size: 3"><summary>${result.slice(0, 200)}</summary>` +
 				`${result}</details>`) : result.replace(/\n/g, '\n||');
-			room.add(`|html|<< ${result}`).update();
+			if (show) {
+				room.add(`|html|<< ${result}`).update();
+			} else {
+				this.sendReply(`|| << ${result}`);
+			}
 			logRoom?.roomlog(`<< ${result}`);
 		} catch (e) {
-			let message = ('' + e.stack).replace(/\n *at CommandContext\.eval [\s\S]*/m, '');
+			let msg = ('' + e.stack).replace(/\n *at CommandContext\.eval [\s\S]*/m, '');
 			logRoom?.roomlog(`<< ${target}`);
-			message = message.length > 200 ? Chat.collapseLineBreaksHTML(
+			msg = show && msg.length > 200 ? Chat.collapseLineBreaksHTML(
 				`<details class="readmore code" style="white-space: ` +
-				`pre-wrap; display: table; tab-size: 3"><summary>${message.slice(0, 200)}</summary>` +
-				`${message.slice(200)}</details>`
-			).replace(/\n/, '<br>') : message.replace(/\n/g, '\n||');
-			room.add(`|html|<< ${message}`).update();
+				`pre-wrap; display: table; tab-size: 3"><summary>${msg.slice(0, 200)}</summary>` +
+				`${msg.slice(200)}</details>`
+			).replace(/\n/, '<br>') : msg.replace(/\n/g, '\n||');
+			if (show) {
+				room.add(`|html|<< ${msg}`).update();
+			} else {
+				this.sendReply(`|| << ${msg}`);
+			}
 		}
 	},
 

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -952,9 +952,9 @@ export const commands: ChatCommands = {
 			logRoom?.roomlog(`<< ${result}`);
 			this.sendReply(`|html|<table><tr><td>&laquo;</td><td>${Chat.getReadmoreCodeBlock(result)}</td></tr><table>`);
 		} catch (e) {
-			let msg = ('' + e.stack).replace(/\n *at CommandContext\.eval [\s\S]*/m, '');
-			this.sendReply(`|html|<table><tr><td>&laquo;</td><td>${Chat.getReadmoreCodeBlock(msg)}</td></tr><table>`);
-			logRoom?.roomlog(`<< ${msg}`);
+			const message = ('' + e.stack).replace(/\n *at CommandContext\.eval [\s\S]*/m, '');
+			this.sendReply(`|html|<table><tr><td>&laquo;</td><td>${Chat.getReadmoreCodeBlock(message)}</td></tr><table>`);
+			logRoom?.roomlog(`<< ${message}`);
 		}
 	},
 

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -931,12 +931,11 @@ export const commands: ChatCommands = {
 		if (!this.runBroadcast(true)) return;
 		const logRoom = Rooms.get('upperstaff') || Rooms.get('staff');
 
-		const broadcasting = this.broadcasting || this.message.startsWith('>>');
-		if (broadcasting) {
-			room.add(`||>> ${target}`).update();
-		} else {
-			this.sendReply(`||>> ${target}`);
+		if (this.message.startsWith('>>') && room) {
+			this.broadcasting = true;
+			this.broadcastToRoom = true;
 		}
+		this.sendReply(`|html|<table><tr><td>&raquo;</td><td>${Chat.getReadmoreCodeBlock(target)}</td></tr><table>`);
 		logRoom?.roomlog(`>> ${target}`);
 		try {
 			/* eslint-disable no-eval, @typescript-eslint/no-unused-vars */

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -950,10 +950,10 @@ export const commands: ChatCommands = {
 			} else {
 				result = Utils.visualize(result);
 			}
-			result = show && result.length > 200 ? Chat.collapseLineBreaksHTML(
-				`<details class="readmore code" style="white-space: ` +
-				`pre-wrap; display: table; tab-size: 3"><summary>${result.slice(0, 200)}</summary>` +
-				`${result}</details>`) : result.replace(/\n/g, '\n||');
+			result = show && result.length > 200 ? (`<details class="readmore code" style="` +
+				Utils.html`display: table; tab-size: 3"><summary>${result.slice(0, 200)}</summary>` +
+				Utils.html`${result.slice(200)}</details>`
+			).replace(/\n/g, '<br>') : result.replace(/\n/g, '\n||');
 			if (show) {
 				room.add(`|html|<< ${result}`).update();
 			} else {
@@ -963,11 +963,11 @@ export const commands: ChatCommands = {
 		} catch (e) {
 			let msg = ('' + e.stack).replace(/\n *at CommandContext\.eval [\s\S]*/m, '');
 			logRoom?.roomlog(`<< ${target}`);
-			msg = show && msg.length > 200 ? Chat.collapseLineBreaksHTML(
-				`<details class="readmore code" style="white-space: ` +
-				`pre-wrap; display: table; tab-size: 3"><summary>${msg.slice(0, 200)}</summary>` +
-				`${msg.slice(200)}</details>`
-			) : msg.replace(/\n/g, '\n||');
+			msg = show && msg.length > 200 ? (
+				`<details class="readmore code" style="display: table; tab-size: 3">` +
+				Utils.html`<summary>${msg.slice(0, 200)}</summary>` +
+				Utils.html`${msg.slice(200)}</details>`
+			).replace(/\n/g, '<br>') : msg.replace(/\n/g, '\n||');
 			if (show) {
 				room.add(`|html|<< ${msg}`).update();
 			} else {

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -949,8 +949,8 @@ export const commands: ChatCommands = {
 			} else {
 				result = Utils.visualize(result);
 			}
-			logRoom?.roomlog(`<< ${result}`);
 			this.sendReply(`|html|<table><tr><td>&laquo;</td><td>${Chat.getReadmoreCodeBlock(result)}</td></tr><table>`);
+			logRoom?.roomlog(`<< ${result}`);
 		} catch (e) {
 			const message = ('' + e.stack).replace(/\n *at CommandContext\.eval [\s\S]*/m, '');
 			this.sendReply(`|html|<table><tr><td>&laquo;</td><td>${Chat.getReadmoreCodeBlock(message)}</td></tr><table>`);

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -929,15 +929,15 @@ export const commands: ChatCommands = {
 	async eval(target, room, user, connection) {
 		if (!this.canUseConsole()) return false;
 		if (!this.runBroadcast(true)) return;
-		const logRoom = Rooms.get('development');
+		const logRoom = Rooms.get('upperstaff') || Rooms.get('staff');
 
-		const show = this.message.startsWith('>>') || this.message.startsWith('!eval');
+		const broadcasting = this.broadcasting || this.message.startsWith('>>');
 		if (show) {
 			room.add(`||>> ${target}`).update();
-			logRoom?.roomlog(`>> ${target}`);
 		} else {
 			this.sendReply(`||>> ${target}`);
 		}
+		logRoom?.roomlog(`>> ${target}`);
 		try {
 			/* eslint-disable no-eval, @typescript-eslint/no-unused-vars */
 			const battle = room.battle;
@@ -956,10 +956,10 @@ export const commands: ChatCommands = {
 			).replace(/\n/g, '<br>') : result.replace(/\n/g, '\n||');
 			if (show) {
 				room.add(`|html|<< ${result}`).update();
-				logRoom?.roomlog(`<< ${result}`);
 			} else {
 				this.sendReply(`|| << ${result}`);
 			}
+			logRoom?.roomlog(`<< ${result}`);
 		} catch (e) {
 			let msg = ('' + e.stack).replace(/\n *at CommandContext\.eval [\s\S]*/m, '');
 			msg = show && msg.length > 200 ? (
@@ -968,11 +968,11 @@ export const commands: ChatCommands = {
 				Utils.html`${msg.slice(200)}</details>`
 			).replace(/\n/g, '<br>') : msg.replace(/\n/g, '\n||');
 			if (show) {
-				logRoom?.roomlog(`<< ${target}`);
 				room.add(`|html|<< ${msg}`).update();
 			} else {
 				this.sendReply(`|| << ${msg}`);
 			}
+			logRoom?.roomlog(`<< ${msg}`);
 		}
 	},
 

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -931,13 +931,13 @@ export const commands: ChatCommands = {
 		if (!this.runBroadcast(true)) return;
 		const logRoom = Rooms.get('development');
 
-		const show = this.message.startsWith('>>');
+		const show = this.message.startsWith('>>') || this.message.startsWith('!eval');
 		if (show) {
 			room.add(`||>> ${target}`).update();
+			logRoom?.roomlog(`>> ${target}`);
 		} else {
 			this.sendReply(`||>> ${target}`);
 		}
-		logRoom?.roomlog(`>> ${target}`);
 		try {
 			/* eslint-disable no-eval, @typescript-eslint/no-unused-vars */
 			const battle = room.battle;
@@ -956,19 +956,19 @@ export const commands: ChatCommands = {
 			).replace(/\n/g, '<br>') : result.replace(/\n/g, '\n||');
 			if (show) {
 				room.add(`|html|<< ${result}`).update();
+				logRoom?.roomlog(`<< ${result}`);
 			} else {
 				this.sendReply(`|| << ${result}`);
 			}
-			logRoom?.roomlog(`<< ${result}`);
 		} catch (e) {
 			let msg = ('' + e.stack).replace(/\n *at CommandContext\.eval [\s\S]*/m, '');
-			logRoom?.roomlog(`<< ${target}`);
 			msg = show && msg.length > 200 ? (
 				`<details class="readmore code" style="display: table; tab-size: 3">` +
 				Utils.html`<summary>${msg.slice(0, 200)}</summary>` +
 				Utils.html`${msg.slice(200)}</details>`
 			).replace(/\n/g, '<br>') : msg.replace(/\n/g, '\n||');
 			if (show) {
+				logRoom?.roomlog(`<< ${target}`);
 				room.add(`|html|<< ${msg}`).update();
 			} else {
 				this.sendReply(`|| << ${msg}`);

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -950,6 +950,7 @@ export const commands: ChatCommands = {
 			} else {
 				result = Utils.visualize(result);
 			}
+			logRoom?.roomlog(`<< ${result}`);
 			const newlineIdx = result.indexOf('\n');
 			result = broadcasting && newlineIdx > -1 ? (`<details class="readmore code" style="` +
 				Utils.html`display: table; tab-size: 3"><summary>${result.slice(0, newlineIdx)}</summary>` +
@@ -960,10 +961,10 @@ export const commands: ChatCommands = {
 			} else {
 				this.sendReply(`|| << ${result}`);
 			}
-			logRoom?.roomlog(`<< ${result}`);
 		} catch (e) {
 			let msg = ('' + e.stack).replace(/\n *at CommandContext\.eval [\s\S]*/m, '');
 			const newlineIdx = msg.indexOf('\n');
+			logRoom?.roomlog(`<< ${msg}`);
 			msg = broadcasting && newlineIdx > -1 ? (
 				`<details class="readmore code" style="display: table; tab-size: 3">` +
 				Utils.html`<summary>${msg.slice(0, newlineIdx)}</summary>` +
@@ -974,7 +975,6 @@ export const commands: ChatCommands = {
 			} else {
 				this.sendReply(`|| << ${msg}`);
 			}
-			logRoom?.roomlog(`<< ${msg}`);
 		}
 	},
 

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -950,12 +950,7 @@ export const commands: ChatCommands = {
 				result = Utils.visualize(result);
 			}
 			logRoom?.roomlog(`<< ${result}`);
-			result = broadcasting ? Chat.getReadmoreCodeBlock(result) : result.replace(/\n/g, '\n||');
-			if (broadcasting) {
-				room.add(`|html|<< ${result}`).update();
-			} else {
-				this.sendReply(`|| << ${result}`);
-			}
+			this.sendReply(`|html|<table><tr><td>&laquo;</td><td>${Chat.getReadmoreCodeBlock(result)}</td></tr><table>`);
 		} catch (e) {
 			let msg = ('' + e.stack).replace(/\n *at CommandContext\.eval [\s\S]*/m, '');
 			logRoom?.roomlog(`<< ${msg}`);

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -953,13 +953,8 @@ export const commands: ChatCommands = {
 			this.sendReply(`|html|<table><tr><td>&laquo;</td><td>${Chat.getReadmoreCodeBlock(result)}</td></tr><table>`);
 		} catch (e) {
 			let msg = ('' + e.stack).replace(/\n *at CommandContext\.eval [\s\S]*/m, '');
+			this.sendReply(`|html|<table><tr><td>&laquo;</td><td>${Chat.getReadmoreCodeBlock(msg)}</td></tr><table>`);
 			logRoom?.roomlog(`<< ${msg}`);
-			msg = broadcasting ? Chat.getReadmoreCodeBlock(msg) : msg.replace(/\n/g, '\n||');
-			if (broadcasting) {
-				room.add(`|html|<< ${msg}`).update();
-			} else {
-				this.sendReply(`|| << ${msg}`);
-			}
 		}
 	},
 

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -967,7 +967,7 @@ export const commands: ChatCommands = {
 				`<details class="readmore code" style="white-space: ` +
 				`pre-wrap; display: table; tab-size: 3"><summary>${msg.slice(0, 200)}</summary>` +
 				`${msg.slice(200)}</details>`
-			).replace(/\n/, '<br>') : msg.replace(/\n/g, '\n||');
+			) : msg.replace(/\n/g, '\n||');
 			if (show) {
 				room.add(`|html|<< ${msg}`).update();
 			} else {

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -951,11 +951,7 @@ export const commands: ChatCommands = {
 				result = Utils.visualize(result);
 			}
 			logRoom?.roomlog(`<< ${result}`);
-			const newlineIdx = result.indexOf('\n');
-			result = broadcasting && newlineIdx > -1 ? (`<details class="readmore code" style="` +
-				Utils.html`display: table; tab-size: 3"><summary>${result.slice(0, newlineIdx)}</summary>` +
-				Utils.html`${result.slice(newlineIdx + 1)}</details>`
-			).replace(/\n/g, '<br>') : result.replace(/\n/g, '\n||');
+			result = broadcasting ? Chat.getReadmoreCodeBlock(result) : result.replace(/\n/g, '\n||');
 			if (broadcasting) {
 				room.add(`|html|<< ${result}`).update();
 			} else {
@@ -963,13 +959,8 @@ export const commands: ChatCommands = {
 			}
 		} catch (e) {
 			let msg = ('' + e.stack).replace(/\n *at CommandContext\.eval [\s\S]*/m, '');
-			const newlineIdx = msg.indexOf('\n');
 			logRoom?.roomlog(`<< ${msg}`);
-			msg = broadcasting && newlineIdx > -1 ? (
-				`<details class="readmore code" style="display: table; tab-size: 3">` +
-				Utils.html`<summary>${msg.slice(0, newlineIdx)}</summary>` +
-				Utils.html`${msg.slice(newlineIdx + 1)}</details>`
-			).replace(/\n/g, '<br>') : msg.replace(/\n/g, '\n||');
+			msg = broadcasting ? Chat.getReadmoreCodeBlock(msg) : msg.replace(/\n/g, '\n||');
 			if (broadcasting) {
 				room.add(`|html|<< ${msg}`).update();
 			} else {

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -932,7 +932,7 @@ export const commands: ChatCommands = {
 		const logRoom = Rooms.get('upperstaff') || Rooms.get('staff');
 
 		const broadcasting = this.broadcasting || this.message.startsWith('>>');
-		if (show) {
+		if (broadcasting) {
 			room.add(`||>> ${target}`).update();
 		} else {
 			this.sendReply(`||>> ${target}`);
@@ -950,11 +950,12 @@ export const commands: ChatCommands = {
 			} else {
 				result = Utils.visualize(result);
 			}
-			result = show && result.length > 200 ? (`<details class="readmore code" style="` +
-				Utils.html`display: table; tab-size: 3"><summary>${result.slice(0, 200)}</summary>` +
-				Utils.html`${result.slice(200)}</details>`
+			const newlineIdx = result.indexOf('\n');
+			result = broadcasting && newlineIdx > -1 ? (`<details class="readmore code" style="` +
+				Utils.html`display: table; tab-size: 3"><summary>${result.slice(0, newlineIdx)}</summary>` +
+				Utils.html`${result.slice(newlineIdx + 1)}</details>`
 			).replace(/\n/g, '<br>') : result.replace(/\n/g, '\n||');
-			if (show) {
+			if (broadcasting) {
 				room.add(`|html|<< ${result}`).update();
 			} else {
 				this.sendReply(`|| << ${result}`);
@@ -962,12 +963,13 @@ export const commands: ChatCommands = {
 			logRoom?.roomlog(`<< ${result}`);
 		} catch (e) {
 			let msg = ('' + e.stack).replace(/\n *at CommandContext\.eval [\s\S]*/m, '');
-			msg = show && msg.length > 200 ? (
+			const newlineIdx = msg.indexOf('\n');
+			msg = broadcasting && newlineIdx > -1 ? (
 				`<details class="readmore code" style="display: table; tab-size: 3">` +
-				Utils.html`<summary>${msg.slice(0, 200)}</summary>` +
-				Utils.html`${msg.slice(200)}</details>`
+				Utils.html`<summary>${msg.slice(0, newlineIdx)}</summary>` +
+				Utils.html`${msg.slice(newlineIdx + 1)}</details>`
 			).replace(/\n/g, '<br>') : msg.replace(/\n/g, '\n||');
-			if (show) {
+			if (broadcasting) {
 				room.add(`|html|<< ${msg}`).update();
 			} else {
 				this.sendReply(`|| << ${msg}`);

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -935,7 +935,7 @@ export const commands: ChatCommands = {
 			this.broadcasting = true;
 			this.broadcastToRoom = true;
 		}
-		this.sendReply(`|html|<table><tr><td>&raquo;</td><td>${Chat.getReadmoreCodeBlock(target)}</td></tr><table>`);
+		this.sendReply(`|html|<table border="0" cellspacing="0" cellpadding="0"><tr><td valign="top">&gt;&gt;&nbsp;</td><td>${Chat.getReadmoreCodeBlock(target)}</td></tr><table>`);
 		logRoom?.roomlog(`>> ${target}`);
 		try {
 			/* eslint-disable no-eval, @typescript-eslint/no-unused-vars */
@@ -949,11 +949,11 @@ export const commands: ChatCommands = {
 			} else {
 				result = Utils.visualize(result);
 			}
-			this.sendReply(`|html|<table><tr><td>&laquo;</td><td>${Chat.getReadmoreCodeBlock(result)}</td></tr><table>`);
+			this.sendReply(`|html|<table border="0" cellspacing="0" cellpadding="0"><tr><td valign="top">&lt;&lt;&nbsp;</td><td>${Chat.getReadmoreCodeBlock(result)}</td></tr><table>`);
 			logRoom?.roomlog(`<< ${result}`);
 		} catch (e) {
 			const message = ('' + e.stack).replace(/\n *at CommandContext\.eval [\s\S]*/m, '');
-			this.sendReply(`|html|<table><tr><td>&laquo;</td><td>${Chat.getReadmoreCodeBlock(message)}</td></tr><table>`);
+			this.sendReply(`|html|<table border="0" cellspacing="0" cellpadding="0"><tr><td valign="top">&lt;&lt;&nbsp;</td><td>${Chat.getReadmoreCodeBlock(message)}</td></tr><table>`);
 			logRoom?.roomlog(`<< ${message}`);
 		}
 	},

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2569,8 +2569,9 @@ export const commands: ChatCommands = {
 		target = this.message.substr(this.cmdToken.length + this.cmd.length + +this.message.includes(' ')).trimRight();
 		if (!this.canBroadcast(true, '!code')) return;
 		const code = Chat.getReadmoreCodeBlock(target);
-		if (/<code>(.+)<\/code>/.test(code)) {
-			return `/html ${code}`;
+		const params = target.split('\n');
+		if (params.length === 1 && params[0].length < 80 && !params[0].includes('```') && this.shouldBroadcast()) {
+			return this.canTalk(`\`\`\`${params[0]}\`\`\``);
 		}
 		this.runBroadcast(true);
 		if (this.broadcasting) {

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2568,7 +2568,7 @@ export const commands: ChatCommands = {
 		if (target.length >= 8192) return this.errorReply("Your code must be under 8192 characters long!");
 		target = this.message.substr(this.cmdToken.length + this.cmd.length + +this.message.includes(' ')).trimRight();
 		if (!this.canBroadcast(true, '!code')) return;
-		const code = Chat.getReadmoreCodeBlock(target)
+		const code = Chat.getReadmoreCodeBlock(target);
 		if (/<code>(.+)<\/code>/.test(code)) {
 			return `/html ${code}`;
 		}

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2566,9 +2566,9 @@ export const commands: ChatCommands = {
 	code(target, room, user) {
 		// target is trimmed by Chat#splitMessage, but leading spaces can be
 		// important to code block indentation.
-		target = this.message.substr(this.cmdToken.length + this.cmd.length + +this.message.includes(' ')).trimRight();
 		if (!target) return this.parse('/help code');
 		if (target.length >= 8192) return this.errorReply("Your code must be under 8192 characters long!");
+		target = this.message.substr(this.cmdToken.length + this.cmd.length + +this.message.includes(' ')).trimRight();
 		if (!this.canBroadcast(true, '!code')) return;
 		const code = Chat.getReadmoreCodeBlock(target);
 		if (target.length < 80 && !target.includes('\n') && !target.includes('```') && this.shouldBroadcast()) {

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2564,14 +2564,15 @@ export const commands: ChatCommands = {
 
 	'!code': true,
 	code(target, room, user) {
+		// target is trimmed by Chat#splitMessage, but leading spaces can be
+		// important to code block indentation.
+		target = this.message.substr(this.cmdToken.length + this.cmd.length + +this.message.includes(' ')).trimRight();
 		if (!target) return this.parse('/help code');
 		if (target.length >= 8192) return this.errorReply("Your code must be under 8192 characters long!");
-		target = this.message.substr(this.cmdToken.length + this.cmd.length + +this.message.includes(' ')).trimRight();
 		if (!this.canBroadcast(true, '!code')) return;
 		const code = Chat.getReadmoreCodeBlock(target);
-		const params = target.split('\n');
-		if (params.length === 1 && params[0].length < 80 && !params[0].includes('```') && this.shouldBroadcast()) {
-			return this.canTalk(`\`\`\`${params[0]}\`\`\``);
+		if (target.length < 80 && !target.includes('\n') && !target.includes('```') && this.shouldBroadcast()) {
+			return this.canTalk(`\`\`\`${target}\`\`\``);
 		}
 		this.runBroadcast(true);
 		if (this.broadcasting) {

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2566,9 +2566,9 @@ export const commands: ChatCommands = {
 	code(target, room, user) {
 		// target is trimmed by Chat#splitMessage, but leading spaces can be
 		// important to code block indentation.
+		target = this.message.substr(this.cmdToken.length + this.cmd.length + +this.message.includes(' ')).trimRight();
 		if (!target) return this.parse('/help code');
 		if (target.length >= 8192) return this.errorReply("Your code must be under 8192 characters long!");
-		target = this.message.substr(this.cmdToken.length + this.cmd.length + +this.message.includes(' ')).trimRight();
 		if (!this.canBroadcast(true, '!code')) return;
 		const code = Chat.getReadmoreCodeBlock(target);
 		if (target.length < 80 && !target.includes('\n') && !target.includes('```') && this.shouldBroadcast()) {

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2569,11 +2569,11 @@ export const commands: ChatCommands = {
 		target = this.message.substr(this.cmdToken.length + this.cmd.length + +this.message.includes(' ')).trimRight();
 		if (!target) return this.parse('/help code');
 		if (target.length >= 8192) return this.errorReply("Your code must be under 8192 characters long!");
-		if (!this.canBroadcast(true, '!code')) return;
-		const code = Chat.getReadmoreCodeBlock(target);
 		if (target.length < 80 && !target.includes('\n') && !target.includes('```') && this.shouldBroadcast()) {
 			return this.canTalk(`\`\`\`${target}\`\`\``);
 		}
+		if (!this.canBroadcast(true, '!code')) return;
+		const code = Chat.getReadmoreCodeBlock(target);
 		this.runBroadcast(true);
 		if (this.broadcasting) {
 			return `/raw <div class="infobox">${code}</div>`;

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2572,7 +2572,9 @@ export const commands: ChatCommands = {
 		if (target.length < 80 && !target.includes('\n') && !target.includes('```') && this.shouldBroadcast()) {
 			return this.canTalk(`\`\`\`${target}\`\`\``);
 		}
+
 		if (!this.canBroadcast(true, '!code')) return;
+
 		const code = Chat.getReadmoreCodeBlock(target);
 		this.runBroadcast(true);
 		if (this.broadcasting) {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1721,7 +1721,9 @@ export const Chat = new class {
 				output.slice(0, cutoff).join('<br />')
 			}</summary>${output.slice(cutoff).join('<br />')}</details></div>`;
 		} else {
-			code = `<div class="chat"><code style="white-space: pre-wrap; display: table; tab-size: 3">${output.join('<br />')}</code></div>`;
+			code = `<div class="chat"><code style="white-space: pre-wrap; display: table; tab-size: 3">${
+				output.join('<br />')
+			}</code></div>`;
 		}
 		return code;
 	}

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1719,7 +1719,9 @@ export const Chat = new class {
 		if (output.length > cutoff) {
 			code = `<div class="chat"><details class="readmore code" style="white-space: pre-wrap; display: table; tab-size: 3"><summary>${
 				output.slice(0, cutoff).join('<br />')
-			}</summary>${output.slice(cutoff).join('<br />')}</details></div>`;
+			}</summary>${
+				output.slice(cutoff).join('<br />')
+			}</details></div>`;
 		} else {
 			code = `<div class="chat"><code style="white-space: pre-wrap; display: table; tab-size: 3">${
 				output.join('<br />')

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1706,10 +1706,9 @@ export const Chat = new class {
 	 * If it has a newline, will make the 3 lines the preview, and fill the rest in.
 	 * @param str string to block
 	 */
-	getReadmoreCodeBlock(str: string) {
-		const params = str.substr(+str.startsWith('\n')).split('\n');
+	getReadmoreCodeBlock(str: string, cutoff = 3) {
+		const params = str.slice(+str.startsWith('\n')).split('\n');
 		const output = [];
-		let cutoff = 3;
 		for (const param of params) {
 			if (output.length < 3 && param.length > 80) cutoff = 2;
 			output.push(Utils.escapeHTML(param));

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1710,7 +1710,7 @@ export const Chat = new class {
 		const params = str.slice(+str.startsWith('\n')).split('\n');
 		const output = [];
 		for (const param of params) {
-			if (output.length < 3 && param.length > 80) cutoff = 2;
+			if (output.length < cutoff && param.length > 80 && cutoff > 2) cutoff--;
 			output.push(Utils.escapeHTML(param));
 		}
 

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1703,9 +1703,6 @@ export const Chat = new class {
 	}
 	getReadmoreCodeBlock(str: string) {
 		const params = str.substr(+str.startsWith('\n')).split('\n');
-		if (params.length === 1 && params[0].length < 80 && !params[0].includes('```')) {
-			return `<code>${params[0]}</code>`;
-		}
 		const output = [];
 		let cutoff = 3;
 		for (const param of params) {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1701,6 +1701,27 @@ export const Chat = new class {
 		htmlContent = htmlContent.replace(/\n/g, '&#10;');
 		return htmlContent;
 	}
+	getReadmoreCodeBlock(str: string) {
+		const params = str.substr(+str.startsWith('\n')).split('\n');
+		if (params.length === 1 && params[0].length < 80 && !params[0].includes('```')) {
+			return `<code>${params[0]}</code>`;
+		}
+		const output = [];
+		let cutoff = 3;
+		for (const param of params) {
+			if (output.length < 3 && param.length > 80) cutoff = 2;
+			output.push(Utils.escapeHTML(param));
+		}
+
+		let code;
+		if (output.length > cutoff) {
+			code = `<div class="chat"><details class="readmore code" style="white-space: pre-wrap; display: table; tab-size: 3"><summary>` +
+				`${output.slice(0, cutoff).join('<br />')}</summary>${output.slice(cutoff).join('<br />')}</details></div>`;
+		} else {
+			code = `<div class="chat"><code style="white-space: pre-wrap; display: table; tab-size: 3">${output.join('<br />')}</code></div>`;
+		}
+		return code;
+	}
 
 	getDataPokemonHTML(species: Species, gen = 7, tier = '') {
 		if (typeof species === 'string') species = Dex.deepClone(Dex.getSpecies(species));

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1717,8 +1717,9 @@ export const Chat = new class {
 
 		let code;
 		if (output.length > cutoff) {
-			code = `<div class="chat"><details class="readmore code" style="white-space: pre-wrap; display: table; tab-size: 3"><summary>` +
-				`${output.slice(0, cutoff).join('<br />')}</summary>${output.slice(cutoff).join('<br />')}</details></div>`;
+			code = `<div class="chat"><details class="readmore code" style="white-space: pre-wrap; display: table; tab-size: 3"><summary>${
+				output.slice(0, cutoff).join('<br />')
+			}</summary>${output.slice(cutoff).join('<br />')}</details></div>`;
 		} else {
 			code = `<div class="chat"><code style="white-space: pre-wrap; display: table; tab-size: 3">${output.join('<br />')}</code></div>`;
 		}

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1701,6 +1701,11 @@ export const Chat = new class {
 		htmlContent = htmlContent.replace(/\n/g, '&#10;');
 		return htmlContent;
 	}
+	/**
+	 * Takes a string of code and transforms it into a block of html using the details tag.
+	 * If it has a newline, will make the 3 lines the preview, and fill the rest in.
+	 * @param str string to block
+	 */
 	getReadmoreCodeBlock(str: string) {
 		const params = str.substr(+str.startsWith('\n')).split('\n');
 		const output = [];

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1714,19 +1714,17 @@ export const Chat = new class {
 			output.push(Utils.escapeHTML(param));
 		}
 
-		let code;
 		if (output.length > cutoff) {
-			code = `<div class="chat"><details class="readmore code" style="white-space: pre-wrap; display: table; tab-size: 3"><summary>${
+			return `<div class="chat"><details class="readmore code" style="white-space: pre-wrap; display: table; tab-size: 3"><summary>${
 				output.slice(0, cutoff).join('<br />')
 			}</summary>${
 				output.slice(cutoff).join('<br />')
 			}</details></div>`;
 		} else {
-			code = `<div class="chat"><code style="white-space: pre-wrap; display: table; tab-size: 3">${
+			return `<div class="chat"><code style="white-space: pre-wrap; display: table; tab-size: 3">${
 				output.join('<br />')
 			}</code></div>`;
 		}
-		return code;
 	}
 
 	getDataPokemonHTML(species: Species, gen = 7, tier = '') {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1715,15 +1715,15 @@ export const Chat = new class {
 		}
 
 		if (output.length > cutoff) {
-			return `<div class="chat"><details class="readmore code" style="white-space: pre-wrap; display: table; tab-size: 3"><summary>${
+			return `<details class="readmore code" style="white-space: pre-wrap; display: table; tab-size: 3"><summary>${
 				output.slice(0, cutoff).join('<br />')
 			}</summary>${
 				output.slice(cutoff).join('<br />')
-			}</details></div>`;
+			}</details>`;
 		} else {
-			return `<div class="chat"><code style="white-space: pre-wrap; display: table; tab-size: 3">${
+			return `<code style="white-space: pre-wrap; display: table; tab-size: 3">${
 				output.join('<br />')
-			}</code></div>`;
+			}</code>`;
 		}
 	}
 

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1086,7 +1086,6 @@ export class BasicChatRoom extends BasicRoom {
 	readonly creationTime: number | null;
 	readonly type: 'chat' | 'battle';
 	minorActivity: Poll | Announcement | null;
-	queuedActivity: Poll[] | null;
 	banwordRegex: RegExp | true | null;
 	parent: Room | null;
 	subRooms: Map<string, ChatRoom> | null;
@@ -1117,7 +1116,6 @@ export class BasicChatRoom extends BasicRoom {
 		if (!options.isPersonal) this.persist = true;
 
 		this.minorActivity = null;
-		this.queuedActivity = [];
 		this.parent = null;
 		if (options.parentid) {
 			const parent = Rooms.get(options.parentid);

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1086,6 +1086,7 @@ export class BasicChatRoom extends BasicRoom {
 	readonly creationTime: number | null;
 	readonly type: 'chat' | 'battle';
 	minorActivity: Poll | Announcement | null;
+	queuedActivity: Poll[] | null;
 	banwordRegex: RegExp | true | null;
 	parent: Room | null;
 	subRooms: Map<string, ChatRoom> | null;
@@ -1116,6 +1117,7 @@ export class BasicChatRoom extends BasicRoom {
 		if (!options.isPersonal) this.persist = true;
 
 		this.minorActivity = null;
+		this.queuedActivity = [];
 		this.parent = null;
 		if (options.parentid) {
 			const parent = Rooms.get(options.parentid);


### PR DESCRIPTION
Similar to /evalbattle, when ``>>`` is used, it now broadcasts into the room. /eval still does not. 
They both log into the development roomlogs. Also puts eval output that's larger than 200 characters (tentative) into a readmore details tag.