### PR TITLE
Fix setting avatars on side servers

### DIFF
--- a/server/chat-commands/avatars.tsx
+++ b/server/chat-commands/avatars.tsx
@@ -77,7 +77,7 @@ export const Avatars = new class {
 		return validatedAvatar;
 	}
 	canUse(userid: ID, avatar: string): AvatarID | null {
-		avatar = avatar.toLowerCase().replace(/[^a-z0-9-]+/g, '');
+		avatar = avatar.toLowerCase().replace(/[^a-z0-9-.]+/g, '');
 		if (OFFICIAL_AVATARS.has(avatar)) return avatar;
 
 		const customs = customAvatars[userid]?.allowed;


### PR DESCRIPTION
`canUse` was replacing `.` for the avatar id which all side server custom avatars have.