### PR TITLE
Refactor ip and modchat permissions

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -600,7 +600,7 @@ exports.grouplist = [
 
 		globalban: true,
 		ban: true,
-		modchatall: true,
+		modchat: 'a',
 		roomvoice: true,
 		roomwhitelist: true,
 		forcerename: true,
@@ -655,7 +655,7 @@ exports.grouplist = [
 		name: "Voice",
 		inherit: ' ',
 
-		alts: 's',
+		altsself: true,
 		makegroupchat: true,
 		joinbattle: true,
 		show: true,
@@ -669,7 +669,7 @@ exports.grouplist = [
 		name: "Whitelist",
 		inherit: ' ',
 		roomonly: true,
-		alts: 's',
+		altsself: true,
 		show: true,
 		showmedia: true,
 		exportinputlog: true,
@@ -677,7 +677,7 @@ exports.grouplist = [
 	},
 	{
 		symbol: ' ',
-		ip: 's',
+		ipself: true,
 	},
 	{
 		name: 'Locked',

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -1203,8 +1203,7 @@ export const commands: ChatCommands = {
 	async search(target, room, user, connection) {
 		if (target) {
 			if (Config.laddermodchat) {
-				const userGroup = user.group;
-				if (Config.groupsranking.indexOf(userGroup) < Config.groupsranking.indexOf(Config.laddermodchat)) {
+				if (!Users.globalAuth.atLeast(user, Config.laddermodchat)) {
 					const groupName = Config.groups[Config.laddermodchat].name || Config.laddermodchat;
 					this.popupReply(`On this server, you must be of rank ${groupName} or higher to search for a battle.`);
 					return false;
@@ -1247,8 +1246,7 @@ export const commands: ChatCommands = {
 			return this.popupReply(`You must choose a username before you challenge someone.`);
 		}
 		if (Config.pmmodchat) {
-			const userGroup = user.group;
-			if (Config.groupsranking.indexOf(userGroup) < Config.groupsranking.indexOf(Config.pmmodchat as GroupSymbol)) {
+			if (Users.globalAuth.atLeast(user, Config.pmmodchat as GroupSymbol)) {
 				const groupName = Config.groups[Config.pmmodchat].name || Config.pmmodchat;
 				this.popupReply(`Because moderated chat is set, you must be of rank ${groupName} or higher to challenge users.`);
 				return false;

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -81,7 +81,7 @@ export const commands: ChatCommands = {
 		if (!showAll) {
 			return this.sendReplyBox(buf);
 		}
-		const canViewAlts = (user === targetUser || user.can('alts', targetUser));
+		const canViewAlts = (user === targetUser ? user.can('altsself') : user.can('alts', targetUser));
 		const canViewPunishments = canViewAlts ||
 			(room && room.settings.isPrivate !== true && user.can('mute', targetUser, room) && targetUser.id in room.users);
 		const canViewSecretRooms = user === targetUser || (canViewAlts && targetUser.locked) || user.can('makeroom');
@@ -154,12 +154,12 @@ export const commands: ChatCommands = {
 				buf += `<br />Semilocked: ${targetUser.semilocked}`;
 			}
 		}
-		if (user.can('ip', targetUser)) {
+		if (user === targetUser ? user.can('ipself') : user.can('ip', targetUser)) {
 			let ips = Object.keys(targetUser.ips);
 			ips = ips.map(ip => {
 				const status = [];
 				const punishment = Punishments.ips.get(ip);
-				if (user.can('globalban') && punishment) {
+				if (user.can('alts') && punishment) {
 					const [punishType, userid] = punishment;
 					let punishMsg = Punishments.punishmentTypes.get(punishType) || 'punished';
 					if (userid !== targetUser.id) punishMsg += ` as ${userid}`;
@@ -359,7 +359,7 @@ export const commands: ChatCommands = {
 
 	host(target, room, user, connection, cmd) {
 		if (!target) return this.parse('/help host');
-		if (!this.can('globalban')) return;
+		if (!this.can('ip')) return;
 		target = target.trim();
 		if (!net.isIPv4(target)) return this.errorReply('You must pass a valid IPv4 IP to /host.');
 		void IPTools.lookup(target).then(({dnsbl, host, hostType}) => {

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -1769,11 +1769,9 @@ export const commands: ChatCommands = {
 			return this.errorReply(`[${duplicates.join(', ')}] ${Chat.plural(duplicates, "are", "is")} already blacklisted.`);
 		}
 
-		const userRank = Config.groupsranking.indexOf(room.auth.get(user.id));
 		for (const userid of targets) {
 			if (!userid) return this.errorReply(`User '${userid}' is not a valid userid.`);
-			const targetRank = Config.groupsranking.indexOf(room.auth.get(userid));
-			if (targetRank >= userRank) {
+			if (!Users.Auth.hasPermission(user, 'ban', room.auth.get(userid), room)) {
 				return this.errorReply(`/blacklistname - Access denied: ${userid} is of equal or higher authority than you.`);
 			}
 
@@ -1865,7 +1863,7 @@ export const commands: ChatCommands = {
 			}
 		}
 
-		if (user.can('globalban')) {
+		if (user.can('ip')) {
 			const roomIps = Punishments.roomIps.get(room.roomid);
 
 			if (roomIps) {

--- a/server/chat-plugins/lottery.ts
+++ b/server/chat-plugins/lottery.ts
@@ -237,7 +237,7 @@ export const commands: ChatCommands = {
 			if (!lottery) {
 				return this.errorReply('This room does not have a lottery running.');
 			}
-			const canSeeIps = user.can('globalban');
+			const canSeeIps = user.can('ip');
 			const participants = Object.entries(lottery.participants).map(([ip, participant]) => {
 				return `- ${participant}${canSeeIps ? ' (IP: ' + ip + ')' : ''}`;
 			});

--- a/server/config-loader.ts
+++ b/server/config-loader.ts
@@ -32,10 +32,10 @@ export function cacheGroupData(config: ConfigType) {
 	if (config.groups) {
 		// Support for old config groups format.
 		// Should be removed soon.
-		console.error(
+		Monitor.error(
 			`You are using a deprecated version of user group specification in config.\n` +
 			`Support for this will be removed soon.\n` +
-			`Please ensure that you update your config.js to the new format (see config-example.js, line 220).\n`
+			`Please ensure that you update your config.js to the new format (see config-example.js, line 457).\n`
 		);
 	} else {
 		config.punishgroups = Object.create(null);
@@ -48,24 +48,39 @@ export function cacheGroupData(config: ConfigType) {
 	const punishgroups = config.punishgroups;
 	const cachedGroups: {[k: string]: 'processing' | true} = {};
 
-	function cacheGroup(sym: string, groupData: GroupInfo) {
-		if (cachedGroups[sym] === 'processing') return false; // cyclic inheritance.
+	function isPermission(key: string) {
+		return !['symbol', 'id', 'name', 'rank', 'globalGroupInPersonalRoom'].includes(key);
+	}
+	function cacheGroup(symbol: string, groupData: GroupInfo) {
+		if (cachedGroups[symbol] === 'processing') {
+			throw new Error(`Cyclic inheritance in group config for symbol "${symbol}"`);
+		}
+		if (cachedGroups[symbol] === true) return;
 
-		if (cachedGroups[sym] !== true && groupData['inherit']) {
-			cachedGroups[sym] = 'processing';
-			const inheritGroup = groups[groupData['inherit']];
-			if (cacheGroup(groupData['inherit'], inheritGroup)) {
-				// Add lower group permissions to higher ranked groups,
-				// preserving permissions specifically declared for the higher group.
-				for (const key in inheritGroup) {
-					if (key in groupData) continue;
-					if (['symbol', 'id', 'name', 'rank', 'globalGroupInPersonalRoom'].includes(key)) continue;
-					(groupData as any)[key] = (inheritGroup as any)[key];
+		for (const key in groupData) {
+			if (isPermission(key)) {
+				const jurisdiction = groupData[key as 'jurisdiction'];
+				if (typeof jurisdiction === 'string' && jurisdiction.includes('s')) {
+					Monitor.error(`Outdated jurisdiction for permission "${key}" of group "${symbol}": 's' is no longer a supported jurisdiction; we now use 'ipself' and 'altsself'`);
+					delete groupData[key as 'jurisdiction'];
 				}
+			}
+		}
+
+		if (groupData['inherit']) {
+			cachedGroups[symbol] = 'processing';
+			const inheritGroup = groups[groupData['inherit']];
+			cacheGroup(groupData['inherit'], inheritGroup);
+			// Add lower group permissions to higher ranked groups,
+			// preserving permissions specifically declared for the higher group.
+			for (const key in inheritGroup) {
+				if (key in groupData) continue;
+				if (!isPermission(key)) continue;
+				(groupData as any)[key] = (inheritGroup as any)[key];
 			}
 			delete groupData['inherit'];
 		}
-		return (cachedGroups[sym] = true);
+		cachedGroups[symbol] = true;
 	}
 
 	if (config.grouplist) { // Using new groups format.

--- a/server/monitor.ts
+++ b/server/monitor.ts
@@ -113,6 +113,11 @@ export const Monitor = new class {
 		}
 	}
 
+	error(text: string) {
+		(Rooms.get('development') || Rooms.get('staff') || Rooms.get('lobby'))?.add(`|error|${text}`).update();
+		if (Config.loglevel <= 3) console.error(text);
+	}
+
 	debug(text: string) {
 		if (Config.loglevel <= 1) console.log(text);
 	}

--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -1424,7 +1424,7 @@ export const Punishments = new class {
 		buf += `<th>Expire time</th>`;
 		buf += `<th>Reason</th>`;
 		buf += `<th>Alts</th>`;
-		if (user.can('globalban')) buf += `<th>IPs</th>`;
+		if (user.can('ip')) buf += `<th>IPs</th>`;
 		buf += `</tr>`;
 		for (const [userid, punishment] of punishments) {
 			const expiresIn = new Date(punishment.expireTime).getTime() - Date.now();
@@ -1436,7 +1436,7 @@ export const Punishments = new class {
 			buf += `<td>${expireString}</td>`;
 			buf += `<td>${punishment.reason || ' - '}</td>`;
 			buf += `<td>${punishment.userids.join(", ") || ' - '}</td>`;
-			if (user.can('globalban')) buf += `<td>${punishment.ips.join(", ") || ' - '}</td>`;
+			if (user.can('ip')) buf += `<td>${punishment.ips.join(", ") || ' - '}</td>`;
 			buf += `</tr>`;
 		}
 		buf += `</table>`;

--- a/server/user-groups.ts
+++ b/server/user-groups.ts
@@ -7,14 +7,14 @@ export const PLAYER_SYMBOL: GroupSymbol = '\u2606';
 export const HOST_SYMBOL: GroupSymbol = '\u2605';
 
 export const ROOM_PERMISSIONS = [
-	'addhtml', 'announce', 'ban', 'bypassafktimer', 'declare', 'editprivacy', 'editroom', 'exportinputlog', 'game', 'gamemanagement', 'gamemoderation', 'joinbattle', 'kick', 'minigame', 'modchat', 'modchatall', 'modlog', 'mute', 'nooverride', 'receiveauthmessages', 'roombot', 'roomdriver', 'roommod', 'roomowner', 'roomvoice', 'show', 'showmedia', 'timer', 'tournaments', 'warn',
+	'addhtml', 'announce', 'ban', 'bypassafktimer', 'declare', 'editprivacy', 'editroom', 'exportinputlog', 'game', 'gamemanagement', 'gamemoderation', 'joinbattle', 'kick', 'minigame', 'modchat', 'modlog', 'mute', 'nooverride', 'receiveauthmessages', 'roombot', 'roomdriver', 'roommod', 'roomowner', 'roomvoice', 'show', 'showmedia', 'timer', 'tournaments', 'warn',
 ] as const;
 
 export const GLOBAL_PERMISSIONS = [
 	// administrative
 	'bypassall', 'console', 'disableladder', 'lockdown', 'potd', 'rawpacket',
 	// other
-	'addhtml', 'alts', 'autotimer', 'globalban', 'bypassblocks', 'bypassafktimer', 'forcepromote', 'forcerename', 'forcewin', 'gdeclare', 'ignorelimits', 'importinputlog', 'ip', 'lock', 'makeroom', 'modlog', 'rangeban', 'promote',
+	'addhtml', 'alts', 'altsself', 'autotimer', 'globalban', 'bypassblocks', 'bypassafktimer', 'forcepromote', 'forcerename', 'forcewin', 'gdeclare', 'ignorelimits', 'importinputlog', 'ip', 'ipself', 'lock', 'makeroom', 'modlog', 'rangeban', 'promote',
 ] as const;
 
 export type RoomPermission = typeof ROOM_PERMISSIONS[number];
@@ -61,7 +61,7 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 		if (!Config.groups[group]) return false;
 		if (user.locked || user.semilocked) return false;
 		if (this.get(user.id) === ' ' && group !== ' ') return false;
-		return Auth.getGroup(this.get(user.id)).rank >= Auth.getGroup(group).rank;
+		return Auth.atLeast(this.get(user.id), group);
 	}
 
 	static defaultSymbol() {
@@ -91,7 +91,7 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 	static hasPermission(
 		user: User,
 		permission: string,
-		target: User | GroupSymbol | null,
+		target: User | EffectiveGroupSymbol | null,
 		room?: BasicRoom | null,
 		cmd?: string
 	): boolean {
@@ -100,7 +100,8 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 		const auth: Auth = room ? room.auth : Users.globalAuth;
 
 		const symbol = auth.getEffectiveSymbol(user);
-		const targetSymbol = (typeof target === 'string' || !target) ? target : auth.get(target);
+		let targetSymbol = (typeof target === 'string' || !target) ? target : auth.get(target);
+		if (targetSymbol === 'whitelist') targetSymbol = Auth.defaultSymbol();
 
 		const group = Auth.getGroup(symbol);
 		if (group['root']) return true;
@@ -120,7 +121,10 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 			}
 		}
 
-		return Auth.hasJurisdiction(symbol, jurisdiction, targetSymbol, target === user);
+		return Auth.hasJurisdiction(symbol, jurisdiction, targetSymbol);
+	}
+	static atLeast(symbol: EffectiveGroupSymbol, symbol2: EffectiveGroupSymbol) {
+		return Auth.getGroup(symbol).rank >= Auth.getGroup(symbol2).rank;
 	}
 	static supportedRoomPermissions(room: Room | null = null) {
 		const permissions: string[] = ROOM_PERMISSIONS.slice();
@@ -136,8 +140,7 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 	static hasJurisdiction(
 		symbol: EffectiveGroupSymbol,
 		jurisdiction?: string | boolean,
-		targetSymbol?: GroupSymbol | null,
-		targetingSelf?: boolean
+		targetSymbol?: GroupSymbol | null
 	) {
 		if (!targetSymbol) {
 			return !!jurisdiction;
@@ -148,11 +151,10 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 		if (jurisdiction.includes(targetSymbol)) {
 			return true;
 		}
-		if (jurisdiction.includes('s') && targetingSelf) {
+		if (jurisdiction.includes('a')) {
 			return true;
 		}
-		if (jurisdiction.includes('u') &&
-			Config.groupsranking.indexOf(symbol) > Config.groupsranking.indexOf(targetSymbol)) {
+		if (jurisdiction.includes('u') && Auth.getGroup(symbol).rank > Auth.getGroup(targetSymbol).rank) {
 			return true;
 		}
 		return false;

--- a/test/server/users.js
+++ b/test/server/users.js
@@ -157,19 +157,6 @@ describe('Users features', function () {
 						if (room) room.destroy();
 					}
 				});
-				it(`should allow 's' permissions only on self`, function () {
-					const user = new User();
-					user.group = '+';
-					assert.equal(user.can('alts', user), true, 'targeting self');
-
-					const target = new User();
-					target.group = ' ';
-					assert.equal(user.can('alts', target), false, 'targeting lower rank');
-					target.group = '+';
-					assert.equal(user.can('alts', target), false, 'targeting same rank');
-					target.group = '%';
-					assert.equal(user.can('alts', target), false, 'targeting higher rank');
-				});
 				it(`should allow 'u' permissions on lower ranked users`, function () {
 					const user = new User();
 					user.group = '@';


### PR DESCRIPTION
- `ip` and `ipself` are now separate permissions. This means that `ip`  is now a generalized permission for viewing IPs (no more need to use `globalban` because `can('ip')` is true for all users)

- `alts` and `altsself` are now also separate (all users used to be able to `altsself`).

- `modchat`, `modchatall`, and `manageroom` are now just one `modchat` permission whose jurisdiction controls how high you can set modchat.