### PR TITLE
Formats: Move legendary validation to Minimal GBU

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1986,17 +1986,6 @@ export const Formats: FormatList = [
 		ruleset: ['Minimal GBU', 'VGC Timer'],
 		banlist: ['Unown'],
 		minSourceGen: 7,
-		onValidateTeam(team) {
-			const legends = [
-				'Mewtwo', 'Lugia', 'Ho-Oh', 'Kyogre', 'Groudon', 'Rayquaza', 'Dialga', 'Palkia', 'Giratina', 'Reshiram', 'Zekrom', 'Kyurem', 'Xerneas', 'Yveltal', 'Zygarde', 'Cosmog', 'Cosmoem', 'Solgaleo', 'Lunala', 'Necrozma',
-			];
-			let n = 0;
-			for (const set of team) {
-				const baseSpecies = this.dex.getSpecies(set.species).baseSpecies;
-				if (legends.includes(baseSpecies)) n++;
-				if (n > 2) return [`You can only use up to two legendary Pok\u00E9mon.`];
-			}
-		},
 	},
 	{
 		name: "[Gen 7] VGC 2018",

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -56,10 +56,29 @@ export const Formats: {[k: string]: FormatData} = {
 			'Victini', 'Keldeo', 'Meloetta', 'Genesect',
 			'Diancie', 'Hoopa', 'Volcanion',
 			'Magearna', 'Marshadow', 'Zeraora',
+			'Zarude',
 		],
 		onValidateSet(set, format) {
 			if (this.gen < 7 && this.toID(set.item) === 'souldew') {
 				return [`${set.name || set.species} has Soul Dew, which is banned in ${format.name}.`];
+			}
+		},
+		onValidateTeam(team) {
+			const legends = [
+				'Mewtwo',
+				'Lugia', 'Ho-Oh',
+				'Kyogre', 'Groudon', 'Rayquaza',
+				'Dialga', 'Palkia', 'Giratina',
+				'Reshiram', 'Zekrom', 'Kyurem',
+				'Xerneas', 'Yveltal', 'Zygarde',
+				'Cosmog', 'Cosmoem', 'Solgaleo', 'Lunala', 'Necrozma',
+				'Zacian', 'Zamazenta', 'Eternatus', 'Calyrex',
+			];
+			let n = 0;
+			for (const set of team) {
+				const baseSpecies = this.dex.getSpecies(set.species).baseSpecies;
+				if (legends.includes(baseSpecies)) n++;
+				if (n > 2) return [`You can only use up to two restricted legendary Pok\u00E9mon.`];
 			}
 		},
 	},


### PR DESCRIPTION
This is useful for custom challenges / room tournaments especially, so you get the whole "only up to 2 legends" rule included if you add Minimal GBU. It also adds the Gen 8 Mythicals / restricted legends.