### PR TITLE
Use HP 100ths in Gen 8 formats

### DIFF
--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1804,7 +1804,7 @@ export class Pokemon {
 		const ratio = this.hp / this.maxhp;
 		if (this.battle.reportExactHP) {
 			shared = secret;
-		} else if (this.battle.reportPercentages) {
+		} else if (this.battle.reportPercentages || this.battle.gen >= 8) {
 			// HP Percentage Mod mechanics
 			let percentage = Math.ceil(ratio * 100);
 			if ((percentage === 100) && (ratio < 1.0)) {


### PR DESCRIPTION
This affects any cartridge-based formats (aka formats not using HP Percentage Mod), such as VGC in Gen 8 only. The current 48ths system was implementing to accurately simulate games where the HP bar was represented with 48 pixels. By Gen 7, we were already using different amounts (99 in SM and 86 in USUM), but I didn't really bother too much about it because the ability to fine-tune HP to such narrow percentages by looking at it would be very challenging and not very rewarding. However, with the Switch comes resolutions of ~267px for HP bars when docked. An attuned player can realistically tell the difference between, say, Sandstorm KO range in Dynamax and it missing the KO, [which 48ths do not let you do](https://replay.pokemonshowdown.com/gen8vgc2021-1276445737-826pswmft5tid0kyjn51ei1fls2dhunpw). I'm also assuming undocked here; a docked Switch with a good res makes it even clearer and more obvious.

A number of VGC players have remarked to me about HP imprecision on Showdown messing up their games when they'd have more precision on cart. I think 100ths is a fairly straightforward solution; you aren't going to actually know the full 267px resolution without a capture card and external tool helping, but 100ths seems very reasonable as a good compromise.