### PR TITLE
Fix Jumpluff EVs

### DIFF
--- a/data/mods/gen7/factory-sets.json
+++ b/data/mods/gen7/factory-sets.json
@@ -6884,7 +6884,7 @@
 				"species": "Jumpluff",
 				"item": [""],
 				"ability": ["Infiltrator"],
-				"evs": {"atk": 252, "def": 4, "spd": 252},
+				"evs": {"atk": 252, "def": 4, "spe": 252},
 				"nature": "Jolly",
 				"moves": [["U-turn", "Swords Dance"], ["Acrobatics"], ["Sleep Powder"], ["Strength Sap"]]
 			}]


### PR DESCRIPTION
Jumpluff has 252 spdef EVs that should be speed. https://www.smogon.com/dex/sm/pokemon/jumpluff/

- Wigglytuff