### PR TITLE
Battlesearch: Support searching for multiple users and searching months

### DIFF
--- a/server/chat-plugins/modlog-viewer.ts
+++ b/server/chat-plugins/modlog-viewer.ts
@@ -20,12 +20,20 @@ import {Dex} from '../../sim/dex';
 import {Config} from '../config-loader';
 import {checkRipgrepAvailability, ModlogID} from '../modlog';
 
-interface Results {
-	[k: string]: number;
+interface BattleOutcome {
+	lost: string;
+	won: string;
+	turns: string;
+}
+
+interface BattleSearchResults {
 	totalBattles: number;
-	totalWins: number;
-	totalLosses: number;
+	/** Total battle outcomes. Null when only searching for one userid.*/
+	totalOutcomes: BattleOutcome[] | null;
+	totalWins: {[k: string]: number};
+	totalLosses: {[k: string]: number};
 	totalTies: number;
+	timesBattled: {[k: string]: number};
 }
 
 const execFile = util.promisify(child_process.execFile);
@@ -217,15 +225,10 @@ async function getModlog(
  * Battle Search Functions
  *********************************************************/
 
-async function runBattleSearch(userid: ID, turnLimit: number, month: string, tierid: ID, date: string) {
+export async function runBattleSearch(userids: ID[], turnLimit: number, month: string, tierid: ID) {
 	const useRipgrep = await checkRipgrepAvailability();
-	const pathString = `logs/${month}/${tierid}/${date}`;
-	const results: Results = {
-		totalBattles: 0,
-		totalWins: 0,
-		totalLosses: 0,
-		totalTies: 0,
-	};
+	const pathString = `logs/${month}/${tierid}/`;
+	const results: {[k: string]: BattleSearchResults} = {};
 	let files = [];
 	try {
 		files = await FS(pathString).readdir();
@@ -235,77 +238,207 @@ async function runBattleSearch(userid: ID, turnLimit: number, month: string, tie
 		}
 		throw err;
 	}
+	const [userid] = userids;
+	files = files.filter(item => item.slice(0, -3) === month).map(item => `logs/${month}/${tierid}/${item}`);
+
 	if (useRipgrep) {
 		// Matches non-word (including _ which counts as a word) characters between letters/numbers
 		// in a user's name so the userid can case-insensitively be matched to the name.
-		const regexString = `("p1":"${[...userid].join('[^a-zA-Z0-9]*')}[^a-zA-Z0-9]*"|"p2":"${[...userid].join('[^a-zA-Z0-9]*')}[^a-zA-Z0-9]*")`;
+		const regexString = userids.map(id => `(.*("p(1|2)":"${[...id].join('[^a-zA-Z0-9]*')}[^a-zA-Z0-9]*"))`).join('');
 		let output;
 		try {
-			output = await execFile('rg', ['-i', regexString, '--no-filename', '--no-line-number', '-tjson', pathString]);
+			output = await execFile('rg', ['-i', regexString, '--no-line-number', '-tjson', ...files]);
 		} catch (error) {
 			return results;
 		}
-		for (const file of output.stdout.split('\n').reverse()) {
-			if (!file) continue;
-			const data = JSON.parse(file);
-			if (data.turns > turnLimit) continue;
-			results.totalBattles++;
-			if (toID(data.winner) === userid) {
-				results.totalWins++;
-			} else if (data.winner) {
-				results.totalLosses++;
-			} else {
-				results.totalTies++;
+		for (const line of output.stdout.split('\n').reverse()) {
+			const [file, raw] = Utils.splitFirst(line, ':');
+			if (!raw || !line) continue;
+			const data = JSON.parse(raw);
+			const day = file.split('/')[3];
+			if (!results[day]) {
+				results[day] = {
+					totalBattles: 0,
+					totalWins: {},
+					totalOutcomes: userids.length > 1 ? [] : null,
+					totalLosses: {},
+					totalTies: 0,
+					timesBattled: {},
+				};
 			}
-			const foe = toID(data.p1) === userid ? toID(data.p2) : toID(data.p1);
-			if (!results[foe]) results[foe] = 0;
-			results[foe]++;
+			const p1id = toID(data.p1);
+			const p2id = toID(data.p2);
+
+			if (userids.length > 1) {
+				// looking for specific userids, only register ones where those users are players
+				if (userids.filter(item => [p1id, p2id].includes(item)).length < userids.length) continue;
+			} else {
+				if (!(p1id === userid || p2id === userid)) continue;
+			}
+
+			if (data.turns > turnLimit) continue;
+			if (!results[day]) {
+				results[day] = {
+					totalBattles: 0,
+					totalWins: {},
+					totalOutcomes: userids.length > 1 ? [] : null,
+					totalLosses: {},
+					totalTies: 0,
+					timesBattled: {},
+				};
+			}
+			results[day].totalBattles++;
+			const winnerid = toID(data.winner);
+			const loser = winnerid === p1id ? p2id : p1id;
+			if (userids.includes(winnerid)) {
+				if (!results[day].totalWins[winnerid]) results[day].totalWins[winnerid] = 0;
+				results[day].totalWins[winnerid]++;
+			} else if (data.winner) {
+				if (!results[day].totalLosses[loser]) results[day].totalLosses[loser] = 0;
+				results[day].totalLosses[loser]++;
+			} else {
+				results[day].totalTies++;
+			}
+			// explicitly state 0 of stats if none
+			for (const id of userids) {
+				if (!results[day].totalLosses[id]) results[day].totalLosses[id] = 0;
+				if (!results[day].totalWins[id]) results[day].totalWins[id] = 0;
+			}
+
+			const outcomes = results[day].totalOutcomes;
+			if (outcomes) {
+				outcomes.push({won: winnerid, lost: loser, turns: data.turns});
+			}
+			// we only want foe data for single-userid searches
+			const foe = userids.length > 1 ? null : userid === toID(data.p1) ? toID(data.p2) : toID(data.p1);
+			if (foe) {
+				if (!results[day].timesBattled[foe]) results[day].timesBattled[foe] = 0;
+				results[day].timesBattled[foe]++;
+			}
 		}
 		return results;
 	}
 	for (const file of files) {
-		const json = await FS(`${pathString}/${file}`).readIfExists();
-		const data = JSON.parse(json);
-		if (toID(data.p1) !== userid && toID(data.p2) !== userid) continue;
-		if (data.turns > turnLimit) continue;
-		results.totalBattles++;
-		if (toID(data.winner) === userid) {
-			results.totalWins++;
-		} else if (data.winner) {
-			results.totalLosses++;
-		} else {
-			results.totalTies++;
+		const subFiles = FS(`${file}`).readdirSync();
+		const day = file.split('/')[3];
+		for (const dayFile of subFiles) {
+			const json = FS(`${file}/${dayFile}`).readIfExistsSync();
+			const data = JSON.parse(json);
+			const p1id = toID(data.p1);
+			const p2id = toID(data.p2);
+			if (userids.length > 1) {
+				// looking for specific userids, only register ones where those users are players
+				if (userids.filter(item => item === p1id || item === p2id).length < userids.length) continue;
+			} else {
+				if (!(p1id === userid || p2id === userid)) continue;
+			}
+			if (data.turns > turnLimit) continue;
+			if (!results[day]) {
+				results[day] = {
+					totalBattles: 0,
+					totalWins: {},
+					totalOutcomes: [],
+					totalLosses: {},
+					totalTies: 0,
+					timesBattled: {},
+				};
+			}
+			results[day].totalBattles++;
+			const winnerid = toID(data.winner);
+			const loser = winnerid === p1id ? p2id : p1id;
+			if (userids.includes(winnerid)) {
+				if (!results[day].totalWins[winnerid]) results[day].totalWins[winnerid] = 0;
+				results[day].totalWins[winnerid]++;
+			} else if (data.winner) {
+				if (!results[day].totalLosses[loser]) results[day].totalLosses[loser] = 0;
+				results[day].totalLosses[loser]++;
+			} else {
+				results[day].totalTies++;
+			}
+			// explicitly state 0 of stats if none
+			for (const id of userids) {
+				if (!results[day].totalLosses[id]) results[day].totalLosses[id] = 0;
+				if (!results[day].totalWins[id]) results[day].totalWins[id] = 0;
+			}
+
+			const outcomes = results[day].totalOutcomes;
+			if (outcomes) {
+				outcomes.push({won: winnerid, lost: loser, turns: data.turns});
+			}
+
+			// we don't want foe data if we're searching for 2 userids
+			const foe = userids.length > 1 ? null : userid === p1id ? p2id : p1id;
+			if (foe) {
+				if (!results[day].timesBattled[foe]) results[day].timesBattled[foe] = 0;
+				results[day].timesBattled[foe]++;
+			}
 		}
-		const foe = toID(data.p1) === userid ? toID(data.p2) : toID(data.p1);
-		if (!results[foe]) results[foe] = 0;
-		results[foe]++;
 	}
 	return results;
 }
 
-function buildResults(data: Results, userid: ID, turnLimit: number, month: string, tierid: ID, date: string) {
-	let buf = `>view-battlesearch-${userid}-${turnLimit}-${month}-${tierid}-${date}-confirm\n|init|html\n|title|[Battle Search][${userid}][${tierid}][${date}]\n`;
-	buf += `|pagehtml|<div class="pad ladder"><p>${tierid} battles on ${date} where ${userid} was a player and the battle lasted less than ${turnLimit} turn${Chat.plural(turnLimit)}:</p>`;
-	buf += `<table style="margin-left: auto; margin-right: auto"><tbody><tr><th colspan="2"><h2 style="margin: 5px auto">${userid}'s ${tierid} Battles</h1></th></tr><tr><th>Category</th><th>Number</th></tr>`;
-	buf += `<tr><td>Total Battles</td><td>${data.totalBattles}</td></tr><tr><td>Total Wins</td><td>${data.totalWins}</td></tr><tr><td>Total Losses</td><td>${data.totalLosses}</td></tr><tr><td>Total Ties</td><td>${data.totalTies}</td></tr>`;
-	buf += `<tr><th>Opponent</th><th>Times Battled</th></tr>`;
-	for (const foe in data) {
-		if (['totalBattles', 'totalWins', 'totalLosses', 'totalTies'].includes(foe)) continue;
-		buf += `<tr><td>${foe}</td><td>${data[foe]}</td></tr>`;
+function buildResults(
+	data: {[k: string]: BattleSearchResults}, userids: ID[],
+	turnLimit: number, month: string, tierid: ID
+) {
+	let buf = `>view-battlesearch-${userids.join('-')}--${turnLimit}--${month}--${tierid}--confirm\n|init|html\n|title|[Battle Search][${userids.join('-')}][${tierid}][${month}]\n`;
+	buf += `|pagehtml|<div class="pad ladder"><p>`;
+	buf += `${tierid} battles on ${month} where the user(s) ${userids.join(', ')} were players and the battle lasted less than ${turnLimit} turn${Chat.plural(turnLimit)}:</p>`;
+	buf += `<li style="display: inline; list-style: none"><a href="/view-battlesearch-${userids.join('-')}--${turnLimit}--${month}--${tierid}" target="replace">`;
+	buf += `<button class="button">Back</button></a></li><br />`;
+	if (userids.length > 1) {
+		const outcomes: BattleOutcome[] = [];
+		for (const day in data) {
+			const curOutcomes = data[day].totalOutcomes;
+			if (curOutcomes) outcomes.push(...curOutcomes);
+		}
+		buf += `<table><tbody><tr><h3 style="margin: 5px auto">Full summary</h3></tr>`;
+		buf += `<tr><th>Won</th><th>Lost</th><th>Turns</th></tr>`;
+		for (const battle of outcomes) {
+			const {won, lost, turns} = battle;
+			buf += `<tr><td>${won}</td><td>${lost}</td><td>${turns}</td></tr>`;
+		}
+	}
+	buf += `</tbody></table><br />`;
+	for (const day in data) {
+		const dayStats = data[day];
+		buf += `<p style="text-align:left">`;
+		const {totalWins, totalLosses} = dayStats;
+		buf += `<table style=""><tbody><tr><th colspan="2"><h3 style="margin: 5px auto">${day}</h3>`;
+		buf += `</th></tr><tr><th>Category</th><th>Number</th></tr>`;
+		buf += `<tr><td>Total Battles</td><td>${dayStats.totalBattles}</td></tr>`;
+		for (const id in totalWins) {
+			// hide userids if we're only searching for 1
+			buf += `<tr><td>Total Wins${userids.length > 1 ? ` (${id}) ` : ''}</td><td>${totalWins[id]}</td></tr>`;
+		}
+		for (const id in totalLosses) {
+			buf += `<tr><td>Total Losses${userids.length > 1 ? ` (${id}) ` : ''}</td><td>${totalLosses[id]}</td></tr>`;
+		}
+		if (userids.length < 2) {
+			buf += `<tr><th>Opponent</th><th>Times Battled</th></tr>`;
+			const [userid] = userids;
+			for (const foe in dayStats.timesBattled) {
+				buf += `<tr><td>`;
+				buf += `<a href="/view-battlesearch-${userid}-${foe}--${turnLimit}--${month}--${tierid}" target="replace">${foe}</a>`;
+				buf += `</td><td>${dayStats.timesBattled[foe]}</td></tr>`;
+			}
+		}
+		buf += `</p><br />`;
 	}
 	buf += `</tbody></table></div>`;
 	return buf;
 }
 
 async function getBattleSearch(
-	connection: Connection, userid: ID, turnLimit = 1,
-	month: string, tierid: ID, date: string
+	connection: Connection, userids: string[], turnLimit = 1,
+	month: string, tierid: ID
 ) {
+	userids = userids.map(toID);
 	const user = connection.user;
 	if (!user.can('forcewin')) return connection.popup(`/battlesearch - Access Denied`);
 
-	const response = await PM.query({userid, turnLimit, month, tierid, date});
-	connection.send(buildResults(response, userid, turnLimit, month, tierid, date));
+	const response = await PM.query({userids, turnLimit, month, tierid});
+	connection.send(buildResults(response, userids as ID[], turnLimit, month, tierid));
 }
 
 export const pages: PageTable = {
@@ -319,13 +452,14 @@ export const pages: PageTable = {
 	async battlesearch(args, user, connection) {
 		if (!user.named) return Rooms.RETRY_AFTER_LOGIN;
 		this.checkCan('forcewin');
-		const userid = toID(args.shift());
-		const turnLimit = parseInt(args.shift()!);
-		if (!userid || !turnLimit || turnLimit < 1) {
+		const [ids, rawLimit, month, formatid, confirmation] = Utils.splitFirst(this.pageid.slice(18), '--', 5);
+		const userids = ids.split('-');
+		const turnLimit = parseInt(rawLimit);
+		if (!ids || !turnLimit || turnLimit < 1) {
 			return user.popup(`Some arguments are missing or invalid for battlesearch. Use /battlesearch to start over.`);
 		}
-		this.title = `[Battle Search][${userid}]`;
-		let buf = `<div class="pad ladder"><h2>Battle Search</h2><p>Userid: ${userid}</p><p>Maximum Turns: ${turnLimit}</p>`;
+		this.title = `[Battle Search][${userids.join(', ')}]`;
+		let buf = `<div class="pad ladder"><h2>Battle Search</h2><p>Userid (s): ${userids.join(', ')}</p><p>Maximum Turns: ${turnLimit}</p>`;
 
 		const months = (await FS('logs/').readdir()).filter(f => f.length === 7 && f.includes('-')).sort((aKey, bKey) => {
 			const a = aKey.split('-').map(n => parseInt(n));
@@ -333,22 +467,20 @@ export const pages: PageTable = {
 			if (a[0] !== b[0]) return b[0] - a[0];
 			return b[1] - a[1];
 		});
-		let month = args.shift();
 		if (!month) {
 			buf += `<p>Please select a month:</p><ul style="list-style: none; display: block; padding: 0">`;
 			for (const i of months) {
-				buf += `<li style="display: inline; list-style: none"><a href="/view-battlesearch-${userid}-${turnLimit}-${i}" target="replace"><button class="button">${i}</button></li>`;
+				buf += `<li style="display: inline; list-style: none"><a href="/view-battlesearch-${userids.join('-')}--${turnLimit}--${i}" target="replace"><button class="button">${i}</button></li>`;
 			}
 			return `${buf}</ul></div>`;
 		} else {
-			month = month += `-${args.shift()}`;
 			if (!months.includes(month)) {
-				return `${buf}Invalid month selected. <a href="/view-battlesearch-${userid}-${turnLimit}" target="replace"><button class="button">Back to month selection</button></a></div>`;
+				return `${buf}Invalid month selected. <a href="/view-battlesearch-${userids.join('-')}--${turnLimit}" target="replace"><button class="button">Back to month selection</button></a></div>`;
 			}
-			buf += `<p><a href="/view-battlesearch-${userid}-${turnLimit}" target="replace"><button class="button">Back</button></a> <button class="button disabled">${month}</button></p>`;
+			buf += `<p><a href="/view-battlesearch-${userids.join('-')}--${turnLimit}" target="replace"><button class="button">Back</button></a> <button class="button disabled">${month}</button></p>`;
 		}
 
-		const tierid = toID(args.shift());
+		const tierid = toID(formatid);
 		const tiers = (await FS(`logs/${month}/`).readdir()).sort((a, b) => {
 			// First sort by gen with the latest being first
 			let aGen = 6;
@@ -375,50 +507,28 @@ export const pages: PageTable = {
 		if (!tierid) {
 			buf += `<p>Please select the tier to search:</p><ul style="list-style: none; display: block; padding: 0">`;
 			for (const tier of tiers) {
-				buf += `<li style="display: inline; list-style: none"><a href="/view-battlesearch-${userid}-${turnLimit}-${month}-${toID(tier)}" target="replace"><button class="button">${tier}</button></a></li>`;
+				buf += `<li style="display: inline; list-style: none">`;
+				buf += `<a href="/view-battlesearch-${userids.join('-')}--${turnLimit}--${month}--${toID(tier)}" target="replace">`;
+				buf += `<button class="button">${tier}</button></a></li><br />`;
 			}
 			return `${buf}</ul></div>`;
 		} else {
-			const tierids = tiers.map(toID);
-			if (!tierids.includes(tierid)) {
-				return `${buf}Invalid tier selected. <a href="/view-battlesearch-${userid}-${turnLimit}-${month}" target="replace"><button class="button">Back to tier selection</button></a></div>`;
+			if (!tiers.map(toID).includes(tierid)) {
+				return `${buf}Invalid tier selected. <a href="/view-battlesearch-${userids.join('-')}--${turnLimit}--${month}" target="replace"><button class="button">Back to tier selection</button></a></div>`;
 			}
 			this.title += `[${tierid}]`;
-			buf += `<p><a href="/view-battlesearch-${userid}-${turnLimit}-${month}" target="replace"><button class="button">Back</button></a> <button class="button disabled">${tierid}</button></p>`;
+			buf += `<p><a href="/view-battlesearch-${userids.join('-')}--${turnLimit}--${month}" target="replace"><button class="button">Back</button></a> <button class="button disabled">${tierid}</button></p>`;
 		}
 
-		let date = args.shift();
-		const days = (await FS(`logs/${month}/${tierid}/`).readdir()).sort((a, b) => {
-			const aNumArray = a.split('-').map(n => parseInt(n));
-			const bNumArray = b.split('-').map(n => parseInt(n));
-			if (aNumArray[0] !== bNumArray[0]) return bNumArray[0] - aNumArray[0];
-			if (aNumArray[1] !== bNumArray[1]) return bNumArray[1] - aNumArray[1];
-			return bNumArray[2] - aNumArray[2];
-		});
-		if (!date) {
-			buf += `<p>Please select the date to search:</p><ul style="list-style: none; display: block; padding: 0">`;
-			for (const day of days) {
-				buf += `<li style="display: inline; list-style: none"><a href="/view-battlesearch-${userid}-${turnLimit}-${month}-${tierid}-${day}" target="replace"><button class="button">${day}</button></a></li>`;
-			}
-			return `${buf}</ul></div>`;
-		} else {
-			date = date += `-${args.shift()}-${args.shift()}`;
-			if (!days.includes(date)) {
-				return `${buf}Invalid date selected. <a href="/view-battlesearch-${userid}-${turnLimit}-${month}-${tierid}" target="replace"><button class="button">Back to date selection</button></a></div>`;
-			}
-			this.title += `[${date}]`;
-			buf += `<p><a href="/view-battlesearch-${userid}-${turnLimit}-${month}-${tierid}" target="replace"><button class="button">Back</button></a> <button class="button disabled">${date}</button></p>`;
-		}
-
-		if (args[0] !== 'confirm') {
-			buf += `<p>Are you sure you want to run a battle search for for ${tierid} battles on ${date} where ${userid} was a player and the battle lasted less than ${turnLimit} turn${Chat.plural(turnLimit)}?</p>`;
-			buf += `<p><a href="/view-battlesearch-${userid}-${turnLimit}-${month}-${tierid}-${date}-confirm" target="replace"><button class="button notifying">Yes, run the battle search</button></a> <a href="/view-battlesearch-${userid}-${turnLimit}-${month}-${tierid}" target="replace"><button class="button">No, go back</button></a></p>`;
+		if (toID(confirmation) !== 'confirm') {
+			buf += `<p>Are you sure you want to run a battle search for for ${tierid} battles on ${month} where the user(s) ${userids.join(', ')} were players and the battle lasted less than ${turnLimit} turn${Chat.plural(turnLimit)}?</p>`;
+			buf += `<p><a href="/view-battlesearch-${userids.join('-')}--${turnLimit}--${month}--${tierid}--confirm" target="replace"><button class="button notifying">Yes, run the battle search</button></a> <a href="/view-battlesearch-${userids.join('-')}--${turnLimit}--${month}--${tierid}" target="replace"><button class="button">No, go back</button></a></p>`;
 			return `${buf}</div>`;
 		}
 
 		// Run search
-		void getBattleSearch(connection, userid, turnLimit, month, tierid, date);
-		return `<div class="pad ladder"><h2>Battle Search</h2><p>Searching for ${tierid} battles on ${date} where ${userid} was a player and the battle lasted less than ${turnLimit} turn${Chat.plural(turnLimit)}.</p><p>Loading... (this will take a while)</p></div>`;
+		void getBattleSearch(connection, userids, turnLimit, month, tierid);
+		return `<div class="pad ladder"><h2>Battle Search</h2><p>Searching for ${tierid} battles on ${month} where the user(s) ${userids.join(', ')} were players player and the battle lasted less than ${turnLimit} turn${Chat.plural(turnLimit)}.</p><p>Loading... (this will take a while)</p></div>`;
 	},
 };
 
@@ -487,9 +597,9 @@ export const commands: ChatCommands = {
 		if (!target.trim()) return this.parse('/help battlesearch');
 		this.checkCan('forcewin');
 
-		const userid = toID(target.split(',')[0]);
-		let turnLimit = parseInt(target.split(',')[1]);
-		if (!userid) return this.parse('/help battlesearch');
+		const [num, ids] = Utils.splitFirst(target, ',');
+		let turnLimit = parseInt(num);
+		if (!ids) return this.parse('/help battlesearch');
 		if (!turnLimit) {
 			turnLimit = 1;
 		} else {
@@ -498,10 +608,10 @@ export const commands: ChatCommands = {
 			}
 		}
 		// Selection on month, tier, and date will be handled in the HTML room
-		return this.parse(`/join view-battlesearch-${userid}-${turnLimit}`);
+		return this.parse(`/join view-battlesearch-${ids.split(',').join('-')}--${turnLimit}`);
 	},
 	battlesearchhelp: [
-		'/battlesearch [user], (turn limit) - Searches a users rated battle history and returns information on battles that ended in less than (turn limit or 1) turns. Requires &',
+		'/battlesearch [turn limit], [userids] - Searches rated battle history for the provided [userids] and returns information on battles that ended in less than [turn limit] turns. Requires &',
 	],
 };
 
@@ -510,16 +620,15 @@ export const commands: ChatCommands = {
  *********************************************************/
 
 export const PM = new QueryProcessManager<AnyObject, AnyObject>(module, async data => {
-	const {userid, turnLimit, month, tierid, date} = data;
+	const {userids, turnLimit, month, tierid} = data;
 	try {
-		return await runBattleSearch(userid, turnLimit, month, tierid, date);
+		return await runBattleSearch(userids, turnLimit, month, tierid);
 	} catch (err) {
 		Monitor.crashlog(err, 'A battle search query', {
-			userid,
+			userids,
 			turnLimit,
 			month,
 			tierid,
-			date,
 		});
 	}
 	return null;


### PR DESCRIPTION
Various improvements requested by Dawoblefet. 
It now searches by month, not day, has a back button, supports searching for 2 users, and the formats list is reformatted.
Screenshots: multisearch (https://prnt.sc/uj8ih4), singlesearch (https://prnt.sc/uj8ioq)