### PR TITLE
Make broadcastBuffer an array

### DIFF
--- a/server/roomlogs.ts
+++ b/server/roomlogs.ts
@@ -54,7 +54,7 @@ export class Roomlog {
 	 * Scrollback log
 	 */
 	log: string[];
-	broadcastBuffer: string;
+	broadcastBuffer: string[];
 	/**
 	 * undefined = uninitialized,
 	 * null = disabled
@@ -75,7 +75,7 @@ export class Roomlog {
 		this.noLogTimes = !!options.noLogTimes;
 
 		this.log = [];
-		this.broadcastBuffer = '';
+		this.broadcastBuffer = [];
 
 		this.modlogStream = undefined;
 		this.roomlogStream = undefined;
@@ -166,7 +166,7 @@ export class Roomlog {
 		this.roomlog(message);
 		message = this.withTimestamp(message);
 		this.log.push(message);
-		this.broadcastBuffer += message + '\n';
+		this.broadcastBuffer.push(message);
 		return this;
 	}
 	private withTimestamp(message: string) {
@@ -220,7 +220,7 @@ export class Roomlog {
 				break;
 			}
 		}
-		this.broadcastBuffer += fullMessage + '\n';
+		this.broadcastBuffer.push(fullMessage);
 	}
 	attributedUhtmlchange(user: User, name: string, message: string) {
 		const start = `/uhtmlchange ${name},`;
@@ -231,7 +231,7 @@ export class Roomlog {
 				break;
 			}
 		}
-		this.broadcastBuffer += fullMessage + '\n';
+		this.broadcastBuffer.push(fullMessage);
 	}
 	private parseChatLine(line: string) {
 		const messageStart = !this.noLogTimes ? '|c:|' : '|c|';

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -376,14 +376,14 @@ export abstract class BasicRoom {
 		this.sendMods('|c|' + user.getIdentity(this.roomid) + '|/log ' + text);
 	}
 	update() {
-		if (!this.log.broadcastBuffer) return;
+		if (!this.log.broadcastBuffer.length) return;
 		if (this.reportJoinsInterval) {
 			clearInterval(this.reportJoinsInterval);
 			this.reportJoinsInterval = null;
 			this.userList = this.getUserList();
 		}
-		this.send(this.log.broadcastBuffer);
-		this.log.broadcastBuffer = '';
+		this.send(this.log.broadcastBuffer.join('\n'));
+		this.log.broadcastBuffer = [];
 		this.log.truncate();
 
 		this.pokeExpireTimer();
@@ -609,7 +609,7 @@ export abstract class BasicRoom {
 		}
 		entry = `|${ucType}|${entry}`;
 		if (this.batchJoins) {
-			this.log.broadcastBuffer += entry + '\n';
+			this.log.broadcastBuffer.push(entry);
 
 			if (!this.reportJoinsInterval) {
 				this.reportJoinsInterval = setTimeout(
@@ -1540,12 +1540,12 @@ export class GameRoom extends BasicRoom {
 		return this.getLog(this.game.playerTable[user.id].num);
 	}
 	update(excludeUser: User | null = null) {
-		if (!this.log.broadcastBuffer) return;
+		if (!this.log.broadcastBuffer.length) return;
 
 		if (this.userCount) {
-			Sockets.channelBroadcast(this.roomid, `>${this.roomid}\n${this.log.broadcastBuffer}`);
+			Sockets.channelBroadcast(this.roomid, `>${this.roomid}\n${this.log.broadcastBuffer.join('\n')}`);
 		}
-		this.log.broadcastBuffer = '';
+		this.log.broadcastBuffer = [];
 
 		this.pokeExpireTimer();
 	}


### PR DESCRIPTION
This removes any extra unnecessary newlines at the end of each message sent to each client, and will always handle all messages assigned to the buffer properly.  (saving bandwidth = yay) Tagging @Zarel because he's was fine with this