### PR TITLE
Use data/tags for validator

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -521,7 +521,7 @@ export const Formats: FormatList = [
 			'Garchomp', 'Gliscor', 'Greninja', 'Gyarados-Mega', 'Heatran', 'Kartana', 'Kommo-o', 'Kyurem', 'Landorus-Therian', 'Lopunny-Mega',
 			'Magnezone', 'Mawile-Mega', 'Medicham-Mega', 'Pelipper', 'Rillaboom', 'Scizor-Mega', 'Serperior', 'Slowbro-Base', 'Swampert-Mega',
 			'Tangrowth', 'Tapu Fini', 'Tapu Koko', 'Tapu Lele', 'Toxapex', 'Tyranitar', 'Victini', 'Volcarona', 'Zapdos-Base',
-			'NDUUBL', // National Dex UUBL
+			'ND UUBL', // National Dex UUBL
 			'Drizzle', 'Drought',
 			// Slowbronite is banned so it doesn't validate on Galarian Slowbro
 			'Slowbronite',

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -521,10 +521,8 @@ export const Formats: FormatList = [
 			'Garchomp', 'Gliscor', 'Greninja', 'Gyarados-Mega', 'Heatran', 'Kartana', 'Kommo-o', 'Kyurem', 'Landorus-Therian', 'Lopunny-Mega',
 			'Magnezone', 'Mawile-Mega', 'Medicham-Mega', 'Pelipper', 'Rillaboom', 'Scizor-Mega', 'Serperior', 'Slowbro-Base', 'Swampert-Mega',
 			'Tangrowth', 'Tapu Fini', 'Tapu Koko', 'Tapu Lele', 'Toxapex', 'Tyranitar', 'Victini', 'Volcarona', 'Zapdos-Base',
-			'nduubl', // National Dex UUBL
-			'Aerodactyl-Mega', 'Azumarill', 'Blacephalon', 'Diancie-Mega', 'Gallade-Mega', 'Gardevoir-Mega', 'Gengar', 'Gyarados', 'Hawlucha',
-			'Heracross-Mega', 'Hydreigon', 'Latias', 'Latias-Mega', 'Latios', 'Manaphy', 'Pinsir-Mega', 'Slowbro-Mega', 'Thundurus',
-			'Venusaur-Mega', 'Xurkitree', 'Zapdos-Galar', 'Drizzle', 'Drought',
+			'NDUUBL', // National Dex UUBL
+			'Drizzle', 'Drought',
 			// Slowbronite is banned so it doesn't validate on Galarian Slowbro
 			'Slowbronite',
 		],

--- a/data/tags.ts
+++ b/data/tags.ts
@@ -164,9 +164,9 @@ export const Tags: {[id: string]: TagData} = {
 		name: "LC",
 		speciesFilter: species => species.doublesTier === 'LC',
 	},
-	cap: {
-		name: "CAP",
-		speciesFilter: species => species.tier === 'CAP',
+	captier: {
+		name: "CAP Tier",
+		speciesFilter: species => species.isNonstandard === 'CAP',
 	},
 	caplc: {
 		name: "CAP LC",
@@ -221,17 +221,25 @@ export const Tags: {[id: string]: TagData} = {
 		name: "Future",
 		genericFilter: thing => thing.isNonstandard === 'Future',
 	},
-	unobtainable: {
-		name: "Unobtainable",
-		genericFilter: thing => thing.isNonstandard === 'Unobtainable',
-	},
 	lgpe: {
 		name: "LGPE",
 		genericFilter: thing => thing.isNonstandard === 'LGPE',
 	},
+	unobtainable: {
+		name: "Unobtainable",
+		genericFilter: thing => thing.isNonstandard === 'Unobtainable',
+	},
+	cap: {
+		name: "CAP",
+		speciesFilter: thing => thing.isNonstandard === 'CAP',
+	},
 	custom: {
 		name: "Custom",
 		genericFilter: thing => thing.isNonstandard === 'Custom',
+	},
+	nonexistent: {
+		name: "Nonexistent",
+		genericFilter: thing => !!thing.isNonstandard && thing.isNonstandard !== 'Unobtainable',
 	},
 
 	// filter columns

--- a/data/tags.ts
+++ b/data/tags.ts
@@ -180,6 +180,14 @@ export const Tags: {[id: string]: TagData} = {
 		name: "AG",
 		speciesFilter: species => species.tier === 'AG',
 	},
+	nduubl: {
+		name: "ND UUBL",
+		speciesFilter: species => [
+			'Aerodactyl-Mega', 'Azumarill', 'Blacephalon', 'Diancie-Mega', 'Gallade-Mega', 'Gardevoir-Mega', 'Gengar', 'Gyarados', 'Hawlucha',
+			'Heracross-Mega', 'Hydreigon', 'Latias', 'Latias-Mega', 'Latios', 'Manaphy', 'Pinsir-Mega', 'Slowbro-Mega', 'Thundurus',
+			'Venusaur-Mega', 'Xurkitree', 'Zapdos-Galar',
+		].includes(species.name),
+	},
 
 	// Doubles tiers
 	// -------------

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -97,6 +97,11 @@ export class RuleTable extends Map<string, string> {
 		return this.has(`*pokemontag:allpokemon`);
 	}
 
+	/**
+	 * - non-empty string: banned, string is the reason
+	 * - '': whitelisted
+	 * - null: neither whitelisted nor banned
+	 */
 	check(thing: string, setHas: {[id: string]: true} | null = null) {
 		if (this.has(`+${thing}`)) return '';
 		if (setHas) setHas[thing] = true;
@@ -619,8 +624,6 @@ export class DexFormats {
 
 	getTagRules(ruleTable: RuleTable) {
 		const tagRules = [];
-		const specificExistenceTagRules = [];
-		const existenceTagRules = [];
 		for (const ruleid of ruleTable.keys()) {
 			if (/^[+*-]pokemontag:/.test(ruleid)) {
 				const banid = ruleid.slice(12);
@@ -629,25 +632,14 @@ export class DexFormats {
 					banid === 'allabilities' || banid === 'allnatures'
 				) {
 					// hardcoded and not a part of the ban rule system
-				} else if (!ruleid.startsWith('+') && (
-					banid === 'past' || banid === 'future' || banid === 'lgpe' ||
-					banid === 'unobtainable' || banid === 'cap' || banid === 'custom'
-				)) {
-					specificExistenceTagRules.push(ruleid);
-				} else if (!ruleid.startsWith('+') && banid === 'nonexistent') {
-					existenceTagRules.push(ruleid);
 				} else {
 					tagRules.push(ruleid);
 				}
 			} else if ('+*-'.includes(ruleid.charAt(0)) && ruleid.slice(1) === 'nonexistent') {
-				if (!ruleid.startsWith('+')) {
-					existenceTagRules.push(ruleid.charAt(0) + 'pokemontag:nonexistent');
-				} else {
-					tagRules.push('+pokemontag:nonexistent');
-				}
+				tagRules.push(ruleid.charAt(0) + 'pokemontag:nonexistent');
 			}
 		}
-		ruleTable.tagRules = [...tagRules, ...existenceTagRules, ...specificExistenceTagRules].reverse();
+		ruleTable.tagRules = tagRules.reverse();
 	}
 
 	validateRule(rule: string, format: Format | null = null) {

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -619,13 +619,29 @@ export class DexFormats {
 
 	getTagRules(ruleTable: RuleTable) {
 		const tagRules = [];
+		const specificExistenceTagRules = [];
+		const existenceTagRules = [];
 		for (const ruleid of ruleTable.keys()) {
 			if (/^[+*-]pokemontag:/.test(ruleid)) {
-				if (ruleid.slice(12) === 'allpokemon') continue;
-				tagRules.push(ruleid);
+				const banid = ruleid.slice(12);
+				if (
+					banid === 'allpokemon' || banid === 'allitems' || banid === 'allmoves' ||
+					banid === 'allabilities' || banid === 'allnatures'
+				) {
+					// hardcoded and not a part of the ban rule system
+				} else if (!ruleid.startsWith('+') && (
+					banid === 'past' || banid === 'future' || banid === 'lgpe' ||
+					banid === 'unobtainable' || banid === 'cap' || banid === 'custom'
+				)) {
+					specificExistenceTagRules.push(ruleid);
+				} else if (!ruleid.startsWith('+') && banid === 'nonexistent') {
+					existenceTagRules.push(ruleid);
+				} else {
+					tagRules.push(ruleid);
+				}
 			}
 		}
-		ruleTable.tagRules = tagRules;
+		ruleTable.tagRules = [...tagRules, ...existenceTagRules, ...specificExistenceTagRules].reverse();
 	}
 
 	validateRule(rule: string, format: Format | null = null) {

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -620,7 +620,7 @@ export class DexFormats {
 	getTagRules(ruleTable: RuleTable) {
 		const tagRules = [];
 		for (const ruleid of ruleTable.keys()) {
-			if (ruleid.startsWith('+pokemontag:') || ruleid.startsWith('-pokemontag:') || ruleid.startsWith('*pokemontag:')) {
+			if (/^[+*-]pokemontag:/.test(ruleid)) {
 				if (ruleid.slice(12) === 'allpokemon') continue;
 				tagRules.push(ruleid);
 			}

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -639,6 +639,12 @@ export class DexFormats {
 				} else {
 					tagRules.push(ruleid);
 				}
+			} else if ('+*-'.includes(ruleid.charAt(0)) && ruleid.slice(1) === 'nonexistent') {
+				if (!ruleid.startsWith('+')) {
+					existenceTagRules.push(ruleid.charAt(0) + 'pokemontag:nonexistent');
+				} else {
+					tagRules.push('+pokemontag:nonexistent');
+				}
 			}
 		}
 		ruleTable.tagRules = [...tagRules, ...existenceTagRules, ...specificExistenceTagRules].reverse();

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -1,6 +1,7 @@
 import {Utils} from '../lib';
 import {toID, BasicEffect} from './dex-data';
 import {EventMethods} from './dex-conditions';
+import {Tags} from '../data/tags';
 
 const DEFAULT_MOD = 'gen8';
 const MAIN_FORMATS = `${__dirname}/../.config-dist/formats`;
@@ -34,6 +35,7 @@ export class RuleTable extends Map<string, string> {
 	checkCanLearn: [TeamValidator['checkCanLearn'], string] | null;
 	timer: [Partial<GameTimerSettings>, string] | null;
 	minSourceGen: [number, string] | null;
+	tagRules: string[];
 
 	constructor() {
 		super();
@@ -42,6 +44,7 @@ export class RuleTable extends Map<string, string> {
 		this.checkCanLearn = null;
 		this.timer = null;
 		this.minSourceGen = null;
+		this.tagRules = [];
 	}
 
 	isBanned(thing: string) {
@@ -54,12 +57,18 @@ export class RuleTable extends Map<string, string> {
 		if (this.has(`-pokemon:${species.id}`)) return true;
 		if (this.has(`+basepokemon:${toID(species.baseSpecies)}`)) return false;
 		if (this.has(`-basepokemon:${toID(species.baseSpecies)}`)) return true;
-		const tier = species.tier === '(PU)' ? 'ZU' : species.tier === '(NU)' ? 'PU' : species.tier;
-		if (this.has(`+pokemontag:${toID(tier)}`)) return false;
-		if (this.has(`-pokemontag:${toID(tier)}`)) return true;
-		const doublesTier = species.doublesTier === '(DUU)' ? 'DNU' : species.doublesTier;
-		if (this.has(`+pokemontag:${toID(doublesTier)}`)) return false;
-		if (this.has(`-pokemontag:${toID(doublesTier)}`)) return true;
+		for (const tagid in Tags) {
+			const tag = Tags[tagid];
+			if (this.has(`-pokemontag:${tagid}`)) {
+				if (tag.speciesFilter!(species)) return false;
+			}
+		}
+		for (const tagid in Tags) {
+			const tag = Tags[tagid];
+			if (this.has(`+pokemontag:${tagid}`)) {
+				if (tag.speciesFilter!(species)) return false;
+			}
+		}
 		return this.has(`-pokemontag:allpokemon`);
 	}
 
@@ -73,12 +82,18 @@ export class RuleTable extends Map<string, string> {
 		if (this.has(`*pokemon:${species.id}`)) return true;
 		if (this.has(`+basepokemon:${toID(species.baseSpecies)}`)) return false;
 		if (this.has(`*basepokemon:${toID(species.baseSpecies)}`)) return true;
-		const tier = species.tier === '(PU)' ? 'ZU' : species.tier === '(NU)' ? 'PU' : species.tier;
-		if (this.has(`+pokemontag:${toID(tier)}`)) return false;
-		if (this.has(`*pokemontag:${toID(tier)}`)) return true;
-		const doublesTier = species.doublesTier === '(DUU)' ? 'DNU' : species.doublesTier;
-		if (this.has(`+pokemontag:${toID(doublesTier)}`)) return false;
-		if (this.has(`*pokemontag:${toID(doublesTier)}`)) return true;
+		for (const tagid in Tags) {
+			const tag = Tags[tagid];
+			if (tag.speciesFilter && this.has(`*pokemontag:${tagid}`)) {
+				if (tag.speciesFilter(species)) return false;
+			}
+		}
+		for (const tagid in Tags) {
+			const tag = Tags[tagid];
+			if (tag.speciesFilter && this.has(`+pokemontag:${tagid}`)) {
+				if (tag.speciesFilter(species)) return false;
+			}
+		}
 		return this.has(`*pokemontag:allpokemon`);
 	}
 
@@ -596,9 +611,21 @@ export class DexFormats {
 				ruleTable.minSourceGen = subRuleTable.minSourceGen;
 			}
 		}
+		this.getTagRules(ruleTable);
 
 		if (!repeals) format.ruleTable = ruleTable;
 		return ruleTable;
+	}
+
+	getTagRules(ruleTable: RuleTable) {
+		const tagRules = [];
+		for (const ruleid of ruleTable.keys()) {
+			if (ruleid.startsWith('+pokemontag:') || ruleid.startsWith('-pokemontag:') || ruleid.startsWith('*pokemontag:')) {
+				if (ruleid.slice(12) === 'allpokemon') continue;
+				tagRules.push(ruleid);
+			}
+		}
+		ruleTable.tagRules = tagRules;
 	}
 
 	validateRule(rule: string, format: Format | null = null) {
@@ -641,6 +668,12 @@ export class DexFormats {
 		}
 	}
 
+	validPokemonTag(tagid: ID) {
+		const tag = Tags.hasOwnProperty(tagid) && Tags[tagid];
+		if (!tag) return false;
+		return !!(tag.speciesFilter || tag.genericFilter);
+	}
+
 	validateBanRule(rule: string) {
 		let id = toID(rule);
 		if (id === 'unreleased') return 'unreleased';
@@ -667,18 +700,12 @@ export class DexFormats {
 			case 'pokemontag':
 				// valid pokemontags
 				const validTags = [
-					// singles tiers
-					'uber', 'ou', 'uubl', 'uu', 'rubl', 'ru', 'nubl', 'nu', 'publ', 'pu', 'zu', 'nfe', 'lc', 'cap', 'caplc', 'capnfe', 'ag',
-					// doubles tiers
-					'duber', 'dou', 'dbl', 'duu', 'dnu',
-					// custom tags -- nduubl is used for national dex teambuilder formatting
-					'mega', 'nduubl',
-					// illegal/nonstandard reasons
-					'past', 'future', 'unobtainable', 'lgpe', 'custom',
 					// all
 					'allpokemon', 'allitems', 'allmoves', 'allabilities', 'allnatures',
 				];
-				if (validTags.includes(ruleid)) matches.push('pokemontag:' + ruleid);
+				if (validTags.includes(ruleid) || this.validPokemonTag(ruleid)) {
+					matches.push('pokemontag:' + ruleid);
+				}
 				continue;
 			default:
 				throw new Error(`Unrecognized match type.`);

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1335,6 +1335,7 @@ export class TeamValidator {
 		}
 
 		const EXISTENCE_TAG = ['past', 'future', 'lgpe', 'unobtainable', 'cap', 'custom', 'nonexistent'];
+		console.log(ruleTable.tagRules);
 		for (const ruleid of ruleTable.tagRules) {
 			if (ruleid.startsWith('*')) continue;
 			const tagid = ruleid.slice(12);

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1334,22 +1334,29 @@ export class TeamValidator {
 			}
 		}
 
+		const EXISTENCE_TAG = ['past', 'future', 'lgpe', 'unobtainable', 'cap', 'custom', 'nonexistent'];
 		for (const ruleid of ruleTable.tagRules) {
 			if (ruleid.startsWith('*')) continue;
-			const tag = Tags[ruleid.slice(12)];
+			const tagid = ruleid.slice(12);
+			const tag = Tags[tagid];
 			if ((tag.speciesFilter || tag.genericFilter)!(tierSpecies)) {
 				if (ruleid.startsWith('+')) return null;
-				if (tag.name === 'Past' || tag.name === 'Future') {
-					return `${tierSpecies.name} does not exist in Gen ${dex.gen}.`;
-				}
-				if (tag.name === 'CAP') {
-					return `${tierSpecies.name} is a CAP and does not exist in this game.`;
-				}
-				if (tag.name === 'Unobtainable') {
-					return `${tierSpecies.name} is not possible to obtain in this game.`;
-				}
-				if (tag.name === 'Gigantamax') {
-					return `${tierSpecies.name} is not obtainable without Gigantamaxing, even through hacking.`;
+				if (EXISTENCE_TAG.includes(tagid)) {
+					if (tierSpecies.isNonstandard === 'Past' || tierSpecies.isNonstandard === 'Future') {
+						return `${tierSpecies.name} does not exist in Gen ${dex.gen}.`;
+					}
+					if (tierSpecies.isNonstandard === 'LGPE') {
+						return `${tierSpecies.name} does not exist in Ultra Sun/Moon, only in Let's Go Pikachu/Eevee.`;
+					}
+					if (tierSpecies.isNonstandard === 'CAP') {
+						return `${tierSpecies.name} is a CAP and does not exist in this game.`;
+					}
+					if (tierSpecies.isNonstandard === 'Unobtainable') {
+						return `${tierSpecies.name} is not possible to obtain in this game.`;
+					}
+					if (tierSpecies.isNonstandard === 'Gigantamax') {
+						return `${tierSpecies.name} is a placeholder for a Gigantamax sprite, not a real Pokémon. (This message is likely to be a validator bug.)`;
+					}
 				}
 				return `${species.name} is tagged ${tag.name}, which is ${banReason}.`;
 			}

--- a/test/sim/team-validator.js
+++ b/test/sim/team-validator.js
@@ -767,16 +767,22 @@ describe('Team Validator', function () {
 
 	it('should support banning/unbanning tag combinations', function () {
 		let team = [
-			{species: 'Blaziken-Mega', ability: 'Speed Boost', moves: ['protect'], evs: {hp: 1}},
+			{species: 'Crucibelle-Mega', ability: 'Regenerator', moves: ['protect'], evs: {hp: 1}},
 		];
 		let illegal = TeamValidator.get('gen8customgame@@@-nonexistent,+mega').validateTeam(team);
 		assert(illegal, "Nonexistent should override all tags that aren't existence-related");
 
 		team = [
-			{species: 'Blaziken-Mega', ability: 'Speed Boost', moves: ['protect'], evs: {hp: 1}},
+			{species: 'Crucibelle-Mega', ability: 'Regenerator', moves: ['protect'], evs: {hp: 1}},
 		];
 		illegal = TeamValidator.get('gen8customgame@@@+mega,-nonexistent').validateTeam(team);
 		assert(illegal, "Nonexistent should override all tags that aren't existence-related");
+
+		team = [
+			{species: 'Crucibelle-Mega', ability: 'Regenerator', moves: ['protect'], evs: {hp: 1}},
+		];
+		illegal = TeamValidator.get('gen8customgame@@@-nonexistent,+crucibellemega').validateTeam(team);
+		assert.equal(illegal, null, "Nonexistent should override all tags that aren't existence-related");
 	});
 
 	it('should allow moves to be banned', function () {

--- a/test/sim/team-validator.js
+++ b/test/sim/team-validator.js
@@ -765,6 +765,20 @@ describe('Team Validator', function () {
 		assert(illegal);
 	});
 
+	it('should support banning/unbanning tag combinations', function () {
+		let team = [
+			{species: 'Blaziken-Mega', ability: 'Speed Boost', moves: ['protect'], evs: {hp: 1}},
+		];
+		let illegal = TeamValidator.get('gen8customgame@@@-nonexistent,+mega').validateTeam(team);
+		assert(illegal, "Nonexistent should override all tags that aren't existence-related");
+
+		team = [
+			{species: 'Blaziken-Mega', ability: 'Speed Boost', moves: ['protect'], evs: {hp: 1}},
+		];
+		illegal = TeamValidator.get('gen8customgame@@@+mega,-nonexistent').validateTeam(team);
+		assert(illegal, "Nonexistent should override all tags that aren't existence-related");
+	});
+
 	it('should allow moves to be banned', function () {
 		const team = [
 			{species: 'pikachu', ability: 'static', moves: ['agility', 'protect', 'thunder', 'thunderbolt'], evs: {hp: 1}},


### PR DESCRIPTION
Previously, the validator had its own hardcoded tag system. This removes the hardcoding and makes it so any pokemon tag in `tags.ts` can be banned or unbanned.