### PR TITLE
Hangman: Correctly check guesses with non-alphabetic answer

### DIFF
--- a/server/chat-plugins/hangman.ts
+++ b/server/chat-plugins/hangman.ts
@@ -113,7 +113,7 @@ export class Hangman extends Rooms.RoomGame {
 	}
 
 	guessWord(word: string, guesser: string) {
-		const ourWord = toID(this.word);
+		const ourWord = toID(this.word.replace(/[^A-Za-z ]/g, ''));
 		const guessedWord = toID(word);
 		if (ourWord === guessedWord) {
 			for (const [i, letter] of this.wordSoFar.entries()) {


### PR DESCRIPTION
Currently word guesses on hangmans with non-alphabetic characters in the answer check the length of the sanitized guess against the unsanitized answer, leading to correct answers being rejected as invalid.