### PR TITLE
Runners: support 4P (and max games for exhaustive)

### DIFF
--- a/sim/tools/exhaustive-runner.ts
+++ b/sim/tools/exhaustive-runner.ts
@@ -81,12 +81,15 @@ export class ExhaustiveRunner {
 		do {
 			this.games++;
 			try {
+				const is4P = dex.getFormat(this.format).gameType === 'multi';
 				// We run these sequentially instead of async so that the team generator
 				// and the AI can coordinate usage properly.
 				await new Runner({
 					prng: this.prng,
 					p1options: {team: generator.generate(), createAI},
 					p2options: {team: generator.generate(), createAI},
+					p3options: is4P ? {team: generator.generate(), createAI} : undefined,
+					p4options: is4P ? {team: generator.generate(), createAI} : undefined,
 					format: this.format,
 					dual: this.dual,
 					error: true,

--- a/sim/tools/runner.ts
+++ b/sim/tools/runner.ts
@@ -28,6 +28,8 @@ export interface RunnerOptions {
 	prng?: PRNG | PRNGSeed | null;
 	p1options?: AIOptions;
 	p2options?: AIOptions;
+	p3options?: AIOptions;
+	p4options?: AIOptions;
 	input?: boolean;
 	output?: boolean;
 	error?: boolean;
@@ -44,6 +46,8 @@ export class Runner {
 	private readonly prng: PRNG;
 	private readonly p1options: AIOptions;
 	private readonly p2options: AIOptions;
+	private readonly p3options: AIOptions;
+	private readonly p4options: AIOptions;
 	private readonly format: string;
 	private readonly input: boolean;
 	private readonly output: boolean;
@@ -57,6 +61,8 @@ export class Runner {
 			options.prng : new PRNG(options.prng);
 		this.p1options = {...Runner.AI_OPTIONS, ...options.p1options};
 		this.p2options = {...Runner.AI_OPTIONS, ...options.p2options};
+		this.p3options = {...Runner.AI_OPTIONS, ...options.p3options};
+		this.p4options = {...Runner.AI_OPTIONS, ...options.p4options};
 
 		this.input = !!options.input;
 		this.output = !!options.output;
@@ -80,8 +86,14 @@ export class Runner {
 		// @ts-ignore - DualStream implements everything relevant from BattleStream.
 		const streams = BattleStreams.getPlayerStreams(battleStream);
 		const spec = {formatid: format, seed: this.prng.seed};
+		const is4P = Dex.getFormat(format).gameType === 'multi';
 		const p1spec = this.getPlayerSpec("Bot 1", this.p1options);
 		const p2spec = this.getPlayerSpec("Bot 2", this.p2options);
+		let p3spec: typeof p1spec, p4spec: typeof p1spec;
+		if (is4P) {
+			p3spec = this.getPlayerSpec("Bot 3", this.p3options);
+			p4spec = this.getPlayerSpec("Bot 4", this.p4options);
+		}
 
 		const p1 = this.p1options.createAI(
 			streams.p1, {seed: this.newSeed(), ...this.p1options}
@@ -89,14 +101,33 @@ export class Runner {
 		const p2 = this.p2options.createAI(
 			streams.p2, {seed: this.newSeed(), ...this.p2options}
 		);
+		let p3: RandomPlayerAI, p4: RandomPlayerAI;
+		if (is4P) {
+			p3 = this.p4options.createAI(
+				streams.p3, {seed: this.newSeed(), ...this.p3options}
+			);
+			p4 = this.p4options.createAI(
+				streams.p4, {seed: this.newSeed(), ...this.p4options}
+			);
+		}
 		// TODO: Use `await Promise.race([streams.omniscient.read(), p1, p2])` to avoid
 		// leaving these promises dangling once it no longer causes memory leaks (v8#9069).
 		void p1.start();
 		void p2.start();
+		if (is4P) {
+			void p3!.start();
+			void p4!.start();
+		}
 
-		void streams.omniscient.write(`>start ${JSON.stringify(spec)}\n` +
-			`>player p1 ${JSON.stringify(p1spec)}\n` +
-			`>player p2 ${JSON.stringify(p2spec)}`);
+		let initMessage = `>start ${JSON.stringify(spec)}\n` +
+		`>player p1 ${JSON.stringify(p1spec)}\n` +
+		`>player p2 ${JSON.stringify(p2spec)}`;
+		if (is4P) {
+			initMessage += `\n` +
+			`>player p3 ${JSON.stringify(p3spec!)}\n` +
+			`>player p4 ${JSON.stringify(p4spec!)}`;
+		}
+		void streams.omniscient.write(initMessage);
 
 		for await (const chunk of streams.omniscient) {
 			if (this.output) console.log(chunk);

--- a/tools/simulate/index.js
+++ b/tools/simulate/index.js
@@ -133,12 +133,13 @@ case 'exhaustive':
 		}
 		const maxFailures = argv.maxFailures || argv.failures || (formats.length > 1 ? ExhaustiveRunner.MAX_FAILURES : 1);
 		const prng = argv.seed && argv.seed.split(',').map(s => Number(s));
+		const maxGames = argv.maxGames || argv.games;
 		(async () => {
 			let failures = 0;
 			do {
 				for (const format of formats) {
 					failures += await new ExhaustiveRunner({
-						format, cycles, prng, maxFailures, log: true, dual: argv.dual,
+						format, cycles, prng, maxFailures, log: true, dual: argv.dual, maxGames,
 					}).run();
 					process.stdout.write('\n');
 					if (failures >= maxFailures) break;


### PR DESCRIPTION
Ran 10000 games of [Gen 8] Multi Hackmons Cup at 6 Pokemon per player (24 pokemon per battle) on the latest version of the server-side multi battle branch, and got 0 crashes.
`[gen8multihackmonscup] P:0 (11/761) I:203 (4/357) A:285 (3/267) M:106 (1/664) = 10000`
Then again, apparently it wasn't actually an exhaustive test because 11 species of Pokemon never got used at all, even though it should have used somewhere between 120,000 and 240,000 individual Pokemon. I can guess those 11 aren't terribly important, though, if they can't appear even in Hackmons Cup.