### PR TITLE
Gen 1: Fix Mirror Move Hyper Beam interaction

### DIFF
--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -67,8 +67,7 @@ export const Scripts: ModdedBattleScriptsData = {
 	},
 	actions: {
 		// This function is the main one when running a move.
-		// It deals with the beforeMove and AfterMoveSelf events.
-		// This leads with partial trapping moves shennanigans after the move has been used.
+		// It deals with the beforeMove event
 		// It also deals with how PP reduction works on gen 1.
 		runMove(moveOrMoveName, pokemon, targetLoc, sourceEffect) {
 			const target = this.battle.getTarget(pokemon, moveOrMoveName, targetLoc);
@@ -115,46 +114,79 @@ export const Scripts: ModdedBattleScriptsData = {
 				}
 			}
 			this.useMove(move, pokemon, target, sourceEffect);
-			this.battle.singleEvent('AfterMove', move, null, pokemon, target, move);
+		},
+		// This function deals with AfterMoveSelf events.
+		// This leads with partial trapping moves shenanigans after the move has been used.
+		useMove(moveOrMoveName, pokemon, target, sourceEffect) {
+			const moveResult = this.useMoveInner(moveOrMoveName, pokemon, target, sourceEffect);
 
-			// If target fainted
-			if (target && target.hp <= 0) {
-				// We remove recharge
-				if (pokemon.volatiles['mustrecharge']) pokemon.removeVolatile('mustrecharge');
-				delete pokemon.volatiles['partialtrappinglock'];
-				// We remove screens
-				target.side.removeSideCondition('reflect');
-				target.side.removeSideCondition('lightscreen');
-				pokemon.removeVolatile('twoturnmove');
-			} else if (pokemon.hp) {
-				this.battle.runEvent('AfterMoveSelf', pokemon, target, move);
+			if (!sourceEffect && this.battle.effect.id) sourceEffect = this.battle.effect;
+			const baseMove = this.battle.dex.moves.get(moveOrMoveName);
+			let move = this.battle.dex.getActiveMove(baseMove);
+			if (target === undefined) target = this.battle.getRandomTarget(pokemon, move);
+			if (move.target === 'self') {
+				target = pokemon;
 			}
-			if (pokemon.volatiles['mustrecharge']) this.battle.add('-mustrecharge', pokemon);
+			if (sourceEffect) move.sourceEffect = sourceEffect.id;
 
-			// For partial trapping moves, we are saving the target
-			if (move.volatileStatus === 'partiallytrapped' && target && target.hp > 0) {
-				// Let's check if the lock exists
-				if (pokemon.volatiles['partialtrappinglock'] && target.volatiles['partiallytrapped']) {
-					// Here the partialtrappinglock volatile has been already applied
-					const sourceVolatile = pokemon.volatiles['partialtrappinglock'];
-					const targetVolatile = target.volatiles['partiallytrapped'];
-					if (!sourceVolatile.locked) {
-						// If it's the first hit, we save the target
-						sourceVolatile.locked = target;
-					} else if (target !== pokemon && target !== sourceVolatile.locked) {
-						// Our target switched out! Re-roll the duration, damage, and accuracy.
-						const duration = this.battle.sample([2, 2, 2, 3, 3, 3, 4, 5]);
-						sourceVolatile.duration = duration;
-						sourceVolatile.locked = target;
-						// Duration reset thus partially trapped at 2 always.
-						targetVolatile.duration = 2;
+			this.battle.singleEvent('ModifyMove', move, null, pokemon, target, move, move);
+			if (baseMove.target !== move.target) {
+				// Target changed in ModifyMove, so we must adjust it here
+				target = this.battle.getRandomTarget(pokemon, move);
+			}
+			move = this.battle.runEvent('ModifyMove', pokemon, target, move, move);
+			if (baseMove.target !== move.target) {
+				// Check again, this shouldn't ever happen on Gen 1.
+				target = this.battle.getRandomTarget(pokemon, move);
+			}
+
+			if (move.id !== 'metronome') {
+				if (move.id !== 'mirrormove' ||
+					(!pokemon.side.foe.active[0]?.lastMove || pokemon.side.foe.active[0].lastMove?.id === 'mirrormove')) {
+					// The move is our 'final' move (a failed Mirror Move, or any move that isn't Metronome or Mirror Move).
+					this.battle.singleEvent('AfterMove', move, null, pokemon, target, move);
+
+					// If target fainted
+					if (target && target.hp <= 0) {
+						// We remove recharge
+						if (pokemon.volatiles['mustrecharge']) pokemon.removeVolatile('mustrecharge');
+						delete pokemon.volatiles['partialtrappinglock'];
+						// We remove screens
+						target.side.removeSideCondition('reflect');
+						target.side.removeSideCondition('lightscreen');
+						pokemon.removeVolatile('twoturnmove');
+					} else if (pokemon.hp) {
+						this.battle.runEvent('AfterMoveSelf', pokemon, target, move);
 					}
-				} // If we move to here, the move failed and there's no partial trapping lock.
+					if (pokemon.volatiles['mustrecharge']) this.battle.add('-mustrecharge', pokemon);
+
+					// For partial trapping moves, we are saving the target
+					if (move.volatileStatus === 'partiallytrapped' && target && target.hp > 0) {
+						// Let's check if the lock exists
+						if (pokemon.volatiles['partialtrappinglock'] && target.volatiles['partiallytrapped']) {
+							// Here the partialtrappinglock volatile has been already applied
+							const sourceVolatile = pokemon.volatiles['partialtrappinglock'];
+							const targetVolatile = target.volatiles['partiallytrapped'];
+							if (!sourceVolatile.locked) {
+								// If it's the first hit, we save the target
+								sourceVolatile.locked = target;
+							} else if (target !== pokemon && target !== sourceVolatile.locked) {
+								// Our target switched out! Re-roll the duration, damage, and accuracy.
+								const duration = this.battle.sample([2, 2, 2, 3, 3, 3, 4, 5]);
+								sourceVolatile.duration = duration;
+								sourceVolatile.locked = target;
+								// Duration reset thus partially trapped at 2 always.
+								targetVolatile.duration = 2;
+							}
+						} // If we move to here, the move failed and there's no partial trapping lock.
+					}
+				}
 			}
+			return moveResult;
 		},
 		// This is the function that actually uses the move, running ModifyMove events.
 		// It uses the move and then deals with the effects after the move.
-		useMove(moveOrMoveName, pokemon, target, sourceEffect) {
+		useMoveInner(moveOrMoveName, pokemon, target, sourceEffect) {
 			if (!sourceEffect && this.battle.effect.id) sourceEffect = this.battle.effect;
 			const baseMove = this.battle.dex.moves.get(moveOrMoveName);
 			let move = this.battle.dex.getActiveMove(baseMove);

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -67,7 +67,7 @@ export const Scripts: ModdedBattleScriptsData = {
 	},
 	actions: {
 		// This function is the main one when running a move.
-		// It deals with the beforeMove event
+		// It deals with the beforeMove event.
 		// It also deals with how PP reduction works on gen 1.
 		runMove(moveOrMoveName, pokemon, targetLoc, sourceEffect) {
 			const target = this.battle.getTarget(pokemon, moveOrMoveName, targetLoc);

--- a/test/sim/moves/mirrormove.js
+++ b/test/sim/moves/mirrormove.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Mirror Move [Gen 1]', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it(`[Gen 1] Mirror Move'd Hyper Beam should force a recharge turn after not KOing a Pokemon`, function () {
+		battle = common.gen(1).createBattle([[
+			{species: 'fearow', moves: ['mirrormove', 'tackle']},
+		], [
+			{species: 'aerodactyl', moves: ['hyperbeam']},
+		]]);
+		battle.makeChoices();
+		assert.cantMove(() => battle.choose('p1', 'move tackle'));
+	});
+
+	it(`[Gen 1] Mirror Move'd Hyper Beam should not force a recharge turn after KOing a Pokemon`, function () {
+		battle = common.gen(1).createBattle([[
+			{species: 'fearow', moves: ['mirrormove', 'tackle']},
+		], [
+			{species: 'kadabra', moves: ['hyperbeam']},
+			{species: 'exeggutor', moves: ['splash']},
+		]]);
+		battle.makeChoices();
+		battle.choose('p2', 'switch exeggutor');
+		assert.false.cantMove(() => battle.choose('p1', 'move tackle'));
+	});
+});


### PR DESCRIPTION
This patch fixes the interaction between Mirror Move and Hyper Beam. When Mirror Move calls Hyper Beam and KO's the enemy, the Mirror Move user should not need to recharge. 

https://www.smogon.com/forums/threads/rby-tradebacks-bug-report-thread.3524844/page-16#post-9004208

Partial trapping and charging moves called by Mirror Move are still messed up, but I think that's also an issue with the implementation of those moves themselves.