### PR TITLE
scavengers Games: Change placeholder name of new twist

### DIFF
--- a/server/chat-plugins/scavenger-games.ts
+++ b/server/chat-plugins/scavenger-games.ts
@@ -364,16 +364,16 @@ const TWISTS: {[k: string]: Twist} = {
 		},
 	},
 
-	mistakes: {
-		id: 'mistakes',
-		name: 'Mistakes',
+	scavengersfeud: {
+		id: 'scavengersfeud',
+		name: 'Scavengers Feud',
 		desc: 'After completing the hunt, players will guess what the most common incorrect answer for each question is.',
 		onAfterLoad() {
 			this.guesses = {};
 			this.incorrect = new Array(this.questions.length).fill({});
 
 			this.questions.push({
-				hint: 'Please enter what you think are the most common incorrect answers to each question.  (Enter your guesses in the order of the previous questions, and seperate them with a comma)',
+				hint: 'Please enter what you think are the most common incorrect answers to each question. (Enter your guesses in the order of the previous questions, and separate them with a comma)',
 				answer: ['Any'],
 				spoilers: [],
 			});


### PR DESCRIPTION
The placeholder name was not replaced with the actual name of the twist. Adjusted to the proper name. 

There was also a typo in 'seperate', fixed that too.