### PR TITLE
Room Settings: Don't display ' ' as a modchat option

### DIFF
--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -1475,7 +1475,7 @@ export const roomSettings: SettingsHandler[] = [
 			'off',
 			'autoconfirmed',
 			'trusted',
-			...RANKS.filter(symbol => Users.Auth.hasPermission(user, 'modchat', symbol, room)),
+			...RANKS.filter(symbol => symbol !== ' ' && Users.Auth.hasPermission(user, 'modchat', symbol, room)),
 		].map(rank => [rank, rank === (room.settings.modchat || 'off') || `modchat ${rank || 'off'}`]),
 	}),
 	(room, user) => ({

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -1475,7 +1475,7 @@ export const roomSettings: SettingsHandler[] = [
 			'off',
 			'autoconfirmed',
 			'trusted',
-			...RANKS.filter(symbol => symbol !== ' ' && Users.Auth.hasPermission(user, 'modchat', symbol, room)),
+			...RANKS.slice(1).filter(symbol => Users.Auth.hasPermission(user, 'modchat', symbol, room)),
 		].map(rank => [rank, rank === (room.settings.modchat || 'off') || `modchat ${rank || 'off'}`]),
 	}),
 	(room, user) => ({


### PR DESCRIPTION
We already have an off button that's hardcoded.