### PR TITLE
Refactor room games to use generic typing

### DIFF
--- a/server/chat-plugins/blackjack.ts
+++ b/server/chat-plugins/blackjack.ts
@@ -17,7 +17,7 @@ type Deck =
 type Symbols = '♥' | '♦' | '♣' | '♠';
 type SymbolName = 'Hearts' | 'Diamonds' | 'Clubs' | 'Spades';
 
-export class Blackjack extends Rooms.RoomGame {
+export class Blackjack extends Rooms.RoomGame<BlackjackPlayer> {
 	room: Room;
 
 	roomID: RoomID;
@@ -51,7 +51,6 @@ export class Blackjack extends Rooms.RoomGame {
 
 	dealer: BlackjackDealer;
 	deck: Deck[];
-	playerTable: {[k: string]: BlackjackPlayer};
 	gameNumber: number;
 
 	constructor(room: Room, user: User, autostartMinutes = 0) {
@@ -73,7 +72,6 @@ export class Blackjack extends Rooms.RoomGame {
 		this.cardHeight = 85;
 
 		this.spectators = Object.create(null);
-		this.playerTable = Object.create(null);
 		this.dealer = new BlackjackDealer();
 
 		this.symbols = {
@@ -485,7 +483,7 @@ export class Blackjack extends Rooms.RoomGame {
 		this.turnLog += turnLine;
 		if (player.cards.length > 2) this.display(turnLine, false, player.name);
 
-		if (player === this.dealer) {
+		if (player instanceof BlackjackDealer) {
 			if (player.points > 21) {
 				let cards = '';
 				for (const card of player.cards) {
@@ -504,7 +502,7 @@ export class Blackjack extends Rooms.RoomGame {
 				return;
 			}
 		} else if (player.points > 21) {
-			(player as BlackjackPlayer).status = 'bust';
+			player.status = 'bust';
 			let cards = '';
 			for (const card of player.cards) {
 				cards += `[${card}] `;
@@ -514,7 +512,7 @@ export class Blackjack extends Rooms.RoomGame {
 			this.display(turnLine, false, player.name);
 			this.clear();
 		} else if (player.points === 21) {
-			(player as BlackjackPlayer).status = 'stand';
+			player.status = 'stand';
 			turnLine = Utils.html`<br /><strong>${player.name}</strong> has blackjack!`;
 			this.turnLog += turnLine;
 			this.display(turnLine, false, player.name);
@@ -591,9 +589,8 @@ export class Blackjack extends Rooms.RoomGame {
 	}
 }
 
-class BlackjackPlayer extends Rooms.RoomGamePlayer {
+class BlackjackPlayer extends Rooms.RoomGamePlayer<Blackjack> {
 	user: User;
-	game: Blackjack;
 
 	points: number;
 	slide: number;
@@ -609,7 +606,6 @@ class BlackjackPlayer extends Rooms.RoomGamePlayer {
 	constructor(user: User, game: Blackjack) {
 		super(user, game);
 		this.user = user;
-		this.game = game;
 
 		this.cards = [];
 		this.points = 0;

--- a/server/chat-plugins/hangman.ts
+++ b/server/chat-plugins/hangman.ts
@@ -41,7 +41,7 @@ try {
 
 const maxMistakes = 6;
 
-export class Hangman extends Rooms.RoomGame {
+export class Hangman extends Rooms.SimpleRoomGame {
 	gameNumber: number;
 	creator: ID;
 	word: string;

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -175,7 +175,7 @@ export function writeStats(line: string) {
 	}
 }
 
-export class HelpTicket extends Rooms.RoomGame {
+export class HelpTicket extends Rooms.SimpleRoomGame {
 	room: ChatRoom;
 	ticket: TicketState;
 	claimQueue: string[];

--- a/server/chat-plugins/jeopardy.ts
+++ b/server/chat-plugins/jeopardy.ts
@@ -16,8 +16,7 @@ interface Question {
 
 type JeopardyState = 'signups' | 'selecting' | 'answering' | 'wagering' | 'buzzing' | 'checking' | 'round2';
 
-export class Jeopardy extends Rooms.RoomGame {
-	playerTable: {[userid: string]: JeopardyGamePlayer};
+export class Jeopardy extends Rooms.RoomGame<JeopardyGamePlayer> {
 	host: User;
 	state: JeopardyState;
 	gameid: ID;
@@ -47,7 +46,6 @@ export class Jeopardy extends Rooms.RoomGame {
 	constructor(room: Room, user: User, categoryCount: number, questionCount: number, playerCap: number) {
 		super(room);
 		this.gameNumber = room.nextGameNumber();
-		this.playerTable = Object.create(null);
 		this.host = user;
 		this.allowRenames = true;
 		this.state = "signups";
@@ -567,7 +565,7 @@ export class Jeopardy extends Rooms.RoomGame {
 	}
 }
 
-class JeopardyGamePlayer extends Rooms.RoomGamePlayer {
+class JeopardyGamePlayer extends Rooms.RoomGamePlayer<Jeopardy> {
 	answer: string;
 	points: number;
 	wager: number;

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -172,8 +172,7 @@ for (const section of tables) {
 }
 writeFile(LOGS_FILE, logs);
 
-class MafiaPlayer extends Rooms.RoomGamePlayer {
-	game: Mafia;
+class MafiaPlayer extends Rooms.RoomGamePlayer<Mafia> {
 	safeName: string;
 	role: MafiaRole | null;
 	voting: ID;
@@ -190,7 +189,6 @@ class MafiaPlayer extends Rooms.RoomGamePlayer {
 	idle: null | boolean;
 	constructor(user: User, game: Mafia) {
 		super(user, game);
-		this.game = game;
 		this.safeName = Utils.escapeHTML(this.name);
 		this.role = null;
 		this.voting = '';
@@ -230,14 +228,13 @@ class MafiaPlayer extends Rooms.RoomGamePlayer {
 	}
 }
 
-class Mafia extends Rooms.RoomGame {
+class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 	started: boolean;
 	theme: MafiaDataTheme | null;
 	hostid: ID;
 	host: string;
 	cohostids: ID[];
 	cohosts: string[];
-	playerTable: {[userid: string]: MafiaPlayer};
 	dead: {[userid: string]: MafiaPlayer};
 
 	subs: ID[];
@@ -288,7 +285,6 @@ class Mafia extends Rooms.RoomGame {
 		this.cohostids = [];
 		this.cohosts = [];
 
-		this.playerTable = Object.create(null);
 		this.dead = Object.create(null);
 		this.subs = [];
 		this.autoSub = true;

--- a/server/chat-plugins/rock-paper-scissors.tsx
+++ b/server/chat-plugins/rock-paper-scissors.tsx
@@ -31,18 +31,15 @@ export class RPSPlayer extends Rooms.RoomGamePlayer {
 	}
 }
 
-export class RPSGame extends Rooms.RoomGame {
+export class RPSGame extends Rooms.RoomGame<RPSPlayer> {
 	currentRound: number;
-	declare playerTable: {[k: string]: RPSPlayer};
 	readonly checkChat = true;
 	roundTimer: NodeJS.Timeout | null = null;
-	players: RPSPlayer[];
 	constructor(room: Room) {
 		super(room);
 		this.currentRound = 0;
 		this.title = 'Rock Paper Scissors';
 		this.gameid = 'rockpaperscissors' as ID;
-		this.players = [];
 
 		this.room.update();
 		this.controls(<div style={{textAlign: 'center'}}>Waiting for another player to join....</div>);
@@ -271,10 +268,13 @@ export class RPSGame extends Rooms.RoomGame {
 	}
 	addPlayer(user: User) {
 		if (this.playerTable[user.id]) throw new Chat.ErrorMessage(`You are already a player in this game.`);
-		this.playerTable[user.id] = new RPSPlayer(user, this);
+		this.playerTable[user.id] = this.makePlayer(user);
 		this.players.push(this.playerTable[user.id]);
 		this.room.auth.set(user.id, Users.PLAYER_SYMBOL);
 		return this.playerTable[user.id];
+	}
+	makePlayer(user: string | User | null): RPSPlayer {
+		return new RPSPlayer(user, this);
 	}
 }
 

--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -331,9 +331,7 @@ class ScavengerHuntDatabase {
 		return `${hunt.hosts.map(host => host.name).join(',')} | ${hunt.questions.map(question => `${question.text} | ${question.answers.join(';')}`).join(' | ')}`;
 	}
 }
-export class ScavengerHunt extends Rooms.RoomGame {
-	playerTable: {[userid: string]: ScavengerHuntPlayer};
-	players: ScavengerHuntPlayer[];
+export class ScavengerHunt extends Rooms.RoomGame<ScavengerHuntPlayer> {
 	gameType: GameTypes;
 	joinedIps: string[];
 	startTime: number;
@@ -361,9 +359,6 @@ export class ScavengerHunt extends Rooms.RoomGame {
 		mod?: string | string[]
 	) {
 		super(room);
-
-		this.playerTable = Object.create(null);
-		this.players = [];
 
 		this.allowRenames = true;
 		this.gameType = gameType;
@@ -987,8 +982,7 @@ export class ScavengerHunt extends Rooms.RoomGame {
 	}
 }
 
-export class ScavengerHuntPlayer extends Rooms.RoomGamePlayer {
-	game: ScavengerHunt;
+export class ScavengerHuntPlayer extends Rooms.RoomGamePlayer<ScavengerHunt> {
 	lastGuess: number;
 	completed: boolean;
 	joinIps: string[];
@@ -997,7 +991,6 @@ export class ScavengerHuntPlayer extends Rooms.RoomGamePlayer {
 	[k: string]: any; // for purposes of adding new temporary properties for the purpose of twists.
 	constructor(user: User, game: ScavengerHunt) {
 		super(user, game);
-		this.game = game;
 
 		this.joinIps = user.ips.slice();
 

--- a/server/chat-plugins/trivia/trivia.ts
+++ b/server/chat-plugins/trivia/trivia.ts
@@ -302,7 +302,7 @@ class Ladder {
 
 export const cachedLadder = new Ladder();
 
-class TriviaPlayer extends Rooms.RoomGamePlayer {
+class TriviaPlayer extends Rooms.RoomGamePlayer<Trivia> {
 	points: number;
 	correctAnswers: number;
 	answer: string;
@@ -312,7 +312,7 @@ class TriviaPlayer extends Rooms.RoomGamePlayer {
 	isCorrect: boolean;
 	isAbsent: boolean;
 
-	constructor(user: User, game: RoomGame) {
+	constructor(user: User, game: Trivia) {
 		super(user, game);
 		this.points = 0;
 		this.correctAnswers = 0;
@@ -355,8 +355,7 @@ class TriviaPlayer extends Rooms.RoomGamePlayer {
 	}
 }
 
-export class Trivia extends Rooms.RoomGame {
-	playerTable: {[k: string]: TriviaPlayer};
+export class Trivia extends Rooms.RoomGame<TriviaPlayer> {
 	gameid: ID;
 	kickedUsers: Set<string>;
 	canLateJoin: boolean;
@@ -376,7 +375,6 @@ export class Trivia extends Rooms.RoomGame {
 		isRandomMode = false, isSubGame = false, isRandomCategory = false,
 	) {
 		super(room, isSubGame);
-		this.playerTable = {};
 		this.gameid = 'trivia' as ID;
 		this.title = 'Trivia';
 		this.allowRenames = true;
@@ -1185,7 +1183,7 @@ export class TriumvirateModeTrivia extends Trivia {
  * and the top n players from those personal rounds go on to the finals,
  * which is a game of First mode trivia that ends after a specified interval.
  */
-export class Mastermind extends Rooms.RoomGame {
+export class Mastermind extends Rooms.SimpleRoomGame {
 	/** userid:score Map */
 	leaderboard: Map<ID, {score: number, hasLeft?: boolean}>;
 	phase: string;

--- a/server/chat-plugins/uno.ts
+++ b/server/chat-plugins/uno.ts
@@ -79,9 +79,7 @@ function createDeck() {
 	]; // 108 cards
 }
 
-export class UNO extends Rooms.RoomGame {
-	playerTable: {[userid: string]: UNOPlayer};
-	players: UNOPlayer[];
+export class UNO extends Rooms.RoomGame<UNOPlayer> {
 	playerCap: number;
 	allowRenames: boolean;
 	maxTime: number;
@@ -102,9 +100,6 @@ export class UNO extends Rooms.RoomGame {
 
 	constructor(room: Room, cap: number, suppressMessages: boolean) {
 		super(room);
-
-		this.playerTable = Object.create(null);
-		this.players = [];
 
 		this.gameNumber = room.nextGameNumber();
 
@@ -570,15 +565,13 @@ export class UNO extends Rooms.RoomGame {
 	}
 }
 
-class UNOPlayer extends Rooms.RoomGamePlayer {
+class UNOPlayer extends Rooms.RoomGamePlayer<UNO> {
 	hand: Card[];
-	game: UNO;
 	cardLock: string | null;
 
 	constructor(user: User, game: UNO) {
 		super(user, game);
 		this.hand = [];
-		this.game = game;
 		this.cardLock = null;
 	}
 

--- a/server/chat-plugins/wifi.tsx
+++ b/server/chat-plugins/wifi.tsx
@@ -94,7 +94,7 @@ const gameidToGame: {[k: string]: Game} = {
 	bdsp: 'BDSP',
 };
 
-class Giveaway extends Rooms.RoomGame {
+class Giveaway extends Rooms.SimpleRoomGame {
 	gaNumber: number;
 	host: User;
 	giver: User;
@@ -725,7 +725,7 @@ export class LotteryGiveaway extends Giveaway {
 	}
 }
 
-export class GTS extends Rooms.RoomGame {
+export class GTS extends Rooms.SimpleRoomGame {
 	gtsNumber: number;
 	room: Room;
 	giver: User;

--- a/server/chat-plugins/youtube.ts
+++ b/server/chat-plugins/youtube.ts
@@ -362,7 +362,7 @@ export const Twitch = new class {
 	}
 };
 
-export class GroupWatch extends Rooms.RoomGame {
+export class GroupWatch extends Rooms.SimpleRoomGame {
 	url: string;
 	info: VideoData;
 	started: number | null = null;
@@ -435,7 +435,7 @@ export class GroupWatch extends Rooms.RoomGame {
 	}
 }
 
-export class TwitchStream extends Rooms.RoomGame {
+export class TwitchStream extends Rooms.SimpleRoomGame {
 	started = false;
 	data: TwitchChannel;
 	constructor(room: Room, data: TwitchChannel) {

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -51,7 +51,7 @@ const DISCONNECTION_BANK_TIME = 300;
 // time after a player disabling the timer before they can re-enable it
 const TIMER_COOLDOWN = 20 * SECONDS;
 
-export class RoomBattlePlayer extends RoomGames.RoomGamePlayer {
+export class RoomBattlePlayer extends RoomGames.RoomGamePlayer<RoomBattle> {
 	readonly slot: SideID;
 	readonly channelIndex: ChannelIndex;
 	request: BattleRequestTracker;
@@ -490,7 +490,7 @@ export interface RoomBattleOptions {
 	seed?: PRNGSeed;
 }
 
-export class RoomBattle extends RoomGames.RoomGame {
+export class RoomBattle extends RoomGames.RoomGame<RoomBattlePlayer> {
 	readonly gameid: ID;
 	readonly room: GameRoom;
 	readonly title: string;
@@ -517,8 +517,6 @@ export class RoomBattle extends RoomGames.RoomGame {
 	active: boolean;
 	replaySaved: boolean;
 	forcedSettings: {modchat?: string | null, privacy?: string | null} = {};
-	playerTable: {[userid: string]: RoomBattlePlayer};
-	players: RoomBattlePlayer[];
 	p1: RoomBattlePlayer;
 	p2: RoomBattlePlayer;
 	p3: RoomBattlePlayer;
@@ -555,11 +553,6 @@ export class RoomBattle extends RoomGames.RoomGame {
 		this.ended = false;
 		this.active = false;
 		this.replaySaved = false;
-
-		// TypeScript bug: no `T extends RoomGamePlayer`
-		this.playerTable = Object.create(null);
-		// TypeScript bug: no `T extends RoomGamePlayer`
-		this.players = [];
 
 		this.playerCap = this.gameType === 'multi' || this.gameType === 'freeforall' ? 4 : 2;
 		this.p1 = null!;
@@ -1067,8 +1060,7 @@ export class RoomBattle extends RoomGames.RoomGame {
 	 * (so the player isn't recreated)
 	 */
 	addPlayer(user: User | null, playerOpts?: RoomBattlePlayerOptions) {
-		// TypeScript bug: no `T extends RoomGamePlayer`
-		const player = super.addPlayer(user) as RoomBattlePlayer;
+		const player = super.addPlayer(user);
 		if (!player) return null;
 		const slot = player.slot;
 		this[slot] = player;

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -34,7 +34,7 @@ import {QueuedHunt} from './chat-plugins/scavengers';
 import {ScavengerGameTemplate} from './chat-plugins/scavenger-games';
 import {RepeatedPhrase} from './chat-plugins/repeats';
 import {PM as RoomBattlePM, RoomBattle, RoomBattlePlayer, RoomBattleTimer, RoomBattleOptions} from "./room-battle";
-import {RoomGame, RoomGamePlayer} from './room-game';
+import {RoomGame, SimpleRoomGame, RoomGamePlayer} from './room-game';
 import {MinorActivity, MinorActivityData} from './room-minor-activity';
 import {Roomlogs} from './roomlogs';
 import * as crypto from 'crypto';
@@ -2040,6 +2040,7 @@ export const Rooms = {
 	ChatRoom: BasicRoom as typeof ChatRoom,
 
 	RoomGame,
+	SimpleRoomGame,
 	RoomGamePlayer,
 
 	MinorActivity,

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -45,7 +45,7 @@ function usersToNames(users: TournamentPlayer[]) {
 	return users.map(user => user.name);
 }
 
-export class TournamentPlayer extends Rooms.RoomGamePlayer {
+export class TournamentPlayer extends Rooms.RoomGamePlayer<Tournament> {
 	readonly availableMatches: Set<TournamentPlayer>;
 	isBusy: boolean;
 	inProgressMatch: {to: TournamentPlayer, room: GameRoom} | null;
@@ -82,9 +82,7 @@ export class TournamentPlayer extends Rooms.RoomGamePlayer {
 	}
 }
 
-export class Tournament extends Rooms.RoomGame {
-	readonly playerTable: {[userid: string]: TournamentPlayer};
-	readonly players: TournamentPlayer[];
+export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 	readonly isTournament: true;
 	readonly completedMatches: Set<RoomID>;
 	/** Format ID not including custom rules */
@@ -124,11 +122,6 @@ export class Tournament extends Rooms.RoomGame {
 		super(room);
 		this.gameid = 'tournament' as ID;
 		const formatId = toID(format);
-
-		// TypeScript bug: no `T extends RoomGamePlayer`
-		this.playerTable = Object.create(null);
-		// TypeScript bug: no `T extends RoomGamePlayer`
-		this.players = [];
 
 		this.title = format.name + ' tournament';
 		this.isTournament = true;
@@ -430,8 +423,8 @@ export class Tournament extends Rooms.RoomGame {
 			output.sendReply(`|tournament|error|BracketFrozen`);
 			return;
 		}
-		// TypeScript bug: no `T extends RoomGamePlayer`
-		const player = this.addPlayer(user) as TournamentPlayer;
+
+		const player = this.addPlayer(user);
 		if (!player) throw new Error("Failed to add player.");
 
 		this.playerTable[user.id] = player;


### PR DESCRIPTION
Redux of #7716 apparently.

`RoomGame` is now an abstract class with a type parameter for the player class. Because the `makePlayer` method must call the player constructor method directly, it is now an abstract method. Games without their own player class now extend `SimpleRoomGame` which has a default `makePlayer` implementation.

This makes RoomGame subclasses ever so slightly neater: for example, they no longer need to override `players` and `playerTable`.