### PR TITLE
Check for berserk before eating item

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -301,7 +301,11 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	},
 	berserk: {
 		onDamage(damage, target, source, effect) {
-			if (effect.effectType === "Move" && (!effect.negateSecondary && !(effect.hasSheerForce && source.hasAbility('sheerforce')))) {
+			if (
+				effect.effectType === "Move" &&
+				!effect.multihit &&
+				(!effect.negateSecondary && !(effect.hasSheerForce && source.hasAbility('sheerforce')))
+			) {
 				target.abilityData.checkedBerserk = false;
 			} else {
 				target.abilityData.checkedBerserk = true;

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -30,7 +30,7 @@ Ratings and how they work:
 	  The sort of ability that defines metagames.
 	ex. Imposter, Shadow Tag
 
-*/	
+*/
 
 export const Abilities: {[abilityid: string]: AbilityData} = {
 	noability: {
@@ -313,7 +313,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		},
 		onTryEatItem(item, pokemon) {
 			const healingItems = [
-				'aguavberry', 'enigmaberry', 'figyberry', 'iapapaberry', 'magoberry', 'sitrusberry', 'wikiberry', 'oranberry', 'berryjuice'
+				'aguavberry', 'enigmaberry', 'figyberry', 'iapapaberry', 'magoberry', 'sitrusberry', 'wikiberry', 'oranberry', 'berryjuice',
 			];
 			if (healingItems.includes(item.id)) {
 				return pokemon.abilityData.checkedBerserk;

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -300,8 +300,12 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 224,
 	},
 	berserk: {
-		onDamage(damage, target) {
-			target.abilityData.checkedBerserk = false;
+		onDamage(damage, target, source, effect) {
+			if (effect.effectType === "Move" && (!effect.negateSecondary && !(effect.hasSheerForce && source.hasAbility('sheerforce'))))
+				target.abilityData.checkedBerserk = false;
+			else {
+				target.abilityData.checkedBerserk = true;
+			}
 		},
 		onAfterMoveSecondary(target, source, move) {
 			if (!source || source === target || !target.hp || !move.totalDamage) {

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -30,7 +30,7 @@ Ratings and how they work:
 	  The sort of ability that defines metagames.
 	ex. Imposter, Shadow Tag
 
-*/
+*/	
 
 export const Abilities: {[abilityid: string]: AbilityData} = {
 	noability: {
@@ -310,6 +310,13 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			} else {
 				target.abilityData.checkedBerserk = true;
 			}
+		},
+		onTryEatItem(item, pokemon) {
+			var healingItems = ['aguavberry', 'enigmaberry', 'figyberry', 'iapapaberry', 'magoberry', 'sitrusberry', 'wikiberry', 'oranberry', 'berryjuice'];
+			if (healingItems.includes(item.id)) {
+				return pokemon.abilityData.checkedBerserk;
+			}
+			return true;
 		},
 		onAfterMoveSecondary(target, source, move) {
 			target.abilityData.checkedBerserk = true;

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -301,27 +301,21 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	},
 	berserk: {
 		onDamage(damage, target, source, effect) {
-			if (effect.effectType === "Move" && (!effect.negateSecondary && !(effect.hasSheerForce && source.hasAbility('sheerforce'))))
+			if (effect.effectType === "Move" && (!effect.negateSecondary && !(effect.hasSheerForce && source.hasAbility('sheerforce')))) {
 				target.abilityData.checkedBerserk = false;
-			else {
+			} else {
 				target.abilityData.checkedBerserk = true;
 			}
 		},
 		onAfterMoveSecondary(target, source, move) {
-			if (!source || source === target || !target.hp || !move.totalDamage) {
-				target.abilityData.checkedBerserk = true;
-				return;
-			}
+			target.abilityData.checkedBerserk = true;
+			if (!source || source === target || !target.hp || !move.totalDamage) return;
 			const lastAttackedBy = target.getLastAttackedBy();
-			if (!lastAttackedBy) {
-				target.abilityData.checkedBerserk = true;
-				return;
-			}
+			if (!lastAttackedBy) return;
 			const damage = move.multihit ? move.totalDamage : lastAttackedBy.damage;
 			if (target.hp <= target.maxhp / 2 && target.hp + damage > target.maxhp / 2) {
 				this.boost({spa: 1});
 			}
-			target.abilityData.checkedBerserk = true;
 		},
 		name: "Berserk",
 		rating: 2,

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -300,14 +300,24 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 224,
 	},
 	berserk: {
+		onDamage(damage, target) {
+			target.abilityData.checkedBerserk = false;
+		},
 		onAfterMoveSecondary(target, source, move) {
-			if (!source || source === target || !target.hp || !move.totalDamage) return;
+			if (!source || source === target || !target.hp || !move.totalDamage) {
+				target.abilityData.checkedBerserk = true;
+				return;
+			}
 			const lastAttackedBy = target.getLastAttackedBy();
-			if (!lastAttackedBy) return;
+			if (!lastAttackedBy) {
+				target.abilityData.checkedBerserk = true;
+				return;
+			}
 			const damage = move.multihit ? move.totalDamage : lastAttackedBy.damage;
 			if (target.hp <= target.maxhp / 2 && target.hp + damage > target.maxhp / 2) {
 				this.boost({spa: 1});
 			}
+			target.abilityData.checkedBerserk = true;
 		},
 		name: "Berserk",
 		rating: 2,

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -312,7 +312,9 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			}
 		},
 		onTryEatItem(item, pokemon) {
-			var healingItems = ['aguavberry', 'enigmaberry', 'figyberry', 'iapapaberry', 'magoberry', 'sitrusberry', 'wikiberry', 'oranberry', 'berryjuice'];
+			const healingItems = [
+				'aguavberry', 'enigmaberry', 'figyberry', 'iapapaberry', 'magoberry', 'sitrusberry', 'wikiberry', 'oranberry', 'berryjuice'
+			];
 			if (healingItems.includes(item.id)) {
 				return pokemon.abilityData.checkedBerserk;
 			}

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1552,7 +1552,6 @@ export class Pokemon {
 	}
 
 	eatItem(force?: boolean, source?: Pokemon, sourceEffect?: Effect) {
-		if (this.hasAbility('berserk') && !this.abilityData.checkedBerserk) return;
 		if (!this.item) return false;
 		if ((!this.hp && this.item !== 'jabocaberry' && this.item !== 'rowapberry') || !this.isActive) return false;
 

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1552,6 +1552,7 @@ export class Pokemon {
 	}
 
 	eatItem(force?: boolean, source?: Pokemon, sourceEffect?: Effect) {
+		if (this.hasAbility('berserk') && !this.abilityData.checkedBerserk) return;
 		if (!this.item) return false;
 		if ((!this.hp && this.item !== 'jabocaberry' && this.item !== 'rowapberry') || !this.isActive) return false;
 

--- a/test/sim/abilities/berserk.js
+++ b/test/sim/abilities/berserk.js
@@ -22,4 +22,17 @@ describe('Berserk', function () {
 		assert.statStage(drampa, 'spa', 1);
 		assert.equal(drampa.hp, Math.floor(drampa.maxhp / 2) + Math.floor(drampa.maxhp / 4));
 	});
+
+	it(`should not activate prior to healing from Sitrus Berry after a multi-hit move`, function () {
+		battle = common.createBattle([[
+			{species: "Drampa", item: 'sitrusberry', ability: 'berserk', evs: {hp: 4}, moves: ['sleeptalk']},
+		], [
+			{species: "wynaut", ability: 'parentalbond', moves: ['seismictoss']},
+		]]);
+
+		battle.makeChoices();
+		const drampa = battle.p1.active[0];
+		assert.statStage(drampa, 'spa', 0);
+		assert.equal(drampa.hp, drampa.maxhp - 200 + Math.floor(drampa.maxhp / 4));
+	});
 });

--- a/test/sim/abilities/berserk.js
+++ b/test/sim/abilities/berserk.js
@@ -10,7 +10,7 @@ describe('Berserk', function () {
 		battle.destroy();
 	});
 
-	it.skip(`should activate prior to healing from Sitrus Berry`, function () {
+	it(`should activate prior to healing from Sitrus Berry`, function () {
 		battle = common.createBattle([[
 			{species: "Drampa", item: 'sitrusberry', ability: 'berserk', evs: {hp: 4}, moves: ['sleeptalk']},
 		], [


### PR DESCRIPTION
https://github.com/smogon/pokemon-showdown/projects/3#card-52059203

Here's a video of it working twice during the same turn in a double battle: https://imgur.com/a/AFVlZdY

The solution does hardcode in the eatItem function, but I don't believe there is another way to do it, since eatItem is called during onUpdate by the berries.