### PR TITLE
Sky Drop: Fix message when target is fainted

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -15574,7 +15574,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 			if (source.volatiles['twoturnmove'] && source.volatiles['twoturnmove'].duration === 1) {
 				source.removeVolatile('skydrop');
 				source.removeVolatile('twoturnmove');
-				this.add('-end', target, 'Sky Drop', '[interrupt]');
+				if (target === this.effectState.target) {
+					this.add('-end', target, 'Sky Drop', '[interrupt]');
+				}
 			}
 		},
 		onTry(source, target) {

--- a/test/sim/moves/skydrop.js
+++ b/test/sim/moves/skydrop.js
@@ -256,7 +256,7 @@ describe('Sky Drop', function () {
 		assert.statStage(battle.p2.active[0], 'spe', 1);
 	});
 
-	it.skip(`should not claim to have dropped a Pokemon if it is already fainted`, function () {
+	it(`should not claim to have dropped a Pokemon if it is already fainted`, function () {
 		battle = common.createBattle([[
 			{species: 'Shedinja', item: 'stickybarb', moves: ['sleeptalk']},
 			{species: 'Wynaut', moves: ['sleeptalk']},


### PR DESCRIPTION
Checks to see if the current target is the one originally picked up by sky drop. I could also check for `this.effectState.target.fainted`, but I thought this would encompass more stuff.