### PR TITLE
Validate tour rules in generator before setting it

### DIFF
--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -214,7 +214,7 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 		let format;
 		try {
 			const tryFormat = Dex.formats.validate(`${this.baseFormat}@@@${rules}`);
-			format = Dex.formats.get(this.tryFormat, true);
+			format = Dex.formats.get(tryFormat, true);
 
 			// In tours of formats with generated teams, custom rule errors should be checked for here,
 			// since users can't edit their teams to avoid them at matching time

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -213,7 +213,7 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 	setCustomRules(rules: string) {
 		let format;
 		try {
-			let tryFormat = Dex.formats.validate(`${this.baseFormat}@@@${rules}`);
+			const tryFormat = Dex.formats.validate(`${this.baseFormat}@@@${rules}`);
 			format = Dex.formats.get(this.tryFormat, true);
 
 			// In tours of formats with generated teams, custom rule errors should be checked for here,

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -213,8 +213,8 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 	setCustomRules(rules: string) {
 		let format;
 		try {
-			this.fullFormat = Dex.formats.validate(`${this.baseFormat}@@@${rules}`);
-			format = Dex.formats.get(this.fullFormat, true);
+			let tryFormat = Dex.formats.validate(`${this.baseFormat}@@@${rules}`);
+			format = Dex.formats.get(this.tryFormat, true);
 
 			// In tours of formats with generated teams, custom rule errors should be checked for here,
 			// since users can't edit their teams to avoid them at matching time
@@ -223,6 +223,7 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 				const testTeamGenerator = Teams.getGenerator(format, testTeamSeed);
 				testTeamGenerator.getTeam(); // Throws error if generation fails
 			}
+			this.fullFormat = tryFormat;
 		} catch (e: any) {
 			throw new Chat.ErrorMessage(`Custom rule error: ${e.message}`);
 		}


### PR DESCRIPTION
Hi, I'm sure the PR name doesn't really make sense. This fixes the bug I posted here:
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-9210558

Basically, prior to this fix, this.fullFormat would get set, and THEN it would check if it would work with formats with generated teams. What happens is, if it doesn't work with those formats, then it throws an error, but this.fullFormat remains, and all players get a "team generator (random) failed using these rules and seed (6503,27336,63804,42074)" error.

This fix holds off on setting this.fullFormat until after generated team formats are checked.