### PR TITLE
Remove outdated getAwakeningValues function

### DIFF
--- a/data/mods/letsgo/rulesets.ts
+++ b/data/mods/letsgo/rulesets.ts
@@ -1,8 +1,0 @@
-export const Formats: {[k: string]: ModdedFormatsData} = {
-	allowavs: {
-		effectType: 'ValidatorRule',
-		name: 'Allow AVs',
-		desc: "Tells formats with the 'letsgo' mod to take Awakening Values into consideration when calculating stats",
-		// implemented in TeamValidator#validateStats
-	},
-};

--- a/data/mods/letsgo/scripts.ts
+++ b/data/mods/letsgo/scripts.ts
@@ -39,8 +39,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			if (stat !== 'hp') {
 				stats[stat] = Math.floor(stats[stat] * friendshipValue / 100);
 			}
-			// @ts-ignore
-			stats[stat] += this.getAwakeningValues(set, stat);
+			stats[stat] += set.evs[stat];
 		}
 		return stats;
 	},

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -995,7 +995,7 @@ export const Formats: {[k: string]: FormatsData} = {
 		effectType: 'ValidatorRule',
 		name: 'Allow AVs',
 		desc: "Tells formats with the 'letsgo' mod to take Awakening Values into consideration when calculating stats",
-		// Implemented in mods/letsgo/rulesets.js
+		// implemented in TeamValidator#validateStats
 	},
 	nfeclause: {
 		effectType: 'ValidatorRule',

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -785,17 +785,6 @@ export class ModdedDex {
 		return nature;
 	}
 
-	getAwakeningValues(set: PokemonSet, statName?: string) {
-		if (typeof statName === 'string') statName = toID(statName);
-		const avs: StatsTable = {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0};
-		let ev: keyof StatsTable;
-		for (ev in set.evs) {
-			avs[ev] = set.evs[ev];
-		}
-		if (typeof statName === 'string' && statName in avs) return avs[statName as keyof StatsTable];
-		return avs;
-	}
-
 	/** Given a table of base stats and a pokemon set, return the actual stats. */
 	spreadModify(baseStats: StatsTable, set: PokemonSet): StatsTable {
 		const modStats: SparseStatsTable = {atk: 10, def: 10, spa: 10, spd: 10, spe: 10};

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -549,7 +549,7 @@ export class Pokemon {
 		for (const stat in this.stats) {
 			statSum += this.calculateStat(stat, this.boosts[stat as BoostName]);
 			awakeningSum += this.calculateStat(
-				stat, this.boosts[stat as BoostName]) + this.battle.getAwakeningValues(this.set, stat);
+				stat, this.boosts[stat as BoostName]) + this.set.evs[stat];
 		}
 		const combatPower = Math.floor(Math.floor(statSum * this.level * 6 / 100) +
 			(Math.floor(awakeningSum) * Math.floor((this.level * 4) / 100 + 2)));


### PR DESCRIPTION
`getAwakeningValues` used to be used by Let's Go's `rulesets.ts` to check that AVs were capped at 200. This was moved to `sim/team-validator.ts` by PR #5840 so now all that remains is a thick wrapper around `set.evs`, which can simply be removed, conveniently additionally increasing type safety.