### PR TITLE
Turn off Format On Save in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "editor.insertSpaces": false,
+  "editor.formatOnSave": false,
   "typescript.tsdk": "node_modules/typescript/lib",
   "javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,
   "typescript.format.semicolons": "insert",


### PR DESCRIPTION
This setting is off by default in vscode, but is commonly enabled at the User-level (it's under "Commonly Used"). Since this repo does not include a standardized formatter, it should be explicitly disabled.