### PR TITLE
Add and improve various move failure messages

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -3694,7 +3694,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	suctioncups: {
 		onDragOutPriority: 1,
 		onDragOut(pokemon) {
-			this.add('-activate', pokemon, 'ability: Suction Cups');
+			this.add('-immune', pokemon, 'ability: Suction Cups');
 			return null;
 		},
 		name: "Suction Cups",
@@ -3843,7 +3843,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	telepathy: {
 		onTryHit(target, source, move) {
 			if (target !== source && target.side === source.side && move.category !== 'Status') {
-				this.add('-activate', target, 'ability: Telepathy');
+				this.add('-immune', target, 'ability: Telepathy');
 				return null;
 			}
 		},

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -573,7 +573,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		onAnyTryMove(target, source, effect) {
 			if (['explosion', 'mindblown', 'mistyexplosion', 'selfdestruct'].includes(effect.id)) {
 				this.attrLastMove('[still]');
-				this.add('cant', this.effectData.target, 'ability: Damp', effect, '[of] ' + target);
+				this.add('-block', this.effectData.target, 'ability: Damp', effect, target);
 				return false;
 			}
 		},
@@ -626,7 +626,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			const dazzlingHolder = this.effectData.target;
 			if ((source.side === dazzlingHolder.side || move.target === 'all') && move.priority > 0.1) {
 				this.attrLastMove('[still]');
-				this.add('cant', dazzlingHolder, 'ability: Dazzling', move, '[of] ' + target);
+				this.add('-block', dazzlingHolder, 'ability: Queenly Majesty', move, target);
 				return false;
 			}
 		},
@@ -2830,7 +2830,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			const dazzlingHolder = this.effectData.target;
 			if ((source.side === dazzlingHolder.side || move.target === 'all') && move.priority > 0.1) {
 				this.attrLastMove('[still]');
-				this.add('cant', dazzlingHolder, 'ability: Queenly Majesty', move, '[of] ' + target);
+				this.add('-block', dazzlingHolder, 'ability: Queenly Majesty', move, target);
 				return false;
 			}
 		},

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -169,7 +169,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (['attract', 'disable', 'encore', 'healblock', 'taunt', 'torment'].includes(status.id)) {
 				if (effect.effectType === 'Move') {
 					const effectHolder = this.effectData.target;
-					this.add('-block', target, 'ability: Aroma Veil', '[of] ' + effectHolder);
+					this.add('-immune', target, 'ability: Aroma Veil', '[of] ' + effectHolder);
 				}
 				return null;
 			}
@@ -573,7 +573,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		onAnyTryMove(target, source, effect) {
 			if (['explosion', 'mindblown', 'mistyexplosion', 'selfdestruct'].includes(effect.id)) {
 				this.attrLastMove('[still]');
-				this.add('-block', this.effectData.target, 'ability: Damp', effect, target);
+				this.add('-immune', this.effectData.target, 'ability: Damp', effect, target);
 				return false;
 			}
 		},
@@ -626,7 +626,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			const dazzlingHolder = this.effectData.target;
 			if ((source.side === dazzlingHolder.side || move.target === 'all') && move.priority > 0.1) {
 				this.attrLastMove('[still]');
-				this.add('-block', dazzlingHolder, 'ability: Queenly Majesty', move, target);
+				this.add('-immune', dazzlingHolder, 'ability: Queenly Majesty', move, target);
 				return false;
 			}
 		},
@@ -1041,7 +1041,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			}
 			if (showMsg && !(effect as ActiveMove).secondaries) {
 				const effectHolder = this.effectData.target;
-				this.add('-block', target, 'ability: Flower Veil', '[of] ' + effectHolder);
+				this.add('-immune', target, 'ability: Flower Veil', '[of] ' + effectHolder);
 			}
 		},
 		onAllySetStatus(status, target, source, effect) {
@@ -1049,7 +1049,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				this.debug('interrupting setStatus with Flower Veil');
 				if (effect.id === 'synchronize' || (effect.effectType === 'Move' && !effect.secondaries)) {
 					const effectHolder = this.effectData.target;
-					this.add('-block', target, 'ability: Flower Veil', '[of] ' + effectHolder);
+					this.add('-immune', target, 'ability: Flower Veil', '[of] ' + effectHolder);
 				}
 				return null;
 			}
