### PR TITLE
Fix getBattles skip behavior wrt private rooms

### DIFF
--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1111,14 +1111,10 @@ export class GlobalRoomState {
 		return Config.rankList;
 	}
 
-	getBattles(/** "formatfilter, elofilter, usernamefilter */ filter: string) {
-		const rooms: GameRoom[] = [];
-		let skipCount = 0;
+	getBattles(/** formatfilter, elofilter, usernamefilter */ filter: string) {
+		let rooms: GameRoom[] = [];
 		const [formatFilter, eloFilterString, usernameFilter] = filter.split(',');
 		const eloFilter = +eloFilterString;
-		if (this.battleCount > 150 && !formatFilter && !eloFilter && !usernameFilter) {
-			skipCount = this.battleCount - 150;
-		}
 		for (const room of Rooms.rooms.values()) {
 			if (!room || !room.active || room.settings.isPrivate) continue;
 			if (room.type !== 'battle') continue;
@@ -1130,9 +1126,11 @@ export class GlobalRoomState {
 				if (!p1userid || !p2userid) continue;
 				if (!p1userid.startsWith(usernameFilter) && !p2userid.startsWith(usernameFilter)) continue;
 			}
-			if (skipCount && skipCount--) continue;
-
 			rooms.push(room);
+		}
+
+		if (rooms.length > 150 && !formatFilter && !eloFilter && !usernameFilter) {
+			rooms = rooms.slice(-150);
 		}
 
 		const roomTable: {[roomid: string]: BattleRoomTable} = {};

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1112,7 +1112,7 @@ export class GlobalRoomState {
 	}
 
 	getBattles(/** formatfilter, elofilter, usernamefilter */ filter: string) {
-		let rooms: GameRoom[] = [];
+		const rooms: GameRoom[] = [];
 		const [formatFilter, eloFilterString, usernameFilter] = filter.split(',');
 		const eloFilter = +eloFilterString;
 		for (const room of Rooms.rooms.values()) {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1129,10 +1129,6 @@ export class GlobalRoomState {
 			rooms.push(room);
 		}
 
-		if (rooms.length > 150 && !formatFilter && !eloFilter && !usernameFilter) {
-			rooms = rooms.slice(-150);
-		}
-
 		const roomTable: {[roomid: string]: BattleRoomTable} = {};
 		for (let i = rooms.length - 1; i >= rooms.length - 100 && i >= 0; i--) {
 			const room = rooms[i];


### PR DESCRIPTION
Rooms.global.battleCount considers both public and private battles,
but getBattles already passes over isPrivate battles, meaning if a
non-trivial number of battles are private, battleCount is much
larger than the number of public battles and all battles will be
skipped resulting in an empty "Watch Battles" tab for "(all
formats)".