### PR TITLE
Gen 1: Don't allow Pokemon to recharge if frozen

### DIFF
--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -87,8 +87,9 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 		effectType: 'Status',
 		onStart(target) {
 			this.add('-status', target, 'frz');
+			delete target.volatiles['mustrecharge']?.duration;
 		},
-		onBeforeMovePriority: 10,
+		onBeforeMovePriority: 12,
 		onBeforeMove(pokemon, target, move) {
 			this.add('cant', pokemon, 'frz');
 			pokemon.lastMove = null;
@@ -220,17 +221,6 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 	},
 	mustrecharge: {
 		inherit: true,
-		onBeforeMove(pokemon) {
-			if (pokemon.status === 'frz') {
-				this.effectData.duration += 1;
-				this.add('cant', pokemon, 'frz');
-				pokemon.lastMove = null;
-				return false;
-			}
-			this.add('cant', pokemon, 'recharge');
-			pokemon.removeVolatile('mustrecharge');
-			return null;
-		},
 		onStart() {},
 	},
 	lockedmove: {

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -87,7 +87,6 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 		effectType: 'Status',
 		onStart(target) {
 			this.add('-status', target, 'frz');
-			delete target.volatiles['mustrecharge']?.duration;
 		},
 		onBeforeMovePriority: 12,
 		onBeforeMove(pokemon, target, move) {
@@ -221,6 +220,7 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 	},
 	mustrecharge: {
 		inherit: true,
+		duration: 0,
 		onStart() {},
 	},
 	lockedmove: {

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -220,6 +220,17 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 	},
 	mustrecharge: {
 		inherit: true,
+		onBeforeMove(pokemon) {
+			if (pokemon.status === 'frz') {
+				this.effectData.duration += 1;
+				this.add('cant', pokemon, 'frz');
+				pokemon.lastMove = null;
+				return false;
+			}
+			this.add('cant', pokemon, 'recharge');
+			pokemon.removeVolatile('mustrecharge');
+			return null;
+		},
 		onStart() {},
 	},
 	lockedmove: {


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-8768936

This implements the above mechanic, where a pokemon that is frozen during its recharge turn can't do anything while it is still frozen, including switching out or actually recharging. I reimplemented the freeze move disabling in the `mustrecharge` condition because of the priority for onBeforeMove in `mustrecharge`.