### PR TITLE
Gen 7 Battle Factory: Remove Quagsire from UU

### DIFF
--- a/data/mods/gen7/factory-sets.json
+++ b/data/mods/gen7/factory-sets.json
@@ -3894,17 +3894,6 @@
 				"moves": [["Stealth Rock"], ["Earthquake"], ["Gyro Ball"], ["Curse"]]
 			}]
 		},
-		"quagsire": {
-			"flags": {},
-			"sets": [{
-				"species": "Quagsire",
-				"item": ["Leftovers"],
-				"ability": ["Unaware"],
-				"evs": {"hp": 252, "def": 252, "spd": 4},
-				"nature": "Relaxed",
-				"moves": [["Scald"], ["Earthquake"], ["Recover"], ["Toxic"]]
-			}]
-		},
 		"volcanion": {
 			"flags": {},
 			"sets": [{


### PR DESCRIPTION
Quagsire remains banned after an initial ban and subsequent retest (https://www.smogon.com/forums/threads/sm-uu-quagsire-revote.3702984/page-2). It should stay banned for the foreseeable future so I'm removing it from the UU tier of BF.

\- Wigglytuff