### PR TITLE
Server side changes to support persistent user settings and privacy changes

### DIFF
--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -158,8 +158,8 @@ export const commands: ChatCommands = {
 			return this.errorReply("You do not have permission to use this command to users who are not in this room.");
 		}
 		if (
-			targetUser.blockPMs &&
-			(targetUser.blockPMs === true || !user.authAtLeast(targetUser.blockPMs)) && !user.can('lock')
+			targetUser.settings.blockPMs &&
+			(targetUser.settings.blockPMs === true || !user.authAtLeast(targetUser.settings.blockPMs)) && !user.can('lock')
 		) {
 			Chat.maybeNotifyBlocked('pm', targetUser, user);
 			return this.errorReply("This user is currently blocking PMs.");
@@ -196,8 +196,8 @@ export const commands: ChatCommands = {
 		if (!(targetUser.id in room.users) && !user.can('addhtml')) {
 			return this.errorReply("You do not have permission to use this command to users who are not in this room.");
 		}
-		if (targetUser.blockPMs &&
-			(targetUser.blockPMs === true || !user.authAtLeast(targetUser.blockPMs)) && !user.can('lock')) {
+		if (targetUser.settings.blockPMs &&
+			(targetUser.settings.blockPMs === true || !user.authAtLeast(targetUser.settings.blockPMs)) && !user.can('lock')) {
 			Chat.maybeNotifyBlocked('pm', targetUser, user);
 			return this.errorReply("This user is currently blocking PMs.");
 		}

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -16,7 +16,7 @@
 
 /* eslint no-else-return: "error" */
 import {Utils} from '../../lib/utils';
-type UserSettings = import('../users').UserSettings;
+type UserSettings = import('../users').User['settings'];
 
 const avatarTable = new Set([
 	'aaron',
@@ -730,7 +730,8 @@ export const commands: ChatCommands = {
 					}
 				}
 			}
-			user.updateSettings(settings);
+			Object.assign(user.settings, settings);
+			user.update();
 		} catch {
 			this.errorReply("Unable to parse settings in /updatesettings!");
 		}
@@ -1289,7 +1290,7 @@ export const commands: ChatCommands = {
 	saveteam: 'useteam',
 	utm: 'useteam',
 	useteam(target, room, user) {
-		user.team = target;
+		user.battleSettings.team = target;
 	},
 
 	vtm(target, room, user, connection) {
@@ -1304,7 +1305,7 @@ export const commands: ChatCommands = {
 		);
 		if (format.effectType !== 'Format') return this.popupReply("Please provide a valid format.");
 
-		return TeamValidatorAsync.get(format.id).validateTeam(user.team).then(result => {
+		return TeamValidatorAsync.get(format.id).validateTeam(user.battleSettings.team).then(result => {
 			const matchMessage = (originalFormat === format ? "" : `The format '${originalFormat.name}' was not found.`);
 			if (result.charAt(0) === '1') {
 				connection.popup(`${(matchMessage ? matchMessage + "\n\n" : "")}Your team is valid for ${format.name}.`);

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -563,18 +563,18 @@ export const commands: ChatCommands = {
 	ignorepm: 'blockpms',
 	blockpms(target, room, user) {
 		if (toID(target) === 'ac') target = 'autoconfirmed';
-		if (user.blockPMs === (target || true)) {
+		if (user.settings.blockPMs === (target || true)) {
 			return this.errorReply(this.tr("You are already blocking private messages! To unblock, use /unblockpms"));
 		}
 		if (target in Config.groups) {
-			user.blockPMs = target;
+			user.settings.blockPMs = target;
 			this.sendReply(this.tr `You are now blocking private messages, except from staff and ${target}.`);
 		} else if (target === 'autoconfirmed' || target === 'trusted' || target === 'unlocked') {
-			user.blockPMs = target;
+			user.settings.blockPMs = target;
 			target = this.tr(target);
 			this.sendReply(this.tr `You are now blocking private messages, except from staff and ${target} users.`);
 		} else {
-			user.blockPMs = true;
+			user.settings.blockPMs = true;
 			this.sendReply(this.tr("You are now blocking private messages, except from staff."));
 		}
 		user.update('blockPMs');
@@ -589,8 +589,10 @@ export const commands: ChatCommands = {
 	unignorepms: 'unblockpms',
 	unignorepm: 'unblockpms',
 	unblockpms(target, room, user) {
-		if (!user.blockPMs) return this.errorReply(this.tr("You are not blocking private messages! To block, use /blockpms"));
-		user.blockPMs = false;
+		if (!user.settings.blockPMs) {
+			return this.errorReply(this.tr("You are not blocking private messages! To block, use /blockpms"));
+		}
+		user.settings.blockPMs = false;
 		user.update('blockPMs');
 		return this.sendReply(this.tr("You are no longer blocking private messages."));
 	},
@@ -1219,8 +1221,8 @@ export const commands: ChatCommands = {
 	blockchall: 'blockchallenges',
 	blockchalls: 'blockchallenges',
 	blockchallenges(target, room, user) {
-		if (user.blockChallenges) return this.errorReply(this.tr("You are already blocking challenges!"));
-		user.blockChallenges = true;
+		if (user.settings.blockChallenges) return this.errorReply(this.tr("You are already blocking challenges!"));
+		user.settings.blockChallenges = true;
 		user.update('blockChallenges');
 		this.sendReply(this.tr("You are now blocking all incoming challenge requests."));
 	},
@@ -1233,8 +1235,8 @@ export const commands: ChatCommands = {
 	unblockchalls: 'allowchallenges',
 	unblockchallenges: 'allowchallenges',
 	allowchallenges(target, room, user) {
-		if (!user.blockChallenges) return this.errorReply(this.tr("You are already available for challenges!"));
-		user.blockChallenges = false;
+		if (!user.settings.blockChallenges) return this.errorReply(this.tr("You are already available for challenges!"));
+		user.settings.blockChallenges = false;
 		user.update('blockChallenges');
 		this.sendReply(this.tr("You are available for challenges from now on."));
 	},

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -139,11 +139,11 @@ export const commands: ChatCommands = {
 		const groupConfig = Config.groups[Users.PLAYER_SYMBOL];
 		if (!groupConfig?.editprivacy) return this.errorReply(`/ionext - Access denied.`);
 		if (this.meansNo(target)) {
-			user.inviteOnlyNextBattle = false;
+			user.settings.inviteOnlyNextBattle = false;
 			user.update('inviteOnlyNextBattle');
 			this.sendReply("Your next battle will be publicly visible.");
 		} else {
-			user.inviteOnlyNextBattle = true;
+			user.settings.inviteOnlyNextBattle = true;
 			user.update('inviteOnlyNextBattle');
 			if (user.forcedPublic) {
 				return this.errorReply(`Your next battle will be invite-only provided it is not rated, otherwise your '${user.forcedPublic}' prefix will force the battle to be public.`);

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -986,6 +986,27 @@ export const commands: ChatCommands = {
 		`/publicroom - Makes a room public. Requires: \u2606 &`,
 	],
 
+	hidenext(target, room, user) {
+		const groupConfig = Config.groups[Users.PLAYER_SYMBOL];
+		if (!groupConfig?.editprivacy) return this.errorReply(`/hidenext - Access denied.`);
+		if (this.meansNo(target)) {
+			user.settings.hideNextBattle = false;
+			user.update();
+			this.sendReply("Your next battle will be publicly visible.");
+		} else {
+			user.settings.hideNextBattle = true;
+			user.update();
+			if (user.forcedPublic) {
+				return this.errorReply(`Your next battle will be hidden provided it is not rated, otherwise your '${user.forcedPublic}' prefix will force the battle to be public.`);
+			}
+			this.sendReply("Your next battle will be hidden");
+		}
+	},
+	hidenexthelp: [
+		`/hidenext - Sets your next battle to be hidden.`,
+		`/hidenext off - Sets your next battle to be publicly visible.`,
+	],
+
 	officialchatroom: 'officialroom',
 	officialroom(target, room, user) {
 		if (!room) return this.requiresRoom();

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -139,11 +139,11 @@ export const commands: ChatCommands = {
 		const groupConfig = Config.groups[Users.PLAYER_SYMBOL];
 		if (!groupConfig?.editprivacy) return this.errorReply(`/ionext - Access denied.`);
 		if (this.meansNo(target)) {
-			user.settings.inviteOnlyNextBattle = false;
+			user.battleSettings.inviteOnly = false;
 			user.update();
 			this.sendReply("Your next battle will be publicly visible.");
 		} else {
-			user.settings.inviteOnlyNextBattle = true;
+			user.battleSettings.inviteOnly = true;
 			user.update();
 			if (user.forcedPublic) {
 				return this.errorReply(`Your next battle will be invite-only provided it is not rated, otherwise your '${user.forcedPublic}' prefix will force the battle to be public.`);
@@ -990,11 +990,11 @@ export const commands: ChatCommands = {
 		const groupConfig = Config.groups[Users.PLAYER_SYMBOL];
 		if (!groupConfig?.editprivacy) return this.errorReply(`/hidenext - Access denied.`);
 		if (this.meansNo(target)) {
-			user.settings.hideNextBattle = false;
+			user.battleSettings.hidden = false;
 			user.update();
 			this.sendReply("Your next battle will be publicly visible.");
 		} else {
-			user.settings.hideNextBattle = true;
+			user.battleSettings.hidden = true;
 			user.update();
 			if (user.forcedPublic) {
 				return this.errorReply(`Your next battle will be hidden provided it is not rated, otherwise your '${user.forcedPublic}' prefix will force the battle to be public.`);

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -140,11 +140,11 @@ export const commands: ChatCommands = {
 		if (!groupConfig?.editprivacy) return this.errorReply(`/ionext - Access denied.`);
 		if (this.meansNo(target)) {
 			user.settings.inviteOnlyNextBattle = false;
-			user.update('inviteOnlyNextBattle');
+			user.update();
 			this.sendReply("Your next battle will be publicly visible.");
 		} else {
 			user.settings.inviteOnlyNextBattle = true;
-			user.update('inviteOnlyNextBattle');
+			user.update();
 			if (user.forcedPublic) {
 				return this.errorReply(`Your next battle will be invite-only provided it is not rated, otherwise your '${user.forcedPublic}' prefix will force the battle to be public.`);
 			}

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -1391,7 +1391,7 @@ export const commands: ChatCommands = {
 				return this.errorReply(`You are already ignoring help ticket notifications. Use /helpticket unignore to receive notifications again.`);
 			}
 			user.settings.ignoreTickets = true;
-			user.update('ignoreTickets');
+			user.update();
 			this.sendReply(`You are now ignoring help ticket notifications.`);
 		},
 		ignorehelp: [`/helpticket ignore - Ignore notifications for unclaimed help tickets. Requires: % @ &`],
@@ -1402,7 +1402,7 @@ export const commands: ChatCommands = {
 				return this.errorReply(`You are not ignoring help ticket notifications. Use /helpticket ignore to stop receiving notifications.`);
 			}
 			user.settings.ignoreTickets = false;
-			user.update('ignoreTickets');
+			user.update();
 			this.sendReply(`You will now receive help ticket notifications.`);
 		},
 		unignorehelp: [`/helpticket unignore - Stop ignoring notifications for help tickets. Requires: % @ &`],

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -368,7 +368,7 @@ function notifyUnclaimedTicket(hasAssistRequest: boolean) {
 	timerEnds[room.roomid] = 0;
 	for (const i in room.users) {
 		const user: User = room.users[i];
-		if (user.can('mute', null, room) && !user.ignoreTickets) {
+		if (user.can('mute', null, room) && !user.settings.ignoreTickets) {
 			user.sendTo(
 				room,
 				`|tempnotify|helptickets|Unclaimed help tickets!|${hasAssistRequest ? 'Public Room Staff need help' : 'There are unclaimed Help tickets'}`
@@ -1387,10 +1387,10 @@ export const commands: ChatCommands = {
 
 		ignore(target, room, user) {
 			if (!this.can('lock')) return;
-			if (user.ignoreTickets) {
+			if (user.settings.ignoreTickets) {
 				return this.errorReply(`You are already ignoring help ticket notifications. Use /helpticket unignore to receive notifications again.`);
 			}
-			user.ignoreTickets = true;
+			user.settings.ignoreTickets = true;
 			user.update('ignoreTickets');
 			this.sendReply(`You are now ignoring help ticket notifications.`);
 		},
@@ -1398,10 +1398,10 @@ export const commands: ChatCommands = {
 
 		unignore(target, room, user) {
 			if (!this.can('lock')) return;
-			if (!user.ignoreTickets) {
+			if (!user.settings.ignoreTickets) {
 				return this.errorReply(`You are not ignoring help ticket notifications. Use /helpticket ignore to stop receiving notifications.`);
 			}
-			user.ignoreTickets = false;
+			user.settings.ignoreTickets = false;
 			user.update('ignoreTickets');
 			this.sendReply(`You will now receive help ticket notifications.`);
 		},

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1877,14 +1877,14 @@ export const Chat = new class {
 		const prefix = `|pm|&|${targetUser.getIdentity()}|/nonotify `;
 		const options = 'or change it in the <button name="openOptions" class="subtle">Options</button> menu in the upper right.';
 		if (blocked === 'pm') {
-			if (!targetUser.blockPMsNotified) {
+			if (!targetUser.notified.blockPMs) {
 				targetUser.send(`${prefix}The user '${Utils.escapeHTML(user.name)}' attempted to PM you but was blocked. To enable PMs, use /unblockpms ${options}`);
-				targetUser.blockPMsNotified = true;
+				targetUser.notified.blockPMs = true;
 			}
 		} else if (blocked === 'challenge') {
-			if (!targetUser.blockChallengesNotified) {
+			if (!targetUser.notified.blockChallenges) {
 				targetUser.send(`${prefix}The user '${Utils.escapeHTML(user.name)}' attempted to challenge you to a battle but was blocked. To enable challenges, use /unblockchallenges ${options}`);
-				targetUser.blockChallengesNotified = true;
+				targetUser.notified.blockChallenges = true;
 			}
 		}
 	}

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -918,8 +918,8 @@ export class CommandContext extends MessageContext {
 					this.errorReply(`On this server, you must be of rank ${groupName} or higher to PM users.`);
 					return null;
 				}
-				if (targetUser.blockPMs &&
-					(targetUser.blockPMs === true || !user.authAtLeast(targetUser.blockPMs)) &&
+				if (targetUser.settings.blockPMs &&
+					(targetUser.settings.blockPMs === true || !user.authAtLeast(targetUser.settings.blockPMs)) &&
 					!user.can('lock')) {
 					Chat.maybeNotifyBlocked('pm', targetUser, user);
 					if (!targetUser.can('lock')) {
@@ -931,8 +931,8 @@ export class CommandContext extends MessageContext {
 						return null;
 					}
 				}
-				if (user.blockPMs && (user.blockPMs === true ||
-					!targetUser.authAtLeast(user.blockPMs)) && !targetUser.can('lock')) {
+				if (user.settings.blockPMs && (user.settings.blockPMs === true ||
+					!targetUser.authAtLeast(user.settings.blockPMs)) && !targetUser.can('lock')) {
 					this.errorReply(`You are blocking private messages right now.`);
 					return null;
 				}

--- a/server/ladders.ts
+++ b/server/ladders.ts
@@ -216,7 +216,7 @@ class Ladder extends LadderStore {
 			connection.popup(`You are already challenging someone. Cancel that challenge before challenging someone else.`);
 			return false;
 		}
-		if (targetUser.blockChallenges && !user.can('bypassblocks', targetUser)) {
+		if (targetUser.settings.blockChallenges && !user.can('bypassblocks', targetUser)) {
 			connection.popup(`The user '${targetUser.name}' is not accepting challenges right now.`);
 			Chat.maybeNotifyBlocked('challenge', targetUser, user);
 			return false;

--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -1093,7 +1093,7 @@ export const Punishments = new class {
 					const appealLink = ticket || (Config.appealurl ? `appeal at: ${Config.appealurl}` : ``);
 					// Prioritize popups for other global punishments
 					user.send(`|popup||html|You are banned from battling${battleban[1] !== userid ? ` because you have the same IP as banned user: ${battleban[1]}` : ''}. Your battle ban will expire in a few days.${battleban[3] ? Utils.html `\n\nReason: ${battleban[3]}` : ``}${appealLink ? `\n\nOr you can ${appealLink}.` : ``}`);
-					user.punishmentNotified = true;
+					user.notified.punishment = true;
 					return;
 				}
 			}
@@ -1128,7 +1128,7 @@ export const Punishments = new class {
 				`Your username (${user.name}) is banned${bannedUnder}. Your ban will expire in a few days.${reason}` +
 				`${Config.appealurl ? `||||Or you can appeal at: ${Config.appealurl}` : ``}`
 			);
-			user.punishmentNotified = true;
+			user.notified.punishment = true;
 			void Punishments.punish(user, punishment, false);
 			user.disconnectAll();
 			return;
@@ -1144,10 +1144,10 @@ export const Punishments = new class {
 				user.send(`|popup||html|Your IP (${user.latestIp}) is currently locked due to being a proxy. We automatically lock these connections since they are used to spam, hack, or otherwise attack our server. Disable any proxies you are using to connect to PS.\n\n<a href="view-help-request--appeal"><button class="button">Help me with a lock from a proxy</button></a>`);
 			} else if (user.latestHostType === 'proxy' && user.locked !== user.id) {
 				user.send(`|popup||html|You are locked${bannedUnder} on the IP (${user.latestIp}), which is a proxy. We automatically lock these connections since they are used to spam, hack, or otherwise attack our server. Disable any proxies you are using to connect to PS.\n\n<a href="view-help-request--appeal"><button class="button">Help me with a lock from a proxy</button></a>`);
-			} else if (!user.lockNotified) {
+			} else if (!user.notified.lock) {
 				user.send(`|popup||html|You are locked${bannedUnder}. ${user.permalocked ? `This lock is permanent.` : `Your lock will expire in a few days.`}${reason}${appeal}`);
 			}
-			user.lockNotified = true;
+			user.notified.lock = true;
 			user.locked = punishUserid;
 			user.updateIdentity();
 		}

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1701,9 +1701,9 @@ export const Rooms = {
 
 		const inviteOnly = (options.inviteOnly || []);
 		for (const user of players) {
-			if (user.inviteOnlyNextBattle) {
+			if (user.settings.inviteOnlyNextBattle) {
 				inviteOnly.push(user.id);
-				user.inviteOnlyNextBattle = false;
+				user.settings.inviteOnlyNextBattle = false;
 			}
 		}
 		if (inviteOnly.length) {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1701,17 +1701,15 @@ export const Rooms = {
 
 		let inviteOnly = false;
 		const privacySetter = new Set<ID>(options.inviteOnly || []);
-		for (const user of players) {
-			if (user.settings.inviteOnlyNextBattle) {
+		for (const p of ['p1', 'p2', 'p3', 'p4']) {
+			if (options[`${p}inviteOnly`]) {
 				inviteOnly = true;
-				privacySetter.add(user.id);
-				user.settings.inviteOnlyNextBattle = false;
-			}
-			if (user.settings.hideNextBattle) {
-				privacySetter.add(user.id);
-				user.settings.hideNextBattle = false;
+				privacySetter.add(options[p].id);
+			} else if (options[`${p}hidden`]) {
+				privacySetter.add(options[p].id);
 			}
 		}
+
 		if (privacySetter.size) {
 			const prefix = battle.forcedPublic();
 			if (prefix) {

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -945,8 +945,8 @@ export class Tournament extends Rooms.RoomGame {
 		const challenge = player.pendingChallenge;
 		if (!challenge || !challenge.from) return;
 
-		const ready = await Ladders(this.fullFormat).prepBattle(output.connection, 'tour');
-		if (!ready) return;
+		const ready2 = await Ladders(this.fullFormat).prepBattle(output.connection, 'tour');
+		if (!ready2) return;
 
 		// Prevent battles between offline users from starting
 		const from = Users.get(challenge.from.id);
@@ -956,14 +956,21 @@ export class Tournament extends Rooms.RoomGame {
 		if (!challenge.from.pendingChallenge) return;
 		if (!player.pendingChallenge) return;
 
+		const ready1 = Ladders.getChallenging(from.id)?.ready;
+		if (!ready1) return;
+
 		const room = Rooms.createBattle(this.fullFormat, {
 			isPrivate: this.room.settings.isPrivate,
 			p1: from,
-			p1team: challenge.team,
+			p1team: ready1.team,
+			p1hidden: ready1.hidden,
+			p1inviteOnly: ready1.inviteOnly,
 			p2: user,
-			p2team: ready.team,
+			p2team: ready2.team,
+			p2hidden: ready2.hidden,
+			p2inviteOnly: ready2.inviteOnly,
 			rated: !Ladders.disabled && this.isRated,
-			challengeType: ready.challengeType,
+			challengeType: ready2.challengeType,
 			tour: this,
 		});
 		if (!room || !room.battle) throw new Error(`Failed to create battle in ${room}`);
@@ -1206,7 +1213,7 @@ const tourCommands: {basic: TourCommands, creation: TourCommands, moderation: To
 			if (Monitor.countPrepBattle(connection.ip, connection)) {
 				return;
 			}
-			void TeamValidatorAsync.get(tournament.fullFormat).validateTeam(user.team).then(result => {
+			void TeamValidatorAsync.get(tournament.fullFormat).validateTeam(user.battleSettings.team).then(result => {
 				if (result.charAt(0) === '1') {
 					connection.popup("Your team is valid for this tournament.");
 				} else {

--- a/server/users.ts
+++ b/server/users.ts
@@ -302,13 +302,14 @@ type ChatQueueEntry = [string, RoomID, Connection];
 export interface UserSettings {
 	blockChallenges: boolean;
 	blockPMs: boolean | GroupSymbol | 'autoconfirmed' | 'trusted' | 'unlocked';
-	inviteOnlyNextBattle: boolean;
+	hideNextBattle: boolean;
 	ignoreTickets: boolean;
+	inviteOnlyNextBattle: boolean;
 }
 type UserSetting = keyof UserSettings;
 
 const SETTINGS: readonly UserSetting[] =
-	['blockChallenges', 'blockPMs', 'ignoreTickets', 'inviteOnlyNextBattle'] as const;
+	['blockChallenges', 'blockPMs', 'hideNextBattle', 'ignoreTickets', 'inviteOnlyNextBattle'] as const;
 
 // User
 export class User extends Chat.MessageContext {
@@ -422,6 +423,7 @@ export class User extends Chat.MessageContext {
 		this.settings = {
 			blockChallenges: false,
 			blockPMs: false,
+			hideNextBattle: false,
 			ignoreTickets: false,
 			inviteOnlyNextBattle: false,
 		};

--- a/test/server/ladders.js
+++ b/test/server/ladders.js
@@ -8,7 +8,7 @@ const {Connection, User} = require('../users-utils');
 describe('Matchmaker', function () {
 	const FORMATID = 'gen7ou';
 	const addSearch = (player, rating = 1000, formatid = FORMATID) => {
-		const search = new Ladders.BattleReady(player.id, formatid, player.team, rating);
+		const search = new Ladders.BattleReady(player.id, formatid, player.battleSettings, rating);
 		Ladders(formatid).addSearch(search, player);
 		return search;
 	};
@@ -28,13 +28,13 @@ describe('Matchmaker', function () {
 		this.p1 = new User(new Connection('127.0.0.1'));
 		this.p1.forceRename('Morfent', true);
 		this.p1.connected = true;
-		this.p1.team = 'Gengar||||lick||252,252,4,,,|||||';
+		this.p1.battleSettings.team = 'Gengar||||lick||252,252,4,,,|||||';
 		Users.users.set(this.p1.id, this.p1);
 
 		this.p2 = new User(new Connection('0.0.0.0'));
 		this.p2.forceRename('Mrofnet', true);
 		this.p2.connected = true;
-		this.p2.team = 'Gengar||||lick||252,252,4,,,|||||';
+		this.p2.battleSettings.team = 'Gengar||||lick||252,252,4,,,|||||';
 		Users.users.set(this.p2.id, this.p2);
 	});
 
@@ -51,7 +51,7 @@ describe('Matchmaker', function () {
 		assert.ok(formatSearches instanceof Map);
 		assert.equal(formatSearches.size, 1);
 		assert.equal(s1.userid, this.p1.id);
-		assert.equal(s1.team, this.p1.team);
+		assert.equal(s1.team, this.p1.battleSettings.team);
 		assert.equal(s1.rating, 1000);
 	});
 


### PR DESCRIPTION
Server side portion of https://github.com/smogon/pokemon-showdown-client/issues/1271, in two commits which can be rebased (instead of squashed). Pretty sure this requires a restart because I dont think we can hotpatch the first change. The change to `SETTINGS` and `updateuser` should be safe, this was its original state before I randomly added the other crap by mistake in a previous commit.

I've confirmed hackily with

```ts
var json = JSON.stringify({inviteOnlyNextBattle: true});
app.send('/updatesettings ' + json  + '\n/trn ' + name + ',0,' + assertion);
```

on the client that the setting seems to accurately be updated:

![Screen Shot 2020-07-02 at 20 03 55](https://user-images.githubusercontent.com/117249/86429523-b37a0c00-bca4-11ea-81be-07d258488c28.png)

I'll open a client side PR tomorrow.

