### PR TITLE
Fix the order of many end-turn resolution effects

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -237,7 +237,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 188,
 	},
 	baddreams: {
-		onResidualOrder: 27,
+		onResidualOrder: 28,
 		onResidualSubOrder: 2,
 		onResidual(pokemon) {
 			if (!pokemon.hp) return;
@@ -1387,7 +1387,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	},
 	harvest: {
 		name: "Harvest",
-		onResidualOrder: 27,
+		onResidualOrder: 28,
 		onResidualSubOrder: 2,
 		onResidual(pokemon) {
 			if (this.field.isWeather(['sunnyday', 'desolateland']) || this.randomChance(1, 2)) {
@@ -1458,7 +1458,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 37,
 	},
 	hungerswitch: {
-		onResidualOrder: 28,
+		onResidualOrder: 29,
 		onResidual(pokemon) {
 			if (pokemon.species.baseSpecies !== 'Morpeko' || pokemon.transformed) return;
 			const targetForme = pokemon.species.name === 'Morpeko' ? 'Morpeko-Hangry' : 'Morpeko';
@@ -2161,7 +2161,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 104,
 	},
 	moody: {
-		onResidualOrder: 27,
+		onResidualOrder: 28,
 		onResidualSubOrder: 2,
 		onResidual(pokemon) {
 			let stats: BoostID[] = [];
@@ -2619,7 +2619,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 124,
 	},
 	pickup: {
-		onResidualOrder: 27,
+		onResidualOrder: 28,
 		onResidualSubOrder: 2,
 		onResidual(pokemon) {
 			if (pokemon.item) return;
@@ -2711,7 +2711,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 143,
 	},
 	powerconstruct: {
-		onResidualOrder: 28,
+		onResidualOrder: 29,
 		onResidual(pokemon) {
 			if (pokemon.baseSpecies.baseSpecies !== 'Zygarde' || pokemon.transformed || !pokemon.hp) return;
 			if (pokemon.species.id === 'zygardecomplete' || pokemon.hp > pokemon.maxhp / 2) return;
@@ -3182,7 +3182,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				}
 			}
 		},
-		onResidualOrder: 28,
+		onResidualOrder: 29,
 		onResidual(pokemon) {
 			if (
 				pokemon.baseSpecies.baseSpecies !== 'Wishiwashi' || pokemon.level < 20 ||
@@ -3347,7 +3347,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				}
 			}
 		},
-		onResidualOrder: 28,
+		onResidualOrder: 29,
 		onResidual(pokemon) {
 			if (pokemon.baseSpecies.baseSpecies !== 'Minior' || pokemon.transformed || !pokemon.hp) return;
 			if (pokemon.hp > pokemon.maxhp / 2) {
@@ -3414,7 +3414,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		},
 		condition: {
 			duration: 5,
-			onResidualOrder: 27,
+			onResidualOrder: 28,
 			onResidualSubOrder: 2,
 			onStart(target) {
 				this.add('-start', target, 'ability: Slow Start');
@@ -3536,7 +3536,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 43,
 	},
 	speedboost: {
-		onResidualOrder: 27,
+		onResidualOrder: 28,
 		onResidualSubOrder: 2,
 		onResidual(pokemon) {
 			if (pokemon.activeTurns) {
@@ -4387,7 +4387,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 147,
 	},
 	zenmode: {
-		onResidualOrder: 28,
+		onResidualOrder: 29,
 		onResidual(pokemon) {
 			if (pokemon.baseSpecies.baseSpecies !== 'Darmanitan' || pokemon.transformed) {
 				return;

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -237,8 +237,8 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 188,
 	},
 	baddreams: {
-		onResidualOrder: 26,
-		onResidualSubOrder: 1,
+		onResidualOrder: 27,
+		onResidualSubOrder: 2,
 		onResidual(pokemon) {
 			if (!pokemon.hp) return;
 			for (const target of pokemon.foes()) {
@@ -1387,8 +1387,8 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	},
 	harvest: {
 		name: "Harvest",
-		onResidualOrder: 26,
-		onResidualSubOrder: 1,
+		onResidualOrder: 27,
+		onResidualSubOrder: 2,
 		onResidual(pokemon) {
 			if (this.field.isWeather(['sunnyday', 'desolateland']) || this.randomChance(1, 2)) {
 				if (pokemon.hp && !pokemon.item && this.dex.items.get(pokemon.lastItem).isBerry) {
@@ -1404,7 +1404,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	healer: {
 		name: "Healer",
 		onResidualOrder: 5,
-		onResidualSubOrder: 4,
+		onResidualSubOrder: 3,
 		onResidual(pokemon) {
 			for (const allyActive of pokemon.adjacentAllies()) {
 				if (allyActive.status && this.randomChance(3, 10)) {
@@ -1458,6 +1458,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 37,
 	},
 	hungerswitch: {
+		onResidualOrder: 28,
 		onResidual(pokemon) {
 			if (pokemon.species.baseSpecies !== 'Morpeko' || pokemon.transformed) return;
 			const targetForme = pokemon.species.name === 'Morpeko' ? 'Morpeko-Hangry' : 'Morpeko';
@@ -1485,7 +1486,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	},
 	hydration: {
 		onResidualOrder: 5,
-		onResidualSubOrder: 4,
+		onResidualSubOrder: 3,
 		onResidual(pokemon) {
 			if (pokemon.status && ['raindance', 'primordialsea'].includes(pokemon.effectiveWeather())) {
 				this.debug('hydration');
@@ -2160,8 +2161,8 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 104,
 	},
 	moody: {
-		onResidualOrder: 26,
-		onResidualSubOrder: 1,
+		onResidualOrder: 27,
+		onResidualSubOrder: 2,
 		onResidual(pokemon) {
 			let stats: BoostID[] = [];
 			const boost: SparseBoostsTable = {};
@@ -2618,8 +2619,8 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 124,
 	},
 	pickup: {
-		onResidualOrder: 26,
-		onResidualSubOrder: 1,
+		onResidualOrder: 27,
+		onResidualSubOrder: 2,
 		onResidual(pokemon) {
 			if (pokemon.item) return;
 			const pickupTargets = this.getAllActive().filter(target => (
@@ -2710,7 +2711,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 143,
 	},
 	powerconstruct: {
-		onResidualOrder: 27,
+		onResidualOrder: 28,
 		onResidual(pokemon) {
 			if (pokemon.baseSpecies.baseSpecies !== 'Zygarde' || pokemon.transformed || !pokemon.hp) return;
 			if (pokemon.species.id === 'zygardecomplete' || pokemon.hp > pokemon.maxhp / 2) return;
@@ -3181,7 +3182,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				}
 			}
 		},
-		onResidualOrder: 27,
+		onResidualOrder: 28,
 		onResidual(pokemon) {
 			if (
 				pokemon.baseSpecies.baseSpecies !== 'Wishiwashi' || pokemon.level < 20 ||
@@ -3285,7 +3286,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	},
 	shedskin: {
 		onResidualOrder: 5,
-		onResidualSubOrder: 4,
+		onResidualSubOrder: 3,
 		onResidual(pokemon) {
 			if (pokemon.hp && pokemon.status && this.randomChance(33, 100)) {
 				this.debug('shed skin');
@@ -3346,7 +3347,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				}
 			}
 		},
-		onResidualOrder: 27,
+		onResidualOrder: 28,
 		onResidual(pokemon) {
 			if (pokemon.baseSpecies.baseSpecies !== 'Minior' || pokemon.transformed || !pokemon.hp) return;
 			if (pokemon.hp > pokemon.maxhp / 2) {
@@ -3413,6 +3414,8 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		},
 		condition: {
 			duration: 5,
+			onResidualOrder: 27,
+			onResidualSubOrder: 2,
 			onStart(target) {
 				this.add('-start', target, 'ability: Slow Start');
 			},
@@ -3533,8 +3536,8 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 43,
 	},
 	speedboost: {
-		onResidualOrder: 26,
-		onResidualSubOrder: 1,
+		onResidualOrder: 27,
+		onResidualSubOrder: 2,
 		onResidual(pokemon) {
 			if (pokemon.activeTurns) {
 				this.boost({spe: 1});
@@ -4384,7 +4387,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 147,
 	},
 	zenmode: {
-		onResidualOrder: 27,
+		onResidualOrder: 28,
 		onResidual(pokemon) {
 			if (pokemon.baseSpecies.baseSpecies !== 'Darmanitan' || pokemon.transformed) {
 				return;

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -12,7 +12,7 @@ export const Conditions: {[k: string]: ConditionData} = {
 			}
 		},
 		// Damage reduction is handled directly in the sim/battle.js damage function
-		onResidualOrder: 9,
+		onResidualOrder: 10,
 		onResidual(pokemon) {
 			this.damage(pokemon.baseMaxhp / 16);
 		},
@@ -214,7 +214,7 @@ export const Conditions: {[k: string]: ConditionData} = {
 			this.add('-activate', pokemon, 'move: ' + this.effectState.sourceEffect, '[of] ' + source);
 			this.effectState.boundDivisor = source.hasItem('bindingband') ? 6 : 8;
 		},
-		onResidualOrder: 11,
+		onResidualOrder: 13,
 		onResidual(pokemon) {
 			const source = this.effectState.source;
 			// G-Max Centiferno and G-Max Sandblast continue even after the user leaves the field

--- a/data/items.ts
+++ b/data/items.ts
@@ -1772,7 +1772,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			basePower: 30,
 			status: 'brn',
 		},
-		onResidualOrder: 27,
+		onResidualOrder: 28,
 		onResidualSubOrder: 3,
 		onResidual(pokemon) {
 			pokemon.trySetStatus('brn', pokemon);
@@ -5300,7 +5300,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		fling: {
 			basePower: 80,
 		},
-		onResidualOrder: 27,
+		onResidualOrder: 28,
 		onResidualSubOrder: 3,
 		onResidual(pokemon) {
 			this.damage(pokemon.baseMaxhp / 8);
@@ -5499,7 +5499,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			basePower: 30,
 			status: 'tox',
 		},
-		onResidualOrder: 27,
+		onResidualOrder: 28,
 		onResidualSubOrder: 3,
 		onResidual(pokemon) {
 			pokemon.trySetStatus('tox', pokemon);

--- a/data/items.ts
+++ b/data/items.ts
@@ -451,7 +451,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			basePower: 30,
 		},
 		onResidualOrder: 5,
-		onResidualSubOrder: 5,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			if (pokemon.hasType('Poison')) {
 				this.heal(pokemon.baseMaxhp / 16);
@@ -1772,8 +1772,8 @@ export const Items: {[itemid: string]: ItemData} = {
 			basePower: 30,
 			status: 'brn',
 		},
-		onResidualOrder: 26,
-		onResidualSubOrder: 2,
+		onResidualOrder: 27,
+		onResidualSubOrder: 3,
 		onResidual(pokemon) {
 			pokemon.trySetStatus('brn', pokemon);
 		},
@@ -2836,7 +2836,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			basePower: 10,
 		},
 		onResidualOrder: 5,
-		onResidualSubOrder: 5,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			this.heal(pokemon.baseMaxhp / 16);
 		},
@@ -5300,8 +5300,8 @@ export const Items: {[itemid: string]: ItemData} = {
 		fling: {
 			basePower: 80,
 		},
-		onResidualOrder: 26,
-		onResidualSubOrder: 2,
+		onResidualOrder: 27,
+		onResidualSubOrder: 3,
 		onResidual(pokemon) {
 			this.damage(pokemon.baseMaxhp / 8);
 		},
@@ -5499,8 +5499,8 @@ export const Items: {[itemid: string]: ItemData} = {
 			basePower: 30,
 			status: 'tox',
 		},
-		onResidualOrder: 26,
-		onResidualSubOrder: 2,
+		onResidualOrder: 27,
+		onResidualSubOrder: 3,
 		onResidual(pokemon) {
 			pokemon.trySetStatus('tox', pokemon);
 		},

--- a/data/mods/gen2/conditions.ts
+++ b/data/mods/gen2/conditions.ts
@@ -68,6 +68,7 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 		onAfterMoveSecondarySelf(pokemon, target, move) {
 			if (move.flags['defrost']) pokemon.cureStatus();
 		},
+		onResidualOrder: 7,
 		onResidual(pokemon) {
 			if (this.randomChance(25, 256)) pokemon.cureStatus();
 		},
@@ -154,6 +155,8 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 		durationCallback(target, source) {
 			return this.random(3, 6);
 		},
+		onResidualOrder: 3,
+		onResidualSubOrder: 1,
 	},
 	lockedmove: {
 		name: 'lockedmove',
@@ -189,8 +192,21 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 			}
 		},
 	},
+	futuremove: {
+		inherit: true,
+		onResidualOrder: 1,
+	},
+	raindance: {
+		inherit: true,
+		onFieldResidualOrder: 2,
+	},
+	sunnyday: {
+		inherit: true,
+		onFieldResidualOrder: 2,
+	},
 	sandstorm: {
 		inherit: true,
+		onFieldResidualOrder: 2,
 		onWeather(target) {
 			this.damage(target.baseMaxhp / 8);
 		},

--- a/data/mods/gen2/items.ts
+++ b/data/mods/gen2/items.ts
@@ -86,6 +86,11 @@ export const Items: {[k: string]: ModdedItemData} = {
 			}
 		},
 	},
+	leftovers: {
+		inherit: true,
+		onResidualOrder: 5,
+		onResidualSubOrder: 1,
+	},
 	lightball: {
 		inherit: true,
 		// In Gen 2 this happens in stat calculation directly.

--- a/data/mods/gen3/abilities.ts
+++ b/data/mods/gen3/abilities.ts
@@ -125,6 +125,17 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			this.addSplit(pokemon.side.id, ['-ability', pokemon, 'Pressure', '[silent]']);
 		},
 	},
+	raindish: {
+		inherit: true,
+		onWeather() {},
+		onResidualOrder: 10,
+		onResidualSubOrder: 3,
+		onResidual(pokemon) {
+			if (['raindance', 'primordialsea'].includes(pokemon.effectiveWeather())) {
+				this.heal(pokemon.baseMaxhp / 16);
+			}
+		},
+	},
 	roughskin: {
 		inherit: true,
 		onDamagingHit(damage, target, source, move) {

--- a/data/mods/gen3/items.ts
+++ b/data/mods/gen3/items.ts
@@ -2,7 +2,8 @@ export const Items: {[k: string]: ModdedItemData} = {
 	aguavberry: {
 		inherit: true,
 		onUpdate() {},
-		onResidualOrder: 5,
+		onResidualOrder: 10,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 2) {
 				pokemon.eatItem();
@@ -12,7 +13,8 @@ export const Items: {[k: string]: ModdedItemData} = {
 	apicotberry: {
 		inherit: true,
 		onUpdate() {},
-		onResidualOrder: 5,
+		onResidualOrder: 10,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4) {
 				pokemon.eatItem();
@@ -22,7 +24,8 @@ export const Items: {[k: string]: ModdedItemData} = {
 	berryjuice: {
 		inherit: true,
 		onUpdate() {},
-		onResidualOrder: 5,
+		onResidualOrder: 10,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 2) {
 				if (this.runEvent('TryHeal', pokemon) && pokemon.useItem()) {
@@ -75,7 +78,8 @@ export const Items: {[k: string]: ModdedItemData} = {
 	figyberry: {
 		inherit: true,
 		onUpdate() {},
-		onResidualOrder: 5,
+		onResidualOrder: 10,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 2) {
 				pokemon.eatItem();
@@ -85,7 +89,8 @@ export const Items: {[k: string]: ModdedItemData} = {
 	ganlonberry: {
 		inherit: true,
 		onUpdate() {},
-		onResidualOrder: 5,
+		onResidualOrder: 10,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4) {
 				pokemon.eatItem();
@@ -103,7 +108,8 @@ export const Items: {[k: string]: ModdedItemData} = {
 	iapapaberry: {
 		inherit: true,
 		onUpdate() {},
-		onResidualOrder: 5,
+		onResidualOrder: 10,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 2) {
 				pokemon.eatItem();
@@ -128,7 +134,8 @@ export const Items: {[k: string]: ModdedItemData} = {
 	lansatberry: {
 		inherit: true,
 		onUpdate() {},
-		onResidualOrder: 5,
+		onResidualOrder: 10,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4) {
 				pokemon.eatItem();
@@ -146,7 +153,8 @@ export const Items: {[k: string]: ModdedItemData} = {
 	liechiberry: {
 		inherit: true,
 		onUpdate() {},
-		onResidualOrder: 5,
+		onResidualOrder: 10,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4) {
 				pokemon.eatItem();
@@ -168,7 +176,8 @@ export const Items: {[k: string]: ModdedItemData} = {
 	magoberry: {
 		inherit: true,
 		onUpdate() {},
-		onResidualOrder: 5,
+		onResidualOrder: 10,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 2) {
 				pokemon.eatItem();
@@ -210,7 +219,8 @@ export const Items: {[k: string]: ModdedItemData} = {
 	oranberry: {
 		inherit: true,
 		onUpdate() {},
-		onResidualOrder: 5,
+		onResidualOrder: 10,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 2) {
 				pokemon.eatItem();
@@ -220,7 +230,8 @@ export const Items: {[k: string]: ModdedItemData} = {
 	petayaberry: {
 		inherit: true,
 		onUpdate() {},
-		onResidualOrder: 5,
+		onResidualOrder: 10,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4) {
 				pokemon.eatItem();
@@ -246,7 +257,8 @@ export const Items: {[k: string]: ModdedItemData} = {
 	salacberry: {
 		inherit: true,
 		onUpdate() {},
-		onResidualOrder: 5,
+		onResidualOrder: 10,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4) {
 				pokemon.eatItem();
@@ -288,7 +300,8 @@ export const Items: {[k: string]: ModdedItemData} = {
 	sitrusberry: {
 		inherit: true,
 		onUpdate() {},
-		onResidualOrder: 5,
+		onResidualOrder: 10,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 2) {
 				pokemon.eatItem();
@@ -317,7 +330,8 @@ export const Items: {[k: string]: ModdedItemData} = {
 	starfberry: {
 		inherit: true,
 		onUpdate() {},
-		onResidualOrder: 5,
+		onResidualOrder: 10,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 4) {
 				pokemon.eatItem();
@@ -335,7 +349,8 @@ export const Items: {[k: string]: ModdedItemData} = {
 	wikiberry: {
 		inherit: true,
 		onUpdate() {},
-		onResidualOrder: 5,
+		onResidualOrder: 10,
+		onResidualSubOrder: 4,
 		onResidual(pokemon) {
 			if (pokemon.hp <= pokemon.maxhp / 2) {
 				pokemon.eatItem();

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -274,7 +274,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onOverrideAction(pokemon) {
 				return this.effectState.move;
 			},
-			onResidualOrder: 13,
+			onResidualOrder: 10,
+			onResidualSubOrder: 14,
 			onResidual(target) {
 				if (
 					target.moves.includes(this.effectState.move) &&
@@ -571,7 +572,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onStart(target) {
 				this.add('-start', target, 'move: Taunt');
 			},
-			onResidualOrder: 12,
+			onResidualOrder: 10,
+			onResidualSubOrder: 15,
 			onEnd(target) {
 				this.add('-end', target, 'move: Taunt', '[silent]');
 			},

--- a/data/mods/gen4/abilities.ts
+++ b/data/mods/gen4/abilities.ts
@@ -15,6 +15,11 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		},
 		rating: 1.5,
 	},
+	baddreams: {
+		inherit: true,
+		onResidualOrder: 10,
+		onResidualSubOrder: 10,
+	},
 	blaze: {
 		onBasePowerPriority: 2,
 		onBasePower(basePower, attacker, defender, move) {
@@ -163,6 +168,17 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 				return accuracy * 0.8;
 			}
 		},
+	},
+	hydration: {
+		onWeather(target, source, effect) {
+			if (effect.id === 'raindance' && target.status) {
+				this.add('-activate', target, 'ability: Hydration');
+				target.cureStatus();
+			}
+		},
+		name: "Hydration",
+		rating: 1.5,
+		num: 93,
 	},
 	insomnia: {
 		inherit: true,
@@ -336,6 +352,11 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			}
 		},
 	},
+	shedskin: {
+		inherit: true,
+		onResidualOrder: 10,
+		onResidualSubOrder: 3,
+	},
 	simple: {
 		onModifyBoost(boosts) {
 			let key: BoostID;
@@ -358,6 +379,11 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 				return accuracy * 0.8;
 			}
 		},
+	},
+	speedboost: {
+		inherit: true,
+		onResidualOrder: 10,
+		onResidualSubOrder: 3,
 	},
 	static: {
 		inherit: true,

--- a/data/mods/gen4/conditions.ts
+++ b/data/mods/gen4/conditions.ts
@@ -1,4 +1,9 @@
 export const Conditions: {[k: string]: ModdedConditionData} = {
+	brn: {
+		inherit: true,
+		onResidualOrder: 10,
+		onResidualSubOrder: 6,
+	},
 	par: {
 		inherit: true,
 		onBeforeMove(pokemon) {
@@ -36,6 +41,16 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 			}
 			return false;
 		},
+	},
+	psn: {
+		inherit: true,
+		onResidualOrder: 10,
+		onResidualSubOrder: 6,
+	},
+	tox: {
+		inherit: true,
+		onResidualOrder: 10,
+		onResidualSubOrder: 6,
 	},
 	confusion: {
 		inherit: true,
@@ -88,12 +103,34 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 			if (source.hasItem('gripclaw')) return 6;
 			return this.random(3, 7);
 		},
+		onResidualOrder: 10,
+		onResidualSubOrder: 9,
+	},
+	futuremove: {
+		inherit: true,
+		onResidualOrder: 11,
 	},
 	stall: {
 		// In gen 3-4, the chance of protect succeeding does not fall below 1/8.
 		// See http://upokecenter.dreamhosters.com/dex/?lang=en&move=182
 		inherit: true,
 		counterMax: 8,
+	},
+	raindance: {
+		inherit: true,
+		onFieldResidualOrder: 8,
+	},
+	sunnyday: {
+		inherit: true,
+		onFieldResidualOrder: 8,
+	},
+	sandstorm: {
+		inherit: true,
+		onFieldResidualOrder: 8,
+	},
+	hail: {
+		inherit: true,
+		onFieldResidualOrder: 8,
 	},
 	// Arceus's true typing for all its formes is Normal, and it's only Multitype
 	// that changes its type, but its formes are specified to be their corresponding

--- a/data/mods/gen4/items.ts
+++ b/data/mods/gen4/items.ts
@@ -16,6 +16,11 @@ export const Items: {[k: string]: ModdedItemData} = {
 			}
 		},
 	},
+	blacksludge: {
+		inherit: true,
+		onResidualOrder: 10,
+		onResidualSubOrder: 4,
+	},
 	brightpowder: {
 		inherit: true,
 		onModifyAccuracyPriority: 5,
@@ -96,6 +101,11 @@ export const Items: {[k: string]: ModdedItemData} = {
 			}
 		},
 	},
+	flameorb: {
+		inherit: true,
+		onResidualOrder: 10,
+		onResidualSubOrder: 20,
+	},
 	focussash: {
 		inherit: true,
 		onDamage() { },
@@ -153,6 +163,11 @@ export const Items: {[k: string]: ModdedItemData} = {
 			this.debug('lax incense - decreasing accuracy');
 			return accuracy * 0.9;
 		},
+	},
+	leftovers: {
+		inherit: true,
+		onResidualOrder: 10,
+		onResidualSubOrder: 4,
 	},
 	lifeorb: {
 		inherit: true,
@@ -285,6 +300,11 @@ export const Items: {[k: string]: ModdedItemData} = {
 			}
 		},
 	},
+	stickybarb: {
+		inherit: true,
+		onResidualOrder: 10,
+		onResidualSubOrder: 20,
+	},
 	thickclub: {
 		inherit: true,
 		onModifyAtk(atk, pokemon) {
@@ -292,6 +312,11 @@ export const Items: {[k: string]: ModdedItemData} = {
 				return this.chainModify(2);
 			}
 		},
+	},
+	toxicorb: {
+		inherit: true,
+		onResidualOrder: 10,
+		onResidualSubOrder: 20,
 	},
 	widelens: {
 		inherit: true,

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -35,6 +35,16 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	aquaring: {
 		inherit: true,
 		flags: {},
+		condition: {
+			onStart(pokemon) {
+				this.add('-start', pokemon, 'Aqua Ring');
+			},
+			onResidualOrder: 10,
+			onResidualSubOrder: 2,
+			onResidual(pokemon) {
+				this.heal(pokemon.baseMaxhp / 16);
+			},
+		},
 	},
 	assist: {
 		inherit: true,
@@ -253,6 +263,16 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				delete move.onHit;
 			}
 		},
+		condition: {
+			onStart(pokemon, source) {
+				this.add('-start', pokemon, 'Curse', '[of] ' + source);
+			},
+			onResidualOrder: 10,
+			onResidualSubOrder: 8,
+			onResidual(pokemon) {
+				this.damage(pokemon.baseMaxhp / 4);
+			},
+		},
 		type: "???",
 	},
 	defog: {
@@ -312,6 +332,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				}
 				return false;
 			},
+			onResidualOrder: 10,
+			onResidualSubOrder: 13,
 			onEnd(pokemon) {
 				this.add('-end', pokemon, 'move: Disable');
 			},
@@ -390,6 +412,18 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				return false;
 			}
 		},
+		condition: {
+			duration: 5,
+			onStart(pokemon) {
+				this.add('-start', pokemon, 'Embargo');
+			},
+			// Item suppression implemented in Pokemon.ignoringItem() within sim/pokemon.js
+			onResidualOrder: 10,
+			onResidualSubOrder: 18,
+			onEnd(pokemon) {
+				this.add('-end', pokemon, 'Embargo');
+			},
+		},
 	},
 	encore: {
 		inherit: true,
@@ -418,7 +452,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onOverrideAction(pokemon) {
 				return this.effectState.move;
 			},
-			onResidualOrder: 13,
+			onResidualOrder: 10,
+			onResidualSubOrder: 14,
 			onResidual(target) {
 				if (
 					target.moves.includes(this.effectState.move) &&
@@ -577,6 +612,78 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		accuracy: 75,
 	},
+	gravity: {
+		inherit: true,
+		condition: {
+			duration: 5,
+			durationCallback(source, effect) {
+				if (source?.hasAbility('persistent')) {
+					this.add('-activate', source, 'ability: Persistent', effect);
+					return 7;
+				}
+				return 5;
+			},
+			onFieldStart() {
+				this.add('-fieldstart', 'move: Gravity');
+				for (const pokemon of this.getAllActive()) {
+					let applies = false;
+					if (pokemon.removeVolatile('bounce') || pokemon.removeVolatile('fly')) {
+						applies = true;
+						this.queue.cancelMove(pokemon);
+						pokemon.removeVolatile('twoturnmove');
+					}
+					if (pokemon.volatiles['skydrop']) {
+						applies = true;
+						this.queue.cancelMove(pokemon);
+
+						if (pokemon.volatiles['skydrop'].source) {
+							this.add('-end', pokemon.volatiles['twoturnmove'].source, 'Sky Drop', '[interrupt]');
+						}
+						pokemon.removeVolatile('skydrop');
+						pokemon.removeVolatile('twoturnmove');
+					}
+					if (pokemon.volatiles['magnetrise']) {
+						applies = true;
+						delete pokemon.volatiles['magnetrise'];
+					}
+					if (pokemon.volatiles['telekinesis']) {
+						applies = true;
+						delete pokemon.volatiles['telekinesis'];
+					}
+					if (applies) this.add('-activate', pokemon, 'move: Gravity');
+				}
+			},
+			onModifyAccuracy(accuracy) {
+				if (typeof accuracy !== 'number') return;
+				return this.chainModify([6840, 4096]);
+			},
+			onDisableMove(pokemon) {
+				for (const moveSlot of pokemon.moveSlots) {
+					if (this.dex.moves.get(moveSlot.id).flags['gravity']) {
+						pokemon.disableMove(moveSlot.id);
+					}
+				}
+			},
+			// groundedness implemented in battle.engine.js:BattlePokemon#isGrounded
+			onBeforeMovePriority: 6,
+			onBeforeMove(pokemon, target, move) {
+				if (move.flags['gravity'] && !move.isZ) {
+					this.add('cant', pokemon, 'move: Gravity', move);
+					return false;
+				}
+			},
+			onModifyMove(move, pokemon, target) {
+				if (move.flags['gravity'] && !move.isZ) {
+					this.add('cant', pokemon, 'move: Gravity', move);
+					return false;
+				}
+			},
+			onFieldResidualOrder: 9,
+			onFieldEnd() {
+				this.add('-fieldend', 'move: Gravity');
+			},
+		},
+	},
 	growth: {
 		inherit: true,
 		onModifyMove() {},
@@ -622,7 +729,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					return false;
 				}
 			},
-			onResidualOrder: 17,
+			onResidualOrder: 10,
+			onResidualSubOrder: 17,
 			onEnd(pokemon) {
 				this.add('-end', pokemon, 'move: Heal Block');
 			},
@@ -682,6 +790,27 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			return false;
 		},
 	},
+	ingrain: {
+		inherit: true,
+		condition: {
+			onStart(pokemon) {
+				this.add('-start', pokemon, 'move: Ingrain');
+			},
+			onResidualOrder: 10,
+			onResidualSubOrder: 1,
+			onResidual(pokemon) {
+				this.heal(pokemon.baseMaxhp / 16);
+			},
+			onTrapPokemon(pokemon) {
+				pokemon.tryTrap();
+			},
+			// groundedness implemented in battle.engine.js:BattlePokemon#isGrounded
+			onDragOut(pokemon) {
+				this.add('-activate', pokemon, 'move: Ingrain');
+				return null;
+			},
+		},
+	},
 	jumpkick: {
 		inherit: true,
 		basePower: 85,
@@ -706,6 +835,27 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		basePower: 130,
 	},
+	leechseed: {
+		inherit: true,
+		condition: {
+			onStart(target) {
+				this.add('-start', target, 'move: Leech Seed');
+			},
+			onResidualOrder: 10,
+			onResidualSubOrder: 5,
+			onResidual(pokemon) {
+				const target = this.getAtSlot(pokemon.volatiles['leechseed'].sourceSlot);
+				if (!target || target.fainted || target.hp <= 0) {
+					this.debug('Nothing to leech into');
+					return;
+				}
+				const damage = this.damage(pokemon.baseMaxhp / 8, pokemon, target);
+				if (damage) {
+					this.heal(damage, target, pokemon);
+				}
+			},
+		},
+	},
 	lightscreen: {
 		inherit: true,
 		condition: {
@@ -728,7 +878,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onSideStart(side) {
 				this.add('-sidestart', side, 'Light Screen');
 			},
-			onSideResidualOrder: 21,
+			onSideResidualOrder: 2,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'Light Screen');
 			},
@@ -750,6 +900,17 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	luckychant: {
 		inherit: true,
 		flags: {},
+		condition: {
+			duration: 5,
+			onSideStart(side) {
+				this.add('-sidestart', side, 'move: Lucky Chant');
+			},
+			onCriticalHit: false,
+			onSideResidualOrder: 6,
+			onSideEnd(side) {
+				this.add('-sideend', side, 'move: Lucky Chant');
+			},
+		},
 	},
 	lunardance: {
 		inherit: true,
@@ -816,8 +977,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onImmunity(type) {
 				if (type === 'Ground') return false;
 			},
-			onResidualOrder: 6,
-			onResidualSubOrder: 9,
+			onResidualOrder: 10,
+			onResidualSubOrder: 16,
 			onEnd(target) {
 				this.add('-end', target, 'Magnet Rise');
 			},
@@ -891,6 +1052,35 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		},
 		target: "self",
 	},
+	mist: {
+		inherit: true,
+		condition: {
+			duration: 5,
+			onBoost(boost, target, source, effect) {
+				if (effect.effectType === 'Move' && effect.infiltrates && !target.isAlly(source)) return;
+				if (source && target !== source) {
+					let showMsg = false;
+					let i: BoostID;
+					for (i in boost) {
+						if (boost[i]! < 0) {
+							delete boost[i];
+							showMsg = true;
+						}
+					}
+					if (showMsg && !(effect as ActiveMove).secondaries) {
+						this.add('-activate', target, 'move: Mist');
+					}
+				}
+			},
+			onSideStart(side) {
+				this.add('-sidestart', side, 'Mist');
+			},
+			onSideResidualOrder: 3,
+			onSideEnd(side) {
+				this.add('-sideend', side, 'Mist');
+			},
+		},
+	},
 	moonlight: {
 		inherit: true,
 		onHit(pokemon) {
@@ -934,6 +1124,23 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			this.actions.useMove('triattack', pokemon);
 		},
 	},
+	nightmare: {
+		inherit: true,
+		condition: {
+			noCopy: true,
+			onStart(pokemon) {
+				if (pokemon.status !== 'slp' && !pokemon.hasAbility('comatose')) {
+					return false;
+				}
+				this.add('-start', pokemon, 'Nightmare');
+			},
+			onResidualOrder: 10,
+			onResidualSubOrder: 7,
+			onResidual(pokemon) {
+				this.damage(pokemon.baseMaxhp / 4);
+			},
+		},
+	},
 	odorsleuth: {
 		inherit: true,
 		flags: {protect: 1, mirror: 1, authentic: 1},
@@ -950,6 +1157,21 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				return 50;
 			}
 			return 100;
+		},
+	},
+	perishsong: {
+		inherit: true,
+		condition: {
+			duration: 4,
+			onEnd(target) {
+				this.add('-start', target, 'perish0');
+				target.faint();
+			},
+			onResidualOrder: 12,
+			onResidual(pokemon) {
+				const duration = pokemon.volatiles['perishsong'].duration;
+				this.add('-start', pokemon, 'perish' + duration);
+			},
 		},
 	},
 	petaldance: {
@@ -1039,7 +1261,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onSideStart(side) {
 				this.add('-sidestart', side, 'Reflect');
 			},
-			onSideResidualOrder: 21,
+			onSideResidualOrder: 1,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'Reflect');
 			},
@@ -1083,6 +1305,46 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			if (bannedTargetAbilities.includes(target.ability) || source.ability === 'multitype') {
 				return false;
 			}
+		},
+	},
+	safeguard: {
+		inherit: true,
+		condition: {
+			duration: 5,
+			durationCallback(target, source, effect) {
+				if (source?.hasAbility('persistent')) {
+					this.add('-activate', source, 'ability: Persistent', effect);
+					return 7;
+				}
+				return 5;
+			},
+			onSetStatus(status, target, source, effect) {
+				if (!effect || !source) return;
+				if (effect.id === 'yawn') return;
+				if (effect.effectType === 'Move' && effect.infiltrates && !target.isAlly(source)) return;
+				if (target !== source) {
+					this.debug('interrupting setStatus');
+					if (effect.id === 'synchronize' || (effect.effectType === 'Move' && !effect.secondaries)) {
+						this.add('-activate', target, 'move: Safeguard');
+					}
+					return null;
+				}
+			},
+			onTryAddVolatile(status, target, source, effect) {
+				if (!effect || !source) return;
+				if (effect.effectType === 'Move' && effect.infiltrates && !target.isAlly(source)) return;
+				if ((status.id === 'confusion' || status.id === 'yawn') && target !== source) {
+					if (effect.effectType === 'Move' && !effect.secondaries) this.add('-activate', target, 'move: Safeguard');
+					return null;
+				}
+			},
+			onSideStart(side) {
+				this.add('-sidestart', side, 'Safeguard');
+			},
+			onSideResidualOrder: 4,
+			onSideEnd(side) {
+				this.add('-sideend', side, 'Safeguard');
+			},
 		},
 	},
 	sandtomb: {
@@ -1261,8 +1523,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onModifySpe(spe) {
 				return spe * 2;
 			},
-			onSideResidualOrder: 21,
-			onSideResidualSubOrder: 4,
+			onSideResidualOrder: 5,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'move: Tailwind');
 			},
@@ -1278,7 +1539,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onStart(target) {
 				this.add('-start', target, 'move: Taunt');
 			},
-			onResidualOrder: 12,
+			onResidualOrder: 10,
+			onResidualSubOrder: 15,
 			onEnd(target) {
 				this.add('-end', target, 'move: Taunt');
 			},
@@ -1345,9 +1607,66 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		flags: {authentic: 1},
 	},
+	trickroom: {
+		inherit: true,
+		condition: {
+			duration: 5,
+			durationCallback(source, effect) {
+				if (source?.hasAbility('persistent')) {
+					this.add('-activate', source, 'ability: Persistent', effect);
+					return 7;
+				}
+				return 5;
+			},
+			onFieldStart(target, source) {
+				this.add('-fieldstart', 'move: Trick Room', '[of] ' + source);
+			},
+			onFieldRestart(target, source) {
+				this.field.removePseudoWeather('trickroom');
+			},
+			// Speed modification is changed in Pokemon.getActionSpeed() in sim/pokemon.js
+			onFieldResidualOrder: 13,
+			onFieldEnd() {
+				this.add('-fieldend', 'move: Trick Room');
+			},
+		},
+	},
 	uproar: {
 		inherit: true,
 		basePower: 50,
+		condition: {
+			duration: 3,
+			onStart(target) {
+				this.add('-start', target, 'Uproar');
+			},
+			onResidual(target) {
+				if (target.volatiles['throatchop']) {
+					target.removeVolatile('uproar');
+					return;
+				}
+				if (target.lastMove && target.lastMove.id === 'struggle') {
+					// don't lock
+					delete target.volatiles['uproar'];
+				}
+				this.add('-start', target, 'Uproar', '[upkeep]');
+			},
+			onResidualOrder: 10,
+			onResidualSubOrder: 11,
+			onEnd(target) {
+				this.add('-end', target, 'Uproar');
+			},
+			onLockMove: 'uproar',
+			onAnySetStatus(status, pokemon) {
+				if (status.id === 'slp') {
+					if (pokemon === this.effectState.target) {
+						this.add('-fail', pokemon, 'slp', '[from] Uproar', '[msg]');
+					} else {
+						this.add('-fail', pokemon, 'slp', '[from] Uproar');
+					}
+					return null;
+				}
+			},
+		},
 	},
 	volttackle: {
 		inherit: true,
@@ -1381,7 +1700,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		slotCondition: 'Wish',
 		condition: {
 			duration: 2,
-			onResidualOrder: 0.5,
+			onResidualOrder: 7,
 			onEnd(target) {
 				if (!target.fainted) {
 					const source = this.effectState.source;
@@ -1412,6 +1731,22 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		basePowerCallback(pokemon, target) {
 			return Math.floor(target.hp * 120 / target.maxhp) + 1;
+		},
+	},
+	yawn: {
+		inherit: true,
+		condition: {
+			noCopy: true, // doesn't get copied by Baton Pass
+			duration: 2,
+			onStart(target, source) {
+				this.add('-start', target, 'move: Yawn', '[of] ' + source);
+			},
+			onResidualOrder: 10,
+			onResidualSubOrder: 19,
+			onEnd(target) {
+				this.add('-end', target, 'move: Yawn', '[silent]');
+				target.trySetStatus('slp', this.effectState.source);
+			},
 		},
 	},
 };

--- a/data/mods/gen5/moves.ts
+++ b/data/mods/gen5/moves.ts
@@ -510,8 +510,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onSideStart(side) {
 				this.add('-sidestart', side, 'move: Light Screen');
 			},
-			onSideResidualOrder: 21,
-			onSideResidualSubOrder: 1,
+			onSideResidualOrder: 26,
+			onSideResidualSubOrder: 2,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'move: Light Screen');
 			},
@@ -711,7 +711,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onSideStart(side) {
 				this.add('-sidestart', side, 'Reflect');
 			},
-			onSideResidualOrder: 21,
+			onSideResidualOrder: 26,
+			onSideResidualSubOrder: 1,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'Reflect');
 			},

--- a/data/mods/gen6/moves.ts
+++ b/data/mods/gen6/moves.ts
@@ -49,7 +49,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onOverrideAction(pokemon, target, move) {
 				if (move.id !== this.effectState.move) return this.effectState.move;
 			},
-			onResidualOrder: 13,
+			onResidualOrder: 16,
 			onResidual(target) {
 				const lockedMoveIndex = target.moves.indexOf(this.effectState.move);
 				if (lockedMoveIndex >= 0 && target.moveSlots[lockedMoveIndex].pp <= 0) {
@@ -141,8 +141,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					this.add('-fieldstart', 'move: Misty Terrain');
 				}
 			},
-			onFieldResidualOrder: 21,
-			onFieldResidualSubOrder: 2,
+			onFieldResidualOrder: 26,
+			onFieldResidualSubOrder: 7,
 			onFieldEnd() {
 				this.add('-fieldend', 'Misty Terrain');
 			},

--- a/data/mods/gen6/moves.ts
+++ b/data/mods/gen6/moves.ts
@@ -141,7 +141,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					this.add('-fieldstart', 'move: Misty Terrain');
 				}
 			},
-			onFieldResidualOrder: 26,
+			onFieldResidualOrder: 27,
 			onFieldResidualSubOrder: 7,
 			onFieldEnd() {
 				this.add('-fieldend', 'Misty Terrain');

--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -209,8 +209,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					this.add('-fieldstart', 'move: Electric Terrain');
 				}
 			},
-			onFieldResidualOrder: 21,
-			onFieldResidualSubOrder: 2,
+			onFieldResidualOrder: 26,
+			onFieldResidualSubOrder: 7,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Electric Terrain');
 			},
@@ -300,6 +300,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				}
 			},
 			onResidualOrder: 5,
+			onResidualSubOrder: 2,
 			onResidual(pokemon) {
 				if (pokemon.isGrounded() && !pokemon.isSemiInvulnerable()) {
 					this.heal(pokemon.baseMaxhp / 16, pokemon, pokemon);
@@ -307,8 +308,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					this.debug(`Pokemon semi-invuln or not grounded; Grassy Terrain skipped`);
 				}
 			},
-			onFieldResidualOrder: 21,
-			onFieldResidualSubOrder: 3,
+			onFieldResidualOrder: 26,
+			onFieldResidualSubOrder: 7,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Grassy Terrain');
 			},
@@ -690,8 +691,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					this.add('-fieldstart', 'move: Psychic Terrain');
 				}
 			},
-			onFieldResidualOrder: 21,
-			onFieldResidualSubOrder: 2,
+			onFieldResidualOrder: 26,
+			onFieldResidualSubOrder: 7,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Psychic Terrain');
 			},

--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -209,7 +209,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					this.add('-fieldstart', 'move: Electric Terrain');
 				}
 			},
-			onFieldResidualOrder: 26,
+			onFieldResidualOrder: 27,
 			onFieldResidualSubOrder: 7,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Electric Terrain');
@@ -308,7 +308,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					this.debug(`Pokemon semi-invuln or not grounded; Grassy Terrain skipped`);
 				}
 			},
-			onFieldResidualOrder: 26,
+			onFieldResidualOrder: 27,
 			onFieldResidualSubOrder: 7,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Grassy Terrain');
@@ -691,7 +691,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					this.add('-fieldstart', 'move: Psychic Terrain');
 				}
 			},
-			onFieldResidualOrder: 26,
+			onFieldResidualOrder: 27,
 			onFieldResidualSubOrder: 7,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Psychic Terrain');

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -19378,7 +19378,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onStart(pokemon, source) {
 				this.effectState.hp = source.maxhp / 2;
 			},
-			onResidualOrder: 3,
+			onResidualOrder: 4,
 			onEnd(target) {
 				if (target && !target.fainted) {
 					const damage = this.heal(this.effectState.hp, target, target);

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -6218,7 +6218,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				if (!target.hasType('Water')) this.damage(target.baseMaxhp / 6, target);
 			},
 			onSideResidualOrder: 21,
-			onSideResidualSubOrder: 1.15,
+			onSideResidualSubOrder: 11,
 			onSideEnd(targetSide) {
 				this.add('-sideend', targetSide, 'G-Max Cannonade');
 			},
@@ -6873,7 +6873,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				if (!target.hasType('Grass')) this.damage(target.baseMaxhp / 6, target);
 			},
 			onSideResidualOrder: 21,
-			onSideResidualSubOrder: 1.15,
+			onSideResidualSubOrder: 11,
 			onSideEnd(targetSide) {
 				this.add('-sideend', targetSide, 'G-Max Vine Lash');
 			},
@@ -6912,7 +6912,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				if (!target.hasType('Rock')) this.damage(target.baseMaxhp / 6, target);
 			},
 			onSideResidualOrder: 21,
-			onSideResidualSubOrder: 1.15,
+			onSideResidualSubOrder: 11,
 			onSideEnd(targetSide) {
 				this.add('-sideend', targetSide, 'G-Max Volcalith');
 			},
@@ -6974,7 +6974,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				if (!target.hasType('Fire')) this.damage(target.baseMaxhp / 6, target);
 			},
 			onSideResidualOrder: 21,
-			onSideResidualSubOrder: 1.15,
+			onSideResidualSubOrder: 11,
 			onSideEnd(targetSide) {
 				this.add('-sideend', targetSide, 'G-Max Wildfire');
 			},

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -802,7 +802,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-sidestart', side, 'move: Aurora Veil');
 			},
 			onSideResidualOrder: 21,
-			onSideResidualSubOrder: 1,
+			onSideResidualSubOrder: 10,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'move: Aurora Veil');
 			},
@@ -2946,7 +2946,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onStart(pokemon, source) {
 				this.add('-start', pokemon, 'Curse', '[of] ' + source);
 			},
-			onResidualOrder: 10,
+			onResidualOrder: 12,
 			onResidual(pokemon) {
 				this.damage(pokemon.baseMaxhp / 4);
 			},
@@ -3334,7 +3334,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				}
 				this.effectState.move = pokemon.lastMove.id;
 			},
-			onResidualOrder: 14,
+			onResidualOrder: 17,
 			onEnd(pokemon) {
 				this.add('-end', pokemon, 'Disable');
 			},
@@ -4118,8 +4118,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 					this.add('-fieldstart', 'move: Electric Terrain');
 				}
 			},
-			onFieldResidualOrder: 21,
-			onFieldResidualSubOrder: 2,
+			onFieldResidualOrder: 26,
+			onFieldResidualSubOrder: 7,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Electric Terrain');
 			},
@@ -4221,7 +4221,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-start', pokemon, 'Embargo');
 			},
 			// Item suppression implemented in Pokemon.ignoringItem() within sim/pokemon.js
-			onResidualOrder: 18,
+			onResidualOrder: 21,
 			onEnd(pokemon) {
 				this.add('-end', pokemon, 'Embargo');
 			},
@@ -4284,7 +4284,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onOverrideAction(pokemon, target, move) {
 				if (move.id !== this.effectState.move) return this.effectState.move;
 			},
-			onResidualOrder: 13,
+			onResidualOrder: 16,
 			onResidual(target) {
 				if (target.moves.includes(this.effectState.move) &&
 					target.moveSlots[target.moves.indexOf(this.effectState.move)].pp <= 0) {
@@ -4919,8 +4919,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onResidual(pokemon) {
 				if (!pokemon.hasType('Fire')) this.damage(pokemon.baseMaxhp / 8, pokemon);
 			},
-			onSideResidualOrder: 5,
-			onSideResidualSubOrder: 1.05,
+			onSideResidualOrder: 21,
+			onSideResidualSubOrder: 8,
 			onSideEnd(targetSide) {
 				this.add('-sideend', targetSide, 'Fire Pledge');
 			},
@@ -6213,11 +6213,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-sidestart', targetSide, 'G-Max Cannonade');
 			},
 			onResidualOrder: 5,
-			onResidualSubOrder: 1.1,
+			onResidualSubOrder: 1,
 			onResidual(target) {
 				if (!target.hasType('Water')) this.damage(target.baseMaxhp / 6, target);
 			},
-			onSideResidualOrder: 5,
+			onSideResidualOrder: 21,
 			onSideResidualSubOrder: 1.15,
 			onSideEnd(targetSide) {
 				this.add('-sideend', targetSide, 'G-Max Cannonade');
@@ -6868,11 +6868,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-sidestart', targetSide, 'G-Max Vine Lash');
 			},
 			onResidualOrder: 5,
-			onResidualSubOrder: 1.1,
+			onResidualSubOrder: 1,
 			onResidual(target) {
 				if (!target.hasType('Grass')) this.damage(target.baseMaxhp / 6, target);
 			},
-			onSideResidualOrder: 5,
+			onSideResidualOrder: 21,
 			onSideResidualSubOrder: 1.15,
 			onSideEnd(targetSide) {
 				this.add('-sideend', targetSide, 'G-Max Vine Lash');
@@ -6907,11 +6907,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-sidestart', targetSide, 'G-Max Volcalith');
 			},
 			onResidualOrder: 5,
-			onResidualSubOrder: 1.1,
+			onResidualSubOrder: 1,
 			onResidual(target) {
 				if (!target.hasType('Rock')) this.damage(target.baseMaxhp / 6, target);
 			},
-			onSideResidualOrder: 5,
+			onSideResidualOrder: 21,
 			onSideResidualSubOrder: 1.15,
 			onSideEnd(targetSide) {
 				this.add('-sideend', targetSide, 'G-Max Volcalith');
@@ -6969,11 +6969,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-sidestart', targetSide, 'G-Max Wildfire');
 			},
 			onResidualOrder: 5,
-			onResidualSubOrder: 1.1,
+			onResidualSubOrder: 1,
 			onResidual(target) {
 				if (!target.hasType('Fire')) this.damage(target.baseMaxhp / 6, target);
 			},
-			onSideResidualOrder: 5,
+			onSideResidualOrder: 21,
 			onSideResidualSubOrder: 1.15,
 			onSideEnd(targetSide) {
 				this.add('-sideend', targetSide, 'G-Max Wildfire');
@@ -7120,6 +7120,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onSideStart(targetSide) {
 				this.add('-sidestart', targetSide, 'Grass Pledge');
 			},
+			onSideResidualOrder: 21,
+			onSideResidualSubOrder: 9,
 			onSideEnd(targetSide) {
 				this.add('-sideend', targetSide, 'Grass Pledge');
 			},
@@ -7206,6 +7208,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				}
 			},
 			onResidualOrder: 5,
+			onResidualSubOrder: 2,
 			onResidual(pokemon) {
 				if (pokemon.isGrounded() && !pokemon.isSemiInvulnerable()) {
 					this.heal(pokemon.baseMaxhp / 16, pokemon, pokemon);
@@ -7213,8 +7216,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 					this.debug(`Pokemon semi-invuln or not grounded; Grassy Terrain skipped`);
 				}
 			},
-			onFieldResidualOrder: 21,
-			onFieldResidualSubOrder: 3,
+			onFieldResidualOrder: 26,
+			onFieldResidualSubOrder: 7,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Grassy Terrain');
 			},
@@ -7322,7 +7325,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 					return false;
 				}
 			},
-			onFieldResidualOrder: 22,
+			onFieldResidualOrder: 26,
+			onFieldResidualSubOrder: 2,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Gravity');
 			},
@@ -7772,7 +7776,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					return false;
 				}
 			},
-			onResidualOrder: 17,
+			onResidualOrder: 20,
 			onEnd(pokemon) {
 				this.add('-end', pokemon, 'move: Heal Block');
 			},
@@ -9695,7 +9699,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-sidestart', side, 'move: Light Screen');
 			},
 			onSideResidualOrder: 21,
-			onSideResidualSubOrder: 1,
+			onSideResidualSubOrder: 2,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'move: Light Screen');
 			},
@@ -9872,7 +9876,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			},
 			onCriticalHit: false,
 			onSideResidualOrder: 21,
-			onSideResidualSubOrder: 5,
+			onSideResidualSubOrder: 6,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'move: Lucky Chant'); // "[side.name]'s team's Lucky Chant wore off!"
 			},
