### PR TITLE
Ban Japanese Gen 1 Events in Int Formats: Part 2

### DIFF
--- a/data/mods/gen2/learnsets.ts
+++ b/data/mods/gen2/learnsets.ts
@@ -998,7 +998,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlwind: ["1M"],
 		},
 		eventData: [
-			{generation: 1, level: 20, moves: ["growl", "leer", "furyattack", "payday"]},
+			{generation: 1, level: 20, moves: ["growl", "leer", "furyattack", "payday"]}, //JP Event
 		],
 	},
 	ekans: {
@@ -1201,7 +1201,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 		},
 		eventData: [
 			{generation: 1, level: 5, moves: ["surf"]},
-			{generation: 1, level: 5, moves: ["fly"]},
+			{generation: 1, level: 5, moves: ["fly"]}, //JP Event
 			{generation: 1, level: 5, moves: ["thundershock", "growl", "surf"]},
 		],
 	},
@@ -4206,7 +4206,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			toxic: ["2M", "1M"],
 		},
 		eventData: [
-			{generation: 1, level: 40, moves: ["ember", "firespin", "stomp", "payday"]},
+			{generation: 1, level: 40, moves: ["ember", "firespin", "stomp", "payday"]}, //JP Event
 		],
 	},
 	slowpoke: {
@@ -7230,7 +7230,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			tackle: ["2L15", "1L15"],
 		},
 		eventData: [
-			{generation: 1, level: 5, moves: ["dragonrage"]},
+			{generation: 1, level: 5, moves: ["dragonrage"]}, //JP Event
 			{generation: 2, level: 5, shiny: 1, moves: ["splash", "bubble"]},
 			{generation: 2, level: 5, shiny: 1, moves: ["splash", "reversal"]},
 		],

--- a/data/mods/gen2/learnsets.ts
+++ b/data/mods/gen2/learnsets.ts
@@ -998,7 +998,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlwind: ["1M"],
 		},
 		eventData: [
-			{generation: 1, level: 20, moves: ["growl", "leer", "furyattack", "payday"]}, //JP Event
+			{generation: 1, level: 20, moves: ["growl", "leer", "furyattack", "payday"], japan: true},
 		],
 	},
 	ekans: {
@@ -1201,7 +1201,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 		},
 		eventData: [
 			{generation: 1, level: 5, moves: ["surf"]},
-			{generation: 1, level: 5, moves: ["fly"]}, //JP Event
+			{generation: 1, level: 5, moves: ["fly"], japan: true},
 			{generation: 1, level: 5, moves: ["thundershock", "growl", "surf"]},
 		],
 	},
@@ -4206,7 +4206,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			toxic: ["2M", "1M"],
 		},
 		eventData: [
-			{generation: 1, level: 40, moves: ["ember", "firespin", "stomp", "payday"]}, //JP Event
+			{generation: 1, level: 40, moves: ["ember", "firespin", "stomp", "payday"], japan: true},
 		],
 	},
 	slowpoke: {
@@ -7230,7 +7230,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			tackle: ["2L15", "1L15"],
 		},
 		eventData: [
-			{generation: 1, level: 5, moves: ["dragonrage"]}, //JP Event
+			{generation: 1, level: 5, moves: ["dragonrage"], japan: true},
 			{generation: 2, level: 5, shiny: 1, moves: ["splash", "bubble"]},
 			{generation: 2, level: 5, shiny: 1, moves: ["splash", "reversal"]},
 		],

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -116,6 +116,8 @@ interface EventInfo {
 	moves?: string[];
 	pokeball?: string;
 	from?: string;
+	/** Japan-only events can't be transferred to international games in Gen 1 */
+	japan?: boolean;
 }
 
 type Effect = Ability | Item | ActiveMove | Species | Condition | Format;


### PR DESCRIPTION
In reference to this, which I assume can be closed now: https://github.com/smogon/pokemon-showdown/pull/7516

Zarel asked for a PR marking the JP Events so he can take it from there? I've marked it with comments as so: "//JP Event". A simple Ctrl+F should have them pop up. 