### PR TITLE
Chat: Add an onConfigRefresh handler

### DIFF
--- a/server/chat-plugins/username-prefixes.ts
+++ b/server/chat-plugins/username-prefixes.ts
@@ -126,3 +126,11 @@ export const commands: Chat.ChatCommands = {
 		);
 	},
 };
+
+export const handlers: Chat.Handlers = {
+	onConfigRefresh() {
+		// ensure that battle prefixes configured via the chat plugin are not overwritten
+		// by battle prefixes manually specified in config.js
+		prefixManager.refreshConfig(true);
+	},
+};

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -71,6 +71,7 @@ export interface Handlers {
 	onBattleStart?: (user: User, room: GameRoom) => void;
 	onBattleLeave?: (user: User, room: GameRoom) => void;
 	onDisconnect?: (user: User) => void;
+	onConfigRefresh?: () => void;
 }
 
 export interface ChatPlugin {

--- a/server/index.ts
+++ b/server/index.ts
@@ -76,9 +76,7 @@ function setupGlobals() {
 		FS(require.resolve('../config/config')).onModify(() => {
 			try {
 				global.Config = ConfigLoader.load(true);
-				// ensure that battle prefixes configured via the chat plugin are not overwritten
-				// by battle prefixes manually specified in config.js
-				Chat.plugins['username-prefixes']?.prefixManager.refreshConfig(true);
+				Chat.runHandlers('ConfigRefresh');
 				Monitor.notice('Reloaded ../config/config.js');
 			} catch (e: any) {
 				Monitor.adminlog("Error reloading ../config/config.js: " + e.stack);


### PR DESCRIPTION
Takes hardcodes out of the main index file, plus lets other plugins hook into config. This is only a PR because it needs a restart.