### PR TITLE
Correct Protean interactions & Gravity-blocked status Z-moves

### DIFF
--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -701,7 +701,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	rest: {
 		inherit: true,
-		onTryMove() {},
+		onTry() {},
 		onHit(target, source, move) {
 			if (target.hp === target.maxhp) return false;
 			// Fail when health is 255 or 511 less than max

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -571,7 +571,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	rest: {
 		inherit: true,
-		onTryMove(pokemon) {
+		onTry(pokemon) {
 			if (pokemon.hp < pokemon.maxhp) return;
 			this.add('-fail', pokemon);
 			return null;

--- a/data/mods/gen5/moves.ts
+++ b/data/mods/gen5/moves.ts
@@ -655,7 +655,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	quickguard: {
 		inherit: true,
 		stallingMove: true,
-		onTryHitSide(side, source) {
+		onTry(source) {
 			return this.queue.willAct() && this.runEvent('StallMove', source);
 		},
 		onHitSide(side, source) {
@@ -1021,7 +1021,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	wideguard: {
 		inherit: true,
 		stallingMove: true,
-		onTryHitSide(side, source) {
+		onTry(source) {
 			return this.queue.willAct() && this.runEvent('StallMove', source);
 		},
 		onHitSide(side, source) {

--- a/data/mods/gen6/moves.ts
+++ b/data/mods/gen6/moves.ts
@@ -6,7 +6,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	darkvoid: {
 		inherit: true,
 		accuracy: 80,
-		onTryMove() {},
+		onTry() {},
 	},
 	destinybond: {
 		inherit: true,

--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -904,7 +904,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		priority: 0,
 		selfSwitch: false,
-		onTryHit: false,
+		onTry: false,
 	},
 	toxicthread: {
 		inherit: true,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -7304,6 +7304,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					return false;
 				}
 			},
+
 			onResidualOrder: 22,
 			onEnd() {
 				this.add('-fieldend', 'move: Gravity');
@@ -8590,7 +8591,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				return null;
 			}
 			this.attrLastMove('[still]');
-			this.add('-fail', pokemon, 'move: Hyperspace Fury');
+			this.add('-fail', source, 'move: Hyperspace Fury');
 			return null;
 		},
 		self: {

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -773,7 +773,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {snatch: 1},
 		sideCondition: 'auroraveil',
-		onTryHitSide() {
+		onTry() {
 			if (!this.field.isWeather('hail')) return false;
 		},
 		condition: {
@@ -913,8 +913,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {},
 		stallingMove: true,
 		volatileStatus: 'banefulbunker',
-		onTryHit(target, source, move) {
-			return !!this.queue.willAct() && this.runEvent('StallMove', target);
+		onPrepareHit(pokemon) {
+			return !!this.queue.willAct() && this.runEvent('StallMove', pokemon);
 		},
 		onHit(pokemon) {
 			pokemon.addVolatile('stall');
@@ -2182,10 +2182,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {snatch: 1, sound: 1, dance: 1},
-		onTryHit(pokemon, target, move) {
+		onTry(pokemon, target, move) {
 			if (pokemon.hp <= (pokemon.maxhp * 33 / 100) || pokemon.maxhp === 1) {
 				return false;
 			}
+		},
+		onTryHit(pokemon, target, move) {
 			if (!this.boost(move.boosts as SparseBoostsTable)) return null;
 			delete move.boosts;
 		},
@@ -2761,7 +2763,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 3,
 		flags: {},
 		sideCondition: 'craftyshield',
-		onTryHitSide(side, source) {
+		onTry(side, source) {
 			return !!this.queue.willAct();
 		},
 		condition: {
@@ -2973,7 +2975,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1},
 		status: 'slp',
-		onTryMove(pokemon, target, move) {
+		onTry(pokemon, target, move) {
 			if (pokemon.species.name === 'Darkrai' || move.hasBounced) {
 				return;
 			}
@@ -4306,8 +4308,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {},
 		stallingMove: true,
 		volatileStatus: 'endure',
-		onTryHit(pokemon) {
-			return this.queue.willAct() && this.runEvent('StallMove', pokemon);
+		onPrepareHit(pokemon) {
+			return !!this.queue.willAct() && this.runEvent('StallMove', pokemon);
 		},
 		onHit(pokemon) {
 			pokemon.addVolatile('stall');
@@ -5497,7 +5499,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 2,
 		flags: {},
 		volatileStatus: 'followme',
-		onTryHit(target) {
+		onTry(target) {
 			if (target.side.active.length < 2) return false;
 		},
 		condition: {
@@ -9226,7 +9228,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {},
 		stallingMove: true,
 		volatileStatus: 'kingsshield',
-		onTryHit(pokemon) {
+		onPrepareHit(pokemon) {
 			return !!this.queue.willAct() && this.runEvent('StallMove', pokemon);
 		},
 		onHit(pokemon) {
@@ -10109,16 +10111,17 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {snatch: 1, gravity: 1},
 		volatileStatus: 'magnetrise',
 		onTry(source, target, move) {
+			if (target.volatiles['smackdown'] || target.volatiles['ingrain']) return false;
+
 			// Additional Gravity check for Z-move variant
 			if (this.field.getPseudoWeather('Gravity')) {
 				this.add('cant', source, 'move: Gravity', move);
-				return false;
+				return null;
 			}
 		},
 		condition: {
 			duration: 5,
 			onStart(target) {
-				if (target.volatiles['smackdown'] || target.volatiles['ingrain']) return false;
 				this.add('-start', target, 'Magnet Rise');
 			},
 			onImmunity(type) {
@@ -10207,11 +10210,13 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {snatch: 1, nonsky: 1},
 		stallingMove: true,
 		sideCondition: 'matblock',
-		onTryHitSide(side, source) {
+		onTry(side, source) {
 			if (source.activeMoveActions > 1) {
 				this.hint("Mat Block only works on your first turn out.");
 				return false;
 			}
+
+			return !!this.queue.willAct();
 		},
 		condition: {
 			duration: 1,
@@ -11909,7 +11914,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {snatch: 1},
 		volatileStatus: 'noretreat',
-		onTryHit(target, source, move) {
+		onTry(target, source, move) {
 			if (target.volatiles['noretreat']) return false;
 			if (target.volatiles['trapped']) {
 				delete move.volatileStatus;
@@ -11977,7 +11982,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {},
 		stallingMove: true,
 		volatileStatus: 'obstruct',
-		onTryHit(pokemon) {
+		onPrepareHit(pokemon) {
 			return !!this.queue.willAct() && this.runEvent('StallMove', pokemon);
 		},
 		onHit(pokemon) {
@@ -13255,7 +13260,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		onPrepareHit(target, source, move) {
+		onTryHit(target, source, move) {
 			if (!source.status) return false;
 			move.status = source.status;
 		},
@@ -13505,7 +13510,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 3,
 		flags: {snatch: 1},
 		sideCondition: 'quickguard',
-		onTryHitSide(side, source) {
+		onTry(side, source) {
 			return !!this.queue.willAct();
 		},
 		onHitSide(side, source) {
@@ -13605,7 +13610,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 2,
 		flags: {powder: 1},
 		volatileStatus: 'ragepowder',
-		onTryHit(target) {
+		onTry(target) {
 			if (target.side.active.length < 2) return false;
 		},
 		condition: {
@@ -13924,12 +13929,17 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {snatch: 1, heal: 1},
-		onTryMove(pokemon) {
+		onTry(pokemon) {
+			if (pokemon.status === 'slp' || pokemon.hasAbility('comatose')) {
+				return false;
+			}
 			if (pokemon.hp === pokemon.maxhp) {
 				this.add('-fail', pokemon, 'heal');
 				return null;
 			}
-			if (pokemon.status === 'slp' || pokemon.hasAbility('comatose')) {
+			const ability = pokemon.getAbility();
+			if (ability.id === 'vitalspirit' || ability.id === 'insomnia') {
+				// TODO: hook up [Pokemon] stayed awake! client message
 				this.add('-fail', pokemon);
 				return null;
 			}
@@ -15523,8 +15533,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-end', target, 'Sky Drop', '[interrupt]');
 			}
 		},
-		onTryHit(target, source, move) {
+		onTry(target, source) {
 			if (target.fainted) return false;
+		},
+		onTryHit(target, source, move) {
 			if (source.removeVolatile(move.id)) {
 				if (target !== source.volatiles['twoturnmove'].source) return false;
 
@@ -15693,7 +15705,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {},
 		sleepUsable: true,
-		onTryHit(pokemon) {
+		onTry(pokemon) {
 			if (pokemon.status !== 'slp' && !pokemon.hasAbility('comatose')) return false;
 		},
 		onHit(pokemon) {
@@ -15984,7 +15996,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1, sound: 1, authentic: 1},
 		sleepUsable: true,
-		onTryHit(target, source) {
+		onTry(target, source) {
 			if (source.status !== 'slp' && !source.hasAbility('comatose')) return false;
 		},
 		secondary: {
@@ -16335,8 +16347,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {},
 		stallingMove: true,
 		volatileStatus: 'spikyshield',
-		onTryHit(target, source, move) {
-			return !!this.queue.willAct() && this.runEvent('StallMove', target);
+		onPrepareHit(pokemon) {
+			return !!this.queue.willAct() && this.runEvent('StallMove', pokemon);
 		},
 		onHit(pokemon) {
 			pokemon.addVolatile('stall');
@@ -16481,7 +16493,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			// Additional Gravity check for Z-move variant
 			if (this.field.getPseudoWeather('Gravity')) {
 				this.add('cant', source, 'move: Gravity', move);
-				return false;
+				return null;
 			}
 		},
 		onTryHit(target, source) {
@@ -16670,7 +16682,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		onTryHit() {
+		onTry() {
 			if (this.field.isTerrain('')) return false;
 		},
 		onHit() {
@@ -16737,7 +16749,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 20,
 		priority: 0,
 		flags: {snatch: 1},
-		onTryHit(pokemon) {
+		onTry(pokemon) {
 			if (pokemon.volatiles['stockpile'] && pokemon.volatiles['stockpile'].layers >= 3) return false;
 		},
 		volatileStatus: 'stockpile',
@@ -17325,7 +17337,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {snatch: 1, heal: 1},
-		onTryHit(pokemon) {
+		onTry(pokemon) {
 			if (!pokemon.volatiles['stockpile'] || !pokemon.volatiles['stockpile'].layers) return false;
 		},
 		onHit(pokemon) {
@@ -17810,7 +17822,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			// Additional Gravity check for Z-move variant
 			if (this.field.getPseudoWeather('Gravity')) {
 				this.add('cant', source, 'move: Gravity', move);
-				return false;
+				return null;
 			}
 		},
 		condition: {
@@ -19205,7 +19217,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 3,
 		flags: {snatch: 1},
 		sideCondition: 'wideguard',
-		onTryHitSide(side, source) {
+		onTry(side, source) {
 			return !!this.queue.willAct();
 		},
 		onHitSide(side, source) {

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -13923,7 +13923,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {snatch: 1, heal: 1},
 		onTry(source) {
 			if (source.status === 'slp' || source.hasAbility('comatose')) return false;
-			
+
 			if (source.hp === source.maxhp) {
 				this.add('-fail', source, 'heal');
 				return null;

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2182,7 +2182,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {snatch: 1, sound: 1, dance: 1},
-		onTry(pokemon, target, move) {
+		onTry(pokemon) {
 			if (pokemon.hp <= (pokemon.maxhp * 33 / 100) || pokemon.maxhp === 1) {
 				return false;
 			}
@@ -2763,7 +2763,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 3,
 		flags: {},
 		sideCondition: 'craftyshield',
-		onTry(side, source) {
+		onTry(pokemon) {
 			return !!this.queue.willAct();
 		},
 		condition: {
@@ -5499,8 +5499,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 2,
 		flags: {},
 		volatileStatus: 'followme',
-		onTry(target) {
-			if (target.side.active.length < 2) return false;
+		onTry(pokemon) {
+			if (pokemon.side.active.length < 2) return false;
 		},
 		condition: {
 			duration: 1,
@@ -10210,12 +10210,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {snatch: 1, nonsky: 1},
 		stallingMove: true,
 		sideCondition: 'matblock',
-		onTry(side, source) {
-			if (source.activeMoveActions > 1) {
+		onTry(pokemon) {
+			if (pokemon.activeMoveActions > 1) {
 				this.hint("Mat Block only works on your first turn out.");
 				return false;
 			}
-
 			return !!this.queue.willAct();
 		},
 		condition: {
@@ -11914,7 +11913,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {snatch: 1},
 		volatileStatus: 'noretreat',
-		onTry(target, source, move) {
+		onTry(source, target, move) {
 			if (target.volatiles['noretreat']) return false;
 			if (target.volatiles['trapped']) {
 				delete move.volatileStatus;
@@ -13510,7 +13509,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 3,
 		flags: {snatch: 1},
 		sideCondition: 'quickguard',
-		onTry(side, source) {
+		onTry(pokemon) {
 			return !!this.queue.willAct();
 		},
 		onHitSide(side, source) {
@@ -13610,8 +13609,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 2,
 		flags: {powder: 1},
 		volatileStatus: 'ragepowder',
-		onTry(target) {
-			if (target.side.active.length < 2) return false;
+		onTry(pokemon) {
+			if (pokemon.side.active.length < 2) return false;
 		},
 		condition: {
 			duration: 1,
@@ -13937,8 +13936,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-fail', pokemon, 'heal');
 				return null;
 			}
-			const ability = pokemon.getAbility();
-			if (ability.id === 'vitalspirit' || ability.id === 'insomnia') {
+			if (pokemon.hasAbility(['insomnia', 'vitalspirit']))) {
 				// TODO: hook up [Pokemon] stayed awake! client message
 				this.add('-fail', pokemon);
 				return null;
@@ -15533,7 +15531,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-end', target, 'Sky Drop', '[interrupt]');
 			}
 		},
-		onTry(target, source) {
+		onTry(source, target) {
 			if (target.fainted) return false;
 		},
 		onTryHit(target, source, move) {
@@ -15996,8 +15994,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1, sound: 1, authentic: 1},
 		sleepUsable: true,
-		onTry(target) {
-			if (target.status !== 'slp' && !target.hasAbility('comatose')) return false;
+		onTry(pokemon) {
+			if (pokemon.status !== 'slp' && !pokemon.hasAbility('comatose')) return false;
 		},
 		secondary: {
 			chance: 30,
@@ -19217,7 +19215,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 3,
 		flags: {snatch: 1},
 		sideCondition: 'wideguard',
-		onTry(side, source) {
+		onTry(pokemon) {
 			return !!this.queue.willAct();
 		},
 		onHitSide(side, source) {

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -13936,7 +13936,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-fail', pokemon, 'heal');
 				return null;
 			}
-			if (pokemon.hasAbility(['insomnia', 'vitalspirit']))) {
+			if (pokemon.hasAbility(['insomnia', 'vitalspirit'])) {
 				// TODO: hook up [Pokemon] stayed awake! client message
 				this.add('-fail', pokemon);
 				return null;

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -726,12 +726,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 				},
 			},
 		},
-		onTry(pokemon) {
-			if (pokemon.species.baseSpecies === 'Morpeko') {
+		onTry(source) {
+			if (source.species.baseSpecies === 'Morpeko') {
 				return;
 			}
 			this.attrLastMove('[still]');
-			this.add('-fail', pokemon, 'move: Aura Wheel');
+			this.add('-fail', source, 'move: Aura Wheel');
 			this.hint("Only a Pokemon whose form is Morpeko or Morpeko-Hangry can use this move.");
 			return null;
 		},
@@ -774,9 +774,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {snatch: 1},
 		sideCondition: 'auroraveil',
-		onTry(pokemon) {
+		onTry(source) {
 			if (!this.field.isWeather('hail')) {
-				this.add('-fail', pokemon);
+				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -2186,9 +2186,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {snatch: 1, sound: 1, dance: 1},
-		onTry(pokemon) {
-			if (pokemon.hp <= (pokemon.maxhp * 33 / 100) || pokemon.maxhp === 1) {
-				this.add('-fail', pokemon);
+		onTry(source) {
+			if (source.hp <= (source.maxhp * 33 / 100) || source.maxhp === 1) {
+				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -2768,9 +2768,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 3,
 		flags: {},
 		sideCondition: 'craftyshield',
-		onTry(pokemon) {
+		onTry(source) {
 			if (!!this.queue.willAct() === false) {
-				this.add('-fail', pokemon);
+				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -2983,11 +2983,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1},
 		status: 'slp',
-		onTry(pokemon, target, move) {
-			if (pokemon.species.name === 'Darkrai' || move.hasBounced) {
+		onTry(source, target, move) {
+			if (source.species.name === 'Darkrai' || move.hasBounced) {
 				return;
 			}
-			this.add('-fail', pokemon, 'move: Dark Void');
+			this.add('-fail', source, 'move: Dark Void');
 			this.hint("Only a Pokemon whose form is Darkrai can use this move.");
 			return null;
 		},
@@ -4592,10 +4592,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 3,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		onTry(pokemon) {
-			if (pokemon.activeMoveActions > 1) {
+		onTry(source) {
+			if (source.activeMoveActions > 1) {
 				this.attrLastMove('[still]');
-				this.add('-fail', pokemon);
+				this.add('-fail', source);
 				this.hint("Fake Out only works on your first turn out.");
 				return null;
 			}
@@ -4948,10 +4948,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 2,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		onTry(pokemon) {
-			if (pokemon.activeMoveActions > 1) {
+		onTry(source) {
+			if (source.activeMoveActions > 1) {
 				this.attrLastMove('[still]');
-				this.add('-fail', pokemon);
+				this.add('-fail', source);
 				this.hint("First Impression only works on your first turn out.");
 				return null;
 			}
@@ -5507,9 +5507,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 2,
 		flags: {},
 		volatileStatus: 'followme',
-		onTry(pokemon) {
+		onTry(source) {
 			if (pokemon.side.active.length < 2) {
-				this.add('-fail', pokemon);
+				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -8579,14 +8579,14 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {mirror: 1, authentic: 1},
 		breaksProtect: true,
-		onTry(pokemon) {
-			if (pokemon.species.name === 'Hoopa-Unbound') {
+		onTry(source) {
+			if (source.species.name === 'Hoopa-Unbound') {
 				return;
 			}
 			this.hint("Only a Pokemon whose form is Hoopa Unbound can use this move.");
-			if (pokemon.species.name === 'Hoopa') {
+			if (source.species.name === 'Hoopa') {
 				this.attrLastMove('[still]');
-				this.add('-fail', pokemon, 'move: Hyperspace Fury', '[forme]');
+				this.add('-fail', source, 'move: Hyperspace Fury', '[forme]');
 				return null;
 			}
 			this.attrLastMove('[still]');
@@ -9395,10 +9395,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		onTry(pokemon) {
+		onTry(source) {
 			let hasLastResort = false; // User must actually have Last Resort for it to succeed
 			let hasUsedAllMoves = true;
-			for (const moveSlot of pokemon.moveSlots) {
+			for (const moveSlot of source.moveSlots) {
 				if (moveSlot.id === 'lastresort') {
 					hasLastResort = true;
 					continue;
@@ -9407,9 +9407,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 			}
 
 			// Last Resort also fails unless the user knows at least 2 moves
-			if (pokemon.moveSlots.length < 2 || !hasLastResort || !hasUsedAllMoves) {
+			if (source.moveSlots.length < 2 || !hasLastResort || !hasUsedAllMoves) {
 				this.attrLastMove('[still]');
-				this.add('-fail', pokemon);
+				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -10232,15 +10232,15 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {snatch: 1, nonsky: 1},
 		stallingMove: true,
 		sideCondition: 'matblock',
-		onTry(pokemon) {
-			if (pokemon.activeMoveActions > 1) {
+		onTry(source) {
+			if (source.activeMoveActions > 1) {
 				this.hint("Mat Block only works on your first turn out.");
-				this.add('-fail', pokemon);
+				this.add('-fail', source);
 				return false;
 			}
-			
+
 			if (!!this.queue.willAct() === false) {
-				this.add('-fail', pokemon);
+				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -13539,9 +13539,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 3,
 		flags: {snatch: 1},
 		sideCondition: 'quickguard',
-		onTry(pokemon) {
+		onTry(source) {
 			if (!!this.queue.willAct() === false) {
-				this.add('-fail', pokemon);
+				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -13642,9 +13642,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 2,
 		flags: {powder: 1},
 		volatileStatus: 'ragepowder',
-		onTry(pokemon) {
-			if (pokemon.side.active.length < 2) {
-				this.add('-fail', pokemon);
+		onTry(source) {
+			if (source.side.active.length < 2) {
+				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -13964,17 +13964,17 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {snatch: 1, heal: 1},
-		onTry(pokemon) {
-			if (pokemon.status === 'slp' || pokemon.hasAbility('comatose')) {
-				this.add('-fail', pokemon);
+		onTry(source) {
+			if (source.status === 'slp' || source.hasAbility('comatose')) {
+				this.add('-fail', source);
 				return false;
 			}
-			if (pokemon.hp === pokemon.maxhp) {
-				this.add('-fail', pokemon, 'heal');
+			if (source.hp === source.maxhp) {
+				this.add('-fail', source, 'heal');
 				return null;
 			}
-			if (pokemon.hasAbility(['insomnia', 'vitalspirit'])) {
-				this.add('-fail', pokemon, '[from] ability: ' + pokemon.ability, '[of] ' + pokemon);
+			if (source.hasAbility(['insomnia', 'vitalspirit'])) {
+				this.add('-fail', source, '[from] ability: ' + source.getAbility().name, '[of] ' + source);
 				return null;
 			}
 		},
@@ -15742,10 +15742,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {},
 		sleepUsable: true,
-		onTry(pokemon) {
-			if (pokemon.status !== 'slp' && !pokemon.hasAbility('comatose')) {
+		onTry(source) {
+			if (source.status !== 'slp' && !source.hasAbility('comatose')) {
 				this.attrLastMove('[still]');
-				this.add('-fail', pokemon);
+				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -16037,10 +16037,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1, sound: 1, authentic: 1},
 		sleepUsable: true,
-		onTry(pokemon) {
-			if (pokemon.status !== 'slp' && !pokemon.hasAbility('comatose')) {
+		onTry(source) {
+			if (source.status !== 'slp' && !source.hasAbility('comatose')) {
 				this.attrLastMove('[still]');
-				this.add('-fail', pokemon);
+				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -16488,10 +16488,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1},
-		onTry(pokemon) {
-			if (!pokemon.volatiles['stockpile']) {
+		onTry(source) {
+			if (!source.volatiles['stockpile']) {
 				this.attrLastMove('[still]');
-				this.add('-fail', pokemon);
+				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -16729,10 +16729,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		onTry() {
+		onTry(source) {
 			if (this.field.isTerrain('')) {
 				this.attrLastMove('[still]');
-				this.add('-fail', pokemon);
+				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -16800,9 +16800,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 20,
 		priority: 0,
 		flags: {snatch: 1},
-		onTry(pokemon) {
-			if (pokemon.volatiles['stockpile'] && pokemon.volatiles['stockpile'].layers >= 3) {
-				this.add('-fail', pokemon);
+		onTry(source) {
+			if (source.volatiles['stockpile'] && source.volatiles['stockpile'].layers >= 3) {
+				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -17392,9 +17392,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {snatch: 1, heal: 1},
-		onTry(pokemon) {
-			if (!pokemon.volatiles['stockpile'] || !pokemon.volatiles['stockpile'].layers) {
-				this.add('-fail', pokemon);
+		onTry(source) {
+			if (!source.volatiles['stockpile'] || !source.volatiles['stockpile'].layers) {
+				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -19276,9 +19276,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 3,
 		flags: {snatch: 1},
 		sideCondition: 'wideguard',
-		onTry(pokemon) {
+		onTry(source) {
 			if (!!this.queue.willAct() === false) {
-				this.add('-fail', pokemon);
+				this.add('-fail', source);
 				return false;
 			}
 		},

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -5508,7 +5508,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {},
 		volatileStatus: 'followme',
 		onTry(source) {
-			if (pokemon.side.active.length < 2) {
+			if (source.side.active.length < 2) {
 				this.add('-fail', source);
 				return false;
 			}

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -15996,8 +15996,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1, sound: 1, authentic: 1},
 		sleepUsable: true,
-		onTry(target, source) {
-			if (source.status !== 'slp' && !source.hasAbility('comatose')) return false;
+		onTry(target) {
+			if (target.status !== 'slp' && !target.hasAbility('comatose')) return false;
 		},
 		secondary: {
 			chance: 30,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -774,11 +774,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {snatch: 1},
 		sideCondition: 'auroraveil',
-		onTry(source) {
-			if (!this.field.isWeather('hail')) {
-				this.add('-fail', source);
-				return false;
-			}
+		onTry() {
+			return this.field.isWeather('hail');
 		},
 		condition: {
 			duration: 5,
@@ -2188,7 +2185,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {snatch: 1, sound: 1, dance: 1},
 		onTry(source) {
 			if (source.hp <= (source.maxhp * 33 / 100) || source.maxhp === 1) {
-				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -2768,11 +2764,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 3,
 		flags: {},
 		sideCondition: 'craftyshield',
-		onTry(source) {
-			if (!!this.queue.willAct() === false) {
-				this.add('-fail', source);
-				return false;
-			}
+		onTry() {
+			return !!this.queue.willAct();
 		},
 		condition: {
 			duration: 1,
@@ -5508,10 +5501,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {},
 		volatileStatus: 'followme',
 		onTry(source) {
-			if (source.side.active.length < 2) {
-				this.add('-fail', source);
-				return false;
-			}
+			return source.side.active.length > 1;
 		},
 		condition: {
 			duration: 1,
@@ -9397,22 +9387,16 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
 		onTry(source) {
+			if (source.moveSlots.length < 2) return false; // Last Resort fails unless the user knows at least 2 moves
 			let hasLastResort = false; // User must actually have Last Resort for it to succeed
-			let hasUsedAllMoves = true;
 			for (const moveSlot of source.moveSlots) {
 				if (moveSlot.id === 'lastresort') {
 					hasLastResort = true;
 					continue;
 				}
-				if (!moveSlot.used) hasUsedAllMoves = false;
+				if (!moveSlot.used) return false;
 			}
-
-			// Last Resort also fails unless the user knows at least 2 moves
-			if (source.moveSlots.length < 2 || !hasLastResort || !hasUsedAllMoves) {
-				this.attrLastMove('[still]');
-				this.add('-fail', source);
-				return false;
-			}
+			return hasLastResort;
 		},
 		secondary: null,
 		target: "normal",
@@ -10132,7 +10116,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 		volatileStatus: 'magnetrise',
 		onTry(source, target, move) {
 			if (target.volatiles['smackdown'] || target.volatiles['ingrain']) {
-				this.add('-fail', source);
 				return false;
 			}
 
@@ -10236,14 +10219,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		onTry(source) {
 			if (source.activeMoveActions > 1) {
 				this.hint("Mat Block only works on your first turn out.");
-				this.add('-fail', source);
 				return false;
 			}
-
-			if (!!this.queue.willAct() === false) {
-				this.add('-fail', source);
-				return false;
-			}
+			return !!this.queue.willAct();
 		},
 		condition: {
 			duration: 1,
@@ -11943,7 +11921,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 		volatileStatus: 'noretreat',
 		onTry(source, target, move) {
 			if (target.volatiles['noretreat']) {
-				this.add('-fail', source);
 				return false;
 			}
 			if (target.volatiles['trapped']) {
@@ -12753,11 +12730,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
 		onTry(source, target) {
-			if (!target.item) {
-				this.attrLastMove('[still]');
-				this.add('-fail', source);
-				return false;
-			}
+			return !!target.item;
 		},
 		onTryHit(target, source, move) {
 			this.add('-activate', target, 'move: Poltergeist', this.dex.getItem(target.item).name);
@@ -13541,10 +13514,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {snatch: 1},
 		sideCondition: 'quickguard',
 		onTry(source) {
-			if (!!this.queue.willAct() === false) {
-				this.add('-fail', source);
-				return false;
-			}
+			return !!this.queue.willAct();
 		},
 		onHitSide(side, source) {
 			source.addVolatile('stall');
@@ -13644,10 +13614,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {powder: 1},
 		volatileStatus: 'ragepowder',
 		onTry(source) {
-			if (source.side.active.length < 2) {
-				this.add('-fail', source);
-				return false;
-			}
+			return source.side.active.length > 1;
 		},
 		condition: {
 			duration: 1,
@@ -13967,7 +13934,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {snatch: 1, heal: 1},
 		onTry(source) {
 			if (source.status === 'slp' || source.hasAbility('comatose')) {
-				this.add('-fail', source);
 				return false;
 			}
 			if (source.hp === source.maxhp) {
@@ -15569,10 +15535,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			}
 		},
 		onTry(source, target) {
-			if (target.fainted) {
-				this.add('-fail', source);
-				return false;
-			}
+			return !target.fainted;
 		},
 		onTryHit(target, source, move) {
 			if (source.removeVolatile(move.id)) {
@@ -15745,8 +15708,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 		sleepUsable: true,
 		onTry(source) {
 			if (source.status !== 'slp' && !source.hasAbility('comatose')) {
-				this.attrLastMove('[still]');
-				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -16040,8 +16001,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 		sleepUsable: true,
 		onTry(source) {
 			if (source.status !== 'slp' && !source.hasAbility('comatose')) {
-				this.attrLastMove('[still]');
-				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -16490,11 +16449,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1},
 		onTry(source) {
-			if (!source.volatiles['stockpile']) {
-				this.attrLastMove('[still]');
-				this.add('-fail', source);
-				return false;
-			}
+			return !!source.volatiles['stockpile'];
 		},
 		onAfterMove(pokemon) {
 			pokemon.removeVolatile('stockpile');
@@ -16730,12 +16685,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		onTry(source) {
-			if (this.field.isTerrain('')) {
-				this.attrLastMove('[still]');
-				this.add('-fail', source);
-				return false;
-			}
+		onTry() {
+			return !this.field.isTerrain('');
 		},
 		onHit() {
 			this.field.clearTerrain();
@@ -16803,7 +16754,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {snatch: 1},
 		onTry(source) {
 			if (source.volatiles['stockpile'] && source.volatiles['stockpile'].layers >= 3) {
-				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -17079,7 +17029,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 			if (item.isBerry && source.eatItem(true)) {
 				this.boost({def: 2}, source, null, null, false, true);
 			} else {
-				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -17224,9 +17173,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			const action = this.queue.willMove(target);
 			const move = action?.choice === 'move' ? action.move : null;
 			if (!move || (move.category === 'Status' && move.id !== 'mefirst') || target.volatiles['mustrecharge']) {
-				this.add('-fail', source);
-				this.attrLastMove('[still]');
-				return null;
+				return false;
 			}
 		},
 		secondary: null,
@@ -17395,7 +17342,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {snatch: 1, heal: 1},
 		onTry(source) {
 			if (!source.volatiles['stockpile'] || !source.volatiles['stockpile'].layers) {
-				this.add('-fail', source);
 				return false;
 			}
 		},
@@ -19278,10 +19224,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {snatch: 1},
 		sideCondition: 'wideguard',
 		onTry(source) {
-			if (!!this.queue.willAct() === false) {
-				this.add('-fail', source);
-				return false;
-			}
+			return !!this.queue.willAct();
 		},
 		onHitSide(side, source) {
 			source.addVolatile('stall');

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -7294,7 +7294,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 					return false;
 				}
 			},
-
 			onResidualOrder: 22,
 			onEnd() {
 				this.add('-fieldend', 'move: Gravity');

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -7286,7 +7286,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			// groundedness implemented in battle.engine.js:BattlePokemon#isGrounded
 			onBeforeMovePriority: 6,
 			onBeforeMove(pokemon, target, move) {
-				if (move.flags['gravity']) {
+				if (move.flags['gravity'] && !move.isZ) {
 					this.add('cant', pokemon, 'move: Gravity', move);
 					return false;
 				}
@@ -10108,6 +10108,13 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {snatch: 1, gravity: 1},
 		volatileStatus: 'magnetrise',
+		onTry(source, target, move) {
+			// Additional Gravity check for Z-move variant
+			if (this.field.getPseudoWeather('Gravity')) {
+				this.add('cant', source, 'move: Gravity', move);
+				return false;
+			}
+		},
 		condition: {
 			duration: 5,
 			onStart(target) {
@@ -16470,6 +16477,13 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 40,
 		priority: 0,
 		flags: {gravity: 1},
+		onTry(source, target, move) {
+			// Additional Gravity check for Z-move variant
+			if (this.field.getPseudoWeather('Gravity')) {
+				this.add('cant', source, 'move: Gravity', move);
+				return false;
+			}
+		},
 		onTryHit(target, source) {
 			this.add('-nothing');
 		},
@@ -16809,7 +16823,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		accuracy: 100,
 		basePower: 75,
 		basePowerCallback(pokemon, target, move) {
-			if (pokemon.moveLastTurnResult === false) return move.basePower * 2;
+			if (pokemon.moveLastTurnResult === false) {
+				this.debug('doubling Stomping Tantrum BP due to previous move failure');
+				return move.basePower * 2;
+			}
 			return move.basePower;
 		},
 		category: "Physical",
@@ -17789,6 +17806,13 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1, gravity: 1, mystery: 1},
 		volatileStatus: 'telekinesis',
+		onTry(source, target, move) {
+			// Additional Gravity check for Z-move variant
+			if (this.field.getPseudoWeather('Gravity')) {
+				this.add('cant', source, 'move: Gravity', move);
+				return false;
+			}
+		},
 		condition: {
 			duration: 3,
 			onStart(target) {

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2184,9 +2184,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {snatch: 1, sound: 1, dance: 1},
 		onTry(source) {
-			if (source.hp <= (source.maxhp * 33 / 100) || source.maxhp === 1) {
-				return false;
-			}
+			if (source.hp <= (source.maxhp * 33 / 100) || source.maxhp === 1) return false;
 		},
 		onTryHit(pokemon, target, move) {
 			if (!this.boost(move.boosts as SparseBoostsTable)) return null;
@@ -4587,10 +4585,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {contact: 1, protect: 1, mirror: 1},
 		onTry(source) {
 			if (source.activeMoveActions > 1) {
-				this.attrLastMove('[still]');
-				this.add('-fail', source);
 				this.hint("Fake Out only works on your first turn out.");
-				return null;
+				return false;
 			}
 		},
 		secondary: {
@@ -4943,10 +4939,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {contact: 1, protect: 1, mirror: 1},
 		onTry(source) {
 			if (source.activeMoveActions > 1) {
-				this.attrLastMove('[still]');
-				this.add('-fail', source);
 				this.hint("First Impression only works on your first turn out.");
-				return null;
+				return false;
 			}
 		},
 		secondary: null,
@@ -10114,9 +10108,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {snatch: 1, gravity: 1},
 		volatileStatus: 'magnetrise',
 		onTry(source, target, move) {
-			if (target.volatiles['smackdown'] || target.volatiles['ingrain']) {
-				return false;
-			}
+			if (target.volatiles['smackdown'] || target.volatiles['ingrain']) return false;
 
 			// Additional Gravity check for Z-move variant
 			if (this.field.getPseudoWeather('Gravity')) {
@@ -11919,10 +11911,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {snatch: 1},
 		volatileStatus: 'noretreat',
 		onTry(source, target, move) {
-			if (target.volatiles['noretreat']) {
-				return false;
-			}
-			if (target.volatiles['trapped']) {
+			if (source.volatiles['noretreat']) return false;
+			if (source.volatiles['trapped']) {
 				delete move.volatileStatus;
 			}
 		},
@@ -13512,7 +13502,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 3,
 		flags: {snatch: 1},
 		sideCondition: 'quickguard',
-		onTry(source) {
+		onTry() {
 			return !!this.queue.willAct();
 		},
 		onHitSide(side, source) {
@@ -13932,9 +13922,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {snatch: 1, heal: 1},
 		onTry(source) {
-			if (source.status === 'slp' || source.hasAbility('comatose')) {
-				return false;
-			}
+			if (source.status === 'slp' || source.hasAbility('comatose')) return false;
+			
 			if (source.hp === source.maxhp) {
 				this.add('-fail', source, 'heal');
 				return null;
@@ -15706,9 +15695,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {},
 		sleepUsable: true,
 		onTry(source) {
-			if (source.status !== 'slp' && !source.hasAbility('comatose')) {
-				return false;
-			}
+			return source.status === 'slp' || source.hasAbility('comatose');
 		},
 		onHit(pokemon) {
 			const noSleepTalk = [
@@ -15999,9 +15986,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {protect: 1, mirror: 1, sound: 1, authentic: 1},
 		sleepUsable: true,
 		onTry(source) {
-			if (source.status !== 'slp' && !source.hasAbility('comatose')) {
-				return false;
-			}
+			return source.status === 'slp' || source.hasAbility('comatose');
 		},
 		secondary: {
 			chance: 30,
@@ -16752,9 +16737,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {snatch: 1},
 		onTry(source) {
-			if (source.volatiles['stockpile'] && source.volatiles['stockpile'].layers >= 3) {
-				return false;
-			}
+			if (source.volatiles['stockpile'] && source.volatiles['stockpile'].layers >= 3) return false;
 		},
 		volatileStatus: 'stockpile',
 		condition: {
@@ -17340,9 +17323,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {snatch: 1, heal: 1},
 		onTry(source) {
-			if (!source.volatiles['stockpile'] || !source.volatiles['stockpile'].layers) {
-				return false;
-			}
+			return !!source.volatiles['stockpile'];
 		},
 		onHit(pokemon) {
 			const healAmount = [0.25, 0.5, 1];
@@ -19222,7 +19203,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 3,
 		flags: {snatch: 1},
 		sideCondition: 'wideguard',
-		onTry(source) {
+		onTry() {
 			return !!this.queue.willAct();
 		},
 		onHitSide(side, source) {

--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -572,11 +572,16 @@ export const Scripts: BattleScriptsData = {
 	tryMoveHit(target, pokemon, move) {
 		this.setActiveMove(move, pokemon, target);
 
-		if (!this.singleEvent('Try', move, null, pokemon, target, move)) {
+		let hitResult = this.singleEvent('Try', move, null, pokemon, target, move);
+		if (!hitResult) {
+			if (hitResult === false) {
+				this.add('-fail', pokemon);
+				this.attrLastMove('[still]');
+			}
 			return false;
 		}
 
-		let hitResult = this.singleEvent('PrepareHit', move, {}, target, pokemon, move);
+		hitResult = this.singleEvent('PrepareHit', move, {}, target, pokemon, move);
 		if (!hitResult) {
 			if (hitResult === false) {
 				this.add('-fail', pokemon);

--- a/test/sim/abilities/comatose.js
+++ b/test/sim/abilities/comatose.js
@@ -39,14 +39,15 @@ describe('Comatose', function () {
 		assert.constant(() => comatoseMon.status, () => battle.makeChoices('move rest', 'move aquajet'));
 	});
 
-	it('should allow the use of Snore and Sleep Talk as if the user were asleep', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Komala", ability: 'comatose', moves: ['snore', 'sleeptalk', 'brickbreak']}]});
-		battle.setPlayer('p2', {team: [{species: "Smeargle", ability: 'technician', moves: ['endure']}]});
+	it.only('should allow the use of Snore and Sleep Talk as if the user were asleep', function () {
+		battle = common.createBattle([[
+			{species: "Komala", item: 'normaliumz', ability: 'comatose', moves: ['snore', 'sleeptalk', 'brickbreak']},
+		], [
+			{species: "Smeargle", moves: ['endure']},
+		]]);
 		const defender = battle.p2.active[0];
-		for (let i = 1; i <= 2; i++) {
-			assert.hurts(defender, () => battle.makeChoices('move ' + i, 'move endure'));
-		}
+		assert.hurts(defender, () => battle.makeChoices('move snore', 'move endure'), "Expected damage from Snore.");
+		assert.hurts(defender, () => battle.makeChoices('move sleeptalk', 'move endure'), "Expected damage from Sleep Talk calling Brick Break.");
 	});
 
 	it('should cause the user to be damaged by Dream Eater as if it were asleep', function () {

--- a/test/sim/abilities/comatose.js
+++ b/test/sim/abilities/comatose.js
@@ -39,7 +39,7 @@ describe('Comatose', function () {
 		assert.constant(() => comatoseMon.status, () => battle.makeChoices('move rest', 'move aquajet'));
 	});
 
-	it.only('should allow the use of Snore and Sleep Talk as if the user were asleep', function () {
+	it('should allow the use of Snore and Sleep Talk as if the user were asleep', function () {
 		battle = common.createBattle([[
 			{species: "Komala", item: 'normaliumz', ability: 'comatose', moves: ['snore', 'sleeptalk', 'brickbreak']},
 		], [

--- a/test/sim/abilities/protean.js
+++ b/test/sim/abilities/protean.js
@@ -10,12 +10,16 @@ describe('Protean', function () {
 		battle.destroy();
 	});
 
-	it('should change the user\'s type when using a move', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Cinderace", ability: 'protean', moves: ['highjumpkick']}]});
-		battle.setPlayer('p2', {team: [{species: "Gengar", moves: ['sleeptalk']}]});
-		battle.makeChoices('move highjumpkick', 'move sleeptalk');
-		assert(battle.p1.active[0].hasType('Fighting'));
+	it(`should change the user's type when using a move`, function () {
+		battle = common.createBattle([[
+			{species: "Cinderace", ability: 'protean', moves: ['highjumpkick']},
+		], [
+			{species: "Gengar", moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		const cinder = battle.p1.active[0];
+		assert(cinder.hasType('Fighting'));
 	});
 
 	it.skip(`should activate on both turns of a charge move`, function () {
@@ -28,18 +32,90 @@ describe('Protean', function () {
 
 		//Turn 1 of Bounce
 		battle.makeChoices();
-		assert.equal(wynaut.getTypes().join('/'), 'Flying');
+		assert(wynaut.hasType('Flying'));
 
 		//Turn 2 of Bounce
 		battle.makeChoices();
-		assert.equal(wynaut.getTypes().join('/'), 'Flying');
+		assert(wynaut.hasType('Flying'));
 	});
 
-	it('should not change the user\'s type when using Fling with no item', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Kecleon", ability: 'protean', moves: ['fling']}]});
-		battle.setPlayer('p2', {team: [{species: "Wobbuffet", moves: ['counter']}]});
-		battle.makeChoices('move fling', 'move counter');
-		assert(battle.p1.active[0].hasType('Normal'));
+	it(`should not change the user's type when using moves that fail earlier than Protean will activate`, function () {
+		battle = common.createBattle([[
+			{species: "Kecleon", ability: 'protean', moves: ['fling', 'suckerpunch', 'steelroller', 'aurawheel']},
+			{species: "Kecleon", ability: 'protean', moves: ['magnetrise', 'ingrain', 'burnup', 'auroraveil']},
+		], [
+			{species: "Wynaut", moves: ['sleeptalk']},
+		]]);
+
+		let kecleon = battle.p1.active[0];
+
+		// Fling with no item
+		battle.makeChoices('move fling', 'move sleeptalk');
+		assert(kecleon.hasType('Normal'), "Fling changed the user's type when it should not have.");
+
+		// Sucker Punch into status move
+		battle.makeChoices('move suckerpunch', 'move sleeptalk');
+		assert(kecleon.hasType('Normal'), "Sucker Punch changed the user's type when it should not have.");
+
+		// Steel Roller with no Terrain active
+		battle.makeChoices('move steelroller', 'move sleeptalk');
+		assert(kecleon.hasType('Normal'), "Steel Roller changed the user's type when it should not have.");
+
+		// Aura Wheel when user is not Morpeko
+		battle.makeChoices('move aurawheel', 'move sleeptalk');
+		assert(kecleon.hasType('Normal'), "Aura Wheel changed the user's type when it should not have.");
+
+		battle.makeChoices('switch 2', 'move sleeptalk');
+		kecleon = battle.p1.active[0];
+
+		// Burn Up when user is not Fire-type
+		battle.makeChoices('move burnup', 'move sleeptalk');
+		assert(kecleon.hasType('Normal'), "Burn Up changed the user's type when it should not have.");
+
+		// Aurora Veil when hail is not active
+		battle.makeChoices('move auroraveil', 'move sleeptalk');
+		assert(kecleon.hasType('Normal'), "Aurora Veil changed the user's type when it should not have.");
+
+		// Magnet Rise when user has Ingrain; note that Kecleon becomes Grass-type from Ingrain
+		battle.makeChoices('move ingrain', 'move sleeptalk');
+		battle.makeChoices('move magnetrise', 'move sleeptalk');
+		assert(kecleon.hasType('Grass'), "Magnet Rise changed the user's type when it should not have.");
+
+		// More examples: https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/post-8548957
+	});
+
+	it(`should not change the user's type when abilities that fail earlier than Protean will activate`, function () {
+		battle = common.createBattle([[
+			{species: "Kecleon", ability: 'protean', moves: ['aquajet', 'mindblown']},
+		], [
+			{species: "Kyogre", ability: 'primordialsea', moves: ['sleeptalk']},
+			{species: "Groudon", ability: 'desolateland', moves: ['powder']},
+			{species: "Tsareena", ability: 'dazzling', moves: ['sleeptalk']},
+			{species: "Golduck", ability: 'damp', moves: ['sleeptalk']},
+		]]);
+
+		const kecleon = battle.p1.active[0];
+
+		// Primordial Sea
+		battle.makeChoices('move mindblown', 'move sleeptalk');
+		assert(kecleon.hasType('Normal'), "Primordial Sea changed the user's type when it should not have.");
+
+		// Desolate Land
+		battle.makeChoices('move aquajet', 'switch 2');
+		assert(kecleon.hasType('Normal'), "Desolate Land changed the user's type when it should not have.");
+
+		// Powder
+		battle.makeChoices('move mindblown', 'move powder');
+		assert(kecleon.hasType('Normal'), "Powder changed the user's type when it should not have.");
+
+		// Dazzling
+		battle.makeChoices('move aquajet', 'switch 3');
+		assert(kecleon.hasType('Normal'), "Dazzling changed the user's type when it should not have.");
+
+		// Damp
+		battle.makeChoices('move mindblown', 'switch 4');
+		assert(kecleon.hasType('Normal'), "Damp changed the user's type when it should not have.");
+
+		// More examples: https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/post-8548957
 	});
 });

--- a/test/sim/abilities/protean.js
+++ b/test/sim/abilities/protean.js
@@ -51,40 +51,40 @@ describe('Protean', function () {
 
 		// Fling with no item
 		battle.makeChoices('move fling', 'move sleeptalk');
-		assert(kecleon.hasType('Normal'), "Fling changed the user's type when it should not have.");
+		assert(kecleon.hasType('Normal'), "Protean + Fling changed the user's type when it should not have.");
 
 		// Sucker Punch into status move
 		battle.makeChoices('move suckerpunch', 'move sleeptalk');
-		assert(kecleon.hasType('Normal'), "Sucker Punch changed the user's type when it should not have.");
+		assert(kecleon.hasType('Normal'), "Protean + Sucker Punch changed the user's type when it should not have.");
 
 		// Steel Roller with no Terrain active
 		battle.makeChoices('move steelroller', 'move sleeptalk');
-		assert(kecleon.hasType('Normal'), "Steel Roller changed the user's type when it should not have.");
+		assert(kecleon.hasType('Normal'), "Protean + Steel Roller changed the user's type when it should not have.");
 
 		// Aura Wheel when user is not Morpeko
 		battle.makeChoices('move aurawheel', 'move sleeptalk');
-		assert(kecleon.hasType('Normal'), "Aura Wheel changed the user's type when it should not have.");
+		assert(kecleon.hasType('Normal'), "Protean + Aura Wheel changed the user's type when it should not have.");
 
 		battle.makeChoices('switch 2', 'move sleeptalk');
 		kecleon = battle.p1.active[0];
 
 		// Burn Up when user is not Fire-type
 		battle.makeChoices('move burnup', 'move sleeptalk');
-		assert(kecleon.hasType('Normal'), "Burn Up changed the user's type when it should not have.");
+		assert(kecleon.hasType('Normal'), "Protean + Burn Up changed the user's type when it should not have.");
 
 		// Aurora Veil when hail is not active
 		battle.makeChoices('move auroraveil', 'move sleeptalk');
-		assert(kecleon.hasType('Normal'), "Aurora Veil changed the user's type when it should not have.");
+		assert(kecleon.hasType('Normal'), "Protean + Aurora Veil changed the user's type when it should not have.");
 
 		// Magnet Rise when user has Ingrain; note that Kecleon becomes Grass-type from Ingrain
 		battle.makeChoices('move ingrain', 'move sleeptalk');
 		battle.makeChoices('move magnetrise', 'move sleeptalk');
-		assert(kecleon.hasType('Grass'), "Magnet Rise changed the user's type when it should not have.");
+		assert(kecleon.hasType('Grass'), "Protean + Magnet Rise changed the user's type when it should not have.");
 
 		// More examples: https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/post-8548957
 	});
 
-	it(`should not change the user's type when abilities that fail earlier than Protean will activate`, function () {
+	it(`should not change the user's type when abilities that activate earlier than Protean will cause the user's moves to fail`, function () {
 		battle = common.createBattle([[
 			{species: "Kecleon", ability: 'protean', moves: ['aquajet', 'mindblown']},
 		], [
@@ -98,23 +98,23 @@ describe('Protean', function () {
 
 		// Primordial Sea
 		battle.makeChoices('move mindblown', 'move sleeptalk');
-		assert(kecleon.hasType('Normal'), "Primordial Sea changed the user's type when it should not have.");
+		assert(kecleon.hasType('Normal'), "Protean + Primordial Sea changed the user's type when it should not have.");
 
 		// Desolate Land
 		battle.makeChoices('move aquajet', 'switch 2');
-		assert(kecleon.hasType('Normal'), "Desolate Land changed the user's type when it should not have.");
+		assert(kecleon.hasType('Normal'), "Protean + Desolate Land changed the user's type when it should not have.");
 
 		// Powder
 		battle.makeChoices('move mindblown', 'move powder');
-		assert(kecleon.hasType('Normal'), "Powder changed the user's type when it should not have.");
+		assert(kecleon.hasType('Normal'), "Protean + Powder changed the user's type when it should not have.");
 
 		// Dazzling
 		battle.makeChoices('move aquajet', 'switch 3');
-		assert(kecleon.hasType('Normal'), "Dazzling changed the user's type when it should not have.");
+		assert(kecleon.hasType('Normal'), "Protean + Dazzling changed the user's type when it should not have.");
 
 		// Damp
 		battle.makeChoices('move mindblown', 'switch 4');
-		assert(kecleon.hasType('Normal'), "Damp changed the user's type when it should not have.");
+		assert(kecleon.hasType('Normal'), "Protean + Damp changed the user's type when it should not have.");
 
 		// More examples: https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/post-8548957
 	});

--- a/test/sim/moves/followme.js
+++ b/test/sim/moves/followme.js
@@ -49,4 +49,21 @@ describe('Follow Me', function () {
 		assert.equal(battle.p2.active[0].boosts['atk'], 1);
 		assert.equal(battle.p2.active[1].boosts['atk'], 1);
 	});
+
+	it(`should allow redirection even if the user is the last slot of a double battle`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: "Wynaut", moves: ['sleeptalk', 'tackle']},
+			{species: "Wynaut", moves: ['sleeptalk', 'tackle']},
+		], [
+			{species: "Accelgor", moves: ['finalgambit']},
+			{species: "Blissey", moves: ['sleeptalk', 'followme']},
+		]]);
+
+		battle.makeChoices('auto', 'move final gambit -2, move sleeptalk');
+		battle.makeChoices('move tackle -2, move tackle -1', 'move followme');
+
+		// Follow Me should have redirected both attacks, so the Wynaut should be at full HP
+		assert.fullHP(battle.p1.active[0]);
+		assert.fullHP(battle.p1.active[1]);
+	});
 });

--- a/test/sim/moves/gravity.js
+++ b/test/sim/moves/gravity.js
@@ -34,4 +34,17 @@ describe('Gravity', function () {
 		assert(!battle.p2.active[0].volatiles['twoturnmove']);
 		assert.cantMove(() => battle.makeChoices('move gravity', 'move fly'), 'Aerodactyl', 'Fly');
 	});
+
+	it('should allow the use of Z-moves of Gravity-blocked moves, but only apply their Z-effects', function () {
+		battle = common.gen(7).createBattle([[
+			{species: "Magikarp", ability: 'protean', item: 'normaliumz', moves: ['splash', 'sleeptalk']},
+		], [
+			{species: "Accelgor", moves: ['gravity']},
+		]]);
+
+		battle.makeChoices('move splash zmove', 'move gravity');
+		assert.statStage(battle.p1.active[0], 'atk', 3);
+		assert(battle.log.some(line => line.includes('|cant')));
+		assert(battle.p1.active[0].hasType('Water'), "Z-Splash with Protean changed the user's type when it should not have.");
+	});
 });

--- a/test/sim/moves/noretreat.js
+++ b/test/sim/moves/noretreat.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('No Retreat', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it(`should not allow usage multiple times in a row normally`, function () {
+		battle = common.createBattle([[
+			{species: "Wynaut", moves: ['noretreat']},
+		], [
+			{species: "Caterpie", moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		battle.makeChoices();
+
+		const wynaut = battle.p1.active[0];
+		assert.statStage(wynaut, 'atk', 1);
+	});
+
+	it(`should allow usage multiple times in a row normally if it has the trapped volatile`, function () {
+		battle = common.createBattle([[
+			{species: "Wynaut", moves: ['noretreat']},
+		], [
+			{species: "Caterpie", moves: ['block']},
+		]]);
+
+		battle.makeChoices();
+		battle.makeChoices();
+
+		const wynaut = battle.p1.active[0];
+		assert.statStage(wynaut, 'atk', 2);
+	});
+});

--- a/test/sim/moves/stompingtantrum.js
+++ b/test/sim/moves/stompingtantrum.js
@@ -87,4 +87,22 @@ describe('Stomping Tantrum', function () {
 		battle.makeChoices('move recharge', 'move sleeptalk');
 		battle.makeChoices('move stompingtantrum', 'move sleeptalk');
 	});
+
+	it('should cause Gravity-negated moves to double in BP, even Z-moves', function () {
+		battle = common.gen(7).createBattle([[
+			{species: "Magikarp", item: 'normaliumz', moves: ['splash', 'stompingtantrum']},
+		], [
+			{species: "Accelgor", moves: ['gravity']},
+		]]);
+
+		battle.onEvent('BasePower', battle.format, function (basePower, pokemon, target, move) {
+			if (move.id === 'stompingtantrum') assert.equal(basePower, 150);
+		});
+
+		battle.makeChoices('move splash', 'move gravity');
+		battle.makeChoices('move stomping tantrum', 'move gravity');
+
+		battle.makeChoices('move splash zmove', 'move gravity');
+		battle.makeChoices('move stomping tantrum', 'move gravity');
+	});
 });

--- a/test/sim/moves/stompingtantrum.js
+++ b/test/sim/moves/stompingtantrum.js
@@ -88,7 +88,7 @@ describe('Stomping Tantrum', function () {
 		battle.makeChoices('move stompingtantrum', 'move sleeptalk');
 	});
 
-	it.only('should cause Gravity-negated moves to double in BP, even Z-moves', function () {
+	it('should cause Gravity-negated moves to double in BP, even Z-moves', function () {
 		battle = common.gen(7).createBattle([[
 			{species: "Magikarp", item: 'normaliumz', moves: ['splash', 'stompingtantrum']},
 		], [
@@ -104,7 +104,5 @@ describe('Stomping Tantrum', function () {
 
 		battle.makeChoices('move splash zmove', 'move gravity');
 		battle.makeChoices('move stomping tantrum', 'move gravity');
-
-		console.log(battle.getDebugLog());
 	});
 });

--- a/test/sim/moves/stompingtantrum.js
+++ b/test/sim/moves/stompingtantrum.js
@@ -88,7 +88,7 @@ describe('Stomping Tantrum', function () {
 		battle.makeChoices('move stompingtantrum', 'move sleeptalk');
 	});
 
-	it('should cause Gravity-negated moves to double in BP, even Z-moves', function () {
+	it.only('should cause Gravity-negated moves to double in BP, even Z-moves', function () {
 		battle = common.gen(7).createBattle([[
 			{species: "Magikarp", item: 'normaliumz', moves: ['splash', 'stompingtantrum']},
 		], [
@@ -104,5 +104,7 @@ describe('Stomping Tantrum', function () {
 
 		battle.makeChoices('move splash zmove', 'move gravity');
 		battle.makeChoices('move stomping tantrum', 'move gravity');
+
+		console.log(battle.getDebugLog());
 	});
 });


### PR DESCRIPTION
Originally, I was just going to add a couple additional Protean tests on The Immortal's recommendation. Thanks to additional [USUM research](https://pastebin.com/bDtvxdT2), we now have a more complete list of what I call in the checks done before move success "[move failure checks part 1](https://docs.google.com/spreadsheets/d/1nn0b7Na9UEoE_NChLLlknV3ERacNeenV4TiMieTpS8U/edit#gid=0)". I just decided to implement it. The only new checks we learned about were:

- Aurora Veil without hail
- Splash / Magnet Rise / Telekinesis used in Gravity - this is why Z-Splash in Gravity boosts to +3 attack but still fails
- Teleport (pre-Gen 8)
- Magnet Rise when the user has Smack Down or Ingrain status
- Sky Drop if the thing it had picked up already fainted

However, Showdown was very inconsistent on how many of its effects were in onTry and onPrepareHit, which are what you need to be pre-Protean. I swapped most of these over and all the tests are passing, but this will definitely be a Marty thing to review.

The only ones I don't know how to do for sure are Counter, Mirror Coat, Metal Burst, and Bide. Their onTryHits don't seem to as easily be moved to onTry unless I'm missing something.

There's also a weird thing with the Protect checks where they do !!this.queue.willAct() and I think this is the "moved last in the turn" check but I'm not 100% sure.