### PR TITLE
Fix Gen 3 Weather Ball and Gen 4 Trick

### DIFF
--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -137,10 +137,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 			onDamagePriority: -101,
 			onDamage(damage, target, source, effect) {
-				const weatherball = (effect.id === 'weatherball' && this.field.effectiveWeather() !== '');
 				if (
 					effect.effectType === 'Move' && !source.isAlly(target) &&
-					this.getCategory(effect.id) === 'Physical' && !weatherball
+					(effect.category === 'Physical' || effect.id === 'hiddenpower')
 				) {
 					this.effectState.slot = source.getSlot();
 					this.effectState.damage = 2 * damage;
@@ -418,10 +417,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 			onDamagePriority: -101,
 			onDamage(damage, target, source, effect) {
-				const weatherball = (effect.id === 'weatherball' && this.field.effectiveWeather() !== '');
 				if (
 					effect.effectType === 'Move' && !source.isAlly(target) &&
-					(this.getCategory(effect.id) === 'Special' || weatherball)
+					effect.category === 'Special' && effect.id !== 'hiddenpower'
 				) {
 					this.effectState.slot = source.getSlot();
 					this.effectState.damage = 2 * damage;

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -413,7 +413,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 			onDamagePriority: -101,
 			onDamage(damage, target, source, effect) {
-				if (effect.effectType === 'Move' && !source.isAlly(target) && this.getCategory(effect.id) === 'Special') {
+				if (effect.effectType === 'Move' && !source.isAlly(target) &&
+				this.getCategory(effect.id) === 'Special' && effect.id !== 'weatherball') {
 					this.effectState.slot = source.getSlot();
 					this.effectState.damage = 2 * damage;
 				}

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -413,8 +413,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 			onDamagePriority: -101,
 			onDamage(damage, target, source, effect) {
-				if (effect.effectType === 'Move' && !source.isAlly(target) &&
-				this.getCategory(effect.id) === 'Special' && effect.id !== 'weatherball') {
+				if (
+					effect.effectType === 'Move' && !source.isAlly(target) &&
+					this.getCategory(effect.id) === 'Special' && effect.id !== 'weatherball'
+				) {
 					this.effectState.slot = source.getSlot();
 					this.effectState.damage = 2 * damage;
 				}

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -137,7 +137,11 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 			onDamagePriority: -101,
 			onDamage(damage, target, source, effect) {
-				if (effect.effectType === 'Move' && !source.isAlly(target) && this.getCategory(effect.id) === 'Physical') {
+				const weatherball = (effect.id === 'weatherball' && this.field.effectiveWeather() !== '');
+				if (
+					effect.effectType === 'Move' && !source.isAlly(target) &&
+					this.getCategory(effect.id) === 'Physical' && !weatherball
+				) {
 					this.effectState.slot = source.getSlot();
 					this.effectState.damage = 2 * damage;
 				}
@@ -413,9 +417,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 			onDamagePriority: -101,
 			onDamage(damage, target, source, effect) {
+				const weatherball = (effect.id === 'weatherball' && this.field.effectiveWeather() !== '');
 				if (
 					effect.effectType === 'Move' && !source.isAlly(target) &&
-					this.getCategory(effect.id) === 'Special' && effect.id !== 'weatherball'
+					(this.getCategory(effect.id) === 'Special' || weatherball)
 				) {
 					this.effectState.slot = source.getSlot();
 					this.effectState.damage = 2 * damage;

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -1345,6 +1345,12 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		flags: {authentic: 1},
 	},
+	trick: {
+		inherit: true,
+		onTryHit(target, source, move) {
+			if (target.hasAbility('multitype')) return false;
+		},
+	},
 	uproar: {
 		inherit: true,
 		basePower: 50,

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -1221,6 +1221,12 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			}
 		},
 	},
+	switcheroo: {
+		inherit: true,
+		onTryHit(target, source, move) {
+			if (target.hasAbility('multitype') || source.hasAbility('multitype')) return false;
+		},
+	},
 	synthesis: {
 		inherit: true,
 		onHit(pokemon) {
@@ -1348,7 +1354,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	trick: {
 		inherit: true,
 		onTryHit(target, source, move) {
-			if (target.hasAbility('multitype')) return false;
+			if (target.hasAbility('multitype') || source.hasAbility('multitype')) return false;
 		},
 	},
 	uproar: {

--- a/test/sim/moves/sleeptalk.js
+++ b/test/sim/moves/sleeptalk.js
@@ -19,15 +19,4 @@ describe('Sleep Talk', function () {
 		assert.fullHP(battle.p2.active[0]);
 		assert.match(battle.log[battle.lastMoveLine + 1], /^\|cant.*move: Gravity|High Jump Kick$/, 'should log that High Jump Kick failed');
 	});
-
-	it.skip('should deduct PP even if it fails in gen 4', function () {
-		battle = common.gen(4).createBattle([[
-			{species: 'metagross', moves: ['sleeptalk']},
-		], [
-			{species: 'feebas', moves: ['splash']},
-		]]);
-		const pokemon = battle.p1.active[0];
-		battle.makeChoices();
-		assert.equal(pokemon.getMoveData('sleeptalk').pp, 15);
-	});
 });

--- a/test/sim/moves/sleeptalk.js
+++ b/test/sim/moves/sleeptalk.js
@@ -19,4 +19,15 @@ describe('Sleep Talk', function () {
 		assert.fullHP(battle.p2.active[0]);
 		assert.match(battle.log[battle.lastMoveLine + 1], /^\|cant.*move: Gravity|High Jump Kick$/, 'should log that High Jump Kick failed');
 	});
+
+	it.skip('should deduct PP even if it fails in gen 4', function () {
+		battle = common.gen(4).createBattle([[
+			{species: 'metagross', moves: ['sleeptalk']},
+		], [
+			{species: 'feebas', moves: ['splash']},
+		]]);
+		const pokemon = battle.p1.active[0];
+		battle.makeChoices();
+		assert.equal(pokemon.getMoveData('sleeptalk').pp, 15);
+	});
 });

--- a/test/sim/moves/weatherball.js
+++ b/test/sim/moves/weatherball.js
@@ -62,7 +62,7 @@ describe('Weather Ball', function () {
 
 	it('should trigger counter when it is physical during gen 3', function () {
 		battle = common.gen(3).createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Sawk', ability: 'plus', moves: ['weatherball']}]});
+		battle.setPlayer('p1', {team: [{species: 'Sawk', ability: 'Sand Stream', moves: ['weatherball']}]});
 		battle.setPlayer('p2', {team: [{species: 'Throh', ability: 'guts', moves: ['counter']}]});
 		battle.makeChoices();
 		assert.notEqual(battle.p1.active[0].maxhp, battle.p1.active[0].hp);

--- a/test/sim/moves/weatherball.js
+++ b/test/sim/moves/weatherball.js
@@ -38,33 +38,33 @@ describe('Weather Ball', function () {
 
 	it('should not trigger counter when it is special during gen 3', function () {
 		battle = common.gen(3).createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Sawk', ability: 'drizzle', moves: ['weatherball']}]});
-		battle.setPlayer('p2', {team: [{species: 'Throh', ability: 'guts', moves: ['counter']}]});
+		battle.setPlayer('p1', {team: [{species: 'Shuckle', ability: 'drizzle', moves: ['weatherball']}]});
+		battle.setPlayer('p2', {team: [{species: 'Shuckle', moves: ['counter']}]});
 		battle.makeChoices();
-		assert.equal(battle.p1.active[0].maxhp, battle.p1.active[0].hp);
+		assert.fullHP(battle.p1.active[0]);
 	});
 
 	it('should trigger mirror coat when it is special during gen 3', function () {
 		battle = common.gen(3).createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Sawk', ability: 'drizzle', moves: ['weatherball']}]});
-		battle.setPlayer('p2', {team: [{species: 'Throh', ability: 'guts', moves: ['mirrorcoat']}]});
+		battle.setPlayer('p1', {team: [{species: 'Shuckle', ability: 'drought', moves: ['weatherball']}]});
+		battle.setPlayer('p2', {team: [{species: 'Shuckle', moves: ['mirrorcoat']}]});
 		battle.makeChoices();
-		assert.notEqual(battle.p1.active[0].maxhp, battle.p1.active[0].hp);
+		assert.false.fullHP(battle.p1.active[0]);
 	});
 
 	it('should not trigger mirror coat when it is physical during gen 3', function () {
 		battle = common.gen(3).createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Sawk', ability: 'plus', moves: ['weatherball']}]});
-		battle.setPlayer('p2', {team: [{species: 'Throh', ability: 'guts', moves: ['mirrorcoat']}]});
+		battle.setPlayer('p1', {team: [{species: 'Shuckle', moves: ['weatherball']}]});
+		battle.setPlayer('p2', {team: [{species: 'Shuckle', moves: ['mirrorcoat']}]});
 		battle.makeChoices();
-		assert.equal(battle.p1.active[0].maxhp, battle.p1.active[0].hp);
+		assert.fullHP(battle.p1.active[0]);
 	});
 
 	it('should trigger counter when it is physical during gen 3', function () {
 		battle = common.gen(3).createBattle();
-		battle.setPlayer('p1', {team: [{species: 'Sawk', ability: 'Sand Stream', moves: ['weatherball']}]});
-		battle.setPlayer('p2', {team: [{species: 'Throh', ability: 'guts', moves: ['counter']}]});
+		battle.setPlayer('p1', {team: [{species: 'Shuckle', ability: 'sandstream', moves: ['weatherball']}]});
+		battle.setPlayer('p2', {team: [{species: 'Shuckle', moves: ['counter']}]});
 		battle.makeChoices();
-		assert.notEqual(battle.p1.active[0].maxhp, battle.p1.active[0].hp);
+		assert.false.fullHP(battle.p1.active[0]);
 	});
 });

--- a/test/sim/moves/weatherball.js
+++ b/test/sim/moves/weatherball.js
@@ -35,4 +35,36 @@ describe('Weather Ball', function () {
 		battle.makeChoices('move assist zmove', 'move splash');
 		assert(!battle.p2.active[0].fainted);
 	});
+
+	it('should not trigger counter when it is special during gen 3', function () {
+		battle = common.gen(3).createBattle();
+		battle.setPlayer('p1', {team: [{species: 'Sawk', ability: 'drizzle', moves: ['weatherball']}]});
+		battle.setPlayer('p2', {team: [{species: 'Throh', ability: 'guts', moves: ['counter']}]});
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].maxhp, battle.p1.active[0].hp);
+	});
+
+	it('should trigger mirror coat when it is special during gen 3', function () {
+		battle = common.gen(3).createBattle();
+		battle.setPlayer('p1', {team: [{species: 'Sawk', ability: 'drizzle', moves: ['weatherball']}]});
+		battle.setPlayer('p2', {team: [{species: 'Throh', ability: 'guts', moves: ['mirrorcoat']}]});
+		battle.makeChoices();
+		assert.notEqual(battle.p1.active[0].maxhp, battle.p1.active[0].hp);
+	});
+
+	it('should not trigger mirror coat when it is physical during gen 3', function () {
+		battle = common.gen(3).createBattle();
+		battle.setPlayer('p1', {team: [{species: 'Sawk', ability: 'plus', moves: ['weatherball']}]});
+		battle.setPlayer('p2', {team: [{species: 'Throh', ability: 'guts', moves: ['mirrorcoat']}]});
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].maxhp, battle.p1.active[0].hp);
+	});
+
+	it('should trigger counter when it is physical during gen 3', function () {
+		battle = common.gen(3).createBattle();
+		battle.setPlayer('p1', {team: [{species: 'Sawk', ability: 'plus', moves: ['weatherball']}]});
+		battle.setPlayer('p2', {team: [{species: 'Throh', ability: 'guts', moves: ['counter']}]});
+		battle.makeChoices();
+		assert.notEqual(battle.p1.active[0].maxhp, battle.p1.active[0].hp);
+	});
 });


### PR DESCRIPTION
Gen 3 weather ball no longer triggers mirror coat

Gen 4 trick fails when the target has multitype

Also added a test for sleep talk PP deduction in gen 4