### PR TITLE
Fix bugs with Sucrase build process

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -23,6 +23,8 @@ To reload chat commands:
 
 */
 
+import * as path from 'path';
+
 import type {RoomPermission, GlobalPermission} from './user-groups';
 import type {Punishment} from './punishments';
 import type {PartialModlogEntry} from './modlog';
@@ -137,7 +139,9 @@ import ProbeModule = require('probe-image-size');
 const probe: (url: string) => Promise<{width: number, height: number}> = ProbeModule;
 
 const EMOJI_REGEX = /[\p{Emoji_Modifier_Base}\p{Emoji_Presentation}\uFE0F]/u;
-const TRANSLATION_DIRECTORY = `${__dirname}/../translations`;
+// to account for Sucrase
+const TRANSLATION_PATH = __dirname.endsWith('.server-dist') ? `../.translations-dist` : `../translations`;
+const TRANSLATION_DIRECTORY = path.resolve(__dirname, TRANSLATION_PATH);
 
 class PatternTester {
 	// This class sounds like a RegExp

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -23,8 +23,6 @@ To reload chat commands:
 
 */
 
-import * as path from 'path';
-
 import type {RoomPermission, GlobalPermission} from './user-groups';
 import type {Punishment} from './punishments';
 import type {PartialModlogEntry} from './modlog';
@@ -141,7 +139,7 @@ const probe: (url: string) => Promise<{width: number, height: number}> = ProbeMo
 const EMOJI_REGEX = /[\p{Emoji_Modifier_Base}\p{Emoji_Presentation}\uFE0F]/u;
 // to account for Sucrase
 const TRANSLATION_PATH = __dirname.endsWith('.server-dist') ? `../.translations-dist` : `../translations`;
-const TRANSLATION_DIRECTORY = path.resolve(__dirname, TRANSLATION_PATH);
+const TRANSLATION_DIRECTORY = `${__dirname}/${TRANSLATION_PATH}`;
 
 class PatternTester {
 	// This class sounds like a RegExp

--- a/tools/build-utils.js
+++ b/tools/build-utils.js
@@ -221,9 +221,9 @@ exports.transpile = (doForce, decl) => {
 
 	sucrase('./translations', './.translations-dist');
 
-	if (sucrase('./tools/set-import', './tools/set-import', null, ['sets'])) {
-		replace('./tools/set-import/importer.js', [
-			{regex: /(require\(.*?)(lib|sim)/g, replace: `$1.$2-dist`},
+	if (sucrase('./tools', './tools', null, ['.', 'sets', 'simulate'])) {
+		replace('tools', [
+			{regex: /(require\(.*?)(lib|sim|server)/g, replace: `$1.$2-dist`},
 		]);
 	}
 


### PR DESCRIPTION
I feel like there should be a `.tools-dist` now.

Fixing this stuff got `.server-dist/index.js` to run, but there are still some more bugs with file paths, since the places where FS is called to access a file is not replaced like how something in `require` is. It would be quite cumbersome to account for sucrase in every part of the code that uses FS, so there has to be a better solution.