### PR TITLE
Utils: Avoid `any`

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1201,7 +1201,7 @@ export const Formats: FormatList = [
 
 			const mixedSpecies = this.dex.deepClone(species);
 			mixedSpecies.weightkg =
-				Math.max(0.1, +(species.weightkg + crossSpecies.weightkg - crossPrevoSpecies.weightkg)).toFixed(1);
+				parseFloat(Math.max(0.1, +(species.weightkg + crossSpecies.weightkg - crossPrevoSpecies.weightkg)).toFixed(1));
 			mixedSpecies.nfe = false;
 			mixedSpecies.evos = [];
 			mixedSpecies.eggGroups = crossSpecies.eggGroups;

--- a/data/mods/gen1/rulesets.ts
+++ b/data/mods/gen1/rulesets.ts
@@ -17,7 +17,8 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 			const bst = newSpecies.bst;
 			if (bst <= 350) {
 				newSpecies.bst = 0;
-				for (const stat in newSpecies.baseStats) {
+				let stat: StatID;
+				for (stat in newSpecies.baseStats) {
 					if (stat === 'spd') continue;
 					newSpecies.baseStats[stat] = this.clampIntRange(newSpecies.baseStats[stat] * 2, 1, 255);
 					newSpecies.bst += newSpecies.baseStats[stat];
@@ -44,7 +45,7 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 				spe: newSpecies.baseStats.hp,
 			};
 			for (const i in newSpecies.baseStats) {
-				newSpecies.baseStats[i] = stats[i];
+				newSpecies.baseStats[i as StatID] = stats[i as StatID];
 			}
 			return newSpecies;
 		},
@@ -61,7 +62,8 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 			const pst: number = newSpecies.bst - newSpecies.baseStats['hp'];
 			const scale = 500 - newSpecies.baseStats['hp'];
 			newSpecies.bst = newSpecies.baseStats['hp'];
-			for (const stat in newSpecies.baseStats) {
+			let stat: StatID;
+			for (stat in newSpecies.baseStats) {
 				if (stat === 'hp' || stat === 'spd') continue;
 				newSpecies.baseStats[stat] = this.clampIntRange(newSpecies.baseStats[stat] * scale / pst, 1, 255);
 				newSpecies.bst += newSpecies.baseStats[stat];

--- a/data/mods/gen1/rulesets.ts
+++ b/data/mods/gen1/rulesets.ts
@@ -44,8 +44,9 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 				spd: newSpecies.baseStats.atk,
 				spe: newSpecies.baseStats.hp,
 			};
-			for (const i in newSpecies.baseStats) {
-				newSpecies.baseStats[i as StatID] = stats[i as StatID];
+			let stat: StatID;
+			for (stat in newSpecies.baseStats) {
+				newSpecies.baseStats[stat] = stats[stat];
 			}
 			return newSpecies;
 		},

--- a/data/mods/gen7mixandmega/scripts.ts
+++ b/data/mods/gen7mixandmega/scripts.ts
@@ -1,3 +1,7 @@
+interface SpeciesMixAndMega extends Mutable<Species> {
+	originalMega?: string | Species;
+}
+
 export const Scripts: ModdedBattleScriptsData = {
 	inherit: 'gen7',
 	init() {
@@ -25,7 +29,10 @@ export const Scripts: ModdedBattleScriptsData = {
 
 			const isUltraBurst = !pokemon.canMegaEvo;
 			// @ts-ignore
-			const species: Species = this.getMixedSpecies(pokemon.m.originalSpecies, pokemon.canMegaEvo || pokemon.canUltraBurst);
+			const species = this.getMixedSpecies(
+				pokemon.m.originalSpecies,
+				pokemon.canMegaEvo || pokemon.canUltraBurst
+			) as SpeciesMixAndMega;
 
 			// Do we have a proper sprite for it?
 			// @ts-ignore assert non-null pokemon.canMegaEvo
@@ -33,7 +40,6 @@ export const Scripts: ModdedBattleScriptsData = {
 				pokemon.formeChange(species, pokemon.getItem(), true);
 			} else {
 				const oSpecies = this.dex.species.get(pokemon.m.originalSpecies);
-				// @ts-ignore
 				const oMegaSpecies = this.dex.species.get(species.originalMega);
 				pokemon.formeChange(species, pokemon.getItem(), true);
 				this.battle.add('-start', pokemon, oMegaSpecies.requiredItem || oMegaSpecies.requiredMove, '[silent]');
@@ -91,7 +97,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		},
 		doGetMixedSpecies(speciesOrSpeciesName, deltas) {
 			if (!deltas) throw new TypeError("Must specify deltas!");
-			const species = this.dex.deepClone(this.dex.species.get(speciesOrSpeciesName));
+			const species = this.dex.deepClone(this.dex.species.get(speciesOrSpeciesName)) as SpeciesMixAndMega;
 			species.abilities = {'0': deltas.ability};
 			if (species.types[0] === deltas.type) {
 				species.types = [deltas.type];
@@ -104,7 +110,6 @@ export const Scripts: ModdedBattleScriptsData = {
 				baseStats[statName] = this.battle.clampIntRange(baseStats[statName] + deltas.baseStats[statName], 1, 255);
 			}
 			species.weighthg = Math.max(1, species.weighthg + deltas.weighthg);
-			// @ts-ignore
 			species.originalMega = deltas.originalMega;
 			species.requiredItem = deltas.requiredItem;
 			if (deltas.isMega) species.isMega = true;

--- a/data/mods/gen7mixandmega/scripts.ts
+++ b/data/mods/gen7mixandmega/scripts.ts
@@ -99,10 +99,12 @@ export const Scripts: ModdedBattleScriptsData = {
 				species.types = [species.types[0], deltas.type];
 			}
 			const baseStats = species.baseStats;
-			for (const statName in baseStats) {
+			let statName: StatID;
+			for (statName in baseStats) {
 				baseStats[statName] = this.battle.clampIntRange(baseStats[statName] + deltas.baseStats[statName], 1, 255);
 			}
 			species.weighthg = Math.max(1, species.weighthg + deltas.weighthg);
+			// @ts-ignore
 			species.originalMega = deltas.originalMega;
 			species.requiredItem = deltas.requiredItem;
 			if (deltas.isMega) species.isMega = true;

--- a/data/mods/mixandmega/scripts.ts
+++ b/data/mods/mixandmega/scripts.ts
@@ -1,3 +1,7 @@
+interface SpeciesMixAndMega extends Mutable<Species> {
+	originalMega?: string | Species;
+}
+
 export const Scripts: ModdedBattleScriptsData = {
 	init() {
 		for (const i in this.data.Items) {
@@ -23,14 +27,16 @@ export const Scripts: ModdedBattleScriptsData = {
 			if (pokemon.species.isMega) return false;
 
 			// @ts-ignore
-			const species: Species = this.getMixedSpecies(pokemon.m.originalSpecies, pokemon.canMegaEvo);
+			const species = this.getMixedSpecies(
+				pokemon.m.originalSpecies,
+				pokemon.canMegaEvo
+			) as SpeciesMixAndMega;
 
 			// Do we have a proper sprite for it?
 			if (this.dex.species.get(pokemon.canMegaEvo!).baseSpecies === pokemon.m.originalSpecies) {
 				pokemon.formeChange(species, pokemon.getItem(), true);
 			} else {
 				const oSpecies = this.dex.species.get(pokemon.m.originalSpecies);
-				// @ts-ignore
 				const oMegaSpecies = this.dex.species.get(species.originalMega);
 				pokemon.formeChange(species, pokemon.getItem(), true);
 				this.battle.add('-start', pokemon, oMegaSpecies.requiredItem, '[silent]');
@@ -85,7 +91,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		},
 		doGetMixedSpecies(speciesOrForme, deltas) {
 			if (!deltas) throw new TypeError("Must specify deltas!");
-			const species = this.dex.deepClone(this.dex.species.get(speciesOrForme));
+			const species = this.dex.deepClone(this.dex.species.get(speciesOrForme)) as SpeciesMixAndMega;
 			species.abilities = {'0': deltas.ability};
 			if (species.types[0] === deltas.type) {
 				species.types = [deltas.type];
@@ -100,7 +106,6 @@ export const Scripts: ModdedBattleScriptsData = {
 				baseStats[statName] = this.battle.clampIntRange(baseStats[statName] + deltas.baseStats[statName], 1, 255);
 			}
 			species.weighthg = Math.max(1, species.weighthg + deltas.weighthg);
-			// @ts-ignore
 			species.originalMega = deltas.originalMega;
 			species.requiredItem = deltas.requiredItem;
 			if (deltas.isMega) species.isMega = true;

--- a/data/mods/mixandmega/scripts.ts
+++ b/data/mods/mixandmega/scripts.ts
@@ -95,10 +95,12 @@ export const Scripts: ModdedBattleScriptsData = {
 				species.types = [species.types[0], deltas.type];
 			}
 			const baseStats = species.baseStats;
-			for (const statName in baseStats) {
+			let statName: StatID;
+			for (statName in baseStats) {
 				baseStats[statName] = this.battle.clampIntRange(baseStats[statName] + deltas.baseStats[statName], 1, 255);
 			}
 			species.weighthg = Math.max(1, species.weighthg + deltas.weighthg);
+			// @ts-ignore
 			species.originalMega = deltas.originalMega;
 			species.requiredItem = deltas.requiredItem;
 			if (deltas.isMega) species.isMega = true;

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1384,7 +1384,8 @@ export const Rulesets: {[k: string]: FormatData} = {
 			const newSpecies = this.dex.deepClone(species);
 			if (newSpecies.bst <= 350) {
 				newSpecies.bst = 0;
-				for (const stat in newSpecies.baseStats) {
+				let stat: StatID;
+				for (stat in newSpecies.baseStats) {
 					newSpecies.baseStats[stat] = this.clampIntRange(newSpecies.baseStats[stat] * 2, 1, 255);
 					newSpecies.bst += newSpecies.baseStats[stat];
 				}
@@ -1404,7 +1405,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 			const newSpecies = this.dex.deepClone(species);
 			const reversedNums = Object.values(newSpecies.baseStats).reverse();
 			for (const [i, statName] of Object.keys(newSpecies.baseStats).entries()) {
-				newSpecies.baseStats[statName] = reversedNums[i];
+				newSpecies.baseStats[statName as StatID] = reversedNums[i];
 			}
 			return newSpecies;
 		},
@@ -1422,7 +1423,8 @@ export const Rulesets: {[k: string]: FormatData} = {
 			const bstWithoutHp: number = newSpecies.bst - newSpecies.baseStats['hp'];
 			const scale = 600 - newSpecies.baseStats['hp'];
 			newSpecies.bst = newSpecies.baseStats['hp'];
-			for (const stat in newSpecies.baseStats) {
+			let stat: StatID;
+			for (stat in newSpecies.baseStats) {
 				if (stat === 'hp') continue;
 				newSpecies.baseStats[stat] = this.clampIntRange(newSpecies.baseStats[stat] * scale / bstWithoutHp, 1, 255);
 				newSpecies.bst += newSpecies.baseStats[stat];
@@ -1853,7 +1855,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 			pokemon.bst = pokemon.baseStats['hp'];
 			const boost = boosts[tier];
 			let statName: StatID;
-			for (statName in pokemon.baseStats as StatsTable) {
+			for (statName in pokemon.baseStats) {
 				if (statName === 'hp') continue;
 				pokemon.baseStats[statName] = this.clampIntRange(pokemon.baseStats[statName] + boost, 1, 255);
 				pokemon.bst += pokemon.baseStats[statName];

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -32,7 +32,7 @@ export type Comparable = number | string | boolean | Comparable[] | {reverse: Co
  * string or a number.
  */
 
-export function getString(str: any): string {
+export function getString(str: unknown): string {
 	return (typeof str === 'string' || typeof str === 'number') ? '' + str : '';
 }
 
@@ -82,7 +82,7 @@ export function formatOrder(place: number) {
 /**
  * Visualizes eval output in a slightly more readable form
  */
-export function visualize(value: any, depth = 0): string {
+export function visualize(value: unknown, depth = 0): string {
 	if (value === undefined) return `undefined`;
 	if (value === null) return `null`;
 	if (typeof value === 'number' || typeof value === 'boolean') {
@@ -115,14 +115,16 @@ export function visualize(value: any, depth = 0): string {
 
 	switch (baseClass) {
 	case 'Map':
+		const valueMap = value as Map<unknown, unknown>;
 		if (depth > 2) return `Map`;
-		const mapped = [...value.entries()].map(
+		const mapped = [...valueMap.entries()].map(
 			val => `${visualize(val[0], depth + 1)} => ${visualize(val[1], depth + 1)}`
 		);
-		return `${constructor} (${value.size}) { ${mapped.join(', ')} }`;
+		return `${constructor} (${valueMap.size}) { ${mapped.join(', ')} }`;
 	case 'Set':
+		const valueSet = value as Set<unknown>;
 		if (depth > 2) return `Set`;
-		return `${constructor} (${value.size}) { ${[...value].map(v => visualize(v), depth + 1).join(', ')} }`;
+		return `${constructor} (${valueSet.size}) { ${[...valueSet].map(v => visualize(v), depth + 1).join(', ')} }`;
 	}
 
 	if (value.toString) {
@@ -145,7 +147,7 @@ export function visualize(value: any, depth = 0): string {
 		if (buf) buf += `, `;
 		let displayedKey = key;
 		if (!/^[A-Za-z0-9_$]+$/.test(key)) displayedKey = JSON.stringify(key);
-		buf += `${displayedKey}: ` + visualize(value[key], depth + 1);
+		buf += `${displayedKey}: ` + visualize((value as Record<string, unknown>)[key], depth + 1);
 	}
 	if (constructor && !buf && constructor !== 'null') return constructor;
 	return `${constructor}{${buf}}`;
@@ -201,7 +203,7 @@ export function sortBy<T>(array: T[], callback: (a: T) => Comparable): T[];
  */
 export function sortBy<T extends Comparable>(array: T[]): T[];
 export function sortBy<T>(array: T[], callback?: (a: T) => Comparable) {
-	if (!callback) return (array as any[]).sort(compare);
+	if (!callback) return (array as Comparable[]).sort(compare);
 	return array.sort((a, b) => compare(callback(a), callback(b)));
 }
 
@@ -239,7 +241,7 @@ export function splitFirst(str: string, delimiter: string, limit = 1) {
 /**
  * Template string tag function for escaping HTML
  */
-export function html(strings: TemplateStringsArray, ...args: any) {
+export function html(strings: TemplateStringsArray, ...args: (Parameters<typeof escapeHTML>[0])[]) {
 	let buf = strings[0];
 	let i = 0;
 	while (i < args.length) {
@@ -293,7 +295,7 @@ export function randomElement<T>(arr: T[]): T {
 }
 
 /** Forces num to be an integer (between min and max). */
-export function clampIntRange(num: any, min?: number, max?: number): number {
+export function clampIntRange(num: number, min?: number, max?: number): number {
 	if (typeof num !== 'number') num = 0;
 	num = Math.floor(num);
 	if (min !== undefined && num < min) num = min;
@@ -318,11 +320,11 @@ export function clearRequireCache(options: {exclude?: string[]} = {}) {
 	}
 }
 
-export function deepClone(obj: any): any {
+export function deepClone<T>(obj: T): Mutable<T> {
 	if (obj === null || typeof obj !== 'object') return obj;
-	if (Array.isArray(obj)) return obj.map(prop => deepClone(prop));
+	if (Array.isArray(obj)) return obj.map(prop => deepClone(prop)) as T;
 	const clone = Object.create(Object.getPrototypeOf(obj));
-	for (const key of Object.keys(obj)) {
+	for (const key of Object.keys(obj) as (keyof typeof obj)[]) {
 		clone[key] = deepClone(obj[key]);
 	}
 	return clone;

--- a/server/chat-commands/room-settings.ts
+++ b/server/chat-commands/room-settings.ts
@@ -1296,7 +1296,7 @@ export const commands: Chat.ChatCommands = {
 
 		const subRoomText = subRooms.map(
 			subRoom =>
-				Utils.html`<a href="/${subRoom.roomid}">${subRoom.title}</a><br/><small>${subRoom.settings.desc}</small>`
+				Utils.html`<a href="/${subRoom.roomid}">${subRoom.title}</a><br/><small>${subRoom.settings.desc ?? ''}</small>`
 		);
 
 		return this.sendReplyBox(`<p style="font-weight:bold;">${Utils.escapeHTML(room.title)}'s subroom${Chat.plural(subRooms)}:</p><ul><li>${subRoomText.join('</li><br/><li>')}</li></ul></strong>`);

--- a/server/chat-plugins/chat-monitor.ts
+++ b/server/chat-plugins/chat-monitor.ts
@@ -587,7 +587,7 @@ export const pages: Chat.PageTable = {
 			content += `<tr><th colspan="2"><h3>${Chat.monitors[key].label} <span style="font-size:8pt;">[${key}]</span></h3></tr></th>`;
 			if (filterWords[key].length) {
 				content += filterWords[key].map(({regex, word, reason, publicReason, replacement, hits}) => {
-					let entry = Utils.html`<abbr title="${reason}"><code>${word}</code></abbr>`;
+					let entry = Utils.html`<abbr title="${reason ?? ''}"><code>${word}</code></abbr>`;
 					if (publicReason) entry += Utils.html` <small>(public reason: ${publicReason})</small>`;
 					if (replacement) entry += Utils.html` &rArr; ${replacement}`;
 					return `<tr><td>${entry}</td><td>${hits}</td></tr>`;

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1613,7 +1613,7 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 
 	const getFullLearnsetOfPokemon = (species: Species) => {
 		let usedSpecies: Species = Utils.deepClone(species);
-		let usedSpeciesLearnset: LearnsetData = Utils.deepClone(mod.species.getLearnset(usedSpecies.id));
+		let usedSpeciesLearnset: LearnsetData | undefined = Utils.deepClone(mod.species.getLearnset(usedSpecies.id));
 		if (!usedSpeciesLearnset) {
 			usedSpecies = Utils.deepClone(mod.species.get(usedSpecies.baseSpecies));
 			usedSpeciesLearnset = Utils.deepClone(mod.species.getLearnset(usedSpecies.id) || {});

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1613,7 +1613,7 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 
 	const getFullLearnsetOfPokemon = (species: Species) => {
 		let usedSpecies: Species = Utils.deepClone(species);
-		let usedSpeciesLearnset: LearnsetData | undefined = Utils.deepClone(mod.species.getLearnset(usedSpecies.id));
+		let usedSpeciesLearnset = Utils.deepClone(mod.species.getLearnset(usedSpecies.id));
 		if (!usedSpeciesLearnset) {
 			usedSpecies = Utils.deepClone(mod.species.get(usedSpecies.baseSpecies));
 			usedSpeciesLearnset = Utils.deepClone(mod.species.getLearnset(usedSpecies.id) || {});

--- a/server/chat-plugins/hosts.ts
+++ b/server/chat-plugins/hosts.ts
@@ -33,7 +33,7 @@ export function visualizeRangeList(ranges: AddressRange[]) {
 		html += `<tr>`;
 		html += `<td>${IPTools.numberToIP(range.minIP)}</td>`;
 		html += `<td>${IPTools.numberToIP(range.maxIP)}</td>`;
-		html += Utils.html`<td>${range.host}</td>`;
+		html += Utils.html`<td>${range.host ?? 'N/A'}</td>`;
 		html += `</tr>`;
 	}
 	return html;

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -15,6 +15,7 @@ interface StoneDeltas {
 }
 
 type TierShiftTiers = 'UU' | 'RUBL' | 'RU' | 'NUBL' | 'NU' | 'PUBL' | 'PU' | 'NFE' | 'LC';
+type OtherMetaTier = "MnM" | "NS" | "CE";
 
 function getMegaStone(stone: string, mod = 'gen8'): Item | null {
 	let dex = Dex;
@@ -143,7 +144,7 @@ export const commands: Chat.ChatCommands = {
 			mixedSpecies.bst += mixedSpecies.baseStats[statName];
 		}
 		mixedSpecies.weighthg = Math.max(1, species.weighthg + deltas.weighthg);
-		mixedSpecies.tier = "MnM";
+		(mixedSpecies.tier as OtherMetaTier) = "MnM";
 		let weighthit = 20;
 		if (mixedSpecies.weighthg >= 2000) {
 			weighthit = 120;
@@ -518,7 +519,7 @@ export const commands: Chat.ChatCommands = {
 			const swap = species.baseStats[natureObj.minus];
 			species.baseStats[natureObj.minus] = species.baseStats[natureObj.plus];
 			species.baseStats[natureObj.plus] = swap;
-			species.tier = 'NS';
+			(species.tier as OtherMetaTier) = 'NS';
 		}
 		this.sendReply(`|raw|${Chat.getDataPokemonHTML(species, dex.gen)}`);
 	},
@@ -582,7 +583,7 @@ export const commands: Chat.ChatCommands = {
 		if (mixedSpecies.weighthg < 1) {
 			mixedSpecies.weighthg = 1;
 		}
-		mixedSpecies.tier = "CE";
+		(mixedSpecies.tier as OtherMetaTier) = "CE";
 		let weighthit = 20;
 		if (mixedSpecies.weighthg >= 2000) {
 			weighthit = 120;
@@ -629,7 +630,7 @@ export const commands: Chat.ChatCommands = {
 		const prevoSpecies = Dex.species.get(evo.prevo);
 		const deltas = Utils.deepClone(evo);
 		if (!isReEvo) {
-			deltas.tier = 'CE';
+			(deltas.tier as OtherMetaTier) = 'CE';
 			deltas.weightkg = evo.weightkg - prevoSpecies.weightkg;
 			deltas.types = [];
 			if (evo.types[0] !== prevoSpecies.types[0]) deltas.types[0] = evo.types[0];

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -311,10 +311,11 @@ export const commands: Chat.ChatCommands = {
 		}
 		const bst = species.bst;
 		species.bst = 0;
-		for (const i in species.baseStats) {
-			if (dex.gen === 1 && i === 'spd') continue;
-			species.baseStats[i] = species.baseStats[i] * (bst <= 350 ? 2 : 1);
-			species.bst += species.baseStats[i];
+		let stat: StatID;
+		for (stat in species.baseStats) {
+			if (dex.gen === 1 && stat === 'spd') continue;
+			species.baseStats[stat] = species.baseStats[stat] * (bst <= 350 ? 2 : 1);
+			species.bst += species.baseStats[stat];
 		}
 		this.sendReply(`|html|${Chat.getDataPokemonHTML(species, dex.gen)}`);
 	},
@@ -362,11 +363,12 @@ export const commands: Chat.ChatCommands = {
 			LC: 40,
 		};
 		let tier = species.tier;
-		if (tier[0] === '(') tier = tier.slice(1, -1);
+		if (tier.startsWith('(')) tier = tier.slice(1, -1) as typeof tier;
 		if (!(tier in boosts)) return this.sendReply(`|html|${Chat.getDataPokemonHTML(species, dex.gen)}`);
 		const boost = boosts[tier as TierShiftTiers];
 		species.bst = species.baseStats.hp;
-		for (const statName in species.baseStats) {
+		let statName: StatID;
+		for (statName in species.baseStats) {
 			if (statName === 'hp') continue;
 			if (dex.gen === 1 && statName === 'spd') continue;
 			species.baseStats[statName] = Utils.clampIntRange(species.baseStats[statName] + boost, 1, 255);
@@ -410,7 +412,8 @@ export const commands: Chat.ChatCommands = {
 		const bstNoHP = species.bst - species.baseStats.hp;
 		const scale = (dex.gen !== 1 ? 600 : 500) - species.baseStats['hp'];
 		species.bst = 0;
-		for (const stat in species.baseStats) {
+		let stat: StatID;
+		for (stat in species.baseStats) {
 			if (stat === 'hp') continue;
 			if (dex.gen === 1 && stat === 'spd') continue;
 			species.baseStats[stat] = Utils.clampIntRange(species.baseStats[stat] * scale / bstNoHP, 1, 255);
@@ -462,7 +465,8 @@ export const commands: Chat.ChatCommands = {
 				spd: species.baseStats.atk,
 				spe: species.baseStats.hp,
 			};
-			for (const stat in species.baseStats) {
+			let stat: StatID;
+			for (stat in species.baseStats) {
 				species.baseStats[stat] = flippedStats[stat];
 			}
 			this.sendReply(`|raw|${Chat.getDataPokemonHTML(species, dex.gen)}`);
@@ -470,7 +474,7 @@ export const commands: Chat.ChatCommands = {
 		}
 		const stats = Object.values(species.baseStats).reverse();
 		for (const [i, statName] of Object.keys(species.baseStats).entries()) {
-			species.baseStats[statName] = stats[i];
+			species.baseStats[statName as StatID] = stats[i];
 		}
 		this.sendReply(`|raw|${Chat.getDataPokemonHTML(species, dex.gen)}`);
 	},
@@ -591,7 +595,7 @@ export const commands: Chat.ChatCommands = {
 		} else if (mixedSpecies.weighthg >= 100) {
 			weighthit = 40;
 		}
-		const details: {[k: string]: string} = {
+		const details: {[k: string]: string | number} = {
 			"Dex#": mixedSpecies.num,
 			Gen: mixedSpecies.gen,
 			Height: mixedSpecies.heightm + " m",
@@ -638,7 +642,7 @@ export const commands: Chat.ChatCommands = {
 
 				if (deltas.types[0] === deltas.types[1]) deltas.types = [deltas.types[0]];
 			} else {
-				deltas.types = null;
+				deltas.types = [];
 			}
 		}
 		deltas.bst = 0;

--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -2150,7 +2150,7 @@ const ScavengerCommands: Chat.ChatCommands = {
 
 		let buffer = `<table><tr><th>Twist</th><th>Description</th></tr>`;
 		buffer += Object.values(ScavMods.twists).map(twist => (
-			Utils.html`<tr><td style="padding: 5px;">${twist.name}</td><td style="padding: 5px;">${twist.desc}</td></tr>`
+			Utils.html`<tr><td style="padding: 5px;">${twist.name}</td><td style="padding: 5px;">${twist.desc ?? ''}</td></tr>`
 		)).join('');
 		buffer += `</table>`;
 

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -1399,7 +1399,7 @@ const commands: Chat.ChatCommands = {
 			for (const format of Dex.formats.all()) {
 				if (!format.tournamentShow) continue;
 				const name = format.name.startsWith(`[Gen ${Dex.gen}] `) ? format.name.slice(8) : format.name;
-				if (format.section !== section) {
+				if (format.section !== section && format.section !== undefined) {
 					section = format.section;
 					buf += Utils.html`<br /><strong>${section}:</strong><br />&bull; ${name}`;
 				} else {

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -310,7 +310,7 @@ export class ModdedDex {
 	getActiveMove(move: Move | string): ActiveMove {
 		if (move && typeof (move as ActiveMove).hit === 'number') return move as ActiveMove;
 		move = this.moves.get(move);
-		const moveCopy: ActiveMove = this.deepClone(move);
+		const moveCopy = this.deepClone(move) as ActiveMove;
 		moveCopy.hit = 0;
 		return moveCopy;
 	}

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -64,7 +64,7 @@ namespace TierTypes {
 	export type Singles = "AG" | "Uber" | "(Uber)" | "OU" | "(OU)" | "UUBL" | "UU" | "RUBL" | "RU" | "NUBL" | "NU" |
 	"(NU)" | "PUBL" | "PU" | "(PU)" | "NFE" | "LC";
 	export type Doubles = "DUber" | "(DUber)" | "DOU" | "(DOU)" | "DBL" | "DUU" | "(DUU)" | "NFE" | "LC";
-	export type Other = "Unreleased" | "Illegal" | "CAP" | "CAP NFE" | "CAP LC" | "NS" | "CE" | "MnM";
+	export type Other = "Unreleased" | "Illegal" | "CAP" | "CAP NFE" | "CAP LC";
 }
 
 interface EventInfo {

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -64,7 +64,7 @@ namespace TierTypes {
 	export type Singles = "AG" | "Uber" | "(Uber)" | "OU" | "(OU)" | "UUBL" | "UU" | "RUBL" | "RU" | "NUBL" | "NU" |
 	"(NU)" | "PUBL" | "PU" | "(PU)" | "NFE" | "LC";
 	export type Doubles = "DUber" | "(DUber)" | "DOU" | "(DOU)" | "DBL" | "DUU" | "(DUU)" | "NFE" | "LC";
-	export type Other = "Unreleased" | "Illegal" | "CAP" | "CAP NFE" | "CAP LC";
+	export type Other = "Unreleased" | "Illegal" | "CAP" | "CAP NFE" | "CAP LC" | "NS" | "CE" | "MnM";
 }
 
 interface EventInfo {


### PR DESCRIPTION
- Improved types in `utils` to avoid `any`
  - https://github.com/smogon/pokemon-showdown/commit/139470c576fa8eb7f79eeac40335c77738910124
- Fixed a bunch of usage code that is now type-aware
  - There's some slight behavioral changes here so please check this since I don't have full context!
  - https://github.com/smogon/pokemon-showdown/commit/83345e180c4c74c923faafbb317c5b0a19fe9bd0