### PR TITLE
Implement VGC 2022

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -387,6 +387,14 @@ export const Formats: FormatList = [
 		banlist: ['Corsola-Galar', 'Cutiefly', 'Ponyta-Base', 'Scyther', 'Sneasel', 'Swirlix', 'Tangela', 'Vulpix', 'Vulpix-Alola'],
 	},
 	{
+		name: "[Gen 8] VGC 2022",
+
+		mod: 'gen8',
+		gameType: 'doubles',
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 8', 'VGC Timer', 'Limit Two Restricted'],
+		restricted: ['Restricted Legendary'],
+	},
+	{
 		name: "[Gen 8] VGC 2021 Series 11",
 		threads: [
 			`&bullet; <a href="https://www.smogon.com/forums/threads/3677186/">VGC 2021 Series 11 Metagame Discussion</a>`,


### PR DESCRIPTION
[Details](https://twitter.com/VGCVictoryRoad/status/1477222934523564033)

Officially the series goes from Feb - August 2022, but we like to get the new formats up early. Since this will be the main format throughout the year, VGC is dropping the [Series] prefix for this one and just going with VGC 2022. Once the current format expires in January (Series 11), Series 9 will be namechanged to "VGC 2021" and that will be our permanent legacy format.

I haven't had a chance to talk with the BSS guys about what they want done yet.