### PR TITLE
Modlog: Fix exact searches and improve hotpatching

### DIFF
--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -391,9 +391,8 @@ export const commands: ChatCommands = {
 				}
 				if (requiresForce(patch)) return this.errorReply(requiresForceMessage);
 
-				let streams = [];
-				streams = Rooms.Modlog.getActiveStreamIDs();
-				await Rooms.Modlog.destroyAll();
+				const streams = Rooms.Modlog.streams;
+				const sharedStreams = Rooms.Modlog.sharedStreams;
 
 				const processManagers = ProcessManager.processManagers;
 				for (const manager of processManagers.slice()) {
@@ -402,9 +401,8 @@ export const commands: ChatCommands = {
 
 				Rooms.Modlog = require('../modlog').modlog;
 				this.sendReply("Modlog has been hot-patched.");
-				for (const stream of streams) {
-					Rooms.Modlog.initialize(stream);
-				}
+				Rooms.Modlog.streams = streams;
+				Rooms.Modlog.sharedStreams = sharedStreams;
 				this.sendReply("Modlog streams have been re-initialized.");
 			} else if (target.startsWith('disable')) {
 				this.sendReply("Disabling hot-patch has been moved to its own command:");

--- a/server/chat-plugins/modlog-viewer.ts
+++ b/server/chat-plugins/modlog-viewer.ts
@@ -176,7 +176,7 @@ async function getModlog(
 		searchString = searchString.substring(1, searchString.length - 1);
 	}
 
-	const response = await Rooms.Modlog.search(roomid, searchString, maxLines, onlyPunishments);
+	const response = await Rooms.Modlog.search(roomid, searchString, maxLines, exactSearch, onlyPunishments);
 
 	connection.send(
 		prettifyResults(

--- a/server/modlog.ts
+++ b/server/modlog.ts
@@ -267,14 +267,8 @@ export class Modlog {
 	}
 
 	async search(
-		roomid: ModlogID = 'global', search = '', maxLines = 20, onlyPunishments = false
+		roomid: ModlogID = 'global', search = '', maxLines = 20, exactSearch = false, onlyPunishments = false
 	): Promise<ModlogResults> {
-		let exactSearch = false;
-		if (/^["'].+["']$/.test(search)) {
-			exactSearch = true;
-			search = search.substring(1, search.length - 1);
-		}
-
 		const rooms = (roomid === 'public' ?
 			[...Rooms.rooms.values()]
 				.filter(room => !room.settings.isPrivate && !room.settings.isPersonal)


### PR DESCRIPTION
Hotpatching modlog "properly" (i.e. reinitializing each stream) turns out to be far too slow in practice, causing the main server to lock up for >30 seconds. This will hopefully be quicker, albeit hackier.