### PR TITLE
Refactor Modlog into one file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /config/*
 !/config/formats.ts
 /logs/*
+/test/modlogs
 /node_modules
 /eslint-cache
 /server/chat-plugins/private

--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -340,7 +340,7 @@ export class FSPath {
 			}
 		}
 		return new Promise((resolve, reject) => {
-			fs.rmdir(this.path, function (err) {
+			fs.rmdir(this.path, err => {
 				err ? reject(err) : resolve();
 			});
 		});

--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -325,6 +325,20 @@ export class FSPath {
 		}
 	}
 
+	rmdir(recursive?: boolean) {
+		if (Config.nofswriting) return Promise.resolve();
+		return new Promise((resolve, reject) => {
+			fs.rmdir(this.path, {recursive}, err => {
+				err ? reject(err) : resolve();
+			});
+		});
+	}
+
+	rmdirSync(recursive?: boolean) {
+		if (Config.nofswriting) return;
+		return fs.rmdirSync(this.path, {recursive});
+	}
+
 	mkdir(mode: string | number = 0o755) {
 		if (Config.nofswriting) return Promise.resolve();
 		return new Promise((resolve, reject) => {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -781,7 +781,7 @@ export class CommandContext extends MessageContext {
 		note: string | null = null,
 		options: Partial<{noalts: any, noip: any}> = {}
 	) {
-		let buf = `(${this.room?.roomid || 'global'}${this.room?.tour ? ` tournament: ${this.room.tour.roomid}` : ``}) ${action}: `;
+		let buf = `${action}: `;
 		if (user) {
 			if (typeof user === 'string') {
 				buf += `[${toID(user)}]`;

--- a/server/index.ts
+++ b/server/index.ts
@@ -126,6 +126,8 @@ global.Punishments = Punishments;
 
 import {Rooms} from './rooms';
 global.Rooms = Rooms;
+// We initialize the global room here because roomlogs.ts needs the Rooms global
+Rooms.global = new Rooms.GlobalRoomState();
 
 import * as Verifier from './verifier';
 global.Verifier = Verifier;

--- a/server/modlog.ts
+++ b/server/modlog.ts
@@ -1,0 +1,316 @@
+/**
+ * Modlog
+ * Pokemon Showdown - http://pokemonshowdown.com/
+ *
+ * Moderator actions are logged into a set of files known as the moderation log, or "modlog."
+ * This file handles reading, writing, and querying the modlog.
+ *
+ * @license MIT
+ */
+
+import * as child_process from 'child_process';
+import {normalize as normalizePath} from 'path';
+import * as util from 'util';
+
+import {FS} from '../lib/fs';
+import {QueryProcessManager} from '../lib/process-manager';
+import {Repl} from '../lib/repl';
+
+const MAX_PROCESSES = 1;
+// If a modlog query takes longer than this, it will be logged.
+const LONG_QUERY_DURATION = 2000;
+const MODLOG_PATH = 'logs/modlog';
+
+const PUNISHMENTS = [
+	'ROOMBAN', 'UNROOMBAN', 'WARN', 'MUTE', 'HOURMUTE', 'UNMUTE', 'CRISISDEMOTE',
+	'WEEKLOCK', 'LOCK', 'UNLOCK', 'UNLOCKNAME', 'UNLOCKRANGE', 'UNLOCKIP', 'BAN',
+	'UNBAN', 'RANGEBAN', 'UNRANGEBAN', 'RANGELOCK', 'TRUSTUSER', 'UNTRUSTUSER',
+	'FORCERENAME', 'BLACKLIST', 'BATTLEBAN', 'UNBATTLEBAN', 'NAMEBLACKLIST',
+	'KICKBATTLE', 'TICKETBAN', 'UNTICKETBAN', 'HIDETEXT', 'HIDEALTSTEXT', 'REDIRECT',
+	'NOTE', 'MAFIAHOSTBAN', 'MAFIAUNHOSTBAN', 'GIVEAWAYBAN', 'GIVEAWAYUNBAN',
+	'TOUR BAN', 'TOUR UNBAN', 'AUTOLOCK', 'AUTONAMELOCK', 'NAMELOCK', 'UNNAMELOCK',
+	'AUTOBAN', 'MONTHLOCK',
+];
+const PUNISHMENTS_REGEX_STRING = `\\b(${PUNISHMENTS.join('|')}):.*`;
+
+const execFile = util.promisify(child_process.execFile);
+
+export type ModlogID = RoomID | 'global';
+
+interface ModlogResults {
+	results: string[];
+	duration?: number;
+}
+
+interface ModlogQuery {
+	rooms: ModlogID[];
+	search: string;
+	isExact: boolean;
+	maxLines: number;
+	onlyPunishments: boolean;
+}
+
+class SortedLimitedLengthList {
+	maxSize: number;
+	list: string[];
+
+	constructor(maxSize: number) {
+		this.maxSize = maxSize;
+		this.list = [];
+	}
+
+	getListClone() {
+		return this.list.slice();
+	}
+
+	insert(element: string) {
+		let insertedAt = -1;
+		for (let i = this.list.length - 1; i >= 0; i--) {
+			if (element.localeCompare(this.list[i]) < 0) {
+				insertedAt = i + 1;
+				if (i === this.list.length - 1) {
+					this.list.push(element);
+					break;
+				}
+				this.list.splice(i + 1, 0, element);
+				break;
+			}
+		}
+		if (insertedAt < 0) this.list.splice(0, 0, element);
+		if (this.list.length > this.maxSize) {
+			this.list.pop();
+		}
+	}
+}
+
+export function checkRipgrepAvailability() {
+	if (Config.ripgrepmodlog === undefined) {
+		Config.ripgrepmodlog = (async () => {
+			try {
+				await execFile('rg', ['--version'], {cwd: normalizePath(`${__dirname}/../`)});
+				await execFile('tac', ['--version'], {cwd: normalizePath(`${__dirname}/../`)});
+				return true;
+			} catch (error) {
+				return false;
+			}
+		})();
+	}
+	return Config.ripgrepmodlog;
+}
+
+export class Modlog {
+	readonly logPath: string;
+	/**
+	 * If a stream is undefined, that means it has not yet been initialized.
+	 * If a stream is truthy, it is open and ready to be written to.
+	 * If a stream is null, it has been destroyed/disabled.
+	 */
+	sharedStreams: Map<ID, Streams.WriteStream | null> = new Map();
+	streams: Map<ModlogID, Streams.WriteStream | null> = new Map();
+
+	constructor(path: string) {
+		this.logPath = path;
+	}
+
+	/**************************************
+	 * Methods for writing to the modlog. *
+	 **************************************/
+	initialize(roomid: ModlogID) {
+		if (this.streams.get(roomid)) return;
+		const sharedStreamId = this.getSharedID(roomid);
+		if (!sharedStreamId) {
+			return this.streams.set(roomid, FS(`${this.logPath}/modlog_${roomid}.txt`).createAppendStream());
+		}
+
+		let stream = this.sharedStreams.get(sharedStreamId);
+		if (!stream) {
+			stream = FS(`${this.logPath}/modlog_${sharedStreamId}.txt`).createAppendStream();
+			this.sharedStreams.set(sharedStreamId, stream);
+		}
+		this.streams.set(roomid, stream);
+	}
+
+	getSharedID(roomid: ModlogID): ID | false {
+		return roomid.includes('-') ? toID(roomid.split('-')[0]) : false;
+	}
+
+	/**
+	 * Writes to the modlog
+	 * @param overrideID Specify this parameter for when the room ID to be displayed
+	 * is different from the ID for the modlog stream
+	 * (The primary use case of this is tournament battles.)
+	 */
+	write(roomid: ModlogID, message: string, overrideID?: string) {
+		const stream = this.streams.get(roomid);
+		if (!stream) throw new Error(`Attempted to write to an uninitialized modlog stream for the room '${roomid}'`);
+		void stream.write(`[${new Date().toJSON()}] (${overrideID || roomid}) ${message}\n`);
+	}
+
+	async destroy(roomid: ModlogID) {
+		const stream = this.streams.get(roomid);
+		if (stream && !this.getSharedID(roomid)) {
+			this.streams.set(roomid, null);
+			await stream.writeEnd();
+		}
+		this.streams.set(roomid, null);
+	}
+
+	async rename(oldID: ModlogID, newID: ModlogID) {
+		const streamExists = this.streams.has(oldID);
+		if (streamExists) await this.destroy(oldID);
+		await FS(`${this.logPath}/modlog_${oldID}.txt`).rename(`${this.logPath}/modlog_${newID}.txt`);
+		if (streamExists) this.initialize(newID);
+	}
+
+	/******************************************
+	 * Methods for reading (searching) modlog *
+	 ******************************************/
+	 async runSearch(
+		rooms: ModlogID[], search: string, isExact: boolean, maxLines: number, onlyPunishments: boolean
+	) {
+		const useRipgrep = await checkRipgrepAvailability();
+		let fileNameList: string[] = [];
+		let checkAllRooms = false;
+		for (const roomid of rooms) {
+			if (roomid === 'all') {
+				checkAllRooms = true;
+				const fileList = await FS(this.logPath).readdir();
+				for (const file of fileList) {
+					if (file !== 'README.md' && file !== 'modlog_global.txt') fileNameList.push(file);
+				}
+			} else {
+				fileNameList.push(`modlog_${roomid}.txt`);
+			}
+		}
+		fileNameList = fileNameList.map(filename => `${this.logPath}/${filename}`);
+
+		// Ensure regexString can never be greater than or equal to the value of
+		// RegExpMacroAssembler::kMaxRegister in v8 (currently 1 << 16 - 1) given a
+		// searchString with max length MAX_QUERY_LENGTH. Otherwise, the modlog
+		// child process will crash when attempting to execute any RegExp
+		// constructed with it (i.e. when not configured to use ripgrep).
+		let regexString;
+		if (!search) {
+			regexString = '.';
+		} else if (isExact) {
+			regexString = search.replace(/[\\.+*?()|[\]{}^$]/g, '\\$&');
+		} else {
+			search = toID(search);
+			regexString = `[^a-zA-Z0-9]${[...search].join('[^a-zA-Z0-9]*')}([^a-zA-Z0-9]|\\z)`;
+		}
+		if (onlyPunishments) regexString = `${PUNISHMENTS_REGEX_STRING}${regexString}`;
+
+		const results = new SortedLimitedLengthList(maxLines);
+		if (useRipgrep) {
+			if (checkAllRooms) fileNameList = [this.logPath];
+			await this.runRipgrepSearch(fileNameList, regexString, results, maxLines);
+		} else {
+			const searchStringRegex = (search || onlyPunishments) ? new RegExp(regexString, 'i') : undefined;
+			for (const fileName of fileNameList) {
+				await this.readRoomModlog(fileName, results, searchStringRegex);
+			}
+		}
+		return results.getListClone().filter(Boolean);
+	}
+
+	async runRipgrepSearch(paths: string[], regexString: string, results: SortedLimitedLengthList, lines: number) {
+		let output;
+		try {
+			const options = [
+				'-i',
+				'-m', '' + lines,
+				'--pre', 'tac',
+				'-e', regexString,
+				'--no-filename',
+				'--no-line-number',
+				...paths,
+				'-g', '!modlog_global.txt', '-g', '!README.md',
+			];
+			output = await execFile('rg', options, {cwd: normalizePath(`${__dirname}/../../`)});
+		} catch (error) {
+			return results;
+		}
+		for (const fileName of output.stdout.split('\n').reverse()) {
+			if (fileName) results.insert(fileName);
+		}
+		return results;
+	}
+
+	async search(
+		roomid: ModlogID = 'global', search = '', maxLines = 20, onlyPunishments = false
+	): Promise<ModlogResults> {
+		let exactSearch = false;
+		if (/^["'].+["']$/.test(search)) {
+			exactSearch = true;
+			search = search.substring(1, search.length - 1);
+		}
+
+		const rooms = (roomid === 'public' ?
+			[...Rooms.rooms.values()]
+				.filter(room => !room.settings.isPrivate && !room.settings.isPersonal)
+				.map(room => room.roomid) :
+			[roomid]);
+
+		const query = {
+			modlogClass: this,
+			rooms: rooms,
+			search: search,
+			isExact: exactSearch,
+			maxLines: maxLines,
+			onlyPunishments: onlyPunishments,
+		};
+		const response = await PM.query(query);
+
+		if (response.duration > LONG_QUERY_DURATION) {
+			Monitor.log(`Long modlog query took ${response.duration} ms to complete: ${query}`);
+		}
+		return {results: response, duration: response.duration};
+	}
+
+	private async readRoomModlog(path: string, results: SortedLimitedLengthList, regex?: RegExp) {
+		const fileStream = FS(path).createReadStream();
+		let line;
+		while ((line = await fileStream.readLine()) !== null) {
+			if (!regex || regex.test(line)) {
+				results.insert(line);
+			}
+		}
+		void fileStream.destroy();
+		return results;
+	}
+}
+
+export const PM = new QueryProcessManager<ModlogQuery, string[] | undefined>(module, async data => {
+	const {rooms, search, isExact, maxLines, onlyPunishments} = data;
+	try {
+		return await modlog.runSearch(rooms, search, isExact, maxLines, onlyPunishments);
+	} catch (err) {
+		Monitor.crashlog(err, 'A modlog query', data);
+	}
+});
+if (!PM.isParentProcess) {
+	global.Config = require('./config-loader').Config;
+	global.toID = require('../sim/dex').Dex.getId;
+
+	// @ts-ignore ???
+	global.Monitor = {
+		crashlog(error: Error, source = 'A modlog process', details: {} | null = null) {
+			const repr = JSON.stringify([error.name, error.message, source, details]);
+			// @ts-ignore please be silent
+			process.send(`THROW\n@!!@${repr}\n${error.stack}`);
+		},
+	};
+
+	process.on('uncaughtException', err => {
+		if (Config.crashguard) {
+			Monitor.crashlog(err, 'A modlog child process');
+		}
+	});
+
+	// eslint-disable-next-line no-eval
+	Repl.start('modlog', cmd => eval(cmd));
+} else {
+	PM.spawn(MAX_PROCESSES);
+}
+
+export const modlog = new Modlog(MODLOG_PATH);

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -333,7 +333,8 @@ export abstract class BasicRoom {
 		return this;
 	}
 	modlog(message: string) {
-		this.log.modlog(message);
+		const override = this.tour ? `${this.roomid} tournament: ${this.tour.roomid}` : undefined;
+		this.log.modlog(message, override);
 		return this;
 	}
 	uhtmlchange(name: string, message: string) {
@@ -892,7 +893,7 @@ export abstract class BasicRoom {
 		}
 		this.logUserStatsInterval = null;
 
-		void this.log.destroy();
+		void this.log.destroy(true);
 
 		// get rid of some possibly-circular references
 		Rooms.rooms.delete(this.roomid);
@@ -912,7 +913,6 @@ export class GlobalRoomState {
 	readonly staffAutojoinList: RoomID[];
 	readonly ladderIpLog: WriteStream;
 	readonly reportUserStatsInterval: NodeJS.Timeout;
-	readonly modlogStream: WriteStream;
 	lockdown: boolean | 'pre' | 'ddos';
 	battleCount: number;
 	lastReportedCrash: number;
@@ -984,7 +984,7 @@ export class GlobalRoomState {
 			this.ladderIpLog = new WriteStream({write() { return undefined; }});
 		}
 		// Create writestream for modlog
-		this.modlogStream = FS('logs/modlog/modlog_global.txt').createAppendStream();
+		Rooms.Modlog.initialize('global');
 
 		this.reportUserStatsInterval = setInterval(
 			() => this.reportUserStats(),
@@ -1010,7 +1010,7 @@ export class GlobalRoomState {
 	}
 
 	modlog(message: string) {
-		void this.modlogStream.write('[' + (new Date().toJSON()) + '] ' + message + '\n');
+		void Rooms.Modlog.write('global', message);
 	}
 
 	writeChatRoomData() {
@@ -1630,6 +1630,7 @@ function getRoom(roomid?: string | BasicRoom) {
 }
 
 export const Rooms = {
+	Modlog: require('./modlog').modlog,
 	/**
 	 * The main roomid:Room table. Please do not hold a reference to a
 	 * room long-term; just store the roomid and grab it from here (with
@@ -1762,9 +1763,6 @@ export const Rooms = {
 		return room;
 	},
 
-	battleModlogStream: FS('logs/modlog/modlog_battle.txt').createAppendStream(),
-	groupchatModlogStream: FS('logs/modlog/modlog_groupchat.txt').createAppendStream(),
-
 	global: null! as GlobalRoomState,
 	lobby: null as ChatRoom | null,
 
@@ -1785,7 +1783,3 @@ export const Rooms = {
 	RoomBattleTimer,
 	PM: RoomBattlePM,
 };
-
-// initialize
-
-Rooms.global = new GlobalRoomState();

--- a/test/server/modlog.js
+++ b/test/server/modlog.js
@@ -1,0 +1,224 @@
+/**
+ * Tests for server/modlog.ts
+ * Written by Annika
+ */
+
+'use strict';
+
+const TEST_PATH = 'test/modlogs';
+
+const {FS} = require('../../.lib-dist/fs');
+
+const ml = require('../../.server-dist/modlog');
+const modlog = new ml.Modlog(TEST_PATH);
+const assert = require('assert').strict;
+
+const DATASET_A = [
+	`[2020-07-29T23:29:49.707Z] (readingtest) ROOMBAN: sometroll [127.0.0.1] by annika (FIRST ENTRY)`,
+	`[2020-07-29T23:29:49.717Z] (readingtest) LOCK: sometroll [127.0.0.1] by annika (ENTRY 2)`,
+	`[2020-07-29T23:29:49.72Z] (readingtest) ROOMBAN: sometroll [127.0.0.1] by annika (ENTRY 3)`,
+	`[2020-07-29T23:29:49.737Z] (readingtest) WEEKLOCK: sometroll [127.0.0.1] by annika (ENTRY 4)`,
+	`[2020-07-29T23:29:49.747Z] (readingtest) ROOMBAN: sometroll [127.0.0.1] by annika (ENTRY 5)`,
+	`[2020-07-29T23:29:49.757Z] (readingtest) ROOMBAN: sometroll [127.0.0.1] by annika (ENTRY 6)`,
+	`[2020-07-29T23:29:49.767Z] (readingtest) MUTE: sometroll [127.0.0.1] by annika (ENTRY 7)`,
+	`[2020-07-29T23:29:49.777Z] (readingtest) ROOMBAN: sometroll [127.0.0.1] by annika (ENTRY 8)`,
+	`[2020-07-29T23:29:49.787Z] (readingtest) ROOMBAN: sometroll [127.0.0.1] by annika (LAST ENTRY)`,
+];
+
+const DATASET_B = [
+	`[2020-07-29T23:29:49.797Z] (readingtest2) ROOMBAN: sometroll [127.0.0.1] by annika`,
+	`[2020-07-29T23:29:49.807Z] (readingtest2) ROOMBAN: sometroll [127.0.0.1] by annika`,
+	`[2020-07-29T23:29:49.817Z] (readingtest2) POLL: by annika`,
+	`[2020-07-29T23:29:49.827Z] (readingtest2) ROOMBAN: sometroll [127.0.0.1] by annika`,
+	`[2020-07-29T23:29:49.837Z] (readingtest2) TOUR START: by annika`,
+];
+
+/**
+ * Normalizes a modlog entry, handling timestamps and the like.
+ */
+const normalizeModlogEntry = (entry) => entry.replace(/\[[^\]]+\]/, `[TIMESTAMP]`);
+
+async function getLines(roomid) {
+	const lines = (await FS(`${TEST_PATH}/modlog_${modlog.getSharedID(roomid) || roomid}.txt`).read()).split('\n');
+	let lastLine;
+	while (!lastLine) lastLine = lines.pop();
+	if (!lastLine) throw new Error(`No modlog lines written.`);
+	return {lastLine, lines};
+}
+
+describe('Modlog (without FS writes)', () => {
+	it('should correctly determine if a room has a shared modlog', () => {
+		assert.ok(modlog.getSharedID('battle-gen8randombattle-42'));
+		assert.ok(modlog.getSharedID('groupchat-annika-shitposting'));
+		assert.ok(modlog.getSharedID('help-mePleaseIAmTrappedInAUnitTestFactory'));
+
+		assert.ok(!modlog.getSharedID('1v1'));
+		assert.ok(!modlog.getSharedID('development'));
+	});
+
+	it('should throw an error when writing to a destroyed modlog stream', () => {
+		modlog.initialize('somedeletedroom');
+		assert.doesNotThrow(() => modlog.write('somedeletedroom', 'ROOMBAN: sometroll [127.0.0.1] by annika'));
+		modlog.destroy('somedeletedroom');
+		assert.throws(() => modlog.write('somedeletedroom', 'ROOMBAN: sometroll [127.0.0.1] by annika'));
+	});
+
+	it('should throw an error when writing to an uninitialized modlog stream', () => {
+		assert.throws(() => modlog.write('lmaothisroomisntreal', 'ROOMBAN: sometroll [127.0.0.1] by annika'));
+		modlog.initialize('itsrealnow');
+		assert.doesNotThrow(() => modlog.write('itsrealnow', 'ROOMBAN: sometroll [127.0.0.1] by annika'));
+	});
+});
+
+describe('Modlog (with FS writes)', () => {
+	before(async () => {
+		/**
+		 * Some modlog tests involve writing to the filesystem.
+		 * Filesystem writes are disabled again in after(),
+		 * so this only affects tests in this describe().
+		 */
+		Config.nofswriting = false;
+
+		await FS(TEST_PATH).mkdirp();
+		await FS(`${TEST_PATH}/modlog_readingtest.txt`).write(DATASET_A.join('\n'));
+		await FS(`${TEST_PATH}/modlog_readingtest2.txt`).write(DATASET_B.join('\n'));
+	});
+
+	after(async () => {
+		await FS(TEST_PATH).rmdir(true);
+		Config.nofswriting = true;
+	});
+
+	/*******************************
+	 * Tests for writing to modlog *
+	 *******************************/
+	it('should write messages serially to the modlog', async () => {
+		modlog.initialize('development');
+		modlog.write('development', 'ROOMOWNER: [somecooluser] by someadmin');
+		modlog.write('development', 'ROOMBAN: [kjnhvgcfg] [127.0.0.1] by annika');
+		await modlog.destroy('development'); // ensure all writes have synced to disk
+
+		const lines = await getLines('development');
+
+		assert.equal(
+			normalizeModlogEntry(lines.lastLine),
+			normalizeModlogEntry('[2020-07-29T23:29:49.797Z] (development) ROOMBAN: [kjnhvgcfg] [127.0.0.1] by annika')
+		);
+		assert.equal(
+			normalizeModlogEntry(lines.lines.pop()),
+			normalizeModlogEntry('[2020-07-29T23:29:49.797Z] (development) ROOMOWNER: [somecooluser] by someadmin')
+		);
+	});
+
+	it('should support renaming modlogs', async () => {
+		const message = 'ROOMREGULAR USER: [somerandomreg] by annika (demote)';
+		// Modlog renaming tests should pass whether or not the room names within the file are changed
+		const messageRegex = /\[[^\]]+\] \((oldroom|newroom)\) ROOMREGULAR USER: \[somerandomreg\] by annika \(demote\)/;
+		modlog.initialize('oldroom');
+		modlog.write('oldroom', message);
+		await modlog.rename('oldroom', 'newroom');
+
+		assert.ok(FS(`${TEST_PATH}/modlog_newroom.txt`).existsSync());
+		assert.throws(() => modlog.write('oldroom', 'something'));
+
+		let lastLine = (await getLines('newroom')).lastLine;
+		assert.ok(messageRegex.test(lastLine));
+
+		modlog.write('newroom', 'ROOMBAN: [kjnhvgcfg] [127.0.0.1] by annika');
+		await modlog.destroy('newroom'); // ensure all writes have synced to disk
+
+		lastLine = (await getLines('newroom')).lastLine;
+		assert.strictEqual(
+			normalizeModlogEntry(lastLine),
+			normalizeModlogEntry('[2020-07-29T23:29:49.797Z] (newroom) ROOMBAN: [kjnhvgcfg] [127.0.0.1] by annika')
+		);
+	});
+
+	it('should use overrideID if specified', async () => {
+		modlog.initialize('battle-gen8randombattle-1337');
+		modlog.write('battle-gen8randombattle-1337', 'MODCHAT: by annika: to +', 'actually this: cool name');
+		await modlog.destroy('battle-gen8randombattle-1337'); // ensure all writes have synced to disk
+
+		const lastLine = (await getLines('battle-gen8randombattle-1337')).lastLine;
+		assert.strictEqual(
+			normalizeModlogEntry(lastLine),
+			normalizeModlogEntry('[2020-07-29T23:29:49.797Z] (actually this: cool name) MODCHAT: by annika: to +')
+		);
+	});
+
+	/**************************************
+	 * Tests for reading/searching modlog *
+	 **************************************/
+	it('should read the entire modlog file when not limited', async () => {
+		const results = await modlog.runSearch(['readingtest'], '', false, 10000, false);
+		assert.equal(results.length, DATASET_A.length);
+	});
+
+	it("should support searching multiple rooms' modlogs", async () => {
+		const results = await modlog.runSearch(['readingtest', 'readingtest2'], '', false, 10000, false);
+		assert.equal(results.length, DATASET_A.length + DATASET_B.length);
+	});
+
+	it('should be case-insensitive', async () => {
+		const notExactUpper = await modlog.runSearch(['readingtest'], 'someTRoll', false, 10000, false);
+		const notExactLower = await modlog.runSearch(['readingtest'], 'someTRoll', false, 10000, false);
+		const exactUpper = await modlog.runSearch(['readingtest'], 'sOmEtRoLl', true, 10000, false);
+		const exactLower = await modlog.runSearch(['readingtest'], 'sOmEtRoLl', true, 10000, false);
+
+		assert.deepStrictEqual(notExactUpper, notExactLower);
+		assert.deepStrictEqual(exactUpper, exactLower);
+	});
+
+	it('should respect isExact', async () => {
+		const notExact = await modlog.runSearch(['readingtest'], 'troll', false, 10000, false);
+		const exact = await modlog.runSearch(['readingtest'], 'troll', true, 10000, false);
+
+		assert.strictEqual(notExact.length, 0);
+		assert.ok(exact.length);
+	});
+
+	it('should be LIFO (last-in, first-out)', async () => {
+		modlog.initialize('lifotest');
+		modlog.write('lifotest', 'firstwrite');
+		modlog.write('lifotest', 'secondwrite');
+		await modlog.destroy('lifotest');
+
+		const search = await modlog.runSearch(['lifotest'], '', false, 10000, false);
+
+		assert.strictEqual(search.length, 2);
+
+		assert.ok(search[0].includes('secondwrite'));
+		assert.ok(!search[0].includes('firstwrite'));
+
+		assert.ok(search[1].includes('firstwrite'));
+		assert.ok(!search[1].includes('secondwrite'));
+	});
+
+	it('should support limiting the number of responses', async () => {
+		const unlimited = await modlog.runSearch(['readingtest'], '', false, 10000, false);
+		const limited = await modlog.runSearch(['readingtest'], '', false, 5, false);
+
+		assert.equal(limited.length, 5);
+		assert.ok(unlimited.length > limited.length);
+
+		assert.ok(limited[0].includes('LAST ENTRY'));
+		assert.ok(unlimited[0].includes('LAST ENTRY'));
+
+		const limitedLast = limited.pop();
+		const unlimitedLast = unlimited.pop();
+
+		assert.ok(!limitedLast.includes('FIRST ENTRY'));
+		assert.ok(unlimitedLast.includes('FIRST ENTRY'));
+	});
+
+	it('should support filtering out non-punishment-related logs', async () => {
+		const all = await modlog.runSearch(['readingtest2'], '', false, 10000, false);
+		const onlyPunishments = await modlog.runSearch(['readingtest2'], '', false, 10000, true);
+
+		assert.ok(all.length > onlyPunishments.length);
+		assert.strictEqual(
+			onlyPunishments.filter(result => result.includes('ROOMBAN')).length,
+			onlyPunishments.length
+		);
+	});
+});


### PR DESCRIPTION
This will make it easier to implement changes to modlog, such as #7074 and #6469.

I'm not sure if battlesearch should stay with the modlog. I find it pretty illogical to group them together in the same file, since they do fairly different things, but it would reduce the number of subprocesses (and they do both search logs, although by that logic you could argue for putting `/searchlog` in modlog.ts as well).