### PR TITLE
Granular Room Permissions Settings

### DIFF
--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -1655,7 +1655,6 @@ export const pages: Chat.PageTable = {
 
 		const roomGroups = ['default', ...Config.groupsranking.slice(1)];
 		const permissions = room.settings.permissions || {};
-		const botPermissions = room.settings.botpermissions || {};
 
 		let buf = `<div class="pad"><h2>Command permissions for ${room.title}</h2>`;
 		buf += `<div class="ladder"><table>`;

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -1666,13 +1666,13 @@ export const pages: Chat.PageTable = {
 			buf += `<tr><td><strong>${permission}</strong></td><td>`;
 			if (room.auth.atLeast(user, '#')) {
 				buf += roomGroups.filter(group => group !== Users.SECTIONLEADER_SYMBOL).map(group => (
-					requiredRank[group]  ?
+					requiredRank[group] ?
 						Utils.html`<button class="button" name="send" value="/msgroom ${room.roomid},/permissions set ${permission}, ${group}" style="font-weight:bold;background:#e3c3a3;">${group}</button>` :
 						Utils.html`<button class="button" name="send" value="/msgroom ${room.roomid},/permissions set ${permission}, ${group}">${group}</button>`
 				)).join(' ');
 			} else {
 				buf += roomGroups.filter(group => group !== Users.SECTIONLEADER_SYMBOL).map(group => (
-					requiredRank[group]  ?
+					requiredRank[group] ?
 						Utils.html`<button class="button disabled">${group}</button>` : ''
 				)).join(' ');
 			}

--- a/server/user-groups.ts
+++ b/server/user-groups.ts
@@ -150,17 +150,20 @@ export abstract class Auth extends Map<ID, GroupSymbol | ''> {
 				if (roomPermissions[`/${cmd}`]) {
 					// this checks sub commands and command objects, but it checks to see if a sub-command
 					// overrides (should a perm for the command object exist) first
+					return roomPermissions[`/${cmd}`][symbol];
 					if (!auth.atLeast(user, roomPermissions[`/${cmd}`])) return false;
 					jurisdiction = 'u';
 					foundSpecificPermission = true;
 				} else if (roomPermissions[`/${namespace}`]) {
 					// if it's for one command object
+					return roomPermissions[`/${namespace}`][symbol];
 					if (!auth.atLeast(user, roomPermissions[`/${namespace}`])) return false;
 					jurisdiction = 'u';
 					foundSpecificPermission = true;
 				}
 			}
 			if (!foundSpecificPermission && roomPermissions[permission]) {
+				return (roomPermissions[permission][symbol]);
 				if (!auth.atLeast(user, roomPermissions[permission])) return false;
 				jurisdiction = 'u';
 			}


### PR DESCRIPTION
Hi, I thought it would be useful for /permissions to be able to turn on/off command options for each rank, rather than setting a minimum. In particular this would be useful for Bots, since (by good reason) they are ranked below Drivers, but would benefit from additional permissions like auto-moderation, Room/Staff intro modification (Officer Jenny does this for tracking watchlisted users for promotions in staff intros), and other useful commands.

My one concern is in the implementation of the user-groups.ts#hasPermission function. I am not sure what the jurisdiction thing is about (a room/global issue?) so I am not sure if simply returning the value of the room permission introduces a security risk. I would like some assistance here (and obviously if this is fine I would remove the non-executed code below it). Any assistance would be appreciated.