### PR TITLE
Focus Punch can't be Flinched

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -5484,6 +5484,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 					pokemon.volatiles['focuspunch'].lostFocus = true;
 				}
 			},
+			onTryAddVolatile(status, pokemon) {
+				if (status.id === 'flinch') return null;
+			},
 		},
 		secondary: null,
 		target: "normal",

--- a/test/sim/moves/fakeout.js
+++ b/test/sim/moves/fakeout.js
@@ -57,4 +57,14 @@ describe('Fake Out', function () {
 		battle.makeChoices('move fakeout', 'move swift');
 		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
+
+	it('should not flinch if the target had prepared to Focus Punch', function () {
+		battle = common.createBattle([[
+			{species: 'Hitmontop', ability: 'steadfast', moves: ['fakeout']},
+		], [
+			{species: 'Gallade', ability: 'steadfast', moves: ['focuspunch']},
+		]]);
+		battle.makeChoices();
+		assert.equal(battle.p2.active[0].boosts.spe, 0);
+	});
 });


### PR DESCRIPTION
As researched by @DaWoblefet.

Although you lose focus, you are never flinched, and can still move normally by way of Dancer, but on the other hand you lose out on the Steadfast boost.