### PR TITLE
Gen 1: Fix flinch interaction & Mist

### DIFF
--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -164,6 +164,9 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 	flinch: {
 		name: 'flinch',
 		duration: 1,
+		onStart(target) {
+			target.removeVolatile('mustrecharge'); //This should let a recharger move if the flinch move goes second.
+		},
 		onBeforeMovePriority: 4,
 		onBeforeMove(pokemon) {
 			if (!this.runEvent('Flinch', pokemon)) {

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -165,7 +165,7 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 		name: 'flinch',
 		duration: 1,
 		onStart(target) {
-			target.removeVolatile('mustrecharge'); //This should let a recharger move if the flinch move goes second.
+			target.removeVolatile('mustrecharge'); // This should let a recharger move if the flinch move goes second.
 		},
 		onBeforeMovePriority: 4,
 		onBeforeMove(pokemon) {

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -165,7 +165,7 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 		name: 'flinch',
 		duration: 1,
 		onStart(target) {
-			target.removeVolatile('mustrecharge'); // This should let a recharger move if the flinch move goes second.
+			target.removeVolatile('mustrecharge');
 		},
 		onBeforeMovePriority: 4,
 		onBeforeMove(pokemon) {

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -538,15 +538,12 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onBoost(boost, target, source, effect) {
 				if (effect.effectType === 'Move' && effect.category !== 'Status') return;
 				if (source && target !== source) {
-					let showMsg = false;
 					let i: BoostID;
 					for (i in boost) {
 						if (boost[i]! < 0) {
 							delete boost[i];
-							showMsg = true;
 						}
 					}
-					if (showMsg) this.add('-activate', target, 'move: Mist');
 				}
 			},
 		},

--- a/data/mods/gen1stadium/conditions.ts
+++ b/data/mods/gen1stadium/conditions.ts
@@ -117,4 +117,17 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 			this.add('-end', pokemon, this.effectState.sourceEffect, '[partiallytrapped]');
 		},
 	},
+	flinch: {
+		name: 'flinch',
+		duration: 1,
+		onStart(target) {}, //preventing the interaction in gen1/conditions.ts
+		onBeforeMovePriority: 4,
+		onBeforeMove(pokemon) {
+			if (!this.runEvent('Flinch', pokemon)) {
+				return;
+			}
+			this.add('cant', pokemon, 'flinch');
+			return false;
+		},
+	},
 };

--- a/data/mods/gen1stadium/conditions.ts
+++ b/data/mods/gen1stadium/conditions.ts
@@ -120,7 +120,7 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 	flinch: {
 		name: 'flinch',
 		duration: 1,
-		onStart(target) {}, //preventing the interaction in gen1/conditions.ts
+		onStart(target) {}, // preventing the interaction in gen1/conditions.ts
 		onBeforeMovePriority: 4,
 		onBeforeMove(pokemon) {
 			if (!this.runEvent('Flinch', pokemon)) {

--- a/data/mods/gen1stadium/conditions.ts
+++ b/data/mods/gen1stadium/conditions.ts
@@ -98,6 +98,10 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 			this.effectState.time = this.random(2, 6);
 		},
 	},
+	flinch: {
+		inherit: true,
+		onStart() {},
+	},
 	partiallytrapped: {
 		name: 'partiallytrapped',
 		duration: 2,
@@ -115,19 +119,6 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 		},
 		onEnd(pokemon) {
 			this.add('-end', pokemon, this.effectState.sourceEffect, '[partiallytrapped]');
-		},
-	},
-	flinch: {
-		name: 'flinch',
-		duration: 1,
-		onStart(target) {}, // preventing the interaction in gen1/conditions.ts
-		onBeforeMovePriority: 4,
-		onBeforeMove(pokemon) {
-			if (!this.runEvent('Flinch', pokemon)) {
-				return;
-			}
-			this.add('cant', pokemon, 'flinch');
-			return false;
 		},
 	},
 };


### PR DESCRIPTION
This resolves two bugs reported here;
https://www.smogon.com/forums/threads/rby-tradebacks-bug-report-thread.3524844/post-8616259
https://www.smogon.com/forums/threads/rby-tradebacks-bug-report-thread.3524844/page-17#post-9252475

If a Pokemon flinches after using Hyper Beam, it should be able to move as normal thereafter. This is a mechanic seen in the disassembly as Enigami points out in the link above. Now, implementing this with the client removing the "mustrecharge" tag would be bad, but luckily, it seems my implementation method keeps it up on the client end, preventing a potential info leak. I've added an empty command in gen1stadium to prevent this from being inherited there, as from what I can tell it doesn't happen. Let me know if that's wrong.
![unknown](https://user-images.githubusercontent.com/36418502/174883913-47f695f2-ca39-4701-825d-ecf2685d509a.png)
This mechanic should rarely come up in a real match. Still got a ways to go with implementing this move correctly, eg. Wrap miss interactions.

Also, here's the mechanic happening on cartridge at a legit irl competitive scene: https://twitter.com/Gold_PBS/status/1248637943326994432

--

For some reason, Mist has status move failure messages show up twice. I removed the weird code that made it do that; from what I can see, it's already covered by the sim itself. It seemed to be making things way, way, way more complicated than they needed to be.

I've attached a ZIP containing two replays showing the mechanics working on my localhost server.
[test replays.zip](https://github.com/smogon/pokemon-showdown/files/8952292/test.replays.zip)

Thank you for your time!