### PR TITLE
Let's Go: Mega Evolve Y & Itemless Megas

### DIFF
--- a/data/mods/gen7letsgo/scripts.ts
+++ b/data/mods/gen7letsgo/scripts.ts
@@ -48,8 +48,8 @@ export const Scripts: ModdedBattleScriptsData = {
 		// mega evolution in LGPE does not require anything to be held
 		canMegaEvo(pokemon: Pokemon) {
 			const species = pokemon.baseSpecies;
-			for (let id in species.otherFormes) {
-				let forme = species.otherFormes[id];
+			for (const id in species.otherFormes) {
+				const forme = species.otherFormes[id];
 				if (forme.includes("-Mega") && forme !== pokemon.name) {
 					return forme;
 				}

--- a/data/mods/gen7letsgo/scripts.ts
+++ b/data/mods/gen7letsgo/scripts.ts
@@ -60,8 +60,8 @@ export const Scripts: ModdedBattleScriptsData = {
 		// lets player select either Charizard or Mewtwo mega evolution during battle
 		canMegaEvoY(pokemon: Pokemon) {
 			const species = pokemon.baseSpecies;
-			for (let id in species.otherFormes) {
-				let forme = species.otherFormes[id];
+			for (const id in species.otherFormes) {
+				const forme = species.otherFormes[id];
 				if (forme.includes("-Mega-Y") && forme !== pokemon.name) {
 					return forme;
 				}

--- a/data/mods/gen7letsgo/scripts.ts
+++ b/data/mods/gen7letsgo/scripts.ts
@@ -43,7 +43,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		}
 		return stats;
 	},
-	
+
 	actions: {
 		// mega evolution in LGPE does not require anything to be held
 		canMegaEvo(pokemon: Pokemon) {
@@ -56,7 +56,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 			return null;
 		},
-		
+
 		// lets player select either Charizard or Mewtwo mega evolution during battle
 		canMegaEvoY(pokemon: Pokemon) {
 			const species = pokemon.baseSpecies;
@@ -68,7 +68,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 			return null;
 		},
-		
+
 		runMegaEvoY(pokemon: Pokemon) {
 			const speciesid = this.canMegaEvoY(pokemon);
 			if (!speciesid) return false;
@@ -87,6 +87,6 @@ export const Scripts: ModdedBattleScriptsData = {
 
 			this.battle.runEvent('AfterMega', pokemon);
 			return true;
-		}
-	}
+		},
+	},
 };

--- a/data/mods/gen7letsgo/scripts.ts
+++ b/data/mods/gen7letsgo/scripts.ts
@@ -43,4 +43,50 @@ export const Scripts: ModdedBattleScriptsData = {
 		}
 		return stats;
 	},
+	
+	actions: {
+		// mega evolution in LGPE does not require anything to be held
+		canMegaEvo(pokemon: Pokemon) {
+			const species = pokemon.baseSpecies;
+			for (let id in species.otherFormes) {
+				let forme = species.otherFormes[id];
+				if (forme.includes("-Mega") && forme !== pokemon.name) {
+					return forme;
+				}
+			}
+			return null;
+		},
+		
+		// lets player select either Charizard or Mewtwo mega evolution during battle
+		canMegaEvoY(pokemon: Pokemon) {
+			const species = pokemon.baseSpecies;
+			for (let id in species.otherFormes) {
+				let forme = species.otherFormes[id];
+				if (forme.includes("-Mega-Y") && forme !== pokemon.name) {
+					return forme;
+				}
+			}
+			return null;
+		},
+		
+		runMegaEvoY(pokemon: Pokemon) {
+			const speciesid = this.canMegaEvoY(pokemon);
+			if (!speciesid) return false;
+
+			pokemon.formeChange(speciesid, pokemon.getItem(), true);
+
+			// Limit one mega evolution
+			const wasMega = pokemon.canMegaEvo;
+			for (const ally of pokemon.side.pokemon) {
+				if (wasMega) {
+					ally.canMegaEvo = null;
+				} else {
+					ally.canUltraBurst = null;
+				}
+			}
+
+			this.battle.runEvent('AfterMega', pokemon);
+			return true;
+		}
+	}
 };

--- a/data/mods/gen7letsgo/scripts.ts
+++ b/data/mods/gen7letsgo/scripts.ts
@@ -48,7 +48,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		// mega evolution in LGPE does not require anything to be held
 		canMegaEvo(pokemon) {
 			const species = pokemon.baseSpecies;
-			for (int i = 0; i < species.otherFormes.length; i++) {
+			for (let i = 0; i < species.otherFormes.length; i++) {
 				const forme = species.otherFormes[i];
 				if (forme.includes("-Mega") && forme !== pokemon.name) {
 					return forme;
@@ -60,7 +60,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		// lets player select either Charizard or Mewtwo mega evolution during battle
 		canMegaEvoY(pokemon) {
 			const species = pokemon.baseSpecies;
-			for (int i = 0; i < species.otherFormes.length; i++) {
+			for (let i = 0; i < species.otherFormes.length; i++) {
 				const forme = species.otherFormes[i];
 				if (forme.includes("-Mega-Y") && forme !== pokemon.name) {
 					return forme;

--- a/data/mods/gen7letsgo/scripts.ts
+++ b/data/mods/gen7letsgo/scripts.ts
@@ -48,8 +48,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		// mega evolution in LGPE does not require anything to be held
 		canMegaEvo(pokemon) {
 			const species = pokemon.baseSpecies;
-			for (let i = 0; i < species.otherFormes.length; i++) {
-				const forme = species.otherFormes[i];
+			for (const forme of species.otherFormes) {
 				if (forme.includes("-Mega") && forme !== pokemon.name) {
 					return forme;
 				}
@@ -60,8 +59,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		// lets player select either Charizard or Mewtwo mega evolution during battle
 		canMegaEvoY(pokemon) {
 			const species = pokemon.baseSpecies;
-			for (let i = 0; i < species.otherFormes.length; i++) {
-				const forme = species.otherFormes[i];
+			for (const forme of species.otherFormes) {
 				if (forme.includes("-Mega-Y") && forme !== pokemon.name) {
 					return forme;
 				}

--- a/data/mods/gen7letsgo/scripts.ts
+++ b/data/mods/gen7letsgo/scripts.ts
@@ -46,10 +46,10 @@ export const Scripts: ModdedBattleScriptsData = {
 
 	actions: {
 		// mega evolution in LGPE does not require anything to be held
-		canMegaEvo(pokemon: Pokemon) {
+		canMegaEvo(pokemon) {
 			const species = pokemon.baseSpecies;
-			for (const id in species.otherFormes) {
-				const forme = species.otherFormes[id];
+			for (int i = 0; i < species.otherFormes.length; i++) {
+				const forme = species.otherFormes[i];
 				if (forme.includes("-Mega") && forme !== pokemon.name) {
 					return forme;
 				}
@@ -58,10 +58,10 @@ export const Scripts: ModdedBattleScriptsData = {
 		},
 
 		// lets player select either Charizard or Mewtwo mega evolution during battle
-		canMegaEvoY(pokemon: Pokemon) {
+		canMegaEvoY(pokemon) {
 			const species = pokemon.baseSpecies;
-			for (const id in species.otherFormes) {
-				const forme = species.otherFormes[id];
+			for (int i = 0; i < species.otherFormes.length; i++) {
+				const forme = species.otherFormes[i];
 				if (forme.includes("-Mega-Y") && forme !== pokemon.name) {
 					return forme;
 				}
@@ -69,7 +69,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			return null;
 		},
 
-		runMegaEvoY(pokemon: Pokemon) {
+		runMegaEvoY(pokemon) {
 			const speciesid = this.canMegaEvoY(pokemon);
 			if (!speciesid) return false;
 

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1765,6 +1765,12 @@ export class BattleActions {
 		}
 		return null;
 	}
+	
+	canMegaEvoY(pokemon: Pokemon) {
+		// implemented in data/mods/gen7letsgo/scripts
+		return null;
+	}
+
 
 	canUltraBurst(pokemon: Pokemon) {
 		if (['Necrozma-Dawn-Wings', 'Necrozma-Dusk-Mane'].includes(pokemon.baseSpecies.name) &&
@@ -1792,6 +1798,11 @@ export class BattleActions {
 
 		this.battle.runEvent('AfterMega', pokemon);
 		return true;
+	}
+	
+	runMegaEvoY(pokemon: Pokemon) {
+		// implemented in data/mods/gen7letsgo/scripts
+		return false;
 	}
 
 	// #endregion

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1765,7 +1765,7 @@ export class BattleActions {
 		}
 		return null;
 	}
-	
+
 	canMegaEvoY(pokemon: Pokemon) {
 		// implemented in data/mods/gen7letsgo/scripts
 		return null;
@@ -1799,7 +1799,7 @@ export class BattleActions {
 		this.battle.runEvent('AfterMega', pokemon);
 		return true;
 	}
-	
+
 	runMegaEvoY(pokemon: Pokemon) {
 		// implemented in data/mods/gen7letsgo/scripts
 		return false;

--- a/sim/battle-queue.ts
+++ b/sim/battle-queue.ts
@@ -92,7 +92,7 @@ export interface FieldAction {
 /** A generic action done by a single pokemon */
 export interface PokemonAction {
 	/** action type */
-	choice: 'megaEvo' | 'shift' | 'runPrimal' | 'runSwitch' | 'event' | 'runUnnerve' | 'runDynamax';
+	choice: 'megaEvo' | 'megaEvoY' | 'shift' | 'runPrimal' | 'runSwitch' | 'event' | 'runUnnerve' | 'runDynamax';
 	/** priority of the action (lower first) */
 	priority: number;
 	/** speed of pokemon doing action (higher first if priority tie) */
@@ -178,6 +178,7 @@ export class BattleQueue {
 				runPrimal: 102,
 				switch: 103,
 				megaEvo: 104,
+				megaEvoY: 104,
 				runDynamax: 105,
 				priorityChargeMove: 106,
 
@@ -205,6 +206,12 @@ export class BattleQueue {
 				if (action.mega && !action.pokemon.isSkyDropped()) {
 					actions.unshift(...this.resolveAction({
 						choice: 'megaEvo',
+						pokemon: action.pokemon,
+					}));
+				}
+				if (action.megay && !action.pokemon.isSkyDropped()) {
+					actions.unshift(...this.resolveAction({
+						choice: 'megaEvoY',
 						pokemon: action.pokemon,
 					}));
 				}

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2461,6 +2461,9 @@ export class Battle {
 		case 'megaEvo':
 			this.actions.runMegaEvo(action.pokemon);
 			break;
+		case 'megaEvoY':
+			this.actions.runMegaEvoY(action.pokemon);
+			break;
 		case 'runDynamax':
 			action.pokemon.addVolatile('dynamax');
 			action.pokemon.side.dynamaxUsed = true;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -244,6 +244,7 @@ export class Pokemon {
 	abilityOrder: number;
 
 	canMegaEvo: string | null | undefined;
+	canMegaEvoY: string | null | undefined;
 	canUltraBurst: string | null | undefined;
 	readonly canGigantamax: string | null;
 
@@ -438,6 +439,7 @@ export class Pokemon {
 		this.abilityOrder = 0;
 
 		this.canMegaEvo = this.battle.actions.canMegaEvo(this);
+		this.canMegaEvoY = this.battle.actions.canMegaEvoY(this);
 		this.canUltraBurst = this.battle.actions.canUltraBurst(this);
 		this.canGigantamax = this.baseSpecies.canGigantamax || null;
 
@@ -986,6 +988,7 @@ export class Pokemon {
 			trapped?: boolean,
 			maybeTrapped?: boolean,
 			canMegaEvo?: boolean,
+			canMegaEvoY?: boolean,
 			canUltraBurst?: boolean,
 			canZMove?: AnyObject | null,
 			canDynamax?: boolean,
@@ -1012,6 +1015,7 @@ export class Pokemon {
 
 		if (!lockedMove) {
 			if (this.canMegaEvo) data.canMegaEvo = true;
+			if (this.canMegaEvoY) data.canMegaEvoY = true;
 			if (this.canUltraBurst) data.canUltraBurst = true;
 			const canZMove = this.battle.actions.canZMove(this);
 			if (canZMove) data.canZMove = canZMove;

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -396,7 +396,7 @@ export class Side {
 		return this.choice.actions.length >= this.active.length;
 	}
 
-	chooseMove(moveText?: string | number, targetLoc = 0, megaDynaOrZ: 'mega' | 'zmove' | 'ultra' | 'dynamax' | '' = '') {
+	chooseMove(moveText?: string | number, targetLoc = 0, megaDynaOrZ: 'mega' | 'megay' | 'zmove' | 'ultra' | 'dynamax' | '' = '') {
 		if (this.requestState !== 'move') {
 			return this.emitChoiceError(`Can't move: You need a ${this.requestState} response`);
 		}
@@ -578,6 +578,7 @@ export class Side {
 		// Mega evolution
 
 		const mega = (megaDynaOrZ === 'mega');
+		const megay = (megaDynaOrZ === 'megay');
 		if (mega && !pokemon.canMegaEvo) {
 			return this.emitChoiceError(`Can't move: ${pokemon.name} can't mega evolve`);
 		}
@@ -614,6 +615,7 @@ export class Side {
 			targetLoc,
 			moveid,
 			mega: mega || ultra,
+			megay: megay,
 			zmove: zMove,
 			maxMove: maxMove ? maxMove.id : undefined,
 		});
@@ -623,6 +625,7 @@ export class Side {
 		}
 
 		if (mega) this.choice.mega = true;
+		if (megay) this.choice.megay = true;
 		if (ultra) this.choice.ultra = true;
 		if (zMove) this.choice.zMove = true;
 		if (dynamax) this.choice.dynamax = true;
@@ -889,9 +892,12 @@ export class Side {
 			switch (choiceType) {
 			case 'move':
 				const original = data;
+				if (data.endsWith(' mega megay')) {
+					return this.emitChoiceError(`Cannot Mega Evolve into X and Y: Please uncheck one box`);
+				}
 				const error = () => this.emitChoiceError(`Conflicting arguments for "move": ${original}`);
 				let targetLoc: number | undefined;
-				let megaDynaOrZ: 'mega' | 'zmove' | 'ultra' | 'dynamax' | '' = '';
+				let megaDynaOrZ: 'mega' | 'megay' | 'zmove' | 'ultra' | 'dynamax' | '' = '';
 				while (true) {
 					// If data ends with a number, treat it as a target location.
 					// We need to special case 'Conversion 2' so it doesn't get
@@ -905,6 +911,10 @@ export class Side {
 						if (megaDynaOrZ) return error();
 						megaDynaOrZ = 'mega';
 						data = data.slice(0, -5);
+					} else if (data.endsWith(' megay')) {
+						if (megaDynaOrZ) return error();
+						megaDynaOrZ = 'megay';
+						data = data.slice(0, -6);
 					} else if (data.endsWith(' zmove')) {
 						if (megaDynaOrZ) return error();
 						megaDynaOrZ = 'zmove';

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -396,8 +396,7 @@ export class Side {
 		return this.choice.actions.length >= this.active.length;
 	}
 
-	chooseMove(moveText?: string | number, targetLoc = 0, 
-	megaDynaOrZ: 'mega' | 'megay' | 'zmove' | 'ultra' | 'dynamax' | '' = '') {
+	chooseMove(moveText?: string | number, targetLoc = 0, megaDynaOrZ: 'mega' | 'megay' | 'zmove' | 'ultra' | 'dynamax' | '' = '') {
 		if (this.requestState !== 'move') {
 			return this.emitChoiceError(`Can't move: You need a ${this.requestState} response`);
 		}

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -36,6 +36,7 @@ export interface ChosenAction {
 	index?: number; // the chosen index in Team Preview
 	side?: Side; // the action's side
 	mega?: boolean | null; // true if megaing or ultra bursting
+	megay?: boolean | null; // true if mega y
 	zmove?: string; // if zmoving, the name of the zmove
 	maxMove?: string; // if dynamaxed, the name of the max move
 	priority?: number; // priority of the action
@@ -51,6 +52,7 @@ export interface Choice {
 	switchIns: Set<number>; // indexes of pokemon chosen to switch in
 	zMove: boolean; // true if a Z-move has already been selected
 	mega: boolean; // true if a mega evolution has already been selected
+	megay: boolean; // true if a mega evolution y has already been selected
 	ultra: boolean; // true if an ultra burst has already been selected
 	dynamax: boolean; // true if a dynamax has already been selected
 }

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -396,7 +396,8 @@ export class Side {
 		return this.choice.actions.length >= this.active.length;
 	}
 
-	chooseMove(moveText?: string | number, targetLoc = 0, megaDynaOrZ: 'mega' | 'megay' | 'zmove' | 'ultra' | 'dynamax' | '' = '') {
+	chooseMove(moveText?: string | number, targetLoc = 0,
+		megaDynaOrZ: 'mega' | 'megay' | 'zmove' | 'ultra' | 'dynamax' | '' = '') {
 		if (this.requestState !== 'move') {
 			return this.emitChoiceError(`Can't move: You need a ${this.requestState} response`);
 		}

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -396,7 +396,8 @@ export class Side {
 		return this.choice.actions.length >= this.active.length;
 	}
 
-	chooseMove(moveText?: string | number, targetLoc = 0, megaDynaOrZ: 'mega' | 'megay' | 'zmove' | 'ultra' | 'dynamax' | '' = '') {
+	chooseMove(moveText?: string | number, targetLoc = 0, 
+	megaDynaOrZ: 'mega' | 'megay' | 'zmove' | 'ultra' | 'dynamax' | '' = '') {
 		if (this.requestState !== 'move') {
 			return this.emitChoiceError(`Can't move: You need a ${this.requestState} response`);
 		}


### PR DESCRIPTION
In Gen 7 Let's Go formats, these changes allow Pokemon to Mega Evolve without a held item, and allow Pokemon with multiple Mega Evolutions to choose between their Mega Evolutions during battle. This is accurate to cartridge. Have tested fairly extensively on my side server, so hopefully it all works! 

This pull request has been made simultaneously with one for smogon/pokemon-showdown-client.