### PR TITLE
Gen 1 Tradebacks OU: Ban Dig/Fly

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2032,7 +2032,6 @@ export const Formats: FormatList = [
 		mod: 'gen1',
 		// searchShow: false,
 		ruleset: ['[Gen 1] OU', 'Allow Tradeback'],
-		banlist: ['Uber'],
 	},
 
 	// Past Gens OU

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2031,7 +2031,7 @@ export const Formats: FormatList = [
 
 		mod: 'gen1',
 		// searchShow: false,
-		ruleset: ['Obtainable', 'Allow Tradeback', 'Sleep Clause Mod', 'Freeze Clause Mod', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause', 'HP Percentage Mod', 'Cancel Mod', 'Desync Clause Mod'],
+		ruleset: ['[Gen 1] OU', 'Allow Tradeback'],
 		banlist: ['Uber'],
 	},
 


### PR DESCRIPTION
@KrisXV told me to make a Pull Request for this. For some reason, the Tradebacks OU challenge option never banned Dig/Fly due to using an archaic ruleset list. Because of this, some _naughty_ people have been using stuff like Fly Articuno on the ladder! I've changed it to use Gen 1 OU + Allow Tradeback, which should fix the problem and prevent more cropping up in the future. Besides, that's kinda what it's meant to be, y'know?