### PR TITLE
Rename "Desync Clause" to "Desync Clause Mod"

### DIFF
--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -604,7 +604,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		damageCallback(pokemon) {
 			const psywaveDamage = (this.random(0, this.trunc(1.5 * pokemon.level)));
 			if (psywaveDamage <= 0) {
-				this.hint("Desync Clause Mod activated.");
+				this.hint("Desync Clause Mod activated!");
 				return false;
 			}
 			return psywaveDamage;

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -604,7 +604,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		damageCallback(pokemon) {
 			const psywaveDamage = (this.random(0, this.trunc(1.5 * pokemon.level)));
 			if (psywaveDamage <= 0) {
-				this.hint("Desync Clause activated.");
+				this.hint("Desync Clause Mod activated.");
 				return false;
 			}
 			return psywaveDamage;


### PR DESCRIPTION
This was a minor mistake when I was writing this thing up. Since Desync Clause isn't something you replicate in RBY, it is more accurate to describe it as a Mod, in line with the ADV Switch Priority Clause Mod.