### PR TITLE
Random Battles Bugfixes

### DIFF
--- a/data/mods/gen2/formats-data.ts
+++ b/data/mods/gen2/formats-data.ts
@@ -498,7 +498,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "UU",
 	},
 	tauros: {
-		randomBattleMoves: ["curse", "doubleedge", "earthquake", "quickattack", "rest", "return", "sleeptalk"],
+		randomBattleMoves: ["curse", "doubleedge", "earthquake", "rest", "return", "sleeptalk"],
 		tier: "UUBL",
 	},
 	magikarp: {

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -277,12 +277,13 @@ export class RandomGen3Teams extends RandomGen4Teams {
 					break;
 				case 'hiddenpower':
 					if (move.type === 'Grass' && hasMove['sunnyday'] && hasMove['solarbeam']) rejected = true;
-					if (
-						hasType[move.type] &&
-						((hasMove['substitute'] && !counter.setupType && !hasMove['toxic']) ||
+					if (hasType[move.type] && (
+						(hasMove['substitute'] && !counter.setupType && !hasMove['toxic']) ||
 						(hasMove['toxic'] && !hasMove['substitute']) ||
-						restTalk)
-					) rejected = true;
+						restTalk
+					)) {
+						rejected = true;
+					}
 					break;
 				case 'brickbreak': case 'crosschop': case 'highjumpkick': case 'skyuppercut':
 					if (hasMove['substitute'] && (hasMove['focuspunch'] || movePool.includes('focuspunch'))) rejected = true;

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -236,7 +236,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 					if (
 						counter.setupType ||
 						counter.speedsetup ||
-						['endure', 'raindance', 'substitute', 'yawn', 'hypnosis'].some(m => hasMove[m])
+						['endure', 'focuspunch', 'raindance', 'yawn', 'hypnosis'].some(m => hasMove[m])
 					) rejected = true;
 					break;
 				case 'trick':
@@ -277,7 +277,12 @@ export class RandomGen3Teams extends RandomGen4Teams {
 					break;
 				case 'hiddenpower':
 					if (move.type === 'Grass' && hasMove['sunnyday'] && hasMove['solarbeam']) rejected = true;
-					if (!hasType[move.type] && (hasMove['substitute'] || hasMove['toxic'] || restTalk)) rejected = true;
+					if (
+						hasType[move.type] &&
+						((hasMove['substitute'] && !counter.setupType && !hasMove['toxic']) ||
+						(hasMove['toxic'] && !hasMove['substitute']) ||
+						restTalk)
+					) rejected = true;
 					break;
 				case 'brickbreak': case 'crosschop': case 'highjumpkick': case 'skyuppercut':
 					if (hasMove['substitute'] && (hasMove['focuspunch'] || movePool.includes('focuspunch'))) rejected = true;
@@ -302,7 +307,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 					!move.weather &&
 					(move.category !== 'Status' || !move.flags.heal) &&
 					(counter.setupType || !move.stallingMove) &&
-					!['batonpass', 'sleeptalk', 'substitute'].includes(moveid)
+					!['batonpass', 'sleeptalk', 'solarbeam', 'substitute', 'sunnyday'].includes(moveid)
 				) && (
 					// Pokemon should have moves that benefit their attributes
 					(
@@ -325,7 +330,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 					(hasType['Water'] && !counter['Water'] && counter.setupType !== 'Physical' && species.baseStats.spa >= 60) ||
 					(movePool.includes('meteormash') || movePool.includes('spore')) ||
 					(hasMove['protect'] && movePool.includes('wish')) ||
-					(hasMove['substitute'] && movePool.includes('morningsun')) ||
+					(hasMove['substitute'] && movePool.includes('morningsun') || movePool.includes('recover')) ||
 					(hasMove['sunnyday'] && movePool.includes('solarbeam'))
 				)) {
 					// Reject Status, non-STAB, or low basepower moves
@@ -459,9 +464,9 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			item = 'Liechi Berry';
 		} else if ((hasMove['substitute'] || hasMove['raindance']) && counter.Special >= 3) {
 			item = 'Petaya Berry';
-		} else if (counter.Physical >= 4) {
+		} else if (counter.Physical >= 4 && !hasMove['fakeout']) {
 			item = 'Choice Band';
-		} else if (counter.Physical >= 3 && (
+		} else if (counter.Physical >= 3 && !hasMove['rapidspin'] && (
 			['firepunch', 'icebeam', 'overheat'].some(m => hasMove[m]) ||
 			(moves.filter(m => this.dex.data.Moves[m].category === 'Special' && hasType[this.dex.data.Moves[m].type]).length)
 		)) {

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -338,12 +338,15 @@ export class RandomGen4Teams extends RandomGen5Teams {
 				case 'shadowclaw':
 					if (hasMove['shadowforce'] || hasMove['suckerpunch'] && !hasType['Ghost']) rejected = true;
 					break;
-				case 'dragonclaw':
-					if (hasMove['outrage']) rejected = true;
-					break;
 				case 'dracometeor':
 					if (hasMove['calmmind'] || restTalk) rejected = true;
 					if (counter.setupType && counter.stab < 2) rejected = true;
+					break;
+				case 'dragonclaw':
+					if (hasMove['outrage']) rejected = true;
+					break;
+				case 'dragonpulse':
+					if (hasMove['dracometeor'] && hasMove['outrage']) rejected = true;
 					break;
 				case 'crunch': case 'nightslash':
 					if (hasMove['suckerpunch']) rejected = true;

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -634,7 +634,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			item = 'Leftovers';
 		} else if (forme === 'Palkia' && (hasMove['dracometeor'] || hasMove['spacialrend']) && hasMove['hydropump']) {
 			item = 'Lustrous Orb';
-		} else if (counter.damagingMoves.length >= 4) {
+		} else if (counter.damagingMoves.length >= 4 && ability !== 'Sturdy') {
 			item = (forme === 'Deoxys-Attack' || counter['Normal'] || !!counter['priority']) ? 'Life Orb' : 'Expert Belt';
 		} else if (
 			isLead &&
@@ -647,6 +647,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		} else if (
 			counter.damagingMoves.length >= 3 &&
 			species.baseStats.spe >= 40 &&
+			species.baseStats.hp + species.baseStats.def + species.baseStats.spd <= 275 &&
 			ability !== 'Sturdy' &&
 			!hasMove['rapidspin'] && !hasMove['uturn']
 		) {

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1245,7 +1245,7 @@ export class RandomTeams {
 		isDoubles: boolean
 	) {
 		// not undefined — we want "no item" not "go find a different item"
-		if (hasMove['acrobatics']) return ability === 'Grassy Surge' ? 'Grassy Seed' : '';
+		if (hasMove['acrobatics'] && ability !== 'Ripen') return ability === 'Grassy Surge' ? 'Grassy Seed' : '';
 		if (hasMove['geomancy'] || hasMove['meteorbeam']) return 'Power Herb';
 		if (hasMove['shellsmash']) return (ability === 'Sturdy' && !isLead && !isDoubles) ? 'Heavy-Duty Boots' : 'White Herb';
 		// Species-specific logic


### PR DESCRIPTION
Patch Notes (2/19/2021):
Gen 2 Random Battle: remove Quick Attack from Tauros to prevent bad sets

Gen 3 Random Battle:
Allow Hidden Power to exist alongside Substitute if the user also has Calm Mind or Toxic (to help prevent garbage sets like double fire move Rapidash or mono-Solarbeam Entei)
Allow Toxic to exist alongside Substitute (again, to help prevent garbage sets on Pokemon like Rapidash)
Prevent Sunny Day from being rejected in favor of a STAB move, to fix mono-Solarbeam on several (but not all) Pokemon.
Prevent Choice Band Fake Out, as well as Choice Band Rapid Spin + one special attack

Gen 4 Random Battle: reject Dragon Pulse if the user also has Draco Meteor and Outrage to prevent triple dragon move sets, and do a little alphabetization.

Gen 5 Random Battle: 
Add a maximum base bulk (HP+DEF+SPD) of 275 to generate Life Orb. Pokemon above this will have Leftovers.
Prevent Life Orb 4 attacks Golem by preventing Sturdy from generating Life Orb.

Random Doubles: Give Acrobatics Flapple Sitrus Berry