### PR TITLE
Gen 1: Fix multiple Transform bugs

### DIFF
--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -18,7 +18,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		getStat(statName, unmodified) {
 			// @ts-ignore - type checking prevents 'hp' from being passed, but we're paranoid
 			if (statName === 'hp') throw new Error("Please read `maxhp` directly");
-			if (unmodified) return this.storedStats[statName];
+			if (unmodified) return this.baseStoredStats[statName];
 			return this.modifiedStats![statName];
 		},
 		// Gen 1 function to apply a stat modification that is only active until the stat is recalculated or mon switched.
@@ -46,9 +46,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				changed = true;
 				// Recalculate the modified stat
 				if (i === 'evasion' || i === 'accuracy') continue;
-				let stat = this.species.baseStats[i];
-				stat = Math.floor(Math.floor(2 * stat + this.set.ivs[i] + Math.floor(this.set.evs[i] / 4)) * this.level / 100 + 5);
-				this.modifiedStats![i] = this.storedStats[i] = Math.floor(stat);
+				this.modifiedStats![i] = this.storedStats[i];
 				if (this.boosts[i] >= 0) {
 					this.modifyStat!(i, [1, 1.5, 2, 2.5, 3, 3.5, 4][this.boosts[i]]);
 				} else {
@@ -63,9 +61,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				this.boosts[i] = 0;
 				// Recalculate the modified stat
 				if (i === 'evasion' || i === 'accuracy') continue;
-				let stat = this.species.baseStats[i];
-				stat = Math.floor(Math.floor(2 * stat + this.set.ivs[i] + Math.floor(this.set.evs[i] / 4)) * this.level / 100 + 5);
-				this.modifiedStats![i] = this.storedStats[i] = Math.floor(stat);
+				this.modifiedStats![i] = this.storedStats[i];
 			}
 		},
 	},

--- a/data/mods/partnersincrime/scripts.ts
+++ b/data/mods/partnersincrime/scripts.ts
@@ -266,6 +266,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			let statName: StatIDExceptHP;
 			for (statName in this.storedStats) {
 				this.storedStats[statName] = pokemon.storedStats[statName];
+				if (this.modifiedStats) this.modifiedStats[statName] = pokemon.modifiedStats![statName]; // Gen 1: Copy modified stats.
 			}
 			this.moveSlots = [];
 			this.set.ivs = (this.battle.gen >= 5 ? this.set.ivs : pokemon.set.ivs);
