### PR TITLE
Linked: Fix priority of linked moves

### DIFF
--- a/data/mods/linked/scripts.ts
+++ b/data/mods/linked/scripts.ts
@@ -394,7 +394,8 @@ export const BattleScripts: ModdedBattleScriptsData = {
 
 		if (this.gen < 5) this.eachEvent('Update');
 
-		if (this.gen >= 8 && this.queue.peek()?.choice === 'move') {
+		const nextAction = this.queue.peek();
+		if (this.gen >= 8 && nextAction?.choice === 'move' && nextAction?.pokemon !== action.pokemon) {
 			// In gen 8, speed is updated dynamically so update the queue's speed properties and sort it.
 			this.updateSpeed();
 			for (const queueAction of this.queue) {


### PR DESCRIPTION
Second move in a chain ignores Gen 8 dynamic turn-order mechanic.