### PR TITLE
Hosts: Fix bug with /ipranges widen

### DIFF
--- a/server/chat-plugins/hosts.ts
+++ b/server/chat-plugins/hosts.ts
@@ -164,10 +164,15 @@ export const commands: ChatCommands = {
 			let successes = 0;
 			for (const range of rangesToAdd) {
 				IPTools.sortRanges();
+				let result;
 				try {
-					IPTools.checkRangeConflicts(range, IPTools.ranges, widen);
+					result = IPTools.checkRangeConflicts(range, IPTools.ranges, widen);
 				} catch (e) {
 					return this.errorReply(e.message);
+				}
+				if (typeof result === 'number') {
+					// Remove the range that is being widened
+					IPTools.removeRange(IPTools.ranges[result].minIP, IPTools.ranges[result].maxIP);
 				}
 				successes++;
 				IPTools.addRange(range);

--- a/server/ip-tools.ts
+++ b/server/ip-tools.ts
@@ -362,7 +362,7 @@ export const IPTools = new class {
 					if (sortedRanges[iMin + 1]?.minIP <= insertion.maxIP) {
 						throw new Error("You can only widen one address range at a time.");
 					}
-					return true;
+					return iMin;
 				}
 				throw new Error(
 					`Too wide: ${IPTools.numberToIP(insertion.minIP)}-${IPTools.numberToIP(insertion.maxIP)} (${insertion.host})\n` +


### PR DESCRIPTION
We need to actually remove ranges that widen is replacing.
(This requires an IPTools hotpatch as well as chat.)