### PR TITLE
Make modnotes global in rooms with shared modlogs

### DIFF
--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -1143,7 +1143,7 @@ export const commands: ChatCommands = {
 		}
 		this.checkCan('receiveauthmessages', null, room);
 		target = target.replace(/\n/g, "; ");
-		if (room.roomid === 'staff' || room.roomid === 'upperstaff') {
+		if (room.roomid === 'staff' || room.roomid === 'upperstaff' || (Rooms.Modlog.getSharedID(room.roomid) && user.can('modlog'))) {
 			this.globalModlog('NOTE', null, ` by ${user.id}: ${target}`);
 		} else {
 			this.modlog('NOTE', null, target);

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -1143,7 +1143,11 @@ export const commands: ChatCommands = {
 		}
 		this.checkCan('receiveauthmessages', null, room);
 		target = target.replace(/\n/g, "; ");
-		if (room.roomid === 'staff' || room.roomid === 'upperstaff' || (Rooms.Modlog.getSharedID(room.roomid) && user.can('modlog'))) {
+		if (
+			room.roomid === 'staff' ||
+			room.roomid === 'upperstaff' ||
+			(Rooms.Modlog.getSharedID(room.roomid) && user.can('modlog'))
+		) {
 			this.globalModlog('NOTE', null, ` by ${user.id}: ${target}`);
 		} else {
 			this.modlog('NOTE', null, target);


### PR DESCRIPTION
This mainly applies to modnotes in help tickets and battles, as well as global staff modnoting in groupchats (in case of misbehavior in a groupchat).