### PR TITLE
Add Gen 8 BSS Factory

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1356,6 +1356,20 @@ export const Formats: FormatList = [
 		ruleset: ['Obtainable', 'Same Type Clause', 'HP Percentage Mod', 'Cancel Mod', 'Sleep Clause Mod'],
 	},
 	{
+		name: "[Gen 8] BSS Factory",
+		desc: `Randomized 3v3 Singles featuring Pok&eacute;mon and movesets popular in Battle Stadium Singles.`,
+		threads: [
+			`&bullet; <a href="https://www.smogon.com/forums/threads/3675374/">Information and Suggestions Thread</a>`,
+		],
+
+		team: 'randomBSSFactory',
+		teamLength: {
+			validate: [3, 6],
+			battle: 3,
+		},
+		ruleset: ['Obtainable', 'Standard GBU'],
+	},
+	{
 		name: "[Gen 8] Super Staff Bros 4",
 		desc: "The fourth iteration of Super Staff Bros is here! Battle with a random team of pokemon created by the sim staff.",
 		threads: [
@@ -1415,20 +1429,6 @@ export const Formats: FormatList = [
 		},
 		searchShow: false,
 		ruleset: ['Obtainable', 'HP Percentage Mod', 'Cancel Mod', 'Team Preview', 'Dynamax Clause'],
-	},
-	{
-		name: "[Gen 8] BSS Factory",
-		desc: `Randomized 3v3 Singles featuring Pok&eacute;mon and movesets popular in Battle Stadium Singles.`,
-		threads: [
-			`&bullet; <a href="https://www.smogon.com/forums/threads/3675374/">Information and Suggestions Thread</a>`,
-		],
-
-		team: 'randomBSSFactory',
-		teamLength: {
-			validate: [3, 6],
-			battle: 3,
-		},
-		ruleset: ['Obtainable', 'Standard GBU'],
 	},
 	{
 		name: "[Gen 8] Hackmons Cup",

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1417,6 +1417,20 @@ export const Formats: FormatList = [
 		ruleset: ['Obtainable', 'HP Percentage Mod', 'Cancel Mod', 'Team Preview', 'Dynamax Clause'],
 	},
 	{
+		name: "[Gen 8] BSS Factory",
+		desc: `Randomized 3v3 Singles featuring Pok&eacute;mon and movesets popular in Battle Stadium Singles.`,
+		threads: [
+			`&bullet; <a href="https://www.smogon.com/forums/threads/3675374/">Information and Suggestions Thread</a>`,
+		],
+
+		team: 'randomBSSFactory',
+		teamLength: {
+			validate: [3, 6],
+			battle: 3,
+		},
+		ruleset: ['Obtainable', 'Standard GBU'],
+	},
+	{
 		name: "[Gen 8] Hackmons Cup",
 		desc: `Randomized teams of level-balanced Pok&eacute;mon with absolutely any ability, moves, and item.`,
 

--- a/data/bss-factory-sets.json
+++ b/data/bss-factory-sets.json
@@ -37,6 +37,7 @@
         "ability": ["Static"],
         "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
+        "ivs": {"atk": 0},
         "moves": [["Hurricane"], ["Thunderbolt"], ["Heat Wave"], ["Roost", "Steel Wing"]]
       },
       {
@@ -706,6 +707,7 @@
         "item": ["Custap Berry", "Weakness Policy"],
         "ability": ["Sturdy"],
         "evs": {"hp": 252, "def": 4, "spa": 252},
+        "ivs": {"atk": 0},
         "nature": "Modest",
         "moves": [["Thunderbolt"], ["Flash Cannon"], ["Volt Switch"], ["Steel Beam", "Mirror Coat"]]
       },
@@ -714,6 +716,7 @@
         "item": ["Assault Vest", "Choice Specs"],
         "ability": ["Analytic"],
         "evs": {"hp": 252, "def": 4, "spa": 252},
+        "ivs": {"atk": 0},
         "nature": "Modest",
         "moves": [["Thunderbolt"], ["Flash Cannon"], ["Volt Switch"], ["Body Press"]]
       }
@@ -736,6 +739,7 @@
         "ability": ["Intimidate"],
         "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
+        "ivs": {"atk": 0},
         "moves": [["Hurricane"], ["Draco Meteor"], ["Fire Blast"], ["Hydro Pump"]]
       }
     ]
@@ -749,7 +753,6 @@
         "ability": ["Speed Boost"],
         "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "ivs": {"atk": 0},
         "moves": [["Flare Blitz"], ["Close Combat"], ["Thunder Punch"], ["Swords Dance", "Earthquake", "Protect"]]
       },
       {
@@ -982,6 +985,7 @@
         "ability": ["Electric Surge"],
         "evs": {"hp": 4, "spa": 252, "spe": 252},
         "nature": "Timid",
+        "ivs": {"atk": 0},
         "moves": [["Thunderbolt"], ["Dazzling Gleam"], ["Grass Knot"], ["Volt Switch"]]
       },
       {
@@ -990,6 +994,7 @@
         "ability": ["Electric Surge"],
         "evs": {"hp": 252, "spa": 4, "spe": 252},
         "nature": "Timid",
+        "ivs": {"atk": 0},
         "moves": [["Reflect"], ["Light Screen"], ["Thunderbolt"], ["Taunt"]]
       },
       {
@@ -1548,10 +1553,7 @@
         "ability": ["Stance Change"],
         "evs": {"hp": 252, "atk": 252, "spd": 4},
         "nature": "Adamant",
-        "moves": [["Shadow Sneak"], ["Iron Head", "Sacred Sword"], ["Swords Dance"], ["King's Shield",
-            "Shadow Claw"
-          ]
-        ]
+        "moves": [["Shadow Sneak"], ["Iron Head", "Sacred Sword"], ["Swords Dance"], ["King's Shield", "Shadow Claw"]]
       },
       {
         "species": "Aegislash",
@@ -2032,9 +2034,7 @@
     "sets": [
       {
         "species": "Cloyster",
-        "item": ["Focus Sash",
-          "King's Rock"
-        ],
+        "item": ["Focus Sash", "King's Rock"],
         "ability": ["Skill Link"],
         "evs": {"atk": 252, "def": 4, "spe": 252},
         "nature": "Jolly",

--- a/data/bss-factory-sets.json
+++ b/data/bss-factory-sets.json
@@ -734,7 +734,7 @@
         "species": "Salamence",
         "item": ["Life Orb"],
         "ability": ["Intimidate"],
-        "evs": {"atk": 252, "spd": 4, "spe": 252},
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
         "moves": [["Hurricane"], ["Draco Meteor"], ["Fire Blast"], ["Hydro Pump"]]
       }

--- a/data/bss-factory-sets.json
+++ b/data/bss-factory-sets.json
@@ -4,94 +4,27 @@
     "sets": [
       {
         "species": "Cinderace-Gmax",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Libero"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Libero"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Pyro Ball"
-          ],
-          [
-            "High Jump Kick",
-            "Counter"
-          ],
-          [
-            "Bounce",
-            "Sucker Punch"
-          ],
-          [
-            "Iron Head",
-            "Gunk Shot",
-            "Zen Headbutt"
-          ]
-        ]
+        "moves": [["Pyro Ball"], ["High Jump Kick", "Counter"], ["Bounce", "Sucker Punch"], ["Iron Head", "Gunk Shot", "Zen Headbutt"]]
       },
       {
         "species": "Cinderace-Gmax",
-        "item": [
-          "Choice Scarf"
-        ],
-        "ability": [
-          "Libero"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Choice Scarf"],
+        "ability": ["Libero"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Pyro Ball"
-          ],
-          [
-            "High Jump Kick"
-          ],
-          [
-            "Bounce"
-          ],
-          [
-            "Iron Head"
-          ]
-        ]
+        "moves": [["Pyro Ball"], ["High Jump Kick"], ["Bounce"], ["Iron Head"]]
       },
       {
         "species": "Cinderace-Gmax",
-        "item": [
-          "Scope Lens"
-        ],
-        "ability": [
-          "Libero"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Scope Lens"],
+        "ability": ["Libero"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Pyro Ball"
-          ],
-          [
-            "Bounce"
-          ],
-          [
-            "Iron Head"
-          ],
-          [
-            "Focus Energy"
-          ]
-        ]
+        "moves": [["Pyro Ball"], ["Bounce"], ["Iron Head"], ["Focus Energy"]]
       }
     ]
   },
@@ -100,102 +33,28 @@
     "sets": [
       {
         "species": "Zapdos",
-        "item": [
-          "Sharp Beak"
-        ],
-        "ability": [
-          "Static"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Sharp Beak"],
+        "ability": ["Static"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "moves": [
-          [
-            "Hurricane"
-          ],
-          [
-            "Thunderbolt"
-          ],
-          [
-            "Heat Wave"
-          ],
-          [
-            "Roost",
-            "Steel Wing"
-          ]
-        ]
+        "moves": [["Hurricane"], ["Thunderbolt"], ["Heat Wave"], ["Roost", "Steel Wing"]]
       },
       {
         "species": "Zapdos",
-        "item": [
-          "Leftovers"
-        ],
-        "ability": [
-          "Pressure"
-        ],
-        "evs": {
-          "hp": 252,
-          "spd": 252,
-          "spe": 4
-        },
+        "item": ["Leftovers"],
+        "ability": ["Pressure"],
+        "evs": {"hp": 252, "spd": 252, "spe": 4},
         "nature": "Calm",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Discharge"
-          ],
-          [
-            "Roost"
-          ],
-          [
-            "Eerie Impulse"
-          ],
-          [
-            "Substitute",
-            "Heat Wave",
-            "Hurricane"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Discharge"], ["Roost"], ["Eerie Impulse"], ["Substitute", "Heat Wave", "Hurricane"]]
       },
       {
         "species": "Zapdos-Galar",
-        "item": [
-          "Weakness Policy",
-          "Life Orb",
-          "Sharp Beak",
-          "Sitrus Berry"
-        ],
-        "ability": [
-          "Defiant"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Weakness Policy", "Life Orb", "Sharp Beak", "Sitrus Berry"],
+        "ability": ["Defiant"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Thunderous Kick",
-            "Close Combat"
-          ],
-          [
-            "Brave Bird",
-            "Dual Wingbeat"
-          ],
-          [
-            "Steel Wing",
-            "Blaze Kick"
-          ],
-          [
-            "Bulk Up"
-          ]
-        ]
+        "moves": [["Thunderous Kick", "Close Combat"], ["Brave Bird", "Dual Wingbeat"], ["Steel Wing", "Blaze Kick"], ["Bulk Up"]]
       }
     ]
   },
@@ -204,124 +63,35 @@
     "sets": [
       {
         "species": "Mimikyu",
-        "item": [
-          "Spell Tag"
-        ],
-        "ability": [
-          "Disguise"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Spell Tag"],
+        "ability": ["Disguise"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Swords Dance"
-          ],
-          [
-            "Play Rough"
-          ],
-          [
-            "Shadow Sneak"
-          ],
-          [
-            "Phantom Force",
-            "Shadow Claw"
-          ]
-        ]
+        "moves": [["Swords Dance"], ["Play Rough"], ["Shadow Sneak"], ["Phantom Force", "Shadow Claw"]]
       },
       {
         "species": "Mimikyu",
-        "item": [
-          "Kee Berry"
-        ],
-        "ability": [
-          "Disguise"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "def": 4
-        },
+        "item": ["Kee Berry"],
+        "ability": ["Disguise"],
+        "evs": {"hp": 252, "atk": 252, "def": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Play Rough"
-          ],
-          [
-            "Shadow Sneak"
-          ],
-          [
-            "Drain Punch"
-          ],
-          [
-            "Swords Dance"
-          ]
-        ]
+        "moves": [["Play Rough"], ["Shadow Sneak"], ["Drain Punch"], ["Swords Dance"]]
       },
       {
         "species": "Mimikyu",
-        "item": [
-          "Babiri Berry"
-        ],
-        "ability": [
-          "Disguise"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "def": 4
-        },
+        "item": ["Babiri Berry"],
+        "ability": ["Disguise"],
+        "evs": {"hp": 252, "atk": 252, "def": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Play Rough"
-          ],
-          [
-            "Shadow Sneak"
-          ],
-          [
-            "Drain Punch"
-          ],
-          [
-            "Swords Dance"
-          ]
-        ]
+        "moves": [["Play Rough"], ["Shadow Sneak"], ["Drain Punch"], ["Swords Dance"]]
       },
       {
         "species": "Mimikyu",
-        "item": [
-          "Custap Berry",
-          "Salac Berry",
-          "Liechi Berry"
-        ],
-        "ability": [
-          "Disguise"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Custap Berry", "Salac Berry", "Liechi Berry"],
+        "ability": ["Disguise"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Substitute"
-          ],
-          [
-            "Curse"
-          ],
-          [
-            "Shadow Sneak",
-            "Play Rough"
-          ],
-          [
-            "Phantom Force",
-            "Shadow Claw"
-          ]
-        ]
+        "moves": [["Substitute"], ["Curse"], ["Shadow Sneak", "Play Rough"], ["Phantom Force", "Shadow Claw"]]
       }
     ]
   },
@@ -330,62 +100,19 @@
     "sets": [
       {
         "species": "Landorus-Therian",
-        "item": [
-          "Sharp Beak",
-          "Choice Scarf"
-        ],
-        "ability": [
-          "Intimidate"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Sharp Beak", "Choice Scarf"],
+        "ability": ["Intimidate"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Earthquake"
-          ],
-          [
-            "Fly"
-          ],
-          [
-            "Stone Edge"
-          ],
-          [
-            "Superpower"
-          ]
-        ]
+        "moves": [["Earthquake"], ["Fly"], ["Stone Edge"], ["Superpower"]]
       },
       {
         "species": "Landorus-Therian",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Intimidate"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Intimidate"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Earthquake"
-          ],
-          [
-            "Rock Tomb"
-          ],
-          [
-            "Stealth Rock"
-          ],
-          [
-            "Self-Destruct"
-          ]
-        ]
+        "moves": [["Earthquake"], ["Rock Tomb"], ["Stealth Rock"], ["Self-Destruct"]]
       }
     ]
   },
@@ -394,71 +121,21 @@
     "sets": [
       {
         "species": "Tapu Fini",
-        "item": [
-          "Leftovers"
-        ],
-        "ability": [
-          "Misty Surge"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Leftovers"],
+        "ability": ["Misty Surge"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Scald",
-            "Hydro Pump"
-          ],
-          [
-            "Moonblast"
-          ],
-          [
-            "Calm Mind"
-          ],
-          [
-            "Taunt",
-            "Reflect",
-            "Iron Defense"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Scald", "Hydro Pump"], ["Moonblast"], ["Calm Mind"], ["Taunt", "Reflect", "Iron Defense"]]
       },
       {
         "species": "Tapu Fini",
-        "item": [
-          "Choice Scarf"
-        ],
-        "ability": [
-          "Misty Surge"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Choice Scarf"],
+        "ability": ["Misty Surge"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Hydro Pump"
-          ],
-          [
-            "Moonblast"
-          ],
-          [
-            "Trick"
-          ],
-          [
-            "Calm Mind",
-            "Ice Beam"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Hydro Pump"], ["Moonblast"], ["Trick"], ["Calm Mind", "Ice Beam"]]
       }
     ]
   },
@@ -467,70 +144,21 @@
     "sets": [
       {
         "species": "Nihilego",
-        "item": [
-          "Power Herb"
-        ],
-        "ability": [
-          "Beast Boost"
-        ],
-        "evs": {
-          "def": 84,
-          "spa": 172,
-          "spe": 252
-        },
+        "item": ["Power Herb"],
+        "ability": ["Beast Boost"],
+        "evs": {"def": 84, "spa": 172, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Power Gem"
-          ],
-          [
-            "Sludge Wave"
-          ],
-          [
-            "Grass Knot",
-            "Thunderbolt",
-            "Dazzling Gleam"
-          ],
-          [
-            "Meteor Beam"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Power Gem"], ["Sludge Wave"], ["Grass Knot", "Thunderbolt", "Dazzling Gleam"], ["Meteor Beam"]]
       },
       {
         "species": "Nihilego",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Beast Boost"
-        ],
-        "evs": {
-          "def": 84,
-          "spa": 172,
-          "spe": 252
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Beast Boost"],
+        "evs": {"def": 84, "spa": 172, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Power Gem"
-          ],
-          [
-            "Sludge Wave",
-            "Toxic Spikes"
-          ],
-          [
-            "Stealth Rock"
-          ],
-          [
-            "Thunder Wave"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Power Gem"], ["Sludge Wave", "Toxic Spikes"], ["Stealth Rock"], ["Thunder Wave"]]
       }
     ]
   },
@@ -539,63 +167,19 @@
     "sets": [
       {
         "species": "Rillaboom-Gmax",
-        "item": [
-          "Choice Band"
-        ],
-        "ability": [
-          "Grassy Surge"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "def": 4
-        },
+        "item": ["Choice Band"],
+        "ability": ["Grassy Surge"],
+        "evs": {"hp": 252, "atk": 252, "def": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Grassy Glide"
-          ],
-          [
-            "Superpower"
-          ],
-          [
-            "Knock Off"
-          ],
-          [
-            "High Horsepower",
-            "U-turn",
-            "Wood Hammer"
-          ]
-        ]
+        "moves": [["Grassy Glide"], ["Superpower"], ["Knock Off"], ["High Horsepower", "U-turn", "Wood Hammer"]]
       },
       {
         "species": "Rillaboom-Gmax",
-        "item": [
-          "Grassy Seed"
-        ],
-        "ability": [
-          "Grassy Surge"
-        ],
-        "evs": {
-          "atk": 252,
-          "def": 4,
-          "spe": 252
-        },
+        "item": ["Grassy Seed"],
+        "ability": ["Grassy Surge"],
+        "evs": {"atk": 252, "def": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Grassy Glide"
-          ],
-          [
-            "Acrobatics"
-          ],
-          [
-            "Drain Punch"
-          ],
-          [
-            "Swords Dance"
-          ]
-        ]
+        "moves": [["Grassy Glide"], ["Acrobatics"], ["Drain Punch"], ["Swords Dance"]]
       }
     ]
   },
@@ -604,105 +188,29 @@
     "sets": [
       {
         "species": "Porygon2",
-        "item": [
-          "Eviolite"
-        ],
-        "ability": [
-          "Trace"
-        ],
-        "evs": {
-          "hp": 244,
-          "def": 252,
-          "spd": 12
-        },
+        "item": ["Eviolite"],
+        "ability": ["Trace"],
+        "evs": {"hp": 244, "def": 252, "spd": 12},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Ice Beam"
-          ],
-          [
-            "Discharge",
-            "Tri Attack",
-            "Shadow Ball",
-            "Foul Play"
-          ],
-          [
-            "Recover"
-          ],
-          [
-            "Trick Room",
-            "Thunder Wave",
-            "Speed Swap"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Ice Beam"], ["Discharge", "Tri Attack", "Shadow Ball", "Foul Play"], ["Recover"], ["Trick Room", "Thunder Wave", "Speed Swap"]]
       },
       {
         "species": "Porygon2",
-        "item": [
-          "Eviolite"
-        ],
-        "ability": [
-          "Download"
-        ],
-        "evs": {
-          "hp": 244,
-          "spa": 252,
-          "spd": 12
-        },
+        "item": ["Eviolite"],
+        "ability": ["Download"],
+        "evs": {"hp": 244, "spa": 252, "spd": 12},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Ice Beam"
-          ],
-          [
-            "Discharge"
-          ],
-          [
-            "Hyper Beam",
-            "Tri Attack"
-          ],
-          [
-            "Trick Room",
-            "Recover"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Ice Beam"], ["Discharge"], ["Hyper Beam", "Tri Attack"], ["Trick Room", "Recover"]]
       },
       {
         "species": "Porygon2",
-        "item": [
-          "Eviolite"
-        ],
-        "ability": [
-          "Download"
-        ],
-        "evs": {
-          "hp": 244,
-          "atk": 28,
-          "def": 172,
-          "spa": 60,
-          "spd": 4
-        },
+        "item": ["Eviolite"],
+        "ability": ["Download"],
+        "evs": {"hp": 244, "atk": 28, "def": 172, "spa": 60, "spd": 4},
         "nature": "Quiet",
-        "moves": [
-          [
-            "Hyper Beam"
-          ],
-          [
-            "Giga Impact"
-          ],
-          [
-            "Ice Beam"
-          ],
-          [
-            "Shadow Ball"
-          ]
-        ]
+        "moves": [["Hyper Beam"], ["Giga Impact"], ["Ice Beam"], ["Shadow Ball"]]
       }
     ]
   },
@@ -711,59 +219,18 @@
     "sets": [
       {
         "species": "Dracovish",
-        "item": [
-          "Choice Band"
-        ],
-        "ability": [
-          "Strong Jaw"
-        ],
-        "evs": {
-          "atk": 252,
-          "def": 4,
-          "spe": 252
-        },
+        "item": ["Choice Band"],
+        "ability": ["Strong Jaw"],
+        "evs": {"atk": 252, "def": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Fishious Rend"
-          ],
-          [
-            "Outrage"
-          ],
-          [
-            "Sleep Talk"
-          ]
-        ]
-      },
+        "moves": [["Fishious Rend"], ["Outrage"], ["Sleep Talk"]]},
       {
         "species": "Dracovish",
-        "item": [
-          "Life Orb"
-        ],
-        "ability": [
-          "Sand Rush"
-        ],
-        "evs": {
-          "atk": 252,
-          "def": 4,
-          "spe": 252
-        },
+        "item": ["Life Orb"],
+        "ability": ["Sand Rush"],
+        "evs": {"atk": 252, "def": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Fishious Rend"
-          ],
-          [
-            "Outrage"
-          ],
-          [
-            "Rock Blast"
-          ],
-          [
-            "Psychic Fangs",
-            "Protect"
-          ]
-        ]
+        "moves": [["Fishious Rend"], ["Outrage"], ["Rock Blast"], ["Psychic Fangs", "Protect"]]
       }
     ]
   },
@@ -772,62 +239,19 @@
     "sets": [
       {
         "species": "Dracozolt",
-        "item": [
-          "Power Herb"
-        ],
-        "ability": [
-          "Sand Rush"
-        ],
-        "evs": {
-          "atk": 252,
-          "spa": 4,
-          "spe": 252
-        },
+        "item": ["Power Herb"],
+        "ability": ["Sand Rush"],
+        "evs": {"atk": 252, "spa": 4, "spe": 252},
         "nature": "Naive",
-        "moves": [
-          [
-            "Bolt Beak"
-          ],
-          [
-            "Outrage"
-          ],
-          [
-            "Meteor Beam"
-          ],
-          [
-            "Fire Blast"
-          ]
-        ]
+        "moves": [["Bolt Beak"], ["Outrage"], ["Meteor Beam"], ["Fire Blast"]]
       },
       {
         "species": "Dracozolt",
-        "item": [
-          "Life Orb"
-        ],
-        "ability": [
-          "Hustle"
-        ],
-        "evs": {
-          "atk": 252,
-          "spa": 4,
-          "spe": 252
-        },
+        "item": ["Life Orb"],
+        "ability": ["Hustle"],
+        "evs": {"atk": 252, "spa": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Bolt Beak"
-          ],
-          [
-            "Outrage"
-          ],
-          [
-            "Aerial Ace"
-          ],
-          [
-            "Fire Fang",
-            "Low Kick"
-          ]
-        ]
+        "moves": [["Bolt Beak"], ["Outrage"], ["Aerial Ace"], ["Fire Fang", "Low Kick"]]
       }
     ]
   },
@@ -836,104 +260,30 @@
     "sets": [
       {
         "species": "Ferrothorn",
-        "item": [
-          "Leftovers"
-        ],
-        "ability": [
-          "Iron Barbs"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Leftovers"],
+        "ability": ["Iron Barbs"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Relaxed",
-        "ivs": {
-          "spe": 0
-        },
-        "moves": [
-          [
-            "Gyro Ball"
-          ],
-          [
-            "Leech Seed"
-          ],
-          [
-            "Protect",
-            "Stealth Rock"
-          ],
-          [
-            "Bullet Seed",
-            "Body Press"
-          ]
-        ]
+        "ivs": {"spe": 0},
+        "moves": [["Gyro Ball"], ["Leech Seed"], ["Protect", "Stealth Rock"], ["Bullet Seed", "Body Press"]]
       },
       {
         "species": "Ferrothorn",
-        "item": [
-          "Leftovers",
-          "Occa Berry"
-        ],
-        "ability": [
-          "Iron Barbs"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Leftovers", "Occa Berry"],
+        "ability": ["Iron Barbs"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Relaxed",
-        "ivs": {
-          "spe": 0
-        },
-        "moves": [
-          [
-            "Gyro Ball"
-          ],
-          [
-            "Iron Defense"
-          ],
-          [
-            "Body Press"
-          ],
-          [
-            "Leech Seed"
-          ]
-        ]
+        "ivs": {"spe": 0},
+        "moves": [["Gyro Ball"], ["Iron Defense"], ["Body Press"], ["Leech Seed"]]
       },
       {
         "species": "Ferrothorn",
-        "item": [
-          "Choice Band"
-        ],
-        "ability": [
-          "Iron Barbs"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "def": 4
-        },
+        "item": ["Choice Band"],
+        "ability": ["Iron Barbs"],
+        "evs": {"hp": 252, "atk": 252, "def": 4},
         "nature": "Brave",
-        "ivs": {
-          "spe": 0
-        },
-        "moves": [
-          [
-            "Gyro Ball"
-          ],
-          [
-            "Bullet Seed",
-            "Power Whip"
-          ],
-          [
-            "Bulldoze",
-            "Knock Off"
-          ],
-          [
-            "Explosion"
-          ]
-        ]
+        "ivs": {"spe": 0},
+        "moves": [["Gyro Ball"], ["Bullet Seed", "Power Whip"], ["Bulldoze", "Knock Off"], ["Explosion"]]
       }
     ]
   },
@@ -942,121 +292,35 @@
     "sets": [
       {
         "species": "Urshifu-Rapid-Strike",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Unseen Fist"
-        ],
-        "evs": {
-          "hp": 4,
-          "atk": 252,
-          "spe": 252
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Unseen Fist"],
+        "evs": {"hp": 4, "atk": 252, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Surging Strikes"
-          ],
-          [
-            "Close Combat"
-          ],
-          [
-            "Counter"
-          ],
-          [
-            "Aqua Jet"
-          ]
-        ]
+        "moves": [["Surging Strikes"], ["Close Combat"], ["Counter"], ["Aqua Jet"]]
       },
       {
         "species": "Urshifu-Rapid-Strike",
-        "item": [
-          "Choice Scarf"
-        ],
-        "ability": [
-          "Unseen Fist"
-        ],
-        "evs": {
-          "hp": 4,
-          "atk": 252,
-          "spe": 252
-        },
+        "item": ["Choice Scarf"],
+        "ability": ["Unseen Fist"],
+        "evs": {"hp": 4, "atk": 252, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Surging Strikes"
-          ],
-          [
-            "Close Combat"
-          ],
-          [
-            "Thunder Punch"
-          ],
-          [
-            "U-turn"
-          ]
-        ]
+        "moves": [["Surging Strikes"], ["Close Combat"], ["Thunder Punch"], ["U-turn"]]
       },
       {
         "species": "Urshifu-Gmax",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Unseen Fist"
-        ],
-        "evs": {
-          "hp": 4,
-          "atk": 252,
-          "spe": 252
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Unseen Fist"],
+        "evs": {"hp": 4, "atk": 252, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Wicked Blow"
-          ],
-          [
-            "Close Combat"
-          ],
-          [
-            "Counter"
-          ],
-          [
-            "Sucker Punch"
-          ]
-        ]
+        "moves": [["Wicked Blow"], ["Close Combat"], ["Counter"], ["Sucker Punch"]]
       },
       {
         "species": "Urshifu-Gmax",
-        "item": [
-          "Choice Band"
-        ],
-        "ability": [
-          "Unseen Fist"
-        ],
-        "evs": {
-          "hp": 4,
-          "atk": 252,
-          "spe": 252
-        },
+        "item": ["Choice Band"],
+        "ability": ["Unseen Fist"],
+        "evs": {"hp": 4, "atk": 252, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Wicked Blow"
-          ],
-          [
-            "Close Combat"
-          ],
-          [
-            "Sucker Punch"
-          ],
-          [
-            "Poison Jab",
-            "Thunder Punch",
-            "Aerial Ace"
-          ]
-        ]
+        "moves": [["Wicked Blow"], ["Close Combat"], ["Sucker Punch"], ["Poison Jab", "Thunder Punch", "Aerial Ace"]]
       }
     ]
   },
@@ -1065,95 +329,27 @@
     "sets": [
       {
         "species": "Dragapult",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Infiltrator"
-        ],
-        "evs": {
-          "atk": 252,
-          "spa": 4,
-          "spe": 252
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Infiltrator"],
+        "evs": {"atk": 252, "spa": 4, "spe": 252},
         "nature": "Naive",
-        "moves": [
-          [
-            "Dragon Darts"
-          ],
-          [
-            "Phantom Force",
-            "Hex"
-          ],
-          [
-            "Dragon Dance"
-          ],
-          [
-            "Will-O-Wisp",
-            "Thunder Wave"
-          ]
-        ]
+        "moves": [["Dragon Darts"], ["Phantom Force", "Hex"], ["Dragon Dance"], ["Will-O-Wisp", "Thunder Wave"]]
       },
       {
         "species": "Dragapult",
-        "item": [
-          "Light Clay"
-        ],
-        "ability": [
-          "Cursed Body"
-        ],
-        "evs": {
-          "hp": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Light Clay"],
+        "ability": ["Cursed Body"],
+        "evs": {"hp": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Reflect"
-          ],
-          [
-            "Light Screen"
-          ],
-          [
-            "Dragon Darts"
-          ],
-          [
-            "Curse"
-          ]
-        ]
+        "moves": [["Reflect"], ["Light Screen"], ["Dragon Darts"], ["Curse"]]
       },
       {
         "species": "Dragapult",
-        "item": [
-          "Choice Specs",
-          "Life Orb"
-        ],
-        "ability": [
-          "Clear Body"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Choice Specs", "Life Orb"],
+        "ability": ["Clear Body"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "moves": [
-          [
-            "Draco Meteor"
-          ],
-          [
-            "Shadow Ball"
-          ],
-          [
-            "Fire Blast",
-            "Thunderbolt"
-          ],
-          [
-            "U-turn",
-            "Hydro Pump"
-          ]
-        ]
+        "moves": [["Draco Meteor"], ["Shadow Ball"], ["Fire Blast", "Thunderbolt"], ["U-turn", "Hydro Pump"]]
       }
     ]
   },
@@ -1162,100 +358,30 @@
     "sets": [
       {
         "species": "Celesteela",
-        "item": [
-          "Leftovers"
-        ],
-        "ability": [
-          "Beast Boost"
-        ],
-        "evs": {
-          "hp": 244,
-          "def": 12,
-          "spe": 252
-        },
+        "item": ["Leftovers"],
+        "ability": ["Beast Boost"],
+        "evs": {"hp": 244, "def": 12, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Air Slash"
-          ],
-          [
-            "Leech Seed"
-          ],
-          [
-            "Protect",
-            "Substitute"
-          ],
-          [
-            "Flamethrower"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Air Slash"], ["Leech Seed"], ["Protect", "Substitute"], ["Flamethrower"]]
       },
       {
         "species": "Celesteela",
-        "item": [
-          "Weakness Policy"
-        ],
-        "ability": [
-          "Beast Boost"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spe": 4
-        },
+        "item": ["Weakness Policy"],
+        "ability": ["Beast Boost"],
+        "evs": {"hp": 252, "spa": 252, "spe": 4},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Air Slash"
-          ],
-          [
-            "Flash Cannon"
-          ],
-          [
-            "Flamethrower"
-          ],
-          [
-            "Giga Drain"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Air Slash"], ["Flash Cannon"], ["Flamethrower"], ["Giga Drain"]]
       },
       {
         "species": "Celesteela",
-        "item": [
-          "Power Herb"
-        ],
-        "ability": [
-          "Beast Boost"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spe": 4
-        },
+        "item": ["Power Herb"],
+        "ability": ["Beast Boost"],
+        "evs": {"hp": 252, "spa": 252, "spe": 4},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Air Slash"
-          ],
-          [
-            "Flash Cannon"
-          ],
-          [
-            "Meteor Beam"
-          ],
-          [
-            "Flamethrower"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Air Slash"], ["Flash Cannon"], ["Meteor Beam"], ["Flamethrower"]]
       }
     ]
   },
@@ -1264,97 +390,28 @@
     "sets": [
       {
         "species": "Dragonite",
-        "item": [
-          "Weakness Policy",
-          "Lum Berry"
-        ],
-        "ability": [
-          "Multiscale"
-        ],
-        "evs": {
-          "hp": 4,
-          "atk": 252,
-          "spe": 252
-        },
+        "item": ["Weakness Policy", "Lum Berry"],
+        "ability": ["Multiscale"],
+        "evs": {"hp": 4, "atk": 252, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Outrage"
-          ],
-          [
-            "Dual Wingbeat"
-          ],
-          [
-            "Dragon Dance"
-          ],
-          [
-            "Roost",
-            "Fire Punch"
-          ]
-        ]
+        "moves": [["Outrage"], ["Dual Wingbeat"], ["Dragon Dance"], ["Roost", "Fire Punch"]]
       },
       {
         "species": "Dragonite",
-        "item": [
-          "Life Orb"
-        ],
-        "ability": [
-          "Inner Focus"
-        ],
-        "evs": {
-          "hp": 4,
-          "atk": 252,
-          "spe": 252
-        },
+        "item": ["Life Orb"],
+        "ability": ["Inner Focus"],
+        "evs": {"hp": 4, "atk": 252, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Outrage"
-          ],
-          [
-            "Dual Wingbeat"
-          ],
-          [
-            "Dragon Dance"
-          ],
-          [
-            "Roost",
-            "Fire Punch"
-          ]
-        ]
+        "moves": [["Outrage"], ["Dual Wingbeat"], ["Dragon Dance"], ["Roost", "Fire Punch"]]
       },
       {
         "species": "Dragonite",
-        "item": [
-          "Expert Belt"
-        ],
-        "ability": [
-          "Multiscale"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Expert Belt"],
+        "ability": ["Multiscale"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Hurricane"
-          ],
-          [
-            "Fire Blast"
-          ],
-          [
-            "Ice Beam"
-          ],
-          [
-            "Thunderbolt",
-            "Roost"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Hurricane"], ["Fire Blast"], ["Ice Beam"], ["Thunderbolt", "Roost"]]
       }
     ]
   },
@@ -1363,63 +420,19 @@
     "sets": [
       {
         "species": "Hippowdon",
-        "item": [
-          "Sitrus Berry",
-          "Figy Berry"
-        ],
-        "ability": [
-          "Sand Stream"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Sitrus Berry", "Figy Berry"],
+        "ability": ["Sand Stream"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Impish",
-        "moves": [
-          [
-            "Stealth Rock"
-          ],
-          [
-            "Yawn"
-          ],
-          [
-            "Earthquake"
-          ],
-          [
-            "Whirlwind"
-          ]
-        ]
+        "moves": [["Stealth Rock"], ["Yawn"], ["Earthquake"], ["Whirlwind"]]
       },
       {
         "species": "Hippowdon",
-        "item": [
-          "Kee Berry"
-        ],
-        "ability": [
-          "Sand Stream"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Kee Berry"],
+        "ability": ["Sand Stream"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Impish",
-        "moves": [
-          [
-            "Earthquake"
-          ],
-          [
-            "Yawn"
-          ],
-          [
-            "Slack Off"
-          ],
-          [
-            "Ice Fang",
-            "Stealth Rock"
-          ]
-        ]
+        "moves": [["Earthquake"], ["Yawn"], ["Slack Off"], ["Ice Fang", "Stealth Rock"]]
       }
     ]
   },
@@ -1428,126 +441,35 @@
     "sets": [
       {
         "species": "Tyranitar",
-        "item": [
-          "Assault Vest",
-          "Weakness Policy"
-        ],
-        "ability": [
-          "Sand Stream"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "spe": 4
-        },
+        "item": ["Assault Vest", "Weakness Policy"],
+        "ability": ["Sand Stream"],
+        "evs": {"hp": 252, "atk": 252, "spe": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Stone Edge",
-            "Rock Blast"
-          ],
-          [
-            "Crunch"
-          ],
-          [
-            "Earthquake"
-          ],
-          [
-            "Iron Head"
-          ]
-        ]
+        "moves": [["Stone Edge", "Rock Blast"], ["Crunch"], ["Earthquake"], ["Iron Head"]]
       },
       {
         "species": "Tyranitar",
-        "item": [
-          "Weakness Policy"
-        ],
-        "ability": [
-          "Sand Stream"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Weakness Policy"],
+        "ability": ["Sand Stream"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Dragon Dance"
-          ],
-          [
-            "Rock Blast"
-          ],
-          [
-            "Ice Punch"
-          ],
-          [
-            "Earthquake"
-          ]
-        ]
+        "moves": [["Dragon Dance"], ["Rock Blast"], ["Ice Punch"], ["Earthquake"]]
       },
       {
         "species": "Tyranitar",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Sand Stream"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Sand Stream"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Stealth Rock"
-          ],
-          [
-            "Thunder Wave"
-          ],
-          [
-            "Rock Blast"
-          ],
-          [
-            "Ice Punch",
-            "Fire Punch",
-            "Iron Head"
-          ]
-        ]
+        "moves": [["Stealth Rock"], ["Thunder Wave"], ["Rock Blast"], ["Ice Punch", "Fire Punch", "Iron Head"]]
       },
       {
         "species": "Tyranitar",
-        "item": [
-          "Chesto Berry"
-        ],
-        "ability": [
-          "Sand Stream"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Chesto Berry"],
+        "ability": ["Sand Stream"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Dragon Dance"
-          ],
-          [
-            "Rock Blast",
-            "Rock Slide"
-          ],
-          [
-            "Crunch",
-            "Ice Punch",
-            "Earthquake"
-          ],
-          [
-            "Rest"
-          ]
-        ]
+        "moves": [["Dragon Dance"], ["Rock Blast", "Rock Slide"], ["Crunch", "Ice Punch", "Earthquake"], ["Rest"]]
       }
     ]
   },
