### PR TITLE
[Gen 8] Pokebilities: Block unsafe pseudo-abilities when run under a different mod

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -646,6 +646,8 @@ export const Formats: FormatList = [
 			'Diglett-Base', 'Dugtrio-Base', 'Gothita', 'Gothitelle', 'Gothorita', 'Trapinch', 'Wobbuffet', 'Wynaut',
 		],
 		onBegin() {
+			const isNativeMod = this.dex.currentMod === 'pokebilities';
+			const nonNativeUnsafeAbilities = ['trace', 'mirrorarmor'];
 			for (const pokemon of this.getAllPokemon()) {
 				if (pokemon.ability === this.toID(pokemon.species.abilities['S'])) {
 					continue;
@@ -653,7 +655,8 @@ export const Formats: FormatList = [
 				pokemon.m.innates = Object.keys(pokemon.species.abilities)
 					.filter(key => key !== 'S' && (key !== 'H' || !pokemon.species.unreleasedHidden))
 					.map(key => this.toID(pokemon.species.abilities[key as "0" | "1" | "H" | "S"]))
-					.filter(ability => ability !== pokemon.ability);
+					.filter(ability => (ability !== pokemon.ability) &&
+						(isNativeMod || !nonNativeUnsafeAbilities.includes(ability)));
 			}
 		},
 		onSwitchInPriority: 2,


### PR DESCRIPTION
Prior to this change, I was able to replicate the expected problem where Trace activated multiple times (not 100% but often) with these sets:-

Side A:

Porygon2 @ Choice Band  
Ability: Analytic  
EVs: 252 HP / 4 SpA / 252 SpD  
Calm Nature  
IVs: 0 Atk  
- Recover  
- Discharge  
- Foul Play  
- Rest

Side B:

Clefable @ Leftovers  
Ability: Magic Guard  
EVs: 252 HP / 152 Def / 104 SpD  
Bold Nature  
IVs: 0 Atk  
- Wish  
- Moonblast  
- Thunder Wave  
- Protect

Challenge code:

/challenge [Gen 8] OU @@@[Gen 8] Pokebilities

The change prevents the problematic abilities from being added only when the battle's mod is not 'pokebilities'.