### PR TITLE
Chat: Disallow HTTP images

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1236,7 +1236,6 @@ export class CommandContext extends MessageContext {
 		} else {
 			throw new Chat.ErrorMessage("Image URLs must begin with 'https://' or 'data:'; 'http://' cannot be used.");
 		}
-		
 	}
 	/**
 	 * This is a quick and dirty first-pass "is this good HTML" check. The full

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1228,45 +1228,15 @@ export class CommandContext extends MessageContext {
 		return true;
 	}
 	/* eslint-enable @typescript-eslint/prefer-optional-chain */
-	checkEmbedURI(uri: string, autofix?: boolean) {
+	checkEmbedURI(uri: string) {
 		if (uri.startsWith('https://')) return uri;
 		if (uri.startsWith('//')) return uri;
-		if (!uri.startsWith('data:')) {
-			if (/^[a-z]+:\/\//.test(uri)) {
-				throw new Chat.ErrorMessage("Image URLs must begin with 'https://' or 'data:'; 'http://' cannot be used.");
-			}
+		if (uri.startsWith('data:')) {
+			return uri;
 		} else {
-			uri = uri.slice(7);
+			throw new Chat.ErrorMessage("Image URLs must begin with 'https://' or 'data:'; 'http://' cannot be used.");
 		}
-		const slashIndex = uri.indexOf('/');
-		let domain = (slashIndex >= 0 ? uri.slice(0, slashIndex) : uri);
-
-		// heuristic that works for all the domains we care about
-		const secondLastDotIndex = domain.lastIndexOf('.', domain.length - 5);
-		if (secondLastDotIndex >= 0) domain = domain.slice(secondLastDotIndex + 1);
-
-		const approvedDomains = [
-			'imgur.com',
-			'gyazo.com',
-			'puu.sh',
-			'rotmgtool.com',
-			'pokemonshowdown.com',
-			'nocookie.net',
-			'blogspot.com',
-			'imageshack.us',
-			'deviantart.net',
-			'd.pr',
-			'pokefans.net',
-		];
-		if (approvedDomains.includes(domain)) {
-			if (autofix) return `//${uri}`;
-			throw new Chat.ErrorMessage(`Please use HTTPS for image "${uri}"`);
-		}
-		if (domain === 'bit.ly') {
-			throw new Chat.ErrorMessage("Please don't use URL shorteners.");
-		}
-		// unknown URI, allow HTTP to be safe
-		return uri;
+		
 	}
 	/**
 	 * This is a quick and dirty first-pass "is this good HTML" check. The full

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1231,10 +1231,9 @@ export class CommandContext extends MessageContext {
 	checkEmbedURI(uri: string, autofix?: boolean) {
 		if (uri.startsWith('https://')) return uri;
 		if (uri.startsWith('//')) return uri;
-		if (uri.startsWith('data:')) return uri;
-		if (!uri.startsWith('http://')) {
+		if (!uri.startsWith('data:')) {
 			if (/^[a-z]+:\/\//.test(uri)) {
-				throw new Chat.ErrorMessage("Image URLs must begin with 'https://' or 'http://' or 'data:'");
+				throw new Chat.ErrorMessage("Image URLs must begin with 'https://' or 'data:'; 'http://' cannot be used.");
 			}
 		} else {
 			uri = uri.slice(7);


### PR DESCRIPTION
As of [Chrome 86](https://www.chromestatus.com/feature/4926989725073408), Chrome attempts to automatically upgrade images with an http source to be https before displaying the image. If the image can't be loaded in https, it'll just fail to load. Unlike Chrome, Firefox currently just marks the whole site as insecure if it finds image mixed content, indicated by the padlock having a triangle warning sign in the address bar.

By disallowing http images, we prevent users from displaying images that may not work in every browser. Compare the Chrome behavior to the Firefox behavior, with an image that can be upgraded from http -> https and an image that cannot.

Chrome 92:
![image](https://user-images.githubusercontent.com/23667022/128646617-9e335fc9-bd4a-48e8-8eb7-eff0e06c8d03.png)

Firefox 90:
![image](https://user-images.githubusercontent.com/23667022/128646581-32c50c1b-286f-4c3a-9ac1-a0151b422b15.png)

Images in question:
http://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/intermediary/f/578a8319-92b6-4d81-9d5f-d6914e6535a0/d5o541m-54dae5d4-710c-44d4-a898-71ea71d7bd28.jpg
http://www.math.com/images/logo.gif
