### PR TITLE
Adding Rollout storage glitch

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -765,7 +765,11 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				effect && effect.effectType === 'Move' &&
 				['mimikyu', 'mimikyutotem'].includes(target.species.id) && !target.transformed
 			) {
-				this.add('-activate', target, 'ability: Disguise');
+				if (this.gen === 7 && ["rollout", "iceball"].includes(effect.id)) {
+					source.volatiles[effect.id].contactHitCount--;
+				}
+
+				this.add("-activate", target, "ability: Disguise");
 				this.effectState.busted = true;
 				return 0;
 			}

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -765,11 +765,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				effect && effect.effectType === 'Move' &&
 				['mimikyu', 'mimikyutotem'].includes(target.species.id) && !target.transformed
 			) {
-				if (this.gen === 7 && ["rollout", "iceball"].includes(effect.id)) {
-					source.volatiles[effect.id].contactHitCount--;
-				}
-
-				this.add("-activate", target, "ability: Disguise");
+				this.add('-activate', target, 'ability: Disguise');
 				this.effectState.busted = true;
 				return 0;
 			}

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -788,4 +788,17 @@ export const Conditions: {[k: string]: ConditionData} = {
 			return [type];
 		},
 	},
+	rolloutstorage: {
+		name: 'rolloutstorage',
+		duration: 2,
+		onBasePower(relayVar, source, target, move) {
+			let bp = Math.max(1, move.basePower);
+			bp *= Math.pow(2, source.volatiles['rolloutstorage'].contactHitCount);
+			if (source.volatiles['defensecurl']) {
+				bp *= 2;
+			}
+			source.removeVolatile('rolloutstorage');
+			return bp;
+		},
+	},
 };

--- a/data/mods/gen7/abilities.ts
+++ b/data/mods/gen7/abilities.ts
@@ -1,6 +1,20 @@
 export const Abilities: {[k: string]: ModdedAbilityData} = {
 	disguise: {
 		inherit: true,
+		onDamage(damage, target, source, effect) {
+			if (
+				effect && effect.effectType === 'Move' &&
+				['mimikyu', 'mimikyutotem'].includes(target.species.id) && !target.transformed
+			) {
+				if (["rollout", "iceball"].includes(effect.id)) {
+					source.volatiles[effect.id].contactHitCount--;
+				}
+
+				this.add("-activate", target, "ability: Disguise");
+				this.effectState.busted = true;
+				return 0;
+			}
+		},
 		onUpdate(pokemon) {
 			if (['mimikyu', 'mimikyutotem'].includes(pokemon.species.id) && this.effectState.busted) {
 				const speciesid = pokemon.species.id === 'mimikyutotem' ? 'Mimikyu-Busted-Totem' : 'Mimikyu-Busted';

--- a/data/mods/gen8dlc1/abilities.ts
+++ b/data/mods/gen8dlc1/abilities.ts
@@ -55,7 +55,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 				this.effectState.busted = true;
 				return 0;
 			}
-		}
+		},
 	},
 	transistor: {
 		inherit: true,

--- a/data/mods/gen8dlc1/abilities.ts
+++ b/data/mods/gen8dlc1/abilities.ts
@@ -15,6 +15,23 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		inherit: true,
 		isNonstandard: "Unobtainable",
 	},
