### PR TITLE
Add /nofeedback command

### DIFF
--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -484,9 +484,8 @@ export const commands: ChatCommands = {
 		user.resetName();
 	},
 
-	nfb: 'nofeedback',
 	nofeedback(target, room, user) {
-		if (!target?.startsWith('/')) return this.parse('/help nofeedback');
+		if (!target.startsWith('/')) return this.parse('/help nofeedback');
 		return this.parse(target, true);
 	},
 	nofeedbackhelp: [`/nofeedback [command] - Runs the command without displaying the response.`],

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -484,11 +484,11 @@ export const commands: ChatCommands = {
 		user.resetName();
 	},
 
-	nofeedback(target, room, user) {
-		if (!target.startsWith('/')) return this.parse('/help nofeedback');
+	noreply(target, room, user) {
+		if (!target.startsWith('/')) return this.parse('/help noreply');
 		return this.parse(target, true);
 	},
-	nofeedbackhelp: [`/nofeedback [command] - Runs the command without displaying the response.`],
+	noreplyhelp: [`/noreply [command] - Runs the command without displaying the response.`],
 
 	r: 'reply',
 	reply(target, room, user) {

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -484,6 +484,13 @@ export const commands: ChatCommands = {
 		user.resetName();
 	},
 
+	nfb: 'nofeedback',
+	nofeedback(target, room, user) {
+		if (!target?.startsWith('/')) return this.parse('/help nofeedback');
+		return this.parse(target, true);
+	},
+	nofeedbackhelp: [`/nofeedback [command] - Runs the command without displaying the response.`],
+
 	r: 'reply',
 	reply(target, room, user) {
 		if (!target) return this.parse('/help reply');

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -312,6 +312,7 @@ export class CommandContext extends MessageContext {
 	cmdToken: string;
 	target: string;
 	fullCmd: string;
+	isQuiet: boolean;
 	broadcasting: boolean;
 	broadcastToRoom: boolean;
 	broadcastMessage: string;
@@ -340,6 +341,7 @@ export class CommandContext extends MessageContext {
 		this.cmdToken = options.cmdToken || '';
 		this.target = options.target || ``;
 		this.fullCmd = options.fullCmd || '';
+		this.isQuiet = false;
 
 		// broadcast context
 		this.broadcasting = false;
@@ -352,10 +354,11 @@ export class CommandContext extends MessageContext {
 		this.inputUsername = "";
 	}
 
-	parse(msg?: string): any {
+	parse(msg?: string, quiet?: boolean): any {
 		if (typeof msg === 'string') {
 			// spawn subcontext
 			const subcontext = new CommandContext(this);
+			if (quiet) subcontext.isQuiet = true;
 			subcontext.recursionDepth++;
 			if (subcontext.recursionDepth > MAX_PARSE_RECURSION) {
 				throw new Error("Too much command recursion");
@@ -642,6 +645,7 @@ export class CommandContext extends MessageContext {
 		}).join(`\n`);
 	}
 	sendReply(data: string) {
+		if (this.isQuiet) return;
 		if (this.broadcasting && this.broadcastToRoom) {
 			// broadcasting
 			this.add(data);


### PR DESCRIPTION
Note that this only suppresses `sendReply()`, so something like `/nofeedback /hourmute SomeTroll` will still display the mute message in chat (which I think is important for transparency). However, this does mean that things like `/nofeedback /hideroom` will still display in chat for the opponent to see (note that `/nofeedback /ionext`, which seems to be the main use-case, is completely suppressed).