### PR TITLE
Gen 1: Fix sleep cure priority

### DIFF
--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -78,6 +78,7 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 			pokemon.lastMove = null;
 			return false;
 		},
+		onAfterMoveSelfPriority: 3,
 		onAfterMoveSelf(pokemon) {
 			if (pokemon.statusState.time <= 0) pokemon.cureStatus();
 		},


### PR DESCRIPTION
sleep checking occurs before burn, poison, and leech seed in game, and the former two are 2 priority where the latter is 1