### PR TITLE
Allow Weezing-Galar to have a VC transfer move without its Hidden Ability

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1013,7 +1013,7 @@ export class TeamValidator {
 				generation: 2,
 				level: isMew ? 5 : isCelebi ? 30 : 3, // Level 1/2 Pokémon can't be obtained by transfer from RBY/GSC
 				perfectIVs: isMew || isCelebi ? 5 : 3,
-				isHidden: !!(!isWeezingGalar && this.dex.mod('gen7').species.get(species.id).abilities['H']),
+				isHidden: !isWeezingGalar && !!this.dex.mod('gen7').species.get(species.id).abilities['H'],
 				shiny: isMew ? undefined : 1,
 				pokeball: 'pokeball',
 				from: 'Gen 1-2 Virtual Console transfer',

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1008,11 +1008,12 @@ export class TeamValidator {
 		} else if (source === '7V') {
 			const isMew = species.id === 'mew';
 			const isCelebi = species.id === 'celebi';
+			const isWeezingGalar = species.id === 'weezinggalar';
 			eventData = {
 				generation: 2,
 				level: isMew ? 5 : isCelebi ? 30 : 3, // Level 1/2 Pokémon can't be obtained by transfer from RBY/GSC
 				perfectIVs: isMew || isCelebi ? 5 : 3,
-				isHidden: !!this.dex.mod('gen7').species.get(species.id).abilities['H'],
+				isHidden: !!(!isWeezingGalar && this.dex.mod('gen7').species.get(species.id).abilities['H']),
 				shiny: isMew ? undefined : 1,
 				pokeball: 'pokeball',
 				from: 'Gen 1-2 Virtual Console transfer',


### PR DESCRIPTION
hardcoded but I don't think there's another solution (aside from remove Galarian Weezing's HA in the gen 7 mod but that seems dumb)