### PR TITLE
Announcements: Make strings translatable

### DIFF
--- a/server/chat-plugins/announcements.ts
+++ b/server/chat-plugins/announcements.ts
@@ -42,7 +42,7 @@ export class Announcement {
 	}
 
 	end() {
-		this.room.send(`|uhtmlchange|announcement${this.announcementNumber}|<div class="infobox">(The announcement has ended.)</div>`);
+		this.room.send(`|uhtmlchange|announcement${this.announcementNumber}|<div class="infobox">(${Chat.tr("The announcement has ended.")}</div>`);
 	}
 }
 
@@ -54,17 +54,19 @@ export const commands: ChatCommands = {
 			if (!room) return this.requiresRoom();
 			if (!target) return this.parse('/help announcement new');
 			target = target.trim();
-			if (room.battle) return this.errorReply("Battles do not support announcements.");
+			if (room.battle) return this.errorReply(this.tr("Battles do not support announcements."));
 
 			const text = Chat.filter(this, target, user, room, connection);
-			if (target !== text) return this.errorReply("You are not allowed to use filtered words in announcements.");
+			if (target !== text) return this.errorReply(this.tr("You are not allowed to use filtered words in announcements."));
 
 			const supportHTML = cmd === 'htmlcreate';
 
 			if (!this.can('minigame', null, room)) return false;
 			if (supportHTML && !this.can('declare', null, room)) return false;
 			if (!this.canTalk()) return;
-			if (room.minorActivity) return this.errorReply("There is already a poll or announcement in progress in this room.");
+			if (room.minorActivity) {
+				return this.errorReply(this.tr("There is already a poll or announcement in progress in this room."));
+			}
 
 			const source = supportHTML ? this.canHTML(target) : Utils.escapeHTML(target);
 			if (!source) return;
@@ -74,28 +76,28 @@ export const commands: ChatCommands = {
 
 			this.roomlog(`${user.name} used ${message}`);
 			this.modlog('ANNOUNCEMENT');
-			return this.privateModAction(`An announcement was started by ${user.name}.`);
+			return this.privateModAction(this.tr`An announcement was started by ${user.name}.`);
 		},
 		newhelp: [`/announcement create [announcement] - Creates an announcement. Requires: % @ # &`],
 
 		timer(target, room, user) {
 			if (!room) return this.requiresRoom();
 			if (!room.minorActivity || room.minorActivity.activityId !== 'announcement') {
-				return this.errorReply("There is no announcement running in this room.");
+				return this.errorReply(this.tr("There is no announcement running in this room."));
 			}
 			const announcement = room.minorActivity;
 
 			if (target) {
 				if (!this.can('minigame', null, room)) return false;
 				if (target === 'clear') {
-					if (!announcement.timeout) return this.errorReply("There is no timer to clear.");
+					if (!announcement.timeout) return this.errorReply(this.tr("There is no timer to clear."));
 					clearTimeout(announcement.timeout);
 					announcement.timeout = null;
 					announcement.timeoutMins = 0;
-					return this.add("The announcement timer was turned off.");
+					return this.add(this.tr("The announcement timer was turned off."));
 				}
 				const timeout = parseFloat(target);
-				if (isNaN(timeout) || timeout <= 0 || timeout > 0x7FFFFFFF) return this.errorReply("Invalid time given.");
+				if (isNaN(timeout) || timeout <= 0 || timeout > 0x7FFFFFFF) return this.errorReply(this.tr("Invalid time given."));
 				if (announcement.timeout) clearTimeout(announcement.timeout);
 				announcement.timeoutMins = timeout;
 				announcement.timeout = setTimeout(() => {
@@ -110,7 +112,7 @@ export const commands: ChatCommands = {
 				if (announcement.timeout) {
 					return this.sendReply(`The announcement timer is on and will end in ${announcement.timeoutMins} minute${Chat.plural(announcement.timeoutMins)}.`);
 				} else {
-					return this.sendReply("The announcement timer is off.");
+					return this.sendReply(this.tr("The announcement timer is off."));
 				}
 			}
 		},
@@ -126,7 +128,7 @@ export const commands: ChatCommands = {
 			if (!this.can('minigame', null, room)) return false;
 			if (!this.canTalk()) return;
 			if (!room.minorActivity || room.minorActivity.activityId !== 'announcement') {
-				return this.errorReply("There is no announcement running in this room.");
+				return this.errorReply(this.tr("There is no announcement running in this room."));
 			}
 			const announcement = room.minorActivity;
 			if (announcement.timeout) clearTimeout(announcement.timeout);
@@ -134,7 +136,7 @@ export const commands: ChatCommands = {
 			announcement.end();
 			room.minorActivity = null;
 			this.modlog('ANNOUNCEMENT END');
-			return this.privateModAction(`The announcement was ended by ${user.name}.`);
+			return this.privateModAction(this.tr`The announcement was ended by ${user.name}.`);
 		},
 		endhelp: [`/announcement end - Ends a announcement and displays the results. Requires: % @ # &`],
 
@@ -142,7 +144,7 @@ export const commands: ChatCommands = {
 		display(target, room, user, connection) {
 			if (!room) return this.requiresRoom();
 			if (!room.minorActivity || room.minorActivity.activityId !== 'announcement') {
-				return this.errorReply("There is no announcement running in this room.");
+				return this.errorReply(this.tr("There is no announcement running in this room."));
 			}
 			const announcement = room.minorActivity;
 			if (!this.runBroadcast()) return;

--- a/translations/dutch.json
+++ b/translations/dutch.json
@@ -131,6 +131,19 @@
 		"You are now blocking all incoming challenge requests.": "Je blokkeert nu alle inkomende uitdagingen.",
 		"You are already blocking challenges!": "Je blokkeert al uitdagingen!",
 		"You are already available for challenges!": "Je bent al beschikbaar voor uitdagingen!",
-		"You are available for challenges from now on.": "Je bent vanaf nu beschikbaar voor uitdagingen."
+		"You are available for challenges from now on.": "Je bent vanaf nu beschikbaar voor uitdagingen.",
+
+		"The announcement has ended.": "",
+		"Battles do not support announcements.": "",
+		"You are not allowed to use filtered words in announcements.": "",
+		"There is already a poll or announcement in progress in this room.": "",
+		"An announcement was started by ${user.name}.": "",
+		"There is no announcement running in this room.": "",
+		"There is no timer to clear.": "",
+		"The announcement timer was turned off.": "",
+		"Invalid time given.": "",
+		"The announcement timer is off.": "",
+		"The announcement was ended by ${user.name}.": "",
+		"Accepts the following commands:": ""
 	}
 }

--- a/translations/english.json
+++ b/translations/english.json
@@ -131,6 +131,19 @@
 		"You are now blocking all incoming challenge requests.": "",
 		"You are already blocking challenges!": "",
 		"You are already available for challenges!": "",
-		"You are available for challenges from now on.": ""
+		"You are available for challenges from now on.": "",
+
+		"The announcement has ended.": "",
+		"Battles do not support announcements.": "",
+		"You are not allowed to use filtered words in announcements.": "",
+		"There is already a poll or announcement in progress in this room.": "",
+		"An announcement was started by ${user.name}.": "",
+		"There is no announcement running in this room.": "",
+		"There is no timer to clear.": "",
+		"The announcement timer was turned off.": "",
+		"Invalid time given.": "",
+		"The announcement timer is off.": "",
+		"The announcement was ended by ${user.name}.": "",
+		"Accepts the following commands:": ""
 	}
 }

--- a/translations/french.json
+++ b/translations/french.json
@@ -127,6 +127,19 @@
 		"You are now blocking all incoming challenge requests.": "Tu bloques maintenant toutes les demandes de challenge à venir.",
 		"You are already blocking challenges!": "Tu bloques déjà les challenges !",
 		"You are already available for challenges!": "Tu es déjà disponible pour les challenges !",
-		"You are available for challenges from now on.": "Tu es maintenant disponible pour les challenges."
+		"You are available for challenges from now on.": "Tu es maintenant disponible pour les challenges.",
+
+		"The announcement has ended.": "",
+		"Battles do not support announcements.": "",
+		"You are not allowed to use filtered words in announcements.": "",
+		"There is already a poll or announcement in progress in this room.": "",
+		"An announcement was started by ${user.name}.": "",
+		"There is no announcement running in this room.": "",
+		"There is no timer to clear.": "",
+		"The announcement timer was turned off.": "",
+		"Invalid time given.": "",
+		"The announcement timer is off.": "",
+		"The announcement was ended by ${user.name}.": "",
+		"Accepts the following commands:": ""
 	}
 }

--- a/translations/german.json
+++ b/translations/german.json
@@ -109,6 +109,19 @@
 		"You are now blocking all incoming challenge requests.": "Du blockierst jetzt alle eingehenden Herausforderungen.",
 		"You are already blocking challenges!": "Du blockierst bereits Herausforderungen!",
 		"You are already available for challenges!": "Du bist bereits für Herausforderungen verfügbar!",
-		"You are available for challenges from now on.": "Du bist ab jetzt für Herausforderungen verfügbar."
+		"You are available for challenges from now on.": "Du bist ab jetzt für Herausforderungen verfügbar.",
+
+		"The announcement has ended.": "",
+		"Battles do not support announcements.": "",
+		"You are not allowed to use filtered words in announcements.": "",
+		"There is already a poll or announcement in progress in this room.": "",
+		"An announcement was started by ${user.name}.": "",
+		"There is no announcement running in this room.": "",
+		"There is no timer to clear.": "",
+		"The announcement timer was turned off.": "",
+		"Invalid time given.": "",
+		"The announcement timer is off.": "",
+		"The announcement was ended by ${user.name}.": "",
+		"Accepts the following commands:": ""
 	}
 }

