### PR TITLE
Gen 1: Move Victreebel and Lapras to OU by technicality

### DIFF
--- a/data/mods/gen1/formats-data.ts
+++ b/data/mods/gen1/formats-data.ts
@@ -368,7 +368,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		randomBattleMoves: ["sleeppowder", "bodyslam", "stunspore"],
 		essentialMove: "razorleaf",
 		comboMoves: ["swordsdance", "hyperbeam"],
-		tier: "OU",
+		tier: "(OU)",
 	},
 	tentacool: {
 		randomBattleMoves: ["barrier", "hydropump", "surf"],
@@ -665,7 +665,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		randomBattleMoves: ["surf", "bodyslam", "sing", "rest", "confuseray"],
 		essentialMove: "blizzard",
 		exclusiveMoves: ["thunderbolt", "thunderbolt"],
-		tier: "OU",
+		tier: "(OU)",
 	},
 	ditto: {
 		randomBattleMoves: ["transform"],


### PR DESCRIPTION
[So the new RBY OU VR is out](https://www.smogon.com/forums/threads/rby-ou-viability-ranking-mark-ii.3572352/page-16#post-8867170), and it's in a state where Lapras and Victreebel would drop.

However, a new policy is being instated by the RBY Council [where drops are delayed by 2 VR Revisions to increase tier stability](https://www.smogon.com/forums/threads/tiering-in-rby.3682580/post-8867192). I've been chatting with Hipmonlee about it, and to display the "held back" mons we want them put in OU by technicality for the duration. 

![image](https://user-images.githubusercontent.com/36418502/119601138-6f25bc00-bde0-11eb-913c-14df055007a7.png)
Here he is agreeing to the OU by technicality proposal and me remembering I can do this 😂 

