### PR TITLE
Usersearch: Make page forcerenames log to staff

### DIFF
--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -1537,7 +1537,7 @@ export const commands: ChatCommands = {
 	],
 
 	fr: 'forcerename',
-	forcerename(target, room, user, connection, cmd) {
+	forcerename(target, room, user) {
 		if (!target) return this.parse('/help forcerename');
 
 		const reason = this.splitTarget(target, true);

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -1537,9 +1537,11 @@ export const commands: ChatCommands = {
 	],
 
 	fr: 'forcerename',
-	forcerename(target, room, user) {
+	forcerenameinstaff: 'forcerename',
+	forcerename(target, room, user, connection, cmd) {
 		if (!target) return this.parse('/help forcerename');
 
+		if (cmd.endsWith('staff') && Rooms.search('staff')) room = this.room = Rooms.search('staff')!;
 		const reason = this.splitTarget(target, true);
 		const targetUser = this.targetUser;
 		const targetID = toID(this.targetUsername);

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -1537,6 +1537,7 @@ export const commands: ChatCommands = {
 	],
 
 	fr: 'forcerename',
+	frinstaff: 'forcerename',
 	forcerenameinstaff: 'forcerename',
 	forcerename(target, room, user, connection, cmd) {
 		if (!target) return this.parse('/help forcerename');

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -1537,12 +1537,9 @@ export const commands: ChatCommands = {
 	],
 
 	fr: 'forcerename',
-	frinstaff: 'forcerename',
-	forcerenameinstaff: 'forcerename',
 	forcerename(target, room, user, connection, cmd) {
 		if (!target) return this.parse('/help forcerename');
 
-		if (cmd.endsWith('staff') && Rooms.search('staff')) room = this.room = Rooms.search('staff')!;
 		const reason = this.splitTarget(target, true);
 		const targetUser = this.targetUser;
 		const targetID = toID(this.targetUsername);

--- a/server/chat-plugins/usersearch.ts
+++ b/server/chat-plugins/usersearch.ts
@@ -11,7 +11,7 @@ function searchUsernames(target: string, page = false) {
 	for (const curUser of Users.users.values()) {
 		if (!curUser.id.includes(target) || curUser.id.startsWith('guest')) continue;
 		const escapedName = Utils.escapeHTML(curUser.name);
-		const buttonHTML = `<button class="button" name="send" value="/forcerename ${escapedName}&#10;/j view-usersearch-${target}">Forcerename</button>`;
+		const buttonHTML = `<button class="button" name="send" value="/forcerenameinstaff ${escapedName}&#10;/j view-usersearch-${target}">Forcerename</button>`;
 		if (curUser.connected) {
 			results.online.push(`${ONLINE_SYMBOL} ${page ? `<username>` : ``}${escapedName}${page ? `</username> ${buttonHTML}` : ``}`);
 		} else {
@@ -89,7 +89,7 @@ export const pages: PageTable = {
 	usersearch(query, user) {
 		this.checkCan('lock');
 		if (!query.length) return this.close();
-		this.title = `Usersearch (${query[0]})`;
+		this.title = `[Usersearch] ${query[0]}`;
 		const target = toID(query[0]);
 		return searchUsernames(target, true);
 	},

--- a/server/chat-plugins/usersearch.ts
+++ b/server/chat-plugins/usersearch.ts
@@ -11,7 +11,7 @@ function searchUsernames(target: string, page = false) {
 	for (const curUser of Users.users.values()) {
 		if (!curUser.id.includes(target) || curUser.id.startsWith('guest')) continue;
 		const escapedName = Utils.escapeHTML(curUser.name);
-		const buttonHTML = `<button class="button" name="send" value="/forcerenameinstaff ${escapedName}&#10;/j view-usersearch-${target}">Forcerename</button>`;
+		const buttonHTML = `<button class="button" name="send" value="/msgroom staff,/fr ${escapedName}&#10;/j view-usersearch-${target}">Forcerename</button>`;
 		if (curUser.connected) {
 			results.online.push(`${ONLINE_SYMBOL} ${page ? `<username>` : ``}${escapedName}${page ? `</username> ${buttonHTML}` : ``}`);
 		} else {


### PR DESCRIPTION
(I also fixed the title @mia-pi-git yw)

approved/requested by aeonic

While this isn't the most optimal solution, it's probably the best at the moment because it a) solves the issue of all /forcerenames for users in Lobby being parsed from the usersearch pages log to Lobby (this isn't good because it clutters the Lobby's modlog and causes their roomstaff to see things they shouldn't have to) and all /forcerenames from staff not in Lobby being PMed to ~, which is annoying for different reasons such as unnecessarily opening a new pm, and b) allows people to run `/frinstaff` to tackle obscene names outside of Usersearch pages before roomstaff have to see those names while shaving off a few additional seconds that it would normally take to copy the name and switch to the Staff room.