### PR TITLE
Fix crash in /invite

### DIFF
--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -544,11 +544,12 @@ export const commands: ChatCommands = {
 			return this.parse(`/pm ${targetUsername}, /invite ${targetRoom.roomid}`);
 		}
 
-		const targetUser = this.pmTarget!; // not room means it's a PM
+		const targetUser = this.pmTarget; // not room means it's a PM
 
 		if (!targetRoom) {
 			return this.errorReply(this.tr`The room "${target}" was not found.`);
 		}
+		if (!targetUser) return this.parse(`/help invite`);
 		if (!targetRoom.checkModjoin(targetUser)) {
 			this.room = targetRoom;
 			this.parse(`/roomvoice ${targetUser.name}`);


### PR DESCRIPTION
Apparently sending an invite to `~` crashes PS. I don't know if this is the ideal way to fix this or if it's better to move the "this message can't be sent" thing, but this should work.