### PR TITLE
Add Sleep Moves Clause to Revelationmons

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -639,7 +639,7 @@ export const Formats: FormatList = [
 		],
 
 		mod: 'gen8',
-		ruleset: ['Standard', 'Dynamax Clause', 'Revelationmons Mod'],
+		ruleset: ['Standard', 'Dynamax Clause', 'Revelationmons Mod', 'Sleep Moves Clause'],
 		banlist: [
 			'Calyrex-Ice', 'Calyrex-Shadow', 'Darmanitan-Galar', 'Dialga', 'Dracovish', 'Dragonite', 'Dragapult', 'Eternatus', 'Genesect',
 			'Giratina', 'Giratina-Origin', 'Groudon', 'Ho-Oh', 'Kommo-o', 'Kyogre', 'Kyurem-Black', 'Kyurem-White', 'Landorus-Base', 'Lugia',


### PR DESCRIPTION
Revelationmons, the current OMotM, should have Sleep Moves Clause implement, and does not. Proof of the clause can be found here: https://www.smogon.com/forums/threads/revelationmons-omotm-for-december.3692297/