### PR TITLE
Update VGC to Series 5

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -288,10 +288,6 @@ export const Formats: (FormatsData | {section: string, column?: number})[] = [
 			battle: 4,
 		},
 		ruleset: ['Standard GBU', 'VGC Timer'],
-		banlist: [
-			// Can't obtain in Galar without transferring
-			'Cobalion', 'Raichu-Alola', 'Terrakion', 'Virizion', 'Weezing-Base',
-		],
 		minSourceGen: 8,
 	},
 	{


### PR DESCRIPTION
Cobalion, Terrakion, and Virizion can all be legally used via the in-game character that wipes their pastgen learnset and gives them the "battle-ready" symbol. Raichu-Alola and Weezing-Kanto can both be obtained naturally now (pretty sure) and even if they couldn't you could use the battle-ready trick to do so.

Given that the rest of DLC is already VGC legal (notably learnsets), there are no other Series 4 tournaments between now and July 1 (when we officially swap), I'm ok pushing this through early to allow hype.