### PR TITLE
Remove duplicate fail message from Encore

### DIFF
--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -199,7 +199,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				const moveIndex = lockedMove ? target.moves.indexOf(lockedMove) : -1;
 				if (moveIndex < 0 || noEncore.includes(lockedMove) || target.moveSlots[moveIndex].pp <= 0) {
 					// it failed
-					this.add('-fail', target);
 					return false;
 				}
 				this.effectData.move = lockedMove;

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -262,8 +262,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					!target.moveSlots[moveIndex] || target.moveSlots[moveIndex].pp <= 0
 				) {
 					// it failed
-					this.add('-fail', source);
-					this.attrLastMove('[still]');
 					return false;
 				}
 				this.effectData.move = target.lastMove.id;

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -413,8 +413,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					!target.moveSlots[moveIndex] || target.moveSlots[moveIndex].pp <= 0
 				) {
 					// it failed
-					this.add('-fail', source);
-					this.attrLastMove('[still]');
 					return false;
 				}
 				this.effectData.move = target.lastMove.id;


### PR DESCRIPTION
Followup to PR #6292, the simplification means that the `-fail` and `[still]` actions are automatically invoked and this no longer needs to be done manually, indeed it causes duplication as pointed out [here](https://www.smogon.com/forums/posts/8591799).