### PR TITLE
Fix renaming groupchats and groupchat creation

### DIFF
--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -741,7 +741,7 @@ export const commands: ChatCommands = {
 			return this.errorReply(`Your group chat name is too similar to existing chat room '${title}'.`);
 		}
 		// Room IDs for groupchats are groupchat-TITLEID
-		let titleid = toID(title);
+		const titleid = toID(title);
 		if (!titleid) {
 			title = `${Math.floor(Math.random() * 100000000)}` as ID;
 		}

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -743,7 +743,7 @@ export const commands: ChatCommands = {
 		// Room IDs for groupchats are groupchat-TITLEID
 		let titleid = toID(title);
 		if (!titleid) {
-			titleid = `${Math.floor(Math.random() * 100000000)}` as ID;
+			title = `${Math.floor(Math.random() * 100000000)}` as ID;
 		}
 		const roomid = `groupchat-${parent || user.id}-${titleid}` as RoomID;
 		// Titles must be unique.
@@ -911,6 +911,7 @@ export const commands: ChatCommands = {
 		}
 		const oldTitle = room.title;
 		const isGroupchat = cmd === 'renamegroupchat';
+		if (!toID(target)) return this.errorReply("Rooms need a title.");
 		if (room.persist && isGroupchat) return this.errorReply(`This isn't a groupchat.`);
 		if (!room.persist && !isGroupchat) return this.errorReply(`Use /renamegroupchat instead.`);
 		if (isGroupchat) {
@@ -921,6 +922,12 @@ export const commands: ChatCommands = {
 			}
 			if (this.filter(target) !== target) {
 				return this.errorReply("Invalid title.");
+			}
+			// `,` is a delimiter used by a lot of /commands
+			// `|` and `[` are delimiters used by the protocol
+			// `-` has special meaning in roomids
+			if (target.includes(',') || target.includes('|') || target.includes('[') || target.includes('-')) {
+				return this.errorReply("Room titles can't contain any of: ,|[-");
 			}
 			target = `[G] ${target}`;
 		} else {

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -741,9 +741,9 @@ export const commands: ChatCommands = {
 			return this.errorReply(`Your group chat name is too similar to existing chat room '${title}'.`);
 		}
 		// Room IDs for groupchats are groupchat-TITLEID
-		const titleid = toID(title);
+		let titleid = toID(title);
 		if (!titleid) {
-			title = `${Math.floor(Math.random() * 100000000)}` as ID;
+			titleid = `${Math.floor(Math.random() * 100000000)}` as ID;
 		}
 		const roomid = `groupchat-${parent || user.id}-${titleid}` as RoomID;
 		// Titles must be unique.

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -672,7 +672,8 @@ export abstract class BasicRoom {
 		// `|` and `[` are delimiters used by the protocol
 		// `-` has special meaning in roomids
 		// groupchats use `[` so allow it to bypass this and run the checks in the commands themselves
-		if (this.persist && (newTitle.includes(',') || newTitle.includes('|') || newTitle.includes('[') || newTitle.includes('-'))) {
+		if (this.persist &&
+			(newTitle.includes(',') || newTitle.includes('|') || newTitle.includes('[') || newTitle.includes('-'))) {
 			throw new Chat.ErrorMessage("Room titles can't contain any of: ,|[-");
 		}
 		if (newID.length > MAX_CHATROOM_ID_LENGTH) throw new Chat.ErrorMessage("The given room title is too long.");

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -671,10 +671,11 @@ export abstract class BasicRoom {
 		// `,` is a delimiter used by a lot of /commands
 		// `|` and `[` are delimiters used by the protocol
 		// `-` has special meaning in roomids
-		// groupchats use `[` so allow it to bypass this and run the checks in the commands themselves
-		if (this.persist &&
-			(newTitle.includes(',') || newTitle.includes('|') || newTitle.includes('[') || newTitle.includes('-'))) {
-			throw new Chat.ErrorMessage("Room titles can't contain any of: ,|[-");
+		if (newTitle.includes(',') || newTitle.includes('|')) {
+			throw new Chat.ErrorMessage(`Room title "${newTitle}" can't contain any of: ,|`);
+		}
+		if ((!newID.includes('-') || newID.startsWith('groupchat-')) && newTitle.includes('-')) {
+			throw new Chat.ErrorMessage(`Room title "${newTitle}" can't contain -`);
 		}
 		if (newID.length > MAX_CHATROOM_ID_LENGTH) throw new Chat.ErrorMessage("The given room title is too long.");
 		if (Rooms.search(newTitle)) throw new Chat.ErrorMessage(`The room '${newTitle}' already exists.`);

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -671,7 +671,8 @@ export abstract class BasicRoom {
 		// `,` is a delimiter used by a lot of /commands
 		// `|` and `[` are delimiters used by the protocol
 		// `-` has special meaning in roomids
-		if (newTitle.includes(',') || newTitle.includes('|') || newTitle.includes('[') || newTitle.includes('-')) {
+		// groupchats use `[` so allow it to bypass this and run the checks in the commands themselves
+		if (this.persist && (newTitle.includes(',') || newTitle.includes('|') || newTitle.includes('[') || newTitle.includes('-'))) {
 			throw new Chat.ErrorMessage("Room titles can't contain any of: ,|[-");
 		}
 		if (newID.length > MAX_CHATROOM_ID_LENGTH) throw new Chat.ErrorMessage("The given room title is too long.");


### PR DESCRIPTION
This allows you to create groupchats again which #6965 entirely broke, @mia-pi-git i suggest you test your code thoroughly in the future because it's apparent you do not, and also patches renaming rooms to no name, for the second time since I already fixed this prior. Again mia, please test your code thoroughly.

