### PR TITLE
Scavengers: fix sorting direction

### DIFF
--- a/server/chat-plugins/scavenger-games.ts
+++ b/server/chat-plugins/scavenger-games.ts
@@ -254,7 +254,7 @@ const TWISTS: {[k: string]: Twist} = {
 		},
 
 		onEnd() {
-			Utils.sortBy(this.completed, entry => -entry.total);
+			Utils.sortBy(this.completed, entry => entry.total);
 		},
 	},
 


### PR DESCRIPTION
@Zarel can you patch this after it goes in? since it's used daily by scavs

I think mia got the sort direction wrong when she made the suggestion