### PR TITLE
Gen 1: Fix Thunder Wave not affecting Ground-types with Inverse Mod

### DIFF
--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -884,16 +884,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			status: 'par',
 		},
 	},
-	thunderwave: {
-		inherit: true,
-		accuracy: 100,
-		onTryHit(target) {
-			if (target.hasType('Ground')) {
-				this.add('-immune', target);
-				return null;
-			}
-		},
-	},
 	triattack: {
 		inherit: true,
 		onHit() {},


### PR DESCRIPTION
This fixes Ground-types not being affected by Thunder Wave in Gen 1 with Inverse Mod.

https://www.smogon.com/forums/threads/rby-tradebacks-bug-report-thread.3524844/page-15#post-8801689

Ground-types are still immune to Thunder Wave in regular battles, since Thunder Wave does not ignore type immunities.