### PR TITLE
Pokebilities: Fix Intimidate counters

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1723,7 +1723,7 @@ export const Formats: FormatList = [
 			// handle switch-in ability-to-ability interactions, e.g. Intimidate counters
 			const neededBeforeSwitchInIDs = [
 				'clearbody', 'competitive', 'contrary', 'defiant', 'fullmetalbody', 'hypercutter', 'innerfocus',
-				'mirrorarmor', 'oblivious', 'owntempo', 'rattled', 'scrappy', 'simple', 'whitesmoke'
+				'mirrorarmor', 'oblivious', 'owntempo', 'rattled', 'scrappy', 'simple', 'whitesmoke',
 			];
 			if (pokemon.m.innates) {
 				for (const innate of pokemon.m.innates) {

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1718,10 +1718,26 @@ export const Formats: FormatList = [
 					.filter(ability => ability !== pokemon.ability);
 			}
 		},
+		onBeforeSwitchIn(pokemon) {
+			// Abilities that must be applied before both sides trigger onSwitchIn to correctly
+			// handle switch-in ability-to-ability interactions, e.g. Intimidate counters
+			const neededBeforeSwitchInIDs = [
+				'clearbody', 'competitive', 'contrary', 'defiant', 'fullmetalbody', 'hypercutter', 'innerfocus',
+				'mirrorarmor', 'oblivious', 'owntempo', 'rattled', 'scrappy', 'simple', 'whitesmoke'
+			];
+			if (pokemon.m.innates) {
+				for (const innate of pokemon.m.innates) {
+					if (!neededBeforeSwitchInIDs.includes(innate)) continue;
+					if (pokemon.hasAbility(innate)) continue;
+					pokemon.addVolatile("ability:" + innate, pokemon);
+				}
+			}
+		},
 		onSwitchInPriority: 2,
 		onSwitchIn(pokemon) {
 			if (pokemon.m.innates) {
 				for (const innate of pokemon.m.innates) {
+					if (pokemon.hasAbility(innate)) continue;
 					pokemon.addVolatile("ability:" + innate, pokemon);
 				}
 			}


### PR DESCRIPTION
Bug report: https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/page-76#post-9205832
Replays: https://replay.pokemonshowdown.com/gen8pokebilities-1566499155-msrutjsdz77jinmo32cqlmy1swgaajspw
https://replay.pokemonshowdown.com/gen8pokebilitiesaaa-1573974793-fg5n05q18nzvsxk8ky8mfdibsww7558pw

Intimidate can activate from one side's onSwitchIn before the other side has received its counter-ability volatile from its own onSwitchIn, so it seems like at least some abilities need to be applied before this. However, just moving all addVolatiles to onBeforeSwitchIn would make the timing of abilities that are announced on switch-in incorrect.

It would be good if there is a less janky way to address this, especially since it's possible that there might be an ability that needs to passively exist during the opponent's switch-in that also announces on the user's switch in, although I couldn't think of an extant example of one.