### PR TITLE
Bug fix: Future Move Failure Message

### DIFF
--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -355,7 +355,7 @@ export const Conditions: {[k: string]: ConditionData} = {
 			// time's up; time to hit! :D
 			const move = this.dex.getMove(data.move);
 			if (target.fainted || target === data.source) {
-				this.hint(`${move.name} did not hit because the target is ${(data.fainted ? 'fainted' : 'the user')}.`);
+				this.hint(`${move.name} did not hit because the target is ${(target.fainted ? 'fainted' : 'the user')}.`);
 				return;
 			}
 

--- a/test/sim/moves/futuresight.js
+++ b/test/sim/moves/futuresight.js
@@ -46,6 +46,21 @@ describe('Future Sight', function () {
 		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
+	it('should alwaystarget randomly as a submove', function () {
+		battle = common.createBattle({gameType: 'doubles', seed: [5, 2, 3, 4]}, [[
+			{species: 'alakazam', moves: ['sleeptalk', 'spore']},
+			{species: 'bronzong', moves: ['sleeptalk', 'futuresight']},
+		], [
+			{species: 'mew', moves: ['sleeptalk', 'healingwish']},
+			{species: 'jirachi', moves: ['sleeptalk']},
+			{species: 'delibird', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices('move spore -2, move sleeptalk', 'move sleeptalk, move sleeptalk');
+		battle.makeChoices('move sleeptalk, move sleeptalk', 'move sleeptalk, move sleeptalk');
+		battle.makeChoices('move sleeptalk, move sleeptalk', 'move healingwish, move sleeptalk');
+		assert.false.fullHP(battle.p2.active[1], 'should have hit the remaining foe');
+	});
+
 	it.skip(`should not double Stomping Tantrum for exiting normally`, function () {
 		battle = common.createBattle([[
 			{species: "Wynaut", moves: ['futuresight', 'stompingtantrum']},

--- a/test/sim/moves/futuresight.js
+++ b/test/sim/moves/futuresight.js
@@ -46,21 +46,6 @@ describe('Future Sight', function () {
 		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
-	it('should alwaystarget randomly as a submove', function () {
-		battle = common.createBattle({gameType: 'doubles', seed: [5, 2, 3, 4]}, [[
-			{species: 'alakazam', moves: ['sleeptalk', 'spore']},
-			{species: 'bronzong', moves: ['sleeptalk', 'futuresight']},
-		], [
-			{species: 'mew', moves: ['sleeptalk', 'healingwish']},
-			{species: 'jirachi', moves: ['sleeptalk']},
-			{species: 'delibird', moves: ['sleeptalk']},
-		]]);
-		battle.makeChoices('move spore -2, move sleeptalk', 'move sleeptalk, move sleeptalk');
-		battle.makeChoices('move sleeptalk, move sleeptalk', 'move sleeptalk, move sleeptalk');
-		battle.makeChoices('move sleeptalk, move sleeptalk', 'move healingwish, move sleeptalk');
-		assert.false.fullHP(battle.p2.active[1], 'should have hit the remaining foe');
-	});
-
 	it.skip(`should not double Stomping Tantrum for exiting normally`, function () {
 		battle = common.createBattle([[
 			{species: "Wynaut", moves: ['futuresight', 'stompingtantrum']},


### PR DESCRIPTION
Regarding the card:

> Moves that call other moves + Future Sight / Doom Desire cause the target to be itself? Also it seems to be deterministic and always targets opponent's left slot? See replay - DW

I also tested the determinism with a few seeds and it is indeed random.