### PR TITLE
Gen VIII: Implement Fly animation target leak

### DIFF
--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -259,6 +259,20 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			return success;
 		},
 	},
+	fly: {
+		inherit: true,
+		onTryMove(attacker, defender, move) {
+			if (attacker.removeVolatile(move.id)) {
+				return;
+			}
+			this.add('-prepare', attacker, move.name);
+			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
+				return;
+			}
+			attacker.addVolatile('twoturnmove', defender);
+			return null;
+		},
+	},
 	foresight: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -5395,8 +5395,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 			// The animation leak target itself isn't "accurate"; the target it reveals is as if Fly weren't a charge movee
 			// (Fly, like all other charge moves, will actually target slots on its charging turn, relevant for things like Follow Me)
 			// We use a generic single-target move to represent this
-			if (this.gameType === 'doubles') {
-				const animatedTarget = attacker.getMoveTargets(this.dex.getActiveMove('tackle'), defender).targets[0];
+			if (this.gameType === 'doubles' || this.gameType === 'multi') {
+				const animatedTarget = attacker.getMoveTargets(this.dex.getActiveMove('aerialace'), defender).targets[0];
 				if (animatedTarget) {
 					this.hint(`${move.name}'s animation targeted ${animatedTarget.name}`);
 				}

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -5387,8 +5387,20 @@ export const Moves: {[moveid: string]: MoveData} = {
 				return;
 			}
 			this.add('-prepare', attacker, move.name);
+
 			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
 				return;
+			}
+
+			// In SwSh, Fly's animation leaks the initial target through a camera focus
+			// The animation leak target itself isn't "accurate"; the target it reveals is as if Fly weren't a charge movee
+			// (Fly, like all other charge moves, will actually target slots on its charging turn, relevant for things like Follow Me)
+			// We use a generic single-target move to represent this
+			if (this.gameType === 'doubles') {
+				const animatedTarget = attacker.getMoveTargets(this.dex.getActiveMove('tackle'), defender).targets[0];
+				if (animatedTarget) {
+					this.hint(`${move.name}'s animation targeted ${animatedTarget.name}`);
+				}
 			}
 			attacker.addVolatile('twoturnmove', defender);
 			return null;

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -5387,7 +5387,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 				return;
 			}
 			this.add('-prepare', attacker, move.name);
-
 			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
 				return;
 			}


### PR DESCRIPTION
See cart footage: https://twitter.com/DaWoblefet/status/1370401423377137665

I've restricted this to doubles because the target leak is irrelevant in singles and we don't know how it'd interact in FFA or whatever other formats that don't exist in Gen 8.