### PR TITLE
Gen 1: Move Aerodactyl and Dewgong to UU

### DIFF
--- a/data/mods/gen1/formats-data.ts
+++ b/data/mods/gen1/formats-data.ts
@@ -445,7 +445,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	dewgong: {
 		randomBattleMoves: ["surf", "blizzard", "bodyslam"],
 		exclusiveMoves: ["rest", "rest", "mimic", "hyperbeam"],
-		tier: "NU",
+		tier: "UU",
 	},
 	grimer: {
 		randomBattleMoves: ["sludge", "bodyslam"],
@@ -719,7 +719,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	aerodactyl: {
 		randomBattleMoves: ["skyattack", "fireblast", "doubleedge", "hyperbeam"],
-		tier: "NU",
+		tier: "UU",
 	},
 	snorlax: {
 		randomBattleMoves: ["rest", "thunderbolt", "bodyslam", "selfdestruct"],


### PR DESCRIPTION
The new RBY UU Viability Rankings were produced yesterday night, and these Pokemon moved up. The 2-revision policy for OU does not apply here. 

Update can be found here: 
https://www.smogon.com/forums/threads/rby-uu-viability-rankings.3647713/post-8935573