### PR TITLE
Tournaments: Check permissions properly

### DIFF
--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -1832,7 +1832,6 @@ export const commands: ChatCommands = {
 		forcetimer(target, room, user, connection, cmd) {
 			room = this.requireRoom();
 			checkPermissions(this, room, user);
-			this.checkCan('gamemanagement', null, room);
 			const tournament = room.getGame(Tournament);
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			target = target.trim();

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -1160,6 +1160,15 @@ function createTournament(
 	);
 	return tour;
 }
+function checkPermissions(context: CommandContext, room: Room, user: User) {
+	if (room.settings.toursEnabled === true) {
+		context.checkCan('tournaments', null, room);
+	} else if (room.settings.toursEnabled === '%') {
+		context.checkCan('gamemoderation', null, room);
+	} else if (!user.can('gamemanagement', null, room)) {
+		throw new Chat.ErrorMessage(`Tournaments are disabled in this room (${room.roomid}).`);
+	}
+}
 
 export const commands: ChatCommands = {
 	tour: 'tournament',
@@ -1254,15 +1263,7 @@ export const commands: ChatCommands = {
 		new: 'create',
 		create(target, room, user, connection, cmd) {
 			room = this.requireRoom();
-			if (room.settings.toursEnabled === true) {
-				this.checkCan('tournaments', null, room);
-			} else if (room.settings.toursEnabled === '%') {
-				this.checkCan('gamemoderation', null, room);
-			} else {
-				if (!user.can('gamemanagement', null, room)) {
-					return this.errorReply(`Tournaments are disabled in this room (${room.roomid}).`);
-				}
-			}
+			checkPermissions(this, room, user);
 			const [format, generator, cap, mod, name] = target.split(',').map(item => item.trim());
 			if (!target || !format || !generator) {
 				return this.sendReply(`Usage: /tour ${cmd} <format>, <type> [, <comma-separated arguments>]`);
@@ -1302,10 +1303,11 @@ export const commands: ChatCommands = {
 		},
 		banuser(target, room, user) {
 			room = this.requireRoom();
-			const [userid, reason] = target.split(',').map(item => item.trim());
+			const [userid, ...reasonsArray] = target.split(',').map(item => item.trim());
 			if (!target) {
 				return this.sendReply(`Usage: /tour banuser <user>, <reason>`);
 			}
+			const reason = reasonsArray.join(',');
 			const targetUser = Users.get(userid);
 			this.checkCan('gamemoderation', targetUser, room);
 
@@ -1447,14 +1449,15 @@ export const commands: ChatCommands = {
 		},
 		settype(target, room, user, connection, cmd) {
 			room = this.requireRoom();
+			checkPermissions(this, room, user);
 			const tournament = room.getGame(Tournament);
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			if (!target) {
 				return this.sendReply(`Usage: /tour ${cmd} <type> [, <comma-separated arguments>]`);
 			}
-			const [cap, name, modifier] = target.split(',').map(item => item.trim());
+			const [generatorType, cap, modifier] = target.split(',').map(item => item.trim());
 			const playerCap = parseInt(cap);
-			const generator = createTournamentGenerator(name, modifier, this);
+			const generator = createTournamentGenerator(generatorType, modifier, this);
 			if (generator && tournament.setGenerator(generator, this)) {
 				if (playerCap && playerCap >= 2) {
 					tournament.playerCap = playerCap;
@@ -1467,9 +1470,9 @@ export const commands: ChatCommands = {
 					room.send(`|tournament|update|{"playerCap": "${playerCap}"}`);
 				}
 				const capNote = (tournament.playerCap ? ' with a player cap of ' + tournament.playerCap : '');
-				this.privateModAction(`${user.name} set tournament type to ${generator.name + capNote}.`);
+				this.privateModAction(`${user.name} set tournament type to ${generator.name}${capNote}.`);
 				this.modlog('TOUR SETTYPE', null, generator.name + capNote);
-				this.sendReply(`Tournament set to ${generator.name + capNote}.`);
+				this.sendReply(`Tournament set to ${generator.name}${capNote}.`);
 			}
 		},
 		cap: 'setplayercap',
@@ -1477,6 +1480,7 @@ export const commands: ChatCommands = {
 		setcap: 'setplayercap',
 		setplayercap(target, room, user, connection, cmd) {
 			room = this.requireRoom();
+			checkPermissions(this, room, user);
 			const tournament = room.getGame(Tournament);
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			target = target.trim();
@@ -1522,6 +1526,7 @@ export const commands: ChatCommands = {
 		stop: 'delete',
 		delete(target, room, user) {
 			room = this.requireRoom();
+			checkPermissions(this, room, user);
 			const tournament = room.getGame(Tournament);
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			tournament.forceEnd();
@@ -1533,6 +1538,7 @@ export const commands: ChatCommands = {
 		rules: 'customrules',
 		customrules(target, room, user, connection, cmd) {
 			room = this.requireRoom();
+			checkPermissions(this, room, user);
 			const tournament = room.getGame(Tournament);
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			const params = target.split(',').map(item => item.trim());
@@ -1549,7 +1555,7 @@ export const commands: ChatCommands = {
 			}
 			if (tournament.setCustomRules(params)) {
 				room.addRaw(
-					`<div class='infobox infobox-limited'>This tournament includes:<br />${tournament.getCustomRules()}</div>`
+					`<div class="infobox infobox-limited">This tournament includes:<br />${tournament.getCustomRules()}</div>`
 				);
 				this.privateModAction(`${user.name} updated the tournament's custom rules.`);
 				this.modlog('TOUR RULES', null, tournament.customRules.join(', '));
@@ -1560,6 +1566,7 @@ export const commands: ChatCommands = {
 		clearrules: 'clearcustomrules',
 		clearcustomrules(target, room, user) {
 			room = this.requireRoom();
+			checkPermissions(this, room, user);
 			const tournament = room.getGame(Tournament);
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			if (tournament.isTournamentStarted) {
@@ -1583,6 +1590,7 @@ export const commands: ChatCommands = {
 		customname: 'setname',
 		setname(target, room, user, connection, cmd) {
 			room = this.requireRoom();
+			checkPermissions(this, room, user);
 			const tournament = room.getGame(Tournament);
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			const name = target.trim();
@@ -1605,6 +1613,7 @@ export const commands: ChatCommands = {
 		resetname: 'clearname',
 		clearname(target, room, user) {
 			room = this.requireRoom();
+			checkPermissions(this, room, user);
 			const tournament = room.getGame(Tournament);
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			if (tournament.name === tournament.baseFormat) return this.errorReply("The tournament does not have a name.");
@@ -1617,6 +1626,7 @@ export const commands: ChatCommands = {
 		begin: 'start',
 		start(target, room, user) {
 			room = this.requireRoom();
+			checkPermissions(this, room, user);
 			const tournament = room.getGame(Tournament);
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			if (tournament.startTournament(this)) {
@@ -1626,6 +1636,7 @@ export const commands: ChatCommands = {
 		dq: 'disqualify',
 		disqualify(target, room, user, connection, cmd) {
 			room = this.requireRoom();
+			checkPermissions(this, room, user);
 			const tournament = room.getGame(Tournament);
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			if (!target) {
@@ -1645,6 +1656,7 @@ export const commands: ChatCommands = {
 		sub: 'replace',
 		replace(target, room, user) {
 			room = this.requireRoom();
+			checkPermissions(this, room, user);
 			const tournament = room.getGame(Tournament);
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			const [oldUser, newUser] = target.split(',').map(item => Users.get(item.trim()));
@@ -1656,6 +1668,7 @@ export const commands: ChatCommands = {
 		autostart: 'setautostart',
 		setautostart(target, room, user, connection, cmd) {
 			room = this.requireRoom();
+			checkPermissions(this, room, user);
 			const tournament = room.getGame(Tournament);
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			target = target.trim();
@@ -1695,6 +1708,7 @@ export const commands: ChatCommands = {
 		autodq: 'setautodq',
 		setautodq(target, room, user, connection, cmd) {
 			room = this.requireRoom();
+			checkPermissions(this, room, user);
 			const tournament = room.getGame(Tournament);
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			target = target.trim();
@@ -1717,6 +1731,7 @@ export const commands: ChatCommands = {
 		},
 		runautodq(target, room, user) {
 			room = this.requireRoom();
+			checkPermissions(this, room, user);
 			const tournament = room.getGame(Tournament);
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			if (tournament.autoDisqualifyTimeout === Infinity) {
@@ -1730,6 +1745,7 @@ export const commands: ChatCommands = {
 		setscout: 'setscouting',
 		setscouting(target, room, user, connection, cmd) {
 			room = this.requireRoom();
+			checkPermissions(this, room, user);
 			const tournament = room.getGame(Tournament);
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			target = target.trim();
@@ -1763,6 +1779,7 @@ export const commands: ChatCommands = {
 		modjoin: 'setmodjoin',
 		setmodjoin(target, room, user, connection, cmd) {
 			room = this.requireRoom();
+			checkPermissions(this, room, user);
 			const tournament = room.getGame(Tournament);
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			target = target.trim();
@@ -1793,6 +1810,7 @@ export const commands: ChatCommands = {
 		},
 		forcepublic(target, room, user, connection, cmd) {
 			room = this.requireRoom();
+			checkPermissions(this, room, user);
 			const tournament = room.getGame(Tournament);
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			target = target.trim();
@@ -1813,6 +1831,8 @@ export const commands: ChatCommands = {
 		},
 		forcetimer(target, room, user, connection, cmd) {
 			room = this.requireRoom();
+			checkPermissions(this, room, user);
+			this.checkCan('gamemanagement', null, room);
 			const tournament = room.getGame(Tournament);
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			target = target.trim();


### PR DESCRIPTION
The conversion to the conventional commands formatting removed all permissions checks, so now regular users can modify tournaments.

This also introduced a bug where the args order for /tour settype was switched around.