### PR TITLE
Helptickets: Stop modlogging to Help room

### DIFF
--- a/server/chat-plugins/modlog-viewer.ts
+++ b/server/chat-plugins/modlog-viewer.ts
@@ -61,6 +61,20 @@ function getMoreButton(
 	}
 }
 
+function getRoomID(id: ModlogID) {
+	switch (id) {
+	case 'helpticket':
+		return 'help-rooms' as ModlogID;
+	case 'groupchat':
+		return 'groupchat-rooms' as ModlogID;
+	case 'battle':
+		return 'battle-rooms' as ModlogID;
+	// more aliases can be added here
+	default:
+		return id;
+	}
+}
+
 function prettifyResults(
 	resultArray: string[], roomid: ModlogID, searchString: string, exactSearch: boolean,
 	addModlogLinks: boolean, hideIps: boolean, maxLines: number, onlyPunishments: boolean
@@ -145,6 +159,7 @@ async function getModlog(
 ) {
 	const targetRoom = Rooms.search(roomid);
 	const user = connection.user;
+	roomid = getRoomID(roomid);
 
 	// permission checking
 	if (roomid === 'all' || roomid === 'public') {

--- a/server/modlog.ts
+++ b/server/modlog.ts
@@ -131,7 +131,7 @@ export class Modlog {
 	}
 
 	getSharedID(roomid: ModlogID): ID | false {
-		return roomid.includes('-') ? toID(roomid.split('-')[0]) : false;
+		return roomid.includes('-') ? `${toID(roomid.split('-')[0])}-rooms` as ID : false;
 	}
 
 	/**


### PR DESCRIPTION
The issue that caused them to log to help room was that when checking shared modlogs, it splits the ID by ``-``. As a result, it got the id `help`, and would write to `modlog_help.txt`. This PR renames shared modlog files to ``[id]-rooms``, so that it doesn't conflict with existing rooms.
Likewise, i've also written a conversion script (https://gist.github.com/mia-pi-git/20b4f501b99445ad592f521776fbf718) to move old ticket entries from the help modlog to the new modlog file. This can also be hotpatchable, someone just needs to force helpticket rooms to set up their modlogStreams again (i can also add that into the script, if that's easier?).