### PR TITLE
Introduce async generator methods for readable streams

### DIFF
--- a/lib/STREAMS.md
+++ b/lib/STREAMS.md
@@ -132,3 +132,19 @@ Can return synchronously. Use `await` or wrap the return value in `Promise.resol
 ### readStream.peekBuffer(byteCount)
 
 Like `readStream.read` and `readStream.peek`, but returns a Buffer instead of a string.
+
+### readStream.peeker([encoding])
+### readStream.reader([encoding])
+### readStream.delimitedReader(delimiter, [encoding])
+### readStream.lineReader([encoding])
+
+Returns an async generator that yields values returned by
+`readStream.peek`/`readStream.read`/`readStream.readDelimitedBy`/`readStream.readLine`
+until they return null or undefined. This can be iterated over with `for await
+... of` syntax:
+
+```js
+for await (const line of stream.lineReader()) {
+	console.log(line);
+}
+```

--- a/server/chat-plugins/chatlog.ts
+++ b/server/chat-plugins/chatlog.ts
@@ -120,8 +120,8 @@ const LogReader = new class {
 		if (!stream) {
 			buf += `<p class="message-error">Room "${roomid}" doesn't have logs for ${day}</p>`;
 		} else {
-			let line;
-			while ((line = await stream.readLine()) !== null && i < limit) {
+			for await (const line of stream.lineReader()) {
+				if (i >= limit) break;
 				const rendered = LogViewer.renderLine(line);
 				if (rendered) {
 					buf += `${line}\n`;
@@ -184,8 +184,7 @@ export const LogViewer = new class {
 		if (!stream) {
 			buf += `<p class="message-error">Room "${roomid}" doesn't have logs for ${day}</p>`;
 		} else {
-			let line;
-			while ((line = await stream.readLine()) !== null) {
+			for await (const line of stream.lineReader()) {
 				buf += this.renderLine(line, opts);
 			}
 		}

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -702,11 +702,9 @@ export class RoomBattle extends RoomGames.RoomGame {
 	}
 
 	async listen() {
-		let next;
 		let disconnected = false;
 		try {
-			// tslint:disable-next-line: no-conditional-assignment
-			while ((next = await this.stream.read())) {
+			for await (const next of this.stream.reader()) {
 				this.receive(next.split('\n'));
 			}
 		} catch (err) {

--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -26,8 +26,7 @@ type ChannelID = 0 | 1 | 2 | 3 | 4;
 export const Sockets = new class {
 	async onSpawn(worker: StreamWorker) {
 		const id = worker.workerid;
-		let data;
-		while ((data = await worker.stream.read())) {
+		for await (const data of worker.stream.reader()) {
 			switch (data.charAt(0)) {
 			case '*': {
 				// *socketid, ip, protocol

--- a/sim/README.md
+++ b/sim/README.md
@@ -8,8 +8,7 @@ const Sim = require('Pokemon-Showdown/sim');
 stream = new Sim.BattleStream();
 
 (async () => {
-    let output;
-    while ((output = await stream.read())) {
+    for await (const output of stream.reader()) {
         console.log(output);
     }
 })();

--- a/sim/battle-stream.ts
+++ b/sim/battle-stream.ts
@@ -167,9 +167,7 @@ export function getPlayerStreams(stream: BattleStream) {
 		}),
 	};
 	(async () => {
-		let chunk;
-		// tslint:disable-next-line:no-conditional-assignment
-		while ((chunk = await stream.read())) {
+		for await (const chunk of stream.reader()) {
 			const [type, data] = splitFirst(chunk, `\n`);
 			switch (type) {
 			case 'update':
@@ -212,9 +210,7 @@ export abstract class BattlePlayer {
 	}
 
 	async start() {
-		let chunk;
-		// tslint:disable-next-line:no-conditional-assignment
-		while ((chunk = await this.stream.read())) {
+		for await (const chunk of this.stream.reader()) {
 			this.receive(chunk);
 		}
 	}
@@ -256,11 +252,9 @@ export class BattleTextStream extends Streams.ReadWriteStream {
 	}
 
 	async start() {
-		let message;
-		// tslint:disable-next-line:no-conditional-assignment
-		while ((message = await this.battleStream.read())) {
+		for await (let message of this.battleStream.reader()) {
 			if (!message.endsWith('\n')) message += '\n';
-			this.push(message + '\n');
+			this.push(`${message}\n`);
 		}
 		this.pushEnd();
 	}


### PR DESCRIPTION
In some parts of PS, while loops combined with await are used to read
chunks of data from a stream sequentially. Async generators offer `for
await ... of` syntax, which can be used instead of this pattern. This
allows these loops to exist without the need to keep mutable state in
most cases and doesn't annoy TSLint.