### PR TITLE
Ensure committed csv files have \n line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+config/*.csv eol=lf


### PR DESCRIPTION
we split these on `\n`, so if git changes the endings to `\r\n` every line has a trailing `\r`