### PR TITLE
/randombattles: Check Gmax forme for moves

### DIFF
--- a/server/chat-plugins/random-battles.ts
+++ b/server/chat-plugins/random-battles.ts
@@ -280,16 +280,18 @@ export const commands: ChatCommands = {
 			}
 			return this.sendReplyBox(`<span style="color:#999999;">Moves for ${species.name} in ${formatName}:</span><br />${lgpeMoves}`);
 		}
-		if (!species.randomBattleMoves) {
+		let randomMoves = species.randomBattleMoves;
+		if (!randomMoves) {
 			const gmaxSpecies = dex.getSpecies(`${args[0]}gmax`);
 			if (!gmaxSpecies.exists || !gmaxSpecies.randomBattleMoves) {
 				return this.errorReply(`Error: No moves data found for ${species.name}${`gen${dex.gen}` in GEN_NAMES ? ` in ${GEN_NAMES[`gen${dex.gen}`]}` : ``}.`);
 			}
 			species = gmaxSpecies;
+			randomMoves = gmaxSpecies.randomBattleMoves;
 		}
 		const moves: string[] = [];
 		// Done because species.randomBattleMoves is readonly
-		for (const move of species.randomBattleMoves!) { // <- TypeScript bug: species.randomBattleMoves can't be undefined
+		for (const move of randomMoves) {
 			moves.push(move);
 		}
 		const m = moves.sort().map(formatMove);

--- a/server/chat-plugins/random-battles.ts
+++ b/server/chat-plugins/random-battles.ts
@@ -260,7 +260,7 @@ export const commands: ChatCommands = {
 			dex = Dex.mod(format.mod);
 			if (format.mod === 'letsgo') isLetsGo = true;
 		}
-		const species = dex.getSpecies(args[0]);
+		let species = dex.getSpecies(args[0]);
 		if (!species.exists) {
 			return this.errorReply(`Error: Pok\u00e9mon '${args[0].trim()}' does not exist.`);
 		}
@@ -281,11 +281,15 @@ export const commands: ChatCommands = {
 			return this.sendReplyBox(`<span style="color:#999999;">Moves for ${species.name} in ${formatName}:</span><br />${lgpeMoves}`);
 		}
 		if (!species.randomBattleMoves) {
-			return this.errorReply(`Error: No moves data found for ${species.name}${`gen${dex.gen}` in GEN_NAMES ? ` in ${GEN_NAMES[`gen${dex.gen}`]}` : ``}.`);
+			const gmaxSpecies = dex.getSpecies(`${args[0]}gmax`);
+			if (!gmaxSpecies.exists || !gmaxSpecies.randomBattleMoves) {
+				return this.errorReply(`Error: No moves data found for ${species.name}${`gen${dex.gen}` in GEN_NAMES ? ` in ${GEN_NAMES[`gen${dex.gen}`]}` : ``}.`);
+			}
+			species = gmaxSpecies;
 		}
 		const moves: string[] = [];
 		// Done because species.randomBattleMoves is readonly
-		for (const move of species.randomBattleMoves) {
+		for (const move of species.randomBattleMoves!) { // <- TypeScript bug: species.randomBattleMoves can't be undefined
 			moves.push(move);
 		}
 		const m = moves.sort().map(formatMove);

--- a/server/chat-plugins/random-battles.ts
+++ b/server/chat-plugins/random-battles.ts
@@ -328,16 +328,18 @@ export const commands: ChatCommands = {
 		if (!species.exists) {
 			return this.errorReply(`Error: Pok\u00e9mon '${args[0].trim()}' does not exist.`);
 		}
-		if (!species.randomDoubleBattleMoves) {
+		let randomMoves = species.randomDoubleBattleMoves;
+		if (!randomMoves) {
 			const gmaxSpecies = dex.getSpecies(`${args[0]}gmax`);
 			if (!gmaxSpecies.exists || !gmaxSpecies.randomDoubleBattleMoves) {
 				return this.errorReply(`Error: No doubles moves data found for ${species.name}${`gen${dex.gen}` in GEN_NAMES ? ` in ${GEN_NAMES[`gen${dex.gen}`]}` : ``}.`);
 			}
 			species = gmaxSpecies;
+			randomMoves = gmaxSpecies.randomDoubleBattleMoves;
 		}
 		const moves: string[] = [];
 		// Done because species.randomDoubleBattleMoves is readonly
-		for (const move of species.randomDoubleBattleMoves!) { // <- TypeScript bug: see above in randombattles
+		for (const move of randomMoves) {
 			moves.push(move);
 		}
 		const m = moves.sort().map(formatMove);

--- a/server/chat-plugins/random-battles.ts
+++ b/server/chat-plugins/random-battles.ts
@@ -319,7 +319,7 @@ export const commands: ChatCommands = {
 				return this.parse(`/help randomdoublesbattle`);
 			}
 		}
-		const species = dex.getSpecies(args[0]);
+		let species = dex.getSpecies(args[0]);
 		const formatName = dex.gen > 6 ? dex.getFormat(`gen${dex.gen}randomdoublesbattle`).name : dex.gen === 6 ?
 			'[Gen 6] Random Doubles Battle' : dex.gen === 5 ?
 				'[Gen 5] Random Doubles Battle' : '[Gen 4] Random Doubles Battle';
@@ -327,11 +327,15 @@ export const commands: ChatCommands = {
 			return this.errorReply(`Error: Pok\u00e9mon '${args[0].trim()}' does not exist.`);
 		}
 		if (!species.randomDoubleBattleMoves) {
-			return this.errorReply(`Error: No doubles moves data found for ${species.name}${`gen${dex.gen}` in GEN_NAMES ? ` in ${GEN_NAMES[`gen${dex.gen}`]}` : ``}.`);
+			const gmaxSpecies = dex.getSpecies(`${args[0]}gmax`);
+			if (!gmaxSpecies.exists || !gmaxSpecies.randomDoubleBattleMoves) {
+				return this.errorReply(`Error: No doubles moves data found for ${species.name}${`gen${dex.gen}` in GEN_NAMES ? ` in ${GEN_NAMES[`gen${dex.gen}`]}` : ``}.`);
+			}
+			species = gmaxSpecies;
 		}
 		const moves: string[] = [];
 		// Done because species.randomDoubleBattleMoves is readonly
-		for (const move of species.randomDoubleBattleMoves) {
+		for (const move of species.randomDoubleBattleMoves!) { // <- TypeScript bug: see above in randombattles
 			moves.push(move);
 		}
 		const m = moves.sort().map(formatMove);


### PR DESCRIPTION
There are several Pokemon species for which only the Gmax forme has a random battles/random doubles move pool, and the /randbats and /randdubs commands would report that these Pokemon had no moves unless users specified said Gmax forme.