### PR TITLE
Remove incorrect host classification

### DIFF
--- a/server/ip-tools.ts
+++ b/server/ip-tools.ts
@@ -178,7 +178,6 @@ export const IPTools = new class {
 		'tmobile.mobile-nohost',
 		'tele2.se',
 		'ideacellular.mobile-nohost',
-		'as13285.net',
 		'att.net',
 	]);
 	readonly connectionTestCache = new Map<string, boolean>();


### PR DESCRIPTION
A large portion of the IPs with that hostname are static broadband connections.