### PR TITLE
Random Battles updates

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -2996,7 +2996,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		tier: "LC",
 	},
 	lucario: {
-		randomBattleMoves: ["closecombat", "extremespeed", "icepunch", "meteormash", "swordsdance"],
+		randomBattleMoves: ["closecombat", "extremespeed", "meteormash", "stoneedge", "swordsdance"],
 		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["closecombat", "darkpulse", "extremespeed", "icepunch", "meteormash", "protect", "swordsdance"],
 		randomDoubleBattleLevel: 84,
@@ -5057,7 +5057,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "(DUU)",
 	},
 	silvallyfairy: {
-		randomBattleMoves: ["firefang", "multiattack", "psychicfangs", "swordsdance"],
+		randomBattleMoves: ["flamecharge", "multiattack", "psychicfangs", "swordsdance"],
 		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["flamethrower", "multiattack", "partingshot", "tailwind"],
 		randomDoubleBattleLevel: 88,
@@ -5439,7 +5439,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "(DUU)",
 	},
 	zeraora: {
-		randomBattleMoves: ["bulkup", "closecombat", "firepunch", "grassknot", "knockoff", "plasmafists", "playrough", "voltswitch"],
+		randomBattleMoves: ["blazekick", "bulkup", "closecombat", "grassknot", "knockoff", "plasmafists", "playrough", "voltswitch"],
 		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["closecombat", "fakeout", "grassknot", "knockoff", "plasmafists", "playrough", "snarl"],
 		randomDoubleBattleLevel: 78,
@@ -5471,7 +5471,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 	},
 	rillaboom: {
 		randomBattleMoves: ["grassyglide", "highhorsepower", "knockoff", "uturn", "woodhammer"],
-		randomBattleLevel: 77,
+		randomBattleLevel: 78,
 		randomDoubleBattleMoves: ["fakeout", "grassyglide", "highhorsepower", "protect", "uturn", "woodhammer"],
 		randomDoubleBattleLevel: 80,
 		tier: "OU",
@@ -5592,7 +5592,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		tier: "LC",
 	},
 	eldegoss: {
-		randomBattleMoves: ["charm", "energyball", "leechseed", "pollenpuff", "rapidspin", "sleeppowder"],
+		randomBattleMoves: ["energyball", "leechseed", "pollenpuff", "rapidspin", "sleeppowder"],
 		randomBattleLevel: 90,
 		randomDoubleBattleMoves: ["charm", "energyball", "helpinghand", "pollenpuff", "protect", "sleeppowder"],
 		randomDoubleBattleLevel: 90,

--- a/data/mods/gen7/formats-data.ts
+++ b/data/mods/gen7/formats-data.ts
@@ -336,7 +336,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	dugtrio: {
-		randomBattleMoves: ["earthquake", "memento", "reversal", "stealthrock", "stoneedge", "substitute", "suckerpunch"],
+		randomBattleMoves: ["earthquake", "reversal", "stealthrock", "stoneedge", "substitute", "suckerpunch"],
 		randomDoubleBattleMoves: ["earthquake", "protect", "rockslide", "stoneedge", "suckerpunch"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -378,7 +378,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	primeape: {
-		randomBattleMoves: ["closecombat", "earthquake", "encore", "gunkshot", "icepunch", "stoneedge", "uturn"],
+		randomBattleMoves: ["closecombat", "earthquake", "gunkshot", "icepunch", "stoneedge", "uturn"],
 		randomDoubleBattleMoves: ["closecombat", "icepunch", "poisonjab", "protect", "rockslide", "stompingtantrum", "stoneedge", "taunt", "uturn"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -684,7 +684,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		doublesTier: "(DUU)",
 	},
 	hitmonchan: {
-		randomBattleMoves: ["bulkup", "drainpunch", "firepunch", "icepunch", "machpunch", "rapidspin"],
+		randomBattleMoves: ["bulkup", "drainpunch", "icepunch", "machpunch", "rapidspin", "stoneedge"],
 		randomDoubleBattleMoves: ["drainpunch", "fakeout", "firepunch", "icepunch", "machpunch", "protect"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -2705,7 +2705,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		doublesTier: "DUber",
 	},
 	palkia: {
-		randomBattleMoves: ["dracometeor", "dragontail", "fireblast", "hydropump", "spacialrend", "thunderwave"],
+		randomBattleMoves: ["dracometeor", "fireblast", "hydropump", "spacialrend", "thunderwave"],
 		randomDoubleBattleMoves: ["dracometeor", "fireblast", "hydropump", "protect", "spacialrend", "thunderbolt"],
 		tier: "Uber",
 		doublesTier: "DUber",
@@ -3499,7 +3499,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	cobalion: {
-		randomBattleMoves: ["closecombat", "hiddenpowerice", "ironhead", "stealthrock", "stoneedge", "swordsdance", "taunt", "voltswitch"],
+		randomBattleMoves: ["closecombat", "hiddenpowerice", "ironhead", "stealthrock", "stoneedge", "swordsdance", "voltswitch"],
 		randomDoubleBattleMoves: ["closecombat", "ironhead", "protect", "stoneedge", "swordsdance", "thunderwave"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -4513,7 +4513,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	tapulele: {
-		randomBattleMoves: ["calmmind", "focusblast", "hiddenpowerfire", "moonblast", "psychic", "psyshock", "taunt"],
+		randomBattleMoves: ["calmmind", "focusblast", "hiddenpowerfire", "moonblast", "psychic", "psyshock"],
 		randomDoubleBattleMoves: ["dazzlinggleam", "focusblast", "moonblast", "protect", "psychic", "taunt"],
 		tier: "OU",
 		doublesTier: "DOU",

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -9,7 +9,10 @@ export class RandomGen7Teams extends RandomTeams {
 
 		this.moveEnforcementCheckers = {
 			Bug: movePool => movePool.includes('megahorn') || movePool.includes('pinmissile'),
-			Dark: (movePool, moves, abilities, types, counter) => !counter.get('Dark') && !abilities.has('Protean'),
+			Dark: (movePool, moves, abilities, types, counter, species) => (
+				(!counter.get('Dark') && !abilities.has('Protean')) ||
+				(moves.has('pursuit') && species.types.length > 1 && counter.get('Dark') === 1)
+			),
 			Dragon: (movePool, moves, abilities, types, counter) => (
 				!counter.get('Dragon') &&
 				!abilities.has('Aerilate') && !abilities.has('Pixilate') &&
@@ -21,10 +24,11 @@ export class RandomGen7Teams extends RandomTeams {
 			),
 			Fighting: (movePool, moves, abilities, types, counter) => !counter.get('Fighting') || !counter.get('stab'),
 			Fire: (movePool, moves, abilities, types, counter) => (
-				!counter.get('Fire') || movePool.includes('flareblitz') || movePool.includes('quiverdance')
+				!counter.get('Fire') || ['eruption', 'flareblitz', 'quiverdance'].some(m => movePool.includes(m))
 			),
-			Flying: (movePool, moves, abilities, types, counter) => (
+			Flying: (movePool, moves, abilities, types, counter, species) => (
 				!counter.get('Flying') && (
+					species.id === 'rotomfan' ||
 					abilities.has('Gale Wings') ||
 					abilities.has('Serene Grace') || (
 						types.has('Normal') && (movePool.includes('beakblast') || movePool.includes('bravebird'))
@@ -72,7 +76,8 @@ export class RandomGen7Teams extends RandomTeams {
 			Water: (movePool, moves, abilities, types, counter, species) => (
 				(!counter.get('Water') && !abilities.has('Protean')) ||
 				!counter.get('stab') ||
-				movePool.includes('crabhammer')
+				movePool.includes('crabhammer') ||
+				(abilities.has('Huge Power') && movePool.includes('aquajet'))
 			),
 			Adaptability: (movePool, moves, abilities, types, counter, species) => (
 				!counter.setupType &&
@@ -1379,6 +1384,9 @@ export class RandomGen7Teams extends RandomTeams {
 			evs.atk = 0;
 			ivs.atk = 0;
 		}
+
+		// Ensure Nihilego's Beast Boost gives it Special Attack boosts instead of Special Defense
+		if (forme === 'Nihilego') evs.spd -= 32;
 
 		if (ability === 'Beast Boost' && counter.get('Special') < 1) {
 			evs.spa = 0;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -943,7 +943,8 @@ export class RandomTeams {
 			return {cull: (
 				!!counter.get('speedsetup') ||
 				(counter.setupType && !bugSwordsDanceCase) ||
-				(isDoubles && moves.has('leechlife'))
+				(isDoubles && moves.has('leechlife')) ||
+				moves.has('shiftgear')
 			)};
 
 		/**
@@ -1111,7 +1112,8 @@ export class RandomTeams {
 			const gutsCullCondition = abilities.has('Guts') && (!moves.has('dynamicpunch') || moves.has('spikes'));
 			const rockSlidePlusStatusPossible = counter.get('Status') && movePool.includes('rockslide');
 			const otherRockMove = moves.has('rockblast') || moves.has('rockslide');
-			return {cull: gutsCullCondition || (!isDoubles && rockSlidePlusStatusPossible) || otherRockMove};
+			const lucarioCull = species.id === 'lucario' && !!counter.setupType;
+			return {cull: gutsCullCondition || (!isDoubles && rockSlidePlusStatusPossible) || otherRockMove || lucarioCull};
 		case 'poltergeist':
 			// Special case for Dhelmise in Doubles, which doesn't want both
 			return {cull: moves.has('knockoff')};
@@ -1191,8 +1193,8 @@ export class RandomTeams {
 			// Special case for Raichu and Heliolisk
 			return {cull: moves.has('surf')};
 		case 'icepunch':
-			// Special cases for Marshadow and Lucario, respectively
-			return {cull: moves.has('rocktomb') || (species.id === 'lucario' && !!counter.setupType)};
+			// Special case for Marshadow
+			return {cull: moves.has('rocktomb')};
 		case 'leechseed':
 			// Special case for Calyrex to prevent Leech Seed + Calm Mind
 			return {cull: !!counter.setupType};
@@ -1442,6 +1444,7 @@ export class RandomTeams {
 		if (species.name === 'Pincurchin') return 'Shuca Berry';
 		if (species.name === 'Wobbuffet' && moves.has('destinybond')) return 'Custap Berry';
 		if (species.name === 'Scyther' && counter.damagingMoves.size > 3) return 'Choice Band';
+		if (species.name === 'Cinccino' && !moves.has('uturn')) return 'Life Orb';
 		if (moves.has('bellydrum') && moves.has('substitute')) return 'Salac Berry';
 
 		// Misc item generation logic
@@ -1553,8 +1556,7 @@ export class RandomTeams {
 		// Choice items
 		if (
 			!isDoubles && counter.get('Physical') >= 4 && ability !== 'Serene Grace' &&
-			['fakeout', 'flamecharge', 'rapidspin'].every(m => !moves.has(m)) &&
-			(!moves.has('tailslap') || moves.has('uturn'))
+			['fakeout', 'flamecharge', 'rapidspin'].every(m => !moves.has(m))
 		) {
 			const scarfReqs = (
 				(species.baseStats.atk >= 100 || ability === 'Huge Power') &&
@@ -1630,7 +1632,8 @@ export class RandomTeams {
 		if (
 			isLead && !isDoubles &&
 			!['Disguise', 'Sturdy'].includes(ability) && !moves.has('substitute') &&
-			!counter.get('drain') && !counter.get('recoil') && !counter.get('recovery') && defensiveStatTotal < 255
+			!counter.get('drain') && !counter.get('recoil') && !counter.get('recovery') &&
+			((defensiveStatTotal <= 250 && counter.get('hazards')) || defensiveStatTotal <= 210)
 		) return 'Focus Sash';
 		if (!isDoubles && ability === 'Water Bubble') return 'Mystic Water';
 		if (

--- a/test/random-battles/gen7.js
+++ b/test/random-battles/gen7.js
@@ -26,22 +26,22 @@ describe('[Gen 7] Random Battle', () => {
 	});
 
 	it('should not generate Pursuit as the only Dark STAB move', () => {
-    	const dex = Dex.forFormat(options.format);
+		const dex = Dex.forFormat(options.format);
 		const darkTypesWithPursuit = dex.species
-        	.all()
-        	.filter(pkmn => pkmn.types.includes('Dark') && pkmn.randomBattleMoves.includes('pursuit'))
-        	.map(pkmn => pkmn.id);
-    	for (const pokemon of darkTypesWithPursuit) {
-        	testSet(pokemon, options, set => {
-            	if (!set.moves.includes('pursuit')) return;
-            	const darkStab = set.moves.filter(m => {
-                	const move = dex.moves.get(m);
-                	if (move.type !== 'Dark') return false;
-                	return move.category !== 'Status';
-            	});
-            	assert(darkStab.length > 1, `${pokemon}: got ${set.moves}`);
-        	});
-    	}
+			.all()
+			.filter(pkmn => pkmn.types.includes('Dark') && pkmn.randomBattleMoves.includes('pursuit'))
+			.map(pkmn => pkmn.id);
+		for (const pokemon of darkTypesWithPursuit) {
+			testSet(pokemon, options, set => {
+				if (!set.moves.includes('pursuit')) return;
+				const darkStab = set.moves.filter(m => {
+					const move = dex.moves.get(m);
+					if (move.type !== 'Dark') return false;
+					return move.category !== 'Status';
+				});
+				assert(darkStab.length > 1, `${pokemon}: got ${set.moves}`);
+			});
+		}
 	});
 
 	it('should not generate Roar + Protect', () => {

--- a/test/random-battles/gen7.js
+++ b/test/random-battles/gen7.js
@@ -13,6 +13,62 @@ describe('[Gen 7] Random Battle', () => {
 		testNotBothMoves('chimecho', options, 'calmmind', 'yawn');
 	});
 
+	it('should give Azumarill Aqua Jet', () => {
+		testSet('azumarill', options, set => {
+			assert(set.moves.includes('aquajet'), `Azumarill: got ${set.moves}`);
+		});
+	});
+
+	it('should give Typhlosion Eruption', () => {
+		testSet('typhlosion', options, set => {
+			assert(set.moves.includes('eruption'), `Typhlosion: got ${set.moves}`);
+		});
+	});
+
+	it('should not generate Pursuit as the only Dark STAB move', () => {
+		testSet('weavile', options, set => {
+			if (set.moves.includes('pursuit')) {
+				assert(set.moves.includes('knockoff'), `Weavile: got ${set.moves}`);
+			}
+		});
+
+		testSet('mukalola', options, set => {
+			if (set.moves.includes('pursuit')) {
+				assert(set.moves.includes('knockoff'), `Muk-Alola: got ${set.moves}`);
+			}
+		});
+
+		testSet('honchkrow', options, set => {
+			if (set.moves.includes('pursuit')) {
+				assert(set.moves.includes('suckerpunch'), `Honchkrow: got ${set.moves}`);
+			}
+		});
+
+		testSet('tyranitar', options, set => {
+			if (set.moves.includes('pursuit')) {
+				assert(set.moves.includes('crunch'), `Tyranitar: got ${set.moves}`);
+			}
+		});
+
+		testSet('skuntank', options, set => {
+			if (set.moves.includes('pursuit')) {
+				assert(set.moves.includes('crunch'), `Skuntank: got ${set.moves}`);
+			}
+		});
+
+		testSet('spiritomb', options, set => {
+			if (set.moves.includes('pursuit')) {
+				assert(set.moves.includes('darkpulse'), `Spiritomb: got ${set.moves}`);
+			}
+		});
+
+		testSet('krookodile', options, set => {
+			if (set.moves.includes('pursuit')) {
+				assert(set.moves.includes('knockoff'), `Krookodile: got ${set.moves}`);
+			}
+		});
+	});
+
 	it('should not generate Roar + Protect', () => {
 		testNotBothMoves('heatran', options, 'roar', 'protect');
 		testNotBothMoves('vaporeon', options, 'roar', 'protect');

--- a/test/random-battles/gen7.js
+++ b/test/random-battles/gen7.js
@@ -26,47 +26,22 @@ describe('[Gen 7] Random Battle', () => {
 	});
 
 	it('should not generate Pursuit as the only Dark STAB move', () => {
-		testSet('weavile', options, set => {
-			if (set.moves.includes('pursuit')) {
-				assert(set.moves.includes('knockoff'), `Weavile: got ${set.moves}`);
-			}
-		});
-
-		testSet('mukalola', options, set => {
-			if (set.moves.includes('pursuit')) {
-				assert(set.moves.includes('knockoff'), `Muk-Alola: got ${set.moves}`);
-			}
-		});
-
-		testSet('honchkrow', options, set => {
-			if (set.moves.includes('pursuit')) {
-				assert(set.moves.includes('suckerpunch'), `Honchkrow: got ${set.moves}`);
-			}
-		});
-
-		testSet('tyranitar', options, set => {
-			if (set.moves.includes('pursuit')) {
-				assert(set.moves.includes('crunch'), `Tyranitar: got ${set.moves}`);
-			}
-		});
-
-		testSet('skuntank', options, set => {
-			if (set.moves.includes('pursuit')) {
-				assert(set.moves.includes('crunch'), `Skuntank: got ${set.moves}`);
-			}
-		});
-
-		testSet('spiritomb', options, set => {
-			if (set.moves.includes('pursuit')) {
-				assert(set.moves.includes('darkpulse'), `Spiritomb: got ${set.moves}`);
-			}
-		});
-
-		testSet('krookodile', options, set => {
-			if (set.moves.includes('pursuit')) {
-				assert(set.moves.includes('knockoff'), `Krookodile: got ${set.moves}`);
-			}
-		});
+    	const dex = Dex.forFormat(options.format);
+		const darkTypesWithPursuit = dex.species
+        	.all()
+        	.filter(pkmn => pkmn.types.includes('Dark') && pkmn.randomBattleMoves.includes('pursuit'))
+        	.map(pkmn => pkmn.id);
+    	for (const pokemon of darkTypesWithPursuit) {
+        	testSet(pokemon, options, set => {
+            	if (!set.moves.includes('pursuit')) return;
+            	const darkStab = set.moves.filter(m => {
+                	const move = dex.moves.get(m);
+                	if (move.type !== 'Dark') return false;
+                	return move.category !== 'Status';
+            	});
+            	assert(darkStab.length > 1, `${pokemon}: got ${set.moves}`);
+        	});
+    	}
 	});
 
 	it('should not generate Roar + Protect', () => {

--- a/test/random-battles/gen7.js
+++ b/test/random-battles/gen7.js
@@ -29,7 +29,7 @@ describe('[Gen 7] Random Battle', () => {
 		const dex = Dex.forFormat(options.format);
 		const darkTypesWithPursuit = dex.species
 			.all()
-			.filter(pkmn => pkmn.types.includes('Dark') && pkmn.randomBattleMoves.includes('pursuit'))
+			.filter(pkmn => pkmn.types.includes('Dark') && pkmn.randomBattleMoves?.includes('pursuit'))
 			.map(pkmn => pkmn.id);
 		for (const pokemon of darkTypesWithPursuit) {
 			testSet(pokemon, options, set => {

--- a/test/random-battles/gen8.js
+++ b/test/random-battles/gen8.js
@@ -19,6 +19,14 @@ describe('[Gen 8] Random Battle', () => {
 		});
 	});
 
+	it('should not generate Stone Edge + Swords Dance Lucario', () => {
+		testNotBothMoves('lucario', options, 'stoneedge', 'swordsdance');
+	});
+
+	it('should not generate Shift Gear + U-turn Genesect', () => {
+		testNotBothMoves('Genesect', options, 'shiftgear', 'uturn');
+	});
+
 	it('should not generate Flame Charge + Flare Blitz Solgaleo', () => {
 		testNotBothMoves('solgaleo', options, 'flamecharge', 'flareblitz');
 	});


### PR DESCRIPTION
Gen 8:
-Lucario: Stone Edge over Ice Punch, adjust corresponding hardcode to match
-Silvally-Fairy: Flame Charge over Fire Fang
-Zeraora: Blaze Kick over Fire Punch; the power is important for several KOs
-Fix Rillaboom and G-Max Rillaboom's level difference
-Eldegoss: -Charm
-Prevent Shift Gear + U-turn Genesect again
-Create new focus sash qualifications s.t. pokemon with 250 total bulk (ex. Mamoswine) and below will get sash with hazards in lead slot and Pokemon with 210 total bulk (ex. Indeedee-M) and below will get focus sash without hazards in the lead slot.
-Rewrite the Cinccino hardcode so it both is more explicitly about cinccino and prevents focus sash from generating

Gen 7:
-Stone Edge over Fire Punch on hitmonchan for better coverage
-remove Memento on dugtrio to prevent leftovers from generating
-trim Primeape, Palkia, Cobalion, and Tapu Lele's movepools to increase overall set quality
-Pursuit should no longer generate as the only Dark move on dual-typed dark-types
-Nihilego should get SpA beast boosts
-force Eruption on Fire-types that have it (typhlosion)
-Rotom-Fan will now actually always have air slash
-Azumarill will have forced aqua jet now