### PR TITLE
BDSP: Make Psycho Boost Unobtainable

### DIFF
--- a/data/mods/gen8bdsp/moves.ts
+++ b/data/mods/gen8bdsp/moves.ts
@@ -693,7 +693,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	psychoboost: {
 		inherit: true,
-		isNonstandard: null,
+		isNonstandard: "Unobtainable",
 	},
 	purify: {
 		inherit: true,


### PR DESCRIPTION
Deoxys is currently unobtainable, which should make psycho boost unobtainable as well.