### PR TITLE
Implement /sendprivatehtmlbox

### DIFF
--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -420,9 +420,9 @@ export const commands: Chat.ChatCommands = {
 		`If a [highlight] is specified, only highlights them if they have that term on their highlight list.`,
 	],
 
-	changeprivateuhtml: 'sendprivatehtml',
-	sendprivateuhtml: 'sendprivatehtml',
-	sendprivatehtml(target, room, user, connection, cmd) {
+	changeprivateuhtml: 'sendprivatehtmlbox',
+	sendprivateuhtml: 'sendprivatehtmlbox',
+	sendprivatehtmlbox(target, room, user, connection, cmd) {
 		room = this.requireRoom();
 		this.checkCan('addhtml', null, room);
 
@@ -439,19 +439,19 @@ export const commands: Chat.ChatCommands = {
 		let html: string;
 		let messageType: string;
 		let name: string | undefined;
-		const plainHtml = cmd === 'sendprivatehtml';
+		const plainHtml = cmd === 'sendprivatehtmlbox';
 		if (plainHtml) {
 			html = rest;
 			messageType = 'html';
 		} else {
 			[name, html] = this.splitOne(rest);
-			if (!name) return this.parse('/help ' + cmd);
+			if (!name) return this.parse('/help sendprivatehtmlbox');
 
 			messageType = `uhtml${(cmd === 'changeprivateuhtml' ? 'change' : '')}|${name}`;
 		}
 
 		html = this.checkHTML(html);
-		if (!html) return this.parse('/help ' + cmd);
+		if (!html) return this.parse('/help sendprivatehtmlbox');
 
 		html = `${Utils.html`<div style="color:#888;font-size:8pt">[Private from ${user.name}]</div>`}${Chat.collapseLineBreaksHTML(html)}`;
 		if (plainHtml) html = `<div class="infobox">${html}</div>`;
@@ -460,8 +460,8 @@ export const commands: Chat.ChatCommands = {
 
 		this.sendReply(`Sent private HTML to ${targetUser.name}.`);
 	},
-	sendprivatehtmlhelp: [
-		`/sendprivatehtml [userid], [html] - Sends [userid] the private [html]. Requires: * # &`,
+	sendprivatehtmlboxhelp: [
+		`/sendprivatehtmlbox [userid], [html] - Sends [userid] the private [html]. Requires: * # &`,
 		`/sendprivateuhtml [userid], [name], [html] - Sends [userid] the private [html] that can change. Requires: * # &`,
 		`/changeprivateuhtml [userid], [name], [html] - Changes the message previously sent with /sendprivateuhtml [userid], [name], [html]. Requires: * # &`,
 	],

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -440,8 +440,8 @@ export const commands: Chat.ChatCommands = {
 		let html: string;
 		let messageType: string;
 		let name: string | undefined;
-		const plainHTML = cmd === 'sendprivatehtml';
-		if (plainHTML) {
+		const plainHtml = cmd === 'sendprivatehtml';
+		if (plainHtml) {
 			html = rest;
 			messageType = 'html';
 		} else {
@@ -455,7 +455,7 @@ export const commands: Chat.ChatCommands = {
 		if (!html) return this.parse('/help ' + cmd);
 
 		html = `${Utils.html`<div style="color:#888;font-size:8pt">[Private from ${user.name}]</div>`}${Chat.collapseLineBreaksHTML(html)}`;
-		if (plainHTML) html = `<div class="infobox">${html}</div>`;
+		if (plainHtml) html = `<div class="infobox">${html}</div>`;
 
 		targetUser.sendTo(room, `|${messageType}|${html}`);
 

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -429,8 +429,7 @@ export const commands: Chat.ChatCommands = {
 		const {targetUser, rest} = this.requireUser(target);
 
 		if (targetUser.locked && !this.user.can('lock')) {
-			this.errorReply("This user is currently locked, so you cannot send them private HTML.");
-			return false;
+			throw new Chat.ErrorMessage("This user is currently locked, so you cannot send them private HTML.");
 		}
 
 		if (!(targetUser.id in room.users)) {
@@ -463,11 +462,7 @@ export const commands: Chat.ChatCommands = {
 	},
 	sendprivatehtmlhelp: [
 		`/sendprivatehtml [userid], [html] - Sends [userid] the private [html]. Requires: * # &`,
-	],
-	sendprivateuhtmlhelp: [
 		`/sendprivateuhtml [userid], [name], [html] - Sends [userid] the private [html] that can change. Requires: * # &`,
-	],
-	changeprivateuhtmlhelp: [
 		`/changeprivateuhtml [userid], [name], [html] - Changes the message previously sent with /sendprivateuhtml [userid], [name], [html]. Requires: * # &`,
 	],
 


### PR DESCRIPTION
Similar use as `/sendhtmlpage` for bots but for cases where the HTML is small or should be easier to reach from the chat room.

![send-private-html](https://user-images.githubusercontent.com/6309262/117555876-9894c880-b028-11eb-9c75-78662846cfea.png)