### PR TITLE
Fix Autoresponder Refresh button bug

### DIFF
--- a/server/chat-plugins/responder.ts
+++ b/server/chat-plugins/responder.ts
@@ -440,16 +440,13 @@ export const pages: PageTable = {
 		const canChange = user.can('ban', null, room);
 		let buf = '';
 		const refresh = (type: string, extra?: string[]) => {
+			if (extra) extra = extra.filter(Boolean);
 			let button = `<button class="button" name="send" value="/join view-autoresponder-${room.roomid}-${type}`;
-			if (extra) {
-				button += `${extra.length ? `-${extra.join('-')}` : ''}" style="float: right">`;
-			} else {
-				button += `" style="float: right">`;
-			}
+			button += `${extra?.length ? `-${extra.join('-')}` : ''}" style="float: right">`;
 			button += `<i class="fa fa-refresh"></i> Refresh</button><br />`;
 			return button;
 		};
-		const back = `<br /><a roomid="view-autoresponder-${room.roomid}-">Back to all</a>`;
+		const back = `<br /><a roomid="view-autoresponder-${room.roomid}">Back to all</a>`;
 		switch (args[0]) {
 		case 'stats':
 			args.shift();

--- a/server/chat-plugins/responder.ts
+++ b/server/chat-plugins/responder.ts
@@ -456,7 +456,7 @@ export const pages: PageTable = {
 				return `<h2>Invalid date.</h2>`;
 			}
 			buf = `<div class="pad"><strong>Stats for the ${room.title} auto-response filter${date ? ` on ${date}` : ''}.</strong>`;
-			buf += `${back}${refresh('stats', (date ? [date] : []))}<hr />`;
+			buf += `${back}${refresh('stats', [date])}<hr />`;
 			const stats = roomData.stats;
 			if (!stats) return `<h2>No stats.</h2>`;
 			this.title = `[Autoresponder Stats] ${date ? date : ''}`;

--- a/server/chat-plugins/responder.ts
+++ b/server/chat-plugins/responder.ts
@@ -441,7 +441,7 @@ export const pages: PageTable = {
 		let buf = '';
 		const refresh = (type: string, extra?: string[]) => {
 			let button = `<button class="button" name="send" value="/join view-autoresponder-${room.roomid}-${type}`;
-			button += `${extra[0] ? `-${extra.join('-')}` : ''}" style="float: right">`;
+			button += `${extra.length ? `-${extra.join('-')}` : ''}" style="float: right">`;
 			button += `<i class="fa fa-refresh"></i> Refresh</button><br />`;
 			return button;
 		};
@@ -455,7 +455,7 @@ export const pages: PageTable = {
 				return `<h2>Invalid date.</h2>`;
 			}
 			buf = `<div class="pad"><strong>Stats for the ${room.title} auto-response filter${date ? ` on ${date}` : ''}.</strong>`;
-			buf += `${back}${refresh('stats', [date])}<hr />`;
+			buf += `${back}${refresh('stats', (date ? [date] : []))}<hr />`;
 			const stats = roomData.stats;
 			if (!stats) return `<h2>No stats.</h2>`;
 			this.title = `[Autoresponder Stats] ${date ? date : ''}`;

--- a/server/chat-plugins/responder.ts
+++ b/server/chat-plugins/responder.ts
@@ -441,7 +441,7 @@ export const pages: PageTable = {
 		let buf = '';
 		const refresh = (type: string, extra?: string[]) => {
 			let button = `<button class="button" name="send" value="/join view-autoresponder-${room.roomid}-${type}`;
-			button += `${extra ? `-${extra.join('-')}` : ''}" style="float: right">`;
+			button += `${extra[0] ? `-${extra.join('-')}` : ''}" style="float: right">`;
 			button += `<i class="fa fa-refresh"></i> Refresh</button><br />`;
 			return button;
 		};

--- a/server/chat-plugins/responder.ts
+++ b/server/chat-plugins/responder.ts
@@ -441,7 +441,11 @@ export const pages: PageTable = {
 		let buf = '';
 		const refresh = (type: string, extra?: string[]) => {
 			let button = `<button class="button" name="send" value="/join view-autoresponder-${room.roomid}-${type}`;
-			button += `${extra.length ? `-${extra.join('-')}` : ''}" style="float: right">`;
+		 	if (extra) {
+				button += `${extra.length ? `-${extra.join('-')}` : ''}" style="float: right">`;
+			} else {
+				button += `" style="float: right">`;
+			}
 			button += `<i class="fa fa-refresh"></i> Refresh</button><br />`;
 			return button;
 		};

--- a/server/chat-plugins/responder.ts
+++ b/server/chat-plugins/responder.ts
@@ -441,7 +441,7 @@ export const pages: PageTable = {
 		let buf = '';
 		const refresh = (type: string, extra?: string[]) => {
 			let button = `<button class="button" name="send" value="/join view-autoresponder-${room.roomid}-${type}`;
-		 	if (extra) {
+			if (extra) {
 				button += `${extra.length ? `-${extra.join('-')}` : ''}" style="float: right">`;
 			} else {
 				button += `" style="float: right">`;


### PR DESCRIPTION
Currently if you go into `/autoresponder view` and choose to view autoresponder Stats, it opens a menu where no date is specified and you can choose a date from there. If, however, you press the Refresh button (where no date is specified), it opens a new page called "view-autoresponder-room-stats-" (note the extra hyphen at the end). This is because the "refresh" function is called (on line 458) with [date], which would equal [""]. This is a truthy value, unlike [] and unlike "". This patch changes the conditional statement to look at the first item in the array's truthfulness - it is either an empty string (falsey) or a non-empty string (truthy) - instead of always being truthy.