### PR TITLE
Gen 1: Fix Hyper Beam unbroken Substitute interaction

### DIFF
--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -392,6 +392,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			// We get the sub to the target to see if it existed
 			const targetSub = (target) ? target.volatiles['substitute'] : false;
 			const targetHadSub = (targetSub !== null && targetSub !== false && (typeof targetSub !== 'undefined'));
+			let targetHasSub: boolean;
 
 			if (target) {
 				hitResult = this.battle.singleEvent('TryHit', moveData, {}, target, pokemon, move);
@@ -424,6 +425,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				}
 
 				if (hitResult === 0) {
+					targetHasSub = !!(target?.volatiles['substitute']);
 					target = null;
 				} else if (!hitResult) {
 					if (hitResult === false) this.battle.add('-fail', target);
@@ -553,7 +555,7 @@ export const Scripts: ModdedBattleScriptsData = {
 					return false;
 				}
 			}
-			const targetHasSub = !!(target?.volatiles['substitute']);
+			targetHasSub ??= !!(target?.volatiles['substitute']);
 
 			// Here's where self effects are applied.
 			const doSelf = (targetHadSub && targetHasSub) || !targetHadSub;

--- a/test/sim/moves/hyperbeam.js
+++ b/test/sim/moves/hyperbeam.js
@@ -42,13 +42,13 @@ describe(`Hyper Beam`, function () {
 		assert.false.cantMove(() => battle.choose('p1', 'move tackle'));
 	});
 
-	it.skip(`[Gen 1] should force a recharge turn after damaging, but not breaking a Substitute`, function () {
+	it(`[Gen 1] should force a recharge turn after damaging, but not breaking a Substitute`, function () {
 		battle = common.gen(1).createBattle([[
-			{species: 'chansey', moves: ['hyperbeam', 'tackle']},
+			{species: 'slowbro', moves: ['hyperbeam', 'tackle']},
 		], [
 			{species: 'rhydon', moves: ['substitute']},
 		]]);
 		battle.makeChoices();
-		assert.false.cantMove(() => battle.choose('p1', 'move tackle'));
+		assert.cantMove(() => battle.choose('p1', 'move tackle'));
 	});
 });


### PR DESCRIPTION
This patch fixes the bug "Hyper Beam should only skip recharge turns when KOing a Substitute, not every time", listed here:

https://www.smogon.com/forums/threads/rby-tradebacks-bug-report-thread.3524844/#post-5933177

Previously, Hyper Beam would skip recharge turns when hitting a Substitute, regardless of whether the Substitute was KOd.