### PR TITLE
Fix Slow Start not halving Sp. Atk for special Z-Moves

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -3428,11 +3428,6 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			onModifyAtk(atk, pokemon) {
 				return this.chainModify(0.5);
 			},
-			onModifySpA(spa, pokemon, target, move) {
-				if (move.isZ) {
-					return this.chainModify(0.5);
-				}
-			},
 			onModifySpe(spe, pokemon) {
 				return this.chainModify(0.5);
 			},

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -3428,6 +3428,11 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			onModifyAtk(atk, pokemon) {
 				return this.chainModify(0.5);
 			},
+			onModifySpA(spa, pokemon, target, move) {
+				if (move.isZ) {
+					return this.chainModify(0.5);
+				}
+			},
 			onModifySpe(spe, pokemon) {
 				return this.chainModify(0.5);
 			},

--- a/data/mods/gen7/abilities.ts
+++ b/data/mods/gen7/abilities.ts
@@ -66,6 +66,35 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		inherit: true,
 		onBoost() {},
 	},
+	slowstart: {
+		inherit: true,
+		condition: {
+			duration: 5,
+			onResidualOrder: 28,
+			onResidualSubOrder: 2,
+			onStart(target) {
+				this.add('-start', target, 'ability: Slow Start');
+			},
+			onModifyAtkPriority: 5,
+			onModifyAtk(atk, pokemon, target, move) {
+				if (this.dex.moves.get(move.id).category === 'Physical') {
+					return this.chainModify(0.5);
+				}
+			},
+			onModifySpAPriority: 5,
+			onModifySpA(spa, pokemon, target, move) {
+				if (this.dex.moves.get(move.id).category === 'Physical') {
+					return this.chainModify(0.5);
+				}
+			},
+			onModifySpe(spe, pokemon) {
+				return this.chainModify(0.5);
+			},
+			onEnd(target) {
+				this.add('-end', target, 'Slow Start');
+			},
+		},
+	},
 	soundproof: {
 		inherit: true,
 		onTryHit(target, source, move) {

--- a/data/mods/gen7/abilities.ts
+++ b/data/mods/gen7/abilities.ts
@@ -83,6 +83,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			},
 			onModifySpAPriority: 5,
 			onModifySpA(spa, pokemon, target, move) {
+				// Ordinary Z-moves like Breakneck Blitz will halve the user's Special Attack as well
 				if (this.dex.moves.get(move.id).category === 'Physical') {
 					return this.chainModify(0.5);
 				}

--- a/data/mods/gen7/abilities.ts
+++ b/data/mods/gen7/abilities.ts
@@ -77,6 +77,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			},
 			onModifyAtkPriority: 5,
 			onModifyAtk(atk, pokemon, target, move) {
+				// This is because the game checks the move's category in data, rather than what it is currently, unlike e.g. Huge Power
 				if (this.dex.moves.get(move.id).category === 'Physical') {
 					return this.chainModify(0.5);
 				}

--- a/test/sim/abilities/slowstart.js
+++ b/test/sim/abilities/slowstart.js
@@ -10,7 +10,7 @@ describe(`Slow Start`, function () {
 		battle.destroy();
 	});
 
-	it.skip(`should halve the user's Sp. Atk when using a special Z-move`, function () {
+	it(`should halve the user's Sp. Atk when using a special Z-move`, function () {
 		battle = common.createBattle([[
 			{species: 'regigigas', ability: 'slowstart', item: 'normaliumz', moves: ['hyperbeam']},
 		], [

--- a/test/sim/abilities/slowstart.js
+++ b/test/sim/abilities/slowstart.js
@@ -28,7 +28,7 @@ describe(`Slow Start`, function () {
 		battle = common.gen(7).createBattle([[
 			{species: 'regigigas', ability: 'slowstart', item: 'normaliumz', moves: ['hyperbeam']},
 		], [
-			{species: 'wynaut', moves: ['sleeptalk']},
+			{species: 'wynaut', ability: 'shellarmor', moves: ['sleeptalk']},
 		]]);
 		battle.makeChoices('move hyperbeam zmove', 'auto');
 		const wynaut = battle.p2.active[0];
@@ -37,12 +37,14 @@ describe(`Slow Start`, function () {
 	});
 
 	it(`[Gen 7] should not halve the user's Attack when using physical Photon Geyser`, function () {
+		// We are using Photon Geyser through Assist, because otherwise Photon Geyser would just ignore Slow Start
 		battle = common.gen(7).createBattle([[
-			{species: 'regigigas', ability: 'slowstart', moves: ['photongeyser']},
+			{species: 'regigigas', ability: 'slowstart', moves: ['assist']},
+			{species: 'necrozma', moves: ['photongeyser']},
 		], [
-			{species: 'wynaut', moves: ['sleeptalk']},
+			{species: 'wynaut', ability: 'shellarmor', moves: ['sleeptalk']},
 		]]);
-		battle.makeChoices('move photongeyser', 'auto');
+		battle.makeChoices();
 		const wynaut = battle.p2.active[0];
 		const damage = wynaut.maxhp - wynaut.hp;
 		assert.bounded(damage, [96, 114]);

--- a/test/sim/abilities/slowstart.js
+++ b/test/sim/abilities/slowstart.js
@@ -5,21 +5,9 @@ const common = require('./../../common');
 
 let battle;
 
-describe(`Slow Start`, function () {
+describe.only(`Slow Start`, function () {
 	afterEach(function () {
 		battle.destroy();
-	});
-
-	it(`should halve the user's Sp. Atk when using a special Z-move`, function () {
-		battle = common.createBattle([[
-			{species: 'regigigas', ability: 'slowstart', item: 'normaliumz', moves: ['hyperbeam']},
-		], [
-			{species: 'wynaut', moves: ['sleeptalk']},
-		]]);
-		battle.makeChoices('move hyperbeam zmove', 'auto');
-		const wynaut = battle.p2.active[0];
-		const damage = wynaut.maxhp - wynaut.hp;
-		assert.bounded(damage, [160, 189]);
 	});
 
 	it(`should not delay activation on switch-in, unlike Speed Boost`, function () {
@@ -34,5 +22,29 @@ describe(`Slow Start`, function () {
 		const log = battle.getDebugLog();
 		const slowStartEnd = log.indexOf('|-end|p1a: Regigigas|Slow Start');
 		assert(slowStartEnd > -1, 'Slow Start should end in 5 turns, including the turn it switched in.');
+	});
+
+	it(`[Gen 7] should halve the user's Special Attack when using a special Z-move`, function () {
+		battle = common.gen(7).createBattle([[
+			{species: 'regigigas', ability: 'slowstart', item: 'normaliumz', moves: ['hyperbeam']},
+		], [
+			{species: 'wynaut', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices('move hyperbeam zmove', 'auto');
+		const wynaut = battle.p2.active[0];
+		const damage = wynaut.maxhp - wynaut.hp;
+		assert.bounded(damage, [160, 189]);
+	});
+
+	it(`[Gen 7] should not halve the user's Attack when using physical Photon Geyser`, function () {
+		battle = common.gen(7).createBattle([[
+			{species: 'regigigas', ability: 'slowstart', moves: ['photongeyser']},
+		], [
+			{species: 'wynaut', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices('move photongeyser', 'auto');
+		const wynaut = battle.p2.active[0];
+		const damage = wynaut.maxhp - wynaut.hp;
+		assert.bounded(damage, [96, 114]);
 	});
 });

--- a/test/sim/abilities/slowstart.js
+++ b/test/sim/abilities/slowstart.js
@@ -5,7 +5,7 @@ const common = require('./../../common');
 
 let battle;
 
-describe.only(`Slow Start`, function () {
+describe(`Slow Start`, function () {
 	afterEach(function () {
 		battle.destroy();
 	});


### PR DESCRIPTION
> If the user holds a typed Z-Crystal and uses a Z-Move based on a special move, Slow Start will also reduce the Special Attack stat for the duration of that move only.

This comes from Bulbapedia and it sounds like I should also be checking `isZOrMaxPowered` but I wasn't sure so I didn't add that check.