@@ -10079,7 +10083,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.field.removePseudoWeather('magicroom');
 			},
 			// Item suppression implemented in Pokemon.ignoringItem() within sim/pokemon.js
-			onFieldResidualOrder: 25,
+			onFieldResidualOrder: 26,
+			onFieldResidualSubOrder: 6,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Magic Room', '[of] ' + this.effectState.source);
 			},
@@ -10175,7 +10180,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onImmunity(type) {
 				if (type === 'Ground') return false;
 			},
-			onResidualOrder: 15,
+			onResidualOrder: 18,
 			onEnd(target) {
 				this.add('-end', target, 'Magnet Rise');
 			},
@@ -11358,7 +11363,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-sidestart', side, 'Mist');
 			},
 			onSideResidualOrder: 21,
-			onSideResidualSubOrder: 3,
+			onSideResidualSubOrder: 4,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'Mist');
 			},
@@ -11454,8 +11459,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 					this.add('-fieldstart', 'move: Misty Terrain');
 				}
 			},
-			onFieldResidualOrder: 21,
-			onFieldResidualSubOrder: 2,
+			onFieldResidualOrder: 26,
+			onFieldResidualSubOrder: 7,
 			onFieldEnd() {
 				this.add('-fieldend', 'Misty Terrain');
 			},
