### PR TITLE
Add Battle Stadium Doubles

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -89,7 +89,7 @@ export const Formats: FormatList = [
 		name: "[Gen 9] Battle Stadium Singles",
 
 		mod: 'gen9',
-		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 8', 'VGC Timer'],
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 9', 'VGC Timer'],
 	},
 	{
 		name: "[Gen 9] Custom Game",
@@ -133,6 +133,13 @@ export const Formats: FormatList = [
 			'Standard Doubles', 'Accuracy Moves Clause', 'Terastal Clause', 'Sleep Clause Mod', 'Evasion Items Clause',
 		],
 		banlist: ['Koraidon', 'Miraidon', 'Commander', 'Focus Sash', 'King\'s Rock', 'Ally Switch', 'Final Gambit', 'Perish Song', 'Swagger'],
+	},
+	{
+		name: "[Gen 9] Battle Stadium Doubles",
+
+		mod: 'gen9',
+		gameType: 'doubles',
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 9', 'VGC Timer'],
 	},
 	{
 		name: "[Gen 9] Doubles Custom Game",


### PR DESCRIPTION
Also corrects BSS's Min Source Gen. Neither has an official ladder right now, but uses the "Official Rules 1" challengeable format available in-game currently. The ladder will be officially revealed December 1, but as expected with a new generation, there is pretty insane demand for Showdown practice. It's unclear if these Battle Stadium Doubles will mirror VGC rules (there's talk of Regional Dex-only or Paradox bans), so if VGC actually gets its ruleset we'll probably rename and nuke this ladder.