### PR TITLE
Add missing time-based evoConditions

### DIFF
--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -13212,7 +13212,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Red",
 		prevo: "Rockruff",
 		evoLevel: 25,
-		evoCondition: "during the night",
+		evoCondition: "at night",
 		eggGroups: ["Field"],
 	},
 	lycanrocdusk: {

--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -459,6 +459,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Black",
 		prevo: "Rattata-Alola",
 		evoLevel: 20,
+		evoCondition: "at night",
 		eggGroups: ["Field"],
 	},
 	raticatealolatotem: {
@@ -2391,6 +2392,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Purple",
 		prevo: "Cubone",
 		evoLevel: 28,
+		evoCondition: "at night",
 		eggGroups: ["Monster"],
 	},
 	marowakalolatotem: {
@@ -5026,6 +5028,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		color: "White",
 		prevo: "Zigzagoon-Galar",
 		evoLevel: 20,
+		evoCondition: "at night",
 		evos: ["Obstagoon"],
 		eggGroups: ["Field"],
 	},
@@ -8096,6 +8099,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		prevo: "Sneasel",
 		evoType: "levelHold",
 		evoItem: "Razor Claw",
+		evoCondition: "at night",
 		eggGroups: ["Field"],
 	},
 	magnezone: {
@@ -12224,6 +12228,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Red",
 		prevo: "Tyrunt",
 		evoLevel: 39,
+		evoCondition: "during the day",
 		eggGroups: ["Monster", "Dragon"],
 	},
 	amaura: {
@@ -12251,6 +12256,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Blue",
 		prevo: "Amaura",
 		evoLevel: 39,
+		evoCondition: "at night",
 		eggGroups: ["Monster"],
 	},
 	sylveon: {
@@ -12970,6 +12976,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Brown",
 		prevo: "Yungoos",
 		evoLevel: 20,
+		evoCondition: "during the day",
 		eggGroups: ["Field"],
 		otherFormes: ["Gumshoos-Totem"],
 		formeOrder: ["Gumshoos", "Gumshoos-Totem"],
@@ -16400,6 +16407,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		prevo: "Sneasel-Hisui",
 		evoType: "useItem",
 		evoItem: "Razor Claw",
+		evoCondition: "during the day",
 		eggGroups: ["Field"],
 	},
 	overqwil: {

--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -5028,7 +5028,6 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		color: "White",
 		prevo: "Zigzagoon-Galar",
 		evoLevel: 20,
-		evoCondition: "at night",
 		evos: ["Obstagoon"],
 		eggGroups: ["Field"],
 	},


### PR DESCRIPTION
- Alter Lycanroc-Midnight's evo condition wording to be consistent with other night-time evolutions.
- Add time-based evoCondition to `Raticate-Alola`, `Marowak-Alola`, `Weavile`, `Tyrantrum`, `Aurorus`, `Gumshoos`, `Sneasler`

Some evos already had these, all friendship-based evolutions seemed to have them, and Obstagoon had a time-based evoCondition even though it evolves simply through level.