### PR TITLE
Allow Pokemon names as arguments in /stone

### DIFF
--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -209,7 +209,7 @@ export const commands: ChatCommands = {
 		const ruleTable = Dex.getRuleTable(Dex.getFormat('gen8mixandmega'));
 		for (const aStone of toDisplay) {
 			if (!aStone) return;
-			if (banlist.includes(aStone.name)) {
+			if (ruleTable.isBanned(`${aStone.name === 'Dragon Ascent' ? 'move' : 'item'}:${aStone.name}`)) {
 				this.errorReply(`Warning: ${aStone.name} is banned from Mix and Mega.`);
 			}
 			if (aStone.name === 'Dragon Ascent') {

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -206,7 +206,8 @@ export const commands: ChatCommands = {
 			}).filter(poke => poke !== null);
 			if (!stones.length) return this.errorReply(`Error: Mega Evolution not found.`);
 		}
-		const toDisplay = (stones || [stone]), banlist = Dex.getFormat('gen8mixandmega').banlist;
+		const toDisplay = (stones || [stone]);
+		const banlist = Dex.getFormat('gen8mixandmega').banlist;
 		toDisplay.forEach(aStone => {
 			if (!aStone) return;
 			if (banlist.includes(aStone.name)) {

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -201,11 +201,7 @@ export const commands: ChatCommands = {
 				const megaPoke = dex.getSpecies(poke);
 				const flag = megaPoke.requiredMove === 'Dragon Ascent' ? megaPoke.requiredMove : megaPoke.requiredItem;
 				if (/mega[xy]$/.test(targetid) && toID(megaPoke.name) !== toID(dex.getSpecies(targetid))) return null;
-				if (!flag) {
-					console.log(megaPoke);
-					console.log(flag);
-					return null;
-				}
+				if (!flag) return null;
 				return getMegaStone(flag, sep[1]);
 			}).filter(poke => poke !== null);
 			if (!stones.length) return this.errorReply(`Error: Mega Evolution not found.`);

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -206,7 +206,7 @@ export const commands: ChatCommands = {
 			if (!stones.length) return this.errorReply(`Error: Mega Evolution not found.`);
 		}
 		const toDisplay = (stones.length ? stones : [stone]);
-		const banlist = Dex.getFormat('gen8mixandmega').banlist;
+		const ruleTable = Dex.getRuleTable(Dex.getFormat('gen8mixandmega'));
 		for (const aStone of toDisplay) {
 			if (!aStone) return;
 			if (banlist.includes(aStone.name)) {

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -208,7 +208,7 @@ export const commands: ChatCommands = {
 		}
 		const toDisplay = (stones || [stone]);
 		const banlist = Dex.getFormat('gen8mixandmega').banlist;
-		toDisplay.forEach(aStone => {
+		for (const aStone of toDisplay) {
 			if (!aStone) return;
 			if (banlist.includes(aStone.name)) {
 				this.errorReply(`Warning: ${aStone.name} is banned from Mix and Mega.`);
@@ -293,7 +293,7 @@ export const commands: ChatCommands = {
 			buf += `</li>`;
 			this.sendReply(`|raw|<div class="message"><ul class="utilichart">${buf}<li style="clear:both"></li></ul></div>`);
 			this.sendReply(`|raw|<font size="1"><font color="#686868">Gen:</font> ${details["Gen"]}&nbsp;|&ThickSpace;<font color="#686868">Weight:</font> ${details["Weight"]}</font>`);
-		});
+		}
 	},
 	stonehelp: [`/stone <mega stone>[, generation] - Shows the changes that a mega stone/orb applies to a Pokemon.`],
 

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -187,7 +187,9 @@ export const commands: ChatCommands = {
 		const targetid = toID(sep[0]);
 		if (!targetid) return this.parse('/help stone');
 		const stone = getMegaStone(targetid, sep[1]);
-		if (stone && dex.gen >= 8 && ['redorb', 'blueorb'].includes(stone.id)) return this.errorReply("The Orbs do not exist in Gen 8 and later.");
+		if (stone && dex.gen >= 8 && ['redorb', 'blueorb'].includes(stone.id)) {
+			return this.errorReply("The Orbs do not exist in Gen 8 and later.");
+		}
 		let stones;
 		if (!stone) {
 			const species = dex.getSpecies(targetid.replace(/(?:mega[xy]?|primal)$/, ''));
@@ -208,8 +210,7 @@ export const commands: ChatCommands = {
 			}).filter(poke => poke !== null);
 			if (!stones.length) return this.errorReply(`Error: Mega Evolution not found.`);
 		}
-		let toDisplay = (stones || [stone]);
-		const banlist = Dex.getFormat('gen8mixandmega').banlist;
+		const toDisplay = (stones || [stone]), banlist = Dex.getFormat('gen8mixandmega').banlist;
 		toDisplay.forEach(singleStone => {
 			if (!singleStone) return;
 			if (banlist.includes(singleStone.name)) {

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -190,23 +190,22 @@ export const commands: ChatCommands = {
 		if (stone && dex.gen >= 8 && ['redorb', 'blueorb'].includes(stone.id)) {
 			return this.errorReply("The Orbs do not exist in Gen 8 and later.");
 		}
-		let stones;
+		let stones = [];
 		if (!stone) {
 			const species = dex.getSpecies(targetid.replace(/(?:mega[xy]?|primal)$/, ''));
 			if (!species.exists) return this.errorReply(`Error: Mega Stone not found.`);
 			if (!species.otherFormes) return this.errorReply(`Error: Mega Evolution not found.`);
-			const megas = species.otherFormes.filter(poke => /(?:-Primal|-Mega(?:-[XY])?)$/.test(poke));
-			if (!megas.length) return this.errorReply(`Error: Mega Evolution not found.`);
-			stones = megas.map(poke => {
+			for (let poke of species.otherFormes) {
+				if (!/(?:-Primal|-Mega(?:-[XY])?)$/.test(poke)) continue;
 				const megaPoke = dex.getSpecies(poke);
 				const flag = megaPoke.requiredMove === 'Dragon Ascent' ? megaPoke.requiredMove : megaPoke.requiredItem;
-				if (/mega[xy]$/.test(targetid) && toID(megaPoke.name) !== toID(dex.getSpecies(targetid))) return null;
-				if (!flag) return null;
-				return getMegaStone(flag, sep[1]);
-			}).filter(poke => poke !== null);
+				if (/mega[xy]$/.test(targetid) && toID(megaPoke.name) !== toID(dex.getSpecies(targetid))) continue;
+				if (!flag) continue;
+				stones.push(getMegaStone(flag, sep[1]));
+			}
 			if (!stones.length) return this.errorReply(`Error: Mega Evolution not found.`);
 		}
-		const toDisplay = (stones || [stone]);
+		const toDisplay = (stones.length ? stones : [stone]);
 		const banlist = Dex.getFormat('gen8mixandmega').banlist;
 		for (const aStone of toDisplay) {
 			if (!aStone) return;

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -225,7 +225,9 @@ export const commands: ChatCommands = {
 			}
 			let baseSpecies = dex.getSpecies(aStone.megaEvolves);
 			let megaSpecies = dex.getSpecies(aStone.megaStone);
-			if (dex.gen >= 8 && ['redorb', 'blueorb'].includes(aStone.id)) return this.errorReply("The Orbs do not exist in Gen 8 and later.");
+			if (dex.gen >= 8 && ['redorb', 'blueorb'].includes(aStone.id)) {
+				return this.errorReply("The Orbs do not exist in Gen 8 and later.");
+			}
 			if (aStone.id === 'redorb') { // Orbs do not have 'Item.megaStone' or 'Item.megaEvolves' properties.
 				megaSpecies = dex.getSpecies("Groudon-Primal");
 				baseSpecies = dex.getSpecies("Groudon");

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -190,7 +190,7 @@ export const commands: ChatCommands = {
 		if (stone && dex.gen >= 8 && ['redorb', 'blueorb'].includes(stone.id)) {
 			return this.errorReply("The Orbs do not exist in Gen 8 and later.");
 		}
-		let stones = [];
+		const stones = [];
 		if (!stone) {
 			const species = dex.getSpecies(targetid.replace(/(?:mega[xy]?|primal)$/, ''));
 			if (!species.exists) return this.errorReply(`Error: Mega Stone not found.`);

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -187,91 +187,113 @@ export const commands: ChatCommands = {
 		const targetid = toID(sep[0]);
 		if (!targetid) return this.parse('/help stone');
 		const stone = getMegaStone(targetid, sep[1]);
-		if (!stone || (dex.gen >= 8 && ['redorb', 'blueorb'].includes(stone.id))) {
-			return this.errorReply(`Error: Mega Stone not found.`);
+		if (stone && dex.gen >= 8 && ['redorb', 'blueorb'].includes(stone.id)) return this.errorReply("The Orbs do not exist in Gen 8 and later.");
+		let stones;
+		if (!stone) {
+			const species = dex.getSpecies(targetid.replace(/(?:mega[xy]?|primal)$/, ''));
+			if (!species.exists) return this.errorReply(`Error: Mega Stone not found.`);
+			if (!species.otherFormes) return this.errorReply(`Error: Mega Evolution not found.`);
+			const megas = species.otherFormes.filter(poke => /(?:-Primal|-Mega(?:-[XY])?)$/.test(poke));
+			if (!megas.length) return this.errorReply(`Error: Mega Evolution not found.`);
+			stones = megas.map(poke => {
+				const megaPoke = dex.getSpecies(poke);
+				const flag = megaPoke.requiredMove === 'Dragon Ascent' ? megaPoke.requiredMove : megaPoke.requiredItem;
+				if (/mega[xy]$/.test(targetid) && toID(megaPoke.name) !== toID(dex.getSpecies(targetid))) return null;
+				if (!flag) {
+					console.log(megaPoke);
+					console.log(flag);
+					return null;
+				}
+				return getMegaStone(flag, sep[1]);
+			}).filter(poke => poke !== null);
+			if (!stones.length) return this.errorReply(`Error: Mega Evolution not found.`);
 		}
+		let toDisplay = (stones || [stone]);
 		const banlist = Dex.getFormat('gen8mixandmega').banlist;
-		if (banlist.includes(stone.name)) {
-			this.errorReply(`Warning: ${stone.name} is banned from Mix and Mega.`);
-		}
-		if (targetid === 'dragonascent') {
-			this.errorReply(`Warning: Only Pokemon with access to Dragon Ascent can mega evolve with Mega Rayquaza's traits.`);
-		}
-		// Fake Mega Stones
-		if (stone.isNonstandard === 'CAP') {
-			this.errorReply(`Warning: ${stone.name} is a fake mega stone created by the CAP Project and is restricted to the CAP ${stone.megaEvolves}.`);
-		}
-		let baseSpecies = dex.getSpecies(stone.megaEvolves);
-		let megaSpecies = dex.getSpecies(stone.megaStone);
-		if (dex.gen >= 8 && ['redorb', 'blueorb'].includes(stone.id)) return this.parse('/help stone');
-		if (stone.id === 'redorb') { // Orbs do not have 'Item.megaStone' or 'Item.megaEvolves' properties.
-			megaSpecies = dex.getSpecies("Groudon-Primal");
-			baseSpecies = dex.getSpecies("Groudon");
-		} else if (stone.id === 'blueorb') {
-			megaSpecies = dex.getSpecies("Kyogre-Primal");
-			baseSpecies = dex.getSpecies("Kyogre");
-		}
-		const deltas: StoneDeltas = {
-			baseStats: Object.create(null),
-			weighthg: megaSpecies.weighthg - baseSpecies.weighthg,
-			bst: megaSpecies.bst - baseSpecies.bst,
-		};
-		let statId: StatName;
-		for (statId in megaSpecies.baseStats) {
-			deltas.baseStats[statId] = megaSpecies.baseStats[statId] - baseSpecies.baseStats[statId];
-		}
-		if (megaSpecies.types.length > baseSpecies.types.length) {
-			deltas.type = megaSpecies.types[1];
-		} else if (megaSpecies.types.length < baseSpecies.types.length) {
-			deltas.type = dex.gen >= 8 ? 'mono' : megaSpecies.types[0];
-		} else if (megaSpecies.types[1] !== baseSpecies.types[1]) {
-			deltas.type = megaSpecies.types[1];
-		}
-		const details = {
-			Gen: stone.gen,
-			Weight: (deltas.weighthg < 0 ? "" : "+") + deltas.weighthg / 10 + " kg",
-		};
-		let tier;
-		if (['redorb', 'blueorb'].includes(stone.id)) {
-			tier = "Orb";
-		} else if (targetid === "dragonascent") {
-			tier = "Move";
-		} else {
-			tier = "Stone";
-		}
-		let buf = `<li class="result">`;
-		buf += `<span class="col numcol">${tier}</span> `;
-		if (targetid === "dragonascent") {
-			buf += `<span class="col itemiconcol"></span>`;
-		} else {
-			buf += `<span class="col itemiconcol"><psicon item="${targetid}"/></span> `;
-		}
-		if (targetid === "dragonascent") {
-			buf += `<span class="col movenamecol" style="white-space:nowrap"><a href="https://${Config.routes.dex}/moves/${targetid}" target="_blank">Dragon Ascent</a></span> `;
-		} else {
-			buf += `<span class="col pokemonnamecol" style="white-space:nowrap"><a href="https://${Config.routes.dex}/items/${stone.id}" target="_blank">${stone.name}</a></span> `;
-		}
-		if (deltas.type && deltas.type !== 'mono') {
-			buf += `<span class="col typecol"><img src="https://${Config.routes.client}/sprites/types/${deltas.type}.png" alt="${deltas.type}" height="14" width="32"></span> `;
-		} else {
-			buf += `<span class="col typecol"></span>`;
-		}
-		buf += `<span style="float:left;min-height:26px">`;
-		buf += `<span class="col abilitycol">${megaSpecies.abilities['0']}</span>`;
-		buf += `<span class="col abilitycol"></span>`;
-		buf += `</span>`;
-		buf += `<span style="float:left;min-height:26px">`;
-		buf += `<span class="col statcol"><em>HP</em><br />0</span> `;
-		buf += `<span class="col statcol"><em>Atk</em><br />${deltas.baseStats.atk}</span> `;
-		buf += `<span class="col statcol"><em>Def</em><br />${deltas.baseStats.def}</span> `;
-		buf += `<span class="col statcol"><em>SpA</em><br />${deltas.baseStats.spa}</span> `;
-		buf += `<span class="col statcol"><em>SpD</em><br />${deltas.baseStats.spd}</span> `;
-		buf += `<span class="col statcol"><em>Spe</em><br />${deltas.baseStats.spe}</span> `;
-		buf += `<span class="col bstcol"><em>BST<br />${deltas.bst}</em></span> `;
-		buf += `</span>`;
-		buf += `</li>`;
-		this.sendReply(`|raw|<div class="message"><ul class="utilichart">${buf}<li style="clear:both"></li></ul></div>`);
-		this.sendReply(`|raw|<font size="1"><font color="#686868">Gen:</font> ${details["Gen"]}&nbsp;|&ThickSpace;<font color="#686868">Weight:</font> ${details["Weight"]}</font>`);
+		toDisplay.forEach(singleStone => {
+			if (!singleStone) return;
+			if (banlist.includes(singleStone.name)) {
+				this.errorReply(`Warning: ${singleStone.name} is banned from Mix and Mega.`);
+			}
+			if (singleStone.name === 'Dragon Ascent') {
+				this.errorReply(`Warning: Only Pokemon with access to Dragon Ascent can mega evolve with Mega Rayquaza's traits.`);
+			}
+			// Fake Mega Stones
+			if (singleStone.isNonstandard === 'CAP') {
+				this.errorReply(`Warning: ${singleStone.name} is a fake mega stone created by the CAP Project and is restricted to the CAP ${singleStone.megaEvolves}.`);
+			}
+			let baseSpecies = dex.getSpecies(singleStone.megaEvolves);
+			let megaSpecies = dex.getSpecies(singleStone.megaStone);
+			if (dex.gen >= 8 && ['redorb', 'blueorb'].includes(singleStone.id)) return this.errorReply("The Orbs do not exist in Gen 8 and later.");
+			if (singleStone.id === 'redorb') { // Orbs do not have 'Item.megaStone' or 'Item.megaEvolves' properties.
+				megaSpecies = dex.getSpecies("Groudon-Primal");
+				baseSpecies = dex.getSpecies("Groudon");
+			} else if (singleStone.id === 'blueorb') {
+				megaSpecies = dex.getSpecies("Kyogre-Primal");
+				baseSpecies = dex.getSpecies("Kyogre");
+			}
+			const deltas: StoneDeltas = {
+				baseStats: Object.create(null),
+				weighthg: megaSpecies.weighthg - baseSpecies.weighthg,
+				bst: megaSpecies.bst - baseSpecies.bst,
+			};
+			let statId: StatName;
+			for (statId in megaSpecies.baseStats) {
+				deltas.baseStats[statId] = megaSpecies.baseStats[statId] - baseSpecies.baseStats[statId];
+			}
+			if (megaSpecies.types.length > baseSpecies.types.length) {
+				deltas.type = megaSpecies.types[1];
+			} else if (megaSpecies.types.length < baseSpecies.types.length) {
+				deltas.type = dex.gen >= 8 ? 'mono' : megaSpecies.types[0];
+			} else if (megaSpecies.types[1] !== baseSpecies.types[1]) {
+				deltas.type = megaSpecies.types[1];
+			}
+			const details = {
+				Gen: singleStone.gen,
+				Weight: (deltas.weighthg < 0 ? "" : "+") + deltas.weighthg / 10 + " kg",
+			};
+			let tier;
+			if (['redorb', 'blueorb'].includes(singleStone.id)) {
+				tier = "Orb";
+			} else if (singleStone.name === "Dragon Ascent") {
+				tier = "Move";
+			} else {
+				tier = "Stone";
+			}
+			let buf = `<li class="result">`;
+			buf += `<span class="col numcol">${tier}</span> `;
+			if (singleStone.name === "Dragon Ascent") {
+				buf += `<span class="col itemiconcol"></span>`;
+			} else {
+				buf += `<span class="col itemiconcol"><psicon item="${toID(singleStone)}"/></span> `;
+			}
+			if (singleStone.name === "Dragon Ascent") {
+				buf += `<span class="col movenamecol" style="white-space:nowrap"><a href="https://${Config.routes.dex}/moves/${targetid}" target="_blank">Dragon Ascent</a></span> `;
+			} else {
+				buf += `<span class="col pokemonnamecol" style="white-space:nowrap"><a href="https://${Config.routes.dex}/items/${singleStone.id}" target="_blank">${singleStone.name}</a></span> `;
+			}
+			if (deltas.type && deltas.type !== 'mono') {
+				buf += `<span class="col typecol"><img src="https://${Config.routes.client}/sprites/types/${deltas.type}.png" alt="${deltas.type}" height="14" width="32"></span> `;
+			} else {
+				buf += `<span class="col typecol"></span>`;
+			}
+			buf += `<span style="float:left;min-height:26px">`;
+			buf += `<span class="col abilitycol">${megaSpecies.abilities['0']}</span>`;
+			buf += `<span class="col abilitycol"></span>`;
+			buf += `</span>`;
+			buf += `<span style="float:left;min-height:26px">`;
+			buf += `<span class="col statcol"><em>HP</em><br />0</span> `;
+			buf += `<span class="col statcol"><em>Atk</em><br />${deltas.baseStats.atk}</span> `;
+			buf += `<span class="col statcol"><em>Def</em><br />${deltas.baseStats.def}</span> `;
+			buf += `<span class="col statcol"><em>SpA</em><br />${deltas.baseStats.spa}</span> `;
+			buf += `<span class="col statcol"><em>SpD</em><br />${deltas.baseStats.spd}</span> `;
+			buf += `<span class="col statcol"><em>Spe</em><br />${deltas.baseStats.spe}</span> `;
+			buf += `<span class="col bstcol"><em>BST<br />${deltas.bst}</em></span> `;
+			buf += `</span>`;
+			buf += `</li>`;
+			this.sendReply(`|raw|<div class="message"><ul class="utilichart">${buf}<li style="clear:both"></li></ul></div>`);
+			this.sendReply(`|raw|<font size="1"><font color="#686868">Gen:</font> ${details["Gen"]}&nbsp;|&ThickSpace;<font color="#686868">Weight:</font> ${details["Weight"]}</font>`);
+		});
 	},
 	stonehelp: [`/stone <mega stone>[, generation] - Shows the changes that a mega stone/orb applies to a Pokemon.`],
 

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -195,7 +195,7 @@ export const commands: ChatCommands = {
 			const species = dex.getSpecies(targetid.replace(/(?:mega[xy]?|primal)$/, ''));
 			if (!species.exists) return this.errorReply(`Error: Mega Stone not found.`);
 			if (!species.otherFormes) return this.errorReply(`Error: Mega Evolution not found.`);
-			for (let poke of species.otherFormes) {
+			for (const poke of species.otherFormes) {
 				if (!/(?:-Primal|-Mega(?:-[XY])?)$/.test(poke)) continue;
 				const megaPoke = dex.getSpecies(poke);
 				const flag = megaPoke.requiredMove === 'Dragon Ascent' ? megaPoke.requiredMove : megaPoke.requiredItem;

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -211,25 +211,25 @@ export const commands: ChatCommands = {
 			if (!stones.length) return this.errorReply(`Error: Mega Evolution not found.`);
 		}
 		const toDisplay = (stones || [stone]), banlist = Dex.getFormat('gen8mixandmega').banlist;
-		toDisplay.forEach(singleStone => {
-			if (!singleStone) return;
-			if (banlist.includes(singleStone.name)) {
-				this.errorReply(`Warning: ${singleStone.name} is banned from Mix and Mega.`);
+		toDisplay.forEach(aStone => {
+			if (!aStone) return;
+			if (banlist.includes(aStone.name)) {
+				this.errorReply(`Warning: ${aStone.name} is banned from Mix and Mega.`);
 			}
-			if (singleStone.name === 'Dragon Ascent') {
+			if (aStone.name === 'Dragon Ascent') {
 				this.errorReply(`Warning: Only Pokemon with access to Dragon Ascent can mega evolve with Mega Rayquaza's traits.`);
 			}
 			// Fake Mega Stones
-			if (singleStone.isNonstandard === 'CAP') {
-				this.errorReply(`Warning: ${singleStone.name} is a fake mega stone created by the CAP Project and is restricted to the CAP ${singleStone.megaEvolves}.`);
+			if (aStone.isNonstandard === 'CAP') {
+				this.errorReply(`Warning: ${aStone.name} is a fake mega stone created by the CAP Project and is restricted to the CAP ${aStone.megaEvolves}.`);
 			}
-			let baseSpecies = dex.getSpecies(singleStone.megaEvolves);
-			let megaSpecies = dex.getSpecies(singleStone.megaStone);
-			if (dex.gen >= 8 && ['redorb', 'blueorb'].includes(singleStone.id)) return this.errorReply("The Orbs do not exist in Gen 8 and later.");
-			if (singleStone.id === 'redorb') { // Orbs do not have 'Item.megaStone' or 'Item.megaEvolves' properties.
+			let baseSpecies = dex.getSpecies(aStone.megaEvolves);
+			let megaSpecies = dex.getSpecies(aStone.megaStone);
+			if (dex.gen >= 8 && ['redorb', 'blueorb'].includes(aStone.id)) return this.errorReply("The Orbs do not exist in Gen 8 and later.");
+			if (aStone.id === 'redorb') { // Orbs do not have 'Item.megaStone' or 'Item.megaEvolves' properties.
 				megaSpecies = dex.getSpecies("Groudon-Primal");
 				baseSpecies = dex.getSpecies("Groudon");
-			} else if (singleStone.id === 'blueorb') {
+			} else if (aStone.id === 'blueorb') {
 				megaSpecies = dex.getSpecies("Kyogre-Primal");
 				baseSpecies = dex.getSpecies("Kyogre");
 			}
@@ -250,28 +250,28 @@ export const commands: ChatCommands = {
 				deltas.type = megaSpecies.types[1];
 			}
 			const details = {
-				Gen: singleStone.gen,
+				Gen: aStone.gen,
 				Weight: (deltas.weighthg < 0 ? "" : "+") + deltas.weighthg / 10 + " kg",
 			};
 			let tier;
-			if (['redorb', 'blueorb'].includes(singleStone.id)) {
+			if (['redorb', 'blueorb'].includes(aStone.id)) {
 				tier = "Orb";
-			} else if (singleStone.name === "Dragon Ascent") {
+			} else if (aStone.name === "Dragon Ascent") {
 				tier = "Move";
 			} else {
 				tier = "Stone";
 			}
 			let buf = `<li class="result">`;
 			buf += `<span class="col numcol">${tier}</span> `;
-			if (singleStone.name === "Dragon Ascent") {
+			if (aStone.name === "Dragon Ascent") {
 				buf += `<span class="col itemiconcol"></span>`;
 			} else {
-				buf += `<span class="col itemiconcol"><psicon item="${toID(singleStone)}"/></span> `;
+				buf += `<span class="col itemiconcol"><psicon item="${toID(aStone)}"/></span> `;
 			}
-			if (singleStone.name === "Dragon Ascent") {
+			if (aStone.name === "Dragon Ascent") {
 				buf += `<span class="col movenamecol" style="white-space:nowrap"><a href="https://${Config.routes.dex}/moves/${targetid}" target="_blank">Dragon Ascent</a></span> `;
 			} else {
-				buf += `<span class="col pokemonnamecol" style="white-space:nowrap"><a href="https://${Config.routes.dex}/items/${singleStone.id}" target="_blank">${singleStone.name}</a></span> `;
+				buf += `<span class="col pokemonnamecol" style="white-space:nowrap"><a href="https://${Config.routes.dex}/items/${aStone.id}" target="_blank">${aStone.name}</a></span> `;
 			}
 			if (deltas.type && deltas.type !== 'mono') {
 				buf += `<span class="col typecol"><img src="https://${Config.routes.client}/sprites/types/${deltas.type}.png" alt="${deltas.type}" height="14" width="32"></span> `;


### PR DESCRIPTION
Suggested in https://www.smogon.com/forums/threads/stone-pokemon-name-instead-of-stone-stone-name.3657629/#post-8620547


Behaviour:

Displays the stone for Pokemon with a single Mega Evolution (Beedrill, Bee, Beedrill-Mega)
Displays all stones if there are multiple Mega Evolutions (Mewtwo, Mewtwo-Mega)
Displays the relevant stone if a particular Mega Evolution is specified (Mewtwo-Mega-X)
Displays Dragon Ascent for Rayquaza-Mega (Rayquaza, Ray, Rayquaza-Mega)

All warnings have been retained.