### PR TITLE
SQL: Automatically prepare statements unless told otherwise

### DIFF
--- a/lib/sql.ts
+++ b/lib/sql.ts
@@ -178,7 +178,7 @@ export class SQLDatabaseManager extends QueryProcessManager<DatabaseQuery, any> 
 		const statement = query.noPrepare ?
 			this.state.statements.get(query.statement) :
 			this.cacheStatement(query.statement);
-		if (!statement) throw new Error(`Missing cached statement ${query.statement} where required`);
+		if (!statement) throw new Error(`Missing cached statement "${query.statement}" where required`);
 		return statement;
 	}
 	setupDatabase() {

--- a/lib/sql.ts
+++ b/lib/sql.ts
@@ -7,7 +7,6 @@ import type * as sqlite from 'better-sqlite3';
 import {FS} from './fs';
 
 export const DB_NOT_FOUND = null;
-export const STATEMENT_NOT_FOUND = false;
 
 export interface SQLOptions {
 	file: string;
@@ -28,17 +27,17 @@ type DatabaseQuery = {
 	/** Prepare a statement - data is the statement. */
 	type: 'prepare', data: string,
 } | {
-	/** Get all lines from a statement. Data is the params, num is the statement number. */
-	type: 'all', data: DataType, statement: string,
+	/** Get all lines from a statement. Data is the params. */
+	type: 'all', data: DataType, statement: string, noPrepare?: boolean,
 } | {
 	/** Execute raw SQL in the database. */
 	type: "exec", data: string,
 } | {
 	/** Get one line from a prepared statement. */
-	type: 'get', data: DataType, statement: string,
+	type: 'get', data: DataType, statement: string, noPrepare?: boolean,
 } | {
 	/** Run a prepared statement. */
-	type: 'run', data: DataType, statement: string,
+	type: 'run', data: DataType, statement: string, noPrepare?: boolean,
 } | {
 	type: 'transaction', name: string, data: DataType,
 } | {
@@ -123,25 +122,19 @@ export class SQLDatabaseManager extends QueryProcessManager<DatabaseQuery, any> 
 					if (!this.database) {
 						return null;
 					}
-					const statement = this.state.statements.get(query.statement);
-					if (!statement) return STATEMENT_NOT_FOUND;
-					return statement.get(query.data);
+					return this.extractStatement(query).get(query.data);
 				}
 				case 'run': {
 					if (!this.database) {
 						return null;
 					}
-					const statement = this.state.statements.get(query.statement);
-					if (!statement) return STATEMENT_NOT_FOUND;
-					return statement.run(query.data);
+					return this.extractStatement(query).run(query.data);
 				}
 				case 'all': {
 					if (!this.database) {
 						return null;
 					}
-					const statement = this.state.statements.get(query.statement);
-					if (!statement) return STATEMENT_NOT_FOUND;
-					return statement.all(query.data);
+					return this.extractStatement(query).all(query.data);
 				}
 				case 'prepare':
 					if (!this.database) {
@@ -168,6 +161,25 @@ export class SQLDatabaseManager extends QueryProcessManager<DatabaseQuery, any> 
 			statements: new Map(),
 		};
 		if (!this.isParentProcess) this.setupDatabase();
+	}
+	private cacheStatement(source: string) {
+		source = source.trim();
+		let statement = this.state.statements.get(source);
+		if (!statement) {
+			statement = this.database!.prepare(source);
+			this.state.statements.set(source, statement);
+		}
+		return statement;
+	}
+	private extractStatement(
+		query: DatabaseQuery & {statement: string, noPrepare?: boolean}
+	) {
+		query.statement = query.statement.trim();
+		const statement = query.noPrepare ?
+			this.state.statements.get(query.statement) :
+			this.cacheStatement(query.statement);
+		if (!statement) throw new Error(`Missing cached statement ${query.statement} where required`);
+		return statement;
 	}
 	setupDatabase() {
 		if (this.dbReady) return;
@@ -208,17 +220,23 @@ export class SQLDatabaseManager extends QueryProcessManager<DatabaseQuery, any> 
 			onDatabaseStart(this.database);
 		}
 	}
