### PR TITLE
FS: Fix hotpatching and add more throttling

### DIFF
--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -28,7 +28,7 @@ import {ReadStream, WriteStream} from './streams';
 const ROOT_PATH = pathModule.resolve(__dirname, '..');
 const DEFAULT_THROTTLE = 5 * 1000; // 5 seconds
 
-export interface PendingUpdate {
+interface PendingUpdate {
 	isWriting: boolean; // true: waiting on a call to FS.write, false: waiting on a throttle
 	pendingDataFetcher: (() => string | Buffer) | null;
 	pendingOptions: AnyObject | null;
@@ -152,7 +152,7 @@ export class FSPath {
 	 * called, if `writeUpdate` is called many times in a short period.
 	 *
 	 * `options.throttle`, if it exists, will make sure updates are not
-	 * written more than once every `options.throttle` milliseconds, else the default is 5 seconds.
+	 * written more than once every `options.throttle` milliseconds.
 	 *
 	 * No synchronous version because there's no risk of race conditions
 	 * with synchronous code; just use `safeWriteSync`.

--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -161,7 +161,7 @@ export class FSPath {
 		if (Config.nofswriting) return;
 		const pendingUpdate: PendingUpdate | undefined = __fsState.pendingUpdates.get(this.path);
 
-		const throttleTime = Date.now() + (options.throttle || 0);
+		const throttleTime = options.throttle ? Date.now() + options.throttle : 0;
 
 		if (pendingUpdate) {
 			pendingUpdate.pendingDataFetcher = dataFetcher;

--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -189,8 +189,7 @@ export class FSPath {
 	}
 
 	writeUpdateNow(dataFetcher: () => string | Buffer, options: AnyObject) {
-		// @ts-ignore
-		const throttleTime = Date.now() + (options.throttle ? options.throttle : DEFAULT_THROTTLE);
+		const throttleTime = options.throttle ? Date.now() + options.throttle : 0;
 		const update = {
 			isWriting: true,
 			pendingDataFetcher: null,

--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -26,7 +26,6 @@ import * as pathModule from 'path';
 import {ReadStream, WriteStream} from './streams';
 
 const ROOT_PATH = pathModule.resolve(__dirname, '..');
-const DEFAULT_THROTTLE = 5 * 1000; // 5 seconds
 
 interface PendingUpdate {
 	isWriting: boolean; // true: waiting on a call to FS.write, false: waiting on a throttle

--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -185,7 +185,7 @@ export class FSPath {
 			pendingOptions: options,
 			throttleTime,
 			throttleTimer: setTimeout(() => this.checkNextUpdate(), throttleTime - Date.now()),
-		}
+		};
 		__fsState.pendingUpdates.set(this.path, update);
 	}
 

--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -154,8 +154,6 @@ export class FSPath {
 	 * `options.throttle`, if it exists, will make sure updates are not
 	 * written more than once every `options.throttle` milliseconds, else the default is 5 seconds.
 	 *
-	 * `options.writeNow`, if it exists, will force it to write *right* now. (Pun is absolutely intended)
-	 *
 	 * No synchronous version because there's no risk of race conditions
 	 * with synchronous code; just use `safeWriteSync`.
 	 */
@@ -163,7 +161,7 @@ export class FSPath {
 		if (Config.nofswriting) return;
 		const pendingUpdate: PendingUpdate | undefined = __fsState.pendingUpdates.get(this.path);
 
-		const throttleTime = Date.now() + (options.throttle ? options.throttle : DEFAULT_THROTTLE);
+		const throttleTime = Date.now() + (options.throttle || 0);
 
 		if (pendingUpdate) {
 			pendingUpdate.pendingDataFetcher = dataFetcher;
@@ -176,7 +174,7 @@ export class FSPath {
 			return;
 		}
 
-		if (options.writeNow) {
+		if (!options.throttle) {
 			this.writeUpdateNow(dataFetcher, options);
 			return;
 		}

--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -36,9 +36,11 @@ export interface PendingUpdate {
 	throttleTimer: NodeJS.Timer | null;
 }
 
+declare const __fsState: {pendingUpdates: Map<string, PendingUpdate>};
+declare const global: {__fsState: typeof __fsState};
 if (!global.__fsState) {
 	global.__fsState = {
-		pendingUpdates: new Map<string, PendingUpdate>(),
+		pendingUpdates: new Map(),
 	};
 }
 

--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -174,7 +174,7 @@ export class FSPath {
 			return;
 		}
 
-		if (!options.throttle) {
+		if (!throttleTime) {
 			this.writeUpdateNow(dataFetcher, options);
 			return;
 		}
@@ -509,4 +509,3 @@ function getFs(path: string) {
 export const FS = Object.assign(getFs, {
 	FileReadStream,
 });
-

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -55,7 +55,7 @@ try {
 
 export function writeTickets() {
 	FS(TICKET_FILE).writeUpdate(
-		() => JSON.stringify(tickets)
+		() => JSON.stringify(tickets), {throttle: 5000}
 	);
 }
 

--- a/server/global-variables.d.ts
+++ b/server/global-variables.d.ts
@@ -16,6 +16,8 @@ import {Tournaments as TournamentsType} from './tournaments';
 
 import {Dex as DexType} from '../sim/dex';
 
+import type {PendingUpdate} from '../lib/fs';
+
 declare global {
 	namespace NodeJS {
 		interface Global {
@@ -36,6 +38,7 @@ declare global {
 			Verifier: any;
 			toID: (item: any) => ID;
 			__version: {head: string, origin?: string, tree?: string};
+			__fsState: {pendingUpdates: Map<string, PendingUpdate>};
 		}
 	}
 	const Config: ConfigType;
@@ -53,4 +56,5 @@ declare global {
 	const Users: typeof UsersType.Users;
 	const Verifier: typeof VerifierType;
 	const toID: typeof DexType.toID;
+	const __fsState: {pendingUpdates: Map<string, PendingUpdate>};
 }

--- a/server/global-variables.d.ts
+++ b/server/global-variables.d.ts
@@ -16,8 +16,6 @@ import {Tournaments as TournamentsType} from './tournaments';
 
 import {Dex as DexType} from '../sim/dex';
 
-import type {PendingUpdate} from '../lib/fs';
-
 declare global {
 	namespace NodeJS {
 		interface Global {

--- a/server/global-variables.d.ts
+++ b/server/global-variables.d.ts
@@ -38,7 +38,6 @@ declare global {
 			Verifier: any;
 			toID: (item: any) => ID;
 			__version: {head: string, origin?: string, tree?: string};
-			__fsState: {pendingUpdates: Map<string, PendingUpdate>};
 		}
 	}
 	const Config: ConfigType;
@@ -56,5 +55,4 @@ declare global {
 	const Users: typeof UsersType.Users;
 	const Verifier: typeof VerifierType;
 	const toID: typeof DexType.toID;
-	const __fsState: {pendingUpdates: Map<string, PendingUpdate>};
 }

--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -286,7 +286,7 @@ export const Punishments = new class {
 				buf += Punishments.renderEntry(entry, id);
 			}
 			return buf;
-		});
+		}, {throttle: 5000});
 	}
 
 	saveRoomPunishments() {
@@ -302,7 +302,7 @@ export const Punishments = new class {
 				buf += Punishments.renderEntry(entry, id);
 			}
 			return buf;
-		});
+		}, {throttle: 5000});
 	}
 
 	getEntry(entryId: string) {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1143,7 +1143,7 @@ export class GlobalRoomState {
 			JSON.stringify(this.settingsList)
 				.replace(/\{"title":/g, '\n{"title":')
 				.replace(/\]$/, '\n]')
-		));
+		), {throttle: 5000});
 	}
 
 	writeNumRooms() {


### PR DESCRIPTION
- `writeUpdate` state is now stored in a global variable, so hotpatching doesn't crash it
- throttling now writes on the tail (so two throttled `writeUpdate` calls will write one update, not two)
- room settings, punishments, and helptickets are now throttled

-----

Discussed with @Zarel, decided this would be the best way to stop the writeUpdate crashes.
(for example, `A main process Promise crashed: Error: ENOENT: no such file or directory, rename '/home/ps/main/config/tickets.json.NEW' -> '/home/ps/main/config/tickets.json'`, etc)