### PR TITLE
Scavengers: Make !scav queue broadcastable

### DIFF
--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -1691,7 +1691,7 @@ const ScavengerCommands: ChatCommands = {
 		}
 		if (!target && this.cmd !== 'queuerecycled') {
 			if (this.cmd === 'queue') {
-				if (!this.runBroadcast()) return false;
+				// Necessary for broadcasting: this.runBroadcast();
 				const commandHandler = ScavengerCommands.viewqueue as ChatHandler;
 				commandHandler.call(this, target, room, user, this.connection, this.cmd, this.message);
 				return;

--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -1691,6 +1691,7 @@ const ScavengerCommands: ChatCommands = {
 		}
 		if (!target && this.cmd !== 'queuerecycled') {
 			if (this.cmd === 'queue') {
+				if (!this.runBroadcast()) return false;
 				const commandHandler = ScavengerCommands.viewqueue as ChatHandler;
 				commandHandler.call(this, target, room, user, this.connection, this.cmd, this.message);
 				return;


### PR DESCRIPTION
Currently, the code is meant to call ``!scav viewqueue`` when no parameters are passed, but the runBroadcast line was missing in that bit. Tested to confirm that it broadcasts !scav queue, and that it doesn't broadcast while queuing a hunt with !scav queue [format].

RO confirmation from @aQrator