### PR TITLE
Add a throttle for pending challenges

### DIFF
--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -1237,6 +1237,9 @@ export const commands: ChatCommands = {
 		if (Punishments.isBattleBanned(user)) {
 			return this.popupReply(`You are banned from battling and cannot challenge users.`);
 		}
+		if (!user.named || user.namelocked) {
+			return this.popupReply(`Unnamed users cannot challenge.`);
+		}
 		if (Config.pmmodchat) {
 			const userGroup = user.group;
 			if (Config.groupsranking.indexOf(userGroup) < Config.groupsranking.indexOf(Config.pmmodchat as GroupSymbol)) {

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -1237,8 +1237,8 @@ export const commands: ChatCommands = {
 		if (Punishments.isBattleBanned(user)) {
 			return this.popupReply(`You are banned from battling and cannot challenge users.`);
 		}
-		if (!user.named || user.namelocked) {
-			return this.popupReply(`Unnamed users cannot challenge.`);
+		if (!user.named) {
+			return this.popupReply(`You must choose a username before you challenge someone.`);
 		}
 		if (Config.pmmodchat) {
 			const userGroup = user.group;

--- a/server/ladders.ts
+++ b/server/ladders.ts
@@ -249,7 +249,8 @@ class Ladder extends LadderStore {
 			connection.popup(`You challenged less than 10 seconds after your last challenge! It's cancelled in case it's a misclick.`);
 			return false;
 		}
-		if (targetUser.currentChallengeCount >= 3 && !user.autoconfirmed) {
+		const currentChallenges = Ladders.challenges.get(targetUser.id);
+		if (currentChallenges && currentChallenges.length >= 3 && !user.autoconfirmed) {
 			connection.popup(
 				`This user already has 3 pending challenges.\n` +
 				`You must be autoconfirmed to challenge them.`
@@ -289,8 +290,6 @@ class Ladder extends LadderStore {
 		if (Ladder.removeChallenge(chall)) {
 			Ladders.match(chall.ready, ready);
 		}
-		const user = connection.user;
-		user.currentChallengeCount--;
 		return true;
 	}
 
@@ -307,7 +306,6 @@ class Ladder extends LadderStore {
 			const toUser = Users.get(challenge.to);
 			if (toUser) {
 				Ladder.updateChallenges(toUser);
-				toUser.currentChallengeCount++;
 			}
 		}
 	}
@@ -328,7 +326,6 @@ class Ladder extends LadderStore {
 			const toUser = Users.get(challenge.to);
 			if (toUser) {
 				Ladder.updateChallenges(toUser);
-				toUser.currentChallengeCount--;
 			}
 		}
 		return true;

--- a/server/ladders.ts
+++ b/server/ladders.ts
@@ -249,6 +249,13 @@ class Ladder extends LadderStore {
 			connection.popup(`You challenged less than 10 seconds after your last challenge! It's cancelled in case it's a misclick.`);
 			return false;
 		}
+		if (targetUser.currentChallengeCount >= 3 && !user.autoconfirmed) {
+			connection.popup(
+				`This user already has 3 pending challenges.\n` +
+				`You must be autoconfirmed to challenge them.`
+			);
+			return false;
+		}
 		const ready = await this.prepBattle(connection, 'challenge');
 		if (!ready) return false;
 		// If our target is already challenging us in the same format,
@@ -282,6 +289,8 @@ class Ladder extends LadderStore {
 		if (Ladder.removeChallenge(chall)) {
 			Ladders.match(chall.ready, ready);
 		}
+		const user = connection.user;
+		user.currentChallengeCount--;
 		return true;
 	}
 
@@ -296,7 +305,10 @@ class Ladder extends LadderStore {
 			const fromUser = Users.get(challenge.from);
 			if (fromUser) Ladder.updateChallenges(fromUser);
 			const toUser = Users.get(challenge.to);
-			if (toUser) Ladder.updateChallenges(toUser);
+			if (toUser) {
+				Ladder.updateChallenges(toUser);
+				toUser.currentChallengeCount++;
+			}
 		}
 	}
 	static removeChallenge(challenge: Challenge, skipUpdate = false) {
@@ -314,7 +326,10 @@ class Ladder extends LadderStore {
 			const fromUser = Users.get(challenge.from);
 			if (fromUser) Ladder.updateChallenges(fromUser);
 			const toUser = Users.get(challenge.to);
-			if (toUser) Ladder.updateChallenges(toUser);
+			if (toUser) {
+				Ladder.updateChallenges(toUser);
+				toUser.currentChallengeCount--;
+			}
 		}
 		return true;
 	}

--- a/server/ladders.ts
+++ b/server/ladders.ts
@@ -304,9 +304,7 @@ class Ladder extends LadderStore {
 			const fromUser = Users.get(challenge.from);
 			if (fromUser) Ladder.updateChallenges(fromUser);
 			const toUser = Users.get(challenge.to);
-			if (toUser) {
-				Ladder.updateChallenges(toUser);
-			}
+			if (toUser) Ladder.updateChallenges(toUser);
 		}
 	}
 	static removeChallenge(challenge: Challenge, skipUpdate = false) {
@@ -324,9 +322,7 @@ class Ladder extends LadderStore {
 			const fromUser = Users.get(challenge.from);
 			if (fromUser) Ladder.updateChallenges(fromUser);
 			const toUser = Users.get(challenge.to);
-			if (toUser) {
-				Ladder.updateChallenges(toUser);
-			}
+			if (toUser) Ladder.updateChallenges(toUser);
 		}
 		return true;
 	}

--- a/server/users.ts
+++ b/server/users.ts
@@ -382,7 +382,6 @@ export class User extends Chat.MessageContext {
 	statusType: StatusType;
 	userMessage: string;
 	lastWarnedAt: number;
-	currentChallengeCount: number;
 	constructor(connection: Connection) {
 		super(connection.user);
 		this.user = this;
@@ -470,7 +469,6 @@ export class User extends Chat.MessageContext {
 		this.userMessage = '';
 		this.lastWarnedAt = 0;
 
-		this.currentChallengeCount = 0;
 		// initialize
 		Users.add(this);
 	}

--- a/server/users.ts
+++ b/server/users.ts
@@ -382,6 +382,7 @@ export class User extends Chat.MessageContext {
 	statusType: StatusType;
 	userMessage: string;
 	lastWarnedAt: number;
+	currentChallengeCount: number;
 	constructor(connection: Connection) {
 		super(connection.user);
 		this.user = this;
@@ -469,6 +470,7 @@ export class User extends Chat.MessageContext {
 		this.userMessage = '';
 		this.lastWarnedAt = 0;
 
+		this.currentChallengeCount = 0;
 		// initialize
 		Users.add(this);
 	}


### PR DESCRIPTION
This is to resolve an issue where a user would be spammed by challenges from unregged bot accounts until their browser crashed. 
This PR:
- prevents unnamed users from challenging 
- Prevents a user from being challenged by a non-autoconfirmed user if they already have 3 challenges pending.
In short, should stop users from spambot-challenging.