### PR TITLE
Gen 1: Stadium Haze should cure user's status

### DIFF
--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -47,7 +47,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			for (const pokemon of this.getAllActive()) {
 				pokemon.clearBoosts();
 				if (pokemon.status !== 'tox') {
-					//This should cure the status of both Pokemon, and subsequently recalculate stats to remove the Paralysis/Burn Speed Drop.
+					// This should cure the status of both Pokemon, and subsequently recalculate stats to remove the Paralysis/Burn Speed Drop.
 					pokemon.cureStatus();
 					pokemon.recalculateStats();
 				}

--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -41,7 +41,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		// FIXME: onBeforeMove() {},
 	},
 	haze: {
-		haze: {
 		inherit: true,
 		onHit(target, source) {
 			this.add('-clearallboost');

--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -48,6 +48,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				pokemon.clearBoosts();
 				// This should cure the status of both Pokemon, and subsequently recalculate stats to remove the Paralysis/Burn Speed Drop.
 				pokemon.cureStatus();
+				pokemon.removeVolatile(id);
+				this.add('-end', pokemon, id);
 				target.recalculateStats!();
 			}
 		},

--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -46,24 +46,11 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			this.add('-clearallboost');
 			for (const pokemon of this.getAllActive()) {
 				pokemon.clearBoosts();
-				if (pokemon.status !== 'tox') {
-					// This should cure the status of both Pokemon, and subsequently recalculate stats to remove the Paralysis/Burn Speed Drop.
-					pokemon.cureStatus();
-					target.recalculateStats!();
+				// This should cure the status of both Pokemon, and subsequently recalculate stats to remove the Paralysis/Burn Speed Drop.
+				pokemon.cureStatus();
+				target.recalculateStats!();
 				}
-				if (pokemon.status === 'tox') {
-					pokemon.setStatus('psn');
-				}
-				for (const id of Object.keys(pokemon.volatiles)) {
-					if (id === 'residualdmg') {
-						pokemon.volatiles[id].counter = 0;
-					} else {
-						pokemon.removeVolatile(id);
-						this.add('-end', pokemon, id);
-					}
-				}
-			}
-		},
+			},
 		target: "self",
 	},
 	highjumpkick: {

--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -48,8 +48,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				pokemon.clearBoosts();
 				// This should cure the status of both Pokemon, and subsequently recalculate stats to remove the Paralysis/Burn Speed Drop.
 				pokemon.cureStatus();
-				pokemon.removeVolatile(id);
-				this.add('-end', pokemon, id);
+				for (const id of Object.keys(pokemon.volatiles)) {
+					pokemon.removeVolatile(id);
+					this.add('-end', pokemon, id);
+				}
 				target.recalculateStats!();
 			}
 		},

--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -49,7 +49,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				if (pokemon.status !== 'tox') {
 					// This should cure the status of both Pokemon, and subsequently recalculate stats to remove the Paralysis/Burn Speed Drop.
 					pokemon.cureStatus();
-					target.recalculateStats();
+					target.recalculateStats!();
 				}
 				if (pokemon.status === 'tox') {
 					pokemon.setStatus('psn');

--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -40,6 +40,33 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		// FIXME: onBeforeMove() {},
 	},
+	haze: {
+		haze: {
+		inherit: true,
+		onHit(target, source) {
+			this.add('-clearallboost');
+			for (const pokemon of this.getAllActive()) {
+				pokemon.clearBoosts();
+				if (pokemon.status !== 'tox') {
+					//This should cure the status of both Pokemon, and subsequently recalculate stats to remove the Paralysis/Burn Speed Drop.
+					pokemon.cureStatus();
+					pokemon.recalculateStats();
+				}
+				if (pokemon.status === 'tox') {
+					pokemon.setStatus('psn');
+				}
+				for (const id of Object.keys(pokemon.volatiles)) {
+					if (id === 'residualdmg') {
+						pokemon.volatiles[id].counter = 0;
+					} else {
+						pokemon.removeVolatile(id);
+						this.add('-end', pokemon, id);
+					}
+				}
+			}
+		},
+		target: "self",
+	},
 	highjumpkick: {
 		inherit: true,
 		desc: "If this attack misses the target, the user takes 1 HP of damage.",

--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -55,7 +55,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				target.recalculateStats!();
 			}
 		},
-		target: "self",
 	},
 	highjumpkick: {
 		inherit: true,

--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -49,8 +49,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				// This should cure the status of both Pokemon, and subsequently recalculate stats to remove the Paralysis/Burn Speed Drop.
 				pokemon.cureStatus();
 				target.recalculateStats!();
-				}
-			},
+			}
+		},
 		target: "self",
 	},
 	highjumpkick: {

--- a/data/mods/stadium/moves.ts
+++ b/data/mods/stadium/moves.ts
@@ -49,7 +49,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				if (pokemon.status !== 'tox') {
 					// This should cure the status of both Pokemon, and subsequently recalculate stats to remove the Paralysis/Burn Speed Drop.
 					pokemon.cureStatus();
-					pokemon.recalculateStats();
+					target.recalculateStats();
 				}
 				if (pokemon.status === 'tox') {
 					pokemon.setStatus('psn');


### PR DESCRIPTION
So, to be clear: this doesn't fix the whole host of bugs this move has. There's a lot of them.

This fix intends to give Haze its "refresh" effect that it has exclusively in Stadium. Not only does it cure the opponent's status, but it also cures the user's as well. This is an important change for Vaporeon in particular, as it makes a decent status absorber. There _may_ be a better way to implement this, I'm not sure, but I'm guessing this'll receive edits during review. My code seems a touch inefficient?

Here is my implementation working on the RBY Server and my subsequent freakout: 
https://replay.pokemonshowdown.com/rby-gen1stadiumou-1735

This addresses part of my vitriolic criticisms of the Haze implementation here:
https://www.smogon.com/forums/threads/stadium-format-is-now-available-on-ps.3526616/post-8503308

For a video of what the implementation should look like, go here: 
https://www.youtube.com/watch?v=LoTM-tsop68
This will also verify what you see on my replay and such. 

Credit to Beelzemon 2003 for assistance with the initial testing of Stadium Haze.