### PR TITLE
Fix IPTools' handling of IP addresses

### DIFF
--- a/test/server/ip-tools.js
+++ b/test/server/ip-tools.js
@@ -72,11 +72,11 @@ describe("IP tools", () => {
 });
 
 describe("IP tools helper functions", () => {
-	it("ipToNumber and numberToIp should be each other's inverses", () => {
-		const numTests = 10;
-		for (let i = 0; i < numTests; i++) {
-			const testNumber = Math.floor(Math.random() * 4294967294) + 1;
-			assert.equal(IPTools.ipToNumber(IPTools.numberToIP(testNumber)), testNumber);
+	it("should produce idempotent IPv4 address representations", () => {
+		for (const address of [0x00000000, 0x7F000001, 0xFFFFFFFF]) {
+			const literal = IPTools.numberToIP(address);
+			const result = IPTools.ipToNumber(literal);
+			assert.equal(result, address);
 		}
 	});
 


### PR DESCRIPTION
The IPv4 address implementation `IPTools` has is broken. Presentation-formatted IP addresses produced by `IPTools` are stored persistently in `config/hosts.csv` and `config/proxies.csv`, which get involved when resolving hosts pertaining to IP addresses. This means there is no guarantee that anyone's host on PS is accurate as things stand now.

This makes the first steps to fixing `IPTools`' IP address handling, but is incomplete in its current state, does nothing to mitigate the damage that's been done, and will break things further if merged now. How best to complete this merits some discussion beforehand.