### PR TITLE
Improve self-hit confusion damage

### DIFF
--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -172,7 +172,7 @@ export const Conditions: {[k: string]: ConditionData} = {
 				return;
 			}
 			this.activeTarget = pokemon;
-			const damage = this.actions.getDamage(pokemon, pokemon, 40);
+			const damage = this.actions.getConfusionDamage(pokemon, 40);
 			if (typeof damage !== 'number') throw new Error("Confusion damage not dealt");
 			const activeMove = {id: this.toID('confused'), effectType: 'Move', type: '???'};
 			this.damage(damage, pokemon, pokemon, activeMove as ActiveMove);

--- a/data/mods/gen4/conditions.ts
+++ b/data/mods/gen4/conditions.ts
@@ -37,6 +37,28 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 			return false;
 		},
 	},
+	confusion: {
+		inherit: true,
+		onBeforeMove(pokemon) {
+			pokemon.volatiles['confusion'].time--;
+			if (!pokemon.volatiles['confusion'].time) {
+				pokemon.removeVolatile('confusion');
+				return;
+			}
+			this.add('-activate', pokemon, 'confusion');
+			if (this.randomChance(1, 2)) {
+				return;
+			}
+			const damage = this.actions.getDamage(pokemon, pokemon, 40);
+			if (typeof damage !== 'number') throw new Error("Confusion damage not dealt");
+			this.damage(damage, pokemon, pokemon, {
+				id: 'confused',
+				effectType: 'Move',
+				type: '???',
+			} as ActiveMove);
+			return false;
+		},
+	},
 	frz: {
 		inherit: true,
 		onBeforeMove(pokemon, target, move) {

--- a/data/mods/gen6/conditions.ts
+++ b/data/mods/gen6/conditions.ts
@@ -25,7 +25,7 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 			if (this.randomChance(1, 2)) {
 				return;
 			}
-			const damage = this.actions.getDamage(pokemon, pokemon, 40);
+			const damage = this.actions.getConfusionDamage(pokemon, 40);
 			if (typeof damage !== 'number') throw new Error("Confusion damage not dealt");
 			this.damage(damage, pokemon, pokemon, {
 				id: 'confused',

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1711,6 +1711,26 @@ export class BattleActions {
 		return tr(baseDamage, 16);
 	}
 
+	/**
+	 * Confusion damage is unique - most typical modifiers that get run when calculating
+	 * damage (e.g. Huge Power, Life Orb, critical hits) don't apply. It also uses a 16-bit
+	 * context for its damage, unlike the regular damage formula (though this only comes up
+	 * for base damage).
+	 */
+	getConfusionDamage(pokemon: Pokemon, basePower: number) {
+		const tr = this.battle.trunc;
+
+		const attack = pokemon.calculateStat('atk', pokemon.boosts['atk']);
+		const defense = pokemon.calculateStat('def', pokemon.boosts['def']);
+		const level = pokemon.level;
+		const baseDamage = tr(tr(tr(tr(2 * level / 5 + 2) * basePower * attack) / defense) / 50) + 2;
+
+		// Damage is 16-bit context in self-hit confusion damage
+		let damage = tr(baseDamage, 16);
+		damage = this.battle.randomizer(damage);
+		return Math.max(1, damage);
+	}
+
 	// #endregion
 
 	// #region MEGA EVOLUTION

--- a/test/sim/misc/confusion.js
+++ b/test/sim/misc/confusion.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Confusion', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it(`should not be affected by modifiers like Huge Power or Life Orb`, function () {
+		battle = common.createBattle([[
+			{species: 'Deoxys-Attack', ability: 'hugepower', item: 'lifeorb', moves: ['sleeptalk']},
+		], [
+			{species: 'Sableye', ability: 'prankster', moves: ['confuseray']},
+		]]);
+		battle.makeChoices();
+		const deoxys = battle.p1.active[0];
+		const damage = deoxys.maxhp - deoxys.hp;
+		assert.bounded(damage, [150, 177]);
+	});
+});


### PR DESCRIPTION
See [battle mechanics research post](https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/post-8843892) for more details; this behavior happens for sure in Gen 7/8 and almost certainly happens in Gen 5/6.

I'm not sure what I should do for Gens 3 and 4 (Gen 2 overrides the condition already). According to [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Confusion_(status_condition)), if I had to guess it looks like confusion damage is using a regular damage calculation, but there's a ton of caveats for each gen. We definitely don't support all those caveats currently and I am not interested in properly researching it for Gens 3 and 4 to sort it out. For now I've just blindly copy-pasted Gen 6's old confusion condition into Gen 4.