### PR TITLE
Users: Fix bug with IP handling

### DIFF
--- a/server/users.ts
+++ b/server/users.ts
@@ -1135,9 +1135,6 @@ export class User extends Chat.MessageContext {
 				for (const roomid of connection.inRooms) {
 					this.leaveRoom(Rooms.get(roomid)!, connection);
 				}
-				if (!this.connections.some(curConnection => curConnection.ip === connection.ip)) {
-					this.ips = this.ips.filter(ip => ip !== connection.ip);
-				}
 				break;
 			}
 		}

--- a/test/server/users.js
+++ b/test/server/users.js
@@ -78,6 +78,14 @@ describe('Users features', function () {
 			});
 		});
 		describe('User', function () {
+			it('should store IP addresses after disconnect', () => {
+				const conn = new Connection('127.0.0.1');
+				const user = new User(conn);
+				assert.deepStrictEqual(['127.0.0.1'], user.ips);
+				user.onDisconnect(conn);
+				assert.deepStrictEqual(['127.0.0.1'], user.ips);
+			});
+
 			describe('#disconnectAll', function () {
 				for (const totalConnections of [1, 2]) {
 					it('should drop all ' + totalConnections + ' connection(s) and mark as inactive', function () {
@@ -135,12 +143,6 @@ describe('Users features', function () {
 					const users = ['127.0.0.1', '127.0.0.2'].map(ip => new User(new Connection(ip)));
 					await Punishments.ban(users[0]);
 					assert.equal(users[1].connected, true);
-				});
-
-				it('should remove IPs properly', async function () {
-					const user = new User();
-					await Punishments.ban(user);
-					assert.equal(user.ips.length, 0);
 				});
 			});
 


### PR DESCRIPTION
This fixes the issue where global moderators/admins can't view the IPs of offline users with `/ip`. It should probably be monkeypatched (unless we want to restart).