### PR TITLE
Scavengers: Improve /edithunt

### DIFF
--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -1592,6 +1592,7 @@ const ScavengerCommands: ChatCommands = {
 		) {
 			return this.errorReply("You cannot edit the hints and answers if you are not the host.");
 		}
+
 		const [question, type, ...value] = target.split(',');
 		if (!game.onEditQuestion(parseInt(question), toID(type), value.join(',').trim())) {
 			return this.sendReply("/scavengers edithunt [question number], [hint | answer], [value] - edits the current scavenger hunt.");

--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -551,7 +551,6 @@ export class ScavengerHunt extends Rooms.RoomGame {
 
 		let answer: string[] = [];
 		if (question_answer === 'answer') {
-			if (value.includes(',')) return false;
 			answer = value.split(';').map(p => p.trim());
 		}
 
@@ -1593,11 +1592,8 @@ const ScavengerCommands: ChatCommands = {
 		) {
 			return this.errorReply("You cannot edit the hints and answers if you are not the host.");
 		}
-		const parts = target.split(',');
-		const question = parseInt(parts[0]);
-		const type = parts[1];
-		const value = parts.slice(2).join(',').trim();
-		if (!game.onEditQuestion(parseInt(question), toID(type), value)) {
+		const [question, type, ...value] = target.split(',');
+		if (!game.onEditQuestion(parseInt(question), toID(type), value.join(',').trim())) {
 			return this.sendReply("/scavengers edithunt [question number], [hint | answer], [value] - edits the current scavenger hunt.");
 		}
 	},

--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -225,7 +225,7 @@ function formatQueue(queue: QueuedHunt[] | undefined, viewer: User, room: Room, 
 					(q, i) => {
 						if (i % 2) {
 							q = q as string[];
-							return Utils.html`<span style="color: green"><em>[${q.join(' / ')}]</em></span><br />`;
+							return Utils.html`<span style="color: green"><em>[${q.join(' ; ')}]</em></span><br />`;
 						} else {
 							q = q as string;
 							return Utils.escapeHTML(q);
@@ -1593,9 +1593,11 @@ const ScavengerCommands: ChatCommands = {
 		) {
 			return this.errorReply("You cannot edit the hints and answers if you are not the host.");
 		}
-
-		const [question, type, ...value] = target.split(',');
-		if (!game.onEditQuestion(parseInt(question), toID(type), value.join(',').trim())) {
+		const parts = target.split(',');
+		const question = parseInt(parts[0]);
+		const type = parts[1];
+		const value = parts.slice(2).join(',').trim();
+		if (!game.onEditQuestion(parseInt(question), toID(type), value)) {
 			return this.sendReply("/scavengers edithunt [question number], [hint | answer], [value] - edits the current scavenger hunt.");
 		}
 	},

--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -225,7 +225,7 @@ function formatQueue(queue: QueuedHunt[] | undefined, viewer: User, room: Room, 
 					(q, i) => {
 						if (i % 2) {
 							q = q as string[];
-							return Utils.html`<span style="color: green"><em>[${q.join(' ; ')}]</em></span><br />`;
+							return Utils.html`<span style="color: green"><em>[${q.join(' / ')}]</em></span><br />`;
 						} else {
 							q = q as string;
 							return Utils.escapeHTML(q);
@@ -699,7 +699,7 @@ export class ScavengerHunt extends Rooms.RoomGame {
 				}</td><td>${
 					i + 1 >= qLimit ?
 						`` :
-						this.forceWrap(q.answer.join(' / '))
+						this.forceWrap(q.answer.join(' ; '))
 				}</td></tr>`
 			)).join("") +
 			`</table><div>`


### PR DESCRIPTION
Two minor changes for the Scavengers plugin:

- In /viewhunt, change the ``/`` for alts to a ``;`` to allow easier copying.
- For /edithunt, allow commas in answers.