### PR TITLE
Allow berries to be eaten when a Pokémon with Unnerve switches out to another Pokémon with Unnerve

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -187,7 +187,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			this.effectData.unnerved = false;
 		},
 		onFoeTryEatItem() {
-			return !this.effectData.unnerved
+			return !this.effectData.unnerved;
 		},
 		onSourceAfterFaint(length, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
@@ -209,7 +209,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			this.effectData.unnerved = false;
 		},
 		onFoeTryEatItem() {
-			return !this.effectData.unnerved
+			return !this.effectData.unnerved;
 		},
 		onSourceAfterFaint(length, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
@@ -4061,7 +4061,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			this.effectData.unnerved = false;
 		},
 		onFoeTryEatItem() {
-			return !this.effectData.unnerved
+			return !this.effectData.unnerved;
 		},
 		name: "Unnerve",
 		rating: 1.5,

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -181,15 +181,13 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		onPreStart(pokemon) {
 			this.add('-ability', pokemon, 'As One');
 			this.add('-ability', pokemon, 'Unnerve', pokemon.side.foe);
+			this.effectData.unnerved = true;
 		},
 		onEnd() {
 			this.effectData.unnerved = false;
 		},
 		onFoeTryEatItem() {
-			if (!this.effectData.unnerved) {
-				return true;
-			}
-			return false;
+			return !this.effectData.unnerved
 		},
 		onSourceAfterFaint(length, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
@@ -205,15 +203,13 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		onPreStart(pokemon) {
 			this.add('-ability', pokemon, 'As One');
 			this.add('-ability', pokemon, 'Unnerve', pokemon.side.foe);
+			this.effectData.unnerved = true;
 		},
 		onEnd() {
 			this.effectData.unnerved = false;
 		},
 		onFoeTryEatItem() {
-			if (!this.effectData.unnerved) {
-				return true;
-			}
-			return false;
+			return !this.effectData.unnerved
 		},
 		onSourceAfterFaint(length, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
@@ -4065,10 +4061,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			this.effectData.unnerved = false;
 		},
 		onFoeTryEatItem() {
-			if (!this.effectData.unnerved) {
-				return true;
-			}
-			return false;
+			return !this.effectData.unnerved
 		},
 		name: "Unnerve",
 		rating: 1.5,

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -182,7 +182,15 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			this.add('-ability', pokemon, 'As One');
 			this.add('-ability', pokemon, 'Unnerve', pokemon.side.foe);
 		},
-		onFoeTryEatItem: false,
+		onEnd() {
+			this.effectData.unnerved = false;
+		},
+		onFoeTryEatItem() {
+			if (!this.effectData.unnerved) {
+				return true;
+			}
+			return false;
+		},
 		onSourceAfterFaint(length, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
 				this.boost({atk: length}, source, source, this.dex.getAbility('chillingneigh'));
@@ -198,7 +206,15 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			this.add('-ability', pokemon, 'As One');
 			this.add('-ability', pokemon, 'Unnerve', pokemon.side.foe);
 		},
-		onFoeTryEatItem: false,
+		onEnd() {
+			this.effectData.unnerved = false;
+		},
+		onFoeTryEatItem() {
+			if (!this.effectData.unnerved) {
+				return true;
+			}
+			return false;
+		},
 		onSourceAfterFaint(length, target, source, effect) {
 			if (effect && effect.effectType === 'Move') {
 				this.boost({spa: length}, source, source, this.dex.getAbility('grimneigh'));
@@ -4045,7 +4061,15 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			this.add('-ability', pokemon, 'Unnerve', pokemon.side.foe);
 			this.effectData.unnerved = true;
 		},
-		onFoeTryEatItem: false,
+		onEnd() {
+			this.effectData.unnerved = false;
+		},
+		onFoeTryEatItem() {
+			if (!this.effectData.unnerved) {
+				return true;
+			}
+			return false;
+		},
 		name: "Unnerve",
 		rating: 1.5,
 		num: 127,

--- a/test/sim/abilities/unnerve.js
+++ b/test/sim/abilities/unnerve.js
@@ -10,7 +10,7 @@ describe(`Unnerve`, function () {
 		battle.destroy();
 	});
 
-	it.skip(`should allow Berry activation between switches of Unnerve`, function () {
+	it(`should allow Berry activation between switches of Unnerve`, function () {
 		battle = common.createBattle([[
 			{species: 'toxapex', ability: 'unnerve', moves: ['toxic']},
 			{species: 'corviknight', ability: 'unnerve', moves: ['sleeptalk']},


### PR DESCRIPTION
https://github.com/smogon/pokemon-showdown/projects/3#card-18659708

The fix was also added to both "as one" abilities.