### PR TITLE
Friends: Hide advanced commands in help broadcast

### DIFF
--- a/server/chat-plugins/friends.ts
+++ b/server/chat-plugins/friends.ts
@@ -459,6 +459,7 @@ export const commands: Chat.ChatCommands = {
 				`<code>/friend list</code> - View current friends.`,
 				`<code>/friend add [name]</code> OR <code>/friend [name]</code> - Send a friend request to [name], if you don't have them added.`,
 				`<code>/friend remove [username]</code> OR <code>/unfriend [username]</code>  - Unfriend the user.`,
+				`<details class="readmore"><summary>More commands...</summary>`,
 				`<code>/friend accept [username]</code> - Accepts the friend request from [username], if it exists.`,
 				`<code>/friend reject [username]</code> - Rejects the friend request from [username], if it exists.`,
 				`<code>/friend toggle [off/on]</code> - Enable or disable receiving of friend requests.`,
@@ -466,7 +467,7 @@ export const commands: Chat.ChatCommands = {
 				`<code>/friend viewnotifications</code> OR <code>viewnotifs</code> - Opts into view friend notifications.`,
 				`<code>/friend listdisplay [on/off]</code> - Opts [in/out] of letting others view your friends list.`,
 				`<code>/friend viewlist [user]</code> - View the given [user]'s friend list, if they're allowing others to see.`,
-				`<code>/friends sharebattles [on|off]</code> - Allow or disallow your friends from seeing your ongoing battles.`,
+				`<code>/friends sharebattles [on|off]</code> - Allow or disallow your friends from seeing your ongoing battles.</details>`,
 			].join('<br />'));
 		}
 		return this.parse('/join view-friends-help');


### PR DESCRIPTION
99% of people will just use the GUI to do the things under the cut, and `!help friends` is something that's broadcasted quite frequently to introduce people to the feature, so this will be far more user-friendly.