### PR TITLE
Fix paralysis modifier application

### DIFF
--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -27,7 +27,14 @@ export const Conditions: {[k: string]: ConditionData} = {
 				this.add('-status', target, 'par');
 			}
 		},
-		// Speed reduction is handled directly in the sim/pokemon.ts getStat function
+		onModifySpe(spe, pokemon) {
+			// Paralysis occurs after all other Speed modifiers, so evaluate all modifiers up to this point first
+			spe = this.finalModify(spe);
+			if (!pokemon.hasAbility('quickfeet')) {
+				spe = Math.floor(spe * 50 / 100);
+			}
+			return spe;
+		},
 		onBeforeMovePriority: 1,
 		onBeforeMove(pokemon) {
 			if (this.randomChance(1, 4)) {

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -27,11 +27,7 @@ export const Conditions: {[k: string]: ConditionData} = {
 				this.add('-status', target, 'par');
 			}
 		},
-		onModifySpe(spe, pokemon) {
-			if (!pokemon.hasAbility('quickfeet')) {
-				return this.chainModify(0.5);
-			}
-		},
+		// Speed reduction is handled directly in the sim/pokemon.ts getStat function
 		onBeforeMovePriority: 1,
 		onBeforeMove(pokemon) {
 			if (this.randomChance(1, 4)) {

--- a/data/mods/gen4/conditions.ts
+++ b/data/mods/gen4/conditions.ts
@@ -6,6 +6,12 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 	},
 	par: {
 		inherit: true,
+		onModifySpe(spe, pokemon) {
+			if (!pokemon.hasAbility('quickfeet')) {
+				return this.chainModify(0.25);
+			}
+			return spe;
+		},
 		onBeforeMove(pokemon) {
 			if (!pokemon.hasAbility('magicguard') && this.randomChance(1, 4)) {
 				this.add('cant', pokemon, 'par');

--- a/data/mods/gen6/conditions.ts
+++ b/data/mods/gen6/conditions.ts
@@ -5,6 +5,17 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 			this.damage(pokemon.baseMaxhp / 8);
 		},
 	},
+	par: {
+		inherit: true,
+		onModifySpe(spe, pokemon) {
+			// Paralysis occurs after all other Speed modifiers, so evaluate all modifiers up to this point first
+			spe = this.finalModify(spe);
+			if (!pokemon.hasAbility('quickfeet')) {
+				spe = Math.floor(spe * 25 / 100);
+			}
+			return spe;
+		},
+	},
 	confusion: {
 		inherit: true,
 		onBeforeMove(pokemon) {

--- a/data/mods/gen6/conditions.ts
+++ b/data/mods/gen6/conditions.ts
@@ -5,14 +5,6 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 			this.damage(pokemon.baseMaxhp / 8);
 		},
 	},
-	par: {
-		inherit: true,
-		onModifySpe(spe, pokemon) {
-			if (!pokemon.hasAbility('quickfeet')) {
-				return this.chainModify(0.25);
-			}
-		},
-	},
 	confusion: {
 		inherit: true,
 		onBeforeMove(pokemon) {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2084,6 +2084,12 @@ export class Battle {
 		return stats;
 	}
 
+	finalModify(relayVar: number) {
+		relayVar = this.modify(relayVar, this.event.modifier);
+		this.event.modifier = 1;
+		return relayVar;
+	}
+
 	getCategory(move: string | Move) {
 		return this.dex.moves.get(move).category || 'Physical';
 	}

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -563,7 +563,6 @@ export class Pokemon {
 		}
 
 		if (statName === 'spe' && stat > 10000 && !this.battle.format.battle?.trunc) stat = 10000;
-
 		return stat;
 	}
 

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -562,7 +562,12 @@ export class Pokemon {
 			stat = this.battle.runEvent('Modify' + statTable[statName], this, null, null, stat);
 		}
 
-		if (statName === 'spe' && stat > 10000 && !this.battle.format.battle?.trunc) stat = 10000;
+		if (statName === 'spe') {
+			const paralysisMultiplier = this.battle.gen >= 7 ? 50 : 25;
+			if (this.status === 'par' && !this.hasAbility('quickfeet')) stat = Math.floor(stat * paralysisMultiplier / 100);
+			if (stat > 10000 && !this.battle.format.battle?.trunc) stat = 10000;
+		}
+
 		return stat;
 	}
 

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -562,11 +562,7 @@ export class Pokemon {
 			stat = this.battle.runEvent('Modify' + statTable[statName], this, null, null, stat);
 		}
 
-		if (statName === 'spe') {
-			const paralysisMultiplier = this.battle.gen >= 7 ? 50 : 25;
-			if (this.status === 'par' && !this.hasAbility('quickfeet')) stat = Math.floor(stat * paralysisMultiplier / 100);
-			if (stat > 10000 && !this.battle.format.battle?.trunc) stat = 10000;
-		}
+		if (statName === 'spe' && stat > 10000 && !this.battle.format.battle?.trunc) stat = 10000;
 
 		return stat;
 	}

--- a/test/sim/misc/statuses.js
+++ b/test/sim/misc/statuses.js
@@ -65,6 +65,17 @@ describe('Paralysis', function () {
 		assert.equal(battle.p1.active[0].getStat('spe'), battle.modify(speed, 0.5));
 	});
 
+	it(`should apply its Speed reduction after all other Speed modifiers`, function () {
+		battle = common.createBattle([[
+			{species: 'goldeen', item: 'choicescarf', evs: {spe: 252}, moves: ['sleeptalk']}, // 225 Speed
+		], [
+			{species: 'wynaut', moves: ['glare']},
+		]]);
+
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].getStat('spe'), 168); // would be 169 if both Choice Scarf and paralysis were chained
+	});
+
 	it('should reduce speed to 25% of its original value in Gen 6', function () {
 		battle = common.gen(6).createBattle();
 		battle.setPlayer('p1', {team: [{species: 'Vaporeon', ability: 'waterabsorb', moves: ['aquaring']}]});


### PR DESCRIPTION
Currently, paralysis is being treated as a Speed modifier, being chained together with other Speed modifiers like Tailwind or Choice Scarf. Paralysis is actually its own independent modifier, taking place outside of that traditional calculation; this can lead to some rounding errors such as outlined in this [bug report](https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-8979399).

This solution works for modern gens fine, but it doesn't work for past gens and mods since I'm hardcoding paralysis. I also don't in fact know for sure how paralysis is applied prior to Gen 6. In Gens 7 & 8, it's applied as a * 50/100 after other modifiers, and in Gen 6 it's the same but * 25 / 100. I assume BW is the same as Gen 6. But I don't know if it's done differently prior to then.

The other approach I thought of was creating a new event, ``onApplyParalysis`` or something, to replace the ``onModifySpe`` currently used for paralysis. But it seems kinda dumb to use a whole event for just one thing. This approach more closely models how we handle burn.

Opinions are appreciated.