### PR TITLE
Ignore As One boosts when already maxed out

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -180,8 +180,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		onFoeTryEatItem: false,
 		onSourceAfterFaint(length, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
-				this.add('-ability', source, 'Chilling Neigh');
-				this.boost({atk: length}, source, source, null, true);
+				this.boost({atk: length}, source, source, this.dex.getEffect('chillingneigh'), true);
 			}
 		},
 		name: "As One (Glastrier)",
@@ -196,8 +195,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		onFoeTryEatItem: false,
 		onSourceAfterFaint(length, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
-				this.add('-ability', source, 'Grim Neigh');
-				this.boost({spa: length}, source, source, null, true);
+				this.boost({spa: length}, source, source, this.dex.getEffect('grimneigh'), true);
 			}
 		},
 		name: "As One (Spectrier)",


### PR DESCRIPTION
As [researched](https://www.smogon.com/forums/posts/8637512) by @DaWoblefet, the boosts should not activate when the stat is already maxed out.