### PR TITLE
Auth: Make whitelist/prizewinner not give trusted status

### DIFF
--- a/server/user-groups.ts
+++ b/server/user-groups.ts
@@ -56,7 +56,7 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 		return super.get(user) || Auth.defaultSymbol();
 	}
 	isStaff(userid: ID) {
-		return this.has(userid) && this.get(userid) !== '+';
+		return this.has(userid) && Auth.atLeast(this.get(userid), '%');
 	}
 	atLeast(user: User, group: AuthLevel) {
 		if (user.hasSysopAccess()) return true;


### PR DESCRIPTION
This seemed a better solution than hardcoding `!['^', ' '].includes(this.get(userid))`. Bug happens because they have a rank in the auth table (which it checks) other than `+`, `' '`, and we didn't account for that implementing whitelist. 
This needs a pretty simple monkeypatch in order to take affect (no, it won't crash things, but giving trusted wrongly is a bit of an issue): 
```ts
>> Users.Auth.prototype.isStaff = function(userid) {
return this.has(userid) && Users.Auth.atLeast(this.get(userid), '%');
}
```