### PR TITLE
Fix Neutralizing Gas ending if another is active

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -2360,6 +2360,14 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			}
 		},
 		onEnd(source) {
+			let nGasActiveElsewhere = false;
+			for (const pokemon of this.getAllActive()) {
+				if (pokemon !== source && pokemon.hasAbility('Neutralizing Gas')) {
+					nGasActiveElsewhere = true;
+					break;
+				}
+			}
+			if (nGasActiveElsewhere) return;
 			this.add('-end', source, 'ability: Neutralizing Gas');
 
 			// FIXME this happens before the pokemon switches out, should be the opposite order.

--- a/test/sim/abilities/neutralizinggas.js
+++ b/test/sim/abilities/neutralizinggas.js
@@ -229,6 +229,19 @@ describe('Neutralizing Gas', function () {
 		assert.equal(firstUnnerveIndex, secondUnnerveIndex, 'Unnerve should have only activated once.');
 	});
 
+	it(`should not announce Neutralizing Gas has worn off, if multiple are active simultenously`, function () {
+		battle = common.createBattle([[
+			{species: "Weezing", ability: 'neutralizinggas', moves: ['sleeptalk']},
+		], [
+			{species: "Weezing", ability: 'neutralizinggas', moves: ['sleeptalk']},
+			{species: "Wynaut", ability: 'intrepidsword', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move sleeptalk', 'switch 2');
+		assert(battle.log.every(line => !line.startsWith('|-end')));
+		assert.statStage(battle.p2.active[0], 'atk', 0);
+	});
+
 	describe(`Ability reactivation order`, function () {
 		it(`should cause entrance Abilities to reactivate in order of Speed`, function () {
 			battle = common.createBattle({gameType: 'doubles'}, [[


### PR DESCRIPTION
Previously, if multiple Neutralizing Gas were active, switching one out would cause the Neutralizing Gas "The effects of the neutralizing gas wore off!" to play when it shouldn't. Ability events were being re-run too unnecessarily (they wouldn't do anything since it was still being negated). Note that it is unlike Primal weather, where Neutralizing Gas _does_ announce itself on switchin, even if the effect is already active.