### PR TITLE
Convert Max Guard to a whitelist

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -10420,16 +10420,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 			},
 			onTryHitPriority: 3,
 			onTryHit(target, source, move) {
-				if (['gmaxoneblow', 'gmaxrapidflow'].includes(move.id)) return;
-				/** moves blocked by Max Guard but not Protect */
-				const overrideBypassProtect = [
-					'block', 'flowershield', 'gearup', 'magneticflux', 'phantomforce', 'psychup', 'shadowforce', 'teatime', 'transform', 'whirlwind',
+				const bypassesMaxGuard = [
+					'acupressure', 'afteryou', 'allyswitch', 'aromatherapy', 'aromaticmist', 'coaching', 'confide', 'copycat', 'curse', 'decorate', 'doomdesire', 'feint', 'futuresight', 'gmaxoneblow', 'gmaxrapidflow', 'healbell', 'holdhands', 'howl', 'junglehealing', 'lifedew', 'meanlook', 'perishsong', 'playnice', 'powertrick', 'roar', 'roleplay', 'tearfullook',
 				];
-				const blockedByMaxGuard = (this.dex.moves.get(move.id).flags['protect'] ||
-						move.isZ || move.isMax || overrideBypassProtect.includes(move.id));
-				if (!blockedByMaxGuard) {
-					return;
-				}
+				if (bypassesMaxGuard.includes(move.id)) return;
 				if (move.smartTarget) {
 					move.smartTarget = false;
 				} else {


### PR DESCRIPTION
Thanks to new research from Anubis, we now know that Max Guard is treated more like a whitelist rather than a "allow all moves that bypass Protect except these" type of check. Because we're pulling this data from BDSP, though, our data doesn't include any of the DLC moves; however, empirical testing helps bridge that gap. This is the list from BDSP:

> 'acupressure', 'afteryou', 'allyswitch', 'aromatherapy', 'aromaticmist', 'confide', 'copycat', 'curse', 'decorate', 'feint', 'futuresight', 'healbell', 'holdhands', 'howl', 'lifedew', 'meanlook', 'perishsong', 'playnice', 'powertrick', 'roar', 'roleplay', 'tearfullook',

These are the additional moves known from empirical testing post-DLC that also bypass Max Guard:

> 'coaching', 'doomdesire', 'gmaxoneblow', 'gmaxrapidflow', 'junglehealing', 

PS's current implementation allows a number of moves that bypass Max Guard that shouldn't, including moves like Hyperspace Fury or Helping Hand, so this change also fixes up those.