### PR TITLE
Godly Gift: Ban Mantine and luck items

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -919,7 +919,7 @@ export const Formats: FormatList = [
 		banlist: [
 			'Blissey', 'Calyrex-Shadow', 'Chansey', 'Dragapult', 'Hawlucha', 'Mantine', 'Marowak-Alola', 'Melmetal', 'Pikachu', 'Toxapex',
 			'Xerneas', 'Zacian', 'Zacian-Crowned', 'Uber > 1', 'AG ++ Uber > 1', 'Arena Trap', 'Huge Power', 'Moody', 'Pure Power',
-			'Shadow Tag', 'Baton Pass', 'King\'s Rock', 'Quick Claw', 'Bright Powder', 'Lax Incense', 'Focus Band',
+			'Shadow Tag', 'Bright Powder', 'Focus Band', 'King\'s Rock', 'Lax Incense', 'Quick Claw', 'Baton Pass',
 		],
 		onValidateTeam(team) {
 			const gods = new Set<string>();


### PR DESCRIPTION
Godly Gift has banned Mantine, King's Rock, Quick Claw, Bright Powder, Lax Incense, and Focus Band. Proof of the bans can be found here: https://www.smogon.com/forums/threads/godly-gift.3660461/post-9106404