### PR TITLE
Fix Chilly Reception failing with no switches left

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2348,11 +2348,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {},
-		onTry(source) {
-			return !!this.canSwitch(source.side);
-		},
-		selfSwitch: true,
+		// TODO show prepare message before the "POKEMON used MOVE!" message
+		// This happens even before sleep shows its "POKEMON is fast asleep." message
 		weather: 'snow',
+		selfSwitch: true,
 		secondary: null,
 		target: "all",
 		type: "Ice",

--- a/data/text/moves.ts
+++ b/data/text/moves.ts
@@ -846,7 +846,7 @@ export const MovesText: {[k: string]: MoveText} = {
 	},
 	chillyreception: {
 		name: "Chilly Reception",
-		desc: "Starts Snow. If this move is successful and the user has not fainted, the user switches out even if it is trapped and is replaced immediately by a selected party member. The user does not switch out if there are no unfainted party members.",
+		desc: "Starts Snow. The user switches out even if it is trapped and is replaced immediately by a selected party member. The user does not switch out if there are no unfainted party members.",
 		shortDesc: "Starts Snow. User switches out.",
 
 		// TODO needs to be implemented

--- a/data/text/moves.ts
+++ b/data/text/moves.ts
@@ -846,8 +846,11 @@ export const MovesText: {[k: string]: MoveText} = {
 	},
 	chillyreception: {
 		name: "Chilly Reception",
-		desc: "Snow begins. If this move is successful and the user has not fainted, the user switches out even if it is trapped and is replaced immediately by a selected party member. The user does not switch out if there are no unfainted party members.",
-		shortDesc: "Snowscape begins. User switches out.",
+		desc: "Starts Snow. If this move is successful and the user has not fainted, the user switches out even if it is trapped and is replaced immediately by a selected party member. The user does not switch out if there are no unfainted party members.",
+		shortDesc: "Starts Snow. User switches out.",
+
+		// TODO needs to be implemented
+		activate: "  [POKEMON] is preparing to tell a chillingly bad joke!",
 	},
 	chipaway: {
 		name: "Chip Away",


### PR DESCRIPTION
Left a TODO comment to implement the "preparing to tell a bad joke" message, because that requires an event before `onBeforeMove` which we don't currently have.