@@ -11643,7 +11648,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 					return this.chainModify([1352, 4096]);
 				}
 			},
-			onFieldResidualOrder: 21,
+			onFieldResidualOrder: 26,
+			onFieldResidualSubOrder: 4,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Mud Sport');
 			},
@@ -11880,7 +11886,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				}
 				this.add('-start', pokemon, 'Nightmare');
 			},
-			onResidualOrder: 9,
+			onResidualOrder: 11,
 			onResidual(pokemon) {
 				this.damage(pokemon.baseMaxhp / 4);
 			},
@@ -12115,7 +12121,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onStart(pokemon, source) {
 				this.add('-start', pokemon, 'move: Octolock', '[of] ' + source);
 			},
-			onResidualOrder: 11,
+			onResidualOrder: 14,
 			onResidual(pokemon) {
 				const source = this.effectState.source;
 				if (source && (!source.isActive || source.hp <= 0 || !source.activeTurns)) {
@@ -12414,7 +12420,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-start', target, 'perish0');
 				target.faint();
 			},
-			onResidualOrder: 20,
+			onResidualOrder: 24,
 			onResidual(pokemon) {
 				const duration = pokemon.volatiles['perishsong'].duration;
 				this.add('-start', pokemon, 'perish' + duration);
@@ -13236,8 +13242,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 					this.add('-fieldstart', 'move: Psychic Terrain');
 				}
 			},
