### PR TITLE
Adjust fractional priority for latest research

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -2990,11 +2990,11 @@ export const BattleAbilities: {[abilityid: string]: AbilityData} = {
 	},
 	quickdraw: {
 		shortDesc: "This Pokemon has a 30% chance to move first in its priority bracket with attacking moves.",
-		onFractionalPriorityPriority: -1,
+		onFractionalPriorityPriority: -2,
 		onFractionalPriority(priority, pokemon, target, move) {
-			if (move.category !== "Status" && this.randomChance(3, 10)) {
+			if (priority <= 0 && move.category !== "Status" && this.randomChance(3, 10)) {
 				this.add('-activate', pokemon, 'ability: Quick Draw');
-				return Math.round(priority) + 0.1;
+				return 0.1;
 			}
 		},
 		name: "Quick Draw",
@@ -3727,9 +3727,7 @@ export const BattleAbilities: {[abilityid: string]: AbilityData} = {
 	},
 	stall: {
 		shortDesc: "This Pokemon moves last among Pokemon using the same or greater priority moves.",
-		onFractionalPriority(priority) {
-			return Math.round(priority) - 0.1;
-		},
+		onFractionalPriority: -0.1,
 		name: "Stall",
 		rating: -1,
 		num: 100,

--- a/data/items.ts
+++ b/data/items.ts
@@ -1095,7 +1095,7 @@ export const BattleItems: {[itemid: string]: ItemData} = {
 			if (pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))) {
 				if (pokemon.eatItem()) {
 					this.add('-activate', pokemon, 'item: Custap Berry', '[consumed]');
-					return Math.round(priority) + 0.1;
+					return 0.1;
 				}
 			}
 		},
@@ -2078,9 +2078,7 @@ export const BattleItems: {[itemid: string]: ItemData} = {
 		fling: {
 			basePower: 10,
 		},
-		onFractionalPriority(priority, pokemon) {
-			return Math.round(priority) - 0.1;
-		},
+		onFractionalPriority: -0.1,
 		num: 316,
 		gen: 4,
 		desc: "Holder moves last in its priority bracket.",
@@ -2913,9 +2911,7 @@ export const BattleItems: {[itemid: string]: ItemData} = {
 		fling: {
 			basePower: 10,
 		},
-		onFractionalPriority(priority, pokemon) {
-			return Math.round(priority) - 0.1;
-		},
+		onFractionalPriority: -0.1,
 		num: 279,
 		gen: 4,
 		desc: "Holder moves last in its priority bracket.",
@@ -4596,11 +4592,11 @@ export const BattleItems: {[itemid: string]: ItemData} = {
 		desc: "A Poke Ball that provides a better catch rate at the start of a wild encounter.",
 	},
 	quickclaw: {
-		onFractionalPriorityPriority: -1,
+		onFractionalPriorityPriority: -3,
 		onFractionalPriority(priority, pokemon) {
-			if (this.randomChance(1, 5)) {
+			if (priority <= 0 && this.randomChance(1, 5)) {
 				this.add('-activate', pokemon, 'item: Quick Claw');
-				return Math.round(priority) + 0.1;
+				return 0.1;
 			}
 		},
 		name: "Quick Claw",

--- a/data/mods/gen2/items.ts
+++ b/data/mods/gen2/items.ts
@@ -81,7 +81,7 @@ export const BattleItems: {[k: string]: ModdedItemData} = {
 		desc: "Each turn, holder has a ~23.4% chance to move first in its priority bracket.",
 		onFractionalPriority(priority, pokemon) {
 			if (this.randomChance(60, 256)) {
-				return Math.round(priority) + 0.1;
+				return 0.1;
 			}
 		},
 	},

--- a/data/mods/gen3/items.ts
+++ b/data/mods/gen3/items.ts
@@ -254,7 +254,7 @@ export const BattleItems: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		onFractionalPriority(priority, pokemon) {
 			if (this.randomChance(1, 5)) {
-				return Math.round(priority) + 0.1;
+				return 0.1;
 			}
 		},
 	},

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -233,7 +233,7 @@ interface EventMethods {
 	onEffectiveness?: MoveEventMethods['onEffectiveness'];
 	onFaint?: CommonHandlers['VoidEffect'];
 	onFlinch?: ((this: Battle, pokemon: Pokemon) => boolean | void) | boolean;
-	onFractionalPriority?: CommonHandlers['ModifierSourceMove'];
+	onFractionalPriority?: CommonHandlers['ModifierSourceMove'] | -0.1;
 	onHit?: MoveEventMethods['onHit'];
 	onImmunity?: (this: Battle, type: string, pokemon: Pokemon) => void;
 	onLockMove?: string | ((this: Battle, pokemon: Pokemon) => void | string);


### PR DESCRIPTION
The main change is due to Anubis's research into Quick Draw and Quick Claw; the latter only gets a chance to activate if the former does not.

While I was there I noticed that the fractional priority is always `-0.1`, `0`, or `0.1`, so that the `Math.round()` is pointless which simplifies the code.

I also assumed that Custap Berry, should it ever be released, will activate in preference to Quick Draw.