### PR TITLE
Random Battles: Fix Toxtricity

### DIFF
--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -905,7 +905,7 @@ export class RandomTeams {
 		case 'taunt':
 			return {cull: hasMove['encore'] || hasMove['nastyplot'] || hasMove['swordsdance']};
 		case 'thunderwave': case 'voltswitch':
-			const cullInDoubles = hasMove['electroweb'] || hasMove['nuzzle'];
+			const cullInDoubles = isDoubles && (hasMove['electroweb'] || hasMove['nuzzle']);
 			return {cull: counter.setupType || counter.speedsetup || hasMove['shiftgear'] || hasMove['raindance'] || cullInDoubles};
 		case 'toxic':
 			return {cull: counter.setupType || ['sludgewave', 'thunderwave', 'willowisp'].some(m => hasMove[m])};

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -906,10 +906,7 @@ export class RandomTeams {
 			return {cull: hasMove['encore'] || hasMove['nastyplot'] || hasMove['swordsdance']};
 		case 'thunderwave': case 'voltswitch':
 			const cullInDoubles = hasMove['electroweb'] || hasMove['nuzzle'];
-			return {
-				cull: counter.setupType || counter.speedsetup || hasMove['shiftgear'] || hasMove['raindance'] ||
-					(isDoubles && cullInDoubles),
-			};
+			return {cull: counter.setupType || counter.speedsetup || hasMove['shiftgear'] || hasMove['raindance'] || cullInDoubles};
 		case 'toxic':
 			return {cull: counter.setupType || ['sludgewave', 'thunderwave', 'willowisp'].some(m => hasMove[m])};
 		case 'toxicspikes':

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -906,12 +906,12 @@ export class RandomTeams {
 			return {cull: hasMove['encore'] || hasMove['nastyplot'] || hasMove['swordsdance']};
 		case 'thunderwave': case 'voltswitch':
 			const cullInDoubles = hasMove['electroweb'] || hasMove['nuzzle'];
-			return {cull: 
+			return {cull:
 				counter.setupType ||
 				counter.speedsetup ||
 				hasMove['shiftgear'] ||
 				hasMove['raindance'] ||
-				(isDoubles && cullInDoubles)
+				(isDoubles && cullInDoubles),
 			};
 		case 'toxic':
 			return {cull: counter.setupType || ['sludgewave', 'thunderwave', 'willowisp'].some(m => hasMove[m])};

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -906,7 +906,13 @@ export class RandomTeams {
 			return {cull: hasMove['encore'] || hasMove['nastyplot'] || hasMove['swordsdance']};
 		case 'thunderwave': case 'voltswitch':
 			const cullInDoubles = hasMove['electroweb'] || hasMove['nuzzle'];
-			return {cull: counter.setupType || counter.speedsetup || hasMove['raindance'] || (isDoubles && cullInDoubles)};
+			return {cull: 
+				counter.setupType ||
+				counter.speedsetup ||
+				hasMove['shiftgear'] ||
+				hasMove['raindance'] ||
+				(isDoubles && cullInDoubles)
+			};
 		case 'toxic':
 			return {cull: counter.setupType || ['sludgewave', 'thunderwave', 'willowisp'].some(m => hasMove[m])};
 		case 'toxicspikes':

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -906,12 +906,9 @@ export class RandomTeams {
 			return {cull: hasMove['encore'] || hasMove['nastyplot'] || hasMove['swordsdance']};
 		case 'thunderwave': case 'voltswitch':
 			const cullInDoubles = hasMove['electroweb'] || hasMove['nuzzle'];
-			return {cull:
-				counter.setupType ||
-				counter.speedsetup ||
-				hasMove['shiftgear'] ||
-				hasMove['raindance'] ||
-				(isDoubles && cullInDoubles),
+			return {
+				cull: counter.setupType || counter.speedsetup || hasMove['shiftgear'] || hasMove['raindance'] ||
+					(isDoubles && cullInDoubles),
 			};
 		case 'toxic':
 			return {cull: counter.setupType || ['sludgewave', 'thunderwave', 'willowisp'].some(m => hasMove[m])};


### PR DESCRIPTION
happens when we remove stuff from speedsetup. as of last update shift gear's gotta be manually called whenever we want to do anything with it since it's not categorized as setupType or speedsetup now.

idea: define speedsetup as "all speed-boosting moves that are not otherwise categorized as setupType and would need to be called in the generator at any point specifically due to their speed boosting properties"