### PR TITLE
Fix Metronome (Item) and two-turn moves interaction

### DIFF
--- a/data/items.ts
+++ b/data/items.ts
@@ -3388,8 +3388,12 @@ export const Items: {[itemid: string]: ItemData} = {
 				}
 				if (this.effectState.lastMove === move.id && pokemon.moveLastTurnResult) {
 					this.effectState.numConsecutive++;
-				} else if (pokemon.volatiles['twoturnmove'] && this.effectState.lastMove !== move.id) {
-					this.effectState.numConsecutive = 1;
+				} else if (pokemon.volatiles['twoturnmove']) {
+					if (this.effectState.lastMove !== move.id) {
+						this.effectState.numConsecutive = 1;
+					} else {
+						this.effectState.numConsecutive++;
+					}
 				} else {
 					this.effectState.numConsecutive = 0;
 				}

--- a/test/sim/items/metronome.js
+++ b/test/sim/items/metronome.js
@@ -56,39 +56,45 @@ describe('Metronome (item)', function () {
 
 	it(`should instantly start moves that use a charging turn at Metronome 1 boost level, then increase linearly`, function () {
 		battle = common.createBattle([[
-			{species: 'wynaut', item: 'metronome', moves: ['solarbeam']},
+			{species: 'dusknoir', item: 'metronome', moves: ['dig']},
 		], [
-			{species: 'cleffa', evs: {hp: 252, spe: 252}, ability: 'shellarmor', moves: ['softboiled']},
+			{species: 'blissey', ability: 'shellarmor', moves: ['softboiled']},
 		]]);
 		battle.makeChoices();
 		battle.makeChoices();
-		const cleffa = battle.p2.active[0];
-		let damage = cleffa.maxhp - cleffa.hp;
-		assert.bounded(damage, [59, 70], `Solar Beam should be Metronome 1 boosted`);
+		const blissey = battle.p2.active[0];
+		let damage = blissey.maxhp - blissey.hp;
+
+		// Metronome 1 and 2 damage rolls always overlap in range, so we can't use assert.bounded here.
+		let possibleDamageRolls = [290, 294, 296, 300, 304, 307, 311, 314, 318, 320, 324, 328, 331, 335, 338, 342];
+		const damageWasMetronome1Boosted = possibleDamageRolls.includes(damage);
+		assert(damageWasMetronome1Boosted, `Dig should be Metronome 1 boosted`);
 
 		battle.makeChoices();
 		battle.makeChoices();
-		damage = cleffa.maxhp - cleffa.hp;
-		assert.bounded(damage, [69, 81], `Solar Beam should be Metronome 2 boosted`);
+		damage = blissey.maxhp - blissey.hp;
+		possibleDamageRolls = [339, 343, 346, 350, 354, 358, 363, 367, 371, 374, 378, 382, 386, 391, 395, 399];
+		const damageWasMetronome2Boosted = possibleDamageRolls.includes(damage);
+		assert(damageWasMetronome2Boosted, `Dig should be Metronome 2 boosted`);
 	});
 
 	it(`should not instantly start moves that skip a charging turn at Metronome 1 boost level`, function () {
 		battle = common.createBattle([[
-			{species: 'wynaut', item: 'metronome', moves: ['solarbeam']},
+			{species: 'slowbro', item: 'metronome', moves: ['solarbeam']},
 		], [
-			{species: 'cleffa', evs: {hp: 252, spe: 252}, ability: 'shellarmor', moves: ['sunnyday']},
-			{species: 'cleffa', evs: {hp: 252, spe: 252}, ability: 'cloudnine', moves: ['softboiled']},
+			{species: 'blissey', ability: 'shellarmor', moves: ['sunnyday']},
+			{species: 'blissey', ability: 'cloudnine', moves: ['luckychant']},
 		]]);
 		battle.makeChoices();
-		const cleffa = battle.p2.active[0];
-		let damage = cleffa.maxhp - cleffa.hp;
-		assert.bounded(damage, [49, 58], `Solar Beam should not be Metronome boosted`);
+		const blissey = battle.p2.active[0];
+		let damage = blissey.maxhp - blissey.hp;
+		assert.bounded(damage, [67, 79], `Solar Beam should not be Metronome boosted`);
 
 		battle.makeChoices('auto', 'switch 2');
 		battle.makeChoices();
-		const newCleffa = battle.p2.active[0];
-		damage = newCleffa.maxhp - newCleffa.hp;
-		assert.bounded(damage, [59, 70], `Solar Beam should be Metronome 1 boosted`);
+		const newBlissey = battle.p2.active[0];
+		damage = newBlissey.maxhp - newBlissey.hp;
+		assert.bounded(damage, [80, 95], `Solar Beam should be Metronome 1 boosted`);
 	});
 
 	it.skip(`should use called moves to determine the Metronome multiplier`, function () {

--- a/test/sim/items/metronome.js
+++ b/test/sim/items/metronome.js
@@ -58,16 +58,16 @@ describe('Metronome (item)', function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', item: 'metronome', moves: ['solarbeam']},
 		], [
-			{species: 'cleffa', evs: {hp: 252, spe: 252}, ability: 'shellarmor', moves: ['sleeptalk', 'softboiled']},
+			{species: 'cleffa', evs: {hp: 252, spe: 252}, ability: 'shellarmor', moves: ['softboiled']},
 		]]);
-		battle.makeChoices('auto', 'move sleeptalk');
-		battle.makeChoices('auto', 'move sleeptalk');
+		battle.makeChoices();
+		battle.makeChoices();
 		const cleffa = battle.p2.active[0];
 		let damage = cleffa.maxhp - cleffa.hp;
 		assert.bounded(damage, [59, 70], `Solar Beam should be Metronome 1 boosted`);
 
-		battle.makeChoices('auto', 'move softboiled');
-		battle.makeChoices('auto', 'move softboiled');
+		battle.makeChoices();
+		battle.makeChoices();
 		damage = cleffa.maxhp - cleffa.hp;
 		assert.bounded(damage, [69, 81], `Solar Beam should be Metronome 2 boosted`);
 	});
