### PR TITLE
Gen 3-4: Fix Camouflage to change to Normal-type

### DIFF
--- a/data/mods/gen4/conditions.ts
+++ b/data/mods/gen4/conditions.ts
@@ -73,4 +73,24 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 		inherit: true,
 		counterMax: 8,
 	},
+	// Arceus's true typing for all its formes is Normal, and it's only Multitype
+	// that changes its type, but its formes are specified to be their corresponding
+	// type in the Pokedex, so that needs to be overridden. Without Multitype it
+	// starts as Normal type, but its type can be changed by other effects.
+	// This is mainly relevant for Hackmons Cup and Balanced Hackmons.
+	arceus: {
+		name: 'Arceus',
+		onBeforeSwitchIn(pokemon) {
+			pokemon.setType('Normal'); // Multitype will prevent this
+		},
+		onSwitchIn(pokemon) {
+			if (pokemon.ability === 'multitype') {
+				const item = pokemon.getItem();
+				const targetForme = (item?.onPlate ? 'Arceus-' + item.onPlate : 'Arceus');
+				if (pokemon.species.name !== targetForme) {
+					pokemon.formeChange(targetForme);
+				}
+			}
+		},
+	},
 };

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -231,7 +231,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		onHit(target) {
 			// includes() is used here over hasType() because for whatever reason Arceus-Water
 			// always returns Normal-type from hasType() which is stupid
-			if (target.types.includes('Normal') || !target.setType('Normal')) return false;
+			if (target.hasType('Normal') || !target.setType('Normal')) return false;
 			this.add('-start', target, 'typechange', 'Normal');
 		},
 	},

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -229,8 +229,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		desc: "The user's type changes based on the battle terrain. Normal type on the regular Wi-Fi terrain. Fails if the user has the Multitype Ability or if the type is one of the user's current types.",
 		shortDesc: "Changes user's type based on terrain. (Normal)",
 		onHit(target) {
-			// includes() is used here over hasType() because for whatever reason Arceus-Water
-			// always returns Normal-type from hasType() which is stupid
 			if (target.hasType('Normal') || !target.setType('Normal')) return false;
 			this.add('-start', target, 'typechange', 'Normal');
 		},

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -228,6 +228,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "The user's type changes based on the battle terrain. Normal type on the regular Wi-Fi terrain. Fails if the user has the Multitype Ability or if the type is one of the user's current types.",
 		shortDesc: "Changes user's type based on terrain. (Normal)",
