### PR TITLE
/movesearch: Search past gen learnsets

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1618,13 +1618,28 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 			usedSpecies = Utils.deepClone(mod.species.get(usedSpecies.baseSpecies));
 			usedSpeciesLearnset = Utils.deepClone(mod.species.getLearnset(usedSpecies.id) || {});
 		}
-		const lsetData = new Set(Object.keys(usedSpeciesLearnset));
+		const lsetData = new Set();
+		for (const move in usedSpeciesLearnset) {
+			let learnset = mod.species.getLearnset(usedSpecies.id);
+			if (!learnset) return {error: `'${usedSpecies.id}' does not have a learnset.`};
+			let sources = learnset[move];
+			for (let learned of sources) {
+				const sourceGen = parseInt(learned.charAt(0));
+				if (sourceGen <= mod.gen) lsetData.add(move);
+			}
+		}
 
 		while (usedSpecies.prevo) {
 			usedSpecies = Utils.deepClone(mod.species.get(usedSpecies.prevo));
 			usedSpeciesLearnset = Utils.deepClone(mod.species.getLearnset(usedSpecies.id));
 			for (const move in usedSpeciesLearnset) {
-				lsetData.add(move);
+				let learnset = mod.species.getLearnset(usedSpecies.id);
+				if (!learnset) return {error: `'${usedSpecies.id}' does not have a learnset.`};
+				let sources = learnset[move];
+				for (let learned of sources) {
+					const sourceGen = parseInt(learned.charAt(0));
+					if (sourceGen <= mod.gen) lsetData.add(move);
+				}
 			}
 		}
 

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1618,10 +1618,10 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 			usedSpecies = Utils.deepClone(mod.species.get(usedSpecies.baseSpecies));
 			usedSpeciesLearnset = Utils.deepClone(mod.species.getLearnset(usedSpecies.id) || {});
 		}
-		const lsetData = new Set();
+		const lsetData = new Set<string>();
 		for (const move in usedSpeciesLearnset) {
 			const learnset = mod.species.getLearnset(usedSpecies.id);
-			if (!learnset) return {error: `'${usedSpecies.id}' does not have a learnset.`};
+			if (!learnset) break;
 			const sources = learnset[move];
 			for (const learned of sources) {
 				const sourceGen = parseInt(learned.charAt(0));
@@ -1634,7 +1634,7 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 			usedSpeciesLearnset = Utils.deepClone(mod.species.getLearnset(usedSpecies.id));
 			for (const move in usedSpeciesLearnset) {
 				const learnset = mod.species.getLearnset(usedSpecies.id);
-				if (!learnset) return {error: `'${usedSpecies.id}' does not have a learnset.`};
+				if (!learnset) break;
 				const sources = learnset[move];
 				for (const learned of sources) {
 					const sourceGen = parseInt(learned.charAt(0));

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1620,10 +1620,10 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 		}
 		const lsetData = new Set();
 		for (const move in usedSpeciesLearnset) {
-			let learnset = mod.species.getLearnset(usedSpecies.id);
+			const learnset = mod.species.getLearnset(usedSpecies.id);
 			if (!learnset) return {error: `'${usedSpecies.id}' does not have a learnset.`};
-			let sources = learnset[move];
-			for (let learned of sources) {
+			const sources = learnset[move];
+			for (const learned of sources) {
 				const sourceGen = parseInt(learned.charAt(0));
 				if (sourceGen <= mod.gen) lsetData.add(move);
 			}
@@ -1633,10 +1633,10 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 			usedSpecies = Utils.deepClone(mod.species.get(usedSpecies.prevo));
 			usedSpeciesLearnset = Utils.deepClone(mod.species.getLearnset(usedSpecies.id));
 			for (const move in usedSpeciesLearnset) {
-				let learnset = mod.species.getLearnset(usedSpecies.id);
+				const learnset = mod.species.getLearnset(usedSpecies.id);
 				if (!learnset) return {error: `'${usedSpecies.id}' does not have a learnset.`};
-				let sources = learnset[move];
-				for (let learned of sources) {
+				const sources = learnset[move];
+				for (const learned of sources) {
 					const sourceGen = parseInt(learned.charAt(0));
 					if (sourceGen <= mod.gen) lsetData.add(move);
 				}


### PR DESCRIPTION
The code for /movesearch in past gens would add a move for a Pokemon without regards to if it could learn the move in a given generation; this change will check a move's source generations and add moves only if the move can be learned in a current or past generation.

This fixes https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-8608692