### PR TITLE
Gen 1: Fix Wrap interaction with residual damage KOs

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1415,6 +1415,24 @@ export class Battle {
 			pokemon.removeVolatile('dynamax');
 		}
 
+		// Gen 1 partial trapping ends when either Pokemon or a switch in faints to residual damage
+		if (this.gen === 1) {
+			for (const pokemon of this.getAllActive()) {
+				if (pokemon.volatiles['partialtrappinglock']) {
+					const target = pokemon.volatiles['partialtrappinglock'].locked;
+					if (target.hp <= 0 || !target.volatiles['partiallytrapped']) {
+						delete pokemon.volatiles['partialtrappinglock'];
+					}
+				}
+				if (pokemon.volatiles['partiallytrapped']) {
+					const source = pokemon.volatiles['partiallytrapped'].source;
+					if (source.hp <= 0 || !source.volatiles['partialtrappinglock']) {
+						delete pokemon.volatiles['partiallytrapped'];
+					}
+				}
+			}
+		}
+
 		const trappedBySide: boolean[] = [];
 		const stalenessBySide: ('internal' | 'external' | undefined)[] = [];
 		for (const side of this.sides) {

--- a/test/sim/misc/trapmoves.js
+++ b/test/sim/misc/trapmoves.js
@@ -195,3 +195,60 @@ describe('Partial Trapping Moves', function () {
 		});
 	}
 });
+
+describe('Partial Trapping Moves [Gen 1]', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('Wrap ends when wrapped Pokemon dies of residual damage', function () {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', {team: [{species: "Arbok", moves: ['wrap', 'toxic']}]});
+		battle.setPlayer('p2', {team: [{species: "Rhydon", moves: ['splash']}, {species: "Exeggutor", moves: ['splash']}]});
+		battle.makeChoices('move toxic', 'move splash');
+		for (let i = 0; i < 6; i++) {
+			battle.makeChoices();
+		}
+		assert(!battle.p1.active[0].volatiles['partialtrappinglock']);
+	});
+
+	it('Wrap ends when wrapped Pokemon switches to a Pokemon that dies of residual damage', function () {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', {team: [{species: "Dragonite", moves: ['wrap', 'seismictoss', 'toxic'], evs: {hp: 255}}]});
+		battle.setPlayer('p2', {team: [{species: "Mewtwo", moves: ['splash'], evs: {hp: 255}}, {species: "Exeggutor", moves: ['splash']}]});
+		for (let i = 0; i < 4; i++) {
+			battle.makeChoices('move seismictoss', 'auto');
+		}
+		battle.makeChoices('move toxic', 'auto');
+		battle.makeChoices('move wrap', 'switch 2');
+		battle.makeChoices('move wrap', 'switch 2');
+		battle.makeChoices();
+		assert(!battle.p1.active[0].volatiles['partialtrappinglock']);
+	});
+
+	it('Wrap ends when wrapper dies to residual damage', function () {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', {team: [{species: "Dragonite", moves: ['wrap', 'splash']}, {species: "Exeggutor", moves: ['splash']}]});
+		battle.setPlayer('p2', {team: [{species: "Rhydon", moves: ['toxic']}]});
+		battle.makeChoices('move splash', 'move toxic');
+		for (let i = 0; i < 7; i++) {
+			battle.makeChoices();
+		}
+		assert(!battle.p2.active[0].volatiles['partiallytrapped']);
+	});
+
+	it('Wrap ends when wrapper switches to a Pokemon that dies of residual damage', function () {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', {team: [{species: "Rhydon", moves: ['splash'], evs: {hp: 255}}, {species: "Dragonite", moves: ['wrap', 'splash']}]});
+		battle.setPlayer('p2', {team: [{species: "Slowbro", moves: ['seismictoss', 'toxic']}]});
+		for (let i = 0; i < 4; i++) {
+			battle.makeChoices();
+		}
+		battle.makeChoices('move splash', 'move toxic');
+		battle.makeChoices('switch 2', 'auto');
+		battle.makeChoices();
+		battle.makeChoices('switch 2', 'auto');
+		battle.makeChoices();
+		assert(!battle.p2.active[0].volatiles['partiallytrapped']);
+	});
+});

--- a/test/sim/misc/trapmoves.js
+++ b/test/sim/misc/trapmoves.js
@@ -239,7 +239,7 @@ describe('Partial Trapping Moves [Gen 1]', function () {
 
 	it('Wrap ends when wrapper switches to a Pokemon that dies of residual damage', function () {
 		battle = common.gen(1).createBattle();
-		battle.setPlayer('p1', {team: [{species: "Rhydon", moves: ['splash'], evs: {hp: 255}}, {species: "Dragonite", moves: ['wrap', 'splash']}]});
+		battle.setPlayer('p1', {team: [{species: "Rhydon", moves: ['splash'], evs: {hp: 255}}, {species: "Dragonite", moves: ['wrap']}]});
 		battle.setPlayer('p2', {team: [{species: "Slowbro", moves: ['seismictoss', 'toxic']}]});
 		for (let i = 0; i < 4; i++) {
 			battle.makeChoices();


### PR DESCRIPTION
This patch fixes the interaction of wrapping moves with residual damage (brn, psn, etc) KOs. Currently on Showdown, partial trapping does not end when either Pokemon faints to residual damage (or switches to a Pokemon that faints to residual damage). 

https://www.smogon.com/forums/threads/rby-tradebacks-bug-report-thread.3524844/page-14#post-8442413
https://www.smogon.com/forums/threads/rby-tradebacks-bug-report-thread.3524844/page-15#post-8707376
https://www.smogon.com/forums/threads/rby-tradebacks-bug-report-thread.3524844/page-16#post-9061756