### PR TITLE
Add various mechanics tests

### DIFF
--- a/data/items.ts
+++ b/data/items.ts
@@ -3398,6 +3398,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			onModifyDamage(damage, source, target, move) {
 				const dmgMod = [4096, 4915, 5734, 6553, 7372, 8192];
 				const numConsecutive = this.effectState.numConsecutive > 5 ? 5 : this.effectState.numConsecutive;
+				this.debug(`Current Metronome boost: ${dmgMod[numConsecutive]}/4096`);
 				return this.chainModify([dmgMod[numConsecutive], 4096]);
 			},
 		},

--- a/test/sim/abilities/berserk.js
+++ b/test/sim/abilities/berserk.js
@@ -12,9 +12,9 @@ describe('Berserk', function () {
 
 	it(`should activate prior to healing from Sitrus Berry`, function () {
 		battle = common.createBattle([[
-			{species: "Drampa", item: 'sitrusberry', ability: 'berserk', evs: {hp: 4}, moves: ['sleeptalk']},
+			{species: 'drampa', item: 'sitrusberry', ability: 'berserk', evs: {hp: 4}, moves: ['sleeptalk']},
 		], [
-			{species: "wynaut", ability: 'compoundeyes', moves: ['superfang']},
+			{species: 'wynaut', ability: 'compoundeyes', moves: ['superfang']},
 		]]);
 
 		battle.makeChoices();
@@ -25,14 +25,28 @@ describe('Berserk', function () {
 
 	it(`should not activate prior to healing from Sitrus Berry after a multi-hit move`, function () {
 		battle = common.createBattle([[
-			{species: "Drampa", item: 'sitrusberry', ability: 'berserk', evs: {hp: 4}, moves: ['sleeptalk']},
+			{species: 'drampa', item: 'sitrusberry', ability: 'berserk', evs: {hp: 4}, moves: ['sleeptalk']},
 		], [
-			{species: "wynaut", ability: 'parentalbond', moves: ['seismictoss']},
+			{species: 'wynaut', ability: 'parentalbond', moves: ['seismictoss']},
 		]]);
 
 		battle.makeChoices();
 		const drampa = battle.p1.active[0];
 		assert.statStage(drampa, 'spa', 0);
 		assert.equal(drampa.hp, drampa.maxhp - 200 + Math.floor(drampa.maxhp / 4));
+	});
+
+	it.skip(`should not activate below 50% HP if it was damaged by Dragon Darts`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'drampa', ability: 'berserk', evs: {hp: 4}, moves: ['sleeptalk']},
+			{species: 'togedemaru', ability: 'compoundeyes', moves: ['superfang']},
+		], [
+			{species: 'wynaut', moves: ['dragondarts']},
+			{species: 'shuckle', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move sleeptalk, move superfang -1', 'auto');
+		const drampa = battle.p1.active[0];
+		assert.statStage(drampa, 'spa', 1);
 	});
 });

--- a/test/sim/abilities/flowerveil.js
+++ b/test/sim/abilities/flowerveil.js
@@ -11,17 +11,36 @@ describe('Flower Veil', function () {
 		battle.destroy();
 	});
 
-	it('should not stop an ally from falling asleep when Yawn was already affecting it', function () {
-		battle = common.createBattle({gameType: 'doubles'});
-		battle.setPlayer('p1', {team: [
+	it(`should block status conditions and stat drops on Grass-type Pokemon and its allies`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Breloom', moves: ['sleeptalk']},
+			{species: 'Venusaur', ability: 'flowerveil', moves: ['sleeptalk']},
+		], [
+			{species: 'Persian', moves: ['sandattack']},
+			{species: 'Raticate', moves: ['glare']},
+		]]);
+
+		battle.makeChoices('auto', 'move sandattack 1, move glare 1');
+		battle.makeChoices('auto', 'move sandattack 2, move glare 2');
+
+		const breloom = battle.p1.active[0];
+		const venusaur = battle.p1.active[1];
+
+		assert.equal(breloom.status, '');
+		assert.equal(venusaur.status, '');
+		assert.statStage(breloom, 'accuracy', 0);
+		assert.statStage(venusaur, 'accuracy', 0);
+	});
+
+	it(`should not stop an ally from falling asleep when Yawn was already affecting it`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: 'Breloom', moves: ['sleeptalk']},
 			{species: 'Heatran', moves: ['sleeptalk']},
 			{species: 'Florges', ability: 'flowerveil', moves: ['sleeptalk']},
-		]});
-		battle.setPlayer('p2', {team: [
+		], [
 			{species: 'Persian', moves: ['sleeptalk', 'yawn']},
 			{species: 'Raticate', moves: ['sleeptalk']},
-		]});
+		]]);
 
 		battle.makeChoices('move sleeptalk, move sleeptalk', 'move yawn 1, move sleeptalk');
 		battle.makeChoices('move sleeptalk, switch 3', 'move sleeptalk, move sleeptalk');

--- a/test/sim/abilities/gulpmissile.js
+++ b/test/sim/abilities/gulpmissile.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Gulp Missile', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it(`should retrieve a catch on the first turn of Dive`, function () {
+		battle = common.createBattle([[
+			{species: 'cramorant', ability: 'gulpmissile', moves: ['dive']},
+		], [
+			{species: 'wynaut', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		assert.species(battle.p1.active[0], 'Cramorant-Gulping');
+	});
+
+	it(`should retrieve a catch only if the move was successful`, function () {
+		battle = common.createBattle([[
+			{species: 'cramorant', ability: 'gulpmissile', moves: ['surf']},
+		], [
+			{species: 'lapras', ability: 'waterabsorb', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		assert.false.species(battle.p1.active[0], 'Cramorant-Gulping');
+	});
+
+	it(`should not spit out its catch if the Cramorant is semi-invulnerable`, function () {
+		battle = common.createBattle([[
+			{species: 'cramorant', ability: 'gulpmissile', moves: ['dive']},
+		], [
+			{species: 'ludicolo', ability: 'noguard', moves: ['sleeptalk', 'machpunch']},
+		]]);
+		battle.makeChoices();
+		battle.makeChoices('auto', 'move machpunch');
+		assert.species(battle.p1.active[0], 'Cramorant-Gulping');
+		assert.statStage(battle.p2.active[0], 'def', 0);
+	});
+
+	it(`should change forms before damage calculation`, function () {
+		battle = common.createBattle([[
+			{species: 'cramorant', ability: 'gulpmissile', moves: ['surf']},
+		], [
+			{species: 'sceptile', ability: 'shellarmor', moves: ['magicpowder']},
+		]]);
+		battle.makeChoices();
+		const sceptile = battle.p2.active[0];
+		const damage = sceptile.maxhp - sceptile.hp;
+		assert.bounded(damage, [48, 57], `Cramorant should have received STAB in damage calculation`);
+	});
+
+	describe(`Hackmons Cramorant`, function () {
+		it(`should be sent out as the hacked form`, function () {
+			battle = common.createBattle([[
+				{species: 'cramorantgulping', ability: 'gulpmissile', moves: ['sleeptalk']},
+				{species: 'wynaut', moves: ['sleeptalk']},
+			], [
+				{species: 'togepi', moves: ['fairywind']},
+			]]);
+			battle.makeChoices();
+
+			const togepi = battle.p2.active[0];
+			assert.equal(togepi.hp, togepi.maxhp - Math.floor(togepi.maxhp / 4));
+			assert.statStage(togepi, 'def', -1);
+			battle.makeChoices('switch 2', 'auto');
+			battle.makeChoices('switch 2', 'auto');
+			assert.equal(togepi.hp, togepi.maxhp - (Math.floor(togepi.maxhp / 4) * 2));
+			assert.statStage(togepi, 'def', -2);
+		});
+
+		it(`should not force Cramorant-Gorging or -Gulping to have Gulp Missile`, function () {
+			battle = common.createBattle([[
+				{species: 'cramorantgorging', ability: 'intimidate', moves: ['sleeptalk']},
+			], [
+				{species: 'togepi', moves: ['fairywind']},
+			]]);
+			battle.makeChoices();
+
+			const togepi = battle.p2.active[0];
+			assert.statStage(togepi, 'atk', -1);
+		});
+	});
+});

--- a/test/sim/abilities/mummy.js
+++ b/test/sim/abilities/mummy.js
@@ -10,33 +10,39 @@ describe('Mummy', function () {
 		battle.destroy();
 	});
 
-	it("should set the attacker's ability to Mummy when the user is hit by a contact move", function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Cofagrigus', ability: 'mummy', moves: ['calmmind']}]});
-		battle.setPlayer('p2', {team: [{species: 'Mew', ability: 'synchronize', moves: ['aerialace']}]});
-		battle.makeChoices('move calmmind', 'move aerialace');
+	it(`should set the attacker's ability to Mummy when the user is hit by a contact move`, function () {
+		battle = common.createBattle([[
+			{species: 'Cofagrigus', ability: 'mummy', moves: ['sleeptalk']},
+		], [
+			{species: 'Mew', ability: 'synchronize', moves: ['aerialace']},
+		]]);
+
+		battle.makeChoices();
 		assert.equal(battle.p2.active[0].ability, 'mummy');
 	});
 
-	it("should not change certain abilities", function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Cofagrigus', ability: 'mummy', moves: ['calmmind']}]});
-		battle.setPlayer('p2', {team: [{species: 'Greninja', ability: 'battlebond', moves: ['aerialace']}]});
-		battle.makeChoices('move calmmind', 'move aerialace');
-		assert.equal(battle.p2.active[0].ability, 'battlebond');
+	it(`should not change isPermanent abilities`, function () {
+		battle = common.createBattle([[
+			{species: 'Cofagrigus', ability: 'mummy', moves: ['sleeptalk']},
+		], [
+			{species: 'Mimikyu', ability: 'disguise', moves: ['aerialace']},
+		]]);
+
+		battle.makeChoices();
+		assert.equal(battle.p2.active[0].ability, 'disguise');
 	});
 
 	it(`should not activate before all damage calculation is complete`, function () {
-		battle = common.createBattle({gameType: 'doubles'});
-		battle.setPlayer('p1', {team: [
+		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: 'Sableye', ability: 'toughclaws', moves: ['brutalswing']},
 			{species: 'Golisopod', ability: 'emergencyexit', moves: ['sleeptalk']},
-		]});
-		battle.setPlayer('p2', {team: [
+		], [
 			{species: 'Cofagrigus', ability: 'mummy', moves: ['sleeptalk']},
 			{species: 'Hoopa', ability: 'shellarmor', moves: ['sleeptalk']},
-		]});
-		battle.makeChoices('move brutalswing, move sleeptalk', 'move sleeptalk, move sleeptalk');
-		assert.fainted(battle.p2.active[1]);
+		]]);
+
+		const hoopa = battle.p2.active[1];
+		battle.makeChoices();
+		assert.fainted(hoopa);
 	});
 });