@@ -1556,99 +478,29 @@
     "sets": [
       {
         "species": "Regieleki",
-        "item": [
-          "Choice Specs",
-          "Life Orb",
-          "Focus Sash"
-        ],
-        "ability": [
-          "Transistor"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Choice Specs", "Life Orb", "Focus Sash"],
+        "ability": ["Transistor"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Volt Switch"
-          ],
-          [
-            "Thunderbolt"
-          ],
-          [
-            "Hyper Beam"
-          ],
-          [
-            "Reflect",
-            "Electroweb"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Volt Switch"], ["Thunderbolt"], ["Hyper Beam"], ["Reflect", "Electroweb"]]
       },
       {
         "species": "Regieleki",
-        "item": [
-          "Light Clay"
-        ],
-        "ability": [
-          "Transistor"
-        ],
-        "evs": {
-          "spa": 252,
-          "atk": 4,
-          "spe": 252
-        },
+        "item": ["Light Clay"],
+        "ability": ["Transistor"],
+        "evs": {"spa": 252, "atk": 4, "spe": 252},
         "nature": "Naive",
-        "moves": [
-          [
-            "Volt Switch"
-          ],
-          [
-            "Reflect"
-          ],
-          [
-            "Light Screen"
-          ],
-          [
-            "Explosion"
-          ]
-        ]
+        "moves": [["Volt Switch"], ["Reflect"], ["Light Screen"], ["Explosion"]]
       },
       {
         "species": "Regieleki",
-        "item": [
-          "Throat Spray"
-        ],
-        "ability": [
-          "Transistor"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Throat Spray"],
+        "ability": ["Transistor"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Round"
-          ],
-          [
-            "Substitute"
-          ],
-          [
-            "Hyper Beam"
-          ],
-          [
-            "Thunderbolt"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Round"], ["Substitute"], ["Hyper Beam"], ["Thunderbolt"]]
       }
     ]
   },
@@ -1657,33 +509,11 @@
     "sets": [
       {
         "species": "Pheromosa",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Beast Boost"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Beast Boost"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Close Combat"
-          ],
-          [
-            "U-turn"
-          ],
-          [
-            "Triple Axel"
-          ],
-          [
-            "Poison Jab",
-            "Drill Run"
-          ]
-        ]
+        "moves": [["Close Combat"], ["U-turn"], ["Triple Axel"], ["Poison Jab", "Drill Run"]]
       }
     ]
   },
