### PR TITLE
Mark several forms as past gen only

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -3401,10 +3401,16 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		tier: "Illegal",
 		natDexTier: "OU",
 	},
+	darmanitanzen: {
+		isNonstandard: "Past",
+	},
 	darmanitangalar: {
 		isNonstandard: "Past",
 		tier: "Illegal",
 		natDexTier: "Uber",
+	},
+	darmanitangalarzen: {
+		isNonstandard: "Past",
 	},
 	maractus: {
 		isNonstandard: "Past",
@@ -4092,6 +4098,9 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		isNonstandard: "Past",
 		tier: "Illegal",
 		natDexTier: "OU",
+	},
+	aegislashblade: {
+		isNonstandard: "Past",
 	},
 	spritzee: {
 		isNonstandard: "Past",
@@ -5292,6 +5301,9 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		isNonstandard: "Past",
 		tier: "Illegal",
 		natDexTier: "OU",
+	},
+	morpekohangry: {
+		isNonstandard: "Past",
 	},
 	cufant: {
 		tier: "LC",


### PR DESCRIPTION
This change prevents these forms from being used in formats that ban nonexistent Pokemon but don't validate obtainable forms, such as Gen 9 Hackmons.

Reported here: https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-9403024