### PR TITLE
Order Move event methods chronologically

### DIFF
--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -84,39 +84,42 @@ export interface SecondaryEffect extends HitEffect {
 }
 
 export interface MoveEventMethods {
-	basePowerCallback?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => number | false | null;
-	/** Return true to stop the move from being used */
-	beforeMoveCallback?: (this: Battle, pokemon: Pokemon, target: Pokemon | null, move: ActiveMove) => boolean | void;
+	onModifyPriority?: CommonHandlers['ModifierSourceMove'];
 	beforeTurnCallback?: (this: Battle, pokemon: Pokemon, target: Pokemon) => void;
+	beforeMoveCallback?: (this: Battle, pokemon: Pokemon, target: Pokemon | null, move: ActiveMove) => boolean | void;
+
+	onModifyType?: (this: Battle, move: ActiveMove, pokemon: Pokemon, target: Pokemon) => void;
+	onModifyMove?: (this: Battle, move: ActiveMove, pokemon: Pokemon, target: Pokemon | null) => void;
+	onTryMove?: CommonHandlers['ResultSourceMove'];
+	onUseMoveMessage?: CommonHandlers['VoidSourceMove'];
+
+	onTry?: CommonHandlers['ResultSourceMove'];
+	onPrepareHit?: CommonHandlers['ResultMove'];
+	onTryImmunity?: CommonHandlers['ResultMove'];
+	onTryHitField?: CommonHandlers['ResultMove'];
+	onTryHitSide?: (this: Battle, side: Side, source: Pokemon, move: ActiveMove) => boolean | null | "" | void;
+	onTryHit?: CommonHandlers['ExtResultSourceMove'];
+
+	/** Return true to stop the move from being used */
 	damageCallback?: (this: Battle, pokemon: Pokemon, target: Pokemon) => number | false;
-
-	onAfterHit?: CommonHandlers['VoidSourceMove'];
-	onAfterSubDamage?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void;
-	onAfterMoveSecondarySelf?: CommonHandlers['VoidSourceMove'];
-	onAfterMoveSecondary?: CommonHandlers['VoidMove'];
-	onAfterMove?: CommonHandlers['VoidSourceMove'];
-
+	basePowerCallback?: (this: Battle, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => number | false | null;
 	/* Invoked by the global BasePower event (onEffect = true) */
 	onBasePower?: CommonHandlers['ModifierSourceMove'];
-
 	onEffectiveness?: (
 		this: Battle, typeMod: number, target: Pokemon | null, type: string, move: ActiveMove
 	) => number | void;
+
+	onAfterSubDamage?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void;
 	onHit?: CommonHandlers['ResultMove'];
 	onHitField?: CommonHandlers['ResultMove'];
 	onHitSide?: (this: Battle, side: Side, source: Pokemon, move: ActiveMove) => boolean | null | "" | void;
-	onModifyMove?: (this: Battle, move: ActiveMove, pokemon: Pokemon, target: Pokemon | null) => void;
-	onModifyPriority?: CommonHandlers['ModifierSourceMove'];
+
+	onAfterHit?: CommonHandlers['VoidSourceMove'];
+	onAfterMoveSecondary?: CommonHandlers['VoidMove'];
+
 	onMoveFail?: CommonHandlers['VoidMove'];
-	onModifyType?: (this: Battle, move: ActiveMove, pokemon: Pokemon, target: Pokemon) => void;
-	onPrepareHit?: CommonHandlers['ResultMove'];
-	onTry?: CommonHandlers['ResultSourceMove'];
-	onTryHit?: CommonHandlers['ExtResultSourceMove'];
-	onTryHitField?: CommonHandlers['ResultMove'];
-	onTryHitSide?: (this: Battle, side: Side, source: Pokemon, move: ActiveMove) => boolean | null | "" | void;
-	onTryImmunity?: CommonHandlers['ResultMove'];
-	onTryMove?: CommonHandlers['ResultSourceMove'];
-	onUseMoveMessage?: CommonHandlers['VoidSourceMove'];
+	onAfterMoveSecondarySelf?: CommonHandlers['VoidSourceMove'];
+	onAfterMove?: CommonHandlers['VoidSourceMove'];
 }
 
 export interface MoveData extends EffectData, MoveEventMethods, HitEffect {


### PR DESCRIPTION
This is ordered according to a list @urkerab gave me:
[moveEventOrder.txt](https://github.com/smogon/pokemon-showdown/files/5656388/moveEventOrder.txt)
I think it's more helpful to have this as a guide to what order things happen in than having them in the psuedo-alphabetical order/grouping they were in before.
