### PR TITLE
Fix minor activity timer not queuing polls

### DIFF
--- a/server/chat-plugins/poll.ts
+++ b/server/chat-plugins/poll.ts
@@ -409,7 +409,8 @@ export const commands: ChatCommands = {
 
 			if (room.minorActivity) {
 				room.queueMinorActivity({
-					question: params[0], answers: questions, multiPoll, supportHTML, activityid: 'poll',
+					// @ts-ignore
+					question: params[0], answers: questions, multiPoll, supportHTML, activityid: 'poll', class: Poll,
 				});
 				this.modlog('QUEUEPOLL');
 				return this.privateModAction(room.tr`${user.name} queued a poll.`);

--- a/server/chat-plugins/poll.ts
+++ b/server/chat-plugins/poll.ts
@@ -410,7 +410,7 @@ export const commands: ChatCommands = {
 			if (room.minorActivity) {
 				room.queueMinorActivity({
 					// @ts-ignore
-					question: params[0], answers: questions, multiPoll, supportHTML, activityid: 'poll', class: Poll,
+					question: params[0], answers: questions, multiPoll, supportHTML, activityid: 'poll',
 				});
 				this.modlog('QUEUEPOLL');
 				return this.privateModAction(room.tr`${user.name} queued a poll.`);

--- a/server/chat-plugins/poll.ts
+++ b/server/chat-plugins/poll.ts
@@ -409,7 +409,6 @@ export const commands: ChatCommands = {
 
 			if (room.minorActivity) {
 				room.queueMinorActivity({
-					// @ts-ignore
 					question: params[0], answers: questions, multiPoll, supportHTML, activityid: 'poll',
 				});
 				this.modlog('QUEUEPOLL');

--- a/server/room-minor-activity.ts
+++ b/server/room-minor-activity.ts
@@ -32,6 +32,7 @@ export interface MinorActivityData {
 	totalVotes?: number;
 	isQuiz?: boolean;
 	answers: string[] | {name: string, votes: number, correct?: boolean}[];
+	class?: MinorActivity;
 }
 
 // globally Rooms.MinorActivity
@@ -95,7 +96,10 @@ export abstract class MinorActivity {
 			});
 
 			if (!MinorActivityClass) {
-				if (pollData.activityid === 'poll') throw new Error('No minorActivity class provided');
+				// hacky fix to make poll queues work with timers
+				const Poll = pollData.class;
+				// @ts-ignore
+				if (pollData.activityid === 'poll') room.setMinorActivity(new Poll(room, pollData));
 			} else {
 				room.setMinorActivity(new MinorActivityClass(room, pollData));
 			}

--- a/server/room-minor-activity.ts
+++ b/server/room-minor-activity.ts
@@ -96,10 +96,10 @@ export abstract class MinorActivity {
 			});
 
 			if (!MinorActivityClass) {
-				// hacky fix to make poll queues work with timers
-				const Poll = pollData.class;
-				// @ts-ignore
-				if (pollData.activityid === 'poll') room.setMinorActivity(new Poll(room, pollData));
+				if (pollData.activityid === 'poll') {
+					const {Poll} = require('./chat-plugins/poll');
+					room.setMinorActivity(new Poll(room, pollData));
+				}
 			} else {
 				room.setMinorActivity(new MinorActivityClass(room, pollData));
 			}

--- a/server/room-minor-activity.ts
+++ b/server/room-minor-activity.ts
@@ -32,7 +32,6 @@ export interface MinorActivityData {
 	totalVotes?: number;
 	isQuiz?: boolean;
 	answers: string[] | {name: string, votes: number, correct?: boolean}[];
-	class?: MinorActivity;
 }
 
 // globally Rooms.MinorActivity


### PR DESCRIPTION
the ``ts-ignores`` are because when i added ``class: Poll`` it says some properties are missing and the other one is "type MinorActivity has no construct signatures". If you recommend handling the errors some way else lmk.

personally I wish it was possible to import poll.ts to room-minor-activity without it crashing on boot but if it was then the ``throw new Error`` line would have never been necessary