### PR TITLE
Chatlog: Automatically determine regex engine

### DIFF
--- a/server/chat-plugins/chatlog.ts
+++ b/server/chat-plugins/chatlog.ts
@@ -654,7 +654,7 @@ export const LogSearcher = new class {
 			if (!month) break;
 			const output = await this.ripgrepSearchMonth({
 				room: roomid, search, date: month,
-				limit, args: [`-m`, `${limit}`, '-C', '3', '-P'], raw: !!userSearch,
+				limit, args: [`-m`, `${limit}`, '-C', '3', '--engine=auto'], raw: !!userSearch,
 			});
 			results = results.concat(output.results);
 			count += output.count;


### PR DESCRIPTION
This makes ripgrep use PCRE2 for searching logs only when necessary.