### PR TITLE
Tournaments: Fix bugs with replacing users

### DIFF
--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -486,6 +486,13 @@ export class Tournament extends Rooms.RoomGame {
 				}
 			}
 		}
+		if (!(replacementUser.id in this.room.users)) {
+			output.errorReply(`${replacementUser.name} is not in this room (${this.room.title}).`);
+			return;
+		}
+		if (this.playerTable[user.id].pendingChallenge) {
+			this.cancelChallenge(user, output);
+		}
 
 		// Replace the player
 		this.renamePlayer(replacementUser, user.id);


### PR DESCRIPTION
- Currently, you can replace the old user with a new user that exists, even if they're not in the room, which leads to easy autodq wins.
- Challenges aren't canceled when replacing users, so a replaced user can still be challenging their opponent without knowing it and go into battle without being able to select a team.