### PR TITLE
Remove 'lynch' from mafia.ts 

### DIFF
--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -765,7 +765,7 @@ class Mafia extends Rooms.RoomGame {
 		}
 
 		if (!player && this.dead[userid] && this.dead[userid].restless) player = this.dead[userid];
-		if (!player?.voting) return this.sendUser(userid, `|error|You are not voting anyone.`);
+		if (!player?.voting) return this.sendUser(userid, `|error|You are not voting for anyone.`);
 		if (player.lastVote + 2000 >= Date.now() && !force) {
 			return this.sendUser(
 				userid,
@@ -797,7 +797,7 @@ class Mafia extends Rooms.RoomGame {
 	}
 
 	/**
-	 * Returns HTML code that contains information on the current vote vote.
+	 * Returns HTML code that contains information about the current vote.
 	 */
 	voteBox() {
 		if (!this.started) return `<strong>The game has not started yet.</strong>`;

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -55,14 +55,14 @@ interface MafiaRole {
 	image: string;
 }
 
-interface MafiaLynch {
-	// number of people on this lynch
+interface MafiaVote {
+	// number of people on this vote
 	count: number;
 	// number of votes, accounting for doublevoter etc
 	trueCount: number;
-	lastLynch: number;
+	lastVote: number;
 	dir: 'up' | 'down';
-	lynchers: ID[];
+	voters: ID[];
 }
 
 interface MafiaIDEAData {
@@ -170,10 +170,10 @@ class MafiaPlayer extends Rooms.RoomGamePlayer {
 	game: Mafia;
 	safeName: string;
 	role: MafiaRole | null;
-	lynching: ID;
+	voting: ID;
 	/** false - can't hammer (priest), true - can only hammer (actor) */
 	hammerRestriction: null | boolean;
-	lastLynch: number;
+	lastVote: number;
 	treestump: boolean;
 	restless: boolean;
 	silenced: boolean;
@@ -187,9 +187,9 @@ class MafiaPlayer extends Rooms.RoomGamePlayer {
 		this.game = game;
 		this.safeName = Utils.escapeHTML(this.name);
 		this.role = null;
-		this.lynching = '';
+		this.voting = '';
 		this.hammerRestriction = null;
-		this.lastLynch = 0;
+		this.lastVote = 0;
 		this.treestump = false;
 		this.restless = false;
 		this.silenced = false;
@@ -216,11 +216,11 @@ class MafiaPlayer extends Rooms.RoomGamePlayer {
 			void Chat.resolvePage(`view-mafia-${this.game.room.roomid}`, user, conn);
 		}
 	}
-	updateHtmlLynches() {
+	updateHtmlVotes() {
 		const user = Users.get(this.id);
 		if (!user?.connected) return;
-		const lynches = this.game.lynchBoxFor(this.id);
-		user.send(`>view-mafia-${this.game.room.roomid}\n|selectorhtml|#mafia-lynches|` + lynches);
+		const votes = this.game.voteBoxFor(this.id);
+		user.send(`>view-mafia-${this.game.room.roomid}\n|selectorhtml|#mafia-votes|` + votes);
 	}
 }
 
@@ -241,13 +241,13 @@ class Mafia extends Rooms.RoomGame {
 	played: ID[];
 
 	hammerCount: number;
-	lynches: {[userid: string]: MafiaLynch};
-	lynchModifiers: {[userid: string]: number};
+	votes: {[userid: string]: MafiaVote};
+	voteModifiers: {[userid: string]: number};
 	hammerModifiers: {[userid: string]: number};
 	hasPlurality: ID | null;
 
 	enableNL: boolean;
-	forceLynch: boolean;
+	forceVote: boolean;
 	closedSetup: boolean;
 	noReveal: boolean;
 	selfEnabled: boolean | 'hammer';
@@ -291,13 +291,13 @@ class Mafia extends Rooms.RoomGame {
 		this.played = [];
 
 		this.hammerCount = 0;
-		this.lynches = Object.create(null);
-		this.lynchModifiers = Object.create(null);
+		this.votes = Object.create(null);
+		this.voteModifiers = Object.create(null);
 		this.hammerModifiers = Object.create(null);
 		this.hasPlurality = null;
 
 		this.enableNL = true;
-		this.forceLynch = false;
+		this.forceVote = false;
 		this.closedSetup = false;
 		this.noReveal = false;
 		this.selfEnabled = false;
@@ -645,7 +645,7 @@ class Mafia extends Rooms.RoomGame {
 		if (this.timer) this.setDeadline(0);
 		if (extension === null) {
 			if (!isNaN(this.hammerCount)) this.hammerCount = Math.floor(Object.keys(this.playerTable).length / 2) + 1;
-			this.clearLynches();
+			this.clearVotes();
 		}
 		this.phase = 'day';
 		if (extension !== null && !initial) {
@@ -683,58 +683,58 @@ class Mafia extends Rooms.RoomGame {
 		if (!early && hasPlurality) {
 			this.sendRoom(`Plurality is on ${this.playerTable[hasPlurality] ? this.playerTable[hasPlurality].name : 'No Vote'}`);
 		}
-		if (!early && !initial) this.sendRoom(`|raw|<div class="infobox">${this.lynchBox()}</div>`);
+		if (!early && !initial) this.sendRoom(`|raw|<div class="infobox">${this.voteBox()}</div>`);
 		if (initial && !isNaN(this.hammerCount)) this.hammerCount = Math.floor(Object.keys(this.playerTable).length / 2) + 1;
 		this.updatePlayers();
 	}
 
-	lynch(userid: ID, target: ID) {
+	vote(userid: ID, target: ID) {
 		if (this.phase !== 'day') return this.sendUser(userid, `|error|You can only vote during the day.`);
 		let player = this.playerTable[userid];
 		if (!player && this.dead[userid] && this.dead[userid].restless) player = this.dead[userid];
 		if (!player) return;
-		if (!(target in this.playerTable) && target !== 'nolynch') {
+		if (!(target in this.playerTable) && target !== 'novote') {
 			return this.sendUser(userid, `|error|${target} is not a valid player.`);
 		}
-		if (!this.enableNL && target === 'nolynch') return this.sendUser(userid, `|error|No Vote is not allowed.`);
+		if (!this.enableNL && target === 'novote') return this.sendUser(userid, `|error|No Vote is not allowed.`);
 		if (target === player.id && !this.selfEnabled) return this.sendUser(userid, `|error|Self voting is not allowed.`);
-		const hammering = this.hammerCount - 1 <= (this.lynches[target] ? this.lynches[target].count : 0);
+		const hammering = this.hammerCount - 1 <= (this.votes[target] ? this.votes[target].count : 0);
 		if (target === player.id && !hammering && this.selfEnabled === 'hammer') {
 			return this.sendUser(userid, `|error|You may only vote yourself when placing the hammer vote.`);
 		}
 		if (player.hammerRestriction !== null) {
-			this.sendUser(userid, `${this.hammerCount - 1} <= ${(this.lynches[target] ? this.lynches[target].count : 0)}`);
+			this.sendUser(userid, `${this.hammerCount - 1} <= ${(this.votes[target] ? this.votes[target].count : 0)}`);
 			if (player.hammerRestriction && !hammering) {
 				return this.sendUser(userid, `|error|You can only vote when placing the hammer vote.`);
 			}
 			if (!player.hammerRestriction && hammering) return this.sendUser(userid, `|error|You cannot place the hammer vote.`);
 		}
-		if (player.lastLynch + 2000 >= Date.now()) {
+		if (player.lastVote + 2000 >= Date.now()) {
 			return this.sendUser(
 				userid,
-				`|error|You must wait another ${Chat.toDurationString((player.lastLynch + 2000) - Date.now()) || '1 second'} before you can change your vote.`
+				`|error|You must wait another ${Chat.toDurationString((player.lastVote + 2000) - Date.now()) || '1 second'} before you can change your vote.`
 			);
 		}
-		const previousLynch = player.lynching;
-		if (previousLynch) this.unlynch(userid, true);
-		let lynch = this.lynches[target];
-		if (!lynch) {
-			this.lynches[target] = {
-				count: 1, trueCount: this.getLynchValue(userid), lastLynch: Date.now(), dir: 'up', lynchers: [userid],
+		const previousVote = player.voting;
+		if (previousVote) this.unvote(userid, true);
+		let vote = this.votes[target];
+		if (!vote) {
+			this.votes[target] = {
+				count: 1, trueCount: this.getVoteValue(userid), lastVote: Date.now(), dir: 'up', voters: [userid],
 			};
-			lynch = this.lynches[target];
+			vote = this.votes[target];
 		} else {
-			lynch.count++;
-			lynch.trueCount += this.getLynchValue(userid);
-			lynch.lastLynch = Date.now();
-			lynch.dir = 'up';
-			lynch.lynchers.push(userid);
+			vote.count++;
+			vote.trueCount += this.getVoteValue(userid);
+			vote.lastVote = Date.now();
+			vote.dir = 'up';
+			vote.voters.push(userid);
 		}
-		player.lynching = target;
-		const name = player.lynching === 'nolynch' ? 'No Vote' : this.playerTable[player.lynching].name;
+		player.voting = target;
+		const name = player.voting === 'novote' ? 'No Vote' : this.playerTable[player.voting].name;
 		const targetUser = Users.get(userid);
-		if (previousLynch) {
-			this.sendTimestamp(`${(targetUser ? targetUser.name : userid)} has shifted their vote from ${previousLynch === 'nolynch' ? 'No Vote' : this.playerTable[previousLynch].name} to ${name}`);
+		if (previousVote) {
+			this.sendTimestamp(`${(targetUser ? targetUser.name : userid)} has shifted their vote from ${previousVote === 'novote' ? 'No Vote' : this.playerTable[previousVote].name} to ${name}`);
 		} else {
 			this.sendTimestamp(
 				name === 'No Vote' ?
@@ -742,132 +742,132 @@ class Mafia extends Rooms.RoomGame {
 					`${(targetUser ? targetUser.name : userid)} has voted ${name}.`
 			);
 		}
-		player.lastLynch = Date.now();
+		player.lastVote = Date.now();
 		this.hasPlurality = null;
-		if (this.getHammerValue(target) <= lynch.trueCount) {
+		if (this.getHammerValue(target) <= vote.trueCount) {
 			// HAMMER
-			this.sendDeclare(`Hammer! ${target === 'nolynch' ? 'Nobody' : Utils.escapeHTML(name)} was voted out!`);
-			this.sendRoom(`|raw|<div class="infobox">${this.lynchBox()}</div>`);
-			if (target !== 'nolynch') this.eliminate(this.playerTable[target], 'kill');
+			this.sendDeclare(`Hammer! ${target === 'novote' ? 'Nobody' : Utils.escapeHTML(name)} was voted out!`);
+			this.sendRoom(`|raw|<div class="infobox">${this.voteBox()}</div>`);
+			if (target !== 'novote') this.eliminate(this.playerTable[target], 'kill');
 			this.night(true);
 			return;
 		}
-		this.updatePlayersLynches();
+		this.updatePlayersVotes();
 	}
 
-	unlynch(userid: ID, force = false) {
+	unvote(userid: ID, force = false) {
 		if (this.phase !== 'day' && !force) return this.sendUser(userid, `|error|You can only vote during the day.`);
 		let player = this.playerTable[userid];
 
-		// autoselflynch blocking doesn't apply to restless spirits
-		if (player && this.forceLynch && !force) {
+		// autoselfvote blocking doesn't apply to restless spirits
+		if (player && this.forceVote && !force) {
 			return this.sendUser(userid, `|error|You can only shift your vote, not unvote.`);
 		}
 
 		if (!player && this.dead[userid] && this.dead[userid].restless) player = this.dead[userid];
-		if (!player?.lynching) return this.sendUser(userid, `|error|You are not voting anyone.`);
-		if (player.lastLynch + 2000 >= Date.now() && !force) {
+		if (!player?.voting) return this.sendUser(userid, `|error|You are not voting anyone.`);
+		if (player.lastVote + 2000 >= Date.now() && !force) {
 			return this.sendUser(
 				userid,
-				`|error|You must wait another ${Chat.toDurationString((player.lastLynch + 2000) - Date.now()) || '1 second'} before you can change your vote.`
+				`|error|You must wait another ${Chat.toDurationString((player.lastVote + 2000) - Date.now()) || '1 second'} before you can change your vote.`
 			);
 		}
-		const lynch = this.lynches[player.lynching];
-		lynch.count--;
-		lynch.trueCount -= this.getLynchValue(userid);
-		if (lynch.count <= 0) {
-			delete this.lynches[player.lynching];
+		const vote = this.votes[player.voting];
+		vote.count--;
+		vote.trueCount -= this.getVoteValue(userid);
+		if (vote.count <= 0) {
+			delete this.votes[player.voting];
 		} else {
-			lynch.lastLynch = Date.now();
-			lynch.dir = 'down';
-			lynch.lynchers.splice(lynch.lynchers.indexOf(userid), 1);
+			vote.lastVote = Date.now();
+			vote.dir = 'down';
+			vote.voters.splice(vote.voters.indexOf(userid), 1);
 		}
 		const targetUser = Users.get(userid);
 		if (!force) {
 			this.sendTimestamp(
-				player.lynching === 'nolynch' ?
+				player.voting === 'novote' ?
 					`${(targetUser ? targetUser.name : userid)} is no longer abstaining from voting.` :
-					`${(targetUser ? targetUser.name : userid)} has unvoted ${this.playerTable[player.lynching].name}.`
+					`${(targetUser ? targetUser.name : userid)} has unvoted ${this.playerTable[player.voting].name}.`
 			);
 		}
-		player.lynching = '';
-		player.lastLynch = Date.now();
+		player.voting = '';
+		player.lastVote = Date.now();
 		this.hasPlurality = null;
-		this.updatePlayersLynches();
+		this.updatePlayersVotes();
 	}
 
 	/**
-	 * Returns HTML code that contains information on the current lynch vote.
+	 * Returns HTML code that contains information on the current vote vote.
 	 */
-	lynchBox() {
+	voteBox() {
 		if (!this.started) return `<strong>The game has not started yet.</strong>`;
 		let buf = `<strong>Votes (Hammer: ${this.hammerCount || "Disabled"})</strong><br />`;
 		const plur = this.getPlurality();
-		const list = Utils.sortBy(Object.entries(this.lynches), ([key, lynch]) => [
+		const list = Utils.sortBy(Object.entries(this.votes), ([key, vote]) => [
 			key === plur,
-			-lynch.count,
+			-vote.count,
 		]);
-		for (const [key, lynch] of list) {
-			buf += `${lynch.count}${plur === key ? '*' : ''} ${this.playerTable[key]?.safeName || 'No Vote'} (${lynch.lynchers.map(a => this.playerTable[a]?.safeName || a).join(', ')})<br />`;
+		for (const [key, vote] of list) {
+			buf += `${vote.count}${plur === key ? '*' : ''} ${this.playerTable[key]?.safeName || 'No Vote'} (${vote.voters.map(a => this.playerTable[a]?.safeName || a).join(', ')})<br />`;
 		}
 		return buf;
 	}
-	lynchBoxFor(userid: ID) {
+	voteBoxFor(userid: ID) {
 		let buf = '';
-		buf += `<h3>Votes (Hammer: ${this.hammerCount || 'Disabled'}) <button class="button" name="send" value="/msgroom ${this.roomid},/mafia refreshlynches"><i class="fa fa-refresh"></i> Refresh</button></h3>`;
+		buf += `<h3>Votes (Hammer: ${this.hammerCount || 'Disabled'}) <button class="button" name="send" value="/msgroom ${this.roomid},/mafia refreshvotes"><i class="fa fa-refresh"></i> Refresh</button></h3>`;
 		const plur = this.getPlurality();
-		for (const key of Object.keys(this.playerTable).concat((this.enableNL ? ['nolynch'] : [])) as ID[]) {
-			if (this.lynches[key]) {
-				buf += `<p style="font-weight:bold">${this.lynches[key].count}${plur === key ? '*' : ''} ${this.playerTable[key] ? `${this.playerTable[key].safeName} ${this.playerTable[key].revealed ? `[${this.playerTable[key].revealed}]` : ''}` : 'No Vote'} (${this.lynches[key].lynchers.map(a => this.playerTable[a] ? this.playerTable[a].safeName : a).join(', ')}) `;
+		for (const key of Object.keys(this.playerTable).concat((this.enableNL ? ['novote'] : [])) as ID[]) {
+			if (this.votes[key]) {
+				buf += `<p style="font-weight:bold">${this.votes[key].count}${plur === key ? '*' : ''} ${this.playerTable[key] ? `${this.playerTable[key].safeName} ${this.playerTable[key].revealed ? `[${this.playerTable[key].revealed}]` : ''}` : 'No Vote'} (${this.votes[key].voters.map(a => this.playerTable[a] ? this.playerTable[a].safeName : a).join(', ')}) `;
 			} else {
 				buf += `<p style="font-weight:bold">0 ${this.playerTable[key] ? `${this.playerTable[key].safeName} ${this.playerTable[key].revealed ? `[${this.playerTable[key].revealed}]` : ''}` : 'No Vote'} `;
 			}
 			const isPlayer = (this.playerTable[userid]);
 			const isSpirit = (this.dead[userid] && this.dead[userid].restless);
 			if (isPlayer || isSpirit) {
-				if (isPlayer && this.playerTable[userid].lynching === key || isSpirit && this.dead[userid].lynching === key) {
-					buf += `<button class="button" name="send" value="/msgroom ${this.roomid},/mafia unlynch">Unvote ${this.playerTable[key] ? this.playerTable[key].safeName : 'No Vote'}</button>`;
+				if (isPlayer && this.playerTable[userid].voting === key || isSpirit && this.dead[userid].voting === key) {
+					buf += `<button class="button" name="send" value="/msgroom ${this.roomid},/mafia unvote">Unvote ${this.playerTable[key] ? this.playerTable[key].safeName : 'No Vote'}</button>`;
 				} else if ((this.selfEnabled && !isSpirit) || userid !== key) {
-					buf += `<button class="button" name="send" value="/msgroom ${this.roomid},/mafia lynch ${key}">Vote ${this.playerTable[key] ? this.playerTable[key].safeName : 'No Vote'}</button>`;
+					buf += `<button class="button" name="send" value="/msgroom ${this.roomid},/mafia vote ${key}">Vote ${this.playerTable[key] ? this.playerTable[key].safeName : 'No Vote'}</button>`;
 				}
 			} else if (userid === this.hostid || this.cohostids.includes(userid)) {
-				const lynch = this.lynches[key];
-				if (lynch && lynch.count !== lynch.trueCount) buf += `(${lynch.trueCount})`;
+				const vote = this.votes[key];
+				if (vote && vote.count !== vote.trueCount) buf += `(${vote.trueCount})`;
 				if (this.hammerModifiers[key]) buf += `(${this.getHammerValue(key)} to hammer)`;
 			}
 			buf += `</p>`;
 		}
 		return buf;
 	}
-	applyLynchModifier(user: User, target: ID, mod: number) {
+	applyVoteModifier(user: User, target: ID, mod: number) {
 		const targetPlayer = this.playerTable[target] || this.dead[target];
 		if (!targetPlayer) return this.sendUser(user, `|error|${target} is not in the game of mafia.`);
 		if (target in this.dead && !targetPlayer.restless) {
 			return this.sendUser(user, `|error|${target} is not alive or a restless spirit, and therefore cannot vote.`);
 		}
-		const oldMod = this.lynchModifiers[target];
+		const oldMod = this.voteModifiers[target];
 		if (mod === oldMod || ((isNaN(mod) || mod === 1) && oldMod === undefined)) {
 			if (isNaN(mod) || mod === 1) return this.sendUser(user, `|error|${target} already has no vote modifier.`);
 			return this.sendUser(user, `|error|${target} already has a vote modifier of ${mod}`);
 		}
 		const newMod = isNaN(mod) ? 1 : mod;
-		if (targetPlayer.lynching) {
-			this.lynches[targetPlayer.lynching].trueCount += oldMod - newMod;
-			if (this.getHammerValue(targetPlayer.lynching) <= this.lynches[targetPlayer.lynching].trueCount) {
-				this.sendRoom(`${targetPlayer.lynching} has been voted out due to a modifier change! They have not been eliminated.`);
+		if (targetPlayer.voting) {
+			this.votes[targetPlayer.voting].trueCount += oldMod - newMod;
+			if (this.getHammerValue(targetPlayer.voting) <= this.votes[targetPlayer.voting].trueCount) {
+				this.sendRoom(`${targetPlayer.voting} has been voted out due to a modifier change! They have not been eliminated.`);
 				this.night(true);
 			}
 		}
 		if (newMod === 1) {
-			delete this.lynchModifiers[target];
+			delete this.voteModifiers[target];
 			return this.sendUser(user, `${targetPlayer.name} has had their vote modifier removed.`);
 		} else {
-			this.lynchModifiers[target] = newMod;
+			this.voteModifiers[target] = newMod;
 			return this.sendUser(user, `${targetPlayer.name} has been given a vote modifier of ${newMod}`);
 		}
 	}
 	applyHammerModifier(user: User, target: ID, mod: number) {
-		if (!(target in this.playerTable || target === 'nolynch')) {
+		if (!(target in this.playerTable || target === 'novote')) {
 			return this.sendUser(user, `|error|${target} is not in the game of mafia.`);
 		}
 		const oldMod = this.hammerModifiers[target];
@@ -876,9 +876,9 @@ class Mafia extends Rooms.RoomGame {
 			return this.sendUser(user, `|error|${target} already has a hammer modifier of ${mod}`);
 		}
 		const newMod = isNaN(mod) ? 0 : mod;
-		if (this.lynches[target]) {
+		if (this.votes[target]) {
 			// do this manually since we havent actually changed the value yet
-			if (this.hammerCount + newMod <= this.lynches[target].trueCount) {
+			if (this.hammerCount + newMod <= this.votes[target].trueCount) {
 				// make sure these strings are the same
 				this.sendRoom(`${target} has been voted due to a modifier change! They have not been eliminated.`);
 				this.night(true);
@@ -892,19 +892,19 @@ class Mafia extends Rooms.RoomGame {
 			return this.sendUser(user, `${target} has been given a hammer modifier of ${newMod}`);
 		}
 	}
-	clearLynchModifiers(user: User) {
+	clearVoteModifiers(user: User) {
 		for (const player of [...Object.keys(this.playerTable), ...Object.keys(this.dead)] as ID[]) {
-			if (this.lynchModifiers[player]) this.applyLynchModifier(user, player, 1);
+			if (this.voteModifiers[player]) this.applyVoteModifier(user, player, 1);
 		}
 	}
 	clearHammerModifiers(user: User) {
-		for (const player of ['nolynch', ...Object.keys(this.playerTable)] as ID[]) {
+		for (const player of ['novote', ...Object.keys(this.playerTable)] as ID[]) {
 			if (this.hammerModifiers[player]) this.applyHammerModifier(user, player, 0);
 		}
 	}
 
-	getLynchValue(userid: ID) {
-		const mod = this.lynchModifiers[userid];
+	getVoteValue(userid: ID) {
+		const mod = this.voteModifiers[userid];
 		return (mod === undefined ? 1 : mod);
 	}
 	getHammerValue(userid: ID) {
@@ -922,7 +922,7 @@ class Mafia extends Rooms.RoomGame {
 		} else {
 			this.sendDeclare(`The hammer count has been set at ${this.hammerCount}, and votes have been reset.`);
 		}
-		this.clearLynches();
+		this.clearVotes();
 	}
 
 	shiftHammer(count: number) {
@@ -933,9 +933,9 @@ class Mafia extends Rooms.RoomGame {
 			this.sendDeclare(`The hammer count has been shifted to ${this.hammerCount}. Votes have not been reset.`);
 		}
 		const hammered = [];
-		for (const lynch in this.lynches) {
-			if (this.lynches[lynch].trueCount >= this.getHammerValue(lynch as ID)) {
-				hammered.push(lynch === 'nolynch' ? 'Nobody' : lynch);
+		for (const vote in this.votes) {
+			if (this.votes[vote].trueCount >= this.getHammerValue(vote as ID)) {
+				hammered.push(vote === 'novote' ? 'Nobody' : vote);
 			}
 		}
 		if (hammered.length) {
@@ -946,26 +946,26 @@ class Mafia extends Rooms.RoomGame {
 
 	getPlurality() {
 		if (this.hasPlurality) return this.hasPlurality;
-		if (!Object.keys(this.lynches).length) return null;
+		if (!Object.keys(this.votes).length) return null;
 		let max = 0;
-		let topLynches: [ID, MafiaLynch][] = [];
-		for (const [key, lynch] of Object.entries(this.lynches)) {
-			if (lynch.count > max) {
-				max = lynch.count;
-				topLynches = [[key as ID, lynch]];
-			} else if (lynch.count === max) {
-				topLynches.push([key as ID, lynch]);
+		let topVotes: [ID, MafiaVote][] = [];
+		for (const [key, vote] of Object.entries(this.votes)) {
+			if (vote.count > max) {
+				max = vote.count;
+				topVotes = [[key as ID, vote]];
+			} else if (vote.count === max) {
+				topVotes.push([key as ID, vote]);
 			}
 		}
-		if (topLynches.length <= 1) {
-			[this.hasPlurality] = topLynches[0];
+		if (topVotes.length <= 1) {
+			[this.hasPlurality] = topVotes[0];
 			return this.hasPlurality;
 		}
-		topLynches = Utils.sortBy(topLynches, ([key, lynch]) => [
-			lynch.dir === 'down',
-			lynch.dir === 'up' ? lynch.lastLynch : -lynch.lastLynch,
+		topVotes = Utils.sortBy(topVotes, ([key, vote]) => [
+			vote.dir === 'down',
+			vote.dir === 'up' ? vote.lastVote : -vote.lastVote,
 		]);
-		[this.hasPlurality] = topLynches[0];
+		[this.hasPlurality] = topVotes[0];
 		return this.hasPlurality;
 	}
 
@@ -1008,7 +1008,7 @@ class Mafia extends Rooms.RoomGame {
 		default:
 			msg += ` was eliminated`;
 		}
-		if (player.lynching) this.unlynch(player.id, true);
+		if (player.voting) this.unvote(player.id, true);
 		this.sendDeclare(`${msg}! ${!this.noReveal && toID(ability) === 'kill' ? `${player.safeName}'s role was ${player.getRole()}.` : ''}`);
 		if (player.role && !this.noReveal && toID(ability) === 'kill') player.revealed = player.getRole()!;
 		const targetRole = player.role;
@@ -1020,7 +1020,7 @@ class Mafia extends Rooms.RoomGame {
 				}
 			}
 		}
-		this.clearLynches(player.id);
+		this.clearVotes(player.id);
 		delete this.playerTable[player.id];
 		let subIndex = this.requestedSub.indexOf(player.id);
 		if (subIndex !== -1) this.requestedSub.splice(subIndex, 1);
@@ -1160,24 +1160,24 @@ class Mafia extends Rooms.RoomGame {
 		const newPlayer = this.makePlayer(newUser);
 		newPlayer.role = oldPlayer.role;
 		newPlayer.IDEA = oldPlayer.IDEA;
-		if (oldPlayer.lynching) {
+		if (oldPlayer.voting) {
 			// Dont change plurality
-			const lynch = this.lynches[oldPlayer.lynching];
-			lynch.lynchers.splice(lynch.lynchers.indexOf(oldPlayer.id), 1);
-			lynch.lynchers.push(newPlayer.id);
-			newPlayer.lynching = oldPlayer.lynching;
-			oldPlayer.lynching = '';
+			const vote = this.votes[oldPlayer.voting];
+			vote.voters.splice(vote.voters.indexOf(oldPlayer.id), 1);
+			vote.voters.push(newPlayer.id);
+			newPlayer.voting = oldPlayer.voting;
+			oldPlayer.voting = '';
 		}
 		this.playerTable[newPlayer.id] = newPlayer;
-		// Transfer lynches on the old player to the new one
-		if (this.lynches[oldPlayer.id]) {
-			this.lynches[newPlayer.id] = this.lynches[oldPlayer.id];
-			delete this.lynches[oldPlayer.id];
+		// Transfer votes on the old player to the new one
+		if (this.votes[oldPlayer.id]) {
+			this.votes[newPlayer.id] = this.votes[oldPlayer.id];
+			delete this.votes[oldPlayer.id];
 			for (const p in this.playerTable) {
-				if (this.playerTable[p].lynching === oldPlayer.id) this.playerTable[p].lynching = newPlayer.id;
+				if (this.playerTable[p].voting === oldPlayer.id) this.playerTable[p].voting = newPlayer.id;
 			}
 			for (const p in this.dead) {
-				if (this.dead[p].restless && this.dead[p].lynching === oldPlayer.id) this.dead[p].lynching = newPlayer.id;
+				if (this.dead[p].restless && this.dead[p].voting === oldPlayer.id) this.dead[p].voting = newPlayer.id;
 			}
 		}
 		if (this.hasPlurality === oldPlayer.id) this.hasPlurality = newPlayer.id;
@@ -1451,12 +1451,12 @@ class Mafia extends Rooms.RoomGame {
 		this.updateHost();
 	}
 
-	updatePlayersLynches() {
+	updatePlayersVotes() {
 		for (const p in this.playerTable) {
-			this.playerTable[p].updateHtmlLynches();
+			this.playerTable[p].updateHtmlVotes();
 		}
 		for (const p in this.dead) {
-			if (this.dead[p].restless || this.dead[p].treestump) this.dead[p].updateHtmlLynches();
+			if (this.dead[p].restless || this.dead[p].treestump) this.dead[p].updateHtmlVotes();
 		}
 	}
 
@@ -1546,55 +1546,55 @@ class Mafia extends Rooms.RoomGame {
 		userObject.sendTo(this.room, message);
 	}
 
-	setSelfLynch(user: User, setting: boolean | 'hammer') {
+	setSelfVote(user: User, setting: boolean | 'hammer') {
 		const from = this.selfEnabled;
 		if (from === setting) {
 			return user.sendTo(
 				this.room,
-				`|error|Selfvoting is already ${setting ? `set to Self${setting === 'hammer' ? 'hammering' : 'lynching'}` : 'disabled'}.`
+				`|error|Selfvoting is already ${setting ? `set to Self${setting === 'hammer' ? 'hammering' : 'voting'}` : 'disabled'}.`
 			);
 		}
 		if (from) {
-			this.sendDeclare(`Self${from === 'hammer' ? 'hammering' : 'lynching'} has been ${setting ? `changed to Self${setting === 'hammer' ? 'hammering' : 'lynching'}` : 'disabled'}.`);
+			this.sendDeclare(`Self${from === 'hammer' ? 'hammering' : 'voting'} has been ${setting ? `changed to Self${setting === 'hammer' ? 'hammering' : 'voting'}` : 'disabled'}.`);
 		} else {
-			this.sendDeclare(`Self${setting === 'hammer' ? 'hammering' : 'lynching'} has been ${setting ? 'enabled' : 'disabled'}.`);
+			this.sendDeclare(`Self${setting === 'hammer' ? 'hammering' : 'voting'} has been ${setting ? 'enabled' : 'disabled'}.`);
 		}
 		this.selfEnabled = setting;
 		if (!setting) {
 			for (const player of Object.values(this.playerTable)) {
-				if (player.lynching === player.id) this.unlynch(player.id, true);
+				if (player.voting === player.id) this.unvote(player.id, true);
 			}
 		}
 		this.updatePlayers();
 	}
-	setNoLynch(user: User, setting: boolean) {
+	setNoVote(user: User, setting: boolean) {
 		if (this.enableNL === setting) {
 			return user.sendTo(this.room, `|error|No Vote is already ${setting ? 'enabled' : 'disabled'}.`);
 		}
 		this.enableNL = setting;
 		this.sendDeclare(`No Vote has been ${setting ? 'enabled' : 'disabled'}.`);
-		if (!setting) this.clearLynches('nolynch');
+		if (!setting) this.clearVotes('novote');
 		this.updatePlayers();
 	}
-	clearLynches(target = '') {
-		if (target) delete this.lynches[target];
+	clearVotes(target = '') {
+		if (target) delete this.votes[target];
 
-		if (!target) this.lynches = Object.create(null);
+		if (!target) this.votes = Object.create(null);
 
 		for (const player of Object.values(this.playerTable)) {
-			if (this.forceLynch) {
-				if (!target || (player.lynching === target)) {
-					player.lynching = player.id;
-					this.lynches[player.id] = {
-						count: 1, trueCount: this.getLynchValue(player.id), lastLynch: Date.now(), dir: 'up', lynchers: [player.id],
+			if (this.forceVote) {
+				if (!target || (player.voting === target)) {
+					player.voting = player.id;
+					this.votes[player.id] = {
+						count: 1, trueCount: this.getVoteValue(player.id), lastVote: Date.now(), dir: 'up', voters: [player.id],
 					};
 				}
 			} else {
-				if (!target || (player.lynching === target)) player.lynching = '';
+				if (!target || (player.voting === target)) player.voting = '';
 			}
 		}
 		for (const player of Object.values(this.dead)) {
-			if (player.restless && (!target || player.lynching === target)) player.lynching = '';
+			if (player.restless && (!target || player.voting === target)) player.voting = '';
 		}
 		this.hasPlurality = null;
 	}
@@ -1819,8 +1819,8 @@ export const pages: Chat.PageTable = {
 			}
 		}
 		if (game.phase === "day") {
-			buf += `<span id="mafia-lynches">`;
-			buf += game.lynchBoxFor(user.id);
+			buf += `<span id="mafia-votes">`;
+			buf += game.voteBoxFor(user.id);
 			buf += `</span>`;
 		} else if (game.phase === "night" && isPlayer) {
 			if (!game.takeIdles) {
@@ -1879,7 +1879,7 @@ export const pages: Chat.PageTable = {
 			} else if (game.phase === 'night') {
 				buf += `<button class="button" name="send" value="/msgroom ${room.roomid},/mafia day">Go to Day ${game.dayNum + 1}</button> <button class="button" name="send" value="/msgroom ${room.roomid},/mafia extend">Return to Day ${game.dayNum}</button>`;
 			}
-			buf += ` <button class="button" name="send" value="/msgroom ${room.roomid},/mafia selflynch ${game.selfEnabled === true ? 'off' : 'on'}">${game.selfEnabled === true ? 'Disable' : 'Enable'} self lynching</button> `;
+			buf += ` <button class="button" name="send" value="/msgroom ${room.roomid},/mafia selfvote ${game.selfEnabled === true ? 'off' : 'on'}">${game.selfEnabled === true ? 'Disable' : 'Enable'} self voting</button> `;
 			buf += `<button class="button" name="send" value="/msgroom ${room.roomid},/mafia ${game.enableNL ? 'disable' : 'enable'}nl">${game.enableNL ? 'Disable' : 'Enable'} No Vote</button> `;
 			buf += `<button class="button" name="send" value="/msgroom ${room.roomid},/mafia reveal ${game.noReveal ? 'on' : 'off'}">${game.noReveal ? 'Enable' : 'Disable'} revealing of roles</button> `;
 			buf += `<button class="button" name="send" value="/msgroom ${room.roomid},/mafia autosub ${game.autoSub ? 'off' : 'on'}">${game.autoSub ? "Disable" : "Enable"} automatic subbing of players</button> `;
@@ -1891,7 +1891,7 @@ export const pages: Chat.PageTable = {
 				const player = game.playerTable[p];
 				buf += `<p><details><summary class="button" style="text-align:left; display:inline-block"><span style="font-weight:bold;">`;
 				buf += `${player.safeName} (${player.role ? player.getRole(true) : ''})`;
-				buf += game.lynchModifiers[p] !== undefined ? `(votes worth ${game.getLynchValue(p as ID)})` : '';
+				buf += game.voteModifiers[p] !== undefined ? `(votes worth ${game.getVoteValue(p as ID)})` : '';
 				buf += player.hammerRestriction !== null ? `(${player.hammerRestriction ? 'actor' : 'priest'})` : '';
 				buf += player.silenced ? '(silenced)' : '';
 				buf += player.nighttalk ? '(insomniac)' : '';
@@ -1907,7 +1907,7 @@ export const pages: Chat.PageTable = {
 				buf += `<p style="font-weight:bold;">${dead.safeName} (${dead.role ? dead.getRole() : ''})`;
 				if (dead.treestump) buf += ` (is a Treestump)`;
 				if (dead.restless) buf += ` (is a Restless Spirit)`;
-				if (game.lynchModifiers[d] !== undefined) buf += ` (votes worth ${game.getLynchValue(d as ID)})`;
+				if (game.voteModifiers[d] !== undefined) buf += ` (votes worth ${game.getVoteValue(d as ID)})`;
 				buf += dead.hammerRestriction !== null ? `(${dead.hammerRestriction ? 'actor' : 'priest'})` : '';
 				buf += dead.silenced ? '(silenced)' : '';
 				buf += dead.nighttalk ? '(insomniac)' : '';
@@ -2405,10 +2405,8 @@ export const commands: Chat.ChatCommands = {
 			`/mafia extend (minutes) - Return to the previous game day. If (minutes) is provided, set the deadline for (minutes) minutes. Requires host % @ # &`,
 		],
 
-		v: 'lynch',
-		vote: 'lynch',
-		l: 'lynch',
-		lynch(target, room, user) {
+		v: 'vote',
+		vote(target, room, user) {
 			room = this.requireRoom();
 			const game = this.requireGame(Mafia);
 			this.checkChat(null, room);
@@ -2416,17 +2414,14 @@ export const commands: Chat.ChatCommands = {
 				(!(user.id in game.dead) || !game.dead[user.id].restless)) {
 				return this.errorReply(`You are not in the game of ${game.title}.`);
 			}
-			game.lynch(user.id, toID(target));
+			game.vote(user.id, toID(target));
 		},
-		lynchhelp: [`/mafia vote [player|novote] - Vote the specified player or abstain from voting.`],
+		votehelp: [`/mafia vote [player|novote] - Vote the specified player or abstain from voting.`],
 
-		uv: 'unlynch',
-		unv: 'unlynch',
-		unvote: 'unlynch',
-		ul: 'unlynch',
-		unl: 'unlynch',
-		unnolynch: 'unlynch',
-		unlynch(target, room, user) {
+		uv: 'unvote',
+		unv: 'unvote',
+		unnovote: 'unvote',
+		unvote(target, room, user) {
 			room = this.requireRoom();
 			const game = this.requireGame(Mafia);
 			this.checkChat(null, room);
@@ -2434,37 +2429,34 @@ export const commands: Chat.ChatCommands = {
 				(!(user.id in game.dead) || !game.dead[user.id].restless)) {
 				return this.errorReply(`You are not in the game of ${game.title}.`);
 			}
-			game.unlynch(user.id);
+			game.unvote(user.id);
 		},
-		unlynchhelp: [`/mafia unvote - Withdraw your vote. Fails if you're not voting anyone`],
+		unvotehelp: [`/mafia unvote - Withdraw your vote. Fails if you're not voting anyone`],
 
-		nv: 'nolynch',
-		novote: 'nolynch',
-		nl: 'nolynch',
-		nolynch() {
-			this.parse('/mafia lynch nolynch');
+		nv: 'novote',
+		novote() {
+			this.parse('/mafia vote novote');
 		},
 
-		enableself: 'selflynch',
-		selfvote: 'selflynch',
-		selflynch(target, room, user, connection, cmd) {
+		enableself: 'selfvote',
+		selfvote(target, room, user, connection, cmd) {
 			room = this.requireRoom();
 			const game = this.requireGame(Mafia);
 			if (game.hostid !== user.id && !game.cohostids.includes(user.id)) this.checkCan('mute', null, room);
 			const action = toID(target);
-			if (!action) return this.parse(`/help mafia selflynch`);
+			if (!action) return this.parse(`/help mafia selfvote`);
 			if (this.meansYes(action)) {
-				game.setSelfLynch(user, true);
+				game.setSelfVote(user, true);
 			} else if (this.meansNo(action)) {
-				game.setSelfLynch(user, false);
+				game.setSelfVote(user, false);
 			} else if (action === 'hammer') {
-				game.setSelfLynch(user, 'hammer');
+				game.setSelfVote(user, 'hammer');
 			} else {
-				return this.parse(`/help mafia selflynch`);
+				return this.parse(`/help mafia selfvote`);
 			}
 			game.logAction(user, `changed selfvote`);
 		},
-		selflynchhelp: [
+		selfvotehelp: [
 			`/mafia selfvote [on|hammer|off] - Allows players to self vote themselves either at hammer or anytime. Requires host % @ # &`,
 		],
 
@@ -2618,7 +2610,6 @@ export const commands: Chat.ChatCommands = {
 		],
 
 		applyvotemodifier: 'applyhammermodifier',
-		applylynchmodifier: 'applyhammermodifier',
 		applyhammermodifier(target, room, user, connection, cmd) {
 			room = this.requireRoom();
 			const game = this.requireGame(Mafia);
@@ -2629,12 +2620,11 @@ export const commands: Chat.ChatCommands = {
 				game.applyHammerModifier(user, toID(player), parseInt(mod));
 				game.secretLogAction(user, `changed a hammer modifier`);
 			} else {
-				game.applyLynchModifier(user, toID(player), parseInt(mod));
+				game.applyVoteModifier(user, toID(player), parseInt(mod));
 				game.secretLogAction(user, `changed a vote modifier`);
 			}
 		},
 		clearvotemodifiers: 'clearhammermodifiers',
-		clearlynchmodifiers: 'clearhammermodifiers',
 		clearhammermodifiers(target, room, user, connection, cmd) {
 			room = this.requireRoom();
 			const game = this.requireGame(Mafia);
@@ -2644,7 +2634,7 @@ export const commands: Chat.ChatCommands = {
 				game.clearHammerModifiers(user);
 				game.secretLogAction(user, `cleared hammer modifiers`);
 			} else {
-				game.clearLynchModifiers(user);
+				game.clearVoteModifiers(user);
 				game.secretLogAction(user, `cleared vote modifiers`);
 			}
 		},
@@ -2673,7 +2663,6 @@ export const commands: Chat.ChatCommands = {
 		unvoteless: 'mayor',
 		unmayor: 'mayor',
 		removevotemodifier: 'mayor',
-		removelynchmodifier: 'mayor',
 		mayor(target, room, user, connection, cmd) {
 			let mod;
 			switch (cmd) {
@@ -2683,11 +2672,11 @@ export const commands: Chat.ChatCommands = {
 			case 'voteless':
 				mod = 0;
 				break;
-			case 'unvoteless': case 'unmayor': case 'removelynchmodifier': case 'removevotemodifier':
+			case 'unvoteless': case 'unmayor': case 'removevotemodifier':
 				mod = 1;
 				break;
 			}
-			this.parse(`/mafia applylynchmodifier ${target}, ${mod}`);
+			this.parse(`/mafia applyvotemodifier ${target}, ${mod}`);
 		},
 
 		unsilence: 'silence',
@@ -2769,8 +2758,8 @@ export const commands: Chat.ChatCommands = {
 			targetPlayer.hammerRestriction = actor;
 			this.sendReply(`${targetPlayer.name} is now ${targetPlayer.hammerRestriction ? "an actor (can only hammer)" : "a priest (can't hammer)"}.`);
 			if (actor) {
-				// target is an actor, remove their lynch because it's now impossible
-				game.unlynch(targetPlayer.id, true);
+				// target is an actor, remove their vote because it's now impossible
+				game.unvote(targetPlayer.id, true);
 			}
 			game.logAction(user, `made a player actor/priest`);
 		},
@@ -2818,9 +2807,9 @@ export const commands: Chat.ChatCommands = {
 			const game = this.requireGame(Mafia);
 			if (game.hostid !== user.id && !game.cohostids.includes(user.id)) this.checkCan('mute', null, room);
 			if (cmd === 'enablenl' || cmd === 'enablenv') {
-				game.setNoLynch(user, true);
+				game.setNoVote(user, true);
 			} else {
-				game.setNoLynch(user, false);
+				game.setNoVote(user, false);
 			}
 			game.logAction(user, `changed novote status`);
 		},
@@ -2828,32 +2817,30 @@ export const commands: Chat.ChatCommands = {
 			`/mafia [enablenv|disablenv] - Allows or disallows players abstain from voting. Requires host % @ # &`,
 		],
 
-		forcevote: 'forcelynch',
-		forcelynch(target, room, user) {
+		forcevote(target, room, user) {
 			room = this.requireRoom();
 			const game = this.requireGame(Mafia);
 			if (game.hostid !== user.id && !game.cohostids.includes(user.id)) this.checkCan('mute', null, room);
 			target = toID(target);
 			if (this.meansYes(target)) {
-				if (game.forceLynch) return this.errorReply(`Forcevoting is already enabled.`);
-				game.forceLynch = true;
+				if (game.forceVote) return this.errorReply(`Forcevoting is already enabled.`);
+				game.forceVote = true;
 				if (game.started) game.resetHammer();
 				game.sendDeclare(`Forcevoting has been enabled. Your vote will start on yourself, and you cannot unvote!`);
 			} else if (this.meansNo(target)) {
-				if (!game.forceLynch) return this.errorReply(`Forcevoting is already disabled.`);
-				game.forceLynch = false;
+				if (!game.forceVote) return this.errorReply(`Forcevoting is already disabled.`);
+				game.forceVote = false;
 				game.sendDeclare(`Forcevoting has been disabled. You can vote normally now!`);
 			} else {
 				this.parse('/help mafia forcevote');
 			}
 			game.logAction(user, `changed forcevote status`);
 		},
-		forcelynchhelp: [
+		forcevotehelp: [
 			`/mafia forcevote [yes/no] - Forces players' votes onto themselves, and prevents unvoting. Requires host % @ # &`,
 		],
 
-		votes: 'lynches',
-		lynches(target, room, user) {
+		votes(target, room, user) {
 			room = this.requireRoom();
 			const game = this.requireGame(Mafia);
 			if (!game.started) return this.errorReply(`The game of mafia has not started yet.`);
@@ -2864,7 +2851,7 @@ export const commands: Chat.ChatCommands = {
 			}
 			if (!this.runBroadcast()) return false;
 
-			this.sendReplyBox(game.lynchBox());
+			this.sendReplyBox(game.voteBox());
 		},
 
 		pl: 'players',
@@ -2929,11 +2916,11 @@ export const commands: Chat.ChatCommands = {
 			return this.parse(`/join view-mafia-${room.roomid}`);
 		},
 
-		refreshlynches(target, room, user, connection) {
+		refreshvotes(target, room, user, connection) {
 			room = this.requireRoom();
 			const game = this.requireGame(Mafia);
-			const lynches = game.lynchBoxFor(user.id);
-			user.send(`>view-mafia-${game.room.roomid}\n|selectorhtml|#mafia-lynches|` + lynches);
+			const votes = game.voteBoxFor(user.id);
+			user.send(`>view-mafia-${game.room.roomid}\n|selectorhtml|#mafia-votes|` + votes);
 		},
 		forcesub: 'sub',
 		sub(target, room, user, connection, cmd) {
@@ -3097,7 +3084,7 @@ export const commands: Chat.ChatCommands = {
 				if (!cmd.includes('force')) {
 					return this.errorReply(`${targetUser.name} could potentially be revived. To continue anyway, use /mafia force${cmd} ${target}.`);
 				}
-				if (game.dead[targetUser.id].lynching) game.unlynch(targetUser.id);
+				if (game.dead[targetUser.id].voting) game.unvote(targetUser.id);
 				game.dead[targetUser.id].destroy();
 				delete game.dead[targetUser.id];
 			}


### PR DESCRIPTION
Final removal of the word "lynch" from mafia.ts due to racial considerations. All uses of the word have been changed to "vote" and all future references to the action will use "vote" instead of "lynch".