### PR TITLE
Random Battles bugfixes/minor updates

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -1377,6 +1377,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["dragonclaw", "dragondance", "dualwingbeat", "extremespeed", "firepunch"],
 		randomDoubleBattleLevel: 82,
+		randomBattleNoDynamaxMoves: ["dragondance", "dualwingbeat", "earthquake", "outrage", "roost"],
 		tier: "OU",
 		doublesTier: "(DUU)",
 	},
@@ -2861,7 +2862,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 	vespiquen: {
 		randomBattleMoves: ["airslash", "defog", "roost", "toxic", "uturn"],
 		randomBattleLevel: 96,
-		randomDoubleBattleMoves: ["defendorder", "infestation", "roost", "toxic"],
+		randomDoubleBattleMoves: ["airslash", "roost", "tailwind", "toxicspikes"],
 		randomDoubleBattleLevel: 96,
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3270,7 +3271,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		isNonstandard: "Past",
 	},
 	victini: {
-		randomBattleMoves: ["blueflare", "boltstrike", "energyball", "glaciate", "trick", "uturn", "vcreate", "zenheadbutt"],
+		randomBattleMoves: ["blueflare", "boltstrike", "energyball", "glaciate", "uturn", "vcreate", "zenheadbutt"],
 		randomBattleLevel: 78,
 		randomDoubleBattleMoves: ["boltstrike", "glaciate", "protect", "uturn", "vcreate", "zenheadbutt"],
 		randomDoubleBattleLevel: 82,
@@ -5983,7 +5984,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 	dragapult: {
 		randomBattleMoves: ["dracometeor", "fireblast", "shadowball", "thunderbolt", "uturn"],
 		randomBattleLevel: 78,
-		randomDoubleBattleMoves: ["dragondance", "dragondarts", "fireblast", "phantomforce", "protect", "shadowball", "thunderbolt", "willowisp"],
+		randomDoubleBattleMoves: ["dragondarts", "fireblast", "protect", "shadowball", "thunderbolt", "willowisp"],
 		randomDoubleBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",


### PR DESCRIPTION
All Gen 8 main formats:
-Fix a large bug regarding Grass-types and STAB enforcement, where Grass-types at or above base 100 Attack would reject every move in their movepool, while Grass-types below that threshold would have their Grass STAB forced erroneously.
-Fix a large bug regarding all Steel-types with Bullet Punch always enforcing another STAB, when usually this is not a great thing to do.
-Fix a bug where Pokemon with two equally viable abilities would get the second-listed ability 85% of the time.

Gen 8 Random Battle:
-Prevent mixed choice item victini by removing Trick.
-Prevent Dual Wingbeat + Roost on Scizor, now that that can actually exist.

Gen 8 Random Doubles Battle:
-Remove Dragon Dance and Phantom Force from Dragapult to prevent really, really bad sets like DD Wisp Shadow Ball Protect.
-Revamp vespiquen.
-Allow healer Aromatisse sometimes.

Gen 8 Random Battle (No Dmax):
-Allow Cloud Nine Golduck
-Make Weak Armor possible on hazards Omastar, and more common on Cursola
-Give Dragonite Roost over Espeed because recovery's pretty good when you're not just clicking the embiggen button
-The legendary Poison Touch Seismitoad is no more.