### PR TITLE
Refactor to new challenge system

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -492,29 +492,13 @@ export const commands: Chat.ChatCommands = {
 		if (!(user1.id in room.users) || !(user2.id in room.users)) {
 			return this.errorReply(`Both users must be in this room.`);
 		}
-		const challenges = [];
-		const user1Challs = Ladders.challenges.get(user1.id);
-		if (user1Challs) {
-			for (const chall of user1Challs) {
-				if (chall.from === user1.id && Users.get(chall.to) === user2) {
-					challenges.push(Utils.html`${user1.name} is challenging ${user2.name} in ${Dex.formats.get(chall.formatid).name}.`);
-					break;
-				}
-			}
-		}
-		const user2Challs = Ladders.challenges.get(user2.id);
-		if (user2Challs) {
-			for (const chall of user2Challs) {
-				if (chall.from === user2.id && Users.get(chall.to) === user1) {
-					challenges.push(Utils.html`${user2.name} is challenging ${user1.name} in ${Dex.formats.get(chall.formatid).name}.`);
-					break;
-				}
-			}
-		}
-		if (!challenges.length) {
+		const chall = Ladders.challenges.search(user1.id, user2.id);
+
+		if (!chall) {
 			return this.sendReplyBox(Utils.html`${user1.name} and ${user2.name} are not challenging each other.`);
 		}
-		this.sendReplyBox(challenges.join(`<br />`));
+		const [from, to] = user1.id === chall.from ? [user1, user2] : [user2, user1];
+		this.sendReplyBox(Utils.html`${from.name} is challenging ${to.name} in ${Dex.formats.get(chall.format).name}.`);
 	},
 	checkchallengeshelp: [`!checkchallenges [user1], [user2] - Check if the specified users are challenging each other. Requires: * @ # &`],
 

--- a/server/global-types.ts
+++ b/server/global-types.ts
@@ -74,3 +74,8 @@ namespace Users {
 	export type User = import('./users').User;
 	export type Connection = import('./users').Connection;
 }
+
+namespace Ladders {
+	export type Challenge = import('./ladders-challenges').Challenge;
+	export type BattleChallenge = import('./ladders-challenges').BattleChallenge;
+}

--- a/server/ladders-challenges.ts
+++ b/server/ladders-challenges.ts
@@ -1,0 +1,188 @@
+import type {ChallengeType} from './room-battle';
+
+/**
+ * A bundle of:
+ - a ID
+ * - a battle format
+ * - a valid team for that format
+ * - misc other preferences for the battle
+ *
+ * To start a battle, you need one of these for every player.
+ */
+export class BattleReady {
+	readonly userid: ID;
+	readonly formatid: string;
+	readonly settings: User['battleSettings'];
+	readonly rating: number;
+	readonly challengeType: ChallengeType;
+	readonly time: number;
+	constructor(
+		userid: ID,
+		formatid: string,
+		settings: User['battleSettings'],
+		rating: number,
+		challengeType: ChallengeType
+	) {
+		this.userid = userid;
+		this.formatid = formatid;
+		this.settings = settings;
+		this.rating = rating;
+		this.challengeType = challengeType;
+		this.time = Date.now();
+	}
+}
+
+export class AbstractChallenge {
+	from: ID;
+	to: ID;
+	ready: BattleReady | null;
+	format: string;
+	acceptCommand: string | null;
+	constructor(from: ID, to: ID, ready: BattleReady | string, acceptCommand: string | null = null) {
+		this.from = from;
+		this.to = to;
+		this.ready = typeof ready === 'string' ? null : ready;
+		this.format = typeof ready === 'string' ? ready : ready.formatid;
+		this.acceptCommand = acceptCommand;
+	}
+}
+export class BattleChallenge extends AbstractChallenge {
+	declare ready: BattleReady;
+	declare acceptCommand: string | null;
+}
+export class GameChallenge extends AbstractChallenge {
+	declare ready: null;
+	declare acceptCommand: string;
+}
+
+/**
+ * The defining difference between a BattleChallenge and a GameChallenge is
+ * that a BattleChallenge has a Ready (and is for a RoomBattle format) and
+ * a GameChallenge doesn't (and is for a RoomGame).
+ *
+ * But remember that both can have a custom acceptCommand.
+ */
+export type Challenge = BattleChallenge | GameChallenge;
+
+/**
+ * Lists outgoing and incoming challenges for each user ID.
+ */
+export class Challenges extends Map<ID, Challenge[]> {
+	getOrCreate(userid: ID): Challenge[] {
+		let challenges = this.get(userid);
+		if (challenges) return challenges;
+		challenges = [];
+		this.set(userid, challenges);
+		return challenges;
+	}
+	/** Returns false if a challenge between these users is already in the table */
+	add(challenge: Challenge): boolean {
+		const oldChallenge = this.search(challenge.to, challenge.from);
+		if (oldChallenge) {
+			return false;
+		}
+		const to = this.getOrCreate(challenge.to);
+		const from = this.getOrCreate(challenge.from);
+		to.push(challenge);
+		from.push(challenge);
+		this.update(challenge.to, challenge.from);
+		return true;
+	}
+	/** Returns false if the challenge isn't in the table */
+	remove(challenge: Challenge): boolean {
+		const to = this.getOrCreate(challenge.to);
+		const from = this.getOrCreate(challenge.from);
+
+		const toIndex = to.indexOf(challenge);
+		let success = false;
+		if (toIndex >= 0) {
+			to.splice(toIndex, 1);
+			if (!to.length) this.delete(challenge.to);
+			success = true;
+		}
+
+		const fromIndex = from.indexOf(challenge);
+		if (fromIndex >= 0) {
+			from.splice(fromIndex, 1);
+			if (!from.length) this.delete(challenge.from);
+		}
+		if (success) this.update(challenge.to, challenge.from);
+		return success;
+	}
+	search(userid1: ID, userid2: ID): Challenge | null {
+		const challenges = this.get(userid1);
+		if (!challenges) return null;
+		for (const challenge of challenges) {
+			if (
+				(challenge.to === userid1 && challenge.from === userid2) ||
+				(challenge.to === userid2 && challenge.from === userid1)
+			) {
+				return challenge;
+			}
+		}
+		return null;
+	}
+	clearFor(userid: ID, reason?: string): number {
+		const user = Users.get(userid);
+		const userIdentity = user ? user.getIdentity() : ` ${userid}`;
+		const challenges = this.get(userid);
+		if (!challenges) return 0;
+		for (const challenge of challenges) {
+			const otherid = challenge.to === userid ? challenge.from : challenge.to;
+			const otherUser = Users.get(otherid);
+			const otherIdentity = otherUser ? otherUser.getIdentity() : ` ${otherid}`;
+
+			const otherChallenges = this.get(otherid)!;
+			const otherIndex = otherChallenges.indexOf(challenge);
+			if (otherIndex >= 0) otherChallenges.splice(otherIndex, 1);
+			if (otherChallenges.length === 0) this.delete(otherid);
+
+			if (!user && !otherUser) continue;
+			const header = `|pm|${userIdentity}|${otherIdentity}|`;
+			let message = `${header}/challenge`;
+			if (reason) message = `${header}/text Challenge cancelled because ${reason}.\n${message}`;
+			user?.send(message);
+			otherUser?.send(message);
+		}
+		this.delete(userid);
+		return challenges.length;
+	}
+	getUpdate(challenge: Challenge | null) {
+		if (!challenge) return `/challenge`;
+		return `/challenge ${challenge.format}|${challenge.ready ? challenge.ready.formatid : ''}`;
+	}
+	update(userid1: ID, userid2: ID) {
+		const challenge = this.search(userid1, userid2);
+		const user1 = Users.get(challenge ? challenge.from : userid1);
+		const user2 = Users.get(challenge ? challenge.to : userid2);
+		const user1Identity = user1 ? user1.getIdentity() : ` ${userid1}`;
+		const user2Identity = user2 ? user2.getIdentity() : ` ${userid2}`;
+		const message = `|pm|${user1Identity}|${user2Identity}|${this.getUpdate(challenge)}`;
+		user1?.send(message);
+		user2?.send(message);
+	}
+	updateFor(connection: Connection | User) {
+		const user = connection.user;
+		const challenges = this.get(user.id);
+		if (!challenges) return;
+
+		const userIdentity = user.getIdentity();
+		let messages = '';
+		for (const challenge of challenges) {
+			let fromIdentity, toIdentity;
+			if (challenge.from === user.id) {
+				fromIdentity = userIdentity;
+				const toUser = Users.get(challenge.to);
+				toIdentity = toUser ? toUser.getIdentity() : ` ${challenge.to}`;
+			} else {
+				const fromUser = Users.get(challenge.from);
+				fromIdentity = fromUser ? fromUser.getIdentity() : ` ${challenge.from}`;
+				toIdentity = userIdentity;
+			}
+			messages += `|pm|${fromIdentity}|${toIdentity}|${this.getUpdate(challenge)}\n`;
+		}
+		connection.send(messages);
+	}
+}
+
+export const challenges = new Challenges();

--- a/server/ladders.ts
+++ b/server/ladders.ts
@@ -16,32 +16,7 @@ const SECONDS = 1000;
 const PERIODIC_MATCH_INTERVAL = 60 * SECONDS;
 
 import type {ChallengeType} from './room-battle';
-
-/**
- * This represents a user's search for a battle under a format.
- */
-class BattleReady {
-	readonly userid: ID;
-	readonly formatid: string;
-	readonly settings: User['battleSettings'];
-	readonly rating: number;
-	readonly challengeType: ChallengeType;
-	readonly time: number;
-	constructor(
-		userid: ID,
-		formatid: string,
-		settings: User['battleSettings'],
-		rating: number,
-		challengeType: ChallengeType
-	) {
-		this.userid = userid;
-		this.formatid = formatid;
-		this.settings = settings;
-		this.rating = rating;
-		this.challengeType = challengeType;
-		this.time = Date.now();
-	}
-}
+import {BattleReady, BattleChallenge, challenges} from './ladders-challenges';
 
 /**
  * Keys are formatids
@@ -51,23 +26,6 @@ const searches = new Map<string, {
 	/** userid:BattleReady */
 	searches: Map<ID, BattleReady>,
 }>();
