### PR TITLE
Searchlog: fix crash

### DIFF
--- a/server/chat-plugins/chatlog.ts
+++ b/server/chat-plugins/chatlog.ts
@@ -545,7 +545,7 @@ export const LogSearcher = new class {
 			});
 			results = stdout.split('--');
 		} catch (e) {
-			if (e.code === 2) throw e; // 2 means an error in ripgrep
+			if (e.code !== 1) throw e; // 2 means an error in ripgrep
 			if (e.stdout) {
 				results = e.stdout.split('--');
 			} else {

--- a/server/chat-plugins/chatlog.ts
+++ b/server/chat-plugins/chatlog.ts
@@ -545,12 +545,12 @@ export const LogSearcher = new class {
 			});
 			results = stdout.split('--');
 		} catch (e) {
-			if (e.stdout || e.message.includes('stdout maxBuffer')) {
+			if (e.code === 2) throw e; // 2 means an error in ripgrep
+			if (e.stdout) {
 				results = e.stdout.split('--');
-				count += results.length;
-				return {results, count};
+			} else {
+				results = [];
 			}
-			throw e;
 		}
 		count += results.length;
 		return {results, count};


### PR DESCRIPTION
Ripgrep doesn't debug well, given the only error it gives is `` Error: Command failed``, which it can throw for legit reasons like no results. Given that, the best solution is to handle it like modlog and just return an empty result array. 
It also checks `e.stdout` since sometimes it errors but still stores the results there. 
If anyone has any better ideas, i'm open, but given the awful nature of child_process.execFile's errors, i think this is the best handling.