### PR TITLE
Don't ban autoclose tags without spaces from html

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1243,8 +1243,8 @@ export class CommandContext extends MessageContext {
 			const stack = [];
 			for (const tag of tags) {
 				const isClosingTag = tag.charAt(1) === '/';
-				const isAutocloseTag = tag.charAt(tag.length - 1) === '/';
-				const tagContent = tag.slice(isClosingTag ? 2 : 1, isAutocloseTag ? tag.length - 1 : undefined).replace(/\s+/, ' ').trim();
+				const isAutoclose = tag.charAt(tag.length - 1) === '/';
+				const tagContent = tag.slice(isClosingTag ? 2 : 1, isAutoclose ? tag.length - 1 : undefined).replace(/\s+/, ' ').trim();
 				const tagNameEndIndex = tagContent.indexOf(' ');
 				const tagName = tagContent.slice(0, tagNameEndIndex >= 0 ? tagNameEndIndex : undefined).toLowerCase();
 				if (tagName === '!--') continue;

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1243,7 +1243,8 @@ export class CommandContext extends MessageContext {
 			const stack = [];
 			for (const tag of tags) {
 				const isClosingTag = tag.charAt(1) === '/';
-				const tagContent = tag.slice(isClosingTag ? 2 : 1).replace(/\s+/, ' ').trim();
+				const isAutocloseTag = tag.charAt(tag.length - 1) === '/';
+				const tagContent = tag.slice(isClosingTag ? 2 : 1, isAutocloseTag ? tag.length - 1 : undefined).replace(/\s+/, ' ').trim();
 				const tagNameEndIndex = tagContent.indexOf(' ');
 				const tagName = tagContent.slice(0, tagNameEndIndex >= 0 ? tagNameEndIndex : undefined).toLowerCase();
 				if (tagName === '!--') continue;

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1243,8 +1243,8 @@ export class CommandContext extends MessageContext {
 			const stack = [];
 			for (const tag of tags) {
 				const isClosingTag = tag.charAt(1) === '/';
-				const isAutoclose = tag.charAt(tag.length - 1) === '/';
-				const tagContent = tag.slice(isClosingTag ? 2 : 1, isAutoclose ? tag.length - 1 : undefined).replace(/\s+/, ' ').trim();
+				const contentEndLoc = tag.charAt(tag.length - 1) === '/' ? -1 : undefined;
+				const tagContent = tag.slice(isClosingTag ? 2 : 1, contentEndLoc).replace(/\s+/, ' ').trim();
 				const tagNameEndIndex = tagContent.indexOf(' ');
 				const tagName = tagContent.slice(0, tagNameEndIndex >= 0 ? tagNameEndIndex : undefined).toLowerCase();
 				if (tagName === '!--') continue;


### PR DESCRIPTION
Not the most elegant solution, but if it works it works.

Fixes tags like `<br/>` being banned because the tag name end gets detected via spaces, leaving tagName to be `br/`, which isn't a valid tag name