### PR TITLE
Porygon doesn't learn Defense Curl in Gen 2

### DIFF
--- a/data/mods/gen2/learnsets.ts
+++ b/data/mods/gen2/learnsets.ts
@@ -7649,7 +7649,6 @@ export const BattleLearnsets: {[k: string]: ModdedLearnsetData} = {
 			blizzard: ["2M", "1M"],
 			conversion: ["2L1", "2S0", "1L1"],
 			curse: ["2M"],
-			defensecurl: ["2M", "2L24"],
 			doubleedge: ["1M"],
 			doubleteam: ["2M", "1M"],
 			dreameater: ["2M"],


### PR DESCRIPTION
Fixes #6975; should only be merged if that issue is accurate.