### PR TITLE
Stop using assert.strict.strictEqual

### DIFF
--- a/test/assert.js
+++ b/test/assert.js
@@ -10,7 +10,8 @@
 
 'use strict';
 
-const assert = require('assert').strict;
+const legacyAssert = require('assert');
+const assert = legacyAssert.strict;
 const AssertionError = assert.AssertionError;
 
 assert.bounded = function (value, range, message) {
@@ -192,6 +193,13 @@ assert.notStrictEqual = () => {
 assert.notDeepStrictEqual = () => {
 	throw new Error(`This API is deprecated; please use assert.notDeepEqual`);
 };
+for (const fn in legacyAssert) {
+	if (fn !== 'strict' && typeof legacyAssert[fn] === 'function') {
+		legacyAssert[fn] = () => {
+			throw new Error(`This API is deprecated; please use assert.strict`);
+		};
+	}
+}
 
 const assertMethods = Object.getOwnPropertyNames(assert).filter(methodName => (
 	methodName !== 'constructor' && methodName !== 'AssertionError' && typeof assert[methodName] === 'function'

--- a/test/assert.js
+++ b/test/assert.js
@@ -182,16 +182,19 @@ assert.sets = function (getter, value, fn, message) {
 };
 
 assert.strictEqual = () => {
-	throw new Error(`This API is deprecated; please use assert.equal`);
+	throw new Error(`This API is deprecated; please use assert.equal()`);
 };
 assert.deepStrictEqual = () => {
-	throw new Error(`This API is deprecated; please use assert.deepEqual`);
+	throw new Error(`This API is deprecated; please use assert.deepEqual()`);
 };
 assert.notStrictEqual = () => {
-	throw new Error(`This API is deprecated; please use assert.notEqual`);
+	throw new Error(`This API is deprecated; please use assert.notEqual()`);
 };
 assert.notDeepStrictEqual = () => {
-	throw new Error(`This API is deprecated; please use assert.notDeepEqual`);
+	throw new Error(`This API is deprecated; please use assert.notDeepEqual()`);
+};
+assert.ok = () => {
+	throw new Error(`This API is deprecated; please use assert()`);
 };
 for (const fn in legacyAssert) {
 	if (fn !== 'strict' && typeof legacyAssert[fn] === 'function') {

--- a/test/assert.js
+++ b/test/assert.js
@@ -167,7 +167,7 @@ assert.constant = function (getter, fn, message) {
 };
 
 assert.sets = function (getter, value, fn, message) {
-	assert.notStrictEqual(getter(), value, `Function was prematurely equal to ${value}.`);
+	assert.notEqual(getter(), value, `Function was prematurely equal to ${value}.`);
 	fn();
 	const finalValue = getter();
 	if (finalValue === value) return;
@@ -178,6 +178,19 @@ assert.sets = function (getter, value, fn, message) {
 		message: message,
 		stackStartFunction: assert.sets,
 	});
+};
+
+assert.strictEqual = () => {
+	throw new Error(`This API is deprecated; please use assert.equal`);
+};
+assert.deepStrictEqual = () => {
+	throw new Error(`This API is deprecated; please use assert.deepEqual`);
+};
+assert.notStrictEqual = () => {
+	throw new Error(`This API is deprecated; please use assert.notEqual`);
+};
+assert.notDeepStrictEqual = () => {
+	throw new Error(`This API is deprecated; please use assert.notDeepEqual`);
 };
 
 const assertMethods = Object.getOwnPropertyNames(assert).filter(methodName => (

--- a/test/common.js
+++ b/test/common.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert').strict;
+const assert = require('./assert');
 const Sim = require('./../.sim-dist');
 const Dex = Sim.Dex;
 

--- a/test/server/chat-commands/moderation.js
+++ b/test/server/chat-commands/moderation.js
@@ -63,6 +63,6 @@ describe('room promotions', () => {
 
 	it('should update Room#auth', () => {
 		moderation.runPromote(this.user, this.room, this.targetUser.id, '#', undefined, true);
-		assert.strictEqual(this.room.auth.get(this.targetUser.id), '#');
+		assert.equal(this.room.auth.get(this.targetUser.id), '#');
 	});
 });

--- a/test/server/chat-plugins/help.js
+++ b/test/server/chat-plugins/help.js
@@ -24,7 +24,7 @@ describe('Help', function () {
 
 	it('should produce valid regexes', function () {
 		const regexString = Help.stringRegex(`uwu & awa`);
-		assert.strictEqual(regexString, "(?=.*?(uwu))(?=.*?(awa))");
+		assert.equal(regexString, "(?=.*?(uwu))(?=.*?(awa))");
 		const regex = new RegExp(regexString);
 		assert.ok(regex.test('uwu awa'));
 	});

--- a/test/server/chat-plugins/help.js
+++ b/test/server/chat-plugins/help.js
@@ -18,28 +18,28 @@ describe('Help', function () {
 	it('should only return true on added regexes', function () {
 		Help.data.pairs.catra = [];
 		Help.data.pairs.catra.push(Help.stringRegex(`Hey & Adora`));
-		assert.ok(Help.match('Hey, Adora', 'catra'));
-		assert.ok(!Help.match('Hello, Adora', 'catra'));
+		assert(Help.match('Hey, Adora', 'catra'));
+		assert(!Help.match('Hello, Adora', 'catra'));
 	});
 
 	it('should produce valid regexes', function () {
 		const regexString = Help.stringRegex(`uwu & awa`);
 		assert.equal(regexString, "(?=.*?(uwu))(?=.*?(awa))");
 		const regex = new RegExp(regexString);
-		assert.ok(regex.test('uwu awa'));
+		assert(regex.test('uwu awa'));
 	});
 	it('should handle |, &, and ! correctly', function () {
 		const and = new RegExp(Help.stringRegex(`Horde & Prime`));
-		assert.ok(and.test('Horde Prime'));
-		assert.ok(!and.test('Horde'));
+		assert(and.test('Horde Prime'));
+		assert(!and.test('Horde'));
 
 		const or = new RegExp(Help.stringRegex(`she-ra|sea-ra`));
-		assert.ok(or.test('sea-ra'));
-		assert.ok(or.test(`she-ra`));
-		assert.ok(!or.test('ADVENTURE'));
+		assert(or.test('sea-ra'));
+		assert(or.test(`she-ra`));
+		assert(!or.test('ADVENTURE'));
 
 		const ignore = new RegExp(Help.stringRegex(`!Hordak`));
-		assert.ok(ignore.test(`FOR THE HONOR OF GREYSKULL`));
-		assert.ok(!ignore.test('Hordak'));
+		assert(ignore.test(`FOR THE HONOR OF GREYSKULL`));
+		assert(!ignore.test('Hordak'));
 	});
 });

--- a/test/server/chat-plugins/hosts.js
+++ b/test/server/chat-plugins/hosts.js
@@ -10,7 +10,7 @@ const hosts = require('../../../.server-dist/chat-plugins/hosts');
 
 describe("Hosts plugin", () => {
 	it('should properly visualize an empty list of ranges', () => {
-		assert.strictEqual(
+		assert.equal(
 			hosts.visualizeRangeList([]),
 			`<tr><th>Lowest IP address</th><th>Highest IP address</th><th>Host</th></tr>`
 		);

--- a/test/server/chat-plugins/repeats.js
+++ b/test/server/chat-plugins/repeats.js
@@ -34,7 +34,7 @@ describe("Repeats plugin", () => {
 		assert.ok(this.room.settings.repeats.some(repeat => repeat.phrase === "^_-"));
 
 		Repeats.removeRepeat(this.room, 'weirdface');
-		assert.strictEqual(Repeats.repeats.get(this.room).get('weirdface'), undefined);
+		assert.equal(Repeats.repeats.get(this.room).get('weirdface'), undefined);
 		assert.ok(!this.room.settings.repeats.some(repeat => repeat.phrase === "^_-"));
 	});
 

--- a/test/server/chat-plugins/repeats.js
+++ b/test/server/chat-plugins/repeats.js
@@ -14,37 +14,37 @@ describe("Repeats plugin", () => {
 	});
 
 	it('should add repeats correctly', () => {
-		assert.ok(!Repeats.repeats.has(this.room));
+		assert(!Repeats.repeats.has(this.room));
 
 		Repeats.addRepeat(this.room, {id: 'happyface', phrase: "^_^", interval: 1});
 
-		assert.ok(Repeats.repeats.has(this.room));
+		assert(Repeats.repeats.has(this.room));
 
-		assert.ok(Repeats.repeats.get(this.room).has('happyface'));
+		assert(Repeats.repeats.get(this.room).has('happyface'));
 
-		assert.ok(Repeats.repeats.get(this.room).get('happyface').has("^_^"));
+		assert(Repeats.repeats.get(this.room).get('happyface').has("^_^"));
 
-		assert.ok(this.room.settings.repeats);
-		assert.ok(this.room.settings.repeats.some(repeat => repeat.phrase === "^_^"));
+		assert(this.room.settings.repeats);
+		assert(this.room.settings.repeats.some(repeat => repeat.phrase === "^_^"));
 	});
 
 	it('should remove repeats correctly', () => {
 		Repeats.addRepeat(this.room, {id: 'weirdface', phrase: "^_-", interval: 1});
-		assert.ok(Repeats.repeats.get(this.room).get('weirdface').has("^_-"));
-		assert.ok(this.room.settings.repeats.some(repeat => repeat.phrase === "^_-"));
+		assert(Repeats.repeats.get(this.room).get('weirdface').has("^_-"));
+		assert(this.room.settings.repeats.some(repeat => repeat.phrase === "^_-"));
 
 		Repeats.removeRepeat(this.room, 'weirdface');
 		assert.equal(Repeats.repeats.get(this.room).get('weirdface'), undefined);
-		assert.ok(!this.room.settings.repeats.some(repeat => repeat.phrase === "^_-"));
+		assert(!this.room.settings.repeats.some(repeat => repeat.phrase === "^_-"));
 	});
 
 	it('should be able to tell if a repeat exists or not', () => {
-		assert.ok(!Repeats.hasRepeat(this.room, 'annoyedface'));
+		assert(!Repeats.hasRepeat(this.room, 'annoyedface'));
 
 		Repeats.addRepeat(this.room, {id: 'annoyedface', phrase: "-_-", interval: 1});
-		assert.ok(Repeats.hasRepeat(this.room, 'annoyedface'));
+		assert(Repeats.hasRepeat(this.room, 'annoyedface'));
 
 		Repeats.removeRepeat(this.room, 'annoyedface');
-		assert.ok(!Repeats.hasRepeat(this.room, 'annoyedface'));
+		assert(!Repeats.hasRepeat(this.room, 'annoyedface'));
 	});
 });

--- a/test/server/chat-plugins/trivia.js
+++ b/test/server/chat-plugins/trivia.js
@@ -204,7 +204,7 @@ describe('Trivia', function () {
 			this.user.joinRoom(this.room);
 			assert.equal(this.player.isAbsent, false);
 			assert.equal(this.game.phase, 'question');
-			assert.ok(this.game.phaseTimeout);
+			assert(this.game.phaseTimeout);
 		});
 	});
 
@@ -268,7 +268,7 @@ describe('Trivia', function () {
 		it('should not give NaN points to correct responders', function () {
 			this.game.answerQuestion('answer', this.user);
 			this.game.tallyAnswers();
-			assert.ok(!isNaN(this.player.points));
+			assert(!isNaN(this.player.points));
 		});
 	});
 
@@ -334,7 +334,7 @@ describe('Trivia', function () {
 				const hrtimeToNanoseconds = hrtime => hrtime[0] * 1e9 + hrtime[1];
 				const playerNs = hrtimeToNanoseconds(this.player.answeredAt);
 				const player2Ns = hrtimeToNanoseconds(this.game.playerTable[this.user2.id].answeredAt);
-				assert.ok(playerNs <= player2Ns);
+				assert(playerNs <= player2Ns);
 
 				done();
 			});
@@ -343,7 +343,7 @@ describe('Trivia', function () {
 		it('should not give NaN points to correct responders', function () {
 			this.game.answerQuestion('answer', this.user);
 			this.game.tallyAnswers();
-			assert.ok(!isNaN(this.player.points));
+			assert(!isNaN(this.player.points));
 		});
 	});
 
@@ -402,7 +402,7 @@ describe('Trivia', function () {
 		it('should not give NaN points to correct responders', function () {
 			this.game.answerQuestion('answer', this.user);
 			this.game.tallyAnswers();
-			assert.ok(!isNaN(this.player.points));
+			assert(!isNaN(this.player.points));
 		});
 	});
 

--- a/test/server/chat-plugins/trivia.js
+++ b/test/server/chat-plugins/trivia.js
@@ -58,13 +58,13 @@ describe('Trivia', function () {
 
 	it('should add new players', function () {
 		this.game.addTriviaPlayer(this.user);
-		assert.strictEqual(this.game.playerCount, 1);
+		assert.equal(this.game.playerCount, 1);
 	});
 
 	it('should not add a player if they have already joined', function () {
 		this.game.addTriviaPlayer(this.user);
 		assert.throws(() => this.game.addTriviaPlayer(this.user));
-		assert.strictEqual(this.game.playerCount, 1);
+		assert.equal(this.game.playerCount, 1);
 	});
 
 	it('should not add a player if another one on the same IP has joined', function () {
@@ -73,7 +73,7 @@ describe('Trivia', function () {
 		const user2 = makeUser('Not Morfent', new Connection('127.0.0.1'));
 		assert.throws(() => this.game.addTriviaPlayer(user2));
 
-		assert.strictEqual(this.game.playerCount, 1);
+		assert.equal(this.game.playerCount, 1);
 		destroyUser(user2);
 	});
 
@@ -87,20 +87,20 @@ describe('Trivia', function () {
 		const user2 = makeUser(name, new Connection('127.0.0.3'));
 		assert.throws(() => this.game.addTriviaPlayer(user2));
 
-		assert.strictEqual(this.game.playerCount, 1);
+		assert.equal(this.game.playerCount, 1);
 		destroyUser(user2);
 	});
 
 	it('should not add a player if they were kicked from the game', function () {
 		this.game.kickedUsers.add(this.tarUser.id);
 		assert.throws(() => this.game.addTriviaPlayer(this.tarUser));
-		assert.strictEqual(this.game.playerCount, 0);
+		assert.equal(this.game.playerCount, 0);
 	});
 
 	it('should kick players from the game', function () {
 		this.game.addTriviaPlayer(this.tarUser);
 		this.game.kick(this.tarUser, this.user);
-		assert.strictEqual(this.game.playerCount, 0);
+		assert.equal(this.game.playerCount, 0);
 	});
 
 	it('should not kick players already kicked from the game', function () {
@@ -117,7 +117,7 @@ describe('Trivia', function () {
 		this.tarUser.forceRename('Not Morfent', true);
 		this.tarUser.previousIDs.push(userid);
 		assert.throws(() => this.game.addTriviaPlayer(this.tarUser));
-		assert.strictEqual(this.game.playerCount, 0);
+		assert.equal(this.game.playerCount, 0);
 	});
 
 	it('should not add users who were kicked under another IP', function () {
@@ -129,32 +129,32 @@ describe('Trivia', function () {
 
 		const user2 = makeUser(name, new Connection('127.0.0.2'));
 		assert.throws(() => this.game.addTriviaPlayer(user2));
-		assert.strictEqual(this.game.playerCount, 0);
+		assert.equal(this.game.playerCount, 0);
 		destroyUser(user2);
 	});
 
 	it('should not kick users that aren\'t players in the game', function () {
 		assert.throws(() => this.game.kick(this.tarUser, this.user));
-		assert.strictEqual(this.game.playerCount, 0);
+		assert.equal(this.game.playerCount, 0);
 	});
 
 	it('should make players leave the game', function () {
 		this.game.addTriviaPlayer(this.user);
-		assert.strictEqual(typeof this.game.playerTable[this.user.id], 'object');
+		assert.equal(typeof this.game.playerTable[this.user.id], 'object');
 		this.game.leave(this.user);
-		assert.strictEqual(typeof this.game.playerTable[this.user.id], 'undefined');
+		assert.equal(typeof this.game.playerTable[this.user.id], 'undefined');
 	});
 
 	it('should not make users who are not players leave the game', function () {
-		assert.strictEqual(typeof this.game.playerTable[this.user.id], 'undefined');
+		assert.equal(typeof this.game.playerTable[this.user.id], 'undefined');
 		assert.throws(() => this.game.leave(this.user));
 	});
 
 	it('should verify answers correctly', function () {
 		this.game.askQuestion();
-		assert.strictEqual(this.game.verifyAnswer('answer'), true);
-		assert.strictEqual(this.game.verifyAnswer('anser'), true);
-		assert.strictEqual(this.game.verifyAnswer('not the right answer'), false);
+		assert.equal(this.game.verifyAnswer('answer'), true);
+		assert.equal(this.game.verifyAnswer('anser'), true);
+		assert.equal(this.game.verifyAnswer('not the right answer'), false);
 	});
 
 	context('marking player absence', function () {
@@ -194,16 +194,16 @@ describe('Trivia', function () {
 
 		it('should mark a player absent on leave and pause the game', function () {
 			this.user.leaveRoom(this.room);
-			assert.strictEqual(this.player.isAbsent, true);
-			assert.strictEqual(this.game.phase, 'limbo');
-			assert.strictEqual(this.game.phaseTimeout, null);
+			assert.equal(this.player.isAbsent, true);
+			assert.equal(this.game.phase, 'limbo');
+			assert.equal(this.game.phaseTimeout, null);
 		});
 
 		it('should unpause the game once enough players have returned', function () {
 			this.user.leaveRoom(this.room);
 			this.user.joinRoom(this.room);
-			assert.strictEqual(this.player.isAbsent, false);
-			assert.strictEqual(this.game.phase, 'question');
+			assert.equal(this.player.isAbsent, false);
+			assert.equal(this.game.phase, 'question');
 			assert.ok(this.game.phaseTimeout);
 		});
 	});
@@ -240,29 +240,29 @@ describe('Trivia', function () {
 
 		it('should calculate player points correctly', function () {
 			const points = this.game.calculatePoints();
-			assert.strictEqual(points, 5);
+			assert.equal(points, 5);
 		});
 
 		it('should allow users to answer questions correctly', function () {
 			this.game.answerQuestion('answer', this.user);
-			assert.strictEqual(this.player.correctAnswers, 1);
+			assert.equal(this.player.correctAnswers, 1);
 		});
 
 		it('should mark players who answer incorrectly', function () {
 			this.game.answerQuestion('not the right answer', this.user);
-			assert.strictEqual(this.player.correctAnswers, 0);
+			assert.equal(this.player.correctAnswers, 0);
 		});
 
 		it('should only reward a player points once per question', function () {
 			this.game.answerQuestion('answer', this.user);
 			assert.throws(() => this.game.answerQuestion('answer', this.user));
-			assert.strictEqual(this.player.correctAnswers, 1);
+			assert.equal(this.player.correctAnswers, 1);
 		});
 
 		it('should clear player answers if none answer correctly', function () {
 			this.game.answerQuestion('not the right answer', this.user);
 			this.game.tallyAnswers();
-			assert.strictEqual(this.player.answer, '');
+			assert.equal(this.player.answer, '');
 		});
 
 		it('should not give NaN points to correct responders', function () {
@@ -308,21 +308,21 @@ describe('Trivia', function () {
 			for (let i = 6; i--;) {
 				diff += totalDiff / 5;
 				const points = this.game.calculatePoints(diff, totalDiff);
-				assert.strictEqual(points, i);
+				assert.equal(points, i);
 			}
 		});
 
 		it('should set players as having answered correctly or incorrectly', function () {
 			this.game.answerQuestion('not the right answer', this.user);
-			assert.strictEqual(this.player.isCorrect, false);
+			assert.equal(this.player.isCorrect, false);
 			this.game.answerQuestion('answer', this.user);
-			assert.strictEqual(this.player.isCorrect, true);
+			assert.equal(this.player.isCorrect, true);
 		});
 
 		it('should give points for correct answers', function () {
 			this.game.answerQuestion('answer', this.user);
 			this.game.tallyAnswers();
-			assert.strictEqual(this.player.correctAnswers, 1);
+			assert.equal(this.player.correctAnswers, 1);
 		});
 
 		it('should choose the quicker answerer on tie', function (done) {
@@ -380,7 +380,7 @@ describe('Trivia', function () {
 		it('should calculate points correctly', function () {
 			this.game.playerCount = 5;
 			for (let i = 1; i <= 5; i++) {
-				assert.strictEqual(this.game.calculatePoints(i), 6 - i);
+				assert.equal(this.game.calculatePoints(i), 6 - i);
 			}
 		});
 
@@ -390,13 +390,13 @@ describe('Trivia', function () {
 		it('should not give points for answering incorrectly', function () {
 			this.game.answerQuestion('not the right answer', this.user);
 			this.game.tallyAnswers();
-			assert.strictEqual(this.player.correctAnswers, 0);
+			assert.equal(this.player.correctAnswers, 0);
 		});
 
 		it('should give points for answering correctly', function () {
 			this.game.answerQuestion('answer', this.user);
 			this.game.tallyAnswers();
-			assert.strictEqual(this.player.correctAnswers, 1);
+			assert.equal(this.player.correctAnswers, 1);
 		});
 
 		it('should not give NaN points to correct responders', function () {
@@ -433,8 +433,8 @@ describe('Trivia', function () {
 			trivia.requestAltMerge('heartofetheria', 'annika');
 			trivia.mergeAlts('heartofetheria', 'annika');
 
-			assert.deepStrictEqual(trivia.triviaData.leaderboard.annika, [4, 4, 4]);
-			assert.strictEqual(trivia.triviaData.leaderboard.heartofetheria, undefined);
+			assert.deepEqual(trivia.triviaData.leaderboard.annika, [4, 4, 4]);
+			assert.equal(trivia.triviaData.leaderboard.heartofetheria, undefined);
 		});
 	});
 });

--- a/test/server/chat-plugins/youtube.js
+++ b/test/server/chat-plugins/youtube.js
@@ -22,8 +22,8 @@ describe(`Youtube features`, function () {
 		const url = 'https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw';
 		const channelId = 'UCuAXFkgsw1L7xaCfnd5JJOw';
 		await Youtube.getChannelData(url, 'Pickle Rick');
-		assert.strictEqual(channelId, Youtube.channelSearch('Pickle Rick'));
-		assert.strictEqual(channelId, Youtube.channelSearch('Official Rick Astley'));
+		assert.equal(channelId, Youtube.channelSearch('Pickle Rick'));
+		assert.equal(channelId, Youtube.channelSearch('Official Rick Astley'));
 	});
 
 	it.skip(`should correctly parse channel links`, function () {
@@ -32,8 +32,8 @@ describe(`Youtube features`, function () {
 		const channelUrl = 'https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw';
 		const Youtube = new YoutubeInterface({});
 		const videoId = Youtube.getId(videoUrl);
-		assert.strictEqual(videoId, 'dQw4w9WgXcQ');
+		assert.equal(videoId, 'dQw4w9WgXcQ');
 		const channelId = Youtube.getId(channelUrl);
-		assert.strictEqual(channelId, 'UCuAXFkgsw1L7xaCfnd5JJOw');
+		assert.equal(channelId, 'UCuAXFkgsw1L7xaCfnd5JJOw');
 	});
 });

--- a/test/server/chat-plugins/youtube.js
+++ b/test/server/chat-plugins/youtube.js
@@ -13,7 +13,7 @@ describe(`Youtube features`, function () {
 		const Youtube = new YoutubeInterface({});
 		const url = 'https://www.youtube.com/channel/UCuAXFkgsw1L7xaCfnd5JJOw';
 		await Youtube.getChannelData(url, undefined);
-		assert.ok(Youtube.data['UCuAXFkgsw1L7xaCfnd5JJOw']);
+		assert(Youtube.data['UCuAXFkgsw1L7xaCfnd5JJOw']);
 	});
 
 	it.skip(`should correctly handle PS names and channel names`, async function () {

--- a/test/server/ip-tools.js
+++ b/test/server/ip-tools.js
@@ -11,25 +11,25 @@ const IPTools = require('../../.server-dist/ip-tools').IPTools;
 describe("IP tools", () => {
 	it('should resolve 127.0.0.1 to localhost', async () => {
 		const lookup = await IPTools.lookup('127.0.0.1');
-		assert.strictEqual(lookup.host, 'localhost');
+		assert.equal(lookup.host, 'localhost');
 	});
 
 	it('should resolve unknown IPs correctly', async () => {
 		const lookup = await IPTools.lookup('255.255.255.255');
-		assert.strictEqual(lookup.host, '255.255?/unknown');
-		assert.strictEqual(lookup.hostType, 'unknown');
+		assert.equal(lookup.host, '255.255?/unknown');
+		assert.equal(lookup.hostType, 'unknown');
 	});
 
 	it('should parse CIDR ranges', () => {
 		const range = IPTools.getCidrRange('42.42.0.0/18');
-		assert.strictEqual(range.minIP, IPTools.ipToNumber('42.42.0.0'));
-		assert.strictEqual(range.maxIP, IPTools.ipToNumber('42.42.63.255'));
+		assert.equal(range.minIP, IPTools.ipToNumber('42.42.0.0'));
+		assert.equal(range.maxIP, IPTools.ipToNumber('42.42.63.255'));
 	});
 
 	it('should guess whether a range is CIDR or hyphen', () => {
 		const cidrRange = IPTools.stringToRange('42.42.0.0/18');
 		const stringRange = IPTools.stringToRange('42.42.0.0 - 42.42.63.255');
-		assert.deepStrictEqual(cidrRange, stringRange);
+		assert.deepEqual(cidrRange, stringRange);
 	});
 
 	it('should check if an IP is in a range', () => {
@@ -49,22 +49,22 @@ describe("IP tools", () => {
 	});
 
 	it('should handle wildcards in string ranges', () => {
-		assert.deepStrictEqual(
+		assert.deepEqual(
 			IPTools.stringToRange('1.*'),
 			{minIP: IPTools.ipToNumber('1.0.0.0'), maxIP: IPTools.ipToNumber('1.255.255.255')}
 		);
-		assert.deepStrictEqual(
+		assert.deepEqual(
 			IPTools.stringToRange('1.1.*'),
 			{minIP: IPTools.ipToNumber('1.1.0.0'), maxIP: IPTools.ipToNumber('1.1.255.255')}
 		);
-		assert.deepStrictEqual(
+		assert.deepEqual(
 			IPTools.stringToRange('1.1.1.*'),
 			{minIP: IPTools.ipToNumber('1.1.1.0'), maxIP: IPTools.ipToNumber('1.1.1.255')}
 		);
 	});
 
 	it('should handle single IPs as string ranges', () => {
-		assert.deepStrictEqual(
+		assert.deepEqual(
 			IPTools.stringToRange('1.1.1.1'),
 			{minIP: IPTools.ipToNumber('1.1.1.1'), maxIP: IPTools.ipToNumber('1.1.1.1')}
 		);
@@ -76,7 +76,7 @@ describe("IP tools helper functions", () => {
 		const numTests = 10;
 		for (let i = 0; i < numTests; i++) {
 			const testNumber = Math.floor(Math.random() * 4294967294) + 1;
-			assert.strictEqual(IPTools.ipToNumber(IPTools.numberToIP(testNumber)), testNumber);
+			assert.equal(IPTools.ipToNumber(IPTools.numberToIP(testNumber)), testNumber);
 		}
 	});
 
@@ -85,19 +85,19 @@ describe("IP tools helper functions", () => {
 		const sortedIPs = ['2.3.4.5', '2.3.5.4', '100.1.1.1', '150.255.255.255', '240.0.0.0'];
 		const sortedIPNumbers = unsortedIPs.map(ip => IPTools.ipToNumber(ip));
 		sortedIPNumbers.sort((a, b) => a - b);
-		assert.deepStrictEqual(sortedIPNumbers.map(ipnum => IPTools.numberToIP(ipnum)), sortedIPs);
+		assert.deepEqual(sortedIPNumbers.map(ipnum => IPTools.numberToIP(ipnum)), sortedIPs);
 	});
 
 	it('should convert URLs to hosts', () => {
-		assert.strictEqual(IPTools.urlToHost('https://www.annika.codes/some/path'), 'annika.codes');
-		assert.strictEqual(IPTools.urlToHost('http://annika.codes/path'), 'annika.codes');
-		assert.strictEqual(IPTools.urlToHost('https://annika.codes/'), 'annika.codes');
+		assert.equal(IPTools.urlToHost('https://www.annika.codes/some/path'), 'annika.codes');
+		assert.equal(IPTools.urlToHost('http://annika.codes/path'), 'annika.codes');
+		assert.equal(IPTools.urlToHost('https://annika.codes/'), 'annika.codes');
 	});
 
 	it('should correctly sort a list of IP addresses', () => {
 		const ipList = ['2.3.4.5', '100.1.1.1', '2.3.5.4', '150.255.255.255', '240.0.0.0'];
 		ipList.sort(IPTools.ipSort);
-		assert.deepStrictEqual(ipList, ['2.3.4.5', '2.3.5.4', '100.1.1.1', '150.255.255.255', '240.0.0.0']);
+		assert.deepEqual(ipList, ['2.3.4.5', '2.3.5.4', '100.1.1.1', '150.255.255.255', '240.0.0.0']);
 	});
 });
 

--- a/test/server/ladders.js
+++ b/test/server/ladders.js
@@ -45,10 +45,10 @@ describe('Matchmaker', function () {
 
 	it('should add a search', function () {
 		const s1 = addSearch(this.p1);
-		assert.ok(Ladders.searches.has(FORMATID));
+		assert(Ladders.searches.has(FORMATID));
 
 		const formatSearches = Ladders.searches.get(FORMATID);
-		assert.ok(formatSearches instanceof Map);
+		assert(formatSearches instanceof Map);
 		assert.equal(formatSearches.size, 1);
 		assert.equal(s1.userid, this.p1.id);
 		assert.equal(s1.team, this.p1.battleSettings.team);
@@ -90,7 +90,7 @@ describe('Matchmaker', function () {
 		addSearch(this.p2);
 		assert.equal(this.p1.games.size, 1);
 		for (const roomid of this.p1.games) {
-			assert.ok(Rooms.get(roomid).battle);
+			assert(Rooms.get(roomid).battle);
 		}
 	});
 

--- a/test/server/modlog.js
+++ b/test/server/modlog.js
@@ -130,7 +130,7 @@ describe.skip('Modlog (with FS writes)', () => {
 		await modlog.destroy('newroom'); // ensure all writes have synced to disk
 
 		lastLine = (await getLines('newroom')).lastLine;
-		assert.strictEqual(
+		assert.equal(
 			normalizeModlogEntry(lastLine),
 			normalizeModlogEntry('[2020-07-29T23:29:49.797Z] (newroom) ROOMBAN: [kjnhvgcfg] [127.0.0.1] by annika')
 		);
@@ -142,7 +142,7 @@ describe.skip('Modlog (with FS writes)', () => {
 		await modlog.destroy('battle-gen8randombattle-1337'); // ensure all writes have synced to disk
 
 		const lastLine = (await getLines('battle-gen8randombattle-1337')).lastLine;
-		assert.strictEqual(
+		assert.equal(
 			normalizeModlogEntry(lastLine),
 			normalizeModlogEntry('[2020-07-29T23:29:49.797Z] (actually this: cool name) MODCHAT: by annika: to +')
 		);
@@ -167,15 +167,15 @@ describe.skip('Modlog (with FS writes)', () => {
 		const exactUpper = await modlog.runSearch(['readingtest'], 'sOmEtRoLl', true, 10000, false);
 		const exactLower = await modlog.runSearch(['readingtest'], 'sOmEtRoLl', true, 10000, false);
 
-		assert.deepStrictEqual(notExactUpper, notExactLower);
-		assert.deepStrictEqual(exactUpper, exactLower);
+		assert.deepEqual(notExactUpper, notExactLower);
+		assert.deepEqual(exactUpper, exactLower);
 	});
 
 	it('should respect isExact', async () => {
 		const notExact = await modlog.runSearch(['readingtest'], 'troll', false, 10000, false);
 		const exact = await modlog.runSearch(['readingtest'], 'troll', true, 10000, false);
 
-		assert.strictEqual(notExact.length, 0);
+		assert.equal(notExact.length, 0);
 		assert.ok(exact.length);
 	});
 
@@ -187,7 +187,7 @@ describe.skip('Modlog (with FS writes)', () => {
 
 		const search = await modlog.runSearch(['lifotest'], '', false, 10000, false);
 
-		assert.strictEqual(search.length, 2);
+		assert.equal(search.length, 2);
 
 		assert.ok(search[0].includes('secondwrite'));
 		assert.ok(!search[0].includes('firstwrite'));
@@ -218,7 +218,7 @@ describe.skip('Modlog (with FS writes)', () => {
 		const onlyPunishments = await modlog.runSearch(['readingtest2'], '', false, 10000, true);
 
 		assert.ok(all.length > onlyPunishments.length);
-		assert.strictEqual(
+		assert.equal(
 			onlyPunishments.filter(result => result.includes('ROOMBAN')).length,
 			onlyPunishments.length
 		);

--- a/test/server/modlog.js
+++ b/test/server/modlog.js
@@ -48,12 +48,12 @@ async function getLines(roomid) {
 
 describe('Modlog (without FS writes)', () => {
 	it('should correctly determine if a room has a shared modlog', () => {
-		assert.ok(modlog.getSharedID('battle-gen8randombattle-42'));
-		assert.ok(modlog.getSharedID('groupchat-annika-shitposting'));
-		assert.ok(modlog.getSharedID('help-mePleaseIAmTrappedInAUnitTestFactory'));
+		assert(modlog.getSharedID('battle-gen8randombattle-42'));
+		assert(modlog.getSharedID('groupchat-annika-shitposting'));
+		assert(modlog.getSharedID('help-mePleaseIAmTrappedInAUnitTestFactory'));
 
-		assert.ok(!modlog.getSharedID('1v1'));
-		assert.ok(!modlog.getSharedID('development'));
+		assert(!modlog.getSharedID('1v1'));
+		assert(!modlog.getSharedID('development'));
 	});
 
 	it('should throw an error when writing to a destroyed modlog stream', () => {
@@ -120,11 +120,11 @@ describe.skip('Modlog (with FS writes)', () => {
 		modlog.write('oldroom', message);
 		await modlog.rename('oldroom', 'newroom');
 
-		assert.ok(FS(`${TEST_PATH}/modlog_newroom.txt`).existsSync());
+		assert(FS(`${TEST_PATH}/modlog_newroom.txt`).existsSync());
 		assert.throws(() => modlog.write('oldroom', 'something'));
 
 		let lastLine = (await getLines('newroom')).lastLine;
-		assert.ok(messageRegex.test(lastLine));
+		assert(messageRegex.test(lastLine));
 
 		modlog.write('newroom', 'ROOMBAN: [kjnhvgcfg] [127.0.0.1] by annika');
 		await modlog.destroy('newroom'); // ensure all writes have synced to disk
@@ -176,7 +176,7 @@ describe.skip('Modlog (with FS writes)', () => {
 		const exact = await modlog.runSearch(['readingtest'], 'troll', true, 10000, false);
 
 		assert.equal(notExact.length, 0);
-		assert.ok(exact.length);
+		assert(exact.length);
 	});
 
 	it('should be LIFO (last-in, first-out)', async () => {
@@ -189,11 +189,11 @@ describe.skip('Modlog (with FS writes)', () => {
 
 		assert.equal(search.length, 2);
 
-		assert.ok(search[0].includes('secondwrite'));
-		assert.ok(!search[0].includes('firstwrite'));
+		assert(search[0].includes('secondwrite'));
+		assert(!search[0].includes('firstwrite'));
 
-		assert.ok(search[1].includes('firstwrite'));
-		assert.ok(!search[1].includes('secondwrite'));
+		assert(search[1].includes('firstwrite'));
+		assert(!search[1].includes('secondwrite'));
 	});
 
 	it('should support limiting the number of responses', async () => {
@@ -201,23 +201,23 @@ describe.skip('Modlog (with FS writes)', () => {
 		const limited = await modlog.runSearch(['readingtest'], '', false, 5, false);
 
 		assert.equal(limited.length, 5);
-		assert.ok(unlimited.length > limited.length);
+		assert(unlimited.length > limited.length);
 
-		assert.ok(limited[0].includes('LAST ENTRY'));
-		assert.ok(unlimited[0].includes('LAST ENTRY'));
+		assert(limited[0].includes('LAST ENTRY'));
+		assert(unlimited[0].includes('LAST ENTRY'));
 
 		const limitedLast = limited.pop();
 		const unlimitedLast = unlimited.pop();
 
-		assert.ok(!limitedLast.includes('FIRST ENTRY'));
-		assert.ok(unlimitedLast.includes('FIRST ENTRY'));
+		assert(!limitedLast.includes('FIRST ENTRY'));
+		assert(unlimitedLast.includes('FIRST ENTRY'));
 	});
 
 	it('should support filtering out non-punishment-related logs', async () => {
 		const all = await modlog.runSearch(['readingtest2'], '', false, 10000, false);
 		const onlyPunishments = await modlog.runSearch(['readingtest2'], '', false, 10000, true);
 
-		assert.ok(all.length > onlyPunishments.length);
+		assert(all.length > onlyPunishments.length);
 		assert.equal(
 			onlyPunishments.filter(result => result.includes('ROOMBAN')).length,
 			onlyPunishments.length

--- a/test/server/rooms.js
+++ b/test/server/rooms.js
@@ -13,7 +13,7 @@ describe('Rooms features', function () {
 		});
 		describe('Rooms.rooms', function () {
 			it('should be a Map', function () {
-				assert.ok(Rooms.rooms instanceof Map);
+				assert(Rooms.rooms instanceof Map);
 			});
 		});
 	});
@@ -57,7 +57,7 @@ describe('Rooms features', function () {
 					p1team: packedTeam,
 					p2team: packedTeam,
 				}, option));
-				assert.ok(room.battle.p1 && room.battle.p2); // Automatically joined
+				assert(room.battle.p1 && room.battle.p2); // Automatically joined
 			}
 		});
 

--- a/test/server/rooms.js
+++ b/test/server/rooms.js
@@ -135,15 +135,15 @@ describe('Rooms features', function () {
 			it("should rename its roomid and title", async function () {
 				room = Rooms.createChatRoom("test", "Test");
 				await room.rename("Test2");
-				assert.strictEqual(room.roomid, "test2");
-				assert.strictEqual(room.title, "Test2");
+				assert.equal(room.roomid, "test2");
+				assert.equal(room.title, "Test2");
 			});
 
 			it("should rename its key in Rooms.rooms", async function () {
 				room = Rooms.createChatRoom("test", "Test");
 				await room.rename("Test2");
-				assert.strictEqual(Rooms.rooms.has("test"), false);
-				assert.strictEqual(Rooms.rooms.has("test2"), true);
+				assert.equal(Rooms.rooms.has("test"), false);
+				assert.equal(Rooms.rooms.has("test2"), true);
 			});
 
 			it("should move the users and their connections", async function () {
@@ -151,25 +151,25 @@ describe('Rooms features', function () {
 				const user = new User();
 				user.joinRoom(room);
 				await room.rename("Test2");
-				assert.strictEqual(user.inRooms.has("test"), false);
-				assert.strictEqual(user.inRooms.has("test2"), true);
-				assert.strictEqual(user.connections[0].inRooms.has("test"), false);
-				assert.strictEqual(user.connections[0].inRooms.has("test2"), true);
+				assert.equal(user.inRooms.has("test"), false);
+				assert.equal(user.inRooms.has("test2"), true);
+				assert.equal(user.connections[0].inRooms.has("test"), false);
+				assert.equal(user.connections[0].inRooms.has("test2"), true);
 			});
 
 			it("should rename their parents subroom reference", async function () {
 				parent = Rooms.createChatRoom("parent", "Parent");
 				subroom = Rooms.createChatRoom("subroom", "Subroom", {parentid: "parent"});
 				await subroom.rename("TheSubroom");
-				assert.strictEqual(parent.subRooms.has("subroom"), false);
-				assert.strictEqual(parent.subRooms.has("thesubroom"), true);
+				assert.equal(parent.subRooms.has("subroom"), false);
+				assert.equal(parent.subRooms.has("thesubroom"), true);
 			});
 
 			it("should rename their subrooms parent reference", async function () {
 				parent = Rooms.createChatRoom("parent", "Parent");
 				subroom = Rooms.createChatRoom("subroom", "Subroom", {parentid: "parent"});
 				await parent.rename("TheParent");
-				assert.strictEqual(subroom.parent, parent);
+				assert.equal(subroom.parent, parent);
 			});
 		});
 	});

--- a/test/server/sockets.js
+++ b/test/server/sockets.js
@@ -96,7 +96,7 @@ describe('Sockets', function () {
 					process.send(!socket);`;
 				Sockets.socketDisconnect(worker, sid);
 			}).then(chain(worker => data => {
-				assert.ok(data);
+				assert(data);
 			}, querySocket));
 		});
 
@@ -140,7 +140,7 @@ describe('Sockets', function () {
 					process.send(room && room.has(${sid}));`;
 				Sockets.roomAdd(worker, cid, sid);
 			}).then(chain(worker => data => {
-				assert.ok(data);
+				assert(data);
 			}, queryChannel));
 		});
 
@@ -154,7 +154,7 @@ describe('Sockets', function () {
 				Sockets.roomAdd(worker, cid, sid);
 				Sockets.roomRemove(worker, cid, sid);
 			}).then(chain(worker => data => {
-				assert.ok(data);
+				assert(data);
 			}, queryChannel));
 		});
 
@@ -181,7 +181,7 @@ describe('Sockets', function () {
 					process.send(!!channel && (channel.get(${sid}) === ${scid}));`;
 				Sockets.channelMove(worker, cid, scid, sid);
 			}).then(chain(worker => data => {
-				assert.ok(data);
+				assert(data);
 			}, queryChannel));
 		});
 
@@ -197,7 +197,7 @@ describe('Sockets', function () {
 				Sockets.channelMove(worker, cid, scid, sid);
 				Sockets.roomRemove(worker, cid, sid);
 			}).then(chain(worker => data => {
-				assert.ok(data);
+				assert(data);
 			}, queryChannel));
 		});
 

--- a/test/server/users.js
+++ b/test/server/users.js
@@ -81,9 +81,9 @@ describe('Users features', function () {
 			it('should store IP addresses after disconnect', () => {
 				const conn = new Connection('127.0.0.1');
 				const user = new User(conn);
-				assert.deepStrictEqual(['127.0.0.1'], user.ips);
+				assert.deepEqual(['127.0.0.1'], user.ips);
 				user.onDisconnect(conn);
-				assert.deepStrictEqual(['127.0.0.1'], user.ips);
+				assert.deepEqual(['127.0.0.1'], user.ips);
 			});
 
 			describe('#disconnectAll', function () {

--- a/test/server/users.js
+++ b/test/server/users.js
@@ -15,12 +15,12 @@ describe('Users features', function () {
 		});
 		describe('connections', function () {
 			it('should be a Map', function () {
-				assert.ok(Users.connections instanceof Map);
+				assert(Users.connections instanceof Map);
 			});
 		});
 		describe('users', function () {
 			it('should be a Map', function () {
-				assert.ok(Users.users instanceof Map);
+				assert(Users.users instanceof Map);
 			});
 		});
 		describe('Connection', function () {
@@ -59,7 +59,7 @@ describe('Users features', function () {
 				it('should join a room if not already present', function () {
 					room = Rooms.createChatRoom('test');
 					this.connection.joinRoom(Rooms.get('test'));
-					assert.ok(this.connection.inRooms.has('test'));
+					assert(this.connection.inRooms.has('test'));
 				});
 			});
 
@@ -73,7 +73,7 @@ describe('Users features', function () {
 					room = Rooms.createChatRoom('test');
 					this.connection.joinRoom(room);
 					this.connection.leaveRoom(room);
-					assert.ok(!this.connection.inRooms.has('test'));
+					assert(!this.connection.inRooms.has('test'));
 				});
 			});
 		});
@@ -107,7 +107,7 @@ describe('Users features', function () {
 
 						user.disconnectAll();
 						for (let i = 0; i < totalConnections; i++) {
-							assert.ok(!Users.connections.has(connections[i].id));
+							assert(!Users.connections.has(connections[i].id));
 						}
 					});
 

--- a/test/sim/abilities/battlearmor.js
+++ b/test/sim/abilities/battlearmor.js
@@ -19,11 +19,11 @@ describe('Battle Armor', function () {
 		battle.onEvent('ModifyDamage', battle.format, function (damage, attacker, defender, move) {
 			if (move.id === 'frostbreath') {
 				successfulEvent = true;
-				assert.ok(!defender.getMoveHitData(move).crit);
+				assert(!defender.getMoveHitData(move).crit);
 			}
 		});
 		battle.makeChoices('move quickattack', 'move frostbreath');
-		assert.ok(successfulEvent);
+		assert(successfulEvent);
 	});
 
 	it('should be suppressed by Mold Breaker', function () {
@@ -36,10 +36,10 @@ describe('Battle Armor', function () {
 		battle.onEvent('ModifyDamage', battle.format, function (damage, attacker, defender, move) {
 			if (move.id === 'frostbreath') {
 				successfulEvent = true;
-				assert.ok(defender.getMoveHitData(move).crit);
+				assert(defender.getMoveHitData(move).crit);
 			}
 		});
 		battle.makeChoices('move quickattack', 'move frostbreath');
-		assert.ok(successfulEvent);
+		assert(successfulEvent);
 	});
 });

--- a/test/sim/abilities/cloudnine.js
+++ b/test/sim/abilities/cloudnine.js
@@ -16,7 +16,7 @@ describe('Cloud Nine', function () {
 		battle.setPlayer('p2', {team: [{species: 'Cherrim', ability: 'flowergift', item: 'laggingtail', moves: ['solarbeam']}]});
 		const [weatherSuppressor, weatherUser] = [battle.p1.active[0], battle.p2.active[0]];
 		assert.false.hurts(weatherSuppressor, () => battle.makeChoices('move sunnyday', 'move solarbeam')); // Solar Beam must charge
-		assert.ok(battle.field.isWeather(''));
+		assert(battle.field.isWeather(''));
 		assert.species(weatherUser, 'Cherrim');
 	});
 

--- a/test/sim/abilities/colorchange.js
+++ b/test/sim/abilities/colorchange.js
@@ -16,7 +16,7 @@ describe('Color Change', function () {
 		battle.setPlayer('p2', {team: [{species: "Paras", ability: 'damp', moves: ['absorb']}]});
 		const ccMon = battle.p1.active[0];
 		battle.makeChoices('move Recover', 'move Absorb');
-		assert.ok(ccMon.hasType('Grass'));
+		assert(ccMon.hasType('Grass'));
 	});
 
 	it('should not change the user\'s type if it had a Substitute when hit', function () {

--- a/test/sim/abilities/dancer.js
+++ b/test/sim/abilities/dancer.js
@@ -114,7 +114,7 @@ describe('Dancer', function () {
 		battle.setPlayer('p1', {team: [{species: 'Oricoriopompom', ability: 'dancer', moves: ['revelationdance']}]});
 		battle.setPlayer('p2', {team: [{species: 'oricorio', ability: 'dancer', level: 1, moves: ['sleeptalk']}, {species: 'oricorio', ability: 'dancer', level: 1, moves: ['sleeptalk']}]});
 		battle.makeChoices();
-		assert.ok(!battle.log.includes('|-activate|p2: Oricorio|ability: Dancer'));
+		assert(!battle.log.includes('|-activate|p2: Oricorio|ability: Dancer'));
 	});
 
 	it('should target the user of a Dance move unless it was an ally attacking an opponent', function () {

--- a/test/sim/abilities/deltastream.js
+++ b/test/sim/abilities/deltastream.js
@@ -14,7 +14,7 @@ describe('Delta Stream', function () {
 		battle = common.createBattle();
 		battle.setPlayer('p1', {team: [{species: "Rayquaza", ability: 'deltastream', moves: ['roost']}]});
 		battle.setPlayer('p2', {team: [{species: "Abra", ability: 'magicguard', moves: ['teleport']}]});
-		assert.ok(battle.field.isWeather('deltastream'));
+		assert(battle.field.isWeather('deltastream'));
 	});
 
 	it('should negate the type weaknesses of the Flying-type', function () {
@@ -65,9 +65,9 @@ describe('Delta Stream', function () {
 		]});
 		for (let i = 2; i <= 5; i++) {
 			battle.makeChoices('move helpinghand', 'switch ' + i);
-			assert.ok(battle.field.isWeather('deltastream'));
+			assert(battle.field.isWeather('deltastream'));
 			battle.makeChoices('move helpinghand', 'move 1');
-			assert.ok(battle.field.isWeather('deltastream'));
+			assert(battle.field.isWeather('deltastream'));
 		}
 	});
 

--- a/test/sim/abilities/desolateland.js
+++ b/test/sim/abilities/desolateland.js
@@ -14,7 +14,7 @@ describe('Desolate Land', function () {
 		battle = common.createBattle();
 		battle.setPlayer('p1', {team: [{species: "Groudon", ability: 'desolateland', moves: ['helpinghand']}]});
 		battle.setPlayer('p2', {team: [{species: "Abra", ability: 'magicguard', moves: ['teleport']}]});
-		assert.ok(battle.field.isWeather('desolateland'));
+		assert(battle.field.isWeather('desolateland'));
 	});
 
 	it('should increase the damage (not the basePower) of Fire-type attacks', function () {
@@ -58,9 +58,9 @@ describe('Desolate Land', function () {
 		]});
 		for (let i = 2; i <= 5; i++) {
 			battle.makeChoices('move helpinghand', 'switch ' + i);
-			assert.ok(battle.field.isWeather('desolateland'));
+			assert(battle.field.isWeather('desolateland'));
 			battle.makeChoices('move helpinghand', 'move 1');
-			assert.ok(battle.field.isWeather('desolateland'));
+			assert(battle.field.isWeather('desolateland'));
 		}
 	});
 

--- a/test/sim/abilities/disguise.js
+++ b/test/sim/abilities/disguise.js
@@ -28,7 +28,7 @@ describe('Disguise', function () {
 		battle.setPlayer('p1', {team: [{species: 'Mimikyu', ability: 'disguise', moves: ['splash']}]});
 		battle.setPlayer('p2', {team: [{species: 'Sableye', ability: 'prankster', moves: ['confuseray']}]});
 		assert.false.hurts(battle.p1.active[0], () => battle.makeChoices());
-		assert.ok(battle.p1.active[0].abilityData.busted);
+		assert(battle.p1.active[0].abilityData.busted);
 	});
 
 	it('should not block damage from weather effects', function () {

--- a/test/sim/abilities/imposter.js
+++ b/test/sim/abilities/imposter.js
@@ -28,7 +28,7 @@ describe('Imposter', function () {
 		]});
 		battle.makeChoices('move substitute', 'move uturn');
 		battle.makeChoices('', 'switch ditto');
-		assert.notStrictEqual(battle.p2.active[0].species, battle.p1.active[0].species);
+		assert.notEqual(battle.p2.active[0].species, battle.p1.active[0].species);
 	});
 
 	it('should not activate if Skill Swapped', function () {
@@ -41,7 +41,7 @@ describe('Imposter', function () {
 			{species: "Greninja", ability: 'torrent', moves: ['sleeptalk']},
 		]});
 		battle.makeChoices('move skillswap', 'switch greninja');
-		assert.notStrictEqual(battle.p1.active[0].species, battle.p2.active[0].species);
+		assert.notEqual(battle.p1.active[0].species, battle.p2.active[0].species);
 	});
 
 	it('should not activate if Neutralizing Gas leaves the field', function () {
@@ -53,9 +53,9 @@ describe('Imposter', function () {
 		battle.setPlayer('p2', {team: [
 			{species: "Ditto", ability: 'imposter', moves: ['sleeptalk']},
 		]});
-		assert.notStrictEqual(battle.p1.active[0].species, battle.p2.active[0].species);
+		assert.notEqual(battle.p1.active[0].species, battle.p2.active[0].species);
 		battle.makeChoices('switch greninja', 'move sleeptalk');
-		assert.notStrictEqual(battle.p1.active[0].species, battle.p2.active[0].species);
-		assert.notStrictEqual(battle.p1.pokemon[1].species, battle.p2.active[0].species);
+		assert.notEqual(battle.p1.active[0].species, battle.p2.active[0].species);
+		assert.notEqual(battle.p1.pokemon[1].species, battle.p2.active[0].species);
 	});
 });

--- a/test/sim/abilities/magicbounce.js
+++ b/test/sim/abilities/magicbounce.js
@@ -39,7 +39,7 @@ describe('Magic Bounce', function () {
 		battle.setPlayer('p2', {team: [{species: "Espeon", ability: 'magicbounce', moves: ['growl', 'recover']}]});
 		battle.makeChoices('switch 2', 'move growl');
 		battle.makeChoices('move roost', 'move recover');
-		assert.notStrictEqual(battle.p1.active[0].lastMove.id, 'growl');
+		assert.notEqual(battle.p1.active[0].lastMove.id, 'growl');
 	});
 
 	it('should be suppressed by Mold Breaker', function () {

--- a/test/sim/abilities/neutralizinggas.js
+++ b/test/sim/abilities/neutralizinggas.js
@@ -22,7 +22,7 @@ describe('Neutralizing Gas', function () {
 		battle.setPlayer('p1', {team: [{species: "Weezing", ability: 'neutralizinggas', item: 'expertbelt', moves: ['sludgebomb']}]});
 		battle.setPlayer('p2', {team: [{species: "Mr. Mime", ability: 'filter', item: 'laggingtail', moves: ['substitute']}]});
 		battle.makeChoices('move sludgebomb', 'move substitute');
-		assert.ok(!battle.p1.active[0].volatiles['substitute']);
+		assert(!battle.p1.active[0].volatiles['substitute']);
 	});
 
 	it('should negate self-healing abilities', function () {

--- a/test/sim/abilities/normalize.js
+++ b/test/sim/abilities/normalize.js
@@ -15,7 +15,7 @@ describe('Normalize', function () {
 		battle.setPlayer('p1', {team: [{species: "Delcatty", ability: 'normalize', moves: ['grassknot']}]});
 		battle.setPlayer('p2', {team: [{species: "Latias", ability: 'colorchange', moves: ['endure']}]});
 		battle.makeChoices('move grassknot', 'move endure');
-		assert.ok(battle.p2.active[0].hasType('Normal'));
+		assert(battle.p2.active[0].hasType('Normal'));
 	});
 
 	it('should not change Hidden Power to Normal-type', function () {
@@ -23,7 +23,7 @@ describe('Normalize', function () {
 		battle.setPlayer('p1', {team: [{species: "Delcatty", ability: 'normalize', moves: ['hiddenpowerfighting']}]});
 		battle.setPlayer('p2', {team: [{species: "Latias", ability: 'colorchange', moves: ['endure']}]});
 		battle.makeChoices('move hiddenpowerfighting', 'move endure');
-		assert.ok(battle.p2.active[0].hasType('Fighting'));
+		assert(battle.p2.active[0].hasType('Fighting'));
 	});
 
 	it('should not change Techno Blast to Normal-type if the user is holding a Drive', function () {
@@ -31,7 +31,7 @@ describe('Normalize', function () {
 		battle.setPlayer('p1', {team: [{species: "Delcatty", ability: 'normalize', item: 'dousedrive', moves: ['technoblast']}]});
 		battle.setPlayer('p2', {team: [{species: "Latias", ability: 'colorchange', moves: ['endure']}]});
 		battle.makeChoices('move technoblast', 'move endure');
-		assert.ok(battle.p2.active[0].hasType('Water'));
+		assert(battle.p2.active[0].hasType('Water'));
 	});
 
 	it('should not change Judgment to Normal-type if the user is holding a Plate', function () {
@@ -39,7 +39,7 @@ describe('Normalize', function () {
 		battle.setPlayer('p1', {team: [{species: "Delcatty", ability: 'normalize', item: 'zapplate', moves: ['judgment']}]});
 		battle.setPlayer('p2', {team: [{species: "Latias", ability: 'colorchange', moves: ['endure']}]});
 		battle.makeChoices('move judgment', 'move endure');
-		assert.ok(battle.p2.active[0].hasType('Electric'));
+		assert(battle.p2.active[0].hasType('Electric'));
 	});
 
 	it('should not change Weather Ball to Normal-type if sun, rain, or hail is an active weather', function () {
@@ -47,7 +47,7 @@ describe('Normalize', function () {
 		battle.setPlayer('p1', {team: [{species: "Delcatty", ability: 'normalize', item: 'laggingtail', moves: ['weatherball']}]});
 		battle.setPlayer('p2', {team: [{species: "Latias", ability: 'colorchange', moves: ['sunnyday']}]});
 		battle.makeChoices('move weatherball', 'move sunnyday');
-		assert.ok(battle.p2.active[0].hasType('Fire'));
+		assert(battle.p2.active[0].hasType('Fire'));
 	});
 
 	it('should not change Natural Gift to Normal-type if the user is holding a Berry', function () {
@@ -55,7 +55,7 @@ describe('Normalize', function () {
 		battle.setPlayer('p1', {team: [{species: "Delcatty", ability: 'normalize', item: 'chopleberry', moves: ['naturalgift']}]});
 		battle.setPlayer('p2', {team: [{species: "Latias", ability: 'colorchange', moves: ['endure']}]});
 		battle.makeChoices('move naturalgift', 'move endure');
-		assert.ok(battle.p2.active[0].hasType('Fighting'));
+		assert(battle.p2.active[0].hasType('Fighting'));
 	});
 });
 
@@ -70,7 +70,7 @@ describe('Normalize [Gen 4]', function () {
 			[{species: "Latias", ability: 'colorchange', moves: ['endure']}],
 		]);
 		battle.makeChoices('move grassknot', 'move endure');
-		assert.ok(battle.p2.active[0].hasType('Normal'));
+		assert(battle.p2.active[0].hasType('Normal'));
 	});
 
 	it('should change Hidden Power to Normal-type', function () {
@@ -79,7 +79,7 @@ describe('Normalize [Gen 4]', function () {
 			[{species: "Latias", ability: 'colorchange', moves: ['endure']}],
 		]);
 		battle.makeChoices('move hiddenpowerfire', 'move endure');
-		assert.ok(battle.p2.active[0].hasType('Normal'));
+		assert(battle.p2.active[0].hasType('Normal'));
 	});
 
 	it('should change Judgment to Normal-type even if the user is holding a Plate', function () {
@@ -88,7 +88,7 @@ describe('Normalize [Gen 4]', function () {
 			[{species: "Latias", ability: 'colorchange', moves: ['endure']}],
 		]);
 		battle.makeChoices('move judgment', 'move endure');
-		assert.ok(battle.p2.active[0].hasType('Normal'));
+		assert(battle.p2.active[0].hasType('Normal'));
 	});
 
 	it('should change Weather Ball to Normal-type even if sun, rain, or hail is an active weather', function () {
@@ -97,6 +97,6 @@ describe('Normalize [Gen 4]', function () {
 			[{species: "Latias", ability: 'colorchange', moves: ['sunnyday']}],
 		]);
 		battle.makeChoices('move weatherball', 'move sunnyday');
-		assert.ok(battle.p2.active[0].hasType('Normal'));
+		assert(battle.p2.active[0].hasType('Normal'));
 	});
 });

--- a/test/sim/abilities/primordialsea.js
+++ b/test/sim/abilities/primordialsea.js
@@ -84,9 +84,9 @@ describe('Primordial Sea', function () {
 		battle.makeChoices('move sonicboom', 'switch 2');
 		assert.equal(myActive[0].getStat('spe'), 2 * myActive[0].storedStats['spe'], "Kingdra's Speed should be doubled by Swift Swim");
 		battle.makeChoices('move sonicboom', 'switch 3');
-		assert.notStrictEqual(myActive[0].maxhp - myActive[0].hp, 20);
+		assert.notEqual(myActive[0].maxhp - myActive[0].hp, 20);
 		battle.makeChoices('move sonicboom', 'switch 4');
-		assert.notStrictEqual(myActive[0].maxhp - myActive[0].hp, 20);
+		assert.notEqual(myActive[0].maxhp - myActive[0].hp, 20);
 		battle.makeChoices('move sonicboom', 'switch 5');
 		battle.makeChoices('move sonicboom', 'move rest');
 		assert.equal(myActive[0].status, '');

--- a/test/sim/abilities/primordialsea.js
+++ b/test/sim/abilities/primordialsea.js
@@ -14,7 +14,7 @@ describe('Primordial Sea', function () {
 		battle = common.createBattle();
 		battle.setPlayer('p1', {team: [{species: "Kyogre", ability: 'primordialsea', moves: ['helpinghand']}]});
 		battle.setPlayer('p2', {team: [{species: "Abra", ability: 'magicguard', moves: ['teleport']}]});
-		assert.ok(battle.field.isWeather('primordialsea'));
+		assert(battle.field.isWeather('primordialsea'));
 	});
 
 	it('should increase the damage (not the basePower) of Water-type attacks', function () {
@@ -57,9 +57,9 @@ describe('Primordial Sea', function () {
 		]});
 		for (let i = 2; i <= 5; i++) {
 			battle.makeChoices('move helpinghand', 'switch ' + i);
-			assert.ok(battle.field.isWeather('primordialsea'));
+			assert(battle.field.isWeather('primordialsea'));
 			battle.makeChoices('auto', 'auto');
-			assert.ok(battle.field.isWeather('primordialsea'));
+			assert(battle.field.isWeather('primordialsea'));
 		}
 	});
 

--- a/test/sim/abilities/shellarmor.js
+++ b/test/sim/abilities/shellarmor.js
@@ -23,7 +23,7 @@ describe('Shell Armor', function () {
 			}
 		});
 		battle.makeChoices('move quickattack', 'move frostbreath');
-		assert.ok(successfulEvent);
+		assert(successfulEvent);
 	});
 
 	it('should be suppressed by Mold Breaker', function () {
@@ -35,10 +35,10 @@ describe('Shell Armor', function () {
 		battle.onEvent('ModifyDamage', battle.format, function (damage, attacker, defender, move) {
 			if (move.id === 'frostbreath') {
 				successfulEvent = true;
-				assert.ok(defender.getMoveHitData(move).crit);
+				assert(defender.getMoveHitData(move).crit);
 			}
 		});
 		battle.makeChoices('move quickattack', 'move frostbreath');
-		assert.ok(successfulEvent);
+		assert(successfulEvent);
 	});
 });

--- a/test/sim/abilities/unaware.js
+++ b/test/sim/abilities/unaware.js
@@ -35,7 +35,7 @@ describe('Unaware', function () {
 		pokemon.hp = pokemon.maxhp;
 		battle.resetRNG();
 		battle.makeChoices('move moonblast', 'move splash');
-		assert.notStrictEqual(pokemon.maxhp - pokemon.hp, damage);
+		assert.notEqual(pokemon.maxhp - pokemon.hp, damage);
 	});
 
 	it('should ignore defense stage changes when Pokemon with it attack', function () {
@@ -62,7 +62,7 @@ describe('Unaware', function () {
 		pokemon.hp = pokemon.maxhp;
 		battle.resetRNG();
 		battle.makeChoices('move irondefense', 'move shadowsneak');
-		assert.notStrictEqual(pokemon.maxhp - pokemon.hp, damage);
+		assert.notEqual(pokemon.maxhp - pokemon.hp, damage);
 	});
 
 	it('should be suppressed by Mold Breaker', function () {
@@ -76,7 +76,7 @@ describe('Unaware', function () {
 		pokemon.hp = pokemon.maxhp;
 		battle.resetRNG();
 		battle.makeChoices('move splash', 'move shadowsneak');
-		assert.notStrictEqual(pokemon.maxhp - pokemon.hp, damage);
+		assert.notEqual(pokemon.maxhp - pokemon.hp, damage);
 	});
 	it('should only apply to targets with Unaware in battles with multiple Pokemon', function () {
 		battle = common.createBattle({gameType: 'doubles'}, [[

--- a/test/sim/abilities/wonderguard.js
+++ b/test/sim/abilities/wonderguard.js
@@ -33,7 +33,7 @@ describe('Wonder Guard', function () {
 		assert.statStage(wwTarget, 'def', -2);
 		assert.hurtsBy(wwTarget, -Math.floor(wwTarget.maxhp / 8), () => battle.makeChoices('move teleport', 'move healpulse'));
 		battle.makeChoices('move teleport', 'move gastroacid');
-		assert.ok(wwTarget.volatiles['gastroacid']);
+		assert(wwTarget.volatiles['gastroacid']);
 		assert.false(wwTarget.hasAbility('wonderguard'));
 	});
 

--- a/test/sim/data.js
+++ b/test/sim/data.js
@@ -188,7 +188,7 @@ describe('Dex data', function () {
 							assert(eventEntry.moves.includes(moveid), `Learn method "${learned}" for ${species.name}'s ${move.name} is invalid: an event move's event entry should include that move`);
 							break;
 						default:
-							assert.strictEqual(learned, learned.slice(0, 2), `Learn method "${learned}" for ${species.name}'s ${move.name} is invalid: it should be 2 characters long`);
+							assert.equal(learned, learned.slice(0, 2), `Learn method "${learned}" for ${species.name}'s ${move.name} is invalid: it should be 2 characters long`);
 							break;
 						}
 					}

--- a/test/sim/decisions.js
+++ b/test/sim/decisions.js
@@ -292,7 +292,7 @@ describe('Choices', function () {
 			}
 			// Geodude's sucker punch should have processed first,
 			// while Aggron was still in slot 2.
-			assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+			assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 			// Aggron's Earthquake should process after Skarmory shifted
 			// but before Golem shifted, so it didn't hit Golem.
 			assert.equal(battle.p2.active[1].hp, battle.p2.active[1].maxhp);
@@ -322,7 +322,7 @@ describe('Choices', function () {
 			battle.makeChoices('move recover', 'move surf');
 
 			assert.equal(battle.turn, 2);
-			assert.notStrictEqual(battle.p2.active[0].lastMove.id, 'struggle');
+			assert.notEqual(battle.p2.active[0].lastMove.id, 'struggle');
 		});
 
 		it('should not force Struggle usage on move attempt when choosing a disabled move', function () {
@@ -334,11 +334,11 @@ describe('Choices', function () {
 
 			assert.cantMove(() => battle.p1.chooseMove(1), 'Mew', 'Recover', true);
 			assert.equal(battle.turn, 1);
-			assert.notStrictEqual(failingAttacker.lastMove && failingAttacker.lastMove.id, 'struggle');
+			assert.notEqual(failingAttacker.lastMove && failingAttacker.lastMove.id, 'struggle');
 
 			assert.cantMove(() => battle.p1.chooseMove(1), 'Mew', 'Recover');
 			assert.equal(battle.turn, 1);
-			assert.notStrictEqual(failingAttacker.lastMove && failingAttacker.lastMove.id, 'struggle');
+			assert.notEqual(failingAttacker.lastMove && failingAttacker.lastMove.id, 'struggle');
 		});
 
 		it('should send meaningful feedback to players if they try to use a disabled move', function () {

--- a/test/sim/dex.js
+++ b/test/sim/dex.js
@@ -22,7 +22,7 @@ describe('Mod loader', function () {
 describe('Dex#getEffect', function () {
 	it('returns the same object for the same id', function () {
 		assert.equal(Dex.getEffect('Stealth Rock'), Dex.getEffect('stealthrock'));
-		assert.notStrictEqual(Dex.getEffect('move: Stealth Rock'), Dex.getEffect('stealthrock'));
+		assert.notEqual(Dex.getEffect('move: Stealth Rock'), Dex.getEffect('stealthrock'));
 	});
 
 	it('does not return elements from the Object prototype', function () {

--- a/test/sim/items/flameorb.js
+++ b/test/sim/items/flameorb.js
@@ -21,7 +21,7 @@ describe('Flame Orb', function () {
 		]});
 		battle.makeChoices('move splash', 'move bulletseed');
 		battle.makeChoices('switch 2', '');
-		assert.notStrictEqual(battle.p1.active[0].status, 'brn');
+		assert.notEqual(battle.p1.active[0].status, 'brn');
 	});
 
 	it('should trigger after one turn', function () {

--- a/test/sim/items/heavydutyboots.js
+++ b/test/sim/items/heavydutyboots.js
@@ -23,6 +23,6 @@ describe("Heavy Duty Boots", function () {
 		battle.makeChoices('auto', 'move toxicspikes');
 		battle.makeChoices('switch 2', 'auto');
 		assert.fullHP(battle.p1.active[0]);
-		assert.notStrictEqual(battle.p1.active[0].status, 'psn');
+		assert.notEqual(battle.p1.active[0].status, 'psn');
 	});
 });

--- a/test/sim/items/ironball.js
+++ b/test/sim/items/ironball.js
@@ -28,11 +28,11 @@ describe('Iron Ball', function () {
 		battle.makeChoices('move earthquake', 'move stealthrock');
 		// Earthquake neutral on Aerodactyl
 		assert.ok(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		battle.makeChoices('move earthquake', 'switch 2');
 		// Earthquake neutral on Tropius
 		assert.ok(!battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
 	it('should not deal neutral type effectiveness to Flying-type Pokemon in Gravity', function () {
@@ -48,11 +48,11 @@ describe('Iron Ball', function () {
 		battle.makeChoices('move earthquake', 'move stealthrock');
 		// Earthquake supereffective on Aerodactyl
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		battle.makeChoices('move earthquake', 'switch 2');
 		// Earthquake not very effective on Tropius
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
 	it('should negate artificial Ground immunities and deal normal type effectiveness', function () {
@@ -64,10 +64,10 @@ describe('Iron Ball', function () {
 		]});
 		battle.makeChoices('move earthquake', 'move rest');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		battle.makeChoices('move earthquake', 'switch 2');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
 	it('should ground Pokemon that are airborne', function () {

--- a/test/sim/items/ironball.js
+++ b/test/sim/items/ironball.js
@@ -27,11 +27,11 @@ describe('Iron Ball', function () {
 		]});
 		battle.makeChoices('move earthquake', 'move stealthrock');
 		// Earthquake neutral on Aerodactyl
-		assert.ok(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+		assert(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		battle.makeChoices('move earthquake', 'switch 2');
 		// Earthquake neutral on Tropius
-		assert.ok(!battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
+		assert(!battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
 		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -47,11 +47,11 @@ describe('Iron Ball', function () {
 
 		battle.makeChoices('move earthquake', 'move stealthrock');
 		// Earthquake supereffective on Aerodactyl
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		battle.makeChoices('move earthquake', 'switch 2');
 		// Earthquake not very effective on Tropius
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
 		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -63,10 +63,10 @@ describe('Iron Ball', function () {
 			{species: "Parasect", ability: 'levitate', item: 'ironball', moves: ['rest']},
 		]});
 		battle.makeChoices('move earthquake', 'move rest');
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		battle.makeChoices('move earthquake', 'switch 2');
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
 		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 

--- a/test/sim/items/lansatberry.js
+++ b/test/sim/items/lansatberry.js
@@ -17,7 +17,7 @@ describe('Lansat Berry', function () {
 		const holder = battle.p1.active[0];
 		battle.makeChoices('move sleeptalk', 'move aurasphere');
 		assert.false.holdsItem(holder);
-		assert.ok('focusenergy' in holder.volatiles);
+		assert('focusenergy' in holder.volatiles);
 	});
 
 	it('should start to apply the effect even in middle of an attack', function () {

--- a/test/sim/items/leppaberry.js
+++ b/test/sim/items/leppaberry.js
@@ -22,6 +22,6 @@ describe('Leppa Berry', function () {
 		battle.makeChoices('move splash', 'move fling');
 
 		assert.equal(pokemon.getMoveData('sleeptalk').pp, 16);
-		assert.false.strictEqual(pokemon.getMoveData('splash').pp, 64);
+		assert.false.equal(pokemon.getMoveData('splash').pp, 64);
 	});
 });

--- a/test/sim/items/lumberry.js
+++ b/test/sim/items/lumberry.js
@@ -23,7 +23,7 @@ describe('Lum Berry', function () {
 		battle.setPlayer('p1', {team: [{species: 'Golurk', ability: 'noguard', moves: ['dynamicpunch']}]});
 		battle.setPlayer('p2', {team: [{species: 'Shuckle', item: 'lumberry', moves: ['sleeptalk']}]});
 		battle.makeChoices('move dynamicpunch', 'move sleeptalk');
-		assert.ok(!battle.p2.active[0].volatiles['confusion']);
+		assert(!battle.p2.active[0].volatiles['confusion']);
 	});
 
 	it('should be eaten immediately when the holder gains a status condition', function () {
@@ -36,6 +36,6 @@ describe('Lum Berry', function () {
 		battle.makeChoices('move outrage', 'move recover');
 		battle.makeChoices('move outrage', 'move banefulbunker');
 		assert.equal(attacker.status, '');
-		assert.ok(attacker.volatiles['confusion']);
+		assert(attacker.volatiles['confusion']);
 	});
 });

--- a/test/sim/items/protectivepads.js
+++ b/test/sim/items/protectivepads.js
@@ -19,7 +19,7 @@ describe('Protective Pads', function () {
 		assert.equal(attacker.ability, 'thickfat');
 		const mummyActivationMessages = battle.log.filter(logStr => logStr.startsWith('|-activate|') && logStr.includes('Mummy'));
 		assert.equal(mummyActivationMessages.length, 1, "Mummy should activate only once");
-		assert.ok(mummyActivationMessages[0].includes('Cofagrigus'), "Source of Mummy activation should be included");
+		assert(mummyActivationMessages[0].includes('Cofagrigus'), "Source of Mummy activation should be included");
 		assert.false(mummyActivationMessages[0].includes('Thick Fat'), "Attacker's ability should not be revealed");
 	});
 

--- a/test/sim/items/ringtarget.js
+++ b/test/sim/items/ringtarget.js
@@ -20,15 +20,15 @@ describe('Ring Target', function () {
 			{species: "Absol", ability: 'superluck', item: 'ringtarget', moves: ['rest']},
 		]});
 		battle.makeChoices('move earthquake', 'move rest');
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		assert.false.fullHP(battle.p2.active[0]);
 
 		battle.makeChoices('move vitalthrow', 'switch 2'); // Drifblim
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
 		assert.false.fullHP(battle.p2.active[0]);
 
 		battle.makeChoices('move shadowball', 'switch 3'); // Girafarig
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		assert.false.fullHP(battle.p2.active[0]);
 
 		battle.makeChoices('move psychic', 'switch 4'); // Absol

--- a/test/sim/items/sitrusberry.js
+++ b/test/sim/items/sitrusberry.js
@@ -49,6 +49,6 @@ describe('Sitrus Berry', function () {
 		const holder = battle.p1.active[0];
 		battle.makeChoices('move sleeptalk', 'move confuseray');
 		assert.holdsItem(holder);
-		assert.false.strictEqual(holder.hp, holder.maxhp);
+		assert.false.equal(holder.hp, holder.maxhp);
 	});
 });

--- a/test/sim/misc/faint-order.js
+++ b/test/sim/misc/faint-order.js
@@ -53,6 +53,6 @@ describe('Fainting', function () {
 		]);
 		battle.makeChoices('move Explosion', 'move Substitute');
 		battle.makeChoices('switch Pikachu', '');
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 });

--- a/test/sim/misc/inversebattle.js
+++ b/test/sim/misc/inversebattle.js
@@ -30,7 +30,7 @@ describe('Inverse Battle', function () {
 		battle.makeChoices('move vitalthrow', 'move rest');
 		battle.makeChoices('move vitalthrow', 'move rest');
 		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
 	it('should affect Stealth Rock damage', function () {

--- a/test/sim/misc/inversebattle.js
+++ b/test/sim/misc/inversebattle.js
@@ -13,7 +13,7 @@ describe('Inverse Battle', function () {
 		battle.setPlayer('p1', {team: [{species: "Hariyama", ability: 'guts', moves: ['vitalthrow']}]});
 		battle.setPlayer('p2', {team: [{species: "Scyther", ability: 'swarm', moves: ['roost']}]});
 		battle.makeChoices('move vitalthrow', 'move roost');
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 	});
 
 	it('should change natural weaknesses into resistances', function () {
@@ -21,7 +21,7 @@ describe('Inverse Battle', function () {
 		battle.setPlayer('p2', {team: [{species: "Absol", ability: 'pressure', moves: ['leer']}]});
 		battle.makeChoices('move vitalthrow', 'move leer');
 		battle.makeChoices('move vitalthrow', 'move leer');
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-resisted|'));
 	});
 
 	it('should negate natural immunities and make them weaknesses', function () {
@@ -29,7 +29,7 @@ describe('Inverse Battle', function () {
 		battle.setPlayer('p2', {team: [{species: "Dusknoir", ability: 'frisk', moves: ['rest']}]});
 		battle.makeChoices('move vitalthrow', 'move rest');
 		battle.makeChoices('move vitalthrow', 'move rest');
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -59,7 +59,7 @@ describe('Inverse Battle', function () {
 		battle.setPlayer('p2', {team: [{species: "Rayquaza-Mega", ability: 'deltastream', moves: ['hiddenpowerbug']}]});
 		battle.makeChoices('move hiddenpower', 'move hiddenpower');
 		battle.makeChoices('move hiddenpower', 'move hiddenpower');
-		assert.ok(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+		assert(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 	});
 
 	it('should make Ghost/Grass types take neutral damage from Flying Press', function () {
@@ -67,7 +67,7 @@ describe('Inverse Battle', function () {
 		battle.setPlayer('p2', {team: [{species: "Gourgeist", ability: 'insomnia', moves: ['shadowsneak']}]});
 		battle.makeChoices('move flyingpress', 'move shadowsneak');
 		battle.makeChoices('move flyingpress', 'move shadowsneak');
-		assert.ok(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+		assert(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 	});
 
 	it('should not affect ability-based immunities', function () {
@@ -75,7 +75,7 @@ describe('Inverse Battle', function () {
 		battle.setPlayer('p2', {team: [{species: "Mismagius", ability: 'levitate', moves: ['shadowsneak']}]});
 		battle.makeChoices('move earthquake', 'move shadowsneak');
 		battle.makeChoices('move earthquake', 'move shadowsneak');
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
 		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
@@ -84,7 +84,7 @@ describe('Inverse Battle', function () {
 		battle.setPlayer('p2', {team: [{species: "Floatzel", ability: 'waterveil', moves: ['aquajet']}]});
 		battle.makeChoices('move freezedry', 'move aquajet');
 		battle.makeChoices('move freezedry', 'move aquajet');
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 	});
 
 	it('should not affect the "ungrounded" state of Flying-type Pokemon', function () {

--- a/test/sim/misc/statusmoves.js
+++ b/test/sim/misc/statusmoves.js
@@ -25,7 +25,7 @@ describe('Most status moves', function () {
 		battle.makeChoices('move glare', 'switch 2'); // Dusknoir
 		assert.equal(battle.p2.active[0].status, 'par');
 		battle.makeChoices('move confuseray', 'switch 3'); // Slaking
-		assert.ok(battle.p2.active[0].volatiles['confusion']);
+		assert(battle.p2.active[0].volatiles['confusion']);
 		battle.makeChoices('move sandattack', 'switch 4'); // Tornadus
 		assert.statStage(battle.p2.active[0], 'accuracy', -1);
 		battle.makeChoices('move sandattack', 'switch 5'); // Unown (Levitate)
@@ -46,27 +46,27 @@ describe('Most status moves', function () {
 
 		battle.makeChoices('move thunderwave', 'move charge');
 		assert.equal(battle.p2.active[0].status, '');
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
 
 		battle.makeChoices('move willowisp', 'switch 2'); // Emboar
 		assert.equal(battle.p2.active[0].status, '');
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
 
 		battle.makeChoices('move poisongas', 'switch 3'); // Muk
 		assert.equal(battle.p2.active[0].status, '');
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
 
 		battle.makeChoices('move toxic', 'move shadowsneak');
 		assert.equal(battle.p2.active[0].status, '');
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
 
 		battle.makeChoices('move poisongas', 'switch 4'); // Aron
 		assert.equal(battle.p2.active[0].status, '');
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
 
 		battle.makeChoices('move toxic', 'move magnetrise');
 		assert.equal(battle.p2.active[0].status, '');
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-immune|'));
 	});
 });
 

--- a/test/sim/misc/typechange.js
+++ b/test/sim/misc/typechange.js
@@ -50,7 +50,7 @@ describe('Type addition', function () {
 						const target = battle.p2.active[0];
 						battle.makeChoices('move ' + moveData.name, 'move spikes');
 						assert.constant(() => target.getTypes().join('/'), () => battle.makeChoices('move ' + moveData.name, 'move spikes'));
-						assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-fail|'));
+						assert(battle.log[battle.lastMoveLine + 1].startsWith('|-fail|'));
 					});
 				} else {
 					it('should override ' + moveData2.name, function () {

--- a/test/sim/moves/curse.js
+++ b/test/sim/moves/curse.js
@@ -64,11 +64,11 @@ describe('Curse', function () {
 
 		battle.makeChoices('auto', 'auto');
 		const hps = [battle.p1.active[0].hp, battle.p2.active[0].hp];
-		assert.notStrictEqual(hps[0], battle.p1.active[0].maxhp); // Curse user cut its HP down + residual damage
+		assert.notEqual(hps[0], battle.p1.active[0].maxhp); // Curse user cut its HP down + residual damage
 		assert.equal(hps[1], battle.p2.active[0].maxhp); // Foe unaffected
 
 		battle.makeChoices('move spite', 'auto');
-		assert.notStrictEqual(hps[0], battle.p1.active[0].hp); // Curse user is hurt by residual damage
+		assert.notEqual(hps[0], battle.p1.active[0].hp); // Curse user is hurt by residual damage
 		assert.equal(hps[1], battle.p2.active[0].hp); // Foe unaffected
 	});
 
@@ -79,13 +79,13 @@ describe('Curse', function () {
 
 		battle.makeChoices('auto', 'auto');
 		const hps = [battle.p1.active[0].hp, battle.p2.active[0].hp];
-		assert.notStrictEqual(hps[0], battle.p1.active[0].maxhp); // Curse user cut its HP down
-		assert.notStrictEqual(hps[1], battle.p2.active[0].maxhp); // Curse residual damage
+		assert.notEqual(hps[0], battle.p1.active[0].maxhp); // Curse user cut its HP down
+		assert.notEqual(hps[1], battle.p2.active[0].maxhp); // Curse residual damage
 
 		battle.makeChoices('move spite', 'auto');
 		// Check residual damage
 		assert.equal(hps[0], battle.p1.active[0].hp); // Curse user unaffected
-		assert.notStrictEqual(hps[1], battle.p2.active[0].hp); // Curse residual damage
+		assert.notEqual(hps[1], battle.p2.active[0].hp); // Curse residual damage
 	});
 });
 
@@ -124,14 +124,14 @@ describe('XY/ORAS Curse targetting when becoming Ghost the same turn', function 
 		const foeHP = [p2active[0].hp, p2active[1].hp];
 		battle.makeChoices(`move 2, move 2`, `move 2, move 2`);
 
-		assert.notStrictEqual(curseUser.hp, curseUser.maxhp); // Curse user cut its HP down
+		assert.notEqual(curseUser.hp, curseUser.maxhp); // Curse user cut its HP down
 		if (curseUser.position === 0) {
 			// Expected behavior
 			assert.equal(cursePartner.hp, cursePartner.maxhp); // Partner unaffected by Curse
 			assert.ok(foeHP[0] !== p2active[0].maxhp || foeHP[1] !== p2active[1].maxhp); // Foe afflicted by Curse
 		} else {
 			// Cartridge glitch
-			assert.notStrictEqual(cursePartner.hp, cursePartner.maxhp); // Partner afflicted by Curse
+			assert.notEqual(cursePartner.hp, cursePartner.maxhp); // Partner afflicted by Curse
 			assert.ok(foeHP[0] === p2active[0].maxhp && foeHP[1] === p2active[1].maxhp); // Foes unaffected by Curse
 		}
 	}
@@ -154,7 +154,7 @@ describe('XY/ORAS Curse targetting when becoming Ghost the same turn', function 
 		for (let i = 0; i < 3; i++) {
 			const allyPokemon = p1active[i];
 			if (allyPokemon === curseUser) {
-				assert.notStrictEqual(allyPokemon.hp, allyPokemon.maxhp); // Curse user cut its HP down
+				assert.notEqual(allyPokemon.hp, allyPokemon.maxhp); // Curse user cut its HP down
 			} else {
 				assert.equal(allyPokemon.hp, allyPokemon.maxhp); // Partners unaffected by Curse
 			}

--- a/test/sim/moves/curse.js
+++ b/test/sim/moves/curse.js
@@ -118,8 +118,8 @@ describe('XY/ORAS Curse targetting when becoming Ghost the same turn', function 
 			`move aurasphere ${curseUser.position + 1}, move lick ${curseUser.position + 1}`
 		);
 
-		assert.ok(curseUser.hasType('Ghost')); // Curse user must be Ghost
-		assert.ok(curseUser.hp < curseUser.maxhp / 2); // Curse user cut its HP down
+		assert(curseUser.hasType('Ghost')); // Curse user must be Ghost
+		assert(curseUser.hp < curseUser.maxhp / 2); // Curse user cut its HP down
 
 		const foeHP = [p2active[0].hp, p2active[1].hp];
 		battle.makeChoices(`move 2, move 2`, `move 2, move 2`);
@@ -128,11 +128,11 @@ describe('XY/ORAS Curse targetting when becoming Ghost the same turn', function 
 		if (curseUser.position === 0) {
 			// Expected behavior
 			assert.equal(cursePartner.hp, cursePartner.maxhp); // Partner unaffected by Curse
-			assert.ok(foeHP[0] !== p2active[0].maxhp || foeHP[1] !== p2active[1].maxhp); // Foe afflicted by Curse
+			assert(foeHP[0] !== p2active[0].maxhp || foeHP[1] !== p2active[1].maxhp); // Foe afflicted by Curse
 		} else {
 			// Cartridge glitch
 			assert.notEqual(cursePartner.hp, cursePartner.maxhp); // Partner afflicted by Curse
-			assert.ok(foeHP[0] === p2active[0].maxhp && foeHP[1] === p2active[1].maxhp); // Foes unaffected by Curse
+			assert(foeHP[0] === p2active[0].maxhp && foeHP[1] === p2active[1].maxhp); // Foes unaffected by Curse
 		}
 	}
 
@@ -147,8 +147,8 @@ describe('XY/ORAS Curse targetting when becoming Ghost the same turn', function 
 			`move aurasphere ${curseUser.position + 1}, move lick ${curseUser.position + 1}, move harden`
 		);
 
-		assert.ok(curseUser.hasType('Ghost')); // Curse user must be Ghost
-		assert.ok(curseUser.hp < curseUser.maxhp / 2); // Curse user cut its HP down
+		assert(curseUser.hasType('Ghost')); // Curse user must be Ghost
+		assert(curseUser.hp < curseUser.maxhp / 2); // Curse user cut its HP down
 
 		let cursedFoe = false;
 		for (let i = 0; i < 3; i++) {
@@ -164,7 +164,7 @@ describe('XY/ORAS Curse targetting when becoming Ghost the same turn', function 
 				cursedFoe = true;
 			}
 		}
-		assert.ok(cursedFoe);
+		assert(cursedFoe);
 	}
 
 	it('should target an opponent in Doubles if the user is on left side and becomes Ghost the same turn', function () {

--- a/test/sim/moves/electricterrain.js
+++ b/test/sim/moves/electricterrain.js
@@ -15,15 +15,15 @@ describe('Electric Terrain', function () {
 		battle.setPlayer('p1', {team: [{species: "Florges", ability: 'symbiosis', moves: ['mist', 'electricterrain']}]});
 		battle.setPlayer('p2', {team: [{species: "Florges", ability: 'symbiosis', moves: ['mist']}]});
 		battle.makeChoices('move electricterrain', 'move mist');
-		assert.ok(battle.field.isTerrain('electricterrain'));
+		assert(battle.field.isTerrain('electricterrain'));
 		battle.makeChoices('move electricterrain', 'move mist');
-		assert.ok(battle.field.isTerrain('electricterrain'));
+		assert(battle.field.isTerrain('electricterrain'));
 		battle.makeChoices('move electricterrain', 'move mist');
-		assert.ok(battle.field.isTerrain('electricterrain'));
+		assert(battle.field.isTerrain('electricterrain'));
 		battle.makeChoices('move electricterrain', 'move mist');
-		assert.ok(battle.field.isTerrain('electricterrain'));
+		assert(battle.field.isTerrain('electricterrain'));
 		battle.makeChoices('move electricterrain', 'move mist');
-		assert.ok(battle.field.isTerrain(''));
+		assert(battle.field.isTerrain(''));
 	});
 
 	it('should increase the base power of Electric-type attacks used by grounded Pokemon', function () {
@@ -64,7 +64,7 @@ describe('Electric Terrain', function () {
 		battle.makeChoices('move electricterrain', 'move yawn');
 		battle.makeChoices('move yawn', 'move yawn');
 		assert.equal(battle.p1.active[0].status, '');
-		assert.ok(!battle.p2.active[0].volatiles['yawn']);
+		assert(!battle.p2.active[0].volatiles['yawn']);
 	});
 
 	it('should cause Rest to fail on grounded Pokemon', function () {

--- a/test/sim/moves/electricterrain.js
+++ b/test/sim/moves/electricterrain.js
@@ -73,7 +73,7 @@ describe('Electric Terrain', function () {
 		battle.setPlayer('p2', {team: [{species: "Pidgeot", ability: 'keeneye', moves: ['doubleedge', 'rest']}]});
 		battle.makeChoices('move electricterrain', 'move doubleedge');
 		battle.makeChoices('move rest', 'move rest');
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 

--- a/test/sim/moves/encore.js
+++ b/test/sim/moves/encore.js
@@ -25,7 +25,7 @@ describe('Encore', function () {
 		// If the Focus Punch user is not interrupted the attack is expected to be successful.
 		battle.makeChoices('move focuspunch 1, move knockoff 1', 'move splash, move extremespeed 2');
 		const hp = battle.p2.active[0].hp;
-		assert.notStrictEqual(hp, battle.p2.active[0].maxhp);
+		assert.notEqual(hp, battle.p2.active[0].maxhp);
 
 		// If a user's previous move was Focus Punch and it is Encored into Focus Punch while attempting to
 		// execute the move, the regular "you can't be hit" effect for Focus Punch will be enforced.
@@ -51,13 +51,13 @@ describe('Encore', function () {
 
 		battle.makeChoices('move focuspunch 1, move knockoff 1', 'move splash, move extremespeed 2');
 		let hp = battle.p2.active[0].hp;
-		assert.notStrictEqual(hp, battle.p2.active[0].maxhp);
+		assert.notEqual(hp, battle.p2.active[0].maxhp);
 
 		// The Pokemon Encored into Focus Punch is not subject to the negative effects of Focus Punch; that is,
 		// if it is hit at any time before or after the Encore, it still uses Focus Punch like normal. It doesn't matter
 		// in the case of Focus Punch if the user was hit before or after the Encore; Focus Punch will still always work.
 		battle.makeChoices('move splash, move teleport', 'move encore 1, move extremespeed 1');
-		assert.notStrictEqual(battle.p2.active[0].hp, hp);
+		assert.notEqual(battle.p2.active[0].hp, hp);
 		hp = battle.p2.active[0].hp;
 
 		// During subsequent turns the normal Focus Punch behavior applies.
@@ -80,17 +80,17 @@ describe('Encore', function () {
 		// If the Shell Trap user is hit the attack is expected to be successful.
 		battle.makeChoices('move shelltrap, move knockoff 1', 'move splash, move quickattack 1');
 		let hp = battle.p2.active[0].hp;
-		assert.notStrictEqual(hp, battle.p2.active[0].maxhp);
+		assert.notEqual(hp, battle.p2.active[0].maxhp);
 
 		// If a user's previous move was Shell Trap and it is Encored into Shell Trap while attempting to
 		// execute the move, the regular "you must be hit" effect for Shell Trap will be enforced
 		battle.makeChoices('move shelltrap, move teleport', 'move encore 1, move quickattack 1');
-		assert.notStrictEqual(battle.p2.active[0].hp, hp);
+		assert.notEqual(battle.p2.active[0].hp, hp);
 		hp = battle.p2.active[0].hp;
 
 		// During subesquent turns the normal Shell Trap behavior applies.
 		battle.makeChoices('move shelltrap, move teleport', 'move splash, move quickattack 1');
-		assert.notStrictEqual(battle.p2.active[0].hp, hp);
+		assert.notEqual(battle.p2.active[0].hp, hp);
 	});
 
 	it('should make Shell Trap always fail if the user\'s decision is changed', function () {
@@ -108,7 +108,7 @@ describe('Encore', function () {
 		// If the Shell Trap user is hit the attack is expected to be successful.
 		battle.makeChoices('move shelltrap, move knockoff 1', 'move splash, move quickattack 1');
 		const hp = battle.p2.active[0].hp;
-		assert.notStrictEqual(hp, battle.p2.active[0].maxhp);
+		assert.notEqual(hp, battle.p2.active[0].maxhp);
 
 		// Shell Trap which has been encored will never be successful - even if it is hit with contact moves, it will never
 		// attack, and will always say "<Pokemon>'s shell trap didn't work. It doesn't matter in the case of Shell Trap if
@@ -118,6 +118,6 @@ describe('Encore', function () {
 
 		// During subsequent turns the normal Shell Trap behavior applies.
 		battle.makeChoices('move shelltrap, move teleport', 'move splash, move quickattack 1');
-		assert.notStrictEqual(battle.p2.active[0].hp, hp);
+		assert.notEqual(battle.p2.active[0].hp, hp);
 	});
 });

--- a/test/sim/moves/fakeout.js
+++ b/test/sim/moves/fakeout.js
@@ -29,7 +29,7 @@ describe('Fake Out', function () {
 		battle.makeChoices('move fakeout', 'move swift');
 		assert.equal(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 		battle.makeChoices('move fakeout', 'move swift');
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
 	it('should flinch after switching out and back in to refresh the move', function () {
@@ -55,6 +55,6 @@ describe('Fake Out', function () {
 		]]);
 		battle.makeChoices('switch 2', 'move quiverdance');
 		battle.makeChoices('move fakeout', 'move swift');
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 });

--- a/test/sim/moves/focuspunch.js
+++ b/test/sim/moves/focuspunch.js
@@ -23,7 +23,7 @@ describe('Focus Punch', function () {
 		battle.setPlayer('p1', {team: [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]});
 		battle.setPlayer('p2', {team: [{species: 'Venusaur', ability: 'overgrow', moves: ['toxic']}]});
 		battle.makeChoices('move focuspunch', 'move toxic');
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
 	it('should not cause the user to lose focus if hit while behind a substitute', function () {
@@ -32,7 +32,7 @@ describe('Focus Punch', function () {
 		battle.setPlayer('p2', {team: [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf']}]});
 		battle.makeChoices('move substitute', 'move magicalleaf');
 		battle.makeChoices('move focuspunch', 'move magicalleaf');
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
 	it('should cause the user to lose focus if hit by a move called by Nature Power', function () {
@@ -50,7 +50,7 @@ describe('Focus Punch', function () {
 		battle.makeChoices('move focuspunch', 'move magicalleaf');
 		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		battle.makeChoices('move focuspunch', 'move toxic');
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
 	it('should cause the user to lose focus if hit by an attacking move followed by a status move in one turn', function () {

--- a/test/sim/moves/foresight.js
+++ b/test/sim/moves/foresight.js
@@ -16,9 +16,9 @@ describe('Foresight', function () {
 		battle.setPlayer('p2', {team: [{species: "Dusknoir", ability: 'prankster', moves: ['recover']}]});
 		battle.makeChoices('move foresight', 'move recover');
 		battle.makeChoices('move vitalthrow', 'move recover');
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		battle.makeChoices('move tackle', 'move recover');
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
 	it('should ignore the effect of positive evasion stat stages', function () {
@@ -29,7 +29,7 @@ describe('Foresight', function () {
 		battle.boost({evasion: 6}, battle.p2.active[0]);
 		for (let i = 0; i < 7; i++) {
 			battle.makeChoices('move avalanche', 'move synthesis');
-			assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+			assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		}
 	});
 
@@ -41,7 +41,7 @@ describe('Foresight', function () {
 		battle.boost({spe: 6, evasion: -6}, battle.p2.active[0]);
 		for (let i = 0; i < 7; i++) {
 			battle.makeChoices('move zapcannon', 'move roost');
-			assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+			assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		}
 	});
 });

--- a/test/sim/moves/futuresight.js
+++ b/test/sim/moves/futuresight.js
@@ -29,7 +29,7 @@ describe('Future Sight', function () {
 		battle.setPlayer('p2', {team: [{species: "Girafarig", ability: 'innerfocus', moves: ['futuresight']}]});
 		battle.makeChoices('auto', 'move futuresight');
 		battle.makeChoices('auto', 'move futuresight');
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-fail|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-fail|'));
 	});
 
 	it('[Gen 2] should damage in two turns, ignoring Protect', function () {

--- a/test/sim/moves/futuresight.js
+++ b/test/sim/moves/futuresight.js
@@ -20,7 +20,7 @@ describe('Future Sight', function () {
 		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		battle.makeChoices('auto', 'move Protect');
 		assert.equal(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
 	it(`should fail when already active for the target's position`, function () {
@@ -42,7 +42,7 @@ describe('Future Sight', function () {
 		battle.makeChoices('auto', 'auto');
 		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		battle.makeChoices('auto', 'move Protect');
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 });

--- a/test/sim/moves/gmaxvolcalith.js
+++ b/test/sim/moves/gmaxvolcalith.js
@@ -38,7 +38,7 @@ describe('G-Max Volcalith', function () {
 		battle.makeChoices('move sleeptalk, move sleeptalk', 'move sleeptalk, move sleeptalk');
 		battle.makeChoices('move sleeptalk, move sleeptalk', 'move sleeptalk, move sleeptalk');
 		battle.makeChoices('move sleeptalk, move sleeptalk', 'move sleeptalk, move sleeptalk');
-		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp - (Math.floor(battle.p2.active[0].maxhp / 6) * 4));
+		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp - (Math.floor(battle.p2.active[0].maxhp / 6) * 4));
 	});
 
 	it.skip('should deal damage alongside Sea of Fire or G-Max Wildfire in the order those field effects were set', function () {
@@ -62,6 +62,6 @@ describe('G-Max Volcalith', function () {
 		battle.makeChoices('move sleeptalk, move sleeptalk', 'switch 3, move superfang -1');
 		const maxHP = battle.p2.active[0].maxhp;
 		const expectedHP = maxHP - Math.floor(maxHP / 2) - Math.floor(maxHP / 6);
-		assert.strictEqual(battle.p2.active[0].hp, expectedHP);
+		assert.equal(battle.p2.active[0].hp, expectedHP);
 	});
 });

--- a/test/sim/moves/gmaxwildfire.js
+++ b/test/sim/moves/gmaxwildfire.js
@@ -38,6 +38,6 @@ describe('G-Max Wildfire', function () {
 		battle.makeChoices('move sleeptalk, move sleeptalk', 'move sleeptalk, move sleeptalk');
 		battle.makeChoices('move sleeptalk, move sleeptalk', 'move sleeptalk, move sleeptalk');
 		battle.makeChoices('move sleeptalk, move sleeptalk', 'move sleeptalk, move sleeptalk');
-		assert.strictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp - (Math.floor(battle.p2.active[0].maxhp / 6) * 4));
+		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp - (Math.floor(battle.p2.active[0].maxhp / 6) * 4));
 	});
 });

--- a/test/sim/moves/grassyterrain.js
+++ b/test/sim/moves/grassyterrain.js
@@ -15,15 +15,15 @@ describe('Grassy Terrain', function () {
 		battle.setPlayer('p1', {team: [{species: "Florges", ability: 'symbiosis', moves: ['mist', 'grassyterrain']}]});
 		battle.setPlayer('p2', {team: [{species: "Florges", ability: 'symbiosis', moves: ['mist']}]});
 		battle.makeChoices('move grassyterrain', 'move mist');
-		assert.ok(battle.field.isTerrain('grassyterrain'));
+		assert(battle.field.isTerrain('grassyterrain'));
 		battle.makeChoices('move mist', 'move mist');
-		assert.ok(battle.field.isTerrain('grassyterrain'));
+		assert(battle.field.isTerrain('grassyterrain'));
 		battle.makeChoices('move mist', 'move mist');
-		assert.ok(battle.field.isTerrain('grassyterrain'));
+		assert(battle.field.isTerrain('grassyterrain'));
 		battle.makeChoices('move mist', 'move mist');
-		assert.ok(battle.field.isTerrain('grassyterrain'));
+		assert(battle.field.isTerrain('grassyterrain'));
 		battle.makeChoices('move mist', 'move mist');
-		assert.ok(battle.field.isTerrain(''));
+		assert(battle.field.isTerrain(''));
 	});
 
 	it('should halve the base power of Earthquake, Bulldoze, Magnitude', function () {

--- a/test/sim/moves/gravity.js
+++ b/test/sim/moves/gravity.js
@@ -31,7 +31,7 @@ describe('Gravity', function () {
 		battle.setPlayer('p1', {team: [{species: 'Spiritomb', ability: 'pressure', moves: ['gravity']}]});
 		battle.setPlayer('p2', {team: [{species: 'Aerodactyl', ability: 'pressure', moves: ['fly']}]});
 		battle.makeChoices('move gravity', 'move fly');
-		assert.ok(!battle.p2.active[0].volatiles['twoturnmove']);
+		assert(!battle.p2.active[0].volatiles['twoturnmove']);
 		assert.cantMove(() => battle.makeChoices('move gravity', 'move fly'), 'Aerodactyl', 'Fly');
 	});
 });

--- a/test/sim/moves/gravity.js
+++ b/test/sim/moves/gravity.js
@@ -15,7 +15,7 @@ describe('Gravity', function () {
 		battle.setPlayer('p1', {team: [{species: 'Aerodactyl', ability: 'pressure', moves: ['gravity']}]});
 		battle.setPlayer('p2', {team: [{species: 'Aron', ability: 'sturdy', moves: ['earthpower']}]});
 		battle.makeChoices('move gravity', 'move earthpower');
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
 	it('should ground Pokemon with Levitate and remove their Ground immunity', function () {
@@ -23,7 +23,7 @@ describe('Gravity', function () {
 		battle.setPlayer('p1', {team: [{species: 'Rotom', ability: 'levitate', moves: ['gravity']}]});
 		battle.setPlayer('p2', {team: [{species: 'Aron', ability: 'sturdy', moves: ['earthpower']}]});
 		battle.makeChoices('move gravity', 'move earthpower');
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
 	it('should interrupt and disable the use of airborne moves', function () {

--- a/test/sim/moves/haze.js
+++ b/test/sim/moves/haze.js
@@ -58,7 +58,7 @@ describe('Haze - RBY', function () {
 		]);
 
 		battle.makeChoices('move splash', 'move focusenergy');
-		assert.ok(battle.p2.active[0].volatiles['focusenergy']);
+		assert(battle.p2.active[0].volatiles['focusenergy']);
 
 		battle.makeChoices('move splash', 'move haze');
 		assert.equal(typeof battle.p2.active[0].volatiles['focusenergy'], 'undefined');
@@ -71,10 +71,10 @@ describe('Haze - RBY', function () {
 		]);
 
 		battle.makeChoices('move reflect', 'move splash');
-		assert.ok(battle.p1.active[0].volatiles['reflect']);
+		assert(battle.p1.active[0].volatiles['reflect']);
 
 		battle.makeChoices('move lightscreen', 'move splash');
-		assert.ok(battle.p1.active[0].volatiles['lightscreen']);
+		assert(battle.p1.active[0].volatiles['lightscreen']);
 
 		battle.makeChoices('move haze', 'move splash');
 		assert.equal(typeof battle.p1.active[0].volatiles['reflect'], 'undefined');

--- a/test/sim/moves/haze.js
+++ b/test/sim/moves/haze.js
@@ -35,7 +35,7 @@ describe('Haze - RBY', function () {
 		assert.equal(battle.p2.active[0].status, 'par');
 
 		battle.makeChoices('move haze', 'move splash');
-		assert.notStrictEqual(battle.p2.active[0].status, 'par');
+		assert.notEqual(battle.p2.active[0].status, 'par');
 	});
 
 	it('should not remove user\'s status', function () {

--- a/test/sim/moves/healblock.js
+++ b/test/sim/moves/healblock.js
@@ -15,7 +15,7 @@ describe('Heal Block', function () {
 		battle.setPlayer('p1', {team: [{species: 'Hippowdon', ability: 'sandstream', moves: ['healblock']}]});
 		battle.setPlayer('p2', {team: [{species: 'Spiritomb', ability: 'pressure', item: 'leftovers', moves: ['calmmind']}]});
 		battle.makeChoices('move healblock', 'move calmmind');
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
 	it('should prevent Pokemon from consuming HP recovery items', function () {
@@ -61,7 +61,7 @@ describe('Heal Block', function () {
 		const hp = battle.p2.active[0].hp;
 		battle.makeChoices('move healblock', 'move leechseed');
 		assert.equal(battle.p2.active[0].hp, hp);
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
 	it('should not prevent the target from using Z-Powered healing status moves or healing from Z Power', function () {
@@ -87,7 +87,7 @@ describe('Heal Block [Gen 5]', function () {
 			[{species: 'Spiritomb', ability: 'pressure', item: 'leftovers', moves: ['calmmind']}],
 		]);
 		battle.makeChoices('move healblock', 'move calmmind');
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
 	it('should prevent Pokemon from consuming HP recovery items', function () {
@@ -129,7 +129,7 @@ describe('Heal Block [Gen 5]', function () {
 		const hp = battle.p2.active[0].hp;
 		battle.makeChoices('move healblock', 'move gigadrain');
 		assert.equal(battle.p2.active[0].hp, hp);
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
 	it('should prevent Leech Seed from healing HP', function () {
@@ -140,7 +140,7 @@ describe('Heal Block [Gen 5]', function () {
 		const hp = battle.p2.active[0].hp;
 		battle.makeChoices('move healblock', 'move leechseed');
 		assert.equal(battle.p2.active[0].hp, hp);
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 });
 
@@ -176,7 +176,7 @@ describe('Heal Block [Gen 4]', function () {
 		const hp = battle.p2.active[0].hp;
 		battle.makeChoices('move healblock', 'move gigadrain');
 		assert.equal(battle.p2.active[0].hp, hp);
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
 	it('should allow HP recovery items to activate', function () {
@@ -186,11 +186,11 @@ describe('Heal Block [Gen 4]', function () {
 		]);
 		battle.makeChoices('move healblock', 'move celebrate');
 		battle.makeChoices('move shadowball', 'move endure');
-		assert.notStrictEqual(battle.p2.active[0].hp, 1);
+		assert.notEqual(battle.p2.active[0].hp, 1);
 		battle.makeChoices('move healblock', 'switch 2');
 		battle.makeChoices('move shadowball', 'move endure');
 		assert.equal(battle.p2.active[0].item, '');
-		assert.notStrictEqual(battle.p2.active[0].hp, 1);
+		assert.notEqual(battle.p2.active[0].hp, 1);
 	});
 
 	it('should allow abilities that recover HP to activate', function () {
@@ -201,7 +201,7 @@ describe('Heal Block [Gen 4]', function () {
 		battle.makeChoices('move healblock', 'move bellydrum');
 		const hp = battle.p2.active[0].hp;
 		battle.makeChoices('move surf', 'move calmmind');
-		assert.notStrictEqual(battle.p2.active[0].hp, hp);
+		assert.notEqual(battle.p2.active[0].hp, hp);
 	});
 
 	it('should prevent Leech Seed from healing HP', function () {
@@ -213,6 +213,6 @@ describe('Heal Block [Gen 4]', function () {
 		const hp = battle.p2.active[0].hp;
 		battle.makeChoices('move healblock', 'move leechseed');
 		assert.equal(battle.p2.active[0].hp, hp);
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 });

--- a/test/sim/moves/imprison.js
+++ b/test/sim/moves/imprison.js
@@ -55,7 +55,7 @@ describe('Imprison', function () {
 
 		battle.makeChoices('move imprison', 'move sunnyday zmove');
 		assert.statStage(battle.p2.active[0], 'spe', 1);
-		assert.ok(battle.field.isWeather('sunnyday'));
+		assert(battle.field.isWeather('sunnyday'));
 	});
 
 	it(`should not prevent the user from using moves that a foe knows`, function () {

--- a/test/sim/moves/ingrain.js
+++ b/test/sim/moves/ingrain.js
@@ -56,7 +56,7 @@ describe('Ingrain', function () {
 		battle.setPlayer('p2', {team: [{species: 'Carnivine', ability: 'levitate', moves: ['earthquake', 'ingrain']}]});
 		battle.makeChoices('move ingrain', 'move ingrain');
 		battle.makeChoices('move earthquake', 'move earthquake');
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 });

--- a/test/sim/moves/miracleeye.js
+++ b/test/sim/moves/miracleeye.js
@@ -18,7 +18,7 @@ describe('Miracle Eye', function () {
 		]]);
 		battle.makeChoices('move miracle eye', 'move nasty plot');
 		battle.makeChoices('move psychic', 'move nasty plot');
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
 	it('should ignore the effect of positive evasion stat stages', function () {
@@ -31,7 +31,7 @@ describe('Miracle Eye', function () {
 		battle.boost({evasion: 6}, battle.p2.active[0]);
 		for (let i = 0; i < 3; i++) {
 			battle.makeChoices('move avalanche', 'move synthesis');
-			assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+			assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		}
 	});
 
@@ -45,7 +45,7 @@ describe('Miracle Eye', function () {
 		battle.boost({spe: 6, evasion: -6}, battle.p2.active[0]);
 		for (let i = 0; i < 3; i++) {
 			battle.makeChoices('move zap cannon', 'move roost');
-			assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+			assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		}
 	});
 });

--- a/test/sim/moves/mistyterrain.js
+++ b/test/sim/moves/mistyterrain.js
@@ -15,15 +15,15 @@ describe('Misty Terrain', function () {
 		battle.setPlayer('p1', {team: [{species: "Florges", ability: 'symbiosis', moves: ['mist', 'mistyterrain']}]});
 		battle.setPlayer('p2', {team: [{species: "Florges", ability: 'symbiosis', moves: ['mist']}]});
 		battle.makeChoices('move mistyterrain', 'move mist');
-		assert.ok(battle.field.isTerrain('mistyterrain'));
+		assert(battle.field.isTerrain('mistyterrain'));
 		battle.makeChoices('move mist', 'move mist');
-		assert.ok(battle.field.isTerrain('mistyterrain'));
+		assert(battle.field.isTerrain('mistyterrain'));
 		battle.makeChoices('move mist', 'move mist');
-		assert.ok(battle.field.isTerrain('mistyterrain'));
+		assert(battle.field.isTerrain('mistyterrain'));
 		battle.makeChoices('move mist', 'move mist');
-		assert.ok(battle.field.isTerrain('mistyterrain'));
+		assert(battle.field.isTerrain('mistyterrain'));
 		battle.makeChoices('move mist', 'move mist');
-		assert.ok(battle.field.isTerrain(''));
+		assert(battle.field.isTerrain(''));
 	});
 
 	it('should halve the base power of Dragon-type attacks on grounded Pokemon', function () {
@@ -66,7 +66,7 @@ describe('Misty Terrain', function () {
 		assert.equal(battle.p1.active[0].status, '');
 		const dataLine = battle.log[battle.lastMoveLine + 1].split('|');
 		assert.equal(dataLine[1], '-start');
-		assert.ok(toID(dataLine[3]).endsWith('yawn'));
+		assert(toID(dataLine[3]).endsWith('yawn'));
 	});
 
 	it('should cause Rest to fail on grounded Pokemon', function () {

--- a/test/sim/moves/mistyterrain.js
+++ b/test/sim/moves/mistyterrain.js
@@ -75,7 +75,7 @@ describe('Misty Terrain', function () {
 		battle.setPlayer('p2', {team: [{species: "Pidgeot", ability: 'keeneye', moves: ['doubleedge', 'rest']}]});
 		battle.makeChoices('move mistyterrain', 'move doubleedge');
 		battle.makeChoices('move rest', 'move rest');
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 

--- a/test/sim/moves/quash.js
+++ b/test/sim/moves/quash.js
@@ -39,6 +39,6 @@ describe('Quash', function () {
 		]});
 		battle.makeChoices('move quash 2, move earthquake', 'move voltswitch 2, move extremespeed 1');
 		battle.makeChoices('', 'switch 3, pass'); // Volt Switch
-		assert.notStrictEqual(battle.log[battle.lastMoveLine].split('|')[3], 'Extremespeed');
+		assert.notEqual(battle.log[battle.lastMoveLine].split('|')[3], 'Extremespeed');
 	});
 });

--- a/test/sim/moves/roost.js
+++ b/test/sim/moves/roost.js
@@ -40,13 +40,13 @@ describe('Roost', function () {
 		battle.makeChoices('move mudslap', 'move doubleedge');
 
 		battle.makeChoices('move mudslap', 'move roost');
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp); // Hit super-effectively by Mud Slap
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp); // Hit super-effectively by Mud Slap
 
 		// Ensure that Aerodactyl has some damage
 		battle.makeChoices('move mudslap', 'move doubleedge');
 
 		battle.makeChoices('move hiddenpowergrasss', 'move roost');
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp); // Hit super-effectively by HP Grass
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp); // Hit super-effectively by HP Grass
 	});
 
 	it('should suppress Flying type yet to be acquired this turn', function () {
@@ -93,9 +93,9 @@ describe('Roost - DPP', function () {
 
 		battle.makeChoices('move roost', 'move astonish');
 		battle.makeChoices('move roost', 'move astonish');
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp); // Affected by Astonish
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp); // Affected by Astonish
 
 		battle.makeChoices('move roost', 'move earthpower');
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp); // Affected by Earth Power
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp); // Affected by Earth Power
 	});
 });

--- a/test/sim/moves/roost.js
+++ b/test/sim/moves/roost.js
@@ -16,7 +16,7 @@ describe('Roost', function () {
 		battle.setPlayer('p1', {team: [{species: "Clefable", item: 'leftovers', ability: 'unaware', moves: ['calmmind']}]});
 		battle.setPlayer('p2', {team: [{species: "Dragonite", item: 'laggingtail', ability: 'multiscale', moves: ['roost']}]});
 		battle.makeChoices('move calmmind', 'move roost');
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-fail|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-fail|'));
 	});
 
 	it('should heal the user', function () {

--- a/test/sim/moves/skydrop.js
+++ b/test/sim/moves/skydrop.js
@@ -17,7 +17,7 @@ describe('Sky Drop', function () {
 		battle.makeChoices('move skydrop', 'move tackle');
 		assert.equal(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 		battle.makeChoices('move skydrop', 'move tackle');
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
 	it('should prevent its target from switching out when it is caught by the effect', function () {
@@ -120,7 +120,7 @@ describe('Sky Drop', function () {
 		battle.makeChoices('move Sky Drop', 'switch Ferrothorn');
 		assert.equal(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 		battle.makeChoices('move Sky Drop', 'move Harden');
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
 	it('should fail if the target has a Substitute', function () {
@@ -129,7 +129,7 @@ describe('Sky Drop', function () {
 		battle.setPlayer('p2', {team: [{species: "Lairon", ability: 'sturdy', moves: ['substitute', 'tackle']}]});
 		battle.makeChoices('move honeclaws', 'move substitute');
 		battle.makeChoices('move skydrop', 'move tackle');
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
 	it('should fail if the target is heavier than 200kg', function () {
@@ -137,7 +137,7 @@ describe('Sky Drop', function () {
 		battle.setPlayer('p1', {team: [{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}]});
 		battle.setPlayer('p2', {team: [{species: "Aggron", ability: 'sturdy', moves: ['tackle']}]});
 		battle.makeChoices('move skydrop', 'move tackle');
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
 	it('should fail if used against an ally', function () {
@@ -157,7 +157,7 @@ describe('Sky Drop', function () {
 		battle.makeChoices('move skydrop 1, move splash', 'move bulkup, move bulkup');
 		battle.makeChoices('move skydrop 1, move splash', 'move bulkup, move allyswitch');
 		assert.equal(battle.p2.active[1].species.id, 'lairon');
-		assert.notStrictEqual(battle.p2.active[1].hp, battle.p2.active[1].maxhp);
+		assert.notEqual(battle.p2.active[1].hp, battle.p2.active[1].maxhp);
 	});
 
 	it('should hit its target even if Follow Me is used that turn', function () {
@@ -167,7 +167,7 @@ describe('Sky Drop', function () {
 		]);
 		battle.makeChoices('move skydrop 1, move splash', 'move bulkup, move bulkup');
 		battle.makeChoices('move skydrop 1, move splash', 'move bulkup, move followme');
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		assert.equal(battle.p2.active[1].hp, battle.p2.active[1].maxhp);
 	});
 
@@ -254,18 +254,18 @@ describe('Sky Drop [Gen 5]', function () {
 
 		it('should end when the user switches out', function () {
 			battle.makeChoices('switch 3, move rockpolish', 'move tackle 2, move nastyplot');
-			assert.notStrictEqual(battle.p1.active[1].hp, battle.p1.active[1].maxhp);
+			assert.notEqual(battle.p1.active[1].hp, battle.p1.active[1].maxhp);
 		});
 
 		it('should end when the user faints', function () {
 			battle.makeChoices('move rockpolish, move recover', 'move tackle 2, move thunderbolt 1');
-			assert.notStrictEqual(battle.p1.active[1].hp, battle.p1.active[1].maxhp);
+			assert.notEqual(battle.p1.active[1].hp, battle.p1.active[1].maxhp);
 		});
 
 		it('should end when the user completes another two-turn move', function () {
 			battle.makeChoices('move dig 2, move recover', 'move sleeptalk, move nastyplot');
 			battle.makeChoices('move rockpolish, move recover', 'move tackle 2, move nastyplot');
-			assert.notStrictEqual(battle.p1.active[1].hp, battle.p1.active[1].maxhp);
+			assert.notEqual(battle.p1.active[1].hp, battle.p1.active[1].maxhp);
 		});
 	});
 });

--- a/test/sim/moves/smellingsalts.js
+++ b/test/sim/moves/smellingsalts.js
@@ -16,6 +16,6 @@ describe('Smelling Salts', function () {
 		battle.setPlayer('p2', {team: [{species: "Dragonite", ability: 'multiscale', moves: ['roost']}]});
 		battle.makeChoices('move thunderwave', 'move roost');
 		battle.makeChoices('move smellingsalts', 'move roost');
-		assert.notStrictEqual(battle.p2.active[0].status, 'par');
+		assert.notEqual(battle.p2.active[0].status, 'par');
 	});
 });

--- a/test/sim/moves/substitute.js
+++ b/test/sim/moves/substitute.js
@@ -45,7 +45,7 @@ describe('Substitute', function () {
 		battle.makeChoices('move substitute', 'move nastyplot');
 		battle.makeChoices('move doubleedge', 'move nastyplot');
 		const pokemon = battle.p1.active[0];
-		assert.notStrictEqual(pokemon.maxhp - pokemon.hp, Math.floor(pokemon.maxhp / 4));
+		assert.notEqual(pokemon.maxhp - pokemon.hp, Math.floor(pokemon.maxhp / 4));
 	});
 
 	it('should take specific recoil damage in Gen 1', function () {
@@ -117,7 +117,7 @@ describe('Substitute', function () {
 		battle.setPlayer('p2', {team: [{species: 'Dragonite', ability: 'hugepower', item: 'laggingtail', moves: ['roost', 'dualchop']}]});
 		battle.makeChoices('move substitute', 'move roost');
 		battle.makeChoices('move roost', 'move dualchop');
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 
 	it('should track what the actual damage would have been without the substitute in Gen 1', function () {

--- a/test/sim/moves/tarshot.js
+++ b/test/sim/moves/tarshot.js
@@ -64,10 +64,10 @@ describe('Tar Shot', function () {
 		battle.setPlayer('p1', {team: [{species: 'Coalossal', ability: 'steamengine', item: 'occaberry', moves: ['tarshot', 'flamecharge']}]});
 		battle.setPlayer('p2', {team: [{species: 'Ferrothorn', ability: 'ironbarbs', moves: ['rest', 'trick']}]});
 		battle.makeChoices('move flamecharge', 'move trick');
-		assert.notStrictEqual(battle.p1.active[0].hp, 0);
+		assert.notEqual(battle.p1.active[0].hp, 0);
 		// Ferrothorn now has the Occa Berry, cancelling out Tar Shot
 		battle.makeChoices('move tarshot', 'move rest');
 		battle.makeChoices('move flamecharge', 'move rest');
-		assert.notStrictEqual(battle.p1.active[0].hp, 0);
+		assert.notEqual(battle.p1.active[0].hp, 0);
 	});
 });

--- a/test/sim/moves/taunt.js
+++ b/test/sim/moves/taunt.js
@@ -26,6 +26,6 @@ describe('Taunt', function () {
 		battle.setPlayer('p2', {team: [{species: 'Charmander', ability: 'blaze', item: 'firiumz', moves: ['sunnyday']}]});
 		battle.makeChoices('move taunt', 'move sunnyday zmove');
 		assert.statStage(battle.p2.active[0], 'spe', 1);
-		assert.ok(battle.field.isWeather('sunnyday'));
+		assert(battle.field.isWeather('sunnyday'));
 	});
 });

--- a/test/sim/moves/thousandarrows.js
+++ b/test/sim/moves/thousandarrows.js
@@ -15,9 +15,9 @@ describe('Thousand Arrows', function () {
 		battle.setPlayer('p1', {team: [{species: "Zygarde", ability: 'aurabreak', item: 'laggingtail', moves: ['thousandarrows', 'earthquake']}]});
 		battle.setPlayer('p2', {team: [{species: "Tropius", ability: 'harvest', moves: ['synthesis']}]});
 		battle.makeChoices('move thousandarrows', 'move synthesis');
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		battle.makeChoices('move earthquake', 'move synthesis');
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
 	it('should ignore type effectiveness on the first hit against Flying-type Pokemon', function () {
@@ -37,7 +37,7 @@ describe('Thousand Arrows', function () {
 		battle.setPlayer('p1', {team: [{species: "Zygarde", level: 10, ability: 'aurabreak', item: 'laggingtail', moves: ['thousandarrows']}]});
 		battle.setPlayer('p2', {team: [{species: "Ho-Oh", ability: 'wonderguard', item: 'ringtarget', moves: ['recover']}]});
 		battle.makeChoices('move thousandarrows', 'move recover');
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
 	it('should not ground or deal neutral damage to Flying-type Pokemon holding an Iron Ball', function () {
@@ -47,7 +47,7 @@ describe('Thousand Arrows', function () {
 		battle.makeChoices('move thousandarrows', 'move recover');
 		assert.ok(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		const hp = battle.p2.active[0].hp;
-		assert.notStrictEqual(hp, battle.p2.active[0].maxhp);
+		assert.notEqual(hp, battle.p2.active[0].maxhp);
 		battle.makeChoices('move mudslap', 'move trick');
 		assert.equal(hp, battle.p2.active[0].hp);
 	});
@@ -73,9 +73,9 @@ describe('Thousand Arrows', function () {
 		battle.setPlayer('p1', {team: [{species: "Zygarde", ability: 'aurabreak', item: 'laggingtail', moves: ['thousandarrows', 'earthquake']}]});
 		battle.setPlayer('p2', {team: [{species: "Cresselia", ability: 'levitate', moves: ['recover']}]});
 		battle.makeChoices('move thousandarrows', 'move recover');
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		battle.makeChoices('move earthquake', 'move recover');
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
 	it('should hit non-Flying-type Pokemon with Levitate with standard type effectiveness', function () {
@@ -92,9 +92,9 @@ describe('Thousand Arrows', function () {
 		battle.setPlayer('p1', {team: [{species: "Zygarde", ability: 'aurabreak', item: 'laggingtail', moves: ['thousandarrows', 'earthquake']}]});
 		battle.setPlayer('p2', {team: [{species: "Donphan", ability: 'sturdy', item: 'airballoon', moves: ['stealthrock']}]});
 		battle.makeChoices('move thousandarrows', 'move stealthrock');
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 		battle.makeChoices('move earthquake', 'move stealthrock');
-		assert.notStrictEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
 	it('should not hit Ground-type Pokemon when affected by Electrify', function () {

--- a/test/sim/moves/thousandarrows.js
+++ b/test/sim/moves/thousandarrows.js
@@ -45,7 +45,7 @@ describe('Thousand Arrows', function () {
 		battle.setPlayer('p1', {team: [{species: "Zygarde", level: 10, ability: 'aurabreak', item: 'laggingtail', moves: ['thousandarrows', 'mudslap']}]});
 		battle.setPlayer('p2', {team: [{species: "Ho-Oh", ability: 'shellarmor', item: 'ironball', moves: ['recover', 'trick']}]});
 		battle.makeChoices('move thousandarrows', 'move recover');
-		assert.ok(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+		assert(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		const hp = battle.p2.active[0].hp;
 		assert.notEqual(hp, battle.p2.active[0].maxhp);
 		battle.makeChoices('move mudslap', 'move trick');
@@ -60,12 +60,12 @@ describe('Thousand Arrows', function () {
 		// During Gravity, Thousand Arrows can be super effective but once it ends has to be neutral for one hit
 		while (battle.field.getPseudoWeather('gravity')) {
 			battle.makeChoices('move thousandarrows', 'move recover');
-			assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+			assert(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		}
 		battle.makeChoices('move thousandarrows', 'move recover');
-		assert.ok(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+		assert(!battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		battle.makeChoices('move thousandarrows', 'move recover');
-		assert.ok(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 	});
 
 	it('should hit Pokemon with Levitate and remove their Ground immunity', function () {

--- a/test/sim/moves/transform.js
+++ b/test/sim/moves/transform.js
@@ -28,8 +28,8 @@ describe('Transform', function () {
 		for (const stat in p1poke.stats) {
 			assert.equal(p1poke.stats[stat], p2poke.stats[stat]);
 		}
-		assert.notStrictEqual(p1poke.hp, p2poke.hp);
-		assert.notStrictEqual(p1poke.maxhp, p2poke.maxhp);
+		assert.notEqual(p1poke.hp, p2poke.hp);
+		assert.notEqual(p1poke.maxhp, p2poke.maxhp);
 	});
 
 	it('should copy all stat changes', function () {
@@ -84,7 +84,7 @@ describe('Transform', function () {
 		battle.setPlayer('p1', {team: [{species: "Ditto", ability: 'limber', moves: ['transform']}]});
 		battle.setPlayer('p2', {team: [{species: "Hitmonlee", ability: 'unburden', item: 'normalgem', moves: ['feint']}]});
 		battle.makeChoices('move transform', 'move feint');
-		assert.notStrictEqual(battle.p1.active[0].getStat('spe'), battle.p2.active[0].getStat('spe'));
+		assert.notEqual(battle.p1.active[0].getStat('spe'), battle.p2.active[0].getStat('spe'));
 	});
 
 	it('should fail against Pokemon with a Substitute', function () {
@@ -92,7 +92,7 @@ describe('Transform', function () {
 		battle.setPlayer('p1', {team: [{species: "Ditto", ability: 'limber', moves: ['transform']}]});
 		battle.setPlayer('p2', {team: [{species: "Mewtwo", ability: 'pressure', moves: ['substitute']}]});
 		battle.makeChoices('move transform', 'move substitute');
-		assert.notStrictEqual(battle.p1.active[0].species, battle.p2.active[0].species);
+		assert.notEqual(battle.p1.active[0].species, battle.p2.active[0].species);
 	});
 
 	it('should fail against Pokemon with Illusion active', function () {
@@ -103,7 +103,7 @@ describe('Transform', function () {
 			{species: "Mewtwo", ability: 'pressure', moves: ['rest']},
 		]});
 		battle.makeChoices('move transform', 'move rest');
-		assert.notStrictEqual(battle.p1.active[0].species, battle.p2.active[0].species);
+		assert.notEqual(battle.p1.active[0].species, battle.p2.active[0].species);
 	});
 
 	it('should fail against tranformed Pokemon', function () {
@@ -117,7 +117,7 @@ describe('Transform', function () {
 		assert.equal(battle.p1.active[0].species, battle.p2.active[0].species);
 		battle.makeChoices('move splash', 'switch 2');
 		battle.makeChoices('move splash', 'move transform');
-		assert.notStrictEqual(battle.p1.active[0].species, battle.p2.active[0].species);
+		assert.notEqual(battle.p1.active[0].species, battle.p2.active[0].species);
 	});
 
 	it(`should copy the target's real type, even if the target is an Arceus`, function () {

--- a/test/sim/moves/transform.js
+++ b/test/sim/moves/transform.js
@@ -51,7 +51,7 @@ describe('Transform', function () {
 		battle.setPlayer('p1', {team: [{species: "Ditto", ability: 'limber', moves: ['transform']}]});
 		battle.setPlayer('p2', {team: [{species: "Sawk", ability: 'sturdy', moves: ['focusenergy']}]});
 		battle.makeChoices('move transform', 'move focusenergy');
-		assert.ok(battle.p1.active[0].volatiles['focusenergy']);
+		assert(battle.p1.active[0].volatiles['focusenergy']);
 	});
 
 	it('should copy the target\'s moves with 5 PP each', function () {
@@ -207,6 +207,6 @@ describe('Transform [Gen 1]', function () {
 		battle.setPlayer('p2', {team: [{species: "Gengar", moves: ['lick']}]});
 		battle.makeChoices('move transform', 'move lick');
 
-		assert.ok(battle.log.every(line => !line.startsWith('|-endability|')));
+		assert(battle.log.every(line => !line.startsWith('|-endability|')));
 	});
 });

--- a/test/sim/moves/trickroom.js
+++ b/test/sim/moves/trickroom.js
@@ -91,6 +91,6 @@ describe('Trick Room', function () {
 		});
 
 		battle.makeChoices('move earthquake', 'move gyroball');
-		assert.notStrictEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
 });

--- a/test/tools/modlog/converter.js
+++ b/test/tools/modlog/converter.js
@@ -662,7 +662,7 @@ describe('Modlog conversion script', () => {
 
 			assert.equal(visualIDEntry.note, 'Write 3');
 			assert.equal(visualIDEntry.visual_roomid, 'development tournament: lobby');
-			assert.ok(!globalEntries[0].visual_roomid);
+			assert(!globalEntries[0].visual_roomid);
 
 			assert.equal(globalEntries[0].timestamp, 1598212249945);
 			assert.equal(globalEntries[0].roomid.replace(/^global-/, ''), 'development');

--- a/test/tools/modlog/converter.js
+++ b/test/tools/modlog/converter.js
@@ -35,16 +35,16 @@ const garfieldCopypasta = [
 describe('Modlog conversion script', () => {
 	describe('bracket parser', () => {
 		it('should correctly parse parentheses', () => {
-			assert.strictEqual(converter.parseBrackets('(id)', '('), 'id');
+			assert.equal(converter.parseBrackets('(id)', '('), 'id');
 		});
 
 		it('should correctly parse square brackets', () => {
-			assert.strictEqual(converter.parseBrackets('[id]', '['), 'id');
+			assert.equal(converter.parseBrackets('[id]', '['), 'id');
 		});
 
 		it('should correctly parse the wrong type of bracket coming before', () => {
-			assert.strictEqual(converter.parseBrackets('(something) [id]', '['), 'id');
-			assert.strictEqual(converter.parseBrackets('[something] (id)', '('), 'id');
+			assert.equal(converter.parseBrackets('(something) [id]', '['), 'id');
+			assert.equal(converter.parseBrackets('[something] (id)', '('), 'id');
 		});
 	});
 
@@ -65,197 +65,197 @@ describe('Modlog conversion script', () => {
 				garfieldCopypasta,
 			];
 			for (const log of modernLogs) {
-				assert.strictEqual(converter.modernizeLog(log), log);
+				assert.equal(converter.modernizeLog(log), log);
 			}
 		});
 
 		it('should correctly parse old-format promotions and demotions', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) [annika] was promoted to Voice by [heartofetheria].'),
 				'[2020-08-23T19:50:49.944Z] (development) GLOBAL VOICE: [annika] by heartofetheria'
 			);
 
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) ([annika] was demoted to Room regular user by [heartofetheria].)'),
 				'[2020-08-23T19:50:49.944Z] (development) ROOMREGULAR USER: [annika] by heartofetheria: (demote)'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog(`[2017-05-31T22:00:33.159Z] (espanol) vodsrtrainer MAR cos was demoted to Room regular user by [blazask].`),
 				`[2017-05-31T22:00:33.159Z] (espanol) ROOMREGULAR USER: [vodsrtrainermarcos] by blazask: (demote)`
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) ([annika] was demoted to Room Moderator by [heartofetheria].)'),
 				'[2020-08-23T19:50:49.944Z] (development) ROOMMODERATOR: [annika] by heartofetheria: (demote)'
 			);
 
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) [annika] was appointed Room Owner by [heartofetheria].'),
 				'[2020-08-23T19:50:49.944Z] (development) ROOMOWNER: [annika] by heartofetheria'
 			);
 		});
 
 		it('should correctly parse entries about modchat and modjoin', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) ([annika] set modchat to autoconfirmed)'),
 				'[2020-08-23T19:50:49.944Z] (development) MODCHAT: by annika: to autoconfirmed'
 			);
 
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) Annika set modjoin to +.'),
 				'[2020-08-23T19:50:49.944Z] (development) MODJOIN: by annika: +'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) Annika turned off modjoin.'),
 				'[2020-08-23T19:50:49.944Z] (development) MODJOIN: by annika: OFF'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) Annika set modjoin to sync.'),
 				'[2020-08-23T19:50:49.944Z] (development) MODJOIN SYNC: by annika'
 			);
 		});
 
 		it('should correctly parse modnotes', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog(`[2020-08-23T19:50:49.944Z] (development) ([annika] notes: I'm making a modnote)`),
 				`[2020-08-23T19:50:49.944Z] (development) NOTE: by annika: I'm making a modnote`
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog(`[2017-10-04T20:48:14.592Z] (bigbang) (Lionyx notes: test was banned by lionyx`),
 				`[2017-10-04T20:48:14.592Z] (bigbang) NOTE: by lionyx: test was banned by lionyx`
 			);
 		});
 
 		it('should correctly parse userids containing `notes`', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog(`[2014-11-24T11:10:34.798Z] (lobby) ([joimnotesyakcity] was trolled by his friends)`),
 				`[2014-11-24T11:10:34.798Z] (lobby) [joimnotesyakcity] was trolled by his friends`
 			);
 		});
 
 		it('should correctly parse roomintro and staffintro entries', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) (Annika changed the roomintro.)'),
 				'[2020-08-23T19:50:49.944Z] (development) ROOMINTRO: by annika'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) (Annika changed the staffintro.)'),
 				'[2020-08-23T19:50:49.944Z] (development) STAFFINTRO: by annika'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) (Annika deleted the roomintro.)'),
 				'[2020-08-23T19:50:49.944Z] (development) DELETEROOMINTRO: by annika'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) (Annika deleted the staffintro.)'),
 				'[2020-08-23T19:50:49.944Z] (development) DELETESTAFFINTRO: by annika'
 			);
 		});
 
 		it('should correctly parse room description changes', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) ([annika] changed the roomdesc to: "a description".)'),
 				'[2020-08-23T19:50:49.944Z] (development) ROOMDESC: by annika: to "a description"'
 			);
 		});
 
 		it('should correctly parse declarations', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) Annika declared I am declaring something'),
 				'[2020-08-23T19:50:49.944Z] (development) DECLARE: by annika: I am declaring something'
 			);
 
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) Annika declared: I am declaring something'),
 				'[2020-08-23T19:50:49.944Z] (development) DECLARE: by annika: I am declaring something'
 			);
 
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) Annika globally declared (chat level) I am chat declaring something'),
 				'[2020-08-23T19:50:49.944Z] (development) CHATDECLARE: by annika: I am chat declaring something'
 			);
 
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) Annika globally declared I am globally declaring something'),
 				'[2020-08-23T19:50:49.944Z] (development) GLOBALDECLARE: by annika: I am globally declaring something'
 			);
 		});
 
 		it('should correctly parse entries about roomevents', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) (Annika edited the roomevent titled "Writing Unit Tests".)'),
 				'[2020-08-23T19:50:49.944Z] (development) ROOMEVENT: by annika: edited "Writing Unit Tests"'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) (Annika removed a roomevent titled "Writing Unit Tests".)'),
 				'[2020-08-23T19:50:49.944Z] (development) ROOMEVENT: by annika: removed "Writing Unit Tests"'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) (Annika added a roomevent titled "Writing Unit Tests".)'),
 				'[2020-08-23T19:50:49.944Z] (development) ROOMEVENT: by annika: added "Writing Unit Tests"'
 			);
 		});
 
 		it('should correctly parse old-format tournament modlogs', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (tournaments) ([annika] created a tournament in randombattle format.)'),
 				'[2020-08-23T19:50:49.944Z] (tournaments) TOUR CREATE: by annika: randombattle'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (tournaments) ([heartofetheria] was disqualified from the tournament by Annika)'),
 				'[2020-08-23T19:50:49.944Z] (tournaments) TOUR DQ: [heartofetheria] by annika'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (tournaments) (The tournament auto disqualify timeout was set to 2 by Annika)'),
 				'[2020-08-23T19:50:49.944Z] (tournaments) TOUR AUTODQ: by annika: 2'
 			);
 		});
 
 		it('should correctly parse old-format roombans', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) [heartofetheria] was banned from room development by annika'),
 				'[2020-08-23T19:50:49.944Z] (development) ROOMBAN: [heartofetheria] by annika'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) [heartofetheria] was banned from room development by annika (reason)'),
 				'[2020-08-23T19:50:49.944Z] (development) ROOMBAN: [heartofetheria] by annika: reason'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog(`[2015-06-07T13:44:30.057Z] (shituusers) ROOMBAN: [eyan] (You have been kicked by +Cynd(~'e')~quil. Reason: Undefined) by shituubot`),
 				`[2015-06-07T13:44:30.057Z] (shituusers) ROOMBAN: [eyan] by shituubot: You have been kicked by +Cynd(~'e')~quil. Reason: Undefined`
 			);
 		});
 
 		it('should correctly parse old-format mutes', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) [heartofetheria] was muted by annikafor1hour (reason)'),
 				'[2020-08-23T19:50:49.944Z] (development) HOURMUTE: [heartofetheria] by annika: reason'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) heartofetheria was muted by Annika for 1 hour (reason)'),
 				'[2020-08-23T19:50:49.944Z] (development) HOURMUTE: [heartofetheria] by annika: reason'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2016-09-27T18:25:55.574Z] (swag) harembe⚠ was muted by rubyfor1hour (harembe was promoted to ! by ruby.)'),
 				'[2016-09-27T18:25:55.574Z] (swag) HOURMUTE: [harembe] by ruby: harembe was promoted to ! by ruby.'
 			);
 		});
 
 		it('should correctly parse old-format weeklocks', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) heartofetheria was locked from talking for a week by annika (reason) [IP]'),
 				'[2020-08-23T19:50:49.944Z] (development) WEEKLOCK: [heartofetheria] [IP] by annika: reason'
 			);
 		});
 
 		it('should correctly parse old-format global bans', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) [heartofetheria] was banned by annika (reason) [IP]'),
 				'[2020-08-23T19:50:49.944Z] (development) BAN: [heartofetheria] [IP] by annika: reason'
 			);
 		});
 
 		it('should correctly parse alts using nextLine', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog(
 					'[2020-08-23T19:50:49.944Z] (development) heartofetheria was locked from talking for a week by annika (reason)',
 					`[2020-08-23T19:50:49.944Z] (development) ([heartofetheria]'s locked alts: [annika0], [hordeprime])`
@@ -263,7 +263,7 @@ describe('Modlog conversion script', () => {
 				'[2020-08-23T19:50:49.944Z] (development) WEEKLOCK: [heartofetheria] alts: [annika0], [hordeprime] by annika: reason'
 			);
 
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog(
 					'[2020-08-23T19:50:49.944Z] (development) [heartofetheria] was banned from room development by annika',
 					`[2020-08-23T19:50:49.944Z] (development) ([heartofetheria]'s banned alts: [annika0], [hordeprime])`
@@ -273,34 +273,34 @@ describe('Modlog conversion script', () => {
 		});
 
 		it('should correctly parse poll modlogs', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) ([apoll] was started by [annika].)',),
 				'[2020-08-23T19:50:49.944Z] (development) POLL: by annika'
 			);
 
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (development) ([thepoll] was ended by [annika].)',),
 				'[2020-08-23T19:50:49.944Z] (development) POLL END: by annika'
 			);
 		});
 
 		it('should correctly parse Trivia modlogs', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (trivia) (User annika won the game of Triumvirate mode trivia under the All category with a cap of 50 points, with 50 points and 10 correct answers! Second place: heartofetheria (10 points), third place: hordeprime (5 points))'),
 				'[2020-08-23T19:50:49.944Z] (trivia) TRIVIAGAME: by unknown: User annika won the game of Triumvirate mode trivia under the All category with a cap of 50 points, with 50 points and 10 correct answers! Second place: heartofetheria (10 points), third place: hordeprime (5 points)'
 			);
 		});
 
 		it('should handle claiming helptickets', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (help-heartofetheria) Annika claimed this ticket.'),
 				'[2020-08-23T19:50:49.944Z] (help-heartofetheria) TICKETCLAIM: by annika'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (help-heartofetheria) This ticket is now claimed by Annika.'),
 				'[2020-08-23T19:50:49.944Z] (help-heartofetheria) TICKETCLAIM: by annika'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (help-heartofetheria) This ticket is now claimed by [annika]'),
 				'[2020-08-23T19:50:49.944Z] (help-heartofetheria) TICKETCLAIM: by annika'
 			);
@@ -308,49 +308,49 @@ describe('Modlog conversion script', () => {
 
 		it('should handle closing helptickets', () => {
 			// Abandonment
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (help-heartofetheria) This ticket is no longer claimed.'),
 				'[2020-08-23T19:50:49.944Z] (help-heartofetheria) TICKETUNCLAIM'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (help-heartofetheria) Heart of Etheria is no longer interested in this ticket.'),
 				'[2020-08-23T19:50:49.944Z] (help-heartofetheria) TICKETABANDON: by heartofetheria'
 			);
 
 			// Closing
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (help-heartofetheria) Annika closed this ticket.'),
 				'[2020-08-23T19:50:49.944Z] (help-heartofetheria) TICKETCLOSE: by annika'
 			);
 
 			// Deletion
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (help-heartofetheria) Annika deleted this ticket.'),
 				'[2020-08-23T19:50:49.944Z] (help-heartofetheria) TICKETDELETE: by annika'
 			);
 		});
 
 		it('should handle opening helptickets', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (help-heartofetheria) Heart of Etheria opened a new ticket. Issue: Being trapped in a unit test factory'),
 				'[2020-08-23T19:50:49.944Z] (help-heartofetheria) TICKETOPEN: by heartofetheria: Being trapped in a unit test factory'
 			);
 		});
 
 		it('should handle Scavengers modlogs', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (scavengers) SCAV SETHOSTPOINTS: [room: subroom] by annika: 42'),
 				'[2020-08-23T19:50:49.944Z] (scavengers) SCAV SETHOSTPOINTS: by annika: 42 [room: subroom]'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (scavengers) SCAV TWIST: [room: subroom] by annika: your mom'),
 				'[2020-08-23T19:50:49.944Z] (scavengers) SCAV TWIST: by annika: your mom [room: subroom]'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (scavengers) SCAV SETPOINTS: [room: subroom] by annika: ååååååå'),
 				'[2020-08-23T19:50:49.944Z] (scavengers) SCAV SETPOINTS: by annika: ååååååå [room: subroom]'
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog('[2020-08-23T19:50:49.944Z] (scavengers) ([annika] has been caught attempting a hunt with 2 connections on the account. The user has also been given 1 infraction point on the player leaderboard.)'),
 				'[2020-08-23T19:50:49.944Z] (scavengers) SCAV CHEATER: [annika]: caught attempting a hunt with 2 connections on the account; has also been given 1 infraction point on the player leaderboard'
 			);
@@ -360,18 +360,18 @@ describe('Modlog conversion script', () => {
 		});
 
 		it('should handle Wi-Fi modlogs', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog(`[2020-08-23T19:50:49.944Z] (wifi) GIVEAWAY WIN: Annika won Heart of Etheria's giveaway for a "deluxe shitposter 1000" (OT: Entrapta TID: 1337)`),
 				`[2020-08-23T19:50:49.944Z] (wifi) GIVEAWAY WIN: [annika]: Heart of Etheria's giveaway for a "deluxe shitposter 1000" (OT: Entrapta TID: 1337)`
 			);
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog(`[2020-08-23T19:50:49.944Z] (wifi) GTS FINISHED: Annika has finished their GTS giveaway for "deluxe shitposter 2000"`),
 				`[2020-08-23T19:50:49.944Z] (wifi) GTS FINISHED: [annika]: their GTS giveaway for "deluxe shitposter 2000"`
 			);
 		});
 
 		it('should handle global declarations mentioning promotions correctly', () => {
-			assert.strictEqual(
+			assert.equal(
 				converter.modernizeLog(`[2015-07-21T06:04:54.369Z] (lobby) xfix declared GrumpyGungan was promoted to a global voice, feel free to congratulate him :-).`),
 				`[2015-07-21T06:04:54.369Z] (lobby) DECLARE: by xfix: GrumpyGungan was promoted to a global voice, feel free to congratulate him :-).`
 			);
@@ -380,7 +380,7 @@ describe('Modlog conversion script', () => {
 
 	describe('text entry to ModlogEntry converter', () => {
 		it('should correctly parse modernized promotions and demotions', () => {
-			assert.deepStrictEqual(
+			assert.deepEqual(
 				converter.parseModlog(`[2020-08-23T19:50:49.944Z] (development) ROOMMODERATOR: [annika] by heartofetheria`),
 				{
 					action: 'ROOMMODERATOR', roomID: 'development', userid: 'annika',
@@ -388,7 +388,7 @@ describe('Modlog conversion script', () => {
 				}
 			);
 
-			assert.deepStrictEqual(
+			assert.deepEqual(
 				converter.parseModlog(`[2020-08-23T19:50:49.944Z] (development) ROOMVOICE: [annika] by heartofetheria: (demote)`),
 				{
 					action: 'ROOMVOICE', roomID: 'development', userid: 'annika',
@@ -399,7 +399,7 @@ describe('Modlog conversion script', () => {
 
 		it('should not mess up HIDEALTSTEXT', () => {
 			// HIDEALTSTEXT apparently was causing bugs
-			assert.deepStrictEqual(
+			assert.deepEqual(
 				converter.parseModlog(`[2020-08-23T19:50:49.944Z] (development) HIDEALTSTEXT: [auser] alts:[alt1] by annika: hnr`),
 				{
 					action: 'HIDEALTSTEXT', roomID: 'development', userid: 'auser', alts: ['alt1'],
@@ -409,14 +409,14 @@ describe('Modlog conversion script', () => {
 		});
 
 		it('should correctly parse modernized punishments, including alts/IP/autoconfirmed', () => {
-			assert.deepStrictEqual(
+			assert.deepEqual(
 				converter.parseModlog(`[2020-08-23T19:50:49.944Z] (development) WEEKLOCK: [gejg] ac: [annika] alts: [annalytically], [heartofetheria] [127.0.0.1] by somemod: terrible user`),
 				{
 					action: 'WEEKLOCK', roomID: 'development', userid: 'gejg', autoconfirmedID: 'annika', alts: ['annalytically', 'heartofetheria'],
 					ip: '127.0.0.1', isGlobal: false, loggedBy: 'somemod', note: 'terrible user', time: 1598212249944,
 				}
 			);
-			assert.deepStrictEqual(
+			assert.deepEqual(
 				converter.parseModlog(`[2020-08-23T19:50:49.944Z] (development) WEEKLOCK: [gejg] ac:[annika] alts:[annalytically], [heartofetheria] [127.0.0.1] by somemod: terrible user`),
 				{
 					action: 'WEEKLOCK', roomID: 'development', userid: 'gejg', autoconfirmedID: 'annika', alts: ['annalytically', 'heartofetheria'],
@@ -425,7 +425,7 @@ describe('Modlog conversion script', () => {
 			);
 
 
-			assert.deepStrictEqual(
+			assert.deepEqual(
 				converter.parseModlog(`[2020-08-23T19:50:49.944Z] (development) WEEKLOCK: [gejg] alts:[annalytically] [127.0.0.1] by somemod: terrible user`),
 				{
 					action: 'WEEKLOCK', roomID: 'development', userid: 'gejg', alts: ['annalytically'],
@@ -433,7 +433,7 @@ describe('Modlog conversion script', () => {
 				}
 			);
 
-			assert.deepStrictEqual(
+			assert.deepEqual(
 				converter.parseModlog(`[2020-08-23T19:50:49.944Z] (development) WEEKLOCK: [gejg] [127.0.0.1] by somemod: terrible user`),
 				{
 					action: 'WEEKLOCK', roomID: 'development', userid: 'gejg',
@@ -443,7 +443,7 @@ describe('Modlog conversion script', () => {
 		});
 
 		it('should correctly parse modnotes', () => {
-			assert.deepStrictEqual(
+			assert.deepEqual(
 				converter.parseModlog(`[2020-08-23T19:50:49.944Z] (development) NOTE: by annika: HELP! I'm trapped in a unit test factory...`),
 				{
 					action: 'NOTE', roomID: 'development', isGlobal: false, loggedBy: 'annika',
@@ -454,15 +454,15 @@ describe('Modlog conversion script', () => {
 
 		it('should correctly parse visual roomids', () => {
 			const withVisualID = converter.parseModlog(`[time] (battle-gen7randombattle-1 tournament: development) SOMETHINGBORING: by annika`);
-			assert.strictEqual(withVisualID.visualRoomID, 'battle-gen7randombattle-1 tournament: development');
-			assert.strictEqual(withVisualID.roomID, 'battle-gen7randombattle-1');
+			assert.equal(withVisualID.visualRoomID, 'battle-gen7randombattle-1 tournament: development');
+			assert.equal(withVisualID.roomID, 'battle-gen7randombattle-1');
 
 			const noVisualID = converter.parseModlog(`[time] (battle-gen7randombattle-1) SOMETHINGBORING: by annika`);
-			assert.strictEqual(noVisualID.visualRoomID, undefined);
+			assert.equal(noVisualID.visualRoomID, undefined);
 		});
 
 		it('should properly handle OLD MODLOG', () => {
-			assert.deepStrictEqual(
+			assert.deepEqual(
 				converter.parseModlog(`[2014-11-20T13:46:00.288Z] (lobby) OLD MODLOG: by unknown: [punchoface] would be muted by [thecaptain] but was already muted.)`),
 				{
 					action: 'OLD MODLOG', roomID: 'lobby', isGlobal: false, loggedBy: 'unknown',
@@ -472,21 +472,21 @@ describe('Modlog conversion script', () => {
 		});
 
 		it('should correctly handle hangman', () => {
-			assert.deepStrictEqual(
+			assert.deepEqual(
 				converter.parseModlog(`[2020-09-19T23:25:24.908Z] (lobby) HANGMAN: by archastl`),
 				{action: 'HANGMAN', roomID: 'lobby', isGlobal: false, loggedBy: 'archastl', time: 1600557924908}
 			);
 		});
 
 		it('should correctly handle nonstandard alt formats', () => {
-			assert.deepStrictEqual(
+			assert.deepEqual(
 				converter.parseModlog(
 					`[2018-01-18T19:47:11.404Z] (battle-gen7randombattle-690788015) AUTOLOCK: [trreckko] alts:[MasterOP13, [luckyfella], Derp11223, [askul], vfffgcfvgvfghj, trreckko, MrShnugglebear] [127.0.0.1]: Pornhub__.__com/killyourself`
 				).alts,
 				['masterop13', 'luckyfella', 'derp11223', 'askul', 'vfffgcfvgvfghj', 'trreckko', 'mrshnugglebear']
 			);
 
-			assert.deepStrictEqual(
+			assert.deepEqual(
 				converter.parseModlog(
 					`[2018-01-20T10:19:19.763Z] (battle-gen7randombattle-691544312) AUTOLOCK: [zilgo] alts:[[ghjkjguygjbjb], zilgo] [127.0.0.1]: www__.__pornhub__.__com`
 				).alts,
@@ -495,14 +495,14 @@ describe('Modlog conversion script', () => {
 		});
 
 		it('should correctly handle modlog entries with an IP but no userid', () => {
-			assert.deepStrictEqual(
+			assert.deepEqual(
 				converter.parseModlog(`[2020-09-30T20:02:12.456Z] (lobby) SHAREDIP: [127.0.0.1] by annika: j`),
 				{
 					action: 'SHAREDIP', roomID: 'lobby', isGlobal: false, loggedBy: 'annika',
 					note: `j`, time: 1601496132456, ip: "127.0.0.1",
 				}
 			);
-			assert.deepStrictEqual(
+			assert.deepEqual(
 				converter.parseModlog(`[2020-09-30T20:02:12.456Z] (lobby) UNSHAREDIP: [127.0.0.1] by annika`),
 				{
 					action: 'UNSHAREDIP', roomID: 'lobby', isGlobal: false, loggedBy: 'annika',
@@ -526,14 +526,14 @@ describe('Modlog conversion script', () => {
 				note: 'Hey Adora~',
 				time: 1598212249944,
 			};
-			assert.strictEqual(
+			assert.equal(
 				converter.rawifyLog(entry),
 				`[2020-08-23T19:50:49.944Z] (development) UNITTEST: [annika] ac: [heartofetheria] alts: [googlegoddess], [princessentrapta] [127.0.0.1] by yourmom: Hey Adora~\n`
 			);
 		});
 
 		it('should handle OLD MODLOG', () => {
-			assert.deepStrictEqual(
+			assert.deepEqual(
 				converter.rawifyLog({
 					action: 'OLD MODLOG', roomID: 'development', isGlobal: false, loggedBy: 'unknown',
 					note: `hello hi test`, time: 1598212249944,
@@ -543,7 +543,7 @@ describe('Modlog conversion script', () => {
 		});
 
 		it('should handle hangman', () => {
-			assert.deepStrictEqual(
+			assert.deepEqual(
 				converter.rawifyLog({action: 'HANGMAN', roomID: 'lobby', isGlobal: false, loggedBy: 'archastl', time: 1600557924908}),
 				`[2020-09-19T23:25:24.908Z] (lobby) HANGMAN: by archastl\n`
 			);
@@ -568,7 +568,7 @@ describe('Modlog conversion script', () => {
 				garfieldCopypasta,
 			];
 			for (const test of tests) {
-				assert.strictEqual(test, converter.rawifyLog(converter.parseModlog(test)).replace('\n', ''));
+				assert.equal(test, converter.rawifyLog(converter.parseModlog(test)).replace('\n', ''));
 			}
 		});
 
@@ -577,7 +577,7 @@ describe('Modlog conversion script', () => {
 				`[2014-11-20T16:30:17.661Z] (lobby) LOCK: [violight] (spamming) by joim`,
 				`[2014-11-20T16:30:17.673Z] (lobby) (violight's ac account: violight)`
 			)).replace('\n', '');
-			assert.strictEqual(originalConvert, converter.rawifyLog(converter.parseModlog(originalConvert)).replace('\n', ''));
+			assert.equal(originalConvert, converter.rawifyLog(converter.parseModlog(originalConvert)).replace('\n', ''));
 		});
 	});
 
@@ -619,7 +619,7 @@ describe('Modlog conversion script', () => {
 			});
 
 			await mlConverter.toTxt();
-			assert.strictEqual(
+			assert.equal(
 				mlConverter.isTesting.files.get('/modlog_development.txt'),
 				`[2020-08-23T19:50:49.944Z] (development) UNITTEST: [annika] ac: [heartofetheria] alts: [googlegoddess], [princessentrapta] [127.0.0.1] by yourmom: Write 1\n` +
 				`[2020-08-23T19:50:49.945Z] (development) UNITTEST: [annika] ac: [heartofetheria] alts: [googlegoddess], [princessentrapta] [127.0.0.1] by yourmom: Write 2\n` +
@@ -627,7 +627,7 @@ describe('Modlog conversion script', () => {
 				`[2020-08-23T19:50:49.947Z] (development) GLOBAL UNITTEST: [annika] ac: [heartofetheria] alts: [googlegoddess], [princessentrapta] [127.0.0.1] by yourmom: Global test\n`
 			);
 
-			assert.strictEqual(
+			assert.equal(
 				mlConverter.isTesting.files.get('/modlog_global.txt'),
 				`[2020-08-23T19:50:49.947Z] (development) GLOBAL UNITTEST: [annika] ac: [heartofetheria] alts: [googlegoddess], [princessentrapta] [127.0.0.1] by yourmom: Global test\n`
 			);
@@ -655,24 +655,24 @@ describe('Modlog conversion script', () => {
 				.prepare(`SELECT *, (SELECT group_concat(userid, ',') FROM alts WHERE alts.modlog_id = modlog.modlog_id) as alts FROM modlog WHERE roomid IN (?, ?) ORDER BY timestamp ASC`)
 				.all('development', 'trivia');
 
-			assert.strictEqual(globalEntries.length, globalLines.length);
-			assert.strictEqual(entries.length, lines.length);
+			assert.equal(globalEntries.length, globalLines.length);
+			assert.equal(entries.length, lines.length);
 
 			const visualIDEntry = entries[entries.length - 1];
 
-			assert.strictEqual(visualIDEntry.note, 'Write 3');
-			assert.strictEqual(visualIDEntry.visual_roomid, 'development tournament: lobby');
+			assert.equal(visualIDEntry.note, 'Write 3');
+			assert.equal(visualIDEntry.visual_roomid, 'development tournament: lobby');
 			assert.ok(!globalEntries[0].visual_roomid);
 
-			assert.strictEqual(globalEntries[0].timestamp, 1598212249945);
-			assert.strictEqual(globalEntries[0].roomid.replace(/^global-/, ''), 'development');
-			assert.strictEqual(globalEntries[0].action, 'GLOBAL UNITTEST');
-			assert.strictEqual(globalEntries[0].action_taker_userid, 'yourmom');
-			assert.strictEqual(globalEntries[0].userid, 'annika');
-			assert.strictEqual(globalEntries[0].autoconfirmed_userid, 'heartofetheria');
-			assert.strictEqual(globalEntries[0].ip, '127.0.0.1');
-			assert.strictEqual(globalEntries[0].note, 'Global Write');
-			assert.strictEqual(globalEntries[0].alts, 'googlegoddess,princessentrapta');
+			assert.equal(globalEntries[0].timestamp, 1598212249945);
+			assert.equal(globalEntries[0].roomid.replace(/^global-/, ''), 'development');
+			assert.equal(globalEntries[0].action, 'GLOBAL UNITTEST');
+			assert.equal(globalEntries[0].action_taker_userid, 'yourmom');
+			assert.equal(globalEntries[0].userid, 'annika');
+			assert.equal(globalEntries[0].autoconfirmed_userid, 'heartofetheria');
+			assert.equal(globalEntries[0].ip, '127.0.0.1');
+			assert.equal(globalEntries[0].note, 'Global Write');
+			assert.equal(globalEntries[0].alts, 'googlegoddess,princessentrapta');
 		});
 	});
 });


### PR DESCRIPTION
It turns out that when I switched us from `assert` to `assert.strict`, I didn't actually update any existing tests or tell anyone:

https://github.com/smogon/pokemon-showdown/commit/0df0d234f2ae65f69e17a15c938a5c7c9a9352ac

So apparently everyone else just kept on using `strictEqual`.

This will be a PR and also throw an error if people continue trying to use it, which should make it much clearer what PS policy is on this.

A lot of the problem may be that TypeScript marks assert.strict.equal as deprecated when it's not. This was fixed 4 days ago:

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48452

But this probably hasn't made it to a thing yet. Until then, you'll have to deal with TS marking your tests as deprecated, but it shouldn't be too long.