### PR TITLE
Update Gen 2/Gen 8 Doubles Random Battle

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -5578,7 +5578,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 	eldegoss: {
 		randomBattleMoves: ["charm", "energyball", "leechseed", "pollenpuff", "rapidspin", "sleeppowder"],
 		randomBattleLevel: 86,
-		randomDoubleBattleMoves: ["energyball", "helpinghand", "leechseed", "pollenpuff", "protect", "sleeppowder", "synthesis"],
+		randomDoubleBattleMoves: ["charm", "energyball", "helpinghand", "pollenpuff", "protect", "sleeppowder"],
 		randomDoubleBattleLevel: 90,
 		tier: "NU",
 		doublesTier: "DUU",

--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -6009,7 +6009,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 	zamazentacrowned: {
 		randomBattleMoves: ["behemothbash", "closecombat", "crunch", "psychicfangs"],
 		randomBattleLevel: 74,
-		randomDoubleBattleMoves: ["behemothbash", "closecombat", "coaching", "crunch", "protect", "psychicfangs"],
+		randomDoubleBattleMoves: ["behemothbash", "closecombat", "crunch", "howl", "protect", "psychicfangs"],
 		randomDoubleBattleLevel: 72,
 		tier: "Uber",
 		doublesTier: "DUber",

--- a/data/mods/gen2/formats-data.ts
+++ b/data/mods/gen2/formats-data.ts
@@ -781,7 +781,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NU",
 	},
 	heracross: {
-		randomBattleMoves: ["curse", "earthquake", "hiddenpowerfighting", "megahorn", "rest", "sleeptalk"],
+		randomBattleMoves: ["curse", "earthquake", "megahorn", "rest", "seismictoss", "sleeptalk"],
 		tier: "OU",
 	},
 	sneasel: {

--- a/data/mods/gen2/formats-data.ts
+++ b/data/mods/gen2/formats-data.ts
@@ -194,7 +194,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	persian: {
-		randomBattleMoves: ["bodyslam", "hypnosis", "icebeam", "irontail", "rest", "return", "thunder"],
+		randomBattleMoves: ["bodyslam", "hypnosis", "irontail", "rest", "return", "thunder"],
 		tier: "NU",
 	},
 	psyduck: {
@@ -312,7 +312,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	dodrio: {
-		randomBattleMoves: ["doubleedge", "drillpeck", "hiddenpowerground", "quickattack", "substitute"],
+		randomBattleMoves: ["doubleedge", "drillpeck", "hiddenpowerground", "rest", "substitute"],
 		tier: "UU",
 	},
 	seel: {
@@ -536,7 +536,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "UUBL",
 	},
 	umbreon: {
-		randomBattleMoves: ["batonpass", "growth", "hiddenpowerdark", "meanlook", "moonlight", "toxic"],
+		randomBattleMoves: ["batonpass", "growth", "hiddenpowerdark", "meanlook", "moonlight"],
 		tier: "OU",
 	},
 	porygon: {
@@ -781,7 +781,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NU",
 	},
 	heracross: {
-		randomBattleMoves: ["curse", "earthquake", "megahorn", "rest", "seismictoss", "sleeptalk"],
+		randomBattleMoves: ["curse", "earthquake", "hiddenpowerfighting", "megahorn", "rest", "sleeptalk"],
 		tier: "OU",
 	},
 	sneasel: {

--- a/data/mods/gen2/random-teams.ts
+++ b/data/mods/gen2/random-teams.ts
@@ -182,7 +182,7 @@ export class RandomGen2Teams extends RandomGen3Teams {
 					rejected = true;
 				}
 
-				if ((!rejected && !isSetup && (move.category !== 'Status' || !move.flags.heal) && (counter.setupType || !move.stallingMove) && !['batonpass', 'rest', 'sleeptalk', 'spikes'].includes(moveid)) &&
+				if ((!rejected && !isSetup && (move.category !== 'Status' || !move.flags.heal) && (counter.setupType || !move.stallingMove) && !['batonpass', 'sleeptalk', 'spikes'].includes(moveid)) &&
 				(
 					// Pokemon should have moves that benefit their attributes
 					(!counter['stab'] && !counter['damage'] && !hasType['Ghost'] && counter['physicalpool'] + counter['specialpool'] > 0) ||

--- a/data/mods/gen2/random-teams.ts
+++ b/data/mods/gen2/random-teams.ts
@@ -74,12 +74,16 @@ export class RandomGen2Teams extends RandomGen3Teams {
 				case 'bellydrum': case 'curse': case 'meditate': case 'screech': case 'swordsdance':
 					if (counter.setupType !== 'Physical' || counter['physicalsetup'] > 1) rejected = true;
 					if (!counter['Physical'] || counter.damagingMoves.length < 2 && !hasMove['batonpass'] && !hasMove['sleeptalk']) rejected = true;
+					if (moveid === 'curse' && hasMove['icebeam'] && hasMove['sleeptalk']) rejected = true; // this fix is jank but i want resttalk piloswine to get stabs
 					isSetup = true;
 					break;
 
 				// Not very useful without their supporting moves
 				case 'batonpass':
 					if (!counter.setupType && !counter['speedsetup'] && !hasMove['meanlook']) rejected = true;
+					break;
+				case 'meanlook':
+					if (movePool.includes('perishsong')) rejected = true;
 					break;
 				case 'nightmare':
 					if (!hasMove['lovelykiss'] && !hasMove['sleeppowder']) rejected = true;
@@ -113,10 +117,10 @@ export class RandomGen2Teams extends RandomGen3Teams {
 					if (hasMove['rockslide']) rejected = true;
 					break;
 				case 'quickattack': case 'selfdestruct':
-					if (hasMove['rest']) rejected = true;
+					if (hasMove['rest'] || hasMove['sleeptalk']) rejected = true;
 					break;
 				case 'rapidspin':
-					if (teamDetails['rapidSpin'] || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (teamDetails['rapidSpin'] || hasMove['sleeptalk']) rejected = true;
 					break;
 				case 'return':
 					if (hasMove['bodyslam']) rejected = true;
@@ -132,6 +136,9 @@ export class RandomGen2Teams extends RandomGen3Teams {
 					break;
 				case 'icebeam':
 					if (hasMove['dragonbreath']) rejected = true;
+					break;
+				case 'hiddenpowerfighting':
+					if (hasMove['sleeptalk']) rejected = true;
 					break;
 				case 'destinybond':
 					if (hasMove['explosion']) rejected = true;
@@ -175,7 +182,7 @@ export class RandomGen2Teams extends RandomGen3Teams {
 					rejected = true;
 				}
 
-				if ((!rejected && !isSetup && !move.weather && (move.category !== 'Status' || !move.flags.heal) && (counter.setupType || !move.stallingMove) && !['batonpass', 'sleeptalk', 'spikes'].includes(moveid)) &&
+				if ((!rejected && !isSetup && (move.category !== 'Status' || !move.flags.heal) && (counter.setupType || !move.stallingMove) && !['batonpass', 'rest', 'sleeptalk', 'spikes'].includes(moveid)) &&
 				(
 					// Pokemon should have moves that benefit their attributes
 					(!counter['stab'] && !counter['damage'] && !hasType['Ghost'] && counter['physicalpool'] + counter['specialpool'] > 0) ||
@@ -190,7 +197,7 @@ export class RandomGen2Teams extends RandomGen3Teams {
 					(movePool.includes('megahorn') || hasMove['present'] && movePool.includes('softboiled')) ||
 					(hasMove['rest'] && movePool.includes('sleeptalk') || (hasMove['sleeptalk'] && movePool.includes('rest'))) ||
 					(hasMove['sunnyday'] && movePool.includes('solarbeam') || (hasMove['solarbeam'] && movePool.includes('sunnyday'))) ||
-					(movePool.includes('meanlook') || movePool.includes('milkdrink') || movePool.includes('recover') || movePool.includes('spore'))
+					(movePool.includes('milkdrink') || movePool.includes('recover') || movePool.includes('spore'))
 				)) {
 					// Reject Status, non-STAB, or low basepower moves
 					if (move.category === 'Status' || !hasType[move.type] || move.basePower && move.basePower < 40) {

--- a/data/mods/gen2/random-teams.ts
+++ b/data/mods/gen2/random-teams.ts
@@ -74,7 +74,7 @@ export class RandomGen2Teams extends RandomGen3Teams {
 				case 'bellydrum': case 'curse': case 'meditate': case 'screech': case 'swordsdance':
 					if (counter.setupType !== 'Physical' || counter['physicalsetup'] > 1) rejected = true;
 					if (!counter['Physical'] || counter.damagingMoves.length < 2 && !hasMove['batonpass'] && !hasMove['sleeptalk']) rejected = true;
-					if (moveid === 'curse' && hasMove['icebeam'] && hasMove['sleeptalk']) rejected = true; // this fix is jank but i want resttalk piloswine to get stabs
+					if (moveid === 'curse' && hasMove['icebeam'] && hasMove['sleeptalk']) rejected = true;
 					isSetup = true;
 					break;
 
@@ -137,8 +137,8 @@ export class RandomGen2Teams extends RandomGen3Teams {
 				case 'icebeam':
 					if (hasMove['dragonbreath']) rejected = true;
 					break;
-				case 'hiddenpowerfighting':
-					if (hasMove['sleeptalk']) rejected = true;
+				case 'seismictoss':
+					if (hasMove['rest'] || hasMove['sleeptalk']) rejected = true;
 					break;
 				case 'destinybond':
 					if (hasMove['explosion']) rejected = true;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -982,7 +982,8 @@ export class RandomTeams {
 					break;
 				case 'substitute':
 					if (hasMove['facade'] || hasMove['rest'] || hasMove['uturn']) rejected = true;
-					if (movePool.includes('bulkup') || movePool.includes('painsplit') || (isDoubles && movePool.includes('powerwhip')) || movePool.includes('roost') || movePool.includes('calmmind') && !counter['recovery']) rejected = true;
+					if (movePool.includes('bulkup') || movePool.includes('painsplit') || movePool.includes('roost') || movePool.includes('calmmind') && !counter['recovery']) rejected = true;
+					if (isDoubles && movePool.includes('powerwhip')) rejected = true;
 					break;
 				case 'helpinghand':
 					if (hasMove['acupressure']) rejected = true;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1089,7 +1089,7 @@ export class RandomTeams {
 				} else if (ability === 'Analytic') {
 					rejectAbility = (hasMove['rapidspin'] || species.nfe || isDoubles);
 				} else if (ability === 'Blaze') {
-					rejectAbility = (isDoubles && hasAbility['Solar Power']); // I'd rather not code this as a forced ability, so it's in the rejections section. Hope you don't mind.
+					rejectAbility = (isDoubles && hasAbility['Solar Power']);
 				} else if (ability === 'Bulletproof' || ability === 'Overcoat') {
 					rejectAbility = (counter.setupType && hasAbility['Soundproof']);
 				} else if (ability === 'Chlorophyll') {

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -982,7 +982,7 @@ export class RandomTeams {
 					break;
 				case 'substitute':
 					if (hasMove['facade'] || hasMove['rest'] || hasMove['uturn']) rejected = true;
-					if (movePool.includes('bulkup') || movePool.includes('painsplit') || movePool.includes('roost') || movePool.includes('calmmind') && !counter['recovery']) rejected = true;
+					if (movePool.includes('bulkup') || movePool.includes('painsplit') || (isDoubles && movePool.includes('powerwhip')) || movePool.includes('roost') || movePool.includes('calmmind') && !counter['recovery']) rejected = true;
 					break;
 				case 'helpinghand':
 					if (hasMove['acupressure']) rejected = true;
@@ -1088,6 +1088,8 @@ export class RandomTeams {
 					rejectAbility = !counter[toID(ability)];
 				} else if (ability === 'Analytic') {
 					rejectAbility = (hasMove['rapidspin'] || species.nfe || isDoubles);
+				} else if (ability === 'Blaze') {
+					rejectAbility = (isDoubles && hasAbility['Solar Power']); // I'd rather not code this as a forced ability, so it's in the rejections section. Hope you don't mind.
 				} else if (ability === 'Bulletproof' || ability === 'Overcoat') {
 					rejectAbility = (counter.setupType && hasAbility['Soundproof']);
 				} else if (ability === 'Chlorophyll') {
@@ -1332,7 +1334,7 @@ export class RandomTeams {
 		} else if (isDoubles && counter.damagingMoves.length >= 3 && species.baseStats.spe >= 60 && ability !== 'Multiscale' && ability !== 'Sturdy' && !hasMove['acidspray'] && !hasMove['clearsmog'] && !hasMove['electroweb'] &&
 			!hasMove['fakeout'] && !hasMove['feint'] && !hasMove['icywind'] && !hasMove['incinerate'] && !hasMove['naturesmadness'] && !hasMove['rapidspin'] && !hasMove['snarl'] && !hasMove['uturn']
 		) {
-			item = (species.baseStats.hp + species.baseStats.def + species.baseStats.spd >= 275) ? 'Sitrus Berry' : 'Life Orb';
+			item = (ability === 'Defeatist' || species.baseStats.hp + species.baseStats.def + species.baseStats.spd >= 275) ? 'Sitrus Berry' : 'Life Orb';
 
 		// Medium priority
 		} else if (counter.Physical >= 4 && ability !== 'Serene Grace' && !hasMove['fakeout'] && !hasMove['flamecharge'] && !hasMove['rapidspin'] && (!hasMove['tailslap'] || hasMove['uturn']) && !isDoubles) {


### PR DESCRIPTION
Gen 2: 
fix various Pokemon getting mono-sleep talk due to various reasons (Curse line is meant to allow both curse resttalk piloswine and resttalk STABs piloswine while fixing mono-sleeptalk)
fix ice beam persian (illegal)
remove quick attack from dodrio to force stabs
improve Umbreon and Misdreavus's sets

Doubles:
Fix mono-poltergeist Gourgeist and Gourgeist-Small
Howl Zamazenta-Crowned over Coaching
Charm Eldegoss
Fix Life Orb Archeops
Remove Blaze Charizard

TI, can you check this one out:
Swords Dance keeps getting rejected on Gen 2 Seaking and Beedrill. This makes Sub+Agility exist. This shouldn't exist. Tried a few ways to fix it. Didn't work.