### PR TITLE
Fix Bird-type crashes

### DIFF
--- a/data/mods/ssb/abilities.ts
+++ b/data/mods/ssb/abilities.ts
@@ -1572,7 +1572,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			if (!pokemon.hp) return;
 			const types = pokemon.moveSlots.map(slot => this.dex.moves.get(slot.id).type);
 			const type = types.length ? this.sample(types) : '???';
-			if (pokemon.setType(type)) {
+			if (this.dex.types.isName(type) && pokemon.setType(type)) {
 				this.add('-ability', pokemon, 'Wild Magic Surge');
 				this.add('-start', pokemon, 'typechange', type);
 			}

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1834,7 +1834,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 		name: "Revelationmons Mod",
 		desc: `The moves in the first slot(s) of a Pok&eacute;mon's set have their types changed to match the Pok&eacute;mon's type(s).`,
 		onBegin() {
-			this.add('rule', 'Revelationmons Mod: The first moveslots have their types changed to match the Pok&eacute;mon\'s types');
+			this.add('rule', 'Revelationmons Mod: The first moveslots have their types changed to match the Pok\u00e9mon\'s types');
 		},
 		onValidateSet(set) {
 			const species = this.dex.species.get(set.species);
@@ -1856,6 +1856,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 			];
 			if (noModifyType.includes(move.id)) return;
 			for (const [i, type] of types.entries()) {
+				if (!this.dex.types.isName(type)) continue;
 				if (pokemon.moveSlots[i] && move.id === pokemon.moveSlots[i].id) move.type = type;
 			}
 		},


### PR DESCRIPTION
Bird-type has caused two recent independent crashes - one with Revelationmons, and one with some unholy combination of Shared Power + Super Staff Bros 4. Both crashes are fixed by not allowing the Bird-type to be set in those scenarios. I also fixed a typo in Revelationmons message at the start of the battle.