### PR TITLE
stop allowAVs from removing items

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -524,7 +524,7 @@ export class TeamValidator {
 		problem = this.checkItem(set, item, setHas);
 		if (problem) problems.push(problem);
 		if (ruleTable.has('obtainablemisc')) {
-			if (dex.gen <= 1)) {
+			if (dex.gen <= 1) {
 				if (item.id) {
 					// no items allowed
 					set.item = '';

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -524,7 +524,7 @@ export class TeamValidator {
 		problem = this.checkItem(set, item, setHas);
 		if (problem) problems.push(problem);
 		if (ruleTable.has('obtainablemisc')) {
-			if (dex.gen <= 1 || ruleTable.has('allowavs')) {
+			if (dex.gen <= 1)) {
 				if (item.id) {
 					// no items allowed
 					set.item = '';


### PR DESCRIPTION
Let's Go formats already disallow any non-Mega Stone items, this code has no purpose other than preventing the use of Mega Stones (not an intended part of Candy formats).