@@ -1692,136 +522,39 @@
     "sets": [
       {
         "species": "Moltres-Galar",
-        "item": [
-          "Weakness Policy",
-          "Sitrus Berry"
-        ],
-        "ability": [
-          "Berserk"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Weakness Policy", "Sitrus Berry"],
+        "ability": ["Berserk"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Fiery Wrath"
-          ],
-          [
-            "Hurricane"
-          ],
-          [
-            "Taunt",
-            "Sucker Punch"
-          ],
-          [
-            "Nasty Plot"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Fiery Wrath"], ["Hurricane"], ["Taunt", "Sucker Punch"], ["Nasty Plot"]]
       },
       {
         "species": "Moltres-Galar",
-        "item": [
-          "Chesto Berry"
-        ],
-        "ability": [
-          "Berserk"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Chesto Berry"],
+        "ability": ["Berserk"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Fiery Wrath"
-          ],
-          [
-            "Hurricane"
-          ],
-          [
-            "Nasty Plot"
-          ],
-          [
-            "Rest"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Fiery Wrath"], ["Hurricane"], ["Nasty Plot"], ["Rest"]]
       },
       {
         "species": "Moltres",
-        "item": [
-          "Life Orb",
-          "Heavy-Duty Boots"
-        ],
-        "ability": [
-          "Flame Body"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Life Orb", "Heavy-Duty Boots"],
+        "ability": ["Flame Body"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Fire Blast",
-            "Burn Up"
-          ],
-          [
-            "Hurricane"
-          ],
-          [
-            "Solar Beam"
-          ],
-          [
-            "Scorching Sands"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Fire Blast", "Burn Up"], ["Hurricane"], ["Solar Beam"], ["Scorching Sands"]]
       },
       {
         "species": "Moltres",
-        "item": [
-          "Kee Berry"
-        ],
-        "ability": [
-          "Flame Body",
-          "Pressure"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Kee Berry"],
+        "ability": ["Flame Body", "Pressure"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Mystical Fire"
-          ],
-          [
-            "Scorching Sands"
-          ],
-          [
-            "Roost"
-          ],
-          [
-            "Will-O-Wisp"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Mystical Fire"], ["Scorching Sands"], ["Roost"], ["Will-O-Wisp"]]
       }
     ]
   },
@@ -1830,91 +563,27 @@
     "sets": [
       {
         "species": "Excadrill",
-        "item": [
-          "Life Orb"
-        ],
-        "ability": [
-          "Sand Rush"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Life Orb"],
+        "ability": ["Sand Rush"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Swords Dance"
-          ],
-          [
-            "Earthquake"
-          ],
-          [
-            "Rock Blast"
-          ],
-          [
-            "Iron Head"
-          ]
-        ]
+        "moves": [["Swords Dance"], ["Earthquake"], ["Rock Blast"], ["Iron Head"]]
       },
       {
         "species": "Excadrill",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Mold Breaker"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Mold Breaker"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Earthquake"
-          ],
-          [
-            "Iron Head"
-          ],
-          [
-            "Stealth Rock"
-          ],
-          [
-            "Rock Tomb"
-          ]
-        ]
+        "moves": [["Earthquake"], ["Iron Head"], ["Stealth Rock"], ["Rock Tomb"]]
       },
       {
         "species": "Excadrill",
-        "item": [
-          "Choice Scarf",
-          "Assault Vest"
-        ],
-        "ability": [
-          "Mold Breaker"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Choice Scarf", "Assault Vest"],
+        "ability": ["Mold Breaker"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Earthquake"
-          ],
-          [
-            "Iron Head"
-          ],
-          [
-            "Rock Tomb"
-          ],
-          [
-            "Horn Drill"
-          ]
-        ]
+        "moves": [["Earthquake"], ["Iron Head"], ["Rock Tomb"], ["Horn Drill"]]
       }
     ]
   },
@@ -1923,72 +592,21 @@
     "sets": [
       {
         "species": "Cresselia",
-        "item": [
-          "Kee Berry"
-        ],
-        "ability": [
-          "Levitate"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Kee Berry"],
+        "ability": ["Levitate"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Stored Power"
-          ],
-          [
-            "Moonblast",
-            "Ice Beam"
-          ],
-          [
-            "Calm Mind"
-          ],
-          [
-            "Moonlight"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Stored Power"], ["Moonblast", "Ice Beam"], ["Calm Mind"], ["Moonlight"]]
       },
       {
         "species": "Cresselia",
-        "item": [
-          "Rocky Helmet"
-        ],
-        "ability": [
-          "Levitate"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Rocky Helmet"],
+        "ability": ["Levitate"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Psychic",
-            "Psyshock"
-          ],
-          [
-            "Trick Room",
-            "Lunar Dance"
-          ],
-          [
-            "Moonlight"
-          ],
-          [
-            "Ice Beam",
-            "Moonblast",
-            "Icy Wind"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Psychic", "Psyshock"], ["Trick Room", "Lunar Dance"], ["Moonlight"], ["Ice Beam", "Moonblast", "Icy Wind"]]
       }
     ]
   },
@@ -1997,64 +615,19 @@
     "sets": [
       {
         "species": "Glastrier",
-        "item": [
-          "Weakness Policy",
-          "Lum Berry",
-          "Assault Vest"
-        ],
-        "ability": [
-          "Chilling Neigh"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "spd": 4
-        },
+        "item": ["Weakness Policy", "Lum Berry", "Assault Vest"],
+        "ability": ["Chilling Neigh"],
+        "evs": {"hp": 252, "atk": 252, "spd": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Icicle Spear"
-          ],
-          [
-            "High Horsepower"
-          ],
-          [
-            "Close Combat"
-          ],
-          [
-            "Heavy Slam",
-            "Swords Dance"
-          ]
-        ]
+        "moves": [["Icicle Spear"], ["High Horsepower"], ["Close Combat"], ["Heavy Slam", "Swords Dance"]]
       },
       {
         "species": "Glastrier",
-        "item": [
-          "Custap Berry"
-        ],
-        "ability": [
-          "Chilling Neigh"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "spd": 4
-        },
+        "item": ["Custap Berry"],
+        "ability": ["Chilling Neigh"],
+        "evs": {"hp": 252, "atk": 252, "spd": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Icicle Spear"
-          ],
-          [
-            "High Horsepower"
-          ],
-          [
-            "Close Combat"
-          ],
-          [
-            "Endure"
-          ]
-        ]
+        "moves": [["Icicle Spear"], ["High Horsepower"], ["Close Combat"], ["Endure"]]
       }
     ]
   },
@@ -2063,69 +636,21 @@
     "sets": [
       {
         "species": "Naganadel",
-        "item": [
-          "Life Orb",
-          "Focus Sash"
-        ],
-        "ability": [
-          "Beast Boost"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Life Orb", "Focus Sash"],
+        "ability": ["Beast Boost"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Sludge Wave"
-          ],
-          [
-            "Draco Meteor"
-          ],
-          [
-            "Fire Blast"
-          ],
-          [
-            "Nasty Plot",
-            "Air Slash"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Sludge Wave"], ["Draco Meteor"], ["Fire Blast"], ["Nasty Plot", "Air Slash"]]
       },
       {
         "species": "Naganadel",
-        "item": [
-          "Choice Scarf"
-        ],
-        "ability": [
-          "Beast Boost"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Choice Scarf"],
+        "ability": ["Beast Boost"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Sludge Wave"
-          ],
-          [
-            "Draco Meteor"
-          ],
-          [
-            "Fire Blast"
-          ],
-          [
-            "U-turn"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Sludge Wave"], ["Draco Meteor"], ["Fire Blast"], ["U-turn"]]
       }
     ]
   },
@@ -2134,37 +659,12 @@
     "sets": [
       {
         "species": "Swampert",
-        "item": [
-          "Sitrus Berry",
-          "Aguav Berry"
-        ],
-        "ability": [
-          "Damp"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Sitrus Berry", "Aguav Berry"],
+        "ability": ["Damp"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Relaxed",
-        "ivs": {
-          "spe": 0
-        },
-        "moves": [
-          [
-            "Stealth Rock"
-          ],
-          [
-            "Yawn"
-          ],
-          [
-            "Flip Turn"
-          ],
-          [
-            "Earthquake",
-            "Ice Beam"
-          ]
-        ]
+        "ivs": {"spe": 0},
+        "moves": [["Stealth Rock"], ["Yawn"], ["Flip Turn"], ["Earthquake", "Ice Beam"]]
       }
     ]
   },
@@ -2173,100 +673,28 @@
     "sets": [
       {
         "species": "Metagross",
-        "item": [
-          "Weakness Policy",
-          "Life Orb"
-        ],
-        "ability": [
-          "Clear Body"
-        ],
-        "evs": {
-          "atk": 252,
-          "def": 4,
-          "spe": 252
-        },
+        "item": ["Weakness Policy", "Life Orb"],
+        "ability": ["Clear Body"],
+        "evs": {"atk": 252, "def": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Meteor Mash"
-          ],
-          [
-            "Earthquake"
-          ],
-          [
-            "Ice Punch",
-            "Thunder Punch",
-            "Zen Headbutt"
-          ],
-          [
-            "Agility"
-          ]
-        ]
+        "moves": [["Meteor Mash"], ["Earthquake"], ["Ice Punch", "Thunder Punch", "Zen Headbutt"], ["Agility"]]
       },
       {
         "species": "Metagross",
-        "item": [
-          "Lagging Tail",
-          "Full Incense"
-        ],
-        "ability": [
-          "Clear Body"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "def": 4
-        },
+        "item": ["Lagging Tail", "Full Incense"],
+        "ability": ["Clear Body"],
+        "evs": {"hp": 252, "atk": 252, "def": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Trick"
-          ],
-          [
-            "Stealth Rock"
-          ],
-          [
-            "Bullet Punch"
-          ],
-          [
-            "Ice Punch",
-            "Self-Destruct"
-          ]
-        ]
+        "moves": [["Trick"], ["Stealth Rock"], ["Bullet Punch"], ["Ice Punch", "Self-Destruct"]]
       },
       {
         "species": "Metagross",
-        "item": [
-          "Power Herb"
-        ],
-        "ability": [
-          "Clear Body"
-        ],
-        "evs": {
-          "def": 4,
-          "spa": 252,
-          "spe": 252
-        },
+        "item": ["Power Herb"],
+        "ability": ["Clear Body"],
+        "evs": {"def": 4, "spa": 252, "spe": 252},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Steel Beam"
-          ],
-          [
-            "Expanding Force"
-          ],
-          [
-            "Meteor Beam"
-          ],
-          [
-            "Sludge Bomb",
-            "Icy Wind",
-            "Agility"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Steel Beam"], ["Expanding Force"], ["Meteor Beam"], ["Sludge Bomb", "Icy Wind", "Agility"]]
       }
     ]
   },
@@ -2275,64 +703,19 @@
     "sets": [
       {
         "species": "Magnezone",
-        "item": [
-          "Custap Berry",
-          "Weakness Policy"
-        ],
-        "ability": [
-          "Sturdy"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 4,
-          "spa": 252
-        },
+        "item": ["Custap Berry", "Weakness Policy"],
+        "ability": ["Sturdy"],
+        "evs": {"hp": 252, "def": 4, "spa": 252},
         "nature": "Modest",
-        "moves": [
-          [
-            "Thunderbolt"
-          ],
-          [
-            "Flash Cannon"
-          ],
-          [
-            "Volt Switch"
-          ],
-          [
-            "Steel Beam",
-            "Mirror Coat"
-          ]
-        ]
+        "moves": [["Thunderbolt"], ["Flash Cannon"], ["Volt Switch"], ["Steel Beam", "Mirror Coat"]]
       },
       {
         "species": "Magnezone",
-        "item": [
-          "Assault Vest",
-          "Choice Specs"
-        ],
-        "ability": [
-          "Analytic"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 4,
-          "spa": 252
-        },
+        "item": ["Assault Vest", "Choice Specs"],
+        "ability": ["Analytic"],
+        "evs": {"hp": 252, "def": 4, "spa": 252},
         "nature": "Modest",
-        "moves": [
-          [
-            "Thunderbolt"
-          ],
-          [
-            "Flash Cannon"
-          ],
-          [
-            "Volt Switch"
-          ],
-          [
-            "Body Press"
-          ]
-        ]
+        "moves": [["Thunderbolt"], ["Flash Cannon"], ["Volt Switch"], ["Body Press"]]
       }
     ]
   },
@@ -2341,61 +724,19 @@
     "sets": [
       {
         "species": "Salamence",
-        "item": [
-          "Lum Berry"
-        ],
-        "ability": [
-          "Moxie"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Lum Berry"],
+        "ability": ["Moxie"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Dual Wingbeat"
-          ],
-          [
-            "Outrage"
-          ],
-          [
-            "Dragon Dance"
-          ],
-          [
-            "Earthquake"
-          ]
-        ]
+        "moves": [["Dual Wingbeat"], ["Outrage"], ["Dragon Dance"], ["Earthquake"]]
       },
       {
         "species": "Salamence",
-        "item": [
-          "Life Orb"
-        ],
-        "ability": [
-          "Intimidate"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Life Orb"],
+        "ability": ["Intimidate"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "moves": [
-          [
-            "Hurricane"
-          ],
-          [
-            "Draco Meteor"
-          ],
-          [
-            "Fire Blast"
-          ],
-          [
-            "Hydro Pump"
-          ]
-        ]
+        "moves": [["Hurricane"], ["Draco Meteor"], ["Fire Blast"], ["Hydro Pump"]]
       }
     ]
   },
@@ -2404,72 +745,21 @@
     "sets": [
       {
         "species": "Blaziken",
-        "item": [
-          "Life Orb",
-          "Focus Sash"
-        ],
-        "ability": [
-          "Speed Boost"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Life Orb", "Focus Sash"],
+        "ability": ["Speed Boost"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Flare Blitz"
-          ],
-          [
-            "Close Combat"
-          ],
-          [
-            "Thunder Punch"
-          ],
-          [
-            "Swords Dance",
-            "Earthquake",
-            "Protect"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Flare Blitz"], ["Close Combat"], ["Thunder Punch"], ["Swords Dance", "Earthquake", "Protect"]]
       },
       {
         "species": "Blaziken",
-        "item": [
-          "Life Orb",
-          "Focus Sash"
-        ],
-        "ability": [
-          "Speed Boost"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Life Orb", "Focus Sash"],
+        "ability": ["Speed Boost"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Fire Blast"
-          ],
-          [
-            "Solar Beam"
-          ],
-          [
-            "Scorching Sands"
-          ],
-          [
-            "Protect",
-            "Baton Pass"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Fire Blast"], ["Solar Beam"], ["Scorching Sands"], ["Protect", "Baton Pass"]]
       }
     ]
   },
@@ -2478,92 +768,27 @@
     "sets": [
       {
         "species": "Kartana",
-        "item": [
-          "Life Orb",
-          "Focus Sash"
-        ],
-        "ability": [
-          "Beast Boost"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Life Orb", "Focus Sash"],
+        "ability": ["Beast Boost"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Leaf Blade"
-          ],
-          [
-            "Smart Strike"
-          ],
-          [
-            "Sacred Sword"
-          ],
-          [
-            "Giga Impact",
-            "Swords Dance"
-          ]
-        ]
+        "moves": [["Leaf Blade"], ["Smart Strike"], ["Sacred Sword"], ["Giga Impact", "Swords Dance"]]
       },
       {
         "species": "Kartana",
-        "item": [
-          "Normal Gem"
-        ],
-        "ability": [
-          "Beast Boost"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Normal Gem"],
+        "ability": ["Beast Boost"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Leaf Blade"
-          ],
-          [
-            "Smart Strike"
-          ],
-          [
-            "Sacred Sword"
-          ],
-          [
-            "Giga Impact"
-          ]
-        ]
+        "moves": [["Leaf Blade"], ["Smart Strike"], ["Sacred Sword"], ["Giga Impact"]]
       },
       {
         "species": "Kartana",
-        "item": [
-          "Choice Scarf"
-        ],
-        "ability": [
-          "Beast Boost"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Choice Scarf"],
+        "ability": ["Beast Boost"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Leaf Blade"
-          ],
-          [
-            "Smart Strike"
-          ],
-          [
-            "Sacred Sword"
-          ],
-          [
-            "Guillotine"
-          ]
-        ]
+        "moves": [["Leaf Blade"], ["Smart Strike"], ["Sacred Sword"], ["Guillotine"]]
       }
     ]
   },
@@ -2572,95 +797,27 @@
     "sets": [
       {
         "species": "Garchomp",
-        "item": [
-          "Focus Sash",
-          "Life Orb",
-          "Lum Berry"
-        ],
-        "ability": [
-          "Rough Skin"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Focus Sash", "Life Orb", "Lum Berry"],
+        "ability": ["Rough Skin"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Swords Dance"
-          ],
-          [
-            "Scale Shot"
-          ],
-          [
-            "Earthquake"
-          ],
-          [
-            "Fire Fang"
-          ]
-        ]
+        "moves": [["Swords Dance"], ["Scale Shot"], ["Earthquake"], ["Fire Fang"]]
       },
       {
         "species": "Garchomp",
-        "item": [
-          "Choice Scarf"
-        ],
-        "ability": [
-          "Rough Skin"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Choice Scarf"],
+        "ability": ["Rough Skin"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Outrage"
-          ],
-          [
-            "Earthquake"
-          ],
-          [
-            "Stone Edge"
-          ],
-          [
-            "Iron Head",
-            "Stealth Rock"
-          ]
-        ]
+        "moves": [["Outrage"], ["Earthquake"], ["Stone Edge"], ["Iron Head", "Stealth Rock"]]
       },
       {
         "species": "Garchomp",
-        "item": [
-          "Focus Sash",
-          "Life Orb"
-        ],
-        "ability": [
-          "Rough Skin"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Focus Sash", "Life Orb"],
+        "ability": ["Rough Skin"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Stealth Rock"
-          ],
-          [
-            "Earthquake"
-          ],
-          [
-            "Scale Shot",
-            "Outrage"
-          ],
-          [
-            "Stone Edge"
-          ]
-        ]
+        "moves": [["Stealth Rock"], ["Earthquake"], ["Scale Shot", "Outrage"], ["Stone Edge"]]
       }
     ]
   },
@@ -2669,69 +826,21 @@
     "sets": [
       {
         "species": "Heatran",
-        "item": [
-          "Assault Vest"
-        ],
-        "ability": [
-          "Flash Fire"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spd": 4
-        },
+        "item": ["Assault Vest"],
+        "ability": ["Flash Fire"],
+        "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Magma Storm",
-            "Fire Blast",
-            "Flamethrower"
-          ],
-          [
-            "Flash Cannon"
-          ],
-          [
-            "Earth Power"
-          ],
-          [
-            "Solar Beam"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Magma Storm", "Fire Blast", "Flamethrower"], ["Flash Cannon"], ["Earth Power"], ["Solar Beam"]]
       },
       {
         "species": "Heatran",
-        "item": [
-          "Air Balloon"
-        ],
-        "ability": [
-          "Flash Fire"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Air Balloon"],
+        "ability": ["Flash Fire"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Magma Storm"
-          ],
-          [
-            "Flash Cannon"
-          ],
-          [
-            "Earth Power"
-          ],
-          [
-            "Stealth Rock"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Magma Storm"], ["Flash Cannon"], ["Earth Power"], ["Stealth Rock"]]
       }
     ]
   },
@@ -2740,305 +849,84 @@
     "sets": [
       {
         "species": "Rotom-Wash",
-        "item": [
-          "Choice Specs"
-        ],
-        "ability": [
-          "Levitate"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spd": 4
-        },
+        "item": ["Choice Specs"],
+        "ability": ["Levitate"],
+        "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Hydro Pump"
-          ],
-          [
-            "Thunderbolt"
-          ],
-          [
-            "Volt Switch"
-          ],
-          [
-            "Trick"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Hydro Pump"], ["Thunderbolt"], ["Volt Switch"], ["Trick"]]
       },
       {
         "species": "Rotom-Wash",
-        "item": [
-          "Assault Vest"
-        ],
-        "ability": [
-          "Levitate"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spd": 4
-        },
+        "item": ["Assault Vest"],
+        "ability": ["Levitate"],
+        "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Hydro Pump"
-          ],
-          [
-            "Thunderbolt"
-          ],
-          [
-            "Volt Switch"
-          ],
-          [
-            "Dark Pulse"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Hydro Pump"], ["Thunderbolt"], ["Volt Switch"], ["Dark Pulse"]]
       },
       {
         "species": "Rotom-Wash",
-        "item": [
-          "Sitrus Berry",
-          "Wiki Berry"
-        ],
-        "ability": [
-          "Levitate"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spd": 4
-        },
+        "item": ["Sitrus Berry", "Wiki Berry"],
+        "ability": ["Levitate"],
+        "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Hydro Pump"
-          ],
-          [
-            "Discharge",
-            "Thunderbolt"
-          ],
-          [
-            "Nasty Plot",
-            "Volt Switch"
-          ],
-          [
-            "Will-O-Wisp"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Hydro Pump"], ["Discharge", "Thunderbolt"], ["Nasty Plot", "Volt Switch"], ["Will-O-Wisp"]]
       },
       {
         "species": "Rotom-Heat",
-        "item": [
-          "Choice Scarf"
-        ],
-        "ability": [
-          "Levitate"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Choice Scarf"],
+        "ability": ["Levitate"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Volt Switch"
-          ],
-          [
-            "Overheat"
-          ],
-          [
-            "Trick"
-          ],
-          [
-            "Will-O-Wisp",
-            "Nasty Plot",
-            "Thunderbolt"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Volt Switch"], ["Overheat"], ["Trick"], ["Will-O-Wisp", "Nasty Plot", "Thunderbolt"]]
       },
       {
         "species": "Rotom-Heat",
-        "item": [
-          "Choice Specs"
-        ],
-        "ability": [
-          "Levitate"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spd": 4
-        },
+        "item": ["Choice Specs"],
+        "ability": ["Levitate"],
+        "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Volt Switch"
-          ],
-          [
-            "Overheat"
-          ],
-          [
-            "Trick"
-          ],
-          [
-            "Will-O-Wisp",
-            "Nasty Plot",
-            "Thunderbolt"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Volt Switch"], ["Overheat"], ["Trick"], ["Will-O-Wisp", "Nasty Plot", "Thunderbolt"]]
       },
       {
         "species": "Rotom-Heat",
-        "item": [
-          "Assault Vest"
-        ],
-        "ability": [
-          "Levitate"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spd": 4
-        },
+        "item": ["Assault Vest"],
+        "ability": ["Levitate"],
+        "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Volt Switch"
-          ],
-          [
-            "Overheat"
-          ],
-          [
-            "Discharge",
-            "Thunderbolt"
-          ],
-          [
-            "Dark Pulse",
-            "Shadow Ball"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Volt Switch"], ["Overheat"], ["Discharge", "Thunderbolt"], ["Dark Pulse", "Shadow Ball"]]
       },
       {
         "species": "Rotom-Heat",
-        "item": [
-          "Sitrus Berry"
-        ],
-        "ability": [
-          "Levitate"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spa": 4
-        },
+        "item": ["Sitrus Berry"],
+        "ability": ["Levitate"],
+        "evs": {"hp": 252, "def": 252, "spa": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Discharge",
-            "Volt Switch"
-          ],
-          [
-            "Overheat"
-          ],
-          [
-            "Nasty Plot"
-          ],
-          [
-            "Dark Pulse",
-            "Will-O-Wisp"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Discharge", "Volt Switch"], ["Overheat"], ["Nasty Plot"], ["Dark Pulse", "Will-O-Wisp"]]
       },
       {
         "species": "Rotom-Mow",
-        "item": [
-          "Choice Specs",
-          "Choice Scarf"
-        ],
-        "ability": [
-          "Levitate"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Choice Specs", "Choice Scarf"],
+        "ability": ["Levitate"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Leaf Storm"
-          ],
-          [
-            "Volt Switch"
-          ],
-          [
-            "Dark Pulse"
-          ],
-          [
-            "Trick"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Leaf Storm"], ["Volt Switch"], ["Dark Pulse"], ["Trick"]]
       },
       {
         "species": "Rotom-Mow",
-        "item": [
-          "Sitrus Berry",
-          "Eject Pack"
-        ],
-        "ability": [
-          "Levitate"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spd": 4
-        },
+        "item": ["Sitrus Berry", "Eject Pack"],
+        "ability": ["Levitate"],
+        "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Leaf Storm"
-          ],
-          [
-            "Volt Switch"
-          ],
-          [
-            "Dark Pulse",
-            "Nasty Plot"
-          ],
-          [
-            "Will-O-Wisp"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Leaf Storm"], ["Volt Switch"], ["Dark Pulse", "Nasty Plot"], ["Will-O-Wisp"]]
       }
     ]
   },
@@ -3047,37 +935,12 @@
     "sets": [
       {
         "species": "Toxapex",
-        "item": [
-          "Black Sludge"
-        ],
-        "ability": [
-          "Regenerator"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Black Sludge"],
+        "ability": ["Regenerator"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Scald"
-          ],
-          [
-            "Recover"
-          ],
-          [
-            "Haze"
-          ],
-          [
-            "Toxic",
-            "Baneful Bunker",
-            "Toxic Spikes"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Scald"], ["Recover"], ["Haze"], ["Toxic", "Baneful Bunker", "Toxic Spikes"]]
       }
     ]
   },
@@ -3086,98 +949,27 @@
     "sets": [
       {
         "species": "Grimmsnarl",
-        "item": [
-          "Light Clay"
-        ],
-        "ability": [
-          "Prankster"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Light Clay"],
+        "ability": ["Prankster"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Impish",
-        "moves": [
-          [
-            "Light Screen"
-          ],
-          [
-            "Reflect"
-          ],
-          [
-            "Spirit Break"
-          ],
-          [
-            "Taunt",
-            "Thunder Wave"
-          ]
-        ]
+        "moves": [["Light Screen"], ["Reflect"], ["Spirit Break"], ["Taunt", "Thunder Wave"]]
       },
       {
         "species": "Grimmsnarl-Gmax",
-        "item": [
-          "Lagging Tail"
-        ],
-        "ability": [
-          "Prankster"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "spd": 4
-        },
+        "item": ["Lagging Tail"],
+        "ability": ["Prankster"],
+        "evs": {"hp": 252, "atk": 252, "spd": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Trick"
-          ],
-          [
-            "Spirit Break"
-          ],
-          [
-            "Sucker Punch"
-          ],
-          [
-            "Substitute",
-            "Light Screen",
-            "Reflect"
-          ]
-        ]
+        "moves": [["Trick"], ["Spirit Break"], ["Sucker Punch"], ["Substitute", "Light Screen", "Reflect"]]
       },
       {
         "species": "Grimmsnarl-Gmax",
-        "item": [
-          "Sitrus Berry",
-          "Leftovers"
-        ],
-        "ability": [
-          "Prankster"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 4,
-          "spd": 252
-        },
+        "item": ["Sitrus Berry", "Leftovers"],
+        "ability": ["Prankster"],
+        "evs": {"hp": 252, "atk": 4, "spd": 252},
         "nature": "Careful",
-        "moves": [
-          [
-            "Sucker Punch",
-            "Darkest Lariat"
-          ],
-          [
-            "Spirit Break",
-            "Play Rough",
-            "Drain Punch"
-          ],
-          [
-            "Bulk Up"
-          ],
-          [
-            "Substitute",
-            "Thunder Wave"
-          ]
-        ]
+        "moves": [["Sucker Punch", "Darkest Lariat"], ["Spirit Break", "Play Rough", "Drain Punch"], ["Bulk Up"], ["Substitute", "Thunder Wave"]]
       }
     ]
   },
@@ -3186,90 +978,27 @@
     "sets": [
       {
         "species": "Tapu Koko",
-        "item": [
-          "Choice Specs"
-        ],
-        "ability": [
-          "Electric Surge"
-        ],
-        "evs": {
-          "hp": 4,
-          "spa": 252,
-          "spe": 252
-        },
+        "item": ["Choice Specs"],
+        "ability": ["Electric Surge"],
+        "evs": {"hp": 4, "spa": 252, "spe": 252},
         "nature": "Timid",
-        "moves": [
-          [
-            "Thunderbolt"
-          ],
-          [
-            "Dazzling Gleam"
-          ],
-          [
-            "Grass Knot"
-          ],
-          [
-            "Volt Switch"
-          ]
-        ]
+        "moves": [["Thunderbolt"], ["Dazzling Gleam"], ["Grass Knot"], ["Volt Switch"]]
       },
       {
         "species": "Tapu Koko",
-        "item": [
-          "Light Clay"
-        ],
-        "ability": [
-          "Electric Surge"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 4,
-          "spe": 252
-        },
+        "item": ["Light Clay"],
+        "ability": ["Electric Surge"],
+        "evs": {"hp": 252, "spa": 4, "spe": 252},
         "nature": "Timid",
-        "moves": [
-          [
-            "Reflect"
-          ],
-          [
-            "Light Screen"
-          ],
-          [
-            "Thunderbolt"
-          ],
-          [
-            "Taunt"
-          ]
-        ]
+        "moves": [["Reflect"], ["Light Screen"], ["Thunderbolt"], ["Taunt"]]
       },
       {
         "species": "Tapu Koko",
-        "item": [
-          "Life Orb"
-        ],
-        "ability": [
-          "Electric Surge"
-        ],
-        "evs": {
-          "hp": 4,
-          "atk": 252,
-          "spe": 252
-        },
+        "item": ["Life Orb"],
+        "ability": ["Electric Surge"],
+        "evs": {"hp": 4, "atk": 252, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Wild Charge"
-          ],
-          [
-            "Brave Bird"
-          ],
-          [
-            "U-turn"
-          ],
-          [
-            "Iron Head"
-          ]
-        ]
+        "moves": [["Wild Charge"], ["Brave Bird"], ["U-turn"], ["Iron Head"]]
       }
     ]
   },
@@ -3278,91 +1007,27 @@
     "sets": [
       {
         "species": "Gyarados",
-        "item": [
-          "Wacan Berry",
-          "Lum Berry"
-        ],
-        "ability": [
-          "Moxie"
-        ],
-        "evs": {
-          "atk": 252,
-          "def": 4,
-          "spe": 252
-        },
+        "item": ["Wacan Berry", "Lum Berry"],
+        "ability": ["Moxie"],
+        "evs": {"atk": 252, "def": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Waterfall"
-          ],
-          [
-            "Bounce"
-          ],
-          [
-            "Power Whip"
-          ],
-          [
-            "Dragon Dance"
-          ]
-        ]
+        "moves": [["Waterfall"], ["Bounce"], ["Power Whip"], ["Dragon Dance"]]
       },
       {
         "species": "Gyarados",
-        "item": [
-          "Sitrus Berry"
-        ],
-        "ability": [
-          "Intimidate"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 156,
-          "spe": 100
-        },
+        "item": ["Sitrus Berry"],
+        "ability": ["Intimidate"],
+        "evs": {"hp": 252, "def": 156, "spe": 100},
         "nature": "Impish",
-        "moves": [
-          [
-            "Waterfall"
-          ],
-          [
-            "Bounce"
-          ],
-          [
-            "Dragon Dance"
-          ],
-          [
-            "Taunt"
-          ]
-        ]
+        "moves": [["Waterfall"], ["Bounce"], ["Dragon Dance"], ["Taunt"]]
       },
       {
         "species": "Gyarados",
-        "item": [
-          "Chesto Berry"
-        ],
-        "ability": [
-          "Intimidate"
-        ],
-        "evs": {
-          "atk": 252,
-          "def": 4,
-          "spe": 252
-        },
+        "item": ["Chesto Berry"],
+        "ability": ["Intimidate"],
+        "evs": {"atk": 252, "def": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Waterfall"
-          ],
-          [
-            "Bounce"
-          ],
-          [
-            "Dragon Dance"
-          ],
-          [
-            "Rest"
-          ]
-        ]
+        "moves": [["Waterfall"], ["Bounce"], ["Dragon Dance"], ["Rest"]]
       }
     ]
   },
@@ -3371,67 +1036,20 @@
     "sets": [
       {
         "species": "Lapras-Gmax",
-        "item": [
-          "Weakness Policy"
-        ],
-        "ability": [
-          "Shell Armor"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 4,
-          "spa": 252
-        },
+        "item": ["Weakness Policy"],
+        "ability": ["Shell Armor"],
+        "evs": {"hp": 252, "def": 4, "spa": 252},
         "nature": "Quiet",
-        "moves": [
-          [
-            "Freeze-Dry"
-          ],
-          [
-            "Ice Shard"
-          ],
-          [
-            "Thunder",
-            "Thunderbolt"
-          ],
-          [
-            "Sparkling Aria",
-            "Hydro Pump"
-          ]
-        ]
+        "moves": [["Freeze-Dry"], ["Ice Shard"], ["Thunder", "Thunderbolt"], ["Sparkling Aria", "Hydro Pump"]]
       },
       {
         "species": "Lapras-Gmax",
-        "item": [
-          "Light Clay",
-          "Assault Vest"
-        ],
-        "ability": [
-          "Water Absorb"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 4,
-          "spa": 252
-        },
+        "item": ["Light Clay", "Assault Vest"],
+        "ability": ["Water Absorb"],
+        "evs": {"hp": 252, "def": 4, "spa": 252},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Freeze-Dry"
-          ],
-          [
-            "Sheer Cold"
-          ],
-          [
-            "Thunderbolt"
-          ],
-          [
-            "Sparkling Aria"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Freeze-Dry"], ["Sheer Cold"], ["Thunderbolt"], ["Sparkling Aria"]]
       }
     ]
   },
@@ -3440,65 +1058,19 @@
     "sets": [
       {
         "species": "Darmanitan-Galar",
-        "item": [
-          "Choice Scarf",
-          "Focus Sash"
-        ],
-        "ability": [
-          "Gorilla Tactics"
-        ],
-        "evs": {
-          "hp": 4,
-          "atk": 252,
-          "spe": 252
-        },
+        "item": ["Choice Scarf", "Focus Sash"],
+        "ability": ["Gorilla Tactics"],
+        "evs": {"hp": 4, "atk": 252, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Icicle Crash"
-          ],
-          [
-            "Flare Blitz"
-          ],
-          [
-            "Earthquake",
-            "Superpower"
-          ],
-          [
-            "U-turn"
-          ]
-        ]
+        "moves": [["Icicle Crash"], ["Flare Blitz"], ["Earthquake", "Superpower"], ["U-turn"]]
       },
       {
         "species": "Darmanitan-Galar",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Zen Mode"
-        ],
-        "evs": {
-          "hp": 4,
-          "atk": 252,
-          "spe": 252
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Zen Mode"],
+        "evs": {"hp": 4, "atk": 252, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Icicle Crash"
-          ],
-          [
-            "Flare Blitz",
-            "Fire Punch"
-          ],
-          [
-            "Earthquake",
-            "Reversal"
-          ],
-          [
-            "Yawn"
-          ]
-        ]
+        "moves": [["Icicle Crash"], ["Flare Blitz", "Fire Punch"], ["Earthquake", "Reversal"], ["Yawn"]]
       }
     ]
   },
@@ -3507,132 +1079,38 @@
     "sets": [
       {
         "species": "Thundurus-Therian",
-        "item": [
-          "Choice Specs",
-          "Assault Vest"
-        ],
-        "ability": [
-          "Volt Absorb"
-        ],
-        "evs": {
-          "def": 4,
-          "spa": 252,
-          "spe": 252
-        },
+        "item": ["Choice Specs", "Assault Vest"],
+        "ability": ["Volt Absorb"],
+        "evs": {"def": 4, "spa": 252, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Thunderbolt"
-          ],
-          [
-            "Volt Switch"
-          ],
-          [
-            "Grass Knot"
-          ],
-          [
-            "Sludge Wave",
-            "Focus Blast"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Thunderbolt"], ["Volt Switch"], ["Grass Knot"], ["Sludge Wave", "Focus Blast"]]
       },
       {
         "species": "Thundurus-Therian",
-        "item": [
-          "Sitrus Berry",
-          "Life Orb"
-        ],
-        "ability": [
-          "Volt Absorb"
-        ],
-        "evs": {
-          "def": 4,
-          "spa": 252,
-          "spe": 252
-        },
+        "item": ["Sitrus Berry", "Life Orb"],
+        "ability": ["Volt Absorb"],
+        "evs": {"def": 4, "spa": 252, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Thunderbolt"
-          ],
-          [
-            "Nasty Plot"
-          ],
-          [
-            "Grass Knot"
-          ],
-          [
-            "Flash Cannon",
-            "Dark Pulse"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Thunderbolt"], ["Nasty Plot"], ["Grass Knot"], ["Flash Cannon", "Dark Pulse"]]
       },
       {
         "species": "Thundurus",
-        "item": [
-          "Sitrus Berry"
-        ],
-        "ability": [
-          "Prankster"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Sitrus Berry"],
+        "ability": ["Prankster"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Volt Switch"
-          ],
-          [
-            "Taunt"
-          ],
-          [
-            "Thunder Wave"
-          ],
-          [
-            "Eerie Impulse"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Volt Switch"], ["Taunt"], ["Thunder Wave"], ["Eerie Impulse"]]
       },
       {
         "species": "Thundurus",
-        "item": [
-          "Life Orb"
-        ],
-        "ability": [
-          "Defiant"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Life Orb"],
+        "ability": ["Defiant"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Wild Charge"
-          ],
-          [
-            "Fly"
-          ],
-          [
-            "Superpower"
-          ],
-          [
-            "Bulk Up"
-          ]
-        ]
+        "moves": [["Wild Charge"], ["Fly"], ["Superpower"], ["Bulk Up"]]
       }
     ]
   },
@@ -3641,63 +1119,19 @@
     "sets": [
       {
         "species": "Rhyperior",
-        "item": [
-          "Weakness Policy"
-        ],
-        "ability": [
-          "Solid Rock"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "spd": 4
-        },
+        "item": ["Weakness Policy"],
+        "ability": ["Solid Rock"],
+        "evs": {"hp": 252, "atk": 252, "spd": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Earthquake"
-          ],
-          [
-            "Rock Blast"
-          ],
-          [
-            "Fire Punch"
-          ],
-          [
-            "Ice Punch",
-            "Swords Dance"
-          ]
-        ]
+        "moves": [["Earthquake"], ["Rock Blast"], ["Fire Punch"], ["Ice Punch", "Swords Dance"]]
       },
       {
         "species": "Rhyperior",
-        "item": [
-          "Assault Vest"
-        ],
-        "ability": [
-          "Solid Rock"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "spd": 4
-        },
+        "item": ["Assault Vest"],
+        "ability": ["Solid Rock"],
+        "evs": {"hp": 252, "atk": 252, "spd": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Earthquake"
-          ],
-          [
-            "Rock Blast"
-          ],
-          [
-            "Fire Punch",
-            "Superpower"
-          ],
-          [
-            "Ice Punch"
-          ]
-        ]
+        "moves": [["Earthquake"], ["Rock Blast"], ["Fire Punch", "Superpower"], ["Ice Punch"]]
       }
     ]
   },
@@ -3706,105 +1140,30 @@
     "sets": [
       {
         "species": "Suicune",
-        "item": [
-          "Leftovers"
-        ],
-        "ability": [
-          "Pressure"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Leftovers"],
+        "ability": ["Pressure"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Scald"
-          ],
-          [
-            "Icy Wind",
-            "Ice Beam",
-            "Protect"
-          ],
-          [
-            "Substitute"
-          ],
-          [
-            "Calm Mind"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Scald"], ["Icy Wind", "Ice Beam", "Protect"], ["Substitute"], ["Calm Mind"]]
       },
       {
         "species": "Suicune",
-        "item": [
-          "Chesto Berry"
-        ],
-        "ability": [
-          "Pressure"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Chesto Berry"],
+        "ability": ["Pressure"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Scald"
-          ],
-          [
-            "Icy Wind",
-            "Ice Beam",
-            "Sleep Talk"
-          ],
-          [
-            "Rest"
-          ],
-          [
-            "Calm Mind"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Scald"], ["Icy Wind", "Ice Beam", "Sleep Talk"], ["Rest"], ["Calm Mind"]]
       },
       {
         "species": "Suicune",
-        "item": [
-          "Weakness Policy",
-          "Life Orb",
-          "Sitrus Berry"
-        ],
-        "ability": [
-          "Pressure"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Weakness Policy", "Life Orb", "Sitrus Berry"],
+        "ability": ["Pressure"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Hydro Pump"
-          ],
-          [
-            "Ice Beam"
-          ],
-          [
-            "Air Slash"
-          ],
-          [
-            "Calm Mind"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Hydro Pump"], ["Ice Beam"], ["Air Slash"], ["Calm Mind"]]
       }
     ]
   },
@@ -3813,79 +1172,21 @@
     "sets": [
       {
         "species": "Tapu Lele",
-        "item": [
-          "Choice Scarf",
-          "Choice Specs",
-          "Assault Vest"
-        ],
-        "ability": [
-          "Psychic Surge"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Choice Scarf", "Choice Specs", "Assault Vest"],
+        "ability": ["Psychic Surge"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Psychic",
-            "Psyshock"
-          ],
-          [
-            "Moonblast"
-          ],
-          [
-            "Thunderbolt",
-            "Energy Ball"
-          ],
-          [
-            "Shadow Ball",
-            "Focus Blast"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Psychic", "Psyshock"], ["Moonblast"], ["Thunderbolt", "Energy Ball"], ["Shadow Ball", "Focus Blast"]]
       },
       {
         "species": "Tapu Lele",
-        "item": [
-          "Life Orb",
-          "Leftovers",
-          "Focus Sash"
-        ],
-        "ability": [
-          "Psychic Surge"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Life Orb", "Leftovers", "Focus Sash"],
+        "ability": ["Psychic Surge"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Psychic",
-            "Psyshock"
-          ],
-          [
-            "Moonblast",
-            "Draining Kiss"
-          ],
-          [
-            "Calm Mind"
-          ],
-          [
-            "Focus Blast",
-            "Energy Ball",
-            "Thunderbolt",
-            "Shadow Ball"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Psychic", "Psyshock"], ["Moonblast", "Draining Kiss"], ["Calm Mind"], ["Focus Blast", "Energy Ball", "Thunderbolt", "Shadow Ball"]]
       }
     ]
   },
@@ -3894,72 +1195,21 @@
     "sets": [
       {
         "species": "Latias",
-        "item": [
-          "Kee Berry",
-          "Leftovers"
-        ],
-        "ability": [
-          "Levitate"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 4,
-          "spe": 252
-        },
+        "item": ["Kee Berry", "Leftovers"],
+        "ability": ["Levitate"],
+        "evs": {"hp": 252, "def": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Stored Power"
-          ],
-          [
-            "Substitute",
-            "Mystical Fire"
-          ],
-          [
-            "Calm Mind"
-          ],
-          [
-            "Recover"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Stored Power"], ["Substitute", "Mystical Fire"], ["Calm Mind"], ["Recover"]]
       },
       {
         "species": "Latias",
-        "item": [
-          "Weakness Policy"
-        ],
-        "ability": [
-          "Levitate"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Weakness Policy"],
+        "ability": ["Levitate"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Stored Power",
-            "Psychic",
-            "Psyshock"
-          ],
-          [
-            "Mystical Fire"
-          ],
-          [
-            "Air Slash"
-          ],
-          [
-            "Draco Meteor",
-            "Calm Mind"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Stored Power", "Psychic", "Psyshock"], ["Mystical Fire"], ["Air Slash"], ["Draco Meteor", "Calm Mind"]]
       }
     ]
   },
@@ -3968,39 +1218,12 @@
     "sets": [
       {
         "species": "Ninetales-Alola",
-        "item": [
-          "Light Clay"
-        ],
-        "ability": [
-          "Snow Warning"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 4,
-          "spe": 252
-        },
+        "item": ["Light Clay"],
+        "ability": ["Snow Warning"],
+        "evs": {"hp": 252, "spa": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Blizzard"
-          ],
-          [
-            "Moonblast",
-            "Freeze-Dry",
-            "Icy Wind"
-          ],
-          [
-            "Aurora Veil"
-          ],
-          [
-            "Sheer Cold",
-            "Nasty Plot",
-            "Hypnosis"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Blizzard"], ["Moonblast", "Freeze-Dry", "Icy Wind"], ["Aurora Veil"], ["Sheer Cold", "Nasty Plot", "Hypnosis"]]
       }
     ]
   },
@@ -4009,124 +1232,35 @@
     "sets": [
       {
         "species": "Mamoswine",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Oblivious"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Oblivious"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Icicle Spear"
-          ],
-          [
-            "Earthquake"
-          ],
-          [
-            "Rock Tomb",
-            "Ice Shard"
-          ],
-          [
-            "Stealth Rock"
-          ]
-        ]
+        "moves": [["Icicle Spear"], ["Earthquake"], ["Rock Tomb", "Ice Shard"], ["Stealth Rock"]]
       },
       {
         "species": "Mamoswine",
-        "item": [
-          "Choice Scarf"
-        ],
-        "ability": [
-          "Oblivious"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Choice Scarf"],
+        "ability": ["Oblivious"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Icicle Crash"
-          ],
-          [
-            "Earthquake"
-          ],
-          [
-            "Superpower"
-          ],
-          [
-            "Stone Edge"
-          ]
-        ]
+        "moves": [["Icicle Crash"], ["Earthquake"], ["Superpower"], ["Stone Edge"]]
       },
       {
         "species": "Mamoswine",
-        "item": [
-          "Life Orb",
-          "Weakness Policy",
-          "Expert Belt"
-        ],
-        "ability": [
-          "Oblivious"
-        ],
-        "evs": {
-          "atk": 252,
-          "spa": 4,
-          "spe": 252
-        },
+        "item": ["Life Orb", "Weakness Policy", "Expert Belt"],
+        "ability": ["Oblivious"],
+        "evs": {"atk": 252, "spa": 4, "spe": 252},
         "nature": "Naive",
-        "moves": [
-          [
-            "Icicle Spear"
-          ],
-          [
-            "Earthquake"
-          ],
-          [
-            "Freeze-Dry"
-          ],
-          [
-            "Superpower"
-          ]
-        ]
+        "moves": [["Icicle Spear"], ["Earthquake"], ["Freeze-Dry"], ["Superpower"]]
       },
       {
         "species": "Mamoswine",
-        "item": [
-          "Assault Vest"
-        ],
-        "ability": [
-          "Thick Fat"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Assault Vest"],
+        "ability": ["Thick Fat"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Icicle Spear",
-            "Icicle Crash"
-          ],
-          [
-            "Earthquake"
-          ],
-          [
-            "Superpower",
-            "Ice Shard"
-          ],
-          [
-            "Stone Edge"
-          ]
-        ]
+        "moves": [["Icicle Spear", "Icicle Crash"], ["Earthquake"], ["Superpower", "Ice Shard"], ["Stone Edge"]]
       }
     ]
   },
@@ -4135,92 +1269,27 @@
     "sets": [
       {
         "species": "Scizor",
-        "item": [
-          "Choice Band"
-        ],
-        "ability": [
-          "Technician"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "spd": 4
-        },
+        "item": ["Choice Band"],
+        "ability": ["Technician"],
+        "evs": {"hp": 252, "atk": 252, "spd": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "U-turn"
-          ],
-          [
-            "Bullet Punch"
-          ],
-          [
-            "Dual Wingbeat"
-          ],
-          [
-            "Superpower"
-          ]
-        ]
+        "moves": [["U-turn"], ["Bullet Punch"], ["Dual Wingbeat"], ["Superpower"]]
       },
       {
         "species": "Scizor",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Technician"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Technician"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Adamant",
-        "moves": [
-          [
-            "U-turn"
-          ],
-          [
-            "Bullet Punch"
-          ],
-          [
-            "Dual Wingbeat"
-          ],
-          [
-            "Counter"
-          ]
-        ]
+        "moves": [["U-turn"], ["Bullet Punch"], ["Dual Wingbeat"], ["Counter"]]
       },
       {
         "species": "Scizor",
-        "item": [
-          "Lum Berry",
-          "Life Orb",
-          "Sitrus Berry"
-        ],
-        "ability": [
-          "Technician"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Lum Berry", "Life Orb", "Sitrus Berry"],
+        "ability": ["Technician"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Bullet Punch"
-          ],
-          [
-            "Dual Wingbeat"
-          ],
-          [
-            "Sand Tomb"
-          ],
-          [
-            "Swords Dance"
-          ]
-        ]
+        "moves": [["Bullet Punch"], ["Dual Wingbeat"], ["Sand Tomb"], ["Swords Dance"]]
       }
     ]
   },
@@ -4229,69 +1298,21 @@
     "sets": [
       {
         "species": "Raikou",
-        "item": [
-          "Leftovers"
-        ],
-        "ability": [
-          "Pressure"
-        ],
-        "evs": {
-          "def": 4,
-          "spa": 252,
-          "spe": 252
-        },
+        "item": ["Leftovers"],
+        "ability": ["Pressure"],
+        "evs": {"def": 4, "spa": 252, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Thunderbolt"
-          ],
-          [
-            "Scald"
-          ],
-          [
-            "Substitute",
-            "Shadow Ball"
-          ],
-          [
-            "Calm Mind"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Thunderbolt"], ["Scald"], ["Substitute", "Shadow Ball"], ["Calm Mind"]]
       },
       {
         "species": "Raikou",
-        "item": [
-          "Choice Specs"
-        ],
-        "ability": [
-          "Pressure"
-        ],
-        "evs": {
-          "def": 4,
-          "spa": 252,
-          "spe": 252
-        },
+        "item": ["Choice Specs"],
+        "ability": ["Pressure"],
+        "evs": {"def": 4, "spa": 252, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Thunderbolt"
-          ],
-          [
-            "Scald"
-          ],
-          [
-            "Shadow Ball",
-            "Aura Sphere"
-          ],
-          [
-            "Volt Switch"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Thunderbolt"], ["Scald"], ["Shadow Ball", "Aura Sphere"], ["Volt Switch"]]
       }
     ]
   },
@@ -4300,110 +1321,30 @@
     "sets": [
       {
         "species": "Latios",
-        "item": [
-          "Choice Specs",
-          "Choice Scarf"
-        ],
-        "ability": [
-          "Levitate"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Choice Specs", "Choice Scarf"],
+        "ability": ["Levitate"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Draco Meteor"
-          ],
-          [
-            "Psychic",
-            "Psyshock"
-          ],
-          [
-            "Mystical Fire"
-          ],
-          [
-            "Trick",
-            "Air Slash",
-            "Ice Beam"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Draco Meteor"], ["Psychic", "Psyshock"], ["Mystical Fire"], ["Trick", "Air Slash", "Ice Beam"]]
       },
       {
         "species": "Latios",
-        "item": [
-          "Soul Dew",
-          "Weakness Policy",
-          "Life Orb"
-        ],
-        "ability": [
-          "Levitate"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Soul Dew", "Weakness Policy", "Life Orb"],
+        "ability": ["Levitate"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Draco Meteor"
-          ],
-          [
-            "Psychic",
-            "Psyshock"
-          ],
-          [
-            "Mystical Fire",
-            "Aura Sphere"
-          ],
-          [
-            "Calm Mind",
-            "Air Slash"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Draco Meteor"], ["Psychic", "Psyshock"], ["Mystical Fire", "Aura Sphere"], ["Calm Mind", "Air Slash"]]
       },
       {
         "species": "Latios",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Levitate"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Levitate"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Psyshock",
-            "Psychic",
-            "Draco Meteor"
-          ],
-          [
-            "Mystical Fire"
-          ],
-          [
-            "Thunder Wave"
-          ],
-          [
-            "Memento"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Psyshock", "Psychic", "Draco Meteor"], ["Mystical Fire"], ["Thunder Wave"], ["Memento"]]
       }
     ]
   },
@@ -4412,101 +1353,30 @@
     "sets": [
       {
         "species": "Whimsicott",
-        "item": [
-          "Leftovers",
-          "Rocky Helmet"
-        ],
-        "ability": [
-          "Prankster"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Leftovers", "Rocky Helmet"],
+        "ability": ["Prankster"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Moonblast"
-          ],
-          [
-            "Leech Seed"
-          ],
-          [
-            "Substitute"
-          ],
-          [
-            "Cotton Guard"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Moonblast"], ["Leech Seed"], ["Substitute"], ["Cotton Guard"]]
       },
       {
         "species": "Whimsicott",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Prankster"
-        ],
-        "evs": {
-          "def": 4,
-          "spa": 252,
-          "spe": 252
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Prankster"],
+        "evs": {"def": 4, "spa": 252, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Moonblast"
-          ],
-          [
-            "Tailwind"
-          ],
-          [
-            "Memento"
-          ],
-          [
-            "Taunt"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Moonblast"], ["Tailwind"], ["Memento"], ["Taunt"]]
       },
       {
         "species": "Whimsicott",
-        "item": [
-          "Lagging Tail",
-          "Full Incense"
-        ],
-        "ability": [
-          "Prankster"
-        ],
-        "evs": {
-          "def": 4,
-          "spa": 252,
-          "spe": 252
-        },
+        "item": ["Lagging Tail", "Full Incense"],
+        "ability": ["Prankster"],
+        "evs": {"def": 4, "spa": 252, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Moonblast"
-          ],
-          [
-            "Switcheroo"
-          ],
-          [
-            "Memento"
-          ],
-          [
-            "Taunt"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Moonblast"], ["Switcheroo"], ["Memento"], ["Taunt"]]
       }
     ]
   },
@@ -4515,97 +1385,28 @@
     "sets": [
       {
         "species": "Azumarill",
-        "item": [
-          "Sitrus Berry"
-        ],
-        "ability": [
-          "Sap Sipper"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 164,
-          "spd": 92
-        },
+        "item": ["Sitrus Berry"],
+        "ability": ["Sap Sipper"],
+        "evs": {"hp": 252, "def": 164, "spd": 92},
         "nature": "Sassy",
-        "ivs": {
-          "atk": 0,
-          "spe": 0
-        },
-        "moves": [
-          [
-            "Whirlpool"
-          ],
-          [
-            "Perish Song"
-          ],
-          [
-            "Protect"
-          ],
-          [
-            "Encore"
-          ]
-        ]
+        "ivs": {"atk": 0, "spe": 0},
+        "moves": [["Whirlpool"], ["Perish Song"], ["Protect"], ["Encore"]]
       },
       {
         "species": "Azumarill",
-        "item": [
-          "Assault Vest"
-        ],
-        "ability": [
-          "Huge Power"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "spd": 4
-        },
+        "item": ["Assault Vest"],
+        "ability": ["Huge Power"],
+        "evs": {"hp": 252, "atk": 252, "spd": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Liquidation"
-          ],
-          [
-            "Play Rough"
-          ],
-          [
-            "Superpower"
-          ],
-          [
-            "Bounce",
-            "Aqua Jet"
-          ]
-        ]
+        "moves": [["Liquidation"], ["Play Rough"], ["Superpower"], ["Bounce", "Aqua Jet"]]
       },
       {
         "species": "Azumarill",
-        "item": [
-          "Sitrus Berry"
-        ],
-        "ability": [
-          "Huge Power"
-        ],
-        "evs": {
-          "hp": 228,
-          "atk": 252,
-          "def": 12,
-          "spd": 12,
-          "spe": 4
-        },
+        "item": ["Sitrus Berry"],
+        "ability": ["Huge Power"],
+        "evs": {"hp": 228, "atk": 252, "def": 12, "spd": 12, "spe": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Aqua Jet"
-          ],
-          [
-            "Play Rough"
-          ],
-          [
-            "Superpower"
-          ],
-          [
-            "Belly Drum"
-          ]
-        ]
+        "moves": [["Aqua Jet"], ["Play Rough"], ["Superpower"], ["Belly Drum"]]
       }
     ]
   },
@@ -4614,99 +1415,27 @@
     "sets": [
       {
         "species": "Snorlax-Gmax",
-        "item": [
-          "Figy Berry",
-          "Custap Berry"
-        ],
-        "ability": [
-          "Gluttony"
-        ],
-        "evs": {
-          "atk": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Figy Berry", "Custap Berry"],
+        "ability": ["Gluttony"],
+        "evs": {"atk": 252, "def": 252, "spd": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Facade",
-            "Body Slam",
-            "Self-Destruct"
-          ],
-          [
-            "Earthquake"
-          ],
-          [
-            "Darkest Lariat",
-            "Heavy Slam",
-            "Heat Crash"
-          ],
-          [
-            "Curse",
-            "Belly Drum"
-          ]
-        ]
+        "moves": [["Facade", "Body Slam", "Self-Destruct"], ["Earthquake"], ["Darkest Lariat", "Heavy Slam", "Heat Crash"], ["Curse", "Belly Drum"]]
       },
       {
         "species": "Snorlax-Gmax",
-        "item": [
-          "Figy Berry"
-        ],
-        "ability": [
-          "Gluttony"
-        ],
-        "evs": {
-          "atk": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Figy Berry"],
+        "ability": ["Gluttony"],
+        "evs": {"atk": 252, "def": 252, "spd": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Body Slam",
-            "Self-Destruct"
-          ],
-          [
-            "Yawn"
-          ],
-          [
-            "Fire Punch"
-          ],
-          [
-            "Protect"
-          ]
-        ]
+        "moves": [["Body Slam", "Self-Destruct"], ["Yawn"], ["Fire Punch"], ["Protect"]]
       },
       {
         "species": "Snorlax",
-        "item": [
-          "Assault Vest"
-        ],
-        "ability": [
-          "Thick Fat"
-        ],
-        "evs": {
-          "atk": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Assault Vest"],
+        "ability": ["Thick Fat"],
+        "evs": {"atk": 252, "def": 252, "spd": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Body Slam"
-          ],
-          [
-            "Earthquake"
-          ],
-          [
-            "Brick Break",
-            "Heavy Slam"
-          ],
-          [
-            "Ice Punch",
-            "Heat Crash"
-          ]
-        ]
+        "moves": [["Body Slam"], ["Earthquake"], ["Brick Break", "Heavy Slam"], ["Ice Punch", "Heat Crash"]]
       }
     ]
   },
@@ -4715,135 +1444,39 @@
     "sets": [
       {
         "species": "Togekiss",
-        "item": [
-          "Sharp Beak",
-          "Life Orb"
-        ],
-        "ability": [
-          "Serene Grace"
-        ],
-        "evs": {
-          "hp": 4,
-          "spa": 252,
-          "spe": 252
-        },
+        "item": ["Sharp Beak", "Life Orb"],
+        "ability": ["Serene Grace"],
+        "evs": {"hp": 4, "spa": 252, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Air Slash"
-          ],
-          [
-            "Dazzling Gleam"
-          ],
-          [
-            "Flamethrower"
-          ],
-          [
-            "Nasty Plot"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Air Slash"], ["Dazzling Gleam"], ["Flamethrower"], ["Nasty Plot"]]
       },
       {
         "species": "Togekiss",
-        "item": [
-          "Scope Lens"
-        ],
-        "ability": [
-          "Super Luck"
-        ],
-        "evs": {
-          "hp": 4,
-          "spa": 252,
-          "spe": 252
-        },
+        "item": ["Scope Lens"],
+        "ability": ["Super Luck"],
+        "evs": {"hp": 4, "spa": 252, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Air Slash"
-          ],
-          [
-            "Dazzling Gleam"
-          ],
-          [
-            "Flamethrower"
-          ],
-          [
-            "Ancient Power",
-            "Grass Knot"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Air Slash"], ["Dazzling Gleam"], ["Flamethrower"], ["Ancient Power", "Grass Knot"]]
       },
       {
         "species": "Togekiss",
-        "item": [
-          "Choice Scarf"
-        ],
-        "ability": [
-          "Serene Grace"
-        ],
-        "evs": {
-          "hp": 4,
-          "spa": 252,
-          "spe": 252
-        },
+        "item": ["Choice Scarf"],
+        "ability": ["Serene Grace"],
+        "evs": {"hp": 4, "spa": 252, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Air Slash"
-          ],
-          [
-            "Dazzling Gleam"
-          ],
-          [
-            "Flamethrower"
-          ],
-          [
-            "Trick"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Air Slash"], ["Dazzling Gleam"], ["Flamethrower"], ["Trick"]]
       },
       {
         "species": "Togekiss",
-        "item": [
-          "Sitrus Berry"
-        ],
-        "ability": [
-          "Serene Grace"
-        ],
-        "evs": {
-          "hp": 244,
-          "def": 4,
-          "spa": 4,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Sitrus Berry"],
+        "ability": ["Serene Grace"],
+        "evs": {"hp": 244, "def": 4, "spa": 4, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Air Slash"
-          ],
-          [
-            "Morning Sun"
-          ],
-          [
-            "Mystical Fire"
-          ],
-          [
-            "Nasty Plot"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Air Slash"], ["Morning Sun"], ["Mystical Fire"], ["Nasty Plot"]]
       }
     ]
   },
@@ -4852,102 +1485,30 @@
     "sets": [
       {
         "species": "Clefable",
-        "item": [
-          "Kee Berry"
-        ],
-        "ability": [
-          "Unaware"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Kee Berry"],
+        "ability": ["Unaware"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Moonblast"
-          ],
-          [
-            "Calm Mind",
-            "Cosmic Power",
-            "Minimize"
-          ],
-          [
-            "Moonlight"
-          ],
-          [
-            "Stored Power"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Moonblast"], ["Calm Mind", "Cosmic Power", "Minimize"], ["Moonlight"], ["Stored Power"]]
       },
       {
         "species": "Clefable",
-        "item": [
-          "Flame Orb"
-        ],
-        "ability": [
-          "Magic Guard"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Flame Orb"],
+        "ability": ["Magic Guard"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Moonblast"
-          ],
-          [
-            "Trick"
-          ],
-          [
-            "Stealth Rock"
-          ],
-          [
-            "Moonlight"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Moonblast"], ["Trick"], ["Stealth Rock"], ["Moonlight"]]
       },
       {
         "species": "Clefable",
-        "item": [
-          "Life Orb",
-          "Power Herb"
-        ],
-        "ability": [
-          "Magic Guard"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spd": 4
-        },
+        "item": ["Life Orb", "Power Herb"],
+        "ability": ["Magic Guard"],
+        "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Moonblast"
-          ],
-          [
-            "Fire Blast"
-          ],
-          [
-            "Thunderbolt"
-          ],
-          [
-            "Meteor Beam"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Moonblast"], ["Fire Blast"], ["Thunderbolt"], ["Meteor Beam"]]
       }
     ]
   },
@@ -4956,39 +1517,12 @@
     "sets": [
       {
         "species": "Quagsire",
-        "item": [
-          "Kee Berry",
-          "Sitrus Berry",
-          "Rocky Helmet"
-        ],
-        "ability": [
-          "Unaware"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Kee Berry", "Sitrus Berry", "Rocky Helmet"],
+        "ability": ["Unaware"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Scald"
-          ],
-          [
-            "Toxic"
-          ],
-          [
-            "Recover"
-          ],
-          [
-            "Earth Power",
-            "Protect",
-            "Stockpile"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Scald"], ["Toxic"], ["Recover"], ["Earth Power", "Protect", "Stockpile"]]
       }
     ]
   },
@@ -4997,36 +1531,11 @@
     "sets": [
       {
         "species": "Arctozolt",
-        "item": [
-          "Life Orb",
-          "Weakness Policy"
-        ],
-        "ability": [
-          "Slush Rush"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Life Orb", "Weakness Policy"],
+        "ability": ["Slush Rush"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Bolt Beak"
-          ],
-          [
-            "Icicle Spear",
-            "Icicle Crash"
-          ],
-          [
-            "Low Kick",
-            "Stomping Tantrum"
-          ],
-          [
-            "Freeze-Dry",
-            "Thunder Wave"
-          ]
-        ]
+        "moves": [["Bolt Beak"], ["Icicle Spear", "Icicle Crash"], ["Low Kick", "Stomping Tantrum"], ["Freeze-Dry", "Thunder Wave"]]
       }
     ]
   },
@@ -5035,95 +1544,30 @@
     "sets": [
       {
         "species": "Aegislash",
-        "item": [
-          "Weakness Policy",
-          "Life Orb",
-          "Leftovers"
-        ],
-        "ability": [
-          "Stance Change"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "spd": 4
-        },
+        "item": ["Weakness Policy", "Life Orb", "Leftovers"],
+        "ability": ["Stance Change"],
+        "evs": {"hp": 252, "atk": 252, "spd": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Shadow Sneak"
-          ],
-          [
-            "Iron Head",
-            "Sacred Sword"
-          ],
-          [
-            "Swords Dance"
-          ],
-          [
-            "King's Shield",
+        "moves": [["Shadow Sneak"], ["Iron Head", "Sacred Sword"], ["Swords Dance"], ["King's Shield",
             "Shadow Claw"
           ]
         ]
       },
       {
         "species": "Aegislash",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Stance Change"
-        ],
-        "evs": {
-          "atk": 196,
-          "spa": 252,
-          "spe": 60
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Stance Change"],
+        "evs": {"atk": 196, "spa": 252, "spe": 60},
         "nature": "Rash",
-        "moves": [
-          [
-            "Shadow Ball"
-          ],
-          [
-            "Close Combat"
-          ],
-          [
-            "Flash Cannon",
-            "Steel Beam"
-          ],
-          [
-            "Shadow Sneak"
-          ]
-        ]
+        "moves": [["Shadow Ball"], ["Close Combat"], ["Flash Cannon", "Steel Beam"], ["Shadow Sneak"]]
       },
       {
         "species": "Aegislash",
-        "item": [
-          "Weakness Policy"
-        ],
-        "ability": [
-          "Stance Change"
-        ],
-        "evs": {
-          "atk": 4,
-          "spa": 252,
-          "spe": 252
-        },
+        "item": ["Weakness Policy"],
+        "ability": ["Stance Change"],
+        "evs": {"atk": 4, "spa": 252, "spe": 252},
         "nature": "Hasty",
-        "moves": [
-          [
-            "Flash Cannon"
-          ],
-          [
-            "Shadow Ball"
-          ],
-          [
-            "Air Slash"
-          ],
-          [
-            "Close Combat"
-          ]
-        ]
+        "moves": [["Flash Cannon"], ["Shadow Ball"], ["Air Slash"], ["Close Combat"]]
       }
     ]
   },
@@ -5132,69 +1576,21 @@
     "sets": [
       {
         "species": "Primarina",
-        "item": [
-          "Assault Vest",
-          "Choice Specs"
-        ],
-        "ability": [
-          "Torrent"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 28,
-          "spa": 228
-        },
-        "ivs": {
-          "atk": 0
-        },
+        "item": ["Assault Vest", "Choice Specs"],
+        "ability": ["Torrent"],
+        "evs": {"hp": 252, "def": 28, "spa": 228},
+        "ivs": {"atk": 0},
         "nature": "Modest",
-        "moves": [
-          [
-            "Moonblast"
-          ],
-          [
-            "Sparkling Aria"
-          ],
-          [
-            "Energy Ball"
-          ],
-          [
-            "Psychic",
-            "Aqua Jet"
-          ]
-        ]
+        "moves": [["Moonblast"], ["Sparkling Aria"], ["Energy Ball"], ["Psychic", "Aqua Jet"]]
       },
       {
         "species": "Primarina",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Torrent"
-        ],
-        "evs": {
-          "def": 4,
-          "spa": 252,
-          "spe": 252
-        },
-        "ivs": {
-          "atk": 0
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Torrent"],
+        "evs": {"def": 4, "spa": 252, "spe": 252},
+        "ivs": {"atk": 0},
         "nature": "Modest",
-        "moves": [
-          [
-            "Moonblast"
-          ],
-          [
-            "Sparkling Aria"
-          ],
-          [
-            "Energy Ball"
-          ],
-          [
-            "Aqua Jet"
-          ]
-        ]
+        "moves": [["Moonblast"], ["Sparkling Aria"], ["Energy Ball"], ["Aqua Jet"]]
       }
     ]
   },
@@ -5203,74 +1599,21 @@
     "sets": [
       {
         "species": "Spectrier",
-        "item": [
-          "Life Orb",
-          "Lum Berry",
-          "Spell Tag"
-        ],
-        "ability": [
-          "Grim Neigh"
-        ],
-        "evs": {
-          "def": 4,
-          "spa": 252,
-          "spe": 252
-        },
-        "ivs": {
-          "atk": 0
-        },
+        "item": ["Life Orb", "Lum Berry", "Spell Tag"],
+        "ability": ["Grim Neigh"],
+        "evs": {"def": 4, "spa": 252, "spe": 252},
+        "ivs": {"atk": 0},
         "nature": "Timid",
-        "moves": [
-          [
-            "Shadow Ball"
-          ],
-          [
-            "Hyper Beam"
-          ],
-          [
-            "Nasty Plot"
-          ],
-          [
-            "Substitute",
-            "Dark Pulse",
-            "Will-O-Wisp",
-            "Mud Shot"
-          ]
-        ]
+        "moves": [["Shadow Ball"], ["Hyper Beam"], ["Nasty Plot"], ["Substitute", "Dark Pulse", "Will-O-Wisp", "Mud Shot"]]
       },
       {
         "species": "Spectrier",
-        "item": [
-          "Choice Scarf",
-          "Choice Specs"
-        ],
-        "ability": [
-          "Grim Neigh"
-        ],
-        "evs": {
-          "def": 4,
-          "spa": 252,
-          "spe": 252
-        },
-        "ivs": {
-          "atk": 0
-        },
+        "item": ["Choice Scarf", "Choice Specs"],
+        "ability": ["Grim Neigh"],
+        "evs": {"def": 4, "spa": 252, "spe": 252},
+        "ivs": {"atk": 0},
         "nature": "Timid",
-        "moves": [
-          [
-            "Shadow Ball"
-          ],
-          [
-            "Hyper Beam"
-          ],
-          [
-            "Dark Pulse"
-          ],
-          [
-            "Will-O-Wisp",
-            "Mud Shot"
-          ]
-        ]
+        "moves": [["Shadow Ball"], ["Hyper Beam"], ["Dark Pulse"], ["Will-O-Wisp", "Mud Shot"]]
       }
     ]
   },
@@ -5279,68 +1622,21 @@
     "sets": [
       {
         "species": "Corsola-Galar",
-        "item": [
-          "Eviolite"
-        ],
-        "ability": [
-          "Cursed Body"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
-        "ivs": {
-          "atk": 0
-        },
+        "item": ["Eviolite"],
+        "ability": ["Cursed Body"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
+        "ivs": {"atk": 0},
         "nature": "Bold",
-        "moves": [
-          [
-            "Night Shade"
-          ],
-          [
-            "Strength Sap"
-          ],
-          [
-            "Will-O-Wisp"
-          ],
-          [
-            "Stealth Rock",
-            "Mirror Coat"
-          ]
-        ]
+        "moves": [["Night Shade"], ["Strength Sap"], ["Will-O-Wisp"], ["Stealth Rock", "Mirror Coat"]]
       },
       {
         "species": "Corsola-Galar",
-        "item": [
-          "Eviolite"
-        ],
-        "ability": [
-          "Cursed Body"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
-        "ivs": {
-          "atk": 0
-        },
+        "item": ["Eviolite"],
+        "ability": ["Cursed Body"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
+        "ivs": {"atk": 0},
         "nature": "Bold",
-        "moves": [
-          [
-            "Hex"
-          ],
-          [
-            "Calm Mind"
-          ],
-          [
-            "Strength Sap"
-          ],
-          [
-            "Will-O-Wisp"
-          ]
-        ]
+        "moves": [["Hex"], ["Calm Mind"], ["Strength Sap"], ["Will-O-Wisp"]]
       }
     ]
   },
@@ -5349,33 +1645,11 @@
     "sets": [
       {
         "species": "Lucario",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Inner Focus"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Inner Focus"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Close Combat"
-          ],
-          [
-            "Meteor Mash"
-          ],
-          [
-            "Extreme Speed"
-          ],
-          [
-            "Ice Punch",
-            "Counter"
-          ]
-        ]
+        "moves": [["Close Combat"], ["Meteor Mash"], ["Extreme Speed"], ["Ice Punch", "Counter"]]
       }
     ]
   },
@@ -5384,37 +1658,12 @@
     "sets": [
       {
         "species": "Blissey",
-        "item": [
-          "Leftovers"
-        ],
-        "ability": [
-          "Serene Grace"
-        ],
-        "evs": {
-          "def": 252,
-          "spa": 4,
-          "spd": 252
-        },
-        "ivs": {
-          "atk": 0
-        },
+        "item": ["Leftovers"],
+        "ability": ["Serene Grace"],
+        "evs": {"def": 252, "spa": 4, "spd": 252},
+        "ivs": {"atk": 0},
         "nature": "Bold",
-        "moves": [
-          [
-            "Tri Attack"
-          ],
-          [
-            "Soft-Boiled"
-          ],
-          [
-            "Ice Beam",
-            "Flamethrower",
-            "Shadow Ball"
-          ],
-          [
-            "Calm Mind"
-          ]
-        ]
+        "moves": [["Tri Attack"], ["Soft-Boiled"], ["Ice Beam", "Flamethrower", "Shadow Ball"], ["Calm Mind"]]
       }
     ]
   },
@@ -5423,73 +1672,21 @@
     "sets": [
       {
         "species": "Charizard-Gmax",
-        "item": [
-          "Life Orb",
-          "Heavy-Duty Boots"
-        ],
-        "ability": [
-          "Blaze"
-        ],
-        "evs": {
-          "spa": 252,
-          "def": 4,
-          "spe": 252
-        },
-        "ivs": {
-          "atk": 0
-        },
+        "item": ["Life Orb", "Heavy-Duty Boots"],
+        "ability": ["Blaze"],
+        "evs": {"spa": 252, "def": 4, "spe": 252},
+        "ivs": {"atk": 0},
         "nature": "Timid",
-        "moves": [
-          [
-            "Blast Burn"
-          ],
-          [
-            "Air Slash",
-            "Hurricane"
-          ],
-          [
-            "Solar Beam"
-          ],
-          [
-            "Scorching Sands",
-            "Dragon Pulse"
-          ]
-        ]
+        "moves": [["Blast Burn"], ["Air Slash", "Hurricane"], ["Solar Beam"], ["Scorching Sands", "Dragon Pulse"]]
       },
       {
         "species": "Charizard",
-        "item": [
-          "Life Orb",
-          "Heavy-Duty Boots"
-        ],
-        "ability": [
-          "Solar Power"
-        ],
-        "evs": {
-          "spa": 252,
-          "def": 4,
-          "spe": 252
-        },
-        "ivs": {
-          "atk": 0
-        },
+        "item": ["Life Orb", "Heavy-Duty Boots"],
+        "ability": ["Solar Power"],
+        "evs": {"spa": 252, "def": 4, "spe": 252},
+        "ivs": {"atk": 0},
         "nature": "Timid",
-        "moves": [
-          [
-            "Fire Blast",
-            "Flamethrower"
-          ],
-          [
-            "Air Slash"
-          ],
-          [
-            "Solar Beam"
-          ],
-          [
-            "Scorching Sands",
-            "Dragon Pulse"
-          ]
-        ]
+        "moves": [["Fire Blast", "Flamethrower"], ["Air Slash"], ["Solar Beam"], ["Scorching Sands", "Dragon Pulse"]]
       }
     ]
   },
@@ -5498,91 +1695,27 @@
     "sets": [
       {
         "species": "Corviknight",
-        "item": [
-          "Rocky Helmet"
-        ],
-        "ability": [
-          "Mirror Armor"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Rocky Helmet"],
+        "ability": ["Mirror Armor"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Impish",
-        "moves": [
-          [
-            "Brave Bird"
-          ],
-          [
-            "Body Press"
-          ],
-          [
-            "Iron Defense"
-          ],
-          [
-            "Roost"
-          ]
-        ]
+        "moves": [["Brave Bird"], ["Body Press"], ["Iron Defense"], ["Roost"]]
       },
       {
         "species": "Corviknight",
-        "item": [
-          "Weakness Policy"
-        ],
-        "ability": [
-          "Mirror Armor"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 4,
-          "spe": 252
-        },
+        "item": ["Weakness Policy"],
+        "ability": ["Mirror Armor"],
+        "evs": {"hp": 252, "atk": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Brave Bird"
-          ],
-          [
-            "Iron Head"
-          ],
-          [
-            "Bulk Up"
-          ],
-          [
-            "Roost"
-          ]
-        ]
+        "moves": [["Brave Bird"], ["Iron Head"], ["Bulk Up"], ["Roost"]]
       },
       {
         "species": "Corviknight",
-        "item": [
-          "Maranga Berry"
-        ],
-        "ability": [
-          "Pressure"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 4,
-          "spd": 252
-        },
+        "item": ["Maranga Berry"],
+        "ability": ["Pressure"],
+        "evs": {"hp": 252, "def": 4, "spd": 252},
         "nature": "Careful",
-        "moves": [
-          [
-            "Brave Bird"
-          ],
-          [
-            "Taunt",
-            "Iron Head"
-          ],
-          [
-            "Bulk Up"
-          ],
-          [
-            "Roost"
-          ]
-        ]
+        "moves": [["Brave Bird"], ["Taunt", "Iron Head"], ["Bulk Up"], ["Roost"]]
       }
     ]
   },
@@ -5591,39 +1724,12 @@
     "sets": [
       {
         "species": "Gengar-Gmax",
-        "item": [
-          "Focus Sash",
-          "Wide Lens"
-        ],
-        "ability": [
-          "Cursed Body"
-        ],
-        "evs": {
-          "spa": 252,
-          "def": 4,
-          "spe": 252
-        },
-        "ivs": {
-          "atk": 0
-        },
+        "item": ["Focus Sash", "Wide Lens"],
+        "ability": ["Cursed Body"],
+        "evs": {"spa": 252, "def": 4, "spe": 252},
+        "ivs": {"atk": 0},
         "nature": "Timid",
-        "moves": [
-          [
-            "Shadow Ball",
-            "Hex"
-          ],
-          [
-            "Sludge Wave"
-          ],
-          [
-            "Icy Wind",
-            "Destiny Bond"
-          ],
-          [
-            "Hypnosis",
-            "Will-O-Wisp"
-          ]
-        ]
+        "moves": [["Shadow Ball", "Hex"], ["Sludge Wave"], ["Icy Wind", "Destiny Bond"], ["Hypnosis", "Will-O-Wisp"]]
       }
     ]
   },
@@ -5632,34 +1738,11 @@
     "sets": [
       {
         "species": "Uxie",
-        "item": [
-          "Sitrus Berry",
-          "Mental Herb"
-        ],
-        "ability": [
-          "Levitate"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spe": 4
-        },
+        "item": ["Sitrus Berry", "Mental Herb"],
+        "ability": ["Levitate"],
+        "evs": {"hp": 252, "def": 252, "spe": 4},
         "nature": "Bold",
-        "moves": [
-          [
-            "Stealth Rock"
-          ],
-          [
-            "Yawn"
-          ],
-          [
-            "Memento"
-          ],
-          [
-            "Trick Room",
-            "U-turn"
-          ]
-        ]
+        "moves": [["Stealth Rock"], ["Yawn"], ["Memento"], ["Trick Room", "U-turn"]]
       }
     ]
   },
@@ -5668,67 +1751,19 @@
     "sets": [
       {
         "species": "Arcanine",
-        "item": [
-          "Sitrus Berry",
-          "Rocky Helmet"
-        ],
-        "ability": [
-          "Intimidate"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spe": 4
-        },
+        "item": ["Sitrus Berry", "Rocky Helmet"],
+        "ability": ["Intimidate"],
+        "evs": {"hp": 252, "def": 252, "spe": 4},
         "nature": "Bold",
-        "moves": [
-          [
-            "Flamethrower"
-          ],
-          [
-            "Morning Sun"
-          ],
-          [
-            "Will-O-Wisp"
-          ],
-          [
-            "Snarl",
-            "Burn Up",
-            "Dragon Pulse"
-          ]
-        ]
+        "moves": [["Flamethrower"], ["Morning Sun"], ["Will-O-Wisp"], ["Snarl", "Burn Up", "Dragon Pulse"]]
       },
       {
         "species": "Arcanine",
-        "item": [
-          "Assault Vest",
-          "Choice Band",
-          "Life Orb"
-        ],
-        "ability": [
-          "Intimidate"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Assault Vest", "Choice Band", "Life Orb"],
+        "ability": ["Intimidate"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Flare Blitz"
-          ],
-          [
-            "Extreme Speed"
-          ],
-          [
-            "Wild Charge"
-          ],
-          [
-            "Play Rough",
-            "Close Combat"
-          ]
-        ]
+        "moves": [["Flare Blitz"], ["Extreme Speed"], ["Wild Charge"], ["Play Rough", "Close Combat"]]
       }
     ]
   },
@@ -5737,33 +1772,11 @@
     "sets": [
       {
         "species": "Chansey",
-        "item": [
-          "Eviolite"
-        ],
-        "ability": [
-          "Natural Cure"
-        ],
-        "evs": {
-          "def": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Eviolite"],
+        "ability": ["Natural Cure"],
+        "evs": {"def": 252, "spd": 4, "spe": 252},
         "nature": "Bold",
-        "moves": [
-          [
-            "Soft-Boiled"
-          ],
-          [
-            "Seismic Toss"
-          ],
-          [
-            "Thunder Wave"
-          ],
-          [
-            "Stealth Rock",
-            "Substitute"
-          ]
-        ]
+        "moves": [["Soft-Boiled"], ["Seismic Toss"], ["Thunder Wave"], ["Stealth Rock", "Substitute"]]
       }
     ]
   },
@@ -5772,36 +1785,11 @@
     "sets": [
       {
         "species": "Buzzwole",
-        "item": [
-          "Life Orb",
-          "Expert Belt",
-          "Choice Scarf"
-        ],
-        "ability": [
-          "Beast Boost"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Life Orb", "Expert Belt", "Choice Scarf"],
+        "ability": ["Beast Boost"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Close Combat"
-          ],
-          [
-            "Ice Punch"
-          ],
-          [
-            "Dual Wingbeat"
-          ],
-          [
-            "Thunder Punch",
-            "Earthquake",
-            "Leech Life"
-          ]
-        ]
+        "moves": [["Close Combat"], ["Ice Punch"], ["Dual Wingbeat"], ["Thunder Punch", "Earthquake", "Leech Life"]]
       }
     ]
   },
@@ -5810,35 +1798,11 @@
     "sets": [
       {
         "species": "Sylveon",
-        "item": [
-          "Pixie Plate",
-          "Leftovers",
-          "Throat Spray"
-        ],
-        "ability": [
-          "Pixilate"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spd": 4
-        },
+        "item": ["Pixie Plate", "Leftovers", "Throat Spray"],
+        "ability": ["Pixilate"],
+        "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Modest",
-        "moves": [
-          [
-            "Hyper Voice"
-          ],
-          [
-            "Mystical Fire"
-          ],
-          [
-            "Yawn"
-          ],
-          [
-            "Quick Attack",
-            "Calm Mind"
-          ]
-        ]
+        "moves": [["Hyper Voice"], ["Mystical Fire"], ["Yawn"], ["Quick Attack", "Calm Mind"]]
       }
     ]
   },
@@ -5847,73 +1811,21 @@
     "sets": [
       {
         "species": "Gastrodon",
-        "item": [
-          "Focus Sash",
-          "Sitrus Berry",
-          "Leftovers"
-        ],
-        "ability": [
-          "Storm Drain"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Focus Sash", "Sitrus Berry", "Leftovers"],
+        "ability": ["Storm Drain"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Recover"
-          ],
-          [
-            "Scald"
-          ],
-          [
-            "Counter"
-          ],
-          [
-            "Mirror Coat"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Recover"], ["Scald"], ["Counter"], ["Mirror Coat"]]
       },
       {
         "species": "Gastrodon",
-        "item": [
-          "Sitrus Berry",
-          "Leftovers",
-          "Rindo Berry"
-        ],
-        "ability": [
-          "Storm Drain"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Sitrus Berry", "Leftovers", "Rindo Berry"],
+        "ability": ["Storm Drain"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Recover"
-          ],
-          [
-            "Scald"
-          ],
-          [
-            "Yawn"
-          ],
-          [
-            "Earth Power",
-            "Clear Smog",
-            "Ice Beam"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Recover"], ["Scald"], ["Yawn"], ["Earth Power", "Clear Smog", "Ice Beam"]]
       }
     ]
   },
@@ -5922,106 +1834,30 @@
     "sets": [
       {
         "species": "Reuniclus",
-        "item": [
-          "Kee Berry",
-          "Leftovers"
-        ],
-        "ability": [
-          "Magic Guard"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spa": 4
-        },
+        "item": ["Kee Berry", "Leftovers"],
+        "ability": ["Magic Guard"],
+        "evs": {"hp": 252, "def": 252, "spa": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Calm Mind"
-          ],
-          [
-            "Recover"
-          ],
-          [
-            "Stored Power",
-            "Psyshock"
-          ],
-          [
-            "Thunder",
-            "Energy Ball"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Calm Mind"], ["Recover"], ["Stored Power", "Psyshock"], ["Thunder", "Energy Ball"]]
       },
       {
         "species": "Reuniclus",
-        "item": [
-          "Life Orb"
-        ],
-        "ability": [
-          "Magic Guard"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spd": 4
-        },
+        "item": ["Life Orb"],
+        "ability": ["Magic Guard"],
+        "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Psychic"
-          ],
-          [
-            "Focus Blast",
-            "Shadow Ball"
-          ],
-          [
-            "Trick Room"
-          ],
-          [
-            "Recover",
-            "Thunder",
-            "Energy Ball"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Psychic"], ["Focus Blast", "Shadow Ball"], ["Trick Room"], ["Recover", "Thunder", "Energy Ball"]]
       },
       {
         "species": "Reuniclus",
-        "item": [
-          "Flame Orb"
-        ],
-        "ability": [
-          "Magic Guard"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spa": 4
-        },
+        "item": ["Flame Orb"],
+        "ability": ["Magic Guard"],
+        "evs": {"hp": 252, "def": 252, "spa": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Calm Mind"
-          ],
-          [
-            "Recover"
-          ],
-          [
-            "Stored Power",
-            "Psyshock"
-          ],
-          [
-            "Trick"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Calm Mind"], ["Recover"], ["Stored Power", "Psyshock"], ["Trick"]]
       }
     ]
   },
@@ -6030,29 +1866,13 @@
     "sets": [
       {
         "species": "Ditto",
-        "item": [
-          "Choice Scarf",
-          "Focus Sash"
-        ],
-        "ability": [
-          "Imposter"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 4,
-          "def": 252
-        },
-        "ivs": {
-          "atk": 0,
-          "spe": 0
-        },
+        "item": ["Choice Scarf", "Focus Sash"],
+        "ability": ["Imposter"],
+        "evs": {"hp": 252, "atk": 4, "def": 252},
+        "ivs": {"atk": 0, "spe": 0},
         "nature": "Relaxed",
-        "moves": [
-          [
-            "Transform"
-          ]
-        ]
-      }
+		"moves": [["Transform"]]
+	  }
     ]
   },
   "goodra": {
@@ -6060,34 +1880,11 @@
     "sets": [
       {
         "species": "Goodra",
-        "item": [
-          "Assault Vest"
-        ],
-        "ability": [
-          "Sap Sipper"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 4,
-          "spa": 252
-        },
+        "item": ["Assault Vest"],
+        "ability": ["Sap Sipper"],
+        "evs": {"hp": 252, "def": 4, "spa": 252},
         "nature": "Modest",
-        "moves": [
-          [
-            "Dragon Pulse",
-            "Draco Meteor"
-          ],
-          [
-            "Flamethrower"
-          ],
-          [
-            "Acid Spray"
-          ],
-          [
-            "Thunderbolt",
-            "Power Whip"
-          ]
-        ]
+        "moves": [["Dragon Pulse", "Draco Meteor"], ["Flamethrower"], ["Acid Spray"], ["Thunderbolt", "Power Whip"]]
       }
     ]
   },
@@ -6096,63 +1893,19 @@
     "sets": [
       {
         "species": "Weavile",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Pickpocket"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Pickpocket"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Triple Axel"
-          ],
-          [
-            "Ice Shard"
-          ],
-          [
-            "Poison Jab",
-            "Throat Chop",
-            "Brick Break"
-          ],
-          [
-            "Counter"
-          ]
-        ]
+        "moves": [["Triple Axel"], ["Ice Shard"], ["Poison Jab", "Throat Chop", "Brick Break"], ["Counter"]]
       },
       {
         "species": "Weavile",
-        "item": [
-          "Choice Band"
-        ],
-        "ability": [
-          "Pressure"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Choice Band"],
+        "ability": ["Pressure"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Triple Axel"
-          ],
-          [
-            "Ice Shard"
-          ],
-          [
-            "Throat Chop"
-          ],
-          [
-            "Poison Jab"
-          ]
-        ]
+        "moves": [["Triple Axel"], ["Ice Shard"], ["Throat Chop"], ["Poison Jab"]]
       }
     ]
   },
@@ -6161,35 +1914,11 @@
     "sets": [
       {
         "species": "Entei",
-        "item": [
-          "Assault Vest",
-          "Choice Band"
-        ],
-        "ability": [
-          "Inner Focus"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Assault Vest", "Choice Band"],
+        "ability": ["Inner Focus"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Sacred Fire"
-          ],
-          [
-            "Extreme Speed"
-          ],
-          [
-            "Stone Edge"
-          ],
-          [
-            "Bulldoze",
-            "Stomping Tantrum",
-            "Iron Head"
-          ]
-        ]
+        "moves": [["Sacred Fire"], ["Extreme Speed"], ["Stone Edge"], ["Bulldoze", "Stomping Tantrum", "Iron Head"]]
       }
     ]
   },
@@ -6198,73 +1927,21 @@
     "sets": [
       {
         "species": "Milotic",
-        "item": [
-          "Flame Orb",
-          "Sitrus Berry",
-          "Leftovers"
-        ],
-        "ability": [
-          "Marvel Scale"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Flame Orb", "Sitrus Berry", "Leftovers"],
+        "ability": ["Marvel Scale"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Scald"
-          ],
-          [
-            "Ice Beam",
-            "Icy Wind"
-          ],
-          [
-            "Recover"
-          ],
-          [
-            "Mirror Coat",
-            "Haze"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Scald"], ["Ice Beam", "Icy Wind"], ["Recover"], ["Mirror Coat", "Haze"]]
       },
       {
         "species": "Milotic",
-        "item": [
-          "Sitrus Berry",
-          "Adrenaline Orb"
-        ],
-        "ability": [
-          "Competitive"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spd": 4
-        },
+        "item": ["Sitrus Berry", "Adrenaline Orb"],
+        "ability": ["Competitive"],
+        "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Hydro Pump"
-          ],
-          [
-            "Ice Beam"
-          ],
-          [
-            "Recover"
-          ],
-          [
-            "Mud Shot",
-            "Mirror Coat"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Hydro Pump"], ["Ice Beam"], ["Recover"], ["Mud Shot", "Mirror Coat"]]
       }
     ]
   },
@@ -6273,71 +1950,21 @@
     "sets": [
       {
         "species": "Hatterene-Gmax",
-        "item": [
-          "Focus Sash",
-          "Life Orb"
-        ],
-        "ability": [
-          "Magic Bounce"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 4,
-          "spa": 252
-        },
+        "item": ["Focus Sash", "Life Orb"],
+        "ability": ["Magic Bounce"],
+        "evs": {"hp": 252, "def": 4, "spa": 252},
         "nature": "Quiet",
-        "ivs": {
-          "atk": 0,
-          "spe": 0
-        },
-        "moves": [
-          [
-            "Trick Room"
-          ],
-          [
-            "Psychic"
-          ],
-          [
-            "Dazzling Gleam",
-            "Misty Explosion"
-          ],
-          [
-            "Mystical Fire"
-          ]
-        ]
+        "ivs": {"atk": 0, "spe": 0},
+        "moves": [["Trick Room"], ["Psychic"], ["Dazzling Gleam", "Misty Explosion"], ["Mystical Fire"]]
       },
       {
         "species": "Hatterene-Gmax",
-        "item": [
-          "Big Root"
-        ],
-        "ability": [
-          "Magic Bounce"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spa": 4
-        },
+        "item": ["Big Root"],
+        "ability": ["Magic Bounce"],
+        "evs": {"hp": 252, "def": 252, "spa": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0,
-          "spe": 0
-        },
-        "moves": [
-          [
-            "Psyshock"
-          ],
-          [
-            "Draining Kiss"
-          ],
-          [
-            "Giga Drain"
-          ],
-          [
-            "Calm Mind"
-          ]
-        ]
+        "ivs": {"atk": 0, "spe": 0},
+        "moves": [["Psyshock"], ["Draining Kiss"], ["Giga Drain"], ["Calm Mind"]]
       }
     ]
   },
@@ -6346,73 +1973,21 @@
     "sets": [
       {
         "species": "Inteleon-Gmax",
-        "item": [
-          "Scope Lens"
-        ],
-        "ability": [
-          "Sniper"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Scope Lens"],
+        "ability": ["Sniper"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Hydro Pump",
-            "Scald",
-            "Snipe Shot",
-            "Hydro Cannon"
-          ],
-          [
-            "Ice Beam"
-          ],
-          [
-            "Air Slash"
-          ],
-          [
-            "Focus Energy"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Hydro Pump", "Scald", "Snipe Shot", "Hydro Cannon"], ["Ice Beam"], ["Air Slash"], ["Focus Energy"]]
       },
       {
         "species": "Inteleon-Gmax",
-        "item": [
-          "Focus Sash",
-          "Petaya Berry"
-        ],
-        "ability": [
-          "Torrent"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Focus Sash", "Petaya Berry"],
+        "ability": ["Torrent"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Hydro Pump",
-            "Scald",
-            "Snipe Shot"
-          ],
-          [
-            "Ice Beam"
-          ],
-          [
-            "Air Slash"
-          ],
-          [
-            "Substitute"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Hydro Pump", "Scald", "Snipe Shot"], ["Ice Beam"], ["Air Slash"], ["Substitute"]]
       }
     ]
   },
@@ -6421,33 +1996,11 @@
     "sets": [
       {
         "species": "Marowak-Alola",
-        "item": [
-          "Thick Club"
-        ],
-        "ability": [
-          "Lightning Rod"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "spd": 4
-        },
+        "item": ["Thick Club"],
+        "ability": ["Lightning Rod"],
+        "evs": {"hp": 252, "atk": 252, "spd": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Flare Blitz"
-          ],
-          [
-            "Poltergeist",
-            "Shadow Bone"
-          ],
-          [
-            "Bonemerang"
-          ],
-          [
-            "Swords Dance"
-          ]
-        ]
+        "moves": [["Flare Blitz"], ["Poltergeist", "Shadow Bone"], ["Bonemerang"], ["Swords Dance"]]
       }
     ]
   },
@@ -6456,69 +2009,21 @@
     "sets": [
       {
         "species": "Slowking-Galar",
-        "item": [
-          "Black Sludge"
-        ],
-        "ability": [
-          "Regenerator"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spd": 4
-        },
+        "item": ["Black Sludge"],
+        "ability": ["Regenerator"],
+        "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Psyshock",
-            "Eerie Spell"
-          ],
-          [
-            "Sludge Bomb"
-          ],
-          [
-            "Flamethrower"
-          ],
-          [
-            "Calm Mind"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Psyshock", "Eerie Spell"], ["Sludge Bomb"], ["Flamethrower"], ["Calm Mind"]]
       },
       {
         "species": "Slowking-Galar",
-        "item": [
-          "Assault Vest"
-        ],
-        "ability": [
-          "Regenerator"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spd": 4
-        },
+        "item": ["Assault Vest"],
+        "ability": ["Regenerator"],
+        "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Psyshock",
-            "Eerie Spell"
-          ],
-          [
-            "Sludge Bomb"
-          ],
-          [
-            "Flamethrower"
-          ],
-          [
-            "Ice Beam"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Psyshock", "Eerie Spell"], ["Sludge Bomb"], ["Flamethrower"], ["Ice Beam"]]
       }
     ]
   },
@@ -6527,33 +2032,13 @@
     "sets": [
       {
         "species": "Cloyster",
-        "item": [
-          "Focus Sash",
+        "item": ["Focus Sash",
           "King's Rock"
         ],
-        "ability": [
-          "Skill Link"
-        ],
-        "evs": {
-          "atk": 252,
-          "def": 4,
-          "spe": 252
-        },
+        "ability": ["Skill Link"],
+        "evs": {"atk": 252, "def": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Shell Smash"
-          ],
-          [
-            "Icicle Spear"
-          ],
-          [
-            "Rock Blast"
-          ],
-          [
-            "Ice Shard"
-          ]
-        ]
+        "moves": [["Shell Smash"], ["Icicle Spear"], ["Rock Blast"], ["Ice Shard"]]
       }
     ]
   },
@@ -6562,36 +2047,12 @@
     "sets": [
       {
         "species": "Aggron",
-        "item": [
-          "Custap Berry"
-        ],
-        "ability": [
-          "Sturdy"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "spd": 4
-        },
+        "item": ["Custap Berry"],
+        "ability": ["Sturdy"],
+        "evs": {"hp": 252, "atk": 252, "spd": 4},
         "nature": "Brave",
-        "ivs": {
-          "spe": 0
-        },
-        "moves": [
-          [
-            "Metal Burst"
-          ],
-          [
-            "Endeavor"
-          ],
-          [
-            "Head Smash",
-            "Rock Tomb"
-          ],
-          [
-            "Stealth Rock"
-          ]
-        ]
+        "ivs": {"spe": 0},
+        "moves": [["Metal Burst"], ["Endeavor"], ["Head Smash", "Rock Tomb"], ["Stealth Rock"]]
       }
     ]
   },
@@ -6600,67 +2061,21 @@
     "sets": [
       {
         "species": "Xurkitree",
-        "item": [
-          "Choice Scarf"
-        ],
-        "ability": [
-          "Beast Boost"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Choice Scarf"],
+        "ability": ["Beast Boost"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Volt Switch"
-          ],
-          [
-            "Thunderbolt"
-          ],
-          [
-            "Energy Ball"
-          ],
-          [
-            "Dazzling Gleam"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Volt Switch"], ["Thunderbolt"], ["Energy Ball"], ["Dazzling Gleam"]]
       },
       {
         "species": "Xurkitree",
-        "item": [
-          "Blunder Policy"
-        ],
-        "ability": [
-          "Beast Boost"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Blunder Policy"],
+        "ability": ["Beast Boost"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Zap Cannon"
-          ],
-          [
-            "Hypnosis"
-          ],
-          [
-            "Energy Ball"
-          ],
-          [
-            "Dazzling Gleam"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Zap Cannon"], ["Hypnosis"], ["Energy Ball"], ["Dazzling Gleam"]]
       }
     ]
   },
@@ -6669,104 +2084,29 @@
     "sets": [
       {
         "species": "Seismitoad",
-        "item": [
-          "Life Orb",
-          "Mystic Water",
-          "Assault Vest",
-          "Rindo Berry"
-        ],
-        "ability": [
-          "Swift Swim"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Life Orb", "Mystic Water", "Assault Vest", "Rindo Berry"],
+        "ability": ["Swift Swim"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Hydro Pump"
-          ],
-          [
-            "Earth Power"
-          ],
-          [
-            "Grass Knot"
-          ],
-          [
-            "Sludge Wave"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Hydro Pump"], ["Earth Power"], ["Grass Knot"], ["Sludge Wave"]]
       },
       {
         "species": "Seismitoad",
-        "item": [
-          "Life Orb",
-          "Mystic Water",
-          "Assault Vest",
-          "Rindo Berry"
-        ],
-        "ability": [
-          "Swift Swim"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Life Orb", "Mystic Water", "Assault Vest", "Rindo Berry"],
+        "ability": ["Swift Swim"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Liquidation"
-          ],
-          [
-            "Earthquake"
-          ],
-          [
-            "Power Whip"
-          ],
-          [
-            "Drain Punch"
-          ]
-        ]
+        "moves": [["Liquidation"], ["Earthquake"], ["Power Whip"], ["Drain Punch"]]
       },
       {
         "species": "Seismitoad",
-        "item": [
-          "Leftovers",
-          "Sitrus Berry"
-        ],
-        "ability": [
-          "Water Absorb"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 4,
-          "spd": 252
-        },
+        "item": ["Leftovers", "Sitrus Berry"],
+        "ability": ["Water Absorb"],
+        "evs": {"hp": 252, "def": 4, "spd": 252},
         "nature": "Calm",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Scald"
-          ],
-          [
-            "Earth Power",
-            "Icy Wind"
-          ],
-          [
-            "Stealth Rock"
-          ],
-          [
-            "Toxic"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Scald"], ["Earth Power", "Icy Wind"], ["Stealth Rock"], ["Toxic"]]
       }
     ]
   },
@@ -6775,38 +2115,12 @@
     "sets": [
       {
         "species": "Pyukumuku",
-        "item": [
-          "Sitrus Berry",
-          "Rocky Helmet",
-          "Leftovers"
-        ],
-        "ability": [
-          "Unaware"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Sitrus Berry", "Rocky Helmet", "Leftovers"],
+        "ability": ["Unaware"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Toxic"
-          ],
-          [
-            "Counter"
-          ],
-          [
-            "Mirror Coat",
-            "Soak"
-          ],
-          [
-            "Recover"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Toxic"], ["Counter"], ["Mirror Coat", "Soak"], ["Recover"]]
       }
     ]
   },
@@ -6815,35 +2129,12 @@
     "sets": [
       {
         "species": "Espeon",
-        "item": [
-          "Light Clay"
-        ],
-        "ability": [
-          "Magic Bounce"
-        ],
-        "evs": {
-          "def": 4,
-          "spa": 252,
-          "spe": 252
-        },
-        "ivs": {
-          "atk": 0
-        },
+        "item": ["Light Clay"],
+        "ability": ["Magic Bounce"],
+        "evs": {"def": 4, "spa": 252, "spe": 252},
+        "ivs": {"atk": 0},
         "nature": "Timid",
-        "moves": [
-          [
-            "Psychic"
-          ],
-          [
-            "Reflect"
-          ],
-          [
-            "Light Screen"
-          ],
-          [
-            "Yawn"
-          ]
-        ]
+        "moves": [["Psychic"], ["Reflect"], ["Light Screen"], ["Yawn"]]
       }
     ]
   },
@@ -6852,68 +2143,20 @@
     "sets": [
       {
         "species": "Nidoking",
-        "item": [
-          "Focus Sash",
-          "Life Orb"
-        ],
-        "ability": [
-          "Sheer Force"
-        ],
-        "evs": {
-          "def": 4,
-          "spa": 252,
-          "spe": 252
-        },
+        "item": ["Focus Sash", "Life Orb"],
+        "ability": ["Sheer Force"],
+        "evs": {"def": 4, "spa": 252, "spe": 252},
         "nature": "Timid",
-        "moves": [
-          [
-            "Sludge Wave"
-          ],
-          [
-            "Earth Power"
-          ],
-          [
-            "Ice Beam"
-          ],
-          [
-            "Flamethrower",
-            "Thunderbolt",
-            "Sucker Punch"
-          ]
-        ]
+        "moves": [["Sludge Wave"], ["Earth Power"], ["Ice Beam"], ["Flamethrower", "Thunderbolt", "Sucker Punch"]]
       },
       {
         "species": "Nidoking",
-        "item": [
-          "Choice Scarf"
-        ],
-        "ability": [
-          "Sheer Force"
-        ],
-        "evs": {
-          "def": 4,
-          "spa": 252,
-          "spe": 252
-        },
+        "item": ["Choice Scarf"],
+        "ability": ["Sheer Force"],
+        "evs": {"def": 4, "spa": 252, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Sludge Wave"
-          ],
-          [
-            "Earth Power"
-          ],
-          [
-            "Ice Beam"
-          ],
-          [
-            "Flamethrower",
-            "Thunderbolt"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Sludge Wave"], ["Earth Power"], ["Ice Beam"], ["Flamethrower", "Thunderbolt"]]
       }
     ]
   },
@@ -6922,61 +2165,19 @@
     "sets": [
       {
         "species": "Skarmory",
-        "item": [
-          "Rocky Helmet"
-        ],
-        "ability": [
-          "Sturdy"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Rocky Helmet"],
+        "ability": ["Sturdy"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Impish",
-        "moves": [
-          [
-            "Brave Bird"
-          ],
-          [
-            "Body Press"
-          ],
-          [
-            "Iron Defense"
-          ],
-          [
-            "Roost"
-          ]
-        ]
+        "moves": [["Brave Bird"], ["Body Press"], ["Iron Defense"], ["Roost"]]
       },
       {
         "species": "Skarmory",
-        "item": [
-          "Custap Berry"
-        ],
-        "ability": [
-          "Sturdy"
-        ],
-        "evs": {
-          "atk": 252,
-          "def": 4,
-          "spe": 252
-        },
+        "item": ["Custap Berry"],
+        "ability": ["Sturdy"],
+        "evs": {"atk": 252, "def": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Brave Bird"
-          ],
-          [
-            "Rock Tomb"
-          ],
-          [
-            "Stealth Rock"
-          ],
-          [
-            "Taunt"
-          ]
-        ]
+        "moves": [["Brave Bird"], ["Rock Tomb"], ["Stealth Rock"], ["Taunt"]]
       }
     ]
   },
@@ -6985,69 +2186,21 @@
     "sets": [
       {
         "species": "Chandelure",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Infiltrator"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spd": 4
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Infiltrator"],
+        "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Quiet",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Flamethrower",
-            "Overheat"
-          ],
-          [
-            "Shadow Ball"
-          ],
-          [
-            "Trick Room"
-          ],
-          [
-            "Memento"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Flamethrower", "Overheat"], ["Shadow Ball"], ["Trick Room"], ["Memento"]]
       },
       {
         "species": "Chandelure",
-        "item": [
-          "Choice Scarf"
-        ],
-        "ability": [
-          "Infiltrator"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spd": 4
-        },
+        "item": ["Choice Scarf"],
+        "ability": ["Infiltrator"],
+        "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Flamethrower",
-            "Overheat"
-          ],
-          [
-            "Shadow Ball"
-          ],
-          [
-            "Energy Ball"
-          ],
-          [
-            "Trick"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Flamethrower", "Overheat"], ["Shadow Ball"], ["Energy Ball"], ["Trick"]]
       }
     ]
   },
@@ -7056,36 +2209,12 @@
     "sets": [
       {
         "species": "Umbreon",
-        "item": [
-          "Leftovers",
-          "Rocky Helmet"
-        ],
-        "ability": [
-          "Synchronize"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Leftovers", "Rocky Helmet"],
+        "ability": ["Synchronize"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Foul Play"
-          ],
-          [
-            "Yawn"
-          ],
-          [
-            "Wish"
-          ],
-          [
-            "Protect"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Foul Play"], ["Yawn"], ["Wish"], ["Protect"]]
       }
     ]
   },
@@ -7094,66 +2223,19 @@
     "sets": [
       {
         "species": "Regirock",
-        "item": [
-          "Weakness Policy",
-          "Assault Vest"
-        ],
-        "ability": [
-          "Clear Body"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "def": 4
-        },
+        "item": ["Weakness Policy", "Assault Vest"],
+        "ability": ["Clear Body"],
+        "evs": {"hp": 252, "atk": 252, "def": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Stone Edge"
-          ],
-          [
-            "Earthquake"
-          ],
-          [
-            "Ice Punch"
-          ],
-          [
-            "Body Press",
-            "Drain Punch",
-            "Explosion"
-          ]
-        ]
+        "moves": [["Stone Edge"], ["Earthquake"], ["Ice Punch"], ["Body Press", "Drain Punch", "Explosion"]]
       },
       {
         "species": "Regirock",
-        "item": [
-          "Custap Berry"
-        ],
-        "ability": [
-          "Sturdy"
-        ],
-        "evs": {
-          "atk": 252,
-          "def": 4,
-          "spe": 252
-        },
+        "item": ["Custap Berry"],
+        "ability": ["Sturdy"],
+        "evs": {"atk": 252, "def": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Stone Edge"
-          ],
-          [
-            "Earthquake",
-            "Body Press",
-            "Explosion"
-          ],
-          [
-            "Stealth Rock"
-          ],
-          [
-            "Thunder Wave"
-          ]
-        ]
+        "moves": [["Stone Edge"], ["Earthquake", "Body Press", "Explosion"], ["Stealth Rock"], ["Thunder Wave"]]
       }
     ]
   },
@@ -7162,34 +2244,11 @@
     "sets": [
       {
         "species": "Torkoal",
-        "item": [
-          "Eject Pack"
-        ],
-        "ability": [
-          "Drought"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spa": 4
-        },
+        "item": ["Eject Pack"],
+        "ability": ["Drought"],
+        "evs": {"hp": 252, "def": 252, "spa": 4},
         "nature": "Relaxed",
-        "moves": [
-          [
-            "Overheat"
-          ],
-          [
-            "Yawn"
-          ],
-          [
-            "Stealth Rock"
-          ],
-          [
-            "Body Press",
-            "Solar Beam",
-            "Earth Power"
-          ]
-        ]
+        "moves": [["Overheat"], ["Yawn"], ["Stealth Rock"], ["Body Press", "Solar Beam", "Earth Power"]]
       }
     ]
   },
@@ -7198,37 +2257,12 @@
     "sets": [
       {
         "species": "Tornadus-Therian",
-        "item": [
-          "Life Orb",
-          "Sharp Beak",
-          "Expert Belt"
-        ],
-        "ability": [
-          "Regenerator"
-        ],
-        "evs": {
-          "def": 4,
-          "spa": 252,
-          "spe": 252
-        },
+        "item": ["Life Orb", "Sharp Beak", "Expert Belt"],
+        "ability": ["Regenerator"],
+        "evs": {"def": 4, "spa": 252, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "spe": 0
-        },
-        "moves": [
-          [
-            "Hurricane"
-          ],
-          [
-            "Heat Wave"
-          ],
-          [
-            "Icy Wind"
-          ],
-          [
-            "Nasty Plot"
-          ]
-        ]
+        "ivs": {"spe": 0},
+        "moves": [["Hurricane"], ["Heat Wave"], ["Icy Wind"], ["Nasty Plot"]]
       }
     ]
   },
@@ -7237,70 +2271,21 @@
     "sets": [
       {
         "species": "Stakataka",
-        "item": [
-          "Assault Vest"
-        ],
-        "ability": [
-          "Beast Boost"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "spd": 4
-        },
+        "item": ["Assault Vest"],
+        "ability": ["Beast Boost"],
+        "evs": {"hp": 252, "atk": 252, "spd": 4},
         "nature": "Brave",
-        "ivs": {
-          "spe": 0
-        },
-        "moves": [
-          [
-            "Rock Blast"
-          ],
-          [
-            "Body Press"
-          ],
-          [
-            "Gyro Ball"
-          ],
-          [
-            "Earthquake"
-          ]
-        ]
+        "ivs": {"spe": 0},
+        "moves": [["Rock Blast"], ["Body Press"], ["Gyro Ball"], ["Earthquake"]]
       },
       {
         "species": "Stakataka",
-        "item": [
-          "Focus Sash",
-          "Air Balloon",
-          "Chople Berry"
-        ],
-        "ability": [
-          "Beast Boost"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "spd": 4
-        },
+        "item": ["Focus Sash", "Air Balloon", "Chople Berry"],
+        "ability": ["Beast Boost"],
+        "evs": {"hp": 252, "atk": 252, "spd": 4},
         "nature": "Brave",
-        "ivs": {
-          "spe": 0
-        },
-        "moves": [
-          [
-            "Rock Blast"
-          ],
-          [
-            "Gyro Ball"
-          ],
-          [
-            "Body Press",
-            "Earthquake"
-          ],
-          [
-            "Trick Room"
-          ]
-        ]
+        "ivs": {"spe": 0},
+        "moves": [["Rock Blast"], ["Gyro Ball"], ["Body Press", "Earthquake"], ["Trick Room"]]
       }
     ]
   },
@@ -7309,65 +2294,19 @@
     "sets": [
       {
         "species": "Diggersby",
-        "item": [
-          "Focus Sash",
-          "Custap Berry"
-        ],
-        "ability": [
-          "Huge Power"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Focus Sash", "Custap Berry"],
+        "ability": ["Huge Power"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Earthquake"
-          ],
-          [
-            "Quick Attack"
-          ],
-          [
-            "Flail"
-          ],
-          [
-            "Endure"
-          ]
-        ]
+        "moves": [["Earthquake"], ["Quick Attack"], ["Flail"], ["Endure"]]
       },
       {
         "species": "Diggersby",
-        "item": [
-          "Life Orb",
-          "Lum Berry"
-        ],
-        "ability": [
-          "Huge Power"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Life Orb", "Lum Berry"],
+        "ability": ["Huge Power"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Earthquake"
-          ],
-          [
-            "Giga Impact",
-            "Swords Dance"
-          ],
-          [
-            "Bounce"
-          ],
-          [
-            "Fire Punch",
-            "Ice Punch"
-          ]
-        ]
+        "moves": [["Earthquake"], ["Giga Impact", "Swords Dance"], ["Bounce"], ["Fire Punch", "Ice Punch"]]
       }
     ]
   },
@@ -7376,37 +2315,12 @@
     "sets": [
       {
         "species": "Articuno-Galar",
-        "item": [
-          "Kee Berry",
-          "Weakness Policy"
-        ],
-        "ability": [
-          "Competitive"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 4,
-          "spe": 252
-        },
+        "item": ["Kee Berry", "Weakness Policy"],
+        "ability": ["Competitive"],
+        "evs": {"hp": 252, "def": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Freezing Glare",
-            "Stored Power"
-          ],
-          [
-            "Hurricane"
-          ],
-          [
-            "Calm Mind"
-          ],
-          [
-            "Recover"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Freezing Glare", "Stored Power"], ["Hurricane"], ["Calm Mind"], ["Recover"]]
       }
     ]
   },
@@ -7415,33 +2329,11 @@
     "sets": [
       {
         "species": "Incineroar",
-        "item": [
-          "Figy Berry"
-        ],
-        "ability": [
-          "Intimidate"
-        ],
-        "evs": {
-          "hp": 252,
-          "atk": 252,
-          "spd": 4
-        },
+        "item": ["Figy Berry"],
+        "ability": ["Intimidate"],
+        "evs": {"hp": 252, "atk": 252, "spd": 4},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Flare Blitz"
-          ],
-          [
-            "Darkest Lariat"
-          ],
-          [
-            "Will-O-Wisp"
-          ],
-          [
-            "Parting Shot",
-            "U-turn"
-          ]
-        ]
+        "moves": [["Flare Blitz"], ["Darkest Lariat"], ["Will-O-Wisp"], ["Parting Shot", "U-turn"]]
       }
     ]
   },
