### PR TITLE
Modlog: Parse entries in the child process

### DIFF
--- a/server/chat-plugins/modlog-viewer.ts
+++ b/server/chat-plugins/modlog-viewer.ts
@@ -111,6 +111,7 @@ function prettifyResults(
 	const lines = resultArray.length;
 	let curDate = '';
 	let resultString = resultArray.map(result => {
+		if (!result) return '';
 		const date = new Date(result.time || Date.now());
 		const entryRoom = result.visualRoomID || result.roomID || 'global';
 		let [dateString, timestamp] = Chat.toTimestamp(date, {human: true}).split(' ');

--- a/server/modlog.ts
+++ b/server/modlog.ts
@@ -352,7 +352,8 @@ export class Modlog {
 }
 
 // if I don't do this TypeScript thinks that (ModlogResult | undefined)[] is a function
-// and complains about spacing for function calls even though it's a type not a function...
+// and complains about an "nexpected newline between function name and paren"
+// even though it's a type not a function...
 type ModlogResult = ModlogEntry | undefined;
 
 export const PM = new QueryProcessManager<ModlogQuery, ModlogResult[]>(module, async data => {


### PR DESCRIPTION
This moves `parseModlog` into the child process so that it doesn't lag the main process. Also I fixed a crash I saw in Dev room.