--- a/translations/hindi.json
+++ b/translations/hindi.json
@@ -132,6 +132,19 @@
 		"You are now blocking all incoming challenge requests.": "आप अब सभी मुकाबले के अनुरोध रोक रहे हैं.",
 		"You are already blocking challenges!": " आप पहले से ही मुकाबले रोक रहे हैं!",
 		"You are already available for challenges!": "आप पहले से ही मुकाबले के लिए तैयार हैं!",
-		"You are available for challenges from now on.": "अब आप मुकाबलों के लिए तैयार हैं."
+		"You are available for challenges from now on.": "अब आप मुकाबलों के लिए तैयार हैं.",
+
+		"The announcement has ended.": "",
+		"Battles do not support announcements.": "",
+		"You are not allowed to use filtered words in announcements.": "",
+		"There is already a poll or announcement in progress in this room.": "",
+		"An announcement was started by ${user.name}.": "",
+		"There is no announcement running in this room.": "",
+		"There is no timer to clear.": "",
+		"The announcement timer was turned off.": "",
+		"Invalid time given.": "",
+		"The announcement timer is off.": "",
+		"The announcement was ended by ${user.name}.": "",
+		"Accepts the following commands:": ""
 	}
 }

--- a/translations/italian.json
+++ b/translations/italian.json
@@ -131,6 +131,19 @@
 		"You are now blocking all incoming challenge requests.": "Stai ora bloccando ogni richiesta di sfida in arrivo.",
 		"You are already blocking challenges!": "Stai già bloccando le sfide!",
 		"You are already available for challenges!": "Sei già disponibile per le sfide!",
