### PR TITLE
Grassy terrain only weakens moves against grounded targets

### DIFF
--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -283,7 +283,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 			onBasePower(basePower, attacker, defender, move) {
 				const weakenedMoves = ['earthquake', 'bulldoze', 'magnitude'];
-				if (weakenedMoves.includes(move.id)) {
+				if (weakenedMoves.includes(move.id) && defender.isGrounded() && !defender.isSemiInvulnerable()) {
 					this.debug('move weakened by grassy terrain');
 					return this.chainModify(0.5);
 				}

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -7169,7 +7169,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onBasePowerPriority: 6,
 			onBasePower(basePower, attacker, defender, move) {
 				const weakenedMoves = ['earthquake', 'bulldoze', 'magnitude'];
-				if (weakenedMoves.includes(move.id)) {
+				if (weakenedMoves.includes(move.id) && defender.isGrounded() && !defender.isSemiInvulnerable()) {
 					this.debug('move weakened by grassy terrain');
 					return this.chainModify(0.5);
 				}

--- a/test/sim/moves/grassyterrain.js
+++ b/test/sim/moves/grassyterrain.js
@@ -24,7 +24,7 @@ describe('Grassy Terrain', function () {
 		assert(battle.field.isTerrain(''));
 	});
 
-	it.skip(`should halve the base power of Earthquake, Bulldoze, and Magnitude against grounded targets`, function () {
+	it(`should halve the base power of Earthquake, Bulldoze, and Magnitude against grounded targets`, function () {
 		battle = common.createBattle([[
 			{species: 'Shaymin', moves: ['grassyterrain']},
 		], [


### PR DESCRIPTION
It also doesn't weaken moves against semi-invulnerable targets, which means that users of Dig take regular doubled damage from Earthquake.