### PR TITLE
VGC 2013: Ban Chatot

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3332,7 +3332,7 @@ export const Formats: FormatList = [
 		gameType: 'doubles',
 		searchShow: false,
 		ruleset: ['Flat Rules'],
-		banlist: ['Dark Void', 'Sky Drop', 'Soul Dew'],
+		banlist: ['Chatot', 'Dark Void', 'Sky Drop', 'Soul Dew'],
 	},
 	{
 		name: "[Gen 5] VGC 2012",


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-9154734

[VGC 2012 Rules](http://assets.pokemon.com/assets/cms/pdf/op/tournaments/2012/pokemon_official_tournament_formats.pdf) | [VGC 2013 Rules](https://assets.pokemon.com/assets/cms/pdf/op/tournaments/2013/Play_Pokemon_VG_Rules_and_Formats.pdf)

The bug report claimed that Chatot should not be allowed in 2012 & 2013 but these official rules docs show that it should only be banned in 2013