### PR TITLE
Spotlights: Don't give an image parameter in source if no image was used

### DIFF
--- a/server/chat-plugins/daily-spotlight.ts
+++ b/server/chat-plugins/daily-spotlight.ts
@@ -292,7 +292,7 @@ export const commands: Chat.ChatCommands = {
 		this.sendReplyBox(html);
 		if (!this.broadcasting && user.can('ban', null, room, 'setdaily')) {
 			const code = Utils.escapeHTML(description).replace(/\n/g, '<br />');
-			this.sendReplyBox(`<details><summary>Source</summary><code style="white-space: pre-wrap; display: table; tab-size: 3">/setdaily ${key},${image},${code}</code></details>`);
+			this.sendReplyBox(`<details><summary>Source</summary><code style="white-space: pre-wrap; display: table; tab-size: 3">/setdaily ${key},${image ? `${image},` : ''}${code}</code></details>`);
 		}
 		room.update();
 	},


### PR DESCRIPTION
Prevents an undefined variable from being showcased in source if there is no image being used for the daily.

Before:
![before](https://user-images.githubusercontent.com/96159984/148613899-f1f06fcc-7255-4ecc-8ff2-790be989f939.png)

After:
![after](https://user-images.githubusercontent.com/96159984/148613897-211ebe58-1750-4a4e-87c6-f4f9fd7ca34e.png)