### PR TITLE
Properly inform client of statusType changes

### DIFF
--- a/server/users.ts
+++ b/server/users.ts
@@ -1408,6 +1408,7 @@ export class User extends Chat.MessageContext {
 		if (type === this.statusType) return;
 		this.statusType = type;
 		this.updateIdentity();
+		this.update();
 	}
 	setUserMessage(message: string) {
 		if (message === this.userMessage) return;


### PR DESCRIPTION
This should fix the bug where usernames remain grey on the client after reloading.