### PR TITLE
Gen 1: Sonic Boom can hit Ghost-types

### DIFF
--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -756,6 +756,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			status: 'psn',
 		},
 	},
+	sonicboom: {
+		inherit: true,
+		ignoreImmunity: true,
+	},
 	softboiled: {
 		inherit: true,
 		heal: null,


### PR DESCRIPTION
In Gen 1, Sonic Boom can hit Ghost-types, which is not currently implemented. Mentioned here and in many other places, and confirmed with in-game testing:

https://www.smogon.com/forums/threads/mechanics-differences-between-generations.3668073/post-8553244