### PR TITLE
Fix validator message for LGPE pokemon

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1352,7 +1352,7 @@ export class TeamValidator {
 				return `${tierSpecies.name} does not exist in Gen ${dex.gen}.`;
 			}
 			if (tierSpecies.isNonstandard === 'LGPE') {
-				return `${tierSpecies.name} does not exist in Ultra Sun/Moon, only in Let's Go Pikachu/Eevee.`;
+				return `${tierSpecies.name} does not exist in this game, only in Let's Go Pikachu/Eevee.`;
 			}
 			if (tierSpecies.isNonstandard === 'CAP') {
 				return `${tierSpecies.name} is a CAP and does not exist in this game.`;


### PR DESCRIPTION
changes "does not exist in Ultra Sun/Moon" to "does not exist in this game", since Sword and Shield (and future games) are a thing.