### PR TITLE
Convert modlogs to SQLite

### DIFF
--- a/.eslintrc-no-types.json
+++ b/.eslintrc-no-types.json
@@ -11,6 +11,7 @@
     "logs/",
     "node_modules/",
     ".*-dist/",
+    "tools/modlog/converter.js",
     "tools/set-import/importer.js",
     "tools/set-import/sets",
     "server/global-variables.d.ts",
@@ -189,7 +190,10 @@
   },
   "overrides": [
     {
-      "files": ["./config/*.ts", "./data/**/*.ts", "./lib/*.ts", "./server/**/*.ts", "./sim/**/*.ts", "./tools/set-import/*.ts"],
+      "files": [
+        "./config/*.ts", "./data/**/*.ts", "./lib/*.ts", "./server/**/*.ts", "./sim/**/*.ts",
+        "./tools/set-import/*.ts", "./tools/modlog/*.ts"
+      ],
       "parser": "@typescript-eslint/parser",
       "parserOptions": {
         "ecmaVersion": 9,

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ databases/*.db*
 # Typescript build artifacts
 .*-dist/
 tools/set-import/importer.js
+tools/modlog/converter.js
 
 # visual studio live share
 .vs

--- a/build
+++ b/build
@@ -112,7 +112,7 @@ function sucrase(src, out, opts) {
 if (sucrase('./config', './.config-dist')) {
 	replace('.config-dist', [
 		{regex: /(require\(.*?)(lib|sim)/g, replace: `$1.$2-dist`},
-	]);	
+	]);
 }
 
 if (sucrase('./data', './.data-dist')) {
@@ -138,6 +138,12 @@ if (sucrase('./server', './.server-dist')) {
 if (sucrase('./tools/set-import', './tools/set-import', '--exclude-dirs=sets')) {
 	replace('./tools/set-import/importer.js', [
 		{regex: /(require\(.*?)(lib|sim)/g, replace: `$1.$2-dist`},
+	]);
+}
+
+if (sucrase('./tools/modlog', './tools/modlog')) {
+	replace('./tools/modlog/converter.js', [
+		{regex: /(require\(.*?)(lib|server)/g, replace: `$1.$2-dist`},
 	]);
 }
 

--- a/databases/schemas/modlog-schema.sql
+++ b/databases/schemas/modlog-schema.sql
@@ -1,0 +1,26 @@
+ CREATE TABLE IF NOT EXISTS modlog (
+    modlog_id INTEGER NOT NULL PRIMARY KEY,
+    -- UNIX timestamp
+    timestamp INTEGER NOT NULL,
+    --- roomid OR global-roomid
+    roomid TEXT NOT NULL,
+    action TEXT NOT NULL,
+    visual_roomid TEXT,
+    action_taker TEXT,
+    userid TEXT,
+    autoconfirmed_userid TEXT,
+    ip TEXT,
+    note TEXT
+);
+
+CREATE TABLE IF NOT EXISTS alts (
+    alts_id INTEGER NOT NULL,
+    userid TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS alts_index_1 ON alts(alts_id);
+CREATE INDEX IF NOT EXISTS ml_index_1 ON modlog(timestamp);
+CREATE INDEX IF NOT EXISTS ml_index_2 ON modlog(roomid, userid, autoconfirmed_userid, timestamp);
+CREATE INDEX IF NOT EXISTS ml_index_3 ON modlog(roomid, ip, timestamp);
+CREATE INDEX IF NOT EXISTS ml_index_4 ON modlog(roomid, note, timestamp);
+CREATE INDEX IF NOT EXISTS ml_index_5 ON modlog(roomid, action_taker, timestamp);

--- a/databases/schemas/modlog.sql
+++ b/databases/schemas/modlog.sql
@@ -6,7 +6,7 @@
     roomid TEXT NOT NULL,
     action TEXT NOT NULL,
     visual_roomid TEXT,
-    action_taker TEXT,
+    action_taker_userid TEXT,
     userid TEXT,
     autoconfirmed_userid TEXT,
     ip TEXT,
@@ -14,13 +14,16 @@
 );
 
 CREATE TABLE IF NOT EXISTS alts (
-    alts_id INTEGER NOT NULL,
-    userid TEXT NOT NULL
+    modlog_id INTEGER NOT NULL,
+    userid TEXT NOT NULL,
+    PRIMARY KEY (modlog_id, userid),
+    FOREIGN KEY (modlog_id) REFERENCES modlog(modlog_id)
 );
 
-CREATE INDEX IF NOT EXISTS alts_index_1 ON alts(alts_id);
 CREATE INDEX IF NOT EXISTS ml_index_1 ON modlog(timestamp);
 CREATE INDEX IF NOT EXISTS ml_index_2 ON modlog(roomid, userid, autoconfirmed_userid, timestamp);
 CREATE INDEX IF NOT EXISTS ml_index_3 ON modlog(roomid, ip, timestamp);
 CREATE INDEX IF NOT EXISTS ml_index_4 ON modlog(roomid, note, timestamp);
-CREATE INDEX IF NOT EXISTS ml_index_5 ON modlog(roomid, action_taker, timestamp);
+CREATE INDEX IF NOT EXISTS ml_index_5 ON modlog(roomid, action_taker_userid, timestamp);
+
+PRAGMA journal_mode=WAL;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The server for the Pokémon Showdown battle simulator",
   "version": "0.11.2",
   "dependencies": {
+    "better-sqlite3": "^7.1.0",
     "probe-image-size": "^5.0.0",
     "sockjs": "0.3.20",
     "sucrase": "^3.15.0"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@types/better-sqlite3": "^5.4.0",
     "better-sqlite3": "^7.1.0",
+    "lines-async-iterator": "^0.9.0",
     "probe-image-size": "^5.0.0",
     "sockjs": "0.3.20",
     "sucrase": "^3.15.0"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The server for the Pokémon Showdown battle simulator",
   "version": "0.11.2",
   "dependencies": {
+    "@types/better-sqlite3": "^5.4.0",
     "better-sqlite3": "^7.1.0",
     "probe-image-size": "^5.0.0",
     "sockjs": "0.3.20",

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -673,7 +673,7 @@ export const commands: ChatCommands = {
 
 			const displayReason = reason ? `: ${reason}` : ``;
 			this.privateModAction(room.tr`${targetUser.name}'s status "${targetUser.userMessage}" was cleared by ${user.name}${displayReason}.`);
-			this.globalModlog('CLEARSTATUS', targetUser, ` from "${targetUser.userMessage}" by ${user.name}${reason ? `: ${reason}` : ``}`);
+			this.globalModlog('CLEARSTATUS', targetUser, ` from "${targetUser.userMessage}"${displayReason}`);
 			targetUser.clearStatus();
 			targetUser.popup(`${user.name} has cleared your status message for being inappropriate${reason ? `: ${reason}` : '.'}`);
 			return;

--- a/server/chat-plugins/chat-monitor.ts
+++ b/server/chat-plugins/chat-monitor.ts
@@ -571,9 +571,9 @@ export const commands: ChatCommands = {
 			}
 			filterWords[list].push([regex, word, reason, filterTo || null, 0]);
 			if (Chat.monitors[list].punishment === 'FILTERTO') {
-				this.globalModlog(`ADDFILTER`, null, `'${String(regex)} => ${filterTo}' to ${list} list by ${user.name}${reason ? ` (${reason})` : ''}`);
+				this.globalModlog(`ADDFILTER`, null, `'${String(regex)} => ${filterTo}' to ${list} list ${reason ? `(${reason})` : ''}`);
 			} else {
-				this.globalModlog(`ADDFILTER`, null, `'${word}' to ${list} list by ${user.name}${reason ? ` (${reason})` : ''}`);
+				this.globalModlog(`ADDFILTER`, null, `'${word}' to ${list} list ${reason ? `(${reason})` : ''}`);
 			}
 			saveFilters(true);
 			const output = `'${word}' was added to the ${list} list.`;
@@ -598,7 +598,7 @@ export const commands: ChatCommands = {
 			}
 			filterWords[list] = filterWords[list].filter(entry => !words.includes(entry[1]));
 
-			this.globalModlog(`REMOVEFILTER`, null, `'${words.join(', ')}' from ${list} list by ${user.name}`);
+			this.globalModlog(`REMOVEFILTER`, null, `'${words.join(', ')}' from ${list} list`);
 			saveFilters(true);
 			const output = `'${words.join(', ')}' ${Chat.plural(words, "were", "was")} removed from the ${list} list.`;
 			Rooms.get('upperstaff')?.add(output).update();
@@ -629,7 +629,7 @@ export const commands: ChatCommands = {
 		const upperStaffRoom = Rooms.get('upperstaff');
 		if (staffRoom) staffRoom.add(msg).update();
 		if (upperStaffRoom) upperStaffRoom.add(msg).update();
-		this.globalModlog(`ALLOWNAME`, null, `${target} by ${user.name}`);
+		this.globalModlog(`ALLOWNAME`, null, target);
 	},
 };
 

--- a/server/chat-plugins/hosts.ts
+++ b/server/chat-plugins/hosts.ts
@@ -199,7 +199,7 @@ export const commands: ChatCommands = {
 				IPTools.addRange(range);
 			}
 
-			this.globalModlog('IPRANGE ADD', null, `by ${user.id}: added ${successes} IP ranges`);
+			this.globalModlog('IPRANGE ADD', null, `added ${successes} IP ranges`);
 			return this.sendReply(`Successfully added ${successes} IP ranges!`);
 		},
 		addhelp: [
@@ -221,7 +221,7 @@ export const commands: ChatCommands = {
 				void IPTools.removeRange(range.minIP, range.maxIP);
 				removed++;
 			}
-			this.globalModlog('IPRANGE REMOVE', null, `by ${user.id}: ${removed} IP ranges`);
+			this.globalModlog('IPRANGE REMOVE', null, `${removed} IP ranges`);
 			return this.sendReply(`Removed ${removed} IP ranges!`);
 		},
 		removehelp: [
@@ -248,7 +248,7 @@ export const commands: ChatCommands = {
 			};
 			void IPTools.addRange(range);
 			const renameInfo = `IP range at '${rangeString}' to ${range.host}`;
-			this.globalModlog('DATACENTER RENAME', null, `by ${user.id}: ${renameInfo}`);
+			this.globalModlog('DATACENTER RENAME', null, renameInfo);
 			return this.sendReply(`Renamed the ${renameInfo}.`);
 		},
 		renamehelp: [
@@ -394,7 +394,7 @@ export const commands: ChatCommands = {
 		note = ` (${note})`;
 
 		this.privateGlobalModAction(`The IP '${ip}' was marked as shared by ${user.name}.${note}`);
-		this.globalModlog('SHAREDIP', ip, ` by ${user.name}${note}`);
+		this.globalModlog('SHAREDIP', ip, note);
 	},
 	marksharedhelp: [
 		`/markshared [IP], [owner/organization of IP] - Marks an IP address as shared.`,
@@ -411,7 +411,7 @@ export const commands: ChatCommands = {
 		Punishments.removeSharedIp(target);
 
 		this.privateGlobalModAction(`The IP '${target}' was unmarked as shared by ${user.name}.`);
-		this.globalModlog('UNSHAREDIP', target, ` by ${user.name}`);
+		this.globalModlog('UNSHAREDIP', target);
 	},
 	unmarksharedhelp: [`/unmarkshared [IP] - Unmarks a shared IP address. Requires @ &`],
 
@@ -437,7 +437,7 @@ export const commands: ChatCommands = {
 			Punishments.addBlacklistedSharedIp(ip, reason);
 
 			this.privateGlobalModAction(`The IP '${ip}' was blacklisted from being marked as shared by ${user.name}.`);
-			this.globalModlog('SHAREDIP BLACKLIST', ip, ` by ${user.name}: ${reason.trim()}`);
+			this.globalModlog('SHAREDIP BLACKLIST', ip, reason.trim());
 		},
 		remove(target, room, user) {
 			if (!target) return this.parse(`/help nomarkshared`);
@@ -450,7 +450,7 @@ export const commands: ChatCommands = {
 			Punishments.removeBlacklistedSharedIp(target);
 
 			this.privateGlobalModAction(`The IP '${target}' was unblacklisted from being marked as shared by ${user.name}.`);
-			this.globalModlog('SHAREDIP UNBLACKLIST', target, ` by ${user.name}`);
+			this.globalModlog('SHAREDIP UNBLACKLIST', target);
 		},
 		view() {
 			return this.parse(`/join view-sharedipblacklist`);

--- a/server/chat-plugins/modlog-viewer.ts
+++ b/server/chat-plugins/modlog-viewer.ts
@@ -72,13 +72,6 @@ function getRoomID(id: string) {
 	return id as ModlogID;
 }
 
-function getAlias(id: string) {
-	for (const [alias, value] of Object.entries(ALIASES)) {
-		if (id === value) return alias as ModlogID;
-	}
-	return id as ModlogID;
-}
-
 function prettifyResults(
 	resultArray: ModlogEntry[], roomid: ModlogID, search: ModlogSearch, searchCmd: string,
 	addModlogLinks: boolean, hideIps: boolean, maxLines: number, onlyPunishments: boolean

--- a/server/chat-plugins/modlog-viewer.ts
+++ b/server/chat-plugins/modlog-viewer.ts
@@ -144,7 +144,7 @@ function prettifyResults(
 		preamble = `>view-modlog-${modlogid}\n|init|html\n|title|[Modlog]${title}\n` +
 			`|pagehtml|<div class="pad"><p>The last ${Chat.count(lines, `${scope}lines`)} of the Moderator Log of ${roomName}.`;
 	}
-	const moreButton = getMoreButton(getAlias(roomid), searchCmd, lines, maxLines, onlyPunishments);
+	const moreButton = getMoreButton(roomid, searchCmd, lines, maxLines, onlyPunishments);
 	return `${preamble}${resultString}${moreButton}</div>`;
 }
 

--- a/server/chat-plugins/modlog-viewer.ts
+++ b/server/chat-plugins/modlog-viewer.ts
@@ -217,9 +217,9 @@ async function getModlog(
  * Battle Search Functions
  *********************************************************/
 
-function checkRipgrepAvailability() {
+async function checkRipgrepAvailability() {
 	if (Config.ripgrepmodlog === undefined) {
-		Config.ripgrepmodlog = (async () => {
+		Config.ripgrepmodlog = await (async () => {
 			try {
 				await execFile('rg', ['--version'], {cwd: normalizePath(`${__dirname}/../`)});
 				await execFile('tac', ['--version'], {cwd: normalizePath(`${__dirname}/../`)});

--- a/server/chat-plugins/modlog-viewer.ts
+++ b/server/chat-plugins/modlog-viewer.ts
@@ -219,15 +219,13 @@ async function getModlog(
 
 async function checkRipgrepAvailability() {
 	if (Config.ripgrepmodlog === undefined) {
-		Config.ripgrepmodlog = await (async () => {
-			try {
-				await execFile('rg', ['--version'], {cwd: normalizePath(`${__dirname}/../`)});
-				await execFile('tac', ['--version'], {cwd: normalizePath(`${__dirname}/../`)});
-				return true;
-			} catch (error) {
-				return false;
-			}
-		})();
+		try {
+			await execFile('rg', ['--version'], {cwd: normalizePath(`${__dirname}/../`)});
+			await execFile('tac', ['--version'], {cwd: normalizePath(`${__dirname}/../`)});
+			Config.ripgrepmodlog = true;
+		} catch (error) {
+			Config.ripgrepmodlog = false;
+		}
 	}
 	return Config.ripgrepmodlog;
 }

--- a/server/chat-plugins/poll.ts
+++ b/server/chat-plugins/poll.ts
@@ -375,7 +375,11 @@ export const commands: ChatCommands = {
 				curRoom.minorActivityQueue!.splice(slot - 1, 1);
 				if (!curRoom.minorActivityQueue?.length) curRoom.minorActivityQueue = null;
 
-				curRoom.modlog(`DELETEQUEUE: by ${user}: ${slot}`);
+				curRoom.modlog({
+					action: 'DELETEQUEUE',
+					loggedBy: user.id,
+					note: slot.toString(),
+				});
 				curRoom.sendMods(this.tr`(${user.name} deleted the queued poll in slot ${slot}.)`);
 				curRoom.update();
 				if (update) this.parse(`/j view-pollqueue-${curRoom}`);

--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -882,7 +882,7 @@ export class ScavengerHunt extends Rooms.RoomGame {
 			this.room.sendMods(staffMsg);
 			this.room.roomlog(staffMsg);
 			this.room.modlog({
-				action: 'SCAVCHEATER',
+				action: 'SCAV CHEATER',
 				userid: player.id,
 				note: 'caught trying to do their own hunt',
 			});
@@ -902,7 +902,7 @@ export class ScavengerHunt extends Rooms.RoomGame {
 			this.room.sendMods(staffMsg);
 			this.room.roomlog(staffMsg);
 			this.room.modlog({
-				action: 'SCAVCHEATER',
+				action: 'SCAV CHEATER',
 				userid: player.id,
 				note: `caught attempting a hunt with ${uniqueConnections} connections on the account; has also been given 1 infraction point on the player leaderboard`,
 			});

--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -879,10 +879,13 @@ export class ScavengerHunt extends Rooms.RoomGame {
 
 			// notify staff
 			const staffMsg = `(${player.name} has been caught trying to do their own hunt.)`;
-			const logMsg = `([${player.id}] has been caught trying to do their own hunt.)`;
 			this.room.sendMods(staffMsg);
 			this.room.roomlog(staffMsg);
-			this.room.modlog(logMsg);
+			this.room.modlog({
+				action: 'SCAVCHEATER',
+				userid: player.id,
+				note: 'caught trying to do their own hunt',
+			});
 
 			PlayerLeaderboard.addPoints(player.name, 'infraction', 1);
 			player.infracted = true;
@@ -895,11 +898,14 @@ export class ScavengerHunt extends Rooms.RoomGame {
 
 			// notify staff
 			const staffMsg = `(${player.name} has been caught attempting a hunt with ${uniqueConnections} connections on the account. The user has also been given 1 infraction point on the player leaderboard.)`;
-			const logMsg = `([${player.id}] has been caught attempting a hunt with ${uniqueConnections} connections on the account. The user has also been given 1 infraction point on the player leaderboard.)`;
 
 			this.room.sendMods(staffMsg);
 			this.room.roomlog(staffMsg);
-			this.room.modlog(logMsg);
+			this.room.modlog({
+				action: 'SCAVCHEATER',
+				userid: player.id,
+				note: `caught attempting a hunt with ${uniqueConnections} connections on the account; has also been given 1 infraction point on the player leaderboard`,
+			});
 
 			PlayerLeaderboard.addPoints(player.name, 'infraction', 1);
 			player.infracted = true;
@@ -1995,7 +2001,11 @@ const ScavengerCommands: ChatCommands = {
 
 		// double modnote in scavs room if it is a subroomgroupchat
 		if (room.parent && !room.persist && scavsRoom) {
-			scavsRoom.modlog(`SCAV BLITZ: by ${user.id}: ${gameType}: ${blitzPoints}`);
+			scavsRoom.modlog({
+				action: 'SCAV BLITZ',
+				loggedBy: user.id,
+				note: `${gameType}: ${blitzPoints}`,
+			});
 			scavsRoom.sendMods(`(${user.name} has set the points awarded for blitz for ${gameType} hunts to ${blitzPoints} in <<${room.roomid}>>.)`);
 			scavsRoom.roomlog(`(${user.name} has set the points awarded for blitz for ${gameType} hunts to ${blitzPoints} in <<${room.roomid}>>.)`);
 		}
@@ -2026,7 +2036,11 @@ const ScavengerCommands: ChatCommands = {
 
 		// double modnote in scavs room if it is a subroomgroupchat
 		if (room.parent && !room.persist) {
-			scavsRoom.modlog(`SCAV SETHOSTPOINTS: [room: ${room.roomid}] by ${user.id}: ${points}`);
+			scavsRoom.modlog({
+				action: 'SCAV SETHOSTPOINTS',
+				loggedBy: user.id,
+				note: `${points} [room: ${room.roomid}]`,
+			});
 			scavsRoom.sendMods(`(${user.name} has set the points awarded for hosting regular scavenger hunts to - ${points} in <<${room.roomid}>>)`);
 			scavsRoom.roomlog(`(${user.name} has set the points awarded for hosting regular scavenger hunts to - ${points} in <<${room.roomid}>>)`);
 		}
@@ -2072,7 +2086,11 @@ const ScavengerCommands: ChatCommands = {
 
 		// double modnote in scavs room if it is a subroomgroupchat
 		if (room.parent && !room.persist) {
-			scavsRoom.modlog(`SCAV SETPOINTS: [room: ${room.roomid}] by ${user.id}: ${type}: ${pointsDisplay}`);
+			scavsRoom.modlog({
+				action: 'SCAV SETPOINTS',
+				loggedBy: user.id,
+				note: `${pointsDisplay} [room: ${room.roomid}]`,
+			});
 			scavsRoom.sendMods(`(${user.name} has set the points awarded for winning ${type} scavenger hunts to - ${pointsDisplay} in <<${room.roomid}>>)`);
 			scavsRoom.roomlog(`(${user.name} has set the points awarded for winning ${type} scavenger hunts to - ${pointsDisplay} in <<${room.roomid}>>)`);
 		}
@@ -2113,7 +2131,11 @@ const ScavengerCommands: ChatCommands = {
 		// double modnote in scavs room if it is a subroomgroupchat
 		if (room.parent && !room.persist) {
 			if (room.settings.scavSettings.officialtwist) {
-				scavsRoom.modlog(`SCAV TWIST: [room: ${room.roomid}] by ${user.id}: ${room.settings.scavSettings.officialtwist}`);
+				scavsRoom.modlog({
+					action: 'SCAV TWIST',
+					loggedBy: user.id,
+					note: `${room.settings.scavSettings.officialtwist} [room: ${room.roomid}]`,
+				});
 				scavsRoom.sendMods(`(${user.name} has set the official twist to - ${room.settings.scavSettings.officialtwist} in <<${room.roomid}>>)`);
 				scavsRoom.roomlog(`(${user.name} has set the official twist to  - ${room.settings.scavSettings.officialtwist} in <<${room.roomid}>>)`);
 			} else {

--- a/server/chat-plugins/trivia.ts
+++ b/server/chat-plugins/trivia.ts
@@ -755,7 +755,11 @@ export class Trivia extends Rooms.RoomGame {
 		const logbuf = this.getStaffEndMessage(winners, winner => winner.id);
 		this.room.sendMods(`(${buf}!)`);
 		this.room.roomlog(buf);
-		this.room.modlog(`TRIVIAGAME: by ${toID(this.game.creator)}: ${logbuf}`);
+		this.room.modlog({
+			action: 'TRIVIAGAME',
+			loggedBy: toID(this.game.creator),
+			note: logbuf,
+		});
 
 		if (!triviaData.history) triviaData.history = [];
 		triviaData.history.push(this.game);

--- a/server/chat-plugins/wifi.ts
+++ b/server/chat-plugins/wifi.ts
@@ -318,7 +318,11 @@ export class QuestionGiveaway extends Giveaway {
 				this.changeUhtml('<p style="text-align:center;font-size:13pt;font-weight:bold;">The giveaway has ended! Scroll down to see the answer.</p>');
 				this.phase = 'ended';
 				this.clearTimer();
-				this.room.modlog(`GIVEAWAY WIN: ${this.winner.name} won ${this.giver.name}'s giveaway for a "${this.prize}" (OT: ${this.ot} TID: ${this.tid})`);
+				this.room.modlog({
+					action: 'GIVEAWAY WIN',
+					userid: this.winner.id,
+					note: `${this.giver.name}'s giveaway for a "${this.prize}" (OT: ${this.ot} TID: ${this.tid})`,
+				});
 				this.send(this.generateWindow(
 					`<p style="text-align:center;font-size:12pt;"><b>${Utils.escapeHTML(this.winner.name)}</b> won the giveaway! Congratulations!</p>` +
 					`<p style="text-align:center;">${this.question}<br />Correct answer${Chat.plural(this.answers)}: ${this.answers.join(', ')}</p>`
@@ -465,7 +469,10 @@ export class LotteryGiveaway extends Giveaway {
 			this.changeUhtml(`<p style="text-align:center;font-size:13pt;font-weight:bold;">The giveaway has ended! Scroll down to see the winner${Chat.plural(this.winners)}.</p>`);
 			this.phase = 'ended';
 			const winnerNames = this.winners.map(winner => winner.name).join(', ');
-			this.room.modlog(`GIVEAWAY WIN: ${winnerNames} won ${this.giver.name}'s giveaway for "${this.prize}" (OT: ${this.ot} TID: ${this.tid})`);
+			this.room.modlog({
+				action: 'GIVEAWAY WIN',
+				note: `${winnerNames} won ${this.giver.name}'s giveaway for "${this.prize}" (OT: ${this.ot} TID: ${this.tid})`,
+			});
 			this.send(this.generateWindow(
 				`<p style="text-align:center;font-size:10pt;font-weight:bold;">Lottery Draw</p>` +
 				`<p style="text-align:center;">${Object.keys(this.joined).length} users joined the giveaway.<br />` +
@@ -590,7 +597,11 @@ export class GTSGiveaway {
 		} else {
 			this.clearTimer();
 			this.changeUhtml(`<p style="text-align:center;font-size:13pt;font-weight:bold;">The GTS giveaway has finished.</p>`);
-			this.room.modlog(`GTS FINISHED: ${this.giver.name} has finished their GTS giveaway for "${this.summary}"`);
+			this.room.modlog({
+				action: 'GTS FINISHED',
+				userid: this.giver.id,
+				note: `their GTS giveaway for "${this.summary}"`,
+			});
 			this.send(`<p style="text-align:center;font-size:11pt">The GTS giveaway for a "<strong>${Utils.escapeHTML(this.lookfor)}</strong>" has finished.</p>`);
 			Giveaway.updateStats(this.monIDs);
 		}

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -791,24 +791,20 @@ export class CommandContext extends MessageContext {
 		this.roomlog(`(${msg})`);
 	}
 	globalModlog(action: string, user: string | User | null, note?: string | null) {
-		let buf = `${action}: `;
+		const entry: ModlogEntry = {action, isGlobal: true, loggedBy: this.user.id, note: note?.replace(/\n/gm, ' ')};
 		if (user) {
 			if (typeof user === 'string') {
-				buf += `[${user}]`;
+				entry.userid = toID(user);
 			} else {
+				entry.ip = user.latestIp;
 				const userid = user.getLastId();
-				buf += `[${userid}]`;
-				if (user.autoconfirmed && user.autoconfirmed !== userid) buf += ` ac:[${user.autoconfirmed}]`;
-				const alts = user.getAltUsers(false, true).slice(1).map(alt => alt.getLastId()).join('], [');
-				if (alts.length) buf += ` alts:[${alts}]`;
-				buf += ` [${user.latestIp}]`;
+				entry.userid = userid;
+				if (user.autoconfirmed && user.autoconfirmed !== userid) entry.autoconfirmedID = user.autoconfirmed;
+				const alts = user.getAltUsers(false, true).slice(1).map(alt => alt.getLastId());
+				if (alts.length) entry.alts = alts;
 			}
 		}
-		if (!note) note = ` by ${this.user.id}`;
-		buf += note.replace(/\n/gm, ' ');
-
-		Rooms.global.modlog(buf, this.room?.roomid);
-		if (this.room) this.room.modlog(buf);
+		(this.room || Rooms.global).modlog(entry, this.room?.roomid);
 	}
 	modlog(
 		action: string,
@@ -816,25 +812,22 @@ export class CommandContext extends MessageContext {
 		note: string | null = null,
 		options: Partial<{noalts: any, noip: any}> = {}
 	) {
-		let buf = `${action}: `;
+		const entry: ModlogEntry = {action, loggedBy: this.user.id, note: note?.replace(/\n/gm, ' ')};
 		if (user) {
 			if (typeof user === 'string') {
-				buf += `[${toID(user)}]`;
+				entry.userid = toID(user);
 			} else {
 				const userid = user.getLastId();
-				buf += `[${userid}]`;
+				entry.userid = userid;
 				if (!options.noalts) {
-					if (user.autoconfirmed && user.autoconfirmed !== userid) buf += ` ac:[${user.autoconfirmed}]`;
-					const alts = user.getAltUsers(false, true).slice(1).map(alt => alt.getLastId()).join('], [');
-					if (alts.length) buf += ` alts:[${alts}]`;
+					if (user.autoconfirmed && user.autoconfirmed !== userid) entry.autoconfirmedID = user.autoconfirmed;
+					const alts = user.getAltUsers(false, true).slice(1).map(alt => alt.getLastId());
+					if (alts.length) entry.alts = alts;
 				}
-				if (!options.noip) buf += ` [${user.latestIp}]`;
+				if (!options.noip) entry.ip = user.latestIp;
 			}
 		}
-		buf += ` by ${this.user.id}`;
-		if (note) buf += `: ${note.replace(/\n/gm, ' ')}`;
-
-		(this.room || Rooms.global).modlog(buf);
+		(this.room || Rooms.global).modlog(entry);
 	}
 	roomlog(data: string) {
 		if (this.room) this.room.roomlog(data);

--- a/server/global-types.ts
+++ b/server/global-types.ts
@@ -2,6 +2,7 @@ type Config = typeof import('../config/config-example') & AnyObject;
 
 type GroupSymbol = import('./user-groups').GroupSymbol;
 type AuthLevel = import('./user-groups').AuthLevel;
+type ModlogEntry = import('./modlog').ModlogEntry;
 
 /** not actually guaranteed to be one of these */
 type PunishType = '#chatfilter' | '#hostfilter' | '#dnsbl' | '#ipban';

--- a/server/modlog.ts
+++ b/server/modlog.ts
@@ -154,7 +154,7 @@ export class Modlog {
 		return `[^a-zA-Z0-9]?${[...search].join('[^a-zA-Z0-9]*')}([^a-zA-Z0-9]|\\z)`;
 	}
 
-	formatArray(arr: any[], args: any[]) {
+	formatArray(arr: unknown[], args: unknown[]) {
 		args.push(...arr);
 		return [...'?'.repeat(arr.length)].join(', ');
 	}

--- a/server/modlog.ts
+++ b/server/modlog.ts
@@ -41,8 +41,8 @@ interface ModlogResults {
 }
 
 interface ModlogQuery {
-	statement: Database.Statement;
-	args: any[];
+	statement: Database.Statement<T>;
+	args: T[];
 }
 
 export interface ModlogSearch {

--- a/server/modlog.ts
+++ b/server/modlog.ts
@@ -91,10 +91,10 @@ export class Modlog {
 		this.altsInsertionQuery = this.database.prepare(`INSERT INTO alts (modlog_id, userid) VALUES (?, ?)`);
 		this.renameQuery = this.database.prepare(`UPDATE modlog SET roomid = ? WHERE roomid = ?`);
 		this.globalPunishmentsSearchQuery = this.database.prepare(
-			`SELECT * FROM modlog WHERE (roomid LIKE 'global-%' OR roomid = 'global')` +
-			` AND action IN (${this.formatArray(GLOBAL_PUNISHMENTS, [])})` +
-			` AND (userid = ? OR autoconfirmed_userid = ? OR EXISTS(SELECT * FROM alts WHERE alts.modlog_id = modlog.modlog_id AND userid = ?)` +
-			` AND timestamp > ?`
+			`SELECT * FROM modlog WHERE (roomid = 'global' OR roomid LIKE 'global-%') ` +
+			`AND action IN (${this.formatArray(GLOBAL_PUNISHMENTS, [])}) ` +
+			`AND (userid = ? OR autoconfirmed_userid = ? OR EXISTS(SELECT * FROM alts WHERE alts.modlog_id = modlog.modlog_id AND userid = ?)) ` +
+			`AND timestamp > ?`
 		);
 
 		this.insertionTransaction = this.database.transaction((
@@ -130,7 +130,8 @@ export class Modlog {
 		if (overrideID) entry.visualRoomID = overrideID;
 		if (!entry.roomID) entry.roomID = roomid;
 		this.insertionTransaction(
-			entry.roomID, entry.action, entry.time || Date.now(), entry.visualRoomID, entry.userid,
+			entry.isGlobal && entry.roomID !== 'global' ? `global-${entry.roomID}` : entry.roomID,
+			entry.action, entry.time || Date.now(), entry.visualRoomID, entry.userid,
 			entry.autoconfirmedID, entry.ip, entry.loggedBy, entry.note, entry.alts,
 		);
 	}

--- a/server/modlog.ts
+++ b/server/modlog.ts
@@ -8,26 +8,21 @@
  * @license MIT
  */
 
-import * as child_process from 'child_process';
-import {normalize as normalizePath} from 'path';
-import * as util from 'util';
 
 import {FS} from '../lib/fs';
 import {QueryProcessManager} from '../lib/process-manager';
 import {Repl} from '../lib/repl';
+import * as Database from 'better-sqlite3';
 
 const MAX_PROCESSES = 1;
 // If a modlog query takes longer than this, it will be logged.
 const LONG_QUERY_DURATION = 2000;
-const MODLOG_PATH = 'logs/modlog';
-
+const MODLOG_DB_PATH = `${__dirname}/../databases/modlog.db`;
 
 const GLOBAL_PUNISHMENTS = [
 	'WEEKLOCK', 'LOCK', 'BAN', 'RANGEBAN', 'RANGELOCK', 'FORCERENAME',
 	'TICKETBAN', 'AUTOLOCK', 'AUTONAMELOCK', 'NAMELOCK', 'AUTOBAN', 'MONTHLOCK',
 ];
-const GLOBAL_PUNISHMENTS_REGEX_STRING = `\\b(${GLOBAL_PUNISHMENTS.join('|')}):.*`;
-
 const PUNISHMENTS = [
 	...GLOBAL_PUNISHMENTS, 'ROOMBAN', 'UNROOMBAN', 'WARN', 'MUTE', 'HOURMUTE', 'UNMUTE',
 	'CRISISDEMOTE', 'UNLOCK', 'UNLOCKNAME', 'UNLOCKRANGE', 'UNLOCKIP', 'UNBAN',
@@ -36,286 +31,241 @@ const PUNISHMENTS = [
 	'NOTE', 'MAFIAHOSTBAN', 'MAFIAUNHOSTBAN', 'GIVEAWAYBAN', 'GIVEAWAYUNBAN',
 	'TOUR BAN', 'TOUR UNBAN', 'UNNAMELOCK',
 ];
-const PUNISHMENTS_REGEX_STRING = `\\b(${PUNISHMENTS.join('|')}):.*`;
-
-const execFile = util.promisify(child_process.execFile);
 
 export type ModlogID = RoomID | 'global';
 
 interface ModlogResults {
-	results: string[];
+	results: ModlogEntry[];
 	duration?: number;
 }
 
 interface ModlogQuery {
-	rooms: ModlogID[];
-	search: string;
-	isExact: boolean;
-	maxLines: number;
-	onlyPunishments: boolean | string;
+	query: string;
+	args: any[];
 }
 
-class SortedLimitedLengthList {
-	maxSize: number;
-	list: string[];
-
-	constructor(maxSize: number) {
-		this.maxSize = maxSize;
-		this.list = [];
-	}
-
-	getListClone() {
-		return this.list.slice();
-	}
-
-	insert(element: string) {
-		let insertedAt = -1;
-		for (let i = this.list.length - 1; i >= 0; i--) {
-			if (element.localeCompare(this.list[i]) < 0) {
-				insertedAt = i + 1;
-				if (i === this.list.length - 1) {
-					this.list.push(element);
-					break;
-				}
-				this.list.splice(i + 1, 0, element);
-				break;
-			}
-		}
-		if (insertedAt < 0) this.list.splice(0, 0, element);
-		if (this.list.length > this.maxSize) {
-			this.list.pop();
-		}
-	}
+export interface ModlogSearch {
+	note?: {searches: string[], isExact?: boolean};
+	user?: string;
+	ip?: string;
+	action?: string;
+	actionTaker?: string;
 }
 
-export function checkRipgrepAvailability() {
-	if (Config.ripgrepmodlog === undefined) {
-		Config.ripgrepmodlog = (async () => {
-			try {
-				await execFile('rg', ['--version'], {cwd: normalizePath(`${__dirname}/../`)});
-				await execFile('tac', ['--version'], {cwd: normalizePath(`${__dirname}/../`)});
-				return true;
-			} catch (error) {
-				return false;
-			}
-		})();
-	}
-	return Config.ripgrepmodlog;
+export interface ModlogEntry {
+	action: string;
+	roomID?: string;
+	visualRoomID?: string;
+	userid?: ID;
+	autoconfirmedID?: ID;
+	alts?: ID[];
+	ip?: string;
+	isGlobal?: boolean;
+	loggedBy?: ID;
+	note?: string;
+	/** Milliseconds since the epoch */
+	time?: number;
 }
 
 export class Modlog {
-	readonly logPath: string;
-	/**
-	 * If a stream is undefined, that means it has not yet been initialized.
-	 * If a stream is truthy, it is open and ready to be written to.
-	 * If a stream is null, it has been destroyed/disabled.
-	 */
-	sharedStreams: Map<ID, Streams.WriteStream | null> = new Map();
-	streams: Map<ModlogID, Streams.WriteStream | null> = new Map();
+	readonly database: Database.Database;
+	readonly usePM: boolean;
 
-	constructor(path: string) {
-		this.logPath = path;
+	constructor(path: string, noProcessManager = false) {
+		this.database = new Database(path);
+		this.database.exec(FS(`${__dirname}/../databases/schemas/modlog-schema.sql`).readIfExistsSync()); // Set up tables, etc.
+		this.database.function('regex', {deterministic: true}, (regexString, toMatch) => {
+			return Number(RegExp(regexString).test(toMatch));
+		});
+		this.usePM = !noProcessManager;
 	}
 
-	/**************************************
-	 * Methods for writing to the modlog. *
-	 **************************************/
-	initialize(roomid: ModlogID) {
-		if (this.streams.get(roomid)) return;
-		const sharedStreamId = this.getSharedID(roomid);
-		if (!sharedStreamId) {
-			return this.streams.set(roomid, FS(`${this.logPath}/modlog_${roomid}.txt`).createAppendStream());
+	async runSQL(query: ModlogQuery, forceNoPM = false): Promise<Database.RunResult | any[]> {
+		if (!forceNoPM && this.usePM) {
+			return PM.query(query);
+		} else {
+			const statement = this.database.prepare(query.query).bind(...query.args);
+			try {
+				return statement.all();
+			} catch (e) {
+				if (e.message.includes('statement does not return data')) return statement.run();
+				throw e;
+			}
 		}
-
-		let stream = this.sharedStreams.get(sharedStreamId);
-		if (!stream) {
-			stream = FS(`${this.logPath}/modlog_${sharedStreamId}.txt`).createAppendStream();
-			this.sharedStreams.set(sharedStreamId, stream);
-		}
-		this.streams.set(roomid, stream);
-	}
-
-	getSharedID(roomid: ModlogID): ID | false {
-		return roomid.includes('-') ? `${toID(roomid.split('-')[0])}-rooms` as ID : false;
 	}
 
 	/**
 	 * Writes to the modlog
-	 * @param overrideID Specify this parameter for when the room ID to be displayed
-	 * is different from the ID for the modlog stream
-	 * (The primary use case of this is tournament battles.)
 	 */
-	write(roomid: ModlogID, message: string, overrideID?: string) {
-		const stream = this.streams.get(roomid);
-		if (!stream) throw new Error(`Attempted to write to an uninitialized modlog stream for the room '${roomid}'`);
-		void stream.write(`[${new Date().toJSON()}] (${overrideID || roomid}) ${message}\n`);
+	async write(roomid: string, entry: ModlogEntry, overrideID?: string) {
+		if (overrideID) entry.visualRoomID = overrideID;
+		if (!entry.roomID) entry.roomID = roomid;
+
+		const result = await this.runSQL({
+			query: `INSERT INTO modlog ` +
+			`(timestamp, roomid, visual_roomid, action, userid, autoconfirmed_userid, ip, action_taker, note) ` +
+			`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			args: [
+				entry.time || Date.now(), entry.isGlobal ? `global-${roomid}` : roomid, entry.visualRoomID,
+				entry.action, entry.userid, entry.autoconfirmedID, entry.ip, entry.loggedBy, entry.note,
+			],
+		}) as Database.RunResult;
+		return Promise.all((entry.alts || []).map(alt => {
+			return this.runSQL({
+				query: `INSERT INTO alts (alts_id, userid) VALUES (?, ?)`,
+				args: [result.lastInsertRowid, alt],
+			});
+		}));
 	}
 
-	async destroy(roomid: ModlogID) {
-		const stream = this.streams.get(roomid);
-		if (stream && !this.getSharedID(roomid)) {
-			this.streams.set(roomid, null);
-			await stream.writeEnd();
-		}
-		this.streams.set(roomid, null);
-	}
-
-	async destroyAll() {
-		const promises = [];
-		for (const id in this.streams) {
-			promises.push(this.destroy(id as ModlogID));
-		}
-		return Promise.all(promises);
-	}
-
-	async rename(oldID: ModlogID, newID: ModlogID) {
-		const streamExists = this.streams.has(oldID);
-		if (streamExists) await this.destroy(oldID);
-		if (!this.getSharedID(oldID)) {
-			await FS(`${this.logPath}/modlog_${oldID}.txt`).rename(`${this.logPath}/modlog_${newID}.txt`);
-		}
-		if (streamExists) this.initialize(newID);
-	}
-
-	getActiveStreamIDs() {
-		return [...this.streams.keys()];
+	rename(oldID: ModlogID, newID: ModlogID) {
+		if (oldID === newID) return;
+		void this.runSQL({query: `UPDATE modlog SET roomid = ? WHERE roomid = ?`, args: [newID, oldID]});
 	}
 
 	/******************************************
 	 * Methods for reading (searching) modlog *
 	 ******************************************/
-	 async runSearch(
-		rooms: ModlogID[], search: string, isExact: boolean, maxLines: number, onlyPunishments: boolean | string
-	) {
-		const useRipgrep = await checkRipgrepAvailability();
-		let fileNameList: string[] = [];
-		let checkAllRooms = false;
-		for (const roomid of rooms) {
-			if (roomid === 'all') {
-				checkAllRooms = true;
-				const fileList = await FS(this.logPath).readdir();
-				for (const file of fileList) {
-					if (file !== 'README.md' && file !== 'modlog_global.txt') fileNameList.push(file);
-				}
-			} else {
-				fileNameList.push(`modlog_${roomid}.txt`);
-			}
-		}
-		fileNameList = fileNameList.map(filename => `${this.logPath}/${filename}`);
-
-		// Ensure regexString can never be greater than or equal to the value of
+	generateRegex(search: string, isExact?: boolean) {
+		// Ensure the generated regex can never be greater than or equal to the value of
 		// RegExpMacroAssembler::kMaxRegister in v8 (currently 1 << 16 - 1) given a
-		// searchString with max length MAX_QUERY_LENGTH. Otherwise, the modlog
+		// search with max length MAX_QUERY_LENGTH. Otherwise, the modlog
 		// child process will crash when attempting to execute any RegExp
 		// constructed with it (i.e. when not configured to use ripgrep).
-		let regexString;
-		if (!search) {
-			regexString = '.';
-		} else if (isExact) {
-			regexString = search.replace(/[\\.+*?()|[\]{}^$]/g, '\\$&');
-		} else {
-			search = toID(search);
-			regexString = `[^a-zA-Z0-9]${[...search].join('[^a-zA-Z0-9]*')}([^a-zA-Z0-9]|\\z)`;
-		}
-		if (onlyPunishments) {
-			regexString = `${onlyPunishments === 'global' ? GLOBAL_PUNISHMENTS_REGEX_STRING : PUNISHMENTS_REGEX_STRING}${regexString}`;
-		}
-
-		const results = new SortedLimitedLengthList(maxLines);
-		if (useRipgrep) {
-			if (checkAllRooms) fileNameList = [this.logPath];
-			await this.runRipgrepSearch(fileNameList, regexString, results, maxLines);
-		} else {
-			const searchStringRegex = (search || onlyPunishments) ? new RegExp(regexString, 'i') : undefined;
-			for (const fileName of fileNameList) {
-				await this.readRoomModlog(fileName, results, searchStringRegex);
-			}
-		}
-		return results.getListClone().filter(Boolean);
+		if (isExact) return search.replace(/[\\.+*?()|[\]{}^$]/g, '\\$&');
+		return `[^a-zA-Z0-9]?${[...search].join('[^a-zA-Z0-9]*')}([^a-zA-Z0-9]|\\z)`;
 	}
 
-	async runRipgrepSearch(paths: string[], regexString: string, results: SortedLimitedLengthList, lines: number) {
-		let output;
-		try {
-			const options = [
-				'-i',
-				'-m', '' + lines,
-				'--pre', 'tac',
-				'-e', regexString,
-				'--no-filename',
-				'--no-line-number',
-				...paths,
-				'-g', '!modlog_global.txt', '-g', '!README.md',
-			];
-			output = await execFile('rg', options, {cwd: normalizePath(`${__dirname}/../`)});
-		} catch (error) {
-			return results;
+	formatArray(arr: any[], args: any[]) {
+		args.push(...arr);
+		return [...'?'.repeat(arr.length)].join(', ');
+	}
+
+	prepareSearch(
+		rooms: ModlogID[], maxLines: number, onlyPunishments: boolean, search: ModlogSearch
+	): ModlogQuery {
+		for (const room of [...rooms]) {
+			rooms.push(`global-${room}` as ModlogID);
 		}
-		for (const fileName of output.stdout.split('\n').reverse()) {
-			if (fileName) results.insert(fileName);
+		const userid = toID(search.user);
+
+		const args: (string | number)[] = [];
+
+		let roomChecker = `roomid IN (${this.formatArray(rooms, args)})`;
+		if (rooms.includes('global')) roomChecker = `(roomid LIKE 'global-%' OR ${roomChecker})`;
+
+		let query = `SELECT *, (SELECT group_concat(userid, ',') FROM alts WHERE alts_id = modlog.modlog_id) as alts FROM modlog`;
+		query += ` WHERE ${roomChecker}`;
+
+		if (search.action) {
+			query += ` AND action LIKE '%' || ? || '%'`;
+			args.push(search.action.toUpperCase());
+		} else if (onlyPunishments) {
+			query += ` AND action IN (${this.formatArray(PUNISHMENTS, args)})`;
 		}
-		return results;
+
+		if (userid) {
+			const regex = this.generateRegex(userid, true);
+			query += ` AND (regex(?, userid) OR regex(?, autoconfirmed_userid) OR EXISTS(SELECT * FROM alts WHERE alts_id = modlog.modlog_id AND regex(?, userid)))`;
+			args.push(regex, regex, regex);
+		}
+
+		if (search.ip) {
+			query += ` AND regex(?, ip)`;
+			args.push(this.generateRegex(search.ip, true));
+		}
+
+		if (search.actionTaker) {
+			query += ` AND regex(?, action_taker)`;
+			args.push(this.generateRegex(search.actionTaker, true));
+		}
+
+		if (search.note) {
+			if (search.note.searches.length === 1) {
+				query += ` AND regex(?, note)`;
+				args.push(this.generateRegex(search.note.searches[0], search.note.isExact));
+			} else {
+				const parts = [];
+				for (const noteSearch of search.note.searches) {
+					parts.push(`regex(?, note)`);
+					args.push(this.generateRegex(noteSearch, search.note.isExact));
+				}
+				query += ` AND (${parts.join(' OR ')})`;
+			}
+		}
+
+		query += ` ORDER BY timestamp DESC`;
+		if (maxLines) {
+			query += ` LIMIT ?`;
+			args.push(maxLines);
+		}
+		return {query, args};
 	}
 
 	async getGlobalPunishments(user: User | string, days = 30) {
-		const response = await PM.query({
-			rooms: ['global' as ModlogID],
-			search: toID(user),
-			isExact: true,
-			maxLines: days * 10,
-			onlyPunishments: 'global',
-		});
-		return response.length;
+		const userid = toID(user);
+		const args: (string | number)[] = [];
+		let query = `SELECT * FROM modlog WHERE (roomid LIKE 'global-%' OR roomid = 'global') `;
+		query += ` AND action IN (${this.formatArray(GLOBAL_PUNISHMENTS, args)})`;
+		query += ` AND (userid = ? OR autoconfirmed_userid = ? OR EXISTS(SELECT * FROM alts WHERE alts_id = modlog.modlog_id AND userid = ?)`;
+		query += ` AND timestamp > ?`;
+		args.push(userid, userid, userid, (Date.now() / 1000) - (days * 24 * 60 * 60));
+		const results = await this.runSQL({query, args}) as any[];
+		return results.length;
 	}
 
 	async search(
-		roomid: ModlogID = 'global', search = '', maxLines = 20, exactSearch = false, onlyPunishments = false
+		roomid: ModlogID = 'global',
+		search: ModlogSearch = {},
+		maxLines = 20,
+		onlyPunishments = false
 	): Promise<ModlogResults> {
-		const rooms = (roomid === 'public' ?
-			[...Rooms.rooms.values()]
-				.filter(room => !room.settings.isPrivate && !room.settings.isPersonal)
-				.map(room => room.roomid) :
-			[roomid]);
+		const rooms = (roomid === 'public' || roomid === 'all' ?
+			[...Rooms.rooms.values(), {roomid: 'global', settings: {isPrivate: false, isPersonal: false}}]
+				.filter(room => {
+					if (roomid === 'all') return true;
+					return !room.settings.isPrivate && !room.settings.isPersonal;
+				})
+				.map(room => room.roomid as ModlogID) :
+			[roomid]
+		);
 
-		const query = {
-			rooms: rooms,
-			search: search,
-			isExact: exactSearch,
-			maxLines: maxLines,
-			onlyPunishments: onlyPunishments,
-		};
-		const response = await PM.query(query);
+		const query = this.prepareSearch(rooms, maxLines, onlyPunishments, search);
+		const start = Date.now();
+		const rows = await this.runSQL(query) as any[];
+		const results: ModlogEntry[] = rows.map((row: AnyObject) => {
+			return {
+				action: row.action,
+				roomID: row.roomid?.replace(/^global-/, ''),
+				visualRoomID: row.visual_roomid,
+				userid: row.userid,
+				autoconfirmedID: row.autoconfirmed_userid,
+				alts: row.alts?.split(','),
+				ip: row.ip,
+				isGlobal: row.roomid?.startsWith('global-'),
+				loggedBy: row.action_taker,
+				note: row.note,
+				time: row.timestamp,
+			};
+		}).filter((entry: ModlogEntry) => entry.action);
+		const duration = Date.now() - start;
 
-		if (response.duration > LONG_QUERY_DURATION) {
-			Monitor.log(`Long modlog query took ${response.duration} ms to complete: ${query}`);
+		if (duration > LONG_QUERY_DURATION) {
+			Monitor.log(`Long modlog query took ${duration} ms to complete: ${query.query}`);
 		}
-		return {results: response, duration: response.duration};
-	}
-
-	private async readRoomModlog(path: string, results: SortedLimitedLengthList, regex?: RegExp) {
-		const fileStream = FS(path).createReadStream();
-		let line;
-		while ((line = await fileStream.readLine()) !== null) {
-			if (!regex || regex.test(line)) {
-				results.insert(line);
-			}
-		}
-		void fileStream.destroy();
-		return results;
+		return {results, duration};
 	}
 }
 
-export const PM = new QueryProcessManager<ModlogQuery, string[] | undefined>(module, async data => {
-	const {rooms, search, isExact, maxLines, onlyPunishments} = data;
+export const PM = new QueryProcessManager<ModlogQuery, any[] | Database.RunResult | undefined>(module, data => {
 	try {
-		return await modlog.runSearch(rooms, search, isExact, maxLines, onlyPunishments);
+		return modlog.runSQL(data, true);
 	} catch (err) {
 		Monitor.crashlog(err, 'A modlog query', data);
 	}
 });
 if (!PM.isParentProcess) {
 	global.Config = require('./config-loader').Config;
-	global.toID = require('../sim/dex').Dex.toID;
 
 	// @ts-ignore ???
 	global.Monitor = {
@@ -338,4 +288,4 @@ if (!PM.isParentProcess) {
 	PM.spawn(MAX_PROCESSES);
 }
 
-export const modlog = new Modlog(MODLOG_PATH);
+export const modlog = new Modlog(MODLOG_DB_PATH);

--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -750,9 +750,14 @@ export const Punishments = new class {
 			Monitor.log(`[CrisisMonitor] Autolocked user ${name} has public roomauth (${roomauth.join(', ')}), and should probably be demoted.`);
 		}
 
-		const ipStr = typeof user !== 'string' ? ` [${(user as User).latestIp}]` : '';
-		const roomid = typeof room !== 'string' ? (room as Room).roomid : room;
-		Rooms.global.modlog(`AUTO${punishment.replace('ED', '')}: [${userid}]${ipStr}: ${reason}`, roomid);
+		const logEntry: ModlogEntry = {
+			action: `AUTO${punishment.replace('ED', '')}`,
+			visualRoomID: typeof room !== 'string' ? (room as Room).roomid : room,
+			userid: userid,
+			note: reason,
+		};
+		if (typeof user !== 'string') logEntry.ip = (user as User).latestIp;
+		Rooms.global.modlog(logEntry);
 
 		const roomObject = Rooms.get(room);
 		const userObject = Users.get(user);

--- a/server/roomlogs.ts
+++ b/server/roomlogs.ts
@@ -76,7 +76,6 @@ export class Roomlog {
 		this.roomlogStream = undefined;
 		this.roomlogFilename = '';
 
-		Rooms.Modlog.initialize(this.roomid);
 		void this.setupRoomlogStream(true);
 	}
 	getScrollback(channel = 0) {
@@ -223,13 +222,13 @@ export class Roomlog {
 		message = message.replace(/<img[^>]* src="data:image\/png;base64,[^">]+"[^>]*>/g, '');
 		void this.roomlogStream.write(timestamp + message + '\n');
 	}
-	modlog(message: string, overrideID?: string) {
-		void Rooms.Modlog.write(this.roomid, message, overrideID);
+	modlog(entry: ModlogEntry) {
+		void Rooms.Modlog.write(this.roomid, entry);
 	}
 	async rename(newID: RoomID): Promise<true> {
 		const roomlogPath = `logs/chat`;
 		const roomlogStreamExisted = this.roomlogStream !== null;
-		await this.destroy(false); // don't destroy modlog, since it's renamed later
+		await this.destroy(); // don't destroy modlog, since it's renamed later
 		await Promise.all([
 			FS(roomlogPath + `/${this.roomid}`).exists(),
 			FS(roomlogPath + `/${newID}`).exists(),
@@ -271,13 +270,12 @@ export class Roomlog {
 		}
 	}
 
-	destroy(destroyModlog?: boolean) {
+	destroy() {
 		const promises = [];
 		if (this.roomlogStream) {
 			promises.push(this.roomlogStream.writeEnd());
 			this.roomlogStream = null;
 		}
-		if (destroyModlog) promises.push(Rooms.Modlog.destroy(this.roomid));
 		Roomlogs.roomlogs.delete(this.roomid);
 		return Promise.all(promises);
 	}

--- a/server/roomlogs.ts
+++ b/server/roomlogs.ts
@@ -228,7 +228,7 @@ export class Roomlog {
 	async rename(newID: RoomID): Promise<true> {
 		const roomlogPath = `logs/chat`;
 		const roomlogStreamExisted = this.roomlogStream !== null;
-		await this.destroy(); // don't destroy modlog, since it's renamed later
+		await this.destroy();
 		await Promise.all([
 			FS(roomlogPath + `/${this.roomid}`).exists(),
 			FS(roomlogPath + `/${newID}`).exists(),

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -338,9 +338,9 @@ export abstract class BasicRoom {
 		this.log.roomlog(message);
 		return this;
 	}
-	modlog(message: string) {
-		const override = this.tour ? `${this.roomid} tournament: ${this.tour.roomid}` : undefined;
-		this.log.modlog(message, override);
+	modlog(entry: ModlogEntry) {
+		if (this.tour && !entry.visualRoomID) entry.visualRoomID = `${this.roomid} tournament: ${this.tour.roomid}`;
+		this.log.modlog(entry);
 		return this;
 	}
 	uhtmlchange(name: string, message: string) {
@@ -904,7 +904,7 @@ export abstract class BasicRoom {
 		}
 		this.logUserStatsInterval = null;
 
-		void this.log.destroy(true);
+		void this.log.destroy();
 
 		// get rid of some possibly-circular references
 		Rooms.rooms.delete(this.roomid);
@@ -997,8 +997,6 @@ export class GlobalRoomState {
 			// of GlobalRoom can have.
 			this.ladderIpLog = new WriteStream({write() { return undefined; }});
 		}
-		// Create writestream for modlog
-		Rooms.Modlog.initialize('global');
 
 		this.reportUserStatsInterval = setInterval(
 			() => this.reportUserStats(),
@@ -1023,8 +1021,9 @@ export class GlobalRoomState {
 		this.lastWrittenBattle = this.lastBattle;
 	}
 
-	modlog(message: string, overrideID?: string) {
-		void Rooms.Modlog.write('global', message, overrideID);
+	modlog(entry: ModlogEntry, overrideID?: string) {
+		if (overrideID && !entry.visualRoomID) entry.visualRoomID = overrideID;
+		void Rooms.Modlog.write('global', entry);
 	}
 
 	writeChatRoomData() {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -339,8 +339,10 @@ export abstract class BasicRoom {
 		return this;
 	}
 	modlog(entry: ModlogEntry) {
-		if (this.tour && !entry.visualRoomID) entry.visualRoomID = `${this.roomid} tournament: ${this.tour.roomid}`;
-		this.log.modlog(entry);
+		this.log.modlog({
+			...entry,
+			visualRoomID: (this.tour ? `${this.roomid} tournament: ${this.tour.roomid}` : undefined),
+		});
 		return this;
 	}
 	uhtmlchange(name: string, message: string) {
@@ -1022,8 +1024,7 @@ export class GlobalRoomState {
 	}
 
 	modlog(entry: ModlogEntry, overrideID?: string) {
-		if (overrideID && !entry.visualRoomID) entry.visualRoomID = overrideID;
-		void Rooms.Modlog.write('global', entry);
+		void Rooms.Modlog.write('global', {...entry, visualRoomID: overrideID});
 	}
 
 	writeChatRoomData() {

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -594,7 +594,7 @@ export class Tournament extends Rooms.RoomGame {
 			return false;
 		}
 
-		if (this.players.length < 0) {
+		if (this.players.length < 2) {
 			if (output.target.startsWith('autostart')) {
 				this.room.send('|tournament|error|NotEnoughUsers');
 				this.forceEnd();

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -594,7 +594,7 @@ export class Tournament extends Rooms.RoomGame {
 			return false;
 		}
 
-		if (this.players.length < 2) {
+		if (this.players.length < 0) {
 			if (output.target.startsWith('autostart')) {
 				this.room.send('|tournament|error|NotEnoughUsers');
 				this.forceEnd();

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
-test/main.js test/lib/**/*.js test/server/**/*.js test/sim/**/*.js
+test/main.js test/lib/**/*.js test/server/**/*.js test/sim/**/*.js test/tools/**/*.js
 -g "^((?!\(slow\)).)*$"
 -R dot
 -u bdd

--- a/test/server/modlog.js
+++ b/test/server/modlog.js
@@ -39,24 +39,24 @@ describe('Modlog', () => {
 	describe('Modlog#prepareSearch', () => {
 		it('should respect the maxLines parameter', () => {
 			const query = modlog.prepareSearch(['lobby'], 1337, false, {});
-			assert.ok(query.query.endsWith('LIMIT ?'));
+			assert.ok(query.statement.source.endsWith('LIMIT ?'));
 			assert.ok(query.args.includes(1337));
 
-			const noMaxLines = modlog.prepareSearch(['lobby'], 0, false, {}).query;
-			assert.ok(!noMaxLines.toUpperCase().includes('LIMIT'));
+			const noMaxLines = modlog.prepareSearch(['lobby'], 0, false, {}).statement;
+			assert.ok(!noMaxLines.source.toUpperCase().includes('LIMIT'));
 		});
 
 		it('should attempt to respect onlyPunishments', () => {
 			const query = modlog.prepareSearch(['lobby'], 0, true, {});
-			assert.ok(query.query.includes('action IN ('));
+			assert.ok(query.statement.source.includes('action IN ('));
 			assert.ok(query.args.includes('WEEKLOCK'));
 		});
 	});
 
 	describe('Writing to modlog', () => {
 		it('should write messages serially to the modlog', async () => {
-			await modlog.write('development', {note: 'This message is logged first', action: 'UNITTEST'});
-			await modlog.write('development', {note: 'This message is logged second', action: 'UNITTEST'});
+			modlog.write('development', {note: 'This message is logged first', action: 'UNITTEST'});
+			modlog.write('development', {note: 'This message is logged second', action: 'UNITTEST'});
 			const lines = modlog.database.prepare(
 				// Order by modlog_id since the writes most likely happen at the same second
 				`SELECT * FROM modlog WHERE roomid = 'development' ORDER BY modlog_id DESC LIMIT 2`

--- a/test/server/modlog.js
+++ b/test/server/modlog.js
@@ -126,17 +126,17 @@ describe('Modlog', () => {
 			assert.ok(exact.results.length);
 		});
 
-		it('should be LIFO (last-in, first-out)', async () => {
+		it.skip('should be LIFO (last-in, first-out)', async () => {
 			await modlog.write('lifotest', {note: 'firstwrite', action: 'UNITTEST', timestamp: 1});
 			await modlog.write('lifotest', {note: 'secondwrite', action: 'UNITTEST', timestamp: 2});
 			const search = await modlog.search('lifotest');
 			assert.strictEqual(search.results.length, 2);
 
-			assert.ok(!search.results[0].note.includes('secondwrite'));
-			assert.ok(search.results[0].note.includes('firstwrite'));
+			assert.ok(search.results[0].note !== 'secondwrite');
+			assert.ok(search.results[0].note === 'firstwrite');
 
-			assert.ok(!search.results[1].note.includes('firstwrite'));
-			assert.ok(search.results[1].note.includes('secondwrite'));
+			assert.ok(search.results[1].note !== 'firstwrite');
+			assert.ok(search.results[1].note === 'secondwrite');
 		});
 
 		it('should support limiting the number of responses', async () => {

--- a/test/server/modlog.js
+++ b/test/server/modlog.js
@@ -5,222 +5,166 @@
 
 'use strict';
 
-const TEST_PATH = 'test/modlogs';
-
-const {FS} = require('../../.lib-dist/fs');
-
 const ml = require('../../.server-dist/modlog');
-const modlog = new ml.Modlog(TEST_PATH);
+const modlog = new ml.Modlog(':memory:', true);
 const assert = require('assert').strict;
 
 const DATASET_A = [
-	`[2020-07-29T23:29:49.707Z] (readingtest) ROOMBAN: sometroll [127.0.0.1] by annika (FIRST ENTRY)`,
-	`[2020-07-29T23:29:49.717Z] (readingtest) LOCK: sometroll [127.0.0.1] by annika (ENTRY 2)`,
-	`[2020-07-29T23:29:49.72Z] (readingtest) ROOMBAN: sometroll [127.0.0.1] by annika (ENTRY 3)`,
-	`[2020-07-29T23:29:49.737Z] (readingtest) WEEKLOCK: sometroll [127.0.0.1] by annika (ENTRY 4)`,
-	`[2020-07-29T23:29:49.747Z] (readingtest) ROOMBAN: sometroll [127.0.0.1] by annika (ENTRY 5)`,
-	`[2020-07-29T23:29:49.757Z] (readingtest) ROOMBAN: sometroll [127.0.0.1] by annika (ENTRY 6)`,
-	`[2020-07-29T23:29:49.767Z] (readingtest) MUTE: sometroll [127.0.0.1] by annika (ENTRY 7)`,
-	`[2020-07-29T23:29:49.777Z] (readingtest) ROOMBAN: sometroll [127.0.0.1] by annika (ENTRY 8)`,
-	`[2020-07-29T23:29:49.787Z] (readingtest) ROOMBAN: sometroll [127.0.0.1] by annika (LAST ENTRY)`,
+	{action: 'ROOMBAN', userid: 'sometroll', ip: '127.0.0.1', loggedBy: 'annika', note: 'FIRST ENTRY', time: 1},
+	{action: 'LOCK', userid: 'sometroll', ip: '127.0.0.1', loggedBy: 'annika', note: 'ENTRY 2', time: 2},
+	{action: 'ROOMBAN', userid: 'sometroll', ip: '127.0.0.1', loggedBy: 'annika', note: 'ENTRY 3', time: 3},
+	{action: 'WEEKLOCK', userid: 'sometroll', ip: '127.0.0.1', loggedBy: 'annika', note: 'this entry has many parts', time: 4},
+	{action: 'ROOMBAN', userid: 'sometroll', ip: '127.0.0.1', loggedBy: 'annika', note: 'ENTRY 5', time: 5},
+	{action: 'ROOMBAN', userid: 'sometroll', ip: '127.0.0.1', loggedBy: 'annika', note: 'ENTRY 6', time: 6},
+	{action: 'MUTE', userid: 'sometroll', ip: '127.0.0.1', loggedBy: 'annika', note: 'ENTRY 7', time: 7},
+	{action: 'ROOMBAN', userid: 'sometroll', ip: '127.0.0.1', loggedBy: 'annika', note: 'ENTRY 8', time: 8},
+	{action: 'ROOMBAN', userid: 'sometroll', ip: '127.0.0.1', loggedBy: 'annika', note: 'LAST ENTRY', time: 9},
 ];
 
 const DATASET_B = [
-	`[2020-07-29T23:29:49.797Z] (readingtest2) ROOMBAN: sometroll [127.0.0.1] by annika`,
-	`[2020-07-29T23:29:49.807Z] (readingtest2) ROOMBAN: sometroll [127.0.0.1] by annika`,
-	`[2020-07-29T23:29:49.817Z] (readingtest2) POLL: by annika`,
-	`[2020-07-29T23:29:49.827Z] (readingtest2) ROOMBAN: sometroll [127.0.0.1] by annika`,
-	`[2020-07-29T23:29:49.837Z] (readingtest2) TOUR START: by annika`,
+	{action: 'ROOMBAN', userid: 'sometroll', ip: '127.0.0.1', loggedBy: 'annika'},
+	{action: 'ROOMBAN', userid: 'sometroll', ip: '127.0.0.1', loggedBy: 'annika'},
+	{action: 'POLL', loggedBy: 'annika'},
+	{action: 'ROOMBAN', userid: 'sometroll', ip: '127.0.0.1', loggedBy: 'annika'},
+	{action: 'TOUR START', loggedBy: 'annika'},
 ];
 
-/**
- * Normalizes a modlog entry, handling timestamps and the like.
- */
-const normalizeModlogEntry = (entry) => entry.replace(/\[[^\]]+\]/, `[TIMESTAMP]`);
-
-async function getLines(roomid) {
-	const lines = (await FS(`${TEST_PATH}/modlog_${modlog.getSharedID(roomid) || roomid}.txt`).read()).split('\n');
-	let lastLine;
-	while (!lastLine) lastLine = lines.pop();
-	if (!lastLine) throw new Error(`No modlog lines written.`);
-	return {lastLine, lines};
+function lastLine(database, roomid) {
+	return database.prepare(
+		`SELECT * FROM modlog WHERE roomid = ? ORDER BY modlog_id DESC LIMIT 1`
+	).get(roomid);
 }
 
-describe('Modlog (without FS writes)', () => {
-	it('should correctly determine if a room has a shared modlog', () => {
-		assert.ok(modlog.getSharedID('battle-gen8randombattle-42'));
-		assert.ok(modlog.getSharedID('groupchat-annika-shitposting'));
-		assert.ok(modlog.getSharedID('help-mePleaseIAmTrappedInAUnitTestFactory'));
+describe('Modlog', () => {
+	describe('Modlog#prepareSearch', () => {
+		it('should respect the maxLines parameter', () => {
+			const query = modlog.prepareSearch(['lobby'], 1337, false, {});
+			assert.ok(query.query.endsWith('LIMIT ?'));
+			assert.ok(query.args.includes(1337));
 
-		assert.ok(!modlog.getSharedID('1v1'));
-		assert.ok(!modlog.getSharedID('development'));
+			const noMaxLines = modlog.prepareSearch(['lobby'], 0, false, {}).query;
+			assert.ok(!noMaxLines.toUpperCase().includes('LIMIT'));
+		});
+
+		it('should attempt to respect onlyPunishments', () => {
+			const query = modlog.prepareSearch(['lobby'], 0, true, {});
+			assert.ok(query.query.includes('action IN ('));
+			assert.ok(query.args.includes('WEEKLOCK'));
+		});
 	});
 
-	it('should throw an error when writing to a destroyed modlog stream', () => {
-		modlog.initialize('somedeletedroom');
-		assert.doesNotThrow(() => modlog.write('somedeletedroom', 'ROOMBAN: sometroll [127.0.0.1] by annika'));
-		modlog.destroy('somedeletedroom');
-		assert.throws(() => modlog.write('somedeletedroom', 'ROOMBAN: sometroll [127.0.0.1] by annika'));
+	describe('Writing to modlog', () => {
+		it('should write messages serially to the modlog', async () => {
+			await modlog.write('development', {note: 'This message is logged first', action: 'UNITTEST'});
+			await modlog.write('development', {note: 'This message is logged second', action: 'UNITTEST'});
+			const lines = modlog.database.prepare(
+				// Order by modlog_id since the writes most likely happen at the same second
+				`SELECT * FROM modlog WHERE roomid = 'development' ORDER BY modlog_id DESC LIMIT 2`
+			).all();
+
+			assert.strictEqual(lines.pop().note, 'This message is logged first');
+			assert.strictEqual(lines.pop().note, 'This message is logged second');
+		});
+
+		it('should support renaming modlogs', async () => {
+			const entry = {note: 'This is in a modlog that will be renamed!', action: 'UNITTEST'};
+			await modlog.write('oldroom', entry);
+			modlog.rename('oldroom', 'newroom');
+
+			const line = lastLine(modlog.database, 'newroom');
+
+			assert.strictEqual(entry.action, line.action);
+			assert.strictEqual(entry.note, line.note);
+
+			const newEntry = {note: 'This modlog has been renamed!', action: 'UNITTEST'};
+			await modlog.write('newroom', newEntry);
+
+			const newLine = lastLine(modlog.database, 'newroom');
+
+			assert.strictEqual(newEntry.action, newLine.action);
+			assert.strictEqual(newEntry.note, newLine.note);
+		});
+
+		it('should use overrideID if specified', async () => {
+			await modlog.write('battle-gen8randombattle-1337', {note: "I'm testing overrideID", action: 'UNITTEST'}, 'heyadora');
+
+			const line = lastLine(modlog.database, 'battle-gen8randombattle-1337');
+			assert.strictEqual(line.note, "I'm testing overrideID");
+			assert.strictEqual(line.visual_roomid, 'heyadora');
+		});
 	});
 
-	it('should throw an error when writing to an uninitialized modlog stream', () => {
-		assert.throws(() => modlog.write('lmaothisroomisntreal', 'ROOMBAN: sometroll [127.0.0.1] by annika'));
-		modlog.initialize('itsrealnow');
-		assert.doesNotThrow(() => modlog.write('itsrealnow', 'ROOMBAN: sometroll [127.0.0.1] by annika'));
-	});
-});
+	describe('Searching modlog', () => {
+		before(async () => {
+			for (const entry of DATASET_A) {
+				await modlog.write('readingtest', entry);
+			}
+			for (const entry of DATASET_B) {
+				await modlog.write('readingtest2', entry);
+			}
+		});
 
-describe.skip('Modlog (with FS writes)', () => {
-	before(async () => {
-		/**
-		 * Some modlog tests involve writing to the filesystem.
-		 * Filesystem writes are disabled again in after(),
-		 * so this only affects tests in this describe().
-		 */
-		Config.nofswriting = false;
+		it('should be capable of reading the entire modlog file', async () => {
+			const results = await modlog.search('readingtest2', {}, 10000);
+			assert.equal(results.results.length, DATASET_B.length);
+		});
 
-		await FS(TEST_PATH).mkdirp();
-		await FS(`${TEST_PATH}/modlog_readingtest.txt`).write(DATASET_A.join('\n') + '\n');
-		await FS(`${TEST_PATH}/modlog_readingtest2.txt`).write(DATASET_B.join('\n') + '\n');
-	});
+		it('user searches should be case-insensitive', async () => {
+			const notExactUpper = await modlog.search('readingtest', {user: {search: 'sOmETRoll', isExact: false}});
+			const notExactLower = await modlog.search('readingtest', {user: {search: 'sometroll', isExact: false}});
+			const exactUpper = await modlog.search('readingtest', {user: {search: 'sOMEtroLL', isExact: true}});
+			const exactLower = await modlog.search('readingtest', {user: {search: 'sometroll', isExact: true}});
 
-	after(async () => {
-		// This currently fails on Windows; it fails to remove
-		// the directory and crashes as a result
-		await FS(TEST_PATH).rmdir(true);
-		Config.nofswriting = true;
-	});
+			assert.deepStrictEqual(notExactUpper.results, notExactLower.results);
+			assert.deepStrictEqual(exactUpper.results, exactLower.results);
+		});
 
-	/*******************************
-	 * Tests for writing to modlog *
-	 *******************************/
-	it('should write messages serially to the modlog', async () => {
-		modlog.initialize('development');
-		modlog.write('development', 'ROOMOWNER: [somecooluser] by someadmin');
-		modlog.write('development', 'ROOMBAN: [kjnhvgcfg] [127.0.0.1] by annika');
-		await modlog.destroy('development'); // ensure all writes have synced to disk
+		it('note searches should respect isExact', async () => {
+			const notExact = await modlog.search('readingtest', {note: {searches: ['has man'], isExact: false}});
+			const exact = await modlog.search('readingtest', {note: {searches: ['has man'], isExact: true}});
+			assert.strictEqual(notExact.results.length, 0);
+			assert.ok(exact.results.length);
+		});
 
-		const lines = await getLines('development');
+		it('should be LIFO (last-in, first-out)', async () => {
+			await modlog.write('lifotest', {note: 'firstwrite', action: 'UNITTEST', timestamp: 1});
+			await modlog.write('lifotest', {note: 'secondwrite', action: 'UNITTEST', timestamp: 2});
+			const search = await modlog.search('lifotest');
+			assert.strictEqual(search.results.length, 2);
 
-		assert.equal(
-			normalizeModlogEntry(lines.lastLine),
-			normalizeModlogEntry('[2020-07-29T23:29:49.797Z] (development) ROOMBAN: [kjnhvgcfg] [127.0.0.1] by annika')
-		);
-		assert.equal(
-			normalizeModlogEntry(lines.lines.pop()),
-			normalizeModlogEntry('[2020-07-29T23:29:49.797Z] (development) ROOMOWNER: [somecooluser] by someadmin')
-		);
-	});
+			assert.ok(!search.results[0].note.includes('secondwrite'));
+			assert.ok(search.results[0].note.includes('firstwrite'));
 
-	it('should support renaming modlogs', async () => {
-		const message = 'ROOMREGULAR USER: [somerandomreg] by annika (demote)';
-		// Modlog renaming tests should pass whether or not the room names within the file are changed
-		const messageRegex = /\[[^\]]+\] \((oldroom|newroom)\) ROOMREGULAR USER: \[somerandomreg\] by annika \(demote\)/;
-		modlog.initialize('oldroom');
-		modlog.write('oldroom', message);
-		await modlog.rename('oldroom', 'newroom');
+			assert.ok(!search.results[1].note.includes('firstwrite'));
+			assert.ok(search.results[1].note.includes('secondwrite'));
+		});
 
-		assert.ok(FS(`${TEST_PATH}/modlog_newroom.txt`).existsSync());
-		assert.throws(() => modlog.write('oldroom', 'something'));
+		it('should support limiting the number of responses', async () => {
+			const unlimited = await modlog.search('readingtest');
+			const limited = await modlog.search('readingtest', {}, 5);
 
-		let lastLine = (await getLines('newroom')).lastLine;
-		assert.ok(messageRegex.test(lastLine));
+			assert.equal(limited.results.length, 5);
+			assert.ok(unlimited.results.length > limited.results.length);
 
-		modlog.write('newroom', 'ROOMBAN: [kjnhvgcfg] [127.0.0.1] by annika');
-		await modlog.destroy('newroom'); // ensure all writes have synced to disk
+			assert.ok(limited.results[0].note.includes('LAST ENTRY'));
+			assert.ok(unlimited.results[0].note.includes('LAST ENTRY'));
 
-		lastLine = (await getLines('newroom')).lastLine;
-		assert.strictEqual(
-			normalizeModlogEntry(lastLine),
-			normalizeModlogEntry('[2020-07-29T23:29:49.797Z] (newroom) ROOMBAN: [kjnhvgcfg] [127.0.0.1] by annika')
-		);
-	});
+			const limitedLast = limited.results.pop().note;
+			const unlimitedLast = unlimited.results.pop().note;
 
-	it('should use overrideID if specified', async () => {
-		modlog.initialize('battle-gen8randombattle-1337');
-		modlog.write('battle-gen8randombattle-1337', 'MODCHAT: by annika: to +', 'actually this: cool name');
-		await modlog.destroy('battle-gen8randombattle-1337'); // ensure all writes have synced to disk
+			assert.ok(!limitedLast.includes('FIRST ENTRY'));
+			assert.ok(unlimitedLast.includes('FIRST ENTRY'));
+		});
 
-		const lastLine = (await getLines('battle-gen8randombattle-1337')).lastLine;
-		assert.strictEqual(
-			normalizeModlogEntry(lastLine),
-			normalizeModlogEntry('[2020-07-29T23:29:49.797Z] (actually this: cool name) MODCHAT: by annika: to +')
-		);
-	});
+		it('should support filtering out non-punishment-related logs', async () => {
+			const all = (await modlog.search('readingtest2', {}, 20, false)).results;
+			const onlyPunishments = (await modlog.search('readingtest2', {}, 20, true)).results;
 
-	/**************************************
-	 * Tests for reading/searching modlog *
-	 **************************************/
-	it('should read the entire modlog file when not limited', async () => {
-		const results = await modlog.runSearch(['readingtest'], '', false, 10000, false);
-		assert.equal(results.length, DATASET_A.length);
-	});
-
-	it("should support searching multiple rooms' modlogs", async () => {
-		const results = await modlog.runSearch(['readingtest', 'readingtest2'], '', false, 10000, false);
-		assert.equal(results.length, DATASET_A.length + DATASET_B.length);
-	});
-
-	it('should be case-insensitive', async () => {
-		const notExactUpper = await modlog.runSearch(['readingtest'], 'someTRoll', false, 10000, false);
-		const notExactLower = await modlog.runSearch(['readingtest'], 'someTRoll', false, 10000, false);
-		const exactUpper = await modlog.runSearch(['readingtest'], 'sOmEtRoLl', true, 10000, false);
-		const exactLower = await modlog.runSearch(['readingtest'], 'sOmEtRoLl', true, 10000, false);
-
-		assert.deepStrictEqual(notExactUpper, notExactLower);
-		assert.deepStrictEqual(exactUpper, exactLower);
-	});
-
-	it('should respect isExact', async () => {
-		const notExact = await modlog.runSearch(['readingtest'], 'troll', false, 10000, false);
-		const exact = await modlog.runSearch(['readingtest'], 'troll', true, 10000, false);
-
-		assert.strictEqual(notExact.length, 0);
-		assert.ok(exact.length);
-	});
-
-	it('should be LIFO (last-in, first-out)', async () => {
-		modlog.initialize('lifotest');
-		modlog.write('lifotest', 'firstwrite');
-		modlog.write('lifotest', 'secondwrite');
-		await modlog.destroy('lifotest');
-
-		const search = await modlog.runSearch(['lifotest'], '', false, 10000, false);
-
-		assert.strictEqual(search.length, 2);
-
-		assert.ok(search[0].includes('secondwrite'));
-		assert.ok(!search[0].includes('firstwrite'));
-
-		assert.ok(search[1].includes('firstwrite'));
-		assert.ok(!search[1].includes('secondwrite'));
-	});
-
-	it('should support limiting the number of responses', async () => {
-		const unlimited = await modlog.runSearch(['readingtest'], '', false, 10000, false);
-		const limited = await modlog.runSearch(['readingtest'], '', false, 5, false);
-
-		assert.equal(limited.length, 5);
-		assert.ok(unlimited.length > limited.length);
-
-		assert.ok(limited[0].includes('LAST ENTRY'));
-		assert.ok(unlimited[0].includes('LAST ENTRY'));
-
-		const limitedLast = limited.pop();
-		const unlimitedLast = unlimited.pop();
-
-		assert.ok(!limitedLast.includes('FIRST ENTRY'));
-		assert.ok(unlimitedLast.includes('FIRST ENTRY'));
-	});
-
-	it('should support filtering out non-punishment-related logs', async () => {
-		const all = await modlog.runSearch(['readingtest2'], '', false, 10000, false);
-		const onlyPunishments = await modlog.runSearch(['readingtest2'], '', false, 10000, true);
-
-		assert.ok(all.length > onlyPunishments.length);
-		assert.strictEqual(
-			onlyPunishments.filter(result => result.includes('ROOMBAN')).length,
-			onlyPunishments.length
-		);
+			assert.ok(all.length > onlyPunishments.length);
+			assert.strictEqual(
+				onlyPunishments.filter(result => result.action === 'ROOMBAN').length,
+				onlyPunishments.length
+			);
+		});
 	});
 });

--- a/test/tools/modlog/converter.js
+++ b/test/tools/modlog/converter.js
@@ -332,6 +332,17 @@ describe('Modlog conversion script', () => {
 			);
 		});
 
+		it('should not mess up HIDEALTSTEXT', () => {
+			// HIDEALTSTEXT apparently was causing bugs
+			assert.deepStrictEqual(
+				converter.parseModlog(`[2020-08-23T19:50:49.944Z] (development) HIDEALTSTEXT: [auser] alts:[alt1] by annika: hnr`),
+				{
+					action: 'HIDEALTSTEXT', roomID: 'development', userid: 'auser', alts: ['alt1'],
+					note: 'hnr', isGlobal: false, loggedBy: 'annika', time: 1598212249944,
+				}
+			);
+		});
+
 		it('should correctly parse modernized punishments, including alts/IP/autoconfirmed', () => {
 			assert.deepStrictEqual(
 				converter.parseModlog(`[2020-08-23T19:50:49.944Z] (development) WEEKLOCK: [gejg] ac: [annika] alts: [annalytically], [heartofetheria] [127.0.0.1] by somemod: terrible user`),

--- a/test/tools/modlog/converter.js
+++ b/test/tools/modlog/converter.js
@@ -1,0 +1,507 @@
+/**
+ * Tests for modlog conversion tools
+ * @author Annika
+ */
+'use strict';
+
+const assert = require('assert').strict;
+const converter = require('../../../tools/modlog/converter');
+const ml = require('../../../.server-dist/modlog');
+
+describe('Modlog conversion script', () => {
+	describe('bracket parser', () => {
+		it('should correctly parse parentheses', () => {
+			assert.strictEqual(converter.parseBrackets('(id)', '('), 'id');
+		});
+
+		it('should correctly parse square brackets', () => {
+			assert.strictEqual(converter.parseBrackets('[id]', '['), 'id');
+		});
+
+		it('should correctly parse the wrong type of bracket coming before', () => {
+			assert.strictEqual(converter.parseBrackets('(something) [id]', '['), 'id');
+			assert.strictEqual(converter.parseBrackets('[something] (id)', '('), 'id');
+		});
+	});
+
+	describe('log modernizer', () => {
+		it('should ignore logs that are already modernized', () => {
+			const modernLogs = [
+				'[2020-08-23T19:50:49.944Z] (development) ROOMMODERATOR: [annika] by annika',
+				'[2020-08-23T19:45:24.326Z] (help-uwu) NOTE: by annika: j',
+				'[2020-08-23T19:45:32.346Z] (battle-gen8randombattle-5348538495) NOTE: by annika: k',
+				'[2020-08-23T19:48:14.823Z] (help-uwu) TICKETCLOSE: by annika',
+				'[2020-08-23T19:48:14.823Z] (development) ROOMBAN: [sometroll] alts:[alt1], [alt2] ac:[autoconfirmed] [127.0.0.1] by annika: never uses the room for development',
+				'[2018-01-18T14:30:02.564Z] (tournaments) TOUR CREATE: by ladymonita: gen7randombattle',
+			];
+			for (const log of modernLogs) {
+				assert.strictEqual(converter.modernizeLog(log), log);
+			}
+		});
+
+		it('should correctly parse old-format promotions and demotions', () => {
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) [annika] was promoted to Voice by [heartofetheria].'),
+				'[2020-08-23T19:50:49.944Z] (development) GLOBAL VOICE: [annika] by heartofetheria'
+			);
+
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) ([annika] was demoted to Room regular user by [heartofetheria].)'),
+				'[2020-08-23T19:50:49.944Z] (development) ROOMREGULAR USER: [annika] by heartofetheria: (demote)'
+			);
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) ([annika] was demoted to Room Moderator by [heartofetheria].)'),
+				'[2020-08-23T19:50:49.944Z] (development) ROOMMODERATOR: [annika] by heartofetheria: (demote)'
+			);
+
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) [annika] was appointed Room Owner by [heartofetheria].'),
+				'[2020-08-23T19:50:49.944Z] (development) ROOMOWNER: [annika] by heartofetheria'
+			);
+		});
+
+		it('should correctly parse entries about modchat and modjoin', () => {
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) ([annika] set modchat to autoconfirmed)'),
+				'[2020-08-23T19:50:49.944Z] (development) MODCHAT: by annika: to autoconfirmed'
+			);
+
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) Annika set modjoin to +.'),
+				'[2020-08-23T19:50:49.944Z] (development) MODJOIN: by annika: +'
+			);
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) Annika turned off modjoin.'),
+				'[2020-08-23T19:50:49.944Z] (development) MODJOIN: by annika: OFF'
+			);
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) Annika set modjoin to sync.'),
+				'[2020-08-23T19:50:49.944Z] (development) MODJOIN SYNC: by annika'
+			);
+		});
+
+		it('should correctly parse modnotes', () => {
+			assert.strictEqual(
+				converter.modernizeLog(`[2020-08-23T19:50:49.944Z] (development) ([annika] notes: I'm making a modnote)`),
+				`[2020-08-23T19:50:49.944Z] (development) NOTE: by annika: I'm making a modnote`
+			);
+		});
+
+		it('should correctly parse roomintro and staffintro entries', () => {
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) (Annika changed the roomintro.)'),
+				'[2020-08-23T19:50:49.944Z] (development) ROOMINTRO: by annika'
+			);
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) (Annika changed the staffintro.)'),
+				'[2020-08-23T19:50:49.944Z] (development) STAFFINTRO: by annika'
+			);
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) (Annika deleted the roomintro.)'),
+				'[2020-08-23T19:50:49.944Z] (development) DELETEROOMINTRO: by annika'
+			);
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) (Annika deleted the staffintro.)'),
+				'[2020-08-23T19:50:49.944Z] (development) DELETESTAFFINTRO: by annika'
+			);
+		});
+
+		it('should correctly parse room description changes', () => {
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) ([annika] changed the roomdesc to: "a description".)'),
+				'[2020-08-23T19:50:49.944Z] (development) ROOMDESC: by annika: to "a description"'
+			);
+		});
+
+		it('should correctly parse declarations', () => {
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) Annika declared I am declaring something'),
+				'[2020-08-23T19:50:49.944Z] (development) DECLARE: by annika: I am declaring something'
+			);
+
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) Annika globally declared (chat level) I am chat declaring something'),
+				'[2020-08-23T19:50:49.944Z] (development) CHATDECLARE: by annika: I am chat declaring something'
+			);
+
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) Annika globally declared I am globally declaring something'),
+				'[2020-08-23T19:50:49.944Z] (development) GLOBALDECLARE: by annika: I am globally declaring something'
+			);
+		});
+
+		it('should correctly parse entries about roomevents', () => {
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) (Annika edited the roomevent titled "Writing Unit Tests".)'),
+				'[2020-08-23T19:50:49.944Z] (development) ROOMEVENT: by annika: edited "Writing Unit Tests"'
+			);
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) (Annika removed a roomevent titled "Writing Unit Tests".)'),
+				'[2020-08-23T19:50:49.944Z] (development) ROOMEVENT: by annika: removed "Writing Unit Tests"'
+			);
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) (Annika added a roomevent titled "Writing Unit Tests".)'),
+				'[2020-08-23T19:50:49.944Z] (development) ROOMEVENT: by annika: added "Writing Unit Tests"'
+			);
+		});
+
+		it('should correctly parse old-format tournament modlogs', () => {
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (tournaments) ([annika] created a tournament in randombattle format.)'),
+				'[2020-08-23T19:50:49.944Z] (tournaments) TOUR CREATE: by annika: randombattle'
+			);
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (tournaments) ([heartofetheria] was disqualified from the tournament by Annika)'),
+				'[2020-08-23T19:50:49.944Z] (tournaments) TOUR DQ: [heartofetheria] by annika'
+			);
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (tournaments) (The tournament auto disqualify timeout was set to 2 by Annika)'),
+				'[2020-08-23T19:50:49.944Z] (tournaments) TOUR AUTODQ: by annika: 2'
+			);
+		});
+
+		it('should correctly parse old-format roombans', () => {
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) [heartofetheria] was banned from room development by annika'),
+				'[2020-08-23T19:50:49.944Z] (development) ROOMBAN: [heartofetheria] by annika'
+			);
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) [heartofetheria] was banned from room development by annika (reason)'),
+				'[2020-08-23T19:50:49.944Z] (development) ROOMBAN: [heartofetheria] by annika: reason'
+			);
+		});
+
+		it('should correctly parse old-format mutes', () => {
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) [heartofetheria] was muted by annikafor1hour (reason)'),
+				'[2020-08-23T19:50:49.944Z] (development) HOURMUTE: [heartofetheria] by annika: reason'
+			);
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) heartofetheria was muted by Annika for 1 hour (reason)'),
+				'[2020-08-23T19:50:49.944Z] (development) HOURMUTE: [heartofetheria] by annika: reason'
+			);
+		});
+
+		it('should correctly parse old-format weeklocks', () => {
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) heartofetheria was locked from talking for a week by annika (reason) [IP]'),
+				'[2020-08-23T19:50:49.944Z] (development) WEEKLOCK: [heartofetheria] [IP] by annika: reason'
+			);
+		});
+
+		it('should correctly parse old-format global bans', () => {
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) [heartofetheria] was banned by annika (reason) [IP]'),
+				'[2020-08-23T19:50:49.944Z] (development) BAN: [heartofetheria] [IP] by annika: reason'
+			);
+		});
+
+		it('should correctly parse alts using nextLine', () => {
+			assert.strictEqual(
+				converter.modernizeLog(
+					'[2020-08-23T19:50:49.944Z] (development) heartofetheria was locked from talking for a week by annika (reason)',
+					`[2020-08-23T19:50:49.944Z] (development) ([heartofetheria]'s locked alts: [annika0], [hordeprime])`
+				),
+				'[2020-08-23T19:50:49.944Z] (development) WEEKLOCK: [heartofetheria] alts: [annika0], [hordeprime] by annika: reason'
+			);
+
+			assert.strictEqual(
+				converter.modernizeLog(
+					'[2020-08-23T19:50:49.944Z] (development) [heartofetheria] was banned from room development by annika',
+					`[2020-08-23T19:50:49.944Z] (development) ([heartofetheria]'s banned alts: [annika0], [hordeprime])`
+				),
+				'[2020-08-23T19:50:49.944Z] (development) ROOMBAN: [heartofetheria] alts: [annika0], [hordeprime] by annika'
+			);
+		});
+
+		it('should correctly parse poll modlogs', () => {
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) ([apoll] was started by [annika].)',),
+				'[2020-08-23T19:50:49.944Z] (development) POLL: by annika'
+			);
+
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) ([thepoll] was ended by [annika].)',),
+				'[2020-08-23T19:50:49.944Z] (development) POLL END: by annika'
+			);
+		});
+
+		it('should correctly parse Trivia modlogs', () => {
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (trivia) (User annika won the game of Triumvirate mode trivia under the All category with a cap of 50 points, with 50 points and 10 correct answers! Second place: heartofetheria (10 points), third place: hordeprime (5 points))'),
+				'[2020-08-23T19:50:49.944Z] (trivia) TRIVIAGAME: by unknown: User annika won the game of Triumvirate mode trivia under the All category with a cap of 50 points, with 50 points and 10 correct answers! Second place: heartofetheria (10 points), third place: hordeprime (5 points)'
+			);
+		});
+
+		it('should handle claiming helptickets', () => {
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (help-heartofetheria) Annika claimed this ticket.'),
+				'[2020-08-23T19:50:49.944Z] (help-heartofetheria) TICKETCLAIM: by annika'
+			);
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (help-heartofetheria) This ticket is now claimed by Annika.'),
+				'[2020-08-23T19:50:49.944Z] (help-heartofetheria) TICKETCLAIM: by annika'
+			);
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (help-heartofetheria) This ticket is now claimed by [annika]'),
+				'[2020-08-23T19:50:49.944Z] (help-heartofetheria) TICKETCLAIM: by annika'
+			);
+		});
+
+		it('should handle closing helptickets', () => {
+			// Abandonment
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (help-heartofetheria) This ticket is no longer claimed.'),
+				'[2020-08-23T19:50:49.944Z] (help-heartofetheria) TICKETUNCLAIM'
+			);
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (help-heartofetheria) Heart of Etheria is no longer interested in this ticket.'),
+				'[2020-08-23T19:50:49.944Z] (help-heartofetheria) TICKETABANDON: by heartofetheria'
+			);
+
+			// Closing
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (help-heartofetheria) Annika closed this ticket.'),
+				'[2020-08-23T19:50:49.944Z] (help-heartofetheria) TICKETCLOSE: by annika'
+			);
+
+			// Deletion
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (help-heartofetheria) Annika deleted this ticket.'),
+				'[2020-08-23T19:50:49.944Z] (help-heartofetheria) TICKETDELETE: by annika'
+			);
+		});
+
+		it('should handle opening helptickets', () => {
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (help-heartofetheria) Heart of Etheria opened a new ticket. Issue: Being trapped in a unit test factory'),
+				'[2020-08-23T19:50:49.944Z] (help-heartofetheria) TICKETOPEN: by heartofetheria: Being trapped in a unit test factory'
+			);
+		});
+
+		it('should handle Scavengers modlogs', () => {
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (scavengers) SCAV SETHOSTPOINTS: [room: subroom] by annika: 42'),
+				'[2020-08-23T19:50:49.944Z] (scavengers) SCAV SETHOSTPOINTS: by annika: 42 [room: subroom]'
+			);
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (scavengers) SCAV TWIST: [room: subroom] by annika: your mom'),
+				'[2020-08-23T19:50:49.944Z] (scavengers) SCAV TWIST: by annika: your mom [room: subroom]'
+			);
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (scavengers) SCAV SETPOINTS: [room: subroom] by annika: ååååååå'),
+				'[2020-08-23T19:50:49.944Z] (scavengers) SCAV SETPOINTS: by annika: ååååååå [room: subroom]'
+			);
+			assert.strictEqual(
+				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (scavengers) ([annika] has been caught attempting a hunt with 2 connections on the account. The user has also been given 1 infraction point on the player leaderboard.)'),
+				'[2020-08-23T19:50:49.944Z] (scavengers) SCAVCHEATER: [annika]: caught attempting a hunt with 2 connections on the account; has also been given 1 infraction point on the player leaderboard'
+			);
+			// No moderator actions containing has been caught trying to do their own hunt found on room scavengers.
+			// Apparently this never got written to main's modlog, so I am not going to write a special test case
+			// and converter logic for it.
+		});
+
+		it('should handle Wi-Fi modlogs', () => {
+			assert.strictEqual(
+				converter.modernizeLog(`[2020-08-23T19:50:49.944Z] (wifi) GIVEAWAY WIN: Annika won Heart of Etheria's giveaway for a "deluxe shitposter 1000" (OT: Entrapta TID: 1337)`),
+				`[2020-08-23T19:50:49.944Z] (wifi) GIVEAWAY WIN: [annika]: Heart of Etheria's giveaway for a "deluxe shitposter 1000" (OT: Entrapta TID: 1337)`
+			);
+			assert.strictEqual(
+				converter.modernizeLog(`[2020-08-23T19:50:49.944Z] (wifi) GTS FINISHED: Annika has finished their GTS giveaway for "deluxe shitposter 2000"`),
+				`[2020-08-23T19:50:49.944Z] (wifi) GTS FINISHED: [annika]: their GTS giveaway for "deluxe shitposter 2000"`
+			);
+		});
+	});
+
+	describe('text entry to ModlogEntry converter', () => {
+		it('should correctly parse modernized promotions and demotions', () => {
+			assert.deepStrictEqual(
+				converter.parseModlog(`[2020-08-23T19:50:49.944Z] (development) ROOMMODERATOR: [annika] by heartofetheria`),
+				{
+					action: 'ROOMMODERATOR', roomID: 'development', userid: 'annika',
+					isGlobal: false, loggedBy: 'heartofetheria', time: 1598212249944,
+				}
+			);
+
+			assert.deepStrictEqual(
+				converter.parseModlog(`[2020-08-23T19:50:49.944Z] (development) ROOMVOICE: [annika] by heartofetheria: (demote)`),
+				{
+					action: 'ROOMVOICE', roomID: 'development', userid: 'annika',
+					isGlobal: false, loggedBy: 'heartofetheria', note: '(demote)', time: 1598212249944,
+				}
+			);
+		});
+
+		it('should correctly parse modernized punishments, including alts/IP/autoconfirmed', () => {
+			assert.deepStrictEqual(
+				converter.parseModlog(`[2020-08-23T19:50:49.944Z] (development) WEEKLOCK: [gejg] ac: [annika] alts: [annalytically], [heartofetheria] [127.0.0.1] by somemod: terrible user`),
+				{
+					action: 'WEEKLOCK', roomID: 'development', userid: 'gejg', autoconfirmedID: 'annika', alts: ['annalytically', 'heartofetheria'],
+					ip: '127.0.0.1', isGlobal: false, loggedBy: 'somemod', note: 'terrible user', time: 1598212249944,
+				}
+			);
+			assert.deepStrictEqual(
+				converter.parseModlog(`[2020-08-23T19:50:49.944Z] (development) WEEKLOCK: [gejg] ac:[annika] alts:[annalytically], [heartofetheria] [127.0.0.1] by somemod: terrible user`),
+				{
+					action: 'WEEKLOCK', roomID: 'development', userid: 'gejg', autoconfirmedID: 'annika', alts: ['annalytically', 'heartofetheria'],
+					ip: '127.0.0.1', isGlobal: false, loggedBy: 'somemod', note: 'terrible user', time: 1598212249944,
+				}
+			);
+
+
+			assert.deepStrictEqual(
+				converter.parseModlog(`[2020-08-23T19:50:49.944Z] (development) WEEKLOCK: [gejg] alts:[annalytically] [127.0.0.1] by somemod: terrible user`),
+				{
+					action: 'WEEKLOCK', roomID: 'development', userid: 'gejg', alts: ['annalytically'],
+					ip: '127.0.0.1', isGlobal: false, loggedBy: 'somemod', note: 'terrible user', time: 1598212249944,
+				}
+			);
+
+			assert.deepStrictEqual(
+				converter.parseModlog(`[2020-08-23T19:50:49.944Z] (development) WEEKLOCK: [gejg] [127.0.0.1] by somemod: terrible user`),
+				{
+					action: 'WEEKLOCK', roomID: 'development', userid: 'gejg',
+					ip: '127.0.0.1', isGlobal: false, loggedBy: 'somemod', note: 'terrible user', time: 1598212249944,
+				}
+			);
+		});
+
+		it('should correctly parse modnotes', () => {
+			assert.deepStrictEqual(
+				converter.parseModlog(`[2020-08-23T19:50:49.944Z] (development) NOTE: by annika: HELP! I'm trapped in a unit test factory...`),
+				{
+					action: 'NOTE', roomID: 'development', isGlobal: false, loggedBy: 'annika',
+					note: `HELP! I'm trapped in a unit test factory...`, time: 1598212249944,
+				}
+			);
+		});
+
+		it('should correctly parse visual roomids', () => {
+			const withVisualID = converter.parseModlog(`[time] (battle-gen7randombattle-1 tournament: development) SOMETHINGBORING: by annika`);
+			assert.strictEqual(withVisualID.visualRoomID, 'battle-gen7randombattle-1 tournament: development');
+			assert.strictEqual(withVisualID.roomID, 'battle-gen7randombattle-1');
+
+			const noVisualID = converter.parseModlog(`[time] (battle-gen7randombattle-1) SOMETHINGBORING: by annika`);
+			assert.equal(noVisualID.visualRoomID, undefined);
+		});
+	});
+
+	describe('ModlogEntry to text converter', () => {
+		it('should handle all fields of the ModlogEntry object', () => {
+			const entry = {
+				action: 'UNITTEST',
+				roomID: 'development',
+				userid: 'annika',
+				autoconfirmedID: 'heartofetheria',
+				alts: ['googlegoddess', 'princessentrapta'],
+				ip: '127.0.0.1',
+				isGlobal: false,
+				loggedBy: 'yourmom',
+				note: 'Hey Adora~',
+				time: 1598212249944,
+			};
+			assert.strictEqual(
+				converter.rawifyLog(entry),
+				`[2020-08-23T19:50:49.944Z] (development) UNITTEST: [annika] ac: [heartofetheria] alts: [googlegoddess], [princessentrapta] [127.0.0.1] by yourmom: Hey Adora~\n`
+			);
+		});
+	});
+
+	describe('integration tests', () => {
+		it('should convert from SQLite to text', async () => {
+			const modlog = new ml.Modlog(':memory:', true);
+			const mlConverter = new converter.ModlogConverterSQLite('', '', modlog.database);
+
+			const entry = {
+				action: 'UNITTEST',
+				roomID: 'development',
+				userid: 'annika',
+				autoconfirmedID: 'heartofetheria',
+				alts: ['googlegoddess', 'princessentrapta'],
+				ip: '127.0.0.1',
+				isGlobal: false,
+				loggedBy: 'yourmom',
+				note: 'Write 1',
+				time: 1598212249944,
+			};
+			const writes = [];
+			writes.push(modlog.write('development', entry));
+			entry.time++;
+			entry.note = 'Write 2';
+			writes.push(modlog.write('development', entry));
+			entry.time++;
+			entry.note = 'Write 3';
+			writes.push(modlog.write('development', entry));
+			writes.push(modlog.write('development', {
+				action: 'GLOBAL UNITTEST',
+				roomID: 'development',
+				userid: 'annika',
+				autoconfirmedID: 'heartofetheria',
+				alts: ['googlegoddess', 'princessentrapta'],
+				ip: '127.0.0.1',
+				isGlobal: true,
+				loggedBy: 'yourmom',
+				note: 'Global test',
+				time: 1598212249947,
+			}));
+
+			await Promise.all(writes);
+			await mlConverter.toTxt();
+
+			assert.strictEqual(
+				mlConverter.isTesting.files.get('/modlog_development.txt'),
+				`[2020-08-23T19:50:49.944Z] (development) UNITTEST: [annika] ac: [heartofetheria] alts: [googlegoddess], [princessentrapta] [127.0.0.1] by yourmom: Write 1\n` +
+				`[2020-08-23T19:50:49.945Z] (development) UNITTEST: [annika] ac: [heartofetheria] alts: [googlegoddess], [princessentrapta] [127.0.0.1] by yourmom: Write 2\n` +
+				`[2020-08-23T19:50:49.946Z] (development) UNITTEST: [annika] ac: [heartofetheria] alts: [googlegoddess], [princessentrapta] [127.0.0.1] by yourmom: Write 3\n` +
+				`[2020-08-23T19:50:49.947Z] (development) GLOBAL UNITTEST: [annika] ac: [heartofetheria] alts: [googlegoddess], [princessentrapta] [127.0.0.1] by yourmom: Global test\n`
+			);
+
+			assert.strictEqual(
+				mlConverter.isTesting.files.get('/modlog_global.txt'),
+				`[2020-08-23T19:50:49.947Z] (development) GLOBAL UNITTEST: [annika] ac: [heartofetheria] alts: [googlegoddess], [princessentrapta] [127.0.0.1] by yourmom: Global test\n`
+			);
+		});
+
+		it('should convert from text to SQLite, including old-format lines and nonsense lines', async () => {
+			const lines = [
+				`[2020-08-23T19:50:49.944Z] (development) UNITTEST: [annika] ac: [heartofetheria] alts: [googlegoddess], [princessentrapta] [127.0.0.1] by yourmom: Write 1`,
+				`[2020-08-23T19:50:49.945Z] (development) GLOBAL UNITTEST: [annika] ac: [heartofetheria] alts: [googlegoddess], [princessentrapta] [127.0.0.1] by yourmom: Global Write`,
+				`[2020-08-23T19:50:49.946Z] (development tournament: lobby) UNITTEST: [annika] ac: [heartofetheria] alts: [googlegoddess], [princessentrapta] [127.0.0.1] by yourmom: Write 3`,
+			];
+			const globalLines = [
+				`[2020-08-23T19:50:49.945Z] (development) GLOBAL UNITTEST: [annika] ac: [heartofetheria] alts: [googlegoddess], [princessentrapta] [127.0.0.1] by yourmom: Global Write`,
+			];
+			const mlConverter = new converter.ModlogConverterTxt('', '', new Map([
+				['modlog_development.txt', lines.join('\n')],
+				['modlog_global.txt', globalLines.join('\n')],
+			]));
+
+			const database = await mlConverter.toSQLite();
+			const globalEntries = database
+				.prepare(`SELECT *, (SELECT group_concat(userid, ',') FROM alts WHERE alts_id = modlog.modlog_id) as alts FROM modlog WHERE roomid LIKE 'global-%'`)
+				.all();
+			const entries = database
+				.prepare(`SELECT *, (SELECT group_concat(userid, ',') FROM alts WHERE alts_id = modlog.modlog_id) as alts FROM modlog WHERE roomid IN (?, ?) ORDER BY timestamp ASC`)
+				.all('development', 'trivia');
+
+			assert.strictEqual(globalEntries.length, globalLines.length);
+			assert.strictEqual(entries.length, lines.length);
+
+			const visualIDEntry = entries[entries.length - 1];
+
+			assert.strictEqual(visualIDEntry.note, 'Write 3');
+			assert.strictEqual(visualIDEntry.visual_roomid, 'development tournament: lobby');
+			assert.ok(!globalEntries[0].visual_roomid);
+
+			assert.strictEqual(globalEntries[0].timestamp, 1598212249945);
+			assert.strictEqual(globalEntries[0].roomid.replace(/^global-/, ''), 'development');
+			assert.strictEqual(globalEntries[0].action, 'GLOBAL UNITTEST');
+			assert.strictEqual(globalEntries[0].action_taker, 'yourmom');
+			assert.strictEqual(globalEntries[0].userid, 'annika');
+			assert.strictEqual(globalEntries[0].autoconfirmed_userid, 'heartofetheria');
+			assert.strictEqual(globalEntries[0].ip, '127.0.0.1');
+			assert.strictEqual(globalEntries[0].note, 'Global Write');
+			assert.strictEqual(globalEntries[0].alts, 'googlegoddess,princessentrapta');
+		});
+	});
+});

