### PR TITLE
Fix /lottery participants from escaping container

### DIFF
--- a/server/chat-plugins/lottery.ts
+++ b/server/chat-plugins/lottery.ts
@@ -243,7 +243,7 @@ export const commands: ChatCommands = {
 			});
 			let buf = '';
 			if (user.can('declare', null, room)) {
-				buf += `<details class="readmore"><summary><b>List of participants (${participants.length}):</b></summary><p>${participants.join('\n')}</p></details>`;
+				buf += `<details class="readmore"><summary><strong>List of participants (${participants.length}):</strong></summary>${participants.join('<br>')}</details>`;
 			} else {
 				buf += `${participants.length} participant(s) joined this lottery.`;
 			}


### PR DESCRIPTION
Before [from this bug report](https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-8474970)
![image](https://user-images.githubusercontent.com/23667022/89113841-98352480-d43b-11ea-86dc-78cb3e33003a.png)

After:
![image](https://user-images.githubusercontent.com/23667022/89113837-8a7f9f00-d43b-11ea-8f35-847c58966da4.png)



