### PR TITLE
Fix typo of Psychic Seed in BDSP items.ts

### DIFF
--- a/data/mods/gen8bdsp/items.ts
+++ b/data/mods/gen8bdsp/items.ts
@@ -266,7 +266,7 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: "Past",
 	},
-	msychicseed: {
+	psychicseed: {
 		inherit: true,
 		isNonstandard: "Past",
 	},


### PR DESCRIPTION
Psychic Seed had incorrect data in the BDSP mod due to its key being misspelled. This commit fixes it.