### PR TITLE
Fix Intimidate failure text

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -1644,7 +1644,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		onBoost(boost, target, source, effect) {
 			if (effect.id === 'intimidate') {
 				delete boost.atk;
-				this.add('-immune', target, '[from] ability: Inner Focus');
+				this.add('-fail', target, 'unboost', 'Attack', '[from] ability: Inner Focus', '[of] ' + target);
 			}
 		},
 		name: "Inner Focus",
@@ -2386,7 +2386,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		onBoost(boost, target, source, effect) {
 			if (effect.id === 'intimidate') {
 				delete boost.atk;
-				this.add('-immune', target, '[from] ability: Oblivious');
+				this.add('-fail', target, 'unboost', 'Attack', '[from] ability: Oblivious', '[of] ' + target);
 			}
 		},
 		name: "Oblivious",
@@ -2445,7 +2445,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		onBoost(boost, target, source, effect) {
 			if (effect.id === 'intimidate') {
 				delete boost.atk;
-				this.add('-immune', target, '[from] ability: Own Tempo');
+				this.add('-fail', target, 'unboost', 'Attack', '[from] ability: Own Tempo', '[of] ' + target);
 			}
 		},
 		name: "Own Tempo",
@@ -3157,7 +3157,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		onBoost(boost, target, source, effect) {
 			if (effect.id === 'intimidate') {
 				delete boost.atk;
-				this.add('-immune', target, '[from] ability: Scrappy');
+				this.add('-fail', target, 'unboost', 'Attack', '[from] ability: Scrappy', '[of] ' + target);
 			}
 		},
 		name: "Scrappy",

--- a/data/text/abilities.ts
+++ b/data/text/abilities.ts
@@ -923,8 +923,6 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 			desc: "This Pokemon cannot be confused. Gaining this Ability while confused cures it.",
 			shortDesc: "This Pokemon cannot be confused.",
 		},
-
-		block: "  [POKEMON] cannot be confused!",
 	},
 	parentalbond: {
 		name: "Parental Bond",


### PR DESCRIPTION
Inner Focus, Oblivious, Scrappy, and Own Tempo were not displaying "[Pokemon]'s Attack was not lowered!", instead a generic immunity message. Additionally, I've removed the string for Own Tempo in ``block``; I tried it out on testclient without it and it still displayed "[Pokemon] cannot be confused!" on Confuse Ray so that should be ok, and it fixes the bug with Own Tempo blocking Intimidate using its confusion blocking message.