### PR TITLE
Gen 1: Fix inaccuracies in damage calculation

### DIFF
--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -817,7 +817,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			damage *= basePower;
 			damage *= attack;
 			damage = Math.floor(damage / defense);
-			damage = this.battle.clampIntRange(Math.floor(damage / 50), 1, 997);
+			damage = this.battle.clampIntRange(Math.floor(damage / 50), 0, 997);
 			damage += 2;
 
 			// STAB damage bonus, the "???" type never gets STAB
@@ -826,26 +826,26 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 
 			// Type effectiveness.
-			// The order here is not correct, must change to check the move versus each type.
-			const totalTypeMod = target.runEffectiveness(move);
-			// Super effective attack
-			if (totalTypeMod > 0) {
-				if (!suppressMessages) this.battle.add('-supereffective', target);
-				damage *= 20;
-				damage = Math.floor(damage / 10);
-				if (totalTypeMod >= 2) {
+			// In Gen 1, type effectiveness is applied against each of the target's types.
+			for (const targetType of target.types) {
+				const typeMod = this.battle.dex.getEffectiveness(type, targetType);
+				if (typeMod > 0) {
+					// Super effective against targetType
 					damage *= 20;
 					damage = Math.floor(damage / 10);
 				}
-			}
-			if (totalTypeMod < 0) {
-				if (!suppressMessages) this.battle.add('-resisted', target);
-				damage *= 5;
-				damage = Math.floor(damage / 10);
-				if (totalTypeMod <= -2) {
+				if (typeMod < 0) {
+					// Not very effective against targetType
 					damage *= 5;
 					damage = Math.floor(damage / 10);
 				}
+			}
+			const totalTypeMod = target.runEffectiveness(move);
+			if (totalTypeMod > 0) {
+				if (!suppressMessages) this.battle.add('-supereffective', target);
+			}
+			if (totalTypeMod < 0) {
+				if (!suppressMessages) this.battle.add('-resisted', target);
 			}
 
 			// If damage becomes 0, the move is made to miss.

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -715,7 +715,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			damage *= basePower;
 			damage *= attack;
 			damage = Math.floor(damage / defense);
-			damage = this.battle.clampIntRange(Math.floor(damage / 50), 1, 997);
+			damage = this.battle.clampIntRange(Math.floor(damage / 50), 0, 997);
 			damage += 2;
 
 			// STAB damage bonus, the "???" type never gets STAB
@@ -724,26 +724,26 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 
 			// Type effectiveness.
-			// The order here is not correct, must change to check the move versus each type.
-			const totalTypeMod = this.dex.getEffectiveness(type, target);
-			// Super effective attack
-			if (totalTypeMod > 0) {
-				if (!suppressMessages) this.battle.add('-supereffective', target);
-				damage *= 20;
-				damage = Math.floor(damage / 10);
-				if (totalTypeMod >= 2) {
+			// In Gen 1, type effectiveness is applied against each of the target's types.
+			for (const targetType of target.types) {
+				const typeMod = this.battle.dex.getEffectiveness(type, targetType);
+				if (typeMod > 0) {
+					// Super effective against targetType
 					damage *= 20;
 					damage = Math.floor(damage / 10);
 				}
-			}
-			if (totalTypeMod < 0) {
-				if (!suppressMessages) this.battle.add('-resisted', target);
-				damage *= 5;
-				damage = Math.floor(damage / 10);
-				if (totalTypeMod <= -2) {
+				if (typeMod < 0) {
+					// Not very effective against targetType
 					damage *= 5;
 					damage = Math.floor(damage / 10);
 				}
+			}
+			const totalTypeMod = target.runEffectiveness(move);
+			if (totalTypeMod > 0) {
+				if (!suppressMessages) this.battle.add('-supereffective', target);
+			}
+			if (totalTypeMod < 0) {
+				if (!suppressMessages) this.battle.add('-resisted', target);
 			}
 
 			// If damage becomes 0, the move is made to miss.


### PR DESCRIPTION
This patches fixes a couple of inaccuracies in damage calculation:

- The damage should be clamped between 0 and 997 (i.e. only clamped from above), not 1 and 997.
- Type effectiveness should be applied individually against each of the target's types. For example, Ice attacks against Articuno are not very effective against the first type, and super effective against the second, and this affects the damage calculation.

https://www.smogon.com/forums/threads/past-gens-research-thread.3506992/#post-5878612