### PR TITLE
Prevent /tour forcepublic spamming rooms

### DIFF
--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -1782,13 +1782,19 @@ const commands: ChatCommands = {
 			target = target.trim();
 			const option = target || 'on';
 			if (this.meansYes(option)) {
+				if (tournament.forcePublic) {
+					throw new Chat.ErrorMessage(`Tournament battles are already being forced public.`);
+				}
 				tournament.forcePublic = true;
-				room.add('Tournament battles forced public: ON');
+				room.add('Tournament battles are now forced to be public.');
 				this.privateModAction(`Tournament public battles were turned ON by ${user.name}`);
 				this.modlog('TOUR FORCEPUBLIC', null, 'ON');
 			} else if (this.meansNo(option) || option === 'stop') {
+				if (!tournament.forcePublic) {
+					throw new Chat.ErrorMessage(`Tournament battles are not being forced public.`);
+				}
 				tournament.forcePublic = false;
-				room.add('Tournament battles forced public: OFF');
+				room.add('Tournament battles are no longer being forced public.');
 				this.privateModAction(`Tournament public battles were turned OFF by ${user.name}`);
 				this.modlog('TOUR FORCEPUBLIC', null, 'OFF');
 			} else {


### PR DESCRIPTION
There's currently no check for if a tournament is already being forced public, which I noticed when testing the feature on my bot.

> [06:01:47] (Tournament public battles were turned ON by Unown)
Tournament battles forced public: ON
[06:01:47] (Tournament public battles were turned ON by Unown)
Tournament battles forced public: ON
[06:01:47] (The tournament auto disqualify timer was set to 2 by Unown)
The tournament's automatic disqualify timer has been set to 2 minutes.
[06:01:48] (The tournament auto start timer was set to 3 by Unown)
The tournament will automatically start in 3 minutes.
[06:01:48] (Tournament public battles were turned ON by Unown)
Tournament battles forced public: ON