-			onFieldResidualOrder: 21,
-			onFieldResidualSubOrder: 2,
+			onFieldResidualOrder: 26,
+			onFieldResidualSubOrder: 7,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Psychic Terrain');
 			},
@@ -13864,6 +13870,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-sidestart', side, 'Reflect');
 			},
 			onSideResidualOrder: 21,
+			onSideResidualSubOrder: 1,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'Reflect');
 			},
@@ -14410,7 +14417,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		},
 		condition: {
 			duration: 1,
-			onResidualOrder: 20,
+			onResidualOrder: 25,
 			onStart(target) {
 				this.add('-singleturn', target, 'move: Roost');
 			},
@@ -14566,7 +14573,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-sidestart', side, 'Safeguard');
 			},
 			onSideResidualOrder: 21,
-			onSideResidualSubOrder: 2,
+			onSideResidualSubOrder: 3,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'Safeguard');
 			},
@@ -17644,7 +17651,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				return this.chainModify(2);
 			},
 			onSideResidualOrder: 21,
-			onSideResidualSubOrder: 4,
+			onSideResidualSubOrder: 5,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'move: Tailwind');
 			},
@@ -17717,7 +17724,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				}
 				this.add('-start', target, 'move: Taunt');
 			},
-			onResidualOrder: 12,
+			onResidualOrder: 15,
 			onEnd(target) {
 				this.add('-end', target, 'move: Taunt');
 			},
