### PR TITLE
Helptickets: Refactor to support text-only tickets

### DIFF
--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -8,8 +8,7 @@ const TICKET_CACHE_TIME = 24 * 60 * 60 * 1000; // 24 hours
 const TICKET_BAN_DURATION = 48 * 60 * 60 * 1000; // 48 hours
 const BATTLES_REGEX = /battle-(?:[a-z0-9]+)-(?:[0-9]+)(?:-[a-z0-9]+pw)?/g;
 const REPLAY_REGEX = new RegExp(
-	`${Config.routes.replays}` +
-	`/(?:[a-z0-9]-)?(?:[a-z0-9]+)-(?:[0-9]+)(?:-[a-z0-9]+pw)?`, "g"
+	`${Config.routes.replays}/(?:[a-z0-9]-)?(?:[a-z0-9]+)-(?:[0-9]+)(?:-[a-z0-9]+pw)?`, "g"
 );
 
 Punishments.addRoomPunishmentType('TICKETBAN', 'banned from creating help tickets');
@@ -589,7 +588,7 @@ function checkIp(ip: string) {
 export function getBattleLinks(text: string) {
 	const rooms: string[] = [];
 	const battles = text.match(BATTLES_REGEX);
-	// yes this is necessary, exec has behavior here that makes it inferior
+	// typescript-eslint is having trouble detecting REPLAY_REGEX as a global regex
 	// eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
 	const replays = text.match(REPLAY_REGEX);
 	if (battles) rooms.push(...battles);

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -215,6 +215,14 @@ export class HelpTicket extends Rooms.RoomGame {
 			if (!this.ticket.claimed) this.lastUnclaimedStart = Date.now();
 			notifyStaff();
 			this.room.add(`|c|&Staff|${this.room.tr`Thank you for the information, global staff will be here shortly. Please stay in the room.`}`).update();
+			switch (this.ticket.type) {
+			case 'PM Harassment':
+				this.room.add(
+					`|c|&Staff|Global staff might take more than a few minutes to handle your report. ` +
+					`If you are being disturbed by another user, you can type \`\`/ignore [username]\`\` in any chat to ignore their messages immediately`
+				).update();
+				break;
+			}
 			this.ticket.needsDelayWarning = true;
 		}
 	}

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -8,7 +8,7 @@ const TICKET_CACHE_TIME = 24 * 60 * 60 * 1000; // 24 hours
 const TICKET_BAN_DURATION = 48 * 60 * 60 * 1000; // 48 hours
 const BATTLES_REGEX = /battle-(?:[a-z0-9]+)-(?:[0-9]+)(?:-[a-z0-9]+pw)?/g;
 const REPLAY_REGEX = new RegExp(
-	`${Config.routes.replays}/(?:[a-z0-9]-)?(?:[a-z0-9]+)-(?:[0-9]+)(?:-[a-z0-9]+pw)?`, "g"
+	`${Utils.escapeRegex(Config.routes.replays)}/(?:[a-z0-9]-)?(?:[a-z0-9]+)-(?:[0-9]+)(?:-[a-z0-9]+pw)?`, "g"
 );
 
 Punishments.addRoomPunishmentType('TICKETBAN', 'banned from creating help tickets');
@@ -56,7 +56,7 @@ try {
 					const ticketGame = ticketRoom.game as HelpTicket;
 					ticketGame.writeStats(false);
 					ticketRoom.expire();
-				} else if (ticket.text) {
+				} else if (ticket.text && ticket.open) {
 					ticket.open = false;
 					writeStats(`${ticket.type}\t${Date.now() - ticket.created}\t0\t0\tdead\tvalid\t`);
 				}
@@ -742,7 +742,7 @@ export const textTickets: {[k: string]: TextTicketInfo} = {
 			}
 
 			let battlelogNoticeAdded = false;
-			for (const [i, url] of rooms.entries()) {
+			for (const [i, url] of [...rooms].entries()) {
 				if (rooms.indexOf(url) !== i) {
 					rooms.splice(i, 1);
 					continue;

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -1,10 +1,16 @@
 import {FS, Utils} from '../../lib';
 import {getCommonBattles} from '../chat-commands/info';
 import type {Punishment} from '../punishments';
+import type {PartialModlogEntry, ModlogID} from '../modlog';
 
 const TICKET_FILE = 'config/tickets.json';
 const TICKET_CACHE_TIME = 24 * 60 * 60 * 1000; // 24 hours
 const TICKET_BAN_DURATION = 48 * 60 * 60 * 1000; // 48 hours
+const BATTLES_REGEX = /battle-(?:[a-z0-9]+)-(?:[0-9]+)(?:-[a-z0-9]+pw)?/g;
+const REPLAY_REGEX = new RegExp(
+	`${Config.routes.replays}` +
+	`/(?:[a-z0-9]-)?(?:[a-z0-9]+)-(?:[0-9]+)(?:-[a-z0-9]+pw)?`, "g"
+);
 
 Punishments.addRoomPunishmentType('TICKETBAN', 'banned from creating help tickets');
 
@@ -19,7 +25,18 @@ interface TicketState {
 	ip: string;
 	needsDelayWarning?: boolean;
 	offline?: boolean;
+	/** [main text, context] */
+	text?: [string, string];
+	resolved?: {time: number, result: string, by: string, seen: boolean};
+	meta?: string;
 }
+
+interface TextTicketInfo {
+	checker?: (input: string, context: string, pageId: string, user: User, reportTarget?: string) => boolean | string[];
+	title: string;
+	getReviewDisplay: (ticket: TicketState & {text: [string, string]}, staff: User, conn: Connection) => string | void;
+}
+
 type TicketResult = 'approved' | 'valid' | 'assisted' | 'denied' | 'invalid' | 'unassisted' | 'ticketban' | 'deleted';
 
 export const tickets: {[k: string]: TicketState} = {};
@@ -40,6 +57,9 @@ try {
 					const ticketGame = ticketRoom.game as HelpTicket;
 					ticketGame.writeStats(false);
 					ticketRoom.expire();
+				} else if (ticket.text) {
+					ticket.open = false;
+					writeStats(`${ticket.type}\t${Date.now() - ticket.created}\t0\t0\tdead\tvalid\t`);
 				}
 				continue;
 			}
@@ -353,7 +373,7 @@ export class HelpTicket extends Rooms.RoomGame {
 		this.playerTable = null;
 	}
 	onChatMessage(message: string, user: User) {
-		const roomids = message.match(/battle-(?:[a-z0-9]+)-(?:[0-9]+)(?:-[a-z0-9]+pw)?/g);
+		const roomids = message.match(BATTLES_REGEX);
 		if (roomids) {
 			for (const roomid of roomids) {
 				const curRoom = Rooms.get(roomid);
@@ -361,6 +381,11 @@ export class HelpTicket extends Rooms.RoomGame {
 				void curRoom.uploadReplay(user, user.connections[0], 'forpunishment');
 			}
 		}
+	}
+	static modlogStream = Rooms.Modlog.initialize('help-texttickets' as ModlogID);
+	// workaround to modlog for no room
+	static modlog(entry: PartialModlogEntry) {
+		Rooms.Modlog.write('help-texttickets' as ModlogID, entry);
 	}
 	static ban(user: User | ID, reason = '') {
 		const userid = toID(user);
@@ -407,6 +432,19 @@ export class HelpTicket extends Rooms.RoomGame {
 			);
 		}
 		return `You are banned from creating help tickets.`;
+	}
+	static notifyResolved(user: User, ticket: TicketState, userid = user.id) {
+		const {result, time, by, seen} = ticket.resolved as {result: string, time: number, by: string, seen: boolean};
+		if (seen) return;
+		user.send(`|pm|&Staff|${user.getIdentity()}|Hello! Your report was resolved by ${by}, ${Chat.toDurationString(Date.now() - time)} ago.`);
+		if (result?.trim()) {
+			user.send(`|pm|&Staff|${user.getIdentity()}|The result was "${result}"`);
+		}
+		tickets[userid].resolved!.seen = true;
+		writeTickets();
+	}
+	static getTypeId(name: string) {
+		return Object.entries(ticketTitles).find(entry => entry[1] === name)?.[0] || toID(name);
 	}
 }
 
@@ -494,14 +532,19 @@ export function notifyStaff() {
 				continue;
 			}
 		}
-		// should always exist
-		const ticketRoom = Rooms.get(`help-${ticket.userid}`) as ChatRoom;
-		const ticketGame = ticketRoom.getGame(HelpTicket)!;
+		// should always exist if it's a normal ticket
+		const ticketRoom = Rooms.get(`help-${ticket.userid}`);
+		const ticketGame = ticketRoom?.getGame(HelpTicket);
 		if (!ticket.claimed) {
 			hasUnclaimed = true;
 			if (ticket.type === 'Public Room Assistance Request') hasAssistRequest = true;
 		}
-		buf += ticketGame.getButton();
+		if (ticketGame) {
+			buf += ticketGame.getButton();
+		} else {
+			buf += `<a class="button notifying" href="/view-help-text-${ticket.userid}"><strong>${ticket.userid}:</strong>`;
+			buf += ` ${ticket.type} (text)</a>`;
+		}
 		count++;
 	}
 	if (hiddenTicketCount > 1) {
@@ -541,6 +584,17 @@ function checkIp(ip: string) {
 		}
 	}
 	return false;
