### PR TITLE
Fix damage from future attacks

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -3477,6 +3477,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					effectType: 'Move',
 					isFutureMove: true,
 					type: 'Steel',
+					recentForme: source.species,
 				},
 			});
 			this.add('-start', source, 'Doom Desire');
@@ -5908,6 +5909,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					effectType: 'Move',
 					isFutureMove: true,
 					type: 'Psychic',
+					recentForme: source.species,
 				},
 			});
 			this.add('-start', source, 'move: Future Sight');

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1604,6 +1604,7 @@ export class BattleActions {
 			defBoosts = 0;
 		}
 
+		if (move.isFutureMove && !source.isActive && move.recentForme) attacker.setSpecies(move.recentForme);
 		let attack = attacker.calculateStat(attackStat, atkBoosts);
 		let defense = defender.calculateStat(defenseStat, defBoosts);
 

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -463,6 +463,8 @@ export class Battle {
 					handler.end.call(...endCallArgs as [any, ...any[]]);
 					if (this.ended) return;
 					continue;
+				} else if (handler.effect.name === "futuremove" && handler.state.source.isActive) {
+					handler.state.moveData.recentForme = handler.state.source.species;
 				}
 			}
 

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -323,6 +323,7 @@ export interface ActiveMove extends MutableMove {
 	totalDamage?: number | false;
 	willChangeForme?: boolean;
 	infiltrates?: boolean;
+	recentForme: Species;
 
 	/**
 	 * Has this move been boosted by a Z-crystal or used by a Dynamax Pokemon? Usually the same as

--- a/test/sim/moves/futuresight.js
+++ b/test/sim/moves/futuresight.js
@@ -310,7 +310,7 @@ describe('Future Sight', function () {
 		assert.bounded(damage, [34, 41]); // Shield Forme damage
 	});
 
-	it.skip(`should use the user's most recent Special Attack stat, even if the user is not on the field`, function () {
+	it(`should use the user's most recent Special Attack stat, even if the user is not on the field`, function () {
 		battle = common.createBattle([[
 			{species: 'Aegislash', ability: 'stancechange', moves: ['futuresight', 'kingsshield']},
 			{species: 'Wynaut', moves: ['sleeptalk']},


### PR DESCRIPTION
[https://github.com/smogon/pokemon-showdown/projects/3#card-70965392](https://github.com/smogon/pokemon-showdown/projects/3#card-70965392)

This adds a new attribute ```recentForme``` to ```ActiveMove```, letting it store the forme of the Pokemon which used the move. This variable is updated with the latest form if the future attack's user is still on the field. The code now passes the previously skipped unit test in futuresight.js.