### PR TITLE
Support per-command permissions for sub-commands

### DIFF
--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -348,7 +348,6 @@ export const commands: ChatCommands = {
 			const allPermissions = Users.Auth.supportedRoomPermissions(room);
 			const permissionGroups = allPermissions.filter(perm => !perm.startsWith('/'));
 			const permissions = allPermissions.filter(perm => perm.startsWith('/') && !perm.includes(' '));
-			const readmore = `<details class="readmore code" style="white-space: pre-wrap; display: table; tab-size: 3"><summary>`;
 			const subPermissions = allPermissions.filter(perm => perm.startsWith('/') && perm.includes(' '));
 
 			let buffer = `<strong>Room permissions help:</strong><hr />`;
@@ -360,8 +359,8 @@ export const commands: ChatCommands = {
 			buffer += `<code>` + permissionGroups.join(`</code> <code>`) + `</code></p>`;
 			buffer += `<p><strong>Single-command permissions:</strong> (will affect one command)<br />`;
 			buffer += `<code>` + permissions.join(`</code> <code>`) + `</code></p>`;
-			buffer += `<p>${readmore}<strong>Sub-commands:</strong> (will affect one sub-command, like /roomevents view)</summary>`;
-			buffer += subPermissions.join(', ') + `</details></p>`;
+			buffer += `<p><details class="readmore"><summary><strong>Sub-commands:</strong> (will affect one sub-command, like /roomevents view)</summary>`;
+			buffer += `<code>` + subPermissions.join(`</code> <code>`) + `</code></details></p>`;
 			return this.sendReplyBox(buffer);
 		},
 	},

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -347,7 +347,8 @@ export const commands: ChatCommands = {
 
 			const allPermissions = Users.Auth.supportedRoomPermissions(room);
 			const permissionGroups = allPermissions.filter(perm => !perm.startsWith('/'));
-			const permissions = allPermissions.filter(perm => perm.startsWith('/'));
+			const permissions = allPermissions.filter(perm => perm.startsWith('/') && !perm.includes(' '));
+			const subPermissions = allPermissions.filter(perm => perm.startsWith('/') && perm.includes(' '));
 
 			let buffer = `<strong>Room permissions help:</strong><hr />`;
 			buffer += `<p><strong>Usage: </strong><br />`;
@@ -356,8 +357,10 @@ export const commands: ChatCommands = {
 			buffer += `<code>/permissions view</code></p>`;
 			buffer += `<p><strong>Group permissions:</strong> (will affect multiple commands or part of one command)<br />`;
 			buffer += `<code>` + permissionGroups.join(`</code> <code>`) + `</code></p>`;
-			buffer += `<p><details><summary><strong>Single-command permissions:</strong> (will affect one command)</summary>`;
-			buffer += `<code>` + permissions.join(`</code> <code>`) + `</code></details></p>`;
+			buffer += `<p><strong>Single-command permissions:</strong> (will affect one command)`;
+			buffer += `<code>` + permissions.join(`</code> <code>`) + `</code></p>`;
+			buffer += `<p><strong>Sub-commands:</strong> (will affect one command within a grouped command, eg /roomevents view)<br />`;
+			buffer += `<code>` + subPermissions.join('</code><code>') + `</code></p>`;
 			return this.sendReplyBox(buffer);
 		},
 	},

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -356,10 +356,10 @@ export const commands: ChatCommands = {
 			buffer += `<code>/permissions set [permission], [rank symbol]</code><br />`;
 			buffer += `<code>/permissions clear [permission]</code><br />`;
 			buffer += `<code>/permissions view</code></p>`;
-			buffer += `<p>${readmore}<strong>Group permissions:</strong> (will affect multiple commands or part of one command)</summary>`;
-			buffer += permissionGroups.join(`</code> <code>`) + `</details></p>`;
-			buffer += `<p>${readmore}<strong>Single-command permissions:</strong> (will affect one command)</summary>`;
-			buffer += permissions.join(`</code> <code>`) + `</details></p>`;
+			buffer += `<p><strong>Group permissions:</strong> (will affect multiple commands or part of one command)<br />`;
+			buffer += `<code>` + permissionGroups.join(`</code> <code>`) + `</code></p>`;
+			buffer += `<p><strong>Single-command permissions:</strong> (will affect one command)<br />`;
+			buffer += `<code>` + permissions.join(`</code> <code>`) + `</code></p>`;
 			buffer += `<p>${readmore}<strong>Sub-commands:</strong> (will affect one sub-command, like /roomevents view)</summary>`;
 			buffer += subPermissions.join(', ') + `</details></p>`;
 			return this.sendReplyBox(buffer);

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -356,8 +356,8 @@ export const commands: ChatCommands = {
 			buffer += `<code>/permissions view</code></p>`;
 			buffer += `<p><strong>Group permissions:</strong> (will affect multiple commands or part of one command)<br />`;
 			buffer += `<code>` + permissionGroups.join(`</code> <code>`) + `</code></p>`;
-			buffer += `<p><strong>Single-command permissions:</strong> (will affect one command)<br />`;
-			buffer += `<code>` + permissions.join(`</code> <code>`) + `</code></p>`;
+			buffer += `<p><details><summary><strong>Single-command permissions:</strong> (will affect one command)</summary>`;
+			buffer += `<code>` + permissions.join(`</code> <code>`) + `</code></details></p>`;
 			return this.sendReplyBox(buffer);
 		},
 	},

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -348,6 +348,7 @@ export const commands: ChatCommands = {
 			const allPermissions = Users.Auth.supportedRoomPermissions(room);
 			const permissionGroups = allPermissions.filter(perm => !perm.startsWith('/'));
 			const permissions = allPermissions.filter(perm => perm.startsWith('/') && !perm.includes(' '));
+			const readmore = `<details class="readmore code" style="white-space: pre-wrap; display: table; tab-size: 3"><summary>`;
 			const subPermissions = allPermissions.filter(perm => perm.startsWith('/') && perm.includes(' '));
 
 			let buffer = `<strong>Room permissions help:</strong><hr />`;
@@ -355,12 +356,12 @@ export const commands: ChatCommands = {
 			buffer += `<code>/permissions set [permission], [rank symbol]</code><br />`;
 			buffer += `<code>/permissions clear [permission]</code><br />`;
 			buffer += `<code>/permissions view</code></p>`;
-			buffer += `<p><strong>Group permissions:</strong> (will affect multiple commands or part of one command)<br />`;
-			buffer += `<code>` + permissionGroups.join(`</code> <code>`) + `</code></p>`;
-			buffer += `<p><strong>Single-command permissions:</strong> (will affect one command)`;
-			buffer += `<code>` + permissions.join(`</code> <code>`) + `</code></p>`;
-			buffer += `<p><strong>Sub-commands:</strong> (will affect one sub-command, like /roomevents view)<br />`;
-			buffer += `<code>` + subPermissions.join('</code><code>') + `</code></p>`;
+			buffer += `<p>${readmore}<strong>Group permissions:</strong> (will affect multiple commands or part of one command)</summary>`;
+			buffer += permissionGroups.join(`</code> <code>`) + `</details></p>`;
+			buffer += `<p>${readmore}<strong>Single-command permissions:</strong> (will affect one command)</summary>`;
+			buffer += permissions.join(`</code> <code>`) + `</details></p>`;
+			buffer += `<p>${readmore}<strong>Sub-commands:</strong> (will affect one sub-command, like /roomevents view)</summary>`;
+			buffer += subPermissions.join(', ') + `</details></p>`;
 			return this.sendReplyBox(buffer);
 		},
 	},

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -359,7 +359,7 @@ export const commands: ChatCommands = {
 			buffer += `<code>` + permissionGroups.join(`</code> <code>`) + `</code></p>`;
 			buffer += `<p><strong>Single-command permissions:</strong> (will affect one command)`;
 			buffer += `<code>` + permissions.join(`</code> <code>`) + `</code></p>`;
-			buffer += `<p><strong>Sub-commands:</strong> (will affect one command within a grouped command, eg /roomevents view)<br />`;
+			buffer += `<p><strong>Sub-commands:</strong> (will affect one sub-command, like /roomevents view)<br />`;
 			buffer += `<code>` + subPermissions.join('</code><code>') + `</code></p>`;
 			return this.sendReplyBox(buffer);
 		},

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -828,7 +828,7 @@ export class CommandContext extends MessageContext {
 	can(permission: GlobalPermission, target?: User | null): boolean;
 	can(permission: string, target: User | null = null, room: Room | null = null) {
 		if (Users.Auth.hasPermission(this.user, permission, target, room, this.cmd, true)) return true;
-		if (Users.Auth.hasPermission(this.user, permission, target, room, this.cmd, false)) {
+		if (Users.Auth.hasPermission(this.user, permission, target, room, this.fullCmd, false)) {
 			// If we need to use the true group's permission, reset the visual group
 			this.user.resetVisualGroup();
 			return true;

--- a/server/global-types.ts
+++ b/server/global-types.ts
@@ -26,6 +26,7 @@ namespace Chat {
 	export type NameFilter = import('./chat').NameFilter;
 	export type StatusFilter = import('./chat').StatusFilter;
 	export type LoginFilter = import('./chat').LoginFilter;
+	export type AnnotatedChatCommands = import('./chat').AnnotatedChatCommands;
 }
 
 // Rooms

--- a/server/user-groups.ts
+++ b/server/user-groups.ts
@@ -138,9 +138,17 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 		const permissions: string[] = ROOM_PERMISSIONS.slice();
 		for (const cmd in Chat.commands) {
 			const entry = Chat.commands[cmd];
-			if (typeof entry !== 'function') continue;
-			if (entry.hasRoomPermissions) {
+			if (typeof entry === 'string' || Array.isArray(entry)) continue;
+			if (typeof entry === 'function' && entry.hasRoomPermissions) {
 				permissions.push(`/${cmd}`);
+			}
+			if (typeof entry === 'object') {
+				for (const subCommand in entry) {
+					const subEntry = (entry as Chat.AnnotatedChatCommands)[subCommand];
+					if (typeof subEntry !== 'function') continue;
+					if (subEntry.hasRoomPermissions) permissions.push(`/${cmd} ${subCommand}`);
+				}
+				continue;
 			}
 		}
 		return permissions;


### PR DESCRIPTION
Reported by randbats roomstaff. Currently, this doesn't check sub command objects, eg /roomevents.
This fixes that.