### PR TITLE
Gen 1: Move Graveler to NFE

### DIFF
--- a/data/mods/gen1/formats-data.ts
+++ b/data/mods/gen1/formats-data.ts
@@ -388,7 +388,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	graveler: {
 		randomBattleMoves: ["bodyslam", "earthquake", "rockslide", "explosion"],
-		tier: "UU",
+		tier: "NFE",
 	},
 	golem: {
 		randomBattleMoves: ["explosion", "bodyslam", "earthquake", "rockslide"],


### PR DESCRIPTION
I originally brought this up with FOMG, and since then, clarification has been given. The RBY Council supports moving Graveler to NFE since Golem has dropped to UU (and will drop to NU should it be made official). There's a screenshot **[here](https://i.imgur.com/dhEt44O.png)**, I guess. 

FOMG originally told Kris but nothing seems to have happened for the past 2 and a half days, so I decided to make the PR myself rather than saddle him with more work. 

Should be mentioned that NU Live Tours in RoA were using Graveler all this time kekw