### PR TITLE
Usergroups: Remove deprecated 's' permission

### DIFF
--- a/server/user-groups.ts
+++ b/server/user-groups.ts
@@ -138,18 +138,18 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 					// this checks sub commands and command objects, but it checks to see if a sub-command
 					// overrides (should a perm for the command object exist) first
 					if (!auth.atLeast(user, roomPermissions[`/${cmd}`])) return false;
-					jurisdiction = 'au';
+					jurisdiction = target ? 'u' : 'a';
 					foundSpecificPermission = true;
 				} else if (roomPermissions[`/${namespace}`]) {
 					// if it's for one command object
 					if (!auth.atLeast(user, roomPermissions[`/${namespace}`])) return false;
-					jurisdiction = 'au';
+					jurisdiction = target ? 'u' : 'a';
 					foundSpecificPermission = true;
 				}
 			}
 			if (!foundSpecificPermission && roomPermissions[permission]) {
 				if (!auth.atLeast(user, roomPermissions[permission])) return false;
-				jurisdiction = 'au';
+				jurisdiction = target ? 'u' : 'a';
 			}
 		}
 		return Auth.hasJurisdiction(symbol, jurisdiction, targetSymbol as GroupSymbol);

--- a/server/user-groups.ts
+++ b/server/user-groups.ts
@@ -138,18 +138,18 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 					// this checks sub commands and command objects, but it checks to see if a sub-command
 					// overrides (should a perm for the command object exist) first
 					if (!auth.atLeast(user, roomPermissions[`/${cmd}`])) return false;
-					jurisdiction = 'su';
+					jurisdiction = 'au';
 					foundSpecificPermission = true;
 				} else if (roomPermissions[`/${namespace}`]) {
 					// if it's for one command object
 					if (!auth.atLeast(user, roomPermissions[`/${namespace}`])) return false;
-					jurisdiction = 'su';
+					jurisdiction = 'au';
 					foundSpecificPermission = true;
 				}
 			}
 			if (!foundSpecificPermission && roomPermissions[permission]) {
 				if (!auth.atLeast(user, roomPermissions[permission])) return false;
-				jurisdiction = 'u';
+				jurisdiction = 'au';
 			}
 		}
 		return Auth.hasJurisdiction(symbol, jurisdiction, targetSymbol as GroupSymbol);

--- a/server/user-groups.ts
+++ b/server/user-groups.ts
@@ -138,7 +138,7 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 					// this checks sub commands and command objects, but it checks to see if a sub-command
 					// overrides (should a perm for the command object exist) first
 					if (!auth.atLeast(user, roomPermissions[`/${cmd}`])) return false;
-					jurisdiction = target ? 'u' : 'a';
+					jurisdiction = 'u';
 					foundSpecificPermission = true;
 				} else if (roomPermissions[`/${namespace}`]) {
 					// if it's for one command object

--- a/server/user-groups.ts
+++ b/server/user-groups.ts
@@ -149,7 +149,7 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 			}
 			if (!foundSpecificPermission && roomPermissions[permission]) {
 				if (!auth.atLeast(user, roomPermissions[permission])) return false;
-				jurisdiction = target ? 'u' : 'a';
+				jurisdiction = 'u';
 			}
 		}
 		return Auth.hasJurisdiction(symbol, jurisdiction, targetSymbol as GroupSymbol);

--- a/server/user-groups.ts
+++ b/server/user-groups.ts
@@ -143,7 +143,7 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 				} else if (roomPermissions[`/${namespace}`]) {
 					// if it's for one command object
 					if (!auth.atLeast(user, roomPermissions[`/${namespace}`])) return false;
-					jurisdiction = target ? 'u' : 'a';
+					jurisdiction = 'u';
 					foundSpecificPermission = true;
 				}
 			}


### PR DESCRIPTION
We deprecated `s`, so this was causing issues. 