### PR TITLE
Set global bot permissions in groupchats to bot

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -560,6 +560,7 @@ exports.grouplist = [
 		name: "Bot",
 		inherit: '%',
 		jurisdiction: 'u',
+		globalGroupInPersonalRoom: '*',
 
 		addhtml: true,
 		declare: true,


### PR DESCRIPTION
Currently, because global bots inherit from %, their groupchat jurisdiction is actually lowered to @, denying them the (valuable) addhtml permission