### PR TITLE
Youtube: ensure video data exists in the response

### DIFF
--- a/server/chat-plugins/youtube.ts
+++ b/server/chat-plugins/youtube.ts
@@ -35,7 +35,7 @@ export class YoutubeInterface {
 		const queryUrl = `${CHANNEL}?part=snippet%2Cstatistics&id=${encodeURIComponent(id)}&key=${Config.youtubeKey}`;
 		const raw = await Net(queryUrl).get();
 		const res = JSON.parse(raw);
-		if (!res || !res.items || res.items.length > 1) return;
+		if (!res || !res.items || res.items.length < 1) return;
 		const data = res.items[0];
 		const cache = {
 			name: data.snippet.title,
@@ -125,7 +125,7 @@ export class YoutubeInterface {
 		const queryUrl = `${ROOT}videos?part=snippet%2Cstatistics&id=${encodeURIComponent(id)}&key=${Config.youtubeKey}`;
 		const raw = await Net(queryUrl).get();
 		const res = JSON.parse(raw);
-		if (!res || !res.items || res.items.length > 1) return;
+		if (!res || !res.items || res.items.length < 1) return;
 		const video = res.items[0];
 		const info = {
 			title: video.snippet.title,

--- a/server/chat-plugins/youtube.ts
+++ b/server/chat-plugins/youtube.ts
@@ -35,7 +35,7 @@ export class YoutubeInterface {
 		const queryUrl = `${CHANNEL}?part=snippet%2Cstatistics&id=${encodeURIComponent(id)}&key=${Config.youtubeKey}`;
 		const raw = await Net(queryUrl).get();
 		const res = JSON.parse(raw);
-		if (!res || !res.items) return null;
+		if (!res || !res.items || res.items.length > 1) return;
 		const data = res.items[0];
 		const cache = {
 			name: data.snippet.title,
@@ -125,7 +125,7 @@ export class YoutubeInterface {
 		const queryUrl = `${ROOT}videos?part=snippet%2Cstatistics&id=${encodeURIComponent(id)}&key=${Config.youtubeKey}`;
 		const raw = await Net(queryUrl).get();
 		const res = JSON.parse(raw);
-		if (!res.items) return;
+		if (!res || !res.items || res.items.length > 1) return;
 		const video = res.items[0];
 		const info = {
 			title: video.snippet.title,


### PR DESCRIPTION
Not sure how this hasn't been tripped before. The first item holds the video data, so without that you get an issue. 