### PR TITLE
Fix /help for room promotion commands

### DIFF
--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -1676,6 +1676,15 @@ export const commands: ChatCommands = {
 				return this.parse(`/${target}`);
 			}
 			if (!nextNamespace) {
+				for (const g in Config.groups) {
+					const groupid = Config.groups[g].id;
+					if (new RegExp(`(global)?(un|de)?${groupid}`).test(target)) {
+						return this.parse(`/help promote`);
+					}
+					if (new RegExp(`room(un|de)?${groupid}`).test(target)) {
+						return this.parse(`/help roompromote`);
+					}
+				}
 				return this.errorReply(this.tr`The command '/${target}' does not exist.`);
 			}
 


### PR DESCRIPTION
I'm not sure if a regex is the right way to do this but it seems more compact than listing every possible variation, and I figure that we care more about readability than performance here.