### PR TITLE
Support automatic expiry for monthlocks

### DIFF
--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -870,6 +870,11 @@ export const Punishments = new class {
 	 * It also expires a punishment if the time is up.
 	 */
 	checkPunishmentTime(user: User, punishment: Punishment) {
+		if (user.punishmentTimer) {
+			clearTimeout(user.punishmentTimer);
+			user.punishmentTimer = null;
+		}
+
 		const [, id, expireTime] = punishment;
 
 		const timeLeft = expireTime - Date.now();

--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -872,14 +872,15 @@ export const Punishments = new class {
 	checkPunishmentTime(user: User, punishment: Punishment) {
 		const [, id, expireTime] = punishment;
 
-		if (expireTime < Date.now()) {
+		const timeLeft = expireTime - Date.now();
+		if (timeLeft <= 1) {
 			if (user.locked === id) Punishments.unlock(user.id);
-		} else {
-			const length = Math.min(expireTime - Date.now(), MAX_PUNISHMENT_TIMER_LENGTH);
-			user.punishmentTimer = setTimeout(() => {
-				Punishments.checkPunishmentTime(user, punishment);
-			}, length);
+			return;
 		}
+		const waitTime = Math.min(timeLeft, MAX_PUNISHMENT_TIMER_LENGTH);
+		user.punishmentTimer = setTimeout(() => {
+			Punishments.checkPunishmentTime(user, punishment);
+		}, waitTime);
 	}
 	async namelock(
 		user: User | ID, expireTime: number | null, id: ID | PunishType | null, ignoreAlts: boolean, ...reason: string[]

--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -881,7 +881,9 @@ export const Punishments = new class {
 	 */
 	pokePunishmentTimer(user: User, punishment: Punishment) {
 		const length = Math.min(punishment[2] - Date.now(), MAX_PUNISHMENT_TIMER_LENGTH);
-		user.punishmentTimer = setTimeout(Punishments.runExpiry, length, user, punishment);
+		user.punishmentTimer = setTimeout(() => {
+			Punishments.runExpiry(user, punishment);
+		}, length);
 	}
 	async namelock(
 		user: User | ID, expireTime: number | null, id: ID | PunishType | null, ignoreAlts: boolean, ...reason: string[]


### PR DESCRIPTION
As discussed in PMs with Zarel, this pokes every punishment timer daily, allowing for punishments longer than Node's maximum timeout length to automatically expire.