### PR TITLE
Support classifying message toxicity locally

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,6 +4,7 @@ data/mods/ssb/ @HoeenCoder @KrisXV
 data/random-teams.ts @AnnikaCodes
 data/text/ @Marty-D
 databases/ @monsanto
+server/artemis/* @mia-pi-git
 server/chat-plugins/friends.ts @mia-pi-git
 server/chat-plugins/github.ts @mia-pi-git
 server/chat-plugins/hosts.ts @AnnikaCodes

--- a/server/artemis/README.md
+++ b/server/artemis/README.md
@@ -1,0 +1,10 @@
+# Artemis
+
+This is the source code for PS's moderation AI, Artemis. 
+
+It has two versions, one local and one remote.
+
+The remote version uses Google's `Perspective API` to classify messages, and requires a key set in `Config.perspectiveKey`.
+
+The local version uses `detoxify` to classify messages. Before using it, run `./server/artemis/install` (this script installs dependencies and the model the local version uses).
+

--- a/server/artemis/index.ts
+++ b/server/artemis/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @author mia-pi-git
+ */
+import {LocalClassifier} from './local';
+import {RemoteClassifier} from './remote';
+
+export {LocalClassifier, RemoteClassifier};
+
+export function destroy() {
+	void LocalClassifier.PM.destroy();
+	void RemoteClassifier.PM.destroy();
+}

--- a/server/artemis/index.ts
+++ b/server/artemis/index.ts
@@ -7,6 +7,6 @@ import {RemoteClassifier} from './remote';
 export {LocalClassifier, RemoteClassifier};
 
 export function destroy() {
-	void LocalClassifier.PM.destroy();
+	void LocalClassifier.destroy();
 	void RemoteClassifier.PM.destroy();
 }

--- a/server/artemis/install
+++ b/server/artemis/install
@@ -1,4 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+set -o errexit
+set -o errtrace
 cd server/artemis/
 python3 -m pip install -r requirements.txt > /dev/null
 echo "Dependencies installed. Starting model installation..."

--- a/server/artemis/install
+++ b/server/artemis/install
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+cd server/artemis/
+python3 -m pip install -r requirements.txt > /dev/null
+echo "Dependencies installed. Starting model installation..."
+python3 -c "import detoxify; detoxify.Detoxify('unbiased')" > /dev/null
+echo "Model installed. Local classifier is ready to use."

