### PR TITLE
Pokebilities AAA: Fix Sheer Force interaction with abilities that add secondaries

### DIFF
--- a/data/mods/pokebilities/abilities.ts
+++ b/data/mods/pokebilities/abilities.ts
@@ -220,6 +220,11 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			}
 		},
 	},
+	sheerforce: {
+		inherit: true,
+		// Activate after abilities that can add a secondary effect
+		onModifyMovePriority: -3,
+	},
 	trace: {
 		inherit: true,
 		onUpdate(pokemon) {

--- a/data/mods/pokebilities/abilities.ts
+++ b/data/mods/pokebilities/abilities.ts
@@ -155,6 +155,12 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			}
 		},
 	},
+	poisontouch: {
+		inherit: true,
+		// Activate after Sheer Force to make interaction determistic. The ordering for this ability is
+		// an arbitary decision, but is modelled on Stench, which is reflective of on-cart behaviour.
+		onModifyMovePriority: -1,
+	},
 	powerofalchemy: {
 		inherit: true,
 		onAllyFaint(ally) {
@@ -219,11 +225,6 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 				this.add('-fail', target, 'unboost', 'Attack', '[from] ability: Scrappy', '[of] ' + target);
 			}
 		},
-	},
-	sheerforce: {
-		inherit: true,
-		// Activate after abilities that can add a secondary effect
-		onModifyMovePriority: -3,
 	},
 	trace: {
 		inherit: true,


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/page-76#post-9207294

Shoutouts to mathfreak for the detailed analysis.

~~This change makes Sheer Force take priority deterministically. Although we can't know for certain how SF 'should' interact with abilities that add secondary effects, it seems logical that affected moves would function like regular SF-compatible moves.~~

I changed my mind after looking into this further:-

https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/page-62#post-8905424

Based on this, it seems that we _can_ know that Stench would activate after Sheer Force on cart if you could somehow have both. Poison Touch still seems to be undetermined behavior but given the above, I think it is more coherent and should be more intuitive to users if it works the same way, with SF always losing in priority when it interacts with abilities that add secondary effects.