@@ -17885,7 +17892,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					this.add('-end', pokemon, 'Telekinesis', '[silent]');
 				}
 			},
-			onResidualOrder: 16,
+			onResidualOrder: 19,
 			onEnd(target) {
 				this.add('-end', target, 'Telekinesis');
 			},
@@ -18547,7 +18554,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.field.removePseudoWeather('trickroom');
 			},
 			// Speed modification is changed in Pokemon.getActionSpeed() in sim/pokemon.js
-			onFieldResidualOrder: 23,
+			onFieldResidualOrder: 26,
+			onFieldResidualSubOrder: 1,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Trick Room');
 			},
@@ -18758,6 +18766,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 				}
 				this.add('-start', target, 'Uproar', '[upkeep]');
 			},
+			onResidualOrder: 27,
+			onResidualSubOrder: 1,
 			onEnd(target) {
 				this.add('-end', target, 'Uproar');
 			},
@@ -19051,6 +19061,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onSideStart(targetSide) {
 				this.add('-sidestart', targetSide, 'Water Pledge');
 			},
+			onSideResidualOrder: 21,
+			onSideResidualSubOrder: 7,
 			onSideEnd(targetSide) {
 				this.add('-sideend', targetSide, 'Water Pledge');
 			},
@@ -19131,7 +19143,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 					return this.chainModify([1352, 4096]);
 				}
 			},
