### PR TITLE
Remove illegal moves from RBY Random Battles

### DIFF
--- a/data/mods/gen1/formats-data.ts
+++ b/data/mods/gen1/formats-data.ts
@@ -68,7 +68,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	kakuna: {
-		randomBattleMoves: ["poisonsting", "stringshot", "harden"],
+		randomBattleMoves: ["poisonsting", "stringshot"],
 		tier: "NFE",
 	},
 	beedrill: {
@@ -653,7 +653,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "OU",
 	},
 	magikarp: {
-		randomBattleMoves: ["tackle", "dragonrage"],
+		randomBattleMoves: ["tackle"],
 		tier: "LC",
 	},
 	gyarados: {


### PR DESCRIPTION
This removes Harden from Kakuna and Dragon Rage from Magikarp. 

Harden is incompatible with Poison Sting and String Shot, as Kakuna doesn't learn it upon evolving like Metapod. 
Source: https://www.smogon.com/forums/threads/random-battles.3526564/post-8577809

Magikarp only gets Dragon Rage via a Japanese event, and since international RBY mechanics are used, it's impossible for this to be used. 

As far as I know, these are the only issues.