### PR TITLE
Gen 8: Fix failure message not showing for Purify

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -13442,7 +13442,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, heal: 1},
 		onHit(target, source) {
-			if (!target.cureStatus()) return this.NOT_FAIL;
+			if (!target.cureStatus()) {
+				this.add('-fail', source);
+				this.attrLastMove('[still]');
+				return this.NOT_FAIL;
+			}
 			this.heal(Math.ceil(source.maxhp * 0.5), source);
 		},
 		secondary: null,


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-9376335

Specified gen 8 since the fail message already shows in gen 7 due to Purifiy's `onHit` event in that gen returning `false` instead of `NOT_FAIL`.