### PR TITLE
Remove User#authAtLeast and add more sysop bypasses

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -288,12 +288,12 @@ exports.restrictLinks = false;
 exports.chatmodchat = false;
 /**
  * battle modchat - default minimum group for speaking in battles; changeable with /modchat
- * @type {false | string}
+ * @type {false | AuthLevel}
  */
 exports.battlemodchat = false;
 /**
- * pm modchat - minimum group for PMing other users, challenging other users
- * @type {false | string}
+ * PM modchat - minimum group for sending private messages or challenges to other users
+ * @type {false | AuthLevel}
  */
 exports.pmmodchat = false;
 /**

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -1223,7 +1223,7 @@ export const commands: ChatCommands = {
 	async search(target, room, user, connection) {
 		if (target) {
 			if (Config.laddermodchat) {
-				if (!Users.globalAuth.atLeast(user, Config.laddermodchat)) {
+				if (!user.isSysop && !Users.globalAuth.atLeast(user, Config.laddermodchat)) {
 					const groupName = Config.groups[Config.laddermodchat].name || Config.laddermodchat;
 					this.popupReply(`On this server, you must be of rank ${groupName} or higher to search for a battle.`);
 					return false;
@@ -1266,7 +1266,7 @@ export const commands: ChatCommands = {
 			return this.popupReply(`You must choose a username before you challenge someone.`);
 		}
 		if (Config.pmmodchat) {
-			if (Users.globalAuth.atLeast(user, Config.pmmodchat as GroupSymbol)) {
+			if (!user.isSysop && !Users.globalAuth.atLeast(user, Config.pmmodchat as GroupSymbol)) {
 				const groupName = Config.groups[Config.pmmodchat].name || Config.pmmodchat;
 				this.popupReply(`Because moderated chat is set, you must be of rank ${groupName} or higher to challenge users.`);
 				return false;

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -1222,12 +1222,10 @@ export const commands: ChatCommands = {
 
 	async search(target, room, user, connection) {
 		if (target) {
-			if (Config.laddermodchat) {
-				if (!user.hasSysopAccess() && !Users.globalAuth.atLeast(user, Config.laddermodchat)) {
-					const groupName = Config.groups[Config.laddermodchat].name || Config.laddermodchat;
-					this.popupReply(`On this server, you must be of rank ${groupName} or higher to search for a battle.`);
-					return false;
-				}
+			if (Config.laddermodchat && !user.hasSysopAccess() && !Users.globalAuth.atLeast(user, Config.laddermodchat)) {
+				const groupName = Config.groups[Config.laddermodchat].name || Config.laddermodchat;
+				this.popupReply(`On this server, you must be of rank ${groupName} or higher to search for a battle.`);
+				return false;
 			}
 			const ladder = Ladders(target);
 			if (!user.registered && Config.forceregisterelo && await ladder.getRating(user.id) >= Config.forceregisterelo) {
@@ -1265,12 +1263,10 @@ export const commands: ChatCommands = {
 		if (!user.named) {
 			return this.popupReply(`You must choose a username before you challenge someone.`);
 		}
-		if (Config.pmmodchat) {
-			if (!user.hasSysopAccess() && !Users.globalAuth.atLeast(user, Config.pmmodchat as GroupSymbol)) {
-				const groupName = Config.groups[Config.pmmodchat].name || Config.pmmodchat;
-				this.popupReply(`Because moderated chat is set, you must be of rank ${groupName} or higher to challenge users.`);
-				return false;
-			}
+		if (Config.pmmodchat &&!user.hasSysopAccess() && !Users.globalAuth.atLeast(user, Config.pmmodchat as GroupSymbol)) {
+			const groupName = Config.groups[Config.pmmodchat].name || Config.pmmodchat;
+			this.popupReply(`Because moderated chat is set, you must be of rank ${groupName} or higher to challenge users.`);
+			return false;
 		}
 		return Ladders(target).makeChallenge(connection, targetUser);
 	},

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -1224,7 +1224,7 @@ export const commands: ChatCommands = {
 		if (target) {
 			if (Config.laddermodchat && !Users.globalAuth.atLeast(user, Config.laddermodchat)) {
 				const groupName = Config.groups[Config.laddermodchat].name || Config.laddermodchat;
-				this.popupReply(`On this server, you must be of rank ${groupName} or higher to search for a battle.`);
+				this.popupReply(`This server requires you to be rank ${groupName} or higher to search for a battle.`);
 				return false;
 			}
 			const ladder = Ladders(target);
@@ -1265,7 +1265,7 @@ export const commands: ChatCommands = {
 		}
 		if (Config.pmmodchat && !user.hasSysopAccess() && !Users.globalAuth.atLeast(user, Config.pmmodchat as GroupSymbol)) {
 			const groupName = Config.groups[Config.pmmodchat].name || Config.pmmodchat;
-			this.popupReply(`Because moderated chat is set, you must be of rank ${groupName} or higher to challenge users.`);
+			this.popupReply(`This server requires you to be rank ${groupName} or higher to challenge users.`);
 			return false;
 		}
 		return Ladders(target).makeChallenge(connection, targetUser);

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -1223,7 +1223,7 @@ export const commands: ChatCommands = {
 	async search(target, room, user, connection) {
 		if (target) {
 			if (Config.laddermodchat) {
-				if (!user.isSysop && !Users.globalAuth.atLeast(user, Config.laddermodchat)) {
+				if (!user.hasSysopAccess() && !Users.globalAuth.atLeast(user, Config.laddermodchat)) {
 					const groupName = Config.groups[Config.laddermodchat].name || Config.laddermodchat;
 					this.popupReply(`On this server, you must be of rank ${groupName} or higher to search for a battle.`);
 					return false;
@@ -1266,7 +1266,7 @@ export const commands: ChatCommands = {
 			return this.popupReply(`You must choose a username before you challenge someone.`);
 		}
 		if (Config.pmmodchat) {
-			if (!user.isSysop && !Users.globalAuth.atLeast(user, Config.pmmodchat as GroupSymbol)) {
+			if (!user.hasSysopAccess() && !Users.globalAuth.atLeast(user, Config.pmmodchat as GroupSymbol)) {
 				const groupName = Config.groups[Config.pmmodchat].name || Config.pmmodchat;
 				this.popupReply(`Because moderated chat is set, you must be of rank ${groupName} or higher to challenge users.`);
 				return false;

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -1222,7 +1222,7 @@ export const commands: ChatCommands = {
 
 	async search(target, room, user, connection) {
 		if (target) {
-			if (Config.laddermodchat && !user.hasSysopAccess() && !Users.globalAuth.atLeast(user, Config.laddermodchat)) {
+			if (Config.laddermodchat && !Users.globalAuth.atLeast(user, Config.laddermodchat)) {
 				const groupName = Config.groups[Config.laddermodchat].name || Config.laddermodchat;
 				this.popupReply(`On this server, you must be of rank ${groupName} or higher to search for a battle.`);
 				return false;

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -572,8 +572,8 @@ export const commands: ChatCommands = {
 		if (user.settings.blockPMs === (target || true)) {
 			return this.errorReply(this.tr("You are already blocking private messages! To unblock, use /unblockpms"));
 		}
-		if (target in Config.groups) {
-			user.settings.blockPMs = target as GroupSymbol;
+		if (Users.Auth.isAuthLevel(target)) {
+			user.settings.blockPMs = target;
 			this.sendReply(this.tr `You are now blocking private messages, except from staff and ${target}.`);
 		} else if (target === 'autoconfirmed' || target === 'trusted' || target === 'unlocked') {
 			user.settings.blockPMs = target;
@@ -748,7 +748,7 @@ export const commands: ChatCommands = {
 			for (const setting in user.settings) {
 				if (setting in raw) {
 					if (setting === 'blockPMs' &&
-						(raw[setting] in Config.groups || ['autoconfirmed', 'trusted', 'unlocked'].includes(raw[setting]))) {
+						Users.Auth.isAuthLevel(raw[setting])) {
 						settings[setting] = raw[setting];
 					} else {
 						settings[setting as keyof UserSettings] = !!raw[setting];

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -1263,7 +1263,7 @@ export const commands: ChatCommands = {
 		if (!user.named) {
 			return this.popupReply(`You must choose a username before you challenge someone.`);
 		}
-		if (Config.pmmodchat &&!user.hasSysopAccess() && !Users.globalAuth.atLeast(user, Config.pmmodchat as GroupSymbol)) {
+		if (Config.pmmodchat && !user.hasSysopAccess() && !Users.globalAuth.atLeast(user, Config.pmmodchat as GroupSymbol)) {
 			const groupName = Config.groups[Config.pmmodchat].name || Config.pmmodchat;
 			this.popupReply(`Because moderated chat is set, you must be of rank ${groupName} or higher to challenge users.`);
 			return false;

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -100,7 +100,7 @@ export const commands: ChatCommands = {
 			if (!Users.Auth.hasPermission(user, 'modchat', target as GroupSymbol, room)) {
 				return this.errorReply(`/modchat - Access denied for setting to ${target}.`);
 			}
-			room.settings.modchat = target;
+			room.settings.modchat = target as AuthLevel;
 			break;
 		}
 		if (currentModchat === room.settings.modchat) {
@@ -211,7 +211,7 @@ export const commands: ChatCommands = {
 				return this.errorReply(`/modjoin - Access denied from setting modjoin past % in group chats.`);
 			}
 			if (room.settings.modjoin === target) return this.errorReply(`Modjoin is already set to ${target} in this room.`);
-			room.settings.modjoin = target;
+			room.settings.modjoin = target as AuthLevel;
 			this.add(`|raw|<div class="broadcast-red"><strong>This room is now invite only!</strong><br />Users must be rank ${target} or invited with <code>/invite</code> to join</div>`);
 			this.addModAction(`${user.name} set modjoin to ${target}.`);
 			this.modlog('MODJOIN', null, target);

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -1560,7 +1560,7 @@ export const pages: PageTable = {
 		this.title = `[Permissions]`;
 		const room = this.extractRoom();
 		if (!room) return `<h2>This room does not exist or does not support permissions.</h2>`;
-		if (!user.authAtLeast('%', room)) return `<h2>Access denied.</h2>`;
+		if (!room.auth.atLeast(user, '%')) return `<h2>Access denied.</h2>`;
 
 		const roomGroups = ['default', ...Config.groupsranking.slice(1)];
 		const permissions = room.settings.permissions || {};
@@ -1573,7 +1573,7 @@ export const pages: PageTable = {
 			const requiredRank = permissions[permission];
 			atLeastOne = true;
 			buf += `<tr><td><strong>${permission}</strong></td><td>`;
-			if (user.authAtLeast('#', room)) {
+			if (room.auth.atLeast(user, '#')) {
 				buf += roomGroups.map(group => (
 					requiredRank === group ?
 						Utils.html`<button class="button disabled" style="font-weight:bold;color:#575757;background:#d3d3d3">${group}</button>` :

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -93,14 +93,14 @@ export const commands: ChatCommands = {
 			target = Users.PLAYER_SYMBOL;
 			/* falls through */
 		default:
