### PR TITLE
Info: Support viewing current media requests and hiding media

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2472,7 +2472,8 @@ export const commands: ChatCommands = {
 		});
 		this.sendReply(`You have requested to show the link: ${link}${comment ? ` (with the comment ${comment})` : ''}.`);
 		const notifyId = `${room.roomid}-rank-driver`;
-		const message = `|tempnotify|${notifyId}|${room.title} media request!|${user.name} has requested to show media in ${room.title}.`;
+		let message = `|tempnotify|${notifyId}|Pending media request!`;
+		message += `|${user.name} has requested to show media in ${room.title}.|new media request`;
 		room.sendRankedUsers(message, '%');
 		room.sendMods(
 			Utils.html`|uhtml|request-${user.id}|<div class="infobox">${user.name} wants to show <a href="${link}">${link}</a><br>` +

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2536,6 +2536,7 @@ export const commands: ChatCommands = {
 
 		room.pendingApprovals!.delete(target);
 		room.sendMods(`|uhtmlchange|request-${target}|`);
+		room.sendRankedUsers(`|tempnotifyoff|pendingapprovals`, '%');
 		this.privateModAction(`(${user.name} denied ${target}'s request to display ${entry.link}.)`);
 	},
 	denyshowhelp: [`/denyshow [user] - Denies the media display request of [user]. Requires: % @ # &`],

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2660,9 +2660,9 @@ export const pages: PageTable = {
 		let buf = `<div class="pad"><strong>Pending media requests on ${room.title}</strong><hr />`;
 		for (const [userid, entry] of room.pendingApprovals) {
 			buf += `<strong>${entry.name}</strong><div class="infobox">`;
-			buf += `<strong>ID:</strong> ${userid}<br>`;
+			buf += `<strong>Requester ID:</strong> ${userid}<br>`;
 			buf += `<strong>Link:</strong> ${entry.link}<br>`;
-			buf += `<strong>Comment:</strong> ${entry.comment}`
+			buf += `<strong>Comment:</strong> ${entry.comment}`;
 			buf += `</div><hr/ >`;
 		}
 		return buf;

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2471,9 +2471,8 @@ export const commands: ChatCommands = {
 			comment: comment,
 		});
 		this.sendReply(`You have requested to show the link: ${link}${comment ? ` (with the comment ${comment})` : ''}.`);
-		const notifyId = `${room.roomid}-rank-driver`;
-		let message = `|tempnotify|${notifyId}|Pending media request!`;
-		message += `|${user.name} has requested to show media in ${room.title}.|new media request`;
+		const message = `|tempnotify|pendingapprovals|Pending media request!` +
+			`|${user.name} has requested to show media in ${room.title}.|new media request`;
 		room.sendRankedUsers(message, '%');
 		room.sendMods(
 			Utils.html`|uhtml|request-${user.id}|<div class="infobox">${user.name} wants to show <a href="${link}">${link}</a><br>` +

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2519,7 +2519,7 @@ export const commands: ChatCommands = {
 		} else {
 			buf += `</small></div>>`;
 		}
-		room.add(`|c|${request.name}|/uhtml ${request.name},${buf}`).update();
+		room.add(`|c|${request.name}|/raw ${buf}`).update();
 		this.privateModAction(`${user.name} has approved the display of ${request.name}'s media approval.`);
 	},
 	approveshowhelp: [`/approveshow [user] - Approves the media display request of [user]. Requires: % @ # &`],

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2520,7 +2520,7 @@ export const commands: ChatCommands = {
 			buf += `</small></div>>`;
 		}
 		room.add(`|c|${request.name}|/raw ${buf}`).update();
-		this.privateModAction(`${user.name} has approved the display of ${request.name}'s media approval.`);
+		this.privateModAction(`${user.name} approved showing media from ${request.name}.`);
 	},
 	approveshowhelp: [`/approveshow [user] - Approves the media display request of [user]. Requires: % @ # &`],
 

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2457,7 +2457,7 @@ export const commands: ChatCommands = {
 		if (!room.settings.requestShowEnabled) {
 			return this.errorReply(`Media approvals are disabled in this room.`);
 		}
-		if (this.can('showmedia', null, room)) return this.errorReply(`Use !show instead.`);
+		if (user.can('showmedia', null, room)) return this.errorReply(`Use !show instead.`);
 		if (room.pendingApprovals?.has(user.id)) return this.errorReply('You have a request pending already.');
 		if (!toID(target)) return this.parse(`/help requestshow`);
 

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2471,6 +2471,9 @@ export const commands: ChatCommands = {
 			comment: comment,
 		});
 		this.sendReply(`You have requested to show the link: ${link}${comment ? ` (with the comment ${comment})` : ''}.`);
