### PR TITLE
Add a Dockerfile for running the server

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,12 +13,17 @@ ENV SHOWDOWNDIR "/showdown"
 # Create user 
 # Create the app dir we use and have the user own it
 # git clone the latest release into the app dir
+# create a sym link from /config to config/config.js 
+# to simplify the syntax to mount a custom config
+# copy config-example as defualt config to /config and chown it
 RUN useradd -u "${PUID}" -m "${USER}" \
 	&& mkdir -p ${SHOWDOWNDIR} \
 	&& chown ${USER} ${SHOWDOWNDIR} \
 	&& su "${USER}" -c \
 		"git clone https://github.com/smogon/pokemon-showdown.git --branch `git ls-remote --tags https://github.com/smogon/pokemon-showdown | tail -1 | cut -d / -f 3` ${SHOWDOWNDIR} \
-		&& ln -s /config.js ${SHOWDOWNDIR}/config/config.js"
+		&& ln -s /config.js ${SHOWDOWNDIR}/config/config.js" \
+  && cp ${SHOWDOWNDIR}/config/config-example.js /config.js \
+  && chown ${USER} /config.js
 
 # switch to the user
 USER ${USER}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,36 @@
+FROM node:16
+
+LABEL author="Brandon Layton"
+
+# Options to set in the environment
+# We will make a user to run the app
+# and a directory to have the app installed in
+ARG PUID=900
+
+ENV USER pokemon
+ENV SHOWDOWNDIR "/showdown"
+
+# Create user 
+# Create the app dir we use and have the user own it
+# git clone the latest release into the app dir
+RUN useradd -u "${PUID}" -m "${USER}" \
+	&& mkdir -p ${SHOWDOWNDIR} \
+	&& chown ${USER} ${SHOWDOWNDIR} \
+	&& su "${USER}" -c \
+		"git clone https://github.com/smogon/pokemon-showdown.git --branch `git ls-remote --tags https://github.com/smogon/pokemon-showdown | tail -1 | cut -d / -f 3` ${SHOWDOWNDIR} \
+		&& ln -s /config.js ${SHOWDOWNDIR}/config/config.js"
+
+# switch to the user
+USER ${USER}
+
+# set the working dir
+WORKDIR ${SHOWDOWNDIR}
+
+# make 3 volumes where data is written to
+VOLUME ${SHOWDOWNDIR}/logs ${SHOWDOWNDIR}/config ${SHOWDOWNDIR}/databases
+
+# expose the port the application uses
+EXPOSE 8000
+
+# finally run the application
+CMD [ "node", "pokemon-showdown" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,38 @@
+# Pokémon Showdown Docker
+
+This Dockerfile will build an image that can be used to run a docker container with. This application needs runs on port 8000, so you need to bind that port to your host. If you want to use a custom config you will also need to supply your own `config.js`, an example of this can be found at `config/config-example.js` of this repository.
+
+
+# Building & Running
+
+To build this image copy `Dockerfile` onto your computer to run with docker run or docker compose. You will need docker and/or docker-compose installed depending on what method you use. This Dockerfile will run the latest released version of Pokémon Showdown at the time  of building.
+
+##  Using docker run
+
+We will build the image first and then run it as a container. 
+While in the same directory this command will build the image and tag it as `pokemon-showdown`.
+```
+docker build . -t pokmon-showdown
+```
+
+After that we will want to run our image, publish port 8000, and add our custom config we have to the container. 
+```
+docker run -p 8000 -v /path/to/config.js:/config.js pokemon-showdown
+```
+If you do use the custom config make sure you include the path to `config.js` on your system. If you do not want to use a `config.js` just leave out `-v /path/to/config.js:/config.js`.
+
+## Using docker-compose
+
+This method requires you to have a docker-compose and docker installed. You will also need to make a `docker-compose.yaml` before you can run the container. This `docker-compose.yaml` will build the image and run it for you. The file you make should be placed in the same directory as the `Dockerfile` you have downloaded. 
+```
+version: "2.4"  
+services:  
+  pokemon-showdown:  
+	  build: .  
+    container_name: pokemon-showdown  
+    ports:  
+      - "8000:8000"  
+    volumes:  
+      - ./config.js:/config.js
+```
+To run the file enter the command `docker-compose up -d` in your terminal or powershell.  


### PR DESCRIPTION
Having a docker image to run the server with makes it simple for a lot of people to host there own server that they might want to use. Having to set this up natively or on a vm is not appealing for many people and may be a stopping point for some when they want to run there own server. A container will make running a server more accessible for people to do. 

I have looked at previous efforts and there seem to be old images and Dockerfiles out there but none that are kept up to date with the latest version. The best effort I saw was with this pull request #6184 and there were some good points to why it was not accepted. The biggest I saw was about the data in certain directories not being persistent. In my version of the Dockerbuild I added volumes for the directories that were stated to be a concern. Adding more as they are needed is also not a hard thing to do. 

I also have my Dockerfile get the latest release automatically from a git clone into the container. This also make the Dockerfile not have to be updated everytime a new release comes out.