### PR TITLE
Datasearch: Support /ds monotype without a type

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -142,7 +142,7 @@ export const commands: ChatCommands = {
 			`You can search for info in a specific generation by appending the generation to ds; e.g. <code>/ds1 normal</code> searches for all Pok\u00e9mon that were Normal type in Generation I.<br/>` +
 			`<code>/dexsearch</code> will search the Galar Pokedex; you can search the National Pokedex by using <code>/nds</code> or by adding <code>natdex</code> as a parameter.<br/>` +
 			`Searching for a Pok\u00e9mon with both egg group and type parameters can be differentiated by adding the suffix <code>group</code> onto the egg group parameter; e.g., seaching for <code>grass, grass group</code> will show all Grass types in the Grass egg group.<br/>` +
-			`The parameter <code>monotype</code> will only show Pok\u00e9mon that are not dual-typed.<br/>` +
+			`The parameter <code>monotype</code> will only show Pok\u00e9mon that are single-typed.<br/>` +
 			`The order of the parameters does not matter.<br/>`
 		);
 	},
@@ -823,18 +823,13 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		}
 	}
 	if (
-		showAll && searches.length === 0 && !maxGen &&
+		showAll && searches.length === 0 && !maxGen && !singleTypeSearch &&
 		megaSearch === null && gmaxSearch === null && fullyEvolvedSearch === null
 	) {
 		return {
 			error: "No search parameters other than 'all' were found. Try '/help dexsearch' for more information on this command.",
 		};
 	}
-
-	if (singleTypeSearch && Object.values(searches)
-		.map(search => Object.keys(search.types).filter(type => search.types[type])[0])
-		.filter(type => type).length !== 1
-	) return {error: "A monotype search must include only one type."};
 
 	if (!maxGen) maxGen = 8;
 	const mod = Dex.mod('gen' + maxGen);
@@ -939,10 +934,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			}
 
 			for (const type in alts.types) {
-				if (
-					(!singleTypeSearch || Object.keys(dex[mon].types).length === 1) &&
-					dex[mon].types.includes(type) === alts.types[type]
-				) {
+				if (dex[mon].types.includes(type) === alts.types[type]) {
 					matched = true;
 					break;
 				}
@@ -1043,6 +1035,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 	}
 	let results: string[] = [];
 	for (const mon of Object.keys(dex).sort()) {
+		if (singleTypeSearch && Object.keys(dex[mon].types).length !== 1) continue;
 		const isAlola = dex[mon].forme === "Alola" && dex[mon].name !== "Pikachu-Alola";
 		const allowGmax = (gmaxSearch || tierSearch);
 		if (!isAlola && dex[mon].baseSpecies && results.includes(dex[mon].baseSpecies)) continue;


### PR DESCRIPTION
When I originally coded this, I assumed no one wanted to see all monotype Pokémon, but apparently that's a useful thing so I changed the implementation to permit it.