### PR TITLE
/dexsearch: Fix immunity check for Thousand Arrows

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -971,9 +971,8 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 				let effectiveness = 0;
 				const move = mod.getMove(targetResist);
 				const attackingType = move.type || targetResist;
-				const notImmune = mod.getImmunity(attackingType, dex[mon]) && (!move.exists || !move.ignoreImmunity ||
-					move.isFutureMove || (move.ignoreImmunity !== true && !move.ignoreImmunity[move.type])) &&
-					(move.id !== 'sheercold' || maxGen < 7 || !dex[mon].types.includes('Ice'));
+				const notImmune = (move.id === 'thousandarrows' || mod.getImmunity(attackingType, dex[mon])) &&
+					!(move.id === 'sheercold' && maxGen >= 7 && dex[mon].types.includes('Ice'));
 				if (notImmune && !move.ohko && move.damage === undefined) {
 					for (const defenderType of dex[mon].types) {
 						const baseMod = mod.getEffectiveness(attackingType, defenderType);
@@ -995,9 +994,8 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 				let effectiveness = 0;
 				const move = mod.getMove(targetWeak);
 				const attackingType = move.type || targetWeak;
-				const notImmune = mod.getImmunity(attackingType, dex[mon]) && (!move.exists || !move.ignoreImmunity ||
-					move.isFutureMove || (move.ignoreImmunity !== true && !move.ignoreImmunity[move.type])) &&
-					(move.id !== 'sheercold' || maxGen < 7 || !dex[mon].types.includes('Ice'));
+				const notImmune = (move.id === 'thousandarrows' || mod.getImmunity(attackingType, dex[mon])) &&
+					!(move.id === 'sheercold' && maxGen >= 7 && dex[mon].types.includes('Ice'));
 				if (notImmune && !move.ohko && move.damage === undefined) {
 					for (const defenderType of dex[mon].types) {
 						const baseMod = mod.getEffectiveness(attackingType, defenderType);


### PR DESCRIPTION
Unlike /effectiveness and /coverage, /dexsearch doesn't need to support arbitrary mods, so Thousand Arrows can be hard-coded as the only move to ignore any immunities. Simplifying the check like this was pretty much necessary for me to actually be able to understand how the logic should be structured to accommodate the opposing exceptions for Thousand Arrows and Sheer Cold.