### PR TITLE
Fix duplicated team display with Team Type Preview

### DIFF
--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1435,6 +1435,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 		name: 'Team Type Preview',
 		desc: "Allows each player to see the Pok&eacute;mon on their opponent's team and those Pok&eacute;mon's types before they choose their lead Pok&eacute;mon",
 		onTeamPreview() {
+			this.add('clearpoke');
 			for (const side of this.sides) {
 				for (const pokemon of side.pokemon) {
 					const details = pokemon.details.replace(', shiny', '')


### PR DESCRIPTION
Battles with both Team Preview and Team Type Preview send the teams twice, which causes duplicated Pokemon to appear. While it may be desirable to have some sort of exclusivity with different types of Team Preview, adding a `clearpoke` fixes the bug on our client. Replay demonstrating the bug: https://replay.pokemonshowdown.com/gen81v1-1643744004