-		"You are available for challenges from now on.": "Da questo momento in poi, sei disponibile per le sfide."
+		"You are available for challenges from now on.": "Da questo momento in poi, sei disponibile per le sfide.",
+
+		"The announcement has ended.": "",
+		"Battles do not support announcements.": "",
+		"You are not allowed to use filtered words in announcements.": "",
+		"There is already a poll or announcement in progress in this room.": "",
+		"An announcement was started by ${user.name}.": "",
+		"There is no announcement running in this room.": "",
+		"There is no timer to clear.": "",
+		"The announcement timer was turned off.": "",
+		"Invalid time given.": "",
+		"The announcement timer is off.": "",
+		"The announcement was ended by ${user.name}.": "",
+		"Accepts the following commands:": ""
 	}
 }

--- a/translations/japanese.json
+++ b/translations/japanese.json
@@ -131,6 +131,19 @@
 		"You are now blocking all incoming challenge requests.": " 対戦の申し込みをブロックしました。",
 		"You are already blocking challenges!": "すでに対戦の申し込みをブロックしています。",
 		"You are already available for challenges!": "現在対戦の申し込みをブロックしていません。",
-		"You are available for challenges from now on.": "対戦の申し込みのブロックを解除しました。"
+		"You are available for challenges from now on.": "対戦の申し込みのブロックを解除しました。",
+
+		"The announcement has ended.": "",
+		"Battles do not support announcements.": "",
+		"You are not allowed to use filtered words in announcements.": "",
+		"There is already a poll or announcement in progress in this room.": "",
+		"An announcement was started by ${user.name}.": "",
+		"There is no announcement running in this room.": "",
+		"There is no timer to clear.": "",
+		"The announcement timer was turned off.": "",
+		"Invalid time given.": "",
+		"The announcement timer is off.": "",
+		"The announcement was ended by ${user.name}.": "",
+		"Accepts the following commands:": ""
 	}
 }

--- a/translations/portuguese.json
+++ b/translations/portuguese.json
@@ -132,6 +132,19 @@
 		"You are now blocking all incoming challenge requests.": "Agora você está bloqueando todos os pedidos de desafio.",
 		"You are already blocking challenges!": "Você já está bloqueando desafios",
 		"You are already available for challenges!": "Você já está disponível para desafios!",
-		"You are available for challenges from now on.": "Você está disponível para desafios a partir de agora."
+		"You are available for challenges from now on.": "Você está disponível para desafios a partir de agora.",
+
+		"The announcement has ended.": "",
+		"Battles do not support announcements.": "",
+		"You are not allowed to use filtered words in announcements.": "",
+		"There is already a poll or announcement in progress in this room.": "",
+		"An announcement was started by ${user.name}.": "",
+		"There is no announcement running in this room.": "",
+		"There is no timer to clear.": "",
+		"The announcement timer was turned off.": "",
+		"Invalid time given.": "",
+		"The announcement timer is off.": "",
+		"The announcement was ended by ${user.name}.": "",
+		"Accepts the following commands:": ""
 	}
 }

