### PR TITLE
Add skipped failing event validator tests

### DIFF
--- a/test/sim/team-validator.js
+++ b/test/sim/team-validator.js
@@ -528,6 +528,32 @@ describe('Team Validator', function () {
 		assert(illegal);
 	});
 
+	it.skip('should not allow evolutions of Shiny-locked events to be Shiny', function () {
+		const team = [
+			{species: 'urshifu', ability: 'unseenfist', shiny: true, moves: ['snore'], evs: {hp: 1}},
+			{species: 'cosmoem', ability: 'sturdy', shiny: true, moves: ['teleport'], evs: {hp: 1}},
+		];
+		const illegal = TeamValidator.get('gen8anythinggoes').validateTeam(team);
+		assert(illegal);
+	});
+
+	it.skip('should not allow unreleased Gmax formes', function () {
+		const team = [
+			{species: 'melmetal-gmax', ability: 'ironfist', moves: ['doubleironbash'], evs: {hp: 1}},
+		];
+		const illegal = TeamValidator.get('gen8anythinggoes').validateTeam(team);
+		assert(illegal);
+	});
+
+	it.skip('should not allow events to use moves only obtainable in a previous generation', function () {
+		const team = [
+			{species: 'zeraora', ability: 'voltabsorb', shiny: true, moves: ['knockoff'], evs: {hp: 1}},
+		];
+		const illegal = TeamValidator.get('gen8anythinggoes').validateTeam(team);
+		assert(illegal);
+	});
+
+
 	/*********************************************************
  	* Custom rules
  	*********************************************************/


### PR DESCRIPTION
Adds 3 failing validator tests related to events:
1. Evolutions of Shiny-locked event Pokemon should not be able to be Shiny (e.g. Urshifu, Cosmoem)
2. Unreleased G-Max Pokemon should not be allowed (Melmetal)
3. Events should not have access to past-generation moves (e.g. Shiny Zeraora is Gen 8-only, so it can't have Knock Off since it only gets that in Gen 7)