### PR TITLE
Proc hazards in the order they were set

### DIFF
--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -451,12 +451,6 @@ export const Conditions: {[k: string]: ConditionData} = {
 			return this.chainModify([5325, 4096]);
 		},
 	},
-	entryhazard: {
-		// this is a side condition
-		onSwitchIn(pokemon) {
-			this.runEvent('EntryHazard', pokemon);
-		},
-	},
 
 	// weather is implemented here since it's so important to the game
 

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -451,6 +451,12 @@ export const Conditions: {[k: string]: ConditionData} = {
 			return this.chainModify([5325, 4096]);
 		},
 	},
+	entryhazard: {
+		// this is a side condition
+		onSwitchIn(pokemon) {
+			this.runEvent('EntryHazard', pokemon);
+		},
+	},
 
 	// weather is implemented here since it's so important to the game
 

--- a/data/items.ts
+++ b/data/items.ts
@@ -2349,7 +2349,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 1120,
 		gen: 8,
-		// Hazard Immunity implemented in moves.js
+		// Hazard Immunity implemented in BattleActions#runSwitch
 	},
 	helixfossil: {
 		name: "Helix Fossil",

--- a/data/items.ts
+++ b/data/items.ts
@@ -2349,7 +2349,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 1120,
 		gen: 8,
-		// Hazard Immunity implemented in BattleActions#runSwitch
+		// Hazard Immunity implemented in moves.ts
 	},
 	helixfossil: {
 		name: "Helix Fossil",

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -1645,7 +1645,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				this.add('-sidestart', side, 'move: Toxic Spikes');
 				this.effectState.layers++;
 			},
