### PR TITLE
Fix tour autostart with less than 2 players

### DIFF
--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -595,7 +595,7 @@ export class Tournament extends Rooms.RoomGame {
 		}
 
 		if (this.players.length < 2) {
-			if (output.target.startsWith('autostart')) {
+			if (output.cmd === 'autostart' || output.cmd === 'setautostart') {
 				this.room.send('|tournament|error|NotEnoughUsers');
 				this.forceEnd();
 				this.room.update();


### PR DESCRIPTION
This was working and broke sometime in the past month or so? Anyway, this is fixes it so tournaments automatically forceend if there's not enough users when the autostart timer reaches 0.