### PR TITLE
Refactor everything to use Utils.sortBy

### DIFF
--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -1,4 +1,5 @@
 import RandomGen4Teams from '../gen4/random-teams';
+import {Utils} from '../../../lib';
 import {PRNG, PRNGSeed} from '../../../sim/prng';
 
 export class RandomGen3Teams extends RandomGen4Teams {
@@ -477,7 +478,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		if (!hasMove['hiddenpower']) ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
 
 		const abilities = Object.values(species.abilities).filter(a => this.dex.abilities.get(a).gen === 3);
-		abilities.sort((a, b) => this.dex.abilities.get(b).rating - this.dex.abilities.get(a).rating);
+		Utils.sortBy(abilities, name => -this.dex.abilities.get(name).rating);
 		let ability0 = this.dex.abilities.get(abilities[0]);
 		let ability1 = this.dex.abilities.get(abilities[1]);
 		if (abilities[1]) {

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -1,4 +1,5 @@
 import RandomGen5Teams from '../gen5/random-teams';
+import {Utils} from '../../../lib';
 import {toID} from '../../../sim/dex';
 import {PRNG} from '../../../sim';
 
@@ -719,7 +720,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		}
 
 		const abilities = Object.values(species.abilities);
-		abilities.sort((a, b) => this.dex.abilities.get(b).rating - this.dex.abilities.get(a).rating);
+		Utils.sortBy(abilities, name => -this.dex.abilities.get(name).rating);
+
 		let ability0 = this.dex.abilities.get(abilities[0]);
 		let ability1 = this.dex.abilities.get(abilities[1]);
 		if (abilities[1]) {

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -1,4 +1,5 @@
 import RandomGen6Teams from '../gen6/random-teams';
+import {Utils} from '../../../lib';
 import {toID} from '../../../sim/dex';
 import {PRNG} from '../../../sim';
 
@@ -646,8 +647,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		}
 
 		const abilityNames: string[] = Object.values(species.abilities);
-		abilityNames.sort((a, b) => this.dex.abilities.get(b).rating - this.dex.abilities.get(a).rating);
-
+		Utils.sortBy(abilityNames, name => -this.dex.abilities.get(name).rating);
 
 		if (abilityNames.length > 1) {
 			const abilities = abilityNames.map(name => this.dex.abilities.get(name));

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -1,6 +1,7 @@
 import {TeamData} from '../../random-teams';
 import RandomGen7Teams from '../gen7/random-teams';
 import {PRNG, PRNGSeed} from '../../../sim/prng';
+import {Utils} from '../../../lib';
 import {toID} from '../../../sim/dex';
 
 export class RandomGen6Teams extends RandomGen7Teams {
@@ -957,7 +958,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		const battleOnly = species.battleOnly && !species.requiredAbility;
 		const baseSpecies: Species = battleOnly ? this.dex.species.get(species.battleOnly as string) : species;
 		const abilityNames: string[] = Object.values(baseSpecies.abilities);
-		abilityNames.sort((a, b) => this.dex.abilities.get(b).rating - this.dex.abilities.get(a).rating);
+		Utils.sortBy(abilityNames, name => -this.dex.abilities.get(name).rating);
 
 		if (abilityNames.length > 1) {
 			const abilities = abilityNames.map(name => this.dex.abilities.get(name));

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1179,7 +1179,7 @@ export class RandomGen7Teams extends RandomTeams {
 		const baseSpecies: Species = battleOnly ? this.dex.species.get(species.battleOnly as string) : species;
 
 		const abilityNames: string[] = Object.values(baseSpecies.abilities);
-		abilityNames.sort((a, b) => this.dex.abilities.get(b).rating - this.dex.abilities.get(a).rating);
+		Utils.sortBy(abilityNames, name => -this.dex.abilities.get(name).rating);
 
 		const abilities = abilityNames.map(name => this.dex.abilities.get(name));
 		if (abilityNames[1]) {

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1,4 +1,5 @@
 import {Dex, toID} from '../sim/dex';
+import {Utils} from '../lib';
 import {PRNG, PRNGSeed} from '../sim/prng';
 
 export interface TeamData {
@@ -1790,7 +1791,7 @@ export class RandomTeams {
 		} while (moves.length < 4 && (movePool.length || rejectedPool.length));
 
 		const abilityNames: string[] = Object.values(species.abilities);
-		abilityNames.sort((a, b) => this.dex.abilities.get(b).rating - this.dex.abilities.get(a).rating);
+		Utils.sortBy(abilityNames, name => -this.dex.abilities.get(name).rating);
 
 		const abilities = abilityNames.map(name => this.dex.abilities.get(name));
 		if (abilityNames[1]) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -172,13 +172,16 @@ export function compare(a: Comparable, b: Comparable): number {
 /**
  * Sorts an array according to the callback's output on its elements.
  *
- * The callback's output is compared according to `PSUtils.compare` (in
- * particular, it supports arrays so you can sort by multiple things).
+ * The callback's output is compared according to `PSUtils.compare`
+ * (numbers low to high, strings A-Z, booleans true-first, arrays in order).
  */
 export function sortBy<T>(array: T[], callback: (a: T) => Comparable): T[];
 /**
-* Sorts an array according to `PSUtils.compare`. (Correctly sorts numbers,
- * unlike `array.sort`)
+ * Sorts an array according to `PSUtils.compare`
+ * (numbers low to high, strings A-Z, booleans true-first, arrays in order).
+ *
+ * Note that array.sort() only works on strings, not numbers, so you'll need
+ * this to sort numbers.
  */
 export function sortBy<T extends Comparable>(array: T[]): T[];
 export function sortBy<T>(array: T[], callback?: (a: T) => Comparable) {

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -841,8 +841,9 @@ export const commands: ChatCommands = {
 		await FS('data/learnsets.js').write(`'use strict';\n\nexports.Learnsets = {\n` +
 			Object.entries(Dex.data.Learnsets).map(([id, entry]) => (
 				`\t${id}: {learnset: {\n` +
-				Object.entries(Dex.species.getLearnsetData(id as ID)).sort(
-					(a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0)
+				Utils.sortBy(
+					Object.entries(Dex.species.getLearnsetData(id as ID)),
+					([moveid]) => moveid
 				).map(([moveid, sources]) => (
 					`\t\t${moveid}: ["` + sources.join(`", "`) + `"],\n`
 				)).join('') +

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2743,11 +2743,12 @@ export const pages: PageTable = {
 		if (!room.persist) return;
 		this.checkCan('mute', null, room);
 		// Ascending order
-		const sortedPunishments = Array.from(Punishments.getPunishments(room.roomid))
-			.sort((a, b) => a[1].expireTime - b[1].expireTime);
+		const sortedPunishments = Utils.sortBy([...Punishments.getPunishments(room.roomid)], ([id, entry]) => (
+			entry.expireTime
+		));
 		const sP = new Map();
-		for (const punishment of sortedPunishments) {
-			sP.set(punishment[0], punishment[1]);
+		for (const [id, entry] of sortedPunishments) {
+			sP.set(id, entry);
 		}
 		buf += Punishments.visualizePunishments(sP, user);
 		return buf;
@@ -2758,7 +2759,9 @@ export const pages: PageTable = {
 		if (!user.named) return Rooms.RETRY_AFTER_LOGIN;
 		this.checkCan('lock');
 		// Ascending order
-		const sortedPunishments = Array.from(Punishments.getPunishments()).sort((a, b) => a[1].expireTime - b[1].expireTime);
+		const sortedPunishments = Utils.sortBy([...Punishments.getPunishments()], ([id, entry]) => (
+			entry.expireTime
+		));
 		const sP = new Map();
 		for (const punishment of sortedPunishments) {
 			sP.set(punishment[0], punishment[1]);

--- a/server/chat-plugins/battlesearch.ts
+++ b/server/chat-plugins/battlesearch.ts
@@ -261,12 +261,10 @@ export const pages: PageTable = {
 		}
 		buf += `</p>`;
 
-		const months = (await FS('logs/').readdir()).filter(f => f.length === 7 && f.includes('-')).sort((aKey, bKey) => {
-			const a = aKey.split('-').map(n => parseInt(n));
-			const b = bKey.split('-').map(n => parseInt(n));
-			if (a[0] !== b[0]) return b[0] - a[0];
-			return b[1] - a[1];
-		});
+		const months = Utils.sortBy(
+			(await FS('logs/').readdir()).filter(f => f.length === 7 && f.includes('-')),
+			name => ({reverse: name})
+		);
 		if (!month) {
 			buf += `<p>Please select a month:</p><ul style="list-style: none; display: block; padding: 0">`;
 			for (const i of months) {
@@ -281,20 +279,12 @@ export const pages: PageTable = {
 		}
 
 		const tierid = toID(formatid);
-		const tiers = (await FS(`logs/${month}/`).readdir()).sort((a, b) => {
+		const tiers = Utils.sortBy(await FS(`logs/${month}/`).readdir(), tier => [
 			// First sort by gen with the latest being first
-			let aGen = 6;
-			let bGen = 6;
-			if (a.startsWith('gen')) aGen = parseInt(a.substring(3, 4));
-			if (b.startsWith('gen')) bGen = parseInt(b.substring(3, 4));
-			if (aGen !== bGen) return bGen - aGen;
-			// Sort alphabetically
-			const aTier = a.substring(4);
-			const bTier = b.substring(4);
-			if (aTier < bTier) return -1;
-			if (aTier > bTier) return 1;
-			return 0;
-		}).map(tier => {
+			tier.startsWith('gen') ? -parseInt(tier.charAt(3)) : -6,
+			// Then sort alphabetically
+			tier,
+		]).map(tier => {
 			// Use the official tier name
 			const format = Dex.formats.get(tier);
 			if (format?.exists) tier = format.name;

--- a/server/chat-plugins/chatlog.ts
+++ b/server/chat-plugins/chatlog.ts
@@ -562,9 +562,7 @@ export abstract class Searcher {
 			}
 			buf += `<br />Total linecount: ${total}<hr />`;
 			buf += '<ol>';
-			const sortedDays = Object.keys(results).sort((a, b) => (
-				new Date(b).getTime() - new Date(a).getTime()
-			));
+			const sortedDays = Utils.sortBy(Object.keys(results), day => ({reverse: day}));
 			for (const day of sortedDays) {
 				const dayResults = results[day][user];
 				if (isNaN(dayResults)) continue;
@@ -582,8 +580,8 @@ export abstract class Searcher {
 				}
 			}
 			const resultKeys = Object.keys(totalResults);
-			const sortedResults = resultKeys.sort((a, b) => (
-				totalResults[b] - totalResults[a]
+			const sortedResults = Utils.sortBy(resultKeys, userid => (
+				-totalResults[userid]
 			)).slice(0, MAX_TOPUSERS);
 			for (const userid of sortedResults) {
 				buf += `<li><span class="username"><username>${userid}</username></span>: `;
@@ -944,13 +942,9 @@ export class RipgrepLogSearcher extends Searcher {
 		if (limit > MAX_RESULTS) limit = MAX_RESULTS;
 		const useOriginal = originalSearch && originalSearch !== search;
 		const searchRegex = new RegExp(useOriginal ? search : this.constructSearchRegex(search), "i");
-		const sorted = results.sort((aLine, bLine) => {
-			const [aName] = aLine.split('.txt');
-			const [bName] = bLine.split('.txt');
-			const aDate = new Date(aName.split('/').pop()!);
-			const bDate = new Date(bName.split('/').pop()!);
-			return bDate.getTime() - aDate.getTime();
-		}).map(chunk => chunk.split('\n').map(rawLine => {
+		const sorted = Utils.sortBy(results, line => (
+			{reverse: line.split('.txt')[0].split('/').pop()!}
+		)).map(chunk => chunk.split('\n').map(rawLine => {
 			if (exactMatches > limit || !toID(rawLine)) return null; // return early so we don't keep sorting
 			const sep = rawLine.includes('.txt-') ? '.txt-' : '.txt:';
 			const [name, text] = rawLine.split(sep);

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -952,9 +952,9 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 	// Prioritize searches with the least alternatives.
 	const accumulateKeyCount = (count: number, searchData: AnyObject) =>
 		count + (typeof searchData === 'object' ? Object.keys(searchData).length : 0);
-	searches.sort(
-		(a, b) => Object.values(a).reduce(accumulateKeyCount, 0) - Object.values(b).reduce(accumulateKeyCount, 0)
-	);
+	Utils.sortBy(searches, search => (
+		Object.values(search).reduce(accumulateKeyCount, 0)
+	));
 
 	for (const alts of searches) {
 		if (alts.skip) continue;
@@ -1164,30 +1164,21 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		if (sort) {
 			const stat = sort.slice(0, -1);
 			const direction = sort.slice(-1);
-			results.sort((a, b) => {
-				const mon1 = mod.species.get(a);
-				const mon2 = mod.species.get(b);
-				let monStat1 = 0;
-				let monStat2 = 0;
+			Utils.sortBy(results, name => {
+				const mon = mod.species.get(name);
+				let monStat = 0;
 				if (stat === 'bst') {
-					for (const monStats in mon1.baseStats) {
-						monStat1 += mon1.baseStats[monStats as StatID];
-						monStat2 += mon2.baseStats[monStats as StatID];
-					}
+					monStat = mon.bst;
 				} else if (stat === 'weight') {
-					monStat1 = mon1.weighthg;
-					monStat2 = mon2.weighthg;
+					monStat = mon.weighthg;
 				} else if (stat === 'height') {
-					monStat1 = mon1.heightm;
-					monStat2 = mon2.heightm;
+					monStat = mon.heightm;
 				} else if (stat === 'gen') {
-					monStat1 = mon1.gen;
-					monStat2 = mon2.gen;
+					monStat = mon.gen;
 				} else {
-					monStat1 = mon1.baseStats[stat as StatID];
-					monStat2 = mon2.baseStats[stat as StatID];
+					monStat = mon.baseStats[stat as StatID];
 				}
-				return (monStat1 - monStat2) * (direction === '+' ? 1 : -1);
+				return monStat * (direction === '+' ? 1 : -1);
 			});
 		}
 		let notShown = 0;
@@ -1908,13 +1899,11 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 		if (sort) {
 			const prop = sort.slice(0, -1);
 			const direction = sort.slice(-1);
-			results.sort((a, b) => {
-				let move1prop = dex[toID(a)][prop as keyof Move] as number;
-				let move2prop = dex[toID(b)][prop as keyof Move] as number;
+			Utils.sortBy(results, moveName => {
+				let moveProp = dex[toID(moveName)][prop as keyof Move] as number;
 				// convert booleans to 0 or 1
-				if (typeof move1prop === 'boolean') move1prop = move1prop ? 1 : 0;
-				if (typeof move2prop === 'boolean') move2prop = move2prop ? 1 : 0;
-				return (move1prop - move2prop) * (direction === '+' ? 1 : -1);
+				if (typeof moveProp === 'boolean') moveProp = moveProp ? 1 : 0;
+				return moveProp * (direction === '+' ? 1 : -1);
 			});
 		}
 		let notShown = 0;

--- a/server/chat-plugins/hosts.ts
+++ b/server/chat-plugins/hosts.ts
@@ -39,13 +39,6 @@ function formatRange(range: AddressRange, includeModlogBrackets?: boolean) {
 	return result;
 }
 
-// ipSort doesn't work on .* ranges, so we can just convert it to range
-// and make the min ip a string to check
-function makeRangeSortable(rangeString: string) {
-	if (!IPTools.ipRangeRegex.test(rangeString)) return rangeString;
-	return IPTools.numberToIP(IPTools.stringToRange(rangeString)!.minIP);
-}
-
 export const pages: PageTable = {
 	proxies(query, user) {
 		this.title = "[Proxies]";
@@ -53,7 +46,7 @@ export const pages: PageTable = {
 
 		const openProxies = [...IPTools.singleIPOpenProxies];
 		const proxyHosts = [...IPTools.proxyHosts];
-		openProxies.sort(IPTools.ipSort);
+		Utils.sortBy(openProxies, IPTools.ipToNumber);
 		proxyHosts.sort();
 		IPTools.sortRanges();
 
@@ -142,12 +135,11 @@ export const pages: PageTable = {
 		} else {
 			buf += `<div class="ladder"><table><tr><th>IP</th><th>Reason</th></tr>`;
 			const sortedSharedIPBlacklist = [...Punishments.sharedIpBlacklist];
-			sortedSharedIPBlacklist.sort(([a], [b]) => {
-				if ([a, b].every(ip => IPTools.ipRegex.test(ip))) {
-					return IPTools.ipSort(a, b);
-				}
-				return IPTools.ipSort(makeRangeSortable(a), makeRangeSortable(b));
-			});
+			Utils.sortBy(sortedSharedIPBlacklist, ([ipOrRange]) => (
+				IPTools.ipRegex.test(ipOrRange) ?
+					IPTools.ipToNumber(ipOrRange) :
+					IPTools.stringToRange(ipOrRange)!.minIP
+			));
 			for (const [ip, reason] of sortedSharedIPBlacklist) {
 				buf += `<tr><td>${ip}</td><td>${reason}</td></tr>`;
 			}
@@ -167,7 +159,7 @@ export const pages: PageTable = {
 		} else {
 			buf += `<div class="ladder"><table><tr><th>IP</th><th>Location</th></tr>`;
 			const sortedSharedIPs = [...Punishments.sharedIps];
-			sortedSharedIPs.sort((a, b) => IPTools.ipSort(a[0], b[0]));
+			Utils.sortBy(sortedSharedIPs, ([ip]) => IPTools.ipToNumber(ip));
 
 			for (const [ip, location] of sortedSharedIPs) {
 				buf += `<tr><td>${ip}</td><td>${location}</td></tr>`;

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -153,17 +153,9 @@ for (const section of tables) {
 	if (!logs[section][month]) logs[section][month] = {};
 	if (Object.keys(logs[section]).length >= 3) {
 		// eliminate the oldest month(s)
-		const keys = Object.keys(logs[section]).sort((aKey, bKey) => {
-			const a = aKey.split('/');
-			const b = bKey.split('/');
-			if (a[1] !== b[1]) {
-				// year
-				if (parseInt(a[1]) < parseInt(b[1])) return -1;
-				return 1;
-			}
-			// month
-			if (parseInt(a[0]) < parseInt(b[0])) return -1;
-			return 1;
+		const keys = Utils.sortBy(Object.keys(logs[section]), key => {
+			const [monthStr, yearStr] = key.split('/');
+			return [parseInt(yearStr), parseInt(monthStr)];
 		});
 		while (keys.length > 2) {
 			const curKey = keys.shift();
@@ -439,7 +431,7 @@ class Mafia extends Rooms.RoomGame {
 				image: '',
 				memo: [`To learn more about your role, PM the host (${this.host}).`],
 			}));
-			this.originalRoles.sort((a, b) => a.name.localeCompare(b.name));
+			Utils.sortBy(this.originalRoles, role => role.name);
 			this.roles = this.originalRoles.slice();
 			this.originalRoleString = this.originalRoles.map(
 				r => `<span style="font-weight:bold;color:${MafiaData.alignments[r.alignment].color || '#FFF'}">${r.safeName}</span>`
@@ -481,7 +473,7 @@ class Mafia extends Rooms.RoomGame {
 		this.IDEA.data = null;
 
 		this.originalRoles = newRoles;
-		this.originalRoles.sort((a, b) => a.alignment.localeCompare(b.alignment) || a.name.localeCompare(b.name));
+		Utils.sortBy(this.originalRoles, role => [role.alignment, role.name]);
 		this.roles = this.originalRoles.slice();
 		this.originalRoleString = this.originalRoles.map(
 			r => `<span style="font-weight:bold;color:${MafiaData.alignments[r.alignment].color || '#FFF'}">${r.safeName}</span>`
@@ -802,13 +794,12 @@ class Mafia extends Rooms.RoomGame {
 		if (!this.started) return `<strong>The game has not started yet.</strong>`;
 		let buf = `<strong>Votes (Hammer: ${this.hammerCount || "Disabled"})</strong><br />`;
 		const plur = this.getPlurality();
-		const list = Object.keys(this.lynches).sort((a, b) => {
-			if (a === plur) return -1;
-			if (b === plur) return 1;
-			return this.lynches[b].count - this.lynches[a].count;
-		});
-		for (const key of list) {
-			buf += `${this.lynches[key].count}${plur === key ? '*' : ''} ${this.playerTable[key] ? this.playerTable[key].safeName : 'No Vote'} (${this.lynches[key].lynchers.map(a => this.playerTable[a] ? this.playerTable[a].safeName : a).join(', ')})<br />`;
+		const list = Utils.sortBy(Object.entries(this.lynches), ([key, lynch]) => [
+			key === plur,
+			-lynch.count,
+		]);
+		for (const [key, lynch] of list) {
+			buf += `${lynch.count}${plur === key ? '*' : ''} ${this.playerTable[key]?.safeName || 'No Vote'} (${lynch.lynchers.map(a => this.playerTable[a]?.safeName || a).join(', ')})<br />`;
 		}
 		return buf;
 	}
@@ -948,30 +939,24 @@ class Mafia extends Rooms.RoomGame {
 		if (this.hasPlurality) return this.hasPlurality;
 		if (!Object.keys(this.lynches).length) return null;
 		let max = 0;
-		let topLynches: ID[] = [];
-		for (const key in this.lynches) {
-			if (this.lynches[key].count > max) {
-				max = this.lynches[key].count;
-				topLynches = [key as ID];
-			} else if (this.lynches[key].count === max) {
-				topLynches.push(key as ID);
+		let topLynches: [ID, MafiaLynch][] = [];
+		for (const [key, lynch] of Object.entries(this.lynches)) {
+			if (lynch.count > max) {
+				max = lynch.count;
+				topLynches = [[key as ID, lynch]];
+			} else if (lynch.count === max) {
+				topLynches.push([key as ID, lynch]);
 			}
 		}
 		if (topLynches.length <= 1) {
-			this.hasPlurality = topLynches[0];
+			[this.hasPlurality] = topLynches[0];
 			return this.hasPlurality;
 		}
-		topLynches = topLynches.sort((key1, key2) => {
-			const l1 = this.lynches[key1];
-			const l2 = this.lynches[key2];
-			if (l1.dir !== l2.dir) {
-				return (l1.dir === 'down' ? -1 : 1);
-			} else {
-				if (l1.dir === 'up') return (l1.lastLynch < l2.lastLynch ? -1 : 1);
-				return (l1.lastLynch > l2.lastLynch ? -1 : 1);
-			}
-		});
-		this.hasPlurality = topLynches[0];
+		topLynches = Utils.sortBy(topLynches, ([key, lynch]) => [
+			lynch.dir === 'down',
+			lynch.dir === 'up' ? lynch.lastLynch : -lynch.lastLynch,
+		]);
+		[this.hasPlurality] = topLynches[0];
 		return this.hasPlurality;
 	}
 
@@ -1082,7 +1067,7 @@ class Mafia extends Rooms.RoomGame {
 				};
 				this.roles.push(deadPlayer.role);
 			}
-			this.roles.sort((a, b) => a.alignment.localeCompare(b.alignment) || a.name.localeCompare(b.name));
+			Utils.sortBy(this.roles, r => [r.alignment, r.name]);
 			delete this.dead[deadPlayer.id];
 		} else {
 			const targetUser = Users.get(toRevive);
@@ -1978,15 +1963,13 @@ export const pages: PageTable = {
 			buf += `${ladder.title} for ${date.toLocaleString("en-us", {month: 'long'})} ${date.getFullYear()} not found.</div>`;
 			return buf;
 		}
-		const keys = Object.keys(logs[section][month]).sort((keyA, keyB) => {
-			const a = logs[section][month][keyA];
-			const b = logs[section][month][keyB];
-			return b - a;
-		});
+		const entries = Utils.sortBy(Object.entries(logs[section][month]), ([key, value]) => (
+			-value
+		));
 		buf += `<table style="margin-left: auto; margin-right: auto"><tbody><tr><th colspan="2"><h2 style="margin: 5px auto">Mafia ${ladder.title} for ${date.toLocaleString("en-us", {month: 'long'})} ${date.getFullYear()}</h1></th></tr>`;
 		buf += `<tr><th>User</th><th>${ladder.type}</th></tr>`;
-		for (const key of keys) {
-			buf += `<tr><td>${key}</td><td>${logs[section][month][key]}</td></tr>`;
+		for (const [key, value] of entries) {
+			buf += `<tr><td>${key}</td><td>${value}</td></tr>`;
 		}
 		return buf + `</table></div>`;
 	},
@@ -2907,11 +2890,9 @@ export const commands: ChatCommands = {
 				return this.sendReplyBox(buf);
 			}
 			const showOrl = (['orl', 'originalrolelist'].includes(cmd) || game.noReveal);
-			const roleString = (showOrl ? game.originalRoles : game.roles).sort((a, b) => {
-				if (a.alignment < b.alignment) return -1;
-				if (b.alignment < a.alignment) return 1;
-				return 0;
-			}).map(role => role.safeName).join(', ');
+			const roleString = Utils.sortBy((showOrl ? game.originalRoles : game.roles), role => (
+				role.alignment
+			)).map(role => role.safeName).join(', ');
 
 			this.sendReplyBox(`${showOrl ? `Original Rolelist: ` : `Rolelist: `}${roleString}`);
 		},

--- a/server/chat-plugins/room-events.ts
+++ b/server/chat-plugins/room-events.ts
@@ -546,7 +546,7 @@ export const commands: ChatCommands = {
 				);
 				break;
 			default:
-				return this.errorReply("No or invalid column name specified. Please use one of: date, eventdate, desc, description, eventdescription, eventname, name.");
+				return this.errorReply(`Invalid column name "${columnName}". Please use one of: date, desc, name.`);
 			}
 
 			// rebuild the room.settings.events object
@@ -557,9 +557,9 @@ export const commands: ChatCommands = {
 			}
 
 			// build communication string
-			const resultString = `sorted by column:` + columnName +
-								 ` in ${multiplier === 1 ? "ascending" : "descending"} order` +
-								 `${delimited.length === 1 ? " (by default)" : ""}`;
+			const resultString = `sorted by column: ${columnName}` +
+				` in ${multiplier === 1 ? "ascending" : "descending"} order` +
+				`${delimited.length === 1 ? " (by default)" : ""}`;
 			this.modlog('ROOMEVENT', null, resultString);
 			return this.sendReply(resultString);
 		},

--- a/server/chat-plugins/room-faqs.ts
+++ b/server/chat-plugins/room-faqs.ts
@@ -146,7 +146,7 @@ export const pages: PageTable = {
 
 		buf += `<h2>FAQs for ${room.title}:</h2>`;
 		const keys = Object.keys(roomFaqs[room.roomid]);
-		const sortedKeys = keys.filter(val => !getAlias(room.roomid, val)).sort((a, b) => a.localeCompare(b));
+		const sortedKeys = Utils.sortBy(keys.filter(val => !getAlias(room.roomid, val)));
 		for (const key of sortedKeys) {
 			const topic = roomFaqs[room.roomid][key];
 			buf += `<div class="infobox">`;

--- a/server/chat-plugins/scavenger-games.ts
+++ b/server/chat-plugins/scavenger-games.ts
@@ -446,7 +446,7 @@ const MODES: {[k: string]: GameMode | string} = {
 			onLoad() {
 				const game = this.room.scavgame!;
 				if (game.round === 0) return;
-				const maxTime = (game.jumpstart as number[]).sort((a, b) => b - a)[0];
+				const maxTime = Math.max(...game.jumpstart);
 
 				this.jumpstartTimers = [];
 				this.answerLock = true;

--- a/server/chat-plugins/scavenger-games.ts
+++ b/server/chat-plugins/scavenger-games.ts
@@ -33,7 +33,7 @@ interface GameMode {
 }
 
 class Leaderboard {
-	data: AnyObject;
+	data: {[userid: string]: AnyObject};
 
 	constructor() {
 		this.data = {};
@@ -53,26 +53,28 @@ class Leaderboard {
 		return this; // allow chaining
 	}
 
+	visualize(sortBy: string): Promise<({rank: number} & AnyObject)[]>;
+	visualize(sortBy: string, userid: string): Promise<({rank: number} & AnyObject) | undefined>;
 	visualize(sortBy: string, userid?: string) {
+		// FIXME: this is not how promises work
 		// return a promise for async sorting - make this less exploitable
 		return new Promise((resolve, reject) => {
 			let lowestScore = Infinity;
 			let lastPlacement = 1;
 
-			const ladder = Object.keys(this.data)
-				.filter(k => sortBy in this.data[k])
-				.sort((a, b) => this.data[b][sortBy] - this.data[a][sortBy])
-				.map((u, i) => {
-					const bit = this.data[u];
-					if (bit[sortBy] !== lowestScore) {
-						lowestScore = bit[sortBy];
-						lastPlacement = i + 1;
-					}
-					return {
-						rank: lastPlacement,
-						...bit,
-					};
-				}); // identify ties
+			const ladder = Utils.sortBy(
+				Object.entries(this.data).filter(([u, bit]) => sortBy in bit),
+				([u, bit]) => -bit[sortBy]
+			).map(([u, bit], i) => {
+				if (bit[sortBy] !== lowestScore) {
+					lowestScore = bit[sortBy];
+					lastPlacement = i + 1;
+				}
+				return {
+					rank: lastPlacement,
+					...bit,
+				} as {rank: number} & AnyObject;
+			}); // identify ties
 			if (userid) {
 				const rank = ladder.find(entry => toID(entry.name) === userid);
 				resolve(rank);
@@ -83,7 +85,7 @@ class Leaderboard {
 	}
 
 	async htmlLadder(): Promise<string> {
-		const data = await this.visualize('points') as AnyObject[];
+		const data = await this.visualize('points');
 		const display = `<div class="ladder" style="overflow-y: scroll; max-height: 170px;"><table style="width: 100%"><tr><th>Rank</th><th>Name</th><th>Points</th></tr>${data.map(line =>
 			`<tr><td>${line.rank}</td><td>${line.name}</td><td>${line.points}</td></tr>`).join('')
 		}</table></div>`;

--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -65,7 +65,7 @@ function getScavsRoom(room?: Room) {
 
 class Ladder {
 	file: string;
-	data: AnyObject;
+	data: {[userid: string]: AnyObject};
 	constructor(file: string) {
 		this.file = file;
 		this.data = {};
@@ -101,26 +101,27 @@ class Ladder {
 		FS(this.file).writeUpdate(() => JSON.stringify(this.data));
 	}
 
+	visualize(sortBy: string): Promise<({rank: number} & AnyObject)[]>;
+	visualize(sortBy: string, userid: ID): Promise<({rank: number} & AnyObject) | undefined>;
 	visualize(sortBy: string, userid?: ID) {
 		// return a promise for async sorting - make this less exploitable
 		return new Promise((resolve, reject) => {
 			let lowestScore = Infinity;
 			let lastPlacement = 1;
 
-			const ladder: AnyObject[] = Object.keys(this.data)
-				.filter(k => this.data[k][sortBy])
-				.sort((a, b) => this.data[b][sortBy] - this.data[a][sortBy])
-				.map((u, i) => {
-					const chunk = this.data[u];
-					if (chunk[sortBy] !== lowestScore) {
-						lowestScore = chunk[sortBy];
-						lastPlacement = i + 1;
-					}
-					return {
-						rank: lastPlacement,
-						...chunk,
-					};
-				}); // identify ties
+			const ladder = Utils.sortBy(
+				Object.entries(this.data).filter(([u, bit]) => sortBy in bit),
+				([u, bit]) => -bit[sortBy]
+			).map(([u, chunk], i) => {
+				if (chunk[sortBy] !== lowestScore) {
+					lowestScore = chunk[sortBy];
+					lastPlacement = i + 1;
+				}
+				return {
+					rank: lastPlacement,
+					...chunk,
+				} as {rank: number} & AnyObject;
+			}); // identify ties
 			if (userid) {
 				const rank = ladder.find(entry => toID(entry.name) === userid);
 				resolve(rank);
@@ -525,18 +526,16 @@ export class ScavengerHunt extends Rooms.RoomGame {
 
 	// returns whether or not the next action should be stopped
 	runEvent(event_id: string, ...args: any[]) {
-		let events = this.mods['on' + event_id];
+		const events = this.mods['on' + event_id];
 		if (!events) return;
 
-		events = events.sort((a, b) => b.priority - a.priority);
+		Utils.sortBy(events, event => -event.priority);
 		let result = undefined;
 
-		if (events) {
-			for (const event of events) {
-				const subResult = event.exec.call(this, ...args) as any;
-				if (subResult === true) return true;
-				result = subResult;
-			}
+		for (const event of events) {
+			const subResult = event.exec.call(this, ...args) as any;
+			if (subResult === true) return true;
+			result = subResult;
 		}
 
 		return result === false ? true : result;

--- a/server/chat-plugins/uno.ts
+++ b/server/chat-plugins/uno.ts
@@ -599,8 +599,8 @@ class UNOPlayer extends Rooms.RoomGamePlayer {
 	}
 
 	buildHand() {
-		return this.hand.sort((a, b) => a.color.localeCompare(b.color) || a.value.localeCompare(b.value))
-			.map((c, i) => cardHTML(c, i === this.hand.length - 1));
+		return Utils.sortBy(this.hand, card => [card.color, card.value])
+			.map((card, i) => cardHTML(card, i === this.hand.length - 1));
 	}
 
 	sendDisplay() {

--- a/server/chat-plugins/youtube.ts
+++ b/server/chat-plugins/youtube.ts
@@ -339,7 +339,7 @@ export const Twitch = new class {
 			throw new Chat.ErrorMessage(`Error retrieving twitch channel: ${e.message}`);
 		}
 		const data = JSON.parse(res);
-		(data.channels as AnyObject[]).sort((a, b) => b.followers - a.followers);
+		Utils.sortBy(data.channels as AnyObject[], c => -c.followers);
 		return data?.channels?.[0] as TwitchChannel | undefined;
 	}
 	visualizeChannel(info: TwitchChannel) {

--- a/server/ip-tools.ts
+++ b/server/ip-tools.ts
@@ -19,7 +19,7 @@ const HOSTS_FILE = 'config/hosts.csv';
 const PROXIES_FILE = 'config/proxies.csv';
 
 import * as dns from 'dns';
-import {FS, Net} from '../lib';
+import {FS, Net, Utils} from '../lib';
 
 export interface AddressRange {
 	minIP: number;
@@ -171,25 +171,9 @@ export const IPTools = new class {
 		return {minIP, maxIP};
 	}
 
-	ipSort(a: string, b: string) {
-		let i = 0;
-		let diff = 0;
-		const aParts = a.split('.');
-		const bParts = b.split('.');
-		while (diff === 0) {
-			const aPart = parseInt(aParts[i]);
-			const bPart = parseInt(bParts[i]);
-			if (isNaN(aPart) || isNaN(bPart)) throw new Error("Invalid IP passed to IPTools.ipSort.");
-			diff = aPart - bPart;
-			i++;
-		}
-		return diff;
-	}
-
 	/******************************
 	 * Range management functions *
 	 ******************************/
-
 
 	checkPattern(patterns: AddressRange[], num: number) {
 		for (const pattern of patterns) {
@@ -424,9 +408,8 @@ export const IPTools = new class {
 	}
 
 	sortRanges() {
-		IPTools.ranges.sort((a, b) => a.minIP - b.minIP);
+		Utils.sortBy(IPTools.ranges, range => range.minIP);
 	}
-
 
 	getRange(minIP: number, maxIP: number) {
 		for (const range of IPTools.ranges) {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1290,7 +1290,7 @@ export class GlobalRoomState {
 		if (Config.rankList) {
 			return Config.rankList;
 		}
-		let rankList = [];
+		const rankList = [];
 
 		for (const rank in Config.groups) {
 			if (!Config.groups[rank] || !rank) continue;
@@ -1307,7 +1307,7 @@ export class GlobalRoomState {
 
 		const typeOrder = ['punishment', 'normal', 'staff', 'leadership'];
 
-		rankList = rankList.sort((a, b) => typeOrder.indexOf(b.type) - typeOrder.indexOf(a.type));
+		Utils.sortBy(rankList, rank => -typeOrder.indexOf(rank.type));
 
 		// add the punishment types at the very end.
 		for (const rank in Config.punishgroups) {

--- a/server/tournaments/generator-round-robin.ts
+++ b/server/tournaments/generator-round-robin.ts
@@ -4,6 +4,7 @@ interface Match {
 	result?: string;
 }
 
+import {Utils} from '../../lib/utils';
 import type {TournamentPlayer} from './index';
 
 export class RoundRobin {
@@ -172,9 +173,7 @@ export class RoundRobin {
 	getResults() {
 		if (!this.isTournamentEnded()) return 'TournamentNotEnded';
 
-		const sortedScores = this.players.slice().sort(
-			(p1, p2) => p2.score - p1.score
-		);
+		const sortedScores = Utils.sortBy([...this.players], p => -p.score);
 
 		const results: TournamentPlayer[][] = [];
 		let currentScore = sortedScores[0].score;

--- a/test/server/ip-tools.js
+++ b/test/server/ip-tools.js
@@ -7,6 +7,7 @@
 
 const assert = require('assert').strict;
 const IPTools = require('../../.server-dist/ip-tools').IPTools;
+const Utils = require('../../.lib-dist/utils').Utils;
 
 describe("IP tools", () => {
 	it('should resolve 127.0.0.1 to localhost', async () => {
@@ -84,7 +85,7 @@ describe("IP tools helper functions", () => {
 		const unsortedIPs = ['2.3.4.5', '100.1.1.1', '2.3.5.4', '150.255.255.255', '240.0.0.0'];
 		const sortedIPs = ['2.3.4.5', '2.3.5.4', '100.1.1.1', '150.255.255.255', '240.0.0.0'];
 		const sortedIPNumbers = unsortedIPs.map(ip => IPTools.ipToNumber(ip));
-		sortedIPNumbers.sort((a, b) => a - b);
+		Utils.sortBy(sortedIPNumbers);
 		assert.deepEqual(sortedIPNumbers.map(ipnum => IPTools.numberToIP(ipnum)), sortedIPs);
 	});
 
@@ -96,7 +97,7 @@ describe("IP tools helper functions", () => {
 
 	it('should correctly sort a list of IP addresses', () => {
 		const ipList = ['2.3.4.5', '100.1.1.1', '2.3.5.4', '150.255.255.255', '240.0.0.0'];
-		ipList.sort(IPTools.ipSort);
+		Utils.sortBy(ipList, IPTools.ipToNumber);
 		assert.deepEqual(ipList, ['2.3.4.5', '2.3.5.4', '100.1.1.1', '150.255.255.255', '240.0.0.0']);
 	});
 });


### PR DESCRIPTION
A few uses of `array.sort()` have been left alone:

- `array.sort((a, b) => b - a)[0]` to get the max of an array (this can be refactored to `Math.max(...array)` but would crash on large arrays - thanks, JavaScript)

- sorting in `data/` because they aren't supposed to import anything

- `set-importer` because I still have no clue what that's for and what dependencies it is/isn't allowed to have

- `sort()` with no arguments used as a lexical sort (at which point `sortBy` offers no benefits)

All other cases have been replaced with `Utils.sortBy`, which should be a massive increase in readability.

Sort orders should be much more readable now, without needing to puzzle through sign issues. The order is always low-to-high, A-to-Z, true-to-false.