### PR TITLE
Gen 1: Add incompatibilities to NC97 Move Legality

### DIFF
--- a/data/mods/gen1jpn/rulesets.ts
+++ b/data/mods/gen1jpn/rulesets.ts
@@ -9,6 +9,18 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 		effectType: 'ValidatorRule',
 		name: 'Nintendo Cup 1997 Move Legality',
 		desc: "Bans move combinations on Pok\u00e9mon that would only be obtainable in Pok\u00e9mon Yellow.",
+		banlist: [
+			// https://www.smogon.com/forums/threads/rby-and-gsc-illegal-movesets.78638/
+			// https://www.smogon.com/forums/threads/rby-tradebacks-bug-report-thread.3524844/post-9235903
+			// Due to Yellow learnset modifications not applying, there are a few more incompatibilities than usual.
+			'Nidoking + Fury Attack + Thrash', 'Nidoking + Double Kick + Thrash',
+			'Butterfree + Tackle + Harden', 'Butterfree + String Shot + Harden',
+			'Exeggutor + Poison Powder + Stomp', 'Exeggutor + Sleep Powder + Stomp', 'Exeggutor + Stun Spore + Stomp',
+			'Eevee + Tackle + Growl',
+			'Vaporeon + Tackle + Growl',
+			'Jolteon + Tackle + Growl', 'Jolteon + Focus Energy + Thunder Shock',
+			'Flareon + Tackle + Growl', 'Flareon + Focus Energy + Ember',
+		],
 		onValidateSet(set) {
 			const rgb97Legality: {[speciesid: string]: {[moveid: string]: 'illegal' | number}} = {
 				charizard: {fly: 'illegal'},


### PR DESCRIPTION
Fixing what I reported here: https://www.smogon.com/forums/threads/rby-tradebacks-bug-report-thread.3524844/post-9235903
Marty said to just copy the banlist from gen2 and add to it, so here I am!

Details on what's up;
- Before Yellow came out, Nidoran-M learned Double Kick at L42, so Nidoking can never get it alongside Thrash.
- Metapod doesn't learn Harden if evolving from Caterpie prior to Yellow, you have to catch a wild Metapod to have it. Ergo, Tackle and String Shot can't be on the same set.

Extremely minor, but that's most of my pull requests. Thank you for your time!