### PR TITLE
Gen 1: Fix Confusion/Psybeam confusion chance and substitute interaction

### DIFF
--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -856,6 +856,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 						const secondary = move.secondary;
 						if (secondary.chance === undefined || this.randomChance(Math.ceil(secondary.chance * 256 / 100) - 1, 256)) {
 							target.addVolatile(move.secondary.volatileStatus, source, move);
+							this.hint(
+								"In Gen 1, moves that inflict confusion as a secondary effect can confuse targets with a Substitute, " +
+								"as long as the move does not break the Substitute."
+							);
 						}
 					}
 				}

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -844,13 +844,19 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				} else {
 					this.add('-activate', target, 'Substitute', '[damage]');
 				}
-				// Drain/recoil does not happen if the substitute breaks
+				// Drain/recoil/secondary effect confusion do not happen if the substitute breaks
 				if (target.volatiles['substitute']) {
 					if (move.recoil) {
 						this.damage(Math.round(uncappedDamage * move.recoil[0] / move.recoil[1]), source, target, 'recoil');
 					}
 					if (move.drain) {
 						this.heal(Math.ceil(uncappedDamage * move.drain[0] / move.drain[1]), source, target, 'drain');
+					}
+					if (move.secondary?.volatileStatus === 'confusion') {
+						const secondary = move.secondary;
+						if (secondary.chance === undefined || this.randomChance(Math.ceil(secondary.chance * 256 / 100) - 1, 256)) {
+							target.addVolatile(move.secondary.volatileStatus, source, move);
+						}
 					}
 				}
 				this.runEvent('AfterSubDamage', target, source, move, uncappedDamage);

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -619,8 +619,15 @@ export const Scripts: ModdedBattleScriptsData = {
 						// That means that a move that does not share the type of the target can status it.
 						// If a move that was not fire-type would exist on Gen 1, it could burn a Pokémon.
 						if (!(secondary.status && ['par', 'brn', 'frz'].includes(secondary.status) && target && target.hasType(move.type))) {
-							if (secondary.chance === undefined || this.battle.randomChance(Math.ceil(secondary.chance * 256 / 100), 256)) {
+							if (secondary.chance === undefined) {
 								this.moveHit(target, pokemon, move, secondary, true, isSelf);
+							} else {
+								let secondaryChance = Math.ceil(secondary.chance * 256 / 100);
+								// If the secondary effect is confusion, the numerator should be decreased by 1 (10% = 25/256 not 26/256).
+								if (secondary?.volatileStatus === 'confusion') secondaryChance--;
+								if (this.battle.randomChance(secondaryChance, 256)) {
+									this.moveHit(target, pokemon, move, secondary, true, isSelf);
+								}
 							}
 						}
 					}

--- a/test/sim/moves/substitute.js
+++ b/test/sim/moves/substitute.js
@@ -134,4 +134,14 @@ describe('Substitute', function () {
 		battle.makeChoices('move growl', 'move clamp');
 		assert.bounded(hp - pokemon.hp, [91, 108]);
 	});
+
+	it('[Gen 1] Substitute should not block secondary effect confusion if it is unbroken', function () {
+		battle = common.gen(1).createBattle({seed: [2, 2, 1, 2]}, [
+			[{species: 'Kadabra', moves: ['psybeam']}],
+			[{species: 'Alakazam', moves: ['substitute']}],
+		]);
+
+		battle.makeChoices();
+		assert(battle.log.some(line => line.includes('confusion')));
+	});
 });


### PR DESCRIPTION
In Gen 1, Confusion/Psybeam's secondary effect should be able to confuse enemies behind a substitute, as long as the substitute is unbroken. Also, the confusion chance should be 25/256, not 26/256. This is in contrast to other moves with '10%' chance of a secondary effect, like Flamethrower, which have a 26/256 chance.

https://github.com/pkmn/engine/blob/main/src/lib/gen1/README.md
https://github.com/pret/pokered/blob/master/engine/battle/effects.asm (lines 1112-1116)