### PR TITLE
Gen 1: Announce Desync Clause Mod, fix Stadium Sleep Clause

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2924,7 +2924,7 @@ export const Formats: FormatList = [
 
 		mod: 'stadium',
 		searchShow: false,
-		ruleset: ['Standard', '!Desync Clause Mod', 'Team Preview', '!Sleep Clause Mod', 'Stadium Sleep Clause'],
+		ruleset: ['Standard', 'Team Preview'],
 		banlist: ['Uber',
 			'Nidoking + Fury Attack + Thrash', 'Exeggutor + Poison Powder + Stomp', 'Exeggutor + Sleep Powder + Stomp',
 			'Exeggutor + Stun Spore + Stomp', 'Jolteon + Focus Energy + Thunder Shock', 'Flareon + Focus Energy + Ember',

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1612,7 +1612,7 @@ export const Formats: FormatList = [
 		team: 'randomCC',
 		searchShow: false,
 		challengeShow: false,
-		ruleset: ['Obtainable', 'Desync Clause Mod', 'HP Percentage Mod', 'Cancel Mod'],
+		ruleset: ['Obtainable', 'HP Percentage Mod', 'Cancel Mod', 'Desync Clause Mod'],
 	},
 
 	// RoA Spotlight
@@ -2913,7 +2913,7 @@ export const Formats: FormatList = [
 
 		mod: 'gen1',
 		searchShow: false,
-		ruleset: ['Obtainable', 'Desync Clause Mod', 'Allow Tradeback', 'Sleep Clause Mod', 'Freeze Clause Mod', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause', 'HP Percentage Mod', 'Cancel Mod'],
+		ruleset: ['Obtainable', 'Allow Tradeback', 'Sleep Clause Mod', 'Freeze Clause Mod', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause', 'HP Percentage Mod', 'Cancel Mod', 'Desync Clause Mod'],
 		banlist: ['Uber',
 			'Nidoking + Fury Attack + Thrash', 'Exeggutor + Poison Powder + Stomp', 'Exeggutor + Sleep Powder + Stomp',
 			'Exeggutor + Stun Spore + Stomp', 'Jolteon + Focus Energy + Thunder Shock', 'Flareon + Focus Energy + Ember',
@@ -2943,6 +2943,6 @@ export const Formats: FormatList = [
 			validate: [1, 24],
 			battle: 24,
 		},
-		ruleset: ['Desync Clause Mod', 'HP Percentage Mod', 'Cancel Mod'],
+		ruleset: ['HP Percentage Mod', 'Cancel Mod', 'Desync Clause Mod'],
 	},
 ];

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1612,7 +1612,7 @@ export const Formats: FormatList = [
 		team: 'randomCC',
 		searchShow: false,
 		challengeShow: false,
-		ruleset: ['Obtainable', 'HP Percentage Mod', 'Cancel Mod'],
+		ruleset: ['Obtainable', 'Desync Clause Mod', 'HP Percentage Mod', 'Cancel Mod'],
 	},
 
 	// RoA Spotlight
@@ -2913,7 +2913,7 @@ export const Formats: FormatList = [
 
 		mod: 'gen1',
 		searchShow: false,
-		ruleset: ['Obtainable', 'Allow Tradeback', 'Sleep Clause Mod', 'Freeze Clause Mod', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause', 'HP Percentage Mod', 'Cancel Mod'],
+		ruleset: ['Obtainable', 'Desync Clause Mod', 'Allow Tradeback', 'Sleep Clause Mod', 'Freeze Clause Mod', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause', 'HP Percentage Mod', 'Cancel Mod'],
 		banlist: ['Uber',
 			'Nidoking + Fury Attack + Thrash', 'Exeggutor + Poison Powder + Stomp', 'Exeggutor + Sleep Powder + Stomp',
 			'Exeggutor + Stun Spore + Stomp', 'Jolteon + Focus Energy + Thunder Shock', 'Flareon + Focus Energy + Ember',
@@ -2924,7 +2924,7 @@ export const Formats: FormatList = [
 
 		mod: 'stadium',
 		searchShow: false,
-		ruleset: ['Standard', 'Team Preview', '!Sleep Clause Mod', 'Stadium Sleep Clause'],
+		ruleset: ['Standard', '!Desync Clause Mod', 'Team Preview', '!Sleep Clause Mod', 'Stadium Sleep Clause'],
 		banlist: ['Uber',
 			'Nidoking + Fury Attack + Thrash', 'Exeggutor + Poison Powder + Stomp', 'Exeggutor + Sleep Powder + Stomp',
 			'Exeggutor + Stun Spore + Stomp', 'Jolteon + Focus Energy + Thunder Shock', 'Flareon + Focus Energy + Ember',
@@ -2943,6 +2943,6 @@ export const Formats: FormatList = [
 			validate: [1, 24],
 			battle: 24,
 		},
-		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
+		ruleset: ['Desync Clause Mod', 'HP Percentage Mod', 'Cancel Mod'],
 	},
 ];

--- a/data/mods/gen1/rulesets.ts
+++ b/data/mods/gen1/rulesets.ts
@@ -2,7 +2,7 @@ export const Formats: {[k: string]: ModdedFormatData} = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',
-		ruleset: ['Obtainable', 'Sleep Clause Mod', 'Freeze Clause Mod', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],
+		ruleset: ['Obtainable', 'Desync Clause Mod', 'Sleep Clause Mod', 'Freeze Clause Mod', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],
 		banlist: ['Dig', 'Fly'],
 	},
 	'350cupmod': {

--- a/data/mods/stadium/rulesets.ts
+++ b/data/mods/stadium/rulesets.ts
@@ -2,6 +2,6 @@ export const Formats: {[k: string]: ModdedFormatData} = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',
-		ruleset: ['Obtainable', 'Sleep Clause Mod', 'Freeze Clause Mod', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Exact HP Mod', 'Cancel Mod'],
+		ruleset: ['Obtainable', 'Stadium Sleep Clause', 'Freeze Clause Mod', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Exact HP Mod', 'Cancel Mod'],
 	},
 };

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -830,7 +830,7 @@ export const Formats: {[k: string]: FormatData} = {
 		effectType: 'Rule',
 		name: 'Desync Clause Mod',
 		desc: 'In the event a move would cause a desync, the move will fail instead. This rule covers Psywave and Counter.',
-		// The effect itself is implemented in gen1/moves.ts. 
+		// The effect itself is implemented in gen1/moves.ts.
 		onBegin() {
 			this.add('rule', 'In the event a move would cause a desync, the move will fail instead.');
 		},

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -829,7 +829,7 @@ export const Formats: {[k: string]: FormatData} = {
 	desyncclausemod: {
 		effectType: 'Rule',
 		name: 'Desync Clause Mod',
-		desc: 'In the event a move would cause a desync, the move will fail instead. This rule covers Psywave and Counter.',
+		desc: 'If a desync would happen, the move fails instead. This rule currently covers Psywave and Counter.',
 		onBegin() {
 			this.add('rule', 'Desync Clause Mod: Desyncs changed to move failure.');
 		},

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -830,10 +830,11 @@ export const Formats: {[k: string]: FormatData} = {
 		effectType: 'Rule',
 		name: 'Desync Clause Mod',
 		desc: 'In the event a move would cause a desync, the move will fail instead. This rule covers Psywave and Counter.',
-		// The effect itself is implemented in gen1/moves.ts.
 		onBegin() {
 			this.add('rule', 'Desync Clause Mod: Desyncs changed to move failure.');
 		},
+		// Hardcoded in gen1/moves.ts
+		// Can't be disabled (no precedent for how else to handle desyncs)
 	},
 	freezeclausemod: {
 		effectType: 'Rule',

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -832,7 +832,7 @@ export const Formats: {[k: string]: FormatData} = {
 		desc: 'In the event a move would cause a desync, the move will fail instead. This rule covers Psywave and Counter.',
 		// The effect itself is implemented in gen1/moves.ts.
 		onBegin() {
-			this.add('rule', 'In the event a move would cause a desync, the move will fail instead.');
+			this.add('rule', 'Desync Clause Mod: Desyncs changed to move failure.');
 		},
 	},
 	freezeclausemod: {

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -826,6 +826,15 @@ export const Formats: {[k: string]: FormatData} = {
 			this.add('rule', 'Switch Priority Clause Mod: Faster Pokémon switch first');
 		},
 	},
+	desyncclausemod: {
+		effectType: 'Rule',
+		name: 'Desync Clause Mod',
+		desc: 'In the event a move would cause a desync, the move will fail instead. This rule covers Psywave and Counter.',
+		// The effect itself is implemented in gen1/moves.ts. 
+		onBegin() {
+			this.add('rule', 'In the event a move would cause a desync, the move will fail instead.');
+		},
+	},
 	freezeclausemod: {
 		effectType: 'Rule',
 		name: 'Freeze Clause Mod',

--- a/test/sim/moves/counter.js
+++ b/test/sim/moves/counter.js
@@ -71,6 +71,48 @@ describe('Counter', function () {
 		assert.false.fullHP(battle.p2.active[1]);
 		assert.fullHP(battle.p2.active[0]);
 	});
+
+	it(`[Gen 1] Counter Desync Clause`, function () {
+		// seed chosen so Water Gun succeeds and Pound full paras
+		battle = common.gen(1).createBattle({seed: [1, 2, 3, 6]}, [[
+			{species: 'Mew', moves: ['pound', 'watergun', 'counter', 'thunderwave']},
+		], [
+			{species: 'Persian', moves: ['pound', 'watergun', 'counter', 'thunderwave']},
+		]]);
+		battle.makeChoices('move watergun', 'move thunderwave');
+		battle.makeChoices('move pound', 'move counter');
+		assert(battle.log.some(line => line.includes('Desync Clause Mod activated')));
+
+		// seed chosen so Pound succeeds and Water Gun full paras
+		battle = common.gen(1).createBattle({seed: [1, 2, 3, 6]}, [[
+			{species: 'Mew', moves: ['pound', 'watergun', 'counter', 'thunderwave']},
+		], [
+			{species: 'Persian', moves: ['pound', 'watergun', 'counter', 'thunderwave']},
+		]]);
+		battle.makeChoices('move pound', 'move thunderwave');
+		battle.makeChoices('move watergun', 'move counter');
+		assert(battle.log.some(line => line.includes('Desync Clause Mod activated')));
+
+		battle = common.gen(1).createBattle([[
+			{species: 'Mew', moves: ['pound', 'watergun', 'counter', 'splash']},
+		], [
+			{species: 'Persian', moves: ['pound', 'watergun', 'counter', 'splash']},
+		]]);
+		battle.makeChoices('move watergun', 'move splash');
+		battle.makeChoices('move pound', 'move counter');
+		assert(!battle.log.some(line => line.includes('Desync Clause Mod activated')));
+		assert.false.fullHP(battle.p1.active[0]);
+
+		battle = common.gen(1).createBattle([[
+			{species: 'Mew', moves: ['pound', 'watergun', 'counter', 'splash']},
+		], [
+			{species: 'Persian', moves: ['pound', 'watergun', 'counter', 'splash']},
+		]]);
+		battle.makeChoices('move pound', 'move splash');
+		battle.makeChoices('move watergun', 'move counter');
+		assert(!battle.log.some(line => line.includes('Desync Clause Mod activated')));
+		assert.fullHP(battle.p1.active[0]);
+	});
 });
 
 describe('Mirror Coat', function () {
@@ -150,47 +192,5 @@ describe('Mirror Coat', function () {
 		const wynaut = battle.p2.active[0];
 		battle.makeChoices('auto', 'move sleeptalk, move dragonpulse 1');
 		assert.equal(wynaut.maxhp, wynaut.hp);
-	});
-
-	it(`[Gen 1] Counter Desync Clause`, function () {
-		// seed chosen so Water Gun succeeds and Pound full paras
-		battle = common.gen(1).createBattle({seed: [1, 2, 3, 6]}, [[
-			{species: 'Mew', moves: ['pound', 'watergun', 'counter', 'thunderwave']},
-		], [
-			{species: 'Persian', moves: ['pound', 'watergun', 'counter', 'thunderwave']},
-		]]);
-		battle.makeChoices('move watergun', 'move thunderwave');
-		battle.makeChoices('move pound', 'move counter');
-		assert(battle.log.some(line => line.includes('Desync Clause Mod')));
-
-		// seed chosen so Pound succeeds and Water Gun full paras
-		battle = common.gen(1).createBattle({seed: [1, 2, 3, 6]}, [[
-			{species: 'Mew', moves: ['pound', 'watergun', 'counter', 'thunderwave']},
-		], [
-			{species: 'Persian', moves: ['pound', 'watergun', 'counter', 'thunderwave']},
-		]]);
-		battle.makeChoices('move pound', 'move thunderwave');
-		battle.makeChoices('move watergun', 'move counter');
-		assert(battle.log.some(line => line.includes('Desync Clause Mod')));
-
-		battle = common.gen(1).createBattle([[
-			{species: 'Mew', moves: ['pound', 'watergun', 'counter', 'splash']},
-		], [
-			{species: 'Persian', moves: ['pound', 'watergun', 'counter', 'splash']},
-		]]);
-		battle.makeChoices('move watergun', 'move splash');
-		battle.makeChoices('move pound', 'move counter');
-		assert(!battle.log.some(line => line.includes('Desync Clause Mod')));
-		assert.false.fullHP(battle.p1.active[0]);
-
-		battle = common.gen(1).createBattle([[
-			{species: 'Mew', moves: ['pound', 'watergun', 'counter', 'splash']},
-		], [
-			{species: 'Persian', moves: ['pound', 'watergun', 'counter', 'splash']},
-		]]);
-		battle.makeChoices('move pound', 'move splash');
-		battle.makeChoices('move watergun', 'move counter');
-		assert(!battle.log.some(line => line.includes('Desync Clause Mod')));
-		assert.fullHP(battle.p1.active[0]);
 	});
 });

--- a/test/sim/moves/counter.js
+++ b/test/sim/moves/counter.js
@@ -161,7 +161,7 @@ describe('Mirror Coat', function () {
 		]]);
 		battle.makeChoices('move watergun', 'move thunderwave');
 		battle.makeChoices('move pound', 'move counter');
-		assert(battle.log.some(line => line.includes('Desync Clause')));
+		assert(battle.log.some(line => line.includes('Desync Clause Mod')));
 
 		// seed chosen so Pound succeeds and Water Gun full paras
 		battle = common.gen(1).createBattle({seed: [1, 2, 3, 6]}, [[
@@ -171,7 +171,7 @@ describe('Mirror Coat', function () {
 		]]);
 		battle.makeChoices('move pound', 'move thunderwave');
 		battle.makeChoices('move watergun', 'move counter');
-		assert(battle.log.some(line => line.includes('Desync Clause')));
+		assert(battle.log.some(line => line.includes('Desync Clause Mod')));
 
 		battle = common.gen(1).createBattle([[
 			{species: 'Mew', moves: ['pound', 'watergun', 'counter', 'splash']},
@@ -180,7 +180,7 @@ describe('Mirror Coat', function () {
 		]]);
 		battle.makeChoices('move watergun', 'move splash');
 		battle.makeChoices('move pound', 'move counter');
-		assert(!battle.log.some(line => line.includes('Desync Clause')));
+		assert(!battle.log.some(line => line.includes('Desync Clause Mod')));
 		assert.false.fullHP(battle.p1.active[0]);
 
 		battle = common.gen(1).createBattle([[
@@ -190,7 +190,7 @@ describe('Mirror Coat', function () {
 		]]);
 		battle.makeChoices('move pound', 'move splash');
 		battle.makeChoices('move watergun', 'move counter');
-		assert(!battle.log.some(line => line.includes('Desync Clause')));
+		assert(!battle.log.some(line => line.includes('Desync Clause Mod')));
 		assert.fullHP(battle.p1.active[0]);
 	});
 });


### PR DESCRIPTION
This is to be added to the "Standard" ruleset, so that "Desync Clause Mod" will show up when you start an RBY game on PS. I'll add this to the gen1/rulesets.ts "Standard" and any Gen 1 formats that don't use it, which should cover everything. 

This isn't meant to actually _do_ anything on its own, only note that the "mod" exists and will trigger in certain scenarios. 

I've written the rule description in a way that it will need updating whenever another desync is patched. There's still quite a few of these, though, and I believe the RBY Council still needs to go over a bunch. This includes Bide and Mirror Move + Partial Trapping. There's also some game crashes involving specific defensive stats but those are different. 

While doing this, I noticed that Stadium OU was removing Smogon Sleep Clause and replacing it with Stadium Sleep Clause, which seemed pretty inefficient, so I thought it would be better to have this in the "Standard" rules instead. 