### PR TITLE
Support renaming battles

### DIFF
--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -878,8 +878,16 @@ export class RoomBattle extends RoomGames.RoomGame {
 		const logfolder = logsubfolder.split('-', 2).join('-');
 		const tier = this.room.format.toLowerCase().replace(/[^a-z0-9]+/g, '');
 		const logpath = `logs/${logfolder}/${tier}/${logsubfolder}/`;
+
+		let logID = this.roomid;
+		if (logID.endsWith('pw')) {
+			const split = logID.split('-');
+			split.pop();
+			logID = split.join('-') as RoomID;
+		}
+
 		await FS(logpath).mkdirp();
-		await FS(logpath + this.room.roomid + '.log.json').write(JSON.stringify(logData));
+		await FS(`${logpath}${logID}.log.json`).write(JSON.stringify(logData));
 		// console.log(JSON.stringify(logData));
 	}
 	onConnect(user: User, connection: Connection | null = null) {

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -879,15 +879,8 @@ export class RoomBattle extends RoomGames.RoomGame {
 		const tier = this.room.format.toLowerCase().replace(/[^a-z0-9]+/g, '');
 		const logpath = `logs/${logfolder}/${tier}/${logsubfolder}/`;
 
-		let logID = this.roomid;
-		if (logID.endsWith('pw')) {
-			const split = logID.split('-');
-			split.pop();
-			logID = split.join('-') as RoomID;
-		}
-
 		await FS(logpath).mkdirp();
-		await FS(`${logpath}${logID}.log.json`).write(JSON.stringify(logData));
+		await FS(`${logpath}${this.room.getReplayData().id}.log.json`).write(JSON.stringify(logData));
 		// console.log(JSON.stringify(logData));
 	}
 	onConnect(user: User, connection: Connection | null = null) {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -684,7 +684,7 @@ export abstract class BasicRoom {
 		if (oldID === 'lobby') {
 			Rooms.lobby = null;
 		} else if (newID === 'lobby') {
-			Rooms.lobby = this as ChatRoom;
+			Rooms.lobby = this;
 		}
 
 		if (keepAliases) {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -673,8 +673,9 @@ export abstract class BasicRoom {
 	 */
 	async rename(newTitle: string, newID?: RoomID, keepAliases = true) {
 		if (!newID) newID = toID(newTitle) as RoomID;
-		if ((this.type === 'chat' && this.game) || this.tour) return;
-
+		if (this.type === 'chat' && this.game) {
+			throw new Chat.ErrorMessage(`Please finish your game (${this.game.title}) before renaming ${this.roomid}.`);
+		}
 		const oldID = this.roomid;
 		this.roomid = newID;
 		this.title = newTitle;

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -706,8 +706,16 @@ export abstract class BasicRoom {
 			if (!this.settings.aliases) this.settings.aliases = [];
 			// resolve an old (fixed) bug in /renameroom
 			if (!this.settings.aliases.includes(oldID)) this.settings.aliases.push(oldID);
-			this.saveSettings();
+		} else {
+			// clear aliases
+			for (const [alias, roomid] of Rooms.aliases.entries()) {
+				if (roomid === oldID) {
+					Rooms.aliases.delete(alias);
+				}
+			}
+			this.settings.aliases = undefined;
 		}
+		this.saveSettings();
 
 		for (const user of Object.values(this.users)) {
 			user.moveConnections(oldID, newID);

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -684,7 +684,7 @@ export abstract class BasicRoom {
 		if (oldID === 'lobby') {
 			Rooms.lobby = null;
 		} else if (newID === 'lobby') {
-			Rooms.lobby = this as ChatRoom; // lobby shouldn't be a GameRoom
+			Rooms.lobby = this as ChatRoom;
 		}
 
 		if (keepAliases) {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -673,7 +673,7 @@ export abstract class BasicRoom {
 	 */
 	async rename(newTitle: string, newID?: RoomID, moveLogs = true, keepAliases = true) {
 		if (!newID) newID = toID(newTitle) as RoomID;
-		if ((this.type === 'battle' && moveLogs) || (this.type === 'chat' && this.game) || this.tour) return;
+		if ((this.type === 'chat' && this.game) || this.tour) return;
 
 		const oldID = this.roomid;
 		this.roomid = newID;

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -679,7 +679,7 @@ export abstract class BasicRoom {
 		this.roomid = newID;
 		this.title = newTitle;
 		Rooms.rooms.delete(oldID);
-		Rooms.rooms.set(newID, (this.game ? this as unknown as GameRoom : this as ChatRoom));
+		Rooms.rooms.set(newID, this as Room);
 
 		if (oldID === 'lobby') {
 			Rooms.lobby = null;

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -675,10 +675,9 @@ export abstract class BasicRoom {
 
 	/**
 	 * @param newID Add this param if the roomid is different from `toID(newTitle)`
-	 * @param moveLogs Whether or not to rename the log file. Defaults to true.
-	 * @param keepAliases Whether or not to point the room's aliases and name to its new name. Defaults to true.
+	 * @param noAlias Set this param to true to not redirect aliases and the room's old name to its new name.
 	 */
-	async rename(newTitle: string, newID?: RoomID, keepAliases = true) {
+	async rename(newTitle: string, newID?: RoomID, noAlias?: boolean) {
 		if (!newID) newID = toID(newTitle) as RoomID;
 		if (this.type === 'chat' && this.game) {
 			throw new Chat.ErrorMessage(`Please finish your game (${this.game.title}) before renaming ${this.roomid}.`);
@@ -695,7 +694,7 @@ export abstract class BasicRoom {
 			Rooms.lobby = this as ChatRoom;
 		}
 
-		if (keepAliases) {
+		if (!noAlias) {
 			for (const [alias, roomid] of Rooms.aliases.entries()) {
 				if (roomid === oldID) {
 					Rooms.aliases.set(alias, newID);

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -666,6 +666,13 @@ export abstract class BasicRoom {
 		);
 	}
 
+	getReplayData() {
+		if (!this.roomid.endsWith('pw')) return {id: this.roomid.slice(7)};
+		const end = this.roomid.length - 2;
+		const lastHyphen = this.roomid.lastIndexOf('-', end);
+		return {id: this.roomid.slice(7, lastHyphen), password: this.roomid.slice(lastHyphen, end)};
+	}
+
 	/**
 	 * @param newID Add this param if the roomid is different from `toID(newTitle)`
 	 * @param moveLogs Whether or not to rename the log file. Defaults to true.

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -673,7 +673,7 @@ export abstract class BasicRoom {
 	 */
 	async rename(newTitle: string, newID?: RoomID, moveLogs = true, keepAliases = true) {
 		if (!newID) newID = toID(newTitle) as RoomID;
-		if ((this.game && moveLogs) || this.tour) return;
+		if ((this.type === 'battle' && moveLogs) || (this.type === 'chat' && this.game) || this.tour) return;
 
 		const oldID = this.roomid;
 		this.roomid = newID;

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -696,12 +696,10 @@ export abstract class BasicRoom {
 
 			// add an alias from the old id
 			Rooms.aliases.set(oldID, newID);
-			if (this.settings) {
-				if (!this.settings.aliases) this.settings.aliases = [];
-				// resolve an old (fixed) bug in /renameroom
-				if (!this.settings.aliases.includes(oldID)) this.settings.aliases.push(oldID);
-				this.saveSettings();
-			}
+			if (!this.settings.aliases) this.settings.aliases = [];
+			// resolve an old (fixed) bug in /renameroom
+			if (!this.settings.aliases.includes(oldID)) this.settings.aliases.push(oldID);
+			this.saveSettings();
 		}
 
 		for (const user of Object.values(this.users)) {
@@ -720,10 +718,8 @@ export abstract class BasicRoom {
 			}
 		}
 
-		if (this.settings) {
-			this.settings.title = newTitle;
-			this.saveSettings();
-		}
+		this.settings.title = newTitle;
+		this.saveSettings();
 
 		return (moveLogs ? this.log.rename(newID) : true);
 	}

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -671,7 +671,7 @@ export abstract class BasicRoom {
 	 * @param moveLogs Whether or not to rename the log file. Defaults to true.
 	 * @param keepAliases Whether or not to point the room's aliases and name to its new name. Defaults to true.
 	 */
-	async rename(newTitle: string, newID?: RoomID, moveLogs = true, keepAliases = true) {
+	async rename(newTitle: string, newID?: RoomID, keepAliases = true) {
 		if (!newID) newID = toID(newTitle) as RoomID;
 		if ((this.type === 'chat' && this.game) || this.tour) return;
 
@@ -684,7 +684,7 @@ export abstract class BasicRoom {
 		if (oldID === 'lobby') {
 			Rooms.lobby = null;
 		} else if (newID === 'lobby') {
-			Rooms.lobby = this;
+			Rooms.lobby = this as ChatRoom;
 		}
 
 		if (keepAliases) {
@@ -721,7 +721,7 @@ export abstract class BasicRoom {
 		this.settings.title = newTitle;
 		this.saveSettings();
 
-		return (moveLogs ? this.log.rename(newID) : true);
+		return this.log.rename(newID);
 	}
 
 	onConnect(user: User, connection: Connection) {

--- a/server/users.ts
+++ b/server/users.ts
@@ -1283,6 +1283,20 @@ export class User extends Chat.MessageContext {
 		Ladders.updateSearch(this, connection);
 	}
 	/**
+	 * Moves the user's connections in a given room to another room.
+	 * This function's main use case is for when a room is renamed.
+	 */
+	moveConnections(oldRoomID: RoomID, newRoomID: RoomID) {
+		this.inRooms.delete(oldRoomID);
+		this.inRooms.add(newRoomID);
+		for (const connection of this.connections) {
+			connection.inRooms.delete(oldRoomID);
+			connection.inRooms.add(newRoomID);
+			Sockets.roomRemove(connection.worker, oldRoomID, connection.socketid);
+			Sockets.roomAdd(connection.worker, newRoomID, connection.socketid);
+		}
+	}
+	/**
 	 * The user says message in room.
 	 * Returns false if the rest of the user's messages should be discarded.
 	 */


### PR DESCRIPTION
This will pave the way for @scheibo's code in #6950 to be implemented.
If you want to actually _use_ `renameBattle()`, smogon/pokemon-showdown-client#1559 will need to be merged (otherwise the client is unable to display chat messages in a renamed battle until you reload it).