### PR TITLE
Fix: Trigger emergency exit after Mind Blown

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -11162,6 +11162,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.damage(Math.round(pokemon.maxhp / 2), pokemon, pokemon, this.dex.conditions.get('Mind Blown'), true);
 			}
 		},
+		onAfterMoveSecondarySelf(pokemon, target, move) {
+			const maxhp = pokemon.getUndynamaxedHP(pokemon.maxhp);
+			if (pokemon.hp && pokemon.ability === "emergencyexit" && pokemon.getUndynamaxedHP() <= maxhp / 2) {
+				this.runEvent('EmergencyExit', pokemon);
+			}
+		},
 		secondary: null,
 		target: "allAdjacent",
 		type: "Fire",
@@ -16771,6 +16777,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 		onAfterMove(pokemon, target, move) {
 			if (move.mindBlownRecoil && !move.multihit) {
 				this.damage(Math.round(pokemon.maxhp / 2), pokemon, pokemon, this.dex.conditions.get('Steel Beam'), true);
+			}
+		},
+		onAfterMoveSecondarySelf(pokemon, target, move) {
+			const maxhp = pokemon.getUndynamaxedHP(pokemon.maxhp);
+			if (pokemon.hp && pokemon.ability === "emergencyexit" && pokemon.getUndynamaxedHP() <= maxhp / 2) {
+				this.runEvent('EmergencyExit', pokemon);
 			}
 		},
 		secondary: null,

--- a/test/sim/abilities/emergencyexit.js
+++ b/test/sim/abilities/emergencyexit.js
@@ -123,7 +123,7 @@ describe(`Emergency Exit`, function () {
 		assert.equal(battle.requestState, 'switch');
 	});
 
-	it.skip('should request switch-out after taking Mind Blown self-damage', function () {
+	it('should request switch-out after taking Mind Blown self-damage', function () {
 		battle = common.createBattle([[
 			{species: "Golisopod", ability: 'emergencyexit', moves: ['mindblown']},
 			{species: "Wynaut", moves: ['sleeptalk']},


### PR DESCRIPTION
As suggested here: [Various Emergency Exit bugs](https://github.com/smogon/pokemon-showdown/projects/3#card-85841440)