-	all<T = any>(statement: string | Statement, data: DataType = []): Promise<T[]> {
+	all<T = any>(
+		statement: string | Statement, data: DataType = [], noPrepare?: boolean
+	): Promise<T[]> {
 		if (typeof statement !== 'string') statement = statement.toString();
-		return this.query({type: 'all', statement, data});
+		return this.query({type: 'all', statement, data, noPrepare});
 	}
-	get<T = any>(statement: string | Statement, data: DataType = []): Promise<T> {
+	get<T = any>(
+		statement: string | Statement, data: DataType = [], noPrepare?: boolean
+	): Promise<T> {
 		if (typeof statement !== 'string') statement = statement.toString();
-		return this.query({type: 'get', statement, data});
+		return this.query({type: 'get', statement, data, noPrepare});
 	}
-	run(statement: string | Statement, data: DataType = []): Promise<sqlite.RunResult> {
+	run(
+		statement: string | Statement, data: DataType = [], noPrepare?: boolean
+	): Promise<sqlite.RunResult> {
 		if (typeof statement !== 'string') statement = statement.toString();
-		return this.query({type: 'run', statement, data});
+		return this.query({type: 'run', statement, data, noPrepare});
 	}
 	transaction<T = any>(name: string, data: DataType = []): Promise<T> {
 		return this.query({type: 'transaction', name, data});
@@ -238,13 +256,6 @@ export class SQLDatabaseManager extends QueryProcessManager<DatabaseQuery, any> 
 	async runFile(file: string) {
 		const contents = await FS(file).read();
 		return this.query({type: 'exec', data: contents});
-	}
-	async query(data: DatabaseQuery) {
-		const result = await super.query(data);
-		if (result === STATEMENT_NOT_FOUND) {
-			throw new Error("Prepare a statement before using another database function with SQLDatabase.prepare");
-		}
-		return result;
 	}
 }
 

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -1311,7 +1311,6 @@ export const commands: Chat.ChatCommands = {
 
 		let result;
 		try {
-			await database.prepare(query);
 			// presume it's attempting to get data first
 			result = await database.all(query, []);
 		} catch (err) {

--- a/server/chat-plugins/trivia/database.ts
+++ b/server/chat-plugins/trivia/database.ts
@@ -280,10 +280,10 @@ export class TriviaSQLiteDatabase implements TriviaDatabase {
 			throw new Chat.ErrorMessage(`Can't accept Trivia question submissions because there is no SQL database open.`);
 		}
 
-		const query = await Chat.database.prepare(
-			`UPDATE trivia_questions SET is_submission = 1 WHERE question IN (${formatSQLArray(submissions)})`
+		await Chat.database.run(
+			`UPDATE trivia_questions SET is_submission = 1 WHERE question IN (${formatSQLArray(submissions)})`,
+			[submissions]
 		);
-		await query?.run(submissions);
 	}
 
 	/*****************************
@@ -333,14 +333,14 @@ export class TriviaSQLiteDatabase implements TriviaDatabase {
 			}
 			args = [limit];
 		} else {
-			query = await Chat.database.prepare(
+			query = (
 				`SELECT * FROM trivia_questions WHERE category IN (${formatSQLArray(categories)}) AND is_submission = 0 ORDER BY ${options.order === 'time' ? 'added_at DESC' : 'RANDOM()'} LIMIT ?`
 			);
 			args = [...categories, limit];
 		}
 
 		if (!query) throw new Error(`Couldn't prepare query`);
-		const rows = await query.all(args);
+		const rows = await Chat.database.all(query, args);
 		return Promise.all(rows.map((row: AnyObject) => this.rowToQuestion(row)));
 	}
 

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1696,18 +1696,14 @@ export const Chat = new class {
 		if (!PM.isParentProcess) return; // We don't need a database in a subprocess that requires Chat.
 		if (!Config.usesqlite) return;
 		// check if we have the db_info table, which will always be present unless the schema needs to be initialized
-		let statement = await this.database.prepare(
+		const {hasDBInfo} = await this.database.get(
 			`SELECT count(*) AS hasDBInfo FROM sqlite_master WHERE type = 'table' AND name = 'db_info'`
 		);
-		if (!statement) return; // I was told this is a best practice for the SQL library
-		const {hasDBInfo} = await this.database.get(statement);
 		if (!hasDBInfo) await this.database.runFile('./databases/schemas/chat-plugins.sql');
 
-		statement = await this.database.prepare(
+		const result = await this.database.get(
 			`SELECT value as curVersion FROM db_info WHERE key = 'version'`
 		);
-		if (!statement) return;
-		const result = await this.database.get(statement);
 		const curVersion = parseInt(result.curVersion);
 		if (!curVersion) throw new Error(`db_info table is present, but schema version could not be parsed`);
 

--- a/test/server/modlog.js
+++ b/test/server/modlog.js
@@ -45,16 +45,16 @@ async function lastLine(database, roomid) {
 
 	describe('Modlog#prepareSQLSearch', () => {
 		it('should respect the maxLines parameter', async () => {
-			const query = await modlog.prepareSQLSearch(['lobby'], 1337, false, {note: [], user: [], ip: [], action: [], actionTaker: []});
+			const query = modlog.prepareSQLSearch(['lobby'], 1337, false, {note: [], user: [], ip: [], action: [], actionTaker: []});
 			assert(query.queryText.endsWith('LIMIT ?'));
 			assert(query.args.includes(1337));
 
-			const noMaxLines = await modlog.prepareSQLSearch(['lobby'], 0, false, {note: [], user: [], ip: [], action: [], actionTaker: []});
+			const noMaxLines = modlog.prepareSQLSearch(['lobby'], 0, false, {note: [], user: [], ip: [], action: [], actionTaker: []});
 			assert(!noMaxLines.queryText.includes('LIMIT'));
 		});
 
 		it('should attempt to respect onlyPunishments', async () => {
-			const query = await modlog.prepareSQLSearch(['lobby'], 0, true, {note: [], user: [], ip: [], action: [], actionTaker: []});
+			const query = modlog.prepareSQLSearch(['lobby'], 0, true, {note: [], user: [], ip: [], action: [], actionTaker: []});
 			assert(query.queryText.includes('action IN ('));
 			assert(query.args.includes('WEEKLOCK'));
 		});


### PR DESCRIPTION
Mostly PRing so @AnnikaCodes can review and decide if she wants her consumers to fully use this (i left in a lot of `this.somethingQuery = await this.db.prepare(....)`.
This makes it so by default, the child process will no longer require you to call .prepare before you query the child again to use the statement. There's a new parameter, `noPrepare?`, added to all the functions (`get`, `run`, `all`) that use prepared statements. If this is passed, it will indeed require you to call `.prepare` before using it, and if it is not prepared, it will throw.
Otherwise, if this isn't passed, the child process will try to find the cached statement, and if not, prepare it and cache it.