--- a/translations/simplifiedchinese.json
+++ b/translations/simplifiedchinese.json
@@ -130,6 +130,19 @@
 		"You are now blocking all incoming challenge requests.": "您已屏蔽所有挑战请求",
 		"You are already blocking challenges!": "您已屏蔽挑战请求",
 		"You are already available for challenges!": "您已能够接收挑战请求",
-		"You are available for challenges from now on.": "您从现在开始接收挑战请求"
+		"You are available for challenges from now on.": "您从现在开始接收挑战请求",
+
+		"The announcement has ended.": "",
+		"Battles do not support announcements.": "",
+		"You are not allowed to use filtered words in announcements.": "",
+		"There is already a poll or announcement in progress in this room.": "",
+		"An announcement was started by ${user.name}.": "",
+		"There is no announcement running in this room.": "",
+		"There is no timer to clear.": "",
+		"The announcement timer was turned off.": "",
+		"Invalid time given.": "",
+		"The announcement timer is off.": "",
+		"The announcement was ended by ${user.name}.": "",
+		"Accepts the following commands:": ""
 	}
 }

--- a/translations/spanish.json
+++ b/translations/spanish.json
@@ -131,6 +131,19 @@
 		"You are now blocking all incoming challenge requests.": "Ahora estás bloqueando todas las solicitudes de batalla entrantes",
 		"You are already blocking challenges!": "¡Ya estás bloqueando solicitudes de batalla!",
 		"You are already available for challenges!": "¡Ya estás disponible para recibir solicitudes de batalla!",
-		"You are available for challenges from now on.": "Estás disponible para recibir solicitudes de batalla de ahora en adelante."
+		"You are available for challenges from now on.": "Estás disponible para recibir solicitudes de batalla de ahora en adelante.",
+
+		"The announcement has ended.": "",
+		"Battles do not support announcements.": "",
+		"You are not allowed to use filtered words in announcements.": "",
+		"There is already a poll or announcement in progress in this room.": "",
+		"An announcement was started by ${user.name}.": "",
+		"There is no announcement running in this room.": "",
+		"There is no timer to clear.": "",
+		"The announcement timer was turned off.": "",
+		"Invalid time given.": "",
+		"The announcement timer is off.": "",
+		"The announcement was ended by ${user.name}.": "",
+		"Accepts the following commands:": ""
 	}
 }

--- a/translations/traditionalchinese.json
+++ b/translations/traditionalchinese.json
@@ -39,9 +39,9 @@
 		"DRIVER COMMANDS": "見習管理指令",
 		"MODERATOR COMMANDS": "管理員指令",
 		"ADMIN COMMANDS": "總管指令",
- 
+
 		"(replace / with ! to broadcast. Broadcasting requires: + % @ # &)": "(把/換成!就可以廣播指令。廣播功能需要：+ % @ # &)",
- 
+
 		"<strong>Room punishments</strong>:": "<strong>房間處罰</strong>:",
 		"<strong>warn</strong> - Displays a popup with the rules.": "<strong>warn</strong> - 顯示規則與警告",
 		"<strong>mute</strong> - Mutes a user (makes them unable to talk) for 7 minutes.": "<strong>mute</strong> - 禁言用戶（不能發言）七分鐘。",
@@ -130,6 +130,19 @@
 		"You are now blocking all incoming challenge requests.": "您已屏蔽所有挑戰請求",
 		"You are already blocking challenges!": "您已屏蔽挑戰請求",
 		"You are already available for challenges!": "您已能夠接收挑戰請求",
-		"You are available for challenges from now on.": "您從現在開始接收挑戰請求"
+		"You are available for challenges from now on.": "您從現在開始接收挑戰請求",
+
+		"The announcement has ended.": "",
+		"Battles do not support announcements.": "",
+		"You are not allowed to use filtered words in announcements.": "",
+		"There is already a poll or announcement in progress in this room.": "",
+		"An announcement was started by ${user.name}.": "",
+		"There is no announcement running in this room.": "",
+		"There is no timer to clear.": "",
+		"The announcement timer was turned off.": "",
+		"Invalid time given.": "",
+		"The announcement timer is off.": "",
+		"The announcement was ended by ${user.name}.": "",
+		"Accepts the following commands:": ""
 	}
 }


### PR DESCRIPTION
Unfortunately, I don't speak any of the languages PS! is translated into well enough to actually do any translation, but I did handle the technical side.

One minor snag (which I want to discuss either here or on Discord) is that `Chat#plural` only correctly creates a plural form for English, and not other languages. Personally, I think if we are to be truly multilingual, assuming that words are always plural is probably simpler (albeit less clean-looking) than trying to programmatically generate plural forms for every language PS is translated into or gets a translation for in the future.