### PR TITLE
Fix healing moves to use healing failure messages

### DIFF
--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -819,7 +819,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	purify: {
 		inherit: true,
 		onHit(target, source) {
-			if (!target.cureStatus()) false;
+			if (!target.cureStatus()) return false;
 			this.heal(Math.ceil(source.maxhp * 0.5), source);
 		},
 	},

--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -240,6 +240,25 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	floralhealing: {
+		inherit: true,
+		onHit(target, source) {
+			let success = false;
+			if (this.field.isTerrain('grassyterrain')) {
+				success = !!this.heal(this.modify(target.baseMaxhp, 0.667));
+			} else {
+				success = !!this.heal(Math.ceil(target.baseMaxhp * 0.5));
+			}
+			if (success && !target.isAlly(source)) {
+				target.staleness = 'external';
+			}
+			if (!success) {
+				this.add('-fail', target, 'heal');
+				return null;
+			}
+			return success;
+		},
+	},
 	foresight: {
 		inherit: true,
 		isNonstandard: null,
@@ -358,6 +377,25 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	healorder: {
 		inherit: true,
 		isNonstandard: null,
+	},
+	healpulse: {
+		inherit: true,
+		onHit(target, source) {
+			let success = false;
+			if (source.hasAbility('megalauncher')) {
+				success = !!this.heal(this.modify(target.baseMaxhp, 0.75));
+			} else {
+				success = !!this.heal(Math.ceil(target.baseMaxhp * 0.5));
+			}
+			if (success && !target.isAlly(source)) {
+				target.staleness = 'external';
+			}
+			if (!success) {
+				this.add('-fail', target, 'heal');
+				return null;
+			}
+			return success;
+		},
 	},
 	heartstamp: {
 		inherit: true,
@@ -608,6 +646,54 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	moonlight: {
+		inherit: true,
+		onHit(pokemon) {
+			let factor = 0.5;
+			switch (pokemon.effectiveWeather()) {
+			case 'sunnyday':
+			case 'desolateland':
+				factor = 0.667;
+				break;
+			case 'raindance':
+			case 'primordialsea':
+			case 'sandstorm':
+			case 'hail':
+				factor = 0.25;
+				break;
+			}
+			const success = !!this.heal(this.modify(pokemon.maxhp, factor));
+			if (!success) {
+				this.add('-fail', pokemon, 'heal');
+				return null;
+			}
+			return success;
+		},
+	},
+	morningsun: {
+		inherit: true,
+		onHit(pokemon) {
+			let factor = 0.5;
+			switch (pokemon.effectiveWeather()) {
+			case 'sunnyday':
+			case 'desolateland':
+				factor = 0.667;
+				break;
+			case 'raindance':
+			case 'primordialsea':
+			case 'sandstorm':
+			case 'hail':
+				factor = 0.25;
+				break;
+			}
+			const success = !!this.heal(this.modify(pokemon.maxhp, factor));
+			if (!success) {
+				this.add('-fail', pokemon, 'heal');
+				return null;
+			}
+			return success;
+		},
+	},
 	mudbomb: {
 		inherit: true,
 		isNonstandard: null,
@@ -651,6 +737,14 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	pollenpuff: {
 		inherit: true,
 		flags: {bullet: 1, protect: 1, mirror: 1},
+		onHit(target, source) {
+			if (source.isAlly(target)) {
+				if (!this.heal(Math.floor(target.baseMaxhp * 0.5))) {
+					this.add('-immune', target);
+					return null;
+				}
+			}
+		},
 	},
 	powder: {
 		inherit: true,
@@ -721,6 +815,13 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	punishment: {
 		inherit: true,
 		isNonstandard: null,
+	},
+	purify: {
+		inherit: true,
+		onHit(target, source) {
+			if (!target.cureStatus()) false;
+			this.heal(Math.ceil(source.maxhp * 0.5), source);
+		},
 	},
 	pursuit: {
 		inherit: true,
@@ -815,6 +916,21 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	shoreup: {
+		inherit: true,
+		onHit(pokemon) {
+			let factor = 0.5;
+			if (this.field.isWeather('sandstorm')) {
+				factor = 0.667;
+			}
+			const success = !!this.heal(this.modify(pokemon.maxhp, factor));
+			if (!success) {
+				this.add('-fail', pokemon, 'heal');
+				return null;
+			}
+			return success;
+		},
+	},
 	signalbeam: {
 		inherit: true,
 		isNonstandard: null,
@@ -898,6 +1014,16 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	swallow: {
+		inherit: true,
+		onHit(pokemon) {
+			const healAmount = [0.25, 0.5, 1];
+			const success = !!this.heal(this.modify(pokemon.maxhp, healAmount[(pokemon.volatiles['stockpile'].layers - 1)]));
+			if (!success) this.add('-fail', pokemon, 'heal');
+			pokemon.removeVolatile('stockpile');
+			return success || null;
+		},
+	},
 	switcheroo: {
 		inherit: true,
 		onHit(target, source, move) {
@@ -934,6 +1060,30 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	synchronoise: {
 		inherit: true,
 		isNonstandard: null,
+	},
+	synthesis: {
+		inherit: true,
+		onHit(pokemon) {
+			let factor = 0.5;
+			switch (pokemon.effectiveWeather()) {
+			case 'sunnyday':
+			case 'desolateland':
+				factor = 0.667;
+				break;
+			case 'raindance':
+			case 'primordialsea':
+			case 'sandstorm':
+			case 'hail':
+				factor = 0.25;
+				break;
+			}
+			const success = !!this.heal(this.modify(pokemon.maxhp, factor));
+			if (!success) {
+				this.add('-fail', pokemon, 'heal');
+				return null;
+			}
+			return success;
+		},
 	},
 	tailglow: {
 		inherit: true,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -9225,7 +9225,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {heal: 1, bypasssub: 1, allyanim: 1},
 		onHit(pokemon) {
-			const success = !!this.heal(this.modify(pokemon.maxhp, 0.25)) || pokemon.cureStatus();
+			const success = pokemon.cureStatus() || !!this.heal(this.modify(pokemon.maxhp, 0.25));
 			return success ? success : this.NOT_FAIL;
 		},
 		secondary: null,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -13417,11 +13417,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		onHit(target, source) {
 			if (!target.cureStatus()) return this.NOT_FAIL;
 			const success = !!this.heal(Math.ceil(source.maxhp * 0.5), source);
-			if (!success) {
-				this.add('-fail', target, 'heal');
-				return this.NOT_FAIL;
-			}
-			return success;
+			return success ? success : this.NOT_FAIL;
 		},
 		secondary: null,
 		target: "normal",

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -13416,8 +13416,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {protect: 1, reflectable: 1, heal: 1},
 		onHit(target, source) {
 			if (!target.cureStatus()) return this.NOT_FAIL;
-			const success = !!this.heal(Math.ceil(source.maxhp * 0.5), source);
-			return success || this.NOT_FAIL;
+			this.heal(Math.ceil(source.maxhp * 0.5), source);
 		},
 		secondary: null,
 		target: "normal",

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -17411,12 +17411,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		onHit(pokemon) {
 			const healAmount = [0.25, 0.5, 1];
 			const success = !!this.heal(this.modify(pokemon.maxhp, healAmount[(pokemon.volatiles['stockpile'].layers - 1)]));
+			if (!success) this.add('-fail', pokemon, 'heal');
 			pokemon.removeVolatile('stockpile');
-			if (!success) {
-				this.add('-fail', pokemon, 'heal');
-				return this.NOT_FAIL;
-			}
-			return success;
+			return success ? success : this.NOT_FAIL;
 		},
 		secondary: null,
 		target: "self",

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -9226,7 +9226,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {heal: 1, bypasssub: 1, allyanim: 1},
 		onHit(pokemon) {
 			const success = pokemon.cureStatus() || !!this.heal(this.modify(pokemon.maxhp, 0.25));
-			return success ? success : this.NOT_FAIL;
+			return success || this.NOT_FAIL;
 		},
 		secondary: null,
 		target: "allies",
@@ -13417,7 +13417,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		onHit(target, source) {
 			if (!target.cureStatus()) return this.NOT_FAIL;
 			const success = !!this.heal(Math.ceil(source.maxhp * 0.5), source);
-			return success ? success : this.NOT_FAIL;
+			return success || this.NOT_FAIL;
 		},
 		secondary: null,
 		target: "normal",
@@ -17413,7 +17413,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			const success = !!this.heal(this.modify(pokemon.maxhp, healAmount[(pokemon.volatiles['stockpile'].layers - 1)]));
 			if (!success) this.add('-fail', pokemon, 'heal');
 			pokemon.removeVolatile('stockpile');
-			return success ? success : this.NOT_FAIL;
+			return success || this.NOT_FAIL;
 		},
 		secondary: null,
 		target: "self",

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -5320,6 +5320,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 			if (success && !target.isAlly(source)) {
 				target.staleness = 'external';
 			}
+			if (!success) {
+				this.add('-fail', target, 'heal');
+				return this.NOT_FAIL;
+			}
 			return success;
 		},
 		secondary: null,
@@ -7854,6 +7858,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 			if (success && !target.isAlly(source)) {
 				target.staleness = 'external';
 			}
+			if (!success) {
+				this.add('-fail', target, 'heal');
+				return this.NOT_FAIL;
+			}
 			return success;
 		},
 		secondary: null,
@@ -9217,8 +9225,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {heal: 1, bypasssub: 1, allyanim: 1},
 		onHit(pokemon) {
-			const success = !!this.heal(this.modify(pokemon.maxhp, 0.25));
-			return pokemon.cureStatus() || success;
+			const success = !!this.heal(this.modify(pokemon.maxhp, 0.25)) || pokemon.cureStatus();
+			return success ? success : this.NOT_FAIL;
 		},
 		secondary: null,
 		target: "allies",
@@ -11514,7 +11522,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 				factor = 0.25;
 				break;
 			}
-			return !!this.heal(this.modify(pokemon.maxhp, factor));
+			const success = !!this.heal(this.modify(pokemon.maxhp, factor));
+			if (!success) {
+				this.add('-fail', pokemon, 'heal');
+				return this.NOT_FAIL;
+			}
+			return success;
 		},
 		secondary: null,
 		target: "self",
@@ -11545,7 +11558,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 				factor = 0.25;
 				break;
 			}
-			return !!this.heal(this.modify(pokemon.maxhp, factor));
+			const success = !!this.heal(this.modify(pokemon.maxhp, factor));
+			if (!success) {
+				this.add('-fail', pokemon, 'heal');
+				return this.NOT_FAIL;
+			}
+			return success;
 		},
 		secondary: null,
 		target: "self",
@@ -12734,6 +12752,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			if (source.isAlly(target)) {
 				if (!this.heal(Math.floor(target.baseMaxhp * 0.5))) {
 					this.add('-immune', target);
+					return this.NOT_FAIL;
 				}
 			}
 		},
@@ -13396,8 +13415,13 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, heal: 1},
 		onHit(target, source) {
-			if (!target.cureStatus()) return false;
-			this.heal(Math.ceil(source.maxhp * 0.5), source);
+			if (!target.cureStatus()) return this.NOT_FAIL;
+			const success = !!this.heal(Math.ceil(source.maxhp * 0.5), source);
+			if (!success) {
+				this.add('-fail', target, 'heal');
+				return this.NOT_FAIL;
+			}
+			return success;
 		},
 		secondary: null,
 		target: "normal",
