### PR TITLE
Force Prankster on Liepard set with Copycat

### DIFF
--- a/data/mods/gen7/factory-sets.json
+++ b/data/mods/gen7/factory-sets.json
@@ -6948,7 +6948,14 @@
 				"ability": ["Limber"],
 				"evs": {"atk": 252, "def": 4, "spe": 252},
 				"nature": "Jolly",
-				"moves": [["Knock Off"], ["Pursuit"], ["Play Rough"], ["U-turn", "Sucker Punch", "Copycat"]]
+				"moves": [["Knock Off"], ["Pursuit"], ["Play Rough"], ["U-turn", "Sucker Punch"]]
+			}, {
+				"species": "Liepard",
+				"item": ["Choice Band"],
+				"ability": ["Prankster"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Knock Off"], ["Pursuit"], ["Play Rough"], ["Copycat"]]
 			}]
 		},
 		"ludicolo": {


### PR DESCRIPTION
On Liepard sets without Copycat, Prankster is useless and Limber is a situational improvement. However, Prankster is needed on Copycat sets to function properly (revenging sun boosted victreebel, for example)