### PR TITLE
Support forcing modchat on ladder tour battles

### DIFF
--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -76,6 +76,14 @@ export const commands: ChatCommands = {
 			if (error) return this.errorReply(error);
 		}
 
+		// only admins can force modchat on a forced public battle
+		if (room.battle?.forcedSettings.modchat && !user.can('rangeban')) {
+			return this.errorReply(
+				`This battle is required to have modchat on due to one of the players having a username that starts with ` +
+				`${room.battle.forcedSettings.modchat}.`
+			);
+		}
+
 		target = target.toLowerCase().trim();
 		const currentModchat = room.settings.modchat;
 		switch (target) {
@@ -193,7 +201,7 @@ export const commands: ChatCommands = {
 		} else {
 			user.battleSettings.inviteOnly = true;
 			user.update();
-			this.sendReply(`Your next battle will be invite-only${user.battlesForcedPublic() ? `, unless it is rated` : ``}.`);
+			this.sendReply(`Your next battle will be invite-only${user.forcedPublic('privacy') ? `, unless it is rated` : ``}.`);
 		}
 	},
 	inviteonlynexthelp: [
@@ -225,8 +233,10 @@ export const commands: ChatCommands = {
 		}
 		if (room.battle) {
 			this.checkCan('editprivacy', null, room);
-			if (room.battle.forcePublic) {
-				return this.errorReply(`This battle is required to be public due to a player having a name prefixed by '${room.battle.forcePublic}'.`);
+			if (room.battle.forcedSettings.privacy) {
+				return this.errorReply(
+					`This battle is required to be public due to a player having a name prefixed by '${room.battle.forcedSettings.privacy}'.`
+				);
 			}
 			if (room.battle.inviteOnlySetter && !user.can('mute', null, room) && room.battle.inviteOnlySetter !== user.id) {
 				return this.errorReply(`Only the person who set this battle to be invite-only can turn it off.`);
@@ -1007,8 +1017,8 @@ export const commands: ChatCommands = {
 		room = this.requireRoom();
 		if (room.battle) {
 			this.checkCan('editprivacy', null, room);
-			if (room.battle.forcePublic) {
-				return this.errorReply(`This battle is required to be public because a player has a name prefixed by '${room.battle.forcePublic}'.`);
+			if (room.battle.forcedSettings.privacy) {
+				return this.errorReply(`This battle is required to be public because a player has a name prefixed by '${room.battle.forcedSettings.privacy}'.`);
 			}
 			if (room.tour?.forcePublic) {
 				return this.errorReply(`This battle can't be hidden, because the tournament is set to be forced public.`);
@@ -1105,7 +1115,7 @@ export const commands: ChatCommands = {
 		} else {
 			user.battleSettings.hidden = true;
 			user.update();
-			this.sendReply(`Your next battle will be hidden${user.battlesForcedPublic() ? `, unless it is rated` : ``}.`);
+			this.sendReply(`Your next battle will be hidden${user.forcedPublic('privacy') ? `, unless it is rated` : ``}.`);
 		}
 	},
 	hidenexthelp: [

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -201,7 +201,7 @@ export const commands: ChatCommands = {
 		} else {
 			user.battleSettings.inviteOnly = true;
 			user.update();
-			this.sendReply(`Your next battle will be invite-only${user.forcedPublic('privacy') ? `, unless it is rated` : ``}.`);
+			this.sendReply(`Your next battle will be invite-only${Rooms.RoomBattle.battleForcedSetting(user, 'privacy') ? `, unless it is rated` : ``}.`);
 		}
 	},
 	inviteonlynexthelp: [
@@ -1115,7 +1115,7 @@ export const commands: ChatCommands = {
 		} else {
 			user.battleSettings.hidden = true;
 			user.update();
-			this.sendReply(`Your next battle will be hidden${user.forcedPublic('privacy') ? `, unless it is rated` : ``}.`);
+			this.sendReply(`Your next battle will be hidden${Rooms.RoomBattle.battleForcedSetting(user, 'privacy') ? `, unless it is rated` : ``}.`);
 		}
 	},
 	hidenexthelp: [

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -504,7 +504,7 @@ export class RoomBattle extends RoomGames.RoomGame {
 	ended: boolean;
 	active: boolean;
 	replaySaved: boolean;
-	forcePublic: string | null = null;
+	forcedSettings: {modchat?: string | null, privacy?: string | null} = {};
 	playerTable: {[userid: string]: RoomBattlePlayer};
 	players: RoomBattlePlayer[];
 	p1: RoomBattlePlayer;
@@ -1070,12 +1070,19 @@ export class RoomBattle extends RoomGames.RoomGame {
 
 		if (user) {
 			this.room.auth.set(player.id, Users.PLAYER_SYMBOL);
-			if (this.rated && !this.forcePublic) {
-				this.forcePublic = user.battlesForcedPublic();
+			if (this.rated) {
+				this.checkForcedSettings(user);
 			}
 		}
 		if (user?.inRooms.has(this.roomid)) this.onConnect(user);
 		return player;
+	}
+
+	checkForcedSettings(user: User) {
+		this.forcedSettings = {
+			modchat: this.forcedSettings.modchat || user.forcedPublic('modchat'),
+			privacy: this.forcedSettings.privacy || user.forcedPublic('privacy'),
+		};
 	}
 
 	makePlayer(user: User) {

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1087,7 +1087,7 @@ export class RoomBattle extends RoomGames.RoomGame {
 			} else if (playerOptions && playerOptions.hidden) {
 				privacySetter.add(playerOptions.user.id);
 			}
-			if (playerOptions) this.checkForcedUserSettings(playerOptions.user);
+			if (playerOptions?.user) this.checkForcedUserSettings(playerOptions.user);
 		}
 
 		if (privacySetter.size) {

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1081,13 +1081,15 @@ export class RoomBattle extends RoomGames.RoomGame {
 		const privacySetter = new Set<ID>([]);
 		for (const p of ['p1', 'p2', 'p3', 'p4'] as const) {
 			const playerOptions = options[p];
-			if (playerOptions && playerOptions.inviteOnly) {
-				inviteOnly = true;
-				privacySetter.add(playerOptions.user.id);
-			} else if (playerOptions && playerOptions.hidden) {
-				privacySetter.add(playerOptions.user.id);
+			if (playerOptions) {
+				if (playerOptions.inviteOnly) {
+					inviteOnly = true;
+					privacySetter.add(playerOptions.user.id);
+				} else if (playerOptions.hidden) {
+					privacySetter.add(playerOptions.user.id);
+				}
+				if (playerOptions.user) this.checkForcedUserSettings(playerOptions.user);
 			}
-			if (playerOptions?.user) this.checkForcedUserSettings(playerOptions.user);
 		}
 
 		if (privacySetter.size) {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1922,8 +1922,6 @@ export const Rooms = {
 		const room = Rooms.createGameRoom(roomid, roomTitle, options);
 		const battle = new Rooms.RoomBattle(room, options);
 		room.game = battle;
-		// Special battles have modchat set to Player from the beginning
-		if (p1Special) room.settings.modchat = '\u2606';
 
 		let inviteOnly = false;
 		const privacySetter = new Set<ID>([]);
@@ -1935,13 +1933,19 @@ export const Rooms = {
 			} else if (playerOptions && playerOptions.hidden) {
 				privacySetter.add(playerOptions.user.id);
 			}
+			if (playerOptions) battle.checkForcedSettings(playerOptions.user);
+		}
+
+		// Special battles have modchat set to Player from the beginning
+		if (p1Special || battle.forcedSettings.modchat) {
+			room.settings.modchat = '\u2606';
 		}
 
 		if (privacySetter.size) {
-			if (battle.forcePublic) {
+			if (battle.forcedSettings.privacy) {
 				room.setPrivate(false);
 				room.settings.modjoin = null;
-				room.add(`|raw|<div class="broadcast-blue"><strong>This battle is required to be public due to a player having a name starting with '${battle.forcePublic}'.</div>`);
+				room.add(`|raw|<div class="broadcast-blue"><strong>This battle is required to be public due to a player having a name starting with '${battle.forcedSettings.privacy}'.</div>`);
 			} else if (!options.tour || (room.tour?.allowModjoin)) {
 				room.setPrivate('hidden');
 				if (inviteOnly) room.settings.modjoin = '%';

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1926,7 +1926,6 @@ export const Rooms = {
 
 		for (const p of players) {
 			if (p) {
-				battle.checkForcedUserSettings(p);
 				p.joinRoom(room);
 				Monitor.countBattle(p.latestIp, p.name);
 			}

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1922,43 +1922,11 @@ export const Rooms = {
 		const room = Rooms.createGameRoom(roomid, roomTitle, options);
 		const battle = new Rooms.RoomBattle(room, options);
 		room.game = battle;
-
-		let inviteOnly = false;
-		const privacySetter = new Set<ID>([]);
-		for (const p of ['p1', 'p2', 'p3', 'p4'] as const) {
-			const playerOptions = options[p];
-			if (playerOptions && playerOptions.inviteOnly) {
-				inviteOnly = true;
-				privacySetter.add(playerOptions.user.id);
-			} else if (playerOptions && playerOptions.hidden) {
-				privacySetter.add(playerOptions.user.id);
-			}
-			if (playerOptions) battle.checkForcedSettings(playerOptions.user);
-		}
-
-		// Special battles have modchat set to Player from the beginning
-		if (p1Special || battle.forcedSettings.modchat) {
-			room.settings.modchat = '\u2606';
-		}
-
-		if (privacySetter.size) {
-			if (battle.forcedSettings.privacy) {
-				room.setPrivate(false);
-				room.settings.modjoin = null;
-				room.add(`|raw|<div class="broadcast-blue"><strong>This battle is required to be public due to a player having a name starting with '${battle.forcedSettings.privacy}'.</div>`);
-			} else if (!options.tour || (room.tour?.allowModjoin)) {
-				room.setPrivate('hidden');
-				if (inviteOnly) room.settings.modjoin = '%';
-				room.privacySetter = privacySetter;
-				if (inviteOnly) {
-					room.settings.modjoin = '%';
-					room.add(`|raw|<div class="broadcast-red"><strong>This battle is invite-only!</strong><br />Users must be invited with <code>/invite</code> (or be staff) to join</div>`);
-				}
-			}
-		}
+		battle.checkPrivacySettings(options);
 
 		for (const p of players) {
 			if (p) {
+				battle.checkForcedUserSettings(p);
 				p.joinRoom(room);
 				Monitor.countBattle(p.latestIp, p.name);
 			}

--- a/server/users.ts
+++ b/server/users.ts
@@ -1480,9 +1480,13 @@ export class User extends Chat.MessageContext {
 			this.registered ? `[registered]` :
 			``;
 	}
-	battlesForcedPublic() {
-		if (!Config.forcedpublicprefixes) return null;
-		for (const prefix of Config.forcedpublicprefixes) {
+	forcedPublic(key: 'modchat' | 'privacy') {
+		if (Config.forcepublicprefixes) {
+			Config.forcedprefixes = {public: Config.forcepublicprefixes};
+			delete Config.forcepublicprefixes;
+		}
+		if (!Config.forcedprefixes?.[key]) return null;
+		for (const prefix of Config.forcedprefixes[key]) {
 			if (this.id.startsWith(toID(prefix))) return prefix;
 		}
 		return null;

--- a/server/users.ts
+++ b/server/users.ts
@@ -1480,17 +1480,6 @@ export class User extends Chat.MessageContext {
 			this.registered ? `[registered]` :
 			``;
 	}
-	forcedPublic(key: 'modchat' | 'privacy') {
-		if (Config.forcepublicprefixes) {
-			Config.forcedprefixes = {public: Config.forcepublicprefixes};
-			delete Config.forcepublicprefixes;
-		}
-		if (!Config.forcedprefixes?.[key]) return null;
-		for (const prefix of Config.forcedprefixes[key]) {
-			if (this.id.startsWith(toID(prefix))) return prefix;
-		}
-		return null;
-	}
 	destroy() {
 		// deallocate user
 		for (const roomid of this.games) {


### PR DESCRIPTION
Requested here https://www.smogon.com/forums/threads/allow-for-auto-modchatting-on-a-prefix.3682737/#post-8829088.
Monkeypatches are here https://gist.github.com/mia-pi-git/61fc91671107113a252d9d39791bad87.
I was told it would be optimal to have this live on the server by the 25th, as there's a tour that'd benefit from this.