### PR TITLE
Magician should not steal Weakness Policy on super-effective hits

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -1918,6 +1918,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (!move || !target) return;
 			if (target !== source && move.category !== 'Status') {
 				if (source.item || source.volatiles['gem'] || move.id === 'fling') return;
+				if (target.hasItem('weaknesspolicy') && source.getMoveHitData(move).typeMod > 0 && target.hp > 0) return;
 				const yourItem = target.takeItem(source);
 				if (!yourItem) return;
 				if (!source.setItem(yourItem)) {


### PR DESCRIPTION
https://github.com/smogon/pokemon-showdown/projects/3#card-52059185
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/page-42#post-8696614

Added a specific condition to check for Magician stealing Weakness Policy. Previously was stealing item without checking if the item got triggered.

I don't think there is an easier away around this issue other than a hard coded if statement because it has to do with trigger order of the item function (onDamagingHit, item.ts line 6665) and Magician ability function (onSourceHit, abilities.ts line 1665). I'm not sure if there needs to be change done for other items or item stealing abilities, but the bug only describes Magician and Weakness Policy. 