### PR TITLE
Moderation: visualize mute times with less precision

### DIFF
--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -586,7 +586,10 @@ export const commands: ChatCommands = {
 		if (targetUser.id in room.users) {
 			targetUser.popup(`|modal|${user.name} has muted you in ${room.roomid} for ${Chat.toDurationString(muteDuration)}. ${target}`);
 		}
-		this.addModAction(`${targetUser.name} was muted by ${user.name} for ${Chat.toDurationString(muteDuration)}.${(target ? ` (${target})` : ``)}`);
+		this.addModAction(
+			`${targetUser.name} was muted by ${user.name} for ${Chat.toDurationString(muteDuration, {precision: 1})}.` +
+			`${(target ? ` (${target})` : ``)}`
+		);
 		this.modlog(`${cmd.includes('h') ? 'HOUR' : ''}MUTE`, targetUser, target);
 		if (targetUser.autoconfirmed && targetUser.autoconfirmed !== targetUser.id) {
 			const displayMessage = `${targetUser.name}'s ac account: ${targetUser.autoconfirmed}`;


### PR DESCRIPTION
This part of this change seems to annoy everyone, and it's not useful for the main chat. 