### PR TITLE
Tournaments: Add /recenttours

### DIFF
--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -2379,7 +2379,10 @@ const roomSettings: Chat.SettingsHandler[] = [
 		permission: "editroom",
 		options: ['off', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15].map(
 			setting => (
-				[`${setting}`, setting === (room.settings.tournaments?.recentToursLength || 'off') || `tour settings recenttours ${setting}`]
+				[
+					`${setting}`,
+					setting === (room.settings.tournaments?.recentToursLength || 'off') || `tour settings recenttours ${setting}`,
+				]
 			)
 		),
 	}),


### PR DESCRIPTION
Requested by tournaments staff and is already used in other rooms with bots. I also fixed the settings permissions because they were never supposed to be accessible to non-ROs