### PR TITLE
Modlog: Fix double spaces when no moderation found

### DIFF
--- a/server/chat-plugins/modlog-viewer.ts
+++ b/server/chat-plugins/modlog-viewer.ts
@@ -79,13 +79,13 @@ function prettifyResults(
 	const includes = search.note.filter(s => !s.isExclusion).map(s => s.search) || [];
 	if (includes.length) searchString += `with a note including any of: ${includes.join(', ')} `;
 	if (excludes.length) searchString += `with a note that does not include any of: ${excludes.join(', ')} `;
-	for (const u of search.user) searchString += `${u.isExclusion ? 'not' : ''} taken against ${u.search} `;
+	for (const u of search.user) searchString += `${u.isExclusion ? 'not ' : ''}taken against ${u.search} `;
 	for (const ip of search.ip) {
-		searchString += `${ip.isExclusion ? 'not' : ''}taken against a user on the IP ${ip.search} `;
+		searchString += `${ip.isExclusion ? 'not ' : ''}taken against a user on the IP ${ip.search} `;
 	}
-	for (const action of search.action) searchString += `${action.isExclusion ? 'not' : ''} of the type ${action.search} `;
+	for (const action of search.action) searchString += `${action.isExclusion ? 'not ' : ''}of the type ${action.search} `;
 	for (const actionTaker of search.actionTaker) {
-		searchString += `${actionTaker.isExclusion ? 'not' : ''} taken by ${actionTaker.search} `;
+		searchString += `${actionTaker.isExclusion ? 'not ' : ''}taken by ${actionTaker.search} `;
 	}
 	if (!resultArray.length) {
 		return `|popup|No ${scope}moderator actions ${searchString}found on ${roomName}.`;


### PR DESCRIPTION
Very, very minor; fixes double spaces for a couple modlog queries when nothing was found.

Before:
![image](https://user-images.githubusercontent.com/23667022/128645662-ab86adb2-48d3-4439-8653-e7b10d7fc4bc.png)

After:
![image](https://user-images.githubusercontent.com/23667022/128645668-7545723e-e9fc-416c-8130-fb12c608659c.png)