### PR TITLE
Gen 1: Fix RBY & Stadium Substitute @ 25%

### DIFF
--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -759,7 +759,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			}
 			// We only prevent when hp is less than one quarter.
 			// If you use substitute at exactly one quarter, you faint.
-			if (target.hp === target.maxhp / 4) target.faint();
 			if (target.hp < target.maxhp / 4) {
 				this.add('-fail', target, 'move: Substitute', '[weak]');
 				return null;

--- a/data/mods/gen1stadium/moves.ts
+++ b/data/mods/gen1stadium/moves.ts
@@ -134,6 +134,17 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	substitute: {
 		inherit: true,
+		onTryHit(target) {
+			if (target.volatiles['substitute']) {
+				this.add('-fail', target, 'move: Substitute');
+				return null;
+			}
+			// Stadium fixes the 25% = you die gag
+			if (target.hp <= target.maxhp / 4) {
+				this.add('-fail', target, 'move: Substitute', '[weak]');
+				return null;
+			}
+		},
 		condition: {
 			onStart(target) {
 				this.add('-start', target, 'Substitute');


### PR DESCRIPTION
This resolves one of the bug reports from years ago [here](https://www.smogon.com/forums/threads/stadium-bug-report-thread.3526616/#post-6144617).

In RBY, when you're at exactly 25% HP and use Substitute, your Pokemon faints. This is implemented, but [in a very strange way](https://replay.pokemonshowdown.com/gen1stadiumou-1616377078) that causes the Pokemon to faint before the Substitute is put in. I found this by accident while testing and realised it was due to a (presumably) unnecessary check, so I removed it, as the second line would faint the user in a much funnier fashion anyway. 

Here's the code working, using only the second line and thus having the Substitute animate, which from what I know is accurate to the cartridge in the first place;
[Gen1OU-2022-07-13-karmatest-may.zip](https://github.com/smogon/pokemon-showdown/files/9102466/Gen1OU-2022-07-13-karmatest-may.zip)

Also, the entire "faint at 25%" gag is fixed in Stadium, which was the main reason I came out to fix it. This just copypastes the Gen1 code, adds a <= sign, and removes the strange faulty check from before. 

Here's that code working;
[Gen1StadiumOU-2022-07-13-may-karmatest.zip](https://github.com/smogon/pokemon-showdown/files/9102457/Gen1StadiumOU-2022-07-13-may-karmatest.zip)

