### PR TITLE
Add |t:| to support real-time replays

### DIFF
--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -153,6 +153,11 @@ The beginning of a battle will look something like this:
 
 > The battle has ended in a tie.
 
+`|t:|TIMESTAMP`
+
+> The current UNIX timestamp (the number of seconds since 1970) - useful for determining
+> when events occured in real time.
+
 ### Identifying Pokémon
 
 Pokémon will be identified by a Pokémon ID (generally labeled `POKEMON` in

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -141,6 +141,9 @@ export class Battle {
 	clampIntRange: (num: any, min?: number, max?: number) => number;
 
 	constructor(options: BattleOptions) {
+		this.log = [];
+		this.add('t:', Math.floor(Date.now() / 1000));
+
 		const format = options.format || Dex.getFormat(options.formatid, true);
 		this.format = format;
 		this.dex = Dex.forFormat(format);
@@ -174,7 +177,6 @@ export class Battle {
 		this.queue = new BattleQueue(this);
 		this.faintQueue = [];
 
-		this.log = [];
 		this.inputLog = [];
 		this.messageLog = [];
 		this.sentLogPos = 0;
@@ -2701,6 +2703,7 @@ export class Battle {
 
 	go() {
 		this.add('');
+		this.add('t:', Math.floor(Date.now() / 1000));
 		if (this.requestState) this.requestState = '';
 
 		if (!this.midTurn) {


### PR DESCRIPTION
https://www.smogon.com/forums/threads/real-time-replay-speed.3666710/

```
|t:|1594612966
|player|p1|Bot 1||
|player|p2|Bot 2||
|teamsize|p1|6
|teamsize|p2|6
|gametype|singles
|gen|4
|tier|[Gen 4] Random Battle
|rule|Sleep Clause Mod: Limit one foe put to sleep
|rule|HP Percentage Mod: HP is shown in percentages
|
|t:|1594612966
|start
|switch|p1a: Ariados|Ariados, L83, M|251/251
|switch|p2a: Sharpedo|Sharpedo, L83, M|252/252
|turn|1
|
|t:|1594612966
|move|p2a: Sharpedo|Hidden Power|p1a: Ariados
|-resisted|p1a: Ariados
|-damage|p1a: Ariados|236/251
|move|p1a: Ariados|Poison Jab|p2a: Sharpedo
|-damage|p2a: Sharpedo|116/252
|-damage|p1a: Ariados|221/251|[from] ability: Rough Skin|[of] p2a: Sharpedo
|
|upkeep
|turn|2
|
|t:|1594612966
|switch|p2a: Mismagius|Mismagius, L79, F|224/224
|move|p1a: Ariados|Toxic Spikes|p2a: Mismagius
|-sidestart|p2: Bot 2|move: Toxic Spikes
|
|upkeep
|turn|3
|
|t:|1594612966
|move|p2a: Mismagius|Pain Split|p1a: Ariados
|-sethp|p1a: Ariados|222/251|[from] move: Pain Split|[silent]
|-sethp|p2a: Mismagius|222/224|[from] move: Pain Split
|move|p1a: Ariados|Bug Bite|p2a: Mismagius
|-resisted|p2a: Mismagius
|-damage|p2a: Mismagius|180/224
```

- not positive `go` is the correct place
- was originally going with just timestamp *offsets* (store the battle start time in the constructor, report only on the diff each time) but this kind of conflicts with how timestamp is reported with `|c:|`/`|:|`, so for consistently this reports the entire timestamp
- the replay viewer obviously requires changes to be able to support this
- i dont know how the client will behave with the new protocol - does it ignore unknown messages by default already?