### PR TITLE
Tours: Enable /tour replace to directly exchange alts

### DIFF
--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -492,7 +492,9 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 			for (const otherPlayer of this.players) {
 				if (!otherPlayer) continue;
 				const otherUser = Users.get(otherPlayer.id);
-				if (otherUser && otherUser.latestIp === replacementUser.latestIp) {
+				if (otherUser &&
+					otherUser.latestIp === replacementUser.latestIp &&
+					replacementUser.latestIp !== user.latestIp) {
 					output.errorReply(`${replacementUser.name} already has an alt in the tournament.`);
 					return;
 				}


### PR DESCRIPTION
It's possible that there is an intended reason not to allow this that I don't understand, but the current behavior that disallows directly substituting alts of the same user is overly aggressive and seems like an oversight. If only alts of the same user can be exchanged, there should still be at most one entry per user in a tour after the transaction completes, since their previous alt must also be removed from the tour.

Use case/current problem: sometimes when a user is briefly disconnected after a tour they have entered starts, their tour entry is turned into that of a Guest account which has the same IP as them, preventing them from being able to enter battles. When they request a driver to perform a replacement of the Guest with their real account, the operation is currently blocked by the IP check.

It is currently possible for drivers to work around this by substituting a dummy account not currently in the tour, such as their own, with the Guest, and then subsequently substituting the dummy with the original stranded user account with a second /tour replace. However, 1. many drivers might not realize that this could work, especially considering the nature of the error message and 2. since it takes more time to think of and execute this work-around, it increases the risk of the stranded user's Guest alt being autodqed, etc before the situation can be resolved.