### PR TITLE
Update comment to reflect the build script

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -2,8 +2,8 @@
  * Main file
  * Pokemon Showdown - http://pokemonshowdown.com/
  *
- * This is the main Pokemon Showdown app, and the file you should be
- * running to start Pokemon Showdown if you're using it normally.
+ * This is the main Pokemon Showdown app, and the file that the
+ * `pokemon-showdown` script runs if you start Pokemon Showdown normally.
  *
  * This file sets up our SockJS server, which handles communication
  * between users and your server, and also sets up globals. You can


### PR DESCRIPTION
As far as I know, our documentation recommends using `node pokemon-showdown` to start PS, not `node build && node .server-dist/index.js`.
Thus, I don't think the latter is considered starting PS normally.