### PR TITLE
Remove unused ceilModifier event property

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2060,13 +2060,7 @@ export class Battle {
 			denominator = numerator[1];
 			numerator = numerator[0];
 		}
-		let nextMod = 0;
-		if (this.event.ceilModifier) {
-			nextMod = Math.ceil(numerator * 4096 / (denominator || 1));
-		} else {
-			nextMod = this.trunc(numerator * 4096 / (denominator || 1));
-		}
-
+		const nextMod = this.trunc(numerator * 4096 / (denominator || 1));
 		this.event.modifier = ((previousMod * nextMod + 2048) >> 12) / 4096;
 	}
 


### PR DESCRIPTION
As far as I know, chainModify() would have never needed to take the ceiling rather than the floor of some modifier like this. I can't think of any particular reason why we would need it; it's pretty old according to git blame, maybe before we understood chaining modifiers well? It's not used anywhere else and I can't find any other history on it besides the [initial commit](https://github.com/smogon/pokemon-showdown/commit/84f983ca06c8f39985e290664a098208c7fad3be) for it, so it may have gone completely unused. Making a PR instead of pushing in case I'm wrong on that.