### PR TITLE
Ripen should double Jaboca and Rowap damage

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -2963,8 +2963,9 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			}
 		},
 		onTryEatItemPriority: -1,
-		onTryEatItem(item, pokemon) {
+		onTryEatItem(itemData, pokemon) {
 			this.add('-activate', pokemon, 'ability: Ripen');
+			itemData.ripe = true;
 		},
 		onEatItem(item, pokemon) {
 			const weakenBerries = [

--- a/data/items.ts
+++ b/data/items.ts
@@ -118,7 +118,7 @@ export const Items: {[itemid: string]: ItemData} = {
 				pokemon.eatItem();
 			}
 		},
-		onTryEatItem(item, pokemon) {
+		onTryEatItem(itemData, pokemon) {
 			if (!this.runEvent('TryHeal', pokemon)) return false;
 		},
 		onEat(pokemon) {
@@ -1537,7 +1537,7 @@ export const Items: {[itemid: string]: ItemData} = {
 				}
 			}
 		},
-		onTryEatItem(item, pokemon) {
+		onTryEatItem(itemData, pokemon) {
 			if (!this.runEvent('TryHeal', pokemon)) return false;
 		},
 		onEat() { },
@@ -1681,7 +1681,7 @@ export const Items: {[itemid: string]: ItemData} = {
 				pokemon.eatItem();
 			}
 		},
-		onTryEatItem(item, pokemon) {
+		onTryEatItem(itemData, pokemon) {
 			if (!this.runEvent('TryHeal', pokemon)) return false;
 		},
 		onEat(pokemon) {
@@ -2413,7 +2413,7 @@ export const Items: {[itemid: string]: ItemData} = {
 				pokemon.eatItem();
 			}
 		},
-		onTryEatItem(item, pokemon) {
+		onTryEatItem(itemData, pokemon) {
 			if (!this.runEvent('TryHeal', pokemon)) return false;
 		},
 		onEat(pokemon) {
@@ -2587,7 +2587,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		onDamagingHit(damage, target, source, move) {
 			if (move.category === 'Physical') {
 				if (target.eatItem()) {
-					this.damage(source.baseMaxhp / 8, source, target);
+					this.damage(source.baseMaxhp / (this.effectData.ripe ? 4 : 8), source, target);
 				}
 			}
 		},
@@ -3152,7 +3152,7 @@ export const Items: {[itemid: string]: ItemData} = {
 				pokemon.eatItem();
 			}
 		},
-		onTryEatItem(item, pokemon) {
+		onTryEatItem(itemData, pokemon) {
 			if (!this.runEvent('TryHeal', pokemon)) return false;
 		},
 		onEat(pokemon) {
@@ -3736,7 +3736,7 @@ export const Items: {[itemid: string]: ItemData} = {
 				pokemon.eatItem();
 			}
 		},
-		onTryEatItem(item, pokemon) {
+		onTryEatItem(itemData, pokemon) {
 			if (!this.runEvent('TryHeal', pokemon)) return false;
 		},
 		onEat(pokemon) {
@@ -4686,7 +4686,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		onDamagingHit(damage, target, source, move) {
 			if (move.category === 'Special') {
 				if (target.eatItem()) {
-					this.damage(source.baseMaxhp / 8, source, target);
+					this.damage(source.baseMaxhp / (this.effectData.ripe ? 4 : 8), source, target);
 				}
 			}
 		},
@@ -5016,7 +5016,7 @@ export const Items: {[itemid: string]: ItemData} = {
 				pokemon.eatItem();
 			}
 		},
-		onTryEatItem(item, pokemon) {
+		onTryEatItem(itemData, pokemon) {
 			if (!this.runEvent('TryHeal', pokemon)) return false;
 		},
 		onEat(pokemon) {
@@ -6763,7 +6763,7 @@ export const Items: {[itemid: string]: ItemData} = {
 				pokemon.eatItem();
 			}
 		},
-		onTryEatItem(item, pokemon) {
+		onTryEatItem(itemData, pokemon) {
 			if (!this.runEvent('TryHeal', pokemon)) return false;
 		},
 		onEat(pokemon) {
@@ -6880,7 +6880,7 @@ export const Items: {[itemid: string]: ItemData} = {
 				pokemon.eatItem();
 			}
 		},
-		onTryEatItem(item, pokemon) {
+		onTryEatItem(itemData, pokemon) {
 			if (!this.runEvent('TryHeal', pokemon)) return false;
 		},
 		onEat(pokemon) {
@@ -6946,7 +6946,7 @@ export const Items: {[itemid: string]: ItemData} = {
 				pokemon.eatItem();
 			}
 		},
-		onTryEatItem(item, pokemon) {
+		onTryEatItem(itemData, pokemon) {
 			if (!this.runEvent('TryHeal', pokemon)) return false;
 		},
 		onEat(pokemon) {

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -1,5 +1,6 @@
 import {BasicEffect} from './dex-data';
 import type {SecondaryEffect, MoveEventMethods} from './dex-moves';
+import type {EffectState} from './pokemon';
 
 export interface EventMethods {
 	onDamagingHit?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void;
@@ -89,7 +90,7 @@ export interface EventMethods {
 	onTryAddVolatile?: (
 		this: Battle, status: Condition, target: Pokemon, source: Pokemon, sourceEffect: Effect
 	) => boolean | null | void;
-	onTryEatItem?: boolean | ((this: Battle, item: Item, pokemon: Pokemon) => boolean | void);
+	onTryEatItem?: boolean | ((this: Battle, data: EffectState, pokemon: Pokemon) => boolean | void);
 	/* FIXME: onTryHeal() is run with two different sets of arguments */
 	onTryHeal?: (
 		((this: Battle, relayVar: number, target: Pokemon, source: Pokemon, effect: Effect) => number | boolean | void) |
@@ -190,7 +191,7 @@ export interface EventMethods {
 	onAllyTryAddVolatile?: (
 		this: Battle, status: Condition, target: Pokemon, source: Pokemon, sourceEffect: Effect
 	) => boolean | null | void;
-	onAllyTryEatItem?: boolean | ((this: Battle, item: Item, pokemon: Pokemon) => boolean | void);
+	onAllyTryEatItem?: boolean | ((this: Battle, data: EffectState, pokemon: Pokemon) => boolean | void);
 	/* FIXME: onAllyTryHeal() is run with two different sets of arguments */
 	onAllyTryHeal?: (
 		((this: Battle, relayVar: number, target: Pokemon, source: Pokemon, effect: Effect) => number | boolean | void) |
@@ -293,7 +294,7 @@ export interface EventMethods {
 	onFoeTryAddVolatile?: (
 		this: Battle, status: Condition, target: Pokemon, source: Pokemon, sourceEffect: Effect
 	) => boolean | null | void;
-	onFoeTryEatItem?: boolean | ((this: Battle, item: Item, pokemon: Pokemon) => boolean | void);
+	onFoeTryEatItem?: boolean | ((this: Battle, data: EffectState, pokemon: Pokemon) => boolean | void);
 	/* FIXME: onFoeTryHeal() is run with two different sets of arguments */
 	onFoeTryHeal?: (
 		((this: Battle, relayVar: number, target: Pokemon, source: Pokemon, effect: Effect) => number | boolean | void) |
@@ -398,7 +399,7 @@ export interface EventMethods {
 	onSourceTryAddVolatile?: (
 		this: Battle, status: Condition, target: Pokemon, source: Pokemon, sourceEffect: Effect
 	) => boolean | null | void;
-	onSourceTryEatItem?: boolean | ((this: Battle, item: Item, pokemon: Pokemon) => boolean | void);
+	onSourceTryEatItem?: boolean | ((this: Battle, data: EffectState, pokemon: Pokemon) => boolean | void);
 	/* FIXME: onSourceTryHeal() is run with two different sets of arguments */
 	onSourceTryHeal?: (
 		((this: Battle, relayVar: number, target: Pokemon, source: Pokemon, effect: Effect) => number | boolean | void) |
@@ -501,7 +502,7 @@ export interface EventMethods {
 	onAnyTryAddVolatile?: (
 		this: Battle, status: Condition, target: Pokemon, source: Pokemon, sourceEffect: Effect
 	) => boolean | null | void;
-	onAnyTryEatItem?: boolean | ((this: Battle, item: Item, pokemon: Pokemon) => boolean | void);
+	onAnyTryEatItem?: boolean | ((this: Battle, data: EffectState, pokemon: Pokemon) => boolean | void);
 	/* FIXME: onAnyTryHeal() is run with two different sets of arguments */
 	onAnyTryHeal?: (
 		((this: Battle, relayVar: number, target: Pokemon, source: Pokemon, effect: Effect) => number | boolean | void) |

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1544,7 +1544,7 @@ export class Pokemon {
 		const item = this.getItem();
 		if (
 			this.battle.runEvent('UseItem', this, null, null, item) &&
-			(force || this.battle.runEvent('TryEatItem', this, null, null, item))
+			(force || this.battle.runEvent('TryEatItem', this, null, item, this.itemData))
 		) {
 			this.battle.add('-enditem', this, item, '[eat]');
 

--- a/test/sim/abilities/ripen.js
+++ b/test/sim/abilities/ripen.js
@@ -33,7 +33,7 @@ describe("Ripen", function () {
 		assert.statStage(ripenWynaut, 'atk', 2);
 	});
 
-	it.skip('should double damage done from Jaboca / Rowap Berries', function () {
+	it('should double damage done from Jaboca / Rowap Berries', function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', ability: 'ripen', item: 'jabocaberry', moves: ['sleeptalk']},
 		], [


### PR DESCRIPTION
I can't use the `Damage` event because the damage has already been rounded by that point, so instead I've set a flag in the item data for maximum flexibility (because who knows what SSB or some other OM or Pet Mod is going to want to do in the future).