### PR TITLE
Rotation Battles

### DIFF
--- a/data/text/default.ts
+++ b/data/text/default.ts
@@ -20,6 +20,8 @@ export const DefaultText: {[k: string]: DefaultText} = {
 		faint: "[POKEMON] fainted!",
 		swap: "[POKEMON] and [TARGET] switched places!",
 		swapCenter: "[POKEMON] moved to the center!",
+		rotateRight: "[TRAINER]'s Pok\u00E9mon rotated to the right!",
+		rotateLeft: "[TRAINER]'s Pok\u00E9mon rotated to the left!",
 
 		// Multi Battles only
 		canDynamax: "  [TRAINER] can dynamax now!",

--- a/sim/SIM-PROTOCOL.md
+++ b/sim/SIM-PROTOCOL.md
@@ -295,6 +295,11 @@ message).
 > Moves already active `POKEMON` to active field `POSITION` where the
 > leftmost position is 0 and each position to the right counts up by 1.
 
+`|rotateleft|SIDE` or `|rotateright|SIDE`
+
+> In a Rotation Battle, `SIDE`'s Pokémon rotated in the given direction,
+> and their 2nd or 3rd Pokémon is now active, respectively
+
 `|cant|POKEMON|REASON` or `|cant|POKEMON|REASON|MOVE`
 
 > The Pokémon `POKEMON` could not perform a move because of the indicated
@@ -686,6 +691,9 @@ To be exact, `CHOICE` is one of:
 - `move MOVESPEC zmove`, to use a z-move version of a move
 
 - `move MOVESPEC max`, to Dynamax/Gigantamax and make a move
+
+- `rotateright move MOVESPEC ...` or `rotateleft move MOVESPEC ...`, 
+in Rotation Battles to rotate to your second or third Pokémon, respectively, and use its move
 
 - `switch SWITCHSPEC`, to make a switch
 

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -183,6 +183,25 @@ export class BattleActions {
 		pokemon.draggedIn = null;
 		return true;
 	}
+	rotateIn(pokemon: Pokemon) {
+		const side = pokemon.side;
+		if (pokemon === side.pokemon[1]) {
+			side.pokemon.unshift(...side.pokemon.splice(1, 2));
+			side.active[0].isActive = false;
+			side.active[0] = pokemon;
+			pokemon.isActive = true;
+			this.battle.add('rotateright', side);
+		} else if (pokemon === side.pokemon[2]) {
+			side.pokemon.unshift(...side.pokemon.splice(2, 1));
+			side.active[0].isActive = false;
+			side.active[0] = pokemon;
+			pokemon.isActive = true;
+			this.battle.add('rotateleft', side);
+		}
+		for (let i = 0; i < side.pokemon.length; i++) {
+			side.pokemon[i].position = i;
+		}
+	}
 
 	// #endregion
 

--- a/sim/battle-queue.ts
+++ b/sim/battle-queue.ts
@@ -49,8 +49,8 @@ export interface MoveAction {
 /** A switch action */
 export interface SwitchAction {
 	/** action type */
-	choice: 'switch' | 'instaswitch';
-	order: 3 | 103;
+	choice: 'switch' | 'instaswitch' | 'rotate';
+	order: 3 | 103 | 104;
 	/** priority of the action (lower first) */
 	priority: number;
 	/** speed of pokemon switching (higher first if priority tie) */
@@ -177,8 +177,9 @@ export class BattleQueue {
 				runSwitch: 101,
 				runPrimal: 102,
 				switch: 103,
-				megaEvo: 104,
-				runDynamax: 105,
+				rotate: 104,
+				megaEvo: 105,
+				runDynamax: 106,
 
 				shift: 200,
 				// default is 200 (for moves)

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -671,6 +671,7 @@ export class Pokemon {
 	getAtLoc(targetLoc: number) {
 		let side = this.battle.sides[targetLoc < 0 ? this.side.n % 2 : (this.side.n + 1) % 2];
 		targetLoc = Math.abs(targetLoc);
+		if (this.battle.gameType === 'rotation') return side.pokemon[targetLoc - 1];
 		if (targetLoc > side.active.length) {
 			targetLoc -= side.active.length;
 			side = this.battle.sides[side.n + 2];


### PR DESCRIPTION
An [approved suggestion](https://www.smogon.com/forums/threads/rotation-battles.3666026/) on Smogon.

This updates the simulator to handle Rotation Battles. They're really just Single Battles with some extra steps, so not a lot needed to be done.

Currently this is a draft to review the protocol and API changes. Once these are approved, I will begin working on the client updates and playability on the main server should be decided. When a format is finalized I will add unit tests but I have tested the core features in the command line and there are no obvious bugs.

## Protocol changes

Input: The `rotateleft` and `rotateright` choices have been added. Both must be followed by a `move` choice.

Output: The `|rotateleft|SIDE` and `|rotateright|SIDE` majors have been added.

No backwards-compatibility issues should arise.