@@ -15255,7 +15279,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 			if (this.field.isWeather('sandstorm')) {
 				factor = 0.667;
 			}
-			return !!this.heal(this.modify(pokemon.maxhp, factor));
+			const success = !!this.heal(this.modify(pokemon.maxhp, factor));
+			if (!success) {
+				this.add('-fail', pokemon, 'heal');
+				return this.NOT_FAIL;
+			}
+			return success;
 		},
 		secondary: null,
 		target: "self",
@@ -17385,9 +17414,13 @@ export const Moves: {[moveid: string]: MoveData} = {
 		},
 		onHit(pokemon) {
 			const healAmount = [0.25, 0.5, 1];
-			const healedBy = this.heal(this.modify(pokemon.maxhp, healAmount[(pokemon.volatiles['stockpile'].layers - 1)]));
+			const success = !!this.heal(this.modify(pokemon.maxhp, healAmount[(pokemon.volatiles['stockpile'].layers - 1)]));
 			pokemon.removeVolatile('stockpile');
-			return !!healedBy;
+			if (!success) {
+				this.add('-fail', pokemon, 'heal');
+				return this.NOT_FAIL;
+			}
+			return success;
 		},
 		secondary: null,
 		target: "self",
@@ -17550,7 +17583,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 				factor = 0.25;
 				break;
 			}
