### PR TITLE
Megas for All: Fix Hawlucha's ability + Data Mod

### DIFF
--- a/data/mods/megasforall/abilities.ts
+++ b/data/mods/megasforall/abilities.ts
@@ -1625,38 +1625,70 @@ export const Abilities: {[abilityid: string]: ModdedAbilityData} = {
 	masquerade: {
 		desc: "This Pokémon inherits the Ability of the last unfainted Pokemon in its party until it takes direct damage from another Pokémon's attack. Abilities that cannot be copied are \"No Ability\", As One, Battle Bond, Comatose, Disguise, Flower Gift, Forecast, Gulp Missile, Hunger Switch, Ice Face, Illusion, Imposter, Multitype, Neutralizing Gas, Power Construct, Power of Alchemy, Receiver, RKS System, Schooling, Shields Down, Stance Change, Trace, Wonder Guard, and Zen Mode.",
 		shortDesc: "Inherits the Ability of the last party member. Wears off when attacked.",
-		onStart(pokemon) {
+		// the same thing happens manually onAfterMega and onSwitchIn, but it should not happen every time the Ability starts
+		onAfterMega(pokemon) {
 			pokemon.addVolatile('masquerade');
-		},
-		condition: {
-			onStart(pokemon) {
-				let masquerade = null;
-				let i;
-				for (i = pokemon.side.pokemon.length - 1; i > pokemon.position; i--) {
-					if (!pokemon.side.pokemon[i]) continue;
-					if (!pokemon.side.pokemon[i].fainted) break;
-				}
-				if (!pokemon.side.pokemon[i]) return;
-				if (pokemon === pokemon.side.pokemon[i]) return;
-				masquerade = pokemon.side.pokemon[i];
+			let masquerade;
+			let i;
+			for (i = pokemon.side.pokemon.length - 1; i > pokemon.position; i--) {
+				if (!pokemon.side.pokemon[i]) continue;
 				const additionalBannedAbilities = [
 					'noability', 'flowergift', 'forecast', 'hungerswitch', 'illusion', 'imposter', 'neutralizinggas', 'powerofalchemy', 'receiver', 'trace', 'wonderguard',
 				];
-				if (masquerade.getAbility().isPermanent || additionalBannedAbilities.includes(masquerade.ability)) {
-					pokemon.setAbility('masquerade');
-					pokemon.removeVolatile('masquerade');
-					return;
+				if (
+					pokemon.side.pokemon[i].fainted ||
+					pokemon.side.pokemon[i].getAbility().isPermanent || additionalBannedAbilities.includes(pokemon.side.pokemon[i].ability)
+				) {
+					continue;
+				} else {
+					break;
 				}
-				pokemon.setAbility(masquerade.ability);
-				this.add('-ability', pokemon, 'Masquerade');
-				this.add('-message', `${pokemon.name} inherited ${this.dex.getAbility(pokemon.ability).name} from ${masquerade.name}!`);
-				this.add('-ability', pokemon, this.dex.getAbility(pokemon.ability).name);
-			},
+			}
+			if (!pokemon.side.pokemon[i]) return;
+			if (pokemon === pokemon.side.pokemon[i]) return;
+			masquerade = pokemon.side.pokemon[i];
+			this.add('-ability', pokemon, 'Masquerade');
+			pokemon.setAbility(masquerade.ability);
+			this.add('-message', `${pokemon.name} inherited ${this.dex.getAbility(pokemon.ability).name} from ${masquerade.name}!`);
+			this.add('-ability', pokemon, this.dex.getAbility(pokemon.ability).name, '[silent]');
+		},
+		onSwitchIn(pokemon) {
+			pokemon.addVolatile('masquerade');
+			let masquerade;
+			let i;
+			for (i = pokemon.side.pokemon.length - 1; i > pokemon.position; i--) {
+				if (!pokemon.side.pokemon[i]) continue;
+				const additionalBannedAbilities = [
+					'noability', 'flowergift', 'forecast', 'hungerswitch', 'illusion', 'imposter', 'neutralizinggas', 'powerofalchemy', 'receiver', 'trace', 'wonderguard',
+				];
+				if (
+					pokemon.side.pokemon[i].fainted ||
+					pokemon.side.pokemon[i].getAbility().isPermanent || additionalBannedAbilities.includes(pokemon.side.pokemon[i].ability)
+				) {
+					continue;
+				} else {
+					break;
+				}
+			}
+			if (!pokemon.side.pokemon[i]) return;
+			if (pokemon === pokemon.side.pokemon[i]) return;
+			masquerade = pokemon.side.pokemon[i];
+			this.add('-ability', pokemon, 'Masquerade');
+			pokemon.setAbility(masquerade.ability);
+			this.add('-message', `${pokemon.name} inherited ${this.dex.getAbility(pokemon.ability).name} from ${masquerade.name}!`);
+			this.add('-ability', pokemon, this.dex.getAbility(pokemon.ability).name, '[silent]');
+		},
+		condition: {
 			onDamagingHit(damage, target, source, move) {
-				target.setAbility('masquerade');
 				target.removeVolatile('masquerade');
-				this.add('-ability', target, 'Masquerade');
-				this.add('-message', `${target.name}'s Masquerade wore off!`);
+			},
+			onFaint(pokemon) {
+				pokemon.removeVolatile('masquerade');
+			},
+			onEnd(pokemon) {
+				this.add('-ability', pokemon, 'Masquerade');
+				this.add('-message', `${pokemon.name}'s Masquerade wore off!`);
+				pokemon.setAbility('masquerade');
 			},
 		},
 		name: "Masquerade",

--- a/data/mods/megasforall/abilities.ts
+++ b/data/mods/megasforall/abilities.ts
@@ -1628,7 +1628,6 @@ export const Abilities: {[abilityid: string]: ModdedAbilityData} = {
 		// the same thing happens manually onAfterMega and onSwitchIn, but it should not happen every time the Ability starts
 		onAfterMega(pokemon) {
 			pokemon.addVolatile('masquerade');
-			let masquerade;
 			let i;
 			for (i = pokemon.side.pokemon.length - 1; i > pokemon.position; i--) {
 				if (!pokemon.side.pokemon[i]) continue;
@@ -1646,7 +1645,7 @@ export const Abilities: {[abilityid: string]: ModdedAbilityData} = {
 			}
 			if (!pokemon.side.pokemon[i]) return;
 			if (pokemon === pokemon.side.pokemon[i]) return;
-			masquerade = pokemon.side.pokemon[i];
+			const masquerade = pokemon.side.pokemon[i];
 			this.add('-ability', pokemon, 'Masquerade');
 			pokemon.setAbility(masquerade.ability);
 			this.add('-message', `${pokemon.name} inherited ${this.dex.getAbility(pokemon.ability).name} from ${masquerade.name}!`);
@@ -1654,7 +1653,6 @@ export const Abilities: {[abilityid: string]: ModdedAbilityData} = {
 		},
 		onSwitchIn(pokemon) {
 			pokemon.addVolatile('masquerade');
-			let masquerade;
 			let i;
 			for (i = pokemon.side.pokemon.length - 1; i > pokemon.position; i--) {
 				if (!pokemon.side.pokemon[i]) continue;
@@ -1672,7 +1670,7 @@ export const Abilities: {[abilityid: string]: ModdedAbilityData} = {
 			}
 			if (!pokemon.side.pokemon[i]) return;
 			if (pokemon === pokemon.side.pokemon[i]) return;
-			masquerade = pokemon.side.pokemon[i];
+			const masquerade = pokemon.side.pokemon[i];
 			this.add('-ability', pokemon, 'Masquerade');
 			pokemon.setAbility(masquerade.ability);
 			this.add('-message', `${pokemon.name} inherited ${this.dex.getAbility(pokemon.ability).name} from ${masquerade.name}!`);

--- a/data/mods/megasforall/rulesets.ts
+++ b/data/mods/megasforall/rulesets.ts
@@ -27,7 +27,10 @@ export const Formats: {[k: string]: FormatData} = {
 				if (target.species.forme.startsWith('Mega') || target.species.forme.startsWith('Ultra')) {
 					this.add('-start', target, 'typechange', target.getTypes(true).join('/'), '[silent]');
 				} else {
-					this.add('-end', target, 'typechange', '[silent]');
+					const types = target.baseSpecies.types;
+					if (target.getTypes().join() === types.join()) {
+						this.add('-end', target, 'typechange', '[silent]');
+					}
 				}
 			}
 		},


### PR DESCRIPTION
We caught that the Ability Masquerade was behaving strangely after some further testing, so this is a fix that I've tested and can confirm works better. Notable changes include that it now skips the last Pokémon and proceeds to the next one instead of giving up when an Ability cannot be copied, and that it can successfully activate more than once per battle, whereas the current implementation appears to fail every time following the first successful activation.

I also tweaked Mega Data Mod slightly so that it doesn't misreport type changes on Pokémon with Illusion. For example, if a Pokémon behind an Illusion was affected by Soak, it would look like this was cleared when it was hit. This no longer happens, and it now keeps the type change indicator if they don't match the types of its base species.

Let me know if there's anything I should change or any way I can help! (and sorry for making this mistake the first time around!)