-			onFieldResidualOrder: 21,
+			onFieldResidualOrder: 26,
+			onFieldResidualSubOrder: 3,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Water Sport');
 			},
@@ -19425,7 +19438,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.field.removePseudoWeather('wonderroom');
 			},
 			// Swapping defenses implemented in sim/pokemon.js:Pokemon#calculateStat and Pokemon#getStat
-			onFieldResidualOrder: 24,
+			onFieldResidualOrder: 26,
+			onFieldResidualSubOrder: 5,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Wonder Room');
 			},
@@ -19578,7 +19592,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onStart(target, source) {
 				this.add('-start', target, 'move: Yawn', '[of] ' + source);
 			},
-			onResidualOrder: 19,
+			onResidualOrder: 23,
 			onEnd(target) {
 				this.add('-end', target, 'move: Yawn', '[silent]');
 				target.trySetStatus('slp', this.effectState.source);

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -9698,7 +9698,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onSideStart(side) {
 				this.add('-sidestart', side, 'move: Light Screen');
 			},
-		onSideResidualOrder: 26,
+			onSideResidualOrder: 26,
 			onSideResidualSubOrder: 2,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'move: Light Screen');
@@ -19061,7 +19061,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onSideStart(targetSide) {
 				this.add('-sidestart', targetSide, 'Water Pledge');
 			},
