### PR TITLE
Avoid `any` in random-teams & fix unhandled nulls

### DIFF
--- a/data/mods/gen1/random-teams.ts
+++ b/data/mods/gen1/random-teams.ts
@@ -129,7 +129,7 @@ export class RandomGen1Teams extends RandomGen2Teams {
 
 		const pokemonPool = this.getPokemonPool(type, pokemon, isMonotype);
 		while (pokemonPool.length && pokemon.length < this.maxTeamSize) {
-			const species = this.dex.species.get(this.sampleNoReplace(pokemonPool));
+			const species = this.dex.species.get(this.sampleNoReplaceOrError(pokemonPool));
 			if (!species.exists || !species.randomBattleMoves) continue;
 			// Only one Ditto is allowed per battle in Generation 1,
 			// as it can cause an endless battle if two Dittos are forced
@@ -226,7 +226,7 @@ export class RandomGen1Teams extends RandomGen2Teams {
 
 		// if we don't have enough Pokémon, go back to rejects, which are already known to not be invalid.
 		while (pokemon.length < this.maxTeamSize && rejectedButNotInvalidPool.length) {
-			const species = this.sampleNoReplace(rejectedButNotInvalidPool);
+			const species = this.sampleNoReplaceOrError(rejectedButNotInvalidPool);
 			pokemon.push(this.randomSet(species));
 		}
 
@@ -297,7 +297,7 @@ export class RandomGen1Teams extends RandomGen2Teams {
 		while (moves.size < this.maxMoveCount && movePool.length) {
 			// Choose next 4 moves from learnset/viable moves and add them to moves list:
 			while (moves.size < this.maxMoveCount && movePool.length) {
-				const moveid = this.sampleNoReplace(movePool);
+				const moveid = this.sampleNoReplaceOrError(movePool);
 				moves.add(moveid);
 			}
 
@@ -397,7 +397,7 @@ export class RandomGen1Teams extends RandomGen2Teams {
 			// Random unique moves
 			const moves = [];
 			do {
-				const move = this.sampleNoReplace(movePool);
+				const move = this.sampleNoReplaceOrError(movePool);
 				if (move.gen <= this.gen && !move.isNonstandard && !move.name.startsWith('Hidden Power ')) {
 					moves.push(move.id);
 				}

--- a/data/mods/gen2/random-teams.ts
+++ b/data/mods/gen2/random-teams.ts
@@ -168,7 +168,7 @@ export class RandomGen2Teams extends RandomGen3Teams {
 		do {
 			// Choose next 4 moves from learnset/viable moves and add them to moves list:
 			while (moves.size < this.maxMoveCount && movePool.length) {
-				const moveid = this.sampleNoReplace(movePool);
+				const moveid = this.sampleNoReplaceOrError(movePool);
 				if (moveid.startsWith('hiddenpower')) {
 					availableHP--;
 					if (hasHiddenPower) continue;
@@ -177,7 +177,7 @@ export class RandomGen2Teams extends RandomGen3Teams {
 				moves.add(moveid);
 			}
 			while (moves.size < this.maxMoveCount && rejectedPool.length) {
-				const moveid = this.sampleNoReplace(rejectedPool);
+				const moveid = this.sampleNoReplaceOrError(rejectedPool);
 				if (moveid.startsWith('hiddenpower')) {
 					if (hasHiddenPower) continue;
 					hasHiddenPower = true;

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -358,7 +358,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		do {
 			// Choose next 4 moves from learnset/viable moves and add them to moves list:
 			while (moves.size < this.maxMoveCount && movePool.length) {
-				const moveid = this.sampleNoReplace(movePool);
+				const moveid = this.sampleNoReplaceOrError(movePool);
 				if (moveid.startsWith('hiddenpower')) {
 					availableHP--;
 					if (hasHiddenPower) continue;
@@ -368,7 +368,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			}
 
 			while (moves.size < this.maxMoveCount && rejectedPool.length) {
-				const moveid = this.sampleNoReplace(rejectedPool);
+				const moveid = this.sampleNoReplaceOrError(rejectedPool);
 				if (moveid.startsWith('hiddenpower')) {
 					if (hasHiddenPower) continue;
 					hasHiddenPower = true;
@@ -592,7 +592,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		const pokemonPool = this.getPokemonPool(type, pokemon, isMonotype);
 
 		while (pokemonPool.length && pokemon.length < this.maxTeamSize) {
-			const species = this.dex.species.get(this.sampleNoReplace(pokemonPool));
+			const species = this.dex.species.get(this.sampleNoReplaceOrError(pokemonPool));
 			if (!species.exists || !species.randomBattleMoves) continue;
 			// Limit to one of each species (Species Clause)
 			if (baseFormes[species.baseSpecies]) continue;

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -538,7 +538,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		do {
 			// Choose next 4 moves from learnset/viable moves and add them to moves list:
 			while (moves.size < this.maxMoveCount && movePool.length) {
-				const moveid = this.sampleNoReplace(movePool);
+				const moveid = this.sampleNoReplaceOrError(movePool);
 				if (moveid.startsWith('hiddenpower')) {
 					availableHP--;
 					if (hasHiddenPower) continue;
@@ -548,7 +548,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			}
 
 			while (moves.size < this.maxMoveCount && rejectedPool.length) {
-				const moveid = this.sampleNoReplace(rejectedPool);
+				const moveid = this.sampleNoReplaceOrError(rejectedPool);
 				if (moveid.startsWith('hiddenpower')) {
 					if (hasHiddenPower) continue;
 					hasHiddenPower = true;

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -480,7 +480,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		do {
 			// Choose next 4 moves from learnset/viable moves and add them to moves list:
 			while (moves.size < this.maxMoveCount && movePool.length) {
-				const moveid = this.sampleNoReplace(movePool);
+				const moveid = this.sampleNoReplaceOrError(movePool);
 				if (moveid.startsWith('hiddenpower')) {
 					availableHP--;
 					if (hasHiddenPower) continue;
@@ -490,7 +490,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			}
 
 			while (moves.size < this.maxMoveCount && rejectedPool.length) {
-				const moveid = this.sampleNoReplace(rejectedPool);
+				const moveid = this.sampleNoReplaceOrError(rejectedPool);
 				if (moveid.startsWith('hiddenpower')) {
 					if (hasHiddenPower) {
 						continue;
@@ -795,7 +795,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		const pokemonPool = this.getPokemonPool(type, pokemon, isMonotype);
 
 		while (pokemonPool.length && pokemon.length < this.maxTeamSize) {
-			const species = this.dex.species.get(this.sampleNoReplace(pokemonPool));
+			const species = this.dex.species.get(this.sampleNoReplaceOrError(pokemonPool));
 			if (!species.exists || !species.randomBattleMoves) continue;
 
 			// Limit to one of each species (Species Clause)

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -808,7 +808,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		do {
 			// Choose next 4 moves from learnset/viable moves and add them to moves list:
 			while (moves.size < this.maxMoveCount && movePool.length) {
-				const moveid = this.sampleNoReplace(movePool);
+				const moveid = this.sampleNoReplaceOrError(movePool);
 				if (moveid.startsWith('hiddenpower')) {
 					availableHP--;
 					if (hasHiddenPower) continue;
@@ -818,7 +818,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			}
 
 			while (moves.size < this.maxMoveCount && rejectedPool.length) {
-				const moveid = this.sampleNoReplace(rejectedPool);
+				const moveid = this.sampleNoReplaceOrError(rejectedPool);
 				if (moveid.startsWith('hiddenpower')) {
 					if (hasHiddenPower) continue;
 					hasHiddenPower = true;
@@ -1232,7 +1232,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		};
 
 		while (pokemonPool.length && pokemon.length < this.maxTeamSize) {
-			const species = this.dex.species.get(this.sampleNoReplace(pokemonPool));
+			const species = this.dex.species.get(this.sampleNoReplaceOrError(pokemonPool));
 			if (!species.exists) continue;
 
 			const speciesFlags = this.randomFactorySets[chosenTier][species.id].flags;

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1073,7 +1073,7 @@ export class RandomGen7Teams extends RandomTeams {
 		do {
 			// Choose next 4 moves from learnset/viable moves and add them to moves list:
 			while (moves.size < this.maxMoveCount && movePool.length) {
-				const moveid = this.sampleNoReplace(movePool);
+				const moveid = this.sampleNoReplaceOrError(movePool);
 				if (moveid.startsWith('hiddenpower')) {
 					availableHP--;
 					if (hasHiddenPower) continue;
@@ -1082,7 +1082,7 @@ export class RandomGen7Teams extends RandomTeams {
 				moves.add(moveid);
 			}
 			while (moves.size < this.maxMoveCount && rejectedPool.length) {
-				const moveid = this.sampleNoReplace(rejectedPool);
+				const moveid = this.sampleNoReplaceOrError(rejectedPool);
 				if (moveid.startsWith('hiddenpower')) {
 					if (hasHiddenPower) continue;
 					hasHiddenPower = true;
@@ -1492,7 +1492,7 @@ export class RandomGen7Teams extends RandomTeams {
 			if (pokemon.length >= this.maxTeamSize) break;
 			const pokemonPool = this.getPokemonPool(type, pokemon, isMonotype);
 			while (pokemonPool.length && pokemon.length < this.maxTeamSize) {
-				const species = this.dex.species.get(this.sampleNoReplace(pokemonPool));
+				const species = this.dex.species.get(this.sampleNoReplaceOrError(pokemonPool));
 
 				// Check if the forme has moves for random battle
 				if (this.format.gameType === 'singles') {
@@ -1796,7 +1796,7 @@ export class RandomGen7Teams extends RandomTeams {
 		};
 
 		while (pokemonPool.length && pokemon.length < this.maxTeamSize) {
-			const species = this.dex.species.get(this.sampleNoReplace(pokemonPool));
+			const species = this.dex.species.get(this.sampleNoReplaceOrError(pokemonPool));
 			if (!species.exists) continue;
 
 			// Lessen the need of deleting sets of Pokemon after tier shifts
@@ -2059,7 +2059,7 @@ export class RandomGen7Teams extends RandomTeams {
 		};
 
 		while (pokemonPool.length && pokemon.length < this.maxTeamSize) {
-			const species = this.dex.species.get(this.sampleNoReplace(pokemonPool));
+			const species = this.dex.species.get(this.sampleNoReplaceOrError(pokemonPool));
 			if (!species.exists) continue;
 
 			const speciesFlags = this.randomBSSFactorySets[species.id].flags;

--- a/data/mods/gen7letsgo/random-teams.ts
+++ b/data/mods/gen7letsgo/random-teams.ts
@@ -132,7 +132,7 @@ export class RandomLetsGoTeams extends RandomTeams {
 		do {
 			// Choose next 4 moves from learnset/viable moves and add them to moves list:
 			while (moves.size < this.maxMoveCount && movePool.length) {
-				const moveid = this.sampleNoReplace(movePool);
+				const moveid = this.sampleNoReplaceOrError(movePool);
 				moves.add(moveid);
 			}
 
@@ -240,7 +240,7 @@ export class RandomLetsGoTeams extends RandomTeams {
 		const teamDetails: RandomTeamsTypes.TeamDetails = {};
 
 		while (pokemonPool.length && pokemon.length < this.maxTeamSize) {
-			const species = this.dex.species.get(this.sampleNoReplace(pokemonPool));
+			const species = this.dex.species.get(this.sampleNoReplaceOrError(pokemonPool));
 			if (!species.exists) continue;
 
 			// Limit to one of each species (Species Clause)

--- a/data/mods/ssb/random-teams.ts
+++ b/data/mods/ssb/random-teams.ts
@@ -888,7 +888,7 @@ export class RandomStaffBrosTeams extends RandomTeams {
 		while (pool.length && team.length < this.maxTeamSize) {
 			if (depth >= 200) throw new Error(`Infinite loop in Super Staff Bros team generation.`);
 			depth++;
-			const name = wiiulegacy ? this.sample(pool) : this.sampleNoReplace(pool);
+			const name = wiiulegacy ? this.sample(pool) : this.sampleNoReplaceOrError(pool);
 			const ssbSet: SSBSet = wiiulegacy ? this.dex.deepClone(afdSSBSets[name]) : this.dex.deepClone(ssbSets[name]);
 			if (ssbSet.skip) continue;
 
@@ -928,10 +928,13 @@ export class RandomStaffBrosTeams extends RandomTeams {
 			const set: PokemonSet = {
 				name: name,
 				species: ssbSet.species,
-				item: Array.isArray(ssbSet.item) ? this.sampleNoReplace(ssbSet.item) : ssbSet.item,
-				ability: Array.isArray(ssbSet.ability) ? this.sampleNoReplace(ssbSet.ability) : ssbSet.ability,
+				item: Array.isArray(ssbSet.item) ? this.sampleNoReplaceOrError(ssbSet.item) : ssbSet.item,
+				ability: Array.isArray(ssbSet.ability) ? this.sampleNoReplaceOrError(ssbSet.ability) : ssbSet.ability,
 				moves: [],
-				nature: ssbSet.nature ? Array.isArray(ssbSet.nature) ? this.sampleNoReplace(ssbSet.nature) : ssbSet.nature : 'Serious',
+				nature: ssbSet.nature ?
+					Array.isArray(ssbSet.nature) ?
+						this.sampleNoReplaceOrError(ssbSet.nature) :
+						ssbSet.nature : 'Serious',
 				gender: ssbSet.gender || this.sample(['M', 'F', 'N']),
 				evs: ssbSet.evs ? {...{hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0}, ...ssbSet.evs} :
 				{hp: 84, atk: 84, def: 84, spa: 84, spd: 84, spe: 84},
@@ -941,8 +944,8 @@ export class RandomStaffBrosTeams extends RandomTeams {
 				shiny: typeof ssbSet.shiny === 'number' ? this.randomChance(1, ssbSet.shiny) : !!ssbSet.shiny,
 			};
 			while (set.moves.length < 3 && ssbSet.moves.length > 0) {
-				let move = this.sampleNoReplace(ssbSet.moves);
-				if (Array.isArray(move)) move = this.sampleNoReplace(move);
+				let move = this.sampleNoReplaceOrError(ssbSet.moves);
+				if (Array.isArray(move)) move = this.sampleNoReplaceOrError(move);
 				set.moves.push(move);
 			}
 			set.moves.push(ssbSet.signatureMove);


### PR DESCRIPTION
- Improved types of utils in `random-teams` to avoid `any`.
- Created `sampleNoReplaceOrError` to get a non-null value. The original func can return nulls, which could result in nulls accidentally propagating across the data in some rare cases (Maybe 0 cases right now? But still better to be safe)