### PR TITLE
Make Scalemons apply before Tier Shift when they are mashed up

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1129,6 +1129,7 @@ export const Formats: FormatList = [
 		searchShow: false,
 		ruleset: ['Standard', 'Dynamax Clause'],
 		banlist: ['Blissey', 'Chansey', 'Toxapex', 'Uber > 1', 'AG ++ Uber > 1', 'Arena Trap', 'Huge Power', 'Moody', 'Pure Power', 'Shadow Tag', 'Baton Pass'],
+		onModifySpeciesPriority: 3,
 		onModifySpecies(species, target, source) {
 			if (source || !target || !target.side) return;
 			const god = target.side.team.find(set => {

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1163,6 +1163,7 @@ export const Formats: {[k: string]: FormatData} = {
 		onBegin() {
 			this.add('rule', '350 Cup Mod: If a Pokemon\'s BST is 350 or lower, all of its stats get doubled.');
 		},
+		onModifySpeciesPriority: 2,
 		onModifySpecies(species) {
 			const newSpecies = this.dex.deepClone(species);
 			if (newSpecies.bst <= 350) {
@@ -1182,6 +1183,7 @@ export const Formats: {[k: string]: FormatData} = {
 		onBegin() {
 			this.add('rule', 'Flipped Mod: Pokemon have their stats flipped (HP becomes Spe, vice versa).');
 		},
+		onModifySpeciesPriority: 2,
 		onModifySpecies(species) {
 			const newSpecies = this.dex.deepClone(species);
 			const reversedNums = Object.values(newSpecies.baseStats).reverse();
@@ -1198,6 +1200,7 @@ export const Formats: {[k: string]: FormatData} = {
 		onBegin() {
 			this.add('rule', 'Scalemons Mod: Every Pokemon\'s stats, barring HP, are scaled to come as close to a BST of 600 as possible');
 		},
+		onModifySpeciesPriority: 1,
 		onModifySpecies(species) {
 			const newSpecies = this.dex.deepClone(species);
 			const bstWithoutHp: number = newSpecies.bst - newSpecies.baseStats['hp'];

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -219,6 +219,7 @@ export class Format extends BasicEffect implements Readonly<BasicEffect> {
 	readonly onChangeSet?: (
 		this: TeamValidator, set: PokemonSet, format: Format, setHas?: AnyObject, teamHas?: AnyObject
 	) => string[] | void;
+	readonly onModifySpeciesPriority?: number;
 	readonly onModifySpecies?: (
 		this: Battle, species: Species, target?: Pokemon, source?: Pokemon, effect?: Effect
 	) => Species | void;


### PR DESCRIPTION
Without a priority, the two event handlers run in random order, which is frustrating the OM mashup community, as Tier Shift Scalemons gives completely different results to Scalemons Tier Shift.

I also added priorities to Flipped and 350 Cup for consistency, although they're not mashed up enough for anyone to care that strongly about it.