@@ -1058,7 +1058,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (target.hasType('Grass') && status.id === 'yawn') {
 				this.debug('Flower Veil blocking yawn');
 				const effectHolder = this.effectData.target;
-				this.add('-block', target, 'ability: Flower Veil', '[of] ' + effectHolder);
+				this.add('-immune', target, 'ability: Flower Veil', '[of] ' + effectHolder);
 				return null;
 			}
 		},
@@ -1241,7 +1241,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				this.addMove('move', pokemon, move.name);
 				this.attrLastMove('[still]');
 				this.debug("Disabled by Gorilla Tactics");
-				this.add('-fail', pokemon);
+				this.add('cant', pokemon, 'choicelock');
 				return false;
 			}
 		},
@@ -2508,7 +2508,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (!['psn', 'tox'].includes(status.id)) return;
 			if ((effect as Move)?.status) {
 				const effectHolder = this.effectData.target;
-				this.add('-block', target, 'ability: Pastel Veil', '[of] ' + effectHolder);
+				this.add('-immune', target, 'ability: Pastel Veil', '[of] ' + effectHolder);
 			}
 			return false;
 		},
@@ -2830,7 +2830,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			const dazzlingHolder = this.effectData.target;
 			if ((source.side === dazzlingHolder.side || move.target === 'all') && move.priority > 0.1) {
 				this.attrLastMove('[still]');
-				this.add('-block', dazzlingHolder, 'ability: Queenly Majesty', move, target);
+				this.add('-immune', dazzlingHolder, 'ability: Queenly Majesty', move, target);
 				return false;
 			}
 		},
@@ -3744,7 +3744,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (status.id === 'slp') {
 				this.debug('Sweet Veil interrupts sleep');
 				const effectHolder = this.effectData.target;
-				this.add('-block', target, 'ability: Sweet Veil', '[of] ' + effectHolder);
+				this.add('-immune', target, 'ability: Sweet Veil', '[of] ' + effectHolder);
 				return null;
 			}
 		},
@@ -3752,7 +3752,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (status.id === 'yawn') {
 				this.debug('Sweet Veil blocking yawn');
 				const effectHolder = this.effectData.target;
-				this.add('-block', target, 'ability: Sweet Veil', '[of] ' + effectHolder);
+				this.add('-immune', target, 'ability: Sweet Veil', '[of] ' + effectHolder);
 				return null;
 			}
 		},

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -313,7 +313,7 @@ export const Conditions: {[k: string]: ConditionData} = {
 				this.addMove('move', pokemon, move.name);
 				this.attrLastMove('[still]');
 				this.debug("Disabled by Choice item lock");
-				this.add('-fail', pokemon);
+				this.add('cant', pokemon, 'choicelock');
 				return false;
 			}
 		},
