### PR TITLE
Add more style linting rules

### DIFF
--- a/.eslintrc-no-types.json
+++ b/.eslintrc-no-types.json
@@ -21,12 +21,6 @@
     "es6": true,
     "node": true
   },
-  "globals": {
-    "Config": false, "Monitor": false, "toID": false, "Dex": false, "LoginServer": false,
-    "Users": false, "Punishments": false, "Rooms": false, "Verifier": false, "Chat": false,
-    "Tournaments": false, "IPTools": false, "Sockets": false, "TeamValidator": false,
-    "TeamValidatorAsync": false, "Ladders": false
-  },
   "extends": "eslint:recommended",
   "rules": {
     // TODO: add/revisit
@@ -101,7 +95,7 @@
     "no-shadow": "off",
     "no-template-curly-in-string": "error",
     "no-throw-literal": "error",
-    "no-undef": ["error", {"typeof": true}],
+    "no-undef": "off",
     "no-unmodified-loop-condition": "error",
     "no-unused-expressions": "error",
     "no-unsafe-finally": "error",
@@ -312,10 +306,7 @@
       "env": {
         "mocha": true
       },
-      "files": ["test/**/*.js"],
-      "globals": {
-        "BattleEngine": false
-      }
+      "files": ["test/**/*.js"]
     }
   ]
 }

