### PR TITLE
Show staff intro + pending requests on autojoin

### DIFF
--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -768,12 +768,8 @@ export abstract class BasicRoom {
 			this.reportJoin('j', user.getIdentityWithStatus(this.roomid), user);
 		}
 
-		if (user.can('mute', null, this)) {
-			this.sendUser(
-				user,
-				this.getStaffIntroMessage(user)
-			);
-		}
+		const staffIntro = this.getStaffIntroMessage(user);
+		if (staffIntro) this.sendUser(user, staffIntro);
 
 		this.users[user.id] = user;
 		this.userCount++;

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -655,6 +655,7 @@ export abstract class BasicRoom {
 			}
 			message += `</details></div>`;
 		}
+		return message ? `|raw|${message}` : ``;
 		return message;
 	}
 	getSubRooms(includeSecret = false) {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -634,7 +634,8 @@ export abstract class BasicRoom {
 		return message;
 	}
 	getStaffIntroMessage(user: User) {
-		let message = Utils.html`\n|raw|`;
+		if (!user.can('mute', null, this)) return ``;
+		let message = ``;
 		if (this.settings.staffMessage) {
 			message += `\n|raw|<div class="infobox">(Staff intro:)<br /><div>` +
 				this.settings.staffMessage.replace(/\n/g, '') +

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -628,9 +628,8 @@ export abstract class BasicRoom {
 				this.settings.introMessage.replace(/\n/g, '') +
 				`</div></div>`;
 		}
-		if (user.can('mute', null, this)) {
-			message += this.getStaffIntroMessage(user);
-		}
+		const staffIntro = this.getStaffIntroMessage(user);
+		if (staffIntro) message += `\n${staffIntro}`;
 		return message;
 	}
 	getStaffIntroMessage(user: User) {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -628,12 +628,19 @@ export abstract class BasicRoom {
 				this.settings.introMessage.replace(/\n/g, '') +
 				`</div></div>`;
 		}
-		if (this.settings.staffMessage && user.can('mute', null, this)) {
+		if (user.can('mute', null, this)) {
+			message += this.getStaffIntroMessage(user);
+		}
+		return message;
+	}
+	getStaffIntroMessage(user: User) {
+		let message = Utils.html`\n|raw|`;
+		if (this.settings.staffMessage) {
 			message += `\n|raw|<div class="infobox">(Staff intro:)<br /><div>` +
 				this.settings.staffMessage.replace(/\n/g, '') +
 				`</div>`;
 		}
-		if (this.pendingApprovals?.size && user.can('mute', null, this)) {
+		if (this.pendingApprovals?.size) {
 			message += `\n|raw|<div class="infobox">`;
 			message += `<details><summary>(Pending media requests: ${this.pendingApprovals.size})</summary>`;
 			for (const [userid, entry] of this.pendingApprovals) {
@@ -643,7 +650,7 @@ export abstract class BasicRoom {
 				message += `<strong>Comment:</strong> ${entry.comment ? entry.comment : 'None.'}<br />`;
 				message += `<button class="button" name="send" value="/approveshow ${userid}">Approve</button>` +
 				`<button class="button" name="send" value="/denyshow ${userid}">Deny</button></div>`;
-				message += `</div><hr />`;
+				message += `<hr />`;
 			}
 			message += `</details></div>`;
 		}
@@ -761,6 +768,13 @@ export abstract class BasicRoom {
 			this.reportJoin('j', user.getIdentityWithStatus(this.roomid), user);
 		}
 
+		if (user.can('mute', null, this)) {
+			this.sendUser(
+				user,
+				this.getStaffIntroMessage(user)
+			);
+		}
+
 		this.users[user.id] = user;
 		this.userCount++;
 
@@ -782,10 +796,10 @@ export abstract class BasicRoom {
 		this.users[user.id] = user;
 		if (joining) {
 			this.reportJoin('j', user.getIdentityWithStatus(this.roomid), user);
-			if (this.settings.staffMessage && user.can('mute', null, this)) {
+			if (user.can('mute', null, this)) {
 				this.sendUser(
 					user,
-					`|raw|<div class="infobox">(Staff intro:)<br /><div>${this.settings.staffMessage.replace(/\n/g, '')}</div></div>`
+					this.getStaffIntroMessage(user)
 				);
 			}
 		} else if (!user.named) {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -796,12 +796,8 @@ export abstract class BasicRoom {
 		this.users[user.id] = user;
 		if (joining) {
 			this.reportJoin('j', user.getIdentityWithStatus(this.roomid), user);
-			if (user.can('mute', null, this)) {
-				this.sendUser(
-					user,
-					this.getStaffIntroMessage(user)
-				);
-			}
+			const staffIntro = this.getStaffIntroMessage(user);
+			if (staffIntro) this.sendUser(user, staffIntro);
 		} else if (!user.named) {
 			this.reportJoin('l', oldid, user);
 		} else {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -655,7 +655,6 @@ export abstract class BasicRoom {
 			message += `</details></div>`;
 		}
 		return message ? `|raw|${message}` : ``;
-		return message;
 	}
 	getSubRooms(includeSecret = false) {
 		if (!this.subRooms) return [];


### PR DESCRIPTION
At the moment, the staff intro and pending requests only appear on manual joins, not on autojoin. This is because `user.can('mute', null, this)` results false when it is run since the user is not yet logged in. This change creates a new method for generating the staff intro that is run after the user is fully logged in. It also modifies the original `getIntroMessage` so that the staff intro and pending requests still appear on manual joins.