+		onHit(target) {
+			if (!target.setType('Normal')) return false;
+			this.add('-start', target, 'typechange', 'Normal');
+		},
 	},
 	chatter: {
 		inherit: true,

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -229,7 +229,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		desc: "The user's type changes based on the battle terrain. Normal type on the regular Wi-Fi terrain. Fails if the user has the Multitype Ability or if the type is one of the user's current types.",
 		shortDesc: "Changes user's type based on terrain. (Normal)",
 		onHit(target) {
-			if (!target.setType('Normal')) return false;
+			// includes() is used here over hasType() because for whatever reason Arceus-Water
+			// always returns Normal-type from hasType() which is stupid
+			if (target.types.includes('Normal') || !target.setType('Normal')) return false;
 			this.add('-start', target, 'typechange', 'Normal');
 		},
 	},

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1795,7 +1795,12 @@ export class Pokemon {
 	 */
 	setType(newType: string | string[], enforce = false) {
 		// First type of Arceus, Silvally cannot be normally changed
-		if (!enforce && (this.species.num === 493 || this.species.num === 773)) return false;
+		if (!enforce) {
+			if ((this.battle.gen >= 5 && (this.species.num === 493 || this.species.num === 773)) ||
+				(this.battle.gen === 4 && this.hasAbility('multitype'))) {
+				return false;
+			}
+		}
 
 		if (!newType) throw new Error("Must pass type to setType");
 		this.types = (typeof newType === 'string' ? [newType] : newType);

--- a/test/sim/moves/camouflage.js
+++ b/test/sim/moves/camouflage.js
@@ -39,7 +39,7 @@ describe('Camouflage', function () {
 		assert.equal(battle.p1.active[0].types[0], 'Ground');
 	});
 
-	it.only('should fail on Multitype in Gen 4 and Arceus itself in Gen 5+', function () {
+	it('should fail on Multitype in Gen 4 and Arceus itself in Gen 5+', function () {
 		// Gen 4
 		battle = common.gen(4).createBattle([[
 			{species: 'arceus', ability: 'flashfire', moves: ['ember', 'conversion', 'camouflage']},
@@ -49,10 +49,7 @@ describe('Camouflage', function () {
 		]]);
 
 		battle.makeChoices('move conversion', 'auto');
-		console.log(battle.p1.active[0].types); // only Fire
-		console.log(battle.p1.active[0].hasType('Normal')); // returns true despite just saying it was only Fire
 		battle.makeChoices('move camouflage', 'auto');
-		console.log(battle.p1.active[0].types); // still Fire type because it doesn't pass the "already has Normal" check
 		assert.equal(battle.p1.active[0].types[0], 'Normal');
 
 		battle.makeChoices('switch 2', 'auto');

--- a/test/sim/moves/camouflage.js
+++ b/test/sim/moves/camouflage.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Camouflage', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should change the user to Normal-type (except in Generation V, to Ground-type)', function () {
+		battle = common.gen(7).createBattle([[
+			{species: 'wynaut', moves: ['camouflage']},
+		], [
+			{species: 'ralts', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].types[0], 'Normal');
+
+		battle = common.gen(4).createBattle([[
+			{species: 'wynaut', moves: ['camouflage']},
+		], [
+			{species: 'ralts', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].types[0], 'Normal');
+
+		battle = common.gen(5).createBattle([[
+			{species: 'wynaut', moves: ['camouflage']},
+		], [
+			{species: 'ralts', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].types[0], 'Ground');
+	});
+
+	it('should fail on Multitype in Gen 4 and Arceus itself in Gen 5+', function () {
+		// Gen 4
+		battle = common.gen(4).createBattle([[
+			{species: 'arceus-water', ability: 'flashfire', moves: ['camouflage']},
+			{species: 'goldeen', ability: 'multitype', moves: ['camouflage']},
+		], [
+			{species: 'feebas', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].types[0], 'Normal');
+
+		battle.makeChoices('switch 2', 'auto');
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].types[0], 'Water'); // If test fails, would be Normal-type
+
+		// Gen 5
+		battle = common.gen(5).createBattle([[
+			{species: 'arceus', ability: 'flashfire', moves: ['camouflage']},
+			{species: 'goldeen', ability: 'multitype', moves: ['camouflage']},
+		], [
+			{species: 'ralts', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].types[0], 'Normal'); // If test fails, would be Ground-type
+
+		battle.makeChoices('switch 2', 'auto');
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].types[0], 'Ground');
+	});
+
+	it('should fail in Gen 3-4 if the user already has what Camouflage would change to as either of its types', function () {
+		// Gen 4
+		battle = common.gen(4).createBattle([[
+			{species: 'pidgey', moves: ['camouflage']},
+		], [
+			{species: 'ralts', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].types.length, 2); // If test fails, would be 1 type only
+
+		// Gen 5
+		battle = common.gen(5).createBattle([[
+			{species: 'gligar', moves: ['camouflage']},
+		], [
+			{species: 'ralts', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].types.length, 1); // If test fails, would be 2 types
+	});
+});

--- a/test/sim/moves/camouflage.js
+++ b/test/sim/moves/camouflage.js
@@ -39,16 +39,20 @@ describe('Camouflage', function () {
 		assert.equal(battle.p1.active[0].types[0], 'Ground');
 	});
 
-	it('should fail on Multitype in Gen 4 and Arceus itself in Gen 5+', function () {
+	it.only('should fail on Multitype in Gen 4 and Arceus itself in Gen 5+', function () {
 		// Gen 4
 		battle = common.gen(4).createBattle([[
-			{species: 'arceus-water', ability: 'flashfire', moves: ['camouflage']},
+			{species: 'arceus', ability: 'flashfire', moves: ['ember', 'conversion', 'camouflage']},
 			{species: 'goldeen', ability: 'multitype', moves: ['camouflage']},
 		], [
 			{species: 'feebas', moves: ['sleeptalk']},
 		]]);
 
-		battle.makeChoices();
+		battle.makeChoices('move conversion', 'auto');
+		console.log(battle.p1.active[0].types); // only Fire
+		console.log(battle.p1.active[0].hasType('Normal')); // returns true despite just saying it was only Fire
+		battle.makeChoices('move camouflage', 'auto');
+		console.log(battle.p1.active[0].types); // still Fire type because it doesn't pass the "already has Normal" check
 		assert.equal(battle.p1.active[0].types[0], 'Normal');
 
 		battle.makeChoices('switch 2', 'auto');


### PR DESCRIPTION
Custom behavior for Gen 5 was being inherited by 3-4. I also bothered to test to make sure Camouflage really does change the user to be Ground-type in Gen 5 Link Battles on cart and it does, which is really stupid. It's Normal-type in Gen 4 and 6-7.