+	disguise: {
+		inherit: true,
+		onDamage(damage, target, source, effect) {
+			if (
+				effect && effect.effectType === 'Move' &&
+				['mimikyu', 'mimikyutotem'].includes(target.species.id) && !target.transformed
+			) {
+				if (["rollout", "iceball"].includes(effect.id)) {
+					source.volatiles[effect.id].contactHitCount--;
+				}
+
+				this.add("-activate", target, "ability: Disguise");
+				this.effectState.busted = true;
+				return 0;
+			}
+		},
+	},
 	dragonsmaw: {
 		inherit: true,
 		isNonstandard: "Unobtainable",
@@ -22,6 +39,23 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	grimneigh: {
 		inherit: true,
 		isNonstandard: "Unobtainable",
+	},
+	iceface: {
+		inherit: true,
+		onDamage(damage, target, source, effect) {
+			if (
+				effect && effect.effectType === 'Move' && effect.category === 'Physical' &&
+				target.species.id === 'eiscue' && !target.transformed
+			) {
+				if (["rollout", "iceball"].includes(effect.id)) {
+					source.volatiles[effect.id].contactHitCount--;
+				}
+
+				this.add("-activate", target, "ability: Disguise");
+				this.effectState.busted = true;
+				return 0;
+			}
+		}
 	},
 	transistor: {
 		inherit: true,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -8709,10 +8709,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 			let bp = move.basePower;
 			const iceballData = pokemon.volatiles['iceball'];
 			if (iceballData?.hitCount) {
-				bp *= Math.pow(2, iceballData.hitCount);
+				bp *= Math.pow(2, iceballData.contactHitCount);
 			}
 			if (iceballData && pokemon.status !== 'slp') {
 				iceballData.hitCount++;
+				iceballData.contactHitCount++;
 				if (iceballData.hitCount < 5) {
 					iceballData.duration = 2;
 				}
@@ -8737,11 +8738,25 @@ export const Moves: {[moveid: string]: MoveData} = {
 			// but it does exist now because addVolatile created it
 			pokemon.volatiles['iceball'].targetSlot = move.sourceEffect ? pokemon.lastMoveTargetLoc : pokemon.getLocOf(target);
 		},
+		onAfterMove(source, target, move) {
+			const iceballData = source.volatiles["iceball"];
+			if (
+				this.gen === 7 &&
+				iceballData.hitCount === 5 &&
+				iceballData.contactHitCount < 5
+			) {
+				source.addVolatile("rolloutstorage");
+				source.volatiles["rolloutstorage"].contactHitCount =
+				iceballData.contactHitCount;
+			}
+		},
+
 		condition: {
 			duration: 1,
 			onLockMove: 'iceball',
 			onStart() {
 				this.effectState.hitCount = 0;
+				this.effectState.contactHitCount = 0;
 			},
 			onResidual(target) {
 				if (target.lastMove && target.lastMove.id === 'struggle') {
@@ -14405,10 +14420,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 			let bp = move.basePower;
 			const rolloutData = pokemon.volatiles['rollout'];
 			if (rolloutData?.hitCount) {
-				bp *= Math.pow(2, rolloutData.hitCount);
+				bp *= Math.pow(2, rolloutData.contactHitCount);
 			}
 			if (rolloutData && pokemon.status !== 'slp') {
 				rolloutData.hitCount++;
+				rolloutData.contactHitCount++;
 				if (rolloutData.hitCount < 5) {
 					rolloutData.duration = 2;
 				}
@@ -14432,11 +14448,24 @@ export const Moves: {[moveid: string]: MoveData} = {
 			// but it does exist now because addVolatile created it
 			pokemon.volatiles['rollout'].targetSlot = move.sourceEffect ? pokemon.lastMoveTargetLoc : pokemon.getLocOf(target);
 		},
+		onAfterMove(source, target, move) {
+			const rolloutData = source.volatiles["rollout"];
+			if (
+				this.gen === 7 &&
+				rolloutData.hitCount === 5 &&
+				rolloutData.contactHitCount < 5
+			) {
+				source.addVolatile("rolloutstorage");
+				source.volatiles["rolloutstorage"].contactHitCount =
+					rolloutData.contactHitCount;
+			}
+		},
 		condition: {
 			duration: 1,
 			onLockMove: 'rollout',
 			onStart() {
 				this.effectState.hitCount = 0;
+				this.effectState.contactHitCount = 0;
 			},
 			onResidual(target) {
 				if (target.lastMove && target.lastMove.id === 'struggle') {

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -8741,9 +8741,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		onAfterMove(source, target, move) {
 			const iceballData = source.volatiles["iceball"];
 			if (
-				this.gen === 7 &&
 				iceballData.hitCount === 5 &&
 				iceballData.contactHitCount < 5
+				// this conditions can only be met in gen7 and gen8dlc1
+				// see `disguise` and `iceface` abilities in the resp mod folders
 			) {
 				source.addVolatile("rolloutstorage");
 				source.volatiles["rolloutstorage"].contactHitCount =
@@ -14451,9 +14452,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		onAfterMove(source, target, move) {
 			const rolloutData = source.volatiles["rollout"];
 			if (
-				this.gen === 7 &&
 				rolloutData.hitCount === 5 &&
 				rolloutData.contactHitCount < 5
+				// this conditions can only be met in gen7 and gen8dlc1
+				// see `disguise` and `iceface` abilities in the resp mod folders
 			) {
 				source.addVolatile("rolloutstorage");
 				source.volatiles["rolloutstorage"].contactHitCount =

--- a/test/sim/moves/rollout.js
+++ b/test/sim/moves/rollout.js
@@ -142,7 +142,7 @@ for (const move of moves) {
 
 				for (let i = 0; i < 5; i++) { battle.makeChoices(); }
 				battle.makeChoices('move watergun', 'switch 2');
-				let snorlax = battle.p2.active[0];
+				const snorlax = battle.p2.active[0];
 				let damage = snorlax.maxhp - snorlax.hp;
 				assert.bounded(damage, [147, 174]); // 40 * 2^4 BP; would be 40 BP otherwise, range 10-12
 				battle.makeChoices("move watergun", "switch 3");

--- a/test/sim/moves/rollout.js
+++ b/test/sim/moves/rollout.js
@@ -130,20 +130,25 @@ for (const move of moves) {
 			assert.equal(hitCount, 1);
 		});
 
-		describe.skip(`Rollout Storage glitch (Gen 7 / Gen 8DLC1)`, function () {
+		describe(`Rollout Storage glitch (Gen 7 / Gen 8DLC1)`, function () {
 			it(`should delay the Rollout multiplier when hitting Disguise or Ice Face`, function () {
 				battle = common.gen(7).createBattle([[
 					{species: 'wynaut', ability: 'compoundeyes', ivs: {atk: '0'}, nature: 'bold', moves: [id, 'watergun']},
 				], [
 					{species: 'mimikyu', ability: 'disguise', evs: {hp: '252', def: '252'}, nature: 'bold', moves: ['gravity']},
 					{species: 'snorlax', ability: 'battlearmor', moves: ['sleeptalk']},
+					{species: 'snorlax', ability: 'battlearmor', moves: ['rest']},
 				]]);
 
 				for (let i = 0; i < 5; i++) { battle.makeChoices(); }
 				battle.makeChoices('move watergun', 'switch 2');
-				const snorlax = battle.p2.active[0];
-				const damage = snorlax.maxhp - snorlax.hp;
+				let snorlax = battle.p2.active[0];
+				let damage = snorlax.maxhp - snorlax.hp;
 				assert.bounded(damage, [147, 174]); // 40 * 2^4 BP; would be 40 BP otherwise, range 10-12
+				battle.makeChoices("move watergun", "switch 3");
+				snorlax = battle.p2.active[0];
+				damage = snorlax.maxhp - snorlax.hp;
+				assert.bounded(damage, [10, 12]);
 			});
 
 			it(`should delay the Rollout multiplier when hitting multiple Disguise or Ice Face`, function () {

--- a/test/sim/moves/rollout.js
+++ b/test/sim/moves/rollout.js
@@ -137,7 +137,7 @@ for (const move of moves) {
 				], [
 					{species: 'mimikyu', ability: 'disguise', evs: {hp: '252', def: '252'}, nature: 'bold', moves: ['gravity']},
 					{species: 'snorlax', ability: 'battlearmor', moves: ['sleeptalk']},
-					{species: 'snorlax', ability: 'battlearmor', moves: ['rest']},
+					{species: 'wigglytuff', ability: 'battlearmor', moves: ['rest']},
 				]]);
 
 				for (let i = 0; i < 5; i++) { battle.makeChoices(); }
@@ -146,9 +146,9 @@ for (const move of moves) {
 				let damage = snorlax.maxhp - snorlax.hp;
 				assert.bounded(damage, [147, 174]); // 40 * 2^4 BP; would be 40 BP otherwise, range 10-12
 				battle.makeChoices("move watergun", "switch 3");
-				snorlax = battle.p2.active[0];
-				damage = snorlax.maxhp - snorlax.hp;
-				assert.bounded(damage, [10, 12]);
+				const wigglytuff = battle.p2.active[0];
+				damage = wigglytuff.maxhp - wigglytuff.hp;
+				assert.bounded(damage, [18, 22]);
 			});
 
 			it(`should delay the Rollout multiplier when hitting multiple Disguise or Ice Face`, function () {


### PR DESCRIPTION
This is ticketed [here](https://github.com/smogon/pokemon-showdown/projects/3#card-61615000)

Want to practise some web-dev. Hence, why I'm picking up a slightly obscure ticket. 

Some notes:
* I'm not sure I've correctly used (or abused) some of the event hooks - for example, `onAfterMove` for checking if we need to store the multiplier for the next non-rollout move. 
* The ticket also specifies that this bug was present pre-patch in Gen 8, though I'm not sure how to check for this (some `gen` attributes need to be ints, so "8 DLC1" wouldn't work). 