### PR TITLE
Mafia:Previous Actions + some help messages

### DIFF
--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -1991,7 +1991,9 @@ export const pages: Chat.PageTable = {
 				buf += `: <button class="button" name="send" value="/msgroom ${room.roomid},/mafia revive ${dead.id}">Revive</button></p>`;
 			}
 			buf += `<hr/></details></p>`;
-			if (game.dayNum > 1) buf += `<p><details><summary class="button" style="text-align:left; display:inline-block">Previous Night Actions</summary>${previousActions}</span></details></p>`;
+			if (game.dayNum > 1) {
+				buf += `<p><details><summary class="button" style="text-align:left; display:inline-block">Previous Night Actions</summary>${previousActions}</span></details></p>`;
+			}
 			buf += `<p><details><summary class="button" style="text-align:left; display:inline-block">How to setup roles</summary>`;
 			buf += `<h3>Setting the roles</h3>`;
 			buf += `<p>To set the roles, use /mafia setroles [comma seperated list of roles] OR /mafia setroles [theme] in ${room.title}.</p>`;


### PR DESCRIPTION
Records the previous actions and idles submitted through the script for both the host and the players.
Adds help messages for hosts regarding /mafia prod,/mafia action [action] and /mafia idle