### PR TITLE
Support Chat.ErrorMessage in async functions

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -568,6 +568,14 @@ export class CommandContext extends MessageContext {
 		let result;
 		try {
 			result = commandHandler.call(this, this.target, this.room, this.user, this.connection, this.cmd, this.message);
+			if (result.then) {
+				result = result.catch((err: Error) => {
+					if (err.name?.endsWith('ErrorMessage')) {
+						this.errorReply(err.message);
+						return false;
+					}
+				});
+			}
 		} catch (err) {
 			if (err.name?.endsWith('ErrorMessage')) {
 				this.errorReply(err.message);


### PR DESCRIPTION
Currently, it just crashes as a normal crash might, even though that's not the intent.
edit: will draft for now, i noticed an error that i'll fix asap, missed it because I tested this wrong.