### PR TITLE
Tests: add a function to save a replay of a battle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !/config/formats.ts
 /logs/*
 /test/modlogs
+/test/replays/*.html
 /node_modules
 /eslint-cache
 /server/chat-plugins/private

--- a/test/common.js
+++ b/test/common.js
@@ -108,9 +108,10 @@ class TestTools {
 
 	/**
 	 * Saves the log of the given battle as a bare-bones replay file in the `test\replays` directory
-	 * To view the replay, simply drag and drop the file into a PS! client window
+	 * You can view the replay by opening the file in any browser or by dragging and dropping the
+	 * file into a PS! client window.
 	 *
-	 * @param {Sim.Battle} [battle]
+	 * @param {Sim.Battle} battle
 	 * @param {string} [fileName]
 	 */
 	saveReplay(battle, fileName) {
@@ -119,7 +120,17 @@ class TestTools {
 		const filePath = path.resolve(__dirname, `./replays/${fileName}-${Date.now()}.html`);
 		const out = fs.createWriteStream(filePath, {flags: 'a'});
 		out.on('open', () => {
-			out.write(`<script type="text/plain" class="log">${battleLog}</script>`);
+			out.write(`<!DOCTYPE html>
+			<meta charset="utf-8" />
+			<!-- version 1 -->
+			
+			<div class="wrapper replay-wrapper" style="max-width:1180px;margin:0 auto">
+			<div class="battle"></div><div class="battle-log"></div><div class="replay-controls"></div><div class="replay-controls-2"></div>
+			<script type="text/plain" class="battle-log-data">${battleLog}</script>
+			</div>
+			<script>
+			let daily = Math.floor(Date.now()/1000/60/60/24);document.write('<script src="https://play.pokemonshowdown.com/js/replay-embed.js?version'+daily+'"></'+'script>');
+			</script>`);
 			out.end();
 		});
 	}

--- a/test/common.js
+++ b/test/common.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const path = require('path');
+const fs = require('fs');
 const assert = require('./assert');
 const Sim = require('./../.sim-dist');
 const Dex = Sim.Dex;
@@ -102,6 +104,24 @@ class TestTools {
 		}
 
 		return new Sim.Battle(battleOptions);
+	}
+
+	/**
+	 * Saves the log of the given battle as a bare-bones replay file in the `test\replays` directory
+	 * To view the replay, simply drag and drop the file into a PS! client window
+	 *
+	 * @param {Sim.Battle} [battle]
+	 * @param {string} [fileName]
+	 */
+	saveReplay(battle, fileName) {
+		const battleLog = battle.getDebugLog();
+		if (!fileName) fileName = 'test-replay';
+		const filePath = path.resolve(__dirname, `./replays/${fileName}-${Date.now()}.html`);
+		const out = fs.createWriteStream(filePath, {flags: 'a'});
+		out.on('open', () => {
+			out.write(`<script type="text/plain" class="log">${battleLog}</script>`);
+			out.end();
+		});
 	}
 }
 

--- a/test/common.js
+++ b/test/common.js
@@ -120,17 +120,11 @@ class TestTools {
 		const filePath = path.resolve(__dirname, `./replays/${fileName}-${Date.now()}.html`);
 		const out = fs.createWriteStream(filePath, {flags: 'a'});
 		out.on('open', () => {
-			out.write(`<!DOCTYPE html>
-			<meta charset="utf-8" />
-			<!-- version 1 -->
-			
-			<div class="wrapper replay-wrapper" style="max-width:1180px;margin:0 auto">
-			<div class="battle"></div><div class="battle-log"></div><div class="replay-controls"></div><div class="replay-controls-2"></div>
-			<script type="text/plain" class="battle-log-data">${battleLog}</script>
-			</div>
-			<script>
-			let daily = Math.floor(Date.now()/1000/60/60/24);document.write('<script src="https://play.pokemonshowdown.com/js/replay-embed.js?version'+daily+'"></'+'script>');
-			</script>`);
+			out.write(
+				`<!DOCTYPE html>\n` +
+				`<script type="text/plain" class="battle-log-data">${battleLog}</script>\n` +
+				`<script src="https://play.pokemonshowdown.com/js/replay-embed.js"></script>\n`
+			);
 			out.end();
 		});
 	}

--- a/test/replays/README.md
+++ b/test/replays/README.md
@@ -1,0 +1,1 @@
+Replays of battles created by tests are stored in this directory via the `common.saveReplay` function.


### PR DESCRIPTION
The intended use for this is to add a `common.saveReplay(battle);` line to tests you want to watch back in the client so you can see why a given assertion might be failing. I don't know enough about the testing suite to figure out how to make it automatically clear out the `replays` folder when `npm test` gets run, but I don't think that's entirely necessary anyway since one might want to compare two replays from different versions of the code.

Now that I think about it, it might be worth automatically storing replays for every applicable test and replacing them all when `npm test` is run to potentially detect regressions by checking for battle logs that have changed even though their assertions all pass. I don't know how to do that either, though.