### PR TITLE
Rooms: Don't send tour battles as subrooms by default

### DIFF
--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -1239,9 +1239,9 @@ export const commands: ChatCommands = {
 
 		if (!this.runBroadcast()) return;
 
-		const showSecret = !this.broadcasting && user.can('mute', null, room);
+		const includeSecret = !this.broadcasting && user.can('mute', null, room);
 
-		const subRooms = room.getSubRooms(showSecret);
+		const subRooms = room.getSubRooms({includeSecret, includeBattles: !this.broadcasting});
 
 		if (!subRooms.length) return this.sendReply(`This room doesn't have any subrooms.`);
 

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -684,11 +684,13 @@ export abstract class BasicRoom {
 		}
 		return message ? `|raw|${message}` : ``;
 	}
-	getSubRooms(includeSecret = false) {
+	getSubRooms(opts: {includeSecret?: boolean, includeBattles?: boolean} = {}) {
 		if (!this.subRooms) return [];
-		return [...this.subRooms.values()].filter(
-			room => !room.settings.isPrivate || includeSecret
-		);
+		return [...this.subRooms.values()].filter(room => {
+			// ignore tour battles
+			if (this.game && room.tour === this.game && !opts.includeBattles) return false;
+			return !room.settings.isPrivate || opts.includeSecret;
+		});
 	}
 	validateTitle(newTitle: string, newID?: string) {
 		if (!newID) newID = toID(newTitle);


### PR DESCRIPTION
Currently, tour battles are being sent as subrooms, which is weird on the display.
Relevant monkeypatch: 
```ts
>> Rooms.BasicRoom.prototype.getSubRooms = function(opts = {}) {
		if (!this.subRooms) return [];
		return [...this.subRooms.values()].filter(room => {
			// ignore tour battles
			if (this.game && room.tour === this.game && !opts.includeBattles) return false;
			return !room.settings.isPrivate || opts.includeSecret;
		});
	}
```