### PR TITLE
Rename VGC 2021 ladder and upgrade Battle Stadium Singles to Series 9

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -270,7 +270,7 @@ export const Formats: FormatList = [
 			validate: [3, 6],
 			battle: 3,
 		},
-		ruleset: ['Single Restricted GBU'],
+		ruleset: ['Standard GBU'],
 		minSourceGen: 8,
 	},
 	{
@@ -363,19 +363,6 @@ export const Formats: FormatList = [
 			battle: 4,
 		},
 		ruleset: ['Standard GBU', 'VGC Timer'],
-		minSourceGen: 8,
-	},
-	{
-		name: "[Gen 8] VGC 2021",
-
-		mod: 'gen8',
-		gameType: 'doubles',
-		forcedLevel: 50,
-		teamLength: {
-			validate: [4, 6],
-			battle: 4,
-		},
-		ruleset: ['Single Restricted GBU', 'VGC Timer'],
 		minSourceGen: 8,
 	},
 	{

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -353,7 +353,7 @@ export const Formats: FormatList = [
 		banlist: ['Corsola-Galar', 'Cutiefly', 'Scyther', 'Sneasel', 'Swirlix', 'Tangela', 'Vulpix', 'Vulpix-Alola'],
 	},
 	{
-		name: "[Gen 8] VGC 2021 Series 9",
+		name: "[Gen 8] VGC 2021",
 
 		mod: 'gen8',
 		gameType: 'doubles',


### PR DESCRIPTION
Approved by chemcoop. This should start May 1 (merging with the other tier changes is fine).

Also removes "VGC 2021" (Series 8), as it is also no longer needed for anything.