### PR TITLE
Fix typo in Challenge Cup team generator

### DIFF
--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -342,7 +342,7 @@ export class RandomTeams {
 				atk: this.random(32),
 				def: this.random(32),
 				spa: this.random(32),
-				pd: this.random(32),
+				spd: this.random(32),
 				spe: this.random(32),
 			};
 


### PR DESCRIPTION
All Pokemon in Challenge Cup were spawning with 31 SpD IVs.