### PR TITLE
CC/HC: Fix level balancing formula

### DIFF
--- a/data/mods/gen1/random-teams.ts
+++ b/data/mods/gen1/random-teams.ts
@@ -36,33 +36,6 @@ export class RandomGen1Teams extends RandomGen2Teams {
 			const species = this.dex.getSpecies(poke);
 			const lsetData = this.dex.getLearnsetData(species.id);
 
-			// Level balance: calculate directly from stats rather than using some silly lookup table.
-			const mbstmin = 1307;
-			const stats = species.baseStats;
-
-			// Modified base stat total assumes 15 DVs, 255 EVs in every stat
-			let mbst = (stats["hp"] * 2 + 30 + 63 + 100) + 10;
-			mbst += (stats["atk"] * 2 + 30 + 63 + 100) + 5;
-			mbst += (stats["def"] * 2 + 30 + 63 + 100) + 5;
-			mbst += (stats["spa"] * 2 + 30 + 63 + 100) + 5;
-			mbst += (stats["spd"] * 2 + 30 + 63 + 100) + 5;
-			mbst += (stats["spe"] * 2 + 30 + 63 + 100) + 5;
-
-			let level = Math.floor(100 * mbstmin / mbst); // Initial level guess will underestimate
-
-			while (level < 100) {
-				mbst = Math.floor((stats["hp"] * 2 + 30 + 63 + 100) * level / 100 + 10);
-				// Since damage is roughly proportional to lvl
-				mbst += Math.floor(((stats["atk"] * 2 + 30 + 63 + 100) * level / 100 + 5) * level / 100);
-				mbst += Math.floor((stats["def"] * 2 + 30 + 63 + 100) * level / 100 + 5);
-				mbst += Math.floor(((stats["spa"] * 2 + 30 + 63 + 100) * level / 100 + 5) * level / 100);
-				mbst += Math.floor((stats["spd"] * 2 + 30 + 63 + 100) * level / 100 + 5);
-				mbst += Math.floor((stats["spe"] * 2 + 30 + 63 + 100) * level / 100 + 5);
-
-				if (mbst >= mbstmin) break;
-				level++;
-			}
-
 			// Random DVs.
 			const ivs = {
 				hp: 0,
@@ -81,6 +54,9 @@ export class RandomGen1Teams extends RandomGen2Teams {
 
 			// Maxed EVs.
 			const evs = {hp: 255, atk: 255, def: 255, spa: 255, spd: 255,	spe: 255};
+
+			// Level balance--calculate directly from stats rather than using some silly lookup table
+			const level = this.levelBalance(species.baseStats, ivs, evs, 'Serious', 15, 255);
 
 			// Four random unique moves from movepool. don't worry about "attacking" or "viable".
 			// Since Gens 1 and 2 learnsets are shared, we need to weed out Gen 2 moves.

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -81,6 +81,64 @@ export class RandomTeams {
 		return this.fastPop(list, index);
 	}
 
+	/**
+	 * Calculates a Pokemon's real in-game stats from its set details
+	 * Prone to rounding errors, but it should be close enough for the purposes of this class's functions
+	 */
+	statCalc(baseStats: StatsTable, ivs: StatsTable | number, evs: StatsTable | number, level: number, nature: string) {
+		if (typeof ivs === 'number') ivs = {hp: ivs, atk: ivs, def: ivs, spa: ivs, spd: ivs, spe: ivs};
+		if (typeof evs === 'number') evs = {hp: evs, atk: evs, def: evs, spa: evs, spd: evs, spe: evs};
+		const realStats: StatsTable = {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0};
+		const evMod = this.gen > 3 ? (ev: number) => Math.floor(ev / 4) : (ev: number) => Math.floor(Math.ceil(Math.sqrt(ev)) / 4);
+		for (const statName in realStats) {
+			const stat = statName as StatName;
+			if (stat === 'hp') {
+				realStats.hp = Math.floor((baseStats.hp * 2 + ivs.hp + evMod(evs.hp)) * level / 100 + level + 10);
+			} else {
+				realStats[stat] = Math.floor((baseStats[stat] * 2 + ivs[stat] + evMod(evs[stat])) * level / 100 + 5);
+				if (stat === 'atk' || stat === 'spa') {
+					// Damage dealt is roughly proportional to level
+					realStats[stat] = Math.floor(realStats[stat] * level / 100);
+				}
+			}
+		}
+		const n = this.dex.getNature(nature);
+		if (n.plus) {
+			realStats[n.plus] = Math.floor(realStats[n.plus] * 1.1);
+		}
+		if (n.minus) {
+			realStats[n.minus] = Math.floor(realStats[n.minus] * 0.9);
+		}
+		return realStats;
+	}
+
+	levelBalance(baseStats: StatsTable, ivs: StatsTable | number, evs: StatsTable | number, nature: string,
+		averageIV = 0, averageEV = 0, weakling?: string) {
+		let realStats: StatsTable = this.statCalc(baseStats, ivs, evs, 100, nature);
+		if (!weakling) weakling = this.gen >= 7 ? 'blipbug' : this.gen >= 2 ? 'sunkern' : 'weedle';
+		const worstStats = this.statCalc(this.dex.getSpecies(weakling).baseStats, averageIV, averageEV, 100, 'Serious');
+		const statRatios = {power: 0, bulk: 0, speed: 0};
+		let statRatioTotal = 0;
+		statRatioTotal += statRatios.power = 2 * Math.log((worstStats.atk + worstStats.spa) / (realStats.atk + realStats.spa));
+		statRatioTotal += statRatios.bulk = 2 * (
+			Math.log(worstStats.hp * worstStats.def * worstStats.spd / (worstStats.def + worstStats.spd)) -
+			Math.log(realStats.hp * realStats.def * realStats.spd / (realStats.def + realStats.spd))
+		);
+		statRatioTotal += statRatios.speed = Math.log(worstStats.spe / realStats.spe);
+		let level = Math.floor(Math.pow(Math.E, statRatioTotal / 5) * 100); // Initial level guess will underestimate
+		if (level > 100) level = 100;
+		while (level < 100) {
+			realStats = this.statCalc(baseStats, ivs, evs, level, nature);
+			statRatioTotal = 0;
+			statRatioTotal += statRatios.power = 2 * Math.log((worstStats.atk + worstStats.spa) / (realStats.atk + realStats.spa));
+			statRatioTotal += statRatios.bulk = 2 * Math.log((worstStats.def + worstStats.spd) * worstStats.hp / ((realStats.def + realStats.spd) * realStats.hp));
+			statRatioTotal += statRatios.speed = Math.log(worstStats.spe / realStats.spe);
+			if (statRatioTotal <= 0) break;
+			level++;
+		}
+		return level;
+	}
+
 	// checkAbilities(selectedAbilities, defaultAbilities) {
 	// 	if (!selectedAbilities.length) return true;
 	// 	const selectedAbility = selectedAbilities.pop();
@@ -186,48 +244,38 @@ export class RandomTeams {
 			// Random EVs
 			const evs: StatsTable = {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0};
 			const s: StatName[] = ["hp", "atk", "def", "spa", "spd", "spe"];
-			let evpool = 510;
-			do {
-				const x = this.sample(s);
-				const y = this.random(Math.min(256 - evs[x], evpool + 1));
-				evs[x] += y;
-				evpool -= y;
-			} while (evpool > 0);
+			if (this.gen > 2) {
+				let evpool = 510;
+				do {
+					const x = this.sample(s);
+					const y = this.random(Math.min(256 - evs[x], evpool + 1));
+					evs[x] += y;
+					evpool -= y;
+				} while (evpool > 0);
+			} else {
+				for (const x of s) {
+					evs[x] = this.random(256);
+				}
+			}
 
 			// Random IVs
-			const ivs = {hp: this.random(32), atk: this.random(32), def: this.random(32), spa: this.random(32), spd: this.random(32), spe: this.random(32)};
+			const ivs = {
+				hp: this.random(32),
+				atk: this.random(32),
+				def: this.random(32),
+				spa: this.random(32),
+				spd: this.random(32),
+				spe: this.random(32),
+			};
 
 			// Random nature
 			const nature = this.sample(natures);
 
 			// Level balance--calculate directly from stats rather than using some silly lookup table
-			const mbstmin = 1307; // Sunkern has the lowest modified base stat total, and that total is 807
-
 			let stats = species.baseStats;
 			// If Wishiwashi, use the school-forme's much higher stats
 			if (species.baseSpecies === 'Wishiwashi') stats = Dex.getSpecies('wishiwashischool').baseStats;
-
-			// Modified base stat total assumes 31 IVs, 85 EVs in every stat
-			let mbst = (stats["hp"] * 2 + 31 + 21 + 100) + 10;
-			mbst += (stats["atk"] * 2 + 31 + 21 + 100) + 5;
-			mbst += (stats["def"] * 2 + 31 + 21 + 100) + 5;
-			mbst += (stats["spa"] * 2 + 31 + 21 + 100) + 5;
-			mbst += (stats["spd"] * 2 + 31 + 21 + 100) + 5;
-			mbst += (stats["spe"] * 2 + 31 + 21 + 100) + 5;
-
-			let level = Math.floor(100 * mbstmin / mbst); // Initial level guess will underestimate
-
-			while (level < 100) {
-				mbst = Math.floor((stats["hp"] * 2 + 31 + 21 + 100) * level / 100 + 10);
-				mbst += Math.floor(((stats["atk"] * 2 + 31 + 21 + 100) * level / 100 + 5) * level / 100); // Since damage is roughly proportional to level
-				mbst += Math.floor((stats["def"] * 2 + 31 + 21 + 100) * level / 100 + 5);
-				mbst += Math.floor(((stats["spa"] * 2 + 31 + 21 + 100) * level / 100 + 5) * level / 100);
-				mbst += Math.floor((stats["spd"] * 2 + 31 + 21 + 100) * level / 100 + 5);
-				mbst += Math.floor((stats["spe"] * 2 + 31 + 21 + 100) * level / 100 + 5);
-
-				if (mbst >= mbstmin) break;
-				level++;
-			}
+			const level = this.levelBalance(stats, ivs, evs, nature, 15, 85);
 
 			// Random happiness
 			const happiness = this.random(256);
@@ -365,25 +413,7 @@ export class RandomTeams {
 			const nature = this.sample(naturePool);
 
 			// Level balance
-			const mbstmin = 1307;
-			const stats = species.baseStats;
-			let mbst = (stats['hp'] * 2 + 31 + 21 + 100) + 10;
-			mbst += (stats['atk'] * 2 + 31 + 21 + 100) + 5;
-			mbst += (stats['def'] * 2 + 31 + 21 + 100) + 5;
-			mbst += (stats['spa'] * 2 + 31 + 21 + 100) + 5;
-			mbst += (stats['spd'] * 2 + 31 + 21 + 100) + 5;
-			mbst += (stats['spe'] * 2 + 31 + 21 + 100) + 5;
-			let level = Math.floor(100 * mbstmin / mbst);
-			while (level < 100) {
-				mbst = Math.floor((stats['hp'] * 2 + 31 + 21 + 100) * level / 100 + 10);
-				mbst += Math.floor(((stats['atk'] * 2 + 31 + 21 + 100) * level / 100 + 5) * level / 100);
-				mbst += Math.floor((stats['def'] * 2 + 31 + 21 + 100) * level / 100 + 5);
-				mbst += Math.floor(((stats['spa'] * 2 + 31 + 21 + 100) * level / 100 + 5) * level / 100);
-				mbst += Math.floor((stats['spd'] * 2 + 31 + 21 + 100) * level / 100 + 5);
-				mbst += Math.floor((stats['spe'] * 2 + 31 + 21 + 100) * level / 100 + 5);
-				if (mbst >= mbstmin) break;
-				level++;
-			}
+			const level = this.levelBalance(species.baseStats, ivs, evs, nature, 15, 127, 'wishiwashi');
 
 			// Random happiness
 			const happiness = this.random(256);

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -115,7 +115,7 @@ export class RandomTeams {
 	levelBalance(baseStats: StatsTable, ivs: StatsTable | number, evs: StatsTable | number, nature: string,
 		averageIV = 0, averageEV = 0, weakling?: string) {
 		let realStats: StatsTable = this.statCalc(baseStats, ivs, evs, 100, nature);
-		if (!weakling) weakling = this.gen >= 7 ? 'blipbug' : this.gen >= 2 ? 'sunkern' : 'weedle';
+		if (!weakling) weakling = this.gen >= 8 ? 'blipbug' : this.gen >= 2 ? 'sunkern' : 'weedle';
 		const worstStats = this.statCalc(this.dex.getSpecies(weakling).baseStats, averageIV, averageEV, 100, 'Serious');
 		const statRatios = {power: 0, bulk: 0, speed: 0};
 		let statRatioTotal = 0;


### PR DESCRIPTION
The old formula was, to put it lightly, terrible. This new formula, besides actually calculating stats correctly, uses logarithms and compares stats more directly to each other instead of just adding them all up, and thus better representing what the stats actually do.

The other big change this makes is actually taking the IVs, EVs, and nature of the Pokemon being level balanced into account instead of just assuming some average values for all stats. A consequence of this is that Pokemon within a species can now be different levels from each other, with wider variance the higher its average level is. Because of this variance, while the balancing still compares stats against the weakest possible Pokemon, that benchmark is given average IVs and EVs to prevent the level balancing from skewing too low for everything else. As such, the actual weakest Pokemon (i.e. a 0 IV 0 EV Wishiwashi in Hackmons Cup) won't be any higher level than the average Pokemon of the same species, but that should be rather rare, and the old formula was even more heavily biased against low BST Pokemon anyway.