-			return !!this.heal(this.modify(pokemon.maxhp, factor));
+			const success = !!this.heal(this.modify(pokemon.maxhp, factor));
+			if (!success) {
+				this.add('-fail', pokemon, 'heal');
+				return this.NOT_FAIL;
+			}
+			return success;
 		},
 		secondary: null,
 		target: "self",

--- a/test/sim/moves/stompingtantrum.js
+++ b/test/sim/moves/stompingtantrum.js
@@ -105,6 +105,75 @@ describe('Stomping Tantrum', function () {
 		battle.makeChoices('move stompingtantrum', 'auto');
 	});
 
+	it(`should double its Base Power on some failure conditions of Rest`, function () {
+		battle = common.createBattle([[
+			{species: 'Magikarp', ability: 'comatose', moves: ['rest', 'stompingtantrum']},
+			{species: 'Feebas', ability: 'insomnia', moves: ['rest', 'stompingtantrum']},
+		], [
+			{species: 'Accelgor', moves: ['sleeptalk', 'nightshade']},
+		]]);
+
+		battle.onEvent('BasePower', battle.format, function (basePower, pokemon, target, move) {
+			if (move.id === 'stompingtantrum') assert.equal(basePower, 150);
+		});
+
+		battle.makeChoices('move rest', 'auto'); // Rest while user already asleep or Comatose
+		battle.makeChoices('move stompingtantrum', 'auto');
+
+		battle.makeChoices('switch 2', 'auto');
+		battle.makeChoices('move rest', 'auto'); // Rest while user at full HP
+		battle.makeChoices('move stompingtantrum', 'auto');
+
+		battle.makeChoices('move rest', 'move nightshade'); // Rest while has Insomnia
+		battle.makeChoices('move stompingtantrum', 'auto');
+	});
+
+	it.skip(`should not double its Base Power on other failure conditions of Rest`, function () {
+		battle = common.createBattle([[
+			{species: 'Magikarp', moves: ['rest', 'stompingtantrum', 'defog']},
+		], [
+			{species: 'Accelgor', moves: ['sleeptalk', 'nightshade', 'electricterrain', 'mistyterrain']},
+		]]);
+
+		battle.onEvent('BasePower', battle.format, function (basePower, pokemon, target, move) {
+			if (move.id === 'stompingtantrum') assert.equal(basePower, 75);
+		});
+
+		battle.makeChoices('move rest', 'move electricterrain');
+		battle.makeChoices('move rest', 'move nightshade'); // Rest in Electric Terrain
+		battle.makeChoices('move stompingtantrum', 'auto');
+
+		battle.makeChoices('move rest', 'move mistyterrain'); // Rest in Misty Terrain
+		battle.makeChoices('move stompingtantrum', 'auto');
+
+		battle.makeChoices('move defog', 'auto');
+		battle.makeChoices('move rest', 'move uproar'); // Rest in Uproar
+		battle.makeChoices('move stompingtantrum', 'auto');
+	});
+
+	it.skip(`should not double its Base Power on most failed healing effects`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Magikarp', moves: ['roost', 'lifedew', 'healpulse', 'stompingtantrum']},
+			{species: 'Feebas', moves: ['shoreup', 'junglehealing', 'pollenpuff', 'stompingtantrum']},
+		], [
+			{species: 'Accelgor', moves: ['sleeptalk']},
+			{species: 'Accelgor', moves: ['sleeptalk']},
+		]]);
+
+		battle.onEvent('BasePower', battle.format, function (basePower, pokemon, target, move) {
+			if (move.id === 'stompingtantrum') assert.equal(basePower, 75);
+		});
+
+		battle.makeChoices('move roost, move shoreup', 'auto');
+		battle.makeChoices('move stompingtantrum 1, move stompingtantrum 1', 'auto');
+
+		battle.makeChoices('move lifedew, move junglehealing', 'auto');
+		battle.makeChoices('move stompingtantrum 1, move stompingtantrum 1', 'auto');
+
+		battle.makeChoices('move healpulse -2, move pollenpuff -1', 'auto');
+		battle.makeChoices('move stompingtantrum 1, move stompingtantrum 1', 'auto');
+	});
+
 	it(`should cause Gravity-negated moves to double in BP, even Z-moves`, function () {
 		battle = common.gen(7).createBattle([[
 			{species: "Magikarp", item: 'normaliumz', moves: ['splash', 'stompingtantrum']},


### PR DESCRIPTION
Mostly, what this PR does is use healing failure messages on moves that don't have straightforward healing (Floral Healing, Heal Pulse, Moonlight, Morning Sun, Shore Up, Swallow, and Synthesis). Instead of giving "But it failed!" it'll show "[POKEMON]'s HP is full!" which matters a bit for revealing Heal Pulse / Floral Healing's target in doubles. Pollen Puff and Jungle Healing also have nonstandard healing failure messages but they were already accounted for.

Since we're talking about healing failure messages, the healing move failures themselves shouldn't double Stomping Tantrum (except for Rest because it wants to be special). Although all of the particular healing edge cases can be set to ``this.NOT_FAIL`` pretty easily, I don't know how to set the general healing cases, like Slack Off or Roost, to use ``this.NOT_FAIL`` (around lines 1136-1140 of battle-actions.ts).

I also adjusted Swallow's HP failure text to be before Stockpile is removed, consistent with Gen 8.