### PR TITLE
Fix exploit in dexsearch

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -78,6 +78,10 @@ export const commands: ChatCommands = {
 		this.checkBroadcast();
 		if (!target) return this.parse('/help dexsearch');
 		target = target.slice(0, 300);
+		// make sure there isn't more than 10 arguments to prevent exploitability
+		if (target.split(",").length > 10) {
+			target = target.split(",").splice(0, 10).join(",");
+		}
 		const targetGen = parseInt(cmd[cmd.length - 1]);
 		if (targetGen) target += `, maxgen${targetGen}`;
 		if (targetGen && targetGen === 5) {


### PR DESCRIPTION
a length of 300 just allows someone to `[do a thing]` over and over until it crashes a server from lag. This isn't as big of an issue on main as it is on side server due to main likely having a very high-end host in comparison to the average side server but it's still something I think should be patched since just to prevent any chance of it being a future issue else where.

If you want me to change the allowed argument limit  or handle it differently lmk, this was just the simplest and quickest fix I thought of