### PR TITLE
Implement held Poke Ball legality

### DIFF
--- a/data/items.ts
+++ b/data/items.ts
@@ -752,6 +752,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		num: 16,
 		gen: 4,
 		isPokeball: true,
+		isNonstandard: "Unobtainable",
 	},
 	chestoberry: {
 		name: "Chesto Berry",
@@ -3773,6 +3774,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		num: 500,
 		gen: 4,
 		isPokeball: true,
+		isNonstandard: "Unobtainable",
 	},
 	passhoberry: {
 		name: "Passho Berry",

--- a/data/items.ts
+++ b/data/items.ts
@@ -1604,7 +1604,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 715,
 		gen: 6,
-		isNonstandard: "Past",
+		isNonstandard: "Unobtainable",
 	},
 	fairymemory: {
 		name: "Fairy Memory",

--- a/data/items.ts
+++ b/data/items.ts
@@ -1604,7 +1604,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 715,
 		gen: 6,
-		isNonstandard: "Unobtainable",
+		isNonstandard: "Past",
 	},
 	fairymemory: {
 		name: "Fairy Memory",

--- a/data/mods/gen2/items.ts
+++ b/data/mods/gen2/items.ts
@@ -50,6 +50,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 			}
 		},
 	},
+	fastball: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	focusband: {
 		inherit: true,
 		onDamage(damage, target, source, effect) {
@@ -67,6 +71,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 				return damage * 1.1;
 			}
 		},
+	},
+	heavyball: {
+		inherit: true,
+		isNonstandard: null,
 	},
 	kingsrock: {
 		inherit: true,
@@ -91,10 +99,18 @@ export const Items: {[k: string]: ModdedItemData} = {
 		onResidualOrder: 5,
 		onResidualSubOrder: 1,
 	},
+	levelball: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	lightball: {
 		inherit: true,
 		// In Gen 2 this happens in stat calculation directly.
 		onModifySpA() {},
+	},
+	loveball: {
+		inherit: true,
+		isNonstandard: null,
 	},
 	luckypunch: {
 		inherit: true,
@@ -104,6 +120,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 				return 3;
 			}
 		},
+	},
+	lureball: {
+		inherit: true,
+		isNonstandard: null,
 	},
 	magnet: {
 		inherit: true,
@@ -137,6 +157,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 				return damage * 1.1;
 			}
 		},
+	},
+	moonball: {
+		inherit: true,
+		isNonstandard: null,
 	},
 	mysticwater: {
 		inherit: true,
@@ -200,6 +224,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 				return damage * 1.1;
 			}
 		},
