### PR TITLE
Ban Japanese Gen 1 Events in International Formats

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2860,7 +2860,7 @@ export const Formats: FormatList = [
 		mod: 'gen1',
 		searchShow: false,
 		ruleset: ['Standard'],
-		banlist: ['Magikarp + Dragon Rage', 'Rapidash + Pay Day', 'Fearow + Pay Day', 'Pikachu + Fly', 'Raichu + Fly']
+		banlist: ['Magikarp + Dragon Rage', 'Rapidash + Pay Day', 'Fearow + Pay Day', 'Pikachu + Fly', 'Raichu + Fly'],
 	},
 	{
 		name: "[Gen 1] UU",
@@ -2887,7 +2887,7 @@ export const Formats: FormatList = [
 		banlist: ['Uber',
 			'Nidoking + Fury Attack + Thrash', 'Exeggutor + Poison Powder + Stomp', 'Exeggutor + Sleep Powder + Stomp',
 			'Exeggutor + Stun Spore + Stomp', 'Jolteon + Focus Energy + Thunder Shock', 'Flareon + Focus Energy + Ember',
-			'Magikarp + Dragon Rage', 'Rapidash + Pay Day', 'Fearow + Pay Day', 'Pikachu + Fly', 'Raichu + Fly'
+			'Magikarp + Dragon Rage', 'Rapidash + Pay Day', 'Fearow + Pay Day', 'Pikachu + Fly', 'Raichu + Fly',
 		],
 	},
 	{
@@ -2899,7 +2899,7 @@ export const Formats: FormatList = [
 		banlist: ['Uber',
 			'Nidoking + Fury Attack + Thrash', 'Exeggutor + Poison Powder + Stomp', 'Exeggutor + Sleep Powder + Stomp',
 			'Exeggutor + Stun Spore + Stomp', 'Jolteon + Focus Energy + Thunder Shock', 'Flareon + Focus Energy + Ember',
-			'Magikarp + Dragon Rage', 'Rapidash + Pay Day', 'Fearow + Pay Day', 'Pikachu + Fly', 'Raichu + Fly'
+			'Magikarp + Dragon Rage', 'Rapidash + Pay Day', 'Fearow + Pay Day', 'Pikachu + Fly', 'Raichu + Fly',
 		],
 	},
 	{

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1717,7 +1717,7 @@ export const Formats: FormatList = [
 
 		mod: 'gen1',
 		ruleset: ['Standard'],
-		banlist: ['Uber'],
+		banlist: ['Uber', 'Pikachu + Fly', 'Raichu + Fly', 'Rapidash + Pay Day', 'Fearow + Pay Day', 'Magikarp + Dragon Rage'],
 	},
 
 	// US/UM Singles
@@ -2860,6 +2860,7 @@ export const Formats: FormatList = [
 		mod: 'gen1',
 		searchShow: false,
 		ruleset: ['Standard'],
+		banlist: ['Magikarp + Dragon Rage', 'Rapidash + Pay Day', 'Fearow + Pay Day', 'Pikachu + Fly', 'Raichu + Fly']
 	},
 	{
 		name: "[Gen 1] UU",
@@ -2871,7 +2872,7 @@ export const Formats: FormatList = [
 		mod: 'gen1',
 		searchShow: false,
 		ruleset: ['[Gen 1] OU'],
-		banlist: ['OU', 'UUBL'],
+		banlist: ['OU', 'UUBL', 'Magikarp + Dragon Rage', 'Rapidash + Pay Day', 'Fearow + Pay Day', 'Pikachu + Fly', 'Raichu + Fly'],
 	},
 	{
 		name: "[Gen 1] OU (Tradeback)",
@@ -2886,6 +2887,7 @@ export const Formats: FormatList = [
 		banlist: ['Uber',
 			'Nidoking + Fury Attack + Thrash', 'Exeggutor + Poison Powder + Stomp', 'Exeggutor + Sleep Powder + Stomp',
 			'Exeggutor + Stun Spore + Stomp', 'Jolteon + Focus Energy + Thunder Shock', 'Flareon + Focus Energy + Ember',
+			'Magikarp + Dragon Rage', 'Rapidash + Pay Day', 'Fearow + Pay Day', 'Pikachu + Fly', 'Raichu + Fly'
 		],
 	},
 	{
@@ -2897,6 +2899,7 @@ export const Formats: FormatList = [
 		banlist: ['Uber',
 			'Nidoking + Fury Attack + Thrash', 'Exeggutor + Poison Powder + Stomp', 'Exeggutor + Sleep Powder + Stomp',
 			'Exeggutor + Stun Spore + Stomp', 'Jolteon + Focus Energy + Thunder Shock', 'Flareon + Focus Energy + Ember',
+			'Magikarp + Dragon Rage', 'Rapidash + Pay Day', 'Fearow + Pay Day', 'Pikachu + Fly', 'Raichu + Fly'
 		],
 	},
 	{


### PR DESCRIPTION
Not sure if this is how to go about it, but since it's impossible for international Game Boy games to trade with Japanese ones, I don't see why these are actually legal on PS. You straight-up can't get these on any international game, which I believe is the base for simulation? I believe you could make some kind of Event Clause or learnset thing for these, but this seems to be the easier way to go about it? 

Feel free to throw this out and ignore if it's the incorrect way to go about it. They're all super niche, it's more of an exhaustive thing. Fly is already banned by Standard due to the semi-invulnerability glitch, but in case it's patched by the council or semi-invulnerability clause is ever instated it's probably best to have this anyway. 

Overall, this bans;
- Flying Pikachu, and by extension Raichu (September 1997 Corocoro Event)
- Dragon Rage Magikarp (Shogakukan "Tamamushi University Hyper Test" Event)
- Pay Day Fearow (Shogakukan Pokemon Stamp Event)
- Pay Day Rapidash (Shogakukan Pokemon Stamp Event)