### PR TITLE
Gen 1: Implement Stadium Tiers

### DIFF
--- a/data/mods/gen1stadium/formats-data.ts
+++ b/data/mods/gen1stadium/formats-data.ts
@@ -36,11 +36,9 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "UU",
 	},
 	weedle: {
-		randomBattleMoves: ["poisonsting", "stringshot"],
 		tier: "LC",
 	},
 	kakuna: {
-		randomBattleMoves: ["poisonsting", "stringshot"],
 		tier: "NFE",
 	},
 	beedrill: {

--- a/data/mods/gen1stadium/formats-data.ts
+++ b/data/mods/gen1stadium/formats-data.ts
@@ -1,0 +1,461 @@
+export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+	bulbasaur: {
+		tier: "LC",
+	},
+	ivysaur: {
+		tier: "NFE",
+	},
+	venusaur: {
+		tier: "UU",
+	},
+	charmander: {
+		tier: "LC",
+	},
+	charmeleon: {
+		tier: "NFE",
+	},
+	charizard: {
+		tier: "UU",
+	},
+	squirtle: {
+		tier: "LC",
+	},
+	wartortle: {
+		tier: "NFE",
+	},
+	blastoise: {
+		tier: "UU",
+	},
+	caterpie: {
+		tier: "LC",
+	},
+	metapod: {
+		tier: "NFE",
+	},
+	butterfree: {
+		tier: "UU",
+	},
+	weedle: {
+		randomBattleMoves: ["poisonsting", "stringshot"],
+		tier: "LC",
+	},
+	kakuna: {
+		randomBattleMoves: ["poisonsting", "stringshot"],
+		tier: "NFE",
+	},
+	beedrill: {
+		tier: "UU",
+	},
+	pidgey: {
+		tier: "LC",
+	},
+	pidgeotto: {
+		tier: "NFE",
+	},
+	pidgeot: {
+		tier: "UU",
+	},
+	rattata: {
+		tier: "LC",
+	},
+	raticate: {
+		tier: "UU",
+	},
+	spearow: {
+		tier: "LC",
+	},
+	fearow: {
+		tier: "UU",
+	},
+	ekans: {
+		tier: "LC",
+	},
+	arbok: {
+		tier: "UU",
+	},
+	pikachu: {
+		tier: "LC",
+	},
+	raichu: {
+		tier: "UU",
+	},
+	sandshrew: {
+		tier: "LC",
+	},
+	sandslash: {
+		tier: "UU",
+	},
+	nidoranf: {
+		tier: "LC",
+	},
+	nidorina: {
+		tier: "NFE",
+	},
+	nidoqueen: {
+		tier: "UU",
+	},
+	nidoranm: {
+		tier: "LC",
+	},
+	nidorino: {
+		tier: "NFE",
+	},
+	nidoking: {
+		tier: "UU",
+	},
+	clefairy: {
+		tier: "NFE",
+	},
+	clefable: {
+		tier: "UU",
+	},
+	vulpix: {
+		tier: "LC",
+	},
+	ninetales: {
+		tier: "UU",
+	},
+	jigglypuff: {
+		tier: "LC",
+	},
+	wigglytuff: {
+		tier: "UU",
+	},
+	zubat: {
+		tier: "LC",
+	},
+	golbat: {
+		tier: "UU",
+	},
+	oddish: {
+		tier: "LC",
+	},
+	gloom: {
+		tier: "NFE",
+	},
+	vileplume: {
+		tier: "UU",
+	},
+	paras: {
+		tier: "LC",
+	},
+	parasect: {
+		tier: "UU",
+	},
+	venonat: {
+		tier: "LC",
+	},
+	venomoth: {
+		tier: "UU",
+	},
+	diglett: {
+		tier: "LC",
+	},
+	dugtrio: {
+		tier: "UU",
+	},
+	meowth: {
+		tier: "LC",
+	},
+	persian: {
+		tier: "OU",
+	},
+	psyduck: {
+		tier: "LC",
+	},
+	golduck: {
+		tier: "UU",
+	},
+	mankey: {
+		tier: "LC",
+	},
+	primeape: {
+		tier: "UU",
+	},
+	growlithe: {
+		tier: "LC",
+	},
+	arcanine: {
+		tier: "UU",
+	},
+	poliwag: {
+		tier: "LC",
+	},
+	poliwhirl: {
+		tier: "NFE",
+	},
+	poliwrath: {
+		tier: "OU",
+	},
+	abra: {
+		tier: "LC",
+	},
+	kadabra: {
+		tier: "UU",
+	},
+	alakazam: {
+		tier: "OU",
+	},
+	machop: {
+		tier: "LC",
+	},
+	machoke: {
+		tier: "NFE",
+	},
+	machamp: {
+		tier: "UU",
+	},
+	bellsprout: {
+		tier: "LC",
+	},
+	weepinbell: {
+		tier: "NFE",
+	},
+	victreebel: {
+		tier: "UU",
+	},
+	tentacool: {
+		tier: "LC",
+	},
+	tentacruel: {
+		tier: "UU",
+	},
+	geodude: {
+		tier: "LC",
+	},
+	graveler: {
+		tier: "NFE",
+	},
+	golem: {
+		tier: "OU",
+	},
+	ponyta: {
+		tier: "LC",
+	},
+	rapidash: {
+		tier: "UU",
+	},
+	slowpoke: {
+		tier: "LC",
+	},
+	slowbro: {
+		tier: "OU",
+	},
+	magnemite: {
+		tier: "LC",
+	},
+	magneton: {
+		tier: "UU",
+	},
+	farfetchd: {
+		tier: "UU",
+	},
+	doduo: {
+		tier: "LC",
+	},
+	dodrio: {
+		tier: "UU",
+	},
+	seel: {
+		tier: "LC",
+	},
+	dewgong: {
+		tier: "UU",
+	},
+	grimer: {
+		tier: "LC",
+	},
+	muk: {
+		tier: "UU",
+	},
+	shellder: {
+		tier: "LC",
+	},
+	cloyster: {
+		tier: "OU",
+	},
+	gastly: {
+		tier: "LC",
+	},
+	haunter: {
+		tier: "UU",
+	},
+	gengar: {
+		tier: "OU",
+	},
+	onix: {
+		tier: "UU",
+	},
+	drowzee: {
+		tier: "LC",
+	},
+	hypno: {
+		tier: "UU",
+	},
+	krabby: {
+		tier: "LC",
+	},
+	kingler: {
+		tier: "UU",
+	},
+	voltorb: {
+		tier: "LC",
+	},
+	electrode: {
+		tier: "UU",
+	},
+	exeggcute: {
+		tier: "LC",
+	},
+	exeggutor: {
+		tier: "OU",
+	},
+	cubone: {
+		tier: "LC",
+	},
+	marowak: {
+		tier: "UU",
+	},
+	hitmonlee: {
+		tier: "UU",
+	},
+	hitmonchan: {
+		tier: "UU",
+	},
+	lickitung: {
+		tier: "UU",
+	},
+	koffing: {
+		tier: "LC",
+	},
+	weezing: {
+		tier: "UU",
+	},
+	rhyhorn: {
+		tier: "LC",
+	},
+	rhydon: {
+		tier: "OU",
+	},
+	chansey: {
+		tier: "OU",
+	},
+	tangela: {
+		tier: "UU",
+	},
+	kangaskhan: {
+		tier: "OU",
+	},
+	horsea: {
+		tier: "LC",
+	},
+	seadra: {
+		tier: "UU",
+	},
+	goldeen: {
+		tier: "LC",
+	},
+	seaking: {
+		tier: "UU",
+	},
+	staryu: {
+		tier: "LC",
+	},
+	starmie: {
+		tier: "OU",
+	},
+	mrmime: {
+		tier: "UU",
+	},
+	scyther: {
+		tier: "UU",
+	},
+	jynx: {
+		tier: "OU",
+	},
+	electabuzz: {
+		tier: "UU",
+	},
+	magmar: {
+		tier: "UU",
+	},
+	pinsir: {
+		tier: "UU",
+	},
+	tauros: {
+		tier: "OU",
+	},
+	magikarp: {
+		tier: "LC",
+	},
+	gyarados: {
+		tier: "UU",
+	},
+	lapras: {
+		tier: "OU",
+	},
+	ditto: {
+		tier: "UU",
+	},
+	eevee: {
+		tier: "LC",
+	},
+	vaporeon: {
+		tier: "UU",
+	},
+	jolteon: {
+		tier: "OU",
+	},
+	flareon: {
+		tier: "UU",
+	},
+	porygon: {
+		tier: "UU",
+	},
+	omanyte: {
+		tier: "LC",
+	},
+	omastar: {
+		tier: "UU",
+	},
+	kabuto: {
+		tier: "LC",
+	},
+	kabutops: {
+		tier: "UU",
+	},
+	aerodactyl: {
+		tier: "UU",
+	},
+	snorlax: {
+		tier: "OU",
+	},
+	articuno: {
+		tier: "UU",
+	},
+	zapdos: {
+		tier: "OU",
+	},
+	moltres: {
+		tier: "UU",
+	},
+	dratini: {
+		tier: "LC",
+	},
+	dragonair: {
+		tier: "NFE",
+	},
+	dragonite: {
+		tier: "UU",
+	},
+	mewtwo: {
+		tier: "Uber",
+	},
+	mew: {
+		tier: "Uber",
+	},
+	missingno: {
+		isNonstandard: "Unobtainable",
+		tier: "Illegal",
+	},
+};


### PR DESCRIPTION
Talked to @KrisXV who said I just submit this tier file and he does the rest. This is based on the [2021 Stadium OU VR](https://www.smogon.com/forums/threads/stadium-ou-poster-viability-rankings-2021.3685877/), using Lutra's proposed cutoff between D4 and E rank. This aims to clean up the teambuilder a mite bit while being somewhat consistent with LGPE OU's stuff.