### PR TITLE
Translations: Properly ignore non-translation directories

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1479,8 +1479,9 @@ export const Chat = new class {
 		// ensure that english is the first entry when we iterate over Chat.languages
 		Chat.languages.set('english' as ID, 'English');
 		for (const dirname of directories) {
+			// translation dirs shouldn't have caps, but things like sourceMaps and the README will
+			if (/[A-Z]/.test(dirname)) continue;
 			const dir = FS(`${TRANSLATION_DIRECTORY}/${dirname}`);
-			if (!dir.isDirectorySync()) continue;
 
 			// For some reason, toID() isn't available as a global when this executes.
 			const languageID = Dex.toID(dirname);

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1480,7 +1480,7 @@ export const Chat = new class {
 		Chat.languages.set('english' as ID, 'English');
 		for (const dirname of directories) {
 			// translation dirs shouldn't have caps, but things like sourceMaps and the README will
-			if (/[A-Z]/.test(dirname)) continue;
+			if (/[^a-z0-9]/.test(dirname)) continue;
 			const dir = FS(`${TRANSLATION_DIRECTORY}/${dirname}`);
 
 			// For some reason, toID() isn't available as a global when this executes.


### PR DESCRIPTION
At the moment, sourceMaps is getting loaded as a language. This is obviously not right, so i replaced the current directory check (which it passes because sourceMaps is a directory) with a simple caps check, since as the comment says none of the languages should have caps in the dir title.