### PR TITLE
Fix /modjoin in battles

### DIFF
--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -281,6 +281,7 @@ export const commands: Chat.ChatCommands = {
 			this.add(`|raw|<div class="broadcast-blue"><strong>This room is no longer invite only!</strong><br />Anyone may now join.</div>`);
 			this.addModAction(`${user.name} turned off modjoin.`);
 			this.modlog('MODJOIN', null, 'OFF');
+			if (room.battle) room.battle.inviteOnlySetter = null;
 			room.saveSettings();
 			return;
 		} else if (target === 'sync') {


### PR DESCRIPTION
This fixes a bug where if Player 1 sets modjoin and turns it off, Player 2 still can't turn it back on.

This doesn't fix everything wrong with modjoin in battles; for example, if Player 1 sets it to +, Player 2 can't set it higher. This is quite minor and requires more reworking than is probably worth for a kinda-deprecated feature.