### PR TITLE
Implement Battle Factory for Gen 8

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2241,6 +2241,14 @@ export const Formats: FormatList = [
 		},
 	},
 	{
+		name: "[Gen 8] Battle Factory",
+		desc: `Randomized teams of Pok&eacute;mon for a generated Smogon tier with sets that are competitively viable.`,
+
+		mod: 'gen8',
+		team: 'randomFactory',
+		ruleset: ['Standard', 'Dynamax Clause'],
+	},
+	{
 		name: "[Gen 8] BSS Factory",
 		desc: `Randomized 3v3 Singles featuring Pok&eacute;mon and movesets popular in Battle Stadium Singles.`,
 		threads: [

--- a/data/factory-sets.json
+++ b/data/factory-sets.json
@@ -2253,15 +2253,15 @@
 				"item": ["Life Orb"],
 				"ability": ["Grassy Surge"],
 				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": ["Adamant", "Jolly"],
-				"moves": [["Horn Leech"], ["Stone Edge"], ["Zen Headbutt"], ["Swords Dance"]]
+				"nature": "Adamant",
+				"moves": [["Horn Leech"], ["Close Combat"], ["Zen Headbutt", "Stone Edge"], ["Swords Dance"]]
 			}, {
 				"species": "Tapu Bulu",
-				"item": ["Heavy-Duty Boots"],
+				"item": ["Choice Scarf", "Choice Band"],
 				"ability": ["Grassy Surge"],
-				"evs": {"hp": 252, "def": 120, "spe": 136},
-				"nature": "Impish",
-				"moves": [["Horn Leech"], ["Dazzling Gleam"], ["Synthesis"], ["Toxic"]]
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Horn Leech"], ["Close Combat"], ["Stone Edge"], ["Zen Headbutt"]]
 			}]
 		},
 		"suicune": {

--- a/data/factory-sets.json
+++ b/data/factory-sets.json
@@ -3205,7 +3205,6 @@
 				"evs": {"hp": 4, "atk": 252, "spe": 252},
 				"nature": "Adamant",
 				"moves": [["Shell Smash"], ["Icicle Spear"], ["Rock Blast", "Explosion"], ["Spikes", "Liquidation", "Ice Shard"]]
-			}, {
 			}]
 		},
 		"gigalith": {

--- a/data/factory-sets.json
+++ b/data/factory-sets.json
@@ -1,0 +1,5581 @@
+{
+	"Uber": {
+		"yveltal": {
+			"sets": [{
+				"species": "Yveltal",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Dark Aura"],
+				"evs": {"hp": 16, "def": 240, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Knock Off", "Foul Play"], ["Taunt", "Toxic"], ["Defog"], ["Roost"]]
+			}, {
+				"species": "Yveltal",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Dark Aura"],
+				"evs": {"hp": 16, "def": 240, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Foul Play"], ["Taunt", "Knock Off"], ["Defog", "Toxic"], ["Roost"]]
+			}, {
+				"species": "Yveltal",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Dark Aura"],
+				"evs": {"hp": 248, "def": 72, "spd": 188},
+				"nature": "Careful",
+				"moves": [["Knock Off"], ["U-turn", "Snarl", "Sucker Punch"], ["Defog"], ["Roost"]]
+			}, {
+				"species": "Yveltal",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Dark Aura"],
+				"evs": {"hp": 248, "def": 72, "spd": 188},
+				"nature": "Careful",
+				"moves": [["Knock Off"], ["U-turn", "Snarl"], ["Sucker Punch"], ["Roost"]]
+			}, {
+				"species": "Yveltal",
+				"item": ["Life Orb", "Black Glasses"],
+				"ability": ["Dark Aura"],
+				"evs": {"atk": 252, "spd": 72, "spe": 184},
+				"nature": "Adamant",
+				"moves": [["Knock Off"], ["Hone Claws"], ["Sucker Punch"], ["Acrobatics"]]
+			}, {
+				"species": "Yveltal",
+				"item": ["Life Orb", "Black Glasses"],
+				"ability": ["Dark Aura"],
+				"evs": {"atk": 252, "spd": 72, "spe": 184},
+				"nature": "Adamant",
+				"moves": [["Knock Off"], ["Hone Claws"], ["Sucker Punch", "Acrobatics"], ["Roost"]]
+			}, {
+				"species": "Yveltal",
+				"item": ["Life Orb"],
+				"ability": ["Dark Aura"],
+				"evs": {"atk": 4, "spa": 252, "spe": 252},
+				"nature": "Hasty",
+				"moves": [["Dark Pulse"], ["Oblivion Wing"], ["Sucker Punch"], ["Taunt", "Rock Slide"]]
+			}, {
+				"species": "Yveltal",
+				"item": ["Choice Scarf"],
+				"ability": ["Dark Aura"],
+				"evs": {"hp": 252, "spd": 72, "spe": 184},
+				"nature": "Hasty",
+				"moves": [["Foul Play"], ["Oblivion Wing"], ["U-turn", "Knock Off"], ["Defog"]]
+			}, {
+				"species": "Yveltal",
+				"item": ["Choice Band"],
+				"ability": ["Dark Aura"],
+				"evs": {"atk": 252, "spd": 72, "spe": 184},
+				"nature": ["Adamant", "Jolly"],
+				"moves": [["Knock Off"], ["Dual Wingbeat"], ["Sucker Punch"], ["U-turn"]]
+			}]
+		},
+		"eternatus": {
+			"sets": [{
+				"species": "Eternatus",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 164, "spd": 252, "spe": 92},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Dynamax Cannon"], ["Recover"], ["Toxic", "Sludge Bomb"], ["Mystical Fire", "Flamethrower"]]
+			}, {
+				"species": "Eternatus",
+				"item": ["Eject Pack"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 164, "spd": 252, "spe": 92},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Draco Meteor"], ["Recover"], ["Toxic", "Sludge Bomb"], ["Mystical Fire", "Flamethrower"]]
+			}, {
+				"species": "Eternatus",
+				"item": ["Power Herb"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Meteor Beam"], ["Dynamax Cannon"], ["Flamethrower"], ["Sludge Bomb", "Substitute"]]
+			}, {
+				"species": "Eternatus",
+				"item": ["Power Herb"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 40, "spd": 252, "spe": 216},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Dynamax Cannon"], ["Meteor Beam"], ["Cosmic Power"], ["Recover"]]
+			}, {
+				"species": "Eternatus",
+				"item": ["Life Orb"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid", "Modest"],
+				"moves": [["Dynamax Cannon"], ["Sludge Bomb"], ["Flamethrower"], ["Recover"]]
+			}, {
+				"species": "Eternatus",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 48, "def": 244, "spe": 216},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Dynamax Cannon"], ["Toxic", "Toxic Spikes"], ["Flamethrower"], ["Recover"]]
+			}]
+		},
+		"necrozmaduskmane": {
+			"sets": [{
+				"species": "Necrozma-Dusk-Mane",
+				"item": ["Leftovers"],
+				"ability": ["Prism Armor"],
+				"evs": {"hp": 252, "spd": 136, "spe": 120},
+				"nature": "Careful",
+				"moves": [["Iron Head"], ["Moonlight"], ["Stealth Rock", "Knock Off"], ["Thunder Wave", "Toxic"]]
+			}, {
+				"species": "Necrozma-Dusk-Mane",
+				"item": ["Leftovers"],
+				"ability": ["Prism Armor"],
+				"evs": {"hp": 136, "atk": 252, "spe": 120},
+				"nature": "Adamant",
+				"moves": [["Iron Head", "Sunsteel Strike"], ["Knock Off", "Stone Edge"], ["Swords Dance", "Dragon Dance"], ["Moonlight"]]
+			}, {
+				"species": "Necrozma-Dusk-Mane",
+				"item": ["Weakness Policy", "Lum Berry"],
+				"ability": ["Prism Armor"],
+				"evs": {"hp": 80, "atk": 252, "spe": 176},
+				"nature": "Adamant",
+				"moves": [["Sunsteel Strike"], ["Stone Edge"], ["Earthquake"], ["Dragon Dance"]]
+			}, {
+				"species": "Necrozma-Dusk-Mane",
+				"item": ["Rocky Helmet", "Leftovers"],
+				"ability": ["Prism Armor"],
+				"evs": {"hp": 252, "def": 136, "spe": 120},
+				"nature": "Impish",
+				"moves": [["Sunsteel Strike", "Iron Head"], ["Stealth Rock"], ["Earthquake"], ["Moonlight"]]
+			}, {
+				"species": "Necrozma-Dusk-Mane",
+				"item": ["Choice Band"],
+				"ability": ["Prism Armor"],
+				"evs": {"hp": 136, "atk": 252, "spe": 120},
+				"nature": "Adamant",
+				"moves": [["Sunsteel Strike"], ["Knock Off"], ["Photon Geyser"], ["Stone Edge", "Moonlight"]]
+			}]
+		},
+		"calyrexshadow": {
+			"sets": [{
+				"species": "Calyrex-Shadow",
+				"item": ["Choice Specs", "Choice Scarf"],
+				"ability": ["As One (Spectrier)"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Astral Barrage"], ["Psyshock"], ["Trick"], ["Aromatherapy", "Nasty Plot"]]
+			}, {
+				"species": "Calyrex-Shadow",
+				"item": ["Leftovers"],
+				"ability": ["As One (Spectrier)"],
+				"evs": {"def": 60, "spa": 196, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Astral Barrage"], ["Nasty Plot"], ["Substitute"], ["Leech Seed"]]
+			}, {
+				"species": "Calyrex-Shadow",
+				"item": ["Focus Sash"],
+				"ability": ["As One (Spectrier)"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Astral Barrage"], ["Nasty Plot"], ["Psyshock"], ["Draining Kiss"]]
+			}, {
+				"species": "Calyrex-Shadow",
+				"item": ["Mental Herb"],
+				"ability": ["As One (Spectrier)"],
+				"evs": {"hp": 48, "def": 128, "spa": 76, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Astral Barrage"], ["Nasty Plot"], ["Disable"], ["Substitute"]]
+			}]
+		},
+		"kyogre": {
+			"sets": [{
+				"species": "Kyogre",
+				"item": ["Leftovers"],
+				"ability": ["Drizzle"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Calm Mind"], ["Scald"], ["Rest"], ["Ice Beam", "Block"]]
+			}, {
+				"species": "Kyogre",
+				"item": ["Choice Specs"],
+				"ability": ["Drizzle"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest", "Timid"],
+				"moves": [["Water Spout"], ["Origin Pulse"], ["Ice Beam"], ["Thunder"]]
+			}, {
+				"species": "Kyogre",
+				"item": ["Choice Scarf"],
+				"ability": ["Drizzle"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Water Spout"], ["Origin Pulse"], ["Ice Beam"], ["Thunder"]]
+			}, {
+				"species": "Kyogre",
+				"item": ["Leftovers"],
+				"ability": ["Drizzle"],
+				"evs": {"hp": 252, "spa": 140, "spe": 116},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Substitute"], ["Calm Mind"], ["Surf"], ["Thunder Wave"]]
+			}]
+		},
+		"groudon": {
+			"sets": [{
+				"species": "Groudon",
+				"item": ["Leftovers"],
+				"ability": ["Drought"],
+				"evs": {"hp": 240, "atk": 252, "spe": 16},
+				"nature": "Adamant",
+				"moves": [["Precipice Blades"], ["Swords Dance", "Bulk Up"], ["Stone Edge"], ["Heat Crash", "Toxic", "Thunder Wave"]]
+			}, {
+				"species": "Groudon",
+				"item": ["Life Orb", "Lum Berry"],
+				"ability": ["Drought"],
+				"evs": {"hp": 180, "atk": 252, "spe": 76},
+				"nature": "Adamant",
+				"moves": [["Precipice Blades"], ["Swords Dance"], ["Rock Polish"], ["Stone Edge"]]
+			}, {
+				"species": "Groudon",
+				"item": ["Leftovers"],
+				"ability": ["Drought"],
+				"evs": {"hp": 252, "def": 240, "spe": 16},
+				"nature": "Impish",
+				"moves": [["Precipice Blades"], ["Stealth Rock"], ["Stone Edge", "Rock Slide"], ["Toxic", "Dragon Tail", "Thunder Wave"]]
+			}]
+		},
+		"zygarde": {
+			"sets": [{
+				"species": "Zygarde",
+				"item": ["Leftovers"],
+				"ability": ["Power Construct"],
+				"evs": {"hp": 16, "atk": 224, "def": 36, "spe": 232},
+				"nature": "Impish",
+				"moves": [["Thousand Arrows"], ["Dragon Dance"], ["Substitute"], ["Glare", "Toxic", "Dragon Tail"]]
+			}, {
+				"species": "Zygarde",
+				"item": ["Leftovers"],
+				"ability": ["Power Construct"],
+				"evs": {"hp": 208, "def": 244, "spe": 56},
+				"nature": "Impish",
+				"moves": [["Thousand Arrows"], ["Coil"], ["Rest"], ["Glare"]]
+			}, {
+				"species": "Zygarde",
+				"item": ["Leftovers"],
+				"ability": ["Power Construct"],
+				"evs": {"hp": 80, "atk": 220, "def": 112, "spe": 96},
+				"nature": "Adamant",
+				"moves": [["Thousand Waves"], ["Coil"], ["Scale Shot"], ["Rest"]]
+			}]
+		},
+		"marshadow": {
+			"sets": [{
+				"species": "Marshadow",
+				"item": ["Life Orb", "Spell Tag"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly", "Adamant"],
+				"moves": [["Spectral Thief"], ["Low Kick"], ["Shadow Sneak"], ["Ice Punch", "Rock Tomb", "Bulk Up"]]
+			}, {
+				"species": "Marshadow",
+				"item": ["Choice Band"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Spectral Thief"], ["Low Kick"], ["Shadow Sneak"], ["Ice Punch", "Rock Tomb", "Poltergeist"]]
+			}]
+		},
+		"xerneas": {
+			"sets": [{
+				"species": "Xerneas",
+				"item": ["Power Herb"],
+				"ability": ["Fairy Aura"],
+				"evs": {"def": 168, "spa": 252, "spe": 88},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Moonblast"], ["Geomancy"], ["Thunder"], ["Aromatherapy", "Substitute", "Ingrain"]]
+			}, {
+				"species": "Xerneas",
+				"item": ["Leftovers"],
+				"ability": ["Fairy Aura"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Moonblast"], ["Rest"], ["Sleep Talk"], ["Aromatherapy", "Defog", "Thunder Wave"]]
+			}, {
+				"species": "Xerneas",
+				"item": ["Choice Scarf"],
+				"ability": ["Fairy Aura"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Moonblast"], ["Thunder", "Focus Blast"], ["Thunder Wave", "Defog"], ["Aromatherapy"]]
+			}]
+		},
+		"hooh": {
+			"sets": [{
+				"species": "Ho-Oh",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 248, "208": 208, "spd": 52},
+				"nature": "Impish",
+				"moves": [["Sacred Fire"], ["Defog"], ["Brave Bird"], ["Toxic", "Thunder Wave", "Whirlwind"]]
+			}, {
+				"species": "Ho-Oh",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 248, "208": 208, "spd": 52},
+				"nature": "Impish",
+				"moves": [["Sacred Fire"], ["Defog"], ["Toxic", "Thunder Wave"], ["Whirlwind"]]
+			}, {
+				"species": "Ho-Oh",
+				"item": ["Choice Band"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 248, "atk": 208, "spd": 52},
+				"nature": "Adamant",
+				"moves": [["Sacred Fire"], ["Brave Bird"], ["Earthquake"], ["Whirlwind", "Flare Blitz", "Defog"]]
+			}, {
+				"species": "Ho-Oh",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 248, "atk": 192, "spd": 52, "spe": 16},
+				"nature": "Adamant",
+				"moves": [["Sacred Fire", "Flare Blitz"], ["Brave Bird"], ["Thunder Wave"], ["Defog", "Whirlwind", "Substitute"]]
+			}]
+		},
+		"ferrothorn": {
+			"sets": [{
+				"species": "Ferrothorn",
+				"item": ["Leftovers"],
+				"ability": ["Iron Barbs"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": "Impish",
+				"moves": [["Leech Seed"], ["Spikes"], ["Knock Off"], ["Curse"]]
+			}, {
+				"species": "Ferrothorn",
+				"item": ["Leftovers"],
+				"ability": ["Iron Barbs"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Leech Seed"], ["Spikes"], ["Iron Defense"], ["Body Press"]]
+			}, {
+				"species": "Ferrothorn",
+				"item": ["Leftovers"],
+				"ability": ["Iron Barbs"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": "Careful",
+				"moves": [["Leech Seed"], ["Spikes"], ["Knock Off"], ["Power Whip", "Curse"]]
+			}, {
+				"species": "Ferrothorn",
+				"item": ["Leftovers"],
+				"ability": ["Iron Barbs"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"spe": 0},
+				"nature": "Sassy",
+				"moves": [["Leech Seed"], ["Spikes"], ["Gyro Ball"], ["Knock Off", "Power Whip"]]
+			}]
+		},
+		"zekrom": {
+			"sets": [{
+				"species": "Zekrom",
+				"item": ["Life Orb", "Leftovers"],
+				"ability": ["Teravolt"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Bolt Strike"], ["Dragon Dance"], ["Dragon Claw"], ["Roost", "Substitute"]]
+			}, {
+				"species": "Zekrom",
+				"item": ["Life Orb"],
+				"ability": ["Teravolt"],
+				"evs": {"atk": 252, "spa": 4, "spe": 252},
+				"nature": "Naive",
+				"moves": [["Bolt Strike"], ["Dragon Dance"], ["Dragon Claw"], ["Draco Meteor"]]
+			}, {
+				"species": "Zekrom",
+				"item": ["Life Orb"],
+				"ability": ["Teravolt"],
+				"evs": {"atk": 252, "spa": 4, "spe": 252},
+				"nature": "Naive",
+				"moves": [["Bolt Strike"], ["Draco Meteor"], ["Roost"], ["Scale Shot"]]
+			}]
+		},
+		"landorustherian": {
+			"sets": [{
+				"species": "Landorus-Therian",
+				"item": ["Leftovers"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 248, "def": 252, "spe": 8},
+				"nature": "Impish",
+				"moves": [["Earthquake"], ["U-turn"], ["Stealth Rock"], ["Stone Edge", "Toxic"]]
+			}]
+		},
+		"darmanitangalar": {
+			"sets": [{
+				"species": "Darmanitan-Galar",
+				"item": ["Choice Scarf"],
+				"ability": ["Gorilla Tactics"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Icicle Crash"], ["Flare Blitz"], ["U-turn"], ["Earthquake", "Rock Slide"]]
+			}, {
+				"species": "Darmanitan-Galar",
+				"item": ["Choice Band"],
+				"ability": ["Gorilla Tactics"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly", "Adamant"],
+				"moves": [["Icicle Crash"], ["Flare Blitz"], ["U-turn", "Rock Slide"], ["Earthquake"]]
+			}]
+		},
+		"weavile": {
+			"sets": [{
+				"species": "Weavile",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Pressure"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly", "Adamant"],
+				"moves": [["Triple Axel"], ["Knock Off"], ["Ice Shard"], ["Swords Dance"]]
+			}]
+		},
+		"lunala": {
+			"sets": [{
+				"species": "Lunala",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Shadow Shield"],
+				"evs": {"hp": 252, "def": 16, "spe": 240},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Ice Beam"], ["Roost"], ["Will-O-Wisp", "Thunder Wave"], ["Hex", "Roar", "Defog"]]
+			}, {
+				"species": "Lunala",
+				"item": ["Power Herb"],
+				"ability": ["Shadow Shield"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Ice Beam"], ["Roost"], ["Moongeist Beam"], ["Meteor Beam"]]
+			}]
+		},
+		"rayquaza": {
+			"sets": [{
+				"species": "Rayquaza",
+				"item": ["Choice Band"],
+				"ability": ["Air Lock"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Dragon Ascent"], ["V-create"], ["Extreme Speed"], ["Earthquake", "Dragon Claw", "Scale Shot"]]
+			}, {
+				"species": "Rayquaza",
+				"item": ["Haban Berry", "Focus Sash"],
+				"ability": ["Air Lock"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Dragon Ascent"], ["V-create", "Earthquake"], ["Scale Shot", "Extreme Speed"], ["Swords Dance"]]
+			}, {
+				"species": "Rayquaza",
+				"item": ["Life Orb"],
+				"ability": ["Air Lock"],
+				"evs": {"atk": 252, "spa": 4, "spe": 252},
+				"nature": "Naive",
+				"moves": [["Dragon Ascent"], ["V-create", "Earthquake"], ["Draco Meteor"], ["Extreme Speed"]]
+			}]
+		},
+		"urshifu": {
+			"sets": [{
+				"species": "Urshifu",
+				"item": ["Choice Band"],
+				"ability": ["Unseen Fist"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Wicked Blow"], ["Low Kick"], ["Sucker Punch"], ["U-turn"]]
+			}, {
+				"species": "Urshifu",
+				"item": ["Black Glasses"],
+				"ability": ["Unseen Fist"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"moves": [["Wicked Blow"], ["Low Kick"], ["Sucker Punch"], ["Bulk Up"]]
+			}]
+		},
+		"blissey": {
+			"sets": [{
+				"species": "Blissey",
+				"item": ["Utility Umbrella"],
+				"ability": ["Natural Cure"],
+				"evs": {"hp": 4, "def": 252, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": "Calm",
+				"moves": [["Soft-Boiled"], ["Teleport"], ["Aromatherapy"], ["Stealth Rock", "Seismic Toss", "Thunder Wave"]]
+			}, {
+				"species": "Blissey",
+				"item": ["Utility Umbrella"],
+				"ability": ["Natural Cure"],
+				"evs": {"hp": 4, "def": 252, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": "Calm",
+				"moves": [["Soft-Boiled"], ["Teleport"], ["Stealth Rock"], ["Seismic Toss", "Thunder Wave"]]
+			}, {
+				"species": "Blissey",
+				"item": ["Utility Umbrella"],
+				"ability": ["Natural Cure"],
+				"evs": {"hp": 4, "def": 252, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": "Calm",
+				"moves": [["Soft-Boiled"], ["Confide"], ["Wish", "Aromatherapy"], ["Stealth Rock", "Seismic Toss", "Thunder Wave"]]
+			}]
+		},
+		"buzzwole": {
+			"sets": [{
+				"species": "Buzzwole",
+				"item": ["Heavy-Duty Boots", "Rocky Helmet"],
+				"ability": ["Beast Boost"],
+				"evs": {"hp": 252, "def": 152, "spe": 104},
+				"nature": "Impish",
+				"moves": [["Bulk Up"], ["Ice Punch"], ["Drain Punch", "Leech Life"], ["Roost"]]
+			}, {
+				"species": "Buzzwole",
+				"item": ["Heavy-Duty Boots", "Choice Band"],
+				"ability": ["Beast Boost"],
+				"evs": {"hp": 152, "atk": 172, "def": 80, "spe": 104},
+				"nature": "Adamant",
+				"moves": [["Close Combat"], ["Ice Punch"], ["Rock Slide"], ["Roost"]]
+			}]
+		},
+		"giratinaorigin": {
+			"sets": [{
+				"species": "Giratina-Origin",
+				"item": ["Griseous Orb"],
+				"ability": ["Levitate"],
+				"evs": {"atk": 12, "def": 216, "spa": 252, "spe": 28},
+				"nature": "Quiet",
+				"moves": [["Shadow Sneak"], ["Hex"], ["Draco Meteor"], ["Will-O-Wisp", "Thunder Wave"]]
+			}, {
+				"species": "Giratina-Origin",
+				"item": ["Griseous Orb"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 176, "atk": 252, "def": 4, "spe": 76},
+				"nature": "Adamant",
+				"moves": [["Shadow Sneak"], ["Poltergeist"], ["Stone Edge"], ["Will-O-Wisp", "Thunder Wave"]]
+			}]
+		},
+		"landorus": {
+			"sets": [{
+				"species": "Landorus",
+				"item": ["Life Orb"],
+				"ability": ["Sheer Force"],
+				"evs": {"atk": 4, "spa": 252, "spe": 252},
+				"nature": "Naive",
+				"moves": [["Earth Power"], ["Rock Slide"], ["Knock Off", "Sludge Wave", "Stealth Rock"], ["Superpower", "Explosion"]]
+			}]
+		},
+		"mewtwo": {
+			"sets": [{
+				"species": "Mewtwo",
+				"item": ["Life Orb"],
+				"ability": ["Pressure"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Psystrike"], ["Ice Beam"], ["Fire Blast"], ["Nasty Plot", "Recover", "Shadow Ball"]]
+			}, {
+				"species": "Mewtwo",
+				"item": ["Expert Belt"],
+				"ability": ["Pressure"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Psystrike"], ["Ice Beam"], ["Fire Blast"], ["Nasty Plot", "Recover", "Shadow Ball"]]
+			}]
+		},
+		"toxapex": {
+			"sets": [{
+				"species": "Toxapex",
+				"item": ["Rocky Helmet"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 248, "def": 252, "spd": 8},
+				"nature": "Bold",
+				"moves": [["Knock Off"], ["Recover"], ["Haze", "Toxic Spikes"], ["Scald", "Toxic"]]
+			}]
+		},
+		"zamazentacrowned": {
+			"sets": [{
+				"species": "Zamazenta-Crowned",
+				"item": ["Rusted Shield"],
+				"ability": ["Dauntless Shield"],
+				"evs": {"hp": 252, "def": 64, "spd": 196},
+				"nature": "Careful",
+				"moves": [["Behemoth Bash"], ["Close Combat"], ["Rest"], ["Sleep Talk", "Howl"]]
+			}, {
+				"species": "Zamazenta-Crowned",
+				"item": ["Rusted Shield"],
+				"ability": ["Dauntless Shield"],
+				"evs": {"hp": 252, "def": 64, "spd": 196},
+				"ivs": {"spe": 0},
+				"nature": "Sassy",
+				"moves": [["Behemoth Bash"], ["Close Combat"], ["Rest"], ["Metal Burst"]]
+			}]
+		},
+		"zarude": {
+			"sets": [{
+				"species": "Zarude",
+				"item": ["Leftovers"],
+				"ability": ["Leaf Guard"],
+				"evs": {"hp": 252, "spd": 120, "spe": 136},
+				"nature": "Jolly",
+				"moves": [["Darkest Lariat"], ["Power Whip"], ["Bulk Up"], ["Synthesis", "Jungle Healing"]]
+			}, {
+				"species": "Zarude",
+				"item": ["Leftovers"],
+				"ability": ["Leaf Guard"],
+				"evs": {"hp": 240, "def": 252, "spe": 16},
+				"nature": "Impish",
+				"moves": [["Darkest Lariat"], ["Power Whip"], ["Bulk Up"], ["Synthesis"]]
+			}]
+		},
+		"clefable": {
+			"sets": [{
+				"species": "Clefable",
+				"item": ["Leftovers"],
+				"ability": ["Magic Guard"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"nature": "Bold",
+				"moves": [["Moonblast"], ["Soft-Boiled"], ["Stealth Rock"], ["Knock Off", "Thunder Wave", "Heal Bell"]]
+			}]
+		},
+		"ditto": {
+			"sets": [{
+				"species": "Ditto",
+				"item": ["Choice Scarf"],
+				"ability": ["Imposter"],
+				"evs": {"hp": 252, "atk": 8, "def": 252},
+				"ivs": {"spe": 0},
+				"nature": "Relaxed",
+				"moves": [["Transform"]]
+			}]
+		},
+		"heatran": {
+			"sets": [{
+				"species": "Heatran",
+				"item": ["Leftovers"],
+				"ability": ["Flash Fire"],
+				"evs": {"hp": 244, "spd": 240, "spe": 20},
+				"ivs": {"atk": 0},
+				"nature": "Calm",
+				"moves": [["Magma Storm"], ["Earth Power"], ["Taunt"], ["Toxic", "Roar", "Stealth Rock"]]
+			}]
+		},
+		"tyranitar": {
+			"sets": [{
+				"species": "Tyranitar",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Sand Stream"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": "Careful",
+				"moves": [["Stealth Rock"], ["Rock Blast"], ["Foul Play", "Thunder Wave"], ["Rest"]]
+			}]
+		},
+		"calyrexice": {
+			"sets": [{
+				"species": "Calyrex-Ice",
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["As One (Glastrier)"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Glacial Lance"], ["Substitute"], ["Leech Seed"], ["Swords Dance"]]
+			}, {
+				"species": "Calyrex-Ice",
+				"item": ["Choice Band"],
+				"ability": ["As One (Glastrier)"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Glacial Lance"], ["High Horsepower"], ["Trick"], ["Icicle Spear", "Aromatherapy"]]
+			}, {
+				"species": "Calyrex-Ice",
+				"item": ["Life Orb", "Weakness Policy"],
+				"ability": ["As One (Glastrier)"],
+				"evs": {"hp": 252, "atk": 252, "spd": 4},
+				"ivs": {"spe": 0},
+				"nature": "Brave",
+				"moves": [["Glacial Lance"], ["High Horsepower"], ["Trick Room"], ["Aromatherapy", "Swords Dance"]]
+			}]
+		},
+		"giratina": {
+			"sets": [{
+				"species": "Giratina",
+				"item": ["Leftovers"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Defog"], ["Toxic", "Roar"], ["Will-O-Wisp"], ["Rest"]]
+			}]
+		},
+		"magearna": {
+			"sets": [{
+				"species": "Magearna",
+				"item": ["Leftovers"],
+				"ability": ["Soul-Heart"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Fleur Cannon"], ["Volt Switch"], ["Pain Split"], ["Heal Bell"]]
+			}]
+		},
+		"kyuremblack": {
+			"sets": [{
+				"species": "Kyurem-Black",
+				"item": ["Leftovers", "Life Orb"],
+				"ability": ["Teravolt"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Icicle Spear"], ["Dragon Dance"], ["Fusion Bolt"], ["Roost", "Substitute"]]
+			}]
+		},
+		"palkia": {
+			"sets": [{
+				"species": "Palkia",
+				"item": ["Leftovers"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 96, "atk": 160, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Substitute"], ["Bulk Up"], ["Scale Shot"], ["Liquidation"]]
+			}]
+		}
+	},
+	"OU": {
+		"landorustherian": {
+			"sets": [{
+				"species": "Landorus-Therian",
+				"item": ["Leftovers"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": "Careful",
+				"moves": [["Earthquake"], ["U-turn"], ["Stealth Rock"], ["Toxic", "Knock Off"]]
+			}, {
+				"species": "Landorus-Therian",
+				"item": ["Leftovers"],
+				"ability": ["Intimidate"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Earthquake"], ["Swords Dance"], ["Stone Edge"], ["Substitute"]]
+			}]
+		},
+		"heatran": {
+			"sets": [{
+				"species": "Heatran",
+				"item": ["Leftovers"],
+				"ability": ["Flash Fire"],
+				"evs": {"hp": 252, "spd": 232, "spe": 24},
+				"ivs": {"atk": 0},
+				"nature": "Calm",
+				"moves": [["Magma Storm"], ["Earth Power"], ["Toxic", "Stealth Rock"], ["Taunt"]]
+			}, {
+				"species": "Heatran",
+				"item": ["Air Balloon"],
+				"ability": ["Flash Fire"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid", "Modest"],
+				"moves": [["Magma Storm"], ["Earth Power"], ["Toxic", "Stealth Rock"], ["Taunt"]]
+			}]
+		},
+		"melmetal": {
+			"sets": [{
+				"species": "Melmetal",
+				"item": ["Protective Pads"],
+				"ability": ["Iron Fist"],
+				"evs": {"hp": 40, "atk": 252, "spd": 104, "spe": 112},
+				"nature": "Adamant",
+				"moves": [["Double Iron Bash"], ["Thunder Punch"], ["Superpower"], ["Thunder Wave"]]
+			}, {
+				"species": "Melmetal",
+				"item": ["Leftovers"],
+				"ability": ["Iron Fist"],
+				"evs": {"atk": 252, "spd": 244, "spe": 12},
+				"nature": "Adamant",
+				"moves": [["Double Iron Bash"], ["Earthquake"], ["Protect"], ["Toxic", "Ice Punch"]]
+			}, {
+				"species": "Melmetal",
+				"item": ["Choice Band"],
+				"ability": ["Iron Fist"],
+				"evs": {"hp": 32, "atk": 252, "spe": 224},
+				"nature": "Adamant",
+				"moves": [["Double Iron Bash"], ["Earthquake"], ["Superpower"], ["Thunder Punch", "Ice Punch", "Toxic"]]
+			}, {
+				"species": "Melmetal",
+				"item": ["Assault Vest"],
+				"ability": ["Iron Fist"],
+				"evs": {"hp": 128, "atk": 116, "spd": 252, "spe": 12},
+				"nature": "Adamant",
+				"moves": [["Double Iron Bash"], ["Earthquake"], ["Ice Punch"], ["Thunder Punch"]]
+			}]
+		},
+		"weavile": {
+			"sets": [{
+				"species": "Weavile",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": ["Jolly", "Adamant"],
+				"moves": [["Knock Off"], ["Triple Axel", "Icicle Crash"], ["Ice Shard"], ["Swords Dance"]]
+			}]
+		},
+		"clefable": {
+			"sets": [{
+				"species": "Clefable",
+				"item": ["Leftovers"],
+				"ability": ["Magic Guard"],
+				"evs": {"hp": 252, "def": 200, "spd": 56},
+				"ivs": {"atk": 0},
+				"nature": "Calm",
+				"moves": [["Moonblast"], ["Soft-Boiled"], ["Stealth Rock", "Wish", "Aromatherapy"], ["Knock Off", "Thunder Wave"]]
+			}, {
+				"species": "Clefable",
+				"item": ["Leftovers", "Life Orb"],
+				"ability": ["Magic Guard"],
+				"evs": {"hp": 252, "def": 196, "spe": 60},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Moonblast"], ["Soft-Boiled"], ["Calm Mind"], ["Thunder", "Flamethrower"]]
+			}]
+		},
+		"dragapult": {
+			"sets": [{
+				"species": "Dragapult",
+				"item": ["Choice Specs"],
+				"ability": ["Infiltrator"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Draco Meteor"], ["U-turn"], ["Shadow Ball"], ["Flamethrower", "Thunder", "Hydro Pump"]]
+			}, {
+				"species": "Dragapult",
+				"item": ["Life Orb"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Dragon Darts"], ["Dragon Dance"], ["Phantom Force"], ["Flamethrower", "Substitute"]]
+			}]
+		},
+		"ferrothorn": {
+			"sets": [{
+				"species": "Ferrothorn",
+				"item": ["Leftovers"],
+				"ability": ["Iron Barbs"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": "Impish",
+				"moves": [["Knock Off"], ["Spikes"], ["Leech Seed"], ["Power Whip", "Body Press"]]
+			}]
+		},
+		"garchomp": {
+			"sets": [{
+				"species": "Garchomp",
+				"item": ["Leftovers"],
+				"ability": ["Rough Skin"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Earthquake"], ["Fire Fang"], ["Swords Dance"], ["Scale Shot"]]
+			}, {
+				"species": "Garchomp",
+				"item": ["Leftovers"],
+				"ability": ["Rough Skin"],
+				"evs": {"hp": 252, "def": 136, "spe": 120},
+				"nature": "Jolly",
+				"moves": [["Earthquake"], ["Stealth Rock"], ["Toxic"], ["Protect", "Flamethrower"]]
+			}]
+		},
+		"kartana": {
+			"sets": [{
+				"species": "Kartana",
+				"item": ["Life Orb", "Protective Pads"],
+				"ability": ["Beast Boost"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Leaf Blade"], ["Knock Off"], ["Sacred Sword"], ["Swords Dance"]]
+			}, {
+				"species": "Kartana",
+				"item": ["Choice Band"],
+				"ability": ["Beast Boost"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Leaf Blade"], ["Knock Off"], ["Sacred Sword"], ["Smart Strike"]]
+			}, {
+				"species": "Kartana",
+				"item": ["Choice Scarf"],
+				"ability": ["Beast Boost"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Leaf Blade"], ["Smart Strike", "Defog"], ["Sacred Sword"], ["Knock Off"]]
+			}]
+		},
+		"tapukoko": {
+			"sets": [{
+				"species": "Tapu Koko",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Electric Surge"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"nature": "Timid",
+				"moves": [["Thunderbolt"], ["Dazzling Gleam"], ["U-turn", "Calm Mind"], ["Roost"]]
+			}]
+		},
+		"tapulele": {
+			"sets": [{
+				"species": "Tapu Lele",
+				"item": ["Choice Specs"],
+				"ability": ["Psychic Surge"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid", "Modest"],
+				"moves": [["Psyshock"], ["Moonblast"], ["Focus Blast"], ["Psychic", "Thunderbolt"]]
+			}, {
+				"species": "Tapu Lele",
+				"item": ["Choice Scarf"],
+				"ability": ["Psychic Surge"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid", "Modest"],
+				"moves": [["Psyshock"], ["Moonblast"], ["Focus Blast"], ["Psychic", "Future Sight"]]
+			}]
+		},
+		"tornadustherian": {
+			"sets": [{
+				"species": "Tornadus-Therian",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Hurricane"], ["Knock Off"], ["Focus Blast", "Heat Wave"], ["Nasty Plot"]]
+			}, {
+				"species": "Tornadus-Therian",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "spa": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Hurricane"], ["Knock Off"], ["U-turn"], ["Defog"]]
+			}]
+		},
+		"urshifurapidstrike": {
+			"sets": [{
+				"species": "Urshifu-Rapid-Strike",
+				"item": ["Choice Band"],
+				"ability": ["Unseen Fist"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Surging Strikes"], ["Close Combat"], ["Aqua Jet"], ["U-turn"]]
+			}, {
+				"species": "Urshifu-Rapid-Strike",
+				"item": ["Protective Pads"],
+				"ability": ["Unseen Fist"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Surging Strikes"], ["Close Combat"], ["Aqua Jet", "Taunt", "Thunder Punch"], ["U-turn"]]
+			}]
+		},
+		"zapdos": {
+			"sets": [{
+				"species": "Zapdos",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Static"],
+				"evs": {"hp": 248, "def": 220, "spe": 40},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Hurricane"], ["Volt Switch"], ["Roost"], ["Defog"]]
+			}, {
+				"species": "Zapdos",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Static"],
+				"evs": {"hp": 96, "def": 100, "spa": 176, "spe": 136},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Hurricane"], ["Volt Switch"], ["Roost"], ["Heat Wave"]]
+			}]
+		},
+		"buzzwole": {
+			"sets": [{
+				"species": "Buzzwole",
+				"item": ["Rocky Helmet", "Heavy-Duty Boots"],
+				"ability": ["Beast Boost"],
+				"evs": {"hp": 152, "atk": 168, "spe": 188},
+				"nature": "Adamant",
+				"moves": [["Close Combat"], ["Ice Punch"], ["Roost"], ["Thunder Punch", "Leech Life", "Earthquake"]]
+			}]
+		},
+		"rotomwash": {
+			"sets": [{
+				"species": "Rotom-Wash",
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "spd": 168, "spe": 88},
+				"ivs": {"atk": 0},
+				"nature": "Calm",
+				"moves": [["Hydro Pump"], ["Volt Switch"], ["Thunder Wave", "Will-O-Wisp"], ["Pain Split"]]
+			}]
+		},
+		"slowbro": {
+			"sets": [{
+				"species": "Slowbro",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 248, "def": 252, "spa": 8},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Scald"], ["Teleport"], ["Future Sight"], ["Slack Off"]]
+			}, {
+				"species": "Slowbro",
+				"item": ["Colbur Berry"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 248, "def": 252, "spa": 8},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Body Press"], ["Teleport"], ["Future Sight"], ["Slack Off"]]
+			}]
+		},
+		"slowkinggalar": {
+			"sets": [{
+				"species": "Slowking-Galar",
+				"item": ["Assault Vest"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 12, "spa": 124, "spd": 120},
+				"ivs": {"atk": 0},
+				"nature": "Calm",
+				"moves": [["Future Sight", "Psychic"], ["Sludge Bomb"], ["Flamethrower"], ["Ice Beam", "Scald"]]
+			}]
+		},
+		"toxapex": {
+			"sets": [{
+				"species": "Toxapex",
+				"item": ["Black Sludge", "Rocky Helmet"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Scald"], ["Recover"], ["Haze"], ["Knock Off", "Toxic Spikes", "Toxic"]]
+			}, {
+				"species": "Toxapex",
+				"item": ["Black Sludge", "Rocky Helmet"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": "Impish",
+				"moves": [["Knock Off"], ["Recover"], ["Haze"], ["Toxic Spikes", "Toxic"]]
+			}]
+		},
+		"blacephalon": {
+			"sets": [{
+				"species": "Blacephalon",
+				"item": ["Choice Scarf"],
+				"ability": ["Beast Boost"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Shadow Ball"], ["Flamethrower"], ["Trick"], ["Overheat"]]
+			}, {
+				"species": "Blacephalon",
+				"item": ["Choice Specs"],
+				"ability": ["Beast Boost"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Shadow Ball"], ["Flamethrower"], ["Trick"], ["Fire Blast"]]
+			}]
+		},
+		"corviknight": {
+			"sets": [{
+				"species": "Corviknight",
+				"item": ["Leftovers", "Rocky Helmet"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 252, "def": 168, "spd": 88},
+				"nature": "Impish",
+				"moves": [["Body Press", "Brave Bird"], ["U-turn"], ["Defog"], ["Roost"]]
+			}]
+		},
+		"dragonite": {
+			"sets": [{
+				"species": "Dragonite",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Multiscale"],
+				"evs": {"hp": 252, "spd": 80, "spe": 176},
+				"nature": "Careful",
+				"moves": [["Ice Punch", "Dual Wingbeat"], ["Earthquake"], ["Roost"], ["Dragon Dance"]]
+			}, {
+				"species": "Dragonite",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Multiscale"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Ice Punch", "Dual Wingbeat"], ["Earthquake"], ["Fire Punch", "Roost"], ["Dragon Dance"]]
+			}]
+		},
+		"excadrill": {
+			"sets": [{
+				"species": "Excadrill",
+				"item": ["Leftovers"],
+				"ability": ["Mold Breaker"],
+				"evs": {"atk": 4, "spd": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Iron Head"], ["Earthquake"], ["Rapid Spin", "Stealth Rock"], ["Toxic", "Swords Dance"]]
+			}]
+		},
+		"slowking": {
+			"sets": [{
+				"species": "Slowking",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 248, "def": 8, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": "Calm",
+				"moves": [["Scald"], ["Teleport"], ["Future Sight"], ["Slack Off"]]
+			}]
+		},
+		"tapufini": {
+			"sets": [{
+				"species": "Tapu Fini",
+				"item": ["Choice Scarf"],
+				"ability": ["Misty Surge"],
+				"evs": {"hp": 252, "spd": 40, "spe": 216},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Scald"], ["Moonblast"], ["Trick"], ["Taunt", "Defog"]]
+			}, {
+				"species": "Tapu Fini",
+				"item": ["Leftovers"],
+				"ability": ["Misty Surge"],
+				"evs": {"hp": 252, "def": 216, "spd": 40},
+				"ivs": {"atk": 0},
+				"nature": "Calm",
+				"moves": [["Whirlpool"], ["Moonblast"], ["Nature's Madness"], ["Taunt"]]
+			}, {
+				"species": "Tapu Fini",
+				"item": ["Leftovers"],
+				"ability": ["Misty Surge"],
+				"evs": {"hp": 252, "def": 116, "spe": 140},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Calm Mind"], ["Scald"], ["Draining Kiss"], ["Taunt", "Substitute"]]
+			}]
+		},
+		"tyranitar": {
+			"sets": [{
+				"species": "Tyranitar",
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Sand Stream"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": "Careful",
+				"moves": [["Rock Blast"], ["Earthquake"], ["Stealth Rock"], ["Thunder Wave", "Toxic"]]
+			}, {
+				"species": "Tyranitar",
+				"item": ["Choice Band"],
+				"ability": ["Sand Stream"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Stone Edge"], ["Crunch"], ["Fire Punch"], ["Ice Punch", "Heavy Slam"]]
+			}]
+		},
+		"victini": {
+			"sets": [{
+				"species": "Victini",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Victory Star"],
+				"evs": {"atk": 252, "spa": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["V-create"], ["Bolt Strike"], ["Glaciate", "Encore", "Taunt"], ["U-turn"]]
+			}]
+		},
+		"volcanion": {
+			"sets": [{
+				"species": "Volcanion",
+				"item": ["Choice Specs"],
+				"ability": ["Water Absorb"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Steam Eruption"], ["Flamethrower"], ["Earth Power"], ["Sludge Wave"]]
+			}]
+		},
+		"volcarona": {
+			"sets": [{
+				"species": "Volcarona",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Flame Body"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Quiver Dance"], ["Bug Buzz", "Giga Drain"], ["Flamethrower", "Fire Blast"], ["Psychic"]]
+			}, {
+				"species": "Volcarona",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Flame Body"],
+				"evs": {"hp": 248, "def": 156, "spa": 16, "spe": 88},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Quiver Dance"], ["Roost"], ["Flamethrower"], ["Psychic", "Safeguard"]]
+			}]
+		},
+		"zeraora": {
+			"sets": [{
+				"species": "Zeraora",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Volt Absorb"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Plasma Fists"], ["Close Combat"], ["Knock Off"], ["Bulk Up", "Volt Switch", "Toxic"]]
+			}]
+		},
+		"magnezone": {
+			"sets": [{
+				"species": "Magnezone",
+				"item": ["Leftovers"],
+				"ability": ["Magnet Pull"],
+				"evs": {"hp": 4, "def": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Thunderbolt"], ["Body Press"], ["Iron Defense"], ["Toxic", "Teleport", "Magnet Rise"]]
+			}, {
+				"species": "Magnezone",
+				"item": ["Choice Specs"],
+				"ability": ["Magnet Pull"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid", "Modest"],
+				"moves": [["Thunderbolt"], ["Flash Cannon"], ["Volt Switch"], ["Toxic", "Body Press"]]
+			}]
+		},
+		"rillaboom": {
+			"sets": [{
+				"species": "Rillaboom",
+				"item": ["Life Orb"],
+				"ability": ["Grassy Surge"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"moves": [["Grassy Glide"], ["Knock Off"], ["Superpower"], ["Swords Dance"]]
+			}, {
+				"species": "Rillaboom",
+				"item": ["Choice Band"],
+				"ability": ["Grassy Surge"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Grassy Glide"], ["Knock Off"], ["Wood Hammer"], ["U-turn"]]
+			}]
+		},
+		"zapdosgalar": {
+			"sets": [{
+				"species": "Zapdos-Galar",
+				"item": ["Choice Band"],
+				"ability": ["Defiant"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Brave Bird"], ["Close Combat"], ["U-turn"], ["Thunderous Kick", "Stomping Tantrum"]]
+			}]
+		},
+		"aegislash": {
+			"sets": [{
+				"species": "Aegislash",
+				"item": ["Choice Specs", "Spell Tag"],
+				"ability": ["Stance Change"],
+				"evs": {"atk": 4, "spa": 252, "spe": 252},
+				"nature": "Modest",
+				"moves": [["Shadow Ball"], ["Flash Cannon"], ["Shadow Sneak"], ["Close Combat"]]
+			}]
+		},
+		"bisharp": {
+			"sets": [{
+				"species": "Bisharp",
+				"item": ["Choice Band"],
+				"ability": ["Defiant"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Knock Off"], ["Iron Head"], ["Sucker Punch"], ["Assurance"]]
+			}, {
+				"species": "Bisharp",
+				"item": ["Life Orb", "Black Glasses"],
+				"ability": ["Defiant"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Knock Off"], ["Iron Head"], ["Sucker Punch"], ["Swords Dance"]]
+			}]
+		},
+		"blaziken": {
+			"sets": [{
+				"species": "Blaziken",
+				"item": ["Life Orb"],
+				"ability": ["Speed Boost"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Swords Dance"], ["Flare Blitz"], ["Close Combat"], ["Thunder Punch", "Earthquake"]]
+			}]
+		},
+		"blissey": {
+			"sets": [{
+				"species": "Blissey",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Natural Cure"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Teleport"], ["Seismic Toss"], ["Soft-Boiled"], ["Toxic", "Thunder Wave"]]
+			}]
+		},
+		"hippowdon": {
+			"sets": [{
+				"species": "Hippowdon",
+				"item": ["Leftovers"],
+				"ability": ["Sand Stream"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": "Careful",
+				"moves": [["Earthquake"], ["Slack Off"], ["Stealth Rock"], ["Toxic"]]
+			}]
+		},
+		"hydreigon": {
+			"sets": [{
+				"species": "Hydreigon",
+				"item": ["Life Orb"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"moves": [["Dark Pulse"], ["Earth Power", "Flamethrower"], ["Roost"], ["Nasty Plot", "Flash Cannon"]]
+			}]
+		},
+		"mew": {
+			"sets": [{
+				"species": "Mew",
+				"item": ["Leftovers"],
+				"ability": ["Synchronize"],
+				"evs": {"hp": 252, "def": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"moves": [["Cosmic Power"], ["Stored Power"], ["Body Press", "Taunt"], ["Roost"]]
+			}, {
+				"species": "Mew",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Synchronize"],
+				"evs": {"hp": 248, "spd": 148, "spe": 112},
+				"nature": ["Jolly"],
+				"moves": [["Spikes"], ["Knock Off"], ["Taunt", "Will-O-Wisp"], ["Roost"]]
+			}]
+		},
+		"moltresgalar": {
+			"sets": [{
+				"species": "Moltres-Galar",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Berserk"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"moves": [["Nasty Plot"], ["Agility"], ["Fiery Wrath"], ["Hurricane", "Air Slash"]]
+			}]
+		},
+		"nidoking": {
+			"sets": [{
+				"species": "Nidoking",
+				"item": ["Life Orb"],
+				"ability": ["Sheer Force"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest", "Timid"],
+				"moves": [["Earth Power"], ["Sludge Wave"], ["Thunderbolt", "Thunder"], ["Flamethrower", "Ice Beam"]]
+			}]
+		},
+		"scizor": {
+			"sets": [{
+				"species": "Scizor",
+				"item": ["Leftovers", "Heavy-Duty Boots"],
+				"ability": ["Technician"],
+				"evs": {"hp": 248, "def": 172, "spd": 88},
+				"nature": "Impish",
+				"moves": [["Bullet Punch"], ["Swords Dance"], ["U-turn", "Knock Off"], ["Roost"]]
+			}, {
+				"species": "Scizor",
+				"item": ["Life Orb"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Bullet Punch"], ["Swords Dance"], ["Knock Off"], ["Superpower", "Roost"]]
+			}]
+		},
+		"skarmory": {
+			"sets": [{
+				"species": "Skarmory",
+				"item": ["Rocky Helmet"],
+				"ability": ["Sturdy"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Body Press"], ["Iron Defense"], ["Spikes"], ["Roost"]]
+			}]
+		},
+		"reuniclus": {
+			"sets": [{
+				"species": "Reuniclus",
+				"item": ["Life Orb"],
+				"ability": ["Magic Guard"],
+				"evs": {"hp": 252, "def": 212, "spe": 44},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Psyshock"], ["Calm Mind"], ["Recover"], ["Thunder", "Focus Blast"]]
+			}]
+		},
+		"jirachi": {
+			"sets": [{
+				"species": "Jirachi",
+				"item": ["Leftovers"],
+				"ability": ["Serene Grace"],
+				"evs": {"hp": 252, "spd": 184, "spe": 72},
+				"nature": "Careful",
+				"moves": [["Iron Head"], ["Wish"], ["Protect"], ["Toxic", "Body Slam"]]
+			}, {
+				"species": "Jirachi",
+				"item": ["Choice Scarf"],
+				"ability": ["Serene Grace"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Iron Head"], ["Fire Punch"], ["U-turn"], ["Trick", "Healing Wish"]]
+			}]
+		},
+		"mandibuzz": {
+			"sets": [{
+				"species": "Mandibuzz",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Overcoat"],
+				"evs": {"hp": 248, "def": 92, "spd": 152, "spe": 16},
+				"nature": "Impish",
+				"moves": [["Foul Play"], ["Roost"], ["Defog"], ["U-turn", "Knock Off"]]
+			}]
+		},
+		"tangrowth": {
+			"sets": [{
+				"species": "Tangrowth",
+				"item": ["Rocky Helmet"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": "Relaxed",
+				"moves": [["Giga Drain"], ["Knock Off"], ["Focus Blast"], ["Sleep Powder", "Stun Spore"]]
+			}]
+		}
+	}, 
+	"UU": {
+		"hippowdon": {
+			"sets": [{
+				"species": "Hippowdon",
+				"item": ["Rocky Helmet", "Leftovers"],
+				"ability": ["Sand Stream"],
+				"evs": {"hp": 252, "atk": 8, "def": 32, "spd": 216},
+				"nature": "Impish",
+				"moves": [["Earthquake"], ["Stealth Rock"], ["Toxic"], ["Slack Off"]]
+			}]
+		},
+		"scizor": {
+			"sets": [{
+				"species": "Scizor",
+				"item": ["Rocky Helmet", "Heavy-Duty Boots"],
+				"ability": ["Technician"],
+				"evs": {"hp": 248, "atk": 16, "def": 244},
+				"nature": "Adamant",
+				"moves": [["Swords Dance"], ["Bullet Punch"], ["Knock Off"], ["Roost"]]
+			}, {
+				"species": "Scizor",
+				"item": ["Rocky Helmet", "Heavy-Duty Boots"],
+				"ability": ["Technician"],
+				"evs": {"hp": 248, "atk": 16, "def": 104, "spd": 140},
+				"nature": "Adamant",
+				"moves": [["Bullet Punch"], ["U-turn"], ["Knock Off"], ["Roost"]]
+			}, {
+				"species": "Scizor",
+				"item": ["Life Orb"],
+				"ability": ["Technician"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Swords Dance"], ["Bullet Punch"], ["Knock Off"], ["Dual Wingbeat", "Bug Bite", "Superpower"]]
+			}]
+		},
+		"cobalion": {
+			"sets": [{
+				"species": "Cobalion",
+				"item": ["Leftovers", "Shuca Berry"],
+				"ability": ["Justified"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Swords Dance"], ["Close Combat"], ["Megahorn"], ["Stone Edge", "Iron Head"]]
+			}, {
+				"species": "Cobalion",
+				"item": ["Rocky Helmet", "Leftovers"],
+				"ability": ["Justified"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Close Combat"], ["Iron Head"], ["Stealth Rock"], ["Swords Dance", "Volt Switch", "Taunt"]]
+			}, {
+				"species": "Cobalion",
+				"item": ["Rocky Helmet", "Leftovers"],
+				"ability": ["Justified"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Close Combat"], ["Toxic"], ["Stealth Rock"], ["Volt Switch"]]
+			}]
+		},
+		"amoonguss": {
+			"sets": [{
+				"species": "Amoonguss",
+				"item": ["Rocky Helmet", "Black Sludge"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 220, "spd": 36},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Spore"], ["Giga Drain", "Synthesis"], ["Sludge Bomb"], ["Foul Play"]]
+            }]
+        },
+		"celesteela": {
+			"sets": [{
+				"species": "Celesteela",
+				"item": ["Leftovers"],
+				"ability": ["Beast Boost"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": "Sassy",
+				"moves": [["Heavy Slam"], ["Flamethrower"], ["Leech Seed"], ["Toxic", "Protect"]]
+			}, {
+				"species": "Celesteela",
+				"item": ["Power Herb"],
+				"ability": ["Beast Boost"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Air Slash"], ["Fire Blast"], ["Meteor Beam"], ["Autotomize"]]
+			}]
+		},
+		"diggersby": {
+			"sets": [{
+				"species": "Diggersby",
+				"item": ["Life Orb"],
+				"ability": ["Huge Power"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Swords Dance"], ["Quick Attack"], ["Earthquake"], ["Fire Punch"]]
+			}, {
+				"species": "Diggersby",
+				"item": ["Silk Scarf"],
+				"ability": ["Huge Power"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Swords Dance"], ["Quick Attack"], ["Earthquake"], ["Mega Kick"]]
+			}, {
+				"species": "Diggersby",
+				"item": ["Choice Scarf"],
+				"ability": ["Huge Power"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"moves": [["Body Slam"], ["Earthquake"], ["U-turn"], ["Fire Punch", "Knock Off"]]
+           }]
+        }, 
+		"keldeo": {
+			"sets": [{
+				"species": "Keldeo",
+				"item": ["Choice Specs"],
+				"ability": ["Justified"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Secret Sword"], ["Hydro Pump"], ["Scald"], ["Icy Wind", "Air Slash"]]
+			}, {
+				"species": "Keldeo",
+				"item": ["Leftovers"],
+				"ability": ["Justified"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Secret Sword"], ["Scald"], ["Calm Mind"], ["Air Slash", "Substitute"]]
+			}]
+		},
+		"salamence": {
+			"sets": [{
+				"species": "Salamence",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Intimidate"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Hurricane"], ["Draco Meteor"], ["Flamethrower"], ["Roost"]]
+			}, {
+				"species": "Salamence",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Intimidate"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Hurricane", "Draco Meteor"], ["Defog"], ["Flamethrower"], ["Roost"]]
+			}, {
+				"species": "Salamence",
+				"item": ["Heavy-Duty Boots", "Life Orb"],
+				"ability": ["Moxie"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Dual Wingbeat"], ["Outrage"], ["Dragon Dance"], ["Earthquake"]]
+			}, {
+				"species": "Salamence",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 252, "def": 160, "spe": 96},
+				"nature": "Impish",
+				"moves": [["Dual Wingbeat"], ["Roost"], ["Flamethrower"], ["Defog"]]
+			}, {
+				"species": "Salamence",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 252, "def": 160, "spe": 96},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Toxic"], ["Roost"], ["Flamethrower"], ["Defog"]]
+			}]
+		},
+		"tangrowth": {
+			"sets": [{
+				"species": "Tangrowth",
+				"item": ["Assault Vest"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 96, "spd": 160},
+				"nature": "Relaxed",
+				"moves": [["Power Whip"], ["Knock Off"], ["Focus Blast", "Earthquake"], ["Sludge Bomb"]]
+			}, {
+				"species": "Tangrowth",
+				"item": ["Rocky Helmet"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": "Relaxed",
+				"moves": [["Giga Drain", "Power Whip"], ["Knock Off"], ["Focus Blast", "Sludge Bomb"], ["Sleep Powder", "Synthesis"]]
+			}]
+		},
+		"primarina": {
+			"sets": [{
+				"species": "Primarina",
+				"item": ["Choice Specs"],
+				"ability": ["Torrent"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Moonblast"], ["Scald"], ["Hydro Pump"], ["Ice Beam"]]
+			}, {				
+				"species": "Primarina",
+				"item": ["Heavy-Duty Boots", "Leftovers"],
+				"ability": ["Torrent"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Moonblast"], ["Scald"], ["Rest"], ["Sleep Talk"]]
+			}, {				
+				"species": "Primarina",
+				"item": ["Leftovers"],
+				"ability": ["Torrent"],
+				"evs": {"hp": 212, "spa": 160, "spe": 136},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Moonblast"], ["Scald"], ["Ice Beam"], ["Calm Mind", "Substitute", "Protect"]]
+			}]
+		},
+		"azelf": {
+			"sets": [{
+				"species": "Azelf",
+				"item": ["Heavy-Duty Boots", "Expert Belt"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"nature": "Naive",
+				"moves": [["Psychic"], ["Knock Off", "Energy Ball"], ["Flamethrower"], ["U-turn"]]
+			}, {
+				"species": "Azelf",
+				"item": ["Life Orb", "Expert Belt"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Naive",
+				"moves": [["Psychic"], ["Nasty Plot"], ["Fire Blast"], ["Dazzling Gleam", "Energy Ball"]]
+			}]
+		},
+		"crobat": {
+			"sets": [{
+				"species": "Crobat",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Inner Focus"],
+				"evs": {"hp": 20, "atk": 204, "def": 148, "spe": 136},
+				"nature": "Jolly",
+				"moves": [["Brave Bird"], ["Roost"], ["Taunt", "Defog"], ["U-turn"]]
+			}]
+		},
+		"hydreigon": {
+			"sets": [{
+				"species": "Hydreigon",
+				"item": ["Choice Specs"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"moves": [["Dark Pulse"], ["Draco Meteor"], ["Flamethrower"], ["Roost", "U-turn"]]
+			}, {
+				"species": "Hydreigon",
+				"item": ["Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid", "Modest"],
+				"moves": [["Dark Pulse"], ["Draco Meteor"], ["U-turn"], ["Defog", "Fire Blast", "Roost"]]
+			}]
+		},
+		"nihilego": {
+			"sets": [{
+				"species": "Nihilego",
+				"item": ["Power Herb"],
+				"ability": ["Beast Boost"],
+				"evs": {"def": 80, "spa": 176, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Sludge Wave"], ["Power Gem", "Thunderbolt"], ["Meteor Beam"], ["Grass Knot"]]
+			}, {
+				"species": "Nihilego",
+				"item": ["Black Sludge"],
+				"ability": ["Beast Boost"],
+				"evs": {"def": 80, "spa": 176, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Sludge Bomb"], ["Power Gem"], ["Stealth Rock"], ["Grass Knot", "Knock Off"]]	
+			}]
+		},
+		"rotomwash": {
+			"sets": [{
+				"species": "Rotom-Wash",
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 248, "def": 12, "spe": 248},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Hydro Pump"], ["Volt Switch"], ["Will-O-Wisp", "Defog"], ["Pain Split"]]
+			}, {
+				"species": "Rotom-Wash",
+				"item": ["Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Hydro Pump"], ["Volt Switch"], ["Trick"], ["Defog"]]
+			}]
+		},
+		"skarmory": {
+			"sets": [{
+				"species": "Skarmory",
+				"item": ["Rocky Helmet", "Safety Goggles"],
+				"ability": ["Sturdy"],
+				"evs": {"hp": 252, "def": 160, "spd": 96},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Body Press"], ["Iron Defense"], ["Spikes", "Defog"], ["Roost"]]
+			}, {
+				"species": "Skarmory",
+				"item": ["Rocky Helmet"],
+				"ability": ["Sturdy"],
+				"evs": {"hp": 252, "def": 160, "spd": 96},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Body Press", "Brave Bird"], ["Toxic", "Whirlwind"], ["Spikes"], ["Roost"]]
+			}]
+		},
+		"slowking": {
+			"sets": [{
+				"species": "Slowking",
+				"item": ["Heavy-Duty Boots", "Colbur Berry"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 248, "def": 252, "spd": 8},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Scald"], ["Teleport"], ["Future Sight", "Psychic"], ["Slack Off"]]
+			}, {
+				"species": "Slowking",
+				"item": ["Colbur Berry"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 248, "def": 252, "spa": 8},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Scald"], ["Calm Mind"], ["Psyshock"], ["Slack Off"]]
+			}]
+		},
+		"thundurustherian": {
+			"sets": [{
+				"species": "Thundurus-Therian",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Volt Absorb"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"nature": "Timid",
+				"moves": [["Thunderbolt"], ["U-turn"], ["Psychic"], ["Grass Knot"]]
+			}, {
+				"species": "Thundurus-Therian",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Volt Absorb"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"nature": "Timid",
+				"moves": [["Volt Switch"], ["Focus Blast", "Knock Off"], ["Psychic"], ["Grass Knot"]]
+			}, {
+				"species": "Thundurus-Therian",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Volt Absorb"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Nasty Plot"], ["Focus Blast"], ["Psychic"], ["Thunderbolt"]]
+			}]
+		},
+		"zarude": {
+			"sets": [{
+				"species": "Zarude",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Leaf Guard"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Darkest Lariat"], ["Power Whip"], ["U-turn"], ["Jungle Healing"]]
+			}, {
+				"species": "Zarude",
+				"item": ["Choice Scarf"],
+				"ability": ["Leaf Guard"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Darkest Lariat"], ["Power Whip"], ["U-turn"], ["Close Combat"]]
+			}]
+		},
+		"chansey": {
+			"sets": [{
+				"species": "Chansey",
+				"item": ["Eviolite"],
+				"ability": ["Natural Cure"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Toxic"], ["Seismic Toss"], ["Soft-Boiled"], ["Teleport", "Aromatherapy", "Stealth Rock"]]
+			}]
+		},
+		"conkeldurr": {
+			"sets": [{
+				"species": "Conkeldurr",
+				"item": ["Flame Orb"],
+				"ability": ["Guts"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Close Combat", "Drain Punch"], ["Facade"], ["Mach Punch"], ["Knock Off"]]
+			}]
+		},
+		"excadrill": {
+			"sets": [{
+				"species": "Excadrill",
+				"item": ["Leftovers"],
+				"ability": ["Mold Breaker"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Iron Head"], ["Earthquake"], ["Rapid Spin"], ["Toxic", "Swords Dance", "Stealth Rock"]]
+			}]
+		},
+		"gyarados": {
+			"sets": [{
+				"species": "Gyarados",
+				"item": ["Heavy-Duty Boots", "Mystic Water", "Lum Berry"],
+				"ability": ["Moxie"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Waterfall"], ["Dragon Dance"], ["Ice Fang"], ["Power Whip"]]
+			}, {
+				"species": "Gyarados",
+				"item": ["Leftovers"],
+				"ability": ["Moxie"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Substitute"], ["Dragon Dance"], ["Bounce"], ["Waterfall"]]
+			}]
+		},
+		"mamoswine": {
+			"sets": [{
+				"species": "Mamoswine",
+				"item": ["Life Orb", "Never-Melt Ice"],
+				"ability": ["Oblivious"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Earthquake"], ["Icicle Crash"], ["Knock Off"], ["Ice Shard"]]
+			}]
+		},
+		"slowbrogalar": {
+			"sets": [{
+				"species": "Slowbro-Galar",
+				"item": ["Assault Vest"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "spa": 16, "spd": 240},
+				"ivs": {"atk": 0},
+				"nature": "Calm",
+				"moves": [["Future Sight", "Ice Beam"], ["Psyshock"], ["Shell Side Arm"], ["Flamethrower"]]
+			}, {
+				"species": "Slowbro-Galar",
+				"item": ["Colbur Berry", "Shuca Berry"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Calm Mind"], ["Sludge Bomb"], ["Scald"], ["Slack Off"]]
+			}, {
+				"species": "Slowbro-Galar",
+				"item": ["Colbur Berry"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Calm Mind"], ["Psyshock", "Sludge Bomb"], ["Flamethrower"], ["Slack Off"]]
+			}]
+		},
+		"zygarde10": {
+			"sets": [{
+				"species": "Zygarde-10%",
+				"item": ["Choice Band"],
+				"ability": ["Aura Break"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Thousand Arrows"], ["Outrage"], ["Extreme Speed"], ["Superpower", "Toxic"]]
+			}]
+		},
+		"hatterene": {
+			"sets": [{
+				"species": "Hatterene",
+				"item": ["Leftovers"],
+				"ability": ["Magic Bounce"],
+				"evs": {"hp": 252, "def": 244, "spa": 12},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Calm Mind"], ["Draining Kiss"], ["Psyshock", "Psychic"], ["Mystical Fire"]]
+			}]
+		},
+		"jirachi": {
+			"sets": [{
+				"species": "Jirachi",
+				"item": ["Leftovers"],
+				"ability": ["Serene Grace"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Iron Head"], ["Substitute"], ["Fire Punch"], ["Toxic"]]
+			}, {
+				"species": "Jirachi",
+				"item": ["Choice Scarf"],
+				"ability": ["Serene Grace"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Iron Head"], ["Fire Punch", "Ice Punch"], ["U-turn"], ["Trick", "Healing Wish"]]
+			}]
+		},
+		"mandibuzz": {
+			"sets": [{
+				"species": "Mandibuzz",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Overcoat"],
+				"evs": {"hp": 248, "def": 164, "spe": 96},
+				"nature": "Impish",
+				"moves": [["Foul Play"], ["Knock Off"], ["U-turn"], ["Roost"]]
+			}, {
+				"species": "Mandibuzz",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Overcoat"],
+				"evs": {"hp": 248, "def": 164, "spe": 96},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Foul Play"], ["Defog"], ["U-turn"], ["Roost"]]
+			}]
+		},
+		"moltres": {
+			"sets": [{
+				"species": "Moltres",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Flame Body"],
+				"evs": {"hp": 252, "spa": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Mystical Fire"], ["Toxic"], ["U-turn"], ["Roost"]]
+			}, {
+				"species": "Moltres",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Flame Body"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Hurricane"], ["Flamethrower"], ["U-turn"], ["Roost"]]
+			}]
+		},
+		"nidoqueen": {
+			"sets": [{
+				"species": "Nidoqueen",
+				"item": ["Life Orb"],
+				"ability": ["Sheer Force"],
+				"evs": {"hp": 120, "spa": 252, "spe": 136},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Earth Power"], ["Sludge Wave"], ["Fire Blast"], ["Stealth Rock"]]
+			}]
+		},
+		"noivern": {
+			"sets": [{
+				"species": "Noivern",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Infiltrator"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Draco Meteor", "Hurricane"], ["Flamethrower"], ["U-turn"], ["Roost"]]
+			}]
+		},
+		"rotomheat": {
+			"sets": [{
+				"species": "Rotom-Heat",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 104, "spe": 152},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Overheat"], ["Volt Switch"], ["Toxic"], ["Pain Split"]]
+			}]
+		},
+		"starmie": {
+			"sets": [{
+				"species": "Starmie",
+				"item": ["Life Orb"],
+				"ability": ["Analytic"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Hydro Pump"], ["Ice Beam"], ["Thunderbolt"], ["Recover"]]
+			}]
+		},
+		"swampert": {
+			"sets": [{
+				"species": "Swampert",
+				"item": ["Leftovers"],
+				"ability": ["Torrent"],
+				"evs": {"hp": 252, "def": 144, "spd": 112},
+				"ivs": {"spe": 0},
+				"nature": "Sassy",
+				"moves": [["Earthquake"], ["Flip Turn"], ["Stealth Rock"], ["Toxic", "Yawn"]]
+			}]
+		},
+		"tentacruel": {
+			"sets": [{
+				"species": "Tentacruel",
+				"item": ["Black Sludge"],
+				"ability": ["Liquid Ooze"],
+				"evs": {"hp": 252, "def": 96, "spe": 160},
+				"nature": "Timid",
+				"moves": [["Scald"], ["Sludge Bomb"], ["Knock Off"], ["Rapid Spin"]]
+			}]
+		},
+		"togekiss": {
+			"sets": [{
+				"species": "Togekiss",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Serene Grace"],
+				"evs": {"hp": 248, "spa": 8, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Air Slash"], ["Nasty Plot"], ["Roost"], ["Thunder Wave", "Heal Bell", "Flamethrower"]]
+			}]
+		},
+		"azumarill": {
+			"sets": [{
+				"species": "Azumarill",
+				"item": ["Choice Band"],
+				"ability": ["Huge Power"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Liquidation"], ["Play Rough"], ["Aqua Jet"], ["Knock Off", "Ice Punch"]]
+			}, {
+				"species": "Azumarill",
+				"item": ["Sitrus Berry"],
+				"ability": ["Huge Power"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Liquidation"], ["Play Rough"], ["Aqua Jet"], ["Belly Drum"]]
+			}]
+		},
+		"chandelure": {
+			"sets": [{
+				"species": "Chandelure",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Flame Body"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Flamethrower"], ["Hex"], ["Toxic", "Will-O-Wisp"], ["Taunt", "Protect"]]
+			}, {
+				"species": "Chandelure",
+				"item": ["Choice Specs"],
+				"ability": ["Flame Body"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Flamethrower"], ["Shadow Ball"], ["Fire Blast"], ["Trick", "Sleep Talk"]]
+			}]
+		},
+		"dhelmise": {
+			"sets": [{
+				"species": "Dhelmise",
+				"item": ["Colbur Berry", "Heavy-Duty Boots"],
+				"ability": ["Steelworker"],
+				"evs": {"hp": 252, "atk": 12, "spd": 136, "spe": 108},
+				"nature": "Careful",
+				"moves": [["Power Whip"], ["Poltergeist"], ["Rapid Spin"], ["Synthesis"]]
+			}]
+		},
+		"krookodile": {
+			"sets": [{
+				"species": "Krookodile",
+				"item": ["Leftovers", "Rocky Helmet", "Chople Berry"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 80, "def": 204, "spe": 224},
+				"nature": "Jolly",
+				"moves": [["Earthquake"], ["Knock Off"], ["Stealth Rock"], ["Taunt", "Toxic"]]
+			}]
+		},
+		"lycanrocdusk": {
+			"sets": [{
+				"species": "Lycanroc-Dusk",
+				"item": ["Life Orb", "Choice Band"],
+				"ability": ["Tough Claws"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Accelerock"], ["Close Combat"], ["Stone Edge"], ["Psychic Fangs"]]
+			}]
+		},
+		"necrozma": {
+			"sets": [{
+				"species": "Necrozma",
+				"item": ["Lum Berry", "Weakness Policy"],
+				"ability": ["Prism Armor"],
+				"evs": {"atk": 252, "spa": 4, "spe": 252},
+				"nature": "Naughty",
+				"moves": [["Photon Geyser"], ["Heat Wave"], ["Dragon Dance"], ["X-Scissor"]]
+			}, {
+				"species": "Necrozma",
+				"item": ["Power Herb"],
+				"ability": ["Prism Armor"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"nature": "Modest",
+				"moves": [["Photon Geyser"], ["Heat Wave"], ["Meteor Beam"], ["Autotomize", "Stealth Rock"]]
+			}, {
+				"species": "Necrozma",
+				"item": ["Colbur Berry"],
+				"ability": ["Prism Armor"],
+				"evs": {"hp": 252, "def": 72, "spa": 156, "spe": 28},
+				"nature": "Bold",
+				"moves": [["Photon Geyser"], ["Heat Wave"], ["Calm Mind"], ["Moonlight"]]
+			}]
+		},
+		"nidoking": {
+			"sets": [{
+				"species": "Nidoking",
+				"item": ["Life Orb"],
+				"ability": ["Sheer Force"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest"],
+				"moves": [["Earth Power"], ["Sludge Wave"], ["Fire Blast"], ["Thunderbolt", "Substitute"]]
+			}]
+		},
+		"raikou": {
+			"sets": [{
+				"species": "Raikou",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Inner Focus"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"moves": [["Volt Switch"], ["Scald"], ["Thunderbolt"], ["Aura Sphere"]]
+			}]
+		},
+		"registeel": {
+			"sets": [{
+				"species": "Registeel",
+				"item": ["Chesto Berry"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": ["Bold"],
+				"moves": [["Body Press"], ["Iron Defense"], ["Amnesia"], ["Rest"]]
+			}, {
+				"species": "Registeel",
+				"item": ["Leftovers"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": ["Careful"],
+				"moves": [["Body Press", "Seismic Toss"], ["Earthquake"], ["Toxic", "Thunder Wave"], ["Stealth Rock"]]
+			}]
+		},
+		"crawdaunt": {
+			"sets": [{
+				"species": "Crawdaunt",
+				"item": ["Choice Band"],
+				"ability": ["Adaptability"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant"],
+				"moves": [["Crabhammer"], ["Knock Off"], ["Aqua Jet"], ["Close Combat"]]
+			}]
+		},
+		"entei": {
+			"sets": [{
+				"species": "Entei",
+				"item": ["Choice Band"],
+				"ability": ["Inner Focus"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly"],
+				"moves": [["Sacred Fire"], ["Flare Blitz"], ["Stone Edge"], ["Extreme Speed"]]
+			}]
+		},
+		"reuniclus": {
+			"sets": [{
+				"species": "Reuniclus",
+				"item": ["Life Orb"],
+				"ability": ["Magic Guard"],
+				"evs": {"hp": 188, "def": 32, "spa": 252, "spd": 36},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Psychic"], ["Focus Blast"], ["Recover"], ["Thunder"]]
+			}]
+		},
+		"rhyperior": {
+			"sets": [{
+				"species": "Rhyperior",
+				"item": ["Leftovers"],
+				"ability": ["Solid Rock"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": "Careful",
+				"moves": [["Earthquake"], ["Stone Edge"], ["Stealth Rock"], ["Heat Crash", "Toxic"]]
+			}]
+		},
+		"tapubulu": {
+			"sets": [{
+				"species": "Tapu Bulu",
+				"item": ["Life Orb"],
+				"ability": ["Grassy Surge"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"moves": [["Horn Leech"], ["Stone Edge"], ["Zen Headbutt"], ["Swords Dance"]]
+			}, {
+				"species": "Tapu Bulu",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Grassy Surge"],
+				"evs": {"hp": 252, "def": 120, "spe": 136},
+				"nature": "Impish",
+				"moves": [["Horn Leech"], ["Dazzling Gleam"], ["Synthesis"], ["Toxic"]]
+			}]
+		},
+		"suicune": {
+			"sets": [{
+				"species": "Suicune",
+				"item": ["Leftovers"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Calm Mind"], ["Scald"], ["Rest"], ["Sleep Talk"]]
+			}]
+		},
+		"jellicent": {
+			"sets": [{
+				"species": "Jellicent",
+				"item": ["Leftovers"],
+				"ability": ["Water Absorb"],
+				"evs": {"hp": 252, "def": 56, "spe": 200},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Recover"], ["Hex"], ["Will-O-Wisp"], ["Taunt"]]
+			}]
+		},
+		"roserade": {
+			"sets": [{
+				"species": "Roserade",
+				"item": ["Black Sludge"],
+				"ability": ["Natural Cure"],
+				"evs": {"hp": 248, "def": 8, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Spikes"], ["Giga Drain"], ["Sludge Bomb"], ["Synthesis", "Sleep Powder"]]
+			}]
+		},
+		"salazzle": {
+			"sets": [{
+				"species": "Salazzle",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Corrosion"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Flamethrower"], ["Sludge Wave"], ["Toxic"], ["Knock Off"]]
+			}]
+		},
+		"vanilluxe": {
+			"sets": [{
+				"species": "Vanilluxe",
+				"item": ["Choice Specs"],
+				"ability": ["Snow Warning"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Blizzard"], ["Freeze-Dry"], ["Sleep Talk"]]
+			}]
+		},
+		"gastrodon": {
+			"sets": [{
+				"species": "Gastrodon",
+				"item": ["Float Stone", "Leftovers"],
+				"ability": ["Storm Drain"],
+				"evs": {"hp": 252, "def": 84, "spd": 172},
+				"ivs": {"atk": 0},
+				"nature": "Sassy",
+				"moves": [["Scald", "Ice Beam"], ["Earthquake"], ["Recover"], ["Toxic"]]
+			}]
+		}
+	},
+	"RU": {
+		"crobat": {
+			"sets": [{
+				"species": "Crobat",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Inner Focus"],
+				"evs": {"hp": 252, "def": 56, "spe": 200},
+				"nature": "Jolly",
+				"moves": [["Brave Bird"], ["Roost"], ["Taunt", "Defog", "Toxic", "Super Fang"], ["U-turn"]]
+			}, {
+				"species": "Crobat",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Inner Focus", "Infiltrator"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"nature": "Timid",
+				"moves": [["Sludge Bomb"], ["Roost", "Giga Drain"], ["Heat Wave"], ["Nasty Plot"]]
+			}]
+		},
+		"flygon": {
+			"sets": [{
+				"species": "Flygon",
+				"item": ["Life Orb"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Dragon Dance"], ["Earthquake"], ["Dragon Claw"], ["Stone Edge"]]
+			}, {
+				"species": "Flygon",
+				"item": ["Lum Berry"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Dragon Dance"], ["Earthquake"], ["Dragon Claw"], ["Stone Edge"]]
+			}, {
+				"species": "Flygon",
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 172, "atk": 112, "spe": 224},
+				"nature": "Jolly",
+				"moves": [["Defog"], ["Earthquake"], ["Roost"], ["U-turn"]]
+			}, {
+				"species": "Flygon",
+				"item": ["Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"atk": 236, "spd": 20, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Stone Edge"], ["Earthquake"], ["Outrage", "Toxic"], ["U-turn"]]
+			}, {
+				"species": "Flygon",
+				"item": ["Choice Band"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Stone Edge"], ["Earthquake"], ["Outrage", "First Impression"], ["U-turn"]]
+			}]
+		},
+		"mimikyu": {
+			"sets": [{
+				"species": "Mimikyu",
+				"item": ["Life Orb"],
+				"ability": ["Disguise"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Swords Dance"], ["Drain Punch"], ["Shadow Claw"], ["Shadow Sneak"]]
+			}]
+		},
+		"registeel": {
+			"sets": [{
+				"species": "Registeel",
+				"item": ["Leftovers"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": "Careful",
+				"moves": [["Stealth Rock"], ["Body Press"], ["Heavy Slam"], ["Toxic"]]
+			}, {
+				"species": "Registeel",
+				"item": ["Leftovers"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": "Careful",
+				"moves": [["Stealth Rock"], ["Seismic Toss"], ["Heavy Slam", "Protect"], ["Toxic"]]
+			}, {
+				"species": "Registeel",
+				"item": ["Leftovers"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "def": 76, "spd": 96, "spe": 84},
+				"nature": "Careful",
+				"moves": [["Stealth Rock"], ["Body Press"], ["Iron Defense"], ["Toxic", "Heavy Slam"]]
+			}, {	
+				"species": "Registeel",
+				"item": ["Chesto Berry"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "def": 76, "spd": 96, "spe": 84},
+				"nature": "Careful",
+				"moves": [["Rest"], ["Body Press"], ["Iron Defense"], ["Toxic", "Heavy Slam"]]
+			}]
+		},
+		"reuniclus": {
+			"sets": [{
+				"species": "Reuniclus",
+				"item": ["Life Orb"],
+				"ability": ["Magic Guard"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Psyshock"], ["Calm Mind"], ["Recover"], ["Focus Blast"]]
+			}, {
+				"species": "Reuniclus",
+				"item": ["Assault Vest"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 248, "spa": 24, "spd": 236},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Psyshock"], ["Future Sight"], ["Knock Off"], ["Focus Blast"]]
+			}]
+		},
+		"togekiss": {
+			"sets": [{
+				"species": "Togekiss",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Serene Grace"],
+				"evs": {"hp": 248, "spa": 8, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Air Slash"], ["Nasty Plot"], ["Roost"], ["Heal Bell", "Flamethrower"]]
+			}, {
+				"species": "Togekiss",
+				"item": ["Choice Scarf"],
+				"ability": ["Serene Grace"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Air Slash"], ["Trick"], ["Roost"], ["Flamethrower"]]
+			}]
+		},
+		"celebi": {
+			"sets": [{
+				"species": "Celebi",
+				"item": ["Heavy-Duty Boots", "Life Orb"],
+				"ability": ["Natural Cure"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Psychic"], ["Nasty Plot"], ["Recover"], ["Aura Sphere", "Earth Power", "Leaf Storm"]]
+			}, {
+				"species": "Celebi",
+				"item": ["Leftovers", "Life Orb"],
+				"ability": ["Natural Cure"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Psychic"], ["Nasty Plot"], ["Leaf Storm"], ["Aura Sphere", "Earth Power"]]
+			}]
+		},
+		"heracross": {
+			"sets": [{
+				"species": "Heracross",
+				"item": ["Flame Orb"],
+				"ability": ["Guts"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Close Combat"], ["Megahorn"], ["Facade"], ["Knock Off"]]
+			}, {
+				"species": "Heracross",
+				"item": ["Choice Scarf"],
+				"ability": ["Moxie"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Close Combat"], ["Megahorn"], ["Stone Edge", "Spikes"], ["Knock Off"]]
+			}]
+		},
+		"incineroar": {
+			"sets": [{
+				"species": "Incineroar",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 252, "atk": 20, "spd": 236},
+				"nature": ["Sassy", "Careful"],
+				"moves": [["Knock Off"], ["Overheat"], ["Toxic", "Swords Dance"], ["U-turn"]]
+			}, {
+				"species": "Incineroar",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"moves": [["Knock Off"], ["Swords Dance"], ["Flare Blitz", "Close Combat"], ["U-turn"]]
+			}]
+		},
+		"lucario": {
+			"sets": [{
+				"species": "Lucario",
+				"item": ["Life Orb"],
+				"ability": ["Inner Focus"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Swords Dance"], ["Close Combat"], ["Meteor Mash"], ["Extreme Speed"]]
+			}]
+		},
+		"metagross": {
+			"sets": [{
+				"species": "Metagross",
+				"item": ["Leftovers"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "atk": 76, "def": 64, "spd": 100, "spe": 16}, 
+				"nature": "Impish",
+				"moves": [["Cosmic Power"], ["Body Press"], ["Meteor Mash"], ["Rest"]]
+			}, {
+				"species": "Metagross",
+				"item": ["Leftovers"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "atk": 124, "spd": 76, "spe": 56}, 
+				"nature": "Adamant",
+				"moves": [["Stealth Rock"], ["Earthquake"], ["Meteor Mash"], ["Toxic"]]
+			}, {
+				"species": "Metagross",
+				"item": ["Choice Scarf"],
+				"ability": ["Clear Body"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252}, 
+				"nature": "Jolly",
+				"moves": [["Trick"], ["Earthquake"], ["Meteor Mash"], ["Ice Punch"]]
+			}, {
+				"species": "Metagross",
+				"item": ["Choice Band"],
+				"ability": ["Clear Body"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252}, 
+				"nature": "Adamant",
+				"moves": [["Bullet Punch"], ["Earthquake"], ["Meteor Mash"], ["Zen Headbutt"]]
+			}]
+		},
+		"milotic": {
+			"sets": [{
+				"species": "Milotic",
+				"item": ["Leftovers"],
+				"ability": ["Marvel Scale"],
+				"evs": {"hp": 252, "def": 168, "spe": 88},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Scald"], ["Ice Beam", "Flip Turn"], ["Recover"], ["Haze", "Toxic"]]
+			}]
+		},
+		"nidoqueen": {
+			"sets": [{
+				"species": "Nidoqueen",
+				"item": ["Life Orb"],
+				"ability": ["Sheer Force"],
+				"evs": {"spa": 232, "spd": 24, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest", "Timid"],
+				"moves": [["Earth Power"], ["Sludge Wave"], ["Ice Beam"], ["Stealth Rock"]]
+			}]
+		},
+		"rhyperior": {
+			"sets": [{
+				"species": "Rhyperior",
+				"item": ["Leftovers"],
+				"ability": ["Solid Rock"],
+				"evs": {"hp": 252, "atk": 16, "spd": 240},
+				"nature": "Adamant",
+				"moves": [["Earthquake"], ["Stone Edge"], ["Stealth Rock"], ["Megahorn", "Toxic", "Swords Dance"]]
+			}]
+		},
+		"sharpedo": {
+			"sets": [{
+				"species": "Sharpedo",
+				"item": ["Life Orb"],
+				"ability": ["Speed Boost"],
+				"evs": {"atk": 4, "spa": 252, "spe": 252},
+				"nature": "Rash",
+				"moves": [["Hydro Pump"], ["Dark Pulse"], ["Close Combat"], ["Protect"]]
+			}, {
+				"species": "Sharpedo",
+				"item": ["Life Orb"],
+				"ability": ["Speed Boost"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Waterfall"], ["Crunch"], ["Close Combat"], ["Protect"]]
+			}]
+		},
+		"starmie": {
+			"sets": [{
+				"species": "Starmie",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Natural Cure"],
+				"evs": {"hp": 252, "spa": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Scald"], ["Rapid Spin"], ["Teleport", "Toxic"], ["Recover"]]
+			}, {
+				"species": "Starmie",
+				"item": ["Life Orb"],
+				"ability": ["Analytic"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Hydro Pump", "Surf"], ["Ice Beam"], ["Grass Knot"], ["Recover"]]
+			}]
+		},
+		"umbreon": {
+			"sets": [{
+				"species": "Umbreon",
+				"item": ["Leftovers"],
+				"ability": ["Synchronize"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": "Calm",
+				"moves": [["Foul Play"], ["Heal Bell"], ["Wish"], ["Protect"]]
+			}]
+		},
+		"xurkitree": {
+			"sets": [{
+				"species": "Xurkitree",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Beast Boost"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Thunderbolt"], ["Volt Switch"], ["Grass Knot", "Energy Ball"], ["Dazzling Gleam"]]
+			}, {
+				"species": "Xurkitree",
+				"item": ["Choice Scarf"],
+				"ability": ["Beast Boost"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Thunderbolt"], ["Volt Switch"], ["Energy Ball"], ["Dazzling Gleam"]]
+			}]
+		},
+		"bewear": {
+			"sets": [{
+				"species": "Bewear",
+				"item": ["Chople Berry", "Silk Scarf"],
+				"ability": ["Fluffy"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Adamant", "Jolly"],
+				"moves": [["Close Combat", "Drain Punch"], ["Double-Edge"], ["Swords Dance"], ["Darkest Lariat"]]
+			}, {
+				"species": "Bewear",
+				"item": ["Choice Band"],
+				"ability": ["Fluffy"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Close Combat"], ["Double-Edge"], ["Drain Punch"], ["Darkest Lariat"]]
+			}]
+		},
+		"chandelure": {
+			"sets": [{
+				"species": "Chandelure",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Flash Fire"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Fire Blast"], ["Hex", "Shadow Ball"], ["Toxic"], ["Protect", "Energy Ball"]]
+			}, {
+				"species": "Chandelure",
+				"item": ["Choice Scarf"],
+				"ability": ["Flash Fire"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Fire Blast"], ["Shadow Ball"], ["Trick"], ["Energy Ball"]]
+			}]
+		},
+		"gardevoir": {
+			"sets": [{
+				"species": "Gardevoir",
+				"item": ["Choice Scarf"],
+				"ability": ["Trace"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Moonblast"], ["Psychic"], ["Trick"], ["Healing Wish"]]
+			}, {
+				"species": "Gardevoir",
+				"item": ["Choice Specs"],
+				"ability": ["Trace"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Moonblast"], ["Psychic"], ["Focus Blast"], ["Shadow Ball"]]
+			}]
+		},
+		"heliolisk": {
+			"sets": [{
+				"species": "Heliolisk",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Dry Skin"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Thunderbolt"], ["Grass Knot"], ["Hyper Voice", "Surf"], ["U-turn", "Volt Switch"]]
+			}]
+		},
+		"noivern": {
+			"sets": [{
+				"species": "Noivern",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Infiltrator"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Draco Meteor"], ["Flamethrower"], ["U-turn", "Defog"], ["Roost"]]
+			}]
+		},
+		"steelix": {
+			"sets": [{
+				"species": "Steelix",
+				"item": ["Leftovers"],
+				"ability": ["Sturdy"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": "Careful",
+				"moves": [["Earthquake"], ["Heavy Slam"], ["Stealth Rock", "Stealth Rock", "Protect"], ["Toxic"]]
+			}]
+		},
+		"suicune": {
+			"sets": [{
+				"species": "Suicune",
+				"item": ["Leftovers"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 252, "def": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Calm Mind"], ["Scald"], ["Substitute"], ["Ice Beam"]]
+			}, {
+				"species": "Suicune",
+				"item": ["Leftovers"],
+				"ability": ["Pressure"],
+				"evs": {"hp": 252, "def": 200, "spe": 56},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Calm Mind"], ["Scald"], ["Rest"], ["Ice Beam"]]
+			}]
+		},
+		"bronzong": {
+			"sets": [{
+				"species": "Bronzong",
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": "Careful",
+				"moves": [["Stealth Rock"], ["Heavy Slam"], ["Toxic"], ["Earthquake"]]
+			}, {
+				"species": "Bronzong",
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"ivs": {"spe": 0},
+				"nature": "Sassy",
+				"moves": [["Stealth Rock"], ["Gyro Ball"], ["Toxic"], ["Earthquake"]]
+			}]
+		},
+		"dhelmise": {
+			"sets": [{
+				"species": "Dhelmise",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Steelworker"],
+				"evs": {"hp": 192, "atk": 216, "spe": 100},
+				"nature": "Adamant",
+				"moves": [["Power Whip"], ["Poltergeist"], ["Rapid Spin"], ["Synthesis"]]
+			}]
+		},
+		"diancie": {
+			"sets": [{
+				"species": "Diancie",
+				"item": ["Leftovers"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "atk": 20, "spd": 216, "spe": 20},
+				"nature": "Careful",
+				"moves": [["Diamond Storm"], ["Body Press"], ["Stealth Rock"], ["Heal Bell", "Toxic"]]
+			}]
+		},
+		"gastrodon": {
+			"sets": [{
+				"species": "Gastrodon",
+				"item": ["Leftovers"],
+				"ability": ["Storm Drain"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Earth Power"], ["Ice Beam"], ["Recover"], ["Toxic", "Scald", "Clear Smog"]]
+			}]
+		},
+		"jellicent": {
+			"sets": [{
+				"species": "Jellicent",
+				"item": ["Leftovers"],
+				"ability": ["Water Absorb"],
+				"evs": {"hp": 252, "def": 212, "spe": 44},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Recover"], ["Hex"], ["Will-O-Wisp", "Scald"], ["Taunt"]]
+			}]
+		},
+		"pangoro": {
+			"sets": [{
+				"species": "Pangoro",
+				"item": ["Choice Band"],
+				"ability": ["Scrappy"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Close Combat"], ["Knock Off"], ["Iron Head"], ["Darkest Lariat", "Bullet Punch"]]
+			}, {
+				"species": "Pangoro",
+				"item": ["Life Orb"],
+				"ability": ["Iron Fist"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Drain Punch"], ["Knock Off"], ["Iron Head", "Bullet Punch"], ["Swords Dance"]]
+			}]
+		},
+		"raikou": {
+			"sets": [{
+				"species": "Raikou",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Inner Focus"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"moves": [["Volt Switch"], ["Scald"], ["Thunderbolt"], ["Toxic"]]
+			}, {
+				"species": "Raikou",
+				"item": ["Leftovers"],
+				"ability": ["Inner Focus"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid"],
+				"moves": [["Calm Mind"], ["Scald"], ["Thunderbolt"], ["Aura Sphere", "Shadow Ball", "Substitute"]]
+			}]
+		},
+		"roserade": {
+			"sets": [{
+				"species": "Roserade",
+				"item": ["Black Sludge"],
+				"ability": ["Natural Cure"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Spikes"], ["Giga Drain", "Leaf Storm"], ["Sludge Bomb"], ["Synthesis", "Sleep Powder"]]
+			}]
+		},
+		"rotommow": {
+			"sets": [{
+				"species": "Rotom-Mow",
+				"item": ["Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Leaf Storm"], ["Volt Switch"], ["Trick"], ["Thunderbolt", "Defog"]]
+			}, {
+				"species": "Rotom-Mow",
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Leaf Storm"], ["Nasty Plot"], ["Thunderbolt"], ["Pain Split", "Volt Switch"]]
+			}]
+		},
+		"snorlax": {
+			"sets": [{
+				"species": "Snorlax",
+				"item": ["Leftovers"],
+				"ability": ["Thick Fat"],
+				"evs": {"hp": 208, "atk": 44, "def": 172, "spd": 84},
+				"ivs": {"atk": 0},
+				"nature": "Careful",
+				"moves": [["Curse"], ["Body Slam"], ["Earthquake", "Darkest Lariat"], ["Rest"]]
+			}]
+		},
+		"stakataka": {
+			"sets": [{
+				"species": "Stakataka",
+				"item": ["Leftovers"],
+				"ability": ["Beast Boost"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"ivs": {"spe": 0},
+				"nature": "Sassy",
+				"moves": [["Stealth Rock"], ["Gyro Ball"], ["Body Press"], ["Stone Edge"]]
+			}]
+		},
+		"tornadus": {
+			"sets": [{
+				"species": "Tornadus",
+				"item": [""],
+				"ability": ["Defiant"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Acrobatics"], ["Knock Off"], ["Superpower"], ["U-turn"]]
+			}, {
+				"species": "Tornadus",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Defiant"],
+				"evs": {"atk": 4, "spa": 252, "spe": 252},
+				"nature": "Timid",
+				"moves": [["Hurricane"], ["Knock Off"], ["Grass Knot"], ["U-turn"]]
+			}]
+		},
+		"klefki": {
+			"sets": [{
+				"species": "Klefki",
+				"item": ["Leftovers"],
+				"ability": ["Prankster"],
+				"evs": {"hp": 252, "spd": 240, "spe": 16},
+				"nature": "Calm",
+				"moves": [["Thunder Wave"], ["Spikes"], ["Dazzling Gleam"], ["Toxic", "Magnet Rise"]]
+			}]
+		},
+		"seismitoad": {
+			"sets": [{
+				"species": "Seismitoad",
+				"item": ["Leftovers"],
+				"ability": ["Water Absorb"],
+				"evs": {"hp": 252, "def": 232, "spe": 24},
+				"nature": "Impish",
+				"moves": [["Earthquake"], ["Knock Off"], ["Toxic"], ["Stealth Rock"]]
+			}, {
+				"species": "Seismitoad",
+				"item": ["Leftovers"],
+				"ability": ["Water Absorb"],
+				"evs": {"hp": 112, "atk": 252, "spe": 144},
+				"nature": "Adamant",
+				"moves": [["Earthquake"], ["Power Whip"], ["Knock Off", "Ice Punch"], ["Stealth Rock"]]
+			}, {
+				"species": "Seismitoad",
+				"item": ["Choice Band"],
+				"ability": ["Water Absorb"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Earthquake"], ["Knock Off"], ["Power Whip"], ["Liquidation", "Ice Punch"]]
+			}]
+		},
+		"sigilyph": {
+			"sets": [{
+				"species": "Sigilyph",
+				"item": ["Life Orb"],
+				"ability": ["Magic Guard"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Air Slash"], ["Heat Wave"], ["Roost"], ["Energy Ball", "Calm Mind", "Defog"]]
+			}, {
+				"species": "Sigilyph",
+				"item": ["Flame Orb"],
+				"ability": ["Magic Guard"],
+				"evs": {"hp": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Air Slash"], ["Psycho Shift"], ["Roost"], ["Calm Mind"]]
+			}]
+		},
+		"toxicroak": {
+			"sets": [{
+				"species": "Toxicroak",
+				"item": ["Life Orb"],
+				"ability": ["Dry Skin"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Sludge Bomb"], ["Focus Blast"], ["Shadow Ball"], ["Nasty Plot"]]
+			}, {
+				"species": "Toxicroak",
+				"item": ["Life Orb"],
+				"ability": ["Dry Skin"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Swords Dance"], ["Gunk Shot"], ["Drain Punch"], ["Sucker Punch", "Knock Off"]]
+			}]
+		},
+		"tyrantrum": {
+			"sets": [{
+				"species": "Tyrantrum",
+				"item": ["Life Orb", "Lum Berry"],
+				"ability": ["Rock Head"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Head Smash"], ["Close Combat", "Earthquake"], ["Dragon Dance"], ["Scale Shot"]]
+			}, {
+				"species": "Tyrantrum",
+				"item": ["Choice Scarf"],
+				"ability": ["Rock Head"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Head Smash"], ["Close Combat"], ["Earthquake"], ["Outrage"]]
+			}]
+		},
+		"vileplume": {
+			"sets": [{
+				"species": "Vileplume",
+				"item": ["Black Sludge"],
+				"ability": ["Effect Spore"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Strength Sap"], ["Sludge Bomb"], ["Giga Drain"], ["Corrosive Gas", "Sleep Powder"]]
+			}]
+		},
+		"weezinggalar": {
+			"sets": [{
+				"species": "Weezing-Galar",
+				"item": ["Black Sludge"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Strange Steam"], ["Will-O-Wisp"], ["Pain Split"], ["Defog", "Toxic Spikes"]]
+			}]
+		},
+		"decidueye": {
+			"sets": [{
+				"species": "Decidueye",
+				"item": ["Choice Band"],
+				"ability": ["Long Reach"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Leaf Blade"], ["Poltergeist"], ["U-turn"], ["Shadow Sneak"]]
+			}]
+		},
+		"entei": {
+			"sets": [{
+				"species": "Entei",
+				"item": ["Choice Band"],
+				"ability": ["Inner Focus"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Sacred Fire"], ["Stone Edge"], ["Extreme Speed"], ["Flare Blitz", "Iron Head", "Toxic"]]
+			}]
+		},
+		"escavalier": {
+			"sets": [{
+				"species": "Escavalier",
+				"item": ["Leftovers"],
+				"ability": ["Shell Armor", "Overcoat"],
+				"evs": {"hp": 248, "atk": 16, "spd": 160, "spe": 84},
+				"nature": "Careful",
+				"moves": [["Iron Head"], ["Megahorn", "Close Combat"], ["Knock Off"], ["Swords Dance"]]
+			}]
+		},
+		"golurk": {
+			"sets": [{
+				"species": "Golurk",
+				"item": ["Choice Band"],
+				"ability": ["No Guard"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Earthquake"], ["Poltergeist"], ["Close Combat"], ["Trick"]]
+			}, {
+				"species": "Golurk",
+				"item": ["Choice Band"],
+				"ability": ["Iron Fist"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Earthquake"], ["Poltergeist"], ["Close Combat"], ["Shadow Punch"]]
+			}]
+		},
+		"goodra": {
+			"sets": [{
+				"species": "Goodra",
+				"item": ["Expert Belt"],
+				"ability": ["Sap Sipper"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Draco Meteor"], ["Fire Blast"], ["Hydro Pump"], ["Thunderbolt", "Thunder"]]
+			}]
+		},
+		"indeedee": {
+			"sets": [{
+				"species": "Indeedee",
+				"item": ["Choice Specs"],
+				"ability": ["Psychic Surge"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Expanding Force"], ["Mystical Fire", "Shadow Ball"], ["Hyper Voice"], ["Trick", "Dazzling Gleam"]]
+			}, {
+				"species": "Indeedee",
+				"item": ["Choice Scarf"],
+				"ability": ["Psychic Surge"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Expanding Force"], ["Mystical Fire"], ["Hyper Voice"], ["Trick"]]
+			}]
+		},
+		"polteageist": {
+			"sets": [{
+				"species": "Polteageist",
+				"item": ["White Herb"],
+				"ability": ["Cursed Body"],
+				"evs": {"hp": 28, "def": 32, "spa": 252, "spe": 196},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Shell Smash"], ["Shadow Ball"], ["Strength Sap"], ["Giga Drain", "Stored Power"]]
+			}]
+		},
+		"salazzle": {
+			"sets": [{
+				"species": "Salazzle",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Corrosion"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Fire Blast"], ["Sludge Wave"], ["Toxic"], ["Knock Off", "Nasty Plot"]]
+			}]
+		},
+		"toxtricity": {
+			"sets": [{
+				"species": "Toxtricity",
+				"item": ["Choice Specs"],
+				"ability": ["Punk Rock"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Boomburst"], ["Volt Switch"], ["Overdrive"], ["Snarl"]]
+			}]
+		},
+		"tsareena": {
+			"sets": [{
+				"species": "Tsareena",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Queenly Majesty"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Power Whip"], ["Rapid Spin"], ["Knock Off"], ["Triple Axel"]]
+			}]
+		},
+		"vaporeon": {
+			"sets": [{
+				"species": "Vaporeon",
+				"item": ["Leftovers"],
+				"ability": ["Water Absorb"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"nature": "Bold",
+				"moves": [["Scald"], ["Flip Turn", "Heal Bell"], ["Wish"], ["Protect"]]
+			}]
+		},
+		"xatu": {
+			"sets": [{
+				"species": "Xatu",
+				"item": ["Rocky Helmet"],
+				"ability": ["Magic Bounce"],
+				"evs": {"hp": 252, "def": 240, "spe": 16},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Future Sight", "Grass Knot"], ["Heat Wave"], ["Roost"], ["Teleport"]]
+			}]
+		},
+		"aerodactyl": {
+			"sets": [{
+				"species": "Aerodactyl",
+				"item": ["Heavy-Duty Boots", "Life Orb"],
+				"ability": ["Unnerve"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Stone Edge"], ["Dual Wingbeat"], ["Earthquake"], ["Roost"]]
+			}, {
+				"species": "Aerodactyl",
+				"item": ["Life Orb"],
+				"ability": ["Unnerve"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": ["Jolly", "Adamant"],
+				"moves": [["Stone Edge"], ["Dual Wingbeat"], ["Earthquake"], ["Dragon Dance"]]
+			}]
+		},
+		"cloyster": {
+			"sets": [{
+				"species": "Cloyster",
+				"item": ["Heavy-Duty Boots", "Life Orb"],
+				"ability": ["Skill Link"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Shell Smash"], ["Icicle Spear"], ["Rock Blast", "Explosion"], ["Spikes", "Liquidation", "Ice Shard"]]
+			}, {
+			}]
+		},
+		"gigalith": {
+			"sets": [{
+				"species": "Gigalith",
+				"item": ["Leftovers"],
+				"ability": ["Sand Stream"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": "Careful",
+				"moves": [["Stone Edge"], ["Earthquake"], ["Stealth Rock"], ["Heavy Slam", "Toxic", "Protect"]]
+			}]
+		},
+		"grimmsnarl": {
+			"sets": [{
+				"species": "Grimmsnarl",
+				"item": ["Choice Band"],
+				"ability": ["Prankster"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Superpower"], ["Darkest Lariat"], ["Play Rough"], ["Trick"]]
+			}]
+		},
+		"linoone": {
+			"sets": [{
+				"species": "Linoone",
+				"item": ["Figy Berry"],
+				"ability": ["Gluttony"],
+				"evs": {"hp": 60, "atk": 252, "spe": 196},
+				"nature": "Adamant",
+				"moves": [["Belly Drum"], ["Extreme Speed"], ["Stomping Tantrum"], ["Throat Chop", "Seed Bomb"]]
+			}]
+		},
+		"regidrago": {
+			"sets": [{
+				"species": "Regidrago",
+				"item": ["Leftovers"],
+				"ability": ["Dragon's Maw"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Dragon Dance"], ["Outrage"], ["Thunder Fang"], ["Substitute"]]
+			}]
+		},
+		"talonflame": {
+			"sets": [{
+				"species": "Talonflame",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Flame Body"],
+				"evs": {"hp": 16, "atk": 252,"spe": 240},
+				"nature": "Jolly",
+				"moves": [["Will-O-Wisp", "Defog"], ["Brave Bird"], ["U-turn"], ["Roost"]]
+			}]
+		},
+		"slurpuff": {
+			"sets": [{
+				"species": "Slurpuff",
+				"item": ["Sitrus Berry"],
+				"ability": ["Unburden"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Belly Drum"], ["Play Rough"], ["Drain Punch"], ["Facade"]]
+			}]
+		}
+	},
+	"NU": {
+		"mudsdale": {
+			"sets": [{
+				"species": "Mudsdale",
+				"item": ["Leftovers"],
+				"ability": ["Stamina"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": "Impish",
+				"moves": [["Earthquake"], ["Stealth Rock"], ["Body Press"], ["Iron Defense", "Toxic"]]
+			}, {
+				"species": "Mudsdale",
+				"item": ["Leftovers"],
+				"ability": ["Stamina"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": "Impish",
+				"moves": [["Earthquake"], ["Stealth Rock"], ["Toxic"], ["Protect"]]
+			}]
+		},
+		"rotommow": {
+			"sets": [{
+				"species": "Rotom-Mow",
+				"item": ["Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Leaf Storm"], ["Volt Switch"], ["Trick"], ["Thunderbolt", "Pain Split", "Defog", "Nasty Plot"]]
+			}, {
+				"species": "Rotom-Mow",
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Leaf Storm"], ["Nasty Plot"], ["Volt Switch"], ["Pain Split"]]
+			}, {
+				"species": "Rotom-Mow",
+				"item": ["Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Leaf Storm"], ["Defog"], ["Volt Switch"], ["Pain Split", "Will-O-Wisp"]]
+			}]
+		},
+		"silvallyground": {
+			"sets": [{
+				"species": "Silvally-Ground",
+				"item": ["Ground Memory"],
+				"ability": ["RKS System"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Multi-Attack"], ["Swords Dance"], ["Rock Slide"], ["U-turn", "Flame Charge"]]
+			}, {
+				"species": "Silvally-Ground",
+				"item": ["Ground Memory"],
+				"ability": ["RKS System"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Multi-Attack"], ["Defog"], ["Rock Slide"], ["U-turn"]]
+			}]
+		},
+		"copperajah": {
+			"sets": [{
+				"species": "Copperajah",
+				"item": ["Assault Vest"],
+				"ability": ["Sheer Force"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Iron Head"], ["Power Whip"], ["Rock Slide"], ["Superpower", "Heat Crash"]]
+			}, {
+				"species": "Copperajah",
+				"item": ["Leftovers"],
+				"ability": ["Heavy Metal"],
+				"evs": {"hp": 156, "atk": 16, "spd": 252, "spe": 84},
+				"nature": "Adamant",
+				"moves": [["Iron Head"], ["Power Whip"], ["Rock Slide"], ["Stealth Rock"]]
+			}]
+		},
+		"indeedeef": {
+			"sets": [{
+				"species": "Indeedee-F",
+				"item": ["Choice Scarf", "Choice Specs"],
+				"ability": ["Psychic Surge"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Expanding Force"], ["Mystical Fire"], ["Dazzling Gleam"], ["Healing Wish", "Trick"]]
+			}, {
+				"species": "Indeedee-F",
+				"item": ["Heavy-Duty Boots", "Twisted Spoon"],
+				"ability": ["Psychic Surge"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Expanding Force"], ["Mystical Fire"], ["Dazzling Gleam"], ["Calm Mind"]]
+			}]
+		},
+		"salazzle": {
+			"sets": [{
+				"species": "Salazzle",
+				"item": ["Heavy-Duty Boots", "Focus Sash"],
+				"ability": ["Oblivious"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Fire Blast", "Flamethrower"], ["Sludge Wave", "Sludge Bomb"], ["Overheat"], ["Nasty Plot"]]
+			}]
+		},
+		"stakataka": {
+			"sets": [{
+				"species": "Stakataka",
+				"item": ["Leftovers"],
+				"ability": ["Beast Boost"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"ivs": {"spe": 0},
+				"nature": "Sassy",
+				"moves": [["Stealth Rock"], ["Gyro Ball"], ["Body Press"], ["Toxic", "Rock Blast", "Iron Defense"]]
+			}, {
+				"species": "Stakataka",
+				"item": ["Life Orb"],
+				"ability": ["Beast Boost"],
+				"evs": {"hp": 252, "atk": 252, "spd": 4},
+				"ivs": {"def": 15, "spe": 0},
+				"nature": "Lonely",
+				"moves": [["Trick Room"], ["Gyro Ball"], ["Earthquake", "Superpower"], ["Stone Edge", "Rock Blast"]]
+			}]
+		},
+		"sylveon": {
+			"sets": [{
+				"species": "Sylveon",
+				"item": ["Leftovers"],
+				"ability": ["Pixilate"],
+				"evs": {"hp": 252, "def": 188, "spd": 68},
+				"ivs": {"atk": 0},
+				"nature": "Calm",
+				"moves": [["Hyper Voice"], ["Heal Bell"], ["Wish"], ["Protect"]]
+			}, {
+				"species": "Sylveon",
+				"item": ["Choice Specs"],
+				"ability": ["Pixilate"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"nature": "Modest",
+				"moves": [["Hyper Voice"], ["Mystical Fire"], ["Shadow Ball"], ["Heal Bell", "Quick Attack"]]
+			}]
+		},
+		"talonflame": {
+			"sets": [{
+				"species": "Talonflame",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Flame Body"],
+				"evs": {"hp": 248, "def": 52,"spe": 208},
+				"nature": "Jolly",
+				"moves": [["Will-O-Wisp", "Defog"], ["Brave Bird"], ["U-turn"], ["Roost"]]
+			}, {
+				"species": "Talonflame",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Flame Body"],
+				"evs": {"hp": 248, "def": 52,"spe": 208},
+				"nature": "Jolly",
+				"moves": [["Toxic", "Defog"], ["Flare Blitz"], ["U-turn"], ["Roost"]]
+			}]
+		},
+		"vaporeon": {
+			"sets": [{
+				"species": "Vaporeon",
+				"item": ["Leftovers"],
+				"ability": ["Water Absorb"],
+				"evs": {"hp": 252, "def": 216, "spd": 40},
+				"ivs": {"atk": 0},
+				"nature": "Calm",
+				"moves": [["Scald"], ["Flip Turn", "Heal Bell", "Toxic", "Ice Beam"], ["Wish"], ["Protect"]]
+			}]
+		},
+		"vileplume": {
+			"sets": [{
+				"species": "Vileplume",
+				"item": ["Black Sludge", ""],
+				"ability": ["Effect Spore"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Strength Sap"], ["Sludge Bomb"], ["Giga Drain"], ["Corrosive Gas", "Sleep Powder"]]
+			}]
+		},
+		"escavalier": {
+			"sets": [{
+				"species": "Escavalier",
+				"item": ["Leftovers"],
+				"ability": ["Shell Armor", "Overcoat"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": "Careful",
+				"moves": [["Iron Head"], ["Toxic"], ["Knock Off"], ["Protect"]]
+			}]
+		},
+		"exeggutoralola": {
+			"sets": [{
+				"species": "Exeggutor-Alola",
+				"item": ["Sitrus Berry"],
+				"ability": ["Harvest"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Leaf Storm"], ["Draco Meteor"], ["Flamethrower"], ["Teleport"]]
+			}, {
+				"species": "Exeggutor-Alola",
+				"item": ["Life Orb", "Choice Specs"],
+				"ability": ["Frisk"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Leaf Storm"], ["Draco Meteor"], ["Flamethrower"], ["Giga Drain"]]
+			}]
+		},
+		"snorlax": {
+			"sets": [{
+				"species": "Snorlax",
+				"item": ["Leftovers"],
+				"ability": ["Thick Fat"],
+				"evs": {"hp": 12, "def": 244, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": "Careful",
+				"moves": [["Curse"], ["Body Slam"], ["Earthquake", "Fire Punch"], ["Rest"]]
+			}]
+		},
+		"toxicroak": {
+			"sets": [{
+				"species": "Toxicroak",
+				"item": ["Life Orb"],
+				"ability": ["Dry Skin"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": ["Jolly", "Adamant"],
+				"moves": [["Swords Dance"], ["Gunk Shot"], ["Drain Punch", "Low Kick"], ["Sucker Punch", "Knock Off", "Earthquake"]]
+			}]
+		},
+		"tsareena": {
+			"sets": [{
+				"species": "Tsareena",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Queenly Majesty"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Power Whip"], ["Rapid Spin"], ["Knock Off"], ["U-turn", "Synthesis"]]
+			}, {
+				"species": "Tsareena",
+				"item": ["Protective Pads"],
+				"ability": ["Queenly Majesty"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Power Whip"], ["Rapid Spin"], ["Knock Off"], ["Triple Axel"]]
+			}]
+		},
+		"xatu": {
+			"sets": [{
+				"species": "Xatu",
+				"item": ["Rocky Helmet"],
+				"ability": ["Magic Bounce"],
+				"evs": {"hp": 252, "def": 240, "spe": 16},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Psychic"], ["Foul Play", "Grass Knot", "Night Shade"], ["Roost"], ["Teleport"]]
+			}]
+		},
+		"decidueye": {
+			"sets": [{
+				"species": "Decidueye",
+				"item": ["Choice Band", "Spell Tag"],
+				"ability": ["Long Reach"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Leaf Blade"], ["Poltergeist"], ["U-turn"], ["Shadow Sneak"]]
+			}, {
+				"species": "Decidueye",
+				"item": ["Choice Specs"],
+				"ability": ["Overgrow"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Shadow Ball"], ["Leaf Storm"], ["Giga Drain"], ["U-turn"]]
+			}, {
+				"species": "Decidueye",
+				"item": ["Spell Tag"],
+				"ability": ["Long Reach"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Leaf Blade"], ["Poltergeist", "Spirit Shackle"], ["Swords Dance"], ["Shadow Sneak"]]
+			}]
+		},
+		"drapion": {
+			"sets": [{
+				"species": "Drapion",
+				"item": ["Shuca Berry", "Black Sludge"],
+				"ability": ["Battle Armor"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Knock Off"], ["Poison Jab"], ["Swords Dance"], ["Aqua Tail", "Earthquake"]]
+			}]
+		},
+		"gastrodon": {
+			"sets": [{
+				"species": "Gastrodon",
+				"item": ["Leftovers"],
+				"ability": ["Storm Drain"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"ivs": {"atk": 0},
+				"nature": "Calm",
+				"moves": [["Earth Power"], ["Ice Beam"], ["Recover"], ["Toxic", "Scald", "Clear Smog"]]
+			}]
+		},
+		"heliolisk": {
+			"sets": [{
+				"species": "Heliolisk",
+				"item": ["Heavy-Duty Boots", "Choice Specs", "Choice Scarf"],
+				"ability": ["Dry Skin"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Thunderbolt"], ["Grass Knot", "Dark Pulse"], ["Hyper Voice"], ["Volt Switch"]]
+			}]
+		},
+		"quagsire": {
+			"sets": [{
+				"species": "Quagsire",
+				"item": ["Leftovers"],
+				"ability": ["Unaware"],
+				"evs": {"hp": 252, "def": 188, "spd": 68},
+				"ivs": {"atk": 0},
+				"nature": "Impish",
+				"moves": [["Earthquake"], ["Scald", "Protect"], ["Recover"], ["Toxic"]]
+			}]
+		},
+		"starmie": {
+			"sets": [{
+				"species": "Starmie",
+				"item": ["Life Orb"],
+				"ability": ["Analytic"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Hydro Pump"], ["Ice Beam", "Psyshock"], ["Thunderbolt"], ["Recover"]]
+			}, {
+				"species": "Starmie",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Natural Cure"],
+				"evs": {"hp": 252, "def": 40, "spe": 216},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Scald"], ["Rapid Spin"], ["Teleport"], ["Recover"]]
+			}]
+		},
+		"tauros": {
+			"sets": [{
+				"species": "Tauros",
+				"item": ["Life Orb"],
+				"ability": ["Sheer Force"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Body Slam"], ["Throat Chop"], ["Close Combat"], ["Iron Head"]]
+			}]
+		},
+		"aerodactyl": {
+			"sets": [{
+				"species": "Aerodactyl",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Unnerve"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Stone Edge"], ["Toxic", "Stealth Rock"], ["Earthquake"], ["Roost"]]
+			}, {
+				"species": "Aerodactyl",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Unnerve", "Pressure"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Stone Edge"], ["Dual Wingbeat", "Aqua Tail"], ["Earthquake"], ["Dragon Dance"]]
+			}]
+		},
+		"blastoise": {
+			"sets": [{
+				"species": "Blastoise",
+				"item": ["White Herb"],
+				"ability": ["Torrent"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Shell Smash"], ["Surf"], ["Dark Pulse"], ["Ice Beam", "Substitute"]]
+			}]
+		},
+		"diancie": {
+			"sets": [{
+				"species": "Diancie",
+				"item": ["Leftovers"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "spd": 56, "spe": 200},
+				"nature": "Careful",
+				"moves": [["Diamond Storm"], ["Body Press"], ["Stealth Rock"], ["Heal Bell", "Moonblast"]]
+			}]
+		},
+		"guzzlord": {
+			"sets": [{
+				"species": "Guzzlord",
+				"item": ["Choice Band"],
+				"ability": ["Beast Boost"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Knock Off"], ["Heavy Slam"], ["Earthquake", "Drain Punch"], ["Outrage"]]
+			}, {
+				"species": "Guzzlord",
+				"item": ["Choice Band"],
+				"ability": ["Beast Boost"],
+				"evs": {"def": 76, "spd": 252, "spe": 180},
+				"nature": "Careful",
+				"moves": [["Knock Off"], ["Heavy Slam", "Earthquake"], ["Toxic"], ["Protect"]]
+			}]
+		},
+		"mantine": {
+			"sets": [{
+				"species": "Mantine",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Water Absorb"],
+				"evs": {"hp": 252, "def": 120, "spe": 136},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Scald"], ["Roost"], ["Defog", "Toxic"], ["Hurricane"]]
+			}]
+		},
+		"passimian": {
+			"sets": [{
+				"species": "Passimian",
+				"item": ["Choice Scarf", "Choice Band", "Protective Pads"],
+				"ability": ["Defiant"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Knock Off"], ["Close Combat"], ["U-turn"], ["Rock Slide", "Gunk Shot"]]
+			}]
+		},
+		"scrafty": {
+			"sets": [{
+				"species": "Scrafty",
+				"item": ["Leftovers"],
+				"ability": ["Shed Skin"],
+				"evs": {"hp": 252, "spd": 164, "spe": 92},
+				"nature": "Careful",
+				"moves": [["Knock Off"], ["Drain Punch"], ["Bulk Up"], ["Rest"]]
+			}]
+		},
+		"silvallysteel": {
+			"sets": [{
+				"species": "Silvally-Steel",
+				"item": ["Steel Memory"],
+				"ability": ["RKS System"],
+				"evs": {"hp": 252, "spd": 192, "spe": 64},
+				"nature": "Jolly",
+				"moves": [["Multi-Attack"], ["Defog"], ["Parting Shot", "U-turn"], ["Flamethrower"]]
+			}]
+		},
+		"tyrantrum": {
+			"sets": [{
+				"species": "Tyrantrum",
+				"item": ["Life Orb", "Lum Berry"],
+				"ability": ["Rock Head"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Head Smash"], ["Close Combat"], ["Dragon Dance", "Hone Claws"], ["Scale Shot"]]
+			}, {
+				"species": "Tyrantrum",
+				"item": ["Choice Band"],
+				"ability": ["Rock Head"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Head Smash"], ["Close Combat"], ["Dragon Claw", "Scale Shot"], ["Outrage"]]
+			}]
+		},
+		"weezing": {
+			"sets": [{
+				"species": "Weezing",
+				"item": ["Rocky Helmet"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 212, "spd": 44},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Sludge Bomb"], ["Will-O-Wisp"], ["Pain Split"], ["Taunt", "Toxic Spikes"]]
+			}]
+		},
+		"araquanid": {
+			"sets": [{
+				"species": "Araquanid",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Water Bubble"],
+				"evs": {"hp": 68, "atk": 252, "spe": 188},
+				"nature": "Adamant",
+				"moves": [["Liquidation"], ["Leech Life"], ["Toxic"], ["Substitute"]]
+			}]
+		},
+		"dhelmise": {
+			"sets": [{
+				"species": "Dhelmise",
+				"item": ["", "Heavy-Duty Boots"],
+				"ability": ["Steelworker"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": "Careful",
+				"moves": [["Power Whip"], ["Poltergeist"], ["Rapid Spin"], ["Synthesis"]]
+			}]
+		},
+		"duraludon": {
+			"sets": [{
+				"species": "Duraludon",
+				"item": ["Expert Belt"],
+				"ability": ["Light Metal"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Draco Meteor"], ["Flash Cannon"], ["Thunderbolt"], ["Body Press"]]
+			}, {
+				"species": "Duraludon",
+				"item": ["Eject Pack"],
+				"ability": ["Light Metal"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Draco Meteor"], ["Flash Cannon"], ["Thunderbolt", "Stealth Rock"], ["Body Press"]]
+			}]
+		},
+		"exploud": {
+			"sets": [{
+				"species": "Exploud",
+				"item": ["Choice Specs"],
+				"ability": ["Scrappy"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest", "Timid"],
+				"moves": [["Boomburst"], ["Surf"], ["Overheat"], ["Focus Blast"]]
+			}]
+		},
+		"golurk": {
+			"sets": [{
+				"species": "Golurk",
+				"item": ["Choice Band"],
+				"ability": ["No Guard"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Earthquake"], ["Poltergeist"], ["Heat Crash"], ["Darkest Lariat"]]
+			}]
+		},
+		"grimmsnarl": {
+			"sets": [{
+				"species": "Grimmsnarl",
+				"item": ["Choice Band"],
+				"ability": ["Frisk"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Superpower"], ["Darkest Lariat"], ["Play Rough"], ["Sucker Punch"]]
+			}, {
+				"species": "Grimmsnarl",
+				"item": ["Choice Band"],
+				"ability": ["Frisk"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Superpower", "Sucker Punch"], ["Darkest Lariat"], ["Play Rough"], ["Power Whip"]]
+			}]
+		},
+		"drampa": {
+			"sets": [{
+				"species": "Drampa",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Berserk", "Sap Sipper"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Hyper Voice"], ["Surf"], ["Flamethrower"], ["Roost"]]
+			}, {
+				"species": "Drampa",
+				"item": ["Choice Specs"],
+				"ability": ["Sap Sipper"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Hyper Voice"], ["Hydro Pump"], ["Fire Blast"], ["Draco Meteor"]]
+			}, {
+				"species": "Drampa",
+				"item": ["Leftovers"],
+				"ability": ["Berserk"],
+				"evs": {"hp": 52, "spa": 204, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Hyper Voice"], ["Calm Mind"], ["Flamethrower", "Surf"], ["Roost"]]
+			}]
+		},
+		"inteleon": {
+			"sets": [{
+				"species": "Inteleon",
+				"item": ["Choice Specs"],
+				"ability": ["Torrent"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Hydro Pump"], ["Dark Pulse"], ["Ice Beam"], ["U-turn"]]
+			}]
+		},
+		"sneasel": {
+			"sets": [{
+				"species": "Sneasel",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Inner Focus"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Triple Axel", "Icicle Crash"], ["Knock Off"], ["Ice Shard"], ["Swords Dance"]]
+			}]
+		},
+		"togedemaru": {
+			"sets": [{
+				"species": "Togedemaru",
+				"item": ["Choice Scarf"],
+				"ability": ["Lightning Rod"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Zing Zap"], ["Iron Head"], ["Nuzzle", "Toxic"], ["U-turn"]]
+			}, {
+				"species": "Togedemaru",
+				"item": ["Leftovers"],
+				"ability": ["Lightning Rod"],
+				"evs": {"hp": 248, "spd": 204, "spe": 56},
+				"nature": "Jolly",
+				"moves": [["Zing Zap", "Iron Head"], ["Wish"], ["Spiky Shield"], ["U-turn", "Toxic"]]
+			}]
+		},
+		"virizion": {
+			"sets": [{
+				"species": "Virizion",
+				"item": ["Lum Berry", "Life Orb"],
+				"ability": ["Justified"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Leaf Blade"], ["Swords Dance"], ["Close Combat"], ["Stone Edge"]]
+			}]
+		},
+		"arcanine": {
+			"sets": [{
+				"species": "Arcanine",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 248, "def": 196, "spe": 64},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Flamethrower"], ["Teleport"], ["Morning Sun"], ["Toxic"]]
+			}]
+		}
+	},
+	"PU": {
+		"charizard": {
+			"sets": [{
+				"species": "Charizard",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Blaze"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Flamethrower"], ["Hurricane"], ["Roost"], ["Toxic", "Defog", "Focus Blast"]]
+			}, {
+				"species": "Charizard",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Blaze"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Flamethrower"], ["Focus Blast"], ["Roost"], ["Toxic", "Defog"]]
+			}, {
+				"species": "Charizard",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Blaze"],
+				"evs": {"hp": 248, "spa": 8, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Flamethrower"], ["Defog"], ["Roost"], ["Toxic"]]
+			}, {
+				"species": "Charizard",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Blaze"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Swords Dance"], ["Flare Blitz"], ["Roost", "Thunder Punch"], ["Earthquake"]]
+			}]
+		},
+		"gigalith": {
+			"sets": [{
+				"species": "Gigalith",
+				"item": ["Leftovers"],
+				"ability": ["Sand Stream"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": "Careful",
+				"moves": [["Stone Edge", "Rock Blast"], ["Earthquake"], ["Stealth Rock"], ["Protect", "Toxic"]]
+			}]
+		},
+		"jellicent": {
+			"sets": [{
+				"species": "Jellicent",
+				"item": ["Colbur Berry", "Heavy-Duty Boots", ""],
+				"ability": ["Water Absorb", "Cursed Body"],
+				"evs": {"hp": 252, "def": 224, "spe": 32},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Recover"], ["Hex"], ["Will-O-Wisp", "Toxic"], ["Taunt"]]
+			}, {
+				"species": "Jellicent",
+				"item": ["Choice Specs"],
+				"ability": ["Water Absorb"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Water Spout"], ["Shadow Ball"], ["Trick"], ["Surf", "Hydro Pump"]]
+			}]
+		},
+		"ribombee": {
+			"sets": [{
+				"species": "Ribombee",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Shield Dust"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Moonblast"], ["Quiver Dance"], ["Roost"], ["Psychic", "Aromatherapy", "U-turn"]]
+			}, {
+				"species": "Ribombee",
+				"item": ["Choice Specs"],
+				"ability": ["Shield Dust"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Moonblast"], ["Bug Buzz"], ["U-turn", "Switcheroo"], ["Psychic"]]
+			}]
+		},
+		"scrafty": {
+			"sets": [{
+				"species": "Scrafty",
+				"item": ["Leftovers"],
+				"ability": ["Shed Skin"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": "Careful",
+				"moves": [["Knock Off"], ["Drain Punch"], ["Bulk Up"], ["Rest"]]
+			}, {
+				"species": "Scrafty",
+				"item": ["Lum Berry"],
+				"ability": ["Moxie"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Knock Off"], ["Close Combat", "High Jump Kick"], ["Dragon Dance"], ["Iron Head"]]
+			}, {
+				"species": "Scrafty",
+				"item": ["Choice Band"],
+				"ability": ["Shed Skin"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Knock Off"], ["Close Combat"], ["Drain Punch"], ["Poison Jab"]]
+			}]
+		},
+		"archeops": {
+			"sets": [{
+				"species": "Archeops",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Defeatist"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Stone Edge"], ["Dual Wingbeat", "U-turn"], ["Earthquake"], ["Roost"]]
+			}, {
+				"species": "Archeops",
+				"item": ["Power Herb"],
+				"ability": ["Defeatist"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Meteor Beam"], ["Air Slash"], ["Earth Power"], ["Roost", "Stealth Rock", "Heat Wave"]]
+			}]
+		},
+		"doublade": {
+			"sets": [{
+				"species": "Doublade",
+				"item": ["Eviolite"],
+				"ability": ["No Guard"],
+				"evs": {"hp": 252, "atk": 252, "spd": 4},
+				"nature": "Adamant",
+				"moves": [["Shadow Sneak"], ["Close Combat"], ["Swords Dance"], ["Shadow Claw", "Iron Head"]]
+			}]
+		},
+		"ferroseed": {
+			"sets": [{
+				"species": "Ferroseed",
+				"item": ["Eviolite"],
+				"ability": ["Iron Barbs"],
+				"evs": {"hp": 252, "atk": 4, "def": 252},
+				"ivs": {"spe": 0},
+				"nature": "Relaxed",
+				"moves": [["Gyro Ball"], ["Spikes", "Stealth Rock"], ["Leech Seed"], ["Protect", "Knock Off"]]
+			}]
+		},
+		"gallade": {
+			"sets": [{
+				"species": "Gallade",
+				"item": ["Muscle Band", "Assault Vest"],
+				"ability": ["Justified"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Close Combat"], ["Psycho Cut", "Zen Headbutt"], ["Shadow Sneak"], ["Knock Off", "Leaf Blade", "Thunder Punch"]]
+			}, {
+				"species": "Gallade",
+				"item": ["Life Orb", "Lum Berry"],
+				"ability": ["Justified"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Close Combat"], ["Psycho Cut", "Zen Headbutt"], ["Shadow Sneak", "Knock Off"], ["Swords Dance"]]
+			}]
+		},
+		"regirock": {
+			"sets": [{
+				"species": "Regirock",
+				"item": ["Leftovers"],
+				"ability": ["Clear Body"],
+				"evs": {"hp": 252, "atk": 4, "def": 252},
+				"nature": "Impish",
+				"moves": [["Body Press"], ["Rock Blast", "Stone Edge"], ["Stealth Rock"], ["Toxic", "Thunder Wave"]]
+			}]
+		},
+		"sandaconda": {
+			"sets": [{
+				"species": "Sandaconda",
+				"item": ["Rocky Helmet", "Leftovers"],
+				"ability": ["Shed Skin"],
+				"evs": {"hp": 252, "def": 168, "spe": 88},
+				"nature": "Impish",
+				"moves": [["Earthquake"], ["Glare"], ["Rest"], ["Stealth Rock"]]
+			}, {
+				"species": "Sandaconda",
+				"item": ["Leftovers"],
+				"ability": ["Shed Skin"],
+				"evs": {"hp": 252, "spd": 168, "spe": 88},
+				"nature": "Careful",
+				"moves": [["Earthquake"], ["Coil"], ["Rest"], ["Stone Edge"]]
+			}]
+		},
+		"quagsire": {
+			"sets": [{
+				"species": "Quagsire",
+				"item": ["Leftovers", "Rocky Helmet", "Heavy-Duty Boots"],
+				"ability": ["Unaware"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Impish",
+				"moves": [["Earthquake"], ["Scald"], ["Recover"], ["Toxic", "Curse"]]
+			}]
+		},
+		"togedemaru": {
+			"sets": [{
+				"species": "Togedemaru",
+				"item": ["Choice Scarf"],
+				"ability": ["Lightning Rod", "Iron Barbs"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Zing Zap"], ["Iron Head"], ["Encore", "Toxic"], ["U-turn"]]
+			}, {
+				"species": "Togedemaru",
+				"item": ["Leftovers"],
+				"ability": ["Lightning Rod"],
+				"evs": {"hp": 252, "spd": 248, "spe": 8},
+				"nature": "Careful",
+				"moves": [["Iron Head"], ["Wish"], ["Spiky Shield"], ["U-turn", "Toxic"]]
+			}, {
+				"species": "Togedemaru",
+				"item": ["Rocky Helmet"],
+				"ability": ["Iron Barbs"],
+				"evs": {"hp": 252, "spd": 248, "spe": 8},
+				"nature": "Careful",
+				"moves": [["Iron Head"], ["Wish"], ["Spiky Shield"], ["U-turn", "Toxic"]]
+			}]
+		},
+		"wishiwashi": {
+			"sets": [{
+				"species": "Wishiwashi",
+				"item": ["Leftovers"],
+				"ability": ["Schooling"],
+				"evs": {"hp": 252, "spa": 4, "spd": 252},
+				"nature": "Calm",
+				"moves": [["Scald"], ["Rest"], ["Sleep Talk"], ["U-turn"]]
+			}, {
+				"species": "Wishiwashi",
+				"item": ["Leftovers"],
+				"ability": ["Schooling"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": "Bold",
+				"moves": [["Scald"], ["Rest"], ["Sleep Talk"], ["U-turn"]]
+			}]
+		},
+		"aggron": {
+			"sets": [{
+				"species": "Aggron",
+				"item": ["Choice Band"],
+				"ability": ["Rock Head"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Head Smash"], ["Heavy Slam"], ["Aqua Tail"], ["Earthquake"]]
+			}, {
+				"species": "Aggron",
+				"item": ["Leftovers"],
+				"ability": ["Rock Head"],
+				"evs": {"hp": 252, "atk": 4, "spd": 252},
+				"nature": "Careful",
+				"moves": [["Head Smash"], ["Earthquake"], ["Stealth Rock"], ["Protect", "Roar", "Toxic"]]
+			}]
+		},
+		"articunogalar": {
+			"sets": [{
+				"species": "Articuno-Galar",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Competitive"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Hurricane"], ["Future Sight"], ["Recover"], ["U-turn"]]
+			}, {
+				"species": "Articuno-Galar",
+				"item": ["Choice Specs"],
+				"ability": ["Competitive"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Hurricane"], ["Psyshock"], ["Freezing Glare"], ["Shadow Ball"]]
+			}]
+		},
+		"eldegoss": {
+			"sets": [{
+				"species": "Eldegoss",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Grass Knot", "Giga Drain"], ["Rapid Spin"], ["Aromatherapy"], ["Leech Seed", "Charm", "Sleep Powder"]]
+			}, {
+				"species": "Eldegoss",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Grass Knot", "Giga Drain"], ["Rapid Spin"], ["Sleep Powder"], ["Leech Seed"]]
+			}, {
+				"species": "Eldegoss",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "spa": 220, "spe": 36},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Grass Knot", "Leaf Storm"], ["Rapid Spin"], ["Sleep Powder", "Aromatherapy"], ["Pollen Puff", "Synthesis"]]
+			}, {
+				"species": "Eldegoss",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "spa": 220, "spe": 36},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Grass Knot", "Leaf Storm"], ["Rapid Spin"], ["Sleep Powder"], ["Aromatherapy"]]
+			}]
+		},
+		"sandslash": {
+			"sets": [{
+				"species": "Sandslash",
+				"item": ["Life Orb"],
+				"ability": ["Sand Rush"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Swords Dance"], ["Earthquake"], ["Knock Off", "Rock Slide"], ["Leech Life", "Rapid Spin"]]
+			}, {
+				"species": "Sandslash",
+				"item": ["Life Orb"],
+				"ability": ["Sand Rush"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Swords Dance"], ["Earthquake"], ["Knock Off"], ["Rock Slide"]]
+			}, {
+				"species": "Sandslash",
+				"item": ["Leftovers", "Heavy-Duty Boots"],
+				"ability": ["Sand Rush"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": "Impish",
+				"moves": [["Spikes"], ["Earthquake"], ["Knock Off"], ["Rapid Spin"]]
+			}]
+		},
+		"sneasel": {
+			"sets": [{
+				"species": "Sneasel",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Inner Focus"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Triple Axel"], ["Knock Off"], ["Ice Shard"], ["Swords Dance"]]
+			}, {
+				"species": "Sneasel",
+				"item": ["Choice Band"],
+				"ability": ["Inner Focus"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Triple Axel"], ["Knock Off"], ["Ice Shard"], ["Low Kick"]]
+			}]
+		},
+		"audino": {
+			"sets": [{
+				"species": "Audino",
+				"item": ["Leftovers", "Heavy-Duty Boots"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": "Careful",
+				"moves": [["Knock Off", "Heal Bell", "Encore"], ["Wish"], ["Protect"], ["Toxic"]]
+			}]
+		},
+		"gourgeistsmall": {
+			"sets": [{
+				"species": "Gourgeist-Small",
+				"item": ["Choice Band", "Choice Scarf"],
+				"ability": ["Frisk"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Power Whip"], ["Poltergeist"], ["Rock Slide"], ["Explosion", "Trick"]]
+			}, {
+				"species": "Gourgeist-Small",
+				"item": ["Choice Band", "Choice Scarf"],
+				"ability": ["Frisk"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Power Whip"], ["Poltergeist"], ["Trick"], ["Explosion", "Synthesis"]]
+			}]
+		},
+		"lycanroc": {
+			"sets": [{
+				"species": "Lycanroc",
+				"item": ["Life Orb"],
+				"ability": ["Sand Rush"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Accelerock"], ["Stone Edge"], ["Close Combat"], ["Swords Dance"]]
+			}]
+		},
+		"mesprit": {
+			"sets": [{
+				"species": "Mesprit",
+				"item": ["Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Psychic"], ["Dazzling Gleam"], ["U-turn"], ["Healing Wish", "Trick"]]
+			}, {
+				"species": "Mesprit",
+				"item": ["Colbur Berry", "Life Orb"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid", "Modest"],
+				"moves": [["Psychic"], ["Dazzling Gleam"], ["Nasty Plot"], ["Shadow Ball", "Thunderbolt"]]
+			}, {
+				"species": "Mesprit",
+				"item": ["Colbur Berry"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Psychic"], ["Dazzling Gleam"], ["Stealth Rock"], ["U-turn", "Healing Wish"]]
+			}, {
+				"species": "Mesprit",
+				"item": ["Choice Specs"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid", "Modest"],
+				"moves": [["Psychic"], ["Dazzling Gleam"], ["Trick"], ["Shadow Ball", "U-turn"]]
+			}, {
+				"species": "Mesprit",
+				"item": ["Choice Specs"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid", "Modest"],
+				"moves": [["Psychic"], ["Dazzling Gleam"], ["Shadow Ball"], ["U-turn"]]
+			}, {
+				"species": "Mesprit",
+				"item": ["Kee Berry"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 248, "def": 236, "spe": 24},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Calm Mind"], ["Dazzling Gleam"], ["Stored Power"], ["Rest"]]
+			}]
+		},
+		"perrserker": {
+			"sets": [{
+				"species": "Perrserker",
+				"item": ["Leftovers"],
+				"ability": ["Steely Spirit"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Iron Head"], ["Seed Bomb"], ["Substitute"], ["Swords Dance"]]
+			}, {
+				"species": "Perrserker",
+				"item": ["Choice Band"],
+				"ability": ["Steely Spirit"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Iron Head"], ["Seed Bomb"], ["Close Combat"], ["U-turn"]]
+			}, {
+				"species": "Perrserker",
+				"item": ["Choice Band"],
+				"ability": ["Tough Claws"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Iron Head"], ["Seed Bomb"], ["Close Combat"], ["U-turn", "Double-Edge"]]
+			}]
+		},
+		"silvallyghost": {
+			"sets": [{
+				"species": "Silvally-Ghost",
+				"item": ["Ghost Memory"],
+				"ability": ["RKS System"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Multi-Attack"], ["Swords Dance"], ["Flame Charge"], ["U-turn", "Explosion", "Substitute"]]
+			}]
+		},
+		"trevenant": {
+			"sets": [{
+				"species": "Trevenant",
+				"item": ["Choice Band"],
+				"ability": ["Natural Cure"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly", "Adamant"],
+				"moves": [["Poltergeist"], ["Wood Hammer"], ["Horn Leech"], ["Earthquake", "Trick"]]
+			}]
+		},
+		"uxie": {
+			"sets": [{
+				"species": "Uxie",
+				"item": ["Colbur Berry", "Leftovers"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": "Bold",
+				"moves": [["Psychic"], ["Stealth Rock"], ["Knock Off", "Thunder Wave"], ["U-turn"]]
+			}, {
+				"species": "Uxie",
+				"item": ["Kee Berry"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Calm Mind"], ["Draining Kiss"], ["Stored Power"], ["Rest"]]
+			}]
+		},
+		"centiskorch": {
+			"sets": [{
+				"species": "Centiskorch",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Flash Fire"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": ["Jolly", "Adamant"],
+				"moves": [["Fire Lash"], ["Power Whip"], ["Leech Life"], ["Knock Off"]]
+			}]
+		},
+		"frosmoth": {
+			"sets": [{
+				"species": "Frosmoth",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Ice Scales"],
+				"evs": {"spa": 252, "spd": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Ice Beam"], ["Quiver Dance"], ["Substitute"], ["Giga Drain"]]
+			}]
+		},
+		"garbodor": {
+			"sets": [{
+				"species": "Garbodor",
+				"item": ["Black Sludge"],
+				"ability": ["Aftermath"],
+				"evs": {"hp": 252, "def": 200, "spe": 56},
+				"nature": "Impish",
+				"moves": [["Gunk Shot"], ["Spikes"], ["Stomping Tantrum"], ["Pain Split", "Toxic Spikes"]]
+			}]
+		},
+		"hattrem": {
+			"sets": [{
+				"species": "Hattrem",
+				"item": ["Eviolite"],
+				"ability": ["Magic Bounce"],
+				"evs": {"hp": 252, "def": 244, "spe": 12},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Psychic"], ["Giga Drain"], ["Healing Wish"], ["Mystical Fire", "Aromatherapy", "Nuzzle"]]
+			}, {
+				"species": "Hattrem",
+				"item": ["Eviolite"],
+				"ability": ["Magic Bounce"],
+				"evs": {"hp": 252, "def": 244, "spe": 12},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Psychic"], ["Aromatherapy"], ["Rest"], ["Sleep Talk"]]
+			}]
+		},
+		"lanturn": {
+			"sets": [{
+				"species": "Lanturn",
+				"item": ["Leftovers"],
+				"ability": ["Volt Absorb"],
+				"evs": {"hp": 88, "def": 172, "spd": 248},
+				"ivs": {"atk": 0},
+				"nature": "Calm",
+				"moves": [["Scald"], ["Volt Switch"], ["Toxic"], ["Protect", "Heal Bell"]]
+			}]
+		},
+		"magmortar": {
+			"sets": [{
+				"species": "Magmortar",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Flame Body"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest", "Timid"],
+				"moves": [["Fire Blast"], ["Thunderbolt"], ["Focus Blast"], ["Scorching Sands", "Taunt", "Toxic"]]
+			}, {
+				"species": "Magmortar",
+				"item": ["Choice Specs"],
+				"ability": ["Flame Body"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Modest", "Timid"],
+				"moves": [["Fire Blast"], ["Thunderbolt"], ["Focus Blast"], ["Scorching Sands", "Overheat"]]
+
+			}]
+		},
+		"palossand": {
+			"sets": [{
+				"species": "Palossand",
+				"item": ["Colbur Berry"],
+				"ability": ["Water Compaction"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Earth Power"], ["Shadow Ball"], ["Stealth Rock"], ["Shore Up"]]
+			}]
+		},
+		"qwilfish": {
+			"sets": [{
+				"species": "Qwilfish",
+				"item": ["Black Sludge", "Rocky Helmet"],
+				"ability": ["Intimidate"],
+				"evs": {"hp": 252, "atk": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Waterfall"], ["Spikes"], ["Taunt"], ["Thunder Wave", "Poison Jab", "Destiny Bond"]]
+			}]
+		},
+		"rotom": {
+			"sets": [{
+				"species": "Rotom",
+				"item": ["Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Thunderbolt"], ["Shadow Ball"], ["Volt Switch"], ["Trick"]]
+			}, {
+				"species": "Rotom",
+				"item": ["Colbur Berry", "Heavy-Duty Boots"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Volt Switch"], ["Defog"], ["Will-O-Wisp"], ["Hex"]]
+			}, {
+				"species": "Rotom",
+				"item": ["Colbur Berry", "Heavy-Duty Boots"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Volt Switch"], ["Defog"], ["Shadow Ball"], ["Thunderbolt", "Pain Split"]]
+			}]
+		},
+		"shiftry": {
+			"sets": [{
+				"species": "Shiftry",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Pickpocket"],
+				"evs": {"hp": 248, "def": 164, "spe": 96},
+				"nature": "Timid",
+				"moves": [["Knock Off"], ["Leaf Storm"], ["Defog"], ["Synthesis"]]
+			}]
+		},
+		"silvallyfairy": {
+			"sets": [{
+				"species": "Silvally-Fairy",
+				"item": ["Fairy Memory"],
+				"ability": ["RKS System"],
+				"evs": {"hp": 252, "def": 96, "spe": 160},
+				"nature": "Jolly",
+				"moves": [["Multi-Attack"], ["Parting Shot"], ["Defog", "Toxic", "Thunder Wave"], ["Flamethrower"]]
+			}, {
+				"species": "Silvally-Fairy",
+				"item": ["Fairy Memory"],
+				"ability": ["RKS System"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Multi-Attack"], ["Swords Dance"], ["Rock Slide"], ["Flame Charge"]]
+			}]
+		},
+		"tangela": {
+			"sets": [{
+				"species": "Tangela",
+				"item": ["Eviolite"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": "Bold",
+				"moves": [["Giga Drain"], ["Knock Off"], ["Leech Seed", "Synthesis"], ["Sleep Powder", "Toxic"]]
+			}]
+		},
+		"vikavolt": {
+			"sets": [{
+				"species": "Vikavolt",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 56, "spa": 252, "spe": 200},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Thunderbolt"], ["Bug Buzz", "Energy Ball"], ["Volt Switch"], ["Roost"]]
+			}, {
+				"species": "Vikavolt",
+				"item": ["Throat Spray"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Thunderbolt"], ["Bug Buzz"], ["Agility"], ["Roost", "Energy Ball"]]
+			}]
+		},
+		"weezing": {
+			"sets": [{
+				"species": "Weezing",
+				"item": ["Rocky Helmet"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 220, "spe": 36},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Sludge Bomb"], ["Will-O-Wisp"], ["Pain Split"], ["Taunt", "Toxic Spikes"]]
+			}, {
+				"species": "Weezing",
+				"item": ["Black Sludge"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 220, "spe": 36},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Sludge Bomb"], ["Will-O-Wisp"], ["Pain Split", "Flamethrower"], ["Taunt", "Toxic Spikes"]]
+			}, {
+				"species": "Weezing",
+				"item": ["Black Sludge"],
+				"ability": ["Levitate"],
+				"evs": {"hp": 252, "def": 220, "spe": 36},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Sludge Bomb"], ["Will-O-Wisp"], ["Toxic Spikes"], ["Taunt"]]
+			}]
+		},
+		"whimsicott": {
+			"sets": [{
+				"species": "Whimsicott",
+				"item": ["Choice Specs"],
+				"ability": ["Infiltrator"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Moonblast"], ["Energy Ball"], ["U-turn", "Psychic", "Shadow Ball"], ["Switcheroo"]]
+			}, {
+				"species": "Whimsicott",
+				"item": ["Choice Specs", "Pixie Plate"],
+				"ability": ["Infiltrator"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Moonblast"], ["Energy Ball"], ["U-turn", "Psychic"], ["Shadow Ball"]]
+			}, {
+				"species": "Whimsicott",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Prankster"],
+				"evs": {"hp": 252, "spa": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Moonblast"], ["Knock Off", "Encore"], ["U-turn"], ["Defog", "Energy Ball", "Giga Drain"]]
+			}, {
+				"species": "Whimsicott",
+				"item": ["Leftovers"],
+				"ability": ["Prankster"],
+				"evs": {"hp": 252, "spa": 4, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Moonblast"], ["Knock Off", "Encore"], ["Substitute"], ["Leech Seed"]]
+			}]
+		},
+		"abomasnow": {
+			"sets": [{
+				"species": "Abomasnow",
+				"item": ["Choice Specs"],
+				"ability": ["Snow Warning"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Blizzard"], ["Earth Power"], ["Leaf Storm"], ["Giga Drain", "Toxic"]]
+			}, {
+				"species": "Abomasnow",
+				"item": ["Life Orb"],
+				"ability": ["Snow Warning"],
+				"evs": {"atk": 252, "spa": 4, "spe": 252},
+				"nature": "Naughty",
+				"moves": [["Blizzard"], ["Wood Hammer"], ["Ice Shard"], ["Earthquake", "Rock Slide"]]
+			}]
+		},
+		"cinccino": {
+			"sets": [{
+				"species": "Cinccino",
+				"item": ["Protective Pads", "Choice Band", "Heavy-Duty Boots"],
+				"ability": ["Skill Link"],
+				"evs": {"atk": 252, "spd": 4, "spe": 252},
+				"nature": "Jolly",
+				"moves": [["Tail Slap"], ["Triple Axel", "Bullet Seed", "Rock Blast"], ["Knock Off"], ["U-turn"]]
+			}]
+		},
+		"clefairy": {
+			"sets": [{
+				"species": "Clefairy",
+				"item": ["Eviolite"],
+				"ability": ["Magic Guard"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": "Bold",
+				"moves": [["Moonblast"], ["Soft-Boiled"], ["Stealth Rock"], ["Knock Off"]]
+			}]
+		},
+		"exeggutor": {
+			"sets": [{
+				"species": "Cinccino",
+				"item": ["Choice Specs"],
+				"ability": ["Chlorophyll", "Harvest"],
+				"evs": {"atk": 4, "spa": 252, "spe": 252},
+				"nature": "Modest",
+				"moves": [["Leaf Storm"], ["Psychic"], ["Stomping Tantrum"], ["Psyshock", "Teleport", "Giga Drain"]]
+			}]
+		},
+		"haunter": {
+			"sets": [{
+				"species": "Haunter",
+				"item": ["Choice Scarf"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Sludge Bomb"], ["Shadow Ball"], ["Dazzling Gleam"], ["Trick"]]
+			}, {
+				"species": "Haunter",
+				"item": ["Life Orb"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Sludge Bomb"], ["Shadow Ball"], ["Dazzling Gleam"], ["Substitute"]]
+			}]
+		},
+		"jolteon": {
+			"sets": [{
+				"species": "Jolteon",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Volt Absorb"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Thunderbolt"], ["Shadow Ball"], ["Volt Switch"], ["Heal Bell", "Toxic", "Yawn"]]
+			}]
+		},
+		"lurantis": {
+			"sets": [{
+				"species": "Lurantis",
+				"item": ["Heavy-Duty Boots", "Leftovers", ""],
+				"ability": ["Contrary"],
+				"evs": {"hp": 252, "def": 252, "spa": 4},
+				"nature": "Bold",
+				"moves": [["Leaf Storm"], ["Superpower"], ["Synthesis"], ["Defog"]]
+			}]
+		},
+		"magneton": {
+			"sets": [{
+				"species": "Magneton",
+				"item": ["Choice Specs"],
+				"ability": ["Levitate"],
+				"evs": {"def": 4, "spa": 252, "spe": 252},
+				"ivs": {"atk": 0},
+				"nature": ["Timid", "Modest"],
+				"moves": [["Thunderbolt"], ["Flash Cannon"], ["Volt Switch"], ["Tri Attack"]]
+			}]
+		},
+		"ninjask": {
+			"sets": [{
+				"species": "Ninjask",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Speed Boost"],
+				"evs": {"hp": 152, "atk": 252, "spe": 104},
+				"nature": "Adamant",
+				"moves": [["Swords Dance"], ["Dual Wingbeat"], ["Protect"], ["U-turn"]]
+			}]
+		},
+		"poliwrath": {
+			"sets": [{
+				"species": "Poliwrath",
+				"item": ["Choice Band"],
+				"ability": ["Water Absorb"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Close Combat"], ["Liquidation"], ["Darkest Lariat"], ["Poison Jab"]]
+			}, {
+				"species": "Poliwrath",
+				"item": ["Leftovers"],
+				"ability": ["Water Absorb"],
+				"evs": {"hp": 252, "def": 160, "spe": 96},
+				"nature": "Bold",
+				"moves": [["Circle Throw"], ["Scald"], ["Rest"], ["Sleep Talk"]]
+			}]
+		},
+		"aromatisse": {
+			"sets": [{
+				"species": "Aromatisse",
+				"item": ["Leftovers", "Heavy-Duty Boots"],
+				"ability": ["Aroma Veil"],
+				"evs": {"hp": 252, "def": 252, "spd": 4},
+				"nature": "Bold",
+				"moves": [["Moonblast"], ["Wish"], ["Protect"], ["Heal Bell", "Toxic"]]
+			}]
+		},
+		"coalossal": {
+			"sets": [{
+				"species": "Coalossal",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Flame Body"],
+				"evs": {"hp": 252, "def": 4, "spd": 252},
+				"nature": "Sassy",
+				"moves": [["Stealth Rock", "Spikes"], ["Rapid Spin"], ["Flamethrower"], ["Rock Blast"]]
+			}]
+		},
+		"galvantula": {
+			"sets": [{
+				"species": "Galvantula",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Compound Eyes"],
+				"evs": {"hp": 4, "spa": 252, "spe": 252},
+				"nature": "Timid",
+				"moves": [["Thunder"], ["Volt Switch"], ["Bug Buzz"], ["Energy Ball"]]
+			}]
+		},
+		"arctovish": {
+			"sets": [{
+				"species": "Poliwrath",
+				"item": ["Choice Band"],
+				"ability": ["Water Absorb"],
+				"evs": {"atk": 252, "def": 4, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Fishious Rend"], ["Icicle Crash"], ["Psychic Fangs"], ["Crunch"]]
+			}]
+		},
+		"glastrier": {
+			"sets": [{
+				"species": "Poliwrath",
+				"item": ["Heavy-Duty Boots"],
+				"ability": ["Water Absorb"],
+				"evs": {"hp": 4, "atk": 252, "spe": 252},
+				"nature": "Adamant",
+				"moves": [["Close Combat"], ["Icicle Crash"], ["Crunch"], ["Swords Dance"]]
+			}]
+		}
+	},
+	"LC": {
+		"abra": {
+			"sets": [{
+				"species": "Abra",
+				"item": ["Life Orb"],
+				"ability": ["Magic Guard"],
+				"evs": {"atk": 116, "spa": 156, "spe": 196},
+				"nature": "Hasty",
+				"moves": [["Psychic"], ["Submission", "Fire Punch"], ["Shadow Ball"], ["Protect", "Substitute"]]
+			}, {
+				"species": "Abra",
+				"item": ["Focus Sash"],
+				"ability": ["Magic Guard"],
+				"evs": {"def": 76, "spa": 236, "spe": 196},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Psychic"], ["Shadow Ball"], ["Thunder Wave", "Counter"], ["Protect"]]
+			}]
+		},
+		"mienfoo": {
+			"sets": [{
+				"species": "Mienfoo",
+				"item": ["Eviolite"],
+				"ability": ["Regenerator"],
+				"evs": {"def": 196, "spd": 36, "spe": 236},
+				"nature": "Jolly",
+				"moves": [["High Jump Kick"], ["Knock Off"], ["Fake Out", "Taunt"], ["U-turn"]]
+			}, {
+				"species": "Mienfoo",
+				"item": ["Choice Scarf"],
+				"ability": ["Reckless"],
+				"evs": {"atk": 236, "def": 36, "spe": 236},
+				"nature": "Jolly",
+				"moves": [["High Jump Kick"], ["Knock Off"], ["Close Combat"], ["U-turn"]]
+			}]
+		},
+		"timburr": {
+			"sets": [{
+				"species": "Timburr",
+				"item": ["Eviolite"],
+				"ability": ["Guts", "Iron Fist"],
+				"evs": {"hp": 76, "atk": 196, "def": 236},
+				"nature": "Adamant",
+				"moves": [["Drain Punch"], ["Knock Off"], ["Mach Punch"], ["Defog", "Thunder Punch"]]
+			}]
+		},
+		"staryu": {
+			"sets": [{
+				"species": "Staryu",
+				"item": ["Eviolite"],
+				"ability": ["Natural Cure"],
+				"evs": {"hp": 116, "def": 156, "spe": 236},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Scald"], ["Thunder Wave", "Thunderbolt"], ["Rapid Spin"], ["Recover"]]
+			}, {
+				"species": "Staryu",
+				"item": ["Eviolite"],
+				"ability": ["Analytic"],
+				"evs": {"def": 156, "spa": 116, "spe": 236},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Hydro Pump"], ["Thunderbolt"], ["Ice Beam", "Psychic"], ["Recover"]]
+			}]
+		},
+		"croagunk": {
+			"sets": [{
+				"species": "Croagunk",
+				"item": ["Berry Juice", "Eviolite"],
+				"ability": ["Dry Skin"],
+				"evs": {"def": 116, "spa": 188, "spe": 196},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Nasty Plot"], ["Sludge Bomb"], ["Focus Blast"], ["Vacuum Wave"]]
+			}]
+		},
+		"grookey": {
+			"sets": [{
+				"species": "Grookey",
+				"item": ["Life Orb"],
+				"ability": ["Grassy Surge"],
+				"evs": {"atk": 236, "def": 36, "spe": 236},
+				"nature": "Jolly",
+				"moves": [["Grassy Glide"], ["Knock Off"], ["U-turn"], ["Drain Punch"]]
+			}, {
+				"species": "Grookey",
+				"item": ["Grassy Seed"],
+				"ability": ["Grassy Surge"],
+				"evs": {"atk": 236, "def": 36, "spe": 236},
+				"nature": "Jolly",
+				"moves": [["Grassy Glide"], ["Acrobatics"], ["Swords Dance", "U-turn"], ["Drain Punch"]]
+			}, {
+				"species": "Grookey",
+				"item": ["Eviolite"],
+				"ability": ["Grassy Surge"],
+				"evs": {"atk": 236, "def": 36, "spe": 236},
+				"nature": "Jolly",
+				"moves": [["Swords Dance"], ["Grassy Glide"], ["Wood Hammer"], ["Drain Punch"]]
+			}]
+		},
+		"diglett": {
+			"sets": [{
+				"species": "Diglett",
+				"item": ["Air Balloon"],
+				"ability": ["Arena Trap"],
+				"evs": {"hp": 36, "atk": 236, "spe": 236},
+				"nature": "Jolly",
+				"moves": [["Earthquake"], ["Beat Up"], ["Protect", "Substitute", "Sucker Punch"], ["Final Gambit"]]
+			}, {
+				"species": "Diglett",
+				"item": ["Eviolite"],
+				"ability": ["Arena Trap"],
+				"evs": {"hp": 36, "atk": 156, "spd": 76, "spe": 236},
+				"nature": "Jolly",
+				"moves": [["Earthquake"], ["Beat Up"], ["Earth Power"], ["Final Gambit"]]
+			}, {
+				"species": "Diglett",
+				"item": ["Eviolite"],
+				"ability": ["Arena Trap"],
+				"evs": {"hp": 36, "atk": 156, "spd": 76, "spe": 236},
+				"nature": "Jolly",
+				"moves": [["Earthquake"], ["Beat Up"], ["Stealth Rock"], ["Final Gambit", "Earth Power"]]
+			}, {
+				"species": "Diglett",
+				"item": ["Life Orb"],
+				"ability": ["Arena Trap"],
+				"evs": {"hp": 36, "atk": 236, "spe": 236},
+				"nature": "Jolly",
+				"moves": [["Earthquake"], ["Beat Up"], ["Substitute"], ["Rock Slide", "Sucker Punch", "Protect"]]
+			}]
+		},
+		"foongus": {
+			"sets": [{
+				"species": "Foongus",
+				"item": ["Eviolite"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 124, "def": 156, "spd": 156},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Spore"], ["Sludge Bomb"], ["Giga Drain"], ["Synthesis"]]
+			}]
+		},
+		"natu": {
+			"sets": [{
+				"species": "Natu",
+				"item": ["Eviolite"],
+				"ability": ["Magic Bounce"],
+				"evs": {"hp": 36, "def": 76, "spa": 116, "spd": 76, "spe": 196},
+				"nature": "Timid",
+				"moves": [["Psychic"], ["Heat Wave"], ["U-turn", "Thunder Wave", "Calm Mind"], ["Roost"]]
+			}]
+		},
+		"trapinch": {
+			"sets": [{
+				"species": "Trapinch",
+				"item": ["Eviolite"],
+				"ability": ["Arena Trap"],
+				"evs": {"atk": 36, "def": 236, "spd": 76, "spe": 116},
+				"nature": "Adamant",
+				"moves": [["Earthquake"], ["First Impression"], ["Feint"], ["Superpower"]]
+			}]
+		},
+		"ferroseed": {
+			"sets": [{
+				"species": "Ferroseed",
+				"item": ["Eviolite"],
+				"ability": ["Iron Barbs"],
+				"evs": {"hp": 84, "atk": 36, "def": 108, "spa": 4, "spd": 228, "spe": 36},
+				"nature": "Bold",
+				"moves": [["Stealth Rock", "Spikes"], ["Giga Drain"], ["Thunder Wave"], ["Knock Off"]]
+			}]
+		},
+		"pawniard": {
+			"sets": [{
+				"species": "Pawniard",
+				"item": ["Eviolite"],
+				"ability": ["Defiant", "Inner Focus"],
+				"evs": {"atk": 156, "def": 36, "spd": 116, "spe": 196},
+				"nature": "Adamant",
+				"moves": [["Stealth Rock"], ["Knock Off"], ["Iron Head"], ["Sucker Punch"]]
+			}]
+		},
+		"shellder": {
+			"sets": [{
+				"species": "Shellder",
+				"item": ["Eviolite"],
+				"ability": ["Skill Link"],
+				"evs": {"hp": 36, "atk": 236, "def": 36, "spe": 196},
+				"nature": "Adamant",
+				"moves": [["Shell Smash"], ["Icicle Spear"], ["Ice Shard", "Liquidation", "Protect"], ["Rock Blast"]]
+			}]
+		},
+		"porygon": {
+			"sets": [{
+				"species": "Porygon",
+				"item": ["Choice Scarf"],
+				"ability": ["Download"],
+				"evs": {"def": 36, "spa": 236, "spe": 196},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Tri Attack"], ["Ice Beam"], ["Psychic"], ["Thunderbolt"]]
+			}, {
+				"species": "Porygon",
+				"item": ["Choice Scarf"],
+				"ability": ["Download"],
+				"evs": {"def": 36, "spa": 236, "spe": 196},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Tri Attack"], ["Ice Beam"], ["Psychic", "Thunderbolt"], ["Trick"]]
+
+			}, {
+				"species": "Porygon",
+				"item": ["Eviolite"],
+				"ability": ["Download"],
+				"evs": {"def": 36, "spa": 236, "spe": 196},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Tri Attack"], ["Ice Beam", "Psychic"], ["Agility"], ["Recover"]]
+			}, {
+				"species": "Porygon",
+				"item": ["Berry Juice"],
+				"ability": ["Download"],
+				"evs": {"def": 36, "spa": 236, "spe": 196},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Tri Attack"], ["Ice Beam"], ["Agility"], ["Thunderbolt", "Psychic"]]
+			}]
+		},
+		"magnemite": {
+			"sets": [{
+				"species": "Magnemite",
+				"item": ["Berry Juice"],
+				"ability": ["Sturdy"],
+				"evs": {"def": 36, "spa": 236, "spe": 236},
+				"ivs": {"atk": 0},
+				"nature": ["Timid", "Modest"],
+				"moves": [["Flash Cannon"], ["Thunderbolt", "Endure", "Steel Beam"], ["Recycle"], ["Volt Switch"]]
+			}, {
+				"species": "Magnemite",
+				"item": ["Choice Scarf"],
+				"ability": ["Analytic"],
+				"evs": {"def": 36, "spa": 236, "spe": 236},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Flash Cannon"], ["Thunderbolt"], ["Steel Beam"], ["Volt Switch"]]
+			}]
+		},
+		"ponyta": {
+			"sets": [{
+				"species": "Ponyta",
+				"item": ["Eviolite"],
+				"ability": ["Flame Body"],
+				"evs": {"atk": 76, "def": 156, "spd": 76, "spe": 196},
+				"nature": "Jolly",
+				"moves": [["Flare Blitz"], ["Will-O-Wisp"], ["High Horsepower", "Flame Charge"], ["Morning Sun"]]
+			}, {
+				"species": "Ponyta",
+				"item": ["Berry Juice"],
+				"ability": ["Flash Fire"],
+				"evs": {"atk": 236, "def": 76, "spe": 196},
+				"nature": "Jolly",
+				"moves": [["Flare Blitz"], ["Flame Charge"], ["High Horsepower"], ["Wild Charge"]]
+			}]
+		},
+		"ponytagalar": {
+			"sets": [{
+				"species": "Ponyta-Galar",
+				"item": ["Eviolite"],
+				"ability": ["Pastel Veil"],
+				"evs": {"spa": 236, "spd": 76, "spe": 196},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Calm Mind"], ["Psychic"], ["Mystical Fire"], ["Morning Sun"]]
+			}]
+		},
+		"carvanha": {
+			"sets": [{
+				"species": "Carvanha",
+				"item": ["Life Orb"],
+				"ability": ["Speed Boost"],
+				"evs": {"atk": 196, "spd": 36, "spe": 236},
+				"ivs": {"hp": 9},
+				"nature": "Adamant",
+				"moves": [["Aqua Jet"], ["Crunch"], ["Psychic Fangs"], ["Protect"]]
+			}]
+		},
+		"mareanie": {
+			"sets": [{
+				"species": "Mareanie",
+				"item": ["Eviolite"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 116, "atk": 12, "def": 180, "spa": 12, "spd": 100, "spe": 180},
+				"nature": "Bold",
+				"moves": [["Knock Off"], ["Scald"], ["Sludge Bomb"], ["Recover"]]
+			}]
+		},
+		"mudbray": {
+			"sets": [{
+				"species": "Mudbray",
+				"item": ["Choice Scarf"],
+				"ability": ["Stamina"],
+				"evs": {"hp": 36, "atk": 196, "def": 36, "spe": 236},
+				"nature": "Jolly",
+				"moves": [["Earthquake"], ["Heavy Slam", "Rock Slide"], ["Close Combat"], ["Earthquake"]]
+			}, {
+				"species": "Mudbray",
+				"item": ["Eviolite"],
+				"ability": ["Stamina"],
+				"evs": {"hp": 36, "atk": 196, "def": 36, "spe": 236},
+				"nature": "Jolly",
+				"moves": [["Stealth Rock"], ["Rock Slide", "Heavy Slam"], ["Close Combat"], ["Earthquake"]]
+			}, {
+				"species": "Mudbray",
+				"item": ["Eviolite"],
+				"ability": ["Stamina"],
+				"evs": {"hp": 116, "atk": 116, "def": 36, "spd": 236},
+				"nature": "Careful",
+				"moves": [["Rest"], ["Earthquake"], ["Heavy Slam"], ["Sleep Talk"]]
+			}]
+		},
+		"magby": {
+			"sets": [{
+				"species": "Magby",
+				"item": ["Berry Juice"],
+				"ability": ["Vital Spirit", "Flame Body"],
+				"evs": {"atk": 236, "spe": 252},
+				"ivs": {"hp": 29},
+				"nature": "Jolly",
+				"moves": [["Belly Drum"], ["Fire Punch"], ["Thunder Punch"], ["Mach Punch"]]
+			}]
+		},
+		"morelull": {
+			"sets": [{
+				"species": "Morelull",
+				"item": ["Eviolite"],
+				"ability": ["Effect Spore"],
+				"evs": {"hp": 196, "def": 236, "spd": 76},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Spore"], ["Moonblast"], ["Giga Drain"], ["Synthesis"]]
+			}]
+		},
+		"slowpoke": {
+			"sets": [{
+				"species": "Slowpoke",
+				"item": ["Eviolite"],
+				"ability": ["Regenerator"],
+				"evs": {"hp": 116, "def": 156, "spa": 36, "spd": 196},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Scald"], ["Teleport"], ["Thunder Wave"], ["Slack Off"]]
+			}]
+		},
+		"spritzee": {
+			"sets": [{
+				"species": "Spritzee",
+				"item": ["Eviolite"],
+				"ability": ["Aroma Veil"],
+				"evs": {"hp": 212, "def": 196, "spa": 12, "spd": 76, "spe": 12},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Moonblast"], ["Wish"], ["Protect"], ["Psychic", "Covet"]]
+			}, {
+				"species": "Spritzee",
+				"item": ["Berry Juice"],
+				"ability": ["Aroma Veil"],
+				"evs": {"hp": 52, "def": 116, "spa": 252, "spd": 76},
+				"ivs": {"atk": 0, "spe": 0},
+				"nature": "Quiet",
+				"moves": [["Nasty Plot"], ["Moonblast"], ["Psychic"], ["Trick Room"]]
+			}]
+		},
+		"tyrunt": {
+			"sets": [{
+				"species": "Tyrunt",
+				"item": ["Eviolite"],
+				"ability": ["Strong Jaw"],
+				"evs": {"hp": 204, "spd": 76, "spe": 212},
+				"nature": "Jolly",
+				"moves": [["Dragon Dance"], ["Rock Blast"], ["Close Combat"], ["Psychic Fangs"]]
+			}]
+		},
+		"zigzagoon": {
+			"sets": [{
+				"species": "Zigzagoon",
+				"item": ["Berry Juice"],
+				"ability": ["Quick Feet"],
+				"evs": {"hp": 132, "atk": 196, "def": 108, "spd": 28, "spe": 36},
+				"nature": "Adamant",
+				"moves": [["Belly Drum"], ["Extreme Speed"], ["Thief"], ["Protect"]]
+			}]
+		},
+		"archen": {
+			"sets": [{
+				"species": "Archen",
+				"item": ["Choice Scarf"],
+				"ability": ["Defeatist"],
+				"evs": {"atk": 180, "def": 76, "spe": 196},
+				"nature": "Jolly",
+				"moves": [["Earthquake"], ["Dual Wingbeat"], ["Knock Off", "Rock Blast"], ["U-turn"]]
+			}]
+		},
+		"wingull": {
+			"sets": [{
+				"species": "Wingull",
+				"item": ["Berry Juice"],
+				"ability": ["Keen Eye"],
+				"evs": {"spa": 236, "spe": 236},
+				"ivs": {"hp": 19},
+				"nature": "Hasty",
+				"moves": [["Hurricane"], ["Scald"], ["Knock Off"], ["Substitute"]]
+			}]
+		},
+		"frillish": {
+			"sets": [{
+				"species": "Frillish",
+				"item": ["Eviolite"],
+				"ability": ["Cursed Body"],
+				"evs": {"hp": 156, "def": 116, "spd": 156, "spe": 36},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Scald"], ["Hex"], ["Will-O-Wisp"], ["Recover"]]
+			}]
+		},
+		"munchlax": {
+			"sets": [{
+				"species": "Munchlax",
+				"item": ["Berry Juice"],
+				"ability": ["Thick Fat"],
+				"evs": {"atk": 76, "def": 196, "spd": 236},
+				"nature": "Impish",
+				"moves": [["Body Slam"], ["Fire Punch"], ["Curse"], ["Recycle"]]
+			}]
+		},
+		"wynaut": {
+			"sets": [{
+				"species": "Wynaut",
+				"item": ["Berry Juice"],
+				"ability": ["Shadow Tag"],
+				"evs": {"hp": 212, "spd": 52, "spe": 172},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Counter"], ["Mirror Coat"], ["Encore"], ["Destiny Bond"]]
+			}]
+		},
+		"cottonee": {
+			"sets": [{
+				"species": "Cottonee",
+				"item": ["Eviolite"],
+				"ability": ["Prankster"],
+				"evs": {"hp": 36, "def": 196, "spd": 36, "spe": 228},
+				"nature": "Timid",
+				"moves": [["Defog", "Encore"], ["Dazzling Gleam"], ["Knock Off"], ["Memento"]]
+			}]
+		},
+		"hippopotas": {
+			"sets": [{
+				"species": "Hippopotas",
+				"item": ["Eviolite"],
+				"ability": ["Sand Stream"],
+				"evs": {"hp": 132, "atk": 20, "def": 132, "spd": 180, "spe": 20},
+				"nature": "Careful",
+				"moves": [["Stealth Rock"], ["Earthquake"], ["Slack Off"], ["Whirlwind", "Toxic"]]
+			}]
+		},
+		"larvesta": {
+			"sets": [{
+				"species": "Larvesta",
+				"item": ["Eviolite"],
+				"ability": ["Flame Body"],
+				"evs": {"hp": 76, "def": 236, "spe": 196},
+				"nature": "Jolly",
+				"moves": [["Flare Blitz"], ["Will-O-Wisp"], ["Morning Sun"], ["U-turn"]]
+			}]
+		},
+		"koffing": {
+			"sets": [{
+				"species": "Koffing",
+				"item": ["Eviolite"],
+				"ability": ["Neutralizing Gas"],
+				"evs": {"hp": 36, "def": 76, "spa": 196, "spe": 156},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Sludge Bomb"], ["Fire Blast"], ["Thunderbolt"], ["Pain Split"]]
+			}]
+		},
+		"onix": {
+			"sets": [{
+				"species": "Onix",
+				"item": ["Berry Juice"],
+				"ability": ["Sturdy"],
+				"evs": {"hp": 76, "atk": 236, "spe": 196},
+				"nature": "Jolly",
+				"moves": [["Earthquake"], ["Rock Blast"], ["Stealth Rock"], ["Explosion", "Endure"]]
+			}]
+		},
+		"drilbur": {
+			"sets": [{
+				"species": "Drilbur",
+				"item": ["Eviolite"],
+				"ability": ["Mold Breaker"],
+				"evs": {"hp": 36, "atk": 236, "spe": 212},
+				"nature": "Jolly",
+				"moves": [["Earthquake"], ["Rapid Spin"], ["Stealth Rock"], ["Rock Slide"]]
+			}]
+		},
+		"stunky": {
+			"sets": [{
+				"species": "Stunky",
+				"item": ["Life Orb"],
+				"ability": ["Aftermath"],
+				"evs": {"hp": 12, "atk": 252, "spe": 244},
+				"nature": "Hasty",
+				"moves": [["Crunch"], ["Sucker Punch"], ["Play Rough"], ["Fire Blast"]]
+			}]
+		},
+		"bunnelby": {
+			"sets": [{
+				"species": "Bunnelby",
+				"item": ["Eviolite"],
+				"ability": ["Huge Power"],
+				"evs": {"hp": 52, "atk": 228, "spe": 228},
+				"nature": ["Adamant", "Jolly"],
+				"moves": [["Strength"], ["Earthquake"], ["Quick Attack"], ["Stone Edge", "Swords Dance"]]
+			}]
+		},
+		"elekid": {
+			"sets": [{
+				"species": "Elekid",
+				"item": ["Life Orb"],
+				"ability": ["Vital Spirit"],
+				"evs": {"atk": 12, "spa": 236, "spe": 236},
+				"nature": "Naive",
+				"moves": [["Thunderbolt"], ["Volt Switch"], ["Psychic"], ["Ice Punch", "Brick Break"]]
+			}]
+		},
+		"farfetchdgalar": {
+			"sets": [{
+				"species": "Farfetch\u2019d-Galar",
+				"item": ["Choice Scarf"],
+				"ability": ["Scrappy"],
+				"evs": {"hp": 20, "atk": 236, "spe": 236},
+				"nature": "Jolly",
+				"moves": [["Close Combat"], ["Knock Off"], ["Brave Bird"], ["Final Gambit"]]
+			}]
+		},
+		"sinistea": {
+			"sets": [{
+				"species": "Sinistea",
+				"item": ["Eviolite"],
+				"ability": ["Weak Armor"],
+				"evs": {"hp": 36, "spa": 244, "spd": 4, "spe": 196},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Shell Smash"], ["Shadow Ball"], ["Stored Power"], ["Will-O-Wisp"]]
+			}]
+		},
+		"trubbish": {
+			"sets": [{
+				"species": "Trubbish",
+				"item": ["Berry Juice"],
+				"ability": ["Sticky Hold"],
+				"evs": {"hp": 116, "atk": 36, "def": 100, "spd": 20, "spe": 236},
+				"nature": "Jolly",
+				"moves": [["Spikes"], ["Recycle"], ["Gunk Shot"], ["Drain Punch"]]
+			}]
+		},
+		"amaura": {
+			"sets": [{
+				"species": "Amaura",
+				"item": ["Choice Scarf"],
+				"ability": ["Snow Warning"],
+				"evs": {"hp": 60, "spa": 220, "spe": 228},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Blizzard"], ["Freeze-Dry"], ["Thunderbolt"], ["Earth Power"]]
+			}]
+		},
+		"anorith": {
+			"sets": [{
+				"species": "Anorith",
+				"item": ["Eviolite"],
+				"ability": ["Battle Armor"],
+				"evs": {"atk": 76, "def": 196, "spe": 236},
+				"nature": "Jolly",
+				"moves": [["Rapid Spin"], ["Knock Off"], ["X-Scissor"], ["Brick Break"]]
+			}, {
+				"species": "Anorith",
+				"item": ["Eviolite"],
+				"ability": ["Battle Armor"],
+				"evs": {"atk": 76, "def": 196, "spe": 236},
+				"nature": "Jolly",
+				"moves": [["Rapid Spin"], ["Knock Off"], ["X-Scissor", "Brick Break"], ["Stealth Rock"]]
+			}]
+		},
+		"chinchou": {
+			"sets": [{
+				"species": "Chinchou",
+				"item": ["Eviolite"],
+				"ability": ["Volt Absorb"],
+				"evs": {"hp": 76, "def": 212, "spa": 152, "spe": 60},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Volt Switch"], ["Ice Beam"], ["Thunderbolt"], ["Scald"]]
+			}]
+		},
+		"corphish": {
+			"sets": [{
+				"species": "Corphish",
+				"item": ["Eviolite"],
+				"ability": ["Adaptability"],
+				"evs": {"atk": 196, "def": 76, "spe": 236},
+				"nature": "Adamant",
+				"moves": [["Crabhammer"], ["Aqua Jet"], ["Knock Off"], ["Swords Dance"]]
+			}, {
+				"species": "Corphish",
+				"item": ["Eviolite"],
+				"ability": ["Adaptability"],
+				"evs": {"atk": 196, "def": 76, "spe": 236},
+				"nature": ["Jolly", "Adamant"],
+				"moves": [["Crabhammer"], ["Aqua Jet"], ["Knock Off"], ["Dragon Dance"]]
+			}]
+		},
+		"golett": {
+			"sets": [{
+				"species": "Golett",
+				"item": ["Choice Scarf"],
+				"ability": ["No Guard"],
+				"evs": {"atk": 244, "spe": 236},
+				"nature": "Jolly",
+				"moves": [["Poltergeist"], ["Dynamic Punch"], ["Earthquake"], ["Rock Slide"]]
+			}]
+		},
+		"lileep": {
+			"sets": [{
+				"species": "Lileep",
+				"item": ["Eviolite"],
+				"ability": ["Storm Drain"],
+				"evs": {"hp": 148, "def": 140, "spd": 220},
+				"ivs": {"atk": 0},
+				"nature": "Bold",
+				"moves": [["Stealth Rock"], ["Giga Drain"], ["Ancient Power"], ["Recover"]]
+			}]
+		},
+		"meowth": {
+			"sets": [{
+				"species": "Meowth",
+				"item": ["Life Orb"],
+				"ability": ["Technician"],
+				"evs": {"atk": 236, "spa": 36, "spd": 36, "spe": 196},
+				"ivs": {"hp": 19},
+				"nature": "Naughty",
+				"moves": [["Fake Out"], ["Feint"], ["Double-Edge"], ["Water Pulse"]]
+			}, {
+				"species": "Meowth",
+				"item": ["Life Orb"],
+				"ability": ["Technician"],
+				"evs": {"atk": 236, "def": 76, "spe": 196},
+				"ivs": {"hp": 19},
+				"nature": "Adamant",
+				"moves": [["Fake Out"], ["Feint"], ["Double-Edge"], ["U-turn"]]
+			}]
+		},
+		"minccino": {
+			"sets": [{
+				"species": "Minccino",
+				"item": ["Life Orb"],
+				"ability": ["Skill Link"],
+				"evs": {"atk": 36, "def": 196, "spd": 36, "spe": 236},
+				"nature": "Jolly",
+				"moves": [["Tail Slap"], ["Knock Off"], ["Seed Bomb"], ["U-turn"]]
+			}]
+		},
+		"omanyte": {
+			"sets": [{
+				"species": "Omanyte",
+				"item": ["Eviolite"],
+				"ability": ["Shell Armor"],
+				"evs": {"hp": 76, "spa": 196, "spe": 236},
+				"ivs": {"atk": 0},
+				"nature": "Modest",
+				"moves": [["Shell Smash"], ["Hydro Pump"], ["Ice Beam"], ["Earth Power"]]
+			}]
+		},
+		"salandit": {
+			"sets": [{
+				"species": "Salandit",
+				"item": ["Berry Juice"],
+				"ability": ["Corrosion"],
+				"evs": {"hp": 52, "spa": 188, "spd": 36, "spe": 220},
+				"ivs": {"atk": 0},
+				"nature": "Timid",
+				"moves": [["Fire Blast"], ["Sludge Bomb"], ["Thief"], ["Substitute"]]
+			}]
+		},
+		"scorbunny": {
+			"sets": [{
+				"species": "Scorbunny",
+				"item": ["Berry Juice"],
+				"ability": ["Libero"],
+				"evs": {"hp": 36, "atk": 188, "def": 36, "spd": 36, "spe": 204},
+				"nature": "Jolly",
+				"moves": [["Blaze Kick"], ["Gunk Shot"], ["High Jump Kick", "Sucker Punch"], ["U-turn"]]
+			}]
+		},
+		"skrelp": {
+			"sets": [{
+				"species": "Skrelp",
+				"item": ["Eviolite"],
+				"ability": ["Adaptability"],
+				"evs": {"hp": 116, "def": 116, "spa": 196, "spd": 36, "spe": 36},
+				"nature": "Modest",
+				"moves": [["Hydro Pump"], ["Sludge Wave"], ["Toxic Spikes"], ["Flip Turn"]]
+			}]
+		},
+		"tirtouga": {
+			"sets": [{
+				"species": "Tirtouga",
+				"item": ["Eviolite"],
+				"ability": ["Solid Rock"],
+				"evs": {"hp": 4, "atk": 212, "def": 92, "spd": 76, "spe": 100},
+				"nature": "Jolly",
+				"moves": [["Shell Smash"], ["Earthquake"], ["Stone Edge"], ["Zen Headbutt"]]
+			}, {
+				"species": "Tirtouga",
+				"item": ["Eviolite"],
+				"ability": ["Solid Rock"],
+				"evs": {"hp": 164, "atk": 52, "def": 92, "spd": 156, "spe": 20},
+				"nature": "Careful",
+				"moves": [["Stealth Rock"], ["Liquidation"], ["Rock Blast"], ["Aqua Jet", "Knock Off"]]
+			}]
+		}
+	}
+}


### PR DESCRIPTION
After a long, long wait, Gen 8 Battle Factory is done. The room staff are comfortable releasing the format as soon as possible.

Credits:
The vast majority of the sets are transcribed from on-site and in-progress analyses.
Most of LC's sets: Wiggleetuff, Merritt

Consultants:
Ubers: fc, Minority
OU: TPP
UU: Estarossa, Hilomilo
RU: Mac3
NU: Ho3nConfirm3d, Rabia
PU avarice, Chloe
LC: Fiend, Acehunter1
Code problems: Kris, Instruct, Annika
Randbats team consultants: Javitu, Roginald, platinumCheesecake, heroicTobias
