### PR TITLE
Centralise the check for a restricted species

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -517,7 +517,7 @@ export const Formats: (FormatsData | {section: string, column?: number})[] = [
 			if (crossSpecies.battleOnly || crossIsUnreleased || !crossSpecies.prevo) {
 				return [`${species.name} cannot cross evolve into ${crossSpecies.name} because it isn't an evolution.`];
 			}
-			if (this.ruleTable.isRestricted(`pokemon:${crossSpecies.id}`) || this.ruleTable.isRestricted(`pokemon:${species.id}`)) {
+			if (this.ruleTable.isRestrictedSpecies(crossSpecies) || this.ruleTable.isRestrictedSpecies(species)) {
 				return [`${species.name} cannot cross evolve into ${crossSpecies.name} because it is banned.`];
 			}
 			const crossPrevoSpecies = this.dex.getSpecies(crossSpecies.prevo);
@@ -676,7 +676,7 @@ export const Formats: (FormatsData | {section: string, column?: number})[] = [
 				if (!item || !item.megaStone) continue;
 				const species = this.dex.getSpecies(set.species);
 				if (species.isNonstandard) return [`${species.baseSpecies} does not exist in gen 8.`];
-				if (this.ruleTable.isRestricted(`pokemon:${species.id}`) || this.ruleTable.isRestricted(`basepokemon:${species.id}`)) {
+				if (this.ruleTable.isRestrictedSpecies(species)) {
 					return [`${species.name} is not allowed to hold ${item.name}.`];
 				}
 				if (itemTable.has(item.id)) {

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -861,8 +861,7 @@ export const BattleFormats: {[k: string]: FormatsData} = {
 		desc: "Prevents Pok&eacute;mon on the Ubers dynamax banlist from dynamaxing",
 		onBegin() {
 			for (const pokemon of this.getAllPokemon()) {
-				if (this.ruleTable.isRestricted(`pokemon:${pokemon.species.id}`) ||
-					this.ruleTable.isRestricted(`basepokemon:${pokemon.species.id}`)) {
+				if (this.ruleTable.isRestrictedSpecies(pokemon.species)) {
 					pokemon.canDynamax = false;
 				}
 			}

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -187,6 +187,20 @@ export class RuleTable extends Map<string, string> {
 		return this.has(`*${thing}`);
 	}
 
+	isRestrictedSpecies(species: Species) {
+		if (this.has(`+pokemon:${species.id}`)) return false;
+		if (this.has(`*pokemon:${species.id}`)) return true;
+		if (this.has(`+basepokemon:${toID(species.baseSpecies)}`)) return false;
+		if (this.has(`*basepokemon:${toID(species.baseSpecies)}`)) return true;
+		const tier = species.tier === '(PU)' ? 'ZU' : species.tier === '(NU)' ? 'PU' : species.tier;
+		if (this.has(`+pokemontag:${toID(tier)}`)) return false;
+		if (this.has(`*pokemontag:${toID(tier)}`)) return true;
+		const doublesTier = species.doublesTier === '(DUU)' ? 'DNU' : species.doublesTier;
+		if (this.has(`+pokemontag:${toID(doublesTier)}`)) return false;
+		if (this.has(`*pokemontag:${toID(doublesTier)}`)) return true;
+		return this.has(`*pokemontag:allpokemon`);
+	}
+
 	check(thing: string, setHas: {[id: string]: true} | null = null) {
 		if (this.has(`+${thing}`)) return '';
 		if (setHas) setHas[thing] = true;


### PR DESCRIPTION
I put all the tier stuff in there too, just in case someone wants to be able to restrict a tier (using Mix and Mega as an example, it would be able to set restricted: Uber, Gengar, Zeraora; unbanlist: Darmanitan, Dracovish, Lunala, Zamazenta).