### PR TITLE
Fix various Ability related issues

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -1036,6 +1036,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				return null;
 			}
 		},
+		isBreakable: true,
 		name: "Earth Eater",
 		rating: 3,
 		num: 297,
@@ -1424,6 +1425,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			this.add('-ability', target, 'Good as Gold');
 			return null;
 		},
+		isBreakable: true,
 		name: "Good as Gold",
 		rating: 2,
 		num: 283,
@@ -1515,11 +1517,10 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			this.add('-activate', pokemon, 'ability: Guard Dog');
 			return null;
 		},
-		// TODO Assuming this means it just undoes the stat drop, check and correct this if needed.
 		onBoost(boost, target, source, effect) {
 			if (effect.name === 'Intimidate') {
 				delete boost.atk;
-				this.add('-fail', target, 'unboost', 'Attack', '[from] ability: Guard Dog', '[of] ' + target);
+				this.boost({atk: 1}, target, target, null, false, true);
 			}
 		},
 		name: "Guard Dog",
@@ -3175,21 +3176,25 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				this.effectState.bestStat = pokemon.getBestStoredStat();
 				this.add('-start', pokemon, 'protosynthesis' + this.effectState.bestStat);
 			},
+			onModifyAtkPriority: 5,
 			onModifyAtk(atk, source, target, move) {
 				if (this.effectState.bestStat !== 'atk') return;
 				this.debug('Protosynthesis atk boost');
 				return this.chainModify(1.5);
 			},
+			onModifyDefPriority: 6,
 			onModifyDef(def, target, source, move) {
 				if (this.effectState.bestStat !== 'def') return;
 				this.debug('Protosynthesis def boost');
 				return this.chainModify(1.5);
 			},
+			onModifySpAPriority: 5,
 			onModifySpA(relayVar, source, target, move) {
 				if (this.effectState.bestStat !== 'spa') return;
 				this.debug('Protosynthesis spa boost');
 				return this.chainModify(1.5);
 			},
+			onModifySpDPriority: 6,
 			onModifySpD(relayVar, target, source, move) {
 				if (this.effectState.bestStat !== 'spd') return;
 				this.debug('Protosynthesis spd boost');
@@ -3303,21 +3308,25 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				this.effectState.bestStat = pokemon.getBestStoredStat();
 				this.add('-start', pokemon, 'quarkdrive' + this.effectState.bestStat);
 			},
+			onModifyAtkPriority: 5,
 			onModifyAtk(atk, source, target, move) {
 				if (this.effectState.bestStat !== 'atk') return;
 				this.debug('Quark Drive atk boost');
 				return this.chainModify(1.5);
 			},
+			onModifyDefPriority: 6,
 			onModifyDef(def, target, source, move) {
 				if (this.effectState.bestStat !== 'def') return;
 				this.debug('Quark Drive def boost');
 				return this.chainModify(1.5);
 			},
+			onModifySpAPriority: 5,
 			onModifySpA(relayVar, source, target, move) {
 				if (this.effectState.bestStat !== 'spa') return;
 				this.debug('Quark Drive spa boost');
 				return this.chainModify(1.5);
 			},
