### PR TITLE
Fix: round down swallow healing

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -17450,7 +17450,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		},
 		onHit(pokemon) {
 			const healAmount = [0.25, 0.5, 1];
-			const success = !!this.heal(this.modify(pokemon.maxhp, healAmount[(pokemon.volatiles['stockpile'].layers - 1)]));
+			const success = !!this.heal(pokemon.maxhp * healAmount[(pokemon.volatiles['stockpile'].layers - 1)]);
 			if (!success) this.add('-fail', pokemon, 'heal');
 			pokemon.removeVolatile('stockpile');
 			return success || this.NOT_FAIL;

--- a/test/sim/moves/swallow.js
+++ b/test/sim/moves/swallow.js
@@ -1,0 +1,60 @@
+"use strict";
+
+const assert = require("./../../assert");
+const common = require("./../../common");
+
+let battle;
+
+describe("Swallow", function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it("should heal 1/4 health (rounded down) after 1 stockpile", function () {
+		battle = common.createBattle([
+			[
+				{
+					species: "Seviper",
+					ability: "shedskin",
+					moves: ["stockpile", "swallow"],
+				},
+			],
+			[{species: "Zangoose", ability: "immunity", moves: ["sleeptalk", "falseswipe"]}],
+		]);
+
+		battle.makeChoices("move stockpile", "move falseswipe");
+		const hpBeforeHeal = battle.p1.active[0].hp;
+		battle.makeChoices("move swallow", "move sleeptalk");
+
+		assert.equal(battle.p1.active[0].hp, hpBeforeHeal + Math.floor(battle.p1.active[0].maxhp / 4));
+	});
+
+	it("should not heal after 0 stockpiles", function () {
+		battle = common.createBattle([
+			[
+				{
+					// Seviper at lvl 100 has Max HP of 287 (for testing rounding down)
+					species: "Seviper",
+					ability: "shedskin",
+					moves: ["stockpile", "swallow", "sleeptalk"],
+				},
+			],
+			[
+				{
+					species: "Zangoose",
+					ability: "immunity",
+					moves: ["sleeptalk", "falseswipe"],
+				},
+			],
+		]);
+
+		battle.makeChoices("move sleeptalk", "move falseswipe");
+		const hpBeforeHeal = battle.p1.active[0].hp;
+		battle.makeChoices("move swallow", "move sleeptalk");
+
+		assert.equal(
+			battle.p1.active[0].hp,
+			hpBeforeHeal
+		);
+	});
+});


### PR DESCRIPTION
Fixing bug described in #8955. Swallow healing should round down, not up. 

Before, the rounding relied on [battle.modify](https://github.com/smogon/pokemon-showdown/blob/master/sim/battle.ts#L2067), which would sometimes round up. For this reason, I'm don't think it's suited for healing ([here](https://github.com/smogon/pokemon-showdown/blob/master/data/moves.ts#L11553), for example). Otherwise, the method is used for stat changes, like Attack.