### PR TITLE
Fix Jungle Healing when target's HP is full

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -9053,9 +9053,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {heal: 1, authentic: 1, mystery: 1},
 		onHit(pokemon) {
-			pokemon.cureStatus();
+			const success = !!this.heal(this.modify(pokemon.maxhp, 0.25));
+			return pokemon.cureStatus() || success;
 		},
-		heal: [1, 4],
 		secondary: null,
 		target: "allies",
 		type: "Grass",


### PR DESCRIPTION
Reported [here](https://www.smogon.com/forums/posts/8537785).

Additionally, Jungle Healing never says "[POKEMON]'s HP is full", it just says "But it failed!", so manually calling `this.heal()` fixes both issues. See @DaWoblefet's [video](https://youtu.be/q54mP60YC3c?t=378).