### PR TITLE
Properly handle Zacian/Zamazenta Crowned formes

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -681,25 +681,6 @@ export const Formats: FormatList = [
 			'Water Bubble', 'Wonder Guard', 'Comatose + Sleep Talk', 'Rusted Sword', 'Court Change', 'Bolt Beak', 'Double Iron Bash',
 			'Octolock', 'Shell Smash',
 		],
-		onChangeSet(set) {
-			const item = this.dex.toID(set.item);
-			if (set.species === 'Zacian' && item === 'rustedsword') {
-				set.species = 'Zacian-Crowned';
-				set.ability = 'Intrepid Sword';
-				const ironHead = set.moves.indexOf('ironhead');
-				if (ironHead >= 0) {
-					set.moves[ironHead] = 'behemothblade';
-				}
-			}
-			if (set.species === 'Zamazenta' && item === 'rustedshield') {
-				set.species = 'Zamazenta-Crowned';
-				set.ability = 'Dauntless Shield';
-				const ironHead = set.moves.indexOf('ironhead');
-				if (ironHead >= 0) {
-					set.moves[ironHead] = 'behemothbash';
-				}
-			}
-		},
 	},
 	{
 		name: "[Gen 8] Almost Any Ability",
@@ -721,15 +702,6 @@ export const Formats: FormatList = [
 			'Innards Out', 'Intrepid Sword', 'Libero', 'Magnet Pull', 'Moody', 'Neutralizing Gas', 'Parental Bond', 'Poison Heal', 'Protean',
 			'Pure Power', 'Shadow Tag', 'Simple', 'Stakeout', 'Speed Boost', 'Water Bubble', 'Wonder Guard', 'King\'s Rock', 'Baton Pass',
 		],
-		onValidateSet(set) {
-			// Temporary fix until battle-only is implemented properly
-			if (this.toID(set.species) === 'zamazentacrowned' && this.toID(set.ability) !== 'dauntlessshield') {
-				return [`Zamazenta-Crowned can only use Dauntless Shield because it is a battle-only forme.`];
-			}
-			if (this.toID(set.species) === 'zaciancrowned' && this.toID(set.ability) !== 'intrepidsword') {
-				return [`Zacian-Crowned can only use Intrepid Sword because it is a battle-only forme.`];
-			}
-		},
 	},
 	{
 		name: "[Gen 8] Mix and Mega",
@@ -900,9 +872,6 @@ export const Formats: FormatList = [
 			const stat = Dex.stats.ids()[target.side.team.indexOf(target.set)];
 			const newSpecies = this.dex.deepClone(species);
 			let godSpecies = this.dex.species.get(god.species);
-			if (godSpecies.forme === 'Crowned') {
-				godSpecies = this.dex.species.get(godSpecies.changesFrom || godSpecies.baseSpecies);
-			}
 			if (typeof godSpecies.battleOnly === 'string') {
 				godSpecies = this.dex.species.get(godSpecies.battleOnly);
 			}

--- a/data/items.ts
+++ b/data/items.ts
@@ -4664,7 +4664,6 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 			return true;
 		},
-		forcedForme: "Zamazenta-Crowned",
 		itemUser: ["Zamazenta-Crowned"],
 		num: 1104,
 		gen: 8,
@@ -4678,7 +4677,6 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 			return true;
 		},
-		forcedForme: "Zacian-Crowned",
 		itemUser: ["Zacian-Crowned"],
 		num: 1103,
 		gen: 8,

--- a/data/learnsets.ts
+++ b/data/learnsets.ts
@@ -76710,7 +76710,7 @@ export const Learnsets: {[speciesid: string]: LearnsetData} = {
 	},
 	zaciancrowned: {
 		learnset: {
-			behemothblade: ["8M", "8L33"],
+			behemothblade: ["8R"],
 		},
 		eventOnly: true,
 	},
@@ -76781,7 +76781,7 @@ export const Learnsets: {[speciesid: string]: LearnsetData} = {
 	},
 	zamazentacrowned: {
 		learnset: {
-			behemothbash: ["8M", "8L33"],
+			behemothbash: ["8R"],
 		},
 		eventOnly: true,
 	},

