### PR TITLE
Fix renaming battle rooms

### DIFF
--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -922,7 +922,7 @@ export const commands: ChatCommands = {
 		this.errorReply("Did you mean /renameroom?");
 	},
 	renamegroupchat: 'renameroom',
-	async renameroom(target, room, user, connection, cmd) {
+	renameroom(target, room, user, connection, cmd) {
 		room = this.requireRoom();
 		if (room.game || room.minorActivity || room.tour) {
 			return this.errorReply("Cannot rename room while a tour/poll/game is running.");
@@ -956,9 +956,7 @@ export const commands: ChatCommands = {
 		}
 		const creatorID = room.roomid.split('-')[1];
 		const id = isGroupchat ? `groupchat-${creatorID}-${toID(target)}` as RoomID : undefined;
-		if (!(await room.rename(target, id))) {
-			return this.errorReply(`An error occured while renaming the room.`);
-		}
+		room.rename(target, id);
 		this.modlog(`RENAME${isGroupchat ? 'GROUPCHAT' : 'ROOM'}`, null, `from ${oldTitle}`);
 		const privacy = room.settings.isPrivate === true ? "Private" :
 			!room.settings.isPrivate ? "Public" :
@@ -1059,11 +1057,14 @@ export const commands: ChatCommands = {
 				}
 				return this.errorReply(`This room is already ${settingName}.`);
 			}
-			room.settings.isPrivate = setting;
 			this.addModAction(`${user.name} made this room ${settingName}.`);
 			this.modlog(`${settingName.toUpperCase()}ROOM`);
-			room.settings.isPrivate = setting;
-			room.saveSettings();
+			if (room.battle) {
+				room.makePrivate(setting);
+			} else {
+				room.settings.isPrivate = setting;
+				room.saveSettings();
+			}
 			room.privacySetter = new Set([user.id]);
 		}
 	},

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -848,7 +848,7 @@ export class RoomBattle extends RoomGames.RoomGame {
 		// If the room's replay was hidden, disable users from joining after the game is over
 		if (this.room.hideReplay) {
 			this.room.settings.modjoin = '%';
-			this.room.settings.isPrivate = 'hidden';
+			this.room.makePrivate('hidden');
 		}
 		this.room.update();
 	}

