### PR TITLE
Gen 1: Fix Stadium Rest

### DIFF
--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -134,6 +134,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			if (!target.setStatus('slp', source, move)) return false;
 			target.statusData.time = 2;
 			target.statusData.startTime = 2;
+			target.recalculateStats(); // Stadium Rest removes statdrops given by Major Status Conditions.
 			this.heal(target.maxhp); // Aesthetic only as the healing happens after you fall asleep in-game
 		},
 	},

--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -134,7 +134,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			if (!target.setStatus('slp', source, move)) return false;
 			target.statusData.time = 2;
 			target.statusData.startTime = 2;
-			target.recalculateStats(); // Stadium Rest removes statdrops given by Major Status Conditions.
+			target.recalculateStats!(); // Stadium Rest removes statdrops given by Major Status Conditions.
 			this.heal(target.maxhp); // Aesthetic only as the healing happens after you fall asleep in-game
 		},
 	},


### PR DESCRIPTION
The current implementation of Rest on the Stadium sim fails to recalculate stats when Rest is used. This means that right now, the stat drops from Paralysis and Burn remain when you use it. This is inaccurate, and a massive problem considering Rest's increased relevance in the Stadium metagame.

Here is a video of how the interaction works in Stadium: https://www.youtube.com/watch?v=8o0uVj4bARo
Here is a replay of the bugged interaction on PS Main: https://replay.pokemonshowdown.com/gen1stadiumou-1132924324
Here is a replay of my fixed version of Rest working on the RBY server: https://replay.pokemonshowdown.com/rby-gen1stadiumou-1448

Note that on Turn 3, Vaporeon moves **first** when fast asleep. That's how you know the fix has succeeded.

Here is my report on the issue from June of this year: https://www.smogon.com/forums/threads/stadium-format-is-now-available-on-ps.3526616/post-8503350

Thanks to Zarel for pointing out the function we use for recalculating stats here. I'll need this for when I get to (partially) fixing Haze.