### PR TITLE
RBY: Move Clefairy to NFE

### DIFF
--- a/data/mods/gen1/formats-data.ts
+++ b/data/mods/gen1/formats-data.ts
@@ -177,7 +177,7 @@ export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		randomBattleMoves: ["bodyslam", "thunderwave", "thunderbolt"],
 		essentialMove: "blizzard",
 		exclusiveMoves: ["counter", "sing", "sing", "psychic", "seismictoss"],
-		tier: "LC",
+		tier: "NFE",
 	},
 	clefable: {
 		randomBattleMoves: ["bodyslam", "thunderwave", "thunderbolt"],


### PR DESCRIPTION
Clefairy isn't available at or below level 5 from RBY or from trading back from GSC