### PR TITLE
/eval: Clients opt into viewing its output

### DIFF
--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -1249,7 +1249,7 @@ export const commands: Chat.ChatCommands = {
 			this.broadcastToRoom = true;
 		}
 		const generateHTML = (direction: string, contents: string) => (
-			`<table class="debug" border="0" cellspacing="0" cellpadding="0"><tr><td valign="top">` +
+			`<table class="debug" style="overflow:auto; max-height:20em;" border="0" cellspacing="0" cellpadding="0"><tr><td valign="top">` +
 				Utils.escapeHTML(direction).repeat(2) +
 				`&nbsp;</td><td>${Chat.getReadmoreCodeBlock(contents)}</td></tr><table>`
 		);

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -1249,7 +1249,7 @@ export const commands: Chat.ChatCommands = {
 			this.broadcastToRoom = true;
 		}
 		const generateHTML = (direction: string, contents: string) => (
-			`<table border="0" cellspacing="0" cellpadding="0"><tr><td valign="top">` +
+			`<table class="debug" border="0" cellspacing="0" cellpadding="0"><tr><td valign="top">` +
 				Utils.escapeHTML(direction).repeat(2) +
 				`&nbsp;</td><td>${Chat.getReadmoreCodeBlock(contents)}</td></tr><table>`
 		);


### PR DESCRIPTION
Leverage ``/showdebug`` for that purpose.

Status quo: ≪development≫ chat is disrupted by evals and may even become unreadable.