### PR TITLE
Extend /repeat multiline pattern for all commands

### DIFF
--- a/server/chat-plugins/repeats.ts
+++ b/server/chat-plugins/repeats.ts
@@ -293,5 +293,5 @@ export const commands: Chat.ChatCommands = {
 };
 
 process.nextTick(() => {
-	Chat.multiLinePattern.register('/repeat ');
+	Chat.multiLinePattern.register('/repeat(html|faq)?(bymessages)? ');
 });


### PR DESCRIPTION
I figured instead of writing down all 6 command variations I'd just use regex for this one