### PR TITLE
Fix crashes in Chimera 1v1 rule interactions

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -619,47 +619,8 @@ export const Formats: FormatList = [
 		],
 
 		mod: 'gen8',
-		ruleset: [
-			'Standard', 'Dynamax Clause', 'Sleep Moves Clause',
-			'Max Team Size = 6', 'Min Team Size = 6', 'Picked Team Size = 6',
-		],
+		ruleset: ['Chimera 1v1 Rule', 'Standard', 'Dynamax Clause', 'Sleep Moves Clause'],
 		banlist: ['Shedinja', 'Huge Power', 'Moody', 'Neutralizing Gas', 'Truant', 'Eviolite', 'Focus Sash', 'Perish Song', 'Transform', 'Fishious Rend', 'Bolt Beak', 'Disable', 'Double Iron Bash'],
-		onValidateSet(set) {
-			if (!set.item) return;
-			const item = this.dex.items.get(set.item);
-			if (item.itemUser && !this.ruleTable.has(`+item:${item.id}`)) {
-				return [`${set.species}'s item ${item.name} is banned.`];
-			}
-		},
-		onValidateTeam() {
-			const table = this.ruleTable;
-			if (table.maxTeamSize !== 6 || table.minTeamSize !== 6 || table.pickedTeamSize !== 6) {
-				return [
-					`You are using custom rules that make the Max Team Size, Min Team Size, or Picked Team Size something other than 6.`,
-					'Doing this causes the server to crash.',
-				];
-			}
-		},
-		onBeforeSwitchIn(pokemon) {
-			const allies = pokemon.side.pokemon.splice(1);
-			pokemon.side.pokemonLeft = 1;
-			const newSpecies = this.dex.deepClone(pokemon.baseSpecies);
-			newSpecies.abilities = allies[1].baseSpecies.abilities;
-			newSpecies.baseStats = allies[2].baseSpecies.baseStats;
-			newSpecies.bst = allies[2].baseSpecies.bst;
-			pokemon.item = allies[0].item;
-			pokemon.ability = pokemon.baseAbility = allies[1].ability;
-			pokemon.set.evs = allies[2].set.evs;
-			pokemon.set.nature = allies[2].set.nature;
-			pokemon.set.ivs = allies[2].set.ivs;
-			pokemon.hpType = (pokemon as any).baseHpType = allies[2].baseHpType;
-			pokemon.moveSlots = (pokemon as any).baseMoveSlots = [
-				...allies[3].baseMoveSlots.slice(0, 2), ...allies[4].baseMoveSlots.slice(2),
-			].filter((move, index, moveSlots) => moveSlots.find(othermove => othermove.id === move.id) === move);
-			// so all HP-related properties get re-initialized in setSpecies
-			pokemon.maxhp = 0;
-			pokemon.setSpecies(newSpecies, null);
-		},
 	},
 
 	// Other Metagames

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1510,4 +1510,51 @@ export const Rulesets: {[k: string]: FormatData} = {
 			pokemon.trapped = true;
 		},
 	},
+	chimera1v1rule: {
+		effectType: 'Rule',
+		name: 'Chimera 1v1 Rule',
+		desc: "Validation and battle effects for Chimera 1v1.",
+		ruleset: ['Team Preview', 'Max Team Size = 6', 'Min Team Size = 6', 'Picked Team Size = 6'],
+		onValidateSet(set) {
+			if (!set.item) return;
+			const item = this.dex.items.get(set.item);
+			if (item.itemUser && !this.ruleTable.has(`+item:${item.id}`)) {
+				return [`${set.species}'s item ${item.name} is banned.`];
+			}
+		},
+		onValidateRule() {
+			const table = this.ruleTable;
+			if (table.maxTeamSize < 6 || table.minTeamSize !== 6 || table.pickedTeamSize !== 6) {
+				throw new Error(
+					`Custom rules that could allow the active team size to be reduced below 6 (Max Team Size < 6, Min Team Size != 6, Picked Team Size != 6) could prevent the Chimera from being fully defined, and are incompatible with Chimera 1v1.`
+				);
+			}
+			const gameType = this.format.gameType;
+			if (gameType === 'doubles' || gameType === 'triples') {
+				throw new Error(
+					`The game type '${gameType}' cannot be 1v1 because sides can have multiple active Pok\u00e9mon, so it is incompatible with Chimera 1v1.`
+				);
+			}
+		},
+		onBeforeSwitchIn(pokemon) {
+			const allies = pokemon.side.pokemon.splice(1);
+			pokemon.side.pokemonLeft = 1;
+			const newSpecies = this.dex.deepClone(pokemon.baseSpecies);
+			newSpecies.abilities = allies[1].baseSpecies.abilities;
+			newSpecies.baseStats = allies[2].baseSpecies.baseStats;
+			newSpecies.bst = allies[2].baseSpecies.bst;
+			pokemon.item = allies[0].item;
+			pokemon.ability = pokemon.baseAbility = allies[1].ability;
+			pokemon.set.evs = allies[2].set.evs;
+			pokemon.set.nature = allies[2].set.nature;
+			pokemon.set.ivs = allies[2].set.ivs;
+			pokemon.hpType = (pokemon as any).baseHpType = allies[2].baseHpType;
+			pokemon.moveSlots = (pokemon as any).baseMoveSlots = [
+				...allies[3].baseMoveSlots.slice(0, 2), ...allies[4].baseMoveSlots.slice(2),
+			].filter((move, index, moveSlots) => moveSlots.find(othermove => othermove.id === move.id) === move);
+			// so all HP-related properties get re-initialized in setSpecies
+			pokemon.maxhp = 0;
+			pokemon.setSpecies(newSpecies, null);
+		},
+	},
 };

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1514,7 +1514,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 		effectType: 'Rule',
 		name: 'Chimera 1v1 Rule',
 		desc: "Validation and battle effects for Chimera 1v1.",
