### PR TITLE
Refactor for multi battles

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -180,7 +180,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	asoneglastrier: {
 		onPreStart(pokemon) {
 			this.add('-ability', pokemon, 'As One');
-			this.add('-ability', pokemon, 'Unnerve', pokemon.side.foe);
+			this.add('-ability', pokemon, 'Unnerve');
 			this.effectData.unnerved = true;
 		},
 		onEnd() {
@@ -202,7 +202,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	asonespectrier: {
 		onPreStart(pokemon) {
 			this.add('-ability', pokemon, 'As One');
-			this.add('-ability', pokemon, 'Unnerve', pokemon.side.foe);
+			this.add('-ability', pokemon, 'Unnerve');
 			this.effectData.unnerved = true;
 		},
 		onEnd() {
@@ -4049,12 +4049,12 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	},
 	unnerve: {
 		onPreStart(pokemon) {
-			this.add('-ability', pokemon, 'Unnerve', pokemon.side.foe);
+			this.add('-ability', pokemon, 'Unnerve');
 			this.effectData.unnerved = true;
 		},
 		onStart(pokemon) {
 			if (this.effectData.unnerved) return;
-			this.add('-ability', pokemon, 'Unnerve', pokemon.side.foe);
+			this.add('-ability', pokemon, 'Unnerve');
 			this.effectData.unnerved = true;
 		},
 		onEnd() {

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -474,7 +474,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	},
 	competitive: {
 		onAfterEachBoost(boost, target, source, effect) {
-			if (!source || target.side === source.side) {
+			if (!source || target.isAlly(source)) {
 				if (effect.id === 'stickyweb') {
 					this.hint("Court Change Sticky Web counts as lowering your own Speed, and Competitive only affects stats lowered by foes.", true, source.side);
 				}
@@ -632,7 +632,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			}
 
 			const dazzlingHolder = this.effectData.target;
-			if ((source.side === dazzlingHolder.side || move.target === 'all') && move.priority > 0.1) {
+			if ((source.isAlly(dazzlingHolder) || move.target === 'all') && move.priority > 0.1) {
 				this.attrLastMove('[still]');
 				this.add('cant', dazzlingHolder, 'ability: Dazzling', move, '[of] ' + target);
 				return false;
@@ -661,7 +661,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	},
 	defiant: {
 		onAfterEachBoost(boost, target, source, effect) {
-			if (!source || target.side === source.side) {
+			if (!source || target.isAlly(source)) {
 				if (effect.id === 'stickyweb') {
 					this.hint("Court Change Sticky Web counts as lowering your own Speed, and Defiant only affects stats lowered by foes.", true, source.side);
 				}
@@ -1143,7 +1143,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	friendguard: {
 		name: "Friend Guard",
 		onAnyModifyDamage(damage, source, target, move) {
-			if (target !== this.effectData.target && target.side === this.effectData.target.side) {
+			if (target !== this.effectData.target && target.isAlly(this.effectData.target)) {
 				this.debug('Friend Guard weaken');
 				return this.chainModify(0.75);
 			}
@@ -1885,7 +1885,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			return null;
 		},
 		onAllyTryHitSide(target, source, move) {
-			if (target.side === source.side || move.hasBounced || !move.flags['reflectable']) {
+			if (target.isAlly(source) || move.hasBounced || !move.flags['reflectable']) {
 				return;
 			}
 			const newMove = this.dex.getActiveMove(move.id);
@@ -2703,7 +2703,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			this.add('-ability', pokemon, 'Pressure');
 		},
 		onDeductPP(target, source) {
-			if (target.side === source.side) return;
+			if (target.isAlly(source)) return;
 			return 1;
 		},
 		name: "Pressure",
@@ -2811,7 +2811,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			}
 
 			const dazzlingHolder = this.effectData.target;
-			if ((source.side === dazzlingHolder.side || move.target === 'all') && move.priority > 0.1) {
+			if ((source.isAlly(dazzlingHolder) || move.target === 'all') && move.priority > 0.1) {
 				this.attrLastMove('[still]');
 				this.add('cant', dazzlingHolder, 'ability: Queenly Majesty', move, '[of] ' + target);
 				return false;
@@ -3086,7 +3086,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			}
 		},
 		onAllyTryHitSide(target, source, move) {
-			if (target === this.effectData.target || target.side !== source.side) return;
+			if (target === this.effectData.target || !target.isAlly(source)) return;
 			if (move.type === 'Grass') {
 				this.boost({atk: 1}, this.effectData.target);
 			}
@@ -3825,7 +3825,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	},
 	telepathy: {
 		onTryHit(target, source, move) {
-			if (target !== source && target.side === source.side && move.category !== 'Status') {
+			if (target !== source && target.isAlly(source) && move.category !== 'Status') {
 				this.add('-activate', target, 'ability: Telepathy');
 				return null;
 			}
@@ -4076,7 +4076,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	victorystar: {
 		onAnyModifyAccuracyPriority: -1,
 		onAnyModifyAccuracy(accuracy, target, source) {
-			if (source.side === this.effectData.target.side && typeof accuracy === 'number') {
+			if (source.isAlly(this.effectData.target) && typeof accuracy === 'number') {
 				return this.chainModify([4506, 4096]);
 			}
 		},
@@ -4127,7 +4127,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (move.flags['contact']) {
 				const sourceAbility = source.setAbility('wanderingspirit', target);
 				if (!sourceAbility) return;
-				if (target.side === source.side) {
+				if (target.isAlly(source)) {
 					this.add('-activate', target, 'Skill Swap', '', '', '[of] ' + source);
 				} else {
 					this.add('-activate', target, 'ability: Wandering Spirit', this.dex.getAbility(sourceAbility).name, 'Wandering Spirit', '[of] ' + source);
@@ -4371,7 +4371,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		onAllyTryHitSide(target, source, move) {
 			if (this.effectData.target.activeTurns) return;
 
-			if (target.side === source.side || move.hasBounced || !move.flags['reflectable']) {
+			if (target.isAlly(source) || move.hasBounced || !move.flags['reflectable']) {
 				return;
 			}
 			const newMove = this.dex.getActiveMove(move.id);

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -1607,6 +1607,8 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		onStart(pokemon) {
 			// Imposter does not activate when Skill Swapped or when Neutralizing Gas leaves the field
 			if (!this.effectData.switchingIn) return;
+			// copies across in multibattle and diagonally in free-for-all
+			// fortunately, side.foe already takes care of all that
 			const target = pokemon.side.foe.active[pokemon.side.foe.active.length - 1 - pokemon.position];
 			if (target) {
 				pokemon.transformInto(target, this.dex.getAbility('imposter'));

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -276,7 +276,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (effect?.effectType !== 'Move') {
 				return;
 			}
-			if (source.species.id === 'greninja' && source.hp && !source.transformed && source.side.foe.pokemonLeft) {
+			if (source.species.id === 'greninja' && source.hp && !source.transformed && source.side.foePokemonLeft()) {
 				this.add('-activate', source, 'ability: Battle Bond');
 				source.formeChange('Greninja-Ash', this.effect, true);
 			}
@@ -3154,19 +3154,14 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		onStart(pokemon) {
 			let activated = false;
 			for (const sideCondition of ['reflect', 'lightscreen', 'auroraveil']) {
-				if (pokemon.side.getSideCondition(sideCondition)) {
-					if (!activated) {
-						this.add('-activate', pokemon, 'ability: Screen Cleaner');
-						activated = true;
+				for (const side of [pokemon.side, ...pokemon.side.foeSidesWithConditions()]) {
+					if (side.getSideCondition(sideCondition)) {
+						if (!activated) {
+							this.add('-activate', pokemon, 'ability: Screen Cleaner');
+							activated = true;
+						}
+						side.removeSideCondition(sideCondition);
 					}
-					pokemon.side.removeSideCondition(sideCondition);
-				}
-				if (pokemon.side.foe.getSideCondition(sideCondition)) {
-					if (!activated) {
-						this.add('-activate', pokemon, 'ability: Screen Cleaner');
-						activated = true;
-					}
-					pokemon.side.foe.removeSideCondition(sideCondition);
 				}
 			}
 		},

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -277,7 +277,7 @@ export const Conditions: {[k: string]: ConditionData} = {
 				moveTarget = this.getRandomTarget(target, effect.id);
 			}
 			// if there are no valid targets, randomly choose one later
-			target.volatiles[effect.id].targetLoc = this.getTargetLoc(moveTarget || target, target);
+			target.volatiles[effect.id].targetLoc = target.getLocOf(moveTarget || target);
 			this.attrLastMove('[still]');
 			// Run side-effects normally associated with hitting (e.g., Protean, Libero)
 			this.runEvent('PrepareHit', target, source, effect);

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -61,7 +61,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				}
 			},
 			onDamage(damage, target, source, move) {
-				if (!source || source.side === target.side) return;
+				if (!source || source.isAlly(target)) return;
 				if (!move || move.effectType !== 'Move') return;
 				if (!damage && this.effectData.lastDamage > 0) {
 					damage = this.effectData.totalDamage;
@@ -396,7 +396,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 			onDamage(damage, target, source, move) {
 				if (!move || move.effectType !== 'Move') return;
-				if (!source || source.side === target.side) return;
+				if (!source || source.isAlly(target)) return;
 				if (move.id === 'gust' || move.id === 'thunder') {
 					this.add('-message', 'The foe ' + target.name + ' can\'t be hit while flying!');
 					return null;

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -56,8 +56,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					const damage = this.effectData.totalDamage;
 					this.effectData.totalDamage += damage;
 					this.effectData.lastDamage = damage;
-					this.effectData.sourcePosition = source.position;
-					this.effectData.sourceSide = source.side;
+					this.effectData.sourceSlot = source.getSlot();
 				}
 			},
 			onDamage(damage, target, source, move) {
@@ -68,8 +67,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				}
 				this.effectData.totalDamage += damage;
 				this.effectData.lastDamage = damage;
-				this.effectData.sourcePosition = source.position;
-				this.effectData.sourceSide = source.side;
+				this.effectData.sourceSlot = source.getSlot();
 			},
 			onAfterSetStatus(status, pokemon) {
 				// Sleep, freeze, and partial trap will just pause duration.
@@ -94,7 +92,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 						return false;
 					}
 					this.add('-end', pokemon, 'Bide');
-					const target = this.effectData.sourceSide.active[this.effectData.sourcePosition];
+					const target = this.getAtSlot(this.effectData.sourceSlot);
 					this.actions.moveHit(target, pokemon, move, {damage: this.effectData.totalDamage * 2} as ActiveMove);
 					return false;
 				}
@@ -500,7 +498,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 			onAfterMoveSelfPriority: 1,
 			onAfterMoveSelf(pokemon) {
-				const leecher = pokemon.side.foe.active[pokemon.volatiles['leechseed'].sourcePosition];
+				const leecher = this.getAtSlot(pokemon.volatiles['leechseed'].sourceSlot);
 				if (!leecher || leecher.fainted || leecher.hp <= 0) {
 					this.debug('Nothing to leech into');
 					return;
@@ -887,7 +885,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				// Add here counter damage
 				const lastAttackedBy = target.getLastAttackedBy();
 				if (!lastAttackedBy) {
-					target.attackedBy.push({source: source, move: move.id, damage: uncappedDamage, thisTurn: true});
+					target.attackedBy.push({source: source, move: move.id, damage: uncappedDamage, slot: source.getSlot(), thisTurn: true});
 				} else {
 					lastAttackedBy.move = move.id;
 					lastAttackedBy.damage = uncappedDamage;

--- a/data/mods/gen1stadium/moves.ts
+++ b/data/mods/gen1stadium/moves.ts
@@ -94,7 +94,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 			onAfterMoveSelfPriority: 1,
 			onAfterMoveSelf(pokemon) {
-				const leecher = pokemon.side.foe.active[pokemon.volatiles['leechseed'].sourcePosition];
+				const leecher = this.getAtSlot(pokemon.volatiles['leechseed'].sourceSlot);
 				if (!leecher || leecher.fainted || leecher.hp <= 0) {
 					this.debug('Nothing to leech into');
 					return;
@@ -220,7 +220,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				// Add here counter damage
 				const lastAttackedBy = target.getLastAttackedBy();
 				if (!lastAttackedBy) {
-					target.attackedBy.push({source: source, move: move.id, damage: damage, thisTurn: true});
+					target.attackedBy.push({source: source, move: move.id, damage: damage, slot: source.getSlot(), thisTurn: true});
 				} else {
 					lastAttackedBy.move = move.id;
 					lastAttackedBy.damage = damage;

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -349,7 +349,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onAfterMoveSelfPriority: 2,
 			onAfterMoveSelf(pokemon) {
 				if (!pokemon.hp) return;
-				const leecher = pokemon.side.foe.active[pokemon.volatiles['leechseed'].sourcePosition];
+				const leecher = this.getAtSlot(pokemon.volatiles['leechseed'].sourceSlot);
 				if (!leecher || leecher.fainted || leecher.hp <= 0) {
 					return;
 				}

--- a/data/mods/gen3/abilities.ts
+++ b/data/mods/gen3/abilities.ts
@@ -152,7 +152,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		inherit: true,
 		onUpdate(pokemon) {
 			if (!pokemon.isStarted) return;
-			const target = pokemon.side.foe.randomActive();
+			const target = pokemon.side.foe.randomAlly();
 			if (!target || target.fainted) return;
 			const ability = target.getAbility();
 			const bannedAbilities = ['forecast', 'multitype', 'trace'];

--- a/data/mods/gen3/abilities.ts
+++ b/data/mods/gen3/abilities.ts
@@ -152,7 +152,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		inherit: true,
 		onUpdate(pokemon) {
 			if (!pokemon.isStarted) return;
-			const target = pokemon.side.foe.randomAlly();
+			const target = pokemon.side.randomFoe();
 			if (!target || target.fainted) return;
 			const ability = target.getAbility();
 			const bannedAbilities = ['forecast', 'multitype', 'trace'];

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -126,18 +126,18 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			duration: 1,
 			noCopy: true,
 			onStart(target, source, move) {
-				this.effectData.position = null;
+				this.effectData.slot = null;
 				this.effectData.damage = 0;
 			},
 			onRedirectTargetPriority: -1,
 			onRedirectTarget(target, source, source2) {
-				if (source !== this.effectData.target) return;
-				return source.side.foe.active[this.effectData.position];
+				if (source !== this.effectData.target || !this.effectData.slot) return;
+				return this.getAtSlot(this.effectData.slot);
 			},
 			onDamagePriority: -101,
 			onDamage(damage, target, source, effect) {
 				if (effect.effectType === 'Move' && !source.isAlly(target) && this.getCategory(effect.id) === 'Physical') {
-					this.effectData.position = source.position;
+					this.effectData.slot = source.getSlot();
 					this.effectData.damage = 2 * damage;
 				}
 			},
@@ -402,18 +402,18 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			duration: 1,
 			noCopy: true,
 			onStart(target, source, move) {
-				this.effectData.position = null;
+				this.effectData.slot = null;
 				this.effectData.damage = 0;
 			},
 			onRedirectTargetPriority: -1,
 			onRedirectTarget(target, source, source2) {
-				if (source !== this.effectData.target) return;
-				return source.side.foe.active[this.effectData.position];
+				if (source !== this.effectData.target || !this.effectData.slot) return;
+				return this.getAtSlot(this.effectData.slot);
 			},
 			onDamagePriority: -101,
 			onDamage(damage, target, source, effect) {
 				if (effect.effectType === 'Move' && !source.isAlly(target) && this.getCategory(effect.id) === 'Special') {
-					this.effectData.position = source.position;
+					this.effectData.slot = source.getSlot();
 					this.effectData.damage = 2 * damage;
 				}
 			},

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -136,7 +136,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 			onDamagePriority: -101,
 			onDamage(damage, target, source, effect) {
-				if (effect.effectType === 'Move' && source.side !== target.side && this.getCategory(effect.id) === 'Physical') {
+				if (effect.effectType === 'Move' && !source.isAlly(target) && this.getCategory(effect.id) === 'Physical') {
 					this.effectData.position = source.position;
 					this.effectData.damage = 2 * damage;
 				}
@@ -412,7 +412,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 			onDamagePriority: -101,
 			onDamage(damage, target, source, effect) {
-				if (effect.effectType === 'Move' && source.side !== target.side && this.getCategory(effect.id) === 'Special') {
+				if (effect.effectType === 'Move' && !source.isAlly(target) && this.getCategory(effect.id) === 'Special') {
 					this.effectData.position = source.position;
 					this.effectData.damage = 2 * damage;
 				}

--- a/data/mods/gen4/abilities.ts
+++ b/data/mods/gen4/abilities.ts
@@ -462,7 +462,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		inherit: true,
 		onUpdate(pokemon) {
 			if (!pokemon.isStarted) return;
-			const target = pokemon.side.foe.randomActive();
+			const target = pokemon.side.foe.randomAlly();
 			if (!target || target.fainted) return;
 			const ability = target.getAbility();
 			const bannedAbilities = ['forecast', 'multitype', 'trace'];

--- a/data/mods/gen4/abilities.ts
+++ b/data/mods/gen4/abilities.ts
@@ -224,12 +224,8 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	},
 	minus: {
 		onModifySpA(spa, pokemon) {
-			const allyActive = pokemon.side.active;
-			if (allyActive.length === 1) {
-				return;
-			}
-			for (const ally of allyActive) {
-				if (ally && ally.position !== pokemon.position && !ally.fainted && ally.ability === 'plus') {
+			for (const ally of pokemon.allies()) {
+				if (ally.ability === 'plus') {
 					return spa * 1.5;
 				}
 			}
@@ -278,12 +274,8 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	},
 	plus: {
 		onModifySpA(spa, pokemon) {
-			const allyActive = pokemon.side.active;
-			if (allyActive.length === 1) {
-				return;
-			}
-			for (const ally of allyActive) {
-				if (ally && ally.position !== pokemon.position && !ally.fainted && ally.ability === 'minus') {
+			for (const ally of pokemon.allies()) {
+				if (ally.ability === 'minus') {
 					return spa * 1.5;
 				}
 			}

--- a/data/mods/gen4/abilities.ts
+++ b/data/mods/gen4/abilities.ts
@@ -454,7 +454,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		inherit: true,
 		onUpdate(pokemon) {
 			if (!pokemon.isStarted) return;
-			const target = pokemon.side.foe.randomAlly();
+			const target = pokemon.side.randomFoe();
 			if (!target || target.fainted) return;
 			const ability = target.getAbility();
 			const bannedAbilities = ['forecast', 'multitype', 'trace'];

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -763,7 +763,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 			onSwitchInPriority: -1,
 			onSwitchIn(target) {
-				if (target.position !== this.effectData.sourcePosition) {
+				if (target.getSlot() !== this.effectData.sourceSlot) {
 					return;
 				}
 				if (target.hp > 0) {

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -716,7 +716,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				return 5;
 			},
 			onAnyModifyDamagePhase1(damage, source, target, move) {
-				if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Special') {
+				if (target !== source && this.effectData.target.hasAlly(target) && this.getCategory(move) === 'Special') {
 					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Light Screen weaken');
 						if (target.alliesAndSelf().length > 1) return this.chainModify(2, 3);
@@ -1027,7 +1027,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				return 5;
 			},
 			onAnyModifyDamagePhase1(damage, source, target, move) {
-				if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Physical') {
+				if (target !== source && this.effectData.target.hasAlly(target) && this.getCategory(move) === 'Physical') {
 					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Reflect weaken');
 						if (target.alliesAndSelf().length > 1) return this.chainModify(2, 3);

--- a/data/mods/gen5/abilities.ts
+++ b/data/mods/gen5/abilities.ts
@@ -19,7 +19,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	frisk: {
 		inherit: true,
 		onStart(pokemon) {
-			const target = pokemon.side.foe.randomActive();
+			const target = pokemon.side.foe.randomAlly();
 			if (target?.item) {
 				this.add('-item', target, target.getItem().name, '[from] ability: Frisk', '[of] ' + pokemon);
 			}

--- a/data/mods/gen5/abilities.ts
+++ b/data/mods/gen5/abilities.ts
@@ -19,7 +19,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	frisk: {
 		inherit: true,
 		onStart(pokemon) {
-			const target = pokemon.side.foe.randomAlly();
+			const target = pokemon.side.randomFoe();
 			if (target?.item) {
 				this.add('-item', target, target.getItem().name, '[from] ability: Frisk', '[of] ' + pokemon);
 			}

--- a/data/mods/gen5/moves.ts
+++ b/data/mods/gen5/moves.ts
@@ -502,7 +502,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Special') {
 					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Light Screen weaken');
-						if (target.side.active.length > 1) return this.chainModify([2703, 4096]);
+						if (this.activePerHalf > 1) return this.chainModify([2703, 4096]);
 						return this.chainModify(0.5);
 					}
 				}
@@ -703,7 +703,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Physical') {
 					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Reflect weaken');
-						if (target.side.active.length > 1) return this.chainModify([2703, 4096]);
+						if (this.activePerHalf > 1) return this.chainModify([2703, 4096]);
 						return this.chainModify(0.5);
 					}
 				}

--- a/data/mods/gen5/moves.ts
+++ b/data/mods/gen5/moves.ts
@@ -499,7 +499,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				return 5;
 			},
 			onAnyModifyDamage(damage, source, target, move) {
-				if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Special') {
+				if (target !== source && this.effectData.target.hasAlly(target) && this.getCategory(move) === 'Special') {
 					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Light Screen weaken');
 						if (this.activePerHalf > 1) return this.chainModify([2703, 4096]);
@@ -700,7 +700,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				return 5;
 			},
 			onAnyModifyDamage(damage, source, target, move) {
-				if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Physical') {
+				if (target !== source && this.effectData.target.hasAlly(target) && this.getCategory(move) === 'Physical') {
 					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Reflect weaken');
 						if (this.activePerHalf > 1) return this.chainModify([2703, 4096]);
@@ -795,7 +795,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					return null;
 				}
 			} else {
-				if (target.volatiles['substitute'] || target.side === source.side) {
+				if (target.volatiles['substitute'] || target.isAlly(source)) {
 					return false;
 				}
 

--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -716,7 +716,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	quash: {
 		inherit: true,
 		onHit(target) {
-			if (target.side.active.length < 2) return false; // fails in singles
+			if (this.activePerHalf === 1) return false; // fails in singles
 			const action = this.queue.willMove(target);
 			if (!action) return false;
 

--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -666,7 +666,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 			onTryHitPriority: 4,
 			onTryHit(target, source, effect) {
-				if (!target.isGrounded() || target.isSemiInvulnerable() || target.side === source.side) return;
+				if (!target.isGrounded() || target.isSemiInvulnerable() || target.isAlly(source)) return;
 				if (effect && (effect.priority <= 0.1 || effect.target === 'self')) {
 					return;
 				}

--- a/data/mods/gennext/abilities.ts
+++ b/data/mods/gennext/abilities.ts
@@ -606,7 +606,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			if (move.category === 'Status' || move.selfdestruct || move.multihit) return;
 			if (!target) return;
 			// singles, or single-target move
-			if (target.side.active.length < 2 || ['any', 'normal', 'randomNormal'].includes(move.target)) {
+			if (this.activePerHalf === 1 || ['any', 'normal', 'randomNormal'].includes(move.target)) {
 				move.multihit = 2;
 				move.accuracy = true;
 				pokemon.addVolatile('parentalbond');

--- a/data/mods/gennext/moves.ts
+++ b/data/mods/gennext/moves.ts
@@ -641,8 +641,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					damage = target.hp - 1;
 				}
 				this.effectData.totalDamage += damage;
-				this.effectData.sourcePosition = source.position;
-				this.effectData.sourceSide = source.side;
+				this.effectData.sourceSlot = source.getSlot();
 				return damage;
 			},
 			onAfterSetStatus(status, pokemon) {
@@ -659,7 +658,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 						return false;
 					}
 					this.add('-end', pokemon, 'Bide');
-					const target = this.effectData.sourceSide.active[this.effectData.sourcePosition];
+					const target = this.getAtSlot(this.effectData.sourceSlot);
 					const moveData = {
 						damage: this.effectData.totalDamage * 2,
 					} as unknown as ActiveMove;

--- a/data/mods/gennext/moves.ts
+++ b/data/mods/gennext/moves.ts
@@ -636,7 +636,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onDamagePriority: -11,
 			onDamage(damage, target, source, effect) {
 				if (!effect || effect.effectType !== 'Move') return;
-				if (!source || source.side === target.side) return;
+				if (!source || source.isAlly(target)) return;
 				if (effect.effectType === 'Move' && damage >= target.hp) {
 					damage = target.hp - 1;
 				}

--- a/data/mods/megasforall/abilities.ts
+++ b/data/mods/megasforall/abilities.ts
@@ -1824,8 +1824,7 @@ export const Abilities: {[abilityid: string]: ModdedAbilityData} = {
 					source: source,
 					target: null,
 					move: move,
-					position: target.position,
-					side: target.side,
+					slot: target.getSlot(),
 					moveData: this.dex.getMove(move),
 				});
 				this.add('-ability', source, 'Clairvoyance');
@@ -1838,7 +1837,7 @@ export const Abilities: {[abilityid: string]: ModdedAbilityData} = {
 			duration: 3,
 			onResidualOrder: 3,
 			onEnd(target) {
-				this.effectData.target = this.effectData.side.active[this.effectData.position];
+				this.effectData.target = this.getAtSlot(this.effectData.slot);
 				const data = this.effectData;
 				const move = this.dex.getMove(data.move);
 				this.add('-ability', this.effectData.source, 'Clairvoyance');
@@ -2153,8 +2152,7 @@ export const Abilities: {[abilityid: string]: ModdedAbilityData} = {
 					duration: numberHits,
 					source: source,
 					move: move,
-					position: target.position,
-					side: target.side,
+					slot: target.getSlot(),
 					moveData: this.dex.getMove(move),
 				});
 				return null;

--- a/data/mods/megasforall/abilities.ts
+++ b/data/mods/megasforall/abilities.ts
@@ -430,7 +430,7 @@ export const Abilities: {[abilityid: string]: ModdedAbilityData} = {
 		desc: "When this Pokémon faints, the Pokémon that knocked it out is cursed, losing 1/4 of its maximum HP, rounded down, at the end of each turn while it is active. In addition, the Pokémon that knocked it out permanently receives this Ability, which persists even through switching, until it is knocked out and the Ability is passed along again.",
 		shortDesc: "If this Pokémon is KOed, the attacker is cursed, then permanently receives this Ability.",
 		onFaint(target, source, effect) {
-			if (!source || !effect || target.side === source.side) return;
+			if (!source || !effect || target.isAlly(source)) return;
 			if (effect.effectType === 'Move' && !effect.isFutureMove) {
 				this.add('-ability', target, 'Nightmare Heart');
 				source.addVolatile('curse');
@@ -807,7 +807,7 @@ export const Abilities: {[abilityid: string]: ModdedAbilityData} = {
 		desc: "After using a physical Dark-type move, this Pokémon permanently replaces its target's Ability with Orderly Target. The Pokémon with Orderly Target cannot knock out Mega Honchkrow - all of its moves will leave Mega Honchkrow with at least 1 HP. Blackmail can only affect one target per battle.",
 		shortDesc: "Single-use. Physical Dark moves: permanently change target's Ability to Orderly Target.",
 		onSourceHit(target, source, move) {
-			if (!move || !target || target.side === source.side || !target.hp || this.effectData.busted) return;
+			if (!move || !target || target.isAlly(source) || !target.hp || this.effectData.busted) return;
 			if (target !== source && move.type === 'Dark' && move.category === 'Physical') {
 				target.setAbility('orderlytarget');
 				target.baseAbility = 'orderlytarget' as ID;
@@ -1179,7 +1179,7 @@ export const Abilities: {[abilityid: string]: ModdedAbilityData} = {
 				this.effectData.duration++;
 			},
 			onHit(target, source, move) {
-				if (target.side === this.effectData.target && move.flags['contact']) {
+				if (this.effectData.target.hasAlly(target) && move.flags['contact']) {
 					source.trySetStatus('brn', target);
 				}
 			},
@@ -2024,12 +2024,12 @@ export const Abilities: {[abilityid: string]: ModdedAbilityData} = {
 		desc: "This Pokémon and its adjacent allies are immune to Water-type moves. For 3 turns after the user or its adjacent allies use a Water-type move or are hit by a Water-type move, they are also immune to Ground-type attacks and the effects of Spikes, Toxic Spikes, Sticky Web, and the Arena Trap Ability as long as they remain active. If they use Baton Pass, the replacement will gain the effect. Ingrain, Smack Down, Thousand Arrows, and Iron Ball override this immunity if the user is under any of their effects.",
 		shortDesc: "Pokémon and allies: gain Ground immunity from Water moves; Water immunity.",
 		onAnyTryHit(target, source, move) {
-			if (target !== source && target.side === this.effectData.target.side && move.type === 'Water') {
+			if (target !== source && target.isAlly(this.effectData.target) && move.type === 'Water') {
 				target.addVolatile('poolfloaties');
 				this.add('-immune', target, '[from] ability: Pool Floaties', '[of] ' + this.effectData.target);
 				return null;
 			}
-			if (target !== source && source.side === this.effectData.target.side && move.type === 'Water') {
+			if (target !== source && source.isAlly(this.effectData.target) && move.type === 'Water') {
 				source.addVolatile('poolfloaties');
 			}
 		},

--- a/data/mods/megasforall/conditions.ts
+++ b/data/mods/megasforall/conditions.ts
@@ -3,7 +3,7 @@ const longwhip: ConditionData = {
 	onResidualOrder: 3,
 	onResidual(target) {
 		// unlike a future move, Long Whip activates each turn
-		this.effectData.target = this.effectData.side.active[this.effectData.position];
+		this.effectData.target = this.getAtSlot(this.effectData.slot);
 		const data = this.effectData;
 		const move = this.dex.getMove(data.move);
 		if (data.target.fainted || data.target === data.source) {
@@ -39,7 +39,7 @@ const longwhip: ConditionData = {
 	},
 	onEnd(target) {
 		// unlike a future move, Long Whip activates each turn
-		this.effectData.target = this.effectData.side.active[this.effectData.position];
+		this.effectData.target = this.getAtSlot(this.effectData.slot);
 		const data = this.effectData;
 		const move = this.dex.getMove(data.move);
 		if (data.target.fainted || data.target === data.source) {

--- a/data/mods/megasforall/moves.ts
+++ b/data/mods/megasforall/moves.ts
@@ -83,7 +83,7 @@ export const Moves: {[moveid: string]: ModdedMoveData} = {
 				if (effect && (effect.priority <= 0.1 || effect.target === 'self')) {
 					return;
 				}
-				if (target.isSemiInvulnerable() || target.side === source.side) return;
+				if (target.isSemiInvulnerable() || target.isAlly(source)) return;
 				if (!target.isGrounded()) {
 					const baseMove = this.dex.getMove(effect.id);
 					if (baseMove.priority > 0) {
@@ -606,7 +606,7 @@ export const Moves: {[moveid: string]: ModdedMoveData} = {
 			} else {
 				success = !!this.heal(Math.ceil(target.baseMaxhp * 0.5));
 			}
-			if (success && target.side !== source.side) {
+			if (success && !target.isAlly(source)) {
 				target.staleness = 'external';
 			}
 			return success;
@@ -1246,7 +1246,7 @@ export const Moves: {[moveid: string]: ModdedMoveData} = {
 				return 5;
 			},
 			onAnyModifyDamage(damage, source, target, move) {
-				if (target !== source && target.side === this.effectData.target) {
+				if (target !== source && this.effectData.target.hasAlly(target)) {
 					if ((target.side.getSideCondition('reflect') && this.getCategory(move) === 'Physical') ||
 							(target.side.getSideCondition('lightscreen') && this.getCategory(move) === 'Special')) {
 						return;

--- a/data/mods/megasforall/scripts.ts
+++ b/data/mods/megasforall/scripts.ts
@@ -355,7 +355,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			] as ID[]);
 			if (RESTORATIVE_BERRIES.has('leppaberry' as ID)) {
 				const inflicted = ['trick', 'switcheroo'].includes(effectid);
-				const external = inflicted && source && source.side.id !== this.side.id;
+				const external = inflicted && source && !source.isAlly(this);
 				this.pendingStaleness = external ? 'external' : 'internal';
 			} else {
 				this.pendingStaleness = undefined;

--- a/data/mods/ssb/abilities.ts
+++ b/data/mods/ssb/abilities.ts
@@ -344,7 +344,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			return null;
 		},
 		onAllyTryHitSide(target, source, move) {
-			if (target.side === source.side || move.hasBounced || !move.flags['reflectable']) {
+			if (target.isAlly(source) || move.hasBounced || !move.flags['reflectable']) {
 				return;
 			}
 			const newMove = this.dex.getActiveMove(move.id);
@@ -411,7 +411,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			return null;
 		},
 		onAllyTryHitSide(target, source, move) {
-			if (target.side === source.side || move.hasBounced || !move.flags['reflectable']) {
+			if (target.isAlly(source) || move.hasBounced || !move.flags['reflectable']) {
 				return;
 			}
 			const newMove = this.dex.getActiveMove(move.id);
@@ -1258,7 +1258,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			}
 
 			const dazzlingHolder = this.effectData.target;
-			if ((source.side === dazzlingHolder.side || move.target === 'all') && move.priority > 0.1) {
+			if ((source.isAlly(dazzlingHolder) || move.target === 'all') && move.priority > 0.1) {
 				this.attrLastMove('[still]');
 				this.add('-ability', dazzlingHolder, 'Dark Royalty');
 				this.add('cant', target, move, '[of] ' + dazzlingHolder);
@@ -1731,7 +1731,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			this.add('-ability', pokemon, 'Royal Aura');
 		},
 		onDeductPP(target, source) {
-			if (target.side === source.side) return;
+			if (target.isAlly(source)) return;
 			return 1;
 		},
 		onTryMove(pokemon, target, move) {

--- a/data/mods/ssb/conditions.ts
+++ b/data/mods/ssb/conditions.ts
@@ -1857,7 +1857,7 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 			if (this.field.isWeather('heavyhailstorm')) this.eachEvent('Weather');
 		},
 		onWeather(target, source, effect) {
-			if (target.side === this.effectData.source.side) return;
+			if (target.isAlly(this.effectData.source)) return;
 			// Hail is stronger from Heavy Hailstorm
 			if (!target.hasType('Ice')) this.damage(target.baseMaxhp / 8);
 		},
@@ -2100,7 +2100,7 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 				return;
 			}
 
-			if ((source.side === dazzlingHolder.side || move.target === 'all') && move.priority > 0.1) {
+			if ((source.isAlly(dazzlingHolder) || move.target === 'all') && move.priority > 0.1) {
 				this.attrLastMove('[still]');
 				this.add('message', 'Minior dazzles!');
 				this.add('cant', target, move, '[of] ' + dazzlingHolder);
@@ -2239,7 +2239,7 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 			return 5;
 		},
 		onAnyModifyDamage(damage, source, target, move) {
-			if (target !== source && target.side === this.effectData.target) {
+			if (target !== source && this.effectData.target.hasAlly(target)) {
 				if ((target.side.getSideCondition('reflect') && this.getCategory(move) === 'Physical') ||
 						(target.side.getSideCondition('lightscreen') && this.getCategory(move) === 'Special')) {
 					return;
@@ -2274,7 +2274,7 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 			return 5;
 		},
 		onAnyModifyDamage(damage, source, target, move) {
-			if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Special') {
+			if (target !== source && this.effectData.target.hasAlly(target) && this.getCategory(move) === 'Special') {
 				if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 					this.debug('Light Screen weaken');
 					if (this.activePerHalf > 1) return this.chainModify([2732, 4096]);
@@ -2299,7 +2299,7 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 		name: "Mist",
 		duration: 5,
 		onBoost(boost, target, source, effect) {
-			if (effect.effectType === 'Move' && effect.infiltrates && target.side !== source.side) return;
+			if (effect.effectType === 'Move' && effect.infiltrates && !target.isAlly(source)) return;
 			if (source && target !== source) {
 				let showMsg = false;
 				let i: BoostName;
@@ -2337,7 +2337,7 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 			return 5;
 		},
 		onAnyModifyDamage(damage, source, target, move) {
-			if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Physical') {
+			if (target !== source && this.effectData.target.hasAlly(target) && this.getCategory(move) === 'Physical') {
 				if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 					this.debug('Reflect weaken');
 					if (this.activePerHalf > 1) return this.chainModify([2732, 4096]);
@@ -2369,7 +2369,7 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 		},
 		onSetStatus(status, target, source, effect) {
 			if (!effect || !source) return;
-			if (effect.effectType === 'Move' && effect.infiltrates && target.side !== source.side) return;
+			if (effect.effectType === 'Move' && effect.infiltrates && !target.isAlly(source)) return;
 			if (target !== source) {
 				this.debug('interrupting setStatus');
 				if (effect.id === 'synchronize' || (effect.effectType === 'Move' && !effect.secondaries)) {
@@ -2380,7 +2380,7 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 		},
 		onTryAddVolatile(status, target, source, effect) {
 			if (!effect || !source) return;
-			if (effect.effectType === 'Move' && effect.infiltrates && target.side !== source.side) return;
+			if (effect.effectType === 'Move' && effect.infiltrates && !target.isAlly(source)) return;
 			if ((status.id === 'confusion' || status.id === 'yawn') && target !== source) {
 				if (effect.effectType === 'Move' && !effect.secondaries) this.add('-activate', target, 'move: Safeguard');
 				return null;

--- a/data/mods/ssb/conditions.ts
+++ b/data/mods/ssb/conditions.ts
@@ -2246,7 +2246,7 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 				}
 				if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 					this.debug('Aurora Veil weaken');
-					if (target.side.active.length > 1) return this.chainModify([2732, 4096]);
+					if (this.activePerHalf > 1) return this.chainModify([2732, 4096]);
 					return this.chainModify(0.5);
 				}
 			}
@@ -2277,7 +2277,7 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 			if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Special') {
 				if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 					this.debug('Light Screen weaken');
-					if (target.side.active.length > 1) return this.chainModify([2732, 4096]);
+					if (this.activePerHalf > 1) return this.chainModify([2732, 4096]);
 					return this.chainModify(0.5);
 				}
 			}
@@ -2340,7 +2340,7 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 			if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Physical') {
 				if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 					this.debug('Reflect weaken');
-					if (target.side.active.length > 1) return this.chainModify([2732, 4096]);
+					if (this.activePerHalf > 1) return this.chainModify([2732, 4096]);
 					return this.chainModify(0.5);
 				}
 			}

--- a/data/mods/ssb/moves.ts
+++ b/data/mods/ssb/moves.ts
@@ -2579,7 +2579,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onHit(pokemon, source, move) {
 				if (!pokemon.hp) return;
 				if (this.effectData.gotHit) return;
-				if (pokemon.side !== source.side && move.category !== 'Status') {
+				if (!pokemon.isAlly(source) && move.category !== 'Status') {
 					this.effectData.gotHit = true;
 					this.add('-message', 'Gossifleur was prepared for the impact!');
 					const boosts: {[k: string]: number} = {def: 2, spd: 2};

--- a/data/mods/ssb/moves.ts
+++ b/data/mods/ssb/moves.ts
@@ -2214,7 +2214,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 						this.add('-activate', pokemon, 'move: The Hunt is On!');
 						alreadyAdded = true;
 					}
-					this.actions.runMove('thehuntison', source, this.getTargetLoc(pokemon, source));
+					this.actions.runMove('thehuntison', source, source.getLocOf(pokemon));
 				}
 			},
 		},

--- a/data/mods/ssb/moves.ts
+++ b/data/mods/ssb/moves.ts
@@ -2491,7 +2491,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onSwitchInPriority: 1,
 			onSwitchIn(target) {
 				const positions: boolean[] = this.effectData.positions;
-				if (target.position !== this.effectData.sourcePosition) {
+				if (target.getSlot() !== this.effectData.sourceSlot) {
 					return;
 				}
 				if (!target.fainted) {

--- a/data/mods/ssb/scripts.ts
+++ b/data/mods/ssb/scripts.ts
@@ -214,7 +214,7 @@ export const Scripts: ModdedBattleScriptsData = {
 					if (this.battle.faintMessages()) break;
 					if (dancer.fainted) continue;
 					this.battle.add('-activate', dancer, 'ability: Dancer');
-					const dancersTarget = target!.side !== dancer.side && pokemon.side === dancer.side ? target! : pokemon;
+					const dancersTarget = !target!.isAlly(dancer) && pokemon.isAlly(dancer) ? target! : pokemon;
 					const dancersTargetLoc = dancer.getLocOf(dancersTarget);
 					this.runMove(move.id, dancer, dancersTargetLoc, this.dex.getAbility('dancer'), undefined, true);
 				}
@@ -236,7 +236,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				} else if (
 					this.battle.gen >= 7 && move.pranksterBoosted &&
 					(pokemon.hasAbility('prankster') || pokemon.hasAbility('plausibledeniability') || pokemon.volatiles['nol']) &&
-					targets[i].side !== pokemon.side && !this.dex.getImmunity('prankster', target)
+					!targets[i].isAlly(pokemon) && !this.dex.getImmunity('prankster', target)
 				) {
 					this.battle.debug('natural prankster immunity');
 					if (!target.illusion) this.battle.hint("Since gen 7, Dark is immune to Prankster moves.");

--- a/data/mods/ssb/scripts.ts
+++ b/data/mods/ssb/scripts.ts
@@ -233,10 +233,11 @@ export const Scripts: ModdedBattleScriptsData = {
 				} else if (!this.battle.singleEvent('TryImmunity', move, {}, target, pokemon, move)) {
 					this.battle.add('-immune', target);
 					hitResults[i] = false;
-				} else if (this.battle.gen >= 7 && move.pranksterBoosted &&
-				// eslint-disable-next-line max-len
-				(pokemon.hasAbility('prankster') || pokemon.hasAbility('plausibledeniability') || pokemon.volatiles['nol']) &&
-				targets[i].side !== pokemon.side && !this.dex.getImmunity('prankster', target)) {
+				} else if (
+					this.battle.gen >= 7 && move.pranksterBoosted &&
+					(pokemon.hasAbility('prankster') || pokemon.hasAbility('plausibledeniability') || pokemon.volatiles['nol']) &&
+					targets[i].side !== pokemon.side && !this.dex.getImmunity('prankster', target)
+				) {
 					this.battle.debug('natural prankster immunity');
 					if (!target.illusion) this.battle.hint("Since gen 7, Dark is immune to Prankster moves.");
 					this.battle.add('-immune', target);

--- a/data/mods/ssb/scripts.ts
+++ b/data/mods/ssb/scripts.ts
@@ -215,7 +215,7 @@ export const Scripts: ModdedBattleScriptsData = {
 					if (dancer.fainted) continue;
 					this.battle.add('-activate', dancer, 'ability: Dancer');
 					const dancersTarget = target!.side !== dancer.side && pokemon.side === dancer.side ? target! : pokemon;
-					const dancersTargetLoc = this.battle.getTargetLoc(dancersTarget, dancer);
+					const dancersTargetLoc = dancer.getLocOf(dancersTarget);
 					this.runMove(move.id, dancer, dancersTargetLoc, this.dex.getAbility('dancer'), undefined, true);
 				}
 			}

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -786,7 +786,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				return 5;
 			},
 			onAnyModifyDamage(damage, source, target, move) {
-				if (target !== source && target.side === this.effectData.target) {
+				if (target !== source && this.effectData.target.hasAlly(target)) {
 					if ((target.side.getSideCondition('reflect') && this.getCategory(move) === 'Physical') ||
 							(target.side.getSideCondition('lightscreen') && this.getCategory(move) === 'Special')) {
 						return;
@@ -2646,7 +2646,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				return source.side.foe.active[this.effectData.position];
 			},
 			onDamagingHit(damage, target, source, move) {
-				if (source.side !== target.side && this.getCategory(move) === 'Physical') {
+				if (!source.isAlly(target) && this.getCategory(move) === 'Physical') {
 					this.effectData.position = source.position;
 					this.effectData.damage = 2 * damage;
 				}
@@ -3122,7 +3122,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-singlemove', pokemon, 'Destiny Bond');
 			},
 			onFaint(target, source, effect) {
-				if (!source || !effect || target.side === source.side) return;
+				if (!source || !effect || target.isAlly(source)) return;
 				if (effect.effectType === 'Move' && !effect.isFutureMove) {
 					if (source.volatiles['dynamax']) {
 						this.add('-hint', "Dynamaxed Pokémon are immune to Destiny Bond.");
@@ -4379,7 +4379,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			const oldAbility = target.setAbility(source.ability);
 			if (oldAbility) {
 				this.add('-ability', target, target.getAbility().name, '[from] move: Entrainment');
-				if (target.side !== source.side) target.volatileStaleness = 'external';
+				if (!target.isAlly(source)) target.volatileStaleness = 'external';
 				return;
 			}
 			return false;
@@ -4852,7 +4852,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				) {
 					continue;
 				}
-				if (action.pokemon.side === source.side && ['grasspledge', 'waterpledge'].includes(action.move.id)) {
+				if (action.pokemon.isAlly(source) && ['grasspledge', 'waterpledge'].includes(action.move.id)) {
 					this.queue.prioritizeAction(action, move);
 					this.add('-waiting', source, action.pokemon);
 					return null;
@@ -5297,7 +5297,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			} else {
 				success = !!this.heal(Math.ceil(target.baseMaxhp * 0.5));
 			}
-			if (success && target.side !== source.side) {
+			if (success && !target.isAlly(source)) {
 				target.staleness = 'external';
 			}
 			return success;
@@ -7070,7 +7070,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				) {
 					continue;
 				}
-				if (action.pokemon.side === source.side && ['waterpledge', 'firepledge'].includes(action.move.id)) {
+				if (action.pokemon.isAlly(source) && ['waterpledge', 'firepledge'].includes(action.move.id)) {
 					this.queue.prioritizeAction(action, move);
 					this.add('-waiting', source, action.pokemon);
 					return null;
@@ -7835,7 +7835,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			} else {
 				success = !!this.heal(Math.ceil(target.baseMaxhp * 0.5));
 			}
-			if (success && target.side !== source.side) {
+			if (success && !target.isAlly(source)) {
 				target.staleness = 'external';
 			}
 			return success;
@@ -9659,7 +9659,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				return 5;
 			},
 			onAnyModifyDamage(damage, source, target, move) {
-				if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Special') {
+				if (target !== source && this.effectData.target.hasAlly(target) && this.getCategory(move) === 'Special') {
 					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Light Screen weaken');
 						if (this.activePerHalf > 1) return this.chainModify([2732, 4096]);
@@ -9996,7 +9996,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				return null;
 			},
 			onAllyTryHitSide(target, source, move) {
-				if (target.side === source.side || move.hasBounced || !move.flags['reflectable']) {
+				if (target.isAlly(source) || move.hasBounced || !move.flags['reflectable']) {
 					return;
 				}
 				const newMove = this.dex.getActiveMove(move.id);
@@ -11250,7 +11250,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				return source.side.foe.active[this.effectData.position];
 			},
 			onDamagingHit(damage, target, source, move) {
-				if (source.side !== target.side && this.getCategory(move) === 'Special') {
+				if (!source.isAlly(target) && this.getCategory(move) === 'Special') {
 					this.effectData.position = source.position;
 					this.effectData.damage = 2 * damage;
 				}
@@ -11318,7 +11318,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		condition: {
 			duration: 5,
 			onBoost(boost, target, source, effect) {
-				if (effect.effectType === 'Move' && effect.infiltrates && target.side !== source.side) return;
+				if (effect.effectType === 'Move' && effect.infiltrates && !target.isAlly(source)) return;
 				if (source && target !== source) {
 					let showMsg = false;
 					let i: BoostName;
@@ -12712,13 +12712,13 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {bullet: 1, protect: 1, mirror: 1},
 		onTryHit(target, source, move) {
-			if (source.side === target.side) {
+			if (source.isAlly(target)) {
 				move.basePower = 0;
 				move.infiltrates = true;
 			}
 		},
 		onHit(target, source) {
-			if (source.side === target.side) {
+			if (source.isAlly(target)) {
 				if (!this.heal(Math.floor(target.baseMaxhp * 0.5))) {
 					this.add('-immune', target);
 				}
@@ -13190,7 +13190,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				if (effect && (effect.priority <= 0.1 || effect.target === 'self')) {
 					return;
 				}
-				if (target.isSemiInvulnerable() || target.side === source.side) return;
+				if (target.isSemiInvulnerable() || target.isAlly(source)) return;
 				if (!target.isGrounded()) {
 					const baseMove = this.dex.getMove(effect.id);
 					if (baseMove.priority > 0) {
@@ -13411,7 +13411,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {contact: 1, protect: 1, mirror: 1},
 		beforeTurnCallback(pokemon) {
 			for (const side of this.sides) {
-				if (side === pokemon.side) continue;
+				if (side.hasAlly(pokemon)) continue;
 				side.addSideCondition('pursuit', pokemon);
 				const data = side.getSideConditionData('pursuit');
 				if (!data.sources) {
@@ -13831,7 +13831,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				return 5;
 			},
 			onAnyModifyDamage(damage, source, target, move) {
-				if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Physical') {
+				if (target !== source && this.effectData.target.hasAlly(target) && this.getCategory(move) === 'Physical') {
 					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Reflect weaken');
 						if (this.activePerHalf > 1) return this.chainModify([2732, 4096]);
@@ -13875,7 +13875,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			this.add('-start', source, 'typechange', '[from] move: Reflect Type', '[of] ' + target);
 			source.setType(newBaseTypes);
 			source.addedType = target.addedType;
-			source.knownType = target.side === source.side && target.knownType;
+			source.knownType = target.isAlly(source) && target.knownType;
 		},
 		secondary: null,
 		target: "normal",
@@ -14524,7 +14524,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onSetStatus(status, target, source, effect) {
 				if (!effect || !source) return;
 				if (effect.id === 'yawn') return;
-				if (effect.effectType === 'Move' && effect.infiltrates && target.side !== source.side) return;
+				if (effect.effectType === 'Move' && effect.infiltrates && !target.isAlly(source)) return;
 				if (target !== source) {
 					this.debug('interrupting setStatus');
 					if (effect.id === 'synchronize' || (effect.effectType === 'Move' && !effect.secondaries)) {
@@ -14535,7 +14535,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			},
 			onTryAddVolatile(status, target, source, effect) {
 				if (!effect || !source) return;
-				if (effect.effectType === 'Move' && effect.infiltrates && target.side !== source.side) return;
+				if (effect.effectType === 'Move' && effect.infiltrates && !target.isAlly(source)) return;
 				if ((status.id === 'confusion' || status.id === 'yawn') && target !== source) {
 					if (effect.effectType === 'Move' && !effect.secondaries) this.add('-activate', target, 'move: Safeguard');
 					return null;
@@ -15173,7 +15173,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-singleturn', pokemon, 'move: Shell Trap');
 			},
 			onHit(pokemon, source, move) {
-				if (pokemon.side !== source.side && move.category === 'Physical') {
+				if (!pokemon.isAlly(source) && move.category === 'Physical') {
 					pokemon.volatiles['shelltrap'].gotHit = true;
 					const action = this.queue.willMove(pokemon);
 					if (action) {
@@ -15424,7 +15424,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		onHit(target, source, move) {
 			const targetAbility = target.getAbility();
 			const sourceAbility = source.getAbility();
-			if (target.side === source.side) {
+			if (target.isAlly(source)) {
 				this.add('-activate', source, 'move: Skill Swap', '', '', '[of] ' + target);
 			} else {
 				this.add('-activate', source, 'move: Skill Swap', targetAbility, sourceAbility, '[of] ' + target);
@@ -15435,7 +15435,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			target.ability = sourceAbility.id;
 			source.abilityData = {id: this.toID(source.ability), target: source};
 			target.abilityData = {id: this.toID(target.ability), target: target};
-			if (target.side !== source.side) target.volatileStaleness = 'external';
+			if (!target.isAlly(source)) target.volatileStaleness = 'external';
 			this.singleEvent('Start', targetAbility, source.abilityData, source);
 			this.singleEvent('Start', sourceAbility, target.abilityData, target);
 		},
@@ -15553,7 +15553,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					return null;
 				}
 			} else {
-				if (target.volatiles['substitute'] || target.side === source.side) {
+				if (target.volatiles['substitute'] || target.isAlly(source)) {
 					return false;
 				}
 				if (target.getWeight() >= 2000) {
@@ -19002,7 +19002,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				) {
 					continue;
 				}
-				if (otherMoveUser.side === source.side && ['firepledge', 'grasspledge'].includes(otherMove.id)) {
+				if (otherMoveUser.isAlly(source) && ['firepledge', 'grasspledge'].includes(otherMove.id)) {
 					this.queue.prioritizeAction(action, move);
 					this.add('-waiting', source, otherMoveUser);
 					return null;

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -13450,7 +13450,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 							}
 						}
 					}
-					this.actions.runMove('pursuit', source, this.getTargetLoc(pokemon, source));
+					this.actions.runMove('pursuit', source, source.getLocOf(pokemon));
 				}
 			},
 		},

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -4877,20 +4877,16 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-sidestart', targetSide, 'Fire Pledge');
 			},
 			onEnd(targetSide) {
-				for (const pokemon of targetSide.activeTeam()) {
-					if (pokemon && !pokemon.hasType('Fire')) {
-						this.damage(pokemon.baseMaxhp / 8, pokemon);
-					}
+				for (const pokemon of targetSide.allies()) {
+					if (!pokemon.hasType('Fire')) this.damage(pokemon.baseMaxhp / 8, pokemon);
 				}
 				this.add('-sideend', targetSide, 'Fire Pledge');
 			},
 			onResidualOrder: 5,
 			onResidualSubOrder: 1,
 			onResidual(side) {
-				for (const pokemon of side.activeTeam()) {
-					if (pokemon && !pokemon.hasType('Fire')) {
-						this.damage(pokemon.baseMaxhp / 8, pokemon);
-					}
+				for (const pokemon of side.allies()) {
+					if (!pokemon.hasType('Fire')) this.damage(pokemon.baseMaxhp / 8, pokemon);
 				}
 			},
 		},
@@ -5944,15 +5940,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {snatch: 1, authentic: 1},
 		onHitSide(side, source, move) {
-			const targets = [];
-			for (const pokemon of side.activeTeam()) {
-				if (
-					pokemon.hasAbility(['plus', 'minus']) &&
-					(!pokemon.volatiles['maxguard'] || this.runEvent('TryHit', pokemon, source, move))
-				) {
-					targets.push(pokemon);
-				}
-			}
+			const targets = side.allies().filter(target => (
+				target.hasAbility(['plus', 'minus']) &&
+				(!target.volatiles['maxguard'] || this.runEvent('TryHit', target, source, move))
+			));
 			if (!targets.length) return false;
 			let didSomething = false;
 			for (const target of targets) {
@@ -6187,13 +6178,13 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onResidualOrder: 5,
 			onResidualSubOrder: 1.1,
 			onResidual(targetSide) {
-				for (const pokemon of targetSide.activeTeam()) {
-					if (!pokemon.hasType('Water')) this.damage(pokemon.baseMaxhp / 6, pokemon);
+				for (const target of targetSide.allies()) {
+					if (!target.hasType('Water')) this.damage(target.baseMaxhp / 6, target);
 				}
 			},
 			onEnd(targetSide) {
-				for (const pokemon of targetSide.activeTeam()) {
-					if (!pokemon.hasType('Water')) this.damage(pokemon.baseMaxhp / 6, pokemon);
+				for (const target of targetSide.allies()) {
+					if (!target.hasType('Water')) this.damage(target.baseMaxhp / 6, target);
 				}
 				this.add('-sideend', targetSide, 'G-Max Cannonade');
 			},
@@ -6839,13 +6830,13 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onResidualOrder: 5,
 			onResidualSubOrder: 1.1,
 			onResidual(targetSide) {
-				for (const pokemon of targetSide.activeTeam()) {
-					if (!pokemon.hasType('Grass')) this.damage(pokemon.baseMaxhp / 6, pokemon);
+				for (const target of targetSide.allies()) {
+					if (!target.hasType('Grass')) this.damage(target.baseMaxhp / 6, target);
 				}
 			},
 			onEnd(targetSide) {
-				for (const pokemon of targetSide.activeTeam()) {
-					if (!pokemon.hasType('Grass')) this.damage(pokemon.baseMaxhp / 6, pokemon);
+				for (const target of targetSide.allies()) {
+					if (!target.hasType('Grass')) this.damage(target.baseMaxhp / 6, target);
 				}
 				this.add('-sideend', targetSide, 'G-Max Vine Lash');
 			},
@@ -6879,13 +6870,13 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onResidualOrder: 5,
 			onResidualSubOrder: 1.1,
 			onResidual(targetSide) {
-				for (const pokemon of targetSide.activeTeam()) {
-					if (!pokemon.hasType('Rock')) this.damage(pokemon.baseMaxhp / 6, pokemon);
+				for (const target of targetSide.allies()) {
+					if (!target.hasType('Rock')) this.damage(target.baseMaxhp / 6, target);
 				}
 			},
 			onEnd(targetSide) {
-				for (const pokemon of targetSide.activeTeam()) {
-					if (!pokemon.hasType('Rock')) this.damage(pokemon.baseMaxhp / 6, pokemon);
+				for (const target of targetSide.allies()) {
+					if (!target.hasType('Rock')) this.damage(target.baseMaxhp / 6, target);
 				}
 				this.add('-sideend', targetSide, 'G-Max Volcalith');
 			},
@@ -6942,13 +6933,13 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onResidualOrder: 5,
 			onResidualSubOrder: 1.1,
 			onResidual(targetSide) {
-				for (const pokemon of targetSide.activeTeam()) {
-					if (!pokemon.hasType('Fire')) this.damage(pokemon.baseMaxhp / 6, pokemon);
+				for (const target of targetSide.allies()) {
+					if (!target.hasType('Fire')) this.damage(target.baseMaxhp / 6, target);
 				}
 			},
 			onEnd(targetSide) {
-				for (const pokemon of targetSide.activeTeam()) {
-					if (!pokemon.hasType('Fire')) this.damage(pokemon.baseMaxhp / 6, pokemon);
+				for (const target of targetSide.allies()) {
+					if (!target.hasType('Fire')) this.damage(target.baseMaxhp / 6, target);
 				}
 				this.add('-sideend', targetSide, 'G-Max Wildfire');
 			},
@@ -10106,16 +10097,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {snatch: 1, distance: 1, authentic: 1},
 		onHitSide(side, source, move) {
-			const targets = [];
-			for (const pokemon of side.activeTeam()) {
-				if (
-					pokemon.hasAbility(['plus', 'minus']) &&
-					(!pokemon.volatiles['maxguard'] || this.runEvent('TryHit', pokemon, source, move))
-				) {
-					targets.push(pokemon);
-				}
-			}
+			const targets = side.allies().filter(ally => (
+				ally.hasAbility(['plus', 'minus']) &&
+				(!ally.volatiles['maxguard'] || this.runEvent('TryHit', ally, source, move))
+			));
 			if (!targets.length) return false;
+
 			let didSomething = false;
 			for (const target of targets) {
 				didSomething = this.boost({def: 1, spd: 1}, target, source, move, false, true) || didSomething;

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2631,23 +2631,23 @@ export const Moves: {[moveid: string]: MoveData} = {
 		},
 		onTryHit(target, source, move) {
 			if (!source.volatiles['counter']) return false;
-			if (source.volatiles['counter'].position === null) return false;
+			if (source.volatiles['counter'].slot === null) return false;
 		},
 		condition: {
 			duration: 1,
 			noCopy: true,
 			onStart(target, source, move) {
-				this.effectData.position = null;
+				this.effectData.slot = null;
 				this.effectData.damage = 0;
 			},
 			onRedirectTargetPriority: -1,
 			onRedirectTarget(target, source, source2) {
-				if (source !== this.effectData.target) return;
-				return source.side.foe.active[this.effectData.position];
+				if (source !== this.effectData.target || !this.effectData.slot) return;
+				return this.getAtSlot(this.effectData.slot);
 			},
 			onDamagingHit(damage, target, source, move) {
 				if (!source.isAlly(target) && this.getCategory(move) === 'Physical') {
-					this.effectData.position = source.position;
+					this.effectData.slot = source.getSlot();
 					this.effectData.damage = 2 * damage;
 				}
 			},
@@ -9539,7 +9539,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			},
 			onResidualOrder: 8,
 			onResidual(pokemon) {
-				const target = this.effectData.source.side.active[pokemon.volatiles['leechseed'].sourcePosition];
+				const target = this.getAtSlot(pokemon.volatiles['leechseed'].sourceSlot);
 				if (!target || target.fainted || target.hp <= 0) {
 					this.debug('Nothing to leech into');
 					return;
@@ -10902,8 +10902,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		},
 		onModifyTarget(targetRelayVar, source, target, move) {
 			const lastDamagedBy = source.getLastDamagedBy(true);
-			if (lastDamagedBy?.position !== undefined) {
-				targetRelayVar.target = source.side.foe.active[lastDamagedBy.position];
+			if (lastDamagedBy) {
+				targetRelayVar.target = this.getAtSlot(lastDamagedBy.slot);
 			}
 		},
 		secondary: null,
@@ -11235,23 +11235,23 @@ export const Moves: {[moveid: string]: MoveData} = {
 		},
 		onTryHit(target, source, move) {
 			if (!source.volatiles['mirrorcoat']) return false;
-			if (source.volatiles['mirrorcoat'].position === null) return false;
+			if (source.volatiles['mirrorcoat'].slot === null) return false;
 		},
 		condition: {
 			duration: 1,
 			noCopy: true,
 			onStart(target, source, move) {
-				this.effectData.position = null;
+				this.effectData.slot = null;
 				this.effectData.damage = 0;
 			},
 			onRedirectTargetPriority: -1,
 			onRedirectTarget(target, source, source2) {
-				if (source !== this.effectData.target) return;
-				return source.side.foe.active[this.effectData.position];
+				if (source !== this.effectData.target || !this.effectData.slot) return;
+				return this.getAtSlot(this.effectData.slot);
 			},
 			onDamagingHit(damage, target, source, move) {
 				if (!source.isAlly(target) && this.getCategory(move) === 'Special') {
-					this.effectData.position = source.position;
+					this.effectData.slot = source.getSlot();
 					this.effectData.damage = 2 * damage;
 				}
 			},

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -793,7 +793,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					}
 					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Aurora Veil weaken');
-						if (target.side.active.length > 1) return this.chainModify([2732, 4096]);
+						if (this.activePerHalf > 1) return this.chainModify([2732, 4096]);
 						return this.chainModify(0.5);
 					}
 				}
@@ -5495,7 +5495,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {},
 		volatileStatus: 'followme',
 		onTry(source) {
-			return source.side.active.length > 1;
+			return this.activePerHalf > 1;
 		},
 		condition: {
 			duration: 1,
@@ -9662,7 +9662,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Special') {
 					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Light Screen weaken');
-						if (target.side.active.length > 1) return this.chainModify([2732, 4096]);
+						if (this.activePerHalf > 1) return this.chainModify([2732, 4096]);
 						return this.chainModify(0.5);
 					}
 				}
@@ -13485,7 +13485,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
 		onHit(target) {
-			if (target.side.active.length < 2) return false; // fails in singles
+			if (this.activePerHalf === 1) return false; // fails in singles
 			const action = this.queue.willMove(target);
 			if (!action) return false;
 
@@ -13624,7 +13624,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {powder: 1},
 		volatileStatus: 'ragepowder',
 		onTry(source) {
-			return source.side.active.length > 1;
+			return this.activePerHalf > 1;
 		},
 		condition: {
 			duration: 1,
@@ -13835,7 +13835,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				if (target !== source && target.side === this.effectData.target && this.getCategory(move) === 'Physical') {
 					if (!target.getMoveHitData(move).crit && !move.infiltrates) {
 						this.debug('Reflect weaken');
-						if (target.side.active.length > 1) return this.chainModify([2732, 4096]);
+						if (this.activePerHalf > 1) return this.chainModify([2732, 4096]);
 						return this.chainModify(0.5);
 					}
 				}
@@ -16579,7 +16579,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {protect: 1, reflectable: 1, mystery: 1},
 		volatileStatus: 'spotlight',
 		onTryHit(target) {
-			if (target.side.active.length < 2) return false;
+			if (this.activePerHalf === 1) return false;
 		},
 		condition: {
 			duration: 1,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -4877,7 +4877,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-sidestart', targetSide, 'Fire Pledge');
 			},
 			onEnd(targetSide) {
-				for (const pokemon of targetSide.active) {
+				for (const pokemon of targetSide.activeTeam()) {
 					if (pokemon && !pokemon.hasType('Fire')) {
 						this.damage(pokemon.baseMaxhp / 8, pokemon);
 					}
@@ -4887,7 +4887,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onResidualOrder: 5,
 			onResidualSubOrder: 1,
 			onResidual(side) {
-				for (const pokemon of side.active) {
+				for (const pokemon of side.activeTeam()) {
 					if (pokemon && !pokemon.hasType('Fire')) {
 						this.damage(pokemon.baseMaxhp / 8, pokemon);
 					}
@@ -5945,7 +5945,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {snatch: 1, authentic: 1},
 		onHitSide(side, source, move) {
 			const targets = [];
-			for (const pokemon of side.active) {
+			for (const pokemon of side.activeTeam()) {
 				if (
 					pokemon.hasAbility(['plus', 'minus']) &&
 					(!pokemon.volatiles['maxguard'] || this.runEvent('TryHit', pokemon, source, move))
@@ -6187,12 +6187,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onResidualOrder: 5,
 			onResidualSubOrder: 1.1,
 			onResidual(targetSide) {
-				for (const pokemon of targetSide.active) {
+				for (const pokemon of targetSide.activeTeam()) {
 					if (!pokemon.hasType('Water')) this.damage(pokemon.baseMaxhp / 6, pokemon);
 				}
 			},
 			onEnd(targetSide) {
-				for (const pokemon of targetSide.active) {
+				for (const pokemon of targetSide.activeTeam()) {
 					if (!pokemon.hasType('Water')) this.damage(pokemon.baseMaxhp / 6, pokemon);
 				}
 				this.add('-sideend', targetSide, 'G-Max Cannonade');
@@ -6839,12 +6839,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onResidualOrder: 5,
 			onResidualSubOrder: 1.1,
 			onResidual(targetSide) {
-				for (const pokemon of targetSide.active) {
+				for (const pokemon of targetSide.activeTeam()) {
 					if (!pokemon.hasType('Grass')) this.damage(pokemon.baseMaxhp / 6, pokemon);
 				}
 			},
 			onEnd(targetSide) {
-				for (const pokemon of targetSide.active) {
+				for (const pokemon of targetSide.activeTeam()) {
 					if (!pokemon.hasType('Grass')) this.damage(pokemon.baseMaxhp / 6, pokemon);
 				}
 				this.add('-sideend', targetSide, 'G-Max Vine Lash');
@@ -6879,12 +6879,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onResidualOrder: 5,
 			onResidualSubOrder: 1.1,
 			onResidual(targetSide) {
-				for (const pokemon of targetSide.active) {
+				for (const pokemon of targetSide.activeTeam()) {
 					if (!pokemon.hasType('Rock')) this.damage(pokemon.baseMaxhp / 6, pokemon);
 				}
 			},
 			onEnd(targetSide) {
-				for (const pokemon of targetSide.active) {
+				for (const pokemon of targetSide.activeTeam()) {
 					if (!pokemon.hasType('Rock')) this.damage(pokemon.baseMaxhp / 6, pokemon);
 				}
 				this.add('-sideend', targetSide, 'G-Max Volcalith');
@@ -6908,7 +6908,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		isMax: "Pikachu",
 		self: {
 			onHit(source) {
-				for (const pokemon of source.side.foe.active) {
+				for (const pokemon of source.foes()) {
 					pokemon.trySetStatus('par', source);
 				}
 			},
@@ -6942,12 +6942,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onResidualOrder: 5,
 			onResidualSubOrder: 1.1,
 			onResidual(targetSide) {
-				for (const pokemon of targetSide.active) {
+				for (const pokemon of targetSide.activeTeam()) {
 					if (!pokemon.hasType('Fire')) this.damage(pokemon.baseMaxhp / 6, pokemon);
 				}
 			},
 			onEnd(targetSide) {
-				for (const pokemon of targetSide.active) {
+				for (const pokemon of targetSide.activeTeam()) {
 					if (!pokemon.hasType('Fire')) this.damage(pokemon.baseMaxhp / 6, pokemon);
 				}
 				this.add('-sideend', targetSide, 'G-Max Wildfire');
@@ -10107,14 +10107,13 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {snatch: 1, distance: 1, authentic: 1},
 		onHitSide(side, source, move) {
 			const targets = [];
-			for (const pokemon of side.active) {
+			for (const pokemon of side.activeTeam()) {
 				if (
 					pokemon.hasAbility(['plus', 'minus']) &&
-					(!pokemon.volatiles['maxguard'] ||
-					  this.runEvent('TryHit', pokemon, source, move))
-				  ) {
+					(!pokemon.volatiles['maxguard'] || this.runEvent('TryHit', pokemon, source, move))
+				) {
 					targets.push(pokemon);
-				  }
+				}
 			}
 			if (!targets.length) return false;
 			let didSomething = false;
@@ -10289,7 +10288,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		self: {
 			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
-				for (const pokemon of source.side.active) {
+				for (const pokemon of source.alliesAndSelf()) {
 					this.boost({spe: 1}, pokemon);
 				}
 			},
@@ -10311,7 +10310,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		self: {
 			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
-				for (const pokemon of source.side.foe.active) {
+				for (const pokemon of source.foes()) {
 					this.boost({spd: -1}, pokemon);
 				}
 			},
@@ -10353,7 +10352,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		self: {
 			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
-				for (const pokemon of source.side.foe.active) {
+				for (const pokemon of source.foes()) {
 					this.boost({spa: -1}, pokemon);
 				}
 			},
@@ -10470,7 +10469,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		self: {
 			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
-				for (const pokemon of source.side.active) {
+				for (const pokemon of source.alliesAndSelf()) {
 					this.boost({atk: 1}, pokemon);
 				}
 			},
@@ -10532,7 +10531,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		self: {
 			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
-				for (const pokemon of source.side.active) {
+				for (const pokemon of source.alliesAndSelf()) {
 					this.boost({spa: 1}, pokemon);
 				}
 			},
@@ -10574,7 +10573,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		self: {
 			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
-				for (const pokemon of source.side.foe.active) {
+				for (const pokemon of source.foes()) {
 					this.boost({def: -1}, pokemon);
 				}
 			},
@@ -10596,7 +10595,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		self: {
 			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
-				for (const pokemon of source.side.active) {
+				for (const pokemon of source.alliesAndSelf()) {
 					this.boost({spd: 1}, pokemon);
 				}
 			},
@@ -10658,7 +10657,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		self: {
 			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
-				for (const pokemon of source.side.active) {
+				for (const pokemon of source.alliesAndSelf()) {
 					this.boost({def: 1}, pokemon);
 				}
 			},
@@ -10680,7 +10679,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		self: {
 			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
-				for (const pokemon of source.side.foe.active) {
+				for (const pokemon of source.foes()) {
 					this.boost({spe: -1}, pokemon);
 				}
 			},
@@ -10702,7 +10701,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		self: {
 			onHit(source) {
 				if (!source.volatiles['dynamax']) return;
-				for (const pokemon of source.side.foe.active) {
+				for (const pokemon of source.foes()) {
 					this.boost({atk: -1}, pokemon);
 				}
 			},
@@ -18710,9 +18709,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 			volatileStatus: 'uproar',
 		},
 		onTryHit(target) {
-			for (const [i, allyActive] of target.side.active.entries()) {
+			const activeTeam = target.side.activeTeam();
+			const foeActiveTeam = target.side.foe.activeTeam();
+			for (const [i, allyActive] of activeTeam.entries()) {
 				if (allyActive && allyActive.status === 'slp') allyActive.cureStatus();
-				const foeActive = target.side.foe.active[i];
+				const foeActive = foeActiveTeam[i];
 				if (foeActive && foeActive.status === 'slp') foeActive.cureStatus();
 			}
 		},

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -863,13 +863,13 @@ export const Formats: {[k: string]: FormatData} = {
 			this.add('rule', 'Sleep Clause Mod: Limit one foe put to sleep');
 		},
 		onSetStatus(status, target, source) {
-			if (source && source.side === target.side) {
+			if (source && source.isAlly(target)) {
 				return;
 			}
 			if (status.id === 'slp') {
 				for (const pokemon of target.side.pokemon) {
 					if (pokemon.hp && pokemon.status === 'slp') {
-						if (!pokemon.statusData.source || pokemon.statusData.source.side !== pokemon.side) {
+						if (!pokemon.statusData.source || !pokemon.statusData.source.isAlly(pokemon)) {
 							this.add('-message', 'Sleep Clause Mod activated.');
 							return false;
 						}
@@ -886,7 +886,7 @@ export const Formats: {[k: string]: FormatData} = {
 			this.add('rule', 'Stadium Sleep Clause: Limit one foe put to sleep');
 		},
 		onSetStatus(status, target, source) {
-			if (source && source.side === target.side) {
+			if (source && source.isAlly(target)) {
 				return;
 			}
 			if (status.id === 'slp') {
@@ -934,7 +934,7 @@ export const Formats: {[k: string]: FormatData} = {
 			this.add('rule', 'Freeze Clause Mod: Limit one foe frozen');
 		},
 		onSetStatus(status, target, source) {
-			if (source && source.side === target.side) {
+			if (source && source.isAlly(target)) {
 				return;
 			}
 			if (status.id === 'frz') {

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -307,7 +307,7 @@ export class BattleActions {
 				if (this.battle.faintMessages()) break;
 				if (dancer.fainted) continue;
 				this.battle.add('-activate', dancer, 'ability: Dancer');
-				const dancersTarget = target!.side !== dancer.side && pokemon.side === dancer.side ? target! : pokemon;
+				const dancersTarget = !target!.isAlly(dancer) && pokemon.isAlly(dancer) ? target! : pokemon;
 				const dancersTargetLoc = dancer.getLocOf(dancersTarget);
 				this.runMove(move.id, dancer, dancersTargetLoc, this.dex.getAbility('dancer'), undefined, true);
 			}
@@ -614,7 +614,7 @@ export class BattleActions {
 				this.battle.add('-immune', target);
 				hitResults[i] = false;
 			} else if (this.battle.gen >= 7 && move.pranksterBoosted && pokemon.hasAbility('prankster') &&
-				targets[i].side !== pokemon.side && !this.dex.getImmunity('prankster', target)) {
+				!targets[i].isAlly(pokemon) && !this.dex.getImmunity('prankster', target)) {
 				this.battle.debug('natural prankster immunity');
 				if (!target.illusion) this.battle.hint("Since gen 7, Dark is immune to Prankster moves.");
 				this.battle.add('-immune', target);
@@ -695,7 +695,7 @@ export class BattleActions {
 				for (const effectid of ['banefulbunker', 'kingsshield', 'obstruct', 'protect', 'spikyshield']) {
 					if (target.removeVolatile(effectid)) broke = true;
 				}
-				if (this.battle.gen >= 6 || target.side !== pokemon.side) {
+				if (this.battle.gen >= 6 || !target.isAlly(pokemon)) {
 					for (const effectid of ['craftyshield', 'matblock', 'quickguard', 'wideguard']) {
 						if (target.side.removeSideCondition(effectid)) broke = true;
 					}

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -308,7 +308,7 @@ export class BattleActions {
 				if (dancer.fainted) continue;
 				this.battle.add('-activate', dancer, 'ability: Dancer');
 				const dancersTarget = target!.side !== dancer.side && pokemon.side === dancer.side ? target! : pokemon;
-				const dancersTargetLoc = this.battle.getTargetLoc(dancersTarget, dancer);
+				const dancersTargetLoc = dancer.getLocOf(dancersTarget);
 				this.runMove(move.id, dancer, dancersTargetLoc, this.dex.getAbility('dancer'), undefined, true);
 			}
 		}

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -176,7 +176,7 @@ export class BattleActions {
 			this.battle.singleEvent('Start', pokemon.getItem(), pokemon.itemData, pokemon);
 		}
 		if (this.battle.gen === 4) {
-			for (const foeActive of pokemon.side.foe.active) {
+			for (const foeActive of pokemon.foes()) {
 				foeActive.removeVolatile('substitutebroken');
 			}
 		}
@@ -1728,11 +1728,10 @@ export class BattleActions {
 	runMegaEvo(pokemon: Pokemon) {
 		const speciesid = pokemon.canMegaEvo || pokemon.canUltraBurst;
 		if (!speciesid) return false;
-		const side = pokemon.side;
 
 		// Pokémon affected by Sky Drop cannot mega evolve. Enforce it here for now.
-		for (const foeActive of side.foe.active) {
-			if (foeActive.volatiles['skydrop'] && foeActive.volatiles['skydrop'].source === pokemon) {
+		for (const foeActive of pokemon.foes()) {
+			if (foeActive.volatiles['skydrop']?.source === pokemon) {
 				return false;
 			}
 		}
@@ -1741,7 +1740,7 @@ export class BattleActions {
 
 		// Limit one mega evolution
 		const wasMega = pokemon.canMegaEvo;
-		for (const ally of side.pokemon) {
+		for (const ally of pokemon.allies()) {
 			if (wasMega) {
 				ally.canMegaEvo = null;
 			} else {

--- a/sim/battle-queue.ts
+++ b/sim/battle-queue.ts
@@ -232,7 +232,7 @@ export class BattleQueue {
 			if (!action.targetLoc) {
 				target = this.battle.getRandomTarget(action.pokemon, action.move);
 				// TODO: what actually happens here?
-				if (target) action.targetLoc = this.battle.getTargetLoc(target, action.pokemon);
+				if (target) action.targetLoc = action.pokemon.getLocOf(target);
 			}
 			action.originalTarget = action.pokemon.getAtLoc(action.targetLoc);
 		}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -399,6 +399,7 @@ export class Battle {
 		let handlers = this.findBattleEventHandlers(callbackName, 'duration');
 		handlers = handlers.concat(this.findFieldEventHandlers(this.field, callbackName, 'duration'));
 		for (const side of this.sides) {
+			if (side.n >= 2 && side.allySide) break;
 			handlers = handlers.concat(this.findSideEventHandlers(side, callbackName, 'duration'));
 			for (const active of side.active) {
 				if (!active) continue;
@@ -834,6 +835,7 @@ export class Battle {
 		}
 		if (target instanceof Side) {
 			for (const side of this.sides) {
+				if (side.n >= 2 && side.allySide) break;
 				if (side === target || side === target.allySide) {
 					handlers.push(...this.findSideEventHandlers(side, `on${eventName}`));
 				} else {
@@ -1508,6 +1510,9 @@ export class Battle {
 			this.sides[0].allySide = this.sides[2]!;
 			this.sides[2]!.allySide = this.sides[0];
 			this.sides[3]!.allySide = this.sides[1];
+			// sync side conditions
+			this.sides[2]!.sideConditions = this.sides[0].sideConditions;
+			this.sides[3]!.sideConditions = this.sides[1].sideConditions;
 		} else {
 			this.sides[1].foe = this.sides[0];
 			this.sides[0].foe = this.sides[1];

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1292,7 +1292,10 @@ export class Battle {
 		return true;
 	}
 
-	getAtSlot(slot: PokemonSlot) {
+	getAtSlot(slot: PokemonSlot): Pokemon;
+	getAtSlot(slot: PokemonSlot | null): Pokemon | null;
+	getAtSlot(slot: PokemonSlot | null) {
+		if (!slot) return null;
 		const side = this.sides[slot.charCodeAt(1) - 49]; // 49 is '1'
 		const position = slot.charCodeAt(2) - 97; // 97 is 'a'
 		const positionOffset = Math.floor(side.n / 2) * side.active.length;

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -833,9 +833,8 @@ export class Battle {
 			handlers.push(...this.findPokemonEventHandlers(source, `onSource${eventName}`));
 		}
 		if (target instanceof Side) {
-			const team = this.gameType === 'multi' ? target.n % 2 : null;
 			for (const side of this.sides) {
-				if (team === null ? side === target : side.n % 2 === team) {
+				if (side === target || side === target.allySide) {
 					handlers.push(...this.findSideEventHandlers(side, `on${eventName}`));
 				} else {
 					handlers.push(...this.findSideEventHandlers(side, `onFoe${eventName}`));
@@ -2119,8 +2118,8 @@ export class Battle {
 		const team3PokemonLeft = this.gameType === 'free-for-all' && this.sides[2]!.pokemonLeft;
 		const team4PokemonLeft = this.gameType === 'free-for-all' && this.sides[3]!.pokemonLeft;
 		if (this.gameType === 'multi') {
-			team1PokemonLeft = this.sides.reduce((total, side) => total + (side.n % 2 === 0 ? side.pokemonLeft : 0), 0);
-			team2PokemonLeft = this.sides.reduce((total, side) => total + (side.n % 2 === 1 ? side.pokemonLeft : 0), 0);
+			team1PokemonLeft += this.sides[2]!.pokemonLeft;
+			team2PokemonLeft += this.sides[3]!.pokemonLeft;
 		}
 		if (!team1PokemonLeft && !team2PokemonLeft && !team3PokemonLeft && !team4PokemonLeft) {
 			this.win(faintData && this.gen > 4 ? faintData.target.side : null);

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1947,13 +1947,8 @@ export class Battle {
 		return false;
 	}
 
-	getTargetLoc(target: Pokemon, source: Pokemon) {
-		const position = target.position + 1;
-		return (target.side === source.side) ? -position : position;
-	}
-
 	validTarget(target: Pokemon, source: Pokemon, targetType: string) {
-		return this.validTargetLoc(this.getTargetLoc(target, source), source, targetType);
+		return this.validTargetLoc(source.getLocOf(target), source, targetType);
 	}
 
 	getTarget(pokemon: Pokemon, move: string | Move, targetLoc: number, originalTarget?: Pokemon) {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1235,7 +1235,9 @@ export class Battle {
 		this.winner = side ? side.name : '';
 
 		this.add('');
-		if (side) {
+		if (side?.allySide) {
+			this.add('win', side.name + ' & ' + side.allySide.name);
+		} else if (side) {
 			this.add('win', side.name);
 		} else {
 			this.add('tie');
@@ -1498,8 +1500,23 @@ export class Battle {
 		if (this.started) throw new Error(`Battle already started`);
 
 		this.started = true;
-		this.sides[1].foe = this.sides[0];
-		this.sides[0].foe = this.sides[1];
+		if (this.gameType === 'multi') {
+			this.sides[1].foe = this.sides[2]!;
+			this.sides[0].foe = this.sides[3]!;
+			this.sides[2]!.foe = this.sides[1];
+			this.sides[3]!.foe = this.sides[0];
+			this.sides[1].allySide = this.sides[3]!;
+			this.sides[0].allySide = this.sides[2]!;
+			this.sides[2]!.allySide = this.sides[0];
+			this.sides[3]!.allySide = this.sides[1];
+		} else {
+			this.sides[1].foe = this.sides[0];
+			this.sides[0].foe = this.sides[1];
+			if (this.sides.length > 2) { // ffa
+				this.sides[2]!.foe = this.sides[3]!;
+				this.sides[3]!.foe = this.sides[2]!;
+			}
+		}
 
 		for (const side of this.sides) {
 			this.add('teamsize', side.id, side.pokemon.length);

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1414,7 +1414,7 @@ export class Battle {
 
 		if (this.maybeTriggerEndlessBattleClause(trappedBySide, stalenessBySide)) return;
 
-		if (this.gameType === 'triples' && !this.sides.filter(side => side.pokemonLeft > 1).length) {
+		if (this.gameType === 'triples' && this.sides.every(side => side.pokemonLeft === 1)) {
 			// If both sides have one Pokemon left in triples and they are not adjacent, they are both moved to the center.
 			const actives = this.getAllActive();
 			if (actives.length > 1 && !actives[0].isAdjacent(actives[1])) {
@@ -1594,7 +1594,7 @@ export class Battle {
 		}
 		if (!target?.hp) return 0;
 		if (!target.isActive) return false;
-		if (this.gen > 5 && !target.side.foe.pokemonLeft) return false;
+		if (this.gen > 5 && !target.side.foePokemonLeft()) return false;
 		boost = this.runEvent('Boost', target, source, effect, {...boost});
 		let success = null;
 		let boosted = isSecondary;
@@ -2062,7 +2062,7 @@ export class Battle {
 				return foeActives[frontPosition];
 			}
 		}
-		return pokemon.side.foe.randomAlly() || pokemon.side.foe.active[0];
+		return pokemon.side.randomFoe() || pokemon.side.foe.active[0];
 	}
 
 	checkFainted() {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2005,7 +2005,7 @@ export class Battle {
 		}
 		if (move.target !== 'randomNormal' && this.validTargetLoc(targetLoc, pokemon, move.target)) {
 			const target = pokemon.getAtLoc(targetLoc);
-			if (target?.fainted && target.side === pokemon.side) {
+			if (target?.fainted && target.isAlly(pokemon)) {
 				// Target is a fainted ally: attack shouldn't retarget
 				return target;
 			}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1373,8 +1373,7 @@ export class Battle {
 				// canceling switches would leak information
 				// if a foe might have a trapping ability
 				if (this.gen > 2) {
-					for (const source of pokemon.side.foe.active) {
-						if (!source || source.fainted) continue;
+					for (const source of pokemon.foes()) {
 						const species = (source.illusion || source).species;
 						if (!species.abilities) continue;
 						for (const abilitySlot in species.abilities) {

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -113,7 +113,9 @@ export interface MoveEventMethods {
 	onModifyPriority?: CommonHandlers['ModifierSourceMove'];
 	onMoveFail?: CommonHandlers['VoidMove'];
 	onModifyType?: (this: Battle, move: ActiveMove, pokemon: Pokemon, target: Pokemon) => void;
-	onModifyTarget?: (this: Battle, relayVar: any, pokemon: Pokemon, target: Pokemon, move: ActiveMove) => void;
+	onModifyTarget?: (
+		this: Battle, relayVar: {target: Pokemon}, pokemon: Pokemon, target: Pokemon, move: ActiveMove
+	) => void;
 	onPrepareHit?: CommonHandlers['ResultMove'];
 	onTry?: CommonHandlers['ResultSourceMove'];
 	onTryHit?: CommonHandlers['ExtResultSourceMove'];

--- a/sim/field.ts
+++ b/sim/field.ts
@@ -70,7 +70,7 @@ export class Field {
 		this.weatherData = {id: status.id};
 		if (source) {
 			this.weatherData.source = source;
-			this.weatherData.sourcePosition = source.position;
+			this.weatherData.sourceSlot = source.getSlot();
 		}
 		if (status.duration) {
 			this.weatherData.duration = status.duration;
@@ -139,7 +139,7 @@ export class Field {
 		this.terrainData = {
 			id: status.id,
 			source,
-			sourcePosition: source.position,
+			sourceSlot: source.getSlot(),
 			duration: status.duration,
 		};
 		if (status.durationCallback) {
@@ -197,7 +197,7 @@ export class Field {
 		effectData = this.pseudoWeather[status.id] = {
 			id: status.id,
 			source,
-			sourcePosition: source?.position,
+			sourceSlot: source?.getSlot(),
 			duration: status.duration,
 		};
 		if (status.durationCallback) {

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -15,6 +15,7 @@ type TeamValidator = import('./team-validator').TeamValidator;
 type PokemonSources = import('./team-validator').PokemonSources;
 
 type ID = '' | string & {__isID: true};
+type PokemonSlot = '' | string & {__isSlot: true};
 interface AnyObject {[k: string]: any}
 interface DexTable<T> {
 	[key: string]: T;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -623,11 +623,12 @@ export class Pokemon {
 	}
 
 	foes(): Pokemon[] {
-		return this.side.foe.allies();
+		return this.side.foes();
 	}
 
 	adjacentFoes(): Pokemon[] {
-		return this.side.foe.allies().filter(foe => this.isAdjacent(foe));
+		if (this.battle.activePerHalf <= 2) return this.side.foes();
+		return this.side.foes().filter(foe => this.isAdjacent(foe));
 	}
 
 	isAlly(pokemon: Pokemon | null) {

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -26,7 +26,7 @@ interface Attacker {
 	damage: number;
 	thisTurn: boolean;
 	move?: ID;
-	position?: number;
+	slot: PokemonSlot;
 	damageValue?: (number | boolean | undefined);
 }
 
@@ -65,6 +65,11 @@ export class Pokemon {
 	hpType: string;
 	hpPower: number;
 
+	/**
+	 * Index of `pokemon.side.pokemon` and `pokemon.side.active`, which are
+	 * guaranteed to be the same for active pokemon. Note that this isn't
+	 * its field position in multi battles - use `getSlot()` for that.
+	 */
 	position: number;
 	details: string;
 
@@ -811,7 +816,7 @@ export class Pokemon {
 			damage: damageNumber,
 			move: move.id,
 			thisTurn: true,
-			position: source.position,
+			slot: source.getSlot(),
 			damageValue: damage,
 		});
 	}
@@ -1757,7 +1762,7 @@ export class Pokemon {
 		this.volatiles[status.id].target = this;
 		if (source) {
 			this.volatiles[status.id].source = source;
-			this.volatiles[status.id].sourcePosition = source.position;
+			this.volatiles[status.id].sourceSlot = source.getSlot();
 		}
 		if (sourceEffect) this.volatiles[status.id].sourceEffect = sourceEffect;
 		if (status.duration) this.volatiles[status.id].duration = status.duration;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -453,10 +453,10 @@ export class Pokemon {
 		return this.baseMoveSlots.map(moveSlot => moveSlot.id);
 	}
 
-	getSlot() {
+	getSlot(): PokemonSlot {
 		const positionOffset = Math.floor(this.side.n / 2) * this.side.active.length;
 		const positionLetter = 'abcdef'.charAt(this.position + positionOffset);
-		return this.side.id + positionLetter;
+		return (this.side.id + positionLetter) as PokemonSlot;
 	}
 
 	toString() {
@@ -606,37 +606,23 @@ export class Pokemon {
 	}
 
 	alliesAndSelf(): Pokemon[] {
-		let allies = this.side.active;
-		if (this.battle.gameType === 'multi') {
-			const team = this.side.n % 2;
-			allies = this.battle.sides.flatMap(
-				(side: Side) => side.n % 2 === team ? side.active : []
-			);
-		}
-		return allies.filter(ally => ally && !ally.fainted);
+		return this.side.allies();
 	}
 
 	allies(): Pokemon[] {
-		return this.alliesAndSelf().filter(ally => ally !== this);
+		return this.side.allies().filter(ally => ally !== this);
 	}
 
 	adjacentAllies(): Pokemon[] {
-		return this.alliesAndSelf().filter(ally => this.isAdjacent(ally));
+		return this.side.allies().filter(ally => this.isAdjacent(ally));
 	}
 
 	foes(): Pokemon[] {
-		let foes = this.side.foe.active;
-		if (this.battle.gameType === 'multi') {
-			const team = this.side.foe.n % 2;
-			foes = this.battle.sides.flatMap(
-				(side: Side) => side.n % 2 === team ? side.active : []
-			);
-		}
-		return foes.filter(foe => foe && !foe.fainted);
+		return this.side.foe.allies();
 	}
 
 	adjacentFoes(): Pokemon[] {
-		return this.foes().filter(foe => this.isAdjacent(foe));
+		return this.side.foe.allies().filter(foe => this.isAdjacent(foe));
 	}
 
 	isAdjacent(pokemon2: Pokemon) {
@@ -827,11 +813,10 @@ export class Pokemon {
 	}
 
 	getLastDamagedBy(filterOutSameSide: boolean) {
-		const damagedBy: Attacker[] = this.attackedBy.filter(
-			(attacker) =>
-			  typeof attacker.damageValue === 'number' &&
-			  (filterOutSameSide === undefined || this.side !== attacker.source.side)
-		  );
+		const damagedBy: Attacker[] = this.attackedBy.filter(attacker => (
+			typeof attacker.damageValue === 'number' &&
+			(filterOutSameSide === undefined || this.side !== attacker.source.side)
+		));
 		if (damagedBy.length === 0) return undefined;
 		return damagedBy[damagedBy.length - 1];
 	}

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -675,6 +675,15 @@ export class Pokemon {
 		}
 	}
 
+	/**
+	 * Returns a relative location: 1-3, positive for foe, and negative for ally.
+	 * Use `getAtLoc` to reverse.
+	 */
+	getLocOf(target: Pokemon) {
+		const position = target.position + 1;
+		return (target.side === this.side) ? -position : position;
+	}
+
 	getMoveTargets(move: ActiveMove, target: Pokemon): {targets: Pokemon[], pressureTargets: Pokemon[]} {
 		let targets: Pokemon[] = [];
 

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -226,6 +226,9 @@ export class Side {
 
 		return this.battle.sides[this.n % 2].active.concat(this.battle.sides[this.n % 2 + 2].active);
 	}
+	hasAlly(pokemon: Pokemon) {
+		return pokemon.side === this || pokemon.side === this.allySide;
+	}
 
 	addSideCondition(
 		status: string | Condition, source: Pokemon | 'debug' | null = null, sourceEffect: Effect | null = null

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -79,6 +79,7 @@ export class Side {
 	/** only used by Gen 1 Counter */
 	lastSelectedMove: ID = '';
 
+	/** these point to the same object as the ally's, in multi battles */
 	sideConditions: {[id: string]: EffectState};
 	slotConditions: {[id: string]: EffectState}[];
 
@@ -233,9 +234,6 @@ export class Side {
 	addSideCondition(
 		status: string | Condition, source: Pokemon | 'debug' | null = null, sourceEffect: Effect | null = null
 	): boolean {
-		if (this.n >= 2 && this.battle.gameType === 'multi') {
-			return this.battle.sides[this.n % 2].addSideCondition(status, source, sourceEffect);
-		}
 		if (!source && this.battle.event && this.battle.event.target) source = this.battle.event.target;
 		if (source === 'debug') source = this.active[0];
 		if (!source) throw new Error(`setting sidecond without a source`);
@@ -264,26 +262,17 @@ export class Side {
 	}
 
 	getSideCondition(status: string | Effect): Effect | null {
-		if (this.n >= 2 && this.battle.gameType === 'multi') {
-			return this.battle.sides[this.n % 2].getSideCondition(status);
-		}
 		status = this.battle.dex.getEffect(status) as Effect;
 		if (!this.sideConditions[status.id]) return null;
 		return status;
 	}
 
 	getSideConditionData(status: string | Effect): AnyObject {
-		if (this.n >= 2 && this.battle.gameType === 'multi') {
-			return this.battle.sides[this.n % 2].getSideConditionData(status);
-		}
 		status = this.battle.dex.getEffect(status) as Effect;
 		return this.sideConditions[status.id] || null;
 	}
 
 	removeSideCondition(status: string | Effect): boolean {
-		if (this.n >= 2 && this.battle.gameType === 'multi') {
-			return this.battle.sides[this.n % 2].removeSideCondition(status);
-		}
 		status = this.battle.dex.getEffect(status) as Effect;
 		if (!this.sideConditions[status.id]) return false;
 		this.battle.singleEvent('End', status, this.sideConditions[status.id], this);

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -209,14 +209,16 @@ export class Side {
 		return this.battle.sample(actives);
 	}
 
-	getAllySide() {
-		if (this.battle.gameType !== 'multi') return null;
-		return this.battle.sides[[2, 3, 0, 1][this.n]]!;
-	}
 	allies() {
+		// called during the first switch-in, so `active` can still contain nulls at this point
 		return this.activeTeam().filter(ally => ally && !ally.fainted);
 	}
 	foes() {
+		if (this.battle.gameType === 'free-for-all') {
+			return this.battle.sides
+				.flatMap(side => side === this ? [] : side.active)
+				.filter(pokemon => pokemon && !pokemon.fainted);
+		}
 		return this.foe.allies();
 	}
 	activeTeam() {

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -247,7 +247,7 @@ export class Side {
 			id: status.id,
 			target: this,
 			source,
-			sourcePosition: source.position,
+			sourceSlot: source.getSlot(),
 			duration: status.duration,
 		};
 		if (status.durationCallback) {
@@ -294,18 +294,18 @@ export class Side {
 			if (!status.onRestart) return false;
 			return this.battle.singleEvent('Restart', status, this.slotConditions[target][status.id], this, source, sourceEffect);
 		}
-		const slotConditionData = this.slotConditions[target][status.id] = {
+		const conditionState = this.slotConditions[target][status.id] = {
 			id: status.id,
 			target: this,
 			source,
-			sourcePosition: source.position,
+			sourceSlot: source.getSlot(),
 			duration: status.duration,
 		};
 		if (status.durationCallback) {
-			slotConditionData.duration =
+			conditionState.duration =
 				status.durationCallback.call(this.battle, this.active[0], source, sourceEffect);
 		}
-		if (!this.battle.singleEvent('Start', status, slotConditionData, this.active[target], source, sourceEffect)) {
+		if (!this.battle.singleEvent('Start', status, conditionState, this.active[target], source, sourceEffect)) {
 			delete this.slotConditions[target][status.id];
 			return false;
 		}

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -64,7 +64,9 @@ export class Side {
 	name: string;
 	avatar: string;
 	maxTeamSize: number;
-	foe: Side;
+	foe: Side = null!; // set in battle.start()
+	/** Only exists in multi battle, for the allied side */
+	allySide: Side | null = null; // set in battle.start()
 	team: PokemonSet[];
 	pokemon: Pokemon[];
 	active: Pokemon[];
@@ -100,7 +102,6 @@ export class Side {
 		this.name = name;
 		this.avatar = '';
 		this.maxTeamSize = 6;
-		this.foe = sideNum ? this.battle.sides[0] : this.battle.sides[1];
 
 		this.team = team;
 		this.pokemon = [];
@@ -221,10 +222,7 @@ export class Side {
 	activeTeam() {
 		if (this.battle.gameType !== 'multi') return this.active;
 
-		const team = this.n % 2;
-		return this.battle.sides.flatMap(
-			side => side.n % 2 === team ? side.active : []
-		);
+		return this.battle.sides[this.n % 2].active.concat(this.battle.sides[this.n % 2 + 2].active);
 	}
 
 	addSideCondition(

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -216,9 +216,8 @@ export class Side {
 	}
 	foes() {
 		if (this.battle.gameType === 'free-for-all') {
-			return this.battle.sides
-				.flatMap(side => side === this ? [] : side.active)
-				.filter(pokemon => pokemon && !pokemon.fainted);
+			return this.battle.sides.map(side => side.active[0])
+				.filter(pokemon => pokemon.side !== this && pokemon && !pokemon.fainted);
 		}
 		return this.foe.allies();
 	}

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -204,12 +204,27 @@ export class Side {
 		return data;
 	}
 
-	randomAlly() {
-		const actives = this.allies();
+	randomFoe() {
+		const actives = this.foes();
 		if (!actives.length) return null;
 		return this.battle.sample(actives);
 	}
 
+	/** Intended as a way to iterate through all foe side conditions - do not use for anything else. */
+	foeSidesWithConditions() {
+		if (this.battle.gameType === 'multi') return this.battle.sides.filter(side => side !== this);
+
+		return [this.foe];
+	}
+	foePokemonLeft() {
+		if (this.battle.gameType === 'multi') {
+			return this.battle.sides.filter(side => side !== this).map(side => side.pokemonLeft).reduce((a, b) => a + b);
+		}
+
+		if (this.foe.allySide) return this.foe.pokemonLeft + this.foe.allySide.pokemonLeft;
+
+		return this.foe.pokemonLeft;
+	}
 	allies() {
 		// called during the first switch-in, so `active` can still contain nulls at this point
 		return this.activeTeam().filter(ally => ally && !ally.fainted);
@@ -217,7 +232,7 @@ export class Side {
 	foes() {
 		if (this.battle.gameType === 'free-for-all') {
 			return this.battle.sides.map(side => side.active[0])
-				.filter(pokemon => pokemon.side !== this && pokemon && !pokemon.fainted);
+				.filter(pokemon => pokemon && pokemon.side !== this && !pokemon.fainted);
 		}
 		return this.foe.allies();
 	}


### PR DESCRIPTION
This is a collection of refactors for multi battles. I went in a different direction from #7929 for some of these.

In particular:

- Most previous uses of `position` have been substituted for `slot`, which should be much easier to work with. `activePosition` is not necessary.

- `side.getActive()` is mostly unnecessary. `side.allies()` is used in most places where you would want a list where indexes don't matter, and where they do, `slot` or hardcoding takes over.

- There's no need for `side.foe` to be an array – I instead just set it to the foe that Imposter copies from.

- There's a new `side.hasAlly`, which removes the need for hardcoded `side.n % 2` code that breaks FFA, for stuff like Pursuit.

The goal here isn't to replace #7929, just to reimplement parts of it, to make it easier to fix the merge conflicts, and also to do a few things differently (by preserving `.active` and `.foe`, there should be fewer compatibility issues with forks, too)