@@ -7450,32 +2342,11 @@
     "sets": [
       {
         "species": "Lycanroc-Dusk",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Tough Claws"
-        ],
-        "evs": {
-          "hp": 4,
-          "atk": 252,
-          "spe": 252
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Tough Claws"],
+        "evs": {"hp": 4, "atk": 252, "spe": 252},
         "nature": "Adamant",
-        "moves": [
-          [
-            "Close Combat"
-          ],
-          [
-            "Stealth Rock"
-          ],
-          [
-            "Counter"
-          ],
-          [
-            "Accelerock"
-          ]
-        ]
+        "moves": [["Close Combat"], ["Stealth Rock"], ["Counter"], ["Accelerock"]]
       }
     ]
   },
@@ -7484,68 +2355,20 @@
     "sets": [
       {
         "species": "Hydreigon",
-        "item": [
-          "Choice Scarf",
-          "Choice Specs"
-        ],
-        "ability": [
-          "Levitate"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Choice Scarf", "Choice Specs"],
+        "ability": ["Levitate"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "moves": [
-          [
-            "Dark Pulse"
-          ],
-          [
-            "Draco Meteor"
-          ],
-          [
-            "Fire Blast",
-            "Flash Cannon"
-          ],
-          [
-            "U-turn"
-          ]
-        ]
+        "moves": [["Dark Pulse"], ["Draco Meteor"], ["Fire Blast", "Flash Cannon"], ["U-turn"]]
       },
       {
         "species": "Hydreigon",
-        "item": [
-          "Salac Berry",
-          "Leftovers"
-        ],
-        "ability": [
-          "Levitate"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Salac Berry", "Leftovers"],
+        "ability": ["Levitate"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Dark Pulse"
-          ],
-          [
-            "Fire Blast",
-            "Flash Cannon"
-          ],
-          [
-            "Nasty Plot"
-          ],
-          [
-            "Substitute"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Dark Pulse"], ["Fire Blast", "Flash Cannon"], ["Nasty Plot"], ["Substitute"]]
       }
     ]
   },
@@ -7554,105 +2377,30 @@
     "sets": [
       {
         "species": "Volcarona",
-        "item": [
-          "Life Orb",
-          "Heavy-Duty Boots",
-          "Lum Berry"
-        ],
-        "ability": [
-          "Flame Body"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Life Orb", "Heavy-Duty Boots", "Lum Berry"],
+        "ability": ["Flame Body"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Fiery Dance"
-          ],
-          [
-            "Quiver Dance"
-          ],
-          [
-            "Giga Drain"
-          ],
-          [
-            "Bug Buzz",
-            "Hurricane",
-            "Psychic"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Fiery Dance"], ["Quiver Dance"], ["Giga Drain"], ["Bug Buzz", "Hurricane", "Psychic"]]
       },
       {
         "species": "Volcarona",
-        "item": [
-          "Weakness Policy"
-        ],
-        "ability": [
-          "Flame Body"
-        ],
-        "evs": {
-          "hp": 4,
-          "def": 28,
-          "spa": 220,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Weakness Policy"],
+        "ability": ["Flame Body"],
+        "evs": {"hp": 4, "def": 28, "spa": 220, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Fire Blast"
-          ],
-          [
-            "Giga Drain"
-          ],
-          [
-            "Hurricane"
-          ],
-          [
-            "Hyper Beam"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Fire Blast"], ["Giga Drain"], ["Hurricane"], ["Hyper Beam"]]
       },
       {
         "species": "Volcarona",
-        "item": [
-          "Throat Spray"
-        ],
-        "ability": [
-          "Swarm"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Throat Spray"],
+        "ability": ["Swarm"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Bug Buzz"
-          ],
-          [
-            "Quiver Dance"
-          ],
-          [
-            "Fiery Dance"
-          ],
-          [
-            "Substitute"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Bug Buzz"], ["Quiver Dance"], ["Fiery Dance"], ["Substitute"]]
       }
     ]
   },
@@ -7661,91 +2409,27 @@
     "sets": [
       {
         "species": "Scolipede",
-        "item": [
-          "Maranga Berry"
-        ],
-        "ability": [
-          "Speed Boost"
-        ],
-        "evs": {
-          "hp": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Maranga Berry"],
+        "ability": ["Speed Boost"],
+        "evs": {"hp": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Protect"
-          ],
-          [
-            "Earthquake",
-            "Poison Jab"
-          ],
-          [
-            "Iron Defense"
-          ],
-          [
-            "Baton Pass"
-          ]
-        ]
+        "moves": [["Protect"], ["Earthquake", "Poison Jab"], ["Iron Defense"], ["Baton Pass"]]
       },
       {
         "species": "Scolipede",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Speed Boost"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Speed Boost"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Poison Jab"
-          ],
-          [
-            "Earthquake"
-          ],
-          [
-            "Swords Dance"
-          ],
-          [
-            "Baton Pass"
-          ]
-        ]
+        "moves": [["Poison Jab"], ["Earthquake"], ["Swords Dance"], ["Baton Pass"]]
       },
       {
         "species": "Scolipede",
-        "item": [
-          "Iapapa Berry"
-        ],
-        "ability": [
-          "Speed Boost"
-        ],
-        "evs": {
-          "hp": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Iapapa Berry"],
+        "ability": ["Speed Boost"],
+        "evs": {"hp": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Toxic"
-          ],
-          [
-            "Substitute"
-          ],
-          [
-            "Iron Defense"
-          ],
-          [
-            "Baton Pass"
-          ]
-        ]
+        "moves": [["Toxic"], ["Substitute"], ["Iron Defense"], ["Baton Pass"]]
       }
     ]
   },
@@ -7754,37 +2438,12 @@
     "sets": [
       {
         "species": "Aurorus",
-        "item": [
-          "Focus Sash",
-          "Custap Berry"
-        ],
-        "ability": [
-          "Snow Warning"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 4,
-          "spa": 252
-        },
-        "ivs": {
-          "atk": 0
-        },
+        "item": ["Focus Sash", "Custap Berry"],
+        "ability": ["Snow Warning"],
+        "evs": {"hp": 252, "def": 4, "spa": 252},
+        "ivs": {"atk": 0},
         "nature": "Modest",
-        "moves": [
-          [
-            "Freeze-Dry",
-            "Blizzard"
-          ],
-          [
-            "Aurora Veil"
-          ],
-          [
-            "Stealth Rock"
-          ],
-          [
-            "Thunder Wave"
-          ]
-        ]
+        "moves": [["Freeze-Dry", "Blizzard"], ["Aurora Veil"], ["Stealth Rock"], ["Thunder Wave"]]
       }
     ]
   },
@@ -7793,62 +2452,19 @@
     "sets": [
       {
         "species": "Haxorus",
-        "item": [
-          "Choice Scarf"
-        ],
-        "ability": [
-          "Mold Breaker"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Choice Scarf"],
+        "ability": ["Mold Breaker"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Outrage"
-          ],
-          [
-            "Earthquake"
-          ],
-          [
-            "Iron Tail"
-          ],
-          [
-            "Close Combat"
-          ]
-        ]
+        "moves": [["Outrage"], ["Earthquake"], ["Iron Tail"], ["Close Combat"]]
       },
       {
         "species": "Haxorus",
-        "item": [
-          "Life Orb",
-          "Lum Berry"
-        ],
-        "ability": [
-          "Mold Breaker"
-        ],
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Life Orb", "Lum Berry"],
+        "ability": ["Mold Breaker"],
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
-        "moves": [
-          [
-            "Outrage"
-          ],
-          [
-            "Earthquake"
-          ],
-          [
-            "Iron Tail"
-          ],
-          [
-            "Dragon Dance"
-          ]
-        ]
+        "moves": [["Outrage"], ["Earthquake"], ["Iron Tail"], ["Dragon Dance"]]
       }
     ]
   },
@@ -7857,36 +2473,12 @@
     "sets": [
       {
         "species": "Cradily",
-        "item": [
-          "Power Herb"
-        ],
-        "ability": [
-          "Storm Drain"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spd": 4
-        },
+        "item": ["Power Herb"],
+        "ability": ["Storm Drain"],
+        "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Meteor Beam"
-          ],
-          [
-            "Giga Drain"
-          ],
-          [
-            "Earth Power"
-          ],
-          [
-            "Recover",
-            "Leech Seed"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Meteor Beam"], ["Giga Drain"], ["Earth Power"], ["Recover", "Leech Seed"]]
       }
     ]
   },
@@ -7895,67 +2487,21 @@
     "sets": [
       {
         "species": "Kingdra",
-        "item": [
-          "Life Orb"
-        ],
-        "ability": [
-          "Swift Swim"
-        ],
-        "evs": {
-          "hp": 4,
-          "spa": 252,
-          "spe": 252
-        },
-        "ivs": {
-          "atk": 0
-        },
+        "item": ["Life Orb"],
+        "ability": ["Swift Swim"],
+        "evs": {"hp": 4, "spa": 252, "spe": 252},
+        "ivs": {"atk": 0},
         "nature": "Timid",
-        "moves": [
-          [
-            "Hurricane"
-          ],
-          [
-            "Hydro Pump"
-          ],
-          [
-            "Draco Meteor"
-          ],
-          [
-            "Yawn"
-          ]
-        ]
+        "moves": [["Hurricane"], ["Hydro Pump"], ["Draco Meteor"], ["Yawn"]]
       },
       {
         "species": "Kingdra",
-        "item": [
-          "Scope Lens"
-        ],
-        "ability": [
-          "Sniper"
-        ],
-        "evs": {
-          "hp": 4,
-          "spa": 252,
-          "spe": 252
-        },
-        "ivs": {
-          "atk": 0
-        },
+        "item": ["Scope Lens"],
+        "ability": ["Sniper"],
+        "evs": {"hp": 4, "spa": 252, "spe": 252},
+        "ivs": {"atk": 0},
         "nature": "Timid",
-        "moves": [
-          [
-            "Hurricane"
-          ],
-          [
-            "Hydro Pump"
-          ],
-          [
-            "Draco Meteor"
-          ],
-          [
-            "Focus Energy"
-          ]
-        ]
+        "moves": [["Hurricane"], ["Hydro Pump"], ["Draco Meteor"], ["Focus Energy"]]
       }
     ]
   },
@@ -7964,65 +2510,20 @@
     "sets": [
       {
         "species": "Regidrago",
-        "item": [
-          "Choice Scarf"
-        ],
-        "ability": [
-          "Dragon's Maw"
-        ],
+        "item": ["Choice Scarf"],
+        "ability": ["Dragon's Maw"],
         "nature": "Timid",
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Dragon Energy"
-          ],
-          [
-            "Draco Meteor"
-          ],
-          [
-            "Ancient Power"
-          ],
-          [
-            "Hyper Beam"
-          ]
-        ]
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
+        "ivs": {"atk": 0},
+        "moves": [["Dragon Energy"], ["Draco Meteor"], ["Ancient Power"], ["Hyper Beam"]]
       },
       {
         "species": "Regidrago",
-        "item": [
-          "Lum Berry"
-        ],
-        "ability": [
-          "Dragon's Maw"
-        ],
+        "item": ["Lum Berry"],
+        "ability": ["Dragon's Maw"],
         "nature": "Jolly",
-        "evs": {
-          "atk": 252,
-          "spd": 4,
-          "spe": 252
-        },
-        "moves": [
-          [
-            "Outrage"
-          ],
-          [
-            "Fire Fang",
-            "Thunder Fang"
-          ],
-          [
-            "Dragon Dance"
-          ],
-          [
-            "Explosion"
-          ]
-        ]
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
+        "moves": [["Outrage"], ["Fire Fang", "Thunder Fang"], ["Dragon Dance"], ["Explosion"]]
       }
     ]
   },
