### PR TITLE
Gen 5 Random Battle updates

### DIFF
--- a/data/mods/gen5/formats-data.ts
+++ b/data/mods/gen5/formats-data.ts
@@ -2220,7 +2220,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	simisage: {
-		randomBattleMoves: ["focusblast", "gigadrain", "hiddenpowerrock", "leechseed", "nastyplot", "substitute", "superpower"],
+		randomBattleMoves: ["focusblast", "gigadrain", "hiddenpowerrock", "leechseed", "nastyplot", "substitute"],
 		tier: "(NU)",
 		doublesTier: "DUU",
 	},
@@ -2228,7 +2228,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	simisear: {
-		randomBattleMoves: ["fireblast", "focusblast", "grassknot", "hiddenpowerrock", "nastyplot", "substitute", "superpower"],
+		randomBattleMoves: ["fireblast", "focusblast", "grassknot", "hiddenpowerrock", "nastyplot", "substitute"],
 		tier: "(NU)",
 		doublesTier: "DUU",
 	},

--- a/data/mods/gen5/formats-data.ts
+++ b/data/mods/gen5/formats-data.ts
@@ -117,7 +117,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NFE",
 	},
 	nidoqueen: {
-		randomBattleMoves: ["earthpower", "fireblast", "focusblast", "icebeam", "sludgewave", "stealthrock", "toxicspikes"],
+		randomBattleMoves: ["earthpower", "fireblast", "icebeam", "sludgewave", "stealthrock", "toxicspikes"],
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -128,7 +128,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NFE",
 	},
 	nidoking: {
-		randomBattleMoves: ["earthpower", "fireblast", "focusblast", "icebeam", "sludgewave", "substitute"],
+		randomBattleMoves: ["earthpower", "fireblast", "icebeam", "sludgewave", "substitute", "superpower"],
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -139,7 +139,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NFE",
 	},
 	clefable: {
-		randomBattleMoves: ["calmmind", "doubleedge", "icebeam", "softboiled", "stealthrock", "thunderbolt"],
+		randomBattleMoves: ["calmmind", "doubleedge", "icebeam", "softboiled", "stealthrock", "thunderbolt", "thunderwave"],
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -186,7 +186,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		doublesTier: "DUU",
 	},
 	bellossom: {
-		randomBattleMoves: ["gigadrain", "hiddenpowerrock", "leafstorm", "leechseed", "sleeppowder", "stunspore", "synthesis"],
+		randomBattleMoves: ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "leafstorm", "leechseed", "sleeppowder", "stunspore", "synthesis"],
 		tier: "(NU)",
 		doublesTier: "DUU",
 	},
@@ -319,7 +319,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	rapidash: {
-		randomBattleMoves: ["batonpass", "drillrun", "flareblitz", "megahorn", "morningsun", "wildcharge"],
+		randomBattleMoves: ["drillrun", "flareblitz", "megahorn", "morningsun", "wildcharge", "willowisp"],
 		tier: "(NU)",
 		doublesTier: "DUU",
 	},
