### PR TITLE
Make Bonus Type modify species after Camomons

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -595,6 +595,7 @@ export const Formats: FormatList = [
 			'Rayquaza', 'Reshiram', 'Shedinja', 'Solgaleo', 'Xerneas', 'Yveltal', 'Zacian', 'Zacian-Crowned', 'Zamazenta',
 			'Zamazenta-Crowned', 'Zekrom', 'Zygarde-Base', 'Arena Trap', 'Moody', 'Power Construct', 'Shadow Tag', 'Baton Pass',
 		],
+		onModifySpeciesPriority: 1,
 		onModifySpecies(species, target, source, effect) {
 			if (!target) return; // Chat command
 			if (effect && ['imposter', 'transform'].includes(effect.id)) return;
@@ -832,6 +833,7 @@ export const Formats: FormatList = [
 			'Necrozma-Dawn-Wings', 'Necrozma-Dusk-Mane', 'Palkia', 'Rayquaza', 'Reshiram', 'Shedinja', 'Solgaleo', 'Xerneas', 'Yveltal', 'Zacian', 'Zacian-Crowned',
 			'Zamazenta', 'Zamazenta-Crowned', 'Zekrom', 'Zeraora', 'Zygarde-Base', 'Arena Trap', 'Moody', 'Power Construct', 'Shadow Tag', 'Baton Pass',
 		],
+		onModifySpeciesPriority: 2,
 		onModifySpecies(species, target, source, effect) {
 			if (!target) return; // Chat command
 			if (effect && ['imposter', 'transform'].includes(effect.id)) return;


### PR DESCRIPTION
Currently, in a battle with both Camomons and Bonus Type battle effects, Camomons will randomly activate last per-switch in, overwriting the Pokemon's typing in full and disabling its Bonus Type. This change makes Bonus Type always activate last so that it is compatible with Camomons.

Similar to https://github.com/smogon/pokemon-showdown/pull/8051