### PR TITLE
Introduce chunk readers for ReadStream

### DIFF
--- a/lib/streams.ts
+++ b/lib/streams.ts
@@ -258,6 +258,42 @@ export class ReadStream {
 		return out;
 	}
 
+	byChunk(byteCount?: number | null) {
+		// eslint-disable-next-line @typescript-eslint/no-this-alias
+		const byteStream = this;
+		return new ObjectReadStream<string>({
+			async read(this: ObjectReadStream<string>) {
+				const next = await byteStream.read(byteCount);
+				if (typeof next === 'string') this.push(next);
+				else this.pushEnd();
+			},
+		});
+	}
+
+	byLine() {
+		// eslint-disable-next-line @typescript-eslint/no-this-alias
+		const byteStream = this;
+		return new ObjectReadStream<string>({
+			async read(this: ObjectReadStream<string>) {
+				const next = await byteStream.readLine();
+				if (typeof next === 'string') this.push(next);
+				else this.pushEnd();
+			},
+		});
+	}
+
+	delimitedBy(delimiter: string) {
+		// eslint-disable-next-line @typescript-eslint/no-this-alias
+		const byteStream = this;
+		return new ObjectReadStream<string>({
+			async read(this: ObjectReadStream<string>) {
+				const next = await byteStream.readDelimitedBy(delimiter);
+				if (typeof next === 'string') this.push(next);
+				else this.pushEnd();
+			},
+		});
+	}
+
 	async readBuffer(byteCount: number | null = null) {
 		await this.loadIntoBuffer(byteCount, true);
 		const out = await this.peekBuffer(byteCount);
@@ -476,6 +512,20 @@ export class ReadWriteStream extends ReadStream implements WriteStream {
 	}
 }
 
+type ObjectReadStreamOptions<T> = {
+	buffer?: T[],
+	read?: (this: ObjectReadStream<T>) => void | Promise<void>,
+	pause?: (this: ObjectReadStream<T>) => void | Promise<void>,
+	destroy?: (this: ObjectReadStream<T>) => void | Promise<void>,
+	nodeStream?: undefined,
+} | {
+	buffer?: undefined,
+	read?: undefined,
+	pause?: undefined,
+	destroy?: undefined,
+	nodeStream: NodeJS.ReadableStream,
+};
+
 export class ObjectReadStream<T> {
 	buf: T[];
 	readSize: number;
@@ -488,7 +538,7 @@ export class ObjectReadStream<T> {
 	nextPush: Promise<void>;
 	awaitingPush: boolean;
 
-	constructor(optionsOrStreamLike: {[k: string]: any} | NodeJS.ReadableStream | T[] = {}) {
+	constructor(optionsOrStreamLike: ObjectReadStreamOptions<T> | NodeJS.ReadableStream | T[] = {}) {
 		this.buf = [];
 		this.readSize = 0;
 		this.atEOF = false;
@@ -502,16 +552,16 @@ export class ObjectReadStream<T> {
 		});
 		this.awaitingPush = false;
 
-		let options;
+		let options: ObjectReadStreamOptions<T>;
 		if (Array.isArray(optionsOrStreamLike)) {
 			options = {buffer: optionsOrStreamLike};
 		} else if (typeof (optionsOrStreamLike as any)._readableState === 'object') {
 			options = {nodeStream: optionsOrStreamLike as NodeJS.ReadableStream};
 		} else {
-			options = optionsOrStreamLike;
+			options = optionsOrStreamLike as ObjectReadStreamOptions<T>;
 		}
-		if (options.nodeStream) {
-			const nodeStream: NodeJS.ReadableStream = options.nodeStream;
+		if ((options as any).nodeStream) {
+			const nodeStream: NodeJS.ReadableStream = (options as any).nodeStream;
 			this.nodeReadableStream = nodeStream;
 			nodeStream.on('data', data => {
 				this.push(data);
@@ -520,12 +570,13 @@ export class ObjectReadStream<T> {
 				this.pushEnd();
 			});
 
-			options.read = function (this: ReadStream, unusedBytes: number) {
-				this.nodeReadableStream!.resume();
-			};
-
-			options.pause = function (this: ReadStream) {
-				this.nodeReadableStream!.pause();
+			options = {
+				read() {
+					this.nodeReadableStream!.resume();
+				},
+				pause() {
+					this.nodeReadableStream!.pause();
+				},
 			};
 		}
 
@@ -742,6 +793,9 @@ export class ObjectWriteStream<T> {
 }
 
 interface ObjectReadWriteStreamOptions<T> {
+	read?: (this: ObjectReadStream<T>) => void | Promise<void>;
+	pause?: (this: ObjectReadStream<T>) => void | Promise<void>;
+	destroy?: (this: ObjectReadStream<T>) => void | Promise<void>;
 	write?: (this: ObjectWriteStream<T>, elem: T) => Promise<any> | undefined | void;
 	writeEnd?: () => Promise<any> | undefined | void;
 }

--- a/server/chat-plugins/chatlog.ts
+++ b/server/chat-plugins/chatlog.ts
@@ -120,12 +120,12 @@ const LogReader = new class {
 		if (!stream) {
 			buf += `<p class="message-error">Room "${roomid}" doesn't have logs for ${day}</p>`;
 		} else {
-			let line;
-			while ((line = await stream.readLine()) !== null && i < limit) {
+			for await (const line of stream.byLine()) {
 				const rendered = LogViewer.renderLine(line);
 				if (rendered) {
 					buf += `${line}\n`;
 					i++;
+					if (i > limit) break;
 				}
 			}
 		}
@@ -184,8 +184,7 @@ export const LogViewer = new class {
 		if (!stream) {
 			buf += `<p class="message-error">Room "${roomid}" doesn't have logs for ${day}</p>`;
 		} else {
-			let line;
-			while ((line = await stream.readLine()) !== null) {
+			for await (const line of stream.byLine()) {
 				buf += this.renderLine(line, opts);
 			}
 		}

--- a/server/modlog.ts
+++ b/server/modlog.ts
@@ -292,8 +292,7 @@ export class Modlog {
 
 	private async readRoomModlog(path: string, results: SortedLimitedLengthList, regex?: RegExp) {
 		const fileStream = FS(path).createReadStream();
-		let line;
-		while ((line = await fileStream.readLine()) !== null) {
+		for await (const line of fileStream.byLine()) {
 			if (!regex || regex.test(line)) {
 				results.insert(line);
 			}


### PR DESCRIPTION
This adds new functions `stream.byChunk(bytes)`, `stream.byLine()` etc which parse a `ReadStream` into an `ObjectReadStream<string>` which can then be consumed with for-await.

Fixes #7195