### PR TITLE
Gen 3: Always break the opponents screens with Brick Break

### DIFF
--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -98,6 +98,15 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		accuracy: 100,
 		ignoreAccuracy: true,
 	},
+	brickbreak: {
+		inherit: true,
+		onTryHit(target, source) {
+			// will shatter screens through sub, before you hit
+			const foe = source.side.foe;
+			foe.removeSideCondition('reflect');
+			foe.removeSideCondition('lightscreen');
+		},
+	},
 	charge: {
 		inherit: true,
 		boosts: null,

--- a/data/text/moves.ts
+++ b/data/text/moves.ts
@@ -603,6 +603,9 @@ export const MovesText: {[k: string]: MoveText} = {
 			desc: "If this attack does not miss and whether or not the target is immune, the effects of Reflect and Light Screen end for the target's side of the field before damage is calculated.",
 			shortDesc: "Destroys screens, even if the target is immune.",
 		},
+		gen3: {
+			desc: "If this attack does not miss and whether or not the target is immune, the effects of Reflect and Light Screen end for the opponent's side of the field before damage is calculated.",
+		},
 
 		activate: "  [POKEMON] shattered [TEAM]'s protections!",
 	},

--- a/test/sim/moves/brickbreak.js
+++ b/test/sim/moves/brickbreak.js
@@ -94,13 +94,13 @@ describe('Brick Break', function () {
 		assert.false(battle.p2.sideConditions['reflect']);
 	});
 
-	it('should break the foe\'s Reflect when used against an ally in Gen 3', function () {
+	it(`should break the foe's Reflect when used against an ally in Gen 3`, function () {
 		battle = common.gen(3).createBattle({gameType: 'doubles'}, [[
 			{species: "mew", moves: ['brickbreak', 'splash']},
 			{species: "mew", moves: ['splash']},
 		], [
 			{species: "gengar", moves: ['reflect', 'splash']},
-			{species: "gengar", moves: ['splash']}
+			{species: "gengar", moves: ['splash']},
 		]]);
 
 		battle.makeChoices('move splash, move splash', 'move reflect, move splash');

--- a/test/sim/moves/brickbreak.js
+++ b/test/sim/moves/brickbreak.js
@@ -93,4 +93,20 @@ describe('Brick Break', function () {
 		battle.makeChoices('move brickbreak', 'move electrify');
 		assert.false(battle.p2.sideConditions['reflect']);
 	});
+
+	it('should break the opponents Reflect when used against an ally in Gen 3', function () {
+		battle = common.gen(3).createBattle({gameType: 'doubles'}, [[
+			{species: "mew", moves: ['brickbreak', 'splash']},
+			{species: "mew", moves: ['splash']},
+		], [
+			{species: "gengar", moves: ['reflect', 'splash']},
+			{species: "gengar", moves: ['splash']}
+		]]);
+
+		battle.makeChoices('move splash, move splash', 'move reflect, move splash');
+		assert(battle.p2.sideConditions['reflect']);
+
+		battle.makeChoices('move brickbreak -2, move splash', 'move splash, move splash');
+		assert.false(battle.p2.sideConditions['reflect']);
+	});
 });

--- a/test/sim/moves/brickbreak.js
+++ b/test/sim/moves/brickbreak.js
@@ -94,7 +94,7 @@ describe('Brick Break', function () {
 		assert.false(battle.p2.sideConditions['reflect']);
 	});
 
-	it('should break the opponents Reflect when used against an ally in Gen 3', function () {
+	it('should break the foe\'s Reflect when used against an ally in Gen 3', function () {
 		battle = common.gen(3).createBattle({gameType: 'doubles'}, [[
 			{species: "mew", moves: ['brickbreak', 'splash']},
 			{species: "mew", moves: ['splash']},


### PR DESCRIPTION
Wasn't mentioned as a past gen bug, but saw it while reading up on the other old gen Brick Break bug on Bulbapedia and noticed this behavior wasn't implemented.