### PR TITLE
Gen 1: Add Nintendo Cup 1999

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3877,7 +3877,7 @@ export const Formats: FormatList = [
         mod: 'gen1stadium', 
 		searchShow: false,
         ruleset: ['Adjust Level Down = 50', 'Picked Team Size = 3', 
-				'Obtainable', 'Team Preview', 'Stadium Sleep Clause', 'Freeze Clause Mod', 'Species Clause', 'Exact HP Mod', 'Cancel Mod', 'Nintendo Cup 1999 Move Legality'],
+				'Obtainable', 'Team Preview', 'Stadium Sleep Clause', 'Freeze Clause Mod', 'Species Clause', 'Exact HP Mod', 'Cancel Mod'],
         banlist: ['Venusaur', 'Dugtrio', 'Alakazam', 'Golem', 'Magneton', 'Gengar', 'Hypno', 'Electrode', 'Exeggutor', 'Chansey', 'Kangaskhan', 'Starmie', 'Jynx', 'Tauros', 'Gyarados', 'Lapras', 'Ditto', 'Vaporeon', 'Jolteon', 'Snorlax', 'Articuno', 'Zapdos', 'Dragonite', 'Mewtwo', 'Mew', 'Flareon + Focus Energy + Ember', 'Nidoking + Fury Attack + Thrash'],
     },
 	{

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3877,7 +3877,7 @@ export const Formats: FormatList = [
         mod: 'gen1stadium', 
 		searchShow: false,
         ruleset: ['Adjust Level Down = 50', 'Picked Team Size = 3', 
-				'Obtainable', 'Team Preview', 'Stadium Sleep Clause', 'Freeze Clause Mod', 'Species Clause', 'Exact HP Mod', 'Cancel Mod'],
+				'Obtainable', 'Team Preview', 'Stadium Sleep Clause', 'Freeze Clause Mod', 'Species Clause', 'Exact HP Mod', 'Cancel Mod', 'Nintendo Cup 1999 Move Legality'],
         banlist: ['Venusaur', 'Dugtrio', 'Alakazam', 'Golem', 'Magneton', 'Gengar', 'Hypno', 'Electrode', 'Exeggutor', 'Chansey', 'Kangaskhan', 'Starmie', 'Jynx', 'Tauros', 'Gyarados', 'Lapras', 'Ditto', 'Vaporeon', 'Jolteon', 'Snorlax', 'Articuno', 'Zapdos', 'Dragonite', 'Mewtwo', 'Mew', 'Flareon + Focus Energy + Ember', 'Nidoking + Fury Attack + Thrash'],
     },
 	{

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3867,18 +3867,20 @@ export const Formats: FormatList = [
 		banlist: ['Uber'],
 	},
 	{
-        name: "[Gen 1] Nintendo Cup 1999",
+		name: "[Gen 1] Nintendo Cup 1999",
 		desc: `The Nintendo Cup that banned Pokemon used at the 1997 at Spaceworld 1997, played on Stadium.`,
 		
 		threads: [
 			`&bullet; <a href="https://www.smogon.com/forums/threads/stadium-cup-format-megathread.3695448/post-9066167">Stadium Cup Format Megathread</a>`,
 		],
 		
-        mod: 'gen1stadium', 
+		mod: 'gen1stadium', 
 		searchShow: false,
-        ruleset: ['Adjust Level Down = 50', 'Picked Team Size = 3', 
+		ruleset: ['Adjust Level Down = 50', 'Picked Team Size = 3', 
 				'Obtainable', 'Team Preview', 'Stadium Sleep Clause', 'Freeze Clause Mod', 'Species Clause', 'Exact HP Mod', 'Cancel Mod'],
-        banlist: ['Venusaur', 'Dugtrio', 'Alakazam', 'Golem', 'Magneton', 'Gengar', 'Hypno', 'Electrode', 'Exeggutor', 'Chansey', 'Kangaskhan', 'Starmie', 'Jynx', 'Tauros', 'Gyarados', 'Lapras', 'Ditto', 'Vaporeon', 'Jolteon', 'Snorlax', 'Articuno', 'Zapdos', 'Dragonite', 'Mewtwo', 'Mew', 'Flareon + Focus Energy + Ember', 'Nidoking + Fury Attack + Thrash'],
+		banlist: ['Venusaur', 'Dugtrio', 'Alakazam', 'Golem', 'Magneton', 'Gengar', 'Hypno', 'Electrode', 'Exeggutor', 'Chansey', 'Kangaskhan', 'Starmie', 
+		'Jynx', 'Tauros', 'Gyarados', 'Lapras', 'Ditto', 'Vaporeon', 'Jolteon', 'Snorlax', 'Articuno', 'Zapdos', 'Dragonite', 'Mewtwo', 'Mew', 
+		'Flareon + Focus Energy + Ember', 'Nidoking + Fury Attack + Thrash'],
     },
 	{
 		name: "[Gen 1] Nintendo Cup 1997",

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1929,7 +1929,7 @@ export const Formats: FormatList = [
 			const TeamValidator: typeof import('../sim/team-validator').TeamValidator =
 				require('../sim/team-validator').TeamValidator;
 
-			const validator = new TeamValidator(dex.formats.get(`${this.format.id}@@@${customRules.join(',')}`));
+			const validator = new TeamValidator(dex.formats.get(`${this.format.id}@@@${customRules.join(', ')}`));
 			const moves = set.moves;
 			set.moves = [ability.id];
 			set.ability = dex.species.get(set.species).abilities['0'];
@@ -3866,6 +3866,20 @@ export const Formats: FormatList = [
 		ruleset: ['Standard'],
 		banlist: ['Uber'],
 	},
+	{
+        name: "[Gen 1] Nintendo Cup 1999",
+		desc: `The Nintendo Cup that banned Pokemon used at the 1997 at Spaceworld 1997, played on Stadium.`,
+		
+		threads: [
+			`&bullet; <a href="https://www.smogon.com/forums/threads/stadium-cup-format-megathread.3695448/post-9066167">Stadium Cup Format Megathread</a>`,
+		],
+		
+        mod: 'gen1stadium', 
+		searchShow: false,
+        ruleset: ['Adjust Level Down = 50', 'Picked Team Size = 3', 
+				'Obtainable', 'Team Preview', 'Stadium Sleep Clause', 'Freeze Clause Mod', 'Species Clause', 'Exact HP Mod', 'Cancel Mod'],
+        banlist: ['Venusaur', 'Dugtrio', 'Alakazam', 'Golem', 'Magneton', 'Gengar', 'Hypno', 'Electrode', 'Exeggutor', 'Chansey', 'Kangaskhan', 'Starmie', 'Jynx', 'Tauros', 'Gyarados', 'Lapras', 'Ditto', 'Vaporeon', 'Jolteon', 'Snorlax', 'Articuno', 'Zapdos', 'Dragonite', 'Mewtwo', 'Mew', 'Flareon + Focus Energy + Ember', 'Nidoking + Fury Attack + Thrash'],
+    },
 	{
 		name: "[Gen 1] Nintendo Cup 1997",
 		threads: [

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1929,7 +1929,7 @@ export const Formats: FormatList = [
 			const TeamValidator: typeof import('../sim/team-validator').TeamValidator =
 				require('../sim/team-validator').TeamValidator;
 
-			const validator = new TeamValidator(dex.formats.get(`${this.format.id}@@@${customRules.join(', ')}`));
+			const validator = new TeamValidator(dex.formats.get(`${this.format.id}@@@${customRules.join(',')}`));
 			const moves = set.moves;
 			set.moves = [ability.id];
 			set.ability = dex.species.get(set.species).abilities['0'];

--- a/data/mods/gen1stadium/rulesets.ts
+++ b/data/mods/gen1stadium/rulesets.ts
@@ -4,4 +4,15 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 		name: 'Standard',
 		ruleset: ['Obtainable', 'Stadium Sleep Clause', 'Freeze Clause Mod', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Exact HP Mod', 'Cancel Mod'],
 	},
+	nintendocup1999movelegality: {
+		effectType: 'ValidatorRule',
+		name: 'Nintendo Cup 1999 Move Legality',
+		onValidateTeam(team) {
+			for (const set of team) {
+				if (eventData.japan) {
+					if (fastReturn) return true;
+				},
+			},
+		},
+	},
 };

--- a/data/mods/gen1stadium/rulesets.ts
+++ b/data/mods/gen1stadium/rulesets.ts
@@ -4,15 +4,4 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 		name: 'Standard',
 		ruleset: ['Obtainable', 'Stadium Sleep Clause', 'Freeze Clause Mod', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Exact HP Mod', 'Cancel Mod'],
 	},
-	nintendocup1999movelegality: {
-		effectType: 'ValidatorRule',
-		name: 'Nintendo Cup 1999 Move Legality',
-		onValidateTeam(team) {
-			for (const set of team) {
-				if (eventData.japan) {
-					if (fastReturn) return true;
-				},
-			},
-		},
-	},
 };

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1653,6 +1653,7 @@ export class TeamValidator {
 	 */
 	validateEvent(set: PokemonSet, eventData: EventInfo, eventSpecies: Species, because = ``, from = `from an event`) {
 		const dex = this.dex;
+		const ruleTable = this.ruleTable;
 		let name = set.species;
 		const species = dex.species.get(set.species);
 		const maxSourceGen = this.ruleTable.has('allowtradeback') ? Utils.clampIntRange(dex.gen + 1, 1, 8) : dex.gen;
@@ -1664,7 +1665,8 @@ export class TeamValidator {
 		const etc = `${because} ${from}`;
 
 		const problems = [];
-
+		
+		
 		if (dex.gen < 8 && this.minSourceGen > eventData.generation) {
 			if (fastReturn) return true;
 			problems.push(`This format requires Pokemon from gen ${this.minSourceGen} or later and ${name} is from gen ${eventData.generation}${etc}.`);
@@ -1673,12 +1675,10 @@ export class TeamValidator {
 			if (fastReturn) return true;
 			problems.push(`This format is in gen ${dex.gen} and ${name} is from gen ${eventData.generation}${etc}.`);
 		}
-
-		if (eventData.japan && dex.currentMod !== 'gen1jpn') {
+		if (eventData.japan && dex.currentMod !== 'gen1jpn' || !this.format.id.startsWith('nintendocup')) {
 			if (fastReturn) return true;
 			problems.push(`${name} has moves from Japan-only events, but this format simulates International Yellow/Crystal which can't trade with Japanese games.`);
 		}
-
 		if (eventData.level && (set.level || 0) < eventData.level) {
 			if (fastReturn) return true;
 			problems.push(`${name} must be at least level ${eventData.level}${etc}.`);
@@ -1753,7 +1753,6 @@ export class TeamValidator {
 			}
 		}
 		// Event-related ability restrictions only matter if we care about illegal abilities
-		const ruleTable = this.ruleTable;
 		if (ruleTable.has('obtainableabilities')) {
 			if (dex.gen <= 5 && eventData.abilities && eventData.abilities.length === 1 && !eventData.isHidden) {
 				if (species.name === eventSpecies.name) {


### PR DESCRIPTION
Annika said I could do this so uh here I am! NC99 is basically the first UU tier to ever exist and has some incredibly interesting history, it's pretty neat. 

This is being done with the presumption that #8822 will go through with Nintendo Cup 1998, essentially completing the "quadrilogy" of the original BSS formats. Given the Stadium mod is way, way, way more accurate than it used to be, with some ancient (and some egregious) bugs being fixed, it makes sense from this perspective as well.

It's a draft because I have zero clue why my validator code isn't working and am praying that someone knows why. Also, it'll create a merge conflict with the NC98 mod because I cannot future-proof to save my life :3