--- a/test/sim/abilities/wanderingspirit.js
+++ b/test/sim/abilities/wanderingspirit.js
@@ -8,29 +8,36 @@ let battle;
 describe('Wandering Spirit', function () {
 	afterEach(() => battle.destroy());
 
-	it('should exchange abilities with an attacker that makes contact', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Decidueye', ability: 'overgrow', moves: ['shadowsneak']}]});
-		battle.setPlayer('p2', {team: [{species: 'Runerigus', ability: 'wanderingspirit', moves: ['sleeptalk']}]});
-		battle.makeChoices('move shadowsneak', 'move sleeptalk');
+	it(`should exchange abilities with an attacker that makes contact`, function () {
+		battle = common.createBattle([[
+			{species: 'Decidueye', ability: 'overgrow', moves: ['shadowsneak']},
+		], [
+			{species: 'Runerigus', ability: 'wanderingspirit', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
 		assert(battle.p1.active[0].hasAbility('wanderingspirit'));
 		assert(battle.p2.active[0].hasAbility('overgrow'));
 	});
 
-	it('should not activate while Dynamaxed', function () {
+	it(`should not activate while Dynamaxed`, function () {
+		battle = common.createBattle([[
+			{species: 'Decidueye', ability: 'overgrow', moves: ['shadowsneak']},
+		], [
+			{species: 'Runerigus', ability: 'wanderingspirit', moves: ['sleeptalk']},
+		]]);
 		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Decidueye', ability: 'overgrow', moves: ['shadowsneak']}]});
-		battle.setPlayer('p2', {team: [{species: 'Runerigus', ability: 'wanderingspirit', moves: ['bodypress']}]});
-		battle.makeChoices('move shadowsneak', 'move 1 dynamax');
+		battle.makeChoices('auto', 'move 1 dynamax');
 		assert(battle.p1.active[0].hasAbility('overgrow'));
 		assert(battle.p2.active[0].hasAbility('wanderingspirit'));
 	});
 
-	it('should not swap with Wonder Guard', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Shedinja', ability: 'wonderguard', moves: ['shadowsneak']}]});
-		battle.setPlayer('p2', {team: [{species: 'Runerigus', ability: 'wanderingspirit', moves: ['sleeptalk']}]});
-		battle.makeChoices('move shadowsneak', 'move sleeptalk');
+	it(`should not swap with Wonder Guard`, function () {
+		battle = common.createBattle([[
+			{species: 'Shedinja', ability: 'wonderguard', moves: ['shadowsneak']},
+		], [
+			{species: 'Runerigus', ability: 'wanderingspirit', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
 		assert(battle.p1.active[0].hasAbility('wonderguard'));
 		assert(battle.p2.active[0].hasAbility('wanderingspirit'));
 	});

--- a/test/sim/abilities/wanderingspirit.js
+++ b/test/sim/abilities/wanderingspirit.js
@@ -23,10 +23,9 @@ describe('Wandering Spirit', function () {
 		battle = common.createBattle([[
 			{species: 'Decidueye', ability: 'overgrow', moves: ['shadowsneak']},
 		], [
-			{species: 'Runerigus', ability: 'wanderingspirit', moves: ['sleeptalk']},
+			{species: 'Runerigus', ability: 'wanderingspirit', moves: ['bodypress']},
 		]]);
-		battle = common.createBattle();
-		battle.makeChoices('auto', 'move 1 dynamax');
+		battle.makeChoices('auto', 'move bodypress dynamax');
 		assert(battle.p1.active[0].hasAbility('overgrow'));
 		assert(battle.p2.active[0].hasAbility('wanderingspirit'));
 	});

--- a/test/sim/items/metronome.js
+++ b/test/sim/items/metronome.js
@@ -10,7 +10,7 @@ describe('Metronome (item)', function () {
 		battle.destroy();
 	});
 
-	it('should increase the damage of moves that have been used successfully and consecutively', function () {
+	it(`should increase the damage of moves that have been used successfully and consecutively`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', item: 'metronome', moves: ['psystrike']},
 		], [
@@ -24,7 +24,7 @@ describe('Metronome (item)', function () {
 		assert.bounded(damage, [115, 137]);
 	});
 
-	it('should reset the multiplier after switching moves', function () {
+	it(`should reset the multiplier after switching moves`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', item: 'metronome', moves: ['psystrike', 'sleeptalk']},
 		], [
@@ -39,7 +39,7 @@ describe('Metronome (item)', function () {
 		assert.bounded(damage, [96, 114]);
 	});
 
-	it('should reset the multiplier after hitting Protect', function () {
+	it(`should reset the multiplier after hitting Protect`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', item: 'metronome', moves: ['psystrike']},
 		], [
@@ -54,16 +54,42 @@ describe('Metronome (item)', function () {
 		assert.bounded(damage, [96, 114]);
 	});
 
-	it('should instantly start moves that use a charging turn at Metronome 1 boost level, then increase linearly', function () {
+	it.skip(`should instantly start moves that use a charging turn at Metronome 1 boost level, then increase linearly`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', item: 'metronome', moves: ['solarbeam']},
 		], [
-			{species: 'cleffa', evs: {hp: 252}, ability: 'shellarmor', moves: ['sleeptalk', 'protect']},
+			{species: 'cleffa', evs: {hp: 252}, ability: 'shellarmor', moves: ['softboiled']},
 		]]);
 		battle.makeChoices();
 		battle.makeChoices();
 		const cleffa = battle.p2.active[0];
-		const damage = cleffa.maxhp - cleffa.hp;
-		assert.bounded(damage, [59, 70]);
+		let damage = cleffa.maxhp - cleffa.hp;
+		assert.bounded(damage, [59, 70], `Solar Beam should be Metronome 1 boosted`);
+
+		battle.makeChoices();
+		battle.makeChoices();
+		damage = cleffa.maxhp - cleffa.hp;
+		assert.bounded(damage, [69, 81], `Solar Beam should be Metronome 2 boosted`);
+	});
+
+	it.skip(`should use called moves to determine the Metronome multiplier`, function () {
+		battle = common.createBattle([[
+			{species: 'goomy', item: 'metronome', moves: ['copycat', 'surf']},
+		], [
+			{species: 'clefable', evs: {hp: 252}, ability: 'shellarmor', moves: ['softboiled', 'surf']},
+		]]);
+		battle.makeChoices('move copycat', 'move surf');
+		const clefable = battle.p2.active[0];
+		let damage = clefable.maxhp - clefable.hp;
+		assert.bounded(damage, [45, 53], `Surf should not be Metronome boosted`);
+
+		const hpAfterOneAttack = clefable.hp;
+		battle.makeChoices('move copycat', 'move surf');
+		damage = hpAfterOneAttack - clefable.hp;
+		assert.bounded(damage, [54, 64], `Surf should be Metronome 1 boosted`);
+
+		battle.makeChoices('move surf', 'move softboiled');
+		damage = clefable.maxhp - clefable.hp;
+		assert.bounded(damage, [63, 74], `Surf should be Metronome 2 boosted`);
 	});
 });

--- a/test/sim/items/ringtarget.js
+++ b/test/sim/items/ringtarget.js
@@ -10,15 +10,16 @@ describe('Ring Target', function () {
 		battle.destroy();
 	});
 
-	it('should negate natural immunities and deal normal type effectiveness with the other type(s)', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Smeargle", ability: 'owntempo', moves: ['earthquake', 'vitalthrow', 'shadowball', 'psychic']}]});
-		battle.setPlayer('p2', {team: [
+	it(`should negate natural immunities and deal normal type effectiveness with the other type(s)`, function () {
+		battle = common.createBattle([[
+			{species: "Smeargle", ability: 'owntempo', moves: ['earthquake', 'vitalthrow', 'shadowball', 'psychic']},
+		], [
 			{species: "Thundurus", ability: 'prankster', item: 'ringtarget', moves: ['rest']},
 			{species: "Drifblim", ability: 'unburden', item: 'ringtarget', moves: ['rest']},
 			{species: "Girafarig", ability: 'innerfocus', item: 'ringtarget', moves: ['rest']},
 			{species: "Absol", ability: 'superluck', item: 'ringtarget', moves: ['rest']},
-		]});
+		]]);
+
 		battle.makeChoices('move earthquake', 'move rest');
 		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-supereffective|'));
 		assert.false.fullHP(battle.p2.active[0]);
@@ -35,18 +36,30 @@ describe('Ring Target', function () {
 		assert.false.fullHP(battle.p2.active[0]);
 	});
 
-	it('should not affect ability-based immunities', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Hariyama", ability: 'guts', moves: ['earthquake']}]});
-		battle.setPlayer('p2', {team: [
-			{species: "Mismagius", ability: 'levitate', item: 'ringtarget', moves: ['shadowsneak']},
-			{species: "Rotom-Fan", ability: 'levitate', item: 'ringtarget', moves: ['snore']},
-		]});
-		battle.makeChoices('move earthquake', 'move shadowsneak');
+	it(`should not affect ability-based immunities`, function () {
+		battle = common.createBattle([[
+			{species: 'Hariyama', moves: ['earthquake']},
+		], [
+			{species: 'Mismagius', ability: 'levitate', item: 'ringtarget', moves: ['sleeptalk']},
+			{species: 'Rotom-Fan', ability: 'levitate', item: 'ringtarget', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
 		assert.fullHP(battle.p2.active[0]);
 
 		// even if Rotom-Fan
 		battle.makeChoices('move earthquake', 'switch 2');
+		assert.fullHP(battle.p2.active[0]);
+	});
+
+	it(`should not affect Magnet Rise`, function () {
+		battle = common.createBattle([[
+			{species: 'Wynaut', moves: ['earthquake']},
+		], [
+			{species: 'Klefki', item: 'ringtarget', moves: ['magnetrise']},
+		]]);
+
+		battle.makeChoices();
 		assert.fullHP(battle.p2.active[0]);
 	});
 });

--- a/test/sim/misc/faint-order.js
+++ b/test/sim/misc/faint-order.js
@@ -10,163 +10,151 @@ describe('Fainting', function () {
 		battle.destroy();
 	});
 
-	it('should end the turn in Gen 1', function () {
+	it(`should end the turn in Gen 1`, function () {
 		// Gen 1 has no end-of-turn effects
-		battle = common.gen(1).createBattle([
-			[
-				{species: 'Electrode', moves: ['explosion']},
-				{species: 'Pikachu', moves: ['growl']},
-			],
-			[
-				{species: 'Haunter', moves: ['substitute']},
-			],
-		]);
-		battle.makeChoices('move Explosion', 'move Substitute');
+		battle = common.gen(1).createBattle([[
+			{species: 'Electrode', moves: ['explosion']},
+			{species: 'Pikachu', moves: ['growl']},
+		], [
+			{species: 'Haunter', moves: ['substitute']},
+		]]);
+		battle.makeChoices();
 		battle.makeChoices('switch Pikachu', '');
-		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.fullHP(battle.p2.active[0]);
 	});
 
-	it('should end the turn in Gen 3', function () {
-		battle = common.gen(3).createBattle([
-			[
-				{species: 'Electrode', ability: 'soundproof', moves: ['explosion']},
-				{species: 'Pikachu', ability: 'lightningrod', moves: ['growl']},
-			],
-			[
-				{species: 'Haunter', ability: 'levitate', moves: ['substitute']},
-			],
-		]);
+	it(`should end the turn in Gen 3`, function () {
+		battle = common.gen(3).createBattle([[
+			{species: 'Electrode', moves: ['explosion']},
+			{species: 'Pikachu', moves: ['growl']},
+		], [
+			{species: 'Haunter', moves: ['substitute']},
+		]]);
 		battle.makeChoices('move Explosion', 'move Substitute');
 		battle.makeChoices('switch Pikachu', '');
-		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.fullHP(battle.p2.active[0]);
 	});
 
-	it('should not end the turn in Gen 4', function () {
-		battle = common.gen(4).createBattle([
-			[
-				{species: 'Electrode', ability: 'soundproof', moves: ['explosion']},
-				{species: 'Pikachu', ability: 'lightningrod', moves: ['growl']},
-			],
-			[
-				{species: 'Haunter', ability: 'levitate', moves: ['substitute']},
-			],
-		]);
+	it(`should not end the turn in Gen 4`, function () {
+		battle = common.gen(4).createBattle([[
+			{species: 'Electrode', moves: ['explosion']},
+			{species: 'Pikachu', moves: ['growl']},
+		], [
+			{species: 'Haunter', moves: ['substitute']},
+		]]);
 		battle.makeChoices('move Explosion', 'move Substitute');
 		battle.makeChoices('switch Pikachu', '');
-		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.false.fullHP(battle.p2.active[0]);
 	});
 
-	it('should check for a winner after an attack', function () {
-		battle = common.gen(4).createBattle([
-			[
-				{species: 'Shedinja', moves: ['shadowsneak']},
-			],
-			[
-				{species: 'Shedinja', moves: ['sleeptalk']},
-			],
-		]);
+	it(`should check for a winner after an attack`, function () {
+		battle = common.gen(4).createBattle([[
+			{species: 'Shedinja', moves: ['shadowsneak']},
+		], [
+			{species: 'Shedinja', moves: ['sleeptalk']},
+		]]);
 		battle.makeChoices();
 		assert.fainted(battle.p2.active[0]);
 		assert.equal(battle.winner, 'Player 1');
 		battle.destroy();
 
-		battle = common.gen(5).createBattle([
-			[
-				{species: 'Shedinja', moves: ['sleeptalk', 'shadowsneak']},
-			],
-			[
-				{species: 'Shedinja', ability: 'prankster', moves: ['spore']},
-			],
-		]);
+		battle = common.gen(5).createBattle([[
+			{species: 'Shedinja', moves: ['sleeptalk', 'shadowsneak']},
+		], [
+			{species: 'Shedinja', ability: 'prankster', moves: ['spore']},
+		]]);
 		battle.makeChoices();
 		assert.fainted(battle.p2.active[0]);
 		assert.equal(battle.winner, 'Player 1');
 	});
 
-	it('should check for a winner after recoil', function () {
-		battle = common.gen(4).createBattle([
-			[
-				{species: 'Shedinja', moves: ['flareblitz']},
-			],
-			[
-				{species: 'Shedinja', moves: ['flareblitz']},
-			],
-		]);
+	it(`should check for a winner after recoil`, function () {
+		battle = common.gen(4).createBattle([[
+			{species: 'Shedinja', moves: ['flareblitz']},
+		], [
+			{species: 'Shedinja', moves: ['flareblitz']},
+		]]);
 		battle.makeChoices();
 		assert.fainted(battle.p1.active[0]);
 		assert.fainted(battle.p2.active[0]);
 		assert.equal(battle.winner, '');
 		battle.destroy();
 
-		battle = common.gen(5).createBattle([
-			[
-				{species: 'Shedinja', moves: ['flareblitz']},
-			],
-			[
-				{species: 'Shedinja', moves: ['sleeptalk']},
-			],
-		]);
+		battle = common.gen(5).createBattle([[
+			{species: 'Shedinja', moves: ['flareblitz']},
+		], [
+			{species: 'Shedinja', moves: ['sleeptalk']},
+		]]);
 		battle.makeChoices();
 		assert.fainted(battle.p1.active[0]);
 		assert.fainted(battle.p2.active[0]);
 		assert.equal(battle.winner, 'Player 1');
 	});
 
-	it('should check for a winner after Rough Skin', function () {
-		battle = common.gen(4).createBattle([
-			[
-				{species: 'Shedinja', moves: ['shadowsneak']},
-			],
-			[
-				{species: 'Shedinja', ability: 'roughskin', moves: ['sleeptalk']},
-			],
-		]);
+	it(`should check for a winner after Rough Skin`, function () {
+		battle = common.gen(4).createBattle([[
+			{species: 'Shedinja', moves: ['shadowsneak']},
+		], [
+			{species: 'Shedinja', ability: 'roughskin', moves: ['sleeptalk']},
+		]]);
 		battle.makeChoices();
 		assert.fainted(battle.p1.active[0]);
 		assert.fainted(battle.p2.active[0]);
 		assert.equal(battle.winner, '');
 		battle.destroy();
 
-		battle = common.gen(6).createBattle([
-			[
-				{species: 'Shedinja', moves: ['shadowsneak']},
-			],
-			[
-				{species: 'Shedinja', ability: 'roughskin', moves: ['sleeptalk']},
-			],
-		]);
+		battle = common.gen(6).createBattle([[
+			{species: 'Shedinja', moves: ['shadowsneak']},
+		], [
+			{species: 'Shedinja', ability: 'roughskin', moves: ['sleeptalk']},
+		]]);
 		battle.makeChoices();
 		assert.fainted(battle.p1.active[0]);
 		assert.fainted(battle.p2.active[0]);
 		assert.equal(battle.winner, 'Player 2');
 		battle.destroy();
 
-		battle = common.gen(7).createBattle([
-			[
-				{species: 'Shedinja', moves: ['shadowsneak']},
-			],
-			[
-				{species: 'Shedinja', ability: 'roughskin', moves: ['sleeptalk']},
-			],
-		]);
+		battle = common.gen(7).createBattle([[
+			{species: 'Shedinja', moves: ['shadowsneak']},
+		], [
+			{species: 'Shedinja', ability: 'roughskin', moves: ['sleeptalk']},
+		]]);
 		battle.makeChoices();
 		assert.fainted(battle.p1.active[0]);
 		assert.fainted(battle.p2.active[0]);
 		assert.equal(battle.winner, 'Player 1');
 	});
 
-	it('should check for a winner after future moves', function () {
-		battle = common.gen(7).createBattle([
-			[
-				{species: 'Shedinja', moves: ['futuresight']},
-			],
-			[
-				{species: 'Shedinja', moves: ['sleeptalk']},
-			],
-		]);
+	it(`should check for a winner after future moves`, function () {
+		battle = common.gen(7).createBattle([[
+			{species: 'Shedinja', moves: ['futuresight']},
+		], [
+			{species: 'Shedinja', moves: ['sleeptalk']},
+		]]);
+		for (let i = 0; i < 3; i++) battle.makeChoices();
+		assert.fainted(battle.p2.active[0]);
+		assert.equal(battle.winner, 'Player 1');
+	});
+
+	it(`should check for a winner after Rocky Helmet`, function () {
+		battle = common.gen(5).createBattle([[
+			{species: 'Shedinja', moves: ['shadowsneak']},
+		], [
+			{species: 'Shedinja', item: 'rockyhelmet', moves: ['sleeptalk']},
+		]]);
 		battle.makeChoices();
+		assert.fainted(battle.p1.active[0]);
+		assert.fainted(battle.p2.active[0]);
+		assert.equal(battle.winner, 'Player 2');
+		battle.destroy();
+
+		battle = common.gen(7).createBattle([[
+			{species: 'Shedinja', moves: ['shadowsneak']},
+		], [
+			{species: 'Shedinja', item: 'rockyhelmet', moves: ['sleeptalk']},
+		]]);
 		battle.makeChoices();
-		battle.makeChoices();
+		assert.fainted(battle.p1.active[0]);
 		assert.fainted(battle.p2.active[0]);
 		assert.equal(battle.winner, 'Player 1');
 	});

--- a/test/sim/misc/target-resolution.js
+++ b/test/sim/misc/target-resolution.js
@@ -323,4 +323,23 @@ describe('Target Resolution', function () {
 		battle.makeChoices('auto', 'move phantomforce 1, move sheercold 1');
 		assert.false.fullHP(battle.p1.active[1], 'Altaria should not be at full HP, because Phantom Force was redirected and targeted it.');
 	});
+
+	it.skip(`should cause Rollout to target the same slot after being called as a submove`, function () {
+		// hardcoded RNG seed to show the erroneous targeting behavior
+		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
+			{species: 'purrloin', ability: 'compoundeyes', moves: ['rollout', 'sleeptalk']},
+			{species: 'regieleki', moves: ['healbell', 'spore']},
+		], [
+			{species: 'aggron', moves: ['sleeptalk']},
+			{species: 'slowbro', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move sleeptalk, move spore -1', 'auto');
+		// Determine which slot was damaged on first turn of Rollout
+		const aggron = battle.p2.active[0];
+		const notTargetedPokemon = aggron.hp === aggron.maxhp ? aggron : battle.p2.active[1];
+
+		for (let i = 0; i < 4; i++) battle.makeChoices();
+		assert.fullHP(notTargetedPokemon);
+	});
 });

--- a/test/sim/moves/acupressure.js
+++ b/test/sim/moves/acupressure.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Acupressure', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it(`should be able to target an ally in doubles`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Wynaut', moves: ['acupressure']},
+			{species: 'Smoochum', moves: ['sleeptalk']},
+		], [
+			{species: 'Clamperl', moves: ['sleeptalk']},
+			{species: 'Whismur', moves: ['sleeptalk']},
+		]]);
+
+		assert.false.cantMove(() => battle.choose('p1', 'move acupressure -2, move sleeptalk'));
+	});
+
+	it(`should be unable to target any opponent in free-for-alls`, function () {
+		battle = common.createBattle({gameType: 'freeforall'}, [[
+			{species: 'Wynaut', moves: ['acupressure']},
+		], [
+			{species: 'Cufant', moves: ['sleeptalk']},
+		], [
+			{species: 'Qwilfish', moves: ['sleeptalk']},
+		], [
+			{species: 'Marowak', moves: ['sleeptalk']},
+		]]);
+
+		assert.cantMove(() => battle.choose('p1', 'move acupressure 1'));
+		assert.cantMove(() => battle.choose('p1', 'move acupressure 2'));
+		assert.cantMove(() => battle.choose('p1', 'move acupressure -2'));
+	});
+});

--- a/test/sim/moves/fling.js
+++ b/test/sim/moves/fling.js
@@ -10,7 +10,7 @@ describe('Fling', function () {
 		battle.destroy();
 	});
 
-	it('should consume the user\'s item after being flung', function () {
+	it(`should consume the user's item after being flung`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', item: 'ironball', moves: ['fling']},
 		], [
@@ -20,7 +20,7 @@ describe('Fling', function () {
 		assert.equal(battle.p1.active[0].item, '');
 	});
 
-	it('should apply custom effects when certain items are flung', function () {
+	it(`should apply custom effects when certain items are flung`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', item: 'flameorb', moves: ['fling']},
 		], [
@@ -30,7 +30,7 @@ describe('Fling', function () {
 		assert.equal(battle.p2.active[0].status, 'brn');
 	});
 
-	it('should not be usuable in Magic Room', function () {
+	it(`should not be usuable in Magic Room`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', item: 'ironball', moves: ['fling']},
 		], [
@@ -40,7 +40,7 @@ describe('Fling', function () {
 		assert.equal(battle.p1.active[0].item, 'ironball');
 	});
 
-	it('should use its item to be flung in damage calculations', function () {
+	it(`should use its item to be flung in damage calculations`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', item: 'lifeorb', moves: ['fling']},
 		], [
@@ -55,5 +55,22 @@ describe('Fling', function () {
 
 		// Wynaut should not have taken Life Orb recoil
 		assert.fullHP(battle.p1.active[0]);
+	});
+
+	it(`should Fling, not consume Leppa Berry when using 1 PP Leppa Berry Fling`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', moves: ['fling', 'sleeptalk']},
+		], [
+			{species: 'cleffa', item: 'leppaberry', moves: ['spite', 'trick', 'sleeptalk']},
+		]]);
+		// Waste 15 Fling PP
+		for (let i = 0; i < 3; i++) battle.makeChoices();
+		battle.makeChoices('move sleeptalk', 'move trick');
+		battle.makeChoices('move fling', 'move sleeptalk');
+
+		const wynaut = battle.p1.active[0];
+		const cleffa = battle.p2.active[0];
+		assert.equal(wynaut.getMoveData('fling').pp, 0);
+		assert.equal(cleffa.getMoveData('spite').pp, 16);
 	});
 });

--- a/test/sim/moves/focuspunch.js
+++ b/test/sim/moves/focuspunch.js
@@ -10,50 +10,60 @@ describe('Focus Punch', function () {
 		battle.destroy();
 	});
 
-	it('should cause the user to lose focus if hit by an attacking move', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]});
-		battle.setPlayer('p2', {team: [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf']}]});
-		battle.makeChoices('move focuspunch', 'move magicalleaf');
-		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	it(`should cause the user to lose focus if hit by an attacking move`, function () {
+		battle = common.createBattle([[
+			{species: 'Chansey', moves: ['focuspunch']},
+		], [
+			{species: 'Venusaur', moves: ['magicalleaf']},
+		]]);
+		battle.makeChoices();
+		assert.fullHP(battle.p2.active[0]);
 	});
 
-	it('should not cause the user to lose focus if hit by a status move', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]});
-		battle.setPlayer('p2', {team: [{species: 'Venusaur', ability: 'overgrow', moves: ['toxic']}]});
-		battle.makeChoices('move focuspunch', 'move toxic');
-		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	it(`should not cause the user to lose focus if hit by a status move`, function () {
+		battle = common.createBattle([[
+			{species: 'Chansey', moves: ['focuspunch']},
+		], [
+			{species: 'Venusaur', moves: ['growl']},
+		]]);
+		battle.makeChoices();
+		assert.false.fullHP(battle.p2.active[0]);
 	});
 
-	it('should not cause the user to lose focus if hit while behind a substitute', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Chansey', ability: 'naturalcure', moves: ['substitute', 'focuspunch']}]});
-		battle.setPlayer('p2', {team: [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf']}]});
-		battle.makeChoices('move substitute', 'move magicalleaf');
-		battle.makeChoices('move focuspunch', 'move magicalleaf');
-		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	it(`should not cause the user to lose focus if hit while behind a substitute`, function () {
+		battle = common.createBattle([[
+			{species: 'Chansey', moves: ['substitute', 'focuspunch']},
+		], [
+			{species: 'Venusaur', moves: ['magicalleaf']},
+		]]);
+		battle.makeChoices();
+		battle.makeChoices('move focuspunch', 'auto');
+		assert.false.fullHP(battle.p2.active[0]);
 	});
 
-	it('should cause the user to lose focus if hit by a move called by Nature Power', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]});
-		battle.setPlayer('p2', {team: [{species: 'Venusaur', ability: 'overgrow', moves: ['naturepower']}]});
-		battle.makeChoices('move focuspunch', 'move naturepower');
-		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	it(`should cause the user to lose focus if hit by a move called by Nature Power`, function () {
+		battle = common.createBattle([[
+			{species: 'Chansey', moves: ['focuspunch']},
+		], [
+			{species: 'Venusaur', moves: ['naturepower']},
+		]]);
+		battle.makeChoices();
+		assert.fullHP(battle.p2.active[0]);
 	});
 
-	it('should not cause the user to lose focus on later uses of Focus Punch if hit', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]});
-		battle.setPlayer('p2', {team: [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf', 'toxic']}]});
-		battle.makeChoices('move focuspunch', 'move magicalleaf');
-		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
-		battle.makeChoices('move focuspunch', 'move toxic');
-		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	it(`should not cause the user to lose focus on later uses of Focus Punch if hit`, function () {
+		battle = common.createBattle([[
+			{species: 'Chansey', moves: ['focuspunch']},
+		], [
+			{species: 'Venusaur', moves: ['magicalleaf', 'growl']},
+		]]);
+		battle.makeChoices();
+		assert.fullHP(battle.p2.active[0]);
+		battle.makeChoices('auto', 'move growl');
+		assert.false.fullHP(battle.p2.active[0]);
 	});
 
-	it('should cause the user to lose focus if hit by an attacking move followed by a status move in one turn', function () {
+	it(`should cause the user to lose focus if hit by an attacking move followed by a status move in one turn`, function () {
 		battle = common.createBattle({gameType: 'doubles'}, [
 			[{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}, {species: 'Blissey', ability: 'naturalcure', moves: ['softboiled']}],
 			[{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf']}, {species: 'Ivysaur', ability: 'overgrow', moves: ['toxic']}],
@@ -63,59 +73,84 @@ describe('Focus Punch', function () {
 		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
-	it('should not deduct PP if the user lost focus', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]});
-		battle.setPlayer('p2', {team: [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf', 'toxic']}]});
-
+	it(`should not deduct PP if the user lost focus`, function () {
+		battle = common.createBattle([[
+			{species: 'Chansey', moves: ['focuspunch']},
+		], [
+			{species: 'Venusaur', moves: ['magicalleaf', 'growl']},
+		]]);
 		const move = battle.p1.active[0].getMoveData(Dex.moves.get('focuspunch'));
-		battle.makeChoices('move focuspunch', 'move magicalleaf');
+		battle.makeChoices();
 		assert.equal(move.pp, move.maxpp);
-		battle.makeChoices('move focuspunch', 'move toxic');
+		battle.makeChoices('auto', 'move growl');
 		assert.equal(move.pp, move.maxpp - 1);
 	});
 
-	it('should deduct PP if the user lost focus before Gen 5', function () {
-		battle = common.gen(4).createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]});
-		battle.setPlayer('p2', {team: [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf', 'toxic']}]});
-
+	it(`should deduct PP if the user lost focus before Gen 5`, function () {
+		battle = common.gen(4).createBattle([[
+			{species: 'Chansey', moves: ['focuspunch']},
+		], [
+			{species: 'Venusaur', moves: ['magicalleaf', 'growl']},
+		]]);
 		const move = battle.p1.active[0].getMoveData(Dex.moves.get('focuspunch'));
-		battle.makeChoices('move focuspunch', 'move magicalleaf');
+		battle.makeChoices();
 		assert.equal(move.pp, move.maxpp - 1);
-		battle.makeChoices('move focuspunch', 'move toxic');
+		battle.makeChoices('auto', 'move growl');
 		assert.equal(move.pp, move.maxpp - 2);
 	});
 
-	it('should not tighten the pokemon\'s focus when Dynamaxing', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]});
-		battle.setPlayer('p2', {team: [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf', 'toxic']}]});
+	it(`should display a message indicating the Pokemon is tightening focus`, function () {
+		battle = common.createBattle([[
+			{species: 'Chansey', moves: ['focuspunch']},
+		], [
+			{species: 'Venusaur', moves: ['magicalleaf']},
+		]]);
 
-		battle.makeChoices('move focuspunch dynamax', 'move magicalleaf');
-		const tighteningFocusMessage = battle.log.filter(str => str === '|-singleturn|p1a: Chansey|move: Focus Punch');
-
-		assert.equal(tighteningFocusMessage.length, 0);
+		battle.makeChoices();
+		const tighteningFocusMessage = battle.log.indexOf('|-singleturn|p1a: Chansey|move: Focus Punch');
+		assert(tighteningFocusMessage > 0);
 	});
 
-	it('should not tighten the pokemon\'s focus when already Dynamaxed', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]});
-		battle.setPlayer('p2', {team: [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf', 'toxic']}]});
+	it(`should not tighten the Pokemon's focus when Dynamaxing or already Dynamaxed`, function () {
+		battle = common.createBattle([[
+			{species: 'Chansey', moves: ['focuspunch']},
+		], [
+			{species: 'Venusaur', moves: ['magicalleaf']},
+		]]);
 
-		battle.makeChoices('move focuspunch dynamax', 'move magicalleaf');
-		battle.makeChoices('move focuspunch', 'move magicalleaf');
-		const tighteningFocusMessage = battle.log.filter(str => str === '|-singleturn|p1a: Chansey|move: Focus Punch');
-		assert.equal(tighteningFocusMessage.length, 0);
+		battle.makeChoices('move focuspunch dynamax', 'auto');
+		battle.makeChoices('move focuspunch', 'auto');
+		const tighteningFocusMessage = battle.log.indexOf('|-singleturn|p1a: Chansey|move: Focus Punch');
+		assert(tighteningFocusMessage < 0);
 	});
 
-	it('should tighten the pokemon\'s focus when not Dynamaxed', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Chansey', ability: 'naturalcure', moves: ['focuspunch']}]});
-		battle.setPlayer('p2', {team: [{species: 'Venusaur', ability: 'overgrow', moves: ['magicalleaf', 'toxic']}]});
+	it.skip(`should tighten focus after switches in Gen 5+`, function () {
+		battle = common.createBattle([[
+			{species: 'salamence', moves: ['focuspunch']},
+		], [
+			{species: 'mew', moves: ['sleeptalk']},
+			{species: 'wynaut', moves: ['sleeptalk']},
+		]]);
 
-		battle.makeChoices('move focuspunch', 'move magicalleaf');
-		const tighteningFocusMessage = battle.log.filter(str => str === '|-singleturn|p1a: Chansey|move: Focus Punch');
-		assert.equal(tighteningFocusMessage.length, 1);
+		battle.makeChoices('move focuspunch', 'switch 2');
+		const log = battle.getDebugLog();
+		const focusPunchChargeIndex = log.indexOf('|-singleturn|');
+		const switchIndex = log.indexOf('|switch|p2a: Wynaut');
+		assert(focusPunchChargeIndex > switchIndex, `Focus Punch's charge message should occur after switches in Gen 5+`);
+	});
+
+	it(`should tighten focus before switches in Gens 3-4`, function () {
+		battle = common.gen(4).createBattle([[
+			{species: 'salamence', moves: ['focuspunch']},
+		], [
+			{species: 'mew', moves: ['sleeptalk']},
+			{species: 'wynaut', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move focuspunch', 'switch 2');
+		const log = battle.getDebugLog();
+		const focusPunchChargeIndex = log.indexOf('|-singleturn|');
+		const switchIndex = log.indexOf('|switch|p2a: Wynaut');
+		assert(focusPunchChargeIndex < switchIndex, `Focus Punch's charge message should occur before switches in Gens 3-4`);
 	});
 });

--- a/test/sim/moves/futuresight.js
+++ b/test/sim/moves/futuresight.js
@@ -10,47 +10,60 @@ describe('Future Sight', function () {
 		battle.destroy();
 	});
 
-	it('should damage in two turns, ignoring Protect, affected by Dark immunities', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Sneasel", ability: 'innerfocus', moves: ['odorsleuth', 'futuresight', 'protect']}]});
-		battle.setPlayer('p2', {team: [{species: "Girafarig", ability: 'innerfocus', moves: ['odorsleuth', 'futuresight', 'protect']}]});
-		battle.makeChoices('move Future Sight', 'move Future Sight');
-		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
-		battle.makeChoices('auto', 'auto');
-		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
-		battle.makeChoices('auto', 'move Protect');
-		assert.equal(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
-		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	it(`should damage in two turns, ignoring Protect, affected by Dark immunities`, function () {
+		battle = common.createBattle([[
+			{species: 'Sneasel', moves: ['sleeptalk', 'futuresight']},
+		], [
+			{species: 'Girafarig', moves: ['sleeptalk', 'futuresight', 'protect']},
+		]]);
+
+		const sneasel = battle.p1.active[0];
+		const girafarig = battle.p2.active[0];
+		battle.makeChoices('move futuresight', 'move futuresight');
+		assert.fullHP(girafarig);
+		battle.makeChoices();
+		assert.fullHP(girafarig);
+		battle.makeChoices('auto', 'move protect');
+		assert.fullHP(sneasel);
+		assert.false.fullHP(girafarig);
 	});
 
 	it(`should fail when already active for the target's position`, function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Sneasel", ability: 'innerfocus', moves: ['odorsleuth']}]});
-		battle.setPlayer('p2', {team: [{species: "Girafarig", ability: 'innerfocus', moves: ['futuresight']}]});
-		battle.makeChoices('auto', 'move futuresight');
-		battle.makeChoices('auto', 'move futuresight');
+		battle = common.createBattle([[
+			{species: 'Sneasel', moves: ['sleeptalk']},
+		], [
+			{species: 'Girafarig', moves: ['futuresight']},
+		]]);
+
+		battle.makeChoices();
+		battle.makeChoices();
 		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-fail|'));
 	});
 
-	it('[Gen 2] should damage in two turns, ignoring Protect', function () {
-		battle = common.gen(2).createBattle();
-		battle.setPlayer('p1', {team: [{species: "Sneasel", moves: ['odorsleuth', 'futuresight', 'protect', 'sweetscent']}]});
-		battle.setPlayer('p2', {team: [{species: "Girafarig", moves: ['odorsleuth', 'futuresight', 'protect', 'sweetscent']}]});
-		battle.makeChoices('move Sweet Scent', 'move Sweet Scent'); // counteract imperfect accuracy
-		battle.makeChoices('move Future Sight', 'move Future Sight');
-		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+	it(`[Gen 2] should damage in two turns, ignoring Protect`, function () {
+		battle = common.gen(2).createBattle([[
+			{species: 'Sneasel', moves: ['sleeptalk', 'futuresight', 'sweetscent']},
+		], [
+			{species: 'Girafarig', moves: ['sleeptalk', 'futuresight', 'protect', 'sweetscent']},
+		]]);
+
+		const sneasel = battle.p1.active[0];
+		const girafarig = battle.p2.active[0];
+		battle.makeChoices('move sweetscent', 'move sweetscent'); // counteract imperfect accuracy
+		battle.makeChoices('move futuresight', 'move futuresight');
+		assert.fullHP(girafarig);
 		battle.makeChoices('auto', 'auto');
-		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.fullHP(girafarig);
 		battle.makeChoices('auto', 'move Protect');
-		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
-		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
+		assert.false.fullHP(sneasel);
+		assert.false.fullHP(girafarig);
 	});
 
 	it(`should not double Stomping Tantrum for exiting normally`, function () {
 		battle = common.createBattle([[
-			{species: "Wynaut", moves: ['futuresight', 'stompingtantrum']},
+			{species: 'Wynaut', moves: ['futuresight', 'stompingtantrum']},
 		], [
-			{species: "Scizor", ability: 'shellarmor', moves: ['sleeptalk']},
+			{species: 'Scizor', ability: 'shellarmor', moves: ['sleeptalk']},
 		]]);
 
 		battle.makeChoices();
@@ -62,24 +75,22 @@ describe('Future Sight', function () {
 
 	it(`should not trigger Eject Button`, function () {
 		battle = common.createBattle([[
-			{species: "Wynaut", moves: ['futuresight']},
+			{species: 'Wynaut', moves: ['futuresight']},
 		], [
-			{species: "Scizor", item: 'ejectbutton', moves: ['sleeptalk']},
-			{species: "Roggenrola", moves: ['sleeptalk']},
+			{species: 'Scizor', item: 'ejectbutton', moves: ['sleeptalk']},
+			{species: 'Roggenrola', moves: ['sleeptalk']},
 		]]);
 
-		battle.makeChoices();
-		battle.makeChoices();
-		battle.makeChoices();
+		for (let i = 0; i < 3; i++) battle.makeChoices();
 		assert.equal(battle.requestState, 'move');
 	});
 
 	it(`should be able to set Future Sight against an empty target slot`, function () {
 		battle = common.createBattle([[
-			{species: "Shedinja", moves: ['finalgambit']},
-			{species: "Roggenrola", moves: ['sleeptalk']},
+			{species: 'Shedinja', moves: ['finalgambit']},
+			{species: 'Roggenrola', moves: ['sleeptalk']},
 		], [
-			{species: "Wynaut", moves: ['sleeptalk', 'futuresight']},
+			{species: 'Wynaut', moves: ['sleeptalk', 'futuresight']},
 		]]);
 
 		battle.makeChoices('auto', 'move future sight');
@@ -92,9 +103,9 @@ describe('Future Sight', function () {
 
 	it(`its damaging hit should not count as copyable for Copycat`, function () {
 		battle = common.createBattle([[
-			{species: "Wynaut", moves: ['sleeptalk', 'futuresight']},
+			{species: 'Wynaut', moves: ['sleeptalk', 'futuresight']},
 		], [
-			{species: "Liepard", moves: ['sleeptalk', 'copycat']},
+			{species: 'Liepard', moves: ['sleeptalk', 'copycat']},
 		]]);
 
 		battle.makeChoices('move futuresight', 'auto');
@@ -138,5 +149,74 @@ describe('Future Sight', function () {
 		battle.makeChoices();
 		battle.makeChoices();
 		assert.false(roggenrola.hasType('Psychic'), `Protean Roggenrola should not change type on Future Sight's damaging turn`);
+	});
+
+	it(`should be boosted by Terrain only if Terrain is active on the damaging turn`, function () {
+		battle = common.createBattle([[
+			{species: 'Blissey', ability: 'shellarmor', moves: ['softboiled']},
+		], [
+			{species: 'Wynaut', ability: 'psychicsurge', moves: ['sleeptalk', 'futuresight']},
+		]]);
+
+		battle.makeChoices('auto', 'move futuresight');
+		battle.makeChoices();
+		battle.makeChoices();
+		const blissey = battle.p1.active[0];
+		let damage = blissey.maxhp - blissey.hp;
+		assert.bounded(damage, [46, 55]);
+
+		battle.makeChoices('auto', 'move futuresight');
+		battle.makeChoices();
+		battle.makeChoices();
+		damage = blissey.maxhp - blissey.hp;
+		assert.bounded(damage, [36, 43]);
+	});
+
+	it(`should be boosted by Terrain even if the user is not on the field, as long as the user is not Flying-type`, function () {
+		battle = common.createBattle([[
+			{species: 'Blissey', ability: 'shellarmor', moves: ['softboiled']},
+		], [
+			{species: 'cresselia', ability: 'levitate', moves: ['sleeptalk', 'futuresight']},
+			{species: 'deino', ability: 'psychicsurge', moves: ['sleeptalk']},
+			{species: 'xatu', moves: ['sleeptalk', 'futuresight']},
+		]]);
+
+		// Cresselia will be Terrain-boosted because its Ability is not checked while not active
+		battle.makeChoices('auto', 'move futuresight');
+		battle.makeChoices();
+		battle.makeChoices('auto', 'switch deino');
+		const blissey = battle.p1.active[0];
+		let damage = blissey.maxhp - blissey.hp;
+		assert.bounded(damage, [102, 121]);
+
+		// Xatu won't be Terrain-boosted because its Flying-type is checked while not active
+		battle.makeChoices('auto', 'switch xatu');
+		battle.makeChoices('auto', 'move futuresight');
+		battle.makeChoices();
+		battle.makeChoices('auto', 'switch deino');
+		damage = blissey.maxhp - blissey.hp;
+		assert.bounded(damage, [96, 114]);
+	});
+
+	it.skip(`should not ignore the target's screens, even when the user is not active on the field`, function () {
+		battle = common.createBattle([[
+			{species: 'Blissey', ability: 'shellarmor', item: 'lightclay', moves: ['softboiled', 'lightscreen']},
+		], [
+			{species: 'Wynaut', moves: ['sleeptalk', 'futuresight']},
+			{species: 'deino', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move lightscreen', 'move futuresight');
+		battle.makeChoices();
+		battle.makeChoices();
+		const blissey = battle.p1.active[0];
+		let damage = blissey.maxhp - blissey.hp;
+		assert.bounded(damage, [18, 21]);
+
+		battle.makeChoices('auto', 'move futuresight');
+		battle.makeChoices();
+		battle.makeChoices('auto', 'switch 2');
+		damage = blissey.maxhp - blissey.hp;
+		assert.bounded(damage, [18, 21]);
 	});
 });

--- a/test/sim/moves/photongeyser.js
+++ b/test/sim/moves/photongeyser.js
@@ -8,56 +8,92 @@ let battle;
 describe(`Photon Geyser`, function () {
 	afterEach(() => battle.destroy());
 
-	it('should become physical when Attack stat is higher than Special Attack stat', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Necrozma-Dusk-Mane", ability: 'prismarmor', moves: ['photongeyser']}]});
-		battle.setPlayer('p2', {team: [{species: "Mew", ability: 'synchronize', item: 'keeberry', moves: ['counter']}]});
-		battle.makeChoices('move photongeyser', 'move counter');
-		assert.statStage(battle.p2.active[0], 'def', 1, "Physical Photon Geyser should trigger Kee Berry");
-		assert.false.fullHP(battle.p1.active[0], "Physical Photon Geyser should be susceptible to Counter");
+	it(`should become physical when Attack stat is higher than Special Attack stat`, function () {
+		battle = common.createBattle([[
+			{species: 'Necrozma-Dusk-Mane', moves: ['photongeyser']},
+		], [
+			{species: 'Mew', item: 'keeberry', moves: ['counter']},
+		]]);
+
+		battle.makeChoices();
+		assert.statStage(battle.p2.active[0], 'def', 1, `physical Photon Geyser should trigger Kee Berry`);
+		assert.false.fullHP(battle.p1.active[0], `physical Photon Geyser should be susceptible to Counter`);
 	});
 
-	it('should determine which attack stat is higher after factoring in stat stages, but no other kind of modifier', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Latias", ability: 'hugepower', item: 'choiceband', moves: ['photongeyser']}]});
-		battle.setPlayer('p2', {team: [{species: "Scizor-Mega", ability: 'technician', item: 'keeberry', moves: ['strugglebug', 'sleeptalk']}]});
-		battle.makeChoices('move photongeyser', 'move strugglebug'); //should be special this turn (196 vs. 256)
-		assert.statStage(battle.p2.active[0], 'def', 0, "incorrectly swayed by Choice Band and/or Huge Power");
-		battle.makeChoices('move photongeyser', 'move sleeptalk'); //should be physical this turn (196 vs. 170)
-		assert.statStage(battle.p2.active[0], 'def', 1, "not correctly swayed by a stat drop");
+	it(`should determine which attack stat is higher after factoring in stat stages, but no other kind of modifier`, function () {
+		battle = common.createBattle([[
+			{species: 'Latias', ability: 'hugepower', item: 'choiceband', moves: ['photongeyser']},
+		], [
+			{species: 'Scizor-Mega', item: 'keeberry', moves: ['strugglebug', 'sleeptalk']},
+		]]);
+
+		const scizor = battle.p2.active[0];
+		battle.makeChoices(); //should be special this turn (196 vs. 256)
+		assert.statStage(scizor, 'def', 0, `incorrectly swayed by Choice Band and/or Huge Power`);
+		battle.makeChoices(); //should be special this turn (196 vs. 256)
+		assert.statStage(scizor, 'def', 1, `the stat drop should have turned Photon Geyser into a special move`);
 	});
 
-	it('should ignore abilities the same way as Mold Breaker', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Necrozma", ability: 'prismarmor', moves: ['photongeyser']}]});
-		battle.setPlayer('p2', {team: [{species: "Mimikyu", ability: 'disguise', moves: ['splash']}]});
-		battle.makeChoices('move photongeyser', 'move splash');
-		assert.false.fullHP(battle.p2.active[0]);
+	it(`should always be a special Max Move, never physical`, function () {
+		battle = common.createBattle([[
+			{species: 'conkeldurr', moves: ['photongeyser']},
+		], [
+			{species: 'cresselia', item: 'marangaberry', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move photongeyser dynamax', 'auto');
+		assert.statStage(battle.p2.active[0], 'spd', 1, `Photon Geyser behaved as a physical Max move, when it shouldn't`);
+	});
+
+	it(`should always be a special Z-move, never physical`, function () {
+		battle = common.gen(7).createBattle([[
+			{species: 'conkeldurr', item: 'psychiumz', moves: ['photongeyser']},
+		], [
+			{species: 'cresselia', item: 'marangaberry', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move photongeyser zmove', 'auto');
+		assert.statStage(battle.p2.active[0], 'spd', 1, `Photon Geyser behaved as a physical Z-move, when it shouldn't`);
+	});
+
+	it(`should ignore abilities the same way as Mold Breaker`, function () {
+		battle = common.createBattle([[
+			{species: 'Necrozma', moves: ['photongeyser']},
+		], [
+			{species: 'Zeraora', ability: 'voltabsorb', moves: ['electrify']},
+		]]);
+
+		battle.makeChoices();
+		assert.false.fullHP(battle.p2.active[0], `Electrified Photon Geyser should damage through Volt Absorb`);
 	});
 
 	it(`should not ignore abilities when called as a submove of another move`, function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [
+		battle = common.createBattle([[
 			{species: 'Liepard', ability: 'prankster', moves: ['assist', 'copycat', 'sleeptalk', 'photongeyser']},
-			{species: 'Necrozma', ability: 'prismarmor', moves: ['photongeyser']},
-		]});
-		battle.setPlayer('p2', {team: [{species: 'Bruxish', ability: 'dazzling', moves: ['photongeyser', 'spore']}]});
-		const pokemon = battle.p2.active[0];
+			{species: 'Necrozma', moves: ['photongeyser']},
+		], [
+			{species: 'Bruxish', ability: 'dazzling', moves: ['photongeyser', 'spore']},
+		]]);
+
+		const bruxish = battle.p2.active[0];
 		battle.makeChoices('move assist', 'move photongeyser');
-		assert.fullHP(pokemon, "incorrectly ignores abilities through Assist");
-		pokemon.hp = pokemon.maxhp;
+		assert.fullHP(bruxish, `incorrectly ignores abilities through Assist`);
+		bruxish.hp = bruxish.maxhp;
 		battle.makeChoices('move copycat', 'move spore');
-		assert.fullHP(pokemon, "incorrectly ignores abilities through Copycat");
-		pokemon.hp = pokemon.maxhp;
+		assert.fullHP(bruxish, `incorrectly ignores abilities through Copycat`);
+		bruxish.hp = bruxish.maxhp;
 		battle.makeChoices('move sleeptalk', 'move photongeyser');
-		assert.fullHP(pokemon, "incorrectly ignores abilities through Sleep Talk");
+		assert.fullHP(bruxish, `incorrectly ignores abilities through Sleep Talk`);
 	});
 
 	it(`should ignore abilities when called as a submove by a Pokemon that also has Mold Breaker`, function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Pangoro', ability: 'moldbreaker', moves: ['sleeptalk', 'photongeyser']}]});
-		battle.setPlayer('p2', {team: [{species: 'Mimikyu', ability: 'disguise', moves: ['spore']}]});
-		battle.makeChoices('move sleeptalk', 'move spore');
-		assert.false.fullHP(battle.p2.active[0]);
+		battle = common.createBattle([[
+			{species: 'Shuckle', ability: 'moldbreaker', moves: ['sleeptalk', 'photongeyser']},
+		], [
+			{species: 'Shedinja', ability: 'disguise', moves: ['spore']},
+		]]);
+
+		battle.makeChoices();
+		assert.fainted(battle.p2.active[0]);
 	});
 });

--- a/test/sim/moves/rapidspin.js
+++ b/test/sim/moves/rapidspin.js
@@ -10,37 +10,39 @@ describe('Rapid Spin', function () {
 		battle.destroy();
 	});
 
-	it('should remove entry hazards', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Omastar", moves: ['stealthrock', 'spikes', 'toxicspikes', 'substitute']}]});
-		battle.setPlayer('p2', {team: [{species: "Armaldo", moves: ['sleeptalk', 'rapidspin']}]});
-		battle.makeChoices('move stealthrock', 'move sleeptalk');
-		battle.makeChoices('move spikes', 'move sleeptalk');
+	it(`should remove entry hazards`, function () {
+		battle = common.createBattle([[
+			{species: 'Omastar', moves: ['stealthrock', 'spikes', 'toxicspikes', 'stickyweb']},
+		], [
+			{species: 'Armaldo', moves: ['sleeptalk', 'rapidspin']},
+		]]);
+		for (let i = 1; i < 5; i++) {
+			battle.makeChoices('move ' + i, 'auto');
+		}
 		battle.makeChoices('move toxicspikes', 'move rapidspin');
-		assert(!battle.p2.sideConditions['stealthrock']);
-		assert(!battle.p2.sideConditions['spikes']);
-		assert(!battle.p2.sideConditions['toxicspikes']);
+		const side = battle.p2.sideConditions;
+		assert(!side['stealthrock'] && !side['spikes'] && !side['toxicspikes'] && !side['stickyweb']);
 	});
 
-	it('should remove entry hazards past a Sub', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Omastar", moves: ['stealthrock', 'spikes', 'toxicspikes', 'substitute']}]});
-		battle.setPlayer('p2', {team: [{species: "Armaldo", moves: ['sleeptalk', 'rapidspin']}]});
-		battle.makeChoices('move stealthrock', 'move sleeptalk');
-		battle.makeChoices('move spikes', 'move sleeptalk');
-		battle.makeChoices('move toxicspikes', 'move sleeptalk');
+	it(`should remove entry hazards past a Substitute`, function () {
+		battle = common.createBattle([[
+			{species: 'Cobalion', moves: ['stealthrock', 'substitute']},
+		], [
+			{species: 'Armaldo', moves: ['sleeptalk', 'rapidspin']},
+		]]);
+		battle.makeChoices();
 		battle.makeChoices('move substitute', 'move rapidspin');
 		assert(!battle.p2.sideConditions['stealthrock']);
-		assert(!battle.p2.sideConditions['spikes']);
-		assert(!battle.p2.sideConditions['toxicspikes']);
 	});
 
-	it('should not remove hazards if the user faints', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Mew", item: 'rockyhelmet', moves: ['stealthrock', 'sleeptalk']}]});
-		battle.setPlayer('p2', {team: [{species: "Shedinja", moves: ['sleeptalk', 'rapidspin']}]});
-		battle.makeChoices('move stealthrock', 'move sleeptalk');
-		battle.makeChoices('move sleeptalk', 'move rapidspin');
+	it(`should not remove hazards if the user faints`, function () {
+		battle = common.createBattle([[
+			{species: 'Mew', item: 'rockyhelmet', moves: ['stealthrock']},
+		], [
+			{species: 'Shedinja', moves: ['rapidspin']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
 		assert(battle.p2.sideConditions['stealthrock']);
 	});
 });

--- a/test/sim/moves/skydrop.js
+++ b/test/sim/moves/skydrop.js
@@ -5,206 +5,269 @@ const common = require('./../../common');
 
 let battle;
 
-describe('Sky Drop', function () {
+describe.only('Sky Drop', function () {
 	afterEach(function () {
 		battle.destroy();
 	});
 
-	it('should prevent its target from moving when it is caught by the effect', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}]});
-		battle.setPlayer('p2', {team: [{species: "Lairon", ability: 'sturdy', moves: ['tackle']}]});
-		battle.makeChoices('move skydrop', 'move tackle');
-		assert.equal(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
-		battle.makeChoices('move skydrop', 'move tackle');
-		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
-	});
-
-	it('should prevent its target from switching out when it is caught by the effect', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}]});
-		battle.setPlayer('p2', {team: [
-			{species: "Lairon", ability: 'sturdy', moves: ['bulkup']},
-			{species: "Aggron", ability: 'sturdy', moves: ['bulkup']},
-		]});
-		battle.makeChoices('move skydrop', 'move bulkup');
-		assert.trapped(() => battle.makeChoices('move skydrop', 'switch aggron'));
-		assert.equal(battle.p2.active[0].species.id, 'lairon');
-	});
-
-	it('should prevent both the user and the target from being forced out when caught by the effect', function () {
-		battle = common.createBattle({gameType: 'doubles'});
-		battle.setPlayer('p1', {team: [
-			{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']},
-			{species: "Machamp", ability: 'noguard', moves: ['circlethrow']},
-			{species: "Kabutops", ability: 'swiftswim', moves: ['shellsmash']},
-		]});
-		battle.setPlayer('p2', {team: [
-			{species: "Armaldo", ability: 'battlearmor', moves: ['bulkup']},
-			{species: "Aggron", ability: 'noguard', moves: ['dragontail']},
-			{species: "Omastar", ability: 'swiftswim', moves: ['shellsmash']},
-		]});
-		battle.makeChoices('move skydrop 1, move circlethrow 1', 'move bulkup, move dragontail 1');
-		assert.equal(battle.p1.active[0].species.id, 'aerodactyl');
-		assert.equal(battle.p2.active[0].species.id, 'armaldo');
-	});
-
-	it('should prevent its target from using Mega Evolution when it is caught by the effect', function () {
-		battle = common.createBattle([
-			[{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}],
-			[{species: "Manectric", ability: 'intimidate', item: 'manectite', moves: ['charge']}],
-		]);
-		battle.makeChoices('move skydrop', 'move charge');
-		battle.makeChoices('move skydrop', 'move charge mega');
-		assert.equal(battle.p2.active[0].species.id, 'manectric');
-	});
-
-	it('should prevent its target from activating Stance Change when it is caught by the effect', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}]});
-		battle.setPlayer('p2', {team: [{species: "Aegislash", ability: 'stancechange', moves: ['tackle', 'kingsshield']}]});
-		battle.makeChoices('move skydrop', 'move tackle');
-		assert.equal(battle.p2.active[0].species.id, 'aegislash');
-		battle.makeChoices('move skydrop', 'move tackle');
-		assert.equal(battle.p2.active[0].species.id, 'aegislashblade');
-		battle.makeChoices('move skydrop', 'move tackle');
-		battle.makeChoices('move skydrop', 'move kingsshield');
-		assert.equal(battle.p2.active[0].species.id, 'aegislashblade');
-	});
-
-	it('should free its target and allow it to move if the user faints', function () {
-		battle = common.createBattle({gameType: 'doubles'}, [
-			[{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}, {species: "Kyogre", ability: 'noguard', moves: ['scald']}],
-			[{species: "Lairon", ability: 'sturdy', moves: ['bulkup']}, {species: "Aggron", ability: 'sturdy', moves: ['bulkup']}],
-		]);
-		battle.makeChoices('move skydrop 1, move scald -1', 'move bulkup, move bulkup');
-		assert.equal(battle.p2.active[0].boosts['atk'], 1);
-		assert.equal(battle.p2.active[0].boosts['def'], 1);
-	});
-
-	it('should pick up Flying-type Pokemon but do no damage', function () {
-		battle = common.createBattle([
-			[{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}],
-			[{species: "Salamence", ability: 'intimidate', moves: ['tackle']}],
-		]);
-		battle.makeChoices('move skydrop', 'move tackle');
-		assert.equal(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
-		battle.makeChoices('move skydrop', 'move tackle');
-		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
-	});
-
-	it('should pick up non-Flying weak Wonder Guard Pokemon but do no damage', function () {
-		battle = common.createBattle([
-			[{species: "Braviary", ability: 'keeneye', moves: ['skydrop']}],
-			[{species: "Shuckle", ability: 'wonderguard', moves: ['tackle']},
-			 {species: "Shedinja", ability: 'wonderguard', moves: ['sleeptalk']},
-			],
-		]);
-		battle.makeChoices('move skydrop', 'move tackle');
-		assert.equal(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
-		battle.makeChoices('move skydrop', 'move tackle');
-		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
-		battle.makeChoices('move skydrop', 'switch 2');
-		assert.hurts(battle.p2.active[0], () => battle.makeChoices('move skydrop', 'move sleeptalk'));
-	});
-
-	it('should only make contact on the way down', function () {
+	it(`should prevent its target from moving when it is caught by the effect`, function () {
 		battle = common.createBattle([[
-			{species: "Aerodactyl", moves: ['skydrop']},
+			{species: 'Aerodactyl', moves: ['skydrop']},
 		], [
-			{species: "Aegislash", moves: ['kingsshield']},
-			{species: "Ferrothorn", ability: 'ironbarbs', moves: ['harden']},
+			{species: 'Lairon', moves: ['tackle']},
 		]]);
-		battle.makeChoices('move Sky Drop', 'move Kings Shield');
-		assert.equal(battle.p1.active[0].boosts.atk, 0);
-		battle.makeChoices('move Sky Drop', 'switch Ferrothorn');
-		assert.equal(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
-		battle.makeChoices('move Sky Drop', 'move Harden');
-		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+
+		const aerodactyl = battle.p1.active[0];
+		battle.makeChoices();
+		assert.fullHP(aerodactyl);
+		battle.makeChoices();
+		assert.false.fullHP(aerodactyl);
 	});
 
-	it('should fail if the target has a Substitute', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Aerodactyl", ability: 'unnerve', moves: ['honeclaws', 'skydrop']}]});
-		battle.setPlayer('p2', {team: [{species: "Lairon", ability: 'sturdy', moves: ['substitute', 'tackle']}]});
-		battle.makeChoices('move honeclaws', 'move substitute');
+	it(`should prevent its target from switching out when it is caught by the effect`, function () {
+		battle = common.createBattle([[
+			{species: 'Aerodactyl', moves: ['skydrop']},
+		], [
+			{species: 'Lairon', moves: ['tackle']},
+			{species: 'Aggron', moves: ['tackle']},
+		]]);
+
+		battle.makeChoices();
+		assert.trapped(() => battle.makeChoices('auto', 'switch aggron'));
+	});
+
+	it(`should prevent both the user and the target from being forced out when caught by the effect`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Aerodactyl', moves: ['skydrop']},
+			{species: 'Machamp', ability: 'noguard', moves: ['circlethrow']},
+			{species: 'Kabutops', moves: ['sleeptalk']},
+		], [
+			{species: 'Armaldo', moves: ['sleeptalk']},
+			{species: 'Aggron', ability: 'noguard', moves: ['dragontail']},
+			{species: 'Omastar', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move skydrop 1, move circlethrow 1', 'move sleeptalk, move dragontail 1');
+		assert.species(battle.p1.active[0], 'Aerodactyl');
+		assert.species(battle.p2.active[0], 'Armaldo');
+	});
+
+	it.skip(`should prevent both the user and the target from being forced out by Eject Button`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Aerodactyl', item: 'ejectbutton', moves: ['skydrop']},
+			{species: 'Machamp', ability: 'noguard', moves: ['tackle']},
+			{species: 'Kabutops', moves: ['sleeptalk']},
+		], [
+			{species: 'Armaldo', item: 'ejectbutton', moves: ['sleeptalk']},
+			{species: 'Aggron', ability: 'noguard', moves: ['watergun']},
+			{species: 'Omastar', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move skydrop 1, move tackle 1', 'move sleeptalk, move watergun 1');
+		assert.holdsItem(battle.p1.active[0]);
+		assert.holdsItem(battle.p2.active[0]);
+	});
+
+	it(`should prevent its target from using Mega Evolution when it is caught by the effect`, function () {
+		battle = common.createBattle([[
+			{species: 'Aerodactyl', moves: ['skydrop']},
+		], [
+			{species: 'Manectric', item: 'manectite', moves: ['charge']},
+		]]);
+		battle.makeChoices();
+		battle.makeChoices('auto', 'move charge mega');
+		assert.false.species(battle.p2.active[0], 'Manectric-Mega');
+	});
+
+	it(`should prevent its target from activating Stance Change when it is caught by the effect`, function () {
+		battle = common.createBattle([[
+			{species: 'Aerodactyl', moves: ['skydrop']},
+		], [
+			{species: 'Aegislash', ability: 'stancechange', moves: ['tackle', 'kingsshield']},
+		]]);
+
+		const aegi = battle.p2.active[0];
+		battle.makeChoices();
+		assert.species(aegi, 'Aegislash');
+		battle.makeChoices();
+		assert.species(aegi, 'Aegislash-Blade');
+		battle.makeChoices();
+		battle.makeChoices('auto', 'move kingsshield');
+		assert.species(aegi, 'Aegislash-Blade');
+	});
+
+	it(`should free its target and allow it to move if the user faints`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Aerodactyl', moves: ['skydrop']},
+			{species: 'Kyogre', ability: 'noguard', moves: ['sheercold']},
+		], [
+			{species: 'Lairon', moves: ['swordsdance']},
+			{species: 'Aggron', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move skydrop 1, move sheercold -1', 'auto');
+		const lairon = battle.p2.active[0];
+		assert.statStage(lairon, 'atk', 2);
+	});
+
+	it(`should pick up Flying-type Pokemon but do no damage`, function () {
+		battle = common.createBattle([[
+			{species: 'Aerodactyl', moves: ['skydrop']},
+		], [
+			{species: 'Salamence', moves: ['tackle']},
+		]]);
+		battle.makeChoices();
+		assert.fullHP(battle.p1.active[0]);
 		battle.makeChoices('move skydrop', 'move tackle');
-		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.fullHP(battle.p2.active[0]);
 	});
 
-	it('should fail if the target is heavier than 200kg', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}]});
-		battle.setPlayer('p2', {team: [{species: "Aggron", ability: 'sturdy', moves: ['tackle']}]});
+	it(`should pick up non-Flying weak Wonder Guard Pokemon but do no damage`, function () {
+		battle = common.createBattle([[
+			{species: 'Aerodactyl', moves: ['skydrop']},
+		], [
+			{species: 'Shuckle', ability: 'wonderguard', moves: ['tackle']},
+			{species: 'Shedinja', ability: 'wonderguard', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		assert.fullHP(battle.p1.active[0]);
+		battle.makeChoices();
+		assert.fullHP(battle.p2.active[0]);
+		battle.makeChoices('auto', 'switch 2');
+		const shedinja = battle.p2.active[0];
+		assert.hurts(shedinja, () => battle.makeChoices());
+	});
+
+	it(`should only make contact on the way down`, function () {
+		battle = common.createBattle([[
+			{species: 'Aerodactyl', moves: ['skydrop']},
+		], [
+			{species: 'Aegislash', moves: ['kingsshield']},
+			{species: 'Ferrothorn', ability: 'ironbarbs', moves: ['sleeptalk']},
+		]]);
+		const aerodactyl = battle.p1.active[0];
+		battle.makeChoices();
+		assert.statStage(aerodactyl, 'atk', 0);
+		battle.makeChoices('auto', 'switch 2');
+		assert.fullHP(aerodactyl);
+		battle.makeChoices();
+		assert.false.fullHP(aerodactyl);
+	});
+
+	it(`should fail if the target has a Substitute`, function () {
+		battle = common.createBattle([[
+			{species: 'Aerodactyl', moves: ['sleeptalk', 'skydrop']},
+		], [
+			{species: 'Lairon', moves: ['substitute', 'tackle']},
+		]]);
+		battle.makeChoices();
 		battle.makeChoices('move skydrop', 'move tackle');
-		assert.notEqual(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+		assert.false.fullHP(battle.p1.active[0]);
 	});
 
-	it('should fail if used against an ally', function () {
-		battle = common.createBattle({gameType: 'doubles'}, [
-			[{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}, {species: "Smeargle", ability: 'owntempo', moves: ['spore']}],
-			[{species: "Lairon", ability: 'sturdy', moves: ['bulkup']}, {species: "Aggron", ability: 'sturdy', moves: ['bulkup']}],
-		]);
-		battle.makeChoices('move skydrop -2, move spore 1', 'move bulkup, move bulkup');
+	it(`should fail if the target is heavier than 200kg`, function () {
+		battle = common.createBattle([[
+			{species: 'Aerodactyl', moves: ['skydrop']},
+		], [
+			{species: 'Aggron', moves: ['tackle']},
+		]]);
+		battle.makeChoices();
+		assert.false.fullHP(battle.p1.active[0]);
+	});
+
+	it(`should fail if used against an ally`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Aerodactyl', moves: ['skydrop']},
+			{species: 'Smeargle', moves: ['spore']},
+		], [
+			{species: 'Lairon', moves: ['sleeptalk']},
+			{species: 'Aggron', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move skydrop -2, move spore 1', 'auto');
 		assert.equal(battle.p2.active[0].status, 'slp');
 	});
 
-	it('should hit its target even if its position changed with Ally Switch', function () {
-		battle = common.createBattle({gameType: 'doubles'}, [
-			[{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}, {species: "Smeargle", ability: 'owntempo', moves: ['splash']}],
-			[{species: "Lairon", ability: 'sturdy', moves: ['bulkup']}, {species: "Aggron", ability: 'sturdy', moves: ['bulkup', 'allyswitch']}],
-		]);
-		battle.makeChoices('move skydrop 1, move splash', 'move bulkup, move bulkup');
-		battle.makeChoices('move skydrop 1, move splash', 'move bulkup, move allyswitch');
-		assert.equal(battle.p2.active[1].species.id, 'lairon');
-		assert.notEqual(battle.p2.active[1].hp, battle.p2.active[1].maxhp);
-	});
-
-	it('should hit its target even if Follow Me is used that turn', function () {
-		battle = common.createBattle({gameType: 'doubles'}, [
-			[{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}, {species: "Smeargle", ability: 'owntempo', moves: ['splash']}],
-			[{species: "Lairon", ability: 'sturdy', moves: ['bulkup']}, {species: "Aggron", ability: 'sturdy', moves: ['bulkup', 'followme']}],
-		]);
-		battle.makeChoices('move skydrop 1, move splash', 'move bulkup, move bulkup');
-		battle.makeChoices('move skydrop 1, move splash', 'move bulkup, move followme');
-		assert.notEqual(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
-		assert.equal(battle.p2.active[1].hp, battle.p2.active[1].maxhp);
-	});
-
-	it('should cause most moves aimed at the user or target to miss', function () {
-		battle = common.createBattle({gameType: 'doubles'}, [
-			[{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}, {species: "Kabutops", ability: 'swiftswim', moves: ['aquajet']}],
-			[{species: "Lairon", ability: 'sturdy', moves: ['bulkup']}, {species: "Azumarill", ability: 'thickfat', moves: ['aquajet']}],
-		]);
-		battle.onEvent('Damage', battle.format, function (damage, target, source, effect) {
-			// mod Sky Drop to deal no damage
-			if (effect.id === 'skydrop') return 0;
-		});
-		battle.makeChoices('move skydrop 1, move aquajet 2', 'move bulkup, move aquajet 2');
-		// Aerodactyl and Lairon are now airborne from Sky Drop
-		battle.makeChoices('move skydrop 1, move aquajet 1', 'move bulkup, move aquajet 1');
-		assert.equal(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
-		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
-	});
-
-	it('should be cancelled by Gravity and allow the target to use its move', function () {
-		battle = common.createBattle({gameType: 'doubles'}, [
-			[{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}, {species: "Jirachi", ability: 'serenegrace', moves: ['gravity']}],
-			[{species: "Lairon", ability: 'sturdy', moves: ['bulkup']}, {species: "Aggron", ability: 'sturdy', moves: ['bulkup']}],
-		]);
-		battle.makeChoices('move skydrop 1, move gravity', 'move bulkup, move bulkup');
-		assert.equal(battle.p2.active[0].boosts['atk'], 1);
-		assert.equal(battle.p2.active[0].boosts['def'], 1);
-	});
-
-	it('should not suppress Speed Boost', function () {
-		battle = common.createBattle([[
-			{species: "Aerodactyl", moves: ['skydrop']},
+	it(`should hit its picked-up target even if its position changed with Ally Switch`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Aerodactyl', moves: ['skydrop']},
+			{species: 'Smeargle', moves: ['sleeptalk']},
 		], [
-			{species: "Mew", ability: 'speedboost', moves: ['splash']},
+			{species: 'Lairon', moves: ['sleeptalk']},
+			{species: 'Aggron', moves: ['sleeptalk', 'allyswitch']},
 		]]);
-		battle.makeChoices('move skydrop', 'move splash');
+		battle.makeChoices('move skydrop 1, move sleeptalk', 'auto');
+		battle.makeChoices('move skydrop 1, move sleeptalk', 'move sleeptalk, move allyswitch');
+		const lairon = battle.p2.active[1];
+		assert.species(lairon, 'Lairon');
+		assert.false.fullHP(lairon);
+	});
+
+	it(`should hit its target even if Follow Me would have otherwise redirected it`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Aerodactyl', moves: ['skydrop']},
+			{species: 'Smeargle', moves: ['sleeptalk']},
+		], [
+			{species: 'Lairon', moves: ['sleeptalk']},
+			{species: 'Clamperl', moves: ['followme']},
+		]]);
+
+		battle.makeChoices('move skydrop 1, move sleeptalk', 'auto');
+		battle.makeChoices();
+		assert.false.fullHP(battle.p2.active[0]);
+		assert.fullHP(battle.p2.active[1]);
+	});
+
+	it(`should cause most moves aimed at the user or target to miss`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Aerodactyl', moves: ['skydrop']},
+			{species: 'Kabutops', moves: ['sleeptalk', 'aquajet']},
+		], [
+			{species: 'Charizard', moves: ['sleeptalk']},
+			{species: 'Azumarill', moves: ['sleeptalk', 'aquajet']},
+		]]);
+
+		battle.makeChoices('move skydrop 1, move sleeptalk', 'auto');
+		battle.makeChoices('move skydrop 1, move aquajet 1', 'move sleeptalk, move aquajet 1');
+		assert.fullHP(battle.p1.active[0]);
+		assert.fullHP(battle.p2.active[0]);
+	});
+
+	it(`should be canceled by Gravity and allow the target to use its move`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Aerodactyl', moves: ['skydrop']},
+			{species: 'Jirachi', moves: ['gravity']},
+		], [
+			{species: 'Lairon', moves: ['swordsdance']},
+			{species: 'Clamperl', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		assert.statStage(battle.p2.active[0], 'atk', 2);
+	});
+
+	it(`should not suppress Speed Boost`, function () {
+		battle = common.createBattle([[
+			{species: 'Aerodactyl', moves: ['skydrop']},
+		], [
+			{species: 'Mew', ability: 'speedboost', moves: ['splash']},
+		]]);
+		battle.makeChoices();
 		assert.statStage(battle.p2.active[0], 'spe', 1);
+	});
+
+	it.skip(`should not claim to have dropped a Pokemon if it is already fainted`, function () {
+		battle = common.createBattle([[
+			{species: 'Shedinja', item: 'stickybarb', moves: ['sleeptalk']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		], [
+			{species: 'Aerodactyl', moves: ['skydrop']},
+		]]);
+
+		battle.makeChoices();
+		battle.makeChoices('switch 2');
+		battle.makeChoices();
+		assert(battle.log.indexOf('|-end|p1a: Wynaut|Sky Drop|[interrupt]') < 0, `Sky Drop should only announce that it failed, not that any Pokemon was freed.`);
 	});
 });
 
@@ -213,59 +276,65 @@ describe('Sky Drop [Gen 5]', function () {
 		battle.destroy();
 	});
 
-	it('should not fail even if the target is heavier than 200kg', function () {
-		battle = common.gen(5).createBattle([
-			[{species: "Aerodactyl", ability: 'unnerve', moves: ['skydrop']}],
-			[{species: "Aggron", ability: 'sturdy', moves: ['tackle']}],
-		]);
-		battle.makeChoices('move skydrop', 'move tackle');
-		assert.equal(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
+	it(`should not fail even if the target is heavier than 200kg`, function () {
+		battle = common.createBattle([[
+			{species: 'Aerodactyl', moves: ['skydrop']},
+		], [
+			{species: 'Aggron', moves: ['tackle']},
+		]]);
+		battle.makeChoices();
+		assert.fullHP(battle.p1.active[0]);
 	});
 
-	describe.skip('Sky Drop Glitch', function () {
+	describe(`Sky Drop Glitch`, function () {
 		beforeEach(function () {
-			battle = common.gen(5).createBattle({gameType: 'doubles'});
-			battle.setPlayer('p1', {team: [
-				{species: "Aerodactyl", ability: 'unnerve', moves: ['rockpolish', 'skydrop', 'dig']},
-				{species: "Arceus", ability: 'multitype', moves: ['recover', 'gravity']},
-				{species: "Aggron", ability: 'sturdy', moves: ['rest']},
-			]});
-			battle.setPlayer('p2', {team: [
-				{species: "Magikarp", ability: 'owntempo', moves: ['sleeptalk', 'tackle']},
-				{species: "Deoxys-Attack", ability: 'sturdy', moves: ['nastyplot', 'thunderbolt', 'roar']},
-				{species: "Azurill", ability: 'thickfat', moves: ['watersport']},
-			]});
+			battle = common.gen(5).createBattle({gameType: 'doubles'}, [[
+				{species: 'Aerodactyl', moves: ['rockpolish', 'skydrop', 'dig']},
+				{species: 'Alakazam', moves: ['recover', 'gravity']},
+				{species: 'Aggron', moves: ['rest']},
+			], [
+				{species: 'Magikarp', moves: ['sleeptalk', 'tackle']},
+				{species: 'Deoxys-Attack', ability: 'sturdy', moves: ['nastyplot', 'thunderbolt', 'roar']},
+				{species: 'Azurill', ability: 'thickfat', moves: ['watersport']},
+			]]);
 			console.log('-------------------------------');
 			battle.makeChoices('move skydrop 1, move gravity', 'move sleeptalk, move nastyplot');
 			// Magikarp should now be stuck because of the Sky Drop glitch.
 		});
 
-		it('should prevent the target from moving or switching', function () {
+		it(`should prevent the target from moving or switching`, function () {
+			const alakazam = battle.p1.active[1];
+			const magikarp = battle.p2.active[0];
 			battle.makeChoices('move rockpolish, move recover', 'move tackle 2, move nastyplot');
-			assert.equal(battle.p1.active[1].hp, battle.p1.active[1].maxhp);
+			assert.fullHP(alakazam);
 			battle.makeChoices('move rockpolish, move recover', 'switch azurill, move nastyplot');
-			assert.equal(battle.p2.active[0].species.id, 'magikarp');
+			assert.species(magikarp, 'Magikarp');
 		});
 
-		it('should prevent the user from being forced out', function () {
+		it(`should prevent the user from being forced out`, function () {
+			const aerodactyl = battle.p1.active[0];
 			battle.makeChoices('move rockpolish, move recover', 'move sleeptalk, move roar 1');
-			assert.equal(battle.p1.active[0].species.id, 'aerodactyl');
+			assert.species(aerodactyl, 'Aerodactyl');
 		});
 
-		it('should end when the user switches out', function () {
-			battle.makeChoices('switch 3, move rockpolish', 'move tackle 2, move nastyplot');
-			assert.notEqual(battle.p1.active[1].hp, battle.p1.active[1].maxhp);
+		it(`should end when the user switches out`, function () {
+			const alakazam = battle.p1.active[1];
+			battle.makeChoices('switch 3, move recover', 'move tackle 2, move nastyplot');
+			assert.false.fullHP(alakazam);
 		});
 
-		it('should end when the user faints', function () {
+		it(`should end when the user faints`, function () {
+			const alakazam = battle.p1.active[1];
 			battle.makeChoices('move rockpolish, move recover', 'move tackle 2, move thunderbolt 1');
-			assert.notEqual(battle.p1.active[1].hp, battle.p1.active[1].maxhp);
+			assert.false.fullHP(alakazam);
 		});
 
-		it('should end when the user completes another two-turn move', function () {
+		it(`should end when the user completes another two-turn move`, function () {
+			const alakazam = battle.p1.active[1];
+			battle.makeChoices('move dig 2, move recover', 'move sleeptalk, move nastyplot');
 			battle.makeChoices('move dig 2, move recover', 'move sleeptalk, move nastyplot');
 			battle.makeChoices('move rockpolish, move recover', 'move tackle 2, move nastyplot');
-			assert.notEqual(battle.p1.active[1].hp, battle.p1.active[1].maxhp);
+			assert.false.fullHP(alakazam);
 		});
 	});
 });

--- a/test/sim/moves/skydrop.js
+++ b/test/sim/moves/skydrop.js
@@ -277,7 +277,7 @@ describe('Sky Drop [Gen 5]', function () {
 	});
 
 	it(`should not fail even if the target is heavier than 200kg`, function () {
-		battle = common.createBattle([[
+		battle = common.gen(5).createBattle([[
 			{species: 'Aerodactyl', moves: ['skydrop']},
 		], [
 			{species: 'Aggron', moves: ['tackle']},
@@ -286,7 +286,7 @@ describe('Sky Drop [Gen 5]', function () {
 		assert.fullHP(battle.p1.active[0]);
 	});
 
-	describe(`Sky Drop Glitch`, function () {
+	describe.skip(`Sky Drop Glitch`, function () {
 		beforeEach(function () {
 			battle = common.gen(5).createBattle({gameType: 'doubles'}, [[
 				{species: 'Aerodactyl', moves: ['rockpolish', 'skydrop', 'dig']},

--- a/test/sim/moves/skydrop.js
+++ b/test/sim/moves/skydrop.js
@@ -5,7 +5,7 @@ const common = require('./../../common');
 
 let battle;
 
-describe.only('Sky Drop', function () {
+describe('Sky Drop', function () {
 	afterEach(function () {
 		battle.destroy();
 	});

--- a/test/sim/moves/sparklingaria.js
+++ b/test/sim/moves/sparklingaria.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Sparkling Aria', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it(`should cure the target's burn`, function () {
+		battle = common.createBattle([[
+			{species: 'Wynaut', ability: 'compoundeyes', moves: ['will-o-wisp', 'sparklingaria']},
+		], [
+			{species: 'Chansey', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		battle.makeChoices('move sparklingaria', 'auto');
+
+		assert.equal(battle.p2.active[0].status, '');
+	});
+
+	it.skip(`should not cure the target's burn if the user fainted`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Shedinja', moves: ['sparklingaria']},
+			{species: 'Wynaut', level: 1, ability: 'innardsout', moves: ['sleeptalk']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		], [
+			{species: 'Chansey', moves: ['sleeptalk']},
+			{species: 'Gengar', ability: 'compoundeyes', moves: ['willowisp']},
+		]]);
+
+		battle.makeChoices('auto', 'move sleeptalk, move willowisp -1');
+		assert.equal(battle.p2.active[0].status, 'brn');
+	});
+});

--- a/test/sim/moves/stompingtantrum.js
+++ b/test/sim/moves/stompingtantrum.js
@@ -105,4 +105,19 @@ describe('Stomping Tantrum', function () {
 		battle.makeChoices('move splash zmove', 'move gravity');
 		battle.makeChoices('move stomping tantrum', 'move gravity');
 	});
+
+	it.skip(`should not double its base power if the user dropped mid-Fly due to Smack Down`, function () {
+		battle = common.createBattle([[
+			{species: 'Magikarp', moves: ['fly', 'stompingtantrum']},
+		], [
+			{species: 'Wynaut', moves: ['smackdown']},
+		]]);
+
+		battle.onEvent('BasePower', battle.format, function (basePower, pokemon, target, move) {
+			if (move.id === 'stompingtantrum') assert.equal(basePower, 75);
+		});
+
+		battle.makeChoices();
+		battle.makeChoices('move stompingtantrum', 'auto');
+	});
 });

--- a/test/sim/moves/stompingtantrum.js
+++ b/test/sim/moves/stompingtantrum.js
@@ -10,46 +10,46 @@ describe('Stomping Tantrum', function () {
 		battle.destroy();
 	});
 
-	it('should double its Base Power if the last move used on the previous turn failed', function () {
-		battle = common.createBattle([
-			[{species: 'Marowak', ability: 'rockhead', moves: ['attract', 'spore', 'stompingtantrum']}],
-			[{species: 'Manaphy', ability: 'hydration', moves: ['rest']}],
-		]);
+	it(`should double its Base Power if the last move used on the previous turn failed`, function () {
+		battle = common.createBattle([[
+			{species: 'Marowak', moves: ['attract', 'spore', 'stompingtantrum']},
+		], [
+			{species: 'Manaphy', moves: ['rest']},
+		]]);
 
 		battle.onEvent('BasePower', battle.format, function (basePower) {
 			assert.equal(basePower, 150);
 		});
 
-		battle.makeChoices('move attract', 'move rest');
+		battle.makeChoices('move attract', 'move rest'); // Manaphy is genderless, so Attract fails
 		battle.makeChoices('move stompingtantrum', 'move rest');
-		battle.makeChoices('move spore', 'move rest');
+		battle.makeChoices('move spore', 'move rest'); // Manaphy is now asleep, so Spore fails
 		battle.makeChoices('move stompingtantrum', 'move rest');
 	});
 
-	it('should not double its Base Power if the last move used on the previous turn hit protect', function () {
-		battle = common.createBattle([
-			[{species: 'Marowak', ability: 'rockhead', moves: ['stompingtantrum']}],
-			[{species: 'Manaphy', ability: 'hydration', moves: ['protect', 'tailglow']}],
-		]);
+	it(`should not double its Base Power if the last move used on the previous turn hit Protect`, function () {
+		battle = common.createBattle([[
+			{species: 'Marowak', moves: ['stompingtantrum']},
+		], [
+			{species: 'Manaphy', moves: ['protect', 'sleeptalk']},
+		]]);
 
 		battle.onEvent('BasePower', battle.format, function (basePower) {
 			assert.equal(basePower, 75);
 		});
 
 		battle.makeChoices('move stompingtantrum', 'move protect');
-		battle.makeChoices('move stompingtantrum', 'move tailglow');
+		battle.makeChoices('move stompingtantrum', 'move sleeptalk');
 	});
 
-	it('should double its Base Power if the last move used was a spread move that partially hit protect and otherwise failed', function () {
-		battle = common.createBattle({gameType: 'doubles'});
-		battle.setPlayer('p1', {team: [
-			{species: 'Cresselia', ability: 'levitate', moves: ['sunnyday']},
-			{species: 'Groudon', ability: 'drought', moves: ['stompingtantrum', 'precipiceblades']},
-		]});
-		battle.setPlayer('p2', {team: [
-			{species: 'Tapu lele', ability: 'psychicsurge', moves: ['protect', 'calmmind']},
-			{species: 'Ho-Oh', ability: 'pressure', moves: ['recover']},
-		]});
+	it(`should double its Base Power if the last move used was a spread move that partially hit Protect and otherwise failed`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Cresselia', moves: ['sunnyday']},
+			{species: 'Groudon', ability: 'noguard', moves: ['stompingtantrum', 'precipiceblades']},
+		], [
+			{species: 'Tapu Lele', moves: ['protect', 'calmmind']},
+			{species: 'Ho-Oh', moves: ['recover']},
+		]]);
 
 		battle.onEvent('BasePower', battle.format, function (basePower, attacker, defender, move) {
 			if (move.id === 'stompingtantrum') assert.equal(basePower, 150);
@@ -59,36 +59,53 @@ describe('Stomping Tantrum', function () {
 		battle.makeChoices('move sunnyday, move stompingtantrum 1', 'move calmmind, move recover');
 	});
 
-	it('should not double its Base Power if the last move used on the previous turn was a successful Celebrate', function () {
-		battle = common.createBattle([
-			[{species: 'Snorlax', ability: 'thickfat', moves: ['celebrate', 'stompingtantrum']}],
-			[{species: 'Manaphy', ability: 'hydration', moves: ['rest']}],
-		]);
+	it(`should not double its Base Power if the last move used on the previous turn was a successful Celebrate`, function () {
+		battle = common.createBattle([[
+			{species: 'Snorlax', moves: ['celebrate', 'stompingtantrum']},
+		], [
+			{species: 'Manaphy', moves: ['sleeptalk']},
+		]]);
 
 		battle.onEvent('BasePower', battle.format, function (basePower) {
 			assert.equal(basePower, 75);
 		});
 
-		battle.makeChoices('move celebrate', 'move rest');
-		battle.makeChoices('move stompingtantrum', 'move rest');
+		battle.makeChoices('move celebrate', 'auto');
+		battle.makeChoices('move stompingtantrum', 'auto');
 	});
 
-	it('should not double its Base Power if the last "move" used on the previous turn was a recharge', function () {
-		battle = common.createBattle([
-			[{species: 'Marowak-Alola', ability: 'rockhead', moves: ['stompingtantrum', 'hyperbeam']}],
-			[{species: 'Lycanroc-Midnight', ability: 'noguard', moves: ['sleeptalk']}],
-		]);
+	it(`should not double its Base Power if the last "move" used on the previous turn was a recharge`, function () {
+		battle = common.createBattle([[
+			{species: 'Marowak-Alola', ability: 'noguard', moves: ['stompingtantrum', 'hyperbeam']},
+		], [
+			{species: 'Lycanroc-Midnight', moves: ['sleeptalk']},
+		]]);
 
 		battle.onEvent('BasePower', battle.format, function (basePower, pokemon, target, move) {
 			if (move.id === 'stompingtantrum') assert.equal(basePower, 75);
 		});
 
-		battle.makeChoices('move hyperbeam', 'move sleeptalk');
-		battle.makeChoices('move recharge', 'move sleeptalk');
-		battle.makeChoices('move stompingtantrum', 'move sleeptalk');
+		battle.makeChoices('move hyperbeam', 'auto');
+		battle.makeChoices('move recharge', 'auto');
+		battle.makeChoices('move stompingtantrum', 'auto');
 	});
 
-	it('should cause Gravity-negated moves to double in BP, even Z-moves', function () {
+	it.skip(`should not double its Base Power if the user dropped mid-Fly due to Smack Down`, function () {
+		battle = common.createBattle([[
+			{species: 'Magikarp', moves: ['fly', 'stompingtantrum']},
+		], [
+			{species: 'Wynaut', moves: ['smackdown']},
+		]]);
+
+		battle.onEvent('BasePower', battle.format, function (basePower, pokemon, target, move) {
+			if (move.id === 'stompingtantrum') assert.equal(basePower, 75);
+		});
+
+		battle.makeChoices();
+		battle.makeChoices('move stompingtantrum', 'auto');
+	});
+
+	it(`should cause Gravity-negated moves to double in BP, even Z-moves`, function () {
 		battle = common.gen(7).createBattle([[
 			{species: "Magikarp", item: 'normaliumz', moves: ['splash', 'stompingtantrum']},
 		], [
@@ -104,20 +121,5 @@ describe('Stomping Tantrum', function () {
 
 		battle.makeChoices('move splash zmove', 'move gravity');
 		battle.makeChoices('move stomping tantrum', 'move gravity');
-	});
-
-	it.skip(`should not double its base power if the user dropped mid-Fly due to Smack Down`, function () {
-		battle = common.createBattle([[
-			{species: 'Magikarp', moves: ['fly', 'stompingtantrum']},
-		], [
-			{species: 'Wynaut', moves: ['smackdown']},
-		]]);
-
-		battle.onEvent('BasePower', battle.format, function (basePower, pokemon, target, move) {
-			if (move.id === 'stompingtantrum') assert.equal(basePower, 75);
-		});
-
-		battle.makeChoices();
-		battle.makeChoices('move stompingtantrum', 'auto');
 	});
 });


### PR DESCRIPTION
This adds 10 new skipped tests, fixes some of the Sky Drop glitch tests that were failing because of bad syntax and not because the condition wouldn't have worked, adds passing unit tests for things missing it that probably should have it (e.g. Gulp Missile), and cleaned up many tests to use our standard style of checking things (obviously not comprehensive, I just tackled a file if I happened to be working in it). [Updated as of here with bug reports](https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-8860308).

As of this PR, I think we have 39 skipped mechanics tests and 3 major sets of tests not implemented (the three are glitches: Symbiosis Eject Button, Sky Drop Gravity, and Rollout Storage). We're generally speaking doing pretty good about keeping these in check! Client definitely has more repeated mechanics bugs overall throughout the bug reports thread.