### PR TITLE
Dexsearch: Add Strength Sap & Jungle Healing to list of recovery moves

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -697,8 +697,8 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			if (target === 'recovery') {
 				if (parameters.length > 1) return {error: "The parameter 'recovery' cannot have alternative parameters"};
 				const recoveryMoves = [
-					"recover", "roost", "moonlight", "morningsun", "synthesis", "milkdrink",
-					"slackoff", "softboiled", "wish", "healorder", "shoreup", "lifedew",
+					"healorder", "junglehealing", "lifedew", "milkdrink", "moonlight", "morningsun", "recover",
+					"roost", "shoreup", "slackoff", "softboiled", "strengthsap", "synthesis", "wish",
 				];
 				for (const move of recoveryMoves) {
 					const invalid = validParameter("moves", move, isNotSearch, target);


### PR DESCRIPTION
Both are viable recovery moves (from what I saw on smogdex analyses, at least), they should be added to the list of possible recovery moves. I also alphabetized this list on top of adding the new elements.