### PR TITLE
Use global punishments instead of fake rooms

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -207,7 +207,7 @@ export const commands: Chat.ChatCommands = {
 			const battlebanned = Punishments.isBattleBanned(targetUser);
 			if (battlebanned) {
 				buf += `<br />BATTLEBANNED: ${battlebanned.id}`;
-				buf += ` (expires ${Punishments.checkPunishmentExpiration(battlebanned)})`;
+				buf += ` ${Punishments.checkPunishmentExpiration(battlebanned)}`;
 				if (battlebanned.reason) buf += Utils.html` (reason: ${battlebanned.reason})`;
 			}
 
@@ -216,6 +216,13 @@ export const commands: Chat.ChatCommands = {
 				buf += `<br />Banned from using groupchats${groupchatbanned.id !== targetUser.id ? `: ${groupchatbanned.id}` : ``}`;
 				buf += ` ${Punishments.checkPunishmentExpiration(groupchatbanned)}`;
 				if (groupchatbanned.reason) buf += Utils.html` (reason: ${groupchatbanned.reason})`;
+			}
+
+			const ticketbanned = Punishments.isTicketBanned(targetUser.id);
+			if (ticketbanned) {
+				buf += `<br />Banned from creating help tickets${ticketbanned.id !== targetUser.id ? `: ${ticketbanned.id}` : ``}`;
+				buf += ` ${Punishments.checkPunishmentExpiration(ticketbanned)}`;
+				if (ticketbanned.reason) buf += Utils.html` (reason: ${ticketbanned.reason})`;
 			}
 
 			if (targetUser.semilocked) {

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -1916,7 +1916,7 @@ export const commands: Chat.ChatCommands = {
 	],
 
 	forcebattleban: 'battleban',
-	battleban(target, room, user, connection, cmd) {
+	async battleban(target, room, user, connection, cmd) {
 		room = this.requireRoom();
 		if (!target) return this.parse(`/help battleban`);
 
@@ -1954,7 +1954,7 @@ export const commands: Chat.ChatCommands = {
 
 		this.globalModlog("BATTLEBAN", targetUser, reasonText);
 		Ladders.cancelSearches(targetUser);
-		Punishments.battleban(targetUser, null, null, reason);
+		await Punishments.battleban(targetUser, null, null, reason);
 		targetUser.popup(`|modal|${user.name} has prevented you from starting new battles for 2 days${reasonText}`);
 
 		// Automatically upload replays as evidence/reference to the punishment
@@ -1986,7 +1986,7 @@ export const commands: Chat.ChatCommands = {
 	monthgroupchatban: 'groupchatban',
 	monthgcban: 'groupchatban',
 	gcban: 'groupchatban',
-	groupchatban(target, room, user, connection, cmd) {
+	async groupchatban(target, room, user, connection, cmd) {
 		room = this.requireRoom();
 		if (!target) return this.parse(`/help groupchatban`);
 		if (!user.can('rangeban')) {
@@ -2015,7 +2015,9 @@ export const commands: Chat.ChatCommands = {
 			Monitor.log(`[CrisisMonitor] Trusted user ${targetUser.name} was banned from using groupchats by ${user.name}, and should probably be demoted.`);
 		}
 
-		const createdGroupchats = Punishments.groupchatBan(targetUser, (isMonth ? Date.now() + 30 * DAY : null), null, reason);
+		const createdGroupchats = await Punishments.groupchatBan(
+			targetUser, (isMonth ? Date.now() + 30 * DAY : null), null, reason
+		);
 		targetUser.popup(`|modal|${user.name} has banned you from using groupchats for a ${isMonth ? 'month' : 'week'}${reasonText}`);
 		this.globalModlog("GROUPCHATBAN", targetUser, ` by ${user.id}${reasonText}`);
 

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -11,7 +11,7 @@ const REPLAY_REGEX = new RegExp(
 	`${Utils.escapeRegex(Config.routes.replays)}/(?:[a-z0-9]-)?(?:[a-z0-9]+)-(?:[0-9]+)(?:-[a-z0-9]+pw)?`, "g"
 );
 
-Punishments.addRoomPunishmentType('TICKETBAN', 'banned from creating help tickets');
+Punishments.addPunishmentType('TICKETBAN', 'banned from creating help tickets');
 
 interface TicketState {
 	creator: string;
@@ -58,12 +58,12 @@ try {
 		const ticket = ticketData[t];
 		if (ticket.banned) {
 			if (ticket.expires && ticket.expires <= Date.now()) continue;
-			Punishments.roomPunish(`staff`, ticket.userid, {
+			void Punishments.punish(ticket.userid, {
 				type: 'TICKETBAN',
 				id: ticket.userid,
 				expireTime: ticket.expires,
 				reason: ticket.reason,
-			});
+			}, false);
 			delete ticketData[t]; // delete the old format
 		} else {
 			if (ticket.created + TICKET_CACHE_TIME <= Date.now()) {
@@ -465,41 +465,20 @@ export class HelpTicket extends Rooms.RoomGame {
 		buf += ` ${ticket.type}</a>`;
 		return buf;
 	}
-	static ban(user: User | ID, reason = '') {
+	static async ban(user: User | ID, reason = '') {
 		const userid = toID(user);
 		const userObj = Users.get(user);
 		if (userObj) user = userObj;
-		return Punishments.roomPunish('staff', user, {
+		return Punishments.punish(user, {
 			type: 'TICKETBAN',
 			id: userid,
 			expireTime: Date.now() + TICKET_BAN_DURATION,
 			reason,
-		});
+		}, false);
 	}
 	static unban(user: ID | User) {
 		user = toID(user);
-		return Punishments.roomUnpunish('staff', user, 'TICKETBAN');
-	}
-	static checkBanned(user: User | ID) {
-		const staffRoom = Rooms.get('staff');
-		if (!staffRoom) return;
-		const ips = [];
-		if (typeof user === 'object') {
-			ips.push(...user.ips);
-			ips.unshift(user.latestIp);
-			user = user.id;
-		}
-		const punishment = Punishments.roomUserids.nestedGetByType('staff', user, 'TICKETBAN');
-		if (punishment) return punishment;
-		// skip if the user is autoconfirmed and on a shared ip
-		// [0] is forced to be the latestIp
-		if (Punishments.sharedIps.has(ips[0])) return false;
-
-		for (const ip of ips) {
-			const curPunishment = Punishments.roomIps.nestedGetByType('staff', ip, 'TICKETBAN');
-			if (curPunishment) return curPunishment;
-		}
-		return false;
+		return Punishments.unpunish(user, 'TICKETBAN');
 	}
 	static getBanMessage(userid: ID, punishment: Punishment) {
 		if (userid !== punishment.id) {
@@ -1005,7 +984,7 @@ export const pages: Chat.PageTable = {
 			this.title = this.tr`Request Help`;
 			let buf = `<div class="pad"><h2>${this.tr`Request help from global staff`}</h2>`;
 
-			const ticketBan = HelpTicket.checkBanned(user);
+			const ticketBan = Punishments.isTicketBanned(user);
 			if (ticketBan) {
 				return connection.popup(HelpTicket.getBanMessage(user.id, ticketBan));
 			}
@@ -1287,7 +1266,7 @@ export const pages: Chat.PageTable = {
 			buf += `<tr><th colspan="5"><h2 style="margin: 5px auto">${this.tr`Ticket Bans`}<i class="fa fa-ban"></i></h2></th></tr>`;
 			buf += `<tr><th>Userids</th><th>IPs</th><th>Expires</th><th>Reason</th></tr>`;
 			const ticketBans = Utils.sortBy(
-				[...Punishments.getPunishments('staff')].filter(([id, entry]) => entry.punishType === 'TICKETBAN'),
+				[...Punishments.getPunishments()].filter(([id, entry]) => entry.punishType === 'TICKETBAN'),
 				([id, entry]) => entry.expireTime
 			);
 			for (const [userid, entry] of ticketBans) {
@@ -1588,7 +1567,7 @@ export const commands: Chat.ChatCommands = {
 				return this.popupReply(this.tr`Global staff can't make tickets. They can only use the form for reference.`);
 			}
 			if (!user.named) return this.popupReply(this.tr`You need to choose a username before doing this.`);
-			const ticketBan = HelpTicket.checkBanned(user);
+			const ticketBan = Punishments.isTicketBanned(user);
 			if (ticketBan) {
 				return this.popupReply(HelpTicket.getBanMessage(user.id, ticketBan));
 			}
@@ -1889,7 +1868,7 @@ export const commands: Chat.ChatCommands = {
 		closehelp: [`/helpticket close [user] - Closes an open ticket. Requires: % @ &`],
 
 		tb: 'ban',
-		ban(target, room, user) {
+		async ban(target, room, user) {
 			if (!target) return this.parse('/help helpticket ban');
 			const {targetUser, targetUsername, rest: reason} = this.splitUser(target, {exactName: true});
 			this.checkCan('lock', targetUser);
@@ -1926,7 +1905,7 @@ export const commands: Chat.ChatCommands = {
 				targetUser.popup(`|modal|${user.name} has banned you from creating help tickets.${(reason ? `\n\nReason: ${reason}` : ``)}\n\nYour ban will expire in a few days.`);
 			}
 
-			const affected = HelpTicket.ban(targetUser || userid, reason);
+			const affected = await HelpTicket.ban(targetUser || userid, reason);
 			this.addGlobalModAction(`${username} was ticket banned by ${user.name}.${reason ? ` (${reason})` : ``}`);
 			const acAccount = (targetUser && targetUser.autoconfirmed !== userid && targetUser.autoconfirmed);
 			let displayMessage = '';
@@ -1987,7 +1966,7 @@ export const commands: Chat.ChatCommands = {
 			this.checkCan('lock');
 			target = toID(target);
 			const targetID: ID = Users.get(target)?.id || target as ID;
-			const banned = HelpTicket.checkBanned(targetID);
+			const banned = Punishments.isTicketBanned(targetID);
 			if (!banned) {
 				return this.errorReply(this.tr`${target} is not ticket banned.`);
 			}

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -94,6 +94,14 @@ export function writeTickets() {
 	);
 }
 
+async function convertRoomPunishments() {
+	for (const [id, punishment] of Punishments.getPunishments('staff')) {
+		if (punishment.punishType !== 'TICKETBAN') continue;
+		Punishments.roomUnpunish('staff', id, 'TICKETBAN');
+		await HelpTicket.ban(id as ID, punishment.reason);
+	}
+}
+
 function writeStats(line: string) {
 	// ticketType\ttotalTime\ttimeToFirstClaim\tinactiveTime\tresolution\tresult\tstaff,userids,seperated,with,commas
 	const date = new Date();
@@ -684,6 +692,9 @@ for (const room of Rooms.rooms.values()) {
 	const game = room.getGame(HelpTicket)!;
 	if (game.ticket && tickets[game.ticket.userid]) game.ticket = tickets[game.ticket.userid];
 }
+
+// convert old-style Staff-room ticketbans to regular ones
+void convertRoomPunishments();
 
 const delayWarningPreamble = `Hi! All global staff members are busy right now and we apologize for the delay. `;
 const delayWarnings: {[k: string]: string} = {

--- a/server/global-types.ts
+++ b/server/global-types.ts
@@ -38,9 +38,7 @@ type MinorActivity = Rooms.MinorActivity;
 type RoomBattle = Rooms.RoomBattle;
 type Roomlog = Rooms.Roomlog;
 type Room = Rooms.Room;
-type RoomID = (
-	"" | "lobby" | "staff" | "upperstaff" | "development" | string & {__isRoomID: true}
-);
+type RoomID = "" | "lobby" | "staff" | "upperstaff" | "development" | string & {__isRoomID: true};
 namespace Rooms {
 	export type GlobalRoomState = import('./rooms').GlobalRoomState;
 	export type ChatRoom = import('./rooms').ChatRoom;

--- a/server/global-types.ts
+++ b/server/global-types.ts
@@ -39,8 +39,7 @@ type RoomBattle = Rooms.RoomBattle;
 type Roomlog = Rooms.Roomlog;
 type Room = Rooms.Room;
 type RoomID = (
-	"" | "lobby" | "staff" | "upperstaff" | "development" |
-	"battle" | "groupchat" | string & {__isRoomID: true}
+	"" | "lobby" | "staff" | "upperstaff" | "development" | string & {__isRoomID: true}
 );
 namespace Rooms {
 	export type GlobalRoomState = import('./rooms').GlobalRoomState;

--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -32,7 +32,7 @@ const BLACKLIST_DURATION = 365 * 24 * 60 * 60 * 1000; // 1 year
 const USERID_REGEX = /^[a-z0-9]+$/;
 const PUNISH_TRUSTED = false;
 
-const PUNISHMENT_POINT_VALUES: {[k: string]: number} = {MUTE: 2, BLACKLIST: 3, BATTLEBAN: 4, ROOMBAN: 4};
+const PUNISHMENT_POINT_VALUES: {[k: string]: number} = {MUTE: 2, BLACKLIST: 3, ROOMBAN: 4};
 const AUTOLOCK_POINT_THRESHOLD = 8;
 
 const AUTOWEEKLOCK_THRESHOLD = 5; // number of global punishments to upgrade autolocks to weeklocks
@@ -264,6 +264,8 @@ export const Punishments = new class {
 		['LOCK', {desc: 'locked'}],
 		['BAN', {desc: 'globally banned'}],
 		['NAMELOCK', {desc: 'namelocked'}],
+		['GROUPCHATBAN', {desc: 'banned from using groupchats'}],
+		['BATTLEBAN', {desc: 'banned from battling'}],
 	]);
 	/**
 	 * For room punishments, they can be anything in the roomPunishmentTypes map.
@@ -275,7 +277,6 @@ export const Punishments = new class {
 	 * By default, this includes:
 	 * - 'ROOMBAN'
 	 * - 'BLACKLIST'
-	 * - 'BATTLEBAN'
 	 * - 'MUTE' (used by getRoomPunishments)
 	 *
 	 */
@@ -285,9 +286,7 @@ export const Punishments = new class {
 		...(global.Punishments?.roomPunishmentTypes || []),
 		['ROOMBAN', {desc: 'banned'}],
 		['BLACKLIST', {desc: 'blacklisted'}],
-		['BATTLEBAN', {desc: 'battlebanned'}],
 		['MUTE', {desc: 'muted'}],
-		['GROUPCHATBAN', {desc: 'banned from using groupchats'}],
 	]);
 	constructor() {
 		setImmediate(() => {
@@ -1089,7 +1088,7 @@ export const Punishments = new class {
 			}
 		}
 
-		return Punishments.roomPunish("battle", user, punishment);
+		return Punishments.punish(user, punishment, false);
 	}
 	unbattleban(userid: string) {
 		const user = Users.get(userid);
@@ -1097,21 +1096,21 @@ export const Punishments = new class {
 			const punishment = Punishments.isBattleBanned(user);
 			if (punishment) userid = punishment.id;
 		}
-		return Punishments.roomUnpunish("battle", userid, 'BATTLEBAN');
+		return Punishments.unpunish(userid, 'BATTLEBAN');
 	}
 	isBattleBanned(user: User) {
 		if (!user) throw new Error(`Trying to check if a non-existent user is battlebanned.`);
 
-		let punishment = Punishments.roomUserids.nestedGetByType("battle", user.id, 'BATTLEBAN');
-		if (punishment && punishment.type === 'BATTLEBAN') return punishment;
+		let punishment = Punishments.userids.getByType(user.id, 'BATTLEBAN');
+		if (punishment) return punishment;
 
 		if (user.autoconfirmed) {
-			punishment = Punishments.roomUserids.nestedGetByType("battle", user.autoconfirmed, 'BATTLEBAN');
-			if (punishment && punishment.type === 'BATTLEBAN') return punishment;
+			punishment = Punishments.userids.getByType(user.autoconfirmed, 'BATTLEBAN');
+			if (punishment) return punishment;
 		}
 
 		for (const ip of user.ips) {
-			punishment = Punishments.roomIps.nestedGetByType("battle", ip, 'BATTLEBAN');
+			punishment = Punishments.ips.getByType(ip, 'BATTLEBAN');
 			if (punishment) {
 				if (Punishments.sharedIps.has(ip) && user.autoconfirmed) return;
 				return punishment;
@@ -1124,7 +1123,7 @@ export const Punishments = new class {
 	 * We don't necessarily want to delete these, since we still need to warn the participants,
 	 * and make a modnote of the participant names, which doesn't seem appropriate for a Punishments method.
 	 */
-	groupchatBan(user: User | ID, expireTime: number | null, id: ID | null, reason: string | null) {
+	async groupchatBan(user: User | ID, expireTime: number | null, id: ID | null, reason: string | null) {
 		if (!expireTime) expireTime = Date.now() + GROUPCHATBAN_DURATION;
 		const punishment = {type: 'GROUPCHATBAN', id, expireTime, reason} as Punishment;
 
@@ -1149,7 +1148,7 @@ export const Punishments = new class {
 			}
 		}
 
-		Punishments.roomPunish("groupchat", user, punishment);
+		await Punishments.punish(user, punishment, false);
 		return groupchatsCreated;
 	}
 
@@ -1159,30 +1158,50 @@ export const Punishments = new class {
 		const punishment = Punishments.isGroupchatBanned(user);
 		if (punishment) userid = punishment.id as ID;
 
-		return Punishments.roomUnpunish("groupchat", userid, 'GROUPCHATBAN');
+		return Punishments.unpunish(userid, 'GROUPCHATBAN');
 	}
 
 	isGroupchatBanned(user: User | ID) {
 		const userid = toID(user);
 		const targetUser = Users.get(user);
 
-		let punishment = Punishments.roomUserids.nestedGetByType("groupchat", userid, 'GROUPCHATBAN');
+		let punishment = Punishments.userids.getByType(userid, 'GROUPCHATBAN');
 		if (punishment) return punishment;
 
 		if (targetUser?.autoconfirmed) {
-			punishment = Punishments.roomUserids.nestedGetByType("groupchat", targetUser.autoconfirmed, 'GROUPCHATBAN');
+			punishment = Punishments.userids.getByType(targetUser.autoconfirmed, 'GROUPCHATBAN');
 			if (punishment) return punishment;
 		}
 
 		if (targetUser && !targetUser.trusted) {
 			for (const ip of targetUser.ips) {
-				punishment = Punishments.roomIps.nestedGetByType("groupchat", ip, 'GROUPCHATBAN');
+				punishment = Punishments.ips.getByType(ip, 'GROUPCHATBAN');
 				if (punishment) {
 					if (Punishments.sharedIps.has(ip) && targetUser.autoconfirmed) return;
 					return punishment;
 				}
 			}
 		}
+	}
+
+	isTicketBanned(user: User | ID) {
+		const ips = [];
+		if (typeof user === 'object') {
+			ips.push(...user.ips);
+			ips.unshift(user.latestIp);
+			user = user.id;
+		}
+		const punishment = Punishments.userids.getByType(user, 'TICKETBAN');
+		if (punishment) return punishment;
+		// skip if the user is autoconfirmed and on a shared ip
+		// [0] is forced to be the latestIp
+		if (Punishments.sharedIps.has(ips[0])) return false;
+
+		for (const ip of ips) {
+			const curPunishment = Punishments.ips.getByType(ip, 'TICKETBAN');
+			if (curPunishment) return curPunishment;
+		}
+		return false;
 	}
 
 	/**
@@ -1534,9 +1553,9 @@ export const Punishments = new class {
 
 		if (battleban) {
 			if (battleban.id !== user.id && Punishments.sharedIps.has(user.latestIp) && user.autoconfirmed) {
-				Punishments.roomUnpunish("battle", userid, 'BATTLEBAN');
+				Punishments.unpunish(userid, 'BATTLEBAN');
 			} else {
-				Punishments.roomPunish("battle", user, battleban);
+				void Punishments.punish(user, battleban, false);
 				user.cancelReady();
 				if (!punishment) {
 					const appealLink = ticket || (Config.appealurl ? `appeal at: ${Config.appealurl}` : ``);


### PR DESCRIPTION
This refactors ticketbans (formerly associated with the Staff room), battlebans (formerly associated with the "battle" room), and groupchatbans (formerly associated with the "groupchat" room) to be global punishments since a user can have multiple now.