### PR TITLE
Create /battlechat command

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -337,6 +337,14 @@ exports.forcetimer = false;
 exports.forceregisterelo = false;
 
 /**
+ * enable the battle chat feature - if enabled, the /battlechat command, when used
+ * in a battle, will create a groupchat that the players can't join.
+ * Intended for tournament servers.
+ * @type {boolean}
+ */
+exports.enablebattlechat = false;
+
+/**
  * backdoor - allows Pokemon Showdown system operators to provide technical
  *            support for your server
  *   This backdoor gives system operators (such as Zarel) console admin

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -907,6 +907,38 @@ export const commands: Chat.ChatCommands = {
 		`/subroomgroupchat [roomname] - Creates a subroom groupchat of the current room. Can only be used in a public room you have staff in.`,
 		`Only users who are staff in a public room or global auth can make groupchats.`,
 	],
+	battlechat(target, room, user) {
+		room = this.requireRoom();
+		this.checkChat();
+		if (!room.battle) return this.errorReply("/battlechat must be used in a battle.");
+		const roomid = room.roomid.replace('battle-', 'battlechat-') as RoomID;
+		if (Rooms.get(roomid)) {
+			if (!this.runBroadcast()) return;
+			this.sendReplyBox(`Join the battle chat: <a href="/${roomid}">${roomid}</a>`);
+			return;
+		}
+		if (!user.can('mute', null, room)) {
+			this.sendReply("This battle does not have a side chat.");
+			return;
+		}
+		const targetRoom = Rooms.createChatRoom(roomid, "[BC] " + room.title, {
+			// TODO: come up with a good titling scheme
+			isPersonal: true,
+			isPrivate: 'hidden',
+			creationTime: Date.now(),
+			modjoin: '+',
+		});
+		if (!targetRoom) {
+			return this.errorReply(`An unknown error occurred while trying to create the battle chat.`);
+		}
+		user.joinRoom(targetRoom.roomid);
+		room.addRaw(`Join the battle chat: <a href="/${roomid}">${roomid}</a>`);
+	},
+	battlechathelp: [
+		`/battlechat - Creates a temporary chatroom inaccessible to the players in the current battle. Requires: % @ # &`,
+		`If the room already exists, responds with the link.`,
+		`!battlechat - Shows everyone a link to the battle chatroom. Requires: + % @ #`,
+	],
 	groupchatuptime: 'roomuptime',
 	roomuptime(target, room, user, connection, cmd) {
 		if (!this.runBroadcast()) return;

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -908,12 +908,13 @@ export const commands: Chat.ChatCommands = {
 		`Only users who are staff in a public room or global auth can make groupchats.`,
 	],
 	battlechat(target, room, user) {
+		if (!Config.enablebattlechat) throw new Chat.ErrorMessage("The /battlechat command is disabled.");
 		room = this.requireRoom();
 		this.checkChat();
-		if (!room.battle) return this.errorReply("/battlechat must be used in a battle.");
+		if (!room.battle) throw new Chat.ErrorMessage("/battlechat must be used in a battle.");
 		const roomid = room.roomid.replace('battle-', 'battlechat-') as RoomID;
 		if (Rooms.get(roomid)) {
-			if (!this.runBroadcast()) return;
+			this.runBroadcast();
 			this.sendReplyBox(`Join the battle chat: <a href="/${roomid}">${roomid}</a>`);
 			return;
 		}
@@ -921,15 +922,14 @@ export const commands: Chat.ChatCommands = {
 			this.sendReply("This battle does not have a side chat.");
 			return;
 		}
-		const targetRoom = Rooms.createChatRoom(roomid, "[BC] " + room.title, {
-			// TODO: come up with a good titling scheme
+		const targetRoom = Rooms.createChatRoom(roomid, "Chat for " + room.title, {
 			isPersonal: true,
 			isPrivate: 'hidden',
 			creationTime: Date.now(),
 			modjoin: '+',
 		});
 		if (!targetRoom) {
-			return this.errorReply(`An unknown error occurred while trying to create the battle chat.`);
+			throw new Chat.ErrorMessage(`An unknown error occurred while trying to create the battle chat.`);
 		}
 		user.joinRoom(targetRoom.roomid);
 		room.addRaw(`Join the battle chat: <a href="/${roomid}">${roomid}</a>`);

--- a/server/users.ts
+++ b/server/users.ts
@@ -1263,10 +1263,17 @@ export class User extends Chat.MessageContext {
 				return false;
 			}
 		}
-		if ((room as GameRoom).tour) {
+		if (room.tour) {
 			const errorMessage = (room as GameRoom).tour!.onBattleJoin(room as GameRoom, this);
 			if (errorMessage) {
 				connection.sendTo(roomid, `|noinit|joinfailed|${errorMessage}`);
+				return false;
+			}
+		}
+		if (roomid.startsWith('battlechat-')) {
+			const battleRoom = Rooms.get(roomid.replace('battlechat-', 'battle-'));
+			if (battleRoom?.battle?.active && this.id in battleRoom.battle.playerTable) {
+				connection.sendTo(roomid, `|noinit|joinfailed|You can't join the battle chat for a battle you're currently playing.`);
 				return false;
 			}
 		}


### PR DESCRIPTION
A proposed feature for smogtours. This is a draft implementation to go along with [this rough specification](https://www.smogon.com/forums/threads/make-a-separate-chat-for-game-discussion-during-tournament-games.3702522/post-9247792) by Lily.

I opted not to make the new group chat a subroom of the battle, so the players who can't see the chat in the first place won't be able to invite anyone they want by voicing them.

This obviously shouldn't be merged until the discussion over on Smogon is resolved.

A short preview of what it looks like right now: https://www.youtube.com/watch?v=eR8iMg8QaAs