### PR TITLE
Fix bug in destroyPersonalRooms()

### DIFF
--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1434,7 +1434,7 @@ export class GlobalRoomState {
 	destroyPersonalRooms(userid: ID) {
 		const roomauth = [];
 		for (const [id, curRoom] of Rooms.rooms) {
-			if (id === 'global' || !curRoom.persist) continue;
+			if (id === 'global') continue;
 			if (curRoom.settings.isPersonal && curRoom.auth.get(userid) === Users.HOST_SYMBOL) {
 				curRoom.destroy();
 			} else {


### PR DESCRIPTION
This will actually destroy groupchats when a user is locked/globally banned, which to my understanding is the intended behavior.
`continue`ing when a room isn't persistent makes no sense, since groupchats are by definition not persistent.