### PR TITLE
Chat: Support accessing the chat-plugin database

### DIFF
--- a/databases/schemas/chat-plugins.sql
+++ b/databases/schemas/chat-plugins.sql
@@ -1,0 +1,11 @@
+-- Database schema for chat plugins
+
+-- As per the design outlined at https://gist.github.com/AnnikaCodes/afa36fc8b17791be812eebbb22182426,
+-- each table should be prefixed by the plugin name.
+
+CREATE TABLE db_info (
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+	PRIMARY KEY (key)
+);
+INSERT INTO db_info VALUES ('version', '1');

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1687,7 +1687,7 @@ export const Chat = new class {
 	 * SQL handler
 	 *
 	 * All chat plugins share one database.
-	 * Chat.database will be null if the database is not yet ready.
+	 * Chat.databaseReadyPromise will be truthy if the database is not yet ready.
 	 */
 	database: SQLDatabaseManager | null = null;
 	databaseReadyPromise: Promise<void> | null = null;

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1415,7 +1415,7 @@ export const Chat = new class {
 		void this.loadTranslations().then(() => {
 			Chat.translationsLoaded = true;
 		});
-		if (Config.usesqlite) void this.prepareDatabase();
+		void this.prepareDatabase();
 	}
 	translationsLoaded = false;
 	/**
@@ -1684,7 +1684,7 @@ export const Chat = new class {
 	 * SQL handler
 	 *
 	 * All chat plugins share one database.
-	 * Chat.database will be null if SQLite was disabled at the last chat hotpatch or the database is not yet ready.
+	 * Chat.database will be null if the database is not yet ready.
 	 */
 	database: DatabaseWrapper | null = null;
 
@@ -1705,7 +1705,7 @@ export const Chat = new class {
 		// automatically run migrations of the form "v{number}.sql" in the migrations/chat-plugins folder
 		const migrationsToRun = [];
 		for (const migrationFile of (await FS('./databases/migrations/chat-plugins').readdir())) {
-			const migrationVersion = parseInt(/v(\d+)\.sql/.exec(migrationFile)?.[1] || '');
+			const migrationVersion = parseInt(/v(\d+)\.sql$/.exec(migrationFile)?.[1] || '');
 			if (!migrationVersion) continue;
 			if (migrationVersion > curVersion) migrationsToRun.push({version: migrationVersion, file: migrationFile});
 		}

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -24,9 +24,10 @@ To reload chat commands:
 */
 
 import type {RoomPermission, GlobalPermission} from './user-groups';
-import {FriendsDatabase, PM} from './friends';
 import type {Punishment} from './punishments';
 import type {PartialModlogEntry} from './modlog';
+import {FriendsDatabase, PM} from './friends';
+import {DatabaseWrapper, SQL} from '../lib/sql';
 
 export type PageHandler = (this: PageContext, query: string[], user: User, connection: Connection)
 => Promise<string | null | void> | string | null | void;
@@ -1414,6 +1415,7 @@ export const Chat = new class {
 		void this.loadTranslations().then(() => {
 			Chat.translationsLoaded = true;
 		});
+		if (Config.usesqlite) void this.prepareDatabase();
 	}
 	translationsLoaded = false;
 	/**
@@ -1676,6 +1678,43 @@ export const Chat = new class {
 			translated = reconstructed;
 		}
 		return translated;
+	}
+
+	/**
+	 * SQL handler
+	 *
+	 * All chat plugins share one database.
+	 * Chat.database will be null if SQLite was disabled at the last chat hotpatch or the database is not yet ready.
+	 */
+	database: DatabaseWrapper | null = null;
+
+	async prepareDatabase() {
+		const database = SQL('./databases/chat-plugins.db');
+		// check if we have the db_info table, which will always be present unless the schema needs to be initialized
+		const {hasDBInfo} = await database.get(await database.prepare(
+			`SELECT count(*) AS hasDBInfo FROM sqlite_master WHERE type = 'table' AND name = 'db_info'`
+		));
+		if (!hasDBInfo) await database.runFile('./databases/schemas/chat-plugins.sql');
+
+		const result = await database.get(await database.prepare(
+			`SELECT value as curVersion FROM db_info WHERE key = 'version'`
+		));
+		const curVersion = parseInt(result.curVersion);
+		if (!curVersion) throw new Error(`db_info table is present, but schema version could not be parsed`);
+
+		// automatically run migrations of the form "v{number}.sql" in the migrations/chat-plugins folder
+		const migrationsToRun = [];
+		for (const migrationFile of (await FS('./databases/migrations/chat-plugins').readdir())) {
+			const migrationVersion = parseInt(/v(\d+)\.sql/.exec(migrationFile)?.[1] || '');
+			if (!migrationVersion) continue;
+			if (migrationVersion > curVersion) migrationsToRun.push({version: migrationVersion, file: migrationFile});
+		}
+		Utils.sortBy(migrationsToRun, ({version}) => version);
+		for (const {file} of migrationsToRun) {
+			await database.runFile(file);
+		}
+		Chat.database = database;
+		Chat.destroyHandlers.push(() => Chat.database?.destroy());
 	}
 
 	readonly MessageContext = MessageContext;


### PR DESCRIPTION
As described in [the design proposal](https://gist.github.com/AnnikaCodes/afa36fc8b17791be812eebbb22182426), all chat plugins will share one SQL database.  Since I think it's overkill to spawn a process for every chat plugin (Trivia only needs to use the database during official games and when questions are edited), it makes sense to have one access wrapper in Chat. I want to convert Trivia to SQLite soon and this needs to happen first.