### PR TITLE
Add more debug messages for moves with custom base power

### DIFF
--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -302,9 +302,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	frustration: {
 		inherit: true,
 		basePowerCallback(pokemon) {
-			const bp = Math.floor(((255 - pokemon.happiness) * 10) / 25) || null;
-			this.debug('BP: ' + bp);
-			return bp;
+			return Math.floor(((255 - pokemon.happiness) * 10) / 25) || null;
 		},
 	},
 	healbell: {
@@ -679,9 +677,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	return: {
 		inherit: true,
 		basePowerCallback(pokemon) {
-			const bp = Math.floor((pokemon.happiness * 10) / 25) || null;
-			this.debug('BP: ' + bp);
-			return bp;
+			return Math.floor((pokemon.happiness * 10) / 25) || null;
 		},
 	},
 	reversal: {

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -302,7 +302,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	frustration: {
 		inherit: true,
 		basePowerCallback(pokemon) {
-			return Math.floor(((255 - pokemon.happiness) * 10) / 25) || null;
+			const bp = Math.floor(((255 - pokemon.happiness) * 10) / 25) || null;
+			this.debug('BP: ' + bp);
+			return bp;
 		},
 	},
 	healbell: {
@@ -677,7 +679,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	return: {
 		inherit: true,
 		basePowerCallback(pokemon) {
-			return Math.floor((pokemon.happiness * 10) / 25) || null;
+			const bp = Math.floor((pokemon.happiness * 10) / 25) || null;
+			this.debug('BP: ' + bp);
+			return bp;
 		},
 	},
 	reversal: {

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -393,10 +393,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	hiddenpower: {
 		inherit: true,
-		basePower: 0,
-		basePowerCallback(pokemon) {
-			return pokemon.hpPower || 70;
-		},
 		category: "Physical",
 		onModifyMove(move, pokemon) {
 			move.type = pokemon.hpType || 'Dark';

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -248,7 +248,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	crushgrip: {
 		inherit: true,
 		basePowerCallback(pokemon, target) {
-			return Math.floor(target.hp * 120 / target.maxhp) + 1;
+			const bp = Math.floor(target.hp * 120 / target.maxhp) + 1;
+			this.debug('BP for ' + target.hp + '/' + target.maxhp + " HP: " + bp);
+			return bp;
 		},
 	},
 	curse: {
@@ -513,23 +515,23 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	flail: {
 		inherit: true,
 		basePowerCallback(pokemon, target) {
-			const ratio = pokemon.hp * 64 / pokemon.maxhp;
+			const ratio = Math.max(Math.floor(pokemon.hp * 64 / pokemon.maxhp), 1);
+			let bp;
 			if (ratio < 2) {
-				return 200;
+				bp = 200;
+			} else if (ratio < 6) {
+				bp = 150;
+			} else if (ratio < 13) {
+				bp = 100;
+			} else if (ratio < 22) {
+				bp = 80;
+			} else if (ratio < 43) {
+				bp = 40;
+			} else {
+				bp = 20;
 			}
-			if (ratio < 6) {
-				return 150;
-			}
-			if (ratio < 13) {
-				return 100;
-			}
-			if (ratio < 22) {
-				return 80;
-			}
-			if (ratio < 43) {
-				return 40;
-			}
-			return 20;
+			this.debug('BP: ' + bp);
+			return bp;
 		},
 	},
 	flareblitz: {
@@ -1166,6 +1168,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			if (this.queue.willMove(target)) {
 				return 50;
 			}
+			this.debug('BP doubled');
 			return 100;
 		},
 	},
@@ -1309,23 +1312,23 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	reversal: {
 		inherit: true,
 		basePowerCallback(pokemon, target) {
-			const ratio = pokemon.hp * 64 / pokemon.maxhp;
+			const ratio = Math.max(Math.floor(pokemon.hp * 64 / pokemon.maxhp), 1);
+			let bp;
 			if (ratio < 2) {
-				return 200;
+				bp = 200;
+			} else if (ratio < 6) {
+				bp = 150;
+			} else if (ratio < 13) {
+				bp = 100;
+			} else if (ratio < 22) {
+				bp = 80;
+			} else if (ratio < 43) {
+				bp = 40;
+			} else {
+				bp = 20;
 			}
-			if (ratio < 6) {
-				return 150;
-			}
-			if (ratio < 13) {
-				return 100;
-			}
-			if (ratio < 22) {
-				return 80;
-			}
-			if (ratio < 43) {
-				return 40;
-			}
-			return 20;
+			this.debug('BP: ' + bp);
+			return bp;
 		},
 	},
 	roar: {
@@ -1806,7 +1809,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	wringout: {
 		inherit: true,
 		basePowerCallback(pokemon, target) {
-			return Math.floor(target.hp * 120 / target.maxhp) + 1;
+			const bp = Math.floor(target.hp * 120 / target.maxhp) + 1;
+			this.debug('BP for ' + target.hp + '/' + target.maxhp + " HP: " + bp);
+			return bp;
 		},
 	},
 	yawn: {

--- a/data/mods/gen5/moves.ts
+++ b/data/mods/gen5/moves.ts
@@ -214,7 +214,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		basePowerCallback(pokemon, target) {
 			const ratio = Math.floor(pokemon.getStat('spe') / Math.max(1, target.getStat('spe')));
 			const bp = [40, 60, 80, 120, 150][Math.min(ratio, 4)];
-			this.debug(`${bp} bp`);
+			this.debug('BP: ' + bp);
 			return bp;
 		},
 	},
@@ -344,7 +344,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		basePowerCallback(pokemon, target) {
 			let power = Math.floor(25 * target.getStat('spe') / Math.max(1, pokemon.getStat('spe'))) + 1;
 			if (power > 150) power = 150;
-			this.debug(`${power} bp`);
+			this.debug('BP: ' + power);
 			return power;
 		},
 	},
@@ -376,7 +376,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		basePower: 0,
 		basePowerCallback(pokemon) {
-			return pokemon.hpPower || 70;
+			const bp = pokemon.hpPower || 70;
+			this.debug('BP: ' + bp);
+			return bp;
 		},
 	},
 	hiddenpowerbug: {

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -5783,9 +5783,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		accuracy: 100,
 		basePower: 0,
 		basePowerCallback(pokemon) {
-			const bp = Math.floor(((255 - pokemon.happiness) * 10) / 25) || 1;
-			this.debug('BP: ' + bp);
-			return bp;
+			return Math.floor(((255 - pokemon.happiness) * 10) / 25) || 1;
 		},
 		category: "Physical",
 		isNonstandard: "Past",
@@ -14079,9 +14077,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		accuracy: 100,
 		basePower: 0,
 		basePowerCallback(pokemon) {
-			const bp = Math.floor((pokemon.happiness * 10) / 25) || 1;
-			this.debug('BP: ' + bp);
-			return bp;
+			return Math.floor((pokemon.happiness * 10) / 25) || 1;
 		},
 		category: "Physical",
 		isNonstandard: "Past",


### PR DESCRIPTION
Adds base power debugging messages (see [Discord discussion](https://discord.com/channels/630837856075513856/630845310033330206/1031028616458407976)). All the moves with custom base power should be covered now (save ones that are immediately obvious, e.g. Pledge moves or Magnitude).

In addition, this fixes Flail / Reversal's ratio calculation in Gen 5+. @Marty-D can you verify if they floor or not in Gen 4?

I've also removed an unnecessary piece of inheritance for Hidden Power in Gen III.