### PR TITLE
Negate Unburden boost when Neutralizing Gas is active.

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -4058,7 +4058,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		},
 		condition: {
 			onModifySpe(spe, pokemon) {
-				if (!pokemon.item) {
+				if (!pokemon.item && !pokemon.ignoringAbility()) {
 					return this.chainModify(2);
 				}
 			},

--- a/test/sim/abilities/neutralizinggas.js
+++ b/test/sim/abilities/neutralizinggas.js
@@ -115,7 +115,7 @@ describe('Neutralizing Gas', function () {
 		assert.equal(wynaut.getStat('spe'), originalSpeed);
 	});
 
-	it.skip(`should negate Unburden when Neutralizing Gas enters the field`, function () {
+	it(`should negate Unburden when Neutralizing Gas enters the field`, function () {
 		battle = common.createBattle([[
 			{species: "Wynaut", ability: 'unburden', item: 'sitrusberry', evs: {hp: 4}, moves: ['bellydrum']},
 		], [


### PR DESCRIPTION
https://github.com/smogon/pokemon-showdown/projects/3#card-52059168

Simply adds checking ignoringAbility in the unburden condition code. Ran both Neutralizing Gas and Unburden tests and they all passed. This probably requires a change in the client tooltips code so unburden's speed boost is not shown when it is suppressed.