### PR TITLE
Fix faint check mid-attack

### DIFF
--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -313,6 +313,8 @@ export class BattleActions {
 			}
 		}
 		if (noLock && pokemon.volatiles['lockedmove']) delete pokemon.volatiles['lockedmove'];
+		this.battle.faintMessages();
+		this.battle.checkWin();
 	}
 	/**
 	 * useMove is the "inside" move caller. It handles effects of the
@@ -894,10 +896,10 @@ export class BattleActions {
 		// hit is 1 higher than the actual hit count
 		if (hit === 1) return damage.fill(false);
 		if (nullDamage) damage.fill(false);
+		this.battle.faintMessages(false, false, !pokemon.hp);
 		if (move.multihit && typeof move.smartTarget !== 'boolean') {
 			this.battle.add('-hitcount', targets[0], hit - 1);
 		}
-		this.battle.faintMessages();
 
 		if (move.recoil && move.totalDamage) {
 			this.battle.damage(this.calcRecoilDamage(move.totalDamage, move), pokemon, pokemon, 'recoil');

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2172,7 +2172,7 @@ export class Battle {
 		}
 	}
 
-	faintMessages(lastFirst = false, forceCheck = false) {
+	faintMessages(lastFirst = false, forceCheck = false, checkWin = true) {
 		if (this.ended) return;
 		const length = this.faintQueue.length;
 		if (!length) {
@@ -2219,7 +2219,7 @@ export class Battle {
 			}
 		}
 
-		if (this.checkWin(faintData)) return true;
+		if (checkWin && this.checkWin(faintData)) return true;
 
 		if (faintData && length) {
 			this.runEvent('AfterFaint', faintData.target, faintData.source, faintData.effect, length);

--- a/test/sim/misc/faint-order.js
+++ b/test/sim/misc/faint-order.js
@@ -55,4 +55,103 @@ describe('Fainting', function () {
 		battle.makeChoices('switch Pikachu', '');
 		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
+
+	it('should check for a winner after an attack', function () {
+		battle = common.gen(4).createBattle([
+			[
+				{species: 'Shedinja', moves: ['shadowsneak']},
+			],
+			[
+				{species: 'Shedinja', moves: ['sleeptalk']},
+			],
+		]);
+		battle.makeChoices();
+		assert.fainted(battle.p2.active[0]);
+		assert.equal(battle.winner, 'Player 1');
+		battle.destroy();
+
+		battle = common.gen(5).createBattle([
+			[
+				{species: 'Shedinja', moves: ['sleeptalk', 'shadowsneak']},
+			],
+			[
+				{species: 'Shedinja', ability: 'prankster', moves: ['spore']},
+			],
+		]);
+		battle.makeChoices();
+		assert.fainted(battle.p2.active[0]);
+		assert.equal(battle.winner, 'Player 1');
+	});
+
+	it('should check for a winner after recoil', function () {
+		battle = common.gen(4).createBattle([
+			[
+				{species: 'Shedinja', moves: ['flareblitz']},
+			],
+			[
+				{species: 'Shedinja', moves: ['flareblitz']},
+			],
+		]);
+		battle.makeChoices();
+		assert.fainted(battle.p1.active[0]);
+		assert.fainted(battle.p2.active[0]);
+		assert.equal(battle.winner, '');
+		battle.destroy();
+
+		battle = common.gen(5).createBattle([
+			[
+				{species: 'Shedinja', moves: ['flareblitz']},
+			],
+			[
+				{species: 'Shedinja', moves: ['sleeptalk']},
+			],
+		]);
+		battle.makeChoices();
+		assert.fainted(battle.p1.active[0]);
+		assert.fainted(battle.p2.active[0]);
+		assert.equal(battle.winner, 'Player 1');
+	});
+
+	it('should check for a winner after Rough Skin', function () {
+		battle = common.gen(4).createBattle([
+			[
+				{species: 'Shedinja', moves: ['shadowsneak']},
+			],
+			[
+				{species: 'Shedinja', ability: 'roughskin', moves: ['sleeptalk']},
+			],
+		]);
+		battle.makeChoices();
+		assert.fainted(battle.p1.active[0]);
+		assert.fainted(battle.p2.active[0]);
+		assert.equal(battle.winner, '');
+		battle.destroy();
+
+		battle = common.gen(6).createBattle([
+			[
+				{species: 'Shedinja', moves: ['shadowsneak']},
+			],
+			[
+				{species: 'Shedinja', ability: 'roughskin', moves: ['sleeptalk']},
+			],
+		]);
+		battle.makeChoices();
+		assert.fainted(battle.p1.active[0]);
+		assert.fainted(battle.p2.active[0]);
+		assert.equal(battle.winner, 'Player 2');
+		battle.destroy();
+
+		battle = common.gen(7).createBattle([
+			[
+				{species: 'Shedinja', moves: ['shadowsneak']},
+			],
+			[
+				{species: 'Shedinja', ability: 'roughskin', moves: ['sleeptalk']},
+			],
+		]);
+		battle.makeChoices();
+		assert.fainted(battle.p1.active[0]);
+		assert.fainted(battle.p2.active[0]);
+		assert.equal(battle.winner, 'Player 1');
+	});
 });


### PR DESCRIPTION
Only bother checking for a winner if the move's user is also fainted at the time, and check for a winner after the move completes.