### PR TITLE
Add suspect tests plugin

### DIFF
--- a/build
+++ b/build
@@ -123,7 +123,7 @@ if (sucrase('./data', './.data-dist')) {
 
 if (sucrase('./sim', './.sim-dist')) {
 	replace('.sim-dist', [
-		{regex: /(require\(.*?)(lib)/g, replace: `$1.lib-dist`},
+		{regex: /(require\(.*?)(lib|server)/g, replace: `$1.$2-dist`},
 	]);
 }
 

--- a/build
+++ b/build
@@ -123,7 +123,7 @@ if (sucrase('./data', './.data-dist')) {
 
 if (sucrase('./sim', './.sim-dist')) {
 	replace('.sim-dist', [
-		{regex: /(require\(.*?)(lib|server)/g, replace: `$1.$2-dist`},
+		{regex: /(require\(.*?)(lib)/g, replace: `$1.lib-dist`},
 	]);
 }
 

--- a/server/chat-plugins/suspect-tests.ts
+++ b/server/chat-plugins/suspect-tests.ts
@@ -9,7 +9,7 @@ interface SuspectTest {
 	url: string;
 }
 
-export const suspectTests: {[format: string]: SuspectTest} = JSON.parse(FS(SUSPECTS_FILE).readIfExistsSync() || "{}");
+const suspectTests: {[format: string]: SuspectTest} = JSON.parse(FS(SUSPECTS_FILE).readIfExistsSync() || "{}");
 
 function saveSuspectTests() {
 	FS(SUSPECTS_FILE).writeUpdate(() => JSON.stringify(suspectTests));
@@ -56,7 +56,7 @@ export const commands: ChatCommands = {
 				!['https://www.smogon.com/forums/threads/', 'https://www.smogon.com/forums/posts/']
 					.some(prefix => urlActual.startsWith(prefix))
 			) {
-				return this.errorReply("Suspect test URLs must be Smogon threads or posts.");
+				throw new Chat.ErrorMessage("Suspect test URLs must be Smogon threads or posts.");
 			}
 
 			this.privateGlobalModAction(`${user.name} ${suspectTests[format.id] ? "edited the" : "added a"} ${format.name} suspect test.`);

--- a/server/chat-plugins/suspect-tests.ts
+++ b/server/chat-plugins/suspect-tests.ts
@@ -1,6 +1,6 @@
 import {FS} from '../../lib/fs';
 
-const SUSPECTS_FILE = 'config/chat-plugins/suspects.json';
+const SUSPECTS_FILE = 'config/suspects.json';
 
 interface SuspectTest {
 	tier: string;

--- a/server/chat-plugins/suspect-tests.ts
+++ b/server/chat-plugins/suspect-tests.ts
@@ -52,10 +52,7 @@ export const commands: ChatCommands = {
 			const dateActual = `${month}/${day}`;
 
 			const urlActual = url.trim();
-			if (
-				!['https://www.smogon.com/forums/threads/', 'https://www.smogon.com/forums/posts/']
-					.some(prefix => urlActual.startsWith(prefix))
-			) {
+			if (!/^https:\/\/www\.smogon\.com\/forums\/(threads|posts)\//.test(urlActual)) {
 				throw new Chat.ErrorMessage("Suspect test URLs must be Smogon threads or posts.");
 			}
 

--- a/server/chat-plugins/suspect-tests.ts
+++ b/server/chat-plugins/suspect-tests.ts
@@ -1,0 +1,101 @@
+import {FS} from '../../lib/fs';
+
+const SUSPECTS_FILE = 'config/chat-plugins/suspects.json';
+
+interface SuspectTest {
+	tier: string;
+	suspect: string;
+	date: string;
+	url: string;
+}
+
+export const suspectTests: {[format: string]: SuspectTest} = JSON.parse(FS(SUSPECTS_FILE).readIfExistsSync() || "{}");
+
+function saveSuspectTests() {
+	FS(SUSPECTS_FILE).writeUpdate(() => JSON.stringify(suspectTests));
+}
+
+export const commands: ChatCommands = {
+	suspect: 'suspects',
+	suspects: {
+		''(target, room, user) {
+			if (!Object.keys(suspectTests).length) {
+				return this.errorReply("There are no suspect tests running.");
+			}
+			if (!this.runBroadcast()) return;
+
+			let buffer = '<strong>Suspect tests currently running:</strong>';
+			for (const i of Object.keys(suspectTests)) {
+				buffer += '<br />';
+				buffer += `${suspectTests[i].tier}: <a href="${suspectTests[i].url}">${suspectTests[i].suspect}</a> (${suspectTests[i].date})`;
+			}
+			return this.sendReplyBox(buffer);
+		},
+
+		edit: 'add',
+		add(target, room, user) {
+			this.checkCan('gdeclare');
+
+			const [tier, suspect, date, url] = target.split(',');
+			if (!(tier && suspect && date && url)) {
+				return this.parse('/help suspects');
+			}
+
+			const format = Dex.getFormat(tier);
+			if (!format.exists) return this.errorReply(`"${tier}" is not a valid tier.`);
+
+			const suspectString = suspect.trim();
+
+			const [month, day] = date.trim().split(date.includes('-') ? '-' : '/');
+			const isValidDate = /[0-1]?[0-9]/.test(month) && /[0-3]?[0-9]/.test(day);
+			if (!isValidDate) return this.errorReply("Dates must be in the format MM/DD.");
+			const dateActual = `${month}/${day}`;
+
+			const urlActual = url.trim();
+			if (
+				!['https://www.smogon.com/forums/threads/', 'https://www.smogon.com/forums/posts/']
+					.some(prefix => urlActual.startsWith(prefix))
+			) {
+				return this.errorReply("Suspect test URLs must be Smogon threads or posts.");
+			}
+
+			this.privateGlobalModAction(`${user.name} ${suspectTests[format.id] ? "edited the" : "added a"} ${format.name} suspect test.`);
+			this.globalModlog('SUSPECTTEST', null, `by ${user.id}: ${suspectTests[format.id] ? "edited" : "added"} ${format.name}`);
+
+			suspectTests[format.id] = {
+				tier: format.name,
+				suspect: suspectString,
+				date: dateActual,
+				url: urlActual,
+			};
+			saveSuspectTests();
+		},
+
+		delete: 'remove',
+		remove(target, room, user) {
+			this.checkCan('gdeclare');
+
+			const format = toID(target);
+			if (!suspectTests[format]) return this.errorReply(`There is no suspect test for '${target}'. Check spelling?`);
+
+			this.privateGlobalModAction(`${user.name} removed the ${suspectTests[format].tier} suspect test.`);
+			this.globalModlog('SUSPECTTEST', null, `by ${user.id}: removed ${suspectTests[format].tier}`);
+
+			delete suspectTests[format];
+			saveSuspectTests();
+		},
+
+		help() {
+			return this.parse('/help suspects');
+		},
+	},
+
+	suspectshelp() {
+		this.sendReplyBox(
+			`Commands to manage suspect tests:<br />` +
+			`<code>/suspects</code>: displays currently running suspect tests.<br />` +
+			`<code>/suspects add [tier], [suspect], [date], [link]</code>: adds a suspect test. Date in the format MM/DD. Requires: &<br />` +
+			`<code>/suspects remove [tier]</code>: deletes a suspect test. Requires: &`
+		);
+	},
+};

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -13,7 +13,9 @@ import {Side} from './side';
 import {State} from './state';
 import {BattleQueue, Action} from './battle-queue';
 import {Utils} from '../lib/utils';
-import {suspectTests} from '../server/chat-plugins/suspect-tests';
+import {FS} from '../lib/fs';
+
+const suspectTests = JSON.parse(FS('../config/chat-plugins/suspects.json').readIfExistsSync() || "{}");
 
 /** A Pokemon that has fainted. */
 interface FaintedPokemon {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -15,7 +15,7 @@ import {BattleQueue, Action} from './battle-queue';
 import {Utils} from '../lib/utils';
 import {FS} from '../lib/fs';
 
-const suspectTests = JSON.parse(FS('../config/chat-plugins/suspects.json').readIfExistsSync() || "{}");
+const suspectTests = JSON.parse(FS('../config/suspects.json').readIfExistsSync() || "{}");
 
 /** A Pokemon that has fainted. */
 interface FaintedPokemon {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -13,6 +13,7 @@ import {Side} from './side';
 import {State} from './state';
 import {BattleQueue, Action} from './battle-queue';
 import {Utils} from '../lib/utils';
+import {suspectTests} from '../server/chat-plugins/suspect-tests';
 
 /** A Pokemon that has fainted. */
 interface FaintedPokemon {
@@ -1616,6 +1617,10 @@ export class Battle {
 		if (this.rated) {
 			if (this.rated === 'Rated battle') this.rated = true;
 			this.add('rated', typeof this.rated === 'string' ? this.rated : '');
+			// Suspect test notice
+			if (suspectTests[format.id]) {
+				this.add('html', `<div class="broadcast-blue"><strong>${format.name} is currently suspecting ${suspectTests[format.id].suspect}! For information on how to participate check out the <a href="${suspectTests[format.id].url}">suspect thread</a>.</strong></div>`);
+			}
 		}
 
 		if (format.onBegin) format.onBegin.call(this);


### PR DESCRIPTION
A chat-plugin to allow suspect test notices to be added and removed via a command rather than modifying the formats file.

Date isn't necessary per say but I included it for the purpose of being able to see suspect deadlines in `/suspects`.

Shoutout Annika for solving some of my TS issues.