### PR TITLE
Fix Soundproof blocking self sound moves in Gen 8

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -3463,7 +3463,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	},
 	soundproof: {
 		onTryHit(target, source, move) {
-			if (move.flags['sound']) {
+			if (target !== source && move.flags['sound']) {
 				this.add('-immune', target, '[from] ability: Soundproof');
 				return null;
 			}

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -3463,7 +3463,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	},
 	soundproof: {
 		onTryHit(target, source, move) {
-			if (move.target !== 'self' && move.flags['sound']) {
+			if (move.flags['sound']) {
 				this.add('-immune', target, '[from] ability: Soundproof');
 				return null;
 			}

--- a/data/mods/gen7/abilities.ts
+++ b/data/mods/gen7/abilities.ts
@@ -66,6 +66,15 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		inherit: true,
 		onBoost() {},
 	},
+	soundproof: {
+		inherit: true,
+		onTryHit(target, source, move) {
+			if (move.flags['sound']) {
+				this.add('-immune', target, '[from] ability: Soundproof');
+				return null;
+			}
+		},
+	},
 	technician: {
 		inherit: true,
 		onBasePowerPriority: 19,

--- a/test/sim/moves/perishsong.js
+++ b/test/sim/moves/perishsong.js
@@ -38,4 +38,28 @@ describe('Perish Song', function () {
 		for (let i = 0; i < 4; i++) { battle.makeChoices(); }
 		assert.equal(battle.winner, 'Player 2');
 	});
+
+	it(`should not affect other Pokemon with the ability Soundproof`, function () {
+		battle = common.createBattle([[
+			{species: 'Weavile', ability: 'soundproof', moves: ['perishsong']},
+		], [
+			{species: 'Slowpoke', ability: 'soundproof', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		assert(battle.p1.active[0].volatiles['perishsong'], 'Weavile should have been affected by its own Perish Song');
+		assert.false(battle.p2.active[0].volatiles['perishsong'], 'Slowpoke should not have been affected by Perish Song');
+	});
+
+	it(`should not affect any Pokemon with the ability Soundproof in Gen 7`, function () {
+		battle = common.gen(7).createBattle([[
+			{species: 'Weavile', ability: 'soundproof', moves: ['perishsong']},
+		], [
+			{species: 'Slowpoke', ability: 'soundproof', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		assert.false(battle.p1.active[0].volatiles['perishsong'], 'Weavile should not have been affected by Perish Song');
+		assert.false(battle.p2.active[0].volatiles['perishsong'], 'Slowpoke should not have been affected by Perish Song');
+	});
 });


### PR DESCRIPTION
Note that the tests are subtly different:
- In the first test, nobody would lose if both Soundproof work, and if you take both Soundproof away, then player 2 wins (as per the previous existing test), so this shows that only Player 2's Soundproof didn't take effect
- In the second test, Player 2 would win if Player 1's Soundproof didn't work, so this shows that Player 1's Soundproof took effect in this gen where it didn't for Player 2 in the previous test