### PR TITLE
Battle Factory: Raise max generation attempts

### DIFF
--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -1202,7 +1202,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 	randomFactoryTeam(side: PlayerOptions, depth = 0): RandomTeamsTypes.RandomFactorySet[] {
 		this.enforceNoDirectCustomBanlistChanges();
 
-		const forceResult = (depth >= 4);
+		const forceResult = (depth >= 12);
 
 		// The teams generated depend on the tier choice in such a way that
 		// no exploitable information is leaked from rolling the tier in getTeam(p1).

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1743,7 +1743,7 @@ export class RandomGen7Teams extends RandomTeams {
 	randomFactoryTeam(side: PlayerOptions, depth = 0): RandomTeamsTypes.RandomFactorySet[] {
 		this.enforceNoDirectCustomBanlistChanges();
 
-		const forceResult = (depth >= 4);
+		const forceResult = (depth >= 12);
 		const isMonotype = !!this.forceMonotype || this.dex.formats.getRuleTable(this.format).has('sametypeclause');
 
 		// The teams generated depend on the tier choice in such a way that

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -2689,7 +2689,7 @@ export class RandomTeams {
 	randomFactoryTeam(side: PlayerOptions, depth = 0): RandomTeamsTypes.RandomFactorySet[] {
 		this.enforceNoDirectCustomBanlistChanges();
 
-		const forceResult = (depth >= 4);
+		const forceResult = (depth >= 12);
 		// Leaving Monotype code in comments in case it's used in the future
 		// const isMonotype = !!this.forceMonotype || this.dex.formats.getRuleTable(this.format).has('sametypeclause');
 


### PR DESCRIPTION
Discussed with @ACakeWearingAHat 

This raises the number of attempts taken by the Battle Factory algorithm to generate a team with the desired parameters, such as having exactly 1 Stealth Rocker and having exactly one hazard remover.

This should be considered only a temporary migitation; a better solution for the future would be to rewrite the generator around guaranteeing teammates with certain features

This won't badly tank performance; time and space complexity are both O(n) with the number of attempts, which is distributed geometrically