### PR TITLE
Don't report multiple punishments for a single room

### DIFF
--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -1576,7 +1576,10 @@ export const Punishments = new class {
 							longestIPPunishment = punishment;
 						}
 					}
-					if (longestIPPunishment) punishments.push([curRoom, longestIPPunishment]);
+					if (longestIPPunishment) {
+						punishments.push([curRoom, longestIPPunishment]);
+						continue;
+					}
 				}
 			}
 			if (checkMutes && curRoom.muteQueue) {


### PR DESCRIPTION
Got a report earlier that a user was autolocked because they had too many punishments. Specifically they were flagged for being muted and banned in a room, which pushed them over the threshold. I feel this is not something that should happen as you really are only affected by one room punishment at a time.

After some digging, I determined the best fix would be to just `continue;` after finding an IP based punishment just like with name based punishments above it. This shouldn't really affect anything negatively unless you consider `/alts` (and other punishment check commands) not reporting mutes for a given when the user is roombanned or blacklisted in that room.

PRing because I'm not sure who is managing punishments right now.