### PR TITLE
Use attributes of CommandContext in Chat.filter

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2616,7 +2616,7 @@ export const commands: ChatCommands = {
 
 		if (this.broadcasting) {
 			if (isPMOrPersonalRoom) {
-				target = Chat.filter(this, target, user, room, connection, this.pmTarget)!;
+				target = Chat.filter(this, target)!;
 				if (!target) return this.errorReply(`Invalid code.`);
 			}
 			return `/raw <div class="infobox">${Chat.getReadmoreCodeBlock(target)}</div>`;

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2616,7 +2616,7 @@ export const commands: ChatCommands = {
 
 		if (this.broadcasting) {
 			if (isPMOrPersonalRoom) {
-				target = Chat.filter(this, target)!;
+				target = this.filter(target)!;
 				if (!target) return this.errorReply(`Invalid code.`);
 			}
 			return `/raw <div class="infobox">${Chat.getReadmoreCodeBlock(target)}</div>`;

--- a/server/chat-plugins/announcements.ts
+++ b/server/chat-plugins/announcements.ts
@@ -56,7 +56,7 @@ export const commands: ChatCommands = {
 			target = target.trim();
 			if (room.battle) return this.errorReply(this.tr("Battles do not support announcements."));
 
-			const text = Chat.filter(this, target, user, room, connection);
+			const text = Chat.filter(this, target);
 			if (target !== text) return this.errorReply(this.tr("You are not allowed to use filtered words in announcements."));
 
 			const supportHTML = cmd === 'htmlcreate';

--- a/server/chat-plugins/announcements.ts
+++ b/server/chat-plugins/announcements.ts
@@ -56,7 +56,7 @@ export const commands: ChatCommands = {
 			target = target.trim();
 			if (room.battle) return this.errorReply(this.tr("Battles do not support announcements."));
 
-			const text = Chat.filter(this, target);
+			const text = this.filter(target);
 			if (target !== text) return this.errorReply(this.tr("You are not allowed to use filtered words in announcements."));
 
 			const supportHTML = cmd === 'htmlcreate';

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -877,7 +877,7 @@ export class CommandContext extends MessageContext {
 	}
 	filter(message: string) {
 		if (!this.room) return null;
-		return Chat.filter(this, message);
+		return Chat.filter(message, this);
 	}
 	statusfilter(status: string) {
 		return Chat.statusfilter(status, this.user);
@@ -1129,7 +1129,7 @@ export class CommandContext extends MessageContext {
 		}
 
 		if (Chat.filters.length) {
-			return Chat.filter(this, message);
+			return this.filter(message);
 		}
 
 		return message;
@@ -1376,7 +1376,7 @@ export const Chat = new class {
 	 * Load chat filters
 	 *********************************************************/
 	readonly filters: ChatFilter[] = [];
-	filter(context: CommandContext, message: string) {
+	filter(message: string, context: CommandContext) {
 		// Chat filters can choose to:
 		// 1. return false OR null - to not send a user's message
 		// 2. return an altered string - to alter a user's message

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -875,9 +875,9 @@ export class CommandContext extends MessageContext {
 	update() {
 		if (this.room) this.room.update();
 	}
-	filter(message: string, targetUser: User | null = null) {
+	filter(message: string) {
 		if (!this.room) return null;
-		return Chat.filter(this, message, this.user, this.room, this.connection, targetUser);
+		return Chat.filter(this, message);
 	}
 	statusfilter(status: string) {
 		return Chat.statusfilter(status, this.user);
@@ -1129,7 +1129,7 @@ export class CommandContext extends MessageContext {
 		}
 
 		if (Chat.filters.length) {
-			return Chat.filter(this, message, user, room, connection, targetUser);
+			return Chat.filter(this, message);
 		}
 
 		return message;
@@ -1376,21 +1376,22 @@ export const Chat = new class {
 	 * Load chat filters
 	 *********************************************************/
 	readonly filters: ChatFilter[] = [];
-	filter(
-		context: CommandContext,
-		message: string,
-		user: User,
-		room: Room | null,
-		connection: Connection,
-		targetUser: User | null = null
-	) {
+	filter(context: CommandContext, message: string) {
 		// Chat filters can choose to:
 		// 1. return false OR null - to not send a user's message
 		// 2. return an altered string - to alter a user's message
 		// 3. return undefined to send the original message through
 		const originalMessage = message;
 		for (const curFilter of Chat.filters) {
-			const output = curFilter.call(context, message, user, room, connection, targetUser, originalMessage);
+			const output = curFilter.call(
+				context,
+				message,
+				context.user,
+				context.room,
+				context.connection,
+				context.pmTarget,
+				originalMessage
+			);
 			if (output === false) return null;
 			if (!output && output !== undefined) return output;
 			if (output !== undefined) message = output;


### PR DESCRIPTION
This does not change the parameters passed to individual filters, in the name of backwards compatibility with old filters.