### PR TITLE
Random Battles updates

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -1234,7 +1234,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (move?.type === 'Flying' && pokemon.hp === pokemon.maxhp) return priority + 1;
 		},
 		name: "Gale Wings",
-		rating: 3,
+		rating: 2.5,
 		num: 177,
 	},
 	galvanize: {

--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -1405,7 +1405,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		natDexTier: "RU",
 	},
 	glaceon: {
-		randomBattleMoves: ["freezedry", "protect", "shadowball", "toxic", "wish"],
+		randomBattleMoves: ["freezedry", "protect", "toxic", "wish"],
 		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["blizzard", "freezedry", "helpinghand", "protect", "shadowball", "wish"],
 		randomDoubleBattleLevel: 88,
@@ -5841,7 +5841,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		natDexTier: "RU",
 	},
 	silvallyghost: {
-		randomBattleMoves: ["multiattack", "partingshot", "swordsdance", "xscissor"],
+		randomBattleMoves: ["flamecharge", "multiattack", "partingshot", "swordsdance", "xscissor"],
 		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["multiattack", "swordsdance", "tailwind", "xscissor"],
 		randomDoubleBattleLevel: 88,

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -185,6 +185,7 @@ export class RandomTeams {
 				].some(moveid => movePool.includes(moveid))
 			),
 			Ghost: (movePool, moves, abilities, types, counter) => {
+				if (moves.has('nightshade')) return false;
 				if (!counter.get('Ghost') && !types.has('Dark')) return true;
 				if (movePool.includes('poltergeist')) return true;
 				return movePool.includes('spectralthief') && !counter.get('Dark');
@@ -1475,7 +1476,7 @@ export class RandomTeams {
 	): boolean {
 		if ([
 			'Flare Boost', 'Hydration', 'Ice Body', 'Immunity', 'Innards Out', 'Insomnia', 'Misty Surge',
-			'Quick Feet', 'Rain Dish', 'Snow Cloak', 'Steadfast', 'Steam Engine',
+			'Perish Body', 'Quick Feet', 'Rain Dish', 'Snow Cloak', 'Steadfast', 'Steam Engine',
 		].includes(ability)) return true;
 
 		switch (ability) {


### PR DESCRIPTION
All of the following were approved by the Random Battles room auth and can be found in the "discussed, actionable points" pin in the gen 8 random battle channel.

- Lowered the frequency of Will-O-Wisp-less Corsola-Galar to 7%, from 33%
- Added Flame Charge to Silvally-Ghost
- Removed Shadow Ball from Glaceon
- Perish Body will no longer appear; Cursola will always have Weak Armor now.
- Gale Wings's ability rating has been lowered by 0.5; this allows Flame Body Talonflame to exist.