-		onSideResidualOrder: 26,
+			onSideResidualOrder: 26,
 			onSideResidualSubOrder: 7,
 			onSideEnd(targetSide) {
 				this.add('-sideend', targetSide, 'Water Pledge');

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -19378,7 +19378,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onStart(pokemon, source) {
 				this.effectState.hp = source.maxhp / 2;
 			},
-			onResidualOrder: 4,
+			onResidualOrder: 3,
 			onEnd(target) {
 				if (target && !target.fainted) {
 					const damage = this.heal(this.effectState.hp, target, target);

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -801,7 +801,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onSideStart(side) {
 				this.add('-sidestart', side, 'move: Aurora Veil');
 			},
-			onSideResidualOrder: 21,
+			onSideResidualOrder: 26,
 			onSideResidualSubOrder: 10,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'move: Aurora Veil');
@@ -4118,7 +4118,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					this.add('-fieldstart', 'move: Electric Terrain');
 				}
 			},
-			onFieldResidualOrder: 26,
+			onFieldResidualOrder: 27,
 			onFieldResidualSubOrder: 7,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Electric Terrain');
@@ -4919,7 +4919,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onResidual(pokemon) {
 				if (!pokemon.hasType('Fire')) this.damage(pokemon.baseMaxhp / 8, pokemon);
 			},
-			onSideResidualOrder: 21,
+			onSideResidualOrder: 26,
 			onSideResidualSubOrder: 8,
 			onSideEnd(targetSide) {
 				this.add('-sideend', targetSide, 'Fire Pledge');
@@ -6217,7 +6217,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onResidual(target) {
 				if (!target.hasType('Water')) this.damage(target.baseMaxhp / 6, target);
 			},
-			onSideResidualOrder: 21,
+			onSideResidualOrder: 26,
 			onSideResidualSubOrder: 11,
 			onSideEnd(targetSide) {
 				this.add('-sideend', targetSide, 'G-Max Cannonade');
@@ -6872,7 +6872,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onResidual(target) {
 				if (!target.hasType('Grass')) this.damage(target.baseMaxhp / 6, target);
 			},
-			onSideResidualOrder: 21,
+			onSideResidualOrder: 26,
 			onSideResidualSubOrder: 11,
 			onSideEnd(targetSide) {
 				this.add('-sideend', targetSide, 'G-Max Vine Lash');
@@ -6911,7 +6911,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onResidual(target) {
 				if (!target.hasType('Rock')) this.damage(target.baseMaxhp / 6, target);
 			},
-			onSideResidualOrder: 21,
+			onSideResidualOrder: 26,
 			onSideResidualSubOrder: 11,
 			onSideEnd(targetSide) {
 				this.add('-sideend', targetSide, 'G-Max Volcalith');
@@ -6973,7 +6973,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onResidual(target) {
 				if (!target.hasType('Fire')) this.damage(target.baseMaxhp / 6, target);
 			},
-			onSideResidualOrder: 21,
+			onSideResidualOrder: 26,
 			onSideResidualSubOrder: 11,
 			onSideEnd(targetSide) {
 				this.add('-sideend', targetSide, 'G-Max Wildfire');
@@ -7120,7 +7120,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onSideStart(targetSide) {
 				this.add('-sidestart', targetSide, 'Grass Pledge');
 			},
-			onSideResidualOrder: 21,
+			onSideResidualOrder: 26,
 			onSideResidualSubOrder: 9,
 			onSideEnd(targetSide) {
 				this.add('-sideend', targetSide, 'Grass Pledge');
@@ -7216,7 +7216,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					this.debug(`Pokemon semi-invuln or not grounded; Grassy Terrain skipped`);
 				}
 			},
-			onFieldResidualOrder: 26,
+			onFieldResidualOrder: 27,
 			onFieldResidualSubOrder: 7,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Grassy Terrain');
@@ -7325,7 +7325,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					return false;
 				}
 			},
-			onFieldResidualOrder: 26,
+			onFieldResidualOrder: 27,
 			onFieldResidualSubOrder: 2,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Gravity');
@@ -9698,7 +9698,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onSideStart(side) {
 				this.add('-sidestart', side, 'move: Light Screen');
 			},
-			onSideResidualOrder: 21,
+		onSideResidualOrder: 26,
 			onSideResidualSubOrder: 2,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'move: Light Screen');
@@ -9875,7 +9875,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-sidestart', side, 'move: Lucky Chant'); // "The Lucky Chant shielded [side.name]'s team from critical hits!"
 			},
 			onCriticalHit: false,
