### PR TITLE
Fix Gen 1 Psywave mechanics

### DIFF
--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -606,9 +606,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			if (psywaveDamage <= 0) {
 				this.hint("Desync Clause activated.");
 				return false;
-			} else {
-				return psywaveDamage;
 			}
+			return psywaveDamage;
 		},
 	},
 	rage: {

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -602,12 +602,12 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		basePower: 1,
 		damageCallback(pokemon) {
-			let psywaveDamage = (this.random(0, (1.5 * pokemon.level)))
+			const psywaveDamage = (this.random(0, (1.5 * pokemon.level)));
 			if (psywaveDamage <= 0) {
 				this.hint("Desync Clause activated.");
 				return false;
-			} else { 
-				return psywaveDamage
+			} else {
+				return psywaveDamage;
 			}
 		},
 	},

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -602,7 +602,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		basePower: 1,
 		damageCallback(pokemon) {
-			const psywaveDamage = (this.random(0, (1.5 * pokemon.level)));
+			const psywaveDamage = (this.random(0, this.trunc(1.5 * pokemon.level)));
 			if (psywaveDamage <= 0) {
 				this.hint("Desync Clause activated.");
 				return false;

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -601,6 +601,15 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	psywave: {
 		inherit: true,
 		basePower: 1,
+		damageCallback(pokemon) {
+			let psywaveDamage = (this.random(0, (1.5 * pokemon.level)))
+			if (psywaveDamage <= 0) {
+				this.hint("Desync Clause activated.");
+				return false;
+			} else { 
+				return psywaveDamage
+			}
+		},
 	},
 	rage: {
 		inherit: true,

--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -55,6 +55,13 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 		},
 	},
+	psywave: {
+		inherit: true,
+		basePower: 1,
+		damageCallback(pokemon) {
+			return (this.random(1, (1.5 * pokemon.level)));
+		},
+	},
 	rage: {
 		inherit: true,
 		self: {

--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -59,7 +59,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		basePower: 1,
 		damageCallback(pokemon) {
-			return (this.random(1, (1.5 * pokemon.level)));
+			return this.random(1, this.trunc(1.5 * pokemon.level));
 		},
 	},
 	rage: {


### PR DESCRIPTION
This implements the Psywave Desync Patch from the tiering decision found [here](https://www.smogon.com/forums/threads/rby-psywave-imperfect-dvs-and-thawing-desync-glitches.3668900/)
For details on how the desync works, go [here](https://www.youtube.com/watch?v=5KmTCdnWzVI)

[Here is a replay from the RBY 2k20 PS Server showing the implementation in action.](https://replay.pokemonshowdown.com/rby-gen1customgame-897)

I'm by no means a _good_ programmer, nor do I consider myself one, so I think my code may be a bit suboptimal. 