--- a/data/mods/gen4/rulesets.ts
+++ b/data/mods/gen4/rulesets.ts
@@ -14,10 +14,7 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 			for (const pokemon of this.getAllPokemon()) {
 				const details = pokemon.details.replace(', shiny', '')
 					.replace(/(Arceus|Gourgeist|Pumpkaboo|Xerneas|Silvally|Urshifu)(-[a-zA-Z?-]+)?/g, '$1-*')
-					// Zacian and Zamazenta should already be in the correct forme for Team Preview
-					// but we still appened "-*" to the base formes so the client doesn't get confused
-					// when they are sent into battle in their Crowned forme
-					.replace(/(Zacian|Zamazenta)(?!-Crowned)/g, '$1-*');
+					.replace(/(Zacian|Zamazenta)(?!-Crowned)/g, '$1-*'); // Hacked-in Crowned formes will be revealed
 				this.add('poke', pokemon.side.id, details, pokemon.item ? 'item' : '');
 			}
 			this.makeRequest('teampreview');

--- a/data/mods/gen4/rulesets.ts
+++ b/data/mods/gen4/rulesets.ts
@@ -13,7 +13,11 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 			this.add('clearpoke');
 			for (const pokemon of this.getAllPokemon()) {
 				const details = pokemon.details.replace(', shiny', '')
-					.replace(/(Arceus|Gourgeist|Genesect|Pumpkaboo|Silvally|Zacian|Zamazenta|Urshifu)(-[a-zA-Z?-]+)?/g, '$1-*');
+					.replace(/(Arceus|Gourgeist|Pumpkaboo|Xerneas|Silvally|Urshifu)(-[a-zA-Z?-]+)?/g, '$1-*')
+					// Zacian and Zamazenta should already be in the correct forme for Team Preview
+					// but we still appened "-*" to the base formes so the client doesn't get confused
+					// when they are sent into battle in their Crowned forme
+					.replace(/(Zacian|Zamazenta)(?!-Crowned)/g, '$1-*');
 				this.add('poke', pokemon.side.id, details, pokemon.item ? 'item' : '');
 			}
 			this.makeRequest('teampreview');

--- a/data/mods/gen5/rulesets.ts
+++ b/data/mods/gen5/rulesets.ts
@@ -20,10 +20,7 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 			for (const pokemon of this.getAllPokemon()) {
 				const details = pokemon.details.replace(', shiny', '')
 					.replace(/(Arceus|Gourgeist|Pumpkaboo|Xerneas|Silvally|Urshifu)(-[a-zA-Z?-]+)?/g, '$1-*')
-					// Zacian and Zamazenta should already be in the correct formes for Team Preview
-					// but we still appened "-*" to the base formes so the client doesn't get confused
-					// when they transform into their Crowned formes before they are sent into battle
-					.replace(/(Zacian|Zamazenta)(?!-Crowned)/g, '$1-*');
+					.replace(/(Zacian|Zamazenta)(?!-Crowned)/g, '$1-*'); // Hacked-in Crowned formes will be revealed
 				const item = pokemon.item.includes('mail') ? 'mail' : pokemon.item ? 'item' : '';
 				this.add('poke', pokemon.side.id, details, item);
 			}

--- a/data/mods/gen5/rulesets.ts
+++ b/data/mods/gen5/rulesets.ts
@@ -19,7 +19,11 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 			this.add('clearpoke');
 			for (const pokemon of this.getAllPokemon()) {
 				const details = pokemon.details.replace(', shiny', '')
-					.replace(/(Arceus|Gourgeist|Genesect|Pumpkaboo|Silvally|Zacian|Zamazenta|Urshifu)(-[a-zA-Z?-]+)?/g, '$1-*');
+					.replace(/(Arceus|Gourgeist|Pumpkaboo|Xerneas|Silvally|Urshifu)(-[a-zA-Z?-]+)?/g, '$1-*')
+					// Zacian and Zamazenta should already be in the correct formes for Team Preview
+					// but we still appened "-*" to the base formes so the client doesn't get confused
+					// when they transform into their Crowned formes before they are sent into battle
+					.replace(/(Zacian|Zamazenta)(?!-Crowned)/g, '$1-*');
 				const item = pokemon.item.includes('mail') ? 'mail' : pokemon.item ? 'item' : '';
 				this.add('poke', pokemon.side.id, details, item);
 			}

