### PR TITLE
SQL: Propagate errors to the parent process

### DIFF
--- a/server/modlog/index.ts
+++ b/server/modlog/index.ts
@@ -8,7 +8,7 @@
  * @license MIT
  */
 
-import {FS, SQL, Utils} from '../../lib';
+import {SQL, Utils} from '../../lib';
 import {Config} from '../config-loader';
 
 // If a modlog query takes longer than this, it will be logged.
@@ -97,9 +97,16 @@ export class Modlog {
 	constructor(databasePath: string, options: Partial<SQL.Options>) {
 		this.queuedEntries = [];
 		this.databaseReady = false;
-		const dbExists = FS(databasePath).existsSync();
+		if (!options.onError) {
+			options.onError = (error, data, isParent) => {
+				if (!isParent) return;
+				Monitor.crashlog(error, 'A modlog SQLite query', {
+					query: JSON.stringify(data),
+				});
+			};
+		}
 		this.database = SQL(module, {
-			file: MODLOG_DB_PATH,
+			file: databasePath,
 			extension: 'server/modlog/transactions.ts',
 			...options,
 		});
@@ -123,18 +130,19 @@ export class Modlog {
 			}
 		}
 
-		this.readyPromise = this.setupDatabase(dbExists).then(result => {
+		this.readyPromise = this.setupDatabase().then(result => {
 			this.databaseReady = result;
 			this.readyPromise = null;
 		});
 	}
 
-	async setupDatabase(dbExists: boolean) {
+	async setupDatabase() {
 		if (!Config.usesqlite) return false;
 		await this.database.exec("PRAGMA foreign_keys = ON;");
 		await this.database.exec(`PRAGMA case_sensitive_like = true;`);
 
 		// Set up tables, etc
+		const dbExists = await this.database.get(`SELECT * FROM sqlite_master WHERE name = 'modlog'`);
 		if (!dbExists) {
 			await this.database.runFile(MODLOG_SCHEMA_PATH);
 		}

--- a/test/server/modlog.js
+++ b/test/server/modlog.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const ModlogConstructor = Config.usesqlite ? (require('../../server/modlog')).Modlog : null;
-const modlog = ModlogConstructor ? new ModlogConstructor(':memory:') : null;
+const modlog = ModlogConstructor ? new ModlogConstructor(':memory:', {}) : null;
 const assert = require('assert').strict;
 
 Config.usesqlitemodlog = true;


### PR DESCRIPTION
This propagates errors to the parent process so promises properly reject. 
In doing so, it also fixes an issue with modlog creating tables several times accidentally in tests (which failed them).