### PR TITLE
Fix interaction of failed Z heal replacements

### DIFF
--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1435,7 +1435,7 @@ export class BattleActions {
 				this.battle.heal(pokemon.maxhp, pokemon, pokemon, zPower);
 				break;
 			case 'healreplacement':
-				pokemon.side.addSlotCondition(pokemon, 'healreplacement', pokemon);
+				pokemon.side.addSlotCondition(pokemon, 'healreplacement', pokemon, move);
 				break;
 			case 'clearnegativeboost':
 				const boosts: SparseBoostsTable = {};

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1436,7 +1436,6 @@ export class BattleActions {
 				break;
 			case 'healreplacement':
 				pokemon.side.addSlotCondition(pokemon, 'healreplacement', pokemon);
-				// move.self = {slotCondition: 'healreplacement'};
 				break;
 			case 'clearnegativeboost':
 				const boosts: SparseBoostsTable = {};

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1435,7 +1435,8 @@ export class BattleActions {
 				this.battle.heal(pokemon.maxhp, pokemon, pokemon, zPower);
 				break;
 			case 'healreplacement':
-				move.self = {slotCondition: 'healreplacement'};
+				pokemon.side.addSlotCondition(pokemon, 'healreplacement', pokemon);
+				// move.self = {slotCondition: 'healreplacement'};
 				break;
 			case 'clearnegativeboost':
 				const boosts: SparseBoostsTable = {};

--- a/test/sim/moves/memento.js
+++ b/test/sim/moves/memento.js
@@ -32,12 +32,12 @@ describe(`Memento`, function () {
 		assert.equal(battle.requestState, 'move');
 	});
 
-	it.skip(`should set the Z-Memento healing flag even if the Memento itself was not successful`, function () {
+	it(`should set the Z-Memento healing flag even if the Memento itself was not successful`, function () {
 		battle = common.createBattle([[
-			{species: 'landorus', ability: 'noguard', moves: ['sleeptalk']},
-			{species: 'whimsicott', ability: 'noguard', item: 'darkiniumz', moves: ['memento']},
+			{species: 'landorus', moves: ['sleeptalk']},
+			{species: 'whimsicott', item: 'darkiniumz', moves: ['memento']},
 		], [
-			{species: 'wynaut', ability: 'prankster', moves: ['circlethrow', 'substitute']},
+			{species: 'wynaut', ability: 'noguard', moves: ['circlethrow', 'substitute']},
 		]]);
 		battle.makeChoices('auto', 'move substitute');
 		battle.makeChoices();


### PR DESCRIPTION
Z-Parting Shot and Z-Memento should succeed in healing their targets even if the move fails for some reason (e.g. Clear Body, Substitute). This change directly adds the side condition, rather than replacing it as the current active move (?) which could cause it to fail early and not use the Z-Power when it should always be doing that.