### PR TITLE
Implement a /cleartext command

### DIFF
--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -1579,7 +1579,7 @@ export const commands: ChatCommands = {
 		`/hidealtstext [username], [optional reason] - Removes a user's messages and their alternate accounts' messages from the chat, with an optional reason.  Requires: % @ # &`,
 		`/hidelines [username], [number], [optional reason] - Removes the [number] most recent messages from a user, with an optional reason. Requires: % @ # &`,
 		`/cleartext [username], [optional reason] - Removes a user's messages from chat, and doesn't show a button to reveal them. Requires: % @ # &`,
-		`/clearlines [username], [number], [optional reason] - Like /cleartext, but only clears [number] lines. Requires: % @ & #`,
+		`/clearlines [username], [number], [optional reason] - Like /cleartext, but only clears [number] lines. Requires: % @ # &`,
 	],
 
 	ab: 'blacklist',

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -1512,10 +1512,15 @@ export const commands: ChatCommands = {
 	hidelines: 'hidetext',
 	forcehidelines: 'hidetext',
 	hlines: 'hidetext',
+	cleartext: 'hidetext',
+	clearlines: 'hidetext',
+	forcecleartext: 'hidetext',
+	forceclearlines: 'hidetext',
 	hidetext(target, room, user, connection, cmd) {
 		if (!target) return this.parse(`/help hidetext`);
 		if (!room) return this.requiresRoom();
 		const hasLineCount = cmd.includes('lines');
+		const hideRevealButton = cmd.includes('clear');
 		target = this.splitTarget(target);
 		let lineCount = 0;
 		if (/^[0-9]+\s*(,|$)/.test(target)) {
@@ -1566,13 +1571,15 @@ export const commands: ChatCommands = {
 				room.send(`|c|~|${name}'s messages were cleared from ${room.title} by ${user.name}.${(reason ? ` (${reason})` : ``)}`);
 			}
 			this.modlog('HIDETEXT', targetUser || userid, reason, {noip: 1, noalts: 1});
-			room.hideText([userid], lineCount);
+			room.hideText([userid], lineCount, hideRevealButton);
 		}
 	},
 	hidetexthelp: [
 		`/hidetext [username], [optional reason] - Removes a user's messages from chat, with an optional reason. Requires: % @ # &`,
 		`/hidealtstext [username], [optional reason] - Removes a user's messages and their alternate accounts' messages from the chat, with an optional reason.  Requires: % @ # &`,
 		`/hidelines [username], [number], [optional reason] - Removes the [number] most recent messages from a user, with an optional reason. Requires: % @ # &`,
+		`/cleartext [username], [optional reason] - Removes a user's messages from chat, and doesn't show a button to reveal them. Requires: % @ # &`,
+		`/clearlines [username], [number], [optional reason] - Like /cleartext, but only clears [number] lines. Requires: % @ & #`,
 	],
 
 	ab: 'blacklist',

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -431,8 +431,8 @@ export const commands: ChatCommands = {
 		targetUser.send(`|c|~|/warn ${target}`);
 
 		const userid = targetUser.getLastId();
-		this.add(`|unlink|${userid}`);
-		if (userid !== toID(this.inputUsername)) this.add(`|unlink|${toID(this.inputUsername)}`);
+		this.add(`|hidelines|unlink|${userid}`);
+		if (userid !== toID(this.inputUsername)) this.add(`|hidelines|unlink|${toID(this.inputUsername)}`);
 
 		targetUser.lastWarnedAt = now;
 
@@ -526,8 +526,8 @@ export const commands: ChatCommands = {
 			this.privateModAction(displayMessage);
 		}
 		const userid = targetUser.getLastId();
-		this.add(`|unlink|${userid}`);
-		if (userid !== toID(this.inputUsername)) this.add(`|unlink|${toID(this.inputUsername)}`);
+		this.add(`|hidelines|unlink|${userid}`);
+		if (userid !== toID(this.inputUsername)) this.add(`|hidelines|unlink|${toID(this.inputUsername)}`);
 
 		room.mute(targetUser, muteDuration);
 	},
@@ -924,7 +924,7 @@ export const commands: ChatCommands = {
 			displayMessage = `${name}'s ${(acAccount ? `ac account: ${acAccount}, ` : ``)} banned alts: ${affectedAlts.join(", ")} ${(guests ? ` [${guests} guests]` : ``)}`;
 			this.privateModAction(displayMessage);
 			for (const id of affectedAlts) {
-				this.add(`|unlink|${toID(id)}`);
+				this.add(`|hidelines|unlink|${toID(id)}`);
 			}
 		} else if (acAccount) {
 			displayMessage = `${name}'s ac account: ${acAccount}`;

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -342,7 +342,7 @@ export abstract class BasicRoom {
 	hideText(userids: ID[], lineCount = 0, hideRevealButton?: boolean) {
 		const cleared = this.log.clearText(userids, lineCount);
 		for (const userid of cleared) {
-			this.send(`|unlink|${hideRevealButton ? 'clear' : 'hide'}|${userid}|${lineCount}`);
+			this.send(`|hidelines|${hideRevealButton ? 'delete' : 'hide'}|${userid}|${lineCount}`);
 		}
 		this.update();
 	}

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -342,7 +342,8 @@ export abstract class BasicRoom {
 	hideText(userids: ID[], lineCount = 0, hideRevealButton?: boolean) {
 		const cleared = this.log.clearText(userids, lineCount);
 		for (const userid of cleared) {
-			this.send(`|hidelines|${hideRevealButton ? 'delete' : 'hide'}|${userid}|${lineCount}`);
+			const showRevealButton = !hideRevealButton || Users.globalAuth.isStaff(userid) || this.auth.isStaff(userid);
+			this.send(`|hidelines|${showRevealButton ? 'hide' : 'delete'}|${userid}|${lineCount}`);
 		}
 		this.update();
 	}

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -339,10 +339,10 @@ export abstract class BasicRoom {
 	attributedUhtmlchange(user: User, name: string, message: string) {
 		this.log.attributedUhtmlchange(user, name, message);
 	}
-	hideText(userids: ID[], lineCount = 0) {
+	hideText(userids: ID[], lineCount = 0, hideRevealButton?: boolean) {
 		const cleared = this.log.clearText(userids, lineCount);
 		for (const userid of cleared) {
-			this.send(`|unlink|hide|${userid}|${lineCount}`);
+			this.send(`|unlink|${hideRevealButton ? 'clear' : 'hide'}|${userid}|${lineCount}`);
 		}
 		this.update();
 	}


### PR DESCRIPTION
This command will allow staff to clear messages while telling the client not to show a reveal button. 
Requires client support in the form of https://github.com/smogon/pokemon-showdown-client/pull/1572.