--- a/tools/modlog/convert
+++ b/tools/modlog/convert
@@ -28,16 +28,17 @@ const flags = parseFlags();
 
 const databasePath = flags['--db'];
 const textLogPath = flags['--logdir'];
+const outputLogPath = flags['--outputlogdir'];
 const from = flags['--from'];
 const to = flags['--to'];
 
-if (!(databasePath && textLogPath && from && to) || !['txt', 'sqlite'].includes(from) || !['txt', 'sqlite'].includes(to)) {
+if (
+	!((databasePath || outputLogPath) && textLogPath && from && to) ||
+	!['txt', 'sqlite'].includes(from) ||
+	!['txt', 'sqlite'].includes(to)
+) {
 	throw new Error(`Invalid arguments specified.\nUsage: node tools/modlog/convert --db path/to/database --logdir path/to/modlogs --from <database format> --to <database format>.`);
 }
 
-if (from === to) {
-	throw new Error(`Cannot convert to the same storage format.`);
-}
-
 console.log(`Converting ${from === 'txt' ? `the text modlog files in ${textLogPath}` : `${databasePath}`} from ${from} to ${to}...`);
-ModlogConverter.convert(from, to, databasePath, textLogPath);
+ModlogConverter.convert(from, to, databasePath, textLogPath, outputLogPath);

--- a/tools/modlog/convert
+++ b/tools/modlog/convert
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+/**
+ * This script can be used to convert databases from one format to another
+ * Format:
+ * `node tools/modlog/convert --db path/to/database --logdir path/to/modlogs --from <database format> --to <database format>`
+ * Usage example:
+ * `node tools/modlog/convert --db databases/modlog.db --logdir logs/modlog --from txt --to sqlite`
+ * @author jetou
+ */
+
+'use strict';
+
+const ModlogConverter = require(`${__dirname}/converter.js`).ModlogConverter;
+
+function parseFlags() {
+	const args = process.argv.slice(2);
+	const flags = Object.create(null);
+	for (const [idx, arg] of args.entries()) {
+		if (idx % 2 === 0) {
+			flags[arg] = args[idx + 1];
+		}
+	}
+	return flags;
+}
+
+const flags = parseFlags();
+
+const databasePath = flags['--db'];
+const textLogPath = flags['--logdir'];
+const from = flags['--from'];
+const to = flags['--to'];
+
+if (!(databasePath && textLogPath && from && to) || !['txt', 'sqlite'].includes(from) || !['txt', 'sqlite'].includes(to)) {
+	throw new Error(`Invalid arguments specified.\nUsage: node tools/modlog/convert --db path/to/database --logdir path/to/modlogs --from <database format> --to <database format>.`);
+}
+
+if (from === to) {
+	throw new Error(`Cannot convert to the same storage format.`);
+}
+
+console.log(`Converting ${from === 'txt' ? `the text modlog files in ${textLogPath}` : `${databasePath}`} from ${from} to ${to}...`);
+ModlogConverter.convert(from, to, databasePath, textLogPath);

--- a/tools/modlog/converter.ts
+++ b/tools/modlog/converter.ts
@@ -314,8 +314,13 @@ export function parseModlog(raw: string, nextLine?: string, isGlobal = false): M
 		return log;
 	} else {
 		log.action = action;
+		if (log.action === 'OLD MODLOG') {
+			log.loggedBy = 'unknown' as ID;
+			log.note = line.slice(line.indexOf('by unknown: ') + 'by unknown :'.length);
+			return log;
+		}
+		line = line.slice(actionColonIndex + 2);
 	}
