### PR TITLE
Gen 1: Fix Counter interaction with Substitute

### DIFF
--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -835,6 +835,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				uncappedDamage = this.runEvent('SubDamage', target, source, move, uncappedDamage);
 				if (!uncappedDamage) return uncappedDamage;
 				source.lastDamage = uncappedDamage;
+				this.lastDamage = uncappedDamage;
 				target.volatiles['substitute'].hp -= uncappedDamage > target.volatiles['substitute'].hp ?
 					target.volatiles['substitute'].hp : uncappedDamage;
 				if (target.volatiles['substitute'].hp <= 0) {

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -248,7 +248,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				'conversion', 'haze', 'mist', 'focusenergy', 'confuseray', 'supersonic', 'transform', 'lightscreen', 'reflect', 'substitute', 'mimic', 'leechseed', 'splash', 'softboiled', 'recover', 'rest',
 			];
 			if (
-				!damage &&
+				!damage && damage !== 0 &&
 				(move.category !== 'Status' || (move.status && !['psn', 'tox', 'par'].includes(move.status))) &&
 				!neverDamageMoves.includes(move.id)
 			) {
@@ -470,7 +470,6 @@ export const Scripts: ModdedBattleScriptsData = {
 				let didSomething = false;
 
 				damage = this.getDamage(pokemon, target, moveData);
-
 				// getDamage has several possible return values:
 				//
 				//   a number:

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -470,7 +470,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				let didSomething = false;
 
 				damage = this.getDamage(pokemon, target, moveData);
-				
+
 				// getDamage has several possible return values:
 				//
 				//   a number:

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -470,6 +470,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				let didSomething = false;
 
 				damage = this.getDamage(pokemon, target, moveData);
+				
 				// getDamage has several possible return values:
 				//
 				//   a number:

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -242,7 +242,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 			damage = this.tryMoveHit(target, pokemon, move);
 
-			// Store 0 damage for last damage if move failed or dealt 0 damage.
+			// Store 0 damage for last damage if move failed.
 			// This only happens on moves that don't deal damage but call GetDamageVarsForPlayerAttack (disassembly).
 			const neverDamageMoves = [
 				'conversion', 'haze', 'mist', 'focusenergy', 'confuseray', 'supersonic', 'transform', 'lightscreen', 'reflect', 'substitute', 'mimic', 'leechseed', 'splash', 'softboiled', 'recover', 'rest',

--- a/data/mods/gen1jpn/moves.ts
+++ b/data/mods/gen1jpn/moves.ts
@@ -84,6 +84,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				uncappedDamage = this.runEvent('SubDamage', target, source, move, uncappedDamage);
 				if (!uncappedDamage) return uncappedDamage;
 				source.lastDamage = uncappedDamage;
+				this.lastDamage = uncappedDamage;
 				target.volatiles['substitute'].hp -= uncappedDamage > target.volatiles['substitute'].hp ?
 					target.volatiles['substitute'].hp : uncappedDamage;
 				if (target.volatiles['substitute'].hp <= 0) {

--- a/data/mods/gen1stadium/moves.ts
+++ b/data/mods/gen1stadium/moves.ts
@@ -176,6 +176,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				if (!damage) return damage;
 				target.volatiles['substitute'].hp -= damage;
 				source.lastDamage = damage;
+				this.lastDamage = damage;
 				if (target.volatiles['substitute'].hp <= 0) {
 					this.debug('Substitute broke');
 					target.removeVolatile('substitute');

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -219,7 +219,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				'conversion', 'haze', 'mist', 'focusenergy', 'confuseray', 'supersonic', 'transform', 'lightscreen', 'reflect', 'substitute', 'mimic', 'leechseed', 'splash', 'softboiled', 'recover', 'rest',
 			];
 			if (
-				!damage &&
+				!damage && damage !== 0 &&
 				(move.category !== 'Status' || (move.status && !['psn', 'tox', 'par'].includes(move.status))) &&
 				!neverDamageMoves.includes(move.id)
 			) {

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -213,7 +213,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 			damage = this.tryMoveHit(target, pokemon, move);
 
-			// Store 0 damage for last damage if move failed or dealt 0 damage.
+			// Store 0 damage for last damage if move failed.
 			// This only happens on moves that don't deal damage but call GetDamageVarsForPlayerAttack (disassembly).
 			const neverDamageMoves = [
 				'conversion', 'haze', 'mist', 'focusenergy', 'confuseray', 'supersonic', 'transform', 'lightscreen', 'reflect', 'substitute', 'mimic', 'leechseed', 'splash', 'softboiled', 'recover', 'rest',

--- a/test/sim/moves/counter.js
+++ b/test/sim/moves/counter.js
@@ -114,6 +114,27 @@ describe('Counter', function () {
 		assert.fullHP(battle.p1.active[0]);
 	});
 
+	it(`[Gen 1] Counter can counter attacks against substitutes`, function () {
+		battle = common.gen(1).createBattle([[
+			{species: 'Chansey', moves: ['substitute', 'counter']},
+		], [
+			{species: 'Snorlax', moves: ['bodyslam']},
+			{species: 'Chansey', moves: ['softboiled']},
+		]]);
+		battle.makeChoices('move substitute', 'move bodyslam');
+		battle.makeChoices('move counter', 'switch 2');
+		assert.fainted(battle.p2.active[0]);
+
+		battle = common.gen(1).createBattle([[
+			{species: 'Chansey', moves: ['substitute', 'counter']},
+		], [
+			{species: 'Snorlax', moves: ['bodyslam', 'splash']},
+		]]);
+		battle.makeChoices('move substitute', 'move splash');
+		battle.makeChoices('move counter', 'move bodyslam');
+		assert.fainted(battle.p2.active[0]);
+	});
+
 	it(`[Gen 1 Stadium] should counter Normal/Fighting moves only`, function () {
 		// should counter Normal/Fighting moves
 		battle = common.mod('gen1stadium').createBattle([[
@@ -125,6 +146,17 @@ describe('Counter', function () {
 		assert.fullHP(battle.p1.active[0]);
 		battle.makeChoices('move pound', 'move counter');
 		assert.false.fullHP(battle.p1.active[0]);
+	});
+
+	it(`[Gen 1 Stadium] Counter can counter attacks against substitutes`, function () {
+		battle = common.mod('gen1stadium').createBattle([[
+			{species: 'Chansey', moves: ['substitute', 'counter']},
+		], [
+			{species: 'Snorlax', moves: ['bodyslam', 'splash']},
+		]]);
+		battle.makeChoices('move substitute', 'move splash');
+		battle.makeChoices('move counter', 'move bodyslam');
+		assert.false.fullHP(battle.p2.active[0]);
 	});
 
 	it(`should not have its target changed by Stalwart`, function () {

--- a/test/sim/moves/counter.js
+++ b/test/sim/moves/counter.js
@@ -148,7 +148,7 @@ describe('Counter', function () {
 		assert.false.fullHP(battle.p1.active[0]);
 	});
 
-	it(`[Gen 1 Stadium] Counter can counter attacks against substitutes`, function () {
+	it(`[Gen 1 Stadium] should counter attacks made against substitutes`, function () {
 		battle = common.mod('gen1stadium').createBattle([[
 			{species: 'Chansey', moves: ['substitute', 'counter']},
 		], [

--- a/test/sim/moves/counter.js
+++ b/test/sim/moves/counter.js
@@ -114,7 +114,7 @@ describe('Counter', function () {
 		assert.fullHP(battle.p1.active[0]);
 	});
 
-	it(`[Gen 1] Counter can counter attacks against substitutes`, function () {
+	it(`[Gen 1] should counter attacks made against substitutes`, function () {
 		battle = common.gen(1).createBattle([[
 			{species: 'Chansey', moves: ['substitute', 'counter']},
 		], [


### PR DESCRIPTION
This patch fixes Counter so that it can counter attacks that hit a substitute. Previously, Counter could not counter attacks that hit a substitute, even if they are 'counterable' in Gen 1. The damage that is countered is the 'uncapped' damage (for non-Stadium), which can be important if the attack breaks the substitute.

https://www.smogon.com/forums/threads/rby-tradebacks-bug-report-thread.3524844/page-16#post-8973042
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/page-30#post-8645108
Also fixes the same Counter/Substitute issue in Gen 1 Stadium, listed here:
https://www.smogon.com/forums/threads/stadium-bug-report-thread.3526616/page-3#post-8644615

(Does NOT fix the same issue with Bide: probably not working on that move for a while)