### PR TITLE
Users: Don't give bots isStaff

### DIFF
--- a/server/users.ts
+++ b/server/users.ts
@@ -1068,7 +1068,8 @@ export class User extends Chat.MessageContext {
 		const groupInfo = Config.groups[this.tempGroup];
 		this.isStaff = !!(groupInfo && (groupInfo.lock || groupInfo.root));
 		if (!this.isStaff) {
-			this.isStaff = !!Rooms.get('staff')?.auth.has(this.id);
+			const rank = Rooms.get('staff')?.auth.get(this.id);
+			this.isStaff = !!(rank && rank !== '*');
 		}
 		if (this.trusted) {
 			if (this.locked && this.permalocked) {
@@ -1099,7 +1100,8 @@ export class User extends Chat.MessageContext {
 		const groupInfo = Config.groups[this.tempGroup];
 		this.isStaff = !!(groupInfo && (groupInfo.lock || groupInfo.root));
 		if (!this.isStaff) {
-			this.isStaff = !!Rooms.get('staff')?.auth.has(this.id);
+			const rank = Rooms.get('staff')?.auth.get(this.id);
+			this.isStaff = !!(rank && rank !== '*');
 		}
 		Rooms.global.checkAutojoin(this);
 		if (this.registered) {

--- a/server/users.ts
+++ b/server/users.ts
@@ -1069,7 +1069,7 @@ export class User extends Chat.MessageContext {
 		this.isStaff = !!(groupInfo && (groupInfo.lock || groupInfo.root));
 		if (!this.isStaff) {
 			const rank = Rooms.get('staff')?.auth.get(this.id);
-			this.isStaff = !!(rank && rank !== '*');
+			this.isStaff = !!(rank && rank !== '*' && rank !== Users.Auth.defaultSymbol());
 		}
 		if (this.trusted) {
 			if (this.locked && this.permalocked) {
@@ -1101,7 +1101,7 @@ export class User extends Chat.MessageContext {
 		this.isStaff = !!(groupInfo && (groupInfo.lock || groupInfo.root));
 		if (!this.isStaff) {
 			const rank = Rooms.get('staff')?.auth.get(this.id);
-			this.isStaff = !!(rank && rank !== '*');
+			this.isStaff = !!(rank && rank !== '*' && rank !== Users.Auth.defaultSymbol());
 		}
 		Rooms.global.checkAutojoin(this);
 		if (this.registered) {


### PR DESCRIPTION
Bots which are staff room bots are currently able to bypass filters, which is bad because they could be used to mail other users slurs.