### PR TITLE
Help: Only write state when relevant to the room

### DIFF
--- a/server/chat-plugins/help.ts
+++ b/server/chat-plugins/help.ts
@@ -180,15 +180,19 @@ export class HelpResponder {
 			return this.roomFaqs;
 		}
 		const roomid = room.roomid;
+		let hasDeletion = false;
 		this.roomFaqs = JSON.parse(FS(ROOMFAQ_FILE).readIfExistsSync() || `{"${roomid}":{}}`)[roomid];
 		for (const key in this.data.pairs) {
-			if (!this.roomFaqs[key]) delete this.data.pairs[key];
+			if (!this.roomFaqs[key]) {
+				delete this.data.pairs[key];
+				hasDeletion = true;
+			}
 		}
-		this.writeState();
+		if (hasDeletion) this.writeState();
 		return this.roomFaqs;
 	}
 	tryAddRegex(inputString: string, raw?: boolean) {
-		let [args, faq] = inputString.split('=>');
+		let [args, faq] = inputString.split('=>').map(item => item.trim());
 		faq = this.getFaqID(toID(faq)) as string;
 		if (!faq) throw new Chat.ErrorMessage("Invalid FAQ.");
 		if (!this.data.pairs) this.data.pairs = {};

--- a/server/chat-plugins/help.ts
+++ b/server/chat-plugins/help.ts
@@ -12,8 +12,8 @@ import {LogViewer} from './chatlog';
 import {roomFaqs} from './room-faqs';
 
 const PATH = 'config/chat-plugins/help.json';
-// 6: filters out conveniently short aliases
-const MINIMUM_LENGTH = 6;
+// 4: filters out conveniently short aliases
+const MINIMUM_LENGTH = 4;
 
 export let helpData: PluginData;
 
@@ -139,7 +139,10 @@ export class HelpResponder {
 	}
 	match(question: string, faq: string) {
 		if (!this.data.pairs[faq]) this.data.pairs[faq] = [];
-		if (!roomFaqs[faq]) {
+		const room = this.getRoom();
+		if (!room) return;
+		// mostly for the purpose of tests
+		if (!Config.nofswriting && !roomFaqs[room.roomid][faq]) {
 			delete this.data.pairs[faq];
 			this.writeState();
 			return null;

--- a/server/chat-plugins/help.ts
+++ b/server/chat-plugins/help.ts
@@ -124,7 +124,7 @@ export class HelpResponder {
 	/**
 	 * Checks if the FAQ exists. If not, deletes all references to it.
 	 */
-	faqExists(faq: string) {
+	updateFaqData(faq: string) {
 		// testing purposes
 		if (Config.nofswriting) return true;
 		const room = this.getRoom();
@@ -137,7 +137,6 @@ export class HelpResponder {
 				this.queue.splice(this.queue.indexOf(item), 1);
 			}
 		}
-		this.writeState();
 		return false;
 	}
 	stringRegex(str: string, raw?: boolean) {
@@ -161,7 +160,6 @@ export class HelpResponder {
 	}
 	match(question: string, faq: string) {
 		if (!this.data.pairs[faq]) this.data.pairs[faq] = [];
-		if (!this.faqExists(faq)) return null;
 		const regexes = this.data.pairs[faq].map(item => new RegExp(item, "i"));
 		if (!regexes) return;
 		for (const regex of regexes) {
@@ -189,6 +187,13 @@ export class HelpResponder {
 		return this.writeState();
 	}
 	writeState() {
+		this.data.queue = this.queue;
+		for (const faq in this.data.pairs) {
+			// while writing, clear old data. In the meantime, the rest of the data is inaccessible
+			// so this is the best place to clear the data
+			this.updateFaqData(faq);
+		}
+		this.data.queue = this.queue;
 		return FS(PATH).writeUpdate(() => JSON.stringify(this.data));
 	}
 	tryAddRegex(inputString: string, raw?: boolean) {

--- a/server/chat-plugins/help.ts
+++ b/server/chat-plugins/help.ts
@@ -205,12 +205,12 @@ export const chatfilter: ChatFilter = (message, user, room) => {
 	const helpRoom = Answerer.getRoom();
 	if (!helpRoom) return message;
 	if (room?.roomid === helpRoom.roomid && helpRoom.auth.get(user.id) === ' ' && !Answerer.disabled) {
+		if (message.startsWith('a:') || message.startsWith('A:')) return message.replace(/(a|A):/, '');
 		const reply = Answerer.visualize(message, false, user);
 		if (message.startsWith('/') || message.startsWith('!')) return message;
 		if (!reply) {
 			return message;
 		} else {
-			if (message.startsWith('a:') || message.startsWith('A:')) return message.replace(/(a|A):/, '');
 			user.sendTo(room.roomid, `|uhtml|askhelp-${user}-${toID(message)}|<div class="infobox">${reply}</div>`);
 			const trimmedMessage = `<div class="infobox">${Answerer.visualize(message, true)}</div>`;
 			setTimeout(() => {
@@ -417,6 +417,7 @@ export const pages: PageTable = {
 				buf += `- <a roomid="view-helpfilter-stats-${key}">${key}</a> (${stats[key].total})<br />`;
 			}
 			break;
+		case 'pairs':
 		case 'keys':
 			this.title = '[Help Regexes]';
 			if (!this.can('show', null, helpRoom)) return;

--- a/server/chat-plugins/help.ts
+++ b/server/chat-plugins/help.ts
@@ -9,7 +9,7 @@
 import {FS} from '../../lib/fs';
 import {Utils} from '../../lib/utils';
 import {LogViewer} from './chatlog';
-import {roomFaqs, ROOMFAQ_FILE} from './room-faqs';
+import {roomFaqs} from './room-faqs';
 
 const PATH = 'config/chat-plugins/help.json';
 // 6: filters out conveniently short aliases

--- a/server/chat-plugins/room-faqs.ts
+++ b/server/chat-plugins/room-faqs.ts
@@ -4,7 +4,7 @@ import {Utils} from '../../lib/utils';
 export const ROOMFAQ_FILE = 'config/chat-plugins/faqs.json';
 const MAX_ROOMFAQ_LENGTH = 8192;
 
-let roomFaqs: {[k: string]: {[k: string]: string}} = {};
+export let roomFaqs: {[k: string]: {[k: string]: string}} = {};
 try {
 	roomFaqs = JSON.parse(FS(ROOMFAQ_FILE).readIfExistsSync() || "{}");
 } catch (e) {

--- a/test/server/chat-plugins/help.js
+++ b/test/server/chat-plugins/help.js
@@ -13,10 +13,6 @@ const Help = new Responder({
 	queue: [],
 });
 
-Help.roomFaqs = {
-	catra: `Don't you get it?`,
-};
-
 describe('Help', function () {
 	it('should only return true on added regexes', function () {
 		Help.data.pairs.catra = [];

--- a/test/server/chat-plugins/help.js
+++ b/test/server/chat-plugins/help.js
@@ -13,12 +13,16 @@ const Help = new Responder({
 	queue: [],
 });
 
+Help.roomFaqs = {
+	catra: `Don't you get it?`,
+};
+
 describe('Help', function () {
 	it('should only return true on added regexes', function () {
 		Help.data.pairs.catra = [];
-		Help.data.pairs.catra.push(Help.stringRegex(`Hey & adora`));
-		assert.ok(Help.match('Hey, adora', 'catra'));
-		assert.ok(!Help.match('Hello, adora', 'catra'));
+		Help.data.pairs.catra.push(Help.stringRegex(`Hey & Adora`));
+		assert.ok(Help.match('Hey, Adora', 'catra'));
+		assert.ok(!Help.match('Hello, Adora', 'catra'));
 	});
 
 	it('should produce valid regexes', function () {


### PR DESCRIPTION
Previously this would write state whenever a faq was changed anywhere - an oversight on my part. 
now this checks to ensure that the roomfaq object has the faq - if not, it deletes the data for that faq and writes state. 
This DOES complicate testing, but the way i went with is asserting that nofswriting is off, since that (mostly) eliminates the point of the step with it on,