### PR TITLE
Update punishment expiration messaging to give a more accurate time

### DIFF
--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -1278,11 +1278,12 @@ export const commands: ChatCommands = {
 				}
 			}
 
+			const {punishment: outputPunishment, affected} = HelpTicket.ban(userid, target);
+
 			if (targetUser) {
-				targetUser.popup(`|modal|${user.name} has banned you from creating help tickets.${(target ? `\n\nReason: ${target}` : ``)}\n\nYour ban will expire in a few days.`);
+				targetUser.popup(`|modal|${user.name} has banned you from creating help tickets.${(target ? `\n\nReason: ${target}` : ``)}\n\nYour ban will expire ${Punishments.getPunishmentExpirationDescription(outputPunishment)}.`);
 			}
 
-			const affected = HelpTicket.ban(userid, target);
 			this.addModAction(`${username} was ticket banned by ${user.name}.${target ? ` (${target})` : ``}`);
 			const acAccount = (targetUser && targetUser.autoconfirmed !== userid && targetUser.autoconfirmed);
 			let displayMessage = '';


### PR DESCRIPTION
Currently, bans/locks/etc. only tell you that they will expire "in a few days". This updates it such that it tells you how many days remain and how many hours if there's less than a day left.

This also refactors the punishment API a bit. Now all of the APIs that punish someone return not only the list of affected users, but also the punishment.

First time contributing, let me know what you think!