### PR TITLE
Support throwing error messages

### DIFF
--- a/server/chat-plugins/trivia.ts
+++ b/server/chat-plugins/trivia.ts
@@ -130,17 +130,16 @@ function isTriviaRoom(room: Room) {
 	return false;
 }
 
-function getTriviaGame(context: CommandContext) {
-	const room = context.room;
-	if (!room) return false;
+function getTriviaGame(room: Room | null) {
+	if (!room) {
+		throw new Chat.ErrorMessage(`This command can only be used in the Trivia room.`);
+	}
 	const game = room.game;
 	if (!game) {
-		context.errorReply(`There is no game in progress.`);
-		return false;
+		throw new Chat.ErrorMessage(`There is no game in progress.`);
 	}
 	if (!game.constructor.name.endsWith('Trivia')) {
-		context.errorReply(`The currently running game is not Trivia, it's ${game.title}.`);
-		return false;
+		throw new Chat.ErrorMessage(`The currently running game is not Trivia, it's ${game.title}.`);
 	}
 	return game as Trivia;
 }
@@ -1131,9 +1130,8 @@ const commands: ChatCommands = {
 
 	join(target, room, user) {
 		if (!room) return this.requiresRoom();
-		if (!isTriviaRoom(room)) return this.errorReply("This command can only be used in Trivia.");
-		const game = getTriviaGame(this);
-		if (!game) return;
+		const game = getTriviaGame(room);
+
 		const res = game.addTriviaPlayer(user);
 		if (res) return this.errorReply(res);
 		this.sendReply('You are now signed up for this game!');
@@ -1142,11 +1140,9 @@ const commands: ChatCommands = {
 
 	kick(target, room, user) {
 		if (!room) return this.requiresRoom();
-		if (!isTriviaRoom(room)) return this.errorReply("This command can only be used in Trivia.");
-		if (!this.can('mute', null, room)) return false;
 		if (!this.canTalk()) return;
-		const game = getTriviaGame(this);
-		if (!game) return;
+		const game = getTriviaGame(room);
+		if (!this.can('mute', null, room)) return false;
 
 		this.splitTarget(target);
 		const targetUser = this.targetUser;
@@ -1158,23 +1154,20 @@ const commands: ChatCommands = {
 	kickhelp: [`/trivia kick [username] - Kick players from a trivia game by username. Requires: % @ # &`],
 
 	leave(target, room, user) {
-		if (!room) return this.requiresRoom();
-		if (!isTriviaRoom(room)) return this.errorReply("This command can only be used in Trivia.");
-		const game = getTriviaGame(this);
-		if (!game) return;
+		const game = getTriviaGame(room);
+
 		const res = game.leave(user);
 		if (res) return this.errorReply(res);
-		this.sendReply("You have left the current game of trivia.");
+		this.sendReply("You have left the current game of Trivia.");
 	},
 	leavehelp: [`/trivia leave - Makes the player leave the game.`],
 
 	start(target, room) {
 		if (!room) return this.requiresRoom();
-		if (!isTriviaRoom(room)) return this.errorReply("This command can only be used in Trivia.");
 		if (!this.can('show', null, room)) return false;
 		if (!this.canTalk()) return;
-		const game = getTriviaGame(this);
-		if (!game) return;
+		const game = getTriviaGame(room);
+
 		const res = game.start();
 		if (res) return this.errorReply(res);
 		// ...
@@ -1183,9 +1176,7 @@ const commands: ChatCommands = {
 
 	answer(target, room, user) {
 		if (!room) return this.requiresRoom();
-		if (!isTriviaRoom(room)) return this.errorReply("This command can only be used in Trivia.");
-		const game = getTriviaGame(this);
-		if (!game) return;
+		const game = getTriviaGame(room);
 
 		const answer = toID(target);
 		if (!answer) return this.errorReply("No valid answer was entered.");
@@ -1202,11 +1193,10 @@ const commands: ChatCommands = {
 
 	end(target, room, user) {
 		if (!room) return this.requiresRoom();
-		if (!isTriviaRoom(room)) return this.errorReply("This command can only be used in Trivia.");
 		if (!this.can('show', null, room)) return false;
 		if (!this.canTalk()) return;
-		const game = getTriviaGame(this);
-		if (!game) return;
+		const game = getTriviaGame(room);
+
 		game.end(user);
 	},
 	endhelp: [`/trivia end - Forcibly end a trivia game. Requires: + % @ # &`],
@@ -1215,10 +1205,9 @@ const commands: ChatCommands = {
 	players: 'status',
 	status(target, room, user) {
 		if (!room) return this.requiresRoom();
-		if (!isTriviaRoom(room)) return this.errorReply("This command can only be used in Trivia.");
 		if (!this.runBroadcast()) return false;
-		const game = getTriviaGame(this);
-		if (!game) return;
+		const game = getTriviaGame(room);
+
 		let tarUser;
 		if (target) {
 			this.splitTarget(target);

--- a/server/chat-plugins/youtube.ts
+++ b/server/chat-plugins/youtube.ts
@@ -28,7 +28,9 @@ export class YoutubeInterface {
 		this.intervalTime = 0;
 	}
 	async getChannelData(link: string, username?: string) {
-		if (!Config.youtubeKey) throw new Error("Must set up Config.youtubeKey");
+		if (!Config.youtubeKey) {
+			throw new Chat.ErrorMessage(`This server does not support YouTube commands. If you're the owner, you can enable them by setting up Config.youtubekey.`);
+		}
 		const id = this.getId(link);
 		if (!id) return null;
 		const raw = await Net(`${ROOT}channels`).get({
@@ -119,7 +121,9 @@ export class YoutubeInterface {
 		return id;
 	}
 	async generateVideoDisplay(link: string) {
-		if (!Config.youtubeKey) throw new Error("Must set up Config.youtubeKey");
+		if (!Config.youtubeKey) {
+			throw new Chat.ErrorMessage(`This server does not support YouTube commands. If you're the owner, you can enable them by setting up Config.youtubekey.`);
+		}
 		const id = this.getId(link);
 		if (!id) return null;
 		const raw = await Net(`${ROOT}videos`).get({
@@ -163,7 +167,6 @@ export const commands: ChatCommands = {
 	async randchannel(target, room, user) {
 		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'youtube') return this.errorReply(`This command can only be used in the YouTube room.`);
-		if (!Config.youtubeKey) return this.errorReply(`Youtube is not configured.`);
 		if (Object.keys(channelData).length < 1) return this.errorReply(`No channels in the database.`);
 		this.runBroadcast();
 		const data = await YouTube.randChannel();
@@ -183,7 +186,6 @@ export const commands: ChatCommands = {
 		async addchannel(target, room, user) {
 			if (!room) return this.requiresRoom();
 			if (room.roomid !== 'youtube') return this.errorReply(`This command can only be used in the YouTube room.`);
-			if (!Config.youtubeKey) return this.errorReply(`Youtube is not configured.`);
 			const [id, name] = target.split(',');
 			if (!id) return this.errorReply('Specify a channel ID.');
 			const data = await YouTube.getChannelData(id, name);
@@ -198,7 +200,6 @@ export const commands: ChatCommands = {
 		removechannel(target, room, user) {
 			if (!room) return this.requiresRoom();
 			if (room.roomid !== 'youtube') return this.errorReply(`This command can only be used in the YouTube room.`);
-			if (!Config.youtubeKey) return this.errorReply(`Youtube is not configured.`);
 			if (!this.can('mute', null, room)) return false;
 			const id = YouTube.channelSearch(target);
 			if (!id) return this.errorReply(`Channel with ID or name ${target} not found.`);
@@ -212,7 +213,6 @@ export const commands: ChatCommands = {
 		async channel(target, room, user) {
 			if (!room) return this.requiresRoom();
 			if (room.roomid !== 'youtube') return this.errorReply(`This command can only be used in the YouTube room.`);
-			if (!Config.youtubeKey) return this.errorReply(`Youtube is not configured.`);
 			const channel = YouTube.channelSearch(target);
 			if (!channel) return this.errorReply(`No channels with ID or name ${target} found.`);
 			const data = await YouTube.generateChannelDisplay(channel);
@@ -231,7 +231,6 @@ export const commands: ChatCommands = {
 		async video(target, room, user) {
 			if (!room) return this.requiresRoom();
 			if (room.roomid !== 'youtube') return this.errorReply(`This command can only be used in the YouTube room.`);
-			if (!Config.youtubeKey) return this.errorReply(`Youtube is not configured.`);
 			if (!target) return this.errorReply(`Provide a valid youtube link.`);
 			const html = await YouTube.generateVideoDisplay(target);
 			if (!html) return this.errorReply(`This url is invalid. Please use a youtu.be link or a youtube.com link.`);
@@ -248,7 +247,6 @@ export const commands: ChatCommands = {
 		channels(target, room, user) {
 			let all;
 			if (toID(target) === 'all') all = true;
-			if (!Config.youtubeKey) return this.errorReply(`Youtube is not configured.`);
 			return this.parse(`/j view-channels${all ? '-all' : ''}`);
 		},
 		help(target, room, user) {
@@ -271,7 +269,6 @@ export const commands: ChatCommands = {
 		async repeat(target, room, user) {
 			if (!room) return this.requiresRoom();
 			if (room.roomid !== 'youtube') return this.errorReply(`This command can only be used in the YouTube room.`);
-			if (!Config.youtubeKey) return this.errorReply(`Youtube is not configured.`);
 			if (!this.can('declare', null, room)) return false;
 			if (!target) return this.sendReply(`Interval is currently set to ${Chat.toDurationString(YouTube.intervalTime)}.`);
 			if (Object.keys(channelData).length < 1) return this.errorReply(`No channels in the database.`);


### PR DESCRIPTION
This has been discussed extensively on Discord, but in case any of you don't keep up there or want more details...

This change adds a new class `Chat.ErrorMessage extends Error`, which can be thrown. If thrown inside a chat command, PS won't crash, but will instead send its message to the user as an error message. Otherwise, PS will crash normally.

The purpose here is to eliminate some boilerplate. This would otherwise have been written:

```ts
try {
  doAThing();
} catch (e) {
  return this.errorReply(e.message);
}
```

But by standardizing an error type that's intended to represent a user error, we can simplify this to:

```ts
doAThing();
```

The main disadvantage here is that it's no longer obvious that `doAThing()` can throw, exiting the scope and preventing anything more from happening. I've mulled a lot of possibilities and think there's no real good solution to this problem, but also that it isn't _that_ important (`throw` already exists). I think we would do well to prefix these sorts of functions with `check` to make it clearer what's going on, where relevant.