### PR TITLE
Random battles: Add meditate to PhysicalSetup moveslist

### DIFF
--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -61,7 +61,7 @@ const ContraryMoves = [
 ];
 // Moves that boost Attack:
 const PhysicalSetup = [
-	'bellydrum', 'bulkup', 'coil', 'curse', 'dragondance', 'honeclaws', 'howl', 'poweruppunch', 'swordsdance',
+	'bellydrum', 'bulkup', 'coil', 'curse', 'dragondance', 'honeclaws', 'howl', 'meditate', 'poweruppunch', 'swordsdance',
 ];
 // Moves which boost Special Attack:
 const SpecialSetup = [


### PR DESCRIPTION
Meditate was not listed as a physical setup move, making it so that Primeape and Hitmonlee could not roll it in gen2 rands.

https://discord.com/channels/294651453279174656/809413306854932510/1030479956762963999