### PR TITLE
Chat#checkHTML: Ban <iframe> tags

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1210,7 +1210,7 @@ export class CommandContext extends MessageContext {
 		const tags = htmlContent.match(/<!--.*?-->|<\/?[^<>]*/g);
 		if (tags) {
 			const ILLEGAL_TAGS = [
-				'script', 'head', 'body', 'html', 'canvas', 'base', 'meta', 'link',
+				'script', 'head', 'body', 'html', 'canvas', 'base', 'meta', 'link', 'iframe',
 			];
 			const LEGAL_AUTOCLOSE_TAGS = [
 				// void elements (no-close tags)


### PR DESCRIPTION
iframes don't work in /htmlbox etc. right now anyway and I don't think there's a good reason to allow it.

Screenshot of current behavior:
![image](https://user-images.githubusercontent.com/23667022/95149745-503cc180-074c-11eb-99b7-7e369f886123.png)
