### PR TITLE
Allow bots to receive private mod actions

### DIFF
--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -328,7 +328,7 @@ export abstract class BasicRoom {
 		if (this.userCount) Sockets.roomBroadcast(this.roomid, message);
 	}
 	sendMods(data: string) {
-		this.sendRankedUsers(data, '%');
+		this.sendRankedUsers(data, '*');
 	}
 	sendRankedUsers(data: string, minRank: GroupSymbol = '+') {
 		if (this.settings.staffRoom) {


### PR DESCRIPTION
This seems like a leftover from when bots were ranked above moderators, and nobody ever noticed that that piece of functionality changed. If this is intended then disregard my PR :)