### PR TITLE
Update Bisharp/Primeape evolution conditions

### DIFF
--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -17976,7 +17976,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Black",
 		prevo: "Bisharp",
 		evoType: "other",
-		evoCondition: "Defeat 3 Bisharp holding Leader's Crest while holding Leader's Crest",
+		evoCondition: "Defeat 3 Bisharp holding Leader's Crest and level-up",
 		eggGroups: ["Human-Like"],
 	},
 	clodsire: {
@@ -18003,7 +18003,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Gray",
 		prevo: "Primeape",
 		evoType: "other",
-		evoCondition: "Use Rage Fist 20 times",
+		evoCondition: "Use Rage Fist 20 times and level-up",
 		eggGroups: ["Field"],
 	},
 	missingno: {

--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -17976,7 +17976,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		color: "Black",
 		prevo: "Bisharp",
 		evoType: "other",
-		evoCondition: "Defeat 3 Bisharp holding Leader's Crest and level-up",
+		evoCondition: "Defeat 3 Bisharp leading Pawniard and level-up",
 		eggGroups: ["Human-Like"],
 	},
 	clodsire: {


### PR DESCRIPTION
All the new gen 9 evolution methods require a level up after satisfying the conditions; it's not an automatic evolve like Galarian Farfetch'd. Not sure where else this ought to be added.

Demo that Bisharp can evolve without Leader's Crest: https://twitter.com/Sibuna_Switch/status/1594022357030551556