### PR TITLE
Display join/leave messages for locked players

### DIFF
--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -594,7 +594,7 @@ export abstract class BasicRoom {
 	}
 	reportJoin(type: 'j' | 'l' | 'n', entry: string, user: User) {
 		const canTalk = user.authAtLeast(this.settings.modchat ?? 'unlocked', this) && !this.isMuted(user);
-		if (this.reportJoins && (canTalk || this.auth.get(user) === Users.PLAYER_SYMBOL)) {
+		if (this.reportJoins && (canTalk || this.auth.has(user))) {
 			this.add(`|${type}|${entry}`).update();
 			return;
 		}

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -35,7 +35,7 @@ import {PM as RoomBattlePM, RoomBattle, RoomBattlePlayer, RoomBattleTimer} from 
 import {RoomGame, RoomGamePlayer} from './room-game';
 import {Roomlogs} from './roomlogs';
 import * as crypto from 'crypto';
-import {RoomAuth} from './user-groups';
+import {RoomAuth, PLAYER_SYMBOL} from './user-groups';
 
 /*********************************************************
  * the Room object.
@@ -594,7 +594,7 @@ export abstract class BasicRoom {
 	}
 	reportJoin(type: 'j' | 'l' | 'n', entry: string, user: User) {
 		const canTalk = user.authAtLeast(this.settings.modchat ?? 'unlocked', this) && !this.isMuted(user);
-		if (this.reportJoins && canTalk) {
+		if (this.reportJoins && (canTalk || this.auth.get(user) === PLAYER_SYMBOL)) {
 			this.add(`|${type}|${entry}`).update();
 			return;
 		}

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -35,7 +35,7 @@ import {PM as RoomBattlePM, RoomBattle, RoomBattlePlayer, RoomBattleTimer} from 
 import {RoomGame, RoomGamePlayer} from './room-game';
 import {Roomlogs} from './roomlogs';
 import * as crypto from 'crypto';
-import {RoomAuth, PLAYER_SYMBOL} from './user-groups';
+import {RoomAuth} from './user-groups';
 
 /*********************************************************
  * the Room object.
@@ -594,7 +594,7 @@ export abstract class BasicRoom {
 	}
 	reportJoin(type: 'j' | 'l' | 'n', entry: string, user: User) {
 		const canTalk = user.authAtLeast(this.settings.modchat ?? 'unlocked', this) && !this.isMuted(user);
-		if (this.reportJoins && (canTalk || this.auth.get(user) === PLAYER_SYMBOL)) {
+		if (this.reportJoins && (canTalk || this.auth.get(user) === Users.PLAYER_SYMBOL)) {
 			this.add(`|${type}|${entry}`).update();
 			return;
 		}

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -594,7 +594,7 @@ export abstract class BasicRoom {
 	}
 	reportJoin(type: 'j' | 'l' | 'n', entry: string, user: User) {
 		const canTalk = user.authAtLeast(this.settings.modchat ?? 'unlocked', this) && !this.isMuted(user);
-		if (this.reportJoins && (canTalk || this.auth.has(user))) {
+		if (this.reportJoins && (canTalk || this.auth.has(user.id))) {
 			this.add(`|${type}|${entry}`).update();
 			return;
 		}


### PR DESCRIPTION
This should fix the bugs about locked users not showing up in the userlist of battle rooms.
(Not letting the join/leave/rename messages of users who can't talk be displayed was originally done to prevent spamming — I assume that the spammers don't actually _play_ the battles? If they do, I can look for another solution.)