### PR TITLE
Random Battles Bugfixes

### DIFF
--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -782,7 +782,7 @@ export class RandomTeams {
 		// Set up once and only if we have the moves for it
 		case 'bellydrum': case 'bulkup': case 'coil': case 'curse': case 'dragondance': case 'honeclaws': case 'swordsdance':
 			if (counter.setupType !== 'Physical') return {cull: true}; // if we're not setting up physically this is pointless
-			if (counter.Physical + counter.physicalpool < 2 && hasRestTalk) return {cull: true};
+			if (counter.Physical + counter.physicalpool < 2 && !hasRestTalk) return {cull: true};
 			if (move.id === 'swordsdance' && hasMove['dragondance']) return {cull: true}; // Dragon Dance is judged as better
 
 			return {cull: false, isSetup: true};
@@ -999,7 +999,7 @@ export class RandomTeams {
 			break;
 		case 'stoneedge':
 			const gutsCullCondition = hasAbility['Guts'] && (!hasMove['dynamicpunch'] || hasMove['spikes']);
-			const rockSlidePlusStatusPossible = counter.Status && movePool.includes('rockslide');
+			const rockSlidePlusStatusPossible = !isDoubles && counter.Status && movePool.includes('rockslide');
 			return {cull: gutsCullCondition || rockSlidePlusStatusPossible || hasMove['rockblast'] || hasMove['rockslide']};
 		case 'poltergeist':
 			// Special case for Dhelmise in Doubles, which doesn't want both
@@ -1045,6 +1045,8 @@ export class RandomTeams {
 			return {cull: hasMove['throatchop'] || (hasMove['stoneedge'] && !hasType['Rock'])};
 		case 'reflect': case 'lightscreen':
 			return {cull: !!teamDetails.screens};
+		case 'slackoff':
+			return {cull: species.id === 'slowking' && !hasMove['scald']};
 		case 'substitute':
 			const moveBasedCull = ['bulkup', 'painsplit', 'roost'].some(m => movePool.includes(m));
 			const doublesPowerWhip = isDoubles && movePool.includes('powerwhip');
@@ -1265,7 +1267,7 @@ export class RandomTeams {
 		}
 		if (species.name === 'Shuckle' && hasMove['stickyweb']) return 'Mental Herb';
 		if (species.name === 'Unfezant' || hasMove['focusenergy']) return 'Scope Lens';
-		if (species.name === 'Eiscue' && hasMove['substitute']) return 'Salac Berry';
+		if (hasMove['bellydrum'] && hasMove['substitute']) return 'Salac Berry';
 
 		// Misc item generation logic
 		if (species.evos.length && !hasMove['uturn']) return 'Eviolite';
@@ -1577,8 +1579,8 @@ export class RandomTeams {
 					// This move might not be beneficial
 					if (
 						(!counter.stab && counter.physicalpool + counter.specialpool > 0) ||
-						// I have no idea why Swords Dance shares a rejection checker with Flying types
-						(hasMove['swordsdance'] && runRejectionChecker('Flying')) ||
+						// To make sure Swords Dance Mew gets Brave Bird
+						(hasMove['swordsdance'] && species.id === 'mew' && runRejectionChecker('Flying')) ||
 						(hasAbility['steelworker'] && runRejectionChecker('Steel')) ||
 						(!isDoubles && runRejectionChecker('recovery')) ||
 						runRejectionChecker('screens') ||

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -999,8 +999,9 @@ export class RandomTeams {
 			break;
 		case 'stoneedge':
 			const gutsCullCondition = hasAbility['Guts'] && (!hasMove['dynamicpunch'] || hasMove['spikes']);
-			const rockSlidePlusStatusPossible = !isDoubles && counter.Status && movePool.includes('rockslide');
-			return {cull: gutsCullCondition || rockSlidePlusStatusPossible || hasMove['rockblast'] || hasMove['rockslide']};
+			const rockSlidePlusStatusPossible = counter.Status && movePool.includes('rockslide');
+			const otherRockMove = hasMove['rockblast'] || hasMove['rockslide'];
+			return {cull: gutsCullCondition || (!isDoubles && rockSlidePlusStatusPossible) || otherRockMove};
 		case 'poltergeist':
 			// Special case for Dhelmise in Doubles, which doesn't want both
 			return {cull: hasMove['knockoff']};


### PR DESCRIPTION
Patch notes (2/15/2021):
Prevent Air Slash from generating on Swords Dance Virizion by further specifying a line in move enforcement (credit to @AnnikaCodes for this one)
Prevent Scaldless Slowking
Make Darmanitan-Zen-Galar get Salac Berry instead of Sitrus Berry
Make Stone Edge more likely to generate in Random Doubles (formerly erroneously uncommon due to a singles rejection)
Fix RestTalk setup sweepers from rejecting the setup move erroneously (affects Type: Null, Throh, Suicune, etc.)