### PR TITLE
Unit Tests: Transition to Gen 9

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -23,7 +23,7 @@ class TestTools {
 		this.currentMod = mod;
 		this.dex = Dex.mod(mod);
 
-		this.modPrefix = this.dex.isBase ? `[gen8] ` : `[${mod}] `;
+		this.modPrefix = this.dex.isBase ? `[gen9] ` : `[${mod}] `;
 	}
 
 	mod(mod) {
@@ -58,10 +58,14 @@ class TestTools {
 		const customRulesID = customRules.length ? `@@@${customRules.join(',')}` : ``;
 
 		let basicFormat = this.currentMod === 'base' && gameType === 'singles' ? 'Anything Goes' : 'Custom Game';
+		let modPrefix = this.modPrefix;
 		if (this.currentMod === 'gen1stadium') basicFormat = 'OU';
-		if (gameType === 'freeforall' || gameType === 'multi') basicFormat = 'randombattle';
+		if (gameType === 'freeforall' || gameType === 'multi') {
+			basicFormat = 'randombattle';
+			modPrefix = `[gen8] `; // Remove when FFA/multis support Gen 9
+		}
 		const gameTypePrefix = gameType === 'singles' ? '' : capitalize(gameType) + ' ';
-		const formatName = `${this.modPrefix}${gameTypePrefix}${basicFormat}${customRulesID}`;
+		const formatName = `${modPrefix}${gameTypePrefix}${basicFormat}${customRulesID}`;
 
 		let format = formatsCache.get(formatName);
 		if (format) return format;
@@ -142,4 +146,4 @@ class TestTools {
 
 const common = exports = module.exports = new TestTools();
 cache.set('base', common);
-cache.set('gen8', common);
+cache.set('gen9', common);

--- a/test/sim/abilities/emergencyexit.js
+++ b/test/sim/abilities/emergencyexit.js
@@ -294,7 +294,7 @@ describe(`Emergency Exit`, function () {
 	});
 
 	it('should request switchout if its HP drops to below 50% while dynamaxed', function () {
-		battle = common.createBattle([
+		battle = common.gen(8).createBattle([
 			[{species: "Golisopod", ability: 'emergencyexit', moves: ['closecombat'], ivs: EMPTY_IVS, level: 30}, {species: "Clefable", ability: 'Unaware', moves: ['metronome']}],
 			[{species: "Gengar", ability: 'cursedbody', moves: ['nightshade']}],
 		]);
@@ -305,7 +305,7 @@ describe(`Emergency Exit`, function () {
 	});
 
 	it('should not request switchout if its HP is below 50% when its dynamax ends', function () {
-		battle = common.createBattle([
+		battle = common.gen(8).createBattle([
 			[{species: "Golisopod", ability: 'emergencyexit', moves: ['drillrun'], ivs: EMPTY_IVS}, {species: "Clefable", ability: 'Unaware', moves: ['metronome']}],
 			[{species: "Landorus", ability: 'sheerforce', moves: ['sludgewave']}],
 		]);

--- a/test/sim/abilities/flowergift.js
+++ b/test/sim/abilities/flowergift.js
@@ -56,7 +56,8 @@ describe('Flower Gift', function () {
 	});
 
 	it(`should not trigger if the Pokemon was KOed`, function () {
-		battle = common.createBattle([[
+		// TODO: Is this interaction possible in Gen 9?
+		battle = common.gen(8).createBattle([[
 			{species: 'Cherrim', ability: 'flowergift', moves: ['sleeptalk']},
 		], [
 			{species: 'Heatran', moves: ['blastburn']},

--- a/test/sim/abilities/iceface.js
+++ b/test/sim/abilities/iceface.js
@@ -25,7 +25,8 @@ describe('Ice Face', function () {
 	});
 
 	it(`should not trigger if the Pokemon was KOed`, function () {
-		battle = common.createBattle([[
+		// TODO: Make compatible with gen 9
+		battle = common.gen(8).createBattle([[
 			{species: 'Eiscue', level: 1, ability: 'iceface', moves: ['sleeptalk']},
 		], [
 			{species: 'Weavile', moves: ['icepunch']},

--- a/test/sim/abilities/illusion.js
+++ b/test/sim/abilities/illusion.js
@@ -11,7 +11,7 @@ describe('Illusion', function () {
 	});
 
 	it(`should not instantly wear off before Dynamaxing`, function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: "Zoroark", ability: 'illusion', moves: ['sleeptalk']},
 			{species: "Diglett", moves: ['sleeptalk']},
 		], [
@@ -23,7 +23,7 @@ describe('Illusion', function () {
 	});
 
 	it(`should prevent the user from Dynamaxed when Illusioning as a Pokemon that cannot Dynamax`, function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: "Zoroark", ability: 'illusion', moves: ['sleeptalk']},
 			{species: "Eternatus", moves: ['sleeptalk']},
 		], [
@@ -34,7 +34,7 @@ describe('Illusion', function () {
 	});
 
 	it(`should be able to wear off normally while Dynamaxed`, function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: "Zoroark", ability: 'illusion', moves: ['machpunch']},
 			{species: "Diglett", moves: ['sleeptalk']},
 		], [
@@ -46,7 +46,7 @@ describe('Illusion', function () {
 	});
 
 	it(`should Illusion as the regular Dynamax version of G-Max Pokemon while Dynamaxed`, function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: "Zoroark", ability: 'illusion', moves: ['sleeptalk']},
 			{species: "Charizard", gigantamax: true, moves: ['ember', 'sleeptalk']},
 		], [

--- a/test/sim/abilities/pressure.js
+++ b/test/sim/abilities/pressure.js
@@ -105,7 +105,7 @@ describe(`Pressure`, function () {
 	});
 
 	it(`should deduct additional PP from Max Moves`, function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: 'wynaut', moves: ['darkpulse']},
 		], [
 			{species: 'absol', ability: 'pressure', moves: ['sleeptalk']},

--- a/test/sim/abilities/protean.js
+++ b/test/sim/abilities/protean.js
@@ -22,23 +22,6 @@ describe('Protean', function () {
 		assert(cinder.hasType('Fighting'));
 	});
 
-	it(`should activate on both turns of a charge move`, function () {
-		battle = common.createBattle([[
-			{species: 'Wynaut', ability: 'protean', moves: ['bounce']},
-		], [
-			{species: 'Helioptile', ability: 'noguard', moves: ['soak']},
-		]]);
-		const wynaut = battle.p1.active[0];
-
-		//Turn 1 of Bounce
-		battle.makeChoices();
-		assert(wynaut.hasType('Flying'));
-
-		//Turn 2 of Bounce
-		battle.makeChoices();
-		assert(wynaut.hasType('Flying'));
-	});
-
 	it(`should not change the user's type when using moves that fail earlier than Protean will activate`, function () {
 		battle = common.createBattle([[
 			{species: 'Kecleon', ability: 'protean', moves: ['fling', 'suckerpunch', 'steelroller', 'aurawheel']},
@@ -115,5 +98,24 @@ describe('Protean', function () {
 		assert(kecleon.hasType('Normal'), `Protean changed typing when a exploding move was blocked by Damp.`);
 
 		// More examples: https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/post-8548957
+	});
+
+	describe('Gen 6-8', function () {
+		it(`should activate on both turns of a charge move`, function () {
+			battle = common.gen(8).createBattle([[
+				{species: 'Wynaut', ability: 'protean', moves: ['bounce']},
+			], [
+				{species: 'Helioptile', ability: 'noguard', moves: ['soak']},
+			]]);
+			const wynaut = battle.p1.active[0];
+
+			//Turn 1 of Bounce
+			battle.makeChoices();
+			assert(wynaut.hasType('Flying'));
+
+			//Turn 2 of Bounce
+			battle.makeChoices();
+			assert(wynaut.hasType('Flying'));
+		});
 	});
 });

--- a/test/sim/abilities/rockhead.js
+++ b/test/sim/abilities/rockhead.js
@@ -42,7 +42,7 @@ describe('Rock Head', function () {
 	it('should not block indirect damage', function () {
 		battle = common.createBattle();
 		battle.setPlayer('p1', {team: [{species: 'Rampardos', ability: 'rockhead', moves: ['splash']}]});
-		battle.setPlayer('p2', {team: [{species: 'Abomasnow', ability: 'snowwarning', moves: ['splash']}]});
+		battle.setPlayer('p2', {team: [{species: 'Abomasnow', ability: 'snowwarning', moves: ['toxic']}]});
 		assert.hurts(battle.p1.active[0], () => battle.makeChoices());
 	});
 });

--- a/test/sim/abilities/stormdrain.js
+++ b/test/sim/abilities/stormdrain.js
@@ -20,7 +20,7 @@ describe('Storm Drain', function () {
 	});
 
 	it('should redirect Max Geyser', function () {
-		battle = common.createBattle({gameType: 'doubles'});
+		battle = common.gen(8).createBattle({gameType: 'doubles'});
 		battle.setPlayer('p1', {team: [
 			{species: 'Gastrodon', ability: 'stormdrain', moves: ['sleep talk']},
 			{species: 'Manaphy', ability: 'hydration', moves: ['scald']},

--- a/test/sim/abilities/wanderingspirit.js
+++ b/test/sim/abilities/wanderingspirit.js
@@ -20,7 +20,7 @@ describe('Wandering Spirit', function () {
 	});
 
 	it(`should not activate while Dynamaxed`, function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: 'Decidueye', ability: 'overgrow', moves: ['shadowsneak']},
 		], [
 			{species: 'Runerigus', ability: 'wanderingspirit', moves: ['bodypress']},

--- a/test/sim/choice-parser.js
+++ b/test/sim/choice-parser.js
@@ -189,7 +189,7 @@ describe('Choice parser', function () {
 			});
 
 			it('should allow Dynamax use in multiple possible formats', function () {
-				battle = common.createBattle([[
+				battle = common.gen(8).createBattle([[
 					{species: "Mew", moves: ['psychic']},
 				], [
 					{species: "Mew", moves: ['psychic']},

--- a/test/sim/items/choiceitem.js
+++ b/test/sim/items/choiceitem.js
@@ -11,7 +11,7 @@ describe("Choice Items", function () {
 	});
 
 	it("should restore the same Choice lock after dynamax ends", function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: 'gyarados', moves: ['sleeptalk', 'splash'], item: 'choicescarf'},
 		], [
 			{species: 'wynaut', moves: ['sleeptalk']},

--- a/test/sim/misc/dynamax.js
+++ b/test/sim/misc/dynamax.js
@@ -11,7 +11,7 @@ describe("Dynamax", function () {
 	});
 
 	it('Max Move effects should not be suppressed by Sheer Force', function () {
-		battle = common.createBattle();
+		battle = common.gen(8).createBattle();
 		battle.setPlayer('p1', {team: [
 			{species: 'Braviary', ability: 'sheerforce', moves: ['heatwave', 'facade', 'superpower']},
 		]});
@@ -27,7 +27,7 @@ describe("Dynamax", function () {
 	});
 
 	it('Max Move versions of disabled moves should not be disabled, except by Assault Vest', function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: 'Mew', item: 'assaultvest', moves: ['watergun', 'protect']},
 		], [
 			{species: 'Mew', item: 'choiceband', moves: ['watergun', 'protect']},
@@ -40,7 +40,7 @@ describe("Dynamax", function () {
 	});
 
 	it('Max Move weather activates even if foe faints', function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: 'Shedinja', moves: ['splash']},
 		], [
 			{species: 'Mew', moves: ['watergun']},
@@ -50,7 +50,7 @@ describe("Dynamax", function () {
 	});
 
 	it('Max Move weather activates before Sand Spit', function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: 'Shedinja', ability: 'sandspit', moves: ['splash']},
 		], [
 			{species: 'Mew', moves: ['watergun']},
@@ -60,7 +60,7 @@ describe("Dynamax", function () {
 	});
 
 	it('makes Liquid Voice stop working', function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: 'Primarina', ability: 'liquidvoice', moves: ['hypervoice']},
 		], [
 			{species: 'Rhyhorn', ability: 'wonderguard', moves: ['splash']},
@@ -70,7 +70,7 @@ describe("Dynamax", function () {
 	});
 
 	it('should execute in order of updated speed when 2 or more Pokemon are Dynamaxing', function () {
-		battle = common.createBattle({gameType: 'doubles'}, [[
+		battle = common.gen(8).createBattle({gameType: 'doubles'}, [[
 			{species: 'kingdra', ability: 'swiftswim', moves: ['sleeptalk']},
 			{species: 'wynaut', moves: ['sleeptalk']},
 			{species: 'groudon', ability: 'drought', moves: ['sleeptalk']},
@@ -86,7 +86,7 @@ describe("Dynamax", function () {
 	});
 
 	it('should revert before the start of the 4th turn, not as an end-of-turn effect on the 3rd turn', function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: 'wynaut', moves: ['sleeptalk', 'psychic']},
 		], [
 			{species: 'weedle', level: 1, moves: ['sleeptalk']},
@@ -102,7 +102,7 @@ describe("Dynamax", function () {
 	});
 
 	it('should be impossible to Dynamax when all the base moves are disabled', function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: "Feebas", moves: ['splash']},
 		], [
 			{species: "Wynaut", moves: ['taunt', 'splash']},
@@ -111,7 +111,7 @@ describe("Dynamax", function () {
 		assert.cantMove(() => battle.choose('p1', 'move splash dynamax'));
 		assert.cantMove(() => battle.choose('p1', 'move struggle dynamax'));
 
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: "Feebas", moves: ['splash']},
 		], [
 			{species: "Wynaut", moves: ['imprison', 'splash']},
@@ -123,7 +123,7 @@ describe("Dynamax", function () {
 	});
 
 	it(`should not allow the user to select max moves with 0 base PP remaining`, function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: 'pichu', ability: 'prankster', level: 1, moves: ['grudge']},
 			{species: 'noibat', ability: 'prankster', level: 1, moves: ['grudge']},
 			{species: 'azurill', moves: ['sleeptalk']},
@@ -142,7 +142,7 @@ describe("Dynamax", function () {
 	});
 
 	it(`should force the user to use Struggle if certain effects are disabling all of its base moves`, function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: "Skwovet", item: 'oranberry', moves: ['sleeptalk', 'belch', 'stuffcheeks']},
 		], [
 			{species: "Calyrex-Shadow", moves: ['disable', 'trick']},
@@ -156,7 +156,7 @@ describe("Dynamax", function () {
 		// Now Skwovet's berry is gone, so Stuff Cheeks is disabled too
 		battle.makeChoices('move struggle', 'auto'); // will throw an error if Skwovet isn't forced to use Struggle
 
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: "Feebas", moves: ['splash']},
 		], [
 			{species: "Clefairy", moves: ['imprison', 'gravity', 'splash']},
@@ -167,7 +167,7 @@ describe("Dynamax", function () {
 	});
 
 	it.skip(`should not remove the variable to Dynamax on forced switches`, function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: 'wynaut', item: 'ejectpack', moves: ['ironhead']},
 			{species: 'audino', item: 'ejectpack', moves: ['sleeptalk']},
 		], [
@@ -185,7 +185,7 @@ describe("Dynamax", function () {
 
 	describe(`Hacked Max Moves`, function () {
 		it(`should not activate Max Move side effects when used without Dynamaxing`, function () {
-			battle = common.createBattle([[
+			battle = common.gen(8).createBattle([[
 				{species: 'wynaut', moves: ['maxflare', 'maxairstream']},
 			], [
 				{species: 'shuckle', moves: ['sleeptalk']},
@@ -198,7 +198,7 @@ describe("Dynamax", function () {
 		});
 
 		it(`should treat Max Moves as 0 BP when used without Dynamaxing`, function () {
-			battle = common.createBattle([[
+			battle = common.gen(8).createBattle([[
 				{species: 'wynaut', moves: ['maxflare', 'maxairstream']},
 			], [
 				{species: 'shuckle', ability: 'shellarmor', moves: ['sleeptalk']},
@@ -211,7 +211,7 @@ describe("Dynamax", function () {
 		});
 
 		it(`should treat Max Moves as physical moves when used without Dynamaxing`, function () {
-			battle = common.createBattle([[
+			battle = common.gen(8).createBattle([[
 				{species: 'wynaut', moves: ['maxflare']},
 			], [
 				{species: 'shuckle', item: 'keeberry', moves: ['sleeptalk']},
@@ -221,7 +221,7 @@ describe("Dynamax", function () {
 		});
 
 		it(`should prevent effects that affect regular Max Moves, like Sleep Talk and Instruct`, function () {
-			battle = common.createBattle([[
+			battle = common.gen(8).createBattle([[
 				{species: 'wynaut', moves: ['maxflare', 'sleeptalk']},
 			], [
 				{species: 'shuckle', moves: ['instruct', 'spore', 'roost']},

--- a/test/sim/misc/pledgemoves.js
+++ b/test/sim/misc/pledgemoves.js
@@ -42,7 +42,7 @@ describe('Pledge Moves', function () {
 	});
 
 	it("should not start a Pledge combo for Max Moves", function () {
-		battle = common.createBattle({gameType: 'doubles'}, [[
+		battle = common.gen(8).createBattle({gameType: 'doubles'}, [[
 			{species: 'Weedle', ability: 'sapsipper', moves: ['sleeptalk']},
 			{species: 'Wynaut', moves: ['sleeptalk']},
 		], [

--- a/test/sim/misc/target-resolution.js
+++ b/test/sim/misc/target-resolution.js
@@ -189,7 +189,7 @@ describe('Target Resolution', function () {
 
 		it(`should support RedirectTarget event for a fainted foe and type 'any'`, function () {
 			battle = common.createBattle({gameType: 'doubles'}, [[
-				{species: 'Aurorus', ability: 'snowwarning', moves: ['watergun']},
+				{species: 'Hippowdon', ability: 'sandstream', moves: ['waterpulse']},
 				{species: 'Shedinja', ability: 'wonderguard', moves: ['agility']},
 			], [
 				{species: 'Gastrodon', ability: 'stormdrain', moves: ['curse']},
@@ -198,13 +198,13 @@ describe('Target Resolution', function () {
 			const redirector = battle.p2.active[0];
 
 			battle.makeChoices('auto', 'auto'); // Shedinjas faint
-			battle.makeChoices('move watergun 2, pass', 'auto');
+			battle.makeChoices('move waterpulse 2, pass', 'auto');
 			assert.statStage(redirector, 'spa', 2);
 		});
 
 		it(`should support RedirectTarget event for a fainted ally and type 'any'`, function () {
 			battle = common.createBattle({gameType: 'doubles'}, [[
-				{species: 'Aurorus', ability: 'snowwarning', moves: ['watergun']},
+				{species: 'Hippowdon', ability: 'sandstream', moves: ['waterpulse']},
 				{species: 'Shedinja', ability: 'wonderguard', moves: ['agility']},
 			], [
 				{species: 'Gastrodon', ability: 'stormdrain', moves: ['curse']},
@@ -213,7 +213,7 @@ describe('Target Resolution', function () {
 			const redirector = battle.p2.active[0];
 
 			battle.makeChoices('auto', 'auto'); // Shedinjas faint
-			battle.makeChoices('move watergun -2, pass', 'auto');
+			battle.makeChoices('move waterpulse -2, pass', 'auto');
 			assert.statStage(redirector, 'spa', 2);
 		});
 	});

--- a/test/sim/misc/terastal.js
+++ b/test/sim/misc/terastal.js
@@ -40,7 +40,7 @@ describe("Terastallization", function () {
 		assert.equal(battle.p1.pokemon[1].getTypes().join('/'), 'Dragon');
 	});
 
-	it.skip('should give STAB correctly to the user\'s old types', function () {
+	it('should give STAB correctly to the user\'s old types', function () {
 		battle = common.createBattle();
 		battle.setPlayer('p1', {team: [
 			{species: 'Ampharos', ability: 'static', moves: ['shockwave', 'swift'], teraType: 'Electric'},
@@ -49,10 +49,12 @@ describe("Terastallization", function () {
 			{species: 'Ampharos', ability: 'static', moves: ['shockwave', 'swift'], teraType: 'Normal'},
 		]});
 		battle.makeChoices('move shockwave terastallize', 'move shockwave terastallize');
-		const teraDamage = battle.p2.active[0].maxhp - battle.p2.active[0].maxhp;
-		assert.bounded(teraDamage, [54, 64],
+		const teraDamage = battle.p2.active[0].maxhp - battle.p2.active[0].hp;
+		// 0 SpA Adaptability Ampharos Shock Wave vs. 0 HP / 0 SpD Ampharos: 108-128
+		assert.bounded(teraDamage, [108, 128],
 			"Terastralizing into the same type did not boost STAB; actual damage: " + teraDamage);
-		const nonTeraDamage = battle.p1.active[0].maxhp - battle.p1.active[0].maxhp;
+		const nonTeraDamage = battle.p1.active[0].maxhp - battle.p1.active[0].hp;
+		// 0 SpA Ampharos Shock Wave vs. 0 HP / 0 SpD Ampharos: 40-48
 		assert.bounded(nonTeraDamage, [40, 48],
 			"Terastralizing did not keep old type's STAB; actual damage: " + teraDamage);
 	});

--- a/test/sim/misc/terastal.js
+++ b/test/sim/misc/terastal.js
@@ -11,8 +11,8 @@ describe("Terastallization", function () {
 	});
 
 	// Don't know why this is failing
-	it.skip('should change the user\'s type to its Tera type after terastallizing', function () {
-		battle = common.createBattle({formatid: 'gen9oubeta'});
+	it('should change the user\'s type to its Tera type after terastallizing', function () {
+		battle = common.createBattle();
 		battle.setPlayer('p1', {team: [
 			{species: 'Ampharos', ability: 'static', moves: ['voltswitch', 'dragonpulse'], teraType: 'Dragon'},
 		]});
@@ -25,8 +25,8 @@ describe("Terastallization", function () {
 
 	// TODO test if actual mechanic
 	// Don't know why this is failing
-	it.skip('should persist the user\'s changed type after switching', function () {
-		battle = common.createBattle({formatid: 'gen9oubeta'});
+	it('should persist the user\'s changed type after switching', function () {
+		battle = common.createBattle();
 		battle.setPlayer('p1', {team: [
 			{species: 'Ampharos', ability: 'static', moves: ['voltswitch', 'dragonpulse'], teraType: 'Dragon'},
 			{species: 'Flaaffy', ability: 'static', moves: ['voltswitch', 'dragonpulse'], teraType: 'Electric'},
@@ -38,5 +38,22 @@ describe("Terastallization", function () {
 		assert.equal(battle.p1.active[0].getTypes().join('/'), 'Dragon');
 		battle.makeChoices('switch 2', 'move voltswitch');
 		assert.equal(battle.p1.pokemon[1].getTypes().join('/'), 'Dragon');
+	});
+
+	it.skip('should give STAB correctly to the user\'s old types', function () {
+		battle = common.createBattle();
+		battle.setPlayer('p1', {team: [
+			{species: 'Ampharos', ability: 'static', moves: ['shockwave', 'swift'], teraType: 'Electric'},
+		]});
+		battle.setPlayer('p2', {team: [
+			{species: 'Ampharos', ability: 'static', moves: ['shockwave', 'swift'], teraType: 'Normal'},
+		]});
+		battle.makeChoices('move shockwave terastallize', 'move shockwave terastallize');
+		const teraDamage = battle.p2.active[0].maxhp - battle.p2.active[0].maxhp;
+		assert.bounded(teraDamage, [54, 64],
+			"Terastralizing into the same type did not boost STAB; actual damage: " + teraDamage);
+		const nonTeraDamage = battle.p1.active[0].maxhp - battle.p1.active[0].maxhp;
+		assert.bounded(nonTeraDamage, [40, 48],
+			"Terastralizing did not keep old type's STAB; actual damage: " + teraDamage);
 	});
 });

--- a/test/sim/misc/terastal.js
+++ b/test/sim/misc/terastal.js
@@ -10,7 +10,6 @@ describe("Terastallization", function () {
 		battle.destroy();
 	});
 
-	// Don't know why this is failing
 	it('should change the user\'s type to its Tera type after terastallizing', function () {
 		battle = common.createBattle();
 		battle.setPlayer('p1', {team: [
@@ -24,7 +23,6 @@ describe("Terastallization", function () {
 	});
 
 	// TODO test if actual mechanic
-	// Don't know why this is failing
 	it('should persist the user\'s changed type after switching', function () {
 		battle = common.createBattle();
 		battle.setPlayer('p1', {team: [

--- a/test/sim/misc/weather.js
+++ b/test/sim/misc/weather.js
@@ -37,7 +37,7 @@ describe('Weather damage calculation', function () {
 	});
 
 	it('should make Hail/Sandstorm damage some pokemon but not others', function () {
-		battle = common.createBattle();
+		battle = common.gen(8).createBattle();
 		battle.randomizer = dmg => dmg; // max damage
 		battle.setPlayer('p1', {team: [{species: 'Abomasnow', ability: 'snowwarning', moves: ['protect']}]});
 		battle.setPlayer('p2', {team: [{species: 'Sandslash', ability: 'sandveil', moves: ['protect']}]});

--- a/test/sim/moves/focuspunch.js
+++ b/test/sim/moves/focuspunch.js
@@ -112,7 +112,7 @@ describe('Focus Punch', function () {
 	});
 
 	it(`should not tighten the Pokemon's focus when Dynamaxing or already Dynamaxed`, function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: 'Chansey', moves: ['focuspunch']},
 		], [
 			{species: 'Venusaur', moves: ['magicalleaf']},

--- a/test/sim/moves/gmaxchistrike.js
+++ b/test/sim/moves/gmaxchistrike.js
@@ -12,7 +12,7 @@ describe('G-Max Chi Strike', function () {
 
 	it('should boost the user and its ally\'s critical hit rate by 1 stage', function () {
 		// hardcoded RNG seed that doesn't roll a crit at +2 crit rate
-		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
+		battle = common.gen(8).createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
 			{species: 'Machamp', moves: ['sleeptalk', 'rocksmash'], gigantamax: true},
 			{species: 'Wynaut', ability: "Super Luck", item: "Scope Lens", moves: ['tackle']},
 		], [
@@ -27,7 +27,7 @@ describe('G-Max Chi Strike', function () {
 
 	it('should provide a crit boost independent of Focus Energy', function () {
 		// hardcoded RNG seed that doesn't roll a crit at +2 crit rate
-		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
+		battle = common.gen(8).createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
 			{species: 'Machamp', moves: ['sleeptalk', 'rocksmash'], gigantamax: true},
 			{species: 'Wynaut', moves: ['focusenergy', 'tackle']},
 		], [
@@ -44,7 +44,7 @@ describe('G-Max Chi Strike', function () {
 
 	it('should be copied by Psych Up', function () {
 		// hardcoded RNG seed ensures Magikarp will not crit at +0
-		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
+		battle = common.gen(8).createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
 			{species: 'Machamp', moves: ['rocksmash', 'sleeptalk'], gigantamax: true},
 			{species: 'Wynaut', moves: ['sleeptalk']},
 			{species: 'Magikarp', moves: ['psychup', 'tackle']},
@@ -66,7 +66,7 @@ describe('G-Max Chi Strike', function () {
 
 	it('should not be passed by Baton Pass', function () {
 		// hardcoded RNG seed ensures Magikarp will not crit at +0
-		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
+		battle = common.gen(8).createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
 			{species: 'Machamp', moves: ['rocksmash', 'batonpass'], gigantamax: true},
 			{species: 'Wynaut', moves: ['sleeptalk']},
 			{species: 'Magikarp', moves: ['tackle']},

--- a/test/sim/moves/gmaxsteelsurge.js
+++ b/test/sim/moves/gmaxsteelsurge.js
@@ -11,7 +11,7 @@ describe('G-Max Steelsurge', function () {
 	});
 
 	it(`should deal 2x damage to Eiscue and Mimikyu`, function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: 'Pyukumuku', moves: ['uturn']},
 			{species: 'Eiscue', ability: 'iceface', moves: ['splash']},
 			{species: 'Mimikyu', ability: 'disguise', moves: ['splash']},

--- a/test/sim/moves/gmaxvolcalith.js
+++ b/test/sim/moves/gmaxvolcalith.js
@@ -11,7 +11,7 @@ describe('G-Max Volcalith', function () {
 	});
 
 	it(`should not damage Rock-types`, function () {
-		battle = common.createBattle({gameType: 'doubles'}, [[
+		battle = common.gen(8).createBattle({gameType: 'doubles'}, [[
 			{species: 'Coalossal', moves: ['rockthrow'], gigantamax: true},
 			{species: 'Wynaut', moves: ['sleeptalk']},
 		], [
@@ -24,7 +24,7 @@ describe('G-Max Volcalith', function () {
 	});
 
 	it(`should deal damage for four turns, including the fourth turn`, function () {
-		battle = common.createBattle({gameType: 'doubles'}, [[
+		battle = common.gen(8).createBattle({gameType: 'doubles'}, [[
 			{species: 'Coalossal', moves: ['sleeptalk', 'rockthrow'], gigantamax: true},
 			{species: 'Wynaut', moves: ['sleeptalk']},
 		], [
@@ -40,7 +40,7 @@ describe('G-Max Volcalith', function () {
 	});
 
 	it.skip(`should deal damage alongside Sea of Fire or G-Max Wildfire in the order those field effects were set`, function () {
-		battle = common.createBattle({gameType: 'doubles'}, [[
+		battle = common.gen(8).createBattle({gameType: 'doubles'}, [[
 			{species: 'Coalossal', item: 'Eject Button', moves: ['rockthrow', 'sleeptalk'], gigantamax: true},
 			{species: 'Wynaut', moves: ['sleeptalk', 'grasspledge']},
 			{species: 'Wynaut', moves: ['sleeptalk', 'firepledge']},
@@ -61,7 +61,7 @@ describe('G-Max Volcalith', function () {
 	});
 
 	it(`should damage Pokemon in order of Speed`, function () {
-		battle = common.createBattle({gameType: 'doubles'}, [[
+		battle = common.gen(8).createBattle({gameType: 'doubles'}, [[
 			{species: 'Coalossal', moves: ['sleeptalk', 'rockthrow'], gigantamax: true},
 			{species: 'Wynaut', moves: ['sleeptalk']},
 		], [
@@ -83,7 +83,7 @@ describe('G-Max Volcalith', function () {
 	});
 
 	it(`should deal damage before Black Sludge recovery/damage`, function () {
-		battle = common.createBattle({gameType: 'doubles'}, [[
+		battle = common.gen(8).createBattle({gameType: 'doubles'}, [[
 			{species: 'Coalossal', moves: ['sleeptalk', 'rockthrow'], gigantamax: true},
 			{species: 'Wynaut', moves: ['sleeptalk']},
 		], [
@@ -97,7 +97,7 @@ describe('G-Max Volcalith', function () {
 	});
 
 	it(`should deal damage before Grassy Terrain recovery`, function () {
-		battle = common.createBattle({gameType: 'doubles'}, [[
+		battle = common.gen(8).createBattle({gameType: 'doubles'}, [[
 			{species: 'Coalossal', moves: ['sleeptalk', 'rockthrow'], gigantamax: true},
 			{species: 'Wynaut', moves: ['sleeptalk']},
 		], [

--- a/test/sim/moves/gmaxwildfire.js
+++ b/test/sim/moves/gmaxwildfire.js
@@ -11,7 +11,7 @@ describe('G-Max Wildfire', function () {
 	});
 
 	it('should not damage Fire-types', function () {
-		battle = common.createBattle({gameType: 'doubles'});
+		battle = common.gen(8).createBattle({gameType: 'doubles'});
 		battle.setPlayer('p1', {team: [
 			{species: 'Charizard', moves: ['ember'], gigantamax: true},
 			{species: 'Wynaut', moves: ['sleeptalk']},
@@ -25,7 +25,7 @@ describe('G-Max Wildfire', function () {
 	});
 
 	it('should deal damage for four turns, including the fourth turn', function () {
-		battle = common.createBattle({gameType: 'doubles'});
+		battle = common.gen(8).createBattle({gameType: 'doubles'});
 		battle.setPlayer('p1', {team: [
 			{species: 'Charizard', moves: ['ember', 'sleeptalk'], gigantamax: true},
 			{species: 'Wynaut', moves: ['sleeptalk']},

--- a/test/sim/moves/maxguard.js
+++ b/test/sim/moves/maxguard.js
@@ -11,7 +11,7 @@ describe('Max Guard', function () {
 	});
 
 	it('should be disallowed by Taunt', function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: "Feebas", moves: ['splash', 'tackle']},
 		], [
 			{species: "Wynaut", moves: ['taunt', 'splash']},
@@ -21,7 +21,7 @@ describe('Max Guard', function () {
 	});
 
 	it('should allow Feint to damage the user, but not break the protection effect', function () {
-		battle = common.createBattle({gameType: 'doubles'}, [[
+		battle = common.gen(8).createBattle({gameType: 'doubles'}, [[
 			{species: 'minun', moves: ['sleeptalk']},
 			{species: 'plusle', moves: ['sleeptalk']},
 		], [
@@ -35,7 +35,7 @@ describe('Max Guard', function () {
 	});
 
 	it('should block certain moves that bypass Protect', function () {
-		battle = common.createBattle({gameType: 'doubles'}, [[
+		battle = common.gen(8).createBattle({gameType: 'doubles'}, [[
 			{species: 'sunflora', item: 'sitrusberry', ability: 'minus', moves: ['sleeptalk']},
 			{species: 'plusle', ability: 'plus', moves: ['magneticflux', 'gearup']},
 		], [

--- a/test/sim/moves/painsplit.js
+++ b/test/sim/moves/painsplit.js
@@ -19,7 +19,7 @@ describe('Pain Split', function () {
 	});
 
 	it('should calculate HP changes against a dynamaxed target properly', function () {
-		battle = common.createBattle();
+		battle = common.gen(8).createBattle();
 		battle.setPlayer('p1', {team: [{species: 'Drifblim', ability: 'unburden', moves: ['painsplit']}]});
 		battle.setPlayer('p2', {team: [{species: 'Blissey', ability: 'serenegrace', moves: ['doubleedge']}]});
 

--- a/test/sim/moves/photongeyser.js
+++ b/test/sim/moves/photongeyser.js
@@ -35,7 +35,7 @@ describe(`Photon Geyser`, function () {
 	});
 
 	it(`should always be a special Max Move, never physical`, function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: 'conkeldurr', moves: ['photongeyser']},
 		], [
 			{species: 'cresselia', item: 'marangaberry', moves: ['sleeptalk']},

--- a/test/sim/moves/shelltrap.js
+++ b/test/sim/moves/shelltrap.js
@@ -43,7 +43,7 @@ describe('Shell Trap', function () {
 	});
 
 	it('should not Max if hit by a Max move', function () {
-		battle = common.createBattle({}, [
+		battle = common.gen(8).createBattle({}, [
 			[{species: 'Turtonator', moves: ['shelltrap']}],
 			[{species: 'Magikarp', moves: ['flail']}],
 		]);

--- a/test/sim/moves/spite.js
+++ b/test/sim/moves/spite.js
@@ -24,7 +24,7 @@ describe('Spite', function () {
 
 	// Eerie Spell and G-Max Depletion should also behave this way
 	it(`should succeed on Max Moves, and announce the base move that PP was deducted from`, function () {
-		battle = common.createBattle([[
+		battle = common.gen(8).createBattle([[
 			{species: 'Gengar', moves: ['shadowball']},
 		], [
 			{species: 'Snorlax', moves: ['spite']},


### PR DESCRIPTION
* Default gen is now Gen 9
* Tests specifically for Dynamax and other legacy mechanics were kept Gen 8
* FFA/Multi will continue to target Gen 8
* A couple tests I wasn't sure how to transition so I left a TODO notice