### PR TITLE
Change wss URL in PROTOCOL.md

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -9,7 +9,7 @@ Showdown directly using WebSocket:
 
     ws://sim.smogon.com:8000/showdown/websocket
       or
-    wss://sim.smogon.com/showdown/websocket
+    wss://sim3.psim.us/showdown/websocket
 
 Client implementations you might want to look at for reference include:
 


### PR DESCRIPTION
The previously shown URL (https://sim.smogon.com/showdown/websocket), along with sim3.smogon.com or sim.psim.us, doesn't work, since it serves a certificate that's only valid for sim3.psim.us, which is also the default domain currently used by the client.