### PR TITLE
Kleavor and Ursaluna evo fields

### DIFF
--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -16335,8 +16335,8 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 89,
 		color: "Brown",
 		prevo: "Scyther",
-		evoType: "other",
-		evoCondition: "Black Augurite",
+		evoType: "useItem",
+		evoItem: "Black Augurite",
 		eggGroups: ["Bug"],
 	},
 	ursaluna: {
@@ -16349,8 +16349,9 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 290,
 		color: "Brown",
 		prevo: "Ursaring",
-		evoType: "other",
-		evoCondition: "Peat Block when there's a full moon",
+		evoType: "useItem",
+		evoItem: "Peat Block",
+		evoCondition: "full moon",
 		eggGroups: ["Field"],
 	},
 	basculegion: {


### PR DESCRIPTION
- Change `evoType` from `"other"` to `"useItem"` for Kleavor and Ursaluna.
- Move item names to `evoItem`.
- Set `evoCondition` for Ursaluna to `"full moon"`.

This is better since Kleavor requires no extra conditions aside from using an item.

Not sure about Ursaluna, but felt like this approach is still more consistent with other Pokémon than what is currently used.