### PR TITLE
Implement secondaries stat chance overflow

### DIFF
--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1272,7 +1272,10 @@ export class BattleActions {
 				this.battle.runEvent('ModifySecondaries', target, source, moveData, moveData.secondaries.slice());
 			for (const secondary of secondaries) {
 				const secondaryRoll = this.battle.random(100);
-				if (typeof secondary.chance === 'undefined' || secondaryRoll < secondary.chance) {
+				// User stat boosts or target stat drops can possibly overflow if it goes beyond 256
+				const secondaryOverflow = (secondary.boosts || secondary.self);
+				if (typeof secondary.chance === 'undefined' ||
+					secondaryRoll < (secondaryOverflow ? secondary.chance % 256 : secondary.chance)) {
 					this.moveHit(target, source, move, secondary, true, isSelf);
 				}
 			}

--- a/test/sim/abilities/serencegrace.js
+++ b/test/sim/abilities/serencegrace.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe(`Serene Grace`, function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it(`should not stack Pledge Rainbow for flinches`, function () {
+		// hardcoded RNG seed to not flinch if it was 60% odds
+		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 5]}, [[
+			{species: 'wynaut', ability: 'serenegrace', moves: ['bite', 'waterpledge']},
+			{species: 'wobbuffet', ability: 'serenegrace', moves: ['sleeptalk', 'firepledge']},
+		], [
+			{species: 'pyukumuku', ability: 'steadfast', moves: ['sleeptalk']},
+			{species: 'feebas', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move waterpledge 1, move firepledge 1', 'auto');
+		battle.makeChoices('move bite 1, move sleeptalk', 'auto');
+
+		const pyuk = battle.p2.active[0];
+		assert.statStage(pyuk, 'spe', 0);
+	});
+
+	it(`should overflow when quadrupling a stat drop effect with Pledge Rainbow`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'wynaut', ability: 'serenegrace', moves: ['poweruppunch', 'waterpledge']},
+			{species: 'wobbuffet', ability: 'serenegrace', moves: ['acidspray', 'firepledge']},
+		], [
+			{species: 'magikarp', moves: ['sleeptalk']},
+			{species: 'feebas', moves: ['sleeptalk']},
+		]]);
+
+		// Modding secondary chances so it will either always apply or never apply
+		// (64 * 2 * 2) % 256 === 0
+		Dex.moves.get('poweruppunch').secondaries[0].chance = 64;
+		Dex.moves.get('acidspray').secondaries[0].chance = 64;
+
+		battle.makeChoices('move waterpledge 1, move firepledge 1', 'auto');
+		battle.makeChoices('move poweruppunch 1, move acidspray 2', 'auto');
+
+		const wynaut = battle.p1.active[0];
+		assert.statStage(wynaut, 'atk', 0);
+		const feebas = battle.p2.active[1];
+		assert.statStage(feebas, 'spd', 0);
+	});
+
+	it(`should not overflow when quadrupling a status effect with Pledge Rainbow`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'wynaut', ability: 'serenegrace', moves: ['nuzzle', 'waterpledge']},
+			{species: 'wobbuffet', ability: 'serenegrace', moves: ['flamethrower', 'firepledge']},
+		], [
+			{species: 'magikarp', moves: ['sleeptalk']},
+			{species: 'feebas', moves: ['sleeptalk']},
+		]]);
+
+		// Modding secondary chances so it will either always apply or never apply
+		// (64 * 2 * 2) % 256 === 0
+		Dex.moves.get('nuzzle').secondaries[0].chance = 64;
+		Dex.moves.get('flamethrower').secondaries[0].chance = 64;
+
+		battle.makeChoices('move waterpledge 1, move firepledge 1', 'auto');
+		battle.makeChoices('move nuzzle 1, move flamethrower 2', 'auto');
+
+		const magikarp = battle.p2.active[0];
+		assert.equal(magikarp.status, 'par');
+		const feebas = battle.p2.active[1];
+		assert.equal(feebas.status, 'brn');
+	});
+});

--- a/test/sim/abilities/serenegrace.js
+++ b/test/sim/abilities/serenegrace.js
@@ -10,7 +10,7 @@ describe(`Serene Grace`, function () {
 		battle.destroy();
 	});
 
-	it(`should not stack Pledge Rainbow for flinches`, function () {
+	it(`should not stack with Pledge Rainbow for flinches`, function () {
 		// hardcoded RNG seed to not flinch if it was 60% odds
 		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 5]}, [[
 			{species: 'wynaut', ability: 'serenegrace', moves: ['bite', 'waterpledge']},

--- a/test/sim/abilities/serenegrace.js
+++ b/test/sim/abilities/serenegrace.js
@@ -38,8 +38,13 @@ describe(`Serene Grace`, function () {
 
 		// Modding secondary chances so it will either always apply or never apply
 		// (64 * 2 * 2) % 256 === 0
-		Dex.moves.get('poweruppunch').secondaries[0].chance = 64;
-		Dex.moves.get('acidspray').secondaries[0].chance = 64;
+		battle.onEvent('ModifyMove', battle.format, 1, function (move) {
+			if (move.secondaries) {
+				for (const secondary of move.secondaries) {
+					secondary.chance = 64;
+				}
+			}
+		});
 
 		battle.makeChoices('move waterpledge 1, move firepledge 1', 'auto');
 		battle.makeChoices('move poweruppunch 1, move acidspray 2', 'auto');
@@ -61,8 +66,13 @@ describe(`Serene Grace`, function () {
 
 		// Modding secondary chances so it will either always apply or never apply
 		// (64 * 2 * 2) % 256 === 0
-		Dex.moves.get('nuzzle').secondaries[0].chance = 64;
-		Dex.moves.get('flamethrower').secondaries[0].chance = 64;
+		battle.onEvent('ModifyMove', battle.format, 1, function (move) {
+			if (move.secondaries) {
+				for (const secondary of move.secondaries) {
+					secondary.chance = 64;
+				}
+			}
+		});
 
 		battle.makeChoices('move waterpledge 1, move firepledge 1', 'auto');
 		battle.makeChoices('move nuzzle 1, move flamethrower 2', 'auto');


### PR DESCRIPTION
For stat increases, and plausibly stat drops, secondaries will overflow when both Serene Grace and Pledge Rainbow are simultaneously active. This is because the variable that stores the value is an unsigned 8-bit integer. The only move this affects is Charge Beam. See the [battle mechanics research thread](https://www.smogon.com/forums/posts/9076566/) for more details on its discovery.

In battle-actions, in addition to the ``secondaries`` function, there's another function called ``selfDrops`` that also checks for secondary chances as far as I can tell, but it seems to be unused throughout the codebase. I have no idea what it does but don't think it needs to be touched here.