### PR TITLE
Gen 2: Fix Return/Frustration min damage

### DIFF
--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -307,6 +307,12 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 		},
 	},
+	frustration: {
+		inherit: true,
+		basePowerCallback(pokemon) {
+			return Math.floor(((255 - pokemon.happiness) * 10) / 25) || null;
+		},
+	},
 	healbell: {
 		inherit: true,
 		onHit(target, source) {
@@ -673,6 +679,12 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			this.heal(target.maxhp);
 		},
 		secondary: null,
+	},
+	return: {
+		inherit: true,
+		basePowerCallback(pokemon) {
+			return Math.floor((pokemon.happiness * 10) / 25) || null;
+		},
 	},
 	reversal: {
 		inherit: true,


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-9116008

Return and Frustration should be able to deal 0 damage (see bug report above for in game footage)