### PR TITLE
Fix /unlockip

### DIFF
--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -863,6 +863,7 @@ export const commands: ChatCommands = {
 
 		for (const curUser of Users.findUsers([], [target])) {
 			if (
+				curUser &&
 				(range ? curUser.locked === '#rangelock' : !curUser.locked.startsWith('#')) &&
 				!Punishments.getPunishType(curUser.id)
 			) {

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -862,7 +862,10 @@ export const commands: ChatCommands = {
 		Punishments.savePunishments();
 
 		for (const curUser of Users.findUsers([], [target])) {
-			if (curUser.locked?.startsWith('#') && !Punishments.getPunishType(curUser.id)) {
+			if (
+				(range ? curUser.locked.startsWith('#') : !curUser.locked.startsWith('#')) &&
+				!Punishments.getPunishType(curUser.id)
+			) {
 				curUser.locked = null;
 				if (curUser.namelocked) {
 					curUser.namelocked = null;

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -863,8 +863,7 @@ export const commands: ChatCommands = {
 
 		for (const curUser of Users.findUsers([], [target])) {
 			if (
-				curUser &&
-				(range ? curUser.locked === '#rangelock' : !curUser.locked.startsWith('#')) &&
+				(range ? curUser.locked === '#rangelock' : !curUser.locked?.startsWith('#')) &&
 				!Punishments.getPunishType(curUser.id)
 			) {
 				curUser.locked = null;

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -863,7 +863,7 @@ export const commands: ChatCommands = {
 
 		for (const curUser of Users.findUsers([], [target])) {
 			if (
-				(range ? curUser.locked.startsWith('#') : !curUser.locked.startsWith('#')) &&
+				(range ? curUser.locked === '#rangelock' : !curUser.locked.startsWith('#')) &&
 				!Punishments.getPunishType(curUser.id)
 			) {
 				curUser.locked = null;


### PR DESCRIPTION
#7266 fixed the behavior of `/unrangelock`, but introduced another bug. As far as I can tell, `/unlockip` should unlock all  users locked by name on the IP, while `/unrangelock` should unlock all users locked by a rangelock on the IP range.