@@ -292,14 +293,6 @@ export const Scripts: ModdedBattleScriptsData = {
 			let boostName: BoostID;
 			for (boostName in pokemon.boosts) {
 				this.boosts[boostName] = pokemon.boosts[boostName];
-				if (this.battle.gen <= 1) {
-					if (boostName === 'evasion' || boostName === 'accuracy') continue;
-					if (this.boosts[boostName] >= 0) {
-						this.modifyStat!(boostName, [1, 1.5, 2, 2.5, 3, 3.5, 4][this.boosts[boostName]]);
-					} else {
-						this.modifyStat!(boostName, [100, 66, 50, 40, 33, 28, 25][-this.boosts[boostName]] / 100);
-					}
-				}
 			}
 			if (this.battle.gen >= 6) {
 				const volatilesToCopy = ['focusenergy', 'gmaxchistrike', 'laserfocus'];

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -1875,7 +1875,13 @@ export const pages: Chat.PageTable = {
 					const ticketGame = room.getGame(HelpTicket)!;
 					buf += `<a href="/${roomid}"><button class="button" ${ticketGame.getPreview()}>${this.tr(!ticket.claimed && ticket.open ? 'Claim' : 'View')}</button></a> `;
 				} else if (ticket.text) {
-					buf += `<a class="button" href="/view-help-text-${ticket.userid}">${ticket.claimed ? `Claim` : `View`}</a>`;
+					let title = Object.entries(ticket.notes || {})
+						.map(([userid, note]) => Utils.html`${note} (by ${userid})`)
+						.join('&#10;');
+					if (title) {
+						title = `title="Staff notes:&#10;${title}"`;
+					}
+					buf += `<a class="button" ${title} href="/view-help-text-${ticket.userid}">${ticket.claimed ? `Claim` : `View`}</a>`;
 				}
 				if (logUrl) {
 					buf += `<a href="${logUrl}"><button class="button">${this.tr`Log`}</button></a>`;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1156,6 +1156,7 @@ export class Pokemon {
 		let statName: StatIDExceptHP;
 		for (statName in this.storedStats) {
 			this.storedStats[statName] = pokemon.storedStats[statName];
+			if (this.modifiedStats) this.modifiedStats[statName] = pokemon.modifiedStats![statName]; // Gen 1: Copy modified stats.
 		}
 		this.moveSlots = [];
 		this.set.ivs = (this.battle.gen >= 5 ? this.set.ivs : pokemon.set.ivs);
@@ -1180,14 +1181,6 @@ export class Pokemon {
 		let boostName: BoostID;
 		for (boostName in pokemon.boosts) {
 			this.boosts[boostName] = pokemon.boosts[boostName];
-			if (this.battle.gen <= 1) {
-				if (boostName === 'evasion' || boostName === 'accuracy') continue;
-				if (this.boosts[boostName] >= 0) {
-					this.modifyStat!(boostName, [1, 1.5, 2, 2.5, 3, 3.5, 4][this.boosts[boostName]]);
-				} else {
-					this.modifyStat!(boostName, [100, 66, 50, 40, 33, 28, 25][-this.boosts[boostName]] / 100);
-				}
-			}
 		}
 		if (this.battle.gen >= 6) {
 			const volatilesToCopy = ['focusenergy', 'gmaxchistrike', 'laserfocus'];

--- a/test/sim/moves/transform.js
+++ b/test/sim/moves/transform.js
@@ -246,4 +246,56 @@ describe('Transform [Gen 1]', function () {
 		battle.makeChoices('move thunderbolt', 'switch 2');
 		assert.fainted(battle.p2.active[0]);
 	});
+
+	it(`should copy the target's stats (except HP), even if different level`, function () {
+		battle = common.gen(1).createBattle([[
+			{species: 'Ditto', moves: ['transform'], level: 5},
+		], [
+			{species: 'Gengar', moves: ['splash']},
+		]]);
+		battle.makeChoices();
+		const p1poke = battle.p1.active[0];
+		const p2poke = battle.p2.active[0];
+		for (const stat in p1poke.storedStats) {
+			assert.equal(p1poke.storedStats[stat], p2poke.storedStats[stat]);
+			assert.equal(p1poke.modifiedStats[stat], p2poke.modifiedStats[stat]);
+		}
+	});
+
+	it(`should copy the target's status-modified stats`, function () {
+		battle = common.gen(1).createBattle([[
+			{species: 'Ditto', moves: ['transform', 'thunderwave']},
+		], [
+			{species: 'Gengar', moves: ['splash']},
+		]]);
+		battle.makeChoices('move thunderwave', 'move splash');
+		battle.makeChoices('move transform', 'move splash');
+		const p1poke = battle.p1.active[0];
+		const p2poke = battle.p2.active[0];
+		assert.equal(p1poke.storedStats['spe'], p2poke.storedStats['spe']);
+		assert.equal(p1poke.modifiedStats['spe'], p2poke.modifiedStats['spe']);
+	});
+
+	it(`should not re-apply status stat modifier after transforming`, function () {
+		battle = common.gen(1).createBattle([[
+			{species: 'Ditto', moves: ['transform', 'splash']},
+		], [
+			{species: 'Gengar', moves: ['splash', 'thunderwave', 'transform']},
+		]]);
+		battle.makeChoices('move splash', 'move thunderwave');
+		battle.makeChoices('move transform', 'move splash');
+		battle.makeChoices('move transform', 'move splash');
+		battle.makeChoices('move transform', 'move splash');
+		battle.makeChoices('move transform', 'move splash');
+		battle.makeChoices('move transform', 'move splash');
+		battle.makeChoices('move transform', 'move splash');
+		battle.makeChoices('move transform', 'move splash');
+		battle.makeChoices('move transform', 'move splash');
+		battle.makeChoices('move transform', 'move splash');
+		battle.makeChoices('move transform', 'move splash');
+		const p1poke = battle.p1.active[0];
+		const p2poke = battle.p2.active[0];
+		assert.equal(p1poke.storedStats['spe'], p2poke.storedStats['spe']);
+		assert.equal(p1poke.modifiedStats['spe'], p2poke.modifiedStats['spe']);
+	});
 });


### PR DESCRIPTION
This patch fixes multiple Transform bugs in Gen 1:

* Fix critical hits not using base stats for damage calculation (https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/page-84#post-9371041)
* Fix Transform not copying stats correctly when the two Pokemon have different levels (https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/page-52#post-8843431)
* Fix Transform not copying stats correctly when at least one of the Pokemon are paralyzed or burned (https://www.smogon.com/forums/threads/rby-tradebacks-bug-report-thread.3524844/page-9#post-6373537)