--- a/server/artemis/local.ts
+++ b/server/artemis/local.ts
@@ -1,0 +1,152 @@
+/**
+ * Typescript wrapper around the Python Artemis model.
+ * By Mia.
+ * @author mia-pi-git
+ */
+
+import * as child_process from 'child_process';
+import {ProcessManager, Streams, Utils, Repl} from '../../lib';
+import {Config} from '../config-loader';
+import {toID} from '../../sim/dex-data';
+
+class ArtemisStream extends Streams.ObjectReadWriteStream<string> {
+	tasks = new Set<string>();
+	private process: child_process.ChildProcessWithoutNullStreams;
+	constructor() {
+		super();
+		this.process = child_process.spawn('python3', [
+			'-u', __dirname + '/model.py', Config.debugartemisprocesses ? "debug" : "",
+		].filter(Boolean));
+		this.listen();
+	}
+	listen() {
+		this.process.stdout.setEncoding('utf8');
+		this.process.stderr.setEncoding('utf8');
+		this.process.stdout.on('data', (data) => {
+			// so many bugs were created by \nready\n
+			data = data.trim();
+			const [taskId, dataStr] = data.split("|");
+			if (this.tasks.has(taskId)) {
+				this.tasks.delete(taskId);
+				return this.push(`${taskId}\n${dataStr}`);
+			}
+			if (taskId === 'error') { // there was a major crash and the script is no longer running
+				const info = JSON.parse(dataStr);
+				Monitor.crashlog(new Error(info.error), "An Artemis script", info);
+				try {
+					this.pushEnd(); // push end first so the stream always closes
+					this.process.disconnect();
+				} catch {}
+			}
+		});
+		this.process.stderr.on('data', data => {
+			data += "";
+			Monitor.crashlog(new Error(data), "An Artemis process");
+		});
+		this.process.on('error', err => {
+			Monitor.crashlog(err, "An Artemis process");
+			this.pushEnd();
+		});
+		this.process.on('close', () => {
+			this.pushEnd();
+		});
+	}
+	_write(chunk: string) {
+		const [taskId, message] = Utils.splitFirst(chunk, '\n');
+		this.tasks.add(taskId);
+		this.process.stdin.write(`${taskId}|${message}\n`);
+	}
+}
+
+export const PM = new ProcessManager.StreamProcessManager(module, () => new ArtemisStream(), message => {
+	if (message.startsWith('SLOW\n')) {
+		Monitor.slow(message.slice(5));
+	}
+});
+
+export class LocalClassifier {
+	static readonly PM = PM;
+	/** If stream exists, model is usable */
+	stream?: Streams.ObjectReadWriteStream<string>;
+	enabled = false;
+	requests = new Map<number, (data: any) => void>();
+	lastTask = 0;
+	readyPromise: Promise<boolean> | null = null;
+	constructor() {
+		void this.setupProcesses();
+	}
+	async setupProcesses() {
+		this.readyPromise = new Promise(resolve => {
+			child_process.exec('python3 -c "import detoxify"', (err, out, stderr) => {
+				if (err || stderr) {
+					resolve(false);
+				} else {
+					resolve(true);
+				}
+			});
+		});
+		const res = await this.readyPromise;
+		this.enabled = res;
+		this.readyPromise = null;
+		if (res) {
+			this.stream = PM.createStream();
+			void this.listen();
+		}
+	}
+	async listen() {
+		if (!this.stream) return null;
+		for await (const chunk of this.stream) {
+			const [rawTaskId, data] = Utils.splitFirst(chunk, '\n');
+			const task = parseInt(rawTaskId);
+			const resolver = this.requests.get(task);
+			if (resolver) {
+				resolver(JSON.parse(data));
+				this.requests.delete(task);
+			}
+		}
+	}
+	destroy() {
+		return this.stream?.destroy();
+	}
+	async classify(text: string) {
+		if (this.readyPromise) await this.readyPromise;
+		if (!this.stream) return null;
+		const taskId = this.lastTask++;
+		const data = await new Promise<any>(resolve => {
+			this.requests.set(taskId, resolve);
+			void this.stream?.write(`${taskId}\n${text}`);
+		});
+		for (const k in data) {
+			// floats have to be made into strings because python's json.dumps
+			// doesn't like float32s
+			data[k] = parseFloat(data[k]);
+		}
+		return data as Record<string, number>;
+	}
+}
+
+// main module check necessary since this gets required in other non-parent processes sometimes
+// when that happens we do not want to take over or set up or anything
+if (!PM.isParentProcess && require.main === module) {
+	// This is a child process!
+	global.Config = Config;
+	global.Monitor = {
+		crashlog(error: Error, source = 'A local Artemis child process', details: AnyObject | null = null) {
+			const repr = JSON.stringify([error.name, error.message, source, details]);
+			process.send!(`THROW\n@!!@${repr}\n${error.stack}`);
+		},
+		slow(text: string) {
+			process.send!(`CALLBACK\nSLOW\n${text}`);
+		},
+	};
+	global.toID = toID;
+	process.on('uncaughtException', err => {
+		if (Config.crashguard) {
+			Monitor.crashlog(err, 'A local Artemis child process');
+		}
+	});
+	// eslint-disable-next-line no-eval
+	Repl.start(`abusemonitor-local-${process.pid}`, cmd => eval(cmd));
+} else if (PM.isParentProcess) {
+	PM.spawn(Config.localartemisprocesses || 1);
+}

