### PR TITLE
Make Heal Bell heal both the user and ally's team

### DIFF
--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -314,9 +314,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			for (const pokemon of source.side.pokemon) {
 				pokemon.clearStatus();
 			}
-			for (const ally of target.side.pokemon) {
-				ally.cureStatus();
-			}
 		},
 	},
 	highjumpkick: {

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -314,6 +314,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			for (const pokemon of source.side.pokemon) {
 				pokemon.clearStatus();
 			}
+			for (const ally of target.side.pokemon) {
+				ally.cureStatus();
+			}
 		},
 	},
 	highjumpkick: {

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -701,6 +701,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			for (const pokemon of source.side.pokemon) {
 				if (!pokemon.hasAbility('soundproof')) pokemon.cureStatus(true);
 			}
+			for (const ally of target.side.pokemon) {
+				if (!ally.hasAbility('soundproof')) ally.cureStatus(true);
+			}
 		},
 	},
 	healblock: {

--- a/data/mods/gen5/moves.ts
+++ b/data/mods/gen5/moves.ts
@@ -355,6 +355,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			for (const pokemon of source.side.pokemon) {
 				pokemon.cureStatus();
 			}
+			for (const ally of target.side.pokemon) {
+				ally.cureStatus();
+			}
 		},
 	},
 	healpulse: {

--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -325,11 +325,14 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	healbell: {
 		inherit: true,
-		onHit(pokemon, source) {
+		onHit(target, source) {
 			this.add('-activate', source, 'move: Heal Bell');
-			const side = pokemon.side;
 			let success = false;
-			for (const ally of side.pokemon) {
+			for (const pokemon of source.side.pokemon) {
+				if (pokemon.hasAbility('soundproof')) continue;
+				if (pokemon.cureStatus()) success = true;
+			}
+			for (const ally of target.side.pokemon) {
 				if (ally.hasAbility('soundproof')) continue;
 				if (ally.cureStatus()) success = true;
 			}

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -7709,7 +7709,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		onHit(target, source) {
 			this.add('-activate', source, 'move: Heal Bell');
 			let success = false;
-			for (const pokemon of source.side.pokemon) {				
+			for (const pokemon of source.side.pokemon) {
 				if (pokemon !== source && pokemon.hasAbility('soundproof')) continue;
 				if (pokemon.cureStatus()) success = true;
 			}

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -7706,11 +7706,14 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {snatch: 1, sound: 1, distance: 1, bypasssub: 1},
-		onHit(pokemon, source) {
+		onHit(target, source) {
 			this.add('-activate', source, 'move: Heal Bell');
-			const side = pokemon.side;
 			let success = false;
-			for (const ally of side.pokemon) {
+			for (const pokemon of source.side.pokemon) {				
+				if (pokemon !== source && pokemon.hasAbility('soundproof')) continue;
+				if (pokemon.cureStatus()) success = true;
+			}
+			for (const ally of target.side.pokemon) {
 				if (ally !== source && ally.hasAbility('soundproof')) continue;
 				if (ally.cureStatus()) success = true;
 			}

--- a/test/sim/moves/healbell.js
+++ b/test/sim/moves/healbell.js
@@ -25,7 +25,7 @@ describe('Heal Bell', function () {
 		assert.equal(battle.p1.pokemon[1].status, '');
 	});
 
-	it.skip(`in a Multi Battle, should heal the major status conditions of the ally's team`, function () {
+	it(`in a Multi Battle, should heal the major status conditions of the ally's team`, function () {
 		battle = common.createBattle({gameType: 'multi'}, [[
 			{species: 'Machamp', ability: 'noguard', moves: ['poisongas']},
 		], [

--- a/test/sim/moves/healbell.js
+++ b/test/sim/moves/healbell.js
@@ -43,20 +43,23 @@ describe('Heal Bell', function () {
 		assert.equal(battle.p2.pokemon[1].status, '', `Diggersby should not be poisoned.`);
 		assert.equal(battle.p4.pokemon[0].status, '', `Wynaut should not be poisoned.`);
 
+		// Heal Bell should work from p2 as well as p4
 		battle = common.createBattle({gameType: 'multi'}, [[
 			{species: 'Machamp', ability: 'noguard', moves: ['poisongas']},
 		], [
-			{species: 'Diggersby', moves: ['sleeptalk', 'healbell']},
+			{species: 'Wynaut', moves: ['sleeptalk', 'healbell']},
 		], [
 			{species: 'Marowak', moves: ['sleeptalk']},
 		], [
-			{species: 'Wynaut', moves: ['sleeptalk']},
+			{species: 'Cubone', moves: ['sleeptalk']},
+			{species: 'Diggersby', moves: ['sleeptalk']},
 		]]);
 
 		battle.makeChoices();
-		battle.makeChoices('auto', 'move healbell', 'auto', 'auto');
-		assert.equal(battle.p2.pokemon[0].status, '', `Diggersby should not be poisoned.`);
-		assert.equal(battle.p4.pokemon[0].status, '', `Wynaut should not be poisoned.`);
+		battle.makeChoices('auto', 'move healbell', 'auto', 'switch diggersby');
+		assert.equal(battle.p4.pokemon[0].status, '', `Cubone should not be poisoned.`);
+		assert.equal(battle.p4.pokemon[1].status, '', `Diggersby should not be poisoned.`);
+		assert.equal(battle.p2.pokemon[0].status, '', `Wynaut should not be poisoned.`);
 	});
 
 	it(`in a Free-For-All, should heal the major status conditions of the user's team, and not any opposing teams`, function () {

--- a/test/sim/moves/healbell.js
+++ b/test/sim/moves/healbell.js
@@ -42,6 +42,21 @@ describe('Heal Bell', function () {
 		assert.equal(battle.p2.pokemon[0].status, '', `Cubone should not be poisoned.`);
 		assert.equal(battle.p2.pokemon[1].status, '', `Diggersby should not be poisoned.`);
 		assert.equal(battle.p4.pokemon[0].status, '', `Wynaut should not be poisoned.`);
+
+		battle = common.createBattle({gameType: 'multi'}, [[
+			{species: 'Machamp', ability: 'noguard', moves: ['poisongas']},
+		], [
+			{species: 'Diggersby', moves: ['sleeptalk', 'healbell']},
+		], [
+			{species: 'Marowak', moves: ['sleeptalk']},
+		], [
+			{species: 'Wynaut', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		battle.makeChoices('auto', 'move healbell', 'auto', 'auto');
+		assert.equal(battle.p2.pokemon[0].status, '', `Diggersby should not be poisoned.`);
+		assert.equal(battle.p4.pokemon[0].status, '', `Wynaut should not be poisoned.`);
 	});
 
 	it(`in a Free-For-All, should heal the major status conditions of the user's team, and not any opposing teams`, function () {


### PR DESCRIPTION
https://github.com/smogon/pokemon-showdown/projects/3#card-69825838

Previously the move only checks the target's side or the source's side, this will make the move only heal one player's pokemons in Multi Battle.
This change will let Heal Bell heal both the user and ally's team, which should be the expected behavior of this move.