+	},
+	sportball: {
+		inherit: true,
+		isNonstandard: null,
 	},
 	stick: {
 		inherit: true,

--- a/data/mods/gen3/items.ts
+++ b/data/mods/gen3/items.ts
@@ -85,7 +85,7 @@ export const Items: {[k: string]: ModdedItemData} = {
 	},
 	fastball: {
 		inherit: true,
-		isNonstandard: "Past",
+		isNonstandard: "Unobtainable",
 	},
 	figyberry: {
 		inherit: true,
@@ -121,7 +121,7 @@ export const Items: {[k: string]: ModdedItemData} = {
 	},
 	heavyball: {
 		inherit: true,
-		isNonstandard: "Past",
+		isNonstandard: "Unobtainable",
 	},
 	iapapaberry: {
 		inherit: true,
@@ -170,7 +170,7 @@ export const Items: {[k: string]: ModdedItemData} = {
 	},
 	levelball: {
 		inherit: true,
-		isNonstandard: "Past",
+		isNonstandard: "Unobtainable",
 	},
 	liechiberry: {
 		inherit: true,
@@ -194,11 +194,11 @@ export const Items: {[k: string]: ModdedItemData} = {
 	},
 	loveball: {
 		inherit: true,
-		isNonstandard: "Past",
+		isNonstandard: "Unobtainable",
 	},
 	lureball: {
 		inherit: true,
-		isNonstandard: "Past",
+		isNonstandard: "Unobtainable",
 	},
 	magnet: {
 		inherit: true,
@@ -243,7 +243,7 @@ export const Items: {[k: string]: ModdedItemData} = {
 	},
 	moonball: {
 		inherit: true,
-		isNonstandard: "Past",
+		isNonstandard: "Unobtainable",
 	},
 	mysticwater: {
 		inherit: true,
@@ -389,7 +389,7 @@ export const Items: {[k: string]: ModdedItemData} = {
 	},
 	sportball: {
 		inherit: true,
-		isNonstandard: "Past",
+		isNonstandard: "Unobtainable",
 	},
 	starfberry: {
 		inherit: true,

--- a/data/mods/gen3/items.ts
+++ b/data/mods/gen3/items.ts
@@ -83,6 +83,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		gen: 3,
 		isNonstandard: "Unobtainable",
 	},
+	fastball: {
+		inherit: true,
+		isNonstandard: "Past",
+	},
 	figyberry: {
 		inherit: true,
 		onUpdate() {},
@@ -114,6 +118,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 				return this.chainModify(1.1);
 			}
 		},
+	},
+	heavyball: {
+		inherit: true,
+		isNonstandard: "Past",
 	},
 	iapapaberry: {
 		inherit: true,
@@ -160,6 +168,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 			return accuracy * 0.95;
 		},
 	},
+	levelball: {
+		inherit: true,
+		isNonstandard: "Past",
+	},
 	liechiberry: {
 		inherit: true,
 		onUpdate() {},
@@ -179,6 +191,14 @@ export const Items: {[k: string]: ModdedItemData} = {
 			}
 		},
 		onBasePower() {},
+	},
+	loveball: {
+		inherit: true,
+		isNonstandard: "Past",
+	},
+	lureball: {
+		inherit: true,
+		isNonstandard: "Past",
 	},
 	magnet: {
 		inherit: true,
@@ -220,6 +240,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 				return this.chainModify(1.1);
 			}
 		},
+	},
+	moonball: {
+		inherit: true,
+		isNonstandard: "Past",
 	},
 	mysticwater: {
 		inherit: true,
@@ -362,6 +386,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 				return this.chainModify(1.1);
 			}
 		},
+	},
+	sportball: {
+		inherit: true,
+		isNonstandard: "Past",
 	},
 	starfberry: {
 		inherit: true,

--- a/data/mods/gen4/items.ts
+++ b/data/mods/gen4/items.ts
@@ -113,6 +113,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 			}
 		},
 	},
+	fastball: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	flameorb: {
 		inherit: true,
 		onResidualOrder: 10,
@@ -148,6 +152,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 			}
 		},
 	},
+	heavyball: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	ironball: {
 		inherit: true,
 		onEffectiveness() {},
@@ -180,6 +188,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		onResidualOrder: 10,
 		onResidualSubOrder: 4,
+	},
+	levelball: {
+		inherit: true,
+		isNonstandard: null,
 	},
 	lifeorb: {
 		inherit: true,
@@ -214,6 +226,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 			}
 		},
 	},
+	loveball: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	luckypunch: {
 		inherit: true,
 		onModifyCritRatio(critRatio, user) {
@@ -221,6 +237,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 				return critRatio + 2;
 			}
 		},
+	},
+	lureball: {
+		inherit: true,
+		isNonstandard: null,
 	},
 	lustrousorb: {
 		inherit: true,
@@ -286,6 +306,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 			},
 		},
 	},
+	moonball: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	razorfang: {
 		inherit: true,
 		onModifyMove(move) {
@@ -300,6 +324,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 				});
 			}
 		},
+	},
+	sportball: {
+		inherit: true,
+		isNonstandard: null,
 	},
 	stick: {
 		inherit: true,

--- a/data/mods/gen5/items.ts
+++ b/data/mods/gen5/items.ts
@@ -299,10 +299,6 @@ export const Items: {[k: string]: ModdedItemData} = {
 			type: "Dragon",
 		},
 	},
