### PR TITLE
 Exclude room-specific commands for other rooms in /permissions

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -43,7 +43,7 @@ export type ChatHandler = (
 	message: string
 ) => void;
 export type AnnotatedChatHandler = ChatHandler & {
-	requiresRoom: boolean,
+	requiresRoom: boolean | RoomID,
 	hasRoomPermissions: boolean,
 	broadcastable: boolean,
 	cmd: string,
@@ -1720,7 +1720,7 @@ export const Chat = new class {
 			if (typeof entry !== 'function') continue;
 
 			const handlerCode = entry.toString();
-			entry.requiresRoom = /requireRoom\((?:'|"|`)(.*?)(?:'|"|`).\)/.exec(handlerCode)?.[1] || /this\.requireRoom\(/.test(handlerCode);
+			entry.requiresRoom = /requireRoom\((?:'|"|`)(.*?)(?:'|"|`) /.exec(handlerCode)?.[1] as RoomID || /this\.requireRoom\(/.test(handlerCode);
 			entry.hasRoomPermissions = /\bthis\.(checkCan|can)\([^,)\n]*, [^,)\n]*,/.test(handlerCode);
 			entry.broadcastable = cmd.endsWith('help') || /\bthis\.(?:(check|can|run)Broadcast)\(/.test(handlerCode);
 			entry.isPrivate = /\bthis\.(?:privately(Check)?Can|commandDoesNotExist)\(/.test(handlerCode);

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -50,6 +50,7 @@ export type AnnotatedChatHandler = ChatHandler & {
 	fullCmd: string,
 	isPrivate: boolean,
 	disabled: boolean,
+	roomSpecific?: string;
 };
 export interface ChatCommands {
 	[k: string]: ChatHandler | string | string[] | ChatCommands;
@@ -1720,7 +1721,8 @@ export const Chat = new class {
 			if (typeof entry !== 'function') continue;
 
 			const handlerCode = entry.toString();
-			entry.requiresRoom = /\bthis\.requires?Room\(/.test(handlerCode);
+			entry.requiresRoom = /\bthis\.require?Room\(/.test(handlerCode);
+			entry.roomSpecific = /requireRoom\((?:'|"|`)(.*?)(?:'|"|`).\)/.exec(handlerCode)?.[1];
 			entry.hasRoomPermissions = /\bthis\.(checkCan|can)\([^,)\n]*, [^,)\n]*,/.test(handlerCode);
 			entry.broadcastable = cmd.endsWith('help') || /\bthis\.(?:(check|can|run)Broadcast)\(/.test(handlerCode);
 			entry.isPrivate = /\bthis\.(?:privately(Check)?Can|commandDoesNotExist)\(/.test(handlerCode);

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -50,7 +50,6 @@ export type AnnotatedChatHandler = ChatHandler & {
 	fullCmd: string,
 	isPrivate: boolean,
 	disabled: boolean,
-	roomSpecific?: string;
 };
 export interface ChatCommands {
 	[k: string]: ChatHandler | string | string[] | ChatCommands;
@@ -1721,8 +1720,7 @@ export const Chat = new class {
 			if (typeof entry !== 'function') continue;
 
 			const handlerCode = entry.toString();
-			entry.requiresRoom = /\bthis\.require?Room\(/.test(handlerCode);
-			entry.roomSpecific = /requireRoom\((?:'|"|`)(.*?)(?:'|"|`).\)/.exec(handlerCode)?.[1];
+			entry.requiresRoom = /requireRoom\((?:'|"|`)(.*?)(?:'|"|`).\)/.exec(handlerCode)?.[1] || /this\.requireRoom\(/.test(handlerCode);
 			entry.hasRoomPermissions = /\bthis\.(checkCan|can)\([^,)\n]*, [^,)\n]*,/.test(handlerCode);
 			entry.broadcastable = cmd.endsWith('help') || /\bthis\.(?:(check|can|run)Broadcast)\(/.test(handlerCode);
 			entry.isPrivate = /\bthis\.(?:privately(Check)?Can|commandDoesNotExist)\(/.test(handlerCode);

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1720,7 +1720,7 @@ export const Chat = new class {
 			if (typeof entry !== 'function') continue;
 
 			const handlerCode = entry.toString();
-			entry.requiresRoom = /requireRoom\((?:'|"|`)(.*?)(?:'|"|`) /.exec(handlerCode)?.[1] as RoomID || /this\.requireRoom\(/.test(handlerCode);
+			entry.requiresRoom = /requireRoom\((?:'|"|`)(.*?)(?:'|"|`)/.exec(handlerCode)?.[1] as RoomID || /this\.requireRoom\(/.test(handlerCode);
 			entry.hasRoomPermissions = /\bthis\.(checkCan|can)\([^,)\n]*, [^,)\n]*,/.test(handlerCode);
 			entry.broadcastable = cmd.endsWith('help') || /\bthis\.(?:(check|can|run)Broadcast)\(/.test(handlerCode);
 			entry.isPrivate = /\bthis\.(?:privately(Check)?Can|commandDoesNotExist)\(/.test(handlerCode);

--- a/server/user-groups.ts
+++ b/server/user-groups.ts
@@ -168,8 +168,8 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 				}
 				if (typeof entry === 'function') {
 					if (!entry.hasRoomPermissions) continue;
-					if (room && entry.roomSpecific) {
-						if (room.roomid !== entry.roomSpecific) continue;
+					if (room && typeof entry.requiresRoom === 'string') {
+						if (room.roomid !== entry.requiresRoom) continue;
 					}
 					permissions.push(`/${namespace}${cmd}`);
 				}

--- a/server/user-groups.ts
+++ b/server/user-groups.ts
@@ -159,22 +159,23 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 	}
 	static supportedRoomPermissions(room: Room | null = null) {
 		const permissions: string[] = ROOM_PERMISSIONS.slice();
-		for (const cmd in Chat.commands) {
-			const entry = Chat.commands[cmd];
-			if (typeof entry === 'string' || Array.isArray(entry)) continue;
-			if (typeof entry === 'function' && entry.hasRoomPermissions) {
-				permissions.push(`/${cmd}`);
-			}
-			if (typeof entry === 'object') {
-				permissions.push(`/${cmd}`);
-				for (const subCommand in entry) {
-					const subEntry = (entry as Chat.AnnotatedChatCommands)[subCommand];
-					if (typeof subEntry !== 'function') continue;
-					if (subEntry.hasRoomPermissions) permissions.push(`/${cmd} ${subCommand}`);
+		function checkCmdTable(table: Chat.AnnotatedChatCommands, namespace = ''): void {
+			for (const cmd in table) {
+				const entry = table[cmd];
+				if (typeof entry === 'string' || Array.isArray(entry)) continue;
+				if (typeof entry === 'object') {
+					checkCmdTable(entry as Chat.AnnotatedChatCommands, `${namespace}${cmd} `);
 				}
-				continue;
+				if (typeof entry === 'function') {
+					if (!entry.hasRoomPermissions) continue;
+					if (room && entry.roomSpecific) {
+						if (room.roomid !== entry.roomSpecific) continue;
+					}
+					permissions.push(`/${namespace}${cmd}`);
+				}
 			}
 		}
+		checkCmdTable(Chat.commands);
 		return permissions;
 	}
 	static hasJurisdiction(


### PR DESCRIPTION
Does what it says on the tin. This is much easier now with `this.requireRoom(roomid)`.