### PR TITLE
/battlefactory: Fix searching for nonexistent tiers

### DIFF
--- a/server/chat-plugins/random-battles.ts
+++ b/server/chat-plugins/random-battles.ts
@@ -102,7 +102,7 @@ function battleFactorySets(species: string | Species, tier: string | null, gen =
 	if (!isBSS) {
 		if (!tier) return {e: `Please provide a valid tier.`};
 		if (!(toID(tier) in TIERS)) return {e: `That tier isn't supported.`};
-		if (['Mono', 'LC'].includes(tier) && genNum < 7) {
+		if (['Mono', 'LC'].includes(TIERS[toID(tier)]) && genNum < 7) {
 			return {e: `That tier is not included for that generation of Battle Factory.`};
 		}
 		const t = statsFile[TIERS[toID(tier)]];

--- a/server/chat-plugins/random-battles.ts
+++ b/server/chat-plugins/random-battles.ts
@@ -102,7 +102,9 @@ function battleFactorySets(species: string | Species, tier: string | null, gen =
 	if (!isBSS) {
 		if (!tier) return {e: `Please provide a valid tier.`};
 		if (!(toID(tier) in TIERS)) return {e: `That tier isn't supported.`};
-		if (['Mono', 'LC'].includes(tier) && genNum < 7) return {e: `That tier is not included for that generation of Battle Factory.`};
+		if (['Mono', 'LC'].includes(tier) && genNum < 7) {
+			return {e: `That tier is not included for that generation of Battle Factory.`};
+		}
 		const t = statsFile[TIERS[toID(tier)]];
 		if (!(species.id in t)) {
 			const formatName = Dex.getFormat(`${gen}battlefactory`).name;

--- a/server/chat-plugins/random-battles.ts
+++ b/server/chat-plugins/random-battles.ts
@@ -103,7 +103,7 @@ function battleFactorySets(species: string | Species, tier: string | null, gen =
 		if (!tier) return {e: `Please provide a valid tier.`};
 		if (!(toID(tier) in TIERS)) return {e: `That tier isn't supported.`};
 		if (['Mono', 'LC'].includes(TIERS[toID(tier)]) && genNum < 7) {
-			return {e: `That tier is not included for that generation of Battle Factory.`};
+			return {e: `${TIERS[toID(tier)]} is not included in [Gen ${genNum}] Battle Factory.`};
 		}
 		const t = statsFile[TIERS[toID(tier)]];
 		if (!(species.id in t)) {

--- a/server/chat-plugins/random-battles.ts
+++ b/server/chat-plugins/random-battles.ts
@@ -102,6 +102,7 @@ function battleFactorySets(species: string | Species, tier: string | null, gen =
 	if (!isBSS) {
 		if (!tier) return {e: `Please provide a valid tier.`};
 		if (!(toID(tier) in TIERS)) return {e: `That tier isn't supported.`};
+		if (['Mono', 'LC'].includes(tier) && genNum < 7) return {e: `That tier is not included for that generation of Battle Factory.`};
 		const t = statsFile[TIERS[toID(tier)]];
 		if (!(species.id in t)) {
 			const formatName = Dex.getFormat(`${gen}battlefactory`).name;


### PR DESCRIPTION
Searching for a Monotype or LC set in Gen 6 battle factory causes PS to puke so here's a fix.

