### PR TITLE
Bug Fix: Protean/Libero on first of two turn moves

### DIFF
--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -279,6 +279,8 @@ export const Conditions: {[k: string]: ConditionData} = {
 			// if there are no valid targets, randomly choose one later
 			target.volatiles[effect.id].targetLoc = this.getTargetLoc(moveTarget || target, target);
 			this.attrLastMove('[still]');
+			// Run side-effects normally associated with hitting (e.g., Protean, Libero)
+			this.runEvent('PrepareHit', target, source, effect);
 		},
 		onEnd(target) {
 			target.removeVolatile(this.effectData.move);

--- a/test/sim/abilities/protean.js
+++ b/test/sim/abilities/protean.js
@@ -22,7 +22,7 @@ describe('Protean', function () {
 		assert(cinder.hasType('Fighting'));
 	});
 
-	it.skip(`should activate on both turns of a charge move`, function () {
+	it(`should activate on both turns of a charge move`, function () {
 		battle = common.createBattle([[
 			{species: "Wynaut", ability: 'protean', moves: ['bounce']},
 		], [


### PR DESCRIPTION
> Protean / Libero should activate on both turns of a charge move like Fly or Phantom Force