### PR TITLE
Improve spread damage return value check

### DIFF
--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -815,10 +815,7 @@ export const Scripts: BattleScriptsData = {
 		damage = this.spreadDamage(damage, targets, pokemon, move);
 
 		for (const i of targets.keys()) {
-			if (!damage && damage !== 0) {
-				this.debug('damage interrupted');
-				targets[i] = false;
-			}
+			if (damage[i] === false) targets[i] = false;
 		}
 
 		// 3. onHit event happens here


### PR DESCRIPTION
Simply replacing these instances with `damage[i]` doesn't work, since `damage[i]` can legally be `undefined` at ths point, typically for status moves, so I just copied the check used for the return value of `getSpreadDamage`.