### PR TITLE
Fix spread move mechanics in ADV Doubles

### DIFF
--- a/data/mods/gen3/scripts.ts
+++ b/data/mods/gen3/scripts.ts
@@ -207,7 +207,9 @@ export const Scripts: ModdedBattleScriptsData = {
 				}
 				if (damage === this.NOT_FAIL) pokemon.moveThisTurnResult = null;
 			}
-			if (move.spreadHit) this.attrLastMove('[spread] ' + hitSlots.join(','));
+			if (move.spreadHit || move.target === "allAdjacent") {
+					this.attrLastMove('[spread] ' + hitSlots.join(','));
+				}
 		} else {
 			target = targets[0];
 			let lacksTarget = !target || target.fainted;

--- a/data/mods/gen3/scripts.ts
+++ b/data/mods/gen3/scripts.ts
@@ -208,8 +208,8 @@ export const Scripts: ModdedBattleScriptsData = {
 				if (damage === this.NOT_FAIL) pokemon.moveThisTurnResult = null;
 			}
 			if (move.spreadHit || move.target === "allAdjacent") {
-					this.attrLastMove('[spread] ' + hitSlots.join(','));
-				}
+				this.attrLastMove('[spread] ' + hitSlots.join(','));
+			}
 		} else {
 			target = targets[0];
 			let lacksTarget = !target || target.fainted;

--- a/data/mods/gen3/scripts.ts
+++ b/data/mods/gen3/scripts.ts
@@ -34,8 +34,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		// Double battle multi-hit
 		// In Generation 3, the spread move modifier is 0.5x instead of 0.75x. Moves that hit both foes
 		// and the user's ally, like Earthquake and Explosion, don't get affected by spread modifiers
-		const {targets} = pokemon.getMoveTargets(move, target);
-		if (move.target === 'allAdjacentFoes' && targets.length > 1) {
+		if (move.spreadHit && move.target === 'allAdjacentFoes') {
 			const spreadModifier = move.spreadModifier || 0.5;
 			this.debug('Spread modifier: ' + spreadModifier);
 			baseDamage = this.modify(baseDamage, spreadModifier);

--- a/data/mods/gen3/scripts.ts
+++ b/data/mods/gen3/scripts.ts
@@ -17,7 +17,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		}
 	},
 	modifyDamage(baseDamage, pokemon, target, move, suppressMessages = false) {
-		// DPP divides modifiers into several mathematically important stages
+		// RSE divides modifiers into several mathematically important stages
 		// The modifiers run earlier than other generations are called with ModifyDamagePhase1 and ModifyDamagePhase2
 
 		if (!move.type) move.type = '???';
@@ -32,7 +32,8 @@ export const Scripts: ModdedBattleScriptsData = {
 		baseDamage = this.runEvent('ModifyDamagePhase1', pokemon, target, move, baseDamage);
 
 		// Double battle multi-hit
-		// In Generation 3, the spread move modifier is 0.5x instead of 0.75x.
+		// In Generation 3, the spread move modifier is 0.5x instead of 0.75x. Moves that hit both foes
+		// and the user's ally, like Earthquake and Explosion, don't get affected by spread modifiers
 		const {targets} = pokemon.getMoveTargets(move, target);
 		if (move.target === 'allAdjacentFoes' && targets.length > 1) {
 			const spreadModifier = move.spreadModifier || 0.5;
@@ -43,7 +44,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		// Weather
 		baseDamage = this.runEvent('WeatherModifyDamage', pokemon, target, move, baseDamage);
 
-		if (this.gen === 3 && move.category === 'Physical' && !Math.floor(baseDamage)) {
+		if (move.category === 'Physical' && !Math.floor(baseDamage)) {
 			baseDamage = 1;
 		}
 
@@ -191,8 +192,6 @@ export const Scripts: ModdedBattleScriptsData = {
 				this.add('-notarget', pokemon);
 				return false;
 			}
-			// In Generation 3, moves that hit both foes and the user's ally,
-			// like Earthquake and Explosion, don't get affected by spread modifiers
 			if (targets.length > 1) move.spreadHit = true;
 			const hitSlots = [];
 			for (const source of targets) {
@@ -208,9 +207,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				}
 				if (damage === this.NOT_FAIL) pokemon.moveThisTurnResult = null;
 			}
-			if (move.spreadHit) {
-				this.attrLastMove('[spread] ' + hitSlots.join(','));
-			}
+			if (move.spreadHit) this.attrLastMove('[spread] ' + hitSlots.join(','));
 		} else {
 			target = targets[0];
 			let lacksTarget = !target || target.fainted;

--- a/data/mods/gen3/scripts.ts
+++ b/data/mods/gen3/scripts.ts
@@ -32,8 +32,9 @@ export const Scripts: ModdedBattleScriptsData = {
 		baseDamage = this.runEvent('ModifyDamagePhase1', pokemon, target, move, baseDamage);
 
 		// Double battle multi-hit
-		if (move.spreadHit) {
-			// In Generation 3, the spread move modifier is 0.5x instead of 0.75x.
+		// In Generation 3, the spread move modifier is 0.5x instead of 0.75x.
+		const {targets} = pokemon.getMoveTargets(move, target);
+		if (move.target === 'allAdjacentFoes' && targets.length > 1) {
 			const spreadModifier = move.spreadModifier || 0.5;
 			this.debug('Spread modifier: ' + spreadModifier);
 			baseDamage = this.modify(baseDamage, spreadModifier);
@@ -192,7 +193,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 			// In Generation 3, moves that hit both foes and the user's ally,
 			// like Earthquake and Explosion, don't get affected by spread modifiers
-			if (targets.length === 2) move.spreadHit = true;
+			if (targets.length > 1) move.spreadHit = true;
 			const hitSlots = [];
 			for (const source of targets) {
 				const hitResult = this.tryMoveHit(source, pokemon, move);
@@ -207,7 +208,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				}
 				if (damage === this.NOT_FAIL) pokemon.moveThisTurnResult = null;
 			}
-			if (move.spreadHit || move.target === "allAdjacent") {
+			if (move.spreadHit) {
 				this.attrLastMove('[spread] ' + hitSlots.join(','));
 			}
 		} else {

--- a/data/mods/gen3/scripts.ts
+++ b/data/mods/gen3/scripts.ts
@@ -16,6 +16,87 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 		}
 	},
+	modifyDamage(baseDamage, pokemon, target, move, suppressMessages = false) {
+		// DPP divides modifiers into several mathematically important stages
+		// The modifiers run earlier than other generations are called with ModifyDamagePhase1 and ModifyDamagePhase2
+
+		if (!move.type) move.type = '???';
+		const type = move.type;
+
+		// Burn
+		if (pokemon.status === 'brn' && baseDamage && move.category === 'Physical' && !pokemon.hasAbility('guts')) {
+			baseDamage = this.modify(baseDamage, 0.5);
+		}
+
+		// Other modifiers (Reflect/Light Screen/etc)
+		baseDamage = this.runEvent('ModifyDamagePhase1', pokemon, target, move, baseDamage);
+
+		// Double battle multi-hit
+		if (move.spreadHit) {
+			// In Generation 3, the spread move modifier is 0.5x instead of 0.75x.
+			const spreadModifier = move.spreadModifier || 0.5;
+			this.debug('Spread modifier: ' + spreadModifier);
+			baseDamage = this.modify(baseDamage, spreadModifier);
+		}
+
+		// Weather
+		baseDamage = this.runEvent('WeatherModifyDamage', pokemon, target, move, baseDamage);
+
+		if (this.gen === 3 && move.category === 'Physical' && !Math.floor(baseDamage)) {
+			baseDamage = 1;
+		}
+
+		baseDamage += 2;
+
+		const isCrit = target.getMoveHitData(move).crit;
+		if (isCrit) {
+			baseDamage = this.modify(baseDamage, move.critModifier || 2);
+		}
+
+		// Mod 2 (Damage is floored after all multipliers are in)
+		baseDamage = Math.floor(this.runEvent('ModifyDamagePhase2', pokemon, target, move, baseDamage));
+
+		// this is not a modifier
+		baseDamage = this.randomizer(baseDamage);
+
+		// STAB
+		if (move.forceSTAB || type !== '???' && pokemon.hasType(type)) {
+			// The "???" type never gets STAB
+			// Not even if you Roost in Gen 4 and somehow manage to use
+			// Struggle in the same turn.
+			// (On second thought, it might be easier to get a MissingNo.)
+			baseDamage = this.modify(baseDamage, move.stab || 1.5);
+		}
+		// types
+		let typeMod = target.runEffectiveness(move);
+		typeMod = this.clampIntRange(typeMod, -6, 6);
+		target.getMoveHitData(move).typeMod = typeMod;
+		if (typeMod > 0) {
+			if (!suppressMessages) this.add('-supereffective', target);
+
+			for (let i = 0; i < typeMod; i++) {
+				baseDamage *= 2;
+			}
+		}
+		if (typeMod < 0) {
+			if (!suppressMessages) this.add('-resisted', target);
+
+			for (let i = 0; i > typeMod; i--) {
+				baseDamage = Math.floor(baseDamage / 2);
+			}
+		}
+
+		if (isCrit && !suppressMessages) this.add('-crit', target);
+
+		// Final modifier.
+		baseDamage = this.runEvent('ModifyDamage', pokemon, target, move, baseDamage);
+
+		if (!Math.floor(baseDamage)) {
+			return 1;
+		}
+
+		return Math.floor(baseDamage);
+	},
 	useMoveInner(moveOrMoveName, pokemon, target, sourceEffect, zMove) {
 		if (!sourceEffect && this.effect.id) sourceEffect = this.effect;
 		if (sourceEffect && sourceEffect.id === 'instruct') sourceEffect = null;
@@ -109,7 +190,9 @@ export const Scripts: ModdedBattleScriptsData = {
 				this.add('-notarget', pokemon);
 				return false;
 			}
-			if (targets.length > 1) move.spreadHit = true;
+			// In Generation 3, moves that hit both foes and the user's ally,
+			// like Earthquake and Explosion, don't get affected by spread modifiers
+			if (targets.length === 2) move.spreadHit = true;
 			const hitSlots = [];
 			for (const source of targets) {
 				const hitResult = this.tryMoveHit(source, pokemon, move);


### PR DESCRIPTION
In ADV, spread moves that hit exactly two opponents have a spread modifier of 0.5x instead of 0.75x. Moves that have more than two targets (Explosion, Earthquake, etc.) don't get affected by spread modification at all.