### PR TITLE
Inheritance: Manually implement 2 Ability Clause

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -707,37 +707,38 @@ export const Formats: FormatList = [
 			return null;
 		},
 		onValidateTeam(team, f, teamHas) {
-			// 2 Ability Clause
-			const abilityTable = new Map<string, number>();
-			const base: {[k: string]: string} = {
-				airlock: 'cloudnine',
-				battlearmor: 'shellarmor',
-				clearbody: 'whitesmoke',
-				dazzling: 'queenlymajesty',
-				emergencyexit: 'wimpout',
-				filter: 'solidrock',
-				gooey: 'tanglinghair',
-				insomnia: 'vitalspirit',
-				ironbarbs: 'roughskin',
-				libero: 'protean',
-				minus: 'plus',
-				moxie: 'chillingneigh',
-				powerofalchemy: 'receiver',
-				propellertail: 'stalwart',
-				teravolt: 'moldbreaker',
-				turboblaze: 'moldbreaker',
-			};
-			for (const set of team) {
-				let ability = this.toID(set.ability.split('0')[0]);
-				if (!ability) continue;
-				if (ability in base) ability = base[ability] as ID;
-				if ((abilityTable.get(ability) || 0) >= 2) {
-					return [
-						`You are limited to two of each ability by 2 Ability Clause.`,
-						`(You have more than two ${this.dex.abilities.get(ability).name} variants)`,
-					];
+			if (this.format.ruleTable?.has('2abilityclause')) {
+				const abilityTable = new Map<string, number>();
+				const base: {[k: string]: string} = {
+					airlock: 'cloudnine',
+					battlearmor: 'shellarmor',
+					clearbody: 'whitesmoke',
+					dazzling: 'queenlymajesty',
+					emergencyexit: 'wimpout',
+					filter: 'solidrock',
+					gooey: 'tanglinghair',
+					insomnia: 'vitalspirit',
+					ironbarbs: 'roughskin',
+					libero: 'protean',
+					minus: 'plus',
+					moxie: 'chillingneigh',
+					powerofalchemy: 'receiver',
+					propellertail: 'stalwart',
+					teravolt: 'moldbreaker',
+					turboblaze: 'moldbreaker',
+				};
+				for (const set of team) {
+					let ability = this.toID(set.ability.split('0')[0]);
+					if (!ability) continue;
+					if (ability in base) ability = base[ability] as ID;
+					if ((abilityTable.get(ability) || 0) >= 2) {
+						return [
+							`You are limited to two of each ability by 2 Ability Clause.`,
+							`(You have more than two ${this.dex.abilities.get(ability).name} variants)`,
+						];
+					}
+					abilityTable.set(ability, (abilityTable.get(ability) || 0) + 1);
 				}
-				abilityTable.set(ability, (abilityTable.get(ability) || 0) + 1);
 			}
 
 			// Donor Clause

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -707,6 +707,39 @@ export const Formats: FormatList = [
 			return null;
 		},
 		onValidateTeam(team, f, teamHas) {
+			// 2 Ability Clause
+			const abilityTable = new Map<string, number>();
+			const base: {[k: string]: string} = {
+				airlock: 'cloudnine',
+				battlearmor: 'shellarmor',
+				clearbody: 'whitesmoke',
+				dazzling: 'queenlymajesty',
+				emergencyexit: 'wimpout',
+				filter: 'solidrock',
+				gooey: 'tanglinghair',
+				insomnia: 'vitalspirit',
+				ironbarbs: 'roughskin',
+				libero: 'protean',
+				minus: 'plus',
+				moxie: 'chillingneigh',
+				powerofalchemy: 'receiver',
+				propellertail: 'stalwart',
+				teravolt: 'moldbreaker',
+				turboblaze: 'moldbreaker',
+			};
+			for (const set of team) {
+				let ability = this.toID(set.ability.split('0')[0]);
+				if (!ability) continue;
+				if (ability in base) ability = base[ability] as ID;
+				if ((abilityTable.get(ability) || 0) >= 2) {
+					return [
+						`You are limited to two of each ability by 2 Ability Clause.`,
+						`(You have more than two ${this.dex.abilities.get(ability).name} variants)`,
+					];
+				}
+				abilityTable.set(ability, (abilityTable.get(ability) || 0) + 1);
+			}
+
 			// Donor Clause
 			const evoFamilyLists = [];
 			for (const set of team) {


### PR DESCRIPTION
https://www.smogon.com/forums/threads/inheritance.3656811/post-8967769

Fixes 2 Ability Clause not working for Inheritance due to how abilities are stored prior to the battle starting. I just reimplemented the code from 2 Ability Clause into Inheritance's `onValidateTeam` function. Should I just check if the format is Inheritance in 2 Ability Clause's code and correct the bug there instead?

I also want to note that I left 2 Ability Clause in `rulesets` for the message it sends in `onBegin`.