### PR TITLE
Add/modify error messages in dexsearch, movesearch

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -632,12 +632,16 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			}
 
 			if (['mono', 'monotype'].includes(toID(target))) {
+				if (singleTypeSearch === isNotSearch) return {error: "A search cannot include and exclude 'monotype'."};
+				if (parameters.length > 1) return {error: "The parameter 'monotype' cannot have alternative parameters."};
 				singleTypeSearch = !isNotSearch;
 				orGroup.skip = true;
 				continue;
 			}
 
 			if (target === 'natdex') {
+				if (isNotSearch) return {error: "A search cannot exclude 'natdex'."};
+				if (parameters.length > 1) return {error: "The parameter 'natdex' cannot have alternative parameters."};
 				nationalSearch = true;
 				orGroup.skip = true;
 				continue;
@@ -679,7 +683,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			}
 
 			if (target.endsWith(' asc') || target.endsWith(' desc')) {
-				if (parameters.length > 1) return {error: `The parameter '${target.split(' ')[1]}' cannot have alternative parameters`};
+				if (parameters.length > 1) return {error: `The parameter '${target.split(' ')[1]}' cannot have alternative parameters.`};
 				const stat = allStatAliases[toID(target.split(' ')[0])] || toID(target.split(' ')[0]);
 				if (!allStats.includes(stat)) return {error: `'${escapeHTML(target)}' did not contain a valid stat.`};
 				sort = `${stat}${target.endsWith(' asc') ? '+' : '-'}`;
@@ -689,7 +693,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 
 			if (target === 'all') {
 				if (!canAll) return {error: "A search with the parameter 'all' cannot be broadcast."};
-				if (parameters.length > 1) return {error: "The parameter 'all' cannot have alternative parameters"};
+				if (parameters.length > 1) return {error: "The parameter 'all' cannot have alternative parameters."};
 				showAll = true;
 				orGroup.skip = true;
 				break;
@@ -710,7 +714,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 
 			if (target === 'megas' || target === 'mega') {
 				if (megaSearch === isNotSearch) return {error: "A search cannot include and exclude 'mega'."};
-				if (parameters.length > 1) return {error: "The parameter 'mega' cannot have alternative parameters"};
+				if (parameters.length > 1) return {error: "The parameter 'mega' cannot have alternative parameters."};
 				megaSearch = !isNotSearch;
 				orGroup.skip = true;
 				break;
@@ -718,7 +722,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 
 			if (target === 'gmax' || target === 'gigantamax') {
 				if (gmaxSearch === isNotSearch) return {error: "A search cannot include and exclude 'gigantamax'."};
-				if (parameters.length > 1) return {error: "The parameter 'gigantamax' cannot have alternative parameters"};
+				if (parameters.length > 1) return {error: "The parameter 'gigantamax' cannot have alternative parameters."};
 				gmaxSearch = !isNotSearch;
 				orGroup.skip = true;
 				break;
@@ -726,7 +730,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 
 			if (['fully evolved', 'fullyevolved', 'fe'].includes(target)) {
 				if (fullyEvolvedSearch === isNotSearch) return {error: "A search cannot include and exclude 'fully evolved'."};
-				if (parameters.length > 1) return {error: "The parameter 'fully evolved' cannot have alternative parameters"};
+				if (parameters.length > 1) return {error: "The parameter 'fully evolved' cannot have alternative parameters."};
 				fullyEvolvedSearch = !isNotSearch;
 				orGroup.skip = true;
 				break;
@@ -1356,7 +1360,7 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 			}
 
 			if (target.endsWith(' asc') || target.endsWith(' desc')) {
-				if (parameters.length > 1) return {error: `The parameter '${target.split(' ')[1]}' cannot have alternative parameters`};
+				if (parameters.length > 1) return {error: `The parameter '${target.split(' ')[1]}' cannot have alternative parameters.`};
 				let prop = target.split(' ')[0];
 				switch (toID(prop)) {
 				case 'basepower': prop = 'basePower'; break;

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -682,7 +682,9 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			}
 
 			if (target.endsWith(' asc') || target.endsWith(' desc')) {
-				if (parameters.length > 1) return {error: `The parameter '${target.split(' ')[1]}' cannot have alternative parameters.`};
+				if (parameters.length > 1) {
+					return {error: `The parameter '${target.split(' ')[1]}' cannot have alternative parameters.`};
+				}
 				const stat = allStatAliases[toID(target.split(' ')[0])] || toID(target.split(' ')[0]);
 				if (!allStats.includes(stat)) return {error: `'${escapeHTML(target)}' did not contain a valid stat.`};
 				sort = `${stat}${target.endsWith(' asc') ? '+' : '-'}`;
@@ -1361,7 +1363,9 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 			}
 
 			if (target.endsWith(' asc') || target.endsWith(' desc')) {
-				if (parameters.length > 1) return {error: `The parameter '${target.split(' ')[1]}' cannot have alternative parameters.`};
+				if (parameters.length > 1) {
+					return {error: `The parameter '${target.split(' ')[1]}' cannot have alternative parameters.`};
+				}
 				let prop = target.split(' ')[0];
 				switch (toID(prop)) {
 				case 'basepower': prop = 'basePower'; break;

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -640,7 +640,6 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 			}
 
 			if (target === 'natdex') {
-				if (isNotSearch) return {error: "A search cannot exclude 'natdex'."};
 				if (parameters.length > 1) return {error: "The parameter 'natdex' cannot have alternative parameters."};
 				nationalSearch = true;
 				orGroup.skip = true;
@@ -1348,12 +1347,14 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 
 			if (target === 'all') {
 				if (!canAll) return {error: "A search with the parameter 'all' cannot be broadcast."};
+				if (parameters.length > 1) return {error: "The parameter 'all' cannot have alternative parameters."};
 				showAll = true;
 				orGroup.skip = true;
 				continue;
 			}
 
 			if (target === 'natdex') {
+				if (parameters.length > 1) return {error: "The parameter 'natdex' cannot have alternative parameters."};
 				nationalSearch = true;
 				orGroup.skip = true;
 				continue;


### PR DESCRIPTION
Some minor changes:
- Add periods to the end of "The parameter '...' cannot have alternative parameters" error messages for consistency with other error messages
- Add error message for using alternative parameters for `monotype` and `natdex` in dexsearch, and `all` and `natdex` in movesearch (as orGroup.skip is set to true for those, similar to the other cases)
- Add "A search cannot include and exclude 'monotype'." error message as it works similarly to the other parameters with that message (just setting a flag rather than adding another orGroup; currently, `/nds mono, !mono` is the same as `/nds !mono` but `/nds !mono, mono` is the same as `/nds mono`)

It might also be helpful to add an error message if the parameter `natdex` or `all` is negated (as e.g. `!natdex` is functionally identical to `natdex`, which may be surprising behavior).