-
-class Challenge {
-	readonly from: ID;
-	readonly to: string;
-	readonly formatid: string;
-	readonly ready: BattleReady;
-	constructor(ready: BattleReady, to: string) {
-		this.from = ready.userid;
-		this.to = to;
-		this.formatid = ready.formatid;
-		this.ready = ready;
-	}
-}
-/**
- * formatid:userid:BattleReady
- */
-const challenges = new Map<string, Challenge[]>();
 
 /**
  * This keeps track of searches for battles, creating a new battle for a newly
@@ -195,44 +153,6 @@ class Ladder extends LadderStore {
 		return null;
 	}
 
-	static cancelChallenging(user: User) {
-		const chall = Ladder.getChallenging(user.id);
-		if (chall) {
-			Ladder.removeChallenge(chall);
-			return true;
-		}
-		return false;
-	}
-	static rejectChallenge(user: User, targetUsername: string) {
-		const targetUserid = toID(targetUsername);
-		const chall = Ladder.getChallenging(targetUserid);
-		if (chall && chall.to === user.id) {
-			Ladder.removeChallenge(chall);
-			return true;
-		}
-		return false;
-	}
-	static clearChallenges(username: string) {
-		const userid = toID(username);
-		const userChalls = Ladders.challenges.get(userid);
-		if (userChalls) {
-			for (const chall of userChalls.slice()) {
-				let otherUserid;
-				if (chall.from === userid) {
-					otherUserid = chall.to;
-				} else {
-					otherUserid = chall.from;
-				}
-				Ladder.removeChallenge(chall, true);
-				const otherUser = Users.get(otherUserid);
-				if (otherUser) Ladder.updateChallenges(otherUser);
-			}
-			const user = Users.get(userid);
-			if (user) Ladder.updateChallenges(user);
-			return true;
-		}
-		return false;
-	}
 	async makeChallenge(connection: Connection, targetUser: User) {
 		const user = connection.user;
 		if (targetUser === user) {
@@ -265,92 +185,36 @@ class Ladder extends LadderStore {
 		if (!ready) return false;
 		// If our target is already challenging us in the same format,
 		// simply accept the pending challenge instead of creating a new one.
-		const targetChalls = Ladders.challenges.get(targetUser.id);
-		if (targetChalls) {
-			for (const chall of targetChalls) {
-				if (chall.from === targetUser.id &&
-					chall.to === user.id &&
-					chall.formatid === this.formatid) {
-					if (Ladder.removeChallenge(chall)) {
-						Ladders.match([chall.ready, ready]);
-						return true;
-					}
+		const existingChall = Ladders.challenges.search(user.id, targetUser.id);
+		if (existingChall) {
+			if (
+				existingChall.from === targetUser.id &&
+				existingChall.to === user.id &&
+				existingChall.format === this.formatid &&
+				existingChall.ready
+			) {
+				if (Ladders.challenges.remove(existingChall)) {
+					Ladders.match([existingChall.ready, ready]);
+					return true;
 				}
+			} else {
+				connection.popup(`There's already a challenge (${existingChall.format}) between you and ${targetUser.name}!`);
+				Ladders.challenges.update(user.id, targetUser.id);
+				return false;
 			}
 		}
-		Ladder.addChallenge(new Challenge(ready, targetUser.id));
+		Ladders.challenges.add(new BattleChallenge(user.id, targetUser.id, ready));
 		user.lastChallenge = Date.now();
 		return true;
 	}
-	static async acceptChallenge(connection: Connection, targetUser: User) {
-		const chall = Ladder.getChallenging(targetUser.id);
-		if (!chall || chall.to !== connection.user.id) {
-			connection.popup(`${targetUser.id} is not challenging you. Maybe they cancelled before you accepted?`);
-			return false;
-		}
-		const ladder = Ladders(chall.formatid);
+	static async acceptChallenge(connection: Connection, chall: BattleChallenge) {
+		const ladder = Ladders(chall.format);
 		const ready = await ladder.prepBattle(connection, 'challenge');
-		if (!ready) return false;
-		if (Ladder.removeChallenge(chall)) {
-			Ladders.match([chall.ready, ready]);
+		if (!ready) return;
+		if (Ladders.challenges.remove(chall)) {
+			return Ladders.match([chall.ready, ready]);
 		}
-		return true;
-	}
-
-	static addChallenge(challenge: Challenge, skipUpdate = false) {
-		let challs1 = Ladders.challenges.get(challenge.from);
-		if (!challs1) Ladders.challenges.set(challenge.from, challs1 = []);
-		let challs2 = Ladders.challenges.get(challenge.to);
-		if (!challs2) Ladders.challenges.set(challenge.to, challs2 = []);
-		challs1.push(challenge);
-		challs2.push(challenge);
-		if (!skipUpdate) {
-			const fromUser = Users.get(challenge.from);
-			if (fromUser) Ladder.updateChallenges(fromUser);
-			const toUser = Users.get(challenge.to);
-			if (toUser) Ladder.updateChallenges(toUser);
-		}
-	}
-	static removeChallenge(challenge: Challenge, skipUpdate = false) {
-		const fromChalls = Ladders.challenges.get(challenge.from);
-		// the challenge may have been cancelled
-		if (!fromChalls) return false;
-		const fromIndex = fromChalls.indexOf(challenge);
-		if (fromIndex < 0) return false;
-		fromChalls.splice(fromIndex, 1);
-		if (!fromChalls.length) Ladders.challenges.delete(challenge.from);
-		const toChalls = Ladders.challenges.get(challenge.to)!;
-		toChalls.splice(toChalls.indexOf(challenge), 1);
-		if (!toChalls.length) Ladders.challenges.delete(challenge.to);
-		if (!skipUpdate) {
-			const fromUser = Users.get(challenge.from);
-			if (fromUser) Ladder.updateChallenges(fromUser);
-			const toUser = Users.get(challenge.to);
-			if (toUser) Ladder.updateChallenges(toUser);
-		}
-		return true;
-	}
-	static updateChallenges(user: User, connection: Connection | null = null) {
-		if (!user.connected) return;
-		let challengeTo = null;
-		const challengesFrom: {[k: string]: string} = {};
-		const userChalls = Ladders.challenges.get(user.id);
-		if (userChalls) {
-			for (const chall of userChalls) {
-				if (chall.from === user.id) {
-					challengeTo = {
-						to: chall.to,
-						format: chall.formatid,
-					};
-				} else {
-					challengesFrom[chall.from] = chall.formatid;
-				}
-			}
-		}
-		(connection || user).send(`|updatechallenges|` + JSON.stringify({
-			challengesFrom,
-			challengeTo,
-		}));
+		return;
 	}
 
 	cancelSearch(user: User) {
@@ -597,12 +461,12 @@ class Ladder extends LadderStore {
 			for (const ready of readies) {
 				Users.get(ready.userid)?.popup(`Sorry, your opponent ${missingUser} went offline before your battle could start.`);
 			}
-			return false;
+			return undefined;
 		}
 		const format = Dex.formats.get(formatid);
 		const delayedStart = (['multi', 'freeforall'].includes(format.gameType) && players.length === 2) ?
 			'multi' : false;
-		Rooms.createBattle({
+		return Rooms.createBattle({
 			format: formatid,
 			p1: players[0],
 			p2: players[1],
@@ -631,11 +495,7 @@ export const Ladders = Object.assign(getLadder, {
 
 	cancelSearches: Ladder.cancelSearches,
 	updateSearch: Ladder.updateSearch,
-	rejectChallenge: Ladder.rejectChallenge,
 	acceptChallenge: Ladder.acceptChallenge,
-	cancelChallenging: Ladder.cancelChallenging,
-	clearChallenges: Ladder.clearChallenges,
-	updateChallenges: Ladder.updateChallenges,
 	visualizeAll: Ladder.visualizeAll,
 	getSearches: Ladder.getSearches,
 	match: Ladder.match,

--- a/server/users.ts
+++ b/server/users.ts
@@ -316,6 +316,7 @@ export interface UserSettings {
 
 // User
 export class User extends Chat.MessageContext {
+	/** In addition to needing it to implement MessageContext, this is also nice for compatibility with Connection. */
 	readonly user: User;
 	readonly inRooms: Set<RoomID>;
 	/**
@@ -1335,7 +1336,7 @@ export class User extends Chat.MessageContext {
 	cancelReady() {
 		// setting variables because this can't be short-circuited
 		const searchesCancelled = Ladders.cancelSearches(this);
-		const challengesCancelled = Ladders.clearChallenges(this.id);
+		const challengesCancelled = Ladders.challenges.clearFor(this.id, 'they changed their username');
 		if (searchesCancelled || challengesCancelled) {
 			this.popup(`Your searches and challenges have been cancelled because you changed your username.`);
 		}
@@ -1349,7 +1350,7 @@ export class User extends Chat.MessageContext {
 	}
 	updateReady(connection: Connection | null = null) {
 		Ladders.updateSearch(this, connection);
-		Ladders.updateChallenges(this, connection);
+		Ladders.challenges.updateFor(connection || this);
 	}
 	updateSearch(connection: Connection | null = null) {
 		Ladders.updateSearch(this, connection);


### PR DESCRIPTION
Specifically, this is for the challenge system in https://github.com/smogon/pokemon-showdown-client/pull/1799

This refactor moves `Ladders.challenges` into its own file and adds some more functionality to it.

There can now only be one challenge between two users. If two users try to challenge each other simultaneously, the second challenge will fail - you will need to accept or reject the first challenge before you can make the second challenge.

The previous functionality (if you challenge someone to the same format they challenge you to, your challenge will automatically be converted to accepting their challenge) remains. But this should further safeguard against the situation where you get confused and start two battles if you try to challenge each other at the same time.

In addition, it's now possible to put custom challenges into `Ladders.challenges`. For instance, if you want to challenge someone to Rock Paper Scissors, just do:

```ts
Ladders.challenges.add(new GameChallenge(user.id, targetUser.id, "Rock Paper Scissors", `/rps accept`));
```

and the challenge system will handle the rest! This system is flexible enough to support any RoomGame, and even multi battle challenges!