### PR TITLE
Fix modlog tests on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [12.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If your distro package manager has an old Node.js version, the simplest way to u
 Detailed installation instructions
 ------------------------------------------------------------------------
 
-Pokémon Showdown requires you to have [Node.js][6] installed, v10.x or later.
+Pokémon Showdown requires you to have [Node.js][6] installed, v12.x or later.
 
 Next, obtain a copy of Pokémon Showdown. If you're reading this outside of GitHub, you've probably already done this. If you're reading this in GitHub, there's a "Clone or download" button near the top right (it's green). I recommend the "Open in Desktop" method - you need to install GitHub Desktop which is more work than "Download ZIP", but it makes it much easier to update in the long run (it lets you use the `/updateserver` command).
 

--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -331,7 +331,7 @@ export class FSPath {
 			// In Node versions before 12, fs.rmdir() didn't support recursion,
 			// so we have to implement recursion ourselves to support Node 10 and 11...
 			for (const file of await this.readdir()) {
-				const subpath = FS(`${this.path}/${file}`);
+				const subpath = FS(`${this.path}${pathModule.sep}${file}`);
 				if (await subpath.isDirectory()) {
 					await subpath.rmdir(true);
 				} else {
@@ -350,7 +350,7 @@ export class FSPath {
 		if (Config.nofswriting) return;
 		if (recursive) {
 			for (const file of this.readdirSync()) {
-				const subpath = FS(`${this.path}/${file}`);
+				const subpath = FS(`${this.path}${pathModule.sep}${file}`);
 				if (subpath.isDirectorySync()) {
 					subpath.rmdirSync(true);
 				} else {

--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -325,40 +325,20 @@ export class FSPath {
 		}
 	}
 
-	async rmdir(recursive?: boolean) {
+	async removeFilesFromDirectory() {
 		if (Config.nofswriting) return Promise.resolve();
-		if (recursive) {
-			// In Node versions before 12, fs.rmdir() didn't support recursion,
-			// so we have to implement recursion ourselves to support Node 10 and 11...
-			for (const file of await this.readdir()) {
-				const subpath = FS(`${this.path}${pathModule.sep}${file}`);
-				if (await subpath.isDirectory()) {
-					await subpath.rmdir(true);
-				} else {
-					await subpath.unlinkIfExists();
-				}
-			}
+		for (const file of await this.readdir()) {
+			const subpath = FS(`${this.path}${pathModule.sep}${file}`);
+			if (!await subpath.isDirectory()) await subpath.unlinkIfExists();
 		}
-		return new Promise((resolve, reject) => {
-			fs.rmdir(this.path, err => {
-				err ? reject(err) : resolve();
-			});
-		});
 	}
 
-	rmdirSync(recursive?: boolean) {
+	removeFilesFromDirectorySync(recursive?: boolean) {
 		if (Config.nofswriting) return;
-		if (recursive) {
-			for (const file of this.readdirSync()) {
-				const subpath = FS(`${this.path}${pathModule.sep}${file}`);
-				if (subpath.isDirectorySync()) {
-					subpath.rmdirSync(true);
-				} else {
-					subpath.unlinkIfExistsSync();
-				}
-			}
+		for (const file of this.readdirSync()) {
+			const subpath = FS(`${this.path}${pathModule.sep}${file}`);
+			if (!subpath.isDirectorySync()) subpath.unlinkIfExistsSync();
 		}
-		return fs.rmdirSync(this.path);
 	}
 
 	mkdir(mode: string | number = 0o755) {

--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -325,20 +325,18 @@ export class FSPath {
 		}
 	}
 
-	async removeFilesFromDirectory() {
+	async rmdir(recursive?: boolean) {
 		if (Config.nofswriting) return Promise.resolve();
-		for (const file of await this.readdir()) {
-			const subpath = FS(`${this.path}${pathModule.sep}${file}`);
-			if (!await subpath.isDirectory()) await subpath.unlinkIfExists();
-		}
+		return new Promise((resolve, reject) => {
+			fs.rmdir(this.path, {recursive}, err => {
+				err ? reject(err) : resolve();
+			});
+		});
 	}
 
-	removeFilesFromDirectorySync(recursive?: boolean) {
+	rmdirSync(recursive?: boolean) {
 		if (Config.nofswriting) return;
-		for (const file of this.readdirSync()) {
-			const subpath = FS(`${this.path}${pathModule.sep}${file}`);
-			if (!subpath.isDirectorySync()) subpath.unlinkIfExistsSync();
-		}
+		return fs.rmdirSync(this.path, {recursive});
 	}
 
 	mkdir(mode: string | number = 0o755) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "sqlite": "^3.0.6"
   },
   "engines": {
-    "node": ">=7.7.0"
+    "node": ">=12.0.0"
   },
   "scripts": {
     "start": "node pokemon-showdown start",

--- a/test/server/modlog.js
+++ b/test/server/modlog.js
@@ -85,7 +85,7 @@ describe('Modlog (with FS writes)', () => {
 	});
 
 	after(async () => {
-		await FS(TEST_PATH).rmdir(true);
+		await FS(TEST_PATH).removeFilesFromDirectory();
 		Config.nofswriting = true;
 	});
 

--- a/test/server/modlog.js
+++ b/test/server/modlog.js
@@ -85,7 +85,7 @@ describe('Modlog (with FS writes)', () => {
 	});
 
 	after(async () => {
-		await FS(TEST_PATH).removeFilesFromDirectory();
+		await FS(TEST_PATH).rmdir(true);
 		Config.nofswriting = true;
 	});
 


### PR DESCRIPTION
While it's certainly possible to implement a `FS#rmdir` method, removing directories on Node versions <12 is rather clunky given the minute idiosyncrasies of different operating systems and Node versions. Since PS! doesn't really need to remove directories, I think simply removing all the files within the directory is a reasonable solution for this usecase.