### PR TITLE
Rooms: Properly rename private battle rooms

### DIFF
--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1699,7 +1699,8 @@ export class GameRoom extends BasicRoom {
 	makePublic() {
 		this.settings.isPrivate = false;
 		if (!this.roomid.endsWith('pw')) return true;
-		this.rename(this.title, this.getReplayData().id as RoomID);
+		const {id} = this.getReplayData();
+		this.rename(this.title, `battle-${id}` as RoomID);
 	}
 }
 


### PR DESCRIPTION
This is causing the /roomban crash.
Relevant monkeypatch: 
```ts
>> Rooms.GameRoom.prototype.makePublic = function() {
		this.settings.isPrivate = false;
		if (!this.roomid.endsWith('pw')) return true;
		const {id} = this.getReplayData();
		this.rename(this.title, `battle-${id}`);
	}