### PR TITLE
Fix ipsearch error message when no results found

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -419,7 +419,7 @@ export const commands: ChatCommands = {
 			}
 		}
 		if (!results.length) {
-			if (!IPTools.ipRegex.test(ip)) return this.errorReply(`${ip} is not a valid IP or host.`);
+			if (!ip.includes('.') && !ip.includes('?/')) return this.errorReply(`${ip} is not a valid IP or host.`);
 			return this.sendReply(`No results found.`);
 		}
 		return this.sendReply(results.join('; '));


### PR DESCRIPTION
Ipsearch takes singular IPs, IP ranges using asterisks, and hostname suffixes. Having a strict regex for all of these doesn't seem very straightforward, and I consider the ability to catch malformed IPs less important than the accuracy of the output messages of a tool I use regularly.