--- a/server/room-game.ts
+++ b/server/room-game.ts
@@ -76,7 +76,7 @@ export class RoomGamePlayer {
  * globally Rooms.RoomGame
  */
 export class RoomGame {
-	readonly roomid: RoomID;
+	roomid: RoomID;
 	/**
 	 * The room this roomgame is in. Rooms can have two RoomGames at a time,
 	 * which are available as `this.room.game === this` and `this.room.subGame === this`.
@@ -202,6 +202,15 @@ export class RoomGame {
 			this.playerTable[user.id].name = user.name;
 			delete this.playerTable[oldUserid];
 		}
+	}
+
+	renameRoom(roomid: RoomID) {
+		for (const player of this.players) {
+			const user = Users.get(player.id);
+			user?.games.delete(this.roomid);
+			user?.games.add(roomid);
+		}
+		this.roomid = roomid;
 	}
 
 	// Commands:

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -15,6 +15,8 @@
  * @license MIT
  */
 
+const ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz'.split('');
+
 const TIMEOUT_EMPTY_DEALLOCATE = 10 * 60 * 1000;
 const TIMEOUT_INACTIVE_DEALLOCATE = 40 * 60 * 1000;
 const REPORT_USER_STATS_INTERVAL = 10 * 60 * 1000;
@@ -694,18 +696,11 @@ export abstract class BasicRoom {
 		if (Rooms.search(newTitle)) throw new Chat.ErrorMessage(`The room '${newTitle}' already exists.`);
 	}
 
-	getReplayData() {
-		if (!this.roomid.endsWith('pw')) return {id: this.roomid.slice(7)};
-		const end = this.roomid.length - 2;
-		const lastHyphen = this.roomid.lastIndexOf('-', end);
-		return {id: this.roomid.slice(7, lastHyphen), password: this.roomid.slice(lastHyphen, end)};
-	}
-
 	/**
 	 * @param newID Add this param if the roomid is different from `toID(newTitle)`
 	 * @param noAlias Set this param to true to not redirect aliases and the room's old name to its new name.
 	 */
-	async rename(newTitle: string, newID?: RoomID, noAlias?: boolean) {
+	rename(newTitle: string, newID?: RoomID, noAlias?: boolean) {
 		if (!newID) newID = toID(newTitle) as RoomID;
 		this.validateTitle(newTitle, newID);
 		if (this.type === 'chat' && this.game) {
@@ -744,6 +739,9 @@ export abstract class BasicRoom {
 			}
 			this.settings.aliases = undefined;
 		}
+
+		this.game?.renameRoom(newID);
+
 		this.saveSettings();
 
 		for (const user of Object.values(this.users)) {
@@ -765,7 +763,7 @@ export abstract class BasicRoom {
 		this.settings.title = newTitle;
 		this.saveSettings();
 
-		return this.log.rename(newID);
+		void this.log.rename(newID);
 	}
 
 	onConnect(user: User, connection: Connection) {
@@ -1622,8 +1620,9 @@ export class GameRoom extends BasicRoom {
 		const datahash = crypto.createHash('md5').update(data.replace(/[^(\x20-\x7F)]+/g, '')).digest('hex');
 		let rating = 0;
 		if (battle.ended && this.rated) rating = this.rated;
+		const {id, password} = this.getReplayData();
 		const [success] = await LoginServer.request('prepreplay', {
-			id: this.roomid.substr(7),
+			id: id,
 			loghash: datahash,
 			p1: battle.p1.name,
 			p2: battle.p2.name,
@@ -1640,9 +1639,40 @@ export class GameRoom extends BasicRoom {
 		}
 		connection.send('|queryresponse|savereplay|' + JSON.stringify({
 			log: data,
-			id: this.roomid.substr(7),
+			id: id,
+			password: password,
 			silent: options === 'forpunishment' || options === 'silent',
 		}));
+	}
+
+	getReplayData() {
+		if (!this.roomid.endsWith('pw')) return {id: this.roomid.slice(7)};
+		const end = this.roomid.length - 2;
+		const lastHyphen = this.roomid.lastIndexOf('-', end);
+		return {id: this.roomid.slice(7, lastHyphen), password: this.roomid.slice(lastHyphen + 1, end)};
+	}
+
+	makePrivate(privacy: true | 'hidden' | 'voice') {
+		// This is the same password generation approach as genPassword in the client replays.lib.php
+		// but obviously will not match given mt_rand there uses a different RNG and seed.
+		let password = '';
+		for (let i = 0; i <= 31; i++) password += ALPHABET[Math.floor(Math.random() * ALPHABET.length)];
+
+		this.settings.isPrivate = privacy;
+		for (const user of Object.values(this.users)) {
+			if (!user.named) {
+				user.leaveRoom(this.roomid);
+				user.popup(`The battle <<${this.roomid}>> has been made private; you must log in to watch private battles.`);
+			}
+		}
+		if (this.roomid.endsWith('pw')) return true;
+		this.rename(this.title, `${this.roomid}-${password}pw` as RoomID, true);
+	}
+
+	makePublic() {
+		this.settings.isPrivate = false;
+		if (!this.roomid.endsWith('pw')) return true;
+		this.rename(this.title, this.getReplayData().id as RoomID);
 	}
 }
 
@@ -1760,11 +1790,11 @@ export const Rooms = {
 
 		if (privacySetter.size) {
 			if (battle.forcePublic) {
-				room.settings.isPrivate = false;
+				room.makePublic();
 				room.settings.modjoin = null;
 				room.add(`|raw|<div class="broadcast-blue"><strong>This battle is required to be public due to a player having a name starting with '${battle.forcePublic}'.</div>`);
 			} else if (!options.tour || (room.tour && room.tour.modjoin)) {
-				room.settings.isPrivate = 'hidden';
+				room.makePrivate('hidden');
 				if (inviteOnly) room.settings.modjoin = '%';
 				room.privacySetter = privacySetter;
 				if (inviteOnly) {


### PR DESCRIPTION
Third time's the charm? The issue was that `RoomGame#roomid` wasn't being updated. I fixed that, and it seems to work fine on localhost (I believe that the replay server already handles replay uploads from battles with passwords, so I didn't put in the extra work to test this on my replay server, but I can do that if we're unsure about the replay server functionality).