### PR TITLE
Bug fix: Metal Burst Submove Interaction

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -10885,7 +10885,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		basePower: 0,
 		damageCallback(pokemon) {
 			const lastDamagedBy = pokemon.getLastDamagedBy();
-			if (lastDamagedBy) {
+			if (lastDamagedBy !== undefined) {
 				return (lastDamagedBy.damage * 1.5) || 1;
 			}
 			return 0;
@@ -10897,7 +10897,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {protect: 1, mirror: 1},
 		onTryHit(target, source, move) {
 			const lastDamagedBy = source.getLastDamagedBy();
-			if (!lastDamagedBy) return false;
+			if (lastDamagedBy === undefined) return false;
 		},
 		onModifyTarget(targetRelayVar, source, target, move) {
 			const lastDamagedBy = source.getLastDamagedBy();

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -10886,7 +10886,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		damageCallback(pokemon) {
 			const lastDamagedBy = pokemon.getLastDamagedBy();
 			if (lastDamagedBy !== undefined) {
-				return (lastDamagedBy.damage * 1.5) || 1;
+				return (lastDamagedBy.damage * 1.5);
 			}
 			return 0;
 		},
@@ -10897,7 +10897,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {protect: 1, mirror: 1},
 		onTryHit(target, source, move) {
 			const lastDamagedBy = source.getLastDamagedBy();
-			if (lastDamagedBy === undefined) return false;
+			if (lastDamagedBy === undefined || !lastDamagedBy.thisTurn) return false;
 		},
 		onModifyTarget(targetRelayVar, source, target, move) {
 			const lastDamagedBy = source.getLastDamagedBy();

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -10886,7 +10886,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		damageCallback(pokemon) {
 			const lastDamagedBy = pokemon.getLastDamagedBy();
 			if (lastDamagedBy !== undefined) {
-				return (lastDamagedBy.damage * 1.5);
+				return (lastDamagedBy.damage * 1.5) || 1;
 			}
 			return 0;
 		},

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -10902,7 +10902,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		onModifyTarget(targetRelayVar, source, target, move) {
 			const lastDamagedBy = source.getLastDamagedBy();
 			if (lastDamagedBy !== undefined) {
-				targetRelayVar.target = lastDamagedBy.source;
+				targetRelayVar.target = source.side.foe.active[lastDamagedBy.position];
 			}
 		},
 		secondary: null,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -10884,7 +10884,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 		accuracy: 100,
 		basePower: 0,
 		damageCallback(pokemon) {
-			return (pokemon.lastDamageTaken * 1.5) || 1;
+			const lastDamagedBy = pokemon.getLastDamagedBy();
+			if (lastDamagedBy) {
+				return (lastDamagedBy.damage * 1.5) || 1;
+			}
+			return 0;
 		},
 		category: "Physical",
 		name: "Metal Burst",
@@ -10892,12 +10896,13 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
 		onTryHit(target, source, move) {
-			if (!source.lastDamageTaken) return false;
+			const lastDamagedBy = source.getLastDamagedBy();
+			if (!lastDamagedBy) return false;
 		},
 		onModifyTarget(targetRelayVar, source, target, move) {
-			const lastAttackedBy = source.getLastAttackedBy();
-			if (lastAttackedBy !== undefined) {
-				targetRelayVar.target = lastAttackedBy.source;
+			const lastDamagedBy = source.getLastDamagedBy();
+			if (lastDamagedBy !== undefined) {
+				targetRelayVar.target = lastDamagedBy.source;
 			}
 		},
 		secondary: null,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -10894,8 +10894,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 		onTryHit(target, source, move) {
 			if (!source.lastDamageTaken) return false;
 		},
-		onRedirectTarget(target, source) {
-			return source.getLastAttackedBy();
+		onModifyTarget(targetRelayVar, source, target, move) {
+			const lastAttackedBy = source.getLastAttackedBy();
+			if (lastAttackedBy !== undefined) {
+				targetRelayVar.target = lastAttackedBy.source;
+			}
 		},
 		secondary: null,
 		target: "scripted",

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -10884,7 +10884,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		accuracy: 100,
 		basePower: 0,
 		damageCallback(pokemon) {
-			const lastDamagedBy = pokemon.getLastDamagedBy();
+			const lastDamagedBy = pokemon.getLastDamagedBy(pokemon.side);
 			if (lastDamagedBy !== undefined) {
 				return (lastDamagedBy.damage * 1.5) || 1;
 			}
@@ -10896,11 +10896,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
 		onTryHit(target, source, move) {
-			const lastDamagedBy = source.getLastDamagedBy();
+			const lastDamagedBy = source.getLastDamagedBy(source.side);
 			if (lastDamagedBy === undefined || !lastDamagedBy.thisTurn) return false;
 		},
 		onModifyTarget(targetRelayVar, source, target, move) {
-			const lastDamagedBy = source.getLastDamagedBy();
+			const lastDamagedBy = source.getLastDamagedBy(source.side);
 			if (lastDamagedBy?.position !== undefined) {
 				targetRelayVar.target = source.side.foe.active[lastDamagedBy.position];
 			}

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -10884,7 +10884,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		accuracy: 100,
 		basePower: 0,
 		damageCallback(pokemon) {
-			const lastDamagedBy = pokemon.getLastDamagedBy(pokemon.side);
+			const lastDamagedBy = pokemon.getLastDamagedBy(true);
 			if (lastDamagedBy !== undefined) {
 				return (lastDamagedBy.damage * 1.5) || 1;
 			}
@@ -10896,11 +10896,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
 		onTryHit(target, source, move) {
-			const lastDamagedBy = source.getLastDamagedBy(source.side);
+			const lastDamagedBy = source.getLastDamagedBy(true);
 			if (lastDamagedBy === undefined || !lastDamagedBy.thisTurn) return false;
 		},
 		onModifyTarget(targetRelayVar, source, target, move) {
-			const lastDamagedBy = source.getLastDamagedBy(source.side);
+			const lastDamagedBy = source.getLastDamagedBy(true);
 			if (lastDamagedBy?.position !== undefined) {
 				targetRelayVar.target = source.side.foe.active[lastDamagedBy.position];
 			}

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -10901,7 +10901,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		},
 		onModifyTarget(targetRelayVar, source, target, move) {
 			const lastDamagedBy = source.getLastDamagedBy();
-			if (lastDamagedBy !== undefined) {
+			if (lastDamagedBy?.position !== undefined) {
 				targetRelayVar.target = source.side.foe.active[lastDamagedBy.position];
 			}
 		},

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -10884,39 +10884,18 @@ export const Moves: {[moveid: string]: MoveData} = {
 		accuracy: 100,
 		basePower: 0,
 		damageCallback(pokemon) {
-			if (!pokemon.volatiles['metalburst']) return 0;
-			return pokemon.volatiles['metalburst'].damage || 1;
+			return (pokemon.lastDamageTaken * 1.5) || 1;
 		},
 		category: "Physical",
 		name: "Metal Burst",
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		beforeTurnCallback(pokemon) {
-			pokemon.addVolatile('metalburst');
-		},
 		onTryHit(target, source, move) {
-			if (!source.volatiles['metalburst']) return false;
-			if (source.volatiles['metalburst'].position === null) return false;
+			if (!source.lastDamageTaken) return false;
 		},
-		condition: {
-			duration: 1,
-			noCopy: true,
-			onStart(target, source, move) {
-				this.effectData.position = null;
-				this.effectData.damage = 0;
-			},
-			onRedirectTargetPriority: -1,
-			onRedirectTarget(target, source, source2) {
-				if (source !== this.effectData.target) return;
-				return source.side.foe.active[this.effectData.position];
-			},
-			onDamagingHit(damage, target, source, effect) {
-				if (source.side !== target.side) {
-					this.effectData.position = source.position;
-					this.effectData.damage = 1.5 * damage;
-				}
-			},
+		onRedirectTarget(target, source) {
+			return source.getLastAttackedBy();
 		},
 		secondary: null,
 		target: "scripted",

--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -173,7 +173,11 @@ export const Scripts: BattleScriptsData = {
 			move.priority = this.activeMove.priority;
 			if (!move.hasBounced) move.pranksterBoosted = this.activeMove.pranksterBoosted;
 		}
+
 		const baseTarget = move.target;
+		let targetRelayVar = {target};
+		targetRelayVar = this.runEvent('ModifyTarget', pokemon, target, move, targetRelayVar, true);
+		if (targetRelayVar.target !== undefined) target = targetRelayVar.target;
 		if (target === undefined) target = this.getRandomTarget(pokemon, move);
 		if (move.target === 'self' || move.target === 'allies') {
 			target = pokemon;

--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -173,7 +173,6 @@ export const Scripts: BattleScriptsData = {
 			move.priority = this.activeMove.priority;
 			if (!move.hasBounced) move.pranksterBoosted = this.activeMove.pranksterBoosted;
 		}
-
 		const baseTarget = move.target;
 		let targetRelayVar = {target};
 		targetRelayVar = this.runEvent('ModifyTarget', pokemon, target, move, targetRelayVar, true);
@@ -823,19 +822,16 @@ export const Scripts: BattleScriptsData = {
 		}
 
 		const damagedTargets: Pokemon[] = [];
-		const damagedDamage: number[] = [];
+		const damagedDamage = [];
 		for (const [i, t] of targets.entries()) {
 			if (typeof damage[i] === 'number' && t) {
 				damagedTargets.push(t);
-				damagedDamage.push(damage[i] as number);
+				damagedDamage.push(damage[i]);
 			}
 		}
 		const pokemonOriginalHP = pokemon.hp;
 		if (damagedDamage.length && !isSecondary && !isSelf) {
 			this.runEvent('DamagingHit', damagedTargets, pokemon, move, damagedDamage);
-			for (const damagedTarget of damagedTargets) {
-				damagedTarget.lastDamageTaken = damagedDamage[damagedDamage.length - 1];
-			}
 			if (moveData.onAfterHit) {
 				for (const t of damagedTargets) {
 					this.singleEvent('AfterHit', moveData, {}, t, pokemon, move);

--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -607,7 +607,7 @@ export const Scripts: BattleScriptsData = {
 		}
 		targetHits = Math.floor(targetHits);
 		let nullDamage = true;
-		let moveDamage: (number | boolean | undefined)[];
+		let moveDamage: (number | boolean | undefined)[] = [];
 		// There is no need to recursively check the ´sleepUsable´ flag as Sleep Talk can only be used while asleep.
 		const isSleepUsable = move.sleepUsable || this.dex.getMove(move.sourceEffect).sleepUsable;
 
@@ -715,7 +715,7 @@ export const Scripts: BattleScriptsData = {
 
 		for (const [i, target] of targetsCopy.entries()) {
 			if (target && pokemon !== target) {
-				target.gotAttacked(move, damage[i] as number | false | undefined, pokemon);
+				target.gotAttacked(move, moveDamage[i] as number | false | undefined, pokemon);
 			}
 		}
 

--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -819,16 +819,19 @@ export const Scripts: BattleScriptsData = {
 		}
 
 		const damagedTargets: Pokemon[] = [];
-		const damagedDamage = [];
+		const damagedDamage: number[] = [];
 		for (const [i, t] of targets.entries()) {
 			if (typeof damage[i] === 'number' && t) {
 				damagedTargets.push(t);
-				damagedDamage.push(damage[i]);
+				damagedDamage.push(damage[i] as number);
 			}
 		}
 		const pokemonOriginalHP = pokemon.hp;
 		if (damagedDamage.length && !isSecondary && !isSelf) {
 			this.runEvent('DamagingHit', damagedTargets, pokemon, move, damagedDamage);
+			for (const damagedTarget of damagedTargets) {
+				damagedTarget.lastDamageTaken = damagedDamage[damagedDamage.length - 1];
+			}
 			if (moveData.onAfterHit) {
 				for (const t of damagedTargets) {
 					this.singleEvent('AfterHit', moveData, {}, t, pokemon, move);

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -56,6 +56,7 @@ export interface EventMethods {
 		this: Battle, secondaries: SecondaryEffect[], target: Pokemon, source: Pokemon, move: ActiveMove
 	) => void;
 	onModifyType?: MoveEventMethods['onModifyType'];
+	onModifyTarget?: MoveEventMethods['onModifyTarget'];
 	onModifySpA?: CommonHandlers['ModifierSourceMove'];
 	onModifySpD?: CommonHandlers['ModifierMove'];
 	onModifySpe?: (this: Battle, spe: number, pokemon: Pokemon) => number | void;
@@ -160,6 +161,7 @@ export interface EventMethods {
 	onAllyModifySpD?: CommonHandlers['ModifierMove'];
 	onAllyModifySpe?: (this: Battle, spe: number, pokemon: Pokemon) => number | void;
 	onAllyModifyType?: MoveEventMethods['onModifyType'];
+	onAllyModifyTarget?: MoveEventMethods['onModifyTarget'];
 	onAllyModifyWeight?: (this: Battle, weighthg: number, pokemon: Pokemon) => number | void;
 	onAllyMoveAborted?: CommonHandlers['VoidMove'];
 	onAllyNegateImmunity?: ((this: Battle, pokemon: Pokemon, type: string) => boolean | void) | boolean;
@@ -262,6 +264,7 @@ export interface EventMethods {
 	onFoeModifySpD?: CommonHandlers['ModifierMove'];
 	onFoeModifySpe?: (this: Battle, spe: number, pokemon: Pokemon) => number | void;
 	onFoeModifyType?: MoveEventMethods['onModifyType'];
+	onFoeModifyTarget?: MoveEventMethods['onModifyTarget'];
 	onFoeModifyWeight?: (this: Battle, weighthg: number, pokemon: Pokemon) => number | void;
 	onFoeMoveAborted?: CommonHandlers['VoidMove'];
 	onFoeNegateImmunity?: ((this: Battle, pokemon: Pokemon, type: string) => boolean | void) | boolean;
@@ -364,6 +367,7 @@ export interface EventMethods {
 	onSourceModifySpD?: CommonHandlers['ModifierMove'];
 	onSourceModifySpe?: (this: Battle, spe: number, pokemon: Pokemon) => number | void;
 	onSourceModifyType?: MoveEventMethods['onModifyType'];
+	onSourceModifyTarget?: MoveEventMethods['onModifyTarget'];
 	onSourceModifyWeight?: (this: Battle, weighthg: number, pokemon: Pokemon) => number | void;
 	onSourceMoveAborted?: CommonHandlers['VoidMove'];
 	onSourceNegateImmunity?: ((this: Battle, pokemon: Pokemon, type: string) => boolean | void) | boolean;
@@ -468,6 +472,7 @@ export interface EventMethods {
 	onAnyModifySpD?: CommonHandlers['ModifierMove'];
 	onAnyModifySpe?: (this: Battle, spe: number, pokemon: Pokemon) => number | void;
 	onAnyModifyType?: MoveEventMethods['onModifyType'];
+	onAnyModifyTarget?: MoveEventMethods['onModifyTarget'];
 	onAnyModifyWeight?: (this: Battle, weighthg: number, pokemon: Pokemon) => number | void;
 	onAnyMoveAborted?: CommonHandlers['VoidMove'];
 	onAnyNegateImmunity?: ((this: Battle, pokemon: Pokemon, type: string) => boolean | void) | boolean;

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -109,11 +109,13 @@ export interface MoveEventMethods {
 	onModifyPriority?: CommonHandlers['ModifierSourceMove'];
 	onMoveFail?: CommonHandlers['VoidMove'];
 	onModifyType?: (this: Battle, move: ActiveMove, pokemon: Pokemon, target: Pokemon) => void;
+	onModifyTarget?: (this: Battle, relayVar: any, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => void;
 	onPrepareHit?: CommonHandlers['ResultMove'];
 	onTry?: CommonHandlers['ResultSourceMove'];
 	onTryHit?: CommonHandlers['ExtResultSourceMove'];
 	onTryHitField?: CommonHandlers['ResultMove'];
-	onTryHitSide?: (this: Battle, side: Side, source: Pokemon, move: ActiveMove) => boolean | null | "" | void;
+	onTryHitSide?: (this: Battle, side: Side, source: Pokemon, move: ActiveMove) => boolean |
+	 null | "" | void;
 	onTryImmunity?: CommonHandlers['ResultMove'];
 	onTryMove?: CommonHandlers['ResultSourceMove'];
 	onUseMoveMessage?: CommonHandlers['VoidSourceMove'];

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -202,6 +202,7 @@ export class Pokemon {
 	hurtThisTurn: number | null;
 	lastDamage: number;
 	attackedBy: {source: Pokemon, damage: number, thisTurn: boolean, move?: ID}[];
+	lastDamageTaken: number;
 
 	isActive: boolean;
 	activeTurns: number;
@@ -400,6 +401,7 @@ export class Pokemon {
 		this.hurtThisTurn = null;
 		this.lastDamage = 0;
 		this.attackedBy = [];
+		this.lastDamageTaken = 0;
 
 		this.isActive = false;
 		this.activeTurns = 0;
@@ -1295,7 +1297,8 @@ export class Pokemon {
 
 		this.lastDamage = 0;
 		this.attackedBy = [];
-		this.hurtThisTurn = null;
+		this.hurtThisTurn = 0;
+		this.lastDamageTaken = 0;
 		this.newlySwitched = true;
 		this.beingCalledBack = false;
 

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -21,6 +21,15 @@ interface MoveSlot {
 	virtual?: boolean;
 }
 
+interface Attacker {
+	source: Pokemon;
+	damage: number;
+	thisTurn: boolean;
+	move?: ID;
+	position?: number;
+	damageValue?: (number | boolean | undefined);
+}
+
 export interface EffectState {
 	// TODO: set this to be an actual number after converting data/ to .ts
 	duration?: number | any;
@@ -201,14 +210,7 @@ export class Pokemon {
 	 */
 	hurtThisTurn: number | null;
 	lastDamage: number;
-	attackedBy: {
-		source: Pokemon,
-		damage: number,
-		thisTurn: boolean,
-		move?: ID,
-		position?: number,
-		damageValue?: (number | boolean | undefined),
-	}[];
+	attackedBy: Attacker[];
 
 	isActive: boolean;
 	activeTurns: number;
@@ -793,9 +795,13 @@ export class Pokemon {
 		if (this.attackedBy.length === 0) return undefined;
 		return this.attackedBy[this.attackedBy.length - 1];
 	}
-
-	getLastDamagedBy() {
-		const damagedBy = this.attackedBy.filter(attacked => typeof attacked.damageValue === 'number');
+	/** attackedSide will filter out Attackers of the same side */
+	getLastDamagedBy(attackedSide?: Side) {
+		const damagedBy: Attacker[] = this.attackedBy.filter(
+			(attacker) =>
+			  typeof attacker.damageValue === 'number' &&
+			  (attackedSide === undefined || attackedSide !== attacker.source.side)
+		  );
 		if (damagedBy.length === 0) return undefined;
 		return damagedBy[damagedBy.length - 1];
 	}

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -201,7 +201,7 @@ export class Pokemon {
 	 */
 	hurtThisTurn: number | null;
 	lastDamage: number;
-	attackedBy: {source: Pokemon, damage: number, thisTurn: boolean, move?: ID}[];
+	attackedBy: {source: Pokemon, damage: number, thisTurn: boolean, move?: ID, position: number}[];
 
 	isActive: boolean;
 	activeTurns: number;
@@ -777,6 +777,7 @@ export class Pokemon {
 			damage,
 			move: move.id,
 			thisTurn: true,
+			position: source.position,
 		});
 	}
 

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -201,7 +201,13 @@ export class Pokemon {
 	 */
 	hurtThisTurn: number | null;
 	lastDamage: number;
-	attackedBy: {source: Pokemon, damage: number, thisTurn: boolean, move?: ID, position: number}[];
+	attackedBy: {
+		source: Pokemon,
+		damage: number,
+		thisTurn: boolean,
+		move?: ID, position: number,
+		damageValue: (number | boolean | undefined),
+	}[];
 
 	isActive: boolean;
 	activeTurns: number;
@@ -770,14 +776,15 @@ export class Pokemon {
 	}
 
 	gotAttacked(move: string | Move, damage: number | false | undefined, source: Pokemon) {
-		if (!damage) damage = 0;
+		const damageNumber = (typeof damage === 'number') ? damage : 0;
 		move = this.battle.dex.getMove(move);
 		this.attackedBy.push({
 			source,
-			damage,
+			damage: damageNumber,
 			move: move.id,
 			thisTurn: true,
 			position: source.position,
+			damageValue: damage,
 		});
 	}
 
@@ -787,7 +794,7 @@ export class Pokemon {
 	}
 
 	getLastDamagedBy() {
-		const damagedBy = this.attackedBy.filter(attacked => attacked.damage);
+		const damagedBy = this.attackedBy.filter(attacked => typeof attacked.damageValue === 'number');
 		if (damagedBy.length === 0) return undefined;
 		return damagedBy[damagedBy.length - 1];
 	}

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -202,7 +202,6 @@ export class Pokemon {
 	hurtThisTurn: number | null;
 	lastDamage: number;
 	attackedBy: {source: Pokemon, damage: number, thisTurn: boolean, move?: ID}[];
-	lastDamageTaken: number;
 
 	isActive: boolean;
 	activeTurns: number;
@@ -401,7 +400,6 @@ export class Pokemon {
 		this.hurtThisTurn = null;
 		this.lastDamage = 0;
 		this.attackedBy = [];
-		this.lastDamageTaken = 0;
 
 		this.isActive = false;
 		this.activeTurns = 0;
@@ -785,6 +783,12 @@ export class Pokemon {
 	getLastAttackedBy() {
 		if (this.attackedBy.length === 0) return undefined;
 		return this.attackedBy[this.attackedBy.length - 1];
+	}
+
+	getLastDamagedBy() {
+		const damagedBy = this.attackedBy.filter(attacked => attacked.damage);
+		if (damagedBy.length === 0) return undefined;
+		return damagedBy[damagedBy.length - 1];
 	}
 
 	/**
@@ -1297,8 +1301,7 @@ export class Pokemon {
 
 		this.lastDamage = 0;
 		this.attackedBy = [];
-		this.hurtThisTurn = 0;
-		this.lastDamageTaken = 0;
+		this.hurtThisTurn = null;
 		this.newlySwitched = true;
 		this.beingCalledBack = false;
 

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -205,8 +205,9 @@ export class Pokemon {
 		source: Pokemon,
 		damage: number,
 		thisTurn: boolean,
-		move?: ID, position: number,
-		damageValue: (number | boolean | undefined),
+		move?: ID,
+		position?: number,
+		damageValue?: (number | boolean | undefined),
 	}[];
 
 	isActive: boolean;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -795,12 +795,12 @@ export class Pokemon {
 		if (this.attackedBy.length === 0) return undefined;
 		return this.attackedBy[this.attackedBy.length - 1];
 	}
-	/** attackedSide will filter out Attackers of the same side */
-	getLastDamagedBy(attackedSide?: Side) {
+
+	getLastDamagedBy(filterOutSameSide: boolean) {
 		const damagedBy: Attacker[] = this.attackedBy.filter(
 			(attacker) =>
 			  typeof attacker.damageValue === 'number' &&
-			  (attackedSide === undefined || attackedSide !== attacker.source.side)
+			  (filterOutSameSide === undefined || this.side !== attacker.source.side)
 		  );
 		if (damagedBy.length === 0) return undefined;
 		return damagedBy[damagedBy.length - 1];

--- a/test/sim/moves/metalburst.js
+++ b/test/sim/moves/metalburst.js
@@ -14,13 +14,13 @@ describe('Metal Burst', function () {
 		battle = common.createBattle({gameType: 'doubles'});
 		battle.setPlayer('p1', {team: [
 			{species: 'snorlax', moves: ['sleeptalk', 'metalburst']},
-			{species: 'tauros', moves: ['sleeptalk']},
+			{species: 'golem', moves: ['sleeptalk', 'tackle']},
 		]});
 		battle.setPlayer('p2', {team: [
 			{species: 'breloom', moves: ['sleeptalk', 'sonicboom']},
 			{species: 'venusaur', moves: ['sleeptalk', 'spore']},
 		]});
-		battle.makeChoices('move metalburst, move sleeptalk', 'move sonicboom 1, move sleeptalk');
+		battle.makeChoices('move metalburst, move tackle -1', 'move sonicboom 1, move sleeptalk');
 		const breloomHpTurn1 = battle.p2.active[0].hp;
 		assert.equal(breloomHpTurn1, battle.p2.active[0].maxhp - battle.dex.getMove('sonicboom').damage * 1.5);
 		battle.makeChoices('move sleeptalk, move sleeptalk', 'move sonicboom 1, move spore 1');

--- a/test/sim/moves/metalburst.js
+++ b/test/sim/moves/metalburst.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Metal Burst', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should run conditions for submove', function () {
+		battle = common.createBattle();
+		battle.setPlayer('p1', {team: [{species: 'snorlax', moves: ['sleeptalk', 'metalburst']}]});
+		battle.setPlayer('p2', {team: [{species: 'breloom', moves: ['spore', 'sonicboom']}]});
+		battle.makeChoices('move metalburst', 'move sonicboom');
+		const breloomHpTurn1 = battle.p2.active[0].hp;
+		assert.equal(breloomHpTurn1, battle.p2.active[0].maxhp - battle.dex.getMove('sonicboom').damage * 1.5);
+		battle.makeChoices('move sleeptalk', 'move spore');
+		battle.makeChoices('move sleeptalk', 'move sonicboom');
+		assert.equal(battle.p2.active[0].hp, breloomHpTurn1 - battle.dex.getMove('sonicboom').damage * 1.5);
+	});
+});

--- a/test/sim/moves/metalburst.js
+++ b/test/sim/moves/metalburst.js
@@ -11,7 +11,7 @@ describe('Metal Burst', function () {
 	});
 
 	it('should run conditions for submove', function () {
-		battle = common.createBattle();
+		battle = common.createBattle({seed: [1, 2, 3, 4]}); // Snorlax needs to sleep for more than 1 turn
 		battle.setPlayer('p1', {team: [{species: 'snorlax', moves: ['sleeptalk', 'metalburst']}]});
 		battle.setPlayer('p2', {team: [{species: 'breloom', moves: ['spore', 'sonicboom']}]});
 		battle.makeChoices('move metalburst', 'move sonicboom');
@@ -23,7 +23,8 @@ describe('Metal Burst', function () {
 	});
 
 	it('should target the opposing Pokemon that hit the user with an attack most recently that turn', function () {
-		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 4].map(i => i + 1111111)});
+		// The seed should select venusaur if the test would otherwise fail
+		battle = common.createBattle({gameType: 'doubles', seed: [3, 4, 5, 6]});
 		battle.setPlayer('p1', {team: [
 			{species: 'snorlax', moves: ['metalburst']},
 			{species: 'tauros', moves: ['sleeptalk']},

--- a/test/sim/moves/metalburst.js
+++ b/test/sim/moves/metalburst.js
@@ -11,14 +11,19 @@ describe('Metal Burst', function () {
 	});
 
 	it('should run conditions for submove', function () {
-		battle = common.createBattle({seed: [1, 2, 3, 4]}); // Snorlax needs to sleep for more than 1 turn
-		battle.setPlayer('p1', {team: [{species: 'snorlax', moves: ['sleeptalk', 'metalburst']}]});
-		battle.setPlayer('p2', {team: [{species: 'breloom', moves: ['spore', 'sonicboom']}]});
-		battle.makeChoices('move metalburst', 'move sonicboom');
+		battle = common.createBattle({gameType: 'doubles'});
+		battle.setPlayer('p1', {team: [
+			{species: 'snorlax', moves: ['sleeptalk', 'metalburst']},
+			{species: 'tauros', moves: ['sleeptalk']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'breloom', moves: ['sleeptalk', 'sonicboom']},
+			{species: 'venusaur', moves: ['sleeptalk', 'spore']},
+		]});
+		battle.makeChoices('move metalburst, move sleeptalk', 'move sonicboom 1, move sleeptalk');
 		const breloomHpTurn1 = battle.p2.active[0].hp;
 		assert.equal(breloomHpTurn1, battle.p2.active[0].maxhp - battle.dex.getMove('sonicboom').damage * 1.5);
-		battle.makeChoices('move sleeptalk', 'move spore');
-		battle.makeChoices('move sleeptalk', 'move sonicboom');
+		battle.makeChoices('move sleeptalk, move sleeptalk', 'move sonicboom 1, move spore 1');
 		assert.equal(battle.p2.active[0].hp, breloomHpTurn1 - battle.dex.getMove('sonicboom').damage * 1.5);
 	});
 

--- a/test/sim/moves/metalburst.js
+++ b/test/sim/moves/metalburst.js
@@ -21,4 +21,19 @@ describe('Metal Burst', function () {
 		battle.makeChoices('move sleeptalk', 'move sonicboom');
 		assert.equal(battle.p2.active[0].hp, breloomHpTurn1 - battle.dex.getMove('sonicboom').damage * 1.5);
 	});
+
+	it('should target the opposing Pokemon that hit the user with an attack most recently that turn', function () {
+		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 4].map(i => i + 1111111)});
+		battle.setPlayer('p1', {team: [
+			{species: 'snorlax', moves: ['metalburst']},
+			{species: 'tauros', moves: ['sleeptalk']},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'breloom', moves: ['swift']},
+			{species: 'venusaur', moves: ['swift']},
+		]});
+		battle.makeChoices();
+		assert.false.fullHP(battle.p2.active[0]);
+		assert.fullHP(battle.p2.active[1]);
+	});
 });

--- a/test/sim/moves/metalburst.js
+++ b/test/sim/moves/metalburst.js
@@ -44,4 +44,14 @@ describe('Metal Burst', function () {
 		assert.false.fullHP(battle.p2.active[0]);
 		assert.fullHP(battle.p2.active[1]);
 	});
+
+	it('should deal 1 damage if hit, but didn\'t take damage', function () {
+		battle = common.createBattle();
+		battle.setPlayer('p1', {team: [{species: 'snorlax', ability: 'sturdy', moves: ['sleeptalk', 'metalburst']}]});
+		battle.setPlayer('p2', {team: [{species: 'breloom', moves: ['closecombat', 'falseswipe']}]});
+
+		battle.makeChoices('move sleeptalk', 'move closecombat');
+		battle.makeChoices('move metalburst', 'move falseswipe');
+		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp - 1);
+	});
 });

--- a/test/sim/moves/metalburst.js
+++ b/test/sim/moves/metalburst.js
@@ -35,9 +35,11 @@ describe('Metal Burst', function () {
 			{species: 'tauros', moves: ['sleeptalk']},
 		]});
 		battle.setPlayer('p2', {team: [
-			{species: 'breloom', moves: ['swift']},
+			{species: 'breloom', moves: ['uturn']},
 			{species: 'venusaur', moves: ['swift']},
+			{species: 'gallade', moves: ['sleeptalk']},
 		]});
+		battle.makeChoices('move metalburst, move sleeptalk', 'move uturn 1, move swift');
 		battle.makeChoices();
 		assert.false.fullHP(battle.p2.active[0]);
 		assert.fullHP(battle.p2.active[1]);


### PR DESCRIPTION
> If a move that calls another move calls Metal Burst it should behave exactly like a normal Metal Burst ie. deal 1.5x damage back to the Pokemon that most recently targeted it. See replay
> 
> Added by scheibo

Question: Smogon states that this move can deal 1 damage if the user of the move did not take damage from an attacker. Does this include all attacks, including failures or non-damaging moves?