### PR TITLE
Typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Also useful is the Suggestions forum (you don't need to worry about approval if 
 
 Also useful is the Mechanics Bugs kanban board: https://github.com/smogon/pokemon-showdown/projects/3
 
-There's no need to worry about code standards too much (unit tests will automatically catch most of what we care about, we'll point out the rest if you make a pull request), but there here if you want them.
+There's no need to worry about code standards too much (unit tests will automatically catch most of what we care about, we'll point out the rest if you make a pull request), but they are here if you want them.
 
 We try to respond to pull requests within a few days, but feel free to bump yours if it seems like we forget about it. Sometimes we did, and sometimes there might be a miscommunication in terms of who is waiting for what.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Also useful is the Suggestions forum (you don't need to worry about approval if 
 
 Also useful is the Mechanics Bugs kanban board: https://github.com/smogon/pokemon-showdown/projects/3
 
-There's no need to worry about code standards too much (unit tests will automatically catch most of what we care about, we'll point out the rest if you make a pull request), but they are here if you want them.
+There's no need to worry about code standards too much (unit tests will automatically catch most of what we care about, we'll point out the rest if you make a pull request), but they're here if you want them.
 
 We try to respond to pull requests within a few days, but feel free to bump yours if it seems like we forget about it. Sometimes we did, and sometimes there might be a miscommunication in terms of who is waiting for what.
 


### PR DESCRIPTION
There was a typo on line 31 of `CONTRIBUTING.md`; changed it from 'there here' to 'they are here'.