### PR TITLE
VGC/BSS: Add Series 13 support

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -291,6 +291,13 @@ export const Formats: FormatList = [
 		restricted: ['Restricted Legendary'],
 	},
 	{
+		name: "[Gen 8] Battle Stadium Singles Series 13",
+
+		mod: 'gen8',
+		searchShow: false,
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 8', '+Mythical'],
+	},
+	{
 		name: "[Gen 8] I Choose 'Chu!",
 		threads: [
 			`&bullet; <a href="https://www.smogon.com/forums/threads/3705481/">I Choose 'Chu! Discussion</a>`,
@@ -385,6 +392,14 @@ export const Formats: FormatList = [
 		gameType: 'doubles',
 		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 8', 'VGC Timer', 'Limit Two Restricted'],
 		restricted: ['Restricted Legendary'],
+	},
+	{
+		name: "[Gen 8] VGC 2022 Series 13",
+
+		mod: 'gen8',
+		gameType: 'doubles',
+		searchShow: false,
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 8', 'VGC Timer', '+Mythical'],
 	},
 	{
 		name: "[Gen 8] VGC 2021",

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -296,6 +296,7 @@ export const Formats: FormatList = [
 		mod: 'gen8',
 		searchShow: false,
 		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 8'],
+		banlist: ['Eternatus-Eternamax'],
 		unbanlist: ['Mythical', 'Restricted Legendary'],
 	},
 	{
@@ -401,6 +402,7 @@ export const Formats: FormatList = [
 		gameType: 'doubles',
 		searchShow: false,
 		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 8', 'VGC Timer'],
+		banlist: ['Eternatus-Eternamax'],
 		unbanlist: ['Mythical', 'Restricted Legendary'],
 	},
 	{

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -400,7 +400,8 @@ export const Formats: FormatList = [
 		mod: 'gen8',
 		gameType: 'doubles',
 		searchShow: false,
-		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 8', 'VGC Timer', '+Mythical'],
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 8', 'VGC Timer'],
+		unbanlist: ['Mythical', 'Restricted Legendary'],
 	},
 	{
 		name: "[Gen 8] VGC 2021",

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -396,7 +396,7 @@ export const Formats: FormatList = [
 		restricted: ['Restricted Legendary'],
 	},
 	{
-		name: "[Gen 8] VGC 2022 Series 13",
+		name: "[Gen 8] Battle Stadium Doubles Series 13",
 
 		mod: 'gen8',
 		gameType: 'doubles',

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -295,7 +295,8 @@ export const Formats: FormatList = [
 
 		mod: 'gen8',
 		searchShow: false,
-		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 8', '+Mythical'],
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 8'],
+		unbanlist: ['Mythical', 'Restricted Legendary'],
 	},
 	{
 		name: "[Gen 8] I Choose 'Chu!",


### PR DESCRIPTION
The latest series allows all Pokemon from Sword/Shield, including Mythicals. There is no limit on how many "restricted" or "mythical" Pokemon you can bring.

Don't merge yet; currently debating the format name for VGC because:
- This would technically be the 2023 format for the circuit
- It assumes this actually will be what we play for VGC (we might continue with standard VGC 2022 [i.e. Series 12] for the rest of our in-person competition)