### PR TITLE
Gen 1: 2022 OU tier shift

### DIFF
--- a/data/mods/gen1/formats-data.ts
+++ b/data/mods/gen1/formats-data.ts
@@ -370,7 +370,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		randomBattleMoves: ["bodyslam", "sleeppowder", "stunspore"],
 		essentialMove: "razorleaf",
 		comboMoves: ["hyperbeam", "swordsdance"],
-		tier: "(OU)",
+		tier: "UU",
 	},
 	tentacool: {
 		randomBattleMoves: ["barrier", "hydropump", "surf"],
@@ -414,7 +414,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	slowbro: {
 		randomBattleMoves: ["amnesia", "surf", "thunderwave"],
 		exclusiveMoves: ["blizzard", "psychic", "rest", "rest"],
-		tier: "OU",
+		tier: "UUBL",
 	},
 	magnemite: {
 		randomBattleMoves: ["thunder", "thunderbolt", "thunderwave"],
@@ -667,7 +667,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		randomBattleMoves: ["bodyslam", "confuseray", "rest", "sing", "surf"],
 		essentialMove: "blizzard",
 		exclusiveMoves: ["thunderbolt", "thunderbolt"],
-		tier: "(OU)",
+		tier: "UUBL",
 	},
 	ditto: {
 		randomBattleMoves: ["transform"],

--- a/data/mods/gen1/random-teams.ts
+++ b/data/mods/gen1/random-teams.ts
@@ -348,7 +348,7 @@ export class RandomGen1Teams extends RandomGen2Teams {
 			NU: 77,
 			NUBL: 76,
 			UU: 74,
-			'(OU)': 71,
+			UUBL: 71,
 			OU: 68,
 			Uber: 65,
 		};


### PR DESCRIPTION
TLDR; Victreebel UU, Slowbro/Lapras UUBL
This is important for the upcoming UU Open and UU Snake Draft! 

https://www.smogon.com/forums/threads/rby-ou-viability-rankings.3685861/page-5#post-9254185
The new 2022 RBY OU VR was just released, and some tier shifts have occurred;
- Lapras and Victreebel are dropping to UU properly now. 
- Slowbro is...being Slowbro.

Slowbro is in its own rank on the VR, but it's juuust slim enough for it to drop to UU, according to phoopes and vapicuno, at least by the quantitative metrics we're using. There's a deep-seated tradition of "The Slowbro Standard" but it's finally crumbled. 

**However, the RBY UU Council has quickbanned Lapras and Slowbro** because, well, yeah...they're very meta-warping, so on, blah blah. Victreebel lives though! There'll be a post on this soon, I'm just making this now so it all goes smoothly. 

Given the OU by Technicality stuff, I've simply changed it to UUBL for Gen 1 Random Battles, it functionally doesn't change Lapras but does buff Slowbro. 

I don't know how the teambuilder processes new tiers, I remember having to flick a switch or something for (OU) and NUBL to show up in the past. I think it was on the client? Is someone able to check on that for me? 

Thank you for your time! 