### PR TITLE
Clean Toxic Debris desc

### DIFF
--- a/data/text/abilities.ts
+++ b/data/text/abilities.ts
@@ -1879,8 +1879,8 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 	},
 	toxicdebris: {
 		name: "Toxic Debris",
-		desc: "When this Pokemon is hit by an attack, Toxic Spikes are set on the opposing side of the field.",
-		shortDesc: "When this Pokemon is hit by an attack, Toxic Spikes are set around the attacker.",
+		desc: "When this Pokemon is hit by a physical attack, Toxic Spikes are set on the opposing side of the field.",
+		shortDesc: "When this Pokemon is hit by a physical attack, Toxic Spikes are set around the attacker.",
 	},
 	trace: {
 		name: "Trace",


### PR DESCRIPTION
Specify physical attacks, special attacks don't trigger Toxic Debris. Moves do not need to make contact.  
It functions correctly but the description is vague and might confuse people.