### PR TITLE
Gen 2: Nintendo Cup 2000 should use gen1stadium2

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3068,10 +3068,10 @@ export const Formats: FormatList = [
 		name: "[Gen 2] Nintendo Cup 2000",
 		threads: [
 			`&bullet; <a href="https://www.smogon.com/forums/threads/3682691/">Nintendo Cup 2000 Resource Hub</a>`,
-			`&bullet; <a href="https://www.smogon.com/forums/threads/3677370/">Differences between Nintendo Cup 2000 and GSC</a>`,
+			`&bullet; <a href="https://www.smogon.com/forums/threads/3677370/">Differences between Nintendo Cup 2000 and GSC OU</a>`,
 		],
 
-		mod: 'gen2',
+		mod: 'gen2stadium2',
 		searchShow: false,
 		ruleset: [
 			'Picked Team Size = 3', 'Min Level = 50', 'Max Level = 55', 'Max Total Level = 155',


### PR DESCRIPTION
NC2000 was played using Stadium 2.

Src: http://pokemon.s20.xrea.com/2nd/rule.html#nintendo 
"対戦環境は「ポケモンスタジアム金銀」。"
This roughly translates to "the battle environment is stadium gold and silver".

There is also an official source here stating that RGBY can be used, which is only possible via Stadium 2
https://www.nintendo.co.jp/n01/n64/software/nus_p_np3j/league/