### PR TITLE
Bugfix: Conversion 2 Submove Interaction

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2440,11 +2440,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {authentic: 1},
 		onHit(target, source) {
-			if (!target.lastMove) {
+			if (!target.lastMoveUsed) {
 				return false;
 			}
 			const possibleTypes = [];
-			const attackType = target.lastMove.type;
+			const attackType = target.lastMoveUsed.type;
 			for (const type in this.dex.data.TypeChart) {
 				if (source.hasType(type)) continue;
 				const typeCheck = this.dex.data.TypeChart[type].damageTaken[attackType];

--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -151,6 +151,7 @@ export const Scripts: BattleScriptsData = {
 		if (sourceEffect && ['instruct', 'custapberry'].includes(sourceEffect.id)) sourceEffect = null;
 
 		let move = this.dex.getActiveMove(moveOrMoveName);
+		pokemon.lastMoveUsed = move;
 		if (move.id === 'weatherball' && zMove) {
 			// Z-Weather Ball only changes types if it's used directly,
 			// not if it's called by Z-Sleep Talk or something.

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -135,6 +135,7 @@ export class Pokemon {
 	beingCalledBack: boolean;
 
 	lastMove: ActiveMove | null;
+	lastMoveUsed: ActiveMove | null;
 	lastMoveTargetLoc?: number;
 	moveThisTurn: string | boolean;
 	statsRaisedThisTurn: boolean;
@@ -394,6 +395,7 @@ export class Pokemon {
 		this.beingCalledBack = false;
 
 		this.lastMove = null;
+		this.lastMoveUsed = null;
 		this.moveThisTurn = '';
 		this.statsRaisedThisTurn = false;
 		this.statsLoweredThisTurn = false;
@@ -1291,6 +1293,7 @@ export class Pokemon {
 		}
 
 		this.lastMove = null;
+		this.lastMoveUsed = null;
 		this.moveThisTurn = '';
 
 		this.lastDamage = 0;

--- a/test/sim/moves/conversion2.js
+++ b/test/sim/moves/conversion2.js
@@ -23,4 +23,15 @@ describe('Conversion2', function () {
 		battle.makeChoices('move conversion2', 'move sleeptalk');
 		assert(['Electric', 'Grass', 'Ground', 'Dragon'].includes(battle.p1.active[0].getTypes()[0]), 'should change type based on submove');
 	});
+
+	it('should respect the determined type of the last move', function () {
+		battle = common.createBattle([
+			[{species: 'porygon2', moves: ['electrify', 'conversion2']}],
+			[{species: 'shuckle', moves: ['tackle']}],
+		]);
+
+		battle.makeChoices('move electrify', 'move tackle');
+		battle.makeChoices('move conversion2', 'move tackle');
+		assert(['Electric', 'Grass', 'Ground', 'Dragon'].includes(battle.p1.active[0].getTypes()[0]), 'Tackle should be considered Electric');
+	});
 });

--- a/test/sim/moves/conversion2.js
+++ b/test/sim/moves/conversion2.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Conversion2', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should change users type to resist', function () {
+		battle = common.createBattle([
+			[{species: 'porygon2', moves: ['sleeptalk', 'conversion2', 'spore']}],
+			[{species: 'raticate', moves: ['tackle']},
+			 {species: 'zapdos', moves: ['thundershock', 'sleeptalk']}],
+		]);
+
+		battle.makeChoices('move conversion2', 'move tackle');
+		assert(['Rock', 'Ghost', 'Steel'].includes(battle.p1.active[0].getTypes()[0]));
+		battle.makeChoices('move spore', 'switch 2');
+		battle.makeChoices('move conversion2', 'move sleeptalk');
+		assert(['Electric', 'Grass', 'Ground', 'Dragon'].includes(battle.p1.active[0].getTypes()[0]), 'should change type based on submove');
+	});
+});


### PR DESCRIPTION
> Conversion 2 vs. moves that call other moves should use the called move, not the original move. e.g. Sleep Talk -> Thunderbolt should roll Ground, Electric, Grass, or Dragon, NOT Steel, Rock, or Ghost. See [replay ](https://replay.pokemonshowdown.com/gen7customgame-969010846)- DW

Are there any other moves in which the differentiation between `runMove` and `useMove` is significant?

Moves with references to `lastMove`: copycat, disable, eeriespell, encore, gmaxdepletion, grudge, iceball, instruct, mimic, mirrormove, rollout, skech, spite, torment, uproar
