### PR TITLE
Chat: Make broadcasted sendReplyBoxes hidetextable

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -701,7 +701,7 @@ export class CommandContext extends MessageContext {
 		this.add(`|html|<div class="infobox">${htmlContent}</div>`);
 	}
 	sendReplyBox(htmlContent: string) {
-		this.sendReply(`|html|<div class="infobox">${htmlContent}</div>`);
+		this.sendReply(`|c|${this.room ? this.user.getIdentity() : '~'}|/raw <div class="infobox">${htmlContent}</div>`);
 	}
 	popupReply(message: string) {
 		this.connection.popup(message);


### PR DESCRIPTION
See https://www.smogon.com/forums/threads/allow-images-displayed-with-show-to-be-hidden-by-hidetext-and-similar-commands.3668239/. Should also be useful to make some other commands (see: /ds, etc) that are really spammy, hidetextable.