### PR TITLE
VGC/BSS: Enable Series 13 ladders, add Spikemuth Cup

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -284,14 +284,6 @@ export const Formats: FormatList = [
 		name: "[Gen 8] Battle Stadium Singles",
 
 		mod: 'gen8',
-		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 8', 'Limit Two Restricted'],
-		restricted: ['Restricted Legendary'],
-	},
-	{
-		name: "[Gen 8] Battle Stadium Singles Series 13",
-
-		mod: 'gen8',
-		searchShow: false,
 		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 8'],
 		banlist: ['Eternatus-Eternamax'],
 		unbanlist: ['Mythical', 'Restricted Legendary'],
@@ -397,10 +389,16 @@ export const Formats: FormatList = [
 
 		mod: 'gen8',
 		gameType: 'doubles',
-		searchShow: false,
 		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 8', 'VGC Timer'],
 		banlist: ['Eternatus-Eternamax'],
 		unbanlist: ['Mythical', 'Restricted Legendary'],
+	},
+	{
+		name: "[Gen 8] Spikemuth Cup",
+
+		mod: 'gen8',
+		gameType: 'doubles',
+		ruleset: ['Flat Rules', 'Dynamax Clause', '!! Adjust Level = 50', 'Min Source Gen = 8', 'VGC Timer'],
 	},
 	{
 		name: "[Gen 8] VGC 2021",


### PR DESCRIPTION
This can be merged September 1 with any other tier/format changes.

We have found out from TPCi that in fact, no official VGC events will occur between now and January 1. The VGC community has sort of been looking for its identity in the meantime and seems to have settled on Spikemuth Cup as its primary format of choice. Several of the major VGC platforms (e.g. Victory Road, Smogon, and Desafío LATAM) have decided to adopt Spikemuth Cup for their tournaments. This is doubles, unlike the singles online cart tourney. Spikemuth Cup was a popular in-person side event at some of our recent majors ([NAIC](https://www.pokemon.com/us/play-pokemon/internationals/2022/north-america/side-events/#pokemon-sword-and-pokemon-shield-side-events), [Worlds](https://www.pokemon.com/us/play-pokemon/worlds/2022/side-events/)).

This does give VGC three concurrent ladders (main VGC 2022, Series 13, and Spikemuth), but I have OKed this with Kris.