### PR TITLE
Add more support for custom punishments

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -267,7 +267,7 @@ export const commands: ChatCommands = {
 
 				buf += punishments.map(([curRoom, curPunishment]) => {
 					const [punishType, punishUserid, expireTime, reason] = curPunishment;
-					let punishDesc = Punishments.roomPunishmentTypes.get(punishType);
+					let punishDesc = Punishments.roomPunishmentTypes.get(punishType)?.display;
 					if (!punishDesc) punishDesc = `punished`;
 					if (punishUserid !== targetUser.id) punishDesc += ` as ${punishUserid}`;
 					const expiresIn = new Date(expireTime).getTime() - Date.now();
@@ -322,7 +322,8 @@ export const commands: ChatCommands = {
 		const punishment = Punishments.userids.get(userid);
 		if (punishment) {
 			const [punishType, punishUserid, , reason] = punishment;
-			const punishName = (Punishments.punishmentTypes.get(punishType) || punishType).toUpperCase();
+			const punishData = (Punishments.punishmentTypes.get(punishType) || punishType);
+			const punishName = (Array.isArray(punishData) ? punishData[0] : punishData).toUpperCase();
 			buf += `${punishName}: ${punishUserid}`;
 			const expiresIn = Punishments.checkLockExpiration(userid);
 			if (expiresIn) buf += expiresIn;
@@ -345,7 +346,7 @@ export const commands: ChatCommands = {
 
 			buf += punishments.map(([curRoom, curPunishment]) => {
 				const [punishType, punishUserid, expireTime, reason] = curPunishment;
-				let punishDesc = Punishments.roomPunishmentTypes.get(punishType);
+				let punishDesc = Punishments.roomPunishmentTypes.get(punishType)?.display;
 				if (!punishDesc) punishDesc = `punished`;
 				if (punishUserid !== userid) punishDesc += ` as ${punishUserid}`;
 				const expiresIn = new Date(expireTime).getTime() - Date.now();

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -267,7 +267,7 @@ export const commands: ChatCommands = {
 
 				buf += punishments.map(([curRoom, curPunishment]) => {
 					const [punishType, punishUserid, expireTime, reason] = curPunishment;
-					let punishDesc = Punishments.roomPunishmentTypes.get(punishType)?.display;
+					let punishDesc = Punishments.roomPunishmentTypes.get(punishType)?.desc;
 					if (!punishDesc) punishDesc = `punished`;
 					if (punishUserid !== targetUser.id) punishDesc += ` as ${punishUserid}`;
 					const expiresIn = new Date(expireTime).getTime() - Date.now();
@@ -346,7 +346,7 @@ export const commands: ChatCommands = {
 
 			buf += punishments.map(([curRoom, curPunishment]) => {
 				const [punishType, punishUserid, expireTime, reason] = curPunishment;
-				let punishDesc = Punishments.roomPunishmentTypes.get(punishType)?.display;
+				let punishDesc = Punishments.roomPunishmentTypes.get(punishType)?.desc;
 				if (!punishDesc) punishDesc = `punished`;
 				if (punishUserid !== userid) punishDesc += ` as ${punishUserid}`;
 				const expiresIn = new Date(expireTime).getTime() - Date.now();

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -6,7 +6,7 @@ const TICKET_FILE = 'config/tickets.json';
 const TICKET_CACHE_TIME = 24 * 60 * 60 * 1000; // 24 hours
 const TICKET_BAN_DURATION = 48 * 60 * 60 * 1000; // 48 hours
 
-Punishments.roomPunishmentTypes.set(`TICKETBAN`, 'banned from creating help tickets');
+Punishments.addRoomPunishmentType('TICKETBAN', 'banned from creating help tickets');
 
 interface TicketState {
 	creator: string;

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -100,8 +100,8 @@ const VALID_IMAGES = [
 let MafiaData: MafiaData = Object.create(null);
 let logs: MafiaLog = {leaderboard: {}, mvps: {}, hosts: {}, plays: {}, leavers: {}};
 
-Punishments.roomPunishmentTypes.set('MAFIAGAMEBAN', 'banned from playing mafia games');
-Punishments.roomPunishmentTypes.set('MAFIAHOSTBAN', 'banned from hosting mafia games');
+Punishments.addRoomPunishmentType('MAFIAGAMEBAN', 'banned from playing mafia games');
+Punishments.addRoomPunishmentType('MAFIAHOSTBAN', 'banned from hosting mafia games');
 
 const hostQueue: ID[] = [];
 

--- a/server/chat-plugins/wifi.ts
+++ b/server/chat-plugins/wifi.ts
@@ -6,7 +6,7 @@
 
 import {FS, Utils} from '../../lib';
 
-Punishments.roomPunishmentTypes.set('GIVEAWAYBAN', 'banned from giveaways');
+Punishments.addRoomPunishmentType('GIVEAWAYBAN', 'banned from giveaways');
 
 const BAN_DURATION = 7 * 24 * 60 * 60 * 1000;
 const RECENT_THRESHOLD = 30 * 24 * 60 * 60 * 1000;

--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -58,13 +58,12 @@ export type Punishment = [string, ID | PunishType, number, string];
 
 /**
  * Info on punishment types. Can be used for either room punishment types or global punishments
- * extended by plugins. It can either be just a string (corresponding to the display in /alts),
- * or a [string, callback] - where the string is the /alts display, and the callback is what to do if the user
+ * extended by plugins. The `desc` is the /alts display, and the `callback` is what to do if the user
  * _does_ have the punishment (can be used to add extra effects in lieu of something like a loginfilter.)
  * Rooms will be specified for room punishments, otherwise it's null for global punishments
  */
 export interface PunishInfo {
-	display: string;
+	desc: string;
 	callback?: (user: User, punishment: Punishment, room: Room | null) => void;
 }
 
@@ -195,15 +194,11 @@ export const Punishments = new class {
 	 *
 	 * This map can be extended with custom punishments by chat plugins.
 	 *
-	 * Keys in the map correspond to punishTypes, values signify the way
-	 * they should be displayed in /alt. Optionally, it can be made an array with [display, callback function]
-	 * with the callback function being called in `checkName`
-	 * (can be used in lieu of a loginfilter to apply the effects of the punishment, or to handle notifying the user.)
-	 */
+	 * Keys in the map correspond to PunishInfo */
 	readonly punishmentTypes = new Map<string, PunishInfo>([
-		['LOCK', {display: 'locked'}],
-		['BAN', {display: 'globally banned'}],
-		['NAMELOCK', {display: 'namelocked'}],
+		['LOCK', {desc: 'locked'}],
+		['BAN', {desc: 'globally banned'}],
+		['NAMELOCK', {desc: 'namelocked'}],
 	]);
 	/**
 	 * For room punishments, they can be anything in the roomPunishmentTypes map.
@@ -220,11 +215,11 @@ export const Punishments = new class {
 	 *
 	 */
 	readonly roomPunishmentTypes = new Map<string, PunishInfo>([
-		['ROOMBAN', {display: 'banned'}],
-		['BLACKLIST', {display: 'blacklisted'}],
-		['BATTLEBAN', {display: 'battlebanned'}],
-		['MUTE', {display: 'muted'}],
-		['GROUPCHATBAN', {display: 'banned from using groupchats'}],
+		['ROOMBAN', {desc: 'banned'}],
+		['BLACKLIST', {desc: 'blacklisted'}],
+		['BATTLEBAN', {desc: 'battlebanned'}],
+		['MUTE', {desc: 'muted'}],
+		['GROUPCHATBAN', {desc: 'banned from using groupchats'}],
 	]);
 	constructor() {
 		setImmediate(() => {
@@ -752,11 +747,11 @@ export const Punishments = new class {
 		return success;
 	}
 
-	addRoomPunishmentType(type: string, display: string, callback?: PunishInfo['callback']) {
-		this.roomPunishmentTypes.set(type, {display, callback});
+	addRoomPunishmentType(type: string, desc: string, callback?: PunishInfo['callback']) {
+		this.roomPunishmentTypes.set(type, {desc, callback});
 	}
-	addPunishmentType(type: string, display: string, callback?: PunishInfo['callback']) {
-		this.punishmentTypes.set(type, {display, callback});
+	addPunishmentType(type: string, desc: string, callback?: PunishInfo['callback']) {
+		this.punishmentTypes.set(type, {desc, callback});
 	}
 
 	/*********************************************************
@@ -1793,7 +1788,7 @@ export const Punishments = new class {
 			const punishmentText = punishments.map(([room, punishment]) => {
 				const [punishType, punishUserid, , reason] = punishment;
 				if (punishType in PUNISHMENT_POINT_VALUES) points += PUNISHMENT_POINT_VALUES[punishType];
-				let punishDesc = Punishments.roomPunishmentTypes.get(punishType)?.display;
+				let punishDesc = Punishments.roomPunishmentTypes.get(punishType)?.desc;
 				if (!punishDesc) punishDesc = `punished`;
 				if (punishUserid !== userid) punishDesc += ` as ${punishUserid}`;
 

--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -55,6 +55,19 @@ const GROUPCHAT_MONITOR_INTERVAL = 10 * 60 * 1000; // 10 minutes
  * A punishment is an array: [punishType, userid | #punishmenttype, expireTime, reason]
  */
 export type Punishment = [string, ID | PunishType, number, string];
+
+/**
+ * Info on punishment types. Can be used for either room punishment types or global punishments
+ * extended by plugins. It can either be just a string (corresponding to the display in /alts),
+ * or a [string, callback] - where the string is the /alts display, and the callback is what to do if the user
+ * _does_ have the punishment (can be used to add extra effects in lieu of something like a loginfilter.)
+ * Rooms will be specified for room punishments, otherwise it's null for global punishments
+ */
+export interface PunishInfo {
+	display: string;
+	callback?: (user: User, punishment: Punishment, room: Room | null) => void;
+}
+
 interface PunishmentEntry {
 	ips: string[];
 	userids: ID[];
@@ -183,13 +196,14 @@ export const Punishments = new class {
 	 * This map can be extended with custom punishments by chat plugins.
 	 *
 	 * Keys in the map correspond to punishTypes, values signify the way
-	 * they should be displayed in /alt
-	 *
+	 * they should be displayed in /alt. Optionally, it can be made an array with [display, callback function]
+	 * with the callback function being called in `checkName`
+	 * (can be used in lieu of a loginfilter to apply the effects of the punishment, or to handle notifying the user.)
 	 */
-	readonly punishmentTypes = new Map<string, string>([
-		['LOCK', 'locked'],
-		['BAN', 'globally banned'],
-		['NAMELOCK', 'namelocked'],
+	readonly punishmentTypes = new Map<string, PunishInfo>([
+		['LOCK', {display: 'locked'}],
+		['BAN', {display: 'globally banned'}],
+		['NAMELOCK', {display: 'namelocked'}],
 	]);
 	/**
 	 * For room punishments, they can be anything in the roomPunishmentTypes map.
@@ -205,12 +219,12 @@ export const Punishments = new class {
 	 * - 'MUTE' (used by getRoomPunishments)
 	 *
 	 */
-	readonly roomPunishmentTypes = new Map<string, string>([
-		['ROOMBAN', 'banned'],
-		['BLACKLIST', 'blacklisted'],
-		['BATTLEBAN', 'battlebanned'],
-		['MUTE', 'muted'],
-		['GROUPCHATBAN', 'banned from using groupchats'],
+	readonly roomPunishmentTypes = new Map<string, PunishInfo>([
+		['ROOMBAN', {display: 'banned'}],
+		['BLACKLIST', {display: 'blacklisted'}],
+		['BATTLEBAN', {display: 'battlebanned'}],
+		['MUTE', {display: 'muted'}],
+		['GROUPCHATBAN', {display: 'banned from using groupchats'}],
 	]);
 	constructor() {
 		setImmediate(() => {
@@ -736,6 +750,13 @@ export const Punishments = new class {
 			Punishments.saveRoomPunishments();
 		}
 		return success;
+	}
+
+	addRoomPunishmentType(type: string, display: string, callback?: PunishInfo['callback']) {
+		this.roomPunishmentTypes.set(type, {display, callback});
+	}
+	addPunishmentType(type: string, display: string, callback?: PunishInfo['callback']) {
+		this.punishmentTypes.set(type, {display, callback});
 	}
 
 	/*********************************************************
@@ -1387,6 +1408,7 @@ export const Punishments = new class {
 		if (!punishment) return;
 
 		const id = punishment[0];
+		const punishmentInfo = this.punishmentTypes.get(id);
 		const punishUserid = punishment[1];
 		const reason = punishment[3] ? Utils.html`\n\nReason: ${punishment[3]}` : '';
 		let appeal = ``;
@@ -1425,7 +1447,7 @@ export const Punishments = new class {
 			user.namelocked = punishUserid;
 			user.resetName();
 			user.updateIdentity();
-		} else {
+		} else if (id === 'LOCK') {
 			if (punishUserid === '#hostfilter' || punishUserid === '#ipban') {
 				user.send(`|popup||html|Your IP (${user.latestIp}) is currently locked due to being a proxy. We automatically lock these connections since they are used to spam, hack, or otherwise attack our server. Disable any proxies you are using to connect to PS.\n\n<a href="view-help-request--appeal"><button class="button">Help me with a lock from a proxy</button></a>`);
 			} else if (user.latestHostType === 'proxy' && user.locked !== user.id) {
@@ -1436,6 +1458,8 @@ export const Punishments = new class {
 			user.notified.lock = true;
 			user.locked = punishUserid;
 			user.updateIdentity();
+		} else if (punishmentInfo?.callback) {
+			punishmentInfo.callback.call(this, user, punishment, null);
 		}
 		Punishments.checkPunishmentTime(user, punishment);
 	}
@@ -1531,6 +1555,11 @@ export const Punishments = new class {
 			}
 		}
 		if (punishment) {
+			const info = this.roomPunishmentTypes.get(punishment[0]);
+			if (info?.callback) {
+				info.callback.call(this, user, punishment, Rooms.get(roomid)!);
+				return punishment;
+			}
 			if (punishment[0] !== 'ROOMBAN' && punishment[0] !== 'BLACKLIST') return null;
 			const room = Rooms.get(roomid)!;
 			if (room.game && room.game.removeBannedUser) {
@@ -1764,7 +1793,7 @@ export const Punishments = new class {
 			const punishmentText = punishments.map(([room, punishment]) => {
 				const [punishType, punishUserid, , reason] = punishment;
 				if (punishType in PUNISHMENT_POINT_VALUES) points += PUNISHMENT_POINT_VALUES[punishType];
-				let punishDesc = Punishments.roomPunishmentTypes.get(punishType);
+				let punishDesc = Punishments.roomPunishmentTypes.get(punishType)?.display;
 				if (!punishDesc) punishDesc = `punished`;
 				if (punishUserid !== userid) punishDesc += ` as ${punishUserid}`;
 

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -24,7 +24,7 @@ const MAX_REASON_LENGTH = 300;
 const MAX_CUSTOM_NAME_LENGTH = 100;
 const TOURBAN_DURATION = 14 * 24 * 60 * 60 * 1000;
 
-Punishments.roomPunishmentTypes.set('TOURBAN', 'banned from tournaments');
+Punishments.addRoomPunishmentType('TOURBAN', 'banned from tournaments');
 
 const TournamentGenerators = {
 	__proto__: null,


### PR DESCRIPTION
This adds a few useful things.
One, punishmentTypes now support callbacks (that are called when a user has the punishment they're set for and has just logged in.) This should make it easier to _do_ things with custom punishments without extra code for a loginfilter that also checks if they have the type.
It also adds support for adding more properties to punishment types.
Lastly, it ensures that when a user has a custom global punishment, it doesn't randomly lock them (as that is frequently undesired behavor) and instead just calls the callback.