### PR TITLE
Trivia: Fix bug in /trivia history

### DIFF
--- a/server/chat-plugins/trivia.ts
+++ b/server/chat-plugins/trivia.ts
@@ -1678,7 +1678,7 @@ const commands: ChatCommands = {
 		if (!this.runBroadcast()) return false;
 		if (!triviaData.history?.length) return this.sendReplyBox("There is no game history.");
 
-		const games = triviaData.history.reverse();
+		const games = [...triviaData.history].reverse();
 		const buf = [];
 		for (const [i, game] of games.entries()) {
 			buf.push(Utils.html`<b>${i + 1}.</b> ${game.mode} mode, ${game.length} length Trivia game in the ${game.category} category.`);


### PR DESCRIPTION
Fixes this bug where the reversed history gets saved.
<img width="603" alt="image" src="https://user-images.githubusercontent.com/56906084/85359014-047e4900-b4ca-11ea-944f-db07321a5bd9.png">
