### PR TITLE
sim/dex: G-Max Move Handling Changed Unexpectedly With Gen 9 Update

### DIFF
--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -565,7 +565,8 @@ export class DataMove extends BasicEffect implements Readonly<BasicEffect & Move
 		}
 
 		if (!this.gen) {
-			if (this.num >= 827) {
+			// special handling for gen8 gmax moves (all of them have num 1000 but they are part of gen8)
+			if (this.num >= 827 && !this.isMax) {
 				this.gen = 9;
 			} else if (this.num >= 743) {
 				this.gen = 8;

--- a/test/sim/dex.js
+++ b/test/sim/dex.js
@@ -71,3 +71,11 @@ describe('Dex#getItem', function () {
 		assert.equal(Dex.forGen(8).items.get('Rock Gem').isNonstandard, "Past");
 	});
 });
+
+describe('Dex#getMove', function () {
+	it(`should correctly handle G-Max moves`, function () {
+		assert.equal(Dex.forGen(8).moves.get('G-Max Befuddle').name, "G-Max Befuddle");
+		assert.equal(Dex.forGen(8).moves.get('G-Max Befuddle').gen, 8);
+		assert.equal(Dex.forGen(8).moves.get('G-Max Befuddle').isNonstandard, "Gigantamax");
+	});
+});


### PR DESCRIPTION
In https://github.com/smogon/pokemon-showdown/blob/master/data/moves.ts#L6756 G-Max moves are classified as `isNonstandard: "Gigantamax"` but after the gen 9 update they are now reporting `gen: 9` and as a consequence `isNonstandard: "Future"`.

I added 3 tests to illustrate the problem and the last two fail in master right now.
```js
assert.equal(Dex.forGen(8).moves.get('G-Max Befuddle').gen, 8); // is 9
assert.equal(Dex.forGen(8).moves.get('G-Max Befuddle').isNonstandard, "Gigantamax"); // is "Future"
```

The reason is in https://github.com/smogon/pokemon-showdown/blob/master/sim/dex-moves.ts#L568 where all moves with num >= 827 are assumed to be gen 9. But since all gmax moves have a dummy num of 1000 they are considered to be gen 9.

I added a quick fix to work around that. This will likely come back with every new gen and especially if "normal" moves reach num 1000.

Please let me know if you would accept this PR and/or if I should change/add anything.

Slightly related question: With max moves being changed to `isNonstandard: "Past"` and then being reset to `isNonstandard: null` in the gen8 mod, shouldn't the same (or something similar) be done with gmax moves?