### PR TITLE
Cursed Body ignores Max Moves

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -547,7 +547,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	cursedbody: {
 		onDamagingHit(damage, target, source, move) {
 			if (source.volatiles['disable']) return;
-			if (!move.isFutureMove) {
+			if (!move.isMax && !move.isFutureMove) {
 				if (this.randomChance(3, 10)) {
 					source.addVolatile('disable', this.effectData.target);
 				}


### PR DESCRIPTION
When enabling Cursed Body against Z-moves in PR #7879 I accidentally allowed it to process against Max moves as well.