### PR TITLE
Gen 1: Fix Japanese OU and Tradebacks OU legality

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3311,10 +3311,7 @@ export const Formats: FormatList = [
 		mod: 'gen1',
 		searchShow: false,
 		ruleset: ['Obtainable', 'Allow Tradeback', 'Sleep Clause Mod', 'Freeze Clause Mod', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause', 'HP Percentage Mod', 'Cancel Mod', 'Desync Clause Mod'],
-		banlist: ['Uber',
-			'Nidoking + Fury Attack + Thrash', 'Exeggutor + Poison Powder + Stomp', 'Exeggutor + Sleep Powder + Stomp',
-			'Exeggutor + Stun Spore + Stomp', 'Jolteon + Focus Energy + Thunder Shock', 'Flareon + Focus Energy + Ember',
-		],
+		banlist: ['Uber'],
 	},
 	{
 		name: "[Gen 1] Japanese OU",
@@ -3322,7 +3319,7 @@ export const Formats: FormatList = [
 
 		mod: 'gen1jpn',
 		searchShow: false,
-		ruleset: ['Standard', 'Japanese Gen 1 Move Legality'],
+		ruleset: ['Standard'],
 		banlist: ['Uber'],
 	},
 	{

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3338,7 +3338,7 @@ export const Formats: FormatList = [
 			battle: 3,
 		},
 		searchShow: false,
-		ruleset: ['Obtainable', 'Team Preview', 'Cup Level Limit', 'Sleep Clause Mod', 'Species Clause', 'Nickname Clause', 'HP Percentage Mod', 'Cancel Mod', 'Japanese Gen 1 Move Legality'],
+		ruleset: ['Obtainable', 'Team Preview', 'Cup Level Limit', 'Sleep Clause Mod', 'Species Clause', 'Nickname Clause', 'HP Percentage Mod', 'Cancel Mod', 'Nintendo Cup 1997 Move Legality'],
 		banlist: ['Uber'],
 	},
 	{

--- a/data/mods/gen1jpn/rulesets.ts
+++ b/data/mods/gen1jpn/rulesets.ts
@@ -2,12 +2,13 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',
-		ruleset: ['Obtainable', 'Sleep Clause Mod', 'Species Clause', 'Cancel Mod'],
+		ruleset: ['Obtainable', 'Desync Clause Mod', 'Sleep Clause Mod', 'Freeze Clause Mod', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],
+		banlist: ['Dig', 'Fly'],
 	},
-	japanesegen1movelegality: {
+	nintendocup1997movelegality: {
 		effectType: 'ValidatorRule',
-		name: 'Japanese Gen 1 Move Legality',
-		desc: "Bans move combinations on Pok\u00e9mon that weren't legal in Japanese versions of Gen 1.",
+		name: 'Nintendo Cup 1997 Move Legality',
+		desc: "Bans move combinations on Pok\u00e9mon that would only be obtainable in Pok\u00e9mon Yellow.",
 		onValidateSet(set) {
 			const rgb97Legality: {[speciesid: string]: {[moveid: string]: 'illegal' | number}} = {
 				charizard: {fly: 'illegal'},


### PR DESCRIPTION
I'm not sure if there was a misunderstanding/miscommunication somewhere, but I'm pretty sure something went wrong when implementing Japanese OU. There was some talk in the RBY Community Discord about it since it suddenly sprang up and a few people are interested. 

- It appears that Japanese OU was using an odd "standard" ruleset. I'm not sure what this was for or how it happened, as NC97 didn't use that standard. Due to this though, there wasn't an OHKO clause or anything, so in this edit, I propose changing it to fit with the [Gen 1] OU standard.
- The "Japanese Gen 1 Move Legality" is a misnomer; this bans moves from Pokemon Yellow and is meant to be used with Nintendo Cup 1997. Unless you want to make Japanese OU a "Red and Green OU", this shouldn't be applied to it at all. I changed this to "Nintendo Cup 1997 Move Legality" to be consistent with NC2000. 
- Tradebacks OU was still complex banning the illegal move combos from RBY; Stadium 2's move relearner fixes these, to my knowledge. There is a source on this [here](https://www.smogon.com/forums/threads/rby-and-gsc-illegal-movesets.78638/). 

On another note, Dragon Rage Magikarp, Pay Day Fearow, and Pay Day Rapidash need to be unbanned in Japanese OU (but not NC97, they're from after that period). Fly Pikachu also, but the moves are banned in standard anyway. I'm not sure how to do that and I doubt anyone would really care though, so I'm just addressing the big stuff. I and Zarel did add a "japan: true" marker to those events. [There's a very contradictory error screen if you try to use them though](https://imgur.com/RxxbpRH).

If I misunderstood anything, please let me know! 