### PR TITLE
Chat: Track slow async commands

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1654,10 +1654,10 @@ export const Chat = new class {
 
 		return result;
 	}
-	logSlowMessage(deltaTime: number, context: CommandContext) {
+	logSlowMessage(timeUsed: number, context: CommandContext) {
 		const logRoom = Rooms.get('slowlog');
 		const logMessage = (
-			`[slow] ${deltaTime}ms - ${context.user.name} (${context.connection.ip}): ` +
+			`[slow] ${timeUsed}ms - ${context.user.name} (${context.connection.ip}): ` +
 			`<${context.room ? context.room.roomid : context.pmTarget ? `PM:${context.pmTarget?.name}` : 'CMD'}> ` +
 			`${context.message.replace(/\n/ig, ' ')}`
 		);

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1634,15 +1634,15 @@ export const Chat = new class {
 		const result = context.parse();
 		if (typeof result?.then === 'function') {
 			void result.then(() => {
-				const delta = Date.now() - start;
-				if (delta > 3000) {
-					this.logSlowMessage(delta, context);
+				const timeUsed = Date.now() - start;
+				if (timeUsed > 3000) {
+					this.logSlowMessage(timeUsed, context);
 				}
 			});
 		} else {
-			const delta = Date.now() - start;
-			if (delta > 1000) {
-				this.logSlowMessage(delta, context);
+			const timeUsed = Date.now() - start;
+			if (timeUsed > 1000) {
+				this.logSlowMessage(timeUsed, context);
 			}
 		}
 		if (room && room.log.getLineCount() !== initialRoomlogLength) {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -127,7 +127,6 @@ import {formatText, linkRegex, stripFormatting} from './chat-formatter';
 
 // @ts-ignore no typedef available
 import ProbeModule = require('probe-image-size');
-import { Monitor } from './monitor';
 const probe: (url: string) => Promise<{width: number, height: number}> = ProbeModule;
 
 const EMOJI_REGEX = /[\p{Emoji_Modifier_Base}\p{Emoji_Presentation}\uFE0F]/u;

--- a/server/users.ts
+++ b/server/users.ts
@@ -1670,13 +1670,8 @@ function socketReceive(worker: StreamWorker, workerid: number, socketid: string,
 		void FS('logs/emergency.log').append(`[${user} (${connection.ip})] ${roomId}|${message}\n`);
 	}
 
-	const startTime = Date.now();
 	for (const line of lines) {
 		if (user.chat(line, room, connection) === false) break;
-	}
-	const deltaTime = Date.now() - startTime;
-	if (deltaTime > 1000) {
-		Monitor.warn(`[slow] ${deltaTime}ms - ${user.name} <${connection.ip}>: ${roomId}|${message}`);
 	}
 }
 


### PR DESCRIPTION
The room was Zarel's suggestion - more accessible.
As a side note, I set errors to be logged since I figure knowing something lasted >3000ms before crashing is still useful knowledge.