@@ -8031,71 +2532,21 @@
     "sets": [
       {
         "species": "Porygon-Z",
-        "item": [
-          "Choice Scarf"
-        ],
-        "ability": [
-          "Adaptability"
-        ],
-        "evs": {
-          "def": 4,
-          "spa": 252,
-          "spe": 252
-        },
+        "item": ["Choice Scarf"],
+        "ability": ["Adaptability"],
+        "evs": {"def": 4, "spa": 252, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Hyper Beam"
-          ],
-          [
-            "Tri Attack"
-          ],
-          [
-            "Dark Pulse",
-            "Ice Beam"
-          ],
-          [
-            "Trick"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Hyper Beam"], ["Tri Attack"], ["Dark Pulse", "Ice Beam"], ["Trick"]]
       },
       {
         "species": "Porygon-Z",
-        "item": [
-          "Chople Berry",
-          "Life Orb"
-        ],
-        "ability": [
-          "Adaptability"
-        ],
-        "evs": {
-          "def": 4,
-          "spa": 252,
-          "spe": 252
-        },
+        "item": ["Chople Berry", "Life Orb"],
+        "ability": ["Adaptability"],
+        "evs": {"def": 4, "spa": 252, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Hyper Beam"
-          ],
-          [
-            "Dark Pulse"
-          ],
-          [
-            "Thunderbolt",
-            "Ice Beam",
-            "Solar Beam"
-          ],
-          [
-            "Nasty Plot"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Hyper Beam"], ["Dark Pulse"], ["Thunderbolt", "Ice Beam", "Solar Beam"], ["Nasty Plot"]]
       }
     ]
   },
@@ -8104,62 +2555,19 @@
     "sets": [
       {
         "species": "Pelipper",
-        "item": [
-          "Damp Rock"
-        ],
-        "ability": [
-          "Drizzle"
-        ],
+        "item": ["Damp Rock"],
+        "ability": ["Drizzle"],
         "nature": "Relaxed",
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
-        "moves": [
-          [
-            "Hurricane"
-          ],
-          [
-            "Scald"
-          ],
-          [
-            "Roost"
-          ],
-          [
-            "U-turn"
-          ]
-        ]
+        "evs": {"hp": 252, "def": 252, "spd": 4},
+        "moves": [["Hurricane"], ["Scald"], ["Roost"], ["U-turn"]]
       },
       {
         "species": "Pelipper",
-        "item": [
-          "Focus Sash",
-          "Choice Specs"
-        ],
-        "ability": [
-          "Drizzle"
-        ],
+        "item": ["Focus Sash", "Choice Specs"],
+        "ability": ["Drizzle"],
         "nature": "Modest",
-        "evs": {
-          "hp": 4,
-          "spa": 252,
-          "spe": 252
-        },
-        "moves": [
-          [
-            "Hurricane"
-          ],
-          [
-            "Hydro Pump"
-          ],
-          [
-            "Ice Beam"
-          ],
-          [
-            "U-turn"
-          ]
-        ]
+        "evs": {"hp": 4, "spa": 252, "spe": 252},
+        "moves": [["Hurricane"], ["Hydro Pump"], ["Ice Beam"], ["U-turn"]]
       }
     ]
   },
@@ -8168,38 +2576,12 @@
     "sets": [
       {
         "species": "Comfey",
-        "item": [
-          "Kee Berry",
-          "Big Root"
-        ],
-        "ability": [
-          "Triage"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Kee Berry", "Big Root"],
+        "ability": ["Triage"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Bold",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Draining Kiss"
-          ],
-          [
-            "Leech Seed"
-          ],
-          [
-            "Synthesis"
-          ],
-          [
-            "Giga Drain",
-            "Charm",
-            "Protect"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Draining Kiss"], ["Leech Seed"], ["Synthesis"], ["Giga Drain", "Charm", "Protect"]]
       }
     ]
   },
@@ -8208,67 +2590,21 @@
     "sets": [
       {
         "species": "Toxtricity",
-        "item": [
-          "Assault Vest"
-        ],
-        "ability": [
-          "Punk Rock"
-        ],
-        "evs": {
-          "hp": 108,
-          "spa": 252,
-          "spe": 148
-        },
+        "item": ["Assault Vest"],
+        "ability": ["Punk Rock"],
+        "evs": {"hp": 108, "spa": 252, "spe": 148},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Overdrive"
-          ],
-          [
-            "Nuzzle"
-          ],
-          [
-            "Boomburst"
-          ],
-          [
-            "Hex"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Overdrive"], ["Nuzzle"], ["Boomburst"], ["Hex"]]
       },
       {
         "species": "Toxtricity-Gmax",
-        "item": [
-          "Throat Spray"
-        ],
-        "ability": [
-          "Punk Rock"
-        ],
-        "evs": {
-          "spa": 252,
-          "spd": 4,
-          "spe": 252
-        },
+        "item": ["Throat Spray"],
+        "ability": ["Punk Rock"],
+        "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Overdrive"
-          ],
-          [
-            "Sludge Wave"
-          ],
-          [
-            "Boomburst"
-          ],
-          [
-            "Shift Gear"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Overdrive"], ["Sludge Wave"], ["Boomburst"], ["Shift Gear"]]
       }
     ]
   },
@@ -8277,100 +2613,30 @@
     "sets": [
       {
         "species": "Duraludon",
-        "item": [
-          "Assault Vest"
-        ],
-        "ability": [
-          "Light Metal"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spd": 4
-        },
+        "item": ["Assault Vest"],
+        "ability": ["Light Metal"],
+        "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Draco Meteor"
-          ],
-          [
-            "Flash Cannon"
-          ],
-          [
-            "Thunderbolt"
-          ],
-          [
-            "Rock Tomb"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Draco Meteor"], ["Flash Cannon"], ["Thunderbolt"], ["Rock Tomb"]]
       },
       {
         "species": "Duraludon",
-        "item": [
-          "Weakness Policy"
-        ],
-        "ability": [
-          "Light Metal"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spd": 4
-        },
+        "item": ["Weakness Policy"],
+        "ability": ["Light Metal"],
+        "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Draco Meteor"
-          ],
-          [
-            "Flash Cannon"
-          ],
-          [
-            "Thunderbolt"
-          ],
-          [
-            "Solar Beam"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Draco Meteor"], ["Flash Cannon"], ["Thunderbolt"], ["Solar Beam"]]
       },
       {
         "species": "Duraludon",
-        "item": [
-          "Focus Sash"
-        ],
-        "ability": [
-          "Light Metal"
-        ],
-        "evs": {
-          "hp": 4,
-          "spa": 252,
-          "spe": 252
-        },
+        "item": ["Focus Sash"],
+        "ability": ["Light Metal"],
+        "evs": {"hp": 4, "spa": 252, "spe": 252},
         "nature": "Timid",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Steel Beam"
-          ],
-          [
-            "Mirror Coat",
-            "Thunder Wave"
-          ],
-          [
-            "Reflect"
-          ],
-          [
-            "Stealth Rock"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Steel Beam"], ["Mirror Coat", "Thunder Wave"], ["Reflect"], ["Stealth Rock"]]
       }
     ]
   },
@@ -8379,34 +2645,11 @@
     "sets": [
       {
         "species": "Avalugg",
-        "item": [
-          "Rocky Helmet",
-          "Custap Berry"
-        ],
-        "ability": [
-          "Sturdy"
-        ],
-        "evs": {
-          "hp": 252,
-          "def": 252,
-          "spd": 4
-        },
+        "item": ["Rocky Helmet", "Custap Berry"],
+        "ability": ["Sturdy"],
+        "evs": {"hp": 252, "def": 252, "spd": 4},
         "nature": "Relaxed",
-        "moves": [
-          [
-            "Icicle Spear"
-          ],
-          [
-            "Body Press"
-          ],
-          [
-            "Recover"
-          ],
-          [
-            "Iron Defense",
-            "Mirror Coat"
-          ]
-        ]
+        "moves": [["Icicle Spear"], ["Body Press"], ["Recover"], ["Iron Defense", "Mirror Coat"]]
       }
     ]
   },
@@ -8415,36 +2658,12 @@
     "sets": [
       {
         "species": "Slowbro-Galar",
-        "item": [
-          "Quick Claw"
-        ],
-        "ability": [
-          "Quick Draw"
-        ],
-        "evs": {
-          "hp": 252,
-          "spa": 252,
-          "spd": 4
-        },
+        "item": ["Quick Claw"],
+        "ability": ["Quick Draw"],
+        "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Modest",
-        "ivs": {
-          "atk": 0
-        },
-        "moves": [
-          [
-            "Shell Side Arm"
-          ],
-          [
-            "Psyshock",
-            "Expanding Force"
-          ],
-          [
-            "Flamethrower"
-          ],
-          [
-            "Nasty Plot"
-          ]
-        ]
+        "ivs": {"atk": 0},
+        "moves": [["Shell Side Arm"], ["Psyshock", "Expanding Force"], ["Flamethrower"], ["Nasty Plot"]]
       }
     ]
   }

