### PR TITLE
Update formats.ts

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -745,7 +745,7 @@ export const Formats: FormatList = [
 		],
 
 		mod: 'gen8',
-		ruleset: ['Chimera 1v1 Rule', 'OHKO Clause', 'Species Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'Dynamax Clause', 'Sleep Moves Clause'],
+		ruleset: ['Chimera 1v1 Rule', 'Standard', 'Dynamax Clause', 'Sleep Moves Clause'],
 		banlist: [
 			'Shedinja', 'Huge Power', 'Moody', 'Neutralizing Gas', 'Truant', 'Perish Body', 'Eviolite', 'Focus Sash', 'Leek', 'Light Ball',
 			'Bolt Beak', 'Disable', 'Double Iron Bash', 'Fishious Rend', 'Perish Song', 'Switcheroo', 'Transform', 'Trick',


### PR DESCRIPTION
Currently Chimera 1v1 is incorrectly validating illegal pokemon (including Pokestar mons), illegal movesets, and illegal abilities. Reverting to the ruleset that was used last time it had a ladder.