### PR TITLE
sendReplyBox: Fix interaction with hidelines

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -770,7 +770,7 @@ export class CommandContext extends MessageContext {
 		this.add(`|html|<div class="infobox">${htmlContent}</div>`);
 	}
 	sendReplyBox(htmlContent: string) {
-		this.sendReply(`|c|${this.room ? this.user.getIdentity() : '~'}|/raw <div class="infobox">${htmlContent}</div>`);
+		this.sendReply(`|c|${this.room && this.broadcasting ? this.user.getIdentity() : '~'}|/raw <div class="infobox">${htmlContent}</div>`);
 	}
 	popupReply(message: string) {
 		this.connection.popup(message);


### PR DESCRIPTION
This makes non-broadcasted reply infoboxes come from user ``~`` (This is questionable - shouldn't it be & by now since the beautiful admin sign ~ is replaced with the super ugly &) instead of the user themselves.  This makes it so that un-broadcasted information searches won't be hidden by any /hidetext, hidelines command.  This is rather important in game rooms that rely on /ds for searches.  If someone accidentally leaks something that might be an answer and the room's staff has to quickly suppress their text, losing progress of all their previous searches would be detrimental to their progress in the current game.