### PR TITLE
Support throttling /requestshow

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2440,6 +2440,12 @@ export const commands: ChatCommands = {
 		if (!/^https?:\/\//.test(link)) link = `https://${link}`;
 		link = encodeURI(link);
 		if (!room.pendingApprovals) room.pendingApprovals = new Map();
+		if (!room.settings.showThrottle) room.settings.showThrottle = 0;
+		if (!room.lastShowRequest) room.lastShowRequest = {};
+		if (room.lastShowRequest[user.id] && Date.now() - room.lastShowRequest[user.id] <= room.settings.showThrottle) {
+			return this.errorReply(`Your request was not submitted because you've been sending them too quickly.`);
+		}
+		room.lastShowRequest[user.id] = Date.now();
 		room.pendingApprovals.set(user.id, {
 			name: user.name,
 			link: link,

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -567,6 +567,36 @@ export const commands: ChatCommands = {
 			);
 		}
 	},
+	showthrottle(target, room, user, connection, cmd) {
+		if (!room) return this.requiresRoom();
+		if (!room.settings.requestShowEnabled) return this.errorReply("/requestshow is not enabled.");
+		if (!target) {
+			return this.sendReplyBox(
+				`The /requestshow throttle is currently set to ` +
+				`${room.settings.showThrottle ? Chat.toDurationString(room.settings.showThrottle) : 'OFF'}.`
+			);
+		}
+		const parsed = parseInt(target);
+		if (!this.can('declare', null, room)) return false;
+		if (this.meansNo(target)) {
+			room.settings.showThrottle = undefined;
+		} else if (isNaN(parsed)) {
+			return this.errorReply("Invalid number.");
+		} else {
+			room.settings.showThrottle = parsed * 60 * 1000;
+		}
+		room.saveSettings();
+		this.modlog(`SHOWTHROTTLE`, null, `to ${Chat.toDurationString(parsed)}`);
+		this.privateModAction(
+			`(${user.name} ${room.settings.showThrottle ?
+				`set the /requestshow throttle to ${Chat.toDurationString(room.settings.showThrottle)}` :
+				`disabled the show throttle.`})`
+		);
+	},
+	showthrottlehelp: [
+		`/showthrottle [number in minutes] - sets the room's /requestshow throttle to [minutes].`,
+		`Requires: # &`,
+	],
 
 	hightraffic(target, room, user) {
 		if (!room) return this.requiresRoom();

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -103,6 +103,7 @@ export interface RoomSettings {
 	dataCommandTierDisplay?: 'tiers' | 'doubles tiers' | 'numbers';
 	requestShowEnabled?: boolean | null;
 	showEnabled?: GroupSymbol | true;
+	showThrottle?: number;
 
 	scavSettings?: AnyObject;
 	scavQueue?: QueuedHunt[];
@@ -184,6 +185,7 @@ export abstract class BasicRoom {
 	expireTimer: NodeJS.Timer | null;
 	userList: string;
 	pendingApprovals: Map<string, {name: string, link: string, comment: string}> | null;
+	lastShowRequest: {[k: string]: number} | null;
 
 	constructor(roomid: RoomID, title?: string, options: Partial<RoomSettings> = {}) {
 		this.users = Object.create(null);
@@ -274,6 +276,7 @@ export abstract class BasicRoom {
 			this.userList = this.getUserList();
 		}
 		this.pendingApprovals = null;
+		this.lastShowRequest = null;
 		this.tour = null;
 		this.game = null;
 		this.battle = null;


### PR DESCRIPTION
This was requested by the staff of Arts & Culture, since apparently people often /requestshow too much.