### PR TITLE
Fix timing of freeze thaws

### DIFF
--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -101,8 +101,13 @@ export const Conditions: {[k: string]: ConditionData} = {
 				pokemon.setStatus('');
 			}
 		},
-		onHit(target, source, move) {
-			if (move.thawsTarget || move.type === 'Fire' && move.category !== 'Status') {
+		onAfterMoveSecondary(target, source, move) {
+			if (move.thawsTarget) {
+				target.cureStatus();
+			}
+		},
+		onDamagingHit(damage, target, source, move) {
+			if (move.type === 'Fire' && move.category !== 'Status') {
 				target.cureStatus();
 			}
 		},

--- a/data/mods/gen2/conditions.ts
+++ b/data/mods/gen2/conditions.ts
@@ -59,7 +59,7 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 			return false;
 		},
 		onModifyMove() {},
-		onHit() {},
+		onDamagingHit() {},
 		onAfterMoveSecondary(target, source, move) {
 			if ((move.secondary && move.secondary.status === 'brn') || move.statusRoll === 'brn') {
 				target.cureStatus();

--- a/data/mods/gen3/conditions.ts
+++ b/data/mods/gen3/conditions.ts
@@ -38,9 +38,9 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 	},
 	frz: {
 		inherit: true,
-		onHit(target, source, move) {
+		onDamagingHit(damage, target, source, move) {
 			// don't count Hidden Power or Weather Ball as Fire-type
-			if (move.thawsTarget || this.dex.moves.get(move.id).type === 'Fire' && move.category !== 'Status') {
+			if (this.dex.moves.get(move.id).type === 'Fire' && move.category !== 'Status') {
 				target.cureStatus();
 			}
 		},

--- a/test/sim/abilities/sheerforce.js
+++ b/test/sim/abilities/sheerforce.js
@@ -43,4 +43,30 @@ describe('Sheer Force', function () {
 		battle.makeChoices('move bodyslam', 'move rest');
 		assert.equal(battle.p1.active[0].hp, battle.p1.active[0].maxhp);
 	});
+
+	it(`should not be possible to thaw a frozen target with a Sheer Force-boosted thawsTarget move`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'sheerforce', moves: ['sleeptalk', 'scald']},
+		], [
+			{species: 'shuckle', moves: ['meteorassault']},
+		]]);
+		battle.makeChoices(); // Use Meteor Assault to force recharge next turn and skip potential thaw
+		const frozenMon = battle.p2.active[0];
+		frozenMon.setStatus('frz');
+		battle.makeChoices('move scald', 'auto');
+		assert.equal(frozenMon.status, 'frz');
+	});
+
+	it(`should be possible to thaw a frozen target with a Sheer Force-boosted Fire-type move`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'sheerforce', moves: ['sleeptalk', 'flamethrower']},
+		], [
+			{species: 'shuckle', moves: ['meteorassault']},
+		]]);
+		battle.makeChoices(); // Use Meteor Assault to force recharge next turn and skip potential thaw
+		const frozenMon = battle.p2.active[0];
+		frozenMon.setStatus('frz');
+		battle.makeChoices('move flamethrower', 'auto');
+		assert.equal(frozenMon.status, '');
+	});
 });

--- a/test/sim/misc/statuses.js
+++ b/test/sim/misc/statuses.js
@@ -192,6 +192,19 @@ describe('Freeze', function () {
 		assert.equal(battle.p1.active[0].status, 'frz');
 		assert.equal(battle.p1.active[0].species.name, 'Shaymin-Sky');
 	});
+
+	it(`should not be possible to burn a frozen target when using a move that thaws that target`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'serenegrace', item: 'widelens', moves: ['sleeptalk', 'sacredfire']},
+		], [
+			{species: 'shuckle', moves: ['meteorassault']},
+		]]);
+		battle.makeChoices(); // Use Meteor Assault to force recharge next turn and skip potential thaw
+		const frozenMon = battle.p2.active[0];
+		frozenMon.setStatus('frz');
+		battle.makeChoices('move sacredfire', 'auto');
+		assert.equal(frozenMon.status, '');
+	});
 });
 
 describe('Burn [Gen 6]', function () {


### PR DESCRIPTION
When using a move like Scald or Sacred Fire, the check for burn potential happens before the check for potentially thawing the target; that is, it is impossible to burn a frozen target after thawing it with something like Scald. Technically it should be its own event, but I think ``onDamagingHit`` works alright for this purpose in the meantime until research is completed on post-move success order.

In addition, the autothaw from Fire-type attacks and the autothaw from Scald, Steam Eruption, and Scorching Sands is at different timings. A Sheer Force-boosted Flamethrower would thaw its target, but a Sheer Force-boosted Scald would not.

I need to verify how this works in pastgens. I would not be super surprised if you _could_ burn a frozen target in Gens prior to 5.