### PR TITLE
Gen 1 JPN: Japanese event move incompatibilities

### DIFF
--- a/data/mods/gen1jpn/rulesets.ts
+++ b/data/mods/gen1jpn/rulesets.ts
@@ -3,7 +3,7 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 		effectType: 'ValidatorRule',
 		name: 'Standard',
 		ruleset: ['Obtainable', 'Desync Clause Mod', 'Sleep Clause Mod', 'Freeze Clause Mod', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],
-		banlist: ['Dig', 'Fly', 'Rapidash + Pay Day + Growl', 'Rapidash + Pay Day + Tail Whip', 'Fearow + Pay Day + Peck', 'Fearow + Pay Day + Mirror Move', 'Magikarp + Dragon Rage + Tackle'],
+		banlist: ['Dig', 'Fly'],
 	},
 	nintendocup1997movelegality: {
 		effectType: 'ValidatorRule',

--- a/data/mods/gen1jpn/rulesets.ts
+++ b/data/mods/gen1jpn/rulesets.ts
@@ -1,9 +1,9 @@
 export const Rulesets: {[k: string]: ModdedFormatData} = {
-	standard: {
+	standard: { // Includes considerations for Japanese event incompatibilities
 		effectType: 'ValidatorRule',
 		name: 'Standard',
 		ruleset: ['Obtainable', 'Desync Clause Mod', 'Sleep Clause Mod', 'Freeze Clause Mod', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],
-		banlist: ['Dig', 'Fly'],
+		banlist: ['Dig', 'Fly', 'Rapidash + Pay Day + Growl', 'Rapidash + Pay Day + Tail Whip', 'Fearow + Pay Day + Peck', 'Fearow + Pay Day + Mirror Move', 'Magikarp + Dragon Rage + Tackle'],
 	},
 	nintendocup1997movelegality: {
 		effectType: 'ValidatorRule',

--- a/data/mods/gen1jpn/rulesets.ts
+++ b/data/mods/gen1jpn/rulesets.ts
@@ -1,5 +1,5 @@
 export const Rulesets: {[k: string]: ModdedFormatData} = {
-	standard: { // Includes considerations for Japanese event incompatibilities
+	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',
 		ruleset: ['Obtainable', 'Desync Clause Mod', 'Sleep Clause Mod', 'Freeze Clause Mod', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],

--- a/data/mods/gen2/rulesets.ts
+++ b/data/mods/gen2/rulesets.ts
@@ -14,6 +14,13 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 			'Vaporeon + Tackle + Growl',
 			'Jolteon + Tackle + Growl', 'Jolteon + Focus Energy + Thunder Shock',
 			'Flareon + Tackle + Growl', 'Flareon + Focus Energy + Ember',
+			
+			// https://github.com/smogon/pokemon-showdown/pull/8869
+			'Rapidash + Pay Day + Growl', 
+			'Rapidash + Pay Day + Tail Whip', 
+			'Fearow + Pay Day + Peck', 
+			'Fearow + Pay Day + Mirror Move', 
+			'Magikarp + Dragon Rage + Tackle'
 		],
 	},
 	standard: {

--- a/data/mods/gen2/rulesets.ts
+++ b/data/mods/gen2/rulesets.ts
@@ -14,13 +14,13 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 			'Vaporeon + Tackle + Growl',
 			'Jolteon + Tackle + Growl', 'Jolteon + Focus Energy + Thunder Shock',
 			'Flareon + Tackle + Growl', 'Flareon + Focus Energy + Ember',
-			
+
 			// https://github.com/smogon/pokemon-showdown/pull/8869
 			'Rapidash + Pay Day + Growl',
 			'Rapidash + Pay Day + Tail Whip',
 			'Fearow + Pay Day + Peck',
 			'Fearow + Pay Day + Mirror Move',
-			'Magikarp + Dragon Rage + Tackle'
+			'Magikarp + Dragon Rage + Tackle',
 		],
 	},
 	standard: {

--- a/data/mods/gen2/rulesets.ts
+++ b/data/mods/gen2/rulesets.ts
@@ -16,10 +16,10 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 			'Flareon + Tackle + Growl', 'Flareon + Focus Energy + Ember',
 			
 			// https://github.com/smogon/pokemon-showdown/pull/8869
-			'Rapidash + Pay Day + Growl', 
-			'Rapidash + Pay Day + Tail Whip', 
-			'Fearow + Pay Day + Peck', 
-			'Fearow + Pay Day + Mirror Move', 
+			'Rapidash + Pay Day + Growl',
+			'Rapidash + Pay Day + Tail Whip',
+			'Fearow + Pay Day + Peck',
+			'Fearow + Pay Day + Mirror Move',
 			'Magikarp + Dragon Rage + Tackle'
 		],
 	},


### PR DESCRIPTION
So I realised that #8821 missed out on actually making the combination of Tackle and Dragon Rage illegal on Magikarp, which was kind of the point of what I was doing, so that was pretty dumb. Anyway, I also looked into the [Fan Club Chairman stuff](https://bulbapedia.bulbagarden.net/wiki/List_of_Japanese_event_Pok%C3%A9mon_distributions_(Generation_I)#Pok.C3.A9mon_Stamp_Pok.C3.A9mon) and realised they have similar issues, so let's sort this out.

- Rapidash is given at L40 with the moveset of Ember, Fire Spin, Stomp, and Pay Day. This means Growl and Tail Whip are impossible.
- Fearow is given at L25 with the moveset of Growl, Leer, Fury Attack, and Pay Day. This means Mirror Move(!) and Peck are impossible.
- Magikarp is given at L15 with Splash and Dragon Rage, with Tackle purposefully removed and thus made impossible.

This is your textbook move incompatibility problem in RBY: caught at a higher level, no move reminder available, so earlier moves cannot be obtained. We know the movesets of each event - check gen2/learnsets.ts for that - so this implementation should be fairly straightforward. Like other incompatibilities brought upon by these issues, I've hardcoded it, only this time into standard.