### PR TITLE
Gen 3 Random Battle updates

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -4193,7 +4193,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 	},
 	genesectdouse: {
 		randomBattleMoves: ["bugbuzz", "extremespeed", "flamethrower", "icebeam", "ironhead", "technoblast", "thunderbolt", "uturn"],
-		randomBattleLevel: 74,
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "(DOU)",
 	},

--- a/data/mods/gen3/formats-data.ts
+++ b/data/mods/gen3/formats-data.ts
@@ -166,7 +166,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "UU",
 	},
 	bellossom: {
-		randomBattleMoves: ["hiddenpowerfire", "hiddenpowergrass", "moonlight", "sleeppowder", "sludgebomb", "solarbeam", "stunspore", "sunnyday"],
+		randomBattleMoves: ["hiddenpowergrass", "leechseed", "moonlight", "sleeppowder", "sludgebomb", "stunspore"],
 		tier: "NU",
 	},
 	paras: {
@@ -208,7 +208,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	primeape: {
-		randomBattleMoves: ["bulkup", "crosschop", "earthquake", "hiddenpowerghost", "reversal", "rockslide", "substitute"],
+		randomBattleMoves: ["bulkup", "crosschop", "earthquake", "hiddenpowerghost", "rockslide", "substitute"],
 		tier: "UU",
 	},
 	growlithe: {
@@ -283,7 +283,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	rapidash: {
-		randomBattleMoves: ["batonpass", "fireblast", "flamethrower", "hiddenpowergrass", "solarbeam", "substitute", "sunnyday", "toxic"],
+		randomBattleMoves: ["fireblast", "hiddenpowergrass", "hiddenpowerrock", "substitute", "toxic"],
 		tier: "UU",
 	},
 	slowpoke: {
@@ -364,7 +364,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	kingler: {
-		randomBattleMoves: ["doubleedge", "endure", "flail", "hiddenpowerghost", "hiddenpowerground", "surf", "swordsdance"],
+		randomBattleMoves: ["doubleedge", "hiddenpowerghost", "hiddenpowerground", "surf", "swordsdance"],
 		tier: "NU",
 	},
 	voltorb: {
@@ -392,7 +392,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	hitmonlee: {
-		randomBattleMoves: ["bulkup", "earthquake", "hiddenpowerghost", "highjumpkick", "machpunch", "reversal", "rockslide", "substitute"],
+		randomBattleMoves: ["bulkup", "earthquake", "hiddenpowerghost", "highjumpkick", "machpunch", "rockslide", "substitute"],
 		tier: "UU",
 	},
 	hitmonchan: {
@@ -400,7 +400,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NU",
 	},
 	hitmontop: {
-		randomBattleMoves: ["bulkup", "earthquake", "endeavor", "endure", "hiddenpowerghost", "highjumpkick", "machpunch", "rockslide", "toxic"],
+		randomBattleMoves: ["bulkup", "earthquake", "hiddenpowerghost", "highjumpkick", "machpunch", "rockslide", "toxic"],
 		tier: "UU",
 	},
 	lickitung: {
@@ -429,7 +429,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "OU",
 	},
 	tangela: {
-		randomBattleMoves: ["hiddenpowerfire", "hiddenpowergrass", "leechseed", "morningsun", "sleeppowder", "solarbeam", "stunspore", "sunnyday"],
+		randomBattleMoves: ["hiddenpowergrass", "leechseed", "morningsun", "sleeppowder", "stunspore"],
 		tier: "NU",
 	},
 	kangaskhan: {
@@ -509,7 +509,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "OU",
 	},
 	lapras: {
-		randomBattleMoves: ["healbell", "hydropump", "icebeam", "rest", "sleeptalk", "thunderbolt", "toxic"],
+		randomBattleMoves: ["healbell", "icebeam", "rest", "sleeptalk", "surf", "thunderbolt", "toxic"],
 		tier: "UUBL",
 	},
 	ditto: {
@@ -536,7 +536,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "UUBL",
 	},
 	umbreon: {
-		randomBattleMoves: ["batonpass", "hiddenpowerdark", "meanlook", "moonlight", "protect", "toxic", "wish"],
+		randomBattleMoves: ["batonpass", "hiddenpowerdark", "meanlook", "protect", "toxic", "wish"],
 		tier: "UUBL",
 	},
 	porygon: {
@@ -557,7 +557,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	kabutops: {
-		randomBattleMoves: ["brickbreak", "doubleedge", "endure", "flail", "hiddenpowerground", "rockslide", "surf", "swordsdance"],
+		randomBattleMoves: ["brickbreak", "doubleedge", "hiddenpowerground", "rockslide", "surf", "swordsdance"],
 		tier: "UU",
 	},
 	aerodactyl: {
@@ -605,7 +605,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NFE",
 	},
 	meganium: {
-		randomBattleMoves: ["counter", "hiddenpowergrass", "leechseed", "lightscreen", "synthesis", "toxic"],
+		randomBattleMoves: ["bodyslam", "hiddenpowergrass", "leechseed", "synthesis", "toxic"],
 		tier: "UU",
 	},
 	cyndaquil: {
@@ -805,7 +805,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	magcargo: {
-		randomBattleMoves: ["fireblast", "flamethrower", "hiddenpowergrass", "rest", "sleeptalk", "toxic", "yawn"],
+		randomBattleMoves: ["fireblast", "hiddenpowergrass", "rest", "sleeptalk", "toxic", "yawn"],
 		tier: "NU",
 	},
 	swinub: {
@@ -873,7 +873,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "UUBL",
 	},
 	suicune: {
-		randomBattleMoves: ["calmmind", "hydropump", "icebeam", "rest", "sleeptalk", "substitute", "surf", "toxic"],
+		randomBattleMoves: ["calmmind", "icebeam", "rest", "sleeptalk", "substitute", "surf", "toxic"],
 		tier: "OU",
 	},
 	larvitar: {
@@ -976,7 +976,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NFE",
 	},
 	shiftry: {
-		randomBattleMoves: ["brickbreak", "explosion", "hiddenpowerfire", "quickattack", "shadowball", "solarbeam", "sunnyday", "swordsdance"],
+		randomBattleMoves: ["brickbreak", "explosion", "hiddenpowerfire", "shadowball", "solarbeam", "sunnyday", "swordsdance"],
 		tier: "UU",
 	},
 	taillow: {
@@ -1014,7 +1014,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	breloom: {
-		randomBattleMoves: ["focuspunch", "hiddenpowerghost", "hiddenpowerrock", "leechseed", "machpunch", "spore", "substitute", "swordsdance"],
+		randomBattleMoves: ["focuspunch", "hiddenpowerghost", "hiddenpowerrock", "leechseed", "machpunch", "skyuppercut", "spore", "substitute", "swordsdance"],
 		tier: "OU",
 	},
 	slakoth: {
@@ -1089,7 +1089,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	medicham: {
-		randomBattleMoves: ["brickbreak", "bulkup", "fakeout", "recover", "reversal", "rockslide", "shadowball", "substitute"],
+		randomBattleMoves: ["brickbreak", "bulkup", "fakeout", "recover", "rockslide", "shadowball", "substitute"],
 		tier: "UUBL",
 	},
 	electrike: {
@@ -1137,7 +1137,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	wailord: {
-		randomBattleMoves: ["hiddenpowergrass", "hydropump", "icebeam", "rest", "selfdestruct", "sleeptalk", "surf", "toxic"],
+		randomBattleMoves: ["hiddenpowergrass", "icebeam", "rest", "selfdestruct", "sleeptalk", "surf", "toxic"],
 		tier: "NU",
 	},
 	numel: {

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -39,6 +39,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		counter: {[k: string]: any},
 		movePool: string[],
 		teamDetails: RandomTeamsTypes.TeamDetails,
+		species: Species,
 	) {
 		const restTalk = hasMove['rest'] && hasMove['sleeptalk'];
 
@@ -77,7 +78,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			return {cull: !hasMove['calmmind'] && !hasMove['batonpass'] && !hasMove['mirrorcoat']};
 		case 'batonpass':
 			return {cull: (
-				(!counter.setupType && !counter.speedsetup) ||
+				(!counter.setupType && !counter.speedsetup) &&
 				['meanlook', 'spiderweb', 'substitute', 'wish'].every(m => !hasMove[m])
 			)};
 		case 'endeavor': case 'flail': case 'reversal':
@@ -89,7 +90,9 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		case 'focuspunch':
 			return {cull: (
 				(counter.damagingMoves.length < 2 || hasMove['rest'] || counter.setupType && !hasMove['spore']) ||
-				(!hasMove['substitute'] && (counter.Physical < 4 || hasMove['fakeout']))
+				(!hasMove['substitute'] && (counter.Physical < 4 || hasMove['fakeout'])) ||
+				// Breloom likes to have coverage
+				(species.id === 'breloom' && hasMove['machpunch'] || hasMove['skyuppercut'])
 			)};
 		case 'moonlight':
 			return {cull: hasMove['wish'] || hasMove['protect']};
@@ -125,7 +128,9 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		case 'encore': case 'painsplit': case 'recover': case 'yawn':
 			return {cull: restTalk};
 		case 'explosion': case 'machpunch': case 'selfdestruct':
-			return {cull: hasMove['rest'] || hasMove['substitute'] || !!counter.recovery};
+			// Snorlax doesn't want to roll selfdestruct as its only STAB move
+			const snorlaxCase = species.id === 'snorlax' && !hasMove['return'] && !hasMove['bodyslam'];
+			return {cull: snorlaxCase || hasMove['rest'] || hasMove['substitute'] || !!counter.recovery};
 		case 'haze':
 			return {cull: counter.setupType || hasMove['raindance'] || restTalk};
 		case 'icywind': case 'pursuit': case 'superpower': case 'transform':
@@ -152,7 +157,8 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			return {cull: counter.setupType || hasMove['substitute'] || restTalk || teamDetails.spikes};
 		case 'substitute':
 			const restOrDD = hasMove['rest'] || (hasMove['dragondance'] && !hasMove['bellydrum']);
-			return {cull: restOrDD || (!hasMove['batonpass'] && movePool.includes('calmmind'))};
+			// This cull condition otherwise causes mono-solarbeam Entei
+			return {cull: restOrDD || (species.id !== 'entei' && !hasMove['batonpass'] && movePool.includes('calmmind'))};
 		case 'thunderwave':
 			return {cull: counter.setupType || hasMove['bodyslam'] || hasMove['substitute'] || restTalk};
 		case 'toxic':
@@ -170,7 +176,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		case 'bodyslam':
 			return {cull: hasMove['return'] && !!counter.Status};
 		case 'headbutt':
-			return {cull: hasMove['bodyslam'] && !hasMove['thunderwave']};
+			return {cull: !hasMove['bodyslam'] && !hasMove['thunderwave']};
 		case 'return':
 			return {cull: (
 				hasMove['endure'] ||
@@ -192,13 +198,13 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		case 'hiddenpower':
 			const stabCondition = hasType[move.type] && (
 				(hasMove['substitute'] && !counter.setupType && !hasMove['toxic']) ||
-				(hasMove['toxic'] && !hasMove['substitute']) ||
+				// This otherwise causes STABless meganium
+				(species.id !== 'meganium' && hasMove['toxic'] && !hasMove['substitute']) ||
 				restTalk
 			);
 			return {cull: stabCondition || (move.type === 'Grass' && hasMove['sunnyday'] && hasMove['solarbeam'])};
-		case 'brickbreak': case 'crosschop': case 'highjumpkick': case 'skyuppercut':
-			const subPunch = hasMove['substitute'] && (hasMove['focuspunch'] || movePool.includes('focuspunch'));
-			return {cull: subPunch || ((hasMove['endure'] || hasMove['substitute']) && hasMove['reversal'])};
+		case 'brickbreak': case 'crosschop': case 'skyuppercut':
+			return {cull: hasMove['substitute'] && (hasMove['focuspunch'] || movePool.includes('focuspunch'))};
 		case 'earthquake':
 			return {cull: hasMove['bonemerang']};
 		}
@@ -229,13 +235,18 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		}
 
 		// Medium priority items
-		if (
-			(hasMove['bellydrum'] && counter.Physical - counter.priority > 1) ||
-			(hasMove['swordsdance'] && counter.Status < 2)
-		) {
+		if (hasMove['dragondance'] && ability !== 'Natural Cure') return 'Lum Berry';
+		if ((hasMove['bellydrum'] && counter.Physical - counter.priority > 1) || (
+			((hasMove['swordsdance'] && counter.Status < 2) || (hasMove['bulkup'] && hasMove['substitute'])) &&
+			!counter.priority &&
+			species.baseStats.spe >= 60 && species.baseStats.spe <= 95
+		)) {
 			return 'Salac Berry';
 		}
-		if (hasMove['endure'] || (hasMove['substitute'] && ['endeavor', 'flail', 'reversal'].some(m => hasMove[m]))) {
+		if (hasMove['endure'] || (
+			hasMove['substitute'] &&
+			['bellydrum', 'endeavor', 'flail', 'reversal'].some(m => hasMove[m])
+		)) {
 			return (
 				species.baseStats.spe <= 100 && ability !== 'Speed Boost' && !counter.speedsetup && !hasMove['focuspunch']
 			) ? 'Salac Berry' : 'Liechi Berry';
@@ -361,7 +372,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 				const move = this.dex.getMove(moveId);
 				const moveid = move.id;
 
-				let {cull, isSetup} = this.shouldCullMove(move, hasType, hasMove, hasAbility, counter, movePool, teamDetails);
+				let {cull, isSetup} = this.shouldCullMove(move, hasType, hasMove, hasAbility, counter, movePool, teamDetails, species);
 
 				// This move doesn't satisfy our setup requirements:
 				if (

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -92,7 +92,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 				(counter.damagingMoves.length < 2 || hasMove['rest'] || counter.setupType && !hasMove['spore']) ||
 				(!hasMove['substitute'] && (counter.Physical < 4 || hasMove['fakeout'])) ||
 				// Breloom likes to have coverage
-				(species.id === 'breloom' && hasMove['machpunch'] || hasMove['skyuppercut'])
+				(species.id === 'breloom' && (hasMove['machpunch'] || hasMove['skyuppercut']))
 			)};
 		case 'moonlight':
 			return {cull: hasMove['wish'] || hasMove['protect']};


### PR DESCRIPTION
-Fully fix issues with mono-solarbeam Pokemon and many Fire-types having two fire moves at once, using a combination of convoluted code and set adjustments.
-Stop Fighting-types from getting Reversal as their only STAB move, by just, like, removing reversal from them
-Prevent Water-types from getting RestTalk with Hydro Pump as the only attack by removing Hydro Pump from those affected.
-Prevent STABless Meganium
-Fix Salac Berry generation to be more specific and more helpful
-Allow Dragon Dance users to get Lum Berry
-Remove endure shenanigans from a bunch of stuff that can't really pull it off well
-give Breloom an actual fighting move that counts as STAB
-remove cb shiftry
-prevent mono-selfdestruct snorlax
-prevent headbutt dunsparce w/o any source of paralysis
-give substitute + belly drum charizard a salac berry