### PR TITLE
Roomsettings: Fix bug with single-command permissions

### DIFF
--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -7,7 +7,7 @@
  * @license MIT
  */
 import {Utils} from '../../lib/utils';
-import {ROOM_PERMISSIONS, GLOBAL_PERMISSIONS, GlobalPermission, RoomPermission} from '../user-groups';
+import type {RoomPermission} from '../user-groups';
 
 const RANKS = Config.groupsranking;
 

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -301,13 +301,14 @@ export const commands: ChatCommands = {
 			if (!Users.Auth.supportedRoomPermissions(room).includes(perm)) {
 				return this.errorReply(`${perm} is not a valid room permission.`);
 			}
-			if (!room.auth.atLeast(user, '#') ||
-				(
-					[...ROOM_PERMISSIONS, ...GLOBAL_PERMISSIONS].includes(perm as GlobalPermission | RoomPermission) &&
-					Users.Auth.hasPermission(user, perm, null, room)
-				)
+			if (!room.auth.atLeast(user, '#')) {
+				return this.errorReply(`/permissions set - You must be at least a Room Owner to set permissions.`);
+			}
+			if (
+				Users.Auth.ROOM_PERMISSIONS.includes(perm as RoomPermission) &&
+				!Users.Auth.hasPermission(user, perm, null, room)
 			) {
-				return this.errorReply(`/permissions set - Access denied.`);
+				return this.errorReply(`/permissions set - You can't set the permission "${perm}" because you don't have it.`);
 			}
 
 			const currentPermissions = room.settings.permissions || {};

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -7,6 +7,7 @@
  * @license MIT
  */
 import {Utils} from '../../lib/utils';
+import {ROOM_PERMISSIONS, GLOBAL_PERMISSIONS, GlobalPermission, RoomPermission} from '../user-groups';
 
 const RANKS = Config.groupsranking;
 
@@ -300,7 +301,12 @@ export const commands: ChatCommands = {
 			if (!Users.Auth.supportedRoomPermissions(room).includes(perm)) {
 				return this.errorReply(`${perm} is not a valid room permission.`);
 			}
-			if (!(room.auth.atLeast(user, '#') && Users.Auth.hasPermission(user, perm, null, room))) {
+			if (!room.auth.atLeast(user, '#') ||
+				(
+					[...ROOM_PERMISSIONS, ...GLOBAL_PERMISSIONS].includes(perm as GlobalPermission | RoomPermission) &&
+					Users.Auth.hasPermission(user, perm, null, room)
+				)
+			) {
 				return this.errorReply(`/permissions set - Access denied.`);
 			}
 


### PR DESCRIPTION
We shouldn't be checking `Auth#hasPermission` if the permission isn't a room or global permission, which I didn't understand in my previous bugfix.