### PR TITLE
Validator: Push problems for all failed events

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -684,18 +684,15 @@ export class TeamValidator {
 				} else {
 					problems.push(`${species.name} is only obtainable from events - it needs to match one of its events, such as:`);
 				}
-				let eventInfo = eventData[0];
-				let eventNum = 1;
 				for (const [i, event] of eventData.entries()) {
 					if (event.generation <= dex.gen && event.generation >= this.minSourceGen) {
-						eventInfo = event;
-						eventNum = i + 1;
-						break;
+						const eventInfo = event;
+						const eventNum = i + 1;
+						const eventName = eventData.length > 1 ? ` #${eventNum}` : ``;
+						const eventProblems = this.validateEvent(set, eventInfo, eventSpecies, ` to be`, `from its event${eventName}`);
+						if (eventProblems) problems.push(...eventProblems);
 					}
 				}
-				const eventName = eventData.length > 1 ? ` #${eventNum}` : ``;
-				const eventProblems = this.validateEvent(set, eventInfo, eventSpecies, ` to be`, `from its event${eventName}`);
-				if (eventProblems) problems.push(...eventProblems);
 			}
 		}
 

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -682,7 +682,7 @@ export class TeamValidator {
 				if (eventData.length === 1) {
 					problems.push(`${species.name} is only obtainable from an event - it needs to match its event:`);
 				} else {
-					problems.push(`${species.name} is only obtainable from events - it needs to match one of its events, such as:`);
+					problems.push(`${species.name} is only obtainable from events - it needs to match one of its events:`);
 				}
 				for (const [i, event] of eventData.entries()) {
 					if (event.generation <= dex.gen && event.generation >= this.minSourceGen) {


### PR DESCRIPTION
Currently, when validating events that fail because of "either/or" reasons, the validator just picks the first event it can find and claims incompatibility with that event. For example, consider a Shiny Eternatus with 0 Atk IVs. Compare before and after:

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/23667022/194797660-67fa8e33-41f1-4627-bb45-607c1d93f419.png">
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/23667022/194797588-40a27b5c-d3c9-414b-8607-f39befa8c0d8.png">
</details>

So I think it's much clearer to list all possible events and their incompatibility with each. This does have the downside of Pokemon with many events making the problems it gives back a bit longer, but I think it's a fine trade-off. This doesn't happen with _every_ event Pokemon incompatibility edge case though; Pokemon that can't be Shiny are a common example of ones affected:

<details>
<summary>Example with Shiny Victini</summary>
<img src="https://user-images.githubusercontent.com/23667022/194797805-714c5beb-599a-48e9-8537-0e74f9814176.png">
</details>