### PR TITLE
Fix Neutralizing Gas Primal weather interaction

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -2348,6 +2348,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (pokemon.transformed) return;
 			this.add('-ability', pokemon, 'Neutralizing Gas');
 			pokemon.abilityState.ending = false;
+			const strongWeathers = ['desolateland', 'primordialsea', 'deltastream'];
 			for (const target of this.getAllActive()) {
 				if (target.illusion) {
 					this.singleEvent('End', this.dex.abilities.get('Illusion'), target.abilityState, target, pokemon, 'neutralizinggas');
@@ -2355,6 +2356,9 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				if (target.volatiles['slowstart']) {
 					delete target.volatiles['slowstart'];
 					this.add('-end', target, 'Slow Start', '[silent]');
+				}
+				if (strongWeathers.includes(target.getAbility().id)) {
+					this.singleEvent('End', this.dex.abilities.get(target.getAbility().id), target.abilityState, target, pokemon, 'neutralizinggas');
 				}
 			}
 		},

--- a/test/sim/abilities/neutralizinggas.js
+++ b/test/sim/abilities/neutralizinggas.js
@@ -82,7 +82,7 @@ describe('Neutralizing Gas', function () {
 		assert.fullHP(battle.p1.active[0]);
 	});
 
-	it.skip(`should negate Primal weather Abilities`, function () {
+	it(`should negate Primal weather Abilities`, function () {
 		battle = common.createBattle([[
 			{species: 'Groudon', item: 'redorb', moves: ['sleeptalk']},
 		], [


### PR DESCRIPTION
Neutralizing gas now negates strong weather abilities and restores them on exit.

As suggested on [this Mechanics Bugs card](https://github.com/smogon/pokemon-showdown/projects/3#card-85843136)