### PR TITLE
Display called moves before becoming Z-Move

### DIFF
--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -157,6 +157,24 @@ export const Scripts: BattleScriptsData = {
 			this.singleEvent('ModifyType', move, null, pokemon, target, move, move);
 			if (move.type !== 'Normal') sourceEffect = move;
 		}
+		if (zMove && sourceEffect) {
+			if (['metronome', 'assist', 'sleeptalk'].includes(sourceEffect.id)) {
+				this.add('message', pokemon.name + ' will change ' + move.name + ' chosen by ' + sourceEffect.name + ' to its Z-Move!');
+			}
+			if (['copycat'].includes(sourceEffect.id)) {
+				this.add('message', pokemon.name + ' will change ' + move.name + ' copied by Copycat to its Z-Move!');
+			}
+			if (['mefirst'].includes(sourceEffect.id)) {
+				this.add('message', pokemon.name + ' will change ' + move.name + ' it stole using Me First to its Z-Move!');
+			}
+			if (['mirrormove'].includes(sourceEffect.id)) {
+				this.add('message', pokemon.name + ' will change ' + move.name + ' to its Z-Move using Mirror Move!');
+			}
+			if (['naturepower'].includes(sourceEffect.id)) {
+				this.singleEvent('ModifyType', move, null, pokemon, target, move, move);
+				this.add('message', pokemon.name + '\'s Nature Power turned into ' + this.getActiveZMove(move, pokemon).name);
+			}
+		}
 		if (zMove || (move.category !== 'Status' && sourceEffect && (sourceEffect as ActiveMove).isZ)) {
 			move = this.getActiveZMove(move, pokemon);
 		}


### PR DESCRIPTION
According to the list of mechanics bugs, there was an issue where ["Z-moves of moves that call other moves should display the called move prior to becoming a Z-move" ](https://github.com/smogon/pokemon-showdown/projects/3#card-23557676)

In data/scripts.ts I've added checks in useMoveInner(), adding the appropriate messages for moves that are to become Z-Moves and which have been called by move-calling moves. I'm not sure if this is the preferred place in the code to handle displaying that text, but I couldn't see any easier way to display it with the correct values (perhaps caused by my unfamiliarity with the codebase). Hopefully my contribution is okay, as it passes all the unit tests, but I'm not quite sure how to check if these messages are being displayed properly when I'm running the simulator locally (much more familiar with playing in the client). Fortunately, it's mostly a visual change as opposed to something that could break the whole battle system, but please let me know if there's anything I should change. Thanks!

(Very new to this, but wanted to contribute to a project that I've spent so many hours enjoying over the years <3)