### PR TITLE
Simplify Team Preview events

### DIFF
--- a/data/mods/fusionevolutionuu/rulesets.ts
+++ b/data/mods/fusionevolutionuu/rulesets.ts
@@ -3,15 +3,13 @@ export const Rulesets: {[k: string]: FormatData} = {
 		effectType: 'Rule',
 		name: 'Team Preview',
 		desc: "Allows each player to see the Pok&eacute;mon on their opponent's team before they choose their lead Pok&eacute;mon",
-		onBegin() {
+		onTeamPreview() {
 			this.add('clearpoke');
 			for (const pokemon of this.getAllPokemon()) {
 				const details = pokemon.details.replace(', shiny', '')
 					.replace(/(Arceus|Gourgeist|Pumpkaboo|Silvally|Urshifu|Silvino)(-[a-zA-Z?-]+)?/g, '$1-*');
 				this.add('poke', pokemon.side.id, details, '');
 			}
-		},
-		onFieldTeamPreview() {
 			this.makeRequest('teampreview');
 		},
 	},

--- a/data/mods/gen7/rulesets.ts
+++ b/data/mods/gen7/rulesets.ts
@@ -32,13 +32,14 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 	},
 	teampreview: {
 		inherit: true,
-		onBegin() {
+		onTeamPreview() {
 			this.add('clearpoke');
 			for (const pokemon of this.getAllPokemon()) {
 				const details = pokemon.details.replace(', shiny', '')
 					.replace(/(Arceus|Gourgeist|Genesect|Pumpkaboo|Silvally|Urshifu)(-[a-zA-Z?-]+)?/g, '$1-*');
 				this.add('poke', pokemon.side.id, details, pokemon.item ? 'item' : '');
 			}
+			this.makeRequest('teampreview');
 		},
 	},
 };

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -391,15 +391,13 @@ export const Rulesets: {[k: string]: FormatData} = {
 		effectType: 'Rule',
 		name: 'Team Preview',
 		desc: "Allows each player to see the Pok&eacute;mon on their opponent's team before they choose their lead Pok&eacute;mon",
-		onBegin() {
+		onTeamPreview() {
 			this.add('clearpoke');
 			for (const pokemon of this.getAllPokemon()) {
 				const details = pokemon.details.replace(', shiny', '')
 					.replace(/(Arceus|Gourgeist|Pumpkaboo|Silvally|Urshifu)(-[a-zA-Z?-]+)?/g, '$1-*');
 				this.add('poke', pokemon.side.id, details, '');
 			}
-		},
-		onFieldTeamPreview() {
 			this.makeRequest('teampreview');
 		},
 	},
@@ -1220,7 +1218,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 		effectType: 'Rule',
 		name: 'Team Type Preview',
 		desc: "Allows each player to see the Pok&eacute;mon on their opponent's team and those Pok&eacute;mon's types before they choose their lead Pok&eacute;mon",
-		onBegin() {
+		onTeamPreview() {
 			for (const side of this.sides) {
 				for (const pokemon of side.pokemon) {
 					const details = pokemon.details.replace(', shiny', '')
@@ -1237,8 +1235,6 @@ export const Rulesets: {[k: string]: FormatData} = {
 				}
 				this.add(`${buf}</span>`);
 			}
-		},
-		onFieldTeamPreview() {
 			this.makeRequest('teampreview');
 		},
 	},
@@ -1396,7 +1392,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 	adjustlevel: {
 		effectType: 'ValidatorRule',
 		name: 'Adjust Level',
-		desc: "All Pokémon will be set to exactly this level (but unlike Max Level and Min Level, it will still be able to learn moves from above this level)",
+		desc: "All Pokémon will be set to exactly this level (but unlike Max Level and Min Level, it will still be able to learn moves from above this level) (when using this, Max Level is the level of the pokemon before it's level-adjusted down)",
 		hasValue: 'positive-integer',
 		mutuallyExclusiveWith: 'adjustleveldown',
 		// hardcoded in sim/team-validator

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -340,7 +340,7 @@ export class Format extends BasicEffect implements Readonly<BasicEffect> {
 		this: Battle, species: Species, target?: Pokemon, source?: Pokemon, effect?: Effect
 	) => Species | void;
 	readonly onFieldStart?: (this: Battle) => void;
-	readonly onFieldTeamPreview?: (this: Battle) => void;
+	readonly onTeamPreview?: (this: Battle) => void;
 	readonly onValidateSet?: (
 		this: TeamValidator, set: PokemonSet, format: Format, setHas: AnyObject, teamHas: AnyObject
 	) => string[] | void;


### PR DESCRIPTION
In format events:

`onFieldTeamPreview` has been renamed back to `onTeamPreview`. It's now a custom event (like `onBegin`), rather than a field event.

Team Preview data has been entirely moved from `onBegin` into `onTeamPreview`.

`onFieldStart` for formats/rules now happens after Team Preview, rather than before. Use `onBegin` for things that happen before Team Preview.