### PR TITLE
Validator: Disallow duplicate moves

### DIFF
--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -265,7 +265,6 @@ export const Rulesets: {[k: string]: FormatData} = {
 					moves.push(moveId);
 				}
 			}
-			set.moves = moves;
 		},
 	},
 	hoennpokedex: {

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -254,7 +254,6 @@ export const Rulesets: {[k: string]: FormatData} = {
 			}
 
 			// limit one of each move
-			const moves = [];
 			if (set.moves) {
 				const hasMove: {[k: string]: true} = {};
 				for (const moveId of set.moves) {
@@ -262,7 +261,6 @@ export const Rulesets: {[k: string]: FormatData} = {
 					const moveid = move.id;
 					if (hasMove[moveid]) return [`${species.baseSpecies} has multiple copies of ${move.name}.`];
 					hasMove[moveid] = true;
-					moves.push(moveId);
 				}
 			}
 		},

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -260,7 +260,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 				for (const moveId of set.moves) {
 					const move = this.dex.moves.get(moveId);
 					const moveid = move.id;
-					if (hasMove[moveid]) continue;
+					if (hasMove[moveid]) return [species.baseSpecies + " has multiple copies of " + move.name + "."];
 					hasMove[moveid] = true;
 					moves.push(moveId);
 				}

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -260,7 +260,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 				for (const moveId of set.moves) {
 					const move = this.dex.moves.get(moveId);
 					const moveid = move.id;
-					if (hasMove[moveid]) return [species.baseSpecies + " has multiple copies of " + move.name + "."];
+					if (hasMove[moveid]) return [`${species.baseSpecies} has multiple copies of ${move.name}.`];
 					hasMove[moveid] = true;
 					moves.push(moveId);
 				}

--- a/test/sim/team-validator.js
+++ b/test/sim/team-validator.js
@@ -668,6 +668,17 @@ describe('Team Validator', function () {
 		assert(illegal);
 	});
 
+	it(`should not allow duplicate moves on the same set, except in hackmons`, function () {
+		const team = [
+			{species: 'corsola', ability: 'hustle', moves: ['snore', 'snore'], evs: {hp: 1}},
+		];
+		let illegal = TeamValidator.get('gen8anythinggoes').validateTeam(team);
+		assert(illegal);
+
+		illegal = TeamValidator.get('gen8purehackmons').validateTeam(team);
+		assert.equal(illegal, null);
+	});
+
 
 	/*********************************************************
  	* Custom rules


### PR DESCRIPTION
Currently, when a user creates a Pokemon with multiple duplicate moves, the validator doesn't say anything is wrong and just removes the duplicated move from the user's moveset automatically. I've definitely made the mistake in the past where I quickly make a Pokemon's set, don't realize I really only have 3 moves, and don't figure it out until the battle. This also fixes an issue with automatic move changes (i.e. Iron Head -> Behemoth moves) where a user accidentally adds both Iron Head and the Behemoth move without realizing Iron Head becomes Behemoth Blade / Bash. This way, the mistake is exposed at the teambuilder level, so they don't think get confused about why a move is missing.

Sample:
![image](https://user-images.githubusercontent.com/23667022/114255876-d5af6180-997b-11eb-923f-7cd02bdbe158.png)


Fixes https://github.com/smogon/pokemon-showdown/projects/3#card-51711810