### PR TITLE
Repeated Smack Down should still cancel Fly and Bounce each time

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -15857,6 +15857,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onRestart(pokemon) {
 				if (pokemon.removeVolatile('fly') || pokemon.removeVolatile('bounce')) {
 					this.queue.cancelMove(pokemon);
+					pokemon.removeVolatile('twoturnmove');
 					this.add('-start', pokemon, 'Smack Down');
 				}
 			},


### PR DESCRIPTION
Reported [here](https://www.smogon.com/forums/posts/9038286).

Although the first Smack Down correctly cancels Fly and Bounce, subsequent uses of Smack Down also need to remove the `twoturnmove` volatile.