@@ -478,7 +478,7 @@ export const Conditions: {[k: string]: ConditionData} = {
 		onTryMove(attacker, defender, move) {
 			if (move.type === 'Fire' && move.category !== 'Status') {
 				this.debug('Primordial Sea fire suppress');
-				this.add('-fail', attacker, move, '[from] Primordial Sea');
+				this.add('-immune', attacker, move, '[from] Primordial Sea');
 				this.attrLastMove('[still]');
 				return null;
 			}
@@ -552,7 +552,7 @@ export const Conditions: {[k: string]: ConditionData} = {
 		onTryMove(attacker, defender, move) {
 			if (move.type === 'Water' && move.category !== 'Status') {
 				this.debug('Desolate Land water suppress');
-				this.add('-fail', attacker, move, '[from] Desolate Land');
+				this.add('-immune', attacker, move, '[from] Desolate Land');
 				this.attrLastMove('[still]');
 				return null;
 			}

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -711,7 +711,7 @@ export const Conditions: {[k: string]: ConditionData} = {
 		},
 		onDragOutPriority: 2,
 		onDragOut(pokemon) {
-			this.add('-block', pokemon, 'Dynamax');
+			this.add('-immune', pokemon, 'Dynamax');
 			return null;
 		},
 		onResidualPriority: -100,

--- a/data/items.ts
+++ b/data/items.ts
@@ -4763,7 +4763,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		onTryHit(pokemon, source, move) {
 			if (move.flags['powder'] && pokemon !== source && this.dex.getImmunity('powder', pokemon)) {
-				this.add('-activate', pokemon, 'item: Safety Goggles', move.name);
+				this.add('-immune', pokemon, 'item: Safety Goggles', move.name);
 				return null;
 			}
 		},

--- a/data/mods/gen5/moves.ts
+++ b/data/mods/gen5/moves.ts
@@ -829,12 +829,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	soak: {
 		inherit: true,
 		onHit(target) {
-			if (!target.setType('Water')) {
-				// Soak should animate even when it fails.
-				// Returning false would suppress the animation.
-				this.add('-fail', target);
-				return null;
-			}
+			if (!target.setType('Water')) return false;
 			this.add('-start', target, 'typechange', 'Water');
 		},
 	},

--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -839,6 +839,18 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	soak: {
+		inherit: true,
+		onHit(target) {
+			if (target.getTypes().join() === 'Water' || !target.setType('Water')) {
+				// Soak should animate even when it fails.
+				// Returning false would suppress the animation.
+				this.add('-fail', target);
+				return null;
+			}
+			this.add('-start', target, 'typechange', 'Water');
+		},
+	},
 	sonicboom: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -10157,7 +10157,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 
 			// Additional Gravity check for Z-move variant
 			if (this.field.getPseudoWeather('Gravity')) {
-				this.add('cant', source, 'move: Gravity', move);
+				this.add('-fail', source, 'move: Gravity', move);
 				return null;
 			}
 		},
@@ -12732,7 +12732,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		onHit(target, source) {
 			if (source.side === target.side) {
 				if (!this.heal(Math.floor(target.baseMaxhp * 0.5))) {
-					this.add('-immune', target);
+					this.add('-fail', target);
 				}
 			}
 		},
@@ -15173,7 +15173,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		onTryMove(pokemon) {
 			if (!pokemon.volatiles['shelltrap']?.gotHit) {
 				this.attrLastMove('[still]');
-				this.add('cant', pokemon, 'Shell Trap', 'Shell Trap');
+				this.add('-fail', pokemon, 'Shell Trap', 'Shell Trap');
 				return null;
 			}
 		},
@@ -16504,7 +16504,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		onTry(source, target, move) {
 			// Additional Gravity check for Z-move variant
 			if (this.field.getPseudoWeather('Gravity')) {
-				this.add('cant', source, 'move: Gravity', move);
+				this.add('-fail', source, 'move: Gravity', move);
 				return null;
 			}
 		},
@@ -17839,7 +17839,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			// Additional Gravity check for Z-move variant
 			if (this.field.getPseudoWeather('Gravity')) {
 				this.attrLastMove('[still]');
-				this.add('cant', source, 'move: Gravity', move);
+				this.add('-fail', source, 'move: Gravity', move);
 				return null;
 			}
 		},

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2551,6 +2551,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 			const item = target.takeItem(source);
 			if (item) {
 				this.add('-enditem', target, item.name, '[from] move: Corrosive Gas', '[of] ' + source);
+			} else {
+				this.add('-fail', target, 'move: Corrosive Gas');
 			}
 		},
 		secondary: null,
@@ -17753,7 +17755,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {authentic: 1},
 		onHitField(target, source, move) {
-			let result = false;
+			this.add('-activate', source, 'move: Teatime');
+			let result = null;
 			for (const active of this.getAllActive()) {
 				if (this.runEvent('Invulnerability', active, source, move) === false) {
 					this.add('-miss', source, active);
@@ -17766,6 +17769,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 						result = true;
 					}
 				}
+			}
+			if (!result) {
+				this.add('-fail', source, '[from] ' + move);
 			}
 			return result;
 		},

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -13951,7 +13951,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {snatch: 1, heal: 1},
-		onTry(source) {
+		onTry(source, target, move) {
 			if (source.status === 'slp' || source.hasAbility('comatose')) return false;
 
 			if (source.hp === source.maxhp) {
@@ -13959,7 +13959,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				return null;
 			}
 			if (source.hasAbility(['insomnia', 'vitalspirit'])) {
-				this.add('-fail', source, '[from] ability: ' + source.getAbility().name, '[of] ' + source);
+				this.add('-fail', source, move, '[from] ability: ' + source.getAbility().name, '[of] ' + source);
 				return null;
 			}
 		},

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -13209,7 +13209,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					}
 					return;
 				}
