### PR TITLE
Gen 1: Fix Tamamushi Magikarp details

### DIFF
--- a/data/mods/gen2/learnsets.ts
+++ b/data/mods/gen2/learnsets.ts
@@ -7593,7 +7593,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			dragonrage: ["1S0"],
 			flail: ["2L30"],
 			reversal: ["2S2"],
-			splash: ["2L1", "2S2", "2S1", "1L1"],
+			splash: ["2L1", "2S2", "2S1", "1L1", "1S0"],
 			tackle: ["2L15", "1L15"],
 		},
 		eventData: [

--- a/data/mods/gen2/learnsets.ts
+++ b/data/mods/gen2/learnsets.ts
@@ -7597,7 +7597,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			tackle: ["2L15", "1L15"],
 		},
 		eventData: [
-			{generation: 1, level: 5, moves: ["dragonrage"], japan: true},
+			{generation: 1, level: 15, moves: ["splash", "dragonrage"], japan: true},
 			{generation: 2, level: 5, shiny: 1, moves: ["splash", "bubble"]},
 			{generation: 2, level: 5, shiny: 1, moves: ["splash", "reversal"]},
 		],


### PR DESCRIPTION
Didn't think my weird rabbit hole would bring me here. ANYWAY!

So for starters, here's the source of the information: 
https://projectpokemon.org/home/forums/topic/41541-information-about-japanese-pm1-pm2-event-pok%C3%A9mon/?do=findComment&comment=258412
I would frankly trust this person with my life, they've done a lot for documenting Gen 1 events in the past. 

Because it's level 15, it can't have Tackle without a move relearner. It seems that this Magikarp is designed to have Dragon Rage be incompatible with Tackle, being "stronger than normal", so to speak. This makes sense, it lines up with the way the anime describes it among other things. 

Another incredibly minor fix that will only impact the memesters who want to use joke Pokemon in a very obscure format!