+			onModifySpDPriority: 6,
 			onModifySpD(relayVar, target, source, move) {
 				if (this.effectState.bestStat !== 'spd') return;
 				this.debug('Quark Drive spd boost');

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -3168,7 +3168,8 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			}
 		},
 		onEnd(pokemon) {
-			pokemon.removeVolatile('protosynthesis');
+			delete pokemon.volatiles['protosynthesis'];
+			this.add('-end', pokemon, 'Protosynthesis', '[silent]');
 		},
 		condition: {
 			noCopy: true,
@@ -3300,7 +3301,8 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			}
 		},
 		onEnd(pokemon) {
-			pokemon.removeVolatile('quarkdrive');
+			delete pokemon.volatiles['quarkdrive'];
+			this.add('-end', pokemon, 'Quark Drive', '[silent]');
 		},
 		condition: {
 			noCopy: true,

--- a/data/text/abilities.ts
+++ b/data/text/abilities.ts
@@ -661,13 +661,21 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 	},
 	icebody: {
 		name: "Ice Body",
-		desc: "If Hail is active, this Pokemon restores 1/16 of its maximum HP, rounded down, at the end of each turn. This Pokemon takes no damage from Hail.",
-		shortDesc: "If Hail is active, this Pokemon heals 1/16 of its max HP each turn; immunity to Hail.",
+		desc: "If Snow is active, this Pokemon restores 1/16 of its maximum HP, rounded down, at the end of each turn.",
+		shortDesc: "If Snow is active, this Pokemon heals 1/16 of its max HP each turn.",
+		gen8: {
+			desc: "If Hail is active, this Pokemon restores 1/16 of its maximum HP, rounded down, at the end of each turn. This Pokemon takes no damage from Hail.",
+			shortDesc: "If Hail is active, this Pokemon heals 1/16 of its max HP each turn; immunity to Hail.",
+		},
 	},
 	iceface: {
 		name: "Ice Face",
-		desc: "If this Pokemon is an Eiscue, the first physical hit it takes in battle deals 0 neutral damage. Its ice face is then broken and it changes forme to Noice Face. Eiscue regains its Ice Face forme when Hail begins or when Eiscue switches in while Hail is active. Confusion damage also breaks the ice face.",
-		shortDesc: "If Eiscue, the first physical hit it takes deals 0 damage. This effect is restored in Hail.",
+		desc: "If this Pokemon is an Eiscue, the first physical hit it takes in battle deals 0 neutral damage. Its ice face is then broken and it changes forme to Noice Face. Eiscue regains its Ice Face forme when Snow begins or when Eiscue switches in while Snow is active. Confusion damage also breaks the ice face.",
+		shortDesc: "If Eiscue, the first physical hit it takes deals 0 damage. This effect is restored in Snow.",
+		gen8: {
+			desc: "If this Pokemon is an Eiscue, the first physical hit it takes in battle deals 0 neutral damage. Its ice face is then broken and it changes forme to Noice Face. Eiscue regains its Ice Face forme when Hail begins or when Eiscue switches in while Hail is active. Confusion damage also breaks the ice face.",
+			shortDesc: "If Eiscue, the first physical hit it takes deals 0 damage. This effect is restored in Hail.",
+		},
 	},
 	icescales: {
 		name: "Ice Scales",
@@ -1088,8 +1096,12 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 	},
 	overcoat: {
 		name: "Overcoat",
-		desc: "This Pokemon is immune to powder moves, damage from Sandstorm or Hail, and the effects of Rage Powder and the Effect Spore Ability.",
-		shortDesc: "This Pokemon is immune to powder moves, Sandstorm or Hail damage, Effect Spore.",
+		desc: "This Pokemon is immune to powder moves, damage from Sandstorm, and the effects of Rage Powder and the Effect Spore Ability.",
+		shortDesc: "This Pokemon is immune to powder moves, Sandstorm damage, and Effect Spore.",
+		gen8: {
+			desc: "This Pokemon is immune to powder moves, damage from Sandstorm or Hail, and the effects of Rage Powder and the Effect Spore Ability.",
+			shortDesc: "This Pokemon is immune to powder moves, Sandstorm or Hail damage, Effect Spore.",
+		},
 		gen5: {
 			desc: "This Pokemon is immune to damage from Sandstorm or Hail.",
 			shortDesc: "This Pokemon is immune to damage from Sandstorm or Hail.",
@@ -1569,7 +1581,10 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 	},
 	slushrush: {
 		name: "Slush Rush",
-		shortDesc: "If Hail is active, this Pokemon's Speed is doubled.",
+		shortDesc: "If Snow is active, this Pokemon's Speed is doubled.",
+		gen8: {
+			shortDesc: "If Hail is active, this Pokemon's Speed is doubled.",
+		},
 	},
 	sniper: {
 		name: "Sniper",
@@ -1577,12 +1592,19 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 	},
 	snowcloak: {
 		name: "Snow Cloak",
-		desc: "If Hail is active, the accuracy of moves used against this Pokemon is multiplied by 0.8. This Pokemon takes no damage from Hail.",
-		shortDesc: "If Hail is active, this Pokemon's evasiveness is 1.25x; immunity to Hail.",
+		desc: "If Snow is active, the accuracy of moves used against this Pokemon is multiplied by 0.8.",
+		shortDesc: "If Snow is active, this Pokemon's evasiveness is 1.25x.",
+		gen8: {
+			desc: "If Hail is active, the accuracy of moves used against this Pokemon is multiplied by 0.8. This Pokemon takes no damage from Hail.",
+			shortDesc: "If Hail is active, this Pokemon's evasiveness is 1.25x; immunity to Hail.",
+		},
 	},
 	snowwarning: {
 		name: "Snow Warning",
-		shortDesc: "On switch-in, this Pokemon summons Hail.",
+		shortDesc: "On switch-in, this Pokemon summons Snow.",
+		gen8: {
+			shortDesc: "On switch-in, this Pokemon summons Hail.",
+		},
 	},
 	solarpower: {
 		name: "Solar Power",
@@ -1880,8 +1902,8 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 	},
 	toxicdebris: {
 		name: "Toxic Debris",
-		desc: "When this Pokemon is hit by an attack, Toxic Spikes are set on the opposing side of the field.",
-		shortDesc: "When this Pokemon is hit by an attack, Toxic Spikes are set around the attacker.",
+		desc: "When this Pokemon is hit by a physical attack, Toxic Spikes are set on the opposing side of the field.",
+		shortDesc: "When this Pokemon is hit by a physical attack, Toxic Spikes are set around the attacker.",
 	},
 	trace: {
 		name: "Trace",

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -434,6 +434,7 @@ interface TextFile extends TextObject {
 	gen5?: ModdedTextObject;
 	gen6?: ModdedTextObject;
 	gen7?: ModdedTextObject;
+	gen8?: ModdedTextObject;
 }
 
 interface MovePlines extends Plines {


### PR DESCRIPTION
- Allow Mold Breaker to bypass Earth Eater and Good as Gold
- Make Guard Dog boost attack after Intimidate
- Remove all mentions of Hail from ability descriptions
- Add priorities to Protosynthesis/Quark Drive stat boosting events, and silently end those abilities in the `onEnd` event