### PR TITLE
Gen 1: Fix simultaneous Counters so that they both fail

### DIFF
--- a/sim/battle-queue.ts
+++ b/sim/battle-queue.ts
@@ -279,9 +279,10 @@ export class BattleQueue {
 		for (const choice of choices) {
 			const resolvedChoices = this.resolveAction(choice);
 			this.list.push(...resolvedChoices);
-			const resolvedChoice = resolvedChoices[0];
-			if (resolvedChoice && resolvedChoice.choice === 'move' && resolvedChoice.move.id !== 'recharge') {
-				resolvedChoice.pokemon.side.lastSelectedMove = resolvedChoice.move.id;
+			for (const resolvedChoice of resolvedChoices) {
+				if (resolvedChoice && resolvedChoice.choice === 'move' && resolvedChoice.move.id !== 'recharge') {
+					resolvedChoice.pokemon.side.lastSelectedMove = resolvedChoice.move.id;
+				}
 			}
 		}
 	}

--- a/test/sim/moves/counter.js
+++ b/test/sim/moves/counter.js
@@ -135,6 +135,21 @@ describe('Counter', function () {
 		assert.fainted(battle.p2.active[0]);
 	});
 
+	it(`[Gen 1] simultaneous counters should both fail`, function () {
+		battle = common.gen(1).createBattle([[
+			{species: 'Golem', moves: ['bodyslam']},
+			{species: 'Chansey', moves: ['counter']},
+		], [
+			{species: 'Tauros', moves: ['bodyslam']},
+			{species: 'Chansey', moves: ['counter']},
+		]]);
+		battle.makeChoices();
+		battle.makeChoices('switch 2', 'switch 2');
+		battle.makeChoices();
+		assert.fullHP(battle.p1.active[0]);
+		assert.fullHP(battle.p2.active[0]);
+	});
+
 	it(`[Gen 1 Stadium] should counter Normal/Fighting moves only`, function () {
 		// should counter Normal/Fighting moves
 		battle = common.mod('gen1stadium').createBattle([[


### PR DESCRIPTION
This patch fixes Counter so that it will always fail when the opponent's last selected move is Counter, including when both Counters are selected on the same turn.

Mentioned here and confirmed in many other places:
https://www.smogon.com/forums/threads/rby-tradebacks-bug-report-thread.3524844/#post-5933177