### PR TITLE
Prevent setting timer after a game has ended

### DIFF
--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -234,6 +234,10 @@ export class RoomBattleTimer {
 	start(requester?: User) {
 		const userid = requester ? requester.id : 'staff' as ID;
 		if (this.timerRequesters.has(userid)) return false;
+		if (this.battle.ended && requester) {
+			this.battle.playerTable[requester.id].sendRoom(`|inactiveoff|The timer can't be enabled after a battle has ended.`);
+			return false;
+		}
 		if (this.timer) {
 			this.battle.room.add(`|inactive|${requester ? requester.name : userid} also wants the timer to be on.`).update();
 			this.timerRequesters.add(userid);

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -234,8 +234,8 @@ export class RoomBattleTimer {
 	start(requester?: User) {
 		const userid = requester ? requester.id : 'staff' as ID;
 		if (this.timerRequesters.has(userid)) return false;
-		if (this.battle.ended && requester) {
-			requester.sendTo(this.battle.roomid, `|inactiveoff|The timer can't be enabled after a battle has ended.`);
+		if (this.battle.ended) {
+			requester?.sendTo(this.battle.roomid, `|inactiveoff|The timer can't be enabled after a battle has ended.`);
 			return false;
 		}
 		if (this.timer) {

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -235,7 +235,7 @@ export class RoomBattleTimer {
 		const userid = requester ? requester.id : 'staff' as ID;
 		if (this.timerRequesters.has(userid)) return false;
 		if (this.battle.ended && requester) {
-			this.battle.playerTable[requester.id].sendRoom(`|inactiveoff|The timer can't be enabled after a battle has ended.`);
+			requester.sendTo(this.battle.roomid, `|inactiveoff|The timer can't be enabled after a battle has ended.`);
 			return false;
 		}
 		if (this.timer) {


### PR DESCRIPTION
I'm trying to fix the bug where if a user has ticked the "automatically start timer" box, it will display that the timer has started after the battle has ended. To approach this, I want to do the following:

1. When attempting to set timer manually after the battle has ended, fail loudly to only the user.
2. When Config.timer is set to true but the battle has ended, don't send a start timer request at all.

The issue with 1) is apparently when calling ``sendRoom``, in that function, it thinks the user object is ``null`` after a game completes, despite the user existing just fine in the ``playerTable``. The issue with 2) is that the timer is set way before the ``.ended`` state of the battle is updated. So it'll always be false by the end of the constructor and you can't use it to check if the game's really ended before starting the timer. Edit: 2) is not a server-side problem, it's client-side!

The easiest way around this would just be to have starting the timer fail quietly after a game ends, but I'm not sure if that's best practice. Advice is appreciated!