### PR TITLE
Gen 3-4: Fix Snatch when used by multiple pokemon

### DIFF
--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -1433,6 +1433,27 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			return !pokemon.volatiles['choicelock'] && !pokemon.volatiles['encore'];
 		},
 	},
+	snatch: {
+		inherit: true,
+		condition: {
+			duration: 1,
+			onStart(pokemon) {
+				this.add('-singleturn', pokemon, 'Snatch');
+			},
+			onAnyPrepareHitPriority: -1,
+			onAnyPrepareHit(source, target, move) {
+				const snatchUser = this.effectState.source;
+				if (snatchUser.isSkyDropped()) return;
+				if (!move || move.isZ || move.isMax || !move.flags['snatch']) {
+					return;
+				}
+				snatchUser.removeVolatile('snatch');
+				this.add('-activate', snatchUser, 'move: Snatch', '[of] ' + source);
+				this.actions.useMove(move.id, snatchUser);
+				return null;
+			},
+		},
+	},
 	spikes: {
 		inherit: true,
 		flags: {},

--- a/test/sim/moves/snatch.js
+++ b/test/sim/moves/snatch.js
@@ -97,16 +97,16 @@ describe('Snatch [Gen 4]', function () {
 	});
 
 	it.skip(`should only deduct additional PP from Snatch if the Snatch was successful`, function () {
-        battle = common.gen(4).createBattle([[
-            {species: 'Palkia', ability: 'pressure', moves: ['watergun', 'calmmind']},
-        ], [
-            {species: 'Dialga', moves: ['snatch']},
-        ]]);
-        battle.makeChoices();
-        const move = battle.p2.active[0].getMoveData(Dex.moves.get('snatch'));
-        assert.equal(move.pp, move.maxpp - 1, `Snatch should only lose 1 PP because it was not successful.`);
+		battle = common.gen(4).createBattle([[
+			{species: 'Palkia', ability: 'pressure', moves: ['watergun', 'calmmind']},
+		], [
+		{species: 'Dialga', moves: ['snatch']},
+		]]);
+		battle.makeChoices();
+		const move = battle.p2.active[0].getMoveData(Dex.moves.get('snatch'));
+		assert.equal(move.pp, move.maxpp - 1, `Snatch should only lose 1 PP because it was not successful.`);
 
-        battle.makeChoices('move calmmind', 'move snatch');
-        assert.equal(move.pp, move.maxpp - 3, `Snatch should be at 13 PP after losing 1 PP earlier and 2 PP this turn`);
-    });
+		battle.makeChoices('move calmmind', 'move snatch');
+		assert.equal(move.pp, move.maxpp - 3, `Snatch should be at 13 PP after losing 1 PP earlier and 2 PP this turn`);
+	});
 });

--- a/test/sim/moves/snatch.js
+++ b/test/sim/moves/snatch.js
@@ -100,7 +100,7 @@ describe('Snatch [Gen 4]', function () {
 		battle = common.gen(4).createBattle([[
 			{species: 'Palkia', ability: 'pressure', moves: ['watergun', 'calmmind']},
 		], [
-		{species: 'Dialga', moves: ['snatch']},
+			{species: 'Dialga', moves: ['snatch']},
 		]]);
 		battle.makeChoices();
 		const move = battle.p2.active[0].getMoveData(Dex.moves.get('snatch'));

--- a/test/sim/moves/snatch.js
+++ b/test/sim/moves/snatch.js
@@ -83,7 +83,7 @@ describe('Snatch [Gen 4]', function () {
 		battle.destroy();
 	});
 
-	it('should benefit the slowest user of Snatch if multiple Pokemon use Snatch in the same turn', function () {
+	it('should Snatch moves that were called by another user of Snatch', function () {
 		battle = common.gen(4).createBattle({gameType: 'doubles'}, [[
 			{species: 'weavile', moves: ['snatch']},
 			{species: 'wynaut', moves: ['howl']},

--- a/test/sim/moves/snatch.js
+++ b/test/sim/moves/snatch.js
@@ -77,3 +77,36 @@ describe('Snatch', function () {
 		assert.match(battle.log[battle.lastMoveLine + 2], /^\|cant.*move: Heal Block\|Recover$/, 'should log that Recover failed');
 	});
 });
+
+describe('Snatch [Gen 4]', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should benefit the slowest user of Snatch if multiple Pokemon use Snatch in the same turn', function () {
+		battle = common.gen(4).createBattle({gameType: 'doubles'}, [[
+			{species: 'weavile', moves: ['snatch']},
+			{species: 'wynaut', moves: ['howl']},
+		], [
+			{species: 'alakazam', moves: ['snatch']},
+			{species: 'wynaut', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		assert.statStage(battle.p2.active[0], 'atk', 1);
+	});
+
+	it.skip(`should only deduct additional PP from Snatch if the Snatch was successful`, function () {
+        battle = common.gen(4).createBattle([[
+            {species: 'Palkia', ability: 'pressure', moves: ['watergun', 'calmmind']},
+        ], [
+            {species: 'Dialga', moves: ['snatch']},
+        ]]);
+        battle.makeChoices();
+        const move = battle.p2.active[0].getMoveData(Dex.moves.get('snatch'));
+        assert.equal(move.pp, move.maxpp - 1, `Snatch should only lose 1 PP because it was not successful.`);
+
+        battle.makeChoices('move calmmind', 'move snatch');
+        assert.equal(move.pp, move.maxpp - 3, `Snatch should be at 13 PP after losing 1 PP earlier and 2 PP this turn`);
+    });
+});


### PR DESCRIPTION
According to Bulbapedia and the long description of the move here on showdown, Snatch should be able to steal moves that were called by another user of Snatch.