### PR TITLE
Add hidestats arg to showteam and improve output

### DIFF
--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -954,7 +954,7 @@ export const commands: ChatCommands = {
 				}
 			}
 		}
-		let resultString = Dex.stringifyTeam(teamStrings, false, hideStats);
+		let resultString = Dex.stringifyTeam(teamStrings, undefined, hideStats);
 		if (showAll) {
 			resultString = `<details><summary>${this.tr`View team`}</summary>${resultString}</details>`;
 		}

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -935,7 +935,7 @@ export const commands: ChatCommands = {
 		if (!battle) return this.errorReply(this.tr("This command can only be used in a battle."));
 		let teamStrings = await battle.getTeam(user);
 		if (!teamStrings) return this.errorReply(this.tr("Only players can extract their team."));
-		if (target && !hideStats) {
+		if (!showAll) {
 			const parsed = parseInt(target);
 			if (parsed > 6) return this.errorReply(this.tr`Use a number between 1-6 to view a specific set.`);
 			if (isNaN(parsed)) {

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -928,7 +928,7 @@ export const commands: ChatCommands = {
 	async showset(target, room, user, connection, cmd) {
 		this.checkChat();
 		const showAll = cmd === 'showteam';
-		const hideStats = target === 'hidestats';
+		const hideStats = toID(target) === 'hidestats';
 		room = this.requireRoom();
 		const battle = room.battle;
 		if (!showAll && !target) return this.parse(`/help showset`);

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -935,23 +935,21 @@ export const commands: ChatCommands = {
 		if (!battle) return this.errorReply(this.tr("This command can only be used in a battle."));
 		let teamStrings = await battle.getTeam(user);
 		if (!teamStrings) return this.errorReply(this.tr("Only players can extract their team."));
-		if (target) {
+		if (target && !hideStats) {
 			const parsed = parseInt(target);
 			if (parsed > 6) return this.errorReply(this.tr`Use a number between 1-6 to view a specific set.`);
-			if (!hideStats) {
-				if (isNaN(parsed)) {
-					const matchedSet = teamStrings.filter(set => {
-						const id = toID(target);
-						return toID(set.name) === id || toID(set.species) === id;
-					})[0];
-					if (!matchedSet) return this.errorReply(this.tr`The Pokemon "${target}" is not in your team.`);
-					teamStrings = [matchedSet];
-				} else {
-					const setIndex = parsed - 1;
-					const indexedSet = teamStrings[setIndex];
-					if (!indexedSet) return this.errorReply(this.tr`That Pokemon is not in your team.`);
-					teamStrings = [indexedSet];
-				}
+			if (isNaN(parsed)) {
+				const matchedSet = teamStrings.filter(set => {
+					const id = toID(target);
+					return toID(set.name) === id || toID(set.species) === id;
+				})[0];
+				if (!matchedSet) return this.errorReply(this.tr`The Pokemon "${target}" is not in your team.`);
+				teamStrings = [matchedSet];
+			} else {
+				const setIndex = parsed - 1;
+				const indexedSet = teamStrings[setIndex];
+				if (!indexedSet) return this.errorReply(this.tr`That Pokemon is not in your team.`);
+				teamStrings = [indexedSet];
 			}
 		}
 		let resultString = Dex.stringifyTeam(teamStrings, undefined, hideStats);

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -928,6 +928,7 @@ export const commands: ChatCommands = {
 	async showset(target, room, user, connection, cmd) {
 		this.checkChat();
 		const showAll = cmd === 'showteam';
+		const hideStats = target === 'hidestats';
 		room = this.requireRoom();
 		const battle = room.battle;
 		if (!showAll && !target) return this.parse(`/help showset`);
@@ -937,21 +938,23 @@ export const commands: ChatCommands = {
 		if (target) {
 			const parsed = parseInt(target);
 			if (parsed > 6) return this.errorReply(this.tr`Use a number between 1-6 to view a specific set.`);
-			if (isNaN(parsed)) {
-				const matchedSet = teamStrings.filter(set => {
-					const id = toID(target);
-					return toID(set.name) === id || toID(set.species) === id;
-				})[0];
-				if (!matchedSet) return this.errorReply(this.tr`The Pokemon "${target}" is not in your team.`);
-				teamStrings = [matchedSet];
-			} else {
-				const setIndex = parsed - 1;
-				const indexedSet = teamStrings[setIndex];
-				if (!indexedSet) return this.errorReply(this.tr`That Pokemon is not in your team.`);
-				teamStrings = [indexedSet];
+			if (!hideStats) {
+				if (isNaN(parsed)) {
+					const matchedSet = teamStrings.filter(set => {
+						const id = toID(target);
+						return toID(set.name) === id || toID(set.species) === id;
+					})[0];
+					if (!matchedSet) return this.errorReply(this.tr`The Pokemon "${target}" is not in your team.`);
+					teamStrings = [matchedSet];
+				} else {
+					const setIndex = parsed - 1;
+					const indexedSet = teamStrings[setIndex];
+					if (!indexedSet) return this.errorReply(this.tr`That Pokemon is not in your team.`);
+					teamStrings = [indexedSet];
+				}
 			}
 		}
-		let resultString = Dex.stringifyTeam(teamStrings);
+		let resultString = Dex.stringifyTeam(teamStrings, false, hideStats);
 		if (showAll) {
 			resultString = `<details><summary>${this.tr`View team`}</summary>${resultString}</details>`;
 		}
@@ -960,6 +963,7 @@ export const commands: ChatCommands = {
 	},
 	showsethelp: [
 		`!showteam - show the team you're using in the current battle (must be used in a battle you're a player in).`,
+		`!showteam hidestats - show the team you're using in the current battle, without displaying any stat-related information.`,
 		`!showset [number] - shows the set of the pokemon corresponding to that number (in original Team Preview order, not necessarily current order)`,
 	],
 

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -1449,11 +1449,11 @@ export class ModdedDex {
 		let output = '';
 		for (const [i, mon] of team.entries()) {
 			const species = Dex.getSpecies(mon.species);
-			const name = mon.gigantamax ? `${species.name}-Gmax` : species.name;
-			output += nicknames ? `${nicknames?.[i]} (${name})` : name;
-			output += mon.item ? ` @ ${Dex.getItem(mon.item).name}<br />` : '<br />';
+			output += nicknames ? `${nicknames?.[i]} (${species.name})` : species.name;
+			output += mon.item ? ` @ ${Dex.getItem(mon.item).name}<br />` : `<br />`;
 			output += `Ability: ${Dex.getAbility(mon.ability).name}<br />`;
 			if (typeof mon.happiness === 'number' && mon.happiness !== 255) output += `Happiness: ${mon.happiness}<br />`;
+			if (mon.gigantamax) output += `Gigantamax: Yes<br />`;
 			if (!hideStats) {
 				const evs = [];
 				for (const stat in mon.evs) {

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -1445,27 +1445,30 @@ export class ModdedDex {
 	/**
 	* Use instead of Dex.packTeam to generate more human-readable team output.
 	*/
-	stringifyTeam(team: PokemonSet[], nicknames?: string[]) {
+	stringifyTeam(team: PokemonSet[], nicknames?: string[], hideStats?: boolean) {
 		let output = '';
 		for (const [i, mon] of team.entries()) {
 			const species = Dex.getSpecies(mon.species);
-			output += nicknames ? `${nicknames?.[i]} (${species.name})` : species.name;
-			output += ` @ ${Dex.getItem(mon.item).name}<br/>`;
-			output += `Ability: ${Dex.getAbility(mon.ability).name}<br/>`;
-			if (typeof mon.happiness === 'number' && mon.happiness !== 255) output += `Happiness: ${mon.happiness}<br/>`;
-			const evs = [];
-			for (const stat in mon.evs) {
-				if (mon.evs[stat as StatName]) evs.push(`${mon.evs[stat as StatName]} ${stat}`);
+			const name = mon.gigantamax ? `${species.name}-Gmax` : species.name;
+			output += nicknames ? `${nicknames?.[i]} (${name})` : name;
+			output += mon.item ? ` @ ${Dex.getItem(mon.item).name}<br />` : '<br />';
+			output += `Ability: ${Dex.getAbility(mon.ability).name}<br />`;
+			if (typeof mon.happiness === 'number' && mon.happiness !== 255) output += `Happiness: ${mon.happiness}<br />`;
+			if (!hideStats) {
+				const evs = [];
+				for (const stat in mon.evs) {
+					if (mon.evs[stat as StatName]) evs.push(`${mon.evs[stat as StatName]} ${stat}`);
+				}
+				if (evs.length) output += `EVs: ${evs.join(' / ')}<br />`;
+				if (mon.nature) output += `${this.getNature(mon.nature).name} Nature<br />`;
+				const ivs = [];
+				for (const stat in mon.ivs) {
+					if (mon.ivs[stat as StatName] !== 31) ivs.push(`${mon.ivs[stat as StatName]} ${stat}`);
+				}
+				if (ivs.length) output += `IVs: ${ivs.join(' / ')}<br />`;
 			}
-			if (evs.length) output += `EVs: ${evs.join(' / ')}<br/>`;
-			if (mon.nature) output += `${this.getNature(mon.nature).name} Nature<br/>`;
-			const ivs = [];
-			for (const stat in mon.ivs) {
-				if (mon.ivs[stat as StatName] !== 31) ivs.push(`${mon.ivs[stat as StatName]} ${stat}`);
-			}
-			if (ivs.length) output += `IVs: ${ivs.join(' / ')}<br/>`;
-			output += mon.moves.map(move => `- ${Dex.getMove(move).name}<br/>`).join('');
-			output += '<br/>';
+			output += mon.moves.map(move => `- ${Dex.getMove(move).name}<br />`).join('');
+			output += '<br />';
 		}
 		return output;
 	}


### PR DESCRIPTION
I'm not sure if it'll ever get used as such, but !showteam is very very close to how VGC Player's Cup works - each side has the other's complete team information, except for stats. This does the following:

- Adds a "hidestats" arg which prevents EVs, IVs, and Nature from printing
- Adds the Gmax forme information if applicable
- Doesn't display the @ if the Pokemon is not holding an item