### PR TITLE
NC97: Run the correct Sleep Clause

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3975,7 +3975,7 @@ export const Formats: FormatList = [
 		searchShow: false,
 		ruleset: [
 			'Picked Team Size = 3', 'Min Level = 50', 'Max Level = 55', 'Max Total Level = 155',
-			'Obtainable', 'Team Preview', 'Sleep Clause Mod', 'Species Clause', 'Nickname Clause', 'HP Percentage Mod', 'Cancel Mod', 'Nintendo Cup 1997 Move Legality',
+			'Obtainable', 'Team Preview', 'Stadium Sleep Clause', 'Species Clause', 'Nickname Clause', 'HP Percentage Mod', 'Cancel Mod', 'Nintendo Cup 1997 Move Legality',
 		],
 		banlist: ['Uber'],
 	},

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -994,7 +994,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 			if (status.id === 'slp') {
 				for (const pokemon of target.side.pokemon) {
 					if (pokemon.hp && pokemon.status === 'slp') {
-						this.add('-message', "Sleep Clause activated. (In Stadium, Sleep Clause activates if any of the opponent's Pokemon are asleep, even if self-inflicted from Rest)");
+						this.add('-message', "Sleep Clause activated. (In Nintendo formats, Sleep Clause activates if any of the opponent's Pokemon are asleep, even if self-inflicted from Rest)");
 						return false;
 					}
 				}


### PR DESCRIPTION
My friend daiginjou brought up the realisation to me that this was a problem with the simulation, so I am putting this in.

Back in the day, Stadium Sleep Clause was the "correct" Sleep Clause, counting Rest. Thus, it makes no sense not to count Rest here, as Smogon (which popularised the change) didn't exist yet, NC2000 runs the Stadium version, all context shows otherwise, and the Japanese scene prefers it done this way. 

I changed the wording on the activation of the clause which should remain un-confusing while being inclusive towards NC97. 