### PR TITLE
Send group for punished users in /cmd userdetails

### DIFF
--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -1376,12 +1376,15 @@ export const commands: ChatCommands = {
 				roomList[roomidWithAuth] = roomData;
 			}
 			if (!targetUser.connected) roomList = false;
+			let group = targetUser.group;
+			if (targetUser.locked) group = Config.punishgroups?.locked?.symbol ?? '\u203d';
+			if (targetUser.namelocked) group = Config.punishgroups?.namelocked?.symbol ?? '✖';
 			const userdetails: AnyObject = {
 				id: target,
 				userid: targetUser.id,
 				name: targetUser.name,
 				avatar: targetUser.avatar,
-				group: targetUser.group,
+				group: group,
 				autoconfirmed: !!targetUser.autoconfirmed,
 				status: targetUser.getStatus(),
 				rooms: roomList,


### PR DESCRIPTION
The server-side portion of https://github.com/smogon/pokemon-showdown-client/pull/1568. This might be better restricted to trusted users (since they can use `/checkpunishment`) — personally, I think it's fine since a locked user in a room will have their status publicly visible, but there is an argument otherwise.