### PR TITLE
Calculate natures with 16-bit truncation

### DIFF
--- a/data/mods/letsgo/scripts.ts
+++ b/data/mods/letsgo/scripts.ts
@@ -20,7 +20,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			const stat = baseStats['hp'];
 			modStats['hp'] = Math.floor(Math.floor(2 * stat + set.ivs['hp'] + 100) * set.level / 100 + 10);
 		}
-		return this.dex.natureModify(modStats, set);
+		return this.natureModify(modStats, set);
 	},
 
 	/**

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2011,15 +2011,18 @@ export class Battle {
 	}
 
 	natureModify(stats: StatsTable, set: PokemonSet): StatsTable {
+		// Natures are calculated with 16-bit truncation.
+		// This only affects Eternatus-Eternmax in Pure Hackmons.
+		const tr = this.trunc;
 		const nature = this.dex.getNature(set.nature);
 		let stat: keyof StatsTable;
 		if (nature.plus) {
 			stat = nature.plus;
-			stats[stat] = Math.floor(stats[stat] * 1.1);
+			stats[stat] = tr(tr(stats[stat] * 110, 16) / 100);
 		}
 		if (nature.minus) {
 			stat = nature.minus;
-			stats[stat] = Math.floor(stats[stat] * 0.9);
+			stats[stat] = tr(tr(stats[stat] * 90, 16) / 100);
 		}
 		return stats;
 	}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1994,6 +1994,36 @@ export class Battle {
 		return tr((tr(value * modifier) + 2048 - 1) / 4096);
 	}
 
+	/** Given a table of base stats and a pokemon set, return the actual stats. */
+	spreadModify(baseStats: StatsTable, set: PokemonSet): StatsTable {
+		const modStats: SparseStatsTable = {atk: 10, def: 10, spa: 10, spd: 10, spe: 10};
+		const tr = this.trunc;
+		let statName: keyof StatsTable;
+		for (statName in modStats) {
+			const stat = baseStats[statName];
+			modStats[statName] = tr(tr(2 * stat + set.ivs[statName] + tr(set.evs[statName] / 4)) * set.level / 100 + 5);
+		}
+		if ('hp' in baseStats) {
+			const stat = baseStats['hp'];
+			modStats['hp'] = tr(tr(2 * stat + set.ivs['hp'] + tr(set.evs['hp'] / 4) + 100) * set.level / 100 + 10);
+		}
+		return this.natureModify(modStats as StatsTable, set);
+	}
+
+	natureModify(stats: StatsTable, set: PokemonSet): StatsTable {
+		const nature = this.dex.getNature(set.nature);
+		let stat: keyof StatsTable;
+		if (nature.plus) {
+			stat = nature.plus;
+			stats[stat] = Math.floor(stats[stat] * 1.1);
+		}
+		if (nature.minus) {
+			stat = nature.minus;
+			stats[stat] = Math.floor(stats[stat] * 0.9);
+		}
+		return stats;
+	}
+
 	getCategory(move: string | Move) {
 		return this.dex.getMove(move).category || 'Physical';
 	}

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -828,36 +828,6 @@ export class ModdedDex {
 		return nature;
 	}
 
-	/** Given a table of base stats and a pokemon set, return the actual stats. */
-	spreadModify(baseStats: StatsTable, set: PokemonSet): StatsTable {
-		const modStats: SparseStatsTable = {atk: 10, def: 10, spa: 10, spd: 10, spe: 10};
-		const tr = this.trunc;
-		let statName: keyof StatsTable;
-		for (statName in modStats) {
-			const stat = baseStats[statName];
-			modStats[statName] = tr(tr(2 * stat + set.ivs[statName] + tr(set.evs[statName] / 4)) * set.level / 100 + 5);
-		}
-		if ('hp' in baseStats) {
-			const stat = baseStats['hp'];
-			modStats['hp'] = tr(tr(2 * stat + set.ivs['hp'] + tr(set.evs['hp'] / 4) + 100) * set.level / 100 + 10);
-		}
-		return this.natureModify(modStats as StatsTable, set);
-	}
-
-	natureModify(stats: StatsTable, set: PokemonSet): StatsTable {
-		const nature = this.getNature(set.nature);
-		let stat: keyof StatsTable;
-		if (nature.plus) {
-			stat = nature.plus;
-			stats[stat] = Math.floor(stats[stat] * 1.1);
-		}
-		if (nature.minus) {
-			stat = nature.minus;
-			stats[stat] = Math.floor(stats[stat] * 0.9);
-		}
-		return stats;
-	}
-
 	getHiddenPower(ivs: AnyObject) {
 		const hpTypes = [
 			'Fighting', 'Flying', 'Poison', 'Ground', 'Rock', 'Bug', 'Ghost', 'Steel',

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1159,7 +1159,7 @@ export class Pokemon {
 		this.knownType = true;
 		this.weighthg = species.weighthg;
 
-		const stats = this.battle.dex.spreadModify(this.species.baseStats, this.set);
+		const stats = this.battle.spreadModify(this.species.baseStats, this.set);
 		if (this.species.maxHP) stats.hp = this.species.maxHP;
 
 		if (!this.maxhp) {


### PR DESCRIPTION
Latest research shows that in Pure Hackmons, Eternatus-Eternamax can have enough EVs such that its stat can overflow when calculating its nature. If with a neutral nature it would have 596 in a stat, the nature adjustment calculates 596 * 110 / 100, however this is a 16-bit calculation and the 596 * 110 overflows. (Its stat can actually go slightly higer than 596 with predictable results.)