--- a/server/artemis/local.ts
+++ b/server/artemis/local.ts
@@ -40,7 +40,6 @@ class ArtemisStream extends Streams.ObjectReadWriteStream<string> {
 			}
 		});
 		this.process.stderr.on('data', data => {
-			data += "";
 			Monitor.crashlog(new Error(data), "An Artemis process");
 		});
 		this.process.on('error', err => {

--- a/server/artemis/model.py
+++ b/server/artemis/model.py
@@ -24,19 +24,17 @@ def now():
 
 logfile = open("logs/artemis.log", "a")
 def log(message):
-	if not debug:
-		return None
-
-	logfile.write(str(now()) + ":" + str.rstrip(message) + "\n")
-	logfile.flush()
+	if debug:
+		logfile.write(f"{str(now())}:{str.rstrip(message)}\n")
+		logfile.flush()
 
 print("ready", flush=True)
 log("ready")
 try:
 	for line in sys.stdin:
-		log("in:" + line)
+		log(f"in:{line}")
 		parts = line.split("|")
-		out = parts.pop(0) + "|"
+		out = f"{parts.pop(0)}|"
 		try:
 			res = model.predict("|".join(parts))
 			for key in res: res[key] = str(res[key]) # json.dumps doesn't like floats
@@ -44,7 +42,7 @@ try:
 		except BaseException as e:
 			out += json.dumps({'error': f"{e}"})
 
-		log("out:" + out)
+		log(f"out:{out}")
 
 		print(out, flush=True)
 except BaseException as e:

--- a/server/artemis/model.py
+++ b/server/artemis/model.py
@@ -1,0 +1,53 @@
+# This file handles the actual processing of messages,
+# and sends them back to the parent process.
+# @author: mia-pi-git
+from detoxify import Detoxify;
+import sys;
+import time;
+import json;
+
+model_name = 'unbiased'
+debug = False
+
+if "multilingual" in sys.argv:
+	model_name = 'multilingual'
+elif "small" in sys.argv:
+	model_name += '-small'
+
+if "debug" in sys.argv:
+	debug = True
+
+model = Detoxify(model_name)
+
+def now():
+	return int(time.time() * 1000)
+
+logfile = open("logs/artemis.log", "a")
+def log(message):
+	if not debug:
+		return None
+
+	logfile.write(str(now()) + ":" + str.rstrip(message) + "\n")
+	logfile.flush()
+
+print("ready", flush=True)
+log("ready")
+try:
+	for line in sys.stdin:
+		log("in:" + line)
+		parts = line.split("|")
+		out = parts.pop(0) + "|"
+		try:
+			res = model.predict("|".join(parts))
+			for key in res: res[key] = str(res[key]) # json.dumps doesn't like floats
+			out += json.dumps(res)
+		except BaseException as e:
+			out += json.dumps({'error': f"{e}"})
+
+		log("out:" + out)
+
+		print(out, flush=True)
+except BaseException as e:
+	print("error|" + json.dumps({'error': f"{e}"}))
+	log(f"majorerror:{e}")
+

--- a/server/artemis/remote.ts
+++ b/server/artemis/remote.ts
@@ -1,0 +1,176 @@
+/**
+ * Code for using Google's Perspective API for filters.
+ * @author mia-pi-git
+ */
+import {ProcessManager, Net, Repl} from '../../lib';
+import {Config} from '../config-loader';
+import {toID} from '../../sim/dex-data';
+
+// 20m. this is mostly here so we can use Monitor.slow()
+const PM_TIMEOUT = 20 * 60 * 1000;
+export const ATTRIBUTES = {
+	"SEVERE_TOXICITY": {},
+	"TOXICITY": {},
+	"IDENTITY_ATTACK": {},
+	"INSULT": {},
+	"PROFANITY": {},
+	"THREAT": {},
+	"SEXUALLY_EXPLICIT": {},
+	"FLIRTATION": {},
+};
+
+export interface PerspectiveRequest {
+	languages: string[];
+	requestedAttributes: AnyObject;
+	comment: {text: string};
+}
+
+function time() {
+	return Math.floor(Date.now() / 1000);
+}
+
+export class RollingCounter {
+	counts: number[] = [0];
+	readonly size: number;
+	constructor(limit: number) {
+		this.size = limit;
+	}
+	increment() {
+		this.counts[this.counts.length - 1]++;
+	}
+	rollOver(amount: number) {
+		if (amount > this.size) {
+			this.counts = Array(this.size).fill(0);
+			return;
+		}
+		for (let i = 0; i < amount; i++) {
+			this.counts.push(0);
+			if (this.counts.length > this.size) this.counts.shift();
+		}
+	}
+	mean() {
+		let total = 0;
+		for (const elem of this.counts) total += elem;
+		return total / this.counts.length;
+	}
+}
+
+export class Limiter {
+	readonly counter: RollingCounter;
+	readonly max: number;
+	lastCounterRoll = time();
+	constructor(max: number, period: number) {
+		this.max = max;
+		this.counter = new RollingCounter(period);
+	}
+	shouldRequest() {
+		const now = time();
+		this.counter.rollOver(now - this.lastCounterRoll);
+		this.lastCounterRoll = now;
+
+		if (this.counter.mean() > this.max) return false;
+		this.counter.increment();
+		return true;
+	}
+}
+
+function isCommon(message: string) {
+	message = message.toLowerCase().replace(/\?!\., ;:/g, '');
+	return ['gg', 'wp', 'ggwp', 'gl', 'hf', 'glhf', 'hello'].includes(message);
+}
+
+let throttleTime: number | null = null;
+export const limiter = new Limiter(15, 10);
+export const PM = new ProcessManager.QueryProcessManager<string, Record<string, number> | null>(module, async text => {
+	if (isCommon(text) || !limiter.shouldRequest()) return null;
+	if (throttleTime && (Date.now() - throttleTime < 10000)) {
+		return null;
+	}
+	if (throttleTime) throttleTime = null;
+
+	const requestData: PerspectiveRequest = {
+		// todo - support 'es', 'it', 'pt', 'fr' - use user.language? room.settings.language...?
+		languages: ['en'],
+		requestedAttributes: ATTRIBUTES,
+		comment: {text},
+	};
+	try {
+		const raw = await Net(`https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze`).post({
+			query: {
+				key: Config.perspectiveKey,
+			},
+			body: JSON.stringify(requestData),
+			headers: {
+				'Content-Type': "application/json",
+			},
+			timeout: 10 * 1000, // 10s
+		});
+		if (!raw) return null;
+		const data = JSON.parse(raw);
+		if (data.error) throw new Error(data.message);
+		const result: {[k: string]: number} = {};
+		for (const k in data.attributeScores) {
+			const score = data.attributeScores[k];
+			result[k] = score.summaryScore.value;
+		}
+		return result;
+	} catch (e: any) {
+		throttleTime = Date.now();
+		if (e.message.startsWith('Request timeout')) {
+			// just ignore this. error on their end not ours.
+			// todo maybe stop sending requests for a bit?
+			return null;
+		}
+		Monitor.crashlog(e, 'A Perspective API request', {request: JSON.stringify(requestData)});
+		return null;
+	}
+}, PM_TIMEOUT);
+
+
+// main module check necessary since this gets required in other non-parent processes sometimes
+// when that happens we do not want to take over or set up or anything
+if (!PM.isParentProcess && require.main === module) {
+	// This is a child process!
+	global.Config = Config;
+	global.Monitor = {
+		crashlog(error: Error, source = 'A remote Artemis child process', details: AnyObject | null = null) {
+			const repr = JSON.stringify([error.name, error.message, source, details]);
+			process.send!(`THROW\n@!!@${repr}\n${error.stack}`);
+		},
+		slow(text: string) {
+			process.send!(`CALLBACK\nSLOW\n${text}`);
+		},
+	};
+	global.toID = toID;
+	process.on('uncaughtException', err => {
+		if (Config.crashguard) {
+			Monitor.crashlog(err, 'A remote Artemis child process');
+		}
+	});
+	// eslint-disable-next-line no-eval
+	Repl.start(`abusemonitor-remote-${process.pid}`, cmd => eval(cmd));
+} else if (PM.isParentProcess) {
+	PM.spawn(Config.remoteartemisprocesses || 1);
+}
+
+export class RemoteClassifier {
+	static readonly PM = PM;
+	static readonly ATTRIBUTES = ATTRIBUTES;
+	classify(text: string) {
+		if (!Config.perspectiveKey) return Promise.resolve(null);
+		return PM.query(text);
+	}
+	destroy() {
+		return PM.destroy();
+	}
+	respawn() {
+		return PM.respawn();
+	}
+	spawn(number: number) {
+		PM.spawn(number);
+	}
+	getActiveProcesses() {
+		return PM.processes.length;
+	}
+}
+

--- a/server/artemis/requirements.txt
+++ b/server/artemis/requirements.txt
@@ -1,0 +1,1 @@
+detoxify

--- a/server/chat-plugins/abuse-monitor.ts
+++ b/server/chat-plugins/abuse-monitor.ts
@@ -7,24 +7,12 @@
  * by Mia.
  * @author mia-pi-git
  */
-
-import {FS, Utils, Net, ProcessManager, Repl} from '../../lib';
+import * as Artemis from '../artemis';
+import {FS, Utils} from '../../lib';
 import {Config} from '../config-loader';
 import {toID} from '../../sim/dex-data';
 
 const WHITELIST = ["mia"];
-// 20m. this is mostly here so we can use Monitor.slow()
-const PM_TIMEOUT = 20 * 60 * 1000;
-const ATTRIBUTES = {
-	"SEVERE_TOXICITY": {},
-	"TOXICITY": {},
-	"IDENTITY_ATTACK": {},
-	"INSULT": {},
-	"PROFANITY": {},
-	"THREAT": {},
-	"SEXUALLY_EXPLICIT": {},
-	"FLIRTATION": {},
-};
 const PUNISHMENTS = ['WARN', 'MUTE', 'LOCK', 'WEEKLOCK'];
 const NOJOIN_COMMAND_WHITELIST: {[k: string]: string} = {
 	'lock': '/lock',
@@ -94,16 +82,6 @@ interface FilterSettings {
 	punishments: PunishmentSettings[];
 }
 
-export interface PerspectiveRequest {
-	languages: string[];
-	requestedAttributes: AnyObject;
-	comment: {text: string};
-}
-
-interface PMRequest {
-	comment: string;
-	fullResponse?: boolean;
-}
 
 interface BattleInfo {
 	players: Record<SideID, ID>;
@@ -155,106 +133,7 @@ function colorName(id: ID, info: BattleInfo) {
 	return REPORT_NAMECOLORS.other;
 }
 
-function time() {
-	return Math.floor(Date.now() / 1000);
-}
-
-export class RollingCounter {
-	counts: number[] = [0];
-	readonly size: number;
-	constructor(limit: number) {
-		this.size = limit;
-	}
-	increment() {
-		this.counts[this.counts.length - 1]++;
-	}
-	rollOver(amount: number) {
-		if (amount > this.size) {
-			this.counts = Array(this.size).fill(0);
-			return;
-		}
-		for (let i = 0; i < amount; i++) {
-			this.counts.push(0);
-			if (this.counts.length > this.size) this.counts.shift();
-		}
-	}
-	mean() {
-		let total = 0;
-		for (const elem of this.counts) total += elem;
-		return total / this.counts.length;
-	}
-}
-
-export class Limiter {
-	readonly counter: RollingCounter;
-	readonly max: number;
-	lastCounterRoll = time();
-	constructor(max: number, period: number) {
-		this.max = max;
-		this.counter = new RollingCounter(period);
-	}
-	shouldRequest() {
-		const now = time();
-		this.counter.rollOver(now - this.lastCounterRoll);
-		this.lastCounterRoll = now;
-
-		if (this.counter.mean() > this.max) return false;
-		this.counter.increment();
-		return true;
-	}
-}
-
-function isCommon(message: string) {
-	message = message.toLowerCase().replace(/\?!\., ;:/g, '');
-	return ['gg', 'wp', 'ggwp', 'gl', 'hf', 'glhf', 'hello'].includes(message);
-}
-
-const limiter = new Limiter(15, 10);
-let throttleTime: number | null = null;
-export async function classify(text: string) {
-	if (isCommon(text) || !limiter.shouldRequest()) return null;
-	if (throttleTime && (Date.now() - throttleTime < 10000)) {
-		return null;
-	}
-	if (throttleTime) throttleTime = null;
-
-	const requestData: PerspectiveRequest = {
-		// todo - support 'es', 'it', 'pt', 'fr' - use user.language? room.settings.language...?
-		languages: ['en'],
-		requestedAttributes: ATTRIBUTES,
-		comment: {text},
-	};
-	try {
-		const raw = await Net(`https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze`).post({
-			query: {
-				key: Config.perspectiveKey,
-			},
-			body: JSON.stringify(requestData),
-			headers: {
-				'Content-Type': "application/json",
-			},
-			timeout: 10 * 1000, // 10s
-		});
-		if (!raw) return null;
-		const data = JSON.parse(raw);
-		if (data.error) throw new Error(data.message);
-		const result: {[k: string]: number} = {};
-		for (const k in data.attributeScores) {
-			const score = data.attributeScores[k];
-			result[k] = score.summaryScore.value;
-		}
-		return result;
-	} catch (e: any) {
-		throttleTime = Date.now();
-		if (e.message.startsWith('Request timeout')) {
-			// just ignore this. error on their end not ours.
-			// todo maybe stop sending requests for a bit?
-			return null;
-		}
-		Monitor.crashlog(e, 'A Perspective API request', {request: JSON.stringify(requestData)});
-		return null;
-	}
-}
+export const classifier = new Artemis.RemoteClassifier();
 
 async function recommend(user: User, room: GameRoom, response: Record<string, number>) {
 	const keys = Utils.sortBy(Object.keys(response), k => -response[k]);
@@ -330,41 +209,6 @@ function makeScore(roomid: RoomID, result: Record<string, number>) {
 	return {score, flags: [...flags], main};
 }
 
-type PMResult = Record<string, number> | null;
-export const PM = new ProcessManager.QueryProcessManager<PMRequest, PMResult>(module, async query => {
-	const result = await classify(query.comment);
-	if (!result) return null;
-	return result;
-}, PM_TIMEOUT, message => {
-	if (message.startsWith('SLOW\n')) {
-		Monitor.slow(message.slice(5));
-	}
-});
-
-if (!PM.isParentProcess) {
-	// This is a child process!
-	global.Config = Config;
-	global.Monitor = {
-		crashlog(error: Error, source = 'An abuse monitor child process', details: AnyObject | null = null) {
-			const repr = JSON.stringify([error.name, error.message, source, details]);
-			process.send!(`THROW\n@!!@${repr}\n${error.stack}`);
-		},
-		slow(text: string) {
-			process.send!(`CALLBACK\nSLOW\n${text}`);
-		},
-	};
-	global.toID = toID;
-	process.on('uncaughtException', err => {
-		if (Config.crashguard) {
-			Monitor.crashlog(err, 'A netfilter child process');
-		}
-	});
-	// eslint-disable-next-line no-eval
-	Repl.start(`abusemonitor-${process.pid}`, cmd => eval(cmd));
-} else {
-	PM.spawn(Config.netfilterprocesses || 1);
-}
-
 export const chatfilter: Chat.ChatFilter = function (message, user, room) {
 	// 2 lines to not hit max-len
 	if (!room?.battle || !['rated', 'unrated'].includes(room.battle.challengeType)) return;
@@ -374,7 +218,7 @@ export const chatfilter: Chat.ChatFilter = function (message, user, room) {
 
 	const roomid = room.roomid;
 	void (async () => {
-		const response = await PM.query({comment: message});
+		const response = await classifier.classify(message);
 		const {score, flags, main} = makeScore(roomid, response || {});
 		if (score) {
 			if (!cache[roomid]) cache[roomid] = {users: {}};
@@ -503,7 +347,7 @@ export const commands: Chat.ChatCommands = {
 			const text = target.trim();
 			if (!text) return this.parse(`/help abusemonitor`);
 			this.runBroadcast();
-			let response = await PM.query({comment: text, fullResponse: true});
+			let response = await classifier.classify(text);
 			if (!response) response = {};
 			// intentionally hardcoded to staff to ensure threshold is never altered.
 			const {score, flags} = makeScore('staff', response);
@@ -629,7 +473,7 @@ export const commands: Chat.ChatCommands = {
 		async respawn(target, room, user) {
 			checkAccess(this);
 			this.sendReply(`Respawning...`);
-			const unspawned = await PM.respawn();
+			const unspawned = await classifier.respawn();
 			this.sendReply(`DONE. ${Chat.count(unspawned, 'processes', 'process')} unspawned.`);
 			this.addGlobalModAction(`${user.name} used /abusemonitor respawn`);
 		},
@@ -687,7 +531,7 @@ export const commands: Chat.ChatCommands = {
 			let [rawType, rawPercent, rawScore] = target.split(',');
 			const type = rawType.toUpperCase().replace(/\s/g, '_');
 			rawScore = toID(rawScore);
-			const types = {...ATTRIBUTES, "ALL": {}};
+			const types = {...Artemis.RemoteClassifier.ATTRIBUTES, "ALL": {}};
 			if (!(type in types)) {
 				return this.errorReply(`Invalid type: ${type}. Valid types: ${Object.keys(types).join(', ')}.`);
 			}
@@ -725,7 +569,7 @@ export const commands: Chat.ChatCommands = {
 			checkAccess(this);
 			const [rawType, rawPercent] = target.split(',');
 			const type = rawType.toUpperCase().replace(/\s/g, '_');
-			const types = {...ATTRIBUTES, "ALL": {}};
+			const types = {...Artemis.RemoteClassifier.ATTRIBUTES, "ALL": {}};
 			if (!(type in types)) {
 				return this.errorReply(`Invalid type: ${type}. Valid types: ${Object.keys(types).join(', ')}.`);
 			}
@@ -798,10 +642,10 @@ export const commands: Chat.ChatCommands = {
 						return this.errorReply(`Duplicate type values.`);
 					}
 					value = value.replace(/\s/g, '_').toUpperCase();
-					if (!ATTRIBUTES[value as keyof typeof ATTRIBUTES]) {
+					if (!Artemis.RemoteClassifier.ATTRIBUTES[value as keyof typeof Artemis.RemoteClassifier.ATTRIBUTES]) {
 						return this.errorReply(
 							`Invalid attribute: ${value}. ` +
-							`Valid attributes: ${Object.keys(ATTRIBUTES).join(', ')}.`
+							`Valid attributes: ${Object.keys(Artemis.RemoteClassifier.ATTRIBUTES).join(', ')}.`
 						);
 					}
 					punishment.type = value;
@@ -1290,7 +1134,10 @@ export const pages: Chat.PageTable = {
 			buf += `<button class="button notifying" type="submit">Add punishment</button></details>`;
 			buf += `</form><br />`;
 			buf += `</div><div class="infobox"><h3>Scoring:</h3><hr />`;
-			const keys = Utils.sortBy(Object.keys(ATTRIBUTES), k => [-Object.keys(settings.specials[k] || {}).length, k]);
+			const keys = Utils.sortBy(
+				Object.keys(Artemis.RemoteClassifier.ATTRIBUTES),
+				k => [-Object.keys(settings.specials[k] || {}).length, k]
+			);
 			for (const k of keys) {
 				buf += `<strong>${k}</strong>:<br />`;
 				if (settings.specials[k]) {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -28,6 +28,7 @@ import type {Punishment} from './punishments';
 import type {PartialModlogEntry} from './modlog';
 import {FriendsDatabase, PM} from './friends';
 import {SQL, Repl, FS, Utils} from '../lib';
+import * as Artemis from './artemis';
 import {Dex} from '../sim';
 import {resolve} from 'path';
 import * as JSX from './chat-jsx';
@@ -1515,7 +1516,7 @@ export const Chat = new class {
 	commands!: AnnotatedChatCommands;
 	basePages!: PageTable;
 	pages!: PageTable;
-	readonly destroyHandlers: (() => void)[] = [];
+	readonly destroyHandlers: (() => void)[] = [Artemis.destroy];
 	readonly crqHandlers: {[k: string]: CRQHandler} = {};
 	readonly handlers: {[k: string]: ((...args: any) => any)[]} = Object.create(null);
 	/** The key is the name of the plugin. */


### PR DESCRIPTION
This PR both adds a local message classifier, and moves the code for the remote classifier using Perspective to a directory in server/. The local classifier is in server/artemis/local.ts, the remote is in server/artemis/remote.ts. The local classifier uses a python dependency to classify messages - the TS file uses `child_process.spawn` to wrap the script. It is kept in a StreamProcessManager, where each stream spawns an instance of the python process. This is done so the spawning isn't done in the main process, since that causes noticeable lag. The remote code was just copy/pasted from the abuse-monitor chat plugin.