### PR TITLE
Gen 1 Stadium: fix battle crashing when Wrap KOs an enemy

### DIFF
--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -130,6 +130,7 @@ export const Scripts: ModdedBattleScriptsData = {
 
 					// If target fainted
 					if (target && target.hp <= 0) {
+						delete pokemon.volatiles['partialtrappinglock'];
 						// We remove screens
 						target.side.removeSideCondition('reflect');
 						target.side.removeSideCondition('lightscreen');


### PR DESCRIPTION
This patch fixes an omission with a previous Wrap-related fix that could cause Stadium battles to crash when a wrapping move KOs an enemy.

Previous change: https://github.com/smogon/pokemon-showdown/pull/9007

Crash: https://replay.pokemonshowdown.com/gen1stadiumou-1717693225-ea0vym1qnuplwtvfsf9780bo9pcg4uipw