### PR TITLE
Fix hazards not applying if the target side is fainted

### DIFF
--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -619,8 +619,8 @@ export class Pokemon {
 		return this.side.allies().filter(ally => this.isAdjacent(ally));
 	}
 
-	foes(): Pokemon[] {
-		return this.side.foes();
+	foes(all?: boolean): Pokemon[] {
+		return this.side.foes(all);
 	}
 
 	adjacentFoes(): Pokemon[] {
@@ -694,7 +694,7 @@ export class Pokemon {
 				targets.push(...this.alliesAndSelf());
 			}
 			if (!move.target.startsWith('ally')) {
-				targets.push(...this.foes());
+				targets.push(...this.foes(true));
 			}
 			if (targets.length && !targets.includes(target)) {
 				this.battle.retargetLastMove(targets[targets.length - 1]);

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -243,16 +243,19 @@ export class Side {
 
 		return this.foe.pokemonLeft;
 	}
-	allies() {
+	allies(all?: boolean) {
 		// called during the first switch-in, so `active` can still contain nulls at this point
-		return this.activeTeam().filter(ally => ally && !ally.fainted);
+		let allies = this.activeTeam().filter(ally => ally);
+		if (!all) allies = allies.filter(ally => !ally.fainted);
+
+		return allies;
 	}
-	foes() {
+	foes(all?: boolean) {
 		if (this.battle.gameType === 'freeforall') {
 			return this.battle.sides.map(side => side.active[0])
 				.filter(pokemon => pokemon && pokemon.side !== this && !pokemon.fainted);
 		}
-		return this.foe.allies();
+		return this.foe.allies(all);
 	}
 	activeTeam() {
 		if (this.battle.gameType !== 'multi') return this.active;

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -253,7 +253,7 @@ export class Side {
 	foes(all?: boolean) {
 		if (this.battle.gameType === 'freeforall') {
 			return this.battle.sides.map(side => side.active[0])
-				.filter(pokemon => pokemon && pokemon.side !== this && !pokemon.fainted);
+				.filter(pokemon => pokemon && pokemon.side !== this && (all || !pokemon.fainted));
 		}
 		return this.foe.allies(all);
 	}

--- a/test/sim/moves/stealthrock.js
+++ b/test/sim/moves/stealthrock.js
@@ -55,22 +55,4 @@ describe('Stealth Rock', function () {
 		const expectedDamage = Math.floor(pokemon.maxhp * expectedPercent);
 		assert.equal(pokemon.maxhp - pokemon.hp, expectedDamage, `${pokemon.name} should take ${expectedPercent * 100}%`);
 	});
-
-	it(`should be applied to every opponents' side in a Free-for-all battle`, function () {
-		battle = common.createBattle({gameType: 'freeforall'}, [[
-			{species: 'Bronzong', moves: ['sleeptalk', 'stealthrock']},
-		], [
-			{species: 'Cufant', moves: ['sleeptalk']},
-		], [
-			{species: 'Qwilfish', moves: ['sleeptalk']},
-		], [
-			{species: 'Marowak', moves: ['stealthrock']},
-		]]);
-
-		battle.makeChoices();
-		assert.deepEqual(battle.sides.map(side => !!side.sideConditions.stealthrock), [true, true, true, false]);
-		battle.makeChoices('move stealthrock', 'auto', 'auto', 'auto');
-		assert.deepEqual(battle.sides.map(side => !!side.sideConditions.stealthrock), [true, true, true, true]);
-		common.saveReplay(battle);
-	});
 });


### PR DESCRIPTION
The 4 player battle changes broke hazards in general, they wont set if the target side has no un-fainted pokemon. This is because no target is provided, unlike in the past. The issue appears to be a combination of changes in two commits https://github.com/smogon/pokemon-showdown/commit/956daf89b6eb73f16846690d032fb7f77052046d which made `foeSide` moves start using an array of targets, and this from the 4-player patch which is used to get that array of targets but ignores fainted pokemon https://github.com/smogon/pokemon-showdown/commit/3b5e8cbfc2546afb19a0abce9f14c48c4e63e315#diff-6c26dba8e16b8854c67b0fc13f79e9811908c5f36d673084e350c8b89252ac81R230 .

This is my proposed patch, there may be a better way though (eg: new methods getAllFoes getAllAllies or w/e). PRing because I'm looking for thoughts.