### PR TITLE
Gen IV: Fix client messages for spread move miss

### DIFF
--- a/data/mods/gen4/scripts.ts
+++ b/data/mods/gen4/scripts.ts
@@ -88,7 +88,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			const hitResults = this.battle.runEvent('Invulnerability', targets, pokemon, move);
 			for (const [i, target] of targets.entries()) {
 				if (hitResults[i] === false) {
-					this.battle.attrLastMove('[miss]');
+					if (!move.spreadHit) this.battle.attrLastMove('[miss]');
 					this.battle.add('-miss', pokemon, target);
 				}
 			}


### PR DESCRIPTION
https://replay.pokemonshowdown.com/gen4vgc2010-1444280291-wzq9jvouu0ez9k6ws7pk8d4i66rrsbxpw - replay showing the bug just in case it's needed (don't skip turns)

EDIT: found smogon bug report for this https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-8930317