### PR TITLE
Chat: Properly handle subfolders when assigning plugin names

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1848,9 +1848,8 @@ export const Chat = new class {
 	packageData: AnyObject = {};
 
 	getPluginName(file: string) {
-		const folder = file.replace(__dirname, '').includes('chat-commands') ? 'chat-commands' : 'chat-plugins';
-		// the .slice(1, ...) removes the / from the beginning
-		let name = file.slice(file.indexOf(folder) + folder.length).slice(1, -file.lastIndexOf('.'));
+		const nameWithExt = pathModule.relative(__dirname, file).replace(/^chat-(?:commands|plugins)./, '');
+		let name = nameWithExt.slice(0, nameWithExt.lastIndexOf('.'));
 		if (name.endsWith('/index')) name = name.slice(0, -6);
 		return name;
 	}

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -29,7 +29,7 @@ import type {PartialModlogEntry} from './modlog';
 import {FriendsDatabase, PM} from './friends';
 import {SQL, Repl, FS, Utils} from '../lib';
 import {Dex} from '../sim';
-import {resolve} from 'path';
+import * as pathModule from 'path';
 import * as JSX from './chat-jsx';
 
 export type PageHandler = (this: PageContext, query: string[], user: User, connection: Connection)
@@ -1755,7 +1755,7 @@ export const Chat = new class {
 		}
 		Utils.sortBy(migrationsToRun, ({version}) => version);
 		for (const {file} of migrationsToRun) {
-			await this.database.runFile(resolve(migrationsFolder, file));
+			await this.database.runFile(pathModule.resolve(migrationsFolder, file));
 		}
 
 		Chat.destroyHandlers.push(() => Chat.database?.destroy());
@@ -1847,15 +1847,23 @@ export const Chat = new class {
 
 	packageData: AnyObject = {};
 
+	getPluginName(file: string) {
+		const ext = pathModule.extname(file);
+		const folder = file.includes('chat-commands') ? 'chat-commands' : 'chat-plugins';
+		// the .slice(1, ...) removes the / from the beginning
+		let name = file.slice(file.indexOf(folder) + folder.length).slice(1, -ext.length);
+		if (name.endsWith('/index')) name = name.slice(0, -6);
+		return name;
+	}
+
 	loadPluginFile(file: string) {
 		if (!VALID_PLUGIN_ENDINGS.some(ext => file.endsWith(ext))) return;
-		const filename = file.split('/').pop() || "";
-		this.loadPlugin(require(file), filename.slice(0, filename.lastIndexOf('.')) || file);
+		this.loadPlugin(require(file), this.getPluginName(file));
 	}
 
 	loadPluginDirectory(dir: string, depth = 0) {
 		for (const file of FS(dir).readdirSync()) {
-			const path = resolve(dir, file);
+			const path = pathModule.resolve(dir, file);
 			if (FS(path).isDirectorySync()) {
 				depth++;
 				if (depth > MAX_PLUGIN_LOADING_DEPTH) continue;

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1848,10 +1848,9 @@ export const Chat = new class {
 	packageData: AnyObject = {};
 
 	getPluginName(file: string) {
-		const ext = pathModule.extname(file);
-		const folder = file.includes('chat-commands') ? 'chat-commands' : 'chat-plugins';
+		const folder = file.replace(__dirname, '').includes('chat-commands') ? 'chat-commands' : 'chat-plugins';
 		// the .slice(1, ...) removes the / from the beginning
-		let name = file.slice(file.indexOf(folder) + folder.length).slice(1, -ext.length);
+		let name = file.slice(file.indexOf(folder) + folder.length).slice(1, -file.lastIndexOf('.'));
 		if (name.endsWith('/index')) name = name.slice(0, -6);
 		return name;
 	}


### PR DESCRIPTION
This is so subfolders with similarly named files (like `trivia/database.ts` and a `plugin/database.ts`, any `index.ts`, etc) won't get overridden in `Chat.plugins`.