### PR TITLE
Fix disqualifyUser bug in tournaments

### DIFF
--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -749,7 +749,13 @@ export class Tournament extends Rooms.RoomGame {
 		if (matchTo) {
 			matchTo.isBusy = false;
 			const matchRoom = matchTo.inProgressMatch!.room;
-			matchRoom.parent = null;
+			if (matchRoom.parent) {
+				matchRoom.parent.subRooms?.delete(matchRoom.roomid);
+				if (!matchRoom.parent.subRooms?.size) {
+					matchRoom.parent.subRooms = null;
+				}
+				matchRoom.parent = null;
+			}
 			this.completedMatches.add(matchRoom.roomid);
 			if (matchRoom.battle) matchRoom.battle.forfeit(player.id);
 			matchTo.inProgressMatch = null;


### PR DESCRIPTION
turns out since "inProgressMatch" only sets on 1 of the players the sub room deletions on line 733 only happen if the user it's set to is disqualified. Not sure if the inProgressMatch setting that way intentional or not so i just figured I'd pr this fix and if it's preferred for me to make it so inProgressMatch is set on both players instead of just one i can do that instead.