### PR TITLE
Tournament options: fix /tour autostart 1

### DIFF
--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -1692,7 +1692,7 @@ const commands: Chat.ChatCommands = {
 				return this.sendReply(`Usage: /tour ${cmd} <on|minutes|off>`);
 			}
 			const option = target.toLowerCase();
-			if (this.meansYes(option) || option === 'start') {
+			if ((this.meansYes(option) && option !== '1') || option === 'start') {
 				if (tournament.isTournamentStarted) {
 					return this.errorReply("The tournament has already started.");
 				} else if (!tournament.playerCap) {


### PR DESCRIPTION
Since `this.meansYes('1')` is true, `/tour autostart 1` sets the tournament to automatically start when the player cap is reached, instead of after 1 minute.