### PR TITLE
Random Battles Bugfixes

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -874,7 +874,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		tier: "LC",
 	},
 	hitmonlee: {
-		randomBattleMoves: ["closecombat", "curse", "highjumpkick", "knockoff", "machpunch", "poisonjab", "stoneedge"],
+		randomBattleMoves: ["closecombat", "curse", "highjumpkick", "knockoff", "poisonjab", "stoneedge"],
 		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["closecombat", "fakeout", "knockoff", "poisonjab", "protect", "rockslide"],
 		randomDoubleBattleLevel: 86,

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -979,7 +979,7 @@ export class RandomTeams {
 			// Turtonator wants Body Press when it doesn't have Shell Smash
 			const turtQuakeCull = species.id === 'turtonator' && movePool.includes('bodypress') && movePool.includes('shellsmash');
 			const subToxicPossible = hasMove['substitute'] && movePool.includes('toxic');
-			return {cull: turtonatorEQCull || (isDoubles && doublesCull) || subToxicPossible || hasMove['bonemerang']};
+			return {cull: turtQuakeCull || (isDoubles && doublesCull) || subToxicPossible || hasMove['bonemerang']};
 		case 'scorchingsands':
 			// Special cases for Ninetales and Palossand; prevents status redundancy
 			return {cull: hasMove['willowisp'] || hasMove['earthpower'] || (hasMove['toxic'] && movePool.includes('earthpower'))};

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -945,7 +945,7 @@ export class RandomTeams {
 			return {cull: betterIceMove || preferThunderWave || movePool.includes('bodyslam')};
 		case 'bodypress':
 			// Turtonator never wants Earthquake + Body Press, and wants EQ+Smash or Press+No Smash
-			const turtonatorCull = hasMove['earthquake'] && movePool.includes('shellsmash');
+			const turtonatorCull = species.id === 'turtonator' && hasMove['earthquake'] && movePool.includes('shellsmash');
 			const pressIncompatible = ['shellsmash', 'mirrorcoat', 'whirlwind'].some(m => hasMove[m]);
 			return {cull: turtonatorCull || pressIncompatible || counter.setupType === 'Special'};
 		case 'circlethrow':
@@ -977,9 +977,9 @@ export class RandomTeams {
 		case 'earthquake':
 			const doublesCull = hasMove['earthpower'] || hasMove['highhorsepower'];
 			// Turtonator wants Body Press when it doesn't have Shell Smash
-			const turtonatorCull2 = movePool.includes('bodypress') && movePool.includes('shellsmash');
+			const turtonatorCull = species.id === 'turtonator' && movePool.includes('bodypress') && movePool.includes('shellsmash');
 			const subToxicPossible = hasMove['substitute'] && movePool.includes('toxic');
-			return {cull: turtonatorCull2 || (isDoubles && doublesCull) || subToxicPossible || hasMove['bonemerang']};
+			return {cull: turtonatorCull || (isDoubles && doublesCull) || subToxicPossible || hasMove['bonemerang']};
 		case 'scorchingsands':
 			// Special cases for Ninetales and Palossand; prevents status redundancy
 			return {cull: hasMove['willowisp'] || hasMove['earthpower'] || (hasMove['toxic'] && movePool.includes('earthpower'))};

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1501,7 +1501,8 @@ export class RandomTeams {
 		) return 'Life Orb';
 		if (!isDoubles && counter.damagingMoves.length >= 4 && !counter.Dragon && !counter.Normal) return 'Expert Belt';
 		if (
-			!isDoubles && !hasMove['substitute'] &&
+			!isDoubles &&
+			!hasMove['substitute'] &&
 			(hasMove['dragondance'] || hasMove['swordsdance']) &&
 			(hasMove['outrage'] || (
 				['Bug', 'Fire', 'Ground', 'Normal', 'Poison'].every(type => !hasType[type]) &&

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -131,7 +131,7 @@ export class RandomTeams {
 				].some(moveid => movePool.includes(moveid))
 			),
 			Ghost: (movePool, hasMove, hasAbility, hasType, counter) => {
-				if (!counter.Ghost) return true;
+				if (!counter.Ghost && !hasType['Dark']) return true;
 				if (movePool.includes('poltergeist')) return true;
 				return movePool.includes('spectralthief') && !counter.Dark;
 			},
@@ -834,17 +834,19 @@ export class RandomTeams {
 			return {cull: counter.setupType || ['protect', 'rapidspin', 'substitute', 'uturn'].some(m => hasMove[m])};
 		case 'healingwish': case 'memento':
 			return {cull: counter.setupType || counter.recovery || hasMove['substitute'] || hasMove['uturn']};
-		case 'highjumpkick': case 'machpunch':
-			// Special case for Hitmonlee to mostly prevent non-Unburden Curse; 1% chance to fail
+		case 'highjumpkick':
+			// Special case for Hitmonlee to prevent non-Unburden Curse
 			return {cull: hasMove['curse']};
 		case 'partingshot':
 			return {cull: counter.speedsetup || hasMove['bulkup'] || hasMove['uturn']};
 		case 'protect':
 			if ((counter.setupType && !hasMove['wish'] && !isDoubles) || hasRestTalk) return {cull: true};
-			if (!isDoubles && counter.Status < 2 && !hasAbility['Hunger Switch'] && !hasAbility['Speed Boost']) return {cull: true};
+			if (!isDoubles &&
+				counter.Status < 2 && ['Hunger Switch', 'Speed Boost', 'Moody'].every(m => !hasAbility[m])
+			) return {cull: true};
 			if (movePool.includes('leechseed') || (movePool.includes('toxic') && !hasMove['wish'])) return {cull: true};
 			if (isDoubles && (
-				['bellydrum', 'fakeout', 'shellsmash', 'spore'].some(m => movePool.includes('m')) ||
+				['bellydrum', 'fakeout', 'shellsmash', 'spore'].some(m => movePool.includes(m)) ||
 				hasMove['tailwind'] || hasMove['waterspout']
 			)) return {cull: true};
 			return {cull: false};
@@ -852,7 +854,8 @@ export class RandomTeams {
 			const setup = ['curse', 'nastyplot', 'shellsmash'].some(m => hasMove[m]);
 			return {cull: !!teamDetails.rapidSpin || setup || (counter.setupType && counter.Fighting >= 2)};
 		case 'shadowsneak':
-			return {cull: hasRestTalk || ['substitute', 'trickroom', 'dualwingbeat', 'toxic'].some(m => hasMove[m])};
+			const sneakIncompatible = ['substitute', 'trickroom', 'dualwingbeat', 'toxic'].some(m => hasMove[m]);
+			return {cull: hasRestTalk || sneakIncompatible || counter.setupType === 'Special'};
 		case 'spikes':
 			return {cull: counter.setupType || (teamDetails.spikes && teamDetails.spikes > 1)};
 		case 'stealthrock':
@@ -874,21 +877,23 @@ export class RandomTeams {
 		case 'toxicspikes':
 			return {cull: counter.setupType || teamDetails.toxicSpikes};
 		case 'uturn':
-			const bugAndRecovery = hasType['Bug'] && counter.recovery;
-			return {cull: counter.speedsetup || (counter.setupType && !bugAndRecovery) || (isDoubles && hasMove['leechlife'])};
+			const bugSwordsDanceCase = hasType['Bug'] && counter.recovery && hasMove['swordsdance'];
+			return {cull: counter.speedsetup || (counter.setupType && !bugSwordsDanceCase) || (isDoubles && hasMove['leechlife'])};
 
 		// Ineffective to have two particular moves together
 		case 'explosion':
-			// Special case for Gigalith
-			// [15:33] A Cake Wearing A Hat: meant to prevent rock blast as only stab on choice band
+			// Rock Blast: Special case for Gigalith to prevent Stone Edge-less Choice Band sets
 			const otherMoves = ['curse', 'drainpunch', 'rockblast', 'painsplit', 'wish'].some(m => hasMove[m]);
 			return {cull: counter.speedsetup || counter.recovery || otherMoves};
 		case 'facade':
+			// Special cases for Braviary and regular Snorlax, respectively
 			return {cull: counter.recovery || movePool.includes('doubleedge')};
 		case 'quickattack':
-			const uturnCullCondition = counter.Physical > 3 && movePool.includes('uturn');
-			return {cull: counter.speedsetup || (hasType['Rock'] && counter.Status) || uturnCullCondition};
+			// Diggersby wants U-turn on Choiced sets
+			const diggersbyCull = counter.Physical > 3 && movePool.includes('uturn');
+			return {cull: counter.speedsetup || (hasType['Rock'] && counter.Status) || diggersbyCull};
 		case 'blazekick':
+			// Special case for Genesect. Remove when Genesect changes
 			return {cull: counter.Special >= 1};
 		case 'firefang': case 'flamethrower':
 			// Fire Fang: Special case for Garchomp, which doesn't want Fire Fang w/o Swords Dance
@@ -914,6 +919,7 @@ export class RandomTeams {
 			// Special case for Goodra, which only wants one move to hit Water-types
 			return {cull: hasMove['powerwhip']};
 		case 'gigadrain':
+			// Celebi always wants Leaf Storm on its more pivoting-focused non-Nasty Plot sets
 			const celebiPreferLeafStorm = species.id === 'celebi' && !counter.setupType && hasMove['uturn'];
 			return {cull: celebiPreferLeafStorm || (hasType['Poison'] && !counter.Poison)};
 		case 'leafblade':
@@ -937,9 +943,10 @@ export class RandomTeams {
 			const preferThunderWave = movePool.includes('thunderwave') && hasType['Electric'];
 			return {cull: betterIceMove || preferThunderWave || movePool.includes('bodyslam')};
 		case 'bodypress':
-			// Partially a special case for Turtonator to make EQ=Smash, Press=Not Smash, never both
-			const eqShellSmashPossible = hasMove['earthquake'] && movePool.includes('shellsmash');
-			return {cull: eqShellSmashPossible || ['shellsmash', 'mirrorcoat', 'whirlwind'].some(m => hasMove[m])};
+			// Turtonator never wants Earthquake + Body Press, and wants EQ+Smash or Press+No Smash
+			const turtonatorCull = hasMove['earthquake'] && movePool.includes('shellsmash');
+			const pressIncompatible = ['shellsmash', 'mirrorcoat', 'whirlwind'].some(m => hasMove[m]);
+			return {cull: turtonatorCull || pressIncompatible || counter.setupType === 'Special'};
 		case 'circlethrow':
 			// Part of a special case for Throh to pick one specific Fighting move depending on its set
 			return {cull: hasMove['stormthrow'] && !hasMove['rest']};
@@ -968,18 +975,20 @@ export class RandomTeams {
 			return {cull: !hasType['Poison'] && counter.Status >= 2};
 		case 'earthquake':
 			const doublesCull = hasMove['earthpower'] || hasMove['highhorsepower'];
-			const movePoolCull = movePool.includes('bodypress') && movePool.includes('shellsmash');
+			// Turtonator wants Body Press when it doesn't have Shell Smash
+			const turtonatorCull2 = movePool.includes('bodypress') && movePool.includes('shellsmash');
 			const subToxicPossible = hasMove['substitute'] && movePool.includes('toxic');
-			return {cull: movePoolCull || (isDoubles && doublesCull) || subToxicPossible || hasMove['bonemerang']};
+			return {cull: turtonatorCull2 || (isDoubles && doublesCull) || subToxicPossible || hasMove['bonemerang']};
 		case 'scorchingsands':
 			// Special cases for Ninetales and Palossand; prevents status redundancy
 			return {cull: hasMove['willowisp'] || hasMove['earthpower'] || (hasMove['toxic'] && movePool.includes('earthpower'))};
 		case 'airslash':
-			return {
-				cull: movePool.includes('flamethrower') ||
-					(hasMove['hurricane'] && !counter.setupType) ||
-					hasRestTalk ||
-					(hasAbility['Simple'] && !!counter.recovery),
+			return {cull:
+				movePool.includes('flamethrower') ||
+				(hasMove['hurricane'] && !counter.setupType) ||
+				hasRestTalk ||
+				(hasAbility['Simple'] && !!counter.recovery) ||
+				counter.setupType === 'Physical',
 			};
 		case 'bravebird':
 			// Special case for Mew, which only wants Brave Bird with Swords Dance
@@ -1010,21 +1019,28 @@ export class RandomTeams {
 			// Special case for Dhelmise in Doubles, which doesn't want both
 			return {cull: hasMove['knockoff']};
 		case 'shadowball':
-			const cull = (
+			return {cull:
 				(isDoubles && hasMove['phantomforce']) ||
+				// Special case for Sylveon, which never wants Shadow Ball as its only coverage move
 				(hasAbility['Pixilate'] && (counter.setupType || counter.Status > 1)) ||
-				(!hasType['Ghost'] && movePool.includes('focusblast'))
-			);
-			return {cull};
+				(!hasType['Ghost'] && movePool.includes('focusblast')),
+			};
 		case 'shadowclaw':
 			return {cull: hasType['Steel'] && hasMove['shadowsneak'] && counter.Physical < 4};
 		case 'dragonpulse': case 'spacialrend':
 			return {cull: hasMove['dracometeor'] && counter.Special < 4};
 		case 'darkpulse':
-			const defogger = hasMove['defog'] && counter.setupType !== 'Special';
-			return {cull: ['foulplay', 'knockoff', 'suckerpunch'].some(m => hasMove[m]) || defogger};
+			const pulseIncompatible = ['defog', 'foulplay', 'knockoff', 'suckerpunch'].some(m => hasMove[m]);
+			// Special clause to prevent bugged Shiftry sets with Sucker Punch + Nasty Plot
+			const shiftryCase = movePool.includes('nastyplot') && !hasMove['defog'];
+			return {cull: pulseIncompatible && !shiftryCase && counter.setupType !== 'Special'};
 		case 'suckerpunch':
-			return {cull: hasMove['rest'] || counter.damagingMoves.length < 2 || (counter.Dark > 1 && !hasType['Dark'])};
+			return {cull:
+				hasMove['rest'] ||
+				counter.damagingMoves.length < 2 ||
+				(counter.setupType === 'Special') ||
+				(counter.Dark > 1 && !hasType['Dark']),
+			};
 		case 'dazzlinggleam':
 			return {cull: ['fleurcannon', 'moonblast', 'petaldance'].some(m => hasMove[m])};
 
@@ -1048,27 +1064,30 @@ export class RandomTeams {
 		case 'reflect': case 'lightscreen':
 			return {cull: !!teamDetails.screens};
 		case 'slackoff':
+			// Special case to prevent Scaldless Slowking
 			return {cull: species.id === 'slowking' && !hasMove['scald']};
 		case 'substitute':
-			const moveBasedCull = ['bulkup', 'painsplit', 'roost'].some(m => movePool.includes(m));
-			const doublesPowerWhip = isDoubles && movePool.includes('powerwhip');
+			const moveBasedCull = ['bulkup', 'nastyplot', 'painsplit', 'roost', 'swordsdance'].some(m => movePool.includes(m));
+			// Smaller formes of Gourgeist in Doubles don't want Poltergeist as their only attack
+			const doublesGourgeist = isDoubles && movePool.includes('powerwhip');
 			// Calyrex wants Substitute + Leech Seed not Calm Mind + Leech Seed
 			const calmMindCullCondition = !counter.recovery && movePool.includes('calmmind') && species.id !== 'calyrex';
+			// Eiscue wants to always have Liquidation and Belly Drum
 			const eiscue = species.id === 'eiscue' && hasMove['zenheadbutt'];
-			return {cull: hasMove['rest'] || moveBasedCull || doublesPowerWhip || calmMindCullCondition || eiscue};
+			return {cull: hasMove['rest'] || moveBasedCull || doublesGourgeist || calmMindCullCondition || eiscue};
 		case 'helpinghand':
 			// Special case for Shuckle in Doubles, which doesn't want sets with no method to harm foes
 			return {cull: hasMove['acupressure']};
 		case 'wideguard':
 			return {cull: hasMove['protect']};
 		case 'grassknot':
-			// Special case for Raichu
+			// Special case for Raichu and Heliolisk
 			return {cull: hasMove['surf']};
 		case 'icepunch':
-			// Special cases for Marshadow and Lucario respectively
-			return {cull: hasMove['rocktomb'] || movePool.includes('extremespeed')};
+			// Special cases for Marshadow and Lucario, respectively
+			return {cull: hasMove['rocktomb'] || (species.id === 'lucario' && counter.setupType)};
 		case 'leechseed':
-			// Special case for Calyrex
+			// Special case for Calyrex to prevent Leech Seed + Calm Mind
 			return {cull: !!counter.setupType};
 		}
 
@@ -1481,7 +1500,7 @@ export class RandomTeams {
 		) return 'Life Orb';
 		if (!isDoubles && counter.damagingMoves.length >= 4 && !counter.Dragon && !counter.Normal) return 'Expert Belt';
 		if (
-			!isDoubles &&
+			!isDoubles && !hasMove['substitute'] &&
 			(hasMove['dragondance'] || hasMove['swordsdance']) &&
 			(hasMove['outrage'] || (
 				['Bug', 'Fire', 'Ground', 'Normal', 'Poison'].every(type => !hasType[type]) &&

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -841,8 +841,10 @@ export class RandomTeams {
 			return {cull: counter.speedsetup || hasMove['bulkup'] || hasMove['uturn']};
 		case 'protect':
 			if ((counter.setupType && !hasMove['wish'] && !isDoubles) || hasRestTalk) return {cull: true};
-			if (!isDoubles &&
-				counter.Status < 2 && ['Hunger Switch', 'Speed Boost', 'Moody'].every(m => !hasAbility[m])
+			if (
+				!isDoubles &&
+				counter.Status < 2 &&
+				['Hunger Switch', 'Speed Boost', 'Moody'].every(m => !hasAbility[m])
 			) return {cull: true};
 			if (movePool.includes('leechseed') || (movePool.includes('toxic') && !hasMove['wish'])) return {cull: true};
 			if (isDoubles && (

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -895,8 +895,7 @@ export class RandomTeams {
 			const diggersbyCull = counter.Physical > 3 && movePool.includes('uturn');
 			return {cull: counter.speedsetup || (hasType['Rock'] && counter.Status) || diggersbyCull};
 		case 'blazekick':
-			// Special case for Genesect. Remove when Genesect changes
-			return {cull: counter.Special >= 1};
+			return {cull: species.id === 'genesect' && counter.Special >= 1};
 		case 'firefang': case 'flamethrower':
 			// Fire Fang: Special case for Garchomp, which doesn't want Fire Fang w/o Swords Dance
 			const otherFireMoves = ['heatwave', 'overheat'].some(m => hasMove[m]);

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -945,9 +945,9 @@ export class RandomTeams {
 			return {cull: betterIceMove || preferThunderWave || movePool.includes('bodyslam')};
 		case 'bodypress':
 			// Turtonator never wants Earthquake + Body Press, and wants EQ+Smash or Press+No Smash
-			const turtonatorCull = species.id === 'turtonator' && hasMove['earthquake'] && movePool.includes('shellsmash');
+			const turtonatorPressCull = species.id === 'turtonator' && hasMove['earthquake'] && movePool.includes('shellsmash');
 			const pressIncompatible = ['shellsmash', 'mirrorcoat', 'whirlwind'].some(m => hasMove[m]);
-			return {cull: turtonatorCull || pressIncompatible || counter.setupType === 'Special'};
+			return {cull: turtonatorPressCull || pressIncompatible || counter.setupType === 'Special'};
 		case 'circlethrow':
 			// Part of a special case for Throh to pick one specific Fighting move depending on its set
 			return {cull: hasMove['stormthrow'] && !hasMove['rest']};
@@ -977,9 +977,9 @@ export class RandomTeams {
 		case 'earthquake':
 			const doublesCull = hasMove['earthpower'] || hasMove['highhorsepower'];
 			// Turtonator wants Body Press when it doesn't have Shell Smash
-			const turtonatorCull = species.id === 'turtonator' && movePool.includes('bodypress') && movePool.includes('shellsmash');
+			const turtQuakeCull = species.id === 'turtonator' && movePool.includes('bodypress') && movePool.includes('shellsmash');
 			const subToxicPossible = hasMove['substitute'] && movePool.includes('toxic');
-			return {cull: turtonatorCull || (isDoubles && doublesCull) || subToxicPossible || hasMove['bonemerang']};
+			return {cull: turtonatorEQCull || (isDoubles && doublesCull) || subToxicPossible || hasMove['bonemerang']};
 		case 'scorchingsands':
 			// Special cases for Ninetales and Palossand; prevents status redundancy
 			return {cull: hasMove['willowisp'] || hasMove['earthpower'] || (hasMove['toxic'] && movePool.includes('earthpower'))};


### PR DESCRIPTION
-Improved documentation and consistency
-Remove Mach Punch from Hitmonlee to fix that one set with High Jump Kick and Curse.
-Prevent special moves from generating on Swords Dance Virizion
-Prevent physical moves from generating on Nasty Plot Shiftry
-Prevent physical moves from generating on Calm Mind Orbeetle
-Prevent Substitute + 3 Attacks sets on Toxicroak and Calyrex-Shadow
-Fix Spiritomb getting Calm Mind+Shadow Sneak, getting Rest+Shadow Sneak, and not getting Will-O-Wisp+Calm Mind
-Actually for real prevent Extremespeedless Lucario
-Actually free Protect Octillery, which hasn't existed before this.
-Give Substitute Pokemon that would otherwise get Lum Berry Leftovers instead. This affects Zygarde and Zekrom, though one of those will probably change soon anyway.