### PR TITLE
Fix Ice Face behavior

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -2381,6 +2381,8 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			this.speedSort(sortedActive);
 			for (const pokemon of sortedActive) {
 				if (pokemon !== source) {
+					if (pokemon.getAbility().isPermanent) continue; // does not interact with e.g Ice Face, Zen Mode
+
 					// Will be suppressed by Pokemon#ignoringAbility if needed
 					this.singleEvent('Start', pokemon.getAbility(), pokemon.abilityState, pokemon);
 				}

--- a/test/sim/abilities/neutralizinggas.js
+++ b/test/sim/abilities/neutralizinggas.js
@@ -242,7 +242,7 @@ describe('Neutralizing Gas', function () {
 		assert.statStage(battle.p2.active[0], 'atk', 0);
 	});
 
-	it.skip(`should not prevent Ice Face from blocking damage nor reform Ice Face when leaving the field`, function () {
+	it(`should not prevent Ice Face from blocking damage nor reform Ice Face when leaving the field`, function () {
 		battle = common.createBattle([[
 			{species: 'Eiscue', ability: 'iceface', moves: ['sleeptalk', 'hail']},
 		], [


### PR DESCRIPTION
Ice Face should not reform when neutralizing gas leaves the field. Caused by triggering onStart for Ice Face in onEnd of Neutralizing Gas.

To fix the bug for Ice Face, the code now ignores abilities that are unaffected by Neutralizing Gas in the onEnd for Neutralizing Gas (using the isPermanent flag). 

I believe this also excludes other abilities unaffected by Neutralizing Gas (such as Schooling) from triggering onStart immediately when Neutralizing Gas leaves the field. Not sure if this is correct from a mechanics perspective; if not, I can change it to only exclude Ice Face! 

Corresponding bug report: https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-8949321