### PR TITLE
Make Unnerve activate after Skill Swap and Neutralising Gas wearing off

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -4068,6 +4068,12 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	unnerve: {
 		onPreStart(pokemon) {
 			this.add('-ability', pokemon, 'Unnerve', pokemon.side.foe);
+			this.effectData.unnerved = true;
+		},
+		onStart(pokemon) {
+			if (this.effectData.unnerved) return;
+			this.add('-ability', pokemon, 'Unnerve', pokemon.side.foe);
+			this.effectData.unnerved = true;
 		},
 		onFoeTryEatItem: false,
 		name: "Unnerve",

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -15435,13 +15435,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 			}
 			this.singleEvent('End', sourceAbility, source.abilityData, source);
 			this.singleEvent('End', targetAbility, target.abilityData, target);
-			if (targetAbility.id !== sourceAbility.id) {
-				source.ability = targetAbility.id;
-				target.ability = sourceAbility.id;
-				source.abilityData = {id: this.toID(source.ability), target: source};
-				target.abilityData = {id: this.toID(target.ability), target: target};
-				if (target.side !== source.side) target.volatileStaleness = 'external';
-			}
+			source.ability = targetAbility.id;
+			target.ability = sourceAbility.id;
+			source.abilityData = {id: this.toID(source.ability), target: source};
+			target.abilityData = {id: this.toID(target.ability), target: target};
+			if (target.side !== source.side) target.volatileStaleness = 'external';
 			this.singleEvent('Start', targetAbility, source.abilityData, source);
 			this.singleEvent('Start', sourceAbility, target.abilityData, target);
 		},

--- a/test/sim/abilities/neutralizinggas.js
+++ b/test/sim/abilities/neutralizinggas.js
@@ -258,7 +258,7 @@ describe('Neutralizing Gas', function () {
 			assert.statStage(battle.p1.active[0], 'atk', 1);
 		});
 
-		it.skip(`should not give Unnerve priority in activation`, function () {
+		it(`should not give Unnerve priority in activation`, function () {
 			battle = common.createBattle({gameType: 'doubles'}, [[
 				{species: "Bisharp", ability: 'defiant', moves: ['sleeptalk']},
 				{species: "Eternatus", ability: 'pressure', moves: ['sleeptalk']},


### PR DESCRIPTION
As recently mentioned by @DaWoblefet, if Unnerve has not yet activated, then it should activate when Neutralising Gas wears off.

It should also activate when Skill Swapped.