-		ruleset: ['Team Preview', 'Max Team Size = 6', 'Min Team Size = 6', 'Picked Team Size = 6'],
+		ruleset: ['Team Preview', 'Picked Team Size = 6'],
 		onValidateSet(set) {
 			if (!set.item) return;
 			const item = this.dex.items.get(set.item);

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1526,7 +1526,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 			const table = this.ruleTable;
 			if ((table.pickedTeamSize || table.minTeamSize) < 6) {
 				throw new Error(
-					`Custom rules that could allow the active team size to be reduced below 6 (Max Team Size < 6, Min Team Size != 6, Picked Team Size != 6) could prevent the Chimera from being fully defined, and are incompatible with Chimera 1v1.`
+					`Custom rules that could allow the active team size to be reduced below 6 (Min Team Size < 6, Picked Team Size < 6) could prevent the Chimera from being fully defined, and are incompatible with Chimera 1v1.`
 				);
 			}
 			const gameType = this.format.gameType;

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1524,7 +1524,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 		},
 		onValidateRule() {
 			const table = this.ruleTable;
-			if (table.maxTeamSize < 6 || table.minTeamSize !== 6 || table.pickedTeamSize !== 6) {
+			if ((table.pickedTeamSize || table.minTeamSize) < 6) {
 				throw new Error(
 					`Custom rules that could allow the active team size to be reduced below 6 (Max Team Size < 6, Min Team Size != 6, Picked Team Size != 6) could prevent the Chimera from being fully defined, and are incompatible with Chimera 1v1.`
 				);


### PR DESCRIPTION
I managed to replicate the Chimera crashes that appeared in the development room yesterday on a test server. Probably they were caused by users creating custom challenges similar to this:
`/challenge gen8randombattle@@@gen8chimera1v1,!!pickedteamsize=1`

It seems like Chimera's onValidateTeam is not called in that case. However, if the onValidateTeam were changed to onValidateRule, it seems like it wouldn't be called in cases where Chimera is the base format. So this change gives Chimera its own rule from which the onValidateRule is called in either case...it feels like it might be useful if base formats had onValidateRule (or something like it) called on them as well, but I don't think encapsulating the Chimera functionality in a rule is a bad thing regardless.

When I was testing things to replicate the crash, I noticed that adding Chimera to doubles battles could cause a different crash, so the doubles/triples case is also handled in this change (I don't think it's actually possible to create a triple Chimera battle currently due to how Moody Clause works in cross-generational format-stacking but just in case...)

Finally, the Max Team Size check was actually made more lenient in this change because I don't think there's any logical or security reason to prevent teams larger than 6 from playing Chimera as long as the Picked Team Size is still 6, and users were already making requests for this kind of thing.

Tested like this:-

Allowed:-
```
/challenge gen8randombattle@@@gen8chimera1v1
/challenge gen8randombattle@@@chimera1v1rule
/challenge gen8chimera1v1@@@!!maxteamsize=7
```

Disallowed:-
```
/challenge gen8chimera1v1@@@!!maxteamsize=7, !!minteamsize=1, !!pickedteamsize=1
/challenge gen8randombattle@@@gen8chimera1v1,!!pickedteamsize=1
/challenge gen8randombattle@@@chimera1v1rule,!!pickedteamsize=1
/challenge gen8randomdoublesbattle@@@gen8chimera1v1
/challenge gen8randomdoublesbattle@@@chimera1v1rule
```