### PR TITLE
Don't show error message on leaving a deleted room

### DIFF
--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -374,7 +374,8 @@ export const commands: ChatCommands = {
 	part(target, room, user, connection) {
 		const targetRoom = target ? Rooms.search(target) : room;
 		if (!targetRoom) {
-			if (target.startsWith('view-')) return;
+			const roomid = target.toLowerCase().replace(/[^a-zA-Z0-9-]/g, '') as RoomID;
+			if (roomid.startsWith('view-') || Rooms.deletedRooms.has(roomid)) return;
 			return this.errorReply(`The room '${target}' does not exist.`);
 		}
 		user.leaveRoom(targetRoom, connection);

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -886,6 +886,7 @@ export abstract class BasicRoom {
 
 		void this.log.destroy(true);
 
+		Rooms.deletedRooms.add(this.roomid);
 		// get rid of some possibly-circular references
 		Rooms.rooms.delete(this.roomid);
 	}
@@ -1635,6 +1636,7 @@ export const Rooms = {
 	 */
 	rooms: new Map<RoomID, Room>(),
 	aliases: new Map<string, RoomID>(),
+	deletedRooms: new Set<RoomID>(),
 
 	get: getRoom,
 	search(name: string): Room | undefined {


### PR DESCRIPTION
This will require either a restart or a monkeypatch to add `Rooms.deletedRooms`. It fixes [this bug](https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/page-26#post-8574270).