### PR TITLE
Gen 1: Remove unnecessary RNG rolls for secondaries

### DIFF
--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -623,7 +623,7 @@ export const Scripts: ModdedBattleScriptsData = {
 						// In the game, this is checked and if true, the random number generator is not called.
 						// That means that a move that does not share the type of the target can status it.
 						// If a move that was not fire-type would exist on Gen 1, it could burn a Pokémon.
-						if (!(secondary.status && ['par', 'brn', 'frz'].includes(secondary.status) && target && target.hasType(move.type))) {
+						if (!(secondary.status && ['par', 'brn', 'frz'].includes(secondary.status) && target.hasType(move.type))) {
 							if (secondary.chance === undefined) {
 								this.moveHit(target, pokemon, move, secondary, true, isSelf);
 							} else {

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -615,7 +615,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 
 			// Apply move secondaries.
-			if (moveData.secondaries) {
+			if (moveData.secondaries && target && target.hp > 0) {
 				for (const secondary of moveData.secondaries) {
 					// Multi-hit moves only roll for status once
 					if (!move.multihit || move.lastHit) {

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -510,7 +510,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 
 			// Apply move secondaries.
-			if (moveData.secondaries) {
+			if (moveData.secondaries && target && target.hp > 0) {
 				for (const secondary of moveData.secondaries) {
 					// Multi-hit moves only roll for status once
 					if (!move.multihit || move.lastHit) {

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -518,7 +518,7 @@ export const Scripts: ModdedBattleScriptsData = {
 						// In the game, this is checked and if true, the random number generator is not called.
 						// That means that a move that does not share the type of the target can status it.
 						// If a move that was not fire-type would exist on Gen 1, it could burn a Pokémon.
-						if (!(secondary.status && ['par', 'brn', 'frz'].includes(secondary.status) && target && target.hasType(move.type))) {
+						if (!(secondary.status && ['par', 'brn', 'frz'].includes(secondary.status) && target.hasType(move.type))) {
 							const effectChance = Math.floor((secondary.chance || 100) * 255 / 100);
 							if (typeof secondary.chance === 'undefined' || this.battle.randomChance(effectChance + 1, 256)) {
 								this.moveHit(target, pokemon, move, secondary, true, isSelf);


### PR DESCRIPTION
This patch removes useless RNG rolls for Gen 1 secondary effects (e.g. Ice Beam's chance to freeze) when the move hits a substitute or the target has already fainted. The code will now first check if the target is available before rolling RNG to see if the secondary effect will be applied.