### PR TITLE
Gen2 Random battles movesets

### DIFF
--- a/data/mods/gen2/formats-data.ts
+++ b/data/mods/gen2/formats-data.ts
@@ -691,7 +691,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	azumarill: {
-		randomBattleMoves: ["charm", "rest", "sleeptalk", "surf", "toxic"],
+		randomBattleMoves: ["perishsong", "rest", "toxic", "whirlpool"],
 		tier: "NU",
 	},
 	sudowoodo: {
@@ -817,7 +817,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	octillery: {
-		randomBattleMoves: ["fireblast", "hiddenpowerelectric", "icebeam", "rest", "sleeptalk", "surf"],
+		randomBattleMoves: ["flamethrower", "hiddenpowerelectric", "icebeam", "rest", "sleeptalk", "surf"],
 		tier: "NU",
 	},
 	delibird: {


### PR DESCRIPTION
Correcting oversights on octillery and azumarill movepools, who actually don't learn fire blast and charm, respectively.