### PR TITLE
Protean should affect the victim of Snatch rather than the user

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -1780,7 +1780,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	},
 	libero: {
 		onPrepareHit(source, target, move) {
-			if (move.hasBounced) return;
+			if (move.hasBounced || move.sourceEffect === 'snatch') return;
 			const type = move.type;
 			if (type && type !== '???' && source.getTypes().join() !== type) {
 				if (!source.setType(type)) return;
@@ -2770,7 +2770,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	},
 	protean: {
 		onPrepareHit(source, target, move) {
-			if (move.hasBounced) return;
+			if (move.hasBounced || move.sourceEffect === 'snatch') return;
 			const type = move.type;
 			if (type && type !== '???' && source.getTypes().join() !== type) {
 				if (!source.setType(type)) return;

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -295,7 +295,7 @@ export const Conditions: {[k: string]: ConditionData} = {
 		noCopy: true,
 		onStart(pokemon) {
 			if (!this.activeMove) throw new Error("Battle.activeMove is null");
-			if (!this.activeMove.id || this.activeMove.hasBounced) return false;
+			if (!this.activeMove.id || this.activeMove.hasBounced || this.activeMove.sourceEffect === 'snatch') return false;
 			this.effectData.move = this.activeMove.id;
 		},
 		onBeforeMove(pokemon, target, move) {

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -15953,7 +15953,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onStart(pokemon) {
 				this.add('-singleturn', pokemon, 'Snatch');
 			},
-			onAnyTryMove(source, target, move) {
+			onAnyPrepareHitPriority: -1,
+			onAnyPrepareHit(source, target, move) {
 				const snatchUser = this.effectData.source;
 				if (snatchUser.isSkyDropped()) return;
 				if (!move || move.isZ || move.isMax || !move.flags['snatch'] || move.sourceEffect === 'snatch') {

--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -337,7 +337,9 @@ export const Scripts: BattleScriptsData = {
 
 		this.setActiveMove(move, pokemon, targets[0]);
 
-		let hitResult = this.singleEvent('Try', move, null, pokemon, targets[0], move);
+		const hitResult = this.singleEvent('Try', move, null, pokemon, targets[0], move) &&
+			this.singleEvent('PrepareHit', move, {}, targets[0], pokemon, move) &&
+			this.runEvent('PrepareHit', pokemon, targets[0], move);
 		if (!hitResult) {
 			if (hitResult === false) {
 				this.add('-fail', pokemon);
@@ -345,16 +347,6 @@ export const Scripts: BattleScriptsData = {
 			}
 			return false;
 		}
-
-		hitResult = this.singleEvent('PrepareHit', move, {}, targets[0], pokemon, move);
-		if (!hitResult) {
-			if (hitResult === false) {
-				this.add('-fail', pokemon);
-				this.attrLastMove('[still]');
-			}
-			return false;
-		}
-		this.runEvent('PrepareHit', pokemon, targets[0], move);
 
 		let atLeastOneFailure!: boolean;
 		for (const step of moveSteps) {
@@ -572,7 +564,9 @@ export const Scripts: BattleScriptsData = {
 	tryMoveHit(target, pokemon, move) {
 		this.setActiveMove(move, pokemon, target);
 
-		let hitResult = this.singleEvent('Try', move, null, pokemon, target, move);
+		let hitResult = this.singleEvent('Try', move, null, pokemon, target, move) &&
+			this.singleEvent('PrepareHit', move, {}, target, pokemon, move) &&
+			this.runEvent('PrepareHit', pokemon, target, move);
 		if (!hitResult) {
 			if (hitResult === false) {
 				this.add('-fail', pokemon);
@@ -580,16 +574,6 @@ export const Scripts: BattleScriptsData = {
 			}
 			return false;
 		}
-
-		hitResult = this.singleEvent('PrepareHit', move, {}, target, pokemon, move);
-		if (!hitResult) {
-			if (hitResult === false) {
-				this.add('-fail', pokemon);
-				this.attrLastMove('[still]');
-			}
-			return false;
-		}
-		this.runEvent('PrepareHit', pokemon, target, move);
 
 		if (move.target === 'all') {
 			hitResult = this.runEvent('TryHitField', target, pokemon, move);

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -525,6 +525,7 @@ export interface EventMethods {
 	onAnyBasePowerPriority?: number;
 	onAnyInvulnerabilityPriority?: number;
 	onAnyFaintPriority?: number;
+	onAnyPrepareHitPriority?: number;
 	onAllyBasePowerPriority?: number;
 	onAllyModifyAtkPriority?: number;
 	onAllyModifySpAPriority?: number;

--- a/test/sim/moves/snatch.js
+++ b/test/sim/moves/snatch.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Snatch', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should cause the victim of Snatch to change typing with Protean rather than the Snatch user', function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'protean', moves: ['snatch']},
+		], [
+			{species: 'dratini', ability: 'protean', moves: ['howl']},
+		]]);
+
+		const wynaut = battle.p1.active[0];
+		const dratini = battle.p2.active[0];
+		battle.makeChoices();
+		assert.statStage(wynaut, 'atk', 1);
+		assert(wynaut.hasType('Dark'));
+		assert(dratini.hasType('Normal'));
+	});
+
+	it('should not Choice lock the user from the snatched move', function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'wynaut', moves: ['snatch', 'howl']},
+			{species: 'accelgor', item: 'choicescarf', moves: ['trick']},
+		], [
+			{species: 'dratini', moves: ['howl']},
+			{species: 'luvdisc', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move snatch, move trick -1', 'auto');
+
+		// This would fail if Choice locked into Howl
+		battle.makeChoices('move snatch, move trick 1', 'auto');
+	});
+
+	it('should not be able to steal Rest when the Rest user is at full HP', function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'wynaut', moves: ['snatch']},
+			{species: 'accelgor', moves: ['rest']},
+		], [
+			{species: 'dratini', moves: ['howl']},
+			{species: 'luvdisc', moves: ['quickattack']},
+		]]);
+
+		const wynaut = battle.p1.active[0];
+		battle.makeChoices('auto', 'move howl, move quickattack 1');
+		assert.equal(wynaut.status, '');
+		assert.statStage(wynaut, 'atk', 1);
+	});
+});


### PR DESCRIPTION
According to the move checks in one of the research threads (and also repeated by @DaWoblefet in PR https://github.com/smogon/pokemon-showdown/pull/7758#issuecomment-738547967), Snatch actually happens just after Protean, so I moved its event to onAnyPrepareHit at lower priority, with fixups so that the `PrepareHit` event can actually cause the move to stop executing. I then made Protean/Libero not run on the Snatched move. After checking with researchers I also ensured that choice locking doesn't happen for Snatched moves (you could be Tricked a choice item in between using Snatch and snatching a move). (I don't know whether it would be worth refactoring `hasBounced` into new property which covers both bounced and snatched moves.)