### PR TITLE
Update Passimian's Ability in Battle Factory

### DIFF
--- a/data/mods/gen7/factory-sets.json
+++ b/data/mods/gen7/factory-sets.json
@@ -5054,7 +5054,7 @@
 			"sets": [{
 				"species": "Passimian",
 				"item": ["Choice Scarf"],
-				"ability": ["Receiver"],
+				"ability": ["Defiant"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
 				"nature": "Jolly",
 				"moves": [["Close Combat"], ["U-turn"], ["Knock Off"], ["Gunk Shot"]]
@@ -5982,7 +5982,7 @@
 			"sets": [{
 				"species": "Passimian",
 				"item": ["Choice Scarf", "Choice Band"],
-				"ability": ["Receiver"],
+				"ability": ["Defiant"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
 				"nature": "Jolly",
 				"moves": [["Close Combat"], ["U-turn"], ["Knock Off"], ["Gunk Shot"]]


### PR DESCRIPTION
Passimian received Defiant as an ability from an event late in Gen 7 (https://twitter.com/SerebiiNet/status/1111223652178112513?s=19). Defiant is objectively better than Receiver within the context of singles, so all Passimian sets should be Defiant. Apologies if there's a more proper way of doing this - I reported this error to the Randbats Auth 3 weeks ago and didn't see it change so I decided to be the change I wanted to see in the world.