@@ -475,7 +475,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	weezing: {
-		randomBattleMoves: ["fireblast", "haze", "painsplit", "sludgebomb", "thunderbolt", "willowisp"],
+		randomBattleMoves: ["fireblast", "haze", "painsplit", "sludgebomb", "willowisp"],
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -496,12 +496,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	chansey: {
-		randomBattleMoves: ["aromatherapy", "protect", "seismictoss", "softboiled", "stealthrock", "toxic", "wish"],
+		randomBattleMoves: ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "toxic"],
 		tier: "UUBL",
 		doublesTier: "NFE",
 	},
 	blissey: {
-		randomBattleMoves: ["aromatherapy", "flamethrower", "protect", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"],
+		randomBattleMoves: ["aromatherapy", "protect", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"],
 		tier: "(OU)",
 		doublesTier: "DUU",
 	},
@@ -839,7 +839,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NFE",
 	},
 	ampharos: {
-		randomBattleMoves: ["focusblast", "healbell", "hiddenpowergrass", "hiddenpowerice", "thunderbolt", "toxic", "voltswitch"],
+		randomBattleMoves: ["agility", "focusblast", "healbell", "hiddenpowergrass", "hiddenpowerice", "thunderbolt", "toxic", "voltswitch"],
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -973,7 +973,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		doublesTier: "DUU",
 	},
 	qwilfish: {
-		randomBattleMoves: ["destinybond", "painsplit", "poisonjab", "spikes", "taunt", "thunderwave", "waterfall"],
+		randomBattleMoves: ["destinybond", "poisonjab", "spikes", "taunt", "thunderwave", "toxicspikes", "waterfall"],
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -991,7 +991,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NFE",
 	},
 	weavile: {
-		randomBattleMoves: ["iceshard", "lowkick", "nightslash", "pursuit", "swordsdance"],
+		randomBattleMoves: ["icepunch", "iceshard", "lowkick", "nightslash", "pursuit", "swordsdance"],
 		tier: "UU",
 		doublesTier: "DOU",
 	},
@@ -1156,7 +1156,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NFE",
 	},
 	swampert: {
-		randomBattleMoves: ["earthquake", "icepunch", "roar", "stealthrock", "superpower", "toxic", "waterfall"],
+		randomBattleMoves: ["earthquake", "icebeam", "protect", "roar", "scald", "stealthrock", "toxic"],
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -2039,7 +2039,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		doublesTier: "DUU",
 	},
 	dialga: {
-		randomBattleMoves: ["aurasphere", "bulkup", "dracometeor", "dragontail", "fireblast", "rest", "sleeptalk", "stealthrock", "thunderbolt"],
+		randomBattleMoves: ["aurasphere", "dracometeor", "dragontail", "fireblast", "stealthrock", "thunderbolt"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
@@ -2676,7 +2676,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	bisharp: {
-		randomBattleMoves: ["ironhead", "lowkick", "nightslash", "substitute", "suckerpunch", "swordsdance"],
+		randomBattleMoves: ["ironhead", "lowkick", "nightslash", "suckerpunch", "swordsdance"],
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -2791,7 +2791,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		doublesTier: "DUU",
 	},
 	kyuremblack: {
-		randomBattleMoves: ["dragonclaw", "fusionbolt", "hiddenpowerfire", "icebeam", "roost", "substitute"],
+		randomBattleMoves: ["dragonclaw", "earthpower", "fusionbolt", "icebeam", "roost", "substitute"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},

--- a/data/mods/gen5/formats-data.ts
+++ b/data/mods/gen5/formats-data.ts
@@ -6,7 +6,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NFE",
 	},
 	venusaur: {
-		randomBattleMoves: ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "leechseed", "naturepower", "powerwhip", "sleeppowder", "sludgebomb", "swordsdance", "synthesis"],
+		randomBattleMoves: ["hiddenpowerfire", "hiddenpowerice", "leechseed", "naturepower", "powerwhip", "sleeppowder", "sludgebomb", "swordsdance", "synthesis"],
 		tier: "(OU)",
 		doublesTier: "DOU",
 	},
@@ -467,7 +467,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	lickilicky: {
-		randomBattleMoves: ["bodyslam", "dragontail", "earthquake", "explosion", "healbell", "powerwhip", "protect", "swordsdance", "toxic", "wish"],
+		randomBattleMoves: ["bodyslam", "earthquake", "healbell", "powerwhip", "protect", "swordsdance", "toxic", "wish"],
 		tier: "NU",
 		doublesTier: "DUU",
 	},

--- a/data/mods/gen5/formats-data.ts
+++ b/data/mods/gen5/formats-data.ts
@@ -29,7 +29,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		doublesTier: "NFE",
 	},
 	blastoise: {
-		randomBattleMoves: ["dragontail", "icebeam", "protect", "rapidspin", "scald", "toxic"],
+		randomBattleMoves: ["icebeam", "protect", "rapidspin", "scald", "toxic"],
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -234,7 +234,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	primeape: {
-		randomBattleMoves: ["closecombat", "encore", "icepunch", "punishment", "stoneedge", "uturn"],
+		randomBattleMoves: ["closecombat", "honeclaws", "icepunch", "stoneedge", "uturn"],
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -327,12 +327,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	slowbro: {
-		randomBattleMoves: ["calmmind", "fireblast", "psyshock", "scald", "slackoff", "thunderwave", "toxic", "trick"],
+		randomBattleMoves: ["calmmind", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	slowking: {
-		randomBattleMoves: ["fireblast", "grassknot", "icebeam", "psychic", "surf", "trick", "trickroom"],
+		randomBattleMoves: ["fireblast", "grassknot", "icebeam", "nastyplot", "psychic", "surf", "trickroom"],
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -510,7 +510,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		doublesTier: "NFE",
 	},
 	tangrowth: {
-		randomBattleMoves: ["gigadrain", "hiddenpowerfire", "leechseed", "powerwhip", "rockslide", "sleeppowder", "synthesis"],
+		randomBattleMoves: ["earthquake", "hiddenpowerfire", "leechseed", "powerwhip", "rockslide", "sleeppowder", "synthesis"],
 		tier: "RU",
 		doublesTier: "DUU",
 	},

--- a/data/mods/gen5/formats-data.ts
+++ b/data/mods/gen5/formats-data.ts
@@ -1994,7 +1994,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	rotom: {
-		randomBattleMoves: ["hiddenpowerfighting", "hiddenpowerice", "shadowball", "substitute", "painsplit", "thunderbolt", "trick", "voltswitch", "willowisp"],
+		randomBattleMoves: ["hiddenpowerice", "shadowball", "substitute", "painsplit", "thunderbolt", "trick", "voltswitch", "willowisp"],
 		tier: "RU",
 		doublesTier: "DUU",
 	},

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -147,7 +147,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 				hasMove['lightscreen'] || hasMove['reflect']
 			)};
 		case 'uturn':
-			// Infernape doesn't want Expert Belt
+			// Infernape doesn't want mixed sets with U-turn
 			const infernapeCase = species.id === 'infernape' && counter.Special;
 			return {cull: counter.setupType || !!counter.speedsetup || hasMove['batonpass'] || infernapeCase};
 		case 'voltswitch':

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -198,7 +198,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		case 'glare': case 'headbutt':
 			return {cull: hasMove['bodyslam']};
 		case 'healbell':
-			return {cull: hasMove['magiccoat']};
+			return {cull: counter.speedsetup || hasMove['magiccoat']};
 		case 'moonlight': case 'painsplit': case 'recover': case 'roost': case 'softboiled': case 'synthesis':
 			return {cull: ['leechseed', 'rest', 'wish'].some(m => hasMove[m])};
 		case 'substitute':
@@ -227,7 +227,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 	) {
 		switch (ability) {
 		case 'Anger Point': case 'Gluttony': case 'Keen Eye': case 'Moody':
-		case 'Sand Veil': case 'Snow Cloak': case 'Steadfast':
+		case 'Sand Veil': case 'Snow Cloak': case 'Steadfast': case 'Weak Armor':
 			return true;
 		case 'Analytic': case 'Download': case 'Hyper Cutter':
 			return species.nfe;
@@ -250,7 +250,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		case 'Immunity':
 			return hasAbility['Toxic Boost'];
 		case 'Intimidate':
-			return hasMove['rest'];
+			return (hasMove['rest'] || species.id === 'staraptor');
 		case 'Lightning Rod':
 			return species.types.includes('Ground');
 		case 'Limber':
@@ -286,7 +286,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		case 'Unaware':
 			return (counter.setupType || hasAbility['Magic Guard']);
 		case 'Unburden':
-			return species.baseStats.spe > 100;
+			return species.baseStats.spe > 100 && !hasMove['acrobatics'];
 		case 'Water Absorb':
 			return (hasAbility['Drizzle'] || hasAbility['Unaware'] || hasAbility['Volt Absorb']);
 		}
@@ -651,10 +651,10 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			if (abilityNames[2] && abilities[1].rating <= abilities[2].rating && this.randomChance(1, 2)) {
 				[abilities[1], abilities[2]] = [abilities[2], abilities[1]];
 			}
-			if (abilities[0].rating <= abilities[1].rating && this.randomChance(1, 2)) {
-				[abilities[0], abilities[1]] = [abilities[1], abilities[0]];
-			} else if (abilities[0].rating - 0.6 <= abilities[1].rating && this.randomChance(2, 3)) {
-				[abilities[0], abilities[1]] = [abilities[1], abilities[0]];
+			if (abilities[0].rating <= abilities[1].rating) {
+				if (this.randomChance(1, 2)) [abilities[0], abilities[1]] = [abilities[1], abilities[0]];
+			} else if (abilities[0].rating - 0.6 <= abilities[1].rating) {
+				if (this.randomChance(2, 3)) [abilities[0], abilities[1]] = [abilities[1], abilities[0]];
 			}
 
 			// Start with the first abiility and work our way through, culling as we go
@@ -676,6 +676,8 @@ export class RandomGen5Teams extends RandomGen6Teams {
 				ability = 'Guts';
 			} else if (abilityNames.includes('Prankster') && counter.Status > 1) {
 				ability = 'Prankster';
+			} else if (abilityNames.includes('Quick Feet') && hasMove['facade']) {
+				ability = 'Quick Feet';
 			} else if (abilityNames.includes('Swift Swim') && hasMove['raindance']) {
 				ability = 'Swift Swim';
 			}

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -403,6 +403,9 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		) {
 			return ability === 'Sturdy' ? 'Custap Berry' : 'Focus Sash';
 		}
+		if (hasMove['voltswitch'] && species.baseStats.spe <= 90) {
+			return 'Leftovers';
+		}
 		if (
 			counter.damagingMoves.length >= 3 &&
 			species.baseStats.spe >= 40 &&

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -392,7 +392,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			return 'Lustrous Orb';
 		}
 		if (counter.damagingMoves.length >= 4 && ability !== 'Sturdy') {
-			return (hasMove['uturn']) ? 'Expert Belt' : 'Life Orb';
+			return hasMove['uturn'] ? 'Expert Belt' : 'Life Orb';
 		}
 		if (
 			isLead &&

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -252,7 +252,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		case 'Immunity':
 			return hasAbility['Toxic Boost'];
 		case 'Intimidate':
-			return (hasMove['rest'] || species.id === 'staraptor');
+			return hasMove['rest'] || species.id === 'staraptor';
 		case 'Lightning Rod':
 			return species.types.includes('Ground');
 		case 'Limber':

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -147,7 +147,9 @@ export class RandomGen5Teams extends RandomGen6Teams {
 				hasMove['lightscreen'] || hasMove['reflect']
 			)};
 		case 'uturn':
-			return {cull: counter.setupType || !!counter.speedsetup || hasMove['batonpass']};
+			// Infernape doesn't want Expert Belt
+			const infernapeCase = species.id === 'infernape' && counter.Special;
+			return {cull: counter.setupType || !!counter.speedsetup || hasMove['batonpass'] || infernapeCase};
 		case 'voltswitch':
 			return {cull: counter.setupType || counter.speedsetup || ['batonpass', 'magnetrise', 'uturn'].some(m => hasMove[m])};
 
@@ -390,7 +392,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			return 'Lustrous Orb';
 		}
 		if (counter.damagingMoves.length >= 4 && ability !== 'Sturdy') {
-			return (species.name === 'Deoxys-Attack' || counter.Normal || !!counter.priority) ? 'Life Orb' : 'Expert Belt';
+			return (hasMove['uturn']) ? 'Expert Belt' : 'Life Orb';
 		}
 		if (
 			isLead &&


### PR DESCRIPTION
This patch updates Gen 5 Random Battle with many of the less controversial improvements proposed

- Superpower gone from the elemental monkeys bc setup + superp is not a fun time
- Swampert is now its usual supporty self
- fix the ability thing that apparently exists in every gen that makes equally rated abilities have unequal appearance rates
- focus blast nidos are a crime against nature
- things like wish chansey and flamethrower blissey just fully do not work in rands and it took way too long for anyone to realize this
- weak armor mandibuzz is bad
- intimidate staraptor is bad
- that one sceptile that should be unburden but isnt is gone
- quick feet is like, actually a thing again on mightyena sometimes
other misc move changes