### PR TITLE
Thing of the Day: Fix bug in removing users

### DIFF
--- a/server/chat-plugins/thing-of-the-day.ts
+++ b/server/chat-plugins/thing-of-the-day.ts
@@ -171,7 +171,7 @@ class OtdHandler {
 		const nomObj = {
 			nomination: nomination,
 			name: user.name,
-			userids: user.previousIDs.slice(),
+			userids: user.previousIDs.concat(user.id),
 			ips: user.ips.slice(),
 		};
 


### PR DESCRIPTION
`user.previousIDs` did not contain the user's _current_ ID, so removing nominations from them wouldn't work, as it checks the property that `user.previousIDs.slice()` was assigned to. This `concat`s the current `id` to the `userid` array so it's properly tracked.