### PR TITLE
Random Doubles updates

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -1895,7 +1895,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 	dunsparce: {
 		randomBattleMoves: ["bodyslam", "coil", "earthquake", "roost"],
 		randomBattleLevel: 90,
-		randomDoubleBattleMoves: ["glare", "headbutt", "helpinghand", "rockslide"],
+		randomDoubleBattleMoves: ["glare", "headbutt", "protect", "rockslide"],
 		randomDoubleBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -4150,7 +4150,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 	darmanitangalar: {
 		randomBattleMoves: ["earthquake", "flareblitz", "iciclecrash", "superpower", "uturn"],
 		randomBattleLevel: 78,
-		randomDoubleBattleMoves: ["earthquake", "flareblitz", "iciclecrash", "superpower", "uturn"],
+		randomDoubleBattleMoves: ["flareblitz", "iciclecrash", "rockslide", "superpower", "uturn"],
 		randomDoubleBattleLevel: 80,
 		tier: "Uber",
 		doublesTier: "(DUU)",
@@ -4661,7 +4661,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 	durant: {
 		randomBattleMoves: ["firstimpression", "honeclaws", "ironhead", "rockslide", "superpower"],
 		randomBattleLevel: 78,
-		randomDoubleBattleMoves: ["firstimpression", "ironhead", "protect", "superpower", "xscissor"],
+		randomDoubleBattleMoves: ["firstimpression", "ironhead", "protect", "stompingtantrum", "superpower", "xscissor"],
 		randomDoubleBattleLevel: 82,
 		tier: "RUBL",
 		doublesTier: "(DUU)",

--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -2879,8 +2879,6 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		tier: "LC",
 	},
 	dusclops: {
-		randomDoubleBattleMoves: ["allyswitch", "haze", "helpinghand", "nightshade", "painsplit", "trickroom", "willowisp"],
-		randomDoubleBattleLevel: 84,
 		tier: "NFE",
 	},
 	dusknoir: {
@@ -5708,7 +5706,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 	oranguru: {
 		randomBattleMoves: ["focusblast", "nastyplot", "psychic", "thunderbolt", "trickroom"],
 		randomBattleLevel: 86,
-		randomDoubleBattleMoves: ["afteryou", "allyswitch", "focusblast", "instruct", "psychic", "trickroom"],
+		randomDoubleBattleMoves: ["allyswitch", "focusblast", "instruct", "psychic", "trickroom"],
 		randomDoubleBattleLevel: 88,
 		tier: "(PU)",
 		doublesTier: "(DUU)",


### PR DESCRIPTION
-Remove After You from Oranguru. i don't really remember why it was added in the first place. honestly.

-Remove Dusclops. It's apparently not good anymore.

-Some other changes.

proof of roomstaff approval will be delivered via pms