### PR TITLE
Fix Red Card's interaction with Life Orb and Shell Bell

### DIFF
--- a/data/items.ts
+++ b/data/items.ts
@@ -2905,7 +2905,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			return this.chainModify([5324, 4096]);
 		},
 		onAfterMoveSecondarySelf(source, target, move) {
-			if (source && source !== target && move && move.category !== 'Status') {
+			if (source && source !== target && move && move.category !== 'Status' && !source.forceSwitchFlag) {
 				this.damage(source.baseMaxhp / 10, source, source, this.dex.items.get('lifeorb'));
 			}
 		},
@@ -4879,7 +4879,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		onAfterMoveSecondarySelfPriority: -1,
 		onAfterMoveSecondarySelf(pokemon, target, move) {
-			if (move.totalDamage) {
+			if (move.totalDamage && !pokemon.forceSwitchFlag) {
 				this.heal(move.totalDamage / 8, pokemon);
 			}
 		},


### PR DESCRIPTION
Manually tested with odd interactions with Red Card and Life Orb/Shell Bell, including the use of ingrain or if the attacking pokemon is the last remaining pokemon on its side. Removed import from npm test in my previous pull request. 