### PR TITLE
Gen 1: Fix Explosion not fainting user when target is semi-invulnerable

### DIFF
--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -240,14 +240,6 @@ export const Scripts: ModdedBattleScriptsData = {
 				this.battle.add('-notarget');
 				return true;
 			}
-
-			// Disable and Selfdestruct/Explosion boost rage, regardless of whether they miss/fail.
-			if (target.boosts.atk < 6 && (move.selfdestruct || move.id === 'disable') && target.volatiles['rage']) {
-				this.battle.boost({atk: 1}, target, pokemon, this.dex.conditions.get('rage'));
-				this.battle.hint(`In Gen 1, using ${move.name} causes the target to build Rage, ` +
-				`even if it misses or fails`, true);
-			}
-
 			damage = this.tryMoveHit(target, pokemon, move);
 
 			// Store 0 damage for last damage if move failed.
@@ -261,6 +253,13 @@ export const Scripts: ModdedBattleScriptsData = {
 				!neverDamageMoves.includes(move.id)
 			) {
 				this.battle.lastDamage = 0;
+			}
+
+			// Disable and Selfdestruct/Explosion boost rage, regardless of whether they miss/fail.
+			if (target.boosts.atk < 6 && (move.selfdestruct || move.id === 'disable') && target.volatiles['rage']) {
+				this.battle.boost({atk: 1}, target, pokemon, this.dex.conditions.get('rage'));
+				this.battle.hint(`In Gen 1, using ${move.name} causes the target to build Rage, ` +
+				`even if it misses or fails`, true);
 			}
 
 			// Go ahead with results of the used move.

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -240,6 +240,12 @@ export const Scripts: ModdedBattleScriptsData = {
 				this.battle.add('-notarget');
 				return true;
 			}
+
+			// Disable and Selfdestruct/Explosion boost rage, regardless of whether they miss/fail.
+			if (target.boosts.atk < 6 && (move.selfdestruct || move.id === 'disable') && target.volatiles['rage']) {
+				this.battle.boost({atk: 1}, target, pokemon, this.dex.conditions.get('rage'));
+			}
+
 			damage = this.tryMoveHit(target, pokemon, move);
 
 			// Store 0 damage for last damage if move failed.
@@ -253,11 +259,6 @@ export const Scripts: ModdedBattleScriptsData = {
 				!neverDamageMoves.includes(move.id)
 			) {
 				this.battle.lastDamage = 0;
-			}
-
-			// Disable and Selfdestruct/Explosion boost rage, regardless of whether they miss/fail.
-			if (target.boosts.atk < 6 && (move.selfdestruct || move.id === 'disable') && target.volatiles['rage']) {
-				this.battle.boost({atk: 1}, target, pokemon, this.dex.conditions.get('rage'));
 			}
 
 			// Go ahead with results of the used move.
@@ -282,6 +283,9 @@ export const Scripts: ModdedBattleScriptsData = {
 			if (hitResult === false) {
 				this.battle.attrLastMove('[miss]');
 				this.battle.add('-miss', pokemon);
+				if (move.selfdestruct) {
+					this.battle.faint(pokemon, pokemon, move);
+				}
 				return false;
 			}
 

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -244,6 +244,8 @@ export const Scripts: ModdedBattleScriptsData = {
 			// Disable and Selfdestruct/Explosion boost rage, regardless of whether they miss/fail.
 			if (target.boosts.atk < 6 && (move.selfdestruct || move.id === 'disable') && target.volatiles['rage']) {
 				this.battle.boost({atk: 1}, target, pokemon, this.dex.conditions.get('rage'));
+				this.battle.hint(`In Gen 1, using ${move.name} causes the target to build Rage, ` +
+				`even if it misses or fails`, true);
 			}
 
 			damage = this.tryMoveHit(target, pokemon, move);

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -130,6 +130,7 @@ export const Scripts: ModdedBattleScriptsData = {
 
 					// If target fainted
 					if (target && target.hp <= 0) {
+						delete pokemon.volatiles['partialtrappinglock'];
 						// We remove screens
 						target.side.removeSideCondition('reflect');
 						target.side.removeSideCondition('lightscreen');

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -130,7 +130,6 @@ export const Scripts: ModdedBattleScriptsData = {
 
 					// If target fainted
 					if (target && target.hp <= 0) {
-						delete pokemon.volatiles['partialtrappinglock'];
 						// We remove screens
 						target.side.removeSideCondition('reflect');
 						target.side.removeSideCondition('lightscreen');
@@ -247,6 +246,9 @@ export const Scripts: ModdedBattleScriptsData = {
 			if (hitResult === false) {
 				this.battle.attrLastMove('[miss]');
 				this.battle.add('-miss', pokemon);
+				if (move.selfdestruct) {
+					this.battle.faint(pokemon, pokemon, move);
+				}
 				return false;
 			}
 

--- a/test/sim/moves/explosion.js
+++ b/test/sim/moves/explosion.js
@@ -61,4 +61,15 @@ describe('Explosion', function () {
 		battle.makeChoices();
 		assert(battle.log.some(line => line.startsWith('|-boost|')));
 	});
+
+	it(`[Gen 1] Explosion should faint the user when the target is semi-invulnerable`, function () {
+		// Explosion hits
+		battle = common.gen(1).createBattle([[
+			{species: 'golem', moves: ['explosion']},
+		], [
+			{species: 'aerodactyl', moves: ['fly']},
+		]]);
+		battle.makeChoices();
+		assert.fainted(battle.p1.active[0]);
+	});
 });


### PR DESCRIPTION
This patch fixes Selfdestruct/Explosion when used against semi-invulnerable (Dig/Fly) enemies. Using Explosion should faint the user, but currently on Showdown it doesn't.

Also, adding a hint for the Disable/Explosion-Rage interaction.