### PR TITLE
CRQ: Don't send friend status for yourself in userdetails

### DIFF
--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -394,7 +394,7 @@ export const crqHandlers: {[k: string]: Chat.CRQHandler} = {
 			autoconfirmed: !!targetUser.autoconfirmed,
 			status: targetUser.getStatus(),
 			rooms: roomList,
-			friended: user.friends?.has(targetUser.id),
+			friended: user.id === targetUser.id ? undefined : user.friends?.has(targetUser.id),
 		};
 	},
 	roomlist(target, user, trustable) {


### PR DESCRIPTION
You can't befriend yourself, so there's some bandwidth to be saved by not sending that info back from server