### PR TITLE
Formats: Use the name VGC 2021 Series 9

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -353,7 +353,7 @@ export const Formats: FormatList = [
 		banlist: ['Corsola-Galar', 'Cutiefly', 'Scyther', 'Sneasel', 'Swirlix', 'Tangela', 'Vulpix', 'Vulpix-Alola'],
 	},
 	{
-		name: "[Gen 8] VGC 2021",
+		name: "[Gen 8] VGC 2021 Series 9",
 
 		mod: 'gen8',
 		gameType: 'doubles',


### PR DESCRIPTION
See https://github.com/smogon/pokemon-showdown/pull/8255#issuecomment-830629704

Going forward, we're trying to keep VGC Series named as such, because TPCi doesn't seem to want to deviate from the Series-style formats (drastically changing the format every 3 months). Having a new ladder each series accurately allows players to start fresh in what is definitely a new format. In addition, having the name of the series in the format name offers additional clarity for newer users.

In addition to THAT, I already have been telling everyone in both VGC's room intro and on Twitter since we launched Series 9 last month that ladder rankings from the Series 9 ladder will transfer over to the proper ladder.