### PR TITLE
Update required version of Node.js

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -11,7 +11,7 @@ Installing
 
     ./pokemon-showdown
 
-(Requires Node.js v10+)
+(Requires Node.js v12+)
 
 If your distro package manager has an old Node.js version, the simplest way to upgrade is `n` – usually no root necessary:
 


### PR DESCRIPTION
It seems that Showdown now requires Node.js v12+ instead of 10+:

```
bash-4.4$ ./pokemon-showdown 
We require Node.js version 12 or later; you're using v10.24.0
child_process.js:669
    throw err;
    ^

Error: Command failed: node build
    at checkExecSyncError (child_process.js:629:11)
    at Object.execSync (child_process.js:666:13)
    at build (/srv/pokemon-showdown/pokemon-showdown:21:27)
    at Object.<anonymous> (/srv/pokemon-showdown/pokemon-showdown:29:2)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
```