### PR TITLE
Add cooldown for unregistered namechanges

### DIFF
--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -592,11 +592,8 @@ export abstract class BasicRoom {
 		this.destroy();
 	}
 	reportJoin(type: 'j' | 'l' | 'n', entry: string, user: User) {
-		let reportJoins = this.reportJoins;
-		if (reportJoins && this.settings.modchat && !user.authAtLeast(this.settings.modchat, this)) {
-			reportJoins = false;
-		}
-		if (reportJoins) {
+		const canTalk = user.authAtLeast(this.settings.modchat ?? 'unlocked', this) && !this.isMuted(user);
+		if (this.reportJoins && canTalk) {
 			this.add(`|${type}|${entry}`).update();
 			return;
 		}

--- a/server/users.ts
+++ b/server/users.ts
@@ -720,7 +720,7 @@ export class User extends Chat.MessageContext {
 			if (elapsed < NAMECHANGE_THROTTLE) {
 				if (this.newNames >= NAMES_PER_THROTTLE) {
 					this.send(
-						`|nametaken|${name}|You must wait ${Math.round((NAMECHANGE_THROTTLE - elapsed) / 1000)} more
+						`|nametaken|${name}|You must wait ${Chat.toDurationString(NAMECHANGE_THROTTLE - elapsed)} more
 						seconds before using another unregistered name.`
 					);
 					return false;


### PR DESCRIPTION
If it would be more useful with a different cooldown length (I just grabbed 2 minutes off the top of my head) or enforcing a cooldown on namechanges to registered alts as well, I'm happy to change it.