### PR TITLE
Bug fix: pursuit switch move interaction

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -13441,6 +13441,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		condition: {
 			duration: 1,
 			onBeforeSwitchOut(pokemon) {
+				if (pokemon.switchFlag === 'batonpass') return;
 				this.debug('Pursuit start');
 				let alreadyAdded = false;
 				pokemon.removeVolatile('destinybond');

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -1004,6 +1004,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 40,
 		priority: 0,
 		flags: {},
+		self: {
+			onHit(source) {
+				source.skipBeforeSwitchOutEventFlag = true;
+			},
+		},
 		selfSwitch: 'copyvolatile',
 		secondary: null,
 		target: "self",
@@ -13441,7 +13446,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 		condition: {
 			duration: 1,
 			onBeforeSwitchOut(pokemon) {
-				if (pokemon.switchFlag === 'batonpass') return;
 				this.debug('Pursuit start');
 				let alreadyAdded = false;
 				pokemon.removeVolatile('destinybond');

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2728,12 +2728,14 @@ export class Battle {
 				switches[i] = false;
 			} else if (switches[i]) {
 				for (const pokemon of this.sides[i].active) {
-					if (!pokemon.skipBeforeSwitchOutEventFlag) this.runEvent('BeforeSwitchOut', pokemon);
-					pokemon.skipBeforeSwitchOutEventFlag = true;
-					this.faintMessages(); // Pokemon may have fainted in BeforeSwitchOut
-					if (pokemon.fainted) {
-						pokemon.switchFlag = false;
-						switches[i] = this.sides[i].active.some(sidePokemon => sidePokemon && !!sidePokemon.switchFlag);
+					if (pokemon.switchFlag && !pokemon.skipBeforeSwitchOutEventFlag) {
+						this.runEvent('BeforeSwitchOut', pokemon);
+						pokemon.skipBeforeSwitchOutEventFlag = true;
+						this.faintMessages(); // Pokemon may have fainted in BeforeSwitchOut
+						if (this.ended) return true;
+						if (pokemon.fainted) {
+							switches[i] = this.sides[i].active.some(sidePokemon => sidePokemon && !!sidePokemon.switchFlag);
+						}
 					}
 				}
 			}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2730,6 +2730,11 @@ export class Battle {
 				for (const pokemon of this.sides[i].active) {
 					if (!pokemon.skipBeforeSwitchOutEventFlag) this.runEvent('BeforeSwitchOut', pokemon);
 					pokemon.skipBeforeSwitchOutEventFlag = true;
+					this.faintMessages(); // Pokemon may have fainted in BeforeSwitchOut
+					if (pokemon.fainted) {
+						pokemon.switchFlag = false;
+						switches[i] = this.sides[i].active.some(sidePokemon => sidePokemon && !!sidePokemon.switchFlag);
+					}
 				}
 			}
 		}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2725,6 +2725,10 @@ export class Battle {
 					pokemon.switchFlag = false;
 				}
 				switches[i] = false;
+			} else if (switches[i]) {
+				for (const pokemon of this.sides[i].active) {
+					this.runEvent('BeforeSwitchOut', pokemon);
+				}
 			}
 		}
 

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -129,7 +129,7 @@ export class Pokemon {
 	 */
 	switchFlag: ID | boolean;
 	forceSwitchFlag: boolean;
-	switchCopyFlag: boolean;
+	skipBeforeSwitchOutEventFlag: boolean;
 	draggedIn: number | null;
 	newlySwitched: boolean;
 	beingCalledBack: boolean;
@@ -388,7 +388,7 @@ export class Pokemon {
 
 		this.switchFlag = false;
 		this.forceSwitchFlag = false;
-		this.switchCopyFlag = false;
+		this.skipBeforeSwitchOutEventFlag = false;
 		this.draggedIn = null;
 		this.newlySwitched = false;
 		this.beingCalledBack = false;

--- a/test/sim/moves/pursuit.js
+++ b/test/sim/moves/pursuit.js
@@ -73,7 +73,7 @@ describe(`Pursuit`, function () {
 
 	it(`should deal damage prior to attacker selecting a switch in after u-turn etc`, function () {
 		battle = common.createBattle([[
-			{species: 'tyranitar', moves: ['pursuit']},
+			{species: 'parasect', moves: ['pursuit']},
 		], [
 			{species: 'emolga', moves: ['voltswitch']},
 			{species: 'zapdos', moves: ['batonpass']},

--- a/test/sim/moves/pursuit.js
+++ b/test/sim/moves/pursuit.js
@@ -70,4 +70,21 @@ describe(`Pursuit`, function () {
 		battle.makeChoices('move Pursuit mega -2, switch 3', 'auto');
 		assert.equal(furret.maxhp - furret.hp, 66);
 	});
+
+	it(`should deal damage prior to attacker selecting a switch in after u-turn etc`, function () {
+		battle = common.createBattle([[
+			{species: 'tyranitar', moves: ['pursuit']},
+		], [
+			{species: 'emolga', moves: ['voltswitch']},
+			{species: 'zapdos', moves: ['batonpass']},
+		]]);
+		battle.makeChoices('move Pursuit', 'move voltswitch');
+		assert.false.fullHP(battle.p2.pokemon[0]);
+		battle.choose('p2', 'switch 2');
+		assert.equal(battle.p2.pokemon[0].name, "Zapdos");
+		battle.makeChoices('move Pursuit', 'move batonpass');
+		battle.choose('p2', 'switch 2');
+		assert.fullHP(battle.p2.pokemon[1], 'should not hit Pokemon that has used Baton Pass');
+		assert.equal(battle.p2.pokemon[0].name, "Emolga");
+	});
 });

--- a/test/sim/moves/pursuit.js
+++ b/test/sim/moves/pursuit.js
@@ -86,5 +86,6 @@ describe(`Pursuit`, function () {
 		battle.choose('p2', 'switch 2');
 		assert.fullHP(battle.p2.pokemon[1], 'should not hit Pokemon that has used Baton Pass');
 		assert.equal(battle.p2.pokemon[0].name, "Emolga");
+		battle.makeChoices('move Pursuit', 'move voltswitch');
 	});
 });


### PR DESCRIPTION
> If Pursuit is used on the same turn a Pokemon uses Volt Switch, U-turn, or Parting Shot (not Baton Pass), the user of the switching move should take damage, then the player should have the option to choose a new Pokemon. Currently, the player is able to select a new Pokemon prior to taking Pursuit damage. See replay. DaWoblefet tested in Gens 5, 6, and 7, and Marty said it's always been this way