### PR TITLE
Fix Dynamax not starting in order of most recent speed

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2606,7 +2606,7 @@ export class Battle {
 
 		if (this.gen < 5) this.eachEvent('Update');
 
-		if (this.gen >= 8 && this.queue.peek()?.choice === 'move') {
+		if (this.gen >= 8 && (this.queue.peek()?.choice === 'move' || this.queue.peek()?.choice === 'runDynamax')) {
 			// In gen 8, speed is updated dynamically so update the queue's speed properties and sort it.
 			this.updateSpeed();
 			for (const queueAction of this.queue.list) {

--- a/test/sim/misc/dynamax.js
+++ b/test/sim/misc/dynamax.js
@@ -80,7 +80,6 @@ describe("Dynamax", function () {
 		]]);
 		battle.makeChoices('move sleeptalk dynamax, switch 3', 'move sleeptalk dynamax, auto');
 		const log = battle.getDebugLog();
-		console.log(log);
 		const kingdraMaxIndex = log.indexOf('|-start|p1a: Kingdra|Dynamax');
 		const kyogreMaxIndex = log.indexOf('|-start|p2a: Kyogre|Dynamax');
 		assert(kyogreMaxIndex < kingdraMaxIndex, 'Kyogre should have Dynamaxed before Kingdra.');

--- a/test/sim/misc/dynamax.js
+++ b/test/sim/misc/dynamax.js
@@ -69,6 +69,23 @@ describe("Dynamax", function () {
 		assert.equal(battle.p2.active[0].hp, battle.p2.active[0].maxhp);
 	});
 
+	it('should execute in order of updated speed when 2 or more Pokemon are Dynamaxing', function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'kingdra', ability: 'swiftswim', moves: ['sleeptalk']},
+			{species: 'wynaut', moves: ['sleeptalk']},
+			{species: 'groudon', ability: 'drought', moves: ['sleeptalk']},
+		], [
+			{species: 'kyogre', ability: 'drizzle', moves: ['sleeptalk']},
+			{species: 'wynaut', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices('move sleeptalk dynamax, switch 3', 'move sleeptalk dynamax, auto');
+		const log = battle.getDebugLog();
+		console.log(log);
+		const kingdraMaxIndex = log.indexOf('|-start|p1a: Kingdra|Dynamax');
+		const kyogreMaxIndex = log.indexOf('|-start|p2a: Kyogre|Dynamax');
+		assert(kyogreMaxIndex < kingdraMaxIndex, 'Kyogre should have Dynamaxed before Kingdra.');
+	});
+
 	it('should revert before the start of the 4th turn, not as an end-of-turn effect on the 3rd turn', function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', moves: ['sleeptalk', 'psychic']},


### PR DESCRIPTION
Talked to @DaWoblefet about this and he felt like the solution I used shouldn't need to be done (manually checking if `runDynamax` is the next action). If someone has input on how speed should be updated for the `runDynamax` action that would be cool.