--- a/data/mods/gen7/rulesets.ts
+++ b/data/mods/gen7/rulesets.ts
@@ -36,7 +36,11 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 			this.add('clearpoke');
 			for (const pokemon of this.getAllPokemon()) {
 				const details = pokemon.details.replace(', shiny', '')
-					.replace(/(Arceus|Gourgeist|Genesect|Pumpkaboo|Silvally|Zacian|Zamazenta|Urshifu)(-[a-zA-Z?-]+)?/g, '$1-*');
+					.replace(/(Arceus|Gourgeist|Pumpkaboo|Xerneas|Silvally|Urshifu)(-[a-zA-Z?-]+)?/g, '$1-*')
+					// Zacian and Zamazenta should already be in the correct formes for Team Preview
+					// but we still appened "-*" to the base formes so the client doesn't get confused
+					// when they transform into their Crowned formes before they are sent into battle
+					.replace(/(Zacian|Zamazenta)(?!-Crowned)/g, '$1-*');
 				this.add('poke', pokemon.side.id, details, pokemon.item ? 'item' : '');
 			}
 			this.makeRequest('teampreview');

--- a/data/mods/gen7/rulesets.ts
+++ b/data/mods/gen7/rulesets.ts
@@ -37,10 +37,7 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 			for (const pokemon of this.getAllPokemon()) {
 				const details = pokemon.details.replace(', shiny', '')
 					.replace(/(Arceus|Gourgeist|Pumpkaboo|Xerneas|Silvally|Urshifu)(-[a-zA-Z?-]+)?/g, '$1-*')
-					// Zacian and Zamazenta should already be in the correct formes for Team Preview
-					// but we still appened "-*" to the base formes so the client doesn't get confused
-					// when they transform into their Crowned formes before they are sent into battle
-					.replace(/(Zacian|Zamazenta)(?!-Crowned)/g, '$1-*');
+					.replace(/(Zacian|Zamazenta)(?!-Crowned)/g, '$1-*'); // Hacked-in Crowned formes will be revealed
 				this.add('poke', pokemon.side.id, details, pokemon.item ? 'item' : '');
 			}
 			this.makeRequest('teampreview');

