### PR TITLE
Chat: Fix slow command logger

### DIFF
--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -524,7 +524,7 @@ export const commands: ChatCommands = {
 			return this.errorReply(this.tr`User ${targetUsername} is offline.`);
 		}
 
-		this.parse(target);
+		return this.parse(target);
 	},
 	msghelp: [`/msg OR /whisper OR /w [username], [message] - Send a private message.`],
 

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -484,7 +484,6 @@ export class CommandContext extends MessageContext {
 			this.user.setStatusType('online');
 		}
 
-		const start = Date.now();
 		try {
 			if (this.handler) {
 				if (this.handler.disabled) {
@@ -537,7 +536,6 @@ export class CommandContext extends MessageContext {
 					this.sendChatMessage(resolvedMessage);
 				}
 				this.update();
-				Chat.logSlowMessage(start, this);
 				if (resolvedMessage === false) return false;
 			}).catch(err => {
 				if (err.name?.endsWith('ErrorMessage')) {
@@ -560,7 +558,6 @@ export class CommandContext extends MessageContext {
 			});
 		} else if (message && message !== true) {
 			this.sendChatMessage(message as string);
-			Chat.logSlowMessage(start, this);
 		}
 
 		this.update();


### PR DESCRIPTION
The `return` makes it so async commands in pms are now properly propagated, which means they're now logged correctly.
This also removes the extra debugger.