### PR TITLE
Trim commands in /help

### DIFF
--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -1773,7 +1773,7 @@ export const commands: Chat.ChatCommands = {
 	man: 'help',
 	help(target, room, user) {
 		if (!this.runBroadcast()) return;
-		target = target.toLowerCase();
+		target = target.toLowerCase().trim();
 		if (target.startsWith('/') || target.startsWith('!')) target = target.slice(1);
 
 		if (!target) {


### PR DESCRIPTION
```
[09:45:39] @PartMan: !h status
Could not find help for '/status ' - displaying help for '/status' instead
/status [note] - Sets a short note as your status, visible when users click your username.
Use /clearstatus to clear your status message.
```