@@ -76,16 +76,16 @@ describe('Metronome (item)', function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', item: 'metronome', moves: ['solarbeam']},
 		], [
-			{species: 'cleffa', evs: {hp: 252, spe: 252}, ability: 'shellarmor', moves: ['sunnyday', 'softboiled']},
-			{species: 'cleffa', evs: {hp: 252, spe: 252}, ability: 'cloudnine', moves: ['sleeptalk', 'softboiled']},
+			{species: 'cleffa', evs: {hp: 252, spe: 252}, ability: 'shellarmor', moves: ['sunnyday']},
+			{species: 'cleffa', evs: {hp: 252, spe: 252}, ability: 'cloudnine', moves: ['softboiled']},
 		]]);
-		battle.makeChoices('auto', 'move sunnyday');
+		battle.makeChoices();
 		const cleffa = battle.p2.active[0];
 		let damage = cleffa.maxhp - cleffa.hp;
 		assert.bounded(damage, [49, 58], `Solar Beam should not be Metronome boosted`);
 
 		battle.makeChoices('auto', 'switch 2');
-		battle.makeChoices('auto', 'move softboiled');
+		battle.makeChoices();
 		const newCleffa = battle.p2.active[0];
 		damage = newCleffa.maxhp - newCleffa.hp;
 		assert.bounded(damage, [59, 70], `Solar Beam should be Metronome 1 boosted`);

--- a/test/sim/items/metronome.js
+++ b/test/sim/items/metronome.js
@@ -54,22 +54,41 @@ describe('Metronome (item)', function () {
 		assert.bounded(damage, [96, 114]);
 	});
 
-	it.skip(`should instantly start moves that use a charging turn at Metronome 1 boost level, then increase linearly`, function () {
+	it(`should instantly start moves that use a charging turn at Metronome 1 boost level, then increase linearly`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', item: 'metronome', moves: ['solarbeam']},
 		], [
-			{species: 'cleffa', evs: {hp: 252}, ability: 'shellarmor', moves: ['softboiled']},
+			{species: 'cleffa', evs: {hp: 252, spe: 252}, ability: 'shellarmor', moves: ['sleeptalk', 'softboiled']},
 		]]);
-		battle.makeChoices();
-		battle.makeChoices();
+		battle.makeChoices('auto', 'move sleeptalk');
+		battle.makeChoices('auto', 'move sleeptalk');
 		const cleffa = battle.p2.active[0];
 		let damage = cleffa.maxhp - cleffa.hp;
 		assert.bounded(damage, [59, 70], `Solar Beam should be Metronome 1 boosted`);
 
-		battle.makeChoices();
-		battle.makeChoices();
+		battle.makeChoices('auto', 'move softboiled');
+		battle.makeChoices('auto', 'move softboiled');
 		damage = cleffa.maxhp - cleffa.hp;
 		assert.bounded(damage, [69, 81], `Solar Beam should be Metronome 2 boosted`);
+	});
+
+	it(`should not instantly start moves that skip a charging turn at Metronome 1 boost level`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', item: 'metronome', moves: ['solarbeam']},
+		], [
+			{species: 'cleffa', evs: {hp: 252, spe: 252}, ability: 'shellarmor', moves: ['sunnyday', 'softboiled']},
+			{species: 'cleffa', evs: {hp: 252, spe: 252}, ability: 'cloudnine', moves: ['sleeptalk', 'softboiled']},
+		]]);
+		battle.makeChoices('auto', 'move sunnyday');
+		const cleffa = battle.p2.active[0];
+		let damage = cleffa.maxhp - cleffa.hp;
+		assert.bounded(damage, [49, 58], `Solar Beam should not be Metronome boosted`);
+
+		battle.makeChoices('auto', 'switch 2');
+		battle.makeChoices('auto', 'move softboiled');
+		const newCleffa = battle.p2.active[0];
+		damage = newCleffa.maxhp - newCleffa.hp;
+		assert.bounded(damage, [59, 70], `Solar Beam should be Metronome 1 boosted`);
 	});
 
 	it.skip(`should use called moves to determine the Metronome multiplier`, function () {


### PR DESCRIPTION
Should fix https://github.com/smogon/pokemon-showdown/projects/3#card-61614782

Also adds a test for the case of a two-turn move that bypasses its charge turn and fixes the original broken test that was here.