### PR TITLE
Spotlights: Fix "Refresh" button opening another tab

### DIFF
--- a/server/chat-plugins/daily-spotlight.ts
+++ b/server/chat-plugins/daily-spotlight.ts
@@ -88,7 +88,7 @@ export const pages: Chat.PageTable = {
 
 		let buf = `<div class="pad ladder">`;
 		buf += `<div class="pad">`;
-		buf += `<button style="float:right;" class="button" name="send" value="/join view-spotlights-${room.roomid}-${sortType}">`;
+		buf += `<button style="float:right;" class="button" name="send" value="/join view-spotlights-${room.roomid}${sortType ? '-' + sortType : ''}">`;
 		buf += `<i class="fa fa-refresh"></i> Refresh</button>`;
 		buf += `<h2>Daily Spotlights</h2>`;
 		// for posterity, all these switches are futureproofing for more sort types


### PR DESCRIPTION
This fixes a bug where the "Refresh" button in the default `/viewspotlights` page would open another tab instead of refreshing the current tab. (e.g. clicking it on `view-spotlights-lobby` would open another tab `view-spotlights-lobby-`)