### PR TITLE
Help: Disable if a room is not set in Config

### DIFF
--- a/server/chat-plugins/help.ts
+++ b/server/chat-plugins/help.ts
@@ -95,14 +95,19 @@ export class HelpResponder {
 		this.settings = data.settings || {queueDisabled: false, filterDisabled: false};
 	}
 	getRoom() {
-		const room = Config.helpFilterRoom ? Rooms.get(Config.helpFilterRoom) : Rooms.get('help');
+		if (!Config.helpFilterRoom) return null;
+		const room = Rooms.get(Config.helpFilterRoom);
 		if (!room) {
-			throw new Chat.ErrorMessage(`A room for the Help filter has not been specified. Set Config.helpFilterRoom to enable it`);
+			throw new Error(`The Help filter is configured for room '${Config.helpFilterRoom}', but that room does not exist.`);
 		}
 		return room;
 	}
+	static roomNotFound(): never {
+		throw new Chat.ErrorMessage(`There is no room configured to use the Help filter.`);
+	}
 	find(question: string, user?: User) {
 		const room = this.getRoom();
+		if (!room) return;
 		const helpFaqs = roomFaqs[room.roomid];
 		const faqs = Object.keys((helpFaqs || '{}'))
 			.filter(item => item.length >= MINIMUM_LENGTH && !helpFaqs[item].startsWith('>'));
@@ -138,6 +143,7 @@ export class HelpResponder {
 		faq = faq.trim();
 		if (!faq) return;
 		const room = this.getRoom();
+		if (!room) return;
 		const entry: string = roomFaqs[room.roomid][faq];
 		if (!entry) return;
 		// ignore short aliases, they cause too many false positives
@@ -152,6 +158,7 @@ export class HelpResponder {
 		// testing purposes
 		if (Config.nofswriting) return true;
 		const room = this.getRoom();
+		if (!room) return;
 		if (roomFaqs[room.roomid][faq]) return true;
 		if (this.data.pairs[faq]) delete this.data.pairs[faq];
 		for (const item of this.queue) {
@@ -255,6 +262,7 @@ export class HelpResponder {
 	}
 	ban(userid: string, reason = '') {
 		const room = this.getRoom();
+		if (!room) return;
 		const user = Users.get(userid)?.id || toID(userid);
 		const punishment: [string, ID, number, string] = ['HELPSUGGESTIONBAN', toID(user), Date.now() + BAN_DURATION, reason];
 		for (const entry of this.queue) {
@@ -268,11 +276,13 @@ export class HelpResponder {
 	}
 	isBanned(user: User | string) {
 		const room = this.getRoom();
+		if (!room) return;
 		return Punishments.getRoomPunishType(room, toID(user)) === 'HELPSUGGESTIONBAN';
 	}
 	static canOverride(user: User) {
 		const devAuth = Rooms.get('development')?.auth;
 		const room = Answerer.getRoom();
+		if (!room) HelpResponder.roomNotFound();
 		return (
 			devAuth?.atLeast(user, '%') && devAuth?.has(user.id) &&
 			room.auth.has(user.id) && room.auth.atLeast(user, '@') ||
@@ -308,7 +318,7 @@ export const chatfilter: ChatFilter = (message, user, room) => {
 
 export const commands: ChatCommands = {
 	question(target, room, user) {
-		if (!Answerer.getRoom()) return this.errorReply(`There is no room configured for use of the Help filter.`);
+		if (!Answerer.getRoom()) HelpResponder.roomNotFound();
 		if (!target) return this.parse("/help question");
 		const reply = Answerer.visualize(target, true);
 		if (!reply) return this.sendReplyBox(`No answer found.`);
@@ -320,7 +330,7 @@ export const commands: ChatCommands = {
 	hf: 'helpfilter',
 	helpfilter: {
 		''(target) {
-			if (!Answerer.getRoom()) return this.errorReply(`There is no room configured for use of the Help filter.`);
+			if (!Answerer.getRoom()) HelpResponder.roomNotFound();
 			if (!target) {
 				this.parse('/help helpfilter');
 				return this.sendReply(
@@ -335,7 +345,7 @@ export const commands: ChatCommands = {
 		toggle(target, room, user) {
 			if (!room) return this.requiresRoom();
 			const helpRoom = Answerer.getRoom();
-			if (!helpRoom) return this.errorReply(`There is no room configured for use of this filter.`);
+			if (!helpRoom) HelpResponder.roomNotFound();
 			if (room.roomid !== helpRoom.roomid) return this.errorReply(`This command is only available in the Help room.`);
 			if (!target) {
 				return this.sendReply(
@@ -359,7 +369,7 @@ export const commands: ChatCommands = {
 		add(target, room, user, connection, cmd) {
 			if (!room) return this.requiresRoom();
 			const helpRoom = Answerer.getRoom();
-			if (!helpRoom) return this.errorReply(`There is no room configured for use of this filter.`);
+			if (!helpRoom) HelpResponder.roomNotFound();
 			if (room.roomid !== helpRoom.roomid) return this.errorReply(`This command is only available in the Help room.`);
 			const force = cmd === 'forceadd';
 			if (force && !HelpResponder.canOverride(user)) {
@@ -386,7 +396,7 @@ export const commands: ChatCommands = {
 		suggest(target, room, user) {
 			if (!room) return this.requiresRoom();
 			const helpRoom = Answerer.getRoom();
-			if (!helpRoom) return this.errorReply(`There is no room configured for use of this filter.`);
+			if (!helpRoom) HelpResponder.roomNotFound();
 			if (room.roomid !== helpRoom.roomid) return this.errorReply(`This command is only available in the Help room.`);
 			if (!target) return this.errorReply(`Specify regex.`);
 			if (!user.autoconfirmed) {
@@ -421,7 +431,7 @@ export const commands: ChatCommands = {
 		},
 		approve(target, room, user) {
 			const helpRoom = Answerer.getRoom();
-			if (!helpRoom) return this.errorReply(`There is no room configured for use of this filter.`);
+			if (!helpRoom) HelpResponder.roomNotFound();
 			if (!this.can('ban', null, helpRoom)) return false;
 			// intended for use mainly within the page, so supports being used in all rooms
 			this.room = helpRoom;
@@ -446,7 +456,7 @@ export const commands: ChatCommands = {
 		},
 		deny(target, room, user) {
 			const helpRoom = Answerer.getRoom();
-			if (!helpRoom) return this.errorReply(`There is no room configured for use of this filter.`);
+			if (!helpRoom) HelpResponder.roomNotFound();
 			if (!this.can('ban', null, helpRoom)) return false;
 			// intended for use mainly within the page, so supports being used in all rooms
 			this.room = helpRoom;
@@ -463,6 +473,7 @@ export const commands: ChatCommands = {
 		unban: 'ban',
 		ban(target, room, user, connection, cmd) {
 			this.room = Answerer.getRoom();
+			if (!this.room) HelpResponder.roomNotFound();
 			target = target.trim();
 			if (!target) return this.parse('/help helpfilter');
 			let [userid, reason] = target.split(',').map(item => item.trim());
@@ -492,7 +503,9 @@ export const commands: ChatCommands = {
 		},
 		queue(target, room, user) {
 			if (!room) return this.requiresRoom();
-			if (room.roomid !== 'help') return this.errorReply(`Must be used in the Help room.`);
+			const helpRoom = Answerer.getRoom();
+			if (!helpRoom) HelpResponder.roomNotFound();
+			if (room.roomid !== helpRoom.roomid) return this.errorReply(`Must be used in the Help room.`);
 			if (!this.can('ban', null, room)) return false;
 			target = target.trim();
 			if (!target) {
@@ -512,7 +525,9 @@ export const commands: ChatCommands = {
 		},
 		clearqueue: 'emptyqueue',
 		emptyqueue(target, room, user) {
-			if (!room || room.roomid !== 'help') return this.errorReply(`Must be used in the Help room.`);
+			const helpRoom = Answerer.getRoom();
+			if (!helpRoom) HelpResponder.roomNotFound();
+			if (!room || room.roomid !== helpRoom.roomid) return this.errorReply(`Must be used in the Help room.`);
 			if (!HelpResponder.canOverride(user)) return this.errorReply(`/helpfilter ${this.cmd} - Access denied.`);
 			Answerer.queue = [];
 			Answerer.writeState();
@@ -540,7 +555,7 @@ export const commands: ChatCommands = {
 export const pages: PageTable = {
 	helpfilter(args, user) {
 		const helpRoom = Answerer.getRoom();
-		if (!helpRoom) return `<h2>There is no room configured to use the help filter.</h2>`;
+		if (!helpRoom) HelpResponder.roomNotFound();
 		const canChange = helpRoom.auth.atLeast(user, '@');
 		let buf = '';
 		const refresh = (type: string, extra?: string[]) => {


### PR DESCRIPTION
This causes issues for other servers to default to help if it doesn't exist. Not worth providing. If you want it, it can just be configured.