### PR TITLE
"Remove" the global room

### DIFF
--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -71,7 +71,7 @@ export const commands: ChatCommands = {
 			html += Utils.html`<div style="float:right;color:#888;font-size:8pt">[${user.name}]</div><div style="clear:both"></div>`;
 		}
 
-		this.room.sendRankedUsers(`|html|<div class="infobox">${html}</div>`, rank as GroupSymbol);
+		room.sendRankedUsers(`|html|<div class="infobox">${html}</div>`, rank as GroupSymbol);
 	},
 	addrankhtmlboxhelp: [
 		`/addrankhtmlbox [rank], [message] - Shows everyone with the specified rank or higher a message, parsing HTML code contained. Requires: * # &`,
@@ -121,7 +121,7 @@ export const commands: ChatCommands = {
 		}
 
 		html = `|uhtml${(cmd === 'changerankuhtml' ? 'change' : '')}|${name}|${html}`;
-		this.room.sendRankedUsers(html, rank as GroupSymbol);
+		room.sendRankedUsers(html, rank as GroupSymbol);
 	},
 	addrankuhtmlhelp: [
 		`/addrankuhtml [rank], [name], [message] - Shows everyone with the specified rank or higher a message that can change, parsing HTML code contained.  Requires: * # &`,
@@ -324,7 +324,7 @@ export const commands: ChatCommands = {
 				// respawn simulator processes
 				void Rooms.PM.respawn();
 				// broadcast the new formats list to clients
-				Rooms.global.send(Rooms.global.formatListText);
+				Rooms.global.sendAll(Rooms.global.formatListText);
 
 				this.sendReply("Formats have been hot-patched.");
 			} else if (target === 'loginserver') {
@@ -787,7 +787,7 @@ export const commands: ChatCommands = {
 
 	refreshpage(target, room, user) {
 		if (!this.can('lockdown')) return false;
-		Rooms.global.send('|refresh|');
+		Rooms.global.sendAll('|refresh|');
 		const logRoom = Rooms.get('staff') || room;
 		logRoom.roomlog(`${user.name} used /refreshpage`);
 	},

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -507,8 +507,8 @@ export const commands: ChatCommands = {
 		target = this.splitTarget(target);
 		const targetUser = this.targetUser;
 		if (this.targetUsername === '~') {
-			this.room = Rooms.global;
 			this.pmTarget = null;
+			this.room = null;
 		} else if (!targetUser) {
 			let error = `User ${this.targetUsername} not found. Did you misspell their name?`;
 			error = `|pm|${this.user.getIdentity()}| ${this.targetUsername}|/error ${error}`;
@@ -516,7 +516,7 @@ export const commands: ChatCommands = {
 			return;
 		} else {
 			this.pmTarget = targetUser;
-			this.room = null!;
+			this.room = null;
 		}
 
 		if (targetUser && !targetUser.connected) {
@@ -547,7 +547,7 @@ export const commands: ChatCommands = {
 
 		const targetUser = this.pmTarget!; // not room means it's a PM
 
-		if (!targetRoom || targetRoom === Rooms.global) {
+		if (!targetRoom) {
 			return this.errorReply(`The room "${target}" was not found.`);
 		}
 		if (!targetRoom.checkModjoin(targetUser)) {
@@ -1393,7 +1393,7 @@ export const commands: ChatCommands = {
 			}
 
 			const targetRoom = Rooms.get(target);
-			if (!targetRoom || targetRoom === Rooms.global || (
+			if (!targetRoom || (
 				targetRoom.settings.isPrivate && !user.inRooms.has(targetRoom.roomid) && !user.games.has(targetRoom.roomid)
 			)) {
 				const roominfo = {id: target, error: 'not found or access denied'};

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -227,7 +227,7 @@ export const commands: ChatCommands = {
 		let userLookup = '';
 		if (cmd === 'roomauth1') userLookup = `\n\nTo look up auth for a user, use /userauth ${target}`;
 		let targetRoom = room;
-		if (target) targetRoom = Rooms.search(target) as ChatRoom | GameRoom;
+		if (target) targetRoom = Rooms.search(target)!;
 		if (!targetRoom || targetRoom.roomid === 'global' || !targetRoom.checkModjoin(user)) {
 			return this.errorReply(`The room "${target}" does not exist.`);
 		}
@@ -262,7 +262,7 @@ export const commands: ChatCommands = {
 				const also = buffer.length === 0 ? `` : ` also`;
 				buffer.push(`${curRoom.title} is a ${roomType}subroom of ${curRoom.parent.title}, so ${curRoom.parent.title} users${inheritedUserType}${also} have authority in this room.`);
 			}
-			curRoom = curRoom.parent as ChatRoom | GameRoom;
+			curRoom = curRoom.parent;
 		}
 		if (!buffer.length) {
 			connection.popup(`The room '${targetRoom.title}' has no auth. ${userLookup}`);
@@ -375,7 +375,7 @@ export const commands: ChatCommands = {
 	leave: 'part',
 	part(target, room, user, connection) {
 		const targetRoom = target ? Rooms.search(target) : room;
-		if (!targetRoom || targetRoom === Rooms.global) {
+		if (!targetRoom) {
 			if (target.startsWith('view-')) return;
 			return this.errorReply(`The room '${target}' does not exist.`);
 		}
@@ -1829,7 +1829,7 @@ export const commands: ChatCommands = {
 	blacklists: 'showblacklist',
 	showbl: 'showblacklist',
 	showblacklist(target, room, user, connection, cmd) {
-		if (target) room = Rooms.search(target) as ChatRoom | GameRoom;
+		if (target) room = Rooms.search(target)!;
 		if (!room) return this.errorReply(`The room "${target}" was not found.`);
 		if (!this.can('mute', null, room)) return false;
 		const SOON_EXPIRING_TIME = 3 * 30 * 24 * 60 * 60 * 1000; // 3 months

--- a/server/chat-plugins/announcements.ts
+++ b/server/chat-plugins/announcements.ts
@@ -7,11 +7,11 @@ import {Utils} from '../../lib/utils';
 export class Announcement {
 	readonly activityId: 'announcement';
 	announcementNumber: number;
-	room: ChatRoom | GameRoom;
+	room: Room;
 	source: string;
 	timeout: NodeJS.Timer | null;
 	timeoutMins: number;
-	constructor(room: ChatRoom | GameRoom, source: string) {
+	constructor(room: Room, source: string) {
 		this.activityId = 'announcement';
 		this.announcementNumber = room.nextGameNumber();
 		this.room = room;

--- a/server/chat-plugins/blackjack.ts
+++ b/server/chat-plugins/blackjack.ts
@@ -18,7 +18,7 @@ type Symbols = '♥' | '♦' | '♣' | '♠';
 type SymbolName = 'Hearts' | 'Diamonds' | 'Clubs' | 'Spades';
 
 export class Blackjack extends Rooms.RoomGame {
-	room: ChatRoom | GameRoom;
+	room: Room;
 
 	blackjack: boolean;
 
@@ -56,7 +56,7 @@ export class Blackjack extends Rooms.RoomGame {
 	playerTable: {[k: string]: BlackjackPlayer};
 	gameNumber: number;
 
-	constructor(room: ChatRoom | GameRoom, user: User, autostartMinutes = 0) {
+	constructor(room: Room, user: User, autostartMinutes = 0) {
 		super(room);
 		this.gameNumber = room.nextGameNumber();
 		this.room = room;

--- a/server/chat-plugins/chat-monitor.ts
+++ b/server/chat-plugins/chat-monitor.ts
@@ -6,7 +6,7 @@ type FilterWord = [RegExp, string, string, string | null, number];
 type MonitorHandler = (
 	this: CommandContext,
 	line: FilterWord,
-	room: ChatRoom | GameRoom | null,
+	room: Room | null,
 	user: User,
 	message: string,
 	lcMessage: string,

--- a/server/chat-plugins/daily-spotlight.ts
+++ b/server/chat-plugins/daily-spotlight.ts
@@ -52,18 +52,20 @@ export const destroy = () => {
 export const pages: PageTable = {
 	async spotlights(query, user, connection) {
 		this.title = 'Daily Spotlights';
-		this.extractRoom();
+		const room = this.extractRoom();
+		if (!room) return;
+
 		let buf = `<div class="pad ladder"><h2>Daily Spotlights</h2>`;
-		if (!spotlights[this.room.roomid]) {
+		if (!spotlights[room.roomid]) {
 			buf += `<p>This room has no daily spotlights.</p></div>`;
 		} else {
-			for (const key in spotlights[this.room.roomid]) {
+			for (const key in spotlights[room.roomid]) {
 				buf += `<table style="margin-bottom:30px;"><th colspan="2"><h3>${key}:</h3></th>`;
-				for (const [i, spotlight] of spotlights[this.room.roomid][key].entries()) {
+				for (const [i, spotlight] of spotlights[room.roomid][key].entries()) {
 					const html = await renderSpotlight(spotlight.description, spotlight.image);
 					buf += `<tr><td>${i ? i : 'Current'}</td><td>${html}</td></tr>`;
 					// @ts-ignore room is definitely a proper room here.
-					if (!user.can('announce', null, this.room)) break;
+					if (!user.can('announce', null, room)) break;
 				}
 				buf += '</table>';
 			}

--- a/server/chat-plugins/hangman.ts
+++ b/server/chat-plugins/hangman.ts
@@ -18,7 +18,7 @@ export class Hangman extends Rooms.RoomGame {
 	lastGuesser: string;
 	wordSoFar: string[];
 
-	constructor(room: ChatRoom | GameRoom, user: User, word: string, hint = '') {
+	constructor(room: Room, user: User, word: string, hint = '') {
 		super(room);
 
 		this.gameNumber = room.nextGameNumber();

--- a/server/chat-plugins/jeopardy.ts
+++ b/server/chat-plugins/jeopardy.ts
@@ -40,7 +40,7 @@ export class Jeopardy extends Rooms.RoomGame {
 	finals: boolean;
 	gameNumber: number;
 
-	constructor(room: ChatRoom | GameRoom, user: User, categoryCount: number, questionCount: number) {
+	constructor(room: Room, user: User, categoryCount: number, questionCount: number) {
 		super(room);
 		this.gameNumber = room.nextGameNumber();
 		this.playerTable = Object.create(null);

--- a/server/chat-plugins/lottery.ts
+++ b/server/chat-plugins/lottery.ts
@@ -264,19 +264,21 @@ export const commands: ChatCommands = {
 
 export const pages: PageTable = {
 	lottery(query, user) {
-		this.extractRoom();
 		this.title = 'Lottery';
+		const room = this.extractRoom();
+		if (!room) return;
+
 		let buf = '<div class="pad">';
-		const lottery = lotteries[this.room.roomid];
+		const lottery = lotteries[room.roomid];
 		if (!lottery) {
-			buf += `<h2>There is no lottery running in ${this.room.title}</h2></div>`;
+			buf += `<h2>There is no lottery running in ${room.title}</h2></div>`;
 			return buf;
 		}
 		buf += `<h2 style="text-align: center">${lottery.name}</h2>${lottery.markup}<br />`;
 		if (lottery.running) {
 			const userSignedUp = lottery.participants[user.latestIp] ||
 				Object.values(lottery.participants).map(toID).includes(user.id);
-			buf += `<button class="button" name="send" style=" display: block; margin: 0 auto" value="/lottery ${userSignedUp ? 'leave' : 'join'} ${this.room.roomid}">${userSignedUp ? "Leave the " : "Sign up for the"} lottery</button>`;
+			buf += `<button class="button" name="send" style=" display: block; margin: 0 auto" value="/lottery ${userSignedUp ? 'leave' : 'join'} ${room.roomid}">${userSignedUp ? "Leave the " : "Sign up for the"} lottery</button>`;
 		} else {
 			buf += '<p style="text-align: center"><b>This lottery has already ended. The winners are:</b></p>';
 			buf += '<ul style="display: table; margin: 0px auto">';

--- a/server/chat-plugins/modlog.ts
+++ b/server/chat-plugins/modlog.ts
@@ -569,7 +569,7 @@ export const commands: ChatCommands = {
 	pl: 'modlog',
 	timedmodlog: 'modlog',
 	modlog(target, room, user, connection, cmd) {
-		if (!room) room = Rooms.get('global') as ChatRoom | GameRoom;
+		if (!room) (room as Room | undefined) = Rooms.get('global');
 		let roomid: RoomID = (room.roomid === 'staff' ? 'global' : room.roomid);
 
 		if (target.includes(',')) {

--- a/server/chat-plugins/poll.ts
+++ b/server/chat-plugins/poll.ts
@@ -14,7 +14,7 @@ interface Option {
 export class Poll {
 	readonly activityId: 'poll';
 	pollNumber: number;
-	room: ChatRoom | GameRoom;
+	room: Room;
 	question: string;
 	supportHTML: boolean;
 	multiPoll: boolean;
@@ -26,7 +26,7 @@ export class Poll {
 	timeoutMins: number;
 	isQuiz: boolean;
 	options: Map<number, Option>;
-	constructor(room: ChatRoom | GameRoom, questionData: QuestionData, options: string[], multi: boolean) {
+	constructor(room: Room, questionData: QuestionData, options: string[], multi: boolean) {
 		this.activityId = 'poll';
 		this.pollNumber = room.nextGameNumber();
 		this.room = room;

--- a/server/chat-plugins/scavenger-games.ts
+++ b/server/chat-plugins/scavenger-games.ts
@@ -663,12 +663,12 @@ const MODES: {[k: string]: GameMode | string} = {
 };
 
 export class ScavengerGameTemplate {
-	room: ChatRoom | GameRoom;
+	room: Room;
 	playerlist: null | string[];
 	timer: NodeJS.Timer | null;
 
 	[k: string]: any;
-	constructor(room: GameRoom | ChatRoom) {
+	constructor(room: Room) {
 		this.room = room;
 		this.playerlist = null;
 		this.timer = null;
@@ -694,7 +694,7 @@ export class ScavengerGameTemplate {
 	}
 }
 
-const LoadGame = function (room: ChatRoom | GameRoom, gameid: string) {
+const LoadGame = function (room: Room, gameid: string) {
 	let game = MODES[gameid];
 	if (!game) return false; // invalid id
 	if (typeof game === 'string') game = MODES[game];

--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -202,7 +202,7 @@ if (LeaderboardRoom) {
 	LeaderboardRoom.scavLeaderboard.scavsPlayerLeaderboard = PlayerLeaderboard;
 }
 
-function formatQueue(queue: QueuedHunt[] | undefined, viewer: User, room: ChatRoom | GameRoom, broadcasting?: boolean) {
+function formatQueue(queue: QueuedHunt[] | undefined, viewer: User, room: Room, broadcasting?: boolean) {
 	const showStaff = viewer.can('mute', null, room) && !broadcasting;
 	const queueDisabled = room.settings.scavSettings?.scavQueueDisabled;
 	const timerDuration = room.settings.scavSettings?.defaultScavTimer || DEFAULT_TIMER_DURATION;
@@ -353,7 +353,7 @@ export class ScavengerHunt extends Rooms.RoomGame {
 
 	[k: string]: any; // for purposes of adding new temporary properties for the purpose of twists.
 	constructor(
-		room: ChatRoom | GameRoom,
+		room: Room,
 		staffHost: User | FakeUser,
 		hosts: FakeUser[],
 		gameType: GameTypes,
@@ -952,7 +952,7 @@ export class ScavengerHunt extends Rooms.RoomGame {
 		return ips.filter((ip, index) => ips.indexOf(ip) === index).length;
 	}
 
-	static parseHosts(hostArray: string[], room: ChatRoom | GameRoom, allowOffline?: boolean) {
+	static parseHosts(hostArray: string[], room: Room, allowOffline?: boolean) {
 		const hosts = [];
 		for (const u of hostArray) {
 			const id = toID(u);
@@ -2345,11 +2345,13 @@ const ScavengerCommands: ChatCommands = {
 export const pages: PageTable = {
 	recycledHunts(query, user, connection) {
 		this.title = 'Recycled Hunts';
+		const room = this.extractRoom();
+		if (!room) return;
+
 		let buf = "";
-		this.extractRoom();
 		if (!user.named) return Rooms.RETRY_AFTER_LOGIN;
-		if (!this.room.persist) return;
-		if (!this.can('mute', null, this.room)) return;
+		if (!room.persist) return;
+		if (!this.can('mute', null, room)) return;
 		buf += `<div class="pad"><h2>List of recycled Scavenger hunts</h2>`;
 		buf += `<ol style="width: 90%;">`;
 		for (const hunt of scavengersData.recycledHunts) {

--- a/server/chat-plugins/thing-of-the-day.ts
+++ b/server/chat-plugins/thing-of-the-day.ts
@@ -680,7 +680,7 @@ export const otdCommands: ChatCommands = {
 		return handler.generateWinnerDisplay().then(text => {
 			if (!text) return this.errorReply("There is no winner yet.");
 			this.sendReplyBox(text);
-			this.room.update();
+			room.update();
 		});
 	},
 };

--- a/server/chat-plugins/trivia.ts
+++ b/server/chat-plugins/trivia.ts
@@ -320,7 +320,7 @@ class Trivia extends Rooms.RoomGame {
 	curAnswers: string[];
 	askedAt: number[];
 	constructor(
-		room: GameRoom | ChatRoom, mode: string, category: string,
+		room: Room, mode: string, category: string,
 		length: string, questions: TriviaQuestion[], isRandomMode = false
 	) {
 		super(room);

--- a/server/chat-plugins/uno.ts
+++ b/server/chat-plugins/uno.ts
@@ -100,7 +100,7 @@ export class UnoGame extends Rooms.RoomGame {
 	isPlusFour: boolean;
 	gameNumber: number;
 
-	constructor(room: ChatRoom | GameRoom, cap: number, suppressMessages: boolean) {
+	constructor(room: Room, cap: number, suppressMessages: boolean) {
 		super(room);
 
 		this.playerTable = Object.create(null);

--- a/server/chat-plugins/wifi.ts
+++ b/server/chat-plugins/wifi.ts
@@ -34,7 +34,7 @@ class Giveaway {
 	gaNumber: number;
 	host: User;
 	giver: User;
-	room: ChatRoom | GameRoom;
+	room: Room;
 	ot: string;
 	tid: string;
 	prize: string;
@@ -45,7 +45,7 @@ class Giveaway {
 	sprite: string;
 
 	constructor(
-		host: User, giver: User, room: ChatRoom | GameRoom,
+		host: User, giver: User, room: Room,
 		ot: string, tid: string, prize: string
 	) {
 		this.gaNumber = room.nextGameNumber();
@@ -111,15 +111,15 @@ class Giveaway {
 		return false;
 	}
 
-	static checkBanned(room: ChatRoom | GameRoom, user: User) {
+	static checkBanned(room: Room, user: User) {
 		return Punishments.getRoomPunishType(room, toID(user)) === 'GIVEAWAYBAN';
 	}
 
-	static ban(room: ChatRoom | GameRoom, user: User, reason: string) {
+	static ban(room: Room, user: User, reason: string) {
 		Punishments.roomPunish(room, user, ['GIVEAWAYBAN', toID(user), Date.now() + BAN_DURATION, reason]);
 	}
 
-	static unban(room: ChatRoom | GameRoom, user: User) {
+	static unban(room: Room, user: User) {
 		Punishments.roomUnpunish(room, toID(user), 'GIVEAWAYBAN', false);
 	}
 
@@ -219,7 +219,7 @@ export class QuestionGiveaway extends Giveaway {
 	winner: User | null;
 
 	constructor(
-		host: User, giver: User, room: ChatRoom | GameRoom, ot: string, tid: string,
+		host: User, giver: User, room: Room, ot: string, tid: string,
 		prize: string, question: string, answers: string[]
 	) {
 		super(host, giver, room, ot, tid, prize);
@@ -359,7 +359,7 @@ export class LotteryGiveaway extends Giveaway {
 	maxWinners: number;
 
 	constructor(
-		host: User, giver: User, room: ChatRoom | GameRoom, ot: string,
+		host: User, giver: User, room: Room, ot: string,
 		tid: string, prize: string, winners: number
 	) {
 		super(host, giver, room, ot, tid, prize);
@@ -484,7 +484,7 @@ export class LotteryGiveaway extends Giveaway {
 
 export class GTSGiveaway {
 	gtsNumber: number;
-	room: ChatRoom | GameRoom;
+	room: Room;
 	giver: User;
 	left: number;
 	summary: string;
@@ -497,7 +497,7 @@ export class GTSGiveaway {
 	timer: NodeJS.Timer | null;
 
 	constructor(
-		room: ChatRoom | GameRoom, giver: User, amount: number,
+		room: Room, giver: User, amount: number,
 		summary: string, deposit: string, lookfor: string
 	) {
 		this.gtsNumber = room.nextGameNumber();

--- a/server/global-types.ts
+++ b/server/global-types.ts
@@ -29,7 +29,7 @@ namespace Chat {
 }
 
 // Rooms
-type GlobalRoom = Rooms.GlobalRoom;
+type GlobalRoomState = Rooms.GlobalRoomState;
 type ChatRoom = Rooms.ChatRoom;
 type GameRoom = Rooms.GameRoom;
 type BasicRoom = Rooms.BasicRoom;
@@ -40,7 +40,7 @@ type Roomlog = Rooms.Roomlog;
 type Room = Rooms.Room;
 type RoomID = "" | "global" | "lobby" | "staff" | "upperstaff" | "development" | "battle" | string & {__isRoomID: true};
 namespace Rooms {
-	export type GlobalRoom = import('./rooms').GlobalRoom;
+	export type GlobalRoomState = import('./rooms').GlobalRoomState;
 	export type ChatRoom = import('./rooms').ChatRoom;
 	export type GameRoom = import('./rooms').GameRoom;
 	export type BasicRoom = import('./rooms').BasicRoom;

--- a/server/room-game.ts
+++ b/server/room-game.ts
@@ -81,7 +81,7 @@ export class RoomGame {
 	 * The room this roomgame is in. Rooms can only have one RoomGame at a time,
 	 * which are available as `this.room.game === this`.
 	 */
-	room: ChatRoom | GameRoom;
+	room: Room;
 	gameid: ID;
 	title: string;
 	allowRenames: boolean;
@@ -100,7 +100,7 @@ export class RoomGame {
 	 * to be later. The /timer command is written to be resilient to this.
 	 */
 	timer?: {timerRequesters?: Set<ID>, start: (force?: User) => void, stop: (force?: User) => void} | NodeJS.Timer | null;
-	constructor(room: ChatRoom | GameRoom) {
+	constructor(room: Room) {
 		this.roomid = room.roomid;
 		this.room = room;
 		this.gameid = 'game' as ID;

--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -458,9 +458,11 @@ export class ServerStream extends Streams.ObjectReadWriteStream<string> {
 		case '#':
 			// #roomid, message
 			// message to all connections in room
+			// #, message
+			// message to all connections
 			nlLoc = data.indexOf('\n');
 			roomid = data.substr(1, nlLoc - 1) as RoomID;
-			room = this.rooms.get(roomid);
+			room = roomid ? this.rooms.get(roomid) : this.sockets;
 			if (!room) return;
 			message = data.substr(nlLoc + 1);
 			for (const curSocket of room.values()) curSocket.write(message);

--- a/server/users.ts
+++ b/server/users.ts
@@ -391,6 +391,7 @@ export class User extends Chat.MessageContext {
 		this.avatar = DEFAULT_TRAINER_SPRITES[Math.floor(Math.random() * DEFAULT_TRAINER_SPRITES.length)];
 
 		this.connected = true;
+		Users.onlineCount++;
 
 		if (connection.user) connection.user = this;
 		this.connections = [connection];
@@ -457,7 +458,7 @@ export class User extends Chat.MessageContext {
 
 	sendTo(roomid: RoomID | BasicRoom | null, data: string) {
 		if (roomid && typeof roomid !== 'string') roomid = (roomid as BasicRoom).roomid;
-		if (roomid && roomid !== 'global' && roomid !== 'lobby') data = `>${roomid}\n${data}`;
+		if (roomid && roomid !== 'lobby') data = `>${roomid}\n${data}`;
 		for (const connection of this.connections) {
 			if (roomid && !connection.inRooms.has(roomid)) continue;
 			connection.send(data);
@@ -479,7 +480,7 @@ export class User extends Chat.MessageContext {
 			const lockedSymbol = (punishgroups.locked && punishgroups.locked.symbol || '\u203d');
 			return lockedSymbol + this.name;
 		}
-		if (roomid && roomid !== 'global') {
+		if (roomid) {
 			const room = Rooms.get(roomid);
 			if (!room) {
 				throw new Error(`Room doesn't exist: ${roomid}`);
@@ -946,7 +947,10 @@ export class User extends Chat.MessageContext {
 	mergeConnection(connection: Connection) {
 		// the connection has changed name to this user's username, and so is
 		// being merged into this account
-		this.connected = true;
+		if (!this.connected) {
+			this.connected = true;
+			Users.onlineCount++;
+		}
 		if (connection.connectedAt > this.lastConnected) {
 			this.lastConnected = connection.connectedAt;
 		}
@@ -1079,7 +1083,9 @@ export class User extends Chat.MessageContext {
 		return removed;
 	}
 	markDisconnected() {
+		if (!this.connected) return;
 		this.connected = false;
+		Users.onlineCount--;
 		this.lastDisconnected = Date.now();
 		if (!this.registered) {
 			// for "safety"
@@ -1217,12 +1223,7 @@ export class User extends Chat.MessageContext {
 		if (!room) throw new Error(`Room not found: ${roomid}`);
 		if (!connection) {
 			for (const curConnection of this.connections) {
-				// only join full clients, not pop-out single-room
-				// clients
-				// (...no, pop-out rooms haven't been implemented yet)
-				if (curConnection.inRooms.has('global')) {
-					this.joinRoom(room, curConnection);
-				}
+				this.joinRoom(room, curConnection);
 			}
 			return;
 		}
@@ -1295,7 +1296,7 @@ export class User extends Chat.MessageContext {
 	 * The user says message in room.
 	 * Returns false if the rest of the user's messages should be discarded.
 	 */
-	chat(message: string, room: Room, connection: Connection) {
+	chat(message: string, room: Room | null, connection: Connection) {
 		const now = Date.now();
 
 		if (message.startsWith('/cmd userdetails') || message.startsWith('>> ') || this.isSysop) {
@@ -1318,10 +1319,10 @@ export class User extends Chat.MessageContext {
 				);
 				return false;
 			} else {
-				this.chatQueue.push([message, room.roomid, connection]);
+				this.chatQueue.push([message, room ? room.roomid : '', connection]);
 			}
 		} else if (now < this.lastChatMessage + throttleDelay) {
-			this.chatQueue = [[message, room.roomid, connection]];
+			this.chatQueue = [[message, room ? room.roomid : '', connection]];
 			this.startChatQueue(throttleDelay - (now - this.lastChatMessage));
 		} else {
 			this.lastChatMessage = now;
@@ -1366,12 +1367,12 @@ export class User extends Chat.MessageContext {
 		this.lastChatMessage = new Date().getTime();
 
 		const room = Rooms.get(roomid);
-		if (room) {
+		if (room || !roomid) {
 			Monitor.activeIp = connection.ip;
 			Chat.parse(message, room, this, connection);
 			Monitor.activeIp = null;
 		} else {
-			// room is expired, do nothing
+			// room no longer exists; do nothing
 		}
 
 		const throttleDelay = this.trusted ? THROTTLE_DELAY_TRUSTED : THROTTLE_DELAY;
@@ -1516,7 +1517,7 @@ function socketConnect(
 		}
 	});
 
-	user.joinRoom('global', connection);
+	Rooms.global.handleConnect(user, connection);
 }
 function socketDisconnect(worker: StreamWorker, workerid: number, socketid: string) {
 	const id = '' + workerid + '-' + socketid;
@@ -1558,11 +1559,10 @@ function socketReceive(worker: StreamWorker, workerid: number, socketid: string,
 	if (!user) return;
 
 	// The client obviates the room id when sending messages to Lobby by default
-	const roomId = message.substr(0, pipeIndex) || (Rooms.lobby || Rooms.global).roomid;
+	const roomId = message.slice(0, pipeIndex) || (Rooms.lobby && 'lobby') || '';
 	message = message.slice(pipeIndex + 1);
 
-	const room = Rooms.get(roomId);
-	if (!room) return;
+	const room = Rooms.get(roomId) || null;
 	const multilineMessage = Chat.multiLinePattern.test(message);
 	if (multilineMessage) {
 		user.chat(multilineMessage, room, connection);
@@ -1571,7 +1571,8 @@ function socketReceive(worker: StreamWorker, workerid: number, socketid: string,
 
 	const lines = message.split('\n');
 	if (!lines[lines.length - 1]) lines.pop();
-	const maxLineCount = (user.isStaff || room.auth.isStaff(user.id)) ?
+	// eslint-disable-next-line @typescript-eslint/prefer-optional-chain
+	const maxLineCount = (user.isStaff || (room && room.auth.isStaff(user.id))) ?
 		THROTTLE_MULTILINE_WARN_STAFF : THROTTLE_MULTILINE_WARN;
 	if (lines.length > maxLineCount) {
 		connection.popup(`You're sending too many lines at once. Try using a paste service like [[Pastebin]].`);
@@ -1603,6 +1604,7 @@ export const Users = {
 	merge,
 	users,
 	prevUsers,
+	onlineCount: 0,
 	get: getUser,
 	getExact: getExactUser,
 	findUsers,

--- a/test/server/chat-plugins/trivia.js
+++ b/test/server/chat-plugins/trivia.js
@@ -14,9 +14,7 @@ let NumberModeTrivia;
 function makeUser(name, connection) {
 	const user = new User(connection);
 	user.forceRename(name, true);
-	user.connected = true;
 	Users.users.set(user.id, user);
-	user.joinRoom('global', connection);
 	user.joinRoom('trivia', connection);
 	return user;
 }

--- a/test/users-utils.js
+++ b/test/users-utils.js
@@ -164,7 +164,6 @@ function createUser(connection) {
 	if (!connection) connection = createConnection();
 
 	const user = new Users.User(connection);
-	user.joinRoom('global', connection);
 	connection.user = user;
 
 	return user;


### PR DESCRIPTION
I couldn't completely remove the global room in one commit, but this solves basically every problem with it by making it no longer a `Room`.

In particular, this means:

- It's no longer of type `Room`
- It's no longer in the `Rooms.rooms` table
- Its class name is now `GlobalRoomState` rather than `GlobalRoom`
- It no longer tracks its own user list (online user count is now provided by `Users.onlineCount`)
- It's no longer a socket channel (there's new syntax for "send this message to every user")