### PR TITLE
Helptickets: Use globalModAction for /ht ban

### DIFF
--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -1319,7 +1319,7 @@ export const commands: ChatCommands = {
 			}
 
 			const affected = HelpTicket.ban(targetUser || userid, target);
-			this.addModAction(`${username} was ticket banned by ${user.name}.${target ? ` (${target})` : ``}`);
+			this.addGlobalModAction(`${username} was ticket banned by ${user.name}.${target ? ` (${target})` : ``}`);
 			const acAccount = (targetUser && targetUser.autoconfirmed !== userid && targetUser.autoconfirmed);
 			let displayMessage = '';
 			if (affected.length > 1) {


### PR DESCRIPTION
Nitpick. addModAction means basically nothing since the room is deleted immediately.