--- a/data/mods/gen8dlc1/rulesets.ts
+++ b/data/mods/gen8dlc1/rulesets.ts
@@ -3,9 +3,9 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 		inherit: true,
 		onBattleStart() {
 			// Xerneas isn't in DLC1 but operated this way pre-1.3.2 update
-			const formesToLeak = ["zaciancrowned", "zamazentacrowned", "xerneas"];
+			const formesToLeak = ['zaciancrowned', 'zamazentacrowned', 'xerneas'];
 			for (const pokemon of this.getAllPokemon()) {
-				if (!formesToLeak.includes(this.toID(pokemon.baseSpecies.name))) continue;
+				if (!formesToLeak.includes(pokemon.baseSpecies.id)) continue;
 				const newDetails = pokemon.details.replace(', shiny', '');
 				this.add('updatepoke', pokemon, newDetails);
 			}

--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -16034,7 +16034,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Blue",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Rusted Sword",
-		changesFrom: "Zacian",
+		battleOnly: "Zacian",
 		cannotDynamax: true,
 	},
 	zamazenta: {
@@ -16068,7 +16068,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Red",
 		eggGroups: ["Undiscovered"],
 		requiredItem: "Rusted Shield",
-		changesFrom: "Zamazenta",
+		battleOnly: "Zamazenta",
 		cannotDynamax: true,
 	},
 	eternatus: {

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -446,7 +446,11 @@ export const Rulesets: {[k: string]: FormatData} = {
 			this.add('clearpoke');
 			for (const pokemon of this.getAllPokemon()) {
 				const details = pokemon.details.replace(', shiny', '')
-					.replace(/(Arceus|Gourgeist|Pumpkaboo|Xerneas|Silvally|Zacian|Zamazenta|Urshifu)(-[a-zA-Z?-]+)?/g, '$1-*');
+					.replace(/(Arceus|Gourgeist|Pumpkaboo|Xerneas|Silvally|Urshifu)(-[a-zA-Z?-]+)?/g, '$1-*')
+					// Zacian and Zamazenta should already be in the correct formes for Team Preview
+					// but we still appened "-*" to the base formes so the client doesn't get confused
+					// when they transform into their Crowned formes before they are sent into battle
+					.replace(/(Zacian|Zamazenta)(?!-Crowned)/g, '$1-*');
 				this.add('poke', pokemon.side.id, details, '');
 			}
 			this.makeRequest('teampreview');
@@ -1146,11 +1150,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 									if (prevo.evos.includes(formeName)) continue;
 								}
 								const forme = dex.species.get(formeName);
-								if (
-									forme.changesFrom === originalForme.name && !forme.battleOnly &&
-									// Temporary workaround
-									forme.forme !== 'Crowned'
-								) {
+								if (forme.changesFrom === originalForme.name && !forme.battleOnly) {
 									speciesTypes.push(...forme.types);
 								}
 							}

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -447,10 +447,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 			for (const pokemon of this.getAllPokemon()) {
 				const details = pokemon.details.replace(', shiny', '')
 					.replace(/(Arceus|Gourgeist|Pumpkaboo|Xerneas|Silvally|Urshifu)(-[a-zA-Z?-]+)?/g, '$1-*')
-					// Zacian and Zamazenta should already be in the correct formes for Team Preview
-					// but we still appened "-*" to the base formes so the client doesn't get confused
-					// when they transform into their Crowned formes before they are sent into battle
-					.replace(/(Zacian|Zamazenta)(?!-Crowned)/g, '$1-*');
+					.replace(/(Zacian|Zamazenta)(?!-Crowned)/g, '$1-*'); // Hacked-in Crowned formes will be revealed
 				this.add('poke', pokemon.side.id, details, '');
 			}
 			this.makeRequest('teampreview');

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2403,7 +2403,6 @@ export class Battle {
 				} else if (pokemon.species.id === 'zamazenta' && pokemon.item === 'rustedshield') {
 					rawSpecies = this.dex.species.get('Zamazenta-Crowned');
 				}
-
 				if (!rawSpecies) continue;
 				const species = pokemon.setSpecies(rawSpecies);
 				if (!species) continue;

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2395,6 +2395,43 @@ export class Battle {
 
 			this.add('start');
 
+			// Change Zacian/Zamazenta into their Crowned formes
+			for (const pokemon of this.getAllPokemon()) {
+				let rawSpecies: Species | null = null;
+				if (pokemon.species.id === 'zacian' && pokemon.item === 'rustedsword') {
+					rawSpecies = this.dex.species.get('Zacian-Crowned');
+				} else if (pokemon.species.id === 'zamazenta' && pokemon.item === 'rustedshield') {
+					rawSpecies = this.dex.species.get('Zamazenta-Crowned');
+				}
+
+				if (!rawSpecies) continue;
+				const species = pokemon.setSpecies(rawSpecies);
+				if (!species) continue;
+				pokemon.baseSpecies = rawSpecies;
+				pokemon.details = species.name + (pokemon.level === 100 ? '' : ', L' + pokemon.level) +
+					(pokemon.gender === '' ? '' : ', ' + pokemon.gender) + (pokemon.set.shiny ? ', shiny' : '');
+				pokemon.setAbility(species.abilities['0'], null, true);
+				pokemon.baseAbility = pokemon.ability;
+
+				const behemothMove: {[k: string]: string} = {
+					'Zacian-Crowned': 'behemothblade', 'Zamazenta-Crowned': 'behemothbash',
+				};
+				const ironHead = pokemon.moves.indexOf('ironhead');
+				if (ironHead >= 0) {
+					const move = this.dex.moves.get(behemothMove[rawSpecies.name]);
+					pokemon.moveSlots[ironHead] = {
+						move: move.name,
+						id: move.id,
+						pp: (move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5,
+						maxpp: (move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5,
+						target: move.target,
+						disabled: false,
+						disabledSource: '',
+						used: false,
+					};
+				}
+			}
+
 			if (this.format.onBattleStart) this.format.onBattleStart.call(this);
 			for (const rule of this.ruleTable.keys()) {
 				if ('+*-!'.includes(rule.charAt(0))) continue;

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -527,6 +527,10 @@ export class TeamValidator {
 				tierSpecies = dex.species.get('Kyogre-Primal');
 			} else if (canMegaEvo && species.id === 'rayquaza' && set.moves.map(toID).includes('dragonascent' as ID)) {
 				tierSpecies = dex.species.get('Rayquaza-Mega');
+			} else if (item.id === 'rustedsword' && species.id === 'zacian') {
+				tierSpecies = dex.species.get('Zacian-Crowned');
+			} else if (item.id === 'rustedshield' && species.id === 'zamazenta') {
+				tierSpecies = dex.species.get('Zamazenta-Crowned');
 			}
 		}
 
@@ -1299,10 +1303,10 @@ export class TeamValidator {
 		const crowned: {[k: string]: string} = {
 			'Zacian-Crowned': 'behemothblade', 'Zamazenta-Crowned': 'behemothbash',
 		};
-		if (set.species in crowned) {
-			const ironHead = set.moves.map(toID).indexOf('ironhead' as ID);
-			if (ironHead >= 0) {
-				set.moves[ironHead] = crowned[set.species];
+		if (species.name in crowned) {
+			const behemothMove = set.moves.map(toID).indexOf(crowned[species.name] as ID);
+			if (behemothMove >= 0) {
+				set.moves[behemothMove] = 'ironhead';
 			}
 		}
 		return problems;

--- a/test/sim/misc/teampreview.js
+++ b/test/sim/misc/teampreview.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const assert = require('../../assert');
+const common = require('../../common');
+
+let battle;
+
+describe("Team Preview", function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('should hide formes of certain Pokemon', function () {
+		battle = common.createBattle('gen8anythinggoes', [[
+			{species: 'Arceus-Steel', ability: 'multitype', item: 'steelplate', moves: ['sleeptalk']},
+			{species: 'Pumpkaboo-Super', ability: 'pickup', moves: ['sleeptalk']},
+			{species: 'Gourgeist-Small', ability: 'pickup', moves: ['sleeptalk']},
+		], [
+			{species: 'Silvally', ability: 'rkssystem', moves: ['sleeptalk']},
+			{species: 'Urshifu-Rapid-Strike', ability: 'unseenfist', moves: ['sleeptalk']},
+			{species: 'Zacian', ability: 'intrepidsword', item: 'rustedsword', moves: ['sleeptalk']},
+		]]);
+		for (const line of battle.log) {
+			if (line.startsWith('|poke|')) {
+				const details = line.split('|')[3];
+				assert(details.match(/(Arceus|Pumpkaboo|Gourgeist|Silvally|Urshifu|Zacian)-\*/), `Forme was not hidden; preview details: ${details}`);
+			}
+		}
+	});
+
+	it('should not hide formes of hacked Zacian/Zamazenta formes', function () {
+		battle = common.createBattle([[
+			{species: 'Zacian-Crowned', moves: ['sleeptalk']},
+		], [
+			{species: 'Zamazenta-Crowned', moves: ['sleeptalk']},
+		]]);
+		for (const line of battle.log) {
+			if (line.startsWith('|poke|')) {
+				const details = line.split('|')[3];
+				assert.false(details.includes('-*'), `Forme was hidden; preview details: ${details}`);
+			}
+		}
+	});
+});

--- a/test/sim/misc/teampreview.js
+++ b/test/sim/misc/teampreview.js
@@ -5,7 +5,7 @@ const common = require('../../common');
 
 let battle;
 
-describe("Team Preview", function () {
+describe('Team Preview', function () {
 	afterEach(function () {
 		battle.destroy();
 	});


### PR DESCRIPTION
- Crowned formes will now use `battleOnly` instead of `changesFrom`, which means the validator will handle them similarly to other battle-only formes.
- Before the first switch-ins, base forme Zacian/Zamazenta holding Rusted Sword/Shield will have their species changed to their Crowned formes, abilities changed to Intrepid Sword/Dauntless Shield, and Iron Head changed to Behemoth Blade/Bash.
- This also fixes issue that Zacian/Zamazenta had with Team Preview in Hackmons. Now only the base forme Zacian/Zamazenta will have `-*` appended to their name at Team Preview, while Crowned forme will be shown normally, as you can no longer have Crowned forme at Team Preview unless `Obtainable Formes` is not in the ruleset.
- Most importantly, the convenience feature of being able to select Crowned formes and Behemoth moves in the teambuilder will still work

Drafting for now in case I missed something in my species-changing code.

This also removes the need for #8729 