### PR TITLE
Add short alias for /sharedbattles

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -310,6 +310,7 @@ export const commands: ChatCommands = {
 		this.sendReplyBox(buf);
 	},
 
+	sbtl: 'sharedbattles',
 	sharedbattles(target, room) {
 		if (!this.can('lock')) return false;
 


### PR DESCRIPTION
This was requested in Staff room a few days back but I forgot about it until now.