### PR TITLE
Fix Gen 7 UU Gligar Battle Factory EVs

### DIFF
--- a/data/mods/gen7/factory-sets.json
+++ b/data/mods/gen7/factory-sets.json
@@ -4447,7 +4447,7 @@
 				"species": "Gligar",
 				"item": ["Eviolite"],
 				"ability": ["Immunity"],
-				"evs": {"spa": 252, "def": 156, "spd": 100},
+				"evs": {"hp": 252, "def": 156, "spd": 100},
 				"nature": "Impish",
 				"moves": [["Stealth Rock", "Defog"], ["Earthquake"], ["Toxic", "U-turn", "Knock Off"], ["Roost"]]
 			}]


### PR DESCRIPTION
I used a regex of `("spe"[^}]*("spd"|"spa"|"def"|"atk"|"hp"))|("spd"[^}]*("spa"|"def"|"atk"|"hp"))|("spa"[^}]*("def"|"atk"|"hp"))|("def"[^}]*("atk"|"hp"))|("atk"[^}]*"hp")` to check through this and the bss file for any other wrong sets. I didn't find any, but that just means there aren't any other sets with EVs in the wrong order, which would be an obvious sign of a mistake, as in the case of this Gligar set.