### PR TITLE
Fix custap berry with gluttony

### DIFF
--- a/data/items.ts
+++ b/data/items.ts
@@ -1027,8 +1027,8 @@ export const Items: {[itemid: string]: ItemData} = {
 		onFractionalPriorityPriority: -2,
 		onFractionalPriority(priority, pokemon) {
 			if (
-				(priority <= 0 && pokemon.hp <= pokemon.maxhp / 4) ||
-				(pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony'))
+				priority <= 0 &&
+				(pokemon.hp <= pokemon.maxhp / 4 || (pokemon.hp <= pokemon.maxhp / 2 && pokemon.hasAbility('gluttony')))
 			) {
 				if (pokemon.eatItem()) {
 					this.add('-activate', pokemon, 'item: Custap Berry', '[consumed]');


### PR DESCRIPTION
Stupid error in PR #6931 where I inserted the `priority <= 0 && ` without bracketing the existing `||` conditions first (confusing someone into helpfully bracketing them the wrong way). Since the only other ways to get a positive fractional priority is either with Quick Claw (and therefore not Custap Berry) or Quick Draw (and therefore not Gluttony), this doesn't affect normal play, but some OMs might misbehave, if anyone wanted to combine these for some reason.