### PR TITLE
Propagate command promises

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -133,6 +133,9 @@ const MAX_MESSAGE_LENGTH = 300;
 
 const BROADCAST_COOLDOWN = 20 * 1000;
 const MESSAGE_COOLDOWN = 5 * 60 * 1000;
+const THROTTLE_MULTILINE_WARN = 3;
+const THROTTLE_MULTILINE_WARN_STAFF = 6;
+const THROTTLE_BUFFER_LIMIT = 6;
 
 const MAX_PARSE_RECURSION = 10;
 
@@ -1448,7 +1451,7 @@ export class CommandContext extends MessageContext {
 	}
 	refreshPage(pageid: string) {
 		if (this.connection.openPages?.has(pageid)) {
-			this.parse(`/join view-${pageid}`);
+			void this.parse(`/join view-${pageid}`);
 		}
 	}
 }
@@ -1803,28 +1806,83 @@ export const Chat = new class {
 	 * @param user - the user that sent the message
 	 * @param connection - the connection the user sent the message from
 	 */
-	parse(message: string, room: Room | null | undefined, user: User, connection: Connection) {
+	async parse(message: string, room: Room | null | undefined, user: User, connection: Connection) {
+		Monitor.activeIp = connection.ip;
 		Chat.loadPlugins();
 
 		const initialRoomlogLength = room?.log.getLineCount();
 		const context = new CommandContext({message, room, user, connection});
 		const start = Date.now();
-		const result = context.parse();
-		if (typeof result?.then === 'function') {
-			void result.then(() => {
-				this.logSlowMessage(start, context);
-			});
-		} else {
-			this.logSlowMessage(start, context);
-		}
+		const result = await context.parse();
+		this.logSlowMessage(start, context);
 		if (room && room.log.getLineCount() !== initialRoomlogLength) {
 			room.messagesSent++;
 			for (const [handler, numMessages] of room.nthMessageHandlers) {
 				if (room.messagesSent % numMessages === 0) handler(room, message);
 			}
 		}
-
+		Monitor.activeIp = null;
 		return result;
+	}
+
+	async queue(message: string, room: Room | null, connection: Connection) {
+		const user = connection.user;
+		const now = Date.now();
+		const noThrottle = user.hasSysopAccess() || Config.nothrottle;
+
+		if (message.startsWith('/cmd userdetails') || message.startsWith('>> ') || noThrottle) {
+			// certain commands are exempt from the queue
+			await Chat.parse(message, room, user, connection);
+			if (noThrottle) return;
+			return false; // but end the loop here
+		}
+
+		const throttleDelay = user.trusted ? Users.THROTTLE_DELAY_TRUSTED : Users.THROTTLE_DELAY;
+
+		if (user.chatQueueTimeout) {
+			if (!user.chatQueue) user.chatQueue = []; // this should never happen
+			if (user.chatQueue.length >= THROTTLE_BUFFER_LIMIT - 1) {
+				connection.sendTo(
+					room,
+					`|raw|<strong class="message-throttle-notice">Your message was not sent because you've been typing too quickly.</strong>`
+				);
+				return false;
+			} else {
+				user.chatQueue.push([message, room ? room.roomid : '', connection]);
+			}
+		} else if (now < user.lastChatMessage + throttleDelay) {
+			user.chatQueue = [[message, room ? room.roomid : '', connection]];
+			user.startChatQueue(throttleDelay - (now - user.lastChatMessage));
+		} else {
+			user.lastChatMessage = now;
+			await Chat.parse(message, room, user, connection);
+		}
+	}
+
+	async receive(message: string, room: Room | null, connection: Connection) {
+		const user = connection.user;
+		const multilineMessage = Chat.multiLinePattern.test(message);
+		if (multilineMessage) {
+			return Chat.queue(multilineMessage, room, connection);
+		}
+
+		const lines = message.split('\n');
+		if (!lines[lines.length - 1]) lines.pop();
+		// eslint-disable-next-line @typescript-eslint/prefer-optional-chain
+		const maxLineCount = (user.isStaff || (room && room.auth.isStaff(user.id))) ?
+			THROTTLE_MULTILINE_WARN_STAFF : THROTTLE_MULTILINE_WARN;
+		if (lines.length > maxLineCount && !Config.nothrottle) {
+			connection.popup(`You're sending too many lines at once. Try using a paste service like [[Pastebin]].`);
+			return;
+		}
+		// Emergency logging
+		if (Config.emergency) {
+			void FS('logs/emergency.log').append(`[${user} (${connection.ip})] ${room}|${message}\n`);
+		}
+
+		for (const line of lines) {
+			if ((await Chat.queue(line, room, connection)) === false) break;
+		}
 	}
 	logSlowMessage(start: number, context: CommandContext) {
 		const timeUsed = Date.now() - start;

--- a/server/punishments.ts
+++ b/server/punishments.ts
@@ -1010,7 +1010,7 @@ export const Punishments = new class {
 		}
 
 		if (roomObject?.battle && userObject && userObject.connections[0]) {
-			Chat.parse('/savereplay forpunishment', roomObject, userObject, userObject.connections[0]);
+			void Chat.parse('/savereplay forpunishment', roomObject, userObject, userObject.connections[0]);
 		}
 
 		const roomauth = Rooms.global.destroyPersonalRooms(userid);

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -882,7 +882,7 @@ export class RoomBattle extends RoomGames.RoomGame {
 		if (this.replaySaved || Config.autosavereplays) {
 			const uploader = Users.get(winnerid || p1id);
 			if (uploader?.connections[0]) {
-				Chat.parse('/savereplay silent', this.room, uploader, uploader.connections[0]);
+				void Chat.parse('/savereplay silent', this.room, uploader, uploader.connections[0]);
 			}
 		}
 		const parentGame = this.room.parent && this.room.parent.game;

--- a/server/users.ts
+++ b/server/users.ts
@@ -32,10 +32,6 @@ type StatusType = 'online' | 'busy' | 'idle';
 
 const THROTTLE_DELAY = 600;
 const THROTTLE_DELAY_TRUSTED = 100;
-const THROTTLE_BUFFER_LIMIT = 6;
-const THROTTLE_MULTILINE_WARN = 3;
-const THROTTLE_MULTILINE_WARN_STAFF = 6;
-
 const NAMECHANGE_THROTTLE = 2 * 60 * 1000; // 2 minutes
 const NAMES_PER_THROTTLE = 3;
 
@@ -1377,49 +1373,13 @@ export class User extends Chat.MessageContext {
 	 * The user says message in room.
 	 * Returns false if the rest of the user's messages should be discarded.
 	 */
-	chat(message: string, room: Room | null, connection: Connection) {
-		const now = Date.now();
-		const noThrottle = this.hasSysopAccess() || Config.nothrottle;
-
-		if (message.startsWith('/cmd userdetails') || message.startsWith('>> ') || noThrottle) {
-			// certain commands are exempt from the queue
-			Monitor.activeIp = connection.ip;
-			Chat.parse(message, room, this, connection);
-			Monitor.activeIp = null;
-			if (noThrottle) return;
-			return false; // but end the loop here
-		}
-
-		const throttleDelay = this.trusted ? THROTTLE_DELAY_TRUSTED : THROTTLE_DELAY;
-
-		if (this.chatQueueTimeout) {
-			if (!this.chatQueue) this.chatQueue = []; // this should never happen
-			if (this.chatQueue.length >= THROTTLE_BUFFER_LIMIT - 1) {
-				connection.sendTo(
-					room,
-					`|raw|<strong class="message-throttle-notice">Your message was not sent because you've been typing too quickly.</strong>`
-				);
-				return false;
-			} else {
-				this.chatQueue.push([message, room ? room.roomid : '', connection]);
-			}
-		} else if (now < this.lastChatMessage + throttleDelay) {
-			this.chatQueue = [[message, room ? room.roomid : '', connection]];
-			this.startChatQueue(throttleDelay - (now - this.lastChatMessage));
-		} else {
-			this.lastChatMessage = now;
-			Monitor.activeIp = connection.ip;
-			Chat.parse(message, room, this, connection);
-			Monitor.activeIp = null;
-		}
-	}
 	startChatQueue(delay: number | null = null) {
 		if (delay === null) {
 			delay = (this.trusted ? THROTTLE_DELAY_TRUSTED : THROTTLE_DELAY) - (Date.now() - this.lastChatMessage);
 		}
 
 		this.chatQueueTimeout = setTimeout(
-			() => this.processChatQueue(),
+			() => void this.processChatQueue(),
 			delay
 		);
 	}
@@ -1430,7 +1390,7 @@ export class User extends Chat.MessageContext {
 			this.chatQueueTimeout = null;
 		}
 	}
-	processChatQueue(): void {
+	async processChatQueue(): Promise<void> {
 		this.chatQueueTimeout = null;
 		if (!this.chatQueue) return;
 		const queueElement = this.chatQueue.shift();
@@ -1450,17 +1410,13 @@ export class User extends Chat.MessageContext {
 
 		const room = Rooms.get(roomid);
 		if (room || !roomid) {
-			Monitor.activeIp = connection.ip;
-			Chat.parse(message, room, this, connection);
-			Monitor.activeIp = null;
-		} else {
-			// room no longer exists; do nothing
-		}
+			await Chat.parse(message, room, this, connection);
+		} // room no longer exists
 
 		const throttleDelay = this.trusted ? THROTTLE_DELAY_TRUSTED : THROTTLE_DELAY;
 
 		if (this.chatQueue.length) {
-			this.chatQueueTimeout = setTimeout(() => this.processChatQueue(), throttleDelay);
+			this.chatQueueTimeout = setTimeout(() => void this.processChatQueue(), throttleDelay);
 		} else {
 			this.chatQueue = null;
 		}
@@ -1660,29 +1616,7 @@ function socketReceive(worker: ProcessManager.StreamWorker, workerid: number, so
 	message = message.slice(pipeIndex + 1);
 
 	const room = Rooms.get(roomId) || null;
-	const multilineMessage = Chat.multiLinePattern.test(message);
-	if (multilineMessage) {
-		user.chat(multilineMessage, room, connection);
-		return;
-	}
-
-	const lines = message.split('\n');
-	if (!lines[lines.length - 1]) lines.pop();
-	// eslint-disable-next-line @typescript-eslint/prefer-optional-chain
-	const maxLineCount = (user.isStaff || (room && room.auth.isStaff(user.id))) ?
-		THROTTLE_MULTILINE_WARN_STAFF : THROTTLE_MULTILINE_WARN;
-	if (lines.length > maxLineCount && !Config.nothrottle) {
-		connection.popup(`You're sending too many lines at once. Try using a paste service like [[Pastebin]].`);
-		return;
-	}
-	// Emergency logging
-	if (Config.emergency) {
-		void FS('logs/emergency.log').append(`[${user} (${connection.ip})] ${roomId}|${message}\n`);
-	}
-
-	for (const line of lines) {
-		if (user.chat(line, room, connection) === false) break;
-	}
+	void Chat.receive(message, room, connection);
 }
 
 const users = new Map<ID, User>();
@@ -1722,4 +1656,6 @@ export const Users = {
 		void logGhostConnections(7 * 24 * 60 * MINUTES);
 	}, 7 * 24 * 60 * MINUTES),
 	socketConnect,
+	THROTTLE_DELAY,
+	THROTTLE_DELAY_TRUSTED,
 };

--- a/test/server/rooms.js
+++ b/test/server/rooms.js
@@ -85,7 +85,7 @@ describe('Rooms features', function () {
 			assert.equal(room.auth.get(makeUser().id), '%');
 		});
 
-		it('should prevent overriding tournament room auth by a tournament player', function () {
+		it('should prevent overriding tournament room auth by a tournament player', async function () {
 			parent = Rooms.createChatRoom('parentroom2');
 			parent.auth.get = () => '%';
 			const p1 = makeUser();
@@ -113,9 +113,9 @@ describe('Rooms features', function () {
 			roomStaff.joinRoom(room);
 			administrator.joinRoom(room);
 			assert.equal(room.auth.get(roomStaff), '%', 'before promotion attempt');
-			Chat.parse("/roomvoice Room auth", room, p1, p1.connections[0]);
+			await Chat.parse("/roomvoice Room auth", room, p1, p1.connections[0]);
 			assert.equal(room.auth.get(roomStaff), '%', 'after promotion attempt');
-			Chat.parse("/roomvoice Room auth", room, administrator, administrator.connections[0]);
+			await Chat.parse("/roomvoice Room auth", room, administrator, administrator.connections[0]);
 			assert.equal(room.auth.get(roomStaff), '%', 'after being promoted by an administrator');
 		});
 	});

--- a/test/server/users.js
+++ b/test/server/users.js
@@ -170,14 +170,14 @@ describe('Users features', function () {
 					target.tempGroup = '&';
 					assert.equal(user.can('globalban', target), false, 'targeting higher rank');
 				});
-				it(`should not allow users to demote themselves`, function () {
+				it(`should not allow users to demote themselves`, async function () {
 					room = Rooms.createChatRoom("test");
 					const user = makeUser("User");
 					user.joinRoom(room);
 					for (const group of [' ', '+', '@']) {
 						room.auth.set(user.id, group);
 						assert.equal(room.auth.get(user.id), group, 'before demotion attempt');
-						Chat.parse("/roomdeauth User", room, user, user.connections[0]);
+						await Chat.parse("/roomdeauth User", room, user, user.connections[0]);
 						assert.equal(room.auth.get(user.id), group, 'after demotion attempt');
 					}
 				});


### PR DESCRIPTION
This PR removes User.chat and breaks its functionality into 3 parts.
- Chat.receive - takes a message, room, and connection, handles multiline messages, and parses everything apart to queue them up
- Chat.queue - puts messages into chat queue where applicable, parses them if not
- Chat.parse - as normal, parses commands.
Chat.parse now is `async` and awaits all commands that return promises.