### PR TITLE
Add Jump! Magikarp format

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -460,6 +460,7 @@ export const Formats: FormatList = [
 		],
 
 		mod: 'gen8',
+		gameType: 'doubles',
 		ruleset: ['Flat Rules', '!! Picked Team Size = 2', '!! Adjust Level = 50', 'Min Source Gen = 8'],
 		banlist: ['Sub-Legendary'],
 		onValidateTeam(team) {
@@ -475,6 +476,7 @@ export const Formats: FormatList = [
 				return [`Your team must contain Magikarp.`];
 			}
 		},
+		// Bringing 1 Magikarp during Team Preview hardcoded in sim/side.ts#chooseTeam
 	},
 	{
 		name: "[Gen 8] Doubles Custom Game",

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -290,15 +290,6 @@ export const Formats: FormatList = [
 		restricted: ['Restricted Legendary'],
 	},
 	{
-		name: "[Gen 8] Single Battle Cup",
-		threads: [
-			`&bullet; <a href="https://www.pokemon.com/us/pokemon-news/register-now-for-the-single-battle-cup-competition/">Single Battle Cup</a>`,
-		],
-
-		mod: 'gen8',
-		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 8'],
-	},
-	{
 		name: "[Gen 8] Custom Game",
 
 		mod: 'gen8',
@@ -458,6 +449,29 @@ export const Formats: FormatList = [
 			}
 			if (set.moves.length !== 1 || this.dex.moves.get(set.moves[0]).id !== 'metronome') {
 				return [`${set.name || set.species} has illegal moves.`, `(Pok\u00e9mon can only have one Metronome in their moveset)`];
+			}
+		},
+	},
+	{
+		name: "[Gen 8] Jump! Magikarp",
+		threads: [
+			`&bullet; <a href="https://www.smogon.com/forums/threads/3704588/">Jump! Magikarp</a>`,
+		],
+
+		mod: 'gen8',
+		ruleset: ['Flat Rules', '!! Picked Team Size = 2', '!! Adjust Level = 50', 'Min Source Gen = 8'],
+		banlist: ['Sub-Legendary'],
+		onValidateTeam(team) {
+			let hasMagikarp = false;
+			for (const set of team) {
+				let species = this.dex.species.get(set.species);
+				if (species.name === 'Magikarp') {
+					hasMagikarp = true;
+					break;
+				}
+			}
+			if (!hasMagikarp) {
+				return [`Your team must contain Magikarp.`];
 			}
 		},
 	},

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -454,6 +454,7 @@ export const Formats: FormatList = [
 	},
 	{
 		name: "[Gen 8] Jump! Magikarp",
+		desc: `Every team must contain Magikarp and bring it to the game.`,
 		threads: [
 			`&bullet; <a href="https://www.smogon.com/forums/threads/3704588/">Jump! Magikarp</a>`,
 		],

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -464,7 +464,7 @@ export const Formats: FormatList = [
 		onValidateTeam(team) {
 			let hasMagikarp = false;
 			for (const set of team) {
-				let species = this.dex.species.get(set.species);
+				const species = this.dex.species.get(set.species);
 				if (species.name === 'Magikarp') {
 					hasMagikarp = true;
 					break;

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -453,10 +453,10 @@ export const Formats: FormatList = [
 		},
 	},
 	{
-		name: "[Gen 8] Jump! Magikarp",
+		name: "[Gen 8] Jump! Magikarp!",
 		desc: `Every team must contain Magikarp and bring it to the game.`,
 		threads: [
-			`&bullet; <a href="https://www.smogon.com/forums/threads/3704588/">Jump! Magikarp</a>`,
+			`&bullet; <a href="https://www.smogon.com/forums/threads/3704588/">Jump! Magikarp!</a>`,
 		],
 
 		mod: 'gen8',

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -784,6 +784,18 @@ export class Side {
 				}
 			}
 		}
+		if (this.battle.format.id === 'gen8jumpmagikarp') {
+			let hasMagikarp = false;
+			for (const pos of positions) {
+				if (this.pokemon[pos].species.name === 'Magikarp') {
+					hasMagikarp = true;
+					break;
+				}
+			}
+			if (!hasMagikarp) {
+				return this.emitChoiceError(`You must bring Magikarp to the battle.`);
+			}
+		}
 		for (const [index, pos] of positions.entries()) {
 			this.choice.switchIns.add(pos);
 			this.choice.actions.push({


### PR DESCRIPTION
https://www.smogon.com/forums/threads/jump-magikarp.3704588/

This isn't complete, because we don't really have a way of enforcing "you must bring Magikarp" - or any "you must bring [Pokemon]" logic at all. I think we should just use standard PS timer and ignore the complications of implementing the VGC timeout logic at Team Preview with this, but that still doesn't solve the issue with forcing a player to bring Magikarp. I'm not even sure where to put the hardcode if we want to go that route.