### PR TITLE
Tournaments: Fix grand subfinals in multi-elimination

### DIFF
--- a/server/tournaments/generator-elimination.ts
+++ b/server/tournaments/generator-elimination.ts
@@ -393,7 +393,7 @@ export class Elimination {
 		if (targetNode.parent) {
 			const parent = targetNode.parent;
 
-			if (loser.losses <= winner.losses) {
+			if (loser.losses <= winner.losses && !loser.isDisqualified) {
 				// grand subfinals rematch
 				const newNode = new ElimNode({state: 'available', losersBracketNode: targetNode.losersBracketNode});
 				newNode.setChildren([targetNode, new ElimNode({user: loser})]);


### PR DESCRIPTION
This fixes a bug in threefold or more elimination tournaments where a player could be scammed out of one or more of their "lives" by losing to a player from a lower bracket. These matches are supposed to be treated as their own grand finals and the top player must lose multiple times before they fall to the lower bracket.

Example: Take a 4-player, triple elimination tournament. P1 has won twice and is the winners finalist. P2 lost to P4 in round 1, but won both losers rounds and now fights P1. If P1 loses, P1 and P2 must fight again, and only then does the loser fall to the second losers bracket. (If P1 won the first game, not only would P2 fall to the second losers bracket right away, but P1 would also have an extra "life" in the grand finals.)