### PR TITLE
Replace @ts-ignore with type assertions or other less unsafe constructs

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -3679,8 +3679,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			this.add('-activate', target, 'ability: Synchronize');
 			// Hack to make status-prevention abilities think Synchronize is a status move
 			// and show messages when activating against it.
-			// @ts-ignore
-			source.trySetStatus(status, target, {status: status.id, id: 'synchronize'});
+			source.trySetStatus(status, target, {status: status.id, id: 'synchronize'} as Effect);
 		},
 		name: "Synchronize",
 		rating: 2,

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -364,10 +364,9 @@ export const Conditions: {[k: string]: ConditionData} = {
 			if (data.source.hasAbility('adaptability') && this.gen >= 6) {
 				data.moveData.stab = 2;
 			}
-			// @ts-ignore
-			const hitMove: ActiveMove = new this.dex.Data.Move(data.moveData);
+			const hitMove: Move = new this.dex.Data.Move(data.moveData);
 
-			this.trySpreadMoveHit([target], data.source, hitMove);
+			this.trySpreadMoveHit([target], data.source, hitMove as ActiveMove);
 		},
 	},
 	healreplacement: {
@@ -404,8 +403,7 @@ export const Conditions: {[k: string]: ConditionData} = {
 			return success;
 		},
 		onRestart() {
-			// @ts-ignore
-			if (this.effectData.counter < this.effect.counterMax) {
+			if (this.effectData.counter < (this.effect as Condition).counterMax!) {
 				this.effectData.counter *= 3;
 			}
 			this.effectData.duration = 2;

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -364,9 +364,9 @@ export const Conditions: {[k: string]: ConditionData} = {
 			if (data.source.hasAbility('adaptability') && this.gen >= 6) {
 				data.moveData.stab = 2;
 			}
-			const hitMove: Move = new this.dex.Data.Move(data.moveData);
+			const hitMove = new this.dex.Data.Move(data.moveData) as Move as ActiveMove;
 
-			this.trySpreadMoveHit([target], data.source, hitMove as ActiveMove);
+			this.trySpreadMoveHit([target], data.source, hitMove);
 		},
 	},
 	healreplacement: {

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -254,8 +254,7 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 			return this.randomChance(1, counter);
 		},
 		onRestart() {
-			// @ts-ignore
-			if (this.effectData.counter < this.effect.counterMax) {
+			if (this.effectData.counter < (this.effect as Condition).counterMax!) {
 				this.effectData.counter *= 2;
 			}
 			this.effectData.duration = 2;

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -531,10 +531,8 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 			if (moveData.forceStatus) {
 				if (target.setStatus(moveData.forceStatus, pokemon, move)) {
-					// @ts-ignore
-					if (moveData.forceStatus === 'brn') target.modifyStat('atk', 0.5);
-					// @ts-ignore
-					if (moveData.forceStatus === 'par') target.modifyStat('spe', 0.25);
+					if (moveData.forceStatus === 'brn') target.modifyStat!('atk', 0.5);
+					if (moveData.forceStatus === 'par') target.modifyStat!('spe', 0.25);
 					didSomething = true;
 				}
 			}
@@ -617,8 +615,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				let msg = '-boost';
 				if (boost[i]! < 0) {
 					msg = '-unboost';
-					// @ts-ignore
-					boost[i] = -boost[i];
+					boost[i] = -boost[i]!;
 					// Re-add attack and speed drops if not present
 					if (i === 'atk' && target.status === 'brn' && !target.volatiles['brnattackdrop']) {
 						target.addVolatile('brnattackdrop');
@@ -636,10 +633,8 @@ export const Scripts: ModdedBattleScriptsData = {
 					}
 				}
 				if (!effect || effect.effectType === 'Move') {
-					// @ts-ignore
 					this.add(msg, target, i, boost[i]);
 				} else {
-					// @ts-ignore
 					this.add(msg, target, i, boost[i], '[from] ' + effect.fullname);
 				}
 				this.runEvent('AfterEachBoost', target, source, effect, currentBoost);

--- a/data/mods/gen5/conditions.ts
+++ b/data/mods/gen5/conditions.ts
@@ -39,8 +39,7 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 			return this.randomChance(1, counter);
 		},
 		onRestart() {
-			// @ts-ignore
-			if (this.effectData.counter < this.effect.counterMax) {
+			if (this.effectData.counter < (this.effect as Condition).counterMax!) {
 				this.effectData.counter *= 2;
 			}
 			this.effectData.duration = 2;

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -180,7 +180,6 @@ export class RandomGen6Teams extends RandomGen7Teams {
 				case 'circlethrow': case 'dragontail':
 					if (counter.setupType && ((!hasMove['rest'] && !hasMove['sleeptalk']) || hasMove['stormthrow'])) rejected = true;
 					if (!!counter['speedsetup'] || hasMove['encore'] || hasMove['raindance'] || hasMove['roar'] || hasMove['trickroom'] || hasMove['whirlwind']) rejected = true;
-					// @ts-ignore
 					if ((counter[move.type] > 1 && counter.Status > 1) || (hasAbility['Sheer Force'] && !!counter['sheerforce'])) rejected = true;
 					break;
 				case 'defog':
@@ -463,7 +462,6 @@ export class RandomGen6Teams extends RandomGen7Teams {
 				// This move doesn't satisfy our setup requirements:
 				if ((move.category === 'Physical' && counter.setupType === 'Special') || (move.category === 'Special' && counter.setupType === 'Physical')) {
 					// Reject STABs last in case the setup type changes later on
-					// @ts-ignore
 					const stabs = counter[species.types[0]] + (counter[species.types[1]] || 0);
 					if (!SetupException.includes(moveid) && (!hasType[move.type] || stabs > 1 || counter[move.category] < 2)) rejected = true;
 				}
@@ -508,7 +506,6 @@ export class RandomGen6Teams extends RandomGen7Teams {
 					(hasType['Rock'] && !counter['Rock'] && !hasType['Fairy'] && (hasAbility['Rock Head'] || counter.setupType === 'Physical')) ||
 					(hasType['Steel'] && !counter['Steel'] && hasAbility['Technician']) ||
 					(hasType['Water'] && (!counter['Water'] || !counter.stab) && !hasAbility['Protean']) ||
-					// @ts-ignore
 					((hasAbility['Adaptability'] && !counter.setupType && species.types.length > 1 && (!counter[species.types[0]] || !counter[species.types[1]])) ||
 					((hasAbility['Aerilate'] || hasAbility['Pixilate'] || hasAbility['Refrigerate'] && !hasMove['blizzard']) && !counter['Normal']) ||
 					(hasAbility['Bad Dreams'] && movePool.includes('darkvoid')) ||
@@ -552,9 +549,9 @@ export class RandomGen6Teams extends RandomGen7Teams {
 				// Handle Hidden Power IVs
 				if (moveid === 'hiddenpower') {
 					const HPivs = this.dex.getType(move.type).HPivs;
-					for (const iv in HPivs) {
-						// @ts-ignore
-						ivs[iv] = HPivs[iv];
+					let iv: StatName;
+					for (iv in HPivs) {
+						ivs[iv] = HPivs[iv]!;
 					}
 				}
 			}
@@ -595,7 +592,6 @@ export class RandomGen6Teams extends RandomGen7Teams {
 				rejectAbility = false;
 				if (counterAbilities.includes(ability)) {
 					// Adaptability, Contrary, Iron Fist, Skill Link, Strong Jaw
-					// @ts-ignore
 					rejectAbility = !counter[toID(ability)];
 				} else if (ateAbilities.includes(ability)) {
 					rejectAbility = !counter['Normal'];
@@ -688,7 +684,6 @@ export class RandomGen6Teams extends RandomGen7Teams {
 						ability = ability2.name;
 					} else {
 						// Default to the highest rated ability if all are rejected
-						// @ts-ignore
 						ability = abilities[0];
 						rejectAbility = false;
 					}

--- a/data/mods/gennext/abilities.ts
+++ b/data/mods/gennext/abilities.ts
@@ -291,10 +291,9 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	clearbody: {
 		inherit: true,
 		onBoost(boost, target, source) {
-			for (const i in boost) {
-				// @ts-ignore
-				if (boost[i] < 0) {
-					// @ts-ignore
+			let i: BoostName;
+			for (i in boost) {
+				if (boost[i]! < 0) {
 					delete boost[i];
 					this.add("-message", target.name + "'s stats were not lowered! (placeholder)");
 				}
@@ -305,10 +304,9 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	whitesmoke: {
 		inherit: true,
 		onBoost(boost, target, source) {
-			for (const i in boost) {
-				// @ts-ignore
-				if (boost[i] < 0) {
-					// @ts-ignore
+			let i: BoostName;
+			for (i in boost) {
+				if (boost[i]! < 0) {
 					delete boost[i];
 					this.add("-message", target.name + "'s stats were not lowered! (placeholder)");
 				}

--- a/data/mods/gennext/moves.ts
+++ b/data/mods/gennext/moves.ts
@@ -2015,8 +2015,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			if (user.illusion) {
 				const illusionMoves = user.illusion.moves.filter(m => this.dex.getMove(m).category !== 'Status');
 				if (!illusionMoves.length) return;
-				// @ts-ignore I'll figure out a better fix for this later
-				move.name = this.dex.getMove(this.sample(illusionMoves)).name;
+				// I'll figure out a better fix for this later
+				(move as any).name = this.dex.getMove(this.sample(illusionMoves)).name;
 			}
 		},
 		desc: "Has a 40% chance to lower the target's accuracy by 1 stage. If Illusion is active, displays as a random non-Status move in the copied Pokémon's moveset.",

--- a/data/mods/stadium/scripts.ts
+++ b/data/mods/stadium/scripts.ts
@@ -55,8 +55,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				}
 				if (delta) changed = true;
 			}
-			// @ts-ignore
-			this.recalculateStats();
+			this.recalculateStats!();
 			return changed;
 		},
 	},
@@ -335,8 +334,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			if (moveData.status) {
 				if (!target.status) {
 					target.setStatus(moveData.status, pokemon, move);
-					// @ts-ignore
-					target.recalculateStats();
+					target.recalculateStats!();
 				} else if (!isSecondary) {
 					if (target.status === moveData.status) {
 						this.add('-fail', target, target.status);
@@ -348,8 +346,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 			if (moveData.forceStatus) {
 				if (target.setStatus(moveData.forceStatus, pokemon, move)) {
-					// @ts-ignore
-					target.recalculateStats();
+					target.recalculateStats!();
 					didSomething = true;
 				}
 			}

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -4783,18 +4783,14 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1, nonsky: 1},
 		onPrepareHit(target, source, move) {
-			for (const action of this.queue) {
+			for (const action of this.queue.list as MoveAction[]) {
 				if (
-					// @ts-ignore
 					!action.move || !action.pokemon || !action.pokemon.isActive ||
-					// @ts-ignore
 					action.pokemon.fainted || action.maxMove || action.zmove
 				) {
 					continue;
 				}
-				// @ts-ignore
 				if (action.pokemon.side === source.side && ['grasspledge', 'waterpledge'].includes(action.move.id)) {
-					// @ts-ignore
 					this.queue.prioritizeAction(action, move);
 					this.add('-waiting', source, action.pokemon);
 					return null;
@@ -6945,18 +6941,14 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1, nonsky: 1},
 		onPrepareHit(target, source, move) {
-			for (const action of this.queue) {
+			for (const action of this.queue.list as MoveAction[]) {
 				if (
-					// @ts-ignore
 					!action.move || !action.pokemon || !action.pokemon.isActive ||
-					// @ts-ignore
 					action.pokemon.fainted || action.maxMove || action.zmove
 				) {
 					continue;
 				}
-				// @ts-ignore
 				if (action.pokemon.side === source.side && ['waterpledge', 'firepledge'].includes(action.move.id)) {
-					// @ts-ignore
 					this.queue.prioritizeAction(action, move);
 					this.add('-waiting', source, action.pokemon);
 					return null;
@@ -14336,12 +14328,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1, sound: 1, authentic: 1},
 		onTry(target, source, move) {
-			for (const action of this.queue) {
-				// @ts-ignore
+			for (const action of this.queue.list as MoveAction[]) {
 				if (!action.pokemon || !action.move || action.maxMove || action.zmove) continue;
-				// @ts-ignore
-				if (action.move?.id === 'round') {
-					// @ts-ignore
+				if (action.move.id === 'round') {
 					this.queue.prioritizeAction(action, move);
 					return;
 				}

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -325,8 +325,7 @@ export const Formats: {[k: string]: FormatData} = {
 			}
 		},
 		onStart() {
-			// @ts-ignore
-			if (this.format.gameType === 'singles') this.format.teamLength = {battle: 1};
+			if (this.format.gameType === 'singles') (this.format as any).teamLength = {battle: 1};
 		},
 	},
 	twovstwo: {
@@ -339,8 +338,7 @@ export const Formats: {[k: string]: FormatData} = {
 			}
 		},
 		onStart() {
-			// @ts-ignore
-			if (this.format.gameType !== 'triples') this.format.teamLength = {battle: 2};
+			if (this.format.gameType !== 'triples') (this.format as any).teamLength = {battle: 2};
 		},
 	},
 	littlecup: {

--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -121,9 +121,7 @@ export const Scripts: BattleScriptsData = {
 				if (this.faintMessages()) break;
 				if (dancer.fainted) continue;
 				this.add('-activate', dancer, 'ability: Dancer');
-				// @ts-ignore - the Dancer ability can't trigger on a move where target is null because it does not copy failed moves.
-				const dancersTarget = target.side !== dancer.side && pokemon.side === dancer.side ? target : pokemon;
-				// @ts-ignore
+				const dancersTarget = target!.side !== dancer.side && pokemon.side === dancer.side ? target! : pokemon;
 				this.runMove(move.id, dancer, this.getTargetLoc(dancersTarget, dancer), this.dex.getAbility('dancer'), undefined, true);
 			}
 		}
@@ -358,10 +356,8 @@ export const Scripts: BattleScriptsData = {
 
 		let atLeastOneFailure!: boolean;
 		for (const step of moveSteps) {
-			// @ts-ignore
 			const hitResults: (number | boolean | "" | undefined)[] | undefined = step.call(this, targets, pokemon, move);
 			if (!hitResults) continue;
-			// @ts-ignore
 			targets = targets.filter((val, i) => hitResults[i] || hitResults[i] === 0);
 			atLeastOneFailure = atLeastOneFailure || hitResults.some(val => val === false);
 			if (!targets.length) {
@@ -694,8 +690,7 @@ export const Scripts: BattleScriptsData = {
 				// purposes of Counter, Metal Burst, and Mirror Coat.
 				damage[i] = md === true || !md ? 0 : md;
 				// Total damage dealt is accumulated for the purposes of recoil (Parental Bond).
-				// @ts-ignore
-				move.totalDamage += damage[i];
+				move.totalDamage += damage[i] as number;
 			}
 			if (move.mindBlownRecoil) {
 				this.damage(Math.round(pokemon.maxhp / 2), pokemon, pokemon, this.dex.getEffect('Mind Blown'), true);
@@ -904,8 +899,7 @@ export const Scripts: BattleScriptsData = {
 				this.faint(pokemon, pokemon, move);
 			}
 			if ((damage[i] || damage[i] === 0) && !target.fainted) {
-				// @ts-ignore
-				if (move.noFaint && damage[i] >= target.hp) {
+				if (move.noFaint && damage[i]! >= target.hp) {
 					damage[i] = target.hp - 1;
 				}
 			}
@@ -1085,8 +1079,7 @@ export const Scripts: BattleScriptsData = {
 	},
 
 	calcRecoilDamage(damageDealt, move) {
-		// @ts-ignore
-		return this.clampIntRange(Math.round(damageDealt * move.recoil[0] / move.recoil[1]), 1);
+		return this.clampIntRange(Math.round(damageDealt * move.recoil![0] / move.recoil![1]), 1);
 	},
 
 	zMoveTable: {
@@ -1138,8 +1131,7 @@ export const Scripts: BattleScriptsData = {
 		if (pokemon) {
 			const item = pokemon.getItem();
 			if (move.name === item.zMoveFrom) {
-				// @ts-ignore
-				const zMove = this.dex.getActiveMove(item.zMove);
+				const zMove = this.dex.getActiveMove(item.zMove as string);
 				zMove.isZOrMaxPowered = true;
 				return zMove;
 			}

--- a/sim/battle-queue.ts
+++ b/sim/battle-queue.ts
@@ -101,6 +101,8 @@ export interface PokemonAction {
 	pokemon: Pokemon;
 	/** `runSwitch` only: the pokemon forcing this pokemon to switch in */
 	dragger?: Pokemon;
+	/** `event` only: the event to run */
+	event?: string;
 }
 
 export type Action = MoveAction | SwitchAction | TeamAction | FieldAction | PokemonAction;
@@ -353,9 +355,8 @@ export class BattleQueue {
 		this.list = [];
 	}
 
-	debug(action?: Action): string {
+	debug(action?: any): string {
 		if (action) {
-			// @ts-ignore
 			return `${action.order || ''}:${action.priority || ''}:${action.speed || ''}:${action.subOrder || ''} - ${action.choice}${action.pokemon ? ' ' + action.pokemon : ''}${action.move ? ' ' + action.move : ''}`;
 		}
 		return this.list.map(

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -783,8 +783,9 @@ export class Battle {
 		handler.priority = handler.effect[`${callbackName}Priority`] || 0;
 		// @ts-ignore
 		handler.subOrder = handler.effect[`${callbackName}SubOrder`] || 0;
-		// @ts-ignore
-		if (handler.effectHolder && handler.effectHolder.getStat) handler.speed = handler.effectHolder.speed;
+		if (handler.effectHolder && (handler.effectHolder as Pokemon).getStat) {
+			(handler as EventListener).speed = (handler.effectHolder as Pokemon).speed;
+		}
 		return handler as EventListener;
 	}
 
@@ -907,7 +908,6 @@ export class Battle {
 		const format = this.format;
 		// @ts-ignore - dynamic lookup
 		callback = format[callbackName];
-		// @ts-ignore - dynamic lookup
 		if (callback !== undefined || (getKey && this.formatData[getKey])) {
 			handlers.push(this.resolvePriority({
 				effect: format, callback, state: this.formatData, end: null, effectHolder: this,
@@ -1645,8 +1645,7 @@ export class Battle {
 	restart(send?: (type: string, data: string | string[]) => void) {
 		if (!this.deserialized) throw new Error('Attempt to restart a battle which has not been deserialized');
 
-		// @ts-ignore - readonly
-		this.send = send;
+		(this as any).send = send;
 	}
 
 	checkEVBalance() {
@@ -2548,8 +2547,7 @@ export class Battle {
 		}
 
 		case 'event':
-			// @ts-ignore - easier than defining a custom event attribute TBH
-			this.runEvent(action.event, action.pokemon);
+			this.runEvent(action.event!, action.pokemon);
 			break;
 		case 'team': {
 			action.pokemon.side.pokemon.splice(action.index, 0, action.pokemon);
@@ -3225,8 +3223,7 @@ export class Battle {
 
 		// deallocate children and get rid of references to them
 		this.field.destroy();
-		// @ts-ignore - readonly
-		this.field = null!;
+		(this as any).field = null!;
 
 		for (let i = 0; i < this.sides.length; i++) {
 			if (this.sides[i]) {
@@ -3241,8 +3238,7 @@ export class Battle {
 		this.queue.battle = null!;
 		this.queue = null!;
 		// in case the garbage collector really sucks, at least deallocate the log
-		// @ts-ignore - readonly
-		this.log = [];
+		(this as any).log = [];
 	}
 }
 

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -636,8 +636,7 @@ export class ModdedDex {
 		}
 		if (effect) {
 			this.effectCache.set(id, effect);
-			// @ts-ignore
-			return effect;
+			return effect as Condition;
 		}
 		return this.getEffectByID(id, effect);
 	}

--- a/sim/field.ts
+++ b/sim/field.ts
@@ -229,7 +229,6 @@ export class Field {
 		// deallocate ourself
 
 		// get rid of some possibly-circular references
-		// @ts-ignore - readonly
-		this.battle = null!;
+		(this as any).battle = null!;
 	}
 }

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -2,6 +2,7 @@ type Battle = import('./battle').Battle;
 type BattleQueue = import('./battle-queue').BattleQueue;
 type Field = import('./field').Field;
 type Action = import('./battle-queue').Action;
+type MoveAction = import('./battle-queue').MoveAction;
 type ActionChoice = import('./battle-queue').ActionChoice;
 type ModdedDex = import('./dex').ModdedDex;
 type Pokemon = import('./pokemon').Pokemon;

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -942,8 +942,7 @@ export class Side {
 		// get rid of some possibly-circular references
 		this.pokemon = [];
 		this.active = [];
-		// @ts-ignore - readonly
-		this.battle = null!;
 		this.foe = null!;
+		(this as any).battle = null!;
 	}
 }

--- a/sim/state.ts
+++ b/sim/state.ts
@@ -147,10 +147,8 @@ export const State = new class {
 		battle.prng = new PRNG(state.prng);
 		const queue = this.deserializeWithRefs(state.queue, battle);
 		battle.queue.list = queue;
-		// @ts-ignore - readonly
-		battle.hints = new Set(state.hints);
-		// @ts-ignore - readonly
-		battle.log = state.log;
+		(battle as any).hints = new Set(state.hints);
+		(battle as any).log = state.log;
 		return battle;
 	}
 
@@ -223,8 +221,7 @@ export const State = new class {
 
 	deserializePokemon(state: /* Pokemon */ AnyObject, pokemon: Pokemon) {
 		this.deserialize(state, pokemon, POKEMON, pokemon.battle);
-		// @ts-ignore - readonly
-		pokemon.set = state.set;
+		(pokemon as any).set = state.set;
 		// baseMoveSlots and moveSlots need to point to the same objects (ie. identity, not equality).
 		// If we serialized the baseMoveSlots, replace any that match moveSlots to preserve the
 		// identity relationship requirement.
@@ -240,8 +237,7 @@ export const State = new class {
 		} else {
 			baseMoveSlots = pokemon.moveSlots.slice();
 		}
-		// @ts-ignore - readonly
-		pokemon.baseMoveSlots = baseMoveSlots;
+		(pokemon as any).baseMoveSlots = baseMoveSlots;
 		if (state.showCure === undefined) pokemon.showCure = undefined;
 	}
 


### PR DESCRIPTION
... or just remove it if it's become unnecessary, of course.

I was also considering changing second parameter to `calcRecoilDamage` to be the recoil rather than the move. Currently most of the implementations assert that the recoil exists, since while the callers all know that the recoil is a tuple, that information is lost to the callee, and I have copied that style to the last place that was using a `@ts-ignore`. If instead the parameter was just the recoil tuple itself, no assertion would be necessary at all.