### PR TITLE
Remove Idle status on login

### DIFF
--- a/server/users.ts
+++ b/server/users.ts
@@ -926,9 +926,8 @@ export class User extends Chat.MessageContext {
 		// active enough that the user should no longer be in the 'idle' state.
 		// Doing this before merging connections ensures the updateuser message
 		// shows the correct idle state.
-		if (this.statusType === 'busy' || oldUser.statusType === 'busy') {
-			this.setStatusType('busy');
-		}
+		const isBusy = this.statusType === 'busy' || oldUser.statusType === 'busy';
+		this.setStatusType(isBusy ? 'busy' : 'online');
 
 		for (const connection of oldUser.connections) {
 			this.mergeConnection(connection);


### PR DESCRIPTION
Currently, users are getting their status set to Idle when they log back in after a time of being logged out. According to the comment in `users.ts`, we consider logging in enough activity to remove Idle status, but this was not borne out in the code.