### PR TITLE
Fix Transform source Ability leak

### DIFF
--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1699,7 +1699,7 @@ export class Pokemon {
 		}
 		if (!this.battle.runEvent('SetAbility', this, source, this.battle.effect, ability)) return false;
 		this.battle.singleEvent('End', this.battle.dex.abilities.get(oldAbility), this.abilityData, this, source);
-		if (this.battle.effect && this.battle.effect.effectType === 'Move') {
+		if (this.battle.effect && this.battle.effect.effectType === 'Move' && !isFromFormeChange) {
 			this.battle.add('-endability', this, this.battle.dex.abilities.get(oldAbility), '[from] move: ' +
 				this.battle.dex.moves.get(this.battle.effect.id));
 		}

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1699,10 +1699,6 @@ export class Pokemon {
 		}
 		if (!this.battle.runEvent('SetAbility', this, source, this.battle.effect, ability)) return false;
 		this.battle.singleEvent('End', this.battle.dex.abilities.get(oldAbility), this.abilityData, this, source);
-		if (this.battle.effect && this.battle.effect.effectType === 'Move' && !isFromFormeChange) {
-			this.battle.add('-endability', this, this.battle.dex.abilities.get(oldAbility), '[from] move: ' +
-				this.battle.dex.moves.get(this.battle.effect.id));
-		}
 		this.ability = ability.id;
 		this.abilityData = {id: ability.id, target: this};
 		if (ability.id && this.battle.gen > 3) {

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1699,6 +1699,10 @@ export class Pokemon {
 		}
 		if (!this.battle.runEvent('SetAbility', this, source, this.battle.effect, ability)) return false;
 		this.battle.singleEvent('End', this.battle.dex.abilities.get(oldAbility), this.abilityData, this, source);
+		if (this.battle.effect && this.battle.effect.effectType === 'Move' && !isFromFormeChange) {
+			this.battle.add('-endability', this, this.battle.dex.abilities.get(oldAbility), '[from] move: ' +
+				this.battle.dex.moves.get(this.battle.effect.id));
+		}
 		this.ability = ability.id;
 		this.abilityData = {id: ability.id, target: this};
 		if (ability.id && this.battle.gen > 3) {

--- a/test/sim/moves/transform.js
+++ b/test/sim/moves/transform.js
@@ -139,7 +139,7 @@ describe('Transform', function () {
 		assert.deepEqual(battle.p1.active[0].getTypes(), ["Fire", "Flying"]);
 	});
 
-	it.skip(`should not announce that its ability was suppressed after Transforming`, function () {
+	it(`should not announce that its ability was suppressed after Transforming`, function () {
 		battle = common.createBattle([[
 			{species: "Mew", ability: 'synchronize', moves: ['transform']},
 		], [


### PR DESCRIPTION
Currently, when Transform sets the user's ability to that of the target's, it sends an ``-endability`` protocol message which leaks the Transform user's Ability. The way I approached this was by turning off that -endability message for all form changes. I'm _pretty_ sure this is fine, because it effectively was doing this anyway with requiring the source to be a move (I think we still need that check so Ability stuff doesn't start leaking all over the place, but I'm not super sure).