### PR TITLE
Pokebilities AAA: Fix Ice Face activation timing

### DIFF
--- a/data/mods/pokebilities/scripts.ts
+++ b/data/mods/pokebilities/scripts.ts
@@ -142,5 +142,63 @@ export const Scripts: ModdedBattleScriptsData = {
 
 			return true;
 		},
+		/**
+		 * Changes this Pokemon's forme to match the given speciesId (or species).
+		 * This function handles all changes to stats, ability, type, species, etc.
+		 * as well as sending all relevant messages sent to the client.
+		 */
+		formeChange(speciesId, source, isPermanent?, message?) {
+			if (!source) source = this.battle.effect;
+
+			const rawSpecies = this.battle.dex.species.get(speciesId);
+	
+			const species = this.setSpecies(rawSpecies, source);
+			if (!species) return false;
+	
+			if (this.battle.gen <= 2) return true;
+	
+			// The species the opponent sees
+			const apparentSpecies =
+				this.illusion ? this.illusion.species.name : species.baseSpecies;
+			if (isPermanent) {
+				this.baseSpecies = rawSpecies;
+				this.details = species.name + (this.level === 100 ? '' : ', L' + this.level) +
+					(this.gender === '' ? '' : ', ' + this.gender) + (this.set.shiny ? ', shiny' : '');
+				this.battle.add('detailschange', this, (this.illusion || this).details);
+				if (source.effectType === 'Item') {
+					if (source.zMove) {
+						this.battle.add('-burst', this, apparentSpecies, species.requiredItem);
+						this.moveThisTurnResult = true; // Ultra Burst counts as an action for Truant
+					} else if (source.onPrimal) {
+						if (this.illusion) {
+							this.ability = '';
+							this.battle.add('-primal', this.illusion);
+						} else {
+							this.battle.add('-primal', this);
+						}
+					} else {
+						this.battle.add('-mega', this, apparentSpecies, species.requiredItem);
+						this.moveThisTurnResult = true; // Mega Evolution counts as an action for Truant
+					}
+				} else if (source.effectType === 'Status') {
+					// Shaymin-Sky -> Shaymin
+					this.battle.add('-formechange', this, species.name, message);
+				}
+			} else {
+				if (source.effectType === 'Ability') {
+					this.battle.add('-formechange', this, species.name, message, `[from] ability: ${source.name}`);
+				} else {
+					this.battle.add('-formechange', this, this.illusion ? this.illusion.species.name : species.name, message);
+				}
+			}
+			if (isPermanent && !['disguise', 'iceface', 'ability:disguise', 'ability:iceface'].includes(source.id)) {
+				if (this.illusion) {
+					this.ability = ''; // Don't allow Illusion to wear off
+				}
+				this.setAbility(species.abilities['0'], null, true);
+				this.baseAbility = this.ability;
+			}
+			return true;
+		},
 	},
 };

--- a/data/mods/pokebilities/scripts.ts
+++ b/data/mods/pokebilities/scripts.ts
@@ -151,12 +151,12 @@ export const Scripts: ModdedBattleScriptsData = {
 			if (!source) source = this.battle.effect;
 
 			const rawSpecies = this.battle.dex.species.get(speciesId);
-	
+
 			const species = this.setSpecies(rawSpecies, source);
 			if (!species) return false;
-	
+
 			if (this.battle.gen <= 2) return true;
-	
+
 			// The species the opponent sees
 			const apparentSpecies =
 				this.illusion ? this.illusion.species.name : species.baseSpecies;

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -312,6 +312,9 @@ interface ModdedBattlePokemon {
 	clearBoosts?: (this: Pokemon) => void;
 	calculateStat?: (this: Pokemon, statName: StatIDExceptHP, boost: number, modifier?: number) => number;
 	cureStatus?: (this: Pokemon, silent?: boolean) => boolean;
+	formeChange?: (
+		this: Pokemon, speciesId: string | Species, source: Effect, isPermanent?: boolean, message?: string
+	) => boolean;
 	getAbility?: (this: Pokemon) => Ability;
 	getActionSpeed?: (this: Pokemon) => number;
 	getItem?: (this: Pokemon) => Item;


### PR DESCRIPTION
Bug report: https://www.smogon.com/forums/threads/om-mashup-megathread-pokeaaa-is-leaders-choice.3657159/page-35#post-9212722

---

pokemon.ts
```
formeChange(
	speciesId: string | Species, source: Effect = this.battle.effect,
	isPermanent?: boolean, message?: string
) {
```
=>
pokebilities/scripts.ts
```
formeChange(speciesId, source, isPermanent?, message?) {
	if (!source) source = this.battle.effect;
```

I don't know if there's a better way to deal with "An outer value of 'this' is shadowed by this container."