### PR TITLE
Gen 1: Fix visual bug with Haze

### DIFF
--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -407,8 +407,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				pokemon.clearBoosts();
 
 				if (pokemon !== source) {
-					// Clears the status from the opponent
-					pokemon.setStatus('');
+					pokemon.cureStatus(true);
 				}
 				if (pokemon.status === 'tox') {
 					pokemon.setStatus('psn');


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-9067020

Haze uses `setStatus('')` to clear the status of the opponent. Doing that by itself does not send a message to the client that the status was cleared. This is not a problem for most other places `setStatus('')` is used since they send other client messages that handle removing the status, but it is an issue for Haze (see bug report above).

The way I chose to fix this was to create a new client message `-clearstatus`, which handles silently removing the status of a pokemon. I've changed some occurrences of `clearStatus()` to `setStatus('')` since those moves don't need the extra client message to be sent.