### PR TITLE
Adding "Obtainable" to Chimera 1v1

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -745,7 +745,7 @@ export const Formats: FormatList = [
 		],
 
 		mod: 'gen8',
-		ruleset: ['Chimera 1v1 Rule', 'OHKO Clause', 'Species Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'Dynamax Clause', 'Sleep Moves Clause'],
+		ruleset: ['Chimera 1v1 Rule', 'OHKO Clause', 'Species Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'Dynamax Clause', 'Sleep Moves Clause', 'Obtainable'],
 		banlist: [
 			'Shedinja', 'Huge Power', 'Moody', 'Neutralizing Gas', 'Truant', 'Perish Body', 'Eviolite', 'Focus Sash', 'Leek', 'Light Ball',
 			'Bolt Beak', 'Disable', 'Double Iron Bash', 'Fishious Rend', 'Perish Song', 'Switcheroo', 'Transform', 'Trick',


### PR DESCRIPTION
Chimera 1v1 is missing "Obtainable" allowing NatDex and Pokestar mons to validate, as well as illegal movesets.