### PR TITLE
Bugfix: fix deterministic speed ties for entrance abilities and primal conversions

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -816,6 +816,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		name: "Drizzle",
 		rating: 4,
 		num: 2,
+		setsWeather: true,
 	},
 	drought: {
 		onStart(source) {
@@ -828,6 +829,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		name: "Drought",
 		rating: 4,
 		num: 70,
+		setsWeather: true,
 	},
 	dryskin: {
 		onTryHit(target, source, move) {
@@ -887,6 +889,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		name: "Electric Surge",
 		rating: 4,
 		num: 226,
+		setsWeather: true,
 	},
 	emergencyexit: {
 		onEmergencyExit(target) {
@@ -1288,6 +1291,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		name: "Grassy Surge",
 		rating: 4,
 		num: 229,
+		setsWeather: true,
 	},
 	grimneigh: {
 		onSourceAfterFaint(length, target, source, effect) {
@@ -2091,6 +2095,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		name: "Misty Surge",
 		rating: 3.5,
 		num: 228,
+		setsWeather: true,
 	},
 	moldbreaker: {
 		onStart(pokemon) {
@@ -2788,6 +2793,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		name: "Psychic Surge",
 		rating: 4,
 		num: 227,
+		setsWeather: true,
 	},
 	punkrock: {
 		onBasePowerPriority: 7,
@@ -3071,6 +3077,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		name: "Sand Stream",
 		rating: 4,
 		num: 45,
+		setsWeather: true,
 	},
 	sandveil: {
 		onImmunity(type, pokemon) {
@@ -3419,6 +3426,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		name: "Snow Warning",
 		rating: 4,
 		num: 117,
+		setsWeather: true,
 	},
 	solarpower: {
 		onModifySpAPriority: 5,

--- a/data/items.ts
+++ b/data/items.ts
@@ -510,7 +510,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		spritenum: 41,
 		onSwitchIn(pokemon) {
 			if (pokemon.isActive && pokemon.baseSpecies.name === 'Kyogre') {
-				this.queue.insertChoice({choice: 'runPrimal', pokemon: pokemon});
+				this.queue.insertChoice({choice: 'runPrimal', pokemon: pokemon}, false, true);
 			}
 		},
 		onPrimal(pokemon) {
@@ -4470,7 +4470,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		spritenum: 390,
 		onSwitchIn(pokemon) {
 			if (pokemon.isActive && pokemon.baseSpecies.name === 'Groudon') {
-				this.queue.insertChoice({choice: 'runPrimal', pokemon: pokemon});
+				this.queue.insertChoice({choice: 'runPrimal', pokemon: pokemon}, false, true);
 			}
 		},
 		onPrimal(pokemon) {

--- a/sim/battle-queue.ts
+++ b/sim/battle-queue.ts
@@ -334,7 +334,7 @@ export class BattleQueue {
 	 * would have happened (sorting by priority/speed), without
 	 * re-sorting the existing actions.
 	 */
-	insertChoice(choices: ActionChoice | ActionChoice[], midTurn = false) {
+	insertChoice(choices: ActionChoice | ActionChoice[], midTurn = false, rng = false) {
 		if (Array.isArray(choices)) {
 			for (const choice of choices) {
 				this.insertChoice(choice);
@@ -348,8 +348,18 @@ export class BattleQueue {
 		}
 		const actions = this.resolveAction(choice, midTurn);
 		for (const [i, curAction] of this.list.entries()) {
-			if (BattleQueue.comparePriority(actions[0], curAction) < 0) {
+			const delta = BattleQueue.comparePriority(actions[0], curAction);
+			if (delta < 0) {
 				this.list.splice(i, 0, ...actions);
+				return;
+			} else if (delta === 0 && rng) {
+				const same_priority_idx = i;
+				let j = i + 1;
+				while (j < this.list.length && BattleQueue.comparePriority(actions[0], this.list[j])) {
+					j++;
+				}
+				const insert_idx = this.battle.prng.next(same_priority_idx, j + 1);
+				this.list.splice(insert_idx, 0, ...actions);
 				return;
 			}
 		}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1325,6 +1325,8 @@ export class Battle {
 		if (isDrag && this.gen >= 5) {
 			// runSwitch happens immediately so that Mold Breaker can make hazards bypass Clear Body and Levitate
 			this.runSwitch(pokemon);
+		} else if (pokemon.getAbility().setsWeather) {
+			this.queue.insertChoice({choice: 'runSwitch', pokemon}, false, true);
 		} else {
 			this.queue.insertChoice({choice: 'runSwitch', pokemon});
 		}

--- a/sim/dex-abilities.ts
+++ b/sim/dex-abilities.ts
@@ -23,6 +23,7 @@ export class Ability extends BasicEffect implements Readonly<BasicEffect> {
 	readonly condition?: Partial<ConditionData>;
 	readonly isPermanent?: boolean;
 	readonly isUnbreakable?: boolean;
+	readonly setsWeather: boolean;
 
 	constructor(data: AnyObject, ...moreData: (AnyObject | null)[]) {
 		super(data, ...moreData);
@@ -32,6 +33,7 @@ export class Ability extends BasicEffect implements Readonly<BasicEffect> {
 		this.effectType = 'Ability';
 		this.suppressWeather = !!data.suppressWeather;
 		this.rating = data.rating || 0;
+		this.setsWeather = !!data.setsWeather;
 
 		if (!this.gen) {
 			if (this.num >= 234) {


### PR DESCRIPTION
This addresses these deterministic speed tie issues:
 https://www.smogon.com/forums/threads/bug-reports-v3-read-original-post-before-posting.3634749/post-8203577 
https://www.smogon.com/forums/threads/bug-reports-v3-read-original-post-before-posting.3634749/post-8201694

The problem is in insertChoice which doesn’t insert randomly for actions with the same priority. You can’t change all switchin events to insert randomly because some moves (pursuit) depend on this behavior, and changing pursuit was too complex for me.

It may not be worth adding a member variable to Ability class just to fix a fringe issue 
