### PR TITLE
UNO: Fix the turn sequence when a user is disqualified

### DIFF
--- a/server/chat-plugins/uno.ts
+++ b/server/chat-plugins/uno.ts
@@ -249,6 +249,10 @@ export class UNO extends Rooms.RoomGame {
 				this.sendToRoom(`|raw|${Utils.escapeHTML(name)} has not picked a color, the color will stay as <span style="color: ${textColors[this.topCard.changedColor]}">${this.topCard.changedColor}</span>.`);
 			}
 		}
+		if (this.isPlusFour) {
+			this.isPlusFour = false;
+			this.onNextPlayer();
+		}
 		if (this.awaitUno === userid) this.awaitUno = null;
 		if (!this.topCard) {
 			throw new Chat.ErrorMessage(`Unable to disqualify ${name}.`);
@@ -257,8 +261,9 @@ export class UNO extends Rooms.RoomGame {
 		// put that player's cards into the discard pile to prevent cards from being permanently lost
 		this.discards.push(...this.playerTable[userid].hand);
 
+		this.onNextPlayer();
 		this.removePlayer(this.playerTable[userid]);
-		this.nextTurn();
+		this.nextTurn(true);
 		return name;
 	}
 


### PR DESCRIPTION
The bug: The turn is always passed to the first in the player list when a user is disqualified from UNO