### PR TITLE
Prevent illegal evolutions from activating Eviolite

### DIFF
--- a/data/items.ts
+++ b/data/items.ts
@@ -1552,13 +1552,15 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		onModifyDefPriority: 2,
 		onModifyDef(def, pokemon) {
-			if (pokemon.baseSpecies.nfe) {
+			if (pokemon.baseSpecies.nfe &&
+				pokemon.baseSpecies.evos?.some(x => !this.dex.species.get(x).isNonstandard)) {
 				return this.chainModify(1.5);
 			}
 		},
 		onModifySpDPriority: 2,
 		onModifySpD(spd, pokemon) {
-			if (pokemon.baseSpecies.nfe) {
+			if (pokemon.baseSpecies.nfe &&
+				pokemon.baseSpecies.evos?.some(x => !this.dex.species.get(x).isNonstandard)) {
 				return this.chainModify(1.5);
 			}
 		},


### PR DESCRIPTION
It's currently possible to successfully run Ursaring with an Eviolite when it supposedly shouldn't work, this should hopefully fix that.