### PR TITLE
Remove "Battle" prefix from data exports

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -32,7 +32,7 @@ Ratings and how they work:
 
 */
 
-export const BattleAbilities: {[abilityid: string]: AbilityData} = {
+export const Abilities: {[abilityid: string]: AbilityData} = {
 	noability: {
 		shortDesc: "Does nothing.",
 		isNonstandard: "Past",

--- a/data/aliases.ts
+++ b/data/aliases.ts
@@ -1,4 +1,4 @@
-export const BattleAliases: {[alias: string]: string} = {
+export const Aliases: {[alias: string]: string} = {
 	// formats
 	randbats: "[Gen 8] Random Battle",
 	uber: "[Gen 8] Ubers",

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -1,4 +1,4 @@
-export const Statuses: {[k: string]: PureEffectData} = {
+export const Conditions: {[k: string]: PureEffectData} = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',

--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: SpeciesFormatsData} = {
+export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/items.ts
+++ b/data/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[itemid: string]: ItemData} = {
+export const Items: {[itemid: string]: ItemData} = {
 	abomasite: {
 		name: "Abomasite",
 		spritenum: 575,

--- a/data/learnsets.ts
+++ b/data/learnsets.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 
-export const BattleLearnsets: {[speciesid: string]: LearnsetData} = {
+export const Learnsets: {[speciesid: string]: LearnsetData} = {
 	missingno: {
 		learnset: {
 			blizzard: ["3L1"],

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -1,14 +1,14 @@
 /**
- * Statuses worked way different.
- * Sleep lasted longer, had no reset on switch and took a whole turn to wake up.
- * Frozen only thaws when hit by fire or Haze.
+ * Status worked very differently in Gen 1.
+ * - Sleep lasted longer, had no reset on switch and took a whole turn to wake up.
+ * - Frozen only thaws when hit by fire or Haze.
  *
- * Secondary effects to status (-speed, -atk) worked differently, so they are
+ * Stat boosts (-speed, -atk) also worked differently, so they are
  * separated as volatile statuses that are applied on switch in, removed
  * under certain conditions and re-applied under other conditions.
  */
 
-export const Statuses: {[k: string]: ModdedPureEffectData} = {
+export const Conditions: {[k: string]: ModdedPureEffectData} = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',

--- a/data/mods/gen1/formats-data.ts
+++ b/data/mods/gen1/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		randomBattleMoves: ["sleeppowder", "bodyslam"],
 		essentialMove: "razorleaf",

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -3,7 +3,7 @@
  * Some moves have had major changes, such as Bite's typing.
  */
 
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const Moves: {[k: string]: ModdedMoveData} = {
 	absorb: {
 		inherit: true,
 		desc: "The user recovers 1/2 the HP lost by the target, rounded down. If this move breaks the target's substitute, the user does not recover any HP.",

--- a/data/mods/gen1/pokedex.ts
+++ b/data/mods/gen1/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 	missingno: {
 		inherit: true,
 		baseStats: {hp: 33, atk: 136, def: 0, spa: 6, spd: 6, spe: 29},

--- a/data/mods/gen1/rulesets.ts
+++ b/data/mods/gen1/rulesets.ts
@@ -1,4 +1,4 @@
-export const BattleFormats: {[k: string]: ModdedFormatsData} = {
+export const Formats: {[k: string]: ModdedFormatsData} = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -4,7 +4,7 @@
  * This generation inherits all the changes from older generations, that must be taken into account when editing code.
  */
 
-export const BattleScripts: ModdedBattleScriptsData = {
+export const Scripts: ModdedBattleScriptsData = {
 	inherit: 'gen2',
 	gen: 1,
 	init() {
@@ -865,4 +865,4 @@ export const BattleScripts: ModdedBattleScriptsData = {
 	},
 };
 
-exports.BattleScripts = BattleScripts;
+exports.Scripts = Scripts;

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -864,5 +864,3 @@ export const Scripts: ModdedBattleScriptsData = {
 		return Math.floor(damage);
 	},
 };
-
-exports.Scripts = Scripts;

--- a/data/mods/gen1/statuses.ts
+++ b/data/mods/gen1/statuses.ts
@@ -257,5 +257,3 @@ export const Statuses: {[k: string]: ModdedPureEffectData} = {
 		},
 	},
 };
-
-exports.Statuses = Statuses;

--- a/data/mods/gen1/statuses.ts
+++ b/data/mods/gen1/statuses.ts
@@ -8,7 +8,7 @@
  * under certain conditions and re-applied under other conditions.
  */
 
-export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
+export const Statuses: {[k: string]: ModdedPureEffectData} = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',
@@ -258,4 +258,4 @@ export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
 	},
 };
 
-exports.BattleStatuses = BattleStatuses;
+exports.Statuses = Statuses;

--- a/data/mods/gen1/typechart.ts
+++ b/data/mods/gen1/typechart.ts
@@ -6,7 +6,7 @@
  * Psychic was immune to ghost
  */
 
-export const BattleTypeChart: {[k: string]: ModdedTypeData | null} = {
+export const TypeChart: {[k: string]: ModdedTypeData | null} = {
 	Bug: {
 		damageTaken: {
 			Bug: 0,

--- a/data/mods/gen2/conditions.ts
+++ b/data/mods/gen2/conditions.ts
@@ -1,4 +1,4 @@
-export const Statuses: {[k: string]: ModdedPureEffectData} = {
+export const Conditions: {[k: string]: ModdedPureEffectData} = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',

--- a/data/mods/gen2/formats-data.ts
+++ b/data/mods/gen2/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen2/items.ts
+++ b/data/mods/gen2/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const Items: {[k: string]: ModdedItemData} = {
 	berryjuice: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/gen2/learnsets.ts
+++ b/data/mods/gen2/learnsets.ts
@@ -1,4 +1,4 @@
-export const BattleLearnsets: {[k: string]: ModdedLearnsetData} = {
+export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 	missingno: {
 		learnset: {
 			blizzard: ["1M"],

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -2,7 +2,7 @@
  * Gen 2 moves
  */
 
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const Moves: {[k: string]: ModdedMoveData} = {
 	absorb: {
 		inherit: true,
 		desc: "The user recovers 1/2 the HP lost by the target, rounded down. If the target has a substitute, this move misses.",

--- a/data/mods/gen2/rulesets.ts
+++ b/data/mods/gen2/rulesets.ts
@@ -1,4 +1,4 @@
-export const BattleFormats: {[k: string]: ModdedFormatsData} = {
+export const Formats: {[k: string]: ModdedFormatsData} = {
 	obtainablemoves: {
 		inherit: true,
 		banlist: [

--- a/data/mods/gen2/scripts.ts
+++ b/data/mods/gen2/scripts.ts
@@ -2,7 +2,7 @@
  * Gen 2 scripts.
  */
 
-export const BattleScripts: ModdedBattleScriptsData = {
+export const Scripts: ModdedBattleScriptsData = {
 	inherit: 'gen3',
 	gen: 2,
 	// BattlePokemon scripts.

--- a/data/mods/gen2/statuses.ts
+++ b/data/mods/gen2/statuses.ts
@@ -1,4 +1,4 @@
-export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
+export const Statuses: {[k: string]: ModdedPureEffectData} = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',
@@ -238,4 +238,4 @@ function residualdmg(battle: Battle, pokemon: Pokemon) {
 	}
 }
 
-exports.BattleStatuses = BattleStatuses;
+exports.Statuses = Statuses;

--- a/data/mods/gen2/statuses.ts
+++ b/data/mods/gen2/statuses.ts
@@ -237,5 +237,3 @@ function residualdmg(battle: Battle, pokemon: Pokemon) {
 		battle.damage(battle.clampIntRange(Math.floor(pokemon.maxhp / 8), 1), pokemon);
 	}
 }
-
-exports.Statuses = Statuses;

--- a/data/mods/gen2/typechart.ts
+++ b/data/mods/gen2/typechart.ts
@@ -1,4 +1,4 @@
-export const BattleTypeChart: {[k: string]: ModdedTypeData} = {
+export const TypeChart: {[k: string]: ModdedTypeData} = {
 	Fire: {
 		inherit: true,
 		damageTaken: {

--- a/data/mods/gen3/abilities.ts
+++ b/data/mods/gen3/abilities.ts
@@ -1,4 +1,4 @@
-export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[k: string]: ModdedAbilityData} = {
 	cutecharm: {
 		inherit: true,
 		desc: "There is a 1/3 chance a Pokemon making contact with this Pokemon will become infatuated if it is of the opposite gender. This effect does not happen if this Pokemon did not lose HP from the attack.",

--- a/data/mods/gen3/conditions.ts
+++ b/data/mods/gen3/conditions.ts
@@ -1,4 +1,4 @@
-export const Statuses: {[k: string]: ModdedPureEffectData} = {
+export const Conditions: {[k: string]: ModdedPureEffectData} = {
 	slp: {
 		name: 'slp',
 		effectType: 'Status',

--- a/data/mods/gen3/formats-data.ts
+++ b/data/mods/gen3/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen3/items.ts
+++ b/data/mods/gen3/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const Items: {[k: string]: ModdedItemData} = {
 	aguavberry: {
 		inherit: true,
 		onUpdate() {},

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -963,5 +963,3 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		basePower: 100,
 	},
 };
-
-exports.Moves = Moves;

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -2,7 +2,7 @@
  * Gen 3 moves
  */
 
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const Moves: {[k: string]: ModdedMoveData} = {
 	absorb: {
 		inherit: true,
 		desc: "The user recovers 1/2 the HP lost by the target, rounded down.",
@@ -964,4 +964,4 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 	},
 };
 
-exports.BattleMovedex = BattleMovedex;
+exports.Moves = Moves;

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -425,7 +425,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			item = 'Petaya Berry';
 		} else if (counter.Physical >= 4) {
 			item = 'Choice Band';
-		} else if (counter.Physical >= 3 && (hasMove['firepunch'] || hasMove['icebeam'] || hasMove['overheat'] || moves.filter(m => this.dex.data.Movedex[m].category === 'Special' && hasType[this.dex.data.Movedex[m].type]).length)) {
+		} else if (counter.Physical >= 3 && (hasMove['firepunch'] || hasMove['icebeam'] || hasMove['overheat'] || moves.filter(m => this.dex.data.Moves[m].category === 'Special' && hasType[this.dex.data.Moves[m].type]).length)) {
 			item = 'Choice Band';
 
 		// Default to Leftovers

--- a/data/mods/gen3/rulesets.ts
+++ b/data/mods/gen3/rulesets.ts
@@ -1,4 +1,4 @@
-export const BattleFormats: {[k: string]: ModdedFormatsData} = {
+export const Formats: {[k: string]: ModdedFormatsData} = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',

--- a/data/mods/gen3/scripts.ts
+++ b/data/mods/gen3/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const Scripts: ModdedBattleScriptsData = {
 	inherit: 'gen4',
 	gen: 3,
 	init() {
@@ -7,12 +7,12 @@ export const BattleScripts: ModdedBattleScriptsData = {
 		}
 		const specialTypes = ['Fire', 'Water', 'Grass', 'Ice', 'Electric', 'Dark', 'Psychic', 'Dragon'];
 		let newCategory = '';
-		for (const i in this.data.Movedex) {
-			if (!this.data.Movedex[i]) console.log(i);
-			if (this.data.Movedex[i].category === 'Status') continue;
-			newCategory = specialTypes.includes(this.data.Movedex[i].type) ? 'Special' : 'Physical';
-			if (newCategory !== this.data.Movedex[i].category) {
-				this.modData('Movedex', i).category = newCategory;
+		for (const i in this.data.Moves) {
+			if (!this.data.Moves[i]) console.log(i);
+			if (this.data.Moves[i].category === 'Status') continue;
+			newCategory = specialTypes.includes(this.data.Moves[i].type) ? 'Special' : 'Physical';
+			if (newCategory !== this.data.Moves[i].category) {
+				this.modData('Moves', i).category = newCategory;
 			}
 		}
 	},

--- a/data/mods/gen3/statuses.ts
+++ b/data/mods/gen3/statuses.ts
@@ -1,4 +1,4 @@
-export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
+export const Statuses: {[k: string]: ModdedPureEffectData} = {
 	slp: {
 		name: 'slp',
 		effectType: 'Status',

--- a/data/mods/gen4/abilities.ts
+++ b/data/mods/gen4/abilities.ts
@@ -1,4 +1,4 @@
-export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[k: string]: ModdedAbilityData} = {
 	angerpoint: {
 		inherit: true,
 		desc: "If this Pokemon, or its substitute, is struck by a critical hit, its Attack is raised by 12 stages.",

--- a/data/mods/gen4/conditions.ts
+++ b/data/mods/gen4/conditions.ts
@@ -1,4 +1,4 @@
-export const Statuses: {[k: string]: ModdedPureEffectData} = {
+export const Conditions: {[k: string]: ModdedPureEffectData} = {
 	par: {
 		inherit: true,
 		onBeforeMove(pokemon) {

--- a/data/mods/gen4/formats-data.ts
+++ b/data/mods/gen4/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen4/items.ts
+++ b/data/mods/gen4/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const Items: {[k: string]: ModdedItemData} = {
 	adamantorb: {
 		inherit: true,
 		onBasePower(basePower, user, target, move) {

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -1,4 +1,4 @@
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const Moves: {[k: string]: ModdedMoveData} = {
 	absorb: {
 		inherit: true,
 		desc: "The user recovers 1/2 the HP lost by the target, rounded down. If Big Root is held by the user, the HP recovered is 1.3x normal, rounded down.",

--- a/data/mods/gen4/pokedex.ts
+++ b/data/mods/gen4/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 	milotic: {
 		inherit: true,
 		evoType: 'levelExtra',

--- a/data/mods/gen4/rulesets.ts
+++ b/data/mods/gen4/rulesets.ts
@@ -1,4 +1,4 @@
-export const BattleFormats: {[k: string]: ModdedFormatsData} = {
+export const Formats: {[k: string]: ModdedFormatsData} = {
 	standard: {
 		inherit: true,
 		ruleset: ['Obtainable', 'Sleep Clause Mod', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],

--- a/data/mods/gen4/scripts.ts
+++ b/data/mods/gen4/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const Scripts: ModdedBattleScriptsData = {
 	inherit: 'gen5',
 	gen: 4,
 	init() {

--- a/data/mods/gen4/statuses.ts
+++ b/data/mods/gen4/statuses.ts
@@ -1,4 +1,4 @@
-export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
+export const Statuses: {[k: string]: ModdedPureEffectData} = {
 	par: {
 		inherit: true,
 		onBeforeMove(pokemon) {

--- a/data/mods/gen5/abilities.ts
+++ b/data/mods/gen5/abilities.ts
@@ -1,4 +1,4 @@
-export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[k: string]: ModdedAbilityData} = {
 	anticipation: {
 		inherit: true,
 		desc: "On switch-in, this Pokemon is alerted if any opposing Pokemon has an attack that is super effective on this Pokemon, or an OHKO move. Counter, Metal Burst, and Mirror Coat count as attacking moves of their respective types, while Hidden Power, Judgment, Natural Gift, Techno Blast, and Weather Ball are considered Normal-type moves.",

--- a/data/mods/gen5/conditions.ts
+++ b/data/mods/gen5/conditions.ts
@@ -1,4 +1,4 @@
-export const Statuses: {[k: string]: ModdedPureEffectData} = {
+export const Conditions: {[k: string]: ModdedPureEffectData} = {
 	slp: {
 		inherit: true,
 		onSwitchIn(target) {

--- a/data/mods/gen5/formats-data.ts
+++ b/data/mods/gen5/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen5/items.ts
+++ b/data/mods/gen5/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const Items: {[k: string]: ModdedItemData} = {
 	aguavberry: {
 		inherit: true,
 		naturalGift: {

--- a/data/mods/gen5/moves.ts
+++ b/data/mods/gen5/moves.ts
@@ -1,4 +1,4 @@
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const Moves: {[k: string]: ModdedMoveData} = {
 	absorb: {
 		inherit: true,
 		flags: {protect: 1, mirror: 1},

--- a/data/mods/gen5/pokedex.ts
+++ b/data/mods/gen5/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 	bulbasaur: {
 		inherit: true,
 		maleOnlyHidden: true,

--- a/data/mods/gen5/rulesets.ts
+++ b/data/mods/gen5/rulesets.ts
@@ -1,4 +1,4 @@
-export const BattleFormats: {[k: string]: ModdedFormatsData} = {
+export const Formats: {[k: string]: ModdedFormatsData} = {
 	standard: {
 		inherit: true,
 		ruleset: [

--- a/data/mods/gen5/scripts.ts
+++ b/data/mods/gen5/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const Scripts: ModdedBattleScriptsData = {
 	inherit: 'gen6',
 	gen: 5,
 };

--- a/data/mods/gen5/statuses.ts
+++ b/data/mods/gen5/statuses.ts
@@ -1,4 +1,4 @@
-export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
+export const Statuses: {[k: string]: ModdedPureEffectData} = {
 	slp: {
 		inherit: true,
 		onSwitchIn(target) {

--- a/data/mods/gen5/typechart.ts
+++ b/data/mods/gen5/typechart.ts
@@ -1,4 +1,4 @@
-export const BattleTypeChart: {[k: string]: ModdedTypeData | null} = {
+export const TypeChart: {[k: string]: ModdedTypeData | null} = {
 	Electric: {
 		inherit: true,
 		damageTaken: {

--- a/data/mods/gen6/abilities.ts
+++ b/data/mods/gen6/abilities.ts
@@ -1,4 +1,4 @@
-export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[k: string]: ModdedAbilityData} = {
 	aerilate: {
 		inherit: true,
 		desc: "This Pokemon's Normal-type moves become Flying-type moves and have their power multiplied by 1.3. This effect comes after other effects that change a move's type, but before Ion Deluge and Electrify's effects.",

--- a/data/mods/gen6/conditions.ts
+++ b/data/mods/gen6/conditions.ts
@@ -1,4 +1,4 @@
-export const Statuses: {[k: string]: ModdedPureEffectData} = {
+export const Conditions: {[k: string]: ModdedPureEffectData} = {
 	brn: {
 		inherit: true,
 		onResidual(pokemon) {

--- a/data/mods/gen6/formats-data.ts
+++ b/data/mods/gen6/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen6/items.ts
+++ b/data/mods/gen6/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const Items: {[k: string]: ModdedItemData} = {
 	aguavberry: {
 		inherit: true,
 		desc: "Restores 1/8 max HP at 1/2 max HP or less; confuses if -SpD Nature. Single use.",
@@ -203,4 +203,4 @@ export const BattleItems: {[k: string]: ModdedItemData} = {
 	},
 };
 
-exports.BattleItems = BattleItems;
+exports.Items = Items;

--- a/data/mods/gen6/items.ts
+++ b/data/mods/gen6/items.ts
@@ -202,5 +202,3 @@ export const Items: {[k: string]: ModdedItemData} = {
 		},
 	},
 };
-
-exports.Items = Items;

--- a/data/mods/gen6/learnsets.ts
+++ b/data/mods/gen6/learnsets.ts
@@ -1,4 +1,4 @@
-export const BattleLearnsets: {[k: string]: ModdedLearnsetData} = {
+export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 	tomohawk: {
 		inherit: true,
 		learnset: {

--- a/data/mods/gen6/moves.ts
+++ b/data/mods/gen6/moves.ts
@@ -1,4 +1,4 @@
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const Moves: {[k: string]: ModdedMoveData} = {
 	allyswitch: {
 		inherit: true,
 		desc: "The user swaps positions with its ally on the opposite side of the field. Fails if there is no Pokemon at that position, if the user is the only Pokemon on its side, or if the user is in the middle.",

--- a/data/mods/gen6/pokedex.ts
+++ b/data/mods/gen6/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 	charizardmegax: {
 		inherit: true,
 		color: "Red",

--- a/data/mods/gen6/scripts.ts
+++ b/data/mods/gen6/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const Scripts: ModdedBattleScriptsData = {
 	inherit: 'gen7',
 	gen: 6,
 };

--- a/data/mods/gen6/statuses.ts
+++ b/data/mods/gen6/statuses.ts
@@ -1,4 +1,4 @@
-export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
+export const Statuses: {[k: string]: ModdedPureEffectData} = {
 	brn: {
 		inherit: true,
 		onResidual(pokemon) {

--- a/data/mods/gen6/typechart.ts
+++ b/data/mods/gen6/typechart.ts
@@ -1,4 +1,4 @@
-export const BattleTypeChart: {[k: string]: ModdedTypeData} = {
+export const TypeChart: {[k: string]: ModdedTypeData} = {
 	Dark: {
 		inherit: true,
 		damageTaken: {

--- a/data/mods/gen7/abilities.ts
+++ b/data/mods/gen7/abilities.ts
@@ -1,4 +1,4 @@
-export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[k: string]: ModdedAbilityData} = {
 	chlorophyll: {
 		inherit: true,
 		desc: "If Sunny Day is active, this Pokemon's Speed is doubled.",

--- a/data/mods/gen7/formats-data.ts
+++ b/data/mods/gen7/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen7/items.ts
+++ b/data/mods/gen7/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const Items: {[k: string]: ModdedItemData} = {
 	abomasite: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -1,4 +1,4 @@
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const Moves: {[k: string]: ModdedMoveData} = {
 	"10000000voltthunderbolt": {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/gen7/pokedex.ts
+++ b/data/mods/gen7/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 	pikachuoriginal: {
 		inherit: true,
 		abilities: {0: "Static"},

--- a/data/mods/gen7/rulesets.ts
+++ b/data/mods/gen7/rulesets.ts
@@ -1,4 +1,4 @@
-export const BattleFormats: {[k: string]: ModdedFormatsData} = {
+export const Formats: {[k: string]: ModdedFormatsData} = {
 	standard: {
 		inherit: true,
 		ruleset: ['Obtainable', 'Team Preview', 'Sleep Clause Mod', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Moody Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],

--- a/data/mods/gen7/scripts.ts
+++ b/data/mods/gen7/scripts.ts
@@ -1,3 +1,3 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const Scripts: ModdedBattleScriptsData = {
 	gen: 7,
 };

--- a/data/mods/gennext/abilities.ts
+++ b/data/mods/gennext/abilities.ts
@@ -1,4 +1,4 @@
-export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[k: string]: ModdedAbilityData} = {
 	swiftswim: {
 		inherit: true,
 		onModifySpe(spe, pokemon) {
@@ -685,4 +685,4 @@ export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
 	},
 };
 
-exports.BattleAbilities = BattleAbilities;
+exports.Abilities = Abilities;

--- a/data/mods/gennext/abilities.ts
+++ b/data/mods/gennext/abilities.ts
@@ -684,5 +684,3 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		onFoeTrapPokemon(pokemon) {},
 	},
 };
-
-exports.Abilities = Abilities;

--- a/data/mods/gennext/conditions.ts
+++ b/data/mods/gennext/conditions.ts
@@ -1,4 +1,4 @@
-export const Statuses: {[k: string]: ModdedPureEffectData} = {
+export const Conditions: {[k: string]: ModdedPureEffectData} = {
 	frz: {
 		name: 'frz',
 		effectType: 'Status',

--- a/data/mods/gennext/formats-data.ts
+++ b/data/mods/gennext/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	aegislash: {
 		inherit: true,
 		tier: "OU",

--- a/data/mods/gennext/items.ts
+++ b/data/mods/gennext/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const Items: {[k: string]: ModdedItemData} = {
 	burndrive: {
 		inherit: true,
 		onBasePower(basePower, user, target, move) {},

--- a/data/mods/gennext/moves.ts
+++ b/data/mods/gennext/moves.ts
@@ -1,4 +1,4 @@
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const Moves: {[k: string]: ModdedMoveData} = {
 	/******************************************************************
 	Perfect accuracy moves:
 	- base power increased to 90
@@ -2120,4 +2120,4 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 	},
 };
 
-exports.BattleMovedex = BattleMovedex;
+exports.Moves = Moves;

--- a/data/mods/gennext/moves.ts
+++ b/data/mods/gennext/moves.ts
@@ -2119,5 +2119,3 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		contestType: "Cute",
 	},
 };
-
-exports.Moves = Moves;

--- a/data/mods/gennext/pokedex.ts
+++ b/data/mods/gennext/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 	genesectdouse: {
 		inherit: true,
 		types: ["Bug", "Water"],

--- a/data/mods/gennext/scripts.ts
+++ b/data/mods/gennext/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const Scripts: ModdedBattleScriptsData = {
 	inherit: 'gen6',
 	init() {
 		this.modData('Pokedex', 'cherrimsunshine').types = ['Grass', 'Fire'];

--- a/data/mods/gennext/statuses.ts
+++ b/data/mods/gennext/statuses.ts
@@ -1,4 +1,4 @@
-export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
+export const Statuses: {[k: string]: ModdedPureEffectData} = {
 	frz: {
 		name: 'frz',
 		effectType: 'Status',

--- a/data/mods/letsgo/formats-data.ts
+++ b/data/mods/letsgo/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		inherit: true,
 		tier: "LC",

--- a/data/mods/letsgo/learnsets.ts
+++ b/data/mods/letsgo/learnsets.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 
-export const BattleLearnsets: {[k: string]: ModdedLearnsetData} = {
+export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 	bulbasaur: {
 		learnset: {
 			doubleedge: ["7L32"],

--- a/data/mods/letsgo/moves.ts
+++ b/data/mods/letsgo/moves.ts
@@ -41,7 +41,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		onHit(target, source, effect) {
 			const moves = [];
-			for (const id in exports.Moves) {
+			for (const id in this.dex.data.Moves) {
 				const move = this.dex.getMove(id);
 				if (move.realMove) continue;
 				if (move.gen !== 1) continue;

--- a/data/mods/letsgo/moves.ts
+++ b/data/mods/letsgo/moves.ts
@@ -1,4 +1,4 @@
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const Moves: {[k: string]: ModdedMoveData} = {
 	absorb: {
 		inherit: true,
 		basePower: 40,
@@ -41,7 +41,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		onHit(target, source, effect) {
 			const moves = [];
-			for (const id in exports.BattleMovedex) {
+			for (const id in exports.Moves) {
 				const move = this.dex.getMove(id);
 				if (move.realMove) continue;
 				if (move.gen !== 1) continue;

--- a/data/mods/letsgo/pokedex.ts
+++ b/data/mods/letsgo/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 	pichu: {
 		inherit: true,
 		evos: [],

--- a/data/mods/letsgo/rulesets.ts
+++ b/data/mods/letsgo/rulesets.ts
@@ -1,4 +1,4 @@
-export const BattleFormats: {[k: string]: ModdedFormatsData} = {
+export const Formats: {[k: string]: ModdedFormatsData} = {
 	allowavs: {
 		effectType: 'ValidatorRule',
 		name: 'Allow AVs',

--- a/data/mods/letsgo/scripts.ts
+++ b/data/mods/letsgo/scripts.ts
@@ -54,5 +54,3 @@ export const Scripts: ModdedBattleScriptsData = {
 		},
 	},
 };
-
-exports.Scripts = Scripts;

--- a/data/mods/letsgo/scripts.ts
+++ b/data/mods/letsgo/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const Scripts: ModdedBattleScriptsData = {
 	inherit: 'gen7',
 	init() {
 		this.modData('Abilities', 'noability').isNonstandard = null;
@@ -55,4 +55,4 @@ export const BattleScripts: ModdedBattleScriptsData = {
 	},
 };
 
-exports.BattleScripts = BattleScripts;
+exports.Scripts = Scripts;

--- a/data/mods/linked/conditions.ts
+++ b/data/mods/linked/conditions.ts
@@ -1,4 +1,4 @@
-export const Statuses: {[k: string]: ModdedPureEffectData} = {
+export const Conditions: {[k: string]: ModdedPureEffectData} = {
 	slp: {
 		inherit: true,
 		onBeforeMove(pokemon, target, move) {

--- a/data/mods/linked/items.ts
+++ b/data/mods/linked/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const Items: {[k: string]: ModdedItemData} = {
 	leppaberry: {
 		inherit: true,
 		onUpdate(pokemon) {

--- a/data/mods/linked/moves.ts
+++ b/data/mods/linked/moves.ts
@@ -1,4 +1,4 @@
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const Moves: {[k: string]: ModdedMoveData} = {
 	pursuit: {
 		inherit: true,
 		beforeTurnCallback(pokemon, target) {

--- a/data/mods/linked/scripts.ts
+++ b/data/mods/linked/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const Scripts: ModdedBattleScriptsData = {
 	runMove(moveOrMoveName, pokemon, targetLoc, sourceEffect, zMove, externalMove, maxMove, originalTarget) {
 		pokemon.activeMoveActions++;
 		let target = this.getTarget(pokemon, maxMove || zMove || moveOrMoveName, targetLoc, originalTarget);

--- a/data/mods/linked/statuses.ts
+++ b/data/mods/linked/statuses.ts
@@ -1,4 +1,4 @@
-export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
+export const Statuses: {[k: string]: ModdedPureEffectData} = {
 	slp: {
 		inherit: true,
 		onBeforeMove(pokemon, target, move) {

--- a/data/mods/megamax/abilities.ts
+++ b/data/mods/megamax/abilities.ts
@@ -1,4 +1,4 @@
-export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[k: string]: ModdedAbilityData} = {
 	calmingtides: {
 		desc: "Water-type Pokemon on this Pokemon's side cannot have their stat stages lowered by other Pokemon or have a major status condition inflicted on them by other Pokemon.",
 		shortDesc: "This side's Water types can't have stats lowered or status inflicted by other Pokemon.",

--- a/data/mods/megamax/items.ts
+++ b/data/mods/megamax/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const Items: {[k: string]: ModdedItemData} = {
 	venusauritez: {
 		name: "Venusaurite Z",
 		spritenum: 608,

--- a/data/mods/megamax/moves.ts
+++ b/data/mods/megamax/moves.ts
@@ -1,4 +1,4 @@
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const Moves: {[k: string]: ModdedMoveData} = {
 	coppermines: {
 		num: -1000,
 		accuracy: true,

--- a/data/mods/megamax/pokedex.ts
+++ b/data/mods/megamax/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 	venusaurgmax: {
 		num: 3,
 		name: "Venusaur-Gmax",

--- a/data/mods/megamax/rulesets.ts
+++ b/data/mods/megamax/rulesets.ts
@@ -1,4 +1,4 @@
-export const BattleFormats: {[k: string]: FormatsData} = {
+export const Formats: {[k: string]: FormatsData} = {
 	dynamaxclause: {
 		effectType: 'Rule',
 		name: 'Dynamax Clause',

--- a/data/mods/megamax/scripts.ts
+++ b/data/mods/megamax/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const Scripts: ModdedBattleScriptsData = {
 	gen: 8,
 	init() {
 		const addNewMoves = (pokemonid: string, moveids: string[], tutor = false) => {

--- a/data/mods/mixandmega/items.ts
+++ b/data/mods/mixandmega/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const Items: {[k: string]: ModdedItemData} = {
 	abomasite: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/mixandmega/scripts.ts
+++ b/data/mods/mixandmega/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const Scripts: ModdedBattleScriptsData = {
 	init() {
 		for (const i in this.data.Items) {
 			if (!this.data.Items[i].megaStone) continue;

--- a/data/mods/mixandmega7/items.ts
+++ b/data/mods/mixandmega7/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const Items: {[k: string]: ModdedItemData} = {
 	blueorb: {
 		inherit: true,
 		onSwitchIn(pokemon) {

--- a/data/mods/mixandmega7/scripts.ts
+++ b/data/mods/mixandmega7/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const Scripts: ModdedBattleScriptsData = {
 	inherit: 'gen7',
 	init() {
 		for (const id in this.data.Items) {

--- a/data/mods/optimons/abilities.ts
+++ b/data/mods/optimons/abilities.ts
@@ -1,4 +1,4 @@
-export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[k: string]: ModdedAbilityData} = {
 	gulpmissile: {
 		inherit: true,
 		desc: "If this Pokemon is a Cramorant, it changes forme when it hits a target with a Water-type move or uses the first turn of Dive successfully. It becomes Gulping Form with an Arrokuda in its mouth if it has more than 1/2 of its maximum HP remaining, or Gorging Form with a Pikachu in its mouth if it has 1/2 or less of its maximum HP remaining. If Cramorant gets hit in Gulping or Gorging Form, it spits the Arrokuda or Pikachu at its attacker, even if it has no HP remaining. The projectile deals damage equal to 1/4 of the target's maximum HP, rounded down; this damage is blocked by the Magic Guard Ability but not by a substitute. An Arrokuda also lowers the target's Defense by 1 stage, and a Pikachu paralyzes the target. Cramorant will return to normal if it spits out a projectile, switches out, or Dynamaxes.",

--- a/data/mods/optimons/moves.ts
+++ b/data/mods/optimons/moves.ts
@@ -1,4 +1,4 @@
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const Moves: {[k: string]: ModdedMoveData} = {
 	bonemerang: {
 		inherit: true,
 		beforeTurnCallback(pokemon, target) {

--- a/data/mods/optimons/pokedex.ts
+++ b/data/mods/optimons/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 	inteleon: {
 		inherit: true,
 		types: ["Water", "Normal"],

--- a/data/mods/optimons/scripts.ts
+++ b/data/mods/optimons/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const Scripts: ModdedBattleScriptsData = {
 	init() {
 		const addNewMoves = (pokemonid: string, moveids: string[]) => {
 			for (const moveid of moveids.map(toID)) {

--- a/data/mods/ssb/abilities.ts
+++ b/data/mods/ssb/abilities.ts
@@ -1,4 +1,4 @@
-export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[k: string]: ModdedAbilityData} = {
 	/*
 	// Example
 	"abilityid": {

--- a/data/mods/ssb/conditions.ts
+++ b/data/mods/ssb/conditions.ts
@@ -1,4 +1,4 @@
-export const Statuses: {[k: string]: ModdedPureEffectData} = {
+export const Conditions: {[k: string]: ModdedPureEffectData} = {
 	/*
 	// Example:
 	userid: {

--- a/data/mods/ssb/items.ts
+++ b/data/mods/ssb/items.ts
@@ -145,5 +145,3 @@ export const Items: {[k: string]: ModdedItemData} = {
 		desc: "Fire-type attacks have 1.2x power. Reshiram with Blue Flare can use Bleh Flame.",
 	},
 };
-
-exports.Items = Items;

--- a/data/mods/ssb/items.ts
+++ b/data/mods/ssb/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const Items: {[k: string]: ModdedItemData} = {
 	// Aeonic
 	noseiumz: {
 		name: "Noseium Z",
@@ -146,4 +146,4 @@ export const BattleItems: {[k: string]: ModdedItemData} = {
 	},
 };
 
-exports.BattleItems = BattleItems;
+exports.Items = Items;

--- a/data/mods/ssb/moves.ts
+++ b/data/mods/ssb/moves.ts
@@ -2,7 +2,7 @@
 import {RandomStaffBrosTeams} from './random-teams';
 import {Pokemon, EffectState} from '../../../sim/pokemon';
 
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const Moves: {[k: string]: ModdedMoveData} = {
 	/*
 	// Example
 	"moveid": {
@@ -2018,7 +2018,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 					this.add('message', `${pokemon.name} was corrupted by a bug in the Scripted Terrain!`);
 					// generate a movepool
 					const moves = [];
-					const pool = Object.keys(this.dex.data.Movedex);
+					const pool = Object.keys(this.dex.data.Moves);
 					this.prng.shuffle(pool);
 					const metronome = this.dex.getMove('metronome');
 					for (const id of pool) {
@@ -2086,8 +2086,8 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		},
 		onHit(target, source, effect) {
 			const moves = [];
-			for (const id in this.dex.data.Movedex) {
-				const move = this.dex.data.Movedex[id];
+			for (const id in this.dex.data.Moves) {
+				const move = this.dex.data.Moves[id];
 				if (move.realMove) continue;
 				if (move.isZ || move.isNonstandard) continue;
 				if (effect.noMetronome && effect.noMetronome.includes(move.name)) continue;
@@ -3249,7 +3249,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		onPrepareHit(target, source) {
 			this.add('-anim', source, "Toxic", target);
 		},
-		// Innate corrosive implemented in BattleScripts#setStatus
+		// Innate corrosive implemented in Scripts#setStatus
 		status: 'tox',
 		secondary: null,
 		target: "normal",
@@ -4506,8 +4506,8 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		},
 		onHit(target, source, effect) {
 			const moves = [];
-			for (const id in exports.BattleMovedex) {
-				const move = exports.BattleMovedex[id];
+			for (const id in exports.Moves) {
+				const move = exports.Moves[id];
 				if (move.realMove || move.id === 'glitzerpopping') continue;
 				// Calling 1 BP move is somewhat lame and disappointing. However,
 				// signature Z moves are fine, as they actually have a base power.

--- a/data/mods/ssb/moves.ts
+++ b/data/mods/ssb/moves.ts
@@ -4506,21 +4506,17 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		},
 		onHit(target, source, effect) {
 			const moves = [];
-			for (const id in exports.Moves) {
-				const move = exports.Moves[id];
+			for (const id in this.dex.data.Moves) {
+				const move = this.dex.getMove(id);
 				if (move.realMove || move.id === 'glitzerpopping') continue;
 				// Calling 1 BP move is somewhat lame and disappointing. However,
 				// signature Z moves are fine, as they actually have a base power.
 				if (move.isZ && move.basePower === 1) continue;
-				if (this.dex.getMove(id).gen > this.gen) continue;
-				moves.push(move);
+				if (move.gen > this.gen) continue;
+				moves.push(move.name);
 			}
-			let randomMove: string;
-			if (moves.length) {
-				randomMove = this.sample(moves).name;
-			} else {
-				return false;
-			}
+			if (!moves.length) return false;
+			const randomMove = this.sample(moves);
 			this.useMove(randomMove, target);
 		},
 		multihit: [2, 5],

--- a/data/mods/ssb/pokedex.ts
+++ b/data/mods/ssb/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 	/*
 	// Example
 	id: {

--- a/data/mods/ssb/scripts.ts
+++ b/data/mods/ssb/scripts.ts
@@ -1,4 +1,4 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const Scripts: ModdedBattleScriptsData = {
 	inherit: 'gen7',
 	runMove(moveOrMoveName, pokemon, targetLoc, sourceEffect, zMove, externalMove) {
 		pokemon.activeMoveActions++;

--- a/data/mods/ssb/statuses.ts
+++ b/data/mods/ssb/statuses.ts
@@ -1,4 +1,4 @@
-export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
+export const Statuses: {[k: string]: ModdedPureEffectData} = {
 	/*
 	// Example:
 	userid: {

--- a/data/mods/stadium/conditions.ts
+++ b/data/mods/stadium/conditions.ts
@@ -1,4 +1,4 @@
-export const Statuses: {[k: string]: ModdedPureEffectData} = {
+export const Conditions: {[k: string]: ModdedPureEffectData} = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',

--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -1,4 +1,4 @@
-export const BattleMovedex: {[k: string]: ModdedMoveData} = {
+export const Moves: {[k: string]: ModdedMoveData} = {
 	bind: {
 		inherit: true,
 		// FIXME: onBeforeMove() {},

--- a/data/mods/stadium/rulesets.ts
+++ b/data/mods/stadium/rulesets.ts
@@ -1,4 +1,4 @@
-export const BattleFormats: {[k: string]: ModdedFormatsData} = {
+export const Formats: {[k: string]: ModdedFormatsData} = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',

--- a/data/mods/stadium/scripts.ts
+++ b/data/mods/stadium/scripts.ts
@@ -1,7 +1,7 @@
 /**
  * Stadium mechanics inherit from gen 1 mechanics, but fixes some stuff.
  */
-export const BattleScripts: ModdedBattleScriptsData = {
+export const Scripts: ModdedBattleScriptsData = {
 	inherit: 'gen1',
 	gen: 1,
 	// BattlePokemon scripts. Stadium shares gen 1 code but it fixes some problems with it.

--- a/data/mods/stadium/statuses.ts
+++ b/data/mods/stadium/statuses.ts
@@ -1,4 +1,4 @@
-export const BattleStatuses: {[k: string]: ModdedPureEffectData} = {
+export const Statuses: {[k: string]: ModdedPureEffectData} = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',

--- a/data/mods/vgc17/formats-data.ts
+++ b/data/mods/vgc17/formats-data.ts
@@ -1,4 +1,4 @@
-export const BattleFormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	pikachupartner: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",

--- a/data/mods/vgc17/items.ts
+++ b/data/mods/vgc17/items.ts
@@ -1,4 +1,4 @@
-export const BattleItems: {[k: string]: ModdedItemData} = {
+export const Items: {[k: string]: ModdedItemData} = {
 	kommoniumz: {
 		inherit: true,
 		isNonstandard: "Unobtainable",

--- a/data/mods/vgc17/learnsets.ts
+++ b/data/mods/vgc17/learnsets.ts
@@ -1,4 +1,4 @@
-export const BattleLearnsets: {[k: string]: ModdedLearnsetData} = {
+export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 	missingno: {inherit: true, learnset: {
 		blizzard: ["5L1"],
 		bubblebeam: ["5L1"],

--- a/data/mods/vgc17/pokedex.ts
+++ b/data/mods/vgc17/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 	litten: {
 		inherit: true,
 		unreleasedHidden: true,

--- a/data/mods/vgc17/rulesets.ts
+++ b/data/mods/vgc17/rulesets.ts
@@ -1,4 +1,4 @@
-export const BattleFormats: {[k: string]: ModdedFormatsData} = {
+export const Formats: {[k: string]: ModdedFormatsData} = {
 	alolapokedex: {
 		effectType: 'ValidatorRule',
 		name: 'Alola Pokedex',

--- a/data/mods/vgc17/scripts.ts
+++ b/data/mods/vgc17/scripts.ts
@@ -1,3 +1,3 @@
-export const BattleScripts: ModdedBattleScriptsData = {
+export const Scripts: ModdedBattleScriptsData = {
 	inherit: 'gen7',
 };

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -26,7 +26,7 @@ sound: Has no effect on Pokemon with the Soundproof Ability.
 
 */
 
-export const BattleMovedex: {[moveid: string]: MoveData} = {
+export const Moves: {[moveid: string]: MoveData} = {
 	"10000000voltthunderbolt": {
 		num: 719,
 		accuracy: true,
@@ -11849,8 +11849,8 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		],
 		onHit(target, source, effect) {
 			const moves: MoveData[] = [];
-			for (const id in BattleMovedex) {
-				const move = BattleMovedex[id];
+			for (const id in Moves) {
+				const move = Moves[id];
 				if (move.realMove) continue;
 				if (move.isZ || move.isMax || move.isNonstandard) continue;
 				if (effect.noMetronome!.includes(move.name)) continue;
@@ -19677,7 +19677,7 @@ export const BattleMovedex: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1},
-		// No Guard-like effect for Poison-type users implemented in BattleScripts#tryMoveHit
+		// No Guard-like effect for Poison-type users implemented in Scripts#tryMoveHit
 		status: 'tox',
 		secondary: null,
 		target: "normal",

--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -1,4 +1,4 @@
-export const BattlePokedex: {[speciesid: string]: SpeciesData} = {
+export const Pokedex: {[speciesid: string]: SpeciesData} = {
 	bulbasaur: {
 		num: 1,
 		name: "Bulbasaur",

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -161,8 +161,8 @@ export class RandomTeams {
 			let moves;
 			let pool = ['struggle'];
 			if (forme === 'Smeargle') {
-				pool = Object.keys(this.dex.data.Movedex).filter(moveid => {
-					const move = this.dex.data.Movedex[moveid];
+				pool = Object.keys(this.dex.data.Moves).filter(moveid => {
+					const move = this.dex.data.Moves[moveid];
 					return !(move.isNonstandard || move.isZ || move.isMax || move.realMove);
 				});
 			} else {
@@ -304,7 +304,7 @@ export class RandomTeams {
 
 		const itemPool = Object.keys(this.dex.data.Items);
 		const abilityPool = Object.keys(this.dex.data.Abilities);
-		const movePool = Object.keys(this.dex.data.Movedex);
+		const movePool = Object.keys(this.dex.data.Moves);
 		const naturePool = Object.keys(this.dex.data.Natures);
 
 		const random6 = this.random6Pokemon();

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1,7 +1,7 @@
 // Note: These are the rules that formats use
 // The list of formats is stored in config/formats.js
 
-export const BattleFormats: {[k: string]: FormatsData} = {
+export const Formats: {[k: string]: FormatsData} = {
 
 	// Rulesets
 	///////////////////////////////////////////////////////////////////

--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -1,6 +1,6 @@
 const CHOOSABLE_TARGETS = new Set(['normal', 'any', 'adjacentAlly', 'adjacentAllyOrSelf', 'adjacentFoe']);
 
-export const BattleScripts: BattleScriptsData = {
+export const Scripts: BattleScriptsData = {
 	gen: 8,
 	/**
 	 * runMove is the "outside" move caller. It handles deducting PP,

--- a/data/statuses.ts
+++ b/data/statuses.ts
@@ -1,4 +1,4 @@
-export const BattleStatuses: {[k: string]: PureEffectData} = {
+export const Statuses: {[k: string]: PureEffectData} = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',

--- a/data/typechart.ts
+++ b/data/typechart.ts
@@ -1,4 +1,4 @@
-export const BattleTypeChart: {[k: string]: TypeData} = {
+export const TypeChart: {[k: string]: TypeData} = {
 	Bug: {
 		damageTaken: {
 			Bug: 0,

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -475,7 +475,7 @@ export const commands: ChatCommands = {
 	async savelearnsets(target, room, user, connection) {
 		if (!this.canUseConsole()) return false;
 		this.sendReply("saving...");
-		await FS('data/learnsets.js').write(`'use strict';\n\nexports.BattleLearnsets = {\n` +
+		await FS('data/learnsets.js').write(`'use strict';\n\nexports.Learnsets = {\n` +
 			Object.entries(Dex.data.Learnsets).map(([id, entry]) => (
 				`\t${id}: {learnset: {\n` +
 				Object.entries(Dex.getLearnsetData(id as ID)).sort(

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -2386,7 +2386,7 @@ function runSearch(query: {tar: string, cmd: string, canAll: boolean, message: s
  * Process manager
  *********************************************************/
 
-const PM = new QueryProcessManager<AnyObject, AnyObject | null>(module, query => {
+export const PM = new QueryProcessManager<AnyObject, AnyObject | null>(module, query => {
 	try {
 		if (Config.debugdexsearchprocesses && process.send) {
 			process.send('DEBUG\n' + JSON.stringify(query));
@@ -2447,5 +2447,3 @@ if (!PM.isParentProcess) {
 } else {
 	PM.spawn(MAX_PROCESSES);
 }
-
-exports.PM = PM;

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -294,7 +294,7 @@ export const commands: ChatCommands = {
 			`Parameters separated with <code>|</code> will be searched as alternatives for each other; e.g., <code>fire | water</code> searches for all moves that are either Fire type or Water type.<br/>` +
 			`If a Pok\u00e9mon is included as a parameter, only moves from its movepool will be included in the search.<br/>` +
 			`You can search for info in a specific generation by appending the generation to ms; e.g. <code>ms1 normal</code> searches for all moves that were Normal type in Generation I.<br/>` +
-			`<code>/ms</code> will search the Galar Movedex; you can search the National Movedex by using <code>/nms</code> or by adding <code>natdex</code> as a parameter.<br/>` +
+			`<code>/ms</code> will search the Galar Moves; you can search the National Moves by using <code>/nms</code> or by adding <code>natdex</code> as a parameter.<br/>` +
 			`The order of the parameters does not matter.`
 		);
 	},
@@ -735,7 +735,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 
 			if (target === 'priority') {
 				if (parameters.length > 1) return {error: "The parameter 'priority' cannot have alternative parameters"};
-				for (const move in Dex.data.Movedex) {
+				for (const move in Dex.data.Moves) {
 					const moveData = Dex.getMove(move);
 					if (moveData.category === "Status" || moveData.id === "bide") continue;
 					if (moveData.priority > 0) {
@@ -1513,7 +1513,7 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 
 	// Since we assume we have no target mons at first
 	// then the valid moveset we can search is the set of all moves.
-	const validMoves = new Set(Object.keys(Dex.data.Movedex));
+	const validMoves = new Set(Object.keys(Dex.data.Moves));
 	validMoves.delete('magikarpsrevenge');
 	for (const mon of targetMons) {
 		const species = mod.getSpecies(mon.name);

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -1437,4 +1437,3 @@ export const commands: ChatCommands = {
 		`/helpticket delete [user] - Deletes a user's ticket. Requires: &`,
 	],
 };
-exports.commands = commands;

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -58,10 +58,10 @@ const dexes: {[mod: string]: ModdedDex} = Object.create(null);
 
 type DataType =
 	'Abilities' | 'Formats' | 'FormatsData' | 'Items' | 'Learnsets' | 'Moves' |
-	'Natures' | 'Pokedex' | 'Scripts' | 'Statuses' | 'TypeChart';
+	'Natures' | 'Pokedex' | 'Scripts' | 'Conditions' | 'TypeChart';
 const DATA_TYPES: (DataType | 'Aliases')[] = [
 	'Abilities', 'Formats', 'FormatsData', 'Items', 'Learnsets', 'Moves',
-	'Natures', 'Pokedex', 'Scripts', 'Statuses', 'TypeChart',
+	'Natures', 'Pokedex', 'Scripts', 'Conditions', 'TypeChart',
 ];
 
 const DATA_FILES = {
@@ -75,7 +75,7 @@ const DATA_FILES = {
 	Natures: 'natures',
 	Pokedex: 'pokedex',
 	Scripts: 'scripts',
-	Statuses: 'statuses',
+	Conditions: 'conditions',
 	TypeChart: 'typechart',
 };
 
@@ -99,7 +99,7 @@ interface DexTableData {
 	Natures: DexTable<Nature>;
 	Pokedex: DexTable<Species>;
 	Scripts: DexTable<AnyObject>;
-	Statuses: DexTable<EffectData>;
+	Conditions: DexTable<EffectData>;
 	TypeChart: DexTable<TypeData>;
 }
 
@@ -409,7 +409,7 @@ export class ModdedDex {
 		if (id && this.data.Pokedex.hasOwnProperty(id)) {
 			species = new Data.Species({name}, this.data.Pokedex[id], this.data.FormatsData[id]);
 			// Inherit any statuses from the base species (Arceus, Silvally).
-			const baseSpeciesStatuses = this.data.Statuses[toID(species.baseSpecies)];
+			const baseSpeciesStatuses = this.data.Conditions[toID(species.baseSpecies)];
 			if (baseSpeciesStatuses !== undefined) {
 				let key: keyof EffectData;
 				for (key in baseSpeciesStatuses) {
@@ -553,11 +553,13 @@ export class ModdedDex {
 		let found;
 		if (this.data.Formats.hasOwnProperty(id)) {
 			effect = new Data.Format({name: id}, this.data.Formats[id]);
-		} else if (this.data.Statuses.hasOwnProperty(id)) {
-			effect = new Data.PureEffect({name: id}, this.data.Statuses[id]);
-		} else if ((this.data.Moves.hasOwnProperty(id) && (found = this.data.Moves[id]).effect) ||
-							 (this.data.Abilities.hasOwnProperty(id) && (found = this.data.Abilities[id]).effect) ||
-							 (this.data.Items.hasOwnProperty(id) && (found = this.data.Items[id]).effect)) {
+		} else if (this.data.Conditions.hasOwnProperty(id)) {
+			effect = new Data.PureEffect({name: id}, this.data.Conditions[id]);
+		} else if (
+			(this.data.Moves.hasOwnProperty(id) && (found = this.data.Moves[id]).effect) ||
+			(this.data.Abilities.hasOwnProperty(id) && (found = this.data.Abilities[id]).effect) ||
+			(this.data.Items.hasOwnProperty(id) && (found = this.data.Items[id]).effect)
+		) {
 			effect = new Data.PureEffect({name: found.name || id}, found.effect!);
 		} else if (id === 'recoil') {
 			effect = new Data.PureEffect({id, name: 'Recoil', effectType: 'Recoil'});

--- a/sim/tools/exhaustive-runner.ts
+++ b/sim/tools/exhaustive-runner.ts
@@ -115,7 +115,7 @@ export class ExhaustiveRunner {
 				(_, p) => (p.name !== 'Pichu-Spiky-eared' && p.name.substr(0, 8) !== 'Pikachu-')), this.prng),
 			items: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Items, i => dex.getItem(i)), this.prng),
 			abilities: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Abilities, a => dex.getAbility(a)), this.prng),
-			moves: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Movedex, m => dex.getMove(m),
+			moves: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Moves, m => dex.getMove(m),
 				m => (m !== 'struggle' && (m === 'hiddenpower' || m.substr(0, 11) !== 'hiddenpower'))), this.prng),
 		};
 	}

--- a/test/sim/data.js
+++ b/test/sim/data.js
@@ -113,10 +113,10 @@ describe('Dex data', function () {
 		}
 	});
 
-	it('should have valid Movedex entries', function () {
-		const Movedex = Dex.data.Movedex;
-		for (const moveid in Movedex) {
-			const entry = Movedex[moveid];
+	it('should have valid Moves entries', function () {
+		const Moves = Dex.data.Moves;
+		for (const moveid in Moves) {
+			const entry = Moves[moveid];
 			assert.equal(toID(entry.name), moveid, `Mismatched Move key "${moveid}" of "${entry.name}"`);
 			assert.equal(typeof entry.num, 'number', `Move ${entry.name} should have a number`);
 			assert.false(entry.infiltrates, `Move ${entry.name} should not have an 'infiltrates' property (no real move has it)`);


### PR DESCRIPTION
`BattlePokedex` is now `Pokedex`, `BattleItems` is now `Items`, etc.

I also renamed `Movedex` to `Moves`.

`TypeChart` isn't `Types` yet, because unlike the others, it's not indexed by ID. That should probably be fixed one day.