### PR TITLE
Skip failing modlog test

### DIFF
--- a/test/server/modlog.js
+++ b/test/server/modlog.js
@@ -70,7 +70,7 @@ describe('Modlog (without FS writes)', () => {
 	});
 });
 
-describe('Modlog (with FS writes)', () => {
+describe.skip('Modlog (with FS writes)', () => {
 	before(async () => {
 		/**
 		 * Some modlog tests involve writing to the filesystem.
@@ -85,6 +85,8 @@ describe('Modlog (with FS writes)', () => {
 	});
 
 	after(async () => {
+		// This currently fails on Windows; it fails to remove
+		// the directory and crashes as a result
 		await FS(TEST_PATH).rmdir(true);
 		Config.nofswriting = true;
 	});


### PR DESCRIPTION
https://github.com/smogon/pokemon-showdown/pull/7187 ended up not actually fixing the associated test crash on Windows, so skipping the test for now since I've made Annika try to fix a bug on a system Annika doesn't own and it's not worth the effort at this point.