+		const notifyId = `${room.roomid}-rank-driver`;
+		const message = `|tempnotify|${notifyId}|${room.title} media request!|${user.name} has requested to show media in ${room.title}.`;
+		room.sendRankedUsers(message, '%');
 		room.sendMods(
 			Utils.html`|uhtml|request-${user.id}|<div class="infobox">${user.name} wants to show <a href="${link}">${link}</a><br>` +
 			`<button class="button" name="send" value="/approveshow ${user.id}">Approve</button><br>` +

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2528,12 +2528,12 @@ export const commands: ChatCommands = {
 		target = toID(target);
 		if (!target) return this.parse(`/help denyshow`);
 
-		const link = room.pendingApprovals?.get(target);
-		if (!link) return this.errorReply(`${target} has no pending request.`);
+		const entry = room.pendingApprovals?.get(target);
+		if (!entry) return this.errorReply(`${target} has no pending request.`);
 
 		room.pendingApprovals!.delete(target);
 		room.sendMods(`|uhtmlchange|request-${target}|`);
-		this.privateModAction(`(${user.name} denied ${target}'s request to display ${link}.)`);
+		this.privateModAction(`(${user.name} denied ${target}'s request to display ${entry.link}.)`);
 	},
 	denyshowhelp: [`/denyshow [user] - Denies the media display request of [user]. Requires: % @ # &`],
 

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2519,7 +2519,7 @@ export const commands: ChatCommands = {
 		} else {
 			buf += `</small></div>>`;
 		}
-		room.add(`|c|${request.name}|/raw ${buf}`).update();
+		room.add(`|c| ${request.name}|/raw ${buf}`);
 		this.privateModAction(`${user.name} approved showing media from ${request.name}.`);
 	},
 	approveshowhelp: [`/approveshow [user] - Approves the media display request of [user]. Requires: % @ # &`],

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2516,7 +2516,7 @@ export const commands: ChatCommands = {
 			buf += `</small></div>>`;
 		}
 		room.add(`|c|${request.name}|/uhtml ${request.name},${buf}`).update();
-		this.modlog('APPROVESHOW', null, `${request.name} (link: ${request.link})`);
+		this.privateModAction(`${user.name} has approved the display of ${request.name}'s media approval.`);
 	},
 	approveshowhelp: [`/approveshow [user] - Approves the media display request of [user]. Requires: % @ # &`],
 
@@ -2534,11 +2534,14 @@ export const commands: ChatCommands = {
 		room.pendingApprovals!.delete(target);
 		room.sendMods(`|uhtmlchange|request-${target}|`);
 		this.privateModAction(`(${user.name} denied ${target}'s request to display ${link}.)`);
-		this.modlog(`DENYSHOW`, null, `${target}`);
 	},
 	denyshowhelp: [`/denyshow [user] - Denies the media display request of [user]. Requires: % @ # &`],
 
