### PR TITLE
Don't override a higher rank in personal rooms

### DIFF
--- a/server/user-groups.ts
+++ b/server/user-groups.ts
@@ -182,7 +182,7 @@ export class RoomAuth extends Auth {
 		const symbol = super.getEffectiveSymbol(user);
 		if (!this.room.persist && symbol === user.group) {
 			const replaceGroup = Auth.getGroup(symbol).globalGroupInPersonalRoom;
-			if (replaceGroup) return replaceGroup;
+			if (replaceGroup && Config.groups[replaceGroup]?.rank > Config.groups[symbol]?.rank) return replaceGroup;
 		}
 		return symbol;
 	}


### PR DESCRIPTION
Currently if you set a lower rank's `globalGroupInPersonalRoom` attribute, the higher ranks will inherit that, potentially causing them to have permission issues in personal rooms.