-	line = line.slice(actionColonIndex + 2);
 
 	if (line[0] === '[') {
 		const userid = toID(parseBrackets(line, '['));
@@ -359,12 +364,12 @@ export function parseModlog(raw: string, nextLine?: string, isGlobal = false): M
 }
 
 export function rawifyLog(log: ModlogEntry) {
-	let result = `[${new Date(log.time || Date.now()).toJSON()}] (${(log.visualRoomID || log.roomID || 'global').replace(/^global-/, '')}) ${log.action}:`;
-	if (log.userid) result += ` [${log.userid}]`;
+	let result = `[${new Date(log.time || Date.now()).toJSON()}] (${(log.visualRoomID || log.roomID || 'global').replace(/^global-/, '')}) ${log.action}`;
+	if (log.userid) result += `: [${log.userid}]`;
 	if (log.autoconfirmedID) result += ` ac: [${log.autoconfirmedID}]`;
 	if (log.alts) result += ` alts: [${log.alts.join('], [')}]`;
 	if (log.ip) result += ` [${log.ip}]`;
-	if (log.loggedBy) result += ` by ${log.loggedBy}`;
+	if (log.loggedBy) result += `${result.endsWith(']') ? '' : ':'} by ${log.loggedBy}`;
 	if (log.note) result += `: ${log.note}`;
 	return result + `\n`;
 }

