### PR TITLE
Mafia: Add /mafia resetgame command and some other minor stuff.

### DIFF
--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -517,8 +517,8 @@ class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 				user.sendTo(this.room.roomid, `|notify|It's night in the game of Mafia! Send in an action or idle.`);
 			}
 		}
-		for (const player in this.playerTable) { 
-			this.playerTable[player].actionArr.splice(0,this.playerTable[player].actionArr.length);
+		for (const player in this.playerTable) {
+			this.playerTable[player].actionArr.splice(0, this.playerTable[player].actionArr.length);
 		}
 		if (this.timer) this.setDeadline(0);
 		this.sendDeclare(`The game  has been reset.`);
@@ -2379,14 +2379,14 @@ export const commands: Chat.ChatCommands = {
 
 		resetgame: 'gamereset',
 		forceresetgame: 'gamereset',
-		gamereset(target,room,user,connection) {
+		gamereset(target, room, user, connection) {
 			room = this.requireRoom();
 			const game = this.requireGame(Mafia);
 			if (game.hostid !== user.id && !game.cohostids.includes(user.id)) this.checkCan('mute', null, room);
 			if (target) return this.parse('/help mafia resetgame');
 			if (game.phase !== 'day' && game.phase !== 'night') return this.errorReply(`The game has not started yet.`);
 			game.resetGame();
-			game.logAction(user,'reset the game state');
+			game.logAction(user, 'reset the game state');
 		},
 		resetgamehelp: [
 			`/mafia resetgame - Resets game data. Does not change settings from the host besides deadlines or add/remove any players. Requires host % @ # &`,

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -521,7 +521,7 @@ class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 			this.playerTable[player].actionArr.splice(0, this.playerTable[player].actionArr.length);
 		}
 		if (this.timer) this.setDeadline(0);
-		this.sendDeclare(`The game  has been reset.`);
+		this.sendDeclare(`The game has been reset.`);
 		this.distributeRoles();
 		if (this.takeIdles) {
 			this.sendDeclare(`Night ${this.dayNum}. Submit whether you are using an action or idle. If you are using an action, DM your action to the host.`);

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -2389,7 +2389,7 @@ export const commands: Chat.ChatCommands = {
 			game.logAction(user, 'reset the game state');
 		},
 		resetgamehelp: [
-			`/mafia resetgame - Resets game data. Does not change settings from the host besides deadlines or add/remove any players. Requires host % @ # &`,
+			`/mafia resetgame - Resets game data. Does not change settings from the host (besides deadlines) or add/remove any players. Requires host % @ # &`,
 		],
 
 		idea(target, room, user) {

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -503,6 +503,33 @@ class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 		if (reset) this.distributeRoles();
 	}
 
+	resetGame() {
+		this.clearVotes();
+		this.dayNum = 0;
+		this.phase = 'night';
+		for (const hostid of [...this.cohostids, this.hostid]) {
+			const host = Users.get(hostid);
+			if (host?.connected) host.send(`>${this.room.roomid}\n|notify|It's night in your game of Mafia!`);
+		}
+		for (const player of Object.values(this.playerTable)) {
+			const user = Users.get(player.id);
+			if (user?.connected) {
+				user.sendTo(this.room.roomid, `|notify|It's night in the game of Mafia! Send in an action or idle.`);
+			}
+		}
+		for (const player in this.playerTable) { 
+			this.playerTable[player].actionArr.splice(0,this.playerTable[player].actionArr.length);
+		}
+		if (this.timer) this.setDeadline(0);
+		this.sendDeclare(`The game  has been reset.`);
+		this.distributeRoles();
+		if (this.takeIdles) {
+			this.sendDeclare(`Night ${this.dayNum}. Submit whether you are using an action or idle. If you are using an action, DM your action to the host.`);
+		} else {
+			this.sendDeclare(`Night ${this.dayNum}. PM the host your action, or idle.`);
+		}
+		return;
+	}
 	static parseRole(roleString: string) {
 		const roleName = roleString.replace(/solo/, '').trim();
 
@@ -2346,6 +2373,21 @@ export const commands: Chat.ChatCommands = {
 			`/mafia resetroles [comma separated roles] - Reset the roles in an ongoing game.`,
 		],
 
+		resetgame: 'gamereset',
+		forceresetgame: 'gamereset',
+		gamereset(target,room,user,connection) {
+			room = this.requireRoom();
+			const game = this.requireGame(Mafia);
+			if (game.hostid !== user.id && !game.cohostids.includes(user.id)) this.checkCan('mute', null, room);
+			if (target) return this.parse('/help mafia resetgame');
+			if (game.phase !== 'day' && game.phase !== 'night') return this.errorReply(`The game has not started yet.`);
+			game.resetGame();
+			game.logAction(user,'reset the game state');
+		},
+		resetgamehelp: [
+			`/mafia resetgame - Resets game data.Does not change settings from the host besides deadlines or add/remove any players.Requires host % @ # &`,
+		],
+
 		idea(target, room, user) {
 			room = this.requireRoom();
 			const game = this.requireGame(Mafia);
@@ -3994,6 +4036,7 @@ export const commands: Chat.ChatCommands = {
 			`/mafia shifthammer [hammer] - sets the hammer count to [hammer] without resetting votes`,
 			`/mafia resethammer - sets the hammer to the default, resetting votes`,
 			`/mafia playerroles - View all the player's roles in chat. Requires host`,
+			`/mafia resetgame - Resets game data.Does not change settings from the host besides deadlines or add/remove any players.Requires host % @ # &`,
 			`/mafia end - End the current game of mafia. Requires host + % @ # &`,
 		].join('<br/>');
 		buf += `</details><details><summary class="button">IDEA Module Commands</summary>`;

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -1983,7 +1983,7 @@ export const pages: Chat.PageTable = {
 			} else if (game.phase === 'night') {
 				if (game.dayNum !== 0) {
 					buf += `<button class="button" name="send" value="/msgroom ${room.roomid},/mafia day">Go to Day ${game.dayNum + 1}</button> <button class="button" name="send" value="/msgroom ${room.roomid},/mafia extend">Return to Day ${game.dayNum}</button>`;
-				} else { 
+				} else {
 					buf += `<button class="button" name="send" value="/msgroom ${room.roomid},/mafia day">Go to Day ${game.dayNum + 1}</button>`;
 				}
 			}
@@ -2390,7 +2390,7 @@ export const commands: Chat.ChatCommands = {
 		},
 		resetgamehelp: [
 			`/mafia resetgame - Resets game data. Does not change settings from the host besides deadlines or add/remove any players. Requires host % @ # &`,
-		],
+		], 
 
 		idea(target, room, user) {
 			room = this.requireRoom();

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -611,7 +611,7 @@ class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 		return {role, problems};
 	}
 
-	start(user: User, night = false) {
+	start(user: User, day = false) {
 		if (!user) return;
 		if (this.phase !== 'locked' && this.phase !== 'IDEAlocked') {
 			if (this.phase === 'signups') return user.sendTo(this.room, `You need to close the signups first.`);
@@ -635,10 +635,10 @@ class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 		this.sendDeclare(`The game of ${this.title} is starting!`);
 		// Mafia#played gets set in distributeRoles
 		this.distributeRoles();
-		if (night) {
-			this.night(false, true);
-		} else {
+		if (day) {
 			this.day(null, true);
+		} else {
+			this.night(false, true);
 		}
 		if (this.IDEA.data && !this.IDEA.discardsHidden) {
 			this.room.add(`|html|<div class="infobox"><details><summary>IDEA discards:</summary>${this.IDEA.discardsHTML}</details></div>`).update();
@@ -1981,7 +1981,11 @@ export const pages: Chat.PageTable = {
 			} else if (game.phase === 'day') {
 				buf += `<button class="button" name="send" value="/msgroom ${room.roomid},/mafia night">Go to Night ${game.dayNum}</button>`;
 			} else if (game.phase === 'night') {
-				buf += `<button class="button" name="send" value="/msgroom ${room.roomid},/mafia day">Go to Day ${game.dayNum + 1}</button> <button class="button" name="send" value="/msgroom ${room.roomid},/mafia extend">Return to Day ${game.dayNum}</button>`;
+				if (game.dayNum !== 0) {
+					buf += `<button class="button" name="send" value="/msgroom ${room.roomid},/mafia day">Go to Day ${game.dayNum + 1}</button> <button class="button" name="send" value="/msgroom ${room.roomid},/mafia extend">Return to Day ${game.dayNum}</button>`;
+				} else { 
+					buf += `<button class="button" name="send" value="/msgroom ${room.roomid},/mafia day">Go to Day ${game.dayNum + 1}</button>`;
+				}
 			}
 			buf += ` <button class="button" name="send" value="/msgroom ${room.roomid},/mafia selfvote ${game.selfEnabled === true ? 'off' : 'on'}">${game.selfEnabled === true ? 'Disable' : 'Enable'} self voting</button> `;
 			buf += `<button class="button" name="send" value="/msgroom ${room.roomid},/mafia ${game.enableNL ? 'disable' : 'enable'}nl">${game.enableNL ? 'Disable' : 'Enable'} No Vote</button> `;
@@ -2385,7 +2389,7 @@ export const commands: Chat.ChatCommands = {
 			game.logAction(user,'reset the game state');
 		},
 		resetgamehelp: [
-			`/mafia resetgame - Resets game data.Does not change settings from the host besides deadlines or add/remove any players.Requires host % @ # &`,
+			`/mafia resetgame - Resets game data. Does not change settings from the host besides deadlines or add/remove any players. Requires host % @ # &`,
 		],
 
 		idea(target, room, user) {
@@ -2485,6 +2489,7 @@ export const commands: Chat.ChatCommands = {
 			`/mafia ideadiscards on - shows discards to the players. Requires host % @ # &`,
 		],
 
+		daystart: 'start',
 		nightstart: 'start',
 		start(target, room, user, connection, cmd) {
 			room = this.requireRoom();
@@ -2496,7 +2501,7 @@ export const commands: Chat.ChatCommands = {
 				this.parse(`/mafia ${cmd}`);
 				return;
 			}
-			game.start(user, cmd === 'nightstart');
+			game.start(user, cmd === 'daystart');
 			game.logAction(user, `started the game`);
 		},
 		starthelp: [`/mafia start - Start the game of mafia. Signups must be closed. Requires host % @ # &`],
@@ -4036,7 +4041,7 @@ export const commands: Chat.ChatCommands = {
 			`/mafia shifthammer [hammer] - sets the hammer count to [hammer] without resetting votes`,
 			`/mafia resethammer - sets the hammer to the default, resetting votes`,
 			`/mafia playerroles - View all the player's roles in chat. Requires host`,
-			`/mafia resetgame - Resets game data.Does not change settings from the host besides deadlines or add/remove any players.Requires host % @ # &`,
+			`/mafia resetgame - Resets game data. Does not change settings from the host besides deadlines or add/remove any players. Requires host % @ # &`,
 			`/mafia end - End the current game of mafia. Requires host + % @ # &`,
 		].join('<br/>');
 		buf += `</details><details><summary class="button">IDEA Module Commands</summary>`;

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -2390,7 +2390,7 @@ export const commands: Chat.ChatCommands = {
 		},
 		resetgamehelp: [
 			`/mafia resetgame - Resets game data. Does not change settings from the host besides deadlines or add/remove any players. Requires host % @ # &`,
-		], 
+		],
 
 		idea(target, room, user) {
 			room = this.requireRoom();


### PR DESCRIPTION
/mafia resetgame resets the game to night 0,removes all action data from the html tab,redistributes the roles and clears all deadlines.Players who died or were kicked are not added,players who subbed in or were added are not removed and no other setting set by the host is changed. (Copied some of the night commands because the other option included a lot of spaghetti).

Return to day X button removed when x = 0 (it couldn't possibly work in any way and would always throw an error message).

Nightstart is now default,/mafia daystart can be used instead to start at day.Actions from night 0 are not tracked.