### PR TITLE
Use uhtml for repeats to prevent flooding

### DIFF
--- a/server/chat-plugins/repeats.ts
+++ b/server/chat-plugins/repeats.ts
@@ -96,7 +96,7 @@ export const Repeats = new class {
 			const repeatedPhrase = repeat.faq ?
 				visualizeFaq(roomFaqs[targetRoom.roomid][repeat.id]) : Chat.formatText(phrase, true);
 			const formattedText = repeat.isHTML ? phrase : repeatedPhrase;
-			targetRoom.add(`|html|<div class="infobox">${formattedText}</div>`);
+			targetRoom.add(`|uhtml|repeat-${repeat.id}|<div class="infobox">${formattedText}</div>`);
 			targetRoom.update();
 		};
 


### PR DESCRIPTION
I did not test this code, but I did check to make sure I got the uhtml protocol right (which I did). The only way this could go wrong is if somehow the `repeat#id` property doesn't exist.