### PR TITLE
Fix interaction of Destiny Bond and Red Card

### DIFF
--- a/data/items.ts
+++ b/data/items.ts
@@ -4412,6 +4412,10 @@ export const Items: {[itemid: string]: ItemData} = {
 			basePower: 10,
 		},
 		onAfterMoveSecondary(target, source, move) {
+			// check faint queue to evaluate destiny bond first
+			if (source && source.battle.faintQueue.length > 0) {
+				source.battle.faintMessages();
+			}
 			if (source && source !== target && source.hp && target.hp && move && move.category !== 'Status') {
 				if (!source.isActive || !this.canSwitch(source.side) || source.forceSwitchFlag || target.forceSwitchFlag) {
 					return;

--- a/data/items.ts
+++ b/data/items.ts
@@ -4412,10 +4412,6 @@ export const Items: {[itemid: string]: ItemData} = {
 			basePower: 10,
 		},
 		onAfterMoveSecondary(target, source, move) {
-			// check faint queue to evaluate destiny bond first
-			if (source && source.battle.faintQueue.length > 0) {
-				source.battle.faintMessages();
-			}
 			if (source && source !== target && source.hp && target.hp && move && move.category !== 'Status') {
 				if (!source.isActive || !this.canSwitch(source.side) || source.forceSwitchFlag || target.forceSwitchFlag) {
 					return;

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -743,7 +743,6 @@ export class BattleActions {
 	afterMoveSecondaryEvent(targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) {
 		// console.log(`${targets}, ${pokemon}, ${move}`)
 		if (!move.negateSecondary && !(move.hasSheerForce && pokemon.hasAbility('sheerforce'))) {
-			this.battle.faintMessages();
 			this.battle.singleEvent('AfterMoveSecondary', move, null, targets[0], pokemon, move);
 			this.battle.runEvent('AfterMoveSecondary', targets, pokemon, move);
 		}
@@ -898,6 +897,7 @@ export class BattleActions {
 		if (move.multihit && typeof move.smartTarget !== 'boolean') {
 			this.battle.add('-hitcount', targets[0], hit - 1);
 		}
+		this.battle.faintMessages();
 
 		if (move.recoil && move.totalDamage) {
 			this.battle.damage(this.calcRecoilDamage(move.totalDamage, move), pokemon, pokemon, 'recoil');

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -743,6 +743,7 @@ export class BattleActions {
 	afterMoveSecondaryEvent(targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) {
 		// console.log(`${targets}, ${pokemon}, ${move}`)
 		if (!move.negateSecondary && !(move.hasSheerForce && pokemon.hasAbility('sheerforce'))) {
+			this.battle.faintMessages();
 			this.battle.singleEvent('AfterMoveSecondary', move, null, targets[0], pokemon, move);
 			this.battle.runEvent('AfterMoveSecondary', targets, pokemon, move);
 		}

--- a/test/sim/items/redcard.js
+++ b/test/sim/items/redcard.js
@@ -10,7 +10,7 @@ describe('Red Card', function () {
 		battle.destroy();
 	});
 
-	it.skip(`should not trigger if the target should be KOed from Destiny Bond and also not crash the client`, function () {
+	it(`should not trigger if the target should be KOed from Destiny Bond and also not crash the client`, function () {
 		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: "Aggron", item: 'redcard', moves: ['rockslide']},
 			{species: "Wynaut", ability: 'prankster', level: 1, moves: ['destinybond']},

--- a/test/sim/items/redcard.js
+++ b/test/sim/items/redcard.js
@@ -23,4 +23,18 @@ describe('Red Card', function () {
 		battle.makeChoices();
 		assert.holdsItem(battle.p1.active[0]);
 	});
+
+	it(`should trigger if the target is still in battle`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: "Aggron", item: 'redcard', moves: ['rockslide']},
+			{species: "Wynaut", ability: 'prankster', level: 1, moves: ['sleeptalk']},
+		], [
+			{species: "Conkeldurr", moves: ['sleeptalk']},
+			{species: "Gardevoir", moves: ['strugglebug']},
+			{species: "Corsola", moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		assert.false(battle.p1.active[0].item, "red card should be used");
+	});
 });

--- a/test/sim/items/redcard.js
+++ b/test/sim/items/redcard.js
@@ -21,7 +21,8 @@ describe('Red Card', function () {
 		]]);
 
 		battle.makeChoices();
-		assert.holdsItem(battle.p1.active[0]);
+		assert.holdsItem(battle.p1.active[0], "Red Card should not be consumed");
+		assert.fainted(battle.p1.pokemon[1], "Gardevoir should faint from Aggron's Destiny Bond");
 	});
 
 	it(`should trigger if the target is still in battle`, function () {
@@ -35,6 +36,7 @@ describe('Red Card', function () {
 		]]);
 
 		battle.makeChoices();
-		assert.false(battle.p1.active[0].item, "red card should be used");
+		assert.false.holdsItem(battle.p1.active[0], "Red Card should be consumed.");
+		assert.species(battle.p2.active[1], "Corsola", "Corsola should be dragged in by Red Card");
 	});
 });


### PR DESCRIPTION
Fixed by checking the faint queue between the end of a multi-hit move and recoil damage, causing the effects of Destiny Bond to be applied before the effects of Red Card are applied. I'm not sure if evaluating the faint queue first will cause incorrect behavior (like ordering shenanigans with something like Soul Heart in doubles), but it seems to pass all the tests.

bug report: https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/page-23#post-8585749
mechanics bugs card: https://github.com/smogon/pokemon-showdown/projects/3#card-52058755