### PR TITLE
Fix RO rank display on side servers

### DIFF
--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1095,7 +1095,7 @@ export class GlobalRoomState {
 			if (!Config.groups[rank] || !rank) continue;
 
 			const tarGroup = Config.groups[rank];
-			const groupType = tarGroup.addhtml || (!tarGroup.mute && !tarGroup.root) ?
+			const groupType = tarGroup.id === 'bot' || (!tarGroup.mute && !tarGroup.root) ?
 				'normal' : (tarGroup.root || tarGroup.declare) ? 'leadership' : 'staff';
 
 			rankList.push({


### PR DESCRIPTION
ROs can addhtml, so it returned normal automatically, when it should have returned `leadership`.
Fixes #7007 