### PR TITLE
Enable tsc warnings about unreachable code

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
         "strict": true,
         "allowJs": true,
         "checkJs": true,
-        "incremental": true
+        "incremental": true,
+        "allowUnreachableCode": false
     },
     "types": ["node"],
     "exclude": [


### PR DESCRIPTION
To me, this seems like a useful thing to check in linting, with no disadvantage that I can see (I found no measurable performance difference in running `tsc` after removing the `.tsbuildinfo` file).