### PR TITLE
Hangman: Prevent impossible guesses and fix HTML escape

### DIFF
--- a/server/chat-plugins/hangman.ts
+++ b/server/chat-plugins/hangman.ts
@@ -150,6 +150,15 @@ export class Hangman extends Rooms.SimpleRoomGame {
 	guessWord(word: string, guesser: string) {
 		const ourWord = toID(this.word.replace(/[0-9]+/g, ''));
 		const guessedWord = toID(word.replace(/[0-9]+/g, ''));
+
+		// Can't be a correct guess if the lengths don't match
+		if (ourWord.length !== guessedWord.length) return false;
+
+		// Can't be a correct guess if the guess has incorrect letters in already guessed indexes
+		for (let i = 0; i < ourWord.length; i++) {
+			if (ourWord.charAt(i) !== '_' && ourWord.charAt(i) !== guessedWord.charAt(i)) return false;
+		}
+
 		if (ourWord === guessedWord) {
 			for (const [i, letter] of this.wordSoFar.entries()) {
 				if (letter === '_') {
@@ -160,15 +169,13 @@ export class Hangman extends Rooms.SimpleRoomGame {
 			this.guesses.push(word);
 			this.lastGuesser = guesser;
 			this.finish();
-			return true;
-		} else if (ourWord.length === guessedWord.length) {
+		} else {
 			this.incorrectGuesses++;
 			this.guesses.push(word);
 			this.lastGuesser = guesser;
 			this.update();
-			return true;
 		}
-		return false;
+		return true;
 	}
 
 	hangingMan() {

--- a/server/chat-plugins/hangman.ts
+++ b/server/chat-plugins/hangman.ts
@@ -7,6 +7,9 @@ import {FS, Utils} from '../../lib';
 const HANGMAN_FILE = 'config/chat-plugins/hangman.json';
 
 const DIACRITICS_AFTER_UNDERSCORE = /_[\u0300-\u036f\u0483-\u0489\u0610-\u0615\u064B-\u065F\u0670\u06D6-\u06DC\u06DF-\u06ED\u0E31\u0E34-\u0E3A\u0E47-\u0E4E]+/g;
+const MAX_HANGMAN_LENGTH = 30;
+const MAX_INDIVIDUAL_WORD_LENGTH = 20;
+const MAX_HINT_LENGTH = 150;
 
 interface HangmanEntry {
 	hints: string[];
@@ -98,7 +101,7 @@ export class Hangman extends Rooms.SimpleRoomGame {
 		if (normalized.length < 1) {
 			throw new Chat.ErrorMessage(`Use "/guess [letter]" to guess a letter, or "/guess [phrase]" to guess the entire Hangman phrase.`);
 		}
-		if (sanitized.length > 30) throw new Chat.ErrorMessage(`Guesses must be 30 or fewer letters – "${word}" is too long.`);
+		if (sanitized.length > MAX_HANGMAN_LENGTH) throw new Chat.ErrorMessage(`Guesses must be ${MAX_HANGMAN_LENGTH} or fewer letters – "${word}" is too long.`);
 
 		for (const guessid of this.guesses) {
 			if (normalized === toID(guessid)) throw new Chat.ErrorMessage(`Your guess "${word}" has already been guessed.`);
@@ -289,15 +292,15 @@ export class Hangman extends Rooms.SimpleRoomGame {
 		const phrase = params[0].normalize('NFD').trim().replace(/_/g, '\uFF3F');
 
 		if (!phrase.length) throw new Chat.ErrorMessage("Enter a valid word");
-		if (phrase.length > 30) throw new Chat.ErrorMessage("Phrase must be less than 30 characters long.");
-		if (phrase.split(' ').some(w => w.length > 20)) {
-			throw new Chat.ErrorMessage("Each word in the phrase must be less than 20 characters long.");
+		if (phrase.length > MAX_HANGMAN_LENGTH) throw new Chat.ErrorMessage(`Phrase must be less than ${MAX_HANGMAN_LENGTH} characters long.`);
+		if (phrase.split(' ').some(w => w.length > MAX_INDIVIDUAL_WORD_LENGTH)) {
+			throw new Chat.ErrorMessage(`Each word in the phrase must be less than ${MAX_INDIVIDUAL_WORD_LENGTH} characters long.`);
 		}
 		if (!/[a-zA-Z]/.test(phrase)) throw new Chat.ErrorMessage("Word must contain at least one letter.");
 		let hint;
 		if (params.length > 1) {
 			hint = params.slice(1).join(',').trim();
-			if (hint.length > 150) throw new Chat.ErrorMessage("Hint too long.");
+			if (hint.length > MAX_HINT_LENGTH) throw new Chat.ErrorMessage(`Hint must be less than ${MAX_HINT_LENGTH} characters long.`);
 		}
 		return {phrase, hint};
 	}

--- a/server/chat-plugins/hangman.ts
+++ b/server/chat-plugins/hangman.ts
@@ -211,7 +211,7 @@ export class Hangman extends Rooms.SimpleRoomGame {
 		wordString = wordString.replace(DIACRITICS_AFTER_UNDERSCORE, '_');
 
 		if (this.hint) output += Utils.html`<div>(Hint: ${this.hint})</div>`;
-		output += `<p style="font-weight:bold;font-size:12pt;letter-spacing:3pt">${wordString}</p>`;
+		output += `<p style="font-weight:bold;font-size:12pt;letter-spacing:3pt">${Utils.escapeHTML(wordString)}</p>`;
 		if (this.guesses.length) {
 			if (this.letterGuesses.length) {
 				output += 'Letters: ' + this.letterGuesses.map(

--- a/server/chat-plugins/hangman.ts
+++ b/server/chat-plugins/hangman.ts
@@ -101,7 +101,9 @@ export class Hangman extends Rooms.SimpleRoomGame {
 		if (normalized.length < 1) {
 			throw new Chat.ErrorMessage(`Use "/guess [letter]" to guess a letter, or "/guess [phrase]" to guess the entire Hangman phrase.`);
 		}
-		if (sanitized.length > MAX_HANGMAN_LENGTH) throw new Chat.ErrorMessage(`Guesses must be ${MAX_HANGMAN_LENGTH} or fewer letters – "${word}" is too long.`);
+		if (sanitized.length > MAX_HANGMAN_LENGTH) {
+			throw new Chat.ErrorMessage(`Guesses must be ${MAX_HANGMAN_LENGTH} or fewer letters – "${word}" is too long.`);
+		}
 
 		for (const guessid of this.guesses) {
 			if (normalized === toID(guessid)) throw new Chat.ErrorMessage(`Your guess "${word}" has already been guessed.`);
@@ -292,7 +294,9 @@ export class Hangman extends Rooms.SimpleRoomGame {
 		const phrase = params[0].normalize('NFD').trim().replace(/_/g, '\uFF3F');
 
 		if (!phrase.length) throw new Chat.ErrorMessage("Enter a valid word");
-		if (phrase.length > MAX_HANGMAN_LENGTH) throw new Chat.ErrorMessage(`Phrase must be less than ${MAX_HANGMAN_LENGTH} characters long.`);
+		if (phrase.length > MAX_HANGMAN_LENGTH) {
+			throw new Chat.ErrorMessage(`Phrase must be less than ${MAX_HANGMAN_LENGTH} characters long.`);
+		}
 		if (phrase.split(' ').some(w => w.length > MAX_INDIVIDUAL_WORD_LENGTH)) {
 			throw new Chat.ErrorMessage(`Each word in the phrase must be less than ${MAX_INDIVIDUAL_WORD_LENGTH} characters long.`);
 		}
@@ -300,7 +304,9 @@ export class Hangman extends Rooms.SimpleRoomGame {
 		let hint;
 		if (params.length > 1) {
 			hint = params.slice(1).join(',').trim();
-			if (hint.length > MAX_HINT_LENGTH) throw new Chat.ErrorMessage(`Hint must be less than ${MAX_HINT_LENGTH} characters long.`);
+			if (hint.length > MAX_HINT_LENGTH) {
+				throw new Chat.ErrorMessage(`Hint must be less than ${MAX_HINT_LENGTH} characters long.`);
+			}
 		}
 		return {phrase, hint};
 	}


### PR DESCRIPTION
Fixes 3 issues with hangman:

1. When a letter is already successfully guessed, other impossible guesses can be submitted that don't take into account the current letters revealed.
<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/23667022/194980444-166b242c-3280-49e2-85ff-7a24e5199211.png">
</details>
<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/23667022/194980872-61e9d7e0-d98c-418c-a3e7-390b4fe8d18f.png">
</details>

2. Words with HTML will break formatting, typically hiding or otherwise obscuring the message. Here's an example with `</div>`.
<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/23667022/194980022-9cd7ca43-7694-4965-b74e-1645957a925a.png">
</details>
<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/23667022/194980098-722233f0-b8ff-47b2-8f73-87d9f7cf039a.png">
</details>

3. Hint length just said "too long" and didn't clarify the number of characters. I refactored all of the length requirements to be constants at the top of the file.