### PR TITLE
Gen 1 UU: Ban Agility + Partial Trapping

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3783,7 +3783,7 @@ export const Formats: FormatList = [
 
 		mod: 'gen1',
 		searchShow: false,
-		ruleset: ['[Gen 1] OU', 'Agility + Partial Trapping Clause'],
+		ruleset: ['[Gen 1] OU', 'APT Clause'],
 		banlist: ['OU', 'UUBL'],
 	},
 	{

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3783,7 +3783,7 @@ export const Formats: FormatList = [
 
 		mod: 'gen1',
 		searchShow: false,
-		ruleset: ['[Gen 1] OU'],
+		ruleset: ['[Gen 1] OU', 'Agility + Partial Trapping Clause'],
 		banlist: ['OU', 'UUBL'],
 	},
 	{

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1585,7 +1585,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 		desc: "Prevents Pok\u00e9mon from having moves that would only be obtainable in Pok\u00e9mon Crystal.",
 		// Implemented in mods/gen2/rulesets.ts
 	},
-	aptclause: {
+	agilitypartialtrappingclause: {
 		effectType: 'ValidatorRule',
 		name: 'Agility + Partial Trapping Clause',
 		desc: "Bans the combination of Agility and partial trapping moves like Wrap.",

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1585,6 +1585,12 @@ export const Rulesets: {[k: string]: FormatData} = {
 		desc: "Prevents Pok\u00e9mon from having moves that would only be obtainable in Pok\u00e9mon Crystal.",
 		// Implemented in mods/gen2/rulesets.ts
 	},
+	aptclause: {
+		effectType: 'ValidatorRule',
+		name: 'Agility + Partial Trapping Clause',
+		desc: "Bans the combination of Agility and partial trapping moves like Wrap.",
+		banlist: ['Agility + Wrap', 'Agility + Fire Spin', 'Agility + Bind', 'Agility + Clamp'],
+	},
 	nintendocup1997movelegality: {
 		effectType: 'ValidatorRule',
 		name: "Nintendo Cup 1997 Move Legality",

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1585,9 +1585,9 @@ export const Rulesets: {[k: string]: FormatData} = {
 		desc: "Prevents Pok\u00e9mon from having moves that would only be obtainable in Pok\u00e9mon Crystal.",
 		// Implemented in mods/gen2/rulesets.ts
 	},
-	agilitypartialtrappingclause: {
+	aptclause: {
 		effectType: 'ValidatorRule',
-		name: 'Agility + Partial Trapping Clause',
+		name: 'APT Clause',
 		desc: "Bans the combination of Agility and partial trapping moves like Wrap.",
 		banlist: ['Agility + Wrap', 'Agility + Fire Spin', 'Agility + Bind', 'Agility + Clamp'],
 	},


### PR DESCRIPTION
https://www.smogon.com/forums/threads/rby-uu-agility-partial-trapping-apt-voting.3703325/page-2#post-9249504

This is going to affect a tournament coming up within the next few days!

I added a rule to rulesets.ts under the assumption this ban may be repeated in other lower tiers. I've seen some groans about it in NU. Technically, only Wrap and Fire Spin are possible alongside Agility; even with Tradebacks, the only new user of this combination is Arcanine with Fire Spin. However, in the spirit of the ban and potential use in something like STABmons room tours, I slapped Bind and Clamp in there as well. Inefficient, but we may as well future-proof.

If the clause name is too long, "APT Clause" is possible, which I think would be understandable at its core. Not sure if I did that right...neither with the position or var name. Regardless, here we are!

Thank you for your time!