-				this.add('-activate', target, 'move: Psychic Terrain');
+				this.add('-immune', target, 'move: Psychic Terrain');
 				return null;
 			},
 			onBasePowerPriority: 6,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -4055,7 +4055,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onSetStatus(status, target, source, effect) {
 				if (status.id === 'slp' && target.isGrounded() && !target.isSemiInvulnerable()) {
 					if (effect.id === 'yawn' || (effect.effectType === 'Move' && !effect.secondaries)) {
-						this.add('-activate', target, 'move: Electric Terrain');
+						this.add('-immune', target, 'move: Electric Terrain');
 					}
 					return false;
 				}
@@ -4063,7 +4063,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onTryAddVolatile(status, target) {
 				if (!target.isGrounded() || target.isSemiInvulnerable()) return;
 				if (status.id === 'yawn') {
-					this.add('-activate', target, 'move: Electric Terrain');
+					this.add('-immune', target, 'move: Electric Terrain');
 					return null;
 				}
 			},
@@ -7046,9 +7046,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 20,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1, nonsky: 1},
-		onTryHit(target, source, move) {
+		onTryHit(target, source) {
 			if (target.volatiles['dynamax']) {
-				this.add('-fail', source, 'move: Grass Knot', '[from] Dynamax');
+				this.add('-immune', source, 'Dynamax');
 				this.attrLastMove('[still]');
 				return null;
 			}
@@ -7935,9 +7935,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1, nonsky: 1},
-		onTryHit(target, pokemon, move) {
+		onTryHit(target, source) {
 			if (target.volatiles['dynamax']) {
-				this.add('-fail', pokemon, 'Dynamax');
+				this.add('-immune', source, 'Dynamax');
 				this.attrLastMove('[still]');
 				return null;
 			}
@@ -7992,9 +7992,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1, nonsky: 1},
-		onTryHit(target, pokemon, move) {
+		onTryHit(target, source) {
 			if (target.volatiles['dynamax']) {
-				this.add('-fail', pokemon, 'Dynamax');
+				this.add('-immune', source, 'Dynamax');
 				this.attrLastMove('[still]');
 				return null;
 			}
@@ -9019,7 +9019,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			},
 			// groundedness implemented in battle.engine.js:BattlePokemon#isGrounded
 			onDragOut(pokemon) {
-				this.add('-activate', pokemon, 'move: Ingrain');
+				this.add('-immune', pokemon, 'move: Ingrain');
 				return null;
 			},
 		},
@@ -9811,9 +9811,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 20,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		onTryHit(target, pokemon, move) {
+		onTryHit(target, source) {
 			if (target.volatiles['dynamax']) {
-				this.add('-fail', pokemon, 'Dynamax');
+				this.add('-immune', source, 'Dynamax');
 				this.attrLastMove('[still]');
 				return null;
 			}
@@ -11342,7 +11342,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 						}
 					}
 					if (showMsg && !(effect as ActiveMove).secondaries) {
-						this.add('-activate', target, 'move: Mist');
+						this.add('-immune', target, 'move: Mist');
 					}
 				}
 			},
@@ -11421,14 +11421,14 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onSetStatus(status, target, source, effect) {
 				if (!target.isGrounded() || target.isSemiInvulnerable()) return;
 				if (effect && ((effect as Move).status || effect.id === 'yawn')) {
-					this.add('-activate', target, 'move: Misty Terrain');
+					this.add('-immune', target, 'move: Misty Terrain');
 				}
 				return false;
 			},
 			onTryAddVolatile(status, target, source, effect) {
 				if (!target.isGrounded() || target.isSemiInvulnerable()) return;
 				if (status.id === 'confusion') {
-					if (effect.effectType === 'Move' && !effect.secondaries) this.add('-activate', target, 'move: Misty Terrain');
+					if (effect.effectType === 'Move' && !effect.secondaries) this.add('-immune', target, 'move: Misty Terrain');
 					return null;
 				}
 			},
@@ -14538,7 +14538,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				if (target !== source) {
 					this.debug('interrupting setStatus');
 					if (effect.id === 'synchronize' || (effect.effectType === 'Move' && !effect.secondaries)) {
-						this.add('-activate', target, 'move: Safeguard');
+						this.add('-immune', target, 'move: Safeguard');
 					}
 					return null;
 				}
