### PR TITLE
Rename and fix maxTeamSize

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -284,7 +284,6 @@ export const Formats: FormatList = [
 		defaultLevel: 100,
 		teamLength: {
 			validate: [1, 24],
-			battle: 24,
 		},
 		// no restrictions, for serious (other than team preview)
 		ruleset: ['Team Preview', 'Cancel Mod'],
@@ -455,7 +454,6 @@ export const Formats: FormatList = [
 		debug: true,
 		teamLength: {
 			validate: [2, 24],
-			battle: 24,
 		},
 		// no restrictions, for serious (other than team preview)
 		ruleset: ['Team Preview', 'Cancel Mod'],
@@ -2343,7 +2341,6 @@ export const Formats: FormatList = [
 		defaultLevel: 100,
 		teamLength: {
 			validate: [1, 24],
-			battle: 24,
 		},
 		// no restrictions, for serious (other than team preview)
 		ruleset: ['Team Preview', 'Cancel Mod'],
@@ -2491,7 +2488,6 @@ export const Formats: FormatList = [
 		debug: true,
 		teamLength: {
 			validate: [2, 24],
-			battle: 24,
 		},
 		// no restrictions, for serious (other than team preview)
 		ruleset: ['Team Preview', 'Cancel Mod'],
@@ -2657,7 +2653,6 @@ export const Formats: FormatList = [
 		defaultLevel: 100,
 		teamLength: {
 			validate: [1, 24],
-			battle: 24,
 		},
 		// no restrictions, for serious (other than team preview)
 		ruleset: ['Team Preview', 'Cancel Mod'],
@@ -2747,7 +2742,6 @@ export const Formats: FormatList = [
 		debug: true,
 		teamLength: {
 			validate: [1, 24],
-			battle: 24,
 		},
 		// no restrictions, for serious (other than team preview)
 		ruleset: ['Team Preview', 'Cancel Mod'],
@@ -2781,7 +2775,6 @@ export const Formats: FormatList = [
 		debug: true,
 		teamLength: {
 			validate: [1, 24],
-			battle: 24,
 		},
 		// no restrictions, for serious (other than team preview)
 		ruleset: ['Team Preview', 'Cancel Mod'],
@@ -2919,7 +2912,6 @@ export const Formats: FormatList = [
 		defaultLevel: 100,
 		teamLength: {
 			validate: [1, 24],
-			battle: 24,
 		},
 		// no restrictions, for serious (other than team preview)
 		ruleset: ['Team Preview', 'Cancel Mod'],
@@ -2972,7 +2964,6 @@ export const Formats: FormatList = [
 		defaultLevel: 100,
 		teamLength: {
 			validate: [1, 24],
-			battle: 24,
 		},
 		// no restrictions, for serious (other than team preview)
 		ruleset: ['Team Preview', 'Cancel Mod'],
@@ -3086,7 +3077,6 @@ export const Formats: FormatList = [
 		defaultLevel: 100,
 		teamLength: {
 			validate: [1, 24],
-			battle: 24,
 		},
 		// no restrictions
 		ruleset: ['Cancel Mod'],
@@ -3122,7 +3112,6 @@ export const Formats: FormatList = [
 		defaultLevel: 100,
 		teamLength: {
 			validate: [1, 24],
-			battle: 24,
 		},
 		// no restrictions
 		ruleset: ['Cancel Mod'],
@@ -3198,7 +3187,6 @@ export const Formats: FormatList = [
 		defaultLevel: 100,
 		teamLength: {
 			validate: [1, 24],
-			battle: 24,
 		},
 		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
 	},
@@ -3211,7 +3199,6 @@ export const Formats: FormatList = [
 		debug: true,
 		teamLength: {
 			validate: [1, 24],
-			battle: 24,
 		},
 		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
 	},
@@ -3285,7 +3272,6 @@ export const Formats: FormatList = [
 		defaultLevel: 100,
 		teamLength: {
 			validate: [1, 24],
-			battle: 24,
 		},
 		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
 	},
@@ -3384,7 +3370,6 @@ export const Formats: FormatList = [
 		defaultLevel: 100,
 		teamLength: {
 			validate: [1, 24],
-			battle: 24,
 		},
 		ruleset: ['HP Percentage Mod', 'Cancel Mod', 'Desync Clause Mod'],
 	},

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1141,16 +1141,15 @@ export class Battle {
 			side.activeRequest = null;
 		}
 
-		const teamLengthData = this.format.teamLength;
-		const maxTeamSize = teamLengthData?.battle;
 		if (type === 'teampreview') {
-			// Send the specified team size to the client even if it's our
-			// default team size of 6 as this means that the format wants
-			// the user to select the team order instead of just their lead.
-			this.add('teampreview' + (maxTeamSize ? '|' + maxTeamSize : ''));
+			// `chosenTeamSize = 6` means the format wants the user to select
+			// the entire team order, unlike `chosenTeamSize = undefined` which
+			// will only ask the user to select their lead(s).
+			const chosenTeamSize = this.format.teamLength?.battle;
+			this.add('teampreview' + (chosenTeamSize ? '|' + chosenTeamSize : ''));
 		}
 
-		const requests = this.getRequests(type, maxTeamSize || 6);
+		const requests = this.getRequests(type);
 		for (let i = 0; i < this.sides.length; i++) {
 			this.sides[i].emitRequest(requests[i]);
 		}
@@ -1168,12 +1167,7 @@ export class Battle {
 		}
 	}
 
-	getMaxTeamSize() {
-		const teamLengthData = this.format.teamLength;
-		return teamLengthData?.battle || 6;
-	}
-
-	getRequests(type: RequestState, maxTeamSize: number) {
+	getRequests(type: RequestState) {
 		// default to no request
 		const requests: AnyObject[] = Array(this.sides.length).fill(null);
 
@@ -1192,8 +1186,8 @@ export class Battle {
 		case 'teampreview':
 			for (let i = 0; i < this.sides.length; i++) {
 				const side = this.sides[i];
-				side.maxTeamSize = maxTeamSize;
-				requests[i] = {teamPreview: true, maxTeamSize, side: side.getRequestData()};
+				const maxChosenTeamSize = this.format.teamLength?.battle;
+				requests[i] = {teamPreview: true, maxChosenTeamSize, side: side.getRequestData()};
 			}
 			break;
 
@@ -1610,11 +1604,7 @@ export class Battle {
 		}
 
 		for (const side of this.sides) {
-			let teamsize = side.pokemon.length;
-			if (format.teamLength && format.teamLength.battle) {
-				teamsize = format.teamLength.battle <= teamsize ? format.teamLength.battle : teamsize;
-			}
-			this.add('teamsize', side.id, teamsize);
+			this.add('teamsize', side.id, side.pokemon.length);
 		}
 
 		this.add('gen', this.gen);
@@ -2294,14 +2284,7 @@ export class Battle {
 		// returns whether or not we ended in a callback
 		switch (action.choice) {
 		case 'start': {
-			// I GIVE UP, WILL WRESTLE WITH EVENT SYSTEM LATER
-			const format = this.format;
-
 			for (const side of this.sides) {
-				if (format.teamLength && format.teamLength.battle) {
-					// Trim the team: not all of the Pokémon brought to Preview will battle.
-					side.pokemon = side.pokemon.slice(0, format.teamLength.battle);
-				}
 				if (side.pokemonLeft) side.pokemonLeft = side.pokemon.length;
 			}
 

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -189,12 +189,24 @@ export class Format extends BasicEffect implements Readonly<BasicEffect> {
 	 * The range of levels on Pokemon that players can bring to battle and
 	 * the summative limit of those levels
 	 */
-	readonly cupLevelLimit?: {range: [number, number], total: number};
-	/**
-	 * The number of Pokemon players can bring to battle and
-	 * the number that can actually be used.
-	 */
-	readonly teamLength?: {battle?: number, validate?: [number, number]};
+	readonly cupLevelLimit?: {
+		/** Minimum and maximum level (redundant with maxLevel) */
+		range: [number, number],
+		/** Maximum total level that can be chosen in Team Preview */
+		total: number,
+	};
+	readonly teamLength?: {
+		/**
+		 * Force this many pokemon to be chosen in Team Preview
+		 * (simultaneously a minimum and a maximum.)
+		 */
+		battle?: number,
+		/**
+		 * Require this many pokemon to be brought into Team Preview
+		 * (or into the battle, for battles without Team Preview)
+		 */
+		validate?: [number, number],
+	};
 	/** An optional function that runs at the start of a battle. */
 	readonly onBegin?: (this: Battle) => void;
 	/** Pokemon must be obtained from this generation or later. */

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -63,7 +63,6 @@ export class Side {
 
 	name: string;
 	avatar: string;
-	maxTeamSize: number;
 	foe: Side = null!; // set in battle.start()
 	/** Only exists in multi battle, for the allied side */
 	allySide: Side | null = null; // set in battle.start()
@@ -110,7 +109,6 @@ export class Side {
 
 		this.name = name;
 		this.avatar = '';
-		this.maxTeamSize = 6;
 
 		this.team = team;
 		this.pokemon = [];
@@ -390,7 +388,7 @@ export class Side {
 		if (this.choice.forcedSwitchesLeft) return false;
 
 		if (this.requestState === 'teampreview') {
-			return this.choice.actions.length >= Math.min(this.maxTeamSize, this.pokemon.length);
+			return this.choice.actions.length >= this.chosenTeamSize();
 		}
 
 		// current request is move/switch
@@ -729,47 +727,62 @@ export class Side {
 		return true;
 	}
 
-	chooseTeam(data?: string) {
-		const autoFill = !data;
-		// default to sending team in order
-		if (!data) data = `123456`;
-		const positions = (('' + data)
-			.split(data.includes(',') ? ',' : '')
-			.map(datum => parseInt(datum) - 1));
-		const format = this.battle.format;
-		if (autoFill && this.choice.actions.length >= this.maxTeamSize) return true;
+	/**
+	 * The number of pokemon you must choose in Team Preview.
+	 *
+	 * Note that PS doesn't support choosing fewer than this number of pokemon.
+	 * In the games, it is sometimes possible to bring fewer than this, but
+	 * since that's nearly always a mistake, we haven't gotten around to
+	 * supporting it.
+	 */
+	chosenTeamSize() {
+		return Math.min(this.pokemon.length, this.battle.format.teamLength?.battle || Infinity);
+	}
+
+	chooseTeam(data = '') {
 		if (this.requestState !== 'teampreview') {
 			return this.emitChoiceError(`Can't choose for Team Preview: You're not in a Team Preview phase`);
 		}
-		// hack for >6 pokemon Custom Game
-		while (positions.length >= 6 && positions.length < this.maxTeamSize && positions.length < this.pokemon.length) {
-			positions.push(positions.length);
-		}
-		if (format.teamLength?.battle && format.cupLevelLimit) {
-			let totalLevel = 0;
-			for (const pos of positions.slice(0, format.teamLength.battle)) {
-				totalLevel += this.pokemon[pos].level;
+
+		const positions = data.split(data.includes(',') ? ',' : '')
+			.map(datum => parseInt(datum) - 1);
+		const format = this.battle.format;
+		const chosenTeamSize = Math.min(this.pokemon.length, this.battle.format.teamLength?.battle || Infinity);
+
+		// make sure positions is exactly of length chosenTeamSize
+		// always autofill the choice to the required team size
+		positions.splice(chosenTeamSize);
+		if (positions.length < chosenTeamSize) {
+			if (positions.length === 0) {
+				for (let i = 0; i < chosenTeamSize; i++) positions.push(i);
+			} else {
+				for (let i = 0; i < chosenTeamSize; i++) {
+					if (!positions.includes(i)) positions.push(i);
+					// duplicate in input, let the rest of the code handle the error message
+					if (positions.length >= chosenTeamSize) break;
+				}
 			}
-			if (totalLevel > format.cupLevelLimit.total) {
-				return this.emitChoiceError(`Your selected team's combined level of ${totalLevel} exceeds the format's maximum of ${format.cupLevelLimit.total}, please select a valid team of ${format.teamLength.battle} Pokémon`);
-			}
 		}
+		// return this.emitChoiceError(`Can't choose for Team Preview: You are limited to ${chosenTeamSize} Pokémon`);
+
 		for (const pos of positions) {
-			const index = this.choice.actions.length;
-			if (index >= this.maxTeamSize || index >= this.pokemon.length) {
-				// client still sends entire team
-				break;
-				// if (autoFill) break;
-				// return this.emitChoiceError(`Can't choose for Team Preview: You are limited to ${this.maxTeamSize} Pokémon`);
-			}
 			if (isNaN(pos) || pos < 0 || pos >= this.pokemon.length) {
 				return this.emitChoiceError(`Can't choose for Team Preview: You do not have a Pokémon in slot ${pos + 1}`);
 			}
+		}
+		if (format.cupLevelLimit) {
+			let totalLevel = 0;
+			for (const pos of positions) totalLevel += this.pokemon[pos].level;
+
+			if (totalLevel > format.cupLevelLimit.total) {
+				return this.emitChoiceError(`Your selected team has a total level of ${totalLevel}, but it can't be above ${format.cupLevelLimit.total}; please select a valid team of ${chosenTeamSize} Pokémon`);
+			}
+		}
+		for (const pos of positions) {
 			if (this.choice.switchIns.has(pos)) {
-				if (autoFill) continue;
 				return this.emitChoiceError(`Can't choose for Team Preview: The Pokémon in slot ${pos + 1} can only switch in once`);
 			}
-
+			const index = this.choice.actions.length;
 			this.choice.switchIns.add(pos);
 			this.choice.actions.push({
 				choice: 'team',
@@ -905,8 +918,6 @@ export class Side {
 				break;
 			case 'team':
 				if (!this.chooseTeam(data)) return false;
-				// Auto-complete
-				this.chooseTeam();
 				break;
 			case 'pass':
 			case 'skip':

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -744,7 +744,7 @@ export class Side {
 			return this.emitChoiceError(`Can't choose for Team Preview: You're not in a Team Preview phase`);
 		}
 
-		const positions = data.split(data.includes(',') ? ',' : '')
+		let positions = data.split(data.includes(',') ? ',' : '')
 			.map(datum => parseInt(datum) - 1);
 		const format = this.battle.format;
 		const chosenTeamSize = Math.min(this.pokemon.length, this.battle.format.teamLength?.battle || Infinity);
@@ -778,7 +778,13 @@ export class Side {
 			for (const pos of positions) totalLevel += this.pokemon[pos].level;
 
 			if (totalLevel > format.cupLevelLimit.total) {
-				return this.emitChoiceError(`Your selected team has a total level of ${totalLevel}, but it can't be above ${format.cupLevelLimit.total}; please select a valid team of ${chosenTeamSize} Pokémon`);
+				if (!data) {
+					// autoChoose
+					positions = [...this.pokemon.keys()].sort((a, b) => (this.pokemon[a].level - this.pokemon[b].level))
+						.slice(0, chosenTeamSize);
+				} else {
+					return this.emitChoiceError(`Your selected team has a total level of ${totalLevel}, but it can't be above ${format.cupLevelLimit.total}; please select a valid team of ${chosenTeamSize} Pokémon`);
+				}
 			}
 		}
 		for (const [index, pos] of positions.entries()) {

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -765,9 +765,12 @@ export class Side {
 		}
 		// return this.emitChoiceError(`Can't choose for Team Preview: You are limited to ${chosenTeamSize} Pokémon`);
 
-		for (const pos of positions) {
+		for (const [index, pos] of positions.entries()) {
 			if (isNaN(pos) || pos < 0 || pos >= this.pokemon.length) {
 				return this.emitChoiceError(`Can't choose for Team Preview: You do not have a Pokémon in slot ${pos + 1}`);
+			}
+			if (positions.indexOf(pos) !== index) {
+				return this.emitChoiceError(`Can't choose for Team Preview: The Pokémon in slot ${pos + 1} can only switch in once`);
 			}
 		}
 		if (format.cupLevelLimit) {
@@ -778,11 +781,7 @@ export class Side {
 				return this.emitChoiceError(`Your selected team has a total level of ${totalLevel}, but it can't be above ${format.cupLevelLimit.total}; please select a valid team of ${chosenTeamSize} Pokémon`);
 			}
 		}
-		for (const pos of positions) {
-			if (this.choice.switchIns.has(pos)) {
-				return this.emitChoiceError(`Can't choose for Team Preview: The Pokémon in slot ${pos + 1} can only switch in once`);
-			}
-			const index = this.choice.actions.length;
+		for (const [index, pos] of positions.entries()) {
 			this.choice.switchIns.add(pos);
 			this.choice.actions.push({
 				choice: 'team',

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -750,20 +750,18 @@ export class Side {
 		const chosenTeamSize = Math.min(this.pokemon.length, this.battle.format.teamLength?.battle || Infinity);
 
 		// make sure positions is exactly of length chosenTeamSize
-		// always autofill the choice to the required team size
+		// - If too big: the client automatically sends a full list, so we just trim it down to size
 		positions.splice(chosenTeamSize);
-		if (positions.length < chosenTeamSize) {
-			if (positions.length === 0) {
-				for (let i = 0; i < chosenTeamSize; i++) positions.push(i);
-			} else {
-				for (let i = 0; i < chosenTeamSize; i++) {
-					if (!positions.includes(i)) positions.push(i);
-					// duplicate in input, let the rest of the code handle the error message
-					if (positions.length >= chosenTeamSize) break;
-				}
+		// - If too small: we intentionally support only sending leads and having the sim fill in the rest
+		if (positions.length === 0) {
+			for (let i = 0; i < chosenTeamSize; i++) positions.push(i);
+		} else if (positions.length < chosenTeamSize) {
+			for (let i = 0; i < chosenTeamSize; i++) {
+				if (!positions.includes(i)) positions.push(i);
+				// duplicate in input, let the rest of the code handle the error message
+				if (positions.length >= chosenTeamSize) break;
 			}
 		}
-		// return this.emitChoiceError(`Can't choose for Team Preview: You are limited to ${chosenTeamSize} Pokémon`);
 
 		for (const [index, pos] of positions.entries()) {
 			if (isNaN(pos) || pos < 0 || pos >= this.pokemon.length) {

--- a/sim/state.ts
+++ b/sim/state.ts
@@ -138,7 +138,7 @@ export const State = new class {
 		// states we wouldnt be using, but also because battle.getRequests will mutate
 		// state on occasion (eg. `pokemon.getMoves` sets `pokemon.trapped = true` if locked).
 		if (activeRequests) {
-			const requests = battle.getRequests(battle.requestState, battle.getMaxTeamSize());
+			const requests = battle.getRequests(battle.requestState);
 			for (const [i, side] of state.sides.entries()) {
 				battle.sides[i].activeRequest = side.activeRequest === null ? null : requests[i];
 			}

--- a/test/sim/decisions.js
+++ b/test/sim/decisions.js
@@ -513,7 +513,7 @@ describe('Choices', function () {
 			}
 		});
 
-		it('should autocomplete a single-slot action in Singles for no Illusion', function () {
+		it('should autocomplete a single-slot choice in Singles', function () {
 			// Backwards-compatibility with the client. It should be useful for 3rd party bots/clients (Android?)
 			for (let i = 0; i < 5; i++) {
 				battle = common.createBattle({preview: true}, SINGLES_TEAMS.full);
@@ -575,7 +575,7 @@ describe('Choices', function () {
 			}
 		});
 
-		it('should autocomplete multi-slot decisions', function () {
+		it('should autocomplete multi-slot choices', function () {
 			for (let i = 0; i < 5; i++) {
 				battle = common.createBattle({preview: true}, SINGLES_TEAMS.full);
 				const teamOrder = Utils.shuffle(BASE_TEAM_ORDER.slice()).slice(0, 2);


### PR DESCRIPTION
`maxTeamSize` is a bad variable name (not that `teamLength.battle` is any better, but that'll get fixed in a future refactor).

- Rename `maxTeamSize` to `chosenTeamSize`, to better indicate that this is the size after Team Preview, and that it is also the minimum size after Team Preview.

- Don't limit team sizes to 6 if `teamLength.battle` isn't specified. This removes an unnecessary `teamLength.battle` requirement in all Custom Game formats.

- Stop requiring `maxTeamSize` as a parameter for `battle.getRequests`. It's not even used except as a hint to the Preact client, and was never state in the first place.

- Stop supporting partial `side.chooseTeam`. This is an unused feature and removing it massively simplifies the code and fixes a bug in `cupLevelLimit` which definitely was not written with the understanding that `chooseTeam` could be partial.

- Fix [a bug in #7929](https://github.com/smogon/pokemon-showdown/pull/7929/files#r625493011) which seemed to misunderstand what `teamsize` was for.