### PR TITLE
Fix Counter redirecting Encored self-target moves

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -4275,6 +4275,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 					// it failed
 					return false;
 				}
+				this.effectState.slot = target.getSlot();
+				this.effectState.user = target;
 				this.effectState.move = move.id;
 				this.add('-start', target, 'Encore');
 				if (!this.queue.willMove(target)) {
@@ -4283,6 +4285,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 			},
 			onOverrideAction(pokemon, target, move) {
 				if (move.id !== this.effectState.move) return this.effectState.move;
+			},
+			onRedirectTargetPriority: 3,
+			onRedirectTarget(target, source, source2, move) {
+				if (move.target !== this.effectState.user && move.target === 'self') {
+					return this.getAtSlot(this.effectState.slot);
+				}
 			},
 			onResidualOrder: 13,
 			onResidual(target) {

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2644,8 +2644,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.effectState.damage = 0;
 			},
 			onRedirectTargetPriority: -1,
-			onRedirectTarget(target, source, source2) {
-				if (source.moveThisTurn !== 'counter') return;
+			onRedirectTarget(target, source, source2, move) {
+				if (move.id !== 'counter') return;
 				if (source !== this.effectState.target || !this.effectState.slot) return;
 				return this.getAtSlot(this.effectState.slot);
 			},

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -11269,8 +11269,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.effectState.damage = 0;
 			},
 			onRedirectTargetPriority: -1,
-			onRedirectTarget(target, source, source2) {
-				if (source.moveThisTurn !== 'mirrorcoat') return;
+			onRedirectTarget(target, source, source2, move) {
+				if (move.id !== 'mirrorcoat') return;
 				if (source !== this.effectState.target || !this.effectState.slot) return;
 				return this.getAtSlot(this.effectState.slot);
 			},

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2645,6 +2645,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			},
 			onRedirectTargetPriority: -1,
 			onRedirectTarget(target, source, source2) {
+				if (source.moveThisTurn !== 'counter') return;
 				if (source !== this.effectState.target || !this.effectState.slot) return;
 				return this.getAtSlot(this.effectState.slot);
 			},
@@ -4285,12 +4286,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 			},
 			onOverrideAction(pokemon, target, move) {
 				if (move.id !== this.effectState.move) return this.effectState.move;
-			},
-			onRedirectTargetPriority: 3,
-			onRedirectTarget(target, source, source2, move) {
-				if (move.target !== this.effectState.user && move.target === 'self') {
-					return this.getAtSlot(this.effectState.slot);
-				}
 			},
 			onResidualOrder: 13,
 			onResidual(target) {
@@ -11275,6 +11270,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			},
 			onRedirectTargetPriority: -1,
 			onRedirectTarget(target, source, source2) {
+				if (source.moveThisTurn !== 'mirrorcoat') return;
 				if (source !== this.effectState.target || !this.effectState.slot) return;
 				return this.getAtSlot(this.effectState.slot);
 			},

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -4276,8 +4276,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 					// it failed
 					return false;
 				}
-				this.effectState.slot = target.getSlot();
-				this.effectState.user = target;
 				this.effectState.move = move.id;
 				this.add('-start', target, 'Encore');
 				if (!this.queue.willMove(target)) {

--- a/test/sim/moves/encore.js
+++ b/test/sim/moves/encore.js
@@ -121,7 +121,7 @@ describe('Encore', function () {
 		assert.notEqual(battle.p2.active[0].hp, hp);
 	});
 
-	it.only(`should not cause self-targeting moves to redirect to the opponent`, function () {
+	it(`should not cause self-targeting moves to redirect to the opponent`, function () {
 		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: "Wynaut", moves: ['destinybond', 'counter']},
 			{species: "Octillery", moves: ['sleeptalk']},
@@ -133,7 +133,6 @@ describe('Encore', function () {
 		battle.makeChoices();
 		// This causes the Counter redirection and Encore redirection to screw up somehow
 		battle.makeChoices('move counter, move sleeptalk', 'move encore 1, move aerialace 1');
-		common.saveReplay(battle, 'encore.js');
 		assert(battle.log.every(line => !line.includes('Raichu|Destiny Bond')));
 	});
 });

--- a/test/sim/moves/encore.js
+++ b/test/sim/moves/encore.js
@@ -121,7 +121,7 @@ describe('Encore', function () {
 		assert.notEqual(battle.p2.active[0].hp, hp);
 	});
 
-	it.skip(`should not cause self-targeting moves to redirect to the opponent`, function () {
+	it.only(`should not cause self-targeting moves to redirect to the opponent`, function () {
 		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: "Wynaut", moves: ['destinybond', 'counter']},
 			{species: "Octillery", moves: ['sleeptalk']},
@@ -131,9 +131,9 @@ describe('Encore', function () {
 		]]);
 
 		battle.makeChoices();
-
 		// This causes the Counter redirection and Encore redirection to screw up somehow
 		battle.makeChoices('move counter, move sleeptalk', 'move encore 1, move aerialace 1');
+		common.saveReplay(battle, 'encore.js');
 		assert(battle.log.every(line => !line.includes('Raichu|Destiny Bond')));
 	});
 });


### PR DESCRIPTION
Counter/mirror coat target redirection carried over because of the decreased priority, this fix makes it so the target is not redirected if the move being used is not counter or mirror coat. 