### PR TITLE
/learn: Add hidden ability checks

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -2469,8 +2469,9 @@ function runLearn(target: string, cmd: string, canAll: boolean, formatid: string
 				const source = setSources.sources[sourceIndex];
 				if (source.charAt(1) === 'S' && learnset.eventData) {
 					const eventData = learnset.eventData[parseInt(source.substr(2))];
-					const hiddenAbilityProblem = validator.validateEventHiddenAbility(species.name, true, eventData, 
-						` because it has a move only available from an event`);
+					const hiddenAbilityProblem = validator.validateEventHiddenAbility(
+						species.name, true, eventData, ` because it has a move only available from an event`
+					);
 					if (hiddenAbilityProblem) {
 						setSources.sources.splice(sourceIndex, 1);
 						sourceIndex--;

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -8,2635 +8,2634 @@
  * @license MIT
  */
 
- import {ProcessManager, Utils} from '../../lib';
- import {TeamValidator} from '../../sim/team-validator';
- import {Chat} from '../chat';
- 
- interface DexOrGroup {
-	 abilities: {[k: string]: boolean};
-	 tiers: {[k: string]: boolean};
-	 doublesTiers: {[k: string]: boolean};
-	 colors: {[k: string]: boolean};
-	 'egg groups': {[k: string]: boolean};
-	 formes: {[k: string]: boolean};
-	 gens: {[k: string]: boolean};
-	 moves: {[k: string]: boolean};
-	 types: {[k: string]: boolean};
-	 resists: {[k: string]: boolean};
-	 weak: {[k: string]: boolean};
-	 stats: {[k: string]: {[k in Direction]: number}};
-	 skip: boolean;
- }
- 
- interface MoveOrGroup {
-	 types: {[k: string]: boolean};
-	 categories: {[k: string]: boolean};
-	 contestTypes: {[k: string]: boolean};
-	 flags: {[k: string]: boolean};
-	 gens: {[k: string]: boolean};
-	 other: {[k: string]: boolean};
-	 mon: {[k: string]: boolean};
-	 property: {[k: string]: {[k in Direction]: number}};
-	 boost: {[k: string]: boolean};
-	 lower: {[k: string]: boolean};
-	 zboost: {[k: string]: boolean};
-	 status: {[k: string]: boolean};
-	 volatileStatus: {[k: string]: boolean};
-	 targets: {[k: string]: boolean};
-	 skip: boolean;
-	 multihit: boolean;
- }
- 
- type Direction = 'less' | 'greater' | 'equal';
- 
- const MAX_PROCESSES = 1;
- const RESULTS_MAX_LENGTH = 10;
- const MAX_RANDOM_RESULTS = 30;
- const dexesHelp = Object.keys((global.Dex?.dexes || {})).filter(x => x !== 'sourceMaps').join('</code>, <code>');
- 
- function escapeHTML(str?: string) {
-	 if (!str) return '';
-	 return ('' + str)
-		 .replace(/&/g, '&amp;')
-		 .replace(/</g, '&lt;')
-		 .replace(/>/g, '&gt;')
-		 .replace(/"/g, '&quot;')
-		 .replace(/'/g, '&apos;')
-		 .replace(/\//g, '&#x2f;');
- }
- 
- function toListString(arr: string[]) {
-	 if (!arr.length) return '';
-	 if (arr.length === 1) return arr[0];
-	 if (arr.length === 2) return `${arr[0]} and ${arr[1]}`;
-	 return `${arr.slice(0, -1).join(", ")}, and ${arr.slice(-1)[0]}`;
- }
- 
- function checkCanAll(room: Room | null) {
-	 if (!room) return false; // no, no good reason for using `all` in pms
-	 const {isPersonal, isHelp} = room.settings;
-	 // allowed if it's a groupchat
-	 return !room.battle && !!isPersonal && !isHelp;
- }
- 
- export const commands: Chat.ChatCommands = {
-	 ds: 'dexsearch',
-	 ds1: 'dexsearch',
-	 ds2: 'dexsearch',
-	 ds3: 'dexsearch',
-	 ds4: 'dexsearch',
-	 ds5: 'dexsearch',
-	 ds6: 'dexsearch',
-	 ds7: 'dexsearch',
-	 ds8: 'dexsearch',
-	 dsearch: 'dexsearch',
-	 nds: 'dexsearch',
-	 async dexsearch(target, room, user, connection, cmd, message) {
-		 this.checkBroadcast();
-		 if (!target) return this.parse('/help dexsearch');
-		 if (target.length > 300) return this.errorReply('Dexsearch queries may not be longer than 300 characters.');
-		 const targetGen = parseInt(cmd[cmd.length - 1]);
-		 if (targetGen) target += `, mod=gen${targetGen}`;
-		 const split = target.split(',').map(term => term.trim());
-		 const index = split.findIndex(x => /^max\s*gen/i.test(x));
-		 if (index >= 0) {
-			 const genNum = parseInt(/\d*$/.exec(split[index])?.[0] || '');
-			 if (!isNaN(genNum) && !(genNum < 1 || genNum > Dex.gen)) {
-				 split[index] = `mod=gen${genNum}`;
-				 target = split.join(',');
-			 }
-		 }
-		 if (!target.includes('mod=')) {
-			 const dex = this.extractFormat(room?.settings.defaultFormat || room?.battle?.format).dex;
-			 if (dex) target += `, mod=${dex.currentMod}`;
-		 }
-		 if (cmd === 'nds') target += ', natdex';
-		 const response = await runSearch({
-			 target,
-			 cmd: 'dexsearch',
-			 canAll: !this.broadcastMessage || checkCanAll(room),
-			 message: (this.broadcastMessage ? "" : message),
-		 });
-		 if (!response.error && !this.runBroadcast()) return;
-		 if (response.error) {
-			 throw new Chat.ErrorMessage(response.error);
-		 } else if (response.reply) {
-			 this.sendReplyBox(response.reply);
-		 } else if (response.dt) {
-			 (Chat.commands.data as Chat.ChatHandler).call(
-				 this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
-			 );
-		 }
-	 },
-	 dexsearchhelp() {
-		 this.sendReply(
-			 `|html| <details class="readmore"><summary><code>/dexsearch [parameter], [parameter], [parameter], ...</code>: searches for Pok\u00e9mon that fulfill the selected criteria<br/>` +
-			 `Search categories are: type, tier, color, moves, ability, gen, resists, weak, recovery, zrecovery, priority, stat, weight, height, egg group, pivot.<br/>` +
-			 `Valid colors are: green, red, blue, white, brown, yellow, purple, pink, gray and black.<br/>` +
-			 `Valid tiers are: Uber/OU/UUBL/UU/RUBL/RU/NUBL/NU/PUBL/PU/ZU/NFE/LC/CAP/CAP NFE/CAP LC.<br/>` +
-			 `Valid doubles tiers are: DUber/DOU/DBL/DUU/DNU.</summary>` +
-			 `Types can be searched for by either having the type precede <code>type</code> or just using the type itself as a parameter; e.g., both <code>fire type</code> and <code>fire</code> show all Fire types; however, using <code>psychic</code> as a parameter will show all Pok\u00e9mon that learn the move Psychic and not Psychic types.<br/>` +
-			 `<code>resists</code> followed by a type or move will show Pok\u00e9mon that resist that typing or move (e.g. <code>resists normal</code>).<br/>` +
-			 `<code>weak</code> followed by a type or move will show Pok\u00e9mon that are weak to that typing or move (e.g. <code>weak fire</code>).<br/>` +
-			 `<code>asc</code> or <code>desc</code> following a stat will show the Pok\u00e9mon in ascending or descending order of that stat respectively (e.g. <code>speed asc</code>).<br/>` +
-			 `Inequality ranges use the characters <code>>=</code> for <code>≥</code> and <code><=</code> for <code>≤</code>; e.g., <code>hp <= 95</code> searches all Pok\u00e9mon with HP less than or equal to 95.<br/>` +
-			 `Parameters can be excluded through the use of <code>!</code>; e.g., <code>!water type</code> excludes all Water types.<br/>` +
-			 `The parameter <code>mega</code> can be added to search for Mega Evolutions only, the parameter <code>gmax</code> can be added to search for Pokemon capable of Gigantamaxing only, and the parameter <code>Fully Evolved</code> (or <code>FE</code>) can be added to search for fully-evolved Pok\u00e9mon.<br/>` +
-			 `<code>Alola</code>, <code>Galar</code>, <code>Therian</code>, <code>Totem</code>, or <code>Primal</code> can be used as parameters to search for those formes.<br/>` +
-			 `Parameters separated with <code>|</code> will be searched as alternatives for each other; e.g., <code>trick | switcheroo</code> searches for all Pok\u00e9mon that learn either Trick or Switcheroo.<br/>` +
-			 `You can search for info in a specific generation by appending the generation to ds or by using the <code>maxgen</code> keyword; e.g. <code>/ds1 normal</code> or <code>/ds normal, maxgen1</code> searches for all Pok\u00e9mon that were Normal type in Generation I.<br/>` +
-			 `You can search for info in a specific mod by using <code>mod=[mod name]</code>; e.g. <code>/nds mod=ssb, protean</code>. All valid mod names are: <code>${dexesHelp}</code><br />` +
-			 `<code>/dexsearch</code> will search the Galar Pokedex; you can search the National Pokedex by using <code>/nds</code> or by adding <code>natdex</code> as a parameter.<br/>` +
-			 `Searching for a Pok\u00e9mon with both egg group and type parameters can be differentiated by adding the suffix <code>group</code> onto the egg group parameter; e.g., seaching for <code>grass, grass group</code> will show all Grass types in the Grass egg group.<br/>` +
-			 `The parameter <code>monotype</code> will only show Pok\u00e9mon that are single-typed.<br/>` +
-			 `The order of the parameters does not matter.<br/>`
-		 );
-	 },
- 
-	 rollmove: 'randommove',
-	 randmove: 'randommove',
-	 async randommove(target, room, user, connection, cmd, message) {
-		 this.checkBroadcast(true);
-		 target = target.slice(0, 300);
-		 const targets = target.split(",");
-		 const targetsBuffer = [];
-		 let qty;
-		 for (const arg of targets) {
-			 if (!arg) continue;
-			 const num = Number(arg);
-			 if (Number.isInteger(num)) {
-				 if (qty) throw new Chat.ErrorMessage("Only specify the number of Pok\u00e9mon Moves once.");
-				 qty = num;
-				 if (qty < 1 || MAX_RANDOM_RESULTS < qty) {
-					 throw new Chat.ErrorMessage(`Number of random Pok\u00e9mon Moves must be between 1 and ${MAX_RANDOM_RESULTS}.`);
-				 }
-				 targetsBuffer.push(`random${qty}`);
-			 } else {
-				 targetsBuffer.push(arg);
-			 }
-		 }
-		 if (!qty) targetsBuffer.push("random1");
- 
-		 const response = await runSearch({
-			 target: targetsBuffer.join(","),
-			 cmd: 'randmove',
-			 canAll: !this.broadcastMessage || checkCanAll(room),
-			 message: (this.broadcastMessage ? "" : message),
-		 });
-		 if (!response.error && !this.runBroadcast(true)) return;
-		 if (response.error) {
-			 throw new Chat.ErrorMessage(response.error);
-		 } else if (response.reply) {
-			 this.sendReplyBox(response.reply);
-		 } else if (response.dt) {
-			 (Chat.commands.data as Chat.ChatHandler).call(
-				 this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
-			 );
-		 }
-	 },
-	 randommovehelp: [
-		 `/randommove - Generates random Pok\u00e9mon Moves based on given search conditions.`,
-		 `/randommove uses the same parameters as /movesearch (see '/help ms').`,
-		 `Adding a number as a parameter returns that many random Pok\u00e9mon Moves, e.g., '/randmove 6' returns 6 random Pok\u00e9mon Moves.`,
-	 ],
- 
-	 rollpokemon: 'randompokemon',
-	 randpoke: 'randompokemon',
-	 async randompokemon(target, room, user, connection, cmd, message) {
-		 this.checkBroadcast(true);
-		 target = target.slice(0, 300);
-		 const targets = target.split(",");
-		 const targetsBuffer = [];
-		 let qty;
-		 for (const arg of targets) {
-			 if (!arg) continue;
-			 const num = Number(arg);
-			 if (Number.isInteger(num)) {
-				 if (qty) throw new Chat.ErrorMessage("Only specify the number of Pok\u00e9mon once.");
-				 qty = num;
-				 if (qty < 1 || MAX_RANDOM_RESULTS < qty) {
-					 throw new Chat.ErrorMessage(`Number of random Pok\u00e9mon must be between 1 and ${MAX_RANDOM_RESULTS}.`);
-				 }
-				 targetsBuffer.push(`random${qty}`);
-			 } else {
-				 targetsBuffer.push(arg);
-			 }
-		 }
-		 if (!qty) targetsBuffer.push("random1");
- 
-		 const response = await runSearch({
-			 target: targetsBuffer.join(","),
-			 cmd: 'randpoke',
-			 canAll: !this.broadcastMessage || checkCanAll(room),
-			 message: (this.broadcastMessage ? "" : message),
-		 });
-		 if (!response.error && !this.runBroadcast(true)) return;
-		 if (response.error) {
-			 throw new Chat.ErrorMessage(response.error);
-		 } else if (response.reply) {
-			 this.sendReplyBox(response.reply);
-		 } else if (response.dt) {
-			 (Chat.commands.data as Chat.ChatHandler).call(
-				 this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
-			 );
-		 }
-	 },
-	 randompokemonhelp: [
-		 `/randompokemon - Generates random Pok\u00e9mon based on given search conditions.`,
-		 `/randompokemon uses the same parameters as /dexsearch (see '/help ds').`,
-		 `Adding a number as a parameter returns that many random Pok\u00e9mon, e.g., '/randpoke 6' returns 6 random Pok\u00e9mon.`,
-	 ],
- 
-	 ms: 'movesearch',
-	 ms1: 'movesearch',
-	 ms2: 'movesearch',
-	 ms3: 'movesearch',
-	 ms4: 'movesearch',
-	 ms5: 'movesearch',
-	 ms6: 'movesearch',
-	 ms7: 'movesearch',
-	 ms8: 'movesearch',
-	 msearch: 'movesearch',
-	 nms: 'movesearch',
-	 async movesearch(target, room, user, connection, cmd, message) {
-		 this.checkBroadcast();
-		 if (!target) return this.parse('/help movesearch');
-		 target = target.slice(0, 300);
-		 const targetGen = parseInt(cmd[cmd.length - 1]);
-		 if (targetGen) target += `, mod=gen${targetGen}`;
-		 const split = target.split(',').map(term => term.trim());
-		 const index = split.findIndex(x => /^max\s*gen/i.test(x));
-		 if (index >= 0) {
-			 const genNum = parseInt(/\d*$/.exec(split[index])?.[0] || '');
-			 if (!isNaN(genNum) && !(genNum < 1 || genNum > Dex.gen)) {
-				 split[index] = `mod=gen${genNum}`;
-				 target = split.join(',');
-			 }
-		 }
-		 if (!target.includes('mod=')) {
-			 const dex = this.extractFormat(room?.settings.defaultFormat || room?.battle?.format).dex;
-			 if (dex) target += `, mod=${dex.currentMod}`;
-		 }
-		 if (cmd === 'nms') target += ', natdex';
-		 const response = await runSearch({
-			 target,
-			 cmd: 'movesearch',
-			 canAll: !this.broadcastMessage || checkCanAll(room),
-			 message: (this.broadcastMessage ? "" : message),
-		 });
-		 if (!response.error && !this.runBroadcast()) return;
-		 if (response.error) {
-			 throw new Chat.ErrorMessage(response.error);
-		 } else if (response.reply) {
-			 this.sendReplyBox(response.reply);
-		 } else if (response.dt) {
-			 (Chat.commands.data as Chat.ChatHandler).call(
-				 this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
-			 );
-		 }
-	 },
-	 movesearchhelp() {
-		 this.sendReply(
-			 `|html| <details class="readmore"><summary><code>/movesearch [parameter], [parameter], [parameter], ...</code>: searches for moves that fulfill the selected criteria.<br/>` +
-			 `Search categories are: type, category, gen, contest condition, flag, status inflicted, type boosted, Pok\u00e9mon targeted, and numeric range for base power, pp, priority, and accuracy.<br/>` +
-			 `Types can be followed by <code> type</code> for clarity; e.g., <code>dragon type</code>.<br/>` +
-			 `Stat boosts must be preceded with <code>boosts </code>, and stat-lowering moves with <code>lowers </code>; e.g., <code>boosts attack</code> searches for moves that boost the Attack stat of either Pok\u00e9mon.<br/>` +
-			 `Z-stat boosts must be preceded with <code>zboosts </code>; e.g., <code>zboosts accuracy</code> searches for all Status moves with Z-Effects that boost the user's accuracy.</summary>` +
-			 `Moves that have a Z-Effect of fully restoring the user's health can be searched for with <code>zrecovery</code>.<br/>` +
-			 `Move targets must be preceded with <code>targets </code>; e.g., <code>targets user</code> searches for moves that target the user.<br/>` +
-			 `Valid move targets are: one ally, user or ally, one adjacent opponent, all Pokemon, all adjacent Pokemon, all adjacent opponents, user and allies, user's side, user's team, any Pokemon, opponent's side, one adjacent Pokemon, random adjacent Pokemon, scripted, and user.<br/>` +
-			 `Inequality ranges use the characters <code>></code> and <code><</code>.<br/>` +
-			 `Parameters can be excluded through the use of <code>!</code>; e.g., <code>!water type</code> excludes all Water-type moves.<br/>` +
-			 `<code>asc</code> or <code>desc</code> following a move property will arrange the names in ascending or descending order of that property, respectively; e.g., <code>basepower asc</code> will arrange moves in ascending order of their base powers.<br/>` +
-			 `Valid flags are: bypasssub (bypasses substitute), bite, bullet, charge, contact, dance, defrost, gravity, mirror (reflected by mirror move), ohko, powder, priority, protect, pulse, punch, recharge, recovery, reflectable, secondary, snatch, sound, zmove, pivot, and multi-hit.<br/>` +
-			 `A search that includes <code>!protect</code> will show all moves that bypass protection.<br/>` +
-			 `<code>protection</code> as a parameter will search protection moves like Protect, Detect, etc.<br/>` +
-			 `<code>max</code> or <code>gmax</code> as parameters will search for Max Moves and G-Max moves respectively.<br/>` +
-			 `Parameters separated with <code>|</code> will be searched as alternatives for each other; e.g., <code>fire | water</code> searches for all moves that are either Fire type or Water type.<br/>` +
-			 `If a Pok\u00e9mon is included as a parameter, only moves from its movepool will be included in the search.<br/>` +
-			 `You can search for info in a specific generation by appending the generation to ms; e.g. <code>/ms1 normal</code> searches for all moves that were Normal type in Generation I.<br/>` +
-			 `You can search for info in a specific mod by using <code>mod=[mod name]</code>; e.g. <code>/nms mod=ssb, dark, bp=100</code>. All valid mod names are: <code>${dexesHelp}</code><br />` +
-			 `<code>/ms</code> will search the Galar Moves; you can search the National Moves by using <code>/nms</code> or by adding <code>natdex</code> as a parameter.<br/>` +
-			 `The order of the parameters does not matter.`
-		 );
-	 },
- 
-	 isearch: 'itemsearch',
-	 is: 'itemsearch',
-	 is2: 'itemsearch',
-	 is3: 'itemsearch',
-	 is4: 'itemsearch',
-	 is5: 'itemsearch',
-	 is6: 'itemsearch',
-	 is7: 'itemsearch',
-	 is8: 'itemsearch',
-	 async itemsearch(target, room, user, connection, cmd, message) {
-		 this.checkBroadcast();
-		 if (!target) return this.parse('/help itemsearch');
-		 target = target.slice(0, 300);
-		 const targetGen = parseInt(cmd[cmd.length - 1]);
-		 if (targetGen) target += ` maxgen${targetGen}`;
- 
-		 const response = await runSearch({
-			 target,
-			 cmd: 'itemsearch',
-			 canAll: !this.broadcastMessage || checkCanAll(room),
-			 message: (this.broadcastMessage ? "" : message),
-		 });
-		 if (!response.error && !this.runBroadcast()) return;
-		 if (response.error) {
-			 throw new Chat.ErrorMessage(response.error);
-		 } else if (response.reply) {
-			 this.sendReplyBox(response.reply);
-		 } else if (response.dt) {
-			 (Chat.commands.data as Chat.ChatHandler).call(
-				 this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
-			 );
-		 }
-	 },
-	 itemsearchhelp() {
-		 this.sendReplyBox(
-			 `<code>/itemsearch [item description]</code>: finds items that match the given keywords.<br/>` +
-			 `This command accepts natural language. (tip: fewer words tend to work better)<br/>` +
-			 `The <code>gen</code> keyword can be used to search for items introduced in a given generation; e.g., <code>/is gen4</code> searches for items introduced in Generation 4.<br/>` +
-			 `To search for items within a generation, append the generation to <code>/is</code> or use the <code>maxgen</code> keyword; e.g., <code>/is4 Water-type</code> or <code>/is maxgen4 Water-type</code> searches for items whose Generation 4 description includes "Water-type".<br/>` +
-			 `Searches with <code>fling</code> in them will find items with the specified Fling behavior.<br/>` +
-			 `Searches with <code>natural gift</code> in them will find items with the specified Natural Gift behavior.`
-		 );
-	 },
- 
-	 asearch: 'abilitysearch',
-	 as: 'abilitysearch',
-	 as3: 'abilitysearch',
-	 as4: 'abilitysearch',
-	 as5: 'abilitysearch',
-	 as6: 'abilitysearch',
-	 as7: 'abilitysearch',
-	 as8: 'abilitysearch',
-	 async abilitysearch(target, room, user, connection, cmd, message) {
-		 this.checkBroadcast();
-		 if (!target) return this.parse('/help abilitysearch');
-		 target = target.slice(0, 300);
-		 const targetGen = parseInt(cmd[cmd.length - 1]);
-		 if (targetGen) target += ` maxgen${targetGen}`;
- 
-		 const response = await runSearch({
-			 target,
-			 cmd: 'abilitysearch',
-			 canAll: !this.broadcastMessage || checkCanAll(room),
-			 message: (this.broadcastMessage ? "" : message),
-		 });
-		 if (!response.error && !this.runBroadcast()) return;
-		 if (response.error) {
-			 throw new Chat.ErrorMessage(response.error);
-		 } else if (response.reply) {
-			 this.sendReplyBox(response.reply);
-		 } else if (response.dt) {
-			 (Chat.commands.data as Chat.ChatHandler).call(
-				 this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
-			 );
-		 }
-	 },
-	 abilitysearchhelp() {
-		 this.sendReplyBox(
-			 `<code>/abilitysearch [ability description]</code>: finds abilities that match the given keywords.<br/>` +
-			 `This command accepts natural language. (tip: fewer words tend to work better)<br/>` +
-			 `The <code>gen</code> keyword can be used to search for abilities introduced in a given generation; e.g., <code>/as gen4</code> searches for abilities introduced in Generation 4.<br/>` +
-			 `To search for abilities within a generation, append the generation to <code>/as</code> or use the <code>maxgen</code> keyword; e.g., <code>/as4 Water-type</code> or <code>/as maxgen4 Water-type</code> searches for abilities whose Generation 4 description includes "Water-type".`
-		 );
-	 },
- 
-	 learnset: 'learn',
-	 learnall: 'learn',
-	 learn5: 'learn',
-	 rbylearn: 'learn',
-	 gsclearn: 'learn',
-	 advlearn: 'learn',
-	 dpplearn: 'learn',
-	 bw2learn: 'learn',
-	 oraslearn: 'learn',
-	 usumlearn: 'learn',
-	 async learn(target, room, user, connection, cmd, message) {
-		 if (!target) return this.parse('/help learn');
-		 if (target.length > 300) throw new Chat.ErrorMessage(`Query too long.`);
- 
-		 const GENS: {[k: string]: number} = {rby: 1, gsc: 2, adv: 3, dpp: 4, bw2: 5, oras: 6, usum: 7};
-		 const cmdGen = GENS[cmd.slice(0, -5)];
-		 if (cmdGen) target = `gen${cmdGen}, ${target}`;
- 
-		 this.checkBroadcast();
-		 const {format, dex, targets} = this.splitFormat(target);
- 
-		 const formatid = format ? format.id : dex.currentMod;
-		 if (cmd === 'learn5') targets.unshift('level5');
- 
-		 const response = await runSearch({
-			 target: targets.join(','),
-			 cmd: 'learn',
-			 canAll: !this.broadcastMessage || checkCanAll(room),
-			 message: formatid,
-		 });
-		 if (!response.error && !this.runBroadcast()) return;
-		 if (response.error) {
-			 throw new Chat.ErrorMessage(response.error);
-		 } else if (response.reply) {
-			 this.sendReplyBox(response.reply);
-		 }
-	 },
-	 learnhelp: [
-		 `/learn [ruleset], [pokemon], [move, move, ...] - Displays how the Pok\u00e9mon can learn the given moves, if it can at all.`,
-		 `!learn [ruleset], [pokemon], [move, move, ...] - Show everyone that information. Requires: + % @ # &`,
-		 `Specifying a ruleset is entirely optional. The ruleset can be a format, a generation (e.g.: gen3) or "min source gen [number]".`,
-		 `A value of 'min source gen [number]' indicates that trading (or Pokémon Bank) from generations before [number] is not allowed.`,
-		 `/learn5 displays how the Pok\u00e9mon can learn the given moves at level 5, if it can at all.`,
-		 `/learnall displays all of the possible fathers for egg moves.`,
-		 `/learn can also be prefixed by a generation acronym (e.g.: /dpplearn) to indicate which generation is used. Valid options are: rby gsc adv dpp bw2 oras usum`,
-	 ],
- };
- 
- function getMod(target: string) {
-	 const arr = target.split(',').map(x => x.trim());
-	 const modTerm = arr.find(x => {
-		 const sanitizedStr = x.toLowerCase().replace(/[^a-z0-9=]+/g, '');
-		 return sanitizedStr.startsWith('mod=') && Dex.dexes[toID(sanitizedStr.split('=')[1])];
-	 });
-	 const count = arr.filter(x => {
-		 const sanitizedStr = x.toLowerCase().replace(/[^a-z0-9=]+/g, '');
-		 return sanitizedStr.startsWith('mod=');
-	 }).length;
-	 if (modTerm) arr.splice(arr.indexOf(modTerm), 1);
-	 return {splitTarget: arr, usedMod: modTerm ? toID(modTerm.split(/ ?= ?/)[1]) : undefined, count};
- }
- 
- function runDexsearch(target: string, cmd: string, canAll: boolean, message: string, isTest: boolean) {
-	 const searches: DexOrGroup[] = [];
-	 const {splitTarget, usedMod, count: c} = getMod(target);
-	 if (c > 1) {
-		 return {error: `You can't run searches for multiple mods.`};
-	 }
- 
-	 const mod = Dex.mod(usedMod || 'base');
-	 const allTiers: {[k: string]: TierTypes.Singles | TierTypes.Other} = Object.assign(Object.create(null), {
-		 anythinggoes: 'AG', ag: 'AG',
-		 uber: 'Uber', ubers: 'Uber', ou: 'OU',
-		 uubl: 'UUBL', uu: 'UU',
-		 rubl: 'RUBL', ru: 'RU',
-		 nubl: 'NUBL', nu: 'NU',
-		 publ: 'PUBL', pu: 'PU', zu: '(PU)',
-		 nfe: 'NFE',
-		 lc: 'LC',
-		 cap: 'CAP', caplc: 'CAP LC', capnfe: 'CAP NFE',
-	 });
-	 const allDoublesTiers: {[k: string]: TierTypes.Singles | TierTypes.Other} = Object.assign(Object.create(null), {
-		 doublesubers: 'DUber', doublesuber: 'DUber', duber: 'DUber', dubers: 'DUber',
-		 doublesou: 'DOU', dou: 'DOU',
-		 doublesbl: 'DBL', dbl: 'DBL',
-		 doublesuu: 'DUU', duu: 'DUU',
-		 doublesnu: '(DUU)', dnu: '(DUU)',
-	 });
-	 const allTypes = Object.create(null);
-	 for (const type of mod.types.all()) {
-		 allTypes[type.id] = type.name;
-	 }
-	 const allColors = ['green', 'red', 'blue', 'white', 'brown', 'yellow', 'purple', 'pink', 'gray', 'black'];
-	 const allEggGroups: {[k: string]: string} = Object.assign(Object.create(null), {
-		 amorphous: 'Amorphous',
-		 bug: 'Bug',
-		 ditto: 'Ditto',
-		 dragon: 'Dragon',
-		 fairy: 'Fairy',
-		 field: 'Field',
-		 flying: 'Flying',
-		 grass: 'Grass',
-		 humanlike: 'Human-Like',
-		 mineral: 'Mineral',
-		 monster: 'Monster',
-		 undiscovered: 'Undiscovered',
-		 water1: 'Water 1',
-		 water2: 'Water 2',
-		 water3: 'Water 3',
-	 });
-	 const allFormes = ['alola', 'galar', 'primal', 'therian', 'totem'];
-	 const allStats = ['hp', 'atk', 'def', 'spa', 'spd', 'spe', 'bst', 'weight', 'height', 'gen'];
-	 const allStatAliases: {[k: string]: string} = {
-		 attack: 'atk', defense: 'def', specialattack: 'spa', spc: 'spa', special: 'spa', spatk: 'spa',
-		 specialdefense: 'spd', spdef: 'spd', speed: 'spe', wt: 'weight', ht: 'height', generation: 'gen',
-	 };
-	 let showAll = false;
-	 let sort = null;
-	 let megaSearch = null;
-	 let gmaxSearch = null;
-	 let tierSearch = null;
-	 let capSearch: boolean | null = null;
-	 let nationalSearch = null;
-	 let fullyEvolvedSearch = null;
-	 let singleTypeSearch = null;
-	 let randomOutput = 0;
-	 const validParameter = (cat: string, param: string, isNotSearch: boolean, input: string) => {
-		 const uniqueTraits = ['colors', 'gens'];
-		 for (const group of searches) {
-			 const g = group[cat as keyof DexOrGroup];
-			 if (g === undefined) continue;
-			 if (typeof g !== 'boolean' && g[param] === undefined) {
-				 if (uniqueTraits.includes(cat)) {
-					 for (const currentParam in g) {
-						 if (g[currentParam] !== isNotSearch && !isNotSearch) return `A Pok&eacute;mon cannot have multiple ${cat}.`;
-					 }
-				 }
-				 continue;
-			 }
-			 if (typeof g !== 'boolean' && g[param] === isNotSearch) {
-				 return `A search cannot both include and exclude '${input}'.`;
-			 } else {
-				 return `The search included '${(isNotSearch ? "!" : "") + input}' more than once.`;
-			 }
-		 }
-		 return false;
-	 };
- 
-	 for (const andGroup of splitTarget) {
-		 const orGroup: DexOrGroup = {
-			 abilities: {}, tiers: {}, doublesTiers: {}, colors: {}, 'egg groups': {}, formes: {},
-			 gens: {}, moves: {}, types: {}, resists: {}, weak: {}, stats: {}, skip: false,
-		 };
-		 const parameters = andGroup.split("|");
-		 if (parameters.length > 3) return {error: "No more than 3 alternatives for each parameter may be used."};
-		 for (const parameter of parameters) {
-			 let isNotSearch = false;
-			 target = parameter.trim().toLowerCase();
-			 if (target.startsWith('!')) {
-				 isNotSearch = true;
-				 target = target.substr(1);
-			 }
- 
-			 const targetAbility = mod.abilities.get(target);
-			 if (targetAbility.exists) {
-				 const invalid = validParameter("abilities", targetAbility.id, isNotSearch, targetAbility.name);
-				 if (invalid) return {error: invalid};
-				 orGroup.abilities[targetAbility.name] = !isNotSearch;
-				 continue;
-			 }
- 
-			 if (toID(target) in allTiers) {
-				 target = allTiers[toID(target)];
-				 if (target.startsWith("CAP")) {
-					 if (capSearch === isNotSearch) return {error: "A search cannot both include and exclude CAP tiers."};
-					 capSearch = !isNotSearch;
-				 }
-				 const invalid = validParameter("tiers", target, isNotSearch, target);
-				 if (invalid) return {error: invalid};
-				 tierSearch = tierSearch || !isNotSearch;
-				 orGroup.tiers[target] = !isNotSearch;
-				 continue;
-			 }
- 
-			 if (toID(target) in allDoublesTiers) {
-				 target = allDoublesTiers[toID(target)];
-				 const invalid = validParameter("doubles tiers", target, isNotSearch, target);
-				 if (invalid) return {error: invalid};
-				 tierSearch = tierSearch || !isNotSearch;
-				 orGroup.doublesTiers[target] = !isNotSearch;
-				 continue;
-			 }
- 
-			 if (allColors.includes(target)) {
-				 target = target.charAt(0).toUpperCase() + target.slice(1);
-				 const invalid = validParameter("colors", target, isNotSearch, target);
-				 if (invalid) return {error: invalid};
-				 orGroup.colors[target] = !isNotSearch;
-				 continue;
-			 }
- 
-			 const targetMove = mod.moves.get(target);
-			 if (targetMove.exists) {
-				 const invalid = validParameter("moves", targetMove.id, isNotSearch, target);
-				 if (invalid) return {error: invalid};
-				 orGroup.moves[targetMove.id] = !isNotSearch;
-				 continue;
-			 }
- 
-			 let targetType;
-			 if (target.endsWith('type')) {
-				 targetType = toID(target.substring(0, target.indexOf('type')));
-			 } else {
-				 targetType = toID(target);
-			 }
-			 if (targetType in allTypes) {
-				 target = allTypes[targetType];
-				 const invalid = validParameter("types", target, isNotSearch, target);
-				 if (invalid) return {error: invalid};
-				 if ((orGroup.types[target] && isNotSearch) || (orGroup.types[target] === false && !isNotSearch)) {
-					 return {error: 'A search cannot both exclude and include a type.'};
-				 }
-				 orGroup.types[target] = !isNotSearch;
-				 continue;
-			 }
- 
-			 if (['mono', 'monotype'].includes(toID(target))) {
-				 if (singleTypeSearch === isNotSearch) return {error: "A search cannot include and exclude 'monotype'."};
-				 if (parameters.length > 1) return {error: "The parameter 'monotype' cannot have alternative parameters."};
-				 singleTypeSearch = !isNotSearch;
-				 orGroup.skip = true;
-				 continue;
-			 }
- 
-			 if (target === 'natdex') {
-				 if (parameters.length > 1) return {error: "The parameter 'natdex' cannot have alternative parameters."};
-				 nationalSearch = true;
-				 orGroup.skip = true;
-				 continue;
-			 }
- 
-			 let groupIndex = target.indexOf('group');
-			 if (groupIndex === -1) groupIndex = target.length;
-			 if (groupIndex !== target.length || toID(target) in allEggGroups) {
-				 target = toID(target.substring(0, groupIndex));
-				 if (target in allEggGroups) {
-					 target = allEggGroups[toID(target)];
-					 const invalid = validParameter("egg groups", target, isNotSearch, target);
-					 if (invalid) return {error: invalid};
-					 orGroup['egg groups'][target] = !isNotSearch;
-					 continue;
-				 } else {
-					 return {error: `'${target}' is not a recognized egg group.`};
-				 }
-			 }
-			 if (toID(target) in allEggGroups) {
-				 target = allEggGroups[toID(target)];
-				 const invalid = validParameter("egg groups", target, isNotSearch, target);
-				 if (invalid) return {error: invalid};
-				 orGroup['egg groups'][target] = !isNotSearch;
-				 continue;
-			 }
- 
-			 let targetInt = 0;
-			 if (target.substr(0, 1) === 'g' && Number.isInteger(parseFloat(target.substr(1)))) {
-				 targetInt = parseInt(target.substr(1).trim());
-			 } else if (target.substr(0, 3) === 'gen' && Number.isInteger(parseFloat(target.substr(3)))) {
-				 targetInt = parseInt(target.substr(3).trim());
-			 }
-			 if (0 < targetInt && targetInt < 9) {
-				 const invalid = validParameter("gens", String(targetInt), isNotSearch, target);
-				 if (invalid) return {error: invalid};
-				 orGroup.gens[targetInt] = !isNotSearch;
-				 continue;
-			 }
- 
-			 if (target.endsWith(' asc') || target.endsWith(' desc')) {
-				 if (parameters.length > 1) {
-					 return {error: `The parameter '${target.split(' ')[1]}' cannot have alternative parameters.`};
-				 }
-				 const stat = allStatAliases[toID(target.split(' ')[0])] || toID(target.split(' ')[0]);
-				 if (!allStats.includes(stat)) return {error: `'${escapeHTML(target)}' did not contain a valid stat.`};
-				 sort = `${stat}${target.endsWith(' asc') ? '+' : '-'}`;
-				 orGroup.skip = true;
-				 break;
-			 }
- 
-			 if (target === 'all') {
-				 if (!canAll) return {error: "A search with the parameter 'all' cannot be broadcast."};
-				 if (parameters.length > 1) return {error: "The parameter 'all' cannot have alternative parameters."};
-				 showAll = true;
-				 orGroup.skip = true;
-				 break;
-			 }
- 
-			 if (target.substr(0, 6) === 'random' && cmd === 'randpoke') {
-				 // Validation for this is in the /randpoke command
-				 randomOutput = parseInt(target.substr(6));
-				 orGroup.skip = true;
-				 continue;
-			 }
- 
-			 if (allFormes.includes(toID(target))) {
-				 target = toID(target);
-				 orGroup.formes[target] = !isNotSearch;
-				 continue;
-			 }
- 
-			 if (target === 'megas' || target === 'mega') {
-				 if (megaSearch === isNotSearch) return {error: "A search cannot include and exclude 'mega'."};
-				 if (parameters.length > 1) return {error: "The parameter 'mega' cannot have alternative parameters."};
-				 megaSearch = !isNotSearch;
-				 orGroup.skip = true;
-				 break;
-			 }
- 
-			 if (target === 'gmax' || target === 'gigantamax') {
-				 if (gmaxSearch === isNotSearch) return {error: "A search cannot include and exclude 'gigantamax'."};
-				 if (parameters.length > 1) return {error: "The parameter 'gigantamax' cannot have alternative parameters."};
-				 gmaxSearch = !isNotSearch;
-				 orGroup.skip = true;
-				 break;
-			 }
- 
-			 if (['fully evolved', 'fullyevolved', 'fe'].includes(target)) {
-				 if (fullyEvolvedSearch === isNotSearch) return {error: "A search cannot include and exclude 'fully evolved'."};
-				 if (parameters.length > 1) return {error: "The parameter 'fully evolved' cannot have alternative parameters."};
-				 fullyEvolvedSearch = !isNotSearch;
-				 orGroup.skip = true;
-				 break;
-			 }
- 
-			 if (target === 'recovery') {
-				 const recoveryMoves = [
-					 "healorder", "junglehealing", "lifedew", "milkdrink", "moonlight", "morningsun", "recover",
-					 "roost", "shoreup", "slackoff", "softboiled", "strengthsap", "synthesis", "wish",
-				 ];
-				 for (const move of recoveryMoves) {
-					 const invalid = validParameter("moves", move, isNotSearch, target);
-					 if (invalid) return {error: invalid};
-					 if (isNotSearch) {
-						 orGroup.skip = true;
-						 const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
-						 bufferObj.moves[move] = false;
-						 searches.push(bufferObj as DexOrGroup);
-					 } else {
-						 orGroup.moves[move] = true;
-					 }
-				 }
-				 continue;
-			 }
- 
-			 if (target === 'zrecovery') {
-				 const recoveryMoves = [
-					 "aromatherapy", "bellydrum", "conversion2", "haze", "healbell", "mist",
-					 "psychup", "refresh", "spite", "stockpile", "teleport", "transform",
-				 ];
-				 for (const moveid of recoveryMoves) {
-					 const invalid = validParameter("moves", moveid, isNotSearch, target);
-					 if (invalid) return {error: invalid};
-					 if (isNotSearch) {
-						 orGroup.skip = true;
-						 const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
-						 bufferObj.moves[moveid] = false;
-						 searches.push(bufferObj as DexOrGroup);
-					 } else {
-						 orGroup.moves[moveid] = true;
-					 }
-				 }
-				 continue;
-			 }
- 
-			 if (target === 'priority') {
-				 for (const moveid in mod.data.Moves) {
-					 const move = mod.moves.get(moveid);
-					 if (move.category === "Status" || move.id === "bide") continue;
-					 if (move.priority > 0) {
-						 const invalid = validParameter("moves", moveid, isNotSearch, target);
-						 if (invalid) return {error: invalid};
-						 if (isNotSearch) {
-							 orGroup.skip = true;
-							 const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
-							 bufferObj.moves[moveid] = false;
-							 searches.push(bufferObj as DexOrGroup);
-						 } else {
-							 orGroup.moves[moveid] = true;
-						 }
-					 }
-				 }
-				 continue;
-			 }
- 
-			 if (target.substr(0, 8) === 'resists ') {
-				 const targetResist = target.substr(8, 1).toUpperCase() + target.substr(9);
-				 if (mod.types.isName(targetResist)) {
-					 const invalid = validParameter("resists", targetResist, isNotSearch, target);
-					 if (invalid) return {error: invalid};
-					 orGroup.resists[targetResist] = !isNotSearch;
-					 continue;
-				 } else {
-					 if (toID(targetResist) in mod.data.Moves) {
-						 const move = mod.moves.get(targetResist);
-						 if (move.category === 'Status') {
-							 return {error: `'${targetResist}' is a status move and can't be used with 'resists'.`};
-						 } else {
-							 const invalid = validParameter("resists", targetResist, isNotSearch, target);
-							 if (invalid) return {error: invalid};
-							 orGroup.resists[targetResist] = !isNotSearch;
-							 continue;
-						 }
-					 } else {
-						 return {error: `'${targetResist}' is not a recognized type or move.`};
-					 }
-				 }
-			 }
- 
-			 if (target.substr(0, 5) === 'weak ') {
-				 const targetWeak = target.substr(5, 1).toUpperCase() + target.substr(6);
-				 if (mod.types.isName(targetWeak)) {
-					 const invalid = validParameter("weak", targetWeak, isNotSearch, target);
-					 if (invalid) return {error: invalid};
-					 orGroup.weak[targetWeak] = !isNotSearch;
-					 continue;
-				 } else {
-					 if (toID(targetWeak) in mod.data.Moves) {
-						 const move = mod.moves.get(targetWeak);
-						 if (move.category === 'Status') {
-							 return {error: `'${targetWeak}' is a status move and can't be used with 'weak'.`};
-						 } else {
-							 const invalid = validParameter("weak", targetWeak, isNotSearch, target);
-							 if (invalid) return {error: invalid};
-							 orGroup.weak[targetWeak] = !isNotSearch;
-							 continue;
-						 }
-					 } else {
-						 return {error: `'${targetWeak}' is not a recognized type or move.`};
-					 }
-				 }
-			 }
- 
-			 if (target === 'pivot') {
-				 for (const move in mod.data.Moves) {
-					 const moveData = mod.moves.get(move);
-					 if (moveData.selfSwitch && moveData.id !== 'batonpass') {
-						 const invalid = validParameter("moves", move, isNotSearch, target);
-						 if (invalid) return {error: invalid};
-						 if (isNotSearch) {
-							 orGroup.skip = true;
-							 const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
-							 bufferObj.moves[move] = false;
-							 searches.push(bufferObj as DexOrGroup);
-						 } else {
-							 orGroup.moves[move] = true;
-						 }
-					 }
-				 }
-				 continue;
-			 }
- 
-			 const inequality = target.search(/>|<|=/);
-			 let inequalityString;
-			 if (inequality >= 0) {
-				 if (isNotSearch) return {error: "You cannot use the negation symbol '!' in stat ranges."};
-				 if (target.charAt(inequality + 1) === '=') {
-					 inequalityString = target.substr(inequality, 2);
-				 } else {
-					 inequalityString = target.charAt(inequality);
-				 }
-				 const targetParts = target.replace(/\s/g, '').split(inequalityString);
-				 let num;
-				 let stat;
-				 const directions: Direction[] = [];
-				 if (!isNaN(parseFloat(targetParts[0]))) {
-					 // e.g. 100 < spe
-					 num = parseFloat(targetParts[0]);
-					 stat = targetParts[1];
-					 if (inequalityString.startsWith('>')) directions.push('less');
-					 if (inequalityString.startsWith('<')) directions.push('greater');
-				 } else if (!isNaN(parseFloat(targetParts[1]))) {
-					 // e.g. spe > 100
-					 num = parseFloat(targetParts[1]);
-					 stat = targetParts[0];
-					 if (inequalityString.startsWith('<')) directions.push('less');
-					 if (inequalityString.startsWith('>')) directions.push('greater');
-				 } else {
-					 return {error: `No value given to compare with '${escapeHTML(target)}'.`};
-				 }
-				 if (inequalityString.endsWith('=')) directions.push('equal');
-				 if (stat in allStatAliases) stat = allStatAliases[stat];
-				 if (!allStats.includes(stat)) return {error: `'${escapeHTML(target)}' did not contain a valid stat.`};
-				 if (!orGroup.stats[stat]) orGroup.stats[stat] = Object.create(null);
-				 for (const direction of directions) {
-					 if (orGroup.stats[stat][direction]) return {error: `Invalid stat range for ${stat}.`};
-					 orGroup.stats[stat][direction] = num;
-				 }
-				 continue;
-			 }
-			 return {error: `'${escapeHTML(target)}' could not be found in any of the search categories.`};
-		 }
-		 if (!orGroup.skip) {
-			 searches.push(orGroup);
-		 }
-	 }
-	 if (
-		 showAll && searches.length === 0 && singleTypeSearch === null &&
-		 megaSearch === null && gmaxSearch === null && fullyEvolvedSearch === null && sort === null
-	 ) {
-		 return {
-			 error: "No search parameters other than 'all' were found. Try '/help dexsearch' for more information on this command.",
-		 };
-	 }
- 
-	 const dex: {[k: string]: Species} = {};
-	 for (const species of mod.species.all()) {
-		 const megaSearchResult = megaSearch === null || megaSearch === !!species.isMega;
-		 const gmaxSearchResult = gmaxSearch === null || gmaxSearch === species.name.endsWith('-Gmax');
-		 const fullyEvolvedSearchResult = fullyEvolvedSearch === null || fullyEvolvedSearch !== species.nfe;
-		 if (
-			 species.gen <= mod.gen &&
-			 (
-				 (
-					 nationalSearch &&
-					 species.isNonstandard &&
-					 !["Custom", "Glitch", "Pokestar", "Future"].includes(species.isNonstandard)
-				 ) ||
-				 (species.tier !== 'Unreleased' && species.tier !== 'Illegal')
-			 ) &&
-			 (!species.tier.startsWith("CAP") || capSearch) &&
-			 megaSearchResult &&
-			 gmaxSearchResult &&
-			 fullyEvolvedSearchResult
-		 ) {
-			 dex[species.id] = species;
-		 }
-	 }
- 
-	 // Prioritize searches with the least alternatives.
-	 const accumulateKeyCount = (count: number, searchData: AnyObject) =>
-		 count + (typeof searchData === 'object' ? Object.keys(searchData).length : 0);
-	 Utils.sortBy(searches, search => (
-		 Object.values(search).reduce(accumulateKeyCount, 0)
-	 ));
- 
-	 for (const alts of searches) {
-		 if (alts.skip) continue;
-		 for (const mon in dex) {
-			 let matched = false;
-			 if (alts.gens && Object.keys(alts.gens).length) {
-				 if (alts.gens[dex[mon].gen]) continue;
-				 if (Object.values(alts.gens).includes(false) && alts.gens[dex[mon].gen] !== false) continue;
-			 }
- 
-			 if (alts.colors && Object.keys(alts.colors).length) {
-				 if (alts.colors[dex[mon].color]) continue;
-				 if (Object.values(alts.colors).includes(false) && alts.colors[dex[mon].color] !== false) continue;
-			 }
- 
-			 for (const eggGroup in alts['egg groups']) {
-				 if (dex[mon].eggGroups.includes(eggGroup) === alts['egg groups'][eggGroup]) {
-					 matched = true;
-					 break;
-				 }
-			 }
- 
-			 if (alts.tiers && Object.keys(alts.tiers).length) {
-				 let tier = dex[mon].tier;
-				 if (nationalSearch) tier = dex[mon].natDexTier;
-				 if (tier.startsWith('(') && tier !== '(PU)') tier = tier.slice(1, -1) as TierTypes.Singles;
-				 // if (tier === 'New') tier = 'OU';
-				 if (alts.tiers[tier]) continue;
-				 if (Object.values(alts.tiers).includes(false) && alts.tiers[tier] !== false) continue;
-				 // LC handling, checks for LC Pokemon in higher tiers that need to be handled separately,
-				 // as well as event-only Pokemon that are not eligible for LC despite being the first stage
-				 let format = Dex.formats.get('gen' + mod.gen + 'lc');
-				 if (!format.exists) format = Dex.formats.get('gen8lc');
-				 if (
-					 alts.tiers.LC &&
-					 !dex[mon].prevo &&
-					 dex[mon].nfe &&
-					 !Dex.formats.getRuleTable(format).isBannedSpecies(dex[mon])
-				 ) {
-					 const lsetData = mod.species.getLearnsetData(dex[mon].id);
-					 if (lsetData.exists && lsetData.eventData && lsetData.eventOnly) {
-						 let validEvents = 0;
-						 for (const event of lsetData.eventData) {
-							 if (event.level && event.level <= 5) validEvents++;
-						 }
-						 if (validEvents > 0) continue;
-					 } else {
-						 continue;
-					 }
-				 }
-			 }
- 
-			 if (alts.doublesTiers && Object.keys(alts.doublesTiers).length) {
-				 let tier = dex[mon].doublesTier;
-				 if (tier && tier.startsWith('(') && tier !== '(DUU)') tier = tier.slice(1, -1) as TierTypes.Doubles;
-				 if (alts.doublesTiers[tier]) continue;
-				 if (Object.values(alts.doublesTiers).includes(false) && alts.doublesTiers[tier] !== false) continue;
-			 }
- 
-			 for (const type in alts.types) {
-				 if (dex[mon].types.includes(type) === alts.types[type]) {
-					 matched = true;
-					 break;
-				 }
-			 }
-			 if (matched) continue;
- 
-			 for (const targetResist in alts.resists) {
-				 let effectiveness = 0;
-				 const move = mod.moves.get(targetResist);
-				 const attackingType = move.type || targetResist;
-				 const notImmune = (move.id === 'thousandarrows' || mod.getImmunity(attackingType, dex[mon])) &&
-					 !(move.id === 'sheercold' && mod.gen >= 7 && dex[mon].types.includes('Ice'));
-				 if (notImmune && !move.ohko && move.damage === undefined) {
-					 for (const defenderType of dex[mon].types) {
-						 const baseMod = mod.getEffectiveness(attackingType, defenderType);
-						 const moveMod = move.onEffectiveness?.call(
-							 {dex: mod} as Battle, baseMod, null, defenderType, move as ActiveMove,
-						 );
-						 effectiveness += typeof moveMod === 'number' ? moveMod : baseMod;
-					 }
-				 }
-				 if (!alts.resists[targetResist]) {
-					 if (notImmune && effectiveness >= 0) matched = true;
-				 } else {
-					 if (!notImmune || effectiveness < 0) matched = true;
-				 }
-			 }
-			 if (matched) continue;
- 
-			 for (const targetWeak in alts.weak) {
-				 let effectiveness = 0;
-				 const move = mod.moves.get(targetWeak);
-				 const attackingType = move.type || targetWeak;
-				 const notImmune = (move.id === 'thousandarrows' || mod.getImmunity(attackingType, dex[mon])) &&
-					 !(move.id === 'sheercold' && mod.gen >= 7 && dex[mon].types.includes('Ice'));
-				 if (notImmune && !move.ohko && move.damage === undefined) {
-					 for (const defenderType of dex[mon].types) {
-						 const baseMod = mod.getEffectiveness(attackingType, defenderType);
-						 const moveMod = move.onEffectiveness?.call(
-							 {dex: mod} as Battle, baseMod, null, defenderType, move as ActiveMove,
-						 );
-						 effectiveness += typeof moveMod === 'number' ? moveMod : baseMod;
-					 }
-				 }
-				 if (alts.weak[targetWeak]) {
-					 if (notImmune && effectiveness >= 1) matched = true;
-				 } else {
-					 if (!notImmune || effectiveness < 1) matched = true;
-				 }
-			 }
-			 if (matched) continue;
- 
-			 for (const ability in alts.abilities) {
-				 if (Object.values(dex[mon].abilities).includes(ability) === alts.abilities[ability]) {
-					 matched = true;
-					 break;
-				 }
-			 }
-			 if (matched) continue;
- 
-			 for (const forme in alts.formes) {
-				 if (toID(dex[mon].forme).includes(forme) === alts.formes[forme]) {
-					 matched = true;
-					 break;
-				 }
-			 }
-			 if (matched) continue;
- 
-			 for (const stat in alts.stats) {
-				 let monStat = 0;
-				 if (stat === 'bst') {
-					 monStat = dex[mon].bst;
-				 } else if (stat === 'weight') {
-					 monStat = dex[mon].weighthg / 10;
-				 } else if (stat === 'height') {
-					 monStat = dex[mon].heightm;
-				 } else if (stat === 'gen') {
-					 monStat = dex[mon].gen;
-				 } else {
-					 monStat = dex[mon].baseStats[stat as StatID];
-				 }
-				 if (typeof alts.stats[stat].less === 'number') {
-					 if (monStat < alts.stats[stat].less) {
-						 matched = true;
-						 break;
-					 }
-				 }
-				 if (typeof alts.stats[stat].greater === 'number') {
-					 if (monStat > alts.stats[stat].greater) {
-						 matched = true;
-						 break;
-					 }
-				 }
-				 if (typeof alts.stats[stat].equal === 'number') {
-					 if (monStat === alts.stats[stat].equal) {
-						 matched = true;
-						 break;
-					 }
-				 }
-			 }
-			 if (matched) continue;
- 
-			 const format = Object.entries(Dex.data.Rulesets).find(([a, f]) => f.mod === usedMod);
-			 const formatStr = format ? format[1].name : 'gen8ou';
-			 const validator = TeamValidator.get(
-				 `${formatStr}${nationalSearch && !Dex.formats.getRuleTable(Dex.formats.get(formatStr)).has('standardnatdex') ? '@@@standardnatdex' : ''}`
-			 );
-			 const pokemonSource = validator.allSources();
-			 for (const move of Object.keys(alts.moves).map(x => mod.moves.get(x))) {
-				 if (move.gen <= mod.gen && !validator.checkCanLearn(move, dex[mon], pokemonSource) === alts.moves[move.id]) {
-					 matched = true;
-					 break;
-				 }
-				 if (!pokemonSource.size()) break;
-			 }
-			 if (matched) continue;
- 
-			 delete dex[mon];
-		 }
-	 }
-	 let results: string[] = [];
-	 for (const mon of Object.keys(dex).sort()) {
-		 if (singleTypeSearch !== null && (dex[mon].types.length === 1) !== singleTypeSearch) continue;
-		 const isRegionalForm = (dex[mon].forme === "Galar" || dex[mon].forme === "Alola") && dex[mon].name !== "Pikachu-Alola";
-		 const allowGmax = (gmaxSearch || tierSearch);
-		 if (!isRegionalForm && dex[mon].baseSpecies && results.includes(dex[mon].baseSpecies)) continue;
-		 if (dex[mon].isNonstandard === 'Gigantamax' && !allowGmax) continue;
-		 results.push(dex[mon].name);
-	 }
- 
-	 if (usedMod === 'gen7letsgo') {
-		 results = results.filter(name => {
-			 const species = mod.species.get(name);
-			 return (species.num <= 151 || ['Meltan', 'Melmetal'].includes(species.name)) &&
-			 (!species.forme || (['Alola', 'Mega', 'Mega-X', 'Mega-Y', 'Starter'].includes(species.forme) &&
-				 species.name !== 'Pikachu-Alola'));
-		 });
-	 }
- 
-	 if (usedMod === 'gen8bdsp') {
-		 results = results.filter(name => {
-			 const species = mod.species.get(name);
-			 if (species.id === 'pichuspikyeared') return false;
-			 if (capSearch) return species.gen <= 4;
-			 return species.gen <= 4 && species.num >= 1;
-		 });
-	 }
- 
-	 if (randomOutput && randomOutput < results.length) {
-		 results = Utils.shuffle(results).slice(0, randomOutput);
-	 }
- 
-	 let resultsStr = (message === "" ? message : `<span style="color:#999999;">${escapeHTML(message)}:</span><br />`);
-	 if (results.length > 1) {
-		 results.sort();
-		 if (sort) {
-			 const stat = sort.slice(0, -1);
-			 const direction = sort.slice(-1);
-			 Utils.sortBy(results, name => {
-				 const mon = mod.species.get(name);
-				 let monStat = 0;
-				 if (stat === 'bst') {
-					 monStat = mon.bst;
-				 } else if (stat === 'weight') {
-					 monStat = mon.weighthg;
-				 } else if (stat === 'height') {
-					 monStat = mon.heightm;
-				 } else if (stat === 'gen') {
-					 monStat = mon.gen;
-				 } else {
-					 monStat = mon.baseStats[stat as StatID];
-				 }
-				 return monStat * (direction === '+' ? 1 : -1);
-			 });
-		 }
-		 let notShown = 0;
-		 if (!showAll && results.length > MAX_RANDOM_RESULTS) {
-			 notShown = results.length - RESULTS_MAX_LENGTH;
-			 results = results.slice(0, RESULTS_MAX_LENGTH);
-		 }
-		 resultsStr += results.map(
-			 result => `<a href="//${Config.routes.dex}/pokemon/${toID(result)}" target="_blank" class="subtle" style="white-space:nowrap"><psicon pokemon="${result}" style="vertical-align:-7px;margin:-2px" />${result}</a>`
-		 ).join(", ");
-		 if (notShown) {
-			 resultsStr += `, and ${notShown} more. <span style="color:#999999;">Redo the search with ', all' at the end to show all results.</span>`;
-		 }
-	 } else if (results.length === 1) {
-		 return {dt: `${results[0]}${usedMod ? `,${usedMod}` : ''}`};
-	 } else {
-		 resultsStr += "No Pok&eacute;mon found.";
-	 }
-	 if (isTest) return {results, reply: resultsStr};
-	 return {reply: resultsStr};
- }
- 
- function runMovesearch(target: string, cmd: string, canAll: boolean, message: string, isTest: boolean) {
-	 const searches: MoveOrGroup[] = [];
-	 const {splitTarget, usedMod, count} = getMod(target);
-	 if (count > 1) {
-		 return {error: `You can't run searches for multiple mods.`};
-	 }
- 
-	 const mod = Dex.mod(usedMod || 'base');
-	 const allCategories = ['physical', 'special', 'status'];
-	 const allContestTypes = ['beautiful', 'clever', 'cool', 'cute', 'tough'];
-	 const allProperties = ['basePower', 'accuracy', 'priority', 'pp'];
-	 const allFlags = [
-		 'bypasssub', 'bite', 'bullet', 'charge', 'contact', 'dance', 'defrost', 'gravity', 'highcrit', 'mirror',
-		 'multihit', 'ohko', 'powder', 'protect', 'pulse', 'punch', 'recharge', 'reflectable', 'secondary',
-		 'snatch', 'sound', 'zmove', 'maxmove', 'gmaxmove', 'protection',
-	 ];
-	 const allStatus = ['psn', 'tox', 'brn', 'par', 'frz', 'slp'];
-	 const allVolatileStatus = ['flinch', 'confusion', 'partiallytrapped'];
-	 const allBoosts = ['hp', 'atk', 'def', 'spa', 'spd', 'spe', 'accuracy', 'evasion'];
-	 const allTargets: {[k: string]: string} = {
-		 oneally: 'adjacentAlly',
-		 userorally: 'adjacentAllyOrSelf',
-		 oneadjacentopponent: 'adjacentFoe',
-		 all: 'all',
-		 alladjacent: 'allAdjacent',
-		 alladjacentopponents: 'allAdjacentFoes',
-		 userandallies: 'allies',
-		 usersside: 'allySide',
-		 usersteam: 'allyTeam',
-		 any: 'any',
-		 opponentsside: 'foeSide',
-		 oneadjacent: 'normal',
-		 randomadjacent: 'randomNormal',
-		 scripted: 'scripted',
-		 user: 'self',
-	 };
-	 const allTypes: {[k: string]: string} = Object.create(null);
-	 for (const type of mod.types.all()) {
-		 allTypes[type.id] = type.name;
-	 }
-	 let showAll = false;
-	 let sort: string | null = null;
-	 const targetMons: {name: string, shouldBeExcluded: boolean}[] = [];
-	 let nationalSearch = null;
-	 let randomOutput = 0;
-	 for (const arg of splitTarget) {
-		 const orGroup: MoveOrGroup = {
-			 types: {}, categories: {}, contestTypes: {}, flags: {}, gens: {}, other: {}, mon: {}, property: {},
-			 boost: {}, lower: {}, zboost: {}, status: {}, volatileStatus: {}, targets: {}, skip: false, multihit: false,
-		 };
-		 const parameters = arg.split("|");
-		 if (parameters.length > 3) return {error: "No more than 3 alternatives for each parameter may be used."};
-		 for (const parameter of parameters) {
-			 let isNotSearch = false;
-			 target = parameter.toLowerCase().trim();
-			 if (target.startsWith('!')) {
-				 isNotSearch = true;
-				 target = target.substr(1);
-			 }
-			 let targetType;
-			 if (target.endsWith('type')) {
-				 targetType = toID(target.substring(0, target.indexOf('type')));
-			 } else {
-				 targetType = toID(target);
-			 }
-			 if (allTypes[targetType]) {
-				 target = allTypes[targetType];
-				 if ((orGroup.types[target] && isNotSearch) || (orGroup.types[target] === false && !isNotSearch)) {
-					 return {error: 'A search cannot both exclude and include a type.'};
-				 }
-				 orGroup.types[target] = !isNotSearch;
-				 continue;
-			 }
- 
-			 if (allCategories.includes(target)) {
-				 target = target.charAt(0).toUpperCase() + target.substr(1);
-				 if (
-					 (orGroup.categories[target] && isNotSearch) ||
-					 (orGroup.categories[target] === false && !isNotSearch)
-				 ) {
-					 return {error: 'A search cannot both exclude and include a category.'};
-				 }
-				 orGroup.categories[target] = !isNotSearch;
-				 continue;
-			 }
- 
-			 if (allContestTypes.includes(target)) {
-				 target = target.charAt(0).toUpperCase() + target.substr(1);
-				 if (
-					 (orGroup.contestTypes[target] && isNotSearch) ||
-					 (orGroup.contestTypes[target] === false && !isNotSearch)
-				 ) {
-					 return {error: 'A search cannot both exclude and include a contest condition.'};
-				 }
-				 orGroup.contestTypes[target] = !isNotSearch;
-				 continue;
-			 }
- 
-			 if (target.startsWith('targets ')) {
-				 target = toID(target.substr('targets '.length));
-				 if (target === 'allpokemon' || target === 'anypokemon' || target.includes('adjacent')) {
-					 target = target.replace('pokemon', '');
-				 }
-				 if (Object.keys(allTargets).includes(target)) {
-					 const moveTarget = allTargets[target];
-					 if (
-						 (orGroup.targets[moveTarget] && isNotSearch) ||
-						 (orGroup.targets[moveTarget] === false && !isNotSearch)
-					 ) {
-						 return {error: 'A search cannot both exclude and include a move target.'};
-					 }
-					 orGroup.targets[moveTarget] = !isNotSearch;
-					 continue;
-				 } else {
-					 return {error: `'${target}' isn't a valid move target.`};
-				 }
-			 }
- 
-			 if (target === 'bypassessubstitute') target = 'bypasssub';
-			 if (target === 'z') target = 'zmove';
-			 if (target === 'max') target = 'maxmove';
-			 if (target === 'gmax') target = 'gmaxmove';
-			 if (target === 'multi' || toID(target) === 'multihit') target = 'multihit';
-			 if (target === 'crit' || toID(target) === 'highcrit') target = 'highcrit';
-			 if (['thaw', 'thaws', 'melt', 'melts', 'defrosts'].includes(target)) target = 'defrost';
-			 if (target === 'bounceable' || toID(target) === 'magiccoat' || toID(target) === 'magicbounce') target = 'reflectable';
-			 if (allFlags.includes(target)) {
-				 if ((orGroup.flags[target] && isNotSearch) || (orGroup.flags[target] === false && !isNotSearch)) {
-					 return {error: `A search cannot both exclude and include '${target}'.`};
-				 }
-				 orGroup.flags[target] = !isNotSearch;
-				 continue;
-			 }
- 
-			 let targetInt = 0;
-			 if (target.substr(0, 1) === 'g' && Number.isInteger(parseFloat(target.substr(1)))) {
-				 targetInt = parseInt(target.substr(1).trim());
-			 } else if (target.substr(0, 3) === 'gen' && Number.isInteger(parseFloat(target.substr(3)))) {
-				 targetInt = parseInt(target.substr(3).trim());
-			 }
- 
-			 if (0 < targetInt && targetInt < 9) {
-				 if ((orGroup.gens[targetInt] && isNotSearch) || (orGroup.flags[targetInt] === false && !isNotSearch)) {
-					 return {error: `A search cannot both exclude and include '${target}'.`};
-				 }
-				 orGroup.gens[targetInt] = !isNotSearch;
-				 continue;
-			 }
- 
-			 if (target === 'all') {
-				 if (!canAll) return {error: "A search with the parameter 'all' cannot be broadcast."};
-				 if (parameters.length > 1) return {error: "The parameter 'all' cannot have alternative parameters."};
-				 showAll = true;
-				 orGroup.skip = true;
-				 continue;
-			 }
- 
-			 if (target === 'natdex') {
-				 if (parameters.length > 1) return {error: "The parameter 'natdex' cannot have alternative parameters."};
-				 nationalSearch = !isNotSearch;
-				 orGroup.skip = true;
-				 continue;
-			 }
- 
-			 if (target.endsWith(' asc') || target.endsWith(' desc')) {
-				 if (parameters.length > 1) {
-					 return {error: `The parameter '${target.split(' ')[1]}' cannot have alternative parameters.`};
-				 }
-				 let prop = target.split(' ')[0];
-				 switch (toID(prop)) {
-				 case 'basepower': prop = 'basePower'; break;
-				 case 'bp': prop = 'basePower'; break;
-				 case 'power': prop = 'basePower'; break;
-				 case 'acc': prop = 'accuracy'; break;
-				 }
-				 if (!allProperties.includes(prop)) return {error: `'${escapeHTML(target)}' did not contain a valid property.`};
-				 sort = `${prop}${target.endsWith(' asc') ? '+' : '-'}`;
-				 orGroup.skip = true;
-				 break;
-			 }
- 
-			 if (target === 'recovery') {
-				 if (orGroup.other.recovery === undefined) {
-					 orGroup.other.recovery = !isNotSearch;
-				 } else if ((orGroup.other.recovery && isNotSearch) || (!orGroup.other.recovery && !isNotSearch)) {
-					 return {error: 'A search cannot both exclude and include recovery moves.'};
-				 }
-				 continue;
-			 }
- 
-			 if (target === 'recoil') {
-				 if (orGroup.other.recoil === undefined) {
-					 orGroup.other.recoil = !isNotSearch;
-				 } else if ((orGroup.other.recoil && isNotSearch) || (!orGroup.other.recoil && !isNotSearch)) {
-					 return {error: 'A search cannot both exclude and include recoil moves.'};
-				 }
-				 continue;
-			 }
- 
-			 if (target.substr(0, 6) === 'random' && cmd === 'randmove') {
-				 // Validation for this is in the /randmove command
-				 randomOutput = parseInt(target.substr(6));
-				 orGroup.skip = true;
-				 continue;
-			 }
- 
-			 if (target === 'zrecovery') {
-				 if (orGroup.other.zrecovery === undefined) {
-					 orGroup.other.zrecovery = !isNotSearch;
-				 } else if ((orGroup.other.zrecovery && isNotSearch) || (!orGroup.other.zrecovery && !isNotSearch)) {
-					 return {error: 'A search cannot both exclude and include z-recovery moves.'};
-				 }
-				 continue;
-			 }
- 
-			 if (target === 'pivot') {
-				 if (orGroup.other.pivot === undefined) {
-					 orGroup.other.pivot = !isNotSearch;
-				 } else if ((orGroup.other.pivot && isNotSearch) || (!orGroup.other.pivot && !isNotSearch)) {
-					 return {error: 'A search cannot both exclude and include pivot moves.'};
-				 }
-				 continue;
-			 }
- 
-			 if (target === 'multihit') {
-				 if (!orGroup.multihit) {
-					 orGroup.multihit = true;
-				 } else if ((orGroup.multihit && isNotSearch) || (!orGroup.multihit && !isNotSearch)) {
-					 return {error: 'A search cannot both exclude and include multi-hit moves.'};
-				 }
-				 continue;
-			 }
- 
-			 const species = mod.species.get(target);
-			 if (species.exists) {
-				 if (parameters.length > 1) return {error: "A Pok\u00e9mon learnset cannot have alternative parameters."};
-				 if (targetMons.some(mon => mon.name === species.name && isNotSearch !== mon.shouldBeExcluded)) {
-					 return {error: "A search cannot both exclude and include the same Pok\u00e9mon."};
-				 }
-				 if (targetMons.some(mon => mon.name === species.name)) {
-					 return {error: "A search should not include a Pok\u00e9mon twice."};
-				 }
-				 targetMons.push({name: species.name, shouldBeExcluded: isNotSearch});
-				 orGroup.skip = true;
-				 continue;
-			 }
- 
-			 const inequality = target.search(/>|<|=/);
-			 if (inequality >= 0) {
-				 let inequalityString;
-				 if (isNotSearch) return {error: "You cannot use the negation symbol '!' in stat ranges."};
-				 if (target.charAt(inequality + 1) === '=') {
-					 inequalityString = target.substr(inequality, 2);
-				 } else {
-					 inequalityString = target.charAt(inequality);
-				 }
-				 const targetParts = target.replace(/\s/g, '').split(inequalityString);
-				 let num;
-				 let prop;
-				 const directions: Direction[] = [];
-				 if (!isNaN(parseFloat(targetParts[0]))) {
-					 // e.g. 100 < bp
-					 num = parseFloat(targetParts[0]);
-					 prop = targetParts[1];
-					 if (inequalityString.startsWith('>')) directions.push('less');
-					 if (inequalityString.startsWith('<')) directions.push('greater');
-				 } else if (!isNaN(parseFloat(targetParts[1]))) {
-					 // e.g. bp > 100
-					 num = parseFloat(targetParts[1]);
-					 prop = targetParts[0];
-					 if (inequalityString.startsWith('<')) directions.push('less');
-					 if (inequalityString.startsWith('>')) directions.push('greater');
-				 } else {
-					 return {error: `No value given to compare with '${escapeHTML(target)}'.`};
-				 }
-				 if (inequalityString.endsWith('=')) directions.push('equal');
-				 switch (toID(prop)) {
-				 case 'basepower': prop = 'basePower'; break;
-				 case 'bp': prop = 'basePower'; break;
-				 case 'power': prop = 'basePower'; break;
-				 case 'acc': prop = 'accuracy'; break;
-				 }
-				 if (!allProperties.includes(prop)) return {error: `'${escapeHTML(target)}' did not contain a valid property.`};
-				 if (!orGroup.property[prop]) orGroup.property[prop] = Object.create(null);
-				 for (const direction of directions) {
-					 if (orGroup.property[prop][direction]) return {error: `Invalid property range for ${prop}.`};
-					 orGroup.property[prop][direction] = num;
-				 }
-				 continue;
-			 }
- 
-			 if (target.substr(0, 8) === 'priority') {
-				 let sign: Direction;
-				 target = target.substr(8).trim();
-				 if (target === "+" || target === "") {
-					 sign = 'greater';
-				 } else if (target === "-") {
-					 sign = 'less';
-				 } else {
-					 return {error: `Priority type '${target}' not recognized.`};
-				 }
-				 if (orGroup.property['priority']) {
-					 return {error: "Priority cannot be set with both shorthand and inequality range."};
-				 } else {
-					 orGroup.property['priority'] = Object.create(null);
-					 orGroup.property['priority'][sign] = 0;
-				 }
-				 continue;
-			 }
-			 if (target.substr(0, 7) === 'boosts ' || target.substr(0, 7) === 'lowers ') {
-				 let isBoost = true;
-				 if (target.substr(0, 7) === 'lowers ') {
-					 isBoost = false;
-				 }
-				 switch (target.substr(7)) {
-				 case 'attack': target = 'atk'; break;
-				 case 'defense': target = 'def'; break;
-				 case 'specialattack': target = 'spa'; break;
-				 case 'spatk': target = 'spa'; break;
-				 case 'specialdefense': target = 'spd'; break;
-				 case 'spdef': target = 'spd'; break;
-				 case 'speed': target = 'spe'; break;
-				 case 'acc': target = 'accuracy'; break;
-				 case 'evasiveness': target = 'evasion'; break;
-				 default: target = target.substr(7);
-				 }
-				 if (!allBoosts.includes(target)) return {error: `'${escapeHTML(target)}' is not a recognized stat.`};
-				 if (isBoost) {
-					 if ((orGroup.boost[target] && isNotSearch) || (orGroup.boost[target] === false && !isNotSearch)) {
-						 return {error: 'A search cannot both exclude and include a stat boost.'};
-					 }
-					 orGroup.boost[target] = !isNotSearch;
-				 } else {
-					 if ((orGroup.lower[target] && isNotSearch) || (orGroup.lower[target] === false && !isNotSearch)) {
-						 return {error: 'A search cannot both exclude and include a stat boost.'};
-					 }
-					 orGroup.lower[target] = !isNotSearch;
-				 }
-				 continue;
-			 }
- 
-			 if (target.substr(0, 8) === 'zboosts ') {
-				 switch (target.substr(8)) {
-				 case 'attack': target = 'atk'; break;
-				 case 'defense': target = 'def'; break;
-				 case 'specialattack': target = 'spa'; break;
-				 case 'spatk': target = 'spa'; break;
-				 case 'specialdefense': target = 'spd'; break;
-				 case 'spdef': target = 'spd'; break;
-				 case 'speed': target = 'spe'; break;
-				 case 'acc': target = 'accuracy'; break;
-				 case 'evasiveness': target = 'evasion'; break;
-				 default: target = target.substr(8);
-				 }
-				 if (!allBoosts.includes(target)) return {error: `'${escapeHTML(target)}' is not a recognized stat.`};
-				 if ((orGroup.zboost[target] && isNotSearch) || (orGroup.zboost[target] === false && !isNotSearch)) {
-					 return {error: 'A search cannot both exclude and include a stat boost.'};
-				 }
-				 orGroup.zboost[target] = !isNotSearch;
-				 continue;
-			 }
- 
-			 const oldTarget = target;
-			 if (target.endsWith('s')) target = target.slice(0, -1);
-			 switch (target) {
-			 case 'toxic': target = 'tox'; break;
-			 case 'poison': target = 'psn'; break;
-			 case 'burn': target = 'brn'; break;
-			 case 'paralyze': target = 'par'; break;
-			 case 'freeze': target = 'frz'; break;
-			 case 'sleep': target = 'slp'; break;
-			 case 'confuse': target = 'confusion'; break;
-			 case 'trap': target = 'partiallytrapped'; break;
-			 case 'flinche': target = 'flinch'; break;
-			 }
- 
-			 if (allStatus.includes(target)) {
-				 if ((orGroup.status[target] && isNotSearch) || (orGroup.status[target] === false && !isNotSearch)) {
-					 return {error: 'A search cannot both exclude and include a status.'};
-				 }
-				 orGroup.status[target] = !isNotSearch;
-				 continue;
-			 }
- 
-			 if (allVolatileStatus.includes(target)) {
-				 if (
-					 (orGroup.volatileStatus[target] && isNotSearch) ||
-					 (orGroup.volatileStatus[target] === false && !isNotSearch)
-				 ) {
-					 return {error: 'A search cannot both exclude and include a volatile status.'};
-				 }
-				 orGroup.volatileStatus[target] = !isNotSearch;
-				 continue;
-			 }
- 
-			 return {error: `'${escapeHTML(oldTarget)}' could not be found in any of the search categories.`};
-		 }
-		 if (!orGroup.skip) {
-			 searches.push(orGroup);
-		 }
-	 }
-	 if (showAll && !searches.length && !targetMons.length && !sort) {
-		 return {
-			 error: "No search parameters other than 'all' were found. Try '/help movesearch' for more information on this command.",
-		 };
-	 }
- 
-	 const getFullLearnsetOfPokemon = (species: Species) => {
-		 let usedSpecies: Species = Utils.deepClone(species);
-		 let usedSpeciesLearnset: LearnsetData = Utils.deepClone(mod.species.getLearnset(usedSpecies.id));
-		 if (!usedSpeciesLearnset) {
-			 usedSpecies = Utils.deepClone(mod.species.get(usedSpecies.baseSpecies));
-			 usedSpeciesLearnset = Utils.deepClone(mod.species.getLearnset(usedSpecies.id) || {});
-		 }
-		 const lsetData = new Set<string>();
-		 for (const move in usedSpeciesLearnset) {
-			 const learnset = mod.species.getLearnset(usedSpecies.id);
-			 if (!learnset) break;
-			 const sources = learnset[move];
-			 for (const learned of sources) {
-				 const sourceGen = parseInt(learned.charAt(0));
-				 if (sourceGen <= mod.gen) lsetData.add(move);
-			 }
-		 }
- 
-		 while (usedSpecies.prevo) {
-			 usedSpecies = Utils.deepClone(mod.species.get(usedSpecies.prevo));
-			 usedSpeciesLearnset = Utils.deepClone(mod.species.getLearnset(usedSpecies.id));
-			 for (const move in usedSpeciesLearnset) {
-				 const learnset = mod.species.getLearnset(usedSpecies.id);
-				 if (!learnset) break;
-				 const sources = learnset[move];
-				 for (const learned of sources) {
-					 const sourceGen = parseInt(learned.charAt(0));
-					 if (sourceGen <= mod.gen) lsetData.add(move);
-				 }
-			 }
-		 }
- 
-		 return lsetData;
-	 };
- 
-	 // Since we assume we have no target mons at first
-	 // then the valid moveset we can search is the set of all moves.
-	 const validMoves = new Set(Object.keys(mod.data.Moves));
-	 for (const mon of targetMons) {
-		 const species = mod.species.get(mon.name);
-		 const lsetData = getFullLearnsetOfPokemon(species);
-		 // This pokemon's learnset needs to be excluded, so we perform a difference operation
-		 // on the valid moveset and this pokemon's moveset.
-		 if (mon.shouldBeExcluded) {
-			 for (const move of lsetData) {
-				 validMoves.delete(move);
-			 }
-		 } else {
-			 // This pokemon's learnset needs to be included, so we perform an intersection operation
-			 // on the valid moveset and this pokemon's moveset.
-			 for (const move of validMoves) {
-				 if (!lsetData.has(move)) {
-					 validMoves.delete(move);
-				 }
-			 }
-		 }
-	 }
- 
-	 // At this point, we've trimmed down the valid moveset to be
-	 // the moves that are appropriate considering the requested pokemon.
-	 const dex: {[moveid: string]: Move} = {};
-	 for (const moveid of validMoves) {
-		 const move = mod.moves.get(moveid);
-		 if (move.gen <= mod.gen) {
-			 if (
-				 (!nationalSearch && move.isNonstandard && move.isNonstandard !== "Gigantamax") ||
-				 (nationalSearch && move.isNonstandard && !["Gigantamax", "Past"].includes(move.isNonstandard))
-			 ) {
-				 continue;
-			 } else {
-				 dex[moveid] = move;
-			 }
-		 }
-	 }
- 
-	 for (const alts of searches) {
-		 if (alts.skip) continue;
-		 for (const moveid in dex) {
-			 const move = dex[moveid];
-			 const recoveryUndefined = alts.other.recovery === undefined;
-			 const zrecoveryUndefined = alts.other.zrecovery === undefined;
-			 let matched = false;
-			 if (Object.keys(alts.types).length) {
-				 if (alts.types[move.type]) continue;
-				 if (Object.values(alts.types).includes(false) && alts.types[move.type] !== false) continue;
-			 }
- 
-			 if (Object.keys(alts.categories).length) {
-				 if (alts.categories[move.category]) continue;
-				 if (Object.values(alts.categories).includes(false) && alts.categories[move.category] !== false) continue;
-			 }
- 
-			 if (Object.keys(alts.contestTypes).length) {
-				 if (alts.contestTypes[move.contestType || 'Cool']) continue;
-				 if (
-					 Object.values(alts.contestTypes).includes(false) &&
-					 alts.contestTypes[move.contestType || 'Cool'] !== false
-				 ) continue;
-			 }
- 
-			 if (Object.keys(alts.targets).length) {
-				 if (alts.targets[move.target]) continue;
-				 if (Object.values(alts.targets).includes(false) && alts.targets[move.target] !== false) continue;
-			 }
- 
-			 for (const flag in alts.flags) {
-				 if (flag === 'secondary') {
-					 if (!(move.secondary || move.secondaries) === !alts.flags[flag]) {
-						 matched = true;
-						 break;
-					 }
-				 } else if (flag === 'zmove') {
-					 if (!move.isZ === !alts.flags[flag]) {
-						 matched = true;
-						 break;
-					 }
-				 } else if (flag === 'highcrit') {
-					 const crit = move.willCrit || (move.critRatio && move.critRatio > 1);
-					 if (!crit === !alts.flags[flag]) {
-						 matched = true;
-						 break;
-					 }
-				 } else if (flag === 'multihit') {
-					 if (!move.multihit === !alts.flags[flag]) {
-						 matched = true;
-						 break;
-					 }
-				 } else if (flag === 'maxmove') {
-					 if (!(typeof move.isMax === 'boolean' && move.isMax) === !alts.flags[flag]) {
-						 matched = true;
-						 break;
-					 }
-				 } else if (flag === 'gmaxmove') {
-					 if (!(typeof move.isMax === 'string') === !alts.flags[flag]) {
-						 matched = true;
-						 break;
-					 }
-				 } else if (flag === 'protection') {
-					 if (!(move.stallingMove && move.id !== "endure") === !alts.flags[flag]) {
-						 matched = true;
-						 break;
-					 }
-				 } else if (flag === 'ohko') {
-					 if (!move.ohko === !alts.flags[flag]) {
-						 matched = true;
-						 break;
-					 }
-				 } else {
-					 if ((flag in move.flags) === alts.flags[flag]) {
-						 if (flag === 'protect' && ['all', 'allyTeam', 'allySide', 'foeSide', 'self'].includes(move.target)) continue;
-						 matched = true;
-						 break;
-					 }
-				 }
-			 }
-			 if (matched) continue;
-			 if (Object.keys(alts.gens).length) {
-				 if (alts.gens[String(move.gen)]) continue;
-				 if (Object.values(alts.gens).includes(false) && alts.gens[String(move.gen)] !== false) continue;
-			 }
-			 if (!zrecoveryUndefined || !recoveryUndefined) {
-				 for (const recoveryType in alts.other) {
-					 let hasRecovery = false;
-					 if (recoveryType === "recovery") {
-						 hasRecovery = !!move.drain || !!move.flags.heal;
-					 } else if (recoveryType === "zrecovery") {
-						 hasRecovery = (move.zMove?.effect === 'heal');
-					 }
-					 if (hasRecovery === alts.other[recoveryType]) {
-						 matched = true;
-						 break;
-					 }
-				 }
-			 }
-			 if (matched) continue;
-			 if (alts.other.recoil !== undefined) {
-				 const recoil = move.recoil || move.hasCrashDamage;
-				 if (recoil && alts.other.recoil || !(recoil || alts.other.recoil)) matched = true;
-			 }
-			 if (matched) continue;
-			 for (const prop in alts.property) {
-				 if (typeof alts.property[prop].less === "number") {
-					 if (
-						 move[prop as keyof Move] !== true &&
-						 (move[prop as keyof Move] as number) < alts.property[prop].less
-					 ) {
-						 matched = true;
-						 break;
-					 }
-				 }
-				 if (typeof alts.property[prop].greater === "number") {
-					 if ((move[prop as keyof Move] === true && move.category !== "Status") ||
-						 move[prop as keyof Move] as number > alts.property[prop].greater) {
-						 matched = true;
-						 break;
-					 }
-				 }
-				 if (typeof alts.property[prop].equal === "number") {
-					 if (move[prop as keyof Move] === alts.property[prop].equal) {
-						 matched = true;
-						 break;
-					 }
-				 }
-			 }
-			 if (matched) continue;
-			 for (const boost in alts.boost) {
-				 if (move.boosts) {
-					 if ((move.boosts[boost as BoostID]! > 0) === alts.boost[boost]) {
-						 matched = true;
-						 break;
-					 }
-				 } else if (move.secondary?.self?.boosts) {
-					 if ((move.secondary.self.boosts[boost as BoostID]! > 0) === alts.boost[boost]) {
-						 matched = true;
-						 break;
-					 }
-				 } else if (move.selfBoost?.boosts) {
-					 if ((move.selfBoost.boosts[boost as BoostID]! > 0) === alts.boost[boost]) {
-						 matched = true;
-						 break;
-					 }
-				 }
-			 }
-			 if (matched) continue;
-			 for (const lower in alts.lower) {
-				 if (move.boosts) {
-					 if ((move.boosts[lower as BoostID]! < 0) === alts.lower[lower]) {
-						 matched = true;
-						 break;
-					 }
-				 } else if (move.secondary?.boosts) {
-					 if ((move.secondary.boosts[lower as BoostID]! < 0) === alts.lower[lower]) {
-						 matched = true;
-						 break;
-					 }
-				 } else if (move.self?.boosts) {
-					 if ((move.self.boosts[lower as BoostID]! < 0) === alts.lower[lower]) {
-						 matched = true;
-						 break;
-					 }
-				 }
-			 }
-			 if (matched) continue;
-			 for (const boost in alts.zboost) {
-				 const zMove = move.zMove;
-				 if (zMove?.boost) {
-					 if ((zMove.boost[boost as BoostID]! > 0) === alts.zboost[boost]) {
-						 matched = true;
-						 break;
-					 }
-				 }
-			 }
-			 if (matched) continue;
- 
-			 for (const searchStatus in alts.status) {
-				 let canStatus = !!(
-					 move.status === searchStatus ||
-					 (move.secondaries && move.secondaries.some(entry => entry.status === searchStatus))
-				 );
-				 if (searchStatus === 'slp') {
-					 canStatus = canStatus || moveid === 'yawn';
-				 }
-				 if (searchStatus === 'brn' || searchStatus === 'frz' || searchStatus === 'par') {
-					 canStatus = canStatus || moveid === 'triattack';
-				 }
-				 if (canStatus === alts.status[searchStatus]) {
-					 matched = true;
-					 break;
-				 }
-			 }
-			 if (matched) continue;
- 
-			 for (const searchStatus in alts.volatileStatus) {
-				 const canStatus = !!(
-					 (move.secondary && move.secondary.volatileStatus === searchStatus) ||
-					 (move.secondaries && move.secondaries.some(entry => entry.volatileStatus === searchStatus)) ||
-					 (move.volatileStatus === searchStatus)
-				 );
-				 if (canStatus === alts.volatileStatus[searchStatus]) {
-					 matched = true;
-					 break;
-				 }
-			 }
-			 if (matched) continue;
-			 if (alts.other.pivot !== undefined) {
-				 const pivot = move.selfSwitch && move.id !== 'batonpass';
-				 if (pivot && alts.other.pivot || !(pivot || alts.other.pivot)) matched = true;
-			 }
-			 if (matched) continue;
- 
-			 delete dex[moveid];
-		 }
-	 }
- 
-	 let results = [];
-	 for (const move in dex) {
-		 results.push(dex[move].name);
-	 }
- 
-	 let resultsStr = "";
-	 if (targetMons.length) {
-		 resultsStr += `<span style="color:#999999;">Matching moves found in learnset(s) for</span> ${targetMons.map(mon => `${mon.shouldBeExcluded ? "!" : ""}${mon.name}`).join(', ')}:<br />`;
-	 } else {
-		 resultsStr += (message === "" ? message : `<span style="color:#999999;">${escapeHTML(message)}:</span><br />`);
-	 }
-	 if (randomOutput && randomOutput < results.length) {
-		 results = Utils.shuffle(results).slice(0, randomOutput);
-	 }
-	 if (results.length > 1) {
-		 results.sort();
-		 if (sort) {
-			 const prop = sort.slice(0, -1);
-			 const direction = sort.slice(-1);
-			 Utils.sortBy(results, moveName => {
-				 let moveProp = dex[toID(moveName)][prop as keyof Move] as number;
-				 // convert booleans to 0 or 1
-				 if (typeof moveProp === 'boolean') moveProp = moveProp ? 1 : 0;
-				 return moveProp * (direction === '+' ? 1 : -1);
-			 });
-		 }
-		 let notShown = 0;
-		 if (!showAll && results.length > MAX_RANDOM_RESULTS) {
-			 notShown = results.length - RESULTS_MAX_LENGTH;
-			 results = results.slice(0, RESULTS_MAX_LENGTH);
-		 }
-		 resultsStr += results.map(
-			 result => `<a href="//${Config.routes.dex}/moves/${toID(result)}" target="_blank" class="subtle" style="white-space:nowrap">${result}</a>` +
-				 `${sort ? ` (${dex[toID(result)][sort.slice(0, -1) as keyof Move] === true ? '-' : dex[toID(result)][sort.slice(0, -1) as keyof Move]})` : ''}`
-		 ).join(", ");
-		 if (notShown) {
-			 resultsStr += `, and ${notShown} more. <span style="color:#999999;">Redo the search with ', all' at the end to show all results.</span>`;
-		 }
-	 } else if (results.length === 1) {
-		 return {dt: `${results[0]}${usedMod ? `,${usedMod}` : ''}`};
-	 } else {
-		 resultsStr += "No moves found.";
-	 }
-	 if (isTest) return {results, reply: resultsStr};
-	 return {reply: resultsStr};
- }
- 
- function runItemsearch(target: string, cmd: string, canAll: boolean, message: string) {
-	 let showAll = false;
-	 let maxGen = 0;
-	 let gen = 0;
- 
-	 target = target.trim();
-	 const lastCommaIndex = target.lastIndexOf(',');
-	 const lastArgumentSubstr = target.substr(lastCommaIndex + 1).trim();
-	 if (lastArgumentSubstr === 'all') {
-		 if (!canAll) return {error: "A search ending in ', all' cannot be broadcast."};
-		 showAll = true;
-		 target = target.substr(0, lastCommaIndex);
-	 }
- 
-	 target = target.toLowerCase().replace('-', ' ').replace(/[^a-z0-9.\s/]/g, '');
-	 const rawSearch = target.replace(/(max ?)?gen \d/g, match => toID(match)).split(' ');
-	 const searchedWords: string[] = [];
-	 let foundItems: string[] = [];
- 
-	 // Refine searched words
-	 for (const [i, search] of rawSearch.entries()) {
-		 let newWord = search.trim();
-		 if (newWord.substr(0, 6) === 'maxgen') {
-			 const parsedGen = parseInt(newWord.substr(6));
-			 if (!isNaN(parsedGen)) {
-				 if (maxGen) return {error: "You cannot specify 'maxgen' multiple times."};
-				 maxGen = parsedGen;
-				 if (maxGen < 2 || maxGen > 8) return {error: "The generation must be between 2 and 8"};
-				 continue;
-			 }
-		 } else if (newWord.substr(0, 3) === 'gen') {
-			 const parsedGen = parseInt(newWord.substr(3));
-			 if (!isNaN(parsedGen)) {
-				 if (gen) return {error: "You cannot specify 'gen' multiple times."};
-				 gen = parsedGen;
-				 if (gen < 2 || gen > 8) return {error: "The generation must be between 2 and 8"};
-				 continue;
-			 }
-		 }
-		 if (isNaN(parseFloat(newWord))) newWord = newWord.replace('.', '');
-		 switch (newWord) {
-		 // Words that don't really help identify item removed to speed up search
-		 case 'a':
-		 case 'an':
-		 case 'is':
-		 case 'it':
-		 case 'its':
-		 case 'the':
-		 case 'that':
-		 case 'which':
-		 case 'user':
-		 case 'holder':
-		 case 'holders':
-			 newWord = '';
-			 break;
-		 // replace variations of common words with standardized versions
-		 case 'opponent': newWord = 'attacker'; break;
-		 case 'flung': newWord = 'fling'; break;
-		 case 'heal': case 'heals':
-		 case 'recovers': newWord = 'restores'; break;
-		 case 'boost':
-		 case 'boosts': newWord = 'raises'; break;
-		 case 'weakens': newWord = 'halves'; break;
-		 case 'more': newWord = 'increases'; break;
-		 case 'super':
-			 if (rawSearch[i + 1] === 'effective') {
-				 newWord = 'supereffective';
-			 }
-			 break;
-		 case 'special':
-			 if (rawSearch[i + 1] === 'defense') {
-				 newWord = 'specialdefense';
-			 } else if (rawSearch[i + 1] === 'attack') {
-				 newWord = 'specialattack';
-			 }
-			 break;
-		 case 'spatk':
-		 case 'spa':
-			 newWord = 'specialattack';
-			 break;
-		 case 'atk':
-		 case 'attack':
-			 if (['sp', 'special'].includes(rawSearch[i - 1])) {
-				 break;
-			 } else {
-				 newWord = 'attack';
-			 }
-			 break;
-		 case 'spd':
-		 case 'spdef':
-			 newWord = 'specialdefense';
-			 break;
-		 case 'def':
-		 case 'defense':
-			 if (['sp', 'special'].includes(rawSearch[i - 1])) {
-				 break;
-			 } else {
-				 newWord = 'defense';
-			 }
-			 break;
-		 case 'burns': newWord = 'burn'; break;
-		 case 'poisons': newWord = 'poison'; break;
-		 default:
-			 if (/x[\d.]+/.test(newWord)) {
-				 newWord = newWord.substr(1) + 'x';
-			 }
-		 }
-		 if (!newWord || searchedWords.includes(newWord)) continue;
-		 searchedWords.push(newWord);
-	 }
- 
-	 if (searchedWords.length === 0 && !gen && !maxGen) {
-		 return {error: "No distinguishing words were used. Try a more specific search."};
-	 }
- 
-	 const dex = maxGen ? Dex.mod("gen" + maxGen) : Dex;
-	 if (searchedWords.includes('fling')) {
-		 let basePower = 0;
-		 let effect;
- 
-		 for (let word of searchedWords) {
-			 let wordEff = "";
-			 switch (word) {
-			 case 'burn': case 'burns':
-			 case 'brn': wordEff = 'brn'; break;
-			 case 'paralyze': case 'paralyzes':
-			 case 'par': wordEff = 'par'; break;
-			 case 'poison': case 'poisons':
-			 case 'psn': wordEff = 'psn'; break;
-			 case 'toxic':
-			 case 'tox': wordEff = 'tox'; break;
-			 case 'flinches':
-			 case 'flinch': wordEff = 'flinch'; break;
-			 case 'badly': wordEff = 'tox'; break;
-			 }
-			 if (wordEff && effect) {
-				 if (!(wordEff === 'psn' && effect === 'tox')) return {error: "Only specify fling effect once."};
-			 } else if (wordEff) {
-				 effect = wordEff;
-			 } else {
-				 if (word.substr(word.length - 2) === 'bp' && word.length > 2) word = word.substr(0, word.length - 2);
-				 if (Number.isInteger(Number(word))) {
-					 if (basePower) return {error: "Only specify a number for base power once."};
-					 basePower = parseInt(word);
-				 }
-			 }
-		 }
- 
-		 for (const item of dex.items.all()) {
-			 if (!item.fling || (gen && item.gen !== gen) || (maxGen && item.gen <= maxGen)) continue;
- 
-			 if (basePower && effect) {
-				 if (item.fling.basePower === basePower &&
-				 (item.fling.status === effect || item.fling.volatileStatus === effect)) foundItems.push(item.name);
-			 } else if (basePower) {
-				 if (item.fling.basePower === basePower) foundItems.push(item.name);
-			 } else {
-				 if (item.fling.status === effect || item.fling.volatileStatus === effect) foundItems.push(item.name);
-			 }
-		 }
-		 if (foundItems.length === 0) return {error: 'No items inflict ' + basePower + 'bp damage when used with Fling.'};
-	 } else if (target.search(/natural ?gift/i) >= 0) {
-		 let basePower = 0;
-		 let type = "";
- 
-		 for (let word of searchedWords) {
-			 if (word in dex.data.TypeChart) {
-				 if (type) return {error: "Only specify natural gift type once."};
-				 type = word.charAt(0).toUpperCase() + word.slice(1);
-			 } else {
-				 if (word.endsWith('bp') && word.length > 2) word = word.slice(0, -2);
-				 if (Number.isInteger(Number(word))) {
-					 if (basePower) return {error: "Only specify a number for base power once."};
-					 basePower = parseInt(word);
-				 }
-			 }
-		 }
- 
-		 for (const item of dex.items.all()) {
-			 if (!item.isBerry || !item.naturalGift || (gen && item.gen !== gen) || (maxGen && item.gen <= maxGen)) continue;
- 
-			 if (basePower && type) {
-				 if (item.naturalGift.basePower === basePower && item.naturalGift.type === type) foundItems.push(item.name);
-			 } else if (basePower) {
-				 if (item.naturalGift.basePower === basePower) foundItems.push(item.name);
-			 } else {
-				 if (item.naturalGift.type === type) foundItems.push(item.name);
-			 }
-		 }
-		 if (foundItems.length === 0) {
-			 return {error: 'No berries inflict ' + basePower + 'bp damage when used with Natural Gift.'};
-		 }
-	 } else {
-		 let bestMatched = 0;
-		 for (const item of dex.items.all()) {
-			 let matched = 0;
-			 // splits words in the description into a toID()-esk format except retaining / and . in numbers
-			 let descWords = item.desc || '';
-			 // add more general quantifier words to descriptions
-			 if (/[1-9.]+x/.test(descWords)) descWords += ' increases';
-			 if (item.isBerry) descWords += ' berry';
-			 descWords = descWords.replace(/super[-\s]effective/g, 'supereffective');
-			 const descWordsArray = descWords.toLowerCase()
-				 .replace('-', ' ')
-				 .replace(/[^a-z0-9\s/]/g, '')
-				 .replace(/(\D)\./, (p0, p1) => p1).split(' ');
- 
-			 for (const word of searchedWords) {
-				 switch (word) {
-				 case 'specialattack':
-					 if (descWordsArray[descWordsArray.indexOf('sp') + 1] === 'atk') matched++;
-					 break;
-				 case 'specialdefense':
-					 if (descWordsArray[descWordsArray.indexOf('sp') + 1] === 'def') matched++;
-					 break;
-				 default:
-					 if (descWordsArray.includes(word)) matched++;
-				 }
-			 }
- 
-			 if (matched >= (searchedWords.length * 3 / 5) && (!maxGen || item.gen <= maxGen) && (!gen || item.gen === gen)) {
-				 if (matched === bestMatched) {
-					 foundItems.push(item.name);
-				 } else if (matched > bestMatched) {
-					 foundItems = [item.name];
-					 bestMatched = matched;
-				 }
-			 }
-		 }
-	 }
- 
-	 let resultsStr = (message === "" ? message : `<span style="color:#999999;">${escapeHTML(message)}:</span><br />`);
-	 if (foundItems.length > 0) {
-		 foundItems.sort();
-		 let notShown = 0;
-		 if (!showAll && foundItems.length > RESULTS_MAX_LENGTH + 5) {
-			 notShown = foundItems.length - RESULTS_MAX_LENGTH;
-			 foundItems = foundItems.slice(0, RESULTS_MAX_LENGTH);
-		 }
-		 resultsStr += foundItems.map(
-			 result => `<a href="//${Config.routes.dex}/items/${toID(result)}" target="_blank" class="subtle" style="white-space:nowrap"><psicon item="${result}" style="vertical-align:-7px" />${result}</a>`
-		 ).join(", ");
-		 if (notShown) {
-			 resultsStr += `, and ${notShown} more. <span style="color:#999999;">Redo the search with ', all' at the end to show all results.</span>`;
-		 }
-	 } else {
-		 resultsStr += "No items found. Try a more general search";
-	 }
-	 return {reply: resultsStr};
- }
- 
- function runAbilitysearch(target: string, cmd: string, canAll: boolean, message: string) {
-	 // based heavily on runItemsearch()
-	 let showAll = false;
-	 let maxGen = 0;
-	 let gen = 0;
- 
-	 target = target.trim();
-	 const lastCommaIndex = target.lastIndexOf(',');
-	 const lastArgumentSubstr = target.substr(lastCommaIndex + 1).trim();
-	 if (lastArgumentSubstr === 'all') {
-		 if (!canAll) return {error: "A search ending in ', all' cannot be broadcast."};
-		 showAll = true;
-		 target = target.substr(0, lastCommaIndex);
-	 }
- 
-	 target = target.toLowerCase().replace('-', ' ').replace(/[^a-z0-9.\s/]/g, '');
-	 const rawSearch = target.replace(/(max ?)?gen \d/g, match => toID(match)).split(' ');
-	 const searchedWords: string[] = [];
-	 let foundAbilities: string[] = [];
- 
-	 for (const [i, search] of rawSearch.entries()) {
-		 let newWord = search.trim();
-		 if (newWord.substr(0, 6) === 'maxgen') {
-			 const parsedGen = parseInt(newWord.substr(6));
-			 if (parsedGen) {
-				 if (maxGen) return {error: "You cannot specify 'maxgen' multiple times."};
-				 maxGen = parsedGen;
-				 if (maxGen < 3 || maxGen > 8) return {error: "The generation must be between 3 and 8"};
-				 continue;
-			 }
-		 } else if (newWord.substr(0, 3) === 'gen') {
-			 const parsedGen = parseInt(newWord.substr(3));
-			 if (parsedGen) {
-				 if (gen) return {error: "You cannot specify 'gen' multiple times."};
-				 gen = parsedGen;
-				 if (gen < 3 || gen > 8) return {error: "The generation must be between 3 and 8"};
-				 continue;
-			 }
-		 }
-		 if (isNaN(parseFloat(newWord))) newWord = newWord.replace('.', '');
-		 switch (newWord) {
-		 // remove extraneous words
-		 case 'a':
-		 case 'an':
-		 case 'is':
-		 case 'it':
-		 case 'its':
-		 case 'the':
-		 case 'that':
-		 case 'which':
-		 case 'user':
-			 newWord = '';
-			 break;
-		 // replace variations of common words with standardized versions
-		 case 'opponent': newWord = 'attacker'; break;
-		 case 'heal':
-		 case 'heals':
-		 case 'recovers': newWord = 'restores'; break;
-		 case 'boost':
-		 case 'boosts': newWord = 'raised'; break;
-		 case 'super':
-			 if (rawSearch[i + 1] === 'effective') {
-				 newWord = 'supereffective';
-			 }
-			 break;
-		 case 'special':
-			 if (rawSearch[i + 1] === 'defense') {
-				 newWord = 'specialdefense';
-			 } else if (rawSearch[i + 1] === 'attack') {
-				 newWord = 'specialattack';
-			 }
-			 break;
-		 case 'spd':
-		 case 'spdef': newWord = 'specialdefense'; break;
-		 case 'spa':
-		 case 'spatk': newWord = 'specialattack'; break;
-		 case 'atk': newWord = 'attack'; break;
-		 case 'def': newWord = 'defense'; break;
-		 case 'spe': newWord = 'speed'; break;
-		 case 'burn':
-		 case 'burns': newWord = 'burned'; break;
-		 case 'poison':
-		 case 'poisons': newWord = 'poisoned'; break;
-		 default:
-			 if (/x[\d.]+/.test(newWord)) {
-				 newWord = newWord.substr(1) + 'x';
-			 }
-		 }
-		 if (!newWord || searchedWords.includes(newWord)) continue;
-		 searchedWords.push(newWord);
-	 }
- 
-	 if (searchedWords.length === 0 && !gen && !maxGen) {
-		 return {error: "No distinguishing words were used. Try a more specific search."};
-	 }
- 
-	 let bestMatched = 0;
-	 const dex = maxGen ? Dex.mod("gen" + maxGen) : Dex;
-	 for (const ability of dex.abilities.all()) {
-		 let matched = 0;
-		 // splits words in the description into a toID()-esque format except retaining / and . in numbers
-		 let descWords = ability.desc || ability.shortDesc || '';
-		 // add more general quantifier words to descriptions
-		 if (/[1-9.]+x/.test(descWords)) descWords += ' increases';
-		 descWords = descWords.replace(/super[-\s]effective/g, 'supereffective');
-		 const descWordsArray = Chat.normalize(descWords).split(' ');
- 
-		 for (const word of searchedWords) {
-			 switch (word) {
-			 case 'specialattack':
-				 if (descWordsArray[descWordsArray.indexOf('special') + 1] === 'attack') matched++;
-				 break;
-			 case 'specialdefense':
-				 if (descWordsArray[descWordsArray.indexOf('special') + 1] === 'defense') matched++;
-				 break;
-			 default:
-				 if (descWordsArray.includes(word)) matched++;
-			 }
-		 }
- 
-		 if (matched >= (searchedWords.length * 3 / 5) && (!maxGen || ability.gen <= maxGen) && (!gen || ability.gen === gen)) {
-			 if (matched === bestMatched) {
-				 foundAbilities.push(ability.name);
-			 } else if (matched > bestMatched) {
-				 foundAbilities = [ability.name];
-				 bestMatched = matched;
-			 }
-		 }
-	 }
- 
-	 if (foundAbilities.length === 1) return {dt: foundAbilities[0]};
-	 let resultsStr = (message === "" ? message : `<span style="color:#999999;">${escapeHTML(message)}:</span><br />`);
-	 if (foundAbilities.length > 0) {
-		 foundAbilities.sort();
-		 let notShown = 0;
-		 if (!showAll && foundAbilities.length > RESULTS_MAX_LENGTH + 5) {
-			 notShown = foundAbilities.length - RESULTS_MAX_LENGTH;
-			 foundAbilities = foundAbilities.slice(0, RESULTS_MAX_LENGTH);
-		 }
-		 resultsStr += foundAbilities.map(
-			 result => `<a href="//${Config.routes.dex}/abilities/${toID(result)}" target="_blank" class="subtle" style="white-space:nowrap">${result}</a>`
-		 ).join(", ");
-		 if (notShown) {
-			 resultsStr += `, and ${notShown} more. <span style="color:#999999;">Redo the search with ', all' at the end to show all results.</span>`;
-		 }
-	 } else {
-		 resultsStr += "No abilities found. Try a more general search.";
-	 }
-	 return {reply: resultsStr};
- }
- 
- function runLearn(target: string, cmd: string, canAll: boolean, formatid: string) {
-	 let format: Format = Dex.formats.get(formatid);
-	 const targets = target.split(',');
-	 let formatName = format.name;
-	 let minSourceGen = undefined;
-	 let level = 100;
- 
-	 while (targets.length) {
-		 const targetid = toID(targets[0]);
-		 if (targetid === 'pentagon') {
-			 if (format.exists) {
-				 return {error: "'pentagon' can't be used with formats."};
-			 }
-			 minSourceGen = 6;
-			 targets.shift();
-			 continue;
-		 }
-		 if (targetid.startsWith('minsourcegen')) {
-			 if (format.exists) {
-				 return {error: "'min source gen' can't be used with formats."};
-			 }
-			 minSourceGen = parseInt(targetid.slice(12));
-			 if (isNaN(minSourceGen) || minSourceGen < 1) return {error: `Invalid min source gen "${targetid.slice(12)}"`};
-			 targets.shift();
-			 continue;
-		 }
-		 if (targetid === 'level5') {
-			 level = 5;
-			 targets.shift();
-			 continue;
-		 }
-		 break;
-	 }
-	 let gen;
-	 const dex = Dex.mod(formatid).includeData();
-	 if (!format.exists) {
-		 // can happen if you hotpatch formats without hotpatching chat
-		 if (!dex) return {error: `"${formatid}" is not a supported format.`};
- 
-		 gen = dex.gen;
-		 format = new Dex.Format({mod: formatid});
-		 formatName = `Gen ${gen}`;
-		 if (minSourceGen) {
-			 formatName += ` (Min Source Gen = ${minSourceGen})`;
-			 const ruleTable = dex.formats.getRuleTable(format);
-			 ruleTable.minSourceGen = minSourceGen;
-		 }
-	 } else {
-		 gen = Dex.forFormat(format).gen;
-	 }
-	 const validator = TeamValidator.get(format);
- 
-	 const species = validator.dex.species.get(targets.shift());
-	 const setSources = validator.allSources(species);
-	 const set: Partial<PokemonSet> = {
-		 name: species.baseSpecies,
-		 species: species.name,
-		 level,
-	 };
-	 const all = (cmd === 'learnall');
- 
-	 if (!species.exists || species.id === 'missingno') {
-		 return {error: `Pok\u00e9mon '${species.id}' not found.`};
-	 }
- 
-	 if (species.gen > gen) {
-		 return {error: `${species.name} didn't exist yet in generation ${gen}.`};
-	 }
- 
-	 if (!targets.length) {
-		 return {error: "You must specify at least one move."};
-	 }
- 
-	 const moveNames = [];
-	 for (const arg of targets) {
-		 if (['ha', 'hidden', 'hiddenability'].includes(toID(arg))) {
-			 if (gen < 5) {
-				 return {error: "Hidden abilities exist only in generations 5 and later."};
-			 }
-			 setSources.isHidden = true;
-			 continue;
-		 }
-		 const move = validator.dex.moves.get(arg);
-		 moveNames.push(move.name);
-		 if (!move.exists) {
-			 return {error: `Move '${move.id}' not found.`};
-		 }
-		 if (move.gen > gen) {
-			 return {error: `${move.name} didn't exist yet in generation ${gen}.`};
-		 }
-	 }
- 
-	 const problems = validator.validateMoves(species, moveNames, setSources, set);
-	 if (setSources.sources.length) {
-		 setSources.sources = setSources.sources.map(source => {
-			 if (source.charAt(1) !== 'E') return source;
-			 const fathers = validator.findEggMoveFathers(source, species, setSources, true);
-			 if (!fathers) return '';
-			 return source + ':' + fathers.join(',');
-		 }).filter(Boolean);
-		 if (!setSources.size()) {
-			 problems.push(`${species.name} doesn't have a valid father for its egg moves (${setSources.limitedEggMoves!.join(', ')})`);
-		 }
-	 }
- 
-	 let buffer = `In ${formatName}, `;
-	 if (setSources.isHidden) {
-		 const canUseAbilityPatch = dex.gen >= 8 && format.mod !== 'gen8dlc1';
-		 console.log(setSources.sourcesBefore);
-		 if (!setSources.sourcesBefore && !canUseAbilityPatch) {
-			 const learnset = dex.species.getLearnsetData(species.id);
-			 for (let sourceIndex = 0; sourceIndex < setSources.sources.length; sourceIndex++) {
-				 const source = setSources.sources[sourceIndex];
-				 if (source.charAt(1) === 'S' && learnset.eventData) {
-					 const eventData = learnset.eventData[parseInt(source.substr(2))];
-					 const hiddenAbilityProblem = validator.validateEventHiddenAbility(species.name, true, eventData, ` because it has a move only available from an event`);
-					 if (hiddenAbilityProblem) {
-						 setSources.sources.splice(sourceIndex, 1);
-						 sourceIndex--;
-						 if (!setSources.sources.length) {
-							 problems.push(hiddenAbilityProblem);
-						 }
-					 }
-				 }
-			 }
-		 }
-		 if (species.maleOnlyHidden && setSources.sourcesBefore < 5) {
-			 for (let sourceIndex = 0; sourceIndex < setSources.sources.length; sourceIndex++) {
-				 const source = setSources.sources[sourceIndex];
-				 if (source.charAt(1) === 'E') {
-					 setSources.sources.splice(sourceIndex, 1);
-					 sourceIndex--;
-					 if (!setSources.sources.length) {
-						 problems.push(`${species.name} has an unbreedable Hidden Ability - it can't use egg moves.`);
-					 }
-				 }
-			 }
-		 }
-		 buffer += `${species.abilities['H'] || 'HA'} `;
-	 }
-	 buffer += `${species.name}` + (problems.length ? ` <span class="message-learn-cannotlearn">can't</span> learn ` : ` <span class="message-learn-canlearn">can</span> learn `) + toListString(moveNames);
-	 if (!problems.length) {
-		 const sourceNames: {[k: string]: string} = {
-			 '7V': "virtual console transfer from gen 1-2", '8V': "Pok&eacute;mon Home transfer from LGPE", E: "", S: "event", D: "dream world", X: "traded-back ", Y: "traded-back event",
-		 };
-		 const sourcesBefore = setSources.sourcesBefore;
-		 let sources = setSources.sources;
-		 if (sources.length || sourcesBefore < gen) buffer += " only when obtained";
-		 buffer += " from:<ul class=\"message-learn-list\">";
-		 if (sources.length) {
-			 sources = sources.map(source => {
-				 if (source.startsWith('1ET')) {
-					 return '2X' + source.slice(3);
-				 }
-				 if (source.startsWith('1ST')) {
-					 return '2Y' + source.slice(3);
-				 }
-				 return source;
-			 }).sort();
-			 for (let source of sources) {
-				 buffer += `<li>Gen ${source.charAt(0)} ${sourceNames[source] || sourceNames[source.charAt(1)]}`;
- 
-				 if (source.charAt(1) === 'E') {
-					 let fathers;
-					 [source, fathers] = source.split(':');
-					 fathers = fathers.split(',');
-					 if (fathers.length > 4 && !all) fathers = fathers.slice(-4).concat('...');
-					 if (source.length > 2) {
-						 buffer += `${source.slice(2)} `;
-					 }
-					 buffer += `egg`;
-					 if (!fathers[0]) {
-						 buffer += `: chainbreed`;
-					 } else {
-						 buffer += `: breed ${fathers.join(', ')}`;
-					 }
-				 }
- 
-				 if (source.startsWith('5E') && species.maleOnlyHidden) {
-					 buffer += " (no hidden ability)";
-				 }
-			 }
-		 }
-		 if (sourcesBefore) {
-			 const sourceGen = sourcesBefore < gen ? `Gen ${sourcesBefore} or earlier` : `anywhere`;
-			 if (moveNames.length === 1) {
-				 if (sourcesBefore >= 8) {
-					 buffer += `<li>${sourceGen} (move is level-up/tutor/TM/HM/egg in Gen ${sourcesBefore})`;
-				 } else {
-					 buffer += `<li>${sourceGen} (move is level-up/tutor/TM/HM in Gen ${sourcesBefore})`;
-				 }
-			 } else if (gen >= 8) {
-				 const orEarlier = sourcesBefore < gen ? ` or level-up/tutor/TM/HM in Gen ${sourcesBefore}${
-					 sourcesBefore < 7 ? " to 7" : ""
-				 }` : ``;
-				 buffer += `<li>${sourceGen} (all moves are level-up/tutor/TM/HM/egg in Gen ${sourcesBefore}${orEarlier})`;
-			 } else {
-				 buffer += `<li>${sourceGen} (all moves are level-up/tutor/TM/HM in Gen ${Math.min(gen, sourcesBefore)}${sourcesBefore < gen ? " to " + gen : ""})`;
-			 }
-		 }
-		 if (setSources.babyOnly && sourcesBefore) {
-			 buffer += `<li>must be obtained as ` + Dex.species.get(setSources.babyOnly).name;
-		 }
-		 buffer += "</ul>";
-	 } else if (problems.length >= 1) {
-		 const expectedError = `${species.name} can't learn ${moveNames[0]}.`;
-		 if (problems.length > 1 || moveNames.length > 1 || problems[0] !== expectedError) {
-			 buffer += ` because:<ul class="message-learn-list">`;
-			 buffer += `<li>` + problems.join(`</li><li>`) + `</li>`;
-			 buffer += `</ul>`;
-		 }
-	 }
-	 return {reply: buffer};
- }
- 
- function runSearch(query: {target: string, cmd: string, canAll: boolean, message: string}) {
-	 return PM.query(query);
- }
- 
- /*********************************************************
-  * Process manager
-  *********************************************************/
- 
- export const PM = new ProcessManager.QueryProcessManager<AnyObject, AnyObject>(module, query => {
-	 try {
-		 if (Config.debugdexsearchprocesses && process.send) {
-			 process.send('DEBUG\n' + JSON.stringify(query));
-		 }
-		 switch (query.cmd) {
-		 case 'randpoke':
-		 case 'dexsearch':
-			 return runDexsearch(query.target, query.cmd, query.canAll, query.message, false);
-		 case 'randmove':
-		 case 'movesearch':
-			 return runMovesearch(query.target, query.cmd, query.canAll, query.message, false);
-		 case 'itemsearch':
-			 return runItemsearch(query.target, query.cmd, query.canAll, query.message);
-		 case 'abilitysearch':
-			 return runAbilitysearch(query.target, query.cmd, query.canAll, query.message);
-		 case 'learn':
-			 return runLearn(query.target, query.cmd, query.canAll, query.message);
-		 default:
-			 throw new Error(`Unrecognized Dexsearch command "${query.cmd}"`);
-		 }
-	 } catch (err) {
-		 Monitor.crashlog(err, 'A search query', query);
-	 }
-	 return {
-		 error: "Sorry! Our search engine crashed on your query. We've been automatically notified and will fix this crash.",
-	 };
- });
- 
- if (!PM.isParentProcess) {
-	 // This is a child process!
-	 global.Config = require('../config-loader').Config;
-	 global.Monitor = {
-		 crashlog(error: Error, source = 'A datasearch process', details: AnyObject | null = null) {
-			 const repr = JSON.stringify([error.name, error.message, source, details]);
-			 process.send!(`THROW\n@!!@${repr}\n${error.stack}`);
-		 },
-	 };
-	 if (Config.crashguard) {
-		 process.on('uncaughtException', err => {
-			 Monitor.crashlog(err, 'A dexsearch process');
-		 });
-	 }
- 
-	 global.Dex = require('../../sim/dex').Dex;
-	 global.toID = Dex.toID;
-	 Dex.includeData();
- 
-	 // @ts-ignore
-	 require('../../lib/repl').Repl.start('dexsearch', cmd => eval(cmd)); // eslint-disable-line no-eval
- } else {
-	 PM.spawn(MAX_PROCESSES);
- }
- 
- export const testables = {
-	 runAbilitysearch: (target: string, cmd: string, canAll: boolean, message: string) =>
-		 runAbilitysearch(target, cmd, canAll, message),
-	 runDexsearch: (target: string, cmd: string, canAll: boolean, message: string) =>
-		 runDexsearch(target, cmd, canAll, message, true),
-	 runMovesearch: (target: string, cmd: string, canAll: boolean, message: string) =>
-		 runMovesearch(target, cmd, canAll, message, true),
- };
- 
+import {ProcessManager, Utils} from '../../lib';
+import {TeamValidator} from '../../sim/team-validator';
+import {Chat} from '../chat';
+
+interface DexOrGroup {
+	abilities: {[k: string]: boolean};
+	tiers: {[k: string]: boolean};
+	doublesTiers: {[k: string]: boolean};
+	colors: {[k: string]: boolean};
+	'egg groups': {[k: string]: boolean};
+	formes: {[k: string]: boolean};
+	gens: {[k: string]: boolean};
+	moves: {[k: string]: boolean};
+	types: {[k: string]: boolean};
+	resists: {[k: string]: boolean};
+	weak: {[k: string]: boolean};
+	stats: {[k: string]: {[k in Direction]: number}};
+	skip: boolean;
+}
+
+interface MoveOrGroup {
+	types: {[k: string]: boolean};
+	categories: {[k: string]: boolean};
+	contestTypes: {[k: string]: boolean};
+	flags: {[k: string]: boolean};
+	gens: {[k: string]: boolean};
+	other: {[k: string]: boolean};
+	mon: {[k: string]: boolean};
+	property: {[k: string]: {[k in Direction]: number}};
+	boost: {[k: string]: boolean};
+	lower: {[k: string]: boolean};
+	zboost: {[k: string]: boolean};
+	status: {[k: string]: boolean};
+	volatileStatus: {[k: string]: boolean};
+	targets: {[k: string]: boolean};
+	skip: boolean;
+	multihit: boolean;
+}
+
+type Direction = 'less' | 'greater' | 'equal';
+
+const MAX_PROCESSES = 1;
+const RESULTS_MAX_LENGTH = 10;
+const MAX_RANDOM_RESULTS = 30;
+const dexesHelp = Object.keys((global.Dex?.dexes || {})).filter(x => x !== 'sourceMaps').join('</code>, <code>');
+
+function escapeHTML(str?: string) {
+	if (!str) return '';
+	return ('' + str)
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&apos;')
+		.replace(/\//g, '&#x2f;');
+}
+
+function toListString(arr: string[]) {
+	if (!arr.length) return '';
+	if (arr.length === 1) return arr[0];
+	if (arr.length === 2) return `${arr[0]} and ${arr[1]}`;
+	return `${arr.slice(0, -1).join(", ")}, and ${arr.slice(-1)[0]}`;
+}
+
+function checkCanAll(room: Room | null) {
+	if (!room) return false; // no, no good reason for using `all` in pms
+	const {isPersonal, isHelp} = room.settings;
+	// allowed if it's a groupchat
+	return !room.battle && !!isPersonal && !isHelp;
+}
+
+export const commands: Chat.ChatCommands = {
+	ds: 'dexsearch',
+	ds1: 'dexsearch',
+	ds2: 'dexsearch',
+	ds3: 'dexsearch',
+	ds4: 'dexsearch',
+	ds5: 'dexsearch',
+	ds6: 'dexsearch',
+	ds7: 'dexsearch',
+	ds8: 'dexsearch',
+	dsearch: 'dexsearch',
+	nds: 'dexsearch',
+	async dexsearch(target, room, user, connection, cmd, message) {
+		this.checkBroadcast();
+		if (!target) return this.parse('/help dexsearch');
+		if (target.length > 300) return this.errorReply('Dexsearch queries may not be longer than 300 characters.');
+		const targetGen = parseInt(cmd[cmd.length - 1]);
+		if (targetGen) target += `, mod=gen${targetGen}`;
+		const split = target.split(',').map(term => term.trim());
+		const index = split.findIndex(x => /^max\s*gen/i.test(x));
+		if (index >= 0) {
+			const genNum = parseInt(/\d*$/.exec(split[index])?.[0] || '');
+			if (!isNaN(genNum) && !(genNum < 1 || genNum > Dex.gen)) {
+				split[index] = `mod=gen${genNum}`;
+				target = split.join(',');
+			}
+		}
+		if (!target.includes('mod=')) {
+			const dex = this.extractFormat(room?.settings.defaultFormat || room?.battle?.format).dex;
+			if (dex) target += `, mod=${dex.currentMod}`;
+		}
+		if (cmd === 'nds') target += ', natdex';
+		const response = await runSearch({
+			target,
+			cmd: 'dexsearch',
+			canAll: !this.broadcastMessage || checkCanAll(room),
+			message: (this.broadcastMessage ? "" : message),
+		});
+		if (!response.error && !this.runBroadcast()) return;
+		if (response.error) {
+			throw new Chat.ErrorMessage(response.error);
+		} else if (response.reply) {
+			this.sendReplyBox(response.reply);
+		} else if (response.dt) {
+			(Chat.commands.data as Chat.ChatHandler).call(
+				this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
+			);
+		}
+	},
+	dexsearchhelp() {
+		this.sendReply(
+			`|html| <details class="readmore"><summary><code>/dexsearch [parameter], [parameter], [parameter], ...</code>: searches for Pok\u00e9mon that fulfill the selected criteria<br/>` +
+			`Search categories are: type, tier, color, moves, ability, gen, resists, weak, recovery, zrecovery, priority, stat, weight, height, egg group, pivot.<br/>` +
+			`Valid colors are: green, red, blue, white, brown, yellow, purple, pink, gray and black.<br/>` +
+			`Valid tiers are: Uber/OU/UUBL/UU/RUBL/RU/NUBL/NU/PUBL/PU/ZU/NFE/LC/CAP/CAP NFE/CAP LC.<br/>` +
+			`Valid doubles tiers are: DUber/DOU/DBL/DUU/DNU.</summary>` +
+			`Types can be searched for by either having the type precede <code>type</code> or just using the type itself as a parameter; e.g., both <code>fire type</code> and <code>fire</code> show all Fire types; however, using <code>psychic</code> as a parameter will show all Pok\u00e9mon that learn the move Psychic and not Psychic types.<br/>` +
+			`<code>resists</code> followed by a type or move will show Pok\u00e9mon that resist that typing or move (e.g. <code>resists normal</code>).<br/>` +
+			`<code>weak</code> followed by a type or move will show Pok\u00e9mon that are weak to that typing or move (e.g. <code>weak fire</code>).<br/>` +
+			`<code>asc</code> or <code>desc</code> following a stat will show the Pok\u00e9mon in ascending or descending order of that stat respectively (e.g. <code>speed asc</code>).<br/>` +
+			`Inequality ranges use the characters <code>>=</code> for <code>≥</code> and <code><=</code> for <code>≤</code>; e.g., <code>hp <= 95</code> searches all Pok\u00e9mon with HP less than or equal to 95.<br/>` +
+			`Parameters can be excluded through the use of <code>!</code>; e.g., <code>!water type</code> excludes all Water types.<br/>` +
+			`The parameter <code>mega</code> can be added to search for Mega Evolutions only, the parameter <code>gmax</code> can be added to search for Pokemon capable of Gigantamaxing only, and the parameter <code>Fully Evolved</code> (or <code>FE</code>) can be added to search for fully-evolved Pok\u00e9mon.<br/>` +
+			`<code>Alola</code>, <code>Galar</code>, <code>Therian</code>, <code>Totem</code>, or <code>Primal</code> can be used as parameters to search for those formes.<br/>` +
+			`Parameters separated with <code>|</code> will be searched as alternatives for each other; e.g., <code>trick | switcheroo</code> searches for all Pok\u00e9mon that learn either Trick or Switcheroo.<br/>` +
+			`You can search for info in a specific generation by appending the generation to ds or by using the <code>maxgen</code> keyword; e.g. <code>/ds1 normal</code> or <code>/ds normal, maxgen1</code> searches for all Pok\u00e9mon that were Normal type in Generation I.<br/>` +
+			`You can search for info in a specific mod by using <code>mod=[mod name]</code>; e.g. <code>/nds mod=ssb, protean</code>. All valid mod names are: <code>${dexesHelp}</code><br />` +
+			`<code>/dexsearch</code> will search the Galar Pokedex; you can search the National Pokedex by using <code>/nds</code> or by adding <code>natdex</code> as a parameter.<br/>` +
+			`Searching for a Pok\u00e9mon with both egg group and type parameters can be differentiated by adding the suffix <code>group</code> onto the egg group parameter; e.g., seaching for <code>grass, grass group</code> will show all Grass types in the Grass egg group.<br/>` +
+			`The parameter <code>monotype</code> will only show Pok\u00e9mon that are single-typed.<br/>` +
+			`The order of the parameters does not matter.<br/>`
+		);
+	},
+
+	rollmove: 'randommove',
+	randmove: 'randommove',
+	async randommove(target, room, user, connection, cmd, message) {
+		this.checkBroadcast(true);
+		target = target.slice(0, 300);
+		const targets = target.split(",");
+		const targetsBuffer = [];
+		let qty;
+		for (const arg of targets) {
+			if (!arg) continue;
+			const num = Number(arg);
+			if (Number.isInteger(num)) {
+				if (qty) throw new Chat.ErrorMessage("Only specify the number of Pok\u00e9mon Moves once.");
+				qty = num;
+				if (qty < 1 || MAX_RANDOM_RESULTS < qty) {
+					throw new Chat.ErrorMessage(`Number of random Pok\u00e9mon Moves must be between 1 and ${MAX_RANDOM_RESULTS}.`);
+				}
+				targetsBuffer.push(`random${qty}`);
+			} else {
+				targetsBuffer.push(arg);
+			}
+		}
+		if (!qty) targetsBuffer.push("random1");
+
+		const response = await runSearch({
+			target: targetsBuffer.join(","),
+			cmd: 'randmove',
+			canAll: !this.broadcastMessage || checkCanAll(room),
+			message: (this.broadcastMessage ? "" : message),
+		});
+		if (!response.error && !this.runBroadcast(true)) return;
+		if (response.error) {
+			throw new Chat.ErrorMessage(response.error);
+		} else if (response.reply) {
+			this.sendReplyBox(response.reply);
+		} else if (response.dt) {
+			(Chat.commands.data as Chat.ChatHandler).call(
+				this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
+			);
+		}
+	},
+	randommovehelp: [
+		`/randommove - Generates random Pok\u00e9mon Moves based on given search conditions.`,
+		`/randommove uses the same parameters as /movesearch (see '/help ms').`,
+		`Adding a number as a parameter returns that many random Pok\u00e9mon Moves, e.g., '/randmove 6' returns 6 random Pok\u00e9mon Moves.`,
+	],
+
+	rollpokemon: 'randompokemon',
+	randpoke: 'randompokemon',
+	async randompokemon(target, room, user, connection, cmd, message) {
+		this.checkBroadcast(true);
+		target = target.slice(0, 300);
+		const targets = target.split(",");
+		const targetsBuffer = [];
+		let qty;
+		for (const arg of targets) {
+			if (!arg) continue;
+			const num = Number(arg);
+			if (Number.isInteger(num)) {
+				if (qty) throw new Chat.ErrorMessage("Only specify the number of Pok\u00e9mon once.");
+				qty = num;
+				if (qty < 1 || MAX_RANDOM_RESULTS < qty) {
+					throw new Chat.ErrorMessage(`Number of random Pok\u00e9mon must be between 1 and ${MAX_RANDOM_RESULTS}.`);
+				}
+				targetsBuffer.push(`random${qty}`);
+			} else {
+				targetsBuffer.push(arg);
+			}
+		}
+		if (!qty) targetsBuffer.push("random1");
+
+		const response = await runSearch({
+			target: targetsBuffer.join(","),
+			cmd: 'randpoke',
+			canAll: !this.broadcastMessage || checkCanAll(room),
+			message: (this.broadcastMessage ? "" : message),
+		});
+		if (!response.error && !this.runBroadcast(true)) return;
+		if (response.error) {
+			throw new Chat.ErrorMessage(response.error);
+		} else if (response.reply) {
+			this.sendReplyBox(response.reply);
+		} else if (response.dt) {
+			(Chat.commands.data as Chat.ChatHandler).call(
+				this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
+			);
+		}
+	},
+	randompokemonhelp: [
+		`/randompokemon - Generates random Pok\u00e9mon based on given search conditions.`,
+		`/randompokemon uses the same parameters as /dexsearch (see '/help ds').`,
+		`Adding a number as a parameter returns that many random Pok\u00e9mon, e.g., '/randpoke 6' returns 6 random Pok\u00e9mon.`,
+	],
+
+	ms: 'movesearch',
+	ms1: 'movesearch',
+	ms2: 'movesearch',
+	ms3: 'movesearch',
+	ms4: 'movesearch',
+	ms5: 'movesearch',
+	ms6: 'movesearch',
+	ms7: 'movesearch',
+	ms8: 'movesearch',
+	msearch: 'movesearch',
+	nms: 'movesearch',
+	async movesearch(target, room, user, connection, cmd, message) {
+		this.checkBroadcast();
+		if (!target) return this.parse('/help movesearch');
+		target = target.slice(0, 300);
+		const targetGen = parseInt(cmd[cmd.length - 1]);
+		if (targetGen) target += `, mod=gen${targetGen}`;
+		const split = target.split(',').map(term => term.trim());
+		const index = split.findIndex(x => /^max\s*gen/i.test(x));
+		if (index >= 0) {
+			const genNum = parseInt(/\d*$/.exec(split[index])?.[0] || '');
+			if (!isNaN(genNum) && !(genNum < 1 || genNum > Dex.gen)) {
+				split[index] = `mod=gen${genNum}`;
+				target = split.join(',');
+			}
+		}
+		if (!target.includes('mod=')) {
+			const dex = this.extractFormat(room?.settings.defaultFormat || room?.battle?.format).dex;
+			if (dex) target += `, mod=${dex.currentMod}`;
+		}
+		if (cmd === 'nms') target += ', natdex';
+		const response = await runSearch({
+			target,
+			cmd: 'movesearch',
+			canAll: !this.broadcastMessage || checkCanAll(room),
+			message: (this.broadcastMessage ? "" : message),
+		});
+		if (!response.error && !this.runBroadcast()) return;
+		if (response.error) {
+			throw new Chat.ErrorMessage(response.error);
+		} else if (response.reply) {
+			this.sendReplyBox(response.reply);
+		} else if (response.dt) {
+			(Chat.commands.data as Chat.ChatHandler).call(
+				this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
+			);
+		}
+	},
+	movesearchhelp() {
+		this.sendReply(
+			`|html| <details class="readmore"><summary><code>/movesearch [parameter], [parameter], [parameter], ...</code>: searches for moves that fulfill the selected criteria.<br/>` +
+			`Search categories are: type, category, gen, contest condition, flag, status inflicted, type boosted, Pok\u00e9mon targeted, and numeric range for base power, pp, priority, and accuracy.<br/>` +
+			`Types can be followed by <code> type</code> for clarity; e.g., <code>dragon type</code>.<br/>` +
+			`Stat boosts must be preceded with <code>boosts </code>, and stat-lowering moves with <code>lowers </code>; e.g., <code>boosts attack</code> searches for moves that boost the Attack stat of either Pok\u00e9mon.<br/>` +
+			`Z-stat boosts must be preceded with <code>zboosts </code>; e.g., <code>zboosts accuracy</code> searches for all Status moves with Z-Effects that boost the user's accuracy.</summary>` +
+			`Moves that have a Z-Effect of fully restoring the user's health can be searched for with <code>zrecovery</code>.<br/>` +
+			`Move targets must be preceded with <code>targets </code>; e.g., <code>targets user</code> searches for moves that target the user.<br/>` +
+			`Valid move targets are: one ally, user or ally, one adjacent opponent, all Pokemon, all adjacent Pokemon, all adjacent opponents, user and allies, user's side, user's team, any Pokemon, opponent's side, one adjacent Pokemon, random adjacent Pokemon, scripted, and user.<br/>` +
+			`Inequality ranges use the characters <code>></code> and <code><</code>.<br/>` +
+			`Parameters can be excluded through the use of <code>!</code>; e.g., <code>!water type</code> excludes all Water-type moves.<br/>` +
+			`<code>asc</code> or <code>desc</code> following a move property will arrange the names in ascending or descending order of that property, respectively; e.g., <code>basepower asc</code> will arrange moves in ascending order of their base powers.<br/>` +
+			`Valid flags are: bypasssub (bypasses substitute), bite, bullet, charge, contact, dance, defrost, gravity, mirror (reflected by mirror move), ohko, powder, priority, protect, pulse, punch, recharge, recovery, reflectable, secondary, snatch, sound, zmove, pivot, and multi-hit.<br/>` +
+			`A search that includes <code>!protect</code> will show all moves that bypass protection.<br/>` +
+			`<code>protection</code> as a parameter will search protection moves like Protect, Detect, etc.<br/>` +
+			`<code>max</code> or <code>gmax</code> as parameters will search for Max Moves and G-Max moves respectively.<br/>` +
+			`Parameters separated with <code>|</code> will be searched as alternatives for each other; e.g., <code>fire | water</code> searches for all moves that are either Fire type or Water type.<br/>` +
+			`If a Pok\u00e9mon is included as a parameter, only moves from its movepool will be included in the search.<br/>` +
+			`You can search for info in a specific generation by appending the generation to ms; e.g. <code>/ms1 normal</code> searches for all moves that were Normal type in Generation I.<br/>` +
+			`You can search for info in a specific mod by using <code>mod=[mod name]</code>; e.g. <code>/nms mod=ssb, dark, bp=100</code>. All valid mod names are: <code>${dexesHelp}</code><br />` +
+			`<code>/ms</code> will search the Galar Moves; you can search the National Moves by using <code>/nms</code> or by adding <code>natdex</code> as a parameter.<br/>` +
+			`The order of the parameters does not matter.`
+		);
+	},
+
+	isearch: 'itemsearch',
+	is: 'itemsearch',
+	is2: 'itemsearch',
+	is3: 'itemsearch',
+	is4: 'itemsearch',
+	is5: 'itemsearch',
+	is6: 'itemsearch',
+	is7: 'itemsearch',
+	is8: 'itemsearch',
+	async itemsearch(target, room, user, connection, cmd, message) {
+		this.checkBroadcast();
+		if (!target) return this.parse('/help itemsearch');
+		target = target.slice(0, 300);
+		const targetGen = parseInt(cmd[cmd.length - 1]);
+		if (targetGen) target += ` maxgen${targetGen}`;
+
+		const response = await runSearch({
+			target,
+			cmd: 'itemsearch',
+			canAll: !this.broadcastMessage || checkCanAll(room),
+			message: (this.broadcastMessage ? "" : message),
+		});
+		if (!response.error && !this.runBroadcast()) return;
+		if (response.error) {
+			throw new Chat.ErrorMessage(response.error);
+		} else if (response.reply) {
+			this.sendReplyBox(response.reply);
+		} else if (response.dt) {
+			(Chat.commands.data as Chat.ChatHandler).call(
+				this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
+			);
+		}
+	},
+	itemsearchhelp() {
+		this.sendReplyBox(
+			`<code>/itemsearch [item description]</code>: finds items that match the given keywords.<br/>` +
+			`This command accepts natural language. (tip: fewer words tend to work better)<br/>` +
+			`The <code>gen</code> keyword can be used to search for items introduced in a given generation; e.g., <code>/is gen4</code> searches for items introduced in Generation 4.<br/>` +
+			`To search for items within a generation, append the generation to <code>/is</code> or use the <code>maxgen</code> keyword; e.g., <code>/is4 Water-type</code> or <code>/is maxgen4 Water-type</code> searches for items whose Generation 4 description includes "Water-type".<br/>` +
+			`Searches with <code>fling</code> in them will find items with the specified Fling behavior.<br/>` +
+			`Searches with <code>natural gift</code> in them will find items with the specified Natural Gift behavior.`
+		);
+	},
+
+	asearch: 'abilitysearch',
+	as: 'abilitysearch',
+	as3: 'abilitysearch',
+	as4: 'abilitysearch',
+	as5: 'abilitysearch',
+	as6: 'abilitysearch',
+	as7: 'abilitysearch',
+	as8: 'abilitysearch',
+	async abilitysearch(target, room, user, connection, cmd, message) {
+		this.checkBroadcast();
+		if (!target) return this.parse('/help abilitysearch');
+		target = target.slice(0, 300);
+		const targetGen = parseInt(cmd[cmd.length - 1]);
+		if (targetGen) target += ` maxgen${targetGen}`;
+
+		const response = await runSearch({
+			target,
+			cmd: 'abilitysearch',
+			canAll: !this.broadcastMessage || checkCanAll(room),
+			message: (this.broadcastMessage ? "" : message),
+		});
+		if (!response.error && !this.runBroadcast()) return;
+		if (response.error) {
+			throw new Chat.ErrorMessage(response.error);
+		} else if (response.reply) {
+			this.sendReplyBox(response.reply);
+		} else if (response.dt) {
+			(Chat.commands.data as Chat.ChatHandler).call(
+				this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
+			);
+		}
+	},
+	abilitysearchhelp() {
+		this.sendReplyBox(
+			`<code>/abilitysearch [ability description]</code>: finds abilities that match the given keywords.<br/>` +
+			`This command accepts natural language. (tip: fewer words tend to work better)<br/>` +
+			`The <code>gen</code> keyword can be used to search for abilities introduced in a given generation; e.g., <code>/as gen4</code> searches for abilities introduced in Generation 4.<br/>` +
+			`To search for abilities within a generation, append the generation to <code>/as</code> or use the <code>maxgen</code> keyword; e.g., <code>/as4 Water-type</code> or <code>/as maxgen4 Water-type</code> searches for abilities whose Generation 4 description includes "Water-type".`
+		);
+	},
+
+	learnset: 'learn',
+	learnall: 'learn',
+	learn5: 'learn',
+	rbylearn: 'learn',
+	gsclearn: 'learn',
+	advlearn: 'learn',
+	dpplearn: 'learn',
+	bw2learn: 'learn',
+	oraslearn: 'learn',
+	usumlearn: 'learn',
+	async learn(target, room, user, connection, cmd, message) {
+		if (!target) return this.parse('/help learn');
+		if (target.length > 300) throw new Chat.ErrorMessage(`Query too long.`);
+
+		const GENS: {[k: string]: number} = {rby: 1, gsc: 2, adv: 3, dpp: 4, bw2: 5, oras: 6, usum: 7};
+		const cmdGen = GENS[cmd.slice(0, -5)];
+		if (cmdGen) target = `gen${cmdGen}, ${target}`;
+
+		this.checkBroadcast();
+		const {format, dex, targets} = this.splitFormat(target);
+
+		const formatid = format ? format.id : dex.currentMod;
+		if (cmd === 'learn5') targets.unshift('level5');
+
+		const response = await runSearch({
+			target: targets.join(','),
+			cmd: 'learn',
+			canAll: !this.broadcastMessage || checkCanAll(room),
+			message: formatid,
+		});
+		if (!response.error && !this.runBroadcast()) return;
+		if (response.error) {
+			throw new Chat.ErrorMessage(response.error);
+		} else if (response.reply) {
+			this.sendReplyBox(response.reply);
+		}
+	},
+	learnhelp: [
+		`/learn [ruleset], [pokemon], [move, move, ...] - Displays how the Pok\u00e9mon can learn the given moves, if it can at all.`,
+		`!learn [ruleset], [pokemon], [move, move, ...] - Show everyone that information. Requires: + % @ # &`,
+		`Specifying a ruleset is entirely optional. The ruleset can be a format, a generation (e.g.: gen3) or "min source gen [number]".`,
+		`A value of 'min source gen [number]' indicates that trading (or Pokémon Bank) from generations before [number] is not allowed.`,
+		`/learn5 displays how the Pok\u00e9mon can learn the given moves at level 5, if it can at all.`,
+		`/learnall displays all of the possible fathers for egg moves.`,
+		`/learn can also be prefixed by a generation acronym (e.g.: /dpplearn) to indicate which generation is used. Valid options are: rby gsc adv dpp bw2 oras usum`,
+	],
+};
+
+function getMod(target: string) {
+	const arr = target.split(',').map(x => x.trim());
+	const modTerm = arr.find(x => {
+		const sanitizedStr = x.toLowerCase().replace(/[^a-z0-9=]+/g, '');
+		return sanitizedStr.startsWith('mod=') && Dex.dexes[toID(sanitizedStr.split('=')[1])];
+	});
+	const count = arr.filter(x => {
+		const sanitizedStr = x.toLowerCase().replace(/[^a-z0-9=]+/g, '');
+		return sanitizedStr.startsWith('mod=');
+	}).length;
+	if (modTerm) arr.splice(arr.indexOf(modTerm), 1);
+	return {splitTarget: arr, usedMod: modTerm ? toID(modTerm.split(/ ?= ?/)[1]) : undefined, count};
+}
+
+function runDexsearch(target: string, cmd: string, canAll: boolean, message: string, isTest: boolean) {
+	const searches: DexOrGroup[] = [];
+	const {splitTarget, usedMod, count: c} = getMod(target);
+	if (c > 1) {
+		return {error: `You can't run searches for multiple mods.`};
+	}
+
+	const mod = Dex.mod(usedMod || 'base');
+	const allTiers: {[k: string]: TierTypes.Singles | TierTypes.Other} = Object.assign(Object.create(null), {
+		anythinggoes: 'AG', ag: 'AG',
+		uber: 'Uber', ubers: 'Uber', ou: 'OU',
+		uubl: 'UUBL', uu: 'UU',
+		rubl: 'RUBL', ru: 'RU',
+		nubl: 'NUBL', nu: 'NU',
+		publ: 'PUBL', pu: 'PU', zu: '(PU)',
+		nfe: 'NFE',
+		lc: 'LC',
+		cap: 'CAP', caplc: 'CAP LC', capnfe: 'CAP NFE',
+	});
+	const allDoublesTiers: {[k: string]: TierTypes.Singles | TierTypes.Other} = Object.assign(Object.create(null), {
+		doublesubers: 'DUber', doublesuber: 'DUber', duber: 'DUber', dubers: 'DUber',
+		doublesou: 'DOU', dou: 'DOU',
+		doublesbl: 'DBL', dbl: 'DBL',
+		doublesuu: 'DUU', duu: 'DUU',
+		doublesnu: '(DUU)', dnu: '(DUU)',
+	});
+	const allTypes = Object.create(null);
+	for (const type of mod.types.all()) {
+		allTypes[type.id] = type.name;
+	}
+	const allColors = ['green', 'red', 'blue', 'white', 'brown', 'yellow', 'purple', 'pink', 'gray', 'black'];
+	const allEggGroups: {[k: string]: string} = Object.assign(Object.create(null), {
+		amorphous: 'Amorphous',
+		bug: 'Bug',
+		ditto: 'Ditto',
+		dragon: 'Dragon',
+		fairy: 'Fairy',
+		field: 'Field',
+		flying: 'Flying',
+		grass: 'Grass',
+		humanlike: 'Human-Like',
+		mineral: 'Mineral',
+		monster: 'Monster',
+		undiscovered: 'Undiscovered',
+		water1: 'Water 1',
+		water2: 'Water 2',
+		water3: 'Water 3',
+	});
+	const allFormes = ['alola', 'galar', 'primal', 'therian', 'totem'];
+	const allStats = ['hp', 'atk', 'def', 'spa', 'spd', 'spe', 'bst', 'weight', 'height', 'gen'];
+	const allStatAliases: {[k: string]: string} = {
+		attack: 'atk', defense: 'def', specialattack: 'spa', spc: 'spa', special: 'spa', spatk: 'spa',
+		specialdefense: 'spd', spdef: 'spd', speed: 'spe', wt: 'weight', ht: 'height', generation: 'gen',
+	};
+	let showAll = false;
+	let sort = null;
+	let megaSearch = null;
+	let gmaxSearch = null;
+	let tierSearch = null;
+	let capSearch: boolean | null = null;
+	let nationalSearch = null;
+	let fullyEvolvedSearch = null;
+	let singleTypeSearch = null;
+	let randomOutput = 0;
+	const validParameter = (cat: string, param: string, isNotSearch: boolean, input: string) => {
+		const uniqueTraits = ['colors', 'gens'];
+		for (const group of searches) {
+			const g = group[cat as keyof DexOrGroup];
+			if (g === undefined) continue;
+			if (typeof g !== 'boolean' && g[param] === undefined) {
+				if (uniqueTraits.includes(cat)) {
+					for (const currentParam in g) {
+						if (g[currentParam] !== isNotSearch && !isNotSearch) return `A Pok&eacute;mon cannot have multiple ${cat}.`;
+					}
+				}
+				continue;
+			}
+			if (typeof g !== 'boolean' && g[param] === isNotSearch) {
+				return `A search cannot both include and exclude '${input}'.`;
+			} else {
+				return `The search included '${(isNotSearch ? "!" : "") + input}' more than once.`;
+			}
+		}
+		return false;
+	};
+
+	for (const andGroup of splitTarget) {
+		const orGroup: DexOrGroup = {
+			abilities: {}, tiers: {}, doublesTiers: {}, colors: {}, 'egg groups': {}, formes: {},
+			gens: {}, moves: {}, types: {}, resists: {}, weak: {}, stats: {}, skip: false,
+		};
+		const parameters = andGroup.split("|");
+		if (parameters.length > 3) return {error: "No more than 3 alternatives for each parameter may be used."};
+		for (const parameter of parameters) {
+			let isNotSearch = false;
+			target = parameter.trim().toLowerCase();
+			if (target.startsWith('!')) {
+				isNotSearch = true;
+				target = target.substr(1);
+			}
+
+			const targetAbility = mod.abilities.get(target);
+			if (targetAbility.exists) {
+				const invalid = validParameter("abilities", targetAbility.id, isNotSearch, targetAbility.name);
+				if (invalid) return {error: invalid};
+				orGroup.abilities[targetAbility.name] = !isNotSearch;
+				continue;
+			}
+
+			if (toID(target) in allTiers) {
+				target = allTiers[toID(target)];
+				if (target.startsWith("CAP")) {
+					if (capSearch === isNotSearch) return {error: "A search cannot both include and exclude CAP tiers."};
+					capSearch = !isNotSearch;
+				}
+				const invalid = validParameter("tiers", target, isNotSearch, target);
+				if (invalid) return {error: invalid};
+				tierSearch = tierSearch || !isNotSearch;
+				orGroup.tiers[target] = !isNotSearch;
+				continue;
+			}
+
+			if (toID(target) in allDoublesTiers) {
+				target = allDoublesTiers[toID(target)];
+				const invalid = validParameter("doubles tiers", target, isNotSearch, target);
+				if (invalid) return {error: invalid};
+				tierSearch = tierSearch || !isNotSearch;
+				orGroup.doublesTiers[target] = !isNotSearch;
+				continue;
+			}
+
+			if (allColors.includes(target)) {
+				target = target.charAt(0).toUpperCase() + target.slice(1);
+				const invalid = validParameter("colors", target, isNotSearch, target);
+				if (invalid) return {error: invalid};
+				orGroup.colors[target] = !isNotSearch;
+				continue;
+			}
+
+			const targetMove = mod.moves.get(target);
+			if (targetMove.exists) {
+				const invalid = validParameter("moves", targetMove.id, isNotSearch, target);
+				if (invalid) return {error: invalid};
+				orGroup.moves[targetMove.id] = !isNotSearch;
+				continue;
+			}
+
+			let targetType;
+			if (target.endsWith('type')) {
+				targetType = toID(target.substring(0, target.indexOf('type')));
+			} else {
+				targetType = toID(target);
+			}
+			if (targetType in allTypes) {
+				target = allTypes[targetType];
+				const invalid = validParameter("types", target, isNotSearch, target);
+				if (invalid) return {error: invalid};
+				if ((orGroup.types[target] && isNotSearch) || (orGroup.types[target] === false && !isNotSearch)) {
+					return {error: 'A search cannot both exclude and include a type.'};
+				}
+				orGroup.types[target] = !isNotSearch;
+				continue;
+			}
+
+			if (['mono', 'monotype'].includes(toID(target))) {
+				if (singleTypeSearch === isNotSearch) return {error: "A search cannot include and exclude 'monotype'."};
+				if (parameters.length > 1) return {error: "The parameter 'monotype' cannot have alternative parameters."};
+				singleTypeSearch = !isNotSearch;
+				orGroup.skip = true;
+				continue;
+			}
+
+			if (target === 'natdex') {
+				if (parameters.length > 1) return {error: "The parameter 'natdex' cannot have alternative parameters."};
+				nationalSearch = true;
+				orGroup.skip = true;
+				continue;
+			}
+
+			let groupIndex = target.indexOf('group');
+			if (groupIndex === -1) groupIndex = target.length;
+			if (groupIndex !== target.length || toID(target) in allEggGroups) {
+				target = toID(target.substring(0, groupIndex));
+				if (target in allEggGroups) {
+					target = allEggGroups[toID(target)];
+					const invalid = validParameter("egg groups", target, isNotSearch, target);
+					if (invalid) return {error: invalid};
+					orGroup['egg groups'][target] = !isNotSearch;
+					continue;
+				} else {
+					return {error: `'${target}' is not a recognized egg group.`};
+				}
+			}
+			if (toID(target) in allEggGroups) {
+				target = allEggGroups[toID(target)];
+				const invalid = validParameter("egg groups", target, isNotSearch, target);
+				if (invalid) return {error: invalid};
+				orGroup['egg groups'][target] = !isNotSearch;
+				continue;
+			}
+
+			let targetInt = 0;
+			if (target.substr(0, 1) === 'g' && Number.isInteger(parseFloat(target.substr(1)))) {
+				targetInt = parseInt(target.substr(1).trim());
+			} else if (target.substr(0, 3) === 'gen' && Number.isInteger(parseFloat(target.substr(3)))) {
+				targetInt = parseInt(target.substr(3).trim());
+			}
+			if (0 < targetInt && targetInt < 9) {
+				const invalid = validParameter("gens", String(targetInt), isNotSearch, target);
+				if (invalid) return {error: invalid};
+				orGroup.gens[targetInt] = !isNotSearch;
+				continue;
+			}
+
+			if (target.endsWith(' asc') || target.endsWith(' desc')) {
+				if (parameters.length > 1) {
+					return {error: `The parameter '${target.split(' ')[1]}' cannot have alternative parameters.`};
+				}
+				const stat = allStatAliases[toID(target.split(' ')[0])] || toID(target.split(' ')[0]);
+				if (!allStats.includes(stat)) return {error: `'${escapeHTML(target)}' did not contain a valid stat.`};
+				sort = `${stat}${target.endsWith(' asc') ? '+' : '-'}`;
+				orGroup.skip = true;
+				break;
+			}
+
+			if (target === 'all') {
+				if (!canAll) return {error: "A search with the parameter 'all' cannot be broadcast."};
+				if (parameters.length > 1) return {error: "The parameter 'all' cannot have alternative parameters."};
+				showAll = true;
+				orGroup.skip = true;
+				break;
+			}
+
+			if (target.substr(0, 6) === 'random' && cmd === 'randpoke') {
+				// Validation for this is in the /randpoke command
+				randomOutput = parseInt(target.substr(6));
+				orGroup.skip = true;
+				continue;
+			}
+
+			if (allFormes.includes(toID(target))) {
+				target = toID(target);
+				orGroup.formes[target] = !isNotSearch;
+				continue;
+			}
+
+			if (target === 'megas' || target === 'mega') {
+				if (megaSearch === isNotSearch) return {error: "A search cannot include and exclude 'mega'."};
+				if (parameters.length > 1) return {error: "The parameter 'mega' cannot have alternative parameters."};
+				megaSearch = !isNotSearch;
+				orGroup.skip = true;
+				break;
+			}
+
+			if (target === 'gmax' || target === 'gigantamax') {
+				if (gmaxSearch === isNotSearch) return {error: "A search cannot include and exclude 'gigantamax'."};
+				if (parameters.length > 1) return {error: "The parameter 'gigantamax' cannot have alternative parameters."};
+				gmaxSearch = !isNotSearch;
+				orGroup.skip = true;
+				break;
+			}
+
+			if (['fully evolved', 'fullyevolved', 'fe'].includes(target)) {
+				if (fullyEvolvedSearch === isNotSearch) return {error: "A search cannot include and exclude 'fully evolved'."};
+				if (parameters.length > 1) return {error: "The parameter 'fully evolved' cannot have alternative parameters."};
+				fullyEvolvedSearch = !isNotSearch;
+				orGroup.skip = true;
+				break;
+			}
+
+			if (target === 'recovery') {
+				const recoveryMoves = [
+					"healorder", "junglehealing", "lifedew", "milkdrink", "moonlight", "morningsun", "recover",
+					"roost", "shoreup", "slackoff", "softboiled", "strengthsap", "synthesis", "wish",
+				];
+				for (const move of recoveryMoves) {
+					const invalid = validParameter("moves", move, isNotSearch, target);
+					if (invalid) return {error: invalid};
+					if (isNotSearch) {
+						orGroup.skip = true;
+						const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
+						bufferObj.moves[move] = false;
+						searches.push(bufferObj as DexOrGroup);
+					} else {
+						orGroup.moves[move] = true;
+					}
+				}
+				continue;
+			}
+
+			if (target === 'zrecovery') {
+				const recoveryMoves = [
+					"aromatherapy", "bellydrum", "conversion2", "haze", "healbell", "mist",
+					"psychup", "refresh", "spite", "stockpile", "teleport", "transform",
+				];
+				for (const moveid of recoveryMoves) {
+					const invalid = validParameter("moves", moveid, isNotSearch, target);
+					if (invalid) return {error: invalid};
+					if (isNotSearch) {
+						orGroup.skip = true;
+						const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
+						bufferObj.moves[moveid] = false;
+						searches.push(bufferObj as DexOrGroup);
+					} else {
+						orGroup.moves[moveid] = true;
+					}
+				}
+				continue;
+			}
+
+			if (target === 'priority') {
+				for (const moveid in mod.data.Moves) {
+					const move = mod.moves.get(moveid);
+					if (move.category === "Status" || move.id === "bide") continue;
+					if (move.priority > 0) {
+						const invalid = validParameter("moves", moveid, isNotSearch, target);
+						if (invalid) return {error: invalid};
+						if (isNotSearch) {
+							orGroup.skip = true;
+							const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
+							bufferObj.moves[moveid] = false;
+							searches.push(bufferObj as DexOrGroup);
+						} else {
+							orGroup.moves[moveid] = true;
+						}
+					}
+				}
+				continue;
+			}
+
+			if (target.substr(0, 8) === 'resists ') {
+				const targetResist = target.substr(8, 1).toUpperCase() + target.substr(9);
+				if (mod.types.isName(targetResist)) {
+					const invalid = validParameter("resists", targetResist, isNotSearch, target);
+					if (invalid) return {error: invalid};
+					orGroup.resists[targetResist] = !isNotSearch;
+					continue;
+				} else {
+					if (toID(targetResist) in mod.data.Moves) {
+						const move = mod.moves.get(targetResist);
+						if (move.category === 'Status') {
+							return {error: `'${targetResist}' is a status move and can't be used with 'resists'.`};
+						} else {
+							const invalid = validParameter("resists", targetResist, isNotSearch, target);
+							if (invalid) return {error: invalid};
+							orGroup.resists[targetResist] = !isNotSearch;
+							continue;
+						}
+					} else {
+						return {error: `'${targetResist}' is not a recognized type or move.`};
+					}
+				}
+			}
+
+			if (target.substr(0, 5) === 'weak ') {
+				const targetWeak = target.substr(5, 1).toUpperCase() + target.substr(6);
+				if (mod.types.isName(targetWeak)) {
+					const invalid = validParameter("weak", targetWeak, isNotSearch, target);
+					if (invalid) return {error: invalid};
+					orGroup.weak[targetWeak] = !isNotSearch;
+					continue;
+				} else {
+					if (toID(targetWeak) in mod.data.Moves) {
+						const move = mod.moves.get(targetWeak);
+						if (move.category === 'Status') {
+							return {error: `'${targetWeak}' is a status move and can't be used with 'weak'.`};
+						} else {
+							const invalid = validParameter("weak", targetWeak, isNotSearch, target);
+							if (invalid) return {error: invalid};
+							orGroup.weak[targetWeak] = !isNotSearch;
+							continue;
+						}
+					} else {
+						return {error: `'${targetWeak}' is not a recognized type or move.`};
+					}
+				}
+			}
+
+			if (target === 'pivot') {
+				for (const move in mod.data.Moves) {
+					const moveData = mod.moves.get(move);
+					if (moveData.selfSwitch && moveData.id !== 'batonpass') {
+						const invalid = validParameter("moves", move, isNotSearch, target);
+						if (invalid) return {error: invalid};
+						if (isNotSearch) {
+							orGroup.skip = true;
+							const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
+							bufferObj.moves[move] = false;
+							searches.push(bufferObj as DexOrGroup);
+						} else {
+							orGroup.moves[move] = true;
+						}
+					}
+				}
+				continue;
+			}
+
+			const inequality = target.search(/>|<|=/);
+			let inequalityString;
+			if (inequality >= 0) {
+				if (isNotSearch) return {error: "You cannot use the negation symbol '!' in stat ranges."};
+				if (target.charAt(inequality + 1) === '=') {
+					inequalityString = target.substr(inequality, 2);
+				} else {
+					inequalityString = target.charAt(inequality);
+				}
+				const targetParts = target.replace(/\s/g, '').split(inequalityString);
+				let num;
+				let stat;
+				const directions: Direction[] = [];
+				if (!isNaN(parseFloat(targetParts[0]))) {
+					// e.g. 100 < spe
+					num = parseFloat(targetParts[0]);
+					stat = targetParts[1];
+					if (inequalityString.startsWith('>')) directions.push('less');
+					if (inequalityString.startsWith('<')) directions.push('greater');
+				} else if (!isNaN(parseFloat(targetParts[1]))) {
+					// e.g. spe > 100
+					num = parseFloat(targetParts[1]);
+					stat = targetParts[0];
+					if (inequalityString.startsWith('<')) directions.push('less');
+					if (inequalityString.startsWith('>')) directions.push('greater');
+				} else {
+					return {error: `No value given to compare with '${escapeHTML(target)}'.`};
+				}
+				if (inequalityString.endsWith('=')) directions.push('equal');
+				if (stat in allStatAliases) stat = allStatAliases[stat];
+				if (!allStats.includes(stat)) return {error: `'${escapeHTML(target)}' did not contain a valid stat.`};
+				if (!orGroup.stats[stat]) orGroup.stats[stat] = Object.create(null);
+				for (const direction of directions) {
+					if (orGroup.stats[stat][direction]) return {error: `Invalid stat range for ${stat}.`};
+					orGroup.stats[stat][direction] = num;
+				}
+				continue;
+			}
+			return {error: `'${escapeHTML(target)}' could not be found in any of the search categories.`};
+		}
+		if (!orGroup.skip) {
+			searches.push(orGroup);
+		}
+	}
+	if (
+		showAll && searches.length === 0 && singleTypeSearch === null &&
+		megaSearch === null && gmaxSearch === null && fullyEvolvedSearch === null && sort === null
+	) {
+		return {
+			error: "No search parameters other than 'all' were found. Try '/help dexsearch' for more information on this command.",
+		};
+	}
+
+	const dex: {[k: string]: Species} = {};
+	for (const species of mod.species.all()) {
+		const megaSearchResult = megaSearch === null || megaSearch === !!species.isMega;
+		const gmaxSearchResult = gmaxSearch === null || gmaxSearch === species.name.endsWith('-Gmax');
+		const fullyEvolvedSearchResult = fullyEvolvedSearch === null || fullyEvolvedSearch !== species.nfe;
+		if (
+			species.gen <= mod.gen &&
+			(
+				(
+					nationalSearch &&
+					species.isNonstandard &&
+					!["Custom", "Glitch", "Pokestar", "Future"].includes(species.isNonstandard)
+				) ||
+				(species.tier !== 'Unreleased' && species.tier !== 'Illegal')
+			) &&
+			(!species.tier.startsWith("CAP") || capSearch) &&
+			megaSearchResult &&
+			gmaxSearchResult &&
+			fullyEvolvedSearchResult
+		) {
+			dex[species.id] = species;
+		}
+	}
+
+	// Prioritize searches with the least alternatives.
+	const accumulateKeyCount = (count: number, searchData: AnyObject) =>
+		count + (typeof searchData === 'object' ? Object.keys(searchData).length : 0);
+	Utils.sortBy(searches, search => (
+		Object.values(search).reduce(accumulateKeyCount, 0)
+	));
+
+	for (const alts of searches) {
+		if (alts.skip) continue;
+		for (const mon in dex) {
+			let matched = false;
+			if (alts.gens && Object.keys(alts.gens).length) {
+				if (alts.gens[dex[mon].gen]) continue;
+				if (Object.values(alts.gens).includes(false) && alts.gens[dex[mon].gen] !== false) continue;
+			}
+
+			if (alts.colors && Object.keys(alts.colors).length) {
+				if (alts.colors[dex[mon].color]) continue;
+				if (Object.values(alts.colors).includes(false) && alts.colors[dex[mon].color] !== false) continue;
+			}
+
+			for (const eggGroup in alts['egg groups']) {
+				if (dex[mon].eggGroups.includes(eggGroup) === alts['egg groups'][eggGroup]) {
+					matched = true;
+					break;
+				}
+			}
+
+			if (alts.tiers && Object.keys(alts.tiers).length) {
+				let tier = dex[mon].tier;
+				if (nationalSearch) tier = dex[mon].natDexTier;
+				if (tier.startsWith('(') && tier !== '(PU)') tier = tier.slice(1, -1) as TierTypes.Singles;
+				// if (tier === 'New') tier = 'OU';
+				if (alts.tiers[tier]) continue;
+				if (Object.values(alts.tiers).includes(false) && alts.tiers[tier] !== false) continue;
+				// LC handling, checks for LC Pokemon in higher tiers that need to be handled separately,
+				// as well as event-only Pokemon that are not eligible for LC despite being the first stage
+				let format = Dex.formats.get('gen' + mod.gen + 'lc');
+				if (!format.exists) format = Dex.formats.get('gen8lc');
+				if (
+					alts.tiers.LC &&
+					!dex[mon].prevo &&
+					dex[mon].nfe &&
+					!Dex.formats.getRuleTable(format).isBannedSpecies(dex[mon])
+				) {
+					const lsetData = mod.species.getLearnsetData(dex[mon].id);
+					if (lsetData.exists && lsetData.eventData && lsetData.eventOnly) {
+						let validEvents = 0;
+						for (const event of lsetData.eventData) {
+							if (event.level && event.level <= 5) validEvents++;
+						}
+						if (validEvents > 0) continue;
+					} else {
+						continue;
+					}
+				}
+			}
+
+			if (alts.doublesTiers && Object.keys(alts.doublesTiers).length) {
+				let tier = dex[mon].doublesTier;
+				if (tier && tier.startsWith('(') && tier !== '(DUU)') tier = tier.slice(1, -1) as TierTypes.Doubles;
+				if (alts.doublesTiers[tier]) continue;
+				if (Object.values(alts.doublesTiers).includes(false) && alts.doublesTiers[tier] !== false) continue;
+			}
+
+			for (const type in alts.types) {
+				if (dex[mon].types.includes(type) === alts.types[type]) {
+					matched = true;
+					break;
+				}
+			}
+			if (matched) continue;
+
+			for (const targetResist in alts.resists) {
+				let effectiveness = 0;
+				const move = mod.moves.get(targetResist);
+				const attackingType = move.type || targetResist;
+				const notImmune = (move.id === 'thousandarrows' || mod.getImmunity(attackingType, dex[mon])) &&
+					!(move.id === 'sheercold' && mod.gen >= 7 && dex[mon].types.includes('Ice'));
+				if (notImmune && !move.ohko && move.damage === undefined) {
+					for (const defenderType of dex[mon].types) {
+						const baseMod = mod.getEffectiveness(attackingType, defenderType);
+						const moveMod = move.onEffectiveness?.call(
+							{dex: mod} as Battle, baseMod, null, defenderType, move as ActiveMove,
+						);
+						effectiveness += typeof moveMod === 'number' ? moveMod : baseMod;
+					}
+				}
+				if (!alts.resists[targetResist]) {
+					if (notImmune && effectiveness >= 0) matched = true;
+				} else {
+					if (!notImmune || effectiveness < 0) matched = true;
+				}
+			}
+			if (matched) continue;
+
+			for (const targetWeak in alts.weak) {
+				let effectiveness = 0;
+				const move = mod.moves.get(targetWeak);
+				const attackingType = move.type || targetWeak;
+				const notImmune = (move.id === 'thousandarrows' || mod.getImmunity(attackingType, dex[mon])) &&
+					!(move.id === 'sheercold' && mod.gen >= 7 && dex[mon].types.includes('Ice'));
+				if (notImmune && !move.ohko && move.damage === undefined) {
+					for (const defenderType of dex[mon].types) {
+						const baseMod = mod.getEffectiveness(attackingType, defenderType);
+						const moveMod = move.onEffectiveness?.call(
+							{dex: mod} as Battle, baseMod, null, defenderType, move as ActiveMove,
+						);
+						effectiveness += typeof moveMod === 'number' ? moveMod : baseMod;
+					}
+				}
+				if (alts.weak[targetWeak]) {
+					if (notImmune && effectiveness >= 1) matched = true;
+				} else {
+					if (!notImmune || effectiveness < 1) matched = true;
+				}
+			}
+			if (matched) continue;
+
+			for (const ability in alts.abilities) {
+				if (Object.values(dex[mon].abilities).includes(ability) === alts.abilities[ability]) {
+					matched = true;
+					break;
+				}
+			}
+			if (matched) continue;
+
+			for (const forme in alts.formes) {
+				if (toID(dex[mon].forme).includes(forme) === alts.formes[forme]) {
+					matched = true;
+					break;
+				}
+			}
+			if (matched) continue;
+
+			for (const stat in alts.stats) {
+				let monStat = 0;
+				if (stat === 'bst') {
+					monStat = dex[mon].bst;
+				} else if (stat === 'weight') {
+					monStat = dex[mon].weighthg / 10;
+				} else if (stat === 'height') {
+					monStat = dex[mon].heightm;
+				} else if (stat === 'gen') {
+					monStat = dex[mon].gen;
+				} else {
+					monStat = dex[mon].baseStats[stat as StatID];
+				}
+				if (typeof alts.stats[stat].less === 'number') {
+					if (monStat < alts.stats[stat].less) {
+						matched = true;
+						break;
+					}
+				}
+				if (typeof alts.stats[stat].greater === 'number') {
+					if (monStat > alts.stats[stat].greater) {
+						matched = true;
+						break;
+					}
+				}
+				if (typeof alts.stats[stat].equal === 'number') {
+					if (monStat === alts.stats[stat].equal) {
+						matched = true;
+						break;
+					}
+				}
+			}
+			if (matched) continue;
+
+			const format = Object.entries(Dex.data.Rulesets).find(([a, f]) => f.mod === usedMod);
+			const formatStr = format ? format[1].name : 'gen8ou';
+			const validator = TeamValidator.get(
+				`${formatStr}${nationalSearch && !Dex.formats.getRuleTable(Dex.formats.get(formatStr)).has('standardnatdex') ? '@@@standardnatdex' : ''}`
+			);
+			const pokemonSource = validator.allSources();
+			for (const move of Object.keys(alts.moves).map(x => mod.moves.get(x))) {
+				if (move.gen <= mod.gen && !validator.checkCanLearn(move, dex[mon], pokemonSource) === alts.moves[move.id]) {
+					matched = true;
+					break;
+				}
+				if (!pokemonSource.size()) break;
+			}
+			if (matched) continue;
+
+			delete dex[mon];
+		}
+	}
+	let results: string[] = [];
+	for (const mon of Object.keys(dex).sort()) {
+		if (singleTypeSearch !== null && (dex[mon].types.length === 1) !== singleTypeSearch) continue;
+		const isRegionalForm = (dex[mon].forme === "Galar" || dex[mon].forme === "Alola") && dex[mon].name !== "Pikachu-Alola";
+		const allowGmax = (gmaxSearch || tierSearch);
+		if (!isRegionalForm && dex[mon].baseSpecies && results.includes(dex[mon].baseSpecies)) continue;
+		if (dex[mon].isNonstandard === 'Gigantamax' && !allowGmax) continue;
+		results.push(dex[mon].name);
+	}
+
+	if (usedMod === 'gen7letsgo') {
+		results = results.filter(name => {
+			const species = mod.species.get(name);
+			return (species.num <= 151 || ['Meltan', 'Melmetal'].includes(species.name)) &&
+			(!species.forme || (['Alola', 'Mega', 'Mega-X', 'Mega-Y', 'Starter'].includes(species.forme) &&
+				species.name !== 'Pikachu-Alola'));
+		});
+	}
+
+	if (usedMod === 'gen8bdsp') {
+		results = results.filter(name => {
+			const species = mod.species.get(name);
+			if (species.id === 'pichuspikyeared') return false;
+			if (capSearch) return species.gen <= 4;
+			return species.gen <= 4 && species.num >= 1;
+		});
+	}
+
+	if (randomOutput && randomOutput < results.length) {
+		results = Utils.shuffle(results).slice(0, randomOutput);
+	}
+
+	let resultsStr = (message === "" ? message : `<span style="color:#999999;">${escapeHTML(message)}:</span><br />`);
+	if (results.length > 1) {
+		results.sort();
+		if (sort) {
+			const stat = sort.slice(0, -1);
+			const direction = sort.slice(-1);
+			Utils.sortBy(results, name => {
+				const mon = mod.species.get(name);
+				let monStat = 0;
+				if (stat === 'bst') {
+					monStat = mon.bst;
+				} else if (stat === 'weight') {
+					monStat = mon.weighthg;
+				} else if (stat === 'height') {
+					monStat = mon.heightm;
+				} else if (stat === 'gen') {
+					monStat = mon.gen;
+				} else {
+					monStat = mon.baseStats[stat as StatID];
+				}
+				return monStat * (direction === '+' ? 1 : -1);
+			});
+		}
+		let notShown = 0;
+		if (!showAll && results.length > MAX_RANDOM_RESULTS) {
+			notShown = results.length - RESULTS_MAX_LENGTH;
+			results = results.slice(0, RESULTS_MAX_LENGTH);
+		}
+		resultsStr += results.map(
+			result => `<a href="//${Config.routes.dex}/pokemon/${toID(result)}" target="_blank" class="subtle" style="white-space:nowrap"><psicon pokemon="${result}" style="vertical-align:-7px;margin:-2px" />${result}</a>`
+		).join(", ");
+		if (notShown) {
+			resultsStr += `, and ${notShown} more. <span style="color:#999999;">Redo the search with ', all' at the end to show all results.</span>`;
+		}
+	} else if (results.length === 1) {
+		return {dt: `${results[0]}${usedMod ? `,${usedMod}` : ''}`};
+	} else {
+		resultsStr += "No Pok&eacute;mon found.";
+	}
+	if (isTest) return {results, reply: resultsStr};
+	return {reply: resultsStr};
+}
+
+function runMovesearch(target: string, cmd: string, canAll: boolean, message: string, isTest: boolean) {
+	const searches: MoveOrGroup[] = [];
+	const {splitTarget, usedMod, count} = getMod(target);
+	if (count > 1) {
+		return {error: `You can't run searches for multiple mods.`};
+	}
+
+	const mod = Dex.mod(usedMod || 'base');
+	const allCategories = ['physical', 'special', 'status'];
+	const allContestTypes = ['beautiful', 'clever', 'cool', 'cute', 'tough'];
+	const allProperties = ['basePower', 'accuracy', 'priority', 'pp'];
+	const allFlags = [
+		'bypasssub', 'bite', 'bullet', 'charge', 'contact', 'dance', 'defrost', 'gravity', 'highcrit', 'mirror',
+		'multihit', 'ohko', 'powder', 'protect', 'pulse', 'punch', 'recharge', 'reflectable', 'secondary',
+		'snatch', 'sound', 'zmove', 'maxmove', 'gmaxmove', 'protection',
+	];
+	const allStatus = ['psn', 'tox', 'brn', 'par', 'frz', 'slp'];
+	const allVolatileStatus = ['flinch', 'confusion', 'partiallytrapped'];
+	const allBoosts = ['hp', 'atk', 'def', 'spa', 'spd', 'spe', 'accuracy', 'evasion'];
+	const allTargets: {[k: string]: string} = {
+		oneally: 'adjacentAlly',
+		userorally: 'adjacentAllyOrSelf',
+		oneadjacentopponent: 'adjacentFoe',
+		all: 'all',
+		alladjacent: 'allAdjacent',
+		alladjacentopponents: 'allAdjacentFoes',
+		userandallies: 'allies',
+		usersside: 'allySide',
+		usersteam: 'allyTeam',
+		any: 'any',
+		opponentsside: 'foeSide',
+		oneadjacent: 'normal',
+		randomadjacent: 'randomNormal',
+		scripted: 'scripted',
+		user: 'self',
+	};
+	const allTypes: {[k: string]: string} = Object.create(null);
+	for (const type of mod.types.all()) {
+		allTypes[type.id] = type.name;
+	}
+	let showAll = false;
+	let sort: string | null = null;
+	const targetMons: {name: string, shouldBeExcluded: boolean}[] = [];
+	let nationalSearch = null;
+	let randomOutput = 0;
+	for (const arg of splitTarget) {
+		const orGroup: MoveOrGroup = {
+			types: {}, categories: {}, contestTypes: {}, flags: {}, gens: {}, other: {}, mon: {}, property: {},
+			boost: {}, lower: {}, zboost: {}, status: {}, volatileStatus: {}, targets: {}, skip: false, multihit: false,
+		};
+		const parameters = arg.split("|");
+		if (parameters.length > 3) return {error: "No more than 3 alternatives for each parameter may be used."};
+		for (const parameter of parameters) {
+			let isNotSearch = false;
+			target = parameter.toLowerCase().trim();
+			if (target.startsWith('!')) {
+				isNotSearch = true;
+				target = target.substr(1);
+			}
+			let targetType;
+			if (target.endsWith('type')) {
+				targetType = toID(target.substring(0, target.indexOf('type')));
+			} else {
+				targetType = toID(target);
+			}
+			if (allTypes[targetType]) {
+				target = allTypes[targetType];
+				if ((orGroup.types[target] && isNotSearch) || (orGroup.types[target] === false && !isNotSearch)) {
+					return {error: 'A search cannot both exclude and include a type.'};
+				}
+				orGroup.types[target] = !isNotSearch;
+				continue;
+			}
+
+			if (allCategories.includes(target)) {
+				target = target.charAt(0).toUpperCase() + target.substr(1);
+				if (
+					(orGroup.categories[target] && isNotSearch) ||
+					(orGroup.categories[target] === false && !isNotSearch)
+				) {
+					return {error: 'A search cannot both exclude and include a category.'};
+				}
+				orGroup.categories[target] = !isNotSearch;
+				continue;
+			}
+
+			if (allContestTypes.includes(target)) {
+				target = target.charAt(0).toUpperCase() + target.substr(1);
+				if (
+					(orGroup.contestTypes[target] && isNotSearch) ||
+					(orGroup.contestTypes[target] === false && !isNotSearch)
+				) {
+					return {error: 'A search cannot both exclude and include a contest condition.'};
+				}
+				orGroup.contestTypes[target] = !isNotSearch;
+				continue;
+			}
+
+			if (target.startsWith('targets ')) {
+				target = toID(target.substr('targets '.length));
+				if (target === 'allpokemon' || target === 'anypokemon' || target.includes('adjacent')) {
+					target = target.replace('pokemon', '');
+				}
+				if (Object.keys(allTargets).includes(target)) {
+					const moveTarget = allTargets[target];
+					if (
+						(orGroup.targets[moveTarget] && isNotSearch) ||
+						(orGroup.targets[moveTarget] === false && !isNotSearch)
+					) {
+						return {error: 'A search cannot both exclude and include a move target.'};
+					}
+					orGroup.targets[moveTarget] = !isNotSearch;
+					continue;
+				} else {
+					return {error: `'${target}' isn't a valid move target.`};
+				}
+			}
+
+			if (target === 'bypassessubstitute') target = 'bypasssub';
+			if (target === 'z') target = 'zmove';
+			if (target === 'max') target = 'maxmove';
+			if (target === 'gmax') target = 'gmaxmove';
+			if (target === 'multi' || toID(target) === 'multihit') target = 'multihit';
+			if (target === 'crit' || toID(target) === 'highcrit') target = 'highcrit';
+			if (['thaw', 'thaws', 'melt', 'melts', 'defrosts'].includes(target)) target = 'defrost';
+			if (target === 'bounceable' || toID(target) === 'magiccoat' || toID(target) === 'magicbounce') target = 'reflectable';
+			if (allFlags.includes(target)) {
+				if ((orGroup.flags[target] && isNotSearch) || (orGroup.flags[target] === false && !isNotSearch)) {
+					return {error: `A search cannot both exclude and include '${target}'.`};
+				}
+				orGroup.flags[target] = !isNotSearch;
+				continue;
+			}
+
+			let targetInt = 0;
+			if (target.substr(0, 1) === 'g' && Number.isInteger(parseFloat(target.substr(1)))) {
+				targetInt = parseInt(target.substr(1).trim());
+			} else if (target.substr(0, 3) === 'gen' && Number.isInteger(parseFloat(target.substr(3)))) {
+				targetInt = parseInt(target.substr(3).trim());
+			}
+
+			if (0 < targetInt && targetInt < 9) {
+				if ((orGroup.gens[targetInt] && isNotSearch) || (orGroup.flags[targetInt] === false && !isNotSearch)) {
+					return {error: `A search cannot both exclude and include '${target}'.`};
+				}
+				orGroup.gens[targetInt] = !isNotSearch;
+				continue;
+			}
+
+			if (target === 'all') {
+				if (!canAll) return {error: "A search with the parameter 'all' cannot be broadcast."};
+				if (parameters.length > 1) return {error: "The parameter 'all' cannot have alternative parameters."};
+				showAll = true;
+				orGroup.skip = true;
+				continue;
+			}
+
+			if (target === 'natdex') {
+				if (parameters.length > 1) return {error: "The parameter 'natdex' cannot have alternative parameters."};
+				nationalSearch = !isNotSearch;
+				orGroup.skip = true;
+				continue;
+			}
+
+			if (target.endsWith(' asc') || target.endsWith(' desc')) {
+				if (parameters.length > 1) {
+					return {error: `The parameter '${target.split(' ')[1]}' cannot have alternative parameters.`};
+				}
+				let prop = target.split(' ')[0];
+				switch (toID(prop)) {
+				case 'basepower': prop = 'basePower'; break;
+				case 'bp': prop = 'basePower'; break;
+				case 'power': prop = 'basePower'; break;
+				case 'acc': prop = 'accuracy'; break;
+				}
+				if (!allProperties.includes(prop)) return {error: `'${escapeHTML(target)}' did not contain a valid property.`};
+				sort = `${prop}${target.endsWith(' asc') ? '+' : '-'}`;
+				orGroup.skip = true;
+				break;
+			}
+
+			if (target === 'recovery') {
+				if (orGroup.other.recovery === undefined) {
+					orGroup.other.recovery = !isNotSearch;
+				} else if ((orGroup.other.recovery && isNotSearch) || (!orGroup.other.recovery && !isNotSearch)) {
+					return {error: 'A search cannot both exclude and include recovery moves.'};
+				}
+				continue;
+			}
+
+			if (target === 'recoil') {
+				if (orGroup.other.recoil === undefined) {
+					orGroup.other.recoil = !isNotSearch;
+				} else if ((orGroup.other.recoil && isNotSearch) || (!orGroup.other.recoil && !isNotSearch)) {
+					return {error: 'A search cannot both exclude and include recoil moves.'};
+				}
+				continue;
+			}
+
+			if (target.substr(0, 6) === 'random' && cmd === 'randmove') {
+				// Validation for this is in the /randmove command
+				randomOutput = parseInt(target.substr(6));
+				orGroup.skip = true;
+				continue;
+			}
+
+			if (target === 'zrecovery') {
+				if (orGroup.other.zrecovery === undefined) {
+					orGroup.other.zrecovery = !isNotSearch;
+				} else if ((orGroup.other.zrecovery && isNotSearch) || (!orGroup.other.zrecovery && !isNotSearch)) {
+					return {error: 'A search cannot both exclude and include z-recovery moves.'};
+				}
+				continue;
+			}
+
+			if (target === 'pivot') {
+				if (orGroup.other.pivot === undefined) {
+					orGroup.other.pivot = !isNotSearch;
+				} else if ((orGroup.other.pivot && isNotSearch) || (!orGroup.other.pivot && !isNotSearch)) {
+					return {error: 'A search cannot both exclude and include pivot moves.'};
+				}
+				continue;
+			}
+
+			if (target === 'multihit') {
+				if (!orGroup.multihit) {
+					orGroup.multihit = true;
+				} else if ((orGroup.multihit && isNotSearch) || (!orGroup.multihit && !isNotSearch)) {
+					return {error: 'A search cannot both exclude and include multi-hit moves.'};
+				}
+				continue;
+			}
+
+			const species = mod.species.get(target);
+			if (species.exists) {
+				if (parameters.length > 1) return {error: "A Pok\u00e9mon learnset cannot have alternative parameters."};
+				if (targetMons.some(mon => mon.name === species.name && isNotSearch !== mon.shouldBeExcluded)) {
+					return {error: "A search cannot both exclude and include the same Pok\u00e9mon."};
+				}
+				if (targetMons.some(mon => mon.name === species.name)) {
+					return {error: "A search should not include a Pok\u00e9mon twice."};
+				}
+				targetMons.push({name: species.name, shouldBeExcluded: isNotSearch});
+				orGroup.skip = true;
+				continue;
+			}
+
+			const inequality = target.search(/>|<|=/);
+			if (inequality >= 0) {
+				let inequalityString;
+				if (isNotSearch) return {error: "You cannot use the negation symbol '!' in stat ranges."};
+				if (target.charAt(inequality + 1) === '=') {
+					inequalityString = target.substr(inequality, 2);
+				} else {
+					inequalityString = target.charAt(inequality);
+				}
+				const targetParts = target.replace(/\s/g, '').split(inequalityString);
+				let num;
+				let prop;
+				const directions: Direction[] = [];
+				if (!isNaN(parseFloat(targetParts[0]))) {
+					// e.g. 100 < bp
+					num = parseFloat(targetParts[0]);
+					prop = targetParts[1];
+					if (inequalityString.startsWith('>')) directions.push('less');
+					if (inequalityString.startsWith('<')) directions.push('greater');
+				} else if (!isNaN(parseFloat(targetParts[1]))) {
+					// e.g. bp > 100
+					num = parseFloat(targetParts[1]);
+					prop = targetParts[0];
+					if (inequalityString.startsWith('<')) directions.push('less');
+					if (inequalityString.startsWith('>')) directions.push('greater');
+				} else {
+					return {error: `No value given to compare with '${escapeHTML(target)}'.`};
+				}
+				if (inequalityString.endsWith('=')) directions.push('equal');
+				switch (toID(prop)) {
+				case 'basepower': prop = 'basePower'; break;
+				case 'bp': prop = 'basePower'; break;
+				case 'power': prop = 'basePower'; break;
+				case 'acc': prop = 'accuracy'; break;
+				}
+				if (!allProperties.includes(prop)) return {error: `'${escapeHTML(target)}' did not contain a valid property.`};
+				if (!orGroup.property[prop]) orGroup.property[prop] = Object.create(null);
+				for (const direction of directions) {
+					if (orGroup.property[prop][direction]) return {error: `Invalid property range for ${prop}.`};
+					orGroup.property[prop][direction] = num;
+				}
+				continue;
+			}
+
+			if (target.substr(0, 8) === 'priority') {
+				let sign: Direction;
+				target = target.substr(8).trim();
+				if (target === "+" || target === "") {
+					sign = 'greater';
+				} else if (target === "-") {
+					sign = 'less';
+				} else {
+					return {error: `Priority type '${target}' not recognized.`};
+				}
+				if (orGroup.property['priority']) {
+					return {error: "Priority cannot be set with both shorthand and inequality range."};
+				} else {
+					orGroup.property['priority'] = Object.create(null);
+					orGroup.property['priority'][sign] = 0;
+				}
+				continue;
+			}
+			if (target.substr(0, 7) === 'boosts ' || target.substr(0, 7) === 'lowers ') {
+				let isBoost = true;
+				if (target.substr(0, 7) === 'lowers ') {
+					isBoost = false;
+				}
+				switch (target.substr(7)) {
+				case 'attack': target = 'atk'; break;
+				case 'defense': target = 'def'; break;
+				case 'specialattack': target = 'spa'; break;
+				case 'spatk': target = 'spa'; break;
+				case 'specialdefense': target = 'spd'; break;
+				case 'spdef': target = 'spd'; break;
+				case 'speed': target = 'spe'; break;
+				case 'acc': target = 'accuracy'; break;
+				case 'evasiveness': target = 'evasion'; break;
+				default: target = target.substr(7);
+				}
+				if (!allBoosts.includes(target)) return {error: `'${escapeHTML(target)}' is not a recognized stat.`};
+				if (isBoost) {
+					if ((orGroup.boost[target] && isNotSearch) || (orGroup.boost[target] === false && !isNotSearch)) {
+						return {error: 'A search cannot both exclude and include a stat boost.'};
+					}
+					orGroup.boost[target] = !isNotSearch;
+				} else {
+					if ((orGroup.lower[target] && isNotSearch) || (orGroup.lower[target] === false && !isNotSearch)) {
+						return {error: 'A search cannot both exclude and include a stat boost.'};
+					}
+					orGroup.lower[target] = !isNotSearch;
+				}
+				continue;
+			}
+
+			if (target.substr(0, 8) === 'zboosts ') {
+				switch (target.substr(8)) {
+				case 'attack': target = 'atk'; break;
+				case 'defense': target = 'def'; break;
+				case 'specialattack': target = 'spa'; break;
+				case 'spatk': target = 'spa'; break;
+				case 'specialdefense': target = 'spd'; break;
+				case 'spdef': target = 'spd'; break;
+				case 'speed': target = 'spe'; break;
+				case 'acc': target = 'accuracy'; break;
+				case 'evasiveness': target = 'evasion'; break;
+				default: target = target.substr(8);
+				}
+				if (!allBoosts.includes(target)) return {error: `'${escapeHTML(target)}' is not a recognized stat.`};
+				if ((orGroup.zboost[target] && isNotSearch) || (orGroup.zboost[target] === false && !isNotSearch)) {
+					return {error: 'A search cannot both exclude and include a stat boost.'};
+				}
+				orGroup.zboost[target] = !isNotSearch;
+				continue;
+			}
+
+			const oldTarget = target;
+			if (target.endsWith('s')) target = target.slice(0, -1);
+			switch (target) {
+			case 'toxic': target = 'tox'; break;
+			case 'poison': target = 'psn'; break;
+			case 'burn': target = 'brn'; break;
+			case 'paralyze': target = 'par'; break;
+			case 'freeze': target = 'frz'; break;
+			case 'sleep': target = 'slp'; break;
+			case 'confuse': target = 'confusion'; break;
+			case 'trap': target = 'partiallytrapped'; break;
+			case 'flinche': target = 'flinch'; break;
+			}
+
+			if (allStatus.includes(target)) {
+				if ((orGroup.status[target] && isNotSearch) || (orGroup.status[target] === false && !isNotSearch)) {
+					return {error: 'A search cannot both exclude and include a status.'};
+				}
+				orGroup.status[target] = !isNotSearch;
+				continue;
+			}
+
+			if (allVolatileStatus.includes(target)) {
+				if (
+					(orGroup.volatileStatus[target] && isNotSearch) ||
+					(orGroup.volatileStatus[target] === false && !isNotSearch)
+				) {
+					return {error: 'A search cannot both exclude and include a volatile status.'};
+				}
+				orGroup.volatileStatus[target] = !isNotSearch;
+				continue;
+			}
+
+			return {error: `'${escapeHTML(oldTarget)}' could not be found in any of the search categories.`};
+		}
+		if (!orGroup.skip) {
+			searches.push(orGroup);
+		}
+	}
+	if (showAll && !searches.length && !targetMons.length && !sort) {
+		return {
+			error: "No search parameters other than 'all' were found. Try '/help movesearch' for more information on this command.",
+		};
+	}
+
+	const getFullLearnsetOfPokemon = (species: Species) => {
+		let usedSpecies: Species = Utils.deepClone(species);
+		let usedSpeciesLearnset: LearnsetData = Utils.deepClone(mod.species.getLearnset(usedSpecies.id));
+		if (!usedSpeciesLearnset) {
+			usedSpecies = Utils.deepClone(mod.species.get(usedSpecies.baseSpecies));
+			usedSpeciesLearnset = Utils.deepClone(mod.species.getLearnset(usedSpecies.id) || {});
+		}
+		const lsetData = new Set<string>();
+		for (const move in usedSpeciesLearnset) {
+			const learnset = mod.species.getLearnset(usedSpecies.id);
+			if (!learnset) break;
+			const sources = learnset[move];
+			for (const learned of sources) {
+				const sourceGen = parseInt(learned.charAt(0));
+				if (sourceGen <= mod.gen) lsetData.add(move);
+			}
+		}
+
+		while (usedSpecies.prevo) {
+			usedSpecies = Utils.deepClone(mod.species.get(usedSpecies.prevo));
+			usedSpeciesLearnset = Utils.deepClone(mod.species.getLearnset(usedSpecies.id));
+			for (const move in usedSpeciesLearnset) {
+				const learnset = mod.species.getLearnset(usedSpecies.id);
+				if (!learnset) break;
+				const sources = learnset[move];
+				for (const learned of sources) {
+					const sourceGen = parseInt(learned.charAt(0));
+					if (sourceGen <= mod.gen) lsetData.add(move);
+				}
+			}
+		}
+
+		return lsetData;
+	};
+
+	// Since we assume we have no target mons at first
+	// then the valid moveset we can search is the set of all moves.
+	const validMoves = new Set(Object.keys(mod.data.Moves));
+	for (const mon of targetMons) {
+		const species = mod.species.get(mon.name);
+		const lsetData = getFullLearnsetOfPokemon(species);
+		// This pokemon's learnset needs to be excluded, so we perform a difference operation
+		// on the valid moveset and this pokemon's moveset.
+		if (mon.shouldBeExcluded) {
+			for (const move of lsetData) {
+				validMoves.delete(move);
+			}
+		} else {
+			// This pokemon's learnset needs to be included, so we perform an intersection operation
+			// on the valid moveset and this pokemon's moveset.
+			for (const move of validMoves) {
+				if (!lsetData.has(move)) {
+					validMoves.delete(move);
+				}
+			}
+		}
+	}
+
+	// At this point, we've trimmed down the valid moveset to be
+	// the moves that are appropriate considering the requested pokemon.
+	const dex: {[moveid: string]: Move} = {};
+	for (const moveid of validMoves) {
+		const move = mod.moves.get(moveid);
+		if (move.gen <= mod.gen) {
+			if (
+				(!nationalSearch && move.isNonstandard && move.isNonstandard !== "Gigantamax") ||
+				(nationalSearch && move.isNonstandard && !["Gigantamax", "Past"].includes(move.isNonstandard))
+			) {
+				continue;
+			} else {
+				dex[moveid] = move;
+			}
+		}
+	}
+
+	for (const alts of searches) {
+		if (alts.skip) continue;
+		for (const moveid in dex) {
+			const move = dex[moveid];
+			const recoveryUndefined = alts.other.recovery === undefined;
+			const zrecoveryUndefined = alts.other.zrecovery === undefined;
+			let matched = false;
+			if (Object.keys(alts.types).length) {
+				if (alts.types[move.type]) continue;
+				if (Object.values(alts.types).includes(false) && alts.types[move.type] !== false) continue;
+			}
+
+			if (Object.keys(alts.categories).length) {
+				if (alts.categories[move.category]) continue;
+				if (Object.values(alts.categories).includes(false) && alts.categories[move.category] !== false) continue;
+			}
+
+			if (Object.keys(alts.contestTypes).length) {
+				if (alts.contestTypes[move.contestType || 'Cool']) continue;
+				if (
+					Object.values(alts.contestTypes).includes(false) &&
+					alts.contestTypes[move.contestType || 'Cool'] !== false
+				) continue;
+			}
+
+			if (Object.keys(alts.targets).length) {
+				if (alts.targets[move.target]) continue;
+				if (Object.values(alts.targets).includes(false) && alts.targets[move.target] !== false) continue;
+			}
+
+			for (const flag in alts.flags) {
+				if (flag === 'secondary') {
+					if (!(move.secondary || move.secondaries) === !alts.flags[flag]) {
+						matched = true;
+						break;
+					}
+				} else if (flag === 'zmove') {
+					if (!move.isZ === !alts.flags[flag]) {
+						matched = true;
+						break;
+					}
+				} else if (flag === 'highcrit') {
+					const crit = move.willCrit || (move.critRatio && move.critRatio > 1);
+					if (!crit === !alts.flags[flag]) {
+						matched = true;
+						break;
+					}
+				} else if (flag === 'multihit') {
+					if (!move.multihit === !alts.flags[flag]) {
+						matched = true;
+						break;
+					}
+				} else if (flag === 'maxmove') {
+					if (!(typeof move.isMax === 'boolean' && move.isMax) === !alts.flags[flag]) {
+						matched = true;
+						break;
+					}
+				} else if (flag === 'gmaxmove') {
+					if (!(typeof move.isMax === 'string') === !alts.flags[flag]) {
+						matched = true;
+						break;
+					}
+				} else if (flag === 'protection') {
+					if (!(move.stallingMove && move.id !== "endure") === !alts.flags[flag]) {
+						matched = true;
+						break;
+					}
+				} else if (flag === 'ohko') {
+					if (!move.ohko === !alts.flags[flag]) {
+						matched = true;
+						break;
+					}
+				} else {
+					if ((flag in move.flags) === alts.flags[flag]) {
+						if (flag === 'protect' && ['all', 'allyTeam', 'allySide', 'foeSide', 'self'].includes(move.target)) continue;
+						matched = true;
+						break;
+					}
+				}
+			}
+			if (matched) continue;
+			if (Object.keys(alts.gens).length) {
+				if (alts.gens[String(move.gen)]) continue;
+				if (Object.values(alts.gens).includes(false) && alts.gens[String(move.gen)] !== false) continue;
+			}
+			if (!zrecoveryUndefined || !recoveryUndefined) {
+				for (const recoveryType in alts.other) {
+					let hasRecovery = false;
+					if (recoveryType === "recovery") {
+						hasRecovery = !!move.drain || !!move.flags.heal;
+					} else if (recoveryType === "zrecovery") {
+						hasRecovery = (move.zMove?.effect === 'heal');
+					}
+					if (hasRecovery === alts.other[recoveryType]) {
+						matched = true;
+						break;
+					}
+				}
+			}
+			if (matched) continue;
+			if (alts.other.recoil !== undefined) {
+				const recoil = move.recoil || move.hasCrashDamage;
+				if (recoil && alts.other.recoil || !(recoil || alts.other.recoil)) matched = true;
+			}
+			if (matched) continue;
+			for (const prop in alts.property) {
+				if (typeof alts.property[prop].less === "number") {
+					if (
+						move[prop as keyof Move] !== true &&
+						(move[prop as keyof Move] as number) < alts.property[prop].less
+					) {
+						matched = true;
+						break;
+					}
+				}
+				if (typeof alts.property[prop].greater === "number") {
+					if ((move[prop as keyof Move] === true && move.category !== "Status") ||
+						move[prop as keyof Move] as number > alts.property[prop].greater) {
+						matched = true;
+						break;
+					}
+				}
+				if (typeof alts.property[prop].equal === "number") {
+					if (move[prop as keyof Move] === alts.property[prop].equal) {
+						matched = true;
+						break;
+					}
+				}
+			}
+			if (matched) continue;
+			for (const boost in alts.boost) {
+				if (move.boosts) {
+					if ((move.boosts[boost as BoostID]! > 0) === alts.boost[boost]) {
+						matched = true;
+						break;
+					}
+				} else if (move.secondary?.self?.boosts) {
+					if ((move.secondary.self.boosts[boost as BoostID]! > 0) === alts.boost[boost]) {
+						matched = true;
+						break;
+					}
+				} else if (move.selfBoost?.boosts) {
+					if ((move.selfBoost.boosts[boost as BoostID]! > 0) === alts.boost[boost]) {
+						matched = true;
+						break;
+					}
+				}
+			}
+			if (matched) continue;
+			for (const lower in alts.lower) {
+				if (move.boosts) {
+					if ((move.boosts[lower as BoostID]! < 0) === alts.lower[lower]) {
+						matched = true;
+						break;
+					}
+				} else if (move.secondary?.boosts) {
+					if ((move.secondary.boosts[lower as BoostID]! < 0) === alts.lower[lower]) {
+						matched = true;
+						break;
+					}
+				} else if (move.self?.boosts) {
+					if ((move.self.boosts[lower as BoostID]! < 0) === alts.lower[lower]) {
+						matched = true;
+						break;
+					}
+				}
+			}
+			if (matched) continue;
+			for (const boost in alts.zboost) {
+				const zMove = move.zMove;
+				if (zMove?.boost) {
+					if ((zMove.boost[boost as BoostID]! > 0) === alts.zboost[boost]) {
+						matched = true;
+						break;
+					}
+				}
+			}
+			if (matched) continue;
+
+			for (const searchStatus in alts.status) {
+				let canStatus = !!(
+					move.status === searchStatus ||
+					(move.secondaries && move.secondaries.some(entry => entry.status === searchStatus))
+				);
+				if (searchStatus === 'slp') {
+					canStatus = canStatus || moveid === 'yawn';
+				}
+				if (searchStatus === 'brn' || searchStatus === 'frz' || searchStatus === 'par') {
+					canStatus = canStatus || moveid === 'triattack';
+				}
+				if (canStatus === alts.status[searchStatus]) {
+					matched = true;
+					break;
+				}
+			}
+			if (matched) continue;
+
+			for (const searchStatus in alts.volatileStatus) {
+				const canStatus = !!(
+					(move.secondary && move.secondary.volatileStatus === searchStatus) ||
+					(move.secondaries && move.secondaries.some(entry => entry.volatileStatus === searchStatus)) ||
+					(move.volatileStatus === searchStatus)
+				);
+				if (canStatus === alts.volatileStatus[searchStatus]) {
+					matched = true;
+					break;
+				}
+			}
+			if (matched) continue;
+			if (alts.other.pivot !== undefined) {
+				const pivot = move.selfSwitch && move.id !== 'batonpass';
+				if (pivot && alts.other.pivot || !(pivot || alts.other.pivot)) matched = true;
+			}
+			if (matched) continue;
+
+			delete dex[moveid];
+		}
+	}
+
+	let results = [];
+	for (const move in dex) {
+		results.push(dex[move].name);
+	}
+
+	let resultsStr = "";
+	if (targetMons.length) {
+		resultsStr += `<span style="color:#999999;">Matching moves found in learnset(s) for</span> ${targetMons.map(mon => `${mon.shouldBeExcluded ? "!" : ""}${mon.name}`).join(', ')}:<br />`;
+	} else {
+		resultsStr += (message === "" ? message : `<span style="color:#999999;">${escapeHTML(message)}:</span><br />`);
+	}
+	if (randomOutput && randomOutput < results.length) {
+		results = Utils.shuffle(results).slice(0, randomOutput);
+	}
+	if (results.length > 1) {
+		results.sort();
+		if (sort) {
+			const prop = sort.slice(0, -1);
+			const direction = sort.slice(-1);
+			Utils.sortBy(results, moveName => {
+				let moveProp = dex[toID(moveName)][prop as keyof Move] as number;
+				// convert booleans to 0 or 1
+				if (typeof moveProp === 'boolean') moveProp = moveProp ? 1 : 0;
+				return moveProp * (direction === '+' ? 1 : -1);
+			});
+		}
+		let notShown = 0;
+		if (!showAll && results.length > MAX_RANDOM_RESULTS) {
+			notShown = results.length - RESULTS_MAX_LENGTH;
+			results = results.slice(0, RESULTS_MAX_LENGTH);
+		}
+		resultsStr += results.map(
+			result => `<a href="//${Config.routes.dex}/moves/${toID(result)}" target="_blank" class="subtle" style="white-space:nowrap">${result}</a>` +
+				`${sort ? ` (${dex[toID(result)][sort.slice(0, -1) as keyof Move] === true ? '-' : dex[toID(result)][sort.slice(0, -1) as keyof Move]})` : ''}`
+		).join(", ");
+		if (notShown) {
+			resultsStr += `, and ${notShown} more. <span style="color:#999999;">Redo the search with ', all' at the end to show all results.</span>`;
+		}
+	} else if (results.length === 1) {
+		return {dt: `${results[0]}${usedMod ? `,${usedMod}` : ''}`};
+	} else {
+		resultsStr += "No moves found.";
+	}
+	if (isTest) return {results, reply: resultsStr};
+	return {reply: resultsStr};
+}
+
+function runItemsearch(target: string, cmd: string, canAll: boolean, message: string) {
+	let showAll = false;
+	let maxGen = 0;
+	let gen = 0;
+
+	target = target.trim();
+	const lastCommaIndex = target.lastIndexOf(',');
+	const lastArgumentSubstr = target.substr(lastCommaIndex + 1).trim();
+	if (lastArgumentSubstr === 'all') {
+		if (!canAll) return {error: "A search ending in ', all' cannot be broadcast."};
+		showAll = true;
+		target = target.substr(0, lastCommaIndex);
+	}
+
+	target = target.toLowerCase().replace('-', ' ').replace(/[^a-z0-9.\s/]/g, '');
+	const rawSearch = target.replace(/(max ?)?gen \d/g, match => toID(match)).split(' ');
+	const searchedWords: string[] = [];
+	let foundItems: string[] = [];
+
+	// Refine searched words
+	for (const [i, search] of rawSearch.entries()) {
+		let newWord = search.trim();
+		if (newWord.substr(0, 6) === 'maxgen') {
+			const parsedGen = parseInt(newWord.substr(6));
+			if (!isNaN(parsedGen)) {
+				if (maxGen) return {error: "You cannot specify 'maxgen' multiple times."};
+				maxGen = parsedGen;
+				if (maxGen < 2 || maxGen > 8) return {error: "The generation must be between 2 and 8"};
+				continue;
+			}
+		} else if (newWord.substr(0, 3) === 'gen') {
+			const parsedGen = parseInt(newWord.substr(3));
+			if (!isNaN(parsedGen)) {
+				if (gen) return {error: "You cannot specify 'gen' multiple times."};
+				gen = parsedGen;
+				if (gen < 2 || gen > 8) return {error: "The generation must be between 2 and 8"};
+				continue;
+			}
+		}
+		if (isNaN(parseFloat(newWord))) newWord = newWord.replace('.', '');
+		switch (newWord) {
+		// Words that don't really help identify item removed to speed up search
+		case 'a':
+		case 'an':
+		case 'is':
+		case 'it':
+		case 'its':
+		case 'the':
+		case 'that':
+		case 'which':
+		case 'user':
+		case 'holder':
+		case 'holders':
+			newWord = '';
+			break;
+		// replace variations of common words with standardized versions
+		case 'opponent': newWord = 'attacker'; break;
+		case 'flung': newWord = 'fling'; break;
+		case 'heal': case 'heals':
+		case 'recovers': newWord = 'restores'; break;
+		case 'boost':
+		case 'boosts': newWord = 'raises'; break;
+		case 'weakens': newWord = 'halves'; break;
+		case 'more': newWord = 'increases'; break;
+		case 'super':
+			if (rawSearch[i + 1] === 'effective') {
+				newWord = 'supereffective';
+			}
+			break;
+		case 'special':
+			if (rawSearch[i + 1] === 'defense') {
+				newWord = 'specialdefense';
+			} else if (rawSearch[i + 1] === 'attack') {
+				newWord = 'specialattack';
+			}
+			break;
+		case 'spatk':
+		case 'spa':
+			newWord = 'specialattack';
+			break;
+		case 'atk':
+		case 'attack':
+			if (['sp', 'special'].includes(rawSearch[i - 1])) {
+				break;
+			} else {
+				newWord = 'attack';
+			}
+			break;
+		case 'spd':
+		case 'spdef':
+			newWord = 'specialdefense';
+			break;
+		case 'def':
+		case 'defense':
+			if (['sp', 'special'].includes(rawSearch[i - 1])) {
+				break;
+			} else {
+				newWord = 'defense';
+			}
+			break;
+		case 'burns': newWord = 'burn'; break;
+		case 'poisons': newWord = 'poison'; break;
+		default:
+			if (/x[\d.]+/.test(newWord)) {
+				newWord = newWord.substr(1) + 'x';
+			}
+		}
+		if (!newWord || searchedWords.includes(newWord)) continue;
+		searchedWords.push(newWord);
+	}
+
+	if (searchedWords.length === 0 && !gen && !maxGen) {
+		return {error: "No distinguishing words were used. Try a more specific search."};
+	}
+
+	const dex = maxGen ? Dex.mod("gen" + maxGen) : Dex;
+	if (searchedWords.includes('fling')) {
+		let basePower = 0;
+		let effect;
+
+		for (let word of searchedWords) {
+			let wordEff = "";
+			switch (word) {
+			case 'burn': case 'burns':
+			case 'brn': wordEff = 'brn'; break;
+			case 'paralyze': case 'paralyzes':
+			case 'par': wordEff = 'par'; break;
+			case 'poison': case 'poisons':
+			case 'psn': wordEff = 'psn'; break;
+			case 'toxic':
+			case 'tox': wordEff = 'tox'; break;
+			case 'flinches':
+			case 'flinch': wordEff = 'flinch'; break;
+			case 'badly': wordEff = 'tox'; break;
+			}
+			if (wordEff && effect) {
+				if (!(wordEff === 'psn' && effect === 'tox')) return {error: "Only specify fling effect once."};
+			} else if (wordEff) {
+				effect = wordEff;
+			} else {
+				if (word.substr(word.length - 2) === 'bp' && word.length > 2) word = word.substr(0, word.length - 2);
+				if (Number.isInteger(Number(word))) {
+					if (basePower) return {error: "Only specify a number for base power once."};
+					basePower = parseInt(word);
+				}
+			}
+		}
+
+		for (const item of dex.items.all()) {
+			if (!item.fling || (gen && item.gen !== gen) || (maxGen && item.gen <= maxGen)) continue;
+
+			if (basePower && effect) {
+				if (item.fling.basePower === basePower &&
+				(item.fling.status === effect || item.fling.volatileStatus === effect)) foundItems.push(item.name);
+			} else if (basePower) {
+				if (item.fling.basePower === basePower) foundItems.push(item.name);
+			} else {
+				if (item.fling.status === effect || item.fling.volatileStatus === effect) foundItems.push(item.name);
+			}
+		}
+		if (foundItems.length === 0) return {error: 'No items inflict ' + basePower + 'bp damage when used with Fling.'};
+	} else if (target.search(/natural ?gift/i) >= 0) {
+		let basePower = 0;
+		let type = "";
+
+		for (let word of searchedWords) {
+			if (word in dex.data.TypeChart) {
+				if (type) return {error: "Only specify natural gift type once."};
+				type = word.charAt(0).toUpperCase() + word.slice(1);
+			} else {
+				if (word.endsWith('bp') && word.length > 2) word = word.slice(0, -2);
+				if (Number.isInteger(Number(word))) {
+					if (basePower) return {error: "Only specify a number for base power once."};
+					basePower = parseInt(word);
+				}
+			}
+		}
+
+		for (const item of dex.items.all()) {
+			if (!item.isBerry || !item.naturalGift || (gen && item.gen !== gen) || (maxGen && item.gen <= maxGen)) continue;
+
+			if (basePower && type) {
+				if (item.naturalGift.basePower === basePower && item.naturalGift.type === type) foundItems.push(item.name);
+			} else if (basePower) {
+				if (item.naturalGift.basePower === basePower) foundItems.push(item.name);
+			} else {
+				if (item.naturalGift.type === type) foundItems.push(item.name);
+			}
+		}
+		if (foundItems.length === 0) {
+			return {error: 'No berries inflict ' + basePower + 'bp damage when used with Natural Gift.'};
+		}
+	} else {
+		let bestMatched = 0;
+		for (const item of dex.items.all()) {
+			let matched = 0;
+			// splits words in the description into a toID()-esk format except retaining / and . in numbers
+			let descWords = item.desc || '';
+			// add more general quantifier words to descriptions
+			if (/[1-9.]+x/.test(descWords)) descWords += ' increases';
+			if (item.isBerry) descWords += ' berry';
+			descWords = descWords.replace(/super[-\s]effective/g, 'supereffective');
+			const descWordsArray = descWords.toLowerCase()
+				.replace('-', ' ')
+				.replace(/[^a-z0-9\s/]/g, '')
+				.replace(/(\D)\./, (p0, p1) => p1).split(' ');
+
+			for (const word of searchedWords) {
+				switch (word) {
+				case 'specialattack':
+					if (descWordsArray[descWordsArray.indexOf('sp') + 1] === 'atk') matched++;
+					break;
+				case 'specialdefense':
+					if (descWordsArray[descWordsArray.indexOf('sp') + 1] === 'def') matched++;
+					break;
+				default:
+					if (descWordsArray.includes(word)) matched++;
+				}
+			}
+
+			if (matched >= (searchedWords.length * 3 / 5) && (!maxGen || item.gen <= maxGen) && (!gen || item.gen === gen)) {
+				if (matched === bestMatched) {
+					foundItems.push(item.name);
+				} else if (matched > bestMatched) {
+					foundItems = [item.name];
+					bestMatched = matched;
+				}
+			}
+		}
+	}
+
+	let resultsStr = (message === "" ? message : `<span style="color:#999999;">${escapeHTML(message)}:</span><br />`);
+	if (foundItems.length > 0) {
+		foundItems.sort();
+		let notShown = 0;
+		if (!showAll && foundItems.length > RESULTS_MAX_LENGTH + 5) {
+			notShown = foundItems.length - RESULTS_MAX_LENGTH;
+			foundItems = foundItems.slice(0, RESULTS_MAX_LENGTH);
+		}
+		resultsStr += foundItems.map(
+			result => `<a href="//${Config.routes.dex}/items/${toID(result)}" target="_blank" class="subtle" style="white-space:nowrap"><psicon item="${result}" style="vertical-align:-7px" />${result}</a>`
+		).join(", ");
+		if (notShown) {
+			resultsStr += `, and ${notShown} more. <span style="color:#999999;">Redo the search with ', all' at the end to show all results.</span>`;
+		}
+	} else {
+		resultsStr += "No items found. Try a more general search";
+	}
+	return {reply: resultsStr};
+}
+
+function runAbilitysearch(target: string, cmd: string, canAll: boolean, message: string) {
+	// based heavily on runItemsearch()
+	let showAll = false;
+	let maxGen = 0;
+	let gen = 0;
+
+	target = target.trim();
+	const lastCommaIndex = target.lastIndexOf(',');
+	const lastArgumentSubstr = target.substr(lastCommaIndex + 1).trim();
+	if (lastArgumentSubstr === 'all') {
+		if (!canAll) return {error: "A search ending in ', all' cannot be broadcast."};
+		showAll = true;
+		target = target.substr(0, lastCommaIndex);
+	}
+
+	target = target.toLowerCase().replace('-', ' ').replace(/[^a-z0-9.\s/]/g, '');
+	const rawSearch = target.replace(/(max ?)?gen \d/g, match => toID(match)).split(' ');
+	const searchedWords: string[] = [];
+	let foundAbilities: string[] = [];
+
+	for (const [i, search] of rawSearch.entries()) {
+		let newWord = search.trim();
+		if (newWord.substr(0, 6) === 'maxgen') {
+			const parsedGen = parseInt(newWord.substr(6));
+			if (parsedGen) {
+				if (maxGen) return {error: "You cannot specify 'maxgen' multiple times."};
+				maxGen = parsedGen;
+				if (maxGen < 3 || maxGen > 8) return {error: "The generation must be between 3 and 8"};
+				continue;
+			}
+		} else if (newWord.substr(0, 3) === 'gen') {
+			const parsedGen = parseInt(newWord.substr(3));
+			if (parsedGen) {
+				if (gen) return {error: "You cannot specify 'gen' multiple times."};
+				gen = parsedGen;
+				if (gen < 3 || gen > 8) return {error: "The generation must be between 3 and 8"};
+				continue;
+			}
+		}
+		if (isNaN(parseFloat(newWord))) newWord = newWord.replace('.', '');
+		switch (newWord) {
+		// remove extraneous words
+		case 'a':
+		case 'an':
+		case 'is':
+		case 'it':
+		case 'its':
+		case 'the':
+		case 'that':
+		case 'which':
+		case 'user':
+			newWord = '';
+			break;
+		// replace variations of common words with standardized versions
+		case 'opponent': newWord = 'attacker'; break;
+		case 'heal':
+		case 'heals':
+		case 'recovers': newWord = 'restores'; break;
+		case 'boost':
+		case 'boosts': newWord = 'raised'; break;
+		case 'super':
+			if (rawSearch[i + 1] === 'effective') {
+				newWord = 'supereffective';
+			}
+			break;
+		case 'special':
+			if (rawSearch[i + 1] === 'defense') {
+				newWord = 'specialdefense';
+			} else if (rawSearch[i + 1] === 'attack') {
+				newWord = 'specialattack';
+			}
+			break;
+		case 'spd':
+		case 'spdef': newWord = 'specialdefense'; break;
+		case 'spa':
+		case 'spatk': newWord = 'specialattack'; break;
+		case 'atk': newWord = 'attack'; break;
+		case 'def': newWord = 'defense'; break;
+		case 'spe': newWord = 'speed'; break;
+		case 'burn':
+		case 'burns': newWord = 'burned'; break;
+		case 'poison':
+		case 'poisons': newWord = 'poisoned'; break;
+		default:
+			if (/x[\d.]+/.test(newWord)) {
+				newWord = newWord.substr(1) + 'x';
+			}
+		}
+		if (!newWord || searchedWords.includes(newWord)) continue;
+		searchedWords.push(newWord);
+	}
+
+	if (searchedWords.length === 0 && !gen && !maxGen) {
+		return {error: "No distinguishing words were used. Try a more specific search."};
+	}
+
+	let bestMatched = 0;
+	const dex = maxGen ? Dex.mod("gen" + maxGen) : Dex;
+	for (const ability of dex.abilities.all()) {
+		let matched = 0;
+		// splits words in the description into a toID()-esque format except retaining / and . in numbers
+		let descWords = ability.desc || ability.shortDesc || '';
+		// add more general quantifier words to descriptions
+		if (/[1-9.]+x/.test(descWords)) descWords += ' increases';
+		descWords = descWords.replace(/super[-\s]effective/g, 'supereffective');
+		const descWordsArray = Chat.normalize(descWords).split(' ');
+
+		for (const word of searchedWords) {
+			switch (word) {
+			case 'specialattack':
+				if (descWordsArray[descWordsArray.indexOf('special') + 1] === 'attack') matched++;
+				break;
+			case 'specialdefense':
+				if (descWordsArray[descWordsArray.indexOf('special') + 1] === 'defense') matched++;
+				break;
+			default:
+				if (descWordsArray.includes(word)) matched++;
+			}
+		}
+
+		if (matched >= (searchedWords.length * 3 / 5) && (!maxGen || ability.gen <= maxGen) && (!gen || ability.gen === gen)) {
+			if (matched === bestMatched) {
+				foundAbilities.push(ability.name);
+			} else if (matched > bestMatched) {
+				foundAbilities = [ability.name];
+				bestMatched = matched;
+			}
+		}
+	}
+
+	if (foundAbilities.length === 1) return {dt: foundAbilities[0]};
+	let resultsStr = (message === "" ? message : `<span style="color:#999999;">${escapeHTML(message)}:</span><br />`);
+	if (foundAbilities.length > 0) {
+		foundAbilities.sort();
+		let notShown = 0;
+		if (!showAll && foundAbilities.length > RESULTS_MAX_LENGTH + 5) {
+			notShown = foundAbilities.length - RESULTS_MAX_LENGTH;
+			foundAbilities = foundAbilities.slice(0, RESULTS_MAX_LENGTH);
+		}
+		resultsStr += foundAbilities.map(
+			result => `<a href="//${Config.routes.dex}/abilities/${toID(result)}" target="_blank" class="subtle" style="white-space:nowrap">${result}</a>`
+		).join(", ");
+		if (notShown) {
+			resultsStr += `, and ${notShown} more. <span style="color:#999999;">Redo the search with ', all' at the end to show all results.</span>`;
+		}
+	} else {
+		resultsStr += "No abilities found. Try a more general search.";
+	}
+	return {reply: resultsStr};
+}
+
+function runLearn(target: string, cmd: string, canAll: boolean, formatid: string) {
+	let format: Format = Dex.formats.get(formatid);
+	const targets = target.split(',');
+	let formatName = format.name;
+	let minSourceGen = undefined;
+	let level = 100;
+
+	while (targets.length) {
+		const targetid = toID(targets[0]);
+		if (targetid === 'pentagon') {
+			if (format.exists) {
+				return {error: "'pentagon' can't be used with formats."};
+			}
+			minSourceGen = 6;
+			targets.shift();
+			continue;
+		}
+		if (targetid.startsWith('minsourcegen')) {
+			if (format.exists) {
+				return {error: "'min source gen' can't be used with formats."};
+			}
+			minSourceGen = parseInt(targetid.slice(12));
+			if (isNaN(minSourceGen) || minSourceGen < 1) return {error: `Invalid min source gen "${targetid.slice(12)}"`};
+			targets.shift();
+			continue;
+		}
+		if (targetid === 'level5') {
+			level = 5;
+			targets.shift();
+			continue;
+		}
+		break;
+	}
+	let gen;
+	const dex = Dex.mod(formatid).includeData();
+	if (!format.exists) {
+		// can happen if you hotpatch formats without hotpatching chat
+		if (!dex) return {error: `"${formatid}" is not a supported format.`};
+
+		gen = dex.gen;
+		format = new Dex.Format({mod: formatid});
+		formatName = `Gen ${gen}`;
+		if (minSourceGen) {
+			formatName += ` (Min Source Gen = ${minSourceGen})`;
+			const ruleTable = dex.formats.getRuleTable(format);
+			ruleTable.minSourceGen = minSourceGen;
+		}
+	} else {
+		gen = Dex.forFormat(format).gen;
+	}
+	const validator = TeamValidator.get(format);
+
+	const species = validator.dex.species.get(targets.shift());
+	const setSources = validator.allSources(species);
+	const set: Partial<PokemonSet> = {
+		name: species.baseSpecies,
+		species: species.name,
+		level,
+	};
+	const all = (cmd === 'learnall');
+
+	if (!species.exists || species.id === 'missingno') {
+		return {error: `Pok\u00e9mon '${species.id}' not found.`};
+	}
+
+	if (species.gen > gen) {
+		return {error: `${species.name} didn't exist yet in generation ${gen}.`};
+	}
+
+	if (!targets.length) {
+		return {error: "You must specify at least one move."};
+	}
+
+	const moveNames = [];
+	for (const arg of targets) {
+		if (['ha', 'hidden', 'hiddenability'].includes(toID(arg))) {
+			if (gen < 5) {
+				return {error: "Hidden abilities exist only in generations 5 and later."};
+			}
+			setSources.isHidden = true;
+			continue;
+		}
+		const move = validator.dex.moves.get(arg);
+		moveNames.push(move.name);
+		if (!move.exists) {
+			return {error: `Move '${move.id}' not found.`};
+		}
+		if (move.gen > gen) {
+			return {error: `${move.name} didn't exist yet in generation ${gen}.`};
+		}
+	}
+
+	const problems = validator.validateMoves(species, moveNames, setSources, set);
+	if (setSources.sources.length) {
+		setSources.sources = setSources.sources.map(source => {
+			if (source.charAt(1) !== 'E') return source;
+			const fathers = validator.findEggMoveFathers(source, species, setSources, true);
+			if (!fathers) return '';
+			return source + ':' + fathers.join(',');
+		}).filter(Boolean);
+		if (!setSources.size()) {
+			problems.push(`${species.name} doesn't have a valid father for its egg moves (${setSources.limitedEggMoves!.join(', ')})`);
+		}
+	}
+
+	let buffer = `In ${formatName}, `;
+	if (setSources.isHidden) {
+		const canUseAbilityPatch = dex.gen >= 8 && format.mod !== 'gen8dlc1';
+		console.log(setSources.sourcesBefore);
+		if (!setSources.sourcesBefore && !canUseAbilityPatch) {
+			const learnset = dex.species.getLearnsetData(species.id);
+			for (let sourceIndex = 0; sourceIndex < setSources.sources.length; sourceIndex++) {
+				const source = setSources.sources[sourceIndex];
+				if (source.charAt(1) === 'S' && learnset.eventData) {
+					const eventData = learnset.eventData[parseInt(source.substr(2))];
+					const hiddenAbilityProblem = validator.validateEventHiddenAbility(species.name, true, eventData, ` because it has a move only available from an event`);
+					if (hiddenAbilityProblem) {
+						setSources.sources.splice(sourceIndex, 1);
+						sourceIndex--;
+						if (!setSources.sources.length) {
+							problems.push(hiddenAbilityProblem);
+						}
+					}
+				}
+			}
+		}
+		if (species.maleOnlyHidden && setSources.sourcesBefore < 5) {
+			for (let sourceIndex = 0; sourceIndex < setSources.sources.length; sourceIndex++) {
+				const source = setSources.sources[sourceIndex];
+				if (source.charAt(1) === 'E') {
+					setSources.sources.splice(sourceIndex, 1);
+					sourceIndex--;
+					if (!setSources.sources.length) {
+						problems.push(`${species.name} has an unbreedable Hidden Ability - it can't use egg moves.`);
+					}
+				}
+			}
+		}
+		buffer += `${species.abilities['H'] || 'HA'} `;
+	}
+	buffer += `${species.name}` + (problems.length ? ` <span class="message-learn-cannotlearn">can't</span> learn ` : ` <span class="message-learn-canlearn">can</span> learn `) + toListString(moveNames);
+	if (!problems.length) {
+		const sourceNames: {[k: string]: string} = {
+			'7V': "virtual console transfer from gen 1-2", '8V': "Pok&eacute;mon Home transfer from LGPE", E: "", S: "event", D: "dream world", X: "traded-back ", Y: "traded-back event",
+		};
+		const sourcesBefore = setSources.sourcesBefore;
+		let sources = setSources.sources;
+		if (sources.length || sourcesBefore < gen) buffer += " only when obtained";
+		buffer += " from:<ul class=\"message-learn-list\">";
+		if (sources.length) {
+			sources = sources.map(source => {
+				if (source.startsWith('1ET')) {
+					return '2X' + source.slice(3);
+				}
+				if (source.startsWith('1ST')) {
+					return '2Y' + source.slice(3);
+				}
+				return source;
+			}).sort();
+			for (let source of sources) {
+				buffer += `<li>Gen ${source.charAt(0)} ${sourceNames[source] || sourceNames[source.charAt(1)]}`;
+
+				if (source.charAt(1) === 'E') {
+					let fathers;
+					[source, fathers] = source.split(':');
+					fathers = fathers.split(',');
+					if (fathers.length > 4 && !all) fathers = fathers.slice(-4).concat('...');
+					if (source.length > 2) {
+						buffer += `${source.slice(2)} `;
+					}
+					buffer += `egg`;
+					if (!fathers[0]) {
+						buffer += `: chainbreed`;
+					} else {
+						buffer += `: breed ${fathers.join(', ')}`;
+					}
+				}
+
+				if (source.startsWith('5E') && species.maleOnlyHidden) {
+					buffer += " (no hidden ability)";
+				}
+			}
+		}
+		if (sourcesBefore) {
+			const sourceGen = sourcesBefore < gen ? `Gen ${sourcesBefore} or earlier` : `anywhere`;
+			if (moveNames.length === 1) {
+				if (sourcesBefore >= 8) {
+					buffer += `<li>${sourceGen} (move is level-up/tutor/TM/HM/egg in Gen ${sourcesBefore})`;
+				} else {
+					buffer += `<li>${sourceGen} (move is level-up/tutor/TM/HM in Gen ${sourcesBefore})`;
+				}
+			} else if (gen >= 8) {
+				const orEarlier = sourcesBefore < gen ? ` or level-up/tutor/TM/HM in Gen ${sourcesBefore}${
+					sourcesBefore < 7 ? " to 7" : ""
+				}` : ``;
+				buffer += `<li>${sourceGen} (all moves are level-up/tutor/TM/HM/egg in Gen ${sourcesBefore}${orEarlier})`;
+			} else {
+				buffer += `<li>${sourceGen} (all moves are level-up/tutor/TM/HM in Gen ${Math.min(gen, sourcesBefore)}${sourcesBefore < gen ? " to " + gen : ""})`;
+			}
+		}
+		if (setSources.babyOnly && sourcesBefore) {
+			buffer += `<li>must be obtained as ` + Dex.species.get(setSources.babyOnly).name;
+		}
+		buffer += "</ul>";
+	} else if (problems.length >= 1) {
+		const expectedError = `${species.name} can't learn ${moveNames[0]}.`;
+		if (problems.length > 1 || moveNames.length > 1 || problems[0] !== expectedError) {
+			buffer += ` because:<ul class="message-learn-list">`;
+			buffer += `<li>` + problems.join(`</li><li>`) + `</li>`;
+			buffer += `</ul>`;
+		}
+	}
+	return {reply: buffer};
+}
+
+function runSearch(query: {target: string, cmd: string, canAll: boolean, message: string}) {
+	return PM.query(query);
+}
+
+/*********************************************************
+ * Process manager
+ *********************************************************/
+
+export const PM = new ProcessManager.QueryProcessManager<AnyObject, AnyObject>(module, query => {
+	try {
+		if (Config.debugdexsearchprocesses && process.send) {
+			process.send('DEBUG\n' + JSON.stringify(query));
+		}
+		switch (query.cmd) {
+		case 'randpoke':
+		case 'dexsearch':
+			return runDexsearch(query.target, query.cmd, query.canAll, query.message, false);
+		case 'randmove':
+		case 'movesearch':
+			return runMovesearch(query.target, query.cmd, query.canAll, query.message, false);
+		case 'itemsearch':
+			return runItemsearch(query.target, query.cmd, query.canAll, query.message);
+		case 'abilitysearch':
+			return runAbilitysearch(query.target, query.cmd, query.canAll, query.message);
+		case 'learn':
+			return runLearn(query.target, query.cmd, query.canAll, query.message);
+		default:
+			throw new Error(`Unrecognized Dexsearch command "${query.cmd}"`);
+		}
+	} catch (err) {
+		Monitor.crashlog(err, 'A search query', query);
+	}
+	return {
+		error: "Sorry! Our search engine crashed on your query. We've been automatically notified and will fix this crash.",
+	};
+});
+
+if (!PM.isParentProcess) {
+	// This is a child process!
+	global.Config = require('../config-loader').Config;
+	global.Monitor = {
+		crashlog(error: Error, source = 'A datasearch process', details: AnyObject | null = null) {
+			const repr = JSON.stringify([error.name, error.message, source, details]);
+			process.send!(`THROW\n@!!@${repr}\n${error.stack}`);
+		},
+	};
+	if (Config.crashguard) {
+		process.on('uncaughtException', err => {
+			Monitor.crashlog(err, 'A dexsearch process');
+		});
+	}
+
+	global.Dex = require('../../sim/dex').Dex;
+	global.toID = Dex.toID;
+	Dex.includeData();
+
+	// @ts-ignore
+	require('../../lib/repl').Repl.start('dexsearch', cmd => eval(cmd)); // eslint-disable-line no-eval
+} else {
+	PM.spawn(MAX_PROCESSES);
+}
+
+export const testables = {
+	runAbilitysearch: (target: string, cmd: string, canAll: boolean, message: string) =>
+		runAbilitysearch(target, cmd, canAll, message),
+	runDexsearch: (target: string, cmd: string, canAll: boolean, message: string) =>
+		runDexsearch(target, cmd, canAll, message, true),
+	runMovesearch: (target: string, cmd: string, canAll: boolean, message: string) =>
+		runMovesearch(target, cmd, canAll, message, true),
+};

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -2469,7 +2469,8 @@ function runLearn(target: string, cmd: string, canAll: boolean, formatid: string
 				const source = setSources.sources[sourceIndex];
 				if (source.charAt(1) === 'S' && learnset.eventData) {
 					const eventData = learnset.eventData[parseInt(source.substr(2))];
-					const hiddenAbilityProblem = validator.validateEventHiddenAbility(species.name, true, eventData, ` because it has a move only available from an event`);
+					const hiddenAbilityProblem = validator.validateEventHiddenAbility(species.name, true, eventData, 
+						` because it has a move only available from an event`);
 					if (hiddenAbilityProblem) {
 						setSources.sources.splice(sourceIndex, 1);
 						sourceIndex--;

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -8,2600 +8,2635 @@
  * @license MIT
  */
 
-import {ProcessManager, Utils} from '../../lib';
-import {TeamValidator} from '../../sim/team-validator';
-import {Chat} from '../chat';
-
-interface DexOrGroup {
-	abilities: {[k: string]: boolean};
-	tiers: {[k: string]: boolean};
-	doublesTiers: {[k: string]: boolean};
-	colors: {[k: string]: boolean};
-	'egg groups': {[k: string]: boolean};
-	formes: {[k: string]: boolean};
-	gens: {[k: string]: boolean};
-	moves: {[k: string]: boolean};
-	types: {[k: string]: boolean};
-	resists: {[k: string]: boolean};
-	weak: {[k: string]: boolean};
-	stats: {[k: string]: {[k in Direction]: number}};
-	skip: boolean;
-}
-
-interface MoveOrGroup {
-	types: {[k: string]: boolean};
-	categories: {[k: string]: boolean};
-	contestTypes: {[k: string]: boolean};
-	flags: {[k: string]: boolean};
-	gens: {[k: string]: boolean};
-	other: {[k: string]: boolean};
-	mon: {[k: string]: boolean};
-	property: {[k: string]: {[k in Direction]: number}};
-	boost: {[k: string]: boolean};
-	lower: {[k: string]: boolean};
-	zboost: {[k: string]: boolean};
-	status: {[k: string]: boolean};
-	volatileStatus: {[k: string]: boolean};
-	targets: {[k: string]: boolean};
-	skip: boolean;
-	multihit: boolean;
-}
-
-type Direction = 'less' | 'greater' | 'equal';
-
-const MAX_PROCESSES = 1;
-const RESULTS_MAX_LENGTH = 10;
-const MAX_RANDOM_RESULTS = 30;
-const dexesHelp = Object.keys((global.Dex?.dexes || {})).filter(x => x !== 'sourceMaps').join('</code>, <code>');
-
-function escapeHTML(str?: string) {
-	if (!str) return '';
-	return ('' + str)
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;')
-		.replace(/'/g, '&apos;')
-		.replace(/\//g, '&#x2f;');
-}
-
-function toListString(arr: string[]) {
-	if (!arr.length) return '';
-	if (arr.length === 1) return arr[0];
-	if (arr.length === 2) return `${arr[0]} and ${arr[1]}`;
-	return `${arr.slice(0, -1).join(", ")}, and ${arr.slice(-1)[0]}`;
-}
-
-function checkCanAll(room: Room | null) {
-	if (!room) return false; // no, no good reason for using `all` in pms
-	const {isPersonal, isHelp} = room.settings;
-	// allowed if it's a groupchat
-	return !room.battle && !!isPersonal && !isHelp;
-}
-
-export const commands: Chat.ChatCommands = {
-	ds: 'dexsearch',
-	ds1: 'dexsearch',
-	ds2: 'dexsearch',
-	ds3: 'dexsearch',
-	ds4: 'dexsearch',
-	ds5: 'dexsearch',
-	ds6: 'dexsearch',
-	ds7: 'dexsearch',
-	ds8: 'dexsearch',
-	dsearch: 'dexsearch',
-	nds: 'dexsearch',
-	async dexsearch(target, room, user, connection, cmd, message) {
-		this.checkBroadcast();
-		if (!target) return this.parse('/help dexsearch');
-		if (target.length > 300) return this.errorReply('Dexsearch queries may not be longer than 300 characters.');
-		const targetGen = parseInt(cmd[cmd.length - 1]);
-		if (targetGen) target += `, mod=gen${targetGen}`;
-		const split = target.split(',').map(term => term.trim());
-		const index = split.findIndex(x => /^max\s*gen/i.test(x));
-		if (index >= 0) {
-			const genNum = parseInt(/\d*$/.exec(split[index])?.[0] || '');
-			if (!isNaN(genNum) && !(genNum < 1 || genNum > Dex.gen)) {
-				split[index] = `mod=gen${genNum}`;
-				target = split.join(',');
-			}
-		}
-		if (!target.includes('mod=')) {
-			const dex = this.extractFormat(room?.settings.defaultFormat || room?.battle?.format).dex;
-			if (dex) target += `, mod=${dex.currentMod}`;
-		}
-		if (cmd === 'nds') target += ', natdex';
-		const response = await runSearch({
-			target,
-			cmd: 'dexsearch',
-			canAll: !this.broadcastMessage || checkCanAll(room),
-			message: (this.broadcastMessage ? "" : message),
-		});
-		if (!response.error && !this.runBroadcast()) return;
-		if (response.error) {
-			throw new Chat.ErrorMessage(response.error);
-		} else if (response.reply) {
-			this.sendReplyBox(response.reply);
-		} else if (response.dt) {
-			(Chat.commands.data as Chat.ChatHandler).call(
-				this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
-			);
-		}
-	},
-	dexsearchhelp() {
-		this.sendReply(
-			`|html| <details class="readmore"><summary><code>/dexsearch [parameter], [parameter], [parameter], ...</code>: searches for Pok\u00e9mon that fulfill the selected criteria<br/>` +
-			`Search categories are: type, tier, color, moves, ability, gen, resists, weak, recovery, zrecovery, priority, stat, weight, height, egg group, pivot.<br/>` +
-			`Valid colors are: green, red, blue, white, brown, yellow, purple, pink, gray and black.<br/>` +
-			`Valid tiers are: Uber/OU/UUBL/UU/RUBL/RU/NUBL/NU/PUBL/PU/ZU/NFE/LC/CAP/CAP NFE/CAP LC.<br/>` +
-			`Valid doubles tiers are: DUber/DOU/DBL/DUU/DNU.</summary>` +
-			`Types can be searched for by either having the type precede <code>type</code> or just using the type itself as a parameter; e.g., both <code>fire type</code> and <code>fire</code> show all Fire types; however, using <code>psychic</code> as a parameter will show all Pok\u00e9mon that learn the move Psychic and not Psychic types.<br/>` +
-			`<code>resists</code> followed by a type or move will show Pok\u00e9mon that resist that typing or move (e.g. <code>resists normal</code>).<br/>` +
-			`<code>weak</code> followed by a type or move will show Pok\u00e9mon that are weak to that typing or move (e.g. <code>weak fire</code>).<br/>` +
-			`<code>asc</code> or <code>desc</code> following a stat will show the Pok\u00e9mon in ascending or descending order of that stat respectively (e.g. <code>speed asc</code>).<br/>` +
-			`Inequality ranges use the characters <code>>=</code> for <code>≥</code> and <code><=</code> for <code>≤</code>; e.g., <code>hp <= 95</code> searches all Pok\u00e9mon with HP less than or equal to 95.<br/>` +
-			`Parameters can be excluded through the use of <code>!</code>; e.g., <code>!water type</code> excludes all Water types.<br/>` +
-			`The parameter <code>mega</code> can be added to search for Mega Evolutions only, the parameter <code>gmax</code> can be added to search for Pokemon capable of Gigantamaxing only, and the parameter <code>Fully Evolved</code> (or <code>FE</code>) can be added to search for fully-evolved Pok\u00e9mon.<br/>` +
-			`<code>Alola</code>, <code>Galar</code>, <code>Therian</code>, <code>Totem</code>, or <code>Primal</code> can be used as parameters to search for those formes.<br/>` +
-			`Parameters separated with <code>|</code> will be searched as alternatives for each other; e.g., <code>trick | switcheroo</code> searches for all Pok\u00e9mon that learn either Trick or Switcheroo.<br/>` +
-			`You can search for info in a specific generation by appending the generation to ds or by using the <code>maxgen</code> keyword; e.g. <code>/ds1 normal</code> or <code>/ds normal, maxgen1</code> searches for all Pok\u00e9mon that were Normal type in Generation I.<br/>` +
-			`You can search for info in a specific mod by using <code>mod=[mod name]</code>; e.g. <code>/nds mod=ssb, protean</code>. All valid mod names are: <code>${dexesHelp}</code><br />` +
-			`<code>/dexsearch</code> will search the Galar Pokedex; you can search the National Pokedex by using <code>/nds</code> or by adding <code>natdex</code> as a parameter.<br/>` +
-			`Searching for a Pok\u00e9mon with both egg group and type parameters can be differentiated by adding the suffix <code>group</code> onto the egg group parameter; e.g., seaching for <code>grass, grass group</code> will show all Grass types in the Grass egg group.<br/>` +
-			`The parameter <code>monotype</code> will only show Pok\u00e9mon that are single-typed.<br/>` +
-			`The order of the parameters does not matter.<br/>`
-		);
-	},
-
-	rollmove: 'randommove',
-	randmove: 'randommove',
-	async randommove(target, room, user, connection, cmd, message) {
-		this.checkBroadcast(true);
-		target = target.slice(0, 300);
-		const targets = target.split(",");
-		const targetsBuffer = [];
-		let qty;
-		for (const arg of targets) {
-			if (!arg) continue;
-			const num = Number(arg);
-			if (Number.isInteger(num)) {
-				if (qty) throw new Chat.ErrorMessage("Only specify the number of Pok\u00e9mon Moves once.");
-				qty = num;
-				if (qty < 1 || MAX_RANDOM_RESULTS < qty) {
-					throw new Chat.ErrorMessage(`Number of random Pok\u00e9mon Moves must be between 1 and ${MAX_RANDOM_RESULTS}.`);
-				}
-				targetsBuffer.push(`random${qty}`);
-			} else {
-				targetsBuffer.push(arg);
-			}
-		}
-		if (!qty) targetsBuffer.push("random1");
-
-		const response = await runSearch({
-			target: targetsBuffer.join(","),
-			cmd: 'randmove',
-			canAll: !this.broadcastMessage || checkCanAll(room),
-			message: (this.broadcastMessage ? "" : message),
-		});
-		if (!response.error && !this.runBroadcast(true)) return;
-		if (response.error) {
-			throw new Chat.ErrorMessage(response.error);
-		} else if (response.reply) {
-			this.sendReplyBox(response.reply);
-		} else if (response.dt) {
-			(Chat.commands.data as Chat.ChatHandler).call(
-				this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
-			);
-		}
-	},
-	randommovehelp: [
-		`/randommove - Generates random Pok\u00e9mon Moves based on given search conditions.`,
-		`/randommove uses the same parameters as /movesearch (see '/help ms').`,
-		`Adding a number as a parameter returns that many random Pok\u00e9mon Moves, e.g., '/randmove 6' returns 6 random Pok\u00e9mon Moves.`,
-	],
-
-	rollpokemon: 'randompokemon',
-	randpoke: 'randompokemon',
-	async randompokemon(target, room, user, connection, cmd, message) {
-		this.checkBroadcast(true);
-		target = target.slice(0, 300);
-		const targets = target.split(",");
-		const targetsBuffer = [];
-		let qty;
-		for (const arg of targets) {
-			if (!arg) continue;
-			const num = Number(arg);
-			if (Number.isInteger(num)) {
-				if (qty) throw new Chat.ErrorMessage("Only specify the number of Pok\u00e9mon once.");
-				qty = num;
-				if (qty < 1 || MAX_RANDOM_RESULTS < qty) {
-					throw new Chat.ErrorMessage(`Number of random Pok\u00e9mon must be between 1 and ${MAX_RANDOM_RESULTS}.`);
-				}
-				targetsBuffer.push(`random${qty}`);
-			} else {
-				targetsBuffer.push(arg);
-			}
-		}
-		if (!qty) targetsBuffer.push("random1");
-
-		const response = await runSearch({
-			target: targetsBuffer.join(","),
-			cmd: 'randpoke',
-			canAll: !this.broadcastMessage || checkCanAll(room),
-			message: (this.broadcastMessage ? "" : message),
-		});
-		if (!response.error && !this.runBroadcast(true)) return;
-		if (response.error) {
-			throw new Chat.ErrorMessage(response.error);
-		} else if (response.reply) {
-			this.sendReplyBox(response.reply);
-		} else if (response.dt) {
-			(Chat.commands.data as Chat.ChatHandler).call(
-				this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
-			);
-		}
-	},
-	randompokemonhelp: [
-		`/randompokemon - Generates random Pok\u00e9mon based on given search conditions.`,
-		`/randompokemon uses the same parameters as /dexsearch (see '/help ds').`,
-		`Adding a number as a parameter returns that many random Pok\u00e9mon, e.g., '/randpoke 6' returns 6 random Pok\u00e9mon.`,
-	],
-
-	ms: 'movesearch',
-	ms1: 'movesearch',
-	ms2: 'movesearch',
-	ms3: 'movesearch',
-	ms4: 'movesearch',
-	ms5: 'movesearch',
-	ms6: 'movesearch',
-	ms7: 'movesearch',
-	ms8: 'movesearch',
-	msearch: 'movesearch',
-	nms: 'movesearch',
-	async movesearch(target, room, user, connection, cmd, message) {
-		this.checkBroadcast();
-		if (!target) return this.parse('/help movesearch');
-		target = target.slice(0, 300);
-		const targetGen = parseInt(cmd[cmd.length - 1]);
-		if (targetGen) target += `, mod=gen${targetGen}`;
-		const split = target.split(',').map(term => term.trim());
-		const index = split.findIndex(x => /^max\s*gen/i.test(x));
-		if (index >= 0) {
-			const genNum = parseInt(/\d*$/.exec(split[index])?.[0] || '');
-			if (!isNaN(genNum) && !(genNum < 1 || genNum > Dex.gen)) {
-				split[index] = `mod=gen${genNum}`;
-				target = split.join(',');
-			}
-		}
-		if (!target.includes('mod=')) {
-			const dex = this.extractFormat(room?.settings.defaultFormat || room?.battle?.format).dex;
-			if (dex) target += `, mod=${dex.currentMod}`;
-		}
-		if (cmd === 'nms') target += ', natdex';
-		const response = await runSearch({
-			target,
-			cmd: 'movesearch',
-			canAll: !this.broadcastMessage || checkCanAll(room),
-			message: (this.broadcastMessage ? "" : message),
-		});
-		if (!response.error && !this.runBroadcast()) return;
-		if (response.error) {
-			throw new Chat.ErrorMessage(response.error);
-		} else if (response.reply) {
-			this.sendReplyBox(response.reply);
-		} else if (response.dt) {
-			(Chat.commands.data as Chat.ChatHandler).call(
-				this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
-			);
-		}
-	},
-	movesearchhelp() {
-		this.sendReply(
-			`|html| <details class="readmore"><summary><code>/movesearch [parameter], [parameter], [parameter], ...</code>: searches for moves that fulfill the selected criteria.<br/>` +
-			`Search categories are: type, category, gen, contest condition, flag, status inflicted, type boosted, Pok\u00e9mon targeted, and numeric range for base power, pp, priority, and accuracy.<br/>` +
-			`Types can be followed by <code> type</code> for clarity; e.g., <code>dragon type</code>.<br/>` +
-			`Stat boosts must be preceded with <code>boosts </code>, and stat-lowering moves with <code>lowers </code>; e.g., <code>boosts attack</code> searches for moves that boost the Attack stat of either Pok\u00e9mon.<br/>` +
-			`Z-stat boosts must be preceded with <code>zboosts </code>; e.g., <code>zboosts accuracy</code> searches for all Status moves with Z-Effects that boost the user's accuracy.</summary>` +
-			`Moves that have a Z-Effect of fully restoring the user's health can be searched for with <code>zrecovery</code>.<br/>` +
-			`Move targets must be preceded with <code>targets </code>; e.g., <code>targets user</code> searches for moves that target the user.<br/>` +
-			`Valid move targets are: one ally, user or ally, one adjacent opponent, all Pokemon, all adjacent Pokemon, all adjacent opponents, user and allies, user's side, user's team, any Pokemon, opponent's side, one adjacent Pokemon, random adjacent Pokemon, scripted, and user.<br/>` +
-			`Inequality ranges use the characters <code>></code> and <code><</code>.<br/>` +
-			`Parameters can be excluded through the use of <code>!</code>; e.g., <code>!water type</code> excludes all Water-type moves.<br/>` +
-			`<code>asc</code> or <code>desc</code> following a move property will arrange the names in ascending or descending order of that property, respectively; e.g., <code>basepower asc</code> will arrange moves in ascending order of their base powers.<br/>` +
-			`Valid flags are: bypasssub (bypasses substitute), bite, bullet, charge, contact, dance, defrost, gravity, mirror (reflected by mirror move), ohko, powder, priority, protect, pulse, punch, recharge, recovery, reflectable, secondary, snatch, sound, zmove, pivot, and multi-hit.<br/>` +
-			`A search that includes <code>!protect</code> will show all moves that bypass protection.<br/>` +
-			`<code>protection</code> as a parameter will search protection moves like Protect, Detect, etc.<br/>` +
-			`<code>max</code> or <code>gmax</code> as parameters will search for Max Moves and G-Max moves respectively.<br/>` +
-			`Parameters separated with <code>|</code> will be searched as alternatives for each other; e.g., <code>fire | water</code> searches for all moves that are either Fire type or Water type.<br/>` +
-			`If a Pok\u00e9mon is included as a parameter, only moves from its movepool will be included in the search.<br/>` +
-			`You can search for info in a specific generation by appending the generation to ms; e.g. <code>/ms1 normal</code> searches for all moves that were Normal type in Generation I.<br/>` +
-			`You can search for info in a specific mod by using <code>mod=[mod name]</code>; e.g. <code>/nms mod=ssb, dark, bp=100</code>. All valid mod names are: <code>${dexesHelp}</code><br />` +
-			`<code>/ms</code> will search the Galar Moves; you can search the National Moves by using <code>/nms</code> or by adding <code>natdex</code> as a parameter.<br/>` +
-			`The order of the parameters does not matter.`
-		);
-	},
-
-	isearch: 'itemsearch',
-	is: 'itemsearch',
-	is2: 'itemsearch',
-	is3: 'itemsearch',
-	is4: 'itemsearch',
-	is5: 'itemsearch',
-	is6: 'itemsearch',
-	is7: 'itemsearch',
-	is8: 'itemsearch',
-	async itemsearch(target, room, user, connection, cmd, message) {
-		this.checkBroadcast();
-		if (!target) return this.parse('/help itemsearch');
-		target = target.slice(0, 300);
-		const targetGen = parseInt(cmd[cmd.length - 1]);
-		if (targetGen) target += ` maxgen${targetGen}`;
-
-		const response = await runSearch({
-			target,
-			cmd: 'itemsearch',
-			canAll: !this.broadcastMessage || checkCanAll(room),
-			message: (this.broadcastMessage ? "" : message),
-		});
-		if (!response.error && !this.runBroadcast()) return;
-		if (response.error) {
-			throw new Chat.ErrorMessage(response.error);
-		} else if (response.reply) {
-			this.sendReplyBox(response.reply);
-		} else if (response.dt) {
-			(Chat.commands.data as Chat.ChatHandler).call(
-				this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
-			);
-		}
-	},
-	itemsearchhelp() {
-		this.sendReplyBox(
-			`<code>/itemsearch [item description]</code>: finds items that match the given keywords.<br/>` +
-			`This command accepts natural language. (tip: fewer words tend to work better)<br/>` +
-			`The <code>gen</code> keyword can be used to search for items introduced in a given generation; e.g., <code>/is gen4</code> searches for items introduced in Generation 4.<br/>` +
-			`To search for items within a generation, append the generation to <code>/is</code> or use the <code>maxgen</code> keyword; e.g., <code>/is4 Water-type</code> or <code>/is maxgen4 Water-type</code> searches for items whose Generation 4 description includes "Water-type".<br/>` +
-			`Searches with <code>fling</code> in them will find items with the specified Fling behavior.<br/>` +
-			`Searches with <code>natural gift</code> in them will find items with the specified Natural Gift behavior.`
-		);
-	},
-
-	asearch: 'abilitysearch',
-	as: 'abilitysearch',
-	as3: 'abilitysearch',
-	as4: 'abilitysearch',
-	as5: 'abilitysearch',
-	as6: 'abilitysearch',
-	as7: 'abilitysearch',
-	as8: 'abilitysearch',
-	async abilitysearch(target, room, user, connection, cmd, message) {
-		this.checkBroadcast();
-		if (!target) return this.parse('/help abilitysearch');
-		target = target.slice(0, 300);
-		const targetGen = parseInt(cmd[cmd.length - 1]);
-		if (targetGen) target += ` maxgen${targetGen}`;
-
-		const response = await runSearch({
-			target,
-			cmd: 'abilitysearch',
-			canAll: !this.broadcastMessage || checkCanAll(room),
-			message: (this.broadcastMessage ? "" : message),
-		});
-		if (!response.error && !this.runBroadcast()) return;
-		if (response.error) {
-			throw new Chat.ErrorMessage(response.error);
-		} else if (response.reply) {
-			this.sendReplyBox(response.reply);
-		} else if (response.dt) {
-			(Chat.commands.data as Chat.ChatHandler).call(
-				this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
-			);
-		}
-	},
-	abilitysearchhelp() {
-		this.sendReplyBox(
-			`<code>/abilitysearch [ability description]</code>: finds abilities that match the given keywords.<br/>` +
-			`This command accepts natural language. (tip: fewer words tend to work better)<br/>` +
-			`The <code>gen</code> keyword can be used to search for abilities introduced in a given generation; e.g., <code>/as gen4</code> searches for abilities introduced in Generation 4.<br/>` +
-			`To search for abilities within a generation, append the generation to <code>/as</code> or use the <code>maxgen</code> keyword; e.g., <code>/as4 Water-type</code> or <code>/as maxgen4 Water-type</code> searches for abilities whose Generation 4 description includes "Water-type".`
-		);
-	},
-
-	learnset: 'learn',
-	learnall: 'learn',
-	learn5: 'learn',
-	rbylearn: 'learn',
-	gsclearn: 'learn',
-	advlearn: 'learn',
-	dpplearn: 'learn',
-	bw2learn: 'learn',
-	oraslearn: 'learn',
-	usumlearn: 'learn',
-	async learn(target, room, user, connection, cmd, message) {
-		if (!target) return this.parse('/help learn');
-		if (target.length > 300) throw new Chat.ErrorMessage(`Query too long.`);
-
-		const GENS: {[k: string]: number} = {rby: 1, gsc: 2, adv: 3, dpp: 4, bw2: 5, oras: 6, usum: 7};
-		const cmdGen = GENS[cmd.slice(0, -5)];
-		if (cmdGen) target = `gen${cmdGen}, ${target}`;
-
-		this.checkBroadcast();
-		const {format, dex, targets} = this.splitFormat(target);
-
-		const formatid = format ? format.id : dex.currentMod;
-		if (cmd === 'learn5') targets.unshift('level5');
-
-		const response = await runSearch({
-			target: targets.join(','),
-			cmd: 'learn',
-			canAll: !this.broadcastMessage || checkCanAll(room),
-			message: formatid,
-		});
-		if (!response.error && !this.runBroadcast()) return;
-		if (response.error) {
-			throw new Chat.ErrorMessage(response.error);
-		} else if (response.reply) {
-			this.sendReplyBox(response.reply);
-		}
-	},
-	learnhelp: [
-		`/learn [ruleset], [pokemon], [move, move, ...] - Displays how the Pok\u00e9mon can learn the given moves, if it can at all.`,
-		`!learn [ruleset], [pokemon], [move, move, ...] - Show everyone that information. Requires: + % @ # &`,
-		`Specifying a ruleset is entirely optional. The ruleset can be a format, a generation (e.g.: gen3) or "min source gen [number]".`,
-		`A value of 'min source gen [number]' indicates that trading (or Pokémon Bank) from generations before [number] is not allowed.`,
-		`/learn5 displays how the Pok\u00e9mon can learn the given moves at level 5, if it can at all.`,
-		`/learnall displays all of the possible fathers for egg moves.`,
-		`/learn can also be prefixed by a generation acronym (e.g.: /dpplearn) to indicate which generation is used. Valid options are: rby gsc adv dpp bw2 oras usum`,
-	],
-};
-
-function getMod(target: string) {
-	const arr = target.split(',').map(x => x.trim());
-	const modTerm = arr.find(x => {
-		const sanitizedStr = x.toLowerCase().replace(/[^a-z0-9=]+/g, '');
-		return sanitizedStr.startsWith('mod=') && Dex.dexes[toID(sanitizedStr.split('=')[1])];
-	});
-	const count = arr.filter(x => {
-		const sanitizedStr = x.toLowerCase().replace(/[^a-z0-9=]+/g, '');
-		return sanitizedStr.startsWith('mod=');
-	}).length;
-	if (modTerm) arr.splice(arr.indexOf(modTerm), 1);
-	return {splitTarget: arr, usedMod: modTerm ? toID(modTerm.split(/ ?= ?/)[1]) : undefined, count};
-}
-
-function runDexsearch(target: string, cmd: string, canAll: boolean, message: string, isTest: boolean) {
-	const searches: DexOrGroup[] = [];
-	const {splitTarget, usedMod, count: c} = getMod(target);
-	if (c > 1) {
-		return {error: `You can't run searches for multiple mods.`};
-	}
-
-	const mod = Dex.mod(usedMod || 'base');
-	const allTiers: {[k: string]: TierTypes.Singles | TierTypes.Other} = Object.assign(Object.create(null), {
-		anythinggoes: 'AG', ag: 'AG',
-		uber: 'Uber', ubers: 'Uber', ou: 'OU',
-		uubl: 'UUBL', uu: 'UU',
-		rubl: 'RUBL', ru: 'RU',
-		nubl: 'NUBL', nu: 'NU',
-		publ: 'PUBL', pu: 'PU', zu: '(PU)',
-		nfe: 'NFE',
-		lc: 'LC',
-		cap: 'CAP', caplc: 'CAP LC', capnfe: 'CAP NFE',
-	});
-	const allDoublesTiers: {[k: string]: TierTypes.Singles | TierTypes.Other} = Object.assign(Object.create(null), {
-		doublesubers: 'DUber', doublesuber: 'DUber', duber: 'DUber', dubers: 'DUber',
-		doublesou: 'DOU', dou: 'DOU',
-		doublesbl: 'DBL', dbl: 'DBL',
-		doublesuu: 'DUU', duu: 'DUU',
-		doublesnu: '(DUU)', dnu: '(DUU)',
-	});
-	const allTypes = Object.create(null);
-	for (const type of mod.types.all()) {
-		allTypes[type.id] = type.name;
-	}
-	const allColors = ['green', 'red', 'blue', 'white', 'brown', 'yellow', 'purple', 'pink', 'gray', 'black'];
-	const allEggGroups: {[k: string]: string} = Object.assign(Object.create(null), {
-		amorphous: 'Amorphous',
-		bug: 'Bug',
-		ditto: 'Ditto',
-		dragon: 'Dragon',
-		fairy: 'Fairy',
-		field: 'Field',
-		flying: 'Flying',
-		grass: 'Grass',
-		humanlike: 'Human-Like',
-		mineral: 'Mineral',
-		monster: 'Monster',
-		undiscovered: 'Undiscovered',
-		water1: 'Water 1',
-		water2: 'Water 2',
-		water3: 'Water 3',
-	});
-	const allFormes = ['alola', 'galar', 'primal', 'therian', 'totem'];
-	const allStats = ['hp', 'atk', 'def', 'spa', 'spd', 'spe', 'bst', 'weight', 'height', 'gen'];
-	const allStatAliases: {[k: string]: string} = {
-		attack: 'atk', defense: 'def', specialattack: 'spa', spc: 'spa', special: 'spa', spatk: 'spa',
-		specialdefense: 'spd', spdef: 'spd', speed: 'spe', wt: 'weight', ht: 'height', generation: 'gen',
-	};
-	let showAll = false;
-	let sort = null;
-	let megaSearch = null;
-	let gmaxSearch = null;
-	let tierSearch = null;
-	let capSearch: boolean | null = null;
-	let nationalSearch = null;
-	let fullyEvolvedSearch = null;
-	let singleTypeSearch = null;
-	let randomOutput = 0;
-	const validParameter = (cat: string, param: string, isNotSearch: boolean, input: string) => {
-		const uniqueTraits = ['colors', 'gens'];
-		for (const group of searches) {
-			const g = group[cat as keyof DexOrGroup];
-			if (g === undefined) continue;
-			if (typeof g !== 'boolean' && g[param] === undefined) {
-				if (uniqueTraits.includes(cat)) {
-					for (const currentParam in g) {
-						if (g[currentParam] !== isNotSearch && !isNotSearch) return `A Pok&eacute;mon cannot have multiple ${cat}.`;
-					}
-				}
-				continue;
-			}
-			if (typeof g !== 'boolean' && g[param] === isNotSearch) {
-				return `A search cannot both include and exclude '${input}'.`;
-			} else {
-				return `The search included '${(isNotSearch ? "!" : "") + input}' more than once.`;
-			}
-		}
-		return false;
-	};
-
-	for (const andGroup of splitTarget) {
-		const orGroup: DexOrGroup = {
-			abilities: {}, tiers: {}, doublesTiers: {}, colors: {}, 'egg groups': {}, formes: {},
-			gens: {}, moves: {}, types: {}, resists: {}, weak: {}, stats: {}, skip: false,
-		};
-		const parameters = andGroup.split("|");
-		if (parameters.length > 3) return {error: "No more than 3 alternatives for each parameter may be used."};
-		for (const parameter of parameters) {
-			let isNotSearch = false;
-			target = parameter.trim().toLowerCase();
-			if (target.startsWith('!')) {
-				isNotSearch = true;
-				target = target.substr(1);
-			}
-
-			const targetAbility = mod.abilities.get(target);
-			if (targetAbility.exists) {
-				const invalid = validParameter("abilities", targetAbility.id, isNotSearch, targetAbility.name);
-				if (invalid) return {error: invalid};
-				orGroup.abilities[targetAbility.name] = !isNotSearch;
-				continue;
-			}
-
-			if (toID(target) in allTiers) {
-				target = allTiers[toID(target)];
-				if (target.startsWith("CAP")) {
-					if (capSearch === isNotSearch) return {error: "A search cannot both include and exclude CAP tiers."};
-					capSearch = !isNotSearch;
-				}
-				const invalid = validParameter("tiers", target, isNotSearch, target);
-				if (invalid) return {error: invalid};
-				tierSearch = tierSearch || !isNotSearch;
-				orGroup.tiers[target] = !isNotSearch;
-				continue;
-			}
-
-			if (toID(target) in allDoublesTiers) {
-				target = allDoublesTiers[toID(target)];
-				const invalid = validParameter("doubles tiers", target, isNotSearch, target);
-				if (invalid) return {error: invalid};
-				tierSearch = tierSearch || !isNotSearch;
-				orGroup.doublesTiers[target] = !isNotSearch;
-				continue;
-			}
-
-			if (allColors.includes(target)) {
-				target = target.charAt(0).toUpperCase() + target.slice(1);
-				const invalid = validParameter("colors", target, isNotSearch, target);
-				if (invalid) return {error: invalid};
-				orGroup.colors[target] = !isNotSearch;
-				continue;
-			}
-
-			const targetMove = mod.moves.get(target);
-			if (targetMove.exists) {
-				const invalid = validParameter("moves", targetMove.id, isNotSearch, target);
-				if (invalid) return {error: invalid};
-				orGroup.moves[targetMove.id] = !isNotSearch;
-				continue;
-			}
-
-			let targetType;
-			if (target.endsWith('type')) {
-				targetType = toID(target.substring(0, target.indexOf('type')));
-			} else {
-				targetType = toID(target);
-			}
-			if (targetType in allTypes) {
-				target = allTypes[targetType];
-				const invalid = validParameter("types", target, isNotSearch, target);
-				if (invalid) return {error: invalid};
-				if ((orGroup.types[target] && isNotSearch) || (orGroup.types[target] === false && !isNotSearch)) {
-					return {error: 'A search cannot both exclude and include a type.'};
-				}
-				orGroup.types[target] = !isNotSearch;
-				continue;
-			}
-
-			if (['mono', 'monotype'].includes(toID(target))) {
-				if (singleTypeSearch === isNotSearch) return {error: "A search cannot include and exclude 'monotype'."};
-				if (parameters.length > 1) return {error: "The parameter 'monotype' cannot have alternative parameters."};
-				singleTypeSearch = !isNotSearch;
-				orGroup.skip = true;
-				continue;
-			}
-
-			if (target === 'natdex') {
-				if (parameters.length > 1) return {error: "The parameter 'natdex' cannot have alternative parameters."};
-				nationalSearch = true;
-				orGroup.skip = true;
-				continue;
-			}
-
-			let groupIndex = target.indexOf('group');
-			if (groupIndex === -1) groupIndex = target.length;
-			if (groupIndex !== target.length || toID(target) in allEggGroups) {
-				target = toID(target.substring(0, groupIndex));
-				if (target in allEggGroups) {
-					target = allEggGroups[toID(target)];
-					const invalid = validParameter("egg groups", target, isNotSearch, target);
-					if (invalid) return {error: invalid};
-					orGroup['egg groups'][target] = !isNotSearch;
-					continue;
-				} else {
-					return {error: `'${target}' is not a recognized egg group.`};
-				}
-			}
-			if (toID(target) in allEggGroups) {
-				target = allEggGroups[toID(target)];
-				const invalid = validParameter("egg groups", target, isNotSearch, target);
-				if (invalid) return {error: invalid};
-				orGroup['egg groups'][target] = !isNotSearch;
-				continue;
-			}
-
-			let targetInt = 0;
-			if (target.substr(0, 1) === 'g' && Number.isInteger(parseFloat(target.substr(1)))) {
-				targetInt = parseInt(target.substr(1).trim());
-			} else if (target.substr(0, 3) === 'gen' && Number.isInteger(parseFloat(target.substr(3)))) {
-				targetInt = parseInt(target.substr(3).trim());
-			}
-			if (0 < targetInt && targetInt < 9) {
-				const invalid = validParameter("gens", String(targetInt), isNotSearch, target);
-				if (invalid) return {error: invalid};
-				orGroup.gens[targetInt] = !isNotSearch;
-				continue;
-			}
-
-			if (target.endsWith(' asc') || target.endsWith(' desc')) {
-				if (parameters.length > 1) {
-					return {error: `The parameter '${target.split(' ')[1]}' cannot have alternative parameters.`};
-				}
-				const stat = allStatAliases[toID(target.split(' ')[0])] || toID(target.split(' ')[0]);
-				if (!allStats.includes(stat)) return {error: `'${escapeHTML(target)}' did not contain a valid stat.`};
-				sort = `${stat}${target.endsWith(' asc') ? '+' : '-'}`;
-				orGroup.skip = true;
-				break;
-			}
-
-			if (target === 'all') {
-				if (!canAll) return {error: "A search with the parameter 'all' cannot be broadcast."};
-				if (parameters.length > 1) return {error: "The parameter 'all' cannot have alternative parameters."};
-				showAll = true;
-				orGroup.skip = true;
-				break;
-			}
-
-			if (target.substr(0, 6) === 'random' && cmd === 'randpoke') {
-				// Validation for this is in the /randpoke command
-				randomOutput = parseInt(target.substr(6));
-				orGroup.skip = true;
-				continue;
-			}
-
-			if (allFormes.includes(toID(target))) {
-				target = toID(target);
-				orGroup.formes[target] = !isNotSearch;
-				continue;
-			}
-
-			if (target === 'megas' || target === 'mega') {
-				if (megaSearch === isNotSearch) return {error: "A search cannot include and exclude 'mega'."};
-				if (parameters.length > 1) return {error: "The parameter 'mega' cannot have alternative parameters."};
-				megaSearch = !isNotSearch;
-				orGroup.skip = true;
-				break;
-			}
-
-			if (target === 'gmax' || target === 'gigantamax') {
-				if (gmaxSearch === isNotSearch) return {error: "A search cannot include and exclude 'gigantamax'."};
-				if (parameters.length > 1) return {error: "The parameter 'gigantamax' cannot have alternative parameters."};
-				gmaxSearch = !isNotSearch;
-				orGroup.skip = true;
-				break;
-			}
-
-			if (['fully evolved', 'fullyevolved', 'fe'].includes(target)) {
-				if (fullyEvolvedSearch === isNotSearch) return {error: "A search cannot include and exclude 'fully evolved'."};
-				if (parameters.length > 1) return {error: "The parameter 'fully evolved' cannot have alternative parameters."};
-				fullyEvolvedSearch = !isNotSearch;
-				orGroup.skip = true;
-				break;
-			}
-
-			if (target === 'recovery') {
-				const recoveryMoves = [
-					"healorder", "junglehealing", "lifedew", "milkdrink", "moonlight", "morningsun", "recover",
-					"roost", "shoreup", "slackoff", "softboiled", "strengthsap", "synthesis", "wish",
-				];
-				for (const move of recoveryMoves) {
-					const invalid = validParameter("moves", move, isNotSearch, target);
-					if (invalid) return {error: invalid};
-					if (isNotSearch) {
-						orGroup.skip = true;
-						const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
-						bufferObj.moves[move] = false;
-						searches.push(bufferObj as DexOrGroup);
-					} else {
-						orGroup.moves[move] = true;
-					}
-				}
-				continue;
-			}
-
-			if (target === 'zrecovery') {
-				const recoveryMoves = [
-					"aromatherapy", "bellydrum", "conversion2", "haze", "healbell", "mist",
-					"psychup", "refresh", "spite", "stockpile", "teleport", "transform",
-				];
-				for (const moveid of recoveryMoves) {
-					const invalid = validParameter("moves", moveid, isNotSearch, target);
-					if (invalid) return {error: invalid};
-					if (isNotSearch) {
-						orGroup.skip = true;
-						const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
-						bufferObj.moves[moveid] = false;
-						searches.push(bufferObj as DexOrGroup);
-					} else {
-						orGroup.moves[moveid] = true;
-					}
-				}
-				continue;
-			}
-
-			if (target === 'priority') {
-				for (const moveid in mod.data.Moves) {
-					const move = mod.moves.get(moveid);
-					if (move.category === "Status" || move.id === "bide") continue;
-					if (move.priority > 0) {
-						const invalid = validParameter("moves", moveid, isNotSearch, target);
-						if (invalid) return {error: invalid};
-						if (isNotSearch) {
-							orGroup.skip = true;
-							const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
-							bufferObj.moves[moveid] = false;
-							searches.push(bufferObj as DexOrGroup);
-						} else {
-							orGroup.moves[moveid] = true;
-						}
-					}
-				}
-				continue;
-			}
-
-			if (target.substr(0, 8) === 'resists ') {
-				const targetResist = target.substr(8, 1).toUpperCase() + target.substr(9);
-				if (mod.types.isName(targetResist)) {
-					const invalid = validParameter("resists", targetResist, isNotSearch, target);
-					if (invalid) return {error: invalid};
-					orGroup.resists[targetResist] = !isNotSearch;
-					continue;
-				} else {
-					if (toID(targetResist) in mod.data.Moves) {
-						const move = mod.moves.get(targetResist);
-						if (move.category === 'Status') {
-							return {error: `'${targetResist}' is a status move and can't be used with 'resists'.`};
-						} else {
-							const invalid = validParameter("resists", targetResist, isNotSearch, target);
-							if (invalid) return {error: invalid};
-							orGroup.resists[targetResist] = !isNotSearch;
-							continue;
-						}
-					} else {
-						return {error: `'${targetResist}' is not a recognized type or move.`};
-					}
-				}
-			}
-
-			if (target.substr(0, 5) === 'weak ') {
-				const targetWeak = target.substr(5, 1).toUpperCase() + target.substr(6);
-				if (mod.types.isName(targetWeak)) {
-					const invalid = validParameter("weak", targetWeak, isNotSearch, target);
-					if (invalid) return {error: invalid};
-					orGroup.weak[targetWeak] = !isNotSearch;
-					continue;
-				} else {
-					if (toID(targetWeak) in mod.data.Moves) {
-						const move = mod.moves.get(targetWeak);
-						if (move.category === 'Status') {
-							return {error: `'${targetWeak}' is a status move and can't be used with 'weak'.`};
-						} else {
-							const invalid = validParameter("weak", targetWeak, isNotSearch, target);
-							if (invalid) return {error: invalid};
-							orGroup.weak[targetWeak] = !isNotSearch;
-							continue;
-						}
-					} else {
-						return {error: `'${targetWeak}' is not a recognized type or move.`};
-					}
-				}
-			}
-
-			if (target === 'pivot') {
-				for (const move in mod.data.Moves) {
-					const moveData = mod.moves.get(move);
-					if (moveData.selfSwitch && moveData.id !== 'batonpass') {
-						const invalid = validParameter("moves", move, isNotSearch, target);
-						if (invalid) return {error: invalid};
-						if (isNotSearch) {
-							orGroup.skip = true;
-							const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
-							bufferObj.moves[move] = false;
-							searches.push(bufferObj as DexOrGroup);
-						} else {
-							orGroup.moves[move] = true;
-						}
-					}
-				}
-				continue;
-			}
-
-			const inequality = target.search(/>|<|=/);
-			let inequalityString;
-			if (inequality >= 0) {
-				if (isNotSearch) return {error: "You cannot use the negation symbol '!' in stat ranges."};
-				if (target.charAt(inequality + 1) === '=') {
-					inequalityString = target.substr(inequality, 2);
-				} else {
-					inequalityString = target.charAt(inequality);
-				}
-				const targetParts = target.replace(/\s/g, '').split(inequalityString);
-				let num;
-				let stat;
-				const directions: Direction[] = [];
-				if (!isNaN(parseFloat(targetParts[0]))) {
-					// e.g. 100 < spe
-					num = parseFloat(targetParts[0]);
-					stat = targetParts[1];
-					if (inequalityString.startsWith('>')) directions.push('less');
-					if (inequalityString.startsWith('<')) directions.push('greater');
-				} else if (!isNaN(parseFloat(targetParts[1]))) {
-					// e.g. spe > 100
-					num = parseFloat(targetParts[1]);
-					stat = targetParts[0];
-					if (inequalityString.startsWith('<')) directions.push('less');
-					if (inequalityString.startsWith('>')) directions.push('greater');
-				} else {
-					return {error: `No value given to compare with '${escapeHTML(target)}'.`};
-				}
-				if (inequalityString.endsWith('=')) directions.push('equal');
-				if (stat in allStatAliases) stat = allStatAliases[stat];
-				if (!allStats.includes(stat)) return {error: `'${escapeHTML(target)}' did not contain a valid stat.`};
-				if (!orGroup.stats[stat]) orGroup.stats[stat] = Object.create(null);
-				for (const direction of directions) {
-					if (orGroup.stats[stat][direction]) return {error: `Invalid stat range for ${stat}.`};
-					orGroup.stats[stat][direction] = num;
-				}
-				continue;
-			}
-			return {error: `'${escapeHTML(target)}' could not be found in any of the search categories.`};
-		}
-		if (!orGroup.skip) {
-			searches.push(orGroup);
-		}
-	}
-	if (
-		showAll && searches.length === 0 && singleTypeSearch === null &&
-		megaSearch === null && gmaxSearch === null && fullyEvolvedSearch === null && sort === null
-	) {
-		return {
-			error: "No search parameters other than 'all' were found. Try '/help dexsearch' for more information on this command.",
-		};
-	}
-
-	const dex: {[k: string]: Species} = {};
-	for (const species of mod.species.all()) {
-		const megaSearchResult = megaSearch === null || megaSearch === !!species.isMega;
-		const gmaxSearchResult = gmaxSearch === null || gmaxSearch === species.name.endsWith('-Gmax');
-		const fullyEvolvedSearchResult = fullyEvolvedSearch === null || fullyEvolvedSearch !== species.nfe;
-		if (
-			species.gen <= mod.gen &&
-			(
-				(
-					nationalSearch &&
-					species.isNonstandard &&
-					!["Custom", "Glitch", "Pokestar", "Future"].includes(species.isNonstandard)
-				) ||
-				(species.tier !== 'Unreleased' && species.tier !== 'Illegal')
-			) &&
-			(!species.tier.startsWith("CAP") || capSearch) &&
-			megaSearchResult &&
-			gmaxSearchResult &&
-			fullyEvolvedSearchResult
-		) {
-			dex[species.id] = species;
-		}
-	}
-
-	// Prioritize searches with the least alternatives.
-	const accumulateKeyCount = (count: number, searchData: AnyObject) =>
-		count + (typeof searchData === 'object' ? Object.keys(searchData).length : 0);
-	Utils.sortBy(searches, search => (
-		Object.values(search).reduce(accumulateKeyCount, 0)
-	));
-
-	for (const alts of searches) {
-		if (alts.skip) continue;
-		for (const mon in dex) {
-			let matched = false;
-			if (alts.gens && Object.keys(alts.gens).length) {
-				if (alts.gens[dex[mon].gen]) continue;
-				if (Object.values(alts.gens).includes(false) && alts.gens[dex[mon].gen] !== false) continue;
-			}
-
-			if (alts.colors && Object.keys(alts.colors).length) {
-				if (alts.colors[dex[mon].color]) continue;
-				if (Object.values(alts.colors).includes(false) && alts.colors[dex[mon].color] !== false) continue;
-			}
-
-			for (const eggGroup in alts['egg groups']) {
-				if (dex[mon].eggGroups.includes(eggGroup) === alts['egg groups'][eggGroup]) {
-					matched = true;
-					break;
-				}
-			}
-
-			if (alts.tiers && Object.keys(alts.tiers).length) {
-				let tier = dex[mon].tier;
-				if (nationalSearch) tier = dex[mon].natDexTier;
-				if (tier.startsWith('(') && tier !== '(PU)') tier = tier.slice(1, -1) as TierTypes.Singles;
-				// if (tier === 'New') tier = 'OU';
-				if (alts.tiers[tier]) continue;
-				if (Object.values(alts.tiers).includes(false) && alts.tiers[tier] !== false) continue;
-				// LC handling, checks for LC Pokemon in higher tiers that need to be handled separately,
-				// as well as event-only Pokemon that are not eligible for LC despite being the first stage
-				let format = Dex.formats.get('gen' + mod.gen + 'lc');
-				if (!format.exists) format = Dex.formats.get('gen8lc');
-				if (
-					alts.tiers.LC &&
-					!dex[mon].prevo &&
-					dex[mon].nfe &&
-					!Dex.formats.getRuleTable(format).isBannedSpecies(dex[mon])
-				) {
-					const lsetData = mod.species.getLearnsetData(dex[mon].id);
-					if (lsetData.exists && lsetData.eventData && lsetData.eventOnly) {
-						let validEvents = 0;
-						for (const event of lsetData.eventData) {
-							if (event.level && event.level <= 5) validEvents++;
-						}
-						if (validEvents > 0) continue;
-					} else {
-						continue;
-					}
-				}
-			}
-
-			if (alts.doublesTiers && Object.keys(alts.doublesTiers).length) {
-				let tier = dex[mon].doublesTier;
-				if (tier && tier.startsWith('(') && tier !== '(DUU)') tier = tier.slice(1, -1) as TierTypes.Doubles;
-				if (alts.doublesTiers[tier]) continue;
-				if (Object.values(alts.doublesTiers).includes(false) && alts.doublesTiers[tier] !== false) continue;
-			}
-
-			for (const type in alts.types) {
-				if (dex[mon].types.includes(type) === alts.types[type]) {
-					matched = true;
-					break;
-				}
-			}
-			if (matched) continue;
-
-			for (const targetResist in alts.resists) {
-				let effectiveness = 0;
-				const move = mod.moves.get(targetResist);
-				const attackingType = move.type || targetResist;
-				const notImmune = (move.id === 'thousandarrows' || mod.getImmunity(attackingType, dex[mon])) &&
-					!(move.id === 'sheercold' && mod.gen >= 7 && dex[mon].types.includes('Ice'));
-				if (notImmune && !move.ohko && move.damage === undefined) {
-					for (const defenderType of dex[mon].types) {
-						const baseMod = mod.getEffectiveness(attackingType, defenderType);
-						const moveMod = move.onEffectiveness?.call(
-							{dex: mod} as Battle, baseMod, null, defenderType, move as ActiveMove,
-						);
-						effectiveness += typeof moveMod === 'number' ? moveMod : baseMod;
-					}
-				}
-				if (!alts.resists[targetResist]) {
-					if (notImmune && effectiveness >= 0) matched = true;
-				} else {
-					if (!notImmune || effectiveness < 0) matched = true;
-				}
-			}
-			if (matched) continue;
-
-			for (const targetWeak in alts.weak) {
-				let effectiveness = 0;
-				const move = mod.moves.get(targetWeak);
-				const attackingType = move.type || targetWeak;
-				const notImmune = (move.id === 'thousandarrows' || mod.getImmunity(attackingType, dex[mon])) &&
-					!(move.id === 'sheercold' && mod.gen >= 7 && dex[mon].types.includes('Ice'));
-				if (notImmune && !move.ohko && move.damage === undefined) {
-					for (const defenderType of dex[mon].types) {
-						const baseMod = mod.getEffectiveness(attackingType, defenderType);
-						const moveMod = move.onEffectiveness?.call(
-							{dex: mod} as Battle, baseMod, null, defenderType, move as ActiveMove,
-						);
-						effectiveness += typeof moveMod === 'number' ? moveMod : baseMod;
-					}
-				}
-				if (alts.weak[targetWeak]) {
-					if (notImmune && effectiveness >= 1) matched = true;
-				} else {
-					if (!notImmune || effectiveness < 1) matched = true;
-				}
-			}
-			if (matched) continue;
-
-			for (const ability in alts.abilities) {
-				if (Object.values(dex[mon].abilities).includes(ability) === alts.abilities[ability]) {
-					matched = true;
-					break;
-				}
-			}
-			if (matched) continue;
-
-			for (const forme in alts.formes) {
-				if (toID(dex[mon].forme).includes(forme) === alts.formes[forme]) {
-					matched = true;
-					break;
-				}
-			}
-			if (matched) continue;
-
-			for (const stat in alts.stats) {
-				let monStat = 0;
-				if (stat === 'bst') {
-					monStat = dex[mon].bst;
-				} else if (stat === 'weight') {
-					monStat = dex[mon].weighthg / 10;
-				} else if (stat === 'height') {
-					monStat = dex[mon].heightm;
-				} else if (stat === 'gen') {
-					monStat = dex[mon].gen;
-				} else {
-					monStat = dex[mon].baseStats[stat as StatID];
-				}
-				if (typeof alts.stats[stat].less === 'number') {
-					if (monStat < alts.stats[stat].less) {
-						matched = true;
-						break;
-					}
-				}
-				if (typeof alts.stats[stat].greater === 'number') {
-					if (monStat > alts.stats[stat].greater) {
-						matched = true;
-						break;
-					}
-				}
-				if (typeof alts.stats[stat].equal === 'number') {
-					if (monStat === alts.stats[stat].equal) {
-						matched = true;
-						break;
-					}
-				}
-			}
-			if (matched) continue;
-
-			const format = Object.entries(Dex.data.Rulesets).find(([a, f]) => f.mod === usedMod);
-			const formatStr = format ? format[1].name : 'gen8ou';
-			const validator = TeamValidator.get(
-				`${formatStr}${nationalSearch && !Dex.formats.getRuleTable(Dex.formats.get(formatStr)).has('standardnatdex') ? '@@@standardnatdex' : ''}`
-			);
-			const pokemonSource = validator.allSources();
-			for (const move of Object.keys(alts.moves).map(x => mod.moves.get(x))) {
-				if (move.gen <= mod.gen && !validator.checkCanLearn(move, dex[mon], pokemonSource) === alts.moves[move.id]) {
-					matched = true;
-					break;
-				}
-				if (!pokemonSource.size()) break;
-			}
-			if (matched) continue;
-
-			delete dex[mon];
-		}
-	}
-	let results: string[] = [];
-	for (const mon of Object.keys(dex).sort()) {
-		if (singleTypeSearch !== null && (dex[mon].types.length === 1) !== singleTypeSearch) continue;
-		const isRegionalForm = (dex[mon].forme === "Galar" || dex[mon].forme === "Alola") && dex[mon].name !== "Pikachu-Alola";
-		const allowGmax = (gmaxSearch || tierSearch);
-		if (!isRegionalForm && dex[mon].baseSpecies && results.includes(dex[mon].baseSpecies)) continue;
-		if (dex[mon].isNonstandard === 'Gigantamax' && !allowGmax) continue;
-		results.push(dex[mon].name);
-	}
-
-	if (usedMod === 'gen7letsgo') {
-		results = results.filter(name => {
-			const species = mod.species.get(name);
-			return (species.num <= 151 || ['Meltan', 'Melmetal'].includes(species.name)) &&
-			(!species.forme || (['Alola', 'Mega', 'Mega-X', 'Mega-Y', 'Starter'].includes(species.forme) &&
-				species.name !== 'Pikachu-Alola'));
-		});
-	}
-
-	if (usedMod === 'gen8bdsp') {
-		results = results.filter(name => {
-			const species = mod.species.get(name);
-			if (species.id === 'pichuspikyeared') return false;
-			if (capSearch) return species.gen <= 4;
-			return species.gen <= 4 && species.num >= 1;
-		});
-	}
-
-	if (randomOutput && randomOutput < results.length) {
-		results = Utils.shuffle(results).slice(0, randomOutput);
-	}
-
-	let resultsStr = (message === "" ? message : `<span style="color:#999999;">${escapeHTML(message)}:</span><br />`);
-	if (results.length > 1) {
-		results.sort();
-		if (sort) {
-			const stat = sort.slice(0, -1);
-			const direction = sort.slice(-1);
-			Utils.sortBy(results, name => {
-				const mon = mod.species.get(name);
-				let monStat = 0;
-				if (stat === 'bst') {
-					monStat = mon.bst;
-				} else if (stat === 'weight') {
-					monStat = mon.weighthg;
-				} else if (stat === 'height') {
-					monStat = mon.heightm;
-				} else if (stat === 'gen') {
-					monStat = mon.gen;
-				} else {
-					monStat = mon.baseStats[stat as StatID];
-				}
-				return monStat * (direction === '+' ? 1 : -1);
-			});
-		}
-		let notShown = 0;
-		if (!showAll && results.length > MAX_RANDOM_RESULTS) {
-			notShown = results.length - RESULTS_MAX_LENGTH;
-			results = results.slice(0, RESULTS_MAX_LENGTH);
-		}
-		resultsStr += results.map(
-			result => `<a href="//${Config.routes.dex}/pokemon/${toID(result)}" target="_blank" class="subtle" style="white-space:nowrap"><psicon pokemon="${result}" style="vertical-align:-7px;margin:-2px" />${result}</a>`
-		).join(", ");
-		if (notShown) {
-			resultsStr += `, and ${notShown} more. <span style="color:#999999;">Redo the search with ', all' at the end to show all results.</span>`;
-		}
-	} else if (results.length === 1) {
-		return {dt: `${results[0]}${usedMod ? `,${usedMod}` : ''}`};
-	} else {
-		resultsStr += "No Pok&eacute;mon found.";
-	}
-	if (isTest) return {results, reply: resultsStr};
-	return {reply: resultsStr};
-}
-
-function runMovesearch(target: string, cmd: string, canAll: boolean, message: string, isTest: boolean) {
-	const searches: MoveOrGroup[] = [];
-	const {splitTarget, usedMod, count} = getMod(target);
-	if (count > 1) {
-		return {error: `You can't run searches for multiple mods.`};
-	}
-
-	const mod = Dex.mod(usedMod || 'base');
-	const allCategories = ['physical', 'special', 'status'];
-	const allContestTypes = ['beautiful', 'clever', 'cool', 'cute', 'tough'];
-	const allProperties = ['basePower', 'accuracy', 'priority', 'pp'];
-	const allFlags = [
-		'bypasssub', 'bite', 'bullet', 'charge', 'contact', 'dance', 'defrost', 'gravity', 'highcrit', 'mirror',
-		'multihit', 'ohko', 'powder', 'protect', 'pulse', 'punch', 'recharge', 'reflectable', 'secondary',
-		'snatch', 'sound', 'zmove', 'maxmove', 'gmaxmove', 'protection',
-	];
-	const allStatus = ['psn', 'tox', 'brn', 'par', 'frz', 'slp'];
-	const allVolatileStatus = ['flinch', 'confusion', 'partiallytrapped'];
-	const allBoosts = ['hp', 'atk', 'def', 'spa', 'spd', 'spe', 'accuracy', 'evasion'];
-	const allTargets: {[k: string]: string} = {
-		oneally: 'adjacentAlly',
-		userorally: 'adjacentAllyOrSelf',
-		oneadjacentopponent: 'adjacentFoe',
-		all: 'all',
-		alladjacent: 'allAdjacent',
-		alladjacentopponents: 'allAdjacentFoes',
-		userandallies: 'allies',
-		usersside: 'allySide',
-		usersteam: 'allyTeam',
-		any: 'any',
-		opponentsside: 'foeSide',
-		oneadjacent: 'normal',
-		randomadjacent: 'randomNormal',
-		scripted: 'scripted',
-		user: 'self',
-	};
-	const allTypes: {[k: string]: string} = Object.create(null);
-	for (const type of mod.types.all()) {
-		allTypes[type.id] = type.name;
-	}
-	let showAll = false;
-	let sort: string | null = null;
-	const targetMons: {name: string, shouldBeExcluded: boolean}[] = [];
-	let nationalSearch = null;
-	let randomOutput = 0;
-	for (const arg of splitTarget) {
-		const orGroup: MoveOrGroup = {
-			types: {}, categories: {}, contestTypes: {}, flags: {}, gens: {}, other: {}, mon: {}, property: {},
-			boost: {}, lower: {}, zboost: {}, status: {}, volatileStatus: {}, targets: {}, skip: false, multihit: false,
-		};
-		const parameters = arg.split("|");
-		if (parameters.length > 3) return {error: "No more than 3 alternatives for each parameter may be used."};
-		for (const parameter of parameters) {
-			let isNotSearch = false;
-			target = parameter.toLowerCase().trim();
-			if (target.startsWith('!')) {
-				isNotSearch = true;
-				target = target.substr(1);
-			}
-			let targetType;
-			if (target.endsWith('type')) {
-				targetType = toID(target.substring(0, target.indexOf('type')));
-			} else {
-				targetType = toID(target);
-			}
-			if (allTypes[targetType]) {
-				target = allTypes[targetType];
-				if ((orGroup.types[target] && isNotSearch) || (orGroup.types[target] === false && !isNotSearch)) {
-					return {error: 'A search cannot both exclude and include a type.'};
-				}
-				orGroup.types[target] = !isNotSearch;
-				continue;
-			}
-
-			if (allCategories.includes(target)) {
-				target = target.charAt(0).toUpperCase() + target.substr(1);
-				if (
-					(orGroup.categories[target] && isNotSearch) ||
-					(orGroup.categories[target] === false && !isNotSearch)
-				) {
-					return {error: 'A search cannot both exclude and include a category.'};
-				}
-				orGroup.categories[target] = !isNotSearch;
-				continue;
-			}
-
-			if (allContestTypes.includes(target)) {
-				target = target.charAt(0).toUpperCase() + target.substr(1);
-				if (
-					(orGroup.contestTypes[target] && isNotSearch) ||
-					(orGroup.contestTypes[target] === false && !isNotSearch)
-				) {
-					return {error: 'A search cannot both exclude and include a contest condition.'};
-				}
-				orGroup.contestTypes[target] = !isNotSearch;
-				continue;
-			}
-
-			if (target.startsWith('targets ')) {
-				target = toID(target.substr('targets '.length));
-				if (target === 'allpokemon' || target === 'anypokemon' || target.includes('adjacent')) {
-					target = target.replace('pokemon', '');
-				}
-				if (Object.keys(allTargets).includes(target)) {
-					const moveTarget = allTargets[target];
-					if (
-						(orGroup.targets[moveTarget] && isNotSearch) ||
-						(orGroup.targets[moveTarget] === false && !isNotSearch)
-					) {
-						return {error: 'A search cannot both exclude and include a move target.'};
-					}
-					orGroup.targets[moveTarget] = !isNotSearch;
-					continue;
-				} else {
-					return {error: `'${target}' isn't a valid move target.`};
-				}
-			}
-
-			if (target === 'bypassessubstitute') target = 'bypasssub';
-			if (target === 'z') target = 'zmove';
-			if (target === 'max') target = 'maxmove';
-			if (target === 'gmax') target = 'gmaxmove';
-			if (target === 'multi' || toID(target) === 'multihit') target = 'multihit';
-			if (target === 'crit' || toID(target) === 'highcrit') target = 'highcrit';
-			if (['thaw', 'thaws', 'melt', 'melts', 'defrosts'].includes(target)) target = 'defrost';
-			if (target === 'bounceable' || toID(target) === 'magiccoat' || toID(target) === 'magicbounce') target = 'reflectable';
-			if (allFlags.includes(target)) {
-				if ((orGroup.flags[target] && isNotSearch) || (orGroup.flags[target] === false && !isNotSearch)) {
-					return {error: `A search cannot both exclude and include '${target}'.`};
-				}
-				orGroup.flags[target] = !isNotSearch;
-				continue;
-			}
-
-			let targetInt = 0;
-			if (target.substr(0, 1) === 'g' && Number.isInteger(parseFloat(target.substr(1)))) {
-				targetInt = parseInt(target.substr(1).trim());
-			} else if (target.substr(0, 3) === 'gen' && Number.isInteger(parseFloat(target.substr(3)))) {
-				targetInt = parseInt(target.substr(3).trim());
-			}
-
-			if (0 < targetInt && targetInt < 9) {
-				if ((orGroup.gens[targetInt] && isNotSearch) || (orGroup.flags[targetInt] === false && !isNotSearch)) {
-					return {error: `A search cannot both exclude and include '${target}'.`};
-				}
-				orGroup.gens[targetInt] = !isNotSearch;
-				continue;
-			}
-
-			if (target === 'all') {
-				if (!canAll) return {error: "A search with the parameter 'all' cannot be broadcast."};
-				if (parameters.length > 1) return {error: "The parameter 'all' cannot have alternative parameters."};
-				showAll = true;
-				orGroup.skip = true;
-				continue;
-			}
-
-			if (target === 'natdex') {
-				if (parameters.length > 1) return {error: "The parameter 'natdex' cannot have alternative parameters."};
-				nationalSearch = !isNotSearch;
-				orGroup.skip = true;
-				continue;
-			}
-
-			if (target.endsWith(' asc') || target.endsWith(' desc')) {
-				if (parameters.length > 1) {
-					return {error: `The parameter '${target.split(' ')[1]}' cannot have alternative parameters.`};
-				}
-				let prop = target.split(' ')[0];
-				switch (toID(prop)) {
-				case 'basepower': prop = 'basePower'; break;
-				case 'bp': prop = 'basePower'; break;
-				case 'power': prop = 'basePower'; break;
-				case 'acc': prop = 'accuracy'; break;
-				}
-				if (!allProperties.includes(prop)) return {error: `'${escapeHTML(target)}' did not contain a valid property.`};
-				sort = `${prop}${target.endsWith(' asc') ? '+' : '-'}`;
-				orGroup.skip = true;
-				break;
-			}
-
-			if (target === 'recovery') {
-				if (orGroup.other.recovery === undefined) {
-					orGroup.other.recovery = !isNotSearch;
-				} else if ((orGroup.other.recovery && isNotSearch) || (!orGroup.other.recovery && !isNotSearch)) {
-					return {error: 'A search cannot both exclude and include recovery moves.'};
-				}
-				continue;
-			}
-
-			if (target === 'recoil') {
-				if (orGroup.other.recoil === undefined) {
-					orGroup.other.recoil = !isNotSearch;
-				} else if ((orGroup.other.recoil && isNotSearch) || (!orGroup.other.recoil && !isNotSearch)) {
-					return {error: 'A search cannot both exclude and include recoil moves.'};
-				}
-				continue;
-			}
-
-			if (target.substr(0, 6) === 'random' && cmd === 'randmove') {
-				// Validation for this is in the /randmove command
-				randomOutput = parseInt(target.substr(6));
-				orGroup.skip = true;
-				continue;
-			}
-
-			if (target === 'zrecovery') {
-				if (orGroup.other.zrecovery === undefined) {
-					orGroup.other.zrecovery = !isNotSearch;
-				} else if ((orGroup.other.zrecovery && isNotSearch) || (!orGroup.other.zrecovery && !isNotSearch)) {
-					return {error: 'A search cannot both exclude and include z-recovery moves.'};
-				}
-				continue;
-			}
-
-			if (target === 'pivot') {
-				if (orGroup.other.pivot === undefined) {
-					orGroup.other.pivot = !isNotSearch;
-				} else if ((orGroup.other.pivot && isNotSearch) || (!orGroup.other.pivot && !isNotSearch)) {
-					return {error: 'A search cannot both exclude and include pivot moves.'};
-				}
-				continue;
-			}
-
-			if (target === 'multihit') {
-				if (!orGroup.multihit) {
-					orGroup.multihit = true;
-				} else if ((orGroup.multihit && isNotSearch) || (!orGroup.multihit && !isNotSearch)) {
-					return {error: 'A search cannot both exclude and include multi-hit moves.'};
-				}
-				continue;
-			}
-
-			const species = mod.species.get(target);
-			if (species.exists) {
-				if (parameters.length > 1) return {error: "A Pok\u00e9mon learnset cannot have alternative parameters."};
-				if (targetMons.some(mon => mon.name === species.name && isNotSearch !== mon.shouldBeExcluded)) {
-					return {error: "A search cannot both exclude and include the same Pok\u00e9mon."};
-				}
-				if (targetMons.some(mon => mon.name === species.name)) {
-					return {error: "A search should not include a Pok\u00e9mon twice."};
-				}
-				targetMons.push({name: species.name, shouldBeExcluded: isNotSearch});
-				orGroup.skip = true;
-				continue;
-			}
-
-			const inequality = target.search(/>|<|=/);
-			if (inequality >= 0) {
-				let inequalityString;
-				if (isNotSearch) return {error: "You cannot use the negation symbol '!' in stat ranges."};
-				if (target.charAt(inequality + 1) === '=') {
-					inequalityString = target.substr(inequality, 2);
-				} else {
-					inequalityString = target.charAt(inequality);
-				}
-				const targetParts = target.replace(/\s/g, '').split(inequalityString);
-				let num;
-				let prop;
-				const directions: Direction[] = [];
-				if (!isNaN(parseFloat(targetParts[0]))) {
-					// e.g. 100 < bp
-					num = parseFloat(targetParts[0]);
-					prop = targetParts[1];
-					if (inequalityString.startsWith('>')) directions.push('less');
-					if (inequalityString.startsWith('<')) directions.push('greater');
-				} else if (!isNaN(parseFloat(targetParts[1]))) {
-					// e.g. bp > 100
-					num = parseFloat(targetParts[1]);
-					prop = targetParts[0];
-					if (inequalityString.startsWith('<')) directions.push('less');
-					if (inequalityString.startsWith('>')) directions.push('greater');
-				} else {
-					return {error: `No value given to compare with '${escapeHTML(target)}'.`};
-				}
-				if (inequalityString.endsWith('=')) directions.push('equal');
-				switch (toID(prop)) {
-				case 'basepower': prop = 'basePower'; break;
-				case 'bp': prop = 'basePower'; break;
-				case 'power': prop = 'basePower'; break;
-				case 'acc': prop = 'accuracy'; break;
-				}
-				if (!allProperties.includes(prop)) return {error: `'${escapeHTML(target)}' did not contain a valid property.`};
-				if (!orGroup.property[prop]) orGroup.property[prop] = Object.create(null);
-				for (const direction of directions) {
-					if (orGroup.property[prop][direction]) return {error: `Invalid property range for ${prop}.`};
-					orGroup.property[prop][direction] = num;
-				}
-				continue;
-			}
-
-			if (target.substr(0, 8) === 'priority') {
-				let sign: Direction;
-				target = target.substr(8).trim();
-				if (target === "+" || target === "") {
-					sign = 'greater';
-				} else if (target === "-") {
-					sign = 'less';
-				} else {
-					return {error: `Priority type '${target}' not recognized.`};
-				}
-				if (orGroup.property['priority']) {
-					return {error: "Priority cannot be set with both shorthand and inequality range."};
-				} else {
-					orGroup.property['priority'] = Object.create(null);
-					orGroup.property['priority'][sign] = 0;
-				}
-				continue;
-			}
-			if (target.substr(0, 7) === 'boosts ' || target.substr(0, 7) === 'lowers ') {
-				let isBoost = true;
-				if (target.substr(0, 7) === 'lowers ') {
-					isBoost = false;
-				}
-				switch (target.substr(7)) {
-				case 'attack': target = 'atk'; break;
-				case 'defense': target = 'def'; break;
-				case 'specialattack': target = 'spa'; break;
-				case 'spatk': target = 'spa'; break;
-				case 'specialdefense': target = 'spd'; break;
-				case 'spdef': target = 'spd'; break;
-				case 'speed': target = 'spe'; break;
-				case 'acc': target = 'accuracy'; break;
-				case 'evasiveness': target = 'evasion'; break;
-				default: target = target.substr(7);
-				}
-				if (!allBoosts.includes(target)) return {error: `'${escapeHTML(target)}' is not a recognized stat.`};
-				if (isBoost) {
-					if ((orGroup.boost[target] && isNotSearch) || (orGroup.boost[target] === false && !isNotSearch)) {
-						return {error: 'A search cannot both exclude and include a stat boost.'};
-					}
-					orGroup.boost[target] = !isNotSearch;
-				} else {
-					if ((orGroup.lower[target] && isNotSearch) || (orGroup.lower[target] === false && !isNotSearch)) {
-						return {error: 'A search cannot both exclude and include a stat boost.'};
-					}
-					orGroup.lower[target] = !isNotSearch;
-				}
-				continue;
-			}
-
-			if (target.substr(0, 8) === 'zboosts ') {
-				switch (target.substr(8)) {
-				case 'attack': target = 'atk'; break;
-				case 'defense': target = 'def'; break;
-				case 'specialattack': target = 'spa'; break;
-				case 'spatk': target = 'spa'; break;
-				case 'specialdefense': target = 'spd'; break;
-				case 'spdef': target = 'spd'; break;
-				case 'speed': target = 'spe'; break;
-				case 'acc': target = 'accuracy'; break;
-				case 'evasiveness': target = 'evasion'; break;
-				default: target = target.substr(8);
-				}
-				if (!allBoosts.includes(target)) return {error: `'${escapeHTML(target)}' is not a recognized stat.`};
-				if ((orGroup.zboost[target] && isNotSearch) || (orGroup.zboost[target] === false && !isNotSearch)) {
-					return {error: 'A search cannot both exclude and include a stat boost.'};
-				}
-				orGroup.zboost[target] = !isNotSearch;
-				continue;
-			}
-
-			const oldTarget = target;
-			if (target.endsWith('s')) target = target.slice(0, -1);
-			switch (target) {
-			case 'toxic': target = 'tox'; break;
-			case 'poison': target = 'psn'; break;
-			case 'burn': target = 'brn'; break;
-			case 'paralyze': target = 'par'; break;
-			case 'freeze': target = 'frz'; break;
-			case 'sleep': target = 'slp'; break;
-			case 'confuse': target = 'confusion'; break;
-			case 'trap': target = 'partiallytrapped'; break;
-			case 'flinche': target = 'flinch'; break;
-			}
-
-			if (allStatus.includes(target)) {
-				if ((orGroup.status[target] && isNotSearch) || (orGroup.status[target] === false && !isNotSearch)) {
-					return {error: 'A search cannot both exclude and include a status.'};
-				}
-				orGroup.status[target] = !isNotSearch;
-				continue;
-			}
-
-			if (allVolatileStatus.includes(target)) {
-				if (
-					(orGroup.volatileStatus[target] && isNotSearch) ||
-					(orGroup.volatileStatus[target] === false && !isNotSearch)
-				) {
-					return {error: 'A search cannot both exclude and include a volatile status.'};
-				}
-				orGroup.volatileStatus[target] = !isNotSearch;
-				continue;
-			}
-
-			return {error: `'${escapeHTML(oldTarget)}' could not be found in any of the search categories.`};
-		}
-		if (!orGroup.skip) {
-			searches.push(orGroup);
-		}
-	}
-	if (showAll && !searches.length && !targetMons.length && !sort) {
-		return {
-			error: "No search parameters other than 'all' were found. Try '/help movesearch' for more information on this command.",
-		};
-	}
-
-	const getFullLearnsetOfPokemon = (species: Species) => {
-		let usedSpecies: Species = Utils.deepClone(species);
-		let usedSpeciesLearnset: LearnsetData = Utils.deepClone(mod.species.getLearnset(usedSpecies.id));
-		if (!usedSpeciesLearnset) {
-			usedSpecies = Utils.deepClone(mod.species.get(usedSpecies.baseSpecies));
-			usedSpeciesLearnset = Utils.deepClone(mod.species.getLearnset(usedSpecies.id) || {});
-		}
-		const lsetData = new Set<string>();
-		for (const move in usedSpeciesLearnset) {
-			const learnset = mod.species.getLearnset(usedSpecies.id);
-			if (!learnset) break;
-			const sources = learnset[move];
-			for (const learned of sources) {
-				const sourceGen = parseInt(learned.charAt(0));
-				if (sourceGen <= mod.gen) lsetData.add(move);
-			}
-		}
-
-		while (usedSpecies.prevo) {
-			usedSpecies = Utils.deepClone(mod.species.get(usedSpecies.prevo));
-			usedSpeciesLearnset = Utils.deepClone(mod.species.getLearnset(usedSpecies.id));
-			for (const move in usedSpeciesLearnset) {
-				const learnset = mod.species.getLearnset(usedSpecies.id);
-				if (!learnset) break;
-				const sources = learnset[move];
-				for (const learned of sources) {
-					const sourceGen = parseInt(learned.charAt(0));
-					if (sourceGen <= mod.gen) lsetData.add(move);
-				}
-			}
-		}
-
-		return lsetData;
-	};
-
-	// Since we assume we have no target mons at first
-	// then the valid moveset we can search is the set of all moves.
-	const validMoves = new Set(Object.keys(mod.data.Moves));
-	for (const mon of targetMons) {
-		const species = mod.species.get(mon.name);
-		const lsetData = getFullLearnsetOfPokemon(species);
-		// This pokemon's learnset needs to be excluded, so we perform a difference operation
-		// on the valid moveset and this pokemon's moveset.
-		if (mon.shouldBeExcluded) {
-			for (const move of lsetData) {
-				validMoves.delete(move);
-			}
-		} else {
-			// This pokemon's learnset needs to be included, so we perform an intersection operation
-			// on the valid moveset and this pokemon's moveset.
-			for (const move of validMoves) {
-				if (!lsetData.has(move)) {
-					validMoves.delete(move);
-				}
-			}
-		}
-	}
-
-	// At this point, we've trimmed down the valid moveset to be
-	// the moves that are appropriate considering the requested pokemon.
-	const dex: {[moveid: string]: Move} = {};
-	for (const moveid of validMoves) {
-		const move = mod.moves.get(moveid);
-		if (move.gen <= mod.gen) {
-			if (
-				(!nationalSearch && move.isNonstandard && move.isNonstandard !== "Gigantamax") ||
-				(nationalSearch && move.isNonstandard && !["Gigantamax", "Past"].includes(move.isNonstandard))
-			) {
-				continue;
-			} else {
-				dex[moveid] = move;
-			}
-		}
-	}
-
-	for (const alts of searches) {
-		if (alts.skip) continue;
-		for (const moveid in dex) {
-			const move = dex[moveid];
-			const recoveryUndefined = alts.other.recovery === undefined;
-			const zrecoveryUndefined = alts.other.zrecovery === undefined;
-			let matched = false;
-			if (Object.keys(alts.types).length) {
-				if (alts.types[move.type]) continue;
-				if (Object.values(alts.types).includes(false) && alts.types[move.type] !== false) continue;
-			}
-
-			if (Object.keys(alts.categories).length) {
-				if (alts.categories[move.category]) continue;
-				if (Object.values(alts.categories).includes(false) && alts.categories[move.category] !== false) continue;
-			}
-
-			if (Object.keys(alts.contestTypes).length) {
-				if (alts.contestTypes[move.contestType || 'Cool']) continue;
-				if (
-					Object.values(alts.contestTypes).includes(false) &&
-					alts.contestTypes[move.contestType || 'Cool'] !== false
-				) continue;
-			}
-
-			if (Object.keys(alts.targets).length) {
-				if (alts.targets[move.target]) continue;
-				if (Object.values(alts.targets).includes(false) && alts.targets[move.target] !== false) continue;
-			}
-
-			for (const flag in alts.flags) {
-				if (flag === 'secondary') {
-					if (!(move.secondary || move.secondaries) === !alts.flags[flag]) {
-						matched = true;
-						break;
-					}
-				} else if (flag === 'zmove') {
-					if (!move.isZ === !alts.flags[flag]) {
-						matched = true;
-						break;
-					}
-				} else if (flag === 'highcrit') {
-					const crit = move.willCrit || (move.critRatio && move.critRatio > 1);
-					if (!crit === !alts.flags[flag]) {
-						matched = true;
-						break;
-					}
-				} else if (flag === 'multihit') {
-					if (!move.multihit === !alts.flags[flag]) {
-						matched = true;
-						break;
-					}
-				} else if (flag === 'maxmove') {
-					if (!(typeof move.isMax === 'boolean' && move.isMax) === !alts.flags[flag]) {
-						matched = true;
-						break;
-					}
-				} else if (flag === 'gmaxmove') {
-					if (!(typeof move.isMax === 'string') === !alts.flags[flag]) {
-						matched = true;
-						break;
-					}
-				} else if (flag === 'protection') {
-					if (!(move.stallingMove && move.id !== "endure") === !alts.flags[flag]) {
-						matched = true;
-						break;
-					}
-				} else if (flag === 'ohko') {
-					if (!move.ohko === !alts.flags[flag]) {
-						matched = true;
-						break;
-					}
-				} else {
-					if ((flag in move.flags) === alts.flags[flag]) {
-						if (flag === 'protect' && ['all', 'allyTeam', 'allySide', 'foeSide', 'self'].includes(move.target)) continue;
-						matched = true;
-						break;
-					}
-				}
-			}
-			if (matched) continue;
-			if (Object.keys(alts.gens).length) {
-				if (alts.gens[String(move.gen)]) continue;
-				if (Object.values(alts.gens).includes(false) && alts.gens[String(move.gen)] !== false) continue;
-			}
-			if (!zrecoveryUndefined || !recoveryUndefined) {
-				for (const recoveryType in alts.other) {
-					let hasRecovery = false;
-					if (recoveryType === "recovery") {
-						hasRecovery = !!move.drain || !!move.flags.heal;
-					} else if (recoveryType === "zrecovery") {
-						hasRecovery = (move.zMove?.effect === 'heal');
-					}
-					if (hasRecovery === alts.other[recoveryType]) {
-						matched = true;
-						break;
-					}
-				}
-			}
-			if (matched) continue;
-			if (alts.other.recoil !== undefined) {
-				const recoil = move.recoil || move.hasCrashDamage;
-				if (recoil && alts.other.recoil || !(recoil || alts.other.recoil)) matched = true;
-			}
-			if (matched) continue;
-			for (const prop in alts.property) {
-				if (typeof alts.property[prop].less === "number") {
-					if (
-						move[prop as keyof Move] !== true &&
-						(move[prop as keyof Move] as number) < alts.property[prop].less
-					) {
-						matched = true;
-						break;
-					}
-				}
-				if (typeof alts.property[prop].greater === "number") {
-					if ((move[prop as keyof Move] === true && move.category !== "Status") ||
-						move[prop as keyof Move] as number > alts.property[prop].greater) {
-						matched = true;
-						break;
-					}
-				}
-				if (typeof alts.property[prop].equal === "number") {
-					if (move[prop as keyof Move] === alts.property[prop].equal) {
-						matched = true;
-						break;
-					}
-				}
-			}
-			if (matched) continue;
-			for (const boost in alts.boost) {
-				if (move.boosts) {
-					if ((move.boosts[boost as BoostID]! > 0) === alts.boost[boost]) {
-						matched = true;
-						break;
-					}
-				} else if (move.secondary?.self?.boosts) {
-					if ((move.secondary.self.boosts[boost as BoostID]! > 0) === alts.boost[boost]) {
-						matched = true;
-						break;
-					}
-				} else if (move.selfBoost?.boosts) {
-					if ((move.selfBoost.boosts[boost as BoostID]! > 0) === alts.boost[boost]) {
-						matched = true;
-						break;
-					}
-				}
-			}
-			if (matched) continue;
-			for (const lower in alts.lower) {
-				if (move.boosts) {
-					if ((move.boosts[lower as BoostID]! < 0) === alts.lower[lower]) {
-						matched = true;
-						break;
-					}
-				} else if (move.secondary?.boosts) {
-					if ((move.secondary.boosts[lower as BoostID]! < 0) === alts.lower[lower]) {
-						matched = true;
-						break;
-					}
-				} else if (move.self?.boosts) {
-					if ((move.self.boosts[lower as BoostID]! < 0) === alts.lower[lower]) {
-						matched = true;
-						break;
-					}
-				}
-			}
-			if (matched) continue;
-			for (const boost in alts.zboost) {
-				const zMove = move.zMove;
-				if (zMove?.boost) {
-					if ((zMove.boost[boost as BoostID]! > 0) === alts.zboost[boost]) {
-						matched = true;
-						break;
-					}
-				}
-			}
-			if (matched) continue;
-
-			for (const searchStatus in alts.status) {
-				let canStatus = !!(
-					move.status === searchStatus ||
-					(move.secondaries && move.secondaries.some(entry => entry.status === searchStatus))
-				);
-				if (searchStatus === 'slp') {
-					canStatus = canStatus || moveid === 'yawn';
-				}
-				if (searchStatus === 'brn' || searchStatus === 'frz' || searchStatus === 'par') {
-					canStatus = canStatus || moveid === 'triattack';
-				}
-				if (canStatus === alts.status[searchStatus]) {
-					matched = true;
-					break;
-				}
-			}
-			if (matched) continue;
-
-			for (const searchStatus in alts.volatileStatus) {
-				const canStatus = !!(
-					(move.secondary && move.secondary.volatileStatus === searchStatus) ||
-					(move.secondaries && move.secondaries.some(entry => entry.volatileStatus === searchStatus)) ||
-					(move.volatileStatus === searchStatus)
-				);
-				if (canStatus === alts.volatileStatus[searchStatus]) {
-					matched = true;
-					break;
-				}
-			}
-			if (matched) continue;
-			if (alts.other.pivot !== undefined) {
-				const pivot = move.selfSwitch && move.id !== 'batonpass';
-				if (pivot && alts.other.pivot || !(pivot || alts.other.pivot)) matched = true;
-			}
-			if (matched) continue;
-
-			delete dex[moveid];
-		}
-	}
-
-	let results = [];
-	for (const move in dex) {
-		results.push(dex[move].name);
-	}
-
-	let resultsStr = "";
-	if (targetMons.length) {
-		resultsStr += `<span style="color:#999999;">Matching moves found in learnset(s) for</span> ${targetMons.map(mon => `${mon.shouldBeExcluded ? "!" : ""}${mon.name}`).join(', ')}:<br />`;
-	} else {
-		resultsStr += (message === "" ? message : `<span style="color:#999999;">${escapeHTML(message)}:</span><br />`);
-	}
-	if (randomOutput && randomOutput < results.length) {
-		results = Utils.shuffle(results).slice(0, randomOutput);
-	}
-	if (results.length > 1) {
-		results.sort();
-		if (sort) {
-			const prop = sort.slice(0, -1);
-			const direction = sort.slice(-1);
-			Utils.sortBy(results, moveName => {
-				let moveProp = dex[toID(moveName)][prop as keyof Move] as number;
-				// convert booleans to 0 or 1
-				if (typeof moveProp === 'boolean') moveProp = moveProp ? 1 : 0;
-				return moveProp * (direction === '+' ? 1 : -1);
-			});
-		}
-		let notShown = 0;
-		if (!showAll && results.length > MAX_RANDOM_RESULTS) {
-			notShown = results.length - RESULTS_MAX_LENGTH;
-			results = results.slice(0, RESULTS_MAX_LENGTH);
-		}
-		resultsStr += results.map(
-			result => `<a href="//${Config.routes.dex}/moves/${toID(result)}" target="_blank" class="subtle" style="white-space:nowrap">${result}</a>` +
-				`${sort ? ` (${dex[toID(result)][sort.slice(0, -1) as keyof Move] === true ? '-' : dex[toID(result)][sort.slice(0, -1) as keyof Move]})` : ''}`
-		).join(", ");
-		if (notShown) {
-			resultsStr += `, and ${notShown} more. <span style="color:#999999;">Redo the search with ', all' at the end to show all results.</span>`;
-		}
-	} else if (results.length === 1) {
-		return {dt: `${results[0]}${usedMod ? `,${usedMod}` : ''}`};
-	} else {
-		resultsStr += "No moves found.";
-	}
-	if (isTest) return {results, reply: resultsStr};
-	return {reply: resultsStr};
-}
-
-function runItemsearch(target: string, cmd: string, canAll: boolean, message: string) {
-	let showAll = false;
-	let maxGen = 0;
-	let gen = 0;
-
-	target = target.trim();
-	const lastCommaIndex = target.lastIndexOf(',');
-	const lastArgumentSubstr = target.substr(lastCommaIndex + 1).trim();
-	if (lastArgumentSubstr === 'all') {
-		if (!canAll) return {error: "A search ending in ', all' cannot be broadcast."};
-		showAll = true;
-		target = target.substr(0, lastCommaIndex);
-	}
-
-	target = target.toLowerCase().replace('-', ' ').replace(/[^a-z0-9.\s/]/g, '');
-	const rawSearch = target.replace(/(max ?)?gen \d/g, match => toID(match)).split(' ');
-	const searchedWords: string[] = [];
-	let foundItems: string[] = [];
-
-	// Refine searched words
-	for (const [i, search] of rawSearch.entries()) {
-		let newWord = search.trim();
-		if (newWord.substr(0, 6) === 'maxgen') {
-			const parsedGen = parseInt(newWord.substr(6));
-			if (!isNaN(parsedGen)) {
-				if (maxGen) return {error: "You cannot specify 'maxgen' multiple times."};
-				maxGen = parsedGen;
-				if (maxGen < 2 || maxGen > 8) return {error: "The generation must be between 2 and 8"};
-				continue;
-			}
-		} else if (newWord.substr(0, 3) === 'gen') {
-			const parsedGen = parseInt(newWord.substr(3));
-			if (!isNaN(parsedGen)) {
-				if (gen) return {error: "You cannot specify 'gen' multiple times."};
-				gen = parsedGen;
-				if (gen < 2 || gen > 8) return {error: "The generation must be between 2 and 8"};
-				continue;
-			}
-		}
-		if (isNaN(parseFloat(newWord))) newWord = newWord.replace('.', '');
-		switch (newWord) {
-		// Words that don't really help identify item removed to speed up search
-		case 'a':
-		case 'an':
-		case 'is':
-		case 'it':
-		case 'its':
-		case 'the':
-		case 'that':
-		case 'which':
-		case 'user':
-		case 'holder':
-		case 'holders':
-			newWord = '';
-			break;
-		// replace variations of common words with standardized versions
-		case 'opponent': newWord = 'attacker'; break;
-		case 'flung': newWord = 'fling'; break;
-		case 'heal': case 'heals':
-		case 'recovers': newWord = 'restores'; break;
-		case 'boost':
-		case 'boosts': newWord = 'raises'; break;
-		case 'weakens': newWord = 'halves'; break;
-		case 'more': newWord = 'increases'; break;
-		case 'super':
-			if (rawSearch[i + 1] === 'effective') {
-				newWord = 'supereffective';
-			}
-			break;
-		case 'special':
-			if (rawSearch[i + 1] === 'defense') {
-				newWord = 'specialdefense';
-			} else if (rawSearch[i + 1] === 'attack') {
-				newWord = 'specialattack';
-			}
-			break;
-		case 'spatk':
-		case 'spa':
-			newWord = 'specialattack';
-			break;
-		case 'atk':
-		case 'attack':
-			if (['sp', 'special'].includes(rawSearch[i - 1])) {
-				break;
-			} else {
-				newWord = 'attack';
-			}
-			break;
-		case 'spd':
-		case 'spdef':
-			newWord = 'specialdefense';
-			break;
-		case 'def':
-		case 'defense':
-			if (['sp', 'special'].includes(rawSearch[i - 1])) {
-				break;
-			} else {
-				newWord = 'defense';
-			}
-			break;
-		case 'burns': newWord = 'burn'; break;
-		case 'poisons': newWord = 'poison'; break;
-		default:
-			if (/x[\d.]+/.test(newWord)) {
-				newWord = newWord.substr(1) + 'x';
-			}
-		}
-		if (!newWord || searchedWords.includes(newWord)) continue;
-		searchedWords.push(newWord);
-	}
-
-	if (searchedWords.length === 0 && !gen && !maxGen) {
-		return {error: "No distinguishing words were used. Try a more specific search."};
-	}
-
-	const dex = maxGen ? Dex.mod("gen" + maxGen) : Dex;
-	if (searchedWords.includes('fling')) {
-		let basePower = 0;
-		let effect;
-
-		for (let word of searchedWords) {
-			let wordEff = "";
-			switch (word) {
-			case 'burn': case 'burns':
-			case 'brn': wordEff = 'brn'; break;
-			case 'paralyze': case 'paralyzes':
-			case 'par': wordEff = 'par'; break;
-			case 'poison': case 'poisons':
-			case 'psn': wordEff = 'psn'; break;
-			case 'toxic':
-			case 'tox': wordEff = 'tox'; break;
-			case 'flinches':
-			case 'flinch': wordEff = 'flinch'; break;
-			case 'badly': wordEff = 'tox'; break;
-			}
-			if (wordEff && effect) {
-				if (!(wordEff === 'psn' && effect === 'tox')) return {error: "Only specify fling effect once."};
-			} else if (wordEff) {
-				effect = wordEff;
-			} else {
-				if (word.substr(word.length - 2) === 'bp' && word.length > 2) word = word.substr(0, word.length - 2);
-				if (Number.isInteger(Number(word))) {
-					if (basePower) return {error: "Only specify a number for base power once."};
-					basePower = parseInt(word);
-				}
-			}
-		}
-
-		for (const item of dex.items.all()) {
-			if (!item.fling || (gen && item.gen !== gen) || (maxGen && item.gen <= maxGen)) continue;
-
-			if (basePower && effect) {
-				if (item.fling.basePower === basePower &&
-				(item.fling.status === effect || item.fling.volatileStatus === effect)) foundItems.push(item.name);
-			} else if (basePower) {
-				if (item.fling.basePower === basePower) foundItems.push(item.name);
-			} else {
-				if (item.fling.status === effect || item.fling.volatileStatus === effect) foundItems.push(item.name);
-			}
-		}
-		if (foundItems.length === 0) return {error: 'No items inflict ' + basePower + 'bp damage when used with Fling.'};
-	} else if (target.search(/natural ?gift/i) >= 0) {
-		let basePower = 0;
-		let type = "";
-
-		for (let word of searchedWords) {
-			if (word in dex.data.TypeChart) {
-				if (type) return {error: "Only specify natural gift type once."};
-				type = word.charAt(0).toUpperCase() + word.slice(1);
-			} else {
-				if (word.endsWith('bp') && word.length > 2) word = word.slice(0, -2);
-				if (Number.isInteger(Number(word))) {
-					if (basePower) return {error: "Only specify a number for base power once."};
-					basePower = parseInt(word);
-				}
-			}
-		}
-
-		for (const item of dex.items.all()) {
-			if (!item.isBerry || !item.naturalGift || (gen && item.gen !== gen) || (maxGen && item.gen <= maxGen)) continue;
-
-			if (basePower && type) {
-				if (item.naturalGift.basePower === basePower && item.naturalGift.type === type) foundItems.push(item.name);
-			} else if (basePower) {
-				if (item.naturalGift.basePower === basePower) foundItems.push(item.name);
-			} else {
-				if (item.naturalGift.type === type) foundItems.push(item.name);
-			}
-		}
-		if (foundItems.length === 0) {
-			return {error: 'No berries inflict ' + basePower + 'bp damage when used with Natural Gift.'};
-		}
-	} else {
-		let bestMatched = 0;
-		for (const item of dex.items.all()) {
-			let matched = 0;
-			// splits words in the description into a toID()-esk format except retaining / and . in numbers
-			let descWords = item.desc || '';
-			// add more general quantifier words to descriptions
-			if (/[1-9.]+x/.test(descWords)) descWords += ' increases';
-			if (item.isBerry) descWords += ' berry';
-			descWords = descWords.replace(/super[-\s]effective/g, 'supereffective');
-			const descWordsArray = descWords.toLowerCase()
-				.replace('-', ' ')
-				.replace(/[^a-z0-9\s/]/g, '')
-				.replace(/(\D)\./, (p0, p1) => p1).split(' ');
-
-			for (const word of searchedWords) {
-				switch (word) {
-				case 'specialattack':
-					if (descWordsArray[descWordsArray.indexOf('sp') + 1] === 'atk') matched++;
-					break;
-				case 'specialdefense':
-					if (descWordsArray[descWordsArray.indexOf('sp') + 1] === 'def') matched++;
-					break;
-				default:
-					if (descWordsArray.includes(word)) matched++;
-				}
-			}
-
-			if (matched >= (searchedWords.length * 3 / 5) && (!maxGen || item.gen <= maxGen) && (!gen || item.gen === gen)) {
-				if (matched === bestMatched) {
-					foundItems.push(item.name);
-				} else if (matched > bestMatched) {
-					foundItems = [item.name];
-					bestMatched = matched;
-				}
-			}
-		}
-	}
-
-	let resultsStr = (message === "" ? message : `<span style="color:#999999;">${escapeHTML(message)}:</span><br />`);
-	if (foundItems.length > 0) {
-		foundItems.sort();
-		let notShown = 0;
-		if (!showAll && foundItems.length > RESULTS_MAX_LENGTH + 5) {
-			notShown = foundItems.length - RESULTS_MAX_LENGTH;
-			foundItems = foundItems.slice(0, RESULTS_MAX_LENGTH);
-		}
-		resultsStr += foundItems.map(
-			result => `<a href="//${Config.routes.dex}/items/${toID(result)}" target="_blank" class="subtle" style="white-space:nowrap"><psicon item="${result}" style="vertical-align:-7px" />${result}</a>`
-		).join(", ");
-		if (notShown) {
-			resultsStr += `, and ${notShown} more. <span style="color:#999999;">Redo the search with ', all' at the end to show all results.</span>`;
-		}
-	} else {
-		resultsStr += "No items found. Try a more general search";
-	}
-	return {reply: resultsStr};
-}
-
-function runAbilitysearch(target: string, cmd: string, canAll: boolean, message: string) {
-	// based heavily on runItemsearch()
-	let showAll = false;
-	let maxGen = 0;
-	let gen = 0;
-
-	target = target.trim();
-	const lastCommaIndex = target.lastIndexOf(',');
-	const lastArgumentSubstr = target.substr(lastCommaIndex + 1).trim();
-	if (lastArgumentSubstr === 'all') {
-		if (!canAll) return {error: "A search ending in ', all' cannot be broadcast."};
-		showAll = true;
-		target = target.substr(0, lastCommaIndex);
-	}
-
-	target = target.toLowerCase().replace('-', ' ').replace(/[^a-z0-9.\s/]/g, '');
-	const rawSearch = target.replace(/(max ?)?gen \d/g, match => toID(match)).split(' ');
-	const searchedWords: string[] = [];
-	let foundAbilities: string[] = [];
-
-	for (const [i, search] of rawSearch.entries()) {
-		let newWord = search.trim();
-		if (newWord.substr(0, 6) === 'maxgen') {
-			const parsedGen = parseInt(newWord.substr(6));
-			if (parsedGen) {
-				if (maxGen) return {error: "You cannot specify 'maxgen' multiple times."};
-				maxGen = parsedGen;
-				if (maxGen < 3 || maxGen > 8) return {error: "The generation must be between 3 and 8"};
-				continue;
-			}
-		} else if (newWord.substr(0, 3) === 'gen') {
-			const parsedGen = parseInt(newWord.substr(3));
-			if (parsedGen) {
-				if (gen) return {error: "You cannot specify 'gen' multiple times."};
-				gen = parsedGen;
-				if (gen < 3 || gen > 8) return {error: "The generation must be between 3 and 8"};
-				continue;
-			}
-		}
-		if (isNaN(parseFloat(newWord))) newWord = newWord.replace('.', '');
-		switch (newWord) {
-		// remove extraneous words
-		case 'a':
-		case 'an':
-		case 'is':
-		case 'it':
-		case 'its':
-		case 'the':
-		case 'that':
-		case 'which':
-		case 'user':
-			newWord = '';
-			break;
-		// replace variations of common words with standardized versions
-		case 'opponent': newWord = 'attacker'; break;
-		case 'heal':
-		case 'heals':
-		case 'recovers': newWord = 'restores'; break;
-		case 'boost':
-		case 'boosts': newWord = 'raised'; break;
-		case 'super':
-			if (rawSearch[i + 1] === 'effective') {
-				newWord = 'supereffective';
-			}
-			break;
-		case 'special':
-			if (rawSearch[i + 1] === 'defense') {
-				newWord = 'specialdefense';
-			} else if (rawSearch[i + 1] === 'attack') {
-				newWord = 'specialattack';
-			}
-			break;
-		case 'spd':
-		case 'spdef': newWord = 'specialdefense'; break;
-		case 'spa':
-		case 'spatk': newWord = 'specialattack'; break;
-		case 'atk': newWord = 'attack'; break;
-		case 'def': newWord = 'defense'; break;
-		case 'spe': newWord = 'speed'; break;
-		case 'burn':
-		case 'burns': newWord = 'burned'; break;
-		case 'poison':
-		case 'poisons': newWord = 'poisoned'; break;
-		default:
-			if (/x[\d.]+/.test(newWord)) {
-				newWord = newWord.substr(1) + 'x';
-			}
-		}
-		if (!newWord || searchedWords.includes(newWord)) continue;
-		searchedWords.push(newWord);
-	}
-
-	if (searchedWords.length === 0 && !gen && !maxGen) {
-		return {error: "No distinguishing words were used. Try a more specific search."};
-	}
-
-	let bestMatched = 0;
-	const dex = maxGen ? Dex.mod("gen" + maxGen) : Dex;
-	for (const ability of dex.abilities.all()) {
-		let matched = 0;
-		// splits words in the description into a toID()-esque format except retaining / and . in numbers
-		let descWords = ability.desc || ability.shortDesc || '';
-		// add more general quantifier words to descriptions
-		if (/[1-9.]+x/.test(descWords)) descWords += ' increases';
-		descWords = descWords.replace(/super[-\s]effective/g, 'supereffective');
-		const descWordsArray = Chat.normalize(descWords).split(' ');
-
-		for (const word of searchedWords) {
-			switch (word) {
-			case 'specialattack':
-				if (descWordsArray[descWordsArray.indexOf('special') + 1] === 'attack') matched++;
-				break;
-			case 'specialdefense':
-				if (descWordsArray[descWordsArray.indexOf('special') + 1] === 'defense') matched++;
-				break;
-			default:
-				if (descWordsArray.includes(word)) matched++;
-			}
-		}
-
-		if (matched >= (searchedWords.length * 3 / 5) && (!maxGen || ability.gen <= maxGen) && (!gen || ability.gen === gen)) {
-			if (matched === bestMatched) {
-				foundAbilities.push(ability.name);
-			} else if (matched > bestMatched) {
-				foundAbilities = [ability.name];
-				bestMatched = matched;
-			}
-		}
-	}
-
-	if (foundAbilities.length === 1) return {dt: foundAbilities[0]};
-	let resultsStr = (message === "" ? message : `<span style="color:#999999;">${escapeHTML(message)}:</span><br />`);
-	if (foundAbilities.length > 0) {
-		foundAbilities.sort();
-		let notShown = 0;
-		if (!showAll && foundAbilities.length > RESULTS_MAX_LENGTH + 5) {
-			notShown = foundAbilities.length - RESULTS_MAX_LENGTH;
-			foundAbilities = foundAbilities.slice(0, RESULTS_MAX_LENGTH);
-		}
-		resultsStr += foundAbilities.map(
-			result => `<a href="//${Config.routes.dex}/abilities/${toID(result)}" target="_blank" class="subtle" style="white-space:nowrap">${result}</a>`
-		).join(", ");
-		if (notShown) {
-			resultsStr += `, and ${notShown} more. <span style="color:#999999;">Redo the search with ', all' at the end to show all results.</span>`;
-		}
-	} else {
-		resultsStr += "No abilities found. Try a more general search.";
-	}
-	return {reply: resultsStr};
-}
-
-function runLearn(target: string, cmd: string, canAll: boolean, formatid: string) {
-	let format: Format = Dex.formats.get(formatid);
-	const targets = target.split(',');
-	let formatName = format.name;
-	let minSourceGen = undefined;
-	let level = 100;
-
-	while (targets.length) {
-		const targetid = toID(targets[0]);
-		if (targetid === 'pentagon') {
-			if (format.exists) {
-				return {error: "'pentagon' can't be used with formats."};
-			}
-			minSourceGen = 6;
-			targets.shift();
-			continue;
-		}
-		if (targetid.startsWith('minsourcegen')) {
-			if (format.exists) {
-				return {error: "'min source gen' can't be used with formats."};
-			}
-			minSourceGen = parseInt(targetid.slice(12));
-			if (isNaN(minSourceGen) || minSourceGen < 1) return {error: `Invalid min source gen "${targetid.slice(12)}"`};
-			targets.shift();
-			continue;
-		}
-		if (targetid === 'level5') {
-			level = 5;
-			targets.shift();
-			continue;
-		}
-		break;
-	}
-	let gen;
-	if (!format.exists) {
-		const dex = Dex.mod(formatid).includeData();
-		// can happen if you hotpatch formats without hotpatching chat
-		if (!dex) return {error: `"${formatid}" is not a supported format.`};
-
-		gen = dex.gen;
-		format = new Dex.Format({mod: formatid});
-		formatName = `Gen ${gen}`;
-		if (minSourceGen) {
-			formatName += ` (Min Source Gen = ${minSourceGen})`;
-			const ruleTable = dex.formats.getRuleTable(format);
-			ruleTable.minSourceGen = minSourceGen;
-		}
-	} else {
-		gen = Dex.forFormat(format).gen;
-	}
-	const validator = TeamValidator.get(format);
-
-	const species = validator.dex.species.get(targets.shift());
-	const setSources = validator.allSources(species);
-	const set: Partial<PokemonSet> = {
-		name: species.baseSpecies,
-		species: species.name,
-		level,
-	};
-	const all = (cmd === 'learnall');
-
-	if (!species.exists || species.id === 'missingno') {
-		return {error: `Pok\u00e9mon '${species.id}' not found.`};
-	}
-
-	if (species.gen > gen) {
-		return {error: `${species.name} didn't exist yet in generation ${gen}.`};
-	}
-
-	if (!targets.length) {
-		return {error: "You must specify at least one move."};
-	}
-
-	const moveNames = [];
-	for (const arg of targets) {
-		if (['ha', 'hidden', 'hiddenability'].includes(toID(arg))) {
-			setSources.isHidden = true;
-			continue;
-		}
-		const move = validator.dex.moves.get(arg);
-		moveNames.push(move.name);
-		if (!move.exists) {
-			return {error: `Move '${move.id}' not found.`};
-		}
-		if (move.gen > gen) {
-			return {error: `${move.name} didn't exist yet in generation ${gen}.`};
-		}
-	}
-
-	const problems = validator.validateMoves(species, moveNames, setSources, set);
-	if (setSources.sources.length) {
-		setSources.sources = setSources.sources.map(source => {
-			if (source.charAt(1) !== 'E') return source;
-			const fathers = validator.findEggMoveFathers(source, species, setSources, true);
-			if (!fathers) return '';
-			return source + ':' + fathers.join(',');
-		}).filter(Boolean);
-		if (!setSources.size()) {
-			problems.push(`${species.name} doesn't have a valid father for its egg moves (${setSources.limitedEggMoves!.join(', ')})`);
-		}
-	}
-
-	let buffer = `In ${formatName}, `;
-	if (setSources.isHidden) {
-		buffer += `${species.abilities['H'] || 'HA'} `;
-	}
-	buffer += `${species.name}` + (problems.length ? ` <span class="message-learn-cannotlearn">can't</span> learn ` : ` <span class="message-learn-canlearn">can</span> learn `) + toListString(moveNames);
-	if (!problems.length) {
-		const sourceNames: {[k: string]: string} = {
-			'7V': "virtual console transfer from gen 1-2", '8V': "Pok&eacute;mon Home transfer from LGPE", E: "", S: "event", D: "dream world", X: "traded-back ", Y: "traded-back event",
-		};
-		const sourcesBefore = setSources.sourcesBefore;
-		let sources = setSources.sources;
-		if (sources.length || sourcesBefore < gen) buffer += " only when obtained";
-		buffer += " from:<ul class=\"message-learn-list\">";
-		if (sources.length) {
-			sources = sources.map(source => {
-				if (source.startsWith('1ET')) {
-					return '2X' + source.slice(3);
-				}
-				if (source.startsWith('1ST')) {
-					return '2Y' + source.slice(3);
-				}
-				return source;
-			}).sort();
-			for (let source of sources) {
-				buffer += `<li>Gen ${source.charAt(0)} ${sourceNames[source] || sourceNames[source.charAt(1)]}`;
-
-				if (source.charAt(1) === 'E') {
-					let fathers;
-					[source, fathers] = source.split(':');
-					fathers = fathers.split(',');
-					if (fathers.length > 4 && !all) fathers = fathers.slice(-4).concat('...');
-					if (source.length > 2) {
-						buffer += `${source.slice(2)} `;
-					}
-					buffer += `egg`;
-					if (!fathers[0]) {
-						buffer += `: chainbreed`;
-					} else {
-						buffer += `: breed ${fathers.join(', ')}`;
-					}
-				}
-
-				if (source.startsWith('5E') && species.maleOnlyHidden) {
-					buffer += " (no hidden ability)";
-				}
-			}
-		}
-		if (sourcesBefore) {
-			const sourceGen = sourcesBefore < gen ? `Gen ${sourcesBefore} or earlier` : `anywhere`;
-			if (moveNames.length === 1) {
-				if (sourcesBefore >= 8) {
-					buffer += `<li>${sourceGen} (move is level-up/tutor/TM/HM/egg in Gen ${sourcesBefore})`;
-				} else {
-					buffer += `<li>${sourceGen} (move is level-up/tutor/TM/HM in Gen ${sourcesBefore})`;
-				}
-			} else if (gen >= 8) {
-				const orEarlier = sourcesBefore < gen ? ` or level-up/tutor/TM/HM in Gen ${sourcesBefore}${
-					sourcesBefore < 7 ? " to 7" : ""
-				}` : ``;
-				buffer += `<li>${sourceGen} (all moves are level-up/tutor/TM/HM/egg in Gen ${sourcesBefore}${orEarlier})`;
-			} else {
-				buffer += `<li>${sourceGen} (all moves are level-up/tutor/TM/HM in Gen ${Math.min(gen, sourcesBefore)}${sourcesBefore < gen ? " to " + gen : ""})`;
-			}
-		}
-		if (setSources.babyOnly && sourcesBefore) {
-			buffer += `<li>must be obtained as ` + Dex.species.get(setSources.babyOnly).name;
-		}
-		buffer += "</ul>";
-	} else if (problems.length >= 1) {
-		const expectedError = `${species.name} can't learn ${moveNames[0]}.`;
-		if (problems.length > 1 || moveNames.length > 1 || problems[0] !== expectedError) {
-			buffer += ` because:<ul class="message-learn-list">`;
-			buffer += `<li>` + problems.join(`</li><li>`) + `</li>`;
-			buffer += `</ul>`;
-		}
-	}
-	return {reply: buffer};
-}
-
-function runSearch(query: {target: string, cmd: string, canAll: boolean, message: string}) {
-	return PM.query(query);
-}
-
-/*********************************************************
- * Process manager
- *********************************************************/
-
-export const PM = new ProcessManager.QueryProcessManager<AnyObject, AnyObject>(module, query => {
-	try {
-		if (Config.debugdexsearchprocesses && process.send) {
-			process.send('DEBUG\n' + JSON.stringify(query));
-		}
-		switch (query.cmd) {
-		case 'randpoke':
-		case 'dexsearch':
-			return runDexsearch(query.target, query.cmd, query.canAll, query.message, false);
-		case 'randmove':
-		case 'movesearch':
-			return runMovesearch(query.target, query.cmd, query.canAll, query.message, false);
-		case 'itemsearch':
-			return runItemsearch(query.target, query.cmd, query.canAll, query.message);
-		case 'abilitysearch':
-			return runAbilitysearch(query.target, query.cmd, query.canAll, query.message);
-		case 'learn':
-			return runLearn(query.target, query.cmd, query.canAll, query.message);
-		default:
-			throw new Error(`Unrecognized Dexsearch command "${query.cmd}"`);
-		}
-	} catch (err) {
-		Monitor.crashlog(err, 'A search query', query);
-	}
-	return {
-		error: "Sorry! Our search engine crashed on your query. We've been automatically notified and will fix this crash.",
-	};
-});
-
-if (!PM.isParentProcess) {
-	// This is a child process!
-	global.Config = require('../config-loader').Config;
-	global.Monitor = {
-		crashlog(error: Error, source = 'A datasearch process', details: AnyObject | null = null) {
-			const repr = JSON.stringify([error.name, error.message, source, details]);
-			process.send!(`THROW\n@!!@${repr}\n${error.stack}`);
-		},
-	};
-	if (Config.crashguard) {
-		process.on('uncaughtException', err => {
-			Monitor.crashlog(err, 'A dexsearch process');
-		});
-	}
-
-	global.Dex = require('../../sim/dex').Dex;
-	global.toID = Dex.toID;
-	Dex.includeData();
-
-	// @ts-ignore
-	require('../../lib/repl').Repl.start('dexsearch', cmd => eval(cmd)); // eslint-disable-line no-eval
-} else {
-	PM.spawn(MAX_PROCESSES);
-}
-
-export const testables = {
-	runAbilitysearch: (target: string, cmd: string, canAll: boolean, message: string) =>
-		runAbilitysearch(target, cmd, canAll, message),
-	runDexsearch: (target: string, cmd: string, canAll: boolean, message: string) =>
-		runDexsearch(target, cmd, canAll, message, true),
-	runMovesearch: (target: string, cmd: string, canAll: boolean, message: string) =>
-		runMovesearch(target, cmd, canAll, message, true),
-};
+ import {ProcessManager, Utils} from '../../lib';
+ import {TeamValidator} from '../../sim/team-validator';
+ import {Chat} from '../chat';
+ 
+ interface DexOrGroup {
+	 abilities: {[k: string]: boolean};
+	 tiers: {[k: string]: boolean};
+	 doublesTiers: {[k: string]: boolean};
+	 colors: {[k: string]: boolean};
+	 'egg groups': {[k: string]: boolean};
+	 formes: {[k: string]: boolean};
+	 gens: {[k: string]: boolean};
+	 moves: {[k: string]: boolean};
+	 types: {[k: string]: boolean};
+	 resists: {[k: string]: boolean};
+	 weak: {[k: string]: boolean};
+	 stats: {[k: string]: {[k in Direction]: number}};
+	 skip: boolean;
+ }
+ 
+ interface MoveOrGroup {
+	 types: {[k: string]: boolean};
+	 categories: {[k: string]: boolean};
+	 contestTypes: {[k: string]: boolean};
+	 flags: {[k: string]: boolean};
+	 gens: {[k: string]: boolean};
+	 other: {[k: string]: boolean};
+	 mon: {[k: string]: boolean};
+	 property: {[k: string]: {[k in Direction]: number}};
+	 boost: {[k: string]: boolean};
+	 lower: {[k: string]: boolean};
+	 zboost: {[k: string]: boolean};
+	 status: {[k: string]: boolean};
+	 volatileStatus: {[k: string]: boolean};
+	 targets: {[k: string]: boolean};
+	 skip: boolean;
+	 multihit: boolean;
+ }
+ 
+ type Direction = 'less' | 'greater' | 'equal';
+ 
+ const MAX_PROCESSES = 1;
+ const RESULTS_MAX_LENGTH = 10;
+ const MAX_RANDOM_RESULTS = 30;
+ const dexesHelp = Object.keys((global.Dex?.dexes || {})).filter(x => x !== 'sourceMaps').join('</code>, <code>');
+ 
+ function escapeHTML(str?: string) {
+	 if (!str) return '';
+	 return ('' + str)
+		 .replace(/&/g, '&amp;')
+		 .replace(/</g, '&lt;')
+		 .replace(/>/g, '&gt;')
+		 .replace(/"/g, '&quot;')
+		 .replace(/'/g, '&apos;')
+		 .replace(/\//g, '&#x2f;');
+ }
+ 
+ function toListString(arr: string[]) {
+	 if (!arr.length) return '';
+	 if (arr.length === 1) return arr[0];
+	 if (arr.length === 2) return `${arr[0]} and ${arr[1]}`;
+	 return `${arr.slice(0, -1).join(", ")}, and ${arr.slice(-1)[0]}`;
+ }
+ 
+ function checkCanAll(room: Room | null) {
+	 if (!room) return false; // no, no good reason for using `all` in pms
+	 const {isPersonal, isHelp} = room.settings;
+	 // allowed if it's a groupchat
+	 return !room.battle && !!isPersonal && !isHelp;
+ }
+ 
+ export const commands: Chat.ChatCommands = {
+	 ds: 'dexsearch',
+	 ds1: 'dexsearch',
+	 ds2: 'dexsearch',
+	 ds3: 'dexsearch',
+	 ds4: 'dexsearch',
+	 ds5: 'dexsearch',
+	 ds6: 'dexsearch',
+	 ds7: 'dexsearch',
+	 ds8: 'dexsearch',
+	 dsearch: 'dexsearch',
+	 nds: 'dexsearch',
+	 async dexsearch(target, room, user, connection, cmd, message) {
+		 this.checkBroadcast();
+		 if (!target) return this.parse('/help dexsearch');
+		 if (target.length > 300) return this.errorReply('Dexsearch queries may not be longer than 300 characters.');
+		 const targetGen = parseInt(cmd[cmd.length - 1]);
+		 if (targetGen) target += `, mod=gen${targetGen}`;
+		 const split = target.split(',').map(term => term.trim());
+		 const index = split.findIndex(x => /^max\s*gen/i.test(x));
+		 if (index >= 0) {
+			 const genNum = parseInt(/\d*$/.exec(split[index])?.[0] || '');
+			 if (!isNaN(genNum) && !(genNum < 1 || genNum > Dex.gen)) {
+				 split[index] = `mod=gen${genNum}`;
+				 target = split.join(',');
+			 }
+		 }
+		 if (!target.includes('mod=')) {
+			 const dex = this.extractFormat(room?.settings.defaultFormat || room?.battle?.format).dex;
+			 if (dex) target += `, mod=${dex.currentMod}`;
+		 }
+		 if (cmd === 'nds') target += ', natdex';
+		 const response = await runSearch({
+			 target,
+			 cmd: 'dexsearch',
+			 canAll: !this.broadcastMessage || checkCanAll(room),
+			 message: (this.broadcastMessage ? "" : message),
+		 });
+		 if (!response.error && !this.runBroadcast()) return;
+		 if (response.error) {
+			 throw new Chat.ErrorMessage(response.error);
+		 } else if (response.reply) {
+			 this.sendReplyBox(response.reply);
+		 } else if (response.dt) {
+			 (Chat.commands.data as Chat.ChatHandler).call(
+				 this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
+			 );
+		 }
+	 },
+	 dexsearchhelp() {
+		 this.sendReply(
+			 `|html| <details class="readmore"><summary><code>/dexsearch [parameter], [parameter], [parameter], ...</code>: searches for Pok\u00e9mon that fulfill the selected criteria<br/>` +
+			 `Search categories are: type, tier, color, moves, ability, gen, resists, weak, recovery, zrecovery, priority, stat, weight, height, egg group, pivot.<br/>` +
+			 `Valid colors are: green, red, blue, white, brown, yellow, purple, pink, gray and black.<br/>` +
+			 `Valid tiers are: Uber/OU/UUBL/UU/RUBL/RU/NUBL/NU/PUBL/PU/ZU/NFE/LC/CAP/CAP NFE/CAP LC.<br/>` +
+			 `Valid doubles tiers are: DUber/DOU/DBL/DUU/DNU.</summary>` +
+			 `Types can be searched for by either having the type precede <code>type</code> or just using the type itself as a parameter; e.g., both <code>fire type</code> and <code>fire</code> show all Fire types; however, using <code>psychic</code> as a parameter will show all Pok\u00e9mon that learn the move Psychic and not Psychic types.<br/>` +
+			 `<code>resists</code> followed by a type or move will show Pok\u00e9mon that resist that typing or move (e.g. <code>resists normal</code>).<br/>` +
+			 `<code>weak</code> followed by a type or move will show Pok\u00e9mon that are weak to that typing or move (e.g. <code>weak fire</code>).<br/>` +
+			 `<code>asc</code> or <code>desc</code> following a stat will show the Pok\u00e9mon in ascending or descending order of that stat respectively (e.g. <code>speed asc</code>).<br/>` +
+			 `Inequality ranges use the characters <code>>=</code> for <code>≥</code> and <code><=</code> for <code>≤</code>; e.g., <code>hp <= 95</code> searches all Pok\u00e9mon with HP less than or equal to 95.<br/>` +
+			 `Parameters can be excluded through the use of <code>!</code>; e.g., <code>!water type</code> excludes all Water types.<br/>` +
+			 `The parameter <code>mega</code> can be added to search for Mega Evolutions only, the parameter <code>gmax</code> can be added to search for Pokemon capable of Gigantamaxing only, and the parameter <code>Fully Evolved</code> (or <code>FE</code>) can be added to search for fully-evolved Pok\u00e9mon.<br/>` +
+			 `<code>Alola</code>, <code>Galar</code>, <code>Therian</code>, <code>Totem</code>, or <code>Primal</code> can be used as parameters to search for those formes.<br/>` +
+			 `Parameters separated with <code>|</code> will be searched as alternatives for each other; e.g., <code>trick | switcheroo</code> searches for all Pok\u00e9mon that learn either Trick or Switcheroo.<br/>` +
+			 `You can search for info in a specific generation by appending the generation to ds or by using the <code>maxgen</code> keyword; e.g. <code>/ds1 normal</code> or <code>/ds normal, maxgen1</code> searches for all Pok\u00e9mon that were Normal type in Generation I.<br/>` +
+			 `You can search for info in a specific mod by using <code>mod=[mod name]</code>; e.g. <code>/nds mod=ssb, protean</code>. All valid mod names are: <code>${dexesHelp}</code><br />` +
+			 `<code>/dexsearch</code> will search the Galar Pokedex; you can search the National Pokedex by using <code>/nds</code> or by adding <code>natdex</code> as a parameter.<br/>` +
+			 `Searching for a Pok\u00e9mon with both egg group and type parameters can be differentiated by adding the suffix <code>group</code> onto the egg group parameter; e.g., seaching for <code>grass, grass group</code> will show all Grass types in the Grass egg group.<br/>` +
+			 `The parameter <code>monotype</code> will only show Pok\u00e9mon that are single-typed.<br/>` +
+			 `The order of the parameters does not matter.<br/>`
+		 );
+	 },
+ 
+	 rollmove: 'randommove',
+	 randmove: 'randommove',
+	 async randommove(target, room, user, connection, cmd, message) {
+		 this.checkBroadcast(true);
+		 target = target.slice(0, 300);
+		 const targets = target.split(",");
+		 const targetsBuffer = [];
+		 let qty;
+		 for (const arg of targets) {
+			 if (!arg) continue;
+			 const num = Number(arg);
+			 if (Number.isInteger(num)) {
+				 if (qty) throw new Chat.ErrorMessage("Only specify the number of Pok\u00e9mon Moves once.");
+				 qty = num;
+				 if (qty < 1 || MAX_RANDOM_RESULTS < qty) {
+					 throw new Chat.ErrorMessage(`Number of random Pok\u00e9mon Moves must be between 1 and ${MAX_RANDOM_RESULTS}.`);
+				 }
+				 targetsBuffer.push(`random${qty}`);
+			 } else {
+				 targetsBuffer.push(arg);
+			 }
+		 }
+		 if (!qty) targetsBuffer.push("random1");
+ 
+		 const response = await runSearch({
+			 target: targetsBuffer.join(","),
+			 cmd: 'randmove',
+			 canAll: !this.broadcastMessage || checkCanAll(room),
+			 message: (this.broadcastMessage ? "" : message),
+		 });
+		 if (!response.error && !this.runBroadcast(true)) return;
+		 if (response.error) {
+			 throw new Chat.ErrorMessage(response.error);
+		 } else if (response.reply) {
+			 this.sendReplyBox(response.reply);
+		 } else if (response.dt) {
+			 (Chat.commands.data as Chat.ChatHandler).call(
+				 this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
+			 );
+		 }
+	 },
+	 randommovehelp: [
+		 `/randommove - Generates random Pok\u00e9mon Moves based on given search conditions.`,
+		 `/randommove uses the same parameters as /movesearch (see '/help ms').`,
+		 `Adding a number as a parameter returns that many random Pok\u00e9mon Moves, e.g., '/randmove 6' returns 6 random Pok\u00e9mon Moves.`,
+	 ],
+ 
+	 rollpokemon: 'randompokemon',
+	 randpoke: 'randompokemon',
+	 async randompokemon(target, room, user, connection, cmd, message) {
+		 this.checkBroadcast(true);
+		 target = target.slice(0, 300);
+		 const targets = target.split(",");
+		 const targetsBuffer = [];
+		 let qty;
+		 for (const arg of targets) {
+			 if (!arg) continue;
+			 const num = Number(arg);
+			 if (Number.isInteger(num)) {
+				 if (qty) throw new Chat.ErrorMessage("Only specify the number of Pok\u00e9mon once.");
+				 qty = num;
+				 if (qty < 1 || MAX_RANDOM_RESULTS < qty) {
+					 throw new Chat.ErrorMessage(`Number of random Pok\u00e9mon must be between 1 and ${MAX_RANDOM_RESULTS}.`);
+				 }
+				 targetsBuffer.push(`random${qty}`);
+			 } else {
+				 targetsBuffer.push(arg);
+			 }
+		 }
+		 if (!qty) targetsBuffer.push("random1");
+ 
+		 const response = await runSearch({
+			 target: targetsBuffer.join(","),
+			 cmd: 'randpoke',
+			 canAll: !this.broadcastMessage || checkCanAll(room),
+			 message: (this.broadcastMessage ? "" : message),
+		 });
+		 if (!response.error && !this.runBroadcast(true)) return;
+		 if (response.error) {
+			 throw new Chat.ErrorMessage(response.error);
+		 } else if (response.reply) {
+			 this.sendReplyBox(response.reply);
+		 } else if (response.dt) {
+			 (Chat.commands.data as Chat.ChatHandler).call(
+				 this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
+			 );
+		 }
+	 },
+	 randompokemonhelp: [
+		 `/randompokemon - Generates random Pok\u00e9mon based on given search conditions.`,
+		 `/randompokemon uses the same parameters as /dexsearch (see '/help ds').`,
+		 `Adding a number as a parameter returns that many random Pok\u00e9mon, e.g., '/randpoke 6' returns 6 random Pok\u00e9mon.`,
+	 ],
+ 
+	 ms: 'movesearch',
+	 ms1: 'movesearch',
+	 ms2: 'movesearch',
+	 ms3: 'movesearch',
+	 ms4: 'movesearch',
+	 ms5: 'movesearch',
+	 ms6: 'movesearch',
+	 ms7: 'movesearch',
+	 ms8: 'movesearch',
+	 msearch: 'movesearch',
+	 nms: 'movesearch',
+	 async movesearch(target, room, user, connection, cmd, message) {
+		 this.checkBroadcast();
+		 if (!target) return this.parse('/help movesearch');
+		 target = target.slice(0, 300);
+		 const targetGen = parseInt(cmd[cmd.length - 1]);
+		 if (targetGen) target += `, mod=gen${targetGen}`;
+		 const split = target.split(',').map(term => term.trim());
+		 const index = split.findIndex(x => /^max\s*gen/i.test(x));
+		 if (index >= 0) {
+			 const genNum = parseInt(/\d*$/.exec(split[index])?.[0] || '');
+			 if (!isNaN(genNum) && !(genNum < 1 || genNum > Dex.gen)) {
+				 split[index] = `mod=gen${genNum}`;
+				 target = split.join(',');
+			 }
+		 }
+		 if (!target.includes('mod=')) {
+			 const dex = this.extractFormat(room?.settings.defaultFormat || room?.battle?.format).dex;
+			 if (dex) target += `, mod=${dex.currentMod}`;
+		 }
+		 if (cmd === 'nms') target += ', natdex';
+		 const response = await runSearch({
+			 target,
+			 cmd: 'movesearch',
+			 canAll: !this.broadcastMessage || checkCanAll(room),
+			 message: (this.broadcastMessage ? "" : message),
+		 });
+		 if (!response.error && !this.runBroadcast()) return;
+		 if (response.error) {
+			 throw new Chat.ErrorMessage(response.error);
+		 } else if (response.reply) {
+			 this.sendReplyBox(response.reply);
+		 } else if (response.dt) {
+			 (Chat.commands.data as Chat.ChatHandler).call(
+				 this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
+			 );
+		 }
+	 },
+	 movesearchhelp() {
+		 this.sendReply(
+			 `|html| <details class="readmore"><summary><code>/movesearch [parameter], [parameter], [parameter], ...</code>: searches for moves that fulfill the selected criteria.<br/>` +
+			 `Search categories are: type, category, gen, contest condition, flag, status inflicted, type boosted, Pok\u00e9mon targeted, and numeric range for base power, pp, priority, and accuracy.<br/>` +
+			 `Types can be followed by <code> type</code> for clarity; e.g., <code>dragon type</code>.<br/>` +
+			 `Stat boosts must be preceded with <code>boosts </code>, and stat-lowering moves with <code>lowers </code>; e.g., <code>boosts attack</code> searches for moves that boost the Attack stat of either Pok\u00e9mon.<br/>` +
+			 `Z-stat boosts must be preceded with <code>zboosts </code>; e.g., <code>zboosts accuracy</code> searches for all Status moves with Z-Effects that boost the user's accuracy.</summary>` +
+			 `Moves that have a Z-Effect of fully restoring the user's health can be searched for with <code>zrecovery</code>.<br/>` +
+			 `Move targets must be preceded with <code>targets </code>; e.g., <code>targets user</code> searches for moves that target the user.<br/>` +
+			 `Valid move targets are: one ally, user or ally, one adjacent opponent, all Pokemon, all adjacent Pokemon, all adjacent opponents, user and allies, user's side, user's team, any Pokemon, opponent's side, one adjacent Pokemon, random adjacent Pokemon, scripted, and user.<br/>` +
+			 `Inequality ranges use the characters <code>></code> and <code><</code>.<br/>` +
+			 `Parameters can be excluded through the use of <code>!</code>; e.g., <code>!water type</code> excludes all Water-type moves.<br/>` +
+			 `<code>asc</code> or <code>desc</code> following a move property will arrange the names in ascending or descending order of that property, respectively; e.g., <code>basepower asc</code> will arrange moves in ascending order of their base powers.<br/>` +
+			 `Valid flags are: bypasssub (bypasses substitute), bite, bullet, charge, contact, dance, defrost, gravity, mirror (reflected by mirror move), ohko, powder, priority, protect, pulse, punch, recharge, recovery, reflectable, secondary, snatch, sound, zmove, pivot, and multi-hit.<br/>` +
+			 `A search that includes <code>!protect</code> will show all moves that bypass protection.<br/>` +
+			 `<code>protection</code> as a parameter will search protection moves like Protect, Detect, etc.<br/>` +
+			 `<code>max</code> or <code>gmax</code> as parameters will search for Max Moves and G-Max moves respectively.<br/>` +
+			 `Parameters separated with <code>|</code> will be searched as alternatives for each other; e.g., <code>fire | water</code> searches for all moves that are either Fire type or Water type.<br/>` +
+			 `If a Pok\u00e9mon is included as a parameter, only moves from its movepool will be included in the search.<br/>` +
+			 `You can search for info in a specific generation by appending the generation to ms; e.g. <code>/ms1 normal</code> searches for all moves that were Normal type in Generation I.<br/>` +
+			 `You can search for info in a specific mod by using <code>mod=[mod name]</code>; e.g. <code>/nms mod=ssb, dark, bp=100</code>. All valid mod names are: <code>${dexesHelp}</code><br />` +
+			 `<code>/ms</code> will search the Galar Moves; you can search the National Moves by using <code>/nms</code> or by adding <code>natdex</code> as a parameter.<br/>` +
+			 `The order of the parameters does not matter.`
+		 );
+	 },
+ 
+	 isearch: 'itemsearch',
+	 is: 'itemsearch',
+	 is2: 'itemsearch',
+	 is3: 'itemsearch',
+	 is4: 'itemsearch',
+	 is5: 'itemsearch',
+	 is6: 'itemsearch',
+	 is7: 'itemsearch',
+	 is8: 'itemsearch',
+	 async itemsearch(target, room, user, connection, cmd, message) {
+		 this.checkBroadcast();
+		 if (!target) return this.parse('/help itemsearch');
+		 target = target.slice(0, 300);
+		 const targetGen = parseInt(cmd[cmd.length - 1]);
+		 if (targetGen) target += ` maxgen${targetGen}`;
+ 
+		 const response = await runSearch({
+			 target,
+			 cmd: 'itemsearch',
+			 canAll: !this.broadcastMessage || checkCanAll(room),
+			 message: (this.broadcastMessage ? "" : message),
+		 });
+		 if (!response.error && !this.runBroadcast()) return;
+		 if (response.error) {
+			 throw new Chat.ErrorMessage(response.error);
+		 } else if (response.reply) {
+			 this.sendReplyBox(response.reply);
+		 } else if (response.dt) {
+			 (Chat.commands.data as Chat.ChatHandler).call(
+				 this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
+			 );
+		 }
+	 },
+	 itemsearchhelp() {
+		 this.sendReplyBox(
+			 `<code>/itemsearch [item description]</code>: finds items that match the given keywords.<br/>` +
+			 `This command accepts natural language. (tip: fewer words tend to work better)<br/>` +
+			 `The <code>gen</code> keyword can be used to search for items introduced in a given generation; e.g., <code>/is gen4</code> searches for items introduced in Generation 4.<br/>` +
+			 `To search for items within a generation, append the generation to <code>/is</code> or use the <code>maxgen</code> keyword; e.g., <code>/is4 Water-type</code> or <code>/is maxgen4 Water-type</code> searches for items whose Generation 4 description includes "Water-type".<br/>` +
+			 `Searches with <code>fling</code> in them will find items with the specified Fling behavior.<br/>` +
+			 `Searches with <code>natural gift</code> in them will find items with the specified Natural Gift behavior.`
+		 );
+	 },
+ 
+	 asearch: 'abilitysearch',
+	 as: 'abilitysearch',
+	 as3: 'abilitysearch',
+	 as4: 'abilitysearch',
+	 as5: 'abilitysearch',
+	 as6: 'abilitysearch',
+	 as7: 'abilitysearch',
+	 as8: 'abilitysearch',
+	 async abilitysearch(target, room, user, connection, cmd, message) {
+		 this.checkBroadcast();
+		 if (!target) return this.parse('/help abilitysearch');
+		 target = target.slice(0, 300);
+		 const targetGen = parseInt(cmd[cmd.length - 1]);
+		 if (targetGen) target += ` maxgen${targetGen}`;
+ 
+		 const response = await runSearch({
+			 target,
+			 cmd: 'abilitysearch',
+			 canAll: !this.broadcastMessage || checkCanAll(room),
+			 message: (this.broadcastMessage ? "" : message),
+		 });
+		 if (!response.error && !this.runBroadcast()) return;
+		 if (response.error) {
+			 throw new Chat.ErrorMessage(response.error);
+		 } else if (response.reply) {
+			 this.sendReplyBox(response.reply);
+		 } else if (response.dt) {
+			 (Chat.commands.data as Chat.ChatHandler).call(
+				 this, response.dt, room, user, connection, 'dt', this.broadcastMessage ? "" : message
+			 );
+		 }
+	 },
+	 abilitysearchhelp() {
+		 this.sendReplyBox(
+			 `<code>/abilitysearch [ability description]</code>: finds abilities that match the given keywords.<br/>` +
+			 `This command accepts natural language. (tip: fewer words tend to work better)<br/>` +
+			 `The <code>gen</code> keyword can be used to search for abilities introduced in a given generation; e.g., <code>/as gen4</code> searches for abilities introduced in Generation 4.<br/>` +
+			 `To search for abilities within a generation, append the generation to <code>/as</code> or use the <code>maxgen</code> keyword; e.g., <code>/as4 Water-type</code> or <code>/as maxgen4 Water-type</code> searches for abilities whose Generation 4 description includes "Water-type".`
+		 );
+	 },
+ 
+	 learnset: 'learn',
+	 learnall: 'learn',
+	 learn5: 'learn',
+	 rbylearn: 'learn',
+	 gsclearn: 'learn',
+	 advlearn: 'learn',
+	 dpplearn: 'learn',
+	 bw2learn: 'learn',
+	 oraslearn: 'learn',
+	 usumlearn: 'learn',
+	 async learn(target, room, user, connection, cmd, message) {
+		 if (!target) return this.parse('/help learn');
+		 if (target.length > 300) throw new Chat.ErrorMessage(`Query too long.`);
+ 
+		 const GENS: {[k: string]: number} = {rby: 1, gsc: 2, adv: 3, dpp: 4, bw2: 5, oras: 6, usum: 7};
+		 const cmdGen = GENS[cmd.slice(0, -5)];
+		 if (cmdGen) target = `gen${cmdGen}, ${target}`;
+ 
+		 this.checkBroadcast();
+		 const {format, dex, targets} = this.splitFormat(target);
+ 
+		 const formatid = format ? format.id : dex.currentMod;
+		 if (cmd === 'learn5') targets.unshift('level5');
+ 
+		 const response = await runSearch({
+			 target: targets.join(','),
+			 cmd: 'learn',
+			 canAll: !this.broadcastMessage || checkCanAll(room),
+			 message: formatid,
+		 });
+		 if (!response.error && !this.runBroadcast()) return;
+		 if (response.error) {
+			 throw new Chat.ErrorMessage(response.error);
+		 } else if (response.reply) {
+			 this.sendReplyBox(response.reply);
+		 }
+	 },
+	 learnhelp: [
+		 `/learn [ruleset], [pokemon], [move, move, ...] - Displays how the Pok\u00e9mon can learn the given moves, if it can at all.`,
+		 `!learn [ruleset], [pokemon], [move, move, ...] - Show everyone that information. Requires: + % @ # &`,
+		 `Specifying a ruleset is entirely optional. The ruleset can be a format, a generation (e.g.: gen3) or "min source gen [number]".`,
+		 `A value of 'min source gen [number]' indicates that trading (or Pokémon Bank) from generations before [number] is not allowed.`,
+		 `/learn5 displays how the Pok\u00e9mon can learn the given moves at level 5, if it can at all.`,
+		 `/learnall displays all of the possible fathers for egg moves.`,
+		 `/learn can also be prefixed by a generation acronym (e.g.: /dpplearn) to indicate which generation is used. Valid options are: rby gsc adv dpp bw2 oras usum`,
+	 ],
+ };
+ 
+ function getMod(target: string) {
+	 const arr = target.split(',').map(x => x.trim());
+	 const modTerm = arr.find(x => {
+		 const sanitizedStr = x.toLowerCase().replace(/[^a-z0-9=]+/g, '');
+		 return sanitizedStr.startsWith('mod=') && Dex.dexes[toID(sanitizedStr.split('=')[1])];
+	 });
+	 const count = arr.filter(x => {
+		 const sanitizedStr = x.toLowerCase().replace(/[^a-z0-9=]+/g, '');
+		 return sanitizedStr.startsWith('mod=');
+	 }).length;
+	 if (modTerm) arr.splice(arr.indexOf(modTerm), 1);
+	 return {splitTarget: arr, usedMod: modTerm ? toID(modTerm.split(/ ?= ?/)[1]) : undefined, count};
+ }
+ 
+ function runDexsearch(target: string, cmd: string, canAll: boolean, message: string, isTest: boolean) {
+	 const searches: DexOrGroup[] = [];
+	 const {splitTarget, usedMod, count: c} = getMod(target);
+	 if (c > 1) {
+		 return {error: `You can't run searches for multiple mods.`};
+	 }
+ 
+	 const mod = Dex.mod(usedMod || 'base');
+	 const allTiers: {[k: string]: TierTypes.Singles | TierTypes.Other} = Object.assign(Object.create(null), {
+		 anythinggoes: 'AG', ag: 'AG',
+		 uber: 'Uber', ubers: 'Uber', ou: 'OU',
+		 uubl: 'UUBL', uu: 'UU',
+		 rubl: 'RUBL', ru: 'RU',
+		 nubl: 'NUBL', nu: 'NU',
+		 publ: 'PUBL', pu: 'PU', zu: '(PU)',
+		 nfe: 'NFE',
+		 lc: 'LC',
+		 cap: 'CAP', caplc: 'CAP LC', capnfe: 'CAP NFE',
+	 });
+	 const allDoublesTiers: {[k: string]: TierTypes.Singles | TierTypes.Other} = Object.assign(Object.create(null), {
+		 doublesubers: 'DUber', doublesuber: 'DUber', duber: 'DUber', dubers: 'DUber',
+		 doublesou: 'DOU', dou: 'DOU',
+		 doublesbl: 'DBL', dbl: 'DBL',
+		 doublesuu: 'DUU', duu: 'DUU',
+		 doublesnu: '(DUU)', dnu: '(DUU)',
+	 });
+	 const allTypes = Object.create(null);
+	 for (const type of mod.types.all()) {
+		 allTypes[type.id] = type.name;
+	 }
+	 const allColors = ['green', 'red', 'blue', 'white', 'brown', 'yellow', 'purple', 'pink', 'gray', 'black'];
+	 const allEggGroups: {[k: string]: string} = Object.assign(Object.create(null), {
+		 amorphous: 'Amorphous',
+		 bug: 'Bug',
+		 ditto: 'Ditto',
+		 dragon: 'Dragon',
+		 fairy: 'Fairy',
+		 field: 'Field',
+		 flying: 'Flying',
+		 grass: 'Grass',
+		 humanlike: 'Human-Like',
+		 mineral: 'Mineral',
+		 monster: 'Monster',
+		 undiscovered: 'Undiscovered',
+		 water1: 'Water 1',
+		 water2: 'Water 2',
+		 water3: 'Water 3',
+	 });
+	 const allFormes = ['alola', 'galar', 'primal', 'therian', 'totem'];
+	 const allStats = ['hp', 'atk', 'def', 'spa', 'spd', 'spe', 'bst', 'weight', 'height', 'gen'];
+	 const allStatAliases: {[k: string]: string} = {
+		 attack: 'atk', defense: 'def', specialattack: 'spa', spc: 'spa', special: 'spa', spatk: 'spa',
+		 specialdefense: 'spd', spdef: 'spd', speed: 'spe', wt: 'weight', ht: 'height', generation: 'gen',
+	 };
+	 let showAll = false;
+	 let sort = null;
+	 let megaSearch = null;
+	 let gmaxSearch = null;
+	 let tierSearch = null;
+	 let capSearch: boolean | null = null;
+	 let nationalSearch = null;
+	 let fullyEvolvedSearch = null;
+	 let singleTypeSearch = null;
+	 let randomOutput = 0;
+	 const validParameter = (cat: string, param: string, isNotSearch: boolean, input: string) => {
+		 const uniqueTraits = ['colors', 'gens'];
+		 for (const group of searches) {
+			 const g = group[cat as keyof DexOrGroup];
+			 if (g === undefined) continue;
+			 if (typeof g !== 'boolean' && g[param] === undefined) {
+				 if (uniqueTraits.includes(cat)) {
+					 for (const currentParam in g) {
+						 if (g[currentParam] !== isNotSearch && !isNotSearch) return `A Pok&eacute;mon cannot have multiple ${cat}.`;
+					 }
+				 }
+				 continue;
+			 }
+			 if (typeof g !== 'boolean' && g[param] === isNotSearch) {
+				 return `A search cannot both include and exclude '${input}'.`;
+			 } else {
+				 return `The search included '${(isNotSearch ? "!" : "") + input}' more than once.`;
+			 }
+		 }
+		 return false;
+	 };
+ 
+	 for (const andGroup of splitTarget) {
+		 const orGroup: DexOrGroup = {
+			 abilities: {}, tiers: {}, doublesTiers: {}, colors: {}, 'egg groups': {}, formes: {},
+			 gens: {}, moves: {}, types: {}, resists: {}, weak: {}, stats: {}, skip: false,
+		 };
+		 const parameters = andGroup.split("|");
+		 if (parameters.length > 3) return {error: "No more than 3 alternatives for each parameter may be used."};
+		 for (const parameter of parameters) {
+			 let isNotSearch = false;
+			 target = parameter.trim().toLowerCase();
+			 if (target.startsWith('!')) {
+				 isNotSearch = true;
+				 target = target.substr(1);
+			 }
+ 
+			 const targetAbility = mod.abilities.get(target);
+			 if (targetAbility.exists) {
+				 const invalid = validParameter("abilities", targetAbility.id, isNotSearch, targetAbility.name);
+				 if (invalid) return {error: invalid};
+				 orGroup.abilities[targetAbility.name] = !isNotSearch;
+				 continue;
+			 }
+ 
+			 if (toID(target) in allTiers) {
+				 target = allTiers[toID(target)];
+				 if (target.startsWith("CAP")) {
+					 if (capSearch === isNotSearch) return {error: "A search cannot both include and exclude CAP tiers."};
+					 capSearch = !isNotSearch;
+				 }
+				 const invalid = validParameter("tiers", target, isNotSearch, target);
+				 if (invalid) return {error: invalid};
+				 tierSearch = tierSearch || !isNotSearch;
+				 orGroup.tiers[target] = !isNotSearch;
+				 continue;
+			 }
+ 
+			 if (toID(target) in allDoublesTiers) {
+				 target = allDoublesTiers[toID(target)];
+				 const invalid = validParameter("doubles tiers", target, isNotSearch, target);
+				 if (invalid) return {error: invalid};
+				 tierSearch = tierSearch || !isNotSearch;
+				 orGroup.doublesTiers[target] = !isNotSearch;
+				 continue;
+			 }
+ 
+			 if (allColors.includes(target)) {
+				 target = target.charAt(0).toUpperCase() + target.slice(1);
+				 const invalid = validParameter("colors", target, isNotSearch, target);
+				 if (invalid) return {error: invalid};
+				 orGroup.colors[target] = !isNotSearch;
+				 continue;
+			 }
+ 
+			 const targetMove = mod.moves.get(target);
+			 if (targetMove.exists) {
+				 const invalid = validParameter("moves", targetMove.id, isNotSearch, target);
+				 if (invalid) return {error: invalid};
+				 orGroup.moves[targetMove.id] = !isNotSearch;
+				 continue;
+			 }
+ 
+			 let targetType;
+			 if (target.endsWith('type')) {
+				 targetType = toID(target.substring(0, target.indexOf('type')));
+			 } else {
+				 targetType = toID(target);
+			 }
+			 if (targetType in allTypes) {
+				 target = allTypes[targetType];
+				 const invalid = validParameter("types", target, isNotSearch, target);
+				 if (invalid) return {error: invalid};
+				 if ((orGroup.types[target] && isNotSearch) || (orGroup.types[target] === false && !isNotSearch)) {
+					 return {error: 'A search cannot both exclude and include a type.'};
+				 }
+				 orGroup.types[target] = !isNotSearch;
+				 continue;
+			 }
+ 
+			 if (['mono', 'monotype'].includes(toID(target))) {
+				 if (singleTypeSearch === isNotSearch) return {error: "A search cannot include and exclude 'monotype'."};
+				 if (parameters.length > 1) return {error: "The parameter 'monotype' cannot have alternative parameters."};
+				 singleTypeSearch = !isNotSearch;
+				 orGroup.skip = true;
+				 continue;
+			 }
+ 
+			 if (target === 'natdex') {
+				 if (parameters.length > 1) return {error: "The parameter 'natdex' cannot have alternative parameters."};
+				 nationalSearch = true;
+				 orGroup.skip = true;
+				 continue;
+			 }
+ 
+			 let groupIndex = target.indexOf('group');
+			 if (groupIndex === -1) groupIndex = target.length;
+			 if (groupIndex !== target.length || toID(target) in allEggGroups) {
+				 target = toID(target.substring(0, groupIndex));
+				 if (target in allEggGroups) {
+					 target = allEggGroups[toID(target)];
+					 const invalid = validParameter("egg groups", target, isNotSearch, target);
+					 if (invalid) return {error: invalid};
+					 orGroup['egg groups'][target] = !isNotSearch;
+					 continue;
+				 } else {
+					 return {error: `'${target}' is not a recognized egg group.`};
+				 }
+			 }
+			 if (toID(target) in allEggGroups) {
+				 target = allEggGroups[toID(target)];
+				 const invalid = validParameter("egg groups", target, isNotSearch, target);
+				 if (invalid) return {error: invalid};
+				 orGroup['egg groups'][target] = !isNotSearch;
+				 continue;
+			 }
+ 
+			 let targetInt = 0;
+			 if (target.substr(0, 1) === 'g' && Number.isInteger(parseFloat(target.substr(1)))) {
+				 targetInt = parseInt(target.substr(1).trim());
+			 } else if (target.substr(0, 3) === 'gen' && Number.isInteger(parseFloat(target.substr(3)))) {
+				 targetInt = parseInt(target.substr(3).trim());
+			 }
+			 if (0 < targetInt && targetInt < 9) {
+				 const invalid = validParameter("gens", String(targetInt), isNotSearch, target);
+				 if (invalid) return {error: invalid};
+				 orGroup.gens[targetInt] = !isNotSearch;
+				 continue;
+			 }
+ 
+			 if (target.endsWith(' asc') || target.endsWith(' desc')) {
+				 if (parameters.length > 1) {
+					 return {error: `The parameter '${target.split(' ')[1]}' cannot have alternative parameters.`};
+				 }
+				 const stat = allStatAliases[toID(target.split(' ')[0])] || toID(target.split(' ')[0]);
+				 if (!allStats.includes(stat)) return {error: `'${escapeHTML(target)}' did not contain a valid stat.`};
+				 sort = `${stat}${target.endsWith(' asc') ? '+' : '-'}`;
+				 orGroup.skip = true;
+				 break;
+			 }
+ 
+			 if (target === 'all') {
+				 if (!canAll) return {error: "A search with the parameter 'all' cannot be broadcast."};
+				 if (parameters.length > 1) return {error: "The parameter 'all' cannot have alternative parameters."};
+				 showAll = true;
+				 orGroup.skip = true;
+				 break;
+			 }
+ 
+			 if (target.substr(0, 6) === 'random' && cmd === 'randpoke') {
+				 // Validation for this is in the /randpoke command
+				 randomOutput = parseInt(target.substr(6));
+				 orGroup.skip = true;
+				 continue;
+			 }
+ 
+			 if (allFormes.includes(toID(target))) {
+				 target = toID(target);
+				 orGroup.formes[target] = !isNotSearch;
+				 continue;
+			 }
+ 
+			 if (target === 'megas' || target === 'mega') {
+				 if (megaSearch === isNotSearch) return {error: "A search cannot include and exclude 'mega'."};
+				 if (parameters.length > 1) return {error: "The parameter 'mega' cannot have alternative parameters."};
+				 megaSearch = !isNotSearch;
+				 orGroup.skip = true;
+				 break;
+			 }
+ 
+			 if (target === 'gmax' || target === 'gigantamax') {
+				 if (gmaxSearch === isNotSearch) return {error: "A search cannot include and exclude 'gigantamax'."};
+				 if (parameters.length > 1) return {error: "The parameter 'gigantamax' cannot have alternative parameters."};
+				 gmaxSearch = !isNotSearch;
+				 orGroup.skip = true;
+				 break;
+			 }
+ 
+			 if (['fully evolved', 'fullyevolved', 'fe'].includes(target)) {
+				 if (fullyEvolvedSearch === isNotSearch) return {error: "A search cannot include and exclude 'fully evolved'."};
+				 if (parameters.length > 1) return {error: "The parameter 'fully evolved' cannot have alternative parameters."};
+				 fullyEvolvedSearch = !isNotSearch;
+				 orGroup.skip = true;
+				 break;
+			 }
+ 
+			 if (target === 'recovery') {
+				 const recoveryMoves = [
+					 "healorder", "junglehealing", "lifedew", "milkdrink", "moonlight", "morningsun", "recover",
+					 "roost", "shoreup", "slackoff", "softboiled", "strengthsap", "synthesis", "wish",
+				 ];
+				 for (const move of recoveryMoves) {
+					 const invalid = validParameter("moves", move, isNotSearch, target);
+					 if (invalid) return {error: invalid};
+					 if (isNotSearch) {
+						 orGroup.skip = true;
+						 const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
+						 bufferObj.moves[move] = false;
+						 searches.push(bufferObj as DexOrGroup);
+					 } else {
+						 orGroup.moves[move] = true;
+					 }
+				 }
+				 continue;
+			 }
+ 
+			 if (target === 'zrecovery') {
+				 const recoveryMoves = [
+					 "aromatherapy", "bellydrum", "conversion2", "haze", "healbell", "mist",
+					 "psychup", "refresh", "spite", "stockpile", "teleport", "transform",
+				 ];
+				 for (const moveid of recoveryMoves) {
+					 const invalid = validParameter("moves", moveid, isNotSearch, target);
+					 if (invalid) return {error: invalid};
+					 if (isNotSearch) {
+						 orGroup.skip = true;
+						 const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
+						 bufferObj.moves[moveid] = false;
+						 searches.push(bufferObj as DexOrGroup);
+					 } else {
+						 orGroup.moves[moveid] = true;
+					 }
+				 }
+				 continue;
+			 }
+ 
+			 if (target === 'priority') {
+				 for (const moveid in mod.data.Moves) {
+					 const move = mod.moves.get(moveid);
+					 if (move.category === "Status" || move.id === "bide") continue;
+					 if (move.priority > 0) {
+						 const invalid = validParameter("moves", moveid, isNotSearch, target);
+						 if (invalid) return {error: invalid};
+						 if (isNotSearch) {
+							 orGroup.skip = true;
+							 const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
+							 bufferObj.moves[moveid] = false;
+							 searches.push(bufferObj as DexOrGroup);
+						 } else {
+							 orGroup.moves[moveid] = true;
+						 }
+					 }
+				 }
+				 continue;
+			 }
+ 
+			 if (target.substr(0, 8) === 'resists ') {
+				 const targetResist = target.substr(8, 1).toUpperCase() + target.substr(9);
+				 if (mod.types.isName(targetResist)) {
+					 const invalid = validParameter("resists", targetResist, isNotSearch, target);
+					 if (invalid) return {error: invalid};
+					 orGroup.resists[targetResist] = !isNotSearch;
+					 continue;
+				 } else {
+					 if (toID(targetResist) in mod.data.Moves) {
+						 const move = mod.moves.get(targetResist);
+						 if (move.category === 'Status') {
+							 return {error: `'${targetResist}' is a status move and can't be used with 'resists'.`};
+						 } else {
+							 const invalid = validParameter("resists", targetResist, isNotSearch, target);
+							 if (invalid) return {error: invalid};
+							 orGroup.resists[targetResist] = !isNotSearch;
+							 continue;
+						 }
+					 } else {
+						 return {error: `'${targetResist}' is not a recognized type or move.`};
+					 }
+				 }
+			 }
+ 
+			 if (target.substr(0, 5) === 'weak ') {
+				 const targetWeak = target.substr(5, 1).toUpperCase() + target.substr(6);
+				 if (mod.types.isName(targetWeak)) {
+					 const invalid = validParameter("weak", targetWeak, isNotSearch, target);
+					 if (invalid) return {error: invalid};
+					 orGroup.weak[targetWeak] = !isNotSearch;
+					 continue;
+				 } else {
+					 if (toID(targetWeak) in mod.data.Moves) {
+						 const move = mod.moves.get(targetWeak);
+						 if (move.category === 'Status') {
+							 return {error: `'${targetWeak}' is a status move and can't be used with 'weak'.`};
+						 } else {
+							 const invalid = validParameter("weak", targetWeak, isNotSearch, target);
+							 if (invalid) return {error: invalid};
+							 orGroup.weak[targetWeak] = !isNotSearch;
+							 continue;
+						 }
+					 } else {
+						 return {error: `'${targetWeak}' is not a recognized type or move.`};
+					 }
+				 }
+			 }
+ 
+			 if (target === 'pivot') {
+				 for (const move in mod.data.Moves) {
+					 const moveData = mod.moves.get(move);
+					 if (moveData.selfSwitch && moveData.id !== 'batonpass') {
+						 const invalid = validParameter("moves", move, isNotSearch, target);
+						 if (invalid) return {error: invalid};
+						 if (isNotSearch) {
+							 orGroup.skip = true;
+							 const bufferObj: {moves: {[k: string]: boolean}} = {moves: {}};
+							 bufferObj.moves[move] = false;
+							 searches.push(bufferObj as DexOrGroup);
+						 } else {
+							 orGroup.moves[move] = true;
+						 }
+					 }
+				 }
+				 continue;
+			 }
+ 
+			 const inequality = target.search(/>|<|=/);
+			 let inequalityString;
+			 if (inequality >= 0) {
+				 if (isNotSearch) return {error: "You cannot use the negation symbol '!' in stat ranges."};
+				 if (target.charAt(inequality + 1) === '=') {
+					 inequalityString = target.substr(inequality, 2);
+				 } else {
+					 inequalityString = target.charAt(inequality);
+				 }
+				 const targetParts = target.replace(/\s/g, '').split(inequalityString);
+				 let num;
+				 let stat;
+				 const directions: Direction[] = [];
+				 if (!isNaN(parseFloat(targetParts[0]))) {
+					 // e.g. 100 < spe
+					 num = parseFloat(targetParts[0]);
+					 stat = targetParts[1];
+					 if (inequalityString.startsWith('>')) directions.push('less');
+					 if (inequalityString.startsWith('<')) directions.push('greater');
+				 } else if (!isNaN(parseFloat(targetParts[1]))) {
+					 // e.g. spe > 100
+					 num = parseFloat(targetParts[1]);
+					 stat = targetParts[0];
+					 if (inequalityString.startsWith('<')) directions.push('less');
+					 if (inequalityString.startsWith('>')) directions.push('greater');
+				 } else {
+					 return {error: `No value given to compare with '${escapeHTML(target)}'.`};
+				 }
+				 if (inequalityString.endsWith('=')) directions.push('equal');
+				 if (stat in allStatAliases) stat = allStatAliases[stat];
+				 if (!allStats.includes(stat)) return {error: `'${escapeHTML(target)}' did not contain a valid stat.`};
+				 if (!orGroup.stats[stat]) orGroup.stats[stat] = Object.create(null);
+				 for (const direction of directions) {
+					 if (orGroup.stats[stat][direction]) return {error: `Invalid stat range for ${stat}.`};
+					 orGroup.stats[stat][direction] = num;
+				 }
+				 continue;
+			 }
+			 return {error: `'${escapeHTML(target)}' could not be found in any of the search categories.`};
+		 }
+		 if (!orGroup.skip) {
+			 searches.push(orGroup);
+		 }
+	 }
+	 if (
+		 showAll && searches.length === 0 && singleTypeSearch === null &&
+		 megaSearch === null && gmaxSearch === null && fullyEvolvedSearch === null && sort === null
+	 ) {
+		 return {
+			 error: "No search parameters other than 'all' were found. Try '/help dexsearch' for more information on this command.",
+		 };
+	 }
+ 
+	 const dex: {[k: string]: Species} = {};
+	 for (const species of mod.species.all()) {
+		 const megaSearchResult = megaSearch === null || megaSearch === !!species.isMega;
+		 const gmaxSearchResult = gmaxSearch === null || gmaxSearch === species.name.endsWith('-Gmax');
+		 const fullyEvolvedSearchResult = fullyEvolvedSearch === null || fullyEvolvedSearch !== species.nfe;
+		 if (
+			 species.gen <= mod.gen &&
+			 (
+				 (
+					 nationalSearch &&
+					 species.isNonstandard &&
+					 !["Custom", "Glitch", "Pokestar", "Future"].includes(species.isNonstandard)
+				 ) ||
+				 (species.tier !== 'Unreleased' && species.tier !== 'Illegal')
+			 ) &&
+			 (!species.tier.startsWith("CAP") || capSearch) &&
+			 megaSearchResult &&
+			 gmaxSearchResult &&
+			 fullyEvolvedSearchResult
+		 ) {
+			 dex[species.id] = species;
+		 }
+	 }
+ 
+	 // Prioritize searches with the least alternatives.
+	 const accumulateKeyCount = (count: number, searchData: AnyObject) =>
+		 count + (typeof searchData === 'object' ? Object.keys(searchData).length : 0);
+	 Utils.sortBy(searches, search => (
+		 Object.values(search).reduce(accumulateKeyCount, 0)
+	 ));
+ 
+	 for (const alts of searches) {
+		 if (alts.skip) continue;
+		 for (const mon in dex) {
+			 let matched = false;
+			 if (alts.gens && Object.keys(alts.gens).length) {
+				 if (alts.gens[dex[mon].gen]) continue;
+				 if (Object.values(alts.gens).includes(false) && alts.gens[dex[mon].gen] !== false) continue;
+			 }
+ 
+			 if (alts.colors && Object.keys(alts.colors).length) {
+				 if (alts.colors[dex[mon].color]) continue;
+				 if (Object.values(alts.colors).includes(false) && alts.colors[dex[mon].color] !== false) continue;
+			 }
+ 
+			 for (const eggGroup in alts['egg groups']) {
+				 if (dex[mon].eggGroups.includes(eggGroup) === alts['egg groups'][eggGroup]) {
+					 matched = true;
+					 break;
+				 }
+			 }
+ 
+			 if (alts.tiers && Object.keys(alts.tiers).length) {
+				 let tier = dex[mon].tier;
+				 if (nationalSearch) tier = dex[mon].natDexTier;
+				 if (tier.startsWith('(') && tier !== '(PU)') tier = tier.slice(1, -1) as TierTypes.Singles;
+				 // if (tier === 'New') tier = 'OU';
+				 if (alts.tiers[tier]) continue;
+				 if (Object.values(alts.tiers).includes(false) && alts.tiers[tier] !== false) continue;
+				 // LC handling, checks for LC Pokemon in higher tiers that need to be handled separately,
+				 // as well as event-only Pokemon that are not eligible for LC despite being the first stage
+				 let format = Dex.formats.get('gen' + mod.gen + 'lc');
+				 if (!format.exists) format = Dex.formats.get('gen8lc');
+				 if (
+					 alts.tiers.LC &&
+					 !dex[mon].prevo &&
+					 dex[mon].nfe &&
+					 !Dex.formats.getRuleTable(format).isBannedSpecies(dex[mon])
+				 ) {
+					 const lsetData = mod.species.getLearnsetData(dex[mon].id);
+					 if (lsetData.exists && lsetData.eventData && lsetData.eventOnly) {
+						 let validEvents = 0;
+						 for (const event of lsetData.eventData) {
+							 if (event.level && event.level <= 5) validEvents++;
+						 }
+						 if (validEvents > 0) continue;
+					 } else {
+						 continue;
+					 }
+				 }
+			 }
+ 
+			 if (alts.doublesTiers && Object.keys(alts.doublesTiers).length) {
+				 let tier = dex[mon].doublesTier;
+				 if (tier && tier.startsWith('(') && tier !== '(DUU)') tier = tier.slice(1, -1) as TierTypes.Doubles;
+				 if (alts.doublesTiers[tier]) continue;
+				 if (Object.values(alts.doublesTiers).includes(false) && alts.doublesTiers[tier] !== false) continue;
+			 }
+ 
+			 for (const type in alts.types) {
+				 if (dex[mon].types.includes(type) === alts.types[type]) {
+					 matched = true;
+					 break;
+				 }
+			 }
+			 if (matched) continue;
+ 
+			 for (const targetResist in alts.resists) {
+				 let effectiveness = 0;
+				 const move = mod.moves.get(targetResist);
+				 const attackingType = move.type || targetResist;
+				 const notImmune = (move.id === 'thousandarrows' || mod.getImmunity(attackingType, dex[mon])) &&
+					 !(move.id === 'sheercold' && mod.gen >= 7 && dex[mon].types.includes('Ice'));
+				 if (notImmune && !move.ohko && move.damage === undefined) {
+					 for (const defenderType of dex[mon].types) {
+						 const baseMod = mod.getEffectiveness(attackingType, defenderType);
+						 const moveMod = move.onEffectiveness?.call(
+							 {dex: mod} as Battle, baseMod, null, defenderType, move as ActiveMove,
+						 );
+						 effectiveness += typeof moveMod === 'number' ? moveMod : baseMod;
+					 }
+				 }
+				 if (!alts.resists[targetResist]) {
+					 if (notImmune && effectiveness >= 0) matched = true;
+				 } else {
+					 if (!notImmune || effectiveness < 0) matched = true;
+				 }
+			 }
+			 if (matched) continue;
+ 
+			 for (const targetWeak in alts.weak) {
+				 let effectiveness = 0;
+				 const move = mod.moves.get(targetWeak);
+				 const attackingType = move.type || targetWeak;
+				 const notImmune = (move.id === 'thousandarrows' || mod.getImmunity(attackingType, dex[mon])) &&
+					 !(move.id === 'sheercold' && mod.gen >= 7 && dex[mon].types.includes('Ice'));
+				 if (notImmune && !move.ohko && move.damage === undefined) {
+					 for (const defenderType of dex[mon].types) {
+						 const baseMod = mod.getEffectiveness(attackingType, defenderType);
+						 const moveMod = move.onEffectiveness?.call(
+							 {dex: mod} as Battle, baseMod, null, defenderType, move as ActiveMove,
+						 );
+						 effectiveness += typeof moveMod === 'number' ? moveMod : baseMod;
+					 }
+				 }
+				 if (alts.weak[targetWeak]) {
+					 if (notImmune && effectiveness >= 1) matched = true;
+				 } else {
+					 if (!notImmune || effectiveness < 1) matched = true;
+				 }
+			 }
+			 if (matched) continue;
+ 
+			 for (const ability in alts.abilities) {
+				 if (Object.values(dex[mon].abilities).includes(ability) === alts.abilities[ability]) {
+					 matched = true;
+					 break;
+				 }
+			 }
+			 if (matched) continue;
+ 
+			 for (const forme in alts.formes) {
+				 if (toID(dex[mon].forme).includes(forme) === alts.formes[forme]) {
+					 matched = true;
+					 break;
+				 }
+			 }
+			 if (matched) continue;
+ 
+			 for (const stat in alts.stats) {
+				 let monStat = 0;
+				 if (stat === 'bst') {
+					 monStat = dex[mon].bst;
+				 } else if (stat === 'weight') {
+					 monStat = dex[mon].weighthg / 10;
+				 } else if (stat === 'height') {
+					 monStat = dex[mon].heightm;
+				 } else if (stat === 'gen') {
+					 monStat = dex[mon].gen;
+				 } else {
+					 monStat = dex[mon].baseStats[stat as StatID];
+				 }
+				 if (typeof alts.stats[stat].less === 'number') {
+					 if (monStat < alts.stats[stat].less) {
+						 matched = true;
+						 break;
+					 }
+				 }
+				 if (typeof alts.stats[stat].greater === 'number') {
+					 if (monStat > alts.stats[stat].greater) {
+						 matched = true;
+						 break;
+					 }
+				 }
+				 if (typeof alts.stats[stat].equal === 'number') {
+					 if (monStat === alts.stats[stat].equal) {
+						 matched = true;
+						 break;
+					 }
+				 }
+			 }
+			 if (matched) continue;
+ 
+			 const format = Object.entries(Dex.data.Rulesets).find(([a, f]) => f.mod === usedMod);
+			 const formatStr = format ? format[1].name : 'gen8ou';
+			 const validator = TeamValidator.get(
+				 `${formatStr}${nationalSearch && !Dex.formats.getRuleTable(Dex.formats.get(formatStr)).has('standardnatdex') ? '@@@standardnatdex' : ''}`
+			 );
+			 const pokemonSource = validator.allSources();
+			 for (const move of Object.keys(alts.moves).map(x => mod.moves.get(x))) {
+				 if (move.gen <= mod.gen && !validator.checkCanLearn(move, dex[mon], pokemonSource) === alts.moves[move.id]) {
+					 matched = true;
+					 break;
+				 }
+				 if (!pokemonSource.size()) break;
+			 }
+			 if (matched) continue;
+ 
+			 delete dex[mon];
+		 }
+	 }
+	 let results: string[] = [];
+	 for (const mon of Object.keys(dex).sort()) {
+		 if (singleTypeSearch !== null && (dex[mon].types.length === 1) !== singleTypeSearch) continue;
+		 const isRegionalForm = (dex[mon].forme === "Galar" || dex[mon].forme === "Alola") && dex[mon].name !== "Pikachu-Alola";
+		 const allowGmax = (gmaxSearch || tierSearch);
+		 if (!isRegionalForm && dex[mon].baseSpecies && results.includes(dex[mon].baseSpecies)) continue;
+		 if (dex[mon].isNonstandard === 'Gigantamax' && !allowGmax) continue;
+		 results.push(dex[mon].name);
+	 }
+ 
+	 if (usedMod === 'gen7letsgo') {
+		 results = results.filter(name => {
+			 const species = mod.species.get(name);
+			 return (species.num <= 151 || ['Meltan', 'Melmetal'].includes(species.name)) &&
+			 (!species.forme || (['Alola', 'Mega', 'Mega-X', 'Mega-Y', 'Starter'].includes(species.forme) &&
+				 species.name !== 'Pikachu-Alola'));
+		 });
+	 }
+ 
+	 if (usedMod === 'gen8bdsp') {
+		 results = results.filter(name => {
+			 const species = mod.species.get(name);
+			 if (species.id === 'pichuspikyeared') return false;
+			 if (capSearch) return species.gen <= 4;
+			 return species.gen <= 4 && species.num >= 1;
+		 });
+	 }
+ 
+	 if (randomOutput && randomOutput < results.length) {
+		 results = Utils.shuffle(results).slice(0, randomOutput);
+	 }
+ 
+	 let resultsStr = (message === "" ? message : `<span style="color:#999999;">${escapeHTML(message)}:</span><br />`);
+	 if (results.length > 1) {
+		 results.sort();
+		 if (sort) {
+			 const stat = sort.slice(0, -1);
+			 const direction = sort.slice(-1);
+			 Utils.sortBy(results, name => {
+				 const mon = mod.species.get(name);
+				 let monStat = 0;
+				 if (stat === 'bst') {
+					 monStat = mon.bst;
+				 } else if (stat === 'weight') {
+					 monStat = mon.weighthg;
+				 } else if (stat === 'height') {
+					 monStat = mon.heightm;
+				 } else if (stat === 'gen') {
+					 monStat = mon.gen;
+				 } else {
+					 monStat = mon.baseStats[stat as StatID];
+				 }
+				 return monStat * (direction === '+' ? 1 : -1);
+			 });
+		 }
+		 let notShown = 0;
+		 if (!showAll && results.length > MAX_RANDOM_RESULTS) {
+			 notShown = results.length - RESULTS_MAX_LENGTH;
+			 results = results.slice(0, RESULTS_MAX_LENGTH);
+		 }
+		 resultsStr += results.map(
+			 result => `<a href="//${Config.routes.dex}/pokemon/${toID(result)}" target="_blank" class="subtle" style="white-space:nowrap"><psicon pokemon="${result}" style="vertical-align:-7px;margin:-2px" />${result}</a>`
+		 ).join(", ");
+		 if (notShown) {
+			 resultsStr += `, and ${notShown} more. <span style="color:#999999;">Redo the search with ', all' at the end to show all results.</span>`;
+		 }
+	 } else if (results.length === 1) {
+		 return {dt: `${results[0]}${usedMod ? `,${usedMod}` : ''}`};
+	 } else {
+		 resultsStr += "No Pok&eacute;mon found.";
+	 }
+	 if (isTest) return {results, reply: resultsStr};
+	 return {reply: resultsStr};
+ }
+ 
+ function runMovesearch(target: string, cmd: string, canAll: boolean, message: string, isTest: boolean) {
+	 const searches: MoveOrGroup[] = [];
+	 const {splitTarget, usedMod, count} = getMod(target);
+	 if (count > 1) {
+		 return {error: `You can't run searches for multiple mods.`};
+	 }
+ 
+	 const mod = Dex.mod(usedMod || 'base');
+	 const allCategories = ['physical', 'special', 'status'];
+	 const allContestTypes = ['beautiful', 'clever', 'cool', 'cute', 'tough'];
+	 const allProperties = ['basePower', 'accuracy', 'priority', 'pp'];
+	 const allFlags = [
+		 'bypasssub', 'bite', 'bullet', 'charge', 'contact', 'dance', 'defrost', 'gravity', 'highcrit', 'mirror',
+		 'multihit', 'ohko', 'powder', 'protect', 'pulse', 'punch', 'recharge', 'reflectable', 'secondary',
+		 'snatch', 'sound', 'zmove', 'maxmove', 'gmaxmove', 'protection',
+	 ];
+	 const allStatus = ['psn', 'tox', 'brn', 'par', 'frz', 'slp'];
+	 const allVolatileStatus = ['flinch', 'confusion', 'partiallytrapped'];
+	 const allBoosts = ['hp', 'atk', 'def', 'spa', 'spd', 'spe', 'accuracy', 'evasion'];
+	 const allTargets: {[k: string]: string} = {
+		 oneally: 'adjacentAlly',
+		 userorally: 'adjacentAllyOrSelf',
+		 oneadjacentopponent: 'adjacentFoe',
+		 all: 'all',
+		 alladjacent: 'allAdjacent',
+		 alladjacentopponents: 'allAdjacentFoes',
+		 userandallies: 'allies',
+		 usersside: 'allySide',
+		 usersteam: 'allyTeam',
+		 any: 'any',
+		 opponentsside: 'foeSide',
+		 oneadjacent: 'normal',
+		 randomadjacent: 'randomNormal',
+		 scripted: 'scripted',
+		 user: 'self',
+	 };
+	 const allTypes: {[k: string]: string} = Object.create(null);
+	 for (const type of mod.types.all()) {
+		 allTypes[type.id] = type.name;
+	 }
+	 let showAll = false;
+	 let sort: string | null = null;
+	 const targetMons: {name: string, shouldBeExcluded: boolean}[] = [];
+	 let nationalSearch = null;
+	 let randomOutput = 0;
+	 for (const arg of splitTarget) {
+		 const orGroup: MoveOrGroup = {
+			 types: {}, categories: {}, contestTypes: {}, flags: {}, gens: {}, other: {}, mon: {}, property: {},
+			 boost: {}, lower: {}, zboost: {}, status: {}, volatileStatus: {}, targets: {}, skip: false, multihit: false,
+		 };
+		 const parameters = arg.split("|");
+		 if (parameters.length > 3) return {error: "No more than 3 alternatives for each parameter may be used."};
+		 for (const parameter of parameters) {
+			 let isNotSearch = false;
+			 target = parameter.toLowerCase().trim();
+			 if (target.startsWith('!')) {
+				 isNotSearch = true;
+				 target = target.substr(1);
+			 }
+			 let targetType;
+			 if (target.endsWith('type')) {
+				 targetType = toID(target.substring(0, target.indexOf('type')));
+			 } else {
+				 targetType = toID(target);
+			 }
+			 if (allTypes[targetType]) {
+				 target = allTypes[targetType];
+				 if ((orGroup.types[target] && isNotSearch) || (orGroup.types[target] === false && !isNotSearch)) {
+					 return {error: 'A search cannot both exclude and include a type.'};
+				 }
+				 orGroup.types[target] = !isNotSearch;
+				 continue;
+			 }
+ 
+			 if (allCategories.includes(target)) {
+				 target = target.charAt(0).toUpperCase() + target.substr(1);
+				 if (
+					 (orGroup.categories[target] && isNotSearch) ||
+					 (orGroup.categories[target] === false && !isNotSearch)
+				 ) {
+					 return {error: 'A search cannot both exclude and include a category.'};
+				 }
+				 orGroup.categories[target] = !isNotSearch;
+				 continue;
+			 }
+ 
+			 if (allContestTypes.includes(target)) {
+				 target = target.charAt(0).toUpperCase() + target.substr(1);
+				 if (
+					 (orGroup.contestTypes[target] && isNotSearch) ||
+					 (orGroup.contestTypes[target] === false && !isNotSearch)
+				 ) {
+					 return {error: 'A search cannot both exclude and include a contest condition.'};
+				 }
+				 orGroup.contestTypes[target] = !isNotSearch;
+				 continue;
+			 }
+ 
+			 if (target.startsWith('targets ')) {
+				 target = toID(target.substr('targets '.length));
+				 if (target === 'allpokemon' || target === 'anypokemon' || target.includes('adjacent')) {
+					 target = target.replace('pokemon', '');
+				 }
+				 if (Object.keys(allTargets).includes(target)) {
+					 const moveTarget = allTargets[target];
+					 if (
+						 (orGroup.targets[moveTarget] && isNotSearch) ||
+						 (orGroup.targets[moveTarget] === false && !isNotSearch)
+					 ) {
+						 return {error: 'A search cannot both exclude and include a move target.'};
+					 }
+					 orGroup.targets[moveTarget] = !isNotSearch;
+					 continue;
+				 } else {
+					 return {error: `'${target}' isn't a valid move target.`};
+				 }
+			 }
+ 
+			 if (target === 'bypassessubstitute') target = 'bypasssub';
+			 if (target === 'z') target = 'zmove';
+			 if (target === 'max') target = 'maxmove';
+			 if (target === 'gmax') target = 'gmaxmove';
+			 if (target === 'multi' || toID(target) === 'multihit') target = 'multihit';
+			 if (target === 'crit' || toID(target) === 'highcrit') target = 'highcrit';
+			 if (['thaw', 'thaws', 'melt', 'melts', 'defrosts'].includes(target)) target = 'defrost';
+			 if (target === 'bounceable' || toID(target) === 'magiccoat' || toID(target) === 'magicbounce') target = 'reflectable';
+			 if (allFlags.includes(target)) {
+				 if ((orGroup.flags[target] && isNotSearch) || (orGroup.flags[target] === false && !isNotSearch)) {
+					 return {error: `A search cannot both exclude and include '${target}'.`};
+				 }
+				 orGroup.flags[target] = !isNotSearch;
+				 continue;
+			 }
+ 
+			 let targetInt = 0;
+			 if (target.substr(0, 1) === 'g' && Number.isInteger(parseFloat(target.substr(1)))) {
+				 targetInt = parseInt(target.substr(1).trim());
+			 } else if (target.substr(0, 3) === 'gen' && Number.isInteger(parseFloat(target.substr(3)))) {
+				 targetInt = parseInt(target.substr(3).trim());
+			 }
+ 
+			 if (0 < targetInt && targetInt < 9) {
+				 if ((orGroup.gens[targetInt] && isNotSearch) || (orGroup.flags[targetInt] === false && !isNotSearch)) {
+					 return {error: `A search cannot both exclude and include '${target}'.`};
+				 }
+				 orGroup.gens[targetInt] = !isNotSearch;
+				 continue;
+			 }
+ 
+			 if (target === 'all') {
+				 if (!canAll) return {error: "A search with the parameter 'all' cannot be broadcast."};
+				 if (parameters.length > 1) return {error: "The parameter 'all' cannot have alternative parameters."};
+				 showAll = true;
+				 orGroup.skip = true;
+				 continue;
+			 }
+ 
+			 if (target === 'natdex') {
+				 if (parameters.length > 1) return {error: "The parameter 'natdex' cannot have alternative parameters."};
+				 nationalSearch = !isNotSearch;
+				 orGroup.skip = true;
+				 continue;
+			 }
+ 
+			 if (target.endsWith(' asc') || target.endsWith(' desc')) {
+				 if (parameters.length > 1) {
+					 return {error: `The parameter '${target.split(' ')[1]}' cannot have alternative parameters.`};
+				 }
+				 let prop = target.split(' ')[0];
+				 switch (toID(prop)) {
+				 case 'basepower': prop = 'basePower'; break;
+				 case 'bp': prop = 'basePower'; break;
+				 case 'power': prop = 'basePower'; break;
+				 case 'acc': prop = 'accuracy'; break;
+				 }
+				 if (!allProperties.includes(prop)) return {error: `'${escapeHTML(target)}' did not contain a valid property.`};
+				 sort = `${prop}${target.endsWith(' asc') ? '+' : '-'}`;
+				 orGroup.skip = true;
+				 break;
+			 }
+ 
+			 if (target === 'recovery') {
+				 if (orGroup.other.recovery === undefined) {
+					 orGroup.other.recovery = !isNotSearch;
+				 } else if ((orGroup.other.recovery && isNotSearch) || (!orGroup.other.recovery && !isNotSearch)) {
+					 return {error: 'A search cannot both exclude and include recovery moves.'};
+				 }
+				 continue;
+			 }
+ 
+			 if (target === 'recoil') {
+				 if (orGroup.other.recoil === undefined) {
+					 orGroup.other.recoil = !isNotSearch;
+				 } else if ((orGroup.other.recoil && isNotSearch) || (!orGroup.other.recoil && !isNotSearch)) {
+					 return {error: 'A search cannot both exclude and include recoil moves.'};
+				 }
+				 continue;
+			 }
+ 
+			 if (target.substr(0, 6) === 'random' && cmd === 'randmove') {
+				 // Validation for this is in the /randmove command
+				 randomOutput = parseInt(target.substr(6));
+				 orGroup.skip = true;
+				 continue;
+			 }
+ 
+			 if (target === 'zrecovery') {
+				 if (orGroup.other.zrecovery === undefined) {
+					 orGroup.other.zrecovery = !isNotSearch;
+				 } else if ((orGroup.other.zrecovery && isNotSearch) || (!orGroup.other.zrecovery && !isNotSearch)) {
+					 return {error: 'A search cannot both exclude and include z-recovery moves.'};
+				 }
+				 continue;
+			 }
+ 
+			 if (target === 'pivot') {
+				 if (orGroup.other.pivot === undefined) {
+					 orGroup.other.pivot = !isNotSearch;
+				 } else if ((orGroup.other.pivot && isNotSearch) || (!orGroup.other.pivot && !isNotSearch)) {
+					 return {error: 'A search cannot both exclude and include pivot moves.'};
+				 }
+				 continue;
+			 }
+ 
+			 if (target === 'multihit') {
+				 if (!orGroup.multihit) {
+					 orGroup.multihit = true;
+				 } else if ((orGroup.multihit && isNotSearch) || (!orGroup.multihit && !isNotSearch)) {
+					 return {error: 'A search cannot both exclude and include multi-hit moves.'};
+				 }
+				 continue;
+			 }
+ 
+			 const species = mod.species.get(target);
+			 if (species.exists) {
+				 if (parameters.length > 1) return {error: "A Pok\u00e9mon learnset cannot have alternative parameters."};
+				 if (targetMons.some(mon => mon.name === species.name && isNotSearch !== mon.shouldBeExcluded)) {
+					 return {error: "A search cannot both exclude and include the same Pok\u00e9mon."};
+				 }
+				 if (targetMons.some(mon => mon.name === species.name)) {
+					 return {error: "A search should not include a Pok\u00e9mon twice."};
+				 }
+				 targetMons.push({name: species.name, shouldBeExcluded: isNotSearch});
+				 orGroup.skip = true;
+				 continue;
+			 }
+ 
+			 const inequality = target.search(/>|<|=/);
+			 if (inequality >= 0) {
+				 let inequalityString;
+				 if (isNotSearch) return {error: "You cannot use the negation symbol '!' in stat ranges."};
+				 if (target.charAt(inequality + 1) === '=') {
+					 inequalityString = target.substr(inequality, 2);
+				 } else {
+					 inequalityString = target.charAt(inequality);
+				 }
+				 const targetParts = target.replace(/\s/g, '').split(inequalityString);
+				 let num;
+				 let prop;
+				 const directions: Direction[] = [];
+				 if (!isNaN(parseFloat(targetParts[0]))) {
+					 // e.g. 100 < bp
+					 num = parseFloat(targetParts[0]);
+					 prop = targetParts[1];
+					 if (inequalityString.startsWith('>')) directions.push('less');
+					 if (inequalityString.startsWith('<')) directions.push('greater');
+				 } else if (!isNaN(parseFloat(targetParts[1]))) {
+					 // e.g. bp > 100
+					 num = parseFloat(targetParts[1]);
+					 prop = targetParts[0];
+					 if (inequalityString.startsWith('<')) directions.push('less');
+					 if (inequalityString.startsWith('>')) directions.push('greater');
+				 } else {
+					 return {error: `No value given to compare with '${escapeHTML(target)}'.`};
+				 }
+				 if (inequalityString.endsWith('=')) directions.push('equal');
+				 switch (toID(prop)) {
+				 case 'basepower': prop = 'basePower'; break;
+				 case 'bp': prop = 'basePower'; break;
+				 case 'power': prop = 'basePower'; break;
+				 case 'acc': prop = 'accuracy'; break;
+				 }
+				 if (!allProperties.includes(prop)) return {error: `'${escapeHTML(target)}' did not contain a valid property.`};
+				 if (!orGroup.property[prop]) orGroup.property[prop] = Object.create(null);
+				 for (const direction of directions) {
+					 if (orGroup.property[prop][direction]) return {error: `Invalid property range for ${prop}.`};
+					 orGroup.property[prop][direction] = num;
+				 }
+				 continue;
+			 }
+ 
+			 if (target.substr(0, 8) === 'priority') {
+				 let sign: Direction;
+				 target = target.substr(8).trim();
+				 if (target === "+" || target === "") {
+					 sign = 'greater';
+				 } else if (target === "-") {
+					 sign = 'less';
+				 } else {
+					 return {error: `Priority type '${target}' not recognized.`};
+				 }
+				 if (orGroup.property['priority']) {
+					 return {error: "Priority cannot be set with both shorthand and inequality range."};
+				 } else {
+					 orGroup.property['priority'] = Object.create(null);
+					 orGroup.property['priority'][sign] = 0;
+				 }
+				 continue;
+			 }
+			 if (target.substr(0, 7) === 'boosts ' || target.substr(0, 7) === 'lowers ') {
+				 let isBoost = true;
+				 if (target.substr(0, 7) === 'lowers ') {
+					 isBoost = false;
+				 }
+				 switch (target.substr(7)) {
+				 case 'attack': target = 'atk'; break;
+				 case 'defense': target = 'def'; break;
+				 case 'specialattack': target = 'spa'; break;
+				 case 'spatk': target = 'spa'; break;
+				 case 'specialdefense': target = 'spd'; break;
+				 case 'spdef': target = 'spd'; break;
+				 case 'speed': target = 'spe'; break;
+				 case 'acc': target = 'accuracy'; break;
+				 case 'evasiveness': target = 'evasion'; break;
+				 default: target = target.substr(7);
+				 }
+				 if (!allBoosts.includes(target)) return {error: `'${escapeHTML(target)}' is not a recognized stat.`};
+				 if (isBoost) {
+					 if ((orGroup.boost[target] && isNotSearch) || (orGroup.boost[target] === false && !isNotSearch)) {
+						 return {error: 'A search cannot both exclude and include a stat boost.'};
+					 }
+					 orGroup.boost[target] = !isNotSearch;
+				 } else {
+					 if ((orGroup.lower[target] && isNotSearch) || (orGroup.lower[target] === false && !isNotSearch)) {
+						 return {error: 'A search cannot both exclude and include a stat boost.'};
+					 }
+					 orGroup.lower[target] = !isNotSearch;
+				 }
+				 continue;
+			 }
+ 
+			 if (target.substr(0, 8) === 'zboosts ') {
+				 switch (target.substr(8)) {
+				 case 'attack': target = 'atk'; break;
+				 case 'defense': target = 'def'; break;
+				 case 'specialattack': target = 'spa'; break;
+				 case 'spatk': target = 'spa'; break;
+				 case 'specialdefense': target = 'spd'; break;
+				 case 'spdef': target = 'spd'; break;
+				 case 'speed': target = 'spe'; break;
+				 case 'acc': target = 'accuracy'; break;
+				 case 'evasiveness': target = 'evasion'; break;
+				 default: target = target.substr(8);
+				 }
+				 if (!allBoosts.includes(target)) return {error: `'${escapeHTML(target)}' is not a recognized stat.`};
+				 if ((orGroup.zboost[target] && isNotSearch) || (orGroup.zboost[target] === false && !isNotSearch)) {
+					 return {error: 'A search cannot both exclude and include a stat boost.'};
+				 }
+				 orGroup.zboost[target] = !isNotSearch;
+				 continue;
+			 }
+ 
+			 const oldTarget = target;
+			 if (target.endsWith('s')) target = target.slice(0, -1);
+			 switch (target) {
+			 case 'toxic': target = 'tox'; break;
+			 case 'poison': target = 'psn'; break;
+			 case 'burn': target = 'brn'; break;
+			 case 'paralyze': target = 'par'; break;
+			 case 'freeze': target = 'frz'; break;
+			 case 'sleep': target = 'slp'; break;
+			 case 'confuse': target = 'confusion'; break;
+			 case 'trap': target = 'partiallytrapped'; break;
+			 case 'flinche': target = 'flinch'; break;
+			 }
+ 
+			 if (allStatus.includes(target)) {
+				 if ((orGroup.status[target] && isNotSearch) || (orGroup.status[target] === false && !isNotSearch)) {
+					 return {error: 'A search cannot both exclude and include a status.'};
+				 }
+				 orGroup.status[target] = !isNotSearch;
+				 continue;
+			 }
+ 
+			 if (allVolatileStatus.includes(target)) {
+				 if (
+					 (orGroup.volatileStatus[target] && isNotSearch) ||
+					 (orGroup.volatileStatus[target] === false && !isNotSearch)
+				 ) {
+					 return {error: 'A search cannot both exclude and include a volatile status.'};
+				 }
+				 orGroup.volatileStatus[target] = !isNotSearch;
+				 continue;
+			 }
+ 
+			 return {error: `'${escapeHTML(oldTarget)}' could not be found in any of the search categories.`};
+		 }
+		 if (!orGroup.skip) {
+			 searches.push(orGroup);
+		 }
+	 }
+	 if (showAll && !searches.length && !targetMons.length && !sort) {
+		 return {
+			 error: "No search parameters other than 'all' were found. Try '/help movesearch' for more information on this command.",
+		 };
+	 }
+ 
+	 const getFullLearnsetOfPokemon = (species: Species) => {
+		 let usedSpecies: Species = Utils.deepClone(species);
+		 let usedSpeciesLearnset: LearnsetData = Utils.deepClone(mod.species.getLearnset(usedSpecies.id));
+		 if (!usedSpeciesLearnset) {
+			 usedSpecies = Utils.deepClone(mod.species.get(usedSpecies.baseSpecies));
+			 usedSpeciesLearnset = Utils.deepClone(mod.species.getLearnset(usedSpecies.id) || {});
+		 }
+		 const lsetData = new Set<string>();
+		 for (const move in usedSpeciesLearnset) {
+			 const learnset = mod.species.getLearnset(usedSpecies.id);
+			 if (!learnset) break;
+			 const sources = learnset[move];
+			 for (const learned of sources) {
+				 const sourceGen = parseInt(learned.charAt(0));
+				 if (sourceGen <= mod.gen) lsetData.add(move);
+			 }
+		 }
+ 
+		 while (usedSpecies.prevo) {
+			 usedSpecies = Utils.deepClone(mod.species.get(usedSpecies.prevo));
+			 usedSpeciesLearnset = Utils.deepClone(mod.species.getLearnset(usedSpecies.id));
+			 for (const move in usedSpeciesLearnset) {
+				 const learnset = mod.species.getLearnset(usedSpecies.id);
+				 if (!learnset) break;
+				 const sources = learnset[move];
+				 for (const learned of sources) {
+					 const sourceGen = parseInt(learned.charAt(0));
+					 if (sourceGen <= mod.gen) lsetData.add(move);
+				 }
+			 }
+		 }
+ 
+		 return lsetData;
+	 };
+ 
+	 // Since we assume we have no target mons at first
+	 // then the valid moveset we can search is the set of all moves.
+	 const validMoves = new Set(Object.keys(mod.data.Moves));
+	 for (const mon of targetMons) {
+		 const species = mod.species.get(mon.name);
+		 const lsetData = getFullLearnsetOfPokemon(species);
+		 // This pokemon's learnset needs to be excluded, so we perform a difference operation
+		 // on the valid moveset and this pokemon's moveset.
+		 if (mon.shouldBeExcluded) {
+			 for (const move of lsetData) {
+				 validMoves.delete(move);
+			 }
+		 } else {
+			 // This pokemon's learnset needs to be included, so we perform an intersection operation
+			 // on the valid moveset and this pokemon's moveset.
+			 for (const move of validMoves) {
+				 if (!lsetData.has(move)) {
+					 validMoves.delete(move);
+				 }
+			 }
+		 }
+	 }
+ 
+	 // At this point, we've trimmed down the valid moveset to be
+	 // the moves that are appropriate considering the requested pokemon.
+	 const dex: {[moveid: string]: Move} = {};
+	 for (const moveid of validMoves) {
+		 const move = mod.moves.get(moveid);
+		 if (move.gen <= mod.gen) {
+			 if (
+				 (!nationalSearch && move.isNonstandard && move.isNonstandard !== "Gigantamax") ||
+				 (nationalSearch && move.isNonstandard && !["Gigantamax", "Past"].includes(move.isNonstandard))
+			 ) {
+				 continue;
+			 } else {
+				 dex[moveid] = move;
+			 }
+		 }
+	 }
+ 
+	 for (const alts of searches) {
+		 if (alts.skip) continue;
+		 for (const moveid in dex) {
+			 const move = dex[moveid];
+			 const recoveryUndefined = alts.other.recovery === undefined;
+			 const zrecoveryUndefined = alts.other.zrecovery === undefined;
+			 let matched = false;
+			 if (Object.keys(alts.types).length) {
+				 if (alts.types[move.type]) continue;
+				 if (Object.values(alts.types).includes(false) && alts.types[move.type] !== false) continue;
+			 }
+ 
+			 if (Object.keys(alts.categories).length) {
+				 if (alts.categories[move.category]) continue;
+				 if (Object.values(alts.categories).includes(false) && alts.categories[move.category] !== false) continue;
+			 }
+ 
+			 if (Object.keys(alts.contestTypes).length) {
+				 if (alts.contestTypes[move.contestType || 'Cool']) continue;
+				 if (
+					 Object.values(alts.contestTypes).includes(false) &&
+					 alts.contestTypes[move.contestType || 'Cool'] !== false
+				 ) continue;
+			 }
+ 
+			 if (Object.keys(alts.targets).length) {
+				 if (alts.targets[move.target]) continue;
+				 if (Object.values(alts.targets).includes(false) && alts.targets[move.target] !== false) continue;
+			 }
+ 
+			 for (const flag in alts.flags) {
+				 if (flag === 'secondary') {
+					 if (!(move.secondary || move.secondaries) === !alts.flags[flag]) {
+						 matched = true;
+						 break;
+					 }
+				 } else if (flag === 'zmove') {
+					 if (!move.isZ === !alts.flags[flag]) {
+						 matched = true;
+						 break;
+					 }
+				 } else if (flag === 'highcrit') {
+					 const crit = move.willCrit || (move.critRatio && move.critRatio > 1);
+					 if (!crit === !alts.flags[flag]) {
+						 matched = true;
+						 break;
+					 }
+				 } else if (flag === 'multihit') {
+					 if (!move.multihit === !alts.flags[flag]) {
+						 matched = true;
+						 break;
+					 }
+				 } else if (flag === 'maxmove') {
+					 if (!(typeof move.isMax === 'boolean' && move.isMax) === !alts.flags[flag]) {
+						 matched = true;
+						 break;
+					 }
+				 } else if (flag === 'gmaxmove') {
+					 if (!(typeof move.isMax === 'string') === !alts.flags[flag]) {
+						 matched = true;
+						 break;
+					 }
+				 } else if (flag === 'protection') {
+					 if (!(move.stallingMove && move.id !== "endure") === !alts.flags[flag]) {
+						 matched = true;
+						 break;
+					 }
+				 } else if (flag === 'ohko') {
+					 if (!move.ohko === !alts.flags[flag]) {
+						 matched = true;
+						 break;
+					 }
+				 } else {
+					 if ((flag in move.flags) === alts.flags[flag]) {
+						 if (flag === 'protect' && ['all', 'allyTeam', 'allySide', 'foeSide', 'self'].includes(move.target)) continue;
+						 matched = true;
+						 break;
+					 }
+				 }
+			 }
+			 if (matched) continue;
+			 if (Object.keys(alts.gens).length) {
+				 if (alts.gens[String(move.gen)]) continue;
+				 if (Object.values(alts.gens).includes(false) && alts.gens[String(move.gen)] !== false) continue;
+			 }
+			 if (!zrecoveryUndefined || !recoveryUndefined) {
+				 for (const recoveryType in alts.other) {
+					 let hasRecovery = false;
+					 if (recoveryType === "recovery") {
+						 hasRecovery = !!move.drain || !!move.flags.heal;
+					 } else if (recoveryType === "zrecovery") {
+						 hasRecovery = (move.zMove?.effect === 'heal');
+					 }
+					 if (hasRecovery === alts.other[recoveryType]) {
+						 matched = true;
+						 break;
+					 }
+				 }
+			 }
+			 if (matched) continue;
+			 if (alts.other.recoil !== undefined) {
+				 const recoil = move.recoil || move.hasCrashDamage;
+				 if (recoil && alts.other.recoil || !(recoil || alts.other.recoil)) matched = true;
+			 }
+			 if (matched) continue;
+			 for (const prop in alts.property) {
+				 if (typeof alts.property[prop].less === "number") {
+					 if (
+						 move[prop as keyof Move] !== true &&
+						 (move[prop as keyof Move] as number) < alts.property[prop].less
+					 ) {
+						 matched = true;
+						 break;
+					 }
+				 }
+				 if (typeof alts.property[prop].greater === "number") {
+					 if ((move[prop as keyof Move] === true && move.category !== "Status") ||
+						 move[prop as keyof Move] as number > alts.property[prop].greater) {
+						 matched = true;
+						 break;
+					 }
+				 }
+				 if (typeof alts.property[prop].equal === "number") {
+					 if (move[prop as keyof Move] === alts.property[prop].equal) {
+						 matched = true;
+						 break;
+					 }
+				 }
+			 }
+			 if (matched) continue;
+			 for (const boost in alts.boost) {
+				 if (move.boosts) {
+					 if ((move.boosts[boost as BoostID]! > 0) === alts.boost[boost]) {
+						 matched = true;
+						 break;
+					 }
+				 } else if (move.secondary?.self?.boosts) {
+					 if ((move.secondary.self.boosts[boost as BoostID]! > 0) === alts.boost[boost]) {
+						 matched = true;
+						 break;
+					 }
+				 } else if (move.selfBoost?.boosts) {
+					 if ((move.selfBoost.boosts[boost as BoostID]! > 0) === alts.boost[boost]) {
+						 matched = true;
+						 break;
+					 }
+				 }
+			 }
+			 if (matched) continue;
+			 for (const lower in alts.lower) {
+				 if (move.boosts) {
+					 if ((move.boosts[lower as BoostID]! < 0) === alts.lower[lower]) {
+						 matched = true;
+						 break;
+					 }
+				 } else if (move.secondary?.boosts) {
+					 if ((move.secondary.boosts[lower as BoostID]! < 0) === alts.lower[lower]) {
+						 matched = true;
+						 break;
+					 }
+				 } else if (move.self?.boosts) {
+					 if ((move.self.boosts[lower as BoostID]! < 0) === alts.lower[lower]) {
+						 matched = true;
+						 break;
+					 }
+				 }
+			 }
+			 if (matched) continue;
+			 for (const boost in alts.zboost) {
+				 const zMove = move.zMove;
+				 if (zMove?.boost) {
+					 if ((zMove.boost[boost as BoostID]! > 0) === alts.zboost[boost]) {
+						 matched = true;
+						 break;
+					 }
+				 }
+			 }
+			 if (matched) continue;
+ 
+			 for (const searchStatus in alts.status) {
+				 let canStatus = !!(
+					 move.status === searchStatus ||
+					 (move.secondaries && move.secondaries.some(entry => entry.status === searchStatus))
+				 );
+				 if (searchStatus === 'slp') {
+					 canStatus = canStatus || moveid === 'yawn';
+				 }
+				 if (searchStatus === 'brn' || searchStatus === 'frz' || searchStatus === 'par') {
+					 canStatus = canStatus || moveid === 'triattack';
+				 }
+				 if (canStatus === alts.status[searchStatus]) {
+					 matched = true;
+					 break;
+				 }
+			 }
+			 if (matched) continue;
+ 
+			 for (const searchStatus in alts.volatileStatus) {
+				 const canStatus = !!(
+					 (move.secondary && move.secondary.volatileStatus === searchStatus) ||
+					 (move.secondaries && move.secondaries.some(entry => entry.volatileStatus === searchStatus)) ||
+					 (move.volatileStatus === searchStatus)
+				 );
+				 if (canStatus === alts.volatileStatus[searchStatus]) {
+					 matched = true;
+					 break;
+				 }
+			 }
+			 if (matched) continue;
+			 if (alts.other.pivot !== undefined) {
+				 const pivot = move.selfSwitch && move.id !== 'batonpass';
+				 if (pivot && alts.other.pivot || !(pivot || alts.other.pivot)) matched = true;
+			 }
+			 if (matched) continue;
+ 
+			 delete dex[moveid];
+		 }
+	 }
+ 
+	 let results = [];
+	 for (const move in dex) {
+		 results.push(dex[move].name);
+	 }
+ 
+	 let resultsStr = "";
+	 if (targetMons.length) {
+		 resultsStr += `<span style="color:#999999;">Matching moves found in learnset(s) for</span> ${targetMons.map(mon => `${mon.shouldBeExcluded ? "!" : ""}${mon.name}`).join(', ')}:<br />`;
+	 } else {
+		 resultsStr += (message === "" ? message : `<span style="color:#999999;">${escapeHTML(message)}:</span><br />`);
+	 }
+	 if (randomOutput && randomOutput < results.length) {
+		 results = Utils.shuffle(results).slice(0, randomOutput);
+	 }
+	 if (results.length > 1) {
+		 results.sort();
+		 if (sort) {
+			 const prop = sort.slice(0, -1);
+			 const direction = sort.slice(-1);
+			 Utils.sortBy(results, moveName => {
+				 let moveProp = dex[toID(moveName)][prop as keyof Move] as number;
+				 // convert booleans to 0 or 1
+				 if (typeof moveProp === 'boolean') moveProp = moveProp ? 1 : 0;
+				 return moveProp * (direction === '+' ? 1 : -1);
+			 });
+		 }
+		 let notShown = 0;
+		 if (!showAll && results.length > MAX_RANDOM_RESULTS) {
+			 notShown = results.length - RESULTS_MAX_LENGTH;
+			 results = results.slice(0, RESULTS_MAX_LENGTH);
+		 }
+		 resultsStr += results.map(
+			 result => `<a href="//${Config.routes.dex}/moves/${toID(result)}" target="_blank" class="subtle" style="white-space:nowrap">${result}</a>` +
+				 `${sort ? ` (${dex[toID(result)][sort.slice(0, -1) as keyof Move] === true ? '-' : dex[toID(result)][sort.slice(0, -1) as keyof Move]})` : ''}`
+		 ).join(", ");
+		 if (notShown) {
+			 resultsStr += `, and ${notShown} more. <span style="color:#999999;">Redo the search with ', all' at the end to show all results.</span>`;
+		 }
+	 } else if (results.length === 1) {
+		 return {dt: `${results[0]}${usedMod ? `,${usedMod}` : ''}`};
+	 } else {
+		 resultsStr += "No moves found.";
+	 }
+	 if (isTest) return {results, reply: resultsStr};
+	 return {reply: resultsStr};
+ }
+ 
+ function runItemsearch(target: string, cmd: string, canAll: boolean, message: string) {
+	 let showAll = false;
+	 let maxGen = 0;
+	 let gen = 0;
+ 
+	 target = target.trim();
+	 const lastCommaIndex = target.lastIndexOf(',');
+	 const lastArgumentSubstr = target.substr(lastCommaIndex + 1).trim();
+	 if (lastArgumentSubstr === 'all') {
+		 if (!canAll) return {error: "A search ending in ', all' cannot be broadcast."};
+		 showAll = true;
+		 target = target.substr(0, lastCommaIndex);
+	 }
+ 
+	 target = target.toLowerCase().replace('-', ' ').replace(/[^a-z0-9.\s/]/g, '');
+	 const rawSearch = target.replace(/(max ?)?gen \d/g, match => toID(match)).split(' ');
+	 const searchedWords: string[] = [];
+	 let foundItems: string[] = [];
+ 
+	 // Refine searched words
+	 for (const [i, search] of rawSearch.entries()) {
+		 let newWord = search.trim();
+		 if (newWord.substr(0, 6) === 'maxgen') {
+			 const parsedGen = parseInt(newWord.substr(6));
+			 if (!isNaN(parsedGen)) {
+				 if (maxGen) return {error: "You cannot specify 'maxgen' multiple times."};
+				 maxGen = parsedGen;
+				 if (maxGen < 2 || maxGen > 8) return {error: "The generation must be between 2 and 8"};
+				 continue;
+			 }
+		 } else if (newWord.substr(0, 3) === 'gen') {
+			 const parsedGen = parseInt(newWord.substr(3));
+			 if (!isNaN(parsedGen)) {
+				 if (gen) return {error: "You cannot specify 'gen' multiple times."};
+				 gen = parsedGen;
+				 if (gen < 2 || gen > 8) return {error: "The generation must be between 2 and 8"};
+				 continue;
+			 }
+		 }
+		 if (isNaN(parseFloat(newWord))) newWord = newWord.replace('.', '');
+		 switch (newWord) {
+		 // Words that don't really help identify item removed to speed up search
+		 case 'a':
+		 case 'an':
+		 case 'is':
+		 case 'it':
+		 case 'its':
+		 case 'the':
+		 case 'that':
+		 case 'which':
+		 case 'user':
+		 case 'holder':
+		 case 'holders':
+			 newWord = '';
+			 break;
+		 // replace variations of common words with standardized versions
+		 case 'opponent': newWord = 'attacker'; break;
+		 case 'flung': newWord = 'fling'; break;
+		 case 'heal': case 'heals':
+		 case 'recovers': newWord = 'restores'; break;
+		 case 'boost':
+		 case 'boosts': newWord = 'raises'; break;
+		 case 'weakens': newWord = 'halves'; break;
+		 case 'more': newWord = 'increases'; break;
+		 case 'super':
+			 if (rawSearch[i + 1] === 'effective') {
+				 newWord = 'supereffective';
+			 }
+			 break;
+		 case 'special':
+			 if (rawSearch[i + 1] === 'defense') {
+				 newWord = 'specialdefense';
+			 } else if (rawSearch[i + 1] === 'attack') {
+				 newWord = 'specialattack';
+			 }
+			 break;
+		 case 'spatk':
+		 case 'spa':
+			 newWord = 'specialattack';
+			 break;
+		 case 'atk':
+		 case 'attack':
+			 if (['sp', 'special'].includes(rawSearch[i - 1])) {
+				 break;
+			 } else {
+				 newWord = 'attack';
+			 }
+			 break;
+		 case 'spd':
+		 case 'spdef':
+			 newWord = 'specialdefense';
+			 break;
+		 case 'def':
+		 case 'defense':
+			 if (['sp', 'special'].includes(rawSearch[i - 1])) {
+				 break;
+			 } else {
+				 newWord = 'defense';
+			 }
+			 break;
+		 case 'burns': newWord = 'burn'; break;
+		 case 'poisons': newWord = 'poison'; break;
+		 default:
+			 if (/x[\d.]+/.test(newWord)) {
+				 newWord = newWord.substr(1) + 'x';
+			 }
+		 }
+		 if (!newWord || searchedWords.includes(newWord)) continue;
+		 searchedWords.push(newWord);
+	 }
+ 
+	 if (searchedWords.length === 0 && !gen && !maxGen) {
+		 return {error: "No distinguishing words were used. Try a more specific search."};
+	 }
+ 
+	 const dex = maxGen ? Dex.mod("gen" + maxGen) : Dex;
+	 if (searchedWords.includes('fling')) {
+		 let basePower = 0;
+		 let effect;
+ 
+		 for (let word of searchedWords) {
+			 let wordEff = "";
+			 switch (word) {
+			 case 'burn': case 'burns':
+			 case 'brn': wordEff = 'brn'; break;
+			 case 'paralyze': case 'paralyzes':
+			 case 'par': wordEff = 'par'; break;
+			 case 'poison': case 'poisons':
+			 case 'psn': wordEff = 'psn'; break;
+			 case 'toxic':
+			 case 'tox': wordEff = 'tox'; break;
+			 case 'flinches':
+			 case 'flinch': wordEff = 'flinch'; break;
+			 case 'badly': wordEff = 'tox'; break;
+			 }
+			 if (wordEff && effect) {
+				 if (!(wordEff === 'psn' && effect === 'tox')) return {error: "Only specify fling effect once."};
+			 } else if (wordEff) {
+				 effect = wordEff;
+			 } else {
+				 if (word.substr(word.length - 2) === 'bp' && word.length > 2) word = word.substr(0, word.length - 2);
+				 if (Number.isInteger(Number(word))) {
+					 if (basePower) return {error: "Only specify a number for base power once."};
+					 basePower = parseInt(word);
+				 }
+			 }
+		 }
+ 
+		 for (const item of dex.items.all()) {
+			 if (!item.fling || (gen && item.gen !== gen) || (maxGen && item.gen <= maxGen)) continue;
+ 
+			 if (basePower && effect) {
+				 if (item.fling.basePower === basePower &&
+				 (item.fling.status === effect || item.fling.volatileStatus === effect)) foundItems.push(item.name);
+			 } else if (basePower) {
+				 if (item.fling.basePower === basePower) foundItems.push(item.name);
+			 } else {
+				 if (item.fling.status === effect || item.fling.volatileStatus === effect) foundItems.push(item.name);
+			 }
+		 }
+		 if (foundItems.length === 0) return {error: 'No items inflict ' + basePower + 'bp damage when used with Fling.'};
+	 } else if (target.search(/natural ?gift/i) >= 0) {
+		 let basePower = 0;
+		 let type = "";
+ 
+		 for (let word of searchedWords) {
+			 if (word in dex.data.TypeChart) {
+				 if (type) return {error: "Only specify natural gift type once."};
+				 type = word.charAt(0).toUpperCase() + word.slice(1);
+			 } else {
+				 if (word.endsWith('bp') && word.length > 2) word = word.slice(0, -2);
+				 if (Number.isInteger(Number(word))) {
+					 if (basePower) return {error: "Only specify a number for base power once."};
+					 basePower = parseInt(word);
+				 }
+			 }
+		 }
+ 
+		 for (const item of dex.items.all()) {
+			 if (!item.isBerry || !item.naturalGift || (gen && item.gen !== gen) || (maxGen && item.gen <= maxGen)) continue;
+ 
+			 if (basePower && type) {
+				 if (item.naturalGift.basePower === basePower && item.naturalGift.type === type) foundItems.push(item.name);
+			 } else if (basePower) {
+				 if (item.naturalGift.basePower === basePower) foundItems.push(item.name);
+			 } else {
+				 if (item.naturalGift.type === type) foundItems.push(item.name);
+			 }
+		 }
+		 if (foundItems.length === 0) {
+			 return {error: 'No berries inflict ' + basePower + 'bp damage when used with Natural Gift.'};
+		 }
+	 } else {
+		 let bestMatched = 0;
+		 for (const item of dex.items.all()) {
+			 let matched = 0;
+			 // splits words in the description into a toID()-esk format except retaining / and . in numbers
+			 let descWords = item.desc || '';
+			 // add more general quantifier words to descriptions
+			 if (/[1-9.]+x/.test(descWords)) descWords += ' increases';
+			 if (item.isBerry) descWords += ' berry';
+			 descWords = descWords.replace(/super[-\s]effective/g, 'supereffective');
+			 const descWordsArray = descWords.toLowerCase()
+				 .replace('-', ' ')
+				 .replace(/[^a-z0-9\s/]/g, '')
+				 .replace(/(\D)\./, (p0, p1) => p1).split(' ');
+ 
+			 for (const word of searchedWords) {
+				 switch (word) {
+				 case 'specialattack':
+					 if (descWordsArray[descWordsArray.indexOf('sp') + 1] === 'atk') matched++;
+					 break;
+				 case 'specialdefense':
+					 if (descWordsArray[descWordsArray.indexOf('sp') + 1] === 'def') matched++;
+					 break;
+				 default:
+					 if (descWordsArray.includes(word)) matched++;
+				 }
+			 }
+ 
+			 if (matched >= (searchedWords.length * 3 / 5) && (!maxGen || item.gen <= maxGen) && (!gen || item.gen === gen)) {
+				 if (matched === bestMatched) {
+					 foundItems.push(item.name);
+				 } else if (matched > bestMatched) {
+					 foundItems = [item.name];
+					 bestMatched = matched;
+				 }
+			 }
+		 }
+	 }
+ 
+	 let resultsStr = (message === "" ? message : `<span style="color:#999999;">${escapeHTML(message)}:</span><br />`);
+	 if (foundItems.length > 0) {
+		 foundItems.sort();
+		 let notShown = 0;
+		 if (!showAll && foundItems.length > RESULTS_MAX_LENGTH + 5) {
+			 notShown = foundItems.length - RESULTS_MAX_LENGTH;
+			 foundItems = foundItems.slice(0, RESULTS_MAX_LENGTH);
+		 }
+		 resultsStr += foundItems.map(
+			 result => `<a href="//${Config.routes.dex}/items/${toID(result)}" target="_blank" class="subtle" style="white-space:nowrap"><psicon item="${result}" style="vertical-align:-7px" />${result}</a>`
+		 ).join(", ");
+		 if (notShown) {
+			 resultsStr += `, and ${notShown} more. <span style="color:#999999;">Redo the search with ', all' at the end to show all results.</span>`;
+		 }
+	 } else {
+		 resultsStr += "No items found. Try a more general search";
+	 }
+	 return {reply: resultsStr};
+ }
+ 
+ function runAbilitysearch(target: string, cmd: string, canAll: boolean, message: string) {
+	 // based heavily on runItemsearch()
+	 let showAll = false;
+	 let maxGen = 0;
+	 let gen = 0;
+ 
+	 target = target.trim();
+	 const lastCommaIndex = target.lastIndexOf(',');
+	 const lastArgumentSubstr = target.substr(lastCommaIndex + 1).trim();
+	 if (lastArgumentSubstr === 'all') {
+		 if (!canAll) return {error: "A search ending in ', all' cannot be broadcast."};
+		 showAll = true;
+		 target = target.substr(0, lastCommaIndex);
+	 }
+ 
+	 target = target.toLowerCase().replace('-', ' ').replace(/[^a-z0-9.\s/]/g, '');
+	 const rawSearch = target.replace(/(max ?)?gen \d/g, match => toID(match)).split(' ');
+	 const searchedWords: string[] = [];
+	 let foundAbilities: string[] = [];
+ 
+	 for (const [i, search] of rawSearch.entries()) {
+		 let newWord = search.trim();
+		 if (newWord.substr(0, 6) === 'maxgen') {
+			 const parsedGen = parseInt(newWord.substr(6));
+			 if (parsedGen) {
+				 if (maxGen) return {error: "You cannot specify 'maxgen' multiple times."};
+				 maxGen = parsedGen;
+				 if (maxGen < 3 || maxGen > 8) return {error: "The generation must be between 3 and 8"};
+				 continue;
+			 }
+		 } else if (newWord.substr(0, 3) === 'gen') {
+			 const parsedGen = parseInt(newWord.substr(3));
+			 if (parsedGen) {
+				 if (gen) return {error: "You cannot specify 'gen' multiple times."};
+				 gen = parsedGen;
+				 if (gen < 3 || gen > 8) return {error: "The generation must be between 3 and 8"};
+				 continue;
+			 }
+		 }
+		 if (isNaN(parseFloat(newWord))) newWord = newWord.replace('.', '');
+		 switch (newWord) {
+		 // remove extraneous words
+		 case 'a':
+		 case 'an':
+		 case 'is':
+		 case 'it':
+		 case 'its':
+		 case 'the':
+		 case 'that':
+		 case 'which':
+		 case 'user':
+			 newWord = '';
+			 break;
+		 // replace variations of common words with standardized versions
+		 case 'opponent': newWord = 'attacker'; break;
+		 case 'heal':
+		 case 'heals':
+		 case 'recovers': newWord = 'restores'; break;
+		 case 'boost':
+		 case 'boosts': newWord = 'raised'; break;
+		 case 'super':
+			 if (rawSearch[i + 1] === 'effective') {
+				 newWord = 'supereffective';
+			 }
+			 break;
+		 case 'special':
+			 if (rawSearch[i + 1] === 'defense') {
+				 newWord = 'specialdefense';
+			 } else if (rawSearch[i + 1] === 'attack') {
+				 newWord = 'specialattack';
+			 }
+			 break;
+		 case 'spd':
+		 case 'spdef': newWord = 'specialdefense'; break;
+		 case 'spa':
+		 case 'spatk': newWord = 'specialattack'; break;
+		 case 'atk': newWord = 'attack'; break;
+		 case 'def': newWord = 'defense'; break;
+		 case 'spe': newWord = 'speed'; break;
+		 case 'burn':
+		 case 'burns': newWord = 'burned'; break;
+		 case 'poison':
+		 case 'poisons': newWord = 'poisoned'; break;
+		 default:
+			 if (/x[\d.]+/.test(newWord)) {
+				 newWord = newWord.substr(1) + 'x';
+			 }
+		 }
+		 if (!newWord || searchedWords.includes(newWord)) continue;
+		 searchedWords.push(newWord);
+	 }
+ 
+	 if (searchedWords.length === 0 && !gen && !maxGen) {
+		 return {error: "No distinguishing words were used. Try a more specific search."};
+	 }
+ 
+	 let bestMatched = 0;
+	 const dex = maxGen ? Dex.mod("gen" + maxGen) : Dex;
+	 for (const ability of dex.abilities.all()) {
+		 let matched = 0;
+		 // splits words in the description into a toID()-esque format except retaining / and . in numbers
+		 let descWords = ability.desc || ability.shortDesc || '';
+		 // add more general quantifier words to descriptions
+		 if (/[1-9.]+x/.test(descWords)) descWords += ' increases';
+		 descWords = descWords.replace(/super[-\s]effective/g, 'supereffective');
+		 const descWordsArray = Chat.normalize(descWords).split(' ');
+ 
+		 for (const word of searchedWords) {
+			 switch (word) {
+			 case 'specialattack':
+				 if (descWordsArray[descWordsArray.indexOf('special') + 1] === 'attack') matched++;
+				 break;
+			 case 'specialdefense':
+				 if (descWordsArray[descWordsArray.indexOf('special') + 1] === 'defense') matched++;
+				 break;
+			 default:
+				 if (descWordsArray.includes(word)) matched++;
+			 }
+		 }
+ 
+		 if (matched >= (searchedWords.length * 3 / 5) && (!maxGen || ability.gen <= maxGen) && (!gen || ability.gen === gen)) {
+			 if (matched === bestMatched) {
+				 foundAbilities.push(ability.name);
+			 } else if (matched > bestMatched) {
+				 foundAbilities = [ability.name];
+				 bestMatched = matched;
+			 }
+		 }
+	 }
+ 
+	 if (foundAbilities.length === 1) return {dt: foundAbilities[0]};
+	 let resultsStr = (message === "" ? message : `<span style="color:#999999;">${escapeHTML(message)}:</span><br />`);
+	 if (foundAbilities.length > 0) {
+		 foundAbilities.sort();
+		 let notShown = 0;
+		 if (!showAll && foundAbilities.length > RESULTS_MAX_LENGTH + 5) {
+			 notShown = foundAbilities.length - RESULTS_MAX_LENGTH;
+			 foundAbilities = foundAbilities.slice(0, RESULTS_MAX_LENGTH);
+		 }
+		 resultsStr += foundAbilities.map(
+			 result => `<a href="//${Config.routes.dex}/abilities/${toID(result)}" target="_blank" class="subtle" style="white-space:nowrap">${result}</a>`
+		 ).join(", ");
+		 if (notShown) {
+			 resultsStr += `, and ${notShown} more. <span style="color:#999999;">Redo the search with ', all' at the end to show all results.</span>`;
+		 }
+	 } else {
+		 resultsStr += "No abilities found. Try a more general search.";
+	 }
+	 return {reply: resultsStr};
+ }
+ 
+ function runLearn(target: string, cmd: string, canAll: boolean, formatid: string) {
+	 let format: Format = Dex.formats.get(formatid);
+	 const targets = target.split(',');
+	 let formatName = format.name;
+	 let minSourceGen = undefined;
+	 let level = 100;
+ 
+	 while (targets.length) {
+		 const targetid = toID(targets[0]);
+		 if (targetid === 'pentagon') {
+			 if (format.exists) {
+				 return {error: "'pentagon' can't be used with formats."};
+			 }
+			 minSourceGen = 6;
+			 targets.shift();
+			 continue;
+		 }
+		 if (targetid.startsWith('minsourcegen')) {
+			 if (format.exists) {
+				 return {error: "'min source gen' can't be used with formats."};
+			 }
+			 minSourceGen = parseInt(targetid.slice(12));
+			 if (isNaN(minSourceGen) || minSourceGen < 1) return {error: `Invalid min source gen "${targetid.slice(12)}"`};
+			 targets.shift();
+			 continue;
+		 }
+		 if (targetid === 'level5') {
+			 level = 5;
+			 targets.shift();
+			 continue;
+		 }
+		 break;
+	 }
+	 let gen;
+	 const dex = Dex.mod(formatid).includeData();
+	 if (!format.exists) {
+		 // can happen if you hotpatch formats without hotpatching chat
+		 if (!dex) return {error: `"${formatid}" is not a supported format.`};
+ 
+		 gen = dex.gen;
+		 format = new Dex.Format({mod: formatid});
+		 formatName = `Gen ${gen}`;
+		 if (minSourceGen) {
+			 formatName += ` (Min Source Gen = ${minSourceGen})`;
+			 const ruleTable = dex.formats.getRuleTable(format);
+			 ruleTable.minSourceGen = minSourceGen;
+		 }
+	 } else {
+		 gen = Dex.forFormat(format).gen;
+	 }
+	 const validator = TeamValidator.get(format);
+ 
+	 const species = validator.dex.species.get(targets.shift());
+	 const setSources = validator.allSources(species);
+	 const set: Partial<PokemonSet> = {
+		 name: species.baseSpecies,
+		 species: species.name,
+		 level,
+	 };
+	 const all = (cmd === 'learnall');
+ 
+	 if (!species.exists || species.id === 'missingno') {
+		 return {error: `Pok\u00e9mon '${species.id}' not found.`};
+	 }
+ 
+	 if (species.gen > gen) {
+		 return {error: `${species.name} didn't exist yet in generation ${gen}.`};
+	 }
+ 
+	 if (!targets.length) {
+		 return {error: "You must specify at least one move."};
+	 }
+ 
+	 const moveNames = [];
+	 for (const arg of targets) {
+		 if (['ha', 'hidden', 'hiddenability'].includes(toID(arg))) {
+			 if (gen < 5) {
+				 return {error: "Hidden abilities exist only in generations 5 and later."};
+			 }
+			 setSources.isHidden = true;
+			 continue;
+		 }
+		 const move = validator.dex.moves.get(arg);
+		 moveNames.push(move.name);
+		 if (!move.exists) {
+			 return {error: `Move '${move.id}' not found.`};
+		 }
+		 if (move.gen > gen) {
+			 return {error: `${move.name} didn't exist yet in generation ${gen}.`};
+		 }
+	 }
+ 
+	 const problems = validator.validateMoves(species, moveNames, setSources, set);
+	 if (setSources.sources.length) {
+		 setSources.sources = setSources.sources.map(source => {
+			 if (source.charAt(1) !== 'E') return source;
+			 const fathers = validator.findEggMoveFathers(source, species, setSources, true);
+			 if (!fathers) return '';
+			 return source + ':' + fathers.join(',');
+		 }).filter(Boolean);
+		 if (!setSources.size()) {
+			 problems.push(`${species.name} doesn't have a valid father for its egg moves (${setSources.limitedEggMoves!.join(', ')})`);
+		 }
+	 }
+ 
+	 let buffer = `In ${formatName}, `;
+	 if (setSources.isHidden) {
+		 const canUseAbilityPatch = dex.gen >= 8 && format.mod !== 'gen8dlc1';
+		 console.log(setSources.sourcesBefore);
+		 if (!setSources.sourcesBefore && !canUseAbilityPatch) {
+			 const learnset = dex.species.getLearnsetData(species.id);
+			 for (let sourceIndex = 0; sourceIndex < setSources.sources.length; sourceIndex++) {
+				 const source = setSources.sources[sourceIndex];
+				 if (source.charAt(1) === 'S' && learnset.eventData) {
+					 const eventData = learnset.eventData[parseInt(source.substr(2))];
+					 const hiddenAbilityProblem = validator.validateEventHiddenAbility(species.name, true, eventData, ` because it has a move only available from an event`);
+					 if (hiddenAbilityProblem) {
+						 setSources.sources.splice(sourceIndex, 1);
+						 sourceIndex--;
+						 if (!setSources.sources.length) {
+							 problems.push(hiddenAbilityProblem);
+						 }
+					 }
+				 }
+			 }
+		 }
+		 if (species.maleOnlyHidden && setSources.sourcesBefore < 5) {
+			 for (let sourceIndex = 0; sourceIndex < setSources.sources.length; sourceIndex++) {
+				 const source = setSources.sources[sourceIndex];
+				 if (source.charAt(1) === 'E') {
+					 setSources.sources.splice(sourceIndex, 1);
+					 sourceIndex--;
+					 if (!setSources.sources.length) {
+						 problems.push(`${species.name} has an unbreedable Hidden Ability - it can't use egg moves.`);
+					 }
+				 }
+			 }
+		 }
+		 buffer += `${species.abilities['H'] || 'HA'} `;
+	 }
+	 buffer += `${species.name}` + (problems.length ? ` <span class="message-learn-cannotlearn">can't</span> learn ` : ` <span class="message-learn-canlearn">can</span> learn `) + toListString(moveNames);
+	 if (!problems.length) {
+		 const sourceNames: {[k: string]: string} = {
+			 '7V': "virtual console transfer from gen 1-2", '8V': "Pok&eacute;mon Home transfer from LGPE", E: "", S: "event", D: "dream world", X: "traded-back ", Y: "traded-back event",
+		 };
+		 const sourcesBefore = setSources.sourcesBefore;
+		 let sources = setSources.sources;
+		 if (sources.length || sourcesBefore < gen) buffer += " only when obtained";
+		 buffer += " from:<ul class=\"message-learn-list\">";
+		 if (sources.length) {
+			 sources = sources.map(source => {
+				 if (source.startsWith('1ET')) {
+					 return '2X' + source.slice(3);
+				 }
+				 if (source.startsWith('1ST')) {
+					 return '2Y' + source.slice(3);
+				 }
+				 return source;
+			 }).sort();
+			 for (let source of sources) {
+				 buffer += `<li>Gen ${source.charAt(0)} ${sourceNames[source] || sourceNames[source.charAt(1)]}`;
+ 
+				 if (source.charAt(1) === 'E') {
+					 let fathers;
+					 [source, fathers] = source.split(':');
+					 fathers = fathers.split(',');
+					 if (fathers.length > 4 && !all) fathers = fathers.slice(-4).concat('...');
+					 if (source.length > 2) {
+						 buffer += `${source.slice(2)} `;
+					 }
+					 buffer += `egg`;
+					 if (!fathers[0]) {
+						 buffer += `: chainbreed`;
+					 } else {
+						 buffer += `: breed ${fathers.join(', ')}`;
+					 }
+				 }
+ 
+				 if (source.startsWith('5E') && species.maleOnlyHidden) {
+					 buffer += " (no hidden ability)";
+				 }
+			 }
+		 }
+		 if (sourcesBefore) {
+			 const sourceGen = sourcesBefore < gen ? `Gen ${sourcesBefore} or earlier` : `anywhere`;
+			 if (moveNames.length === 1) {
+				 if (sourcesBefore >= 8) {
+					 buffer += `<li>${sourceGen} (move is level-up/tutor/TM/HM/egg in Gen ${sourcesBefore})`;
+				 } else {
+					 buffer += `<li>${sourceGen} (move is level-up/tutor/TM/HM in Gen ${sourcesBefore})`;
+				 }
+			 } else if (gen >= 8) {
+				 const orEarlier = sourcesBefore < gen ? ` or level-up/tutor/TM/HM in Gen ${sourcesBefore}${
+					 sourcesBefore < 7 ? " to 7" : ""
+				 }` : ``;
+				 buffer += `<li>${sourceGen} (all moves are level-up/tutor/TM/HM/egg in Gen ${sourcesBefore}${orEarlier})`;
+			 } else {
+				 buffer += `<li>${sourceGen} (all moves are level-up/tutor/TM/HM in Gen ${Math.min(gen, sourcesBefore)}${sourcesBefore < gen ? " to " + gen : ""})`;
+			 }
+		 }
+		 if (setSources.babyOnly && sourcesBefore) {
+			 buffer += `<li>must be obtained as ` + Dex.species.get(setSources.babyOnly).name;
+		 }
+		 buffer += "</ul>";
+	 } else if (problems.length >= 1) {
+		 const expectedError = `${species.name} can't learn ${moveNames[0]}.`;
+		 if (problems.length > 1 || moveNames.length > 1 || problems[0] !== expectedError) {
+			 buffer += ` because:<ul class="message-learn-list">`;
+			 buffer += `<li>` + problems.join(`</li><li>`) + `</li>`;
+			 buffer += `</ul>`;
+		 }
+	 }
+	 return {reply: buffer};
+ }
+ 
+ function runSearch(query: {target: string, cmd: string, canAll: boolean, message: string}) {
+	 return PM.query(query);
+ }
+ 
+ /*********************************************************
+  * Process manager
+  *********************************************************/
+ 
+ export const PM = new ProcessManager.QueryProcessManager<AnyObject, AnyObject>(module, query => {
+	 try {
+		 if (Config.debugdexsearchprocesses && process.send) {
+			 process.send('DEBUG\n' + JSON.stringify(query));
+		 }
+		 switch (query.cmd) {
+		 case 'randpoke':
+		 case 'dexsearch':
+			 return runDexsearch(query.target, query.cmd, query.canAll, query.message, false);
+		 case 'randmove':
+		 case 'movesearch':
+			 return runMovesearch(query.target, query.cmd, query.canAll, query.message, false);
+		 case 'itemsearch':
+			 return runItemsearch(query.target, query.cmd, query.canAll, query.message);
+		 case 'abilitysearch':
+			 return runAbilitysearch(query.target, query.cmd, query.canAll, query.message);
+		 case 'learn':
+			 return runLearn(query.target, query.cmd, query.canAll, query.message);
+		 default:
+			 throw new Error(`Unrecognized Dexsearch command "${query.cmd}"`);
+		 }
+	 } catch (err) {
+		 Monitor.crashlog(err, 'A search query', query);
+	 }
+	 return {
+		 error: "Sorry! Our search engine crashed on your query. We've been automatically notified and will fix this crash.",
+	 };
+ });
+ 
+ if (!PM.isParentProcess) {
+	 // This is a child process!
+	 global.Config = require('../config-loader').Config;
+	 global.Monitor = {
+		 crashlog(error: Error, source = 'A datasearch process', details: AnyObject | null = null) {
+			 const repr = JSON.stringify([error.name, error.message, source, details]);
+			 process.send!(`THROW\n@!!@${repr}\n${error.stack}`);
+		 },
+	 };
+	 if (Config.crashguard) {
+		 process.on('uncaughtException', err => {
+			 Monitor.crashlog(err, 'A dexsearch process');
+		 });
+	 }
+ 
+	 global.Dex = require('../../sim/dex').Dex;
+	 global.toID = Dex.toID;
+	 Dex.includeData();
+ 
+	 // @ts-ignore
+	 require('../../lib/repl').Repl.start('dexsearch', cmd => eval(cmd)); // eslint-disable-line no-eval
+ } else {
+	 PM.spawn(MAX_PROCESSES);
+ }
+ 
+ export const testables = {
+	 runAbilitysearch: (target: string, cmd: string, canAll: boolean, message: string) =>
+		 runAbilitysearch(target, cmd, canAll, message),
+	 runDexsearch: (target: string, cmd: string, canAll: boolean, message: string) =>
+		 runDexsearch(target, cmd, canAll, message, true),
+	 runMovesearch: (target: string, cmd: string, canAll: boolean, message: string) =>
+		 runMovesearch(target, cmd, canAll, message, true),
+ };
+ 

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -2462,7 +2462,6 @@ function runLearn(target: string, cmd: string, canAll: boolean, formatid: string
 	let buffer = `In ${formatName}, `;
 	if (setSources.isHidden) {
 		const canUseAbilityPatch = dex.gen >= 8 && format.mod !== 'gen8dlc1';
-		console.log(setSources.sourcesBefore);
 		if (!setSources.sourcesBefore && !canUseAbilityPatch) {
 			const learnset = dex.species.getLearnsetData(species.id);
 			for (let sourceIndex = 0; sourceIndex < setSources.sources.length; sourceIndex++) {

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -7,2254 +7,2265 @@
  * @license MIT
  */
 
-import {Dex, toID} from './dex';
-import {Utils} from '../lib';
-import {Tags} from '../data/tags';
-import {Teams} from './teams';
-import {PRNG} from './prng';
-
-/**
- * Describes a possible way to get a pokemon. Is not exhaustive!
- * sourcesBefore covers all sources that do not have exclusive
- * moves (like catching wild pokemon).
- *
- * First character is a generation number, 1-8.
- * Second character is a source ID, one of:
- *
- * - E = egg, 3rd char+ is the father in gen 2-5, empty in gen 6-7
- *   because egg moves aren't restricted to fathers anymore
- * - S = event, 3rd char+ is the index in .eventData
- * - D = Dream World, only 5D is valid
- * - V = Virtual Console or Let's Go transfer, only 7V/8V is valid
- *
- * Designed to match MoveSource where possible.
- */
-export type PokemonSource = string;
-
-/**
- * Represents a set of possible ways to get a Pokémon with a given
- * set.
- *
- * `new PokemonSources()` creates an empty set;
- * `new PokemonSources(dex.gen)` allows all Pokemon.
- *
- * The set mainly stored as an Array `sources`, but for sets that
- * could be sourced from anywhere (for instance, TM moves), we
- * instead just set `sourcesBefore` to a number meaning "any
- * source at or before this gen is possible."
- *
- * In other words, this variable represents the set of all
- * sources in `sources`, union all sources at or before
- * gen `sourcesBefore`.
- */
-export class PokemonSources {
-	/**
-	 * A set of specific possible PokemonSources; implemented as
-	 * an Array rather than a Set for perf reasons.
-	 */
-	sources: PokemonSource[];
-	/**
-	 * if nonzero: the set also contains all possible sources from
-	 * this gen and earlier.
-	 */
-	sourcesBefore: number;
-	/**
-	 * the set requires sources from this gen or later
-	 * this should be unchanged from the format's minimum past gen
-	 * (3 in modern games, 6 if pentagon is required, etc)
-	 */
-	sourcesAfter: number;
-	isHidden: boolean | null;
-	/**
-	 * `limitedEggMoves` is a list of moves that can only be obtained from an
-	 * egg with another father in gen 2-5. If there are multiple such moves,
-	 * potential fathers need to be checked to see if they can actually
-	 * learn the move combination in question.
-	 *
-	 * `null` = the current move is definitely not a limited egg move
-	 *
-	 * `undefined` = the current move may or may not be a limited egg move
-	 */
-	limitedEggMoves?: ID[] | null;
-	/**
-	 * Some Pokemon evolve by having a move in their learnset (like Piloswine
-	 * with Ancient Power). These can only carry three other moves from their
-	 * prevo, because the fourth move must be the evo move. This restriction
-	 * doesn't apply to gen 6+ eggs, which can get around the restriction with
-	 * the relearner.
-	 */
-	moveEvoCarryCount: number;
-
-	babyOnly?: string;
-	sketchMove?: string;
-	hm?: string;
-	restrictiveMoves?: string[];
-	/** Obscure learn methods */
-	restrictedMove?: ID;
-
-	constructor(sourcesBefore = 0, sourcesAfter = 0) {
-		this.sources = [];
-		this.sourcesBefore = sourcesBefore;
-		this.sourcesAfter = sourcesAfter;
-		this.isHidden = null;
-		this.limitedEggMoves = undefined;
-		this.moveEvoCarryCount = 0;
-	}
-	size() {
-		if (this.sourcesBefore) return Infinity;
-		return this.sources.length;
-	}
-	add(source: PokemonSource, limitedEggMove?: ID | null) {
-		if (this.sources[this.sources.length - 1] !== source) this.sources.push(source);
-		if (limitedEggMove && this.limitedEggMoves !== null) {
-			this.limitedEggMoves = [limitedEggMove];
-		} else if (limitedEggMove === null) {
-			this.limitedEggMoves = null;
-		}
-	}
-	addGen(sourceGen: number) {
-		this.sourcesBefore = Math.max(this.sourcesBefore, sourceGen);
-		this.limitedEggMoves = null;
-	}
-	minSourceGen() {
-		if (this.sourcesBefore) return this.sourcesAfter || 1;
-		let min = 10;
-		for (const source of this.sources) {
-			const sourceGen = parseInt(source.charAt(0));
-			if (sourceGen < min) min = sourceGen;
-		}
-		if (min === 10) return 0;
-		return min;
-	}
-	maxSourceGen() {
-		let max = this.sourcesBefore;
-		for (const source of this.sources) {
-			const sourceGen = parseInt(source.charAt(0));
-			if (sourceGen > max) max = sourceGen;
-		}
-		return max;
-	}
-	intersectWith(other: PokemonSources) {
-		if (other.sourcesBefore || this.sourcesBefore) {
-			// having sourcesBefore is the equivalent of having everything before that gen
-			// in sources, so we fill the other array in preparation for intersection
-			if (other.sourcesBefore > this.sourcesBefore) {
-				for (const source of this.sources) {
-					const sourceGen = parseInt(source.charAt(0));
-					if (sourceGen <= other.sourcesBefore) {
-						other.sources.push(source);
-					}
-				}
-			} else if (this.sourcesBefore > other.sourcesBefore) {
-				for (const source of other.sources) {
-					const sourceGen = parseInt(source.charAt(0));
-					if (sourceGen <= this.sourcesBefore) {
-						this.sources.push(source);
-					}
-				}
-			}
-			this.sourcesBefore = Math.min(other.sourcesBefore, this.sourcesBefore);
-		}
-		if (this.sources.length) {
-			if (other.sources.length) {
-				const sourcesSet = new Set(other.sources);
-				const intersectSources = this.sources.filter(source => sourcesSet.has(source));
-				this.sources = intersectSources;
-			} else {
-				this.sources = [];
-			}
-		}
-
-		if (other.restrictedMove && other.restrictedMove !== this.restrictedMove) {
-			if (this.restrictedMove) {
-				// incompatible
-				this.sources = [];
-				this.sourcesBefore = 0;
-			} else {
-				this.restrictedMove = other.restrictedMove;
-			}
-		}
-		if (other.limitedEggMoves) {
-			if (!this.limitedEggMoves) {
-				this.limitedEggMoves = other.limitedEggMoves;
-			} else {
-				this.limitedEggMoves.push(...other.limitedEggMoves);
-			}
-		}
-		this.moveEvoCarryCount += other.moveEvoCarryCount;
-		if (other.sourcesAfter > this.sourcesAfter) this.sourcesAfter = other.sourcesAfter;
-		if (other.isHidden) this.isHidden = true;
-	}
-}
-
-export class TeamValidator {
-	readonly format: Format;
-	readonly dex: ModdedDex;
-	readonly gen: number;
-	readonly ruleTable: import('./dex-formats').RuleTable;
-	readonly minSourceGen: number;
-
-	readonly toID: (str: any) => ID;
-	constructor(format: string | Format, dex = Dex) {
-		this.format = dex.formats.get(format);
-		this.dex = dex.forFormat(this.format);
-		this.gen = this.dex.gen;
-		this.ruleTable = this.dex.formats.getRuleTable(this.format);
-
-		this.minSourceGen = this.ruleTable.minSourceGen;
-
-		this.toID = toID;
-	}
-
-	validateTeam(
-		team: PokemonSet[] | null,
-		options: {
-			removeNicknames?: boolean,
-			skipSets?: {[name: string]: {[key: string]: boolean}},
-		} = {}
-	): string[] | null {
-		if (team && this.format.validateTeam) {
-			return this.format.validateTeam.call(this, team, options) || null;
-		}
-		return this.baseValidateTeam(team, options);
-	}
-
-	baseValidateTeam(
-		team: PokemonSet[] | null,
-		options: {
-			removeNicknames?: boolean,
-			skipSets?: {[name: string]: {[key: string]: boolean}},
-		} = {}
-	): string[] | null {
-		const format = this.format;
-		const dex = this.dex;
-
-		let problems: string[] = [];
-		const ruleTable = this.ruleTable;
-		if (format.team) {
-			if (team) {
-				return [
-					`This format doesn't let you use your own team.`,
-					`If you're not using a custom client, please report this as a bug. If you are, remember to use \`/utm null\` before starting a game in this format.`,
-				];
-			}
-			const testTeamSeed = PRNG.generateSeed();
-			try {
-				const testTeamGenerator = Teams.getGenerator(format, testTeamSeed);
-				testTeamGenerator.getTeam(options); // Throws error if generation fails
-			} catch (e) {
-				return [
-					`${format.name}'s team generator (${format.team}) failed using these rules and seed (${testTeamSeed}):-`,
-					`${e}`,
-				];
-			}
-			return null;
-		}
-		if (!team) {
-			return [
-				`This format requires you to use your own team.`,
-				`If you're not using a custom client, please report this as a bug.`,
-			];
-		}
-		if (!Array.isArray(team)) {
-			throw new Error(`Invalid team data`);
-		}
-
-		if (team.length < ruleTable.minTeamSize) {
-			problems.push(`You must bring at least ${ruleTable.minTeamSize} Pok\u00E9mon (your team has ${team.length}).`);
-		}
-		if (team.length > ruleTable.maxTeamSize) {
-			return [`You may only bring up to ${ruleTable.maxTeamSize} Pok\u00E9mon (your team has ${team.length}).`];
-		}
-
-		// A limit is imposed here to prevent too much engine strain or
-		// too much layout deformation - to be exact, this is the limit
-		// allowed in Custom Game.
-		if (team.length > 24) {
-			problems.push(`Your team has more than than 24 Pok\u00E9mon, which the simulator can't handle.`);
-			return problems;
-		}
-
-		const teamHas: {[k: string]: number} = {};
-		let lgpeStarterCount = 0;
-		let deoxysType;
-		for (const set of team) {
-			if (!set) return [`You sent invalid team data. If you're not using a custom client, please report this as a bug.`];
-
-			let setProblems: string[] | null = null;
-			if (options.skipSets && options.skipSets[set.name]) {
-				for (const i in options.skipSets[set.name]) {
-					teamHas[i] = (teamHas[i] || 0) + 1;
-				}
-			} else {
-				setProblems = (format.validateSet || this.validateSet).call(this, set, teamHas);
-			}
-
-			if (set.species === 'Pikachu-Starter' || set.species === 'Eevee-Starter') {
-				lgpeStarterCount++;
-				if (lgpeStarterCount === 2 && ruleTable.isBanned('nonexistent')) {
-					problems.push(`You can only have one of Pikachu-Starter or Eevee-Starter on a team.`);
-				}
-			}
-			if (dex.gen === 3 && set.species.startsWith('Deoxys')) {
-				if (!deoxysType) {
-					deoxysType = set.species;
-				} else if (deoxysType !== set.species && ruleTable.isBanned('nonexistent')) {
-					return [
-						`You cannot have more than one type of Deoxys forme.`,
-						`(Each game in Gen 3 supports only one forme of Deoxys.)`,
-					];
-				}
-			}
-			if (setProblems) {
-				problems = problems.concat(setProblems);
-			}
-			if (options.removeNicknames) {
-				const species = dex.species.get(set.species);
-				let crossSpecies: Species;
-				if (format.name === '[Gen 8] Cross Evolution' && (crossSpecies = dex.species.get(set.name)).exists) {
-					set.name = crossSpecies.name;
-				} else {
-					set.name = species.baseSpecies;
-					if (species.baseSpecies === 'Unown') set.species = 'Unown';
-				}
-			}
-		}
-
-		for (const [rule, source, limit, bans] of ruleTable.complexTeamBans) {
-			let count = 0;
-			for (const ban of bans) {
-				if (teamHas[ban] > 0) {
-					count += limit ? teamHas[ban] : 1;
-				}
-			}
-			if (limit && count > limit) {
-				const clause = source ? ` by ${source}` : ``;
-				problems.push(`You are limited to ${limit} of ${rule}${clause}.`);
-			} else if (!limit && count >= bans.length) {
-				const clause = source ? ` by ${source}` : ``;
-				problems.push(`Your team has the combination of ${rule}, which is banned${clause}.`);
-			}
-		}
-
-		for (const rule of ruleTable.keys()) {
-			if ('!+-'.includes(rule.charAt(0))) continue;
-			const subformat = dex.formats.get(rule);
-			if (subformat.onValidateTeam && ruleTable.has(subformat.id)) {
-				problems = problems.concat(subformat.onValidateTeam.call(this, team, format, teamHas) || []);
-			}
-		}
-		if (format.onValidateTeam) {
-			problems = problems.concat(format.onValidateTeam.call(this, team, format, teamHas) || []);
-		}
-
-		if (!problems.length) return null;
-		return problems;
-	}
-
-	getEventOnlyData(species: Species, noRecurse?: boolean): {species: Species, eventData: EventInfo[]} | null {
-		const dex = this.dex;
-		const learnset = dex.species.getLearnsetData(species.id);
-		if (!learnset?.eventOnly) {
-			if (noRecurse) return null;
-			return this.getEventOnlyData(dex.species.get(species.prevo), true);
-		}
-
-		if (!learnset.eventData && species.forme) {
-			return this.getEventOnlyData(dex.species.get(species.baseSpecies), true);
-		}
-		if (!learnset.eventData) {
-			throw new Error(`Event-only species ${species.name} has no eventData table`);
-		}
-
-		return {species, eventData: learnset.eventData};
-	}
-
-	validateSet(set: PokemonSet, teamHas: AnyObject): string[] | null {
-		const format = this.format;
-		const dex = this.dex;
-		const ruleTable = this.ruleTable;
-
-		let problems: string[] = [];
-		if (!set) {
-			return [`This is not a Pokemon.`];
-		}
-
-		let species = dex.species.get(set.species);
-		set.species = species.name;
-		// Backwards compatability with old Gmax format
-		if (set.species.toLowerCase().endsWith('-gmax') && this.format.id !== 'gen8megamax') {
-			set.species = set.species.slice(0, -5);
-			species = dex.species.get(set.species);
-			if (set.name && set.name.endsWith('-Gmax')) set.name = species.baseSpecies;
-			set.gigantamax = true;
-		}
-		if (set.name && set.name.length > 18) {
-			if (set.name === set.species) {
-				set.name = species.baseSpecies;
-			} else {
-				problems.push(`Nickname "${set.name}" too long (should be 18 characters or fewer)`);
-			}
-		}
-		set.name = dex.getName(set.name);
-		let item = dex.items.get(Utils.getString(set.item));
-		set.item = item.name;
-		let ability = dex.abilities.get(Utils.getString(set.ability));
-		set.ability = ability.name;
-		let nature = dex.natures.get(Utils.getString(set.nature));
-		set.nature = nature.name;
-		if (!Array.isArray(set.moves)) set.moves = [];
-
-		set.name = set.name || species.baseSpecies;
-		let name = set.species;
-		if (set.species !== set.name && species.baseSpecies !== set.name) {
-			name = `${set.name} (${set.species})`;
-		}
-
-		if (!set.level) set.level = ruleTable.defaultLevel;
-
-		let adjustLevel = ruleTable.adjustLevel;
-		if (ruleTable.adjustLevelDown && set.level >= ruleTable.adjustLevelDown) {
-			adjustLevel = ruleTable.adjustLevelDown;
-		}
-		if (set.level === adjustLevel || (set.level === 100 && ruleTable.maxLevel < 100)) {
-			// Note that we're temporarily setting level 50 pokemon in VGC to level 100
-			// This allows e.g. level 50 Hydreigon even though it doesn't evolve until level 64.
-			// Leveling up can't make an obtainable pokemon unobtainable, so this is safe.
-			// Just remember to set the level back to adjustLevel at the end of validation.
-			set.level = ruleTable.maxLevel;
-		}
-		if (set.level < ruleTable.minLevel) {
-			problems.push(`${name} (level ${set.level}) is below the minimum level of ${ruleTable.minLevel}${ruleTable.blame('minlevel')}`);
-		}
-		if (set.level > ruleTable.maxLevel) {
-			problems.push(`${name} (level ${set.level}) is above the maximum level of ${ruleTable.maxLevel}${ruleTable.blame('maxlevel')}`);
-		}
-
-		const setHas: {[k: string]: true} = {};
-
-		if (!set.evs) set.evs = TeamValidator.fillStats(null, ruleTable.evLimit === null ? 252 : 0);
-		if (!set.ivs) set.ivs = TeamValidator.fillStats(null, 31);
-
-		if (ruleTable.has('obtainableformes')) {
-			problems.push(...this.validateForme(set));
-			species = dex.species.get(set.species);
-		}
-		const setSources = this.allSources(species);
-
-		for (const [rule] of ruleTable) {
-			if ('!+-'.includes(rule.charAt(0))) continue;
-			const subformat = dex.formats.get(rule);
-			if (subformat.onChangeSet && ruleTable.has(subformat.id)) {
-				problems = problems.concat(subformat.onChangeSet.call(this, set, format, setHas, teamHas) || []);
-			}
-		}
-		if (format.onChangeSet) {
-			problems = problems.concat(format.onChangeSet.call(this, set, format, setHas, teamHas) || []);
-		}
-
-		// onChangeSet can modify set.species, set.item, set.ability
-		species = dex.species.get(set.species);
-		item = dex.items.get(set.item);
-		ability = dex.abilities.get(set.ability);
-
-		let outOfBattleSpecies = species;
-		let tierSpecies = species;
-		if (ability.id === 'battlebond' && species.id === 'greninja') {
-			outOfBattleSpecies = dex.species.get('greninjaash');
-			if (ruleTable.has('obtainableformes')) {
-				tierSpecies = outOfBattleSpecies;
-			}
-			if (ruleTable.has('obtainablemisc')) {
-				if (set.gender && set.gender !== 'M') {
-					problems.push(`Battle Bond Greninja must be male.`);
-				}
-				set.gender = 'M';
-			}
-		}
-		if (ability.id === 'owntempo' && species.id === 'rockruff') {
-			tierSpecies = outOfBattleSpecies = dex.species.get('rockruffdusk');
-		}
-		if (species.id === 'melmetal' && set.gigantamax && this.dex.species.getLearnsetData(species.id).eventData) {
-			setSources.sourcesBefore = 0;
-			setSources.sources = ['8S0 melmetal'];
-		}
-		if (!species.exists) {
-			return [`The Pokemon "${set.species}" does not exist.`];
-		}
-
-		if (item.id && !item.exists) {
-			return [`"${set.item}" is an invalid item.`];
-		}
-		if (ability.id && !ability.exists) {
-			if (dex.gen < 3) {
-				// gen 1-2 don't have abilities, just silently remove
-				ability = dex.abilities.get('');
-				set.ability = '';
-			} else {
-				return [`"${set.ability}" is an invalid ability.`];
-			}
-		}
-		if (nature.id && !nature.exists) {
-			if (dex.gen < 3) {
-				// gen 1-2 don't have natures, just remove them
-				nature = dex.natures.get('');
-				set.nature = '';
-			} else {
-				problems.push(`"${set.nature}" is an invalid nature.`);
-			}
-		}
-		if (set.happiness !== undefined && isNaN(set.happiness)) {
-			problems.push(`${name} has an invalid happiness value.`);
-		}
-		if (set.hpType) {
-			const type = dex.types.get(set.hpType);
-			if (!type.exists || ['normal', 'fairy'].includes(type.id)) {
-				problems.push(`${name}'s Hidden Power type (${set.hpType}) is invalid.`);
-			} else {
-				set.hpType = type.name;
-			}
-		}
-
-		if (ruleTable.has('obtainableformes')) {
-			const canMegaEvo = dex.gen <= 7 || ruleTable.has('standardnatdex');
-			if (item.megaEvolves === species.name) {
-				if (!item.megaStone) throw new Error(`Item ${item.name} has no base form for mega evolution`);
-				tierSpecies = dex.species.get(item.megaStone);
-			} else if (item.id === 'redorb' && species.id === 'groudon') {
-				tierSpecies = dex.species.get('Groudon-Primal');
-			} else if (item.id === 'blueorb' && species.id === 'kyogre') {
-				tierSpecies = dex.species.get('Kyogre-Primal');
-			} else if (canMegaEvo && species.id === 'rayquaza' && set.moves.map(toID).includes('dragonascent' as ID)) {
-				tierSpecies = dex.species.get('Rayquaza-Mega');
-			} else if (item.id === 'rustedsword' && species.id === 'zacian') {
-				tierSpecies = dex.species.get('Zacian-Crowned');
-			} else if (item.id === 'rustedshield' && species.id === 'zamazenta') {
-				tierSpecies = dex.species.get('Zamazenta-Crowned');
-			}
-		}
-
-		let problem = this.checkSpecies(set, species, tierSpecies, setHas);
-		if (problem) problems.push(problem);
-
-		problem = this.checkItem(set, item, setHas);
-		if (problem) problems.push(problem);
-		if (ruleTable.has('obtainablemisc')) {
-			if (dex.gen === 4 && item.id === 'griseousorb' && species.num !== 487) {
-				problems.push(`${set.name} cannot hold the Griseous Orb.`, `(In Gen 4, only Giratina could hold the Griseous Orb).`);
-			}
-			if (dex.gen <= 1) {
-				if (item.id) {
-					// no items allowed
-					set.item = '';
-				}
-			}
-		}
-
-		if (!set.ability) set.ability = 'No Ability';
-		if (ruleTable.has('obtainableabilities')) {
-			if (dex.gen <= 2 || dex.currentMod === 'gen7letsgo') {
-				set.ability = 'No Ability';
-			} else {
-				if (!ability.name || ability.name === 'No Ability') {
-					problems.push(`${name} needs to have an ability.`);
-				} else if (!Object.values(species.abilities).includes(ability.name)) {
-					if (tierSpecies.abilities[0] === ability.name) {
-						set.ability = species.abilities[0];
-					} else {
-						problems.push(`${name} can't have ${set.ability}.`);
-					}
-				}
-				if (ability.name === species.abilities['H']) {
-					setSources.isHidden = true;
-
-					let unreleasedHidden = species.unreleasedHidden;
-					if (unreleasedHidden === 'Past' && this.minSourceGen < dex.gen) unreleasedHidden = false;
-
-					if (unreleasedHidden && ruleTable.has('-unreleased')) {
-						problems.push(`${name}'s Hidden Ability is unreleased.`);
-					} else if (dex.gen === 7 && ['entei', 'suicune', 'raikou'].includes(species.id) && this.minSourceGen > 1) {
-						problems.push(`${name}'s Hidden Ability is only available from Virtual Console, which is not allowed in this format.`);
-					} else if (dex.gen === 6 && ability.name === 'Symbiosis' &&
-						(set.species.endsWith('Orange') || set.species.endsWith('White'))) {
-						problems.push(`${name}'s Hidden Ability is unreleased for the Orange and White forms.`);
-					} else if (dex.gen === 5 && set.level < 10 && (species.maleOnlyHidden || species.gender === 'N')) {
-						problems.push(`${name} must be at least level 10 to have a Hidden Ability.`);
-					}
-					if (species.maleOnlyHidden) {
-						if (set.gender && set.gender !== 'M') {
-							problems.push(`${name} must be male to have a Hidden Ability.`);
-						}
-						set.gender = 'M';
-						setSources.sources = ['5D'];
-					}
-				} else {
-					setSources.isHidden = false;
-				}
-			}
-		}
-
-		ability = dex.abilities.get(set.ability);
-		problem = this.checkAbility(set, ability, setHas);
-		if (problem) problems.push(problem);
-
-		if (!set.nature || dex.gen <= 2) {
-			set.nature = '';
-		}
-		nature = dex.natures.get(set.nature);
-		problem = this.checkNature(set, nature, setHas);
-		if (problem) problems.push(problem);
-
-		if (set.moves && Array.isArray(set.moves)) {
-			set.moves = set.moves.filter(val => val);
-		}
-		if (!set.moves?.length) {
-			problems.push(`${name} has no moves (it must have at least one to be usable).`);
-			set.moves = [];
-		}
-		if (set.moves.length > ruleTable.maxMoveCount) {
-			problems.push(`${name} has ${set.moves.length} moves, which is more than the limit of ${ruleTable.maxMoveCount}.`);
-			return problems;
-		}
-
-		if (ruleTable.isBanned('nonexistent')) {
-			problems.push(...this.validateStats(set, species, setSources));
-		}
-
-		for (const moveName of set.moves) {
-			if (!moveName) continue;
-			const move = dex.moves.get(Utils.getString(moveName));
-			if (!move.exists) return [`"${move.name}" is an invalid move.`];
-
-			problem = this.checkMove(set, move, setHas);
-			if (problem) problems.push(problem);
-		}
-
-		if (ruleTable.has('obtainablemoves')) {
-			problems.push(...this.validateMoves(outOfBattleSpecies, set.moves, setSources, set, name));
-		}
-
-		const learnsetSpecies = dex.species.getLearnsetData(outOfBattleSpecies.id);
-		let eventOnlyData;
-
-		if (!setSources.sourcesBefore && setSources.sources.length) {
-			let legal = false;
-			for (const source of setSources.sources) {
-				if (this.validateSource(set, source, setSources, outOfBattleSpecies)) continue;
-				legal = true;
-				break;
-			}
-
-			if (!legal) {
-				let nonEggSource = null;
-				for (const source of setSources.sources) {
-					if (source.charAt(1) !== 'E') {
-						nonEggSource = source;
-						break;
-					}
-				}
-				if (!nonEggSource) {
-					// all egg moves
-					problems.push(`${name} can't get its egg move combination (${setSources.limitedEggMoves!.join(', ')}) from any possible father.`);
-					problems.push(`(Is this incorrect? If so, post the chainbreeding instructions in Bug Reports)`);
-				} else {
-					if (setSources.sources.length > 1) {
-						problems.push(`${name} has an event-exclusive move that it doesn't qualify for (only one of several ways to get the move will be listed):`);
-					}
-					const eventProblems = this.validateSource(
-						set, nonEggSource, setSources, outOfBattleSpecies, ` because it has a move only available`
-					);
-					if (eventProblems) problems.push(...eventProblems);
-				}
-			}
-		} else if (ruleTable.has('obtainablemisc') && (eventOnlyData = this.getEventOnlyData(outOfBattleSpecies))) {
-			const {species: eventSpecies, eventData} = eventOnlyData;
-			let legal = false;
-			for (const event of eventData) {
-				if (this.validateEvent(set, setSources, event, eventSpecies)) continue;
-				legal = true;
-				break;
-			}
-			if (!legal && species.gen <= 2 && dex.gen >= 7 && !this.validateSource(set, '7V', setSources, species)) {
-				legal = true;
-			}
-			if (!legal) {
-				if (eventData.length === 1) {
-					problems.push(`${species.name} is only obtainable from an event - it needs to match its event:`);
-				} else {
-					problems.push(`${species.name} is only obtainable from events - it needs to match one of its events:`);
-				}
-				for (const [i, event] of eventData.entries()) {
-					if (event.generation <= dex.gen && event.generation >= this.minSourceGen) {
-						const eventInfo = event;
-						const eventNum = i + 1;
-						const eventName = eventData.length > 1 ? ` #${eventNum}` : ``;
-						const eventProblems = this.validateEvent(
-							set, setSources, eventInfo, eventSpecies, ` to be`, `from its event${eventName}`
-						);
-						if (eventProblems) problems.push(...eventProblems);
-					}
-				}
-			}
-		}
-
-		let isFromRBYEncounter = false;
-		if (this.gen === 1 && ruleTable.has('obtainablemisc') && !this.ruleTable.has('allowtradeback')) {
-			let lowestEncounterLevel;
-			for (const encounter of learnsetSpecies.encounters || []) {
-				if (encounter.generation !== 1) continue;
-				if (!encounter.level) continue;
-				if (lowestEncounterLevel && encounter.level > lowestEncounterLevel) continue;
-
-				lowestEncounterLevel = encounter.level;
-			}
-
-			if (lowestEncounterLevel) {
-				if (set.level < lowestEncounterLevel) {
-					problems.push(`${name} is not obtainable at levels below ${lowestEncounterLevel} in Gen 1.`);
-				}
-				isFromRBYEncounter = true;
-			}
-		}
-		if (!isFromRBYEncounter && ruleTable.has('obtainablemisc')) {
-			// FIXME: Event pokemon given at a level under what it normally can be attained at gives a false positive
-			let evoSpecies = species;
-			while (evoSpecies.prevo) {
-				if (set.level < (evoSpecies.evoLevel || 0)) {
-					problems.push(`${name} must be at least level ${evoSpecies.evoLevel} to be evolved.`);
-					break;
-				}
-				evoSpecies = dex.species.get(evoSpecies.prevo);
-			}
-		}
-
-		if (ruleTable.has('obtainablemoves')) {
-			if (species.id === 'keldeo' && set.moves.includes('secretsword') && this.minSourceGen > 5 && dex.gen <= 7) {
-				problems.push(`${name} has Secret Sword, which is only compatible with Keldeo-Ordinary obtained from Gen 5.`);
-			}
-			const requiresGen3Source = setSources.maxSourceGen() <= 3;
-			if (requiresGen3Source && dex.abilities.get(set.ability).gen === 4 && !species.prevo && dex.gen <= 5) {
-				// Ability Capsule allows this in Gen 6+
-				problems.push(`${name} has a Gen 4 ability and isn't evolved - it can't use moves from Gen 3.`);
-			}
-			const canUseAbilityPatch = dex.gen >= 8 && format.mod !== 'gen8dlc1';
-			if (setSources.isHidden && !canUseAbilityPatch && setSources.maxSourceGen() < 5) {
-				problems.push(`${name} has a Hidden Ability - it can't use moves from before Gen 5.`);
-			}
-			if (
-				species.maleOnlyHidden && setSources.isHidden && setSources.sourcesBefore < 5 &&
-				setSources.sources.every(source => source.charAt(1) === 'E')
-			) {
-				problems.push(`${name} has an unbreedable Hidden Ability - it can't use egg moves.`);
-			}
-		}
-
-		if (teamHas) {
-			for (const i in setHas) {
-				if (i in teamHas) {
-					teamHas[i]++;
-				} else {
-					teamHas[i] = 1;
-				}
-			}
-		}
-		for (const [rule, source, limit, bans] of ruleTable.complexBans) {
-			let count = 0;
-			for (const ban of bans) {
-				if (setHas[ban]) count++;
-			}
-			if (limit && count > limit) {
-				const clause = source ? ` by ${source}` : ``;
-				problems.push(`${name} is limited to ${limit} of ${rule}${clause}.`);
-			} else if (!limit && count >= bans.length) {
-				const clause = source ? ` by ${source}` : ``;
-				if (source === 'Obtainable Moves') {
-					problems.push(`${name} has the combination of ${rule}, which is impossible to obtain legitimately.`);
-				} else {
-					problems.push(`${name} has the combination of ${rule}, which is banned${clause}.`);
-				}
-			}
-		}
-
-		for (const [rule] of ruleTable) {
-			if ('!+-'.includes(rule.charAt(0))) continue;
-			const subformat = dex.formats.get(rule);
-			if (subformat.onValidateSet && ruleTable.has(subformat.id)) {
-				problems = problems.concat(subformat.onValidateSet.call(this, set, format, setHas, teamHas) || []);
-			}
-		}
-		if (format.onValidateSet) {
-			problems = problems.concat(format.onValidateSet.call(this, set, format, setHas, teamHas) || []);
-		}
-
-		const nameSpecies = dex.species.get(set.name);
-		if (nameSpecies.exists && nameSpecies.name.toLowerCase() === set.name.toLowerCase()) {
-			// nickname is the name of a species
-			if (nameSpecies.baseSpecies === species.baseSpecies) {
-				set.name = species.baseSpecies;
-			} else if (nameSpecies.name !== species.name && nameSpecies.name !== species.baseSpecies) {
-				// nickname species doesn't match actual species
-				// Nickname Clause
-				problems.push(`${name} must not be nicknamed a different Pokémon species than what it actually is.`);
-			}
-		}
-
-		if (!problems.length) {
-			if (adjustLevel) set.level = adjustLevel;
-			return null;
-		}
-
-		return problems;
-	}
-
-	validateStats(set: PokemonSet, species: Species, setSources: PokemonSources) {
-		const ruleTable = this.ruleTable;
-		const dex = this.dex;
-
-		const allowAVs = ruleTable.has('allowavs');
-		const evLimit = ruleTable.evLimit;
-		const canBottleCap = dex.gen >= 7 && (set.level >= 100 || !ruleTable.has('obtainablemisc'));
-
-		if (!set.evs) set.evs = TeamValidator.fillStats(null, evLimit === null ? 252 : 0);
-		if (!set.ivs) set.ivs = TeamValidator.fillStats(null, 31);
-
-		const problems = [];
-		const name = set.name || set.species;
-
-		const maxedIVs = Object.values(set.ivs).every(stat => stat === 31);
-		for (const moveName of set.moves) {
-			const move = dex.moves.get(moveName);
-			if (move.id === 'hiddenpower' && move.type !== 'Normal') {
-				if (!set.hpType) {
-					set.hpType = move.type;
-				} else if (set.hpType !== move.type && ruleTable.has('obtainablemisc')) {
-					problems.push(`${name}'s Hidden Power type ${set.hpType} is incompatible with Hidden Power ${move.type}`);
-				}
-			}
-		}
-		if (set.hpType && maxedIVs && ruleTable.has('obtainablemisc')) {
-			if (dex.gen <= 2) {
-				const HPdvs = dex.types.get(set.hpType).HPdvs;
-				set.ivs = {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30};
-				let statName: StatID;
-				for (statName in HPdvs) {
-					set.ivs[statName] = HPdvs[statName]! * 2;
-				}
-				set.ivs.hp = -1;
-			} else if (!canBottleCap) {
-				set.ivs = TeamValidator.fillStats(dex.types.get(set.hpType).HPivs, 31);
-			}
-		}
-
-		const cantBreedNorEvolve = (species.eggGroups[0] === 'Undiscovered' && !species.prevo && !species.nfe);
-		const isLegendary = (cantBreedNorEvolve && ![
-			'Pikachu', 'Unown', 'Dracozolt', 'Arctozolt', 'Dracovish', 'Arctovish',
-		].includes(species.baseSpecies)) || [
-			'Manaphy', 'Cosmog', 'Cosmoem', 'Solgaleo', 'Lunala',
-		].includes(species.baseSpecies);
-		const diancieException = species.name === 'Diancie' && !set.shiny;
-		const has3PerfectIVs = setSources.minSourceGen() >= 6 && isLegendary && !diancieException;
-
-		if (set.hpType === 'Fighting' && ruleTable.has('obtainablemisc')) {
-			if (has3PerfectIVs) {
-				// Legendary Pokemon must have at least 3 perfect IVs in gen 6+
-				problems.push(`${name} must not have Hidden Power Fighting because it starts with 3 perfect IVs because it's a Gen 6+ legendary.`);
-			}
-		}
-
-		if (has3PerfectIVs && ruleTable.has('obtainablemisc')) {
-			let perfectIVs = 0;
-			for (const stat in set.ivs) {
-				if (set.ivs[stat as 'hp'] >= 31) perfectIVs++;
-			}
-			if (perfectIVs < 3) {
-				const reason = (this.minSourceGen === 6 ? ` and this format requires Gen ${dex.gen} Pokémon` : ` in Gen 6 or later`);
-				problems.push(`${name} must have at least three perfect IVs because it's a legendary${reason}.`);
-			}
-		}
-
-		if (set.hpType && !canBottleCap) {
-			const ivHpType = dex.getHiddenPower(set.ivs).type;
-			if (set.hpType !== ivHpType) {
-				problems.push(`${name} has Hidden Power ${set.hpType}, but its IVs are for Hidden Power ${ivHpType}.`);
-			}
-		} else if (set.hpType) {
-			if (!this.possibleBottleCapHpType(set.hpType, set.ivs)) {
-				problems.push(`${name} has Hidden Power ${set.hpType}, but its IVs don't allow this even with (Bottle Cap) Hyper Training.`);
-			}
-		}
-
-		if (dex.gen <= 2) {
-			// validate DVs
-			const ivs = set.ivs;
-			const atkDV = Math.floor(ivs.atk / 2);
-			const defDV = Math.floor(ivs.def / 2);
-			const speDV = Math.floor(ivs.spe / 2);
-			const spcDV = Math.floor(ivs.spa / 2);
-			const expectedHpDV = (atkDV % 2) * 8 + (defDV % 2) * 4 + (speDV % 2) * 2 + (spcDV % 2);
-			if (ivs.hp === -1) ivs.hp = expectedHpDV * 2;
-			const hpDV = Math.floor(ivs.hp / 2);
-			if (expectedHpDV !== hpDV) {
-				problems.push(`${name} has an HP DV of ${hpDV}, but its Atk, Def, Spe, and Spc DVs give it an HP DV of ${expectedHpDV}.`);
-			}
-			if (ivs.spa !== ivs.spd) {
-				if (dex.gen === 2) {
-					problems.push(`${name} has different SpA and SpD DVs, which is not possible in Gen 2.`);
-				} else {
-					ivs.spd = ivs.spa;
-				}
-			}
-			if (dex.gen > 1 && !species.gender) {
-				// Gen 2 gender is calculated from the Atk DV.
-				// High Atk DV <-> M. The meaning of "high" depends on the gender ratio.
-				const genderThreshold = species.genderRatio.F * 16;
-
-				const expectedGender = (atkDV >= genderThreshold ? 'M' : 'F');
-				if (set.gender && set.gender !== expectedGender) {
-					problems.push(`${name} is ${set.gender}, but it has an Atk DV of ${atkDV}, which makes its gender ${expectedGender}.`);
-				} else {
-					set.gender = expectedGender;
-				}
-			}
-			if (
-				set.species === 'Marowak' && toID(set.item) === 'thickclub' &&
-				set.moves.map(toID).includes('swordsdance' as ID) && set.level === 100
-			) {
-				// Marowak hack
-				set.ivs.atk = Math.floor(set.ivs.atk / 2) * 2;
-				while (set.evs.atk > 0 && 2 * 80 + set.ivs.atk + Math.floor(set.evs.atk / 4) + 5 > 255) {
-					set.evs.atk -= 4;
-				}
-			}
-			if (dex.gen > 1) {
-				const expectedShiny = !!(defDV === 10 && speDV === 10 && spcDV === 10 && atkDV % 4 >= 2);
-				if (expectedShiny && !set.shiny) {
-					problems.push(`${name} is not shiny, which does not match its DVs.`);
-				} else if (!expectedShiny && set.shiny) {
-					problems.push(`${name} is shiny, which does not match its DVs (its DVs must all be 10, except Atk which must be 2, 3, 6, 7, 10, 11, 14, or 15).`);
-				}
-			}
-			set.nature = 'Serious';
-		}
-
-		for (const stat in set.evs) {
-			if (set.evs[stat as 'hp'] < 0) {
-				problems.push(`${name} has less than 0 ${allowAVs ? 'Awakening Values' : 'EVs'} in ${Dex.stats.names[stat as 'hp']}.`);
-			}
-		}
-
-		if (dex.currentMod === 'gen7letsgo') { // AVs
-			for (const stat in set.evs) {
-				if (set.evs[stat as 'hp'] > 0 && !allowAVs) {
-					problems.push(`${name} has Awakening Values but this format doesn't allow them.`);
-					break;
-				} else if (set.evs[stat as 'hp'] > 200) {
-					problems.push(`${name} has more than 200 Awakening Values in ${Dex.stats.names[stat as 'hp']}.`);
-				}
-			}
-		} else { // EVs
-			for (const stat in set.evs) {
-				if (set.evs[stat as StatID] > 255) {
-					problems.push(`${name} has more than 255 EVs in ${Dex.stats.names[stat as 'hp']}.`);
-				}
-			}
-			if (dex.gen <= 2) {
-				if (set.evs.spa !== set.evs.spd) {
-					if (dex.gen === 2) {
-						problems.push(`${name} has different SpA and SpD EVs, which is not possible in Gen 2.`);
-					} else {
-						set.evs.spd = set.evs.spa;
-					}
-				}
-			}
-		}
-
-		let totalEV = 0;
-		for (const stat in set.evs) totalEV += set.evs[stat as 'hp'];
-		if (!this.format.debug) {
-			if (set.level > 1 && evLimit !== 0 && totalEV === 0) {
-				problems.push(`${name} has exactly 0 EVs - did you forget to EV it? (If this was intentional, add exactly 1 to one of your EVs, which won't change its stats but will tell us that it wasn't a mistake).`);
-			} else if (![508, 510].includes(evLimit!) && [508, 510].includes(totalEV)) {
-				problems.push(`${name} has exactly ${totalEV} EVs, but this format does not restrict you to 510 EVs (If this was intentional, add exactly 1 to one of your EVs, which won't change its stats but will tell us that it wasn't a mistake).`);
-			}
-			// Check for level import errors from user in VGC -> DOU, etc.
-			// Note that in VGC etc (Adjust Level Down = 50), `set.level` will be 100 here for validation purposes
-			if (set.level === 50 && ruleTable.maxLevel !== 50 && !ruleTable.maxTotalLevel && evLimit !== 0 && totalEV % 4 === 0) {
-				problems.push(`${name} is level 50, but this format allows level ${ruleTable.maxLevel} Pokémon. (If this was intentional, add exactly 1 to one of your EVs, which won't change its stats but will tell us that it wasn't a mistake).`);
-			}
-		}
-
-		if (evLimit !== null && totalEV > evLimit) {
-			if (!evLimit) {
-				problems.push(`${name} has EVs, which is not allowed by this format.`);
-			} else {
-				problems.push(`${name} has ${totalEV} total EVs, which is more than this format's limit of ${evLimit}.`);
-			}
-		}
-
-		return problems;
-	}
-
-	/**
-	 * Not exhaustive, just checks Atk and Spe, which are the only competitively
-	 * relevant IVs outside of extremely obscure situations.
-	 */
-	possibleBottleCapHpType(type: string, ivs: StatsTable) {
-		if (!type) return true;
-		if (['Dark', 'Dragon', 'Grass', 'Ghost', 'Poison'].includes(type)) {
-			// Spe must be odd
-			if (ivs.spe % 2 === 0) return false;
-		}
-		if (['Psychic', 'Fire', 'Rock', 'Fighting'].includes(type)) {
-			// Spe must be even
-			if (ivs.spe !== 31 && ivs.spe % 2 === 1) return false;
-		}
-		if (type === 'Dark') {
-			// Atk must be odd
-			if (ivs.atk % 2 === 0) return false;
-		}
-		if (['Ice', 'Water'].includes(type)) {
-			// Spe or Atk must be odd
-			if (ivs.spe % 2 === 0 && ivs.atk % 2 === 0) return false;
-		}
-		return true;
-	}
-
-	validateSource(
-		set: PokemonSet, source: PokemonSource, setSources: PokemonSources, species: Species, because: string
-	): string[] | undefined;
-	validateSource(
-		set: PokemonSet, source: PokemonSource, setSources: PokemonSources, species: Species
-	): true | undefined;
-	/**
-	 * Returns array of error messages if invalid, undefined if valid
-	 *
-	 * If `because` is not passed, instead returns true if invalid.
-	 */
-	validateSource(
-		set: PokemonSet, source: PokemonSource, setSources: PokemonSources, species: Species, because?: string
-	) {
-		let eventData: EventInfo | undefined;
-		let eventSpecies = species;
-		if (source.charAt(1) === 'S') {
-			const splitSource = source.substr(source.charAt(2) === 'T' ? 3 : 2).split(' ');
-			const dex = (this.dex.gen === 1 ? this.dex.mod('gen2') : this.dex);
-			eventSpecies = dex.species.get(splitSource[1]);
-			const eventLsetData = this.dex.species.getLearnsetData(eventSpecies.id);
-			eventData = eventLsetData.eventData?.[parseInt(splitSource[0])];
-			if (!eventData) {
-				throw new Error(`${eventSpecies.name} from ${species.name} doesn't have data for event ${source}`);
-			}
-		} else if (source === '7V') {
-			const isMew = species.id === 'mew';
-			const isCelebi = species.id === 'celebi';
-			const g7speciesName = (species.gen > 2 && species.prevo) ? species.prevo : species.id;
-			const isHidden = !!this.dex.mod('gen7').species.get(g7speciesName).abilities['H'];
-			eventData = {
-				generation: 2,
-				level: isMew ? 5 : isCelebi ? 30 : 3, // Level 1/2 Pokémon can't be obtained by transfer from RBY/GSC
-				perfectIVs: isMew || isCelebi ? 5 : 3,
-				isHidden,
-				shiny: isMew ? undefined : 1,
-				pokeball: 'pokeball',
-				from: 'Gen 1-2 Virtual Console transfer',
-			};
-		} else if (source === '8V') {
-			const isMew = species.id === 'mew';
-			eventData = {
-				generation: 8,
-				perfectIVs: isMew ? 3 : undefined,
-				shiny: isMew ? undefined : 1,
-				from: 'Gen 7 Let\'s Go! HOME transfer',
-			};
-		} else if (source.charAt(1) === 'D') {
-			eventData = {
-				generation: 5,
-				level: 10,
-				from: 'Gen 5 Dream World',
-				isHidden: !!this.dex.mod('gen5').species.get(species.id).abilities['H'],
-			};
-		} else if (source.charAt(1) === 'E') {
-			if (this.findEggMoveFathers(source, species, setSources)) {
-				return undefined;
-			}
-			if (because) throw new Error(`Wrong place to get an egg incompatibility message`);
-			return true;
-		} else {
-			throw new Error(`Unidentified source ${source} passed to validateSource`);
-		}
-
-		// complicated fancy return signature
-		return this.validateEvent(set, setSources, eventData, eventSpecies, because as any) as any;
-	}
-
-	findEggMoveFathers(source: PokemonSource, species: Species, setSources: PokemonSources): boolean;
-	findEggMoveFathers(source: PokemonSource, species: Species, setSources: PokemonSources, getAll: true): ID[] | null;
-	findEggMoveFathers(source: PokemonSource, species: Species, setSources: PokemonSources, getAll = false) {
-		// tradebacks have an eggGen of 2 even though the source is 1ET
-		const eggGen = Math.max(parseInt(source.charAt(0)), 2);
-		const fathers: ID[] = [];
-		// Gen 6+ don't have egg move incompatibilities
-		// (except for certain cases with baby Pokemon not handled here)
-		if (!getAll && eggGen >= 6) return true;
-
-		const eggMoves = setSources.limitedEggMoves;
-		// must have 2 or more egg moves to have egg move incompatibilities
-		if (!eggMoves) {
-			// happens often in gen 1-6 LC if your only egg moves are level-up moves,
-			// which aren't limited and so aren't in `limitedEggMoves`
-			return getAll ? ['*'] : true;
-		}
-		if (!getAll && eggMoves.length <= 1) return true;
-
-		// gen 1 eggs come from gen 2 breeding
-		const dex = this.dex.gen === 1 ? this.dex.mod('gen2') : this.dex;
-		// In Gen 5 and earlier, egg moves can only be inherited from the father
-		// we'll test each possible father separately
-		let eggGroups = species.eggGroups;
-		if (species.id === 'nidoqueen' || species.id === 'nidorina') {
-			eggGroups = dex.species.get('nidoranf').eggGroups;
-		} else if (species.id === 'shedinja') {
-			// Shedinja and Nincada are different Egg groups; Shedinja itself is genderless
-			eggGroups = dex.species.get('nincada').eggGroups;
-		} else if (dex !== this.dex) {
-			// Gen 1 tradeback; grab the egg groups from Gen 2
-			eggGroups = dex.species.get(species.id).eggGroups;
-		}
-		if (eggGroups[0] === 'Undiscovered') eggGroups = dex.species.get(species.evos[0]).eggGroups;
-		if (eggGroups[0] === 'Undiscovered' || !eggGroups.length) {
-			throw new Error(`${species.name} has no egg groups for source ${source}`);
-		}
-		// no chainbreeding necessary if the father can be Smeargle
-		if (!getAll && eggGroups.includes('Field')) return true;
-
-		// try to find a father to inherit the egg move combination from
-		for (const father of dex.species.all()) {
-			// can't inherit from CAP pokemon
-			if (father.isNonstandard) continue;
-			// can't breed mons from future gens
-			if (father.gen > eggGen) continue;
-			// father must be male
-			if (father.gender === 'N' || father.gender === 'F') continue;
-			// can't inherit from dex entries with no learnsets
-			if (!dex.species.getLearnset(father.id)) continue;
-			// something is clearly wrong if its only possible father is itself
-			// (exceptions: ExtremeSpeed Dragonite, Self-destruct Snorlax)
-			if (species.id === father.id && !['dragonite', 'snorlax'].includes(father.id)) continue;
-			// don't check NFE Pokémon - their evolutions will know all their moves and more
-			// exception: Combee/Salandit, because their evos can't be fathers
-			if (father.evos.length) {
-				const evolvedFather = dex.species.get(father.evos[0]);
-				if (evolvedFather.gen <= eggGen && evolvedFather.gender !== 'F') continue;
-			}
-
-			// must be able to breed with father
-			if (!father.eggGroups.some(eggGroup => eggGroups.includes(eggGroup))) continue;
-
-			// father must be able to learn the move
-			if (!this.fatherCanLearn(father, eggMoves, eggGen)) continue;
-
-			// father found!
-			if (!getAll) return true;
-			fathers.push(father.id);
-		}
-		if (!getAll) return false;
-		return (!fathers.length && eggGen < 6) ? null : fathers;
-	}
-
-	/**
-	 * We could, if we wanted, do a complete move validation of the father's
-	 * moveset to see if it's valid. This would recurse and be NP-Hard so
-	 * instead we won't. We'll instead use a simplified algorithm: The father
-	 * can learn the moveset if it has at most one egg/event move.
-	 *
-	 * `eggGen` should be 5 or earlier. Later gens should never call this
-	 * function (the answer is always yes).
-	 */
-	fatherCanLearn(species: Species, moves: ID[], eggGen: number) {
-		let learnset = this.dex.species.getLearnset(species.id);
-		if (!learnset) return false;
-
-		if (species.id === 'smeargle') return true;
-		const canBreedWithSmeargle = species.eggGroups.includes('Field');
-
-		let eggMoveCount = 0;
-		for (const move of moves) {
-			let curSpecies: Species | null = species;
-			/** 1 = can learn from egg, 2 = can learn unrestricted */
-			let canLearn: 0 | 1 | 2 = 0;
-
-			while (curSpecies) {
-				learnset = this.dex.species.getLearnset(curSpecies.id);
-				if (learnset && learnset[move]) {
-					for (const moveSource of learnset[move]) {
-						if (parseInt(moveSource.charAt(0)) > eggGen) continue;
-						const canLearnFromSmeargle = moveSource.charAt(1) === 'E' && canBreedWithSmeargle;
-						if (!'ESDV'.includes(moveSource.charAt(1)) || canLearnFromSmeargle) {
-							canLearn = 2;
-							break;
-						} else {
-							canLearn = 1;
-						}
-					}
-				}
-				if (canLearn === 2) break;
-				curSpecies = this.learnsetParent(curSpecies);
-			}
-
-			if (!canLearn) return false;
-			if (canLearn === 1) {
-				eggMoveCount++;
-				if (eggMoveCount > 1) return false;
-			}
-		}
-		return true;
-	}
-
-	validateForme(set: PokemonSet) {
-		const dex = this.dex;
-		const name = set.name || set.species;
-
-		const problems = [];
-		const item = dex.items.get(set.item);
-		const species = dex.species.get(set.species);
-
-		if (species.name === 'Necrozma-Ultra') {
-			const whichMoves = (set.moves.includes('sunsteelstrike') ? 1 : 0) +
-				(set.moves.includes('moongeistbeam') ? 2 : 0);
-			if (item.name !== 'Ultranecrozium Z') {
-				// Necrozma-Ultra transforms from one of two formes, and neither one is the base forme
-				problems.push(`Necrozma-Ultra must start the battle holding Ultranecrozium Z.`);
-			} else if (whichMoves === 1) {
-				set.species = 'Necrozma-Dusk-Mane';
-			} else if (whichMoves === 2) {
-				set.species = 'Necrozma-Dawn-Wings';
-			} else {
-				problems.push(`Necrozma-Ultra must start the battle as Necrozma-Dusk-Mane or Necrozma-Dawn-Wings holding Ultranecrozium Z. Please specify which Necrozma it should start as.`);
-			}
-		} else if (species.name === 'Zygarde-Complete') {
-			problems.push(`Zygarde-Complete must start the battle as Zygarde or Zygarde-10% with Power Construct. Please specify which Zygarde it should start as.`);
-		} else if (species.battleOnly) {
-			if (species.requiredAbility && set.ability !== species.requiredAbility) {
-				// Darmanitan-Zen
-				problems.push(`${species.name} transforms in-battle with ${species.requiredAbility}, please fix its ability.`);
-			}
-			if (species.requiredItems) {
-				if (!species.requiredItems.includes(item.name)) {
-					// Mega or Primal
-					problems.push(`${species.name} transforms in-battle with ${species.requiredItem}, please fix its item.`);
-				}
-			}
-			if (species.requiredMove && !set.moves.map(toID).includes(toID(species.requiredMove))) {
-				// Meloetta-Pirouette, Rayquaza-Mega
-				problems.push(`${species.name} transforms in-battle with ${species.requiredMove}, please fix its moves.`);
-			}
-			if (typeof species.battleOnly !== 'string') {
-				// Ultra Necrozma and Complete Zygarde are already checked above
-				throw new Error(`${species.name} should have a string battleOnly`);
-			}
-			// Set to out-of-battle forme
-			set.species = species.battleOnly;
-		} else {
-			if (species.requiredAbility) {
-				// Impossible!
-				throw new Error(`Species ${species.name} has a required ability despite not being a battle-only forme; it should just be in its abilities table.`);
-			}
-			if (species.requiredItems && !species.requiredItems.includes(item.name)) {
-				if (dex.gen >= 8 && (species.baseSpecies === 'Arceus' || species.baseSpecies === 'Silvally')) {
-					// Arceus/Silvally formes in gen 8 only require the item with Multitype/RKS System
-					if (set.ability === species.abilities[0]) {
-						problems.push(
-							`${name} needs to hold ${species.requiredItems.join(' or ')}.`,
-							`(It will revert to its Normal forme if you remove the item or give it a different item.)`
-						);
-					}
-				} else {
-					// Memory/Drive/Griseous Orb/Plate/Z-Crystal - Forme mismatch
-					const baseSpecies = this.dex.species.get(species.changesFrom);
-					problems.push(
-						`${name} needs to hold ${species.requiredItems.join(' or ')} to be in its ${species.forme} forme.`,
-						`(It will revert to its ${baseSpecies.baseForme || 'base'} forme if you remove the item or give it a different item.)`
-					);
-				}
-			}
-			if (species.requiredMove && !set.moves.map(toID).includes(toID(species.requiredMove))) {
-				const baseSpecies = this.dex.species.get(species.changesFrom);
-				problems.push(
-					`${name} needs to know the move ${species.requiredMove} to be in its ${species.forme} forme.`,
-					`(It will revert to its ${baseSpecies.baseForme} forme if it forgets the move.)`
-				);
-			}
-
-			// Mismatches between the set forme (if not base) and the item signature forme will have been rejected already.
-			// It only remains to assign the right forme to a set with the base species (Arceus/Genesect/Giratina/Silvally).
-			if (item.forcedForme && species.name === dex.species.get(item.forcedForme).baseSpecies) {
-				set.species = item.forcedForme;
-			}
-		}
-
-		if (species.name === 'Pikachu-Cosplay') {
-			const cosplay: {[k: string]: string} = {
-				meteormash: 'Pikachu-Rock-Star', iciclecrash: 'Pikachu-Belle', drainingkiss: 'Pikachu-Pop-Star',
-				electricterrain: 'Pikachu-PhD', flyingpress: 'Pikachu-Libre',
-			};
-			for (const moveid of set.moves) {
-				if (moveid in cosplay) {
-					set.species = cosplay[moveid];
-					break;
-				}
-			}
-		}
-
-		if (species.name === 'Keldeo' && set.moves.map(toID).includes('secretsword' as ID) && dex.gen >= 8) {
-			set.species = 'Keldeo-Resolute';
-		}
-
-		const crowned: {[k: string]: string} = {
-			'Zacian-Crowned': 'behemothblade', 'Zamazenta-Crowned': 'behemothbash',
-		};
-		if (species.name in crowned) {
-			const behemothMove = set.moves.map(toID).indexOf(crowned[species.name] as ID);
-			if (behemothMove >= 0) {
-				set.moves[behemothMove] = 'ironhead';
-			}
-		}
-		return problems;
-	}
-
-	checkSpecies(set: PokemonSet, species: Species, tierSpecies: Species, setHas: {[k: string]: true}) {
-		const dex = this.dex;
-		const ruleTable = this.ruleTable;
-
-		// https://www.smogon.com/forums/posts/8659168
-		if (
-			(tierSpecies.id === 'zamazentacrowned' && species.id === 'zamazenta') ||
-			(tierSpecies.id === 'zaciancrowned' && species.id === 'zacian')
-		) {
-			species = tierSpecies;
-		}
-
-		setHas['pokemon:' + species.id] = true;
-		setHas['basepokemon:' + toID(species.baseSpecies)] = true;
-
-		let isMega = false;
-		if (tierSpecies !== species) {
-			setHas['pokemon:' + tierSpecies.id] = true;
-			if (tierSpecies.isMega || tierSpecies.isPrimal) {
-				setHas['pokemontag:mega'] = true;
-				isMega = true;
-			}
-		}
-
-		let isGmax = false;
-		if (tierSpecies.canGigantamax && set.gigantamax) {
-			setHas['pokemon:' + tierSpecies.id + 'gmax'] = true;
-			isGmax = true;
-		}
-
-		const tier = tierSpecies.tier === '(PU)' ? 'ZU' : tierSpecies.tier === '(NU)' ? 'PU' : tierSpecies.tier;
-		const tierTag = 'pokemontag:' + toID(tier);
-		setHas[tierTag] = true;
-
-		const doublesTier = tierSpecies.doublesTier === '(DUU)' ? 'DNU' : tierSpecies.doublesTier;
-		const doublesTierTag = 'pokemontag:' + toID(doublesTier);
-		setHas[doublesTierTag] = true;
-
-		const ndTier = tierSpecies.natDexTier === '(PU)' ? 'ZU' :
-			tierSpecies.natDexTier === '(NU)' ? 'PU' : tierSpecies.natDexTier;
-		const ndTierTag = 'pokemontag:nd' + toID(ndTier);
-		setHas[ndTierTag] = true;
-
-		// Only pokemon that can gigantamax should have the Gmax flag
-		if (!tierSpecies.canGigantamax && set.gigantamax) {
-			return `${tierSpecies.name} cannot Gigantamax but is flagged as being able to.`;
-		}
-
-		let banReason = ruleTable.check('pokemon:' + species.id);
-		if (banReason) {
-			return `${species.name} is ${banReason}.`;
-		}
-		if (banReason === '') return null;
-
-		if (tierSpecies !== species) {
-			banReason = ruleTable.check('pokemon:' + tierSpecies.id);
-			if (banReason) {
-				return `${tierSpecies.name} is ${banReason}.`;
-			}
-			if (banReason === '') return null;
-		}
-
-		if (isMega) {
-			banReason = ruleTable.check('pokemontag:mega', setHas);
-			if (banReason) {
-				return `Mega evolutions are ${banReason}.`;
-			}
-		}
-
-		if (isGmax) {
-			banReason = ruleTable.check('pokemon:' + tierSpecies.id + 'gmax');
-			if (banReason) {
-				return `Gigantamaxing ${species.name} is ${banReason}.`;
-			}
-		}
-
-		banReason = ruleTable.check('basepokemon:' + toID(species.baseSpecies));
-		if (banReason) {
-			return `${species.name} is ${banReason}.`;
-		}
-		if (banReason === '') {
-			// don't allow nonstandard speciess when whitelisting standard base species
-			// i.e. unbanning Pichu doesn't mean allowing Pichu-Spiky-Eared outside of Gen 4
-			const baseSpecies = dex.species.get(species.baseSpecies);
-			if (baseSpecies.isNonstandard === species.isNonstandard) {
-				return null;
-			}
-		}
-
-		// We can't return here because the `-nonexistent` rule is a bit
-		// complicated in terms of what trumps it. We don't want e.g.
-		// +Mythical to unban Shaymin in Gen 1, for instance.
-		let nonexistentCheck = Tags.nonexistent.genericFilter!(tierSpecies) && ruleTable.check('nonexistent');
-
-		const EXISTENCE_TAG = ['past', 'future', 'lgpe', 'unobtainable', 'cap', 'custom', 'nonexistent'];
-
-		for (const ruleid of ruleTable.tagRules) {
-			if (ruleid.startsWith('*')) continue;
-			const tagid = ruleid.slice(12);
-			const tag = Tags[tagid];
-			if ((tag.speciesFilter || tag.genericFilter)!(tierSpecies)) {
-				const existenceTag = EXISTENCE_TAG.includes(tagid);
-				if (ruleid.startsWith('+')) {
-					// we want rules like +CAP to trump -Nonexistent, but most tags shouldn't
-					if (!existenceTag && nonexistentCheck) continue;
-					return null;
-				}
-				if (existenceTag) {
-					// for a nicer error message
-					nonexistentCheck = 'banned';
-					break;
-				}
-				return `${species.name} is tagged ${tag.name}, which is ${ruleTable.check(ruleid.slice(1)) || "banned"}.`;
-			}
-		}
-
-		if (nonexistentCheck) {
-			if (tierSpecies.isNonstandard === 'Past' || tierSpecies.isNonstandard === 'Future') {
-				return `${tierSpecies.name} does not exist in Gen ${dex.gen}.`;
-			}
-			if (tierSpecies.isNonstandard === 'LGPE') {
-				return `${tierSpecies.name} does not exist in this game, only in Let's Go Pikachu/Eevee.`;
-			}
-			if (tierSpecies.isNonstandard === 'CAP') {
-				return `${tierSpecies.name} is a CAP and does not exist in this game.`;
-			}
-			if (tierSpecies.isNonstandard === 'Unobtainable') {
-				return `${tierSpecies.name} is not possible to obtain in this game.`;
-			}
-			if (tierSpecies.isNonstandard === 'Gigantamax') {
-				return `${tierSpecies.name} is a placeholder for a Gigantamax sprite, not a real Pokémon. (This message is likely to be a validator bug.)`;
-			}
-			return `${tierSpecies.name} does not exist in this game.`;
-		}
-		if (nonexistentCheck === '') return null;
-
-		// Special casing for Pokemon that can Gmax, but their Gmax factor cannot be legally obtained
-		if (tierSpecies.gmaxUnreleased && set.gigantamax) {
-			banReason = ruleTable.check('pokemontag:unobtainable');
-			if (banReason) {
-				return `${tierSpecies.name} is flagged as gigantamax, but it cannot gigantamax without hacking or glitches.`;
-			}
-			if (banReason === '') return null;
-		}
-
-		banReason = ruleTable.check('pokemontag:allpokemon');
-		if (banReason) {
-			return `${species.name} is not in the list of allowed pokemon.`;
-		}
-
-		return null;
-	}
-
-	checkItem(set: PokemonSet, item: Item, setHas: {[k: string]: true}) {
-		const dex = this.dex;
-		const ruleTable = this.ruleTable;
-
-		setHas['item:' + item.id] = true;
-
-		let banReason = ruleTable.check('item:' + (item.id || 'noitem'));
-		if (banReason) {
-			if (!item.id) {
-				return `${set.name} not holding an item is ${banReason}.`;
-			}
-			return `${set.name}'s item ${item.name} is ${banReason}.`;
-		}
-		if (banReason === '') return null;
-
-		if (!item.id) return null;
-
-		banReason = ruleTable.check('pokemontag:allitems');
-		if (banReason) {
-			return `${set.name}'s item ${item.name} is not in the list of allowed items.`;
-		}
-
-		// obtainability
-		if (item.isNonstandard) {
-			banReason = ruleTable.check('pokemontag:' + toID(item.isNonstandard));
-			if (banReason) {
-				if (item.isNonstandard === 'Unobtainable') {
-					return `${item.name} is not obtainable without hacking or glitches.`;
-				}
-				return `${set.name}'s item ${item.name} is tagged ${item.isNonstandard}, which is ${banReason}.`;
-			}
-			if (banReason === '') return null;
-		}
-
-		if (item.isNonstandard && item.isNonstandard !== 'Unobtainable') {
-			banReason = ruleTable.check('nonexistent', setHas);
-			if (banReason) {
-				if (['Past', 'Future'].includes(item.isNonstandard)) {
-					return `${set.name}'s item ${item.name} does not exist in Gen ${dex.gen}.`;
-				}
-				return `${set.name}'s item ${item.name} does not exist in this game.`;
-			}
-			if (banReason === '') return null;
-		}
-
-		return null;
-	}
-
-	checkMove(set: PokemonSet, move: Move, setHas: {[k: string]: true}) {
-		const dex = this.dex;
-		const ruleTable = this.ruleTable;
-
-		setHas['move:' + move.id] = true;
-
-		let banReason = ruleTable.check('move:' + move.id);
-		if (banReason) {
-			return `${set.name}'s move ${move.name} is ${banReason}.`;
-		}
-		if (banReason === '') return null;
-
-		banReason = ruleTable.check('pokemontag:allmoves');
-		if (banReason) {
-			return `${set.name}'s move ${move.name} is not in the list of allowed moves.`;
-		}
-
-		// obtainability
-		if (move.isNonstandard) {
-			banReason = ruleTable.check('pokemontag:' + toID(move.isNonstandard));
-			if (banReason) {
-				if (move.isNonstandard === 'Unobtainable') {
-					return `${move.name} is not obtainable without hacking or glitches.`;
-				}
-				if (move.isNonstandard === 'Gigantamax') {
-					return `${move.name} is not usable without Gigantamaxing its user, ${move.isMax}.`;
-				}
-				return `${set.name}'s move ${move.name} is tagged ${move.isNonstandard}, which is ${banReason}.`;
-			}
-			if (banReason === '') return null;
-		}
-
-		if (move.isNonstandard && move.isNonstandard !== 'Unobtainable') {
-			banReason = ruleTable.check('nonexistent', setHas);
-			if (banReason) {
-				if (['Past', 'Future'].includes(move.isNonstandard)) {
-					return `${set.name}'s move ${move.name} does not exist in Gen ${dex.gen}.`;
-				}
-				return `${set.name}'s move ${move.name} does not exist in this game.`;
-			}
-			if (banReason === '') return null;
-		}
-
-		return null;
-	}
-
-	checkAbility(set: PokemonSet, ability: Ability, setHas: {[k: string]: true}) {
-		const dex = this.dex;
-		const ruleTable = this.ruleTable;
-
-		setHas['ability:' + ability.id] = true;
-
-		if (this.format.id.startsWith('gen8pokebilities')) {
-			const species = dex.species.get(set.species);
-			const unSeenAbilities = Object.keys(species.abilities)
-				.filter(key => key !== 'S' && (key !== 'H' || !species.unreleasedHidden))
-				.map(key => species.abilities[key as "0" | "1" | "H" | "S"]);
-
-			if (ability.id !== this.toID(species.abilities['S'])) {
-				for (const abilityName of unSeenAbilities) {
-					setHas['ability:' + toID(abilityName)] = true;
-				}
-			}
-		}
-
-		let banReason = ruleTable.check('ability:' + ability.id);
-		if (banReason) {
-			return `${set.name}'s ability ${ability.name} is ${banReason}.`;
-		}
-		if (banReason === '') return null;
-
-		banReason = ruleTable.check('pokemontag:allabilities');
-		if (banReason) {
-			return `${set.name}'s ability ${ability.name} is not in the list of allowed abilities.`;
-		}
-
-		// obtainability
-		if (ability.isNonstandard) {
-			banReason = ruleTable.check('pokemontag:' + toID(ability.isNonstandard));
-			if (banReason) {
-				return `${set.name}'s ability ${ability.name} is tagged ${ability.isNonstandard}, which is ${banReason}.`;
-			}
-			if (banReason === '') return null;
-
-			banReason = ruleTable.check('nonexistent', setHas);
-			if (banReason) {
-				if (['Past', 'Future'].includes(ability.isNonstandard)) {
-					return `${set.name}'s ability ${ability.name} does not exist in Gen ${dex.gen}.`;
-				}
-				return `${set.name}'s ability ${ability.name} does not exist in this game.`;
-			}
-			if (banReason === '') return null;
-		}
-
-		return null;
-	}
-
-	checkNature(set: PokemonSet, nature: Nature, setHas: {[k: string]: true}) {
-		const dex = this.dex;
-		const ruleTable = this.ruleTable;
-
-		setHas['nature:' + nature.id] = true;
-
-		let banReason = ruleTable.check('nature:' + nature.id);
-		if (banReason) {
-			return `${set.name}'s nature ${nature.name} is ${banReason}.`;
-		}
-		if (banReason === '') return null;
-
-		banReason = ruleTable.check('allnatures');
-		if (banReason) {
-			return `${set.name}'s nature ${nature.name} is not in the list of allowed natures.`;
-		}
-
-		// obtainability
-		if (nature.isNonstandard) {
-			banReason = ruleTable.check('pokemontag:' + toID(nature.isNonstandard));
-			if (banReason) {
-				return `${set.name}'s nature ${nature.name} is tagged ${nature.isNonstandard}, which is ${banReason}.`;
-			}
-			if (banReason === '') return null;
-
-			banReason = ruleTable.check('nonexistent', setHas);
-			if (banReason) {
-				if (['Past', 'Future'].includes(nature.isNonstandard)) {
-					return `${set.name}'s nature ${nature.name} does not exist in Gen ${dex.gen}.`;
-				}
-				return `${set.name}'s nature ${nature.name} does not exist in this game.`;
-			}
-			if (banReason === '') return null;
-		}
-		return null;
-	}
-
-	validateEvent(
-		set: PokemonSet, setSources: PokemonSources, eventData: EventInfo, eventSpecies: Species
-	): true | undefined;
-	validateEvent(
-		set: PokemonSet, setSources: PokemonSources, eventData: EventInfo, eventSpecies: Species,
-		because: string, from?: string
-	): string[] | undefined;
-	/**
-	 * Returns array of error messages if invalid, undefined if valid
-	 *
-	 * If `because` is not passed, instead returns true if invalid.
-	 */
-	validateEvent(
-		set: PokemonSet, setSources: PokemonSources, eventData: EventInfo, eventSpecies: Species,
-		because = ``, from = `from an event`
-	) {
-		const dex = this.dex;
-		let name = set.species;
-		const species = dex.species.get(set.species);
-		const maxSourceGen = this.ruleTable.has('allowtradeback') ? Utils.clampIntRange(dex.gen + 1, 1, 8) : dex.gen;
-		if (!eventSpecies) eventSpecies = species;
-		if (set.name && set.species !== set.name && species.baseSpecies !== set.name) name = `${set.name} (${set.species})`;
-
-		const fastReturn = !because;
-		if (eventData.from) from = `from ${eventData.from}`;
-		const etc = `${because} ${from}`;
-
-		const problems = [];
-
-		if (dex.gen < 8 && this.minSourceGen > eventData.generation) {
-			if (fastReturn) return true;
-			problems.push(`This format requires Pokemon from gen ${this.minSourceGen} or later and ${name} is from gen ${eventData.generation}${etc}.`);
-		}
-		if (maxSourceGen < eventData.generation) {
-			if (fastReturn) return true;
-			problems.push(`This format is in gen ${dex.gen} and ${name} is from gen ${eventData.generation}${etc}.`);
-		}
-
-		if (eventData.japan && dex.currentMod !== 'gen1jpn') {
-			if (fastReturn) return true;
-			problems.push(`${name} has moves from Japan-only events, but this format simulates International Yellow/Crystal which can't trade with Japanese games.`);
-		}
-
-		if (eventData.level && (set.level || 0) < eventData.level) {
-			if (fastReturn) return true;
-			problems.push(`${name} must be at least level ${eventData.level}${etc}.`);
-		}
-		if ((eventData.shiny === true && !set.shiny) || (!eventData.shiny && set.shiny)) {
-			if (fastReturn) return true;
-			const shinyReq = eventData.shiny ? ` be shiny` : ` not be shiny`;
-			problems.push(`${name} must${shinyReq}${etc}.`);
-		}
-		if (eventData.gender) {
-			if (set.gender && eventData.gender !== set.gender) {
-				if (fastReturn) return true;
-				problems.push(`${name}'s gender must be ${eventData.gender}${etc}.`);
-			}
-		}
-		const canMint = dex.gen > 7;
-		if (eventData.nature && eventData.nature !== set.nature && !canMint) {
-			if (fastReturn) return true;
-			problems.push(`${name} must have a ${eventData.nature} nature${etc} - Mints are only available starting gen 8.`);
-		}
-		let requiredIVs = 0;
-		if (eventData.ivs) {
-			/** In Gen 7, IVs can be changed to 31 */
-			const canBottleCap = (dex.gen >= 7 && set.level === 100);
-
-			if (!set.ivs) set.ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
-			let statName: StatID;
-			for (statName in eventData.ivs) {
-				if (canBottleCap && set.ivs[statName] === 31) continue;
-				if (set.ivs[statName] !== eventData.ivs[statName]) {
-					if (fastReturn) return true;
-					problems.push(`${name} must have ${eventData.ivs[statName]} ${Dex.stats.names[statName]} IVs${etc}.`);
-				}
-			}
-
-			if (canBottleCap) {
-				// IVs can be overridden but Hidden Power type can't
-				if (Object.keys(eventData.ivs).length >= 6) {
-					const requiredHpType = dex.getHiddenPower(eventData.ivs).type;
-					if (set.hpType && set.hpType !== requiredHpType) {
-						if (fastReturn) return true;
-						problems.push(`${name} can only have Hidden Power ${requiredHpType}${etc}.`);
-					}
-					set.hpType = requiredHpType;
-				}
-			}
-		} else {
-			requiredIVs = eventData.perfectIVs || 0;
-		}
-		if (requiredIVs && set.ivs) {
-			// Legendary Pokemon must have at least 3 perfect IVs in gen 6
-			// Events can also have a certain amount of guaranteed perfect IVs
-			let perfectIVs = 0;
-			let statName: StatID;
-			for (statName in set.ivs) {
-				if (set.ivs[statName] >= 31) perfectIVs++;
-			}
-			if (perfectIVs < requiredIVs) {
-				if (fastReturn) return true;
-				if (eventData.perfectIVs) {
-					problems.push(`${name} must have at least ${requiredIVs} perfect IVs${etc}.`);
-				}
-			}
-			// The perfect IV count affects Hidden Power availability
-			if (dex.gen >= 3 && requiredIVs >= 3 && set.hpType === 'Fighting') {
-				if (fastReturn) return true;
-				problems.push(`${name} can't use Hidden Power Fighting because it must have at least three perfect IVs${etc}.`);
-			} else if (dex.gen >= 3 && requiredIVs >= 5 && set.hpType &&
-					!['Dark', 'Dragon', 'Electric', 'Steel', 'Ice'].includes(set.hpType)) {
-				if (fastReturn) return true;
-				problems.push(`${name} can only use Hidden Power Dark/Dragon/Electric/Steel/Ice because it must have at least 5 perfect IVs${etc}.`);
-			}
-		}
-		const ruleTable = this.ruleTable;
-		if (ruleTable.has('obtainablemoves')) {
-			const ssMaxSourceGen = setSources.maxSourceGen();
-			const tradebackEligible = dex.gen === 2 && species.gen === 1;
-			if (ssMaxSourceGen && eventData.generation > ssMaxSourceGen && !tradebackEligible) {
-				if (fastReturn) return true;
-				problems.push(`${name} must not have moves only learnable in gen ${ssMaxSourceGen}${etc}.`);
-			}
-		}
-		if (ruleTable.has('obtainableabilities')) {
-			if (dex.gen <= 5 && eventData.abilities && eventData.abilities.length === 1 && !eventData.isHidden) {
-				if (species.name === eventSpecies.name) {
-					// has not evolved, abilities must match
-					const requiredAbility = dex.abilities.get(eventData.abilities[0]).name;
-					if (set.ability !== requiredAbility) {
-						if (fastReturn) return true;
-						problems.push(`${name} must have ${requiredAbility}${etc}.`);
-					}
-				} else {
-					// has evolved
-					const ability1 = dex.abilities.get(eventSpecies.abilities['1']);
-					if (ability1.gen && eventData.generation >= ability1.gen) {
-						// pokemon had 2 available abilities in the gen the event happened
-						// ability is restricted to a single ability slot
-						const requiredAbilitySlot = (toID(eventData.abilities[0]) === ability1.id ? 1 : 0);
-						const requiredAbility = dex.abilities.get(species.abilities[requiredAbilitySlot] || species.abilities['0']).name;
-						if (set.ability !== requiredAbility) {
-							const originalAbility = dex.abilities.get(eventData.abilities[0]).name;
-							if (fastReturn) return true;
-							problems.push(`${name} must have ${requiredAbility}${because} from a ${originalAbility} ${eventSpecies.name} event.`);
-						}
-					}
-				}
-			}
-			if (species.abilities['H']) {
-				const isHidden = (set.ability === species.abilities['H']);
-				if (!isHidden && eventData.isHidden) {
-					if (fastReturn) return true;
-					problems.push(`${name} must have its Hidden Ability${etc}.`);
-				}
-
-				const canUseAbilityPatch = dex.gen >= 8 && this.format.mod !== 'gen8dlc1';
-				if (isHidden && !eventData.isHidden && !canUseAbilityPatch) {
-					if (fastReturn) return true;
-					problems.push(`${name} must not have its Hidden Ability${etc}.`);
-				}
-			}
-		}
-		if (problems.length) return problems;
-		if (eventData.gender) set.gender = eventData.gender;
-	}
-
-	allSources(species?: Species) {
-		let minSourceGen = this.minSourceGen;
-		if (this.dex.gen >= 3 && minSourceGen < 3) minSourceGen = 3;
-		if (species) minSourceGen = Math.max(minSourceGen, species.gen);
-		const maxSourceGen = this.ruleTable.has('allowtradeback') ? Utils.clampIntRange(this.dex.gen + 1, 1, 8) : this.dex.gen;
-		return new PokemonSources(maxSourceGen, minSourceGen);
-	}
-
-	validateMoves(
-		species: Species, moves: string[], setSources: PokemonSources, set?: Partial<PokemonSet>,
-		name: string = species.name
-	) {
-		const dex = this.dex;
-		const ruleTable = this.ruleTable;
-
-		const problems = [];
-
-		const checkCanLearn = (ruleTable.checkCanLearn && ruleTable.checkCanLearn[0] || this.checkCanLearn);
-		for (const moveName of moves) {
-			const move = dex.moves.get(moveName);
-			const problem = checkCanLearn.call(this, move, species, setSources, set);
-			if (problem) {
-				problems.push(`${name}${problem}`);
-				break;
-			}
-		}
-
-		if (setSources.size() && setSources.moveEvoCarryCount > 3) {
-			if (setSources.sourcesBefore < 6) setSources.sourcesBefore = 0;
-			setSources.sources = setSources.sources.filter(
-				source => source.charAt(1) === 'E' && parseInt(source.charAt(0)) >= 6
-			);
-			if (!setSources.size()) {
-				problems.push(`${name} needs to know ${species.evoMove || 'a Fairy-type move'} to evolve, so it can only know 3 other moves from ${species.prevo}.`);
-			}
-		}
-
-		if (problems.length) return problems;
-
-		if (setSources.isHidden) {
-			setSources.sources = setSources.sources.filter(
-				source => parseInt(source.charAt(0)) >= 5
-			);
-			if (setSources.sourcesBefore < 5) setSources.sourcesBefore = 0;
-			const canUseAbilityPatch = dex.gen >= 8 && this.format.mod !== 'gen8dlc1';
-			if (!setSources.size() && !canUseAbilityPatch) {
-				problems.push(`${name} has a hidden ability - it can't have moves only learned before gen 5.`);
-				return problems;
-			}
-		}
-
-		if (setSources.babyOnly && setSources.sources.length) {
-			const baby = dex.species.get(setSources.babyOnly);
-			const babyEvo = toID(baby.evos[0]);
-			setSources.sources = setSources.sources.filter(source => {
-				if (source.charAt(1) === 'S') {
-					const sourceId = source.split(' ')[1];
-					if (sourceId !== baby.id) return false;
-				}
-				if (source.charAt(1) === 'E') {
-					if (babyEvo && source.slice(2) === babyEvo) return false;
-				}
-				if (source.charAt(1) === 'D') {
-					if (babyEvo && source.slice(2) === babyEvo) return false;
-				}
-				return true;
-			});
-			if (!setSources.size()) {
-				problems.push(`${name}'s event/egg moves are from an evolution, and are incompatible with its moves from ${baby.name}.`);
-			}
-		}
-		if (setSources.babyOnly && setSources.size() && this.gen > 2) {
-			// there do theoretically exist evo/tradeback incompatibilities in
-			// gen 2, but those are very complicated to validate and should be
-			// handled separately anyway, so for now we just treat them all as
-			// legal (competitively relevant ones can be manually banned)
-			const baby = dex.species.get(setSources.babyOnly);
-			setSources.sources = setSources.sources.filter(source => {
-				if (baby.gen > parseInt(source.charAt(0)) && !source.startsWith('1ST')) return false;
-				if (baby.gen > 2 && source === '7V') return false;
-				return true;
-			});
-			if (setSources.sourcesBefore < baby.gen) setSources.sourcesBefore = 0;
-			if (!setSources.size()) {
-				problems.push(`${name} has moves from before Gen ${baby.gen}, which are incompatible with its moves from ${baby.name}.`);
-			}
-		}
-
-		return problems;
-	}
-
-	/** Returns null if you can learn the move, or a string explaining why you can't learn it */
-	checkCanLearn(
-		move: Move,
-		s: Species,
-		setSources = this.allSources(s),
-		set: Partial<PokemonSet> = {}
-	): string | null {
-		const dex = this.dex;
-		if (!setSources.size()) throw new Error(`Bad sources passed to checkCanLearn`);
-
-		move = dex.moves.get(move);
-		const moveid = move.id;
-		const baseSpecies = dex.species.get(s);
-		let species: Species | null = baseSpecies;
-
-		const format = this.format;
-		const ruleTable = dex.formats.getRuleTable(format);
-		const alreadyChecked: {[k: string]: boolean} = {};
-		const level = set.level || 100;
-
-		let cantLearnReason = null;
-
-		let limit1 = true;
-		let sketch = false;
-		let blockedHM = false;
-
-		let babyOnly = '';
-
-		// This is a pretty complicated algorithm
-
-		// Abstractly, what it does is construct the union of sets of all
-		// possible ways this pokemon could be obtained, and then intersect
-		// it with a the pokemon's existing set of all possible ways it could
-		// be obtained. If this intersection is non-empty, the move is legal.
-
-		// set of possible sources of a pokemon with this move
-		const moveSources = new PokemonSources();
-
-		/**
-		 * The format doesn't allow Pokemon traded from the future
-		 * (This is everything except in Gen 1 Tradeback)
-		 */
-		const noFutureGen = !ruleTable.has('allowtradeback');
-		/**
-		 * The format allows Sketch to copy moves in Gen 8
-		 */
-		const canSketchGen8Moves = ruleTable.has('sketchgen8moves') || this.dex.currentMod === 'gen8bdsp';
-
-		let tradebackEligible = false;
-		while (species?.name && !alreadyChecked[species.id]) {
-			alreadyChecked[species.id] = true;
-			if (dex.gen <= 2 && species.gen === 1) tradebackEligible = true;
-			const learnset = dex.species.getLearnset(species.id);
-			if (!learnset) {
-				if ((species.changesFrom || species.baseSpecies) !== species.name) {
-					// forme without its own learnset
-					species = dex.species.get(species.changesFrom || species.baseSpecies);
-					// warning: formes with their own learnset, like Wormadam, should NOT
-					// inherit from their base forme unless they're freely switchable
-					continue;
-				}
-				if (species.isNonstandard) {
-					// It's normal for a nonstandard species not to have learnset data
-
-					// Formats should replace the `Obtainable Moves` rule if they want to
-					// allow pokemon without learnsets.
-					return ` can't learn any moves at all.`;
-				}
-				// should never happen
-				throw new Error(`Species with no learnset data: ${species.id}`);
-			}
-			const checkingPrevo = species.baseSpecies !== s.baseSpecies;
-			if (checkingPrevo && !moveSources.size()) {
-				if (!setSources.babyOnly || !species.prevo) {
-					babyOnly = species.id;
-				}
-			}
-
-			let sources = learnset[moveid];
-			if (moveid === 'sketch') {
-				sketch = true;
-			} else if (learnset['sketch']) {
-				if (move.noSketch || move.isZ || move.isMax) {
-					cantLearnReason = `can't be Sketched.`;
-				} else if (move.gen > 7 && !canSketchGen8Moves) {
-					cantLearnReason = `can't be Sketched because it's a Gen 8 move and Sketch isn't available in Gen 8.`;
-				} else {
-					if (!sources) sketch = true;
-					sources = learnset['sketch'].concat(sources || []);
-				}
-			}
-
-			if (typeof sources === 'string') sources = [sources];
-			if (sources) {
-				for (let learned of sources) {
-					// Every `learned` represents a single way a pokemon might
-					// learn a move. This can be handled one of several ways:
-					// `continue`
-					//   means we can't learn it
-					// `return null`
-					//   means we can learn it with no restrictions
-					//   (there's a way to just teach any pokemon of this species
-					//   the move in the current gen, like a TM.)
-					// `moveSources.add(source)`
-					//   means we can learn it only if obtained that exact way described
-					//   in source
-					// `moveSources.addGen(learnedGen)`
-					//   means we can learn it only if obtained at or before learnedGen
-					//   (i.e. get the pokemon however you want, transfer to that gen,
-					//   teach it, and transfer it to the current gen.)
-
-					const learnedGen = parseInt(learned.charAt(0));
-					if (learnedGen < this.minSourceGen) {
-						if (!cantLearnReason) {
-							cantLearnReason = `can't be transferred from Gen ${learnedGen} to ${this.minSourceGen}.`;
-						}
-						continue;
-					}
-					if (noFutureGen && learnedGen > dex.gen) {
-						if (!cantLearnReason) {
-							cantLearnReason = `can't be transferred from Gen ${learnedGen} to ${dex.gen}.`;
-						}
-						continue;
-					}
-
-					// redundant
-					if (learnedGen <= moveSources.sourcesBefore) continue;
-
-					if (baseSpecies.evoRegion === 'Alola' && checkingPrevo && learnedGen >= 8) {
-						cantLearnReason = `is from a ${species.name} that can't be transferred to USUM to evolve into ${baseSpecies.name}.`;
-						continue;
-					}
-
-					const canUseAbilityPatch = dex.gen >= 8 && format.mod !== 'gen8dlc1';
-					if (
-						learnedGen < 7 && setSources.isHidden && !canUseAbilityPatch &&
-						!dex.mod('gen' + learnedGen).species.get(baseSpecies.name).abilities['H']
-					) {
-						cantLearnReason = `can only be learned in gens without Hidden Abilities.`;
-						continue;
-					}
-					if (!species.isNonstandard) {
-						// HMs can't be transferred
-						if (dex.gen >= 4 && learnedGen <= 3 && [
-							'cut', 'fly', 'surf', 'strength', 'flash', 'rocksmash', 'waterfall', 'dive',
-						].includes(moveid)) {
-							cantLearnReason = `can't be transferred from Gen 3 to 4 because it's an HM move.`;
-							continue;
-						}
-						if (dex.gen >= 5 && learnedGen <= 4 && [
-							'cut', 'fly', 'surf', 'strength', 'rocksmash', 'waterfall', 'rockclimb',
-						].includes(moveid)) {
-							cantLearnReason = `can't be transferred from Gen 4 to 5 because it's an HM move.`;
-							continue;
-						}
-						// Defog and Whirlpool can't be transferred together
-						if (dex.gen >= 5 && ['defog', 'whirlpool'].includes(moveid) && learnedGen <= 4) blockedHM = true;
-					}
-
-					if (learned.charAt(1) === 'L') {
-						// special checking for level-up moves
-						if (level >= parseInt(learned.substr(2)) || learnedGen === 7) {
-							// we're past the required level to learn it
-							// (gen 7 level-up moves can be relearnered at any level)
-							// falls through to LMT check below
-						} else if (level >= 5 && learnedGen === 3 && species.canHatch) {
-							// Pomeg Glitch
-						} else if ((!species.gender || species.gender === 'F') && learnedGen >= 2 && species.canHatch) {
-							// available as egg move
-							learned = learnedGen + 'Eany';
-							// falls through to E check below
-						} else {
-							// this move is unavailable, skip it
-							cantLearnReason = `is learned at level ${parseInt(learned.substr(2))}.`;
-							continue;
-						}
-					}
-
-					// Gen 8 egg moves can be taught to any pokemon from any source
-					if (learned === '8E' || 'LMTR'.includes(learned.charAt(1))) {
-						if (learnedGen === dex.gen && learned.charAt(1) !== 'R') {
-							// current-gen level-up, TM or tutor moves:
-							//   always available
-							if (learned !== '8E' && babyOnly) setSources.babyOnly = babyOnly;
-							if (!moveSources.moveEvoCarryCount) return null;
-						}
-						// past-gen level-up, TM, or tutor moves:
-						//   available as long as the source gen was or was before this gen
-						if (learned.charAt(1) === 'R') {
-							moveSources.restrictedMove = moveid;
-						}
-						limit1 = false;
-						moveSources.addGen(learnedGen);
-					} else if (learned.charAt(1) === 'E') {
-						// egg moves:
-						//   only if hatched from an egg
-						let limitedEggMove: ID | null | undefined = undefined;
-						if (learned.slice(1) === 'Eany') {
-							limitedEggMove = null;
-						} else if (learnedGen < 6) {
-							limitedEggMove = move.id;
-						}
-						learned = learnedGen + 'E' + (species.prevo ? species.id : '');
-						if (tradebackEligible && learnedGen === 2 && move.gen <= 1) {
-							// can tradeback
-							moveSources.add('1ET' + learned.slice(2));
-						}
-						moveSources.add(learned, limitedEggMove);
-					} else if (learned.charAt(1) === 'S') {
-						// event moves:
-						//   only if that was the source
-						// Event Pokémon:
-						// 	Available as long as the past gen can get the Pokémon and then trade it back.
-						if (tradebackEligible && learnedGen === 2 && move.gen <= 1) {
-							// can tradeback
-							moveSources.add('1ST' + learned.slice(2) + ' ' + species.id);
-						}
-						moveSources.add(learned + ' ' + species.id);
-					} else if (learned.charAt(1) === 'D') {
-						// DW moves:
-						//   only if that was the source
-						moveSources.add(learned + species.id);
-					} else if (learned.charAt(1) === 'V' && this.minSourceGen < learnedGen) {
-						// Virtual Console or Let's Go transfer moves:
-						//   only if that was the source
-						moveSources.add(learned);
-					}
-				}
-			}
-			if (ruleTable.has('mimicglitch') && species.gen < 5) {
-				// include the Mimic Glitch when checking this mon's learnset
-				const glitchMoves = ['metronome', 'copycat', 'transform', 'mimic', 'assist'];
-				let getGlitch = false;
-				for (const i of glitchMoves) {
-					if (learnset[i]) {
-						if (!(i === 'mimic' && dex.abilities.get(set.ability).gen === 4 && !species.prevo)) {
-							getGlitch = true;
-							break;
-						}
-					}
-				}
-				if (getGlitch) {
-					moveSources.addGen(4);
-					if (move.gen < 5) {
-						limit1 = false;
-					}
-				}
-			}
-
-			if (!moveSources.size()) {
-				if (
-					(species.evoType === 'levelMove' && species.evoMove !== move.name) ||
-					(species.id === 'sylveon' && move.type !== 'Fairy')
-				) {
-					moveSources.moveEvoCarryCount = 1;
-				}
-			}
-
-			// also check to see if the mon's prevo or freely switchable formes can learn this move
-			species = this.learnsetParent(species);
-		}
-
-		if (limit1 && sketch) {
-			// limit 1 sketch move
-			if (setSources.sketchMove) {
-				return ` can't Sketch ${move.name} and ${setSources.sketchMove} because it can only Sketch 1 move.`;
-			}
-			setSources.sketchMove = move.name;
-		}
-
-		if (blockedHM) {
-			// Limit one of Defog/Whirlpool to be transferred
-			if (setSources.hm) return ` can't simultaneously transfer Defog and Whirlpool from Gen 4 to 5.`;
-			setSources.hm = moveid;
-		}
-
-		if (!setSources.restrictiveMoves) {
-			setSources.restrictiveMoves = [];
-		}
-		setSources.restrictiveMoves.push(move.name);
-
-		// Now that we have our list of possible sources, intersect it with the current list
-		if (!moveSources.size()) {
-			if (cantLearnReason) return `'s move ${move.name} ${cantLearnReason}`;
-			return ` can't learn ${move.name}.`;
-		}
-		const backupSources = setSources.sources;
-		const backupSourcesBefore = setSources.sourcesBefore;
-		setSources.intersectWith(moveSources);
-		if (!setSources.size()) {
-			// pretend this pokemon didn't have this move:
-			// prevents a crash if OMs override `checkCanLearn` to keep validating after an error
-			setSources.sources = backupSources;
-			setSources.sourcesBefore = backupSourcesBefore;
-			return `'s moves ${(setSources.restrictiveMoves || []).join(', ')} are incompatible.`;
-		}
-
-		if (babyOnly) setSources.babyOnly = babyOnly;
-		return null;
-	}
-
-	learnsetParent(species: Species) {
-		// Own Tempo Rockruff and Battle Bond Greninja are special event formes
-		// that are visually indistinguishable from their base forme but have
-		// different learnsets. To prevent a leak, we make them show up as their
-		// base forme, but hardcode their learnsets into Rockruff-Dusk and
-		// Greninja-Ash
-		if (['Gastrodon', 'Pumpkaboo', 'Sinistea'].includes(species.baseSpecies) && species.forme) {
-			return this.dex.species.get(species.baseSpecies);
-		} else if (species.name === 'Lycanroc-Dusk') {
-			return this.dex.species.get('Rockruff-Dusk');
-		} else if (species.name === 'Greninja-Ash') {
-			return null;
-		} else if (species.prevo) {
-			// there used to be a check for Hidden Ability here, but apparently it's unnecessary
-			// Shed Skin Pupitar can definitely evolve into Unnerve Tyranitar
-			species = this.dex.species.get(species.prevo);
-			if (species.gen > Math.max(2, this.dex.gen)) return null;
-			return species;
-		} else if (species.changesFrom && species.baseSpecies !== 'Kyurem') {
-			// For Pokemon like Rotom and Necrozma whose movesets are extensions are their base formes
-			return this.dex.species.get(species.changesFrom);
-		}
-		return null;
-	}
-
-	static fillStats(stats: SparseStatsTable | null, fillNum = 0): StatsTable {
-		const filledStats: StatsTable = {hp: fillNum, atk: fillNum, def: fillNum, spa: fillNum, spd: fillNum, spe: fillNum};
-		if (stats) {
-			let statName: StatID;
-			for (statName in filledStats) {
-				const stat = stats[statName];
-				if (typeof stat === 'number') filledStats[statName] = stat;
-			}
-		}
-		return filledStats;
-	}
-
-	static get(format: string | Format) {
-		return new TeamValidator(format);
-	}
-}
+ import {Dex, toID} from './dex';
+ import {Utils} from '../lib';
+ import {Tags} from '../data/tags';
+ import {Teams} from './teams';
+ import {PRNG} from './prng';
+ 
+ /**
+  * Describes a possible way to get a pokemon. Is not exhaustive!
+  * sourcesBefore covers all sources that do not have exclusive
+  * moves (like catching wild pokemon).
+  *
+  * First character is a generation number, 1-8.
+  * Second character is a source ID, one of:
+  *
+  * - E = egg, 3rd char+ is the father in gen 2-5, empty in gen 6-7
+  *   because egg moves aren't restricted to fathers anymore
+  * - S = event, 3rd char+ is the index in .eventData
+  * - D = Dream World, only 5D is valid
+  * - V = Virtual Console or Let's Go transfer, only 7V/8V is valid
+  *
+  * Designed to match MoveSource where possible.
+  */
+ export type PokemonSource = string;
+ 
+ /**
+  * Represents a set of possible ways to get a Pokémon with a given
+  * set.
+  *
+  * `new PokemonSources()` creates an empty set;
+  * `new PokemonSources(dex.gen)` allows all Pokemon.
+  *
+  * The set mainly stored as an Array `sources`, but for sets that
+  * could be sourced from anywhere (for instance, TM moves), we
+  * instead just set `sourcesBefore` to a number meaning "any
+  * source at or before this gen is possible."
+  *
+  * In other words, this variable represents the set of all
+  * sources in `sources`, union all sources at or before
+  * gen `sourcesBefore`.
+  */
+ export class PokemonSources {
+	 /**
+	  * A set of specific possible PokemonSources; implemented as
+	  * an Array rather than a Set for perf reasons.
+	  */
+	 sources: PokemonSource[];
+	 /**
+	  * if nonzero: the set also contains all possible sources from
+	  * this gen and earlier.
+	  */
+	 sourcesBefore: number;
+	 /**
+	  * the set requires sources from this gen or later
+	  * this should be unchanged from the format's minimum past gen
+	  * (3 in modern games, 6 if pentagon is required, etc)
+	  */
+	 sourcesAfter: number;
+	 isHidden: boolean | null;
+	 /**
+	  * `limitedEggMoves` is a list of moves that can only be obtained from an
+	  * egg with another father in gen 2-5. If there are multiple such moves,
+	  * potential fathers need to be checked to see if they can actually
+	  * learn the move combination in question.
+	  *
+	  * `null` = the current move is definitely not a limited egg move
+	  *
+	  * `undefined` = the current move may or may not be a limited egg move
+	  */
+	 limitedEggMoves?: ID[] | null;
+	 /**
+	  * Some Pokemon evolve by having a move in their learnset (like Piloswine
+	  * with Ancient Power). These can only carry three other moves from their
+	  * prevo, because the fourth move must be the evo move. This restriction
+	  * doesn't apply to gen 6+ eggs, which can get around the restriction with
+	  * the relearner.
+	  */
+	 moveEvoCarryCount: number;
+ 
+	 babyOnly?: string;
+	 sketchMove?: string;
+	 hm?: string;
+	 restrictiveMoves?: string[];
+	 /** Obscure learn methods */
+	 restrictedMove?: ID;
+ 
+	 constructor(sourcesBefore = 0, sourcesAfter = 0) {
+		 this.sources = [];
+		 this.sourcesBefore = sourcesBefore;
+		 this.sourcesAfter = sourcesAfter;
+		 this.isHidden = null;
+		 this.limitedEggMoves = undefined;
+		 this.moveEvoCarryCount = 0;
+	 }
+	 size() {
+		 if (this.sourcesBefore) return Infinity;
+		 return this.sources.length;
+	 }
+	 add(source: PokemonSource, limitedEggMove?: ID | null) {
+		 if (this.sources[this.sources.length - 1] !== source) this.sources.push(source);
+		 if (limitedEggMove && this.limitedEggMoves !== null) {
+			 this.limitedEggMoves = [limitedEggMove];
+		 } else if (limitedEggMove === null) {
+			 this.limitedEggMoves = null;
+		 }
+	 }
+	 addGen(sourceGen: number) {
+		 this.sourcesBefore = Math.max(this.sourcesBefore, sourceGen);
+		 this.limitedEggMoves = null;
+	 }
+	 minSourceGen() {
+		 if (this.sourcesBefore) return this.sourcesAfter || 1;
+		 let min = 10;
+		 for (const source of this.sources) {
+			 const sourceGen = parseInt(source.charAt(0));
+			 if (sourceGen < min) min = sourceGen;
+		 }
+		 if (min === 10) return 0;
+		 return min;
+	 }
+	 maxSourceGen() {
+		 let max = this.sourcesBefore;
+		 for (const source of this.sources) {
+			 const sourceGen = parseInt(source.charAt(0));
+			 if (sourceGen > max) max = sourceGen;
+		 }
+		 return max;
+	 }
+	 intersectWith(other: PokemonSources) {
+		 if (other.sourcesBefore || this.sourcesBefore) {
+			 // having sourcesBefore is the equivalent of having everything before that gen
+			 // in sources, so we fill the other array in preparation for intersection
+			 if (other.sourcesBefore > this.sourcesBefore) {
+				 for (const source of this.sources) {
+					 const sourceGen = parseInt(source.charAt(0));
+					 if (sourceGen <= other.sourcesBefore) {
+						 other.sources.push(source);
+					 }
+				 }
+			 } else if (this.sourcesBefore > other.sourcesBefore) {
+				 for (const source of other.sources) {
+					 const sourceGen = parseInt(source.charAt(0));
+					 if (sourceGen <= this.sourcesBefore) {
+						 this.sources.push(source);
+					 }
+				 }
+			 }
+			 this.sourcesBefore = Math.min(other.sourcesBefore, this.sourcesBefore);
+		 }
+		 if (this.sources.length) {
+			 if (other.sources.length) {
+				 const sourcesSet = new Set(other.sources);
+				 const intersectSources = this.sources.filter(source => sourcesSet.has(source));
+				 this.sources = intersectSources;
+			 } else {
+				 this.sources = [];
+			 }
+		 }
+ 
+		 if (other.restrictedMove && other.restrictedMove !== this.restrictedMove) {
+			 if (this.restrictedMove) {
+				 // incompatible
+				 this.sources = [];
+				 this.sourcesBefore = 0;
+			 } else {
+				 this.restrictedMove = other.restrictedMove;
+			 }
+		 }
+		 if (other.limitedEggMoves) {
+			 if (!this.limitedEggMoves) {
+				 this.limitedEggMoves = other.limitedEggMoves;
+			 } else {
+				 this.limitedEggMoves.push(...other.limitedEggMoves);
+			 }
+		 }
+		 this.moveEvoCarryCount += other.moveEvoCarryCount;
+		 if (other.sourcesAfter > this.sourcesAfter) this.sourcesAfter = other.sourcesAfter;
+		 if (other.isHidden) this.isHidden = true;
+	 }
+ }
+ 
+ export class TeamValidator {
+	 readonly format: Format;
+	 readonly dex: ModdedDex;
+	 readonly gen: number;
+	 readonly ruleTable: import('./dex-formats').RuleTable;
+	 readonly minSourceGen: number;
+ 
+	 readonly toID: (str: any) => ID;
+	 constructor(format: string | Format, dex = Dex) {
+		 this.format = dex.formats.get(format);
+		 this.dex = dex.forFormat(this.format);
+		 this.gen = this.dex.gen;
+		 this.ruleTable = this.dex.formats.getRuleTable(this.format);
+ 
+		 this.minSourceGen = this.ruleTable.minSourceGen;
+ 
+		 this.toID = toID;
+	 }
+ 
+	 validateTeam(
+		 team: PokemonSet[] | null,
+		 options: {
+			 removeNicknames?: boolean,
+			 skipSets?: {[name: string]: {[key: string]: boolean}},
+		 } = {}
+	 ): string[] | null {
+		 if (team && this.format.validateTeam) {
+			 return this.format.validateTeam.call(this, team, options) || null;
+		 }
+		 return this.baseValidateTeam(team, options);
+	 }
+ 
+	 baseValidateTeam(
+		 team: PokemonSet[] | null,
+		 options: {
+			 removeNicknames?: boolean,
+			 skipSets?: {[name: string]: {[key: string]: boolean}},
+		 } = {}
+	 ): string[] | null {
+		 const format = this.format;
+		 const dex = this.dex;
+ 
+		 let problems: string[] = [];
+		 const ruleTable = this.ruleTable;
+		 if (format.team) {
+			 if (team) {
+				 return [
+					 `This format doesn't let you use your own team.`,
+					 `If you're not using a custom client, please report this as a bug. If you are, remember to use \`/utm null\` before starting a game in this format.`,
+				 ];
+			 }
+			 const testTeamSeed = PRNG.generateSeed();
+			 try {
+				 const testTeamGenerator = Teams.getGenerator(format, testTeamSeed);
+				 testTeamGenerator.getTeam(options); // Throws error if generation fails
+			 } catch (e) {
+				 return [
+					 `${format.name}'s team generator (${format.team}) failed using these rules and seed (${testTeamSeed}):-`,
+					 `${e}`,
+				 ];
+			 }
+			 return null;
+		 }
+		 if (!team) {
+			 return [
+				 `This format requires you to use your own team.`,
+				 `If you're not using a custom client, please report this as a bug.`,
+			 ];
+		 }
+		 if (!Array.isArray(team)) {
+			 throw new Error(`Invalid team data`);
+		 }
+ 
+		 if (team.length < ruleTable.minTeamSize) {
+			 problems.push(`You must bring at least ${ruleTable.minTeamSize} Pok\u00E9mon (your team has ${team.length}).`);
+		 }
+		 if (team.length > ruleTable.maxTeamSize) {
+			 return [`You may only bring up to ${ruleTable.maxTeamSize} Pok\u00E9mon (your team has ${team.length}).`];
+		 }
+ 
+		 // A limit is imposed here to prevent too much engine strain or
+		 // too much layout deformation - to be exact, this is the limit
+		 // allowed in Custom Game.
+		 if (team.length > 24) {
+			 problems.push(`Your team has more than than 24 Pok\u00E9mon, which the simulator can't handle.`);
+			 return problems;
+		 }
+ 
+		 const teamHas: {[k: string]: number} = {};
+		 let lgpeStarterCount = 0;
+		 let deoxysType;
+		 for (const set of team) {
+			 if (!set) return [`You sent invalid team data. If you're not using a custom client, please report this as a bug.`];
+ 
+			 let setProblems: string[] | null = null;
+			 if (options.skipSets && options.skipSets[set.name]) {
+				 for (const i in options.skipSets[set.name]) {
+					 teamHas[i] = (teamHas[i] || 0) + 1;
+				 }
+			 } else {
+				 setProblems = (format.validateSet || this.validateSet).call(this, set, teamHas);
+			 }
+ 
+			 if (set.species === 'Pikachu-Starter' || set.species === 'Eevee-Starter') {
+				 lgpeStarterCount++;
+				 if (lgpeStarterCount === 2 && ruleTable.isBanned('nonexistent')) {
+					 problems.push(`You can only have one of Pikachu-Starter or Eevee-Starter on a team.`);
+				 }
+			 }
+			 if (dex.gen === 3 && set.species.startsWith('Deoxys')) {
+				 if (!deoxysType) {
+					 deoxysType = set.species;
+				 } else if (deoxysType !== set.species && ruleTable.isBanned('nonexistent')) {
+					 return [
+						 `You cannot have more than one type of Deoxys forme.`,
+						 `(Each game in Gen 3 supports only one forme of Deoxys.)`,
+					 ];
+				 }
+			 }
+			 if (setProblems) {
+				 problems = problems.concat(setProblems);
+			 }
+			 if (options.removeNicknames) {
+				 const species = dex.species.get(set.species);
+				 let crossSpecies: Species;
+				 if (format.name === '[Gen 8] Cross Evolution' && (crossSpecies = dex.species.get(set.name)).exists) {
+					 set.name = crossSpecies.name;
+				 } else {
+					 set.name = species.baseSpecies;
+					 if (species.baseSpecies === 'Unown') set.species = 'Unown';
+				 }
+			 }
+		 }
+ 
+		 for (const [rule, source, limit, bans] of ruleTable.complexTeamBans) {
+			 let count = 0;
+			 for (const ban of bans) {
+				 if (teamHas[ban] > 0) {
+					 count += limit ? teamHas[ban] : 1;
+				 }
+			 }
+			 if (limit && count > limit) {
+				 const clause = source ? ` by ${source}` : ``;
+				 problems.push(`You are limited to ${limit} of ${rule}${clause}.`);
+			 } else if (!limit && count >= bans.length) {
+				 const clause = source ? ` by ${source}` : ``;
+				 problems.push(`Your team has the combination of ${rule}, which is banned${clause}.`);
+			 }
+		 }
+ 
+		 for (const rule of ruleTable.keys()) {
+			 if ('!+-'.includes(rule.charAt(0))) continue;
+			 const subformat = dex.formats.get(rule);
+			 if (subformat.onValidateTeam && ruleTable.has(subformat.id)) {
+				 problems = problems.concat(subformat.onValidateTeam.call(this, team, format, teamHas) || []);
+			 }
+		 }
+		 if (format.onValidateTeam) {
+			 problems = problems.concat(format.onValidateTeam.call(this, team, format, teamHas) || []);
+		 }
+ 
+		 if (!problems.length) return null;
+		 return problems;
+	 }
+ 
+	 getEventOnlyData(species: Species, noRecurse?: boolean): {species: Species, eventData: EventInfo[]} | null {
+		 const dex = this.dex;
+		 const learnset = dex.species.getLearnsetData(species.id);
+		 if (!learnset?.eventOnly) {
+			 if (noRecurse) return null;
+			 return this.getEventOnlyData(dex.species.get(species.prevo), true);
+		 }
+ 
+		 if (!learnset.eventData && species.forme) {
+			 return this.getEventOnlyData(dex.species.get(species.baseSpecies), true);
+		 }
+		 if (!learnset.eventData) {
+			 throw new Error(`Event-only species ${species.name} has no eventData table`);
+		 }
+ 
+		 return {species, eventData: learnset.eventData};
+	 }
+ 
+	 validateSet(set: PokemonSet, teamHas: AnyObject): string[] | null {
+		 const format = this.format;
+		 const dex = this.dex;
+		 const ruleTable = this.ruleTable;
+ 
+		 let problems: string[] = [];
+		 if (!set) {
+			 return [`This is not a Pokemon.`];
+		 }
+ 
+		 let species = dex.species.get(set.species);
+		 set.species = species.name;
+		 // Backwards compatability with old Gmax format
+		 if (set.species.toLowerCase().endsWith('-gmax') && this.format.id !== 'gen8megamax') {
+			 set.species = set.species.slice(0, -5);
+			 species = dex.species.get(set.species);
+			 if (set.name && set.name.endsWith('-Gmax')) set.name = species.baseSpecies;
+			 set.gigantamax = true;
+		 }
+		 if (set.name && set.name.length > 18) {
+			 if (set.name === set.species) {
+				 set.name = species.baseSpecies;
+			 } else {
+				 problems.push(`Nickname "${set.name}" too long (should be 18 characters or fewer)`);
+			 }
+		 }
+		 set.name = dex.getName(set.name);
+		 let item = dex.items.get(Utils.getString(set.item));
+		 set.item = item.name;
+		 let ability = dex.abilities.get(Utils.getString(set.ability));
+		 set.ability = ability.name;
+		 let nature = dex.natures.get(Utils.getString(set.nature));
+		 set.nature = nature.name;
+		 if (!Array.isArray(set.moves)) set.moves = [];
+ 
+		 set.name = set.name || species.baseSpecies;
+		 let name = set.species;
+		 if (set.species !== set.name && species.baseSpecies !== set.name) {
+			 name = `${set.name} (${set.species})`;
+		 }
+ 
+		 if (!set.level) set.level = ruleTable.defaultLevel;
+ 
+		 let adjustLevel = ruleTable.adjustLevel;
+		 if (ruleTable.adjustLevelDown && set.level >= ruleTable.adjustLevelDown) {
+			 adjustLevel = ruleTable.adjustLevelDown;
+		 }
+		 if (set.level === adjustLevel || (set.level === 100 && ruleTable.maxLevel < 100)) {
+			 // Note that we're temporarily setting level 50 pokemon in VGC to level 100
+			 // This allows e.g. level 50 Hydreigon even though it doesn't evolve until level 64.
+			 // Leveling up can't make an obtainable pokemon unobtainable, so this is safe.
+			 // Just remember to set the level back to adjustLevel at the end of validation.
+			 set.level = ruleTable.maxLevel;
+		 }
+		 if (set.level < ruleTable.minLevel) {
+			 problems.push(`${name} (level ${set.level}) is below the minimum level of ${ruleTable.minLevel}${ruleTable.blame('minlevel')}`);
+		 }
+		 if (set.level > ruleTable.maxLevel) {
+			 problems.push(`${name} (level ${set.level}) is above the maximum level of ${ruleTable.maxLevel}${ruleTable.blame('maxlevel')}`);
+		 }
+ 
+		 const setHas: {[k: string]: true} = {};
+ 
+		 if (!set.evs) set.evs = TeamValidator.fillStats(null, ruleTable.evLimit === null ? 252 : 0);
+		 if (!set.ivs) set.ivs = TeamValidator.fillStats(null, 31);
+ 
+		 if (ruleTable.has('obtainableformes')) {
+			 problems.push(...this.validateForme(set));
+			 species = dex.species.get(set.species);
+		 }
+		 const setSources = this.allSources(species);
+ 
+		 for (const [rule] of ruleTable) {
+			 if ('!+-'.includes(rule.charAt(0))) continue;
+			 const subformat = dex.formats.get(rule);
+			 if (subformat.onChangeSet && ruleTable.has(subformat.id)) {
+				 problems = problems.concat(subformat.onChangeSet.call(this, set, format, setHas, teamHas) || []);
+			 }
+		 }
+		 if (format.onChangeSet) {
+			 problems = problems.concat(format.onChangeSet.call(this, set, format, setHas, teamHas) || []);
+		 }
+ 
+		 // onChangeSet can modify set.species, set.item, set.ability
+		 species = dex.species.get(set.species);
+		 item = dex.items.get(set.item);
+		 ability = dex.abilities.get(set.ability);
+ 
+		 let outOfBattleSpecies = species;
+		 let tierSpecies = species;
+		 if (ability.id === 'battlebond' && species.id === 'greninja') {
+			 outOfBattleSpecies = dex.species.get('greninjaash');
+			 if (ruleTable.has('obtainableformes')) {
+				 tierSpecies = outOfBattleSpecies;
+			 }
+			 if (ruleTable.has('obtainablemisc')) {
+				 if (set.gender && set.gender !== 'M') {
+					 problems.push(`Battle Bond Greninja must be male.`);
+				 }
+				 set.gender = 'M';
+			 }
+		 }
+		 if (ability.id === 'owntempo' && species.id === 'rockruff') {
+			 tierSpecies = outOfBattleSpecies = dex.species.get('rockruffdusk');
+		 }
+		 if (species.id === 'melmetal' && set.gigantamax && this.dex.species.getLearnsetData(species.id).eventData) {
+			 setSources.sourcesBefore = 0;
+			 setSources.sources = ['8S0 melmetal'];
+		 }
+		 if (!species.exists) {
+			 return [`The Pokemon "${set.species}" does not exist.`];
+		 }
+ 
+		 if (item.id && !item.exists) {
+			 return [`"${set.item}" is an invalid item.`];
+		 }
+		 if (ability.id && !ability.exists) {
+			 if (dex.gen < 3) {
+				 // gen 1-2 don't have abilities, just silently remove
+				 ability = dex.abilities.get('');
+				 set.ability = '';
+			 } else {
+				 return [`"${set.ability}" is an invalid ability.`];
+			 }
+		 }
+		 if (nature.id && !nature.exists) {
+			 if (dex.gen < 3) {
+				 // gen 1-2 don't have natures, just remove them
+				 nature = dex.natures.get('');
+				 set.nature = '';
+			 } else {
+				 problems.push(`"${set.nature}" is an invalid nature.`);
+			 }
+		 }
+		 if (set.happiness !== undefined && isNaN(set.happiness)) {
+			 problems.push(`${name} has an invalid happiness value.`);
+		 }
+		 if (set.hpType) {
+			 const type = dex.types.get(set.hpType);
+			 if (!type.exists || ['normal', 'fairy'].includes(type.id)) {
+				 problems.push(`${name}'s Hidden Power type (${set.hpType}) is invalid.`);
+			 } else {
+				 set.hpType = type.name;
+			 }
+		 }
+ 
+		 if (ruleTable.has('obtainableformes')) {
+			 const canMegaEvo = dex.gen <= 7 || ruleTable.has('standardnatdex');
+			 if (item.megaEvolves === species.name) {
+				 if (!item.megaStone) throw new Error(`Item ${item.name} has no base form for mega evolution`);
+				 tierSpecies = dex.species.get(item.megaStone);
+			 } else if (item.id === 'redorb' && species.id === 'groudon') {
+				 tierSpecies = dex.species.get('Groudon-Primal');
+			 } else if (item.id === 'blueorb' && species.id === 'kyogre') {
+				 tierSpecies = dex.species.get('Kyogre-Primal');
+			 } else if (canMegaEvo && species.id === 'rayquaza' && set.moves.map(toID).includes('dragonascent' as ID)) {
+				 tierSpecies = dex.species.get('Rayquaza-Mega');
+			 } else if (item.id === 'rustedsword' && species.id === 'zacian') {
+				 tierSpecies = dex.species.get('Zacian-Crowned');
+			 } else if (item.id === 'rustedshield' && species.id === 'zamazenta') {
+				 tierSpecies = dex.species.get('Zamazenta-Crowned');
+			 }
+		 }
+ 
+		 let problem = this.checkSpecies(set, species, tierSpecies, setHas);
+		 if (problem) problems.push(problem);
+ 
+		 problem = this.checkItem(set, item, setHas);
+		 if (problem) problems.push(problem);
+		 if (ruleTable.has('obtainablemisc')) {
+			 if (dex.gen === 4 && item.id === 'griseousorb' && species.num !== 487) {
+				 problems.push(`${set.name} cannot hold the Griseous Orb.`, `(In Gen 4, only Giratina could hold the Griseous Orb).`);
+			 }
+			 if (dex.gen <= 1) {
+				 if (item.id) {
+					 // no items allowed
+					 set.item = '';
+				 }
+			 }
+		 }
+ 
+		 if (!set.ability) set.ability = 'No Ability';
+		 if (ruleTable.has('obtainableabilities')) {
+			 if (dex.gen <= 2 || dex.currentMod === 'gen7letsgo') {
+				 set.ability = 'No Ability';
+			 } else {
+				 if (!ability.name || ability.name === 'No Ability') {
+					 problems.push(`${name} needs to have an ability.`);
+				 } else if (!Object.values(species.abilities).includes(ability.name)) {
+					 if (tierSpecies.abilities[0] === ability.name) {
+						 set.ability = species.abilities[0];
+					 } else {
+						 problems.push(`${name} can't have ${set.ability}.`);
+					 }
+				 }
+				 if (ability.name === species.abilities['H']) {
+					 setSources.isHidden = true;
+ 
+					 let unreleasedHidden = species.unreleasedHidden;
+					 if (unreleasedHidden === 'Past' && this.minSourceGen < dex.gen) unreleasedHidden = false;
+ 
+					 if (unreleasedHidden && ruleTable.has('-unreleased')) {
+						 problems.push(`${name}'s Hidden Ability is unreleased.`);
+					 } else if (dex.gen === 7 && ['entei', 'suicune', 'raikou'].includes(species.id) && this.minSourceGen > 1) {
+						 problems.push(`${name}'s Hidden Ability is only available from Virtual Console, which is not allowed in this format.`);
+					 } else if (dex.gen === 6 && ability.name === 'Symbiosis' &&
+						 (set.species.endsWith('Orange') || set.species.endsWith('White'))) {
+						 problems.push(`${name}'s Hidden Ability is unreleased for the Orange and White forms.`);
+					 } else if (dex.gen === 5 && set.level < 10 && (species.maleOnlyHidden || species.gender === 'N')) {
+						 problems.push(`${name} must be at least level 10 to have a Hidden Ability.`);
+					 }
+					 if (species.maleOnlyHidden) {
+						 if (set.gender && set.gender !== 'M') {
+							 problems.push(`${name} must be male to have a Hidden Ability.`);
+						 }
+						 set.gender = 'M';
+						 setSources.sources = ['5D'];
+					 }
+				 } else {
+					 setSources.isHidden = false;
+				 }
+			 }
+		 }
+ 
+		 ability = dex.abilities.get(set.ability);
+		 problem = this.checkAbility(set, ability, setHas);
+		 if (problem) problems.push(problem);
+ 
+		 if (!set.nature || dex.gen <= 2) {
+			 set.nature = '';
+		 }
+		 nature = dex.natures.get(set.nature);
+		 problem = this.checkNature(set, nature, setHas);
+		 if (problem) problems.push(problem);
+ 
+		 if (set.moves && Array.isArray(set.moves)) {
+			 set.moves = set.moves.filter(val => val);
+		 }
+		 if (!set.moves?.length) {
+			 problems.push(`${name} has no moves (it must have at least one to be usable).`);
+			 set.moves = [];
+		 }
+		 if (set.moves.length > ruleTable.maxMoveCount) {
+			 problems.push(`${name} has ${set.moves.length} moves, which is more than the limit of ${ruleTable.maxMoveCount}.`);
+			 return problems;
+		 }
+ 
+		 if (ruleTable.isBanned('nonexistent')) {
+			 problems.push(...this.validateStats(set, species, setSources));
+		 }
+ 
+		 for (const moveName of set.moves) {
+			 if (!moveName) continue;
+			 const move = dex.moves.get(Utils.getString(moveName));
+			 if (!move.exists) return [`"${move.name}" is an invalid move.`];
+ 
+			 problem = this.checkMove(set, move, setHas);
+			 if (problem) problems.push(problem);
+		 }
+ 
+		 if (ruleTable.has('obtainablemoves')) {
+			 problems.push(...this.validateMoves(outOfBattleSpecies, set.moves, setSources, set, name));
+		 }
+ 
+		 const learnsetSpecies = dex.species.getLearnsetData(outOfBattleSpecies.id);
+		 let eventOnlyData;
+ 
+		 if (!setSources.sourcesBefore && setSources.sources.length) {
+			 let legal = false;
+			 for (const source of setSources.sources) {
+				 if (this.validateSource(set, source, setSources, outOfBattleSpecies)) continue;
+				 legal = true;
+				 break;
+			 }
+ 
+			 if (!legal) {
+				 let nonEggSource = null;
+				 for (const source of setSources.sources) {
+					 if (source.charAt(1) !== 'E') {
+						 nonEggSource = source;
+						 break;
+					 }
+				 }
+				 if (!nonEggSource) {
+					 // all egg moves
+					 problems.push(`${name} can't get its egg move combination (${setSources.limitedEggMoves!.join(', ')}) from any possible father.`);
+					 problems.push(`(Is this incorrect? If so, post the chainbreeding instructions in Bug Reports)`);
+				 } else {
+					 if (setSources.sources.length > 1) {
+						 problems.push(`${name} has an event-exclusive move that it doesn't qualify for (only one of several ways to get the move will be listed):`);
+					 }
+					 const eventProblems = this.validateSource(
+						 set, nonEggSource, setSources, outOfBattleSpecies, ` because it has a move only available`
+					 );
+					 if (eventProblems) problems.push(...eventProblems);
+				 }
+			 }
+		 } else if (ruleTable.has('obtainablemisc') && (eventOnlyData = this.getEventOnlyData(outOfBattleSpecies))) {
+			 const {species: eventSpecies, eventData} = eventOnlyData;
+			 let legal = false;
+			 for (const event of eventData) {
+				 if (this.validateEvent(set, setSources, event, eventSpecies)) continue;
+				 legal = true;
+				 break;
+			 }
+			 if (!legal && species.gen <= 2 && dex.gen >= 7 && !this.validateSource(set, '7V', setSources, species)) {
+				 legal = true;
+			 }
+			 if (!legal) {
+				 if (eventData.length === 1) {
+					 problems.push(`${species.name} is only obtainable from an event - it needs to match its event:`);
+				 } else {
+					 problems.push(`${species.name} is only obtainable from events - it needs to match one of its events:`);
+				 }
+				 for (const [i, event] of eventData.entries()) {
+					 if (event.generation <= dex.gen && event.generation >= this.minSourceGen) {
+						 const eventInfo = event;
+						 const eventNum = i + 1;
+						 const eventName = eventData.length > 1 ? ` #${eventNum}` : ``;
+						 const eventProblems = this.validateEvent(
+							 set, setSources, eventInfo, eventSpecies, ` to be`, `from its event${eventName}`
+						 );
+						 if (eventProblems) problems.push(...eventProblems);
+					 }
+				 }
+			 }
+		 }
+ 
+		 let isFromRBYEncounter = false;
+		 if (this.gen === 1 && ruleTable.has('obtainablemisc') && !this.ruleTable.has('allowtradeback')) {
+			 let lowestEncounterLevel;
+			 for (const encounter of learnsetSpecies.encounters || []) {
+				 if (encounter.generation !== 1) continue;
+				 if (!encounter.level) continue;
+				 if (lowestEncounterLevel && encounter.level > lowestEncounterLevel) continue;
+ 
+				 lowestEncounterLevel = encounter.level;
+			 }
+ 
+			 if (lowestEncounterLevel) {
+				 if (set.level < lowestEncounterLevel) {
+					 problems.push(`${name} is not obtainable at levels below ${lowestEncounterLevel} in Gen 1.`);
+				 }
+				 isFromRBYEncounter = true;
+			 }
+		 }
+		 if (!isFromRBYEncounter && ruleTable.has('obtainablemisc')) {
+			 // FIXME: Event pokemon given at a level under what it normally can be attained at gives a false positive
+			 let evoSpecies = species;
+			 while (evoSpecies.prevo) {
+				 if (set.level < (evoSpecies.evoLevel || 0)) {
+					 problems.push(`${name} must be at least level ${evoSpecies.evoLevel} to be evolved.`);
+					 break;
+				 }
+				 evoSpecies = dex.species.get(evoSpecies.prevo);
+			 }
+		 }
+ 
+		 if (ruleTable.has('obtainablemoves')) {
+			 if (species.id === 'keldeo' && set.moves.includes('secretsword') && this.minSourceGen > 5 && dex.gen <= 7) {
+				 problems.push(`${name} has Secret Sword, which is only compatible with Keldeo-Ordinary obtained from Gen 5.`);
+			 }
+			 const requiresGen3Source = setSources.maxSourceGen() <= 3;
+			 if (requiresGen3Source && dex.abilities.get(set.ability).gen === 4 && !species.prevo && dex.gen <= 5) {
+				 // Ability Capsule allows this in Gen 6+
+				 problems.push(`${name} has a Gen 4 ability and isn't evolved - it can't use moves from Gen 3.`);
+			 }
+			 const canUseAbilityPatch = dex.gen >= 8 && format.mod !== 'gen8dlc1';
+			 if (setSources.isHidden && !canUseAbilityPatch && setSources.maxSourceGen() < 5) {
+				 problems.push(`${name} has a Hidden Ability - it can't use moves from before Gen 5.`);
+			 }
+			 if (
+				 species.maleOnlyHidden && setSources.isHidden && setSources.sourcesBefore < 5 &&
+				 setSources.sources.every(source => source.charAt(1) === 'E')
+			 ) {
+				 problems.push(`${name} has an unbreedable Hidden Ability - it can't use egg moves.`);
+			 }
+		 }
+ 
+		 if (teamHas) {
+			 for (const i in setHas) {
+				 if (i in teamHas) {
+					 teamHas[i]++;
+				 } else {
+					 teamHas[i] = 1;
+				 }
+			 }
+		 }
+		 for (const [rule, source, limit, bans] of ruleTable.complexBans) {
+			 let count = 0;
+			 for (const ban of bans) {
+				 if (setHas[ban]) count++;
+			 }
+			 if (limit && count > limit) {
+				 const clause = source ? ` by ${source}` : ``;
+				 problems.push(`${name} is limited to ${limit} of ${rule}${clause}.`);
+			 } else if (!limit && count >= bans.length) {
+				 const clause = source ? ` by ${source}` : ``;
+				 if (source === 'Obtainable Moves') {
+					 problems.push(`${name} has the combination of ${rule}, which is impossible to obtain legitimately.`);
+				 } else {
+					 problems.push(`${name} has the combination of ${rule}, which is banned${clause}.`);
+				 }
+			 }
+		 }
+ 
+		 for (const [rule] of ruleTable) {
+			 if ('!+-'.includes(rule.charAt(0))) continue;
+			 const subformat = dex.formats.get(rule);
+			 if (subformat.onValidateSet && ruleTable.has(subformat.id)) {
+				 problems = problems.concat(subformat.onValidateSet.call(this, set, format, setHas, teamHas) || []);
+			 }
+		 }
+		 if (format.onValidateSet) {
+			 problems = problems.concat(format.onValidateSet.call(this, set, format, setHas, teamHas) || []);
+		 }
+ 
+		 const nameSpecies = dex.species.get(set.name);
+		 if (nameSpecies.exists && nameSpecies.name.toLowerCase() === set.name.toLowerCase()) {
+			 // nickname is the name of a species
+			 if (nameSpecies.baseSpecies === species.baseSpecies) {
+				 set.name = species.baseSpecies;
+			 } else if (nameSpecies.name !== species.name && nameSpecies.name !== species.baseSpecies) {
+				 // nickname species doesn't match actual species
+				 // Nickname Clause
+				 problems.push(`${name} must not be nicknamed a different Pokémon species than what it actually is.`);
+			 }
+		 }
+ 
+		 if (!problems.length) {
+			 if (adjustLevel) set.level = adjustLevel;
+			 return null;
+		 }
+ 
+		 return problems;
+	 }
+ 
+	 validateStats(set: PokemonSet, species: Species, setSources: PokemonSources) {
+		 const ruleTable = this.ruleTable;
+		 const dex = this.dex;
+ 
+		 const allowAVs = ruleTable.has('allowavs');
+		 const evLimit = ruleTable.evLimit;
+		 const canBottleCap = dex.gen >= 7 && (set.level >= 100 || !ruleTable.has('obtainablemisc'));
+ 
+		 if (!set.evs) set.evs = TeamValidator.fillStats(null, evLimit === null ? 252 : 0);
+		 if (!set.ivs) set.ivs = TeamValidator.fillStats(null, 31);
+ 
+		 const problems = [];
+		 const name = set.name || set.species;
+ 
+		 const maxedIVs = Object.values(set.ivs).every(stat => stat === 31);
+		 for (const moveName of set.moves) {
+			 const move = dex.moves.get(moveName);
+			 if (move.id === 'hiddenpower' && move.type !== 'Normal') {
+				 if (!set.hpType) {
+					 set.hpType = move.type;
+				 } else if (set.hpType !== move.type && ruleTable.has('obtainablemisc')) {
+					 problems.push(`${name}'s Hidden Power type ${set.hpType} is incompatible with Hidden Power ${move.type}`);
+				 }
+			 }
+		 }
+		 if (set.hpType && maxedIVs && ruleTable.has('obtainablemisc')) {
+			 if (dex.gen <= 2) {
+				 const HPdvs = dex.types.get(set.hpType).HPdvs;
+				 set.ivs = {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30};
+				 let statName: StatID;
+				 for (statName in HPdvs) {
+					 set.ivs[statName] = HPdvs[statName]! * 2;
+				 }
+				 set.ivs.hp = -1;
+			 } else if (!canBottleCap) {
+				 set.ivs = TeamValidator.fillStats(dex.types.get(set.hpType).HPivs, 31);
+			 }
+		 }
+ 
+		 const cantBreedNorEvolve = (species.eggGroups[0] === 'Undiscovered' && !species.prevo && !species.nfe);
+		 const isLegendary = (cantBreedNorEvolve && ![
+			 'Pikachu', 'Unown', 'Dracozolt', 'Arctozolt', 'Dracovish', 'Arctovish',
+		 ].includes(species.baseSpecies)) || [
+			 'Manaphy', 'Cosmog', 'Cosmoem', 'Solgaleo', 'Lunala',
+		 ].includes(species.baseSpecies);
+		 const diancieException = species.name === 'Diancie' && !set.shiny;
+		 const has3PerfectIVs = setSources.minSourceGen() >= 6 && isLegendary && !diancieException;
+ 
+		 if (set.hpType === 'Fighting' && ruleTable.has('obtainablemisc')) {
+			 if (has3PerfectIVs) {
+				 // Legendary Pokemon must have at least 3 perfect IVs in gen 6+
+				 problems.push(`${name} must not have Hidden Power Fighting because it starts with 3 perfect IVs because it's a Gen 6+ legendary.`);
+			 }
+		 }
+ 
+		 if (has3PerfectIVs && ruleTable.has('obtainablemisc')) {
+			 let perfectIVs = 0;
+			 for (const stat in set.ivs) {
+				 if (set.ivs[stat as 'hp'] >= 31) perfectIVs++;
+			 }
+			 if (perfectIVs < 3) {
+				 const reason = (this.minSourceGen === 6 ? ` and this format requires Gen ${dex.gen} Pokémon` : ` in Gen 6 or later`);
+				 problems.push(`${name} must have at least three perfect IVs because it's a legendary${reason}.`);
+			 }
+		 }
+ 
+		 if (set.hpType && !canBottleCap) {
+			 const ivHpType = dex.getHiddenPower(set.ivs).type;
+			 if (set.hpType !== ivHpType) {
+				 problems.push(`${name} has Hidden Power ${set.hpType}, but its IVs are for Hidden Power ${ivHpType}.`);
+			 }
+		 } else if (set.hpType) {
+			 if (!this.possibleBottleCapHpType(set.hpType, set.ivs)) {
+				 problems.push(`${name} has Hidden Power ${set.hpType}, but its IVs don't allow this even with (Bottle Cap) Hyper Training.`);
+			 }
+		 }
+ 
+		 if (dex.gen <= 2) {
+			 // validate DVs
+			 const ivs = set.ivs;
+			 const atkDV = Math.floor(ivs.atk / 2);
+			 const defDV = Math.floor(ivs.def / 2);
+			 const speDV = Math.floor(ivs.spe / 2);
+			 const spcDV = Math.floor(ivs.spa / 2);
+			 const expectedHpDV = (atkDV % 2) * 8 + (defDV % 2) * 4 + (speDV % 2) * 2 + (spcDV % 2);
+			 if (ivs.hp === -1) ivs.hp = expectedHpDV * 2;
+			 const hpDV = Math.floor(ivs.hp / 2);
+			 if (expectedHpDV !== hpDV) {
+				 problems.push(`${name} has an HP DV of ${hpDV}, but its Atk, Def, Spe, and Spc DVs give it an HP DV of ${expectedHpDV}.`);
+			 }
+			 if (ivs.spa !== ivs.spd) {
+				 if (dex.gen === 2) {
+					 problems.push(`${name} has different SpA and SpD DVs, which is not possible in Gen 2.`);
+				 } else {
+					 ivs.spd = ivs.spa;
+				 }
+			 }
+			 if (dex.gen > 1 && !species.gender) {
+				 // Gen 2 gender is calculated from the Atk DV.
+				 // High Atk DV <-> M. The meaning of "high" depends on the gender ratio.
+				 const genderThreshold = species.genderRatio.F * 16;
+ 
+				 const expectedGender = (atkDV >= genderThreshold ? 'M' : 'F');
+				 if (set.gender && set.gender !== expectedGender) {
+					 problems.push(`${name} is ${set.gender}, but it has an Atk DV of ${atkDV}, which makes its gender ${expectedGender}.`);
+				 } else {
+					 set.gender = expectedGender;
+				 }
+			 }
+			 if (
+				 set.species === 'Marowak' && toID(set.item) === 'thickclub' &&
+				 set.moves.map(toID).includes('swordsdance' as ID) && set.level === 100
+			 ) {
+				 // Marowak hack
+				 set.ivs.atk = Math.floor(set.ivs.atk / 2) * 2;
+				 while (set.evs.atk > 0 && 2 * 80 + set.ivs.atk + Math.floor(set.evs.atk / 4) + 5 > 255) {
+					 set.evs.atk -= 4;
+				 }
+			 }
+			 if (dex.gen > 1) {
+				 const expectedShiny = !!(defDV === 10 && speDV === 10 && spcDV === 10 && atkDV % 4 >= 2);
+				 if (expectedShiny && !set.shiny) {
+					 problems.push(`${name} is not shiny, which does not match its DVs.`);
+				 } else if (!expectedShiny && set.shiny) {
+					 problems.push(`${name} is shiny, which does not match its DVs (its DVs must all be 10, except Atk which must be 2, 3, 6, 7, 10, 11, 14, or 15).`);
+				 }
+			 }
+			 set.nature = 'Serious';
+		 }
+ 
+		 for (const stat in set.evs) {
+			 if (set.evs[stat as 'hp'] < 0) {
+				 problems.push(`${name} has less than 0 ${allowAVs ? 'Awakening Values' : 'EVs'} in ${Dex.stats.names[stat as 'hp']}.`);
+			 }
+		 }
+ 
+		 if (dex.currentMod === 'gen7letsgo') { // AVs
+			 for (const stat in set.evs) {
+				 if (set.evs[stat as 'hp'] > 0 && !allowAVs) {
+					 problems.push(`${name} has Awakening Values but this format doesn't allow them.`);
+					 break;
+				 } else if (set.evs[stat as 'hp'] > 200) {
+					 problems.push(`${name} has more than 200 Awakening Values in ${Dex.stats.names[stat as 'hp']}.`);
+				 }
+			 }
+		 } else { // EVs
+			 for (const stat in set.evs) {
+				 if (set.evs[stat as StatID] > 255) {
+					 problems.push(`${name} has more than 255 EVs in ${Dex.stats.names[stat as 'hp']}.`);
+				 }
+			 }
+			 if (dex.gen <= 2) {
+				 if (set.evs.spa !== set.evs.spd) {
+					 if (dex.gen === 2) {
+						 problems.push(`${name} has different SpA and SpD EVs, which is not possible in Gen 2.`);
+					 } else {
+						 set.evs.spd = set.evs.spa;
+					 }
+				 }
+			 }
+		 }
+ 
+		 let totalEV = 0;
+		 for (const stat in set.evs) totalEV += set.evs[stat as 'hp'];
+		 if (!this.format.debug) {
+			 if (set.level > 1 && evLimit !== 0 && totalEV === 0) {
+				 problems.push(`${name} has exactly 0 EVs - did you forget to EV it? (If this was intentional, add exactly 1 to one of your EVs, which won't change its stats but will tell us that it wasn't a mistake).`);
+			 } else if (![508, 510].includes(evLimit!) && [508, 510].includes(totalEV)) {
+				 problems.push(`${name} has exactly ${totalEV} EVs, but this format does not restrict you to 510 EVs (If this was intentional, add exactly 1 to one of your EVs, which won't change its stats but will tell us that it wasn't a mistake).`);
+			 }
+			 // Check for level import errors from user in VGC -> DOU, etc.
+			 // Note that in VGC etc (Adjust Level Down = 50), `set.level` will be 100 here for validation purposes
+			 if (set.level === 50 && ruleTable.maxLevel !== 50 && !ruleTable.maxTotalLevel && evLimit !== 0 && totalEV % 4 === 0) {
+				 problems.push(`${name} is level 50, but this format allows level ${ruleTable.maxLevel} Pokémon. (If this was intentional, add exactly 1 to one of your EVs, which won't change its stats but will tell us that it wasn't a mistake).`);
+			 }
+		 }
+ 
+		 if (evLimit !== null && totalEV > evLimit) {
+			 if (!evLimit) {
+				 problems.push(`${name} has EVs, which is not allowed by this format.`);
+			 } else {
+				 problems.push(`${name} has ${totalEV} total EVs, which is more than this format's limit of ${evLimit}.`);
+			 }
+		 }
+ 
+		 return problems;
+	 }
+ 
+	 /**
+	  * Not exhaustive, just checks Atk and Spe, which are the only competitively
+	  * relevant IVs outside of extremely obscure situations.
+	  */
+	 possibleBottleCapHpType(type: string, ivs: StatsTable) {
+		 if (!type) return true;
+		 if (['Dark', 'Dragon', 'Grass', 'Ghost', 'Poison'].includes(type)) {
+			 // Spe must be odd
+			 if (ivs.spe % 2 === 0) return false;
+		 }
+		 if (['Psychic', 'Fire', 'Rock', 'Fighting'].includes(type)) {
+			 // Spe must be even
+			 if (ivs.spe !== 31 && ivs.spe % 2 === 1) return false;
+		 }
+		 if (type === 'Dark') {
+			 // Atk must be odd
+			 if (ivs.atk % 2 === 0) return false;
+		 }
+		 if (['Ice', 'Water'].includes(type)) {
+			 // Spe or Atk must be odd
+			 if (ivs.spe % 2 === 0 && ivs.atk % 2 === 0) return false;
+		 }
+		 return true;
+	 }
+ 
+	 validateSource(
+		 set: PokemonSet, source: PokemonSource, setSources: PokemonSources, species: Species, because: string
+	 ): string[] | undefined;
+	 validateSource(
+		 set: PokemonSet, source: PokemonSource, setSources: PokemonSources, species: Species
+	 ): true | undefined;
+	 /**
+	  * Returns array of error messages if invalid, undefined if valid
+	  *
+	  * If `because` is not passed, instead returns true if invalid.
+	  */
+	 validateSource(
+		 set: PokemonSet, source: PokemonSource, setSources: PokemonSources, species: Species, because?: string
+	 ) {
+		 let eventData: EventInfo | undefined;
+		 let eventSpecies = species;
+		 if (source.charAt(1) === 'S') {
+			 const splitSource = source.substr(source.charAt(2) === 'T' ? 3 : 2).split(' ');
+			 const dex = (this.dex.gen === 1 ? this.dex.mod('gen2') : this.dex);
+			 eventSpecies = dex.species.get(splitSource[1]);
+			 const eventLsetData = this.dex.species.getLearnsetData(eventSpecies.id);
+			 eventData = eventLsetData.eventData?.[parseInt(splitSource[0])];
+			 if (!eventData) {
+				 throw new Error(`${eventSpecies.name} from ${species.name} doesn't have data for event ${source}`);
+			 }
+		 } else if (source === '7V') {
+			 const isMew = species.id === 'mew';
+			 const isCelebi = species.id === 'celebi';
+			 const g7speciesName = (species.gen > 2 && species.prevo) ? species.prevo : species.id;
+			 const isHidden = !!this.dex.mod('gen7').species.get(g7speciesName).abilities['H'];
+			 eventData = {
+				 generation: 2,
+				 level: isMew ? 5 : isCelebi ? 30 : 3, // Level 1/2 Pokémon can't be obtained by transfer from RBY/GSC
+				 perfectIVs: isMew || isCelebi ? 5 : 3,
+				 isHidden,
+				 shiny: isMew ? undefined : 1,
+				 pokeball: 'pokeball',
+				 from: 'Gen 1-2 Virtual Console transfer',
+			 };
+		 } else if (source === '8V') {
+			 const isMew = species.id === 'mew';
+			 eventData = {
+				 generation: 8,
+				 perfectIVs: isMew ? 3 : undefined,
+				 shiny: isMew ? undefined : 1,
+				 from: 'Gen 7 Let\'s Go! HOME transfer',
+			 };
+		 } else if (source.charAt(1) === 'D') {
+			 eventData = {
+				 generation: 5,
+				 level: 10,
+				 from: 'Gen 5 Dream World',
+				 isHidden: !!this.dex.mod('gen5').species.get(species.id).abilities['H'],
+			 };
+		 } else if (source.charAt(1) === 'E') {
+			 if (this.findEggMoveFathers(source, species, setSources)) {
+				 return undefined;
+			 }
+			 if (because) throw new Error(`Wrong place to get an egg incompatibility message`);
+			 return true;
+		 } else {
+			 throw new Error(`Unidentified source ${source} passed to validateSource`);
+		 }
+ 
+		 // complicated fancy return signature
+		 return this.validateEvent(set, setSources, eventData, eventSpecies, because as any) as any;
+	 }
+ 
+	 findEggMoveFathers(source: PokemonSource, species: Species, setSources: PokemonSources): boolean;
+	 findEggMoveFathers(source: PokemonSource, species: Species, setSources: PokemonSources, getAll: true): ID[] | null;
+	 findEggMoveFathers(source: PokemonSource, species: Species, setSources: PokemonSources, getAll = false) {
+		 // tradebacks have an eggGen of 2 even though the source is 1ET
+		 const eggGen = Math.max(parseInt(source.charAt(0)), 2);
+		 const fathers: ID[] = [];
+		 // Gen 6+ don't have egg move incompatibilities
+		 // (except for certain cases with baby Pokemon not handled here)
+		 if (!getAll && eggGen >= 6) return true;
+ 
+		 const eggMoves = setSources.limitedEggMoves;
+		 // must have 2 or more egg moves to have egg move incompatibilities
+		 if (!eggMoves) {
+			 // happens often in gen 1-6 LC if your only egg moves are level-up moves,
+			 // which aren't limited and so aren't in `limitedEggMoves`
+			 return getAll ? ['*'] : true;
+		 }
+		 if (!getAll && eggMoves.length <= 1) return true;
+ 
+		 // gen 1 eggs come from gen 2 breeding
+		 const dex = this.dex.gen === 1 ? this.dex.mod('gen2') : this.dex;
+		 // In Gen 5 and earlier, egg moves can only be inherited from the father
+		 // we'll test each possible father separately
+		 let eggGroups = species.eggGroups;
+		 if (species.id === 'nidoqueen' || species.id === 'nidorina') {
+			 eggGroups = dex.species.get('nidoranf').eggGroups;
+		 } else if (species.id === 'shedinja') {
+			 // Shedinja and Nincada are different Egg groups; Shedinja itself is genderless
+			 eggGroups = dex.species.get('nincada').eggGroups;
+		 } else if (dex !== this.dex) {
+			 // Gen 1 tradeback; grab the egg groups from Gen 2
+			 eggGroups = dex.species.get(species.id).eggGroups;
+		 }
+		 if (eggGroups[0] === 'Undiscovered') eggGroups = dex.species.get(species.evos[0]).eggGroups;
+		 if (eggGroups[0] === 'Undiscovered' || !eggGroups.length) {
+			 throw new Error(`${species.name} has no egg groups for source ${source}`);
+		 }
+		 // no chainbreeding necessary if the father can be Smeargle
+		 if (!getAll && eggGroups.includes('Field')) return true;
+ 
+		 // try to find a father to inherit the egg move combination from
+		 for (const father of dex.species.all()) {
+			 // can't inherit from CAP pokemon
+			 if (father.isNonstandard) continue;
+			 // can't breed mons from future gens
+			 if (father.gen > eggGen) continue;
+			 // father must be male
+			 if (father.gender === 'N' || father.gender === 'F') continue;
+			 // can't inherit from dex entries with no learnsets
+			 if (!dex.species.getLearnset(father.id)) continue;
+			 // something is clearly wrong if its only possible father is itself
+			 // (exceptions: ExtremeSpeed Dragonite, Self-destruct Snorlax)
+			 if (species.id === father.id && !['dragonite', 'snorlax'].includes(father.id)) continue;
+			 // don't check NFE Pokémon - their evolutions will know all their moves and more
+			 // exception: Combee/Salandit, because their evos can't be fathers
+			 if (father.evos.length) {
+				 const evolvedFather = dex.species.get(father.evos[0]);
+				 if (evolvedFather.gen <= eggGen && evolvedFather.gender !== 'F') continue;
+			 }
+ 
+			 // must be able to breed with father
+			 if (!father.eggGroups.some(eggGroup => eggGroups.includes(eggGroup))) continue;
+ 
+			 // father must be able to learn the move
+			 if (!this.fatherCanLearn(father, eggMoves, eggGen)) continue;
+ 
+			 // father found!
+			 if (!getAll) return true;
+			 fathers.push(father.id);
+		 }
+		 if (!getAll) return false;
+		 return (!fathers.length && eggGen < 6) ? null : fathers;
+	 }
+ 
+	 /**
+	  * We could, if we wanted, do a complete move validation of the father's
+	  * moveset to see if it's valid. This would recurse and be NP-Hard so
+	  * instead we won't. We'll instead use a simplified algorithm: The father
+	  * can learn the moveset if it has at most one egg/event move.
+	  *
+	  * `eggGen` should be 5 or earlier. Later gens should never call this
+	  * function (the answer is always yes).
+	  */
+	 fatherCanLearn(species: Species, moves: ID[], eggGen: number) {
+		 let learnset = this.dex.species.getLearnset(species.id);
+		 if (!learnset) return false;
+ 
+		 if (species.id === 'smeargle') return true;
+		 const canBreedWithSmeargle = species.eggGroups.includes('Field');
+ 
+		 let eggMoveCount = 0;
+		 for (const move of moves) {
+			 let curSpecies: Species | null = species;
+			 /** 1 = can learn from egg, 2 = can learn unrestricted */
+			 let canLearn: 0 | 1 | 2 = 0;
+ 
+			 while (curSpecies) {
+				 learnset = this.dex.species.getLearnset(curSpecies.id);
+				 if (learnset && learnset[move]) {
+					 for (const moveSource of learnset[move]) {
+						 if (parseInt(moveSource.charAt(0)) > eggGen) continue;
+						 const canLearnFromSmeargle = moveSource.charAt(1) === 'E' && canBreedWithSmeargle;
+						 if (!'ESDV'.includes(moveSource.charAt(1)) || canLearnFromSmeargle) {
+							 canLearn = 2;
+							 break;
+						 } else {
+							 canLearn = 1;
+						 }
+					 }
+				 }
+				 if (canLearn === 2) break;
+				 curSpecies = this.learnsetParent(curSpecies);
+			 }
+ 
+			 if (!canLearn) return false;
+			 if (canLearn === 1) {
+				 eggMoveCount++;
+				 if (eggMoveCount > 1) return false;
+			 }
+		 }
+		 return true;
+	 }
+ 
+	 validateForme(set: PokemonSet) {
+		 const dex = this.dex;
+		 const name = set.name || set.species;
+ 
+		 const problems = [];
+		 const item = dex.items.get(set.item);
+		 const species = dex.species.get(set.species);
+ 
+		 if (species.name === 'Necrozma-Ultra') {
+			 const whichMoves = (set.moves.includes('sunsteelstrike') ? 1 : 0) +
+				 (set.moves.includes('moongeistbeam') ? 2 : 0);
+			 if (item.name !== 'Ultranecrozium Z') {
+				 // Necrozma-Ultra transforms from one of two formes, and neither one is the base forme
+				 problems.push(`Necrozma-Ultra must start the battle holding Ultranecrozium Z.`);
+			 } else if (whichMoves === 1) {
+				 set.species = 'Necrozma-Dusk-Mane';
+			 } else if (whichMoves === 2) {
+				 set.species = 'Necrozma-Dawn-Wings';
+			 } else {
+				 problems.push(`Necrozma-Ultra must start the battle as Necrozma-Dusk-Mane or Necrozma-Dawn-Wings holding Ultranecrozium Z. Please specify which Necrozma it should start as.`);
+			 }
+		 } else if (species.name === 'Zygarde-Complete') {
+			 problems.push(`Zygarde-Complete must start the battle as Zygarde or Zygarde-10% with Power Construct. Please specify which Zygarde it should start as.`);
+		 } else if (species.battleOnly) {
+			 if (species.requiredAbility && set.ability !== species.requiredAbility) {
+				 // Darmanitan-Zen
+				 problems.push(`${species.name} transforms in-battle with ${species.requiredAbility}, please fix its ability.`);
+			 }
+			 if (species.requiredItems) {
+				 if (!species.requiredItems.includes(item.name)) {
+					 // Mega or Primal
+					 problems.push(`${species.name} transforms in-battle with ${species.requiredItem}, please fix its item.`);
+				 }
+			 }
+			 if (species.requiredMove && !set.moves.map(toID).includes(toID(species.requiredMove))) {
+				 // Meloetta-Pirouette, Rayquaza-Mega
+				 problems.push(`${species.name} transforms in-battle with ${species.requiredMove}, please fix its moves.`);
+			 }
+			 if (typeof species.battleOnly !== 'string') {
+				 // Ultra Necrozma and Complete Zygarde are already checked above
+				 throw new Error(`${species.name} should have a string battleOnly`);
+			 }
+			 // Set to out-of-battle forme
+			 set.species = species.battleOnly;
+		 } else {
+			 if (species.requiredAbility) {
+				 // Impossible!
+				 throw new Error(`Species ${species.name} has a required ability despite not being a battle-only forme; it should just be in its abilities table.`);
+			 }
+			 if (species.requiredItems && !species.requiredItems.includes(item.name)) {
+				 if (dex.gen >= 8 && (species.baseSpecies === 'Arceus' || species.baseSpecies === 'Silvally')) {
+					 // Arceus/Silvally formes in gen 8 only require the item with Multitype/RKS System
+					 if (set.ability === species.abilities[0]) {
+						 problems.push(
+							 `${name} needs to hold ${species.requiredItems.join(' or ')}.`,
+							 `(It will revert to its Normal forme if you remove the item or give it a different item.)`
+						 );
+					 }
+				 } else {
+					 // Memory/Drive/Griseous Orb/Plate/Z-Crystal - Forme mismatch
+					 const baseSpecies = this.dex.species.get(species.changesFrom);
+					 problems.push(
+						 `${name} needs to hold ${species.requiredItems.join(' or ')} to be in its ${species.forme} forme.`,
+						 `(It will revert to its ${baseSpecies.baseForme || 'base'} forme if you remove the item or give it a different item.)`
+					 );
+				 }
+			 }
+			 if (species.requiredMove && !set.moves.map(toID).includes(toID(species.requiredMove))) {
+				 const baseSpecies = this.dex.species.get(species.changesFrom);
+				 problems.push(
+					 `${name} needs to know the move ${species.requiredMove} to be in its ${species.forme} forme.`,
+					 `(It will revert to its ${baseSpecies.baseForme} forme if it forgets the move.)`
+				 );
+			 }
+ 
+			 // Mismatches between the set forme (if not base) and the item signature forme will have been rejected already.
+			 // It only remains to assign the right forme to a set with the base species (Arceus/Genesect/Giratina/Silvally).
+			 if (item.forcedForme && species.name === dex.species.get(item.forcedForme).baseSpecies) {
+				 set.species = item.forcedForme;
+			 }
+		 }
+ 
+		 if (species.name === 'Pikachu-Cosplay') {
+			 const cosplay: {[k: string]: string} = {
+				 meteormash: 'Pikachu-Rock-Star', iciclecrash: 'Pikachu-Belle', drainingkiss: 'Pikachu-Pop-Star',
+				 electricterrain: 'Pikachu-PhD', flyingpress: 'Pikachu-Libre',
+			 };
+			 for (const moveid of set.moves) {
+				 if (moveid in cosplay) {
+					 set.species = cosplay[moveid];
+					 break;
+				 }
+			 }
+		 }
+ 
+		 if (species.name === 'Keldeo' && set.moves.map(toID).includes('secretsword' as ID) && dex.gen >= 8) {
+			 set.species = 'Keldeo-Resolute';
+		 }
+ 
+		 const crowned: {[k: string]: string} = {
+			 'Zacian-Crowned': 'behemothblade', 'Zamazenta-Crowned': 'behemothbash',
+		 };
+		 if (species.name in crowned) {
+			 const behemothMove = set.moves.map(toID).indexOf(crowned[species.name] as ID);
+			 if (behemothMove >= 0) {
+				 set.moves[behemothMove] = 'ironhead';
+			 }
+		 }
+		 return problems;
+	 }
+ 
+	 checkSpecies(set: PokemonSet, species: Species, tierSpecies: Species, setHas: {[k: string]: true}) {
+		 const dex = this.dex;
+		 const ruleTable = this.ruleTable;
+ 
+		 // https://www.smogon.com/forums/posts/8659168
+		 if (
+			 (tierSpecies.id === 'zamazentacrowned' && species.id === 'zamazenta') ||
+			 (tierSpecies.id === 'zaciancrowned' && species.id === 'zacian')
+		 ) {
+			 species = tierSpecies;
+		 }
+ 
+		 setHas['pokemon:' + species.id] = true;
+		 setHas['basepokemon:' + toID(species.baseSpecies)] = true;
+ 
+		 let isMega = false;
+		 if (tierSpecies !== species) {
+			 setHas['pokemon:' + tierSpecies.id] = true;
+			 if (tierSpecies.isMega || tierSpecies.isPrimal) {
+				 setHas['pokemontag:mega'] = true;
+				 isMega = true;
+			 }
+		 }
+ 
+		 let isGmax = false;
+		 if (tierSpecies.canGigantamax && set.gigantamax) {
+			 setHas['pokemon:' + tierSpecies.id + 'gmax'] = true;
+			 isGmax = true;
+		 }
+ 
+		 const tier = tierSpecies.tier === '(PU)' ? 'ZU' : tierSpecies.tier === '(NU)' ? 'PU' : tierSpecies.tier;
+		 const tierTag = 'pokemontag:' + toID(tier);
+		 setHas[tierTag] = true;
+ 
+		 const doublesTier = tierSpecies.doublesTier === '(DUU)' ? 'DNU' : tierSpecies.doublesTier;
+		 const doublesTierTag = 'pokemontag:' + toID(doublesTier);
+		 setHas[doublesTierTag] = true;
+ 
+		 const ndTier = tierSpecies.natDexTier === '(PU)' ? 'ZU' :
+			 tierSpecies.natDexTier === '(NU)' ? 'PU' : tierSpecies.natDexTier;
+		 const ndTierTag = 'pokemontag:nd' + toID(ndTier);
+		 setHas[ndTierTag] = true;
+ 
+		 // Only pokemon that can gigantamax should have the Gmax flag
+		 if (!tierSpecies.canGigantamax && set.gigantamax) {
+			 return `${tierSpecies.name} cannot Gigantamax but is flagged as being able to.`;
+		 }
+ 
+		 let banReason = ruleTable.check('pokemon:' + species.id);
+		 if (banReason) {
+			 return `${species.name} is ${banReason}.`;
+		 }
+		 if (banReason === '') return null;
+ 
+		 if (tierSpecies !== species) {
+			 banReason = ruleTable.check('pokemon:' + tierSpecies.id);
+			 if (banReason) {
+				 return `${tierSpecies.name} is ${banReason}.`;
+			 }
+			 if (banReason === '') return null;
+		 }
+ 
+		 if (isMega) {
+			 banReason = ruleTable.check('pokemontag:mega', setHas);
+			 if (banReason) {
+				 return `Mega evolutions are ${banReason}.`;
+			 }
+		 }
+ 
+		 if (isGmax) {
+			 banReason = ruleTable.check('pokemon:' + tierSpecies.id + 'gmax');
+			 if (banReason) {
+				 return `Gigantamaxing ${species.name} is ${banReason}.`;
+			 }
+		 }
+ 
+		 banReason = ruleTable.check('basepokemon:' + toID(species.baseSpecies));
+		 if (banReason) {
+			 return `${species.name} is ${banReason}.`;
+		 }
+		 if (banReason === '') {
+			 // don't allow nonstandard speciess when whitelisting standard base species
+			 // i.e. unbanning Pichu doesn't mean allowing Pichu-Spiky-Eared outside of Gen 4
+			 const baseSpecies = dex.species.get(species.baseSpecies);
+			 if (baseSpecies.isNonstandard === species.isNonstandard) {
+				 return null;
+			 }
+		 }
+ 
+		 // We can't return here because the `-nonexistent` rule is a bit
+		 // complicated in terms of what trumps it. We don't want e.g.
+		 // +Mythical to unban Shaymin in Gen 1, for instance.
+		 let nonexistentCheck = Tags.nonexistent.genericFilter!(tierSpecies) && ruleTable.check('nonexistent');
+ 
+		 const EXISTENCE_TAG = ['past', 'future', 'lgpe', 'unobtainable', 'cap', 'custom', 'nonexistent'];
+ 
+		 for (const ruleid of ruleTable.tagRules) {
+			 if (ruleid.startsWith('*')) continue;
+			 const tagid = ruleid.slice(12);
+			 const tag = Tags[tagid];
+			 if ((tag.speciesFilter || tag.genericFilter)!(tierSpecies)) {
+				 const existenceTag = EXISTENCE_TAG.includes(tagid);
+				 if (ruleid.startsWith('+')) {
+					 // we want rules like +CAP to trump -Nonexistent, but most tags shouldn't
+					 if (!existenceTag && nonexistentCheck) continue;
+					 return null;
+				 }
+				 if (existenceTag) {
+					 // for a nicer error message
+					 nonexistentCheck = 'banned';
+					 break;
+				 }
+				 return `${species.name} is tagged ${tag.name}, which is ${ruleTable.check(ruleid.slice(1)) || "banned"}.`;
+			 }
+		 }
+ 
+		 if (nonexistentCheck) {
+			 if (tierSpecies.isNonstandard === 'Past' || tierSpecies.isNonstandard === 'Future') {
+				 return `${tierSpecies.name} does not exist in Gen ${dex.gen}.`;
+			 }
+			 if (tierSpecies.isNonstandard === 'LGPE') {
+				 return `${tierSpecies.name} does not exist in this game, only in Let's Go Pikachu/Eevee.`;
+			 }
+			 if (tierSpecies.isNonstandard === 'CAP') {
+				 return `${tierSpecies.name} is a CAP and does not exist in this game.`;
+			 }
+			 if (tierSpecies.isNonstandard === 'Unobtainable') {
+				 return `${tierSpecies.name} is not possible to obtain in this game.`;
+			 }
+			 if (tierSpecies.isNonstandard === 'Gigantamax') {
+				 return `${tierSpecies.name} is a placeholder for a Gigantamax sprite, not a real Pokémon. (This message is likely to be a validator bug.)`;
+			 }
+			 return `${tierSpecies.name} does not exist in this game.`;
+		 }
+		 if (nonexistentCheck === '') return null;
+ 
+		 // Special casing for Pokemon that can Gmax, but their Gmax factor cannot be legally obtained
+		 if (tierSpecies.gmaxUnreleased && set.gigantamax) {
+			 banReason = ruleTable.check('pokemontag:unobtainable');
+			 if (banReason) {
+				 return `${tierSpecies.name} is flagged as gigantamax, but it cannot gigantamax without hacking or glitches.`;
+			 }
+			 if (banReason === '') return null;
+		 }
+ 
+		 banReason = ruleTable.check('pokemontag:allpokemon');
+		 if (banReason) {
+			 return `${species.name} is not in the list of allowed pokemon.`;
+		 }
+ 
+		 return null;
+	 }
+ 
+	 checkItem(set: PokemonSet, item: Item, setHas: {[k: string]: true}) {
+		 const dex = this.dex;
+		 const ruleTable = this.ruleTable;
+ 
+		 setHas['item:' + item.id] = true;
+ 
+		 let banReason = ruleTable.check('item:' + (item.id || 'noitem'));
+		 if (banReason) {
+			 if (!item.id) {
+				 return `${set.name} not holding an item is ${banReason}.`;
+			 }
+			 return `${set.name}'s item ${item.name} is ${banReason}.`;
+		 }
+		 if (banReason === '') return null;
+ 
+		 if (!item.id) return null;
+ 
+		 banReason = ruleTable.check('pokemontag:allitems');
+		 if (banReason) {
+			 return `${set.name}'s item ${item.name} is not in the list of allowed items.`;
+		 }
+ 
+		 // obtainability
+		 if (item.isNonstandard) {
+			 banReason = ruleTable.check('pokemontag:' + toID(item.isNonstandard));
+			 if (banReason) {
+				 if (item.isNonstandard === 'Unobtainable') {
+					 return `${item.name} is not obtainable without hacking or glitches.`;
+				 }
+				 return `${set.name}'s item ${item.name} is tagged ${item.isNonstandard}, which is ${banReason}.`;
+			 }
+			 if (banReason === '') return null;
+		 }
+ 
+		 if (item.isNonstandard && item.isNonstandard !== 'Unobtainable') {
+			 banReason = ruleTable.check('nonexistent', setHas);
+			 if (banReason) {
+				 if (['Past', 'Future'].includes(item.isNonstandard)) {
+					 return `${set.name}'s item ${item.name} does not exist in Gen ${dex.gen}.`;
+				 }
+				 return `${set.name}'s item ${item.name} does not exist in this game.`;
+			 }
+			 if (banReason === '') return null;
+		 }
+ 
+		 return null;
+	 }
+ 
+	 checkMove(set: PokemonSet, move: Move, setHas: {[k: string]: true}) {
+		 const dex = this.dex;
+		 const ruleTable = this.ruleTable;
+ 
+		 setHas['move:' + move.id] = true;
+ 
+		 let banReason = ruleTable.check('move:' + move.id);
+		 if (banReason) {
+			 return `${set.name}'s move ${move.name} is ${banReason}.`;
+		 }
+		 if (banReason === '') return null;
+ 
+		 banReason = ruleTable.check('pokemontag:allmoves');
+		 if (banReason) {
+			 return `${set.name}'s move ${move.name} is not in the list of allowed moves.`;
+		 }
+ 
+		 // obtainability
+		 if (move.isNonstandard) {
+			 banReason = ruleTable.check('pokemontag:' + toID(move.isNonstandard));
+			 if (banReason) {
+				 if (move.isNonstandard === 'Unobtainable') {
+					 return `${move.name} is not obtainable without hacking or glitches.`;
+				 }
+				 if (move.isNonstandard === 'Gigantamax') {
+					 return `${move.name} is not usable without Gigantamaxing its user, ${move.isMax}.`;
+				 }
+				 return `${set.name}'s move ${move.name} is tagged ${move.isNonstandard}, which is ${banReason}.`;
+			 }
+			 if (banReason === '') return null;
+		 }
+ 
+		 if (move.isNonstandard && move.isNonstandard !== 'Unobtainable') {
+			 banReason = ruleTable.check('nonexistent', setHas);
+			 if (banReason) {
+				 if (['Past', 'Future'].includes(move.isNonstandard)) {
+					 return `${set.name}'s move ${move.name} does not exist in Gen ${dex.gen}.`;
+				 }
+				 return `${set.name}'s move ${move.name} does not exist in this game.`;
+			 }
+			 if (banReason === '') return null;
+		 }
+ 
+		 return null;
+	 }
+ 
+	 checkAbility(set: PokemonSet, ability: Ability, setHas: {[k: string]: true}) {
+		 const dex = this.dex;
+		 const ruleTable = this.ruleTable;
+ 
+		 setHas['ability:' + ability.id] = true;
+ 
+		 if (this.format.id.startsWith('gen8pokebilities')) {
+			 const species = dex.species.get(set.species);
+			 const unSeenAbilities = Object.keys(species.abilities)
+				 .filter(key => key !== 'S' && (key !== 'H' || !species.unreleasedHidden))
+				 .map(key => species.abilities[key as "0" | "1" | "H" | "S"]);
+ 
+			 if (ability.id !== this.toID(species.abilities['S'])) {
+				 for (const abilityName of unSeenAbilities) {
+					 setHas['ability:' + toID(abilityName)] = true;
+				 }
+			 }
+		 }
+ 
+		 let banReason = ruleTable.check('ability:' + ability.id);
+		 if (banReason) {
+			 return `${set.name}'s ability ${ability.name} is ${banReason}.`;
+		 }
+		 if (banReason === '') return null;
+ 
+		 banReason = ruleTable.check('pokemontag:allabilities');
+		 if (banReason) {
+			 return `${set.name}'s ability ${ability.name} is not in the list of allowed abilities.`;
+		 }
+ 
+		 // obtainability
+		 if (ability.isNonstandard) {
+			 banReason = ruleTable.check('pokemontag:' + toID(ability.isNonstandard));
+			 if (banReason) {
+				 return `${set.name}'s ability ${ability.name} is tagged ${ability.isNonstandard}, which is ${banReason}.`;
+			 }
+			 if (banReason === '') return null;
+ 
+			 banReason = ruleTable.check('nonexistent', setHas);
+			 if (banReason) {
+				 if (['Past', 'Future'].includes(ability.isNonstandard)) {
+					 return `${set.name}'s ability ${ability.name} does not exist in Gen ${dex.gen}.`;
+				 }
+				 return `${set.name}'s ability ${ability.name} does not exist in this game.`;
+			 }
+			 if (banReason === '') return null;
+		 }
+ 
+		 return null;
+	 }
+ 
+	 checkNature(set: PokemonSet, nature: Nature, setHas: {[k: string]: true}) {
+		 const dex = this.dex;
+		 const ruleTable = this.ruleTable;
+ 
+		 setHas['nature:' + nature.id] = true;
+ 
+		 let banReason = ruleTable.check('nature:' + nature.id);
+		 if (banReason) {
+			 return `${set.name}'s nature ${nature.name} is ${banReason}.`;
+		 }
+		 if (banReason === '') return null;
+ 
+		 banReason = ruleTable.check('allnatures');
+		 if (banReason) {
+			 return `${set.name}'s nature ${nature.name} is not in the list of allowed natures.`;
+		 }
+ 
+		 // obtainability
+		 if (nature.isNonstandard) {
+			 banReason = ruleTable.check('pokemontag:' + toID(nature.isNonstandard));
+			 if (banReason) {
+				 return `${set.name}'s nature ${nature.name} is tagged ${nature.isNonstandard}, which is ${banReason}.`;
+			 }
+			 if (banReason === '') return null;
+ 
+			 banReason = ruleTable.check('nonexistent', setHas);
+			 if (banReason) {
+				 if (['Past', 'Future'].includes(nature.isNonstandard)) {
+					 return `${set.name}'s nature ${nature.name} does not exist in Gen ${dex.gen}.`;
+				 }
+				 return `${set.name}'s nature ${nature.name} does not exist in this game.`;
+			 }
+			 if (banReason === '') return null;
+		 }
+		 return null;
+	 }
+ 
+	 validateEvent(
+		 set: PokemonSet, setSources: PokemonSources, eventData: EventInfo, eventSpecies: Species
+	 ): true | undefined;
+	 validateEvent(
+		 set: PokemonSet, setSources: PokemonSources, eventData: EventInfo, eventSpecies: Species,
+		 because: string, from?: string
+	 ): string[] | undefined;
+	 /**
+	  * Returns array of error messages if invalid, undefined if valid
+	  *
+	  * If `because` is not passed, instead returns true if invalid.
+	  */
+	 validateEvent(
+		 set: PokemonSet, setSources: PokemonSources, eventData: EventInfo, eventSpecies: Species,
+		 because = ``, from = `from an event`
+	 ) {
+		 const dex = this.dex;
+		 let name = set.species;
+		 const species = dex.species.get(set.species);
+		 const maxSourceGen = this.ruleTable.has('allowtradeback') ? Utils.clampIntRange(dex.gen + 1, 1, 8) : dex.gen;
+		 if (!eventSpecies) eventSpecies = species;
+		 if (set.name && set.species !== set.name && species.baseSpecies !== set.name) name = `${set.name} (${set.species})`;
+ 
+		 const fastReturn = !because;
+		 if (eventData.from) from = `from ${eventData.from}`;
+		 const etc = `${because} ${from}`;
+ 
+		 const problems = [];
+ 
+		 if (dex.gen < 8 && this.minSourceGen > eventData.generation) {
+			 if (fastReturn) return true;
+			 problems.push(`This format requires Pokemon from gen ${this.minSourceGen} or later and ${name} is from gen ${eventData.generation}${etc}.`);
+		 }
+		 if (maxSourceGen < eventData.generation) {
+			 if (fastReturn) return true;
+			 problems.push(`This format is in gen ${dex.gen} and ${name} is from gen ${eventData.generation}${etc}.`);
+		 }
+ 
+		 if (eventData.japan && dex.currentMod !== 'gen1jpn') {
+			 if (fastReturn) return true;
+			 problems.push(`${name} has moves from Japan-only events, but this format simulates International Yellow/Crystal which can't trade with Japanese games.`);
+		 }
+ 
+		 if (eventData.level && (set.level || 0) < eventData.level) {
+			 if (fastReturn) return true;
+			 problems.push(`${name} must be at least level ${eventData.level}${etc}.`);
+		 }
+		 if ((eventData.shiny === true && !set.shiny) || (!eventData.shiny && set.shiny)) {
+			 if (fastReturn) return true;
+			 const shinyReq = eventData.shiny ? ` be shiny` : ` not be shiny`;
+			 problems.push(`${name} must${shinyReq}${etc}.`);
+		 }
+		 if (eventData.gender) {
+			 if (set.gender && eventData.gender !== set.gender) {
+				 if (fastReturn) return true;
+				 problems.push(`${name}'s gender must be ${eventData.gender}${etc}.`);
+			 }
+		 }
+		 const canMint = dex.gen > 7;
+		 if (eventData.nature && eventData.nature !== set.nature && !canMint) {
+			 if (fastReturn) return true;
+			 problems.push(`${name} must have a ${eventData.nature} nature${etc} - Mints are only available starting gen 8.`);
+		 }
+		 let requiredIVs = 0;
+		 if (eventData.ivs) {
+			 /** In Gen 7, IVs can be changed to 31 */
+			 const canBottleCap = (dex.gen >= 7 && set.level === 100);
+ 
+			 if (!set.ivs) set.ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
+			 let statName: StatID;
+			 for (statName in eventData.ivs) {
+				 if (canBottleCap && set.ivs[statName] === 31) continue;
+				 if (set.ivs[statName] !== eventData.ivs[statName]) {
+					 if (fastReturn) return true;
+					 problems.push(`${name} must have ${eventData.ivs[statName]} ${Dex.stats.names[statName]} IVs${etc}.`);
+				 }
+			 }
+ 
+			 if (canBottleCap) {
+				 // IVs can be overridden but Hidden Power type can't
+				 if (Object.keys(eventData.ivs).length >= 6) {
+					 const requiredHpType = dex.getHiddenPower(eventData.ivs).type;
+					 if (set.hpType && set.hpType !== requiredHpType) {
+						 if (fastReturn) return true;
+						 problems.push(`${name} can only have Hidden Power ${requiredHpType}${etc}.`);
+					 }
+					 set.hpType = requiredHpType;
+				 }
+			 }
+		 } else {
+			 requiredIVs = eventData.perfectIVs || 0;
+		 }
+		 if (requiredIVs && set.ivs) {
+			 // Legendary Pokemon must have at least 3 perfect IVs in gen 6
+			 // Events can also have a certain amount of guaranteed perfect IVs
+			 let perfectIVs = 0;
+			 let statName: StatID;
+			 for (statName in set.ivs) {
+				 if (set.ivs[statName] >= 31) perfectIVs++;
+			 }
+			 if (perfectIVs < requiredIVs) {
+				 if (fastReturn) return true;
+				 if (eventData.perfectIVs) {
+					 problems.push(`${name} must have at least ${requiredIVs} perfect IVs${etc}.`);
+				 }
+			 }
+			 // The perfect IV count affects Hidden Power availability
+			 if (dex.gen >= 3 && requiredIVs >= 3 && set.hpType === 'Fighting') {
+				 if (fastReturn) return true;
+				 problems.push(`${name} can't use Hidden Power Fighting because it must have at least three perfect IVs${etc}.`);
+			 } else if (dex.gen >= 3 && requiredIVs >= 5 && set.hpType &&
+					 !['Dark', 'Dragon', 'Electric', 'Steel', 'Ice'].includes(set.hpType)) {
+				 if (fastReturn) return true;
+				 problems.push(`${name} can only use Hidden Power Dark/Dragon/Electric/Steel/Ice because it must have at least 5 perfect IVs${etc}.`);
+			 }
+		 }
+		 const ruleTable = this.ruleTable;
+		 if (ruleTable.has('obtainablemoves')) {
+			 const ssMaxSourceGen = setSources.maxSourceGen();
+			 const tradebackEligible = dex.gen === 2 && species.gen === 1;
+			 if (ssMaxSourceGen && eventData.generation > ssMaxSourceGen && !tradebackEligible) {
+				 if (fastReturn) return true;
+				 problems.push(`${name} must not have moves only learnable in gen ${ssMaxSourceGen}${etc}.`);
+			 }
+		 }
+		 if (ruleTable.has('obtainableabilities')) {
+			 if (dex.gen <= 5 && eventData.abilities && eventData.abilities.length === 1 && !eventData.isHidden) {
+				 if (species.name === eventSpecies.name) {
+					 // has not evolved, abilities must match
+					 const requiredAbility = dex.abilities.get(eventData.abilities[0]).name;
+					 if (set.ability !== requiredAbility) {
+						 if (fastReturn) return true;
+						 problems.push(`${name} must have ${requiredAbility}${etc}.`);
+					 }
+				 } else {
+					 // has evolved
+					 const ability1 = dex.abilities.get(eventSpecies.abilities['1']);
+					 if (ability1.gen && eventData.generation >= ability1.gen) {
+						 // pokemon had 2 available abilities in the gen the event happened
+						 // ability is restricted to a single ability slot
+						 const requiredAbilitySlot = (toID(eventData.abilities[0]) === ability1.id ? 1 : 0);
+						 const requiredAbility = dex.abilities.get(species.abilities[requiredAbilitySlot] || species.abilities['0']).name;
+						 if (set.ability !== requiredAbility) {
+							 const originalAbility = dex.abilities.get(eventData.abilities[0]).name;
+							 if (fastReturn) return true;
+							 problems.push(`${name} must have ${requiredAbility}${because} from a ${originalAbility} ${eventSpecies.name} event.`);
+						 }
+					 }
+				 }
+			 }
+			 if (species.abilities['H']) {
+				 const isHidden = (set.ability === species.abilities['H']);
+				 const canUseAbilityPatch = dex.gen >= 8 && this.format.mod !== 'gen8dlc1';
+				 if (!isHidden || !canUseAbilityPatch) {
+					 const hiddenAbilityProblem = this.validateEventHiddenAbility(name, isHidden, eventData, etc);
+					 if (hiddenAbilityProblem) {
+						 if (fastReturn) return true;
+						 problems.push(hiddenAbilityProblem);
+					 }
+				 }
+			 }
+		 }
+		 if (problems.length) return problems;
+		 if (eventData.gender) set.gender = eventData.gender;
+	 }
+ 
+	 validateEventHiddenAbility(name: string, isHidden: boolean, eventData: EventInfo, etc: string) {
+		 if (!isHidden && eventData.isHidden) {
+			 return `${name} must have its Hidden Ability${etc}.`;
+		 }
+ 
+		 if (isHidden && !eventData.isHidden) {
+			 return `${name} must not have its Hidden Ability${etc}.`;
+		 }
+		 return null;
+	 }
+ 
+	 allSources(species?: Species) {
+		 let minSourceGen = this.minSourceGen;
+		 if (this.dex.gen >= 3 && minSourceGen < 3) minSourceGen = 3;
+		 if (species) minSourceGen = Math.max(minSourceGen, species.gen);
+		 const maxSourceGen = this.ruleTable.has('allowtradeback') ? Utils.clampIntRange(this.dex.gen + 1, 1, 8) : this.dex.gen;
+		 return new PokemonSources(maxSourceGen, minSourceGen);
+	 }
+ 
+	 validateMoves(
+		 species: Species, moves: string[], setSources: PokemonSources, set?: Partial<PokemonSet>,
+		 name: string = species.name
+	 ) {
+		 const dex = this.dex;
+		 const ruleTable = this.ruleTable;
+ 
+		 const problems = [];
+ 
+		 const checkCanLearn = (ruleTable.checkCanLearn && ruleTable.checkCanLearn[0] || this.checkCanLearn);
+		 for (const moveName of moves) {
+			 const move = dex.moves.get(moveName);
+			 const problem = checkCanLearn.call(this, move, species, setSources, set);
+			 if (problem) {
+				 problems.push(`${name}${problem}`);
+				 break;
+			 }
+		 }
+ 
+		 if (setSources.size() && setSources.moveEvoCarryCount > 3) {
+			 if (setSources.sourcesBefore < 6) setSources.sourcesBefore = 0;
+			 setSources.sources = setSources.sources.filter(
+				 source => source.charAt(1) === 'E' && parseInt(source.charAt(0)) >= 6
+			 );
+			 if (!setSources.size()) {
+				 problems.push(`${name} needs to know ${species.evoMove || 'a Fairy-type move'} to evolve, so it can only know 3 other moves from ${species.prevo}.`);
+			 }
+		 }
+ 
+		 if (problems.length) return problems;
+ 
+		 
+		 const canUseAbilityPatch = dex.gen >= 8 && this.format.mod !== 'gen8dlc1';
+		 if (setSources.isHidden && !canUseAbilityPatch) {
+			 setSources.sources = setSources.sources.filter(
+				 source => parseInt(source.charAt(0)) >= 5
+			 );
+			 if (setSources.sourcesBefore < 5) setSources.sourcesBefore = 0;
+			 if (!setSources.size()) {
+				 problems.push(`${name} has a hidden ability - it can't have moves only learned before gen 5.`);
+				 return problems;
+			 }
+		 }
+ 
+		 if (setSources.babyOnly && setSources.sources.length) {
+			 const baby = dex.species.get(setSources.babyOnly);
+			 const babyEvo = toID(baby.evos[0]);
+			 setSources.sources = setSources.sources.filter(source => {
+				 if (source.charAt(1) === 'S') {
+					 const sourceId = source.split(' ')[1];
+					 if (sourceId !== baby.id) return false;
+				 }
+				 if (source.charAt(1) === 'E') {
+					 if (babyEvo && source.slice(2) === babyEvo) return false;
+				 }
+				 if (source.charAt(1) === 'D') {
+					 if (babyEvo && source.slice(2) === babyEvo) return false;
+				 }
+				 return true;
+			 });
+			 if (!setSources.size()) {
+				 problems.push(`${name}'s event/egg moves are from an evolution, and are incompatible with its moves from ${baby.name}.`);
+			 }
+		 }
+		 if (setSources.babyOnly && setSources.size() && this.gen > 2) {
+			 // there do theoretically exist evo/tradeback incompatibilities in
+			 // gen 2, but those are very complicated to validate and should be
+			 // handled separately anyway, so for now we just treat them all as
+			 // legal (competitively relevant ones can be manually banned)
+			 const baby = dex.species.get(setSources.babyOnly);
+			 setSources.sources = setSources.sources.filter(source => {
+				 if (baby.gen > parseInt(source.charAt(0)) && !source.startsWith('1ST')) return false;
+				 if (baby.gen > 2 && source === '7V') return false;
+				 return true;
+			 });
+			 if (setSources.sourcesBefore < baby.gen) setSources.sourcesBefore = 0;
+			 if (!setSources.size()) {
+				 problems.push(`${name} has moves from before Gen ${baby.gen}, which are incompatible with its moves from ${baby.name}.`);
+			 }
+		 }
+ 
+		 return problems;
+	 }
+ 
+	 /** Returns null if you can learn the move, or a string explaining why you can't learn it */
+	 checkCanLearn(
+		 move: Move,
+		 s: Species,
+		 setSources = this.allSources(s),
+		 set: Partial<PokemonSet> = {}
+	 ): string | null {
+		 const dex = this.dex;
+		 if (!setSources.size()) throw new Error(`Bad sources passed to checkCanLearn`);
+ 
+		 move = dex.moves.get(move);
+		 const moveid = move.id;
+		 const baseSpecies = dex.species.get(s);
+		 let species: Species | null = baseSpecies;
+ 
+		 const format = this.format;
+		 const ruleTable = dex.formats.getRuleTable(format);
+		 const alreadyChecked: {[k: string]: boolean} = {};
+		 const level = set.level || 100;
+ 
+		 let cantLearnReason = null;
+ 
+		 let limit1 = true;
+		 let sketch = false;
+		 let blockedHM = false;
+ 
+		 let babyOnly = '';
+ 
+		 // This is a pretty complicated algorithm
+ 
+		 // Abstractly, what it does is construct the union of sets of all
+		 // possible ways this pokemon could be obtained, and then intersect
+		 // it with a the pokemon's existing set of all possible ways it could
+		 // be obtained. If this intersection is non-empty, the move is legal.
+ 
+		 // set of possible sources of a pokemon with this move
+		 const moveSources = new PokemonSources();
+ 
+		 /**
+		  * The format doesn't allow Pokemon traded from the future
+		  * (This is everything except in Gen 1 Tradeback)
+		  */
+		 const noFutureGen = !ruleTable.has('allowtradeback');
+		 /**
+		  * The format allows Sketch to copy moves in Gen 8
+		  */
+		 const canSketchGen8Moves = ruleTable.has('sketchgen8moves') || this.dex.currentMod === 'gen8bdsp';
+ 
+		 let tradebackEligible = false;
+		 while (species?.name && !alreadyChecked[species.id]) {
+			 alreadyChecked[species.id] = true;
+			 if (dex.gen <= 2 && species.gen === 1) tradebackEligible = true;
+			 const learnset = dex.species.getLearnset(species.id);
+			 if (!learnset) {
+				 if ((species.changesFrom || species.baseSpecies) !== species.name) {
+					 // forme without its own learnset
+					 species = dex.species.get(species.changesFrom || species.baseSpecies);
+					 // warning: formes with their own learnset, like Wormadam, should NOT
+					 // inherit from their base forme unless they're freely switchable
+					 continue;
+				 }
+				 if (species.isNonstandard) {
+					 // It's normal for a nonstandard species not to have learnset data
+ 
+					 // Formats should replace the `Obtainable Moves` rule if they want to
+					 // allow pokemon without learnsets.
+					 return ` can't learn any moves at all.`;
+				 }
+				 // should never happen
+				 throw new Error(`Species with no learnset data: ${species.id}`);
+			 }
+			 const checkingPrevo = species.baseSpecies !== s.baseSpecies;
+			 if (checkingPrevo && !moveSources.size()) {
+				 if (!setSources.babyOnly || !species.prevo) {
+					 babyOnly = species.id;
+				 }
+			 }
+ 
+			 let sources = learnset[moveid];
+			 if (moveid === 'sketch') {
+				 sketch = true;
+			 } else if (learnset['sketch']) {
+				 if (move.noSketch || move.isZ || move.isMax) {
+					 cantLearnReason = `can't be Sketched.`;
+				 } else if (move.gen > 7 && !canSketchGen8Moves) {
+					 cantLearnReason = `can't be Sketched because it's a Gen 8 move and Sketch isn't available in Gen 8.`;
+				 } else {
+					 if (!sources) sketch = true;
+					 sources = learnset['sketch'].concat(sources || []);
+				 }
+			 }
+ 
+			 if (typeof sources === 'string') sources = [sources];
+			 if (sources) {
+				 for (let learned of sources) {
+					 // Every `learned` represents a single way a pokemon might
+					 // learn a move. This can be handled one of several ways:
+					 // `continue`
+					 //   means we can't learn it
+					 // `return null`
+					 //   means we can learn it with no restrictions
+					 //   (there's a way to just teach any pokemon of this species
+					 //   the move in the current gen, like a TM.)
+					 // `moveSources.add(source)`
+					 //   means we can learn it only if obtained that exact way described
+					 //   in source
+					 // `moveSources.addGen(learnedGen)`
+					 //   means we can learn it only if obtained at or before learnedGen
+					 //   (i.e. get the pokemon however you want, transfer to that gen,
+					 //   teach it, and transfer it to the current gen.)
+ 
+					 const learnedGen = parseInt(learned.charAt(0));
+					 if (learnedGen < this.minSourceGen) {
+						 if (!cantLearnReason) {
+							 cantLearnReason = `can't be transferred from Gen ${learnedGen} to ${this.minSourceGen}.`;
+						 }
+						 continue;
+					 }
+					 if (noFutureGen && learnedGen > dex.gen) {
+						 if (!cantLearnReason) {
+							 cantLearnReason = `can't be transferred from Gen ${learnedGen} to ${dex.gen}.`;
+						 }
+						 continue;
+					 }
+ 
+					 // redundant
+					 if (learnedGen <= moveSources.sourcesBefore) continue;
+ 
+					 if (baseSpecies.evoRegion === 'Alola' && checkingPrevo && learnedGen >= 8) {
+						 cantLearnReason = `is from a ${species.name} that can't be transferred to USUM to evolve into ${baseSpecies.name}.`;
+						 continue;
+					 }
+ 
+					 const canUseAbilityPatch = dex.gen >= 8 && format.mod !== 'gen8dlc1';
+					 if (
+						 learnedGen < 7 && setSources.isHidden && !canUseAbilityPatch &&
+						 !dex.mod('gen' + learnedGen).species.get(baseSpecies.name).abilities['H']
+					 ) {
+						 cantLearnReason = `can only be learned in gens without Hidden Abilities.`;
+						 continue;
+					 }
+					 if (!species.isNonstandard) {
+						 // HMs can't be transferred
+						 if (dex.gen >= 4 && learnedGen <= 3 && [
+							 'cut', 'fly', 'surf', 'strength', 'flash', 'rocksmash', 'waterfall', 'dive',
+						 ].includes(moveid)) {
+							 cantLearnReason = `can't be transferred from Gen 3 to 4 because it's an HM move.`;
+							 continue;
+						 }
+						 if (dex.gen >= 5 && learnedGen <= 4 && [
+							 'cut', 'fly', 'surf', 'strength', 'rocksmash', 'waterfall', 'rockclimb',
+						 ].includes(moveid)) {
+							 cantLearnReason = `can't be transferred from Gen 4 to 5 because it's an HM move.`;
+							 continue;
+						 }
+						 // Defog and Whirlpool can't be transferred together
+						 if (dex.gen >= 5 && ['defog', 'whirlpool'].includes(moveid) && learnedGen <= 4) blockedHM = true;
+					 }
+ 
+					 if (learned.charAt(1) === 'L') {
+						 // special checking for level-up moves
+						 if (level >= parseInt(learned.substr(2)) || learnedGen === 7) {
+							 // we're past the required level to learn it
+							 // (gen 7 level-up moves can be relearnered at any level)
+							 // falls through to LMT check below
+						 } else if (level >= 5 && learnedGen === 3 && species.canHatch) {
+							 // Pomeg Glitch
+						 } else if ((!species.gender || species.gender === 'F') && learnedGen >= 2 && species.canHatch) {
+							 // available as egg move
+							 learned = learnedGen + 'Eany';
+							 // falls through to E check below
+						 } else {
+							 // this move is unavailable, skip it
+							 cantLearnReason = `is learned at level ${parseInt(learned.substr(2))}.`;
+							 continue;
+						 }
+					 }
+ 
+					 // Gen 8 egg moves can be taught to any pokemon from any source
+					 if (learned === '8E' || 'LMTR'.includes(learned.charAt(1))) {
+						 if (learnedGen === dex.gen && learned.charAt(1) !== 'R') {
+							 // current-gen level-up, TM or tutor moves:
+							 //   always available
+							 if (learned !== '8E' && babyOnly) setSources.babyOnly = babyOnly;
+							 if (!moveSources.moveEvoCarryCount) return null;
+						 }
+						 // past-gen level-up, TM, or tutor moves:
+						 //   available as long as the source gen was or was before this gen
+						 if (learned.charAt(1) === 'R') {
+							 moveSources.restrictedMove = moveid;
+						 }
+						 limit1 = false;
+						 moveSources.addGen(learnedGen);
+					 } else if (learned.charAt(1) === 'E') {
+						 // egg moves:
+						 //   only if hatched from an egg
+						 let limitedEggMove: ID | null | undefined = undefined;
+						 if (learned.slice(1) === 'Eany') {
+							 limitedEggMove = null;
+						 } else if (learnedGen < 6) {
+							 limitedEggMove = move.id;
+						 }
+						 learned = learnedGen + 'E' + (species.prevo ? species.id : '');
+						 if (tradebackEligible && learnedGen === 2 && move.gen <= 1) {
+							 // can tradeback
+							 moveSources.add('1ET' + learned.slice(2));
+						 }
+						 moveSources.add(learned, limitedEggMove);
+					 } else if (learned.charAt(1) === 'S') {
+						 // event moves:
+						 //   only if that was the source
+						 // Event Pokémon:
+						 // 	Available as long as the past gen can get the Pokémon and then trade it back.
+						 if (tradebackEligible && learnedGen === 2 && move.gen <= 1) {
+							 // can tradeback
+							 moveSources.add('1ST' + learned.slice(2) + ' ' + species.id);
+						 }
+						 moveSources.add(learned + ' ' + species.id);
+					 } else if (learned.charAt(1) === 'D') {
+						 // DW moves:
+						 //   only if that was the source
+						 moveSources.add(learned + species.id);
+					 } else if (learned.charAt(1) === 'V' && this.minSourceGen < learnedGen) {
+						 // Virtual Console or Let's Go transfer moves:
+						 //   only if that was the source
+						 moveSources.add(learned);
+					 }
+				 }
+			 }
+			 if (ruleTable.has('mimicglitch') && species.gen < 5) {
+				 // include the Mimic Glitch when checking this mon's learnset
+				 const glitchMoves = ['metronome', 'copycat', 'transform', 'mimic', 'assist'];
+				 let getGlitch = false;
+				 for (const i of glitchMoves) {
+					 if (learnset[i]) {
+						 if (!(i === 'mimic' && dex.abilities.get(set.ability).gen === 4 && !species.prevo)) {
+							 getGlitch = true;
+							 break;
+						 }
+					 }
+				 }
+				 if (getGlitch) {
+					 moveSources.addGen(4);
+					 if (move.gen < 5) {
+						 limit1 = false;
+					 }
+				 }
+			 }
+ 
+			 if (!moveSources.size()) {
+				 if (
+					 (species.evoType === 'levelMove' && species.evoMove !== move.name) ||
+					 (species.id === 'sylveon' && move.type !== 'Fairy')
+				 ) {
+					 moveSources.moveEvoCarryCount = 1;
+				 }
+			 }
+ 
+			 // also check to see if the mon's prevo or freely switchable formes can learn this move
+			 species = this.learnsetParent(species);
+		 }
+ 
+		 if (limit1 && sketch) {
+			 // limit 1 sketch move
+			 if (setSources.sketchMove) {
+				 return ` can't Sketch ${move.name} and ${setSources.sketchMove} because it can only Sketch 1 move.`;
+			 }
+			 setSources.sketchMove = move.name;
+		 }
+ 
+		 if (blockedHM) {
+			 // Limit one of Defog/Whirlpool to be transferred
+			 if (setSources.hm) return ` can't simultaneously transfer Defog and Whirlpool from Gen 4 to 5.`;
+			 setSources.hm = moveid;
+		 }
+ 
+		 if (!setSources.restrictiveMoves) {
+			 setSources.restrictiveMoves = [];
+		 }
+		 setSources.restrictiveMoves.push(move.name);
+ 
+		 // Now that we have our list of possible sources, intersect it with the current list
+		 if (!moveSources.size()) {
+			 if (cantLearnReason) return `'s move ${move.name} ${cantLearnReason}`;
+			 return ` can't learn ${move.name}.`;
+		 }
+		 const backupSources = setSources.sources;
+		 const backupSourcesBefore = setSources.sourcesBefore;
+		 setSources.intersectWith(moveSources);
+		 if (!setSources.size()) {
+			 // pretend this pokemon didn't have this move:
+			 // prevents a crash if OMs override `checkCanLearn` to keep validating after an error
+			 setSources.sources = backupSources;
+			 setSources.sourcesBefore = backupSourcesBefore;
+			 return `'s moves ${(setSources.restrictiveMoves || []).join(', ')} are incompatible.`;
+		 }
+ 
+		 if (babyOnly) setSources.babyOnly = babyOnly;
+		 return null;
+	 }
+ 
+	 learnsetParent(species: Species) {
+		 // Own Tempo Rockruff and Battle Bond Greninja are special event formes
+		 // that are visually indistinguishable from their base forme but have
+		 // different learnsets. To prevent a leak, we make them show up as their
+		 // base forme, but hardcode their learnsets into Rockruff-Dusk and
+		 // Greninja-Ash
+		 if (['Gastrodon', 'Pumpkaboo', 'Sinistea'].includes(species.baseSpecies) && species.forme) {
+			 return this.dex.species.get(species.baseSpecies);
+		 } else if (species.name === 'Lycanroc-Dusk') {
+			 return this.dex.species.get('Rockruff-Dusk');
+		 } else if (species.name === 'Greninja-Ash') {
+			 return null;
+		 } else if (species.prevo) {
+			 // there used to be a check for Hidden Ability here, but apparently it's unnecessary
+			 // Shed Skin Pupitar can definitely evolve into Unnerve Tyranitar
+			 species = this.dex.species.get(species.prevo);
+			 if (species.gen > Math.max(2, this.dex.gen)) return null;
+			 return species;
+		 } else if (species.changesFrom && species.baseSpecies !== 'Kyurem') {
+			 // For Pokemon like Rotom and Necrozma whose movesets are extensions are their base formes
+			 return this.dex.species.get(species.changesFrom);
+		 }
+		 return null;
+	 }
+ 
+	 static fillStats(stats: SparseStatsTable | null, fillNum = 0): StatsTable {
+		 const filledStats: StatsTable = {hp: fillNum, atk: fillNum, def: fillNum, spa: fillNum, spd: fillNum, spe: fillNum};
+		 if (stats) {
+			 let statName: StatID;
+			 for (statName in filledStats) {
+				 const stat = stats[statName];
+				 if (typeof stat === 'number') filledStats[statName] = stat;
+			 }
+		 }
+		 return filledStats;
+	 }
+ 
+	 static get(format: string | Format) {
+		 return new TeamValidator(format);
+	 }
+ }
+ 

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -7,2265 +7,2264 @@
  * @license MIT
  */
 
- import {Dex, toID} from './dex';
- import {Utils} from '../lib';
- import {Tags} from '../data/tags';
- import {Teams} from './teams';
- import {PRNG} from './prng';
- 
- /**
-  * Describes a possible way to get a pokemon. Is not exhaustive!
-  * sourcesBefore covers all sources that do not have exclusive
-  * moves (like catching wild pokemon).
-  *
-  * First character is a generation number, 1-8.
-  * Second character is a source ID, one of:
-  *
-  * - E = egg, 3rd char+ is the father in gen 2-5, empty in gen 6-7
-  *   because egg moves aren't restricted to fathers anymore
-  * - S = event, 3rd char+ is the index in .eventData
-  * - D = Dream World, only 5D is valid
-  * - V = Virtual Console or Let's Go transfer, only 7V/8V is valid
-  *
-  * Designed to match MoveSource where possible.
-  */
- export type PokemonSource = string;
- 
- /**
-  * Represents a set of possible ways to get a Pokémon with a given
-  * set.
-  *
-  * `new PokemonSources()` creates an empty set;
-  * `new PokemonSources(dex.gen)` allows all Pokemon.
-  *
-  * The set mainly stored as an Array `sources`, but for sets that
-  * could be sourced from anywhere (for instance, TM moves), we
-  * instead just set `sourcesBefore` to a number meaning "any
-  * source at or before this gen is possible."
-  *
-  * In other words, this variable represents the set of all
-  * sources in `sources`, union all sources at or before
-  * gen `sourcesBefore`.
-  */
- export class PokemonSources {
-	 /**
-	  * A set of specific possible PokemonSources; implemented as
-	  * an Array rather than a Set for perf reasons.
-	  */
-	 sources: PokemonSource[];
-	 /**
-	  * if nonzero: the set also contains all possible sources from
-	  * this gen and earlier.
-	  */
-	 sourcesBefore: number;
-	 /**
-	  * the set requires sources from this gen or later
-	  * this should be unchanged from the format's minimum past gen
-	  * (3 in modern games, 6 if pentagon is required, etc)
-	  */
-	 sourcesAfter: number;
-	 isHidden: boolean | null;
-	 /**
-	  * `limitedEggMoves` is a list of moves that can only be obtained from an
-	  * egg with another father in gen 2-5. If there are multiple such moves,
-	  * potential fathers need to be checked to see if they can actually
-	  * learn the move combination in question.
-	  *
-	  * `null` = the current move is definitely not a limited egg move
-	  *
-	  * `undefined` = the current move may or may not be a limited egg move
-	  */
-	 limitedEggMoves?: ID[] | null;
-	 /**
-	  * Some Pokemon evolve by having a move in their learnset (like Piloswine
-	  * with Ancient Power). These can only carry three other moves from their
-	  * prevo, because the fourth move must be the evo move. This restriction
-	  * doesn't apply to gen 6+ eggs, which can get around the restriction with
-	  * the relearner.
-	  */
-	 moveEvoCarryCount: number;
- 
-	 babyOnly?: string;
-	 sketchMove?: string;
-	 hm?: string;
-	 restrictiveMoves?: string[];
-	 /** Obscure learn methods */
-	 restrictedMove?: ID;
- 
-	 constructor(sourcesBefore = 0, sourcesAfter = 0) {
-		 this.sources = [];
-		 this.sourcesBefore = sourcesBefore;
-		 this.sourcesAfter = sourcesAfter;
-		 this.isHidden = null;
-		 this.limitedEggMoves = undefined;
-		 this.moveEvoCarryCount = 0;
-	 }
-	 size() {
-		 if (this.sourcesBefore) return Infinity;
-		 return this.sources.length;
-	 }
-	 add(source: PokemonSource, limitedEggMove?: ID | null) {
-		 if (this.sources[this.sources.length - 1] !== source) this.sources.push(source);
-		 if (limitedEggMove && this.limitedEggMoves !== null) {
-			 this.limitedEggMoves = [limitedEggMove];
-		 } else if (limitedEggMove === null) {
-			 this.limitedEggMoves = null;
-		 }
-	 }
-	 addGen(sourceGen: number) {
-		 this.sourcesBefore = Math.max(this.sourcesBefore, sourceGen);
-		 this.limitedEggMoves = null;
-	 }
-	 minSourceGen() {
-		 if (this.sourcesBefore) return this.sourcesAfter || 1;
-		 let min = 10;
-		 for (const source of this.sources) {
-			 const sourceGen = parseInt(source.charAt(0));
-			 if (sourceGen < min) min = sourceGen;
-		 }
-		 if (min === 10) return 0;
-		 return min;
-	 }
-	 maxSourceGen() {
-		 let max = this.sourcesBefore;
-		 for (const source of this.sources) {
-			 const sourceGen = parseInt(source.charAt(0));
-			 if (sourceGen > max) max = sourceGen;
-		 }
-		 return max;
-	 }
-	 intersectWith(other: PokemonSources) {
-		 if (other.sourcesBefore || this.sourcesBefore) {
-			 // having sourcesBefore is the equivalent of having everything before that gen
-			 // in sources, so we fill the other array in preparation for intersection
-			 if (other.sourcesBefore > this.sourcesBefore) {
-				 for (const source of this.sources) {
-					 const sourceGen = parseInt(source.charAt(0));
-					 if (sourceGen <= other.sourcesBefore) {
-						 other.sources.push(source);
-					 }
-				 }
-			 } else if (this.sourcesBefore > other.sourcesBefore) {
-				 for (const source of other.sources) {
-					 const sourceGen = parseInt(source.charAt(0));
-					 if (sourceGen <= this.sourcesBefore) {
-						 this.sources.push(source);
-					 }
-				 }
-			 }
-			 this.sourcesBefore = Math.min(other.sourcesBefore, this.sourcesBefore);
-		 }
-		 if (this.sources.length) {
-			 if (other.sources.length) {
-				 const sourcesSet = new Set(other.sources);
-				 const intersectSources = this.sources.filter(source => sourcesSet.has(source));
-				 this.sources = intersectSources;
-			 } else {
-				 this.sources = [];
-			 }
-		 }
- 
-		 if (other.restrictedMove && other.restrictedMove !== this.restrictedMove) {
-			 if (this.restrictedMove) {
-				 // incompatible
-				 this.sources = [];
-				 this.sourcesBefore = 0;
-			 } else {
-				 this.restrictedMove = other.restrictedMove;
-			 }
-		 }
-		 if (other.limitedEggMoves) {
-			 if (!this.limitedEggMoves) {
-				 this.limitedEggMoves = other.limitedEggMoves;
-			 } else {
-				 this.limitedEggMoves.push(...other.limitedEggMoves);
-			 }
-		 }
-		 this.moveEvoCarryCount += other.moveEvoCarryCount;
-		 if (other.sourcesAfter > this.sourcesAfter) this.sourcesAfter = other.sourcesAfter;
-		 if (other.isHidden) this.isHidden = true;
-	 }
- }
- 
- export class TeamValidator {
-	 readonly format: Format;
-	 readonly dex: ModdedDex;
-	 readonly gen: number;
-	 readonly ruleTable: import('./dex-formats').RuleTable;
-	 readonly minSourceGen: number;
- 
-	 readonly toID: (str: any) => ID;
-	 constructor(format: string | Format, dex = Dex) {
-		 this.format = dex.formats.get(format);
-		 this.dex = dex.forFormat(this.format);
-		 this.gen = this.dex.gen;
-		 this.ruleTable = this.dex.formats.getRuleTable(this.format);
- 
-		 this.minSourceGen = this.ruleTable.minSourceGen;
- 
-		 this.toID = toID;
-	 }
- 
-	 validateTeam(
-		 team: PokemonSet[] | null,
-		 options: {
-			 removeNicknames?: boolean,
-			 skipSets?: {[name: string]: {[key: string]: boolean}},
-		 } = {}
-	 ): string[] | null {
-		 if (team && this.format.validateTeam) {
-			 return this.format.validateTeam.call(this, team, options) || null;
-		 }
-		 return this.baseValidateTeam(team, options);
-	 }
- 
-	 baseValidateTeam(
-		 team: PokemonSet[] | null,
-		 options: {
-			 removeNicknames?: boolean,
-			 skipSets?: {[name: string]: {[key: string]: boolean}},
-		 } = {}
-	 ): string[] | null {
-		 const format = this.format;
-		 const dex = this.dex;
- 
-		 let problems: string[] = [];
-		 const ruleTable = this.ruleTable;
-		 if (format.team) {
-			 if (team) {
-				 return [
-					 `This format doesn't let you use your own team.`,
-					 `If you're not using a custom client, please report this as a bug. If you are, remember to use \`/utm null\` before starting a game in this format.`,
-				 ];
-			 }
-			 const testTeamSeed = PRNG.generateSeed();
-			 try {
-				 const testTeamGenerator = Teams.getGenerator(format, testTeamSeed);
-				 testTeamGenerator.getTeam(options); // Throws error if generation fails
-			 } catch (e) {
-				 return [
-					 `${format.name}'s team generator (${format.team}) failed using these rules and seed (${testTeamSeed}):-`,
-					 `${e}`,
-				 ];
-			 }
-			 return null;
-		 }
-		 if (!team) {
-			 return [
-				 `This format requires you to use your own team.`,
-				 `If you're not using a custom client, please report this as a bug.`,
-			 ];
-		 }
-		 if (!Array.isArray(team)) {
-			 throw new Error(`Invalid team data`);
-		 }
- 
-		 if (team.length < ruleTable.minTeamSize) {
-			 problems.push(`You must bring at least ${ruleTable.minTeamSize} Pok\u00E9mon (your team has ${team.length}).`);
-		 }
-		 if (team.length > ruleTable.maxTeamSize) {
-			 return [`You may only bring up to ${ruleTable.maxTeamSize} Pok\u00E9mon (your team has ${team.length}).`];
-		 }
- 
-		 // A limit is imposed here to prevent too much engine strain or
-		 // too much layout deformation - to be exact, this is the limit
-		 // allowed in Custom Game.
-		 if (team.length > 24) {
-			 problems.push(`Your team has more than than 24 Pok\u00E9mon, which the simulator can't handle.`);
-			 return problems;
-		 }
- 
-		 const teamHas: {[k: string]: number} = {};
-		 let lgpeStarterCount = 0;
-		 let deoxysType;
-		 for (const set of team) {
-			 if (!set) return [`You sent invalid team data. If you're not using a custom client, please report this as a bug.`];
- 
-			 let setProblems: string[] | null = null;
-			 if (options.skipSets && options.skipSets[set.name]) {
-				 for (const i in options.skipSets[set.name]) {
-					 teamHas[i] = (teamHas[i] || 0) + 1;
-				 }
-			 } else {
-				 setProblems = (format.validateSet || this.validateSet).call(this, set, teamHas);
-			 }
- 
-			 if (set.species === 'Pikachu-Starter' || set.species === 'Eevee-Starter') {
-				 lgpeStarterCount++;
-				 if (lgpeStarterCount === 2 && ruleTable.isBanned('nonexistent')) {
-					 problems.push(`You can only have one of Pikachu-Starter or Eevee-Starter on a team.`);
-				 }
-			 }
-			 if (dex.gen === 3 && set.species.startsWith('Deoxys')) {
-				 if (!deoxysType) {
-					 deoxysType = set.species;
-				 } else if (deoxysType !== set.species && ruleTable.isBanned('nonexistent')) {
-					 return [
-						 `You cannot have more than one type of Deoxys forme.`,
-						 `(Each game in Gen 3 supports only one forme of Deoxys.)`,
-					 ];
-				 }
-			 }
-			 if (setProblems) {
-				 problems = problems.concat(setProblems);
-			 }
-			 if (options.removeNicknames) {
-				 const species = dex.species.get(set.species);
-				 let crossSpecies: Species;
-				 if (format.name === '[Gen 8] Cross Evolution' && (crossSpecies = dex.species.get(set.name)).exists) {
-					 set.name = crossSpecies.name;
-				 } else {
-					 set.name = species.baseSpecies;
-					 if (species.baseSpecies === 'Unown') set.species = 'Unown';
-				 }
-			 }
-		 }
- 
-		 for (const [rule, source, limit, bans] of ruleTable.complexTeamBans) {
-			 let count = 0;
-			 for (const ban of bans) {
-				 if (teamHas[ban] > 0) {
-					 count += limit ? teamHas[ban] : 1;
-				 }
-			 }
-			 if (limit && count > limit) {
-				 const clause = source ? ` by ${source}` : ``;
-				 problems.push(`You are limited to ${limit} of ${rule}${clause}.`);
-			 } else if (!limit && count >= bans.length) {
-				 const clause = source ? ` by ${source}` : ``;
-				 problems.push(`Your team has the combination of ${rule}, which is banned${clause}.`);
-			 }
-		 }
- 
-		 for (const rule of ruleTable.keys()) {
-			 if ('!+-'.includes(rule.charAt(0))) continue;
-			 const subformat = dex.formats.get(rule);
-			 if (subformat.onValidateTeam && ruleTable.has(subformat.id)) {
-				 problems = problems.concat(subformat.onValidateTeam.call(this, team, format, teamHas) || []);
-			 }
-		 }
-		 if (format.onValidateTeam) {
-			 problems = problems.concat(format.onValidateTeam.call(this, team, format, teamHas) || []);
-		 }
- 
-		 if (!problems.length) return null;
-		 return problems;
-	 }
- 
-	 getEventOnlyData(species: Species, noRecurse?: boolean): {species: Species, eventData: EventInfo[]} | null {
-		 const dex = this.dex;
-		 const learnset = dex.species.getLearnsetData(species.id);
-		 if (!learnset?.eventOnly) {
-			 if (noRecurse) return null;
-			 return this.getEventOnlyData(dex.species.get(species.prevo), true);
-		 }
- 
-		 if (!learnset.eventData && species.forme) {
-			 return this.getEventOnlyData(dex.species.get(species.baseSpecies), true);
-		 }
-		 if (!learnset.eventData) {
-			 throw new Error(`Event-only species ${species.name} has no eventData table`);
-		 }
- 
-		 return {species, eventData: learnset.eventData};
-	 }
- 
-	 validateSet(set: PokemonSet, teamHas: AnyObject): string[] | null {
-		 const format = this.format;
-		 const dex = this.dex;
-		 const ruleTable = this.ruleTable;
- 
-		 let problems: string[] = [];
-		 if (!set) {
-			 return [`This is not a Pokemon.`];
-		 }
- 
-		 let species = dex.species.get(set.species);
-		 set.species = species.name;
-		 // Backwards compatability with old Gmax format
-		 if (set.species.toLowerCase().endsWith('-gmax') && this.format.id !== 'gen8megamax') {
-			 set.species = set.species.slice(0, -5);
-			 species = dex.species.get(set.species);
-			 if (set.name && set.name.endsWith('-Gmax')) set.name = species.baseSpecies;
-			 set.gigantamax = true;
-		 }
-		 if (set.name && set.name.length > 18) {
-			 if (set.name === set.species) {
-				 set.name = species.baseSpecies;
-			 } else {
-				 problems.push(`Nickname "${set.name}" too long (should be 18 characters or fewer)`);
-			 }
-		 }
-		 set.name = dex.getName(set.name);
-		 let item = dex.items.get(Utils.getString(set.item));
-		 set.item = item.name;
-		 let ability = dex.abilities.get(Utils.getString(set.ability));
-		 set.ability = ability.name;
-		 let nature = dex.natures.get(Utils.getString(set.nature));
-		 set.nature = nature.name;
-		 if (!Array.isArray(set.moves)) set.moves = [];
- 
-		 set.name = set.name || species.baseSpecies;
-		 let name = set.species;
-		 if (set.species !== set.name && species.baseSpecies !== set.name) {
-			 name = `${set.name} (${set.species})`;
-		 }
- 
-		 if (!set.level) set.level = ruleTable.defaultLevel;
- 
-		 let adjustLevel = ruleTable.adjustLevel;
-		 if (ruleTable.adjustLevelDown && set.level >= ruleTable.adjustLevelDown) {
-			 adjustLevel = ruleTable.adjustLevelDown;
-		 }
-		 if (set.level === adjustLevel || (set.level === 100 && ruleTable.maxLevel < 100)) {
-			 // Note that we're temporarily setting level 50 pokemon in VGC to level 100
-			 // This allows e.g. level 50 Hydreigon even though it doesn't evolve until level 64.
-			 // Leveling up can't make an obtainable pokemon unobtainable, so this is safe.
-			 // Just remember to set the level back to adjustLevel at the end of validation.
-			 set.level = ruleTable.maxLevel;
-		 }
-		 if (set.level < ruleTable.minLevel) {
-			 problems.push(`${name} (level ${set.level}) is below the minimum level of ${ruleTable.minLevel}${ruleTable.blame('minlevel')}`);
-		 }
-		 if (set.level > ruleTable.maxLevel) {
-			 problems.push(`${name} (level ${set.level}) is above the maximum level of ${ruleTable.maxLevel}${ruleTable.blame('maxlevel')}`);
-		 }
- 
-		 const setHas: {[k: string]: true} = {};
- 
-		 if (!set.evs) set.evs = TeamValidator.fillStats(null, ruleTable.evLimit === null ? 252 : 0);
-		 if (!set.ivs) set.ivs = TeamValidator.fillStats(null, 31);
- 
-		 if (ruleTable.has('obtainableformes')) {
-			 problems.push(...this.validateForme(set));
-			 species = dex.species.get(set.species);
-		 }
-		 const setSources = this.allSources(species);
- 
-		 for (const [rule] of ruleTable) {
-			 if ('!+-'.includes(rule.charAt(0))) continue;
-			 const subformat = dex.formats.get(rule);
-			 if (subformat.onChangeSet && ruleTable.has(subformat.id)) {
-				 problems = problems.concat(subformat.onChangeSet.call(this, set, format, setHas, teamHas) || []);
-			 }
-		 }
-		 if (format.onChangeSet) {
-			 problems = problems.concat(format.onChangeSet.call(this, set, format, setHas, teamHas) || []);
-		 }
- 
-		 // onChangeSet can modify set.species, set.item, set.ability
-		 species = dex.species.get(set.species);
-		 item = dex.items.get(set.item);
-		 ability = dex.abilities.get(set.ability);
- 
-		 let outOfBattleSpecies = species;
-		 let tierSpecies = species;
-		 if (ability.id === 'battlebond' && species.id === 'greninja') {
-			 outOfBattleSpecies = dex.species.get('greninjaash');
-			 if (ruleTable.has('obtainableformes')) {
-				 tierSpecies = outOfBattleSpecies;
-			 }
-			 if (ruleTable.has('obtainablemisc')) {
-				 if (set.gender && set.gender !== 'M') {
-					 problems.push(`Battle Bond Greninja must be male.`);
-				 }
-				 set.gender = 'M';
-			 }
-		 }
-		 if (ability.id === 'owntempo' && species.id === 'rockruff') {
-			 tierSpecies = outOfBattleSpecies = dex.species.get('rockruffdusk');
-		 }
-		 if (species.id === 'melmetal' && set.gigantamax && this.dex.species.getLearnsetData(species.id).eventData) {
-			 setSources.sourcesBefore = 0;
-			 setSources.sources = ['8S0 melmetal'];
-		 }
-		 if (!species.exists) {
-			 return [`The Pokemon "${set.species}" does not exist.`];
-		 }
- 
-		 if (item.id && !item.exists) {
-			 return [`"${set.item}" is an invalid item.`];
-		 }
-		 if (ability.id && !ability.exists) {
-			 if (dex.gen < 3) {
-				 // gen 1-2 don't have abilities, just silently remove
-				 ability = dex.abilities.get('');
-				 set.ability = '';
-			 } else {
-				 return [`"${set.ability}" is an invalid ability.`];
-			 }
-		 }
-		 if (nature.id && !nature.exists) {
-			 if (dex.gen < 3) {
-				 // gen 1-2 don't have natures, just remove them
-				 nature = dex.natures.get('');
-				 set.nature = '';
-			 } else {
-				 problems.push(`"${set.nature}" is an invalid nature.`);
-			 }
-		 }
-		 if (set.happiness !== undefined && isNaN(set.happiness)) {
-			 problems.push(`${name} has an invalid happiness value.`);
-		 }
-		 if (set.hpType) {
-			 const type = dex.types.get(set.hpType);
-			 if (!type.exists || ['normal', 'fairy'].includes(type.id)) {
-				 problems.push(`${name}'s Hidden Power type (${set.hpType}) is invalid.`);
-			 } else {
-				 set.hpType = type.name;
-			 }
-		 }
- 
-		 if (ruleTable.has('obtainableformes')) {
-			 const canMegaEvo = dex.gen <= 7 || ruleTable.has('standardnatdex');
-			 if (item.megaEvolves === species.name) {
-				 if (!item.megaStone) throw new Error(`Item ${item.name} has no base form for mega evolution`);
-				 tierSpecies = dex.species.get(item.megaStone);
-			 } else if (item.id === 'redorb' && species.id === 'groudon') {
-				 tierSpecies = dex.species.get('Groudon-Primal');
-			 } else if (item.id === 'blueorb' && species.id === 'kyogre') {
-				 tierSpecies = dex.species.get('Kyogre-Primal');
-			 } else if (canMegaEvo && species.id === 'rayquaza' && set.moves.map(toID).includes('dragonascent' as ID)) {
-				 tierSpecies = dex.species.get('Rayquaza-Mega');
-			 } else if (item.id === 'rustedsword' && species.id === 'zacian') {
-				 tierSpecies = dex.species.get('Zacian-Crowned');
-			 } else if (item.id === 'rustedshield' && species.id === 'zamazenta') {
-				 tierSpecies = dex.species.get('Zamazenta-Crowned');
-			 }
-		 }
- 
-		 let problem = this.checkSpecies(set, species, tierSpecies, setHas);
-		 if (problem) problems.push(problem);
- 
-		 problem = this.checkItem(set, item, setHas);
-		 if (problem) problems.push(problem);
-		 if (ruleTable.has('obtainablemisc')) {
-			 if (dex.gen === 4 && item.id === 'griseousorb' && species.num !== 487) {
-				 problems.push(`${set.name} cannot hold the Griseous Orb.`, `(In Gen 4, only Giratina could hold the Griseous Orb).`);
-			 }
-			 if (dex.gen <= 1) {
-				 if (item.id) {
-					 // no items allowed
-					 set.item = '';
-				 }
-			 }
-		 }
- 
-		 if (!set.ability) set.ability = 'No Ability';
-		 if (ruleTable.has('obtainableabilities')) {
-			 if (dex.gen <= 2 || dex.currentMod === 'gen7letsgo') {
-				 set.ability = 'No Ability';
-			 } else {
-				 if (!ability.name || ability.name === 'No Ability') {
-					 problems.push(`${name} needs to have an ability.`);
-				 } else if (!Object.values(species.abilities).includes(ability.name)) {
-					 if (tierSpecies.abilities[0] === ability.name) {
-						 set.ability = species.abilities[0];
-					 } else {
-						 problems.push(`${name} can't have ${set.ability}.`);
-					 }
-				 }
-				 if (ability.name === species.abilities['H']) {
-					 setSources.isHidden = true;
- 
-					 let unreleasedHidden = species.unreleasedHidden;
-					 if (unreleasedHidden === 'Past' && this.minSourceGen < dex.gen) unreleasedHidden = false;
- 
-					 if (unreleasedHidden && ruleTable.has('-unreleased')) {
-						 problems.push(`${name}'s Hidden Ability is unreleased.`);
-					 } else if (dex.gen === 7 && ['entei', 'suicune', 'raikou'].includes(species.id) && this.minSourceGen > 1) {
-						 problems.push(`${name}'s Hidden Ability is only available from Virtual Console, which is not allowed in this format.`);
-					 } else if (dex.gen === 6 && ability.name === 'Symbiosis' &&
-						 (set.species.endsWith('Orange') || set.species.endsWith('White'))) {
-						 problems.push(`${name}'s Hidden Ability is unreleased for the Orange and White forms.`);
-					 } else if (dex.gen === 5 && set.level < 10 && (species.maleOnlyHidden || species.gender === 'N')) {
-						 problems.push(`${name} must be at least level 10 to have a Hidden Ability.`);
-					 }
-					 if (species.maleOnlyHidden) {
-						 if (set.gender && set.gender !== 'M') {
-							 problems.push(`${name} must be male to have a Hidden Ability.`);
-						 }
-						 set.gender = 'M';
-						 setSources.sources = ['5D'];
-					 }
-				 } else {
-					 setSources.isHidden = false;
-				 }
-			 }
-		 }
- 
-		 ability = dex.abilities.get(set.ability);
-		 problem = this.checkAbility(set, ability, setHas);
-		 if (problem) problems.push(problem);
- 
-		 if (!set.nature || dex.gen <= 2) {
-			 set.nature = '';
-		 }
-		 nature = dex.natures.get(set.nature);
-		 problem = this.checkNature(set, nature, setHas);
-		 if (problem) problems.push(problem);
- 
-		 if (set.moves && Array.isArray(set.moves)) {
-			 set.moves = set.moves.filter(val => val);
-		 }
-		 if (!set.moves?.length) {
-			 problems.push(`${name} has no moves (it must have at least one to be usable).`);
-			 set.moves = [];
-		 }
-		 if (set.moves.length > ruleTable.maxMoveCount) {
-			 problems.push(`${name} has ${set.moves.length} moves, which is more than the limit of ${ruleTable.maxMoveCount}.`);
-			 return problems;
-		 }
- 
-		 if (ruleTable.isBanned('nonexistent')) {
-			 problems.push(...this.validateStats(set, species, setSources));
-		 }
- 
-		 for (const moveName of set.moves) {
-			 if (!moveName) continue;
-			 const move = dex.moves.get(Utils.getString(moveName));
-			 if (!move.exists) return [`"${move.name}" is an invalid move.`];
- 
-			 problem = this.checkMove(set, move, setHas);
-			 if (problem) problems.push(problem);
-		 }
- 
-		 if (ruleTable.has('obtainablemoves')) {
-			 problems.push(...this.validateMoves(outOfBattleSpecies, set.moves, setSources, set, name));
-		 }
- 
-		 const learnsetSpecies = dex.species.getLearnsetData(outOfBattleSpecies.id);
-		 let eventOnlyData;
- 
-		 if (!setSources.sourcesBefore && setSources.sources.length) {
-			 let legal = false;
-			 for (const source of setSources.sources) {
-				 if (this.validateSource(set, source, setSources, outOfBattleSpecies)) continue;
-				 legal = true;
-				 break;
-			 }
- 
-			 if (!legal) {
-				 let nonEggSource = null;
-				 for (const source of setSources.sources) {
-					 if (source.charAt(1) !== 'E') {
-						 nonEggSource = source;
-						 break;
-					 }
-				 }
-				 if (!nonEggSource) {
-					 // all egg moves
-					 problems.push(`${name} can't get its egg move combination (${setSources.limitedEggMoves!.join(', ')}) from any possible father.`);
-					 problems.push(`(Is this incorrect? If so, post the chainbreeding instructions in Bug Reports)`);
-				 } else {
-					 if (setSources.sources.length > 1) {
-						 problems.push(`${name} has an event-exclusive move that it doesn't qualify for (only one of several ways to get the move will be listed):`);
-					 }
-					 const eventProblems = this.validateSource(
-						 set, nonEggSource, setSources, outOfBattleSpecies, ` because it has a move only available`
-					 );
-					 if (eventProblems) problems.push(...eventProblems);
-				 }
-			 }
-		 } else if (ruleTable.has('obtainablemisc') && (eventOnlyData = this.getEventOnlyData(outOfBattleSpecies))) {
-			 const {species: eventSpecies, eventData} = eventOnlyData;
-			 let legal = false;
-			 for (const event of eventData) {
-				 if (this.validateEvent(set, setSources, event, eventSpecies)) continue;
-				 legal = true;
-				 break;
-			 }
-			 if (!legal && species.gen <= 2 && dex.gen >= 7 && !this.validateSource(set, '7V', setSources, species)) {
-				 legal = true;
-			 }
-			 if (!legal) {
-				 if (eventData.length === 1) {
-					 problems.push(`${species.name} is only obtainable from an event - it needs to match its event:`);
-				 } else {
-					 problems.push(`${species.name} is only obtainable from events - it needs to match one of its events:`);
-				 }
-				 for (const [i, event] of eventData.entries()) {
-					 if (event.generation <= dex.gen && event.generation >= this.minSourceGen) {
-						 const eventInfo = event;
-						 const eventNum = i + 1;
-						 const eventName = eventData.length > 1 ? ` #${eventNum}` : ``;
-						 const eventProblems = this.validateEvent(
-							 set, setSources, eventInfo, eventSpecies, ` to be`, `from its event${eventName}`
-						 );
-						 if (eventProblems) problems.push(...eventProblems);
-					 }
-				 }
-			 }
-		 }
- 
-		 let isFromRBYEncounter = false;
-		 if (this.gen === 1 && ruleTable.has('obtainablemisc') && !this.ruleTable.has('allowtradeback')) {
-			 let lowestEncounterLevel;
-			 for (const encounter of learnsetSpecies.encounters || []) {
-				 if (encounter.generation !== 1) continue;
-				 if (!encounter.level) continue;
-				 if (lowestEncounterLevel && encounter.level > lowestEncounterLevel) continue;
- 
-				 lowestEncounterLevel = encounter.level;
-			 }
- 
-			 if (lowestEncounterLevel) {
-				 if (set.level < lowestEncounterLevel) {
-					 problems.push(`${name} is not obtainable at levels below ${lowestEncounterLevel} in Gen 1.`);
-				 }
-				 isFromRBYEncounter = true;
-			 }
-		 }
-		 if (!isFromRBYEncounter && ruleTable.has('obtainablemisc')) {
-			 // FIXME: Event pokemon given at a level under what it normally can be attained at gives a false positive
-			 let evoSpecies = species;
-			 while (evoSpecies.prevo) {
-				 if (set.level < (evoSpecies.evoLevel || 0)) {
-					 problems.push(`${name} must be at least level ${evoSpecies.evoLevel} to be evolved.`);
-					 break;
-				 }
-				 evoSpecies = dex.species.get(evoSpecies.prevo);
-			 }
-		 }
- 
-		 if (ruleTable.has('obtainablemoves')) {
-			 if (species.id === 'keldeo' && set.moves.includes('secretsword') && this.minSourceGen > 5 && dex.gen <= 7) {
-				 problems.push(`${name} has Secret Sword, which is only compatible with Keldeo-Ordinary obtained from Gen 5.`);
-			 }
-			 const requiresGen3Source = setSources.maxSourceGen() <= 3;
-			 if (requiresGen3Source && dex.abilities.get(set.ability).gen === 4 && !species.prevo && dex.gen <= 5) {
-				 // Ability Capsule allows this in Gen 6+
-				 problems.push(`${name} has a Gen 4 ability and isn't evolved - it can't use moves from Gen 3.`);
-			 }
-			 const canUseAbilityPatch = dex.gen >= 8 && format.mod !== 'gen8dlc1';
-			 if (setSources.isHidden && !canUseAbilityPatch && setSources.maxSourceGen() < 5) {
-				 problems.push(`${name} has a Hidden Ability - it can't use moves from before Gen 5.`);
-			 }
-			 if (
-				 species.maleOnlyHidden && setSources.isHidden && setSources.sourcesBefore < 5 &&
-				 setSources.sources.every(source => source.charAt(1) === 'E')
-			 ) {
-				 problems.push(`${name} has an unbreedable Hidden Ability - it can't use egg moves.`);
-			 }
-		 }
- 
-		 if (teamHas) {
-			 for (const i in setHas) {
-				 if (i in teamHas) {
-					 teamHas[i]++;
-				 } else {
-					 teamHas[i] = 1;
-				 }
-			 }
-		 }
-		 for (const [rule, source, limit, bans] of ruleTable.complexBans) {
-			 let count = 0;
-			 for (const ban of bans) {
-				 if (setHas[ban]) count++;
-			 }
-			 if (limit && count > limit) {
-				 const clause = source ? ` by ${source}` : ``;
-				 problems.push(`${name} is limited to ${limit} of ${rule}${clause}.`);
-			 } else if (!limit && count >= bans.length) {
-				 const clause = source ? ` by ${source}` : ``;
-				 if (source === 'Obtainable Moves') {
-					 problems.push(`${name} has the combination of ${rule}, which is impossible to obtain legitimately.`);
-				 } else {
-					 problems.push(`${name} has the combination of ${rule}, which is banned${clause}.`);
-				 }
-			 }
-		 }
- 
-		 for (const [rule] of ruleTable) {
-			 if ('!+-'.includes(rule.charAt(0))) continue;
-			 const subformat = dex.formats.get(rule);
-			 if (subformat.onValidateSet && ruleTable.has(subformat.id)) {
-				 problems = problems.concat(subformat.onValidateSet.call(this, set, format, setHas, teamHas) || []);
-			 }
-		 }
-		 if (format.onValidateSet) {
-			 problems = problems.concat(format.onValidateSet.call(this, set, format, setHas, teamHas) || []);
-		 }
- 
-		 const nameSpecies = dex.species.get(set.name);
-		 if (nameSpecies.exists && nameSpecies.name.toLowerCase() === set.name.toLowerCase()) {
-			 // nickname is the name of a species
-			 if (nameSpecies.baseSpecies === species.baseSpecies) {
-				 set.name = species.baseSpecies;
-			 } else if (nameSpecies.name !== species.name && nameSpecies.name !== species.baseSpecies) {
-				 // nickname species doesn't match actual species
-				 // Nickname Clause
-				 problems.push(`${name} must not be nicknamed a different Pokémon species than what it actually is.`);
-			 }
-		 }
- 
-		 if (!problems.length) {
-			 if (adjustLevel) set.level = adjustLevel;
-			 return null;
-		 }
- 
-		 return problems;
-	 }
- 
-	 validateStats(set: PokemonSet, species: Species, setSources: PokemonSources) {
-		 const ruleTable = this.ruleTable;
-		 const dex = this.dex;
- 
-		 const allowAVs = ruleTable.has('allowavs');
-		 const evLimit = ruleTable.evLimit;
-		 const canBottleCap = dex.gen >= 7 && (set.level >= 100 || !ruleTable.has('obtainablemisc'));
- 
-		 if (!set.evs) set.evs = TeamValidator.fillStats(null, evLimit === null ? 252 : 0);
-		 if (!set.ivs) set.ivs = TeamValidator.fillStats(null, 31);
- 
-		 const problems = [];
-		 const name = set.name || set.species;
- 
-		 const maxedIVs = Object.values(set.ivs).every(stat => stat === 31);
-		 for (const moveName of set.moves) {
-			 const move = dex.moves.get(moveName);
-			 if (move.id === 'hiddenpower' && move.type !== 'Normal') {
-				 if (!set.hpType) {
-					 set.hpType = move.type;
-				 } else if (set.hpType !== move.type && ruleTable.has('obtainablemisc')) {
-					 problems.push(`${name}'s Hidden Power type ${set.hpType} is incompatible with Hidden Power ${move.type}`);
-				 }
-			 }
-		 }
-		 if (set.hpType && maxedIVs && ruleTable.has('obtainablemisc')) {
-			 if (dex.gen <= 2) {
-				 const HPdvs = dex.types.get(set.hpType).HPdvs;
-				 set.ivs = {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30};
-				 let statName: StatID;
-				 for (statName in HPdvs) {
-					 set.ivs[statName] = HPdvs[statName]! * 2;
-				 }
-				 set.ivs.hp = -1;
-			 } else if (!canBottleCap) {
-				 set.ivs = TeamValidator.fillStats(dex.types.get(set.hpType).HPivs, 31);
-			 }
-		 }
- 
-		 const cantBreedNorEvolve = (species.eggGroups[0] === 'Undiscovered' && !species.prevo && !species.nfe);
-		 const isLegendary = (cantBreedNorEvolve && ![
-			 'Pikachu', 'Unown', 'Dracozolt', 'Arctozolt', 'Dracovish', 'Arctovish',
-		 ].includes(species.baseSpecies)) || [
-			 'Manaphy', 'Cosmog', 'Cosmoem', 'Solgaleo', 'Lunala',
-		 ].includes(species.baseSpecies);
-		 const diancieException = species.name === 'Diancie' && !set.shiny;
-		 const has3PerfectIVs = setSources.minSourceGen() >= 6 && isLegendary && !diancieException;
- 
-		 if (set.hpType === 'Fighting' && ruleTable.has('obtainablemisc')) {
-			 if (has3PerfectIVs) {
-				 // Legendary Pokemon must have at least 3 perfect IVs in gen 6+
-				 problems.push(`${name} must not have Hidden Power Fighting because it starts with 3 perfect IVs because it's a Gen 6+ legendary.`);
-			 }
-		 }
- 
-		 if (has3PerfectIVs && ruleTable.has('obtainablemisc')) {
-			 let perfectIVs = 0;
-			 for (const stat in set.ivs) {
-				 if (set.ivs[stat as 'hp'] >= 31) perfectIVs++;
-			 }
-			 if (perfectIVs < 3) {
-				 const reason = (this.minSourceGen === 6 ? ` and this format requires Gen ${dex.gen} Pokémon` : ` in Gen 6 or later`);
-				 problems.push(`${name} must have at least three perfect IVs because it's a legendary${reason}.`);
-			 }
-		 }
- 
-		 if (set.hpType && !canBottleCap) {
-			 const ivHpType = dex.getHiddenPower(set.ivs).type;
-			 if (set.hpType !== ivHpType) {
-				 problems.push(`${name} has Hidden Power ${set.hpType}, but its IVs are for Hidden Power ${ivHpType}.`);
-			 }
-		 } else if (set.hpType) {
-			 if (!this.possibleBottleCapHpType(set.hpType, set.ivs)) {
-				 problems.push(`${name} has Hidden Power ${set.hpType}, but its IVs don't allow this even with (Bottle Cap) Hyper Training.`);
-			 }
-		 }
- 
-		 if (dex.gen <= 2) {
-			 // validate DVs
-			 const ivs = set.ivs;
-			 const atkDV = Math.floor(ivs.atk / 2);
-			 const defDV = Math.floor(ivs.def / 2);
-			 const speDV = Math.floor(ivs.spe / 2);
-			 const spcDV = Math.floor(ivs.spa / 2);
-			 const expectedHpDV = (atkDV % 2) * 8 + (defDV % 2) * 4 + (speDV % 2) * 2 + (spcDV % 2);
-			 if (ivs.hp === -1) ivs.hp = expectedHpDV * 2;
-			 const hpDV = Math.floor(ivs.hp / 2);
-			 if (expectedHpDV !== hpDV) {
-				 problems.push(`${name} has an HP DV of ${hpDV}, but its Atk, Def, Spe, and Spc DVs give it an HP DV of ${expectedHpDV}.`);
-			 }
-			 if (ivs.spa !== ivs.spd) {
-				 if (dex.gen === 2) {
-					 problems.push(`${name} has different SpA and SpD DVs, which is not possible in Gen 2.`);
-				 } else {
-					 ivs.spd = ivs.spa;
-				 }
-			 }
-			 if (dex.gen > 1 && !species.gender) {
-				 // Gen 2 gender is calculated from the Atk DV.
-				 // High Atk DV <-> M. The meaning of "high" depends on the gender ratio.
-				 const genderThreshold = species.genderRatio.F * 16;
- 
-				 const expectedGender = (atkDV >= genderThreshold ? 'M' : 'F');
-				 if (set.gender && set.gender !== expectedGender) {
-					 problems.push(`${name} is ${set.gender}, but it has an Atk DV of ${atkDV}, which makes its gender ${expectedGender}.`);
-				 } else {
-					 set.gender = expectedGender;
-				 }
-			 }
-			 if (
-				 set.species === 'Marowak' && toID(set.item) === 'thickclub' &&
-				 set.moves.map(toID).includes('swordsdance' as ID) && set.level === 100
-			 ) {
-				 // Marowak hack
-				 set.ivs.atk = Math.floor(set.ivs.atk / 2) * 2;
-				 while (set.evs.atk > 0 && 2 * 80 + set.ivs.atk + Math.floor(set.evs.atk / 4) + 5 > 255) {
-					 set.evs.atk -= 4;
-				 }
-			 }
-			 if (dex.gen > 1) {
-				 const expectedShiny = !!(defDV === 10 && speDV === 10 && spcDV === 10 && atkDV % 4 >= 2);
-				 if (expectedShiny && !set.shiny) {
-					 problems.push(`${name} is not shiny, which does not match its DVs.`);
-				 } else if (!expectedShiny && set.shiny) {
-					 problems.push(`${name} is shiny, which does not match its DVs (its DVs must all be 10, except Atk which must be 2, 3, 6, 7, 10, 11, 14, or 15).`);
-				 }
-			 }
-			 set.nature = 'Serious';
-		 }
- 
-		 for (const stat in set.evs) {
-			 if (set.evs[stat as 'hp'] < 0) {
-				 problems.push(`${name} has less than 0 ${allowAVs ? 'Awakening Values' : 'EVs'} in ${Dex.stats.names[stat as 'hp']}.`);
-			 }
-		 }
- 
-		 if (dex.currentMod === 'gen7letsgo') { // AVs
-			 for (const stat in set.evs) {
-				 if (set.evs[stat as 'hp'] > 0 && !allowAVs) {
-					 problems.push(`${name} has Awakening Values but this format doesn't allow them.`);
-					 break;
-				 } else if (set.evs[stat as 'hp'] > 200) {
-					 problems.push(`${name} has more than 200 Awakening Values in ${Dex.stats.names[stat as 'hp']}.`);
-				 }
-			 }
-		 } else { // EVs
-			 for (const stat in set.evs) {
-				 if (set.evs[stat as StatID] > 255) {
-					 problems.push(`${name} has more than 255 EVs in ${Dex.stats.names[stat as 'hp']}.`);
-				 }
-			 }
-			 if (dex.gen <= 2) {
-				 if (set.evs.spa !== set.evs.spd) {
-					 if (dex.gen === 2) {
-						 problems.push(`${name} has different SpA and SpD EVs, which is not possible in Gen 2.`);
-					 } else {
-						 set.evs.spd = set.evs.spa;
-					 }
-				 }
-			 }
-		 }
- 
-		 let totalEV = 0;
-		 for (const stat in set.evs) totalEV += set.evs[stat as 'hp'];
-		 if (!this.format.debug) {
-			 if (set.level > 1 && evLimit !== 0 && totalEV === 0) {
-				 problems.push(`${name} has exactly 0 EVs - did you forget to EV it? (If this was intentional, add exactly 1 to one of your EVs, which won't change its stats but will tell us that it wasn't a mistake).`);
-			 } else if (![508, 510].includes(evLimit!) && [508, 510].includes(totalEV)) {
-				 problems.push(`${name} has exactly ${totalEV} EVs, but this format does not restrict you to 510 EVs (If this was intentional, add exactly 1 to one of your EVs, which won't change its stats but will tell us that it wasn't a mistake).`);
-			 }
-			 // Check for level import errors from user in VGC -> DOU, etc.
-			 // Note that in VGC etc (Adjust Level Down = 50), `set.level` will be 100 here for validation purposes
-			 if (set.level === 50 && ruleTable.maxLevel !== 50 && !ruleTable.maxTotalLevel && evLimit !== 0 && totalEV % 4 === 0) {
-				 problems.push(`${name} is level 50, but this format allows level ${ruleTable.maxLevel} Pokémon. (If this was intentional, add exactly 1 to one of your EVs, which won't change its stats but will tell us that it wasn't a mistake).`);
-			 }
-		 }
- 
-		 if (evLimit !== null && totalEV > evLimit) {
-			 if (!evLimit) {
-				 problems.push(`${name} has EVs, which is not allowed by this format.`);
-			 } else {
-				 problems.push(`${name} has ${totalEV} total EVs, which is more than this format's limit of ${evLimit}.`);
-			 }
-		 }
- 
-		 return problems;
-	 }
- 
-	 /**
-	  * Not exhaustive, just checks Atk and Spe, which are the only competitively
-	  * relevant IVs outside of extremely obscure situations.
-	  */
-	 possibleBottleCapHpType(type: string, ivs: StatsTable) {
-		 if (!type) return true;
-		 if (['Dark', 'Dragon', 'Grass', 'Ghost', 'Poison'].includes(type)) {
-			 // Spe must be odd
-			 if (ivs.spe % 2 === 0) return false;
-		 }
-		 if (['Psychic', 'Fire', 'Rock', 'Fighting'].includes(type)) {
-			 // Spe must be even
-			 if (ivs.spe !== 31 && ivs.spe % 2 === 1) return false;
-		 }
-		 if (type === 'Dark') {
-			 // Atk must be odd
-			 if (ivs.atk % 2 === 0) return false;
-		 }
-		 if (['Ice', 'Water'].includes(type)) {
-			 // Spe or Atk must be odd
-			 if (ivs.spe % 2 === 0 && ivs.atk % 2 === 0) return false;
-		 }
-		 return true;
-	 }
- 
-	 validateSource(
-		 set: PokemonSet, source: PokemonSource, setSources: PokemonSources, species: Species, because: string
-	 ): string[] | undefined;
-	 validateSource(
-		 set: PokemonSet, source: PokemonSource, setSources: PokemonSources, species: Species
-	 ): true | undefined;
-	 /**
-	  * Returns array of error messages if invalid, undefined if valid
-	  *
-	  * If `because` is not passed, instead returns true if invalid.
-	  */
-	 validateSource(
-		 set: PokemonSet, source: PokemonSource, setSources: PokemonSources, species: Species, because?: string
-	 ) {
-		 let eventData: EventInfo | undefined;
-		 let eventSpecies = species;
-		 if (source.charAt(1) === 'S') {
-			 const splitSource = source.substr(source.charAt(2) === 'T' ? 3 : 2).split(' ');
-			 const dex = (this.dex.gen === 1 ? this.dex.mod('gen2') : this.dex);
-			 eventSpecies = dex.species.get(splitSource[1]);
-			 const eventLsetData = this.dex.species.getLearnsetData(eventSpecies.id);
-			 eventData = eventLsetData.eventData?.[parseInt(splitSource[0])];
-			 if (!eventData) {
-				 throw new Error(`${eventSpecies.name} from ${species.name} doesn't have data for event ${source}`);
-			 }
-		 } else if (source === '7V') {
-			 const isMew = species.id === 'mew';
-			 const isCelebi = species.id === 'celebi';
-			 const g7speciesName = (species.gen > 2 && species.prevo) ? species.prevo : species.id;
-			 const isHidden = !!this.dex.mod('gen7').species.get(g7speciesName).abilities['H'];
-			 eventData = {
-				 generation: 2,
-				 level: isMew ? 5 : isCelebi ? 30 : 3, // Level 1/2 Pokémon can't be obtained by transfer from RBY/GSC
-				 perfectIVs: isMew || isCelebi ? 5 : 3,
-				 isHidden,
-				 shiny: isMew ? undefined : 1,
-				 pokeball: 'pokeball',
-				 from: 'Gen 1-2 Virtual Console transfer',
-			 };
-		 } else if (source === '8V') {
-			 const isMew = species.id === 'mew';
-			 eventData = {
-				 generation: 8,
-				 perfectIVs: isMew ? 3 : undefined,
-				 shiny: isMew ? undefined : 1,
-				 from: 'Gen 7 Let\'s Go! HOME transfer',
-			 };
-		 } else if (source.charAt(1) === 'D') {
-			 eventData = {
-				 generation: 5,
-				 level: 10,
-				 from: 'Gen 5 Dream World',
-				 isHidden: !!this.dex.mod('gen5').species.get(species.id).abilities['H'],
-			 };
-		 } else if (source.charAt(1) === 'E') {
-			 if (this.findEggMoveFathers(source, species, setSources)) {
-				 return undefined;
-			 }
-			 if (because) throw new Error(`Wrong place to get an egg incompatibility message`);
-			 return true;
-		 } else {
-			 throw new Error(`Unidentified source ${source} passed to validateSource`);
-		 }
- 
-		 // complicated fancy return signature
-		 return this.validateEvent(set, setSources, eventData, eventSpecies, because as any) as any;
-	 }
- 
-	 findEggMoveFathers(source: PokemonSource, species: Species, setSources: PokemonSources): boolean;
-	 findEggMoveFathers(source: PokemonSource, species: Species, setSources: PokemonSources, getAll: true): ID[] | null;
-	 findEggMoveFathers(source: PokemonSource, species: Species, setSources: PokemonSources, getAll = false) {
-		 // tradebacks have an eggGen of 2 even though the source is 1ET
-		 const eggGen = Math.max(parseInt(source.charAt(0)), 2);
-		 const fathers: ID[] = [];
-		 // Gen 6+ don't have egg move incompatibilities
-		 // (except for certain cases with baby Pokemon not handled here)
-		 if (!getAll && eggGen >= 6) return true;
- 
-		 const eggMoves = setSources.limitedEggMoves;
-		 // must have 2 or more egg moves to have egg move incompatibilities
-		 if (!eggMoves) {
-			 // happens often in gen 1-6 LC if your only egg moves are level-up moves,
-			 // which aren't limited and so aren't in `limitedEggMoves`
-			 return getAll ? ['*'] : true;
-		 }
-		 if (!getAll && eggMoves.length <= 1) return true;
- 
-		 // gen 1 eggs come from gen 2 breeding
-		 const dex = this.dex.gen === 1 ? this.dex.mod('gen2') : this.dex;
-		 // In Gen 5 and earlier, egg moves can only be inherited from the father
-		 // we'll test each possible father separately
-		 let eggGroups = species.eggGroups;
-		 if (species.id === 'nidoqueen' || species.id === 'nidorina') {
-			 eggGroups = dex.species.get('nidoranf').eggGroups;
-		 } else if (species.id === 'shedinja') {
-			 // Shedinja and Nincada are different Egg groups; Shedinja itself is genderless
-			 eggGroups = dex.species.get('nincada').eggGroups;
-		 } else if (dex !== this.dex) {
-			 // Gen 1 tradeback; grab the egg groups from Gen 2
-			 eggGroups = dex.species.get(species.id).eggGroups;
-		 }
-		 if (eggGroups[0] === 'Undiscovered') eggGroups = dex.species.get(species.evos[0]).eggGroups;
-		 if (eggGroups[0] === 'Undiscovered' || !eggGroups.length) {
-			 throw new Error(`${species.name} has no egg groups for source ${source}`);
-		 }
-		 // no chainbreeding necessary if the father can be Smeargle
-		 if (!getAll && eggGroups.includes('Field')) return true;
- 
-		 // try to find a father to inherit the egg move combination from
-		 for (const father of dex.species.all()) {
-			 // can't inherit from CAP pokemon
-			 if (father.isNonstandard) continue;
-			 // can't breed mons from future gens
-			 if (father.gen > eggGen) continue;
-			 // father must be male
-			 if (father.gender === 'N' || father.gender === 'F') continue;
-			 // can't inherit from dex entries with no learnsets
-			 if (!dex.species.getLearnset(father.id)) continue;
-			 // something is clearly wrong if its only possible father is itself
-			 // (exceptions: ExtremeSpeed Dragonite, Self-destruct Snorlax)
-			 if (species.id === father.id && !['dragonite', 'snorlax'].includes(father.id)) continue;
-			 // don't check NFE Pokémon - their evolutions will know all their moves and more
-			 // exception: Combee/Salandit, because their evos can't be fathers
-			 if (father.evos.length) {
-				 const evolvedFather = dex.species.get(father.evos[0]);
-				 if (evolvedFather.gen <= eggGen && evolvedFather.gender !== 'F') continue;
-			 }
- 
-			 // must be able to breed with father
-			 if (!father.eggGroups.some(eggGroup => eggGroups.includes(eggGroup))) continue;
- 
-			 // father must be able to learn the move
-			 if (!this.fatherCanLearn(father, eggMoves, eggGen)) continue;
- 
-			 // father found!
-			 if (!getAll) return true;
-			 fathers.push(father.id);
-		 }
-		 if (!getAll) return false;
-		 return (!fathers.length && eggGen < 6) ? null : fathers;
-	 }
- 
-	 /**
-	  * We could, if we wanted, do a complete move validation of the father's
-	  * moveset to see if it's valid. This would recurse and be NP-Hard so
-	  * instead we won't. We'll instead use a simplified algorithm: The father
-	  * can learn the moveset if it has at most one egg/event move.
-	  *
-	  * `eggGen` should be 5 or earlier. Later gens should never call this
-	  * function (the answer is always yes).
-	  */
-	 fatherCanLearn(species: Species, moves: ID[], eggGen: number) {
-		 let learnset = this.dex.species.getLearnset(species.id);
-		 if (!learnset) return false;
- 
-		 if (species.id === 'smeargle') return true;
-		 const canBreedWithSmeargle = species.eggGroups.includes('Field');
- 
-		 let eggMoveCount = 0;
-		 for (const move of moves) {
-			 let curSpecies: Species | null = species;
-			 /** 1 = can learn from egg, 2 = can learn unrestricted */
-			 let canLearn: 0 | 1 | 2 = 0;
- 
-			 while (curSpecies) {
-				 learnset = this.dex.species.getLearnset(curSpecies.id);
-				 if (learnset && learnset[move]) {
-					 for (const moveSource of learnset[move]) {
-						 if (parseInt(moveSource.charAt(0)) > eggGen) continue;
-						 const canLearnFromSmeargle = moveSource.charAt(1) === 'E' && canBreedWithSmeargle;
-						 if (!'ESDV'.includes(moveSource.charAt(1)) || canLearnFromSmeargle) {
-							 canLearn = 2;
-							 break;
-						 } else {
-							 canLearn = 1;
-						 }
-					 }
-				 }
-				 if (canLearn === 2) break;
-				 curSpecies = this.learnsetParent(curSpecies);
-			 }
- 
-			 if (!canLearn) return false;
-			 if (canLearn === 1) {
-				 eggMoveCount++;
-				 if (eggMoveCount > 1) return false;
-			 }
-		 }
-		 return true;
-	 }
- 
-	 validateForme(set: PokemonSet) {
-		 const dex = this.dex;
-		 const name = set.name || set.species;
- 
-		 const problems = [];
-		 const item = dex.items.get(set.item);
-		 const species = dex.species.get(set.species);
- 
-		 if (species.name === 'Necrozma-Ultra') {
-			 const whichMoves = (set.moves.includes('sunsteelstrike') ? 1 : 0) +
-				 (set.moves.includes('moongeistbeam') ? 2 : 0);
-			 if (item.name !== 'Ultranecrozium Z') {
-				 // Necrozma-Ultra transforms from one of two formes, and neither one is the base forme
-				 problems.push(`Necrozma-Ultra must start the battle holding Ultranecrozium Z.`);
-			 } else if (whichMoves === 1) {
-				 set.species = 'Necrozma-Dusk-Mane';
-			 } else if (whichMoves === 2) {
-				 set.species = 'Necrozma-Dawn-Wings';
-			 } else {
-				 problems.push(`Necrozma-Ultra must start the battle as Necrozma-Dusk-Mane or Necrozma-Dawn-Wings holding Ultranecrozium Z. Please specify which Necrozma it should start as.`);
-			 }
-		 } else if (species.name === 'Zygarde-Complete') {
-			 problems.push(`Zygarde-Complete must start the battle as Zygarde or Zygarde-10% with Power Construct. Please specify which Zygarde it should start as.`);
-		 } else if (species.battleOnly) {
-			 if (species.requiredAbility && set.ability !== species.requiredAbility) {
-				 // Darmanitan-Zen
-				 problems.push(`${species.name} transforms in-battle with ${species.requiredAbility}, please fix its ability.`);
-			 }
-			 if (species.requiredItems) {
-				 if (!species.requiredItems.includes(item.name)) {
-					 // Mega or Primal
-					 problems.push(`${species.name} transforms in-battle with ${species.requiredItem}, please fix its item.`);
-				 }
-			 }
-			 if (species.requiredMove && !set.moves.map(toID).includes(toID(species.requiredMove))) {
-				 // Meloetta-Pirouette, Rayquaza-Mega
-				 problems.push(`${species.name} transforms in-battle with ${species.requiredMove}, please fix its moves.`);
-			 }
-			 if (typeof species.battleOnly !== 'string') {
-				 // Ultra Necrozma and Complete Zygarde are already checked above
-				 throw new Error(`${species.name} should have a string battleOnly`);
-			 }
-			 // Set to out-of-battle forme
-			 set.species = species.battleOnly;
-		 } else {
-			 if (species.requiredAbility) {
-				 // Impossible!
-				 throw new Error(`Species ${species.name} has a required ability despite not being a battle-only forme; it should just be in its abilities table.`);
-			 }
-			 if (species.requiredItems && !species.requiredItems.includes(item.name)) {
-				 if (dex.gen >= 8 && (species.baseSpecies === 'Arceus' || species.baseSpecies === 'Silvally')) {
-					 // Arceus/Silvally formes in gen 8 only require the item with Multitype/RKS System
-					 if (set.ability === species.abilities[0]) {
-						 problems.push(
-							 `${name} needs to hold ${species.requiredItems.join(' or ')}.`,
-							 `(It will revert to its Normal forme if you remove the item or give it a different item.)`
-						 );
-					 }
-				 } else {
-					 // Memory/Drive/Griseous Orb/Plate/Z-Crystal - Forme mismatch
-					 const baseSpecies = this.dex.species.get(species.changesFrom);
-					 problems.push(
-						 `${name} needs to hold ${species.requiredItems.join(' or ')} to be in its ${species.forme} forme.`,
-						 `(It will revert to its ${baseSpecies.baseForme || 'base'} forme if you remove the item or give it a different item.)`
-					 );
-				 }
-			 }
-			 if (species.requiredMove && !set.moves.map(toID).includes(toID(species.requiredMove))) {
-				 const baseSpecies = this.dex.species.get(species.changesFrom);
-				 problems.push(
-					 `${name} needs to know the move ${species.requiredMove} to be in its ${species.forme} forme.`,
-					 `(It will revert to its ${baseSpecies.baseForme} forme if it forgets the move.)`
-				 );
-			 }
- 
-			 // Mismatches between the set forme (if not base) and the item signature forme will have been rejected already.
-			 // It only remains to assign the right forme to a set with the base species (Arceus/Genesect/Giratina/Silvally).
-			 if (item.forcedForme && species.name === dex.species.get(item.forcedForme).baseSpecies) {
-				 set.species = item.forcedForme;
-			 }
-		 }
- 
-		 if (species.name === 'Pikachu-Cosplay') {
-			 const cosplay: {[k: string]: string} = {
-				 meteormash: 'Pikachu-Rock-Star', iciclecrash: 'Pikachu-Belle', drainingkiss: 'Pikachu-Pop-Star',
-				 electricterrain: 'Pikachu-PhD', flyingpress: 'Pikachu-Libre',
-			 };
-			 for (const moveid of set.moves) {
-				 if (moveid in cosplay) {
-					 set.species = cosplay[moveid];
-					 break;
-				 }
-			 }
-		 }
- 
-		 if (species.name === 'Keldeo' && set.moves.map(toID).includes('secretsword' as ID) && dex.gen >= 8) {
-			 set.species = 'Keldeo-Resolute';
-		 }
- 
-		 const crowned: {[k: string]: string} = {
-			 'Zacian-Crowned': 'behemothblade', 'Zamazenta-Crowned': 'behemothbash',
-		 };
-		 if (species.name in crowned) {
-			 const behemothMove = set.moves.map(toID).indexOf(crowned[species.name] as ID);
-			 if (behemothMove >= 0) {
-				 set.moves[behemothMove] = 'ironhead';
-			 }
-		 }
-		 return problems;
-	 }
- 
-	 checkSpecies(set: PokemonSet, species: Species, tierSpecies: Species, setHas: {[k: string]: true}) {
-		 const dex = this.dex;
-		 const ruleTable = this.ruleTable;
- 
-		 // https://www.smogon.com/forums/posts/8659168
-		 if (
-			 (tierSpecies.id === 'zamazentacrowned' && species.id === 'zamazenta') ||
-			 (tierSpecies.id === 'zaciancrowned' && species.id === 'zacian')
-		 ) {
-			 species = tierSpecies;
-		 }
- 
-		 setHas['pokemon:' + species.id] = true;
-		 setHas['basepokemon:' + toID(species.baseSpecies)] = true;
- 
-		 let isMega = false;
-		 if (tierSpecies !== species) {
-			 setHas['pokemon:' + tierSpecies.id] = true;
-			 if (tierSpecies.isMega || tierSpecies.isPrimal) {
-				 setHas['pokemontag:mega'] = true;
-				 isMega = true;
-			 }
-		 }
- 
-		 let isGmax = false;
-		 if (tierSpecies.canGigantamax && set.gigantamax) {
-			 setHas['pokemon:' + tierSpecies.id + 'gmax'] = true;
-			 isGmax = true;
-		 }
- 
-		 const tier = tierSpecies.tier === '(PU)' ? 'ZU' : tierSpecies.tier === '(NU)' ? 'PU' : tierSpecies.tier;
-		 const tierTag = 'pokemontag:' + toID(tier);
-		 setHas[tierTag] = true;
- 
-		 const doublesTier = tierSpecies.doublesTier === '(DUU)' ? 'DNU' : tierSpecies.doublesTier;
-		 const doublesTierTag = 'pokemontag:' + toID(doublesTier);
-		 setHas[doublesTierTag] = true;
- 
-		 const ndTier = tierSpecies.natDexTier === '(PU)' ? 'ZU' :
-			 tierSpecies.natDexTier === '(NU)' ? 'PU' : tierSpecies.natDexTier;
-		 const ndTierTag = 'pokemontag:nd' + toID(ndTier);
-		 setHas[ndTierTag] = true;
- 
-		 // Only pokemon that can gigantamax should have the Gmax flag
-		 if (!tierSpecies.canGigantamax && set.gigantamax) {
-			 return `${tierSpecies.name} cannot Gigantamax but is flagged as being able to.`;
-		 }
- 
-		 let banReason = ruleTable.check('pokemon:' + species.id);
-		 if (banReason) {
-			 return `${species.name} is ${banReason}.`;
-		 }
-		 if (banReason === '') return null;
- 
-		 if (tierSpecies !== species) {
-			 banReason = ruleTable.check('pokemon:' + tierSpecies.id);
-			 if (banReason) {
-				 return `${tierSpecies.name} is ${banReason}.`;
-			 }
-			 if (banReason === '') return null;
-		 }
- 
-		 if (isMega) {
-			 banReason = ruleTable.check('pokemontag:mega', setHas);
-			 if (banReason) {
-				 return `Mega evolutions are ${banReason}.`;
-			 }
-		 }
- 
-		 if (isGmax) {
-			 banReason = ruleTable.check('pokemon:' + tierSpecies.id + 'gmax');
-			 if (banReason) {
-				 return `Gigantamaxing ${species.name} is ${banReason}.`;
-			 }
-		 }
- 
-		 banReason = ruleTable.check('basepokemon:' + toID(species.baseSpecies));
-		 if (banReason) {
-			 return `${species.name} is ${banReason}.`;
-		 }
-		 if (banReason === '') {
-			 // don't allow nonstandard speciess when whitelisting standard base species
-			 // i.e. unbanning Pichu doesn't mean allowing Pichu-Spiky-Eared outside of Gen 4
-			 const baseSpecies = dex.species.get(species.baseSpecies);
-			 if (baseSpecies.isNonstandard === species.isNonstandard) {
-				 return null;
-			 }
-		 }
- 
-		 // We can't return here because the `-nonexistent` rule is a bit
-		 // complicated in terms of what trumps it. We don't want e.g.
-		 // +Mythical to unban Shaymin in Gen 1, for instance.
-		 let nonexistentCheck = Tags.nonexistent.genericFilter!(tierSpecies) && ruleTable.check('nonexistent');
- 
-		 const EXISTENCE_TAG = ['past', 'future', 'lgpe', 'unobtainable', 'cap', 'custom', 'nonexistent'];
- 
-		 for (const ruleid of ruleTable.tagRules) {
-			 if (ruleid.startsWith('*')) continue;
-			 const tagid = ruleid.slice(12);
-			 const tag = Tags[tagid];
-			 if ((tag.speciesFilter || tag.genericFilter)!(tierSpecies)) {
-				 const existenceTag = EXISTENCE_TAG.includes(tagid);
-				 if (ruleid.startsWith('+')) {
-					 // we want rules like +CAP to trump -Nonexistent, but most tags shouldn't
-					 if (!existenceTag && nonexistentCheck) continue;
-					 return null;
-				 }
-				 if (existenceTag) {
-					 // for a nicer error message
-					 nonexistentCheck = 'banned';
-					 break;
-				 }
-				 return `${species.name} is tagged ${tag.name}, which is ${ruleTable.check(ruleid.slice(1)) || "banned"}.`;
-			 }
-		 }
- 
-		 if (nonexistentCheck) {
-			 if (tierSpecies.isNonstandard === 'Past' || tierSpecies.isNonstandard === 'Future') {
-				 return `${tierSpecies.name} does not exist in Gen ${dex.gen}.`;
-			 }
-			 if (tierSpecies.isNonstandard === 'LGPE') {
-				 return `${tierSpecies.name} does not exist in this game, only in Let's Go Pikachu/Eevee.`;
-			 }
-			 if (tierSpecies.isNonstandard === 'CAP') {
-				 return `${tierSpecies.name} is a CAP and does not exist in this game.`;
-			 }
-			 if (tierSpecies.isNonstandard === 'Unobtainable') {
-				 return `${tierSpecies.name} is not possible to obtain in this game.`;
-			 }
-			 if (tierSpecies.isNonstandard === 'Gigantamax') {
-				 return `${tierSpecies.name} is a placeholder for a Gigantamax sprite, not a real Pokémon. (This message is likely to be a validator bug.)`;
-			 }
-			 return `${tierSpecies.name} does not exist in this game.`;
-		 }
-		 if (nonexistentCheck === '') return null;
- 
-		 // Special casing for Pokemon that can Gmax, but their Gmax factor cannot be legally obtained
-		 if (tierSpecies.gmaxUnreleased && set.gigantamax) {
-			 banReason = ruleTable.check('pokemontag:unobtainable');
-			 if (banReason) {
-				 return `${tierSpecies.name} is flagged as gigantamax, but it cannot gigantamax without hacking or glitches.`;
-			 }
-			 if (banReason === '') return null;
-		 }
- 
-		 banReason = ruleTable.check('pokemontag:allpokemon');
-		 if (banReason) {
-			 return `${species.name} is not in the list of allowed pokemon.`;
-		 }
- 
-		 return null;
-	 }
- 
-	 checkItem(set: PokemonSet, item: Item, setHas: {[k: string]: true}) {
-		 const dex = this.dex;
-		 const ruleTable = this.ruleTable;
- 
-		 setHas['item:' + item.id] = true;
- 
-		 let banReason = ruleTable.check('item:' + (item.id || 'noitem'));
-		 if (banReason) {
-			 if (!item.id) {
-				 return `${set.name} not holding an item is ${banReason}.`;
-			 }
-			 return `${set.name}'s item ${item.name} is ${banReason}.`;
-		 }
-		 if (banReason === '') return null;
- 
-		 if (!item.id) return null;
- 
-		 banReason = ruleTable.check('pokemontag:allitems');
-		 if (banReason) {
-			 return `${set.name}'s item ${item.name} is not in the list of allowed items.`;
-		 }
- 
-		 // obtainability
-		 if (item.isNonstandard) {
-			 banReason = ruleTable.check('pokemontag:' + toID(item.isNonstandard));
-			 if (banReason) {
-				 if (item.isNonstandard === 'Unobtainable') {
-					 return `${item.name} is not obtainable without hacking or glitches.`;
-				 }
-				 return `${set.name}'s item ${item.name} is tagged ${item.isNonstandard}, which is ${banReason}.`;
-			 }
-			 if (banReason === '') return null;
-		 }
- 
-		 if (item.isNonstandard && item.isNonstandard !== 'Unobtainable') {
-			 banReason = ruleTable.check('nonexistent', setHas);
-			 if (banReason) {
-				 if (['Past', 'Future'].includes(item.isNonstandard)) {
-					 return `${set.name}'s item ${item.name} does not exist in Gen ${dex.gen}.`;
-				 }
-				 return `${set.name}'s item ${item.name} does not exist in this game.`;
-			 }
-			 if (banReason === '') return null;
-		 }
- 
-		 return null;
-	 }
- 
-	 checkMove(set: PokemonSet, move: Move, setHas: {[k: string]: true}) {
-		 const dex = this.dex;
-		 const ruleTable = this.ruleTable;
- 
-		 setHas['move:' + move.id] = true;
- 
-		 let banReason = ruleTable.check('move:' + move.id);
-		 if (banReason) {
-			 return `${set.name}'s move ${move.name} is ${banReason}.`;
-		 }
-		 if (banReason === '') return null;
- 
-		 banReason = ruleTable.check('pokemontag:allmoves');
-		 if (banReason) {
-			 return `${set.name}'s move ${move.name} is not in the list of allowed moves.`;
-		 }
- 
-		 // obtainability
-		 if (move.isNonstandard) {
-			 banReason = ruleTable.check('pokemontag:' + toID(move.isNonstandard));
-			 if (banReason) {
-				 if (move.isNonstandard === 'Unobtainable') {
-					 return `${move.name} is not obtainable without hacking or glitches.`;
-				 }
-				 if (move.isNonstandard === 'Gigantamax') {
-					 return `${move.name} is not usable without Gigantamaxing its user, ${move.isMax}.`;
-				 }
-				 return `${set.name}'s move ${move.name} is tagged ${move.isNonstandard}, which is ${banReason}.`;
-			 }
-			 if (banReason === '') return null;
-		 }
- 
-		 if (move.isNonstandard && move.isNonstandard !== 'Unobtainable') {
-			 banReason = ruleTable.check('nonexistent', setHas);
-			 if (banReason) {
-				 if (['Past', 'Future'].includes(move.isNonstandard)) {
-					 return `${set.name}'s move ${move.name} does not exist in Gen ${dex.gen}.`;
-				 }
-				 return `${set.name}'s move ${move.name} does not exist in this game.`;
-			 }
-			 if (banReason === '') return null;
-		 }
- 
-		 return null;
-	 }
- 
-	 checkAbility(set: PokemonSet, ability: Ability, setHas: {[k: string]: true}) {
-		 const dex = this.dex;
-		 const ruleTable = this.ruleTable;
- 
-		 setHas['ability:' + ability.id] = true;
- 
-		 if (this.format.id.startsWith('gen8pokebilities')) {
-			 const species = dex.species.get(set.species);
-			 const unSeenAbilities = Object.keys(species.abilities)
-				 .filter(key => key !== 'S' && (key !== 'H' || !species.unreleasedHidden))
-				 .map(key => species.abilities[key as "0" | "1" | "H" | "S"]);
- 
-			 if (ability.id !== this.toID(species.abilities['S'])) {
-				 for (const abilityName of unSeenAbilities) {
-					 setHas['ability:' + toID(abilityName)] = true;
-				 }
-			 }
-		 }
- 
-		 let banReason = ruleTable.check('ability:' + ability.id);
-		 if (banReason) {
-			 return `${set.name}'s ability ${ability.name} is ${banReason}.`;
-		 }
-		 if (banReason === '') return null;
- 
-		 banReason = ruleTable.check('pokemontag:allabilities');
-		 if (banReason) {
-			 return `${set.name}'s ability ${ability.name} is not in the list of allowed abilities.`;
-		 }
- 
-		 // obtainability
-		 if (ability.isNonstandard) {
-			 banReason = ruleTable.check('pokemontag:' + toID(ability.isNonstandard));
-			 if (banReason) {
-				 return `${set.name}'s ability ${ability.name} is tagged ${ability.isNonstandard}, which is ${banReason}.`;
-			 }
-			 if (banReason === '') return null;
- 
-			 banReason = ruleTable.check('nonexistent', setHas);
-			 if (banReason) {
-				 if (['Past', 'Future'].includes(ability.isNonstandard)) {
-					 return `${set.name}'s ability ${ability.name} does not exist in Gen ${dex.gen}.`;
-				 }
-				 return `${set.name}'s ability ${ability.name} does not exist in this game.`;
-			 }
-			 if (banReason === '') return null;
-		 }
- 
-		 return null;
-	 }
- 
-	 checkNature(set: PokemonSet, nature: Nature, setHas: {[k: string]: true}) {
-		 const dex = this.dex;
-		 const ruleTable = this.ruleTable;
- 
-		 setHas['nature:' + nature.id] = true;
- 
-		 let banReason = ruleTable.check('nature:' + nature.id);
-		 if (banReason) {
-			 return `${set.name}'s nature ${nature.name} is ${banReason}.`;
-		 }
-		 if (banReason === '') return null;
- 
-		 banReason = ruleTable.check('allnatures');
-		 if (banReason) {
-			 return `${set.name}'s nature ${nature.name} is not in the list of allowed natures.`;
-		 }
- 
-		 // obtainability
-		 if (nature.isNonstandard) {
-			 banReason = ruleTable.check('pokemontag:' + toID(nature.isNonstandard));
-			 if (banReason) {
-				 return `${set.name}'s nature ${nature.name} is tagged ${nature.isNonstandard}, which is ${banReason}.`;
-			 }
-			 if (banReason === '') return null;
- 
-			 banReason = ruleTable.check('nonexistent', setHas);
-			 if (banReason) {
-				 if (['Past', 'Future'].includes(nature.isNonstandard)) {
-					 return `${set.name}'s nature ${nature.name} does not exist in Gen ${dex.gen}.`;
-				 }
-				 return `${set.name}'s nature ${nature.name} does not exist in this game.`;
-			 }
-			 if (banReason === '') return null;
-		 }
-		 return null;
-	 }
- 
-	 validateEvent(
-		 set: PokemonSet, setSources: PokemonSources, eventData: EventInfo, eventSpecies: Species
-	 ): true | undefined;
-	 validateEvent(
-		 set: PokemonSet, setSources: PokemonSources, eventData: EventInfo, eventSpecies: Species,
-		 because: string, from?: string
-	 ): string[] | undefined;
-	 /**
-	  * Returns array of error messages if invalid, undefined if valid
-	  *
-	  * If `because` is not passed, instead returns true if invalid.
-	  */
-	 validateEvent(
-		 set: PokemonSet, setSources: PokemonSources, eventData: EventInfo, eventSpecies: Species,
-		 because = ``, from = `from an event`
-	 ) {
-		 const dex = this.dex;
-		 let name = set.species;
-		 const species = dex.species.get(set.species);
-		 const maxSourceGen = this.ruleTable.has('allowtradeback') ? Utils.clampIntRange(dex.gen + 1, 1, 8) : dex.gen;
-		 if (!eventSpecies) eventSpecies = species;
-		 if (set.name && set.species !== set.name && species.baseSpecies !== set.name) name = `${set.name} (${set.species})`;
- 
-		 const fastReturn = !because;
-		 if (eventData.from) from = `from ${eventData.from}`;
-		 const etc = `${because} ${from}`;
- 
-		 const problems = [];
- 
-		 if (dex.gen < 8 && this.minSourceGen > eventData.generation) {
-			 if (fastReturn) return true;
-			 problems.push(`This format requires Pokemon from gen ${this.minSourceGen} or later and ${name} is from gen ${eventData.generation}${etc}.`);
-		 }
-		 if (maxSourceGen < eventData.generation) {
-			 if (fastReturn) return true;
-			 problems.push(`This format is in gen ${dex.gen} and ${name} is from gen ${eventData.generation}${etc}.`);
-		 }
- 
-		 if (eventData.japan && dex.currentMod !== 'gen1jpn') {
-			 if (fastReturn) return true;
-			 problems.push(`${name} has moves from Japan-only events, but this format simulates International Yellow/Crystal which can't trade with Japanese games.`);
-		 }
- 
-		 if (eventData.level && (set.level || 0) < eventData.level) {
-			 if (fastReturn) return true;
-			 problems.push(`${name} must be at least level ${eventData.level}${etc}.`);
-		 }
-		 if ((eventData.shiny === true && !set.shiny) || (!eventData.shiny && set.shiny)) {
-			 if (fastReturn) return true;
-			 const shinyReq = eventData.shiny ? ` be shiny` : ` not be shiny`;
-			 problems.push(`${name} must${shinyReq}${etc}.`);
-		 }
-		 if (eventData.gender) {
-			 if (set.gender && eventData.gender !== set.gender) {
-				 if (fastReturn) return true;
-				 problems.push(`${name}'s gender must be ${eventData.gender}${etc}.`);
-			 }
-		 }
-		 const canMint = dex.gen > 7;
-		 if (eventData.nature && eventData.nature !== set.nature && !canMint) {
-			 if (fastReturn) return true;
-			 problems.push(`${name} must have a ${eventData.nature} nature${etc} - Mints are only available starting gen 8.`);
-		 }
-		 let requiredIVs = 0;
-		 if (eventData.ivs) {
-			 /** In Gen 7, IVs can be changed to 31 */
-			 const canBottleCap = (dex.gen >= 7 && set.level === 100);
- 
-			 if (!set.ivs) set.ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
-			 let statName: StatID;
-			 for (statName in eventData.ivs) {
-				 if (canBottleCap && set.ivs[statName] === 31) continue;
-				 if (set.ivs[statName] !== eventData.ivs[statName]) {
-					 if (fastReturn) return true;
-					 problems.push(`${name} must have ${eventData.ivs[statName]} ${Dex.stats.names[statName]} IVs${etc}.`);
-				 }
-			 }
- 
-			 if (canBottleCap) {
-				 // IVs can be overridden but Hidden Power type can't
-				 if (Object.keys(eventData.ivs).length >= 6) {
-					 const requiredHpType = dex.getHiddenPower(eventData.ivs).type;
-					 if (set.hpType && set.hpType !== requiredHpType) {
-						 if (fastReturn) return true;
-						 problems.push(`${name} can only have Hidden Power ${requiredHpType}${etc}.`);
-					 }
-					 set.hpType = requiredHpType;
-				 }
-			 }
-		 } else {
-			 requiredIVs = eventData.perfectIVs || 0;
-		 }
-		 if (requiredIVs && set.ivs) {
-			 // Legendary Pokemon must have at least 3 perfect IVs in gen 6
-			 // Events can also have a certain amount of guaranteed perfect IVs
-			 let perfectIVs = 0;
-			 let statName: StatID;
-			 for (statName in set.ivs) {
-				 if (set.ivs[statName] >= 31) perfectIVs++;
-			 }
-			 if (perfectIVs < requiredIVs) {
-				 if (fastReturn) return true;
-				 if (eventData.perfectIVs) {
-					 problems.push(`${name} must have at least ${requiredIVs} perfect IVs${etc}.`);
-				 }
-			 }
-			 // The perfect IV count affects Hidden Power availability
-			 if (dex.gen >= 3 && requiredIVs >= 3 && set.hpType === 'Fighting') {
-				 if (fastReturn) return true;
-				 problems.push(`${name} can't use Hidden Power Fighting because it must have at least three perfect IVs${etc}.`);
-			 } else if (dex.gen >= 3 && requiredIVs >= 5 && set.hpType &&
-					 !['Dark', 'Dragon', 'Electric', 'Steel', 'Ice'].includes(set.hpType)) {
-				 if (fastReturn) return true;
-				 problems.push(`${name} can only use Hidden Power Dark/Dragon/Electric/Steel/Ice because it must have at least 5 perfect IVs${etc}.`);
-			 }
-		 }
-		 const ruleTable = this.ruleTable;
-		 if (ruleTable.has('obtainablemoves')) {
-			 const ssMaxSourceGen = setSources.maxSourceGen();
-			 const tradebackEligible = dex.gen === 2 && species.gen === 1;
-			 if (ssMaxSourceGen && eventData.generation > ssMaxSourceGen && !tradebackEligible) {
-				 if (fastReturn) return true;
-				 problems.push(`${name} must not have moves only learnable in gen ${ssMaxSourceGen}${etc}.`);
-			 }
-		 }
-		 if (ruleTable.has('obtainableabilities')) {
-			 if (dex.gen <= 5 && eventData.abilities && eventData.abilities.length === 1 && !eventData.isHidden) {
-				 if (species.name === eventSpecies.name) {
-					 // has not evolved, abilities must match
-					 const requiredAbility = dex.abilities.get(eventData.abilities[0]).name;
-					 if (set.ability !== requiredAbility) {
-						 if (fastReturn) return true;
-						 problems.push(`${name} must have ${requiredAbility}${etc}.`);
-					 }
-				 } else {
-					 // has evolved
-					 const ability1 = dex.abilities.get(eventSpecies.abilities['1']);
-					 if (ability1.gen && eventData.generation >= ability1.gen) {
-						 // pokemon had 2 available abilities in the gen the event happened
-						 // ability is restricted to a single ability slot
-						 const requiredAbilitySlot = (toID(eventData.abilities[0]) === ability1.id ? 1 : 0);
-						 const requiredAbility = dex.abilities.get(species.abilities[requiredAbilitySlot] || species.abilities['0']).name;
-						 if (set.ability !== requiredAbility) {
-							 const originalAbility = dex.abilities.get(eventData.abilities[0]).name;
-							 if (fastReturn) return true;
-							 problems.push(`${name} must have ${requiredAbility}${because} from a ${originalAbility} ${eventSpecies.name} event.`);
-						 }
-					 }
-				 }
-			 }
-			 if (species.abilities['H']) {
-				 const isHidden = (set.ability === species.abilities['H']);
-				 const canUseAbilityPatch = dex.gen >= 8 && this.format.mod !== 'gen8dlc1';
-				 if (!isHidden || !canUseAbilityPatch) {
-					 const hiddenAbilityProblem = this.validateEventHiddenAbility(name, isHidden, eventData, etc);
-					 if (hiddenAbilityProblem) {
-						 if (fastReturn) return true;
-						 problems.push(hiddenAbilityProblem);
-					 }
-				 }
-			 }
-		 }
-		 if (problems.length) return problems;
-		 if (eventData.gender) set.gender = eventData.gender;
-	 }
- 
-	 validateEventHiddenAbility(name: string, isHidden: boolean, eventData: EventInfo, etc: string) {
-		 if (!isHidden && eventData.isHidden) {
-			 return `${name} must have its Hidden Ability${etc}.`;
-		 }
- 
-		 if (isHidden && !eventData.isHidden) {
-			 return `${name} must not have its Hidden Ability${etc}.`;
-		 }
-		 return null;
-	 }
- 
-	 allSources(species?: Species) {
-		 let minSourceGen = this.minSourceGen;
-		 if (this.dex.gen >= 3 && minSourceGen < 3) minSourceGen = 3;
-		 if (species) minSourceGen = Math.max(minSourceGen, species.gen);
-		 const maxSourceGen = this.ruleTable.has('allowtradeback') ? Utils.clampIntRange(this.dex.gen + 1, 1, 8) : this.dex.gen;
-		 return new PokemonSources(maxSourceGen, minSourceGen);
-	 }
- 
-	 validateMoves(
-		 species: Species, moves: string[], setSources: PokemonSources, set?: Partial<PokemonSet>,
-		 name: string = species.name
-	 ) {
-		 const dex = this.dex;
-		 const ruleTable = this.ruleTable;
- 
-		 const problems = [];
- 
-		 const checkCanLearn = (ruleTable.checkCanLearn && ruleTable.checkCanLearn[0] || this.checkCanLearn);
-		 for (const moveName of moves) {
-			 const move = dex.moves.get(moveName);
-			 const problem = checkCanLearn.call(this, move, species, setSources, set);
-			 if (problem) {
-				 problems.push(`${name}${problem}`);
-				 break;
-			 }
-		 }
- 
-		 if (setSources.size() && setSources.moveEvoCarryCount > 3) {
-			 if (setSources.sourcesBefore < 6) setSources.sourcesBefore = 0;
-			 setSources.sources = setSources.sources.filter(
-				 source => source.charAt(1) === 'E' && parseInt(source.charAt(0)) >= 6
-			 );
-			 if (!setSources.size()) {
-				 problems.push(`${name} needs to know ${species.evoMove || 'a Fairy-type move'} to evolve, so it can only know 3 other moves from ${species.prevo}.`);
-			 }
-		 }
- 
-		 if (problems.length) return problems;
- 
-		 
-		 const canUseAbilityPatch = dex.gen >= 8 && this.format.mod !== 'gen8dlc1';
-		 if (setSources.isHidden && !canUseAbilityPatch) {
-			 setSources.sources = setSources.sources.filter(
-				 source => parseInt(source.charAt(0)) >= 5
-			 );
-			 if (setSources.sourcesBefore < 5) setSources.sourcesBefore = 0;
-			 if (!setSources.size()) {
-				 problems.push(`${name} has a hidden ability - it can't have moves only learned before gen 5.`);
-				 return problems;
-			 }
-		 }
- 
-		 if (setSources.babyOnly && setSources.sources.length) {
-			 const baby = dex.species.get(setSources.babyOnly);
-			 const babyEvo = toID(baby.evos[0]);
-			 setSources.sources = setSources.sources.filter(source => {
-				 if (source.charAt(1) === 'S') {
-					 const sourceId = source.split(' ')[1];
-					 if (sourceId !== baby.id) return false;
-				 }
-				 if (source.charAt(1) === 'E') {
-					 if (babyEvo && source.slice(2) === babyEvo) return false;
-				 }
-				 if (source.charAt(1) === 'D') {
-					 if (babyEvo && source.slice(2) === babyEvo) return false;
-				 }
-				 return true;
-			 });
-			 if (!setSources.size()) {
-				 problems.push(`${name}'s event/egg moves are from an evolution, and are incompatible with its moves from ${baby.name}.`);
-			 }
-		 }
-		 if (setSources.babyOnly && setSources.size() && this.gen > 2) {
-			 // there do theoretically exist evo/tradeback incompatibilities in
-			 // gen 2, but those are very complicated to validate and should be
-			 // handled separately anyway, so for now we just treat them all as
-			 // legal (competitively relevant ones can be manually banned)
-			 const baby = dex.species.get(setSources.babyOnly);
-			 setSources.sources = setSources.sources.filter(source => {
-				 if (baby.gen > parseInt(source.charAt(0)) && !source.startsWith('1ST')) return false;
-				 if (baby.gen > 2 && source === '7V') return false;
-				 return true;
-			 });
-			 if (setSources.sourcesBefore < baby.gen) setSources.sourcesBefore = 0;
-			 if (!setSources.size()) {
-				 problems.push(`${name} has moves from before Gen ${baby.gen}, which are incompatible with its moves from ${baby.name}.`);
-			 }
-		 }
- 
-		 return problems;
-	 }
- 
-	 /** Returns null if you can learn the move, or a string explaining why you can't learn it */
-	 checkCanLearn(
-		 move: Move,
-		 s: Species,
-		 setSources = this.allSources(s),
-		 set: Partial<PokemonSet> = {}
-	 ): string | null {
-		 const dex = this.dex;
-		 if (!setSources.size()) throw new Error(`Bad sources passed to checkCanLearn`);
- 
-		 move = dex.moves.get(move);
-		 const moveid = move.id;
-		 const baseSpecies = dex.species.get(s);
-		 let species: Species | null = baseSpecies;
- 
-		 const format = this.format;
-		 const ruleTable = dex.formats.getRuleTable(format);
-		 const alreadyChecked: {[k: string]: boolean} = {};
-		 const level = set.level || 100;
- 
-		 let cantLearnReason = null;
- 
-		 let limit1 = true;
-		 let sketch = false;
-		 let blockedHM = false;
- 
-		 let babyOnly = '';
- 
-		 // This is a pretty complicated algorithm
- 
-		 // Abstractly, what it does is construct the union of sets of all
-		 // possible ways this pokemon could be obtained, and then intersect
-		 // it with a the pokemon's existing set of all possible ways it could
-		 // be obtained. If this intersection is non-empty, the move is legal.
- 
-		 // set of possible sources of a pokemon with this move
-		 const moveSources = new PokemonSources();
- 
-		 /**
-		  * The format doesn't allow Pokemon traded from the future
-		  * (This is everything except in Gen 1 Tradeback)
-		  */
-		 const noFutureGen = !ruleTable.has('allowtradeback');
-		 /**
-		  * The format allows Sketch to copy moves in Gen 8
-		  */
-		 const canSketchGen8Moves = ruleTable.has('sketchgen8moves') || this.dex.currentMod === 'gen8bdsp';
- 
-		 let tradebackEligible = false;
-		 while (species?.name && !alreadyChecked[species.id]) {
-			 alreadyChecked[species.id] = true;
-			 if (dex.gen <= 2 && species.gen === 1) tradebackEligible = true;
-			 const learnset = dex.species.getLearnset(species.id);
-			 if (!learnset) {
-				 if ((species.changesFrom || species.baseSpecies) !== species.name) {
-					 // forme without its own learnset
-					 species = dex.species.get(species.changesFrom || species.baseSpecies);
-					 // warning: formes with their own learnset, like Wormadam, should NOT
-					 // inherit from their base forme unless they're freely switchable
-					 continue;
-				 }
-				 if (species.isNonstandard) {
-					 // It's normal for a nonstandard species not to have learnset data
- 
-					 // Formats should replace the `Obtainable Moves` rule if they want to
-					 // allow pokemon without learnsets.
-					 return ` can't learn any moves at all.`;
-				 }
-				 // should never happen
-				 throw new Error(`Species with no learnset data: ${species.id}`);
-			 }
-			 const checkingPrevo = species.baseSpecies !== s.baseSpecies;
-			 if (checkingPrevo && !moveSources.size()) {
-				 if (!setSources.babyOnly || !species.prevo) {
-					 babyOnly = species.id;
-				 }
-			 }
- 
-			 let sources = learnset[moveid];
-			 if (moveid === 'sketch') {
-				 sketch = true;
-			 } else if (learnset['sketch']) {
-				 if (move.noSketch || move.isZ || move.isMax) {
-					 cantLearnReason = `can't be Sketched.`;
-				 } else if (move.gen > 7 && !canSketchGen8Moves) {
-					 cantLearnReason = `can't be Sketched because it's a Gen 8 move and Sketch isn't available in Gen 8.`;
-				 } else {
-					 if (!sources) sketch = true;
-					 sources = learnset['sketch'].concat(sources || []);
-				 }
-			 }
- 
-			 if (typeof sources === 'string') sources = [sources];
-			 if (sources) {
-				 for (let learned of sources) {
-					 // Every `learned` represents a single way a pokemon might
-					 // learn a move. This can be handled one of several ways:
-					 // `continue`
-					 //   means we can't learn it
-					 // `return null`
-					 //   means we can learn it with no restrictions
-					 //   (there's a way to just teach any pokemon of this species
-					 //   the move in the current gen, like a TM.)
-					 // `moveSources.add(source)`
-					 //   means we can learn it only if obtained that exact way described
-					 //   in source
-					 // `moveSources.addGen(learnedGen)`
-					 //   means we can learn it only if obtained at or before learnedGen
-					 //   (i.e. get the pokemon however you want, transfer to that gen,
-					 //   teach it, and transfer it to the current gen.)
- 
-					 const learnedGen = parseInt(learned.charAt(0));
-					 if (learnedGen < this.minSourceGen) {
-						 if (!cantLearnReason) {
-							 cantLearnReason = `can't be transferred from Gen ${learnedGen} to ${this.minSourceGen}.`;
-						 }
-						 continue;
-					 }
-					 if (noFutureGen && learnedGen > dex.gen) {
-						 if (!cantLearnReason) {
-							 cantLearnReason = `can't be transferred from Gen ${learnedGen} to ${dex.gen}.`;
-						 }
-						 continue;
-					 }
- 
-					 // redundant
-					 if (learnedGen <= moveSources.sourcesBefore) continue;
- 
-					 if (baseSpecies.evoRegion === 'Alola' && checkingPrevo && learnedGen >= 8) {
-						 cantLearnReason = `is from a ${species.name} that can't be transferred to USUM to evolve into ${baseSpecies.name}.`;
-						 continue;
-					 }
- 
-					 const canUseAbilityPatch = dex.gen >= 8 && format.mod !== 'gen8dlc1';
-					 if (
-						 learnedGen < 7 && setSources.isHidden && !canUseAbilityPatch &&
-						 !dex.mod('gen' + learnedGen).species.get(baseSpecies.name).abilities['H']
-					 ) {
-						 cantLearnReason = `can only be learned in gens without Hidden Abilities.`;
-						 continue;
-					 }
-					 if (!species.isNonstandard) {
-						 // HMs can't be transferred
-						 if (dex.gen >= 4 && learnedGen <= 3 && [
-							 'cut', 'fly', 'surf', 'strength', 'flash', 'rocksmash', 'waterfall', 'dive',
-						 ].includes(moveid)) {
-							 cantLearnReason = `can't be transferred from Gen 3 to 4 because it's an HM move.`;
-							 continue;
-						 }
-						 if (dex.gen >= 5 && learnedGen <= 4 && [
-							 'cut', 'fly', 'surf', 'strength', 'rocksmash', 'waterfall', 'rockclimb',
-						 ].includes(moveid)) {
-							 cantLearnReason = `can't be transferred from Gen 4 to 5 because it's an HM move.`;
-							 continue;
-						 }
-						 // Defog and Whirlpool can't be transferred together
-						 if (dex.gen >= 5 && ['defog', 'whirlpool'].includes(moveid) && learnedGen <= 4) blockedHM = true;
-					 }
- 
-					 if (learned.charAt(1) === 'L') {
-						 // special checking for level-up moves
-						 if (level >= parseInt(learned.substr(2)) || learnedGen === 7) {
-							 // we're past the required level to learn it
-							 // (gen 7 level-up moves can be relearnered at any level)
-							 // falls through to LMT check below
-						 } else if (level >= 5 && learnedGen === 3 && species.canHatch) {
-							 // Pomeg Glitch
-						 } else if ((!species.gender || species.gender === 'F') && learnedGen >= 2 && species.canHatch) {
-							 // available as egg move
-							 learned = learnedGen + 'Eany';
-							 // falls through to E check below
-						 } else {
-							 // this move is unavailable, skip it
-							 cantLearnReason = `is learned at level ${parseInt(learned.substr(2))}.`;
-							 continue;
-						 }
-					 }
- 
-					 // Gen 8 egg moves can be taught to any pokemon from any source
-					 if (learned === '8E' || 'LMTR'.includes(learned.charAt(1))) {
-						 if (learnedGen === dex.gen && learned.charAt(1) !== 'R') {
-							 // current-gen level-up, TM or tutor moves:
-							 //   always available
-							 if (learned !== '8E' && babyOnly) setSources.babyOnly = babyOnly;
-							 if (!moveSources.moveEvoCarryCount) return null;
-						 }
-						 // past-gen level-up, TM, or tutor moves:
-						 //   available as long as the source gen was or was before this gen
-						 if (learned.charAt(1) === 'R') {
-							 moveSources.restrictedMove = moveid;
-						 }
-						 limit1 = false;
-						 moveSources.addGen(learnedGen);
-					 } else if (learned.charAt(1) === 'E') {
-						 // egg moves:
-						 //   only if hatched from an egg
-						 let limitedEggMove: ID | null | undefined = undefined;
-						 if (learned.slice(1) === 'Eany') {
-							 limitedEggMove = null;
-						 } else if (learnedGen < 6) {
-							 limitedEggMove = move.id;
-						 }
-						 learned = learnedGen + 'E' + (species.prevo ? species.id : '');
-						 if (tradebackEligible && learnedGen === 2 && move.gen <= 1) {
-							 // can tradeback
-							 moveSources.add('1ET' + learned.slice(2));
-						 }
-						 moveSources.add(learned, limitedEggMove);
-					 } else if (learned.charAt(1) === 'S') {
-						 // event moves:
-						 //   only if that was the source
-						 // Event Pokémon:
-						 // 	Available as long as the past gen can get the Pokémon and then trade it back.
-						 if (tradebackEligible && learnedGen === 2 && move.gen <= 1) {
-							 // can tradeback
-							 moveSources.add('1ST' + learned.slice(2) + ' ' + species.id);
-						 }
-						 moveSources.add(learned + ' ' + species.id);
-					 } else if (learned.charAt(1) === 'D') {
-						 // DW moves:
-						 //   only if that was the source
-						 moveSources.add(learned + species.id);
-					 } else if (learned.charAt(1) === 'V' && this.minSourceGen < learnedGen) {
-						 // Virtual Console or Let's Go transfer moves:
-						 //   only if that was the source
-						 moveSources.add(learned);
-					 }
-				 }
-			 }
-			 if (ruleTable.has('mimicglitch') && species.gen < 5) {
-				 // include the Mimic Glitch when checking this mon's learnset
-				 const glitchMoves = ['metronome', 'copycat', 'transform', 'mimic', 'assist'];
-				 let getGlitch = false;
-				 for (const i of glitchMoves) {
-					 if (learnset[i]) {
-						 if (!(i === 'mimic' && dex.abilities.get(set.ability).gen === 4 && !species.prevo)) {
-							 getGlitch = true;
-							 break;
-						 }
-					 }
-				 }
-				 if (getGlitch) {
-					 moveSources.addGen(4);
-					 if (move.gen < 5) {
-						 limit1 = false;
-					 }
-				 }
-			 }
- 
-			 if (!moveSources.size()) {
-				 if (
-					 (species.evoType === 'levelMove' && species.evoMove !== move.name) ||
-					 (species.id === 'sylveon' && move.type !== 'Fairy')
-				 ) {
-					 moveSources.moveEvoCarryCount = 1;
-				 }
-			 }
- 
-			 // also check to see if the mon's prevo or freely switchable formes can learn this move
-			 species = this.learnsetParent(species);
-		 }
- 
-		 if (limit1 && sketch) {
-			 // limit 1 sketch move
-			 if (setSources.sketchMove) {
-				 return ` can't Sketch ${move.name} and ${setSources.sketchMove} because it can only Sketch 1 move.`;
-			 }
-			 setSources.sketchMove = move.name;
-		 }
- 
-		 if (blockedHM) {
-			 // Limit one of Defog/Whirlpool to be transferred
-			 if (setSources.hm) return ` can't simultaneously transfer Defog and Whirlpool from Gen 4 to 5.`;
-			 setSources.hm = moveid;
-		 }
- 
-		 if (!setSources.restrictiveMoves) {
-			 setSources.restrictiveMoves = [];
-		 }
-		 setSources.restrictiveMoves.push(move.name);
- 
-		 // Now that we have our list of possible sources, intersect it with the current list
-		 if (!moveSources.size()) {
-			 if (cantLearnReason) return `'s move ${move.name} ${cantLearnReason}`;
-			 return ` can't learn ${move.name}.`;
-		 }
-		 const backupSources = setSources.sources;
-		 const backupSourcesBefore = setSources.sourcesBefore;
-		 setSources.intersectWith(moveSources);
-		 if (!setSources.size()) {
-			 // pretend this pokemon didn't have this move:
-			 // prevents a crash if OMs override `checkCanLearn` to keep validating after an error
-			 setSources.sources = backupSources;
-			 setSources.sourcesBefore = backupSourcesBefore;
-			 return `'s moves ${(setSources.restrictiveMoves || []).join(', ')} are incompatible.`;
-		 }
- 
-		 if (babyOnly) setSources.babyOnly = babyOnly;
-		 return null;
-	 }
- 
-	 learnsetParent(species: Species) {
-		 // Own Tempo Rockruff and Battle Bond Greninja are special event formes
-		 // that are visually indistinguishable from their base forme but have
-		 // different learnsets. To prevent a leak, we make them show up as their
-		 // base forme, but hardcode their learnsets into Rockruff-Dusk and
-		 // Greninja-Ash
-		 if (['Gastrodon', 'Pumpkaboo', 'Sinistea'].includes(species.baseSpecies) && species.forme) {
-			 return this.dex.species.get(species.baseSpecies);
-		 } else if (species.name === 'Lycanroc-Dusk') {
-			 return this.dex.species.get('Rockruff-Dusk');
-		 } else if (species.name === 'Greninja-Ash') {
-			 return null;
-		 } else if (species.prevo) {
-			 // there used to be a check for Hidden Ability here, but apparently it's unnecessary
-			 // Shed Skin Pupitar can definitely evolve into Unnerve Tyranitar
-			 species = this.dex.species.get(species.prevo);
-			 if (species.gen > Math.max(2, this.dex.gen)) return null;
-			 return species;
-		 } else if (species.changesFrom && species.baseSpecies !== 'Kyurem') {
-			 // For Pokemon like Rotom and Necrozma whose movesets are extensions are their base formes
-			 return this.dex.species.get(species.changesFrom);
-		 }
-		 return null;
-	 }
- 
-	 static fillStats(stats: SparseStatsTable | null, fillNum = 0): StatsTable {
-		 const filledStats: StatsTable = {hp: fillNum, atk: fillNum, def: fillNum, spa: fillNum, spd: fillNum, spe: fillNum};
-		 if (stats) {
-			 let statName: StatID;
-			 for (statName in filledStats) {
-				 const stat = stats[statName];
-				 if (typeof stat === 'number') filledStats[statName] = stat;
-			 }
-		 }
-		 return filledStats;
-	 }
- 
-	 static get(format: string | Format) {
-		 return new TeamValidator(format);
-	 }
- }
- 
+import {Dex, toID} from './dex';
+import {Utils} from '../lib';
+import {Tags} from '../data/tags';
+import {Teams} from './teams';
+import {PRNG} from './prng';
+
+/**
+ * Describes a possible way to get a pokemon. Is not exhaustive!
+ * sourcesBefore covers all sources that do not have exclusive
+ * moves (like catching wild pokemon).
+ *
+ * First character is a generation number, 1-8.
+ * Second character is a source ID, one of:
+ *
+ * - E = egg, 3rd char+ is the father in gen 2-5, empty in gen 6-7
+ *   because egg moves aren't restricted to fathers anymore
+ * - S = event, 3rd char+ is the index in .eventData
+ * - D = Dream World, only 5D is valid
+ * - V = Virtual Console or Let's Go transfer, only 7V/8V is valid
+ *
+ * Designed to match MoveSource where possible.
+ */
+export type PokemonSource = string;
+
+/**
+ * Represents a set of possible ways to get a Pokémon with a given
+ * set.
+ *
+ * `new PokemonSources()` creates an empty set;
+ * `new PokemonSources(dex.gen)` allows all Pokemon.
+ *
+ * The set mainly stored as an Array `sources`, but for sets that
+ * could be sourced from anywhere (for instance, TM moves), we
+ * instead just set `sourcesBefore` to a number meaning "any
+ * source at or before this gen is possible."
+ *
+ * In other words, this variable represents the set of all
+ * sources in `sources`, union all sources at or before
+ * gen `sourcesBefore`.
+ */
+export class PokemonSources {
+	/**
+	 * A set of specific possible PokemonSources; implemented as
+	 * an Array rather than a Set for perf reasons.
+	 */
+	sources: PokemonSource[];
+	/**
+	 * if nonzero: the set also contains all possible sources from
+	 * this gen and earlier.
+	 */
+	sourcesBefore: number;
+	/**
+	 * the set requires sources from this gen or later
+	 * this should be unchanged from the format's minimum past gen
+	 * (3 in modern games, 6 if pentagon is required, etc)
+	 */
+	sourcesAfter: number;
+	isHidden: boolean | null;
+	/**
+	 * `limitedEggMoves` is a list of moves that can only be obtained from an
+	 * egg with another father in gen 2-5. If there are multiple such moves,
+	 * potential fathers need to be checked to see if they can actually
+	 * learn the move combination in question.
+	 *
+	 * `null` = the current move is definitely not a limited egg move
+	 *
+	 * `undefined` = the current move may or may not be a limited egg move
+	 */
+	limitedEggMoves?: ID[] | null;
+	/**
+	 * Some Pokemon evolve by having a move in their learnset (like Piloswine
+	 * with Ancient Power). These can only carry three other moves from their
+	 * prevo, because the fourth move must be the evo move. This restriction
+	 * doesn't apply to gen 6+ eggs, which can get around the restriction with
+	 * the relearner.
+	 */
+	moveEvoCarryCount: number;
+
+	babyOnly?: string;
+	sketchMove?: string;
+	hm?: string;
+	restrictiveMoves?: string[];
+	/** Obscure learn methods */
+	restrictedMove?: ID;
+
+	constructor(sourcesBefore = 0, sourcesAfter = 0) {
+		this.sources = [];
+		this.sourcesBefore = sourcesBefore;
+		this.sourcesAfter = sourcesAfter;
+		this.isHidden = null;
+		this.limitedEggMoves = undefined;
+		this.moveEvoCarryCount = 0;
+	}
+	size() {
+		if (this.sourcesBefore) return Infinity;
+		return this.sources.length;
+	}
+	add(source: PokemonSource, limitedEggMove?: ID | null) {
+		if (this.sources[this.sources.length - 1] !== source) this.sources.push(source);
+		if (limitedEggMove && this.limitedEggMoves !== null) {
+			this.limitedEggMoves = [limitedEggMove];
+		} else if (limitedEggMove === null) {
+			this.limitedEggMoves = null;
+		}
+	}
+	addGen(sourceGen: number) {
+		this.sourcesBefore = Math.max(this.sourcesBefore, sourceGen);
+		this.limitedEggMoves = null;
+	}
+	minSourceGen() {
+		if (this.sourcesBefore) return this.sourcesAfter || 1;
+		let min = 10;
+		for (const source of this.sources) {
+			const sourceGen = parseInt(source.charAt(0));
+			if (sourceGen < min) min = sourceGen;
+		}
+		if (min === 10) return 0;
+		return min;
+	}
+	maxSourceGen() {
+		let max = this.sourcesBefore;
+		for (const source of this.sources) {
+			const sourceGen = parseInt(source.charAt(0));
+			if (sourceGen > max) max = sourceGen;
+		}
+		return max;
+	}
+	intersectWith(other: PokemonSources) {
+		if (other.sourcesBefore || this.sourcesBefore) {
+			// having sourcesBefore is the equivalent of having everything before that gen
+			// in sources, so we fill the other array in preparation for intersection
+			if (other.sourcesBefore > this.sourcesBefore) {
+				for (const source of this.sources) {
+					const sourceGen = parseInt(source.charAt(0));
+					if (sourceGen <= other.sourcesBefore) {
+						other.sources.push(source);
+					}
+				}
+			} else if (this.sourcesBefore > other.sourcesBefore) {
+				for (const source of other.sources) {
+					const sourceGen = parseInt(source.charAt(0));
+					if (sourceGen <= this.sourcesBefore) {
+						this.sources.push(source);
+					}
+				}
+			}
+			this.sourcesBefore = Math.min(other.sourcesBefore, this.sourcesBefore);
+		}
+		if (this.sources.length) {
+			if (other.sources.length) {
+				const sourcesSet = new Set(other.sources);
+				const intersectSources = this.sources.filter(source => sourcesSet.has(source));
+				this.sources = intersectSources;
+			} else {
+				this.sources = [];
+			}
+		}
+
+		if (other.restrictedMove && other.restrictedMove !== this.restrictedMove) {
+			if (this.restrictedMove) {
+				// incompatible
+				this.sources = [];
+				this.sourcesBefore = 0;
+			} else {
+				this.restrictedMove = other.restrictedMove;
+			}
+		}
+		if (other.limitedEggMoves) {
+			if (!this.limitedEggMoves) {
+				this.limitedEggMoves = other.limitedEggMoves;
+			} else {
+				this.limitedEggMoves.push(...other.limitedEggMoves);
+			}
+		}
+		this.moveEvoCarryCount += other.moveEvoCarryCount;
+		if (other.sourcesAfter > this.sourcesAfter) this.sourcesAfter = other.sourcesAfter;
+		if (other.isHidden) this.isHidden = true;
+	}
+}
+
+export class TeamValidator {
+	readonly format: Format;
+	readonly dex: ModdedDex;
+	readonly gen: number;
+	readonly ruleTable: import('./dex-formats').RuleTable;
+	readonly minSourceGen: number;
+
+	readonly toID: (str: any) => ID;
+	constructor(format: string | Format, dex = Dex) {
+		this.format = dex.formats.get(format);
+		this.dex = dex.forFormat(this.format);
+		this.gen = this.dex.gen;
+		this.ruleTable = this.dex.formats.getRuleTable(this.format);
+
+		this.minSourceGen = this.ruleTable.minSourceGen;
+
+		this.toID = toID;
+	}
+
+	validateTeam(
+		team: PokemonSet[] | null,
+		options: {
+			removeNicknames?: boolean,
+			skipSets?: {[name: string]: {[key: string]: boolean}},
+		} = {}
+	): string[] | null {
+		if (team && this.format.validateTeam) {
+			return this.format.validateTeam.call(this, team, options) || null;
+		}
+		return this.baseValidateTeam(team, options);
+	}
+
+	baseValidateTeam(
+		team: PokemonSet[] | null,
+		options: {
+			removeNicknames?: boolean,
+			skipSets?: {[name: string]: {[key: string]: boolean}},
+		} = {}
+	): string[] | null {
+		const format = this.format;
+		const dex = this.dex;
+
+		let problems: string[] = [];
+		const ruleTable = this.ruleTable;
+		if (format.team) {
+			if (team) {
+				return [
+					`This format doesn't let you use your own team.`,
+					`If you're not using a custom client, please report this as a bug. If you are, remember to use \`/utm null\` before starting a game in this format.`,
+				];
+			}
+			const testTeamSeed = PRNG.generateSeed();
+			try {
+				const testTeamGenerator = Teams.getGenerator(format, testTeamSeed);
+				testTeamGenerator.getTeam(options); // Throws error if generation fails
+			} catch (e) {
+				return [
+					`${format.name}'s team generator (${format.team}) failed using these rules and seed (${testTeamSeed}):-`,
+					`${e}`,
+				];
+			}
+			return null;
+		}
+		if (!team) {
+			return [
+				`This format requires you to use your own team.`,
+				`If you're not using a custom client, please report this as a bug.`,
+			];
+		}
+		if (!Array.isArray(team)) {
+			throw new Error(`Invalid team data`);
+		}
+
+		if (team.length < ruleTable.minTeamSize) {
+			problems.push(`You must bring at least ${ruleTable.minTeamSize} Pok\u00E9mon (your team has ${team.length}).`);
+		}
+		if (team.length > ruleTable.maxTeamSize) {
+			return [`You may only bring up to ${ruleTable.maxTeamSize} Pok\u00E9mon (your team has ${team.length}).`];
+		}
+
+		// A limit is imposed here to prevent too much engine strain or
+		// too much layout deformation - to be exact, this is the limit
+		// allowed in Custom Game.
+		if (team.length > 24) {
+			problems.push(`Your team has more than than 24 Pok\u00E9mon, which the simulator can't handle.`);
+			return problems;
+		}
+
+		const teamHas: {[k: string]: number} = {};
+		let lgpeStarterCount = 0;
+		let deoxysType;
+		for (const set of team) {
+			if (!set) return [`You sent invalid team data. If you're not using a custom client, please report this as a bug.`];
+
+			let setProblems: string[] | null = null;
+			if (options.skipSets && options.skipSets[set.name]) {
+				for (const i in options.skipSets[set.name]) {
+					teamHas[i] = (teamHas[i] || 0) + 1;
+				}
+			} else {
+				setProblems = (format.validateSet || this.validateSet).call(this, set, teamHas);
+			}
+
+			if (set.species === 'Pikachu-Starter' || set.species === 'Eevee-Starter') {
+				lgpeStarterCount++;
+				if (lgpeStarterCount === 2 && ruleTable.isBanned('nonexistent')) {
+					problems.push(`You can only have one of Pikachu-Starter or Eevee-Starter on a team.`);
+				}
+			}
+			if (dex.gen === 3 && set.species.startsWith('Deoxys')) {
+				if (!deoxysType) {
+					deoxysType = set.species;
+				} else if (deoxysType !== set.species && ruleTable.isBanned('nonexistent')) {
+					return [
+						`You cannot have more than one type of Deoxys forme.`,
+						`(Each game in Gen 3 supports only one forme of Deoxys.)`,
+					];
+				}
+			}
+			if (setProblems) {
+				problems = problems.concat(setProblems);
+			}
+			if (options.removeNicknames) {
+				const species = dex.species.get(set.species);
+				let crossSpecies: Species;
+				if (format.name === '[Gen 8] Cross Evolution' && (crossSpecies = dex.species.get(set.name)).exists) {
+					set.name = crossSpecies.name;
+				} else {
+					set.name = species.baseSpecies;
+					if (species.baseSpecies === 'Unown') set.species = 'Unown';
+				}
+			}
+		}
+
+		for (const [rule, source, limit, bans] of ruleTable.complexTeamBans) {
+			let count = 0;
+			for (const ban of bans) {
+				if (teamHas[ban] > 0) {
+					count += limit ? teamHas[ban] : 1;
+				}
+			}
+			if (limit && count > limit) {
+				const clause = source ? ` by ${source}` : ``;
+				problems.push(`You are limited to ${limit} of ${rule}${clause}.`);
+			} else if (!limit && count >= bans.length) {
+				const clause = source ? ` by ${source}` : ``;
+				problems.push(`Your team has the combination of ${rule}, which is banned${clause}.`);
+			}
+		}
+
+		for (const rule of ruleTable.keys()) {
+			if ('!+-'.includes(rule.charAt(0))) continue;
+			const subformat = dex.formats.get(rule);
+			if (subformat.onValidateTeam && ruleTable.has(subformat.id)) {
+				problems = problems.concat(subformat.onValidateTeam.call(this, team, format, teamHas) || []);
+			}
+		}
+		if (format.onValidateTeam) {
+			problems = problems.concat(format.onValidateTeam.call(this, team, format, teamHas) || []);
+		}
+
+		if (!problems.length) return null;
+		return problems;
+	}
+
+	getEventOnlyData(species: Species, noRecurse?: boolean): {species: Species, eventData: EventInfo[]} | null {
+		const dex = this.dex;
+		const learnset = dex.species.getLearnsetData(species.id);
+		if (!learnset?.eventOnly) {
+			if (noRecurse) return null;
+			return this.getEventOnlyData(dex.species.get(species.prevo), true);
+		}
+
+		if (!learnset.eventData && species.forme) {
+			return this.getEventOnlyData(dex.species.get(species.baseSpecies), true);
+		}
+		if (!learnset.eventData) {
+			throw new Error(`Event-only species ${species.name} has no eventData table`);
+		}
+
+		return {species, eventData: learnset.eventData};
+	}
+
+	validateSet(set: PokemonSet, teamHas: AnyObject): string[] | null {
+		const format = this.format;
+		const dex = this.dex;
+		const ruleTable = this.ruleTable;
+
+		let problems: string[] = [];
+		if (!set) {
+			return [`This is not a Pokemon.`];
+		}
+
+		let species = dex.species.get(set.species);
+		set.species = species.name;
+		// Backwards compatability with old Gmax format
+		if (set.species.toLowerCase().endsWith('-gmax') && this.format.id !== 'gen8megamax') {
+			set.species = set.species.slice(0, -5);
+			species = dex.species.get(set.species);
+			if (set.name && set.name.endsWith('-Gmax')) set.name = species.baseSpecies;
+			set.gigantamax = true;
+		}
+		if (set.name && set.name.length > 18) {
+			if (set.name === set.species) {
+				set.name = species.baseSpecies;
+			} else {
+				problems.push(`Nickname "${set.name}" too long (should be 18 characters or fewer)`);
+			}
+		}
+		set.name = dex.getName(set.name);
+		let item = dex.items.get(Utils.getString(set.item));
+		set.item = item.name;
+		let ability = dex.abilities.get(Utils.getString(set.ability));
+		set.ability = ability.name;
+		let nature = dex.natures.get(Utils.getString(set.nature));
+		set.nature = nature.name;
+		if (!Array.isArray(set.moves)) set.moves = [];
+
+		set.name = set.name || species.baseSpecies;
+		let name = set.species;
+		if (set.species !== set.name && species.baseSpecies !== set.name) {
+			name = `${set.name} (${set.species})`;
+		}
+
+		if (!set.level) set.level = ruleTable.defaultLevel;
+
+		let adjustLevel = ruleTable.adjustLevel;
+		if (ruleTable.adjustLevelDown && set.level >= ruleTable.adjustLevelDown) {
+			adjustLevel = ruleTable.adjustLevelDown;
+		}
+		if (set.level === adjustLevel || (set.level === 100 && ruleTable.maxLevel < 100)) {
+			// Note that we're temporarily setting level 50 pokemon in VGC to level 100
+			// This allows e.g. level 50 Hydreigon even though it doesn't evolve until level 64.
+			// Leveling up can't make an obtainable pokemon unobtainable, so this is safe.
+			// Just remember to set the level back to adjustLevel at the end of validation.
+			set.level = ruleTable.maxLevel;
+		}
+		if (set.level < ruleTable.minLevel) {
+			problems.push(`${name} (level ${set.level}) is below the minimum level of ${ruleTable.minLevel}${ruleTable.blame('minlevel')}`);
+		}
+		if (set.level > ruleTable.maxLevel) {
+			problems.push(`${name} (level ${set.level}) is above the maximum level of ${ruleTable.maxLevel}${ruleTable.blame('maxlevel')}`);
+		}
+
+		const setHas: {[k: string]: true} = {};
+
+		if (!set.evs) set.evs = TeamValidator.fillStats(null, ruleTable.evLimit === null ? 252 : 0);
+		if (!set.ivs) set.ivs = TeamValidator.fillStats(null, 31);
+
+		if (ruleTable.has('obtainableformes')) {
+			problems.push(...this.validateForme(set));
+			species = dex.species.get(set.species);
+		}
+		const setSources = this.allSources(species);
+
+		for (const [rule] of ruleTable) {
+			if ('!+-'.includes(rule.charAt(0))) continue;
+			const subformat = dex.formats.get(rule);
+			if (subformat.onChangeSet && ruleTable.has(subformat.id)) {
+				problems = problems.concat(subformat.onChangeSet.call(this, set, format, setHas, teamHas) || []);
+			}
+		}
+		if (format.onChangeSet) {
+			problems = problems.concat(format.onChangeSet.call(this, set, format, setHas, teamHas) || []);
+		}
+
+		// onChangeSet can modify set.species, set.item, set.ability
+		species = dex.species.get(set.species);
+		item = dex.items.get(set.item);
+		ability = dex.abilities.get(set.ability);
+
+		let outOfBattleSpecies = species;
+		let tierSpecies = species;
+		if (ability.id === 'battlebond' && species.id === 'greninja') {
+			outOfBattleSpecies = dex.species.get('greninjaash');
+			if (ruleTable.has('obtainableformes')) {
+				tierSpecies = outOfBattleSpecies;
+			}
+			if (ruleTable.has('obtainablemisc')) {
+				if (set.gender && set.gender !== 'M') {
+					problems.push(`Battle Bond Greninja must be male.`);
+				}
+				set.gender = 'M';
+			}
+		}
+		if (ability.id === 'owntempo' && species.id === 'rockruff') {
+			tierSpecies = outOfBattleSpecies = dex.species.get('rockruffdusk');
+		}
+		if (species.id === 'melmetal' && set.gigantamax && this.dex.species.getLearnsetData(species.id).eventData) {
+			setSources.sourcesBefore = 0;
+			setSources.sources = ['8S0 melmetal'];
+		}
+		if (!species.exists) {
+			return [`The Pokemon "${set.species}" does not exist.`];
+		}
+
+		if (item.id && !item.exists) {
+			return [`"${set.item}" is an invalid item.`];
+		}
+		if (ability.id && !ability.exists) {
+			if (dex.gen < 3) {
+				// gen 1-2 don't have abilities, just silently remove
+				ability = dex.abilities.get('');
+				set.ability = '';
+			} else {
+				return [`"${set.ability}" is an invalid ability.`];
+			}
+		}
+		if (nature.id && !nature.exists) {
+			if (dex.gen < 3) {
+				// gen 1-2 don't have natures, just remove them
+				nature = dex.natures.get('');
+				set.nature = '';
+			} else {
+				problems.push(`"${set.nature}" is an invalid nature.`);
+			}
+		}
+		if (set.happiness !== undefined && isNaN(set.happiness)) {
+			problems.push(`${name} has an invalid happiness value.`);
+		}
+		if (set.hpType) {
+			const type = dex.types.get(set.hpType);
+			if (!type.exists || ['normal', 'fairy'].includes(type.id)) {
+				problems.push(`${name}'s Hidden Power type (${set.hpType}) is invalid.`);
+			} else {
+				set.hpType = type.name;
+			}
+		}
+
+		if (ruleTable.has('obtainableformes')) {
+			const canMegaEvo = dex.gen <= 7 || ruleTable.has('standardnatdex');
+			if (item.megaEvolves === species.name) {
+				if (!item.megaStone) throw new Error(`Item ${item.name} has no base form for mega evolution`);
+				tierSpecies = dex.species.get(item.megaStone);
+			} else if (item.id === 'redorb' && species.id === 'groudon') {
+				tierSpecies = dex.species.get('Groudon-Primal');
+			} else if (item.id === 'blueorb' && species.id === 'kyogre') {
+				tierSpecies = dex.species.get('Kyogre-Primal');
+			} else if (canMegaEvo && species.id === 'rayquaza' && set.moves.map(toID).includes('dragonascent' as ID)) {
+				tierSpecies = dex.species.get('Rayquaza-Mega');
+			} else if (item.id === 'rustedsword' && species.id === 'zacian') {
+				tierSpecies = dex.species.get('Zacian-Crowned');
+			} else if (item.id === 'rustedshield' && species.id === 'zamazenta') {
+				tierSpecies = dex.species.get('Zamazenta-Crowned');
+			}
+		}
+
+		let problem = this.checkSpecies(set, species, tierSpecies, setHas);
+		if (problem) problems.push(problem);
+
+		problem = this.checkItem(set, item, setHas);
+		if (problem) problems.push(problem);
+		if (ruleTable.has('obtainablemisc')) {
+			if (dex.gen === 4 && item.id === 'griseousorb' && species.num !== 487) {
+				problems.push(`${set.name} cannot hold the Griseous Orb.`, `(In Gen 4, only Giratina could hold the Griseous Orb).`);
+			}
+			if (dex.gen <= 1) {
+				if (item.id) {
+					// no items allowed
+					set.item = '';
+				}
+			}
+		}
+
+		if (!set.ability) set.ability = 'No Ability';
+		if (ruleTable.has('obtainableabilities')) {
+			if (dex.gen <= 2 || dex.currentMod === 'gen7letsgo') {
+				set.ability = 'No Ability';
+			} else {
+				if (!ability.name || ability.name === 'No Ability') {
+					problems.push(`${name} needs to have an ability.`);
+				} else if (!Object.values(species.abilities).includes(ability.name)) {
+					if (tierSpecies.abilities[0] === ability.name) {
+						set.ability = species.abilities[0];
+					} else {
+						problems.push(`${name} can't have ${set.ability}.`);
+					}
+				}
+				if (ability.name === species.abilities['H']) {
+					setSources.isHidden = true;
+
+					let unreleasedHidden = species.unreleasedHidden;
+					if (unreleasedHidden === 'Past' && this.minSourceGen < dex.gen) unreleasedHidden = false;
+
+					if (unreleasedHidden && ruleTable.has('-unreleased')) {
+						problems.push(`${name}'s Hidden Ability is unreleased.`);
+					} else if (dex.gen === 7 && ['entei', 'suicune', 'raikou'].includes(species.id) && this.minSourceGen > 1) {
+						problems.push(`${name}'s Hidden Ability is only available from Virtual Console, which is not allowed in this format.`);
+					} else if (dex.gen === 6 && ability.name === 'Symbiosis' &&
+						(set.species.endsWith('Orange') || set.species.endsWith('White'))) {
+						problems.push(`${name}'s Hidden Ability is unreleased for the Orange and White forms.`);
+					} else if (dex.gen === 5 && set.level < 10 && (species.maleOnlyHidden || species.gender === 'N')) {
+						problems.push(`${name} must be at least level 10 to have a Hidden Ability.`);
+					}
+					if (species.maleOnlyHidden) {
+						if (set.gender && set.gender !== 'M') {
+							problems.push(`${name} must be male to have a Hidden Ability.`);
+						}
+						set.gender = 'M';
+						setSources.sources = ['5D'];
+					}
+				} else {
+					setSources.isHidden = false;
+				}
+			}
+		}
+
+		ability = dex.abilities.get(set.ability);
+		problem = this.checkAbility(set, ability, setHas);
+		if (problem) problems.push(problem);
+
+		if (!set.nature || dex.gen <= 2) {
+			set.nature = '';
+		}
+		nature = dex.natures.get(set.nature);
+		problem = this.checkNature(set, nature, setHas);
+		if (problem) problems.push(problem);
+
+		if (set.moves && Array.isArray(set.moves)) {
+			set.moves = set.moves.filter(val => val);
+		}
+		if (!set.moves?.length) {
+			problems.push(`${name} has no moves (it must have at least one to be usable).`);
+			set.moves = [];
+		}
+		if (set.moves.length > ruleTable.maxMoveCount) {
+			problems.push(`${name} has ${set.moves.length} moves, which is more than the limit of ${ruleTable.maxMoveCount}.`);
+			return problems;
+		}
+
+		if (ruleTable.isBanned('nonexistent')) {
+			problems.push(...this.validateStats(set, species, setSources));
+		}
+
+		for (const moveName of set.moves) {
+			if (!moveName) continue;
+			const move = dex.moves.get(Utils.getString(moveName));
+			if (!move.exists) return [`"${move.name}" is an invalid move.`];
+
+			problem = this.checkMove(set, move, setHas);
+			if (problem) problems.push(problem);
+		}
+
+		if (ruleTable.has('obtainablemoves')) {
+			problems.push(...this.validateMoves(outOfBattleSpecies, set.moves, setSources, set, name));
+		}
+
+		const learnsetSpecies = dex.species.getLearnsetData(outOfBattleSpecies.id);
+		let eventOnlyData;
+
+		if (!setSources.sourcesBefore && setSources.sources.length) {
+			let legal = false;
+			for (const source of setSources.sources) {
+				if (this.validateSource(set, source, setSources, outOfBattleSpecies)) continue;
+				legal = true;
+				break;
+			}
+
+			if (!legal) {
+				let nonEggSource = null;
+				for (const source of setSources.sources) {
+					if (source.charAt(1) !== 'E') {
+						nonEggSource = source;
+						break;
+					}
+				}
+				if (!nonEggSource) {
+					// all egg moves
+					problems.push(`${name} can't get its egg move combination (${setSources.limitedEggMoves!.join(', ')}) from any possible father.`);
+					problems.push(`(Is this incorrect? If so, post the chainbreeding instructions in Bug Reports)`);
+				} else {
+					if (setSources.sources.length > 1) {
+						problems.push(`${name} has an event-exclusive move that it doesn't qualify for (only one of several ways to get the move will be listed):`);
+					}
+					const eventProblems = this.validateSource(
+						set, nonEggSource, setSources, outOfBattleSpecies, ` because it has a move only available`
+					);
+					if (eventProblems) problems.push(...eventProblems);
+				}
+			}
+		} else if (ruleTable.has('obtainablemisc') && (eventOnlyData = this.getEventOnlyData(outOfBattleSpecies))) {
+			const {species: eventSpecies, eventData} = eventOnlyData;
+			let legal = false;
+			for (const event of eventData) {
+				if (this.validateEvent(set, setSources, event, eventSpecies)) continue;
+				legal = true;
+				break;
+			}
+			if (!legal && species.gen <= 2 && dex.gen >= 7 && !this.validateSource(set, '7V', setSources, species)) {
+				legal = true;
+			}
+			if (!legal) {
+				if (eventData.length === 1) {
+					problems.push(`${species.name} is only obtainable from an event - it needs to match its event:`);
+				} else {
+					problems.push(`${species.name} is only obtainable from events - it needs to match one of its events:`);
+				}
+				for (const [i, event] of eventData.entries()) {
+					if (event.generation <= dex.gen && event.generation >= this.minSourceGen) {
+						const eventInfo = event;
+						const eventNum = i + 1;
+						const eventName = eventData.length > 1 ? ` #${eventNum}` : ``;
+						const eventProblems = this.validateEvent(
+							set, setSources, eventInfo, eventSpecies, ` to be`, `from its event${eventName}`
+						);
+						if (eventProblems) problems.push(...eventProblems);
+					}
+				}
+			}
+		}
+
+		let isFromRBYEncounter = false;
+		if (this.gen === 1 && ruleTable.has('obtainablemisc') && !this.ruleTable.has('allowtradeback')) {
+			let lowestEncounterLevel;
+			for (const encounter of learnsetSpecies.encounters || []) {
+				if (encounter.generation !== 1) continue;
+				if (!encounter.level) continue;
+				if (lowestEncounterLevel && encounter.level > lowestEncounterLevel) continue;
+
+				lowestEncounterLevel = encounter.level;
+			}
+
+			if (lowestEncounterLevel) {
+				if (set.level < lowestEncounterLevel) {
+					problems.push(`${name} is not obtainable at levels below ${lowestEncounterLevel} in Gen 1.`);
+				}
+				isFromRBYEncounter = true;
+			}
+		}
+		if (!isFromRBYEncounter && ruleTable.has('obtainablemisc')) {
+			// FIXME: Event pokemon given at a level under what it normally can be attained at gives a false positive
+			let evoSpecies = species;
+			while (evoSpecies.prevo) {
+				if (set.level < (evoSpecies.evoLevel || 0)) {
+					problems.push(`${name} must be at least level ${evoSpecies.evoLevel} to be evolved.`);
+					break;
+				}
+				evoSpecies = dex.species.get(evoSpecies.prevo);
+			}
+		}
+
+		if (ruleTable.has('obtainablemoves')) {
+			if (species.id === 'keldeo' && set.moves.includes('secretsword') && this.minSourceGen > 5 && dex.gen <= 7) {
+				problems.push(`${name} has Secret Sword, which is only compatible with Keldeo-Ordinary obtained from Gen 5.`);
+			}
+			const requiresGen3Source = setSources.maxSourceGen() <= 3;
+			if (requiresGen3Source && dex.abilities.get(set.ability).gen === 4 && !species.prevo && dex.gen <= 5) {
+				// Ability Capsule allows this in Gen 6+
+				problems.push(`${name} has a Gen 4 ability and isn't evolved - it can't use moves from Gen 3.`);
+			}
+			const canUseAbilityPatch = dex.gen >= 8 && format.mod !== 'gen8dlc1';
+			if (setSources.isHidden && !canUseAbilityPatch && setSources.maxSourceGen() < 5) {
+				problems.push(`${name} has a Hidden Ability - it can't use moves from before Gen 5.`);
+			}
+			if (
+				species.maleOnlyHidden && setSources.isHidden && setSources.sourcesBefore < 5 &&
+				setSources.sources.every(source => source.charAt(1) === 'E')
+			) {
+				problems.push(`${name} has an unbreedable Hidden Ability - it can't use egg moves.`);
+			}
+		}
+
+		if (teamHas) {
+			for (const i in setHas) {
+				if (i in teamHas) {
+					teamHas[i]++;
+				} else {
+					teamHas[i] = 1;
+				}
+			}
+		}
+		for (const [rule, source, limit, bans] of ruleTable.complexBans) {
+			let count = 0;
+			for (const ban of bans) {
+				if (setHas[ban]) count++;
+			}
+			if (limit && count > limit) {
+				const clause = source ? ` by ${source}` : ``;
+				problems.push(`${name} is limited to ${limit} of ${rule}${clause}.`);
+			} else if (!limit && count >= bans.length) {
+				const clause = source ? ` by ${source}` : ``;
+				if (source === 'Obtainable Moves') {
+					problems.push(`${name} has the combination of ${rule}, which is impossible to obtain legitimately.`);
+				} else {
+					problems.push(`${name} has the combination of ${rule}, which is banned${clause}.`);
+				}
+			}
+		}
+
+		for (const [rule] of ruleTable) {
+			if ('!+-'.includes(rule.charAt(0))) continue;
+			const subformat = dex.formats.get(rule);
+			if (subformat.onValidateSet && ruleTable.has(subformat.id)) {
+				problems = problems.concat(subformat.onValidateSet.call(this, set, format, setHas, teamHas) || []);
+			}
+		}
+		if (format.onValidateSet) {
+			problems = problems.concat(format.onValidateSet.call(this, set, format, setHas, teamHas) || []);
+		}
+
+		const nameSpecies = dex.species.get(set.name);
+		if (nameSpecies.exists && nameSpecies.name.toLowerCase() === set.name.toLowerCase()) {
+			// nickname is the name of a species
+			if (nameSpecies.baseSpecies === species.baseSpecies) {
+				set.name = species.baseSpecies;
+			} else if (nameSpecies.name !== species.name && nameSpecies.name !== species.baseSpecies) {
+				// nickname species doesn't match actual species
+				// Nickname Clause
+				problems.push(`${name} must not be nicknamed a different Pokémon species than what it actually is.`);
+			}
+		}
+
+		if (!problems.length) {
+			if (adjustLevel) set.level = adjustLevel;
+			return null;
+		}
+
+		return problems;
+	}
+
+	validateStats(set: PokemonSet, species: Species, setSources: PokemonSources) {
+		const ruleTable = this.ruleTable;
+		const dex = this.dex;
+
+		const allowAVs = ruleTable.has('allowavs');
+		const evLimit = ruleTable.evLimit;
+		const canBottleCap = dex.gen >= 7 && (set.level >= 100 || !ruleTable.has('obtainablemisc'));
+
+		if (!set.evs) set.evs = TeamValidator.fillStats(null, evLimit === null ? 252 : 0);
+		if (!set.ivs) set.ivs = TeamValidator.fillStats(null, 31);
+
+		const problems = [];
+		const name = set.name || set.species;
+
+		const maxedIVs = Object.values(set.ivs).every(stat => stat === 31);
+		for (const moveName of set.moves) {
+			const move = dex.moves.get(moveName);
+			if (move.id === 'hiddenpower' && move.type !== 'Normal') {
+				if (!set.hpType) {
+					set.hpType = move.type;
+				} else if (set.hpType !== move.type && ruleTable.has('obtainablemisc')) {
+					problems.push(`${name}'s Hidden Power type ${set.hpType} is incompatible with Hidden Power ${move.type}`);
+				}
+			}
+		}
+		if (set.hpType && maxedIVs && ruleTable.has('obtainablemisc')) {
+			if (dex.gen <= 2) {
+				const HPdvs = dex.types.get(set.hpType).HPdvs;
+				set.ivs = {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30};
+				let statName: StatID;
+				for (statName in HPdvs) {
+					set.ivs[statName] = HPdvs[statName]! * 2;
+				}
+				set.ivs.hp = -1;
+			} else if (!canBottleCap) {
+				set.ivs = TeamValidator.fillStats(dex.types.get(set.hpType).HPivs, 31);
+			}
+		}
+
+		const cantBreedNorEvolve = (species.eggGroups[0] === 'Undiscovered' && !species.prevo && !species.nfe);
+		const isLegendary = (cantBreedNorEvolve && ![
+			'Pikachu', 'Unown', 'Dracozolt', 'Arctozolt', 'Dracovish', 'Arctovish',
+		].includes(species.baseSpecies)) || [
+			'Manaphy', 'Cosmog', 'Cosmoem', 'Solgaleo', 'Lunala',
+		].includes(species.baseSpecies);
+		const diancieException = species.name === 'Diancie' && !set.shiny;
+		const has3PerfectIVs = setSources.minSourceGen() >= 6 && isLegendary && !diancieException;
+
+		if (set.hpType === 'Fighting' && ruleTable.has('obtainablemisc')) {
+			if (has3PerfectIVs) {
+				// Legendary Pokemon must have at least 3 perfect IVs in gen 6+
+				problems.push(`${name} must not have Hidden Power Fighting because it starts with 3 perfect IVs because it's a Gen 6+ legendary.`);
+			}
+		}
+
+		if (has3PerfectIVs && ruleTable.has('obtainablemisc')) {
+			let perfectIVs = 0;
+			for (const stat in set.ivs) {
+				if (set.ivs[stat as 'hp'] >= 31) perfectIVs++;
+			}
+			if (perfectIVs < 3) {
+				const reason = (this.minSourceGen === 6 ? ` and this format requires Gen ${dex.gen} Pokémon` : ` in Gen 6 or later`);
+				problems.push(`${name} must have at least three perfect IVs because it's a legendary${reason}.`);
+			}
+		}
+
+		if (set.hpType && !canBottleCap) {
+			const ivHpType = dex.getHiddenPower(set.ivs).type;
+			if (set.hpType !== ivHpType) {
+				problems.push(`${name} has Hidden Power ${set.hpType}, but its IVs are for Hidden Power ${ivHpType}.`);
+			}
+		} else if (set.hpType) {
+			if (!this.possibleBottleCapHpType(set.hpType, set.ivs)) {
+				problems.push(`${name} has Hidden Power ${set.hpType}, but its IVs don't allow this even with (Bottle Cap) Hyper Training.`);
+			}
+		}
+
+		if (dex.gen <= 2) {
+			// validate DVs
+			const ivs = set.ivs;
+			const atkDV = Math.floor(ivs.atk / 2);
+			const defDV = Math.floor(ivs.def / 2);
+			const speDV = Math.floor(ivs.spe / 2);
+			const spcDV = Math.floor(ivs.spa / 2);
+			const expectedHpDV = (atkDV % 2) * 8 + (defDV % 2) * 4 + (speDV % 2) * 2 + (spcDV % 2);
+			if (ivs.hp === -1) ivs.hp = expectedHpDV * 2;
+			const hpDV = Math.floor(ivs.hp / 2);
+			if (expectedHpDV !== hpDV) {
+				problems.push(`${name} has an HP DV of ${hpDV}, but its Atk, Def, Spe, and Spc DVs give it an HP DV of ${expectedHpDV}.`);
+			}
+			if (ivs.spa !== ivs.spd) {
+				if (dex.gen === 2) {
+					problems.push(`${name} has different SpA and SpD DVs, which is not possible in Gen 2.`);
+				} else {
+					ivs.spd = ivs.spa;
+				}
+			}
+			if (dex.gen > 1 && !species.gender) {
+				// Gen 2 gender is calculated from the Atk DV.
+				// High Atk DV <-> M. The meaning of "high" depends on the gender ratio.
+				const genderThreshold = species.genderRatio.F * 16;
+
+				const expectedGender = (atkDV >= genderThreshold ? 'M' : 'F');
+				if (set.gender && set.gender !== expectedGender) {
+					problems.push(`${name} is ${set.gender}, but it has an Atk DV of ${atkDV}, which makes its gender ${expectedGender}.`);
+				} else {
+					set.gender = expectedGender;
+				}
+			}
+			if (
+				set.species === 'Marowak' && toID(set.item) === 'thickclub' &&
+				set.moves.map(toID).includes('swordsdance' as ID) && set.level === 100
+			) {
+				// Marowak hack
+				set.ivs.atk = Math.floor(set.ivs.atk / 2) * 2;
+				while (set.evs.atk > 0 && 2 * 80 + set.ivs.atk + Math.floor(set.evs.atk / 4) + 5 > 255) {
+					set.evs.atk -= 4;
+				}
+			}
+			if (dex.gen > 1) {
+				const expectedShiny = !!(defDV === 10 && speDV === 10 && spcDV === 10 && atkDV % 4 >= 2);
+				if (expectedShiny && !set.shiny) {
+					problems.push(`${name} is not shiny, which does not match its DVs.`);
+				} else if (!expectedShiny && set.shiny) {
+					problems.push(`${name} is shiny, which does not match its DVs (its DVs must all be 10, except Atk which must be 2, 3, 6, 7, 10, 11, 14, or 15).`);
+				}
+			}
+			set.nature = 'Serious';
+		}
+
+		for (const stat in set.evs) {
+			if (set.evs[stat as 'hp'] < 0) {
+				problems.push(`${name} has less than 0 ${allowAVs ? 'Awakening Values' : 'EVs'} in ${Dex.stats.names[stat as 'hp']}.`);
+			}
+		}
+
+		if (dex.currentMod === 'gen7letsgo') { // AVs
+			for (const stat in set.evs) {
+				if (set.evs[stat as 'hp'] > 0 && !allowAVs) {
+					problems.push(`${name} has Awakening Values but this format doesn't allow them.`);
+					break;
+				} else if (set.evs[stat as 'hp'] > 200) {
+					problems.push(`${name} has more than 200 Awakening Values in ${Dex.stats.names[stat as 'hp']}.`);
+				}
+			}
+		} else { // EVs
+			for (const stat in set.evs) {
+				if (set.evs[stat as StatID] > 255) {
+					problems.push(`${name} has more than 255 EVs in ${Dex.stats.names[stat as 'hp']}.`);
+				}
+			}
+			if (dex.gen <= 2) {
+				if (set.evs.spa !== set.evs.spd) {
+					if (dex.gen === 2) {
+						problems.push(`${name} has different SpA and SpD EVs, which is not possible in Gen 2.`);
+					} else {
+						set.evs.spd = set.evs.spa;
+					}
+				}
+			}
+		}
+
+		let totalEV = 0;
+		for (const stat in set.evs) totalEV += set.evs[stat as 'hp'];
+		if (!this.format.debug) {
+			if (set.level > 1 && evLimit !== 0 && totalEV === 0) {
+				problems.push(`${name} has exactly 0 EVs - did you forget to EV it? (If this was intentional, add exactly 1 to one of your EVs, which won't change its stats but will tell us that it wasn't a mistake).`);
+			} else if (![508, 510].includes(evLimit!) && [508, 510].includes(totalEV)) {
+				problems.push(`${name} has exactly ${totalEV} EVs, but this format does not restrict you to 510 EVs (If this was intentional, add exactly 1 to one of your EVs, which won't change its stats but will tell us that it wasn't a mistake).`);
+			}
+			// Check for level import errors from user in VGC -> DOU, etc.
+			// Note that in VGC etc (Adjust Level Down = 50), `set.level` will be 100 here for validation purposes
+			if (set.level === 50 && ruleTable.maxLevel !== 50 && !ruleTable.maxTotalLevel && evLimit !== 0 && totalEV % 4 === 0) {
+				problems.push(`${name} is level 50, but this format allows level ${ruleTable.maxLevel} Pokémon. (If this was intentional, add exactly 1 to one of your EVs, which won't change its stats but will tell us that it wasn't a mistake).`);
+			}
+		}
+
+		if (evLimit !== null && totalEV > evLimit) {
+			if (!evLimit) {
+				problems.push(`${name} has EVs, which is not allowed by this format.`);
+			} else {
+				problems.push(`${name} has ${totalEV} total EVs, which is more than this format's limit of ${evLimit}.`);
+			}
+		}
+
+		return problems;
+	}
+
+	/**
+	 * Not exhaustive, just checks Atk and Spe, which are the only competitively
+	 * relevant IVs outside of extremely obscure situations.
+	 */
+	possibleBottleCapHpType(type: string, ivs: StatsTable) {
+		if (!type) return true;
+		if (['Dark', 'Dragon', 'Grass', 'Ghost', 'Poison'].includes(type)) {
+			// Spe must be odd
+			if (ivs.spe % 2 === 0) return false;
+		}
+		if (['Psychic', 'Fire', 'Rock', 'Fighting'].includes(type)) {
+			// Spe must be even
+			if (ivs.spe !== 31 && ivs.spe % 2 === 1) return false;
+		}
+		if (type === 'Dark') {
+			// Atk must be odd
+			if (ivs.atk % 2 === 0) return false;
+		}
+		if (['Ice', 'Water'].includes(type)) {
+			// Spe or Atk must be odd
+			if (ivs.spe % 2 === 0 && ivs.atk % 2 === 0) return false;
+		}
+		return true;
+	}
+
+	validateSource(
+		set: PokemonSet, source: PokemonSource, setSources: PokemonSources, species: Species, because: string
+	): string[] | undefined;
+	validateSource(
+		set: PokemonSet, source: PokemonSource, setSources: PokemonSources, species: Species
+	): true | undefined;
+	/**
+	 * Returns array of error messages if invalid, undefined if valid
+	 *
+	 * If `because` is not passed, instead returns true if invalid.
+	 */
+	validateSource(
+		set: PokemonSet, source: PokemonSource, setSources: PokemonSources, species: Species, because?: string
+	) {
+		let eventData: EventInfo | undefined;
+		let eventSpecies = species;
+		if (source.charAt(1) === 'S') {
+			const splitSource = source.substr(source.charAt(2) === 'T' ? 3 : 2).split(' ');
+			const dex = (this.dex.gen === 1 ? this.dex.mod('gen2') : this.dex);
+			eventSpecies = dex.species.get(splitSource[1]);
+			const eventLsetData = this.dex.species.getLearnsetData(eventSpecies.id);
+			eventData = eventLsetData.eventData?.[parseInt(splitSource[0])];
+			if (!eventData) {
+				throw new Error(`${eventSpecies.name} from ${species.name} doesn't have data for event ${source}`);
+			}
+		} else if (source === '7V') {
+			const isMew = species.id === 'mew';
+			const isCelebi = species.id === 'celebi';
+			const g7speciesName = (species.gen > 2 && species.prevo) ? species.prevo : species.id;
+			const isHidden = !!this.dex.mod('gen7').species.get(g7speciesName).abilities['H'];
+			eventData = {
+				generation: 2,
+				level: isMew ? 5 : isCelebi ? 30 : 3, // Level 1/2 Pokémon can't be obtained by transfer from RBY/GSC
+				perfectIVs: isMew || isCelebi ? 5 : 3,
+				isHidden,
+				shiny: isMew ? undefined : 1,
+				pokeball: 'pokeball',
+				from: 'Gen 1-2 Virtual Console transfer',
+			};
+		} else if (source === '8V') {
+			const isMew = species.id === 'mew';
+			eventData = {
+				generation: 8,
+				perfectIVs: isMew ? 3 : undefined,
+				shiny: isMew ? undefined : 1,
+				from: 'Gen 7 Let\'s Go! HOME transfer',
+			};
+		} else if (source.charAt(1) === 'D') {
+			eventData = {
+				generation: 5,
+				level: 10,
+				from: 'Gen 5 Dream World',
+				isHidden: !!this.dex.mod('gen5').species.get(species.id).abilities['H'],
+			};
+		} else if (source.charAt(1) === 'E') {
+			if (this.findEggMoveFathers(source, species, setSources)) {
+				return undefined;
+			}
+			if (because) throw new Error(`Wrong place to get an egg incompatibility message`);
+			return true;
+		} else {
+			throw new Error(`Unidentified source ${source} passed to validateSource`);
+		}
+
+		// complicated fancy return signature
+		return this.validateEvent(set, setSources, eventData, eventSpecies, because as any) as any;
+	}
+
+	findEggMoveFathers(source: PokemonSource, species: Species, setSources: PokemonSources): boolean;
+	findEggMoveFathers(source: PokemonSource, species: Species, setSources: PokemonSources, getAll: true): ID[] | null;
+	findEggMoveFathers(source: PokemonSource, species: Species, setSources: PokemonSources, getAll = false) {
+		// tradebacks have an eggGen of 2 even though the source is 1ET
+		const eggGen = Math.max(parseInt(source.charAt(0)), 2);
+		const fathers: ID[] = [];
+		// Gen 6+ don't have egg move incompatibilities
+		// (except for certain cases with baby Pokemon not handled here)
+		if (!getAll && eggGen >= 6) return true;
+
+		const eggMoves = setSources.limitedEggMoves;
+		// must have 2 or more egg moves to have egg move incompatibilities
+		if (!eggMoves) {
+			// happens often in gen 1-6 LC if your only egg moves are level-up moves,
+			// which aren't limited and so aren't in `limitedEggMoves`
+			return getAll ? ['*'] : true;
+		}
+		if (!getAll && eggMoves.length <= 1) return true;
+
+		// gen 1 eggs come from gen 2 breeding
+		const dex = this.dex.gen === 1 ? this.dex.mod('gen2') : this.dex;
+		// In Gen 5 and earlier, egg moves can only be inherited from the father
+		// we'll test each possible father separately
+		let eggGroups = species.eggGroups;
+		if (species.id === 'nidoqueen' || species.id === 'nidorina') {
+			eggGroups = dex.species.get('nidoranf').eggGroups;
+		} else if (species.id === 'shedinja') {
+			// Shedinja and Nincada are different Egg groups; Shedinja itself is genderless
+			eggGroups = dex.species.get('nincada').eggGroups;
+		} else if (dex !== this.dex) {
+			// Gen 1 tradeback; grab the egg groups from Gen 2
+			eggGroups = dex.species.get(species.id).eggGroups;
+		}
+		if (eggGroups[0] === 'Undiscovered') eggGroups = dex.species.get(species.evos[0]).eggGroups;
+		if (eggGroups[0] === 'Undiscovered' || !eggGroups.length) {
+			throw new Error(`${species.name} has no egg groups for source ${source}`);
+		}
+		// no chainbreeding necessary if the father can be Smeargle
+		if (!getAll && eggGroups.includes('Field')) return true;
+
+		// try to find a father to inherit the egg move combination from
+		for (const father of dex.species.all()) {
+			// can't inherit from CAP pokemon
+			if (father.isNonstandard) continue;
+			// can't breed mons from future gens
+			if (father.gen > eggGen) continue;
+			// father must be male
+			if (father.gender === 'N' || father.gender === 'F') continue;
+			// can't inherit from dex entries with no learnsets
+			if (!dex.species.getLearnset(father.id)) continue;
+			// something is clearly wrong if its only possible father is itself
+			// (exceptions: ExtremeSpeed Dragonite, Self-destruct Snorlax)
+			if (species.id === father.id && !['dragonite', 'snorlax'].includes(father.id)) continue;
+			// don't check NFE Pokémon - their evolutions will know all their moves and more
+			// exception: Combee/Salandit, because their evos can't be fathers
+			if (father.evos.length) {
+				const evolvedFather = dex.species.get(father.evos[0]);
+				if (evolvedFather.gen <= eggGen && evolvedFather.gender !== 'F') continue;
+			}
+
+			// must be able to breed with father
+			if (!father.eggGroups.some(eggGroup => eggGroups.includes(eggGroup))) continue;
+
+			// father must be able to learn the move
+			if (!this.fatherCanLearn(father, eggMoves, eggGen)) continue;
+
+			// father found!
+			if (!getAll) return true;
+			fathers.push(father.id);
+		}
+		if (!getAll) return false;
+		return (!fathers.length && eggGen < 6) ? null : fathers;
+	}
+
+	/**
+	 * We could, if we wanted, do a complete move validation of the father's
+	 * moveset to see if it's valid. This would recurse and be NP-Hard so
+	 * instead we won't. We'll instead use a simplified algorithm: The father
+	 * can learn the moveset if it has at most one egg/event move.
+	 *
+	 * `eggGen` should be 5 or earlier. Later gens should never call this
+	 * function (the answer is always yes).
+	 */
+	fatherCanLearn(species: Species, moves: ID[], eggGen: number) {
+		let learnset = this.dex.species.getLearnset(species.id);
+		if (!learnset) return false;
+
+		if (species.id === 'smeargle') return true;
+		const canBreedWithSmeargle = species.eggGroups.includes('Field');
+
+		let eggMoveCount = 0;
+		for (const move of moves) {
+			let curSpecies: Species | null = species;
+			/** 1 = can learn from egg, 2 = can learn unrestricted */
+			let canLearn: 0 | 1 | 2 = 0;
+
+			while (curSpecies) {
+				learnset = this.dex.species.getLearnset(curSpecies.id);
+				if (learnset && learnset[move]) {
+					for (const moveSource of learnset[move]) {
+						if (parseInt(moveSource.charAt(0)) > eggGen) continue;
+						const canLearnFromSmeargle = moveSource.charAt(1) === 'E' && canBreedWithSmeargle;
+						if (!'ESDV'.includes(moveSource.charAt(1)) || canLearnFromSmeargle) {
+							canLearn = 2;
+							break;
+						} else {
+							canLearn = 1;
+						}
+					}
+				}
+				if (canLearn === 2) break;
+				curSpecies = this.learnsetParent(curSpecies);
+			}
+
+			if (!canLearn) return false;
+			if (canLearn === 1) {
+				eggMoveCount++;
+				if (eggMoveCount > 1) return false;
+			}
+		}
+		return true;
+	}
+
+	validateForme(set: PokemonSet) {
+		const dex = this.dex;
+		const name = set.name || set.species;
+
+		const problems = [];
+		const item = dex.items.get(set.item);
+		const species = dex.species.get(set.species);
+
+		if (species.name === 'Necrozma-Ultra') {
+			const whichMoves = (set.moves.includes('sunsteelstrike') ? 1 : 0) +
+				(set.moves.includes('moongeistbeam') ? 2 : 0);
+			if (item.name !== 'Ultranecrozium Z') {
+				// Necrozma-Ultra transforms from one of two formes, and neither one is the base forme
+				problems.push(`Necrozma-Ultra must start the battle holding Ultranecrozium Z.`);
+			} else if (whichMoves === 1) {
+				set.species = 'Necrozma-Dusk-Mane';
+			} else if (whichMoves === 2) {
+				set.species = 'Necrozma-Dawn-Wings';
+			} else {
+				problems.push(`Necrozma-Ultra must start the battle as Necrozma-Dusk-Mane or Necrozma-Dawn-Wings holding Ultranecrozium Z. Please specify which Necrozma it should start as.`);
+			}
+		} else if (species.name === 'Zygarde-Complete') {
+			problems.push(`Zygarde-Complete must start the battle as Zygarde or Zygarde-10% with Power Construct. Please specify which Zygarde it should start as.`);
+		} else if (species.battleOnly) {
+			if (species.requiredAbility && set.ability !== species.requiredAbility) {
+				// Darmanitan-Zen
+				problems.push(`${species.name} transforms in-battle with ${species.requiredAbility}, please fix its ability.`);
+			}
+			if (species.requiredItems) {
+				if (!species.requiredItems.includes(item.name)) {
+					// Mega or Primal
+					problems.push(`${species.name} transforms in-battle with ${species.requiredItem}, please fix its item.`);
+				}
+			}
+			if (species.requiredMove && !set.moves.map(toID).includes(toID(species.requiredMove))) {
+				// Meloetta-Pirouette, Rayquaza-Mega
+				problems.push(`${species.name} transforms in-battle with ${species.requiredMove}, please fix its moves.`);
+			}
+			if (typeof species.battleOnly !== 'string') {
+				// Ultra Necrozma and Complete Zygarde are already checked above
+				throw new Error(`${species.name} should have a string battleOnly`);
+			}
+			// Set to out-of-battle forme
+			set.species = species.battleOnly;
+		} else {
+			if (species.requiredAbility) {
+				// Impossible!
+				throw new Error(`Species ${species.name} has a required ability despite not being a battle-only forme; it should just be in its abilities table.`);
+			}
+			if (species.requiredItems && !species.requiredItems.includes(item.name)) {
+				if (dex.gen >= 8 && (species.baseSpecies === 'Arceus' || species.baseSpecies === 'Silvally')) {
+					// Arceus/Silvally formes in gen 8 only require the item with Multitype/RKS System
+					if (set.ability === species.abilities[0]) {
+						problems.push(
+							`${name} needs to hold ${species.requiredItems.join(' or ')}.`,
+							`(It will revert to its Normal forme if you remove the item or give it a different item.)`
+						);
+					}
+				} else {
+					// Memory/Drive/Griseous Orb/Plate/Z-Crystal - Forme mismatch
+					const baseSpecies = this.dex.species.get(species.changesFrom);
+					problems.push(
+						`${name} needs to hold ${species.requiredItems.join(' or ')} to be in its ${species.forme} forme.`,
+						`(It will revert to its ${baseSpecies.baseForme || 'base'} forme if you remove the item or give it a different item.)`
+					);
+				}
+			}
+			if (species.requiredMove && !set.moves.map(toID).includes(toID(species.requiredMove))) {
+				const baseSpecies = this.dex.species.get(species.changesFrom);
+				problems.push(
+					`${name} needs to know the move ${species.requiredMove} to be in its ${species.forme} forme.`,
+					`(It will revert to its ${baseSpecies.baseForme} forme if it forgets the move.)`
+				);
+			}
+
+			// Mismatches between the set forme (if not base) and the item signature forme will have been rejected already.
+			// It only remains to assign the right forme to a set with the base species (Arceus/Genesect/Giratina/Silvally).
+			if (item.forcedForme && species.name === dex.species.get(item.forcedForme).baseSpecies) {
+				set.species = item.forcedForme;
+			}
+		}
+
+		if (species.name === 'Pikachu-Cosplay') {
+			const cosplay: {[k: string]: string} = {
+				meteormash: 'Pikachu-Rock-Star', iciclecrash: 'Pikachu-Belle', drainingkiss: 'Pikachu-Pop-Star',
+				electricterrain: 'Pikachu-PhD', flyingpress: 'Pikachu-Libre',
+			};
+			for (const moveid of set.moves) {
+				if (moveid in cosplay) {
+					set.species = cosplay[moveid];
+					break;
+				}
+			}
+		}
+
+		if (species.name === 'Keldeo' && set.moves.map(toID).includes('secretsword' as ID) && dex.gen >= 8) {
+			set.species = 'Keldeo-Resolute';
+		}
+
+		const crowned: {[k: string]: string} = {
+			'Zacian-Crowned': 'behemothblade', 'Zamazenta-Crowned': 'behemothbash',
+		};
+		if (species.name in crowned) {
+			const behemothMove = set.moves.map(toID).indexOf(crowned[species.name] as ID);
+			if (behemothMove >= 0) {
+				set.moves[behemothMove] = 'ironhead';
+			}
+		}
+		return problems;
+	}
+
+	checkSpecies(set: PokemonSet, species: Species, tierSpecies: Species, setHas: {[k: string]: true}) {
+		const dex = this.dex;
+		const ruleTable = this.ruleTable;
+
+		// https://www.smogon.com/forums/posts/8659168
+		if (
+			(tierSpecies.id === 'zamazentacrowned' && species.id === 'zamazenta') ||
+			(tierSpecies.id === 'zaciancrowned' && species.id === 'zacian')
+		) {
+			species = tierSpecies;
+		}
+
+		setHas['pokemon:' + species.id] = true;
+		setHas['basepokemon:' + toID(species.baseSpecies)] = true;
+
+		let isMega = false;
+		if (tierSpecies !== species) {
+			setHas['pokemon:' + tierSpecies.id] = true;
+			if (tierSpecies.isMega || tierSpecies.isPrimal) {
+				setHas['pokemontag:mega'] = true;
+				isMega = true;
+			}
+		}
+
+		let isGmax = false;
+		if (tierSpecies.canGigantamax && set.gigantamax) {
+			setHas['pokemon:' + tierSpecies.id + 'gmax'] = true;
+			isGmax = true;
+		}
+
+		const tier = tierSpecies.tier === '(PU)' ? 'ZU' : tierSpecies.tier === '(NU)' ? 'PU' : tierSpecies.tier;
+		const tierTag = 'pokemontag:' + toID(tier);
+		setHas[tierTag] = true;
+
+		const doublesTier = tierSpecies.doublesTier === '(DUU)' ? 'DNU' : tierSpecies.doublesTier;
+		const doublesTierTag = 'pokemontag:' + toID(doublesTier);
+		setHas[doublesTierTag] = true;
+
+		const ndTier = tierSpecies.natDexTier === '(PU)' ? 'ZU' :
+			tierSpecies.natDexTier === '(NU)' ? 'PU' : tierSpecies.natDexTier;
+		const ndTierTag = 'pokemontag:nd' + toID(ndTier);
+		setHas[ndTierTag] = true;
+
+		// Only pokemon that can gigantamax should have the Gmax flag
+		if (!tierSpecies.canGigantamax && set.gigantamax) {
+			return `${tierSpecies.name} cannot Gigantamax but is flagged as being able to.`;
+		}
+
+		let banReason = ruleTable.check('pokemon:' + species.id);
+		if (banReason) {
+			return `${species.name} is ${banReason}.`;
+		}
+		if (banReason === '') return null;
+
+		if (tierSpecies !== species) {
+			banReason = ruleTable.check('pokemon:' + tierSpecies.id);
+			if (banReason) {
+				return `${tierSpecies.name} is ${banReason}.`;
+			}
+			if (banReason === '') return null;
+		}
+
+		if (isMega) {
+			banReason = ruleTable.check('pokemontag:mega', setHas);
+			if (banReason) {
+				return `Mega evolutions are ${banReason}.`;
+			}
+		}
+
+		if (isGmax) {
+			banReason = ruleTable.check('pokemon:' + tierSpecies.id + 'gmax');
+			if (banReason) {
+				return `Gigantamaxing ${species.name} is ${banReason}.`;
+			}
+		}
+
+		banReason = ruleTable.check('basepokemon:' + toID(species.baseSpecies));
+		if (banReason) {
+			return `${species.name} is ${banReason}.`;
+		}
+		if (banReason === '') {
+			// don't allow nonstandard speciess when whitelisting standard base species
+			// i.e. unbanning Pichu doesn't mean allowing Pichu-Spiky-Eared outside of Gen 4
+			const baseSpecies = dex.species.get(species.baseSpecies);
+			if (baseSpecies.isNonstandard === species.isNonstandard) {
+				return null;
+			}
+		}
+
+		// We can't return here because the `-nonexistent` rule is a bit
+		// complicated in terms of what trumps it. We don't want e.g.
+		// +Mythical to unban Shaymin in Gen 1, for instance.
+		let nonexistentCheck = Tags.nonexistent.genericFilter!(tierSpecies) && ruleTable.check('nonexistent');
+
+		const EXISTENCE_TAG = ['past', 'future', 'lgpe', 'unobtainable', 'cap', 'custom', 'nonexistent'];
+
+		for (const ruleid of ruleTable.tagRules) {
+			if (ruleid.startsWith('*')) continue;
+			const tagid = ruleid.slice(12);
+			const tag = Tags[tagid];
+			if ((tag.speciesFilter || tag.genericFilter)!(tierSpecies)) {
+				const existenceTag = EXISTENCE_TAG.includes(tagid);
+				if (ruleid.startsWith('+')) {
+					// we want rules like +CAP to trump -Nonexistent, but most tags shouldn't
+					if (!existenceTag && nonexistentCheck) continue;
+					return null;
+				}
+				if (existenceTag) {
+					// for a nicer error message
+					nonexistentCheck = 'banned';
+					break;
+				}
+				return `${species.name} is tagged ${tag.name}, which is ${ruleTable.check(ruleid.slice(1)) || "banned"}.`;
+			}
+		}
+
+		if (nonexistentCheck) {
+			if (tierSpecies.isNonstandard === 'Past' || tierSpecies.isNonstandard === 'Future') {
+				return `${tierSpecies.name} does not exist in Gen ${dex.gen}.`;
+			}
+			if (tierSpecies.isNonstandard === 'LGPE') {
+				return `${tierSpecies.name} does not exist in this game, only in Let's Go Pikachu/Eevee.`;
+			}
+			if (tierSpecies.isNonstandard === 'CAP') {
+				return `${tierSpecies.name} is a CAP and does not exist in this game.`;
+			}
+			if (tierSpecies.isNonstandard === 'Unobtainable') {
+				return `${tierSpecies.name} is not possible to obtain in this game.`;
+			}
+			if (tierSpecies.isNonstandard === 'Gigantamax') {
+				return `${tierSpecies.name} is a placeholder for a Gigantamax sprite, not a real Pokémon. (This message is likely to be a validator bug.)`;
+			}
+			return `${tierSpecies.name} does not exist in this game.`;
+		}
+		if (nonexistentCheck === '') return null;
+
+		// Special casing for Pokemon that can Gmax, but their Gmax factor cannot be legally obtained
+		if (tierSpecies.gmaxUnreleased && set.gigantamax) {
+			banReason = ruleTable.check('pokemontag:unobtainable');
+			if (banReason) {
+				return `${tierSpecies.name} is flagged as gigantamax, but it cannot gigantamax without hacking or glitches.`;
+			}
+			if (banReason === '') return null;
+		}
+
+		banReason = ruleTable.check('pokemontag:allpokemon');
+		if (banReason) {
+			return `${species.name} is not in the list of allowed pokemon.`;
+		}
+
+		return null;
+	}
+
+	checkItem(set: PokemonSet, item: Item, setHas: {[k: string]: true}) {
+		const dex = this.dex;
+		const ruleTable = this.ruleTable;
+
+		setHas['item:' + item.id] = true;
+
+		let banReason = ruleTable.check('item:' + (item.id || 'noitem'));
+		if (banReason) {
+			if (!item.id) {
+				return `${set.name} not holding an item is ${banReason}.`;
+			}
+			return `${set.name}'s item ${item.name} is ${banReason}.`;
+		}
+		if (banReason === '') return null;
+
+		if (!item.id) return null;
+
+		banReason = ruleTable.check('pokemontag:allitems');
+		if (banReason) {
+			return `${set.name}'s item ${item.name} is not in the list of allowed items.`;
+		}
+
+		// obtainability
+		if (item.isNonstandard) {
+			banReason = ruleTable.check('pokemontag:' + toID(item.isNonstandard));
+			if (banReason) {
+				if (item.isNonstandard === 'Unobtainable') {
+					return `${item.name} is not obtainable without hacking or glitches.`;
+				}
+				return `${set.name}'s item ${item.name} is tagged ${item.isNonstandard}, which is ${banReason}.`;
+			}
+			if (banReason === '') return null;
+		}
+
+		if (item.isNonstandard && item.isNonstandard !== 'Unobtainable') {
+			banReason = ruleTable.check('nonexistent', setHas);
+			if (banReason) {
+				if (['Past', 'Future'].includes(item.isNonstandard)) {
+					return `${set.name}'s item ${item.name} does not exist in Gen ${dex.gen}.`;
+				}
+				return `${set.name}'s item ${item.name} does not exist in this game.`;
+			}
+			if (banReason === '') return null;
+		}
+
+		return null;
+	}
+
+	checkMove(set: PokemonSet, move: Move, setHas: {[k: string]: true}) {
+		const dex = this.dex;
+		const ruleTable = this.ruleTable;
+
+		setHas['move:' + move.id] = true;
+
+		let banReason = ruleTable.check('move:' + move.id);
+		if (banReason) {
+			return `${set.name}'s move ${move.name} is ${banReason}.`;
+		}
+		if (banReason === '') return null;
+
+		banReason = ruleTable.check('pokemontag:allmoves');
+		if (banReason) {
+			return `${set.name}'s move ${move.name} is not in the list of allowed moves.`;
+		}
+
+		// obtainability
+		if (move.isNonstandard) {
+			banReason = ruleTable.check('pokemontag:' + toID(move.isNonstandard));
+			if (banReason) {
+				if (move.isNonstandard === 'Unobtainable') {
+					return `${move.name} is not obtainable without hacking or glitches.`;
+				}
+				if (move.isNonstandard === 'Gigantamax') {
+					return `${move.name} is not usable without Gigantamaxing its user, ${move.isMax}.`;
+				}
+				return `${set.name}'s move ${move.name} is tagged ${move.isNonstandard}, which is ${banReason}.`;
+			}
+			if (banReason === '') return null;
+		}
+
+		if (move.isNonstandard && move.isNonstandard !== 'Unobtainable') {
+			banReason = ruleTable.check('nonexistent', setHas);
+			if (banReason) {
+				if (['Past', 'Future'].includes(move.isNonstandard)) {
+					return `${set.name}'s move ${move.name} does not exist in Gen ${dex.gen}.`;
+				}
+				return `${set.name}'s move ${move.name} does not exist in this game.`;
+			}
+			if (banReason === '') return null;
+		}
+
+		return null;
+	}
+
+	checkAbility(set: PokemonSet, ability: Ability, setHas: {[k: string]: true}) {
+		const dex = this.dex;
+		const ruleTable = this.ruleTable;
+
+		setHas['ability:' + ability.id] = true;
+
+		if (this.format.id.startsWith('gen8pokebilities')) {
+			const species = dex.species.get(set.species);
+			const unSeenAbilities = Object.keys(species.abilities)
+				.filter(key => key !== 'S' && (key !== 'H' || !species.unreleasedHidden))
+				.map(key => species.abilities[key as "0" | "1" | "H" | "S"]);
+
+			if (ability.id !== this.toID(species.abilities['S'])) {
+				for (const abilityName of unSeenAbilities) {
+					setHas['ability:' + toID(abilityName)] = true;
+				}
+			}
+		}
+
+		let banReason = ruleTable.check('ability:' + ability.id);
+		if (banReason) {
+			return `${set.name}'s ability ${ability.name} is ${banReason}.`;
+		}
+		if (banReason === '') return null;
+
+		banReason = ruleTable.check('pokemontag:allabilities');
+		if (banReason) {
+			return `${set.name}'s ability ${ability.name} is not in the list of allowed abilities.`;
+		}
+
+		// obtainability
+		if (ability.isNonstandard) {
+			banReason = ruleTable.check('pokemontag:' + toID(ability.isNonstandard));
+			if (banReason) {
+				return `${set.name}'s ability ${ability.name} is tagged ${ability.isNonstandard}, which is ${banReason}.`;
+			}
+			if (banReason === '') return null;
+
+			banReason = ruleTable.check('nonexistent', setHas);
+			if (banReason) {
+				if (['Past', 'Future'].includes(ability.isNonstandard)) {
+					return `${set.name}'s ability ${ability.name} does not exist in Gen ${dex.gen}.`;
+				}
+				return `${set.name}'s ability ${ability.name} does not exist in this game.`;
+			}
+			if (banReason === '') return null;
+		}
+
+		return null;
+	}
+
+	checkNature(set: PokemonSet, nature: Nature, setHas: {[k: string]: true}) {
+		const dex = this.dex;
+		const ruleTable = this.ruleTable;
+
+		setHas['nature:' + nature.id] = true;
+
+		let banReason = ruleTable.check('nature:' + nature.id);
+		if (banReason) {
+			return `${set.name}'s nature ${nature.name} is ${banReason}.`;
+		}
+		if (banReason === '') return null;
+
+		banReason = ruleTable.check('allnatures');
+		if (banReason) {
+			return `${set.name}'s nature ${nature.name} is not in the list of allowed natures.`;
+		}
+
+		// obtainability
+		if (nature.isNonstandard) {
+			banReason = ruleTable.check('pokemontag:' + toID(nature.isNonstandard));
+			if (banReason) {
+				return `${set.name}'s nature ${nature.name} is tagged ${nature.isNonstandard}, which is ${banReason}.`;
+			}
+			if (banReason === '') return null;
+
+			banReason = ruleTable.check('nonexistent', setHas);
+			if (banReason) {
+				if (['Past', 'Future'].includes(nature.isNonstandard)) {
+					return `${set.name}'s nature ${nature.name} does not exist in Gen ${dex.gen}.`;
+				}
+				return `${set.name}'s nature ${nature.name} does not exist in this game.`;
+			}
+			if (banReason === '') return null;
+		}
+		return null;
+	}
+
+	validateEvent(
+		set: PokemonSet, setSources: PokemonSources, eventData: EventInfo, eventSpecies: Species
+	): true | undefined;
+	validateEvent(
+		set: PokemonSet, setSources: PokemonSources, eventData: EventInfo, eventSpecies: Species,
+		because: string, from?: string
+	): string[] | undefined;
+	/**
+	 * Returns array of error messages if invalid, undefined if valid
+	 *
+	 * If `because` is not passed, instead returns true if invalid.
+	 */
+	validateEvent(
+		set: PokemonSet, setSources: PokemonSources, eventData: EventInfo, eventSpecies: Species,
+		because = ``, from = `from an event`
+	) {
+		const dex = this.dex;
+		let name = set.species;
+		const species = dex.species.get(set.species);
+		const maxSourceGen = this.ruleTable.has('allowtradeback') ? Utils.clampIntRange(dex.gen + 1, 1, 8) : dex.gen;
+		if (!eventSpecies) eventSpecies = species;
+		if (set.name && set.species !== set.name && species.baseSpecies !== set.name) name = `${set.name} (${set.species})`;
+
+		const fastReturn = !because;
+		if (eventData.from) from = `from ${eventData.from}`;
+		const etc = `${because} ${from}`;
+
+		const problems = [];
+
+		if (dex.gen < 8 && this.minSourceGen > eventData.generation) {
+			if (fastReturn) return true;
+			problems.push(`This format requires Pokemon from gen ${this.minSourceGen} or later and ${name} is from gen ${eventData.generation}${etc}.`);
+		}
+		if (maxSourceGen < eventData.generation) {
+			if (fastReturn) return true;
+			problems.push(`This format is in gen ${dex.gen} and ${name} is from gen ${eventData.generation}${etc}.`);
+		}
+
+		if (eventData.japan && dex.currentMod !== 'gen1jpn') {
+			if (fastReturn) return true;
+			problems.push(`${name} has moves from Japan-only events, but this format simulates International Yellow/Crystal which can't trade with Japanese games.`);
+		}
+
+		if (eventData.level && (set.level || 0) < eventData.level) {
+			if (fastReturn) return true;
+			problems.push(`${name} must be at least level ${eventData.level}${etc}.`);
+		}
+		if ((eventData.shiny === true && !set.shiny) || (!eventData.shiny && set.shiny)) {
+			if (fastReturn) return true;
+			const shinyReq = eventData.shiny ? ` be shiny` : ` not be shiny`;
+			problems.push(`${name} must${shinyReq}${etc}.`);
+		}
+		if (eventData.gender) {
+			if (set.gender && eventData.gender !== set.gender) {
+				if (fastReturn) return true;
+				problems.push(`${name}'s gender must be ${eventData.gender}${etc}.`);
+			}
+		}
+		const canMint = dex.gen > 7;
+		if (eventData.nature && eventData.nature !== set.nature && !canMint) {
+			if (fastReturn) return true;
+			problems.push(`${name} must have a ${eventData.nature} nature${etc} - Mints are only available starting gen 8.`);
+		}
+		let requiredIVs = 0;
+		if (eventData.ivs) {
+			/** In Gen 7, IVs can be changed to 31 */
+			const canBottleCap = (dex.gen >= 7 && set.level === 100);
+
+			if (!set.ivs) set.ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
+			let statName: StatID;
+			for (statName in eventData.ivs) {
+				if (canBottleCap && set.ivs[statName] === 31) continue;
+				if (set.ivs[statName] !== eventData.ivs[statName]) {
+					if (fastReturn) return true;
+					problems.push(`${name} must have ${eventData.ivs[statName]} ${Dex.stats.names[statName]} IVs${etc}.`);
+				}
+			}
+
+			if (canBottleCap) {
+				// IVs can be overridden but Hidden Power type can't
+				if (Object.keys(eventData.ivs).length >= 6) {
+					const requiredHpType = dex.getHiddenPower(eventData.ivs).type;
+					if (set.hpType && set.hpType !== requiredHpType) {
+						if (fastReturn) return true;
+						problems.push(`${name} can only have Hidden Power ${requiredHpType}${etc}.`);
+					}
+					set.hpType = requiredHpType;
+				}
+			}
+		} else {
+			requiredIVs = eventData.perfectIVs || 0;
+		}
+		if (requiredIVs && set.ivs) {
+			// Legendary Pokemon must have at least 3 perfect IVs in gen 6
+			// Events can also have a certain amount of guaranteed perfect IVs
+			let perfectIVs = 0;
+			let statName: StatID;
+			for (statName in set.ivs) {
+				if (set.ivs[statName] >= 31) perfectIVs++;
+			}
+			if (perfectIVs < requiredIVs) {
+				if (fastReturn) return true;
+				if (eventData.perfectIVs) {
+					problems.push(`${name} must have at least ${requiredIVs} perfect IVs${etc}.`);
+				}
+			}
+			// The perfect IV count affects Hidden Power availability
+			if (dex.gen >= 3 && requiredIVs >= 3 && set.hpType === 'Fighting') {
+				if (fastReturn) return true;
+				problems.push(`${name} can't use Hidden Power Fighting because it must have at least three perfect IVs${etc}.`);
+			} else if (dex.gen >= 3 && requiredIVs >= 5 && set.hpType &&
+					!['Dark', 'Dragon', 'Electric', 'Steel', 'Ice'].includes(set.hpType)) {
+				if (fastReturn) return true;
+				problems.push(`${name} can only use Hidden Power Dark/Dragon/Electric/Steel/Ice because it must have at least 5 perfect IVs${etc}.`);
+			}
+		}
+		const ruleTable = this.ruleTable;
+		if (ruleTable.has('obtainablemoves')) {
+			const ssMaxSourceGen = setSources.maxSourceGen();
+			const tradebackEligible = dex.gen === 2 && species.gen === 1;
+			if (ssMaxSourceGen && eventData.generation > ssMaxSourceGen && !tradebackEligible) {
+				if (fastReturn) return true;
+				problems.push(`${name} must not have moves only learnable in gen ${ssMaxSourceGen}${etc}.`);
+			}
+		}
+		if (ruleTable.has('obtainableabilities')) {
+			if (dex.gen <= 5 && eventData.abilities && eventData.abilities.length === 1 && !eventData.isHidden) {
+				if (species.name === eventSpecies.name) {
+					// has not evolved, abilities must match
+					const requiredAbility = dex.abilities.get(eventData.abilities[0]).name;
+					if (set.ability !== requiredAbility) {
+						if (fastReturn) return true;
+						problems.push(`${name} must have ${requiredAbility}${etc}.`);
+					}
+				} else {
+					// has evolved
+					const ability1 = dex.abilities.get(eventSpecies.abilities['1']);
+					if (ability1.gen && eventData.generation >= ability1.gen) {
+						// pokemon had 2 available abilities in the gen the event happened
+						// ability is restricted to a single ability slot
+						const requiredAbilitySlot = (toID(eventData.abilities[0]) === ability1.id ? 1 : 0);
+						const requiredAbility = dex.abilities.get(species.abilities[requiredAbilitySlot] || species.abilities['0']).name;
+						if (set.ability !== requiredAbility) {
+							const originalAbility = dex.abilities.get(eventData.abilities[0]).name;
+							if (fastReturn) return true;
+							problems.push(`${name} must have ${requiredAbility}${because} from a ${originalAbility} ${eventSpecies.name} event.`);
+						}
+					}
+				}
+			}
+			if (species.abilities['H']) {
+				const isHidden = (set.ability === species.abilities['H']);
+				const canUseAbilityPatch = dex.gen >= 8 && this.format.mod !== 'gen8dlc1';
+				if (!isHidden || !canUseAbilityPatch) {
+					const hiddenAbilityProblem = this.validateEventHiddenAbility(name, isHidden, eventData, etc);
+					if (hiddenAbilityProblem) {
+						if (fastReturn) return true;
+						problems.push(hiddenAbilityProblem);
+					}
+				}
+			}
+		}
+		if (problems.length) return problems;
+		if (eventData.gender) set.gender = eventData.gender;
+	}
+
+	validateEventHiddenAbility(name: string, isHidden: boolean, eventData: EventInfo, etc: string) {
+		if (!isHidden && eventData.isHidden) {
+			return `${name} must have its Hidden Ability${etc}.`;
+		}
+
+		if (isHidden && !eventData.isHidden) {
+			return `${name} must not have its Hidden Ability${etc}.`;
+		}
+		return null;
+	}
+
+	allSources(species?: Species) {
+		let minSourceGen = this.minSourceGen;
+		if (this.dex.gen >= 3 && minSourceGen < 3) minSourceGen = 3;
+		if (species) minSourceGen = Math.max(minSourceGen, species.gen);
+		const maxSourceGen = this.ruleTable.has('allowtradeback') ? Utils.clampIntRange(this.dex.gen + 1, 1, 8) : this.dex.gen;
+		return new PokemonSources(maxSourceGen, minSourceGen);
+	}
+
+	validateMoves(
+		species: Species, moves: string[], setSources: PokemonSources, set?: Partial<PokemonSet>,
+		name: string = species.name
+	) {
+		const dex = this.dex;
+		const ruleTable = this.ruleTable;
+
+		const problems = [];
+
+		const checkCanLearn = (ruleTable.checkCanLearn && ruleTable.checkCanLearn[0] || this.checkCanLearn);
+		for (const moveName of moves) {
+			const move = dex.moves.get(moveName);
+			const problem = checkCanLearn.call(this, move, species, setSources, set);
+			if (problem) {
+				problems.push(`${name}${problem}`);
+				break;
+			}
+		}
+
+		if (setSources.size() && setSources.moveEvoCarryCount > 3) {
+			if (setSources.sourcesBefore < 6) setSources.sourcesBefore = 0;
+			setSources.sources = setSources.sources.filter(
+				source => source.charAt(1) === 'E' && parseInt(source.charAt(0)) >= 6
+			);
+			if (!setSources.size()) {
+				problems.push(`${name} needs to know ${species.evoMove || 'a Fairy-type move'} to evolve, so it can only know 3 other moves from ${species.prevo}.`);
+			}
+		}
+
+		if (problems.length) return problems;
+
+		
+		const canUseAbilityPatch = dex.gen >= 8 && this.format.mod !== 'gen8dlc1';
+		if (setSources.isHidden && !canUseAbilityPatch) {
+			setSources.sources = setSources.sources.filter(
+				source => parseInt(source.charAt(0)) >= 5
+			);
+			if (setSources.sourcesBefore < 5) setSources.sourcesBefore = 0;
+			if (!setSources.size()) {
+				problems.push(`${name} has a hidden ability - it can't have moves only learned before gen 5.`);
+				return problems;
+			}
+		}
+
+		if (setSources.babyOnly && setSources.sources.length) {
+			const baby = dex.species.get(setSources.babyOnly);
+			const babyEvo = toID(baby.evos[0]);
+			setSources.sources = setSources.sources.filter(source => {
+				if (source.charAt(1) === 'S') {
+					const sourceId = source.split(' ')[1];
+					if (sourceId !== baby.id) return false;
+				}
+				if (source.charAt(1) === 'E') {
+					if (babyEvo && source.slice(2) === babyEvo) return false;
+				}
+				if (source.charAt(1) === 'D') {
+					if (babyEvo && source.slice(2) === babyEvo) return false;
+				}
+				return true;
+			});
+			if (!setSources.size()) {
+				problems.push(`${name}'s event/egg moves are from an evolution, and are incompatible with its moves from ${baby.name}.`);
+			}
+		}
+		if (setSources.babyOnly && setSources.size() && this.gen > 2) {
+			// there do theoretically exist evo/tradeback incompatibilities in
+			// gen 2, but those are very complicated to validate and should be
+			// handled separately anyway, so for now we just treat them all as
+			// legal (competitively relevant ones can be manually banned)
+			const baby = dex.species.get(setSources.babyOnly);
+			setSources.sources = setSources.sources.filter(source => {
+				if (baby.gen > parseInt(source.charAt(0)) && !source.startsWith('1ST')) return false;
+				if (baby.gen > 2 && source === '7V') return false;
+				return true;
+			});
+			if (setSources.sourcesBefore < baby.gen) setSources.sourcesBefore = 0;
+			if (!setSources.size()) {
+				problems.push(`${name} has moves from before Gen ${baby.gen}, which are incompatible with its moves from ${baby.name}.`);
+			}
+		}
+
+		return problems;
+	}
+
+	/** Returns null if you can learn the move, or a string explaining why you can't learn it */
+	checkCanLearn(
+		move: Move,
+		s: Species,
+		setSources = this.allSources(s),
+		set: Partial<PokemonSet> = {}
+	): string | null {
+		const dex = this.dex;
+		if (!setSources.size()) throw new Error(`Bad sources passed to checkCanLearn`);
+
+		move = dex.moves.get(move);
+		const moveid = move.id;
+		const baseSpecies = dex.species.get(s);
+		let species: Species | null = baseSpecies;
+
+		const format = this.format;
+		const ruleTable = dex.formats.getRuleTable(format);
+		const alreadyChecked: {[k: string]: boolean} = {};
+		const level = set.level || 100;
+
+		let cantLearnReason = null;
+
+		let limit1 = true;
+		let sketch = false;
+		let blockedHM = false;
+
+		let babyOnly = '';
+
+		// This is a pretty complicated algorithm
+
+		// Abstractly, what it does is construct the union of sets of all
+		// possible ways this pokemon could be obtained, and then intersect
+		// it with a the pokemon's existing set of all possible ways it could
+		// be obtained. If this intersection is non-empty, the move is legal.
+
+		// set of possible sources of a pokemon with this move
+		const moveSources = new PokemonSources();
+
+		/**
+		 * The format doesn't allow Pokemon traded from the future
+		 * (This is everything except in Gen 1 Tradeback)
+		 */
+		const noFutureGen = !ruleTable.has('allowtradeback');
+		/**
+		 * The format allows Sketch to copy moves in Gen 8
+		 */
+		const canSketchGen8Moves = ruleTable.has('sketchgen8moves') || this.dex.currentMod === 'gen8bdsp';
+
+		let tradebackEligible = false;
+		while (species?.name && !alreadyChecked[species.id]) {
+			alreadyChecked[species.id] = true;
+			if (dex.gen <= 2 && species.gen === 1) tradebackEligible = true;
+			const learnset = dex.species.getLearnset(species.id);
+			if (!learnset) {
+				if ((species.changesFrom || species.baseSpecies) !== species.name) {
+					// forme without its own learnset
+					species = dex.species.get(species.changesFrom || species.baseSpecies);
+					// warning: formes with their own learnset, like Wormadam, should NOT
+					// inherit from their base forme unless they're freely switchable
+					continue;
+				}
+				if (species.isNonstandard) {
+					// It's normal for a nonstandard species not to have learnset data
+
+					// Formats should replace the `Obtainable Moves` rule if they want to
+					// allow pokemon without learnsets.
+					return ` can't learn any moves at all.`;
+				}
+				// should never happen
+				throw new Error(`Species with no learnset data: ${species.id}`);
+			}
+			const checkingPrevo = species.baseSpecies !== s.baseSpecies;
+			if (checkingPrevo && !moveSources.size()) {
+				if (!setSources.babyOnly || !species.prevo) {
+					babyOnly = species.id;
+				}
+			}
+
+			let sources = learnset[moveid];
+			if (moveid === 'sketch') {
+				sketch = true;
+			} else if (learnset['sketch']) {
+				if (move.noSketch || move.isZ || move.isMax) {
+					cantLearnReason = `can't be Sketched.`;
+				} else if (move.gen > 7 && !canSketchGen8Moves) {
+					cantLearnReason = `can't be Sketched because it's a Gen 8 move and Sketch isn't available in Gen 8.`;
+				} else {
+					if (!sources) sketch = true;
+					sources = learnset['sketch'].concat(sources || []);
+				}
+			}
+
+			if (typeof sources === 'string') sources = [sources];
+			if (sources) {
+				for (let learned of sources) {
+					// Every `learned` represents a single way a pokemon might
+					// learn a move. This can be handled one of several ways:
+					// `continue`
+					//   means we can't learn it
+					// `return null`
+					//   means we can learn it with no restrictions
+					//   (there's a way to just teach any pokemon of this species
+					//   the move in the current gen, like a TM.)
+					// `moveSources.add(source)`
+					//   means we can learn it only if obtained that exact way described
+					//   in source
+					// `moveSources.addGen(learnedGen)`
+					//   means we can learn it only if obtained at or before learnedGen
+					//   (i.e. get the pokemon however you want, transfer to that gen,
+					//   teach it, and transfer it to the current gen.)
+
+					const learnedGen = parseInt(learned.charAt(0));
+					if (learnedGen < this.minSourceGen) {
+						if (!cantLearnReason) {
+							cantLearnReason = `can't be transferred from Gen ${learnedGen} to ${this.minSourceGen}.`;
+						}
+						continue;
+					}
+					if (noFutureGen && learnedGen > dex.gen) {
+						if (!cantLearnReason) {
+							cantLearnReason = `can't be transferred from Gen ${learnedGen} to ${dex.gen}.`;
+						}
+						continue;
+					}
+
+					// redundant
+					if (learnedGen <= moveSources.sourcesBefore) continue;
+
+					if (baseSpecies.evoRegion === 'Alola' && checkingPrevo && learnedGen >= 8) {
+						cantLearnReason = `is from a ${species.name} that can't be transferred to USUM to evolve into ${baseSpecies.name}.`;
+						continue;
+					}
+
+					const canUseAbilityPatch = dex.gen >= 8 && format.mod !== 'gen8dlc1';
+					if (
+						learnedGen < 7 && setSources.isHidden && !canUseAbilityPatch &&
+						!dex.mod('gen' + learnedGen).species.get(baseSpecies.name).abilities['H']
+					) {
+						cantLearnReason = `can only be learned in gens without Hidden Abilities.`;
+						continue;
+					}
+					if (!species.isNonstandard) {
+						// HMs can't be transferred
+						if (dex.gen >= 4 && learnedGen <= 3 && [
+							'cut', 'fly', 'surf', 'strength', 'flash', 'rocksmash', 'waterfall', 'dive',
+						].includes(moveid)) {
+							cantLearnReason = `can't be transferred from Gen 3 to 4 because it's an HM move.`;
+							continue;
+						}
+						if (dex.gen >= 5 && learnedGen <= 4 && [
+							'cut', 'fly', 'surf', 'strength', 'rocksmash', 'waterfall', 'rockclimb',
+						].includes(moveid)) {
+							cantLearnReason = `can't be transferred from Gen 4 to 5 because it's an HM move.`;
+							continue;
+						}
+						// Defog and Whirlpool can't be transferred together
+						if (dex.gen >= 5 && ['defog', 'whirlpool'].includes(moveid) && learnedGen <= 4) blockedHM = true;
+					}
+
+					if (learned.charAt(1) === 'L') {
+						// special checking for level-up moves
+						if (level >= parseInt(learned.substr(2)) || learnedGen === 7) {
+							// we're past the required level to learn it
+							// (gen 7 level-up moves can be relearnered at any level)
+							// falls through to LMT check below
+						} else if (level >= 5 && learnedGen === 3 && species.canHatch) {
+							// Pomeg Glitch
+						} else if ((!species.gender || species.gender === 'F') && learnedGen >= 2 && species.canHatch) {
+							// available as egg move
+							learned = learnedGen + 'Eany';
+							// falls through to E check below
+						} else {
+							// this move is unavailable, skip it
+							cantLearnReason = `is learned at level ${parseInt(learned.substr(2))}.`;
+							continue;
+						}
+					}
+
+					// Gen 8 egg moves can be taught to any pokemon from any source
+					if (learned === '8E' || 'LMTR'.includes(learned.charAt(1))) {
+						if (learnedGen === dex.gen && learned.charAt(1) !== 'R') {
+							// current-gen level-up, TM or tutor moves:
+							//   always available
+							if (learned !== '8E' && babyOnly) setSources.babyOnly = babyOnly;
+							if (!moveSources.moveEvoCarryCount) return null;
+						}
+						// past-gen level-up, TM, or tutor moves:
+						//   available as long as the source gen was or was before this gen
+						if (learned.charAt(1) === 'R') {
+							moveSources.restrictedMove = moveid;
+						}
+						limit1 = false;
+						moveSources.addGen(learnedGen);
+					} else if (learned.charAt(1) === 'E') {
+						// egg moves:
+						//   only if hatched from an egg
+						let limitedEggMove: ID | null | undefined = undefined;
+						if (learned.slice(1) === 'Eany') {
+							limitedEggMove = null;
+						} else if (learnedGen < 6) {
+							limitedEggMove = move.id;
+						}
+						learned = learnedGen + 'E' + (species.prevo ? species.id : '');
+						if (tradebackEligible && learnedGen === 2 && move.gen <= 1) {
+							// can tradeback
+							moveSources.add('1ET' + learned.slice(2));
+						}
+						moveSources.add(learned, limitedEggMove);
+					} else if (learned.charAt(1) === 'S') {
+						// event moves:
+						//   only if that was the source
+						// Event Pokémon:
+						// 	Available as long as the past gen can get the Pokémon and then trade it back.
+						if (tradebackEligible && learnedGen === 2 && move.gen <= 1) {
+							// can tradeback
+							moveSources.add('1ST' + learned.slice(2) + ' ' + species.id);
+						}
+						moveSources.add(learned + ' ' + species.id);
+					} else if (learned.charAt(1) === 'D') {
+						// DW moves:
+						//   only if that was the source
+						moveSources.add(learned + species.id);
+					} else if (learned.charAt(1) === 'V' && this.minSourceGen < learnedGen) {
+						// Virtual Console or Let's Go transfer moves:
+						//   only if that was the source
+						moveSources.add(learned);
+					}
+				}
+			}
+			if (ruleTable.has('mimicglitch') && species.gen < 5) {
+				// include the Mimic Glitch when checking this mon's learnset
+				const glitchMoves = ['metronome', 'copycat', 'transform', 'mimic', 'assist'];
+				let getGlitch = false;
+				for (const i of glitchMoves) {
+					if (learnset[i]) {
+						if (!(i === 'mimic' && dex.abilities.get(set.ability).gen === 4 && !species.prevo)) {
+							getGlitch = true;
+							break;
+						}
+					}
+				}
+				if (getGlitch) {
+					moveSources.addGen(4);
+					if (move.gen < 5) {
+						limit1 = false;
+					}
+				}
+			}
+
+			if (!moveSources.size()) {
+				if (
+					(species.evoType === 'levelMove' && species.evoMove !== move.name) ||
+					(species.id === 'sylveon' && move.type !== 'Fairy')
+				) {
+					moveSources.moveEvoCarryCount = 1;
+				}
+			}
+
+			// also check to see if the mon's prevo or freely switchable formes can learn this move
+			species = this.learnsetParent(species);
+		}
+
+		if (limit1 && sketch) {
+			// limit 1 sketch move
+			if (setSources.sketchMove) {
+				return ` can't Sketch ${move.name} and ${setSources.sketchMove} because it can only Sketch 1 move.`;
+			}
+			setSources.sketchMove = move.name;
+		}
+
+		if (blockedHM) {
+			// Limit one of Defog/Whirlpool to be transferred
+			if (setSources.hm) return ` can't simultaneously transfer Defog and Whirlpool from Gen 4 to 5.`;
+			setSources.hm = moveid;
+		}
+
+		if (!setSources.restrictiveMoves) {
+			setSources.restrictiveMoves = [];
+		}
+		setSources.restrictiveMoves.push(move.name);
+
+		// Now that we have our list of possible sources, intersect it with the current list
+		if (!moveSources.size()) {
+			if (cantLearnReason) return `'s move ${move.name} ${cantLearnReason}`;
+			return ` can't learn ${move.name}.`;
+		}
+		const backupSources = setSources.sources;
+		const backupSourcesBefore = setSources.sourcesBefore;
+		setSources.intersectWith(moveSources);
+		if (!setSources.size()) {
+			// pretend this pokemon didn't have this move:
+			// prevents a crash if OMs override `checkCanLearn` to keep validating after an error
+			setSources.sources = backupSources;
+			setSources.sourcesBefore = backupSourcesBefore;
+			return `'s moves ${(setSources.restrictiveMoves || []).join(', ')} are incompatible.`;
+		}
+
+		if (babyOnly) setSources.babyOnly = babyOnly;
+		return null;
+	}
+
+	learnsetParent(species: Species) {
+		// Own Tempo Rockruff and Battle Bond Greninja are special event formes
+		// that are visually indistinguishable from their base forme but have
+		// different learnsets. To prevent a leak, we make them show up as their
+		// base forme, but hardcode their learnsets into Rockruff-Dusk and
+		// Greninja-Ash
+		if (['Gastrodon', 'Pumpkaboo', 'Sinistea'].includes(species.baseSpecies) && species.forme) {
+			return this.dex.species.get(species.baseSpecies);
+		} else if (species.name === 'Lycanroc-Dusk') {
+			return this.dex.species.get('Rockruff-Dusk');
+		} else if (species.name === 'Greninja-Ash') {
+			return null;
+		} else if (species.prevo) {
+			// there used to be a check for Hidden Ability here, but apparently it's unnecessary
+			// Shed Skin Pupitar can definitely evolve into Unnerve Tyranitar
+			species = this.dex.species.get(species.prevo);
+			if (species.gen > Math.max(2, this.dex.gen)) return null;
+			return species;
+		} else if (species.changesFrom && species.baseSpecies !== 'Kyurem') {
+			// For Pokemon like Rotom and Necrozma whose movesets are extensions are their base formes
+			return this.dex.species.get(species.changesFrom);
+		}
+		return null;
+	}
+
+	static fillStats(stats: SparseStatsTable | null, fillNum = 0): StatsTable {
+		const filledStats: StatsTable = {hp: fillNum, atk: fillNum, def: fillNum, spa: fillNum, spd: fillNum, spe: fillNum};
+		if (stats) {
+			let statName: StatID;
+			for (statName in filledStats) {
+				const stat = stats[statName];
+				if (typeof stat === 'number') filledStats[statName] = stat;
+			}
+		}
+		return filledStats;
+	}
+
+	static get(format: string | Format) {
+		return new TeamValidator(format);
+	}
+}

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1870,9 +1870,7 @@ export class TeamValidator {
 				problems.push(`${name} needs to know ${species.evoMove || 'a Fairy-type move'} to evolve, so it can only know 3 other moves from ${species.prevo}.`);
 			}
 		}
-
 		if (problems.length) return problems;
-		
 		const canUseAbilityPatch = dex.gen >= 8 && this.format.mod !== 'gen8dlc1';
 		if (setSources.isHidden && !canUseAbilityPatch) {
 			setSources.sources = setSources.sources.filter(

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1872,7 +1872,6 @@ export class TeamValidator {
 		}
 
 		if (problems.length) return problems;
-
 		
 		const canUseAbilityPatch = dex.gen >= 8 && this.format.mod !== 'gen8dlc1';
 		if (setSources.isHidden && !canUseAbilityPatch) {


### PR DESCRIPTION
It's like 5 days until the turn of the next generation, and this is such a niche feature of a command, but whatever, I decided to work on this anyway. This changes the behavior of /learn when checking the validity of a Pokemon with a combination of a given move and a hidden ability. The following changes were made:

- Method validateEventHiddenAbility was added as a split from code originally in validateEvent, and is called by its original method and the method for /learn. It returns null if the ability being hidden or not is compatible with a given event, otherwise it returns the reason for incompatibility.
- If a Pokemon is marked as having its hidden ability, its sources should not be restricted if the Ability Patch can be used. This shouldn't change any Pokemon legality, but should prevent /learn from returning no sources for a move that is legitimately learnable.
- If a Pokemon does not have a set sourcesBefore, /learn will go through all of its possible event sources and check if it is compatible with a hidden ability. Events that do not have a hidden ability will be removed from sources, and if this results in a Pokemon having no sources, the command returns that the move can't be learned.
- If a Pokemon is marked as a species that can only be male with a hidden ability, Gen 5 egg sources will be removed (this is already detected by /learn in its current state, with a visual indicator of no hidden ability). If this results in a Pokemon having no sources, the command returns that the move can't be learned.
- A purely aesthetic change I added is that /learn will fail if used with a hidden ability in a Gen before Gen 5. I made this change because it will always return that the move can't be learned, and hidden ability slots, which can have significance in Gens with hidden abilities, are of no relevance in other Gens.

These changes deal with the bug reported in this post: https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-9361247

These changes only attempt to check if a combination of a hidden ability and a move or moves are compatible; it does not check if a hidden ability alone is legal. Also when making these changes, I realized that there might be a possible legality error with Gen 5 male only hidden abilities: in Gen 6, a Tyrogue shouldn't be able to have its hidden ability Vital Spirit and know Bullet Punch and Work Up. This is because Bullet Punch is a move Tyrogue learns only through breeding in Gens 4-6, and because it has its hidden ability, it can't come from Gen 4, which was before hidden abilities, and it can't come from Gen 5 because Tyrogue is a male only species, so it is also a male only hidden ability species and shouldn't have egg moves from Gen 5. So this Tyrogue must come from Gen 6, but it knows Work Up, a move which it can only learn in Gen 5. If this is indeed not supposed to be legal, I would have caught this in my changes, but for now, I would prefer for my changes to be consistent with the team validator.