### PR TITLE
Don't sort player array in-place when scoring round robin tournaments

### DIFF
--- a/server/tournaments/generator-round-robin.ts
+++ b/server/tournaments/generator-round-robin.ts
@@ -172,7 +172,7 @@ export class RoundRobin {
 	getResults() {
 		if (!this.isTournamentEnded()) return 'TournamentNotEnded';
 
-		const sortedScores = this.players.sort(
+		const sortedScores = this.players.slice().sort(
 			(p1, p2) => p2.score - p1.score
 		);
 


### PR DESCRIPTION
Fixes a regression from PR #5492 which removed a `map` from the relevant expression, thus causing the player array itself to become sorted, which means that players are no longer associated with their correct battle results (the scores are still correct though).