### PR TITLE
Fix Mimic accuracy in gens 1 and 2

### DIFF
--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -415,7 +415,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	mimic: {
 		inherit: true,
-		accuracy: 100,
 		ignoreAccuracy: undefined,
 		ignoreEvasion: undefined,
 		noSketch: true,

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -415,7 +415,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	mimic: {
 		inherit: true,
-		accuracy: true,
+		accuracy: 100,
 		ignoreAccuracy: undefined,
 		ignoreEvasion: undefined,
 		noSketch: true,


### PR DESCRIPTION
Mimic accuracy fixed, changed from can't miss to 100% for gens 1 and 2. 100% is the correct accuracy.

Reported as a bug (for gen 1): 
https://www.smogon.com/forums/threads/rby-tradebacks-bug-report-thread.3524844/page-14#post-8558474

Mimic's accuracy: https://bulbapedia.bulbagarden.net/wiki/Mimic_(move)