### PR TITLE
Fix extraneous error message in /back

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -438,7 +438,9 @@ export class CommandContext extends MessageContext {
 			}
 		}
 
-		if (this.user.statusType === 'idle') this.user.setStatusType('online');
+		if (this.user.statusType === 'idle' && !['unaway', 'unafk', 'back'].includes(this.cmd)) {
+			this.user.setStatusType('online');
+		}
 
 		try {
 			if (this.handler) {


### PR DESCRIPTION
As per [this bug report](https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-8517371), the help message directs you to type `/back` when marked as idle/away, when really, `/back` is only necessary for the Busy status.