### PR TITLE
Validator: Allow Hidden Ability Entei/Raikou/Suicune in Gen 8 natively

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -514,7 +514,7 @@ export class TeamValidator {
 
 					if (unreleasedHidden && ruleTable.has('-unreleased')) {
 						problems.push(`${name}'s Hidden Ability is unreleased.`);
-					} else if (['entei', 'suicune', 'raikou'].includes(species.id) && this.minSourceGen > 1 && this.gen < 8) {
+					} else if (dex.gen === 7 && ['entei', 'suicune', 'raikou'].includes(species.id) && this.minSourceGen > 1) {
 						problems.push(`${name}'s Hidden Ability is only available from Virtual Console, which is not allowed in this format.`);
 					} else if (dex.gen === 6 && ability.name === 'Symbiosis' &&
 						(set.species.endsWith('Orange') || set.species.endsWith('White'))) {

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -514,7 +514,7 @@ export class TeamValidator {
 
 					if (unreleasedHidden && ruleTable.has('-unreleased')) {
 						problems.push(`${name}'s Hidden Ability is unreleased.`);
-					} else if (['entei', 'suicune', 'raikou'].includes(species.id) && this.minSourceGen > 1) {
+					} else if (['entei', 'suicune', 'raikou'].includes(species.id) && this.minSourceGen > 1 && this.gen < 8) {
 						problems.push(`${name}'s Hidden Ability is only available from Virtual Console, which is not allowed in this format.`);
 					} else if (dex.gen === 6 && ability.name === 'Symbiosis' &&
 						(set.species.endsWith('Orange') || set.species.endsWith('White'))) {

--- a/test/sim/team-validator.js
+++ b/test/sim/team-validator.js
@@ -579,6 +579,23 @@ describe('Team Validator', function () {
 		assert(illegal);
 	});
 
+	it('should allow use of a Hidden Ability if the format has the item Ability Patch', function () {
+		let team = [
+			{species: 'heatran', ability: 'flamebody', moves: ['sleeptalk'], evs: {hp: 1}},
+			{species: 'entei', ability: 'innerfocus', moves: ['sleeptalk'], evs: {hp: 1}},
+			{species: 'dracovish', ability: 'sandrush', moves: ['sleeptalk'], evs: {hp: 1}},
+			{species: 'zapdos', ability: 'static', moves: ['sleeptalk'], evs: {hp: 1}},
+		];
+		let illegal = TeamValidator.get('gen8vgc2021').validateTeam(team);
+		assert.equal(illegal, null);
+
+		team = [
+			{species: 'heatran', ability: 'flamebody', moves: ['sleeptalk'], evs: {hp: 1}},
+		];
+		illegal = TeamValidator.get('gen7anythinggoes').validateTeam(team);
+		assert(illegal);
+	});
+
 
 	/*********************************************************
  	* Custom rules


### PR DESCRIPTION
I believe this only affects the hardcode on Entei/Suicune/Raikou. What I did is functional but not sure if I did it correctly and/or if there's other checks here that should be freed with the release of Ability Patch.