### PR TITLE
Stop defaulting messages to Lobby in protocol

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -38,9 +38,9 @@ Messages from the user to the server are in the form:
 
     ROOMID|TEXT
 
-`ROOMID` can optionally be left blank if the room is irrelevant (for instance, if `TEXT` is a command like
-`/join lobby` where it doesn't matter what room it's sent from, you can
-just send `|/join lobby`.)
+`ROOMID` can optionally be left blank if unneeded (commands like `/join lobby`
+can be sent anywhere). Responses will be sent to a PM box with no username
+(so `|/command` is equivalent to `|/pm &, /command`).
 
 `TEXT` can contain newlines, in which case it'll be treated the same
 way as if each line were sent to the room separately.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -38,8 +38,7 @@ Messages from the user to the server are in the form:
 
     ROOMID|TEXT
 
-`ROOMID` can optionally be left blank if it's the lobby, or if the room
-is irrelevant (for instance, if `TEXT` is a command like
+`ROOMID` can optionally be left blank if the room is irrelevant (for instance, if `TEXT` is a command like
 `/join lobby` where it doesn't matter what room it's sent from, you can
 just send `|/join lobby`.)
 

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -545,11 +545,7 @@ export class CommandContext extends MessageContext {
 		}
 
 		if (this.room && !(this.user.id in this.room.users)) {
-			if (this.room.roomid === 'lobby') {
-				this.room = null;
-			} else {
-				return this.popupReply(`You tried to send "${message}" to the room "${this.room.roomid}" but it failed because you were not in that room.`);
-			}
+			return this.popupReply(`You tried to send "${message}" to the room "${this.room.roomid}" but it failed because you were not in that room.`);
 		}
 
 		if (this.user.statusType === 'idle' && !['unaway', 'unafk', 'back'].includes(this.cmd)) {

--- a/server/users.ts
+++ b/server/users.ts
@@ -1655,8 +1655,9 @@ function socketReceive(worker: ProcessManager.StreamWorker, workerid: number, so
 	const user = connection.user;
 	if (!user) return;
 
-	// The client obviates the room id when sending messages to Lobby by default
-	const roomId = message.slice(0, pipeIndex) || (Rooms.lobby && 'lobby') || '';
+	// LEGACY: The client obviates the room id when sending messages to Lobby by default
+	// now: we do not do that
+	const roomId = message.slice(0, pipeIndex) || '';
 	message = message.slice(pipeIndex + 1);
 
 	const room = Rooms.get(roomId) || null;

--- a/server/users.ts
+++ b/server/users.ts
@@ -1655,8 +1655,8 @@ function socketReceive(worker: ProcessManager.StreamWorker, workerid: number, so
 	const user = connection.user;
 	if (!user) return;
 
-	// LEGACY: The client obviates the room id when sending messages to Lobby by default
-	// now: we do not do that
+	// LEGACY: In the past, an empty room ID would default to Lobby,
+	// but that is no longer supported
 	const roomId = message.slice(0, pipeIndex) || '';
 	message = message.slice(pipeIndex + 1);
 


### PR DESCRIPTION
Zarel description:

In the past, the client would send `|MESSAGE` as a shorthand for `lobby|MESSAGE`. The bandwidth savings are negligible nowadays and we've definitely had bugs arise from this behavior, so the client now consistently sends `lobby|MESSAGE` when sending to Lobby. The server will now always interpret `|MESSAGE` as a room-less command (in the past, it was considered a message to Lobby if you were in Lobby, and a room-less command otherwise).

-----

As per #sim-dev. I believe this should be everything, deployable with the client changes to explicitly send `lobby|message`.