### PR TITLE
Throw unrelated errors caught in runPromote

### DIFF
--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -189,7 +189,9 @@ export const commands: ChatCommands = {
 			try {
 				shouldPopup = runPromote(user, room, userid, nextSymbol, toPromote, force);
 			} catch (err) {
-				if (err.name?.endsWith('ErrorMessage')) this.errorReply(err.message);
+				// Throw actual crashes, but don't throw chat ErrorMessages
+				if (!err.name?.endsWith('ErrorMessage')) throw err;
+				this.errorReply(err.message);
 				continue;
 			}
 			const targetUser = Users.getExact(userid);

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -189,10 +189,11 @@ export const commands: ChatCommands = {
 			try {
 				shouldPopup = runPromote(user, room, userid, nextSymbol, toPromote, force);
 			} catch (err) {
-				// Throw actual crashes, but don't throw chat ErrorMessages
-				if (!err.name?.endsWith('ErrorMessage')) throw err;
-				this.errorReply(err.message);
-				continue;
+				if (err.name?.endsWith('ErrorMessage')) {
+					this.errorReply(err.message);
+					continue;
+				}
+				throw err;
 			}
 			const targetUser = Users.getExact(userid);
 			const name = targetUser?.name || toPromote;


### PR DESCRIPTION
We shouldn't be suppressing errors caught here that are really errors. Caused an obscure bug this morning that I had to hunt down.