### PR TITLE
Fix multiple bugs in events

### DIFF
--- a/server/chat-plugins/room-events.ts
+++ b/server/chat-plugins/room-events.ts
@@ -245,7 +245,7 @@ export const commands: ChatCommands = {
 				return this.errorReply(`There is no event titled '${target}'. Check spelling?`);
 			}
 
-			delete room.settings.events[target];
+			delete room.settings.events[eventID];
 			for (const alias of getAliases(room, eventID)) {
 				delete room.settings.events[alias];
 			}

--- a/server/chat-plugins/room-events.ts
+++ b/server/chat-plugins/room-events.ts
@@ -522,9 +522,9 @@ export const commands: ChatCommands = {
 			}
 
 			// rebuild the room.settings.events object
-			room.settings.events = {};
 			for (const sortedObj of sortable) {
 				const eventId = toID(sortedObj.eventName);
+				delete room.settings.events[eventId];
 				room.settings.events[eventId] = sortedObj;
 			}
 

--- a/server/chat-plugins/room-events.ts
+++ b/server/chat-plugins/room-events.ts
@@ -522,6 +522,7 @@ export const commands: ChatCommands = {
 			}
 
 			// rebuild the room.settings.events object
+			room.settings.events = {};
 			for (const sortedObj of sortable) {
 				const eventId = toID(sortedObj.eventName);
 				room.settings.events[eventId] = sortedObj;


### PR DESCRIPTION
Pretty self-explanatory, `/events remove Test Event` didn't remove the event because Test Event isn't an ID. Now it uses eventID

Edit: found a second bug, added a commit to fix.