--- a/data/bss-factory-sets.json
+++ b/data/bss-factory-sets.json
@@ -3,7 +3,8 @@
     "usage": 10,
     "sets": [
       {
-        "species": "Cinderace-Gmax",
+        "species": "Cinderace",
+        "gigantamax": true,
         "item": ["Focus Sash"],
         "ability": ["Libero"],
         "evs": {"atk": 252, "spd": 4, "spe": 252},
@@ -11,7 +12,8 @@
         "moves": [["Pyro Ball"], ["High Jump Kick", "Counter"], ["Bounce", "Sucker Punch"], ["Iron Head", "Gunk Shot", "Zen Headbutt"]]
       },
       {
-        "species": "Cinderace-Gmax",
+        "species": "Cinderace",
+        "gigantamax": true,
         "item": ["Choice Scarf"],
         "ability": ["Libero"],
         "evs": {"atk": 252, "spd": 4, "spe": 252},
@@ -19,7 +21,8 @@
         "moves": [["Pyro Ball"], ["High Jump Kick"], ["Bounce"], ["Iron Head"]]
       },
       {
-        "species": "Cinderace-Gmax",
+        "species": "Cinderace",
+        "gigantamax": true,
         "item": ["Scope Lens"],
         "ability": ["Libero"],
         "evs": {"atk": 252, "spd": 4, "spe": 252},
@@ -167,7 +170,8 @@
     "usage": 8,
     "sets": [
       {
-        "species": "Rillaboom-Gmax",
+        "species": "Rillaboom",
+        "gigantamax": true,
         "item": ["Choice Band"],
         "ability": ["Grassy Surge"],
         "evs": {"hp": 252, "atk": 252, "def": 4},
@@ -175,7 +179,8 @@
         "moves": [["Grassy Glide"], ["Superpower"], ["Knock Off"], ["High Horsepower", "U-turn", "Wood Hammer"]]
       },
       {
-        "species": "Rillaboom-Gmax",
+        "species": "Rillaboom",
+        "gigantamax": true,
         "item": ["Grassy Seed"],
         "ability": ["Grassy Surge"],
         "evs": {"atk": 252, "def": 4, "spe": 252},
@@ -308,7 +313,8 @@
         "moves": [["Surging Strikes"], ["Close Combat"], ["Thunder Punch"], ["U-turn"]]
       },
       {
-        "species": "Urshifu-Gmax",
+        "species": "Urshifu",
+        "gigantamax": true,
         "item": ["Focus Sash"],
         "ability": ["Unseen Fist"],
         "evs": {"hp": 4, "atk": 252, "spe": 252},
@@ -316,7 +322,8 @@
         "moves": [["Wicked Blow"], ["Close Combat"], ["Counter"], ["Sucker Punch"]]
       },
       {
-        "species": "Urshifu-Gmax",
+        "species": "Urshifu",
+        "gigantamax": true,
         "item": ["Choice Band"],
         "ability": ["Unseen Fist"],
         "evs": {"hp": 4, "atk": 252, "spe": 252},
@@ -959,7 +966,8 @@
         "moves": [["Light Screen"], ["Reflect"], ["Spirit Break"], ["Taunt", "Thunder Wave"]]
       },
       {
-        "species": "Grimmsnarl-Gmax",
+        "species": "Grimmsnarl",
+        "gigantamax": true,
         "item": ["Lagging Tail"],
         "ability": ["Prankster"],
         "evs": {"hp": 252, "atk": 252, "spd": 4},
@@ -967,7 +975,8 @@
         "moves": [["Trick"], ["Spirit Break"], ["Sucker Punch"], ["Substitute", "Light Screen", "Reflect"]]
       },
       {
-        "species": "Grimmsnarl-Gmax",
+        "species": "Grimmsnarl",
+        "gigantamax": true,
         "item": ["Sitrus Berry", "Leftovers"],
         "ability": ["Prankster"],
         "evs": {"hp": 252, "atk": 4, "spd": 252},
@@ -1040,7 +1049,8 @@
     "usage": 6,
     "sets": [
       {
-        "species": "Lapras-Gmax",
+        "species": "Lapras",
+        "gigantamax": true,
         "item": ["Weakness Policy"],
         "ability": ["Shell Armor"],
         "evs": {"hp": 252, "def": 4, "spa": 252},
@@ -1048,7 +1058,8 @@
         "moves": [["Freeze-Dry"], ["Ice Shard"], ["Thunder", "Thunderbolt"], ["Sparkling Aria", "Hydro Pump"]]
       },
       {
-        "species": "Lapras-Gmax",
+        "species": "Lapras",
+        "gigantamax": true,
         "item": ["Light Clay", "Assault Vest"],
         "ability": ["Water Absorb"],
         "evs": {"hp": 252, "def": 4, "spa": 252},
@@ -1419,7 +1430,8 @@
     "usage": 6,
     "sets": [
       {
-        "species": "Snorlax-Gmax",
+        "species": "Snorlax",
+        "gigantamax": true,
         "item": ["Figy Berry", "Custap Berry"],
         "ability": ["Gluttony"],
         "evs": {"atk": 252, "def": 252, "spd": 4},
@@ -1427,7 +1439,8 @@
         "moves": [["Facade", "Body Slam", "Self-Destruct"], ["Earthquake"], ["Darkest Lariat", "Heavy Slam", "Heat Crash"], ["Curse", "Belly Drum"]]
       },
       {
-        "species": "Snorlax-Gmax",
+        "species": "Snorlax",
+        "gigantamax": true,
         "item": ["Figy Berry"],
         "ability": ["Gluttony"],
         "evs": {"atk": 252, "def": 252, "spd": 4},
@@ -1673,7 +1686,8 @@
     "usage": 2,
     "sets": [
       {
-        "species": "Charizard-Gmax",
+        "species": "Charizard",
+        "gigantamax": true,
         "item": ["Life Orb", "Heavy-Duty Boots"],
         "ability": ["Blaze"],
         "evs": {"spa": 252, "def": 4, "spe": 252},
@@ -1725,7 +1739,8 @@
     "usage": 1,
     "sets": [
       {
-        "species": "Gengar-Gmax",
+        "species": "Gengar",
+        "gigantamax": true,
         "item": ["Focus Sash", "Wide Lens"],
         "ability": ["Cursed Body"],
         "evs": {"spa": 252, "def": 4, "spe": 252},
@@ -1951,7 +1966,8 @@
     "usage": 1,
     "sets": [
       {
-        "species": "Hatterene-Gmax",
+        "species": "Hatterene",
+        "gigantamax": true,
         "item": ["Focus Sash", "Life Orb"],
         "ability": ["Magic Bounce"],
         "evs": {"hp": 252, "def": 4, "spa": 252},
@@ -1960,7 +1976,8 @@
         "moves": [["Trick Room"], ["Psychic"], ["Dazzling Gleam", "Misty Explosion"], ["Mystical Fire"]]
       },
       {
-        "species": "Hatterene-Gmax",
+        "species": "Hatterene",
+        "gigantamax": true,
         "item": ["Big Root"],
         "ability": ["Magic Bounce"],
         "evs": {"hp": 252, "def": 252, "spa": 4},
@@ -1974,7 +1991,8 @@
     "usage": 1,
     "sets": [
       {
-        "species": "Inteleon-Gmax",
+        "species": "Inteleon",
+        "gigantamax": true,
         "item": ["Scope Lens"],
         "ability": ["Sniper"],
         "evs": {"spa": 252, "spd": 4, "spe": 252},
@@ -1983,7 +2001,8 @@
         "moves": [["Hydro Pump", "Scald", "Snipe Shot", "Hydro Cannon"], ["Ice Beam"], ["Air Slash"], ["Focus Energy"]]
       },
       {
-        "species": "Inteleon-Gmax",
+        "species": "Inteleon",
+        "gigantamax": true,
         "item": ["Focus Sash", "Petaya Berry"],
         "ability": ["Torrent"],
         "evs": {"spa": 252, "spd": 4, "spe": 252},
@@ -2598,7 +2617,8 @@
         "moves": [["Overdrive"], ["Nuzzle"], ["Boomburst"], ["Hex"]]
       },
       {
-        "species": "Toxtricity-Gmax",
+        "species": "Toxtricity",
+        "gigantamax": true,
         "item": ["Throat Spray"],
         "ability": ["Punk Rock"],
         "evs": {"spa": 252, "spd": 4, "spe": 252},

--- a/data/bss-factory-sets.json
+++ b/data/bss-factory-sets.json
@@ -1,0 +1,8451 @@
+{
+  "cinderace": {
+    "usage": 10,
+    "sets": [
+      {
+        "species": "Cinderace-Gmax",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Libero"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Pyro Ball"
+          ],
+          [
+            "High Jump Kick",
+            "Counter"
+          ],
+          [
+            "Bounce",
+            "Sucker Punch"
+          ],
+          [
+            "Iron Head",
+            "Gunk Shot",
+            "Zen Headbutt"
+          ]
+        ]
+      },
+      {
+        "species": "Cinderace-Gmax",
+        "item": [
+          "Choice Scarf"
+        ],
+        "ability": [
+          "Libero"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Pyro Ball"
+          ],
+          [
+            "High Jump Kick"
+          ],
+          [
+            "Bounce"
+          ],
+          [
+            "Iron Head"
+          ]
+        ]
+      },
+      {
+        "species": "Cinderace-Gmax",
+        "item": [
+          "Scope Lens"
+        ],
+        "ability": [
+          "Libero"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Pyro Ball"
+          ],
+          [
+            "Bounce"
+          ],
+          [
+            "Iron Head"
+          ],
+          [
+            "Focus Energy"
+          ]
+        ]
+      }
+    ]
+  },
+  "zapdos": {
+    "usage": 10,
+    "sets": [
+      {
+        "species": "Zapdos",
+        "item": [
+          "Sharp Beak"
+        ],
+        "ability": [
+          "Static"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "moves": [
+          [
+            "Hurricane"
+          ],
+          [
+            "Thunderbolt"
+          ],
+          [
+            "Heat Wave"
+          ],
+          [
+            "Roost",
+            "Steel Wing"
+          ]
+        ]
+      },
+      {
+        "species": "Zapdos",
+        "item": [
+          "Leftovers"
+        ],
+        "ability": [
+          "Pressure"
+        ],
+        "evs": {
+          "hp": 252,
+          "spd": 252,
+          "spe": 4
+        },
+        "nature": "Calm",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Discharge"
+          ],
+          [
+            "Roost"
+          ],
+          [
+            "Eerie Impulse"
+          ],
+          [
+            "Substitute",
+            "Heat Wave",
+            "Hurricane"
+          ]
+        ]
+      },
+      {
+        "species": "Zapdos-Galar",
+        "item": [
+          "Weakness Policy",
+          "Life Orb",
+          "Sharp Beak",
+          "Sitrus Berry"
+        ],
+        "ability": [
+          "Defiant"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Thunderous Kick",
+            "Close Combat"
+          ],
+          [
+            "Brave Bird",
+            "Dual Wingbeat"
+          ],
+          [
+            "Steel Wing",
+            "Blaze Kick"
+          ],
+          [
+            "Bulk Up"
+          ]
+        ]
+      }
+    ]
+  },
+  "mimikyu": {
+    "usage": 10,
+    "sets": [
+      {
+        "species": "Mimikyu",
+        "item": [
+          "Spell Tag"
+        ],
+        "ability": [
+          "Disguise"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Swords Dance"
+          ],
+          [
+            "Play Rough"
+          ],
+          [
+            "Shadow Sneak"
+          ],
+          [
+            "Phantom Force",
+            "Shadow Claw"
+          ]
+        ]
+      },
+      {
+        "species": "Mimikyu",
+        "item": [
+          "Kee Berry"
+        ],
+        "ability": [
+          "Disguise"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "def": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Play Rough"
+          ],
+          [
+            "Shadow Sneak"
+          ],
+          [
+            "Drain Punch"
+          ],
+          [
+            "Swords Dance"
+          ]
+        ]
+      },
+      {
+        "species": "Mimikyu",
+        "item": [
+          "Babiri Berry"
+        ],
+        "ability": [
+          "Disguise"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "def": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Play Rough"
+          ],
+          [
+            "Shadow Sneak"
+          ],
+          [
+            "Drain Punch"
+          ],
+          [
+            "Swords Dance"
+          ]
+        ]
+      },
+      {
+        "species": "Mimikyu",
+        "item": [
+          "Custap Berry",
+          "Salac Berry",
+          "Liechi Berry"
+        ],
+        "ability": [
+          "Disguise"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Substitute"
+          ],
+          [
+            "Curse"
+          ],
+          [
+            "Shadow Sneak",
+            "Play Rough"
+          ],
+          [
+            "Phantom Force",
+            "Shadow Claw"
+          ]
+        ]
+      }
+    ]
+  },
+  "landorus": {
+    "usage": 8,
+    "sets": [
+      {
+        "species": "Landorus-Therian",
+        "item": [
+          "Sharp Beak",
+          "Choice Scarf"
+        ],
+        "ability": [
+          "Intimidate"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Earthquake"
+          ],
+          [
+            "Fly"
+          ],
+          [
+            "Stone Edge"
+          ],
+          [
+            "Superpower"
+          ]
+        ]
+      },
+      {
+        "species": "Landorus-Therian",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Intimidate"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Earthquake"
+          ],
+          [
+            "Rock Tomb"
+          ],
+          [
+            "Stealth Rock"
+          ],
+          [
+            "Self-Destruct"
+          ]
+        ]
+      }
+    ]
+  },
+  "tapufini": {
+    "usage": 9,
+    "sets": [
+      {
+        "species": "Tapu Fini",
+        "item": [
+          "Leftovers"
+        ],
+        "ability": [
+          "Misty Surge"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Scald",
+            "Hydro Pump"
+          ],
+          [
+            "Moonblast"
+          ],
+          [
+            "Calm Mind"
+          ],
+          [
+            "Taunt",
+            "Reflect",
+            "Iron Defense"
+          ]
+        ]
+      },
+      {
+        "species": "Tapu Fini",
+        "item": [
+          "Choice Scarf"
+        ],
+        "ability": [
+          "Misty Surge"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Hydro Pump"
+          ],
+          [
+            "Moonblast"
+          ],
+          [
+            "Trick"
+          ],
+          [
+            "Calm Mind",
+            "Ice Beam"
+          ]
+        ]
+      }
+    ]
+  },
+  "nihilego": {
+    "usage": 6,
+    "sets": [
+      {
+        "species": "Nihilego",
+        "item": [
+          "Power Herb"
+        ],
+        "ability": [
+          "Beast Boost"
+        ],
+        "evs": {
+          "def": 84,
+          "spa": 172,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Power Gem"
+          ],
+          [
+            "Sludge Wave"
+          ],
+          [
+            "Grass Knot",
+            "Thunderbolt",
+            "Dazzling Gleam"
+          ],
+          [
+            "Meteor Beam"
+          ]
+        ]
+      },
+      {
+        "species": "Nihilego",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Beast Boost"
+        ],
+        "evs": {
+          "def": 84,
+          "spa": 172,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Power Gem"
+          ],
+          [
+            "Sludge Wave",
+            "Toxic Spikes"
+          ],
+          [
+            "Stealth Rock"
+          ],
+          [
+            "Thunder Wave"
+          ]
+        ]
+      }
+    ]
+  },
+  "rillaboom": {
+    "usage": 8,
+    "sets": [
+      {
+        "species": "Rillaboom-Gmax",
+        "item": [
+          "Choice Band"
+        ],
+        "ability": [
+          "Grassy Surge"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "def": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Grassy Glide"
+          ],
+          [
+            "Superpower"
+          ],
+          [
+            "Knock Off"
+          ],
+          [
+            "High Horsepower",
+            "U-turn",
+            "Wood Hammer"
+          ]
+        ]
+      },
+      {
+        "species": "Rillaboom-Gmax",
+        "item": [
+          "Grassy Seed"
+        ],
+        "ability": [
+          "Grassy Surge"
+        ],
+        "evs": {
+          "atk": 252,
+          "def": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Grassy Glide"
+          ],
+          [
+            "Acrobatics"
+          ],
+          [
+            "Drain Punch"
+          ],
+          [
+            "Swords Dance"
+          ]
+        ]
+      }
+    ]
+  },
+  "porygon2": {
+    "usage": 9,
+    "sets": [
+      {
+        "species": "Porygon2",
+        "item": [
+          "Eviolite"
+        ],
+        "ability": [
+          "Trace"
+        ],
+        "evs": {
+          "hp": 244,
+          "def": 252,
+          "spd": 12
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Ice Beam"
+          ],
+          [
+            "Discharge",
+            "Tri Attack",
+            "Shadow Ball",
+            "Foul Play"
+          ],
+          [
+            "Recover"
+          ],
+          [
+            "Trick Room",
+            "Thunder Wave",
+            "Speed Swap"
+          ]
+        ]
+      },
+      {
+        "species": "Porygon2",
+        "item": [
+          "Eviolite"
+        ],
+        "ability": [
+          "Download"
+        ],
+        "evs": {
+          "hp": 244,
+          "spa": 252,
+          "spd": 12
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Ice Beam"
+          ],
+          [
+            "Discharge"
+          ],
+          [
+            "Hyper Beam",
+            "Tri Attack"
+          ],
+          [
+            "Trick Room",
+            "Recover"
+          ]
+        ]
+      },
+      {
+        "species": "Porygon2",
+        "item": [
+          "Eviolite"
+        ],
+        "ability": [
+          "Download"
+        ],
+        "evs": {
+          "hp": 244,
+          "atk": 28,
+          "def": 172,
+          "spa": 60,
+          "spd": 4
+        },
+        "nature": "Quiet",
+        "moves": [
+          [
+            "Hyper Beam"
+          ],
+          [
+            "Giga Impact"
+          ],
+          [
+            "Ice Beam"
+          ],
+          [
+            "Shadow Ball"
+          ]
+        ]
+      }
+    ]
+  },
+  "dracovish": {
+    "usage": 8,
+    "sets": [
+      {
+        "species": "Dracovish",
+        "item": [
+          "Choice Band"
+        ],
+        "ability": [
+          "Strong Jaw"
+        ],
+        "evs": {
+          "atk": 252,
+          "def": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Fishious Rend"
+          ],
+          [
+            "Outrage"
+          ],
+          [
+            "Sleep Talk"
+          ]
+        ]
+      },
+      {
+        "species": "Dracovish",
+        "item": [
+          "Life Orb"
+        ],
+        "ability": [
+          "Sand Rush"
+        ],
+        "evs": {
+          "atk": 252,
+          "def": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Fishious Rend"
+          ],
+          [
+            "Outrage"
+          ],
+          [
+            "Rock Blast"
+          ],
+          [
+            "Psychic Fangs",
+            "Protect"
+          ]
+        ]
+      }
+    ]
+  },
+  "dracozolt": {
+    "usage": 5,
+    "sets": [
+      {
+        "species": "Dracozolt",
+        "item": [
+          "Power Herb"
+        ],
+        "ability": [
+          "Sand Rush"
+        ],
+        "evs": {
+          "atk": 252,
+          "spa": 4,
+          "spe": 252
+        },
+        "nature": "Naive",
+        "moves": [
+          [
+            "Bolt Beak"
+          ],
+          [
+            "Outrage"
+          ],
+          [
+            "Meteor Beam"
+          ],
+          [
+            "Fire Blast"
+          ]
+        ]
+      },
+      {
+        "species": "Dracozolt",
+        "item": [
+          "Life Orb"
+        ],
+        "ability": [
+          "Hustle"
+        ],
+        "evs": {
+          "atk": 252,
+          "spa": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Bolt Beak"
+          ],
+          [
+            "Outrage"
+          ],
+          [
+            "Aerial Ace"
+          ],
+          [
+            "Fire Fang",
+            "Low Kick"
+          ]
+        ]
+      }
+    ]
+  },
+  "ferrothorn": {
+    "usage": 8,
+    "sets": [
+      {
+        "species": "Ferrothorn",
+        "item": [
+          "Leftovers"
+        ],
+        "ability": [
+          "Iron Barbs"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Relaxed",
+        "ivs": {
+          "spe": 0
+        },
+        "moves": [
+          [
+            "Gyro Ball"
+          ],
+          [
+            "Leech Seed"
+          ],
+          [
+            "Protect",
+            "Stealth Rock"
+          ],
+          [
+            "Bullet Seed",
+            "Body Press"
+          ]
+        ]
+      },
+      {
+        "species": "Ferrothorn",
+        "item": [
+          "Leftovers",
+          "Occa Berry"
+        ],
+        "ability": [
+          "Iron Barbs"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Relaxed",
+        "ivs": {
+          "spe": 0
+        },
+        "moves": [
+          [
+            "Gyro Ball"
+          ],
+          [
+            "Iron Defense"
+          ],
+          [
+            "Body Press"
+          ],
+          [
+            "Leech Seed"
+          ]
+        ]
+      },
+      {
+        "species": "Ferrothorn",
+        "item": [
+          "Choice Band"
+        ],
+        "ability": [
+          "Iron Barbs"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "def": 4
+        },
+        "nature": "Brave",
+        "ivs": {
+          "spe": 0
+        },
+        "moves": [
+          [
+            "Gyro Ball"
+          ],
+          [
+            "Bullet Seed",
+            "Power Whip"
+          ],
+          [
+            "Bulldoze",
+            "Knock Off"
+          ],
+          [
+            "Explosion"
+          ]
+        ]
+      }
+    ]
+  },
+  "urshifu": {
+    "usage": 8,
+    "sets": [
+      {
+        "species": "Urshifu-Rapid-Strike",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Unseen Fist"
+        ],
+        "evs": {
+          "hp": 4,
+          "atk": 252,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Surging Strikes"
+          ],
+          [
+            "Close Combat"
+          ],
+          [
+            "Counter"
+          ],
+          [
+            "Aqua Jet"
+          ]
+        ]
+      },
+      {
+        "species": "Urshifu-Rapid-Strike",
+        "item": [
+          "Choice Scarf"
+        ],
+        "ability": [
+          "Unseen Fist"
+        ],
+        "evs": {
+          "hp": 4,
+          "atk": 252,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Surging Strikes"
+          ],
+          [
+            "Close Combat"
+          ],
+          [
+            "Thunder Punch"
+          ],
+          [
+            "U-turn"
+          ]
+        ]
+      },
+      {
+        "species": "Urshifu-Gmax",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Unseen Fist"
+        ],
+        "evs": {
+          "hp": 4,
+          "atk": 252,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Wicked Blow"
+          ],
+          [
+            "Close Combat"
+          ],
+          [
+            "Counter"
+          ],
+          [
+            "Sucker Punch"
+          ]
+        ]
+      },
+      {
+        "species": "Urshifu-Gmax",
+        "item": [
+          "Choice Band"
+        ],
+        "ability": [
+          "Unseen Fist"
+        ],
+        "evs": {
+          "hp": 4,
+          "atk": 252,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Wicked Blow"
+          ],
+          [
+            "Close Combat"
+          ],
+          [
+            "Sucker Punch"
+          ],
+          [
+            "Poison Jab",
+            "Thunder Punch",
+            "Aerial Ace"
+          ]
+        ]
+      }
+    ]
+  },
+  "dragapult": {
+    "usage": 9,
+    "sets": [
+      {
+        "species": "Dragapult",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Infiltrator"
+        ],
+        "evs": {
+          "atk": 252,
+          "spa": 4,
+          "spe": 252
+        },
+        "nature": "Naive",
+        "moves": [
+          [
+            "Dragon Darts"
+          ],
+          [
+            "Phantom Force",
+            "Hex"
+          ],
+          [
+            "Dragon Dance"
+          ],
+          [
+            "Will-O-Wisp",
+            "Thunder Wave"
+          ]
+        ]
+      },
+      {
+        "species": "Dragapult",
+        "item": [
+          "Light Clay"
+        ],
+        "ability": [
+          "Cursed Body"
+        ],
+        "evs": {
+          "hp": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Reflect"
+          ],
+          [
+            "Light Screen"
+          ],
+          [
+            "Dragon Darts"
+          ],
+          [
+            "Curse"
+          ]
+        ]
+      },
+      {
+        "species": "Dragapult",
+        "item": [
+          "Choice Specs",
+          "Life Orb"
+        ],
+        "ability": [
+          "Clear Body"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "moves": [
+          [
+            "Draco Meteor"
+          ],
+          [
+            "Shadow Ball"
+          ],
+          [
+            "Fire Blast",
+            "Thunderbolt"
+          ],
+          [
+            "U-turn",
+            "Hydro Pump"
+          ]
+        ]
+      }
+    ]
+  },
+  "celesteela": {
+    "usage": 9,
+    "sets": [
+      {
+        "species": "Celesteela",
+        "item": [
+          "Leftovers"
+        ],
+        "ability": [
+          "Beast Boost"
+        ],
+        "evs": {
+          "hp": 244,
+          "def": 12,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Air Slash"
+          ],
+          [
+            "Leech Seed"
+          ],
+          [
+            "Protect",
+            "Substitute"
+          ],
+          [
+            "Flamethrower"
+          ]
+        ]
+      },
+      {
+        "species": "Celesteela",
+        "item": [
+          "Weakness Policy"
+        ],
+        "ability": [
+          "Beast Boost"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spe": 4
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Air Slash"
+          ],
+          [
+            "Flash Cannon"
+          ],
+          [
+            "Flamethrower"
+          ],
+          [
+            "Giga Drain"
+          ]
+        ]
+      },
+      {
+        "species": "Celesteela",
+        "item": [
+          "Power Herb"
+        ],
+        "ability": [
+          "Beast Boost"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spe": 4
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Air Slash"
+          ],
+          [
+            "Flash Cannon"
+          ],
+          [
+            "Meteor Beam"
+          ],
+          [
+            "Flamethrower"
+          ]
+        ]
+      }
+    ]
+  },
+  "dragonite": {
+    "usage": 8,
+    "sets": [
+      {
+        "species": "Dragonite",
+        "item": [
+          "Weakness Policy",
+          "Lum Berry"
+        ],
+        "ability": [
+          "Multiscale"
+        ],
+        "evs": {
+          "hp": 4,
+          "atk": 252,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Outrage"
+          ],
+          [
+            "Dual Wingbeat"
+          ],
+          [
+            "Dragon Dance"
+          ],
+          [
+            "Roost",
+            "Fire Punch"
+          ]
+        ]
+      },
+      {
+        "species": "Dragonite",
+        "item": [
+          "Life Orb"
+        ],
+        "ability": [
+          "Inner Focus"
+        ],
+        "evs": {
+          "hp": 4,
+          "atk": 252,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Outrage"
+          ],
+          [
+            "Dual Wingbeat"
+          ],
+          [
+            "Dragon Dance"
+          ],
+          [
+            "Roost",
+            "Fire Punch"
+          ]
+        ]
+      },
+      {
+        "species": "Dragonite",
+        "item": [
+          "Expert Belt"
+        ],
+        "ability": [
+          "Multiscale"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Hurricane"
+          ],
+          [
+            "Fire Blast"
+          ],
+          [
+            "Ice Beam"
+          ],
+          [
+            "Thunderbolt",
+            "Roost"
+          ]
+        ]
+      }
+    ]
+  },
+  "hippowdon": {
+    "usage": 6,
+    "sets": [
+      {
+        "species": "Hippowdon",
+        "item": [
+          "Sitrus Berry",
+          "Figy Berry"
+        ],
+        "ability": [
+          "Sand Stream"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Impish",
+        "moves": [
+          [
+            "Stealth Rock"
+          ],
+          [
+            "Yawn"
+          ],
+          [
+            "Earthquake"
+          ],
+          [
+            "Whirlwind"
+          ]
+        ]
+      },
+      {
+        "species": "Hippowdon",
+        "item": [
+          "Kee Berry"
+        ],
+        "ability": [
+          "Sand Stream"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Impish",
+        "moves": [
+          [
+            "Earthquake"
+          ],
+          [
+            "Yawn"
+          ],
+          [
+            "Slack Off"
+          ],
+          [
+            "Ice Fang",
+            "Stealth Rock"
+          ]
+        ]
+      }
+    ]
+  },
+  "tyranitar": {
+    "usage": 4,
+    "sets": [
+      {
+        "species": "Tyranitar",
+        "item": [
+          "Assault Vest",
+          "Weakness Policy"
+        ],
+        "ability": [
+          "Sand Stream"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "spe": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Stone Edge",
+            "Rock Blast"
+          ],
+          [
+            "Crunch"
+          ],
+          [
+            "Earthquake"
+          ],
+          [
+            "Iron Head"
+          ]
+        ]
+      },
+      {
+        "species": "Tyranitar",
+        "item": [
+          "Weakness Policy"
+        ],
+        "ability": [
+          "Sand Stream"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Dragon Dance"
+          ],
+          [
+            "Rock Blast"
+          ],
+          [
+            "Ice Punch"
+          ],
+          [
+            "Earthquake"
+          ]
+        ]
+      },
+      {
+        "species": "Tyranitar",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Sand Stream"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Stealth Rock"
+          ],
+          [
+            "Thunder Wave"
+          ],
+          [
+            "Rock Blast"
+          ],
+          [
+            "Ice Punch",
+            "Fire Punch",
+            "Iron Head"
+          ]
+        ]
+      },
+      {
+        "species": "Tyranitar",
+        "item": [
+          "Chesto Berry"
+        ],
+        "ability": [
+          "Sand Stream"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Dragon Dance"
+          ],
+          [
+            "Rock Blast",
+            "Rock Slide"
+          ],
+          [
+            "Crunch",
+            "Ice Punch",
+            "Earthquake"
+          ],
+          [
+            "Rest"
+          ]
+        ]
+      }
+    ]
+  },
+  "regieleki": {
+    "usage": 7,
+    "sets": [
+      {
+        "species": "Regieleki",
+        "item": [
+          "Choice Specs",
+          "Life Orb",
+          "Focus Sash"
+        ],
+        "ability": [
+          "Transistor"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Volt Switch"
+          ],
+          [
+            "Thunderbolt"
+          ],
+          [
+            "Hyper Beam"
+          ],
+          [
+            "Reflect",
+            "Electroweb"
+          ]
+        ]
+      },
+      {
+        "species": "Regieleki",
+        "item": [
+          "Light Clay"
+        ],
+        "ability": [
+          "Transistor"
+        ],
+        "evs": {
+          "spa": 252,
+          "atk": 4,
+          "spe": 252
+        },
+        "nature": "Naive",
+        "moves": [
+          [
+            "Volt Switch"
+          ],
+          [
+            "Reflect"
+          ],
+          [
+            "Light Screen"
+          ],
+          [
+            "Explosion"
+          ]
+        ]
+      },
+      {
+        "species": "Regieleki",
+        "item": [
+          "Throat Spray"
+        ],
+        "ability": [
+          "Transistor"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Round"
+          ],
+          [
+            "Substitute"
+          ],
+          [
+            "Hyper Beam"
+          ],
+          [
+            "Thunderbolt"
+          ]
+        ]
+      }
+    ]
+  },
+  "pheromosa": {
+    "usage": 8,
+    "sets": [
+      {
+        "species": "Pheromosa",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Beast Boost"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Close Combat"
+          ],
+          [
+            "U-turn"
+          ],
+          [
+            "Triple Axel"
+          ],
+          [
+            "Poison Jab",
+            "Drill Run"
+          ]
+        ]
+      }
+    ]
+  },
+  "moltres": {
+    "usage": 2,
+    "sets": [
+      {
+        "species": "Moltres-Galar",
+        "item": [
+          "Weakness Policy",
+          "Sitrus Berry"
+        ],
+        "ability": [
+          "Berserk"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Fiery Wrath"
+          ],
+          [
+            "Hurricane"
+          ],
+          [
+            "Taunt",
+            "Sucker Punch"
+          ],
+          [
+            "Nasty Plot"
+          ]
+        ]
+      },
+      {
+        "species": "Moltres-Galar",
+        "item": [
+          "Chesto Berry"
+        ],
+        "ability": [
+          "Berserk"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Fiery Wrath"
+          ],
+          [
+            "Hurricane"
+          ],
+          [
+            "Nasty Plot"
+          ],
+          [
+            "Rest"
+          ]
+        ]
+      },
+      {
+        "species": "Moltres",
+        "item": [
+          "Life Orb",
+          "Heavy-Duty Boots"
+        ],
+        "ability": [
+          "Flame Body"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Fire Blast",
+            "Burn Up"
+          ],
+          [
+            "Hurricane"
+          ],
+          [
+            "Solar Beam"
+          ],
+          [
+            "Scorching Sands"
+          ]
+        ]
+      },
+      {
+        "species": "Moltres",
+        "item": [
+          "Kee Berry"
+        ],
+        "ability": [
+          "Flame Body",
+          "Pressure"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Mystical Fire"
+          ],
+          [
+            "Scorching Sands"
+          ],
+          [
+            "Roost"
+          ],
+          [
+            "Will-O-Wisp"
+          ]
+        ]
+      }
+    ]
+  },
+  "excadrill": {
+    "usage": 6,
+    "sets": [
+      {
+        "species": "Excadrill",
+        "item": [
+          "Life Orb"
+        ],
+        "ability": [
+          "Sand Rush"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Swords Dance"
+          ],
+          [
+            "Earthquake"
+          ],
+          [
+            "Rock Blast"
+          ],
+          [
+            "Iron Head"
+          ]
+        ]
+      },
+      {
+        "species": "Excadrill",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Mold Breaker"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Earthquake"
+          ],
+          [
+            "Iron Head"
+          ],
+          [
+            "Stealth Rock"
+          ],
+          [
+            "Rock Tomb"
+          ]
+        ]
+      },
+      {
+        "species": "Excadrill",
+        "item": [
+          "Choice Scarf",
+          "Assault Vest"
+        ],
+        "ability": [
+          "Mold Breaker"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Earthquake"
+          ],
+          [
+            "Iron Head"
+          ],
+          [
+            "Rock Tomb"
+          ],
+          [
+            "Horn Drill"
+          ]
+        ]
+      }
+    ]
+  },
+  "cresselia": {
+    "usage": 7,
+    "sets": [
+      {
+        "species": "Cresselia",
+        "item": [
+          "Kee Berry"
+        ],
+        "ability": [
+          "Levitate"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Stored Power"
+          ],
+          [
+            "Moonblast",
+            "Ice Beam"
+          ],
+          [
+            "Calm Mind"
+          ],
+          [
+            "Moonlight"
+          ]
+        ]
+      },
+      {
+        "species": "Cresselia",
+        "item": [
+          "Rocky Helmet"
+        ],
+        "ability": [
+          "Levitate"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Psychic",
+            "Psyshock"
+          ],
+          [
+            "Trick Room",
+            "Lunar Dance"
+          ],
+          [
+            "Moonlight"
+          ],
+          [
+            "Ice Beam",
+            "Moonblast",
+            "Icy Wind"
+          ]
+        ]
+      }
+    ]
+  },
+  "glastrier": {
+    "usage": 8,
+    "sets": [
+      {
+        "species": "Glastrier",
+        "item": [
+          "Weakness Policy",
+          "Lum Berry",
+          "Assault Vest"
+        ],
+        "ability": [
+          "Chilling Neigh"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "spd": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Icicle Spear"
+          ],
+          [
+            "High Horsepower"
+          ],
+          [
+            "Close Combat"
+          ],
+          [
+            "Heavy Slam",
+            "Swords Dance"
+          ]
+        ]
+      },
+      {
+        "species": "Glastrier",
+        "item": [
+          "Custap Berry"
+        ],
+        "ability": [
+          "Chilling Neigh"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "spd": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Icicle Spear"
+          ],
+          [
+            "High Horsepower"
+          ],
+          [
+            "Close Combat"
+          ],
+          [
+            "Endure"
+          ]
+        ]
+      }
+    ]
+  },
+  "naganadel": {
+    "usage": 8,
+    "sets": [
+      {
+        "species": "Naganadel",
+        "item": [
+          "Life Orb",
+          "Focus Sash"
+        ],
+        "ability": [
+          "Beast Boost"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Sludge Wave"
+          ],
+          [
+            "Draco Meteor"
+          ],
+          [
+            "Fire Blast"
+          ],
+          [
+            "Nasty Plot",
+            "Air Slash"
+          ]
+        ]
+      },
+      {
+        "species": "Naganadel",
+        "item": [
+          "Choice Scarf"
+        ],
+        "ability": [
+          "Beast Boost"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Sludge Wave"
+          ],
+          [
+            "Draco Meteor"
+          ],
+          [
+            "Fire Blast"
+          ],
+          [
+            "U-turn"
+          ]
+        ]
+      }
+    ]
+  },
+  "swampert": {
+    "usage": 4,
+    "sets": [
+      {
+        "species": "Swampert",
+        "item": [
+          "Sitrus Berry",
+          "Aguav Berry"
+        ],
+        "ability": [
+          "Damp"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Relaxed",
+        "ivs": {
+          "spe": 0
+        },
+        "moves": [
+          [
+            "Stealth Rock"
+          ],
+          [
+            "Yawn"
+          ],
+          [
+            "Flip Turn"
+          ],
+          [
+            "Earthquake",
+            "Ice Beam"
+          ]
+        ]
+      }
+    ]
+  },
+  "metagross": {
+    "usage": 7,
+    "sets": [
+      {
+        "species": "Metagross",
+        "item": [
+          "Weakness Policy",
+          "Life Orb"
+        ],
+        "ability": [
+          "Clear Body"
+        ],
+        "evs": {
+          "atk": 252,
+          "def": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Meteor Mash"
+          ],
+          [
+            "Earthquake"
+          ],
+          [
+            "Ice Punch",
+            "Thunder Punch",
+            "Zen Headbutt"
+          ],
+          [
+            "Agility"
+          ]
+        ]
+      },
+      {
+        "species": "Metagross",
+        "item": [
+          "Lagging Tail",
+          "Full Incense"
+        ],
+        "ability": [
+          "Clear Body"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "def": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Trick"
+          ],
+          [
+            "Stealth Rock"
+          ],
+          [
+            "Bullet Punch"
+          ],
+          [
+            "Ice Punch",
+            "Self-Destruct"
+          ]
+        ]
+      },
+      {
+        "species": "Metagross",
+        "item": [
+          "Power Herb"
+        ],
+        "ability": [
+          "Clear Body"
+        ],
+        "evs": {
+          "def": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Steel Beam"
+          ],
+          [
+            "Expanding Force"
+          ],
+          [
+            "Meteor Beam"
+          ],
+          [
+            "Sludge Bomb",
+            "Icy Wind",
+            "Agility"
+          ]
+        ]
+      }
+    ]
+  },
+  "magnezone": {
+    "usage": 6,
+    "sets": [
+      {
+        "species": "Magnezone",
+        "item": [
+          "Custap Berry",
+          "Weakness Policy"
+        ],
+        "ability": [
+          "Sturdy"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 4,
+          "spa": 252
+        },
+        "nature": "Modest",
+        "moves": [
+          [
+            "Thunderbolt"
+          ],
+          [
+            "Flash Cannon"
+          ],
+          [
+            "Volt Switch"
+          ],
+          [
+            "Steel Beam",
+            "Mirror Coat"
+          ]
+        ]
+      },
+      {
+        "species": "Magnezone",
+        "item": [
+          "Assault Vest",
+          "Choice Specs"
+        ],
+        "ability": [
+          "Analytic"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 4,
+          "spa": 252
+        },
+        "nature": "Modest",
+        "moves": [
+          [
+            "Thunderbolt"
+          ],
+          [
+            "Flash Cannon"
+          ],
+          [
+            "Volt Switch"
+          ],
+          [
+            "Body Press"
+          ]
+        ]
+      }
+    ]
+  },
+  "salamence": {
+    "usage": 7,
+    "sets": [
+      {
+        "species": "Salamence",
+        "item": [
+          "Lum Berry"
+        ],
+        "ability": [
+          "Moxie"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Dual Wingbeat"
+          ],
+          [
+            "Outrage"
+          ],
+          [
+            "Dragon Dance"
+          ],
+          [
+            "Earthquake"
+          ]
+        ]
+      },
+      {
+        "species": "Salamence",
+        "item": [
+          "Life Orb"
+        ],
+        "ability": [
+          "Intimidate"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "moves": [
+          [
+            "Hurricane"
+          ],
+          [
+            "Draco Meteor"
+          ],
+          [
+            "Fire Blast"
+          ],
+          [
+            "Hydro Pump"
+          ]
+        ]
+      }
+    ]
+  },
+  "blaziken": {
+    "usage": 6,
+    "sets": [
+      {
+        "species": "Blaziken",
+        "item": [
+          "Life Orb",
+          "Focus Sash"
+        ],
+        "ability": [
+          "Speed Boost"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Flare Blitz"
+          ],
+          [
+            "Close Combat"
+          ],
+          [
+            "Thunder Punch"
+          ],
+          [
+            "Swords Dance",
+            "Earthquake",
+            "Protect"
+          ]
+        ]
+      },
+      {
+        "species": "Blaziken",
+        "item": [
+          "Life Orb",
+          "Focus Sash"
+        ],
+        "ability": [
+          "Speed Boost"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Fire Blast"
+          ],
+          [
+            "Solar Beam"
+          ],
+          [
+            "Scorching Sands"
+          ],
+          [
+            "Protect",
+            "Baton Pass"
+          ]
+        ]
+      }
+    ]
+  },
+  "kartana": {
+    "usage": 6,
+    "sets": [
+      {
+        "species": "Kartana",
+        "item": [
+          "Life Orb",
+          "Focus Sash"
+        ],
+        "ability": [
+          "Beast Boost"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Leaf Blade"
+          ],
+          [
+            "Smart Strike"
+          ],
+          [
+            "Sacred Sword"
+          ],
+          [
+            "Giga Impact",
+            "Swords Dance"
+          ]
+        ]
+      },
+      {
+        "species": "Kartana",
+        "item": [
+          "Normal Gem"
+        ],
+        "ability": [
+          "Beast Boost"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Leaf Blade"
+          ],
+          [
+            "Smart Strike"
+          ],
+          [
+            "Sacred Sword"
+          ],
+          [
+            "Giga Impact"
+          ]
+        ]
+      },
+      {
+        "species": "Kartana",
+        "item": [
+          "Choice Scarf"
+        ],
+        "ability": [
+          "Beast Boost"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Leaf Blade"
+          ],
+          [
+            "Smart Strike"
+          ],
+          [
+            "Sacred Sword"
+          ],
+          [
+            "Guillotine"
+          ]
+        ]
+      }
+    ]
+  },
+  "garchomp": {
+    "usage": 6,
+    "sets": [
+      {
+        "species": "Garchomp",
+        "item": [
+          "Focus Sash",
+          "Life Orb",
+          "Lum Berry"
+        ],
+        "ability": [
+          "Rough Skin"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Swords Dance"
+          ],
+          [
+            "Scale Shot"
+          ],
+          [
+            "Earthquake"
+          ],
+          [
+            "Fire Fang"
+          ]
+        ]
+      },
+      {
+        "species": "Garchomp",
+        "item": [
+          "Choice Scarf"
+        ],
+        "ability": [
+          "Rough Skin"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Outrage"
+          ],
+          [
+            "Earthquake"
+          ],
+          [
+            "Stone Edge"
+          ],
+          [
+            "Iron Head",
+            "Stealth Rock"
+          ]
+        ]
+      },
+      {
+        "species": "Garchomp",
+        "item": [
+          "Focus Sash",
+          "Life Orb"
+        ],
+        "ability": [
+          "Rough Skin"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Stealth Rock"
+          ],
+          [
+            "Earthquake"
+          ],
+          [
+            "Scale Shot",
+            "Outrage"
+          ],
+          [
+            "Stone Edge"
+          ]
+        ]
+      }
+    ]
+  },
+  "heatran": {
+    "usage": 7,
+    "sets": [
+      {
+        "species": "Heatran",
+        "item": [
+          "Assault Vest"
+        ],
+        "ability": [
+          "Flash Fire"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spd": 4
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Magma Storm",
+            "Fire Blast",
+            "Flamethrower"
+          ],
+          [
+            "Flash Cannon"
+          ],
+          [
+            "Earth Power"
+          ],
+          [
+            "Solar Beam"
+          ]
+        ]
+      },
+      {
+        "species": "Heatran",
+        "item": [
+          "Air Balloon"
+        ],
+        "ability": [
+          "Flash Fire"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Magma Storm"
+          ],
+          [
+            "Flash Cannon"
+          ],
+          [
+            "Earth Power"
+          ],
+          [
+            "Stealth Rock"
+          ]
+        ]
+      }
+    ]
+  },
+  "rotom": {
+    "usage": 7,
+    "sets": [
+      {
+        "species": "Rotom-Wash",
+        "item": [
+          "Choice Specs"
+        ],
+        "ability": [
+          "Levitate"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spd": 4
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Hydro Pump"
+          ],
+          [
+            "Thunderbolt"
+          ],
+          [
+            "Volt Switch"
+          ],
+          [
+            "Trick"
+          ]
+        ]
+      },
+      {
+        "species": "Rotom-Wash",
+        "item": [
+          "Assault Vest"
+        ],
+        "ability": [
+          "Levitate"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spd": 4
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Hydro Pump"
+          ],
+          [
+            "Thunderbolt"
+          ],
+          [
+            "Volt Switch"
+          ],
+          [
+            "Dark Pulse"
+          ]
+        ]
+      },
+      {
+        "species": "Rotom-Wash",
+        "item": [
+          "Sitrus Berry",
+          "Wiki Berry"
+        ],
+        "ability": [
+          "Levitate"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spd": 4
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Hydro Pump"
+          ],
+          [
+            "Discharge",
+            "Thunderbolt"
+          ],
+          [
+            "Nasty Plot",
+            "Volt Switch"
+          ],
+          [
+            "Will-O-Wisp"
+          ]
+        ]
+      },
+      {
+        "species": "Rotom-Heat",
+        "item": [
+          "Choice Scarf"
+        ],
+        "ability": [
+          "Levitate"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Volt Switch"
+          ],
+          [
+            "Overheat"
+          ],
+          [
+            "Trick"
+          ],
+          [
+            "Will-O-Wisp",
+            "Nasty Plot",
+            "Thunderbolt"
+          ]
+        ]
+      },
+      {
+        "species": "Rotom-Heat",
+        "item": [
+          "Choice Specs"
+        ],
+        "ability": [
+          "Levitate"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spd": 4
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Volt Switch"
+          ],
+          [
+            "Overheat"
+          ],
+          [
+            "Trick"
+          ],
+          [
+            "Will-O-Wisp",
+            "Nasty Plot",
+            "Thunderbolt"
+          ]
+        ]
+      },
+      {
+        "species": "Rotom-Heat",
+        "item": [
+          "Assault Vest"
+        ],
+        "ability": [
+          "Levitate"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spd": 4
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Volt Switch"
+          ],
+          [
+            "Overheat"
+          ],
+          [
+            "Discharge",
+            "Thunderbolt"
+          ],
+          [
+            "Dark Pulse",
+            "Shadow Ball"
+          ]
+        ]
+      },
+      {
+        "species": "Rotom-Heat",
+        "item": [
+          "Sitrus Berry"
+        ],
+        "ability": [
+          "Levitate"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spa": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Discharge",
+            "Volt Switch"
+          ],
+          [
+            "Overheat"
+          ],
+          [
+            "Nasty Plot"
+          ],
+          [
+            "Dark Pulse",
+            "Will-O-Wisp"
+          ]
+        ]
+      },
+      {
+        "species": "Rotom-Mow",
+        "item": [
+          "Choice Specs",
+          "Choice Scarf"
+        ],
+        "ability": [
+          "Levitate"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Leaf Storm"
+          ],
+          [
+            "Volt Switch"
+          ],
+          [
+            "Dark Pulse"
+          ],
+          [
+            "Trick"
+          ]
+        ]
+      },
+      {
+        "species": "Rotom-Mow",
+        "item": [
+          "Sitrus Berry",
+          "Eject Pack"
+        ],
+        "ability": [
+          "Levitate"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spd": 4
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Leaf Storm"
+          ],
+          [
+            "Volt Switch"
+          ],
+          [
+            "Dark Pulse",
+            "Nasty Plot"
+          ],
+          [
+            "Will-O-Wisp"
+          ]
+        ]
+      }
+    ]
+  },
+  "toxapex": {
+    "usage": 7,
+    "sets": [
+      {
+        "species": "Toxapex",
+        "item": [
+          "Black Sludge"
+        ],
+        "ability": [
+          "Regenerator"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Scald"
+          ],
+          [
+            "Recover"
+          ],
+          [
+            "Haze"
+          ],
+          [
+            "Toxic",
+            "Baneful Bunker",
+            "Toxic Spikes"
+          ]
+        ]
+      }
+    ]
+  },
+  "grimmsnarl": {
+    "usage": 5,
+    "sets": [
+      {
+        "species": "Grimmsnarl",
+        "item": [
+          "Light Clay"
+        ],
+        "ability": [
+          "Prankster"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Impish",
+        "moves": [
+          [
+            "Light Screen"
+          ],
+          [
+            "Reflect"
+          ],
+          [
+            "Spirit Break"
+          ],
+          [
+            "Taunt",
+            "Thunder Wave"
+          ]
+        ]
+      },
+      {
+        "species": "Grimmsnarl-Gmax",
+        "item": [
+          "Lagging Tail"
+        ],
+        "ability": [
+          "Prankster"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "spd": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Trick"
+          ],
+          [
+            "Spirit Break"
+          ],
+          [
+            "Sucker Punch"
+          ],
+          [
+            "Substitute",
+            "Light Screen",
+            "Reflect"
+          ]
+        ]
+      },
+      {
+        "species": "Grimmsnarl-Gmax",
+        "item": [
+          "Sitrus Berry",
+          "Leftovers"
+        ],
+        "ability": [
+          "Prankster"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 4,
+          "spd": 252
+        },
+        "nature": "Careful",
+        "moves": [
+          [
+            "Sucker Punch",
+            "Darkest Lariat"
+          ],
+          [
+            "Spirit Break",
+            "Play Rough",
+            "Drain Punch"
+          ],
+          [
+            "Bulk Up"
+          ],
+          [
+            "Substitute",
+            "Thunder Wave"
+          ]
+        ]
+      }
+    ]
+  },
+  "tapukoko": {
+    "usage": 6,
+    "sets": [
+      {
+        "species": "Tapu Koko",
+        "item": [
+          "Choice Specs"
+        ],
+        "ability": [
+          "Electric Surge"
+        ],
+        "evs": {
+          "hp": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "moves": [
+          [
+            "Thunderbolt"
+          ],
+          [
+            "Dazzling Gleam"
+          ],
+          [
+            "Grass Knot"
+          ],
+          [
+            "Volt Switch"
+          ]
+        ]
+      },
+      {
+        "species": "Tapu Koko",
+        "item": [
+          "Light Clay"
+        ],
+        "ability": [
+          "Electric Surge"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "moves": [
+          [
+            "Reflect"
+          ],
+          [
+            "Light Screen"
+          ],
+          [
+            "Thunderbolt"
+          ],
+          [
+            "Taunt"
+          ]
+        ]
+      },
+      {
+        "species": "Tapu Koko",
+        "item": [
+          "Life Orb"
+        ],
+        "ability": [
+          "Electric Surge"
+        ],
+        "evs": {
+          "hp": 4,
+          "atk": 252,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Wild Charge"
+          ],
+          [
+            "Brave Bird"
+          ],
+          [
+            "U-turn"
+          ],
+          [
+            "Iron Head"
+          ]
+        ]
+      }
+    ]
+  },
+  "gyarados": {
+    "usage": 6,
+    "sets": [
+      {
+        "species": "Gyarados",
+        "item": [
+          "Wacan Berry",
+          "Lum Berry"
+        ],
+        "ability": [
+          "Moxie"
+        ],
+        "evs": {
+          "atk": 252,
+          "def": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Waterfall"
+          ],
+          [
+            "Bounce"
+          ],
+          [
+            "Power Whip"
+          ],
+          [
+            "Dragon Dance"
+          ]
+        ]
+      },
+      {
+        "species": "Gyarados",
+        "item": [
+          "Sitrus Berry"
+        ],
+        "ability": [
+          "Intimidate"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 156,
+          "spe": 100
+        },
+        "nature": "Impish",
+        "moves": [
+          [
+            "Waterfall"
+          ],
+          [
+            "Bounce"
+          ],
+          [
+            "Dragon Dance"
+          ],
+          [
+            "Taunt"
+          ]
+        ]
+      },
+      {
+        "species": "Gyarados",
+        "item": [
+          "Chesto Berry"
+        ],
+        "ability": [
+          "Intimidate"
+        ],
+        "evs": {
+          "atk": 252,
+          "def": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Waterfall"
+          ],
+          [
+            "Bounce"
+          ],
+          [
+            "Dragon Dance"
+          ],
+          [
+            "Rest"
+          ]
+        ]
+      }
+    ]
+  },
+  "lapras": {
+    "usage": 6,
+    "sets": [
+      {
+        "species": "Lapras-Gmax",
+        "item": [
+          "Weakness Policy"
+        ],
+        "ability": [
+          "Shell Armor"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 4,
+          "spa": 252
+        },
+        "nature": "Quiet",
+        "moves": [
+          [
+            "Freeze-Dry"
+          ],
+          [
+            "Ice Shard"
+          ],
+          [
+            "Thunder",
+            "Thunderbolt"
+          ],
+          [
+            "Sparkling Aria",
+            "Hydro Pump"
+          ]
+        ]
+      },
+      {
+        "species": "Lapras-Gmax",
+        "item": [
+          "Light Clay",
+          "Assault Vest"
+        ],
+        "ability": [
+          "Water Absorb"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 4,
+          "spa": 252
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Freeze-Dry"
+          ],
+          [
+            "Sheer Cold"
+          ],
+          [
+            "Thunderbolt"
+          ],
+          [
+            "Sparkling Aria"
+          ]
+        ]
+      }
+    ]
+  },
+  "darmanitan": {
+    "usage": 5,
+    "sets": [
+      {
+        "species": "Darmanitan-Galar",
+        "item": [
+          "Choice Scarf",
+          "Focus Sash"
+        ],
+        "ability": [
+          "Gorilla Tactics"
+        ],
+        "evs": {
+          "hp": 4,
+          "atk": 252,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Icicle Crash"
+          ],
+          [
+            "Flare Blitz"
+          ],
+          [
+            "Earthquake",
+            "Superpower"
+          ],
+          [
+            "U-turn"
+          ]
+        ]
+      },
+      {
+        "species": "Darmanitan-Galar",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Zen Mode"
+        ],
+        "evs": {
+          "hp": 4,
+          "atk": 252,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Icicle Crash"
+          ],
+          [
+            "Flare Blitz",
+            "Fire Punch"
+          ],
+          [
+            "Earthquake",
+            "Reversal"
+          ],
+          [
+            "Yawn"
+          ]
+        ]
+      }
+    ]
+  },
+  "thundurus": {
+    "usage": 6,
+    "sets": [
+      {
+        "species": "Thundurus-Therian",
+        "item": [
+          "Choice Specs",
+          "Assault Vest"
+        ],
+        "ability": [
+          "Volt Absorb"
+        ],
+        "evs": {
+          "def": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Thunderbolt"
+          ],
+          [
+            "Volt Switch"
+          ],
+          [
+            "Grass Knot"
+          ],
+          [
+            "Sludge Wave",
+            "Focus Blast"
+          ]
+        ]
+      },
+      {
+        "species": "Thundurus-Therian",
+        "item": [
+          "Sitrus Berry",
+          "Life Orb"
+        ],
+        "ability": [
+          "Volt Absorb"
+        ],
+        "evs": {
+          "def": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Thunderbolt"
+          ],
+          [
+            "Nasty Plot"
+          ],
+          [
+            "Grass Knot"
+          ],
+          [
+            "Flash Cannon",
+            "Dark Pulse"
+          ]
+        ]
+      },
+      {
+        "species": "Thundurus",
+        "item": [
+          "Sitrus Berry"
+        ],
+        "ability": [
+          "Prankster"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Volt Switch"
+          ],
+          [
+            "Taunt"
+          ],
+          [
+            "Thunder Wave"
+          ],
+          [
+            "Eerie Impulse"
+          ]
+        ]
+      },
+      {
+        "species": "Thundurus",
+        "item": [
+          "Life Orb"
+        ],
+        "ability": [
+          "Defiant"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Wild Charge"
+          ],
+          [
+            "Fly"
+          ],
+          [
+            "Superpower"
+          ],
+          [
+            "Bulk Up"
+          ]
+        ]
+      }
+    ]
+  },
+  "rhyperior": {
+    "usage": 5,
+    "sets": [
+      {
+        "species": "Rhyperior",
+        "item": [
+          "Weakness Policy"
+        ],
+        "ability": [
+          "Solid Rock"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "spd": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Earthquake"
+          ],
+          [
+            "Rock Blast"
+          ],
+          [
+            "Fire Punch"
+          ],
+          [
+            "Ice Punch",
+            "Swords Dance"
+          ]
+        ]
+      },
+      {
+        "species": "Rhyperior",
+        "item": [
+          "Assault Vest"
+        ],
+        "ability": [
+          "Solid Rock"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "spd": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Earthquake"
+          ],
+          [
+            "Rock Blast"
+          ],
+          [
+            "Fire Punch",
+            "Superpower"
+          ],
+          [
+            "Ice Punch"
+          ]
+        ]
+      }
+    ]
+  },
+  "suicune": {
+    "usage": 6,
+    "sets": [
+      {
+        "species": "Suicune",
+        "item": [
+          "Leftovers"
+        ],
+        "ability": [
+          "Pressure"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Scald"
+          ],
+          [
+            "Icy Wind",
+            "Ice Beam",
+            "Protect"
+          ],
+          [
+            "Substitute"
+          ],
+          [
+            "Calm Mind"
+          ]
+        ]
+      },
+      {
+        "species": "Suicune",
+        "item": [
+          "Chesto Berry"
+        ],
+        "ability": [
+          "Pressure"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Scald"
+          ],
+          [
+            "Icy Wind",
+            "Ice Beam",
+            "Sleep Talk"
+          ],
+          [
+            "Rest"
+          ],
+          [
+            "Calm Mind"
+          ]
+        ]
+      },
+      {
+        "species": "Suicune",
+        "item": [
+          "Weakness Policy",
+          "Life Orb",
+          "Sitrus Berry"
+        ],
+        "ability": [
+          "Pressure"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Hydro Pump"
+          ],
+          [
+            "Ice Beam"
+          ],
+          [
+            "Air Slash"
+          ],
+          [
+            "Calm Mind"
+          ]
+        ]
+      }
+    ]
+  },
+  "tapulele": {
+    "usage": 6,
+    "sets": [
+      {
+        "species": "Tapu Lele",
+        "item": [
+          "Choice Scarf",
+          "Choice Specs",
+          "Assault Vest"
+        ],
+        "ability": [
+          "Psychic Surge"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Psychic",
+            "Psyshock"
+          ],
+          [
+            "Moonblast"
+          ],
+          [
+            "Thunderbolt",
+            "Energy Ball"
+          ],
+          [
+            "Shadow Ball",
+            "Focus Blast"
+          ]
+        ]
+      },
+      {
+        "species": "Tapu Lele",
+        "item": [
+          "Life Orb",
+          "Leftovers",
+          "Focus Sash"
+        ],
+        "ability": [
+          "Psychic Surge"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Psychic",
+            "Psyshock"
+          ],
+          [
+            "Moonblast",
+            "Draining Kiss"
+          ],
+          [
+            "Calm Mind"
+          ],
+          [
+            "Focus Blast",
+            "Energy Ball",
+            "Thunderbolt",
+            "Shadow Ball"
+          ]
+        ]
+      }
+    ]
+  },
+  "latias": {
+    "usage": 5,
+    "sets": [
+      {
+        "species": "Latias",
+        "item": [
+          "Kee Berry",
+          "Leftovers"
+        ],
+        "ability": [
+          "Levitate"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Stored Power"
+          ],
+          [
+            "Substitute",
+            "Mystical Fire"
+          ],
+          [
+            "Calm Mind"
+          ],
+          [
+            "Recover"
+          ]
+        ]
+      },
+      {
+        "species": "Latias",
+        "item": [
+          "Weakness Policy"
+        ],
+        "ability": [
+          "Levitate"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Stored Power",
+            "Psychic",
+            "Psyshock"
+          ],
+          [
+            "Mystical Fire"
+          ],
+          [
+            "Air Slash"
+          ],
+          [
+            "Draco Meteor",
+            "Calm Mind"
+          ]
+        ]
+      }
+    ]
+  },
+  "ninetales": {
+    "usage": 3,
+    "sets": [
+      {
+        "species": "Ninetales-Alola",
+        "item": [
+          "Light Clay"
+        ],
+        "ability": [
+          "Snow Warning"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Blizzard"
+          ],
+          [
+            "Moonblast",
+            "Freeze-Dry",
+            "Icy Wind"
+          ],
+          [
+            "Aurora Veil"
+          ],
+          [
+            "Sheer Cold",
+            "Nasty Plot",
+            "Hypnosis"
+          ]
+        ]
+      }
+    ]
+  },
+  "mamoswine": {
+    "usage": 5,
+    "sets": [
+      {
+        "species": "Mamoswine",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Oblivious"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Icicle Spear"
+          ],
+          [
+            "Earthquake"
+          ],
+          [
+            "Rock Tomb",
+            "Ice Shard"
+          ],
+          [
+            "Stealth Rock"
+          ]
+        ]
+      },
+      {
+        "species": "Mamoswine",
+        "item": [
+          "Choice Scarf"
+        ],
+        "ability": [
+          "Oblivious"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Icicle Crash"
+          ],
+          [
+            "Earthquake"
+          ],
+          [
+            "Superpower"
+          ],
+          [
+            "Stone Edge"
+          ]
+        ]
+      },
+      {
+        "species": "Mamoswine",
+        "item": [
+          "Life Orb",
+          "Weakness Policy",
+          "Expert Belt"
+        ],
+        "ability": [
+          "Oblivious"
+        ],
+        "evs": {
+          "atk": 252,
+          "spa": 4,
+          "spe": 252
+        },
+        "nature": "Naive",
+        "moves": [
+          [
+            "Icicle Spear"
+          ],
+          [
+            "Earthquake"
+          ],
+          [
+            "Freeze-Dry"
+          ],
+          [
+            "Superpower"
+          ]
+        ]
+      },
+      {
+        "species": "Mamoswine",
+        "item": [
+          "Assault Vest"
+        ],
+        "ability": [
+          "Thick Fat"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Icicle Spear",
+            "Icicle Crash"
+          ],
+          [
+            "Earthquake"
+          ],
+          [
+            "Superpower",
+            "Ice Shard"
+          ],
+          [
+            "Stone Edge"
+          ]
+        ]
+      }
+    ]
+  },
+  "scizor": {
+    "usage": 3,
+    "sets": [
+      {
+        "species": "Scizor",
+        "item": [
+          "Choice Band"
+        ],
+        "ability": [
+          "Technician"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "spd": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "U-turn"
+          ],
+          [
+            "Bullet Punch"
+          ],
+          [
+            "Dual Wingbeat"
+          ],
+          [
+            "Superpower"
+          ]
+        ]
+      },
+      {
+        "species": "Scizor",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Technician"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "U-turn"
+          ],
+          [
+            "Bullet Punch"
+          ],
+          [
+            "Dual Wingbeat"
+          ],
+          [
+            "Counter"
+          ]
+        ]
+      },
+      {
+        "species": "Scizor",
+        "item": [
+          "Lum Berry",
+          "Life Orb",
+          "Sitrus Berry"
+        ],
+        "ability": [
+          "Technician"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Bullet Punch"
+          ],
+          [
+            "Dual Wingbeat"
+          ],
+          [
+            "Sand Tomb"
+          ],
+          [
+            "Swords Dance"
+          ]
+        ]
+      }
+    ]
+  },
+  "raikou": {
+    "usage": 6,
+    "sets": [
+      {
+        "species": "Raikou",
+        "item": [
+          "Leftovers"
+        ],
+        "ability": [
+          "Pressure"
+        ],
+        "evs": {
+          "def": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Thunderbolt"
+          ],
+          [
+            "Scald"
+          ],
+          [
+            "Substitute",
+            "Shadow Ball"
+          ],
+          [
+            "Calm Mind"
+          ]
+        ]
+      },
+      {
+        "species": "Raikou",
+        "item": [
+          "Choice Specs"
+        ],
+        "ability": [
+          "Pressure"
+        ],
+        "evs": {
+          "def": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Thunderbolt"
+          ],
+          [
+            "Scald"
+          ],
+          [
+            "Shadow Ball",
+            "Aura Sphere"
+          ],
+          [
+            "Volt Switch"
+          ]
+        ]
+      }
+    ]
+  },
+  "latios": {
+    "usage": 5,
+    "sets": [
+      {
+        "species": "Latios",
+        "item": [
+          "Choice Specs",
+          "Choice Scarf"
+        ],
+        "ability": [
+          "Levitate"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Draco Meteor"
+          ],
+          [
+            "Psychic",
+            "Psyshock"
+          ],
+          [
+            "Mystical Fire"
+          ],
+          [
+            "Trick",
+            "Air Slash",
+            "Ice Beam"
+          ]
+        ]
+      },
+      {
+        "species": "Latios",
+        "item": [
+          "Soul Dew",
+          "Weakness Policy",
+          "Life Orb"
+        ],
+        "ability": [
+          "Levitate"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Draco Meteor"
+          ],
+          [
+            "Psychic",
+            "Psyshock"
+          ],
+          [
+            "Mystical Fire",
+            "Aura Sphere"
+          ],
+          [
+            "Calm Mind",
+            "Air Slash"
+          ]
+        ]
+      },
+      {
+        "species": "Latios",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Levitate"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Psyshock",
+            "Psychic",
+            "Draco Meteor"
+          ],
+          [
+            "Mystical Fire"
+          ],
+          [
+            "Thunder Wave"
+          ],
+          [
+            "Memento"
+          ]
+        ]
+      }
+    ]
+  },
+  "whimsicott": {
+    "usage": 5,
+    "sets": [
+      {
+        "species": "Whimsicott",
+        "item": [
+          "Leftovers",
+          "Rocky Helmet"
+        ],
+        "ability": [
+          "Prankster"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Moonblast"
+          ],
+          [
+            "Leech Seed"
+          ],
+          [
+            "Substitute"
+          ],
+          [
+            "Cotton Guard"
+          ]
+        ]
+      },
+      {
+        "species": "Whimsicott",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Prankster"
+        ],
+        "evs": {
+          "def": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Moonblast"
+          ],
+          [
+            "Tailwind"
+          ],
+          [
+            "Memento"
+          ],
+          [
+            "Taunt"
+          ]
+        ]
+      },
+      {
+        "species": "Whimsicott",
+        "item": [
+          "Lagging Tail",
+          "Full Incense"
+        ],
+        "ability": [
+          "Prankster"
+        ],
+        "evs": {
+          "def": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Moonblast"
+          ],
+          [
+            "Switcheroo"
+          ],
+          [
+            "Memento"
+          ],
+          [
+            "Taunt"
+          ]
+        ]
+      }
+    ]
+  },
+  "azumarill": {
+    "usage": 5,
+    "sets": [
+      {
+        "species": "Azumarill",
+        "item": [
+          "Sitrus Berry"
+        ],
+        "ability": [
+          "Sap Sipper"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 164,
+          "spd": 92
+        },
+        "nature": "Sassy",
+        "ivs": {
+          "atk": 0,
+          "spe": 0
+        },
+        "moves": [
+          [
+            "Whirlpool"
+          ],
+          [
+            "Perish Song"
+          ],
+          [
+            "Protect"
+          ],
+          [
+            "Encore"
+          ]
+        ]
+      },
+      {
+        "species": "Azumarill",
+        "item": [
+          "Assault Vest"
+        ],
+        "ability": [
+          "Huge Power"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "spd": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Liquidation"
+          ],
+          [
+            "Play Rough"
+          ],
+          [
+            "Superpower"
+          ],
+          [
+            "Bounce",
+            "Aqua Jet"
+          ]
+        ]
+      },
+      {
+        "species": "Azumarill",
+        "item": [
+          "Sitrus Berry"
+        ],
+        "ability": [
+          "Huge Power"
+        ],
+        "evs": {
+          "hp": 228,
+          "atk": 252,
+          "def": 12,
+          "spd": 12,
+          "spe": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Aqua Jet"
+          ],
+          [
+            "Play Rough"
+          ],
+          [
+            "Superpower"
+          ],
+          [
+            "Belly Drum"
+          ]
+        ]
+      }
+    ]
+  },
+  "snorlax": {
+    "usage": 6,
+    "sets": [
+      {
+        "species": "Snorlax-Gmax",
+        "item": [
+          "Figy Berry",
+          "Custap Berry"
+        ],
+        "ability": [
+          "Gluttony"
+        ],
+        "evs": {
+          "atk": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Facade",
+            "Body Slam",
+            "Self-Destruct"
+          ],
+          [
+            "Earthquake"
+          ],
+          [
+            "Darkest Lariat",
+            "Heavy Slam",
+            "Heat Crash"
+          ],
+          [
+            "Curse",
+            "Belly Drum"
+          ]
+        ]
+      },
+      {
+        "species": "Snorlax-Gmax",
+        "item": [
+          "Figy Berry"
+        ],
+        "ability": [
+          "Gluttony"
+        ],
+        "evs": {
+          "atk": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Body Slam",
+            "Self-Destruct"
+          ],
+          [
+            "Yawn"
+          ],
+          [
+            "Fire Punch"
+          ],
+          [
+            "Protect"
+          ]
+        ]
+      },
+      {
+        "species": "Snorlax",
+        "item": [
+          "Assault Vest"
+        ],
+        "ability": [
+          "Thick Fat"
+        ],
+        "evs": {
+          "atk": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Body Slam"
+          ],
+          [
+            "Earthquake"
+          ],
+          [
+            "Brick Break",
+            "Heavy Slam"
+          ],
+          [
+            "Ice Punch",
+            "Heat Crash"
+          ]
+        ]
+      }
+    ]
+  },
+  "togekiss": {
+    "usage": 6,
+    "sets": [
+      {
+        "species": "Togekiss",
+        "item": [
+          "Sharp Beak",
+          "Life Orb"
+        ],
+        "ability": [
+          "Serene Grace"
+        ],
+        "evs": {
+          "hp": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Air Slash"
+          ],
+          [
+            "Dazzling Gleam"
+          ],
+          [
+            "Flamethrower"
+          ],
+          [
+            "Nasty Plot"
+          ]
+        ]
+      },
+      {
+        "species": "Togekiss",
+        "item": [
+          "Scope Lens"
+        ],
+        "ability": [
+          "Super Luck"
+        ],
+        "evs": {
+          "hp": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Air Slash"
+          ],
+          [
+            "Dazzling Gleam"
+          ],
+          [
+            "Flamethrower"
+          ],
+          [
+            "Ancient Power",
+            "Grass Knot"
+          ]
+        ]
+      },
+      {
+        "species": "Togekiss",
+        "item": [
+          "Choice Scarf"
+        ],
+        "ability": [
+          "Serene Grace"
+        ],
+        "evs": {
+          "hp": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Air Slash"
+          ],
+          [
+            "Dazzling Gleam"
+          ],
+          [
+            "Flamethrower"
+          ],
+          [
+            "Trick"
+          ]
+        ]
+      },
+      {
+        "species": "Togekiss",
+        "item": [
+          "Sitrus Berry"
+        ],
+        "ability": [
+          "Serene Grace"
+        ],
+        "evs": {
+          "hp": 244,
+          "def": 4,
+          "spa": 4,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Air Slash"
+          ],
+          [
+            "Morning Sun"
+          ],
+          [
+            "Mystical Fire"
+          ],
+          [
+            "Nasty Plot"
+          ]
+        ]
+      }
+    ]
+  },
+  "clefable": {
+    "usage": 5,
+    "sets": [
+      {
+        "species": "Clefable",
+        "item": [
+          "Kee Berry"
+        ],
+        "ability": [
+          "Unaware"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Moonblast"
+          ],
+          [
+            "Calm Mind",
+            "Cosmic Power",
+            "Minimize"
+          ],
+          [
+            "Moonlight"
+          ],
+          [
+            "Stored Power"
+          ]
+        ]
+      },
+      {
+        "species": "Clefable",
+        "item": [
+          "Flame Orb"
+        ],
+        "ability": [
+          "Magic Guard"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Moonblast"
+          ],
+          [
+            "Trick"
+          ],
+          [
+            "Stealth Rock"
+          ],
+          [
+            "Moonlight"
+          ]
+        ]
+      },
+      {
+        "species": "Clefable",
+        "item": [
+          "Life Orb",
+          "Power Herb"
+        ],
+        "ability": [
+          "Magic Guard"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spd": 4
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Moonblast"
+          ],
+          [
+            "Fire Blast"
+          ],
+          [
+            "Thunderbolt"
+          ],
+          [
+            "Meteor Beam"
+          ]
+        ]
+      }
+    ]
+  },
+  "quagsire": {
+    "usage": 2,
+    "sets": [
+      {
+        "species": "Quagsire",
+        "item": [
+          "Kee Berry",
+          "Sitrus Berry",
+          "Rocky Helmet"
+        ],
+        "ability": [
+          "Unaware"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Scald"
+          ],
+          [
+            "Toxic"
+          ],
+          [
+            "Recover"
+          ],
+          [
+            "Earth Power",
+            "Protect",
+            "Stockpile"
+          ]
+        ]
+      }
+    ]
+  },
+  "arctozolt": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Arctozolt",
+        "item": [
+          "Life Orb",
+          "Weakness Policy"
+        ],
+        "ability": [
+          "Slush Rush"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Bolt Beak"
+          ],
+          [
+            "Icicle Spear",
+            "Icicle Crash"
+          ],
+          [
+            "Low Kick",
+            "Stomping Tantrum"
+          ],
+          [
+            "Freeze-Dry",
+            "Thunder Wave"
+          ]
+        ]
+      }
+    ]
+  },
+  "aegislash": {
+    "usage": 5,
+    "sets": [
+      {
+        "species": "Aegislash",
+        "item": [
+          "Weakness Policy",
+          "Life Orb",
+          "Leftovers"
+        ],
+        "ability": [
+          "Stance Change"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "spd": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Shadow Sneak"
+          ],
+          [
+            "Iron Head",
+            "Sacred Sword"
+          ],
+          [
+            "Swords Dance"
+          ],
+          [
+            "King's Shield",
+            "Shadow Claw"
+          ]
+        ]
+      },
+      {
+        "species": "Aegislash",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Stance Change"
+        ],
+        "evs": {
+          "atk": 196,
+          "spa": 252,
+          "spe": 60
+        },
+        "nature": "Rash",
+        "moves": [
+          [
+            "Shadow Ball"
+          ],
+          [
+            "Close Combat"
+          ],
+          [
+            "Flash Cannon",
+            "Steel Beam"
+          ],
+          [
+            "Shadow Sneak"
+          ]
+        ]
+      },
+      {
+        "species": "Aegislash",
+        "item": [
+          "Weakness Policy"
+        ],
+        "ability": [
+          "Stance Change"
+        ],
+        "evs": {
+          "atk": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "nature": "Hasty",
+        "moves": [
+          [
+            "Flash Cannon"
+          ],
+          [
+            "Shadow Ball"
+          ],
+          [
+            "Air Slash"
+          ],
+          [
+            "Close Combat"
+          ]
+        ]
+      }
+    ]
+  },
+  "primarina": {
+    "usage": 4,
+    "sets": [
+      {
+        "species": "Primarina",
+        "item": [
+          "Assault Vest",
+          "Choice Specs"
+        ],
+        "ability": [
+          "Torrent"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 28,
+          "spa": 228
+        },
+        "ivs": {
+          "atk": 0
+        },
+        "nature": "Modest",
+        "moves": [
+          [
+            "Moonblast"
+          ],
+          [
+            "Sparkling Aria"
+          ],
+          [
+            "Energy Ball"
+          ],
+          [
+            "Psychic",
+            "Aqua Jet"
+          ]
+        ]
+      },
+      {
+        "species": "Primarina",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Torrent"
+        ],
+        "evs": {
+          "def": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "ivs": {
+          "atk": 0
+        },
+        "nature": "Modest",
+        "moves": [
+          [
+            "Moonblast"
+          ],
+          [
+            "Sparkling Aria"
+          ],
+          [
+            "Energy Ball"
+          ],
+          [
+            "Aqua Jet"
+          ]
+        ]
+      }
+    ]
+  },
+  "spectrier": {
+    "usage": 5,
+    "sets": [
+      {
+        "species": "Spectrier",
+        "item": [
+          "Life Orb",
+          "Lum Berry",
+          "Spell Tag"
+        ],
+        "ability": [
+          "Grim Neigh"
+        ],
+        "evs": {
+          "def": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "ivs": {
+          "atk": 0
+        },
+        "nature": "Timid",
+        "moves": [
+          [
+            "Shadow Ball"
+          ],
+          [
+            "Hyper Beam"
+          ],
+          [
+            "Nasty Plot"
+          ],
+          [
+            "Substitute",
+            "Dark Pulse",
+            "Will-O-Wisp",
+            "Mud Shot"
+          ]
+        ]
+      },
+      {
+        "species": "Spectrier",
+        "item": [
+          "Choice Scarf",
+          "Choice Specs"
+        ],
+        "ability": [
+          "Grim Neigh"
+        ],
+        "evs": {
+          "def": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "ivs": {
+          "atk": 0
+        },
+        "nature": "Timid",
+        "moves": [
+          [
+            "Shadow Ball"
+          ],
+          [
+            "Hyper Beam"
+          ],
+          [
+            "Dark Pulse"
+          ],
+          [
+            "Will-O-Wisp",
+            "Mud Shot"
+          ]
+        ]
+      }
+    ]
+  },
+  "corsola": {
+    "usage": 3,
+    "sets": [
+      {
+        "species": "Corsola-Galar",
+        "item": [
+          "Eviolite"
+        ],
+        "ability": [
+          "Cursed Body"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "ivs": {
+          "atk": 0
+        },
+        "nature": "Bold",
+        "moves": [
+          [
+            "Night Shade"
+          ],
+          [
+            "Strength Sap"
+          ],
+          [
+            "Will-O-Wisp"
+          ],
+          [
+            "Stealth Rock",
+            "Mirror Coat"
+          ]
+        ]
+      },
+      {
+        "species": "Corsola-Galar",
+        "item": [
+          "Eviolite"
+        ],
+        "ability": [
+          "Cursed Body"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "ivs": {
+          "atk": 0
+        },
+        "nature": "Bold",
+        "moves": [
+          [
+            "Hex"
+          ],
+          [
+            "Calm Mind"
+          ],
+          [
+            "Strength Sap"
+          ],
+          [
+            "Will-O-Wisp"
+          ]
+        ]
+      }
+    ]
+  },
+  "lucario": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Lucario",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Inner Focus"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Close Combat"
+          ],
+          [
+            "Meteor Mash"
+          ],
+          [
+            "Extreme Speed"
+          ],
+          [
+            "Ice Punch",
+            "Counter"
+          ]
+        ]
+      }
+    ]
+  },
+  "blissey": {
+    "usage": 5,
+    "sets": [
+      {
+        "species": "Blissey",
+        "item": [
+          "Leftovers"
+        ],
+        "ability": [
+          "Serene Grace"
+        ],
+        "evs": {
+          "def": 252,
+          "spa": 4,
+          "spd": 252
+        },
+        "ivs": {
+          "atk": 0
+        },
+        "nature": "Bold",
+        "moves": [
+          [
+            "Tri Attack"
+          ],
+          [
+            "Soft-Boiled"
+          ],
+          [
+            "Ice Beam",
+            "Flamethrower",
+            "Shadow Ball"
+          ],
+          [
+            "Calm Mind"
+          ]
+        ]
+      }
+    ]
+  },
+  "charizard": {
+    "usage": 2,
+    "sets": [
+      {
+        "species": "Charizard-Gmax",
+        "item": [
+          "Life Orb",
+          "Heavy-Duty Boots"
+        ],
+        "ability": [
+          "Blaze"
+        ],
+        "evs": {
+          "spa": 252,
+          "def": 4,
+          "spe": 252
+        },
+        "ivs": {
+          "atk": 0
+        },
+        "nature": "Timid",
+        "moves": [
+          [
+            "Blast Burn"
+          ],
+          [
+            "Air Slash",
+            "Hurricane"
+          ],
+          [
+            "Solar Beam"
+          ],
+          [
+            "Scorching Sands",
+            "Dragon Pulse"
+          ]
+        ]
+      },
+      {
+        "species": "Charizard",
+        "item": [
+          "Life Orb",
+          "Heavy-Duty Boots"
+        ],
+        "ability": [
+          "Solar Power"
+        ],
+        "evs": {
+          "spa": 252,
+          "def": 4,
+          "spe": 252
+        },
+        "ivs": {
+          "atk": 0
+        },
+        "nature": "Timid",
+        "moves": [
+          [
+            "Fire Blast",
+            "Flamethrower"
+          ],
+          [
+            "Air Slash"
+          ],
+          [
+            "Solar Beam"
+          ],
+          [
+            "Scorching Sands",
+            "Dragon Pulse"
+          ]
+        ]
+      }
+    ]
+  },
+  "corviknight": {
+    "usage": 5,
+    "sets": [
+      {
+        "species": "Corviknight",
+        "item": [
+          "Rocky Helmet"
+        ],
+        "ability": [
+          "Mirror Armor"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Impish",
+        "moves": [
+          [
+            "Brave Bird"
+          ],
+          [
+            "Body Press"
+          ],
+          [
+            "Iron Defense"
+          ],
+          [
+            "Roost"
+          ]
+        ]
+      },
+      {
+        "species": "Corviknight",
+        "item": [
+          "Weakness Policy"
+        ],
+        "ability": [
+          "Mirror Armor"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Brave Bird"
+          ],
+          [
+            "Iron Head"
+          ],
+          [
+            "Bulk Up"
+          ],
+          [
+            "Roost"
+          ]
+        ]
+      },
+      {
+        "species": "Corviknight",
+        "item": [
+          "Maranga Berry"
+        ],
+        "ability": [
+          "Pressure"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 4,
+          "spd": 252
+        },
+        "nature": "Careful",
+        "moves": [
+          [
+            "Brave Bird"
+          ],
+          [
+            "Taunt",
+            "Iron Head"
+          ],
+          [
+            "Bulk Up"
+          ],
+          [
+            "Roost"
+          ]
+        ]
+      }
+    ]
+  },
+  "gengar": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Gengar-Gmax",
+        "item": [
+          "Focus Sash",
+          "Wide Lens"
+        ],
+        "ability": [
+          "Cursed Body"
+        ],
+        "evs": {
+          "spa": 252,
+          "def": 4,
+          "spe": 252
+        },
+        "ivs": {
+          "atk": 0
+        },
+        "nature": "Timid",
+        "moves": [
+          [
+            "Shadow Ball",
+            "Hex"
+          ],
+          [
+            "Sludge Wave"
+          ],
+          [
+            "Icy Wind",
+            "Destiny Bond"
+          ],
+          [
+            "Hypnosis",
+            "Will-O-Wisp"
+          ]
+        ]
+      }
+    ]
+  },
+  "uxie": {
+    "usage": 2,
+    "sets": [
+      {
+        "species": "Uxie",
+        "item": [
+          "Sitrus Berry",
+          "Mental Herb"
+        ],
+        "ability": [
+          "Levitate"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spe": 4
+        },
+        "nature": "Bold",
+        "moves": [
+          [
+            "Stealth Rock"
+          ],
+          [
+            "Yawn"
+          ],
+          [
+            "Memento"
+          ],
+          [
+            "Trick Room",
+            "U-turn"
+          ]
+        ]
+      }
+    ]
+  },
+  "arcanine": {
+    "usage": 2,
+    "sets": [
+      {
+        "species": "Arcanine",
+        "item": [
+          "Sitrus Berry",
+          "Rocky Helmet"
+        ],
+        "ability": [
+          "Intimidate"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spe": 4
+        },
+        "nature": "Bold",
+        "moves": [
+          [
+            "Flamethrower"
+          ],
+          [
+            "Morning Sun"
+          ],
+          [
+            "Will-O-Wisp"
+          ],
+          [
+            "Snarl",
+            "Burn Up",
+            "Dragon Pulse"
+          ]
+        ]
+      },
+      {
+        "species": "Arcanine",
+        "item": [
+          "Assault Vest",
+          "Choice Band",
+          "Life Orb"
+        ],
+        "ability": [
+          "Intimidate"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Flare Blitz"
+          ],
+          [
+            "Extreme Speed"
+          ],
+          [
+            "Wild Charge"
+          ],
+          [
+            "Play Rough",
+            "Close Combat"
+          ]
+        ]
+      }
+    ]
+  },
+  "chansey": {
+    "usage": 3,
+    "sets": [
+      {
+        "species": "Chansey",
+        "item": [
+          "Eviolite"
+        ],
+        "ability": [
+          "Natural Cure"
+        ],
+        "evs": {
+          "def": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Bold",
+        "moves": [
+          [
+            "Soft-Boiled"
+          ],
+          [
+            "Seismic Toss"
+          ],
+          [
+            "Thunder Wave"
+          ],
+          [
+            "Stealth Rock",
+            "Substitute"
+          ]
+        ]
+      }
+    ]
+  },
+  "buzzwole": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Buzzwole",
+        "item": [
+          "Life Orb",
+          "Expert Belt",
+          "Choice Scarf"
+        ],
+        "ability": [
+          "Beast Boost"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Close Combat"
+          ],
+          [
+            "Ice Punch"
+          ],
+          [
+            "Dual Wingbeat"
+          ],
+          [
+            "Thunder Punch",
+            "Earthquake",
+            "Leech Life"
+          ]
+        ]
+      }
+    ]
+  },
+  "sylveon": {
+    "usage": 4,
+    "sets": [
+      {
+        "species": "Sylveon",
+        "item": [
+          "Pixie Plate",
+          "Leftovers",
+          "Throat Spray"
+        ],
+        "ability": [
+          "Pixilate"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spd": 4
+        },
+        "nature": "Modest",
+        "moves": [
+          [
+            "Hyper Voice"
+          ],
+          [
+            "Mystical Fire"
+          ],
+          [
+            "Yawn"
+          ],
+          [
+            "Quick Attack",
+            "Calm Mind"
+          ]
+        ]
+      }
+    ]
+  },
+  "gastrodon": {
+    "usage": 3,
+    "sets": [
+      {
+        "species": "Gastrodon",
+        "item": [
+          "Focus Sash",
+          "Sitrus Berry",
+          "Leftovers"
+        ],
+        "ability": [
+          "Storm Drain"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Recover"
+          ],
+          [
+            "Scald"
+          ],
+          [
+            "Counter"
+          ],
+          [
+            "Mirror Coat"
+          ]
+        ]
+      },
+      {
+        "species": "Gastrodon",
+        "item": [
+          "Sitrus Berry",
+          "Leftovers",
+          "Rindo Berry"
+        ],
+        "ability": [
+          "Storm Drain"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Recover"
+          ],
+          [
+            "Scald"
+          ],
+          [
+            "Yawn"
+          ],
+          [
+            "Earth Power",
+            "Clear Smog",
+            "Ice Beam"
+          ]
+        ]
+      }
+    ]
+  },
+  "reuniclus": {
+    "usage": 2,
+    "sets": [
+      {
+        "species": "Reuniclus",
+        "item": [
+          "Kee Berry",
+          "Leftovers"
+        ],
+        "ability": [
+          "Magic Guard"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spa": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Calm Mind"
+          ],
+          [
+            "Recover"
+          ],
+          [
+            "Stored Power",
+            "Psyshock"
+          ],
+          [
+            "Thunder",
+            "Energy Ball"
+          ]
+        ]
+      },
+      {
+        "species": "Reuniclus",
+        "item": [
+          "Life Orb"
+        ],
+        "ability": [
+          "Magic Guard"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spd": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Psychic"
+          ],
+          [
+            "Focus Blast",
+            "Shadow Ball"
+          ],
+          [
+            "Trick Room"
+          ],
+          [
+            "Recover",
+            "Thunder",
+            "Energy Ball"
+          ]
+        ]
+      },
+      {
+        "species": "Reuniclus",
+        "item": [
+          "Flame Orb"
+        ],
+        "ability": [
+          "Magic Guard"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spa": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Calm Mind"
+          ],
+          [
+            "Recover"
+          ],
+          [
+            "Stored Power",
+            "Psyshock"
+          ],
+          [
+            "Trick"
+          ]
+        ]
+      }
+    ]
+  },
+  "ditto": {
+    "usage": 4,
+    "sets": [
+      {
+        "species": "Ditto",
+        "item": [
+          "Choice Scarf",
+          "Focus Sash"
+        ],
+        "ability": [
+          "Imposter"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 4,
+          "def": 252
+        },
+        "ivs": {
+          "atk": 0,
+          "spe": 0
+        },
+        "nature": "Relaxed",
+        "moves": [
+          [
+            "Transform"
+          ]
+        ]
+      }
+    ]
+  },
+  "goodra": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Goodra",
+        "item": [
+          "Assault Vest"
+        ],
+        "ability": [
+          "Sap Sipper"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 4,
+          "spa": 252
+        },
+        "nature": "Modest",
+        "moves": [
+          [
+            "Dragon Pulse",
+            "Draco Meteor"
+          ],
+          [
+            "Flamethrower"
+          ],
+          [
+            "Acid Spray"
+          ],
+          [
+            "Thunderbolt",
+            "Power Whip"
+          ]
+        ]
+      }
+    ]
+  },
+  "weavile": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Weavile",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Pickpocket"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Triple Axel"
+          ],
+          [
+            "Ice Shard"
+          ],
+          [
+            "Poison Jab",
+            "Throat Chop",
+            "Brick Break"
+          ],
+          [
+            "Counter"
+          ]
+        ]
+      },
+      {
+        "species": "Weavile",
+        "item": [
+          "Choice Band"
+        ],
+        "ability": [
+          "Pressure"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Triple Axel"
+          ],
+          [
+            "Ice Shard"
+          ],
+          [
+            "Throat Chop"
+          ],
+          [
+            "Poison Jab"
+          ]
+        ]
+      }
+    ]
+  },
+  "entei": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Entei",
+        "item": [
+          "Assault Vest",
+          "Choice Band"
+        ],
+        "ability": [
+          "Inner Focus"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Sacred Fire"
+          ],
+          [
+            "Extreme Speed"
+          ],
+          [
+            "Stone Edge"
+          ],
+          [
+            "Bulldoze",
+            "Stomping Tantrum",
+            "Iron Head"
+          ]
+        ]
+      }
+    ]
+  },
+  "milotic": {
+    "usage": 2,
+    "sets": [
+      {
+        "species": "Milotic",
+        "item": [
+          "Flame Orb",
+          "Sitrus Berry",
+          "Leftovers"
+        ],
+        "ability": [
+          "Marvel Scale"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Scald"
+          ],
+          [
+            "Ice Beam",
+            "Icy Wind"
+          ],
+          [
+            "Recover"
+          ],
+          [
+            "Mirror Coat",
+            "Haze"
+          ]
+        ]
+      },
+      {
+        "species": "Milotic",
+        "item": [
+          "Sitrus Berry",
+          "Adrenaline Orb"
+        ],
+        "ability": [
+          "Competitive"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spd": 4
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Hydro Pump"
+          ],
+          [
+            "Ice Beam"
+          ],
+          [
+            "Recover"
+          ],
+          [
+            "Mud Shot",
+            "Mirror Coat"
+          ]
+        ]
+      }
+    ]
+  },
+  "hatterene": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Hatterene-Gmax",
+        "item": [
+          "Focus Sash",
+          "Life Orb"
+        ],
+        "ability": [
+          "Magic Bounce"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 4,
+          "spa": 252
+        },
+        "nature": "Quiet",
+        "ivs": {
+          "atk": 0,
+          "spe": 0
+        },
+        "moves": [
+          [
+            "Trick Room"
+          ],
+          [
+            "Psychic"
+          ],
+          [
+            "Dazzling Gleam",
+            "Misty Explosion"
+          ],
+          [
+            "Mystical Fire"
+          ]
+        ]
+      },
+      {
+        "species": "Hatterene-Gmax",
+        "item": [
+          "Big Root"
+        ],
+        "ability": [
+          "Magic Bounce"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spa": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0,
+          "spe": 0
+        },
+        "moves": [
+          [
+            "Psyshock"
+          ],
+          [
+            "Draining Kiss"
+          ],
+          [
+            "Giga Drain"
+          ],
+          [
+            "Calm Mind"
+          ]
+        ]
+      }
+    ]
+  },
+  "inteleon": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Inteleon-Gmax",
+        "item": [
+          "Scope Lens"
+        ],
+        "ability": [
+          "Sniper"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Hydro Pump",
+            "Scald",
+            "Snipe Shot",
+            "Hydro Cannon"
+          ],
+          [
+            "Ice Beam"
+          ],
+          [
+            "Air Slash"
+          ],
+          [
+            "Focus Energy"
+          ]
+        ]
+      },
+      {
+        "species": "Inteleon-Gmax",
+        "item": [
+          "Focus Sash",
+          "Petaya Berry"
+        ],
+        "ability": [
+          "Torrent"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Hydro Pump",
+            "Scald",
+            "Snipe Shot"
+          ],
+          [
+            "Ice Beam"
+          ],
+          [
+            "Air Slash"
+          ],
+          [
+            "Substitute"
+          ]
+        ]
+      }
+    ]
+  },
+  "marowak": {
+    "usage": 3,
+    "sets": [
+      {
+        "species": "Marowak-Alola",
+        "item": [
+          "Thick Club"
+        ],
+        "ability": [
+          "Lightning Rod"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "spd": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Flare Blitz"
+          ],
+          [
+            "Poltergeist",
+            "Shadow Bone"
+          ],
+          [
+            "Bonemerang"
+          ],
+          [
+            "Swords Dance"
+          ]
+        ]
+      }
+    ]
+  },
+  "slowking": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Slowking-Galar",
+        "item": [
+          "Black Sludge"
+        ],
+        "ability": [
+          "Regenerator"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spd": 4
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Psyshock",
+            "Eerie Spell"
+          ],
+          [
+            "Sludge Bomb"
+          ],
+          [
+            "Flamethrower"
+          ],
+          [
+            "Calm Mind"
+          ]
+        ]
+      },
+      {
+        "species": "Slowking-Galar",
+        "item": [
+          "Assault Vest"
+        ],
+        "ability": [
+          "Regenerator"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spd": 4
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Psyshock",
+            "Eerie Spell"
+          ],
+          [
+            "Sludge Bomb"
+          ],
+          [
+            "Flamethrower"
+          ],
+          [
+            "Ice Beam"
+          ]
+        ]
+      }
+    ]
+  },
+  "cloyster": {
+    "usage": 3,
+    "sets": [
+      {
+        "species": "Cloyster",
+        "item": [
+          "Focus Sash",
+          "King's Rock"
+        ],
+        "ability": [
+          "Skill Link"
+        ],
+        "evs": {
+          "atk": 252,
+          "def": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Shell Smash"
+          ],
+          [
+            "Icicle Spear"
+          ],
+          [
+            "Rock Blast"
+          ],
+          [
+            "Ice Shard"
+          ]
+        ]
+      }
+    ]
+  },
+  "aggron": {
+    "usage": 2,
+    "sets": [
+      {
+        "species": "Aggron",
+        "item": [
+          "Custap Berry"
+        ],
+        "ability": [
+          "Sturdy"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "spd": 4
+        },
+        "nature": "Brave",
+        "ivs": {
+          "spe": 0
+        },
+        "moves": [
+          [
+            "Metal Burst"
+          ],
+          [
+            "Endeavor"
+          ],
+          [
+            "Head Smash",
+            "Rock Tomb"
+          ],
+          [
+            "Stealth Rock"
+          ]
+        ]
+      }
+    ]
+  },
+  "xurkitree": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Xurkitree",
+        "item": [
+          "Choice Scarf"
+        ],
+        "ability": [
+          "Beast Boost"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Volt Switch"
+          ],
+          [
+            "Thunderbolt"
+          ],
+          [
+            "Energy Ball"
+          ],
+          [
+            "Dazzling Gleam"
+          ]
+        ]
+      },
+      {
+        "species": "Xurkitree",
+        "item": [
+          "Blunder Policy"
+        ],
+        "ability": [
+          "Beast Boost"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Zap Cannon"
+          ],
+          [
+            "Hypnosis"
+          ],
+          [
+            "Energy Ball"
+          ],
+          [
+            "Dazzling Gleam"
+          ]
+        ]
+      }
+    ]
+  },
+  "seismitoad": {
+    "usage": 4,
+    "sets": [
+      {
+        "species": "Seismitoad",
+        "item": [
+          "Life Orb",
+          "Mystic Water",
+          "Assault Vest",
+          "Rindo Berry"
+        ],
+        "ability": [
+          "Swift Swim"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Hydro Pump"
+          ],
+          [
+            "Earth Power"
+          ],
+          [
+            "Grass Knot"
+          ],
+          [
+            "Sludge Wave"
+          ]
+        ]
+      },
+      {
+        "species": "Seismitoad",
+        "item": [
+          "Life Orb",
+          "Mystic Water",
+          "Assault Vest",
+          "Rindo Berry"
+        ],
+        "ability": [
+          "Swift Swim"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Liquidation"
+          ],
+          [
+            "Earthquake"
+          ],
+          [
+            "Power Whip"
+          ],
+          [
+            "Drain Punch"
+          ]
+        ]
+      },
+      {
+        "species": "Seismitoad",
+        "item": [
+          "Leftovers",
+          "Sitrus Berry"
+        ],
+        "ability": [
+          "Water Absorb"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 4,
+          "spd": 252
+        },
+        "nature": "Calm",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Scald"
+          ],
+          [
+            "Earth Power",
+            "Icy Wind"
+          ],
+          [
+            "Stealth Rock"
+          ],
+          [
+            "Toxic"
+          ]
+        ]
+      }
+    ]
+  },
+  "pyukumuku": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Pyukumuku",
+        "item": [
+          "Sitrus Berry",
+          "Rocky Helmet",
+          "Leftovers"
+        ],
+        "ability": [
+          "Unaware"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Toxic"
+          ],
+          [
+            "Counter"
+          ],
+          [
+            "Mirror Coat",
+            "Soak"
+          ],
+          [
+            "Recover"
+          ]
+        ]
+      }
+    ]
+  },
+  "espeon": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Espeon",
+        "item": [
+          "Light Clay"
+        ],
+        "ability": [
+          "Magic Bounce"
+        ],
+        "evs": {
+          "def": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "ivs": {
+          "atk": 0
+        },
+        "nature": "Timid",
+        "moves": [
+          [
+            "Psychic"
+          ],
+          [
+            "Reflect"
+          ],
+          [
+            "Light Screen"
+          ],
+          [
+            "Yawn"
+          ]
+        ]
+      }
+    ]
+  },
+  "nidoking": {
+    "usage": 2,
+    "sets": [
+      {
+        "species": "Nidoking",
+        "item": [
+          "Focus Sash",
+          "Life Orb"
+        ],
+        "ability": [
+          "Sheer Force"
+        ],
+        "evs": {
+          "def": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "moves": [
+          [
+            "Sludge Wave"
+          ],
+          [
+            "Earth Power"
+          ],
+          [
+            "Ice Beam"
+          ],
+          [
+            "Flamethrower",
+            "Thunderbolt",
+            "Sucker Punch"
+          ]
+        ]
+      },
+      {
+        "species": "Nidoking",
+        "item": [
+          "Choice Scarf"
+        ],
+        "ability": [
+          "Sheer Force"
+        ],
+        "evs": {
+          "def": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Sludge Wave"
+          ],
+          [
+            "Earth Power"
+          ],
+          [
+            "Ice Beam"
+          ],
+          [
+            "Flamethrower",
+            "Thunderbolt"
+          ]
+        ]
+      }
+    ]
+  },
+  "skarmory": {
+    "usage": 4,
+    "sets": [
+      {
+        "species": "Skarmory",
+        "item": [
+          "Rocky Helmet"
+        ],
+        "ability": [
+          "Sturdy"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Impish",
+        "moves": [
+          [
+            "Brave Bird"
+          ],
+          [
+            "Body Press"
+          ],
+          [
+            "Iron Defense"
+          ],
+          [
+            "Roost"
+          ]
+        ]
+      },
+      {
+        "species": "Skarmory",
+        "item": [
+          "Custap Berry"
+        ],
+        "ability": [
+          "Sturdy"
+        ],
+        "evs": {
+          "atk": 252,
+          "def": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Brave Bird"
+          ],
+          [
+            "Rock Tomb"
+          ],
+          [
+            "Stealth Rock"
+          ],
+          [
+            "Taunt"
+          ]
+        ]
+      }
+    ]
+  },
+  "chandelure": {
+    "usage": 2,
+    "sets": [
+      {
+        "species": "Chandelure",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Infiltrator"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spd": 4
+        },
+        "nature": "Quiet",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Flamethrower",
+            "Overheat"
+          ],
+          [
+            "Shadow Ball"
+          ],
+          [
+            "Trick Room"
+          ],
+          [
+            "Memento"
+          ]
+        ]
+      },
+      {
+        "species": "Chandelure",
+        "item": [
+          "Choice Scarf"
+        ],
+        "ability": [
+          "Infiltrator"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spd": 4
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Flamethrower",
+            "Overheat"
+          ],
+          [
+            "Shadow Ball"
+          ],
+          [
+            "Energy Ball"
+          ],
+          [
+            "Trick"
+          ]
+        ]
+      }
+    ]
+  },
+  "umbreon": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Umbreon",
+        "item": [
+          "Leftovers",
+          "Rocky Helmet"
+        ],
+        "ability": [
+          "Synchronize"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Foul Play"
+          ],
+          [
+            "Yawn"
+          ],
+          [
+            "Wish"
+          ],
+          [
+            "Protect"
+          ]
+        ]
+      }
+    ]
+  },
+  "regirock": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Regirock",
+        "item": [
+          "Weakness Policy",
+          "Assault Vest"
+        ],
+        "ability": [
+          "Clear Body"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "def": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Stone Edge"
+          ],
+          [
+            "Earthquake"
+          ],
+          [
+            "Ice Punch"
+          ],
+          [
+            "Body Press",
+            "Drain Punch",
+            "Explosion"
+          ]
+        ]
+      },
+      {
+        "species": "Regirock",
+        "item": [
+          "Custap Berry"
+        ],
+        "ability": [
+          "Sturdy"
+        ],
+        "evs": {
+          "atk": 252,
+          "def": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Stone Edge"
+          ],
+          [
+            "Earthquake",
+            "Body Press",
+            "Explosion"
+          ],
+          [
+            "Stealth Rock"
+          ],
+          [
+            "Thunder Wave"
+          ]
+        ]
+      }
+    ]
+  },
+  "torkoal": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Torkoal",
+        "item": [
+          "Eject Pack"
+        ],
+        "ability": [
+          "Drought"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spa": 4
+        },
+        "nature": "Relaxed",
+        "moves": [
+          [
+            "Overheat"
+          ],
+          [
+            "Yawn"
+          ],
+          [
+            "Stealth Rock"
+          ],
+          [
+            "Body Press",
+            "Solar Beam",
+            "Earth Power"
+          ]
+        ]
+      }
+    ]
+  },
+  "tornadus": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Tornadus-Therian",
+        "item": [
+          "Life Orb",
+          "Sharp Beak",
+          "Expert Belt"
+        ],
+        "ability": [
+          "Regenerator"
+        ],
+        "evs": {
+          "def": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "spe": 0
+        },
+        "moves": [
+          [
+            "Hurricane"
+          ],
+          [
+            "Heat Wave"
+          ],
+          [
+            "Icy Wind"
+          ],
+          [
+            "Nasty Plot"
+          ]
+        ]
+      }
+    ]
+  },
+  "stakataka": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Stakataka",
+        "item": [
+          "Assault Vest"
+        ],
+        "ability": [
+          "Beast Boost"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "spd": 4
+        },
+        "nature": "Brave",
+        "ivs": {
+          "spe": 0
+        },
+        "moves": [
+          [
+            "Rock Blast"
+          ],
+          [
+            "Body Press"
+          ],
+          [
+            "Gyro Ball"
+          ],
+          [
+            "Earthquake"
+          ]
+        ]
+      },
+      {
+        "species": "Stakataka",
+        "item": [
+          "Focus Sash",
+          "Air Balloon",
+          "Chople Berry"
+        ],
+        "ability": [
+          "Beast Boost"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "spd": 4
+        },
+        "nature": "Brave",
+        "ivs": {
+          "spe": 0
+        },
+        "moves": [
+          [
+            "Rock Blast"
+          ],
+          [
+            "Gyro Ball"
+          ],
+          [
+            "Body Press",
+            "Earthquake"
+          ],
+          [
+            "Trick Room"
+          ]
+        ]
+      }
+    ]
+  },
+  "diggersby": {
+    "usage": 5,
+    "sets": [
+      {
+        "species": "Diggersby",
+        "item": [
+          "Focus Sash",
+          "Custap Berry"
+        ],
+        "ability": [
+          "Huge Power"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Earthquake"
+          ],
+          [
+            "Quick Attack"
+          ],
+          [
+            "Flail"
+          ],
+          [
+            "Endure"
+          ]
+        ]
+      },
+      {
+        "species": "Diggersby",
+        "item": [
+          "Life Orb",
+          "Lum Berry"
+        ],
+        "ability": [
+          "Huge Power"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Earthquake"
+          ],
+          [
+            "Giga Impact",
+            "Swords Dance"
+          ],
+          [
+            "Bounce"
+          ],
+          [
+            "Fire Punch",
+            "Ice Punch"
+          ]
+        ]
+      }
+    ]
+  },
+  "articuno": {
+    "usage": 3,
+    "sets": [
+      {
+        "species": "Articuno-Galar",
+        "item": [
+          "Kee Berry",
+          "Weakness Policy"
+        ],
+        "ability": [
+          "Competitive"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Freezing Glare",
+            "Stored Power"
+          ],
+          [
+            "Hurricane"
+          ],
+          [
+            "Calm Mind"
+          ],
+          [
+            "Recover"
+          ]
+        ]
+      }
+    ]
+  },
+  "incineroar": {
+    "usage": 3,
+    "sets": [
+      {
+        "species": "Incineroar",
+        "item": [
+          "Figy Berry"
+        ],
+        "ability": [
+          "Intimidate"
+        ],
+        "evs": {
+          "hp": 252,
+          "atk": 252,
+          "spd": 4
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Flare Blitz"
+          ],
+          [
+            "Darkest Lariat"
+          ],
+          [
+            "Will-O-Wisp"
+          ],
+          [
+            "Parting Shot",
+            "U-turn"
+          ]
+        ]
+      }
+    ]
+  },
+  "lycanroc": {
+    "usage": 4,
+    "sets": [
+      {
+        "species": "Lycanroc-Dusk",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Tough Claws"
+        ],
+        "evs": {
+          "hp": 4,
+          "atk": 252,
+          "spe": 252
+        },
+        "nature": "Adamant",
+        "moves": [
+          [
+            "Close Combat"
+          ],
+          [
+            "Stealth Rock"
+          ],
+          [
+            "Counter"
+          ],
+          [
+            "Accelerock"
+          ]
+        ]
+      }
+    ]
+  },
+  "hydreigon": {
+    "usage": 3,
+    "sets": [
+      {
+        "species": "Hydreigon",
+        "item": [
+          "Choice Scarf",
+          "Choice Specs"
+        ],
+        "ability": [
+          "Levitate"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "moves": [
+          [
+            "Dark Pulse"
+          ],
+          [
+            "Draco Meteor"
+          ],
+          [
+            "Fire Blast",
+            "Flash Cannon"
+          ],
+          [
+            "U-turn"
+          ]
+        ]
+      },
+      {
+        "species": "Hydreigon",
+        "item": [
+          "Salac Berry",
+          "Leftovers"
+        ],
+        "ability": [
+          "Levitate"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Dark Pulse"
+          ],
+          [
+            "Fire Blast",
+            "Flash Cannon"
+          ],
+          [
+            "Nasty Plot"
+          ],
+          [
+            "Substitute"
+          ]
+        ]
+      }
+    ]
+  },
+  "volcarona": {
+    "usage": 4,
+    "sets": [
+      {
+        "species": "Volcarona",
+        "item": [
+          "Life Orb",
+          "Heavy-Duty Boots",
+          "Lum Berry"
+        ],
+        "ability": [
+          "Flame Body"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Fiery Dance"
+          ],
+          [
+            "Quiver Dance"
+          ],
+          [
+            "Giga Drain"
+          ],
+          [
+            "Bug Buzz",
+            "Hurricane",
+            "Psychic"
+          ]
+        ]
+      },
+      {
+        "species": "Volcarona",
+        "item": [
+          "Weakness Policy"
+        ],
+        "ability": [
+          "Flame Body"
+        ],
+        "evs": {
+          "hp": 4,
+          "def": 28,
+          "spa": 220,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Fire Blast"
+          ],
+          [
+            "Giga Drain"
+          ],
+          [
+            "Hurricane"
+          ],
+          [
+            "Hyper Beam"
+          ]
+        ]
+      },
+      {
+        "species": "Volcarona",
+        "item": [
+          "Throat Spray"
+        ],
+        "ability": [
+          "Swarm"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Bug Buzz"
+          ],
+          [
+            "Quiver Dance"
+          ],
+          [
+            "Fiery Dance"
+          ],
+          [
+            "Substitute"
+          ]
+        ]
+      }
+    ]
+  },
+  "scolipede": {
+    "usage": 3,
+    "sets": [
+      {
+        "species": "Scolipede",
+        "item": [
+          "Maranga Berry"
+        ],
+        "ability": [
+          "Speed Boost"
+        ],
+        "evs": {
+          "hp": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Protect"
+          ],
+          [
+            "Earthquake",
+            "Poison Jab"
+          ],
+          [
+            "Iron Defense"
+          ],
+          [
+            "Baton Pass"
+          ]
+        ]
+      },
+      {
+        "species": "Scolipede",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Speed Boost"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Poison Jab"
+          ],
+          [
+            "Earthquake"
+          ],
+          [
+            "Swords Dance"
+          ],
+          [
+            "Baton Pass"
+          ]
+        ]
+      },
+      {
+        "species": "Scolipede",
+        "item": [
+          "Iapapa Berry"
+        ],
+        "ability": [
+          "Speed Boost"
+        ],
+        "evs": {
+          "hp": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Toxic"
+          ],
+          [
+            "Substitute"
+          ],
+          [
+            "Iron Defense"
+          ],
+          [
+            "Baton Pass"
+          ]
+        ]
+      }
+    ]
+  },
+  "aurorus": {
+    "usage": 2,
+    "sets": [
+      {
+        "species": "Aurorus",
+        "item": [
+          "Focus Sash",
+          "Custap Berry"
+        ],
+        "ability": [
+          "Snow Warning"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 4,
+          "spa": 252
+        },
+        "ivs": {
+          "atk": 0
+        },
+        "nature": "Modest",
+        "moves": [
+          [
+            "Freeze-Dry",
+            "Blizzard"
+          ],
+          [
+            "Aurora Veil"
+          ],
+          [
+            "Stealth Rock"
+          ],
+          [
+            "Thunder Wave"
+          ]
+        ]
+      }
+    ]
+  },
+  "haxorus": {
+    "usage": 3,
+    "sets": [
+      {
+        "species": "Haxorus",
+        "item": [
+          "Choice Scarf"
+        ],
+        "ability": [
+          "Mold Breaker"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Outrage"
+          ],
+          [
+            "Earthquake"
+          ],
+          [
+            "Iron Tail"
+          ],
+          [
+            "Close Combat"
+          ]
+        ]
+      },
+      {
+        "species": "Haxorus",
+        "item": [
+          "Life Orb",
+          "Lum Berry"
+        ],
+        "ability": [
+          "Mold Breaker"
+        ],
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Jolly",
+        "moves": [
+          [
+            "Outrage"
+          ],
+          [
+            "Earthquake"
+          ],
+          [
+            "Iron Tail"
+          ],
+          [
+            "Dragon Dance"
+          ]
+        ]
+      }
+    ]
+  },
+  "cradily": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Cradily",
+        "item": [
+          "Power Herb"
+        ],
+        "ability": [
+          "Storm Drain"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spd": 4
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Meteor Beam"
+          ],
+          [
+            "Giga Drain"
+          ],
+          [
+            "Earth Power"
+          ],
+          [
+            "Recover",
+            "Leech Seed"
+          ]
+        ]
+      }
+    ]
+  },
+  "kingdra": {
+    "usage": 4,
+    "sets": [
+      {
+        "species": "Kingdra",
+        "item": [
+          "Life Orb"
+        ],
+        "ability": [
+          "Swift Swim"
+        ],
+        "evs": {
+          "hp": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "ivs": {
+          "atk": 0
+        },
+        "nature": "Timid",
+        "moves": [
+          [
+            "Hurricane"
+          ],
+          [
+            "Hydro Pump"
+          ],
+          [
+            "Draco Meteor"
+          ],
+          [
+            "Yawn"
+          ]
+        ]
+      },
+      {
+        "species": "Kingdra",
+        "item": [
+          "Scope Lens"
+        ],
+        "ability": [
+          "Sniper"
+        ],
+        "evs": {
+          "hp": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "ivs": {
+          "atk": 0
+        },
+        "nature": "Timid",
+        "moves": [
+          [
+            "Hurricane"
+          ],
+          [
+            "Hydro Pump"
+          ],
+          [
+            "Draco Meteor"
+          ],
+          [
+            "Focus Energy"
+          ]
+        ]
+      }
+    ]
+  },
+  "regidrago": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Regidrago",
+        "item": [
+          "Choice Scarf"
+        ],
+        "ability": [
+          "Dragon's Maw"
+        ],
+        "nature": "Timid",
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Dragon Energy"
+          ],
+          [
+            "Draco Meteor"
+          ],
+          [
+            "Ancient Power"
+          ],
+          [
+            "Hyper Beam"
+          ]
+        ]
+      },
+      {
+        "species": "Regidrago",
+        "item": [
+          "Lum Berry"
+        ],
+        "ability": [
+          "Dragon's Maw"
+        ],
+        "nature": "Jolly",
+        "evs": {
+          "atk": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "moves": [
+          [
+            "Outrage"
+          ],
+          [
+            "Fire Fang",
+            "Thunder Fang"
+          ],
+          [
+            "Dragon Dance"
+          ],
+          [
+            "Explosion"
+          ]
+        ]
+      }
+    ]
+  },
+  "porygonz": {
+    "usage": 4,
+    "sets": [
+      {
+        "species": "Porygon-Z",
+        "item": [
+          "Choice Scarf"
+        ],
+        "ability": [
+          "Adaptability"
+        ],
+        "evs": {
+          "def": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Hyper Beam"
+          ],
+          [
+            "Tri Attack"
+          ],
+          [
+            "Dark Pulse",
+            "Ice Beam"
+          ],
+          [
+            "Trick"
+          ]
+        ]
+      },
+      {
+        "species": "Porygon-Z",
+        "item": [
+          "Chople Berry",
+          "Life Orb"
+        ],
+        "ability": [
+          "Adaptability"
+        ],
+        "evs": {
+          "def": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Hyper Beam"
+          ],
+          [
+            "Dark Pulse"
+          ],
+          [
+            "Thunderbolt",
+            "Ice Beam",
+            "Solar Beam"
+          ],
+          [
+            "Nasty Plot"
+          ]
+        ]
+      }
+    ]
+  },
+  "pelipper": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Pelipper",
+        "item": [
+          "Damp Rock"
+        ],
+        "ability": [
+          "Drizzle"
+        ],
+        "nature": "Relaxed",
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "moves": [
+          [
+            "Hurricane"
+          ],
+          [
+            "Scald"
+          ],
+          [
+            "Roost"
+          ],
+          [
+            "U-turn"
+          ]
+        ]
+      },
+      {
+        "species": "Pelipper",
+        "item": [
+          "Focus Sash",
+          "Choice Specs"
+        ],
+        "ability": [
+          "Drizzle"
+        ],
+        "nature": "Modest",
+        "evs": {
+          "hp": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "moves": [
+          [
+            "Hurricane"
+          ],
+          [
+            "Hydro Pump"
+          ],
+          [
+            "Ice Beam"
+          ],
+          [
+            "U-turn"
+          ]
+        ]
+      }
+    ]
+  },
+  "comfey": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Comfey",
+        "item": [
+          "Kee Berry",
+          "Big Root"
+        ],
+        "ability": [
+          "Triage"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Bold",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Draining Kiss"
+          ],
+          [
+            "Leech Seed"
+          ],
+          [
+            "Synthesis"
+          ],
+          [
+            "Giga Drain",
+            "Charm",
+            "Protect"
+          ]
+        ]
+      }
+    ]
+  },
+  "toxtricity": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Toxtricity",
+        "item": [
+          "Assault Vest"
+        ],
+        "ability": [
+          "Punk Rock"
+        ],
+        "evs": {
+          "hp": 108,
+          "spa": 252,
+          "spe": 148
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Overdrive"
+          ],
+          [
+            "Nuzzle"
+          ],
+          [
+            "Boomburst"
+          ],
+          [
+            "Hex"
+          ]
+        ]
+      },
+      {
+        "species": "Toxtricity-Gmax",
+        "item": [
+          "Throat Spray"
+        ],
+        "ability": [
+          "Punk Rock"
+        ],
+        "evs": {
+          "spa": 252,
+          "spd": 4,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Overdrive"
+          ],
+          [
+            "Sludge Wave"
+          ],
+          [
+            "Boomburst"
+          ],
+          [
+            "Shift Gear"
+          ]
+        ]
+      }
+    ]
+  },
+  "duraludon": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Duraludon",
+        "item": [
+          "Assault Vest"
+        ],
+        "ability": [
+          "Light Metal"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spd": 4
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Draco Meteor"
+          ],
+          [
+            "Flash Cannon"
+          ],
+          [
+            "Thunderbolt"
+          ],
+          [
+            "Rock Tomb"
+          ]
+        ]
+      },
+      {
+        "species": "Duraludon",
+        "item": [
+          "Weakness Policy"
+        ],
+        "ability": [
+          "Light Metal"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spd": 4
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Draco Meteor"
+          ],
+          [
+            "Flash Cannon"
+          ],
+          [
+            "Thunderbolt"
+          ],
+          [
+            "Solar Beam"
+          ]
+        ]
+      },
+      {
+        "species": "Duraludon",
+        "item": [
+          "Focus Sash"
+        ],
+        "ability": [
+          "Light Metal"
+        ],
+        "evs": {
+          "hp": 4,
+          "spa": 252,
+          "spe": 252
+        },
+        "nature": "Timid",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Steel Beam"
+          ],
+          [
+            "Mirror Coat",
+            "Thunder Wave"
+          ],
+          [
+            "Reflect"
+          ],
+          [
+            "Stealth Rock"
+          ]
+        ]
+      }
+    ]
+  },
+  "avalugg": {
+    "usage": 2,
+    "sets": [
+      {
+        "species": "Avalugg",
+        "item": [
+          "Rocky Helmet",
+          "Custap Berry"
+        ],
+        "ability": [
+          "Sturdy"
+        ],
+        "evs": {
+          "hp": 252,
+          "def": 252,
+          "spd": 4
+        },
+        "nature": "Relaxed",
+        "moves": [
+          [
+            "Icicle Spear"
+          ],
+          [
+            "Body Press"
+          ],
+          [
+            "Recover"
+          ],
+          [
+            "Iron Defense",
+            "Mirror Coat"
+          ]
+        ]
+      }
+    ]
+  },
+  "slowbro": {
+    "usage": 1,
+    "sets": [
+      {
+        "species": "Slowbro-Galar",
+        "item": [
+          "Quick Claw"
+        ],
+        "ability": [
+          "Quick Draw"
+        ],
+        "evs": {
+          "hp": 252,
+          "spa": 252,
+          "spd": 4
+        },
+        "nature": "Modest",
+        "ivs": {
+          "atk": 0
+        },
+        "moves": [
+          [
+            "Shell Side Arm"
+          ],
+          [
+            "Psyshock",
+            "Expanding Force"
+          ],
+          [
+            "Flamethrower"
+          ],
+          [
+            "Nasty Plot"
+          ]
+        ]
+      }
+    ]
+  }
+}

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -902,7 +902,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		const priorityPool = [];
 		for (const curSet of setList) {
 			const itemData = this.dex.getItem(curSet.item);
-			if (teamData.megaCount > 0 && itemData.megaStone) continue; // reject 2+ mega stones
+			if (teamData.megaCount && teamData.megaCount > 0 && itemData.megaStone) continue; // reject 2+ mega stones
 			if (itemsMax[itemData.id] && teamData.has[itemData.id] >= itemsMax[itemData.id]) continue;
 
 			const abilityData = this.dex.getAbility(curSet.ability);
@@ -994,6 +994,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			if (teamData.baseFormes[species.baseSpecies]) continue;
 
 			// Limit the number of Megas to one
+			if (!teamData.megaCount) teamData.megaCount = 0;
 			if (teamData.megaCount >= 1 && speciesFlags.megaOnly) continue;
 
 			// Limit 2 of any type

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1235,7 +1235,7 @@ export class RandomGen7Teams extends RandomTeams {
 		const priorityPool = [];
 		for (const curSet of setList) {
 			const item = this.dex.getItem(curSet.item);
-			if (teamData.megaCount > 0 && item.megaStone) continue; // reject 2+ mega stones
+			if (teamData.megaCount && teamData.megaCount > 0 && item.megaStone) continue; // reject 2+ mega stones
 			if (teamData.zCount && teamData.zCount > 0 && item.zMove) continue; // reject 2+ Z stones
 			if (itemsMax[item.id] && teamData.has[item.id] >= itemsMax[item.id]) continue;
 
@@ -1362,6 +1362,7 @@ export class RandomGen7Teams extends RandomTeams {
 			if (teamData.baseFormes[species.baseSpecies]) continue;
 
 			// Limit the number of Megas to one
+			if (!teamData.megaCount) teamData.megaCount = 0;
 			if (teamData.megaCount >= 1 && speciesFlags.megaOnly) continue;
 
 			const set = this.randomFactorySet(species, teamData, chosenTier);
@@ -1518,7 +1519,7 @@ export class RandomGen7Teams extends RandomTeams {
 		const priorityPool = [];
 		for (const curSet of setList) {
 			const item = this.dex.getItem(curSet.item);
-			if (teamData.megaCount > 1 && item.megaStone) continue; // reject 3+ mega stones
+			if (teamData.megaCount && teamData.megaCount > 1 && item.megaStone) continue; // reject 3+ mega stones
 			if (teamData.zCount && teamData.zCount > 1 && item.zMove) continue; // reject 3+ Z stones
 			if (teamData.has[item.id]) continue; // Item clause
 
@@ -1610,6 +1611,7 @@ export class RandomGen7Teams extends RandomTeams {
 			if (!species.exists) continue;
 
 			const speciesFlags = this.randomBSSFactorySets[species.id].flags;
+			if (!teamData.megaCount) teamData.megaCount = 0;
 
 			// Limit to one of each species (Species Clause)
 			if (teamData.baseFormes[species.baseSpecies]) continue;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -7,7 +7,7 @@ export interface TeamData {
 	typeCount: {[k: string]: number};
 	typeComboCount: {[k: string]: number};
 	baseFormes: {[k: string]: number};
-	megaCount: number;
+	megaCount?: number;
 	zCount?: number;
 	has: {[k: string]: number};
 	forceResult: boolean;
@@ -15,6 +15,7 @@ export interface TeamData {
 	resistances: {[k: string]: number};
 	weather?: string;
 	eeveeLimCount?: number;
+	gigantamax?: boolean;
 }
 
 export class RandomTeams {
@@ -1632,6 +1633,233 @@ export class RandomTeams {
 			};
 			pokemon.push(set);
 		}
+		return pokemon;
+	}
+
+	randomBSSFactorySets: AnyObject = require('./bss-factory-sets.json');
+
+	randomBSSFactorySet(
+		species: Species, teamData: RandomTeamsTypes.FactoryTeamDetails
+	): RandomTeamsTypes.RandomFactorySet | null {
+		const id = toID(species.name);
+		const setList = this.randomBSSFactorySets[id].sets;
+
+		const movesMax: {[k: string]: number} = {
+			batonpass: 1,
+			stealthrock: 1,
+			toxicspikes: 1,
+			trickroom: 1,
+			auroraveil: 1,
+		};
+
+		const requiredMoves: {[k: string]: number} = {};
+
+		// Build a pool of eligible sets, given the team partners
+		// Also keep track of sets with moves the team requires
+		let effectivePool: {set: AnyObject, moveVariants?: number[], itemVariants?: number, abilityVariants?: number}[] = [];
+		const priorityPool = [];
+		for (const curSet of setList) {
+			let reject = false;
+			let hasRequiredMove = false;
+			const curSetMoveVariants = [];
+			for (const move of curSet.moves) {
+				const variantIndex = this.random(move.length);
+				const moveId = toID(move[variantIndex]);
+				if (movesMax[moveId] && teamData.has[moveId] >= movesMax[moveId]) {
+					reject = true;
+					break;
+				}
+				if (requiredMoves[moveId] && !teamData.has[requiredMoves[moveId]]) {
+					hasRequiredMove = true;
+				}
+				curSetMoveVariants.push(variantIndex);
+			}
+			if (reject) continue;
+			const set = {set: curSet, moveVariants: curSetMoveVariants};
+			effectivePool.push(set);
+			if (hasRequiredMove) priorityPool.push(set);
+		}
+		if (priorityPool.length) effectivePool = priorityPool;
+
+		if (!effectivePool.length) {
+			if (!teamData.forceResult) return null;
+			for (const curSet of setList) {
+				effectivePool.push({set: curSet});
+			}
+		}
+
+		const setData = this.sample(effectivePool);
+		const moves = [];
+		for (const [i, moveSlot] of setData.set.moves.entries()) {
+			moves.push(setData.moveVariants ? moveSlot[setData.moveVariants[i]] : this.sample(moveSlot));
+		}
+
+		const isGmax: boolean = setData.set.species.includes("-Gmax");
+
+		return {
+			name: setData.set.nickname || setData.set.name || species.baseSpecies,
+			species: isGmax ? species.baseSpecies : setData.set.species,
+			gigantamax: isGmax,
+			gender: setData.set.gender || species.gender || (this.randomChance(1, 2) ? 'M' : 'F'),
+			item: (Array.isArray(setData.set.item) ? this.sample(setData.set.item) : setData.set.itemy) || '',
+			ability: (Array.isArray(setData.set.ability) ? this.sample(setData.set.ability) : setData.set.ability) || species.abilities['0'],
+			shiny: typeof setData.set.shiny === 'undefined' ? this.randomChance(1, 1024) : setData.set.shiny,
+			level: setData.set.level || 50,
+			happiness: typeof setData.set.happiness === 'undefined' ? 255 : setData.set.happiness,
+			evs: {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0, ...setData.set.evs},
+			ivs: {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31, ...setData.set.ivs},
+			nature: setData.set.nature || 'Serious',
+			moves: moves,
+		};
+	}
+
+	randomBSSFactoryTeam(side: PlayerOptions, depth = 0): RandomTeamsTypes.RandomFactorySet[] {
+		const forceResult = (depth >= 4);
+
+		const pokemon = [];
+
+		const pokemonPool = Object.keys(this.randomBSSFactorySets);
+
+		const teamData: TeamData = {
+			typeCount: {}, typeComboCount: {}, baseFormes: {}, has: {}, forceResult: forceResult,
+			weaknesses: {}, resistances: {},
+		};
+		const requiredMoveFamilies: string[] = [];
+		const requiredMoves: {[k: string]: string} = {};
+		const weatherAbilitiesSet: {[k: string]: string} = {
+			drizzle: 'raindance',
+			drought: 'sunnyday',
+			snowwarning: 'hail',
+			sandstream: 'sandstorm',
+		};
+		const resistanceAbilities: {[k: string]: string[]} = {
+			waterabsorb: ['Water'],
+			flashfire: ['Fire'],
+			lightningrod: ['Electric'], voltabsorb: ['Electric'],
+			thickfat: ['Ice', 'Fire'],
+			levitate: ['Ground'],
+		};
+
+		while (pokemonPool.length && pokemon.length < 6) {
+			// Weighted random sampling
+			let maxUsage = 0;
+			const sets: {[k: string]: number} = {};
+			for (const specie of pokemonPool) {
+				if (teamData.baseFormes[this.dex.getSpecies(specie).baseSpecies]) continue; // Species Clause
+				const usage: number = this.randomBSSFactorySets[specie].usage;
+				sets[specie] = usage + maxUsage;
+				maxUsage += usage;
+			}
+
+			const usage = this.random(1, maxUsage);
+			let last = 0;
+			let specie;
+			for (const key of Object.keys(sets)) {
+				 if (usage > last && usage <= sets[key]) {
+					 specie = key;
+					 break;
+				 }
+				 last = sets[key];
+			}
+
+			const species = this.dex.getSpecies(specie);
+			if (!species.exists) continue;
+
+			// Limit to one of each species (Species Clause)
+			if (teamData.baseFormes[species.baseSpecies]) continue;
+
+			// Limit 2 of any type (most of the time)
+			const types = species.types;
+			let skip = false;
+			for (const type of types) {
+				if (teamData.typeCount[type] > 1 && this.randomChance(4, 5)) {
+					skip = true;
+					break;
+				}
+			}
+			if (skip) continue;
+
+			const set = this.randomBSSFactorySet(species, teamData);
+			if (!set) continue;
+
+			// Limit 1 of any type combination
+			let typeCombo = types.slice().sort().join();
+			if (set.ability === 'Drought' || set.ability === 'Drizzle') {
+				// Drought and Drizzle don't count towards the type combo limit
+				typeCombo = set.ability;
+			}
+			if (typeCombo in teamData.typeComboCount) continue;
+
+			const itemData = this.dex.getItem(set.item);
+			if (teamData.has[itemData.id]) continue;
+
+			// Okay, the set passes, add it to our team
+			pokemon.push(set);
+
+			// Now that our Pokemon has passed all checks, we can update team data:
+			for (const type of types) {
+				if (type in teamData.typeCount) {
+					teamData.typeCount[type]++;
+				} else {
+					teamData.typeCount[type] = 1;
+				}
+			}
+			teamData.typeComboCount[typeCombo] = 1;
+
+			teamData.baseFormes[species.baseSpecies] = 1;
+
+			teamData.has[itemData.id] = 1;
+
+			const abilityData = this.dex.getAbility(set.ability);
+			if (abilityData.id in weatherAbilitiesSet) {
+				teamData.weather = weatherAbilitiesSet[abilityData.id];
+			}
+
+			for (const move of set.moves) {
+				const moveId = toID(move);
+				if (moveId in teamData.has) {
+					teamData.has[moveId]++;
+				} else {
+					teamData.has[moveId] = 1;
+				}
+				if (moveId in requiredMoves) {
+					teamData.has[requiredMoves[moveId]] = 1;
+				}
+			}
+
+			for (const typeName in this.dex.data.TypeChart) {
+				// Cover any major weakness (3+) with at least one resistance
+				if (teamData.resistances[typeName] >= 1) continue;
+				if (
+					resistanceAbilities[abilityData.id] && resistanceAbilities[abilityData.id].includes(typeName) ||
+					!this.dex.getImmunity(typeName, types)
+				) {
+					// Heuristic: assume that Pokémon with these abilities don't have (too) negative typing.
+					teamData.resistances[typeName] = (teamData.resistances[typeName] || 0) + 1;
+					if (teamData.resistances[typeName] >= 1) teamData.weaknesses[typeName] = 0;
+					continue;
+				}
+				const typeMod = this.dex.getEffectiveness(typeName, types);
+				if (typeMod < 0) {
+					teamData.resistances[typeName] = (teamData.resistances[typeName] || 0) + 1;
+					if (teamData.resistances[typeName] >= 1) teamData.weaknesses[typeName] = 0;
+				} else if (typeMod > 0) {
+					teamData.weaknesses[typeName] = (teamData.weaknesses[typeName] || 0) + 1;
+				}
+			}
+		}
+		if (pokemon.length < 6) return this.randomBSSFactoryTeam(side, ++depth);
+
+		// Quality control
+		if (!teamData.forceResult) {
+			for (const requiredFamily of requiredMoveFamilies) {
+				if (!teamData.has[requiredFamily]) return this.randomBSSFactoryTeam(side, ++depth);
+			}
+			for (const type in teamData.weaknesses) {
+				if (teamData.weaknesses[type] >= 3) return this.randomBSSFactoryTeam(side, ++depth);
+			}
+		}
+
 		return pokemon;
 	}
 }

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1701,7 +1701,7 @@ export class RandomTeams {
 			species: isGmax ? species.baseSpecies : setData.set.species,
 			gigantamax: isGmax,
 			gender: setData.set.gender || species.gender || (this.randomChance(1, 2) ? 'M' : 'F'),
-			item: (Array.isArray(setData.set.item) ? this.sample(setData.set.item) : setData.set.itemy) || '',
+			item: (Array.isArray(setData.set.item) ? this.sample(setData.set.item) : setData.set.item) || '',
 			ability: (Array.isArray(setData.set.ability) ? this.sample(setData.set.ability) : setData.set.ability) || species.abilities['0'],
 			shiny: typeof setData.set.shiny === 'undefined' ? this.randomChance(1, 1024) : setData.set.shiny,
 			level: setData.set.level || 50,
@@ -1791,7 +1791,7 @@ export class RandomTeams {
 			if (typeCombo in teamData.typeComboCount) continue;
 
 			const itemData = this.dex.getItem(set.item);
-			if (teamData.has[itemData.id]) continue;
+			if (teamData.has[itemData.id]) continue; // Item Clause
 
 			// Okay, the set passes, add it to our team
 			pokemon.push(set);

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1694,12 +1694,10 @@ export class RandomTeams {
 			moves.push(setData.moveVariants ? moveSlot[setData.moveVariants[i]] : this.sample(moveSlot));
 		}
 
-		const isGmax: boolean = setData.set.species.includes("-Gmax");
-
 		return {
 			name: setData.set.nickname || setData.set.name || species.baseSpecies,
-			species: isGmax ? species.baseSpecies : setData.set.species,
-			gigantamax: isGmax,
+			species: setData.set.species,
+			gigantamax: setData.set.gigantamax,
 			gender: setData.set.gender || species.gender || (this.randomChance(1, 2) ? 'M' : 'F'),
 			item: (Array.isArray(setData.set.item) ? this.sample(setData.set.item) : setData.set.item) || '',
 			ability: (Array.isArray(setData.set.ability) ? this.sample(setData.set.ability) : setData.set.ability) || species.abilities['0'],

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -504,7 +504,7 @@ namespace RandomTeamsTypes {
 		statusCure?: number;
 	}
 	export interface FactoryTeamDetails {
-		megaCount: number;
+		megaCount?: number;
 		zCount?: number;
 		forceResult: boolean;
 		weather?: string;
@@ -514,6 +514,7 @@ namespace RandomTeamsTypes {
 		has: {[k: string]: number};
 		weaknesses: {[k: string]: number};
 		resistances: {[k: string]: number};
+		gigantamax?: boolean;
 	}
 	export interface RandomSet {
 		name: string;
@@ -543,5 +544,6 @@ namespace RandomTeamsTypes {
 		ivs: SparseStatsTable;
 		nature: string;
 		moves: string[];
+		gigantamax?: boolean;
 	}
 }

--- a/tools/build-utils.js
+++ b/tools/build-utils.js
@@ -225,6 +225,7 @@ exports.transpile = (doForce) => {
 	}
 
 	// sucrase doesn't copy JSON over, so we'll have to do it ourselves
+	copyOverDataJSON('bss-factory-sets.json');
 	copyOverDataJSON('cap-1v1-sets.json');
 	copyOverDataJSON('mods/gen7/factory-sets.json');
 	copyOverDataJSON('mods/gen7/bss-factory-sets.json');


### PR DESCRIPTION
@ACakeWearingAHat and @cantsay wanted me to try and get this open before the end of the year, so here it is! Relevant smogon thread will be un-deleted once this is merged.

Most copy-paste from last gen's BSS Factory with updated sets, though I've used weighted random sampling (based off viability) in an attempt to create "better" teams, unlike previous Factory implementations (at the request of the vast majority of the playerbase). Thanks to xfix for giving Kala the idea, it only took me 2 years to figure out how to implement it 😅 

It's also my first time properly working with TypeScript so please let me know if I goofed anything up, though `full-test` passes fine on my machine.