### PR TITLE
Config: Move Bot rank below Driver 

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -628,9 +628,11 @@ exports.grouplist = [
 		modchat: true,
 		hiderank: true,
 	},
-	// Bots are ranked below Driver so that they can be kept out of modjoin % rooms.
-	// This was motivated by rhe desire to promote Global Bots whose owners do not hav Staff room access.
 	{
+		// Bots are ranked below Driver/Mod so that Global Bots can be kept out
+		// of modjoin % rooms (namely, Staff).
+		// (They were previously above Driver/Mod so they can have game management
+		// permissions drivers don't, but these permissions can be manually given.)
 		symbol: '*',
 		id: "bot",
 		name: "Bot",

--- a/config/config-example.js
+++ b/config/config-example.js
@@ -586,23 +586,6 @@ exports.grouplist = [
 		joinbattle: true,
 	},
 	{
-		symbol: '*',
-		id: "bot",
-		name: "Bot",
-		inherit: '%',
-		jurisdiction: 'u',
-
-		addhtml: true,
-		tournaments: true,
-		declare: true,
-		bypassafktimer: true,
-
-		ip: false,
-		globalban: false,
-		lock: false,
-		alts: false,
-	},
-	{
 		symbol: '@',
 		id: "mod",
 		name: "Moderator",
@@ -644,6 +627,26 @@ exports.grouplist = [
 		minigame: true,
 		modchat: true,
 		hiderank: true,
+	},
+	// Bots are ranked below Driver so that they can be kept out of modjoin % rooms.
+	// This was motivated by rhe desire to promote Global Bots whose owners do not hav Staff room access.
+	{
+		symbol: '*',
+		id: "bot",
+		name: "Bot",
+		inherit: '%',
+		jurisdiction: 'u',
+
+		addhtml: true,
+		tournaments: true,
+		declare: true,
+		bypassafktimer: true,
+
+		ip: false,
+		globalban: false,
+		lock: false,
+		forcerename: false,
+		alts: false,
 	},
 	{
 		symbol: '\u2606',

--- a/config/config-example.js
+++ b/config/config-example.js
@@ -641,6 +641,7 @@ exports.grouplist = [
 		tournaments: true,
 		declare: true,
 		bypassafktimer: true,
+		gamemanagement: true,
 
 		ip: false,
 		globalban: false,


### PR DESCRIPTION
This allows users to be banned from modjoined autojoined rooms (which is useful for keeping global bots out of Staff room when some of their owners aren't global staff).