### PR TITLE
Combine `lint` and `full-lint` NPM scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,13 +34,13 @@
     "build": "node build",
     "tsc": "tsc",
     "fast-lint": "eslint . --config .eslintrc-no-types.json --cache --cache-location .eslintcache-no-types --ext .js,.ts,.tsx",
-    "lint": "eslint . --cache --ext .js,.ts,.tsx",
+    "lint": "eslint . --cache --ext .js,.ts,.tsx --max-warnings 0",
     "fix": "eslint . --cache --ext .js,.ts,.tsx --fix",
-    "full-lint": "eslint . --cache --ext .js,.ts --max-warnings 0",
+    "full-lint": "npm run lint",
     "pretest": "npm run lint",
     "test": "mocha",
     "posttest": "npm run tsc",
-    "full-test": "npm run full-lint && npm run tsc && mocha --timeout 8000 --forbid-only -g \".*\""
+    "full-test": "npm run lint && npm run tsc && mocha --timeout 8000 --forbid-only -g \".*\""
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Now that [`lint` and `full-lint` use the same configuration](https://github.com/smogon/pokemon-showdown/commit/c57fcf25c69454bc8c9a21e183c75cfe75ed68a9), the only difference between them is the `--max-warnings` flag.

This separation causes some problems:
- In small terminal windows, warnings can be obscured by terminal scroll due to the large volume of unit tests. These warnings in turn cause CI failures since GitHub Actions runs `full-lint`.
- When changes to the linting script need to be made, **three** scripts need to be updated. This can lead to oversights such as `full-lint` not being updated for `.tsx` files when JSX support was added.

I've made this a PR in case anyone else has opinions.