### PR TITLE
Properly implement Gen 1 Wrap

### DIFF
--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -192,6 +192,7 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 			this.add('cant', pokemon, 'partiallytrapped');
 			return false;
 		},
+		onLockMove: 'fight',
 	},
 	partialtrappinglock: {
 		name: 'partialtrappinglock',

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -190,9 +190,9 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 		onBeforeMovePriority: 4,
 		onBeforeMove(pokemon) {
 			this.add('cant', pokemon, 'partiallytrapped');
+			pokemon.maybePartialTrappingLock = true;
 			return false;
 		},
-		onLockMove: 'fight',
 	},
 	partialtrappinglock: {
 		name: 'partialtrappinglock',
@@ -218,6 +218,9 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 				}
 			}
 		},
+		onBeforeMove(pokemon) {
+			pokemon.maybePartialTrappingLock = true;
+		}
 	},
 	mustrecharge: {
 		inherit: true,

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -861,6 +861,13 @@ export class Pokemon {
 					id: 'recharge',
 				}];
 			}
+			if (lockedMove === 'fight') {
+				this.trapped = false;
+				return [{
+					move: 'Fight',
+					id: 'fight',
+				}];
+			}
 			for (const moveSlot of this.moveSlots) {
 				if (moveSlot.id !== lockedMove) continue;
 				return [{

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -388,7 +388,8 @@ export class Pokemon {
 		this.trapped = false;
 		this.maybeTrapped = false;
 		this.maybeDisabled = false;
-
+		this.maybePartialTrappingLock = false;
+		
 		this.illusion = null;
 		this.transformed = false;
 
@@ -860,13 +861,6 @@ export class Pokemon {
 				return [{
 					move: 'Recharge',
 					id: 'recharge',
-				}];
-			}
-			if (lockedMove === 'fight') {
-				this.trapped = false;
-				return [{
-					move: 'Fight',
-					id: 'fight',
 				}];
 			}
 			for (const moveSlot of this.moveSlots) {

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -118,7 +118,8 @@ export class Pokemon {
 	trapped: boolean | "hidden";
 	maybeTrapped: boolean;
 	maybeDisabled: boolean;
-
+	maybePartialTrappingLock: boolean | "hidden";
+	
 	illusion: Pokemon | null;
 	transformed: boolean;
 

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -510,7 +510,16 @@ export class Side {
 				return this.emitChoiceError(`Can't move: You can't choose a target for ${move.name}`);
 			}
 		}
-
+		if (pokemon.maybePartialTrappingLock) {
+			this.choice.cantUndo = true;
+			if (!pokemon.volatiles['partiallytrapped'] && !pokemon.volatiles['partialtrappinglock']) {
+				this.choice.cantUndo=false;
+				const status = this.emitChoiceError(`Your Pokemon is able to choose an attack now.`, true);
+				this.emitRequest(this.activeRequest!);
+				pokemon.maybePartialTrappingLock = false;
+				return status;
+			}
+		}
 		const lockedMove = pokemon.getLockedMove();
 		if (lockedMove) {
 			let lockedMoveTargetLoc = pokemon.lastMoveTargetLoc || 0;

--- a/test/sim/moves/substitute.js
+++ b/test/sim/moves/substitute.js
@@ -131,7 +131,7 @@ describe('Substitute', function () {
 		assert.equal(pokemon.maxhp - pokemon.hp, Math.floor(pokemon.maxhp / 4));
 
 		const hp = pokemon.hp;
-		battle.makeChoices('move growl', 'move clamp');
+		battle.makeChoices('move fight', 'move clamp');
 		assert.bounded(hp - pokemon.hp, [91, 108]);
 	});
 });

--- a/test/sim/moves/substitute.js
+++ b/test/sim/moves/substitute.js
@@ -131,7 +131,7 @@ describe('Substitute', function () {
 		assert.equal(pokemon.maxhp - pokemon.hp, Math.floor(pokemon.maxhp / 4));
 
 		const hp = pokemon.hp;
-		battle.makeChoices('move fight', 'move clamp');
+		battle.makeChoices('move growl', 'move clamp');
 		assert.bounded(hp - pokemon.hp, [91, 108]);
 	});
 });


### PR DESCRIPTION
So as covered here, https://www.smogon.com/forums/threads/rby-fight-button-simulation-improvements-fix-partial-trapping-improve-counter.3673280/, Wrap is currently not properly implemented since there is not a "Fight" button, now while yes Pokemon Showdown does implement it as if the Pokemon being wrapped opens up the FIGHT menu first, then attacks. The issue is that when a wrapped player tries to open the "Fight" Menu, the menu doesn't even come up in the first place, which tells the player being wrapped if they can attack or not, which is very important information when it comes to mind games and predicting switches. As an example, if you know the opponent's wrap has ended, you can predict they will switch to something defensive and can capitalize on that with your own switch. On cartridge, the player being wrapped would have this information because they could check if they can move or not by attempting to open the fight menu and seeing if it opens or not, on Pokemon Showdown they cannot. This is the issue with Showdown's current implementation that Plague Von Karma tried to explain, it is hiding information that should be available to the player being wrapped.

How this code fixes Gen 1 Wrap is by locking the user's moves to just a "Fight" option when they are wrapped while also giving them the freedom to switch. Since a player would always cancel the "Fight" option when being wrapped since it gives them information of if they can attack or not, this implementation should be correct from an information perspective. If I need to clarify anything, please ask, thanks.