### PR TITLE
Build: Delete built files with no .ts counterpart

### DIFF
--- a/build
+++ b/build
@@ -92,12 +92,13 @@ function needsSucrase(source, dest, path = '') {
 			const files = fs.readdirSync(source + path);
 			for (const oldFile of oldFiles) {
 				if (!oldFile.endsWith('.js') || files.includes(oldFile)) continue;
-				if (!files.includes(oldFile.slice(0, -2) + 'ts')) {
+				if (!files.includes(oldFile.slice(0, -2) + 'ts') || force) {
 					fs.unlink(dest + path + '/' + oldFile, function (err) {
 						if (err) throw err;
 					});
 				}
 			}
+			if (force) return true;
 			for (const file of files) {
 				if (needsSucrase(source, dest, path + '/' + file)) {
 					return true;
@@ -113,7 +114,7 @@ function needsSucrase(source, dest, path = '') {
 
 function sucrase(src, out, opts) {
 	try {
-		if (!force && src !== './config' && !needsSucrase(src, out)) {
+		if (src !== './config' && !needsSucrase(src, out)) {
 			return false;
 		}
 	} catch (e) {}

--- a/build
+++ b/build
@@ -86,7 +86,15 @@ function needsSucrase(source, dest, path = '') {
 	if (!path.includes('.')) {
 		// probably dir
 		try {
+			const oldFiles = fs.readdirSync(dest + path);
 			const files = fs.readdirSync(source + path);
+			for (const oldFile of oldFiles) {
+				if (files.includes(oldFile)) continue; // .js ending in main
+				if (!oldFile.endsWith('.js')) continue;
+				if (!files.includes(oldFile.slice(0, -2) + 'ts')) {
+					fs.unlinkSync(dest + path + '/' + oldFile);
+				}
+			}
 			for (const file of files) {
 				if (needsSucrase(source, dest, path + '/' + file)) {
 					return true;
@@ -100,30 +108,12 @@ function needsSucrase(source, dest, path = '') {
 	return false;
 }
 
-function clearPath(path, src, isJs = false) {
-	try {
-		const stats = fs.lstatSync(path);
-		if (stats.isDirectory()) {
-			for (const file of fs.readdirSync(path)) {
-				const source = src + '/' + file;
-				clearPath(path + '/' + file, source, fs.existsSync(source));
-			}
-			return;
-		}
-		if (!isJs) src = src.replace('.js', '.ts');
-		if (!fs.existsSync(src)) {
-			fs.unlinkSync(path);
-		}
-	} catch (e) {}
-}
-
 function sucrase(src, out, opts) {
 	try {
 		if (!force && src !== './config' && !needsSucrase(src, out)) {
 			return false;
 		}
 	} catch (e) {}
-	clearPath(out, src); // empty the dir to get rid of built js files with no ts couterpart
 	shell(`npx sucrase ${opts || ''} -q ${src} -d ${out} --transforms typescript,imports --enable-legacy-typescript-module-interop`);
 	return true;
 }

--- a/build
+++ b/build
@@ -53,7 +53,7 @@ function copyOverDataJSON(file) {
 	fs.readFile(source, function (err, text) {
 		if (err) throw err;
 		fs.writeFile(dest, text, function (err) {
-			if (err) throw err;
+			throw err;
 		});
 	});
 }
@@ -89,10 +89,11 @@ function needsSucrase(source, dest, path = '') {
 			const oldFiles = fs.readdirSync(dest + path);
 			const files = fs.readdirSync(source + path);
 			for (const oldFile of oldFiles) {
-				if (files.includes(oldFile)) continue; // .js ending in main
-				if (!oldFile.endsWith('.js')) continue;
+				if (!oldFile.endsWith('.js') || files.includes(oldFile)) continue;
 				if (!files.includes(oldFile.slice(0, -2) + 'ts')) {
-					fs.unlinkSync(dest + path + '/' + oldFile);
+					fs.unlink(dest + path + '/' + oldFile, function (err) {
+						if (err) throw err;
+					});
 				}
 			}
 			for (const file of files) {

--- a/build
+++ b/build
@@ -53,7 +53,9 @@ function copyOverDataJSON(file) {
 	fs.readFile(source, function (err, text) {
 		if (err) throw err;
 		fs.writeFile(dest, text, function (err) {
-			throw err;
+			if (err && err.code !== 'ENOENT') {
+				throw err;
+			}
 		});
 	});
 }

--- a/build
+++ b/build
@@ -100,12 +100,30 @@ function needsSucrase(source, dest, path = '') {
 	return false;
 }
 
+function clearPath(path, src, isJs = false) {
+	try {
+		const stats = fs.lstatSync(path);
+		if (stats.isDirectory()) {
+			for (const file of fs.readdirSync(path)) {
+				const source = src + '/' + file;
+				clearPath(path + '/' + file, source, fs.existsSync(source));
+			}
+			return;
+		}
+		if (!isJs) src = src.replace('.js', '.ts');
+		if (!fs.existsSync(src)) {
+			fs.unlinkSync(path);
+		}
+	} catch (e) {}
+}
+
 function sucrase(src, out, opts) {
 	try {
 		if (!force && src !== './config' && !needsSucrase(src, out)) {
 			return false;
 		}
 	} catch (e) {}
+	clearPath(out, src); // empty the dir to get rid of built js files with no ts couterpart
 	shell(`npx sucrase ${opts || ''} -q ${src} -d ${out} --transforms typescript,imports --enable-legacy-typescript-module-interop`);
 	return true;
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "pretest": "npm run lint && npm run build",
     "test": "mocha",
     "posttest": "npm run tsc",
-    "full-test": "npm run full-lint && npm run build && npm run tsc && mocha --forbid-only -g \".*\""
+    "full-test": "npm run full-lint && npm run build --force && npm run tsc && mocha --forbid-only -g \".*\""
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This is to ensure that files that don't exist in the TS directory don't exist in the built directory, to avoid crashes that pull data from old files.
Not sure if this is the best solution, but it seemed the best way to clear out deleted files as quickly and simply as possible.