### PR TITLE
Gen 3-4: Fix Knock Off mechanics

### DIFF
--- a/data/mods/gen4/abilities.ts
+++ b/data/mods/gen4/abilities.ts
@@ -160,6 +160,16 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			this.add('-activate', pokemon, 'ability: Forewarn', warnMove);
 		},
 	},
+	frisk: {
+		inherit: true,
+		onStart(pokemon) {
+			for (const target of pokemon.foes()) {
+				if (target.item && !target.itemState.knockedOff) {
+					this.add('-item', target, target.getItem().name, '[from] ability: Frisk', '[of] ' + pokemon, '[identify]');
+				}
+			}
+		},
+	},
 	hustle: {
 		inherit: true,
 		onSourceModifyAccuracyPriority: 7,
@@ -502,6 +512,16 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			if (pokemon.setAbility(ability)) {
 				this.add('-ability', pokemon, ability, '[from] ability: Trace', '[of] ' + target);
 			}
+		},
+	},
+	unburden: {
+		inherit: true,
+		condition: {
+			onModifySpe(spe, pokemon) {
+				if ((!pokemon.item || pokemon.itemState.knockedOff) && !pokemon.ignoringAbility()) {
+					return this.chainModify(2);
+				}
+			},
 		},
 	},
 	vitalspirit: {

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -832,7 +832,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			const item = target.getItem();
 			if (this.singleEvent('TakeItem', item, target.itemState, target, target, move, item)) {
 				target.itemState.knockedOff = true;
-				this.add('-enditem', target, item.name, '[from] move: Knock Off', '[of] ' + source);
+				this.add('-item', target, item.name, '[from] move: Knock Off', '[silent]');
 				this.hint("In Gens 3-4, Knock Off only makes the target's item unusable; it cannot obtain a new item.", true);
 			}
 		},

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -828,10 +828,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	knockoff: {
 		inherit: true,
 		onAfterHit(target, source) {
-			const item = target.takeItem();
-			if (item) {
-				this.add('-enditem', target, item.name, '[from] move: Knock Off', '[of] ' + source);
-			}
+			if (!target.item) return;
+			target.itemState.knockedOff = true;
+			const item = target.getItem();
+			this.add('-enditem', target, item.name, '[from] move: Knock Off', '[of] ' + source);
 		},
 	},
 	lastresort: {

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -829,9 +829,11 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		onAfterHit(target, source) {
 			if (!target.item || target.itemState.knockedOff) return;
-			target.itemState.knockedOff = true;
 			const item = target.getItem();
-			this.add('-enditem', target, item.name, '[from] move: Knock Off', '[of] ' + source);
+			if (this.runEvent('TakeItem', target, target, null, item)) {
+				target.itemState.knockedOff = true;
+				this.add('-enditem', target, item.name, '[from] move: Knock Off', '[of] ' + source);
+			}
 		},
 	},
 	lastresort: {

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -832,7 +832,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			const item = target.getItem();
 			if (this.singleEvent('TakeItem', item, target.itemState, target, target, move, item)) {
 				target.itemState.knockedOff = true;
-				this.add('-item', target, item.name, '[from] move: Knock Off', '[silent]');
+				this.add('-enditem', target, item.name, '[from] move: Knock Off');
 				this.hint("In Gens 3-4, Knock Off only makes the target's item unusable; it cannot obtain a new item.", true);
 			}
 		},

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -827,12 +827,13 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	knockoff: {
 		inherit: true,
-		onAfterHit(target, source) {
+		onAfterHit(target, source, move) {
 			if (!target.item || target.itemState.knockedOff) return;
 			const item = target.getItem();
-			if (this.runEvent('TakeItem', target, target, null, item)) {
+			if (this.singleEvent('TakeItem', item, target.itemState, target, target, move, item)) {
 				target.itemState.knockedOff = true;
 				this.add('-enditem', target, item.name, '[from] move: Knock Off', '[of] ' + source);
+				this.hint("Prior to Gen 5, Knock Off did not actually remove the target's item. Instead, the item would be unusable for the rest of the battle, and the target would not be able to obtain a new item.", true);
 			}
 		},
 	},

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -833,7 +833,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			if (this.singleEvent('TakeItem', item, target.itemState, target, target, move, item)) {
 				target.itemState.knockedOff = true;
 				this.add('-enditem', target, item.name, '[from] move: Knock Off', '[of] ' + source);
-				this.hint("Prior to Gen 5, Knock Off did not actually remove the target's item. Instead, the item would be unusable for the rest of the battle, and the target would not be able to obtain a new item.", true);
+				this.hint("In Gens 3-4, Knock Off only makes the target's item unusable; it cannot obtain a new item.", true);
 			}
 		},
 	},

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -828,7 +828,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	knockoff: {
 		inherit: true,
 		onAfterHit(target, source) {
-			if (!target.item) return;
+			if (!target.item || target.itemState.knockedOff) return;
 			target.itemState.knockedOff = true;
 			const item = target.getItem();
 			this.add('-enditem', target, item.name, '[from] move: Knock Off', '[of] ' + source);

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1575,7 +1575,7 @@ export class Pokemon {
 	}
 
 	eatItem(force?: boolean, source?: Pokemon, sourceEffect?: Effect) {
-		if (!this.item) return false;
+		if (!this.item || this.itemState.knockedOff) return false;
 		if ((!this.hp && this.item !== 'jabocaberry' && this.item !== 'rowapberry') || !this.isActive) return false;
 
 		if (!sourceEffect && this.battle.effect) sourceEffect = this.battle.effect;
@@ -1615,7 +1615,7 @@ export class Pokemon {
 
 	useItem(source?: Pokemon, sourceEffect?: Effect) {
 		if ((!this.hp && !this.getItem().isGem) || !this.isActive) return false;
-		if (!this.item) return false;
+		if (!this.item || this.itemState.knockedOff) return false;
 
 		if (!sourceEffect && this.battle.effect) sourceEffect = this.battle.effect;
 		if (!source && this.battle.event && this.battle.event.target) source = this.battle.event.target;
@@ -1651,8 +1651,7 @@ export class Pokemon {
 
 	takeItem(source?: Pokemon) {
 		if (!this.isActive) return false;
-		if (!this.item) return false;
-		if (this.itemState.knockedOff) return false;
+		if (!this.item || this.itemState.knockedOff) return false;
 		if (!source) source = this;
 		if (this.battle.gen === 4) {
 			if (toID(this.ability) === 'multitype') return false;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1669,6 +1669,7 @@ export class Pokemon {
 
 	setItem(item: string | Item, source?: Pokemon, effect?: Effect) {
 		if (!this.hp || !this.isActive) return false;
+		if (this.itemState.knockedOff) return false;
 		if (typeof item === 'string') item = this.battle.dex.items.get(item);
 
 		const effectid = this.battle.effect ? this.battle.effect.id : '';

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -785,9 +785,12 @@ export class Pokemon {
 	}
 
 	ignoringItem() {
-		return !!((this.battle.gen >= 5 && !this.isActive) ||
+		return !!(
+			this.itemState.knockedOff || // Gen 3-4
+			(this.battle.gen >= 5 && !this.isActive) ||
 			(this.hasAbility('klutz') && !this.getItem().ignoreKlutz) ||
-			this.volatiles['embargo'] || this.battle.field.pseudoWeather['magicroom']);
+			this.volatiles['embargo'] || this.battle.field.pseudoWeather['magicroom']
+		);
 	}
 
 	deductPP(move: string | Move, amount?: number | null, target?: Pokemon | null | false) {
@@ -1649,10 +1652,11 @@ export class Pokemon {
 	takeItem(source?: Pokemon) {
 		if (!this.isActive) return false;
 		if (!this.item) return false;
+		if (this.itemState.knockedOff) return false;
 		if (!source) source = this;
 		if (this.battle.gen === 4) {
 			if (toID(this.ability) === 'multitype') return false;
-			if (source && toID(source.ability) === 'multitype') return false;
+			if (toID(source.ability) === 'multitype') return false;
 		}
 		const item = this.getItem();
 		if (this.battle.runEvent('TakeItem', this, source, null, item)) {

--- a/test/sim/moves/knockoff.js
+++ b/test/sim/moves/knockoff.js
@@ -66,3 +66,34 @@ describe('Knock Off', function () {
 		assert.equal(battle.p2.active[0].item, 'rockyhelmet');
 	});
 });
+
+describe.only('Knock Off [Gen 4]', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should only make the held item unusable, not actually remove it', function() {
+		battle = common.gen(4).createBattle([[
+			{species: 'Wynaut', moves: ['knockoff']},
+		], [
+			{species: 'Aggron', item: 'leftovers', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		assert(battle.p2.active[0].item, 'Aggron should still be holding leftovers.');
+		assert.false.fullHP(battle.p2.active[0], 'Aggron should not have been healed by leftovers.');
+	});
+
+	it('should make the target unable to gain a new item', function() {
+		battle = common.gen(4).createBattle([[
+			{species: 'Wynaut', item: 'pokeball', moves: ['knockoff', 'trick']},
+		], [
+			{species: 'Blissey', item: 'leftovers', moves: ['sleeptalk', 'thief']},
+		]]);
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].item, 'pokeball');
+		assert.equal(battle.p2.active[0].item, 'leftovers');
+		battle.makeChoices('move trick', 'move thief');
+		assert.equal(battle.p1.active[0].item, 'pokeball');
+		assert.equal(battle.p2.active[0].item, 'leftovers');
+	});
+});

--- a/test/sim/moves/knockoff.js
+++ b/test/sim/moves/knockoff.js
@@ -67,7 +67,7 @@ describe('Knock Off', function () {
 	});
 });
 
-describe.only('Knock Off [Gen 4]', function () {
+describe('Knock Off [Gen 4]', function () {
 	afterEach(function () {
 		battle.destroy();
 	});

--- a/test/sim/moves/knockoff.js
+++ b/test/sim/moves/knockoff.js
@@ -72,7 +72,7 @@ describe.only('Knock Off [Gen 4]', function () {
 		battle.destroy();
 	});
 
-	it('should only make the held item unusable, not actually remove it', function() {
+	it('should only make the held item unusable, not actually remove it', function () {
 		battle = common.gen(4).createBattle([[
 			{species: 'Wynaut', moves: ['knockoff']},
 		], [
@@ -83,7 +83,7 @@ describe.only('Knock Off [Gen 4]', function () {
 		assert.false.fullHP(battle.p2.active[0], 'Aggron should not have been healed by leftovers.');
 	});
 
-	it('should make the target unable to gain a new item', function() {
+	it('should make the target unable to gain a new item', function () {
 		battle = common.gen(4).createBattle([[
 			{species: 'Wynaut', item: 'pokeball', moves: ['knockoff', 'trick']},
 		], [


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-9056030

Draft for now as I still have to write tests.

Also, I was wondering if a new client message should be created for this. Modifying `-enditem` to make it keep the item for Gen 3-4 knock off would probably break some older replays, which is why I think creating a new client message that specifically handles Gen 3-4 knock off could be a good idea.