### PR TITLE
ProcessManager: Handle Monitor#slow in subprocesses

### DIFF
--- a/lib/process-manager.ts
+++ b/lib/process-manager.ts
@@ -126,11 +126,6 @@ export class QueryProcessWrapper<T, U> implements ProcessWrapper {
 				throw error;
 			}
 
-			if (message.startsWith(`SLOW\n`)) {
-				Monitor.slow(message.slice(5));
-				return;
-			}
-
 			if (message.startsWith('DEBUG\n')) {
 				this.debug = message.slice(6);
 				return;

--- a/lib/process-manager.ts
+++ b/lib/process-manager.ts
@@ -124,6 +124,11 @@ export class QueryProcessWrapper<T, U> implements ProcessWrapper {
 				throw error;
 			}
 
+			if (message.startsWith(`SLOW\n`)) {
+				Monitor.slow(message.slice(5));
+				return;
+			}
+
 			if (message.startsWith('DEBUG\n')) {
 				this.debug = message.slice(6);
 				return;
@@ -211,6 +216,11 @@ export class StreamProcessWrapper implements ProcessWrapper {
 				const error = new Error();
 				error.stack = message.slice(6);
 				throw error;
+			}
+
+			if (message.startsWith(`SLOW\n`)) {
+				Monitor.slow(message.slice(5));
+				return;
 			}
 
 			if (message.startsWith('DEBUG\n')) {

--- a/server/chat-plugins/battlesearch.ts
+++ b/server/chat-plugins/battlesearch.ts
@@ -368,8 +368,14 @@ export const commands: ChatCommands = {
 
 export const PM = new ProcessManager.QueryProcessManager<AnyObject, AnyObject>(module, async data => {
 	const {userids, turnLimit, month, tierid} = data;
+	const start = Date.now();
 	try {
-		return await runBattleSearch(userids, month, tierid, turnLimit);
+		const result = await runBattleSearch(userids, month, tierid, turnLimit);
+		const elapsedTime = Date.now() - start;
+		if (elapsedTime > 10 * 60 * 1000) {
+			Monitor.slow(`[Slow battlesearch query] ${elapsedTime}ms: ${JSON.stringify(data)}`);
+		}
+		return result;
 	} catch (err) {
 		Monitor.crashlog(err, 'A battle search query', {
 			userids,
@@ -388,6 +394,9 @@ if (!PM.isParentProcess) {
 		crashlog(error: Error, source = 'A battle search process', details: AnyObject | null = null) {
 			const repr = JSON.stringify([error.name, error.message, source, details]);
 			process.send!(`THROW\n@!!@${repr}\n${error.stack}`);
+		},
+		slow(text: string) {
+			process.send!(`SLOW\n${text}`);
 		},
 	};
 	process.on('uncaughtException', err => {

--- a/server/chat-plugins/battlesearch.ts
+++ b/server/chat-plugins/battlesearch.ts
@@ -385,7 +385,11 @@ export const PM = new ProcessManager.QueryProcessManager<AnyObject, AnyObject>(m
 		});
 	}
 	return null;
-}, BATTLESEARCH_PROCESS_TIMEOUT);
+}, BATTLESEARCH_PROCESS_TIMEOUT, message => {
+	if (message.startsWith('SLOW\n')) {
+		Monitor.slow(message.slice(5));
+	}
+});
 
 if (!PM.isParentProcess) {
 	// This is a child process!
@@ -396,7 +400,7 @@ if (!PM.isParentProcess) {
 			process.send!(`THROW\n@!!@${repr}\n${error.stack}`);
 		},
 		slow(text: string) {
-			process.send!(`SLOW\n${text}`);
+			process.send!(`CALLBACK\nSLOW\n${text}`);
 		},
 	};
 	process.on('uncaughtException', err => {

--- a/server/chat-plugins/chatlog.ts
+++ b/server/chat-plugins/chatlog.ts
@@ -1035,6 +1035,7 @@ export const PM = new ProcessManager.QueryProcessManager<AnyObject, any>(module,
 			break;
 		case 'sharedsearch':
 			result = await LogSearcher.getSharedBattles(search);
+			break;
 		case 'battlesearch':
 			result = await LogReader.findBattleLog(roomid, search);
 			break;

--- a/server/chat-plugins/chatlog.ts
+++ b/server/chat-plugins/chatlog.ts
@@ -1053,7 +1053,11 @@ export const PM = new ProcessManager.QueryProcessManager<AnyObject, any>(module,
 		Monitor.crashlog(e, 'A chatlog search query', data);
 		return LogViewer.error(`Sorry! Your chatlog search crashed. We've been notified and will fix this.`);
 	}
-}, CHATLOG_PM_TIMEOUT);
+}, CHATLOG_PM_TIMEOUT, message => {
+	if (message.startsWith(`SLOW\n`)) {
+		Monitor.slow(message.slice(5));
+	}
+});
 
 if (!PM.isParentProcess) {
 	// This is a child process!
@@ -1064,7 +1068,7 @@ if (!PM.isParentProcess) {
 			process.send!(`THROW\n@!!@${repr}\n${error.stack}`);
 		},
 		slow(text: string) {
-			process.send!(`SLOW\n${text}`);
+			process.send!(`CALLBACK\nSLOW\n${text}`);
 		},
 	};
 	global.Dex = Dex;

--- a/server/chat-plugins/chatlog.ts
+++ b/server/chat-plugins/chatlog.ts
@@ -1022,20 +1022,30 @@ export class RipgrepLogSearcher extends Searcher {
 export const LogSearcher: Searcher = new (Config.chatlogreader === 'ripgrep' ? RipgrepLogSearcher : FSLogSearcher)();
 
 export const PM = new ProcessManager.QueryProcessManager<AnyObject, any>(module, async data => {
+	const start = Date.now();
 	try {
+		let result: any;
 		const {date, search, roomid, limit, queryType} = data;
 		switch (queryType) {
 		case 'linecount':
-			return LogSearcher.searchLinecounts(roomid, date, search);
+			result = await LogSearcher.searchLinecounts(roomid, date, search);
+			break;
 		case 'search':
-			return LogSearcher.searchLogs(roomid, search, limit, date);
+			result = await LogSearcher.searchLogs(roomid, search, limit, date);
+			break;
 		case 'sharedsearch':
-			return LogSearcher.getSharedBattles(search);
+			result = await LogSearcher.getSharedBattles(search);
 		case 'battlesearch':
-			return LogReader.findBattleLog(roomid, search);
+			result = await LogReader.findBattleLog(roomid, search);
+			break;
 		default:
 			return LogViewer.error(`Config.chatlogreader is not configured.`);
 		}
+		const elapsedTime = Date.now() - start;
+		if (elapsedTime > 3000) {
+			Monitor.slow(`[Slow chatlog query]: ${elapsedTime}ms: ${JSON.stringify(data)}`);
+		}
+		return result;
 	} catch (e) {
 		if (e.name?.endsWith('ErrorMessage')) {
 			return LogViewer.error(e.message);
@@ -1052,6 +1062,9 @@ if (!PM.isParentProcess) {
 		crashlog(error: Error, source = 'A chatlog search process', details: AnyObject | null = null) {
 			const repr = JSON.stringify([error.name, error.message, source, details]);
 			process.send!(`THROW\n@!!@${repr}\n${error.stack}`);
+		},
+		slow(text: string) {
+			process.send!(`SLOW\n${text}`);
 		},
 	};
 	global.Dex = Dex;

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1196,7 +1196,7 @@ export class RoomBattleStream extends BattleStream {
 		if (this.battle) this.battle.sendUpdates();
 		const deltaTime = Date.now() - startTime;
 		if (deltaTime > 1000) {
-			Monitor.slow(`[slow battle] ${deltaTime}ms - ${chunk}`);
+			Monitor.slow(`[slow battle] ${deltaTime}ms - ${chunk.replace(/\n/ig, ' | ')}`);
 		}
 	}
 }
@@ -1216,6 +1216,9 @@ if (!PM.isParentProcess) {
 		crashlog(error: Error, source = 'A simulator process', details: AnyObject | null = null) {
 			const repr = JSON.stringify([error.name, error.message, source, details]);
 			process.send!(`THROW\n@!!@${repr}\n${error.stack}`);
+		},
+		slow(text: string) {
+			process.send!(`SLOW\n${text}`);
 		},
 	};
 	global.__version = {head: ''};

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1211,7 +1211,7 @@ export const PM = new ProcessManager.StreamProcessManager(module,
 		if (message.startsWith(`SLOW\n`)) {
 			Monitor.slow(message.slice(5));
 		}
-	},
+	}
 );
 
 if (!PM.isParentProcess) {

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1205,14 +1205,11 @@ export class RoomBattleStream extends BattleStream {
  * Process manager
  *********************************************************/
 
-export const PM = new ProcessManager.StreamProcessManager(module,
-	() => new RoomBattleStream(),
-	message => {
-		if (message.startsWith(`SLOW\n`)) {
-			Monitor.slow(message.slice(5));
-		}
+export const PM = new ProcessManager.StreamProcessManager(module, () => new RoomBattleStream(), message => {
+	if (message.startsWith(`SLOW\n`)) {
+		Monitor.slow(message.slice(5));
 	}
-);
+});
 
 if (!PM.isParentProcess) {
 	// This is a child process!

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1205,7 +1205,14 @@ export class RoomBattleStream extends BattleStream {
  * Process manager
  *********************************************************/
 
-export const PM = new ProcessManager.StreamProcessManager(module, () => new RoomBattleStream());
+export const PM = new ProcessManager.StreamProcessManager(module,
+	() => new RoomBattleStream(),
+	message => {
+		if (message.startsWith(`SLOW\n`)) {
+			Monitor.slow(message.slice(5));
+		}
+	},
+);
 
 if (!PM.isParentProcess) {
 	// This is a child process!
@@ -1218,7 +1225,7 @@ if (!PM.isParentProcess) {
 			process.send!(`THROW\n@!!@${repr}\n${error.stack}`);
 		},
 		slow(text: string) {
-			process.send!(`SLOW\n${text}`);
+			process.send!(`CALLBACK\nSLOW\n${text}`);
 		},
 	};
 	global.__version = {head: ''};


### PR DESCRIPTION
Fixes ``A simulator process crashed: TypeError: Monitor.slow is not a function``