### PR TITLE
Refactor getIdentity not to take roomids

### DIFF
--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -450,7 +450,7 @@ export const crqHandlers: {[k: string]: Chat.CRQHandler} = {
 		for (const userid in targetRoom.users) {
 			const curUser = targetRoom.users[userid];
 			if (!curUser.named) continue;
-			const userinfo = curUser.getIdentity(targetRoom.roomid);
+			const userinfo = curUser.getIdentity(targetRoom);
 			roominfo.users.push(userinfo);
 		}
 		return roominfo;
@@ -474,7 +474,7 @@ export const commands: Chat.ChatCommands = {
 		for (const id in room.users) {
 			const curUser = Users.get(room.users[id]);
 			if (!curUser?.named) continue;
-			userList.push(Utils.escapeHTML(curUser.getIdentity(room.roomid)));
+			userList.push(Utils.escapeHTML(curUser.getIdentity(room)));
 		}
 
 		let output = `There ${Chat.plural(userList, "are", "is")} <strong style="color:#24678d">${Chat.count(userList, "</strong> users")} in this room:<br />`;
@@ -492,7 +492,7 @@ export const commands: Chat.ChatCommands = {
 		target = this.checkChat(`/${this.cmd} ${target || ''}`);
 
 		if (this.message.startsWith(`/ME`)) {
-			const uppercaseIdentity = user.getIdentity(room?.roomid).toUpperCase();
+			const uppercaseIdentity = user.getIdentity(room).toUpperCase();
 			if (this.pmTarget) {
 				const msg = `|pm|${uppercaseIdentity}|${this.pmTarget.getIdentity()}|${target}`;
 				user.send(msg);

--- a/server/chat-commands/moderation.ts
+++ b/server/chat-commands/moderation.ts
@@ -236,7 +236,7 @@ export const commands: Chat.ChatCommands = {
 
 			if (this.pmTarget && targetUser) {
 				const text = `${targetUser.name} was invited (and promoted to Room ${nextGroupName}) by ${user.name}.`;
-				room.add(`|c|${user.getIdentity(room.roomid)}|/log ${text}`).update();
+				room.add(`|c|${user.getIdentity(room)}|/log ${text}`).update();
 				this.modlog('INVITE', targetUser, null, {noip: 1, noalts: 1});
 			} else if (
 				nextSymbol in Config.groups && oldSymbol in Config.groups &&

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -670,7 +670,7 @@ export class CommandContext extends MessageContext {
 			}
 			Chat.sendPM(message, this.user, this.pmTarget);
 		} else if (this.room) {
-			this.room.add(`|c|${this.user.getIdentity(this.room.roomid)}|${message}`);
+			this.room.add(`|c|${this.user.getIdentity(this.room)}|${message}`);
 			if (this.room.game && this.room.game.onLogMessage) {
 				this.room.game.onLogMessage(message, this.user);
 			}
@@ -1033,7 +1033,7 @@ export class CommandContext extends MessageContext {
 		if (this.pmTarget) {
 			this.sendReply(`|c~|${message}`);
 		} else {
-			this.sendReply(`|c|${this.user.getIdentity(this.room ? this.room.roomid : '')}|${message}`);
+			this.sendReply(`|c|${this.user.getIdentity(this.room)}|${message}`);
 		}
 		if (this.room) {
 			// We don't want broadcasted messages in a room to be translated

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1294,7 +1294,7 @@ export class RoomBattle extends RoomGames.RoomGame {
 	onChatMessage(message: string, user: User) {
 		const parts = message.split('\n');
 		for (const line of parts) {
-			void this.stream.write(`>chat-inputlogonly ${user.getIdentity(this.room.roomid)}|${line}`);
+			void this.stream.write(`>chat-inputlogonly ${user.getIdentity(this.room)}|${line}`);
 		}
 	}
 	async getLog(): Promise<string[] | void> {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -397,19 +397,19 @@ export abstract class BasicRoom {
 	 * highlight the user.
 	 */
 	addByUser(user: User, text: string): this {
-		return this.add('|c|' + user.getIdentity(this.roomid) + '|/log ' + text);
+		return this.add('|c|' + user.getIdentity(this) + '|/log ' + text);
 	}
 	/**
 	 * Like addByUser, but without logging
 	 */
 	sendByUser(user: User | null, text: string) {
-		this.send('|c|' + (user ? user.getIdentity(this.roomid) : '&') + '|/log ' + text);
+		this.send('|c|' + (user ? user.getIdentity(this) : '&') + '|/log ' + text);
 	}
 	/**
 	 * Like addByUser, but sends to mods only.
 	 */
 	sendModsByUser(user: User, text: string) {
-		this.sendMods('|c|' + user.getIdentity(this.roomid) + '|/log ' + text);
+		this.sendMods('|c|' + user.getIdentity(this) + '|/log ' + text);
 	}
 	update() {
 		if (!this.log.broadcastBuffer.length) return;
@@ -433,7 +433,7 @@ export abstract class BasicRoom {
 				continue;
 			}
 			counter++;
-			buffer += ',' + this.users[i].getIdentityWithStatus(this.roomid);
+			buffer += ',' + this.users[i].getIdentityWithStatus(this);
 		}
 		const msg = `|users|${counter}${buffer}`;
 		return msg;
@@ -966,7 +966,7 @@ export abstract class BasicRoom {
 		if (this.users[user.id]) return false;
 
 		if (user.named) {
-			this.reportJoin('j', user.getIdentityWithStatus(this.roomid), user);
+			this.reportJoin('j', user.getIdentityWithStatus(this), user);
 		}
 
 		const staffIntro = this.getStaffIntroMessage(user);
@@ -994,13 +994,13 @@ export abstract class BasicRoom {
 		delete this.users[oldid];
 		this.users[user.id] = user;
 		if (joining) {
-			this.reportJoin('j', user.getIdentityWithStatus(this.roomid), user);
+			this.reportJoin('j', user.getIdentityWithStatus(this), user);
 			const staffIntro = this.getStaffIntroMessage(user);
 			if (staffIntro) this.sendUser(user, staffIntro);
 		} else if (!user.named) {
 			this.reportJoin('l', oldid, user);
 		} else {
-			this.reportJoin('n', user.getIdentityWithStatus(this.roomid) + '|' + oldid, user);
+			this.reportJoin('n', user.getIdentityWithStatus(this) + '|' + oldid, user);
 		}
 		this.minorActivity?.onRename?.(user, oldid, joining);
 		this.checkAutoModchat(user);
@@ -1013,7 +1013,7 @@ export abstract class BasicRoom {
 		if (user?.connected) {
 			if (!this.users[user.id]) return false;
 			if (user.named) {
-				this.reportJoin('n', user.getIdentityWithStatus(this.roomid) + '|' + user.id, user);
+				this.reportJoin('n', user.getIdentityWithStatus(this) + '|' + user.id, user);
 			}
 		}
 		return true;
@@ -1029,7 +1029,7 @@ export abstract class BasicRoom {
 		this.userCount--;
 
 		if (user.named) {
-			this.reportJoin('l', user.getIdentity(this.roomid), user);
+			this.reportJoin('l', user.getIdentity(this), user);
 		}
 		if (this.game && this.game.onLeave) this.game.onLeave(user);
 		this.runAutoModchat();

--- a/server/users.ts
+++ b/server/users.ts
@@ -508,17 +508,13 @@ export class User extends Chat.MessageContext {
 	popup(message: string) {
 		this.send(`|popup|` + message.replace(/\n/g, '||'));
 	}
-	getIdentity(roomid: RoomID = '') {
+	getIdentity(room: BasicRoom | null = null) {
 		const punishgroups = Config.punishgroups || {locked: null, muted: null};
 		if (this.locked || this.namelocked) {
 			const lockedSymbol = (punishgroups.locked && punishgroups.locked.symbol || '\u203d');
 			return lockedSymbol + this.name;
 		}
-		if (roomid) {
-			const room = Rooms.get(roomid);
-			if (!room) {
-				throw new Error(`Room doesn't exist: ${roomid}`);
-			}
+		if (room) {
 			if (room.isMuted(this)) {
 				const mutedSymbol = (punishgroups.muted && punishgroups.muted.symbol || '!');
 				return mutedSymbol + this.name;
@@ -531,8 +527,8 @@ export class User extends Chat.MessageContext {
 		}
 		return this.tempGroup + this.name;
 	}
-	getIdentityWithStatus(roomid: RoomID = '') {
-		const identity = this.getIdentity(roomid);
+	getIdentityWithStatus(room: BasicRoom | null = null) {
+		const identity = this.getIdentity(room);
 		const status = this.statusType === 'online' ? '' : '@!';
 		return `${identity}${status}`;
 	}


### PR DESCRIPTION
This is a PR basically only because it's not hotpatchable, so I want people to know about it. You _could_ monkeypatch it, but I'm planning to restart tonight, so I'm going to skip that.

This is partly to work around unnecessary "room not found" issues from race conditions, but this should also improve performance.