### PR TITLE
Fix hidden messages

### DIFF
--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -609,7 +609,7 @@ export abstract class BasicRoom {
 		}
 		entry = `|${ucType}|${entry}`;
 		if (this.batchJoins) {
-			this.log.broadcastBuffer += entry;
+			this.log.broadcastBuffer += entry + '\n';
 
 			if (!this.reportJoinsInterval) {
 				this.reportJoinsInterval = setTimeout(


### PR DESCRIPTION
Whenever there is a silent join in room, previously any other silent joins following will not display.  You'll end up with ``|J|muted|J|locked`` which not long doesn't display user "locked" as joining the room, nor will "locked" appear in the userlist.  

However, the big issue with this is: when a chat message ``room.log.add()`` is sent within 100ms of a silent join, the message will disappear. The resultant message ends up as ``|J|troll|c:|696969696969|sparkychild|I can evade filters all i want and none of you can do anything about it``.

I'm not sure if there was originally a purpose for not having \n between entries (without doing .update() in between makes a giant mess!), but this should fix any missing messages.

Shoutout to @Volco  for discovering and ranting about this mysterious phenomenon in Dawn admin chat. 