### PR TITLE
Copycat and Encore should fail against a Z move

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2688,7 +2688,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 			let move: Move | ActiveMove | null = this.lastMove;
 			if (!move) return;
 
-			if ((move as ActiveMove).isZOrMaxPowered) move = this.dex.getMove(move.baseMove);
+			if (move.isMax && move.baseMove) move = this.dex.getMove(move.baseMove);
 			if (noCopycat.includes(move.id) || move.isZ || move.isMax) {
 				return false;
 			}
@@ -4547,7 +4547,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 				let move: Move | ActiveMove | null = target.lastMove;
 				if (!move || target.volatiles['dynamax']) return false;
 
-				if ((move as ActiveMove).isZOrMaxPowered) move = this.dex.getMove(move.baseMove);
+				if (move.isMax && move.baseMove) move = this.dex.getMove(move.baseMove);
 				const moveIndex = target.moves.indexOf(move.id);
 				if (move.isZ || noEncore.includes(move.id) || !target.moveSlots[moveIndex] || target.moveSlots[moveIndex].pp <= 0) {
 					// it failed


### PR DESCRIPTION
PR #6652 accidentally changed the logic for Copycat and Encore which previously only special-cased Max Moves (the previous condition was just `move.maxPowered`). In order to appease TypeScript I just check `move.baseMove` direcfly, however I still need to check `move.isMax` because of a hack SSB needs for Snaquaza's Z-move, and someone might try to Encore it, which would be bad.