### PR TITLE
Commands: Allow the room parameter to be null

### DIFF
--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -24,6 +24,7 @@ export const commands: ChatCommands = {
 
 	htmlbox(target, room, user) {
 		if (!target) return this.parse('/help htmlbox');
+		if (!room) return this.requiresRoom();
 		target = this.canHTML(target)!;
 		if (!target) return;
 		target = Chat.collapseLineBreaksHTML(target);
@@ -44,6 +45,7 @@ export const commands: ChatCommands = {
 	],
 	addhtmlbox(target, room, user, connection, cmd) {
 		if (!target) return this.parse('/help ' + cmd);
+		if (!room) return this.requiresRoom();
 		if (!this.canTalk()) return;
 		target = this.canHTML(target)!;
 		if (!target) return;
@@ -59,6 +61,7 @@ export const commands: ChatCommands = {
 		`/addhtmlbox [message] - Shows everyone a message, parsing HTML code contained. Requires: * # &`,
 	],
 	addrankhtmlbox(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
 		if (!target) return this.parse('/help ' + cmd);
 		if (!this.canTalk()) return;
 		let [rank, html] = this.splitOne(target);
@@ -78,6 +81,7 @@ export const commands: ChatCommands = {
 	],
 	changeuhtml: 'adduhtml',
 	adduhtml(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
 		if (!target) return this.parse('/help ' + cmd);
 		if (!this.canTalk()) return;
 
@@ -105,6 +109,7 @@ export const commands: ChatCommands = {
 	],
 	changerankuhtml: 'addrankuhtml',
 	addrankuhtml(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
 		if (!target) return this.parse('/help ' + cmd);
 		if (!this.canTalk()) return;
 
@@ -130,14 +135,16 @@ export const commands: ChatCommands = {
 		`/changerankuhtml [rank], [name], [message] - Changes the message previously shown with /addrankuhtml [rank], [name]. Requires: * # &`,
 	],
 
+	'!addline': true,
 	addline(target, room, user) {
 		if (!this.can('rawpacket')) return false;
 		// secret sysop command
-		room.add(target);
+		this.add(target);
 	},
 
 	pminfobox(target, room, user, connection) {
 		if (!this.canTalk()) return;
+		if (!room) return this.requiresRoom();
 		if (!this.can('addhtml', null, room)) return false;
 		if (!target) return this.parse("/help pminfobox");
 
@@ -176,6 +183,7 @@ export const commands: ChatCommands = {
 	pmuhtmlchange: 'pmuhtml',
 	pmuhtml(target, room, user, connection, cmd) {
 		if (!this.canTalk()) return;
+		if (!room) return this.requiresRoom();
 		if (!this.can('addhtml', null, room)) return false;
 		if (!target) return this.parse("/help " + cmd);
 
@@ -621,7 +629,7 @@ export const commands: ChatCommands = {
 
 		Rooms.global.startLockdown();
 
-		const logRoom = Rooms.get('staff') || room;
+		const logRoom = Rooms.get('staff')!;
 		logRoom.roomlog(`${user.name} used /lockdown`);
 	},
 	lockdownhelp: [
@@ -632,14 +640,13 @@ export const commands: ChatCommands = {
 	autolockdownkill(target, room, user) {
 		if (!this.can('lockdown')) return false;
 		if (Config.autolockdown === undefined) Config.autolockdown = true;
-
+		const logRoom = Rooms.get('staff')!;
 		if (this.meansYes(target)) {
 			if (Config.autolockdown) {
 				return this.errorReply("The server is already set to automatically kill itself upon the final battle finishing.");
 			}
 			Config.autolockdown = true;
 			this.sendReply("The server is now set to automatically kill itself upon the final battle finishing.");
-			const logRoom = Rooms.get('staff') || room;
 			logRoom.roomlog(`${user.name} used /autolockdownkill on`);
 		} else if (this.meansNo(target)) {
 			if (!Config.autolockdown) {
@@ -647,7 +654,6 @@ export const commands: ChatCommands = {
 			}
 			Config.autolockdown = false;
 			this.sendReply("The server is now set to not automatically kill itself upon the final battle finishing.");
-			const logRoom = Rooms.get('staff') || room;
 			logRoom.roomlog(`${user.name} used /autolockdownkill off`);
 		} else {
 			return this.parse('/help autolockdownkill');
@@ -662,8 +668,8 @@ export const commands: ChatCommands = {
 		if (!this.can('lockdown')) return false;
 		Rooms.global.lockdown = 'pre';
 		this.sendReply("Tournaments have been disabled in preparation for the server restart.");
-		const logRoom = Rooms.get('staff') || room;
-		logRoom.roomlog(`${user.name} used /prelockdown`);
+		const logRoom = Rooms.get('staff');
+		logRoom!.roomlog(`${user.name} used /prelockdown`);
 	},
 
 	slowlockdown(target, room, user) {
@@ -671,8 +677,8 @@ export const commands: ChatCommands = {
 
 		Rooms.global.startLockdown(undefined, true);
 
-		const logRoom = Rooms.get('staff') || room;
-		logRoom.roomlog(`${user.name} used /slowlockdown`);
+		const logRoom = Rooms.get('staff');
+		logRoom!.roomlog(`${user.name} used /slowlockdown`);
 	},
 
 	crashfixed: 'endlockdown',
@@ -701,8 +707,8 @@ export const commands: ChatCommands = {
 		}
 		Rooms.global.lockdown = false;
 
-		const logRoom = Rooms.get('staff') || room;
-		logRoom.roomlog(`${user.name} used /endlockdown`);
+		const logRoom = Rooms.get('staff');
+		logRoom!.roomlog(`${user.name} used /endlockdown`);
 	},
 	endlockdownhelp: [
 		`/endlockdown - Cancels the server restart and takes the server out of lockdown state. Requires: &`,
@@ -722,8 +728,8 @@ export const commands: ChatCommands = {
 			}
 		}
 
-		const logRoom = Rooms.get('staff') || room;
-		logRoom.roomlog(`${user.name} used /emergency.`);
+		const logRoom = Rooms.get('staff');
+		logRoom!.roomlog(`${user.name} used /emergency.`);
 	},
 
 	endemergency(target, room, user) {
@@ -739,8 +745,8 @@ export const commands: ChatCommands = {
 			}
 		}
 
-		const logRoom = Rooms.get('staff') || room;
-		logRoom.roomlog(`${user.name} used /endemergency.`);
+		const logRoom = Rooms.get('staff');
+		logRoom!.roomlog(`${user.name} used /endemergency.`);
 	},
 
 	kill(target, room, user) {
@@ -754,12 +760,12 @@ export const commands: ChatCommands = {
 			return this.errorReply("Wait for /updateserver to finish before using /kill.");
 		}
 
-		const logRoom = Rooms.get('staff') || room;
+		const logRoom = Rooms.get('staff');
 		if (!(logRoom as any).destroyLog) {
 			process.exit();
 			return;
 		}
-		logRoom.roomlog(`${user.name} used /kill`);
+		logRoom!.roomlog(`${user.name} used /kill`);
 		(logRoom as any).destroyLog(() => {
 			process.exit();
 		});
@@ -788,8 +794,8 @@ export const commands: ChatCommands = {
 	refreshpage(target, room, user) {
 		if (!this.can('lockdown')) return false;
 		Rooms.global.sendAll('|refresh|');
-		const logRoom = Rooms.get('staff') || room;
-		logRoom.roomlog(`${user.name} used /refreshpage`);
+		const logRoom = Rooms.get('staff');
+		logRoom!.roomlog(`${user.name} used /refreshpage`);
 	},
 
 	async updateserver(target, room, user, connection) {
@@ -801,24 +807,24 @@ export const commands: ChatCommands = {
 
 		Monitor.updateServerLock = true;
 
-		const logRoom = Rooms.get('staff') || room;
+		const logRoom = Rooms.get('staff');
 
 		function exec(command: string): Promise<[number, string, string]> {
-			logRoom.roomlog(`$ ${command}`);
+			logRoom!.roomlog(`$ ${command}`);
 			return new Promise((resolve, reject) => {
 				child_process.exec(command, {
 					cwd: __dirname,
 				}, (error, stdout, stderr) => {
 					let log = `[o] ${stdout}[e] ${stderr}`;
 					if (error) log = `[c] ${error.code}\n${log}`;
-					logRoom.roomlog(log);
+					logRoom!.roomlog(log);
 					resolve([error?.code || 0, stdout, stderr]);
 				});
 			});
 		}
 
 		this.sendReply(`Fetching newest version...`);
-		logRoom.roomlog(`${user.name} used /updateserver`);
+		logRoom!.roomlog(`${user.name} used /updateserver`);
 
 		let [code, stdout, stderr] = await exec(`git fetch`);
 		if (code) throw new Error(`updateserver: Crash while fetching - make sure this is a Git repository`);
@@ -885,17 +891,17 @@ export const commands: ChatCommands = {
 	},
 
 	async rebuild(target, room, user, connection) {
-		const logRoom = Rooms.get('staff') || room;
+		const logRoom = Rooms.get('staff');
 
 		function exec(command: string): Promise<[number, string, string]> {
-			logRoom.roomlog(`$ ${command}`);
+			logRoom!.roomlog(`$ ${command}`);
 			return new Promise((resolve, reject) => {
 				child_process.exec(command, {
 					cwd: __dirname,
 				}, (error, stdout, stderr) => {
 					let log = `[o] ${stdout}[e] ${stderr}`;
 					if (error) log = `[c] ${error.code}\n${log}`;
-					logRoom.roomlog(log);
+					logRoom!.roomlog(log);
 					resolve([error?.code || 0, stdout, stderr]);
 				});
 			});
@@ -927,6 +933,7 @@ export const commands: ChatCommands = {
 	bashhelp: [`/bash [command] - Executes a bash command on the server. Requires: & console access`],
 
 	async eval(target, room, user, connection) {
+		if (!room) return this.requiresRoom();
 		if (!this.canUseConsole()) return false;
 		if (!this.runBroadcast(true)) return;
 		const logRoom = Rooms.get('upperstaff') || Rooms.get('staff');
@@ -959,6 +966,7 @@ export const commands: ChatCommands = {
 	},
 
 	evalbattle(target, room, user, connection) {
+		if (!room) return this.requiresRoom();
 		if (!this.canUseConsole()) return false;
 		if (!this.runBroadcast(true)) return;
 		if (!room.battle) {
@@ -970,6 +978,7 @@ export const commands: ChatCommands = {
 
 	ebat: 'editbattle',
 	editbattle(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.can('forcewin')) return false;
 		if (!target) return this.parse('/help editbattle');
 		if (!room.battle) {

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -790,8 +790,8 @@ export const commands: ChatCommands = {
 	refreshpage(target, room, user) {
 		if (!this.can('lockdown')) return false;
 		Rooms.global.sendAll('|refresh|');
-		const logRoom = Rooms.get('staff');
-		logRoom!.roomlog(`${user.name} used /refreshpage`);
+		const logRoom = Rooms.get('staff') || room;
+		logRoom?.roomlog(`${user.name} used /refreshpage`);
 	},
 
 	async updateserver(target, room, user, connection) {
@@ -887,17 +887,17 @@ export const commands: ChatCommands = {
 	},
 
 	async rebuild(target, room, user, connection) {
-		const logRoom = Rooms.get('staff');
+		const logRoom = Rooms.get('staff') || room;
 
 		function exec(command: string): Promise<[number, string, string]> {
-			logRoom!.roomlog(`$ ${command}`);
+			logRoom?.roomlog(`$ ${command}`);
 			return new Promise((resolve, reject) => {
 				child_process.exec(command, {
 					cwd: __dirname,
 				}, (error, stdout, stderr) => {
 					let log = `[o] ${stdout}[e] ${stderr}`;
 					if (error) log = `[c] ${error.code}\n${log}`;
-					logRoom!.roomlog(log);
+					logRoom?.roomlog(log);
 					resolve([error?.code || 0, stdout, stderr]);
 				});
 			});

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -135,7 +135,6 @@ export const commands: ChatCommands = {
 		`/changerankuhtml [rank], [name], [message] - Changes the message previously shown with /addrankuhtml [rank], [name]. Requires: * # &`,
 	],
 
-	'!addline': true,
 	addline(target, room, user) {
 		if (!this.can('rawpacket')) return false;
 		// secret sysop command
@@ -437,7 +436,6 @@ export const commands: ChatCommands = {
 		`/nohotpatch [chat|formats|battles|validator|tournaments|punishments|all] [reason] - Disables hotpatching the specified part of the simulator. Requires: &`,
 	],
 
-	'!processes': true,
 	processes(target, room, user) {
 		if (!this.can('lockdown')) return false;
 

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -763,7 +763,7 @@ export const commands: ChatCommands = {
 
 		if (!logRoom?.log.roomlogStream) return process.exit();
 
-		logRoom.log.roomlogStream.writeEnd().then(() => {
+		void logRoom.log.roomlogStream.writeEnd().then(() => {
 			process.exit();
 		});
 

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -349,6 +349,7 @@ export const commands: ChatCommands = {
 	},
 
 	userlist(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const userList = [];
 
 		for (const id in room.users) {
@@ -731,6 +732,7 @@ export const commands: ChatCommands = {
 	 *********************************************************/
 
 	allowexportinputlog(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const battle = room.battle;
 		if (!battle) {
 			return this.errorReply(`Must be in a battle.`);
@@ -763,6 +765,7 @@ export const commands: ChatCommands = {
 
 	requestinputlog: 'exportinputlog',
 	exportinputlog(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const battle = room.battle;
 		if (!battle) {
 			return this.errorReply(`This command only works in battle rooms.`);
@@ -851,6 +854,7 @@ export const commands: ChatCommands = {
 	offerdraw: 'offertie',
 	requesttie: 'offertie',
 	offertie(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
 		const battle = room.battle;
 		if (!battle) return this.errorReply("Must be in a battle room.");
 		if (!Config.allowrequestingties) {
@@ -902,6 +906,7 @@ export const commands: ChatCommands = {
 
 	rejectdraw: 'rejecttie',
 	rejecttie(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const battle = room.battle;
 		if (!battle) return this.errorReply("Must be in a battle room.");
 		const player = battle.playerTable[user.id];
@@ -929,6 +934,7 @@ export const commands: ChatCommands = {
 	 *********************************************************/
 
 	forfeit(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!room.game) return this.errorReply("This room doesn't have an active game.");
 		if (!room.game.forfeit) {
 			return this.errorReply("This kind of game can't be forfeited.");
@@ -937,6 +943,7 @@ export const commands: ChatCommands = {
 	},
 
 	choose(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!room.game) return this.errorReply("This room doesn't have an active game.");
 		if (!room.game.choose) return this.errorReply("This game doesn't support /choose");
 
@@ -959,6 +966,7 @@ export const commands: ChatCommands = {
 	},
 
 	undo(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!room.game) return this.errorReply("This room doesn't have an active game.");
 		if (!room.game.undo) return this.errorReply("This game doesn't support /undo");
 
@@ -988,6 +996,7 @@ export const commands: ChatCommands = {
 	},
 
 	addplayer(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!target) return this.parse('/help addplayer');
 		if (!room.battle) return this.errorReply("You can only do this in battle rooms.");
 		if (room.rated) return this.errorReply("You can only add a Player to unrated battles.");
@@ -1028,6 +1037,7 @@ export const commands: ChatCommands = {
 	],
 
 	restoreplayers(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!room.battle) return this.errorReply("You can only do this in battle rooms.");
 		if (room.rated) return this.errorReply("You can only add a Player to unrated battles.");
 
@@ -1051,6 +1061,7 @@ export const commands: ChatCommands = {
 
 	joinbattle: 'joingame',
 	joingame(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!room.game) return this.errorReply("This room doesn't have an active game.");
 		if (!room.game.joinGame) return this.errorReply("This game doesn't support /joingame");
 
@@ -1060,6 +1071,7 @@ export const commands: ChatCommands = {
 	leavebattle: 'leavegame',
 	partbattle: 'leavegame',
 	leavegame(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!room.game) return this.errorReply("This room doesn't have an active game.");
 		if (!room.game.leaveGame) return this.errorReply("This game doesn't support /leavegame");
 
@@ -1068,6 +1080,7 @@ export const commands: ChatCommands = {
 
 	kickbattle: 'kickgame',
 	kickgame(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!room.battle) return this.errorReply("You can only do this in battle rooms.");
 		if (room.battle.challengeType === 'tour' || room.battle.rated) {
 			return this.errorReply("You can only do this in unrated non-tour battles.");
@@ -1093,6 +1106,7 @@ export const commands: ChatCommands = {
 
 	timer(target, room, user) {
 		target = toID(target);
+		if (!room) return this.requiresRoom();
 		if (!room.game || !room.game.timer) {
 			return this.errorReply(`You can only set the timer from inside a battle room.`);
 		}
@@ -1143,6 +1157,7 @@ export const commands: ChatCommands = {
 
 	forcetie: 'forcewin',
 	forcewin(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.can('forcewin')) return false;
 		if (!room.battle) {
 			this.errorReply("/forcewin - This is not a battle room.");

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -342,7 +342,6 @@ for (const avatar of avatarTableGnomowladny) avatarTable.add(avatar);
 
 export const commands: ChatCommands = {
 
-	'!version': true,
 	version(target, room, user) {
 		if (!this.runBroadcast()) return;
 		this.sendReplyBox(`Server version: <b>${Chat.packageData.version}</b>`);
@@ -365,7 +364,6 @@ export const commands: ChatCommands = {
 	},
 	userlisthelp: [`/userlist - Displays a list of users who are currently in the room.`],
 
-	'!me': true,
 	mee: 'me',
 	me(target, room, user) {
 		if (this.cmd === 'mee' && /[A-Z-a-z0-9/]/.test(target.charAt(0))) {
@@ -389,7 +387,6 @@ export const commands: ChatCommands = {
 		return target;
 	},
 
-	'!shrug': true,
 	shrug(target) {
 		target = target ? ' ' + target + ' ' : '';
 		if (target.startsWith(' /me')) target = target.slice(1);
@@ -397,7 +394,6 @@ export const commands: ChatCommands = {
 	},
 	shrughelp: ['/shrug [message] - Sends the given message, if any, appended with ¯\\_(ツ)_/¯'],
 
-	'!tableflip': true,
 	tableflip(target) {
 		target = target ? ' ' + target + ' ' : '';
 		if (target.startsWith(' /me')) target = target.slice(1);
@@ -405,7 +401,6 @@ export const commands: ChatCommands = {
 	},
 	tablefliphelp: ['/tableflip [message] - Sends the given message, if any, appended with (╯°□°）╯︵ ┻━┻'],
 
-	'!tableunflip': true,
 	tableunflip(target) {
 		target = target ? ' ' + target + ' ' : '';
 		if (target.startsWith(' /me')) target = target.slice(1);
@@ -413,7 +408,6 @@ export const commands: ChatCommands = {
 	},
 	tableunfliphelp: ['/tableunflip [message] - Sends the given message, if any, appended with ┬──┬◡ﾉ(° -°ﾉ)'],
 
-	'!battle': true,
 	'battle!': 'battle',
 	battle(target, room, user, connection, cmd) {
 		if (cmd === 'battle') {
@@ -423,7 +417,6 @@ export const commands: ChatCommands = {
 		return this.parse(`/search ${target}`);
 	},
 
-	'!avatar': true,
 	avatar(target, room, user) {
 		if (!target) return this.parse(`${this.cmdToken}avatars`);
 		const parts = target.split(',');
@@ -479,7 +472,6 @@ export const commands: ChatCommands = {
 	},
 	avatarhelp: [`/avatar [avatar number 1 to 293] - Change your trainer sprite.`],
 
-	'!logout': true,
 	signout: 'logout',
 	logout(target, room, user) {
 		user.resetName();
@@ -495,7 +487,6 @@ export const commands: ChatCommands = {
 	},
 	replyhelp: [`/reply OR /r [message] - Send a message to the last user you got a message from, or sent a message to.`],
 
-	'!msg': true,
 	pm: 'msg',
 	whisper: 'msg',
 	w: 'msg',
@@ -528,7 +519,6 @@ export const commands: ChatCommands = {
 	},
 	msghelp: [`/msg OR /whisper OR /w [username], [message] - Send a private message.`],
 
-	'!invite': true,
 	inv: 'invite',
 	invite(target, room, user) {
 		if (!target) return this.parse('/help invite');
@@ -568,7 +558,6 @@ export const commands: ChatCommands = {
 		`(in a PM) /invite [roomname] - Invites the player you're PMing to join the room [roomname].`,
 	],
 
-	'!blockpms': true,
 	blockpm: 'blockpms',
 	ignorepms: 'blockpms',
 	ignorepm: 'blockpms',
@@ -596,7 +585,6 @@ export const commands: ChatCommands = {
 		`/blockpms [unlocked/ac/trusted/+] - Blocks private messages except from staff and the specified group.`,
 	],
 
-	'!unblockpms': true,
 	unblockpm: 'unblockpms',
 	unignorepms: 'unblockpms',
 	unignorepm: 'unblockpms',
@@ -608,7 +596,6 @@ export const commands: ChatCommands = {
 	},
 	unblockpmshelp: [`/unblockpms - Unblocks private messages. Block them with /blockpms.`],
 
-	'!status': true,
 	status(target, room, user, connection, cmd) {
 		if (user.locked || user.semilocked) {
 			return this.errorReply(this.tr("Your status cannot be updated while you are locked or semilocked."));
@@ -630,7 +617,6 @@ export const commands: ChatCommands = {
 		 `Use /clearstatus to clear your status message.`,
 	],
 
-	'!busy': true,
 	busy(target, room, user) {
 		if (target) {
 			this.errorReply("Setting status messages in /busy is no longer supported. Set a status using /status.");
@@ -645,7 +631,6 @@ export const commands: ChatCommands = {
 		`Use /back to mark yourself as back.`,
 	 ],
 
-	'!away': true,
 	idle: 'away',
 	afk: 'away',
 	brb: 'away',
@@ -685,7 +670,6 @@ export const commands: ChatCommands = {
 		`/clearstatus user, reason - Clears another person's status message. Requires: % @ &`,
 	],
 
-	'!back': true,
 	unaway: 'back',
 	unafk: 'back',
 	back(target, room, user) {
@@ -706,7 +690,6 @@ export const commands: ChatCommands = {
 	},
 	backhelp: [`/back - Marks you as back if you are away.`],
 
-	'!rank': true,
 	rank(target, room, user) {
 		if (!target) target = user.name;
 
@@ -1185,7 +1168,6 @@ export const commands: ChatCommands = {
 	 * Challenging and searching commands
 	 *********************************************************/
 
-	'!search': true,
 	search(target, room, user, connection) {
 		if (target) {
 			if (Config.laddermodchat) {
@@ -1201,7 +1183,6 @@ export const commands: ChatCommands = {
 		return Ladders.cancelSearches(user);
 	},
 
-	'!cancelsearch': true,
 	cancelsearch(target, room, user) {
 		if (target) {
 			Ladders(toID(target)).cancelSearch(user);
@@ -1210,7 +1191,6 @@ export const commands: ChatCommands = {
 		}
 	},
 
-	'!challenge': true,
 	chall: 'challenge',
 	challenge(target, room, user, connection) {
 		target = this.splitTarget(target);
@@ -1235,7 +1215,6 @@ export const commands: ChatCommands = {
 		return Ladders(target).makeChallenge(connection, targetUser);
 	},
 
-	'!blockchallenges': true,
 	bch: 'blockchallenges',
 	blockchall: 'blockchallenges',
 	blockchalls: 'blockchallenges',
@@ -1249,7 +1228,6 @@ export const commands: ChatCommands = {
 		`/blockchallenges - Blocks challenges so no one can challenge you. Unblock them with /unblockchallenges.`,
 	],
 
-	'!allowchallenges': true,
 	unbch: 'allowchallenges',
 	unblockchall: 'allowchallenges',
 	unblockchalls: 'allowchallenges',
@@ -1263,13 +1241,11 @@ export const commands: ChatCommands = {
 	allowchallengeshelp: [
 		`/unblockchallenges - Unblocks challenges so you can be challenged again. Block them with /blockchallenges.`,
 	],
-	'!cancelchallenge': true,
 	cchall: 'cancelChallenge',
 	cancelchallenge(target, room, user) {
 		Ladders.cancelChallenging(user);
 	},
 
-	'!accept': true,
 	accept(target, room, user, connection) {
 		target = this.splitTarget(target);
 		if (target) return this.popupReply(`This command does not support specifying multiple users`);
@@ -1278,21 +1254,18 @@ export const commands: ChatCommands = {
 		return Ladders.acceptChallenge(connection, targetUser);
 	},
 
-	'!reject': true,
 	reject(target, room, user) {
 		target = toID(target);
 		if (!target && this.pmTarget) target = this.pmTarget.id;
 		Ladders.rejectChallenge(user, target);
 	},
 
-	'!useteam': true,
 	saveteam: 'useteam',
 	utm: 'useteam',
 	useteam(target, room, user) {
 		user.team = target;
 	},
 
-	'!vtm': true,
 	vtm(target, room, user, connection) {
 		if (Monitor.countPrepBattle(connection.ip, connection)) {
 			return;
@@ -1319,7 +1292,6 @@ export const commands: ChatCommands = {
 	 * Low-level
 	 *********************************************************/
 
-	'!crq': true,
 	cmd: 'crq',
 	query: 'crq',
 	crq(target, room, user, connection) {
@@ -1454,7 +1426,6 @@ export const commands: ChatCommands = {
 		}
 	},
 
-	'!trn': true,
 	trn(target, room, user, connection) {
 		if (target === user.name) return false;
 
@@ -1479,7 +1450,6 @@ export const commands: ChatCommands = {
 	 * Help commands
 	 *********************************************************/
 
-	'!help': true,
 	commands: 'help',
 	h: 'help',
 	'?': 'help',

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -334,6 +334,7 @@ export const commands: ChatCommands = {
 
 	sp: 'showpunishments',
 	showpunishments(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!room.persist) {
 			return this.errorReply("This command is unavailable in temporary rooms.");
 		}
@@ -419,6 +420,7 @@ export const commands: ChatCommands = {
 	ipsearchhelp: [`/ipsearch [ip|range|host], (room) - Find all users with specified IP, IP range, or host. If a room is provided only users in the room will be shown. Requires: &`],
 
 	checkchallenges(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.can('ban', null, room)) return false;
 		if (!this.runBroadcast(true)) return;
 		if (!this.broadcasting) {
@@ -1885,6 +1887,7 @@ export const commands: ChatCommands = {
 
 	'!roomhelp': true,
 	roomhelp(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.canBroadcast(false, '!htmlbox')) return;
 		if (this.broadcastMessage && !this.can('declare', null, room)) return false;
 
@@ -2452,6 +2455,7 @@ export const commands: ChatCommands = {
 	},
 
 	requestshow(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.canTalk()) return false;
 		if (!room.settings.requestShowEnabled) {
 			return this.errorReply(`Media approvals are disabled in this room.`);
@@ -2482,6 +2486,7 @@ export const commands: ChatCommands = {
 	requestshowhelp: [`/requestshow [link], [comment] - Requests permission to show media in the room.`],
 
 	async approveshow(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.can('mute', null, room)) return false;
 		if (!room.settings.requestShowEnabled) {
 			return this.errorReply(`Media approvals are disabled in this room.`);
@@ -2523,6 +2528,7 @@ export const commands: ChatCommands = {
 	approveshowhelp: [`/approveshow [user] - Approves the media display request of [user]. Requires: % @ # &`],
 
 	denyshow(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.can('mute', null, room)) return false;
 		if (!room.settings.requestShowEnabled) {
 			return this.errorReply(`Media approvals are disabled in this room.`);
@@ -2541,10 +2547,12 @@ export const commands: ChatCommands = {
 	denyshowhelp: [`/denyshow [user] - Denies the media display request of [user]. Requires: % @ # &`],
 
 	approvallog(target, room, user) {
+		if (!room) return this.requiresRoom();
 		return this.parse(`/sl approved showing media from, ${room.roomid}`);
 	},
 
 	viewapprovals(target, room, user) {
+		if (!room) return this.requiresRoom();
 		return this.parse(`/join view-approvals-${room.roomid}`);
 	},
 

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -13,7 +13,6 @@ import {YoutubeInterface} from '../chat-plugins/youtube';
 import {Utils} from '../../lib/utils';
 
 export const commands: ChatCommands = {
-	'!whois': true,
 	ip: 'whois',
 	rooms: 'whois',
 	alt: 'whois',
@@ -233,7 +232,6 @@ export const commands: ChatCommands = {
 		`/whois [username] - Get details on a username: alts (Requires: % @ &), group, IP address (Requires: @ &), and rooms.`,
 	],
 
-	'!offlinewhois': true,
 	'chp': 'offlinewhois',
 	checkpunishment: 'offlinewhois',
 	offlinewhois(target, room, user) {
@@ -349,7 +347,6 @@ export const commands: ChatCommands = {
 	},
 	showglobalpunishmentshelp: [`/showpunishments - Shows the current global punishments. Requires: % @ # &`],
 
-	'!host': true,
 	host(target, room, user, connection, cmd) {
 		if (!target) return this.parse('/help host');
 		if (!this.can('ip')) return;
@@ -362,7 +359,6 @@ export const commands: ChatCommands = {
 	},
 	hosthelp: [`/host [ip] - Gets the host for a given IP. Requires: @ &`],
 
-	'!ipsearch': true,
 	searchip: 'ipsearch',
 	ipsearchall: 'ipsearch',
 	hostsearch: 'ipsearch',
@@ -476,7 +472,6 @@ export const commands: ChatCommands = {
 	 * Data Search Dex
 	 *********************************************************/
 
-	'!data': true,
 	pstats: 'data',
 	stats: 'data',
 	dex: 'data',
@@ -787,7 +782,6 @@ export const commands: ChatCommands = {
 		`!data [pokemon/item/move/ability/nature] - Show everyone these details. Requires: + % @ # &`,
 	],
 
-	'!details': true,
 	dt: 'details',
 	dt1: 'details',
 	dt2: 'details',
@@ -811,7 +805,6 @@ export const commands: ChatCommands = {
 		);
 	},
 
-	'!weakness': true,
 	weaknesses: 'weakness',
 	weak: 'weakness',
 	resist: 'weakness',
@@ -918,7 +911,6 @@ export const commands: ChatCommands = {
 		`!weakness [type 1]/[type 2] - Shows everyone a type or type combination's resistances, weaknesses, and immunities, ignoring abilities. Requires: + % @ # &`,
 	],
 
-	'!effectiveness': true,
 	eff: 'effectiveness',
 	type: 'effectiveness',
 	matchup: 'effectiveness',
@@ -993,7 +985,6 @@ export const commands: ChatCommands = {
 		`!effectiveness [attack], [defender] - Shows everyone the effectiveness of a move or type on another type or a Pok\u00e9mon.`,
 	],
 
-	'!coverage': true,
 	cover: 'coverage',
 	coverage(target, room, user) {
 		if (!this.runBroadcast()) return;
@@ -1201,7 +1192,6 @@ export const commands: ChatCommands = {
 		`Adding the parameter 'all' or 'table' will display the information with a table of all type combinations.`,
 	],
 
-	'!statcalc': true,
 	statcalc(target, room, user) {
 		if (!target) return this.parse("/help statcalc");
 		if (!this.runBroadcast()) return;
@@ -1470,7 +1460,6 @@ export const commands: ChatCommands = {
 	 * Informational commands
 	 *********************************************************/
 
-	'!uptime': true,
 	uptime(target, room, user) {
 		if (!this.runBroadcast()) return;
 		const uptime = process.uptime();
@@ -1486,7 +1475,6 @@ export const commands: ChatCommands = {
 		this.sendReplyBox("Uptime: <b>" + uptimeText + "</b>");
 	},
 
-	'!servertime': true,
 	st: 'servertime',
 	servertime(target, room, user) {
 		if (!this.runBroadcast()) return;
@@ -1494,7 +1482,6 @@ export const commands: ChatCommands = {
 		this.sendReplyBox(`Server time: <b>${servertime.toLocaleString()}</b>`);
 	},
 
-	'!groups': true,
 	groups(target, room, user) {
 		if (!this.runBroadcast()) return;
 		const showRoom = (target !== 'global');
@@ -1530,7 +1517,6 @@ export const commands: ChatCommands = {
 		`!groups - Shows everyone that information. Requires: + % @ # &`,
 	],
 
-	'!punishments': true,
 	punishments(target, room, user) {
 		if (!this.runBroadcast()) return;
 		const showRoom = (target !== 'global');
@@ -1564,7 +1550,6 @@ export const commands: ChatCommands = {
 		`!punishments - Show everyone that information. Requires: + % @ # &`,
 	],
 
-	'!opensource': true,
 	repo: 'opensource',
 	repository: 'opensource',
 	git: 'opensource',
@@ -1584,19 +1569,16 @@ export const commands: ChatCommands = {
 		`!opensource - Show everyone that information. Requires: + % @ # &`,
 	],
 
-	'!staff': true,
 	staff(target, room, user) {
 		if (!this.runBroadcast()) return;
 		this.sendReplyBox(`<a href="https://www.smogon.com/sim/staff_list">Pok&eacute;mon Showdown Staff List</a>`);
 	},
 
-	'!forums': true,
 	forums(target, room, user) {
 		if (!this.runBroadcast()) return;
 		this.sendReplyBox(`<a href="https://www.smogon.com/forums/forums/209/">Pok&eacute;mon Showdown Forums</a>`);
 	},
 
-	'!privacypolicy': true,
 	privacypolicy(target, room, user) {
 		if (!this.runBroadcast()) return;
 		this.sendReplyBox(
@@ -1607,13 +1589,11 @@ export const commands: ChatCommands = {
 		);
 	},
 
-	'!suggestions': true,
 	suggestions(target, room, user) {
 		if (!this.runBroadcast()) return;
 		this.sendReplyBox(`<a href="https://www.smogon.com/forums/forums/517/">Make a suggestion for Pok&eacute;mon Showdown</a>`);
 	},
 
-	'!bugs': true,
 	bugreport: 'bugs',
 	bugreports: 'bugs',
 	bugs(target, room, user) {
@@ -1629,7 +1609,6 @@ export const commands: ChatCommands = {
 		}
 	},
 
-	'!avatars': true,
 	avatars(target, room, user) {
 		if (!this.runBroadcast()) return;
 		this.sendReplyBox(`You can <button name="avatars">change your avatar</button> by clicking on it in the <button name="openOptions"><i class="fa fa-cog"></i> Options</button> menu in the upper right. Custom avatars are only obtainable by staff.`);
@@ -1639,13 +1618,11 @@ export const commands: ChatCommands = {
 		`!avatars - Show everyone that information. Requires: + % @ # &`,
 	],
 
-	'!optionsbutton': true,
 	optionbutton: 'optionsbutton',
 	optionsbutton(target, room, user) {
 		if (!this.runBroadcast()) return;
 		this.sendReplyBox(`<button name="openOptions" class="button"><i style="font-size: 16px; vertical-align: -1px" class="fa fa-cog"></i> Options</button> (The Sound and Options buttons are at the top right, next to your username)`);
 	},
-	'!soundbutton': true,
 	soundsbutton: 'soundbutton',
 	volumebutton: 'soundbutton',
 	soundbutton(target, room, user) {
@@ -1653,7 +1630,6 @@ export const commands: ChatCommands = {
 		this.sendReplyBox(`<button name="openSounds" class="button"><i style="font-size: 16px; vertical-align: -1px" class="fa fa-volume-up"></i> Sound</button> (The Sound and Options buttons are at the top right, next to your username)`);
 	},
 
-	'!intro': true,
 	introduction: 'intro',
 	intro(target, room, user) {
 		if (!this.runBroadcast()) return;
@@ -1671,7 +1647,6 @@ export const commands: ChatCommands = {
 		`!intro - Show everyone that information. Requires: + % @ # &`,
 	],
 
-	'!smogintro': true,
 	mentoring: 'smogintro',
 	smogonintro: 'smogintro',
 	smogintro(target, room, user) {
@@ -1683,7 +1658,6 @@ export const commands: ChatCommands = {
 		);
 	},
 
-	'!calc': true,
 	bsscalc: 'calc',
 	calculator: 'calc',
 	cantsaycalc: 'calc',
@@ -1734,7 +1708,6 @@ export const commands: ChatCommands = {
 		`!calc - Shows everyone a link to a damage calculator. Requires: + % @ # &`,
 	],
 
-	'!cap': true,
 	capintro: 'cap',
 	cap(target, room, user) {
 		if (!this.runBroadcast()) return;
@@ -1751,7 +1724,6 @@ export const commands: ChatCommands = {
 		`!cap - Show everyone that information. Requires: + % @ # &`,
 	],
 
-	'!gennext': true,
 	gennext(target, room, user) {
 		if (!this.runBroadcast()) return;
 		this.sendReplyBox(
@@ -1763,7 +1735,6 @@ export const commands: ChatCommands = {
 		);
 	},
 
-	'!formathelp': true,
 	banlists: 'formathelp',
 	tier: 'formathelp',
 	tiers: 'formathelp',
@@ -1885,7 +1856,6 @@ export const commands: ChatCommands = {
 		return this.sendReply(`|raw|${buf.join("")}`);
 	},
 
-	'!roomhelp': true,
 	roomhelp(target, room, user) {
 		if (!room) return this.requiresRoom();
 		if (!this.canBroadcast(false, '!htmlbox')) return;
@@ -1949,7 +1919,6 @@ export const commands: ChatCommands = {
 		);
 	},
 
-	'!restarthelp': true,
 	restarthelp(target, room, user) {
 		if (!Rooms.global.lockdown && !this.can('lockdown')) return false;
 		if (!this.runBroadcast()) return;
@@ -1962,7 +1931,6 @@ export const commands: ChatCommands = {
 		);
 	},
 
-	'!rules': true,
 	rule: 'rules',
 	rules(target, room, user) {
 		if (!target) {
@@ -2004,7 +1972,6 @@ export const commands: ChatCommands = {
 		`/rules remove - Removes a room rules URL. Requires: # &`,
 	],
 
-	'!faq': true,
 	faq(target, room, user) {
 		if (!this.runBroadcast()) return;
 		target = target.toLowerCase().trim();
@@ -2048,7 +2015,6 @@ export const commands: ChatCommands = {
 		`!faq [theme] - Shows everyone a link to the FAQ. Add autoconfirmed, badges, coil, ladder, staff, or tiers for a link to these questions. Add all for all of them. Requires: + % @ # &`,
 	],
 
-	'!smogdex': true,
 	analysis: 'smogdex',
 	strategy: 'smogdex',
 	smogdex(target, room, user) {
@@ -2218,7 +2184,6 @@ export const commands: ChatCommands = {
 		`!analysis [pokemon], [generation], [format] - Shows everyone this link. Requires: + % @ # &`,
 	],
 
-	'!veekun': true,
 	veekun(target, broadcast, user) {
 		if (!target) return this.parse('/help veekun');
 		if (!this.runBroadcast()) return;
@@ -2308,7 +2273,6 @@ export const commands: ChatCommands = {
 		`!veekun [pokemon] - Shows everyone this link. Requires: + % @ # &`,
 	],
 
-	'!register': true,
 	register() {
 		if (!this.runBroadcast()) return;
 		this.sendReplyBox(`You will be prompted to register upon winning a rated battle. Alternatively, there is a register button in the <button name="openOptions"><i class="fa fa-cog"></i> Options</button> menu in the upper right.`);
@@ -2318,7 +2282,6 @@ export const commands: ChatCommands = {
 	 * Miscellaneous commands
 	 *********************************************************/
 
-	'!dice': true,
 	roll: 'dice',
 	dice(target, room, user) {
 		if (!target || /[^\d\sdHL+-]/i.test(target)) return this.parse('/help dice');
@@ -2422,7 +2385,6 @@ export const commands: ChatCommands = {
 		`/dice [number of dice]d[number of sides]-[H/L] - Simulates rolling a number of dice with removal of extreme values, e.g., /dice 3d8-L: rolls three 8-sided dice; the result ignores the lowest value.`,
 	],
 
-	'!pickrandom': true,
 	pr: 'pickrandom',
 	pick: 'pickrandom',
 	pickrandom(target, room, user) {
@@ -2438,7 +2400,6 @@ export const commands: ChatCommands = {
 	},
 	pickrandomhelp: [`/pick [option], [option], ... - Randomly selects an item from a list containing 2 or more elements.`],
 
-	'!shuffle': true,
 	shuffle(target, room, user) {
 		if (!target || !target.includes(',')) return this.parse('/help shuffle');
 		const args = target.split(',');
@@ -2556,7 +2517,6 @@ export const commands: ChatCommands = {
 		return this.parse(`/join view-approvals-${room.roomid}`);
 	},
 
-	'!show': true,
 	async show(target, room, user) {
 		if (!room?.persist && !this.pmTarget) return this.errorReply(`/show cannot be used in temporary rooms.`);
 		if (!toID(target).trim()) return this.parse(`/help show`);
@@ -2596,7 +2556,6 @@ export const commands: ChatCommands = {
 	},
 	showhelp: [`/show [url] - shows an image or video url in chat. Requires: whitelist % @ # &`],
 
-	'!pi': true,
 	pi(target, room, user) {
 		if (!this.runBroadcast()) return false;
 		return this.sendReplyBox(
@@ -2607,7 +2566,6 @@ export const commands: ChatCommands = {
 		);
 	},
 
-	'!code': true,
 	code(target, room, user) {
 		// target is trimmed by Chat#splitMessage, but leading spaces can be
 		// important to code block indentation.

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -964,9 +964,9 @@ export const commands: ChatCommands = {
 		`/globalban OR /gban [username], [reason] spoiler: [proof] - Marks proof in modlog only.`,
 	],
 
+	'!unglobalban': true,
 	globalunban: 'unglobalban',
 	unglobalban(target, room, user) {
-		if (!room) return this.requiresRoom();
 		if (!target) return this.parse(`/help unglobalban`);
 		if (!this.can('ban')) return false;
 
@@ -977,9 +977,7 @@ export const commands: ChatCommands = {
 		if (name) {
 			this.addModAction(unbanMessage);
 			// Notify staff room when a user is unbanned outside of it.
-			if (room.roomid !== 'staff') {
-				Rooms.get('staff')?.addByUser(user, `<<${room.roomid}>> ${unbanMessage}`);
-			}
+			Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PM: ${this.pmTarget}>`} ${unbanMessage}`);
 			this.globalModlog("UNBAN", target, ` by ${user.id}`);
 		} else {
 			this.errorReply(`User '${target}' is not globally banned.`);
@@ -1492,6 +1490,7 @@ export const commands: ChatCommands = {
 	},
 	namelockhelp: [`/namelock OR /nl [user], [reason] - Name locks a [user] and shows the [reason]. Requires: % @ &`],
 
+	'!unnamelock': true,
 	unl: 'unnamelock',
 	unnamelock(target, room, user) {
 		if (!target) return this.parse('/help unnamelock');

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -740,7 +740,7 @@ export const commands: ChatCommands = {
 		this.addModAction(lockMessage);
 		// Notify staff room when a user is locked outside of it.
 		if (!room || room.roomid !== 'staff') {
-			 Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PMs: ${this.pmTarget}>`} ${lockMessage}`);
+			Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PM:${this.pmTarget}>`} ${lockMessage}`);
 		}
 		if (room) room.hideText([userid, toID(this.inputUsername)]);
 		const acAccount = (targetUser && targetUser.autoconfirmed !== userid && targetUser.autoconfirmed);
@@ -804,7 +804,7 @@ export const commands: ChatCommands = {
 			this.addModAction(unlockMessage);
 			// Notify staff room when a user is unlocked outside of it.
 			if (!room || room.roomid !== 'staff') {
-				Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PMs: ${this.pmTarget}>`} ${unlockMessage}`);
+				Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PM:${this.pmTarget}>`} ${unlockMessage}`);
 			}
 			if (!reason) this.globalModlog("UNLOCK", toID(target), ` by ${user.id}`);
 			if (targetUser) targetUser.popup(`${user.name} has unlocked you.`);
@@ -925,7 +925,7 @@ export const commands: ChatCommands = {
 
 		// Notify staff room when a user is banned outside of it.
 		if (!room || room.roomid !== 'staff') {
-			Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PMs: ${this.pmTarget}>`} ${banMessage}`);
+			Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PM:${this.pmTarget}>`} ${banMessage}`);
 		}
 		const affected = await Punishments.ban(targetUser, null, null, false, userReason);
 		const acAccount = (targetUser.autoconfirmed !== userid && targetUser.autoconfirmed);
@@ -970,7 +970,7 @@ export const commands: ChatCommands = {
 			this.addModAction(unbanMessage);
 			// Notify staff room when a user is unbanned outside of it.
 			if (!room || room.roomid !== 'staff') {
-				Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PM: ${this.pmTarget}>`} ${unbanMessage}`);
+				Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PM:${this.pmTarget}>`} ${unbanMessage}`);
 			}
 			this.globalModlog("UNBAN", target, ` by ${user.id}`);
 		} else {
@@ -1430,7 +1430,7 @@ export const commands: ChatCommands = {
 		const rankMessage = targetUser.getAccountStatusString();
 		Rooms.global.notifyRooms(
 			['staff'],
-			`|html|${room ? `<<${room.roomid}>>` : `<PM: ${this.pmTarget}>`}` +
+			`|html|${room ? `<<${room.roomid}>>` : `<PM:${this.pmTarget}>`}` +
 			Utils.html`<span class="username">${targetUser.name}</span> ${rankMessage} ${forceRenameMessage}`
 		);
 
@@ -1465,7 +1465,7 @@ export const commands: ChatCommands = {
 
 		// Notify staff room when a user is locked outside of it.
 		if (!room || room.roomid !== 'staff') {
-			Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PM: ${this.pmTarget}>`} ${lockMessage}`);
+			Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PM:${this.pmTarget}>`} ${lockMessage}`);
 		}
 		const roomauth = Rooms.global.destroyPersonalRooms(targetUser.id);
 		if (roomauth.length) {

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -1429,8 +1429,8 @@ export const commands: ChatCommands = {
 			if (!Chat.forceRenames.has(targetUser.id)) Chat.forceRenames.set(targetUser.id, 0);
 		}
 
-		if (room.roomid !== 'staff') this.privateModAction(`(${targetUser.name} ${forceRenameMessage})`);
-		const roomMessage = this.pmTarget ? `<PM:${this.pmTarget.userid}>` :
+		if (room?.roomid !== 'staff') this.privateModAction(`(${targetUser.name} ${forceRenameMessage})`);
+		const roomMessage = this.pmTarget ? `<PM:${this.pmTarget.id}>` :
 			room && room.roomid !== 'staff' ? `«<a href="/${room.roomid}" target="_blank">${room.roomid}</a>» ` :
 			'';
 		const rankMessage = targetUser.getAccountStatusString();

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -951,7 +951,7 @@ export const commands: ChatCommands = {
 			this.privateModAction(displayMessage);
 		}
 
-		if (room) room.hideText([userid, toID(this.inputUsername)]);
+		room?.hideText([userid, toID(this.inputUsername)]);
 
 		const globalReason = (target ? `: ${userReason} ${proof}` : '');
 		this.globalModlog("BAN", targetUser, ` by ${user.id}${globalReason}`);

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -1433,8 +1433,7 @@ export const commands: ChatCommands = {
 		const rankMessage = targetUser.getAccountStatusString();
 		Rooms.global.notifyRooms(
 			['staff'],
-			`|html|${room ? `<<${room.roomid}>>` : `<PM:${this.pmTarget}>`}` +
-			Utils.html`<span class="username">${targetUser.name}</span> ${rankMessage} ${forceRenameMessage}`
+			`|html|${roomMessage}` + Utils.html`<span class="username">${targetUser.name}</span> ${rankMessage} ${forceRenameMessage}`
 		);
 
 		targetUser.resetName(true);

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -865,8 +865,10 @@ export const commands: ChatCommands = {
 		}
 		this.globalModlog(`UNLOCK${range ? 'RANGE' : 'IP'}`, target, ` by ${user.name}`);
 
-		if (!room || room?.roomid !== 'staff') {
-			Rooms.get('staff')?.addByUser(user, `${user.name} unlocked the ${range ? "IP range" : "IP"}: ${target}`);
+		const logRoom = Rooms.get('staff') || room;
+		logRoom?.addByUser(user, `${user.name} unlocked the ${range ? "IP range" : "IP"}: ${target}`);
+		if (!logRoom || logRoom !== room) {
+			this.privateModAction(`(${user.name} unlocked the ${range ? "IP range" : "IP"}: ${target})`);
 		}
 	},
 	unlockiphelp: [`/unlockip [ip] - Unlocks a punished ip while leaving the original punishment intact. Requires: @ &`],

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -739,8 +739,9 @@ export const commands: ChatCommands = {
 		const lockMessage = `${name} was locked from talking${durationMsg} by ${user.name}.` + (userReason ? ` (${userReason})` : "");
 		this.addModAction(lockMessage);
 		// Notify staff room when a user is locked outside of it.
-		Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PMs: ${this.pmTarget}>`} ${lockMessage}`);
-
+		if (!room || room.roomid !== 'staff') {
+			 Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PMs: ${this.pmTarget}>`} ${lockMessage}`);
+		}
 		if (room) room.hideText([userid, toID(this.inputUsername)]);
 		const acAccount = (targetUser && targetUser.autoconfirmed !== userid && targetUser.autoconfirmed);
 		let displayMessage = '';

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -742,7 +742,7 @@ export const commands: ChatCommands = {
 		if (!room || room?.roomid !== 'staff') {
 			Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PM:${this.pmTarget}>`} ${lockMessage}`);
 		}
-		if (room) room.hideText([userid, toID(this.inputUsername)]);
+		room?.hideText([userid, toID(this.inputUsername)]);
 		const acAccount = (targetUser && targetUser.autoconfirmed !== userid && targetUser.autoconfirmed);
 		let displayMessage = '';
 		if (affected.length > 1) {

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -739,7 +739,7 @@ export const commands: ChatCommands = {
 		const lockMessage = `${name} was locked from talking${durationMsg} by ${user.name}.` + (userReason ? ` (${userReason})` : "");
 		this.addModAction(lockMessage);
 		// Notify staff room when a user is locked outside of it.
-		if (!room || room.roomid !== 'staff') {
+		if (!room || room?.roomid !== 'staff') {
 			Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PM:${this.pmTarget}>`} ${lockMessage}`);
 		}
 		if (room) room.hideText([userid, toID(this.inputUsername)]);
@@ -803,7 +803,7 @@ export const commands: ChatCommands = {
 			const unlockMessage = `${unlocked.join(", ")} ${((unlocked.length > 1) ? "were" : "was")} unlocked by ${user.name}.${reason}`;
 			this.addModAction(unlockMessage);
 			// Notify staff room when a user is unlocked outside of it.
-			if (!room || room.roomid !== 'staff') {
+			if (!room || room?.roomid !== 'staff') {
 				Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PM:${this.pmTarget}>`} ${unlockMessage}`);
 			}
 			if (!reason) this.globalModlog("UNLOCK", toID(target), ` by ${user.id}`);
@@ -837,7 +837,9 @@ export const commands: ChatCommands = {
 		const unlockMessage = `The name '${target}' was unlocked by ${user.name}.`;
 
 		this.addModAction(unlockMessage);
-		Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PMs: ${this.pmTarget}>`} ${unlockMessage}`);
+		if (!room || room?.roomid !== 'staff') {
+			Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PMs: ${this.pmTarget}>`} ${unlockMessage}`);
+		}
 	},
 	unlockip(target, room, user) {
 		target = target.trim();
@@ -863,8 +865,9 @@ export const commands: ChatCommands = {
 		}
 		this.globalModlog(`UNLOCK${range ? 'RANGE' : 'IP'}`, target, ` by ${user.name}`);
 
-		const broadcastRoom = Rooms.get('staff');
-		broadcastRoom!.addByUser(user, `${user.name} unlocked the ${range ? "IP range" : "IP"}: ${target}`);
+		if (!room || room?.roomid !== 'staff') {
+			Rooms.get('staff')?.addByUser(user, `${user.name} unlocked the ${range ? "IP range" : "IP"}: ${target}`);
+		}
 	},
 	unlockiphelp: [`/unlockip [ip] - Unlocks a punished ip while leaving the original punishment intact. Requires: @ &`],
 	unlocknamehelp: [`/unlockname [name] - Unlocks a punished alt, leaving the original lock intact. Requires: % @ &`],

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -1430,7 +1430,7 @@ export const commands: ChatCommands = {
 		}
 
 		if (room.roomid !== 'staff') this.privateModAction(`(${targetUser.name} ${forceRenameMessage})`);
-		const roomMessage = this.pmTarget ? &lt;PM:${this.pmTarget.userid}>` :
+		const roomMessage = this.pmTarget ? `<PM:${this.pmTarget.userid}>` :
 			room && room.roomid !== 'staff' ? `«<a href="/${room.roomid}" target="_blank">${room.roomid}</a>» ` :
 			'';
 		const rankMessage = targetUser.getAccountStatusString();

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -56,7 +56,6 @@ export const commands: ChatCommands = {
 	},
 	roomownerhelp: [`/roomowner [username] - Appoints [username] as a room owner. Requires: &`],
 
-	'!roompromote': true,
 	roomdemote: 'roompromote',
 	forceroompromote: 'roompromote',
 	forceroomdemote: 'roompromote',
@@ -180,7 +179,6 @@ export const commands: ChatCommands = {
 		`/roomdeauth [username] - Removes all room rank from the user. Requires: @ # &`,
 	],
 
-	'!authority': true,
 	auth: 'authority',
 	stafflist: 'authority',
 	globalauth: 'authority',
@@ -221,7 +219,6 @@ export const commands: ChatCommands = {
 		`/auth [user] - Show what global and roomauth a user has.`,
 	],
 
-	'!roomauth': true,
 	roomstaff: 'roomauth',
 	roomauth1: 'roomauth',
 	roomauth(target, room, user, connection, cmd) {
@@ -279,7 +276,6 @@ export const commands: ChatCommands = {
 		connection.popup(`${buffer.join("\n\n")}${userLookup}`);
 	},
 
-	'!userauth': true,
 	userauth(target, room, user, connection) {
 		const targetId = toID(target) || user.id;
 		const targetUser = Users.getExact(targetId);
@@ -331,7 +327,6 @@ export const commands: ChatCommands = {
 		connection.popup(buffer.join("\n\n"));
 	},
 
-	'!autojoin': true,
 	autojoin(target, room, user, connection) {
 		const targets = target.split(',');
 		if (targets.length > 16 || connection.inRooms.size > 1) {
@@ -353,7 +348,6 @@ export const commands: ChatCommands = {
 		});
 	},
 
-	'!join': true,
 	joim: 'join',
 	j: 'join',
 	join(target, room, user, connection) {
@@ -373,7 +367,6 @@ export const commands: ChatCommands = {
 	},
 	joinhelp: [`/join [roomname] - Attempt to join the room [roomname].`],
 
-	'!part': true,
 	leave: 'part',
 	part(target, room, user, connection) {
 		const targetRoom = target ? Rooms.search(target) : room;
@@ -668,7 +661,6 @@ export const commands: ChatCommands = {
 	wl: 'lock',
 	weeklock: 'lock',
 	monthlock: 'lock',
-	'!lock': true,
 	async lock(target, room, user, connection, cmd) {
 		const week = cmd === 'wl' || cmd === 'weeklock';
 		const month = cmd === 'monthlock';
@@ -791,7 +783,6 @@ export const commands: ChatCommands = {
 		`/lock OR /l [username], [reason] spoiler: [proof] - Marks proof in modlog only.`,
 	],
 
-	'!unlock': true,
 	unlock(target, room, user) {
 		if (!target) return this.parse('/help unlock');
 		if (!this.can('lock')) return false;
@@ -818,7 +809,6 @@ export const commands: ChatCommands = {
 			this.errorReply(`User '${target}' is not locked.`);
 		}
 	},
-	'!unlockname': true,
 	unlockname(target, room, user) {
 		if (!target) return this.parse('/help unlock');
 		if (!this.can('lock')) return false;
@@ -883,7 +873,6 @@ export const commands: ChatCommands = {
 
 	forceglobalban: 'globalban',
 	gban: 'globalban',
-	'!globalban': true,
 	async globalban(target, room, user, connection, cmd) {
 		if (!target) return this.parse('/help globalban');
 
@@ -964,7 +953,6 @@ export const commands: ChatCommands = {
 		`/globalban OR /gban [username], [reason] spoiler: [proof] - Marks proof in modlog only.`,
 	],
 
-	'!unglobalban': true,
 	globalunban: 'unglobalban',
 	unglobalban(target, room, user) {
 		if (!target) return this.parse(`/help unglobalban`);
@@ -1353,7 +1341,6 @@ export const commands: ChatCommands = {
 	},
 	chatdeclarehelp: [`/cdeclare [message] - Anonymously announces a message to all chatrooms on the server. Requires: &`],
 
-	'!announce': true,
 	wall: 'announce',
 	announce(target, room, user) {
 		if (!target) return this.parse('/help announce');
@@ -1406,7 +1393,6 @@ export const commands: ChatCommands = {
 	],
 
 	fr: 'forcerename',
-	'!forcerename': true,
 	forcerename(target, room, user) {
 		if (!target) return this.parse('/help forcerename');
 
@@ -1450,7 +1436,6 @@ export const commands: ChatCommands = {
 		`/allowname [username] - Unmarks a forcerenamed username, stopping staff from being notified when it is used. Requires % @ &`,
 	],
 
-	'!namelock': true,
 	nl: 'namelock',
 	forcenamelock: 'namelock',
 	async namelock(target, room, user, connection, cmd) {
@@ -1490,7 +1475,6 @@ export const commands: ChatCommands = {
 	},
 	namelockhelp: [`/namelock OR /nl [user], [reason] - Name locks a [user] and shows the [reason]. Requires: % @ &`],
 
-	'!unnamelock': true,
 	unl: 'unnamelock',
 	unnamelock(target, room, user) {
 		if (!target) return this.parse('/help unnamelock');

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -803,7 +803,9 @@ export const commands: ChatCommands = {
 			const unlockMessage = `${unlocked.join(", ")} ${((unlocked.length > 1) ? "were" : "was")} unlocked by ${user.name}.${reason}`;
 			this.addModAction(unlockMessage);
 			// Notify staff room when a user is unlocked outside of it.
-			Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PMs: ${this.pmTarget}>`} ${unlockMessage}`);
+			if (!room || room.roomid !== 'staff') {
+				Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PMs: ${this.pmTarget}>`} ${unlockMessage}`);
+			}
 			if (!reason) this.globalModlog("UNLOCK", toID(target), ` by ${user.id}`);
 			if (targetUser) targetUser.popup(`${user.name} has unlocked you.`);
 		} else {
@@ -922,8 +924,9 @@ export const commands: ChatCommands = {
 		this.addModAction(banMessage);
 
 		// Notify staff room when a user is banned outside of it.
-		Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PMs: ${this.pmTarget}>`} ${banMessage}`);
-
+		if (!room || room.roomid !== 'staff') {
+			Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PMs: ${this.pmTarget}>`} ${banMessage}`);
+		}
 		const affected = await Punishments.ban(targetUser, null, null, false, userReason);
 		const acAccount = (targetUser.autoconfirmed !== userid && targetUser.autoconfirmed);
 		let displayMessage = '';
@@ -966,7 +969,9 @@ export const commands: ChatCommands = {
 		if (name) {
 			this.addModAction(unbanMessage);
 			// Notify staff room when a user is unbanned outside of it.
-			Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PM: ${this.pmTarget}>`} ${unbanMessage}`);
+			if (!room || room.roomid !== 'staff') {
+				Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PM: ${this.pmTarget}>`} ${unbanMessage}`);
+			}
 			this.globalModlog("UNBAN", target, ` by ${user.id}`);
 		} else {
 			this.errorReply(`User '${target}' is not globally banned.`);
@@ -1459,8 +1464,9 @@ export const commands: ChatCommands = {
 		this.privateModAction(`(${lockMessage})`);
 
 		// Notify staff room when a user is locked outside of it.
-		Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PM: ${this.pmTarget}>`} ${lockMessage}`);
-
+		if (!room || room.roomid !== 'staff') {
+			Rooms.get('staff')?.addByUser(user, `${room ? `<<${room.roomid}>>` : `<PM: ${this.pmTarget}>`} ${lockMessage}`);
+		}
 		const roomauth = Rooms.global.destroyPersonalRooms(targetUser.id);
 		if (roomauth.length) {
 			Monitor.log(`[CrisisMonitor] Namelocked user ${targetUser.name} has public roomauth (${roomauth.join(', ')}), and should probably be demoted.`);

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -1429,7 +1429,10 @@ export const commands: ChatCommands = {
 			if (!Chat.forceRenames.has(targetUser.id)) Chat.forceRenames.set(targetUser.id, 0);
 		}
 
-		this.privateModAction(`(${targetUser.name} ${forceRenameMessage})`);
+		if (room.roomid !== 'staff') this.privateModAction(`(${targetUser.name} ${forceRenameMessage})`);
+		const roomMessage = this.pmTarget ? &lt;PM:${this.pmTarget.userid}>` :
+			room && room.roomid !== 'staff' ? `«<a href="/${room.roomid}" target="_blank">${room.roomid}</a>» ` :
+			'';
 		const rankMessage = targetUser.getAccountStatusString();
 		Rooms.global.notifyRooms(
 			['staff'],

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -19,6 +19,7 @@ const MAX_CHATROOM_ID_LENGTH = 225;
 export const commands: ChatCommands = {
 	roomsetting: 'roomsettings',
 	roomsettings(target, room, user, connection) {
+		if (!room) return this.requiresRoom();
 		if (room.battle) return this.errorReply("This command cannot be used in battle rooms.");
 		let uhtml = 'uhtml';
 
@@ -56,6 +57,7 @@ export const commands: ChatCommands = {
 	roomsettingshelp: [`/roomsettings - Shows current room settings with buttons to change them (if you can).`],
 
 	modchat(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!target) {
 			const modchatSetting = (room.settings.modchat || "OFF");
 			return this.sendReply(`Moderated chat is currently set to: ${modchatSetting}`);
@@ -171,6 +173,7 @@ export const commands: ChatCommands = {
 	],
 
 	modjoin(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!target) {
 			const modjoinSetting = room.settings.modjoin === true ? "SYNC" : room.settings.modjoin || "OFF";
 			return this.sendReply(`Modjoin is currently set to: ${modjoinSetting}`);
@@ -237,6 +240,7 @@ export const commands: ChatCommands = {
 	],
 
 	roomlanguage(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!target) {
 			return this.sendReply(`This room's primary language is ${Chat.languages.get(room.settings.language || '') || 'English'}`);
 		}
@@ -257,6 +261,7 @@ export const commands: ChatCommands = {
 	],
 
 	slowchat(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!target) {
 			const slowchatSetting = (room.settings.slowchat || "OFF");
 			return this.sendReply(`Slow chat is currently set to: ${slowchatSetting}`);
@@ -294,6 +299,7 @@ export const commands: ChatCommands = {
 	stretching: 'stretchfilter',
 	stretchingfilter: 'stretchfilter',
 	stretchfilter(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!target) {
 			const stretchSetting = (room.settings.filterStretching ? "ON" : "OFF");
 			return this.sendReply(`This room's stretch filter is currently: ${stretchSetting}`);
@@ -322,6 +328,7 @@ export const commands: ChatCommands = {
 	capitals: 'capsfilter',
 	capitalsfilter: 'capsfilter',
 	capsfilter(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!target) {
 			const capsSetting = (room.settings.filterCaps ? "ON" : "OFF");
 			return this.sendReply(`This room's caps filter is currently: ${capsSetting}`);
@@ -349,6 +356,7 @@ export const commands: ChatCommands = {
 	emojis: 'emojifilter',
 	emoji: 'emojifilter',
 	emojifilter(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!target) {
 			const emojiSetting = (room.settings.filterEmojis ? "ON" : "OFF");
 			return this.sendReply(`This room's emoji filter is currently: ${emojiSetting}`);
@@ -378,6 +386,7 @@ export const commands: ChatCommands = {
 		regexadd: 'add',
 		addregex: 'add',
 		add(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			if (!target || target === ' ') return this.parse('/help banword');
 			if (!this.can('declare', null, room)) return false;
 
@@ -443,6 +452,7 @@ export const commands: ChatCommands = {
 		},
 
 		delete(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!target) return this.parse('/help banword');
 			if (!this.can('declare', null, room)) return false;
 
@@ -478,6 +488,7 @@ export const commands: ChatCommands = {
 		},
 
 		list(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('mute', null, room)) return false;
 
 			if (!room.settings.banwords || !room.settings.banwords.length) {
@@ -498,6 +509,7 @@ export const commands: ChatCommands = {
 	],
 
 	showapprovals(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.can('declare', null, room)) return false;
 		target = toID(target);
 		if (!target) {
@@ -525,6 +537,7 @@ export const commands: ChatCommands = {
 	},
 
 	showmedia(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.can('declare', null, room)) return false;
 		target = target.trim();
 		if (this.meansNo(target)) {
@@ -557,6 +570,7 @@ export const commands: ChatCommands = {
 	},
 
 	hightraffic(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!target) {
 			return this.sendReply(`This room is: ${!room.settings.highTraffic ? 'high traffic' : 'low traffic'}`);
 		}
@@ -584,6 +598,7 @@ export const commands: ChatCommands = {
 
 	makeprivatechatroom: 'makechatroom',
 	makechatroom(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
 		if (!this.can('makeroom')) return;
 
 		// `,` is a delimiter used by a lot of /commands
@@ -630,6 +645,7 @@ export const commands: ChatCommands = {
 
 	subroomgroupchat: 'makegroupchat',
 	makegroupchat(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
 		if (!this.canTalk()) return;
 		if (!user.autoconfirmed) {
 			return this.errorReply("You must be autoconfirmed to make a groupchat.");
@@ -762,6 +778,7 @@ export const commands: ChatCommands = {
 	deletechatroom: 'deleteroom',
 	deletegroupchat: 'deleteroom',
 	deleteroom(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
 		const roomid = target.trim();
 		if (!roomid) {
 			// allow deleting personal rooms without typing out the room name
@@ -834,6 +851,7 @@ export const commands: ChatCommands = {
 
 	async renameroom(target, room) {
 		if (!this.can('makeroom')) return;
+		if (!room) return this.requiresRoom();
 		if (room.minorActivity || room.game || room.tour) {
 			return this.errorReply("Cannot rename room when there's a tour/game/poll/announcement running.");
 		}
@@ -875,6 +893,7 @@ export const commands: ChatCommands = {
 	secretroom: 'privateroom',
 	publicroom: 'privateroom',
 	privateroom(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
 		if (room.settings.isPersonal) {
 			if (!this.can('editroom', null, room)) return;
 		} else if (room.battle) {
@@ -971,6 +990,7 @@ export const commands: ChatCommands = {
 
 	officialchatroom: 'officialroom',
 	officialroom(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.can('makeroom')) return;
 		if (!room.persist) {
 			return this.errorReply(`/officialroom - This room can't be made official`);
@@ -994,6 +1014,7 @@ export const commands: ChatCommands = {
 
 	psplwinnerroom(target, room, user) {
 		if (!this.can('makeroom')) return;
+		if (!room) return this.requiresRoom();
 		if (!room.persist) {
 			return this.errorReply(`/psplwinnerroom - This room can't be marked as a PSPL Winner room`);
 		}
@@ -1016,6 +1037,7 @@ export const commands: ChatCommands = {
 
 	setsubroom: 'subroom',
 	subroom(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!user.can('makeroom')) return this.errorReply(`/subroom - Access denied. Did you mean /subrooms?`);
 		if (!target) return this.parse('/help subroom');
 
@@ -1067,6 +1089,7 @@ export const commands: ChatCommands = {
 	removesubroom: 'unsubroom',
 	desubroom: 'unsubroom',
 	unsubroom(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.can('makeroom')) return;
 		if (!room.parent || !room.persist) {
 			return this.errorReply(`This room is not currently a subroom of a public room.`);
@@ -1093,6 +1116,7 @@ export const commands: ChatCommands = {
 
 	parentroom: 'subrooms',
 	subrooms(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
 		if (cmd === 'parentroom') {
 			if (!room.parent) return this.errorReply(`This room is not a subroom.`);
 			return this.sendReply(`This is a subroom of ${room.parent.title}.`);
@@ -1123,6 +1147,7 @@ export const commands: ChatCommands = {
 	],
 
 	roomdesc(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!target) {
 			if (!this.runBroadcast()) return;
 			if (!room.settings.desc) return this.sendReply(`This room does not have a description set.`);
@@ -1155,6 +1180,7 @@ export const commands: ChatCommands = {
 
 	topic: 'roomintro',
 	roomintro(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
 		if (!target) {
 			if (!this.runBroadcast()) return;
 			if (!room.settings.introMessage) return this.sendReply("This room does not have an introduction set.");
@@ -1189,6 +1215,7 @@ export const commands: ChatCommands = {
 
 	deletetopic: 'deleteroomintro',
 	deleteroomintro(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.can('declare', null, room)) return false;
 		if (!room.settings.introMessage) return this.errorReply("This room does not have a introduction set.");
 
@@ -1201,6 +1228,7 @@ export const commands: ChatCommands = {
 
 	stafftopic: 'staffintro',
 	staffintro(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
 		if (!target) {
 			if (!this.can('mute', null, room)) return false;
 			if (!room.settings.staffMessage) return this.sendReply("This room does not have a staff introduction set.");
@@ -1235,6 +1263,7 @@ export const commands: ChatCommands = {
 
 	deletestafftopic: 'deletestaffintro',
 	deletestaffintro(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.can('ban', null, room)) return false;
 		if (!room.settings.staffMessage) return this.errorReply("This room does not have a staff introduction set.");
 
@@ -1246,6 +1275,7 @@ export const commands: ChatCommands = {
 	},
 
 	roomalias(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!target) {
 			if (!this.runBroadcast()) return;
 			if (!room.settings.aliases) return this.sendReplyBox("This room does not have any aliases.");
@@ -1282,6 +1312,7 @@ export const commands: ChatCommands = {
 	deroomalias: 'removeroomalias',
 	unroomalias: 'removeroomalias',
 	removeroomalias(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!room.settings.aliases) return this.errorReply("This room does not have any aliases.");
 		if (!this.can('makeroom')) return false;
 		if (target.includes(',')) {
@@ -1312,6 +1343,7 @@ export const commands: ChatCommands = {
 
 	resettierdisplay: 'roomtierdisplay',
 	roomtierdisplay(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
 		const resetTier = cmd === 'resettierdisplay';
 		if (!target) {
 			if (!this.runBroadcast()) return;
@@ -1321,7 +1353,7 @@ export const commands: ChatCommands = {
 		}
 		if (!this.can('declare', null, room)) return false;
 
-		const displayIDToName: {[k: string]: typeof room.settings.dataCommandTierDisplay} = {
+		const displayIDToName: {[k: string]: Room['settings']['dataCommandTierDisplay']} = {
 			tiers: 'tiers',
 			doublestiers: 'doubles tiers',
 			numbers: 'numbers',

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -134,7 +134,6 @@ export const commands: ChatCommands = {
 	ioo(target, room, user) {
 		return this.parse('/modjoin %');
 	},
-	'!ionext': true,
 	inviteonlynext: 'ionext',
 	ionext(target, room, user) {
 		const groupConfig = Config.groups[Users.PLAYER_SYMBOL];
@@ -727,7 +726,6 @@ export const commands: ChatCommands = {
 		`/subroomgroupchat [roomname] - Creates a subroom groupchat of the current room. Can only be used in a public room you have staff in.`,
 	],
 
-	'!roomuptime': true,
 	groupchatuptime: 'roomuptime',
 	roomuptime(target, room, user, connection, cmd) {
 		if (!this.runBroadcast()) return;

--- a/server/chat-plugins/announcements.ts
+++ b/server/chat-plugins/announcements.ts
@@ -51,6 +51,7 @@ export const commands: ChatCommands = {
 		htmlcreate: 'new',
 		create: 'new',
 		new(target, room, user, connection, cmd, message) {
+			if (!room) return this.requiresRoom();
 			if (!target) return this.parse('/help announcement new');
 			target = target.trim();
 			if (room.battle) return this.errorReply("Battles do not support announcements.");
@@ -78,6 +79,7 @@ export const commands: ChatCommands = {
 		newhelp: [`/announcement create [announcement] - Creates an announcement. Requires: % @ # &`],
 
 		timer(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!room.minorActivity || room.minorActivity.activityId !== 'announcement') {
 				return this.errorReply("There is no announcement running in this room.");
 			}
@@ -120,6 +122,7 @@ export const commands: ChatCommands = {
 		close: 'end',
 		stop: 'end',
 		end(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('minigame', null, room)) return false;
 			if (!this.canTalk()) return;
 			if (!room.minorActivity || room.minorActivity.activityId !== 'announcement') {
@@ -137,6 +140,7 @@ export const commands: ChatCommands = {
 
 		show: 'display',
 		display(target, room, user, connection) {
+			if (!room) return this.requiresRoom();
 			if (!room.minorActivity || room.minorActivity.activityId !== 'announcement') {
 				return this.errorReply("There is no announcement running in this room.");
 			}

--- a/server/chat-plugins/blackjack.ts
+++ b/server/chat-plugins/blackjack.ts
@@ -662,6 +662,7 @@ export const commands: ChatCommands = {
 	blackjack: {
 		new: 'create',
 		create(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('minigame', null, room)) return;
 			if (room.game) return this.errorReply("There is already a game running in this room.");
 			if (room.settings.blackjackDisabled) return this.errorReply("Blackjack is currently disabled in this room.");
@@ -675,6 +676,7 @@ export const commands: ChatCommands = {
 			room.game = new Blackjack(room, user, autostartMinutes);
 		},
 		start(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('minigame', null, room)) return;
 			const game = room.getGame(Blackjack);
 			if (!game || !game.blackjack) {
@@ -688,6 +690,7 @@ export const commands: ChatCommands = {
 		},
 		forceend: 'end',
 		end(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('minigame', null, room)) return;
 			const game = room.getGame(Blackjack);
 			if (!game || !game.blackjack) {
@@ -702,6 +705,7 @@ export const commands: ChatCommands = {
 			}
 		},
 		hit(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Blackjack);
 			if (!game || !game.blackjack) {
 				return this.errorReply("There is no game of blackjack currently ongoing in this room.");
@@ -710,6 +714,7 @@ export const commands: ChatCommands = {
 			game.hit(user);
 		},
 		stand(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Blackjack);
 			if (!game || !game.blackjack) {
 				return this.errorReply("There is no game of blackjack currently ongoing in this room.");
@@ -718,6 +723,7 @@ export const commands: ChatCommands = {
 			game.stand(user);
 		},
 		slide(target, room, user) { // undocumented (used in UI)
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Blackjack);
 			if (!game || !game.blackjack) {
 				return this.errorReply("There is no game of blackjack currently ongoing in this room.");
@@ -735,6 +741,7 @@ export const commands: ChatCommands = {
 		},
 		unspectate: 'spectate',
 		spectate(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Blackjack);
 			if (!game || !game.blackjack) {
 				return this.errorReply("There is no game of blackjack currently ongoing in this room.");
@@ -747,6 +754,7 @@ export const commands: ChatCommands = {
 			}
 		},
 		disable(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('gamemanagement', null, room)) return;
 			if (room.settings.blackjackDisabled) {
 				return this.errorReply("Blackjack is already disabled in this room.");
@@ -756,6 +764,7 @@ export const commands: ChatCommands = {
 			this.sendReply(`Blackjack has been disabled for this room.`);
 		},
 		enable(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('gamemanagement', null, room)) return;
 			if (!room.settings.blackjackDisabled) {
 				return this.errorReply("Blackjack is already enabled in this room.");

--- a/server/chat-plugins/calculator.ts
+++ b/server/chat-plugins/calculator.ts
@@ -137,7 +137,6 @@ function solveRPN(rpn: string[]) {
 }
 
 export const commands: ChatCommands = {
-	'!calculate': true,
 	math: "calculate",
 	calculate(target, room, user) {
 		if (!target) return this.parse('/help calculate');

--- a/server/chat-plugins/chat-monitor.ts
+++ b/server/chat-plugins/chat-monitor.ts
@@ -569,7 +569,7 @@ export const commands: ChatCommands = {
 			const output = `'${word}' was added to the ${list} list.`;
 			const upperStaff = Rooms.get('upperstaff');
 			if (upperStaff) upperStaff.add(output).update();
-			if (room.roomid !== 'upperstaff') return this.sendReply(output);
+			return this.sendReply(output);
 		},
 		remove(target, room, user) {
 			if (!this.can('rangeban')) return false;
@@ -594,7 +594,7 @@ export const commands: ChatCommands = {
 			const output = `'${words.join(', ')}' ${Chat.plural(words, "were", "was")} removed from the ${list} list.`;
 			const upperStaff = Rooms.get('upperstaff');
 			if (upperStaff) upperStaff.add(output).update();
-			if (room.roomid !== 'upperstaff') return this.sendReply(output);
+			return this.sendReply(output);
 		},
 		'': 'view',
 		list: 'view',

--- a/server/chat-plugins/chat-monitor.ts
+++ b/server/chat-plugins/chat-monitor.ts
@@ -567,8 +567,7 @@ export const commands: ChatCommands = {
 			}
 			saveFilters(true);
 			const output = `'${word}' was added to the ${list} list.`;
-			const upperStaff = Rooms.get('upperstaff');
-			if (upperStaff) upperStaff.add(output).update();
+			Rooms.get('upperstaff')?.add(output).update();
 			return this.sendReply(output);
 		},
 		remove(target, room, user) {

--- a/server/chat-plugins/chat-monitor.ts
+++ b/server/chat-plugins/chat-monitor.ts
@@ -567,9 +567,8 @@ export const commands: ChatCommands = {
 			}
 			saveFilters(true);
 			const output = `'${word}' was added to the ${list} list.`;
-			if (room?.roomid !== 'upperstaff') this.sendReply(output);
 			Rooms.get('upperstaff')?.add(output).update();
-			return this.sendReply(output);
+			if (room?.roomid !== 'upperstaff') this.sendReply(output);
 		},
 		remove(target, room, user) {
 			if (!this.can('rangeban')) return false;
@@ -592,8 +591,7 @@ export const commands: ChatCommands = {
 			this.globalModlog(`REMOVEFILTER`, null, `'${words.join(', ')}' from ${list} list by ${user.name}`);
 			saveFilters(true);
 			const output = `'${words.join(', ')}' ${Chat.plural(words, "were", "was")} removed from the ${list} list.`;
-			const upperStaff = Rooms.get('upperstaff');
-			if (upperStaff) upperStaff.add(output).update();
+			Rooms.get('upperstaff')?.add(output).update();
 			if (room?.roomid !== 'upperstaff') this.sendReply(output);
 		},
 		'': 'view',

--- a/server/chat-plugins/chat-monitor.ts
+++ b/server/chat-plugins/chat-monitor.ts
@@ -567,6 +567,7 @@ export const commands: ChatCommands = {
 			}
 			saveFilters(true);
 			const output = `'${word}' was added to the ${list} list.`;
+			if (room?.roomid !== 'upperstaff') this.sendReply(output);
 			Rooms.get('upperstaff')?.add(output).update();
 			return this.sendReply(output);
 		},
@@ -593,7 +594,7 @@ export const commands: ChatCommands = {
 			const output = `'${words.join(', ')}' ${Chat.plural(words, "were", "was")} removed from the ${list} list.`;
 			const upperStaff = Rooms.get('upperstaff');
 			if (upperStaff) upperStaff.add(output).update();
-			return this.sendReply(output);
+			if (room?.roomid !== 'upperstaff') this.sendReply(output);
 		},
 		'': 'view',
 		list: 'view',

--- a/server/chat-plugins/daily-spotlight.ts
+++ b/server/chat-plugins/daily-spotlight.ts
@@ -76,6 +76,7 @@ export const pages: PageTable = {
 
 export const commands: ChatCommands = {
 	removedaily(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
 		let [key, rest] = target.split(',');
 		key = toID(key);
@@ -106,6 +107,7 @@ export const commands: ChatCommands = {
 	},
 	queuedaily: 'setdaily',
 	async setdaily(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
 		if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
 		let [key, ...rest] = target.split(',');
 		key = toID(key);
@@ -147,6 +149,7 @@ export const commands: ChatCommands = {
 		saveSpotlights();
 	},
 	async daily(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
 		const key = toID(target);
 		if (!key) return this.parse('/help daily');
@@ -164,6 +167,7 @@ export const commands: ChatCommands = {
 		room.update();
 	},
 	viewspotlights(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
 		return this.parse(`/join view-spotlights-${room.roomid}`);
 	},

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -63,7 +63,6 @@ function escapeHTML(str?: string) {
 }
 
 export const commands: ChatCommands = {
-	'!dexsearch': true,
 	ds: 'dexsearch',
 	ds1: 'dexsearch',
 	ds2: 'dexsearch',
@@ -148,7 +147,6 @@ export const commands: ChatCommands = {
 		);
 	},
 
-	'!randommove': true,
 	rollmove: 'randommove',
 	randmove: 'randommove',
 	randommove(target, room, user, connection, cmd, message) {
@@ -194,7 +192,6 @@ export const commands: ChatCommands = {
 		`/randommove uses the same parameters as /movesearch (see '/help ms').`,
 		`Adding a number as a parameter returns that many random Pok\u00e9mon Moves, e.g., '/randmove 6' returns 6 random Pok\u00e9mon Moves.`,
 	],
-	'!randompokemon': true,
 	rollpokemon: 'randompokemon',
 	randpoke: 'randompokemon',
 	randompokemon(target, room, user, connection, cmd, message) {
@@ -241,7 +238,6 @@ export const commands: ChatCommands = {
 		`Adding a number as a parameter returns that many random Pok\u00e9mon, e.g., '/randpoke 6' returns 6 random Pok\u00e9mon.`,
 	],
 
-	'!movesearch': true,
 	ms: 'movesearch',
 	ms1: 'movesearch',
 	ms2: 'movesearch',
@@ -303,7 +299,6 @@ export const commands: ChatCommands = {
 		);
 	},
 
-	'!itemsearch': true,
 	isearch: 'itemsearch',
 	is: 'itemsearch',
 	is2: 'itemsearch',
@@ -349,7 +344,6 @@ export const commands: ChatCommands = {
 		);
 	},
 
-	'!abilitysearch': true,
 	asearch: 'abilitysearch',
 	as: 'abilitysearch',
 	as3: 'abilitysearch',
@@ -392,7 +386,6 @@ export const commands: ChatCommands = {
 		);
 	},
 
-	'!learn': true,
 	learnset: 'learn',
 	learnall: 'learn',
 	learn5: 'learn',

--- a/server/chat-plugins/hangman.ts
+++ b/server/chat-plugins/hangman.ts
@@ -208,6 +208,7 @@ export const commands: ChatCommands = {
 	hangman: {
 		create: 'new',
 		new(target, room, user, connection) {
+			if (!room) return this.requiresRoom();
 			const text = this.filter(target);
 			if (target !== text) return this.errorReply("You are not allowed to use filtered words in hangmans.");
 			const params = text.split(',');
@@ -242,6 +243,7 @@ export const commands: ChatCommands = {
 		createhelp: ["/hangman create [word], [hint] - Makes a new hangman game. Requires: % @ # &"],
 
 		guess(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!target) return this.parse('/help guess');
 			const game = room.getGame(Hangman);
 			if (!game) return this.errorReply("There is no game of hangman running in this room.");
@@ -256,6 +258,7 @@ export const commands: ChatCommands = {
 
 		stop: 'end',
 		end(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('minigame', null, room)) return false;
 			if (!this.canTalk()) return;
 			const game = room.getGame(Hangman);
@@ -268,6 +271,7 @@ export const commands: ChatCommands = {
 		endhelp: ["/hangman end - Ends the game of hangman before the man is hanged or word is guessed. Requires: % @ # &"],
 
 		disable(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('gamemanagement', null, room)) return;
 			if (room.settings.hangmanDisabled) {
 				return this.errorReply("Hangman is already disabled.");
@@ -278,6 +282,7 @@ export const commands: ChatCommands = {
 		},
 
 		enable(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('gamemanagement', null, room)) return;
 			if (!room.settings.hangmanDisabled) {
 				return this.errorReply("Hangman is already enabled.");
@@ -288,6 +293,7 @@ export const commands: ChatCommands = {
 		},
 
 		display(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Hangman);
 			if (!game) return this.errorReply("There is no game of hangman running in this room.");
 			if (!this.runBroadcast()) return;
@@ -313,6 +319,7 @@ export const commands: ChatCommands = {
 	],
 
 	guess(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const game = room.getGame(Hangman);
 		if (!game) return this.errorReply("There is no game of hangman running in this room.");
 		if (!this.canTalk()) return;

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -1031,7 +1031,6 @@ export const pages: PageTable = {
 };
 
 export const commands: ChatCommands = {
-	'!report': true,
 	report(target, room, user) {
 		if (!this.runBroadcast()) return;
 		const meta = this.pmTarget ? `-user-${this.pmTarget.id}` : this.room ? `-room-${this.room.roomid}` : '';
@@ -1043,7 +1042,6 @@ export const commands: ChatCommands = {
 		return this.parse(`/join view-help-request--report${meta}`);
 	},
 
-	'!appeal': true,
 	appeal(target, room, user) {
 		if (!this.runBroadcast()) return;
 		const meta = this.pmTarget ? `-user-${this.pmTarget.id}` : this.room ? `-room-${this.room.roomid}` : '';
@@ -1059,7 +1057,6 @@ export const commands: ChatCommands = {
 	helprequest: 'helpticket',
 	ht: 'helpticket',
 	helpticket: {
-		'!create': true,
 		'': 'create',
 		create(target, room, user) {
 			if (!this.runBroadcast()) return;
@@ -1075,7 +1072,6 @@ export const commands: ChatCommands = {
 		},
 		createhelp: [`/helpticket create - Creates a new ticket requesting help from global staff.`],
 
-		'!submit': true,
 		submit(target, room, user, connection) {
 			if (user.can('lock') && !user.can('bypassall')) {
 				return this.popupReply(`Global staff can't make tickets. They can only use the form for reference.`);
@@ -1219,21 +1215,18 @@ export const commands: ChatCommands = {
 			connection.send(`>view-help-request\n|deinit`);
 		},
 
-		'!list': true,
 		list(target, room, user) {
 			if (!this.can('lock')) return;
 			this.parse('/join view-help-tickets');
 		},
 		listhelp: [`/helpticket list - Lists all tickets. Requires: % @ &`],
 
-		'!stats': true,
 		stats(target, room, user) {
 			if (!this.can('lock')) return;
 			this.parse('/join view-help-stats');
 		},
 		statshelp: [`/helpticket stats - List the stats for help tickets. Requires: % @ &`],
 
-		'!close': true,
 		close(target, room, user) {
 			if (!target) return this.parse(`/help helpticket close`);
 			let result = !(this.splitTarget(target) === 'false');

--- a/server/chat-plugins/jeopardy.ts
+++ b/server/chat-plugins/jeopardy.ts
@@ -565,6 +565,7 @@ export const commands: ChatCommands = {
 	jeopardy: {
 		off: 'disable',
 		disable(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('gamemanagement', null, room)) return;
 			if (room.settings.jeopardyDisabled) {
 				return this.errorReply("Jeopardy is already disabled in this room.");
@@ -576,6 +577,7 @@ export const commands: ChatCommands = {
 
 		on: 'enable',
 		enable(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('gamemanagement', null, room)) return;
 			if (!room.settings.jeopardyDisabled) {
 				return this.errorReply("Jeopardy is already enabled in this room.");
@@ -591,6 +593,7 @@ export const commands: ChatCommands = {
 
 		create: 'new',
 		new(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (room.game) {
 				return this.errorReply(`There is already a game of ${room.game.title} in progress in this room.`);
 			}
@@ -612,6 +615,7 @@ export const commands: ChatCommands = {
 		},
 
 		categories(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Jeopardy);
 			if (!game) return this.errorReply("There is no game of Jeopardy going on in this room.");
 			if (user.id !== game.host.id) return this.errorReply("This command can only be used by the host.");
@@ -624,6 +628,7 @@ export const commands: ChatCommands = {
 		},
 
 		category(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Jeopardy);
 			if (!game) return this.errorReply("There is no game of Jeopardy going on in this room.");
 			if (user.id !== game.host.id) return this.errorReply("This command can only be used by the host.");
@@ -642,6 +647,7 @@ export const commands: ChatCommands = {
 		},
 
 		select(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Jeopardy);
 			if (!game) return this.errorReply("There is no game of Jeopardy going on in this room.");
 			const reply = game.select(target, user);
@@ -649,6 +655,7 @@ export const commands: ChatCommands = {
 		},
 
 		buzz(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Jeopardy);
 			if (!game) return this.errorReply("There is no game of Jeopardy going on in this room.");
 			const reply = game.buzz(user);
@@ -656,6 +663,7 @@ export const commands: ChatCommands = {
 		},
 
 		wager(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Jeopardy);
 			if (!game) return this.errorReply("There is no game of Jeopardy going on in this room.");
 			const reply = game.wager(target, user);
@@ -663,6 +671,7 @@ export const commands: ChatCommands = {
 		},
 
 		answer(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Jeopardy);
 			if (!game) return this.errorReply("There is no game of Jeopardy going on in this room.");
 			const reply = game.answer(target, user);
@@ -670,6 +679,7 @@ export const commands: ChatCommands = {
 		},
 
 		import(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Jeopardy);
 			if (!target) return this.errorReply("You must specify at least one question");
 			if (!game) return this.errorReply("There is no game of Jeopardy going on in this room.");
@@ -715,6 +725,7 @@ export const commands: ChatCommands = {
 
 		dd: 'dailydouble',
 		dailydouble(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Jeopardy);
 			if (!game) return this.errorReply("There is no game of Jeopardy going on in this room.");
 			if (user.id !== game.host.id) return this.errorReply("This command can only be used by the host.");
@@ -740,6 +751,7 @@ export const commands: ChatCommands = {
 		],
 
 		view(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Jeopardy);
 			if (!game) return this.errorReply("There is no game of Jeopardy going on in this room.");
 			if (user.id !== game.host.id) return this.errorReply("This command can only be used by the host.");
@@ -758,6 +770,7 @@ export const commands: ChatCommands = {
 
 		addplayer: 'adduser',
 		adduser(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Jeopardy);
 			if (!game) return this.errorReply("There is no game of Jeopardy going on in this room.");
 			if (user.id !== game.host.id) return this.errorReply("This command can only be used by the host.");
@@ -773,6 +786,7 @@ export const commands: ChatCommands = {
 
 		incorrect: 'correct',
 		correct(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Jeopardy);
 			if (!game) return this.errorReply("There is no game of Jeopardy going on in this room.");
 			if (user.id !== game.host.id) return this.errorReply("This command can only be used by the host.");
@@ -781,6 +795,7 @@ export const commands: ChatCommands = {
 		},
 
 		start(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Jeopardy);
 			if (!game) return this.errorReply("There is no game of Jeopardy going on in this room.");
 			if (user.id !== game.host.id) return this.errorReply("This command can only be used by the host.");
@@ -789,6 +804,7 @@ export const commands: ChatCommands = {
 		},
 		removeplayer: 'removeuser',
 		removeuser(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Jeopardy);
 			if (!game) return this.errorReply("There is no game of Jeopardy going on in this room.");
 			if (user.id !== game.host.id) return this.errorReply("This command can only be used by the host.");
@@ -802,6 +818,7 @@ export const commands: ChatCommands = {
 		},
 
 		subhost(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Jeopardy);
 			if (!game) return this.errorReply("There is no game of Jeopardy going on in this room.");
 			if (user.id !== game.host.id) return this.errorReply("This command can only be used by the host.");
@@ -812,6 +829,7 @@ export const commands: ChatCommands = {
 		},
 
 		state(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Jeopardy);
 			if (!game) return this.errorReply("There is no game of Jeopardy going on in this room.");
 			if (user.id !== game.host.id) return this.errorReply("This command can only be used by the host.");
@@ -819,6 +837,7 @@ export const commands: ChatCommands = {
 		},
 
 		end(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Jeopardy);
 			if (!game) return this.errorReply("There is no game of Jeopardy going on in this room.");
 			if (!this.can('minigame', null, room)) return;
@@ -828,6 +847,7 @@ export const commands: ChatCommands = {
 		},
 
 		pass(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Jeopardy);
 			if (!game) return this.errorReply("There is no game of Jeopardy going on in this room.");
 			if (user.id !== game.host.id) return this.errorReply("This command can only be used by the host.");
@@ -835,6 +855,7 @@ export const commands: ChatCommands = {
 		},
 
 		timer(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Jeopardy);
 			if (!game) return this.errorReply("There is no game of Jeopardy going on in this room.");
 			if (user.id !== game.host.id) return this.errorReply("This command can only be used by the host.");
@@ -847,6 +868,7 @@ export const commands: ChatCommands = {
 		},
 
 		finaltimer(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(Jeopardy);
 			if (!game) return this.errorReply("There is no game of Jeopardy going on in this room.");
 			if (user.id !== game.host.id) return this.errorReply("This command can only be used by the host.");

--- a/server/chat-plugins/lottery.ts
+++ b/server/chat-plugins/lottery.ts
@@ -88,6 +88,7 @@ function getWinnersInLottery(roomid: RoomID) {
 export const commands: ChatCommands = {
 	lottery: {
 		''(target, room) {
+			if (!room) return this.requiresRoom();
 			const lottery = lotteries[room.roomid];
 			if (!lottery) {
 				return this.errorReply("This room doesn't have a lottery running.");
@@ -96,6 +97,7 @@ export const commands: ChatCommands = {
 		},
 		edit: 'create',
 		create(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('declare', null, room)) return;
 			if (room.battle || !room.persist) {
 				return this.errorReply('This room does not support the creation of lotteries.');
@@ -136,6 +138,7 @@ export const commands: ChatCommands = {
 			this.modlog(`LOTTERY ${edited ? 'EDIT' : 'CREATE'} ${name}`, null, `${maxWinnersNum} max winners`);
 		},
 		delete(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('declare', null, room)) return;
 			const lottery = lotteries[room.roomid];
 			if (!lottery) {
@@ -147,6 +150,7 @@ export const commands: ChatCommands = {
 			this.sendReply('The lottery was successfully deleted.');
 		},
 		end(target, room) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('declare', null, room)) return;
 			const lottery = lotteries[room.roomid];
 			if (!lottery) {
@@ -230,6 +234,7 @@ export const commands: ChatCommands = {
 			}
 		},
 		participants(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const lottery = lotteries[room.roomid];
 			if (!lottery) {
 				return this.errorReply('This room does not have a lottery running.');

--- a/server/chat-plugins/lottery.ts
+++ b/server/chat-plugins/lottery.ts
@@ -180,7 +180,6 @@ export const commands: ChatCommands = {
 			this.modlog(`LOTTERY END ${lottery.name}`);
 			endLottery(room.roomid, winners);
 		},
-		'!join': true,
 		join(target, room, user) {
 			// This hack is used for the HTML room to be able to
 			// join lotteries in other rooms from the global room
@@ -211,7 +210,6 @@ export const commands: ChatCommands = {
 				this.popupReply('You are already in the lottery.');
 			}
 		},
-		'!leave': true,
 		leave(target, room, user) {
 			// This hack is used for the HTML room to be able to
 			// join lotteries in other rooms from the global room

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -1924,6 +1924,7 @@ export const pages: PageTable = {
 export const commands: ChatCommands = {
 	mafia: {
 		''(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(MafiaTracker);
 			if (game) {
 				if (!this.runBroadcast()) return;
@@ -1935,9 +1936,10 @@ export const commands: ChatCommands = {
 		forcehost: 'host',
 		nexthost: 'host',
 		host(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			if (room.settings.mafiaDisabled) return this.errorReply(`Mafia is disabled for this room.`);
 			if (!this.canTalk()) return;
-			if (!room || room.type !== 'chat') return this.errorReply(`This command is only meant to be used in chat rooms.`);
+			if (room.type !== 'chat') return this.errorReply(`This command is only meant to be used in chat rooms.`);
 			if (room.game) return this.errorReply(`There is already a game of ${room.game.title} in progress in this room.`);
 			if (!user.can('broadcast', null, room)) return this.errorReply(`/mafia ${cmd} - Access denied.`);
 
@@ -2002,6 +2004,7 @@ export const commands: ChatCommands = {
 
 		q: 'queue',
 		queue(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (room.settings.mafiaDisabled) return this.errorReply(`Mafia is disabled for this room.`);
 			if (room.roomid !== 'mafia') return this.errorReply(`This command can only be used in the Mafia room.`);
 			const args = target.split(',').map(toID);
@@ -2092,6 +2095,7 @@ export const commands: ChatCommands = {
 		leavehelp: [`/mafia leave - Leave the game. Can only be done while signups are open.`],
 
 		playercap(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
@@ -2113,6 +2117,7 @@ export const commands: ChatCommands = {
 
 		'!close': true,
 		close(target, room, user) {
+			if (!room) return this.requiresRoom();
 			let targetRoom = Rooms.get(target);
 			if (!targetRoom || targetRoom.type !== 'chat' || !targetRoom.users[user.id]) {
 				if (!room || room.type !== 'chat') return this.errorReply(`This command is only meant to be used in chat rooms.`);
@@ -2133,6 +2138,7 @@ export const commands: ChatCommands = {
 		'!closedsetup': true,
 		cs: 'closedsetup',
 		closedsetup(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const args = target.split(',');
 			let targetRoom = Rooms.get(args[0]);
 			if (!targetRoom || targetRoom.type !== 'chat' || !targetRoom.users[user.id]) {
@@ -2165,6 +2171,7 @@ export const commands: ChatCommands = {
 
 		'!reveal': true,
 		reveal(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const args = target.split(',');
 			let targetRoom = Rooms.get(args[0]);
 			if (!targetRoom || targetRoom.type !== 'chat' || !targetRoom.users[user.id]) {
@@ -2195,6 +2202,7 @@ export const commands: ChatCommands = {
 		forceresetroles: 'setroles',
 		forcesetroles: 'setroles',
 		setroles(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
@@ -2218,6 +2226,7 @@ export const commands: ChatCommands = {
 		],
 
 		idea(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (!this.can('broadcast', null, room)) return;
@@ -2239,6 +2248,7 @@ export const commands: ChatCommands = {
 		],
 
 		customidea(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('mute', null, room)) return;
 			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
@@ -2287,6 +2297,7 @@ export const commands: ChatCommands = {
 
 		'!ideareroll': true,
 		ideareroll(target, room, user) {
+			if (!room) return this.requiresRoom();
 			let targetRoom = Rooms.get(target);
 			if (!targetRoom || targetRoom.type !== 'chat' || !targetRoom.users[user.id]) {
 				if (!room || room.type !== 'chat') return this.errorReply(`This command is only meant to be used in chat rooms.`);
@@ -2302,6 +2313,7 @@ export const commands: ChatCommands = {
 
 		discards: 'ideadiscards',
 		ideadiscards(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (!game.IDEA.data) return this.errorReply(`There is no IDEA module in the mafia game.`);
@@ -2333,6 +2345,7 @@ export const commands: ChatCommands = {
 		'!start': true,
 		nightstart: 'start',
 		start(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			let targetRoom = Rooms.get(target);
 			if (!targetRoom || targetRoom.type !== 'chat' || !targetRoom.users[user.id]) {
 				if (!room || room.type !== 'chat') return this.errorReply(`This command is only meant to be used in chat rooms.`);
@@ -2358,6 +2371,7 @@ export const commands: ChatCommands = {
 		extend: 'day',
 		night: 'day',
 		day(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			const args = target.split(',');
 			let targetRoom = Rooms.get(args[0]);
 			if (!targetRoom || targetRoom.type !== 'chat' || !targetRoom.users[user.id]) {
@@ -2440,6 +2454,7 @@ export const commands: ChatCommands = {
 		'!selflynch': true,
 		enableself: 'selflynch',
 		selflynch(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			const args = target.split(',');
 			let targetRoom = Rooms.get(args[0]);
 			if (!targetRoom || targetRoom.type !== 'chat' || !targetRoom.users[user.id]) {
@@ -2474,6 +2489,7 @@ export const commands: ChatCommands = {
 		spiritstump: 'kill',
 		kick: 'kill',
 		kill(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			const args = target.split(',');
 			let targetRoom = Rooms.get(args[0]);
 			if (!targetRoom || targetRoom.type !== 'chat' || !targetRoom.users[user.id]) {
@@ -2504,10 +2520,11 @@ export const commands: ChatCommands = {
 		forceadd: 'revive',
 		add: 'revive',
 		revive(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			const args = target.split(',');
 			let targetRoom = Rooms.get(args[0]);
 			if (!targetRoom || targetRoom.type !== 'chat' || !targetRoom.users[user.id]) {
-				if (!room || room.type !== 'chat') return this.errorReply(`This command is only meant to be used in chat rooms.`);
+				if (room.type !== 'chat') return this.errorReply(`This command is only meant to be used in chat rooms.`);
 				targetRoom = room;
 			} else {
 				args.shift();
@@ -2528,6 +2545,7 @@ export const commands: ChatCommands = {
 
 		dl: 'deadline',
 		deadline(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			target = toID(target);
@@ -2560,6 +2578,7 @@ export const commands: ChatCommands = {
 
 		applylynchmodifier: 'applyhammermodifier',
 		applyhammermodifier(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
@@ -2575,6 +2594,7 @@ export const commands: ChatCommands = {
 		},
 		clearlynchmodifiers: 'clearhammermodifiers',
 		clearhammermodifiers(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
@@ -2630,6 +2650,7 @@ export const commands: ChatCommands = {
 
 		unsilence: 'silence',
 		silence(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
@@ -2655,6 +2676,7 @@ export const commands: ChatCommands = {
 		uninsomniac: 'nighttalk',
 		unnighttalk: 'nighttalk',
 		nighttalk(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			const game = room?.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
@@ -2679,6 +2701,7 @@ export const commands: ChatCommands = {
 		unactor: 'priest',
 		unpriest: 'priest',
 		priest(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			const game = room?.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
@@ -2720,6 +2743,7 @@ export const commands: ChatCommands = {
 		shifthammer: 'hammer',
 		resethammer: 'hammer',
 		hammer(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
@@ -2751,6 +2775,7 @@ export const commands: ChatCommands = {
 		'!enablenl': true,
 		disablenl: 'enablenl',
 		enablenl(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			let targetRoom = Rooms.get(target);
 			if (!targetRoom || targetRoom.type !== 'chat' || !targetRoom.users[user.id]) {
 				if (!room || room.type !== 'chat') return this.errorReply(`This command is only meant to be used in chat rooms.`);
@@ -2771,6 +2796,7 @@ export const commands: ChatCommands = {
 		],
 
 		forcelynch(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id) && !this.can('mute', null, room)) return;
@@ -2794,6 +2820,7 @@ export const commands: ChatCommands = {
 		],
 
 		lynches(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (!game.started) return this.errorReply(`The game of mafia has not started yet.`);
@@ -2809,6 +2836,7 @@ export const commands: ChatCommands = {
 
 		pl: 'players',
 		players(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 
@@ -2829,6 +2857,7 @@ export const commands: ChatCommands = {
 		orl: 'rolelist',
 		rl: 'rolelist',
 		rolelist(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.closedSetup) return this.errorReply(`You cannot show roles in a closed setup.`);
@@ -2848,6 +2877,7 @@ export const commands: ChatCommands = {
 		},
 
 		playerroles(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (game.hostid !== user.id && !game.cohosts.includes(user.id)) return this.errorReply(`Only the host can view roles.`);
@@ -2860,6 +2890,7 @@ export const commands: ChatCommands = {
 
 		spectate: 'view',
 		view(target, room, user, connection) {
+			if (!room) return this.requiresRoom();
 			const game = room?.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (!this.runBroadcast()) return;
@@ -2884,6 +2915,7 @@ export const commands: ChatCommands = {
 		'!sub': true,
 		forcesub: 'sub',
 		sub(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			const args = target.split(',');
 			let targetRoom = Rooms.get(args[0]);
 			if (!targetRoom || targetRoom.type !== 'chat' || !targetRoom.users[user.id]) {
@@ -3015,10 +3047,11 @@ export const commands: ChatCommands = {
 
 		"!autosub": true,
 		autosub(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const args = target.split(',');
 			let targetRoom = Rooms.get(args[0]);
 			if (!targetRoom || targetRoom.type !== 'chat' || !targetRoom.users[user.id]) {
-				if (!room || room.type !== 'chat') return this.errorReply(`This command is only meant to be used in chat rooms.`);
+				if (room.type !== 'chat') return this.errorReply(`This command is only meant to be used in chat rooms.`);
 				targetRoom = room;
 			} else {
 				args.shift();
@@ -3048,6 +3081,7 @@ export const commands: ChatCommands = {
 		forcecohost: 'subhost',
 		forcesubhost: 'subhost',
 		subhost(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (!this.canTalk()) return;
@@ -3099,6 +3133,7 @@ export const commands: ChatCommands = {
 
 		uncohost: 'removecohost',
 		removecohost(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(MafiaTracker);
 			if (!game) return this.errorReply(`There is no game of mafia running in this room.`);
 			if (!this.canTalk()) return;
@@ -3120,6 +3155,7 @@ export const commands: ChatCommands = {
 
 		'!end': true,
 		end(target, room, user) {
+			if (!room) return this.requiresRoom();
 			let targetRoom = Rooms.get(target);
 			if (!targetRoom || targetRoom.type !== 'chat' || !targetRoom.users[user.id]) {
 				if (!room || room.type !== 'chat') return this.errorReply(`This command is only meant to be used in chat rooms.`);

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -2066,7 +2066,6 @@ export const commands: ChatCommands = {
 			this.parse(`/mafia queue remove, ${target}`);
 		},
 
-		'!join': true,
 		join(target, room, user) {
 			let targetRoom = Rooms.get(target);
 			if (!targetRoom || targetRoom.type !== 'chat' || !targetRoom.users[user.id]) {
@@ -2081,7 +2080,6 @@ export const commands: ChatCommands = {
 		},
 		joinhelp: [`/mafia join - Join the game.`],
 
-		'!leave': true,
 		leave(target, room, user) {
 			let targetRoom = Rooms.get(target);
 			if (!targetRoom || targetRoom.type !== 'chat' || !targetRoom.users[user.id]) {
@@ -2115,7 +2113,6 @@ export const commands: ChatCommands = {
 			`/mafia playercap [cap|none]- Limit the number of players being able to join the game. Player cap cannot be more than 20 or less than 2. Requires: host % @ # &`,
 		],
 
-		'!close': true,
 		close(target, room, user) {
 			if (!room) return this.requiresRoom();
 			let targetRoom = Rooms.get(target);
@@ -2135,7 +2132,6 @@ export const commands: ChatCommands = {
 		},
 		closehelp: [`/mafia close - Closes signups for the current game. Requires: host % @ # &`],
 
-		'!closedsetup': true,
 		cs: 'closedsetup',
 		closedsetup(target, room, user) {
 			if (!room) return this.requiresRoom();
@@ -2169,7 +2165,6 @@ export const commands: ChatCommands = {
 			`/mafia closedsetup [on|off] - Sets if the game is a closed setup. Closed setups don't show the role list to players. Requires host % @ # &`,
 		],
 
-		'!reveal': true,
 		reveal(target, room, user) {
 			if (!room) return this.requiresRoom();
 			const args = target.split(',');
@@ -2272,7 +2267,6 @@ export const commands: ChatCommands = {
 			`choices refers to the number of roles you get to pick from. In GI, this is 2, in GestI, this is 3.`,
 			`picks refers to what you choose. In GI, this should be 'role', in GestI, this should be 'role, alignment'`,
 		],
-		'!ideapick': true,
 		ideapick(target, room, user) {
 			const args = target.split(',');
 			let targetRoom = Rooms.get(args[0]);
@@ -2295,7 +2289,6 @@ export const commands: ChatCommands = {
 			game.ideaPick(user, args);
 		},
 
-		'!ideareroll': true,
 		ideareroll(target, room, user) {
 			if (!room) return this.requiresRoom();
 			let targetRoom = Rooms.get(target);
@@ -2342,7 +2335,6 @@ export const commands: ChatCommands = {
 			`/mafia ideadiscards on - shows discards to the players. Requires host % @ # &`,
 		],
 
-		'!start': true,
 		nightstart: 'start',
 		start(target, room, user, connection, cmd) {
 			if (!room) return this.requiresRoom();
@@ -2367,7 +2359,6 @@ export const commands: ChatCommands = {
 		},
 		starthelp: [`/mafia start - Start the game of mafia. Signups must be closed. Requires host % @ # &`],
 
-		'!day': true,
 		extend: 'day',
 		night: 'day',
 		day(target, room, user, connection, cmd) {
@@ -2403,7 +2394,6 @@ export const commands: ChatCommands = {
 			`/mafia extend (minutes) - Return to the previous game day. If (minutes) is provided, set the deadline for (minutes) minutes. Requires host % @ # &`,
 		],
 
-		'!lynch': true,
 		l: 'lynch',
 		lynch(target, room, user) {
 			const args = target.split(',');
@@ -2425,7 +2415,6 @@ export const commands: ChatCommands = {
 		},
 		lynchhelp: [`/mafia lynch [player|nolynch] - Vote to lynch the specified player or to not lynch anyone.`],
 
-		'!unlynch': true,
 		ul: 'unlynch',
 		unl: 'unlynch',
 		unnolynch: 'unlynch',
@@ -2451,7 +2440,6 @@ export const commands: ChatCommands = {
 			this.parse('/mafia lynch nolynch');
 		},
 
-		'!selflynch': true,
 		enableself: 'selflynch',
 		selflynch(target, room, user, connection, cmd) {
 			if (!room) return this.requiresRoom();
@@ -2483,7 +2471,6 @@ export const commands: ChatCommands = {
 			`/mafia selflynch [on|hammer|off] - Allows players to self lynch themselves either at hammer or anytime. Requires host % @ # &`,
 		],
 
-		'!kill': true,
 		treestump: 'kill',
 		spirit: 'kill',
 		spiritstump: 'kill',
@@ -2516,7 +2503,6 @@ export const commands: ChatCommands = {
 			`/mafia spiritstump [player] Kills a player, but allows them to talk during the day, and vote on the lynch.`,
 		],
 
-		'!revive': true,
 		forceadd: 'revive',
 		add: 'revive',
 		revive(target, room, user, connection, cmd) {
@@ -2772,7 +2758,6 @@ export const commands: ChatCommands = {
 			`/mafia resethammer - sets the hammer to the default, resetting lynches`,
 		],
 
-		'!enablenl': true,
 		disablenl: 'enablenl',
 		enablenl(target, room, user, connection, cmd) {
 			if (!room) return this.requiresRoom();
@@ -2900,7 +2885,6 @@ export const commands: ChatCommands = {
 			return this.parse(`/join view-mafia-${room.roomid}`);
 		},
 
-		'!refreshlynches': true,
 		refreshlynches(target, room, user, connection) {
 			let targetRoom = Rooms.get(target);
 			if (!targetRoom || targetRoom.type !== 'chat' || !targetRoom.users[user.id]) {
@@ -2912,7 +2896,6 @@ export const commands: ChatCommands = {
 			const lynches = game.lynchBoxFor(user.id);
 			user.send(`>view-mafia-${game.room.roomid}\n|selectorhtml|#mafia-lynches|` + lynches);
 		},
-		'!sub': true,
 		forcesub: 'sub',
 		sub(target, room, user, connection, cmd) {
 			if (!room) return this.requiresRoom();
@@ -3045,7 +3028,6 @@ export const commands: ChatCommands = {
 			`/mafia sub [player], [user] - Forcibly sub [player] for [user]. Requires host % @ # &`,
 		],
 
-		"!autosub": true,
 		autosub(target, room, user) {
 			if (!room) return this.requiresRoom();
 			const args = target.split(',');
@@ -3153,7 +3135,6 @@ export const commands: ChatCommands = {
 			this.modlog('MAFIAUNCOHOST', target, null, {noalts: true, noip: true});
 		},
 
-		'!end': true,
 		end(target, room, user) {
 			if (!room) return this.requiresRoom();
 			let targetRoom = Rooms.get(target);
@@ -3170,7 +3151,6 @@ export const commands: ChatCommands = {
 		},
 		endhelp: [`/mafia end - End the current game of mafia. Requires host + % @ # &`],
 
-		'!data': true,
 		role: 'data',
 		alignment: 'data',
 		theme: 'data',

--- a/server/chat-plugins/modlog.ts
+++ b/server/chat-plugins/modlog.ts
@@ -569,7 +569,7 @@ export const commands: ChatCommands = {
 	pl: 'modlog',
 	timedmodlog: 'modlog',
 	modlog(target, room, user, connection, cmd) {
-		if (!room) (room as Room | undefined) = Rooms.get('global');
+		if (!room) room = Rooms.get('global') as ChatRoom | GameRoom;
 		let roomid: RoomID = (room.roomid === 'staff' ? 'global' : room.roomid);
 
 		if (target.includes(',')) {

--- a/server/chat-plugins/modlog.ts
+++ b/server/chat-plugins/modlog.ts
@@ -563,7 +563,6 @@ export const pages: PageTable = {
 };
 
 export const commands: ChatCommands = {
-	'!modlog': true,
 	ml: 'modlog',
 	punishlog: 'modlog',
 	pl: 'modlog',

--- a/server/chat-plugins/modlog.ts
+++ b/server/chat-plugins/modlog.ts
@@ -568,13 +568,13 @@ export const commands: ChatCommands = {
 	pl: 'modlog',
 	timedmodlog: 'modlog',
 	modlog(target, room, user, connection, cmd) {
-		if (!room) room = Rooms.get('global') as ChatRoom | GameRoom;
-		let roomid: RoomID = (room.roomid === 'staff' ? 'global' : room.roomid);
+		let roomid: RoomID = (!room || room.roomid === 'staff' ? 'global' : room.roomid);
 
 		if (target.includes(',')) {
 			const targets = target.split(',');
 			target = targets[1].trim();
-			roomid = toID(targets[0]) as RoomID || room.roomid;
+			const newid = toID(targets[0]) as RoomID;
+			if (newid) roomid = newid;
 		}
 
 		const targetRoom = Rooms.search(roomid);

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -39,7 +39,6 @@ function getMegaStone(stone: string, mod = 'gen8'): Item | null {
 }
 
 export const commands: ChatCommands = {
-	'!othermetas': true,
 	om: 'othermetas',
 	othermetas(target, room, user) {
 		if (!this.runBroadcast()) return;
@@ -76,7 +75,6 @@ export const commands: ChatCommands = {
 		`!om - Show everyone that information. Requires: + % @ # &`,
 	],
 
-	'!mixandmega': true,
 	mnm: 'mixandmega',
 	mixandmega(target, room, user) {
 		if (!this.runBroadcast()) return;
@@ -175,7 +173,6 @@ export const commands: ChatCommands = {
 		`/mnm <pokemon> @ <mega stone>[, generation] - Shows the Mix and Mega evolved Pokemon's type and stats.`,
 	],
 
-	'!stone': true,
 	orb: 'stone',
 	megastone: 'stone',
 	stone(target) {
@@ -277,7 +274,6 @@ export const commands: ChatCommands = {
 	},
 	stonehelp: [`/stone <mega stone>[, generation] - Shows the changes that a mega stone/orb applies to a Pokemon.`],
 
-	'!350cup': true,
 	350: '350cup',
 	'350cup'(target, room, user) {
 		if (!this.runBroadcast()) return;
@@ -309,7 +305,6 @@ export const commands: ChatCommands = {
 		`/350 OR /350cup <pokemon>[, gen] - Shows the base stats that a Pok\u00e9mon would have in 350 Cup.`,
 	],
 
-	'!tiershift': true,
 	ts: 'tiershift',
 	ts1: 'tiershift',
 	ts2: 'tiershift',
@@ -365,7 +360,6 @@ export const commands: ChatCommands = {
 		`Alternatively, you can use /ts[gen number] to see a Pokemon's stats in that generation.`,
 	],
 
-	'!scalemons': true,
 	scale: 'scalemons',
 	scale1: 'scalemons',
 	scale2: 'scalemons',
@@ -410,7 +404,6 @@ export const commands: ChatCommands = {
 		`Alternatively, you can use /scale[gen number] to see a Pokemon's scaled stats in that generation.`,
 	],
 
-	'!natureswap': true,
 	ns: 'natureswap',
 	ns3: 'natureswap',
 	ns4: 'natureswap',
@@ -457,7 +450,6 @@ export const commands: ChatCommands = {
 		`Alternatively, you can use /ns[gen number] to see a Pokemon's stats in that generation.`,
 	],
 
-	'!crossevolve': true,
 	ce: 'crossevolve',
 	crossevo: 'crossevolve',
 	crossevolve(target, user, room) {

--- a/server/chat-plugins/poll.ts
+++ b/server/chat-plugins/poll.ts
@@ -270,6 +270,7 @@ export const commands: ChatCommands = {
 		queuemulti: 'new',
 		htmlqueuemulti: 'new',
 		new(target, room, user, connection, cmd, message) {
+			if (!room) return this.requiresRoom();
 			if (!target) return this.parse('/help poll new');
 			target = target.trim();
 			if (target.length > 1024) return this.errorReply("Poll too long.");
@@ -336,6 +337,7 @@ export const commands: ChatCommands = {
 		],
 
 		viewqueue(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('mute', null, room)) return false;
 			this.parse(`/join view-pollqueue-${room.roomid}`);
 		},
@@ -343,6 +345,7 @@ export const commands: ChatCommands = {
 
 		clearqueue: 'deletequeue',
 		deletequeue(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('mute', null, room)) return false;
 			if (!room.minorActivityQueue) {
 				return this.errorReply("The queue is already empty.");
@@ -379,6 +382,7 @@ export const commands: ChatCommands = {
 		deselect: 'select',
 		vote: 'select',
 		select(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			if (!room.minorActivity || room.minorActivity.activityId !== 'poll') {
 				return this.errorReply("There is no poll running in this room.");
 			}
@@ -400,7 +404,9 @@ export const commands: ChatCommands = {
 			`/poll select [number] - Select option [number].`,
 			`/poll deselect [number] - Deselects option [number].`,
 		],
+
 		submit(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!room.minorActivity || room.minorActivity.activityId !== 'poll') {
 				return this.errorReply("There is no poll running in this room.");
 			}
@@ -411,6 +417,7 @@ export const commands: ChatCommands = {
 		submithelp: [`/poll submit - Submits your vote.`],
 
 		timer(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!room.minorActivity || room.minorActivity.activityId !== 'poll') {
 				return this.errorReply("There is no poll running in this room.");
 			}
@@ -458,6 +465,7 @@ export const commands: ChatCommands = {
 		],
 
 		results(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!room.minorActivity || room.minorActivity.activityId !== 'poll') {
 				return this.errorReply("There is no poll running in this room.");
 			}
@@ -472,6 +480,7 @@ export const commands: ChatCommands = {
 		close: 'end',
 		stop: 'end',
 		end(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('minigame', null, room)) return false;
 			if (!this.canTalk()) return;
 			if (!room.minorActivity || room.minorActivity.activityId !== 'poll') {
@@ -497,6 +506,7 @@ export const commands: ChatCommands = {
 		show: '',
 		display: '',
 		''(target, room, user, connection) {
+			if (!room) return this.requiresRoom();
 			if (!room.minorActivity || room.minorActivity.activityId !== 'poll') {
 				return this.errorReply("There is no poll running in this room.");
 			}

--- a/server/chat-plugins/random-battles.ts
+++ b/server/chat-plugins/random-battles.ts
@@ -293,7 +293,6 @@ function CAP1v1Sets(species: string | Species) {
 }
 
 export const commands: ChatCommands = {
-	'!randombattles': true,
 	randbats: 'randombattles',
 	randombattles(target, room, user) {
 		if (!this.runBroadcast()) return;
@@ -351,7 +350,6 @@ export const commands: ChatCommands = {
 		`/randombattles OR /randbats [pokemon], [gen] - Displays a Pok\u00e9mon's Random Battle Moves. Defaults to Gen 8. If used in a battle, defaults to the gen of that battle.`,
 	],
 
-	'!randomdoublesbattle': true,
 	randdubs: 'randomdoublesbattle',
 	randomdoublesbattle(target, room, user) {
 		if (!this.runBroadcast()) return;
@@ -394,7 +392,6 @@ export const commands: ChatCommands = {
 		`/randomdoublesbattle OR /randdubs [pokemon], [gen] - Displays a Pok\u00e9mon's Random Doubles Battle Moves. Supports Gens 4-8. Defaults to Gen 8. If used in a battle, defaults to that gen.`,
 	],
 
-	'!battlefactory': true,
 	bssfactory: 'battlefactory',
 	battlefactory(target, room, user, connection, cmd) {
 		if (!this.runBroadcast()) return;
@@ -457,7 +454,6 @@ export const commands: ChatCommands = {
 		`/bssfactory [pokemon], [gen] - Displays a Pok\u00e9mon's BSS Factory sets. Supports Gen 7. Defaults to Gen 7.`,
 	],
 
-	'!cap1v1': true,
 	cap1v1(target, room, user) {
 		if (!this.runBroadcast()) return;
 		if (!target) return this.parse(`/help cap1v1`);

--- a/server/chat-plugins/room-events.ts
+++ b/server/chat-plugins/room-events.ts
@@ -103,6 +103,7 @@ export const commands: ChatCommands = {
 	roomevent: 'roomevents',
 	roomevents: {
 		''(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
 			if (!room.settings.events || !Object.keys(room.settings.events).length) {
 				return this.errorReply("There are currently no planned upcoming events for this room.");
@@ -129,6 +130,7 @@ export const commands: ChatCommands = {
 		create: 'add',
 		edit: 'add',
 		add(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
 			if (!this.can('ban', null, room)) return false;
 			if (!room.settings.events) room.settings.events = Object.create(null);
@@ -166,6 +168,7 @@ export const commands: ChatCommands = {
 		},
 
 		rename(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
 			if (!this.can('ban', null, room)) return false;
 			let [oldName, newName] = target.split(target.includes('|') ? '|' : ',');
@@ -198,6 +201,7 @@ export const commands: ChatCommands = {
 
 		begin: 'start',
 		start(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
 			if (!this.can('ban', null, room)) return false;
 			if (!room.settings.events || !Object.keys(room.settings.events).length) {
@@ -232,6 +236,7 @@ export const commands: ChatCommands = {
 
 		delete: 'remove',
 		remove(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
 			if (!this.can('ban', null, room)) return false;
 			if (!room.settings.events || Object.keys(room.settings.events).length === 0) {
@@ -256,6 +261,7 @@ export const commands: ChatCommands = {
 		},
 
 		view(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
 			if (!room.settings.events || !Object.keys(room.settings.events).length) {
 				return this.errorReply("There are currently no planned upcoming events for this room.");
@@ -316,6 +322,7 @@ export const commands: ChatCommands = {
 
 		alias: 'addalias',
 		addalias(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
 			if (!this.can('ban', null, room)) return false;
 			const [alias, eventId] = target.split(target.includes('|') ? '|' : ',').map(argument => toID(argument));
@@ -338,6 +345,7 @@ export const commands: ChatCommands = {
 
 		deletealias: 'removealias',
 		removealias(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
 			if (!this.can('ban', null, room)) return false;
 			target = toID(target);
@@ -357,6 +365,7 @@ export const commands: ChatCommands = {
 		},
 
 		addtocategory(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
 			if (!this.can('ban', null, room)) return false;
 			const [eventId, categoryId] = target.split(target.includes('|') ? '|' : ',').map(argument => toID(argument));
@@ -387,6 +396,7 @@ export const commands: ChatCommands = {
 		},
 
 		removefromcategory(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
 			if (!this.can('ban', null, room)) return false;
 			const [eventId, categoryId] = target.split(target.includes('|') ? '|' : ',').map(argument => toID(argument));
@@ -420,6 +430,7 @@ export const commands: ChatCommands = {
 
 		addcat: 'addcategory',
 		addcategory(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
 			if (!this.can('ban', null, room)) return false;
 			const categoryId = toID(target);
@@ -443,6 +454,7 @@ export const commands: ChatCommands = {
 		removecat: 'removecategory',
 		rmcat: 'removecategory',
 		removecategory(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
 			if (!this.can('ban', null, room)) return false;
 			const categoryId = toID(target);
@@ -464,6 +476,7 @@ export const commands: ChatCommands = {
 		},
 
 		sortby(target, room, user) {
+			if (!room) return this.requiresRoom();
 			// preconditions
 			if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
 			if (!room.settings.events || !Object.keys(room.settings.events).length) {

--- a/server/chat-plugins/room-faqs.ts
+++ b/server/chat-plugins/room-faqs.ts
@@ -30,6 +30,7 @@ function getAlias(roomid: RoomID, key: string) {
 
 export const commands: ChatCommands = {
 	addfaq(target, room, user, connection) {
+		if (!room) return this.requiresRoom();
 		if (!this.can('ban', null, room)) return false;
 		if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
 		if (!target) return this.parse('/help roomfaq');
@@ -57,6 +58,7 @@ export const commands: ChatCommands = {
 		this.modlog('RFAQ', null, `added '${topic}'`);
 	},
 	removefaq(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.canTalk()) return this.errorReply("You cannot do this while unable to talk.");
 		if (!this.can('ban', null, room)) return false;
 		if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
@@ -76,6 +78,7 @@ export const commands: ChatCommands = {
 		this.modlog('ROOMFAQ', null, `removed ${topic}`);
 	},
 	addalias(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.canTalk()) return this.errorReply("You cannot do this while unable to talk.");
 		if (!this.can('ban', null, room)) return false;
 		if (!room.persist) return this.errorReply("This command is unavailable in temporary rooms.");
@@ -98,6 +101,7 @@ export const commands: ChatCommands = {
 	viewfaq: 'roomfaq',
 	rfaq: 'roomfaq',
 	roomfaq(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
 		if (!roomFaqs[room.roomid]) return this.errorReply("This room has no FAQ topics.");
 		let topic: string = toID(target);
 		if (topic === 'constructor') return false;

--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -1052,6 +1052,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	guess(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const game = room.getGame(ScavengerHunt);
 		if (!game) return this.errorReply("There is no scavenger hunt currently running.");
 		if (!this.canTalk()) {
@@ -1062,6 +1063,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	join(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const game = room.getGame(ScavengerHunt);
 		if (!game) return this.errorReply("There is no scavenger hunt currently running.");
 		if (!this.canTalk()) return this.errorReply("You cannot join the scavenger hunt when you are unable to talk.");
@@ -1070,6 +1072,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	leave(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const game = room.getGame(ScavengerHunt);
 		if (!game) return this.errorReply("There is no scavenger hunt currently running.");
 		game.leaveGame(user);
@@ -1088,6 +1091,7 @@ const ScavengerCommands: ChatCommands = {
 		create: 'start',
 		new: 'start',
 		start(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('mute', null, room)) return false;
 			if (room.scavgame) return this.errorReply('There is already a scavenger game running.');
 			if (room.getGame(ScavengerHunt)) {
@@ -1108,6 +1112,7 @@ const ScavengerCommands: ChatCommands = {
 		},
 
 		end(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('mute', null, room)) return false;
 			if (!room.scavgame) return this.errorReply(`There is no scavenger game currently running.`);
 
@@ -1118,6 +1123,7 @@ const ScavengerCommands: ChatCommands = {
 		},
 
 		kick(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('mute', null, room)) return false;
 			if (!room.scavgame) return this.errorReply(`There is no scavenger game currently running.`);
 
@@ -1141,6 +1147,7 @@ const ScavengerCommands: ChatCommands = {
 		score: 'leaderboard',
 		scoreboard: 'leaderboard',
 		async leaderboard(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!room.scavgame) return this.errorReply(`There is no scavenger game currently running.`);
 			if (!room.scavgame.leaderboard) return this.errorReply("This scavenger game does not have a leaderboard.");
 			if (!this.runBroadcast()) return false;
@@ -1151,6 +1158,7 @@ const ScavengerCommands: ChatCommands = {
 		},
 
 		async rank(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!room.scavgame) return this.errorReply(`There is no scavenger game currently running.`);
 			if (!room.scavgame.leaderboard) return this.errorReply("This scavenger game does not have a leaderboard.");
 			if (!this.runBroadcast()) return false;
@@ -1170,6 +1178,7 @@ const ScavengerCommands: ChatCommands = {
 	teamscavs: {
 		addteam: 'createteam',
 		createteam(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('mute', null, room)) return false;
 			// if (room.getGame(ScavengerHunt)) return this.errorReply('Teams cannot be modified after the hunt starts.');
 
@@ -1189,6 +1198,7 @@ const ScavengerCommands: ChatCommands = {
 
 		deleteteam: 'removeteam',
 		removeteam(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('mute', null, room)) return false;
 			// if (room.getGame(ScavengerHunt)) return this.errorReply('Teams cannot be modified after the hunt starts.');
 
@@ -1202,6 +1212,7 @@ const ScavengerCommands: ChatCommands = {
 		},
 
 		addplayer(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.scavgame;
 			if (!game || game.id !== 'teamscavs') return this.errorReply('There is currently no game of Team Scavs going on.');
 			// if (room.getGame(ScavengerHunt)) return this.errorReply('Teams cannot be modified after the hunt starts.');
@@ -1236,6 +1247,7 @@ const ScavengerCommands: ChatCommands = {
 		},
 
 		editplayers(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.scavgame;
 			if (!game || game.id !== 'teamscavs') return this.errorReply('There is currently no game of Team Scavs going on.');
 			if (!this.can('mute', null, room)) return false;
@@ -1285,6 +1297,7 @@ const ScavengerCommands: ChatCommands = {
 
 		teams(target, room, user) {
 			if (!this.runBroadcast()) return false;
+			if (!room) return this.requiresRoom();
 
 			const game = room.scavgame;
 			if (!game || game.id !== 'teamscavs') return this.errorReply('There is currently no game of Team Scavs going on.');
@@ -1299,6 +1312,7 @@ const ScavengerCommands: ChatCommands = {
 		},
 
 		guesses(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.scavgame;
 			if (!game || game.id !== 'teamscavs') return this.errorReply('There is currently no game of Team Scavs going on.');
 
@@ -1310,6 +1324,7 @@ const ScavengerCommands: ChatCommands = {
 
 		chat: 'note',
 		note(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.scavgame;
 			if (!game || game.id !== 'teamscavs') return this.errorReply('There is currently no game of Team Scavs going on.');
 
@@ -1347,6 +1362,7 @@ const ScavengerCommands: ChatCommands = {
 	forcecreateunrated: 'create',
 	createrecycled: 'create',
 	create(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
 		if (!getScavsRoom(room)) {
 			return this.errorReply("Scavenger hunts can only be created in the scavengers room.");
 		}
@@ -1421,6 +1437,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	status(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const game = room.getGame(ScavengerHunt);
 		if (!game) return this.errorReply(`There is no scavenger hunt currently running.`);
 
@@ -1456,12 +1473,14 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	hint(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const game = room.getGame(ScavengerHunt);
 		if (!game) return this.errorReply(`There is no scavenger hunt currently running.`);
 		if (!game.onSendQuestion(user, true)) this.errorReply("You are not currently participating in the hunt.");
 	},
 
 	timer(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.can('mute', null, room)) return false;
 		const game = room.getGame(ScavengerHunt);
 		if (!game) return this.errorReply(`There is no scavenger hunt currently running.`);
@@ -1475,6 +1494,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	inherit(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.can('mute', null, room)) return false;
 		const game = room.getGame(ScavengerHunt);
 		if (!game) return this.errorReply(`There is no scavenger hunt currently running.`);
@@ -1493,6 +1513,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	reset(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.can('mute', null, room)) return false;
 		const game = room.getGame(ScavengerHunt);
 		if (!game) return this.errorReply(`There is no scavenger hunt currently running.`);
@@ -1504,6 +1525,7 @@ const ScavengerCommands: ChatCommands = {
 
 	forceend: 'end',
 	end(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.can('mute', null, room)) return false;
 		if (!room.game && room.scavgame) return this.parse('/scav games end');
 		const game = room.getGame(ScavengerHunt);
@@ -1525,6 +1547,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	viewhunt(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const game = room.getGame(ScavengerHunt);
 		if (!game) return this.errorReply(`There is no scavenger hunt currently running.`);
 
@@ -1534,6 +1557,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	edithunt(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const game = room.getGame(ScavengerHunt);
 		if (!game) return this.errorReply(`There is no scavenger hunt currently running.`);
 		if (
@@ -1551,6 +1575,7 @@ const ScavengerCommands: ChatCommands = {
 
 	addhint: 'spoiler',
 	spoiler(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const game = room.getGame(ScavengerHunt);
 		if (!game) return this.errorReply(`There is no scavenger hunt currently running.`);
 		if (
@@ -1572,6 +1597,7 @@ const ScavengerCommands: ChatCommands = {
 
 	deletehint: 'removehint',
 	removehint(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const game = room.getGame(ScavengerHunt);
 		if (!game) return this.errorReply(`There is no scavenger hunt currently running.`);
 		if (
@@ -1595,6 +1621,7 @@ const ScavengerCommands: ChatCommands = {
 
 	modifyhint: 'edithint',
 	edithint(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const game = room.getGame(ScavengerHunt);
 		if (!game) return this.errorReply(`There is no scavenger hunt currently running.`);
 		if (
@@ -1619,6 +1646,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	kick(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const game = room.getGame(ScavengerHunt);
 		if (!game) return this.errorReply(`There is no scavenger hunt currently running.`);
 
@@ -1640,6 +1668,7 @@ const ScavengerCommands: ChatCommands = {
 	queuerated: 'queue',
 	queuerecycled: 'queue',
 	queue(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!getScavsRoom(room)) {
 			return this.errorReply("This command can only be used in the scavengers room.");
 		}
@@ -1702,6 +1731,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	dequeue(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!getScavsRoom(room)) {
 			return this.errorReply("This command can only be used in the scavengers room.");
 		}
@@ -1719,6 +1749,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	viewqueue(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!getScavsRoom(room)) {
 			return this.errorReply("This command can only be used in the scavengers room.");
 		}
@@ -1728,6 +1759,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	next(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!getScavsRoom(room)) {
 			return this.errorReply("This command can only be used in the scavengers room.");
 		}
@@ -1760,6 +1792,7 @@ const ScavengerCommands: ChatCommands = {
 
 	enablequeue: 'disablequeue',
 	disablequeue(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!getScavsRoom(room)) {
 			return this.errorReply("This command can only be used in the scavengers room.");
 		}
@@ -1781,6 +1814,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	defaulttimer(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!getScavsRoom(room)) {
 			return this.errorReply("This command can only be used in the scavengers room.");
 		}
@@ -1807,6 +1841,7 @@ const ScavengerCommands: ChatCommands = {
 	 * Leaderboard Commands
 	 */
 	addpoints(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'scavengers') return this.errorReply("This command can only be used in the scavengers room.");
 		if (!this.can('mute', null, room)) return false;
 
@@ -1824,6 +1859,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	removepoints(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'scavengers') return this.errorReply("This command can only be used in the scavengers room.");
 		if (!this.can('mute', null, room)) return false;
 
@@ -1841,6 +1877,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	resetladder(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'scavengers') return this.errorReply("This command can only be used in the scavengers room.");
 		if (!this.can('declare', null, room)) return false;
 
@@ -1851,6 +1888,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 	top: 'ladder',
 	async ladder(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!getScavsRoom(room)) {
 			return this.errorReply("This command can only be used in the scavengers room.");
 		}
@@ -1876,6 +1914,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	async rank(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!getScavsRoom(room)) {
 			return this.errorReply("This command can only be used in the scavengers room.");
 		}
@@ -1896,6 +1935,7 @@ const ScavengerCommands: ChatCommands = {
 	 * Leaderboard Point Distribution Editing
 	 */
 	setblitz(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const scavsRoom = getScavsRoom(room);
 		if (!scavsRoom) {
 			return this.errorReply("This command can only be used in the scavengers room.");
@@ -1938,6 +1978,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	sethostpoints(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const scavsRoom = getScavsRoom(room);
 		if (!scavsRoom) {
 			return this.errorReply("This command can only be used in the scavengers room.");
@@ -1967,6 +2008,7 @@ const ScavengerCommands: ChatCommands = {
 		}
 	},
 	setpoints(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const scavsRoom = getScavsRoom(room);
 		if (!scavsRoom) {
 			return this.errorReply("This command can only be used in the scavengers room.");
@@ -2014,6 +2056,7 @@ const ScavengerCommands: ChatCommands = {
 
 	resettwist: 'settwist',
 	settwist(target, room, user) {
+		if (!room) return this.requiresRoom();
 		const scavsRoom = getScavsRoom(room);
 		if (!scavsRoom) {
 			return this.errorReply("This command can only be used in the scavengers room.");
@@ -2057,6 +2100,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	twists(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!getScavsRoom(room)) {
 			return this.errorReply("This command can only be used in the scavengers room.");
 		}
@@ -2078,6 +2122,7 @@ const ScavengerCommands: ChatCommands = {
 	 */
 	huntcount: 'huntlogs',
 	async huntlogs(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'scavengers') return this.errorReply("This command can only be used in the scavengers room.");
 		if (!this.can('mute', null, room)) return false;
 
@@ -2119,6 +2164,7 @@ const ScavengerCommands: ChatCommands = {
 	},
 
 	async playlogs(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'scavengers') return this.errorReply("This command can only be used in the scavengers room.");
 		if (!this.can('mute', null, room)) return false;
 
@@ -2170,6 +2216,7 @@ const ScavengerCommands: ChatCommands = {
 
 	uninfract: "infract",
 	infract(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'scavengers') return this.errorReply("This command can only be used in the scavengers room.");
 		if (!this.can('mute', null, room)) return false;
 
@@ -2186,6 +2233,7 @@ const ScavengerCommands: ChatCommands = {
 	modsettings: {
 		'': 'update',
 		'update'(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('declare', null, room) || !getScavsRoom(room)) return false;
 			const settings = room.settings.scavSettings?.scavmod || {};
 
@@ -2195,6 +2243,7 @@ const ScavengerCommands: ChatCommands = {
 		},
 
 		'ipcheck'(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('declare', null, room) || !getScavsRoom(room)) return false;
 
 			if (!room.settings.scavSettings) room.settings.scavSettings = {};
@@ -2225,6 +2274,7 @@ const ScavengerCommands: ChatCommands = {
 	 * Database Commands
 	 */
 	recycledhunts(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!this.can('mute', null, room)) return false;
 		if (!getScavsRoom(room)) {
 			return this.errorReply("Scavenger Hunts can only be added to the database in the scavengers room.");

--- a/server/chat-plugins/tcgtabletop.ts
+++ b/server/chat-plugins/tcgtabletop.ts
@@ -46,6 +46,7 @@ export const commands: ChatCommands = {
 	ygo: 'yugioh',
 	yugioh(target, room, user) {
 		if (!this.canBroadcast()) return;
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'tcgtabletop') return this.errorReply("This command can only be used in the TCG & Tabletop room.");
 		const subdomain = 'yugioh';
 		const query = target.trim();

--- a/server/chat-plugins/thecafe.ts
+++ b/server/chat-plugins/thecafe.ts
@@ -106,6 +106,7 @@ function generateDish(): [string, string[]] {
 
 export const commands: ChatCommands = {
 	foodfight(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== thecafe.roomid) return this.errorReply("This command is only available in The Café.");
 
 		if (!Object.keys(dishes).length) return this.errorReply("No dishes found. Add some dishes first.");
@@ -133,6 +134,7 @@ export const commands: ChatCommands = {
 		return this.sendReplyBox(`<div class="ladder"><table style="text-align:center;"><tr><th colspan="7" style="font-size:10pt;">Your dish is: <u>${newDish}</u></th></tr><tr><th>Team</th>${team.map(mon => `<td><psicon pokemon="${mon}"/> ${mon}</td>`).join('')}</tr><tr><th>Ingredients</th>${newIngredients.map(ingredient => `<td>${ingredient}</td>`).join('')}</tr>${importStr}</table></div>`);
 	},
 	checkfoodfight(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== thecafe.roomid) return this.errorReply("This command is only available in The Café.");
 
 		const targetUser = this.targetUserOrSelf(target, false);
@@ -146,6 +148,7 @@ export const commands: ChatCommands = {
 	},
 	addingredients: 'adddish',
 	adddish(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== thecafe.roomid) return this.errorReply("This command is only available in The Café.");
 		if (!this.can('mute', null, room)) return false;
 
@@ -180,6 +183,7 @@ export const commands: ChatCommands = {
 		this.sendReply(`${cmd.slice(3)} '${dish}: ${ingredients.join(', ')}' added successfully.`);
 	},
 	removedish(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== thecafe.roomid) return this.errorReply("This command is only available in The Café.");
 		if (!this.can('mute', null, room)) return false;
 
@@ -192,6 +196,7 @@ export const commands: ChatCommands = {
 		this.sendReply(`Dish '${target}' deleted successfully.`);
 	},
 	viewdishes(target, room, user, connection) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== thecafe.roomid) return this.errorReply("This command is only available in The Café.");
 
 		return this.parse(`/join view-foodfight`);

--- a/server/chat-plugins/trivia.ts
+++ b/server/chat-plugins/trivia.ts
@@ -1063,6 +1063,7 @@ class TriumvirateModeTrivia extends Trivia {
 
 const commands: ChatCommands = {
 	new(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!isTriviaRoom(room)) return this.errorReply("This command can only be used in the Trivia room.");
 		if (!this.can('broadcast', null, room)) return false;
 		if (!this.canTalk()) return;
@@ -1129,6 +1130,7 @@ const commands: ChatCommands = {
 	newhelp: [`/trivia new [mode], [category], [length] - Begin a new trivia game. Requires: + % @ # &`],
 
 	join(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!isTriviaRoom(room)) return this.errorReply("This command can only be used in Trivia.");
 		const game = getTriviaGame(this);
 		if (!game) return;
@@ -1139,6 +1141,7 @@ const commands: ChatCommands = {
 	joinhelp: [`/trivia join - Join the current trivia game.`],
 
 	kick(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!isTriviaRoom(room)) return this.errorReply("This command can only be used in Trivia.");
 		if (!this.can('mute', null, room)) return false;
 		if (!this.canTalk()) return;
@@ -1155,6 +1158,7 @@ const commands: ChatCommands = {
 	kickhelp: [`/trivia kick [username] - Kick players from a trivia game by username. Requires: % @ # &`],
 
 	leave(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!isTriviaRoom(room)) return this.errorReply("This command can only be used in Trivia.");
 		const game = getTriviaGame(this);
 		if (!game) return;
@@ -1165,6 +1169,7 @@ const commands: ChatCommands = {
 	leavehelp: [`/trivia leave - Makes the player leave the game.`],
 
 	start(target, room) {
+		if (!room) return this.requiresRoom();
 		if (!isTriviaRoom(room)) return this.errorReply("This command can only be used in Trivia.");
 		if (!this.can('broadcast', null, room)) return false;
 		if (!this.canTalk()) return;
@@ -1177,6 +1182,7 @@ const commands: ChatCommands = {
 	starthelp: [`/trivia start - Ends the signup phase of a trivia game and begins the game. Requires: + % @ # &`],
 
 	answer(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!isTriviaRoom(room)) return this.errorReply("This command can only be used in Trivia.");
 		const game = getTriviaGame(this);
 		if (!game) return;
@@ -1195,6 +1201,7 @@ const commands: ChatCommands = {
 	answerhelp: [`/trivia answer OR /ta [answer] - Answer a pending question.`],
 
 	end(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!isTriviaRoom(room)) return this.errorReply("This command can only be used in Trivia.");
 		if (!this.can('broadcast', null, room)) return false;
 		if (!this.canTalk()) return;
@@ -1207,6 +1214,7 @@ const commands: ChatCommands = {
 	'': 'status',
 	players: 'status',
 	status(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!isTriviaRoom(room)) return this.errorReply("This command can only be used in Trivia.");
 		if (!this.runBroadcast()) return false;
 		const game = getTriviaGame(this);
@@ -1238,6 +1246,7 @@ const commands: ChatCommands = {
 
 	submit: 'add',
 	add(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'questionworkshop') return this.errorReply('This command can only be used in Question Workshop.');
 		if (cmd === 'add' && !this.can('mute', null, room)) return false;
 		if (cmd === 'submit' && !this.can('broadcast', null, room)) return false;
@@ -1314,6 +1323,7 @@ const commands: ChatCommands = {
 	addhelp: [`/trivia add [category] | [question] | [answer1], [answer2], ... [answern] - Adds question(s) to the question database. Requires: % @ # &`],
 
 	review(target, room) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'questionworkshop') return this.errorReply('This command can only be used in Question Workshop.');
 		if (!this.can('ban', null, room)) return false;
 
@@ -1339,6 +1349,7 @@ const commands: ChatCommands = {
 
 	reject: 'accept',
 	accept(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'questionworkshop') return this.errorReply('This command can only be used in Question Workshop.');
 		if (!this.can('ban', null, room)) return false;
 		if (!this.canTalk()) return;
@@ -1425,6 +1436,7 @@ const commands: ChatCommands = {
 	rejecthelp: [`/trivia reject [index1], [index2], ... [indexn] OR all - Remove questions from the submission database using their index numbers or ranges of them. Requires: @ # &`],
 
 	delete(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'questionworkshop') return this.errorReply('This command can only be used in Question Workshop.');
 		if (!this.can('mute', null, room)) return false;
 		if (!this.canTalk()) return;
@@ -1453,6 +1465,7 @@ const commands: ChatCommands = {
 	deletehelp: [`/trivia delete [question] - Delete a question from the trivia database. Requires: % @ # &`],
 
 	move(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'questionworkshop') {
 			return this.errorReply('This command can only be used in Question Workshop.');
 		}
@@ -1504,6 +1517,7 @@ const commands: ChatCommands = {
 	],
 
 	qs(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'questionworkshop') return this.errorReply('This command can only be used in Question Workshop.');
 
 		let buffer = "|raw|<div class=\"ladder\" style=\"overflow-y: scroll; max-height: 300px;\"><table>";
@@ -1564,6 +1578,7 @@ const commands: ChatCommands = {
 	],
 
 	search(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'questionworkshop') return this.errorReply("This command can only be used in Question Workshop.");
 		if (!this.can('broadcast', null, room)) return false;
 		if (!target.includes(',')) return this.errorReply("No valid search arguments entered.");
@@ -1597,6 +1612,7 @@ const commands: ChatCommands = {
 	searchhelp: [`/trivia search [type], [query] - Searches for questions based on their type and their query. Valid types: submissions, subs, questions, qs. Requires: + % @ * &`],
 
 	rank(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (!isTriviaRoom(room)) return this.errorReply("This command can only be used in Trivia.");
 
 		let name;
@@ -1629,6 +1645,7 @@ const commands: ChatCommands = {
 
 	alltimeladder: 'ladder',
 	ladder(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
 		if (!isTriviaRoom(room)) return this.errorReply('This command can only be used in Trivia.');
 		if (!this.runBroadcast()) return false;
 		const cache = cmd === 'ladder' ? cachedAltLadder : cachedLadder;
@@ -1659,6 +1676,7 @@ const commands: ChatCommands = {
 
 	clearquestions: 'clearqs',
 	clearqs(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'questionworkshop') return this.errorReply("This command can only be used in Question Workshop");
 		if (!this.can('declare', null, room)) return false;
 		const category = toID(target);
@@ -1678,6 +1696,7 @@ const commands: ChatCommands = {
 
 	pastgames: 'history',
 	history(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'trivia') return this.errorReply("This command can only be used in Trivia.");
 		if (!this.runBroadcast()) return false;
 		if (!triviaData.history?.length) return this.sendReplyBox("There is no game history.");

--- a/server/chat-plugins/uno.ts
+++ b/server/chat-plugins/uno.ts
@@ -632,6 +632,7 @@ export const commands: ChatCommands = {
 		// roomowner commands
 		off: 'disable',
 		disable(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('gamemanagement', null, room)) return;
 			if (room.settings.unoDisabled) {
 				return this.errorReply("UNO is already disabled in this room.");
@@ -643,6 +644,7 @@ export const commands: ChatCommands = {
 
 		on: 'enable',
 		enable(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('gamemanagement', null, room)) return;
 			if (!room.settings.unoDisabled) {
 				return this.errorReply("UNO is already enabled in this room.");
@@ -660,6 +662,7 @@ export const commands: ChatCommands = {
 		createprivate: 'create',
 		makeprivate: 'create',
 		create(target, room, user, connection, cmd) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('minigame', null, room)) return;
 			if (room.settings.unoDisabled) return this.errorReply("UNO is currently disabled for this room.");
 			if (room.game) return this.errorReply("There is already a game in progress in this room.");
@@ -675,6 +678,7 @@ export const commands: ChatCommands = {
 		},
 
 		start(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('minigame', null, room)) return;
 			const game = room.getGame(UnoGame);
 			if (!game || game.state !== 'signups') {
@@ -688,6 +692,7 @@ export const commands: ChatCommands = {
 
 		stop: 'end',
 		end(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('minigame', null, room)) return;
 			if (!room.game || room.game.gameid !== 'uno') return this.errorReply("There is no UNO game going on in this room.");
 			room.game.destroy();
@@ -697,6 +702,7 @@ export const commands: ChatCommands = {
 		},
 
 		timer(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('minigame', null, room)) return;
 			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room.");
@@ -713,6 +719,7 @@ export const commands: ChatCommands = {
 		},
 
 		autostart(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('minigame', null, room)) return;
 			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
@@ -736,6 +743,7 @@ export const commands: ChatCommands = {
 
 		dq: 'disqualify',
 		disqualify(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (!this.can('minigame', null, room)) return;
 			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
@@ -750,6 +758,7 @@ export const commands: ChatCommands = {
 		// player/user commands
 		j: 'join',
 		join(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			if (!this.canTalk()) return false;
@@ -760,6 +769,7 @@ export const commands: ChatCommands = {
 
 		l: 'leave',
 		leave(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			if (!game.leaveGame(user)) return this.errorReply("Unable to leave the game.");
@@ -767,6 +777,7 @@ export const commands: ChatCommands = {
 		},
 
 		play(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			const player: UnoGamePlayer | undefined = game.playerTable[user.id];
@@ -776,6 +787,7 @@ export const commands: ChatCommands = {
 		},
 
 		draw(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			const player: UnoGamePlayer | undefined = game.playerTable[user.id];
@@ -785,6 +797,7 @@ export const commands: ChatCommands = {
 		},
 
 		pass(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			if (game.currentPlayerid !== user.id) return this.errorReply("It is currently not your turn.");
@@ -798,6 +811,7 @@ export const commands: ChatCommands = {
 		},
 
 		color(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(UnoGame);
 			if (!game) return false;
 			const player: UnoGamePlayer | undefined = game.playerTable[user.id];
@@ -812,6 +826,7 @@ export const commands: ChatCommands = {
 		},
 
 		uno(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(UnoGame);
 			if (!game) return false;
 			const player: UnoGamePlayer | undefined = game.playerTable[user.id];
@@ -822,6 +837,7 @@ export const commands: ChatCommands = {
 		// information commands
 		'': 'hand',
 		hand(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(UnoGame);
 			if (!game) return this.parse("/help uno");
 			game.onSendHand(user);
@@ -831,6 +847,7 @@ export const commands: ChatCommands = {
 		users: 'getusers',
 		getplayers: 'getusers',
 		getusers(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			if (!this.runBroadcast()) return false;
@@ -843,6 +860,7 @@ export const commands: ChatCommands = {
 
 		// suppression commands
 		suppress(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 			if (!this.can('minigame', null, room)) return;
@@ -864,6 +882,7 @@ export const commands: ChatCommands = {
 		},
 
 		spectate(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 
@@ -875,6 +894,7 @@ export const commands: ChatCommands = {
 		},
 
 		unspectate(target, room, user) {
+			if (!room) return this.requiresRoom();
 			const game = room.getGame(UnoGame);
 			if (!game) return this.errorReply("There is no UNO game going on in this room right now.");
 

--- a/server/chat-plugins/wifi.ts
+++ b/server/chat-plugins/wifi.ts
@@ -622,6 +622,7 @@ const cmds: ChatCommands = {
 	quiz: 'question',
 	qg: 'question',
 	question(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'wifi' || !target) return false;
 		if (room.giveaway) return this.errorReply("There is already a giveaway going on!");
 
@@ -650,6 +651,7 @@ const cmds: ChatCommands = {
 	},
 	changeanswer: 'changequestion',
 	changequestion(target, room, user, conn, cmd) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'wifi') return false;
 		if (!room.giveaway) return this.errorReply("There is no giveaway going on at the moment.");
 		if (room.giveaway.type !== 'question') return this.errorReply("This is not a question giveaway.");
@@ -660,6 +662,7 @@ const cmds: ChatCommands = {
 	},
 	showanswer: 'viewanswer',
 	viewanswer(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'wifi') return false;
 		const giveaway = room.giveaway as QuestionGiveaway;
 		if (!giveaway) return this.errorReply("There is no giveaway going on at the moment.");
@@ -671,6 +674,7 @@ const cmds: ChatCommands = {
 	},
 	guessanswer: 'guess',
 	guess(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'wifi') return this.errorReply("This command can only be used in the Wi-Fi room.");
 		if (!this.canTalk()) return;
 		if (!room.giveaway) return this.errorReply("There is no giveaway going on at the moment.");
@@ -682,6 +686,7 @@ const cmds: ChatCommands = {
 	lg: 'lottery',
 	lotto: 'lottery',
 	lottery(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'wifi' || !target) return false;
 		if (room.giveaway) return this.errorReply("There is already a giveaway going on!");
 
@@ -720,6 +725,7 @@ const cmds: ChatCommands = {
 	joinlotto: 'join',
 	joinlottery: 'join',
 	join(target, room, user, conn, cmd) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'wifi') return this.errorReply("This command can only be used in the Wi-Fi room.");
 		if (!this.canTalk() || user.semilocked) return;
 		const giveaway = room.giveaway as LotteryGiveaway;
@@ -743,6 +749,7 @@ const cmds: ChatCommands = {
 	gts: {
 		new: 'start',
 		start(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (room.roomid !== 'wifi' || !target) return false;
 			if (room.gtsga) return this.errorReply("There is already a GTS giveaway going on!");
 
@@ -770,6 +777,7 @@ const cmds: ChatCommands = {
 			this.modlog('GTS GIVEAWAY', null, `for ${targetUser.getLastId()} with ${amount} Pokémon`);
 		},
 		left(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (room.roomid !== 'wifi') return false;
 			if (!room.gtsga) return this.errorReply("There is no GTS giveaway going on!");
 			if (!user.can('warn', null, room) && user !== room.gtsga.giver) {
@@ -791,6 +799,7 @@ const cmds: ChatCommands = {
 			room.gtsga.updateLeft(newamount);
 		},
 		sent(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (room.roomid !== 'wifi') return false;
 			if (!room.gtsga) return this.errorReply("There is no GTS giveaway going on!");
 			if (!user.can('warn', null, room) && user !== room.gtsga.giver) {
@@ -802,6 +811,7 @@ const cmds: ChatCommands = {
 			room.gtsga.updateSent(target);
 		},
 		full(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (room.roomid !== 'wifi') return false;
 			if (!room.gtsga) return this.errorReply("There is no GTS giveaway going on!");
 			if (!user.can('warn', null, room) && user !== room.gtsga.giver) {
@@ -812,6 +822,7 @@ const cmds: ChatCommands = {
 			room.gtsga.stopDeposits();
 		},
 		end(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (room.roomid !== 'wifi') return this.errorReply("This command can only be used in the Wi-Fi room.");
 			if (!room.gtsga) return this.errorReply("There is no GTS giveaway going on at the moment.");
 			if (!this.can('warn', null, room)) return false;
@@ -828,6 +839,7 @@ const cmds: ChatCommands = {
 	// general.
 	ban(target, room, user) {
 		if (!target) return false;
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'wifi') return this.errorReply("This command can only be used in the Wi-Fi room.");
 		if (!this.can('warn', null, room)) return false;
 
@@ -849,6 +861,7 @@ const cmds: ChatCommands = {
 	},
 	unban(target, room, user) {
 		if (!target) return false;
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'wifi') return this.errorReply("This command can only be used in the Wi-Fi room.");
 		if (!this.can('warn', null, room)) return false;
 
@@ -865,6 +878,7 @@ const cmds: ChatCommands = {
 	},
 	stop: 'end',
 	end(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'wifi') return this.errorReply("This command can only be used in the Wi-Fi room.");
 		if (!room.giveaway) return this.errorReply("There is no giveaway going on at the moment.");
 		if (!this.can('warn', null, room) && user.id !== room.giveaway.host.id) return false;
@@ -879,6 +893,7 @@ const cmds: ChatCommands = {
 	},
 	rm: 'remind',
 	remind(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'wifi') return this.errorReply("This command can only be used in the Wi-Fi room.");
 		const giveaway = room.giveaway;
 		if (!giveaway) return this.errorReply("There is no giveaway going on at the moment.");
@@ -891,6 +906,7 @@ const cmds: ChatCommands = {
 		}
 	},
 	count(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'wifi') return this.errorReply("This command can only be used in the Wi-Fi room.");
 		target = [...Giveaway.getSprite(target)[0]][0];
 		if (!target) return this.errorReply("No mon entered - /giveaway count pokemon.");
@@ -905,6 +921,7 @@ const cmds: ChatCommands = {
 	},
 	'': 'help',
 	help(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'wifi') return this.errorReply("This command can only be used in the Wi-Fi room.");
 
 		let reply = '';

--- a/server/chat-plugins/youtube.ts
+++ b/server/chat-plugins/youtube.ts
@@ -161,6 +161,7 @@ const YouTube = new YoutubeInterface();
 
 export const commands: ChatCommands = {
 	async randchannel(target, room, user) {
+		if (!room) return this.requiresRoom();
 		if (room.roomid !== 'youtube') return this.errorReply(`This command can only be used in the YouTube room.`);
 		if (!Config.youtubeKey) return this.errorReply(`Youtube is not configured.`);
 		if (Object.keys(channelData).length < 1) return this.errorReply(`No channels in the database.`);
@@ -180,6 +181,7 @@ export const commands: ChatCommands = {
 	yt: 'youtube',
 	youtube: {
 		async addchannel(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (room.roomid !== 'youtube') return this.errorReply(`This command can only be used in the YouTube room.`);
 			if (!Config.youtubeKey) return this.errorReply(`Youtube is not configured.`);
 			const [id, name] = target.split(',');
@@ -194,6 +196,7 @@ export const commands: ChatCommands = {
 		addchannelhelp: [`/addchannel - Add channel data to the YouTube database. Requires: % @ #`],
 
 		removechannel(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (room.roomid !== 'youtube') return this.errorReply(`This command can only be used in the YouTube room.`);
 			if (!Config.youtubeKey) return this.errorReply(`Youtube is not configured.`);
 			if (!this.can('mute', null, room)) return false;
@@ -207,6 +210,7 @@ export const commands: ChatCommands = {
 		removechannelhelp: [`/youtube removechannel - Delete channel data from the YouTube database. Requires: % @ #`],
 
 		async channel(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (room.roomid !== 'youtube') return this.errorReply(`This command can only be used in the YouTube room.`);
 			if (!Config.youtubeKey) return this.errorReply(`Youtube is not configured.`);
 			const channel = YouTube.channelSearch(target);
@@ -225,6 +229,7 @@ export const commands: ChatCommands = {
 			'/youtube channel - View the data of a specified channel. Can be either channel ID or channel name.',
 		],
 		async video(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (room.roomid !== 'youtube') return this.errorReply(`This command can only be used in the YouTube room.`);
 			if (!Config.youtubeKey) return this.errorReply(`Youtube is not configured.`);
 			if (!target) return this.errorReply(`Provide a valid youtube link.`);
@@ -251,6 +256,7 @@ export const commands: ChatCommands = {
 		},
 
 		update(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (room.roomid !== 'youtube') return this.errorReply(`This command can only be used in the YouTube room.`);
 			if (!this.can('mute', null, room)) return false;
 			const [channel, name] = target.split(',');
@@ -263,6 +269,7 @@ export const commands: ChatCommands = {
 		},
 		interval: 'repeat',
 		async repeat(target, room, user) {
+			if (!room) return this.requiresRoom();
 			if (room.roomid !== 'youtube') return this.errorReply(`This command can only be used in the YouTube room.`);
 			if (!Config.youtubeKey) return this.errorReply(`Youtube is not configured.`);
 			if (!this.can('declare', null, room)) return false;

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -374,7 +374,7 @@ export class CommandContext extends MessageContext {
 		} else {
 			if (commandHandler === '!') {
 				if (!this.room) {
-					return this.popupReply(`You tried use "${message}" as a global command, but it is not a global command.`);
+					return this.popupReply(`You tried to use "${message}" as a global command, but it is not a global command.`);
 				} else if (this.room) {
 					return this.popupReply(`You tried to send "${message}" to the room "${this.room.roomid}" but it failed because you were not in that room.`);
 				}

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -35,7 +35,7 @@ export interface PageTable {
 export type ChatHandler = (
 	this: CommandContext,
 	target: string,
-	room: Room,
+	room: Room | null,
 	user: User,
 	connection: Connection,
 	cmd: string,
@@ -1235,6 +1235,11 @@ export class CommandContext extends MessageContext {
 		this.inputUsername = name.trim();
 		this.targetUsername = this.targetUser ? this.targetUser.name : this.inputUsername;
 		return rest;
+	}
+
+	requiresRoom() {
+		this.errorReply(`You tried to use ${this.cmd} as a global command, but it is not one.`);
+		this.errorReply(`Use it in a room instead.`);
 	}
 }
 

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1238,8 +1238,7 @@ export class CommandContext extends MessageContext {
 	}
 
 	requiresRoom() {
-		this.errorReply(`You tried to use ${this.cmd} as a global command, but it is not one.`);
-		this.errorReply(`Use it in a room instead.`);
+		this.errorReply(`/${this.cmd} - must be used in a chat room, not a ${this.pmTarget ? "PM" : "console"}`);
 	}
 }
 

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -368,7 +368,11 @@ export class CommandContext extends MessageContext {
 		const commandHandler = this.splitCommand(message);
 
 		if (this.room && !(this.user.id in this.room.users)) {
-			return this.popupReply(`You tried to send "${message}" to the room "${this.room.roomid}" but it failed because you were not in that room.`);
+			if (this.room.roomid === 'lobby') {
+				this.room = null;
+			} else {
+				return this.popupReply(`You tried to send "${message}" to the room "${this.room.roomid}" but it failed because you were not in that room.`);
+			}
 		}
 
 		if (this.user.statusType === 'idle') this.user.setStatusType('online');

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -1568,6 +1568,7 @@ export const commands: ChatCommands = {
 	tours: 'tournament',
 	tournaments: 'tournament',
 	tournament(target, room, user, connection) {
+		if (!room) return this.requiresRoom();
 		let cmd;
 		[cmd, target] = Utils.splitFirst(target, ' ');
 		cmd = toID(cmd);


### PR DESCRIPTION
Per Zarel.
This either makes it so commands error if used without a room, or makes some commands (mostly administration commands like /emergency or global moderation commands like /lock) usable in pms, with the necessary changes made.