### PR TITLE
Hackmons Cup: Fix custom un/bans with formes

### DIFF
--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -547,7 +547,7 @@ export class RandomTeams {
 
 					banReason = ruleTable.check('basepokemon:' + toID(species.baseSpecies));
 					if (banReason) continue;
-					if (banReason !== '' || this.dex.species.get(species.baseSpecies).isNonstandard === species.isNonstandard) {
+					if (banReason !== '' || this.dex.species.get(species.baseSpecies).isNonstandard !== species.isNonstandard) {
 						const nonexistentCheck = Tags.nonexistent.genericFilter!(species) && nonexistentBanReason;
 						let tagWhitelisted = false;
 						let tagBlacklisted = false;
@@ -572,10 +572,10 @@ export class RandomTeams {
 						}
 					}
 				}
+				speciesPool.push(species);
 				const num = species.num;
 				if (pool.includes(num)) continue;
 				pool.push(num);
-				speciesPool.push(species);
 			}
 		}
 


### PR DESCRIPTION
This fixes two bugs when using a custom ruleset for Hackmons Cup:
- Pokemon with multiple formes weren't being added to the pool when whitelisted except for formes that *did* have a different `isNonstandard` value (e.g. a ruleset of `-allpokemon, +mewtwo` would *only* add the megas in Gen 8)
- For Pokemon with multiple formes, only the first forme was being added to the pool (e.g. a ruleset of `-allpokemon, +zapdos` would only allow Zapdos instead of having an equal chance to pick Zapdos or Zapdos-Galar)