### PR TITLE
Gen2 Random Battles: HP grass instead of Giga Drain on celebi and vileplume

### DIFF
--- a/data/mods/gen2/formats-data.ts
+++ b/data/mods/gen2/formats-data.ts
@@ -162,7 +162,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NU",
 	},
 	vileplume: {
-		randomBattleMoves: ["gigadrain", "moonlight", "sleeppowder", "sludgebomb", "stunspore", "swordsdance"],
+		randomBattleMoves: ["hiddenpowergrass", "moonlight", "sleeppowder", "sludgebomb", "stunspore", "swordsdance"],
 		tier: "UU",
 	},
 	bellossom: {
@@ -889,7 +889,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "Uber",
 	},
 	celebi: {
-		randomBattleMoves: ["gigadrain", "healbell", "leechseed", "psychic", "recover", "toxic"],
+		randomBattleMoves: ["hiddenpowergrass", "healbell", "leechseed", "psychic", "recover", "toxic"],
 		tier: "Uber",
 	},
 };


### PR DESCRIPTION
Just a small sets change.

https://discord.com/channels/294651453279174656/809413306854932510/1030479956762963999