### PR TITLE
Slight HTML Button Improvements

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1293,17 +1293,17 @@ export class CommandContext extends MessageContext {
 					if ((!this.room || this.room.settings.isPersonal || this.room.settings.isPrivate === true) && !this.user.can('lock')) {
 						const buttonName = / name ?= ?"([^"]*)"/i.exec(tagContent)?.[1];
 						const buttonValue = / value ?= ?"([^"]*)"/i.exec(tagContent)?.[1];
-						if (buttonName === 'send' && buttonValue?.startsWith('/msg ')) {
-							const [pmTarget] = buttonValue.slice(5).split(',');
+						if (buttonName === 'send' && (buttonValue?.startsWith('/msg ') || buttonValue?.startsWith('/pm '))) {
+							const [pmTarget] = buttonValue.replace(/^\/(?:msg|pm) /, '').split(',');
 							const auth = this.room ? this.room.auth : Users.globalAuth;
-							if (auth.get(toID(pmTarget)) !== '*') {
+							if (auth.get(toID(pmTarget)) !== '*' && toID(pmTarget) !== this.user.id) {
 								this.errorReply(`This button is not allowed: <${tagContent}>`);
 								this.errorReply(`Your scripted button can't send PMs to ${pmTarget}, because that user is not a Room Bot.`);
 								return null;
 							}
 						} else if (buttonName) {
 							this.errorReply(`This button is not allowed: <${tagContent}>`);
-							this.errorReply(`You do not have permission to use most buttons. Here are the two types you're allowed can use:`);
+							this.errorReply(`You do not have permission to use most buttons. Here are the two types you're allowed to use:`);
 							this.errorReply(`1. Linking to a room: <a href="/roomid"><button>go to a place</button></a>`);
 							this.errorReply(`2. Sending a message to a Bot: <button name="send" value="/msg BOT_USERNAME, MESSAGE">send the thing</button>`);
 							return null;

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1293,7 +1293,7 @@ export class CommandContext extends MessageContext {
 					if ((!this.room || this.room.settings.isPersonal || this.room.settings.isPrivate === true) && !this.user.can('lock')) {
 						const buttonName = / name ?= ?"([^"]*)"/i.exec(tagContent)?.[1];
 						const buttonValue = / value ?= ?"([^"]*)"/i.exec(tagContent)?.[1];
-						const msgCommandRegex = /^\/(?:msg|pm|w) /;
+						const msgCommandRegex = /^\/(?:msg|pm|w|whisper) /i;
 						if (buttonName === 'send' && msgCommandRegex.test(buttonValue || '')) {
 							const [pmTarget] = buttonValue.replace(msgCommandRegex, '').split(',');
 							const auth = this.room ? this.room.auth : Users.globalAuth;

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1293,8 +1293,9 @@ export class CommandContext extends MessageContext {
 					if ((!this.room || this.room.settings.isPersonal || this.room.settings.isPrivate === true) && !this.user.can('lock')) {
 						const buttonName = / name ?= ?"([^"]*)"/i.exec(tagContent)?.[1];
 						const buttonValue = / value ?= ?"([^"]*)"/i.exec(tagContent)?.[1];
-						if (buttonName === 'send' && (buttonValue?.startsWith('/msg ') || buttonValue?.startsWith('/pm '))) {
-							const [pmTarget] = buttonValue.replace(/^\/(?:msg|pm) /, '').split(',');
+						const msgCommandRegex = /^\/(?:msg|pm|w) /;
+						if (buttonName === 'send' && msgCommandRegex.test(buttonValue || '')) {
+							const [pmTarget] = buttonValue.replace(msgCommandRegex, '').split(',');
 							const auth = this.room ? this.room.auth : Users.globalAuth;
 							if (auth.get(toID(pmTarget)) !== '*' && toID(pmTarget) !== this.user.id) {
 								this.errorReply(`This button is not allowed: <${tagContent}>`);

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1294,7 +1294,7 @@ export class CommandContext extends MessageContext {
 						const buttonName = / name ?= ?"([^"]*)"/i.exec(tagContent)?.[1];
 						const buttonValue = / value ?= ?"([^"]*)"/i.exec(tagContent)?.[1];
 						const msgCommandRegex = /^\/(?:msg|pm|w|whisper) /i;
-						if (buttonName === 'send' && msgCommandRegex.test(buttonValue || '')) {
+						if (buttonName === 'send' && buttonValue && msgCommandRegex.test(buttonValue)) {
 							const [pmTarget] = buttonValue.replace(msgCommandRegex, '').split(',');
 							const auth = this.room ? this.room.auth : Users.globalAuth;
 							if (auth.get(toID(pmTarget)) !== '*' && toID(pmTarget) !== this.user.id) {


### PR DESCRIPTION
Changes this makes:
a) Lets people use `/pm` instead of `/msg` in buttons, which is a lot more intuitive.
b) Permits the author of the HTML to direct messages towards themselves via buttons (useful for when Bots create subroomgroupchats and become #, or if they suddenly want hugs from random people).

(Didn't add /w since line limits are worse than horizontally sliced bread)