### PR TITLE
Correct multi-hit distribution and confusion odds

### DIFF
--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -168,7 +168,7 @@ export const Conditions: {[k: string]: ConditionData} = {
 				return;
 			}
 			this.add('-activate', pokemon, 'confusion');
-			if (!this.randomChance(1, 3)) {
+			if (!this.randomChance(33, 100)) {
 				return;
 			}
 			this.activeTarget = pokemon;

--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -612,7 +612,8 @@ export const Scripts: BattleScriptsData = {
 			// yes, it's hardcoded... meh
 			if (targetHits[0] === 2 && targetHits[1] === 5) {
 				if (this.gen >= 5) {
-					targetHits = this.sample([2, 2, 3, 3, 4, 5]);
+					// 35-35-15-15 out of 100 for 2-3-4-5 hits
+					targetHits = this.sample([2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 5, 5, 5]);
 				} else {
 					targetHits = this.sample([2, 2, 2, 3, 3, 3, 4, 5]);
 				}


### PR DESCRIPTION
Based on new research, multi-hit distribution is now known to be 35-35-15-15 rather than 1/3-1/3-1/6-1/6, and confusion is now known to be 33/100 rather than 1/3.

See videos:
https://www.youtube.com/watch?v=Il1sMnFUh9s
https://www.youtube.com/watch?v=TMtpLva4_qM

I think the way I corrected multi-hit move distribution is accurate, but it looks kind of dumb; not sure if there's a preferable way to do it.