### PR TITLE
Use |-swapsideconditions| for Court Change

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2727,7 +2727,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					}
 					success = true;
 				}
-				this.add('-sideswitch', '[silent]');
+				this.add('-sideswitch');
 			}
 			if (!success) return false;
 			this.add('-activate', source, 'move: Court Change');

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2712,7 +2712,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 				const sourceSide = source.side;
 				const targetSide = source.side.foe;
 				for (const id of sideConditions) {
-					const effectName = this.dex.conditions.get(id).name;
 					if (sourceSide.sideConditions[id] && targetSide.sideConditions[id]) {
 						[sourceSide.sideConditions[id], targetSide.sideConditions[id]] = [
 							targetSide.sideConditions[id], sourceSide.sideConditions[id],
@@ -2726,9 +2725,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 					} else {
 						continue;
 					}
-					this.add('-sideswitch', effectName, '[silent]');
 					success = true;
 				}
+				this.add('-sideswitch', '[silent]');
 			}
 			if (!success) return false;
 			this.add('-activate', source, 'move: Court Change');

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2726,12 +2726,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 					} else {
 						continue;
 					}
-					let sourceLayers = sourceSide.sideConditions[id] ? (sourceSide.sideConditions[id].layers || 1) : 0;
-					let targetLayers = targetSide.sideConditions[id] ? (targetSide.sideConditions[id].layers || 1) : 0;
-					for (; sourceLayers > 0; sourceLayers--) {
+					
+					if (sourceSide.sideConditions[id]) {
 						this.add('-sideswitch', targetSide, sourceSide, effectName, '[silent]');
 					}
-					for (; targetLayers > 0; targetLayers--) {
+					if (targetSide.sideConditions[id]) {
 						this.add('-sideswitch', sourceSide, targetSide, effectName, '[silent]');
 					}
 					success = true;

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2726,13 +2726,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					} else {
 						continue;
 					}
-
-					if (sourceSide.sideConditions[id]) {
-						this.add('-sideswitch', targetSide, sourceSide, effectName, '[silent]');
-					}
-					if (targetSide.sideConditions[id]) {
-						this.add('-sideswitch', sourceSide, targetSide, effectName, '[silent]');
-					}
+					this.add('-sideswitch', effectName, '[silent]');
 					success = true;
 				}
 			}

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2717,26 +2717,22 @@ export const Moves: {[moveid: string]: MoveData} = {
 						[sourceSide.sideConditions[id], targetSide.sideConditions[id]] = [
 							targetSide.sideConditions[id], sourceSide.sideConditions[id],
 						];
-						this.add('-sideend', sourceSide, effectName, '[silent]');
-						this.add('-sideend', targetSide, effectName, '[silent]');
 					} else if (sourceSide.sideConditions[id] && !targetSide.sideConditions[id]) {
 						targetSide.sideConditions[id] = sourceSide.sideConditions[id];
 						delete sourceSide.sideConditions[id];
-						this.add('-sideend', sourceSide, effectName, '[silent]');
 					} else if (targetSide.sideConditions[id] && !sourceSide.sideConditions[id]) {
 						sourceSide.sideConditions[id] = targetSide.sideConditions[id];
 						delete targetSide.sideConditions[id];
-						this.add('-sideend', targetSide, effectName, '[silent]');
 					} else {
 						continue;
 					}
 					let sourceLayers = sourceSide.sideConditions[id] ? (sourceSide.sideConditions[id].layers || 1) : 0;
 					let targetLayers = targetSide.sideConditions[id] ? (targetSide.sideConditions[id].layers || 1) : 0;
 					for (; sourceLayers > 0; sourceLayers--) {
-						this.add('-sidestart', sourceSide, effectName, '[silent]');
+						this.add('-sideswitch', targetSide, sourceSide, effectName, '[silent]');
 					}
 					for (; targetLayers > 0; targetLayers--) {
-						this.add('-sidestart', targetSide, effectName, '[silent]');
+						this.add('-sideswitch', sourceSide, targetSide, effectName, '[silent]');
 					}
 					success = true;
 				}

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2727,7 +2727,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					}
 					success = true;
 				}
-				this.add('-sideswitch');
+				this.add('-swapsideconditions');
 			}
 			if (!success) return false;
 			this.add('-activate', source, 'move: Court Change');

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2726,7 +2726,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					} else {
 						continue;
 					}
-					
+
 					if (sourceSide.sideConditions[id]) {
 						this.add('-sideswitch', targetSide, sourceSide, effectName, '[silent]');
 					}

--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -444,9 +444,9 @@ stat boosts are minor actions.
 
 > Indicates that the side condition `CONDITION` ended for the given `SIDE`.
 
-`|-sideswitch|SIDE1|SIDE2|CONDITION`
+`|-sideswitch|CONDITION`
 
-> Swaps a side condition `CONDITION` from `SIDE1` to `SIDE2`.
+> Swaps a side condition `CONDITION` between sides.
 > Used for Court Change.
 
 `|-start|POKEMON|EFFECT`

--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -444,7 +444,7 @@ stat boosts are minor actions.
 
 > Indicates that the side condition `CONDITION` ended for the given `SIDE`.
 
-`|-sideswitch`
+`|-swapsideconditions`
 
 > Swaps side conditions between sides. Used for Court Change.
 

--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -444,6 +444,11 @@ stat boosts are minor actions.
 
 > Indicates that the side condition `CONDITION` ended for the given `SIDE`.
 
+`|-sideswitch|SIDE1|SIDE2|CONDITION`
+
+> Swaps a side condition `CONDITION` from `SIDE1` to `SIDE2`.
+> Used for Court Change.
+
 `|-start|POKEMON|EFFECT`
 
 > A [*volatile* status](https://bulbapedia.bulbagarden.net/wiki/Status_condition#Volatile_status)

--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -444,10 +444,9 @@ stat boosts are minor actions.
 
 > Indicates that the side condition `CONDITION` ended for the given `SIDE`.
 
-`|-sideswitch|CONDITION`
+`|-sideswitch`
 
-> Swaps a side condition `CONDITION` between sides.
-> Used for Court Change.
+> Swaps side conditions between sides. Used for Court Change.
 
 `|-start|POKEMON|EFFECT`
 


### PR DESCRIPTION
Corresponding client change: smogon/pokemon-showdown-client#1783

Uses a new pline `-sideswitch`, which swaps side conditions between sides. Right now it only uses it for non ffa battles, mostly cause I don't really understand the ffa code rn, and was hoping I could get some help on that one.

https://user-images.githubusercontent.com/32044378/117557824-1cf54480-b045-11eb-9be0-e11c2e20ea69.mp4