-			onSwitchIn(pokemon) {
+			onEntryHazard(pokemon) {
 				if (!pokemon.isGrounded()) return;
 				if (pokemon.hasType('Poison')) {
 					this.add('-sideend', pokemon.side, 'move: Toxic Spikes', '[of] ' + pokemon);

--- a/data/mods/gennext/moves.ts
+++ b/data/mods/gennext/moves.ts
@@ -825,7 +825,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onSideStart(side) {
 				this.add('-sidestart', side, 'move: Stealth Rock');
 			},
-			onSwitchIn(pokemon) {
+			onEntryHazard(pokemon) {
 				let factor = 2;
 				if (pokemon.hasType('Flying')) factor = 4;
 				this.damage(pokemon.maxhp * factor / 16);

--- a/data/mods/ssb/conditions.ts
+++ b/data/mods/ssb/conditions.ts
@@ -2393,8 +2393,7 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 			}
 			this.add('-sidestart', side, 'move: G-Max Steelsurge');
 		},
-		onSwitchIn(pokemon) {
-			if (pokemon.hasItem('heavydutyboots')) return;
+		onEntryHazard(pokemon) {
 			// Ice Face and Disguise correctly get typed damage from Stealth Rock
 			// because Stealth Rock bypasses Substitute.
 			// They don't get typed damage from Steelsurge because Steelsurge doesn't,
@@ -2420,9 +2419,8 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 			this.add('-sidestart', side, 'Spikes');
 			this.effectState.layers++;
 		},
-		onSwitchIn(pokemon) {
+		onEntryHazard(pokemon) {
 			if (!pokemon.isGrounded()) return;
-			if (pokemon.hasItem('heavydutyboots')) return;
 			const damageAmounts = [0, 3, 4, 6]; // 1/8, 1/6, 1/4
 			this.damage(damageAmounts[this.effectState.layers] * pokemon.maxhp / 24);
 		},
@@ -2436,8 +2434,7 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 			}
 			this.add('-sidestart', side, 'move: Stealth Rock');
 		},
-		onSwitchIn(pokemon) {
-			if (pokemon.hasItem('heavydutyboots')) return;
+		onEntryHazard(pokemon) {
 			const typeMod = this.clampIntRange(pokemon.runEffectiveness(this.dex.getActiveMove('stealthrock')), -6, 6);
 			this.damage(pokemon.maxhp * Math.pow(2, typeMod) / 8);
 		},
@@ -2451,9 +2448,8 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 			}
 			this.add('-sidestart', side, 'move: Sticky Web');
 		},
-		onSwitchIn(pokemon) {
+		onEntryHazard(pokemon) {
 			if (!pokemon.isGrounded()) return;
-			if (pokemon.hasItem('heavydutyboots')) return;
 			this.add('-activate', pokemon, 'move: Sticky Web');
 			this.boost({spe: -1}, pokemon, pokemon.side.foe.active[0], this.dex.getActiveMove('stickyweb'));
 		},
@@ -2473,12 +2469,12 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 			this.add('-sidestart', side, 'move: Toxic Spikes');
 			this.effectState.layers++;
 		},
-		onSwitchIn(pokemon) {
+		onEntryHazard(pokemon) {
 			if (!pokemon.isGrounded()) return;
 			if (pokemon.hasType('Poison')) {
 				this.add('-sideend', pokemon.side, 'move: Toxic Spikes', '[of] ' + pokemon);
 				pokemon.side.removeSideCondition('toxicspikes');
-			} else if (pokemon.hasType('Steel') || pokemon.hasItem('heavydutyboots')) {
+			} else if (pokemon.hasType('Steel')) {
 				return;
 			} else if (this.effectState.layers >= 2) {
 				pokemon.trySetStatus('tox', pokemon.side.foe.active[0]);

--- a/data/mods/ssb/conditions.ts
+++ b/data/mods/ssb/conditions.ts
@@ -2394,6 +2394,7 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 			this.add('-sidestart', side, 'move: G-Max Steelsurge');
 		},
 		onEntryHazard(pokemon) {
+			if (pokemon.hasItem('heavydutyboots')) return;
 			// Ice Face and Disguise correctly get typed damage from Stealth Rock
 			// because Stealth Rock bypasses Substitute.
 			// They don't get typed damage from Steelsurge because Steelsurge doesn't,
@@ -2420,7 +2421,7 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 			this.effectState.layers++;
 		},
 		onEntryHazard(pokemon) {
-			if (!pokemon.isGrounded()) return;
+			if (!pokemon.isGrounded() || pokemon.hasItem('heavydutyboots')) return;
 			const damageAmounts = [0, 3, 4, 6]; // 1/8, 1/6, 1/4
 			this.damage(damageAmounts[this.effectState.layers] * pokemon.maxhp / 24);
 		},
@@ -2435,6 +2436,7 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 			this.add('-sidestart', side, 'move: Stealth Rock');
 		},
 		onEntryHazard(pokemon) {
+			if (pokemon.hasItem('heavydutyboots')) return;
 			const typeMod = this.clampIntRange(pokemon.runEffectiveness(this.dex.getActiveMove('stealthrock')), -6, 6);
 			this.damage(pokemon.maxhp * Math.pow(2, typeMod) / 8);
 		},
@@ -2449,7 +2451,7 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 			this.add('-sidestart', side, 'move: Sticky Web');
 		},
 		onEntryHazard(pokemon) {
-			if (!pokemon.isGrounded()) return;
+			if (!pokemon.isGrounded() || pokemon.hasItem('heavydutyboots')) return;
 			this.add('-activate', pokemon, 'move: Sticky Web');
 			this.boost({spe: -1}, pokemon, pokemon.side.foe.active[0], this.dex.getActiveMove('stickyweb'));
 		},
@@ -2474,7 +2476,7 @@ export const Conditions: {[k: string]: ModdedConditionData & {innateName?: strin
 			if (pokemon.hasType('Poison')) {
 				this.add('-sideend', pokemon.side, 'move: Toxic Spikes', '[of] ' + pokemon);
 				pokemon.side.removeSideCondition('toxicspikes');
-			} else if (pokemon.hasType('Steel')) {
+			} else if (pokemon.hasType('Steel') || pokemon.hasItem('heavydutyboots')) {
 				return;
 			} else if (this.effectState.layers >= 2) {
 				pokemon.trySetStatus('tox', pokemon.side.foe.active[0]);

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2695,17 +2695,17 @@ export const Moves: {[moveid: string]: MoveData} = {
 						if (!sideConditions.includes(id)) continue;
 						temp[side.n][id] = side.sideConditions[id];
 						delete side.sideConditions[id];
+						const effectName = this.dex.conditions.get(id).name;
+						this.add('-sideend', side, effectName, '[silent]');
 						success = true;
 					}
 				}
 				for (let i = 0; i < 4; i++) {
-					const sourceSide = sides[i];
-					const sourceSideConditions = temp[sourceSide.n];
+					const sourceSideConditions = temp[sides[i].n];
 					const targetSide = sides[(i + offset) % 4]; // the next side in rotation
 					for (const id in sourceSideConditions) {
-						const effectName = this.dex.conditions.get(id).name;
-						this.add('-sideend', sourceSide, effectName, '[silent]');
 						targetSide.sideConditions[id] = sourceSideConditions[id];
+						const effectName = this.dex.conditions.get(id).name;
 						let layers = sourceSideConditions[id].layers || 1;
 						for (; layers > 0; layers--) this.add('-sidestart', targetSide, effectName, '[silent]');
 					}

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -6706,6 +6706,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-sidestart', side, 'move: G-Max Steelsurge');
 			},
 			onEntryHazard(pokemon) {
+				if (pokemon.hasItem('heavydutyboots')) return;
 				// Ice Face and Disguise correctly get typed damage from Stealth Rock
 				// because Stealth Rock bypasses Substitute.
 				// They don't get typed damage from Steelsurge because Steelsurge doesn't,
@@ -16395,7 +16396,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.effectState.layers++;
 			},
 			onEntryHazard(pokemon) {
-				if (!pokemon.isGrounded()) return;
+				if (!pokemon.isGrounded() || pokemon.hasItem('heavydutyboots')) return;
 				const damageAmounts = [0, 3, 4, 6]; // 1/8, 1/6, 1/4
 				this.damage(damageAmounts[this.effectState.layers] * pokemon.maxhp / 24);
 			},
@@ -16679,6 +16680,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-sidestart', side, 'move: Stealth Rock');
 			},
 			onEntryHazard(pokemon) {
+				if (pokemon.hasItem('heavydutyboots')) return;
 				const typeMod = this.clampIntRange(pokemon.runEffectiveness(this.dex.getActiveMove('stealthrock')), -6, 6);
 				this.damage(pokemon.maxhp * Math.pow(2, typeMod) / 8);
 			},
@@ -16802,7 +16804,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-sidestart', side, 'move: Sticky Web');
 			},
 			onEntryHazard(pokemon) {
-				if (!pokemon.isGrounded()) return;
+				if (!pokemon.isGrounded() || pokemon.hasItem('heavydutyboots')) return;
 				this.add('-activate', pokemon, 'move: Sticky Web');
 				this.boost({spe: -1}, pokemon, this.effectState.source, this.dex.getActiveMove('stickyweb'));
 			},
@@ -18411,7 +18413,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				if (pokemon.hasType('Poison')) {
 					this.add('-sideend', pokemon.side, 'move: Toxic Spikes', '[of] ' + pokemon);
 					pokemon.side.removeSideCondition('toxicspikes');
-				} else if (pokemon.hasType('Steel')) {
+				} else if (pokemon.hasType('Steel') || pokemon.hasItem('heavydutyboots')) {
 					return;
 				} else if (this.effectState.layers >= 2) {
 					pokemon.trySetStatus('tox', pokemon.side.foe.active[0]);

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2681,7 +2681,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {mirror: 1},
 		onHitField(target, source) {
 			const sideConditions = [
-				'entryhazard', 'mist', 'lightscreen', 'reflect', 'spikes', 'safeguard', 'tailwind', 'toxicspikes', 'stealthrock', 'waterpledge', 'firepledge', 'grasspledge', 'stickyweb', 'auroraveil', 'gmaxsteelsurge', 'gmaxcannonade', 'gmaxvinelash', 'gmaxwildfire',
+				'mist', 'lightscreen', 'reflect', 'spikes', 'safeguard', 'tailwind', 'toxicspikes', 'stealthrock', 'waterpledge', 'firepledge', 'grasspledge', 'stickyweb', 'auroraveil', 'gmaxsteelsurge', 'gmaxcannonade', 'gmaxvinelash', 'gmaxwildfire',
 			];
 			let success = false;
 			if (this.gameType === "freeforall") {
@@ -2698,7 +2698,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 						const targetSide = sides[(i + offset) % 4]; // the next side in rotation
 						rotatedSides.push(targetSide.sideConditions[id]);
 						if (sourceSide.sideConditions[id]) {
-							if (id !== 'entryhazard') this.add('-sideend', sourceSide, effectName, '[silent]');
+							this.add('-sideend', sourceSide, effectName, '[silent]');
 							someCondition = true;
 						}
 					}
@@ -2708,14 +2708,14 @@ export const Moves: {[moveid: string]: MoveData} = {
 						sides[2]!.sideConditions[id], sides[3]!.sideConditions[id],
 					] = [...rotatedSides];
 					for (const side of sides) {
-						if (side.sideConditions[id] && id !== 'entryhazard') {
+						if (side.sideConditions[id]) {
 							let layers = side.sideConditions[id].layers || 1;
 							for (; layers > 0; layers--) this.add('-sidestart', side, effectName, '[silent]');
 						} else if (id in side.sideConditions) {
 							delete side.sideConditions[id];
 						}
 					}
-					if (id !== 'entryhazard') success = true;
+					success = true;
 				}
 			} else {
 				const sourceSide = source.side;
@@ -2734,7 +2734,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					} else {
 						continue;
 					}
-					if (id !== 'entryhazard') success = true;
+					success = true;
 				}
 				this.add('-swapsideconditions');
 			}
@@ -3112,10 +3112,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 			let success = false;
 			if (!target.volatiles['substitute'] || move.infiltrates) success = !!this.boost({evasion: -1});
 			const removeTarget = [
-				'reflect', 'lightscreen', 'auroraveil', 'safeguard', 'mist', 'entryhazard', 'spikes', 'toxicspikes', 'stealthrock', 'stickyweb', 'gmaxsteelsurge',
+				'reflect', 'lightscreen', 'auroraveil', 'safeguard', 'mist', 'spikes', 'toxicspikes', 'stealthrock', 'stickyweb', 'gmaxsteelsurge',
 			];
 			const removeAll = [
-				'entryhazard', 'spikes', 'toxicspikes', 'stealthrock', 'stickyweb', 'gmaxsteelsurge',
+				'spikes', 'toxicspikes', 'stealthrock', 'stickyweb', 'gmaxsteelsurge',
 			];
 			for (const targetCondition of removeTarget) {
 				if (target.side.removeSideCondition(targetCondition)) {
@@ -3125,7 +3125,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				}
 			}
 			for (const sideCondition of removeAll) {
-				if (source.side.removeSideCondition(sideCondition) && sideCondition !== 'entryhazard') {
+				if (source.side.removeSideCondition(sideCondition)) {
 					this.add('-sideend', source.side, this.dex.conditions.get(sideCondition).name, '[from] move: Defog', '[of] ' + source);
 					success = true;
 				}
@@ -6706,11 +6706,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		},
 		condition: {
 			onSideStart(side) {
-				side.addSideCondition('entryhazard');
 				this.add('-sidestart', side, 'move: G-Max Steelsurge');
 			},
 			onEntryHazard(pokemon) {
-				if (pokemon.hasItem('heavydutyboots')) return;
 				// Ice Face and Disguise correctly get typed damage from Stealth Rock
 				// because Stealth Rock bypasses Substitute.
 				// They don't get typed damage from Steelsurge because Steelsurge doesn't,
@@ -13723,9 +13721,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 			if (pokemon.hp && pokemon.removeVolatile('leechseed')) {
 				this.add('-end', pokemon, 'Leech Seed', '[from] move: Rapid Spin', '[of] ' + pokemon);
 			}
-			const sideConditions = ['entryhazard', 'spikes', 'toxicspikes', 'stealthrock', 'stickyweb', 'gmaxsteelsurge'];
+			const sideConditions = ['spikes', 'toxicspikes', 'stealthrock', 'stickyweb', 'gmaxsteelsurge'];
 			for (const condition of sideConditions) {
-				if (pokemon.hp && pokemon.side.removeSideCondition(condition) && condition !== 'entryhazard') {
+				if (pokemon.hp && pokemon.side.removeSideCondition(condition)) {
 					this.add('-sideend', pokemon.side, this.dex.conditions.get(condition).name, '[from] move: Rapid Spin', '[of] ' + pokemon);
 				}
 			}
@@ -16391,7 +16389,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 		condition: {
 			// this is a side condition
 			onSideStart(side) {
-				side.addSideCondition('entryhazard');
 				this.add('-sidestart', side, 'Spikes');
 				this.effectState.layers = 1;
 			},
@@ -16402,7 +16399,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 			},
 			onEntryHazard(pokemon) {
 				if (!pokemon.isGrounded()) return;
-				if (pokemon.hasItem('heavydutyboots')) return;
 				const damageAmounts = [0, 3, 4, 6]; // 1/8, 1/6, 1/4
 				this.damage(damageAmounts[this.effectState.layers] * pokemon.maxhp / 24);
 			},
@@ -16683,11 +16679,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		condition: {
 			// this is a side condition
 			onSideStart(side) {
-				side.addSideCondition('entryhazard');
 				this.add('-sidestart', side, 'move: Stealth Rock');
 			},
 			onEntryHazard(pokemon) {
-				if (pokemon.hasItem('heavydutyboots')) return;
 				const typeMod = this.clampIntRange(pokemon.runEffectiveness(this.dex.getActiveMove('stealthrock')), -6, 6);
 				this.damage(pokemon.maxhp * Math.pow(2, typeMod) / 8);
 			},
@@ -16808,12 +16802,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		sideCondition: 'stickyweb',
 		condition: {
 			onSideStart(side) {
-				side.addSideCondition('entryhazard');
 				this.add('-sidestart', side, 'move: Sticky Web');
 			},
 			onEntryHazard(pokemon) {
 				if (!pokemon.isGrounded()) return;
-				if (pokemon.hasItem('heavydutyboots')) return;
 				this.add('-activate', pokemon, 'move: Sticky Web');
 				this.boost({spe: -1}, pokemon, this.effectState.source, this.dex.getActiveMove('stickyweb'));
 			},
@@ -18409,7 +18401,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 		condition: {
 			// this is a side condition
 			onSideStart(side) {
-				side.addSideCondition('entryhazard');
 				this.add('-sidestart', side, 'move: Toxic Spikes');
 				this.effectState.layers = 1;
 			},
@@ -18423,7 +18414,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				if (pokemon.hasType('Poison')) {
 					this.add('-sideend', pokemon.side, 'move: Toxic Spikes', '[of] ' + pokemon);
 					pokemon.side.removeSideCondition('toxicspikes');
-				} else if (pokemon.hasType('Steel') || pokemon.hasItem('heavydutyboots')) {
+				} else if (pokemon.hasType('Steel')) {
 					return;
 				} else if (this.effectState.layers >= 2) {
 					pokemon.trySetStatus('tox', pokemon.side.foe.active[0]);

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -170,9 +170,7 @@ export class BattleActions {
 			this.battle.runEvent('SwitchIn', pokemon);
 		}
 
-		if (!pokemon.hasItem('heavydutyboots')) {
-			this.battle.runEvent('EntryHazard', pokemon);
-		}
+		this.battle.runEvent('EntryHazard', pokemon);
 
 		if (this.battle.gen <= 4) {
 			this.battle.runEvent('SwitchIn', pokemon);

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -165,7 +165,19 @@ export class BattleActions {
 	}
 	runSwitch(pokemon: Pokemon) {
 		this.battle.runEvent('Swap', pokemon);
-		this.battle.runEvent('SwitchIn', pokemon);
+
+		if (this.battle.gen >= 5) {
+			this.battle.runEvent('SwitchIn', pokemon);
+		}
+
+		if (!pokemon.hasItem('heavydutyboots')) {
+			this.battle.runEvent('EntryHazard', pokemon);
+		}
+
+		if (this.battle.gen <= 4) {
+			this.battle.runEvent('SwitchIn', pokemon);
+		}
+
 		if (this.battle.gen <= 2 && !pokemon.side.faintedThisTurn && pokemon.draggedIn !== this.battle.turn) {
 			this.battle.runEvent('AfterSwitchInSelf', pokemon);
 		}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -693,7 +693,7 @@ export class Battle {
 			}
 		}
 
-		if (eventid === 'Invulnerability' || eventid === 'TryHit' || eventid === 'DamagingHit') {
+		if (['Invulnerability', 'TryHit', 'DamagingHit', 'EntryHazard'].includes(eventid)) {
 			handlers.sort(Battle.compareLeftToRightOrder);
 		} else if (fastExit) {
 			handlers.sort(Battle.compareRedirectOrder);

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -38,6 +38,7 @@ export interface EventMethods {
 	onDragOut?: (this: Battle, pokemon: Pokemon, source?: Pokemon, move?: ActiveMove) => void;
 	onEatItem?: (this: Battle, item: Item, pokemon: Pokemon) => void;
 	onEffectiveness?: MoveEventMethods['onEffectiveness'];
+	onEntryHazard?: (this: Battle, pokemon: Pokemon) => void;
 	onFaint?: CommonHandlers['VoidEffect'];
 	onFlinch?: ((this: Battle, pokemon: Pokemon) => boolean | void) | boolean;
 	onFractionalPriority?: CommonHandlers['ModifierSourceMove'] | -0.1;

--- a/test/sim/misc/hazards.js
+++ b/test/sim/misc/hazards.js
@@ -67,7 +67,7 @@ describe('Hazards', function () {
 		assert.statStage(battle.p1.active[0], 'spe', -1);
 	});
 
-	it.skip(`should apply hazards in the order they were set up`, function () {
+	it(`should apply hazards in the order they were set up`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', moves: ['sleeptalk', 'uturn']},
 			{species: 'whismur', moves: ['sleeptalk']},


### PR DESCRIPTION
https://github.com/smogon/pokemon-showdown/projects/3#card-23557574

Entry hazards now use a new `EntryHazard` event, which is run immediately after `SwitchIn` and uses a stable sort for its resolution. (String keys in objects are guaranteed to remain in insertion order, and `Array#sort` is guaranteed stable.)