### PR TITLE
Scavengers: Italicize host names on hunt end

### DIFF
--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -735,7 +735,7 @@ export class ScavengerHunt extends Rooms.RoomGame {
 		if (!reset) {
 			const sliceIndex = this.gameType === 'official' ? 5 : 3;
 
-			const hosts = Utils.escapeHTML(Chat.toListString(this.hosts.map(h => h.name)));
+			const hosts = Chat.toListString(this.hosts.map(h => `<em>${Utils.escapeHTML(h.name)}</em>`));
 
 			this.announce(
 				`The ${this.gameType ? `${this.gameType} ` : ""}scavenger hunt by ${hosts} was ended ${(endedBy ? "by " + Utils.escapeHTML(endedBy.name) : "automatically")}.<br />` +


### PR DESCRIPTION
The `<em>` being wrapped around each individual username and not the entire host string is intentional since it looks better  - and also allows parsing of hosts from the finishing message

Approval from LittEleven https://cdn.discordapp.com/attachments/762324232948023316/841056528491741214/littappr.png