-			if (!Config.groups[target]) {
+			if (!Users.Auth.isAuthLevel(target)) {
 				this.errorReply(`The rank '${target}' was unrecognized as a modchat level.`);
 				return this.parse('/help modchat');
 			}
 			if (!Users.Auth.hasPermission(user, 'modchat', target as GroupSymbol, room)) {
 				return this.errorReply(`/modchat - Access denied for setting to ${target}.`);
 			}
-			room.settings.modchat = target as AuthLevel;
+			room.settings.modchat = target;
 			break;
 		}
 		if (currentModchat === room.settings.modchat) {
@@ -203,7 +203,7 @@ export const commands: ChatCommands = {
 			this.add(`|raw|<div class="broadcast-red"><strong>Moderated join is set to autoconfirmed!</strong><br />Users must be rank autoconfirmed or invited with <code>/invite</code> to join</div>`);
 			this.addModAction(`${user.name} set modjoin to autoconfirmed.`);
 			this.modlog('MODJOIN', null, 'autoconfirmed');
-		} else if (target in Config.groups || target === 'trusted') {
+		} else if (Users.Auth.isAuthLevel(target)) {
 			if (room.battle && !user.can('makeroom') && !'+%'.includes(target)) {
 				return this.errorReply(`/modjoin - Access denied from setting modjoin past % in battles.`);
 			}
@@ -211,7 +211,7 @@ export const commands: ChatCommands = {
 				return this.errorReply(`/modjoin - Access denied from setting modjoin past % in group chats.`);
 			}
 			if (room.settings.modjoin === target) return this.errorReply(`Modjoin is already set to ${target} in this room.`);
-			room.settings.modjoin = target as AuthLevel;
+			room.settings.modjoin = target;
 			this.add(`|raw|<div class="broadcast-red"><strong>This room is now invite only!</strong><br />Users must be rank ${target} or invited with <code>/invite</code> to join</div>`);
 			this.addModAction(`${user.name} set modjoin to ${target}.`);
 			this.modlog('MODJOIN', null, target);

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -108,7 +108,6 @@ import {formatText, linkRegex, stripFormatting} from './chat-formatter';
 
 // @ts-ignore no typedef available
 import ProbeModule = require('probe-image-size');
-import {ExtendedGroup} from './user-groups';
 const probe: (url: string) => Promise<{width: number, height: number}> = ProbeModule;
 
 const EMOJI_REGEX = /[\p{Emoji_Modifier_Base}\p{Emoji_Presentation}\uFE0F]/u;
@@ -944,7 +943,7 @@ export class CommandContext extends MessageContext {
 					this.errorReply(this.tr(`You are muted and cannot talk in this room.`));
 					return null;
 				}
-				if (room.settings.modchat && !room.auth.atLeast(user, room.settings.modchat as ExtendedGroup)) {
+				if (room.settings.modchat && !room.auth.atLeast(user, room.settings.modchat)) {
 					if (room.settings.modchat === 'autoconfirmed') {
 						this.errorReply(
 							this.tr(
@@ -986,7 +985,7 @@ export class CommandContext extends MessageContext {
 					this.errorReply(`The user "${targetUser.name}" is locked and cannot be PMed.`);
 					return null;
 				}
-				if (Config.pmmodchat && !Users.globalAuth.atLeast(user, Config.pmmodchat as ExtendedGroup) &&
+				if (Config.pmmodchat && !Users.globalAuth.atLeast(user, Config.pmmodchat) &&
 					!Users.Auth.hasPermission(targetUser, 'promote', Config.pmmodchat as GroupSymbol)) {
 					const groupName = Config.groups[Config.pmmodchat] && Config.groups[Config.pmmodchat].name || Config.pmmodchat;
 					this.errorReply(`On this server, you must be of rank ${groupName} or higher to PM users.`);

--- a/server/global-types.ts
+++ b/server/global-types.ts
@@ -1,6 +1,7 @@
 type Config = typeof import('../config/config-example') & AnyObject;
 
 type GroupSymbol = import('./user-groups').GroupSymbol;
+type AuthLevel = import('./user-groups').AuthLevel;
 
 /** not actually guaranteed to be one of these */
 type PunishType = '#chatfilter' | '#hostfilter' | '#dnsbl' | '#ipban';

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -469,6 +469,7 @@ export abstract class BasicRoom {
 		Rooms.global.writeChatRoomData();
 	}
 	checkModjoin(user: User) {
+		if (user.hasSysopAccess()) return true;
 		if (user.id in this.users) return true;
 		if (!this.settings.modjoin) return true;
 		// users with a room rank can always join
@@ -489,7 +490,7 @@ export abstract class BasicRoom {
 		}
 		if (!(userGroup in Config.groups)) return false;
 		if (!(modjoinGroup in Config.groups)) throw new Error(`Invalid modjoin setting in ${this.roomid}: ${modjoinGroup}`);
-		return Config.groups[userGroup].rank >= Config.groups[modjoinGroup].rank || user.isSysop;
+		return Config.groups[userGroup].rank >= Config.groups[modjoinGroup].rank;
 	}
 	mute(user: User, setTime?: number) {
 		const userid = user.id;

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -36,7 +36,7 @@ import {PM as RoomBattlePM, RoomBattle, RoomBattlePlayer, RoomBattleTimer} from 
 import {RoomGame, RoomGamePlayer} from './room-game';
 import {Roomlogs} from './roomlogs';
 import * as crypto from 'crypto';
-import {RoomAuth, ExtendedGroup} from './user-groups';
+import {RoomAuth} from './user-groups';
 
 /*********************************************************
  * the Room object.
@@ -76,8 +76,8 @@ export interface RoomSettings {
 	aliases?: string[];
 	banwords?: string[];
 	isPrivate?: boolean | 'hidden' | 'voice';
-	modjoin?: string | true | null;
-	modchat?: string | null;
+	modjoin?: AuthLevel | true | null;
+	modchat?: AuthLevel | null;
 	staffRoom?: boolean;
 	language?: string | false;
 	slowchat?: number | false;
@@ -478,7 +478,7 @@ export abstract class BasicRoom {
 		if (!modjoinSetting) return true;
 		if (!(modjoinSetting in Config.groups)) throw new Error(`Invalid modjoin setting in ${this.roomid}: ${modjoinSetting}`);
 
-		return Users.globalAuth.atLeast(user, modjoinSetting as ExtendedGroup);
+		return Users.globalAuth.atLeast(user, modjoinSetting);
 	}
 	mute(user: User, setTime?: number) {
 		const userid = user.id;
@@ -585,7 +585,7 @@ export abstract class BasicRoom {
 		this.destroy();
 	}
 	reportJoin(type: 'j' | 'l' | 'n', entry: string, user: User) {
-		const canTalk = this.auth.atLeast(user, (this.settings.modchat ?? 'unlocked') as ExtendedGroup) && !this.isMuted(user);
+		const canTalk = this.auth.atLeast(user, this.settings.modchat ?? 'unlocked') && !this.isMuted(user);
 		if (this.reportJoins && (canTalk || this.auth.has(user.id))) {
 			this.add(`|${type}|${entry}`).update();
 			return;

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -489,7 +489,7 @@ export abstract class BasicRoom {
 		}
 		if (!(userGroup in Config.groups)) return false;
 		if (!(modjoinGroup in Config.groups)) throw new Error(`Invalid modjoin setting in ${this.roomid}: ${modjoinGroup}`);
-		return Config.groups[userGroup].rank >= Config.groups[modjoinGroup].rank;
+		return Config.groups[userGroup].rank >= Config.groups[modjoinGroup].rank || user.isSysop;
 	}
 	mute(user: User, setTime?: number) {
 		const userid = user.id;

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -476,8 +476,9 @@ export abstract class BasicRoom {
 
 		const modjoinSetting = this.settings.modjoin !== true ? this.settings.modjoin : this.settings.modchat;
 		if (!modjoinSetting) return true;
-		if (!(modjoinSetting in Config.groups)) throw new Error(`Invalid modjoin setting in ${this.roomid}: ${modjoinSetting}`);
-
+		if (!Users.Auth.isAuthLevel(modjoinSetting)) {
+			Monitor.error(`Invalid modjoin setting in ${this.roomid}: ${modjoinSetting}`);
+		}
 		return Users.globalAuth.atLeast(user, modjoinSetting);
 	}
 	mute(user: User, setTime?: number) {

--- a/server/user-groups.ts
+++ b/server/user-groups.ts
@@ -185,6 +185,10 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 		if (symbol.length !== 1) return false;
 		return !/[A-Za-z0-9|,]/.test(symbol);
 	}
+	static isAuthLevel(level: string): level is AuthLevel {
+		if (this.isValidSymbol(level)) return true;
+		return ['unlocked', 'trusted', 'autoconfirmed', 'whitelist'].includes(level);
+	}
 	static ROOM_PERMISSIONS = ROOM_PERMISSIONS;
 	static GLOBAL_PERMISSIONS = GLOBAL_PERMISSIONS;
 }

--- a/server/user-groups.ts
+++ b/server/user-groups.ts
@@ -2,6 +2,7 @@ import {FS} from '../lib/fs';
 
 export type GroupSymbol = '~' | '&' | '#' | '★' | '*' | '@' | '%' | '☆' | '+' | ' ' | '‽' | '!';
 export type EffectiveGroupSymbol = GroupSymbol | 'whitelist';
+export type ExtendedGroup = EffectiveGroupSymbol | 'unlocked' | 'trusted' | 'autoconfirmed';
 
 export const PLAYER_SYMBOL: GroupSymbol = '\u2606';
 export const HOST_SYMBOL: GroupSymbol = '\u2605';
@@ -58,9 +59,16 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 	isStaff(userid: ID) {
 		return this.has(userid) && this.get(userid) !== '+';
 	}
-	atLeast(user: User, group: GroupSymbol, isPermissionCheck?: boolean) {
-		if (!Config.groups[group]) return false;
+	atLeast(user: User, group: ExtendedGroup, isPermissionCheck?: boolean) {
+		if (user.hasSysopAccess()) return true;
+		if (group === 'trusted' || group === 'autoconfirmed') {
+			if (user.trusted && group === 'trusted') return true;
+			if (user.autoconfirmed && group === 'autoconfirmed') return true;
+			group = Config.groupsranking[1];
+		}
 		if (user.locked || user.semilocked) return false;
+		if (group === 'unlocked') return true;
+		if (!Config.groups[group]) return false;
 		if (this.get(user.id) === ' ' && group !== ' ') return false;
 		if (Auth.atLeast(this.get(user.id, true), group)) {
 			return true;
@@ -109,7 +117,9 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 
 		const symbol = auth.getEffectiveSymbol(user, useVisualGroup);
 		let targetSymbol = (typeof target === 'string' || !target) ? target : auth.get(target);
-		if (targetSymbol === 'whitelist') targetSymbol = Auth.defaultSymbol();
+		if (!targetSymbol || ['whitelist', 'trusted', 'autoconfirmed'].includes(targetSymbol)) {
+			targetSymbol = Auth.defaultSymbol();
+		}
 
 		const group = Auth.getGroup(symbol);
 		if (group['root']) return true;
@@ -129,7 +139,7 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 			}
 		}
 
-		return Auth.hasJurisdiction(symbol, jurisdiction, targetSymbol);
+		return Auth.hasJurisdiction(symbol, jurisdiction, targetSymbol as GroupSymbol);
 	}
 	static atLeast(symbol: EffectiveGroupSymbol, symbol2: EffectiveGroupSymbol) {
 		return Auth.getGroup(symbol).rank >= Auth.getGroup(symbol2).rank;

--- a/server/user-groups.ts
+++ b/server/user-groups.ts
@@ -2,7 +2,7 @@ import {FS} from '../lib/fs';
 
 export type GroupSymbol = '~' | '&' | '#' | '★' | '*' | '@' | '%' | '☆' | '+' | ' ' | '‽' | '!';
 export type EffectiveGroupSymbol = GroupSymbol | 'whitelist';
-export type ExtendedGroup = EffectiveGroupSymbol | 'unlocked' | 'trusted' | 'autoconfirmed';
+export type AuthLevel = EffectiveGroupSymbol | 'unlocked' | 'trusted' | 'autoconfirmed';
 
 export const PLAYER_SYMBOL: GroupSymbol = '\u2606';
 export const HOST_SYMBOL: GroupSymbol = '\u2605';
@@ -59,7 +59,7 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 	isStaff(userid: ID) {
 		return this.has(userid) && this.get(userid) !== '+';
 	}
-	atLeast(user: User, group: ExtendedGroup, isPermissionCheck?: boolean) {
+	atLeast(user: User, group: AuthLevel, isPermissionCheck?: boolean) {
 		if (user.hasSysopAccess()) return true;
 		if (group === 'trusted' || group === 'autoconfirmed') {
 			if (user.trusted && group === 'trusted') return true;

--- a/server/users.ts
+++ b/server/users.ts
@@ -531,21 +531,6 @@ export class User extends Chat.MessageContext {
 		const status = statusMessage + (this.userMessage || '');
 		return status;
 	}
-	authAtLeast(minAuth: string, room: BasicRoom | null = null) {
-		if (this.hasSysopAccess()) return true;
-		if (!minAuth || minAuth === ' ') return true;
-		if (this.locked || this.semilocked) return false;
-		if (minAuth === 'unlocked') return true;
-		if (minAuth === 'trusted' && this.trusted) return true;
-		if (minAuth === 'autoconfirmed' && this.autoconfirmed) return true;
-
-		if (minAuth === 'trusted' || minAuth === 'autoconfirmed') {
-			minAuth = Config.groupsranking[1];
-		}
-		if (!(minAuth in Config.groups)) return false;
-		const auth = (room && !this.can('makeroom') ? room.auth.get(this.id) : this.group);
-		return auth in Config.groups && Config.groups[auth].rank >= Config.groups[minAuth].rank;
-	}
 	can(permission: RoomPermission, target: User | null, room: BasicRoom, cmd?: string, useVisualGroup?: boolean): boolean;
 	can(
 		permission: GlobalPermission,

--- a/server/users.ts
+++ b/server/users.ts
@@ -532,7 +532,7 @@ export class User extends Chat.MessageContext {
 		return status;
 	}
 	authAtLeast(minAuth: string, room: BasicRoom | null = null) {
-		if (!minAuth || minAuth === ' ' || this.isSysop) return true;
+		if (!minAuth || minAuth === ' ' || this.hasSysopAccess()) return true;
 		if (this.locked || this.semilocked) return false;
 		if (minAuth === 'unlocked') return true;
 		if (minAuth === 'trusted' && this.trusted) return true;
@@ -1360,7 +1360,7 @@ export class User extends Chat.MessageContext {
 	chat(message: string, room: Room | null, connection: Connection) {
 		const now = Date.now();
 
-		if (message.startsWith('/cmd userdetails') || message.startsWith('>> ') || this.isSysop) {
+		if (message.startsWith('/cmd userdetails') || message.startsWith('>> ') || this.hasSysopAccess()) {
 			// certain commands are exempt from the queue
 			Monitor.activeIp = connection.ip;
 			Chat.parse(message, room, this, connection);

--- a/server/users.ts
+++ b/server/users.ts
@@ -532,7 +532,8 @@ export class User extends Chat.MessageContext {
 		return status;
 	}
 	authAtLeast(minAuth: string, room: BasicRoom | null = null) {
-		if (!minAuth || minAuth === ' ' || this.hasSysopAccess()) return true;
+		if (this.hasSysopAccess()) return true;
+		if (!minAuth || minAuth === ' ') return true;
 		if (this.locked || this.semilocked) return false;
 		if (minAuth === 'unlocked') return true;
 		if (minAuth === 'trusted' && this.trusted) return true;
@@ -1365,7 +1366,7 @@ export class User extends Chat.MessageContext {
 			Monitor.activeIp = connection.ip;
 			Chat.parse(message, room, this, connection);
 			Monitor.activeIp = null;
-			if (this.isSysop) return;
+			if (this.hasSysopAccess()) return;
 			return false; // but end the loop here
 		}
 

--- a/server/users.ts
+++ b/server/users.ts
@@ -343,7 +343,7 @@ export class User extends Chat.MessageContext {
 
 	settings: {
 		blockChallenges: boolean,
-		blockPMs: boolean | GroupSymbol | 'autoconfirmed' | 'trusted' | 'unlocked',
+		blockPMs: boolean | AuthLevel,
 		ignoreTickets: boolean,
 		hideBattlesFromTrainerCard: boolean,
 	};

--- a/server/users.ts
+++ b/server/users.ts
@@ -532,7 +532,7 @@ export class User extends Chat.MessageContext {
 		return status;
 	}
 	authAtLeast(minAuth: string, room: BasicRoom | null = null) {
-		if (!minAuth || minAuth === ' ') return true;
+		if (!minAuth || minAuth === ' ' || this.isSysop) return true;
 		if (this.locked || this.semilocked) return false;
 		if (minAuth === 'unlocked') return true;
 		if (minAuth === 'trusted' && this.trusted) return true;


### PR DESCRIPTION
This ~~allows global staff to set modchat up to % in battles, and~~ allows sysops to bypass a few permissions checks that they previously weren't able to.