+}
+
+export function getBattleLinks(text: string) {
+	const rooms: string[] = [];
+	const battles = text.match(BATTLES_REGEX);
+	// yes this is necessary, exec has behavior here that makes it inferior
+	// eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
+	const replays = text.match(REPLAY_REGEX);
+	if (battles) rooms.push(...battles);
+	if (replays) rooms.push(...replays);
+	return rooms;
 }
 
 // Prevent a desynchronization issue when hotpatching
@@ -636,6 +690,134 @@ const cheatingScenarios = [
 	],
 ];
 
+export const textTickets: {[k: string]: TextTicketInfo} = {
+	inapname: {
+		title: "What's the inappropriate username?",
+		checker(input) {
+			if (!Users.get(input)) {
+				return [
+					"Please specify a valid username - that name was not found.",
+					"Maybe you spelled it wrong?",
+				];
+			}
+			return true;
+		},
+		getReviewDisplay(ticket) {
+			let buf = ``;
+			if (!ticket.open) return buf;
+			if (ticket.meta?.startsWith('user-')) {
+				const tar = ticket.meta.slice(5);
+				buf += `<strong>Username: ${tar}</strong><br />`;
+				buf += `<form data-submitsend="/forcerename ${tar},{reason}">`;
+			} else {
+				buf += `<strong>Provide a username to forcerename:</strong><br />`;
+				buf += `<form data-submitsend="/msgroom staff,/forcerename {text},{reason}">`;
+				buf += `Name: <input name="text" /><br />`;
+			}
+			buf += `Reason (optional:) <input name="reason" /><br />`;
+			buf += `<br /><button class="button notifying" type="submit">Forcerename</button></form>`;
+			return buf;
+		},
+	},
+	battleharassment: {
+		title: "Please provide a link to the battle (taken from the \"Upload and share\" button or copied from the browser URL)",
+		checker(input) {
+			if (BATTLES_REGEX.test(input) || REPLAY_REGEX.test(input)) return true;
+			return ['Please provide at least one valid battle or replay URL.'];
+		},
+		getReviewDisplay(ticket, staff, connection) {
+			let buf = ``;
+			const [text, context] = ticket.text;
+			const rooms = getBattleLinks(text);
+
+			if (context) {
+				rooms.push(...getBattleLinks(context));
+			}
+
+			let battlelogNoticeAdded = false;
+			for (const [i, url] of rooms.entries()) {
+				if (rooms.indexOf(url) !== i) {
+					rooms.splice(i, 1);
+					continue;
+				}
+				const room = Rooms.get(url);
+				if (room) {
+					staff.joinRoom(room, connection);
+				} else {
+					if (battlelogNoticeAdded) continue;
+					buf += `<small>(use /battlelog to view logs if the battle is expired)</small><br />`;
+					battlelogNoticeAdded = true;
+				}
+			}
+			buf += `Battle links: ${rooms.map(url => {
+				if (BATTLES_REGEX.test(url)) return `<a href="https://${Config.routes.client}/${url}">${url}</a>`;
+				return `<a href="https://${url}">${url}</a>`;
+			}).join(' | ')}<br />`;
+			if (ticket.meta) {
+				const [type, meta] = ticket.meta.split('-');
+				if (type === 'user') {
+					buf += `<br />`;
+					buf += `<strong>Reported user:</strong> ${meta}<br />`;
+					buf += `<button class="button" name="send" value="/msgroom staff,/lock ${meta},${rooms.join(',')}">Lock reported user</button><br />`;
+				}
+			}
+			return buf;
+		},
+	},
+	roomhelp: {
+		title: "Enter the name of the room",
+		getReviewDisplay(ticket, staff) {
+			let buf = ``;
+			const room = Rooms.search(ticket.text[0]) as Room;
+			if (!staff.inRooms.has(room.roomid)) {
+				buf += `<button class="button" name="send" value="/msgroom staff,/join ${room.roomid}">Join room</button>`;
+				buf += `<br />`;
+			} else {
+				buf += `<p>You're already in that room.</p>`;
+			}
+			return buf;
+		},
+		checker(input) {
+			const room = Rooms.search(input);
+			if (!room) {
+				return [
+					`That room was not found.`,
+					`Enter either the room name or a room alias.`,
+				];
+			}
+			if (room.settings.isPrivate !== undefined) {
+				return ['You may only request help for public rooms.'];
+			}
+			return true;
+		},
+	},
+	inappokemon: {
+		title: "Please provide replays of the battle with inappropriate Pokemon nicknames",
+		checker(input) {
+			if (BATTLES_REGEX.test(input) || REPLAY_REGEX.test(input)) return true;
+			return ['Please provide at least one valid battle or replay URL.'];
+		},
+		getReviewDisplay(ticket, staff, conn) {
+			let buf = ``;
+			const [text, context] = ticket.text;
+			const links = getBattleLinks(text);
+			if (context) links.push(...getBattleLinks(context));
+			buf += `<p><strong>Battle links given:</strong><p>`;
+			for (const [i, link] of links.entries()) {
+				if (links.indexOf(link) !== i) continue;
+				buf += `<a href="${link}">${link}</a>`;
+				const battles = link.match(BATTLES_REGEX);
+				if (battles) {
+					for (const battle of battles) {
+						void (Rooms.get(battle) as GameRoom | null)?.uploadReplay?.(staff, conn, "forpunishment");
+					}
+				}
+			}
+			return buf;
+		},
+	},
+};
+
 export const pages: Chat.PageTable = {
 	help: {
 		request(query, user, connection) {
@@ -708,12 +890,20 @@ export const pages: Chat.PageTable = {
 					buf += `<p><Button>cheating</Button></p>`;
 					break;
 				case 'pmharassment':
-					buf += `<p>${this.tr`If someone is harassing you in private messages (PMs), click the button below and a global staff member will take a look. If you are being harassed in a chatroom, please ask a room staff member to handle it. If it's a minor issue, consider using <code>/ignore [username]</code> instead.`}</p>`;
+					buf += `<p>${this.tr`If someone is harassing you in private messages (PMs), click the button below and a global staff member will take a look. If you are being harassed in a chatroom, please ask a room staff member to handle it.`}`;
+					if (!this.pageid.includes('confirm')) {
+						buf += ` If it's a minor issue, consider using <code>/ignore [username]</code> instead.`;
+					}
+					buf += `</p>`;
 					if (!isLast) break;
 					buf += `<p><Button>confirmpmharassment</Button></p>`;
 					break;
 				case 'battleharassment':
-					buf += `<p>${this.tr`If someone is harassing you in a battle, click the button below and a global staff member will take a look. If you are being harassed in a chatroom, please ask a room staff member to handle it. If it's a minor issue, consider using <code>/ignore [username]</code> instead.`}</p>`;
+					buf += `<p>${this.tr`If someone is harassing you in a battle, click the button below and a global staff member will take a look. If you are being harassed in a chatroom, please ask a room staff member to handle it.`}`;
+					if (!this.pageid.includes('confirm')) {
+						buf += ` If it's a minor issue, consider using <code>/ignore [username]</code> instead.`;
+					}
+					buf += `</p>`;
 					buf += `<p>${this.tr`Please save a replay of the battle if it has ended, or provide a link to the battle if it is still ongoing.`}</p>`;
 					if (!isLast) break;
 					buf += `<p><Button>confirmbattleharassment</Button></p>`;
@@ -829,9 +1019,25 @@ export const pages: Chat.PageTable = {
 						break;
 					}
 					const type = this.tr(ticketTitles[page.slice(7)]);
-					buf += `<p><b>${this.tr`Are you sure you want to submit a ticket for ${type}?`}</b></p>`;
 					const submitMeta = Utils.splitFirst(meta, '-', 2).join('|'); // change the delimiter as some ticket titles include -
-					buf += `<p><button class="button notifying" name="send" value="/helpticket submit ${ticketTitles[page.slice(7)]} ${submitMeta}">${this.tr`Yes, contact global staff`}</button> <a href="/view-help-request-${query.slice(0, i).join('-')}${meta}" target="replace"><button class="button">${this.tr`No, cancel`}</button></a></p>`;
+					const textTicket = textTickets[page.slice(7)];
+					if (textTicket) {
+						buf += `<p><b>${this.tr(textTicket.title)}</b></p>`;
+						buf += `<form data-submitsend="/helpticket submit ${ticketTitles[page.slice(7)]} ${submitMeta} | {text} | {context}">`;
+						buf += `<textarea name="text"></textarea><br />`;
+						buf += `<strong>Do you have any other information you want to provide? (this is optional)</strong><br />`;
+						buf += `<textarea name="context"></textarea><br />`;
+						buf += `<br /><button class="button notifying" type="submit">Submit ticket</button></form>`;
+					} else {
+						buf += `<p><b>${this.tr`Are you sure you want to submit a ticket for ${type}?`}</b></p>`;
+						buf += `<p><button class="button notifying" name="send" value="/helpticket submit ${ticketTitles[page.slice(7)]} ${submitMeta}">${this.tr`Yes, contact global staff`}</button> <a href="/view-help-request-${query.slice(0, i).join('-')}${meta}" target="replace">`;
+						buf += `<button class="button">${this.tr`No, cancel`}</button></a></p>`;
+					}
+					if (textTicket || page.includes('confirmpmharassment')) {
+						buf += `<p>`;
+						buf += `Global staff might take more than a few minutes to handle your report. `;
+						buf += `If you are being disturbed by another user, we advise you to type <code>/ignore [username]</code> in a chatroom to ignore their messages.`;
+					}
 					break;
 				}
 			}
@@ -865,7 +1071,9 @@ export const pages: Chat.PageTable = {
 				}
 				let icon = `<span style="color:gray"><i class="fa fa-check-circle-o"></i> ${this.tr`Closed`}</span>`;
 				if (ticket.open) {
-					if (!ticket.active) {
+					if (ticket.text) {
+						icon = `<span style="color:orange"><i class="fa fa-circle-o"></i> ${this.tr`Text ticket`}</span>`;
+					} else if (!ticket.active) {
 						icon = `<span style="color:gray"><i class="fa fa-circle-o"></i> ${this.tr`Inactive`}</span>`;
 					} else if (ticket.claimed) {
 						icon = `<span style="color:green"><i class="fa fa-circle-o"></i> ${this.tr`Claimed`}</span>`;
@@ -891,6 +1099,8 @@ export const pages: Chat.PageTable = {
 				if (room) {
 					const ticketGame = room.getGame(HelpTicket)!;
 					buf += `<a href="/${roomid}"><button class="button" ${ticketGame.getPreview()}>${this.tr(!ticket.claimed && ticket.open ? 'Claim' : 'View')}</button></a> `;
+				} else if (ticket.text) {
+					buf += `<a class="button" href="/view-help-text-${ticket.userid}">View</a>`;
 				}
 				if (logUrl) {
 					buf += `<a href="${logUrl}"><button class="button">${this.tr`Log`}</button></a>`;
@@ -915,6 +1125,49 @@ export const pages: Chat.PageTable = {
 				buf += `<td>${entry.reason || ''}</td></tr>`;
 			}
 			buf += `</tbody></table></div>`;
+			return buf;
+		},
+		text(query, user, connection) {
+			if (!user.named) return Rooms.RETRY_AFTER_LOGIN;
+			this.title = this.tr`Queued Tickets`;
+			this.checkCan('lock');
+			const userid = query.shift();
+			if (!userid) {
+				return this.errorReply(`Specify a userid to view the ticket for.`);
+			}
+			const ticket = tickets[toID(userid)];
+			if (!ticket) {
+				return this.errorReply(`Ticket not found.`);
+			}
+			if (!ticket.text) {
+				return this.errorReply(`That is either not a text ticket, or it has not yet been submitted.`);
+			}
+			const ticketInfo = textTickets[HelpTicket.getTypeId(ticket.type)];
+			this.title = `[Text Ticket] ${ticket.userid}`;
+			let buf = `<div class="pad">`;
+			buf += `<button class="button" name="send" value="/join ${this.pageid}" style="float:right"><i class="fa fa-refresh"></i> ${this.tr`Refresh`}</button>`;
+			buf += `<h2>Issue: ${ticket.type}</h2>`;
+			buf += `<strong>From: ${ticket.userid}</strong>`;
+			buf += `  <button class="button" name="send" value="/msgroom staff,/ht ban ${ticket.userid}">Ticketban</button> | `;
+			buf += `<button class="button" name="send" value="/modlog global,${ticket.userid}">Global Modlog</button><br />`;
+			buf += `<br />`;
+			buf += ticketInfo.getReviewDisplay(ticket as TicketState & {text: [string, string]}, user, connection);
+			buf += `<br />`;
+			buf += `<div class="infobox">`;
+			const [text, context] = ticket.text;
+			buf += `<p><strong>Report text:</strong></p><hr />`;
+			buf += Chat.formatText(text);
+			if (ticket.text[1]) {
+				buf += `<br /><hr /><strong>Context given: </strong><br />`;
+				buf += Chat.formatText(context);
+			}
+			buf += `</div>`;
+			if (!ticket.resolved) {
+				buf += `<form data-submitsend="/helpticket resolve ${ticket.userid},{text}">`;
+				buf += `<br /><strong>Resolve:</strong><br />`;
+				buf += `<textarea name="text"></textarea><br />`;
+				buf += `<br /><button class="button notifying" type="submit">Resolve ticket</button></form>`;
+			}
 			return buf;
 		},
 		stats(query, user, connection) {
@@ -1142,7 +1395,8 @@ export const commands: Chat.ChatCommands = {
 		},
 		createhelp: [`/helpticket create - Creates a new ticket requesting help from global staff.`],
 
-		submit(target, room, user, connection) {
+		submittext: 'submit',
+		submit(target, room, user, connection, cmd) {
 			if (user.can('lock') && !user.can('bypassall')) {
 				return this.popupReply(this.tr`Global staff can't make tickets. They can only use the form for reference.`);
 			}
@@ -1155,22 +1409,25 @@ export const commands: Chat.ChatCommands = {
 			const ipTicket = checkIp(user.latestIp);
 			if (ticket?.open || ipTicket) {
 				if (!ticket && ipTicket) ticket = ipTicket;
+				if (ticket.text) {
+					return this.popupReply(`You already have a pending ticket, please wait.`);
+				}
 				const helpRoom = Rooms.get(`help-${ticket.userid}`);
 				if (!helpRoom) {
-					// Should never happen
-					tickets[ticket.userid].open = false;
-					writeTickets();
-				} else {
-					if (!helpRoom.auth.has(user.id)) helpRoom.auth.set(user.id, '+');
-					this.popupReply(this.tr`You already have an open ticket; please wait for global staff to respond.`);
-					return this.parse(`/join help-${ticket.userid}`);
+					ticket.open = false;
+					return;
 				}
+				helpRoom.auth.set(user.id, '+');
+				this.popupReply(`You already have a pending ticket, please wait.`);
+				return this.parse(`/join help-${ticket.userid}`);
 			}
 			if (Monitor.countTickets(user.latestIp)) {
 				const maxTickets = Punishments.sharedIps.has(user.latestIp) ? `50` : `5`;
 				return this.popupReply(this.tr`Due to high load, you are limited to creating ${maxTickets} tickets every hour.`);
 			}
-			let [ticketType, reportTargetType, reportTarget] = Utils.splitFirst(target, '|', 2).map(s => s.trim());
+			let [
+				ticketType, reportTargetType, reportTarget, text, contextString,
+			] = Utils.splitFirst(target, '|', 4).map(s => s.trim());
 			reportTarget = Utils.escapeHTML(reportTarget);
 			if (!Object.values(ticketTitles).includes(ticketType)) return this.parse('/helpticket');
 			const contexts: {[k: string]: string} = {
@@ -1197,6 +1454,46 @@ export const commands: Chat.ChatCommands = {
 				claimed: null,
 				ip: user.latestIp,
 			};
+
+			if (toID(reportTarget)) {
+				ticket.meta = `${reportTargetType}-${reportTarget}`;
+			}
+			const typeId = HelpTicket.getTypeId(ticketType);
+			const textTicket = textTickets[typeId];
+			if (textTicket) {
+				let pageId = '';
+				for (const page of connection.openPages || new Set()) {
+					if (page.includes('confirm' + typeId)) {
+						pageId = page;
+					}
+				}
+				if (!toID(text)) {
+					this.parse(`/join view-${pageId}`);
+					return this.popupReply(`Please tell us what is happening.`);
+				}
+				if (text.length > 8192) {
+					return this.popupReply(`Your report is too long. Please use fewer words.`);
+				}
+				const validation = textTicket.checker?.(text, contextString || '', ticket.type, user, reportTarget);
+				if (Array.isArray(validation) && validation.length) {
+					this.parse(`/join view-${pageId}`);
+					return this.popupReply(validation.join('||'));
+				}
+				ticket.text = [text, contextString];
+				ticket.active = true;
+				tickets[user.id] = ticket;
+				HelpTicket.modlog({
+					action: 'TEXTTICKET OPEN',
+					loggedBy: user.id,
+					note: `(${ticket.type}) ${text}${contextString ? `, context: ${contextString}` : ''}`,
+				});
+				writeTickets();
+				notifyStaff();
+
+				connection.send(`>view-${pageId}\n|deinit`);
+				return this.popupReply(`Your report has been submitted.`);
+			}
+
 			let closeButtons = ``;
 			switch (ticket.type) {
 			case 'Appeal':
@@ -1317,6 +1614,47 @@ export const commands: Chat.ChatCommands = {
 			connection.send(`>view-help-request\n|deinit`);
 		},
 
+		text(target, room, user) {
+			this.checkCan('lock');
+			return this.parse(`/join view-help-text-${toID(target)}`);
+		},
+
+		resolve(target, room, user) {
+			this.checkCan('lock');
+			const [ticketerName, result] = Utils.splitFirst(target, ',').map(i => i.trim());
+			const ticketId = toID(ticketerName);
+			if (!ticketId || !result) {
+				return this.parse(`/help helpticket`);
+			}
+			const ticket = tickets[ticketId];
+			if (!ticket) return this.popupReply(`That ticket was not found.`);
+			if (ticket.resolved) {
+				return this.popupReply(`That ticket has already been resolved.`);
+			}
+			if (!ticket.text) {
+				return this.popupReply(`That ticket cannot be resolved with /helpticket resolve. Join it instead.`);
+			}
+			ticket.resolved = {
+				result, time: Date.now(), by: user.name, seen: false,
+			};
+			ticket.open = false;
+			writeTickets();
+			const tarUser = Users.get(ticketId);
+			if (tarUser) {
+				HelpTicket.notifyResolved(tarUser, ticket, ticketId);
+			}
+			// ticketType\ttotalTime\ttimeToFirstClaim\tinactiveTime\tresolution\tresult\tstaff,userids,seperated,with,commas
+			writeStats(`${ticket.type}\t${Date.now() - ticket.created}\t0\t0\tresolved\tvalid\t${user.id}`);
+			this.popupReply(`You resolved ${ticketId}'s ticket.`);
+			HelpTicket.modlog({
+				action: 'TEXTTICKET CLOSE',
+				loggedBy: user.id,
+				note: result,
+				userid: ticketId,
+			});
+			notifyStaff();
+		},
+
 		list(target, room, user) {
 			this.checkCan('lock');
 			return this.parse('/join view-help-tickets');
@@ -1336,6 +1674,9 @@ export const commands: Chat.ChatCommands = {
 			const ticket = tickets[toID(targetUsername)];
 			if (!ticket?.open || (ticket.userid !== user.id && !user.can('lock'))) {
 				return this.errorReply(this.tr`${targetUsername} does not have an open ticket.`);
+			}
+			if (typeof ticket.text !== 'undefined') {
+				return this.parse(`/helpticket resolve ${target}`);
 			}
 			const helpRoom = Rooms.get(`help-${ticket.userid}`) as ChatRoom | null;
 			if (helpRoom) {
@@ -1507,5 +1848,12 @@ export const punishmentfilter: Chat.PunishmentFilter = (user, punishment) => {
 		if (helpRoom?.game?.gameid !== 'helpticket') return;
 		const ticket = helpRoom.game as HelpTicket;
 		ticket.close('ticketban');
+	}
+};
+
+export const loginfilter: Chat.LoginFilter = (user) => {
+	const ticket = tickets[user.id];
+	if (ticket?.resolved) {
+		HelpTicket.notifyResolved(user, ticket);
 	}
 };

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -748,9 +748,7 @@ export const textTickets: {[k: string]: TextTicketInfo} = {
 					continue;
 				}
 				const room = Rooms.get(url);
-				if (room) {
-					staff.joinRoom(room, connection);
-				} else {
+				if (!room) {
 					if (battlelogNoticeAdded) continue;
 					buf += `<small>(use /battlelog to view logs if the battle is expired)</small><br />`;
 					battlelogNoticeAdded = true;


### PR DESCRIPTION
This should cover support for almost everything discussed here https://www.smogon.com/forums/threads/3673339/page-2#post-8677283.
I opted for a separate resolving command for text tickets to avoid cluttering up the other command, though /ht close will parse /ht resolve if the target ticket is a text ticket.