@@ -14547,7 +14547,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				if (!effect || !source) return;
 				if (effect.effectType === 'Move' && effect.infiltrates && target.side !== source.side) return;
 				if ((status.id === 'confusion' || status.id === 'yawn') && target !== source) {
-					if (effect.effectType === 'Move' && !effect.secondaries) this.add('-activate', target, 'move: Safeguard');
+					if (effect.effectType === 'Move' && !effect.secondaries) this.add('-immune', target, 'move: Safeguard');
 					return null;
 				}
 			},
@@ -18742,9 +18742,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onAnySetStatus(status, pokemon) {
 				if (status.id === 'slp') {
 					if (pokemon === this.effectData.target) {
-						this.add('-fail', pokemon, 'slp', '[from] Uproar', '[msg]');
+						this.add('-immune', pokemon, 'slp', '[from] Uproar', '[msg]');
 					} else {
-						this.add('-fail', pokemon, 'slp', '[from] Uproar');
+						this.add('-immune', pokemon, 'slp', '[from] Uproar');
 					}
 					return null;
 				}

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -15170,7 +15170,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		beforeTurnCallback(pokemon) {
 			pokemon.addVolatile('shelltrap');
 		},
-		onTryMove(pokemon) {
+		onTry(pokemon) {
 			if (!pokemon.volatiles['shelltrap']?.gotHit) {
 				this.attrLastMove('[still]');
 				this.add('-fail', pokemon, 'Shell Trap', 'Shell Trap');

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -16036,12 +16036,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1, mystery: 1},
 		onHit(target) {
-			if (target.getTypes().join() === 'Water' || !target.setType('Water')) {
-				// Soak should animate even when it fails.
-				// Returning false would suppress the animation.
-				this.add('-fail', target);
-				return null;
-			}
+			if (target.getTypes().join() === 'Water' || !target.setType('Water')) return false;
 			this.add('-start', target, 'typechange', 'Water');
 		},
 		secondary: null,

--- a/data/text/abilities.ts
+++ b/data/text/abilities.ts
@@ -923,6 +923,7 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 			desc: "This Pokemon cannot be confused. Gaining this Ability while confused cures it.",
 			shortDesc: "This Pokemon cannot be confused.",
 		},
+		block: "  [POKEMON] cannot be confused!",
 	},
 	parentalbond: {
 		name: "Parental Bond",

--- a/data/text/moves.ts
+++ b/data/text/moves.ts
@@ -2903,8 +2903,8 @@ export const MovesText: {[k: string]: MoveText} = {
 		},
 
 		activate: "#shadowforce",
-		fail: "But [POKEMON] can't use the move!",
-		failWrongForme: "But [POKEMON] can't use it the way it is now!",
+		fail: "  But [POKEMON] can't use the move!",
+		failWrongForme: "  But [POKEMON] can't use it the way it is now!",
 	},
 	hyperspacehole: {
 		name: "Hyperspace Hole",

--- a/data/text/moves.ts
+++ b/data/text/moves.ts
@@ -251,6 +251,8 @@ export const MovesText: {[k: string]: MoveText} = {
 		name: "Aura Wheel",
 		desc: "Has a 100% chance to raise the user's Speed by 1 stage. If the user is a Morpeko in Full Belly Mode, this move is Electric type. If the user is a Morpeko in Hangry Mode, this move is Dark type. This move cannot be used successfully unless the user's current form, while considering Transform, is Full Belly or Hangry Mode Morpeko.",
 		shortDesc: "Morpeko: Electric; Hangry: Dark; 100% +1 Spe.",
+
+		fail: "#hyperspacefury",
 	},
 	aurorabeam: {
 		name: "Aurora Beam",
@@ -949,6 +951,7 @@ export const MovesText: {[k: string]: MoveText} = {
 		shortDesc: "Removes adjacent Pokemon's held items.",
 
 		removeItem: "  [SOURCE] corroded [POKEMON]'s [ITEM]!",
+		fail: "#healblock",
 	},
 	cosmicpower: {
 		name: "Cosmic Power",
@@ -1092,8 +1095,7 @@ export const MovesText: {[k: string]: MoveText} = {
 			shortDesc: "Causes the foe(s) to fall asleep.",
 		},
 
-		fail: "But [POKEMON] can't use the move!",
-		failWrongForme: "But [POKEMON] can't use it the way it is now!",
+		fail: "#hyperspacefury",
 	},
 	dazzlinggleam: {
 		name: "Dazzling Gleam",
@@ -1234,6 +1236,7 @@ export const MovesText: {[k: string]: MoveText} = {
 		},
 
 		start: "  [POKEMON]'s [MOVE] was disabled!",
+		cant: "  [POKEMON]'s [MOVE] is disabled!",
 		end: "  [POKEMON]'s move is no longer disabled!",
 	},
 	disarmingvoice: {
@@ -2900,7 +2903,8 @@ export const MovesText: {[k: string]: MoveText} = {
 		},
 
 		activate: "#shadowforce",
-		fail: "#darkvoid",
+		fail: "But [POKEMON] can't use the move!",
+		failWrongForme: "But [POKEMON] can't use it the way it is now!",
 	},
 	hyperspacehole: {
 		name: "Hyperspace Hole",
@@ -3410,7 +3414,7 @@ export const MovesText: {[k: string]: MoveText} = {
 		desc: "Has a 100% chance to confuse the target and lower its Defense and Special Attack by 1 stage. The user recovers 1/2 the HP lost by the target, rounded half up. If Big Root is held by the user, the HP recovered is 1.3x normal, rounded half down. The user steals the foe's boosts. If this move is successful, the weather changes to rain unless it is already in effect, and the user gains the effects of Aqua Ring and Magic Coat.",
 		shortDesc: "Does many things turn 1. Can't move turn 2.",
 
-		fail: "#darkvoid",
+		fail: "#hyperspacefury",
 	},
 	magmastorm: {
 		name: "Magma Storm",
@@ -4742,6 +4746,8 @@ export const MovesText: {[k: string]: MoveText} = {
 		gen1: {
 			desc: "The user falls asleep for the next two turns and restores all of its HP, curing itself of any non-volatile status condition in the process. This does not remove the user's stat penalty for burn or paralysis. Fails if the user has full HP.",
 		},
+		fail: "  [POKEMON] stayed awake!",
+
 	},
 	retaliate: {
 		name: "Retaliate",
@@ -6135,6 +6141,9 @@ export const MovesText: {[k: string]: MoveText} = {
 		name: "Teatime",
 		desc: "All active Pokemon consume their held Berries. This effect is not prevented by substitutes, the Klutz or Unnerve Abilities, or the effects of Embargo or Magic Room. Fails if no active Pokemon is holding a Berry.",
 		shortDesc: "All active Pokemon consume held Berries.",
+
+		activate: "  It's teatime! Everyone dug in to their Berries!",
+		fail: "  But nothing happened!",
 	},
 	technoblast: {
 		name: "Techno Blast",

--- a/test/sim/moves/gravity.js
+++ b/test/sim/moves/gravity.js
@@ -35,16 +35,17 @@ describe('Gravity', function () {
 		assert.cantMove(() => battle.makeChoices('move gravity', 'move fly'), 'Aerodactyl', 'Fly');
 	});
 
-	it('should allow the use of Z-moves of Gravity-blocked moves, but only apply their Z-effects', function () {
+	it.only(`should allow the use of Z-moves of Gravity-blocked moves, but only apply their Z-effects`, function () {
 		battle = common.gen(7).createBattle([[
-			{species: "Magikarp", ability: 'protean', item: 'normaliumz', moves: ['splash', 'sleeptalk']},
+			{species: 'Magikarp', ability: 'protean', item: 'normaliumz', moves: ['splash']},
 		], [
-			{species: "Accelgor", moves: ['gravity']},
+			{species: 'Accelgor', moves: ['gravity']},
 		]]);
 
 		battle.makeChoices('move splash zmove', 'move gravity');
-		assert.statStage(battle.p1.active[0], 'atk', 3);
-		assert(battle.log.some(line => line.includes('|cant')));
-		assert(battle.p1.active[0].hasType('Water'), "Z-Splash with Protean changed the user's type when it should not have.");
+		const magikarp = battle.p1.active[0];
+		assert.statStage(magikarp, 'atk', 3);
+		assert(battle.log.some(line => line.includes('|-fail|')));
+		assert(magikarp.hasType('Water'), `Z-Splash with Protean changed the user's type when it should not have.`);
 	});
 });

--- a/test/sim/moves/gravity.js
+++ b/test/sim/moves/gravity.js
@@ -35,7 +35,7 @@ describe('Gravity', function () {
 		assert.cantMove(() => battle.makeChoices('move gravity', 'move fly'), 'Aerodactyl', 'Fly');
 	});
 
-	it.only(`should allow the use of Z-moves of Gravity-blocked moves, but only apply their Z-effects`, function () {
+	it(`should allow the use of Z-moves of Gravity-blocked moves, but only apply their Z-effects`, function () {
 		battle = common.gen(7).createBattle([[
 			{species: 'Magikarp', ability: 'protean', item: 'normaliumz', moves: ['splash']},
 		], [

--- a/test/sim/moves/shelltrap.js
+++ b/test/sim/moves/shelltrap.js
@@ -10,43 +10,42 @@ describe('Shell Trap', function () {
 		battle.destroy();
 	});
 
-	it('should deduct PP regardless if it was successful', function () {
-		battle = common.createBattle({gameType: 'doubles'}, [
-			[
-				{species: 'Turtonator', ability: 'shellarmor', moves: ['shelltrap']},
-				{species: 'Magikarp', ability: 'swiftswim', moves: ['splash']},
-			],
-			[
-				{species: 'Turtonator', ability: 'shellarmor', moves: ['tackle', 'irondefense']},
-				{species: 'Magikarp', ability: 'swiftswim', moves: ['splash']},
-			],
-		]);
+	it(`should deduct PP regardless if it was successful`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Turtonator', moves: ['shelltrap']},
+			{species: 'Magikarp', moves: ['splash']},
+		], [
+			{species: 'Wynaut', moves: ['tackle', 'irondefense']},
+			{species: 'Magikarp', moves: ['splash']},
+		]]);
 
 		const move = battle.p1.active[0].getMoveData(Dex.getMove('shelltrap'));
 		battle.makeChoices('move shelltrap, move splash', 'move irondefense, move splash');
 		assert.equal(move.pp, move.maxpp - 1);
 
-		const cant = '|cant|p1a: Turtonator|Shell Trap|Shell Trap';
-		assert.equal(battle.log.filter(m => m === cant).length, 1);
+		const failProtocolString = '|-fail|p1a: Turtonator|Shell Trap|Shell Trap';
+		assert.equal(battle.log.filter(m => m === failProtocolString).length, 1);
 
 		battle.makeChoices('move shelltrap, move splash', 'move tackle 1, move splash');
 		assert.equal(move.pp, move.maxpp - 2);
 	});
 
-	it('should not Z-power if hit by a Z-move', function () {
-		battle = common.createBattle({}, [
-			[{species: 'Turtonator', moves: ['shelltrap']}],
-			[{species: 'Magikarp', item: 'normaliumz', moves: ['flail']}],
-		]);
+	it(`should not Z-power if hit by a Z-move`, function () {
+		battle = common.createBattle([[
+			{species: 'Turtonator', moves: ['shelltrap']},
+		], [
+			{species: 'Magikarp', item: 'normaliumz', moves: ['flail']},
+		]]);
 		battle.makeChoices('move shelltrap', 'move flail zmove');
 		assert(battle.log.some(line => line.includes('|Shell Trap|')));
 	});
 
-	it('should not Max if hit by a Max move', function () {
-		battle = common.createBattle({}, [
-			[{species: 'Turtonator', moves: ['shelltrap']}],
-			[{species: 'Magikarp', moves: ['flail']}],
-		]);
+	it(`should not Max if hit by a Max move`, function () {
+		battle = common.createBattle([[
+			{species: 'Turtonator', moves: ['shelltrap']},
+		], [
+			{species: 'Magikarp', moves: ['flail']},
+		]]);
 		battle.makeChoices('move shelltrap', 'move flail dynamax');
 		assert(battle.log.some(line => line.includes('|Shell Trap|')));
 	});


### PR DESCRIPTION
This PR does a number of small things:

- Convert Damp, Queenly Majesty, and Dazzling protocol to properly use ``-block`` protocol
- Add a failure message to Corrosive Gas
- Add the always-plays and failure message of Teatime
- Add the proper message for a Pokemon attempting to use an attack mid-Disable
- Add the proper fail message to Aura Wheel

While I'm at it, I'd like to properly add the failure messages for Rest vs. Insomnia / Vital Spirit and Own Tempo vs. confusion, but I  those require a client-side update too, so I'm drafting this for now until I figure out how to properly test my server-side changes there.