### PR TITLE
Fix Emergency Exit not activating after recoil damage

### DIFF
--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -906,10 +906,15 @@ export class BattleActions {
 		}
 
 		if (move.recoil && move.totalDamage) {
+			const hpBeforeRecoil = pokemon.hp;
 			this.battle.damage(this.calcRecoilDamage(move.totalDamage, move), pokemon, pokemon, 'recoil');
+			if (pokemon.hp <= pokemon.maxhp / 2 && hpBeforeRecoil > pokemon.maxhp / 2) {
+				this.battle.runEvent('EmergencyExit', pokemon, pokemon);
+			}
 		}
 
 		if (move.struggleRecoil) {
+			const hpBeforeRecoil = pokemon.hp;
 			let recoilDamage;
 			if (this.dex.gen >= 5) {
 				recoilDamage = this.battle.clampIntRange(Math.round(pokemon.baseMaxhp / 4), 1);
@@ -917,6 +922,9 @@ export class BattleActions {
 				recoilDamage = this.battle.clampIntRange(this.battle.trunc(pokemon.maxhp / 4), 1);
 			}
 			this.battle.directDamage(recoilDamage, pokemon, pokemon, {id: 'strugglerecoil'} as Condition);
+			if (pokemon.hp <= pokemon.maxhp / 2 && hpBeforeRecoil > pokemon.maxhp / 2) {
+				this.battle.runEvent('EmergencyExit', pokemon, pokemon);
+			}
 		}
 
 		// smartTarget messes up targetsCopy, but smartTarget should in theory ensure that targets will never fail, anyway

--- a/test/sim/abilities/emergencyexit.js
+++ b/test/sim/abilities/emergencyexit.js
@@ -353,4 +353,28 @@ describe(`Emergency Exit`, function () {
 
 		assert.equal(battle.requestState, 'switch');
 	});
+
+	it(`should request a switchout after taking regular recoil damage`, function () {
+		battle = common.createBattle([[
+			{species: 'Golisopod', ability: 'Emergency Exit', moves: ['flareblitz']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		], [
+			{species: 'Chansey', moves: ['sleeptalk']},
+		]])
+		const eePokemon = battle.p1.active[0];
+		battle.makeChoices();
+		assert.atMost(eePokemon.hp, eePokemon.maxhp / 2);
+		assert.equal(battle.requestState, 'switch');
+	});
+
+	it(`should request a switchout after taking struggle recoil damage`, function () {
+		battle = common.createBattle([[
+			{species: 'Golisopod', ability: 'Emergency Exit', moves: ['sketch']},
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		], [
+			{species: 'Klefki', ability: 'Prankster', moves: ['craftyshield']},
+		]])
+		for (var i = 0; i < 3; i++) battle.makeChoices();
+		assert.equal(battle.requestState, 'switch');
+	});
 });

--- a/test/sim/abilities/emergencyexit.js
+++ b/test/sim/abilities/emergencyexit.js
@@ -360,7 +360,7 @@ describe(`Emergency Exit`, function () {
 			{species: 'Wynaut', moves: ['sleeptalk']},
 		], [
 			{species: 'Chansey', moves: ['sleeptalk']},
-		]])
+		]]);
 		const eePokemon = battle.p1.active[0];
 		battle.makeChoices();
 		assert.atMost(eePokemon.hp, eePokemon.maxhp / 2);
@@ -369,12 +369,13 @@ describe(`Emergency Exit`, function () {
 
 	it(`should request a switchout after taking struggle recoil damage`, function () {
 		battle = common.createBattle([[
-			{species: 'Golisopod', ability: 'Emergency Exit', moves: ['sketch']},
+			{species: 'Golisopod', item: 'Assault Vest', ability: 'Emergency Exit', moves: ['protect']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
 		], [
-			{species: 'Klefki', ability: 'Prankster', moves: ['craftyshield']},
-		]])
-		for (var i = 0; i < 3; i++) battle.makeChoices();
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		battle.makeChoices();
 		assert.equal(battle.requestState, 'switch');
 	});
 });


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-8947695

Specifically, after recoil from moves like Flare Blitz and struggle. I've added tests for both types.