### PR TITLE
Introduce Chat.oldPlugins

### DIFF
--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -330,6 +330,7 @@ export const commands: ChatCommands = {
 				}
 				if (requiresForce(patch)) return this.errorReply(requiresForceMessage);
 
+				const oldPlugins = Chat.plugins;
 				Chat.destroy();
 
 				const processManagers = ProcessManager.processManagers;
@@ -346,7 +347,7 @@ export const commands: ChatCommands = {
 				global.Tournaments = require('../tournaments').Tournaments;
 
 				this.sendReply("Chat commands have been hot-patched.");
-				Chat.loadPlugins();
+				Chat.loadPlugins(oldPlugins);
 				this.sendReply("Chat plugins have been loaded.");
 			} else if (target === 'tournaments') {
 				if (lock['tournaments']) {

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -42,8 +42,7 @@ try {
 				continue;
 			}
 			// Close open tickets after a restart
-			// (i.e. if the server has been running for less than a minute)
-			if (ticket.open && process.uptime() <= 60) ticket.open = false;
+			if (ticket.open && !Chat.oldPlugins.helptickets) ticket.open = false;
 			tickets[t] = ticket;
 		}
 	}


### PR DESCRIPTION
This provides a new way to persist chat plugin data across hotpatches: `Chat.oldPlugins`.

In a plugin, you can now do:

```
export const cache = Chat.oldPlugins.pluginname?.cache || {};
```

to create a cache that will persist across hotpatches.