### PR TITLE
Filters: Properly stop forcerenamed names from being used

### DIFF
--- a/server/chat-plugins/chat-monitor.ts
+++ b/server/chat-plugins/chat-monitor.ts
@@ -374,6 +374,9 @@ export const namefilter: NameFilter = (name, user) => {
 };
 export const loginfilter: LoginFilter = user => {
 	if (user.namelocked) return;
+	if (Monitor.forceRenames.has(user.id) && !Punishments.namefilterwhitelist.has(user.id)) {
+		return '';
+	}
 
 	if (user.trackRename) {
 		const manualForceRename = Monitor.forceRenames.get(toID(user.trackRename));
@@ -385,10 +388,6 @@ export const loginfilter: LoginFilter = user => {
 	}
 };
 export const nicknamefilter: NameFilter = (name, user) => {
-	if (Monitor.forceRenames.has(user.id) && !Punishments.namefilterwhitelist.has(user.id)) {
-		return '';
-	}
-
 	let lcName = name
 		.replace(/\u039d/g, 'N').toLowerCase()
 		.replace(/[\u200b\u007F\u00AD]/g, '')


### PR DESCRIPTION
https://www.smogon.com/forums/threads/staff-suggestions-bugs.3514540/page-17#post-8642512
(before this change, it was just stopping users that had been forcerenamed from using pokemon nicknames)