### PR TITLE
Add FAQs for custom avatars and the privacy policy

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2072,7 +2072,7 @@ export const commands: Chat.ChatCommands = {
 		if (showAll || ['vpn', 'proxy'].includes(target)) {
 			buffer.push(`<a href="https://pokemonshowdown.com/${this.tr`pages/proxyhelp`}">${this.tr`Proxy lock help`}</a>`);
 		}
-		if (showAll || target === 'ca' || target === 'customavatar' || target === 'customavatars' || target === 'customavi' ||target === 'customavis') {
+		if (showAll || target === 'ca' || target === 'customavatar' || target === 'customavatars' || target === 'customavi' || target === 'customavis') {
 			buffer.push(this.tr`Custom avatars are given to Global Staff members, contributors (coders and spriters) to Pokemon Showdown, and Smogon badgeholders at the discretion of Zarel. They are also sometimes given out as prizes for major room events or Smogon tournaments.`);
 		}
 		if (showAll || ['privacy', 'private'].includes(target)) {

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2072,7 +2072,7 @@ export const commands: Chat.ChatCommands = {
 		if (showAll || ['vpn', 'proxy'].includes(target)) {
 			buffer.push(`<a href="https://pokemonshowdown.com/${this.tr`pages/proxyhelp`}">${this.tr`Proxy lock help`}</a>`);
 		}
-		if (showAll || target === 'ca' || target === 'customavatar' || target === 'customavatars') {
+		if (showAll || ['ca', 'customavatar', 'customavatars'].includes('target') {
 			buffer.push(this.tr`Custom avatars are given to Global Staff members, contributors (coders and spriters) to Pokemon Showdown, and Smogon badgeholders at the discretion of Zarel. They are also sometimes given out as prizes for major room events or Smogon tournaments.`);
 		}
 		if (showAll || ['privacy', 'private'].includes(target)) {

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2072,6 +2072,12 @@ export const commands: Chat.ChatCommands = {
 		if (showAll || ['vpn', 'proxy'].includes(target)) {
 			buffer.push(`<a href="https://pokemonshowdown.com/${this.tr`pages/proxyhelp`}">${this.tr`Proxy lock help`}</a>`);
 		}
+		if (showAll || target === 'ca' || target === 'customavatar' || target === 'customavatars' || target === 'customavi' ||target === 'customavis') {
+			buffer.push(this.tr`Custom avatars are given to Global Staff members, contributors (coders and spriters) to Pokemon Showdown, and Smogon badgeholders at the discretion of Zarel. They are also sometimes given out as prizes for major room events or Smogon tournaments.`);
+		}
+		if (showAll || ['privacy', 'private'].includes(target)) {
+			buffer.push(`<a href="https://pokemonshowdown.com/${this.tr`pages/privacy`}">${this.tr`Pokémon Showdown privacy policy`}</a>`);
+		}
 		if (!buffer.length && target) {
 			this.errorReply(`'${target}' is an invalid FAQ.`);
 			return this.parse(`/help faq`);

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2072,7 +2072,7 @@ export const commands: Chat.ChatCommands = {
 		if (showAll || ['vpn', 'proxy'].includes(target)) {
 			buffer.push(`<a href="https://pokemonshowdown.com/${this.tr`pages/proxyhelp`}">${this.tr`Proxy lock help`}</a>`);
 		}
-		if (showAll || target === 'ca' || target === 'customavatar' || target === 'customavatars' || target === 'customavi' || target === 'customavis') {
+		if (showAll || target === 'ca' || target === 'customavatar' || target === 'customavatars') {
 			buffer.push(this.tr`Custom avatars are given to Global Staff members, contributors (coders and spriters) to Pokemon Showdown, and Smogon badgeholders at the discretion of Zarel. They are also sometimes given out as prizes for major room events or Smogon tournaments.`);
 		}
 		if (showAll || ['privacy', 'private'].includes(target)) {

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2072,7 +2072,7 @@ export const commands: Chat.ChatCommands = {
 		if (showAll || ['vpn', 'proxy'].includes(target)) {
 			buffer.push(`<a href="https://pokemonshowdown.com/${this.tr`pages/proxyhelp`}">${this.tr`Proxy lock help`}</a>`);
 		}
-		if (showAll || ['ca', 'customavatar', 'customavatars'].includes('target') {
+		if (showAll || ['ca', 'customavatar', 'customavatars'].includes('target')) {
 			buffer.push(this.tr`Custom avatars are given to Global Staff members, contributors (coders and spriters) to Pokemon Showdown, and Smogon badgeholders at the discretion of Zarel. They are also sometimes given out as prizes for major room events or Smogon tournaments.`);
 		}
 		if (showAll || ['privacy', 'private'].includes(target)) {


### PR DESCRIPTION
these are very frequently asked questions across the sim and having global FAQs for them rather than relying on room FAQs is just simplifying and uniformising things.