### PR TITLE
Gen 1: Rename [Gen 1] OU (Tradeback) to [Gen 1] Tradebacks OU

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3267,7 +3267,7 @@ export const Formats: FormatList = [
 		banlist: ['UU', 'NUBL'],
 	},
 	{
-		name: "[Gen 1] OU (Tradeback)",
+		name: "[Gen 1] Tradebacks OU",
 		desc: `RBY OU with movepool additions from the Time Capsule.`,
 		threads: [
 			`&bullet; <a href="https://www.smogon.com/articles/rby-tradebacks-ou">RBY Tradebacks OU</a>`,


### PR DESCRIPTION
This is to coincide with my suggestion [here](https://www.smogon.com/forums/threads/rename-gen-1-ou-tradeback-to-gen-1-tradebacks-ou.3681565/).

I believe this name change allows for players to use team folders with Tradebacks, which reduces a lot of complication with RoA Room Tours and any potential spotlight ladders in the future. I _think_ this lets the Strategy Dex feed sample sets via import/export as well? I'm a boomer who doesn't know how stuff works...