--- a/.eslintrc-no-types.json
+++ b/.eslintrc-no-types.json
@@ -210,7 +210,6 @@
       ],
       "rules": {
         // TODO revisit
-        "prefer-object-spread": "off",
         "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/member-ordering": "off",
@@ -284,6 +283,7 @@
         "@typescript-eslint/prefer-function-type": "error",
         "@typescript-eslint/prefer-includes": "error",
         "@typescript-eslint/prefer-namespace-keyword": "error",
+        "prefer-object-spread": "error",
         "@typescript-eslint/triple-slash-reference": "error",
         "@typescript-eslint/unified-signatures": "error",
 

--- a/.eslintrc-no-types.json
+++ b/.eslintrc-no-types.json
@@ -123,6 +123,7 @@
 
     // syntax style (local syntactical, usually autofixable formatting decisions)
     "arrow-parens": "off",
+    "arrow-body-style": "error",
     "brace-style": ["error", "1tbs", {"allowSingleLine": true}],
     "comma-dangle": ["error", {"arrays": "always-multiline", "objects": "always-multiline", "imports": "always-multiline", "exports": "always-multiline", "functions": "ignore"}],
     "comma-style": ["error", "last"],

--- a/.eslintrc-no-types.json
+++ b/.eslintrc-no-types.json
@@ -215,8 +215,8 @@
         "@typescript-eslint/member-ordering": "off",
         // "@typescript-eslint/no-extraneous-class": "error",
         // "@typescript-eslint/no-type-alias": "error",
-        "@typescript-eslint/no-parameter-properties": "off",
         "@typescript-eslint/prefer-optional-chain": "off",
+        // "@typescript-eslint/consistent-type-imports": "error", // TODO after no-duplicate-imports fix
 
         // test only (should never be committed, but useful when testing)
         "no-unused-vars": "off",
@@ -271,12 +271,12 @@
         "@typescript-eslint/array-type": "error",
         "@typescript-eslint/consistent-type-assertions": ["error", {"assertionStyle": "as"}],
         "@typescript-eslint/consistent-type-definitions": ["error", "interface"],
-        // "@typescript-eslint/consistent-type-imports": "error", // TODO AUTOFIX
         "@typescript-eslint/explicit-member-accessibility": ["error", {"accessibility": "no-public"}],
         "@typescript-eslint/member-delimiter-style": ["error", {"overrides": {"typeLiteral": {
           "multiline": {"delimiter": "comma", "requireLast": true},
           "singleline": {"delimiter": "comma", "requireLast": false}
         }}}],
+        "@typescript-eslint/no-parameter-properties": "error",
         "@typescript-eslint/no-this-alias": "error",
         "@typescript-eslint/prefer-as-const": "error",
         "@typescript-eslint/prefer-for-of": "error",

--- a/.eslintrc-types.json
+++ b/.eslintrc-types.json
@@ -24,7 +24,7 @@
       "rules": {
         // TODO investigate
         "@typescript-eslint/restrict-plus-operands": "off",
-        "@typescript-eslint/prefer-string-starts-ends-with": "off",
+        // "@typescript-eslint/restrict-plus-operands": ["error", {"checkCompoundAssignments": true}],
         // "@typescript-eslint/switch-exhaustiveness-check": "error",
 
         // typescript-eslint defaults too strict
@@ -54,7 +54,8 @@
         "@typescript-eslint/no-unnecessary-qualifier": "off",
         "@typescript-eslint/no-unnecessary-type-arguments": "error",
         "@typescript-eslint/no-unnecessary-type-assertion": "error",
-        "@typescript-eslint/prefer-regexp-exec": "error"
+        "@typescript-eslint/prefer-regexp-exec": "error",
+        "@typescript-eslint/prefer-string-starts-ends-with": "error"
       }
     }
   ]

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -680,7 +680,7 @@ export const Formats: FormatList = [
 			if (!target) return; // Chat command
 			if (effect && ['imposter', 'transform'].includes(effect.id)) return;
 			const types = [...new Set(target.baseMoveSlots.slice(0, 2).map(move => this.dex.getMove(move.id).type))];
-			return Object.assign({}, species, {types: types});
+			return {...species, types: types};
 		},
 		onSwitchIn(pokemon) {
 			this.add('-start', pokemon, 'typechange', pokemon.getTypes(true).join('/'), '[silent]');

--- a/data/mods/gen1/random-teams.ts
+++ b/data/mods/gen1/random-teams.ts
@@ -89,7 +89,7 @@ export class RandomGen1Teams extends RandomGen2Teams {
 			if (lsetData.learnset) {
 				for (const move in lsetData.learnset) {
 					if (this.dex.getMove(move).gen !== 1) continue;
-					if (lsetData.learnset[move].some(learned => learned[0] === '1')) {
+					if (lsetData.learnset[move].some(learned => learned.startsWith('1'))) {
 						pool.push(move);
 					}
 				}

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -605,7 +605,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		if (typeof effect === 'string') effect = this.dex.getEffect(effect);
 		if (!target || !target.hp) return 0;
 		let success = null;
-		boost = this.runEvent('Boost', target, source, effect, Object.assign({}, boost));
+		boost = this.runEvent('Boost', target, source, effect, {...boost});
 		let i: BoostName;
 		for (i in boost) {
 			const currentBoost: SparseBoostsTable = {};

--- a/data/mods/gen2/random-teams.ts
+++ b/data/mods/gen2/random-teams.ts
@@ -149,12 +149,12 @@ export class RandomGen2Teams extends RandomGen3Teams {
 
 		let discard = false;
 		let rerollsLeft = 3;
-		const isPhazingMove = (move: string) => {
-			return (move === "roar" || move === "whirlwind");
-		};
-		const isSleepMove = (move: string) => {
-			return (move === "sleeppowder" || move === "lovelykiss" || move === "sing" || move === "hypnosis" || move === "spore");
-		};
+		const isPhazingMove = (move: string) => (
+			move === "roar" || move === "whirlwind"
+		);
+		const isSleepMove = (move: string) => (
+			move === "sleeppowder" || move === "lovelykiss" || move === "sing" || move === "hypnosis" || move === "spore"
+		);
 
 		// Choose one of the available sets (up to four) at random
 		// Prevent certain moves from showing up more than once or twice:

--- a/data/mods/gen3/scripts.ts
+++ b/data/mods/gen3/scripts.ts
@@ -306,7 +306,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		let boost: number;
 		if (accuracy !== true) {
 			if (!move.ignoreAccuracy) {
-				boosts = this.runEvent('ModifyBoost', pokemon, null, null, Object.assign({}, pokemon.boosts));
+				boosts = this.runEvent('ModifyBoost', pokemon, null, null, {...pokemon.boosts});
 				boost = this.clampIntRange(boosts['accuracy'], -6, 6);
 				if (boost > 0) {
 					accuracy *= boostTable[boost];
@@ -315,7 +315,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				}
 			}
 			if (!move.ignoreEvasion) {
-				boosts = this.runEvent('ModifyBoost', target, null, null, Object.assign({}, target.boosts));
+				boosts = this.runEvent('ModifyBoost', target, null, null, {...target.boosts});
 				boost = this.clampIntRange(boosts['evasion'], -6, 6);
 				if (boost > 0) {
 					accuracy /= boostTable[boost];
@@ -395,7 +395,7 @@ export const Scripts: ModdedBattleScriptsData = {
 					accuracy = move.accuracy;
 					if (accuracy !== true) {
 						if (!move.ignoreAccuracy) {
-							boosts = this.runEvent('ModifyBoost', pokemon, null, null, Object.assign({}, pokemon.boosts));
+							boosts = this.runEvent('ModifyBoost', pokemon, null, null, {...pokemon.boosts});
 							boost = this.clampIntRange(boosts['accuracy'], -6, 6);
 							if (boost > 0) {
 								accuracy *= boostTable[boost];
@@ -404,7 +404,7 @@ export const Scripts: ModdedBattleScriptsData = {
 							}
 						}
 						if (!move.ignoreEvasion) {
-							boosts = this.runEvent('ModifyBoost', target, null, null, Object.assign({}, target.boosts));
+							boosts = this.runEvent('ModifyBoost', target, null, null, {...target.boosts});
 							boost = this.clampIntRange(boosts['evasion'], -6, 6);
 							if (boost > 0) {
 								accuracy /= boostTable[boost];

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1291,8 +1291,8 @@ export class RandomGen7Teams extends RandomTeams {
 			shiny: typeof setData.set.shiny === 'undefined' ? this.randomChance(1, 1024) : setData.set.shiny,
 			level: setData.set.level ? setData.set.level : tier === "LC" ? 5 : 100,
 			happiness: typeof setData.set.happiness === 'undefined' ? 255 : setData.set.happiness,
-			evs: Object.assign({hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0}, setData.set.evs),
-			ivs: Object.assign({hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31}, setData.set.ivs),
+			evs: {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0, ...setData.set.evs},
+			ivs: {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31, ...setData.set.ivs},
 			nature: nature || 'Serious',
 			moves: moves,
 		};
@@ -1572,8 +1572,8 @@ export class RandomGen7Teams extends RandomTeams {
 			shiny: typeof setData.set.shiny === 'undefined' ? this.randomChance(1, 1024) : setData.set.shiny,
 			level: setData.set.level || 50,
 			happiness: typeof setData.set.happiness === 'undefined' ? 255 : setData.set.happiness,
-			evs: Object.assign({hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0}, setData.set.evs),
-			ivs: Object.assign({hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31}, setData.set.ivs),
+			evs: {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0, ...setData.set.evs},
+			ivs: {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31, ...setData.set.ivs},
 			nature: setData.set.nature || 'Serious',
 			moves: moves,
 		};

--- a/data/mods/ssb/abilities.ts
+++ b/data/mods/ssb/abilities.ts
@@ -638,9 +638,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 					Castform: ['Rain Dance', 'Sunny Day', 'Hail', 'Weather Forecast'],
 				};
 				// Store percentage of PP left for each moveSlot
-				const carryOver = pokemon.moveSlots.slice().map(m => {
-					return m.pp / m.maxpp;
-				});
+				const carryOver = pokemon.moveSlots.slice().map(m => m.pp / m.maxpp);
 				// Incase theres ever less than 4 moves
 				while (carryOver.length < 4) {
 					carryOver.push(1);

--- a/data/mods/ssb/abilities.ts
+++ b/data/mods/ssb/abilities.ts
@@ -638,7 +638,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 					Castform: ['Rain Dance', 'Sunny Day', 'Hail', 'Weather Forecast'],
 				};
 				// Store percentage of PP left for each moveSlot
-				const carryOver = pokemon.moveSlots.slice().map(m => m.pp / m.maxpp);
+				const carryOver = pokemon.moveSlots.map(m => m.pp / m.maxpp);
 				// Incase theres ever less than 4 moves
 				while (carryOver.length < 4) {
 					carryOver.push(1);

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1624,9 +1624,9 @@ export class RandomTeams {
 				item: (Array.isArray(setData.item) ? this.sample(setData.item) : setData.item) || '',
 				ability: (Array.isArray(setData.ability) ? this.sample(setData.ability) : setData.ability),
 				shiny: this.randomChance(1, 1024),
-				evs: Object.assign({hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0}, setData.evs),
+				evs: {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0, ...setData.evs},
 				nature: setData.nature,
-				ivs: Object.assign({hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31}, setData.ivs || {}),
+				ivs: {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31, ...setData.ivs || {}},
 				moves: setData.moves.map((move: any) => Array.isArray(move) ? this.sample(move) : move),
 			};
 			pokemon.push(set);

--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -464,7 +464,7 @@ export const Scripts: BattleScriptsData = {
 				let boost!: number;
 				if (accuracy !== true) {
 					if (!move.ignoreAccuracy) {
-						boosts = this.runEvent('ModifyBoost', pokemon, null, null, Object.assign({}, pokemon.boosts));
+						boosts = this.runEvent('ModifyBoost', pokemon, null, null, {...pokemon.boosts});
 						boost = this.clampIntRange(boosts['accuracy'], -6, 6);
 						if (boost > 0) {
 							accuracy *= boostTable[boost];
@@ -473,7 +473,7 @@ export const Scripts: BattleScriptsData = {
 						}
 					}
 					if (!move.ignoreEvasion) {
-						boosts = this.runEvent('ModifyBoost', target, null, null, Object.assign({}, target.boosts));
+						boosts = this.runEvent('ModifyBoost', target, null, null, {...target.boosts});
 						boost = this.clampIntRange(boosts['evasion'], -6, 6);
 						if (boost > 0) {
 							accuracy /= boostTable[boost];
@@ -651,7 +651,7 @@ export const Scripts: BattleScriptsData = {
 				const boostTable = [1, 4 / 3, 5 / 3, 2, 7 / 3, 8 / 3, 3];
 				if (accuracy !== true) {
 					if (!move.ignoreAccuracy) {
-						const boosts = this.runEvent('ModifyBoost', pokemon, null, null, Object.assign({}, pokemon.boosts));
+						const boosts = this.runEvent('ModifyBoost', pokemon, null, null, {...pokemon.boosts});
 						const boost = this.clampIntRange(boosts['accuracy'], -6, 6);
 						if (boost > 0) {
 							accuracy *= boostTable[boost];
@@ -660,7 +660,7 @@ export const Scripts: BattleScriptsData = {
 						}
 					}
 					if (!move.ignoreEvasion) {
-						const boosts = this.runEvent('ModifyBoost', target, null, null, Object.assign({}, target.boosts));
+						const boosts = this.runEvent('ModifyBoost', target, null, null, {...target.boosts});
 						const boost = this.clampIntRange(boosts['evasion'], -6, 6);
 						if (boost > 0) {
 							accuracy /= boostTable[boost];

--- a/lib/dashycode.ts
+++ b/lib/dashycode.ts
@@ -158,17 +158,17 @@ export function encode(str: string, allowCaps = false) {
 		}
 	}
 	let unsafePart = streamGetCode(unsafeStream);
-	if (safePart.charAt(0) === '-') {
+	if (safePart.startsWith('-')) {
 		safePart = safePart.slice(1);
 		unsafePart = unsafePart + '2';
 	}
-	if (safePart.slice(-1) === '-') {
+	if (safePart.endsWith('-')) {
 		safePart = safePart.slice(0, -1);
 	}
 	if (!safePart) {
 		safePart = '0';
 		unsafePart = '0' + unsafePart;
-		if (unsafePart.slice(-1) === '2') unsafePart = unsafePart.slice(0, -1);
+		if (unsafePart.endsWith('2')) unsafePart = unsafePart.slice(0, -1);
 	}
 	if (!unsafePart) return safePart;
 	return safePart + '--' + unsafePart;
@@ -183,13 +183,13 @@ export function decode(codedStr: string) {
 		return codedStr.replace(/-/g, ' ');
 	}
 	if (codedStr.charAt(lastDashIndex + 2) === '0') {
-		if (codedStr.charAt(0) !== '0' || lastDashIndex !== 1) {
+		if (!codedStr.startsWith('0') || lastDashIndex !== 1) {
 			throw new Error("Invalid Dashycode");
 		}
 		lastDashIndex -= 1;
 		codedStr = '--' + codedStr.slice(4);
 	}
-	if (codedStr.slice(-1) === '2') {
+	if (codedStr.endsWith('2')) {
 		codedStr = '-' + codedStr.slice(0, -1);
 		lastDashIndex += 1;
 	}
@@ -268,11 +268,11 @@ export function decode(codedStr: string) {
 
 export function vizStream(codeBuf: string, translate = true) {
 	let spacedStream = '';
-	if (codeBuf.charAt(0) === '0') {
+	if (codeBuf.startsWith('0')) {
 		codeBuf = codeBuf.slice(1);
 		spacedStream = ' [no safe chars]' + spacedStream;
 	}
-	if (codeBuf.slice(-1) === '2') {
+	if (codeBuf.endsWith('2')) {
 		codeBuf = codeBuf.slice(0, -1);
 		spacedStream = ' [start unsafe]' + spacedStream;
 	}

--- a/lib/process-manager.ts
+++ b/lib/process-manager.ts
@@ -91,19 +91,19 @@ export class QueryProcessWrapper implements ProcessWrapper {
 		this.resolveRelease = null;
 
 		this.process.on('message', (message: string) => {
-			const nlLoc = message.indexOf('\n');
-			if (nlLoc <= 0) throw new Error(`Invalid response ${message}`);
-			if (message.slice(0, nlLoc) === 'THROW') {
+			if (message.startsWith('THROW\n')) {
 				const error = new Error();
-				error.stack = message.slice(nlLoc + 1);
+				error.stack = message.slice(6);
 				throw error;
 			}
 
-			if (message.slice(0, nlLoc) === 'DEBUG') {
-				this.debug = message.slice(nlLoc + 1);
+			if (message.startsWith('DEBUG\n')) {
+				this.debug = message.slice(6);
 				return;
 			}
 
+			const nlLoc = message.indexOf('\n');
+			if (nlLoc <= 0) throw new Error(`Invalid response ${message}`);
 			const taskId = parseInt(message.slice(0, nlLoc));
 			const resolve = this.pendingTasks.get(taskId);
 			if (!resolve) throw new Error(`Invalid taskId ${message.slice(0, nlLoc)}`);
@@ -180,19 +180,19 @@ export class StreamProcessWrapper implements ProcessWrapper {
 		this.process = child_process.fork(file, [], {cwd: ROOT_DIR});
 
 		this.process.on('message', (message: string) => {
-			let nlLoc = message.indexOf('\n');
-			if (nlLoc <= 0) throw new Error(`Invalid response ${message}`);
-			if (message.slice(0, nlLoc) === 'THROW') {
+			if (message.startsWith('THROW\n')) {
 				const error = new Error();
-				error.stack = message.slice(nlLoc + 1);
+				error.stack = message.slice(6);
 				throw error;
 			}
 
-			if (message.slice(0, nlLoc) === 'DEBUG') {
-				this.setDebug(message.slice(nlLoc + 1));
+			if (message.startsWith('DEBUG\n')) {
+				this.setDebug(message.slice(6));
 				return;
 			}
 
+			let nlLoc = message.indexOf('\n');
+			if (nlLoc <= 0) throw new Error(`Invalid response ${message}`);
 			const taskId = parseInt(message.slice(0, nlLoc));
 			const stream = this.activeStreams.get(taskId);
 			if (!stream) return; // stream already destroyed

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -959,7 +959,7 @@ export const commands: ChatCommands = {
 			cmd = target.toLowerCase();
 			target = '';
 		}
-		if (cmd.charAt(cmd.length - 1) === ',') cmd = cmd.slice(0, -1);
+		if (cmd.endsWith(',')) cmd = cmd.slice(0, -1);
 		const targets = target.split(',');
 		function getPlayer(input: string) {
 			const player = battle.playerTable[toID(input)];

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -710,24 +710,23 @@ export const commands: ChatCommands = {
 	},
 	backhelp: [`/back - Marks you as back if you are away.`],
 
-	rank(target, room, user) {
+	async rank(target, room, user) {
 		if (!target) target = user.name;
 
-		return Ladders.visualizeAll(target).then(values => {
-			let buffer = `<div class="ladder"><table>`;
-			buffer += Utils.html`<tr><td colspan="8">User: <strong>${target}</strong></td></tr>`;
+		const values = await Ladders.visualizeAll(target);
+		let buffer = `<div class="ladder"><table>`;
+		buffer += Utils.html`<tr><td colspan="8">User: <strong>${target}</strong></td></tr>`;
 
-			const ratings = values.join(``);
-			if (!ratings) {
-				buffer += `<tr><td colspan="8"><em>${this.tr`This user has not played any ladder games yet.`}</em></td></tr>`;
-			} else {
-				buffer += `<tr><th>${this.tr`Format`}</th><th><abbr title="Elo rating">Elo</abbr></th><th>${this.tr`W`}</th><th>${this.tr`L`}</th><th>${this.tr`Total`}</th>`;
-				buffer += ratings;
-			}
-			buffer += `</table></div>`;
+		const ratings = values.join(``);
+		if (!ratings) {
+			buffer += `<tr><td colspan="8"><em>${this.tr`This user has not played any ladder games yet.`}</em></td></tr>`;
+		} else {
+			buffer += `<tr><th>${this.tr`Format`}</th><th><abbr title="Elo rating">Elo</abbr></th><th>${this.tr`W`}</th><th>${this.tr`L`}</th><th>${this.tr`Total`}</th>`;
+			buffer += ratings;
+		}
+		buffer += `</table></div>`;
 
-			this.sendReply(`|raw|${buffer}`);
-		});
+		this.sendReply(`|raw|${buffer}`);
 	},
 
 	showrank: 'hiderank',

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -402,7 +402,7 @@ export const commands: ChatCommands = {
 			if (results.length > 100 && !isAll) {
 				return this.sendReply(`More than 100 users match the specified IP range. Use /ipsearchall to retrieve the full list.`);
 			}
-		} else if (ip.slice(-1) === '*') {
+		} else if (ip.endsWith('*')) {
 			// IP range
 			this.sendReply(`Users in IP range ${ip}${targetRoom ? ` in the room ${targetRoom.title}` : ``}:`);
 			ip = ip.slice(0, -1);
@@ -1357,10 +1357,10 @@ export const commands: ChatCommands = {
 				if (['band', 'scarf', 'specs'].includes(arg)) {
 					modifier = 1;
 					modSet = true;
-				} else if (arg.charAt(0) === '+') {
+				} else if (arg.startsWith('+')) {
 					modifier = parseInt(arg.charAt(1));
 					modSet = true;
-				} else if (arg.charAt(0) === '-') {
+				} else if (arg.startsWith('-')) {
 					positiveMod = false;
 					modifier = parseInt(arg.charAt(1));
 					modSet = true;

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -364,15 +364,14 @@ export const commands: ChatCommands = {
 	},
 	showglobalpunishmentshelp: [`/showpunishments - Shows the current global punishments. Requires: % @ # &`],
 
-	host(target, room, user, connection, cmd) {
+	async host(target, room, user, connection, cmd) {
 		if (!target) return this.parse('/help host');
 		this.checkCan('ip');
 		target = target.trim();
 		if (!net.isIPv4(target)) return this.errorReply('You must pass a valid IPv4 IP to /host.');
-		void IPTools.lookup(target).then(({dnsbl, host, hostType}) => {
-			const dnsblMessage = dnsbl ? ` [${dnsbl}]` : ``;
-			this.sendReply(`IP ${target}: ${host || "ERROR"} [${hostType}]${dnsblMessage}`);
-		});
+		const {dnsbl, host, hostType} = await IPTools.lookup(target);
+		const dnsblMessage = dnsbl ? ` [${dnsbl}]` : ``;
+		this.sendReply(`IP ${target}: ${host || "ERROR"} [${hostType}]${dnsblMessage}`);
 	},
 	hosthelp: [`/host [ip] - Gets the host for a given IP. Requires: @ &`],
 

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -384,7 +384,7 @@ export const commands: ChatCommands = {
 		connection.popup(buffer.join("\n\n"));
 	},
 
-	autojoin(target, room, user, connection) {
+	async autojoin(target, room, user, connection) {
 		const targets = target.split(',');
 		if (targets.length > 16 || connection.inRooms.size > 1) {
 			return connection.popup("To prevent DoS attacks, you can only use /autojoin for 16 or fewer rooms, when you haven't joined any rooms yet. Please use /join for each room separately.");
@@ -400,27 +400,25 @@ export const commands: ChatCommands = {
 			})
 		);
 
-		return Promise.all(promises).then(() => {
-			connection.autojoins = autojoins.join(',');
-		});
+		await Promise.all(promises);
+		connection.autojoins = autojoins.join(',');
 	},
 
 	joim: 'join',
 	j: 'join',
-	join(target, room, user, connection) {
+	async join(target, room, user, connection) {
 		if (!target) return this.parse('/help join');
 		if (target.startsWith('http://')) target = target.slice(7);
 		if (target.startsWith('https://')) target = target.slice(8);
 		if (target.startsWith(`${Config.routes.client}/`)) target = target.slice(Config.routes.client.length + 1);
 		if (target.startsWith('psim.us/')) target = target.slice(8);
-		return user.tryJoinRoom(target as RoomID, connection).then(ret => {
-			if (ret === Rooms.RETRY_AFTER_LOGIN) {
-				connection.sendTo(
-					target as RoomID,
-					`|noinit|namerequired|The room '${target}' does not exist or requires a login to join.`
-				);
-			}
-		});
+		const ret = user.tryJoinRoom(target as RoomID, connection);
+		if (ret === Rooms.RETRY_AFTER_LOGIN) {
+			connection.sendTo(
+				target as RoomID,
+				`|noinit|namerequired|The room '${target}' does not exist or requires a login to join.`
+			);
+		}
 	},
 	joinhelp: [`/join [roomname] - Attempt to join the room [roomname].`],
 

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -872,7 +872,7 @@ export const commands: ChatCommands = {
 			return this.errorReply(`User ${targetUser.name} is namelocked, not locked. Use /unnamelock to unnamelock them.`);
 		}
 		let reason = '';
-		if (targetUser?.locked && targetUser.locked.charAt(0) === '#') {
+		if (targetUser?.locked && targetUser.locked.startsWith('#')) {
 			reason = ` (${targetUser.locked})`;
 		}
 
@@ -916,7 +916,7 @@ export const commands: ChatCommands = {
 		target = target.trim();
 		if (!target) return this.parse('/help unlock');
 		this.checkCan('globalban');
-		const range = target.charAt(target.length - 1) === '*';
+		const range = target.endsWith('*');
 		if (range) this.checkCan('rangeban');
 
 		if (!(range ? IPTools.ipRangeRegex : IPTools.ipRegex).test(target)) {
@@ -1135,7 +1135,7 @@ export const commands: ChatCommands = {
 		}
 		Punishments.ips.delete(target);
 
-		this.addGlobalModAction(`${user.name} unbanned the ${(target.charAt(target.length - 1) === '*' ? "IP range" : "IP")}: ${target}`);
+		this.addGlobalModAction(`${user.name} unbanned the ${(target.endsWith('*') ? "IP range" : "IP")}: ${target}`);
 		this.modlog('UNRANGEBAN', null, target);
 	},
 	unbaniphelp: [`/unbanip [ip] - Unbans. Accepts wildcards to ban ranges. Requires: &`],

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -412,7 +412,7 @@ export const commands: ChatCommands = {
 		if (target.startsWith('https://')) target = target.slice(8);
 		if (target.startsWith(`${Config.routes.client}/`)) target = target.slice(Config.routes.client.length + 1);
 		if (target.startsWith('psim.us/')) target = target.slice(8);
-		const ret = user.tryJoinRoom(target as RoomID, connection);
+		const ret = await user.tryJoinRoom(target as RoomID, connection);
 		if (ret === Rooms.RETRY_AFTER_LOGIN) {
 			connection.sendTo(
 				target as RoomID,

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -1267,10 +1267,10 @@ export const commands: ChatCommands = {
 		if (normalizedTarget.includes(' welcome ')) {
 			return this.errorReply(`Error: Room description must not contain the word "welcome".`);
 		}
-		if (normalizedTarget.slice(0, 9) === ' discuss ') {
+		if (normalizedTarget.startsWith(' discuss ')) {
 			return this.errorReply(`Error: Room description must not start with the word "discuss".`);
 		}
-		if (normalizedTarget.slice(0, 12) === ' talk about ' || normalizedTarget.slice(0, 17) === ' talk here about ') {
+		if (normalizedTarget.startsWith(' talk about ') || normalizedTarget.startsWith(' talk here about ')) {
 			return this.errorReply(`Error: Room description must not start with the phrase "talk about".`);
 		}
 

--- a/server/chat-formatter.ts
+++ b/server/chat-formatter.ts
@@ -90,7 +90,7 @@ class TextFormatter {
 			} else {
 				fulluri = uri.replace(/^([a-z]*[^a-z:])/g, 'http://$1');
 				if (uri.substr(0, 24) === 'https://docs.google.com/' || uri.substr(0, 16) === 'docs.google.com/') {
-					if (uri.slice(0, 5) === 'https') uri = uri.slice(8);
+					if (uri.startsWith('https')) uri = uri.slice(8);
 					if (uri.substr(-12) === '?usp=sharing' || uri.substr(-12) === '&usp=sharing') uri = uri.slice(0, -12);
 					if (uri.substr(-6) === '#gid=0') uri = uri.slice(0, -6);
 					let slashIndex = uri.lastIndexOf('/');

--- a/server/chat-plugins/chat-monitor.ts
+++ b/server/chat-plugins/chat-monitor.ts
@@ -184,8 +184,8 @@ Chat.registerMonitor('wordfilter', {
 		while (match) {
 			let filtered = replacement || '';
 			if (match[0] === match[0].toUpperCase()) filtered = filtered.toUpperCase();
-			if (match[0][0] === match[0][0].toUpperCase()) {
-				filtered = `${filtered ? filtered[0].toUpperCase() : ''}${filtered.slice(1)}`;
+			if (match[0].startsWith(match[0].charAt(0).toUpperCase())) {
+				filtered = `${filtered ? filtered.charAt(0).toUpperCase() : ''}${filtered.slice(1)}`;
 			}
 			message = message.replace(match[0], filtered);
 			match = regex.exec(message);

--- a/server/chat-plugins/chatlog.ts
+++ b/server/chat-plugins/chatlog.ts
@@ -41,7 +41,7 @@ export class LogReaderRoom {
 	async listDays(month: string) {
 		try {
 			const listing = await FS(`logs/chat/${this.roomid}/${month}`).readdir();
-			return listing.filter(file => /\.txt$/.test(file)).map(file => file.slice(0, -4));
+			return listing.filter(file => file.endsWith(".txt")).map(file => file.slice(0, -4));
 		} catch (err) {
 			return [];
 		}
@@ -315,7 +315,7 @@ export const LogViewer = new class {
 				if (opts !== 'all') return `<div class="notice">[uhtml box hidden]</div>`;
 				return `<div class="notice">${message.slice(message.indexOf(',') + 1)}</div>`;
 			}
-			const group = name.charAt(0) !== ' ' ? `<small>${name.charAt(0)}</small>` : ``;
+			const group = !name.startsWith(' ') ? `<small>${name.charAt(0)}</small>` : ``;
 			return `<div class="chat"><small>[${timestamp}] </small><strong>${group}${Utils.escapeHTML(name.slice(1))}:</strong> <q>${Chat.formatText(message)}</q></div>`;
 		}
 		case 'html': case 'raw': {

--- a/server/chat-plugins/chatlog.ts
+++ b/server/chat-plugins/chatlog.ts
@@ -633,28 +633,26 @@ export const LogSearcher = new class {
 			const aDate = new Date(aName.split('/').pop()!);
 			const bDate = new Date(bName.split('/').pop()!);
 			return bDate.getTime() - aDate.getTime();
-		}).map(chunk => {
-			return chunk.split('\n').map(line => {
-				if (exactMatches > limit || !toID(line)) return null; // return early so we don't keep sorting
-				const sep = line.includes('.txt-') ? '.txt-' : '.txt:';
-				const [name, text] = line.split(sep);
-				line = LogViewer.renderLine(text, 'all');
-				if (!line || name.includes('today')) return null;
+		}).map(chunk => chunk.split('\n').map(line => {
+			if (exactMatches > limit || !toID(line)) return null; // return early so we don't keep sorting
+			const sep = line.includes('.txt-') ? '.txt-' : '.txt:';
+			const [name, text] = line.split(sep);
+			line = LogViewer.renderLine(text, 'all');
+			if (!line || name.includes('today')) return null;
 				 // gets rid of some edge cases / duplicates
-				let date = name.replace(`logs/chat/${roomid}${toID(month) === 'all' ? '' : `/${month}`}`, '').slice(9);
-				if (searchRegex.test(line)) {
-					if (++exactMatches > limit) return null;
-					line = `<div class="chat chatmessage highlighted">${line}</div>`;
-				}
-				if (curDate !== date) {
-					curDate = date;
-					date = `</div></details><details open><summary>[<a href="view-chatlog-${roomid}--${date}">${date}</a>]</summary>`;
-				} else {
-					date = '';
-				}
-				return `${date} ${line}`;
-			}).filter(Boolean).join(' ');
-		}).filter(Boolean);
+			let date = name.replace(`logs/chat/${roomid}${toID(month) === 'all' ? '' : `/${month}`}`, '').slice(9);
+			if (searchRegex.test(line)) {
+				if (++exactMatches > limit) return null;
+				line = `<div class="chat chatmessage highlighted">${line}</div>`;
+			}
+			if (curDate !== date) {
+				curDate = date;
+				date = `</div></details><details open><summary>[<a href="view-chatlog-${roomid}--${date}">${date}</a>]</summary>`;
+			} else {
+				date = '';
+			}
+			return `${date} ${line}`;
+		}).filter(Boolean).join(' ')).filter(Boolean);
 		let buf = `<div class ="pad"><strong>Results on ${roomid} for ${search}:</strong>`;
 		buf += limit ? ` ${exactMatches} (capped at ${limit})` : '';
 		buf += `<hr /></div><blockquote>`;

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -509,7 +509,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		for (const parameter of parameters) {
 			let isNotSearch = false;
 			target = parameter.trim().toLowerCase();
-			if (target.charAt(0) === '!') {
+			if (target.startsWith('!')) {
 				isNotSearch = true;
 				target = target.substr(1);
 			}
@@ -789,18 +789,18 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 					// e.g. 100 < spe
 					num = parseFloat(targetParts[0]);
 					stat = targetParts[1];
-					if (inequalityString[0] === '>') directions.push('less');
-					if (inequalityString[0] === '<') directions.push('greater');
+					if (inequalityString.startsWith('>')) directions.push('less');
+					if (inequalityString.startsWith('<')) directions.push('greater');
 				} else if (!isNaN(parseFloat(targetParts[1]))) {
 					// e.g. spe > 100
 					num = parseFloat(targetParts[1]);
 					stat = targetParts[0];
-					if (inequalityString[0] === '<') directions.push('less');
-					if (inequalityString[0] === '>') directions.push('greater');
+					if (inequalityString.startsWith('<')) directions.push('less');
+					if (inequalityString.startsWith('>')) directions.push('greater');
 				} else {
 					return {error: `No value given to compare with '${escapeHTML(target)}'.`};
 				}
-				if (inequalityString.slice(-1) === '=') directions.push('equal');
+				if (inequalityString.endsWith('=')) directions.push('equal');
 				if (stat in allStatAliases) stat = allStatAliases[stat];
 				if (!allStats.includes(stat)) return {error: `'${escapeHTML(target)}' did not contain a valid stat.`};
 				if (!orGroup.stats[stat]) orGroup.stats[stat] = Object.create(null);
@@ -892,7 +892,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 
 			if (alts.tiers && Object.keys(alts.tiers).length) {
 				let tier = dex[mon].tier;
-				if (tier[0] === '(' && tier !== '(PU)' && tier !== '(NU)') tier = tier.slice(1, -1) as TierTypes.Singles;
+				if (tier.startsWith('(') && tier !== '(PU)' && tier !== '(NU)') tier = tier.slice(1, -1) as TierTypes.Singles;
 				// if (tier === 'New') tier = 'OU';
 				if (alts.tiers[tier]) continue;
 				if (Object.values(alts.tiers).includes(false) && alts.tiers[tier] !== false) continue;
@@ -922,7 +922,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 
 			if (alts.doublesTiers && Object.keys(alts.doublesTiers).length) {
 				let tier = dex[mon].doublesTier;
-				if (tier && tier[0] === '(' && tier !== '(DUU)') tier = tier.slice(1, -1) as TierTypes.Doubles;
+				if (tier && tier.startsWith('(') && tier !== '(DUU)') tier = tier.slice(1, -1) as TierTypes.Doubles;
 				if (alts.doublesTiers[tier]) continue;
 				if (Object.values(alts.doublesTiers).includes(false) && alts.doublesTiers[tier] !== false) continue;
 			}
@@ -1138,7 +1138,7 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 		for (const parameter of parameters) {
 			let isNotSearch = false;
 			target = parameter.toLowerCase().trim();
-			if (target.charAt(0) === '!') {
+			if (target.startsWith('!')) {
 				isNotSearch = true;
 				target = target.substr(1);
 			}
@@ -1434,7 +1434,7 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 			}
 
 			const oldTarget = target;
-			if (target.charAt(target.length - 1) === 's') target = target.substr(0, target.length - 1);
+			if (target.endsWith('s')) target = target.slice(0, -1);
 			switch (target) {
 			case 'toxic': target = 'tox'; break;
 			case 'poison': target = 'psn'; break;
@@ -2306,10 +2306,10 @@ function runLearn(target: string, cmd: string, canAll: boolean, message: string)
 		buffer += " from:<ul class=\"message-learn-list\">";
 		if (sources.length) {
 			sources = sources.map(source => {
-				if (source.slice(0, 3) === '1ET') {
+				if (source.startsWith('1ET')) {
 					return '2X' + source.slice(3);
 				}
-				if (source.slice(0, 3) === '1ST') {
+				if (source.startsWith('1ST')) {
 					return '2Y' + source.slice(3);
 				}
 				return source;
@@ -2333,7 +2333,7 @@ function runLearn(target: string, cmd: string, canAll: boolean, message: string)
 					}
 				}
 
-				if (source.slice(0, 2) === '5E' && species.maleOnlyHidden) {
+				if (source.startsWith('5E') && species.maleOnlyHidden) {
 					buffer += " (no hidden ability)";
 				}
 			}

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -74,7 +74,7 @@ export const commands: ChatCommands = {
 	ds8: 'dexsearch',
 	dsearch: 'dexsearch',
 	nds: 'dexsearch',
-	dexsearch(target, room, user, connection, cmd, message) {
+	async dexsearch(target, room, user, connection, cmd, message) {
 		this.checkBroadcast();
 		if (!target) return this.parse('/help dexsearch');
 		target = target.slice(0, 300);
@@ -103,25 +103,23 @@ export const commands: ChatCommands = {
 			target = targArray.join(',');
 		}
 		if (cmd === 'nds') target += ', natdex';
-		return runSearch({
+		const response = await runSearch({
 			target,
 			cmd: 'dexsearch',
 			canAll: !this.broadcastMessage || !!room?.settings.isPersonal,
 			message: (this.broadcastMessage ? "" : message),
-		}).then(response => {
-			if (!response.error && !this.runBroadcast()) return;
-			if (response.error) {
-				throw new Chat.ErrorMessage(response.error);
-			} else if (response.reply) {
-				this.sendReplyBox(response.reply);
-			} else if (response.dt) {
-				if (targetGen) response.dt += `, gen${targetGen}`;
-				(Chat.commands.data as Chat.ChatHandler).call(
-					this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
-				);
-			}
-			this.update();
 		});
+		if (!response.error && !this.runBroadcast()) return;
+		if (response.error) {
+			throw new Chat.ErrorMessage(response.error);
+		} else if (response.reply) {
+			this.sendReplyBox(response.reply);
+		} else if (response.dt) {
+			if (targetGen) response.dt += `, gen${targetGen}`;
+			(Chat.commands.data as Chat.ChatHandler).call(
+				this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
+			);
+		}
 	},
 
 	dexsearchhelp() {
@@ -150,7 +148,7 @@ export const commands: ChatCommands = {
 
 	rollmove: 'randommove',
 	randmove: 'randommove',
-	randommove(target, room, user, connection, cmd, message) {
+	async randommove(target, room, user, connection, cmd, message) {
 		this.checkBroadcast(true);
 		target = target.slice(0, 300);
 		const targets = target.split(",");
@@ -170,24 +168,22 @@ export const commands: ChatCommands = {
 		}
 		if (!qty) targetsBuffer.push("random1");
 
-		return runSearch({
+		const response = await runSearch({
 			target: targetsBuffer.join(","),
 			cmd: 'randmove',
 			canAll: !this.broadcastMessage || !!room?.settings.isPersonal,
 			message: (this.broadcastMessage ? "" : message),
-		}).then(response => {
-			if (!response.error && !this.runBroadcast(true)) return;
-			if (response.error) {
-				throw new Chat.ErrorMessage(response.error);
-			} else if (response.reply) {
-				this.sendReplyBox(response.reply);
-			} else if (response.dt) {
-				(Chat.commands.data as Chat.ChatHandler).call(
-					this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
-				);
-			}
-			this.update();
 		});
+		if (!response.error && !this.runBroadcast(true)) return;
+		if (response.error) {
+			throw new Chat.ErrorMessage(response.error);
+		} else if (response.reply) {
+			this.sendReplyBox(response.reply);
+		} else if (response.dt) {
+			(Chat.commands.data as Chat.ChatHandler).call(
+				this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
+			);
+		}
 	},
 	randommovehelp: [
 		`/randommove - Generates random Pok\u00e9mon Moves based on given search conditions.`,
@@ -196,7 +192,7 @@ export const commands: ChatCommands = {
 	],
 	rollpokemon: 'randompokemon',
 	randpoke: 'randompokemon',
-	randompokemon(target, room, user, connection, cmd, message) {
+	async randompokemon(target, room, user, connection, cmd, message) {
 		this.checkBroadcast(true);
 		target = target.slice(0, 300);
 		const targets = target.split(",");
@@ -216,24 +212,22 @@ export const commands: ChatCommands = {
 		}
 		if (!qty) targetsBuffer.push("random1");
 
-		return runSearch({
+		const response = await runSearch({
 			target: targetsBuffer.join(","),
 			cmd: 'randpoke',
 			canAll: !this.broadcastMessage || !!room?.settings.isPersonal,
 			message: (this.broadcastMessage ? "" : message),
-		}).then(response => {
-			if (!response.error && !this.runBroadcast(true)) return;
-			if (response.error) {
-				throw new Chat.ErrorMessage(response.error);
-			} else if (response.reply) {
-				this.sendReplyBox(response.reply);
-			} else if (response.dt) {
-				(Chat.commands.data as Chat.ChatHandler).call(
-					this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
-				);
-			}
-			this.update();
 		});
+		if (!response.error && !this.runBroadcast(true)) return;
+		if (response.error) {
+			throw new Chat.ErrorMessage(response.error);
+		} else if (response.reply) {
+			this.sendReplyBox(response.reply);
+		} else if (response.dt) {
+			(Chat.commands.data as Chat.ChatHandler).call(
+				this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
+			);
+		}
 	},
 	randompokemonhelp: [
 		`/randompokemon - Generates random Pok\u00e9mon based on given search conditions.`,
@@ -252,31 +246,29 @@ export const commands: ChatCommands = {
 	ms8: 'movesearch',
 	msearch: 'movesearch',
 	nms: 'movesearch',
-	movesearch(target, room, user, connection, cmd, message) {
+	async movesearch(target, room, user, connection, cmd, message) {
 		this.checkBroadcast();
 		if (!target) return this.parse('/help movesearch');
 		target = target.slice(0, 300);
 		const targetGen = parseInt(cmd[cmd.length - 1]);
 		if (targetGen) target += `, maxgen${targetGen}`;
 		if (cmd === 'nms') target += ', natdex';
-		return runSearch({
+		const response = await runSearch({
 			target,
 			cmd: 'movesearch',
 			canAll: !this.broadcastMessage || !!room?.settings.isPersonal,
 			message: (this.broadcastMessage ? "" : message),
-		}).then(response => {
-			if (!response.error && !this.runBroadcast()) return;
-			if (response.error) {
-				throw new Chat.ErrorMessage(response.error);
-			} else if (response.reply) {
-				this.sendReplyBox(response.reply);
-			} else if (response.dt) {
-				(Chat.commands.data as Chat.ChatHandler).call(
-					this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
-				);
-			}
-			this.update();
 		});
+		if (!response.error && !this.runBroadcast()) return;
+		if (response.error) {
+			throw new Chat.ErrorMessage(response.error);
+		} else if (response.reply) {
+			this.sendReplyBox(response.reply);
+		} else if (response.dt) {
+			(Chat.commands.data as Chat.ChatHandler).call(
+				this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
+			);
+		}
 	},
 	movesearchhelp() {
 		this.sendReplyBox(
@@ -312,31 +304,29 @@ export const commands: ChatCommands = {
 	is6: 'itemsearch',
 	is7: 'itemsearch',
 	is8: 'itemsearch',
-	itemsearch(target, room, user, connection, cmd, message) {
+	async itemsearch(target, room, user, connection, cmd, message) {
 		this.checkBroadcast();
 		if (!target) return this.parse('/help itemsearch');
 		target = target.slice(0, 300);
 		const targetGen = parseInt(cmd[cmd.length - 1]);
 		if (targetGen) target += ` maxgen${targetGen}`;
 
-		return runSearch({
+		const response = await runSearch({
 			target,
 			cmd: 'itemsearch',
 			canAll: !this.broadcastMessage || !!room?.settings.isPersonal,
 			message: (this.broadcastMessage ? "" : message),
-		}).then(response => {
-			if (!response.error && !this.runBroadcast()) return;
-			if (response.error) {
-				throw new Chat.ErrorMessage(response.error);
-			} else if (response.reply) {
-				this.sendReplyBox(response.reply);
-			} else if (response.dt) {
-				(Chat.commands.data as Chat.ChatHandler).call(
-					this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
-				);
-			}
-			this.update();
 		});
+		if (!response.error && !this.runBroadcast()) return;
+		if (response.error) {
+			throw new Chat.ErrorMessage(response.error);
+		} else if (response.reply) {
+			this.sendReplyBox(response.reply);
+		} else if (response.dt) {
+			(Chat.commands.data as Chat.ChatHandler).call(
+				this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
+			);
+		}
 	},
 	itemsearchhelp() {
 		this.sendReplyBox(
@@ -357,31 +347,29 @@ export const commands: ChatCommands = {
 	as6: 'abilitysearch',
 	as7: 'abilitysearch',
 	as8: 'abilitysearch',
-	abilitysearch(target, room, user, connection, cmd, message) {
+	async abilitysearch(target, room, user, connection, cmd, message) {
 		this.checkBroadcast();
 		if (!target) return this.parse('/help abilitysearch');
 		target = target.slice(0, 300);
 		const targetGen = parseInt(cmd[cmd.length - 1]);
 		if (targetGen) target += ` maxgen${targetGen}`;
 
-		return runSearch({
+		const response = await runSearch({
 			target,
 			cmd: 'abilitysearch',
 			canAll: !this.broadcastMessage || !!room?.settings.isPersonal,
 			message: (this.broadcastMessage ? "" : message),
-		}).then(response => {
-			if (!response.error && !this.runBroadcast()) return;
-			if (response.error) {
-				throw new Chat.ErrorMessage(response.error);
-			} else if (response.reply) {
-				this.sendReplyBox(response.reply);
-			} else if (response.dt) {
-				(Chat.commands.data as Chat.ChatHandler).call(
-					this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
-				);
-			}
-			this.update();
 		});
+		if (!response.error && !this.runBroadcast()) return;
+		if (response.error) {
+			throw new Chat.ErrorMessage(response.error);
+		} else if (response.reply) {
+			this.sendReplyBox(response.reply);
+		} else if (response.dt) {
+			(Chat.commands.data as Chat.ChatHandler).call(
+				this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
+			);
+		}
 	},
 	abilitysearchhelp() {
 		this.sendReplyBox(
@@ -402,25 +390,23 @@ export const commands: ChatCommands = {
 	bw2learn: 'learn',
 	oraslearn: 'learn',
 	usumlearn: 'learn',
-	learn(target, room, user, connection, cmd, message) {
+	async learn(target, room, user, connection, cmd, message) {
 		if (!target) return this.parse('/help learn');
 		target = target.slice(0, 300);
 		this.checkBroadcast();
 
-		return runSearch({
+		const response = await runSearch({
 			target,
 			cmd: 'learn',
 			canAll: !this.broadcastMessage || !!room?.settings.isPersonal,
 			message: cmd,
-		}).then(response => {
-			if (!response.error && !this.runBroadcast()) return;
-			if (response.error) {
-				throw new Chat.ErrorMessage(response.error);
-			} else if (response.reply) {
-				this.sendReplyBox(response.reply);
-			}
-			this.update();
 		});
+		if (!response.error && !this.runBroadcast()) return;
+		if (response.error) {
+			throw new Chat.ErrorMessage(response.error);
+		} else if (response.reply) {
+			this.sendReplyBox(response.reply);
+		}
 	},
 	learnhelp: [
 		`/learn [ruleset], [pokemon], [move, move, ...] - Displays how the Pok\u00e9mon can learn the given moves, if it can at all.`,

--- a/server/chat-plugins/help.ts
+++ b/server/chat-plugins/help.ts
@@ -151,7 +151,7 @@ export class HelpResponder {
 		const entry: string = roomFaqs[room.roomid][faq];
 		if (!entry) throw new Chat.ErrorMessage(`FAQ ID "${faq}" not found.`);
 
-		if (entry.charAt(0) !== '>') return faq; // not an alias
+		if (!entry.startsWith('>')) return faq; // not an alias
 		return entry.slice(1);
 	}
 	/**

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -119,9 +119,9 @@ export class HelpTicket extends Rooms.RoomGame {
 				this.firstClaimTime = Date.now();
 				// I'd use the player list for this, but it dosen't track DCs so were checking the userlist
 				// Non-staff users in the room currently (+ the ticket creator even if they are staff)
-				const users = Object.entries(this.room.users).filter(u => {
-					return !((u[1].isStaff && u[1].id !== this.ticket.userid) || !u[1].named);
-				});
+				const users = Object.entries(this.room.users).filter(
+					u => !((u[1].isStaff && u[1].id !== this.ticket.userid) || !u[1].named)
+				);
 				if (!users.length) this.emptyRoom = true;
 			}
 			if (this.ticket.active) {

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -52,9 +52,9 @@ try {
 }
 
 function writeTickets() {
-	FS(TICKET_FILE).writeUpdate(() => (
-		JSON.stringify(Object.assign({}, tickets))
-	));
+	FS(TICKET_FILE).writeUpdate(
+		() => JSON.stringify(tickets)
+	);
 }
 
 function writeStats(line: string) {

--- a/server/chat-plugins/lottery.ts
+++ b/server/chat-plugins/lottery.ts
@@ -238,9 +238,9 @@ export const commands: ChatCommands = {
 				return this.errorReply('This room does not have a lottery running.');
 			}
 			const canSeeIps = user.can('ip');
-			const participants = Object.entries(lottery.participants).map(([ip, participant]) => {
-				return `- ${participant}${canSeeIps ? ' (IP: ' + ip + ')' : ''}`;
-			});
+			const participants = Object.entries(lottery.participants).map(
+				([ip, participant]) => `- ${participant}${canSeeIps ? ' (IP: ' + ip + ')' : ''}`
+			);
 			let buf = '';
 			if (user.can('declare', null, room)) {
 				buf += `<details class="readmore"><summary><strong>List of participants (${participants.length}):</strong></summary>${participants.join('<br>')}</details>`;

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -451,7 +451,7 @@ class MafiaTracker extends Rooms.RoomGame {
 		for (const roleName of roles) {
 			const roleId = roleName.toLowerCase().replace(/[^\w\d\s]/g, '');
 			if (roleId in cache) {
-				newRoles.push(Object.assign({}, cache[roleId]));
+				newRoles.push({...cache[roleId]});
 			} else {
 				const role = MafiaTracker.parseRole(roleName);
 				if (role.problems.length) {

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -425,16 +425,14 @@ class MafiaTracker extends Rooms.RoomGame {
 		}
 
 		if (force) {
-			this.originalRoles = roles.map(r => {
-				return {
-					name: r,
-					safeName: Utils.escapeHTML(r),
-					id: toID(r),
-					alignment: 'solo',
-					image: '',
-					memo: [`To learn more about your role, PM the host (${this.host}).`],
-				};
-			});
+			this.originalRoles = roles.map(r => ({
+				name: r,
+				safeName: Utils.escapeHTML(r),
+				id: toID(r),
+				alignment: 'solo',
+				image: '',
+				memo: [`To learn more about your role, PM the host (${this.host}).`],
+			}));
 			this.originalRoles.sort((a, b) => a.name.localeCompare(b.name));
 			this.roles = this.originalRoles.slice();
 			this.originalRoleString = this.originalRoles.map(

--- a/server/chat-plugins/modlog-viewer.ts
+++ b/server/chat-plugins/modlog-viewer.ts
@@ -245,7 +245,7 @@ export async function runBattleSearch(userids: ID[], month: string, tierid: ID, 
 		throw err;
 	}
 	const [userid] = userids;
-	files = files.filter(item => item.slice(0, -3) === month).map(item => `logs/${month}/${tierid}/${item}`);
+	files = files.filter(file => file.startsWith(month)).map(file => `logs/${month}/${tierid}/${file}`);
 
 	if (useRipgrep) {
 		// Matches non-word (including _ which counts as a word) characters between letters/numbers
@@ -491,8 +491,8 @@ export const pages: PageTable = {
 			// First sort by gen with the latest being first
 			let aGen = 6;
 			let bGen = 6;
-			if (a.substring(0, 3) === 'gen') aGen = parseInt(a.substring(3, 4));
-			if (b.substring(0, 3) === 'gen') bGen = parseInt(b.substring(3, 4));
+			if (a.startsWith('gen')) aGen = parseInt(a.substring(3, 4));
+			if (b.startsWith('gen')) bGen = parseInt(b.substring(3, 4));
 			if (aGen !== bGen) return bGen - aGen;
 			// Sort alphabetically
 			const aTier = a.substring(4);
@@ -505,7 +505,7 @@ export const pages: PageTable = {
 			const format = Dex.getFormat(tier);
 			if (format?.exists) tier = format.name;
 			// Otherwise format as best as possible
-			if (tier.substring(0, 3) === 'gen') {
+			if (tier.startsWith('gen')) {
 				return `[Gen ${tier.substring(3, 4)}] ${tier.substring(4)}`;
 			}
 			return tier;

--- a/server/chat-plugins/rock-paper-scissors.ts
+++ b/server/chat-plugins/rock-paper-scissors.ts
@@ -62,9 +62,7 @@ export class RPSGame extends Rooms.RoomGame {
 		return attacker;
 	}
 	sendOptions() {
-		const button = (cmd: string, title: string) => {
-			return `<button class="button" name="send" value="/${cmd}">${title}</button>`;
-		};
+		const button = (cmd: string, title: string) => `<button class="button" name="send" value="/${cmd}">${title}</button>`;
 		let buf = `<center><strong>Make your choice, quick!</strong><br />`;
 		for (const item of ['Rock', 'Paper', 'Scissors']) {
 			buf += `${button(`choose ${item}`, `${item} ${ICONS[item]}`)}`;

--- a/server/chat-plugins/room-faqs.ts
+++ b/server/chat-plugins/room-faqs.ts
@@ -18,7 +18,7 @@ function saveRoomFaqs() {
 export function getAlias(roomid: RoomID, key: string) {
 	if (!roomFaqs[roomid]) return false;
 	const value = roomFaqs[roomid][key];
-	if (value && value[0] === '>') return value.substr(1);
+	if (value && value.startsWith('>')) return value.substr(1);
 	return false;
 }
 

--- a/server/chat-plugins/scavenger-games.ts
+++ b/server/chat-plugins/scavenger-games.ts
@@ -68,10 +68,10 @@ class Leaderboard {
 						lowestScore = bit[sortBy];
 						lastPlacement = i + 1;
 					}
-					return Object.assign(
-						{rank: lastPlacement},
-						bit
-					);
+					return {
+						rank: lastPlacement,
+						...bit,
+					};
 				}); // identify ties
 			if (userid) {
 				const rank = ladder.find(entry => toID(entry.name) === userid);

--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -138,7 +138,7 @@ class PlayerLadder extends Ladder {
 	}
 
 	addPoints(name: string, aspect: string, points: number, noUpdate?: boolean) {
-		if (aspect.indexOf('cumulative-') !== 0) {
+		if (!aspect.startsWith('cumulative-')) {
 			this.addPoints(name, `cumulative-${aspect}`, points, noUpdate);
 		}
 		const userid = toID(name);

--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -2047,9 +2047,10 @@ const ScavengerCommands: ChatCommands = {
 		if (!room.settings.scavSettings) room.settings.scavSettings = {};
 		if (!target) {
 			const points = [];
-			const source = Object.entries(
-				{...DEFAULT_POINTS, ...(room.settings.scavSettings.winPoints || {})}
-			) as [string, number[]][];
+			const source = Object.entries({
+				...DEFAULT_POINTS,
+				...(room.settings.scavSettings.winPoints as typeof DEFAULT_POINTS || {}),
+			});
 
 			for (const entry of source) {
 				points.push(`${entry[0]}: ${entry[1].map((p: number, i: number) => `(${(i + 1)}) ${p}`).join(', ')}`);

--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -155,6 +155,7 @@ class PlayerLadder extends Ladder {
 	}
 
 	// add the different keys to the history - async for larger leaderboards
+	// FIXME: this is not what "async" means
 	softReset() {
 		return new Promise((resolve, reject) => {
 			for (const u in this.data) {
@@ -2165,11 +2166,10 @@ const ScavengerCommands: ChatCommands = {
 
 		if (target === 'RESET') {
 			this.checkCan('declare', null, room);
-			HostLeaderboard.softReset().then(() => {
-				HostLeaderboard.write();
-				this.privateModAction(`${user.name} has reset the host log leaderboard into the next month.`);
-				this.modlog('SCAV HUNTLOGS', null, 'RESET');
-			});
+			await HostLeaderboard.softReset();
+			HostLeaderboard.write();
+			this.privateModAction(`${user.name} has reset the host log leaderboard into the next month.`);
+			this.modlog('SCAV HUNTLOGS', null, 'RESET');
 			return;
 		} else if (target === 'HARD RESET') {
 			this.checkCan('declare', null, room);
@@ -2212,11 +2212,10 @@ const ScavengerCommands: ChatCommands = {
 
 		if (target === 'RESET') {
 			this.checkCan('declare', null, room);
-			PlayerLeaderboard.softReset().then(() => {
-				PlayerLeaderboard.write();
-				this.privateModAction(`${user.name} has reset the player log leaderboard into the next month.`);
-				this.modlog('SCAV PLAYLOGS', null, 'RESET');
-			});
+			await PlayerLeaderboard.softReset();
+			PlayerLeaderboard.write();
+			this.privateModAction(`${user.name} has reset the player log leaderboard into the next month.`);
+			this.modlog('SCAV PLAYLOGS', null, 'RESET');
 			return;
 		} else if (target === 'HARD RESET') {
 			this.checkCan('declare', null, room);

--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -117,10 +117,10 @@ class Ladder {
 						lowestScore = chunk[sortBy];
 						lastPlacement = i + 1;
 					}
-					return Object.assign(
-						{rank: lastPlacement},
-						chunk
-					);
+					return {
+						rank: lastPlacement,
+						...chunk,
+					};
 				}); // identify ties
 			if (userid) {
 				const rank = ladder.find(entry => toID(entry.name) === userid);
@@ -2046,9 +2046,9 @@ const ScavengerCommands: ChatCommands = {
 		if (!room.settings.scavSettings) room.settings.scavSettings = {};
 		if (!target) {
 			const points = [];
-			const source: [string, number[]][] = Object.entries(
-				Object.assign({}, DEFAULT_POINTS, room.settings.scavSettings.winPoints || {})
-			) as [];
+			const source = Object.entries(
+				{...DEFAULT_POINTS, ...(room.settings.scavSettings.winPoints || {})}
+			) as [string, number[]][];
 
 			for (const entry of source) {
 				points.push(`${entry[0]}: ${entry[1].map((p: number, i: number) => `(${(i + 1)}) ${p}`).join(', ')}`);

--- a/server/chat-plugins/thing-of-the-day.ts
+++ b/server/chat-plugins/thing-of-the-day.ts
@@ -677,7 +677,7 @@ export const otdCommands: ChatCommands = {
 	},
 	winnershelp: [`/-otd winners - Displays a list of previous things of the day.`],
 
-	''(target, room) {
+	async ''(target, room) {
 		this.checkChat();
 		if (!this.runBroadcast()) return false;
 
@@ -686,11 +686,9 @@ export const otdCommands: ChatCommands = {
 
 		if (room !== handler.room) return this.errorReply(`This command can only be used in ${handler.room.title}.`);
 
-		return handler.generateWinnerDisplay().then(text => {
-			if (!text) return this.errorReply("There is no winner yet.");
-			this.sendReplyBox(text);
-			room.update();
-		});
+		const text = await handler.generateWinnerDisplay();
+		if (!text) return this.errorReply("There is no winner yet.");
+		this.sendReplyBox(text);
 	},
 };
 

--- a/server/chat-plugins/trivia.ts
+++ b/server/chat-plugins/trivia.ts
@@ -858,11 +858,9 @@ export class Trivia extends Rooms.RoomGame {
 			if ((options.requirePoints && !player.points) || !user) continue;
 			ranks.push({id: userid, player, name: user.name});
 		}
-		ranks.sort((a, b) => {
-			return b.player.points - a.player.points ||
+		ranks.sort((a, b) => b.player.points - a.player.points ||
 				a.player.lastQuestion - b.player.lastQuestion ||
-				hrtimeToNanoseconds(a.player.answeredAt) - hrtimeToNanoseconds(b.player.answeredAt);
-		});
+				hrtimeToNanoseconds(a.player.answeredAt) - hrtimeToNanoseconds(b.player.answeredAt));
 		return options.max === null ? ranks : ranks.slice(0, options.max);
 	}
 
@@ -909,9 +907,7 @@ export class Trivia extends Rooms.RoomGame {
  * Helper function for timer and number modes. Milliseconds are not precise
  * enough to score players properly in rare cases.
  */
-const hrtimeToNanoseconds = (hrtime: number[]) => {
-	return hrtime[0] * 1e9 + hrtime[1];
-};
+const hrtimeToNanoseconds = (hrtime: number[]) => hrtime[0] * 1e9 + hrtime[1];
 
 /**
  * First mode rewards points to the first user to answer the question
@@ -2073,16 +2069,16 @@ const triviaCommands: ChatCommands = {
 			queryString = queryString.toLowerCase();
 			transformQuestion = (question: string) => question.toLowerCase();
 		}
-		const results = (triviaData as any)[type].filter((q: TriviaQuestion) => {
-			return transformQuestion(q.question).includes(queryString) && !SPECIAL_CATEGORIES[q.category];
-		});
+		const results = triviaData[type as 'questions' | 'submissions']!.filter(
+			q => transformQuestion(q.question).includes(queryString) && !SPECIAL_CATEGORIES[q.category]
+		);
 		if (!results.length) return this.sendReply(this.tr`No results found under the ${type} list.`);
 
 		let buffer = `|raw|<div class="ladder"><table><tr><th>#</th><th>${this.tr`Category`}</th><th>${this.tr`Question`}</th></tr>` +
 			`<tr><td colspan="3">${this.tr`There are <strong>${results.length}</strong> matches for your query:`}</td></tr>`;
-		buffer += results.map((q: TriviaQuestion, i: number) => {
-			return this.tr`<tr><td><strong>${i + 1}</strong></td><td>${q.category}</td><td>${q.question}</td></tr>`;
-		}).join('');
+		buffer += results.map(
+			(q, i) => this.tr`<tr><td><strong>${i + 1}</strong></td><td>${q.category}</td><td>${q.question}</td></tr>`
+		).join('');
 		buffer += "</table></div>";
 
 		this.sendReply(buffer);

--- a/server/chat-plugins/uno.ts
+++ b/server/chat-plugins/uno.ts
@@ -293,7 +293,7 @@ export class UNO extends Rooms.RoomGame {
 	}
 
 	onAwaitUno() {
-		return new Promise(resolve => {
+		return new Promise<void>(resolve => {
 			if (!this.awaitUno) return resolve();
 
 			this.state = "uno";
@@ -308,23 +308,22 @@ export class UNO extends Rooms.RoomGame {
 	}
 
 	nextTurn(starting?: boolean) {
-		void this.onAwaitUno()
-			.then(x => {
-				if (!starting) this.onNextPlayer();
+		void this.onAwaitUno().then(() => {
+			if (!starting) this.onNextPlayer();
 
-				if (this.timer) clearTimeout(this.timer);
-				const player = this.playerTable[this.currentPlayerid];
+			if (this.timer) clearTimeout(this.timer);
+			const player = this.playerTable[this.currentPlayerid];
 
-				this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|&|${player.name}'s turn.`);
-				this.state = 'play';
-				if (player.cardLock) player.cardLock = null;
-				player.sendDisplay();
+			this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|&|${player.name}'s turn.`);
+			this.state = 'play';
+			if (player.cardLock) player.cardLock = null;
+			player.sendDisplay();
 
-				this.timer = setTimeout(() => {
-					this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|&|${player.name} has been automatically disqualified.`);
-					this.eliminate(this.currentPlayerid);
-				}, this.maxTime * 1000);
-			});
+			this.timer = setTimeout(() => {
+				this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|&|${player.name} has been automatically disqualified.`);
+				this.eliminate(this.currentPlayerid);
+			}, this.maxTime * 1000);
+		});
 	}
 
 	onNextPlayer() {

--- a/server/chat-plugins/youtube.ts
+++ b/server/chat-plugins/youtube.ts
@@ -429,9 +429,8 @@ export const pages: PageTable = {
 				return this.errorReply(`There are currently no categories in the Youtube channel database.`);
 			}
 			const sorted: {[k: string]: string[]} = {};
-			const channels = Object.assign({}, YouTube.data.channels);
-			for (const id of Object.keys(channels)) {
-				const channel = channels[id];
+			const channels = YouTube.data.channels;
+			for (const [id, channel] of Object.entries(channels)) {
 				const category = channel.category || "No category";
 				if (!sorted[category]) {
 					sorted[category] = [];

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1229,7 +1229,7 @@ export class CommandContext extends MessageContext {
 			const stack = [];
 			for (const tag of tags) {
 				const isClosingTag = tag.charAt(1) === '/';
-				const contentEndLoc = tag.charAt(tag.length - 1) === '/' ? -1 : undefined;
+				const contentEndLoc = tag.endsWith('/') ? -1 : undefined;
 				const tagContent = tag.slice(isClosingTag ? 2 : 1, contentEndLoc).replace(/\s+/, ' ').trim();
 				const tagNameEndIndex = tagContent.indexOf(' ');
 				const tagName = tagContent.slice(0, tagNameEndIndex >= 0 ? tagNameEndIndex : undefined).toLowerCase();

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1567,9 +1567,7 @@ export const Chat = new class {
 			throw new Error(`Trying to translate to a nonexistent language: ${language}`);
 		}
 		if (!strings.length) {
-			return ((fStrings: TemplateStringsArray | string, ...fKeys: any) => {
-				return Chat.tr(language, fStrings, ...fKeys);
-			});
+			return ((fStrings: TemplateStringsArray | string, ...fKeys: any) => Chat.tr(language, fStrings, ...fKeys));
 		}
 
 		const entry = Chat.translations.get(language)!.get(trString);

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -2014,7 +2014,7 @@ export const Chat = new class {
 		return `<div class="message"><ul class="utilichart">${buf}<li style="clear:both"></li></ul></div>`;
 	}
 	getDataMoveHTML(move: Move) {
-		if (typeof move === 'string') move = Object.assign({}, Dex.getMove(move));
+		if (typeof move === 'string') move = Dex.getMove(move);
 		let buf = `<ul class="utilichart"><li class="result">`;
 		buf += `<span class="col movenamecol"><a href="https://${Config.routes.dex}/moves/${move.id}">${move.name}</a></span> `;
 		// encoding is important for the ??? type icon
@@ -2033,7 +2033,7 @@ export const Chat = new class {
 		return buf;
 	}
 	getDataAbilityHTML(ability: Ability) {
-		if (typeof ability === 'string') ability = Object.assign({}, Dex.getAbility(ability));
+		if (typeof ability === 'string') ability = Dex.getAbility(ability);
 		let buf = `<ul class="utilichart"><li class="result">`;
 		buf += `<span class="col namecol"><a href="https://${Config.routes.dex}/abilities/${ability.id}">${ability.name}</a></span> `;
 		buf += `<span class="col abilitydesccol">${ability.shortDesc || ability.desc}</span> `;
@@ -2041,7 +2041,7 @@ export const Chat = new class {
 		return buf;
 	}
 	getDataItemHTML(item: string | Item) {
-		if (typeof item === 'string') item = Object.assign({}, Dex.getItem(item));
+		if (typeof item === 'string') item = Dex.getItem(item);
 		let buf = `<ul class="utilichart"><li class="result">`;
 		buf += `<span class="col itemiconcol"><psicon item="${item.id}"></span> <span class="col namecol"><a href="https://${Config.routes.dex}/items/${item.id}">${item.name}</a></span> `;
 		buf += `<span class="col itemdesccol">${item.shortDesc || item.desc}</span> `;

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -2014,7 +2014,6 @@ export const Chat = new class {
 		return `<div class="message"><ul class="utilichart">${buf}<li style="clear:both"></li></ul></div>`;
 	}
 	getDataMoveHTML(move: Move) {
-		if (typeof move === 'string') move = Dex.getMove(move);
 		let buf = `<ul class="utilichart"><li class="result">`;
 		buf += `<span class="col movenamecol"><a href="https://${Config.routes.dex}/moves/${move.id}">${move.name}</a></span> `;
 		// encoding is important for the ??? type icon
@@ -2033,15 +2032,13 @@ export const Chat = new class {
 		return buf;
 	}
 	getDataAbilityHTML(ability: Ability) {
-		if (typeof ability === 'string') ability = Dex.getAbility(ability);
 		let buf = `<ul class="utilichart"><li class="result">`;
 		buf += `<span class="col namecol"><a href="https://${Config.routes.dex}/abilities/${ability.id}">${ability.name}</a></span> `;
 		buf += `<span class="col abilitydesccol">${ability.shortDesc || ability.desc}</span> `;
 		buf += `</li><li style="clear:both"></li></ul>`;
 		return buf;
 	}
-	getDataItemHTML(item: string | Item) {
-		if (typeof item === 'string') item = Dex.getItem(item);
+	getDataItemHTML(item: Item) {
 		let buf = `<ul class="utilichart"><li class="result">`;
 		buf += `<span class="col itemiconcol"><psicon item="${item.id}"></span> <span class="col namecol"><a href="https://${Config.routes.dex}/items/${item.id}">${item.name}</a></span> `;
 		buf += `<span class="col itemdesccol">${item.shortDesc || item.desc}</span> `;

--- a/server/config-loader.ts
+++ b/server/config-loader.ts
@@ -19,9 +19,9 @@ const CONFIG_PATH = require.resolve('../config/config');
 
 export function load(invalidate = false) {
 	if (invalidate) delete require.cache[CONFIG_PATH];
-	const config = Object.assign({}, defaults, require('../config/config')) as ConfigType;
+	const config = ({...defaults, ...require('../config/config')}) as ConfigType;
 	// config.routes is nested - we need to ensure values are set for its keys as well.
-	config.routes = Object.assign({}, defaults.routes, config.routes);
+	config.routes = {...defaults.routes, ...config.routes};
 	cacheGroupData(config);
 	return config;
 }

--- a/server/ladders-local.ts
+++ b/server/ladders-local.ts
@@ -284,13 +284,13 @@ export class LadderStore {
 			}
 
 			let reasons = '' + (Math.round(p1newElo) - Math.round(p1elo)) + ' for ' + (p1score > 0.9 ? 'winning' : (p1score < 0.1 ? 'losing' : 'tying'));
-			if (reasons.charAt(0) !== '-') reasons = '+' + reasons;
+			if (!reasons.startsWith('-')) reasons = '+' + reasons;
 			room.addRaw(
 				Utils.html`${p1name}'s rating: ${Math.round(p1elo)} &rarr; <strong>${Math.round(p1newElo)}</strong><br />(${reasons})`
 			);
 
 			reasons = '' + (Math.round(p2newElo) - Math.round(p2elo)) + ' for ' + (p2score > 0.9 ? 'winning' : (p2score < 0.1 ? 'losing' : 'tying'));
-			if (reasons.charAt(0) !== '-') reasons = '+' + reasons;
+			if (!reasons.startsWith('-')) reasons = '+' + reasons;
 			room.addRaw(
 				Utils.html`${p2name}'s rating: ${Math.round(p2elo)} &rarr; <strong>${Math.round(p2newElo)}</strong><br />(${reasons})`
 			);

--- a/server/ladders-remote.ts
+++ b/server/ladders-remote.ts
@@ -118,7 +118,7 @@ export class LadderStore {
 			let elo = Math.round(p1rating.elo);
 			let act = (p1score > 0.9 ? `winning` : (p1score < 0.1 ? `losing` : `tying`));
 			let reasons = `${elo - oldelo} for ${act}`;
-			if (reasons.charAt(0) !== '-') reasons = '+' + reasons;
+			if (!reasons.startsWith('-')) reasons = '+' + reasons;
 			room.addRaw(Utils.html`${p1name}'s rating: ${oldelo} &rarr; <strong>${elo}</strong><br />(${reasons})`);
 			let minElo = elo;
 
@@ -126,7 +126,7 @@ export class LadderStore {
 			elo = Math.round(p2rating.elo);
 			act = (p1score > 0.9 || p1score < 0 ? `losing` : (p1score < 0.1 ? `winning` : `tying`));
 			reasons = `${elo - oldelo} for ${act}`;
-			if (reasons.charAt(0) !== '-') reasons = '+' + reasons;
+			if (!reasons.startsWith('-')) reasons = '+' + reasons;
 			room.addRaw(Utils.html`${p2name}'s rating: ${oldelo} &rarr; <strong>${elo}</strong><br />(${reasons})`);
 			if (elo < minElo) minElo = elo;
 			room.rated = minElo;

--- a/server/ladders.ts
+++ b/server/ladders.ts
@@ -8,7 +8,6 @@
  * @license MIT
  */
 
-// eslint-disable-next-line no-undef
 const LadderStore: typeof LadderStoreT = (typeof Config === 'object' && Config.remoteladder ?
 	require('./ladders-remote') :
 	require('./ladders-local')).LadderStore;

--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -319,7 +319,7 @@ export const Punishments = new class {
 	}
 
 	appendPunishment(entry: PunishmentEntry, id: string, filename: string) {
-		if (id.charAt(0) === '#') return;
+		if (id.startsWith('#')) return;
 		const buf = Punishments.renderEntry(entry, id);
 		return FS(filename).append(buf);
 	}
@@ -500,7 +500,7 @@ export const Punishments = new class {
 		if (!lastUserId.startsWith('guest')) {
 			Punishments.userids.set(lastUserId, punishment);
 		}
-		if (user.locked && user.locked.charAt(0) !== '#') {
+		if (user.locked && !user.locked.startsWith('#')) {
 			Punishments.userids.set(user.locked, punishment);
 			userids.add(user.locked as ID);
 		}
@@ -812,7 +812,7 @@ export const Punishments = new class {
 			user.updateIdentity();
 			success.push(user.getLastName());
 		}
-		if (id.charAt(0) !== '#') {
+		if (!id.startsWith('#')) {
 			for (const curUser of Users.users.values()) {
 				if (curUser.locked === id) {
 					curUser.locked = null;
@@ -861,7 +861,7 @@ export const Punishments = new class {
 			user.resetName();
 			success.push(user.getLastName());
 		}
-		if (id.charAt(0) !== '#') {
+		if (!id.startsWith('#')) {
 			for (const curUser of Users.users.values()) {
 				if (curUser.locked === id) {
 					curUser.locked = null;
@@ -1464,7 +1464,7 @@ export const Punishments = new class {
 		// `Punishments.roomIps.get(roomid)` guaranteed to exist above
 		(roomid ? Punishments.roomIps.get(roomid)! : Punishments.ips).forEach((punishment, ip) => {
 			const [punishType, id, expireTime, reason, ...rest] = punishment;
-			if (id.charAt(0) === '#') return;
+			if (id.startsWith('#')) return;
 			let entry = punishmentTable.get(id);
 
 			if (entry) {
@@ -1485,7 +1485,7 @@ export const Punishments = new class {
 		// `Punishments.roomIps.get(roomid)` guaranteed to exist above
 		(roomid ? Punishments.roomUserids.get(roomid)! : Punishments.userids).forEach((punishment, userid) => {
 			const [punishType, id, expireTime, reason, ...rest] = punishment;
-			if (id.charAt(0) === '#') return;
+			if (id.startsWith('#')) return;
 			let entry = punishmentTable.get(id);
 
 			if (!entry) {

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -203,7 +203,7 @@ export class RoomBattleTimer {
 			if (timerSettings[k] === undefined) delete timerSettings[k];
 		}
 
-		this.settings = Object.assign({
+		this.settings = {
 			dcTimer: !isChallenge,
 			dcTimerBank: isChallenge,
 			starting: isChallenge ? STARTING_TIME_CHALLENGE : STARTING_TIME,
@@ -213,7 +213,8 @@ export class RoomBattleTimer {
 			maxFirstTurn: isChallenge ? MAX_TURN_TIME_CHALLENGE : MAX_TURN_TIME,
 			timeoutAutoChoose: false,
 			accelerate: !timerSettings,
-		}, timerSettings);
+			...timerSettings,
+		};
 		if (this.settings.maxPerTurn <= 0) this.settings.maxPerTurn = Infinity;
 
 		for (const player of this.battle.players) {

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1260,9 +1260,7 @@ export class RoomBattleStream extends BattleStream {
  * Process manager
  *********************************************************/
 
-export const PM = new StreamProcessManager(module, () => {
-	return new RoomBattleStream();
-});
+export const PM = new StreamProcessManager(module, () => new RoomBattleStream());
 
 if (!PM.isParentProcess) {
 	// This is a child process!

--- a/server/roomlogs.ts
+++ b/server/roomlogs.ts
@@ -231,14 +231,13 @@ export class Roomlog {
 		const roomlogPath = `logs/chat`;
 		const roomlogStreamExisted = this.roomlogStream !== null;
 		await this.destroy(false); // don't destroy modlog, since it's renamed later
-		await Promise.all([
+		const [roomlogExists, newRoomlogExists] = await Promise.all([
 			FS(roomlogPath + `/${this.roomid}`).exists(),
 			FS(roomlogPath + `/${newID}`).exists(),
-		]).then(([roomlogExists, newRoomlogExists]) => Promise.all([
-			roomlogExists && !newRoomlogExists ?
-				FS(roomlogPath + `/${this.roomid}`).rename(roomlogPath + `/${newID}`) :
-				undefined,
-		]));
+		]);
+		if (roomlogExists && !newRoomlogExists) {
+			await FS(roomlogPath + `/${this.roomid}`).rename(roomlogPath + `/${newID}`);
+		}
 		await Rooms.Modlog.rename(this.roomid, newID);
 		this.roomid = newID;
 		Roomlogs.roomlogs.set(newID, this);

--- a/server/roomlogs.ts
+++ b/server/roomlogs.ts
@@ -234,13 +234,11 @@ export class Roomlog {
 		await Promise.all([
 			FS(roomlogPath + `/${this.roomid}`).exists(),
 			FS(roomlogPath + `/${newID}`).exists(),
-		]).then(([roomlogExists, newRoomlogExists]) => {
-			return Promise.all([
-				roomlogExists && !newRoomlogExists ?
-					FS(roomlogPath + `/${this.roomid}`).rename(roomlogPath + `/${newID}`) :
-					undefined,
-			]);
-		});
+		]).then(([roomlogExists, newRoomlogExists]) => Promise.all([
+			roomlogExists && !newRoomlogExists ?
+				FS(roomlogPath + `/${this.roomid}`).rename(roomlogPath + `/${newID}`) :
+				undefined,
+		]));
 		await Rooms.Modlog.rename(this.roomid, newID);
 		this.roomid = newID;
 		Roomlogs.roomlogs.set(newID, this);

--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -208,7 +208,7 @@ export class ServerStream extends Streams.ObjectReadWriteStream<string> {
 			if (key && cert) {
 				try {
 					// In case there are additional SSL config settings besides the key and cert...
-					this.serverSsl = https.createServer(Object.assign({}, config.ssl.options, {key, cert}));
+					this.serverSsl = https.createServer({...config.ssl.options, key, cert});
 				} catch (e) {
 					crashlogger(new Error(`The SSL settings are misconfigured:\n${e.stack}`), `Socket process ${process.pid}`);
 				}

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -1378,23 +1378,22 @@ const commands: ChatCommands = {
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			void tournament.acceptChallenge(user, this);
 		},
-		vtm(target, room, user, connection) {
+		async vtm(target, room, user, connection) {
 			room = this.requireRoom();
 			const tournament = room.getGame(Tournament);
 			if (!tournament) return this.errorReply(`There is no tournament running.`);
 			if (Monitor.countPrepBattle(connection.ip, connection)) {
 				return;
 			}
-			void TeamValidatorAsync.get(tournament.fullFormat).validateTeam(user.battleSettings.team).then(result => {
-				if (result.charAt(0) === '1') {
-					connection.popup("Your team is valid for this tournament.");
-				} else {
-					const formatName = Dex.getFormat(tournament.baseFormat).name;
-					// split/join is the easiest way to do a find/replace with an untrusted string, sadly
-					const reasons = result.slice(1).split(formatName).join('this tournament');
-					connection.popup(`Your team was rejected for the following reasons:\n\n- ${reasons.replace(/\n/g, '\n- ')}`);
-				}
-			});
+			const result = await TeamValidatorAsync.get(tournament.fullFormat).validateTeam(user.battleSettings.team);
+			if (result.charAt(0) === '1') {
+				connection.popup("Your team is valid for this tournament.");
+			} else {
+				const formatName = Dex.getFormat(tournament.baseFormat).name;
+				// split/join is the easiest way to do a find/replace with an untrusted string, sadly
+				const reasons = result.slice(1).split(formatName).join('this tournament');
+				connection.popup(`Your team was rejected for the following reasons:\n\n- ${reasons.replace(/\n/g, '\n- ')}`);
+			}
 		},
 		viewruleset: 'viewcustomrules',
 		viewbanlist: 'viewcustomrules',

--- a/server/user-groups.ts
+++ b/server/user-groups.ts
@@ -83,11 +83,12 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 		if (fallback !== undefined) return fallback;
 
 		// unidentified groups are treated as voice
-		return Object.assign({}, Config.groups['+'] || {}, {
+		return {
+			...(Config.groups['+'] || {}),
 			symbol,
 			id: 'voice',
 			name: symbol,
-		});
+		};
 	}
 	getEffectiveSymbol(user: User): EffectiveGroupSymbol {
 		const group = this.get(user);

--- a/server/users.ts
+++ b/server/users.ts
@@ -646,7 +646,7 @@ export class User extends Chat.MessageContext {
 			}
 		}
 
-		if (!token || token.charAt(0) === ';') {
+		if (!token || token.startsWith(';')) {
 			this.send(`|nametaken|${name}|Your authentication token was invalid.`);
 			return false;
 		}
@@ -1578,7 +1578,7 @@ function socketReceive(worker: StreamWorker, workerid: number, socketid: string,
 	// from propagating out of this function.
 
 	// drop legacy JSON messages
-	if (message.charAt(0) === '{') return;
+	if (message.startsWith('{')) return;
 
 	const pipeIndex = message.indexOf('|');
 	if (pipeIndex < 0) {

--- a/server/users.ts
+++ b/server/users.ts
@@ -907,11 +907,9 @@ export class User extends Chat.MessageContext {
 			oldUser.locked !== oldUser.id &&
 			this.locked !== this.id &&
 			// Only unlock if no previous names are locked
-			!oldUser.previousIDs.some(id => {
-				return !!Punishments.search(id)
-					.filter(punishment => punishment[2][0] === 'LOCK' && punishment[2][1] === id)
-					.length;
-			})
+			!oldUser.previousIDs.some(id => !!Punishments.search(id)
+				.filter(punishment => punishment[2][0] === 'LOCK' && punishment[2][1] === id)
+				.length)
 		) {
 			this.locked = null;
 		} else if (this.locked !== this.id) {

--- a/sim/battle-stream.ts
+++ b/sim/battle-stream.ts
@@ -64,7 +64,7 @@ export class BattleStream extends Streams.ObjectReadWriteStream<string> {
 
 	_writeLines(chunk: string) {
 		for (const line of chunk.split('\n')) {
-			if (line.charAt(0) === '>') {
+			if (line.startsWith('>')) {
 				const [type, message] = splitFirst(line.slice(1), ' ');
 				this._writeLine(type, message);
 			}
@@ -227,7 +227,7 @@ export abstract class BattlePlayer {
 
 	receiveLine(line: string) {
 		if (this.debug) console.log(line);
-		if (line.charAt(0) !== '|') return;
+		if (!line.startsWith('|')) return;
 		const [cmd, rest] = splitFirst(line.slice(1), '|');
 		if (cmd === 'request') return this.receiveRequest(JSON.parse(rest));
 		if (cmd === 'error') return this.receiveError(new Error(rest));

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1681,7 +1681,7 @@ export class Battle {
 		if (!target || !target.hp) return 0;
 		if (!target.isActive) return false;
 		if (this.gen > 5 && !target.side.foe.pokemonLeft) return false;
-		boost = this.runEvent('Boost', target, source, effect, Object.assign({}, boost));
+		boost = this.runEvent('Boost', target, source, effect, {...boost});
 		let success = null;
 		let boosted = isSecondary;
 		let boostName: BoostName;

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -386,9 +386,9 @@ export class ModdedDex {
 
 		name = (name || '').trim();
 		let id = toID(name);
-		if (id === 'nidoran' && name.slice(-1) === '♀') {
+		if (id === 'nidoran' && name.endsWith('♀')) {
 			id = 'nidoranf' as ID;
-		} else if (id === 'nidoran' && name.slice(-1) === '♂') {
+		} else if (id === 'nidoran' && name.endsWith('♂')) {
 			id = 'nidoranm' as ID;
 		}
 		let species: any = this.speciesCache.get(id);
@@ -1039,7 +1039,7 @@ export class ModdedDex {
 			if (rule.slice(1).includes('>') || rule.slice(1).includes('+')) {
 				let buf = rule.slice(1);
 				const gtIndex = buf.lastIndexOf('>');
-				let limit = rule.charAt(0) === '+' ? Infinity : 0;
+				let limit = rule.startsWith('+') ? Infinity : 0;
 				if (gtIndex >= 0 && /^[0-9]+$/.test(buf.slice(gtIndex + 1).trim())) {
 					if (limit === 0) limit = parseInt(buf.slice(gtIndex + 1));
 					buf = buf.slice(0, gtIndex);
@@ -1064,7 +1064,7 @@ export class ModdedDex {
 			if (!this.data.Formats.hasOwnProperty(id)) {
 				throw new Error(`Unrecognized rule "${rule}"`);
 			}
-			if (rule.charAt(0) === '!') return `!${id}`;
+			if (rule.startsWith('!')) return `!${id}`;
 			return id;
 		}
 	}
@@ -1076,7 +1076,7 @@ export class ModdedDex {
 		const matches = [];
 		let matchTypes = ['pokemon', 'move', 'ability', 'item', 'pokemontag'];
 		for (const matchType of matchTypes) {
-			if (rule.slice(0, 1 + matchType.length) === matchType + ':') {
+			if (rule.startsWith(`${matchType}:`)) {
 				matchTypes = [matchType];
 				id = id.slice(matchType.length) as ID;
 				break;
@@ -1119,7 +1119,7 @@ export class ModdedDex {
 					}
 				}
 				matches.push(matchType + ':' + id);
-			} else if (matchType === 'pokemon' && id.slice(-4) === 'base') {
+			} else if (matchType === 'pokemon' && id.endsWith('base')) {
 				id = id.slice(0, -4) as ID;
 				if (table.hasOwnProperty(id)) {
 					matches.push('pokemon:' + id);
@@ -1303,7 +1303,7 @@ export class ModdedDex {
 	fastUnpackTeam(buf: string): PokemonSet[] | null {
 		if (!buf) return null;
 		if (typeof buf !== 'string') return buf;
-		if (buf.charAt(0) === '[' && buf.charAt(buf.length - 1) === ']') {
+		if (buf.startsWith('[') && buf.endsWith(']')) {
 			buf = this.packTeam(JSON.parse(buf));
 		}
 

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -1212,6 +1212,10 @@ export class ModdedDex {
 	packTeam(team: PokemonSet[] | null): string {
 		if (!team) return '';
 
+		function getIv(ivs: StatsTable, s: keyof StatsTable): string {
+			return ivs[s] === 31 || ivs[s] === undefined ? '' : ivs[s].toString();
+		}
+
 		let buf = '';
 		for (const set of team) {
 			if (buf) buf += ']';
@@ -1254,9 +1258,6 @@ export class ModdedDex {
 			}
 
 			// ivs
-			const getIv = (ivs: StatsTable, s: keyof StatsTable): string => {
-				return ivs[s] === 31 || ivs[s] === undefined ? '' : ivs[s].toString();
-			};
 			let ivs = '|';
 			if (set.ivs) {
 				ivs = '|' + getIv(set.ivs, 'hp') + ',' + getIv(set.ivs, 'atk') + ',' + getIv(set.ivs, 'def') +

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -514,7 +514,7 @@ export class Pokemon {
 
 		// stat boosts
 		if (!unboosted) {
-			const boosts = this.battle.runEvent('ModifyBoost', this, null, null, Object.assign({}, this.boosts));
+			const boosts = this.battle.runEvent('ModifyBoost', this, null, null, {...this.boosts});
 			let boost = boosts[statName];
 			const boostTable = [1, 1.5, 2, 2.5, 3, 3.5, 4];
 			if (boost > 6) boost = 6;
@@ -1037,7 +1037,7 @@ export class Pokemon {
 		for (const i in pokemon.volatiles) {
 			if (this.battle.dex.getEffectByID(i as ID).noCopy) continue;
 			// shallow clones
-			this.volatiles[i] = Object.assign({}, pokemon.volatiles[i]);
+			this.volatiles[i] = {...pokemon.volatiles[i]};
 			if (this.volatiles[i].linkedPokemon) {
 				delete pokemon.volatiles[i].linkedPokemon;
 				delete pokemon.volatiles[i].linkedStatus;

--- a/sim/state.ts
+++ b/sim/state.ts
@@ -385,7 +385,7 @@ export const State = new class {
 		// class types to be decode, so we're probably OK. We could make the reference
 		// markers more esoteric with additional sigils etc to avoid collisions, but
 		// we're making a conscious decision to favor readability over robustness.
-		if (ref.charAt(0) !== '[' && ref.slice(-1) !== ']') return undefined;
+		if (!ref.startsWith('[') && !ref.endsWith(']')) return undefined;
 
 		ref = ref.substring(1, ref.length - 1);
 		// There's only one instance of these thus they don't need an id to differentiate.

--- a/sim/tools/multi-random-runner.ts
+++ b/sim/tools/multi-random-runner.ts
@@ -42,7 +42,7 @@ export class MultiRandomRunner {
 	private numGames: number;
 
 	constructor(options: MultiRandomRunnerOptions) {
-		this.options = Object.assign({}, options);
+		this.options = {...options};
 
 		this.totalGames = options.totalGames;
 
@@ -73,7 +73,7 @@ export class MultiRandomRunner {
 			}
 
 			const seed = this.prng.seed;
-			const game = new Runner(Object.assign({format}, this.options)).run().catch(err => {
+			const game = new Runner({format, ...this.options}).run().catch(err => {
 				failures++;
 				console.error(
 					`Run \`node tools/simulate multi 1 --format=${format} --seed=${seed.join()}\` ` +

--- a/sim/tools/runner.ts
+++ b/sim/tools/runner.ts
@@ -55,8 +55,8 @@ export class Runner {
 
 		this.prng = (options.prng && !Array.isArray(options.prng)) ?
 			options.prng : new PRNG(options.prng);
-		this.p1options = Object.assign({}, Runner.AI_OPTIONS, options.p1options);
-		this.p2options = Object.assign({}, Runner.AI_OPTIONS, options.p2options);
+		this.p1options = {...Runner.AI_OPTIONS, ...options.p1options};
+		this.p2options = {...Runner.AI_OPTIONS, ...options.p2options};
 
 		this.input = !!options.input;
 		this.output = !!options.output;
@@ -84,10 +84,10 @@ export class Runner {
 		const p2spec = this.getPlayerSpec("Bot 2", this.p2options);
 
 		const p1 = this.p1options.createAI(
-			streams.p1, Object.assign({seed: this.newSeed()}, this.p1options)
+			streams.p1, {seed: this.newSeed(), ...this.p1options}
 		);
 		const p2 = this.p2options.createAI(
-			streams.p2, Object.assign({seed: this.newSeed()}, this.p2options)
+			streams.p2, {seed: this.newSeed(), ...this.p2options}
 		);
 		// TODO: Use `await Promise.race([streams.omniscient.read(), p1, p2])` to avoid
 		// leaving these promises dangling once it no longer causes memory leaks (v8#9069).

--- a/test/lib/dashycode.js
+++ b/test/lib/dashycode.js
@@ -4,12 +4,12 @@ const assert = require('assert').strict;
 const Dashycode = require('./../../.lib-dist/dashycode');
 
 describe('Dashycode', function () {
-	const ascii = Array.from({length: 0x80}, (v, k) => k);
-	const iso88591 = Array.from({length: 0x80}, (v, k) => k + 0x80);
-	const utf16 = Array.from({length: 0xFF00}, (v, k) => k + 0x100);
+	const ascii = Array.from({length: 0x80}, (v, i) => i);
+	const iso88591 = Array.from({length: 0x80}, (v, i) => i + 0x80);
+	const utf16 = Array.from({length: 0xFF00}, (v, i) => i + 0x100);
 
-	const latinL = Array.from({length: 26}, (v, k) => k + 0x60);
-	const latinU = Array.from({length: 26}, (v, k) => k + 0x41);
+	const latinL = Array.from({length: 26}, (v, i) => i + 0x60);
+	const latinU = Array.from({length: 26}, (v, i) => i + 0x41);
 
 	const encoded = new Map();
 
@@ -56,15 +56,15 @@ describe('Dashycode', function () {
 	};
 
 	it('should encode all codepoints uniquely', function () {
-		return [...ascii, ...iso88591, ...utf16].reduce((p, codepoint) => (
-			p.then(v => encode(codepoint))
-		), Promise.resolve());
+		for (const codepoint of [...ascii, ...iso88591, ...utf16]) {
+			encode(codepoint);
+		}
 	});
 
 	it('should decode all codepoints accurately', function () {
-		return [...encoded.keys()].reduce((p, dashycode) => (
-			p.then(v => decode(dashycode))
-		), Promise.resolve());
+		for (const dashycode of encoded.keys()) {
+			decode(dashycode);
+		}
 	});
 
 	it('should transcode multiple spaces in a row', transcode('ayy  lmao'));

--- a/tools/modlog/converter.ts
+++ b/tools/modlog/converter.ts
@@ -61,9 +61,10 @@ export function modernizeLog(line: string, nextLine?: string): string | undefine
 	if (line.startsWith('SCAV ')) {
 		line = line.replace(/: (\[room: .*?\]) by (.*)/, (match, roominfo, rest) => `: by ${rest} ${roominfo}`);
 	}
-	line = line.replace(/(GIVEAWAY WIN|GTS FINISHED): ([A-Za-z0-9].*?)(won|has finished)/, (match, action, user) => {
-		return `${action}: [${toID(user)}]:`;
-	});
+	line = line.replace(
+		/(GIVEAWAY WIN|GTS FINISHED): ([A-Za-z0-9].*?)(won|has finished)/,
+		(match, action, user) => `${action}: [${toID(user)}]:`
+	);
 
 	if (line.includes(':')) {
 		const possibleModernAction = line.slice(0, line.indexOf(':')).trim();

--- a/tools/modlog/converter.ts
+++ b/tools/modlog/converter.ts
@@ -486,18 +486,16 @@ export class ModlogConverterTest {
 	}
 }
 
-export class ModlogConverter {
-	static async convert(
+export const ModlogConverter = {
+	async convert(
 		from: ModlogFormat, to: ModlogFormat, databasePath: string,
 		textLogDirectoryPath: string, outputLogPath?: string
 	) {
 		if (from === 'txt' && to === 'txt' && outputLogPath) {
 			const converter = new ModlogConverterTest(textLogDirectoryPath, outputLogPath);
-			return converter.toTxt().then(() => {
-				console.log("\nDone!");
-				process.exit();
-			});
+			await converter.toTxt();
+			console.log("\nDone!");
+			process.exit();
 		}
-	}
-}
-
+	},
+};

--- a/tools/set-import/importer.ts
+++ b/tools/set-import/importer.ts
@@ -194,7 +194,7 @@ async function importSmogonSets(
 				addSmogonSet(dex, format, pokemon, name, set, setsForPokemon, numByFormat);
 				for (const battleOnlyForme of battleOnlyFormes) {
 					// Note: this is just a shallow copy which is fine because we're just modifying the ability
-					const s = Object.assign({}, set);
+					const s = {...set};
 					if (!format.id.includes('balancedhackmons')) s.ability = battleOnlyForme.abilities[0];
 					if (typeof battleOnlyForme.battleOnly !== 'string') {
 						if (!battleOnlyForme.battleOnly!.includes(pokemon)) continue;
@@ -336,20 +336,20 @@ function toPokemonSet(
 				set.hpType = type;
 				fill = 31;
 			} else if (dex.gen === 2) {
-				const dvs = Object.assign({}, dex.getType(type).HPdvs);
+				const dvs = {...dex.getType(type).HPdvs};
 				let stat: StatName;
 				for (stat in dvs) {
 					dvs[stat]! *= 2;
 				}
-				set.ivs = Object.assign({}, dvs, set.ivs);
+				set.ivs = {...dvs, ...set.ivs};
 				set.ivs.hp = expectedHP(set.ivs);
 			} else {
-				set.ivs = Object.assign({}, dex.getType(type).HPivs, set.ivs);
+				set.ivs = {...dex.getType(type).HPivs, ...set.ivs};
 			}
 		}
 	}
 
-	const copy = Object.assign({species: pokemon}, set) as PokemonSet;
+	const copy = {species: pokemon, ...set} as PokemonSet;
 	copy.ivs = fillStats(set.ivs, fill);
 	// The validator expects us to have at least 1 EV set to prove it is intentional
 	if (!set.evs && dex.gen >= 3 && format.id !== 'gen7letsgoou') set.evs = {spe: 1};


### PR DESCRIPTION
This is a PR so everyone knows what's up, and in case people want to object to one of these.

`arrow-body-style` means

```ts
// this is wrong:
[1, 2, 3].map(a => { return a + 1; });

// this is right:
[1, 2, 3].map(a => a + 1);
```
 
`prefer-object-spread` means:

```ts
// this is wrong:
const fooCopy = Object.assign({}, foo);

// this is right:
const fooCopy = {...foo};
```

In addition, a lot of you seem to be using `{...foo}` in places you could just use `foo`. Remember, you don't need to clone an object unless you want to modify it for some reason. `JSON.stringify` etc do not modify objects.

`no-parameter-properties` means:

```ts
// this is wrong:
class Foo {
  constructor(public bar: string) {}
}

// this is right:
class Foo {
  bar: string;
  constructor(bar: string) {
    this.bar = bar;
  }
}
```

This is something we already do, but I'm turning it on just in case we have a contributor used to a different convention.