### PR TITLE
Fix TypeScript declaration file generation

### DIFF
--- a/tools/build-utils.js
+++ b/tools/build-utils.js
@@ -156,7 +156,7 @@ function replace(file, replacements) {
 		if (err) throw err;
 		if (stats.isSymbolicLink()) return;
 		if (stats.isFile()) {
-			if (!file.endsWith('.js')) return;
+			if (!file.endsWith('.js') && !file.endsWith('.d.ts')) return;
 			fs.readFile(file, "utf-8", function (err, text) {
 				if (err) throw err;
 				let anyMatch = false;
@@ -208,6 +208,7 @@ exports.transpile = (doForce, decl) => {
 	if (sucrase('./sim', './.sim-dist')) {
 		replace('.sim-dist', [
 			{regex: /(require\(.*?)\/(lib|data|config)/g, replace: `$1/.$2-dist`},
+			{regex: /(from '.*?)\/(lib|data|config)/g, replace: `$1/.$2-dist`},
 		]);
 	}
 


### PR DESCRIPTION
Currently, the published version of the `pokemon-showdown` npm package improperly reference non-transpiled Showdown code over the properly transpiled code with `.d.ts` declarations.

For example, `.sim-dist/battle-stream.d.ts` has a `import { Streams } from '../lib'` statement which would reference the non-transpiled source code. This causes dependent projects to also transpile the `../lib` code a second time which often leads to multiple TypeScript errors due to not sharing the same TypeScript configuration as `pokemon-showdown` (such as not including `global-types.ts`). It should instead reference it as `import { Streams } from '../.lib-dist'` to avoid this issue entirely.

This updates `tools/build-utils.ts` to not only update the emitted `.js` files with the proper `require` statements referencing `.*-dist` directories but also updates the emitted `.d.ts` files with the proper `import` statements.

I was able to verify this fixing TypeScript build issues in dependent projects by linking a locally built version of the package to another TypeScript project with divergeant configuration.

I'm not sure if this is the best approach, but it *does* fix the issue.