-			onSideResidualOrder: 21,
+			onSideResidualOrder: 26,
 			onSideResidualSubOrder: 6,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'move: Lucky Chant'); // "[side.name]'s team's Lucky Chant wore off!"
@@ -10083,7 +10083,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.field.removePseudoWeather('magicroom');
 			},
 			// Item suppression implemented in Pokemon.ignoringItem() within sim/pokemon.js
-			onFieldResidualOrder: 26,
+			onFieldResidualOrder: 27,
 			onFieldResidualSubOrder: 6,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Magic Room', '[of] ' + this.effectState.source);
@@ -11362,7 +11362,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onSideStart(side) {
 				this.add('-sidestart', side, 'Mist');
 			},
-			onSideResidualOrder: 21,
+			onSideResidualOrder: 26,
 			onSideResidualSubOrder: 4,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'Mist');
@@ -11459,7 +11459,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					this.add('-fieldstart', 'move: Misty Terrain');
 				}
 			},
-			onFieldResidualOrder: 26,
+			onFieldResidualOrder: 27,
 			onFieldResidualSubOrder: 7,
 			onFieldEnd() {
 				this.add('-fieldend', 'Misty Terrain');
@@ -11648,7 +11648,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					return this.chainModify([1352, 4096]);
 				}
 			},
-			onFieldResidualOrder: 26,
+			onFieldResidualOrder: 27,
 			onFieldResidualSubOrder: 4,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Mud Sport');
@@ -13242,7 +13242,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					this.add('-fieldstart', 'move: Psychic Terrain');
 				}
 			},
-			onFieldResidualOrder: 26,
+			onFieldResidualOrder: 27,
 			onFieldResidualSubOrder: 7,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Psychic Terrain');
@@ -13869,7 +13869,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onSideStart(side) {
 				this.add('-sidestart', side, 'Reflect');
 			},
-			onSideResidualOrder: 21,
+			onSideResidualOrder: 26,
 			onSideResidualSubOrder: 1,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'Reflect');
@@ -14572,7 +14572,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onSideStart(side) {
 				this.add('-sidestart', side, 'Safeguard');
 			},
-			onSideResidualOrder: 21,
+			onSideResidualOrder: 26,
 			onSideResidualSubOrder: 3,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'Safeguard');
@@ -17650,7 +17650,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onModifySpe(spe, pokemon) {
 				return this.chainModify(2);
 			},
-			onSideResidualOrder: 21,
+			onSideResidualOrder: 26,
 			onSideResidualSubOrder: 5,
 			onSideEnd(side) {
 				this.add('-sideend', side, 'move: Tailwind');
@@ -18554,7 +18554,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.field.removePseudoWeather('trickroom');
 			},
 			// Speed modification is changed in Pokemon.getActionSpeed() in sim/pokemon.js
-			onFieldResidualOrder: 26,
+			onFieldResidualOrder: 27,
 			onFieldResidualSubOrder: 1,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Trick Room');
@@ -18766,7 +18766,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				}
 				this.add('-start', target, 'Uproar', '[upkeep]');
 			},
-			onResidualOrder: 27,
+			onResidualOrder: 28,
 			onResidualSubOrder: 1,
 			onEnd(target) {
 				this.add('-end', target, 'Uproar');
@@ -19061,7 +19061,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onSideStart(targetSide) {
 				this.add('-sidestart', targetSide, 'Water Pledge');
 			},
-			onSideResidualOrder: 21,
+		onSideResidualOrder: 26,
 			onSideResidualSubOrder: 7,
 			onSideEnd(targetSide) {
 				this.add('-sideend', targetSide, 'Water Pledge');
@@ -19143,7 +19143,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					return this.chainModify([1352, 4096]);
 				}
 			},
-			onFieldResidualOrder: 26,
+			onFieldResidualOrder: 27,
 			onFieldResidualSubOrder: 3,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Water Sport');
@@ -19438,7 +19438,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.field.removePseudoWeather('wonderroom');
 			},
 			// Swapping defenses implemented in sim/pokemon.js:Pokemon#calculateStat and Pokemon#getStat
-			onFieldResidualOrder: 26,
+			onFieldResidualOrder: 27,
 			onFieldResidualSubOrder: 5,
 			onFieldEnd() {
 				this.add('-fieldend', 'move: Wonder Room');

--- a/test/sim/misc/weather.js
+++ b/test/sim/misc/weather.js
@@ -47,4 +47,46 @@ describe('Weather damage calculation', function () {
 		assert.equal(p1active.hp, p1active.maxhp);
 		assert.notEqual(p2active.hp, p2active.maxhp);
 	});
+
+	it(`should wear off on the final turn before weather effects are applied`, function () {
+		battle = common.createBattle([[
+			{species: 'Tyranitar', ability: 'sandstream', moves: ['sleeptalk']},
+		], [
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		]]);
+
+		for (let i = 0; i < 5; i++) battle.makeChoices();
+		const wynaut = battle.p2.active[0];
+		assert.equal(wynaut.hp, wynaut.maxhp - (Math.floor(wynaut.maxhp / 16) * 4));
+	});
+
+	it(`should wear off before future attacks`, function () {
+		battle = common.createBattle([[
+			{species: 'Tyranitar', ability: 'sandstream', moves: ['doomdesire', 'soak']},
+		], [
+			{species: 'Roggenrola', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		battle.makeChoices();
+		battle.makeChoices('move soak', 'auto');
+		const log = battle.getDebugLog();
+		const sandDamageIndex = log.indexOf('[from] Sandstorm');
+		const futureDamageIndex = log.indexOf('|-end|p2a: Roggenrola|move: Doom Desire');
+		assert(sandDamageIndex < futureDamageIndex, `Sandstorm should have dealt damage before Doom Desire`);
+	});
+
+	it(`should run residual weather effects in order of Speed`, function () {
+		battle = common.createBattle([[
+			{species: 'Sunkern', ability: 'solarpower', moves: ['sunnyday']},
+		], [
+			{species: 'Charizard', ability: 'dryskin', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		const log = battle.getDebugLog();
+		const drySkinIndex = log.indexOf('ability: Dry Skin');
+		const solarPowerIndex = log.indexOf('ability: Solar Power');
+		assert(drySkinIndex < solarPowerIndex, `Charizard should be damaged before Sunkern, because it is faster`);
+	});
 });

--- a/test/sim/moves/gmaxvolcalith.js
+++ b/test/sim/moves/gmaxvolcalith.js
@@ -95,4 +95,18 @@ describe('G-Max Volcalith', function () {
 		const toxicroak = battle.p2.active[0];
 		assert.equal(toxicroak.hp, toxicroak.maxhp - Math.floor(toxicroak.maxhp / 6) + Math.floor(toxicroak.maxhp / 16));
 	});
+
+	it(`should deal damage before Grassy Terrain recovery`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Coalossal', moves: ['sleeptalk', 'rockthrow'], gigantamax: true},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		], [
+			{species: 'Rillaboom', ability: 'grassysurge', moves: ['sleeptalk']},
+			{species: 'Boldore', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move rockthrow 2 dynamax, move sleeptalk', 'move sleeptalk, move sleeptalk');
+		const rillaboom = battle.p2.active[0];
+		assert.equal(rillaboom.hp, rillaboom.maxhp - Math.floor(rillaboom.maxhp / 6) + Math.floor(rillaboom.maxhp / 16));
+	});
 });


### PR DESCRIPTION
I noticed Grassy Terrain was happening before Volcalith because of it missing an ``onResidualSubOrder``, decided to audit the rest of the end-turn resolution order numbers and got to fix quite a few. List is partially based on my [post from October 2019](https://www.smogon.com/forums/threads/ultra-sun-ultra-moon-battle-mechanics-research-read-post-2.3620030/post-8264465) as well as notes from [new USUM research](https://github.com/smogon/pokemon-showdown/pull/8222#issuecomment-825941312). As far as new effects go:
- Octolock is sandwiched between binding moves and Taunt according to Zaggyo
- G-Max chip _technically_ doesn't have an ending message on cart, but there's no way it's anything but the same block as Pledge moves / screens etc. I just gave it values higher than Aurora Veil.

I did not touch mods (like SSB) or anything before Gen 5, but these orders should be backported into Gens 5-7.