### PR TITLE
Support hiding battles from /cmd userdetails

### DIFF
--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -1321,15 +1321,17 @@ export const commands: ChatCommands = {
 		});
 	},
 
-	nodisplaybattles: 'displaybattles',
-	displaybattles(target, room, user, connection, cmd) {
-		const shouldHide = cmd.includes('no');
-		user.settings.hideBattles = shouldHide;
-		this.sendReply(`Battles are now ${shouldHide ? "hidden (except to staff)" : "visible"} in your usercard.`);
+	showbattlesinusercard: 'hidebattlesfromtrainercard',
+	hidebattlesfromusercard: 'hidebattlesfromtrainercard',
+	showbattlesintrainercard: 'hidebattlesfromtrainercard',
+	hidebattlesfromtrainercard(target, room, user, connection, cmd) {
+		const shouldHide = cmd.includes('hide');
+		user.settings.hideBattlesFromTrainerCard = shouldHide;
+		this.sendReply(`Battles are now ${shouldHide ? "hidden (except to staff)" : "visible"} in your trainer card.`);
 	},
-	displaybattleshelp: [
-		`/nodisplaybattles - Hides your battles in your usercard.`,
-		`/displaybattles - Displays your battles in your usercard.`,
+	hidebattlesfromtrainercardhelp: [
+		`/hidebattlesfromtrainercard - Hides your battles in your trainer card.`,
+		`/showbattlesintrainercard - Displays your battles in your trainer card.`,
 	],
 
 	/*********************************************************
@@ -1377,7 +1379,7 @@ export const commands: ChatCommands = {
 					roomData.isPrivate = true;
 				}
 				if (targetRoom.battle) {
-					if (targetUser.settings.hideBattles && user.id !== targetUser.id && !user.can('lock')) continue;
+					if (targetUser.settings.hideBattlesFromTrainerCard && user.id !== targetUser.id && !user.can('lock')) continue;
 					const battle = targetRoom.battle;
 					roomData.p1 = battle.p1 ? ' ' + battle.p1.name : '';
 					roomData.p2 = battle.p2 ? ' ' + battle.p2.name : '';

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -1321,6 +1321,17 @@ export const commands: ChatCommands = {
 		});
 	},
 
+	nodisplaybattles: 'displaybattles',
+	displaybattles(target, room, user, connection, cmd) {
+		const shouldHide = cmd.includes('no');
+		user.settings.hideBattles = shouldHide;
+		this.sendReply(`Battles are now ${shouldHide ? "hidden (except to staff)" : "visible"} in your usercard.`);
+	},
+	displaybattleshelp: [
+		`/nodisplaybattles - Hides your battles in your usercard.`,
+		`/displaybattles - Displays your battles in your usercard.`,
+	],
+
 	/*********************************************************
 	 * Low-level
 	 *********************************************************/
@@ -1366,6 +1377,7 @@ export const commands: ChatCommands = {
 					roomData.isPrivate = true;
 				}
 				if (targetRoom.battle) {
+					if (targetUser.settings.hideBattles && user.id !== targetUser.id && !user.can('lock')) continue;
 					const battle = targetRoom.battle;
 					roomData.p1 = battle.p1 ? ' ' + battle.p1.name : '';
 					roomData.p2 = battle.p2 ? ' ' + battle.p2.name : '';

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -1327,6 +1327,7 @@ export const commands: ChatCommands = {
 	hidebattlesfromtrainercard(target, room, user, connection, cmd) {
 		const shouldHide = cmd.includes('hide');
 		user.settings.hideBattlesFromTrainerCard = shouldHide;
+		user.update();
 		this.sendReply(`Battles are now ${shouldHide ? "hidden (except to staff)" : "visible"} in your trainer card.`);
 	},
 	hidebattlesfromtrainercardhelp: [

--- a/server/users.ts
+++ b/server/users.ts
@@ -338,7 +338,7 @@ export class User extends Chat.MessageContext {
 		blockChallenges: boolean,
 		blockPMs: boolean | GroupSymbol | 'autoconfirmed' | 'trusted' | 'unlocked',
 		ignoreTickets: boolean,
-		hideBattles: boolean,
+		hideBattlesFromTrainerCard: boolean,
 	};
 
 	battleSettings: {
@@ -424,7 +424,7 @@ export class User extends Chat.MessageContext {
 			blockChallenges: false,
 			blockPMs: false,
 			ignoreTickets: false,
-			hideBattles: false,
+			hideBattlesFromTrainerCard: false,
 		};
 		this.battleSettings = {
 			team: '',

--- a/server/users.ts
+++ b/server/users.ts
@@ -338,6 +338,7 @@ export class User extends Chat.MessageContext {
 		blockChallenges: boolean,
 		blockPMs: boolean | GroupSymbol | 'autoconfirmed' | 'trusted' | 'unlocked',
 		ignoreTickets: boolean,
+		hideBattles: boolean,
 	};
 
 	battleSettings: {
@@ -423,6 +424,7 @@ export class User extends Chat.MessageContext {
 			blockChallenges: false,
 			blockPMs: false,
 			ignoreTickets: false,
+			hideBattles: false,
 		};
 		this.battleSettings = {
 			team: '',


### PR DESCRIPTION
I've heard that some global staff want this feature as a way to prevent people from joining battles by clicking their usercard, without full-on hiding all battles they play in.