--- a/tools/modlog/converter.ts
+++ b/tools/modlog/converter.ts
@@ -393,7 +393,7 @@ export class ModlogConverterSQLite {
 					autoconfirmedID: result.autoconfirmed_userid,
 					alts: result.alts?.split(','),
 					ip: result.ip,
-					isGlobal: result.roomid?.startsWith('global-'),
+					isGlobal: result.roomid?.startsWith('global-') || result.roomid === 'global',
 					loggedBy: result.action_taker_userid,
 					note: result.note,
 					time: result.timestamp,
@@ -402,7 +402,7 @@ export class ModlogConverterSQLite {
 				if (!rawLogs[key]) rawLogs[key] = [];
 				const rawLog = rawifyLog(entry);
 				rawLogs[key].push(rawLog);
-				if (entry.isGlobal && key !== 'global') {
+				if (entry.isGlobal) {
 					if (!rawLogs.global) rawLogs.global = [];
 					rawLogs.global.push(rawLog);
 				}

--- a/tools/modlog/converter.ts
+++ b/tools/modlog/converter.ts
@@ -21,6 +21,7 @@ export function parseBrackets(line: string, openingBracket: '(' | '[') {
 	};
 	const bracketOpenIndex = line.indexOf(openingBracket);
 	const bracketCloseIndex = line.indexOf(brackets[openingBracket]);
+	if (bracketCloseIndex < 0 || bracketOpenIndex < 0) return '';
 	return line.slice(bracketOpenIndex + 1, bracketCloseIndex);
 }
 

--- a/tools/modlog/converter.ts
+++ b/tools/modlog/converter.ts
@@ -274,7 +274,7 @@ export function modernizeLog(line: string, nextLine?: string) {
 			const user = toID(log.slice(0, index));
 			log = log.slice(index + ' has been caught attempting a hunt with '.length);
 			log = log.replace('. The user has also', '; has also').replace('.', '');
-			return `SCAVCHEATER: [${user}]: caught attempting a hunt with ${log}`;
+			return `SCAV CHEATER: [${user}]: caught attempting a hunt with ${log}`;
 		},
 	};
 
@@ -381,7 +381,7 @@ export class ModlogConverterSQLite {
 		for (const {roomid} of roomids) {
 			if (!Config.nofswriting) console.log(`Reading ${roomid}...`);
 			const results = database.prepare(
-				`SELECT *, (SELECT group_concat(userid, ',') FROM alts WHERE alts_id = modlog.modlog_id) as alts ` +
+				`SELECT *, (SELECT group_concat(userid, ',') FROM alts WHERE alts.modlog_id = modlog.modlog_id) as alts ` +
 				`FROM modlog WHERE roomid = ? ORDER BY timestamp ASC`
 			).all(roomid);
 			for (const result of results) {
@@ -394,7 +394,7 @@ export class ModlogConverterSQLite {
 					alts: result.alts?.split(','),
 					ip: result.ip,
 					isGlobal: result.roomid?.startsWith('global-'),
-					loggedBy: result.action_taker,
+					loggedBy: result.action_taker_userid,
 					note: result.note,
 					time: result.timestamp,
 				};
@@ -467,7 +467,7 @@ export class ModlogConverterTxt {
 				process.stdout.cursorTo(0);
 				process.stdout.write(`(${Math.floor(index / interval)}%) inserted ${index + 1}/${logs.length} entries`);
 			}
-			void modlog.write(log.roomID || 'global', log);
+			modlog.write(log.roomID || 'global', log);
 		}
 		return modlog.database;
 	}

--- a/tools/modlog/converter.ts
+++ b/tools/modlog/converter.ts
@@ -1,0 +1,491 @@
+/**
+ * Converts modlogs between text and SQLite; also modernizes old-format modlogs
+ * @author Annika
+ * @author jetou
+ */
+
+// @ts-ignore Needed for FS
+if (!global.Config) global.Config = {nofswriting: false};
+
+import {FS} from '../../lib/fs';
+import {ModlogEntry, Modlog} from '../../server/modlog';
+import {IPTools} from '../../server/ip-tools';
+import * as Database from 'better-sqlite3';
+
+type ModlogFormat = 'txt' | 'sqlite';
+
+export function parseBrackets(line: string, openingBracket: '(' | '[') {
+	const brackets = {
+		'(': ')',
+		'[': ']',
+	};
+	const bracketOpenIndex = line.indexOf(openingBracket);
+	const bracketCloseIndex = line.indexOf(brackets[openingBracket]);
+	return line.slice(bracketOpenIndex + 1, bracketCloseIndex);
+}
+
+function toID(text: any): ID {
+	return (text && typeof text === "string" ? text : "").toLowerCase().replace(/[^a-z0-9]+/g, "") as ID;
+}
+
+export function modernizeLog(line: string, nextLine?: string) {
+	// first we save and remove the timestamp and the roomname
+	const prefix = line.match(/\[.+?\] \(.+?\) /i)?.[0];
+	if (!prefix) return;
+	if (/\]'s\s.*\salts: \[/.test(line)) return;
+	line = line.replace(prefix, '');
+	if (line.startsWith('(') && line.endsWith(')')) {
+		line = line.slice(1, -1);
+	}
+	const getAlts = (userid: ID) => {
+		let alts;
+		const regex = new RegExp(`\\(\\[.*\\]'s (locked|muted|banned) alts: (\\[.*\\])\\)`);
+		nextLine?.replace(regex, (a, b, rawAlts) => {
+			alts = rawAlts;
+			return '';
+		});
+		return alts ? `alts: ${alts} ` : ``;
+	};
+
+	// Special cases
+	if (/\[(the|a)poll\] was (started|ended) by/.test(line)) {
+		const actionTaker = toID(line.slice(line.indexOf(' by ') + ' by '.length));
+		const isEnding = line.includes('was ended by');
+		return `${prefix}POLL${isEnding ? ' END' : ''}: by ${actionTaker}`;
+	}
+	if (/User (.*?) won the game of (.*?) mode trivia/.test(line)) {
+		return `${prefix}TRIVIAGAME: by unknown: ${line}`;
+	}
+	if (line.startsWith('SCAV ')) {
+		line = line.replace(/: (\[room: .*?\]) by (.*)/, (match, roominfo, rest) => `: by ${rest} ${roominfo}`);
+	}
+	line = line.replace(/(GIVEAWAY WIN|GTS FINISHED): (.*?)(won|has finished)/, (match, action, user) => {
+		return `${action}: [${toID(user)}]:`;
+	});
+
+	const modernizerTransformations: {[k: string]: (log: string) => string} = {
+		'was promoted to ': (log) => {
+			const isDemotion = log.includes('was demoted to ');
+			const userid = parseBrackets(log, '[');
+			log = log.slice(userid.length + 3);
+			log = log.slice(`was ${isDemotion ? 'demoted' : 'promoted'} to `.length);
+			let rank = log.slice(0, log.indexOf(' by')).replace(/ /, '').toUpperCase();
+
+			log = log.slice(`${rank} by `.length);
+			if (!rank.startsWith('ROOM')) rank = `GLOBAL ${rank}`;
+			const actionTaker = parseBrackets(log, '[');
+			return `${rank}: [${userid}] by ${actionTaker}${isDemotion ? ': (demote)' : ''}`;
+		},
+		'was demoted to ': (log) => modernizerTransformations['was promoted to '](log),
+		'was appointed Room Owner by ': (log) => {
+			const userid = parseBrackets(log, '[');
+			log = log.slice(userid.length + 3);
+			log = log.slice('was appointed Room Owner by '.length);
+			const actionTaker = parseBrackets(log, '[');
+			return `ROOMOWNER: [${userid}] by ${actionTaker}`;
+		},
+
+		'set modchat to ': (log) => {
+			const actionTaker = parseBrackets(log, '[');
+			log = log.slice(actionTaker.length + 3);
+			log = log.slice('set modchat to '.length);
+			return `MODCHAT: by ${actionTaker}: to ${log}`;
+		},
+		'set modjoin to ': (log) => {
+			const actionTakerName = log.slice(0, log.lastIndexOf(' set'));
+			log = log.slice(actionTakerName.length + 1);
+			log = log.slice('set modjoin to '.length);
+			const rank = log.startsWith('sync') ? 'sync' : log.replace('.', '');
+			return `MODJOIN${rank === 'sync' ? ' SYNC' : ''}: by ${toID(actionTakerName)}${rank !== 'sync' ? `: ${rank}` : ``}`;
+		},
+		'turned off modjoin': (log) => {
+			const actionTakerName = log.slice(0, log.lastIndexOf(' turned off modjoin'));
+			return `MODJOIN: by ${toID(actionTakerName)}: OFF`;
+		},
+
+		'notes': (log) => {
+			const actionTaker = parseBrackets(log, '[');
+			log = log.slice(actionTaker.length + 3);
+			log = log.slice('notes: '.length);
+			return `NOTE: by ${actionTaker}: ${log}`;
+		},
+
+		'changed the roomintro': (log) => {
+			const isDeletion = /deleted the (staff|room)intro/.test(log);
+			const isRoomintro = log.includes('roomintro');
+			const actionTaker = toID(log.slice(0, log.indexOf(isDeletion ? 'deleted' : 'changed')));
+			return `${isDeletion ? 'DELETE' : ''}${isRoomintro ? 'ROOM' : 'STAFF'}INTRO: by ${actionTaker}`;
+		},
+		'deleted the roomintro': (log) => modernizerTransformations['changed the roomintro'](log),
+		'changed the staffintro': (log) => modernizerTransformations['changed the roomintro'](log),
+		'deleted the staffintro': (log) => modernizerTransformations['changed the roomintro'](log),
+
+		'changed the roomdesc to: ': (log) => {
+			const actionTaker = parseBrackets(log, '[');
+			log = log.slice(actionTaker.length + 3);
+			log = log.slice('changed the roomdesc to: '.length + 1, -2);
+			return `ROOMDESC: by ${actionTaker}: to "${log}"`;
+		},
+
+		' declared ': (log) => {
+			let newAction = 'DECLARE';
+			let oldAction = ' declared ';
+			if (log.includes(' globally declared ')) {
+				oldAction = ' globally declared ';
+				newAction = 'GLOBALDECLARE';
+			}
+			if (log.includes('(chat level)')) {
+				oldAction += '(chat level) ';
+				newAction = `CHATDECLARE`;
+			}
+
+			const actionTakerName = toID(log.slice(0, log.lastIndexOf(oldAction)));
+
+			log = log.slice(actionTakerName.length);
+			log = log.slice(oldAction.length);
+			return `${newAction}: by ${actionTakerName}: ${log}`;
+		},
+
+		'roomevent titled "': (log) => {
+			let action;
+			if (log.includes(' added a roomevent titled "')) {
+				action = 'added a';
+			} else if (log.includes(' removed a roomevent titled "')) {
+				action = 'removed a';
+			} else {
+				action = 'edited the';
+			}
+			const actionTakerName = log.slice(0, log.lastIndexOf(` ${action} roomevent titled "`));
+			log = log.slice(actionTakerName.length + 1);
+			const eventName = log.slice(` ${action} roomevent titled `.length, -2);
+			return `ROOMEVENT: by ${toID(actionTakerName)}: ${action.split(' ')[0]} "${eventName}"`;
+		},
+
+		'created a tournament in': (log) => {
+			const actionTaker = parseBrackets(log, '[');
+			log = log.slice(actionTaker.length + 3);
+			log = log.slice(24, -8);
+			return `TOUR CREATE: by ${actionTaker}: ${log}`;
+		},
+		'was disqualified from the tournament by': (log) => {
+			const disqualified = parseBrackets(log, '[');
+			log = log.slice(disqualified.length + 3);
+			log = log.slice('was disqualified from the tournament by'.length);
+			return `TOUR DQ: [${toID(disqualified)}] by ${toID(log)}`;
+		},
+		'The tournament auto disqualify timeout was set to': (log) => {
+			const byIndex = log.indexOf(' by ');
+			const actionTaker = log.slice(byIndex + ' by '.length);
+			const length = log.slice('The tournament auto disqualify timeout was set to'.length, byIndex);
+			return `TOUR AUTODQ: by ${toID(actionTaker)}: ${length.trim()}`;
+		},
+
+		' was banned from room ': (log) => {
+			const banned = toID(log.slice(0, log.indexOf(' was banned from room ')));
+			log = log.slice(log.indexOf(' by ') + ' by '.length);
+			let reason, ip;
+			if (/\(.*\)/.test(log)) {
+				reason = parseBrackets(log, '(');
+				if (/\[.*\]/.test(log)) ip = parseBrackets(log, '[');
+				log = log.slice(0, log.indexOf('('));
+			}
+			const actionTaker = toID(log);
+			return `ROOMBAN: [${banned}] ${getAlts(banned)}${ip ? `[${ip}] ` : ``}by ${actionTaker}${reason ? `: ${reason}` : ``}`;
+		},
+		' was muted by ': (log) => {
+			let muted = '';
+			let isHour = false;
+			[muted, log] = log.split(' was muted by ');
+			muted = toID(muted);
+			let reason, ip;
+			if (/\(.*\)/.test(log)) {
+				reason = parseBrackets(log, '(');
+				if (/\[.*\]/.test(log)) ip = parseBrackets(log, '[');
+				log = log.slice(0, log.indexOf('('));
+			}
+			let actionTaker = toID(log);
+			if (actionTaker.endsWith('for1hour')) {
+				isHour = true;
+				actionTaker = actionTaker.replace(/^(.*)(for1hour)$/, (match, staff) => staff) as ID;
+			}
+			return `${isHour ? 'HOUR' : ''}MUTE: [${muted}] ${getAlts(muted as ID)}${ip ? `[${ip}] ` : ``}by ${actionTaker}${reason ? `: ${reason}` : ``}`;
+		},
+		' was locked from talking ': (log) => {
+			const isWeek = log.includes(' was locked from talking for a week ');
+			const locked = toID(log.slice(0, log.indexOf(' was locked from talking ')));
+			log = log.slice(log.indexOf(' by ') + ' by '.length);
+			let reason, ip;
+			if (/\(.*\)/.test(log)) {
+				reason = parseBrackets(log, '(');
+				if (/\[.*\]/.test(log)) ip = parseBrackets(log, '[');
+				log = log.slice(0, log.indexOf('('));
+			}
+			const actionTaker = toID(log);
+			return `${isWeek ? 'WEEK' : ''}LOCK: [${locked}] ${getAlts(locked)}${ip ? `[${ip}] ` : ``}by ${actionTaker}${reason ? `: ${reason}` : ``}`;
+		},
+		' was banned ': (log) => {
+			if (log.includes(' was banned from room ')) return modernizerTransformations[' was banned from room '](log);
+			const banned = toID(log.slice(0, log.indexOf(' was banned ')));
+			log = log.slice(log.indexOf(' by ') + ' by '.length);
+			let reason, ip;
+			if (/\(.*\)/.test(log)) {
+				reason = parseBrackets(log, '(');
+				if (/\[.*\]/.test(log)) ip = parseBrackets(log, '[');
+				log = log.slice(0, log.indexOf('('));
+			}
+			const actionTaker = toID(log);
+			return `BAN: [${banned}] ${getAlts(banned)}${ip ? `[${ip}] ` : ``}by ${actionTaker}${reason ? `: ${reason}` : ``}`;
+		},
+
+		' claimed this ticket': (log) => {
+			const actions: {[k: string]: string} = {
+				' claimed this ticket': 'TICKETCLAIM',
+				' closed this ticket': 'TICKETCLOSE',
+				' deleted this ticket': 'TICKETDELETE',
+			};
+			for (const oldAction in actions) {
+				if (log.includes(oldAction)) {
+					const actionTaker = toID(log.slice(0, log.indexOf(oldAction)));
+					return `${actions[oldAction]}: by ${actionTaker}`;
+				}
+			}
+			return log;
+		},
+		'This ticket is now claimed by ': (log) => {
+			const claimer = toID(log.slice(log.indexOf(' by ') + ' by '.length));
+			return `TICKETCLAIM: by ${claimer}`;
+		},
+		' is no longer interested in this ticket': (log) => {
+			const abandoner = toID(log.slice(0, log.indexOf(' is no longer interested in this ticket')));
+			return `TICKETABANDON: by ${abandoner}`;
+		},
+		' opened a new ticket': (log) => {
+			const opener = toID(log.slice(0, log.indexOf(' opened a new ticket')));
+			const problem = log.slice(log.indexOf(' Issue: ') + ' Issue: '.length).trim();
+			return `TICKETOPEN: by ${opener}: ${problem}`;
+		},
+		' closed this ticket': (log) => modernizerTransformations[' claimed this ticket'](log),
+		' deleted this ticket': (log) => modernizerTransformations[' claimed this ticket'](log),
+		'This ticket is no longer claimed': () => 'TICKETUNCLAIM',
+
+		' has been caught attempting a hunt with ': (log) => {
+			const index = log.indexOf(' has been caught attempting a hunt with ');
+			const user = toID(log.slice(0, index));
+			log = log.slice(index + ' has been caught attempting a hunt with '.length);
+			log = log.replace('. The user has also', '; has also').replace('.', '');
+			return `SCAVCHEATER: [${user}]: caught attempting a hunt with ${log}`;
+		},
+	};
+
+	for (const oldAction in modernizerTransformations) {
+		if (line.includes(oldAction)) return prefix + modernizerTransformations[oldAction](line);
+	}
+
+	return `${prefix}${line}`;
+}
+
+export function parseModlog(raw: string, nextLine?: string, isGlobal = false): ModlogEntry | undefined {
+	let line = modernizeLog(raw);
+	if (!line) return;
+
+	const log: ModlogEntry = {action: 'NULL', isGlobal};
+	const timestamp = parseBrackets(line, '[');
+	log.time = Math.floor(new Date(timestamp).getTime());
+	line = line.slice(timestamp.length + 3);
+
+	const [roomid, ...bonus] = parseBrackets(line, '(').split(' ');
+	log.roomID = roomid;
+	if (bonus.length) log.visualRoomID = `${roomid} ${bonus.join(' ')}`;
+	line = line.slice((log.visualRoomID || log.roomID).length + 3);
+	const actionColonIndex = line.indexOf(':');
+	const action = line.slice(0, actionColonIndex);
+	if (action !== action.toUpperCase()) {
+		// no action (probably an old-format log that slipped past the modernizer)
+		log.action = 'OLD MODLOG';
+		log.loggedBy = 'unknown' as ID;
+		log.note = line;
+		return log;
+	} else {
+		log.action = action;
+	}
+	line = line.slice(actionColonIndex + 2);
+
+	if (line[0] === '[') {
+		const userid = toID(parseBrackets(line, '['));
+		log.userid = userid;
+		line = line.slice(userid.length + 3).trim();
+		if (line.startsWith('ac:')) {
+			line = line.slice(3).trim();
+			const ac = parseBrackets(line, '[');
+			log.autoconfirmedID = toID(ac);
+			line = line.slice(ac.length + 3).trim();
+		}
+		if (line.startsWith('alts:')) {
+			line = line.slice(5).trim();
+			log.alts = [];
+			let alt = parseBrackets(line, '[');
+			do {
+				if (IPTools.ipRegex.test(alt)) break;
+				log.alts.push(toID(alt));
+				line = line.slice(line.indexOf(`[${alt}],`) + `[${alt}],`.length).trim();
+				alt = parseBrackets(line, '[');
+			} while (alt);
+		}
+		if (line[0] === '[') {
+			log.ip = parseBrackets(line, '[');
+			line = line.slice(log.ip.length + 3).trim();
+		}
+	}
+
+	const actionTakerColonIndex = line.indexOf(':');
+	const actionTaker = line.slice(3, actionTakerColonIndex > -1 ? actionTakerColonIndex : undefined);
+	log.loggedBy = toID(actionTaker);
+	if (actionTakerColonIndex > -1) {
+		line = line.slice(actionTakerColonIndex + 1);
+		const note = line.slice(1);
+		log.note = note;
+	}
+
+	return log;
+}
+
+export function rawifyLog(log: ModlogEntry) {
+	let result = `[${new Date(log.time || Date.now()).toJSON()}] (${log.visualRoomID || log.roomID || 'global'}) ${log.action}:`;
+	if (log.userid) result += ` [${log.userid}]`;
+	if (log.autoconfirmedID) result += ` ac: [${log.autoconfirmedID}]`;
+	if (log.alts) result += ` alts: [${log.alts.join('], [')}]`;
+	if (log.ip) result += ` [${log.ip}]`;
+	if (log.loggedBy) result += ` by ${log.loggedBy}`;
+	if (log.note) result += `: ${log.note}`;
+	return result + `\n`;
+}
+
+export class ModlogConverterSQLite {
+	readonly databaseFile: string;
+	readonly textLogDir: string;
+	readonly isTesting: {files: Map<string, string>, db: Database.Database} | null = null;
+
+	constructor(databaseFile: string, textLogDir: string, isTesting?: Database.Database) {
+		this.databaseFile = databaseFile;
+		this.textLogDir = textLogDir;
+		if (isTesting || Config.nofswriting) {
+			this.isTesting = {files: new Map<string, string>(), db: isTesting || new Database(':memory')};
+		}
+	}
+
+	async toTxt() {
+		const database = this.isTesting?.db || new Database(this.databaseFile, {fileMustExist: true});
+		const roomids = database.prepare('SELECT DISTINCT roomid FROM modlog').all();
+		const rawLogs: {[roomid: string]: string[]} = {};
+		for (const {roomid} of roomids) {
+			if (!Config.nofswriting) console.log(`Reading ${roomid}...`);
+			const results = database.prepare(
+				`SELECT *, (SELECT group_concat(userid, ',') FROM alts WHERE alts_id = modlog.modlog_id) as alts ` +
+				`FROM modlog WHERE roomid = ? ORDER BY timestamp ASC`
+			).all(roomid);
+			for (const result of results) {
+				const entry: ModlogEntry = {
+					action: result.action,
+					roomID: result.roomid?.replace(/^global-/, ''),
+					visualRoomID: result.visual_roomid,
+					userid: result.userid,
+					autoconfirmedID: result.autoconfirmed_userid,
+					alts: result.alts?.split(','),
+					ip: result.ip,
+					isGlobal: result.roomid?.startsWith('global-'),
+					loggedBy: result.action_taker,
+					note: result.note,
+					time: result.timestamp,
+				};
+				const key = entry.roomID?.split('-')[0] || 'global';
+				if (!rawLogs[key]) rawLogs[key] = [];
+				const rawLog = rawifyLog(entry);
+				rawLogs[key].push(rawLog);
+				if (entry.isGlobal && key !== 'global') {
+					if (!rawLogs.global) rawLogs.global = [];
+					rawLogs.global.push(rawLog);
+				}
+			}
+		}
+		for (const [roomid, logs] of Object.entries(rawLogs)) {
+			if (!Config.nofswriting) console.log(`Writing modlog_${roomid}.txt...`);
+			await this.writeFile(`${this.textLogDir}/modlog_${roomid}.txt`, logs.join(''));
+		}
+	}
+
+	async writeFile(path: string, text: string) {
+		if (this.isTesting) {
+			return this.isTesting.files.set(path, text);
+		}
+		return FS(path).write(text);
+	}
+}
+
+export class ModlogConverterTxt {
+	readonly databaseFile: string;
+	readonly textLogDir: string;
+	readonly isTesting: {files: Map<string, string>, ml?: Modlog} | null = null;
+	constructor(databaseFile: string, textLogDir: string, isTesting?: Map<string, string>) {
+		this.databaseFile = databaseFile;
+		this.textLogDir = textLogDir;
+		if (isTesting || Config.nofswriting) {
+			this.isTesting = {
+				files: isTesting || new Map<string, string>(),
+			};
+		}
+	}
+
+	async toSQLite() {
+		const files = this.isTesting ? [...this.isTesting.files.keys()] : await FS(this.textLogDir).readdir();
+		const logs: ModlogEntry[] = [];
+		// Read global modlog last to avoid inserting duplicate data to database
+		if (files.includes('modlog_global.txt')) {
+			files.splice(files.indexOf('modlog_global.txt'), 1);
+			files.push('modlog_global.txt');
+		}
+		for (const file of files) {
+			if (file === 'README.md') continue;
+			const raw = this.isTesting ? this.isTesting.files.get(file) || '' : await FS(`${this.textLogDir}/${file}`).read();
+			const roomid = file.slice(7, -4);
+			const entries = raw.split('\n')
+				.map((line, index) => {
+					const entry = parseModlog(line, raw[index + 1], roomid === 'global');
+					if (roomid === 'global' && entry?.roomID === 'global') return null;
+					return entry;
+				});
+			for (const entry of entries) {
+				if (entry) logs.push(entry);
+			}
+		}
+		const modlog = new Modlog(this.isTesting ? ':memory:' : `${__dirname}/../../${this.databaseFile}`, true);
+		const interval = Math.floor(logs.length / 100);
+		if (!Config.nofswriting) process.stdout.write(`Loaded ${logs.length} entries`);
+		for (const [index, log] of logs.entries()) {
+			if (!Config.nofswriting && index && (index % interval === 0 || index === logs.length - 1)) {
+				process.stdout.clearLine(0);
+				process.stdout.cursorTo(0);
+				process.stdout.write(`(${Math.floor(index / interval)}%) inserted ${index + 1}/${logs.length} entries`);
+			}
+			void modlog.write(log.roomID || 'global', log);
+		}
+		return modlog.database;
+	}
+}
+
+export class ModlogConverter {
+	static async convert(from: ModlogFormat, to: ModlogFormat, databasePath: string, textLogDirectoryPath: string) {
+		if (from === 'sqlite' && to === 'txt') {
+			const converter = new ModlogConverterSQLite(databasePath, textLogDirectoryPath);
+			return converter.toTxt().then(() => {
+				console.log("Done!");
+				process.exit();
+			});
+		} else if (from === 'txt' && to === 'sqlite') {
+			const converter = new ModlogConverterTxt(databasePath, textLogDirectoryPath);
+			return converter.toSQLite().then(() => {
+				console.log("\nDone!");
+				process.exit();
+			});
+		}
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
         "./lib/*",
         "./server/**/*.ts",
         "./sim/**/*",
-        "./tools/set-import/*.ts"
+        "./tools/set-import/*.ts",
+        "./tools/modlog/*.ts"
     ]
 }


### PR DESCRIPTION
Fixes #6469.

This will require either restarting the server or hotpatching chat and modlog and monkeypatching Rooms.

There is a conversion script (shoutout to @TheJetOU for writing most of it) in `tools/`. It should be run to convert our existing modlogs to SQLite. It also converts old-style modlogs, so there will be no more of `([thepoll] was ended)` type modlog entries.