### PR TITLE
Indicate pending promises in /eval

### DIFF
--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -924,6 +924,7 @@ export const commands: ChatCommands = {
 			if (result?.then) {
 				uhtmlId = `eval-${room.nextGameNumber()}`;
 				this.sendReply(`|uhtml|${uhtmlId}|${generateHTML('<', 'Promise pending')}`);
+				this.update();
 				result = `Promise -> ${Utils.visualize(await result)}`;
 				this.sendReply(`|uhtmlchange|${uhtmlId}|${generateHTML('<', result)}`);
 			} else {


### PR DESCRIPTION
After this change running a command like this:

```
/eval new Promise(resolve => { setTimeout(() => resolve(42), 1000) })
```

will print

```
<< Promise pending
```

before saying

```
<< Promise -> 42
```

This will make it clearer that the promise is resolving.