### PR TITLE
Random Battles: Refactor for code standards and readability

### DIFF
--- a/data/mods/gen2/random-teams.ts
+++ b/data/mods/gen2/random-teams.ts
@@ -162,10 +162,7 @@ export class RandomGen2Teams extends RandomGen3Teams {
 					if (hasMove['bodyslam'] || hasMove['surf'] || restTalk) rejected = true;
 					break;
 				case 'lovelykiss':
-					if (
-						['healbell', 'moonlight', 'morningsun'].some(m => hasMove[m]) ||
-						(restTalk)
-					) rejected = true;
+					if (['healbell', 'moonlight', 'morningsun'].some(m => hasMove[m]) || restTalk) rejected = true;
 					break;
 				case 'sleeptalk':
 					if (hasMove['curse'] && counter.stab >= 2) rejected = true;

--- a/data/mods/gen2/random-teams.ts
+++ b/data/mods/gen2/random-teams.ts
@@ -1,5 +1,3 @@
-/* eslint max-len: ["error", 240] */
-
 import RandomGen3Teams from '../gen3/random-teams';
 import {PRNG, PRNGSeed} from '../../../sim/prng';
 
@@ -69,11 +67,15 @@ export class RandomGen2Teams extends RandomGen3Teams {
 				let rejected = false;
 				let isSetup = false;
 
+				const restTalk = hasMove['rest'] && hasMove['sleeptalk'];
+
 				switch (moveid) {
 				// Set up once and only if we have the moves for it
 				case 'bellydrum': case 'curse': case 'meditate': case 'screech': case 'swordsdance':
 					if (counter.setupType !== 'Physical' || counter['physicalsetup'] > 1) rejected = true;
-					if (!counter['Physical'] || counter.damagingMoves.length < 2 && !hasMove['batonpass'] && !hasMove['sleeptalk']) rejected = true;
+					if (!counter['Physical'] || counter.damagingMoves.length < 2 && !hasMove['batonpass'] && !hasMove['sleeptalk']) {
+						rejected = true;
+					}
 					isSetup = true;
 					break;
 
@@ -96,7 +98,7 @@ export class RandomGen2Teams extends RandomGen3Teams {
 					if (counter.setupType) rejected = true;
 					break;
 				case 'haze':
-					if (counter.setupType || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (counter.setupType || restTalk) rejected = true;
 					break;
 				case 'reflect': case 'lightscreen':
 					if (counter.setupType || hasMove['rest']) rejected = true;
@@ -110,7 +112,7 @@ export class RandomGen2Teams extends RandomGen3Teams {
 					if (hasMove['softboiled']) rejected = true;
 					break;
 				case 'extremespeed':
-					if (hasMove['bodyslam'] || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (hasMove['bodyslam'] || restTalk) rejected = true;
 					break;
 				case 'hyperbeam':
 					if (hasMove['rockslide']) rejected = true;
@@ -154,13 +156,16 @@ export class RandomGen2Teams extends RandomGen3Teams {
 
 				// Status and illegal move rejections
 				case 'confuseray': case 'roar': case 'whirlwind':
-					if (hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (restTalk) rejected = true;
 					break;
 				case 'encore':
-					if (hasMove['bodyslam'] || hasMove['surf'] || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (hasMove['bodyslam'] || hasMove['surf'] || restTalk) rejected = true;
 					break;
 				case 'lovelykiss':
-					if (hasMove['healbell'] || hasMove['moonlight'] || hasMove['morningsun'] || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (
+						['healbell', 'moonlight', 'morningsun'].some(m => hasMove[m]) ||
+						(restTalk)
+					) rejected = true;
 					break;
 				case 'sleeptalk':
 					if (hasMove['curse'] && counter.stab >= 2) rejected = true;
@@ -187,7 +192,11 @@ export class RandomGen2Teams extends RandomGen3Teams {
 					rejected = true;
 				}
 
-				if ((!rejected && !isSetup && (move.category !== 'Status' || !move.flags.heal) && (counter.setupType || !move.stallingMove) && !['batonpass', 'sleeptalk', 'spikes', 'sunnyday'].includes(moveid)) &&
+				if ((
+					!rejected && !isSetup &&
+					(move.category !== 'Status' || !move.flags.heal) &&
+					(counter.setupType || !move.stallingMove) &&
+					!['batonpass', 'sleeptalk', 'spikes', 'sunnyday'].includes(moveid)) &&
 				(
 					// Pokemon should have moves that benefit their attributes
 					(!counter['stab'] && !counter['damage'] && !hasType['Ghost'] && counter['physicalpool'] + counter['specialpool'] > 0) ||
@@ -211,7 +220,10 @@ export class RandomGen2Teams extends RandomGen3Teams {
 				}
 
 				// Remove rejected moves from the move list
-				if (rejected && (movePool.length - availableHP || availableHP && (moveid === 'hiddenpower' || !hasMove['hiddenpower']))) {
+				if (
+					rejected &&
+					(movePool.length - availableHP || availableHP && (moveid === 'hiddenpower' || !hasMove['hiddenpower']))
+				) {
 					if (move.category !== 'Status' && !move.damage && (moveid !== 'hiddenpower' || !availableHP)) {
 						rejectedPool.push(moves[k]);
 					}
@@ -267,7 +279,12 @@ export class RandomGen2Teams extends RandomGen3Teams {
 			// Medium priority
 		} else if (hasMove['rest'] && !hasMove['sleeptalk']) {
 			item = 'Mint Berry';
-		} else if ((hasMove['bellydrum'] || hasMove['swordsdance']) && species.baseStats.spe >= 60 && !hasType['Ground'] && !hasMove['sleeptalk'] && !hasMove['substitute'] && this.randomChance(1, 2)) {
+		} else if (
+			(hasMove['bellydrum'] || hasMove['swordsdance']) &&
+			species.baseStats.spe >= 60 && !hasType['Ground'] &&
+			!hasMove['sleeptalk'] && !hasMove['substitute'] &&
+			this.randomChance(1, 2)
+		) {
 			item = 'Miracle Berry';
 
 		// Default to Leftovers

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -452,9 +452,9 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		) {
 			item = 'Salac Berry';
 		} else if (hasMove['endure'] || (hasMove['substitute'] && ['endeavor', 'flail', 'reversal'].some(m => hasMove[m]))) {
-			item = (species.baseStats.spe <= 100 && ability !== 'Speed Boost' && !counter['speedsetup'] && !hasMove['focuspunch']) ?
-				'Salac Berry' :
-				'Liechi Berry';
+			item = (
+				species.baseStats.spe <= 100 && ability !== 'Speed Boost' && !counter['speedsetup'] && !hasMove['focuspunch']
+			) ? 'Salac Berry' : 'Liechi Berry';
 		} else if (hasMove['substitute'] && counter.Physical >= 3 && species.baseStats.spe >= 120) {
 			item = 'Liechi Berry';
 		} else if ((hasMove['substitute'] || hasMove['raindance']) && counter.Special >= 3) {

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -219,7 +219,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 					if (counter.setupType || hasMove['thunderbolt']) rejected = true;
 					break;
 				case 'spikes':
-					if (counter.setupType || hasMove['substitute'] || (restTalk) || teamDetails.spikes) {
+					if (counter.setupType || hasMove['substitute'] || restTalk || teamDetails.spikes) {
 						rejected = true;
 					}
 					break;
@@ -228,7 +228,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 					if (!hasMove['batonpass'] && movePool.includes('calmmind')) rejected = true;
 					break;
 				case 'thunderwave':
-					if (counter.setupType || hasMove['bodyslam'] || hasMove['substitute'] || (restTalk)) {
+					if (counter.setupType || hasMove['bodyslam'] || hasMove['substitute'] || restTalk) {
 						rejected = true;
 					}
 					break;

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -1,5 +1,3 @@
-/* eslint max-len: ["error", 240] */
-
 import RandomGen4Teams from '../gen4/random-teams';
 import {PRNG, PRNGSeed} from '../../../sim/prng';
 
@@ -84,21 +82,31 @@ export class RandomGen3Teams extends RandomGen4Teams {
 				let rejected = false;
 				let isSetup = false;
 
+				const restTalk = hasMove['rest'] && hasMove['sleeptalk'];
+
 				switch (moveid) {
 				// Set up once and only if we have the moves for it
 				case 'bulkup': case 'curse': case 'dragondance': case 'swordsdance':
 					if (counter.setupType !== 'Physical' || counter['physicalsetup'] > 1) rejected = true;
-					if (counter.Physical + counter['physicalpool'] < 2 && !hasMove['batonpass'] && (!hasMove['rest'] || !hasMove['sleeptalk'])) rejected = true;
+					if (
+						counter.Physical + counter['physicalpool'] < 2 &&
+						!hasMove['batonpass'] &&
+						(!hasMove['rest'] || !hasMove['sleeptalk'])
+					) rejected = true;
 					isSetup = true;
 					break;
 				case 'calmmind':
 					if (counter.setupType !== 'Special') rejected = true;
-					if (counter.Special + counter['specialpool'] < 2 && !hasMove['batonpass'] && (!hasMove['rest'] || !hasMove['sleeptalk'])) rejected = true;
+					if (
+						counter.Special + counter['specialpool'] < 2 &&
+						!hasMove['batonpass'] &&
+						(!hasMove['rest'] || !hasMove['sleeptalk'])
+					) rejected = true;
 					isSetup = true;
 					break;
 				case 'agility':
 					if (counter.damagingMoves.length < 2 && !hasMove['batonpass']) rejected = true;
-					if (hasMove['substitute'] || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (hasMove['substitute'] || restTalk) rejected = true;
 					if (!counter.setupType) isSetup = true;
 					break;
 
@@ -119,7 +127,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 					break;
 				case 'endeavor': case 'flail': case 'reversal':
 					if (!hasMove['endure'] && !hasMove['substitute']) rejected = true;
-					if (hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (restTalk) rejected = true;
 					break;
 				case 'endure':
 					if (movePool.includes('destinybond')) rejected = true;
@@ -160,10 +168,10 @@ export class RandomGen3Teams extends RandomGen4Teams {
 					if (hasMove['rest'] || teamDetails['statusCure']) rejected = true;
 					break;
 				case 'confuseray':
-					if (counter.setupType || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (counter.setupType || restTalk) rejected = true;
 					break;
 				case 'counter': case 'mirrorcoat':
-					if (counter.setupType || hasMove['rest'] || hasMove['substitute'] || hasMove['toxic']) rejected = true;
+					if (counter.setupType || ['rest', 'substitute', 'toxic'].some(m => hasMove[m])) rejected = true;
 					break;
 				case 'destinybond':
 					if (counter.setupType || hasMove['explosion'] || hasMove['selfdestruct']) rejected = true;
@@ -172,13 +180,13 @@ export class RandomGen3Teams extends RandomGen4Teams {
 					if (counter.Status >= 1 || moveid === 'doubleedge' && hasMove['return']) rejected = true;
 					break;
 				case 'encore': case 'painsplit': case 'recover': case 'yawn':
-					if (hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (restTalk) rejected = true;
 					break;
 				case 'explosion': case 'machpunch': case 'selfdestruct':
 					if (hasMove['rest'] || hasMove['substitute'] || !!counter['recovery']) rejected = true;
 					break;
 				case 'haze':
-					if (counter.setupType || hasMove['raindance'] || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (counter.setupType || hasMove['raindance'] || restTalk) rejected = true;
 					break;
 				case 'icywind': case 'pursuit': case 'superpower': case 'transform':
 					if (counter.setupType || hasMove['rest']) rejected = true;
@@ -211,18 +219,25 @@ export class RandomGen3Teams extends RandomGen4Teams {
 					if (counter.setupType || hasMove['thunderbolt']) rejected = true;
 					break;
 				case 'spikes':
-					if (counter.setupType || hasMove['substitute'] || (hasMove['rest'] && hasMove['sleeptalk']) || teamDetails.spikes) rejected = true;
+					if (counter.setupType || hasMove['substitute'] || (restTalk) || teamDetails.spikes) {
+						rejected = true;
+					}
 					break;
 				case 'substitute':
 					if (hasMove['rest'] || hasMove['dragondance'] && !hasMove['bellydrum']) rejected = true;
 					if (!hasMove['batonpass'] && movePool.includes('calmmind')) rejected = true;
 					break;
 				case 'thunderwave':
-					if (counter.setupType || hasMove['bodyslam'] || hasMove['substitute'] || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (counter.setupType || hasMove['bodyslam'] || hasMove['substitute'] || (restTalk)) {
+						rejected = true;
+					}
 					break;
 				case 'toxic':
-					if (counter.setupType || !!counter['speedsetup'] || hasMove['endure'] || hasMove['raindance'] || hasMove['substitute']) rejected = true;
-					if (hasMove['hypnosis'] || hasMove['yawn']) rejected = true;
+					if (
+						counter.setupType ||
+						counter.speedsetup ||
+						['endure', 'raindance', 'substitute', 'yawn', 'hypnosis'].some(m => hasMove[m])
+					) rejected = true;
 					break;
 				case 'trick':
 					if (counter.Status > 1) rejected = true;
@@ -262,7 +277,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 					break;
 				case 'hiddenpower':
 					if (move.type === 'Grass' && hasMove['sunnyday'] && hasMove['solarbeam']) rejected = true;
-					if (!hasType[move.type] && (hasMove['substitute'] || hasMove['toxic'] || hasMove['rest'] && hasMove['sleeptalk'])) rejected = true;
+					if (!hasType[move.type] && (hasMove['substitute'] || hasMove['toxic'] || restTalk)) rejected = true;
 					break;
 				case 'brickbreak': case 'crosschop': case 'highjumpkick': case 'skyuppercut':
 					if (hasMove['substitute'] && (hasMove['focuspunch'] || movePool.includes('focuspunch'))) rejected = true;
@@ -281,10 +296,19 @@ export class RandomGen3Teams extends RandomGen4Teams {
 					rejected = true;
 				}
 
-				if ((!rejected && !isSetup && !move.weather && (move.category !== 'Status' || !move.flags.heal) && (counter.setupType || !move.stallingMove) && !['batonpass', 'sleeptalk', 'substitute'].includes(moveid)) &&
-				(
+				if ((
+					!rejected &&
+					!isSetup &&
+					!move.weather &&
+					(move.category !== 'Status' || !move.flags.heal) &&
+					(counter.setupType || !move.stallingMove) &&
+					!['batonpass', 'sleeptalk', 'substitute'].includes(moveid)
+				) && (
 					// Pokemon should have moves that benefit their attributes
-					(!counter['stab'] && !counter['damage'] && !counter['Ice'] && !counter.setupType && counter['physicalpool'] + counter['specialpool'] > 0) ||
+					(
+						!counter['stab'] && !counter['damage'] && !counter['Ice'] &&
+						!counter.setupType && counter['physicalpool'] + counter['specialpool'] > 0
+					) ||
 					(counter.setupType && counter[counter.setupType] < 2) ||
 					(hasType['Bug'] && (movePool.includes('megahorn') || (!species.types[1] && movePool.includes('hiddenpowerbug')))) ||
 					(hasType['Electric'] && !counter['Electric']) ||
@@ -292,7 +316,11 @@ export class RandomGen3Teams extends RandomGen4Teams {
 					(hasType['Fire'] && !counter['Fire']) ||
 					(hasType['Ground'] && !counter['Ground']) ||
 					(hasType['Normal'] && !counter['Normal'] && counter.setupType === 'Physical') ||
-					(hasType['Psychic'] && (movePool.includes('psychic') || movePool.includes('psychoboost')) && species.baseStats.spa >= 100) ||
+					(
+						hasType['Psychic'] &&
+						(movePool.includes('psychic') || movePool.includes('psychoboost')) &&
+						species.baseStats.spa >= 100
+					) ||
 					(hasType['Rock'] && !counter['Rock'] && species.baseStats.atk >= 100) ||
 					(hasType['Water'] && !counter['Water'] && counter.setupType !== 'Physical' && species.baseStats.spa >= 60) ||
 					(movePool.includes('meteormash') || movePool.includes('spore')) ||
@@ -319,7 +347,10 @@ export class RandomGen3Teams extends RandomGen4Teams {
 				}
 
 				// Remove rejected moves from the move list
-				if (rejected && (movePool.length - availableHP || availableHP && (moveid === 'hiddenpower' || !hasMove['hiddenpower']))) {
+				if (
+					rejected &&
+					(movePool.length - availableHP || availableHP && (moveid === 'hiddenpower' || !hasMove['hiddenpower']))
+				) {
 					if (move.category !== 'Status' && !move.damage && (moveid !== 'hiddenpower' || !availableHP)) {
 						rejectedPool.push(moves[k]);
 					}
@@ -415,17 +446,25 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			item = 'Chesto Berry';
 
 		// Medium priority
-		} else if ((hasMove['bellydrum'] && counter.Physical - counter['priority'] > 1) || (hasMove['swordsdance'] && counter.Status < 2)) {
+		} else if (
+			(hasMove['bellydrum'] && counter.Physical - counter['priority'] > 1) ||
+			(hasMove['swordsdance'] && counter.Status < 2)
+		) {
 			item = 'Salac Berry';
-		} else if (hasMove['endure'] || (hasMove['substitute'] && (hasMove['endeavor'] || hasMove['flail'] || hasMove['reversal']))) {
-			item = (species.baseStats.spe <= 100 && ability !== 'Speed Boost' && !counter['speedsetup'] && !hasMove['focuspunch']) ? 'Salac Berry' : 'Liechi Berry';
+		} else if (hasMove['endure'] || (hasMove['substitute'] && ['endeavor', 'flail', 'reversal'].some(m => hasMove[m]))) {
+			item = (species.baseStats.spe <= 100 && ability !== 'Speed Boost' && !counter['speedsetup'] && !hasMove['focuspunch']) ?
+				'Salac Berry' :
+				'Liechi Berry';
 		} else if (hasMove['substitute'] && counter.Physical >= 3 && species.baseStats.spe >= 120) {
 			item = 'Liechi Berry';
 		} else if ((hasMove['substitute'] || hasMove['raindance']) && counter.Special >= 3) {
 			item = 'Petaya Berry';
 		} else if (counter.Physical >= 4) {
 			item = 'Choice Band';
-		} else if (counter.Physical >= 3 && (hasMove['firepunch'] || hasMove['icebeam'] || hasMove['overheat'] || moves.filter(m => this.dex.data.Moves[m].category === 'Special' && hasType[this.dex.data.Moves[m].type]).length)) {
+		} else if (counter.Physical >= 3 && (
+			['firepunch', 'icebeam', 'overheat'].some(m => hasMove[m]) ||
+			(moves.filter(m => this.dex.data.Moves[m].category === 'Special' && hasType[this.dex.data.Moves[m].type]).length)
+		)) {
 			item = 'Choice Band';
 
 		// Default to Leftovers
@@ -451,7 +490,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 
 		// Prepare optimal HP
 		let hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
-		if (hasMove['substitute'] && (hasMove['endeavor'] || hasMove['flail'] || hasMove['reversal'])) {
+		if (hasMove['substitute'] && ['endeavor', 'flail', 'reversal'].some(m => hasMove[m])) {
 			// Endeavor/Flail/Reversal users should be able to use four Substitutes
 			if (hp % 4 === 0) evs.hp -= 4;
 		} else if (hasMove['substitute'] && (item === 'Salac Berry' || item === 'Petaya Berry' || item === 'Liechi Berry')) {
@@ -572,7 +611,10 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			// To prevent this, we prevent more than one Wobbuffet in a single battle.
 			if (set.ability === 'Shadow Tag') this.hasWobbuffet = true;
 		}
-		if (pokemon.length < 6 && !isMonotype) throw new Error(`Could not build a random team for ${this.format} (seed=${seed})`);
+
+		if (pokemon.length < 6 && !isMonotype) {
+			throw new Error(`Could not build a random team for ${this.format} (seed=${seed})`);
+		}
 
 		return pokemon;
 	}

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -709,9 +709,9 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		) {
 			item = 'Focus Sash';
 		} else if (counter.damagingMoves.length >= 4) {
-			item = (counter['Normal'] || counter['Dragon'] > 1 || hasMove['chargebeam'] || hasMove['suckerpunch']) ?
-				'Life Orb' :
-				'Expert Belt';
+			item = (
+				counter['Normal'] || counter['Dragon'] > 1 || hasMove['chargebeam'] || hasMove['suckerpunch']
+			) ? 'Life Orb' : 'Expert Belt';
 		} else if (counter.damagingMoves.length >= 3 && !hasMove['superfang'] && !hasMove['metalburst']) {
 			const totalBulk = species.baseStats.hp + species.baseStats.def + species.baseStats.spd;
 			item = (

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -1,10 +1,12 @@
-/* eslint max-len: ["error", 240] */
-
 import RandomGen5Teams from '../gen5/random-teams';
 import {toID} from '../../../sim/dex';
 
 export class RandomGen4Teams extends RandomGen5Teams {
-	randomSet(species: string | Species, teamDetails: RandomTeamsTypes.TeamDetails = {}, isLead = false): RandomTeamsTypes.RandomSet {
+	randomSet(
+		species: string | Species,
+		teamDetails: RandomTeamsTypes.TeamDetails = {},
+		isLead = false
+	): RandomTeamsTypes.RandomSet {
 		species = this.dex.getSpecies(species);
 		let forme = species.name;
 
@@ -54,7 +56,10 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		const SetupException = ['dracometeor', 'overheat'];
 
 		// Give recovery moves priority over certain other defensive status moves
-		const recoveryMoves = ['healorder', 'milkdrink', 'moonlight', 'morningsun', 'painsplit', 'recover', 'rest', 'roost', 'slackoff', 'softboiled', 'synthesis', 'wish'];
+		const recoveryMoves = [
+			'healorder', 'milkdrink', 'moonlight', 'morningsun', 'painsplit', 'recover', 'rest', 'roost',
+			'slackoff', 'softboiled', 'synthesis', 'wish',
+		];
 		const defensiveStatusMoves = ['aromatherapy', 'haze', 'healbell', 'roar', 'whirlwind', 'willowisp', 'yawn'];
 
 		let hasMove: {[k: string]: boolean} = {};
@@ -101,6 +106,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 				let rejected = false;
 				let isSetup = false;
 
+				const restTalk = hasMove['rest'] && hasMove['sleeptalk'];
+
 				switch (moveid) {
 				// Not very useful without their supporting moves
 				case 'batonpass':
@@ -140,17 +147,25 @@ export class RandomGen4Teams extends RandomGen5Teams {
 				// Set up once and only if we have the moves for it
 				case 'bellydrum': case 'bulkup': case 'curse': case 'dragondance': case 'swordsdance':
 					if (counter.setupType !== 'Physical' || counter['physicalsetup'] > 1 || hasMove['sunnyday']) rejected = true;
-					if (counter.Physical + counter['physicalpool'] < 2 && !hasMove['batonpass'] && (!hasMove['rest'] || !hasMove['sleeptalk'])) rejected = true;
+					if (
+						counter.Physical + counter['physicalpool'] < 2 &&
+						!hasMove['batonpass'] &&
+						(!hasMove['rest'] || !hasMove['sleeptalk'])
+					) rejected = true;
 					isSetup = true;
 					break;
 				case 'calmmind': case 'nastyplot': case 'tailglow':
 					if (counter.setupType !== 'Special' || counter['specialsetup'] > 1) rejected = true;
-					if (counter.Special + counter['specialpool'] < 2 && !hasMove['batonpass'] && (!hasMove['rest'] || !hasMove['sleeptalk'])) rejected = true;
+					if (
+						counter.Special + counter['specialpool'] < 2 &&
+						!hasMove['batonpass'] &&
+						(!hasMove['rest'] || !hasMove['sleeptalk'])
+					) rejected = true;
 					isSetup = true;
 					break;
 				case 'agility': case 'rockpolish':
 					if (counter.damagingMoves.length < 2 && !hasMove['batonpass']) rejected = true;
-					if (hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (restTalk) rejected = true;
 					if (!counter.setupType) isSetup = true;
 					break;
 
@@ -160,7 +175,10 @@ export class RandomGen4Teams extends RandomGen5Teams {
 					break;
 				case 'explosion': case 'selfdestruct':
 					if (counter.setupType === 'Special') rejected = true;
-					if (moves.some(id => recoveryMoves.includes(id) || defensiveStatusMoves.includes(id)) || hasMove['batonpass'] || hasMove['protect'] || hasMove['substitute']) rejected = true;
+					if (
+						moves.some(id => recoveryMoves.includes(id) || defensiveStatusMoves.includes(id)) ||
+						['batonpass', 'protect', 'substitute'].some(m => hasMove[m])
+					) rejected = true;
 					break;
 				case 'foresight': case 'roar': case 'whirlwind':
 					if (counter.setupType && !hasAbility['Speed Boost']) rejected = true;
@@ -169,11 +187,13 @@ export class RandomGen4Teams extends RandomGen5Teams {
 					if (counter.setupType || hasMove['rest'] || hasMove['substitute']) rejected = true;
 					break;
 				case 'protect':
-					if (!(hasAbility['Guts'] || hasAbility['Quick Feet'] || hasAbility['Speed Boost'] || hasMove['toxic'] || hasMove['wish'])) rejected = true;
+					if (!['Guts', 'Quick Feet', 'Speed Boost'].some(abil => hasAbility[abil]) || hasMove['toxic'] || hasMove['wish']) {
+						rejected = true;
+					}
 					if (hasMove['rest'] || hasMove['softboiled']) rejected = true;
 					break;
 				case 'wish':
-					if (!(hasMove['batonpass'] || hasMove['protect'] || hasMove['uturn'])) rejected = true;
+					if (!['batonpass', 'protect', 'uturn'].some(m => hasMove[m])) rejected = true;
 					if (hasMove['rest'] || !!counter['speedsetup']) rejected = true;
 					break;
 				case 'rapidspin':
@@ -186,21 +206,27 @@ export class RandomGen4Teams extends RandomGen5Teams {
 					if (counter.setupType || !!counter['speedsetup'] || hasMove['substitute']) rejected = true;
 					break;
 				case 'stealthrock':
-					if (counter.setupType || !!counter['speedsetup'] || hasMove['rest'] || hasMove['substitute'] || teamDetails.stealthRock) rejected = true;
+					if (counter.setupType || counter['speedsetup'] || hasMove['rest'] || hasMove['substitute'] || teamDetails.stealthRock) {
+						rejected = true;
+					}
 					break;
 				case 'switcheroo': case 'trick':
 					if (counter.Physical + counter.Special < 3 || counter.setupType) rejected = true;
-					if (hasMove['fakeout'] || hasMove['lightscreen'] || hasMove['reflect'] || hasMove['suckerpunch'] || hasMove['trickroom']) rejected = true;
+					if (['fakeout', 'lightscreen', 'reflect', 'suckerpunch', 'trickroom'].some(m => hasMove[m])) rejected = true;
 					break;
 				case 'toxic': case 'toxicspikes':
 					if (counter.setupType || !!counter['speedsetup'] || teamDetails.toxicSpikes || hasMove['willowisp']) rejected = true;
 					break;
 				case 'trickroom':
 					if (counter.setupType || !!counter['speedsetup'] || counter.damagingMoves.length < 2) rejected = true;
-					if (hasMove['lightscreen'] || hasMove['reflect'] || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (hasMove['lightscreen'] || hasMove['reflect'] || restTalk) rejected = true;
 					break;
 				case 'uturn':
-					if (counter.setupType || !!counter['speedsetup'] || hasMove['batonpass'] || hasMove['substitute'] || hasAbility['Speed Boost'] && hasMove['protect']) rejected = true;
+					if (
+						counter.setupType || counter['speedsetup'] ||
+						hasMove['batonpass'] || hasMove['substitute'] ||
+						(hasAbility['Speed Boost'] && hasMove['protect'])
+					) rejected = true;
 					if (hasType['Bug'] && counter.stab < 2 && counter.damagingMoves.length > 1) rejected = true;
 					break;
 
@@ -210,7 +236,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 					if (hasMove['facade'] || hasMove['return']) rejected = true;
 					break;
 				case 'doubleedge':
-					if (hasMove['bodyslam'] || hasMove['facade'] || hasMove['return']) rejected = true;
+					if (['bodyslam', 'facade', 'return'].some(m => hasMove[m])) rejected = true;
 					break;
 				case 'endeavor':
 					if (!isLead) rejected = true;
@@ -236,7 +262,9 @@ export class RandomGen4Teams extends RandomGen5Teams {
 					if (hasMove['flareblitz'] && counter.setupType !== 'Special') rejected = true;
 					break;
 				case 'overheat':
-					if (counter.setupType === 'Special' || hasMove['batonpass'] || hasMove['fireblast'] || hasMove['flareblitz']) rejected = true;
+					if (counter.setupType === 'Special' || ['batonpass', 'fireblast', 'flareblitz'].some(m => hasMove[m])) {
+						rejected = true;
+					}
 					break;
 				case 'aquajet':
 					if (hasMove['dragondance'] || (hasMove['waterfall'] && counter.Physical < 3)) rejected = true;
@@ -262,7 +290,13 @@ export class RandomGen4Teams extends RandomGen5Teams {
 					if (hasMove['woodhammer'] || (hasMove['sunnyday'] && hasMove['solarbeam'])) rejected = true;
 					break;
 				case 'leafstorm':
-					if (counter.setupType || hasMove['batonpass'] || hasMove['powerwhip'] || (hasMove['sunnyday'] && hasMove['solarbeam'])) rejected = true;
+					if (
+						counter.setupType ||
+						hasMove['batonpass'] || hasMove['powerwhip'] ||
+						(hasMove['sunnyday'] && hasMove['solarbeam'])
+					) {
+						rejected = true;
+					}
 					break;
 				case 'solarbeam':
 					if (counter.setupType === 'Physical' || !hasMove['sunnyday']) rejected = true;
@@ -308,7 +342,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 					if (hasMove['outrage']) rejected = true;
 					break;
 				case 'dracometeor':
-					if (hasMove['calmmind'] || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (hasMove['calmmind'] || restTalk) rejected = true;
 					if (counter.setupType && counter.stab < 2) rejected = true;
 					break;
 				case 'crunch': case 'nightslash':
@@ -323,25 +357,31 @@ export class RandomGen4Teams extends RandomGen5Teams {
 
 				// Status:
 				case 'encore':
-					if (hasMove['roar'] || hasMove['taunt'] || hasMove['whirlwind'] || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (['roar', 'taunt', 'whirlwind'].some(m => hasMove[m]) || restTalk) rejected = true;
 					break;
 				case 'haze': case 'taunt':
-					if (hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (restTalk) rejected = true;
 					break;
 				case 'leechseed': case 'painsplit':
 					if (counter.setupType || !!counter['speedsetup'] || hasMove['rest']) rejected = true;
 					break;
 				case 'recover': case 'slackoff':
-					if (hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (restTalk) rejected = true;
 					break;
 				case 'stunspore':
-					if (counter.setupType || hasMove['toxic'] || movePool.includes('sleeppowder') || movePool.includes('spore')) rejected = true;
+					if (counter.setupType || hasMove['toxic'] || movePool.includes('sleeppowder') || movePool.includes('spore')) {
+						rejected = true;
+					}
 					break;
 				case 'substitute':
-					if (hasMove['pursuit'] || hasMove['rapidspin'] || hasMove['rest'] || hasMove['taunt']) rejected = true;
+					if (['pursuit', 'rapidspin', 'rest', 'taunt'].some(m => hasMove[m])) rejected = true;
 					break;
 				case 'thunderwave':
-					if (counter.setupType || hasMove['toxic'] || hasMove['trickroom'] || hasMove['bodyslam'] && hasAbility['Serene Grace']) rejected = true;
+					if (
+						counter.setupType ||
+						hasMove['toxic'] || hasMove['trickroom'] ||
+						(hasMove['bodyslam'] && hasAbility['Serene Grace'])
+					) rejected = true;
 					break;
 				case 'yawn':
 					if (hasMove['thunderwave'] || hasMove['toxic']) rejected = true;
@@ -354,59 +394,109 @@ export class RandomGen4Teams extends RandomGen5Teams {
 				}
 
 				// This move doesn't satisfy our setup requirements:
-				if ((move.category === 'Physical' && counter.setupType === 'Special') || (move.category === 'Special' && counter.setupType === 'Physical')) {
+				if (
+					(move.category === 'Physical' && counter.setupType === 'Special') ||
+					(move.category === 'Special' && counter.setupType === 'Physical')
+				) {
 					// Reject STABs last in case the setup type changes later on
-					if (!SetupException.includes(moveid) && (!hasType[move.type] || counter.stab > 1 || counter[move.category] < 2)) rejected = true;
+					if (!SetupException.includes(moveid) && (!hasType[move.type] || counter.stab > 1 || counter[move.category] < 2)) {
+						rejected = true;
+					}
 				}
-				if (counter.setupType && !isSetup && move.category !== counter.setupType && counter[counter.setupType] < 2 && !hasMove['batonpass']) {
+				if (
+					counter.setupType && !isSetup && move.category !== counter.setupType &&
+					counter[counter.setupType] < 2 && !hasMove['batonpass']
+				) {
 					// Mono-attacking with setup and RestTalk or recovery + status healing is allowed
 					if (moveid !== 'rest' && moveid !== 'sleeptalk' &&
 						!(recoveryMoves.includes(moveid) && (hasMove['healbell'] || hasMove['refresh'])) &&
 						!((moveid === 'healbell' || moveid === 'refresh') && moves.some(id => !!recoveryMoves.includes(id)))) {
 						// Reject Status moves only if there is nothing else to reject
-						if (move.category !== 'Status' || counter[counter.setupType] + counter.Status > 3 && counter['physicalsetup'] + counter['specialsetup'] < 2) rejected = true;
+						if (
+							move.category !== 'Status' ||
+							counter[counter.setupType] + counter.Status > 3 && counter['physicalsetup'] + counter['specialsetup'] < 2
+						) rejected = true;
 					}
 				}
-				if (counter.setupType === 'Special' && moveid === 'hiddenpower' && species.types.length > 1 && counter['Special'] <= 2 && !hasType[move.type] && !counter['Physical'] && counter['specialpool']) {
+				if (
+					counter.setupType === 'Special' && moveid === 'hiddenpower' &&
+					species.types.length > 1 && counter['Special'] <= 2 && !hasType[move.type] &&
+					!counter['Physical'] && counter['specialpool']
+				) {
 					// Hidden Power isn't good enough
 					if (!(hasType['Ghost'] && move.type === 'Fighting' || hasType['Electric'] && move.type === 'Ice')) rejected = true;
 				}
 
 				// Reject defensive status moves if a reliable recovery move is available but not selected.
 				// Toxic is only defensive if used with another status move other than Protect (Toxic + 3 attacks and Toxic + Protect are ok).
-				if ((defensiveStatusMoves.includes(moveid) || moveid === 'toxic' && ((counter.Status > 1 && !hasMove['protect']) || counter.Status > 2)) &&
-					!moves.some(id => recoveryMoves.includes(id)) && movePool.some(id => recoveryMoves.includes(id))) {
+				if (
+					(
+						defensiveStatusMoves.includes(moveid) || moveid === 'toxic' &&
+						((counter.Status > 1 && !hasMove['protect']) || counter.Status > 2)
+					) && !moves.some(id => recoveryMoves.includes(id)) && movePool.some(id => recoveryMoves.includes(id))
+				) {
 					rejected = true;
 				}
 
 				// Pokemon should have moves that benefit their Ability/Type/Weather, as well as moves required by its forme
-				if (!rejected && !['judgment', 'sleeptalk'].includes(moveid) && (counter['physicalsetup'] + counter['specialsetup'] < 2 &&
-					(!counter.setupType || counter.setupType === 'Mixed' || (move.category !== counter.setupType && move.category !== 'Status') || counter[counter.setupType] + counter.Status > 3)
-				) && (
-					(!counter.stab && !counter['damage'] && (species.types.length > 1 || (species.types[0] !== 'Normal' && species.types[0] !== 'Psychic') || !hasMove['icebeam'] || species.baseStats.spa >= species.baseStats.spd)) ||
-					(hasType['Bug'] && !counter['Bug'] && (movePool.includes('bugbuzz') || movePool.includes('megahorn'))) ||
-					(hasType['Dark'] && (!counter['Dark'] || (counter['Dark'] === 1 && hasMove['pursuit'])) && movePool.includes('suckerpunch') && counter.setupType !== 'Special') ||
-					(hasType['Dragon'] && !counter['Dragon']) ||
-					(hasType['Electric'] && !counter['Electric']) ||
-					(hasType['Fighting'] && !counter['Fighting'] && (counter.setupType || !counter['Status'] || movePool.includes('closecombat') || movePool.includes('highjumpkick'))) ||
-					(hasType['Fire'] && !counter['Fire']) ||
-					(hasType['Flying'] && !counter['Flying'] && (counter.setupType !== 'Special' && movePool.includes('bravebird'))) ||
-					(hasType['Grass'] && !counter['Grass'] && (movePool.includes('leafblade') || movePool.includes('leafstorm') || movePool.includes('seedflare') || movePool.includes('woodhammer'))) ||
-					(hasType['Ground'] && !counter['Ground']) ||
-					(hasType['Ice'] && !counter['Ice'] && (!hasType['Water'] || !counter['Water'])) ||
-					(hasType['Rock'] && !counter['Rock'] && (movePool.includes('headsmash') || movePool.includes('stoneedge'))) ||
-					(hasType['Steel'] && !counter['Steel'] && movePool.includes('meteormash')) ||
-					(hasType['Water'] && !counter['Water'] && (hasMove['raindance'] || !hasType['Ice'] || !counter['Ice'])) ||
-					(hasAbility['Adaptability'] && !counter.setupType && species.types.length > 1 && (!counter[species.types[0]] || !counter[species.types[1]])) ||
-					(hasAbility['Guts'] && hasType['Normal'] && movePool.includes('facade')) ||
-					(hasAbility['Slow Start'] && movePool.includes('substitute')) ||
-					(counter['defensesetup'] && !counter.recovery && !hasMove['rest']) ||
-					(movePool.includes('spore') || (!moves.some(id => recoveryMoves.includes(id)) && (movePool.includes('softboiled') || (species.baseSpecies === 'Arceus' && movePool.includes('recover'))))) ||
-					(species.requiredMove && movePool.includes(toID(species.requiredMove)))
-				)) {
+				if (
+					!rejected && !['judgment', 'sleeptalk'].includes(moveid) && (counter['physicalsetup'] + counter['specialsetup'] < 2 && (
+						!counter.setupType || counter.setupType === 'Mixed' ||
+						(move.category !== counter.setupType && move.category !== 'Status') ||
+						counter[counter.setupType] + counter.Status > 3
+					)) && (
+						(!counter.stab && !counter['damage'] && (
+							species.types.length > 1 ||
+							(species.types[0] !== 'Normal' && species.types[0] !== 'Psychic') ||
+							!hasMove['icebeam'] ||
+							species.baseStats.spa >= species.baseStats.spd)
+						) ||
+						(hasType['Bug'] && !counter['Bug'] && (movePool.includes('bugbuzz') || movePool.includes('megahorn'))) ||
+						(
+							hasType['Dark'] &&
+							(!counter['Dark'] || (counter['Dark'] === 1 && hasMove['pursuit'])) &&
+							movePool.includes('suckerpunch') &&
+							counter.setupType !== 'Special'
+						) ||
+						(hasType['Dragon'] && !counter['Dragon']) ||
+						(hasType['Electric'] && !counter['Electric']) ||
+						(
+							hasType['Fighting'] && !counter['Fighting'] &&
+							(counter.setupType || !counter['Status'] || movePool.includes('closecombat') || movePool.includes('highjumpkick'))
+						) ||
+						(hasType['Fire'] && !counter['Fire']) ||
+						(hasType['Flying'] && !counter['Flying'] && (counter.setupType !== 'Special' && movePool.includes('bravebird'))) ||
+						(
+							hasType['Grass'] && !counter['Grass'] &&
+							['leafblade', 'leafstorm', 'seedflare', 'woodhammer'].some(m => movePool.includes(m))
+						) ||
+						(hasType['Ground'] && !counter['Ground']) ||
+						(hasType['Ice'] && !counter['Ice'] && (!hasType['Water'] || !counter['Water'])) ||
+						(hasType['Rock'] && !counter['Rock'] && (movePool.includes('headsmash') || movePool.includes('stoneedge'))) ||
+						(hasType['Steel'] && !counter['Steel'] && movePool.includes('meteormash')) ||
+						(hasType['Water'] && !counter['Water'] && (hasMove['raindance'] || !hasType['Ice'] || !counter['Ice'])) ||
+						(
+							hasAbility['Adaptability'] &&
+							!counter.setupType &&
+							species.types.length > 1 &&
+							(!counter[species.types[0]] || !counter[species.types[1]])
+						) ||
+						(hasAbility['Guts'] && hasType['Normal'] && movePool.includes('facade')) ||
+						(hasAbility['Slow Start'] && movePool.includes('substitute')) ||
+						(counter['defensesetup'] && !counter.recovery && !hasMove['rest']) ||
+						(movePool.includes('spore') || (!moves.some(id => recoveryMoves.includes(id)) && (
+							movePool.includes('softboiled') ||
+							(species.baseSpecies === 'Arceus' && movePool.includes('recover'))
+						))) ||
+						(species.requiredMove && movePool.includes(toID(species.requiredMove)))
+					)
+				) {
 					// Reject Status or non-STAB
-					if (!isSetup && !move.weather && !move.damage && (move.category !== 'Status' || !move.flags.heal)) {
-						if (move.category === 'Status' || !hasType[move.type] || move.basePower && move.basePower < 40 && !move.multihit) rejected = true;
+					if (
+						!isSetup && !move.weather && !move.damage && (move.category !== 'Status' || !move.flags.heal) &&
+						(move.category === 'Status' || !hasType[move.type] || (move.basePower && move.basePower < 40 && !move.multihit))
+					) {
+						rejected = true;
 					}
 				}
 
@@ -423,7 +513,9 @@ export class RandomGen4Teams extends RandomGen5Teams {
 				}
 
 				// Remove rejected moves from the move list
-				if (rejected && (movePool.length - availableHP || availableHP && (moveid === 'hiddenpower' || !hasMove['hiddenpower']))) {
+				if (rejected && (
+					movePool.length - availableHP || availableHP && (moveid === 'hiddenpower' || !hasMove['hiddenpower'])
+				)) {
 					if (move.category !== 'Status' && (moveid !== 'hiddenpower' || !availableHP)) rejectedPool.push(moves[i]);
 					moves.splice(i, 1);
 					break;
@@ -578,28 +670,56 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			item = 'Focus Sash';
 
 		// Medium priority
-		} else if (ability === 'Slow Start' || hasMove['curse'] || hasMove['leechseed'] || hasMove['protect'] || hasMove['roar'] || hasMove['sleeptalk'] || hasMove['whirlwind'] ||
-			(ability === 'Serene Grace' && (hasMove['bodyslam'] || hasMove['headbutt'] || hasMove['ironhead']))) {
+		} else if (
+			ability === 'Slow Start' ||
+			['curse', 'leechseed', 'protect', 'roar', 'sleeptalk', 'whirlwind'].some(m => hasMove[m]) ||
+			(ability === 'Serene Grace' && ['bodyslam', 'headbutt', 'ironhead'].some(m => hasMove[m]))
+		) {
 			item = 'Leftovers';
 		} else if (counter.Physical >= 4 && !hasMove['fakeout'] && !hasMove['rapidspin'] && !hasMove['suckerpunch']) {
-			item = species.baseStats.spe >= 60 && species.baseStats.spe <= 108 && !counter['priority'] && !hasMove['bodyslam'] && this.randomChance(2, 3) ? 'Choice Scarf' : 'Choice Band';
-		} else if ((counter.Special >= 4 || (counter.Special >= 3 && (hasMove['batonpass'] || hasMove['uturn'] || hasMove['waterspout'] && hasMove['selfdestruct']))) && !hasMove['chargebeam']) {
-			item = species.baseStats.spe >= 60 && species.baseStats.spe <= 108 && ability !== 'Speed Boost' && !counter['priority'] && this.randomChance(2, 3) ? 'Choice Scarf' : 'Choice Specs';
+			item = (
+				species.baseStats.spe >= 60 && species.baseStats.spe <= 108 &&
+				!counter['priority'] && !hasMove['bodyslam'] && this.randomChance(2, 3)
+			) ? 'Choice Scarf' : 'Choice Band';
+		} else if (
+			(counter.Special >= 4 || (
+				counter.Special >= 3 &&
+				['batonpass', 'uturn', 'waterspout', 'selfdestruct'].some(m => hasMove[m])
+			)) &&
+			!hasMove['chargebeam']
+		) {
+			item = (
+				species.baseStats.spe >= 60 && species.baseStats.spe <= 108 &&
+				ability !== 'Speed Boost' && !counter['priority'] && this.randomChance(2, 3)
+			) ? 'Choice Scarf' : 'Choice Specs';
 		} else if (hasMove['outrage'] && counter.setupType) {
 			item = 'Lum Berry';
 		} else if (hasMove['substitute']) {
-			item = counter.damagingMoves.length < 2 ||
-				!counter['drain'] && (counter.damagingMoves.length < 3 || species.baseStats.hp >= 60 || species.baseStats.def + species.baseStats.spd >= 180) ? 'Leftovers' : 'Life Orb';
+			item = (counter.damagingMoves.length < 2 ||
+				!counter['drain'] &&
+				(counter.damagingMoves.length < 3 || species.baseStats.hp >= 60 || species.baseStats.def + species.baseStats.spd >= 180)
+			) ? 'Leftovers' : 'Life Orb';
 		} else if (ability === 'Guts') {
 			item = 'Toxic Orb';
-		} else if (isLead && !counter['recoil'] && !moves.some(id => !!recoveryMoves.includes(id)) && species.baseStats.hp + species.baseStats.def + species.baseStats.spd < 225) {
+		} else if (
+			isLead &&
+			!counter['recoil'] &&
+			!moves.some(id => !!recoveryMoves.includes(id)) &&
+			species.baseStats.hp + species.baseStats.def + species.baseStats.spd < 225
+		) {
 			item = 'Focus Sash';
 		} else if (counter.damagingMoves.length >= 4) {
-			item = (!!counter['Normal'] || counter['Dragon'] > 1 || hasMove['chargebeam'] || hasMove['suckerpunch']) ? 'Life Orb' : 'Expert Belt';
+			item = (counter['Normal'] || counter['Dragon'] > 1 || hasMove['chargebeam'] || hasMove['suckerpunch']) ?
+				'Life Orb' :
+				'Expert Belt';
 		} else if (counter.damagingMoves.length >= 3 && !hasMove['superfang'] && !hasMove['metalburst']) {
 			const totalBulk = species.baseStats.hp + species.baseStats.def + species.baseStats.spd;
-			item = (!!counter['speedsetup'] || !!counter['priority'] || hasMove['dragondance'] || hasMove['trickroom'] ||
-				totalBulk < 235 || (species.baseStats.spe >= 70 && (totalBulk < 260 || (!!counter['recovery'] && totalBulk < 285)))) ? 'Life Orb' : 'Leftovers';
+			item = (
+				counter['speedsetup'] || counter['priority'] ||
+				hasMove['dragondance'] || hasMove['trickroom'] ||
+				totalBulk < 235 ||
+				(species.baseStats.spe >= 70 && (totalBulk < 260 || (!!counter['recovery'] && totalBulk < 285)))
+			) ? 'Life Orb' : 'Leftovers';
 
 		// This is the "REALLY can't think of a good item" cutoff
 		} else if (hasType['Poison']) {
@@ -634,12 +754,20 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		if (customScale[species.name]) level = customScale[species.name];
 
 		// Prepare optimal HP
-		let hp = Math.floor(Math.floor(2 * species.baseStats.hp + (ivs.hp || 31) + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
+		let hp = Math.floor(
+			Math.floor(
+				2 * species.baseStats.hp + (ivs.hp || 31) + Math.floor(evs.hp / 4) + 100
+			) * level / 100 + 10
+		);
 		if (hasMove['substitute'] && item === 'Sitrus Berry') {
 			// Two Substitutes should activate Sitrus Berry
 			while (hp % 4 > 0) {
 				evs.hp -= 4;
-				hp = Math.floor(Math.floor(2 * species.baseStats.hp + (ivs.hp || 31) + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
+				hp = Math.floor(
+					Math.floor(
+						2 * species.baseStats.hp + (ivs.hp || 31) + Math.floor(evs.hp / 4) + 100
+					) * level / 100 + 10
+				);
 			}
 		} else if (hasMove['bellydrum'] && item === 'Sitrus Berry') {
 			// Belly Drum should activate Sitrus Berry
@@ -656,7 +784,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			ivs.atk = hasMove['hiddenpower'] ? (ivs.atk || 31) - 28 : 0;
 		}
 
-		if (hasMove['gyroball'] || hasMove['metalburst'] || hasMove['trickroom']) {
+		if (['gyroball', 'metalburst', 'trickroom'].some(m => hasMove[m])) {
 			evs.spe = 0;
 			ivs.spe = hasMove['hiddenpower'] ? (ivs.spe || 31) - 28 : 0;
 		}

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -1,5 +1,3 @@
-/* eslint max-len: ["error", 240] */
-
 import {TeamData} from '../../random-teams';
 import RandomGen7Teams from '../gen7/random-teams';
 import {PRNG, PRNGSeed} from '../../../sim/prng';
@@ -10,7 +8,11 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		super(format, prng);
 	}
 
-	randomSet(species: string | Species, teamDetails: RandomTeamsTypes.TeamDetails = {}, isLead = false): RandomTeamsTypes.RandomSet {
+	randomSet(
+		species: string | Species,
+		teamDetails: RandomTeamsTypes.TeamDetails = {},
+		isLead = false
+	): RandomTeamsTypes.RandomSet {
 		species = this.dex.getSpecies(species);
 		let forme = species.name;
 
@@ -105,6 +107,8 @@ export class RandomGen6Teams extends RandomGen7Teams {
 				let rejected = false;
 				let isSetup = false;
 
+				const restTalk = hasMove['rest'] && hasMove['sleeptalk'];
+
 				switch (moveid) {
 				// Not very useful without their supporting moves
 				case 'cottonguard': case 'defendorder':
@@ -165,7 +169,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 					isSetup = true;
 					break;
 				case 'agility': case 'autotomize': case 'rockpolish': case 'shiftgear':
-					if (counter.damagingMoves.length < 2 || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (counter.damagingMoves.length < 2 || restTalk) rejected = true;
 					if (!counter.setupType) isSetup = true;
 					break;
 				case 'flamecharge':
@@ -176,17 +180,34 @@ export class RandomGen6Teams extends RandomGen7Teams {
 				// Bad after setup
 				case 'circlethrow': case 'dragontail':
 					if (counter.setupType && ((!hasMove['rest'] && !hasMove['sleeptalk']) || hasMove['stormthrow'])) rejected = true;
-					if (!!counter['speedsetup'] || hasMove['encore'] || hasMove['raindance'] || hasMove['roar'] || hasMove['trickroom'] || hasMove['whirlwind']) rejected = true;
-					if ((counter[move.type] > 1 && counter.Status > 1) || (hasAbility['Sheer Force'] && !!counter['sheerforce'])) rejected = true;
+					if (
+						counter['speedsetup'] ||
+						['encore', 'raindance', 'roar', 'trickroom', 'whirlwind'].some(m => hasMove[m])
+					) rejected = true;
+					if (
+						(counter[move.type] > 1 && counter.Status > 1) ||
+						(hasAbility['Sheer Force'] && !!counter['sheerforce'])
+					) rejected = true;
 					break;
 				case 'defog':
-					if (counter.setupType || hasMove['spikes'] || hasMove['stealthrock'] || (hasMove['rest'] && hasMove['sleeptalk']) || teamDetails.defog) rejected = true;
+					if (
+						counter.setupType ||
+						hasMove['spikes'] || hasMove['stealthrock'] ||
+						(restTalk) ||
+						teamDetails.defog
+					) rejected = true;
 					break;
 				case 'fakeout': case 'tailwind':
-					if (counter.setupType || hasMove['substitute'] || hasMove['switcheroo'] || hasMove['trick']) rejected = true;
+					if (counter.setupType || ['substitute', 'switcheroo', 'trick'].some(m => hasMove[m])) rejected = true;
 					break;
 				case 'foulplay':
-					if (counter.setupType || !!counter['speedsetup'] || counter['Dark'] > 2 || hasMove['clearsmog'] || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (
+						counter.setupType ||
+						counter['speedsetup'] ||
+						counter['Dark'] > 2 ||
+						hasMove['clearsmog'] ||
+						(restTalk)
+					) rejected = true;
 					if (counter.damagingMoves.length - 1 === counter['priority']) rejected = true;
 					break;
 				case 'haze': case 'spikes':
@@ -209,14 +230,23 @@ export class RandomGen6Teams extends RandomGen7Teams {
 					if (hasMove['rest'] || hasMove['lightscreen'] && hasMove['reflect']) rejected = true;
 					break;
 				case 'pursuit':
-					if (counter.setupType || counter.Status > 1 || counter['Dark'] > 2 || hasMove['knockoff'] && !hasType['Dark']) rejected = true;
+					if (counter.setupType || counter.Status > 1 || counter['Dark'] > 2 || hasMove['knockoff'] && !hasType['Dark']) {
+						rejected = true;
+					}
 					if (hasMove['nightslash']) rejected = true;
 					break;
 				case 'rapidspin':
 					if (counter.setupType || teamDetails.rapidSpin) rejected = true;
 					break;
 				case 'stealthrock':
-					if (counter.setupType || !!counter['speedsetup'] || hasMove['rest'] || hasMove['substitute'] || hasMove['trickroom'] || teamDetails.stealthRock) rejected = true;
+					if (
+						counter.setupType ||
+						!!counter['speedsetup'] ||
+						['rest', 'substitute', 'trickroom'].some(m => hasMove[m]) ||
+						teamDetails.stealthRock
+					) {
+						rejected = true;
+					}
 					break;
 				case 'stickyweb':
 					if (teamDetails.stickyWeb) rejected = true;
@@ -229,7 +259,12 @@ export class RandomGen6Teams extends RandomGen7Teams {
 					if (hasMove['lightscreen'] || hasMove['reflect']) rejected = true;
 					break;
 				case 'uturn':
-					if (counter.setupType || !!counter['speedsetup'] || hasType['Bug'] && counter.stab < 2 && counter.damagingMoves.length > 2 && !hasAbility['Adaptability'] && !hasAbility['Download']) rejected = true;
+					if (counter.setupType || !!counter['speedsetup'] || (
+						hasType['Bug'] &&
+						counter.stab < 2 &&
+						counter.damagingMoves.length > 2 &&
+						!hasAbility['Adaptability'] && !hasAbility['Download']
+					)) rejected = true;
 					if ((hasAbility['Speed Boost'] && hasMove['protect']) || (hasAbility['Protean'] && counter.Status > 2)) rejected = true;
 					break;
 				case 'voltswitch':
@@ -242,10 +277,10 @@ export class RandomGen6Teams extends RandomGen7Teams {
 					if (hasMove['uturn'] && !counter.setupType && !hasAbility['Tinted Lens']) rejected = true;
 					break;
 				case 'darkpulse':
-					if ((hasMove['crunch'] || hasMove['knockoff'] || hasMove['hyperspacefury']) && counter.setupType !== 'Special') rejected = true;
+					if (['crunch', 'knockoff', 'hyperspacefury'].some(m => hasMove[m]) && counter.setupType !== 'Special') rejected = true;
 					break;
 				case 'suckerpunch':
-					if (counter.damagingMoves.length < 2 || hasMove['glare'] || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (counter.damagingMoves.length < 2 || hasMove['glare'] || restTalk) rejected = true;
 					if (counter['Dark'] > 1 && !hasType['Dark']) rejected = true;
 					break;
 				case 'dragonclaw':
@@ -255,7 +290,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 					if (hasMove['swordsdance'] || counter.setupType === 'Physical' && counter['Dragon'] > 1) rejected = true;
 					break;
 				case 'dragonpulse': case 'spacialrend':
-					if (hasMove['dracometeor'] || hasMove['outrage'] || hasMove['dragontail'] && !counter.setupType) rejected = true;
+					if (hasMove['dracometeor'] || hasMove['outrage'] || (hasMove['dragontail'] && !counter.setupType)) rejected = true;
 					break;
 				case 'outrage':
 					if (hasMove['dracometeor'] && counter.damagingMoves.length < 3) rejected = true;
@@ -268,25 +303,28 @@ export class RandomGen6Teams extends RandomGen7Teams {
 					break;
 				case 'aurasphere': case 'focusblast':
 					if ((hasMove['closecombat'] || hasMove['superpower']) && counter.setupType !== 'Special') rejected = true;
-					if (hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (restTalk) rejected = true;
 					break;
 				case 'drainpunch':
 					if (!hasMove['bulkup'] && (hasMove['closecombat'] || hasMove['highjumpkick'])) rejected = true;
 					if ((hasMove['focusblast'] || hasMove['superpower']) && counter.setupType !== 'Physical') rejected = true;
 					break;
 				case 'closecombat': case 'highjumpkick':
-					if ((hasMove['aurasphere'] || hasMove['focusblast'] || movePool.includes('aurasphere')) && counter.setupType === 'Special') rejected = true;
+					if (
+						(hasMove['aurasphere'] || hasMove['focusblast'] || movePool.includes('aurasphere')) &&
+						counter.setupType === 'Special'
+					) rejected = true;
 					if (hasMove['bulkup'] && hasMove['drainpunch']) rejected = true;
 					break;
 				case 'machpunch':
 					if (hasType['Fighting'] && counter.stab < 2 && !hasAbility['Technician']) rejected = true;
 					break;
 				case 'stormthrow':
-					if (hasMove['circlethrow'] && hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (hasMove['circlethrow'] && restTalk) rejected = true;
 					break;
 				case 'superpower':
 					if (counter['Fighting'] > 1 && counter.setupType) rejected = true;
-					if (hasMove['rest'] && hasMove['sleeptalk'] && !hasAbility['Contrary']) rejected = true;
+					if (restTalk && !hasAbility['Contrary']) rejected = true;
 					if (hasAbility['Contrary']) isSetup = true;
 					break;
 				case 'vacuumwave':
@@ -316,10 +354,10 @@ export class RandomGen6Teams extends RandomGen7Teams {
 					break;
 				case 'shadowsneak':
 					if (hasType['Ghost'] && species.types.length > 1 && counter.stab < 2) rejected = true;
-					if (hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (restTalk) rejected = true;
 					break;
 				case 'gigadrain': case 'powerwhip':
-					if (hasMove['seedbomb'] || hasMove['petaldance'] || hasMove['sunnyday'] && hasMove['solarbeam']) rejected = true;
+					if (hasMove['seedbomb'] || hasMove['petaldance'] || (hasMove['sunnyday'] && hasMove['solarbeam'])) rejected = true;
 					if (counter.Special < 4 && !counter.setupType && hasMove['leafstorm']) rejected = true;
 					break;
 				case 'leafblade': case 'woodhammer':
@@ -393,7 +431,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 					if (hasMove['substitute']) rejected = true;
 					break;
 				case 'hydropump':
-					if (hasMove['razorshell'] || hasMove['waterfall'] || (hasMove['rest'] && hasMove['sleeptalk'])) rejected = true;
+					if (hasMove['razorshell'] || hasMove['waterfall'] || (restTalk)) rejected = true;
 					if (hasMove['scald'] && (counter.Special < 4 || species.types.length > 1 && counter.stab < 3)) rejected = true;
 					break;
 				case 'originpulse': case 'surf':
@@ -408,22 +446,22 @@ export class RandomGen6Teams extends RandomGen7Teams {
 					if (hasMove['bodyslam'] || !hasMove['glare']) rejected = true;
 					break;
 				case 'stunspore': case 'thunderwave':
-					if (counter.setupType || !!counter['speedsetup'] || (hasMove['rest'] && hasMove['sleeptalk'])) rejected = true;
-					if (hasMove['discharge'] || hasMove['spore'] || hasMove['toxic'] || hasMove['trickroom'] || hasMove['yawn']) rejected = true;
+					if (counter.setupType || !!counter['speedsetup'] || (restTalk)) rejected = true;
+					if (['discharge', 'spore', 'toxic', 'trickroom', 'yawn'].some(m => hasMove[m])) rejected = true;
 					break;
 				case 'toxic':
-					if (hasMove['hypnosis'] || hasMove['sleeppowder'] || hasMove['toxicspikes'] || hasMove['willowisp'] || hasMove['yawn']) rejected = true;
+					if (['hypnosis', 'sleeppowder', 'toxicspikes', 'willowisp', 'yawn'].some(m => hasMove[m])) rejected = true;
 					if (counter.setupType || hasMove['flamecharge'] || hasMove['raindance']) rejected = true;
 					break;
 				case 'willowisp':
 					if (hasMove['scald']) rejected = true;
 					break;
 				case 'raindance':
-					if (counter.Physical + counter.Special < 2 || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (counter.Physical + counter.Special < 2 || restTalk) rejected = true;
 					if (!hasType['Water'] && !counter['Water']) rejected = true;
 					break;
 				case 'sunnyday':
-					if (counter.Physical + counter.Special < 2 || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (counter.Physical + counter.Special < 2 || restTalk) rejected = true;
 					if (!hasAbility['Chlorophyll'] && !hasAbility['Flower Gift'] && !hasMove['solarbeam']) rejected = true;
 					if (rejected && movePool.length > 1) {
 						const solarbeam = movePool.indexOf('solarbeam');
@@ -435,77 +473,134 @@ export class RandomGen6Teams extends RandomGen7Teams {
 					}
 					break;
 				case 'milkdrink': case 'moonlight': case 'painsplit': case 'recover': case 'roost': case 'synthesis':
-					if (hasMove['leechseed'] || hasMove['rest'] || hasMove['wish']) rejected = true;
+					if (['leechseed', 'rest', 'wish'].some(m => hasMove[m])) rejected = true;
 					break;
 				case 'safeguard':
 					if (hasMove['destinybond']) rejected = true;
 					break;
 				case 'substitute':
 					if (hasMove['dracometeor'] || hasMove['leafstorm'] && !hasAbility['Contrary']) rejected = true;
-					if (hasMove['pursuit'] || hasMove['rest'] || hasMove['taunt'] || hasMove['uturn'] || hasMove['voltswitch'] || hasMove['whirlwind']) rejected = true;
+					if (['pursuit', 'rest', 'taunt', 'uturn', 'voltswitch', 'whirlwind'].some(m => hasMove[m])) rejected = true;
 					if (movePool.includes('copycat')) rejected = true;
 					break;
 				}
 
 				// This move doesn't satisfy our setup requirements:
-				if ((move.category === 'Physical' && counter.setupType === 'Special') || (move.category === 'Special' && counter.setupType === 'Physical')) {
+				if (
+					(move.category === 'Physical' && counter.setupType === 'Special') ||
+					(move.category === 'Special' && counter.setupType === 'Physical')
+				) {
 					// Reject STABs last in case the setup type changes later on
 					const stabs = counter[species.types[0]] + (counter[species.types[1]] || 0);
-					if (!SetupException.includes(moveid) && (!hasType[move.type] || stabs > 1 || counter[move.category] < 2)) rejected = true;
+					if (
+						!SetupException.includes(moveid) &&
+						(!hasType[move.type] || stabs > 1 || counter[move.category] < 2)
+					) rejected = true;
 				}
 				if (
 					counter.setupType && !isSetup && counter.setupType !== 'Mixed' && move.category !== counter.setupType &&
 					counter[counter.setupType] < 2 && (move.category !== 'Status' || !move.flags.heal) &&
-					moveid !== 'sleeptalk' && !hasType['Dark'] && !hasMove['darkpulse']
+					moveid !== 'sleeptalk' && !hasType['Dark'] && !hasMove['darkpulse'] && (
+						move.category !== 'Status' ||
+						(counter[counter.setupType] + counter.Status > 3 && counter['physicalsetup'] + counter['specialsetup'] < 2)
+					)
 				) {
 					// Mono-attacking with setup and RestTalk is allowed
 					// Reject Status moves only if there is nothing else to reject
-					if (move.category !== 'Status' || counter[counter.setupType] + counter.Status > 3 && counter['physicalsetup'] + counter['specialsetup'] < 2) {
-						rejected = true;
-					}
+					rejected = true;
 				}
-				if (counter.setupType === 'Special' && moveid === 'hiddenpower' && species.types.length > 1 && counter['Special'] <= 2 && !hasType[move.type] && !counter['Physical'] && counter['specialpool']) {
+
+				if (
+					counter.setupType === 'Special' &&
+					moveid === 'hiddenpower' &&
+					species.types.length > 1 &&
+					counter['Special'] <= 2 &&
+					!hasType[move.type] &&
+					!counter['Physical'] &&
+					counter['specialpool']
+				) {
 					// Hidden Power isn't good enough
 					rejected = true;
 				}
 
 				// Pokemon should have moves that benefit their Type/Ability/Weather, as well as moves required by its forme
-				if (!rejected && !['judgment', 'sleeptalk', 'toxic'].includes(moveid) && (counter['physicalsetup'] + counter['specialsetup'] < 2 &&
-					(!counter.setupType || counter.setupType === 'Mixed' || (move.category !== counter.setupType && move.category !== 'Status') || counter[counter.setupType] + counter.Status > 3)
-				) && (
-					(!counter.stab && !hasMove['nightshade'] && !hasMove['seismictoss'] && (
-						species.types.length > 1 || (species.types[0] !== 'Normal' && species.types[0] !== 'Psychic') || !hasMove['icebeam'] || species.baseStats.spa >= species.baseStats.spd)) ||
-					(hasType['Bug'] && (movePool.includes('megahorn') || movePool.includes('pinmissile'))) ||
-					((hasType['Dark'] && !counter['Dark'] && !hasAbility['Protean']) || hasMove['suckerpunch'] && counter.stab < species.types.length) ||
-					(hasType['Dragon'] && !counter['Dragon'] && !hasAbility['Aerilate'] && !hasAbility['Pixilate'] && !hasMove['rest'] && !hasMove['sleeptalk']) ||
-					(hasType['Electric'] && !counter['Electric']) ||
-					(hasType['Fairy'] && !counter['Fairy'] && !hasAbility['Pixilate'] && (counter.setupType || !counter['Status'])) ||
-					(hasType['Fighting'] && !counter['Fighting'] && (species.baseStats.atk >= 110 || hasAbility['Justified'] || hasAbility['Unburden'] || counter.setupType || !counter['Status'])) ||
-					(hasType['Fire'] && (!counter['Fire'] || movePool.includes('quiverdance'))) ||
-					(hasType['Flying'] && !counter['Flying'] && (hasAbility['Gale Wings'] || hasAbility['Serene Grace'] || hasType['Normal'] && movePool.includes('bravebird'))) ||
-					(hasType['Ghost'] && !hasType['Dark'] && !counter['Ghost']) ||
-					(hasType['Grass'] && !counter['Grass'] && !hasType['Fairy'] && !hasType['Poison'] && !hasType['Steel']) ||
-					(hasType['Ground'] && !counter['Ground'] && !hasMove['rest'] && !hasMove['sleeptalk']) ||
-					(hasType['Ice'] && !counter['Ice'] && !hasAbility['Refrigerate']) ||
-					(hasType['Normal'] && movePool.includes('facade')) ||
-					(hasType['Psychic'] && !!counter['Psychic'] && !hasType['Flying'] && !hasAbility['Pixilate'] && counter.stab < species.types.length) ||
-					(hasType['Rock'] && !counter['Rock'] && !hasType['Fairy'] && (hasAbility['Rock Head'] || counter.setupType === 'Physical')) ||
-					(hasType['Steel'] && !counter['Steel'] && (hasAbility['Technician'] || movePool.includes('meteormash'))) ||
-					(hasType['Water'] && (!counter['Water'] || !counter.stab) && !hasAbility['Protean']) ||
-					((hasAbility['Adaptability'] && !counter.setupType && species.types.length > 1 && (!counter[species.types[0]] || !counter[species.types[1]])) ||
-					((hasAbility['Aerilate'] || hasAbility['Pixilate'] || hasAbility['Refrigerate'] && !hasMove['blizzard']) && !counter['Normal']) ||
-					(hasAbility['Bad Dreams'] && movePool.includes('darkvoid')) ||
-					(hasAbility['Contrary'] && !counter['contrary'] && species.name !== 'Shuckle') ||
-					(hasAbility['Slow Start'] && movePool.includes('substitute')) ||
-					(!counter.recovery && !counter.setupType && !hasMove['healingwish'] && (
-						movePool.includes('recover') || movePool.includes('roost') || movePool.includes('softboiled')
-					) && (counter.Status > 1 || (species.nfe && !!counter['Status']))) ||
-					(movePool.includes('stickyweb') && !counter.setupType && !teamDetails.stickyWeb) ||
-					(species.requiredMove && movePool.includes(toID(species.requiredMove))))
-				)) {
+				if (
+					!rejected &&
+					!['judgment', 'sleeptalk', 'toxic'].includes(moveid) &&
+					(counter['physicalsetup'] + counter['specialsetup'] < 2 &&
+					(
+						!counter.setupType || counter.setupType === 'Mixed' ||
+						(move.category !== counter.setupType && move.category !== 'Status') ||
+						counter[counter.setupType] + counter.Status > 3
+					)) && (
+						(!counter.stab && !hasMove['nightshade'] && !hasMove['seismictoss'] && (
+							species.types.length > 1 ||
+							(species.types[0] !== 'Normal' && species.types[0] !== 'Psychic') ||
+							!hasMove['icebeam'] ||
+							species.baseStats.spa >= species.baseStats.spd)
+						) || (hasType['Bug'] && (movePool.includes('megahorn') || movePool.includes('pinmissile'))) || (
+							(hasType['Dark'] && !counter['Dark'] && !hasAbility['Protean']) ||
+							(hasMove['suckerpunch'] && counter.stab < species.types.length)
+						) || (
+							hasType['Dragon'] &&
+							!counter['Dragon'] &&
+							!hasAbility['Aerilate'] &&
+							!hasAbility['Pixilate'] &&
+							!hasMove['rest'] &&
+							!hasMove['sleeptalk']
+						) || (hasType['Electric'] && !counter['Electric']) ||
+						(hasType['Fairy'] && !counter['Fairy'] && !hasAbility['Pixilate'] && (counter.setupType || !counter['Status'])) || (
+							hasType['Fighting'] &&
+							!counter['Fighting'] && (
+								species.baseStats.atk >= 110 ||
+								hasAbility['Justified'] || hasAbility['Unburden'] ||
+								counter.setupType || !counter['Status']
+							)
+						) || (hasType['Fire'] && (!counter['Fire'] || movePool.includes('quiverdance'))) || (
+							hasType['Flying'] &&
+							!counter['Flying'] &&
+							(hasAbility['Gale Wings'] || hasAbility['Serene Grace'] || hasType['Normal'] && movePool.includes('bravebird'))
+						) || (hasType['Ghost'] && !hasType['Dark'] && !counter['Ghost']) ||
+						(hasType['Grass'] && !counter['Grass'] && !hasType['Fairy'] && !hasType['Poison'] && !hasType['Steel']) ||
+						(hasType['Ground'] && !counter['Ground'] && !hasMove['rest'] && !hasMove['sleeptalk']) ||
+						(hasType['Ice'] && !counter['Ice'] && !hasAbility['Refrigerate']) ||
+						(hasType['Normal'] && movePool.includes('facade')) || (
+							hasType['Psychic'] &&
+							counter['Psychic'] &&
+							!hasType['Flying'] &&
+							!hasAbility['Pixilate'] &&
+							counter.stab < species.types.length
+						) || (
+							hasType['Rock'] &&
+							!counter['Rock'] &&
+							!hasType['Fairy'] &&
+							(hasAbility['Rock Head'] || counter.setupType === 'Physical')
+						) || (hasType['Steel'] && !counter['Steel'] && (hasAbility['Technician'] || movePool.includes('meteormash'))) ||
+						(hasType['Water'] && (!counter['Water'] || !counter.stab) && !hasAbility['Protean']) || (
+							hasAbility['Adaptability'] &&
+							!counter.setupType &&
+							species.types.length > 1 &&
+							(!counter[species.types[0]] || !counter[species.types[1]])
+						) || (
+							(hasAbility['Aerilate'] || hasAbility['Pixilate'] || (hasAbility['Refrigerate'] && !hasMove['blizzard'])) &&
+							!counter['Normal']
+						) || (hasAbility['Bad Dreams'] && movePool.includes('darkvoid')) ||
+						(hasAbility['Contrary'] && !counter['contrary'] && species.name !== 'Shuckle') ||
+						(hasAbility['Slow Start'] && movePool.includes('substitute')) ||
+						(!counter.recovery && !counter.setupType && !hasMove['healingwish'] && (
+							movePool.includes('recover') || movePool.includes('roost') || movePool.includes('softboiled')
+						) && (counter.Status > 1 || (species.nfe && !!counter['Status']))) ||
+						(movePool.includes('stickyweb') && !counter.setupType && !teamDetails.stickyWeb) ||
+						(species.requiredMove && movePool.includes(toID(species.requiredMove)))
+					)
+				) {
 					// Reject Status or non-STAB
 					if (!isSetup && !move.weather && !move.damage && (move.category !== 'Status' || !move.flags.heal)) {
-						if (move.category === 'Status' || !hasType[move.type] || move.basePower && move.basePower < 40 && !move.multihit) rejected = true;
+						if (
+							move.category === 'Status' ||
+							!hasType[move.type] ||
+							(move.basePower && move.basePower < 40 && !move.multihit)
+						) rejected = true;
 					}
 				}
 
@@ -522,8 +617,15 @@ export class RandomGen6Teams extends RandomGen7Teams {
 				}
 
 				// Remove rejected moves from the move list
-				if (rejected && (movePool.length - availableHP || availableHP && (moveid === 'hiddenpower' || !hasMove['hiddenpower']))) {
-					if (move.category !== 'Status' && !move.damage && !move.flags.charge && (moveid !== 'hiddenpower' || !availableHP)) rejectedPool.push(moves[i]);
+				if (rejected && (
+					movePool.length - availableHP ||
+					(availableHP && (moveid === 'hiddenpower' || !hasMove['hiddenpower']))
+				)) {
+					if (
+						move.category !== 'Status' &&
+						!move.damage && !move.flags.charge &&
+						(moveid !== 'hiddenpower' || !availableHP)
+					) rejectedPool.push(moves[i]);
 					moves.splice(i, 1);
 					break;
 				}
@@ -556,7 +658,8 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
 		}
 
-		const baseSpecies: Species = species.battleOnly && !species.requiredAbility ? this.dex.getSpecies(species.battleOnly as string) : species;
+		const battleOnly = species.battleOnly && !species.requiredAbility;
+		const baseSpecies: Species = battleOnly ? this.dex.getSpecies(species.battleOnly as string) : species;
 		const abilities = Object.values(baseSpecies.abilities);
 		abilities.sort((a, b) => this.dex.getAbility(b).rating - this.dex.getAbility(a).rating);
 		let ability0 = this.dex.getAbility(abilities[0]);
@@ -587,7 +690,11 @@ export class RandomGen6Teams extends RandomGen7Teams {
 				} else if (ability === 'Battle Armor' || ability === 'Sturdy') {
 					rejectAbility = (!!counter['recoil'] && !counter['recovery']);
 				} else if (ability === 'Chlorophyll' || ability === 'Leaf Guard') {
-					rejectAbility = (species.baseStats.spe > 100 || abilities.includes('Harvest') || !hasMove['sunnyday'] && !teamDetails['sun']);
+					rejectAbility = (
+						species.baseStats.spe > 100 ||
+						abilities.includes('Harvest') ||
+						(!hasMove['sunnyday'] && !teamDetails['sun'])
+					);
 				} else if (ability === 'Competitive') {
 					rejectAbility = (!counter['Special'] || hasMove['rest'] && hasMove['sleeptalk']);
 				} else if (ability === 'Compound Eyes' || ability === 'No Guard') {
@@ -615,7 +722,11 @@ export class RandomGen6Teams extends RandomGen7Teams {
 				} else if (ability === 'Magnet Pull') {
 					rejectAbility = (!hasType['Electric'] && !hasMove['earthpower']);
 				} else if (ability === 'Mold Breaker') {
-					rejectAbility = (hasMove['acrobatics'] || abilities.includes('Adaptability') || abilities.includes('Sheer Force') && !!counter['sheerforce']);
+					rejectAbility = (
+						hasMove['acrobatics'] ||
+						abilities.includes('Adaptability') ||
+						(abilities.includes('Sheer Force') && counter['sheerforce'])
+					);
 				} else if (ability === 'Overgrow') {
 					rejectAbility = !counter['Grass'];
 				} else if (ability === 'Poison Heal') {
@@ -649,7 +760,12 @@ export class RandomGen6Teams extends RandomGen7Teams {
 				} else if (ability === 'Technician') {
 					rejectAbility = (!counter['technician'] || hasMove['tailslap'] || !!species.isMega);
 				} else if (ability === 'Tinted Lens') {
-					rejectAbility = (hasMove['protect'] || abilities.includes('Prankster') || counter['damage'] >= counter.damagingMoves.length || counter.Status > 2 && !counter.setupType);
+					rejectAbility = (
+						hasMove['protect'] ||
+						abilities.includes('Prankster') ||
+						counter['damage'] >= counter.damagingMoves.length ||
+						(counter.Status > 2 && !counter.setupType)
+					);
 				} else if (ability === 'Torrent') {
 					rejectAbility = (!counter['Water'] || !!species.isMega);
 				} else if (ability === 'Unaware') {
@@ -675,7 +791,11 @@ export class RandomGen6Teams extends RandomGen7Teams {
 				}
 			} while (rejectAbility);
 
-			if (abilities.includes('Guts') && ability !== 'Quick Feet' && (hasMove['facade'] || hasMove['protect'] || (hasMove['rest'] && hasMove['sleeptalk']))) {
+			if (
+				abilities.includes('Guts') &&
+				ability !== 'Quick Feet' &&
+				(hasMove['facade'] || hasMove['protect'] || (hasMove['rest'] && hasMove['sleeptalk']))
+			) {
 				ability = 'Guts';
 			} else if (abilities.includes('Moxie') && counter.Physical > 3) {
 				ability = 'Moxie';
@@ -690,6 +810,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			ability = ability0.name;
 		}
 
+		const defensiveStatTotal = species.baseStats.hp + species.baseStats.def + species.baseStats.spd;
 		item = 'Leftovers';
 		if (species.requiredItem) {
 			item = species.requiredItem;
@@ -733,20 +854,26 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			item = 'Choice Band';
 		} else if (hasMove['bellydrum']) {
 			item = 'Sitrus Berry';
-		} else if (hasMove['geomancy'] || hasMove['solarbeam'] && ability !== 'Drought' && !hasMove['sunnyday'] && !teamDetails['sun']) {
+		} else if (
+			hasMove['geomancy'] ||
+			(hasMove['solarbeam'] && ability !== 'Drought' && !hasMove['sunnyday'] && !teamDetails['sun'])
+		) {
 			item = 'Power Herb';
 		} else if (hasMove['shellsmash']) {
 			item = (ability === 'Solid Rock' && !!counter['priority']) ? 'Weakness Policy' : 'White Herb';
 		} else if ((ability === 'Guts' || hasMove['facade'] || hasMove['psychoshift']) && !hasMove['sleeptalk']) {
 			item = hasMove['drainpunch'] ? 'Flame Orb' : 'Toxic Orb';
-		} else if ((ability === 'Magic Guard' && counter.damagingMoves.length > 1) || (ability === 'Sheer Force' && !!counter['sheerforce'])) {
+		} else if (
+			(ability === 'Magic Guard' && counter.damagingMoves.length > 1) ||
+			(ability === 'Sheer Force' && !!counter['sheerforce'])
+		) {
 			item = 'Life Orb';
 		} else if (ability === 'Poison Heal') {
 			item = 'Toxic Orb';
 		} else if (ability === 'Unburden') {
 			if (hasMove['fakeout']) {
 				item = 'Normal Gem';
-			} else if (hasMove['dracometeor'] || hasMove['leafstorm'] || hasMove['overheat']) {
+			} else if (['dracometeor', 'leafstorm', 'overheat'].some(m => hasMove[m])) {
 				item = 'White Herb';
 			} else if (hasMove['substitute'] || counter.setupType) {
 				item = 'Sitrus Berry';
@@ -767,17 +894,42 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		// Medium priority
 		} else if ((ability === 'Speed Boost' || ability === 'Stance Change') && counter.Physical + counter.Special > 2) {
 			item = 'Life Orb';
-		} else if (counter.Physical >= 4 && !hasMove['bodyslam'] && !hasMove['dragontail'] && !hasMove['fakeout'] && !hasMove['flamecharge'] && !hasMove['rapidspin'] && !hasMove['suckerpunch']) {
-			item = (species.baseStats.atk >= 100 || ability === 'Huge Power') && species.baseStats.spe >= 60 && species.baseStats.spe <= 108 && !counter['priority'] && this.randomChance(2, 3) ? 'Choice Scarf' : 'Choice Band';
-		} else if (counter.Special >= 4 && !hasMove['acidspray'] && !hasMove['clearsmog'] && !hasMove['fierydance']) {
-			item = species.baseStats.spa >= 100 && species.baseStats.spe >= 60 && species.baseStats.spe <= 108 && !counter['priority'] && this.randomChance(2, 3) ? 'Choice Scarf' : 'Choice Specs';
-		} else if (counter.Physical >= 3 && hasMove['defog'] && species.baseStats.spe >= 60 && species.baseStats.spe <= 108 && !counter['priority'] && !hasMove['foulplay']) {
+		} else if (
+			counter.Physical >= 4 &&
+			['bodyslam', 'dragontail', 'fakeout', 'flamecharge', 'rapidspin', 'suckerpunch'].every(m => !hasMove[m])
+		) {
+			item = (
+				(species.baseStats.atk >= 100 || ability === 'Huge Power') &&
+				species.baseStats.spe >= 60 && species.baseStats.spe <= 108 &&
+				!counter['priority'] &&
+				this.randomChance(2, 3)
+			) ? 'Choice Scarf' : 'Choice Band';
+		} else if (
+			counter.Special >= 4 &&
+			!hasMove['acidspray'] && !hasMove['clearsmog'] && !hasMove['fierydance']
+		) {
+			item = (
+				species.baseStats.spa >= 100 &&
+				species.baseStats.spe >= 60 && species.baseStats.spe <= 108 &&
+				!counter['priority'] && this.randomChance(2, 3)
+			) ? 'Choice Scarf' : 'Choice Specs';
+		} else if (
+			counter.Physical >= 3 &&
+			hasMove['defog'] &&
+			species.baseStats.spe >= 60 && species.baseStats.spe <= 108 &&
+			!counter['priority'] &&
+			!hasMove['foulplay']
+		) {
 			item = 'Choice Scarf';
 		} else if (counter.Special >= 3 && hasMove['uturn'] && !hasMove['acidspray']) {
 			item = 'Choice Specs';
-		} else if (ability === 'Slow Start' || hasMove['bite'] || hasMove['clearsmog'] || hasMove['curse'] || hasMove['protect'] || hasMove['sleeptalk'] || species.name.includes('Rotom-')) {
+		} else if (
+			ability === 'Slow Start' ||
+			['bite', 'clearsmog', 'curse', 'protect', 'sleeptalk'].some(m => hasMove[m]) ||
+			species.name.includes('Rotom-')
+		) {
 			item = 'Leftovers';
-		} else if ((hasMove['endeavor'] || hasMove['flail'] || hasMove['reversal']) && ability !== 'Sturdy') {
+		} else if (['endeavor', 'flail', 'reversal'].some(m => hasMove[m]) && ability !== 'Sturdy') {
 			item = (ability === 'Defeatist') ? 'Expert Belt' : 'Focus Sash';
 		} else if (hasMove['outrage'] && counter.setupType) {
 			item = 'Lum Berry';
@@ -787,15 +939,24 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			item = 'Air Balloon';
 		} else if ((ability === 'Iron Barbs' || ability === 'Rough Skin') && this.randomChance(1, 2)) {
 			item = 'Rocky Helmet';
-		} else if (counter.Physical + counter.Special >= 4 && species.baseStats.spd >= 50 && species.baseStats.hp + species.baseStats.def + species.baseStats.spd >= 235) {
+		} else if (
+			counter.Physical + counter.Special >= 4 &&
+			species.baseStats.spd >= 50 &&
+			defensiveStatTotal >= 235
+		) {
 			item = 'Assault Vest';
 		} else if (species.name === 'Palkia' && (hasMove['dracometeor'] || hasMove['spacialrend']) && hasMove['hydropump']) {
 			item = 'Lustrous Orb';
 		} else if (counter.damagingMoves.length >= 4) {
 			item = (!!counter['Dragon'] || !!counter['Dark'] || !!counter['Normal']) ? 'Life Orb' : 'Expert Belt';
-		} else if (counter.damagingMoves.length >= 3 && !!counter['speedsetup'] && species.baseStats.hp + species.baseStats.def + species.baseStats.spd >= 300) {
+		} else if (counter.damagingMoves.length >= 3 && counter['speedsetup'] && defensiveStatTotal >= 300) {
 			item = 'Weakness Policy';
-		} else if (isLead && ability !== 'Regenerator' && ability !== 'Sturdy' && !counter['recoil'] && !counter['recovery'] && species.baseStats.hp + species.baseStats.def + species.baseStats.spd <= 275) {
+		} else if (
+			isLead &&
+			ability !== 'Regenerator' && ability !== 'Sturdy' &&
+			!counter['recoil'] && !counter['recovery'] &&
+			defensiveStatTotal <= 275
+		) {
 			item = 'Focus Sash';
 
 		// This is the "REALLY can't think of a good item" cutoff
@@ -809,8 +970,15 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			item = 'Custap Berry';
 		} else if (ability === 'Super Luck') {
 			item = 'Scope Lens';
-		} else if (counter.damagingMoves.length >= 3 && ability !== 'Sturdy' && !hasMove['acidspray'] && !hasMove['dragontail'] && !hasMove['foulplay'] && !hasMove['rapidspin'] && !hasMove['superfang'] && !hasMove['uturn']) {
-			item = (!!counter['speedsetup'] || hasMove['trickroom'] || species.baseStats.spe > 40 && species.baseStats.hp + species.baseStats.def + species.baseStats.spd <= 275) ? 'Life Orb' : 'Leftovers';
+		} else if (
+			counter.damagingMoves.length >= 3 && ability !== 'Sturdy' &&
+			['acidspray', 'dragontail', 'foulplay', 'rapidspin', 'superfang', 'uturn'].every(m => !hasMove[m])
+		) {
+			item = (
+				counter['speedsetup'] ||
+				hasMove['trickroom'] ||
+				(species.baseStats.spe > 40 && defensiveStatTotal <= 275)
+			) ? 'Life Orb' : 'Leftovers';
 		}
 
 		// For Trick / Switcheroo
@@ -858,7 +1026,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			ivs.atk = hasMove['hiddenpower'] ? ivs.atk - 30 : 0;
 		}
 
-		if (hasMove['gyroball'] || hasMove['metalburst'] || hasMove['trickroom']) {
+		if (['gyroball', 'metalburst', 'trickroom'].some(m => hasMove[m])) {
 			evs.spe = 0;
 			ivs.spe = hasMove['hiddenpower'] ? ivs.spe - 30 : 0;
 		}
@@ -879,13 +1047,19 @@ export class RandomGen6Teams extends RandomGen7Teams {
 
 	randomFactorySets: AnyObject = require('./factory-sets.json');
 
-	randomFactorySet(species: Species, teamData: RandomTeamsTypes.FactoryTeamDetails, tier: string): RandomTeamsTypes.RandomFactorySet | null {
+	randomFactorySet(
+		species: Species,
+		teamData: RandomTeamsTypes.FactoryTeamDetails,
+		tier: string
+	): RandomTeamsTypes.RandomFactorySet | null {
 		const id = toID(species.name);
 		// const flags = this.randomFactorySets[tier][id].flags;
 		const setList = this.randomFactorySets[tier][id].sets;
 
-		const itemsMax: {[K: string]: number} = {choicespecs: 1, choiceband: 1, choicescarf: 1};
-		const movesMax: {[k: string]: number} = {rapidspin: 1, batonpass: 1, stealthrock: 1, defog: 1, spikes: 1, toxicspikes: 1};
+		const itemsMax: {[k: string]: number} = {choicespecs: 1, choiceband: 1, choicescarf: 1};
+		const movesMax: {[k: string]: number} = {
+			rapidspin: 1, batonpass: 1, stealthrock: 1, defog: 1, spikes: 1, toxicspikes: 1,
+		};
 		const requiredMoves: {[k: string]: string} = {stealthrock: 'hazardSet', rapidspin: 'hazardClear', defog: 'hazardClear'};
 		const weatherAbilitiesRequire: {[k: string]: string} = {
 			hydration: 'raindance', swiftswim: 'raindance',
@@ -970,10 +1144,15 @@ export class RandomGen6Teams extends RandomGen7Teams {
 
 		const pokemonPool = Object.keys(this.randomFactorySets[chosenTier]);
 
-		const teamData: TeamData = {typeCount: {}, typeComboCount: {}, baseFormes: {}, megaCount: 0, has: {}, forceResult: forceResult, weaknesses: {}, resistances: {}};
+		const teamData: TeamData = {
+			typeCount: {}, typeComboCount: {}, baseFormes: {}, megaCount: 0, has: {}, forceResult: forceResult,
+			weaknesses: {}, resistances: {},
+		};
 		const requiredMoveFamilies = ['hazardSet', 'hazardClear'];
 		const requiredMoves: {[k: string]: string} = {stealthrock: 'hazardSet', rapidspin: 'hazardClear', defog: 'hazardClear'};
-		const weatherAbilitiesSet: {[k: string]: string} = {drizzle: 'raindance', drought: 'sunnyday', snowwarning: 'hail', sandstream: 'sandstorm'};
+		const weatherAbilitiesSet: {[k: string]: string} = {
+			drizzle: 'raindance', drought: 'sunnyday', snowwarning: 'hail', sandstream: 'sandstorm',
+		};
 		const resistanceAbilities: {[k: string]: string[]} = {
 			dryskin: ['Water'], waterabsorb: ['Water'], stormdrain: ['Water'],
 			flashfire: ['Fire'], heatproof: ['Fire'],
@@ -1061,7 +1240,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			for (const typeName in this.dex.data.TypeChart) {
 				// Cover any major weakness (3+) with at least one resistance
 				if (teamData.resistances[typeName] >= 1) continue;
-				if (resistanceAbilities[abilityData.id] && resistanceAbilities[abilityData.id].includes(typeName) || !this.dex.getImmunity(typeName, types)) {
+				if (resistanceAbilities[abilityData.id]?.includes(typeName) || !this.dex.getImmunity(typeName, types)) {
 					// Heuristic: assume that Pokemon with these abilities don't have (too) negative typing.
 					teamData.resistances[typeName] = (teamData.resistances[typeName] || 0) + 1;
 					if (teamData.resistances[typeName] >= 1) teamData.weaknesses[typeName] = 0;

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -193,7 +193,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 					if (
 						counter.setupType ||
 						hasMove['spikes'] || hasMove['stealthrock'] ||
-						(restTalk) ||
+						restTalk ||
 						teamDetails.defog
 					) rejected = true;
 					break;
@@ -206,7 +206,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 						counter['speedsetup'] ||
 						counter['Dark'] > 2 ||
 						hasMove['clearsmog'] ||
-						(restTalk)
+						restTalk
 					) rejected = true;
 					if (counter.damagingMoves.length - 1 === counter['priority']) rejected = true;
 					break;
@@ -431,7 +431,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 					if (hasMove['substitute']) rejected = true;
 					break;
 				case 'hydropump':
-					if (hasMove['razorshell'] || hasMove['waterfall'] || (restTalk)) rejected = true;
+					if (hasMove['razorshell'] || hasMove['waterfall'] || restTalk) rejected = true;
 					if (hasMove['scald'] && (counter.Special < 4 || species.types.length > 1 && counter.stab < 3)) rejected = true;
 					break;
 				case 'originpulse': case 'surf':
@@ -446,7 +446,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 					if (hasMove['bodyslam'] || !hasMove['glare']) rejected = true;
 					break;
 				case 'stunspore': case 'thunderwave':
-					if (counter.setupType || !!counter['speedsetup'] || (restTalk)) rejected = true;
+					if (counter.setupType || !!counter['speedsetup'] || restTalk) rejected = true;
 					if (['discharge', 'spore', 'toxic', 'trickroom', 'yawn'].some(m => hasMove[m])) rejected = true;
 					break;
 				case 'toxic':

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1,5 +1,3 @@
-/* eslint max-len: ["error", 240] */
-
 import {RandomTeams, TeamData} from '../../random-teams';
 import {PRNG, PRNGSeed} from '../../../sim/prng';
 import {Utils} from '../../../lib';
@@ -10,7 +8,12 @@ export class RandomGen7Teams extends RandomTeams {
 		super(format, prng);
 	}
 
-	randomSet(species: string | Species, teamDetails: RandomTeamsTypes.TeamDetails = {}, isLead = false, isDoubles = false): RandomTeamsTypes.RandomSet {
+	randomSet(
+		species: string | Species,
+		teamDetails: RandomTeamsTypes.TeamDetails = {},
+		isLead = false,
+		isDoubles = false
+	): RandomTeamsTypes.RandomSet {
 		species = this.dex.getSpecies(species);
 		let forme = species.name;
 
@@ -22,7 +25,9 @@ export class RandomGen7Teams extends RandomTeams {
 			forme = this.sample([species.name].concat(species.cosmeticFormes));
 		}
 
-		const randMoves = !isDoubles ? species.randomBattleMoves : (species.randomDoubleBattleMoves || species.randomBattleMoves);
+		const randMoves = !isDoubles ?
+			species.randomBattleMoves :
+			(species.randomDoubleBattleMoves || species.randomBattleMoves);
 		const movePool = (randMoves || Object.keys(Dex.getLearnsetData(species.id).learnset!)).slice();
 		const rejectedPool = [];
 		const moves: string[] = [];
@@ -138,7 +143,9 @@ export class RandomGen7Teams extends RandomTeams {
 					if (!counter.setupType) rejected = true;
 					break;
 				case 'switcheroo': case 'trick':
-					if (counter.Physical + counter.Special < 3 || hasMove['electroweb'] || hasMove['snarl'] || hasMove['suckerpunch']) rejected = true;
+					if (counter.Physical + counter.Special < 3 || ['electroweb', 'snarl', 'suckerpunch'].some(m => hasMove[m])) {
+						rejected = true;
+					}
 					break;
 
 				// Set up once and only if we have the moves for it
@@ -175,19 +182,33 @@ export class RandomGen7Teams extends RandomTeams {
 
 				// Bad after setup
 				case 'circlethrow': case 'dragontail':
-					if (counter.setupType && ((!hasMove['rest'] && !hasMove['sleeptalk']) || hasMove['stormthrow'])) rejected = true;
-					if (!!counter['speedsetup'] || hasMove['encore'] || hasMove['raindance'] || hasMove['roar'] || hasMove['trickroom'] || hasMove['whirlwind']) rejected = true;
-					if ((counter[move.type] > 1 && counter.Status > 1) || hasAbility['Sheer Force'] && !!counter['sheerforce']) rejected = true;
+					if (
+						counter.setupType &&
+						((!hasMove['rest'] && !hasMove['sleeptalk']) || hasMove['stormthrow'])
+					) rejected = true;
+					if (
+						counter['speedsetup'] ||
+						['encore', 'raindance', 'roar', 'trickroom', 'whirlwind'].some(m => hasMove[m])
+					) rejected = true;
+					if (
+						(counter[move.type] > 1 && counter.Status > 1) ||
+						hasAbility['Sheer Force'] &&
+						!!counter['sheerforce']
+					) rejected = true;
 					if (isDoubles && hasMove['superpower']) rejected = true;
 					break;
 				case 'defog':
 					if (counter.setupType || hasMove['spikes'] || hasMove['stealthrock'] || teamDetails.defog) rejected = true;
 					break;
 				case 'fakeout': case 'tailwind':
-					if (counter.setupType || hasMove['substitute'] || hasMove['switcheroo'] || hasMove['trick']) rejected = true;
+					if (counter.setupType || ['substitute', 'switcheroo', 'trick'].some(m => hasMove[m])) rejected = true;
 					break;
 				case 'foulplay':
-					if (counter.setupType || !!counter['speedsetup'] || counter['Dark'] > 2 || hasMove['clearsmog'] || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
+					if (
+						counter.setupType || counter['speedsetup'] || counter['Dark'] > 2 ||
+						hasMove['clearsmog'] ||
+						(hasMove['rest'] && hasMove['sleeptalk'])
+					) rejected = true;
 					if (counter.damagingMoves.length - 1 === counter['priority']) rejected = true;
 					break;
 				case 'haze': case 'spikes':
@@ -212,10 +233,18 @@ export class RandomGen7Teams extends RandomTeams {
 				case 'protect':
 					if (counter.setupType && !hasMove['wish'] && !isDoubles) rejected = true;
 					if (!!counter['speedsetup'] || hasMove['rest'] || hasMove['lightscreen'] && hasMove['reflect']) rejected = true;
-					if (isDoubles && (hasMove['fakeout'] || movePool.includes('bellydrum') || movePool.includes('shellsmash') || hasMove['tailwind'] && hasMove['roost'])) rejected = true;
+					if (isDoubles && (
+						hasMove['fakeout'] ||
+						(hasMove['tailwind'] && hasMove['roost']) ||
+						movePool.includes('bellydrum') ||
+						movePool.includes('shellsmash')
+					)) rejected = true;
 					break;
 				case 'pursuit':
-					if (counter.setupType || counter.Status > 1 || counter['Dark'] > 2 || hasMove['knockoff'] && !hasType['Dark']) rejected = true;
+					if (
+						counter.setupType || counter.Status > 1 || counter['Dark'] > 2 ||
+						(hasMove['knockoff'] && !hasType['Dark'])
+					) rejected = true;
 					break;
 				case 'rapidspin':
 					if (counter.setupType || teamDetails.rapidSpin) rejected = true;
@@ -227,7 +256,11 @@ export class RandomGen7Teams extends RandomTeams {
 					if (!hasAbility['Parental Bond'] && (counter.damagingMoves.length > 1 || counter.setupType)) rejected = true;
 					break;
 				case 'stealthrock':
-					if (counter.setupType || !!counter['speedsetup'] || hasMove['rest'] || hasMove['substitute'] || hasMove['trickroom'] || teamDetails.stealthRock) rejected = true;
+					if (
+						counter.setupType || counter['speedsetup'] ||
+						['rest', 'substitute', 'trickroom'].some(m => hasMove[m]) ||
+						teamDetails.stealthRock
+					) rejected = true;
 					break;
 				case 'stickyweb':
 					if (teamDetails.stickyWeb) rejected = true;
@@ -240,11 +273,18 @@ export class RandomGen7Teams extends RandomTeams {
 					if (hasMove['lightscreen'] || hasMove['reflect']) rejected = true;
 					break;
 				case 'uturn':
-					if (counter.setupType || !!counter['speedsetup'] || hasType['Bug'] && counter.stab < 2 && counter.damagingMoves.length > 2 && !hasAbility['Adaptability'] && !hasAbility['Download']) rejected = true;
+					if (counter.setupType || counter['speedsetup'] || (
+						hasType['Bug'] &&
+						counter.stab < 2 && counter.damagingMoves.length > 2 &&
+						!hasAbility['Adaptability'] && !hasAbility['Download']
+					)) rejected = true;
 					if ((hasAbility['Speed Boost'] && hasMove['protect']) || (hasAbility['Protean'] && counter.Status > 2)) rejected = true;
 					break;
 				case 'voltswitch':
-					if (counter.setupType || !!counter['speedsetup'] || hasMove['electricterrain'] || hasMove['raindance'] || hasMove['uturn']) rejected = true;
+					if (
+						counter.setupType || counter['speedsetup'] ||
+						['electricterrain', 'raindance', 'uturn'].some(m => hasMove[m])
+					) rejected = true;
 					break;
 
 				// Bit redundant to have both
@@ -256,7 +296,7 @@ export class RandomGen7Teams extends RandomTeams {
 					if (hasMove['knockoff'] || hasMove['pursuit']) rejected = true;
 					break;
 				case 'darkpulse':
-					if ((hasMove['crunch'] || hasMove['knockoff'] || hasMove['hyperspacefury']) && counter.setupType !== 'Special') rejected = true;
+					if (['crunch', 'knockoff', 'hyperspacefury'].some(m => hasMove[m]) && counter.setupType !== 'Special') rejected = true;
 					break;
 				case 'suckerpunch':
 					if (counter.damagingMoves.length < 2 || hasMove['glare'] || !hasType['Dark'] && counter['Dark'] > 1) rejected = true;
@@ -265,7 +305,7 @@ export class RandomGen7Teams extends RandomTeams {
 					if (hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
 					break;
 				case 'dragonpulse': case 'spacialrend':
-					if (hasMove['dracometeor'] || hasMove['outrage'] || hasMove['dragontail'] && !counter.setupType) rejected = true;
+					if (hasMove['dracometeor'] || hasMove['outrage'] || (hasMove['dragontail'] && !counter.setupType)) rejected = true;
 					break;
 				case 'outrage':
 					if (hasMove['dragonclaw'] || hasMove['dracometeor'] && counter.damagingMoves.length < 3) rejected = true;
@@ -286,7 +326,9 @@ export class RandomGen7Teams extends RandomTeams {
 					if ((hasMove['focusblast'] || hasMove['superpower']) && counter.setupType !== 'Physical') rejected = true;
 					break;
 				case 'closecombat': case 'highjumpkick':
-					if ((hasMove['aurasphere'] || hasMove['focusblast'] || movePool.includes('aurasphere') || movePool.includes('focusblast')) && counter.setupType === 'Special') rejected = true;
+					if (counter.setupType === 'Special' && ['aurasphere', 'focusblast'].some(m => hasMove[m] || movePool.includes(m))) {
+						rejected = true;
+					}
 					if (hasMove['bulkup'] && hasMove['drainpunch']) rejected = true;
 					break;
 				case 'dynamicpunch': case 'vacuumwave':
@@ -304,7 +346,7 @@ export class RandomGen7Teams extends RandomTeams {
 					if (hasMove['fireblast'] && (!!counter.Status || isDoubles)) rejected = true;
 					break;
 				case 'firefang': case 'firepunch': case 'flamethrower':
-					if (hasMove['blazekick'] || hasMove['heatwave'] || hasMove['overheat']) rejected = true;
+					if (['blazekick', 'heatwave', 'overheat'].some(m => hasMove[m])) rejected = true;
 					if ((hasMove['fireblast'] || hasMove['lavaplume']) && counter.setupType !== 'Physical') rejected = true;
 					break;
 				case 'fireblast': case 'magmastorm':
@@ -315,7 +357,7 @@ export class RandomGen7Teams extends RandomTeams {
 					if (hasMove['firepunch'] || hasMove['fireblast'] && (counter.setupType || !!counter['speedsetup'])) rejected = true;
 					break;
 				case 'overheat':
-					if (hasMove['fireblast'] || hasMove['flareblitz'] || hasMove['lavaplume']) rejected = true;
+					if (['fireblast', 'flareblitz', 'lavaplume'].some(m => hasMove[m])) rejected = true;
 					break;
 				case 'hurricane':
 					if (hasMove['bravebird'] || hasMove['airslash'] && !!counter.Status) rejected = true;
@@ -430,8 +472,11 @@ export class RandomGen7Teams extends RandomTeams {
 					if ((hasMove['ironhead'] || hasMove['meteormash']) && counter.setupType !== 'Special') rejected = true;
 					break;
 				case 'hydropump':
-					if (hasMove['liquidation'] || hasMove['waterfall'] || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
-					if (hasMove['scald'] && ((counter.Special < 4 && !hasMove['uturn']) || (species.types.length > 1 && counter.stab < 3))) rejected = true;
+					if (hasMove['liquidation'] || hasMove['waterfall'] || (hasMove['rest'] && hasMove['sleeptalk'])) rejected = true;
+					if (hasMove['scald'] && (
+						(counter.Special < 4 && !hasMove['uturn']) ||
+						(species.types.length > 1 && counter.stab < 3)
+					)) rejected = true;
 					break;
 				case 'muddywater':
 					if (isDoubles && (hasMove['scald'] || hasMove['hydropump'])) rejected = true;
@@ -440,19 +485,19 @@ export class RandomGen7Teams extends RandomTeams {
 					if (hasMove['hydropump'] || hasMove['scald']) rejected = true;
 					break;
 				case 'scald':
-					if (hasMove['liquidation'] || hasMove['waterfall'] || hasMove['waterpulse']) rejected = true;
+					if (['liquidation', 'waterfall', 'waterpulse'].some(m => hasMove[m])) rejected = true;
 					break;
 
 				// Status:
 				case 'electroweb': case 'stunspore': case 'thunderwave':
 					if (counter.setupType || !!counter['speedsetup'] || (hasMove['rest'] && hasMove['sleeptalk'])) rejected = true;
-					if (hasMove['discharge'] || hasMove['spore'] || hasMove['toxic'] || hasMove['trickroom'] || hasMove['yawn']) rejected = true;
+					if (['discharge', 'spore', 'toxic', 'trickroom', 'yawn'].some(m => hasMove[m])) rejected = true;
 					break;
 				case 'glare': case 'headbutt':
 					if (hasMove['bodyslam'] || !hasMove['glare']) rejected = true;
 					break;
 				case 'toxic':
-					if (hasMove['hypnosis'] || hasMove['sleeppowder'] || hasMove['toxicspikes'] || hasMove['willowisp'] || hasMove['yawn']) rejected = true;
+					if (['hypnosis', 'sleeppowder', 'toxicspikes', 'willowisp', 'yawn'].some(m => hasMove[m])) rejected = true;
 					if (counter.setupType || hasMove['flamecharge'] || hasMove['raindance']) rejected = true;
 					break;
 				case 'willowisp':
@@ -479,7 +524,7 @@ export class RandomGen7Teams extends RandomTeams {
 					break;
 				case 'substitute':
 					if (hasMove['dracometeor'] || hasMove['leafstorm'] && !hasAbility['Contrary']) rejected = true;
-					if (hasMove['encore'] || hasMove['pursuit'] || hasMove['rest'] || hasMove['taunt'] || hasMove['uturn'] || hasMove['voltswitch'] || hasMove['whirlwind']) rejected = true;
+					if (['encore', 'pursuit', 'rest', 'taunt', 'uturn', 'voltswitch', 'whirlwind'].some(m => hasMove[m])) rejected = true;
 					if (movePool.includes('copycat')) rejected = true;
 					break;
 				case 'powersplit':
@@ -491,50 +536,118 @@ export class RandomGen7Teams extends RandomTeams {
 				}
 
 				// This move doesn't satisfy our setup requirements:
-				if ((move.category === 'Physical' && counter.setupType === 'Special') || (move.category === 'Special' && counter.setupType === 'Physical')) {
+				if (
+					(move.category === 'Physical' && counter.setupType === 'Special') ||
+					(move.category === 'Special' && counter.setupType === 'Physical')
+				) {
 					// Reject STABs last in case the setup type changes later on
 					const stabs = counter[species.types[0]] + (counter[species.types[1]] || 0);
-					if (!SetupException.includes(moveid) && (!hasType[move.type] || stabs > 1 || counter[move.category] < 2)) rejected = true;
+					if (
+						!SetupException.includes(moveid) &&
+						(!hasType[move.type] || stabs > 1 || counter[move.category] < 2)
+					) rejected = true;
 				}
 				// Hidden Power isn't good enough
-				if (counter.setupType === 'Special' && moveid === 'hiddenpower' && species.types.length > 1 && counter['Special'] <= 2 && !hasType[move.type] && !counter['Physical'] && counter['specialpool']) {
+				if (
+					counter.setupType === 'Special' &&
+					moveid === 'hiddenpower' &&
+					species.types.length > 1 &&
+					counter['Special'] <= 2 &&
+					!hasType[move.type] &&
+					!counter['Physical'] &&
+					counter['specialpool']
+				) {
 					rejected = true;
 				}
 
 				// Pokemon should have moves that benefit their Type/Ability/Weather, as well as moves required by its forme
 				if (!rejected && !move.damage && !isSetup && !move.weather && !move.stallingMove &&
-					(isDoubles || (!['judgment', 'lightscreen', 'reflect', 'sleeptalk', 'toxic'].includes(moveid) && (move.category !== 'Status' || !move.flags.heal))) &&
-					(!counter.setupType || counter.setupType === 'Mixed' || (move.category !== counter.setupType && move.category !== 'Status') || (counter[counter.setupType] + counter.Status > 3 && !counter.hazards)) &&
-				(
-					(!counter.stab && !hasMove['nightshade'] && !hasMove['seismictoss'] &&
-						(species.types.length > 1 || (species.types[0] !== 'Normal' && species.types[0] !== 'Psychic') || !hasMove['icebeam'] || species.baseStats.spa >= species.baseStats.spd)) ||
-					(hasType['Bug'] && (movePool.includes('megahorn') || movePool.includes('pinmissile'))) ||
-					((hasType['Dark'] && !counter['Dark'] && !hasAbility['Protean']) || hasMove['suckerpunch'] && !hasAbility['Contrary'] && counter.stab < species.types.length) ||
-					(hasType['Dragon'] && !counter['Dragon'] && !hasAbility['Aerilate'] && !hasAbility['Pixilate'] && !hasMove['fly'] && !hasMove['rest'] && !hasMove['sleeptalk']) ||
-					(hasType['Electric'] && (!counter['Electric'] || movePool.includes('thunder'))) ||
+					(isDoubles || (
+						!['judgment', 'lightscreen', 'reflect', 'sleeptalk', 'toxic'].includes(moveid) &&
+						(move.category !== 'Status' || !move.flags.heal)
+					)) && (
+					!counter.setupType || counter.setupType === 'Mixed' ||
+					(move.category !== counter.setupType && move.category !== 'Status') ||
+					(counter[counter.setupType] + counter.Status > 3 && !counter.hazards)
+				) && (
+					(!counter.stab && !hasMove['nightshade'] && !hasMove['seismictoss'] && (
+						species.types.length > 1 ||
+						(species.types[0] !== 'Normal' && species.types[0] !== 'Psychic') ||
+						!hasMove['icebeam'] ||
+						species.baseStats.spa >= species.baseStats.spd)
+					) || (hasType['Bug'] && (movePool.includes('megahorn') || movePool.includes('pinmissile'))) || (
+						hasType['Dark'] &&
+						!counter['Dark'] &&
+						!hasAbility['Protean']
+					) || (
+						hasMove['suckerpunch'] && !hasAbility['Contrary'] && counter.stab < species.types.length
+					) || (
+						hasType['Dragon'] &&
+						!counter['Dragon'] &&
+						!hasAbility['Aerilate'] && !hasAbility['Pixilate'] &&
+						!hasMove['fly'] && !hasMove['rest'] && !hasMove['sleeptalk']
+					) || (hasType['Electric'] && (!counter['Electric'] || movePool.includes('thunder'))) ||
 					(hasType['Fairy'] && !counter['Fairy'] && !hasType['Flying'] && !hasAbility['Pixilate']) ||
 					(hasType['Fighting'] && (!counter['Fighting'] || !counter.stab)) ||
-					(hasType['Fire'] && (!counter['Fire'] || movePool.includes('flareblitz') || movePool.includes('quiverdance'))) ||
-					(hasType['Flying'] && !counter['Flying'] && (hasAbility['Gale Wings'] || hasAbility['Serene Grace'] || (hasType['Normal'] && (movePool.includes('beakblast') || movePool.includes('bravebird'))))) ||
-					(hasType['Ghost'] && (!counter['Ghost'] || movePool.includes('spectralthief')) && !hasType['Dark'] && !hasAbility['Steelworker']) ||
-					(hasType['Grass'] && !counter['Grass'] && (species.baseStats.atk >= 100 || movePool.includes('leafstorm'))) ||
-					(hasType['Ground'] && !counter['Ground'] && !hasMove['rest'] && !hasMove['sleeptalk']) ||
-					(hasType['Ice'] && !hasAbility['Refrigerate'] && (!counter['Ice'] || movePool.includes('iciclecrash') || (hasAbility['Snow Warning'] && movePool.includes('blizzard')))) ||
-					(hasType['Normal'] && movePool.includes('facade')) ||
-					(hasType['Poison'] && !counter['Poison'] && (counter.setupType || hasAbility['Adaptability'] || hasAbility['Sheer Force'] || movePool.includes('gunkshot'))) ||
-					(hasType['Psychic'] && !counter['Psychic'] && (hasAbility['Psychic Surge'] || movePool.includes('psychicfangs') || !hasType['Flying'] && !hasAbility['Pixilate'] && counter.stab < species.types.length)) ||
-					(hasType['Rock'] && !counter['Rock'] && !hasType['Fairy'] && (counter.setupType === 'Physical' || species.baseStats.atk >= 105 || hasAbility['Rock Head'])) ||
-					(hasType['Steel'] && !counter['Steel'] && (species.baseStats.atk >= 100 || hasAbility['Steelworker'])) ||
-					(hasType['Water'] && ((!counter['Water'] && !hasAbility['Protean']) || !counter.stab || movePool.includes('crabhammer'))) ||
-					(hasAbility['Adaptability'] && !counter.setupType && species.types.length > 1 && (!counter[species.types[0]] || !counter[species.types[1]])) ||
-					((hasAbility['Aerilate'] || hasAbility['Pixilate'] || (hasAbility['Refrigerate'] && !hasMove['blizzard'])) && !counter['Normal']) ||
-					(hasAbility['Contrary'] && !counter['contrary'] && species.name !== 'Shuckle') ||
+					(hasType['Fire'] && (!counter['Fire'] || movePool.includes('flareblitz') || movePool.includes('quiverdance'))) || (
+						hasType['Flying'] &&
+						!counter['Flying'] &&
+						(hasAbility['Gale Wings'] || hasAbility['Serene Grace'] || (
+							hasType['Normal'] && (movePool.includes('beakblast') || movePool.includes('bravebird'))
+						))
+					) || (
+						hasType['Ghost'] &&
+						(!counter['Ghost'] || movePool.includes('spectralthief')) &&
+						!hasType['Dark'] &&
+						!hasAbility['Steelworker']
+					) || (hasType['Grass'] && !counter['Grass'] && (species.baseStats.atk >= 100 || movePool.includes('leafstorm'))) ||
+					(hasType['Ground'] && !counter['Ground'] && !hasMove['rest'] && !hasMove['sleeptalk']) || (
+						hasType['Ice'] && !hasAbility['Refrigerate'] && (
+							!counter['Ice'] ||
+							movePool.includes('iciclecrash') ||
+							(hasAbility['Snow Warning'] && movePool.includes('blizzard'))
+						)
+					) || (hasType['Normal'] && movePool.includes('facade')) || (
+						hasType['Poison'] &&
+						!counter['Poison'] &&
+						(counter.setupType || hasAbility['Adaptability'] || hasAbility['Sheer Force'] || movePool.includes('gunkshot'))
+					) || (hasType['Psychic'] && !counter['Psychic'] && (
+						hasAbility['Psychic Surge'] ||
+						movePool.includes('psychicfangs') ||
+						(!hasType['Flying'] && !hasAbility['Pixilate'] && counter.stab < species.types.length)
+					)) || (
+						hasType['Rock'] &&
+						!counter['Rock'] &&
+						!hasType['Fairy'] &&
+						(counter.setupType === 'Physical' || species.baseStats.atk >= 105 || hasAbility['Rock Head'])
+					) || (hasType['Steel'] && !counter['Steel'] && (species.baseStats.atk >= 100 || hasAbility['Steelworker'])) || (
+						hasType['Water'] &&
+						((!counter['Water'] && !hasAbility['Protean']) || !counter.stab || movePool.includes('crabhammer'))
+					) || (
+						hasAbility['Adaptability'] &&
+						!counter.setupType &&
+						species.types.length > 1 &&
+						(!counter[species.types[0]] || !counter[species.types[1]])
+					) || (
+						!counter['Normal'] &&
+						(hasAbility['Aerilate'] || hasAbility['Pixilate'] || (hasAbility['Refrigerate'] && !hasMove['blizzard']))
+					) || (hasAbility['Contrary'] && !counter['contrary'] && species.name !== 'Shuckle') ||
 					(hasAbility['Slow Start'] && movePool.includes('substitute')) ||
-					((movePool.includes('recover') || movePool.includes('roost') || movePool.includes('slackoff') || movePool.includes('softboiled')) &&
-						!!counter.Status && !counter.setupType && !hasMove['healingwish'] && !hasMove['trick'] && !hasMove['trickroom']) ||
-					(movePool.includes('milkdrink') || movePool.includes('shoreup') || movePool.includes('stickyweb') && !counter.setupType && !teamDetails.stickyWeb) ||
-					(isLead && movePool.includes('stealthrock') && !!counter.Status && !counter.setupType && !counter['speedsetup'] && !hasMove['substitute']) ||
-					(species.requiredMove && movePool.includes(toID(species.requiredMove)))
+					(
+						(['recover', 'roost', 'slackoff', 'softboiled'].some(m => movePool.includes(m))) &&
+						counter.Status &&
+						!counter.setupType &&
+						['healingwish', 'trick', 'trickroom'].every(m => !hasMove[m])
+					) || (
+						movePool.includes('milkdrink') ||
+						movePool.includes('shoreup') ||
+						(movePool.includes('stickyweb') && !counter.setupType && !teamDetails.stickyWeb)
+					) || (
+						isLead &&
+						movePool.includes('stealthrock') &&
+						counter.Status && !counter.setupType &&
+						!counter['speedsetup'] && !hasMove['substitute']
+					) || (species.requiredMove && movePool.includes(toID(species.requiredMove)))
 				)) {
 					// Reject Status or non-STAB, or low basepower moves
 					if (move.category === 'Status' || !hasType[move.type] || move.basePower && move.basePower < 40 && !move.multihit) {
@@ -555,7 +668,10 @@ export class RandomGen7Teams extends RandomTeams {
 				}
 
 				// Remove rejected moves from the move list
-				if (rejected && (movePool.length - availableHP || availableHP && (moveid === 'hiddenpower' || !hasMove['hiddenpower']))) {
+				if (rejected && (
+					movePool.length - availableHP ||
+					(availableHP && (moveid === 'hiddenpower' || !hasMove['hiddenpower']))
+				)) {
 					if (move.category !== 'Status' && !move.damage && !move.flags.charge && (moveid !== 'hiddenpower' || !availableHP)) {
 						rejectedPool.push(moves[k]);
 					}
@@ -584,8 +700,10 @@ export class RandomGen7Teams extends RandomTeams {
 			moves[moves.indexOf('workup')] = 'bulkup';
 		}
 
-		const baseSpecies: Species = species.battleOnly && !species.requiredAbility ? this.dex.getSpecies(species.battleOnly as string) : species;
+		const battleOnly = species.battleOnly && !species.requiredAbility;
+		const baseSpecies: Species = battleOnly ? this.dex.getSpecies(species.battleOnly as string) : species;
 		const abilities: string[] = Object.values(baseSpecies.abilities);
+		const defensiveStatTotal = species.baseStats.hp + species.baseStats.def + species.baseStats.spd;
 		abilities.sort((a, b) => this.dex.getAbility(b).rating - this.dex.getAbility(a).rating);
 		let ability0 = this.dex.getAbility(abilities[0]);
 		let ability1 = this.dex.getAbility(abilities[1]);
@@ -604,7 +722,9 @@ export class RandomGen7Teams extends RandomTeams {
 			let rejectAbility: boolean;
 			do {
 				rejectAbility = false;
-				if (['Battle Bond', 'Dazzling', 'Flare Boost', 'Hyper Cutter', 'Ice Body', 'Innards Out', 'Moody', 'Steadfast'].includes(ability)) {
+				if ([
+					'Battle Bond', 'Dazzling', 'Flare Boost', 'Hyper Cutter', 'Ice Body', 'Innards Out', 'Moody', 'Steadfast',
+				].includes(ability)) {
 					rejectAbility = true;
 				} else if (['Aerilate', 'Galvanize', 'Pixilate', 'Refrigerate'].includes(ability)) {
 					rejectAbility = !counter['Normal'];
@@ -613,7 +733,11 @@ export class RandomGen7Teams extends RandomTeams {
 				} else if (ability === 'Battle Armor' || ability === 'Sturdy') {
 					rejectAbility = (!!counter['recoil'] && !counter['recovery']);
 				} else if (ability === 'Chlorophyll' || ability === 'Leaf Guard') {
-					rejectAbility = (species.baseStats.spe > 100 || abilities.includes('Harvest') || !hasMove['sunnyday'] && !teamDetails['sun']);
+					rejectAbility = (
+						species.baseStats.spe > 100 ||
+						abilities.includes('Harvest') ||
+						(!hasMove['sunnyday'] && !teamDetails['sun'])
+					);
 				} else if (ability === 'Competitive') {
 					rejectAbility = (!counter['Special'] || hasMove['rest'] && hasMove['sleeptalk']);
 				} else if (ability === 'Compound Eyes' || ability === 'No Guard') {
@@ -651,7 +775,11 @@ export class RandomGen7Teams extends RandomTeams {
 				} else if (ability === 'Magnet Pull') {
 					rejectAbility = (!!counter['Normal'] || !hasType['Electric'] && !hasMove['earthpower']);
 				} else if (ability === 'Mold Breaker') {
-					rejectAbility = (hasMove['acrobatics'] || hasMove['sleeptalk'] || abilities.includes('Adaptability') || abilities.includes('Iron Fist') || abilities.includes('Sheer Force') && !!counter['sheerforce']);
+					rejectAbility = (
+						hasMove['acrobatics'] || hasMove['sleeptalk'] ||
+						abilities.includes('Adaptability') || abilities.includes('Iron Fist') ||
+						(abilities.includes('Sheer Force') && counter['sheerforce'])
+					);
 				} else if (ability === 'Overgrow') {
 					rejectAbility = !counter['Grass'];
 				} else if (ability === 'Poison Heal') {
@@ -687,7 +815,12 @@ export class RandomGen7Teams extends RandomTeams {
 				} else if (ability === 'Technician') {
 					rejectAbility = (!counter['technician'] || hasMove['tailslap'] || !!species.isMega);
 				} else if (ability === 'Tinted Lens') {
-					rejectAbility = (hasMove['protect'] || !!counter['damage'] || (counter.Status > 2 && !counter.setupType) || abilities.includes('Prankster') || abilities.includes('Magic Guard') && !!counter['Status']);
+					rejectAbility = (
+						hasMove['protect'] || !!counter['damage'] ||
+						(counter.Status > 2 && !counter.setupType) ||
+						abilities.includes('Prankster') ||
+						(abilities.includes('Magic Guard') && !!counter['Status'])
+					);
 				} else if (ability === 'Torrent') {
 					rejectAbility = (!counter['Water'] || !!species.isMega);
 				} else if (ability === 'Unaware') {
@@ -695,7 +828,7 @@ export class RandomGen7Teams extends RandomTeams {
 				} else if (ability === 'Unburden') {
 					rejectAbility = (!!species.isMega || abilities.includes('Prankster') || !counter.setupType && !hasMove['acrobatics']);
 				} else if (ability === 'Water Absorb') {
-					rejectAbility = (hasMove['raindance'] || abilities.includes('Drizzle') || abilities.includes('Unaware') || abilities.includes('Volt Absorb'));
+					rejectAbility = hasMove['raindance'] || ['Drizzle', 'Unaware', 'Volt Absorb'].some(abil => abilities.includes(abil));
 				} else if (ability === 'Weak Armor') {
 					rejectAbility = counter.setupType !== 'Physical';
 				}
@@ -713,7 +846,11 @@ export class RandomGen7Teams extends RandomTeams {
 				}
 			} while (rejectAbility);
 
-			if (abilities.includes('Guts') && ability !== 'Quick Feet' && (hasMove['facade'] || (hasMove['protect'] && !isDoubles) || (hasMove['rest'] && hasMove['sleeptalk']))) {
+			if (
+				abilities.includes('Guts') &&
+				ability !== 'Quick Feet' &&
+				(hasMove['facade'] || (hasMove['protect'] && !isDoubles) || (hasMove['rest'] && hasMove['sleeptalk']))
+			) {
 				ability = 'Guts';
 			} else if (abilities.includes('Moxie') && (counter.Physical > 3 || hasMove['bounce']) && !isDoubles) {
 				ability = 'Moxie';
@@ -780,10 +917,20 @@ export class RandomGen7Teams extends RandomTeams {
 				}
 			}
 		} else if (species.name === 'Pikachu') {
-			if (!isDoubles) forme = `Pikachu${this.sample(['', '-Original', '-Hoenn', '-Sinnoh', '-Unova', '-Kalos', '-Alola', '-Partner'])}`;
+			if (!isDoubles) {
+				const pikachuForme = this.sample(['', '-Original', '-Hoenn', '-Sinnoh', '-Unova', '-Kalos', '-Alola', '-Partner']);
+				forme = `Pikachu${pikachuForme}`;
+			}
 			if (forme !== 'Pikachu') ability = 'Static';
 			item = 'Light Ball';
-		} else if (species.name === 'Porygon-Z' && hasMove['nastyplot'] && !hasMove['trick'] && !['nastyplot', 'icebeam', 'triattack'].includes(moves[0]) && !teamDetails.zMove && !isDoubles) {
+		} else if (
+			!isDoubles &&
+			species.name === 'Porygon-Z' &&
+			hasMove['nastyplot'] &&
+			!hasMove['trick'] &&
+			!['nastyplot', 'icebeam', 'triattack'].includes(moves[0]) &&
+			!teamDetails.zMove
+		) {
 			moves[moves.indexOf('nastyplot')] = 'conversion';
 			moves[moves.indexOf('triattack')] = 'recover';
 			item = 'Normalium Z';
@@ -827,15 +974,26 @@ export class RandomGen7Teams extends RandomTeams {
 			item = (ability === 'Solid Rock' && !!counter['priority']) ? 'Weakness Policy' : 'White Herb';
 		} else if ((ability === 'Guts' || hasMove['facade']) && !hasMove['sleeptalk']) {
 			item = (hasType['Fire'] || ability === 'Quick Feet' || ability === 'Toxic Boost') ? 'Toxic Orb' : 'Flame Orb';
-		} else if ((ability === 'Magic Guard' && counter.damagingMoves.length > 1) || ability === 'Sheer Force' && !!counter['sheerforce']) {
+		} else if (
+			(ability === 'Magic Guard' && counter.damagingMoves.length > 1) ||
+			(ability === 'Sheer Force' && counter['sheerforce'])
+		) {
 			item = 'Life Orb';
 		} else if (ability === 'Unburden') {
 			item = hasMove['fakeout'] ? 'Normal Gem' : 'Sitrus Berry';
 		} else if (hasMove['acrobatics']) {
 			item = '';
-		} else if (hasMove['bugbuzz'] && counter.setupType && species.baseStats.spa > 100 && !teamDetails.zMove) {
+		} else if (
+			hasMove['bugbuzz'] &&
+			counter.setupType &&
+			species.baseStats.spa > 100 &&
+			!teamDetails.zMove
+		) {
 			item = 'Buginium Z';
-		} else if (((hasMove['darkpulse'] && ability === 'Fur Coat' && counter.setupType) || (hasMove['suckerpunch'] && ability === 'Moxie' && counter['Dark'] < 2)) && !teamDetails.zMove) {
+		} else if (!teamDetails.zMove && (
+			(hasMove['darkpulse'] && ability === 'Fur Coat' && counter.setupType) ||
+			(hasMove['suckerpunch'] && ability === 'Moxie' && counter['Dark'] < 2)
+		)) {
 			item = 'Darkinium Z';
 		} else if (hasMove['outrage'] && counter.setupType && !hasMove['fly'] && !teamDetails.zMove) {
 			item = 'Dragonium Z';
@@ -843,19 +1001,30 @@ export class RandomGen7Teams extends RandomTeams {
 			item = 'Electrium Z';
 		} else if (hasMove['fleurcannon'] && !!counter['speedsetup'] && !teamDetails.zMove) {
 			item = 'Fairium Z';
-		} else if (((hasMove['focusblast'] && hasType['Fighting'] && counter.setupType) || (hasMove['reversal'] && hasMove['substitute'])) && !teamDetails.zMove) {
+		} else if (!teamDetails.zMove && (
+			(hasMove['focusblast'] && hasType['Fighting'] && counter.setupType) ||
+			(hasMove['reversal'] && hasMove['substitute'])
+		)) {
 			item = 'Fightinium Z';
 		} else if (hasMove['magmastorm'] && !teamDetails.zMove) {
 			item = 'Firium Z';
-		} else if (!teamDetails.zMove && (hasMove['fly'] || (hasMove['hurricane'] && species.baseStats.spa >= 125 && (!!counter.Status || hasMove['superpower'])) || ((hasMove['bounce'] || hasMove['bravebird']) && counter.setupType))) {
+		} else if (!teamDetails.zMove && (
+			hasMove['fly'] ||
+			(hasMove['hurricane'] && species.baseStats.spa >= 125 && (!!counter.Status || hasMove['superpower'])) ||
+			((hasMove['bounce'] || hasMove['bravebird']) && counter.setupType)
+		)) {
 			item = 'Flyinium Z';
-		} else if (hasMove['shadowball'] && counter.setupType && ability === 'Beast Boost' && !teamDetails.zMove) {
+		} else if (!teamDetails.zMove && hasMove['shadowball'] && counter.setupType && ability === 'Beast Boost') {
 			item = 'Ghostium Z';
-		} else if (hasMove['sleeppowder'] && hasType['Grass'] && counter.setupType && species.baseStats.spe <= 70 && !teamDetails.zMove) {
+		} else if (
+			!teamDetails.zMove &&
+			hasMove['sleeppowder'] && hasType['Grass'] &&
+			counter.setupType && species.baseStats.spe <= 70
+		) {
 			item = 'Grassium Z';
 		} else if (hasMove['dig'] && !teamDetails.zMove) {
 			item = 'Groundium Z';
-		} else if (hasMove['happyhour'] || hasMove['holdhands'] || hasMove['encore'] && ability === 'Contrary') {
+		} else if (hasMove['happyhour'] || hasMove['holdhands'] || (hasMove['encore'] && ability === 'Contrary')) {
 			item = 'Normalium Z';
 		} else if (hasMove['photongeyser'] && counter.setupType && !teamDetails.zMove) {
 			item = 'Psychium Z';
@@ -881,52 +1050,103 @@ export class RandomGen7Teams extends RandomTeams {
 			}
 		} else if (hasMove['auroraveil'] || hasMove['lightscreen'] && hasMove['reflect']) {
 			item = 'Light Clay';
-		} else if (hasMove['rest'] && !hasMove['sleeptalk'] && ability !== 'Natural Cure' && ability !== 'Shed Skin' && ability !== 'Shadow Tag') {
+		} else if (
+			hasMove['rest'] && !hasMove['sleeptalk'] &&
+			ability !== 'Natural Cure' && ability !== 'Shed Skin' && ability !== 'Shadow Tag'
+		) {
 			item = 'Chesto Berry';
 
 		// Medium priority
-		} else if ((ability === 'Speed Boost' || ability === 'Stance Change' || species.name === 'Pheromosa') && counter.Physical + counter.Special > 2 && !hasMove['uturn']) {
+		} else if (
+			(ability === 'Speed Boost' || ability === 'Stance Change' || species.name === 'Pheromosa') &&
+			counter.Physical + counter.Special > 2 &&
+			!hasMove['uturn']
+		) {
 			item = 'Life Orb';
 		} else if (isDoubles && hasMove['uturn'] && counter.Physical === 4 && !hasMove['fakeout']) {
-			item = (species.baseStats.spe >= 60 && species.baseStats.spe <= 108 && !counter['priority'] && this.randomChance(1, 2)) ? 'Choice Scarf' : 'Choice Band';
+			item = (
+				species.baseStats.spe >= 60 && species.baseStats.spe <= 108 &&
+				!counter['priority'] && this.randomChance(1, 2)
+			) ? 'Choice Scarf' : 'Choice Band';
 		} else if (isDoubles && counter.Special === 4 && hasMove['waterspout'] || hasMove['eruption']) {
 			item = 'Choice Scarf';
-		} else if (counter.Physical >= 4 && !hasMove['bodyslam'] && !hasMove['dragontail'] && !hasMove['fakeout'] && !hasMove['flamecharge'] && !hasMove['rapidspin'] && !hasMove['suckerpunch'] && !isDoubles) {
-			item = (species.baseStats.atk >= 100 || ability === 'Huge Power') && species.baseStats.spe >= 60 && species.baseStats.spe <= 108 && !counter['priority'] && this.randomChance(2, 3) ? 'Choice Scarf' : 'Choice Band';
-		} else if ((counter.Special >= 4 || (counter.Special >= 3 && hasMove['uturn'])) && !hasMove['acidspray'] && !hasMove['clearsmog'] && !isDoubles) {
-			if (species.baseStats.spa >= 100 && species.baseStats.spe >= 60 && species.baseStats.spe <= 108 && ability !== 'Tinted Lens' && !counter.Physical && !counter['priority'] && this.randomChance(2, 3)) {
-				item = 'Choice Scarf';
-			} else {
-				item = 'Choice Specs';
-			}
-		} else if (counter.Physical >= 3 && hasMove['defog'] && species.baseStats.spe >= 60 && species.baseStats.spe <= 108 && !counter['priority'] && !hasMove['foulplay'] && !isDoubles) {
+		} else if (
+			!isDoubles &&
+			counter.Physical >= 4 &&
+			['bodyslam', 'dragontail', 'fakeout', 'flamecharge', 'rapidspin', 'suckerpunch'].every(m => !hasMove[m])
+		) {
+			item = (
+				(species.baseStats.atk >= 100 || ability === 'Huge Power') &&
+				species.baseStats.spe >= 60 && species.baseStats.spe <= 108 &&
+				!counter['priority'] &&
+				this.randomChance(2, 3)
+			) ? 'Choice Scarf' : 'Choice Band';
+		} else if (
+			!isDoubles &&
+			(counter.Special >= 4 || (counter.Special >= 3 && hasMove['uturn'])) &&
+			!hasMove['acidspray'] && !hasMove['clearsmog']
+		) {
+			item = (
+				species.baseStats.spa >= 100 &&
+				species.baseStats.spe >= 60 && species.baseStats.spe <= 108 &&
+				ability !== 'Tinted Lens' &&
+				!counter.Physical && !counter['priority'] &&
+				this.randomChance(2, 3)
+			) ? 'Choice Scarf' : 'Choice Specs';
+		} else if (
+			!isDoubles &&
+			counter.Physical >= 3 &&
+			hasMove['defog'] &&
+			!hasMove['foulplay'] &&
+			species.baseStats.spe >= 60 && species.baseStats.spe <= 108 &&
+			!counter['priority']
+		) {
 			item = 'Choice Scarf';
 		} else if ((ability === 'Drizzle' || ability === 'Slow Start' || species.name.includes('Rotom-') ||
-			hasMove['aromatherapy'] || hasMove['bite'] || hasMove['clearsmog'] || hasMove['curse'] || hasMove['protect'] || hasMove['sleeptalk']) && !isDoubles
+			['aromatherapy', 'bite', 'clearsmog', 'curse', 'protect', 'sleeptalk'].some(m => hasMove[m])) && !isDoubles
 		) {
 			item = 'Leftovers';
-		} else if ((hasMove['endeavor'] || hasMove['flail'] || hasMove['reversal']) && ability !== 'Sturdy') {
+		} else if (['endeavor', 'flail', 'reversal'].some(m => hasMove[m]) && ability !== 'Sturdy') {
 			item = (ability === 'Defeatist') ? 'Expert Belt' : 'Focus Sash';
 		} else if (hasMove['outrage'] && counter.setupType) {
 			item = 'Lum Berry';
-		} else if (isDoubles && counter.damagingMoves.length >= 3 && species.baseStats.spe >= 70 && ability !== 'Multiscale' && ability !== 'Sturdy' && !hasMove['acidspray'] && !hasMove['electroweb'] && !hasMove['fakeout'] &&
-			!hasMove['feint'] && !hasMove['flamecharge'] && !hasMove['icywind'] && !hasMove['incinerate'] && !hasMove['naturesmadness'] && !hasMove['rapidspin'] && !hasMove['snarl'] && !hasMove['suckerpunch'] && !hasMove['uturn']) {
-			item = (species.baseStats.hp + species.baseStats.def + species.baseStats.spd >= 275) ? 'Sitrus Berry' : 'Life Orb';
+		} else if (
+			isDoubles &&
+			counter.damagingMoves.length >= 3 &&
+			species.baseStats.spe >= 70 &&
+			ability !== 'Multiscale' && ability !== 'Sturdy' && [
+				'acidspray', 'electroweb', 'fakeout', 'feint', 'flamecharge', 'icywind',
+				'incinerate', 'naturesmadness', 'rapidspin', 'snarl', 'suckerpunch', 'uturn',
+			].every(m => !hasMove[m])
+		) {
+			item = (defensiveStatTotal >= 275) ? 'Sitrus Berry' : 'Life Orb';
 		} else if (hasMove['substitute']) {
 			item = counter.damagingMoves.length > 2 && !!counter['drain'] ? 'Life Orb' : 'Leftovers';
-		} else if (this.dex.getEffectiveness('Ground', species) >= 2 && ability !== 'Levitate' && !hasMove['magnetrise'] && !isDoubles) {
+		} else if (
+			!isDoubles &&
+			this.dex.getEffectiveness('Ground', species) >= 2 &&
+			ability !== 'Levitate' &&
+			!hasMove['magnetrise']
+		) {
 			item = 'Air Balloon';
 		} else if ((ability === 'Iron Barbs' || ability === 'Rough Skin') && this.randomChance(1, 2)) {
 			item = 'Rocky Helmet';
-		} else if (counter.Physical + counter.Special >= 4 && species.baseStats.spd >= 50 && species.baseStats.hp + species.baseStats.def + species.baseStats.spd >= 235) {
+		} else if (
+			counter.Physical + counter.Special >= 4 &&
+			species.baseStats.spd >= 50 && defensiveStatTotal >= 235) {
 			item = 'Assault Vest';
 		} else if (species.name === 'Palkia' && (hasMove['dracometeor'] || hasMove['spacialrend']) && hasMove['hydropump']) {
 			item = 'Lustrous Orb';
 		} else if (counter.damagingMoves.length >= 4) {
-			item = (!!counter['Dragon'] || !!counter['Dark'] || !!counter['Normal']) ? 'Life Orb' : 'Expert Belt';
-		} else if (counter.damagingMoves.length >= 3 && !!counter['speedsetup'] && species.baseStats.hp + species.baseStats.def + species.baseStats.spd >= 300) {
+			item = (counter['Dragon'] || counter['Dark'] || counter['Normal']) ? 'Life Orb' : 'Expert Belt';
+		} else if (counter.damagingMoves.length >= 3 && !!counter['speedsetup'] && defensiveStatTotal >= 300) {
 			item = 'Weakness Policy';
-		} else if (isLead && !['Regenerator', 'Sturdy'].includes(ability) && !counter['recoil'] && !counter['recovery'] && species.baseStats.hp + species.baseStats.def + species.baseStats.spd < 255 && !isDoubles) {
+		} else if (
+			!isDoubles && isLead &&
+			!['Regenerator', 'Sturdy'].includes(ability) &&
+			!counter['recoil'] && !counter['recovery'] &&
+			defensiveStatTotal < 255
+		) {
 			item = 'Focus Sash';
 
 		// This is the "REALLY can't think of a good item" cutoff
@@ -938,8 +1158,15 @@ export class RandomGen7Teams extends RandomTeams {
 			item = 'Custap Berry';
 		} else if (ability === 'Super Luck') {
 			item = 'Scope Lens';
-		} else if (counter.damagingMoves.length >= 3 && ability !== 'Sturdy' && !hasMove['acidspray'] && !hasMove['dragontail'] && !hasMove['foulplay'] && !hasMove['rapidspin'] && !hasMove['superfang'] && !hasMove['uturn'] && !isDoubles) {
-			if (!!counter['speedsetup'] || hasMove['trickroom'] || species.baseStats.spe > 40 && species.baseStats.hp + species.baseStats.def + species.baseStats.spd < 275) item = 'Life Orb';
+		} else if (
+			!isDoubles && counter.damagingMoves.length >= 3 && ability !== 'Sturdy' &&
+			['acidspray', 'dragontail', 'foulplay', 'rapidspin', 'superfang', 'uturn'].every(m => !hasMove[m]) && (
+				counter['speedsetup'] ||
+				hasMove['trickroom'] ||
+				(species.baseStats.spe > 40 && defensiveStatTotal < 275)
+			)
+		) {
+			item = 'Life Orb';
 		}
 
 		// For Trick / Switcheroo
@@ -1001,7 +1228,10 @@ export class RandomGen7Teams extends RandomTeams {
 			if (hasMove['substitute'] && hasMove['reversal']) {
 				// Reversal users should be able to use four Substitutes
 				if (hp % 4 > 0) break;
-			} else if (hasMove['substitute'] && (item === 'Petaya Berry' || item === 'Sitrus Berry' || ability === 'Power Construct' && item !== 'Leftovers')) {
+			} else if (hasMove['substitute'] && (
+				item === 'Petaya Berry' || item === 'Sitrus Berry' ||
+				(ability === 'Power Construct' && item !== 'Leftovers')
+			)) {
 				// Three Substitutes should activate Petaya Berry for Dedenne
 				// Two Substitutes should activate Sitrus Berry or Power Construct
 				if (hp % 4 === 0) break;
@@ -1026,7 +1256,7 @@ export class RandomGen7Teams extends RandomTeams {
 			ivs.spa = 0;
 		}
 
-		if (hasMove['gyroball'] || hasMove['metalburst'] || hasMove['trickroom']) {
+		if (['gyroball', 'metalburst', 'trickroom'].some(m => hasMove[m])) {
 			evs.spe = 0;
 			ivs.spe = 0;
 		}
@@ -1103,8 +1333,11 @@ export class RandomGen7Teams extends RandomTeams {
 					if (this.gen >= 7 && this.randomChance(1, 2)) continue;
 					break;
 				}
-				if (species.otherFormes && !hasMega) {
-					if (species.otherFormes.includes(species.name + '-Mega') || species.otherFormes.includes(species.name + '-Mega-X')) continue;
+				if (species.otherFormes && !hasMega && (
+					species.otherFormes.includes(species.name + '-Mega') ||
+					species.otherFormes.includes(species.name + '-Mega-X')
+				)) {
+					continue;
 				}
 
 				const tier = species.tier;
@@ -1458,10 +1691,7 @@ export class RandomGen7Teams extends RandomTeams {
 			for (const typeName in this.dex.data.TypeChart) {
 				// Cover any major weakness (3+) with at least one resistance
 				if (teamData.resistances[typeName] >= 1) continue;
-				if (
-					resistanceAbilities[abilityData.id] && resistanceAbilities[abilityData.id].includes(typeName) ||
-					!this.dex.getImmunity(typeName, types)
-				) {
+				if (resistanceAbilities[abilityData.id]?.includes(typeName) || !this.dex.getImmunity(typeName, types)) {
 					// Heuristic: assume that Pokémon with these abilities don't have (too) negative typing.
 					teamData.resistances[typeName] = (teamData.resistances[typeName] || 0) + 1;
 					if (teamData.resistances[typeName] >= 1) teamData.weaknesses[typeName] = 0;
@@ -1694,10 +1924,7 @@ export class RandomGen7Teams extends RandomTeams {
 			for (const typeName in this.dex.data.TypeChart) {
 				// Cover any major weakness (3+) with at least one resistance
 				if (teamData.resistances[typeName] >= 1) continue;
-				if (
-					resistanceAbilities[abilityData.id] && resistanceAbilities[abilityData.id].includes(typeName) ||
-					!this.dex.getImmunity(typeName, types)
-				) {
+				if (resistanceAbilities[abilityData.id]?.includes(typeName) || !this.dex.getImmunity(typeName, types)) {
 					// Heuristic: assume that Pokémon with these abilities don't have (too) negative typing.
 					teamData.resistances[typeName] = (teamData.resistances[typeName] || 0) + 1;
 					if (teamData.resistances[typeName] >= 1) teamData.weaknesses[typeName] = 0;

--- a/data/mods/letsgo/random-teams.ts
+++ b/data/mods/letsgo/random-teams.ts
@@ -1,5 +1,3 @@
-/* eslint max-len: ["error", 240] */
-
 import RandomTeams from '../../random-teams';
 
 export class RandomLetsGoTeams extends RandomTeams {
@@ -70,7 +68,9 @@ export class RandomLetsGoTeams extends RandomTeams {
 
 				// Bad after setup
 				case 'dragontail':
-					if (counter.setupType || !!counter['speedsetup'] || hasMove['encore'] || hasMove['roar'] || hasMove['whirlwind']) rejected = true;
+					if (counter.setupType || !!counter['speedsetup'] || ['encore', 'roar', 'whirlwind'].some(m => hasMove[m])) {
+						rejected = true;
+					}
 					break;
 				case 'fakeout': case 'uturn':
 					if (counter.setupType || !!counter['speedsetup'] || hasMove['substitute']) rejected = true;
@@ -79,7 +79,7 @@ export class RandomLetsGoTeams extends RandomTeams {
 					if (counter.setupType || !!counter['speedsetup'] || hasMove['dragontail']) rejected = true;
 					break;
 				case 'protect':
-					if (counter.setupType || hasMove['rest'] || hasMove['lightscreen'] || hasMove['reflect']) rejected = true;
+					if (counter.setupType || ['rest', 'lightscreen', 'reflect'].some(m => hasMove[m])) rejected = true;
 					break;
 				case 'seismictoss':
 					if (counter.damagingMoves.length > 1 || counter.setupType) rejected = true;
@@ -111,7 +111,7 @@ export class RandomLetsGoTeams extends RandomTeams {
 					if (hasMove['blizzard']) rejected = true;
 					break;
 				case 'return':
-					if (hasMove['bodyslam'] || hasMove['facade'] || hasMove['doubleedge']) rejected = true;
+					if (['bodyslam', 'facade', 'doubleedge'].some(m => hasMove[m])) rejected = true;
 					break;
 				case 'psychic':
 					if (hasMove['psyshock']) rejected = true;
@@ -133,14 +133,25 @@ export class RandomLetsGoTeams extends RandomTeams {
 				}
 
 				// This move doesn't satisfy our setup requirements:
-				if ((move.category === 'Physical' && counter.setupType === 'Special') || (move.category === 'Special' && counter.setupType === 'Physical')) {
+				if (
+					(move.category === 'Physical' && counter.setupType === 'Special') ||
+					(move.category === 'Special' && counter.setupType === 'Physical')
+				) {
 					// Reject STABs last in case the setup type changes later on
 					if (!hasType[move.type] || counter.stab > 1 || counter[move.category] < 2) rejected = true;
 				}
-				if (counter.setupType && !isSetup && counter.setupType !== 'Mixed' && move.category !== counter.setupType && counter[counter.setupType] < 2) {
+				if (
+					!isSetup &&
+					counter.setupType && counter.setupType !== 'Mixed' &&
+					move.category !== counter.setupType &&
+					counter[counter.setupType] < 2
+				) {
 					// Mono-attacking with setup and RestTalk is allowed
 					// Reject Status moves only if there is nothing else to reject
-					if (move.category !== 'Status' || counter[counter.setupType] + counter.Status > 3 && counter['physicalsetup'] + counter['specialsetup'] < 2) {
+					if (
+						move.category !== 'Status' ||
+						counter[counter.setupType] + counter.Status > 3 && counter['physicalsetup'] + counter['specialsetup'] < 2
+					) {
 						rejected = true;
 					}
 				}
@@ -164,7 +175,12 @@ export class RandomLetsGoTeams extends RandomTeams {
 				)) {
 					// Reject Status or non-STAB
 					if (!isSetup && !move.damage && (move.category !== 'Status' || !move.flags.heal)) {
-						if (move.category === 'Status' || !hasType[move.type] || move.selfSwitch || move.basePower && move.basePower < 40 && !move.multihit) rejected = true;
+						if (
+							move.category === 'Status' ||
+							!hasType[move.type] ||
+							move.selfSwitch ||
+							move.basePower && move.basePower < 40 && !move.multihit
+						) rejected = true;
 					}
 				}
 

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -183,9 +183,9 @@ export class RandomTeams {
 	}
 
 	getTeam(options?: PlayerOptions | null): PokemonSet[] {
-		const generatorName = (typeof this.format.team === 'string' && this.format.team.startsWith('random') ?
-			this.format.team + 'Team' :
-			'');
+		const generatorName = (
+			typeof this.format.team === 'string' && this.format.team.startsWith('random')
+		 ) ? this.format.team + 'Team' : '';
 		// @ts-ignore
 		return this[generatorName || 'randomTeam'](options);
 	}
@@ -1273,9 +1273,9 @@ export class RandomTeams {
 			(counter.Special >= 4 && (hasType['Dragon'] || hasType['Fighting'] || hasType['Rock'] || hasMove['voltswitch'])) ||
 			((counter.Special >= 3 && (hasMove['flipturn'] || hasMove['uturn'])) && !hasMove['acidspray'] && !hasMove['electroweb'])
 		) {
-			return (species.baseStats.spe >= 60 && species.baseStats.spe <= 100 && this.randomChance(1, 2)) ?
-				'Choice Scarf' :
-				'Choice Specs';
+			return (
+				species.baseStats.spe >= 60 && species.baseStats.spe <= 100 && this.randomChance(1, 2)
+			) ? 'Choice Scarf' : 'Choice Specs';
 		}
 		if (counter.damagingMoves.length >= 4 && defensiveStatTotal >= 280) return 'Assault Vest';
 		if (

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -227,10 +227,10 @@ export class RandomTeams {
 		return this.fastPop(list, index);
 	}
 
-	isBeneficialInSingles(move: Move) {
-		return [
+	skipExtraRejectionInSingles(move: Move) {
+		return (move.category !== 'Status' || !move.flags.heal) && ![
 			'facade', 'lightscreen', 'reflect', 'sleeptalk', 'spore', 'substitute', 'switcheroo', 'teleport', 'toxic', 'trick',
-		].includes(move.id) && (move.category !== 'Status' || !move.flags.heal);
+		].includes(move.id);
 	}
 
 	randomCCTeam(): RandomTeamsTypes.RandomSet[] {
@@ -1502,7 +1502,7 @@ export class RandomTeams {
 					!rejected && !isSetup && !move.weather && !move.stallingMove && move.category === 'Status' ||
 					!hasType[move.type] ||
 					(isLowBP && !move.multihit && !hasAbility['Technician']) ||
-					(isDoubles || this.isBeneficialInSingles(move)) ||
+					(isDoubles || this.skipExtraRejectionInSingles(move)) ||
 					!counter.setupType || counter.setupType === 'Mixed' ||
 					(move.category !== counter.setupType && move.category !== 'Status') ||
 					(counter[counter.setupType] + counter.Status > 3 && !counter.hazards)

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -726,20 +726,26 @@ export class RandomTeams {
 		case 'acrobatics': case 'junglehealing':
 			return {cull: !isDoubles && !counter.setupType};
 		case 'destinybond': case 'healbell':
+			// Destiny Bond: Special case for preventing Leftovers Sharpedo
 			return {cull: movePool.includes('protect') || movePool.includes('wish')};
 		case 'dualwingbeat': case 'fly': case 'storedpower':
 			return {cull: !hasType[move.type] && !counter.setupType && counter.Status};
 		case 'fireblast':
+			// Special case for Togekiss, which always wants Aura Sphere
 			return {cull: hasAbility['Serene Grace'] && (!hasMove['trick'] || counter.Status > 1)};
 		case 'firepunch':
+			// Special case for Darmanitan-Zen-Galar, which doesn't always want Fire Punch
 			return {cull: movePool.includes('bellydrum') || (hasMove['earthquake'] && movePool.includes('substitute'))};
 		case 'flamecharge': case 'sacredsword':
+			// Special cases for regular Silvally and Doublade, which don't want these without Swords Dance
 			const fewDamagingMoves = counter.damagingMoves.length < 3 && !counter.setupType;
 			const swordsDance = !hasType['Grass'] && movePool.includes('swordsdance');
 			return {cull: fewDamagingMoves || swordsDance};
 		case 'hypervoice':
+			// Special case for Heliolisk, which always wants Thunderbolt
 			return {cull: hasType['Electric'] && movePool.includes('thunderbolt')};
 		case 'payback': case 'psychocut':
+			// Special case for Type: Null and Malamar, which don't want these + RestTalk
 			return {cull: !counter.Status || hasRestTalk};
 		case 'rest':
 			const bulkySetup = !hasMove['sleeptalk'] && ['bulkup', 'calmmind', 'coil', 'curse'].some(m => movePool.includes(m));
@@ -789,6 +795,7 @@ export class RandomTeams {
 
 		// Bad after setup
 		case 'counter': case 'reversal':
+			// Special case for Alakazam, which doesn't want Counter + Nasty Plot
 			return {cull: !!counter.setupType};
 		case 'firstimpression': case 'glare': case 'icywind': case 'tailwind': case 'waterspout':
 			return {cull: (counter.setupType && !isDoubles) || counter.speedsetup || hasMove['rest']};
@@ -812,6 +819,7 @@ export class RandomTeams {
 		case 'healingwish': case 'memento':
 			return {cull: counter.setupType || counter.recovery || hasMove['substitute'] || hasMove['uturn']};
 		case 'highjumpkick': case 'machpunch':
+			// Special case for Hitmonlee to mostly prevent non-Unburden Curse; 1% chance to fail
 			return {cull: hasMove['curse']};
 		case 'partingshot':
 			return {cull: counter.speedsetup || hasMove['bulkup'] || hasMove['uturn']};
@@ -867,13 +875,16 @@ export class RandomTeams {
 		case 'blazekick':
 			return {cull: counter.Special >= 1};
 		case 'firefang': case 'flamethrower':
+			// Fire Fang: Special case for Garchomp, which doesn't want Fire Fang w/o Swords Dance
 			const otherFireMoves = ['heatwave', 'overheat'].some(m => hasMove[m]);
 			return {cull: (hasMove['fireblast'] && counter.setupType !== 'Physical') || otherFireMoves};
 		case 'overheat':
 			return {cull: hasMove['flareblitz'] || (isDoubles && hasMove['calmmind'])};
-		case 'aquajet': case 'psychicfangs':
-			return {cull: hasMove['rapidspin'] || hasMove['taunt']};
+		case 'psychicfangs':
+			// Special case for Morpeko, which doesn't want 4 attacks Leftovers
+			return {cull: hasMove['rapidspin']};
 		case 'aquatail': case 'flipturn': case 'retaliate':
+			// Retaliate: Special case for Braviary to prevent Retaliate on non-Choice
 			return {cull: hasMove['aquajet'] || counter.Status};
 		case 'hydropump':
 			return {cull: hasMove['scald'] && (
@@ -881,17 +892,21 @@ export class RandomTeams {
 				(species.types.length > 1 && counter.stab < 3)
 			)};
 		case 'scald':
+			// Special case for Clawitzer
 			return {cull: hasMove['waterpulse']};
 		case 'thunderbolt':
+			// Special case for Goodra, which only wants one move to hit Water-types
 			return {cull: hasMove['powerwhip']};
 		case 'gigadrain':
 			return {cull: (!counter.setupType && hasMove['uturn']) || (hasType['Poison'] && !counter.Poison)};
 		case 'leafblade':
+			// Special case for Virizion to prevent Leaf Blade on Assault Vest sets
 			return {cull: (hasMove['leafstorm'] || movePool.includes('leafstorm')) && counter.setupType !== 'Physical'};
 		case 'leafstorm':
 			return {cull: (hasMove['gigadrain'] && counter.Status) || (isDoubles && hasMove['energyball'])};
 		case 'powerwhip':
-			return {cull: hasMove['leechlife'] || (!hasType['Grass'] && counter.Physical > 3 && movePool.includes('uturn'))};
+			// Special case for Centiskorch, which doesn't want Assault Vest
+			return {cull: hasMove['leechlife']};
 		case 'woodhammer':
 			return {cull: hasMove['hornleech'] && counter.Physical < 4};
 		case 'freezedry':
@@ -899,19 +914,25 @@ export class RandomTeams {
 			const preferThunderWave = movePool.includes('thunderwave') && hasType['Electric'];
 			return {cull: betterIceMove || preferThunderWave || movePool.includes('bodyslam')};
 		case 'bodypress':
+			// Partially a special case for Turtonator to make EQ=Smash, Press=Not Smash, never both
 			const eqShellSmashPossible = hasMove['earthquake'] && movePool.includes('shellsmash');
 			return {cull: eqShellSmashPossible || ['shellsmash', 'mirrorcoat', 'whirlwind'].some(m => hasMove[m])};
 		case 'circlethrow':
+			// Part of a special case for Throh to pick one specific Fighting move depending on its set
 			return {cull: hasMove['stormthrow'] && !hasMove['rest']};
 		case 'drainpunch':
 			return {cull: hasMove['closecombat'] || (!hasType['Fighting'] && movePool.includes('swordsdance'))};
 		case 'dynamicpunch': case 'thunderouskick':
+			// Dynamic Punch: Special case for Machamp to better split Guts and No Guard sets
 			return {cull: hasMove['closecombat'] || hasMove['facade']};
 		case 'focusblast':
+			// Special cases for Blastoise and Regice; Blastoise wants Shell Smash, and Regice wants Thunderbolt
 			return {cull: movePool.includes('shellsmash') || hasRestTalk};
 		case 'hammerarm':
+			// Special case for Kangaskhan, which always wants Sucker Punch
 			return {cull: hasMove['fakeout']};
 		case 'stormthrow':
+			// Part of a special case for Throh to pick one specific Fighting move depending on its set
 			return {cull: hasRestTalk};
 		case 'superpower':
 			return {
@@ -928,6 +949,7 @@ export class RandomTeams {
 			const subToxicPossible = hasMove['substitute'] && movePool.includes('toxic');
 			return {cull: movePoolCull || (isDoubles && doublesCull) || subToxicPossible || hasMove['bonemerang']};
 		case 'scorchingsands':
+			// Special cases for Ninetales and Palossand; prevents status redundancy
 			return {cull: hasMove['willowisp'] || hasMove['earthpower'] || (hasMove['toxic'] && movePool.includes('earthpower'))};
 		case 'airslash':
 			return {
@@ -937,12 +959,15 @@ export class RandomTeams {
 					(hasAbility['Simple'] && !!counter.recovery),
 			};
 		case 'bravebird':
+			// Special case for Mew, which only wants Brave Bird with Swords Dance
 			return {cull: hasMove['dragondance']};
 		case 'hurricane':
+			// Special case for Noctowl, which wants Air Slash if Nasty Plot instead
 			return {cull: hasAbility['Tinted Lens'] && counter.setupType && !isDoubles};
 		case 'futuresight':
 			return {cull: hasMove['psyshock'] || hasMove['trick'] || movePool.includes('teleport')};
 		case 'photongeyser':
+			// Special case for Necrozma-DM, which always wants Dragon Dance
 			return {cull: hasMove['morningsun']};
 		case 'psychic':
 			return {cull: hasMove['psyshock'] && (counter.setupType || isDoubles)};
@@ -959,6 +984,7 @@ export class RandomTeams {
 			const rockSlidePlusStatusPossible = counter.Status && movePool.includes('rockslide');
 			return {cull: gutsCullCondition || rockSlidePlusStatusPossible || hasMove['rockblast'] || hasMove['rockslide']};
 		case 'poltergeist':
+			// Special case for Dhelmise in Doubles, which doesn't want both
 			return {cull: hasMove['knockoff']};
 		case 'shadowball':
 			const cull = (
@@ -977,6 +1003,7 @@ export class RandomTeams {
 		case 'suckerpunch':
 			return {cull: hasMove['rest'] || counter.damagingMoves.length < 2 || (counter.Dark > 1 && !hasType['Dark'])};
 		case 'meteormash':
+			// Special case for Lucario, which always wants Extreme Speed
 			return {cull: movePool.includes('extremespeed')};
 		case 'dazzlinggleam':
 			return {cull: ['fleurcannon', 'moonblast', 'petaldance'].some(m => hasMove[m])};
@@ -986,14 +1013,17 @@ export class RandomTeams {
 			const toxicCullCondition = hasMove['toxic'] && !hasType['Normal'];
 			return {cull: hasMove['sludgebomb'] || hasMove['trick'] || movePool.includes('recover') || toxicCullCondition};
 		case 'haze':
+			// Special case for Corsola-Galar, which always wants Will-O-Wisp
 			return {cull: !teamDetails.stealthRock && (hasMove['stealthrock'] || movePool.includes('stealthrock'))};
 		case 'hypnosis':
+			// Special case for Xurkitree to properly split Blunder Policy and Choice item sets
 			return {cull: hasMove['voltswitch']};
 		case 'willowisp': case 'yawn':
 			return {cull: hasMove['thunderwave'] || hasMove['toxic']};
 		case 'painsplit': case 'recover': case 'synthesis':
 			return {cull: hasMove['rest'] || hasMove['wish'] || (move.id === 'synthesis' && hasMove['gigadrain'])};
 		case 'roost':
+			// Special case for Hawlucha, which doesn't want Roost + 3 attacks
 			return {cull: hasMove['throatchop'] || (hasMove['stoneedge'] && !hasType['Rock'])};
 		case 'reflect': case 'lightscreen':
 			return {cull: !!teamDetails.screens};
@@ -1003,6 +1033,7 @@ export class RandomTeams {
 			const calmMindCullCondition = !counter.recovery && movePool.includes('calmmind');
 			return {cull: hasMove['rest'] || moveBasedCull || doublesPowerWhip || calmMindCullCondition};
 		case 'helpinghand':
+			// Special case for Shuckle in Doubles, which doesn't want sets with no method to harm foes
 			return {cull: hasMove['acupressure']};
 		case 'wideguard':
 			return {cull: hasMove['protect']};

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1,5 +1,3 @@
-/* eslint max-len: ["error", 240] */
-
 import {Dex, toID} from '../sim/dex';
 import {PRNG, PRNGSeed} from '../sim/prng';
 
@@ -18,12 +16,64 @@ export interface TeamData {
 	gigantamax?: boolean;
 }
 
+type MoveRejectionChecker = (
+	movePool: string[], hasMove: {[k: string]: boolean}, hasAbility: {[k: string]: boolean}, hasType: {[k: string]: true},
+	counter: {[k: string]: any}, species: Species, teamDetails: RandomTeamsTypes.TeamDetails
+) => boolean;
+
+// Moves that restore HP:
+const RecoveryMove = [
+	'healorder', 'milkdrink', 'moonlight', 'morningsun', 'recover', 'roost', 'shoreup', 'slackoff', 'softboiled', 'strengthsap', 'synthesis',
+];
+// Moves that drop stats:
+const StatDroppingMoves = [
+	'closecombat', 'leafstorm', 'overheat', 'superpower', 'vcreate',
+];
+// Moves that boost Attack:
+const PhysicalSetup = [
+	'bellydrum', 'bulkup', 'coil', 'curse', 'dragondance', 'honeclaws', 'howl', 'poweruppunch', 'swordsdance',
+];
+// Moves which boost Special Attack:
+const SpecialSetup = [
+	'calmmind', 'chargebeam', 'geomancy', 'nastyplot', 'quiverdance', 'tailglow',
+];
+// Moves which boost Attack AND Special Attack:
+const MixedSetup = [
+	'clangoroussoul', 'growth', 'happyhour', 'holdhands', 'noretreat', 'shellsmash', 'workup',
+];
+// Moves which boost Speed:
+const SpeedSetup = [
+	'agility', 'autotomize', 'flamecharge', 'rockpolish', 'shiftgear',
+];
+// Moves that shouldn't be the only STAB moves:
+const NoStab = [
+	'accelerock', 'aquajet', 'beakblast', 'bounce', 'breakingswipe', 'explosion', 'fakeout', 'firstimpression', 'flamecharge',
+	'flipturn', 'iceshard', 'machpunch', 'pluck', 'pursuit', 'quickattack', 'selfdestruct', 'skydrop', 'suckerpunch', 'watershuriken',
+	'chatter', 'clearsmog', 'eruption', 'icywind', 'incinerate', 'meteorbeam', 'snarl', 'vacuumwave', 'voltswitch', 'waterspout',
+];
+// Hazard-setting moves
+const Hazards = [
+	'spikes', 'stealthrock', 'stickyweb', 'toxicspikes',
+];
 export class RandomTeams {
 	dex: ModdedDex;
 	gen: number;
 	factoryTier: string;
 	format: Format;
 	prng: PRNG;
+
+	/**
+	 * Checkers for move rejection based on a Pokémon's types or other factors
+	 *
+	 * returns true to reject, false otherwise.
+	 */
+	moveRejectionCheckers: {
+		screens: MoveRejectionChecker,
+		recovery: MoveRejectionChecker,
+		doubles: MoveRejectionChecker,
+		lead: MoveRejectionChecker,
+		[k: string]: MoveRejectionChecker,
+	};
 
 	constructor(format: Format | string, prng: PRNG | PRNGSeed | null) {
 		format = Dex.getFormat(format);
@@ -33,6 +83,99 @@ export class RandomTeams {
 		this.factoryTier = '';
 		this.format = format;
 		this.prng = prng && !Array.isArray(prng) ? prng : new PRNG(prng);
+
+		this.moveRejectionCheckers = {
+			screens: (movePool, hasMove, hasAbility, hasType, counter, species, teamDetails) => {
+				if (teamDetails.screens) return false;
+				return (
+					(hasMove['lightscreen'] && movePool.includes('reflect')) ||
+					(hasMove['reflect'] && movePool.includes('lightscreen'))
+				);
+			},
+			recovery: (movePool, hasMove, hasAbility, hasType, counter, species, teamDetails) => (
+				counter.Status &&
+				!counter.setupType &&
+				['morningsun', 'recover', 'roost', 'slackoff', 'softboiled'].some(moveid => movePool.includes(moveid)) &&
+				['healingwish', 'switcheroo', 'trick', 'trickroom'].every(moveid => !hasMove[moveid])
+			),
+			misc: (movePool, hasMove, hasAbility, hasType, counter, species, teamDetails) => {
+				if (movePool.includes('milkdrink') || movePool.includes('quiverdance')) return true;
+				return movePool.includes('stickyweb') && !counter.setupType && !teamDetails.stickyWeb;
+			},
+			lead: (movePool, hasMove, hasAbility, hasType, counter) => (
+				movePool.includes('stealthrock') &&
+				counter.Status &&
+				!counter.setupType &&
+				!counter.speedsetup &&
+				!hasMove['substitute']
+			),
+			doubles: (movePool, hasMove, hasAbility, hasType, counter, species) => (
+				species.baseStats.def >= 140 && movePool.includes('bodypress')
+			),
+			Bug: (movePool) => movePool.includes('megahorn'),
+			Dark: (movePool, hasMove, hasAbility, hasType, counter) => {
+				if (!counter.Dark) return true;
+				return hasMove['suckerpunch'] && (movePool.includes('knockoff') || movePool.includes('wickedblow'));
+			},
+			Dragon: (movePool, hasMove, hasAbility, hasType, counter) => (
+				!counter.Dragon &&
+				!hasMove['dragonascent'] &&
+				!hasMove['substitute'] &&
+				!(hasMove['rest'] && hasMove['sleeptalk'])
+			),
+			Electric: (movePool, hasMove, hasAbility, hasType, counter) => !counter.Electric || movePool.includes('thunder'),
+			Fairy: (movePool, hasMove, hasAbility, hasType, counter) => (
+				!counter.Fairy &&
+				['dazzlinggleam', 'moonblast', 'fleurcannon', 'playrough'].some(moveid => movePool.includes(moveid))
+			),
+			Fighting: (movePool, hasMove, hasAbility, hasType, counter) => !counter.Fighting || !counter.stab,
+			Fire: (movePool, hasMove, hasAbility, hasType, counter) => (
+				!hasMove['bellydrum'] && (!counter.Fire || movePool.includes('flareblitz'))
+			),
+			Flying: (movePool, hasMove, hasAbility, hasType, counter) => (
+				!counter.Flying && [
+					'airslash', 'bravebird', 'dualwingbeat', 'oblivionwing',
+				].some(moveid => movePool.includes(moveid))
+			),
+			Ghost: (movePool, hasMove, hasAbility, hasType, counter) => {
+				if (!counter.Ghost) return true;
+				if (movePool.includes('poltergeist')) return true;
+				return movePool.includes('spectralthief') && !counter.Dark;
+			},
+			Grass: (movePool, hasMove, hasAbility, hasType, counter, species) => {
+				if (counter.Grass) return false;
+				if (species.baseStats.atk >= 100 || movePool.includes('leafstorm')) return true;
+				return movePool.includes('grassyglide');
+			},
+			Ground: (movePool, hasMove, hasAbility, hasType, counter) => !counter.Ground,
+			Ice: (movePool, hasMove, hasAbility, hasType, counter) => {
+				if (!counter.Ice) return true;
+				if (movePool.includes('iciclecrash')) return true;
+				return hasAbility['Snow Warning'] && movePool.includes('blizzard');
+			},
+			Normal: (movePool, hasMove, hasAbility, hasType, counter) => (
+				(hasAbility['Guts'] && movePool.includes('facade')) || (hasAbility['Pixilate'] && !counter.Normal)
+			),
+			Poison: (movePool, hasMove, hasAbility, hasType, counter) => {
+				if (counter.Poison) return false;
+				return hasType['Ground'] || hasType['Psychic'] || counter.setupType || movePool.includes('gunkshot');
+			},
+			Psychic: (movePool, hasMove, hasAbility, hasType, counter) => {
+				if (counter.Psychic) return false;
+				if (hasType['Ghost'] || hasType['Steel']) return false;
+				return hasAbility['Psychic Surge'] || counter.setupType || movePool.includes('psychicfangs');
+			},
+			Rock: (movePool, hasMove, hasAbility, hasType, counter, species) => !counter.Rock && species.baseStats.atk >= 80,
+			Steel: (movePool, hasMove, hasAbility, hasType, counter, species) => {
+				if (species.baseStats.atk < 95) return false;
+				return !counter.Steel || (hasMove['bulletpunch'] && counter.stab < 2);
+			},
+			Water: (movePool, hasMove, hasAbility, hasType, counter, species) => {
+				if (!counter.Water && !hasMove['hypervoice']) return true;
+				if (movePool.includes('hypervoice')) return true;
+				return hasAbility['Huge Power'] && movePool.includes('aquajet');
+			},
+		};
 	}
 
 	setSeed(prng?: PRNG | PRNGSeed) {
@@ -40,7 +183,9 @@ export class RandomTeams {
 	}
 
 	getTeam(options?: PlayerOptions | null): PokemonSet[] {
-		const generatorName = typeof this.format.team === 'string' && this.format.team.startsWith('random') ? this.format.team + 'Team' : '';
+		const generatorName = (typeof this.format.team === 'string' && this.format.team.startsWith('random') ?
+			this.format.team + 'Team' :
+			'');
 		// @ts-ignore
 		return this[generatorName || 'randomTeam'](options);
 	}
@@ -82,28 +227,12 @@ export class RandomTeams {
 		return this.fastPop(list, index);
 	}
 
-	// checkAbilities(selectedAbilities, defaultAbilities) {
-	// 	if (!selectedAbilities.length) return true;
-	// 	const selectedAbility = selectedAbilities.pop();
-	// 	const isValid = false;
-	// 	for (const i = 0; i < defaultAbilities.length; i++) {
-	// 		const defaultAbility = defaultAbilities[i];
-	// 		if (!defaultAbility) break;
-	// 		if (defaultAbility.includes(selectedAbility)) {
-	// 			defaultAbilities.splice(i, 1);
-	// 			isValid = this.checkAbilities(selectedAbilities, defaultAbilities);
-	// 			if (isValid) break;
-	// 			defaultAbilities.splice(i, 0, defaultAbility);
-	// 		}
-	// 	}
-	// 	if (!isValid) selectedAbilities.push(selectedAbility);
-	// 	return isValid;
-	// }
-	// hasMegaEvo(species) {
-	// 	if (!species.otherFormes) return false;
-	// 	const firstForme = this.dex.getSpecies(species.otherFormes[0]);
-	// 	return !!firstForme.isMega;
-	// }
+	isBeneficialInSingles(move: Move) {
+		return [
+			'facade', 'lightscreen', 'reflect', 'sleeptalk', 'spore', 'substitute', 'switcheroo', 'teleport', 'toxic', 'trick',
+		].includes(move.id) && (move.category !== 'Status' || !move.flags.heal);
+	}
+
 	randomCCTeam(): RandomTeamsTypes.RandomSet[] {
 		const dex = this.dex;
 		const team = [];
@@ -146,7 +275,11 @@ export class RandomTeams {
 				do {
 					item = this.sample(items);
 					itemData = this.dex.getItem(item);
-				} while (itemData.gen > this.gen || itemData.isNonstandard || itemData.forcedForme && forme === this.dex.getSpecies(itemData.forcedForme).baseSpecies);
+				} while (
+					itemData.gen > this.gen ||
+					itemData.isNonstandard ||
+					(itemData.forcedForme && forme === this.dex.getSpecies(itemData.forcedForme).baseSpecies)
+				);
 			}
 
 			// Random legal ability
@@ -162,7 +295,8 @@ export class RandomTeams {
 					return !(move.isNonstandard || move.isZ || move.isMax || move.realMove);
 				});
 			} else {
-				let learnset = this.dex.data.Learnsets[species.id] && this.dex.data.Learnsets[species.id].learnset && !['gastrodoneast', 'pumpkaboosuper', 'zygarde10'].includes(species.id) ?
+				const formes = ['gastrodoneast', 'pumpkaboosuper', 'zygarde10'];
+				let learnset = this.dex.data.Learnsets[species.id]?.learnset && !formes.includes(species.id) ?
 					this.dex.data.Learnsets[species.id].learnset :
 					this.dex.data.Learnsets[this.dex.getSpecies(species.baseSpecies).id].learnset;
 				if (learnset) {
@@ -181,7 +315,12 @@ export class RandomTeams {
 			if (pool.length <= 4) {
 				moves = pool;
 			} else {
-				moves = [this.sampleNoReplace(pool), this.sampleNoReplace(pool), this.sampleNoReplace(pool), this.sampleNoReplace(pool)];
+				moves = [
+					this.sampleNoReplace(pool),
+					this.sampleNoReplace(pool),
+					this.sampleNoReplace(pool),
+					this.sampleNoReplace(pool),
+				];
 			}
 
 			// Random EVs
@@ -196,7 +335,14 @@ export class RandomTeams {
 			} while (evpool > 0);
 
 			// Random IVs
-			const ivs = {hp: this.random(32), atk: this.random(32), def: this.random(32), spa: this.random(32), spd: this.random(32), spe: this.random(32)};
+			const ivs = {
+				hp: this.random(32),
+				atk: this.random(32),
+				def: this.random(32),
+				spa: this.random(32),
+				pd: this.random(32),
+				spe: this.random(32),
+			};
 
 			// Random nature
 			const nature = this.sample(natures);
@@ -220,7 +366,8 @@ export class RandomTeams {
 
 			while (level < 100) {
 				mbst = Math.floor((stats["hp"] * 2 + 31 + 21 + 100) * level / 100 + 10);
-				mbst += Math.floor(((stats["atk"] * 2 + 31 + 21 + 100) * level / 100 + 5) * level / 100); // Since damage is roughly proportional to level
+				// Since damage is roughly proportional to level
+				mbst += Math.floor(((stats["atk"] * 2 + 31 + 21 + 100) * level / 100 + 5) * level / 100);
 				mbst += Math.floor((stats["def"] * 2 + 31 + 21 + 100) * level / 100 + 5);
 				mbst += Math.floor(((stats["spa"] * 2 + 31 + 21 + 100) * level / 100 + 5) * level / 100);
 				mbst += Math.floor((stats["spd"] * 2 + 31 + 21 + 100) * level / 100 + 5);
@@ -263,7 +410,10 @@ export class RandomTeams {
 
 		const pool: number[] = [];
 		for (const id in this.dex.data.FormatsData) {
-			if (!this.dex.data.Pokedex[id] || this.dex.data.FormatsData[id].isNonstandard && this.dex.data.FormatsData[id].isNonstandard !== 'Unobtainable') continue;
+			if (
+				!this.dex.data.Pokedex[id] ||
+				(this.dex.data.FormatsData[id].isNonstandard && this.dex.data.FormatsData[id].isNonstandard !== 'Unobtainable')
+			) continue;
 			const num = this.dex.data.Pokedex[id].num;
 			if (num <= 0 || pool.includes(num)) continue;
 			if (num > last) break;
@@ -411,10 +561,16 @@ export class RandomTeams {
 		return team;
 	}
 
-	queryMoves(moves: string[] | null, hasType: {[k: string]: boolean} = {}, hasAbility: {[k: string]: boolean} = {}, movePool: string[] = []) {
+	queryMoves(
+		moves: string[] | null,
+		hasType: {[k: string]: boolean} = {},
+		hasAbility: {[k: string]: boolean} = {},
+		movePool: string[] = []
+	) {
 		// This is primarily a helper function for random setbuilder functions.
 		const counter: {[k: string]: any} = {
-			Physical: 0, Special: 0, Status: 0, damage: 0, recovery: 0, stab: 0, inaccurate: 0, priority: 0, recoil: 0, drain: 0, sound: 0,
+			Physical: 0, Special: 0, Status: 0, damage: 0, recovery: 0, stab: 0,
+			inaccurate: 0, priority: 0, recoil: 0, drain: 0, sound: 0,
 			contrary: 0, ironfist: 0, serenegrace: 0, sheerforce: 0, skilllink: 0, strongjaw: 0, technician: 0,
 			physicalsetup: 0, specialsetup: 0, mixedsetup: 0, speedsetup: 0, physicalpool: 0, specialpool: 0, hazards: 0,
 			damagingMoves: [],
@@ -423,44 +579,11 @@ export class RandomTeams {
 			Ice: 0, Normal: 0, Poison: 0, Psychic: 0, Rock: 0, Steel: 0, Water: 0,
 		};
 
-		let typeDef: string;
-		for (typeDef in this.dex.data.TypeChart) {
+		for (const typeDef in this.dex.data.TypeChart) {
 			counter[typeDef] = 0;
 		}
 
-		if (!moves || !moves.length) return counter;
-
-		// Moves that restore HP:
-		const RecoveryMove = [
-			'healorder', 'milkdrink', 'moonlight', 'morningsun', 'recover', 'roost', 'shoreup', 'slackoff', 'softboiled', 'strengthsap', 'synthesis',
-		];
-		// Moves which drop stats:
-		const ContraryMove = [
-			'closecombat', 'leafstorm', 'overheat', 'superpower', 'vcreate',
-		];
-		// Moves that boost Attack:
-		const PhysicalSetup = [
-			'bellydrum', 'bulkup', 'coil', 'curse', 'dragondance', 'honeclaws', 'howl', 'poweruppunch', 'swordsdance',
-		];
-		// Moves which boost Special Attack:
-		const SpecialSetup = [
-			'calmmind', 'chargebeam', 'geomancy', 'nastyplot', 'quiverdance', 'tailglow',
-		];
-		// Moves which boost Attack AND Special Attack:
-		const MixedSetup = [
-			'clangoroussoul', 'growth', 'happyhour', 'holdhands', 'noretreat', 'shellsmash', 'workup',
-		];
-		// Moves which boost Speed:
-		const SpeedSetup = [
-			'agility', 'autotomize', 'flamecharge', 'rockpolish', 'shiftgear',
-		];
-		// Moves that shouldn't be the only STAB moves:
-		const NoStab = [
-			'accelerock', 'aquajet', 'beakblast', 'bounce', 'breakingswipe', 'explosion', 'fakeout', 'firstimpression', 'flamecharge',
-			'flipturn', 'iceshard', 'machpunch', 'pluck', 'pursuit', 'quickattack', 'selfdestruct', 'skydrop', 'suckerpunch', 'watershuriken',
-
-			'chatter', 'clearsmog', 'eruption', 'icywind', 'incinerate', 'meteorbeam', 'snarl', 'vacuumwave', 'voltswitch', 'waterspout',
-		];
+		if (!moves?.length) return counter;
 
 		// Iterate through all moves we've chosen so far and keep track of what they do:
 		for (const moveId of moves) {
@@ -469,88 +592,91 @@ export class RandomTeams {
 				if (this.gen === 5) move = this.dex.getMove('earthquake');
 			}
 			const moveid = move.id;
-			let movetype = move.type;
-			if (['judgment', 'multiattack', 'revelationdance'].includes(moveid)) movetype = Object.keys(hasType)[0];
+			let moveType = move.type;
+			if (['judgment', 'multiattack', 'revelationdance'].includes(moveid)) moveType = Object.keys(hasType)[0];
 			if (move.damage || move.damageCallback) {
 				// Moves that do a set amount of damage:
-				counter['damage']++;
+				counter.damage++;
 				counter.damagingMoves.push(move);
 			} else {
 				// Are Physical/Special/Status moves:
 				counter[move.category]++;
 			}
 			// Moves that have a low base power:
-			if (moveid === 'lowkick' || (move.basePower && move.basePower <= 60 && moveid !== 'rapidspin')) counter['technician']++;
+			if (moveid === 'lowkick' || (move.basePower && move.basePower <= 60 && moveid !== 'rapidspin')) counter.technician++;
 			// Moves that hit up to 5 times:
-			if (move.multihit && Array.isArray(move.multihit) && move.multihit[1] === 5) counter['skilllink']++;
-			if (move.recoil || move.hasCrashDamage) counter['recoil']++;
-			if (move.drain) counter['drain']++;
+			if (move.multihit && Array.isArray(move.multihit) && move.multihit[1] === 5) counter.skilllink++;
+			if (move.recoil || move.hasCrashDamage) counter.recoil++;
+			if (move.drain) counter.drain++;
 			// Moves which have a base power, but aren't super-weak like Rapid Spin:
 			if (move.basePower > 30 || move.multihit || move.basePowerCallback || moveid === 'infestation') {
-				counter[movetype]++;
-				if (hasType[movetype]) {
+				counter[moveType]++;
+				if (hasType[moveType]) {
 					// STAB:
 					// Certain moves aren't acceptable as a Pokemon's only STAB attack
 					if (!NoStab.includes(moveid) && (moveid !== 'hiddenpower' || Object.keys(hasType).length === 1)) {
-						counter['stab']++;
+						counter.stab++;
 						// Ties between Physical and Special setup should broken in favor of STABs
 						counter[move.category] += 0.1;
 					}
-				} else if (movetype === 'Normal' && (hasAbility['Aerilate'] || hasAbility['Galvanize'] || hasAbility['Pixilate'] || hasAbility['Refrigerate'])) {
-					counter['stab']++;
-				} else if (move.priority === 0 && (hasAbility['Libero'] || hasAbility['Protean']) && !NoStab.includes(moveid)) {
-					counter['stab']++;
-				} else if (movetype === 'Steel' && hasAbility['Steelworker']) {
-					counter['stab']++;
+				} else if (
+					// Less obvious forms of STAB
+					(moveType === 'Normal' && (['Aerilate', 'Galvanize', 'Pixilate', 'Refrigerate'].some(abil => hasAbility[abil]))) ||
+					(move.priority === 0 && (hasAbility['Libero'] || hasAbility['Protean']) && !NoStab.includes(moveid)) ||
+					(moveType === 'Steel' && hasAbility['Steelworker'])
+				) {
+					counter.stab++;
 				}
-				if (move.flags['bite']) counter['strongjaw']++;
-				if (move.flags['punch']) counter['ironfist']++;
-				if (move.flags['sound']) counter['sound']++;
+
+				if (move.flags['bite']) counter.strongjaw++;
+				if (move.flags['punch']) counter.ironfist++;
+				if (move.flags['sound']) counter.sound++;
 				if (move.priority !== 0 || (moveid === 'grassyglide' && hasAbility['Grassy Surge'])) {
-					counter['priority']++;
+					counter.priority++;
 				}
 				counter.damagingMoves.push(move);
 			}
 			// Moves with secondary effects:
 			if (move.secondary) {
-				counter['sheerforce']++;
+				counter.sheerforce++;
 				if (move.secondary.chance && move.secondary.chance >= 20 && move.secondary.chance < 100) {
-					counter['serenegrace']++;
+					counter.serenegrace++;
 				}
 			}
 			// Moves with low accuracy:
-			if (move.accuracy && move.accuracy !== true && move.accuracy < 90) counter['inaccurate']++;
+			if (move.accuracy && move.accuracy !== true && move.accuracy < 90) counter.inaccurate++;
 
 			// Moves that change stats:
-			if (RecoveryMove.includes(moveid)) counter['recovery']++;
-			if (ContraryMove.includes(moveid)) counter['contrary']++;
+			if (RecoveryMove.includes(moveid)) counter.recovery++;
+			if (StatDroppingMoves.includes(moveid)) counter.contrary++;
 			if (PhysicalSetup.includes(moveid)) {
-				counter['physicalsetup']++;
+				counter.physicalsetup++;
 				counter.setupType = 'Physical';
 			} else if (SpecialSetup.includes(moveid)) {
-				counter['specialsetup']++;
+				counter.specialsetup++;
 				counter.setupType = 'Special';
 			}
-			if (MixedSetup.includes(moveid)) counter['mixedsetup']++;
-			if (SpeedSetup.includes(moveid)) counter['speedsetup']++;
-			if (['spikes', 'stealthrock', 'stickyweb', 'toxicspikes'].includes(moveid)) counter['hazards']++;
+
+			if (MixedSetup.includes(moveid)) counter.mixedsetup++;
+			if (SpeedSetup.includes(moveid)) counter.speedsetup++;
+			if (Hazards.includes(moveid)) counter.hazards++;
 		}
 
 		// Keep track of the available moves
 		for (const moveid of movePool) {
 			const move = this.dex.getMove(moveid);
 			if (move.damageCallback) continue;
-			if (move.category === 'Physical') counter['physicalpool']++;
-			if (move.category === 'Special') counter['specialpool']++;
+			if (move.category === 'Physical') counter.physicalpool++;
+			if (move.category === 'Special') counter.specialpool++;
 		}
 
 		// Choose a setup type:
-		if (counter['mixedsetup']) {
+		if (counter.mixedsetup) {
 			counter.setupType = 'Mixed';
-		} else if (counter['physicalsetup'] && counter['specialsetup']) {
+		} else if (counter.physicalsetup && counter.specialsetup) {
 			const pool = {
-				Physical: counter.Physical + counter['physicalpool'],
-				Special: counter.Special + counter['specialpool'],
+				Physical: counter.Physical + counter.physicalpool,
+				Special: counter.Special + counter.specialpool,
 			};
 			if (pool.Physical === pool.Special) {
 				if (counter.Physical > counter.Special) counter.setupType = 'Physical';
@@ -559,22 +685,740 @@ export class RandomTeams {
 				counter.setupType = pool.Physical > pool.Special ? 'Physical' : 'Special';
 			}
 		} else if (counter.setupType === 'Physical') {
-			if ((counter.Physical < 2 && (!counter.stab || !counter['physicalpool'])) && (!moves.includes('rest') || !moves.includes('sleeptalk'))) {
+			if (
+				(counter.Physical < 2 && (!counter.stab || !counter.physicalpool)) &&
+				!(moves.includes('rest') && moves.includes('sleeptalk'))
+			) {
 				counter.setupType = '';
 			}
 		} else if (counter.setupType === 'Special') {
-			if ((counter.Special < 2 && (!counter.stab || !counter['specialpool'])) && (!moves.includes('rest') || !moves.includes('sleeptalk')) && (!moves.includes('wish') || !moves.includes('protect'))) {
+			if (
+				(counter.Special < 2 && (!counter.stab || !counter.specialpool)) &&
+				!(moves.includes('rest') && moves.includes('sleeptalk')) &&
+				!(moves.includes('wish') && moves.includes('protect'))
+			) {
 				counter.setupType = '';
 			}
 		}
 
-		counter['Physical'] = Math.floor(counter['Physical']);
-		counter['Special'] = Math.floor(counter['Special']);
+		counter.Physical = Math.floor(counter.Physical);
+		counter.Special = Math.floor(counter.Special);
 
 		return counter;
 	}
 
-	randomSet(species: string | Species, teamDetails: RandomTeamsTypes.TeamDetails = {}, isLead = false, isDoubles = false): RandomTeamsTypes.RandomSet {
+	shouldCullMove(
+		move: Move,
+		hasType: {[k: string]: true},
+		hasMove: {[k: string]: true},
+		hasAbility: {[k: string]: true},
+		counter: {[k: string]: any},
+		movePool: string[],
+		teamDetails: RandomTeamsTypes.TeamDetails,
+		species: Species,
+		isLead: boolean,
+		isDoubles: boolean
+	): {cull: boolean, isSetup?: boolean} {
+		const hasRestTalk = hasMove['rest'] && hasMove['sleeptalk'];
+
+		// Reject moves that need support
+		switch (move.id) {
+		case 'acrobatics': case 'junglehealing':
+			return {cull: !isDoubles && !counter.setupType};
+		case 'destinybond': case 'healbell':
+			return {cull: movePool.includes('protect') || movePool.includes('wish')};
+		case 'dualwingbeat': case 'fly': case 'storedpower':
+			return {cull: !hasType[move.type] && !counter.setupType && counter.Status};
+		case 'fireblast':
+			return {cull: hasAbility['Serene Grace'] && (!hasMove['trick'] || counter.Status > 1)};
+		case 'firepunch':
+			return {cull: movePool.includes('bellydrum') || (hasMove['earthquake'] && movePool.includes('substitute'))};
+		case 'flamecharge': case 'sacredsword':
+			const fewDamagingMoves = counter.damagingMoves.length < 3 && !counter.setupType;
+			const swordsDance = !hasType['Grass'] && movePool.includes('swordsdance');
+			return {cull: fewDamagingMoves || swordsDance};
+		case 'hypervoice':
+			return {cull: hasType['Electric'] && movePool.includes('thunderbolt')};
+		case 'payback': case 'psychocut':
+			return {cull: !counter.Status || hasRestTalk};
+		case 'rest':
+			const bulkySetup = !hasMove['sleeptalk'] && ['bulkup', 'calmmind', 'coil', 'curse'].some(m => movePool.includes(m));
+			return {cull: movePool.includes('sleeptalk') || bulkySetup};
+		case 'sleeptalk':
+			if (!hasMove['rest']) return {cull: true};
+			if (movePool.length > 1 && !hasAbility['Contrary']) {
+				const rest = movePool.indexOf('rest');
+				if (rest >= 0) this.fastPop(movePool, rest);
+			}
+			break;
+		case 'switcheroo': case 'trick':
+			return {cull: counter.Physical + counter.Special < 3 || hasMove['rapidspin']};
+		case 'trickroom':
+			const webs = !!teamDetails.stickyWeb;
+			return {cull: isLead || webs || counter.damagingMoves.length < 2 || movePool.includes('nastyplot')};
+		case 'zenheadbutt':
+			// Special case for Victini, which should prefer Bolt Strike to Zen Headbutt
+			return {cull: movePool.includes('boltstrike')};
+
+		// Set up once and only if we have the moves for it
+		case 'bellydrum': case 'bulkup': case 'coil': case 'curse': case 'dragondance': case 'honeclaws': case 'swordsdance':
+			if (counter.setupType !== 'Physical') return {cull: true}; // if we're not setting up physically this is pointless
+			if (counter.Physical + counter.physicalpool < 2 && hasRestTalk) return {cull: true};
+			if (move.id === 'swordsdance' && hasMove['dragondance']) return {cull: true}; // Dragon Dance is judged as better
+
+			return {cull: false, isSetup: true};
+		case 'calmmind': case 'nastyplot':
+			if (counter.setupType !== 'Special') return {cull: true};
+			if (
+				(counter.Special + counter.specialpool) < 2 &&
+				!hasRestTalk &&
+				!(hasMove['wish'] && hasMove['protect'])
+			) return {cull: true};
+			if (hasMove['healpulse'] || move.id === 'calmmind' && hasMove['trickroom']) return {cull: true};
+			return {cull: false, isSetup: true};
+		case 'quiverdance':
+			return {cull: false, isSetup: true};
+		case 'clangoroussoul': case 'shellsmash': case 'workup':
+			if (counter.setupType !== 'Mixed') return {cull: true};
+			if (counter.damagingMoves.length + counter.physicalpool + counter.specialpool < 2) return {cull: true};
+			return {cull: false, isSetup: true};
+		case 'agility': case 'autotomize': case 'rockpolish': case 'shiftgear':
+			if (counter.damagingMoves.length < 2 || hasMove['rest']) return {cull: true};
+			if (movePool.includes('calmmind') || movePool.includes('nastyplot')) return {cull: true};
+			return {cull: false, isSetup: !counter.setupType};
+
+		// Bad after setup
+		case 'counter': case 'reversal':
+			return {cull: !!counter.setupType};
+		case 'firstimpression': case 'glare': case 'icywind': case 'tailwind': case 'waterspout':
+			return {cull: (counter.setupType && !isDoubles) || counter.speedsetup || hasMove['rest']};
+		case 'bulletpunch': case 'extremespeed': case 'rockblast':
+			return {cull: counter.speedsetup || counter.damagingMoves.length < 2};
+		case 'closecombat': case 'flashcannon': case 'pollenpuff':
+			const substituteCullCondition = (
+				(hasMove['substitute'] && !hasType['Fighting']) ||
+				(hasMove['toxic'] && movePool.includes('substitute'))
+			);
+			const preferHJKOverCCCullCondition = (
+				move.id === 'closecombat' &&
+				!counter.setupType &&
+				(hasMove['highjumpkick'] || movePool.includes('highjumpkick'))
+			);
+			return {cull: substituteCullCondition || preferHJKOverCCCullCondition};
+		case 'defog':
+			return {cull: counter.setupType || hasMove['healbell'] || hasMove['toxicspikes'] || teamDetails.defog};
+		case 'fakeout':
+			return {cull: counter.setupType || ['protect', 'rapidspin', 'substitute', 'uturn'].some(m => hasMove[m])};
+		case 'healingwish': case 'memento':
+			return {cull: counter.setupType || counter.recovery || hasMove['substitute'] || hasMove['uturn']};
+		case 'highjumpkick': case 'machpunch':
+			return {cull: hasMove['curse']};
+		case 'partingshot':
+			return {cull: counter.speedsetup || hasMove['bulkup'] || hasMove['uturn']};
+		case 'protect':
+			if ((counter.setupType && !hasMove['wish'] && !isDoubles) || hasRestTalk) return {cull: true};
+			if (!isDoubles && counter.Status < 2 && !hasAbility['Hunger Switch'] && !hasAbility['Speed Boost']) return {cull: true};
+			if (movePool.includes('leechseed') || (movePool.includes('toxic') && !hasMove['wish'])) return {cull: true};
+			if (isDoubles && (
+				['fakeout', 'shellsmash', 'spore'].some(m => movePool.includes('m')) ||
+				hasMove['tailwind'] || hasMove['waterspout']
+			)) return {cull: true};
+			return {cull: false};
+		case 'rapidspin':
+			const setup = ['curse', 'nastyplot', 'shellsmash'].some(m => hasMove[m]);
+			return {cull: teamDetails.rapidSpin || setup || (counter.setupType && counter.Fighting >= 2)};
+		case 'shadowsneak':
+			return {cull: hasRestTalk || ['substitute', 'trickroom', 'dualwingbeat', 'toxic'].some(m => hasMove[m])};
+		case 'spikes':
+			return {cull: counter.setupType || (teamDetails.spikes && teamDetails.spikes > 1)};
+		case 'stealthrock':
+			return {cull:
+				counter.setupType ||
+				counter.speedsetup ||
+				teamDetails.stealthRock ||
+				['rest', 'substitute', 'trickroom'].some(m => hasMove[m]),
+			};
+		case 'stickyweb':
+			return {cull: counter.setupType === 'Special' || !!teamDetails.stickyWeb};
+		case 'taunt':
+			return {cull: hasMove['nastyplot'] || hasMove['swordsdance']};
+		case 'thunderwave': case 'voltswitch':
+			const cullInDoubles = hasMove['electroweb'] || hasMove['nuzzle'];
+			return {cull: counter.setupType || counter.speedsetup || hasMove['raindance'] || (isDoubles && cullInDoubles)};
+		case 'toxic':
+			return {cull: counter.setupType || ['sludgewave', 'thunderwave', 'willowisp'].some(m => hasMove[m])};
+		case 'toxicspikes':
+			return {cull: counter.setupType || teamDetails.toxicSpikes};
+		case 'uturn':
+			const bugAndRecovery = hasType['Bug'] && counter.recovery;
+			return {cull: counter.speedsetup || (counter.setupType && !bugAndRecovery) || (isDoubles && hasMove['leechlife'])};
+
+		// Ineffective to have two particular moves together
+		case 'explosion':
+			// Special case for Gigalith
+			// [15:33] A Cake Wearing A Hat: meant to prevent rock blast as only stab on choice band
+			const otherMoves = ['curse', 'drainpunch', 'rockblast', 'painsplit', 'wish'].some(m => hasMove[m]);
+			return {cull: counter.speedsetup || counter.recovery || otherMoves};
+		case 'facade':
+			return {cull: counter.recovery || movePool.includes('doubleedge')};
+		case 'quickattack':
+			const uturnCullCondition = counter.Physical > 3 && movePool.includes('uturn');
+			return {cull: counter.speedsetup || (hasType['Rock'] && counter.Status) || uturnCullCondition};
+		case 'blazekick':
+			return {cull: counter.Special >= 1};
+		case 'firefang': case 'flamethrower':
+			const otherFireMoves = ['heatwave', 'overheat'].some(m => hasMove[m]);
+			return {cull: (hasMove['fireblast'] && counter.setupType !== 'Physical') || otherFireMoves};
+		case 'overheat':
+			return {cull: hasMove['flareblitz'] || (isDoubles && hasMove['calmmind'])};
+		case 'aquajet': case 'psychicfangs':
+			return {cull: hasMove['rapidspin'] || hasMove['taunt']};
+		case 'aquatail': case 'flipturn': case 'retaliate':
+			return {cull: hasMove['aquajet'] || counter.Status};
+		case 'hydropump':
+			return {cull: hasMove['scald'] && (
+				(counter.Special < 4 && !hasMove['uturn']) ||
+				(species.types.length > 1 && counter.stab < 3)
+			)};
+		case 'scald':
+			return {cull: hasMove['waterpulse']};
+		case 'thunderbolt':
+			return {cull: hasMove['powerwhip']};
+		case 'gigadrain':
+			return {cull: (!counter.setupType && hasMove['uturn']) || (hasType['Poison'] && !counter.Poison)};
+		case 'leafblade':
+			return {cull: (hasMove['leafstorm'] || movePool.includes('leafstorm')) && counter.setupType !== 'Physical'};
+		case 'leafstorm':
+			return {cull: (hasMove['gigadrain'] && counter.Status) || (isDoubles && hasMove['energyball'])};
+		case 'powerwhip':
+			return {cull: hasMove['leechlife'] || (!hasType['Grass'] && counter.Physical > 3 && movePool.includes('uturn'))};
+		case 'woodhammer':
+			return {cull: hasMove['hornleech'] && counter.Physical < 4};
+		case 'freezedry':
+			const betterIceMove = (hasMove['blizzard'] && counter.setupType) || (hasMove['icebeam'] && counter.Special < 4);
+			const preferThunderWave = movePool.includes('thunderwave') && hasType['Electric'];
+			return {cull: betterIceMove || preferThunderWave || movePool.includes('bodyslam')};
+		case 'bodypress':
+			const eqShellSmashPossible = hasMove['earthquake'] && movePool.includes('shellsmash');
+			return {cull: eqShellSmashPossible || ['shellsmash', 'mirrorcoat', 'whirlwind'].some(m => hasMove[m])};
+		case 'circlethrow':
+			return {cull: hasMove['stormthrow'] && !hasMove['rest']};
+		case 'drainpunch':
+			return {cull: hasMove['closecombat'] || (!hasType['Fighting'] && movePool.includes('swordsdance'))};
+		case 'dynamicpunch': case 'thunderouskick':
+			return {cull: hasMove['closecombat'] || hasMove['facade']};
+		case 'focusblast':
+			return {cull: movePool.includes('shellsmash') || hasRestTalk};
+		case 'hammerarm':
+			return {cull: hasMove['fakeout']};
+		case 'stormthrow':
+			return {cull: hasRestTalk};
+		case 'superpower':
+			return {
+				cull: hasMove['hydropump'] ||
+					(counter.Physical >= 4 && movePool.includes('uturn')) ||
+					(hasMove['substitute'] && !hasAbility['Contrary']),
+				isSetup: hasAbility['Contrary'],
+			};
+		case 'poisonjab':
+			return {cull: !hasType['Poison'] && counter.Status >= 2};
+		case 'earthquake':
+			const doublesCull = hasMove['earthpower'] || hasMove['highhorsepower'];
+			const movePoolCull = movePool.includes('bodypress') && movePool.includes('shellsmash');
+			const subToxicPossible = hasMove['substitute'] && movePool.includes('toxic');
+			return {cull: movePoolCull || (isDoubles && doublesCull) || subToxicPossible || hasMove['bonemerang']};
+		case 'scorchingsands':
+			return {cull: hasMove['willowisp'] || hasMove['earthpower'] || (hasMove['toxic'] && movePool.includes('earthpower'))};
+		case 'airslash':
+			return {
+				cull: movePool.includes('flamethrower') ||
+					(hasMove['hurricane'] && !counter.setupType) ||
+					hasRestTalk ||
+					(hasAbility['Simple'] && !!counter.recovery),
+			};
+		case 'bravebird':
+			return {cull: hasMove['dragondance']};
+		case 'hurricane':
+			return {cull: hasAbility['Tinted Lens'] && counter.setupType && !isDoubles};
+		case 'futuresight':
+			return {cull: hasMove['psyshock'] || hasMove['trick'] || movePool.includes('teleport')};
+		case 'photongeyser':
+			return {cull: hasMove['morningsun']};
+		case 'psychic':
+			return {cull: hasMove['psyshock'] && (counter.setupType || isDoubles)};
+		case 'psyshock':
+			const cullNoSetup = (hasAbility['Multiscale'] && !counter.setupType) || (hasAbility['Pixilate'] && counter.Special < 4);
+			return {cull: hasMove['psychic'] || (!counter.setupType && cullNoSetup) || (isDoubles && hasMove['psychic'])};
+		case 'bugbuzz':
+			return {cull: hasMove['uturn'] && !counter.setupType};
+		case 'leechlife':
+			return {cull: (isDoubles && hasMove['lunge']) || movePool.includes('firstimpression') || movePool.includes('spikes')};
+			break;
+		case 'stoneedge':
+			const gutsCullCondition = hasAbility['Guts'] && (!hasMove['dynamicpunch'] || hasMove['spikes']);
+			const rockSlidePlusStatusPossible = counter.Status && movePool.includes('rockslide');
+			return {cull: gutsCullCondition || rockSlidePlusStatusPossible || hasMove['rockblast'] || hasMove['rockslide']};
+		case 'poltergeist':
+			return {cull: hasMove['knockoff']};
+		case 'shadowball':
+			const cull = (
+				(isDoubles && hasMove['phantomforce']) ||
+				(hasAbility['Pixilate'] && (counter.setupType || counter.Status > 1)) ||
+				(!hasType['Ghost'] && movePool.includes('focusblast'))
+			);
+			return {cull};
+		case 'shadowclaw':
+			return {cull: hasType['Steel'] && hasMove['shadowsneak'] && counter.Physical < 4};
+		case 'dragonpulse': case 'spacialrend':
+			return {cull: hasMove['dracometeor'] && counter.Special < 4};
+		case 'darkpulse':
+			const defogger = hasMove['defog'] && counter.setupType !== 'Special';
+			return {cull: ['foulplay', 'knockoff', 'suckerpunch'].some(m => hasMove[m]) || defogger};
+		case 'suckerpunch':
+			return {cull: hasMove['rest'] || counter.damagingMoves.length < 2 || (counter.Dark > 1 && !hasType['Dark'])};
+		case 'meteormash':
+			return {cull: movePool.includes('extremespeed')};
+		case 'dazzlinggleam':
+			return {cull: ['fleurcannon', 'moonblast', 'petaldance'].some(m => hasMove[m])};
+
+		// Status:
+		case 'bodyslam': case 'clearsmog':
+			const toxicCullCondition = hasMove['toxic'] && !hasType['Normal'];
+			return {cull: hasMove['sludgebomb'] || hasMove['trick'] || movePool.includes('recover') || toxicCullCondition};
+		case 'haze':
+			return {cull: !teamDetails.stealthRock && (hasMove['stealthrock'] || movePool.includes('stealthrock'))};
+		case 'hypnosis':
+			return {cull: hasMove['voltswitch']};
+		case 'willowisp': case 'yawn':
+			return {cull: hasMove['thunderwave'] || hasMove['toxic']};
+		case 'painsplit': case 'recover': case 'synthesis':
+			return {cull: hasMove['rest'] || hasMove['wish'] || (move.id === 'synthesis' && hasMove['gigadrain'])};
+		case 'roost':
+			return {cull: hasMove['throatchop'] || (hasMove['stoneedge'] && !hasType['Rock'])};
+		case 'reflect': case 'lightscreen':
+			return {cull: !!teamDetails.screens};
+		case 'substitute':
+			const moveBasedCull = ['bulkup', 'painsplit', 'roost'].some(m => movePool.includes(m));
+			const doublesPowerWhip = isDoubles && movePool.includes('powerwhip');
+			const calmMindCullCondition = !counter.recovery && movePool.includes('calmmind');
+			return {cull: hasMove['rest'] || moveBasedCull || doublesPowerWhip || calmMindCullCondition};
+		case 'helpinghand':
+			return {cull: hasMove['acupressure']};
+		case 'wideguard':
+			return {cull: hasMove['protect']};
+		}
+
+		if (move.id !== 'photongeyser' && (
+			(move.category === 'Physical' && counter.setupType === 'Special') ||
+			(move.category === 'Special' && counter.setupType === 'Physical')
+		)) {
+			// Reject STABs last in case the setup type changes later on
+			const stabs = counter[species.types[0]] + (counter[species.types[1]] || 0);
+			if (!hasType[move.type] || stabs > 1 || counter[move.category] < 2) return {cull: true};
+		}
+
+		return {cull: false};
+	}
+
+	shouldCullAbility(
+		ability: string,
+		hasType: {[k: string]: true},
+		hasMove: {[k: string]: true},
+		hasAbility: {[k: string]: true},
+		counter: {[k: string]: any},
+		movePool: string[],
+		teamDetails: RandomTeamsTypes.TeamDetails,
+		species: Species,
+		isDoubles: boolean
+	): boolean {
+		if ([
+			'Cloud Nine', 'Flare Boost', 'Hydration', 'Ice Body', 'Innards Out', 'Insomnia', 'Misty Surge',
+			'Quick Feet', 'Rain Dish', 'Snow Cloak', 'Steadfast', 'Steam Engine', 'Weak Armor',
+		].includes(ability)) return true;
+
+		switch (ability) {
+		// Abilities which are primarily useful for certain moves
+		case 'Contrary': case 'Serene Grace': case 'Skill Link': case 'Strong Jaw':
+			return !counter[toID(ability)];
+		case 'Adaptability':
+			return !!counter.speedsetup;
+		case 'Analytic':
+			return (hasMove['rapidspin'] || species.nfe || isDoubles);
+		case 'Blaze':
+			return (isDoubles && hasAbility['Solar Power']);
+		case 'Bulletproof' || ability === 'Overcoat':
+			return (counter.setupType && hasAbility['Soundproof']);
+		case 'Chlorophyll':
+			return (species.baseStats.spe > 100 || !counter.Fire && !hasMove['sunnyday'] && !teamDetails.sun);
+		case 'Competitive':
+			return (counter.Special < 2 || (hasMove['rest'] && hasMove['sleeptalk']));
+		case 'Compound Eyes' || ability === 'No Guard':
+			return !counter.inaccurate;
+		case 'Cursed Body':
+			return hasAbility['Infiltrator'];
+		case 'Defiant':
+			return !counter.Physical;
+		case 'Download':
+			return (counter.damagingMoves.length < 3 || hasMove['trick']);
+		case 'Early Bird':
+			return (hasType['Grass'] && isDoubles);
+		case 'Flash Fire':
+			return (this.dex.getEffectiveness('Fire', species) < -1 || hasAbility['Drought']);
+		case 'Gluttony':
+			return !hasMove['bellydrum'];
+		case 'Guts':
+			return (!hasMove['facade'] && !hasMove['sleeptalk'] && !species.nfe);
+		case 'Harvest':
+			return (hasAbility['Frisk'] && !isDoubles);
+		case 'Hustle': case 'Inner Focus':
+			return (counter.Physical < 2 || hasAbility['Iron Fist']);
+		case 'Infiltrator':
+			return (hasMove['rest'] && hasMove['sleeptalk']) || (isDoubles && hasAbility['Clear Body']);
+		case 'Intimidate':
+			return ['bodyslam', 'bounce', 'tripleaxel'].some(m => hasMove[m]);
+		case 'Iron Fist':
+			return (counter.ironfist < 2 || hasMove['dynamicpunch']);
+		case 'Justified':
+			return (isDoubles && hasAbility['Inner Focus']);
+		case 'Lightning Rod':
+			return (species.types.includes('Ground') || counter.setupType === 'Physical');
+		case 'Limber':
+			return species.types.includes('Electric');
+		case 'Liquid Voice':
+			return !hasMove['hypervoice'];
+		case 'Magic Guard':
+			return (hasAbility['Tinted Lens'] && !counter.Status && !isDoubles);
+		case 'Mold Breaker':
+			return (
+				hasAbility['Adaptability'] || hasAbility['Scrappy'] || (hasAbility['Unburden'] && counter.setupType) ||
+				(hasAbility['Sheer Force'] && counter.sheerforce)
+			);
+		case 'Moxie':
+			return (counter.Physical < 2 || hasMove['stealthrock']);
+		case 'Neutralizing Gas':
+			return !hasMove['toxicspikes'];
+		case 'Overgrow':
+			return !counter.Grass;
+		case 'Own Tempo':
+			return !hasMove['petaldance'];
+		case 'Power Construct':
+			return (species.forme === '10%' && !isDoubles);
+		case 'Prankster':
+			return !counter.Status;
+		case 'Pressure':
+			return (counter.setupType || counter.Status < 2 || isDoubles);
+		case 'Refrigerate':
+			return !counter.Normal;
+		case 'Regenerator':
+			return hasAbility['Magic Guard'];
+		case 'Reckless' || ability === 'Rock Head':
+			return !counter.recoil;
+		case 'Sand Force' || ability === 'Sand Veil':
+			return !teamDetails.sand;
+		case 'Sand Rush':
+			return (!teamDetails.sand && (!counter.setupType || !counter.Rock || hasMove['rapidspin']));
+		case 'Sap Sipper':
+			return hasMove['roost'];
+		case 'Scrappy':
+			return (hasMove['earthquake'] && hasMove['milkdrink']);
+		case 'Screen Cleaner':
+			return !!teamDetails.screens;
+		case 'Shadow Tag':
+			return (species.name === 'Gothitelle' && !isDoubles);
+		case 'Shed Skin':
+			return hasMove['dragondance'];
+		case 'Sheer Force':
+			return (!counter.sheerforce || hasAbility['Guts']);
+		case 'Slush Rush':
+			return (!teamDetails.hail && !hasAbility['Swift Swim']);
+		case 'Sniper':
+			return (counter.Water > 1 && !hasMove['focusenergy']);
+		case 'Steely Spirit':
+			return (hasMove['fakeout'] && !isDoubles);
+		case 'Sturdy':
+			return (hasMove['bulkup'] || counter.recoil || hasAbility['Solid Rock']);
+		case 'Swarm':
+			return (!counter.Bug || counter.recovery);
+		case 'Sweet Veil':
+			return hasType['Grass'];
+		case 'Swift Swim':
+			return (!hasMove['raindance'] && (
+				['Intimidate', 'Rock Head', 'Slush Rush', 'Water Absorb'].some(abil => hasAbility[abil]) ||
+				(hasAbility['Lightning Rod'] && !counter.setupType)
+			));
+		case 'Synchronize':
+			return counter.Status < 3;
+		case 'Technician':
+			return (
+				!counter.technician ||
+				hasMove['tailslap'] ||
+				hasAbility['Punk Rock'] ||
+				movePool.includes('snarl')
+			);
+		case 'Tinted Lens':
+			return (hasMove['defog'] || hasMove['hurricane'] || counter.Status > 2 && !counter.setupType);
+		case 'Torrent':
+			return (hasMove['focusenergy'] || hasMove['hypervoice']);
+		case 'Tough Claws':
+			return (hasType['Steel'] && !hasMove['fakeout']);
+		case 'Unaware':
+			return (counter.setupType || hasMove['fireblast']);
+		case 'Unburden':
+			return (hasAbility['Prankster'] || !counter.setupType && !isDoubles);
+		case 'Volt Absorb':
+			return (this.dex.getEffectiveness('Electric', species) < -1);
+		case 'Water Absorb':
+			return (
+				hasMove['raindance'] ||
+				['Drizzle', 'Strong Jaw', 'Unaware', 'Volt Absorb'].some(abil => hasAbility[abil])
+			);
+		}
+
+		return false;
+	}
+
+	getHighPriorityItem(
+		ability: string,
+		hasType: {[k: string]: true},
+		hasMove: {[k: string]: true},
+		counter: {[k: string]: any},
+		teamDetails: RandomTeamsTypes.TeamDetails,
+		species: Species,
+		isDoubles: boolean
+	) {
+		// Species-specific logic
+		if (
+			['Corsola', 'Garchomp', 'Tangrowth'].includes(species.name) &&
+			counter.Status &&
+			!counter.setupType &&
+			!isDoubles
+		) return 'Rocky Helmet';
+		if (species.name === 'Eternatus' && counter.Status < 2) return 'Metronome';
+		if (species.name === 'Farfetch\u2019d') return 'Leek';
+		if (species.name === 'Froslass' && !isDoubles) return 'Wide Lens';
+		if (species.name === 'Latios' && counter.Special === 2 && !isDoubles) return 'Soul Dew';
+		if (species.name === 'Lopunny') return isDoubles ? 'Iron Ball' : 'Toxic Orb';
+		if (species.baseSpecies === 'Marowak') return 'Thick Club';
+		if (species.baseSpecies === 'Pikachu') return 'Light Ball';
+		if (species.name === 'Regieleki' && !isDoubles) return 'Magnet';
+		if (species.name === 'Shedinja') {
+			const noSash = !teamDetails.defog && !teamDetails.rapidSpin && !isDoubles;
+			return noSash ? 'Heavy-Duty Boots' : 'Focus Sash';
+		}
+		if (species.name === 'Shuckle' && hasMove['stickyweb']) return 'Mental Herb';
+		if (species.name === 'Unfezant' || hasMove['focusenergy']) return 'Scope Lens';
+
+		// Ability based logic and miscellaneous logic
+		if (species.name === 'Wobbuffet' || ['Cheek Pouch', 'Harvest', 'Ripen'].includes(ability)) return 'Sitrus Berry';
+		if (ability === 'Gluttony') return this.sample(['Aguav', 'Figy', 'Iapapa', 'Mago', 'Wiki']) + ' Berry';
+		if (
+			ability === 'Gorilla Tactics' || ability === 'Imposter' ||
+			(ability === 'Magnet Pull' && hasMove['bodypress'] && !isDoubles)
+		) return 'Choice Scarf';
+		if (ability === 'Guts' && (counter.Physical > 2 || isDoubles)) return hasType['Fire'] ? 'Toxic Orb' : 'Flame Orb';
+		if (ability === 'Magic Guard' && counter.damagingMoves.length > 1) {
+			return hasMove['counter'] ? 'Focus Sash' : 'Life Orb';
+		}
+		if (ability === 'Sheer Force' && counter.sheerforce) return 'Life Orb';
+		if (ability === 'Unburden') return (hasMove['closecombat'] || hasMove['curse']) ? 'White Herb' : 'Sitrus Berry';
+
+		// Move based logic
+		if (hasMove['trick'] || hasMove['switcheroo'] && !isDoubles) {
+			if (species.baseStats.spe >= 60 && species.baseStats.spe <= 108 && !counter.priority && ability !== 'Triage') {
+				return 'Choice Scarf';
+			} else {
+				return (counter.Physical > counter.Special) ? 'Choice Band' : 'Choice Specs';
+			}
+		}
+		// not undefined — we want "no item" not "go find a different item"
+		if (hasMove['acrobatics']) return ability === 'Grassy Surge' ? 'Grassy Seed' : '';
+		if (hasMove['auroraveil'] || hasMove['lightscreen'] && hasMove['reflect']) return 'Light Clay';
+		if (hasMove['rest'] && !hasMove['sleeptalk'] && ability !== 'Shed Skin') return 'Chesto Berry';
+		if (hasMove['hypnosis'] && ability === 'Beast Boost') return 'Blunder Policy';
+
+		// Misc item generation logic
+		if (species.evos.length && !hasMove['uturn']) return 'Eviolite';
+		if (this.dex.getEffectiveness('Rock', species) >= 2 && !isDoubles) return 'Heavy-Duty Boots';
+	}
+
+	/** Move generation specific to Random Doubles */
+	getDoublesItem(
+		ability: string,
+		hasType: {[k: string]: true},
+		hasMove: {[k: string]: true},
+		hasAbility: {[k: string]: true},
+		counter: {[k: string]: any},
+		teamDetails: RandomTeamsTypes.TeamDetails,
+		species: Species,
+	) {
+		const defensiveStatTotal = species.baseStats.hp + species.baseStats.def + species.baseStats.spd;
+
+		if (
+			(['dragonenergy', 'eruption', 'waterspout'].some(m => hasMove[m])) &&
+			counter.damagingMoves.length >= 4
+		) return 'Choice Scarf';
+		if (hasMove['blizzard'] && ability !== 'Snow Warning' && !teamDetails.hail) return 'Blunder Policy';
+		if (this.dex.getEffectiveness('Rock', species) >= 2 && !hasType['Flying']) return 'Heavy-Duty Boots';
+		if (counter.Physical >= 4 && ['fakeout', 'feint', 'rapidspin', 'suckerpunch'].every(m => !hasMove[m]) && (
+			hasType['Dragon'] || hasType['Fighting'] || hasType['Rock'] ||
+			hasMove['flipturn'] || hasMove['uturn']
+		)) {
+			return (
+				!counter.priority && !hasAbility['Speed Boost'] &&
+				!hasMove['aerialace'] && species.baseStats.spe >= 60 &&
+				species.baseStats.spe <= 100 && this.randomChance(1, 2)
+			) ? 'Choice Scarf' : 'Choice Band';
+		}
+		if (
+			(counter.Special >= 4 && (hasType['Dragon'] || hasType['Fighting'] || hasType['Rock'] || hasMove['voltswitch'])) ||
+			((counter.Special >= 3 && (hasMove['flipturn'] || hasMove['uturn'])) && !hasMove['acidspray'] && !hasMove['electroweb'])
+		) {
+			return (species.baseStats.spe >= 60 && species.baseStats.spe <= 100 && this.randomChance(1, 2)) ?
+				'Choice Scarf' :
+				'Choice Specs';
+		}
+		if (counter.damagingMoves.length >= 4 && defensiveStatTotal >= 280) return 'Assault Vest';
+		if (
+			counter.damagingMoves.length >= 3 &&
+			species.baseStats.spe >= 60 &&
+			ability !== 'Multiscale' && ability !== 'Sturdy' &&
+			[
+				'acidspray', 'clearsmog', 'electroweb', 'fakeout', 'feint', 'icywind',
+				'incinerate', 'naturesmadness', 'rapidspin', 'snarl', 'uturn',
+			].every(m => !hasMove[m])
+		) return (ability === 'Defeatist' || defensiveStatTotal >= 275) ? 'Sitrus Berry' : 'Life Orb';
+	}
+
+	getMediumPriorityItem(
+		ability: string,
+		hasMove: {[k: string]: true},
+		counter: {[k: string]: any},
+		species: Species,
+		isDoubles: boolean
+	) {
+		const defensiveStatTotal = species.baseStats.hp + species.baseStats.def + species.baseStats.spd;
+
+		// Choice items
+		if (
+			!isDoubles && counter.Physical >= 4 && ability !== 'Serene Grace' &&
+			['fakeout', 'flamecharge', 'rapidspin'].every(m => !hasMove[m]) &&
+			(!hasMove['tailslap'] || hasMove['uturn'])
+		) {
+			const scarfReqs = (
+				(species.baseStats.atk >= 100 || ability === 'Huge Power') &&
+				species.baseStats.spe >= 60 && species.baseStats.spe <= 108 &&
+				ability !== 'Speed Boost' && !counter.priority &&
+				['aerialace', 'bounce', 'dualwingbeat'].every(m => !hasMove[m])
+			);
+			return (scarfReqs && this.randomChance(2, 3)) ? 'Choice Scarf' : 'Choice Band';
+		}
+		if (!isDoubles && (
+			(counter.Special >= 4 && !hasMove['futuresight']) ||
+			(counter.Special >= 3 && ['flipturn', 'partingshot', 'uturn'].some(m => hasMove[m]))
+		)) {
+			const scarfReqs = (
+				species.baseStats.spa >= 100 &&
+				species.baseStats.spe >= 60 && species.baseStats.spe <= 108 &&
+				ability !== 'Tinted Lens' && !counter.Physical
+			);
+			return (scarfReqs && this.randomChance(2, 3)) ? 'Choice Scarf' : 'Choice Specs';
+		}
+		if (
+			!isDoubles &&
+			counter.Physical >= 3 &&
+			!hasMove['rapidspin'] &&
+			['copycat', 'memento', 'partingshot'].some(m => hasMove[m])
+		) return 'Choice Band';
+		if (
+			!isDoubles &&
+			((counter.Physical >= 3 && hasMove['defog']) || (counter.Special >= 3 && hasMove['healingwish'])) &&
+			!counter.priority && !hasMove['uturn']
+		) return 'Choice Scarf';
+
+		// Other items
+		if (
+			hasMove['raindance'] || hasMove['sunnyday'] ||
+			(ability === 'Speed Boost' && !counter.hazards) ||
+			(ability === 'Stance Change' && counter.damagingMoves.length >= 3)
+		) return 'Life Orb';
+		if (
+			!isDoubles &&
+			this.dex.getEffectiveness('Rock', species) >= 1 && (
+				['Defeatist', 'Emergency Exit', 'Multiscale'].includes(ability) ||
+				['courtchange', 'defog', 'rapidspin'].some(m => hasMove[m])
+			)
+		) return 'Heavy-Duty Boots';
+		if (species.name === 'Necrozma-Dusk-Mane' || (
+			this.dex.getEffectiveness('Ground', species) < 2 &&
+			counter.speedsetup &&
+			counter.damagingMoves.length >= 3 &&
+			defensiveStatTotal >= 300
+		)) return 'Weakness Policy';
+		if (counter.damagingMoves.length >= 4 && defensiveStatTotal >= 235) return 'Assault Vest';
+		if (
+			['clearsmog', 'curse', 'haze', 'healbell', 'protect', 'sleeptalk', 'strangesteam'].some(m => hasMove[m]) &&
+			(ability === 'Moody' || !isDoubles)
+		) return 'Leftovers';
+	}
+
+	getLowPriorityItem(
+		ability: string,
+		hasType: {[k: string]: true},
+		hasMove: {[k: string]: true},
+		hasAbility: {[k: string]: true},
+		counter: {[k: string]: any},
+		teamDetails: RandomTeamsTypes.TeamDetails,
+		species: Species,
+		isLead: boolean,
+		isDoubles: boolean
+	) {
+		const defensiveStatTotal = species.baseStats.hp + species.baseStats.def + species.baseStats.spd;
+
+		if (
+			isLead && !isDoubles &&
+			!['Disguise', 'Sturdy'].includes(ability) && !hasMove['substitute'] &&
+			!counter.recoil && !counter.recovery && defensiveStatTotal < 255
+		) return 'Focus Sash';
+		if (!isDoubles && ability === 'Water Bubble') return 'Mystic Water';
+		if (hasMove['clangoroussoul'] || (hasMove['boomburst'] && counter.speedsetup)) return 'Throat Spray';
+		if (((
+			this.dex.getEffectiveness('Rock', species) >= 1 &&
+			(!teamDetails.defog || ability === 'Intimidate' || hasMove['uturn'] || hasMove['voltswitch'])
+		) ||
+			!isDoubles && (hasMove['rapidspin'] && (ability === 'Regenerator' || !!counter.recovery)))
+		) return 'Heavy-Duty Boots';
+		if (
+			!isDoubles && this.dex.getEffectiveness('Ground', species) >= 2 && !hasType['Poison'] &&
+			ability !== 'Levitate' && !hasAbility['Iron Barbs']
+		) return 'Air Balloon';
+		if (
+			!isDoubles &&
+			counter.damagingMoves.length >= 3 &&
+			!counter.damage &&
+			ability !== 'Sturdy' &&
+			['foulplay', 'rapidspin', 'substitute', 'uturn'].every(m => !hasMove[m]) && (
+				counter.speedsetup || counter.drain ||
+				hasMove['trickroom'] || hasMove['psystrike'] ||
+				(species.baseStats.spe > 40 && defensiveStatTotal < 275)
+			)
+		) return 'Life Orb';
+		if (!isDoubles && counter.damagingMoves.length >= 4 && !counter.Dragon && !counter.Normal) return 'Expert Belt';
+		if (
+			!isDoubles &&
+			(hasMove['dragondance'] || hasMove['swordsdance']) &&
+			(hasMove['outrage'] || (
+				['Bug', 'Fire', 'Ground', 'Normal', 'Poison'].every(type => !hasType[type]) &&
+				!['Pastel Veil', 'Storm Drain'].includes(ability)
+			))
+		) return 'Lum Berry';
+	}
+
+	randomSet(
+		species: string | Species,
+		teamDetails: RandomTeamsTypes.TeamDetails = {},
+		isLead = false,
+		isDoubles = false
+	): RandomTeamsTypes.RandomSet {
 		species = this.dex.getSpecies(species);
 		let forme = species.name;
 		let gmax = false;
@@ -591,34 +1435,35 @@ export class RandomTeams {
 			gmax = true;
 		}
 
-		const randMoves = !isDoubles ? species.randomBattleMoves : (species.randomDoubleBattleMoves || species.randomBattleMoves);
+		const randMoves = !isDoubles ?
+			species.randomBattleMoves :
+			(species.randomDoubleBattleMoves || species.randomBattleMoves);
 		const movePool = (randMoves || Object.keys(this.dex.data.Learnsets[species.id]!.learnset!)).slice();
 		const rejectedPool = [];
 		const moves: string[] = [];
 		let ability = '';
-		let item = '';
-		const evs = {
-			hp: 85, atk: 85, def: 85, spa: 85, spd: 85, spe: 85,
-		};
-		const ivs = {
-			hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31,
-		};
+		let item = undefined;
+
+		const evs = {hp: 85, atk: 85, def: 85, spa: 85, spd: 85, spe: 85};
+		const ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
+
 		const hasType: {[k: string]: true} = {};
 		hasType[species.types[0]] = true;
 		if (species.types[1]) {
 			hasType[species.types[1]] = true;
 		}
+
 		const hasAbility: {[k: string]: true} = {};
 		hasAbility[species.abilities[0]] = true;
 		if (species.abilities[1]) {
 			hasAbility[species.abilities[1]] = true;
 		}
-		if (species.abilities['H']) {
-			hasAbility[species.abilities['H']] = true;
+		if (species.abilities.H) {
+			hasAbility[species.abilities.H] = true;
 		}
 
-		let hasMove: {[k: string]: boolean} = {};
-		let counter;
+		let hasMove: {[k: string]: true} = {};
+		let counter: {[k: string]: any};
 
 		do {
 			// Keep track of all moves we have:
@@ -636,402 +1481,52 @@ export class RandomTeams {
 			}
 
 			counter = this.queryMoves(moves, hasType, hasAbility, movePool);
+			const runRejectionChecker = (checkerName: string) => (
+				this.moveRejectionCheckers[checkerName]?.(
+					movePool, hasMove, hasAbility, hasType, counter, species as Species, teamDetails
+				)
+			);
 
 			// Iterate through the moves again, this time to cull them:
 			for (const [k, moveId] of moves.entries()) {
 				const move = this.dex.getMove(moveId);
-				const moveid = move.id;
-				let rejected = false;
-				let isSetup = false;
 
-				switch (moveid) {
-				// Not very useful without their supporting moves
-				case 'acrobatics': case 'junglehealing':
-					if (!counter.setupType && !isDoubles) rejected = true;
-					break;
-				case 'destinybond': case 'healbell':
-					if (movePool.includes('protect') || movePool.includes('wish')) rejected = true;
-					break;
-				case 'dualwingbeat': case 'fly': case 'storedpower':
-					if (!hasType[move.type] && !counter.setupType && !!counter.Status) rejected = true;
-					break;
-				case 'fireblast':
-					if (hasAbility['Serene Grace'] && (!hasMove['trick'] || counter.Status > 1)) rejected = true;
-					break;
-				case 'firepunch':
-					if (movePool.includes('bellydrum') || hasMove['earthquake'] && movePool.includes('substitute')) rejected = true;
-					break;
-				case 'flamecharge': case 'sacredsword':
-					if (counter.damagingMoves.length < 3 && !counter.setupType) rejected = true;
-					if (!hasType['Grass'] && movePool.includes('swordsdance')) rejected = true;
-					break;
-				case 'hypervoice':
-					if (hasType['Electric'] && movePool.includes('thunderbolt')) rejected = true;
-					break;
-				case 'payback': case 'psychocut':
-					if (!counter.Status || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
-					break;
-				case 'rest':
-					if (movePool.includes('sleeptalk')) rejected = true;
-					if (!hasMove['sleeptalk'] && (movePool.includes('bulkup') || movePool.includes('calmmind') || movePool.includes('coil') || movePool.includes('curse'))) rejected = true;
-					break;
-				case 'sleeptalk':
-					if (!hasMove['rest']) rejected = true;
-					if (movePool.length > 1 && !hasAbility['Contrary']) {
-						const rest = movePool.indexOf('rest');
-						if (rest >= 0) this.fastPop(movePool, rest);
-					}
-					break;
-				case 'switcheroo': case 'trick':
-					if (counter.Physical + counter.Special < 3 || hasMove['rapidspin']) rejected = true;
-					break;
-				case 'trickroom':
-					if (counter.damagingMoves.length < 2 || movePool.includes('nastyplot') || isLead || teamDetails.stickyWeb) rejected = true;
-					break;
-				case 'zenheadbutt':
-					if (movePool.includes('boltstrike')) rejected = true;
-					break;
-
-				// Set up once and only if we have the moves for it
-				case 'bellydrum': case 'bulkup': case 'coil': case 'curse': case 'dragondance': case 'honeclaws': case 'swordsdance':
-					if (counter.setupType !== 'Physical') rejected = true;
-					if (counter.Physical + counter['physicalpool'] < 2 && (!hasMove['rest'] || !hasMove['sleeptalk'])) rejected = true;
-					if (moveid === 'swordsdance' && hasMove['dragondance']) rejected = true;
-					isSetup = true;
-					break;
-				case 'calmmind': case 'nastyplot':
-					if (counter.setupType !== 'Special') rejected = true;
-					if (counter.Special + counter['specialpool'] < 2 && (!hasMove['rest'] || !hasMove['sleeptalk']) && (!hasMove['wish'] || !hasMove['protect'])) rejected = true;
-					if (hasMove['healpulse'] || moveid === 'calmmind' && hasMove['trickroom']) rejected = true;
-					isSetup = true;
-					break;
-				case 'quiverdance':
-					isSetup = true;
-					break;
-				case 'clangoroussoul': case 'shellsmash': case 'workup':
-					if (counter.setupType !== 'Mixed') rejected = true;
-					if (counter.damagingMoves.length + counter['physicalpool'] + counter['specialpool'] < 2) rejected = true;
-					isSetup = true;
-					break;
-				case 'agility': case 'autotomize': case 'rockpolish': case 'shiftgear':
-					if (counter.damagingMoves.length < 2 || hasMove['rest']) rejected = true;
-					if (movePool.includes('calmmind') || movePool.includes('nastyplot')) rejected = true;
-					if (!counter.setupType) isSetup = true;
-					break;
-
-				// Bad after setup
-				case 'counter': case 'reversal':
-					if (counter.setupType) rejected = true;
-					break;
-				case 'firstimpression': case 'glare': case 'icywind': case 'tailwind': case 'waterspout':
-					if ((counter.setupType && !isDoubles) || !!counter['speedsetup'] || hasMove['rest']) rejected = true;
-					break;
-				case 'bulletpunch': case 'extremespeed': case 'rockblast':
-					if (!!counter['speedsetup'] || counter.damagingMoves.length < 2) rejected = true;
-					break;
-				case 'closecombat': case 'flashcannon': case 'pollenpuff':
-					if ((hasMove['substitute'] && !hasType['Fighting']) || hasMove['toxic'] && movePool.includes('substitute')) rejected = true;
-					if (moveid === 'closecombat' && (hasMove['highjumpkick'] || movePool.includes('highjumpkick')) && !counter.setupType) rejected = true;
-					break;
-				case 'defog':
-					if (counter.setupType || hasMove['healbell'] || hasMove['toxicspikes'] || teamDetails.defog) rejected = true;
-					break;
-				case 'fakeout':
-					if (counter.setupType || hasMove['protect'] || hasMove['rapidspin'] || hasMove['substitute'] || hasMove['uturn']) rejected = true;
-					break;
-				case 'healingwish': case 'memento':
-					if (counter.setupType || !!counter['recovery'] || hasMove['substitute'] || hasMove['uturn']) rejected = true;
-					break;
-				case 'highjumpkick': case 'machpunch':
-					if (hasMove['curse']) rejected = true;
-					break;
-				case 'partingshot':
-					if (!!counter['speedsetup'] || hasMove['bulkup'] || hasMove['uturn']) rejected = true;
-					break;
-				case 'protect':
-					if ((counter.setupType && !hasMove['wish'] && !isDoubles) || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
-					if (counter.Status < 2 && !hasAbility['Hunger Switch'] && !hasAbility['Speed Boost'] && !isDoubles) rejected = true;
-					if (movePool.includes('leechseed') || movePool.includes('toxic') && !hasMove['wish']) rejected = true;
-					if (isDoubles && (movePool.includes('fakeout') || movePool.includes('shellsmash') || movePool.includes('spore') || hasMove['tailwind'] || hasMove['waterspout'])) rejected = true;
-					break;
-				case 'rapidspin':
-					if (hasMove['curse'] || hasMove['nastyplot'] || hasMove['shellsmash'] || teamDetails.rapidSpin) rejected = true;
-					if (counter.setupType && counter['Fighting'] >= 2) rejected = true;
-					break;
-				case 'shadowsneak':
-					if (hasMove['substitute'] || hasMove['trickroom']) rejected = true;
-					if (hasMove['dualwingbeat'] || hasMove['toxic'] || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
-					break;
-				case 'spikes':
-					if (counter.setupType || teamDetails.spikes && teamDetails.spikes > 1) rejected = true;
-					break;
-				case 'stealthrock':
-					if (counter.setupType || !!counter['speedsetup'] || hasMove['rest'] || hasMove['substitute'] || hasMove['trickroom'] || teamDetails.stealthRock) rejected = true;
-					break;
-				case 'stickyweb':
-					if (counter.setupType === 'Special' || teamDetails.stickyWeb) rejected = true;
-					break;
-				case 'taunt':
-					if (hasMove['nastyplot'] || hasMove['swordsdance']) rejected = true;
-					break;
-				case 'thunderwave': case 'voltswitch':
-					if (counter.setupType || !!counter['speedsetup'] || hasMove['raindance']) rejected = true;
-					if (isDoubles && (hasMove['electroweb'] || hasMove['nuzzle'])) rejected = true;
-					break;
-				case 'toxic':
-					if (counter.setupType || hasMove['sludgewave'] || hasMove['thunderwave'] || hasMove['willowisp']) rejected = true;
-					break;
-				case 'toxicspikes':
-					if (counter.setupType || teamDetails.toxicSpikes) rejected = true;
-					break;
-				case 'uturn':
-					if (!!counter['speedsetup'] || (counter.setupType && (!hasType['Bug'] || !counter.recovery))) rejected = true;
-					if (isDoubles && hasMove['leechlife']) rejected = true;
-					break;
-
-				// Ineffective having both
-				// Attacks:
-				case 'explosion':
-					if (!!counter['recovery'] || hasMove['painsplit'] || hasMove['wish']) rejected = true;
-					if (!!counter['speedsetup'] || hasMove['curse'] || hasMove['drainpunch'] || hasMove['rockblast']) rejected = true;
-					break;
-				case 'facade':
-					if (!!counter['recovery'] || movePool.includes('doubleedge')) rejected = true;
-					break;
-				case 'quickattack':
-					if (!!counter['speedsetup'] || hasType['Rock'] && !!counter.Status) rejected = true;
-					if (counter.Physical > 3 && movePool.includes('uturn')) rejected = true;
-					break;
-				case 'blazekick':
-					if (counter.Special >= 1) rejected = true;
-					break;
-				case 'firefang': case 'flamethrower':
-					if (hasMove['heatwave'] || hasMove['overheat'] || hasMove['fireblast'] && counter.setupType !== 'Physical') rejected = true;
-					break;
-				case 'overheat':
-					if (hasMove['flareblitz'] || isDoubles && hasMove['calmmind']) rejected = true;
-					break;
-				case 'aquajet': case 'psychicfangs':
-					if (hasMove['rapidspin'] || hasMove['taunt']) rejected = true;
-					break;
-				case 'aquatail': case 'flipturn': case 'retaliate':
-					if (hasMove['aquajet'] || !!counter.Status) rejected = true;
-					break;
-				case 'hydropump':
-					if (hasMove['scald'] && ((counter.Special < 4 && !hasMove['uturn']) || (species.types.length > 1 && counter.stab < 3))) rejected = true;
-					break;
-				case 'scald':
-					if (hasMove['waterpulse']) rejected = true;
-					break;
-				case 'thunderbolt':
-					if (hasMove['powerwhip']) rejected = true;
-					break;
-				case 'gigadrain':
-					if ((!counter.setupType && hasMove['uturn']) || hasType['Poison'] && !counter['Poison']) rejected = true;
-					break;
-				case 'leafblade':
-					if ((hasMove['leafstorm'] || movePool.includes('leafstorm')) && counter.setupType !== 'Physical') rejected = true;
-					break;
-				case 'leafstorm':
-					if (hasMove['gigadrain'] && !!counter.Status) rejected = true;
-					if (isDoubles && hasMove['energyball']) rejected = true;
-					break;
-				case 'powerwhip':
-					if (hasMove['leechlife'] || !hasType['Grass'] && counter.Physical > 3 && movePool.includes('uturn')) rejected = true;
-					break;
-				case 'woodhammer':
-					if (hasMove['hornleech'] && counter.Physical < 4) rejected = true;
-					break;
-				case 'freezedry':
-					if ((hasMove['blizzard'] && counter.setupType) || hasMove['icebeam'] && counter.Special < 4) rejected = true;
-					if (movePool.includes('bodyslam') || movePool.includes('thunderwave') && hasType['Electric']) rejected = true;
-					break;
-				case 'bodypress':
-					if (hasMove['mirrorcoat'] || hasMove['whirlwind']) rejected = true;
-					if (hasMove['shellsmash'] || hasMove['earthquake'] && movePool.includes('shellsmash')) rejected = true;
-					break;
-				case 'circlethrow':
-					if (hasMove['stormthrow'] && !hasMove['rest']) rejected = true;
-					break;
-				case 'drainpunch':
-					if (hasMove['closecombat'] || !hasType['Fighting'] && movePool.includes('swordsdance')) rejected = true;
-					break;
-				case 'dynamicpunch': case 'thunderouskick':
-					if (hasMove['closecombat'] || hasMove['facade']) rejected = true;
-					break;
-				case 'focusblast':
-					if (movePool.includes('shellsmash') || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
-					break;
-				case 'hammerarm':
-					if (hasMove['fakeout']) rejected = true;
-					break;
-				case 'stormthrow':
-					if (hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
-					break;
-				case 'superpower':
-					if (hasMove['hydropump'] || counter.Physical >= 4 && movePool.includes('uturn')) rejected = true;
-					if (hasMove['substitute'] && !hasAbility['Contrary']) rejected = true;
-					if (hasAbility['Contrary']) isSetup = true;
-					break;
-				case 'poisonjab':
-					if (!hasType['Poison'] && counter.Status >= 2) rejected = true;
-					break;
-				case 'earthquake':
-					if (hasMove['bonemerang'] || hasMove['substitute'] && movePool.includes('toxic')) rejected = true;
-					if (movePool.includes('bodypress') && movePool.includes('shellsmash')) rejected = true;
-					if (isDoubles && (hasMove['earthpower'] || hasMove['highhorsepower'])) rejected = true;
-					break;
-				case 'scorchingsands':
-					if (hasMove['earthpower'] || hasMove['toxic'] && movePool.includes('earthpower')) rejected = true;
-					if (hasMove['willowisp']) rejected = true;
-					break;
-				case 'airslash':
-					if ((hasMove['hurricane'] && !counter.setupType) || hasMove['rest'] && hasMove['sleeptalk']) rejected = true;
-					if (movePool.includes('flamethrower') || hasAbility['Simple'] && !!counter['recovery']) rejected = true;
-					break;
-				case 'bravebird':
-					if (hasMove['dragondance']) rejected = true;
-					break;
-				case 'hurricane':
-					if (hasAbility['Tinted Lens'] && counter.setupType && !isDoubles) rejected = true;
-					break;
-				case 'futuresight':
-					if (hasMove['psyshock'] || hasMove['trick'] || movePool.includes('teleport')) rejected = true;
-					break;
-				case 'photongeyser':
-					if (hasMove['morningsun']) rejected = true;
-					break;
-				case 'psychic':
-					if (hasMove['psyshock'] && (counter.setupType || isDoubles)) rejected = true;
-					break;
-				case 'psyshock':
-					if ((hasMove['psychic'] || hasAbility['Pixilate']) && counter.Special < 4 && !counter.setupType) rejected = true;
-					if (hasAbility['Multiscale'] && !counter.setupType) rejected = true;
-					if (isDoubles && hasMove['psychic']) rejected = true;
-					break;
-				case 'bugbuzz':
-					if (hasMove['uturn'] && !counter.setupType) rejected = true;
-					break;
-				case 'leechlife':
-					if (isDoubles && hasMove['lunge']) rejected = true;
-					if (movePool.includes('firstimpression') || movePool.includes('spikes')) rejected = true;
-					break;
-				case 'stoneedge':
-					if (hasMove['rockblast'] || hasMove['rockslide'] || !!counter.Status && movePool.includes('rockslide')) rejected = true;
-					if (hasAbility['Guts'] && (!hasMove['dynamicpunch'] || hasMove['spikes'])) rejected = true;
-					break;
-				case 'poltergeist':
-					if (hasMove['knockoff']) rejected = true;
-					break;
-				case 'shadowball':
-					if (hasAbility['Pixilate'] && (counter.setupType || counter.Status > 1)) rejected = true;
-					if (!hasType['Ghost'] && movePool.includes('focusblast')) rejected = true;
-					if (isDoubles && hasMove ['phantomforce']) rejected = true;
-					break;
-				case 'shadowclaw':
-					if (hasType['Steel'] && hasMove['shadowsneak'] && counter.Physical < 4) rejected = true;
-					break;
-				case 'dragonpulse': case 'spacialrend':
-					if (hasMove['dracometeor'] && counter.Special < 4) rejected = true;
-					break;
-				case 'darkpulse':
-					if ((hasMove['foulplay'] || hasMove['knockoff'] || hasMove['suckerpunch'] || hasMove['defog']) && counter.setupType !== 'Special') rejected = true;
-					break;
-				case 'suckerpunch':
-					if (counter.damagingMoves.length < 2 || counter['Dark'] > 1 && !hasType['Dark']) rejected = true;
-					if (hasMove['rest']) rejected = true;
-					break;
-				case 'meteormash':
-					if (movePool.includes('extremespeed')) rejected = true;
-					break;
-				case 'dazzlinggleam':
-					if (hasMove['fleurcannon'] || hasMove['moonblast'] || hasMove['petaldance']) rejected = true;
-					break;
-
-				// Status:
-				case 'bodyslam': case 'clearsmog':
-					if (hasMove['sludgebomb'] || hasMove['toxic'] && !hasType['Normal']) rejected = true;
-					if (hasMove['trick'] || movePool.includes('recover')) rejected = true;
-					break;
-				case 'haze':
-					if ((hasMove['stealthrock'] || movePool.includes('stealthrock')) && !teamDetails.stealthRock) rejected = true;
-					break;
-				case 'hypnosis':
-					if (hasMove['voltswitch']) rejected = true;
-					break;
-				case 'willowisp': case 'yawn':
-					if (hasMove['thunderwave'] || hasMove['toxic']) rejected = true;
-					break;
-				case 'painsplit': case 'recover': case 'synthesis':
-					if (hasMove['rest'] || hasMove['wish']) rejected = true;
-					if (moveid === 'synthesis' && hasMove['gigadrain']) rejected = true;
-					break;
-				case 'roost':
-					if (hasMove['throatchop'] || hasMove['stoneedge'] && !hasType['Rock']) rejected = true;
-					break;
-				case 'reflect': case 'lightscreen':
-					if (teamDetails.screens) rejected = true;
-					break;
-				case 'substitute':
-					if (hasMove['rest'] || !counter['recovery'] && movePool.includes('calmmind')) rejected = true;
-					if (movePool.includes('bulkup') || movePool.includes('painsplit') || movePool.includes('roost')) rejected = true;
-					if (isDoubles && movePool.includes('powerwhip')) rejected = true;
-					break;
-				case 'helpinghand':
-					if (hasMove['acupressure']) rejected = true;
-					break;
-				case 'wideguard':
-					if (hasMove['protect']) rejected = true;
-					break;
-				}
-
-				// This move doesn't satisfy our setup requirements:
-				if (((move.category === 'Physical' && counter.setupType === 'Special') || (move.category === 'Special' && counter.setupType === 'Physical')) && moveid !== 'photongeyser') {
-					// Reject STABs last in case the setup type changes later on
-					const stabs: number = counter[species.types[0]] + (counter[species.types[1]] || 0);
-					if (!hasType[move.type] || stabs > 1 || counter[move.category] < 2) rejected = true;
-				}
+				let {cull: rejected, isSetup} = this.shouldCullMove(
+					move, hasType, hasMove, hasAbility, counter,
+					movePool, teamDetails, species, isLead, isDoubles
+				);
 
 				// Pokemon should have moves that benefit their types, stats, or ability
-				if (!rejected && !move.damage && !isSetup && !move.weather && !move.stallingMove &&
-					(isDoubles || (!['facade', 'lightscreen', 'reflect', 'sleeptalk', 'spore', 'substitute', 'switcheroo', 'teleport', 'toxic', 'trick'].includes(moveid) && (move.category !== 'Status' || !move.flags.heal))) &&
-					(!counter.setupType || counter.setupType === 'Mixed' || (move.category !== counter.setupType && move.category !== 'Status') || (counter[counter.setupType] + counter.Status > 3 && !counter.hazards)) &&
-				(
-					(!counter.stab && counter['physicalpool'] + counter['specialpool'] > 0) ||
-					(hasType['Bug'] && movePool.includes('megahorn')) ||
-					(hasType['Dark'] && (!counter['Dark'] || (hasMove['suckerpunch'] && (movePool.includes('knockoff') || movePool.includes('wickedblow'))))) ||
-					(hasType['Dragon'] && !counter['Dragon'] && !hasMove['dragonascent'] && !hasMove['substitute'] && !(hasMove['rest'] && hasMove['sleeptalk'])) ||
-					(hasType['Electric'] && (!counter['Electric'] || movePool.includes('thunder'))) ||
-					(hasType['Fairy'] && !counter['Fairy'] && (movePool.includes('dazzlinggleam') || movePool.includes('fleurcannon') || movePool.includes('moonblast') || movePool.includes('playrough'))) ||
-					(hasType['Fighting'] && (!counter['Fighting'] || !counter.stab)) ||
-					(hasType['Fire'] && (!counter['Fire'] || movePool.includes('flareblitz')) && !hasMove['bellydrum']) ||
-					((hasType['Flying'] || hasMove['swordsdance']) && !counter['Flying'] && (movePool.includes('airslash') || movePool.includes('bravebird') || movePool.includes('dualwingbeat') || movePool.includes('oblivionwing'))) ||
-					(hasType['Ghost'] && (!counter['Ghost'] || movePool.includes('poltergeist') || movePool.includes('spectralthief')) && !counter['Dark']) ||
-					(hasType['Grass'] && ((!counter['Grass'] && (species.baseStats.atk >= 100 || movePool.includes('leafstorm'))) || movePool.includes('grassyglide'))) ||
-					(hasType['Ground'] && !counter['Ground']) ||
-					(hasType['Ice'] && (!counter['Ice'] || movePool.includes('iciclecrash') || (hasAbility['Snow Warning'] && movePool.includes('blizzard')))) ||
-					((hasType['Normal'] && hasAbility['Guts'] && movePool.includes('facade')) || (hasAbility['Pixilate'] && !counter['Normal'])) ||
-					(hasType['Poison'] && !counter['Poison'] && (hasType['Ground'] || hasType['Psychic'] || counter.setupType || movePool.includes('gunkshot'))) ||
-					(hasType['Psychic'] && !counter['Psychic'] && !hasType['Ghost'] && !hasType['Steel'] && (hasAbility['Psychic Surge'] || counter.setupType || movePool.includes('psychicfangs'))) ||
-					(hasType['Rock'] && !counter['Rock'] && species.baseStats.atk >= 80) ||
-					((hasType['Steel'] || hasAbility['Steelworker']) && (!counter['Steel'] || (hasMove['bulletpunch'] && counter.stab < 2)) && species.baseStats.atk >= 95) ||
-					(hasType['Water'] && ((!counter['Water'] && !hasMove['hypervoice']) || movePool.includes('hypervoice') || (hasAbility['Huge Power'] && movePool.includes('aquajet')))) ||
-					((hasAbility['Moody'] || hasMove['wish']) && movePool.includes('protect')) ||
-					(((hasMove['lightscreen'] && movePool.includes('reflect')) || (hasMove['reflect'] && movePool.includes('lightscreen'))) && !teamDetails.screens) ||
-					((movePool.includes('morningsun') || movePool.includes('recover') || movePool.includes('roost') || movePool.includes('slackoff') || movePool.includes('softboiled')) &&
-						!!counter.Status && !counter.setupType && !hasMove['healingwish'] && !hasMove['switcheroo'] && !hasMove['trick'] && !hasMove['trickroom'] && !isDoubles) ||
-					(movePool.includes('milkdrink') || movePool.includes('quiverdance') || movePool.includes('stickyweb') && !counter.setupType && !teamDetails.stickyWeb) ||
-					(isLead && movePool.includes('stealthrock') && !!counter.Status && !counter.setupType && !counter['speedsetup'] && !hasMove['substitute']) ||
-					(isDoubles && species.baseStats.def >= 140 && movePool.includes('bodypress'))
-				)) {
-					// Reject Status, non-STAB, or low basepower moves
-					if (move.category === 'Status' || !hasType[move.type] || move.basePower && move.basePower < 50 && !move.multihit && !hasAbility['Technician']) {
+				const isLowBP = move.basePower && move.basePower < 50;
+				if (
+					!rejected && !isSetup && !move.weather && !move.stallingMove && move.category === 'Status' ||
+					!hasType[move.type] ||
+					(isLowBP && !move.multihit && !hasAbility['Technician']) ||
+					(isDoubles || this.isBeneficialInSingles(move)) ||
+					!counter.setupType || counter.setupType === 'Mixed' ||
+					(move.category !== counter.setupType && move.category !== 'Status') ||
+					(counter[counter.setupType] + counter.Status > 3 && !counter.hazards)
+				) {
+					// This move might not be beneficial
+					if (
+						(!counter.stab && counter.physicalpool + counter.specialpool > 0) ||
+						// I have no idea why Swords Dance shares a rejection checker with Flying types
+						(hasMove['swordsdance'] && runRejectionChecker('Flying')) ||
+						(hasAbility['steelworker'] && runRejectionChecker('Steel')) ||
+						(isDoubles ? runRejectionChecker('doubles') : runRejectionChecker('recovery')) ||
+						runRejectionChecker('screens') ||
+						(isLead && runRejectionChecker('lead'))
+					) {
 						rejected = true;
+					} else {
+						for (const type of Object.keys(hasType)) {
+							if (runRejectionChecker(type)) rejected = true;
+						}
 					}
 				}
 
 				// Sleep Talk shouldn't be selected without Rest
-				if (moveid === 'rest' && rejected) {
+				if (move.id === 'rest' && rejected) {
 					const sleeptalk = movePool.indexOf('sleeptalk');
 					if (sleeptalk >= 0) {
 						if (movePool.length < 2) {
@@ -1055,162 +1550,43 @@ export class RandomTeams {
 			}
 		} while (moves.length < 4 && (movePool.length || rejectedPool.length));
 
-		const abilities: string[] = Object.values(species.abilities);
-		abilities.sort((a, b) => this.dex.getAbility(b).rating - this.dex.getAbility(a).rating);
-		let ability0 = this.dex.getAbility(abilities[0]);
-		let ability1 = this.dex.getAbility(abilities[1]);
-		let ability2 = this.dex.getAbility(abilities[2]);
-		if (abilities[1]) {
-			if (abilities[2] && ability1.rating <= ability2.rating && this.randomChance(1, 2)) {
-				[ability1, ability2] = [ability2, ability1];
-			}
-			if (ability0.rating <= ability1.rating && this.randomChance(1, 2)) {
-				[ability0, ability1] = [ability1, ability0];
-			} else if (ability0.rating - 0.6 <= ability1.rating && this.randomChance(2, 3)) {
-				[ability0, ability1] = [ability1, ability0];
-			}
-			ability = ability0.name;
+		const abilityNames: string[] = Object.values(species.abilities);
+		abilityNames.sort((a, b) => this.dex.getAbility(b).rating - this.dex.getAbility(a).rating);
 
-			let rejectAbility: boolean;
+		const abilities = abilityNames.map(name => this.dex.getAbility(name));
+		if (abilityNames[1]) {
+			// Sort abilities by rating with an element of randomness
+			if (abilityNames[2] && abilities[1].rating <= abilities[2].rating && this.randomChance(1, 2)) {
+				[abilities[1], abilities[2]] = [abilities[2], abilities[1]];
+			}
+			if (abilities[0].rating <= abilities[1].rating && this.randomChance(1, 2)) {
+				[abilities[0], abilities[1]] = [abilities[1], abilities[0]];
+			} else if (abilities[0].rating - 0.6 <= abilities[1].rating && this.randomChance(2, 3)) {
+				[abilities[0], abilities[1]] = [abilities[1], abilities[0]];
+			}
+
+			// Start with the first abiility and work our way through, culling as we go
+			ability = abilities[0].name;
+			let rejectAbility = false;
 			do {
-				rejectAbility = false;
-				if (['Cloud Nine', 'Flare Boost', 'Hydration', 'Ice Body', 'Innards Out', 'Insomnia', 'Misty Surge', 'Quick Feet', 'Rain Dish', 'Snow Cloak', 'Steadfast', 'Steam Engine', 'Weak Armor'].includes(ability)) {
-					rejectAbility = true;
-				} else if (['Contrary', 'Serene Grace', 'Skill Link', 'Strong Jaw'].includes(ability)) {
-					rejectAbility = !counter[toID(ability)];
-				} else if (ability === 'Adaptability') {
-					rejectAbility = !!counter['speedsetup'];
-				} else if (ability === 'Analytic') {
-					rejectAbility = (hasMove['rapidspin'] || species.nfe || isDoubles);
-				} else if (ability === 'Blaze') {
-					rejectAbility = (isDoubles && hasAbility['Solar Power']);
-				} else if (ability === 'Bulletproof' || ability === 'Overcoat') {
-					rejectAbility = (counter.setupType && hasAbility['Soundproof']);
-				} else if (ability === 'Chlorophyll') {
-					rejectAbility = (species.baseStats.spe > 100 || !counter['Fire'] && !hasMove['sunnyday'] && !teamDetails['sun']);
-				} else if (ability === 'Competitive') {
-					rejectAbility = (counter['Special'] < 2 || hasMove['rest'] && hasMove['sleeptalk']);
-				} else if (ability === 'Compound Eyes' || ability === 'No Guard') {
-					rejectAbility = !counter['inaccurate'];
-				} else if (ability === 'Cursed Body') {
-					rejectAbility = hasAbility['Infiltrator'];
-				} else if (ability === 'Defiant') {
-					rejectAbility = !counter['Physical'];
-				} else if (ability === 'Download') {
-					rejectAbility = (counter.damagingMoves.length < 3 || hasMove['trick']);
-				} else if (ability === 'Early Bird') {
-					rejectAbility = (hasType['Grass'] && isDoubles);
-				} else if (ability === 'Flash Fire') {
-					rejectAbility = (this.dex.getEffectiveness('Fire', species) < -1 || hasAbility['Drought']);
-				} else if (ability === 'Gluttony') {
-					rejectAbility = !hasMove['bellydrum'];
-				} else if (ability === 'Guts') {
-					rejectAbility = (!hasMove['facade'] && !hasMove['sleeptalk'] && !species.nfe);
-				} else if (ability === 'Harvest') {
-					rejectAbility = (hasAbility['Frisk'] && !isDoubles);
-				} else if (ability === 'Hustle' || ability === 'Inner Focus') {
-					rejectAbility = (counter.Physical < 2 || hasAbility['Iron Fist']);
-				} else if (ability === 'Infiltrator') {
-					rejectAbility = ((hasMove['rest'] && hasMove['sleeptalk']) || isDoubles && hasAbility['Clear Body']);
-				} else if (ability === 'Intimidate') {
-					rejectAbility = (hasMove['bodyslam'] || hasMove['bounce'] || hasMove['tripleaxel']);
-				} else if (ability === 'Iron Fist') {
-					rejectAbility = (counter['ironfist'] < 2 || hasMove['dynamicpunch']);
-				} else if (ability === 'Justified') {
-					rejectAbility = (isDoubles && hasAbility['Inner Focus']);
-				} else if (ability === 'Lightning Rod') {
-					rejectAbility = (species.types.includes('Ground') || counter.setupType === 'Physical');
-				} else if (ability === 'Limber') {
-					rejectAbility = species.types.includes('Electric');
-				} else if (ability === 'Liquid Voice') {
-					rejectAbility = !hasMove['hypervoice'];
-				} else if (ability === 'Magic Guard') {
-					rejectAbility = (hasAbility['Tinted Lens'] && !counter.Status && !isDoubles);
-				} else if (ability === 'Mold Breaker') {
-					rejectAbility = (hasAbility['Adaptability'] || hasAbility['Scrappy'] || (hasAbility['Sheer Force'] && !!counter['sheerforce']) || hasAbility['Unburden'] && counter.setupType);
-				} else if (ability === 'Moxie') {
-					rejectAbility = (counter.Physical < 2 || hasMove['stealthrock']);
-				} else if (ability === 'Neutralizing Gas') {
-					rejectAbility = !hasMove['toxicspikes'];
-				} else if (ability === 'Overgrow') {
-					rejectAbility = !counter['Grass'];
-				} else if (ability === 'Own Tempo') {
-					rejectAbility = !hasMove['petaldance'];
-				} else if (ability === 'Power Construct') {
-					rejectAbility = (species.forme === '10%' && !isDoubles);
-				} else if (ability === 'Prankster') {
-					rejectAbility = !counter['Status'];
-				} else if (ability === 'Pressure') {
-					rejectAbility = (counter.setupType || counter.Status < 2 || isDoubles);
-				} else if (ability === 'Refrigerate') {
-					rejectAbility = !counter['Normal'];
-				} else if (ability === 'Regenerator') {
-					rejectAbility = hasAbility['Magic Guard'];
-				} else if (ability === 'Reckless' || ability === 'Rock Head') {
-					rejectAbility = !counter['recoil'];
-				} else if (ability === 'Sand Force' || ability === 'Sand Veil') {
-					rejectAbility = !teamDetails['sand'];
-				} else if (ability === 'Sand Rush') {
-					rejectAbility = (!teamDetails['sand'] && (!counter.setupType || !counter['Rock'] || hasMove['rapidspin']));
-				} else if (ability === 'Sap Sipper') {
-					rejectAbility = hasMove['roost'];
-				} else if (ability === 'Scrappy') {
-					rejectAbility = (hasMove['earthquake'] && hasMove['milkdrink']);
-				} else if (ability === 'Screen Cleaner') {
-					rejectAbility = !!teamDetails['screens'];
-				} else if (ability === 'Shadow Tag') {
-					rejectAbility = (species.name === 'Gothitelle' && !isDoubles);
-				} else if (ability === 'Shed Skin') {
-					rejectAbility = hasMove['dragondance'];
-				} else if (ability === 'Sheer Force') {
-					rejectAbility = (!counter['sheerforce'] || hasAbility['Guts']);
-				} else if (ability === 'Slush Rush') {
-					rejectAbility = (!teamDetails['hail'] && !hasAbility['Swift Swim']);
-				} else if (ability === 'Sniper') {
-					rejectAbility = (counter['Water'] > 1 && !hasMove['focusenergy']);
-				} else if (ability === 'Steely Spirit') {
-					rejectAbility = (hasMove['fakeout'] && !isDoubles);
-				} else if (ability === 'Sturdy') {
-					rejectAbility = (hasMove['bulkup'] || !!counter['recoil'] || hasAbility['Solid Rock']);
-				} else if (ability === 'Swarm') {
-					rejectAbility = (!counter['Bug'] || !!counter['recovery']);
-				} else if (ability === 'Sweet Veil') {
-					rejectAbility = hasType['Grass'];
-				} else if (ability === 'Swift Swim') {
-					rejectAbility = (!hasMove['raindance'] && (hasAbility['Intimidate'] || (hasAbility['Lightning Rod'] && !counter.setupType) || hasAbility['Rock Head'] || hasAbility['Slush Rush'] || hasAbility['Water Absorb']));
-				} else if (ability === 'Synchronize') {
-					rejectAbility = counter.Status < 3;
-				} else if (ability === 'Technician') {
-					rejectAbility = (!counter['technician'] || hasMove['tailslap'] || hasAbility['Punk Rock'] || movePool.includes('snarl'));
-				} else if (ability === 'Tinted Lens') {
-					rejectAbility = (hasMove['defog'] || hasMove['hurricane'] || counter.Status > 2 && !counter.setupType);
-				} else if (ability === 'Torrent') {
-					rejectAbility = (hasMove['focusenergy'] || hasMove['hypervoice']);
-				} else if (ability === 'Tough Claws') {
-					rejectAbility = (hasType['Steel'] && !hasMove['fakeout']);
-				} else if (ability === 'Unaware') {
-					rejectAbility = (counter.setupType || hasMove['fireblast']);
-				} else if (ability === 'Unburden') {
-					rejectAbility = (hasAbility['Prankster'] || !counter.setupType && !isDoubles);
-				} else if (ability === 'Volt Absorb') {
-					rejectAbility = (this.dex.getEffectiveness('Electric', species) < -1);
-				} else if (ability === 'Water Absorb') {
-					rejectAbility = (hasMove['raindance'] || hasAbility['Drizzle'] || hasAbility['Strong Jaw'] || hasAbility['Unaware'] || hasAbility['Volt Absorb']);
-				}
+				rejectAbility = this.shouldCullAbility(
+					ability, hasType, hasMove, hasAbility, counter, movePool, teamDetails, species, isDoubles
+				);
 
 				if (rejectAbility) {
-					if (ability === ability0.name && ability1.rating >= 1) {
-						ability = ability1.name;
-					} else if (ability === ability1.name && abilities[2] && ability2.rating >= 1) {
-						ability = ability2.name;
+					if (ability === abilities[0].name && abilities[1].rating >= 1) {
+						ability = abilities[1].name;
+					} else if (ability === abilities[1].name && abilityNames[2] && abilities[2].rating >= 1) {
+						ability = abilities[2].name;
 					} else {
 						// Default to the highest rated ability if all are rejected
-						ability = abilities[0];
+						ability = abilityNames[0];
 						rejectAbility = false;
 					}
 				}
 			} while (rejectAbility);
 
+			// Hardcoded abilities for certain contexts
 			if (forme === 'Copperajah' && gmax) {
 				ability = 'Heavy Metal';
 			} else if (hasAbility['Guts'] && (hasMove['facade'] || (hasMove['rest'] && hasMove['sleeptalk']))) {
@@ -1234,164 +1610,49 @@ export class RandomTeams {
 				if (hasAbility['Telepathy'] && (ability === 'Pressure' || hasAbility['Analytic'])) ability = 'Telepathy';
 			}
 		} else {
-			ability = ability0.name;
+			ability = abilities[0].name;
 		}
 
-		item = !isDoubles ? 'Leftovers' : 'Sitrus Berry';
+		// item = !isDoubles ? 'Leftovers' : 'Sitrus Berry';
 		if (species.requiredItems) {
 			item = this.sample(species.requiredItems);
-
 		// First, the extra high-priority items
-		} else if (['Corsola', 'Garchomp', 'Tangrowth'].includes(species.name) && !!counter.Status && !counter.setupType && !isDoubles) {
-			item = 'Rocky Helmet';
-		} else if (species.name === 'Eternatus' && counter.Status < 2) {
-			item = 'Metronome';
-		} else if (species.name === 'Farfetch\u2019d') {
-			item = 'Leek';
-		} else if (species.name === 'Froslass' && !isDoubles) {
-			item = 'Wide Lens';
-		} else if (species.name === 'Latios' && counter.Special === 2 && !isDoubles) {
-			item = 'Soul Dew';
-		} else if (species.name === 'Lopunny') {
-			item = isDoubles ? 'Iron Ball' : 'Toxic Orb';
-		} else if (species.baseSpecies === 'Marowak') {
-			item = 'Thick Club';
-		} else if (species.baseSpecies === 'Pikachu') {
-			forme = 'Pikachu' + this.sample(['', '-Original', '-Hoenn', '-Sinnoh', '-Unova', '-Kalos', '-Alola', '-Partner', '-World']);
-			item = 'Light Ball';
-		} else if (species.name === 'Regieleki' && !isDoubles) {
-			item = 'Magnet';
-		} else if (species.name === 'Shedinja') {
-			item = (!teamDetails.defog && !teamDetails.rapidSpin && !isDoubles) ? 'Heavy-Duty Boots' : 'Focus Sash';
-		} else if (species.name === 'Shuckle' && hasMove['stickyweb']) {
-			item = 'Mental Herb';
-		} else if (species.name === 'Unfezant' || hasMove['focusenergy']) {
-			item = 'Scope Lens';
-		} else if (species.name === 'Wobbuffet' || ['Cheek Pouch', 'Harvest', 'Ripen'].includes(ability)) {
-			item = 'Sitrus Berry';
-		} else if (ability === 'Gluttony') {
-			item = this.sample(['Aguav', 'Figy', 'Iapapa', 'Mago', 'Wiki']) + ' Berry';
-		} else if (ability === 'Gorilla Tactics' || ability === 'Imposter' || (ability === 'Magnet Pull' && hasMove['bodypress'] && !isDoubles)) {
-			item = 'Choice Scarf';
-		} else if (hasMove['trick'] || hasMove['switcheroo'] && !isDoubles) {
-			if (species.baseStats.spe >= 60 && species.baseStats.spe <= 108 && !counter['priority'] && ability !== 'Triage') {
-				item = 'Choice Scarf';
-			} else {
-				item = (counter.Physical > counter.Special) ? 'Choice Band' : 'Choice Specs';
+		} else {
+			item = this.getHighPriorityItem(ability, hasType, hasMove, counter, teamDetails, species, isDoubles);
+			if (!item && isDoubles) {
+				item = this.getDoublesItem(ability, hasType, hasMove, hasAbility, counter, teamDetails, species);
 			}
-		} else if (species.evos.length && !hasMove['uturn']) {
-			item = 'Eviolite';
-		} else if (hasMove['bellydrum']) {
-			item = (!!counter['priority'] || !hasMove['substitute']) ? 'Sitrus Berry' : 'Salac Berry';
-		} else if (hasMove['geomancy'] || hasMove['meteorbeam']) {
-			item = 'Power Herb';
-		} else if (hasMove['shellsmash']) {
-			item = (ability === 'Sturdy' && !isLead && !isDoubles) ? 'Heavy-Duty Boots' : 'White Herb';
-		} else if (ability === 'Guts' && (counter.Physical > 2 || isDoubles)) {
-			item = hasType['Fire'] ? 'Toxic Orb' : 'Flame Orb';
-		} else if (ability === 'Magic Guard' && counter.damagingMoves.length > 1) {
-			item = hasMove['counter'] ? 'Focus Sash' : 'Life Orb';
-		} else if (ability === 'Sheer Force' && !!counter['sheerforce']) {
-			item = 'Life Orb';
-		} else if (ability === 'Unburden') {
-			item = (hasMove['closecombat'] || hasMove['curse']) ? 'White Herb' : 'Sitrus Berry';
-		} else if (hasMove['acrobatics']) {
-			item = (ability === 'Grassy Surge') ? 'Grassy Seed' : '';
-		} else if (hasMove['auroraveil'] || hasMove['lightscreen'] && hasMove['reflect']) {
-			item = 'Light Clay';
-		} else if (hasMove['rest'] && !hasMove['sleeptalk'] && ability !== 'Shed Skin') {
-			item = 'Chesto Berry';
-		} else if (hasMove['hypnosis'] && ability === 'Beast Boost') {
-			item = 'Blunder Policy';
-		} else if (this.dex.getEffectiveness('Rock', species) >= 2 && !isDoubles) {
-			item = 'Heavy-Duty Boots';
+			if (!item) item = this.getMediumPriorityItem(ability, hasMove, counter, species, isDoubles);
+			if (!item) {
+				item = this.getLowPriorityItem(ability, hasType, hasMove, hasAbility, counter, teamDetails, species, isLead, isDoubles);
+			}
 
-		// Doubles
-		} else if (isDoubles && (hasMove['dragonenergy'] || hasMove['eruption'] || hasMove['waterspout']) && counter.damagingMoves.length >= 4) {
-			item = 'Choice Scarf';
-		} else if (isDoubles && hasMove['blizzard'] && ability !== 'Snow Warning' && !teamDetails['hail']) {
-			item = 'Blunder Policy';
-		} else if (isDoubles && this.dex.getEffectiveness('Rock', species) >= 2 && !hasType['Flying']) {
-			item = 'Heavy-Duty Boots';
-		} else if (isDoubles && counter.Physical >= 4 && (hasType['Dragon'] || hasType['Fighting'] || hasType['Rock'] || hasMove['flipturn'] || hasMove['uturn']) &&
-			!hasMove['fakeout'] && !hasMove['feint'] && !hasMove['rapidspin'] && !hasMove['suckerpunch']
-		) {
-			item = (!counter['priority'] && !hasAbility['Speed Boost'] && !hasMove['aerialace'] && species.baseStats.spe >= 60 && species.baseStats.spe <= 100 && this.randomChance(1, 2)) ? 'Choice Scarf' : 'Choice Band';
-		} else if (isDoubles && ((counter.Special >= 4 && (hasType['Dragon'] || hasType ['Fighting'] || hasType['Rock'] || hasMove['voltswitch'])) || (counter.Special >= 3 &&
-			(hasMove['flipturn'] || hasMove['uturn'])) && !hasMove['acidspray'] && !hasMove['electroweb'])
-		) {
-			item = (species.baseStats.spe >= 60 && species.baseStats.spe <= 100 && this.randomChance(1, 2)) ? 'Choice Scarf' : 'Choice Specs';
-		} else if (isDoubles && counter.damagingMoves.length >= 4 && species.baseStats.hp + species.baseStats.def + species.baseStats.spd >= 280) {
-			item = 'Assault Vest';
-		} else if (isDoubles && counter.damagingMoves.length >= 3 && species.baseStats.spe >= 60 && ability !== 'Multiscale' && ability !== 'Sturdy' && !hasMove['acidspray'] && !hasMove['clearsmog'] && !hasMove['electroweb'] &&
-			!hasMove['fakeout'] && !hasMove['feint'] && !hasMove['icywind'] && !hasMove['incinerate'] && !hasMove['naturesmadness'] && !hasMove['rapidspin'] && !hasMove['snarl'] && !hasMove['uturn']
-		) {
-			item = (ability === 'Defeatist' || species.baseStats.hp + species.baseStats.def + species.baseStats.spd >= 275) ? 'Sitrus Berry' : 'Life Orb';
-
-		// Medium priority
-		} else if (counter.Physical >= 4 && ability !== 'Serene Grace' && !hasMove['fakeout'] && !hasMove['flamecharge'] && !hasMove['rapidspin'] && (!hasMove['tailslap'] || hasMove['uturn']) && !isDoubles) {
-			const scarfReqs = (
-				(species.baseStats.atk >= 100 || ability === 'Huge Power') && species.baseStats.spe >= 60 && species.baseStats.spe <= 108 &&
-				ability !== 'Speed Boost' && !counter['priority'] && !hasMove['aerialace'] && !hasMove['bounce'] && !hasMove['dualwingbeat']
-			);
-			item = (scarfReqs && this.randomChance(2, 3)) ? 'Choice Scarf' : 'Choice Band';
-		} else if (counter.Physical >= 3 && (hasMove['copycat'] || hasMove['memento'] || hasMove['partingshot']) && !hasMove['rapidspin'] && !isDoubles) {
-			item = 'Choice Band';
-		} else if (((counter.Special >= 4 && !hasMove['futuresight']) || (counter.Special >= 3 && (hasMove['flipturn'] || hasMove['partingshot'] || hasMove['uturn']))) && !isDoubles) {
-			const scarfReqs = species.baseStats.spa >= 100 && species.baseStats.spe >= 60 && species.baseStats.spe <= 108 && ability !== 'Tinted Lens' && !counter.Physical;
-			item = (scarfReqs && this.randomChance(2, 3)) ? 'Choice Scarf' : 'Choice Specs';
-		} else if (((counter.Physical >= 3 && hasMove['defog']) || (counter.Special >= 3 && hasMove['healingwish'])) && !counter['priority'] && !hasMove['uturn'] && !isDoubles) {
-			item = 'Choice Scarf';
-		} else if (hasMove['raindance'] || hasMove['sunnyday'] || (ability === 'Speed Boost' && !counter['hazards']) || ability === 'Stance Change' && counter.damagingMoves.length >= 3) {
-			item = 'Life Orb';
-		} else if (this.dex.getEffectiveness('Rock', species) >= 1 && (['Defeatist', 'Emergency Exit', 'Multiscale'].includes(ability) || hasMove['courtchange'] || hasMove['defog'] || hasMove['rapidspin']) && !isDoubles) {
-			item = 'Heavy-Duty Boots';
-		} else if (species.name === 'Necrozma-Dusk-Mane' || (this.dex.getEffectiveness('Ground', species) < 2 && !!counter['speedsetup'] &&
-			counter.damagingMoves.length >= 3 && species.baseStats.hp + species.baseStats.def + species.baseStats.spd >= 300)
-		) {
-			item = 'Weakness Policy';
-		} else if (counter.damagingMoves.length >= 4 && species.baseStats.hp + species.baseStats.def + species.baseStats.spd >= 235) {
-			item = 'Assault Vest';
-		} else if ((hasMove['clearsmog'] || hasMove['curse'] || hasMove['haze'] || hasMove['healbell'] || hasMove['protect'] || hasMove['sleeptalk'] || hasMove['strangesteam']) && (ability === 'Moody' || !isDoubles)) {
-			item = 'Leftovers';
-
-		// Better than Leftovers
-		} else if (isLead && !['Disguise', 'Sturdy'].includes(ability) && !hasMove['substitute'] && !counter['recoil'] && !counter['recovery'] && species.baseStats.hp + species.baseStats.def + species.baseStats.spd < 255 && !isDoubles) {
-			item = 'Focus Sash';
-		} else if (ability === 'Water Bubble' && !isDoubles) {
-			item = 'Mystic Water';
-		} else if (hasMove['clangoroussoul'] || hasMove['boomburst'] && !!counter['speedsetup']) {
-			item = 'Throat Spray';
-		} else if (((this.dex.getEffectiveness('Rock', species) >= 1 && (!teamDetails.defog || ability === 'Intimidate' || hasMove['uturn'] || hasMove['voltswitch'])) ||
-			(hasMove['rapidspin'] && (ability === 'Regenerator' || !!counter['recovery']))) && !isDoubles
-		) {
-			item = 'Heavy-Duty Boots';
-		} else if (this.dex.getEffectiveness('Ground', species) >= 2 && !hasType['Poison'] && ability !== 'Levitate' && !hasAbility['Iron Barbs'] && !isDoubles) {
-			item = 'Air Balloon';
-		} else if (counter.damagingMoves.length >= 3 && !counter['damage'] && ability !== 'Sturdy' && !hasMove['foulplay'] && !hasMove['rapidspin'] && !hasMove['substitute'] && !hasMove['uturn'] && !isDoubles &&
-			(!!counter['speedsetup'] || hasMove['trickroom'] || !!counter['drain'] || hasMove['psystrike'] || (species.baseStats.spe > 40 && species.baseStats.hp + species.baseStats.def + species.baseStats.spd < 275))
-		) {
-			item = 'Life Orb';
-		} else if (counter.damagingMoves.length >= 4 && !counter['Dragon'] && !counter['Normal'] && !isDoubles) {
-			item = 'Expert Belt';
-		} else if ((hasMove['dragondance'] || hasMove['swordsdance']) && !isDoubles &&
-			(hasMove['outrage'] || !hasType['Bug'] && !hasType['Fire'] && !hasType['Ground'] && !hasType['Normal'] && !hasType['Poison'] && !['Pastel Veil', 'Storm Drain'].includes(ability))
-		) {
-			item = 'Lum Berry';
+			// fallback
+			if (!item) item = isDoubles ? 'Sitrus Berry' : 'Leftovers';
 		}
 
 		// For Trick / Switcheroo
 		if (item === 'Leftovers' && hasType['Poison']) {
 			item = 'Black Sludge';
 		}
+		if (species.baseSpecies === 'Pikachu') {
+			forme = 'Pikachu' + this.sample(['', '-Original', '-Hoenn', '-Sinnoh', '-Unova', '-Kalos', '-Alola', '-Partner', '-World']);
+		}
 
-		const level: number = (!isDoubles ? species.randomBattleLevel : species.randomDoubleBattleLevel) || 80;
+		const level: number = (isDoubles ? species.randomDoubleBattleLevel : species.randomBattleLevel) || 80;
 
 		// Prepare optimal HP
-		const srWeakness = (ability === 'Magic Guard' || item === 'Heavy-Duty Boots' ? 0 : this.dex.getEffectiveness('Rock', species));
+		const srImmunity = ability === 'Magic Guard' || item === 'Heavy-Duty Boots';
+		const srWeakness = srImmunity ? 0 : this.dex.getEffectiveness('Rock', species);
 		while (evs.hp > 1) {
 			const hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
-			if (hasMove['substitute'] && (item === 'Sitrus Berry' || ability === 'Power Construct' || (hasMove['bellydrum'] && item === 'Salac Berry'))) {
+			const multipleOfFourNecessary = (
+				hasMove['substitute'] ||
+				item === 'Sitrus Berry' ||
+				ability === 'Power Construct' ||
+				(hasMove['bellydrum'] && item === 'Salac Berry')
+			);
+			if (multipleOfFourNecessary) {
 				// Two Substitutes should activate Sitrus Berry
 				if (hp % 4 === 0) break;
 			} else if (hasMove['bellydrum'] && (item === 'Sitrus Berry' || ability === 'Gluttony')) {
@@ -1410,7 +1671,7 @@ export class RandomTeams {
 		if (hasMove['shellsidearm'] && item === 'Choice Specs') evs.atk -= 4;
 
 		// Minimize confusion damage
-		if (!counter['Physical'] && !hasMove['transform'] && (!hasMove['shellsidearm'] || !counter.Status)) {
+		if (!counter.Physical && !hasMove['transform'] && (!hasMove['shellsidearm'] || !counter.Status)) {
 			evs.atk = 0;
 			ivs.atk = 0;
 		}
@@ -1424,19 +1685,19 @@ export class RandomTeams {
 			name: species.baseSpecies,
 			species: forme,
 			gender: species.gender,
-			moves: moves,
-			ability: ability,
-			evs: evs,
-			ivs: ivs,
-			item: item,
-			level: level,
 			shiny: this.randomChance(1, 1024),
 			gigantamax: gmax,
+			moves,
+			ability,
+			evs,
+			ivs,
+			item,
+			level,
 		};
 	}
 
-	getPokemonPool(type: string, pokemon: RandomTeamsTypes.RandomSet[] = [], isMonotype = false) {
-		const exclude = pokemon.map(p => toID(p.species));
+	getPokemonPool(type: string, pokemonToExclude: RandomTeamsTypes.RandomSet[] = [], isMonotype = false) {
+		const exclude = pokemonToExclude.map(p => toID(p.species));
 		const pokemonPool = [];
 		for (const id in this.dex.data.FormatsData) {
 			let species = this.dex.getSpecies(id);
@@ -1464,10 +1725,9 @@ export class RandomTeams {
 		const type = this.sample(typePool);
 
 		// PotD stuff
-		let potd: Species | false = false;
-		if (global.Config && Config.potd && ruleTable.has('potd')) {
-			potd = this.dex.getSpecies(Config.potd);
-		}
+		const usePotD = global.Config && Config.potd && ruleTable.has('potd');
+		const potd = usePotD ? this.dex.getSpecies(Config.potd) : null;
+		console.log(Config.potd);
 
 		const baseFormes: {[k: string]: number} = {};
 
@@ -1492,6 +1752,7 @@ export class RandomTeams {
 			if (baseFormes[species.baseSpecies]) continue;
 
 			// Adjust rate for species with multiple sets
+			// TODO: investigate automating this by searching for Pokémon with multiple sets
 			switch (species.baseSpecies) {
 			case 'Arceus': case 'Silvally':
 				if (this.randomChance(8, 9) && !isMonotype) continue;
@@ -1506,7 +1767,8 @@ export class RandomTeams {
 				if (species.gen === 8 && this.randomChance(1, 2)) continue;
 				break;
 			case 'Magearna': case 'Toxtricity': case 'Zacian': case 'Zamazenta': case 'Zarude':
-			case 'Appletun': case 'Blastoise': case 'Butterfree': case 'Copperajah': case 'Grimmsnarl': case 'Inteleon': case 'Rillaboom': case 'Snorlax': case 'Urshifu':
+			case 'Appletun': case 'Blastoise': case 'Butterfree': case 'Copperajah': case 'Grimmsnarl':
+			case 'Inteleon': case 'Rillaboom': case 'Snorlax': case 'Urshifu':
 				if (this.gen >= 8 && this.randomChance(1, 2)) continue;
 				break;
 			}
@@ -1539,7 +1801,7 @@ export class RandomTeams {
 			if (typeComboCount[typeCombo] >= (isMonotype ? 2 : 1)) continue;
 
 			// The Pokemon of the Day
-			if (!!potd && potd.exists && pokemon.length === 1) species = potd;
+			if (potd?.exists && pokemon.length === 1) species = potd;
 
 			const set = this.randomSet(species, teamDetails, pokemon.length === 0, this.format.gameType !== 'singles');
 
@@ -1548,7 +1810,7 @@ export class RandomTeams {
 
 			if (pokemon.length === 6) {
 				// Set Zoroark's level to be the same as the last Pokemon
-				const illusion = teamDetails['illusion'];
+				const illusion = teamDetails.illusion;
 				if (illusion) pokemon[illusion - 1].level = pokemon[5].level;
 
 				// Don't bother tracking details for the 6th Pokemon
@@ -1580,20 +1842,22 @@ export class RandomTeams {
 			}
 
 			// Track what the team has
-			if (set.ability === 'Drizzle' || set.moves.includes('raindance')) teamDetails['rain'] = 1;
-			if (set.ability === 'Drought' || set.moves.includes('sunnyday')) teamDetails['sun'] = 1;
-			if (set.ability === 'Sand Stream') teamDetails['sand'] = 1;
-			if (set.ability === 'Snow Warning') teamDetails['hail'] = 1;
-			if (set.moves.includes('spikes')) teamDetails['spikes'] = (teamDetails['spikes'] || 0) + 1;
-			if (set.moves.includes('stealthrock')) teamDetails['stealthRock'] = 1;
-			if (set.moves.includes('stickyweb')) teamDetails['stickyWeb'] = 1;
-			if (set.moves.includes('toxicspikes')) teamDetails['toxicSpikes'] = 1;
-			if (set.moves.includes('defog')) teamDetails['defog'] = 1;
-			if (set.moves.includes('rapidspin')) teamDetails['rapidSpin'] = 1;
-			if (set.moves.includes('auroraveil') || set.moves.includes('reflect') && set.moves.includes('lightscreen')) teamDetails['screens'] = 1;
+			if (set.ability === 'Drizzle' || set.moves.includes('raindance')) teamDetails.rain = 1;
+			if (set.ability === 'Drought' || set.moves.includes('sunnyday')) teamDetails.sun = 1;
+			if (set.ability === 'Sand Stream') teamDetails.sand = 1;
+			if (set.ability === 'Snow Warning') teamDetails.hail = 1;
+			if (set.moves.includes('spikes')) teamDetails.spikes = (teamDetails.spikes || 0) + 1;
+			if (set.moves.includes('stealthrock')) teamDetails.stealthRock = 1;
+			if (set.moves.includes('stickyweb')) teamDetails.stickyWeb = 1;
+			if (set.moves.includes('toxicspikes')) teamDetails.toxicSpikes = 1;
+			if (set.moves.includes('defog')) teamDetails.defog = 1;
+			if (set.moves.includes('rapidspin')) teamDetails.rapidSpin = 1;
+			if (set.moves.includes('auroraveil') || (set.moves.includes('reflect') && set.moves.includes('lightscreen'))) {
+				teamDetails.screens = 1;
+			}
 
 			// For setting Zoroark's level
-			if (set.ability === 'Illusion') teamDetails['illusion'] = pokemon.length;
+			if (set.ability === 'Illusion') teamDetails.illusion = pokemon.length;
 		}
 		if (pokemon.length < 6) throw new Error(`Could not build a random team for ${this.format} (seed=${seed})`);
 
@@ -1686,20 +1950,21 @@ export class RandomTeams {
 			moves.push(setData.moveVariants ? moveSlot[setData.moveVariants[i]] : this.sample(moveSlot));
 		}
 
+		const setDataAbility = Array.isArray(setData.set.ability) ? this.sample(setData.set.ability) : setData.set.ability;
 		return {
 			name: setData.set.nickname || setData.set.name || species.baseSpecies,
 			species: setData.set.species,
 			gigantamax: setData.set.gigantamax,
 			gender: setData.set.gender || species.gender || (this.randomChance(1, 2) ? 'M' : 'F'),
 			item: (Array.isArray(setData.set.item) ? this.sample(setData.set.item) : setData.set.item) || '',
-			ability: (Array.isArray(setData.set.ability) ? this.sample(setData.set.ability) : setData.set.ability) || species.abilities['0'],
+			ability: setDataAbility || species.abilities['0'],
 			shiny: typeof setData.set.shiny === 'undefined' ? this.randomChance(1, 1024) : setData.set.shiny,
 			level: setData.set.level || 50,
 			happiness: typeof setData.set.happiness === 'undefined' ? 255 : setData.set.happiness,
 			evs: {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0, ...setData.set.evs},
 			ivs: {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31, ...setData.set.ivs},
 			nature: setData.set.nature || 'Serious',
-			moves: moves,
+			moves,
 		};
 	}
 
@@ -1820,10 +2085,7 @@ export class RandomTeams {
 			for (const typeName in this.dex.data.TypeChart) {
 				// Cover any major weakness (3+) with at least one resistance
 				if (teamData.resistances[typeName] >= 1) continue;
-				if (
-					resistanceAbilities[abilityData.id] && resistanceAbilities[abilityData.id].includes(typeName) ||
-					!this.dex.getImmunity(typeName, types)
-				) {
+				if (resistanceAbilities[abilityData.id]?.includes(typeName) || !this.dex.getImmunity(typeName, types)) {
 					// Heuristic: assume that Pokémon with these abilities don't have (too) negative typing.
 					teamData.resistances[typeName] = (teamData.resistances[typeName] || 0) + 1;
 					if (teamData.resistances[typeName] >= 1) teamData.weaknesses[typeName] = 0;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1646,12 +1646,11 @@ export class RandomTeams {
 		const srWeakness = srImmunity ? 0 : this.dex.getEffectiveness('Rock', species);
 		while (evs.hp > 1) {
 			const hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
-			const multipleOfFourNecessary = (
-				hasMove['substitute'] ||
+			const multipleOfFourNecessary = (hasMove['substitute'] && (
 				item === 'Sitrus Berry' ||
 				ability === 'Power Construct' ||
 				(hasMove['bellydrum'] && item === 'Salac Berry')
-			);
+			));
 			if (multipleOfFourNecessary) {
 				// Two Substitutes should activate Sitrus Berry
 				if (hp % 4 === 0) break;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -26,7 +26,7 @@ const RecoveryMove = [
 	'healorder', 'milkdrink', 'moonlight', 'morningsun', 'recover', 'roost', 'shoreup', 'slackoff', 'softboiled', 'strengthsap', 'synthesis',
 ];
 // Moves that drop stats:
-const StatDroppingMoves = [
+const ContraryMoves = [
 	'closecombat', 'leafstorm', 'overheat', 'superpower', 'vcreate',
 ];
 // Moves that boost Attack:
@@ -648,7 +648,7 @@ export class RandomTeams {
 
 			// Moves that change stats:
 			if (RecoveryMove.includes(moveid)) counter.recovery++;
-			if (StatDroppingMoves.includes(moveid)) counter.contrary++;
+			if (ContraryMoves.includes(moveid)) counter.contrary++;
 			if (PhysicalSetup.includes(moveid)) {
 				counter.physicalsetup++;
 				counter.setupType = 'Physical';


### PR DESCRIPTION
This PR
- Brings all Random Battles code up to the standard 120-charaacter line length limit
- Improves readability for all Random Battles code
- Refactors current-gen Random Battles team generation to be more modular and readable

Ideas for the future:
- Further refactors (I'm waiting on this until I'm more familiar with the codebase)
- Possibly adding unit tests
- Ideally, properly divorcing code and data like Battle Factory has

cc @KrisXV @ACakeWearingAHat