### PR TITLE
Pokebilities: Streamline ability bans

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1643,6 +1643,21 @@ export const Formats: FormatList = [
 			// Shadow Tag/Arena Trap
 			'Diglett-Base', 'Dugtrio-Base', 'Gothita', 'Gothitelle', 'Gothorita', 'Trapinch', 'Wobbuffet', 'Wynaut',
 		],
+		onValidateSet(set) {
+			const species = this.dex.species.get(set.species);
+			const unSeenAbilities = Object.keys(species.abilities)
+				.filter(key => key !== 'S' && (key !== 'H' || !species.unreleasedHidden))
+				.map(key => species.abilities[key as "0" | "1" | "H" | "S"])
+				.filter(ability => ability !== set.ability);
+			if (unSeenAbilities.length && this.toID(set.ability) !== this.toID(species.abilities['S'])) {
+				for (const abilityName of unSeenAbilities) {
+					const banReason = this.ruleTable.check('ability:' + this.toID(abilityName));
+					if (banReason) {
+						return [`${set.name}'s ability ${abilityName} is ${banReason}.`];
+					}
+				}
+			}
+		},
 		onBegin() {
 			for (const pokemon of this.getAllPokemon()) {
 				if (pokemon.ability === this.toID(pokemon.species.abilities['S'])) {

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1548,6 +1548,19 @@ export class TeamValidator {
 
 		setHas['ability:' + ability.id] = true;
 
+		if (this.format.id === 'gen8pokebilities') {
+			const species = dex.species.get(set.species);
+			const unSeenAbilities = Object.keys(species.abilities)
+				.filter(key => key !== 'S' && (key !== 'H' || !species.unreleasedHidden))
+				.map(key => species.abilities[key as "0" | "1" | "H" | "S"]);
+
+			if (ability.id !== this.toID(species.abilities['S'])) {
+				for (const abilityName of unSeenAbilities) {
+					setHas['ability:' + toID(abilityName)] = true;
+				}
+			}
+		}
+
 		let banReason = ruleTable.check('ability:' + ability.id);
 		if (banReason) {
 			return `${set.name}'s ability ${ability.name} is ${banReason}.`;


### PR DESCRIPTION
Allows one to ban abilities without having to go through every single pokemon who has said ability. This also eases complex banning in pokebilities which makes tournament codes exponentially more condensed.