### PR TITLE
Use onAfterMoveSecondary for Magician effect

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -1939,7 +1939,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 98,
 	},
 	magician: {
-		onAfterMoveSecondary(target, source, move) {
+		onAfterMoveSecondarySelf(source, target, move) {
 			if (!move || !target) return;
 			if (target !== source && move.category !== 'Status') {
 				if (source.item || source.volatiles['gem'] || move.id === 'fling') return;

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -1939,7 +1939,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 98,
 	},
 	magician: {
-		onSourceHit(target, source, move) {
+		onAfterMoveSecondary(target, source, move) {
 			if (!move || !target) return;
 			if (target !== source && move.category !== 'Status') {
 				if (source.item || source.volatiles['gem'] || move.id === 'fling') return;

--- a/data/items.ts
+++ b/data/items.ts
@@ -33,8 +33,8 @@ export const Items: {[itemid: string]: ItemData} = {
 		fling: {
 			basePower: 30,
 		},
-		onDamagingHit(damage, target, source, move) {
-			if (move.type === 'Water') {
+		onDamage(damage, target, source, effect) {
+			if (effect && effect.effectType === "Move" && effect.type === 'Water') {
 				target.useItem();
 			}
 		},
@@ -647,8 +647,8 @@ export const Items: {[itemid: string]: ItemData} = {
 		fling: {
 			basePower: 30,
 		},
-		onDamagingHit(damage, target, source, move) {
-			if (move.type === 'Electric') {
+		onDamage(damage, target, source, effect) {
+			if (effect && effect.effectType === "Move" && effect.type === 'Electric') {
 				target.useItem();
 			}
 		},
@@ -3039,8 +3039,8 @@ export const Items: {[itemid: string]: ItemData} = {
 		fling: {
 			basePower: 30,
 		},
-		onDamagingHit(damage, target, source, move) {
-			if (move.type === 'Water') {
+		onDamage(damage, target, source, effect) {
+			if (effect && effect.effectType === "Move" && effect.type === 'Water') {
 				target.useItem();
 			}
 		},
@@ -5096,8 +5096,8 @@ export const Items: {[itemid: string]: ItemData} = {
 		fling: {
 			basePower: 30,
 		},
-		onDamagingHit(damage, target, source, move) {
-			if (move.type === 'Ice') {
+		onDamage(damage, target, source, effect) {
+			if (effect && effect.effectType === "Move" && effect.type === 'Ice') {
 				target.useItem();
 			}
 		},
@@ -6662,8 +6662,9 @@ export const Items: {[itemid: string]: ItemData} = {
 		fling: {
 			basePower: 80,
 		},
-		onDamagingHit(damage, target, source, move) {
-			if (!move.damage && !move.damageCallback && target.getMoveHitData(move).typeMod > 0) {
+		onDamage(damage, target, source, effect) {
+			if (effect && effect.effectType === "Move" && 
+				!effect.damage && !effect.damageCallback && target.getMoveHitData(effect).typeMod > 0) {
 				target.useItem();
 			}
 		},

--- a/data/items.ts
+++ b/data/items.ts
@@ -33,8 +33,8 @@ export const Items: {[itemid: string]: ItemData} = {
 		fling: {
 			basePower: 30,
 		},
-		onDamage(damage, target, source, effect) {
-			if (effect && effect.effectType === "Move" && effect.type === 'Water') {
+		onDamagingHit(damage, target, source, move) {
+			if (move.type === 'Water') {
 				target.useItem();
 			}
 		},
@@ -647,8 +647,8 @@ export const Items: {[itemid: string]: ItemData} = {
 		fling: {
 			basePower: 30,
 		},
-		onDamage(damage, target, source, effect) {
-			if (effect && effect.effectType === "Move" && effect.type === 'Electric') {
+		onDamagingHit(damage, target, source, move) {
+			if (move.type === 'Electric') {
 				target.useItem();
 			}
 		},
@@ -3039,8 +3039,8 @@ export const Items: {[itemid: string]: ItemData} = {
 		fling: {
 			basePower: 30,
 		},
-		onDamage(damage, target, source, effect) {
-			if (effect && effect.effectType === "Move" && effect.type === 'Water') {
+		onDamagingHit(damage, target, source, move) {
+			if (move.type === 'Water') {
 				target.useItem();
 			}
 		},
@@ -5096,8 +5096,8 @@ export const Items: {[itemid: string]: ItemData} = {
 		fling: {
 			basePower: 30,
 		},
-		onDamage(damage, target, source, effect) {
-			if (effect && effect.effectType === "Move" && effect.type === 'Ice') {
+		onDamagingHit(damage, target, source, move) {
+			if (move.type === 'Ice') {
 				target.useItem();
 			}
 		},
@@ -6662,9 +6662,8 @@ export const Items: {[itemid: string]: ItemData} = {
 		fling: {
 			basePower: 80,
 		},
-		onDamage(damage, target, source, effect) {
-			if (effect && effect.effectType === "Move" &&
-				!effect.damage && !effect.damageCallback && target.getMoveHitData(effect).typeMod > 0) {
+		onDamagingHit(damage, target, source, move) {
+			if (!move.damage && !move.damageCallback && target.getMoveHitData(move).typeMod > 0) {
 				target.useItem();
 			}
 		},

--- a/data/items.ts
+++ b/data/items.ts
@@ -6663,7 +6663,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			basePower: 80,
 		},
 		onDamage(damage, target, source, effect) {
-			if (effect && effect.effectType === "Move" && 
+			if (effect && effect.effectType === "Move" &&
 				!effect.damage && !effect.damageCallback && target.getMoveHitData(effect).typeMod > 0) {
 				target.useItem();
 			}

--- a/test/sim/abilities/magician.js
+++ b/test/sim/abilities/magician.js
@@ -10,7 +10,7 @@ describe('Magician', function () {
 		battle.destroy();
 	});
 
-	it.skip(`should not steal Weakness Policy on super-effective hits`, function () {
+	it(`should not steal Weakness Policy on super-effective hits`, function () {
 		battle = common.createBattle([[
 			{species: 'klefki', ability: 'magician', moves: ['flashcannon']},
 		], [

--- a/test/sim/abilities/magician.js
+++ b/test/sim/abilities/magician.js
@@ -10,6 +10,16 @@ describe('Magician', function () {
 		battle.destroy();
 	});
 
+	it(`should steal the opponents item`, function () {
+		battle = common.createBattle([[
+			{species: 'klefki', ability: 'magician', moves: ['flashcannon']},
+		], [
+			{species: 'wynaut', item: 'tr69', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].item, 'tr69');
+	});
+
 	it(`should not steal Weakness Policy on super-effective hits`, function () {
 		battle = common.createBattle([[
 			{species: 'klefki', ability: 'magician', moves: ['flashcannon']},


### PR DESCRIPTION
This was done to fix the timing of item activation for Magician, which currently steals these items before they can activate. The bug report for this Magician interaction stated this happening to Weakness Policy, but Magician should interact in the same way with the other items I have changed. Should I add additional tests for the other items like Snowball, Cell Battery etc.?