-	viewrequests(target, room, user) {
+	approvallog(target, room, user) {
+		return this.parse(`/sl has approved the display of, ${room.roomid}`);
+	},
+
+	viewapprovals(target, room, user) {
 		return this.parse(`/join view-approvals-${room.roomid}`);
 	},
 
@@ -2652,7 +2655,7 @@ export const pages: PageTable = {
 		buf += Punishments.visualizePunishments(sP, user);
 		return buf;
 	},
-	approvals(args, user) {
+	approvals(args) {
 		const room = Rooms.get(args[0]) as ChatRoom | GameRoom;
 		if (!this.can('mute', null, this.room)) return;
 		if (!room.pendingApprovals) room.pendingApprovals = new Map();
@@ -2661,7 +2664,7 @@ export const pages: PageTable = {
 		for (const [userid, entry] of room.pendingApprovals) {
 			buf += `<strong>${entry.name}</strong><div class="infobox">`;
 			buf += `<strong>Requester ID:</strong> ${userid}<br>`;
-			buf += `<strong>Link:</strong> ${entry.link}<br>`;
+			buf += `<strong>Link:</strong> <a href="${entry.link}">${entry.link}</a><br>`;
 			buf += `<strong>Comment:</strong> ${entry.comment}`;
 			buf += `</div><hr/ >`;
 		}

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2496,7 +2496,8 @@ export const commands: ChatCommands = {
 			return this.errorReply(`You can't approve your own /show request.`);
 		}
 		room.pendingApprovals!.delete(userid);
-		room.sendMods(`|uhtmlchange|request-${userid}|`);
+		room.sendMods(`|uhtmlchange|request-${target}|`);
+		room.sendRankedUsers(`|tempnotifyoff|pendingapprovals`, '%');
 
 		let buf;
 		if (/^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.be)(\/|$)/i.test(request.link)) {

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2542,7 +2542,7 @@ export const commands: ChatCommands = {
 	denyshowhelp: [`/denyshow [user] - Denies the media display request of [user]. Requires: % @ # &`],
 
 	approvallog(target, room, user) {
-		return this.parse(`/sl has approved the display of, ${room.roomid}`);
+		return this.parse(`/sl approved showing media from, ${room.roomid}`);
 	},
 
 	viewapprovals(target, room, user) {
@@ -2667,10 +2667,10 @@ export const pages: PageTable = {
 		let buf = `<div class="pad"><strong>Pending media requests on ${room.title}</strong><hr />`;
 		for (const [userid, entry] of room.pendingApprovals) {
 			buf += `<strong>${entry.name}</strong><div class="infobox">`;
-			buf += `<strong>Requester ID:</strong> ${userid}<br>`;
-			buf += `<strong>Link:</strong> <a href="${entry.link}">${entry.link}</a><br>`;
+			buf += `<strong>Requester ID:</strong> ${userid}<br />`;
+			buf += `<strong>Link:</strong> <a href="${entry.link}">${entry.link}</a><br />`;
 			buf += `<strong>Comment:</strong> ${entry.comment}`;
-			buf += `</div><hr/ >`;
+			buf += `</div><hr />`;
 		}
 		return buf;
 	},

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2517,7 +2517,7 @@ export const commands: ChatCommands = {
 		if (request.comment) {
 			buf += Utils.html`<br />${request.comment}</small></div>`;
 		} else {
-			buf += `</small></div>>`;
+			buf += `</small></div>`;
 		}
 		room.add(`|c| ${request.name}|/raw ${buf}`);
 		this.privateModAction(`${user.name} approved showing media from ${request.name}.`);

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1292,9 +1292,9 @@ export class BasicChatRoom extends BasicRoom {
 				message += `<div class="infobox">`;
 				message += `<strong>Requester ID:</strong> ${userid}<br/ >`;
 				message += `<strong>Link:</strong> <a href="${entry.link}">${entry.link}</a><br/ >`;
-				message+= `<strong>Comment:</strong> ${entry.comment ? entry.comment : 'None.'}<br/ >`;
+				message += `<strong>Comment:</strong> ${entry.comment ? entry.comment : 'None.'}<br/ >`;
 				message += `<button class="button" name="send" value="/approveshow ${userid}">Approve</button>` +
-				`<button class="button" name="send" value="/denyshow ${userid}">Deny</button></div>`
+				`<button class="button" name="send" value="/denyshow ${userid}">Deny</button></div>`;
 				message += `</div><hr/ >`;
 			}
 			message += `</details></div>`;

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1285,7 +1285,7 @@ export class BasicChatRoom extends BasicRoom {
 				this.settings.staffMessage.replace(/\n/g, '') +
 				`</div>`;
 		}
-		if (this.pendingApprovals && this.pendingApprovals.size > 0 && user.can('mute', null, this)) {
+		if (this.pendingApprovals?.size && user.can('mute', null, this)) {
 			message += `\n|raw|<div class="infobox">`;
 			message += `<details><summary>(Pending media requests: ${this.pendingApprovals.size})</summary>`;
 			for (const [userid, entry] of this.pendingApprovals) {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1290,12 +1290,12 @@ export class BasicChatRoom extends BasicRoom {
 			message += `<details><summary>(Pending media requests: ${this.pendingApprovals.size})</summary>`;
 			for (const [userid, entry] of this.pendingApprovals) {
 				message += `<div class="infobox">`;
-				message += `<strong>Requester ID:</strong> ${userid}<br/ >`;
-				message += `<strong>Link:</strong> <a href="${entry.link}">${entry.link}</a><br/ >`;
-				message += `<strong>Comment:</strong> ${entry.comment ? entry.comment : 'None.'}<br/ >`;
+				message += `<strong>Requester ID:</strong> ${userid}<br />`;
+				message += `<strong>Link:</strong> <a href="${entry.link}">${entry.link}</a><br />`;
+				message += `<strong>Comment:</strong> ${entry.comment ? entry.comment : 'None.'}<br />`;
 				message += `<button class="button" name="send" value="/approveshow ${userid}">Approve</button>` +
 				`<button class="button" name="send" value="/denyshow ${userid}">Deny</button></div>`;
-				message += `</div><hr/ >`;
+				message += `</div><hr />`;
 			}
 			message += `</details></div>`;
 		}

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1285,6 +1285,20 @@ export class BasicChatRoom extends BasicRoom {
 				this.settings.staffMessage.replace(/\n/g, '') +
 				`</div>`;
 		}
+		if (this.pendingApprovals && this.pendingApprovals.size > 0) {
+			message += `\n|raw|<div class="infobox">`;
+			message += `<details><summary>(Pending media requests: ${this.pendingApprovals.size})</summary>`;
+			for (const [userid, entry] of this.pendingApprovals) {
+				message += `<div class="infobox">`;
+				message += `<strong>Requester ID:</strong> ${userid}<br/ >`;
+				message += `<strong>Link:</strong> <a href="${entry.link}">${entry.link}</a><br/ >`;
+				message+= `<strong>Comment:</strong> ${entry.comment ? entry.comment : 'None.'}<br/ >`;
+				message += `<button class="button" name="send" value="/approveshow ${userid}">Approve</button>` +
+				`<button class="button" name="send" value="/denyshow ${userid}">Deny</button></div>`
+				message += `</div><hr/ >`;
+			}
+			message += `</details></div>`;
+		}
 		return message;
 	}
 	getSubRooms(includeSecret = false) {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1285,7 +1285,7 @@ export class BasicChatRoom extends BasicRoom {
 				this.settings.staffMessage.replace(/\n/g, '') +
 				`</div>`;
 		}
-		if (this.pendingApprovals && this.pendingApprovals.size > 0) {
+		if (this.pendingApprovals && this.pendingApprovals.size > 0 && user.can('mute', null, this)) {
 			message += `\n|raw|<div class="infobox">`;
 			message += `<details><summary>(Pending media requests: ${this.pendingApprovals.size})</summary>`;
 			for (const [userid, entry] of this.pendingApprovals) {


### PR DESCRIPTION
Requests from various room staff.
- support /hidetexting requested media once shown (done with using /uhtml)
- support viewing pending requests (done in a page)
- modlog who approves / denies a link 
On another note, makes the comment on /requestshow more viewable by putting it in a box.
