### PR TITLE
Gen 1: Fix Wrap when hitting a substitute

### DIFF
--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -827,9 +827,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				// Substitute, here we deliberately use the uncapped damage when tracking lastDamage etc.
 				// Also, multi-hit moves must always deal the same damage as the first hit for any subsequent hits
 				let uncappedDamage = move.hit > 1 ? source.lastDamage : this.actions.getDamage(source, target, move);
-				if (!uncappedDamage) return null;
+				if (!uncappedDamage && uncappedDamage !== 0) return null;
 				uncappedDamage = this.runEvent('SubDamage', target, source, move, uncappedDamage);
-				if (!uncappedDamage) return uncappedDamage;
+				if (!uncappedDamage && uncappedDamage !== 0) return uncappedDamage;
 				source.lastDamage = uncappedDamage;
 				this.lastDamage = uncappedDamage;
 				target.volatiles['substitute'].hp -= uncappedDamage > target.volatiles['substitute'].hp ?

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -438,6 +438,11 @@ export const Scripts: ModdedBattleScriptsData = {
 				// Handle here the applying of partial trapping moves to Pokémon with Substitute
 				if (targetSub && moveData.volatileStatus && moveData.volatileStatus === 'partiallytrapped') {
 					target.addVolatile(moveData.volatileStatus, pokemon, move);
+					if (!pokemon.volatiles['partialtrappinglock'] || pokemon.volatiles['partialtrappinglock'].duration > 1) {
+						target.volatiles[moveData.volatileStatus].duration = 2;
+					} else {
+						target.volatiles[moveData.volatileStatus].duration = 1;
+					}
 				}
 
 				if (!hitResult) {

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -440,8 +440,6 @@ export const Scripts: ModdedBattleScriptsData = {
 					target.addVolatile(moveData.volatileStatus, pokemon, move);
 					if (!pokemon.volatiles['partialtrappinglock'] || pokemon.volatiles['partialtrappinglock'].duration > 1) {
 						target.volatiles[moveData.volatileStatus].duration = 2;
-					} else {
-						target.volatiles[moveData.volatileStatus].duration = 1;
 					}
 				}
 

--- a/data/mods/gen1jpn/moves.ts
+++ b/data/mods/gen1jpn/moves.ts
@@ -80,9 +80,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				// Substitute, here we deliberately use the uncapped damage when tracking lastDamage etc.
 				// Also, multi-hit moves must always deal the same damage as the first hit for any subsequent hits
 				let uncappedDamage = move.hit > 1 ? source.lastDamage : this.actions.getDamage(source, target, move);
-				if (!uncappedDamage) return null;
+				if (!uncappedDamage && uncappedDamage !== 0) return null;
 				uncappedDamage = this.runEvent('SubDamage', target, source, move, uncappedDamage);
-				if (!uncappedDamage) return uncappedDamage;
+				if (!uncappedDamage && uncappedDamage !== 0) return uncappedDamage;
 				source.lastDamage = uncappedDamage;
 				this.lastDamage = uncappedDamage;
 				target.volatiles['substitute'].hp -= uncappedDamage > target.volatiles['substitute'].hp ?

--- a/data/mods/gen1stadium/moves.ts
+++ b/data/mods/gen1stadium/moves.ts
@@ -248,9 +248,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				}
 				if (move.volatileStatus && target === source) return;
 				let damage = this.actions.getDamage(source, target, move);
-				if (!damage) return null;
+				if (!damage && damage !== 0) return null;
 				damage = this.runEvent('SubDamage', target, source, move, damage);
-				if (!damage) return damage;
+				if (!damage && damage !== 0) return damage;
 				target.volatiles['substitute'].hp -= damage;
 				source.lastDamage = damage;
 				this.lastDamage = damage;

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -389,6 +389,9 @@ export const Scripts: ModdedBattleScriptsData = {
 				const targetHadSub = !!target.volatiles['substitute'];
 				if (targetHadSub && moveData.volatileStatus && moveData.volatileStatus === 'partiallytrapped') {
 					target.addVolatile(moveData.volatileStatus, pokemon, move);
+					if (!pokemon.volatiles['partialtrappinglock'] || pokemon.volatiles['partialtrappinglock'].duration > 1) {
+						target.volatiles[moveData.volatileStatus].duration = 2;
+					}
 				}
 
 				if (!hitResult) {


### PR DESCRIPTION
This patch fixes the behavior of Wrap when it hits a substitute. Previously, a faster target with substitute up would be able to attack every second turn when being wrapped, and there were some other inaccurate behaviors as well.

https://www.smogon.com/forums/threads/rby-tradebacks-bug-report-thread.3524844/page-11#post-6893249
https://www.smogon.com/forums/threads/rby-tradebacks-bug-report-thread.3524844/page-14#post-8442413
https://www.smogon.com/forums/threads/rby-tradebacks-bug-report-thread.3524844/page-15#post-8622471
https://www.smogon.com/forums/threads/rby-tradebacks-bug-report-thread.3524844/page-16#post-8999638

scripts.ts: By resetting the duration of the target's partial trapping every time Wrap hits the target's substitute, we ensure that the target will remain partially trapped until Wrap ends. Previously, a faster target would be able to attack every second turn as the duration decreased from 2 to 0.

moves.ts: Wrap hitting a Ghost type's substitute will be treated as a hit, resulting in the same partial trapping as with hitting a non-Ghost type.