### PR TITLE
Gen 2: Ban JP Phanpy Event in Int Formats

### DIFF
--- a/data/mods/gen2/learnsets.ts
+++ b/data/mods/gen2/learnsets.ts
@@ -11590,7 +11590,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 		},
 		eventData: [
 			{generation: 2, level: 5, shiny: 1, moves: ["tackle", "growl", "absorb"]},
-			{generation: 2, level: 5, moves: ["tackle", "growl", "encore"]},
+			{generation: 2, level: 5, moves: ["tackle", "growl", "encore"], japan: true},
 		],
 	},
 	donphan: {


### PR DESCRIPTION
As a follow-up to this Pull Request: https://github.com/smogon/pokemon-showdown/pull/7581
And in response to this: https://www.smogon.com/forums/threads/gen-2-ps-development-post-bugs-here.3524926/page-16#post-8746635

GSC is similar to RBY in that if you trade with a game with different letter characters, it'll corrupt your save file. As such, it is impossible to obtain this Phanpy in western copies of GSC. This can also be applied to Korean events, though as far as I know, they never got any notable ones nor any with special moves. I believe this is the only Japanese GSC event that did not get imported.

This effectively removes Encore Phanpy and Donphan from Gen 2 OU. 

Thanks to Zarel for alerting me to do this!

(also what a nerf between regions holy shit imagine having encore replaced with absorb LMFAOOOO)