### PR TITLE
Chat monitor: Refactor to handle private filters better

### DIFF
--- a/server/chat-plugins/chat-monitor.ts
+++ b/server/chat-plugins/chat-monitor.ts
@@ -286,40 +286,46 @@ Chat.registerMonitor('shorteners', {
  * Location: EVERYWHERE, PUBLIC, NAMES, BATTLES
  * Punishment: AUTOLOCK, WARN, FILTERTO, SHORTENER, MUTE, EVASION
  */
-void FS(MONITOR_FILE).readIfExists().then(data => {
-	const lines = data.split('\n');
-	loop: for (const line of lines) {
-		if (!line || line === '\r') continue;
-		const [location, word, punishment, reason, times, ...rest] = line.split('\t').map(param => param.trim());
-		if (location === 'Location') continue;
-		if (!(location && word && punishment)) continue;
 
-		for (const key in Chat.monitors) {
-			if (Chat.monitors[key].location === location && Chat.monitors[key].punishment === punishment) {
-				const replacement = rest[0];
-				const publicReason = rest[1];
-				let regex: RegExp;
-				if (punishment === 'EVASION') {
-					regex = constructEvasionRegex(word);
-				} else {
-					regex = new RegExp(punishment === 'SHORTENER' ? `\\b${word}` : word, replacement ? 'igu' : 'iu');
+export function loadFilters() {
+	try {
+		const data = FS(MONITOR_FILE).readSync();
+		const lines = data.split('\n');
+		loop: for (const line of lines) {
+			if (!line || line === '\r') continue;
+			const [location, word, punishment, reason, times, ...rest] = line.split('\t').map(param => param.trim());
+			if (location === 'Location') continue;
+			for (const key in Chat.monitors) {
+				if (Chat.monitors[key].location === location && Chat.monitors[key].punishment === punishment) {
+					const replacement = rest[0];
+					const publicReason = rest[1];
+					let regex: RegExp;
+					if (punishment === 'EVASION') {
+						regex = constructEvasionRegex(word);
+					} else {
+						regex = new RegExp(punishment === 'SHORTENER' ? `\\b${word}` : word, replacement ? 'igu' : 'iu');
+					}
+
+					const filterWord: FilterWord = {regex, word, hits: parseInt(times) || 0};
+
+					// "undefined" is the result of an issue with filter storage.
+					// As far as I'm aware, nothing is actually filtered with "undefined" as the reason.
+					if (reason && reason !== "undefined") filterWord.reason = reason;
+					if (publicReason) filterWord.publicReason = publicReason;
+					if (replacement) filterWord.replacement = replacement;
+					filterWords[key].push(filterWord);
+					continue loop;
 				}
-
-				const filterWord: FilterWord = {regex, word, hits: parseInt(times) || 0};
-
-				// "undefined" is the result of an issue with filter storage.
-				// As far as I'm aware, nothing is actually filtered with "undefined" as the reason.
-				if (reason && reason !== "undefined") filterWord.reason = reason;
-				if (publicReason) filterWord.publicReason = publicReason;
-				if (replacement) filterWord.replacement = replacement;
-				filterWords[key].push(filterWord);
-
-				continue loop;
 			}
+			// this is not thrown because we DO NOT WANT SECRET FILTERS TO BE LEAKED, but we want this to be known
+			Monitor.crashlog(new Error("Couldn't find [location, punishment] pair for a filter word"), "The main process", {
+				location, word, punishment, reason, times, rest,
+			});
 		}
-		throw new Error(`Unrecognized [location, punishment] pair for filter word entry: ${[location, word, punishment, reason, times]}`);
+	} catch (e) {
+		if (e.code !== 'ENOENT') throw e;
 	}
-});
+}
 
 /* The sucrase transformation of optional chaining is too expensive to be used in a hot function like this. */
 /* eslint-disable @typescript-eslint/prefer-optional-chain */
@@ -661,4 +667,5 @@ export const commands: ChatCommands = {
 
 process.nextTick(() => {
 	Chat.multiLinePattern.register('/filter (add|remove) ');
+	loadFilters();
 });


### PR DESCRIPTION
This does two things. One, it abstracts filter loading into a function (which is run a tick after the module is done), and makes it so missing filter words don't throw, as to avoid leaking private into. Loading is done a tick after the module to allow for other files to be loaded (the crashes were because they weren't being loaded before the filter loading was done, afaict.)