### PR TITLE
Support automatically handling helptickets

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,7 @@ server/artemis/* @mia-pi-git
 server/chat-plugins/friends.ts @mia-pi-git
 server/chat-plugins/github.ts @mia-pi-git
 server/chat-plugins/hosts.ts @AnnikaCodes
+server/chat-plugins/helptickets*.ts @mia-pi-git
 server/chat-plugins/mafia.ts @HoeenCoder
 server/chat-plugins/othermetas.ts @KrisXV
 server/chat-plugins/quotes.ts @mia-pi-git @KrisXV

--- a/server/artemis/local.ts
+++ b/server/artemis/local.ts
@@ -75,6 +75,15 @@ export const PM = new ProcessManager.StreamProcessManager(module, () => new Arte
 
 export class LocalClassifier {
 	static readonly PM = PM;
+	static readonly ATTRIBUTES: Record<string, unknown> = {
+		sexual_explicit: {},
+		severe_toxicity: {},
+		toxicity: {},
+		obscene: {},
+		identity_attack: {},
+		insult: {},
+		threat: {},
+	};
 	static classifiers: LocalClassifier[] = [];
 	static destroy() {
 		for (const classifier of this.classifiers) classifier.destroy();

--- a/server/chat-plugins/helptickets-auto.ts
+++ b/server/chat-plugins/helptickets-auto.ts
@@ -159,7 +159,10 @@ function closeTicket(ticket: TicketState, msg?: string) {
 		seen: false,
 		staffReason: '',
 		result: msg || '',
-		note: `Want to learn more about the AI? <a href="https://570628/#post-9056769">Visit the information thread</a>.`,
+		note: (
+			`Want to learn more about the AI? ` +
+			`<a href="https://www.smogon.com/forums/threads/\3570628/#post-9056769">Visit the information thread</a>.`
+		),
 	};
 	writeTickets();
 	notifyStaff();
@@ -519,7 +522,6 @@ export async function runPunishments(ticket: TicketState & {text: [string, strin
 }
 
 export const commands: Chat.ChatCommands = {
-	ath: 'autohelpticket',
 	aht: 'autohelpticket',
 	autohelpticket: {
 		''() {

--- a/server/chat-plugins/helptickets-auto.ts
+++ b/server/chat-plugins/helptickets-auto.ts
@@ -53,8 +53,6 @@ function saveSettings() {
 	return FS('config/chat-plugins/ht-auto.json').writeUpdate(() => JSON.stringify(settings));
 }
 
-// partial is just to accept the 'partial' autopunishments done when they're created
-// (they aren't really partial but even if they are, it doesn't matter)
 function visualizePunishment(punishment: AutoPunishment) {
 	const buf = [`punishment: ${punishment.punishment?.toUpperCase()}`];
 	buf.push(`ticket type: ${punishment.ticketType}`);
@@ -97,6 +95,7 @@ export function determinePunishment(
 			for (const type of punishment.severity.type) {
 				if (results[type] < punishment.severity.certainty) continue;
 				hit = true;
+				break;
 			}
 			if (!hit) continue;
 		}

--- a/server/chat-plugins/helptickets-auto.ts
+++ b/server/chat-plugins/helptickets-auto.ts
@@ -161,7 +161,7 @@ function closeTicket(ticket: TicketState, msg?: string) {
 		result: msg || '',
 		note: (
 			`Want to learn more about the AI? ` +
-			`<a href="https://www.smogon.com/forums/threads/\3570628/#post-9056769">Visit the information thread</a>.`
+			`<a href="https://www.smogon.com/forums/threads/3570628/#post-9056769">Visit the information thread</a>.`
 		),
 	};
 	writeTickets();

--- a/server/chat-plugins/helptickets-auto.ts
+++ b/server/chat-plugins/helptickets-auto.ts
@@ -719,7 +719,7 @@ export const pages: Chat.PageTable = {
 			return this.errorReply(`Invalid month. Must be in YYYY-MM format.`);
 		}
 
-		this.title = `[Artmeis Ticket Stats] ${month}`;
+		this.title = `[Artemis Ticket Stats] ${month}`;
 		this.setHTML(`<div class="pad"><h3>Artemis ticket stats</h3><hr />Searching...`);
 
 		const found = await HelpTicket.getTextLogs(['recommendResult'], month);

--- a/server/chat-plugins/helptickets-auto.ts
+++ b/server/chat-plugins/helptickets-auto.ts
@@ -1,0 +1,671 @@
+import {FS, Utils} from '../../lib';
+import type {ModlogSearch, ModlogEntry} from '../modlog';
+import {
+	TicketState, getBattleLog, getBattleLinks, writeTickets, notifyStaff, writeStats, HelpTicket,
+} from './helptickets';
+import * as Artemis from '../artemis';
+
+const ORDERED_PUNISHMENTS = ['WARN', 'FORCERENAME', 'LOCK', 'NAMELOCK', 'WEEKLOCK', 'WEEKNAMELOCK'];
+const PMLOG_IGNORE_TIME = 24 * 60 * 60 * 1000;
+const WHITELIST = ['mia'];
+
+export interface AutoPunishment {
+	modlogCount?: number;
+	severity?: {type: string[], certainty: number};
+	/**
+	 * Should it be run on just one message?
+	 * or is it safe to run on averages (for the types that use averages)
+	 */
+	isSingleMessage?: boolean;
+	punishment: string;
+	ticketType: string;
+}
+
+export interface AutoSettings {
+	punishments: AutoPunishment[];
+	applyPunishments: boolean;
+}
+
+const defaults: AutoSettings = {
+	punishments: [{
+		ticketType: 'inapname',
+		punishment: 'forcerename',
+		severity: {type: ['sexual_explicit', 'severe_toxicity', 'identity_attack'], certainty: 0.4},
+	}, {
+		ticketType: 'pmharassment',
+		punishment: 'warn',
+		severity: {type: ['sexual_explicit', 'severe_toxicity', 'identity_attack'], certainty: 0.15},
+	}],
+	applyPunishments: false,
+};
+
+export const settings: AutoSettings = (() => {
+	try {
+		// spreading w/ default means that
+		// adding new things won't crash by not existing
+		return {...defaults, ...JSON.parse(FS('config/chat-plugins/ht-auto.json').readSync())};
+	} catch {
+		return defaults;
+	}
+})();
+
+function saveSettings() {
+	return FS('config/chat-plugins/ht-auto.json').writeUpdate(() => JSON.stringify(settings));
+}
+
+// partial is just to accept the 'partial' autopunishments done when they're created
+// (they aren't really partial but even if they are, it doesn't matter)
+function visualizePunishment(punishment: AutoPunishment) {
+	const buf = [`punishment: ${punishment.punishment?.toUpperCase()}`];
+	buf.push(`ticket type: ${punishment.ticketType}`);
+	if (punishment.severity) {
+		buf.push(`severity: ${punishment.severity.certainty} (for ${punishment.severity.type.join(', ')})`);
+	}
+	if (punishment.modlogCount) {
+		buf.push(`required modlog: ${punishment.modlogCount}`);
+	}
+	if (punishment.isSingleMessage) {
+		buf.push(`for single messages only`);
+	}
+	return buf.join(', ');
+}
+
+function checkAccess(context: Chat.CommandContext | Chat.PageContext) {
+	if (!WHITELIST.includes(context.user.id)) context.checkCan('bypassall');
+}
+
+export function punishmentsFor(type: string) {
+	return settings.punishments.filter(t => t.ticketType === type);
+}
+
+/** Is punishment1 higher than punishment2 on the list? */
+function supersedes(p1: string, p2: string) {
+	return ORDERED_PUNISHMENTS.indexOf(p1) > ORDERED_PUNISHMENTS.indexOf(p2);
+}
+
+export function determinePunishment(
+	ticketType: string, results: Record<string, number>, modlog: ModlogEntry[], isSingleMessage = false
+) {
+	const punishments = punishmentsFor(ticketType);
+	let action: string | null = null;
+	Utils.sortBy(punishments, p => -ORDERED_PUNISHMENTS.indexOf(p.punishment));
+	for (const punishment of punishments) {
+		if (isSingleMessage && !punishment.isSingleMessage) continue;
+		if (punishment.modlogCount && modlog.length < punishment.modlogCount) continue;
+		if (punishment.severity) {
+			let hit = false;
+			for (const type of punishment.severity.type) {
+				if (results[type] < punishment.severity.certainty) continue;
+				hit = true;
+			}
+			if (!hit) continue;
+		}
+		if (!action || supersedes(punishment.punishment, action)) {
+			action = punishment.punishment;
+		}
+	}
+	return action;
+}
+
+export function globalModlog(action: string, user: User | ID | null, note: string, roomid?: string) {
+	user = Users.get(user) || user;
+	void Rooms.Modlog.write(roomid || 'global', {
+		action,
+		ip: user && typeof user === 'object' ? user.latestIp : undefined,
+		userid: toID(user) || undefined,
+		loggedBy: 'artemis' as ID,
+		note,
+	});
+}
+
+export function addModAction(message: string) {
+	Rooms.get('staff')?.add(`|c|&|/log ${message}`).update();
+}
+
+export async function getModlog(params: {user?: ID, ip?: string, actions?: string[]}) {
+	const search: ModlogSearch = {
+		note: [],
+		user: [],
+		ip: [],
+		action: [],
+		actionTaker: [],
+	};
+	if (params.user) search.user = [{search: params.user, isExact: true}];
+	if (params.ip) search.ip = [{search: params.ip}];
+	if (params.actions) search.action = params.actions.map(s => ({search: s}));
+	const res = await Rooms.Modlog.search('global', search);
+	return res?.results || [];
+}
+
+function closeTicket(ticket: TicketState, msg?: string) {
+	if (!ticket.open) return;
+	ticket.open = false;
+	ticket.active = false;
+	ticket.resolved = {
+		time: Date.now(),
+		by: 'the Artemis AI', // we want it to be clear to end users that it was not a human
+		seen: false,
+		staffReason: '',
+		result: msg || "",
+		note: `Want to learn more about the AI? <a href="https://570628/#post-9056769">Visit the information thread</a>.`,
+	};
+	writeTickets();
+	notifyStaff();
+	const tarUser = Users.get(ticket.userid);
+	if (tarUser) {
+		HelpTicket.notifyResolved(tarUser, ticket, ticket.userid);
+	}
+	// TODO: Support closing as invalid
+	writeStats(`${ticket.type}\t${Date.now() - ticket.created}\t0\t0\tresolved\tvalid\tartemis`);
+}
+
+async function lock(
+	user: User | ID,
+	result: CheckerResult,
+	ticket: TicketState,
+	isWeek?: boolean,
+	isName?: boolean
+) {
+	const id = toID(user);
+	let desc, type;
+	const expireTime = isWeek ? Date.now() + 7 * 24 * 60 * 60 * 1000 : null;
+	if (isName) {
+		if (typeof user === 'object') user.resetName();
+		desc = 'locked your username and prevented you from changing names';
+		type = `locked from talking${isWeek ? ` for a week` : ""}`;
+		await Punishments.namelock(id, expireTime, null, false, result.reason || "Automatically locked due to a user report");
+	} else {
+		type = isWeek ? 'weeknamelocked' : 'namelocked';
+		desc = 'locked you from talking in chats, battles, and PMing regular users';
+		await Punishments.lock(id, expireTime, null, false, result.reason || "Automatically locked due to a user report");
+	}
+	if (typeof user !== 'string') {
+		let message = `|popup||html|${user.name} has ${desc} for ${isWeek ? '7' : '2'} days.`;
+		if (result.reason) message += `\n\nReason: ${result.reason}`;
+		let appeal = '';
+		if (Chat.pages.help) {
+			appeal += `<a href="view-help-request--appeal"><button class="button"><strong>Appeal your punishment</strong></button></a>`;
+		} else if (Config.appealurl) {
+			appeal += `appeal: <a href="${Config.appealurl}">${Config.appealurl}</a>`;
+		}
+		if (appeal) message += `\n\nIf you feel that your lock was unjustified, you can ${appeal}.`;
+		message += `\n\nYour lock will expire in a few days.`;
+		user.send(message);
+	}
+	addModAction(`${id} was ${type} by Artemis. (${result.reason || `report from ${ticket.creator}`})`);
+	globalModlog(
+		`${isWeek ? 'WEEK' : ""}${isName ? "NAME" : ""}LOCK`, id,
+		(result.reason || `report from ${ticket.creator}`) + (result.proof ? ` PROOF: ${result.proof}` : "")
+	);
+}
+
+export const actionHandlers: {
+	[k: string]: (user: User | ID, result: CheckerResult, ticket: TicketState) => string | void | Promise<string | void>,
+} = {
+	forcerename(user, result, ticket) {
+		if (typeof user === 'string') return; // they can only submit users with existing userobjects anyway
+		const id = toID(user);
+		user.resetName();
+		user.trackRename = id;
+		Monitor.forceRenames.set(id, true);
+		user.send(
+			'|nametaken|Staff considers your name inappropriate. ' +
+			`${result.reason ? `Reason: ${result.reason}. ` : ""}` +
+			'Please change it, or submit a help ticket by typing /ht in chat to appeal this action.'
+		);
+		Rooms.get('staff')?.add(
+			`|html|<span class="username">${id}</span> ` +
+			`was automatically forced to choose a new name by Artemis (report from ${ticket.userid}).`
+		).update();
+		globalModlog(
+			'FORCERENAME', id, `username determined to be inappropriate due to a report by ${ticket.creator}`, result.roomid
+		);
+		return `${id} was automatically forcerenamed. Thank you for reporting.`;
+	},
+	async namelock(user, result, ticket) {
+		await lock(user, result, ticket, false, true);
+		return `${toID(user)} was automatically namelocked. Thank you for reporting.`;
+	},
+	async weeknamelock(user, result, ticket) {
+		await lock(user, result, ticket, true, true);
+		return `${toID(user)} was automatically weeknamelocked. Thank you for reporting.`;
+	},
+	async lock(user, result, ticket) {
+		await lock(user, result, ticket);
+		return `${toID(user)} was automatically locked. Thank you for reporting.`;
+	},
+	async weeklock(user, result, ticket) {
+		await lock(user, result, ticket, true);
+		return `${toID(user)} was automatically weeklocked. Thank you for reporting.`;
+	},
+	warn(user, result, ticket) {
+		user = toID(user);
+		user = Users.get(user) || user;
+		if (typeof user === 'object') {
+			user.send(`|c|~|/warn ${result.reason || ""}`);
+		} else {
+			Punishments.offlineWarns.set(user, result.reason);
+		}
+		addModAction(
+			`${user} was warned by Artemis. ${typeof user === 'string' ? 'while offline ' : ""}` +
+			`(${result.reason || `report from ${ticket.creator}`})`
+		);
+		globalModlog(
+			'WARN', user, result.reason || `report from ${ticket.creator}`
+		);
+		return `${user} was automatically warned. Thank you for reporting.`;
+	},
+};
+
+export async function getMessageAverages(messages: string[]) {
+	const counts: Record<string, {count: number, raw: number}> = {};
+	const classified = [];
+	for (const message of messages) {
+		const res = await classifier.classify(message);
+		if (!res) continue;
+		classified.push(res);
+		for (const k in res) {
+			if (!counts[k]) counts[k] = {count: 0, raw: 0};
+			counts[k].count++;
+			counts[k].raw += res[k];
+		}
+	}
+	const averages: Record<string, number> = {};
+	for (const k in counts) {
+		averages[k] = counts[k].raw / counts[k].count;
+	}
+	return {averages, classified};
+}
+
+interface CheckerResult {
+	action: string;
+	user: User | ID;
+	result: Record<string, number>;
+	reason: string;
+	roomid?: string;
+	displayReason?: string;
+	proof?: string;
+}
+
+type CheckerOutput = void | Map<string, CheckerResult>;
+
+export const checkers: {
+	[k: string]: (ticket: TicketState & {text: [string, string]}) => CheckerOutput | Promise<CheckerOutput>,
+} = {
+	async inapname(ticket) {
+		const id = toID(ticket.text[0]);
+		const user = Users.getExact(id);
+		if (user && !user.trusted) {
+			const result = await classifier.classify(user.name);
+			if (!result) return;
+			const keys = ['identity_attack', 'sexual_explicit', 'severe_toxicity'];
+			const matched = keys.some(k => result[k] >= 0.4);
+			if (matched) {
+				const modlog = await getModlog({
+					ip: user.latestIp,
+					actions: ['FORCERENAME', 'NAMELOCK', 'WEEKNAMELOCK'],
+				});
+				let action = determinePunishment('inapname', result, modlog);
+				if (!action) action = 'forcerename';
+				return new Map([[user.id, {
+					action,
+					user,
+					result,
+					reason: "Username detected to be breaking username rules",
+				}]]);
+			}
+		}
+	},
+	async inappokemon(ticket) {
+		const actions = new Map();
+		const links = [...getBattleLinks(ticket.text[0]), ...getBattleLinks(ticket.text[1])];
+		for (const link of links) {
+			const log = await getBattleLog(link);
+			if (!log) continue;
+			for (const [userid, pokemon] of Object.entries(log.pokemon)) {
+				let result: {
+					action: string, name: string, result: Record<string, number>, replay: string,
+				} | null = null;
+				for (const set of pokemon) {
+					if (!set.name) continue;
+					const results = await classifier.classify(set.name);
+					if (!results) continue;
+					// atm don't factor in modlog
+					const curAction = determinePunishment('inappokemon', results, []);
+					if (curAction && (!result || supersedes(curAction, result.action))) {
+						result = {action: curAction, name: set.name, result: results, replay: link};
+					}
+				}
+				if (result) {
+					// if action exists, the rest will exist. this is just for TS
+					actions.set(toID(userid), {
+						action: result.action,
+						user: toID(userid),
+						result: result.result,
+						reason: `Pokemon name detected to be breaking rules - '${result.name}'`,
+						roomid: link,
+					});
+				}
+			}
+		}
+		if (actions.size) return actions;
+	},
+	async battleharassment(ticket) {
+		const urls = getBattleLinks(ticket.text[0]);
+		const actions = new Map<string, CheckerResult>();
+		for (const url of urls) {
+			const log = await getBattleLog(url);
+			if (!log) continue;
+			const messages: Record<string, string[]> = {};
+			for (const message of log.log) {
+				const [username, text] = Utils.splitFirst(message.slice(3), '|').map(f => f.trim());
+				const id = toID(username);
+				if (!id) continue;
+				if (!messages[id]) messages[id] = [];
+				messages[id].push(text);
+			}
+			for (const [id, messageList] of Object.entries(messages)) {
+				const {averages, classified} = await getMessageAverages(messageList);
+				const punishment = determinePunishment('battleharassment', averages, []);
+				if (!punishment) continue;
+				const existingPunishment = actions.get(id);
+				if (!existingPunishment || supersedes(punishment, existingPunishment.action)) {
+					actions.set(id, {
+						action: punishment,
+						user: toID(id),
+						result: averages,
+						reason: `Not following rules in battles`,
+						proof: urls.join(', '),
+					});
+				}
+				for (const result of classified) {
+					const curPunishment = determinePunishment('battleharassment', result, [], true);
+					if (!curPunishment) continue;
+					const exists = actions.get(id);
+					if (!exists || supersedes(curPunishment, exists.action)) {
+						actions.set(id, {
+							action: curPunishment,
+							user: toID(id),
+							result: averages,
+							reason: `Not following rules in battles`,
+							proof: urls.join(', '),
+						});
+					}
+				}
+			}
+		}
+		// ensure reasons are clear
+		const creatorWasPunished = actions.get(ticket.userid);
+		if (creatorWasPunished) {
+			let displayReason = 'You were punished for your behavior.';
+			if (actions.size !== 1) { // more than 1 was punished
+				displayReason += ` ${actions.size - 1} other(s) were also punished.`;
+			}
+			creatorWasPunished.displayReason = displayReason;
+		}
+
+		if (actions.size) return actions;
+	},
+	async pmharassment(ticket) {
+		const actions = new Map<string, CheckerResult>();
+		const targetId = toID(ticket.text[0]);
+		const creator = ticket.userid;
+		if (!Config.getpmlog) return;
+		const pmLog = await Config.getpmlog(targetId, creator) as {
+			message: string, from: string, to: string, timestamp: string,
+		}[];
+		const messages: Record<string, string[]> = {};
+		const ids = new Set<ID>();
+		// sort messages by user who sent them, also filter out old ones
+		for (const {from, message, timestamp} of pmLog) {
+			// ignore pmlogs more than 24h old
+			if ((Date.now() - new Date(timestamp).getTime()) > PMLOG_IGNORE_TIME) continue;
+			const id = toID(from);
+			ids.add(id);
+			if (!messages[id]) messages[id] = [];
+			messages[id].push(message);
+		}
+		for (const id of ids) {
+			let punishment;
+			const {averages, classified} = await getMessageAverages(messages[id]);
+			const curPunishment = determinePunishment('pmharassment', averages, []);
+			if (!curPunishment) continue;
+			if (!punishment || supersedes(curPunishment, punishment)) {
+				punishment = curPunishment;
+			}
+			if (punishment) {
+				actions.set(id, {
+					action: punishment,
+					user: id,
+					result: {},
+					reason: "PM harassment",
+				});
+			}
+			for (const result of classified) {
+				const singlePunishment = determinePunishment('pmharassment', result, [], true);
+				if (!singlePunishment) continue;
+				const exists = actions.get(id);
+				if (!exists || supersedes(singlePunishment, exists.action)) {
+					actions.set(id, {
+						action: singlePunishment,
+						user: id,
+						result: {},
+						reason: "PM harassment",
+					});
+				}
+			}
+		}
+
+		const creatorWasPunished = actions.get(ticket.userid);
+		if (creatorWasPunished) {
+			let displayReason = `You were punished for your behavior. `;
+			if (actions.has(targetId) && targetId !== ticket.userid) {
+				displayReason += ` The person you reported was also punished.`;
+			}
+			creatorWasPunished.displayReason = displayReason;
+		}
+
+		if (actions.size) return actions;
+	},
+};
+
+export const classifier = new Artemis.LocalClassifier();
+
+export async function runPunishments(ticket: TicketState & {text: [string, string]}, typeId: string) {
+	let result: Map<string, CheckerResult> | null = null;
+	if (checkers[typeId]) {
+		result = await checkers[typeId](ticket) || null;
+	}
+	if (result) {
+		if (settings.applyPunishments) {
+			const responses: [string, string][] = [];
+			for (const res of result.values()) {
+				const curResult = await actionHandlers[res.action.toLowerCase()](res.user, res, ticket);
+				if (curResult) responses.push([res.action, res.displayReason || curResult]);
+				if (toID(res.user) === ticket.creator) {
+					// just close the ticket here.
+					closeTicket(ticket, res.displayReason);
+				}
+			}
+			if (responses.length) {
+				// if we don't have one for the user, find one.
+				Utils.sortBy(responses, r => -ORDERED_PUNISHMENTS.indexOf(r[0]));
+				closeTicket(ticket, responses[0][1]);
+			} else {
+				closeTicket(ticket); // no good response. just close it, because we __have__ dispatched an action.
+			}
+		} else {
+			ticket.recommended = [];
+			for (const res of result.values()) {
+				Rooms.get('abuselog')?.add(
+					`[${ticket.type} Monitor] Recommended: ${res.action}: for ${res.user} (${res.reason})`
+				).update();
+				ticket.recommended.push(`${res.action}: for ${res.user} (${res.reason})`);
+			}
+		}
+	}
+}
+
+export const commands: Chat.ChatCommands = {
+	ath: 'autohelpticket',
+	aht: "autohelpticket",
+	autohelpticket: {
+		''() {
+			return this.parse(`/help autohelpticket`);
+		},
+		ap: 'addpunishment',
+		addpunishment(target, room, user) {
+			checkAccess(this);
+			if (!toID(target)) return this.parse(`/help autohelpticket`);
+			const args = Chat.parseArguments(target);
+			const punishment: Partial<AutoPunishment> = {};
+			for (const [k, list] of Object.entries(args)) {
+				if (k !== 'type' && list.length > 1) throw new Chat.ErrorMessage(`More than one ${k} param provided.`);
+				const val = list[0]; // if key exists, val must exist too
+				switch (k) {
+				case 'type': case 't':
+					const types = list.map(f => f.toLowerCase().replace(/\s/g, '_'));
+					for (const type of types) {
+						if (!Artemis.LocalClassifier.ATTRIBUTES[type]) {
+							return this.errorReply(
+								`Invalid classifier type '${type}'. Valid types are ` +
+								Object.keys(Artemis.LocalClassifier.ATTRIBUTES).join(', ')
+							);
+						}
+					}
+					if (!punishment.severity) {
+						punishment.severity = {certainty: 0, type: []};
+					}
+					punishment.severity.type.push(...types);
+					break;
+				case 'certainty': case 'c':
+					const num = parseFloat(val);
+					if (isNaN(num) || num < 0 || num > 1) {
+						return this.errorReply(`Certainty must be a number below 1 and above 0.`);
+					}
+					if (!punishment.severity) {
+						punishment.severity = {certainty: 0, type: []};
+					}
+					punishment.severity.certainty = num;
+					break;
+				case 'modlog': case 'm':
+					const count = parseInt(val);
+					if (isNaN(count) || count < 0) {
+						return this.errorReply(`Modlog count must be a number above 0.`);
+					}
+					punishment.modlogCount = count;
+					break;
+				case 'ticket': case 'tt': case 'tickettype':
+					const type = toID(val);
+					if (!(type in checkers)) {
+						return this.errorReply(
+							`The ticket type '${type}' does not exist or is not supported. ` +
+							`Supported types are ${Object.keys(checkers).join(', ')}.`
+						);
+					}
+					punishment.ticketType = type;
+					break;
+				case 'p': case 'punishment':
+					const name = toID(val).toUpperCase();
+					if (!ORDERED_PUNISHMENTS.includes(name)) {
+						return this.errorReply(
+							`Punishment '${name}' not supported. ` +
+							`Supported punishments: ${ORDERED_PUNISHMENTS.join(', ')}`
+						);
+					}
+					punishment.punishment = name;
+					break;
+				case 'single': case 's':
+					if (!this.meansYes(toID(val))) {
+						return this.errorReply(
+							`The 'single' value must always be 'on'. ` +
+							`If you don't want it enabled, just do not use this argument type.`
+						);
+					}
+					punishment.isSingleMessage = true;
+					break;
+				}
+			}
+			if (!punishment.ticketType) {
+				return this.errorReply(`Must specify a ticket type to handle.`);
+			}
+			if (!punishment.punishment) {
+				return this.errorReply(`Must specify a punishment to apply.`);
+			}
+			if (!(punishment.severity?.certainty && punishment.severity?.type.length)) {
+				return this.errorReply(`A severity to monitor for must be specified (certainty).`);
+			}
+			for (const curP of settings.punishments) {
+				let matches = 0;
+				for (const k in curP) {
+					if (punishment[k as keyof AutoPunishment] === curP[k as keyof AutoPunishment]) {
+						matches++;
+					}
+				}
+				if (matches === Object.keys(punishment).length) {
+					return this.errorReply(`That punishment is already added.`);
+				}
+			}
+			settings.punishments.push(punishment as AutoPunishment);
+			saveSettings();
+			this.privateGlobalModAction(
+				`${user.name} added a ${punishment.punishment} punishment to the Artemis helpticket handler.`
+			);
+			this.globalModlog(`AUTOHELPTICKET ADDPUNISHMENT`, null, visualizePunishment(punishment as AutoPunishment));
+		},
+		dp: 'deletepunishment',
+		deletepunishment(target, room, user) {
+			checkAccess(this);
+			const num = parseInt(target) - 1;
+			if (isNaN(num)) return this.parse(`/h autohelpticket`);
+			const punishment = settings.punishments[num];
+			if (!punishment) return this.errorReply(`There is no punishment at index ${num + 1}.`);
+			settings.punishments.splice(num, 1);
+			this.privateGlobalModAction(
+				`${user.name} removed the Artemis helpticket ${punishment.punishment} punishment indexed at ${num + 1}`
+			);
+			this.globalModlog(`AUTOHELPTICKET REMOVE`, null, visualizePunishment(punishment));
+		},
+		vp: 'viewpunishments',
+		viewpunishments() {
+			checkAccess(this);
+			let buf = `<strong>Artemis helpticket punishments</strong><hr />`;
+			if (!settings.punishments.length) {
+				buf += `None.`;
+				return this.sendReplyBox(buf);
+			}
+			buf += settings.punishments.map(
+				(curP, i) => `<strong>${i + 1}:</strong> ${visualizePunishment(curP)}`
+			).join('<br />');
+			return this.sendReplyBox(buf);
+		},
+		togglepunishments(target, room, user) {
+			checkAccess(this);
+			let message;
+			if (this.meansYes(target)) {
+				if (settings.applyPunishments) {
+					return this.errorReply(`Automatic punishments are already enabled.`);
+				}
+				settings.applyPunishments = true;
+				message = `${user.name} enabled automatic punishments for the Artemis ticket handler`;
+			} else if (this.meansNo(target)) {
+				if (!settings.applyPunishments) {
+					return this.errorReply(`Automatic punishments are already disabled.`);
+				}
+				settings.applyPunishments = false;
+				message = `${user.name} disabled automatic punishments for the Artemis ticket handler`;
+			} else {
+				return this.errorReply(`Invalid setting. Must be 'on' or 'off'.`);
+			}
+			this.privateGlobalModAction(message);
+			this.globalModlog(`AUTOHELPTICKET TOGGLE`, null, settings.applyPunishments ? 'on' : 'off');
+			saveSettings();
+		},
+	},
+	autohelptickethelp: [
+		`/aht addpunishment [args] - Adds a punishment with the given [args]. Requires: whitelist &`,
+		`/aht deletepunishment [index] - Deletes the automatic helpticket punishment at [index]. Requires: whitelist &`,
+		`/aht viewpunishments - View automatic helpticket punishments. Requires: whitelist &`,
+		`/aht togglepunishments [on | off] - Turn [on | off] automatic helpticket punishments. Requires: whitelist &`,
+	],
+};

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -521,7 +521,7 @@ export class HelpTicket extends Rooms.RoomGame {
 		const results = [];
 		if (await checkRipgrepAvailability()) {
 			const args = [
-				`-e`, search[1] ? `${search[0]}":"${search[1]}` : `${search[0]}":`,
+				`-e`, search.length > 1 ? `${search[0]}":"${search[1]}` : `${search[0]}":`,
 				'--no-filename',
 			];
 			let lines;

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -3,13 +3,14 @@ import {getCommonBattles} from '../chat-commands/info';
 import {checkRipgrepAvailability} from '../config-loader';
 import type {Punishment} from '../punishments';
 import type {PartialModlogEntry, ModlogID} from '../modlog';
+import {runPunishments} from './helptickets-auto';
 
 const TICKET_FILE = 'config/tickets.json';
 const SETTINGS_FILE = 'config/chat-plugins/ticket-settings.json';
 const TICKET_CACHE_TIME = 24 * 60 * 60 * 1000; // 24 hours
 const TICKET_BAN_DURATION = 48 * 60 * 60 * 1000; // 48 hours
-const BATTLES_REGEX = /\bbattle-(?:[a-z0-9]+)-(?:[0-9]+)(?:-[a-z0-9]{31}pw)?/g;
-const REPLAY_REGEX = new RegExp(
+export const BATTLES_REGEX = /\bbattle-(?:[a-z0-9]+)-(?:[0-9]+)(?:-[a-z0-9]{31}pw)?/g;
+export const REPLAY_REGEX = new RegExp(
 	`${Utils.escapeRegex(Config.routes.replays)}/(?:[a-z0-9]-)?(?:[a-z0-9]+)-(?:[0-9]+)(?:-[a-z0-9]{31}pw)?`, "g"
 );
 const REPORT_NAMECOLORS: {[k: string]: string} = {
@@ -30,7 +31,7 @@ interface TicketSettings {
 	responses: {[ticketType: string]: {[title: string]: string}};
 }
 
-interface TicketState {
+export interface TicketState {
 	creator: string;
 	userid: ID;
 	open: boolean;
@@ -51,6 +52,8 @@ interface TicketState {
 	 * Use `TextTicketInfo#getState` to set it at creation (store properties of the user object, etc)
 	 */
 	state?: AnyObject & {claimTime?: number};
+	/** Recommendations from the Artemis monitor, if it is set to only recommend. */
+	recommended?: string[];
 }
 
 interface ResolvedTicketInfo {
@@ -59,6 +62,8 @@ interface ResolvedTicketInfo {
 	by: string;
 	seen: boolean;
 	staffReason: string;
+	/** <small> note under the resolved */
+	note?: string;
 }
 
 export interface TextTicketInfo {
@@ -86,6 +91,7 @@ interface BattleInfo {
 	url: string;
 	title: string;
 	players: {p1: ID, p2: ID, p3?: ID, p4?: ID};
+	pokemon: Record<string, {species: string, name?: string}[]>;
 }
 
 type TicketResult = 'approved' | 'valid' | 'assisted' | 'denied' | 'invalid' | 'unassisted' | 'ticketban' | 'deleted';
@@ -158,7 +164,7 @@ async function convertRoomPunishments() {
 	}
 }
 
-function writeStats(line: string) {
+export function writeStats(line: string) {
 	// ticketType\ttotalTime\ttimeToFirstClaim\tinactiveTime\tresolution\tresult\tstaff,userids,seperated,with,commas
 	const date = new Date();
 	const month = Chat.toTimestamp(date).split(' ')[0].split('-', 2).join('-');
@@ -679,12 +685,15 @@ export class HelpTicket extends Rooms.RoomGame {
 		return `You are banned from creating help tickets.`;
 	}
 	static notifyResolved(user: User, ticket: TicketState, userid = user.id) {
-		const {result, time, by, seen} = ticket.resolved as {result: string, time: number, by: string, seen: boolean};
+		const {result, time, by, seen, note} = ticket.resolved as ResolvedTicketInfo;
 		if (seen) return;
 		const timeString = (Date.now() - time) > 1000 ? `, ${Chat.toDurationString(Date.now() - time)} ago.` : '.';
 		user.send(`|pm|&Staff|${user.getIdentity()}|Hello! Your report was resolved by ${by}${timeString}`);
 		if (result?.trim()) {
 			user.send(`|pm|&Staff|${user.getIdentity()}|The result was "${result}"`);
+		}
+		if (note?.trim()) {
+			user.send(`|pm|&Staff|${user.getIdentity()}|/raw <small>${note}</small>`);
 		}
 		tickets[userid].resolved!.seen = true;
 		writeTickets();
@@ -899,21 +908,54 @@ export async function getOpponent(link: string, submitter: ID): Promise<string |
 
 export async function getBattleLog(battle: string): Promise<BattleInfo | null> {
 	const battleRoom = Rooms.get(battle);
+	const seenPokemon = new Set<string>();
 	if (battleRoom && battleRoom.type !== 'chat') {
 		const playerTable: Partial<BattleInfo['players']> = {};
+		const monTable: BattleInfo['pokemon'] = {};
 		// i kinda hate this, but this will always be accurate to the battle players.
 		// consulting room.battle.playerTable might be invalid (if battle is over), etc.
-		const playerLines = battleRoom.log.log.filter(line => line.startsWith('|player|'));
-		for (const line of playerLines) {
-			// |player|p1|Mia|miapi.png|1000
-			const [, , playerSlot, name] = line.split('|');
-			playerTable[playerSlot as SideID] = toID(name);
+		for (const line of battleRoom.log.log) {
+			// |switch|p2a: badnite|Dragonite, M|323/323
+			if (line.startsWith('|switch|')) { // name cannot have been seen until it switches in
+				const [, , playerWithNick, speciesWithGender] = line.split('|');
+				let [slot, name] = playerWithNick.split(':');
+				const species = speciesWithGender.split(',')[0].trim(); // should always exist
+				slot = slot.slice(0, -1); // p2a -> p2
+				if (!monTable[slot]) monTable[slot] = [];
+				const identifier = `${name || ""}-${species}`;
+				if (seenPokemon.has(identifier)) continue;
+				// technically, if several mons have the same name and species, this will ignore them.
+				// BUT if they have the same name and species we only need to see it once
+				// so it doesn't matter
+				seenPokemon.add(identifier);
+				name = name?.trim() || "";
+				monTable[slot].push({
+					species,
+					name: species === name ? undefined : name,
+				});
+			}
+			if (line.startsWith('|player|')) {
+				// |player|p1|Mia|miapi.png|1000
+				const [, , playerSlot, name] = line.split('|');
+				playerTable[playerSlot as SideID] = toID(name);
+			}
+			for (const k in monTable) {
+				// SideID => userID, cannot do conversion at time of collection
+				// because the playerID => userid mapping might not be there.
+				// strictly, yes it will, but this is for maximum safety.
+				const userid = playerTable[k as SideID];
+				if (userid) {
+					monTable[userid] = monTable[k];
+					delete monTable[k];
+				}
+			}
 		}
 		return {
 			log: battleRoom.log.log.filter(k => k.startsWith('|c|')),
 			title: battleRoom.title,
 			url: `/${battle}`,
 			players: playerTable as BattleInfo['players'],
+			pokemon: monTable,
 		};
 	}
 	battle = battle.replace(`battle-`, ''); // don't wanna strip passwords
@@ -921,16 +963,43 @@ export async function getBattleLog(battle: string): Promise<BattleInfo | null> {
 		const raw = await Net(`https://${Config.routes.replays}/${battle}.json`).get();
 		const data = JSON.parse(raw);
 		if (data.log?.length) {
+			const log = data.log.split('\n');
+			const players = {
+				p1: toID(data.p1),
+				p2: toID(data.p2),
+				p3: toID(data.p3),
+				p4: toID(data.p4),
+			};
+			const chat = [];
+			const mons: BattleInfo['pokemon'] = {};
+			for (const line of log) {
+				if (line.startsWith('|c|')) {
+					chat.push(line);
+				} else if (line.startsWith('|switch|')) {
+					const [, , playerWithNick, speciesWithGender] = line.split('|');
+					const species = speciesWithGender.split(',')[0].trim(); // should always exist
+					let [slot, name] = playerWithNick.split(':');
+					slot = slot.slice(0, -1); // p2a -> p2
+					// safe to not check here bc this should always exist in the players table.
+					// if it doesn't, there's a problem
+					const id = players[slot as SideID];
+					if (!mons[id]) mons[id] = [];
+					name = name?.trim() || "";
+					const setId = `${name || ""}-${species}`;
+					if (seenPokemon.has(setId)) continue;
+					seenPokemon.add(setId);
+					mons[id].push({
+						species, // don't want to see a name if it's the same as the species
+						name: name === species ? undefined : name,
+					});
+				}
+			}
 			return {
-				log: data.log.split('\n').filter((k: string) => k.startsWith('|c|')),
+				log: chat,
 				title: `${data.p1} vs ${data.p2}`,
 				url: `https://${Config.routes.replays}/${battle}`,
-				players: {
-					p1: toID(data.p1),
-					p2: toID(data.p2),
-					p3: toID(data.p3),
-					p4: toID(data.p4),
-				},
+				players,
+				pokemon: mons,
 			};
 		}
 	} catch {}
@@ -1842,6 +1911,16 @@ export const pages: Chat.PageTable = {
 			buf += `<strong>From: ${ticket.userid}</strong>`;
 			buf += `  <button class="button" name="send" value="/msgroom staff,/ht ban ${ticket.userid}">Ticketban</button> | `;
 			buf += `<button class="button" name="send" value="/modlog room=global,user='${ticket.userid}'">Global Modlog</button><br />`;
+			if (ticket.recommended?.length) {
+				if (ticket.recommended.length > 1) {
+					buf += `<details class="readmore"><summary><strong>Recommended from Artemis</strong></summary>`;
+					buf += ticket.recommended.join('<br />');
+					buf += `</details>`;
+				} else {
+					buf += `<strong>Recommended from Artemis:</strong> ${ticket.recommended[0]}`;
+				}
+				buf += `<br /><br />`;
+			}
 			buf += await ticketInfo.getReviewDisplay(ticket as TicketState & {text: [string, string]}, user, connection);
 			buf += `<br />`;
 			buf += `<div class="infobox">`;
@@ -2283,6 +2362,7 @@ export const commands: Chat.ChatCommands = {
 				writeTickets();
 				notifyStaff();
 				textTicket.onSubmit?.(ticket, [text, contextString], this.user, this.connection);
+				void runPunishments(ticket as TicketState & {text: [string, string]}, typeId);
 				if (textTicket.getState) {
 					ticket.state = textTicket.getState(ticket, user);
 				}

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -2455,6 +2455,20 @@ export const Chat = new class {
 		return probe(url);
 	}
 
+	parseArguments(str: string, delim = ',', paramDelim = '=', useIDs = true) {
+		const result: Record<string, string[]> = {};
+		for (const part of str.split(delim)) {
+			let [key, val] = Utils.splitFirst(part, paramDelim).map(f => f.trim());
+			if (useIDs) key = toID(key);
+			if (!toID(key) || !toID(val)) {
+				throw new Chat.ErrorMessage(`Invalid option ${part}. Must be in [key]${paramDelim}[val] format.`);
+			}
+			if (!result[key]) result[key] = [];
+			result[key].push(val);
+		}
+		return result;
+	}
+
 	/**
 	 * Normalize a message for the purposes of applying chat filters.
 	 *

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -2461,7 +2461,7 @@ export const Chat = new class {
 			let [key, val] = Utils.splitFirst(part, paramDelim).map(f => f.trim());
 			if (useIDs) key = toID(key);
 			if (!toID(key) || !toID(val)) {
-				throw new Chat.ErrorMessage(`Invalid option ${part}. Must be in [key]${paramDelim}[val] format.`);
+				throw new Chat.ErrorMessage(`Invalid option ${part}. Must be in [key]${paramDelim}[value] format.`);
 			}
 			if (!result[key]) result[key] = [];
 			result[key].push(val);


### PR DESCRIPTION
This adds a new plugin file, `/chat-plugins/helptickets-auto.ts`, that hooks into the submission functions for text tickets, and attempts to make determinations on the action once submitted. It runs the ticket through a checker function for that type, which determines who to punish & what punishment to make (also attaches proof, a reason, etc). The result of the checker is passed to an action function, which essentially just reimplements certain punishments. It can be toggled to either deal out the punishments itself, or just make recommendations to staff. For a trial period, it will solely make recommendations.

I also added a `Chat.parseArguments` function to parse command targets (formatted like `key1=val1, key2=val2, etc`) into an object for easy usage.