### PR TITLE
Properly update Diamond Storm boosts for Gen 7

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -3180,6 +3180,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 					if (secondary.chance) secondary.chance *= 2;
 				}
 			}
+			if (move.self?.chance) move.self.chance *= 2;
 		},
 		name: "Serene Grace",
 		rating: 3.5,
@@ -3233,6 +3234,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (move.secondaries) {
 				delete move.secondaries;
 				// Technically not a secondary effect, but it is negated
+				delete move.self;
 				if (move.id === 'clangoroussoulblaze') delete move.selfBoost;
 				// Actual negation of `AfterMoveSecondary` effects implemented in scripts.js
 				move.hasSheerForce = true;

--- a/data/mods/gen6/moves.ts
+++ b/data/mods/gen6/moves.ts
@@ -16,6 +16,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	diamondstorm: {
 		inherit: true,
+		self: null,
 		secondary: {
 			chance: 50,
 			self: {

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -3191,13 +3191,14 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: {
+		self: {
 			chance: 50,
-			self: {
-				boosts: {
-					def: 2,
-				},
+			boosts: {
+				def: 2,
 			},
+		},
+		secondary: {
+			// Sheer Force negates the self even though it is not secondary
 		},
 		target: "allAdjacentFoes",
 		type: "Rock",
@@ -18965,6 +18966,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					for (const secondary of move.secondaries) {
 						if (secondary.chance) secondary.chance *= 2;
 					}
+					if (move.self?.chance) move.self.chance *= 2;
 				}
 			},
 		},

--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -1038,11 +1038,14 @@ export const Scripts: BattleScriptsData = {
 			if (target === false) continue;
 			if (moveData.self && !move.selfDropped) {
 				if (!isSecondary && moveData.self.boosts) {
-					// This is done solely to mimic in-game RNG behaviour. All self drops have a 100% chance of happening but still grab a random number.
-					this.random(100);
+					const secondaryRoll = this.random(100);
+					if (typeof moveData.self.chance === 'undefined' || secondaryRoll < moveData.self.chance) {
+						this.moveHit(pokemon, pokemon, move, moveData.self, isSecondary, true);
+					}
 					if (!move.multihit) move.selfDropped = true;
+				} else {
+					this.moveHit(pokemon, pokemon, move, moveData.self, isSecondary, true);
 				}
-				this.moveHit(pokemon, pokemon, move, moveData.self, isSecondary, true);
 			}
 		}
 	},

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -186,7 +186,7 @@ export interface MoveData extends EffectData, MoveEventMethods, HitEffect {
 	struggleRecoil?: boolean;
 	secondary?: SecondaryEffect | null;
 	secondaries?: SecondaryEffect[] | null;
-	self?: HitEffect | null;
+	self?: SecondaryEffect | null;
 
 	// Hit effect modifiers
 	// --------------------


### PR DESCRIPTION
As researched by @DaWoblefet, Diamond Storm boosts only apply once per move, like Clangorous Soulblaze. To get this to work correctly:

- Moved boost from `secondary` to `selfBoost` except in Gen 6
- Added support for `chance` on `selfBoost`, including Serene Grace and Fire+Water Pledge combo rainbow
- Sheer Force deletes the `selfBoost` if the move also has secondaries (dummy secondary added to Diamond Storm to enable this)