### PR TITLE
Fix Stadium Mechanics (Struggle VS Ghost-types)

### DIFF
--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -177,6 +177,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		target: "self",
 		type: "Normal",
 	},
+	struggle: {
+  		inherit: true,
+  		ignoreImmunity: {'Normal': true},
+	},
 	wrap: {
 		inherit: true,
 		// FIXME: onBeforeMove() {},

--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -178,8 +178,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		type: "Normal",
 	},
 	struggle: {
-  		inherit: true,
-  		ignoreImmunity: {'Normal': true},
+		inherit: true,
+		ignoreImmunity: {'Normal': true},
 	},
 	wrap: {
 		inherit: true,


### PR DESCRIPTION
Struggle should affect Ghost-types in Stadium, designed to avoid infinite battles. Thanks to Kris for helping me figure out what to do...

Source: https://www.smogon.com/forums/threads/stadium-format-is-now-available-on-ps.3526616/post-8517229

I'm not necessarily a _programmer_, but if I can help the Stadium sim improve in some way, that's good enough for me.