### PR TITLE
Fix move-disabling mechanics for dynamaxed Pokemon

### DIFF
--- a/data/scripts.ts
+++ b/data/scripts.ts
@@ -72,10 +72,6 @@ export const Scripts: BattleScriptsData = {
 			if (!lockedMove) {
 				if (!pokemon.deductPP(baseMove, null, target) && (move.id !== 'struggle')) {
 					this.add('cant', pokemon, 'nopp', move);
-					const gameConsole = [
-						null, 'Game Boy', 'Game Boy Color', 'Game Boy Advance', 'DS', 'DS', '3DS', '3DS',
-					][this.gen] || 'Switch';
-					this.hint(`This is not a bug, this is really how it works on the ${gameConsole}; try it yourself if you don't believe us.`);
 					this.clearActiveMove(true);
 					pokemon.moveThisTurnResult = false;
 					return;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -840,7 +840,9 @@ export class Pokemon {
 			}
 			let disabled = moveSlot.disabled;
 			if (this.volatiles['dynamax']) {
-				disabled = this.maxMoveDisabled(this.battle.dex.getMove(moveSlot.id));
+				// if each of a Pokemon's base moves are disabled by one of these effects, it will Struggle
+				const canCauseStruggle = ['Encore', 'Disable', 'Taunt', 'Assault Vest', 'Belch', 'Stuff Cheeks'];
+				disabled = this.maxMoveDisabled(moveSlot.id) || disabled && canCauseStruggle.includes(moveSlot.disabledSource!);
 			} else if (
 				(moveSlot.pp <= 0 && !this.volatiles['partialtrappinglock']) || disabled &&
 				this.side.active.length >= 2 && this.battle.targetTypeChoices(target!)
@@ -866,8 +868,11 @@ export class Pokemon {
 		return hasValidMove ? moves : [];
 	}
 
-	maxMoveDisabled(move: Move) {
-		return !!(move.category === 'Status' && (this.hasItem('assaultvest') || this.volatiles['taunt']));
+	/** This should be passed the base move and not the corresponding max move so we can check how much PP is left. */
+	maxMoveDisabled(baseMove: Move | string) {
+		baseMove = this.battle.dex.getMove(baseMove);
+		if (!this.getMoveData(baseMove.id)?.pp) return true;
+		return !!(baseMove.category === 'Status' && (this.hasItem('assaultvest') || this.volatiles['taunt']));
 	}
 
 	getDynamaxRequest(skipChecks?: boolean) {
@@ -889,7 +894,7 @@ export class Pokemon {
 			const move = this.battle.dex.getMove(moveSlot.id);
 			const maxMove = this.battle.getMaxMove(move, this);
 			if (maxMove) {
-				if (this.maxMoveDisabled(maxMove)) {
+				if (this.maxMoveDisabled(move)) {
 					result.maxMoves.push({move: maxMove.id, target: maxMove.target, disabled: true});
 				} else {
 					result.maxMoves.push({move: maxMove.id, target: maxMove.target});
@@ -945,7 +950,7 @@ export class Pokemon {
 			if (this.trapped) data.trapped = true;
 		}
 
-		if (!lockedMove) {
+		if (!lockedMove || lockedMove === 'struggle') {
 			if (this.canMegaEvo) data.canMegaEvo = true;
 			if (this.canUltraBurst) data.canUltraBurst = true;
 			const canZMove = this.battle.canZMove(this);
@@ -1376,7 +1381,7 @@ export class Pokemon {
 		for (const moveSlot of this.moveSlots) {
 			if (moveSlot.id === moveid && moveSlot.disabled !== true) {
 				moveSlot.disabled = (isHidden || true);
-				moveSlot.disabledSource = (sourceEffect ? sourceEffect.fullname : '');
+				moveSlot.disabledSource = (sourceEffect?.fullname || moveSlot.move);
 			}
 		}
 	}

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -467,8 +467,8 @@ export class Side {
 			if (this.battle.gen <= 4) this.send('-activate', pokemon, 'move: Struggle');
 			moveid = 'struggle';
 		} else if (maxMove) {
-			// Dynamaxed; only Taunt and Assault Vest disable Max Guard
-			if (pokemon.maxMoveDisabled(maxMove)) {
+			// Dynamaxed; only Taunt and Assault Vest disable Max Guard, but the base move must have PP remaining
+			if (pokemon.maxMoveDisabled(move)) {
 				return this.emitChoiceError(`Can't move: ${pokemon.name}'s ${maxMove.name} is disabled`);
 			}
 		} else if (!zMove) {

--- a/test/sim/misc/dynamax.js
+++ b/test/sim/misc/dynamax.js
@@ -119,16 +119,47 @@ describe("Dynamax", function () {
 		assert.cantMove(() => battle.choose('p1', 'move splash dynamax'));
 	});
 
-	it.skip(`should not allow the user to select max moves with 0 base PP remaining`, function () {
+	it(`should not allow the user to select max moves with 0 base PP remaining`, function () {
 		battle = common.createBattle([[
 			{species: 'pichu', ability: 'prankster', level: 1, moves: ['grudge']},
-			{species: 'wynaut', moves: ['sleeptalk']},
+			{species: 'noibat', ability: 'prankster', level: 1, moves: ['grudge']},
+			{species: 'azurill', moves: ['sleeptalk']},
 		], [
-			{species: 'wynaut', moves: ['earthquake', 'sleeptalk']},
+			{species: 'wynaut', moves: ['earthquake', 'icebeam']},
 		]]);
 
 		battle.makeChoices('auto', 'move earthquake dynamax');
 		battle.makeChoices();
-		assert.cantMove(() => battle.p2.chooseMove(1), 'wynaut', 'earthquake', true);
+		assert.cantMove(() => battle.p2.chooseMove('earthquake'), 'wynaut', 'Max Quake');
+		battle.makeChoices(); // Noibat uses Grudge and Wynaut uses Max Hailstorm
+		assert.fainted(battle.p1.active[0]);
+		battle.makeChoices();
+		assert.cantMove(() => battle.p2.chooseMove('icebeam'), 'wynaut', 'icebeam');
+		battle.makeChoices('auto', 'move struggle'); // will throw an error if Wynaut isn't forced to use Struggle
+	});
+
+	it(`should force the user to use Struggle if certain effects are disabling all of its base moves`, function () {
+		battle = common.createBattle([[
+			{species: "Skwovet", item: 'oranberry', moves: ['sleeptalk', 'belch', 'stuffcheeks']},
+		], [
+			{species: "Calyrex-Shadow", moves: ['disable', 'trick']},
+		]]);
+		battle.makeChoices();
+		// Skwovet's Sleep Talk and Belch are disabled, but Stuff Cheeks isn't so Skwovet can still use Max Ooze
+		battle.makeChoices('move belch dynamax', 'auto');
+		assert.equal(battle.p1.active[0].boosts.spa, 1);
+		battle.makeChoices('move belch', 'move trick');
+		assert.equal(battle.p1.active[0].boosts.spa, 2);
+		// Now Skwovet's berry is gone, so Stuff Cheeks is disabled too
+		battle.makeChoices('move struggle', 'auto'); // will throw an error if Skwovet isn't forced to use Struggle
+
+		battle = common.createBattle([[
+			{species: "Feebas", moves: ['splash']},
+		], [
+			{species: "Clefairy", moves: ['imprison', 'gravity', 'splash']},
+		]]);
+		battle.makeChoices('move splash dynamax', 'auto');
+		battle.makeChoices('move splash', 'move gravity'); // will throw an error if Feebas is forced to use Struggle by Imprison
+		battle.makeChoices('move splash', 'auto'); // will throw an error if Feebas is forced to use Struggle by Gravity
 	});
 });


### PR DESCRIPTION
To sum up what I've seen from research, it should work like this:
- Taunt and Assault Vest disable Max Guard
- No Max Move can be used if the base move is out of PP
- No other effects can individually disable Max Moves, but if each and every one of a dynamaxed Pokemon's base moves is disabled by way of being out of PP, or by the effects of Encore, Disable, Taunt, Assault Vest, or Belch or Stuff Cheeks disabling themselves, then the Pokemon will be forced to use Struggle anyway

I removed the no-PP hint because I think this is at least the third time it's been wrong, and Metronome Battle players have been seeing that message every time they dynamax at 1 PP left to win Struggle wars, so when that doesn't work anymore you can bet there will be at least irate post in the bugs thread about it.