### PR TITLE
Fix VGC 2009 bans

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3510,7 +3510,7 @@ export const Formats: FormatList = [
 		gameType: 'doubles',
 		searchShow: false,
 		ruleset: ['Flat Rules', '! Adjust Level Down', 'Max Level = 50', 'Max Team Size = 4'],
-		banlist: ['Soul Dew', 'Rotom-Heat', 'Rotom-Wash', 'Rotom-Frost', 'Rotom-Fan', 'Rotom-Mow'],
+		banlist: ['Tyranitar', 'Rotom', 'Judgment', 'Soul Dew'],
 	},
 	{
 		name: "[Gen 4] Doubles Custom Game",


### PR DESCRIPTION
https://web.archive.org/web/20090412160033/http://origin.pokemonvgc.com/en/rules/rrg.html

Found the official rules doc, here are the specific things that are getting fixed

- All Rotom formes, including the base, should be banned (previously the formes were banned but not the base)
- Judgment should be banned (rules say that Sketch can only use moves learned by dex numbers 1-492. Arceus is 493 so Judgment can't be used)
- I also explicitly banned Tyranitar even though it's implicitly banned due to `Max Level` being set to 50 so that the validator message could be clearer ("Tyranitar is banned" instead of "Tyranitar must be at least level 55 to be evolved")