### PR TITLE
Grassy Terrain should heal before Leftovers

### DIFF
--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -304,6 +304,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onResidual() {
 				this.eachEvent('Terrain');
 			},
+			onTerrainPriority: 1,
 			onTerrain(pokemon) {
 				if (pokemon.isGrounded() && !pokemon.isSemiInvulnerable()) {
 					this.debug('Pokemon is grounded, healing through Grassy Terrain.');

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -7195,6 +7195,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onResidual() {
 				this.eachEvent('Terrain');
 			},
+			onTerrainPriority: 1,
 			onTerrain(pokemon) {
 				if (pokemon.isGrounded() && !pokemon.isSemiInvulnerable()) {
 					this.debug('Pokemon is grounded, healing through Grassy Terrain.');

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -573,6 +573,7 @@ export interface EventMethods {
 	onSourceModifyDamagePriority?: number;
 	onSourceModifySpAPriority?: number;
 	onSwitchInPriority?: number;
+	onTerrainPriority?: number;
 	onTrapPokemonPriority?: number;
 	onTryEatItemPriority?: number;
 	onTryHealPriority?: number;

--- a/test/sim/moves/grassyterrain.js
+++ b/test/sim/moves/grassyterrain.js
@@ -79,7 +79,7 @@ describe('Grassy Terrain', function () {
 		assert.equal(resultMove, 'energyball');
 	});
 
-	it.skip(`should heal by Speed order in the same block as Leftovers`, function () {
+	it(`should heal by Speed order in the same block as Leftovers`, function () {
 		battle = common.createBattle([[
 			{species: 'rillaboom', ability: 'grassysurge', item: 'leftovers', moves: ['seismictoss']},
 		], [
@@ -89,8 +89,8 @@ describe('Grassy Terrain', function () {
 		battle.makeChoices();
 		const log = battle.getDebugLog();
 		const zamGrassyIndex = log.indexOf('|-heal|p2a: Alakazam|166/251|[from] Grassy Terrain');
-		const rillaGrassyIndex = log.indexOf('|-heal|p1a: Rillaboom|283/341|[from] Grassy Terrain');
-		const rillaLeftoversIndex = log.indexOf('|-heal|p1a: Rillaboom|262/341|[from] item: Leftovers');
+		const rillaGrassyIndex = log.indexOf('|-heal|p1a: Rillaboom|262/341|[from] Grassy Terrain');
+		const rillaLeftoversIndex = log.indexOf('|-heal|p1a: Rillaboom|283/341|[from] item: Leftovers');
 		assert(zamGrassyIndex < rillaGrassyIndex, 'Alakazam should heal from Grassy Terrain before Rillaboom');
 		assert(rillaGrassyIndex < rillaLeftoversIndex, 'Rillaboom should heal from Grassy Terrain before Leftovers');
 	});


### PR DESCRIPTION
The test was a little fragile until I worked out that it was looking for the wrong amount of healing, so Alakazam was still healing first, even though the test thought it wasn't.