### PR TITLE
Correct eslint.options.configFile for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
-    "editor.insertSpaces": false,
-    "typescript.tsdk": "node_modules/typescript/lib",
-    "javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,
-    "typescript.format.semicolons": "insert",
-    "eslint.options": {
-      "configFile": ".eslintrc-types.json",
-    }
+  "editor.insertSpaces": false,
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,
+  "typescript.format.semicolons": "insert",
+  "eslint.options": {
+    "configFile": ".eslintrc.json"
+  }
 }


### PR DESCRIPTION
Fixes the error in vscode for the ESLint Plugin:

Error: ENOENT: no such file or directory, open '******/pokemon-showdown/.eslintrc-types.json'
