### PR TITLE
Brick Break should destroy screens if type immunity is bypassed

### DIFF
--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -165,13 +165,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		recoil: [1, 3],
 	},
-	brickbreak: {
-		inherit: true,
-		onTryHit(pokemon) {
-			pokemon.side.removeSideCondition('reflect');
-			pokemon.side.removeSideCondition('lightscreen');
-		},
-	},
 	bulletseed: {
 		inherit: true,
 		basePower: 10,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -1653,11 +1653,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {contact: 1, protect: 1, mirror: 1},
 		onTryHit(pokemon) {
 			// will shatter screens through sub, before you hit
-			if (pokemon.runImmunity('Fighting')) {
-				pokemon.side.removeSideCondition('reflect');
-				pokemon.side.removeSideCondition('lightscreen');
-				pokemon.side.removeSideCondition('auroraveil');
-			}
+			pokemon.side.removeSideCondition('reflect');
+			pokemon.side.removeSideCondition('lightscreen');
+			pokemon.side.removeSideCondition('auroraveil');
 		},
 		secondary: null,
 		target: "normal",
@@ -13166,11 +13164,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {bite: 1, contact: 1, protect: 1, mirror: 1},
 		onTryHit(pokemon) {
 			// will shatter screens through sub, before you hit
-			if (pokemon.runImmunity('Psychic')) {
-				pokemon.side.removeSideCondition('reflect');
-				pokemon.side.removeSideCondition('lightscreen');
-				pokemon.side.removeSideCondition('auroraveil');
-			}
+			pokemon.side.removeSideCondition('reflect');
+			pokemon.side.removeSideCondition('lightscreen');
+			pokemon.side.removeSideCondition('auroraveil');
 		},
 		secondary: null,
 		target: "normal",

--- a/test/sim/moves/brickbreak.js
+++ b/test/sim/moves/brickbreak.js
@@ -23,4 +23,74 @@ describe('Brick Break', function () {
 		battle.makeChoices('move brickbreak', 'move splash');
 		assert.false(battle.p2.sideConditions['reflect']);
 	});
+
+	it('should not break Reflect when used against a Ghost-type', function () {
+		battle = common.createBattle([[
+			{species: "mew", moves: ['brickbreak', 'splash']},
+		], [
+			{species: "gengar", moves: ['reflect', 'splash']},
+		]]);
+
+		battle.makeChoices('move splash', 'move reflect');
+		assert(battle.p2.sideConditions['reflect']);
+
+		battle.makeChoices('move brickbreak', 'move splash');
+		assert(battle.p2.sideConditions['reflect']);
+	});
+
+	it.skip('should break Reflect when used against a Ghost-type in Gen 4 or earlier', function () {
+		battle = common.gen(4).createBattle([[
+			{species: "mew", moves: ['brickbreak', 'splash']},
+		], [
+			{species: "gengar", moves: ['reflect', 'splash']},
+		]]);
+
+		battle.makeChoices('move splash', 'move reflect');
+		assert(battle.p2.sideConditions['reflect']);
+
+		battle.makeChoices('move brickbreak', 'move splash');
+		assert.false(battle.p2.sideConditions['reflect']);
+	});
+
+	it('should break Reflect against a Ghost type whose type immunity is being ignored', function () {
+		battle = common.createBattle([[
+			{species: "mew", moves: ['brickbreak', 'splash']},
+		], [
+			{species: "gengar", item: "ringtarget", moves: ['reflect', 'splash']},
+		]]);
+
+		battle.makeChoices('move splash', 'move reflect');
+		assert(battle.p2.sideConditions['reflect']);
+
+		battle.makeChoices('move brickbreak', 'move splash');
+		assert.false(battle.p2.sideConditions['reflect']);
+	});
+
+	it('should break Reflect against a Ghost type whose type immunity is being ignored', function () {
+		battle = common.createBattle([[
+			{species: "mew", ability: "scrappy", moves: ['brickbreak', 'splash']},
+		], [
+			{species: "gengar", moves: ['reflect', 'splash']},
+		]]);
+
+		battle.makeChoices('move splash', 'move reflect');
+		assert(battle.p2.sideConditions['reflect']);
+
+		battle.makeChoices('move brickbreak', 'move splash');
+		assert.false(battle.p2.sideConditions['reflect']);
+	});
+
+	it('should break Reflect against a Ghost type if it has been electrified', function () {
+		battle = common.createBattle([[
+			{species: "mew", moves: ['brickbreak', 'splash']},
+		], [
+			{species: "gengar", moves: ['reflect', 'electrify']},
+		]]);
+
+		battle.makeChoices('move splash', 'move reflect');
+		assert(battle.p2.sideConditions['reflect']);
+
+		battle.makeChoices('move brickbreak', 'move electrify');
+		assert.false(battle.p2.sideConditions['reflect']);
+	});
 });


### PR DESCRIPTION
Currently for Gen 5 or later the sim hard-codes the type immunity when checking whether Brick Break should destroy screens, but it doesn't for Gen 4. This suggests that the order of events was different back in the day. Sadly I can't figure out what the correct order of events is for Gen 4, so I'll just have to limit myself for fixing Gen 5 or later, by removing the explicit type immunity check and relying on type immunity having been checked before this event runs. This fixes using Brick Break against Ghost types in a number of scenarios, such as if the move is Electrified, or type immunity is bypassed through such means as Scrappy or the Ring Target.