### PR TITLE
Scavengers: Fix startrecycled/queuerecycled index

### DIFF
--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -1378,7 +1378,7 @@ const ScavengerCommands: Chat.ChatCommands = {
 			if (questions) {
 				const huntNumber = parseInt(questions);
 				if (!ScavengerHuntDatabase.hasHunt(huntNumber)) return this.errorReply("You specified an invalid hunt number.");
-				hunt = scavengersData.recycledHunts[huntNumber];
+				hunt = scavengersData.recycledHunts[huntNumber - 1];
 			} else {
 				hunt = ScavengerHuntDatabase.getRecycledHuntFromDatabase();
 			}
@@ -1719,9 +1719,9 @@ const ScavengerCommands: Chat.ChatCommands = {
 
 			let next;
 			if (target) {
-				const huntNumber = parseInt(target) - 1;
+				const huntNumber = parseInt(target);
 				if (!ScavengerHuntDatabase.hasHunt(huntNumber)) return this.errorReply("You specified an invalid hunt number.");
-				next = scavengersData.recycledHunts[huntNumber];
+				next = scavengersData.recycledHunts[huntNumber - 1];
 			} else {
 				next = ScavengerHuntDatabase.getRecycledHuntFromDatabase();
 			}


### PR DESCRIPTION
Apparently the clamp was [1, N], not [0, N-1]