### PR TITLE
Auth: Fix changing a group's permission for commands

### DIFF
--- a/server/user-groups.ts
+++ b/server/user-groups.ts
@@ -122,6 +122,7 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 		}
 		const roomPermissions = room ? room.settings.permissions : null;
 		if (roomPermissions) {
+			let foundSpecificPermission = false;
 			if (cmd) {
 				const namespace = cmd.slice(0, cmd.indexOf(' '));
 				if (roomPermissions[`/${cmd}`]) {
@@ -129,17 +130,19 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 					// overrides (should a perm for the command object exist) first
 					if (!auth.atLeast(user, roomPermissions[`/${cmd}`])) return false;
 					jurisdiction = 'su';
+					foundSpecificPermission = true;
 				} else if (roomPermissions[`/${namespace}`]) {
 					// if it's for one command object
 					if (!auth.atLeast(user, roomPermissions[`/${namespace}`])) return false;
 					jurisdiction = 'su';
+					foundSpecificPermission = true;
 				}
-			} else if (roomPermissions[permission]) {
+			}
+			if (!foundSpecificPermission && roomPermissions[permission]) {
 				if (!auth.atLeast(user, roomPermissions[permission])) return false;
 				jurisdiction = 'u';
 			}
 		}
-
 		return Auth.hasJurisdiction(symbol, jurisdiction, targetSymbol as GroupSymbol);
 	}
 	static atLeast(symbol: EffectiveGroupSymbol, symbol2: EffectiveGroupSymbol) {


### PR DESCRIPTION
as far as I can tell, all uses of `checkCan` will provide `cmd`, so setting a group permission to change perms across lots of commands doesn't work at all.