### PR TITLE
Allow custom formats (e.g. for tours) to modify format restrictions

### DIFF
--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -860,9 +860,8 @@ export const BattleFormats: {[k: string]: FormatsData} = {
 		name: 'Dynamax Ubers Clause',
 		desc: "Prevents Pok&eacute;mon on the Ubers dynamax banlist from dynamaxing",
 		onBegin() {
-			const cannotDynamax = this.format.restricted || [];
 			for (const pokemon of this.getAllPokemon()) {
-				if (cannotDynamax.includes(pokemon.species.name)) pokemon.canDynamax = false;
+				if (this.ruleTable.isRestricted('pokemon:' + pokemon.species.id)) pokemon.canDynamax = false;
 			}
 			this.add('html', 'Ubers Dynamax Clause: Pokémon on the <a href="https://www.smogon.com/dex/ss/formats/uber/">Ubers Dynamax Banlist</a> cannot Dynamax.');
 		},
@@ -917,9 +916,8 @@ export const BattleFormats: {[k: string]: FormatsData} = {
 		name: 'STABmons Move Legality',
 		desc: "Allows Pok&eacute;mon to use any move that they or a previous evolution/out-of-battle forme share a type with",
 		checkLearnset(move, species, setSources, set) {
-			const restrictedMoves = this.format.restricted || [];
 			const nonstandard = move.isNonstandard === 'Past' && !this.ruleTable.has('standardnatdex');
-			if (!restrictedMoves.includes(move.name) && !nonstandard && !move.isZ && !move.isMax) {
+			if (!nonstandard && !move.isZ && !move.isMax && !this.ruleTable.isRestricted('move:' + move.id)) {
 				const dex = this.dex;
 				let types: string[];
 				if (species.forme || species.otherFormes) {

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -182,6 +182,11 @@ export class RuleTable extends Map<string, string> {
 		return this.has(`-${thing}`);
 	}
 
+	isRestricted(thing: string) {
+		if (this.has(`+${thing}`)) return false;
+		return this.has(`*${thing}`);
+	}
+
 	check(thing: string, setHas: {[id: string]: true} | null = null) {
 		if (this.has(`+${thing}`)) return '';
 		if (setHas) setHas[thing] = true;
@@ -259,6 +264,8 @@ export class Format extends BasicEffect implements Readonly<BasicEffect & Format
 	readonly baseRuleset: string[];
 	/** List of banned effects. */
 	readonly banlist: string[];
+	/** List of effects that aren't completely banned. */
+	readonly restricted: string[];
 	/** List of inherited banned effects to override. */
 	readonly unbanlist: string[];
 	/** List of ruleset and banlist changes in a custom format. */
@@ -317,6 +324,7 @@ export class Format extends BasicEffect implements Readonly<BasicEffect & Format
 		this.ruleset = data.ruleset || [];
 		this.baseRuleset = data.baseRuleset || [];
 		this.banlist = data.banlist || [];
+		this.restricted = data.restricted || [];
 		this.unbanlist = data.unbanlist || [];
 		this.customRules = data.customRules || null;
 		this.ruleTable = null;

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -829,6 +829,9 @@ export class ModdedDex {
 		for (const ban of format.banlist) {
 			ruleset.push('-' + ban);
 		}
+		for (const ban of format.restricted) {
+			ruleset.push('*' + ban);
+		}
 		for (const ban of format.unbanlist) {
 			ruleset.push('+' + ban);
 		}
@@ -881,12 +884,11 @@ export class ModdedDex {
 				continue;
 			}
 
-			if ("+-".includes(ruleSpec.charAt(0))) {
-				if (ruleSpec.startsWith('+')) ruleTable.delete('-' + ruleSpec.slice(1));
-				if (ruleSpec.startsWith('-')) ruleTable.delete('+' + ruleSpec.slice(1));
+			if ("+*-".includes(ruleSpec.charAt(0))) {
 				if (ruleTable.has(ruleSpec)) {
 					throw new Error(`Rule "${rule}" was added by "${format.name}" but already exists in "${ruleTable.get(ruleSpec) || format.name}"`);
 				}
+				for (const prefix of "-*+") ruleTable.delete(prefix + ruleSpec.slice(1));
 				ruleTable.set(ruleSpec, '');
 				continue;
 			}
@@ -953,6 +955,7 @@ export class ModdedDex {
 	validateRule(rule: string, format: Format | null = null) {
 		switch (rule.charAt(0)) {
 		case '-':
+		case '*':
 		case '+':
 			if (format?.team) throw new Error(`We don't currently support bans in generated teams`);
 			if (rule.slice(1).includes('>') || rule.slice(1).includes('+')) {

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -1247,6 +1247,7 @@ interface Format extends Readonly<BasicEffect & FormatsData> {
 	readonly defaultLevel: number;
 	readonly maxLevel: number;
 	readonly noLog: boolean;
+	readonly restricted: string[];
 	readonly ruleset: string[];
 	readonly unbanlist: string[];
 	ruleTable: import('./dex-data').RuleTable | null;


### PR DESCRIPTION
This puts the restrictions in the rule table, thus allowing them to be inherited and modified, but also avoids having to guess where to find them in the code that implements them.

I just picked `*` because it's the next mathematical symbol after `+` and `-`...