### PR TITLE
ScavFeud: Fix Matching bug

### DIFF
--- a/server/chat-plugins/scavenger-games.ts
+++ b/server/chat-plugins/scavenger-games.ts
@@ -393,7 +393,7 @@ const TWISTS: {[k: string]: Twist} = {
 			const currentQuestion = player.currentQuestion;
 
 			if (currentQuestion + 1 === this.questions.length) {
-				this.guesses[player.id] = value.split(',').map((part: string) => part.trim());
+				this.guesses[player.id] = value.split(',').map((part: string) => toID(part));
 
 				this.onComplete(player);
 				return true;


### PR DESCRIPTION
I have no idea what inspired me to use .trim() here when it obviously should have been toID().