### PR TITLE
Modlog viewer: Update regex for new modlog syntax

### DIFF
--- a/server/chat-plugins/modlog-viewer.ts
+++ b/server/chat-plugins/modlog-viewer.ts
@@ -619,7 +619,7 @@ export const commands: ChatCommands = {
 			connection,
 			roomid,
 			search,
-			target.replace(/,?\s*(room|lines)\s*=[^,]*,?/g, ''),
+			target.replace(/^\s?([^,=]*),\s?/, '').replace(/,?\s*(room|lines)\s*=[^,]*,?/g, ''),
 			lines,
 			(cmd === 'punishlog' || cmd === 'pl'),
 			cmd === 'timedmodlog'


### PR DESCRIPTION
It looks like #7436 didn't do this which is causing problems when trying to view older results.