### PR TITLE
Fix two-turn submoves + Ally Switch in doubles

### DIFF
--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -269,7 +269,15 @@ export const Conditions: {[k: string]: ConditionData} = {
 		duration: 2,
 		onStart(target, source, effect) {
 			this.effectData.move = effect.id;
-			target.addVolatile(effect.id, source);
+			target.addVolatile(effect.id);
+			let moveTarget: Pokemon | null = source;
+			if (effect.sourceEffect && this.dex.getMove(effect.id).target === 'normal') {
+				// this move was called by another move such as metronome and needs a random target to be determined now
+				// TODO: research what should happen if one or more randomly targetable positions is empty
+				moveTarget = this.getRandomTarget(target, effect.id);
+			}
+			// (see above TODO) for now, target the user if there's no valid target right now
+			target.volatiles[effect.id].targetLoc = this.getTargetLoc(moveTarget || target, target);
 			this.attrLastMove('[still]');
 		},
 		onEnd(target) {

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -273,10 +273,10 @@ export const Conditions: {[k: string]: ConditionData} = {
 			let moveTarget: Pokemon | null = source;
 			if (effect.sourceEffect && this.dex.getMove(effect.id).target === 'normal') {
 				// this move was called by another move such as metronome and needs a random target to be determined now
-				// TODO: research what should happen if one or more randomly targetable positions is empty
+				// won't randomly choose an empty slot if there's at least one valid target
 				moveTarget = this.getRandomTarget(target, effect.id);
 			}
-			// (see above TODO) for now, target the user if there's no valid target right now
+			// if there are no valid targets, randomly choose one later
 			target.volatiles[effect.id].targetLoc = this.getTargetLoc(moveTarget || target, target);
 			this.attrLastMove('[still]');
 		},

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -445,12 +445,16 @@ export class Side {
 
 		const lockedMove = pokemon.getLockedMove();
 		if (lockedMove) {
-			const lockedMoveTarget = pokemon.lastMoveTargetLoc || 0;
+			let lockedMoveTargetLoc = pokemon.lastMoveTargetLoc || 0;
+			const lockedMoveID = toID(lockedMove);
+			if (pokemon.volatiles[lockedMoveID] && pokemon.volatiles[lockedMoveID].targetLoc) {
+				lockedMoveTargetLoc = pokemon.volatiles[lockedMoveID].targetLoc;
+			}
 			this.choice.actions.push({
 				choice: 'move',
 				pokemon,
-				targetLoc: lockedMoveTarget,
-				moveid: toID(lockedMove),
+				targetLoc: lockedMoveTargetLoc,
+				moveid: lockedMoveID,
 			});
 			return true;
 		} else if (!moves.length && !zMove) {

--- a/test/sim/misc/target-resolution.js
+++ b/test/sim/misc/target-resolution.js
@@ -199,7 +199,7 @@ describe('Target Resolution', function () {
 		});
 	});
 
-	it.skip('should not force charge moves called by another move to target an ally after Ally Switch', function () {
+	it('should not force charge moves called by another move to target an ally after Ally Switch', function () {
 		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: 'purrloin', ability: 'prankster', moves: ['copycat', 'sleeptalk']},
 			{species: 'wynaut', moves: ['allyswitch', 'solarbeam']},


### PR DESCRIPTION
Previously, two-turn moves called by another move such as Metronome would target the user’s ally if Ally Switch was used to make the user and its ally trade places on the second turn. This change makes the move correctly choose a random target on the first turn instead of the second and makes the battle engine respect that choice instead of defaulting to what the user’s previous move targeted (when the two-turn move was called by a self-targeting move, this would make the two-turn move target the user which would conveniently be interpreted as a random opponent except when the user and ally traded places).