### PR TITLE
Chat: Move forcerename tracking to Monitor and Punishments

### DIFF
--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -1464,13 +1464,13 @@ export const commands: ChatCommands = {
 		if (targetUser.connected) {
 			forceRenameMessage = `was forced to choose a new name by ${user.name}${(reason ? `: ${reason}` : ``)}`;
 			this.globalModlog('FORCERENAME', targetUser, ` by ${user.name}${(reason ? `: ${reason}` : ``)}`);
-			Chat.forceRenames.set(targetUser.id, (Chat.forceRenames.get(targetUser.id) || 0) + 1);
+			Monitor.forceRenames.set(targetUser.id, (Monitor.forceRenames.get(targetUser.id) || 0) + 1);
 			Ladders.cancelSearches(targetUser);
 			targetUser.send(`|nametaken||${user.name} considers your name inappropriate${(reason ? `: ${reason}` : ".")}`);
 		} else {
 			forceRenameMessage = `would be forced to choose a new name by ${user.name} but is offline${(reason ? `: ${reason}` : ``)}`;
 			this.globalModlog('FORCERENAME OFFLINE', targetUser, ` by ${user.name}${(reason ? `: ${reason}` : ``)}`);
-			if (!Chat.forceRenames.has(targetUser.id)) Chat.forceRenames.set(targetUser.id, 0);
+			if (!Monitor.forceRenames.has(targetUser.id)) Monitor.forceRenames.set(targetUser.id, 0);
 		}
 
 		if (room?.roomid !== 'staff') this.privateModAction(`${targetUser.name} ${forceRenameMessage}`);

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -1484,6 +1484,9 @@ export const commands: ChatCommands = {
 		);
 
 		targetUser.resetName(true);
+		if (Punishments.namefilterwhitelist.has(targetUser.id)) {
+			Punishments.unwhitelistName(targetUser.id);
+		}
 		return true;
 	},
 	forcerenamehelp: [

--- a/server/chat-plugins/chat-monitor.ts
+++ b/server/chat-plugins/chat-monitor.ts
@@ -348,7 +348,7 @@ export const chatfilter: ChatFilter = function (message, user, room) {
 
 export const namefilter: NameFilter = (name, user) => {
 	const id = toID(name);
-	if (Chat.namefilterwhitelist.has(id)) return name;
+	if (Monitor.namefilterwhitelist.has(id)) return name;
 	if (id === toID(user.trackRename)) return '';
 	let lcName = name
 		.replace(/\u039d/g, 'N').toLowerCase()
@@ -384,16 +384,16 @@ export const namefilter: NameFilter = (name, user) => {
 export const loginfilter: LoginFilter = user => {
 	if (user.namelocked) return;
 
-	const forceRenamed = Chat.forceRenames.get(user.id);
+	const forceRenamed = Monitor.forceRenames.get(user.id);
 	if (user.trackRename) {
-		const manualForceRename = Chat.forceRenames.get(toID(user.trackRename));
+		const manualForceRename = Monitor.forceRenames.get(toID(user.trackRename));
 		Rooms.global.notifyRooms(
 			['staff'],
 			Utils.html`|html|[NameMonitor] Username used: <span class="username">${user.name}</span> ${user.getAccountStatusString()} (${!manualForceRename ? 'automatically ' : ''}forcerenamed from <span class="username">${user.trackRename}</span>)`
 		);
 		user.trackRename = '';
 	}
-	if (Chat.namefilterwhitelist.has(user.id)) return;
+	if (Monitor.namefilterwhitelist.has(user.id)) return;
 	if (typeof forceRenamed === 'number') {
 		const count = forceRenamed ? ` (forcerenamed ${forceRenamed} time${Chat.plural(forceRenamed)})` : '';
 		Rooms.global.notifyRooms(
@@ -507,9 +507,9 @@ export const pages: PageTable = {
 			}
 		}
 
-		if (Chat.namefilterwhitelist.size) {
+		if (Monitor.namefilterwhitelist.size) {
 			content += `<tr><th colspan="2"><h3>Whitelisted names</h3></tr></th>`;
-			for (const [val] of Chat.namefilterwhitelist) {
+			for (const [val] of Monitor.namefilterwhitelist) {
 				content += `<tr><td>${val}</td></tr>`;
 			}
 		}
@@ -622,7 +622,7 @@ export const commands: ChatCommands = {
 		this.checkCan('forcerename');
 		target = toID(target);
 		if (!target) return this.errorReply(`Syntax: /allowname username`);
-		Chat.namefilterwhitelist.set(target, user.name);
+		Monitor.namefilterwhitelist.set(target, user.name);
 
 		const msg = `${target} was allowed as a username by ${user.name}.`;
 		const staffRoom = Rooms.get('staff');

--- a/server/chat-plugins/chat-monitor.ts
+++ b/server/chat-plugins/chat-monitor.ts
@@ -627,11 +627,9 @@ export const commands: ChatCommands = {
 		}
 
 		const msg = `${target} was allowed as a username by ${user.name}.`;
-		const staffRoom = Rooms.get('staff');
-		const upperStaffRoom = Rooms.get('upperstaff');
-		if (staffRoom) staffRoom.add(msg).update();
-		if (upperStaffRoom) upperStaffRoom.add(msg).update();
-		if (room !== staffRoom && room !== upperStaffRoom) {
+		const toNotify: RoomID[] = ['staff', 'upperstaff'];
+		Rooms.global.notifyRooms(toNotify, `|c|${user.getIdentity()}|/log ${msg}`);
+		if (!room || !toNotify.includes(room.roomid)) {
 			this.sendReply(msg);
 		}
 		this.globalModlog(`ALLOWNAME`, null, `${target} by ${user.name}`);

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -2106,11 +2106,6 @@ export const Chat = new class {
 
 	readonly filterWords: {[k: string]: FilterWord[]} = {};
 	readonly monitors: {[k: string]: Monitor} = {};
-	readonly namefilterwhitelist = new Map<string, string>();
-	/**
-	 * Inappropriate userid : number of times the name has been forcerenamed
-	 */
-	readonly forceRenames = new Map<ID, number>();
 
 	registerMonitor(id: string, entry: Monitor) {
 		if (!Chat.filterWords[id]) Chat.filterWords[id] = [];

--- a/server/monitor.ts
+++ b/server/monitor.ts
@@ -69,6 +69,12 @@ export const Monitor = new class {
 	updateServerLock = false;
 	cleanInterval: NodeJS.Timeout | null = null;
 
+	readonly namefilterwhitelist = new Map<string, string>();
+	/**
+	 * Inappropriate userid : number of times the name has been forcerenamed
+	 */
+	readonly forceRenames = new Map<ID, number>();
+
 	/*********************************************************
 	 * Logging
 	 *********************************************************/

--- a/server/monitor.ts
+++ b/server/monitor.ts
@@ -68,8 +68,6 @@ export const Monitor = new class {
 
 	updateServerLock = false;
 	cleanInterval: NodeJS.Timeout | null = null;
-
-	readonly namefilterwhitelist = new Map<string, string>();
 	/**
 	 * Inappropriate userid : number of times the name has been forcerenamed
 	 */

--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -18,6 +18,7 @@ const PUNISHMENT_FILE = 'config/punishments.tsv';
 const ROOM_PUNISHMENT_FILE = 'config/room-punishments.tsv';
 const SHAREDIPS_FILE = 'config/sharedips.tsv';
 const SHAREDIPS_BLACKLIST_FILE = 'config/sharedips-blacklist.tsv';
+const WHITELISTED_NAMES_FILE = 'config/name-whitelist.tsv';
 
 const RANGELOCK_DURATION = 60 * 60 * 1000; // 1 hour
 const LOCK_DURATION = 48 * 60 * 60 * 1000; // 48 hours
@@ -143,6 +144,10 @@ export const Punishments = new class {
 	 */
 	readonly sharedIpBlacklist = new Map<string, string>();
 	/**
+	 * namefilterwhitelist is a whitelistedname:whitelister Map
+	 */
+	readonly namefilterwhitelist = new Map<string, string>();
+	/**
 	 * Connection flood table. Separate table from IP bans.
 	 */
 	readonly cfloods = new Set<string>();
@@ -188,6 +193,7 @@ export const Punishments = new class {
 			void Punishments.loadBanlist();
 			void Punishments.loadSharedIps();
 			void Punishments.loadSharedIpBlacklist();
+			void Punishments.loadWhitelistedNames();
 		});
 	}
 
@@ -399,6 +405,29 @@ export const Punishments = new class {
 			buf += `${ip}\t${reason}\r\n`;
 		});
 		return FS(SHAREDIPS_BLACKLIST_FILE).write(buf);
+	}
+
+	async loadWhitelistedNames() {
+		const data = await FS(WHITELISTED_NAMES_FILE).readIfExists();
+		if (!data) return;
+		const lines = data.split('\n');
+		lines.shift();
+		for (const line of lines) {
+			const [userid, whitelister] = line.split('\t');
+			this.namefilterwhitelist.set(userid, whitelister);
+		}
+	}
+
+	appendWhitelistedName(name: string, whitelister: string) {
+		return FS(WHITELISTED_NAMES_FILE).append(`${toID(name)}\t${toID(whitelister)}\r\n`);
+	}
+
+	saveNameWhitelist() {
+		let buf = `Userid\tWhitelister\t\r\n`;
+		Punishments.namefilterwhitelist.forEach((userid, whitelister) => {
+			buf += `${userid}\t${whitelister}\r\n`;
+		});
+		return FS(WHITELISTED_NAMES_FILE).write(buf);
 	}
 
 	/*********************************************************
@@ -1014,6 +1043,23 @@ export const Punishments = new class {
 	removeBlacklistedSharedIp(ip: string) {
 		Punishments.sharedIpBlacklist.delete(ip);
 		void Punishments.saveSharedIpBlacklist();
+	}
+
+	whitelistName(name: string, whitelister: string) {
+		if (this.namefilterwhitelist.has(name)) return false;
+		name = toID(name);
+		whitelister = toID(whitelister);
+		this.namefilterwhitelist.set(name, whitelister);
+		void this.appendWhitelistedName(name, whitelister);
+		return true;
+	}
+
+	unwhitelistName(name: string) {
+		name = toID(name);
+		if (!this.namefilterwhitelist.has(name)) return false;
+		this.namefilterwhitelist.delete(name);
+		void this.saveNameWhitelist();
+		return true;
 	}
 
 	/*********************************************************


### PR DESCRIPTION
This is so they don't get cleared on hotpatch. 
Monkeypatch (NECESSARY, OR BAD THINGS CRASH) 
```ts
>> Punishments.namefilterwhitelist = Chat.namefilterwhitelist;
Punishments.saveNameWhitelist();
Monitor.forceRenames = Chat.forceRenames;
delete Chat.forceRenames;
delete Chat.namefilterwhitelist;
```