### PR TITLE
Fix Gastrodon-East in Challenge Cup

### DIFF
--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -161,7 +161,7 @@ export class RandomTeams {
 					return !(move.isNonstandard || move.isZ || move.isMax || move.realMove);
 				});
 			} else {
-				let learnset = this.dex.data.Learnsets[species.id] && this.dex.data.Learnsets[species.id].learnset && !['pumpkaboosuper', 'zygarde10'].includes(species.id) ?
+				let learnset = this.dex.data.Learnsets[species.id] && this.dex.data.Learnsets[species.id].learnset && !['gastrodoneast', 'pumpkaboosuper', 'zygarde10'].includes(species.id) ?
 					this.dex.data.Learnsets[species.id].learnset :
 					this.dex.data.Learnsets[this.dex.getSpecies(species.baseSpecies).id].learnset;
 				if (learnset) {


### PR DESCRIPTION
Unfortunately my crash log doesn't actually include the seed used to generate the invalid team for some reason, and the battle had already expired so I couldn't check it directly, so I can't test this...