### PR TITLE
Add VGC 2021 Series 11 support

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -359,6 +359,14 @@ export const Formats: FormatList = [
 		banlist: ['Corsola-Galar', 'Cutiefly', 'Ponyta-Base', 'Scyther', 'Sneasel', 'Swirlix', 'Tangela', 'Vulpix', 'Vulpix-Alola'],
 	},
 	{
+		name: "[Gen 8] VGC 2021 Series 11",
+
+		mod: 'gen8',
+		gameType: 'doubles',
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 8', 'VGC Timer', 'Limit One Restricted'],
+		restricted: ['Restricted Legendary'],
+	},
+	{
 		name: "[Gen 8] VGC 2021 Series 10",
 		threads: [
 			`&bullet; <a href="https://www.smogon.com/forums/threads/3677186/">VGC 2021 Series 10 Metagame Discussion</a>`,


### PR DESCRIPTION
Come the end of month, VGC and BSS will completely remove their Series 10 formats and leave Series 9 as challenge-only. For now, this just adds the ladder a bit earlier for some extra VGC practice ahead of the end of the month.