### PR TITLE
Datasearch: Minor refactor

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -86,10 +86,10 @@ export const commands: Chat.ChatCommands = {
 	async dexsearch(target, room, user, connection, cmd, message) {
 		this.checkBroadcast();
 		if (!target) return this.parse('/help dexsearch');
-		target = target.slice(0, 300);
+		if (target.length > 300) return this.errorReply('Dexsearch queries may not be longer than 300 characters.');
 		const targetGen = parseInt(cmd[cmd.length - 1]);
 		if (targetGen) target += `, mod=gen${targetGen}`;
-		const split = target.split(',');
+		const split = target.split(',').map(term => term.trim());
 		const index = split.findIndex(x => x.startsWith('maxgen'));
 		if (index >= 0) {
 			const genNum = parseInt(split[index][split[index].length - 1]);
@@ -462,16 +462,16 @@ export const commands: Chat.ChatCommands = {
 
 function getMod(target: string) {
 	const arr = target.split(',').map(x => x.trim());
-	const usedMod = arr.find(x => {
+	const modTerm = arr.find(x => {
 		const sanitizedStr = x.toLowerCase().replace(/[^a-z0-9=]+/g, '');
 		return sanitizedStr.startsWith('mod=') && Dex.dexes[toID(sanitizedStr.split('=')[1])];
-	})?.split('=')[1];
+	});
 	const count = arr.filter(x => {
 		const sanitizedStr = x.toLowerCase().replace(/[^a-z0-9=]+/g, '');
 		return sanitizedStr.startsWith('mod=');
 	}).length;
-	if (usedMod) arr.splice(arr.indexOf('mod=' + usedMod), 1);
-	return {splitTarget: arr, usedMod: usedMod ? toID(usedMod) : undefined, count};
+	if (modTerm) arr.splice(arr.indexOf(modTerm), 1);
+	return {splitTarget: arr, usedMod: modTerm ? toID(modTerm.split(/ ?= ?/)[1]) : undefined, count};
 }
 
 function runDexsearch(target: string, cmd: string, canAll: boolean, message: string, isTest: boolean) {
@@ -1944,23 +1944,29 @@ function runItemsearch(target: string, cmd: string, canAll: boolean, message: st
 	}
 
 	target = target.toLowerCase().replace('-', ' ').replace(/[^a-z0-9.\s/]/g, '');
-	const rawSearch = target.split(' ');
+	const rawSearch = target.replace(/gen \d/g, match => toID(match)).split(' ');
 	const searchedWords: string[] = [];
 	let foundItems: string[] = [];
 
 	// Refine searched words
 	for (const [i, search] of rawSearch.entries()) {
 		let newWord = search.trim();
-		if (newWord.substr(0, 6) === 'maxgen' && parseInt(newWord[6])) {
-			if (maxGen) return {error: "You cannot specify 'maxgen' multiple times."};
-			maxGen = parseInt(newWord[6]);
-			if (maxGen < 2 || maxGen > 8) return {error: "The generation must be between 2 and 8"};
-			continue;
-		} else if (newWord.substr(0, 3) === 'gen' && parseInt(newWord[3])) {
-			if (gen) return {error: "You cannot specify 'gen' multiple times."};
-			gen = parseInt(newWord[3]);
-			if (gen < 2 || gen > 8) return {error: "The generation must be between 2 and 8"};
-			continue;
+		if (newWord.substr(0, 6) === 'maxgen') {
+			const parsedGen = parseInt(newWord.substr(6));
+			if (!isNaN(parsedGen)) {
+				if (maxGen) return {error: "You cannot specify 'maxgen' multiple times."};
+				maxGen = parsedGen;
+				if (maxGen < 2 || maxGen > 8) return {error: "The generation must be between 2 and 8"};
+				continue;
+			}
+		} else if (newWord.substr(0, 3) === 'gen') {
+			const parsedGen = parseInt(newWord.substr(3));
+			if (!isNaN(parsedGen)) {
+				if (gen) return {error: "You cannot specify 'gen' multiple times."};
+				gen = parsedGen;
+				if (gen < 2 || gen > 8) return {error: "The generation must be between 2 and 8"};
+				continue;
+			}
 		}
 		if (isNaN(parseFloat(newWord))) newWord = newWord.replace('.', '');
 		switch (newWord) {
@@ -2190,22 +2196,28 @@ function runAbilitysearch(target: string, cmd: string, canAll: boolean, message:
 	}
 
 	target = target.toLowerCase().replace('-', ' ').replace(/[^a-z0-9.\s/]/g, '');
-	const rawSearch = target.split(' ');
+	const rawSearch = target.replace(/gen \d/g, match => toID(match)).split(' ');
 	const searchedWords: string[] = [];
 	let foundAbilities: string[] = [];
 
 	for (const [i, search] of rawSearch.entries()) {
 		let newWord = search.trim();
-		if (newWord.substr(0, 6) === 'maxgen' && parseInt(newWord[6])) {
-			if (maxGen) return {error: "You cannot specify 'maxgen' multiple times."};
-			maxGen = parseInt(newWord[6]);
-			if (maxGen < 3 || maxGen > 8) return {error: "The generation must be between 3 and 8"};
-			continue;
-		} else if (newWord.substr(0, 3) === 'gen' && parseInt(newWord[3])) {
-			if (gen) return {error: "You cannot specify 'gen' multiple times."};
-			gen = parseInt(newWord[3]);
-			if (gen < 3 || gen > 8) return {error: "The generation must be between 3 and 8"};
-			continue;
+		if (newWord.substr(0, 6) === 'maxgen') {
+			const parsedGen = parseInt(newWord.substr(6));
+			if (parsedGen) {
+				if (maxGen) return {error: "You cannot specify 'maxgen' multiple times."};
+				maxGen = parsedGen;
+				if (maxGen < 3 || maxGen > 8) return {error: "The generation must be between 3 and 8"};
+				continue;
+			}
+		} else if (newWord.substr(0, 3) === 'gen') {
+			const parsedGen = parseInt(newWord.substr(3));
+			if (parsedGen) {
+				if (gen) return {error: "You cannot specify 'gen' multiple times."};
+				gen = parsedGen;
+				if (gen < 3 || gen > 8) return {error: "The generation must be between 3 and 8"};
+				continue;
+			}
 		}
 		if (isNaN(parseFloat(newWord))) newWord = newWord.replace('.', '');
 		switch (newWord) {


### PR DESCRIPTION
This fixes/changes a couple things:

a) Long dexsearch queries now reject with an error instead of blindly trimming and giving stuff like ``retur could not be found in any of the search categories``.
b) Maxgen now works properly (before this, the maxgen parameter only worked if it was either the first term or if there were no spaces after the preceding comma).
c) Mod now allows spaces around the equals sign (`mod = SSB`) instead of matching properly and failing on the split.
d) Gen0 no longer works in abilitysearch / itemsearch (not that relevant, but since current behaviour is to block Gen 1/2, seems a bit weird to allow 0).
e) Gen X and Maxgen X now work in abilitysearch / itemsearch (before this, they'd give a blank 'no results found').
f) Gen X and Maxgen X now support multi-digit generations (well in advance before Gen 10 releases, but doesn't hurt to be ready).