### PR TITLE
Replace BDSP PH with Sw/Sh PH

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1269,17 +1269,6 @@ export const Formats: FormatList = [
 		ruleset: ['Flat Rules', 'Min Source Gen = 8'],
 	},
 	{
-		name: "[Gen 8 BDSP] Pure Hackmons",
-		desc: `Anything that can be hacked in-game and is usable in local battles is allowed.`,
-		threads: [
-			`&bullet; <a href="https://www.smogon.com/forums/threads/3693868/">Pure Hackmons</a>`,
-		],
-
-		mod: 'gen8bdsp',
-		searchShow: false,
-		ruleset: ['-Nonexistent', 'Team Preview', 'HP Percentage Mod', 'Cancel Mod', 'Endless Battle Clause'],
-	},
-	{
 		section: "Challengeable OMs",
 		column: 2,
 	},
@@ -1788,6 +1777,17 @@ export const Formats: FormatList = [
 			}
 			pokemon.m.innates = undefined;
 		},
+	},
+	{
+		name: "[Gen 8] Pure Hackmons",
+		desc: `Anything that can be hacked in-game and is usable in local battles is allowed.`,
+		threads: [
+			`&bullet; <a href="https://www.smogon.com/forums/threads/3656851/">Pure Hackmons</a>`,
+		],
+
+		mod: 'gen8',
+		searchShow: false,
+		ruleset: ['-Nonexistent', 'Team Preview', 'HP Percentage Mod', 'Cancel Mod', 'Endless Battle Clause'],
 	},
 	{
 		name: "[Gen 8] Shared Power",


### PR DESCRIPTION
After a recent definition change, BDSP PH is being replaced with Sw/Sh PH. This commit is to remove BDSP PH from the challengeable list and replace it with Sw/Sh PH. Announcement can be found here: https://www.smogon.com/forums/threads/pure-hackmons.3656851/post-9279060