### PR TITLE
Chat: Implement Discord spoilers

### DIFF
--- a/server/chat-formatter.ts
+++ b/server/chat-formatter.ts
@@ -60,7 +60,7 @@ REGEXFREE SOURCE FOR LINKREGEX
 */
 export const linkRegex = /(?:(?:https?:\/\/[a-z0-9-]+(?:\.[a-z0-9-]+)*|www\.[a-z0-9-]+(?:\.[a-z0-9-]+)+|\b[a-z0-9-]+(?:\.[a-z0-9-]+)*\.(?:com?|org|net|edu|info|us|jp|[a-z]{2,3}(?=:[0-9]|\/)))(?::[0-9]+)?(?:\/(?:(?:[^\s()&<>]|&amp;|&quot;|\((?:[^\\s()<>&]|&amp;)*\))*(?:[^\s()[\]{}".,!?;:&<>*`^~\\]|\((?:[^\s()<>&]|&amp;)*\)))?)?|[a-z0-9.]+@[a-z0-9-]+(?:\.[a-z0-9-]+)*\.[a-z]{2,})(?![^ ]*&gt;)/ig;
 
-type SpanType = '_' | '*' | '~' | '^' | '\\' | '<' | '[' | '`' | 'a' | 'spoiler' | '>' | '(';
+type SpanType = '_' | '*' | '~' | '^' | '\\' | '|' | '<' | '[' | '`' | 'a' | 'spoiler' | '>' | '(';
 
 type FormatSpan = [SpanType, number];
 
@@ -175,15 +175,17 @@ class TextFormatter {
 		const span = this.stack.pop()!;
 		const startIndex = span[1];
 		let tagName = '';
+		let attrs = '';
 		switch (spanType) {
 		case '_': tagName = 'i'; break;
 		case '*': tagName = 'b'; break;
 		case '~': tagName = 's'; break;
 		case '^': tagName = 'sup'; break;
 		case '\\': tagName = 'sub'; break;
+		case '|': tagName = 'span'; attrs = ' class="spoiler"'; break;
 		}
 		if (tagName) {
-			this.buffers[startIndex] = `<${tagName}>`;
+			this.buffers[startIndex] = `<${tagName}${attrs}>`;
 			this.buffers.push(`</${tagName}>`);
 			this.offset = end;
 		}
@@ -373,6 +375,7 @@ class TextFormatter {
 			case '~':
 			case '^':
 			case '\\':
+			case '|':
 				if (this.at(i + 1) === char && this.at(i + 2) !== char) {
 					if (!(this.at(i - 1) !== ' ' && this.closeSpan(char, i, i + 2))) {
 						if (this.at(i + 2) !== ' ') this.pushSpan(char, i, i + 2);

--- a/test/server/chat.js
+++ b/test/server/chat.js
@@ -37,6 +37,10 @@ describe('Chat', function () {
 			`hi <i>spoiler: <span class="spoiler">bye</span></i> hi again (parenthetical spoiler: <span class="spoiler">bye again (or not!!!!)</span>) that was fun`
 		);
 		assert.equal(
+			Chat.formatText(`hi __||bye||__ hi again (parenthetical ||bye again (or not!!!!)||) that was fun`),
+			`hi <i><span class="spoiler">bye</span></i> hi again (parenthetical <span class="spoiler">bye again (or not!!!!)</span>) that was fun`
+		);
+		assert.equal(
 			Chat.formatText(`hi google.com/__a__ bye >w<`),
 			`hi <a href="http://google.com/__a__" rel="noopener" target="_blank">google.com/__a__</a> bye &gt;w&lt;`
 		);


### PR DESCRIPTION
Mostly so A/M can say "spoilers work like Discord", instead of teaching them a new syntax.

Added a new span type `'|'` instead of reusing `'spoiler'` so as to avoid unwanted interactions in `popAllSpans`.