### PR TITLE
Inheritance: Fix validation issue

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1049,6 +1049,7 @@ export const Formats: (FormatsData | {section: string, column?: number})[] = [
 				if (validSources.includes(evoFamily)) continue;
 
 				set.species = donorSpecies.name;
+				set.name = donorSpecies.baseSpecies;
 				const problems = this.validateSet(set, teamHas) || [];
 				if (!problems.length) {
 					validSources.push(evoFamily);

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1049,7 +1049,7 @@ export const Formats: (FormatsData | {section: string, column?: number})[] = [
 				if (validSources.includes(evoFamily)) continue;
 
 				set.species = donorSpecies.name;
-				set.name = donorSpecies.baseSpecies;
+				if (!set.name) set.name = donorSpecies.baseSpecies;
 				const problems = this.validateSet(set, teamHas) || [];
 				if (!problems.length) {
 					validSources.push(evoFamily);


### PR DESCRIPTION
There's currently an issue in validation where sets will not validate unless the Pokemon has a nickname, and since locked users can't nickname Pokemon, they're unable to play the format.

nicknames get reassigned later in the validation process, so this is just to make the validator be quiet.