### PR TITLE
Reremove accidentally readded removed line

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -7,7 +7,6 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 	},
 	venusaur: {
 		randomBattleMoves: ["gigadrain", "leechseed", "sleeppowder", "sludgebomb", "substitute"],
-		randomDoubleBattleMoves: ["gigadrain", "leechseed", "sleeppowder", "sludgebomb", "substitute"],
 		randomBattleLevel: 82,
 		tier: "RUBL",
 		doublesTier: "DUU",


### PR DESCRIPTION
(Reversion of https://github.com/smogon/pokemon-showdown/commit/23cc9519bb2bec73b02af7d5d7bec6f6404cba4d)

Regular Venusaur should not have a doubles set, as it has no corresponding level.