-	normalgem: {
-		inherit: true,
-		isNonstandard: null,
-	},
 	occaberry: {
 		inherit: true,
 		naturalGift: {

--- a/data/mods/gen6/items.ts
+++ b/data/mods/gen6/items.ts
@@ -27,7 +27,7 @@ export const Items: {[k: string]: ModdedItemData} = {
 	},
 	fastball: {
 		inherit: true,
-		isNonstandard: "Past",
+		isNonstandard: "Unobtainable",
 	},
 	figyberry: {
 		inherit: true,
@@ -45,7 +45,7 @@ export const Items: {[k: string]: ModdedItemData} = {
 	},
 	heavyball: {
 		inherit: true,
-		isNonstandard: "Past",
+		isNonstandard: "Unobtainable",
 	},
 	iapapaberry: {
 		inherit: true,
@@ -73,7 +73,7 @@ export const Items: {[k: string]: ModdedItemData} = {
 	},
 	levelball: {
 		inherit: true,
-		isNonstandard: "Past",
+		isNonstandard: "Unobtainable",
 	},
 	lifeorb: {
 		inherit: true,
@@ -85,11 +85,11 @@ export const Items: {[k: string]: ModdedItemData} = {
 	},
 	loveball: {
 		inherit: true,
-		isNonstandard: "Past",
+		isNonstandard: "Unobtainable",
 	},
 	lureball: {
 		inherit: true,
-		isNonstandard: "Past",
+		isNonstandard: "Unobtainable",
 	},
 	machobrace: {
 		inherit: true,
@@ -115,7 +115,7 @@ export const Items: {[k: string]: ModdedItemData} = {
 	},
 	moonball: {
 		inherit: true,
-		isNonstandard: "Past",
+		isNonstandard: "Unobtainable",
 	},
 	nanabberry: {
 		inherit: true,

--- a/data/mods/gen6/items.ts
+++ b/data/mods/gen6/items.ts
@@ -25,6 +25,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	fastball: {
+		inherit: true,
+		isNonstandard: "Past",
+	},
 	figyberry: {
 		inherit: true,
 		onUpdate(pokemon) {
@@ -38,6 +42,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 				pokemon.addVolatile('confusion');
 			}
 		},
+	},
+	heavyball: {
+		inherit: true,
+		isNonstandard: "Past",
 	},
 	iapapaberry: {
 		inherit: true,
@@ -63,6 +71,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 			}
 		},
 	},
+	levelball: {
+		inherit: true,
+		isNonstandard: "Past",
+	},
 	lifeorb: {
 		inherit: true,
 		onAfterMoveSecondarySelf(source, target, move) {
@@ -70,6 +82,14 @@ export const Items: {[k: string]: ModdedItemData} = {
 				this.damage(source.baseMaxhp / 10, source, source, this.dex.items.get('lifeorb'));
 			}
 		},
+	},
+	loveball: {
+		inherit: true,
+		isNonstandard: "Past",
+	},
+	lureball: {
+		inherit: true,
+		isNonstandard: "Past",
 	},
 	machobrace: {
 		inherit: true,
@@ -92,6 +112,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 	magostberry: {
 		inherit: true,
 		isNonstandard: null,
+	},
+	moonball: {
+		inherit: true,
+		isNonstandard: "Past",
 	},
 	nanabberry: {
 		inherit: true,

--- a/data/mods/gen6/items.ts
+++ b/data/mods/gen6/items.ts
@@ -13,10 +13,6 @@ export const Items: {[k: string]: ModdedItemData} = {
 			}
 		},
 	},
-	beastball: {
-		inherit: true,
-		isNonstandard: "Future",
-	},
 	belueberry: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/gen6/items.ts
+++ b/data/mods/gen6/items.ts
@@ -13,6 +13,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 			}
 		},
 	},
+	beastball: {
+		inherit: true,
+		isNonstandard: "Future",
+	},
 	belueberry: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/gen7/items.ts
+++ b/data/mods/gen7/items.ts
@@ -72,6 +72,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	buggem: {
+		inherit: true,
+		isNonstandard: "Unobtainable",
+	},
 	buginiumz: {
 		inherit: true,
 		isNonstandard: null,
@@ -100,6 +104,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	darkgem: {
+		inherit: true,
+		isNonstandard: "Unobtainable",
+	},
 	darkiniumz: {
 		inherit: true,
 		isNonstandard: null,
@@ -119,6 +127,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 	dracoplate: {
 		inherit: true,
 		isNonstandard: null,
+	},
+	dragongem: {
+		inherit: true,
+		isNonstandard: "Unobtainable",
 	},
 	dragoniumz: {
 		inherit: true,
@@ -144,6 +156,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	electricgem: {
+		inherit: true,
+		isNonstandard: "Unobtainable",
+	},
 	electriumz: {
 		inherit: true,
 		isNonstandard: null,
@@ -151,6 +167,14 @@ export const Items: {[k: string]: ModdedItemData} = {
 	fairiumz: {
 		inherit: true,
 		isNonstandard: null,
+	},
+	fairygem: {
+		inherit: true,
+		isNonstandard: "Unobtainable",
+	},
+	fightinggem: {
+		inherit: true,
+		isNonstandard: "Unobtainable",
 	},
 	fightiniumz: {
 		inherit: true,
@@ -165,6 +189,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 			}
 		},
 	},
+	firegem: {
+		inherit: true,
+		isNonstandard: "Unobtainable",
+	},
 	firiumz: {
 		inherit: true,
 		isNonstandard: null,
@@ -176,6 +204,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 	flameplate: {
 		inherit: true,
 		isNonstandard: null,
+	},
+	flyinggem: {
+		inherit: true,
+		isNonstandard: "Unobtainable",
 	},
 	flyiniumz: {
 		inherit: true,
@@ -197,6 +229,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	ghostgem: {
+		inherit: true,
+		isNonstandard: "Unobtainable",
+	},
 	ghostiumz: {
 		inherit: true,
 		isNonstandard: null,
@@ -205,9 +241,17 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	grassgem: {
+		inherit: true,
+		isNonstandard: "Unobtainable",
+	},
 	grassiumz: {
 		inherit: true,
 		isNonstandard: null,
+	},
+	groundgem: {
+		inherit: true,
+		isNonstandard: "Unobtainable",
 	},
 	groundiumz: {
 		inherit: true,
@@ -237,6 +281,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 				pokemon.addVolatile('confusion');
 			}
 		},
+	},
+	icegem: {
+		inherit: true,
+		isNonstandard: "Unobtainable",
 	},
 	icicleplate: {
 		inherit: true,
@@ -399,6 +447,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	poisongem: {
+		inherit: true,
+		isNonstandard: "Unobtainable",
+	},
 	poisoniumz: {
 		inherit: true,
 		isNonstandard: null,
@@ -426,6 +478,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 	redorb: {
 		inherit: true,
 		isNonstandard: null,
+	},
+	rockgem: {
+		inherit: true,
+		isNonstandard: "Unobtainable",
 	},
 	rockiumz: {
 		inherit: true,
@@ -499,6 +555,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: "Past",
 	},
+	steelgem: {
+		inherit: true,
+		isNonstandard: "Unobtainable",
+	},
 	steeliumz: {
 		inherit: true,
 		isNonstandard: null,
@@ -538,6 +598,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 	venusaurite: {
 		inherit: true,
 		isNonstandard: null,
+	},
+	watergem: {
+		inherit: true,
+		isNonstandard: "Unobtainable",
 	},
 	wateriumz: {
 		inherit: true,

--- a/data/mods/gen7/items.ts
+++ b/data/mods/gen7/items.ts
@@ -72,10 +72,6 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
-	buggem: {
-		inherit: true,
-		isNonstandard: "Unobtainable",
-	},
 	buginiumz: {
 		inherit: true,
 		isNonstandard: null,
@@ -104,10 +100,6 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
-	darkgem: {
-		inherit: true,
-		isNonstandard: "Unobtainable",
-	},
 	darkiniumz: {
 		inherit: true,
 		isNonstandard: null,
@@ -127,10 +119,6 @@ export const Items: {[k: string]: ModdedItemData} = {
 	dracoplate: {
 		inherit: true,
 		isNonstandard: null,
-	},
-	dragongem: {
-		inherit: true,
-		isNonstandard: "Unobtainable",
 	},
 	dragoniumz: {
 		inherit: true,
@@ -156,10 +144,6 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
-	electricgem: {
-		inherit: true,
-		isNonstandard: "Unobtainable",
-	},
 	electriumz: {
 		inherit: true,
 		isNonstandard: null,
@@ -167,14 +151,6 @@ export const Items: {[k: string]: ModdedItemData} = {
 	fairiumz: {
 		inherit: true,
 		isNonstandard: null,
-	},
-	fairygem: {
-		inherit: true,
-		isNonstandard: "Unobtainable",
-	},
-	fightinggem: {
-		inherit: true,
-		isNonstandard: "Unobtainable",
 	},
 	fightiniumz: {
 		inherit: true,
@@ -189,10 +165,6 @@ export const Items: {[k: string]: ModdedItemData} = {
 			}
 		},
 	},
-	firegem: {
-		inherit: true,
-		isNonstandard: "Unobtainable",
-	},
 	firiumz: {
 		inherit: true,
 		isNonstandard: null,
@@ -204,10 +176,6 @@ export const Items: {[k: string]: ModdedItemData} = {
 	flameplate: {
 		inherit: true,
 		isNonstandard: null,
-	},
-	flyinggem: {
-		inherit: true,
-		isNonstandard: "Unobtainable",
 	},
 	flyiniumz: {
 		inherit: true,
@@ -229,10 +197,6 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
-	ghostgem: {
-		inherit: true,
-		isNonstandard: "Unobtainable",
-	},
 	ghostiumz: {
 		inherit: true,
 		isNonstandard: null,
@@ -241,17 +205,9 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
-	grassgem: {
-		inherit: true,
-		isNonstandard: "Unobtainable",
-	},
 	grassiumz: {
 		inherit: true,
 		isNonstandard: null,
-	},
-	groundgem: {
-		inherit: true,
-		isNonstandard: "Unobtainable",
 	},
 	groundiumz: {
 		inherit: true,
@@ -281,10 +237,6 @@ export const Items: {[k: string]: ModdedItemData} = {
 				pokemon.addVolatile('confusion');
 			}
 		},
-	},
-	icegem: {
-		inherit: true,
-		isNonstandard: "Unobtainable",
 	},
 	icicleplate: {
 		inherit: true,
@@ -447,10 +399,6 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
-	poisongem: {
-		inherit: true,
-		isNonstandard: "Unobtainable",
-	},
 	poisoniumz: {
 		inherit: true,
 		isNonstandard: null,
@@ -458,10 +406,6 @@ export const Items: {[k: string]: ModdedItemData} = {
 	primariumz: {
 		inherit: true,
 		isNonstandard: null,
-	},
-	psychicgem: {
-		inherit: true,
-		isNonstandard: "Unobtainable",
 	},
 	psychiumz: {
 		inherit: true,
@@ -482,10 +426,6 @@ export const Items: {[k: string]: ModdedItemData} = {
 	redorb: {
 		inherit: true,
 		isNonstandard: null,
-	},
-	rockgem: {
-		inherit: true,
-		isNonstandard: "Unobtainable",
 	},
 	rockiumz: {
 		inherit: true,
@@ -559,10 +499,6 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: "Past",
 	},
-	steelgem: {
-		inherit: true,
-		isNonstandard: "Unobtainable",
-	},
 	steeliumz: {
 		inherit: true,
 		isNonstandard: null,
@@ -602,10 +538,6 @@ export const Items: {[k: string]: ModdedItemData} = {
 	venusaurite: {
 		inherit: true,
 		isNonstandard: null,
-	},
-	watergem: {
-		inherit: true,
-		isNonstandard: "Unobtainable",
 	},
 	wateriumz: {
 		inherit: true,

--- a/data/mods/gen7/items.ts
+++ b/data/mods/gen7/items.ts
@@ -140,6 +140,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	dreamball: {
+		inherit: true,
+		isNonstandard: "Future",
+	},
 	durinberry: {
 		inherit: true,
 		isNonstandard: "Unobtainable",
@@ -495,6 +499,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	safariball: {
+		inherit: true,
+		isNonstandard: "Future",
+	},
 	sailfossil: {
 		inherit: true,
 		isNonstandard: null,
@@ -546,6 +554,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 	spookyplate: {
 		inherit: true,
 		isNonstandard: null,
+	},
+	sportball: {
+		inherit: true,
+		isNonstandard: "Past",
 	},
 	steelgem: {
 		inherit: true,

--- a/data/mods/gen7/items.ts
+++ b/data/mods/gen7/items.ts
@@ -142,7 +142,7 @@ export const Items: {[k: string]: ModdedItemData} = {
 	},
 	dreamball: {
 		inherit: true,
-		isNonstandard: "Future",
+		isNonstandard: "Unobtainable",
 	},
 	durinberry: {
 		inherit: true,
@@ -497,7 +497,7 @@ export const Items: {[k: string]: ModdedItemData} = {
 	},
 	safariball: {
 		inherit: true,
-		isNonstandard: "Future",
+		isNonstandard: "Unobtainable",
 	},
 	sailfossil: {
 		inherit: true,
@@ -553,7 +553,7 @@ export const Items: {[k: string]: ModdedItemData} = {
 	},
 	sportball: {
 		inherit: true,
-		isNonstandard: "Past",
+		isNonstandard: "Unobtainable",
 	},
 	steelgem: {
 		inherit: true,

--- a/data/mods/gen7/items.ts
+++ b/data/mods/gen7/items.ts
@@ -459,6 +459,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	psychicgem: {
+		inherit: true,
+		isNonstandard: "Unobtainable",
+	},
 	psychiumz: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/gen8bdsp/items.ts
+++ b/data/mods/gen8bdsp/items.ts
@@ -83,6 +83,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	dreamball: {
+		inherit: true,
+		isNonstandard: "Past",
+	},
 	earthplate: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/gen8bdsp/items.ts
+++ b/data/mods/gen8bdsp/items.ts
@@ -23,6 +23,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: "Past",
 	},
+	beastball: {
+		inherit: true,
+		isNonstandard: "Past",
+	},
 	blunderpolicy: {
 		inherit: true,
 		isNonstandard: "Past",
@@ -309,6 +313,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		isNonstandard: "Past",
 	},
 	sachet: {
+		inherit: true,
+		isNonstandard: "Past",
+	},
+	safariball: {
 		inherit: true,
 		isNonstandard: "Past",
 	},

--- a/test/sim/dex.js
+++ b/test/sim/dex.js
@@ -57,13 +57,20 @@ describe('Dex#getSpecies', function () {
 });
 
 describe('Dex#getItem', function () {
-	it('should not mark Gems as as Nonstandard in Gens 5-7', function () {
-		assert(!Dex.forGen(5).items.get('Rock Gem').isNonstandard);
-		assert(!Dex.forGen(5).items.get('Normal Gem').isNonstandard);
+	it(`should correctly mark Gem legality`, function () {
+		assert.false(Dex.forGen(5).items.get('Rock Gem').isNonstandard);
+		assert.false(Dex.forGen(5).items.get('Normal Gem').isNonstandard);
 
-		assert.equal(Dex.forGen(6).items.get('Rock Gem').isNonstandard, 'Unobtainable');
-		assert(!Dex.forGen(6).items.get('Normal Gem').isNonstandard);
+		assert.false(Dex.forGen(6).items.get('Normal Gem').isNonstandard);
+		assert.equal(Dex.forGen(6).items.get('Rock Gem').isNonstandard, "Past");
+		assert.equal(Dex.forGen(6).items.get('Fairy Gem').isNonstandard, "Unobtainable");
 
-		assert.equal(Dex.forGen(8).items.get('Rock Gem').isNonstandard, 'Past');
+		assert.false(Dex.forGen(7).items.get('Normal Gem').isNonstandard);
+		assert.equal(Dex.forGen(7).items.get('Rock Gem').isNonstandard, "Past");
+		assert.equal(Dex.forGen(7).items.get('Fairy Gem').isNonstandard, "Unobtainable");
+
+		assert.false(Dex.forGen(8).items.get('Normal Gem').isNonstandard);
+		assert.equal(Dex.forGen(8).items.get('Rock Gem').isNonstandard, "Past");
+		assert.equal(Dex.forGen(8).items.get('Fairy Gem').isNonstandard, "Unobtainable");
 	});
 });

--- a/test/sim/dex.js
+++ b/test/sim/dex.js
@@ -57,7 +57,7 @@ describe('Dex#getSpecies', function () {
 });
 
 describe('Dex#getItem', function () {
-	it.only(`should correctly mark Gem legality`, function () {
+	it(`should correctly mark Gem legality`, function () {
 		assert.false(Dex.forGen(5).items.get('Normal Gem').isNonstandard);
 		assert.false(Dex.forGen(5).items.get('Rock Gem').isNonstandard);
 

--- a/test/sim/dex.js
+++ b/test/sim/dex.js
@@ -57,20 +57,17 @@ describe('Dex#getSpecies', function () {
 });
 
 describe('Dex#getItem', function () {
-	it(`should correctly mark Gem legality`, function () {
-		assert.false(Dex.forGen(5).items.get('Rock Gem').isNonstandard);
+	it.only(`should correctly mark Gem legality`, function () {
 		assert.false(Dex.forGen(5).items.get('Normal Gem').isNonstandard);
+		assert.false(Dex.forGen(5).items.get('Rock Gem').isNonstandard);
 
 		assert.false(Dex.forGen(6).items.get('Normal Gem').isNonstandard);
-		assert.equal(Dex.forGen(6).items.get('Rock Gem').isNonstandard, "Past");
-		assert.equal(Dex.forGen(6).items.get('Fairy Gem').isNonstandard, "Unobtainable");
+		assert.equal(Dex.forGen(6).items.get('Rock Gem').isNonstandard, "Unobtainable");
 
 		assert.false(Dex.forGen(7).items.get('Normal Gem').isNonstandard);
-		assert.equal(Dex.forGen(7).items.get('Rock Gem').isNonstandard, "Past");
-		assert.equal(Dex.forGen(7).items.get('Fairy Gem').isNonstandard, "Unobtainable");
+		assert.equal(Dex.forGen(7).items.get('Rock Gem').isNonstandard, "Unobtainable");
 
 		assert.false(Dex.forGen(8).items.get('Normal Gem').isNonstandard);
 		assert.equal(Dex.forGen(8).items.get('Rock Gem').isNonstandard, "Past");
-		assert.equal(Dex.forGen(8).items.get('Fairy Gem').isNonstandard, "Unobtainable");
 	});
 });


### PR DESCRIPTION
Various Poke Balls have only been available at one point or another as held items:

- Cherish Ball and Park Ball have never been available
- Dream Ball and Safari Ball are only available as of Gen 8
- Beast Ball, Dream Ball, and Safari Ball aren't available in BDSP
- The Apricorn balls (Fast, Heavy, Level, Love, Lure, and Moon) are only available in Gens 2, 4, and 7-onwards
- Sport Ball is only available in Gens 2, 4, and 8

For Gems, Fairy Gem should be marked as ``Unobtainable``, while everything but Normal Gem should presumably be marked as ``Past``. Fairy Gem was added in Gen 6 but never released, whereas all the other Gems used to be in Gen 5. I know there's a test saying otherwise but I'm pretty sure they should be semantically marked as ``Past`` and the test itself is wrong (checking [Discord activity around the time](https://discord.com/channels/630837856075513856/630845310033330206/699491404690227232), I think pre just edited it to make it pass, back when we were using ``isUnreleased`` notation).