### PR TITLE
Added another example of client implementation

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -13,6 +13,8 @@ Showdown directly using WebSocket:
 
 Client implementations you might want to look at for reference include:
 
+- Majeur's android client (Kotlin/Java) -
+    https://github.com/MajeurAndroid/Android-Unofficial-Showdown-Client
 - pickdenis' chat bot (Ruby) -
     https://github.com/pickdenis/ps-chatbot
 - Quinella and TalkTakesTime's chat bot (Node.js) -


### PR DESCRIPTION
Added Android-Unofficial-Showdown-Client as an example of ps client implementation. This might help people to understand Pokémon Showdown's protocol easily.