### PR TITLE
Add VGC/BSS Series 10 support

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -256,6 +256,14 @@ export const Formats: FormatList = [
 		banlist: ['Crucibellite'],
 	},
 	{
+		name: "[Gen 8] Battle Stadium Singles Series 10",
+
+		mod: 'gen8',
+		searchShow: false,
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 8', 'Limit One Restricted', 'Dynamax Clause'],
+		restricted: ['Restricted Legendary'],
+	},
+	{
 		name: "[Gen 8] Battle Stadium Singles",
 		threads: [
 			`&bullet; <a href="https://www.smogon.com/forums/threads/3679374/">BSS Discussion</a>`,
@@ -346,6 +354,14 @@ export const Formats: FormatList = [
 		searchShow: false,
 		ruleset: ['Standard Doubles', 'Little Cup', 'Dynamax Clause', 'Swagger Clause', 'Sleep Clause Mod'],
 		banlist: ['Corsola-Galar', 'Cutiefly', 'Scyther', 'Sneasel', 'Swirlix', 'Tangela', 'Vulpix', 'Vulpix-Alola'],
+	},
+	{
+		name: "[Gen 8] VGC 2021 Series 10",
+
+		mod: 'gen8',
+		gameType: 'doubles',
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 8', 'VGC Timer', 'Limit One Restricted', 'Dynamax Clause'],
+		restricted: ['Restricted Legendary'],
 	},
 	{
 		name: "[Gen 8] VGC 2021 Series 9",


### PR DESCRIPTION
I talked with chemcoop about this and discussed a bit with Kris in PMs, but this is the general idea of what we (chemcoop and I) would prefer to do:

- VGC will run a Series 10 ladder concurrently with Series 9. At the end of the month, Series 9 will be converted to challenge-only.
- Battle Stadium Singles will have a challenge-only Series 10 option. At the end of the month, Series 10 will be renamed to Battle Stadium Singles, and Series 9 will be renamed and converted to challenge-only.

Both VGC and BSS have tournaments involving Series 9 after the format officially switches August 1. There is also a non-zero chance, imo, that they will switch back to Series 7/9-style again after Series 10 is over. The reason VGC is requesting a VGC Series 10 ladder so early is because there is significant traffic for it right now; we're getting consistent 40-50+ player room tournaments, and side servers hosting the format are getting a ton of activity.