### PR TITLE
Tweak team stringification

### DIFF
--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -1359,10 +1359,11 @@ export class ModdedDex {
 	stringifyTeam(team: PokemonSet[], nicknames?: string[]) {
 		let output = '';
 		for (const [i, mon] of team.entries()) {
-			output += nicknames ? `${nicknames?.[i]} (${mon.species})` : `${mon.species}`;
+			const species = Dex.getSpecies(mon.species);
+			output += nicknames ? `${nicknames?.[i]} (${species.name})` : species.name;
 			output += ` @ ${Dex.getItem(mon.item).name}<br/>`;
 			output += `Ability: ${Dex.getAbility(mon.ability).name}<br/>`;
-			if (mon.happiness && mon.happiness !== 255) output += `Happiness: ${mon.happiness}<br/>`;
+			if (typeof mon.happiness === 'number' && mon.happiness !== 255) output += `Happiness: ${mon.happiness}<br/>`;
 			const evs = [];
 			for (const stat in mon.evs) {
 				if (mon.evs[stat as StatName]) evs.push(`${mon.evs[stat as StatName]} ${stat}`);


### PR DESCRIPTION
As [reported](https://www.smogon.com/forums/posts/8575456) in the bug reports thread, it was using the id instead of the name. This change ensures that we're using the name.

While I was there I noticed that zero happiness wasn't going to work. I'm not sure that this is the preferred test so feel free to suggest something else.