### PR TITLE
Gen 1: Fix stat modification, implement stat overflow glitch

### DIFF
--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -14,7 +14,6 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 		effectType: 'Status',
 		onStart(target) {
 			this.add('-status', target, 'brn');
-			target.addVolatile('brnattackdrop');
 		},
 		onAfterMoveSelfPriority: 2,
 		onAfterMoveSelf(pokemon) {
@@ -23,9 +22,6 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 			if (pokemon.volatiles['residualdmg']) {
 				this.hint("In Gen 1, Toxic's counter is retained after Rest and applies to PSN/BRN.", true);
 			}
-		},
-		onSwitchIn(pokemon) {
-			pokemon.addVolatile('brnattackdrop');
 		},
 		onAfterSwitchInSelf(pokemon) {
 			this.damage(this.clampIntRange(Math.floor(pokemon.maxhp / 16), 1));
@@ -36,7 +32,6 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 		effectType: 'Status',
 		onStart(target) {
 			this.add('-status', target, 'par');
-			target.addVolatile('parspeeddrop');
 		},
 		onBeforeMovePriority: 2,
 		onBeforeMove(pokemon) {
@@ -51,9 +46,6 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 				pokemon.removeVolatile('partialtrappinglock');
 				return false;
 			}
-		},
-		onSwitchIn(pokemon) {
-			pokemon.addVolatile('parspeeddrop');
 		},
 	},
 	slp: {

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -884,21 +884,6 @@ export const Scripts: ModdedBattleScriptsData = {
 				if (boost[i]! < 0) {
 					msg = '-unboost';
 					boost[i] = -boost[i]!;
-					// Re-add attack and speed drops if not present
-					if (i === 'atk' && target.status === 'brn' && !target.volatiles['brnattackdrop']) {
-						target.addVolatile('brnattackdrop');
-					}
-					if (i === 'spe' && target.status === 'par' && !target.volatiles['parspeeddrop']) {
-						target.addVolatile('parspeeddrop');
-					}
-				} else {
-					// Check for boost increases deleting attack or speed drops
-					if (i === 'atk' && target.status === 'brn' && target.volatiles['brnattackdrop']) {
-						target.removeVolatile('brnattackdrop');
-					}
-					if (i === 'spe' && target.status === 'par' && target.volatiles['parspeeddrop']) {
-						target.removeVolatile('parspeeddrop');
-					}
 				}
 				if (!effect || effect.effectType === 'Move') {
 					this.add(msg, target, i, boost[i]);

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -844,7 +844,12 @@ export const Scripts: ModdedBattleScriptsData = {
 			if (attack >= 256 || defense >= 256) {
 				attack = this.battle.clampIntRange(Math.floor(attack / 4) % 256, 1);
 				// Defense isn't checked on the cartridge, but we don't want those / 0 bugs on the sim.
-				defense = this.battle.clampIntRange(Math.floor(defense / 4) % 256, 1);
+				defense = Math.floor(defense / 4) % 256;
+				if (defense === 0) {
+					this.battle.hint('Pokemon Showdown avoids division by zero by rounding defense up to 1.' +
+						'In game, the battle would have crashed.');
+					defense = 1;
+				}
 			}
 
 			// Self destruct moves halve defense at this point.

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -24,33 +24,76 @@ export const Scripts: ModdedBattleScriptsData = {
 		// Gen 1 function to apply a stat modification that is only active until the stat is recalculated or mon switched.
 		modifyStat(statName, modifier) {
 			if (!(statName in this.storedStats)) throw new Error("Invalid `statName` passed to `modifyStat`");
-			const modifiedStats = this.battle.clampIntRange(Math.floor(this.modifiedStats![statName] * modifier), 1, 999);
+			const modifiedStats = this.battle.clampIntRange(Math.floor(this.modifiedStats![statName] * modifier), 1);
 			this.modifiedStats![statName] = modifiedStats;
 		},
 		// In generation 1, boosting function increases the stored modified stat and checks for opponent's status.
 		boostBy(boost) {
-			let changed = false;
+			let changed: boolean | number = false;
 			let i: BoostID;
 			for (i in boost) {
 				const delta = boost[i];
 				if (delta === undefined) continue;
 				if (delta > 0 && this.boosts[i] >= 6) continue;
 				if (delta < 0 && this.boosts[i] <= -6) continue;
-				this.boosts[i] += delta;
-				if (this.boosts[i] > 6) {
-					this.boosts[i] = 6;
+				if (i === 'evasion' || i === 'accuracy') {
+					this.boosts[i] += delta;
+					if (this.boosts[i] > 6) {
+						this.boosts[i] = 6;
+					}
+					if (this.boosts[i] < -6) {
+						this.boosts[i] = -6;
+					}
+					changed = true;
+					continue;
 				}
-				if (this.boosts[i] < -6) {
-					this.boosts[i] = -6;
+				// Stat being modified is not evasion or accuracy, so change modifiedStats.
+				if (delta > 0) {
+					if (this.modifiedStats![i] === 999) {
+						// Intended max stat value
+						this.boosts[i] += delta;
+						if (this.boosts[i] > 6) {
+							this.boosts[i] = 6;
+						}
+						this.boosts[i]--;
+						// changed = 0 corresponds to increasing stats at 999 (or decreasing at 1).
+						changed = 0;
+					} else {
+						this.boosts[i] += delta;
+						if (this.boosts[i] > 6) {
+							this.boosts[i] = 6;
+						}
+						changed = true;
+					}
 				}
-				changed = true;
+				if (delta < 0) {
+					if (this.modifiedStats![i] === 1) {
+						// Minimum stat value
+						this.boosts[i] += delta;
+						if (this.boosts[i] < -6) {
+							this.boosts[i] = -6;
+						}
+						this.boosts[i]++;
+						// changed = 0 corresponds to increasing stats at 999 (or decreasing at 1).
+						changed = 0;
+					} else {
+						this.boosts[i] += delta;
+						if (this.boosts[i] < -6) {
+							this.boosts[i] = -6;
+						}
+						changed = true;
+					}
+				}
 				// Recalculate the modified stat
-				if (i === 'evasion' || i === 'accuracy') continue;
 				this.modifiedStats![i] = this.storedStats[i];
 				if (this.boosts[i] >= 0) {
 					this.modifyStat!(i, [1, 1.5, 2, 2.5, 3, 3.5, 4][this.boosts[i]]);
 				} else {
 					this.modifyStat!(i, [100, 66, 50, 40, 33, 28, 25][-this.boosts[i]] / 100);
+				}
+				if (delta > 0 && this.modifiedStats![i] > 999) {
+					// Cap the stat at 999
+					this.modifiedStats![i] = 999;
 				}
 			}
 			return changed;
@@ -863,7 +906,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			return Math.floor(damage);
 		},
 	},
-	// deals with Pokémon stat boosting, including Gen 1 buggy behaviour with burn and paralyse.
+	// deals with Pokémon stat boosting.
 	boost(boost, target, source = null, effect = null) {
 		if (this.event) {
 			if (!target) target = this.event.target;
@@ -878,19 +921,44 @@ export const Scripts: ModdedBattleScriptsData = {
 		for (i in boost) {
 			const currentBoost: SparseBoostsTable = {};
 			currentBoost[i] = boost[i];
-			if (boost[i] !== 0 && target.boostBy(currentBoost)) {
-				success = true;
-				let msg = '-boost';
-				if (boost[i]! < 0) {
-					msg = '-unboost';
-					boost[i] = -boost[i]!;
+			if (boost[i] !== 0) {
+				const boostResult = target.boostBy(currentBoost);
+				if (boostResult) {
+					success = true;
+					let msg = '-boost';
+					if (boost[i]! < 0) {
+						msg = '-unboost';
+						boost[i] = -boost[i]!;
+					}
+					if (!effect || effect.effectType === 'Move') {
+						this.add(msg, target, i, boost[i]);
+					} else {
+						this.add(msg, target, i, boost[i], '[from] ' + effect.fullname);
+					}
+					this.runEvent('AfterEachBoost', target, source, effect, currentBoost);
 				}
-				if (!effect || effect.effectType === 'Move') {
-					this.add(msg, target, i, boost[i]);
-				} else {
-					this.add(msg, target, i, boost[i], '[from] ' + effect.fullname);
+				// Tried to boost at 999 or unboost at 1. This does not count as a success: par/brn effects are not applied afterwards.
+				if (boostResult === 0) {
+					let msg = '-boost';
+					let secondmsg = '-unboost';
+					if (boost[i]! < 0) {
+						msg = '-unboost';
+						secondmsg = '-boost';
+						boost[i] = -boost[i]!;
+					}
+					if (!effect || effect.effectType === 'Move') {
+						this.add(msg, target, i, boost[i]);
+					} else {
+						this.add(msg, target, i, boost[i], '[from] ' + effect.fullname);
+					}
+					this.add(secondmsg, target, i, 1);
+					if (msg === '-boost') {
+						this.hint(`In Gen 1, boosting a stat at 999 will apply a -1 drop afterwards, and the stat stays at 999.`, true);
+					} else {
+						this.hint(`In Gen 1, dropping a stat at 1 will apply a +1 boost afterwards, and the stat stays at 1.`, true);
+					}
+					this.runEvent('AfterEachBoost', target, source, effect, currentBoost);
 				}
-				this.runEvent('AfterEachBoost', target, source, effect, currentBoost);
 			}
 		}
 		this.runEvent('AfterBoost', target, source, effect, boost);

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -953,9 +953,9 @@ export const Scripts: ModdedBattleScriptsData = {
 					}
 					this.add(secondmsg, target, i, 1);
 					if (msg === '-boost') {
-						this.hint(`In Gen 1, boosting a stat at 999 will apply a -1 drop afterwards, and the stat stays at 999.`, true);
+						this.hint(`In Gen 1, boosting a stat at 999 will apply a -1 drop afterwards, and the stat remains at 999.`, true);
 					} else {
-						this.hint(`In Gen 1, dropping a stat at 1 will apply a +1 boost afterwards, and the stat stays at 1.`, true);
+						this.hint(`In Gen 1, dropping a stat at 1 will apply a +1 boost afterwards, and the stat remains at 1.`, true);
 					}
 					this.runEvent('AfterEachBoost', target, source, effect, currentBoost);
 				}

--- a/test/sim/misc/statdownoverflow.js
+++ b/test/sim/misc/statdownoverflow.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('[Gen 1] Stat Drop Overflow', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it('SafeTwo', function () {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', {team: [{species: "Mewtwo", moves: ['amnesia', 'psychic'], evs: {'spa': 104, 'spd': 104}, ivs: {'spa': 3, 'spd': 3}}]});
+		battle.setPlayer('p2', {team: [{species: "Slowbro", moves: ['amnesia', 'psychic', 'surf'], evs: {'spa': 255, 'spd': 255}, dvs: {'spa': 15, 'spd': 15}}]});
+		const mewtwo = battle.p1.active[0];
+		console.log(mewtwo.storedStats['spa']);
+		assert(mewtwo.storedStats['spa'] === 341);
+		battle.makeChoices();
+		battle.makeChoices();
+		assert(mewtwo.modifiedStats['spa'] === 999);
+		battle.makeChoices('move amnesia', 'move psychic');
+		assert(mewtwo.modifiedStats['spa'] === 1023);
+		// Mewtwo's Special has not overflowed
+		battle.makeChoices('move psychic', 'move surf');
+		assert.false.fainted(mewtwo);
+	});
+
+	it('Not SafeTwo', function () {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', {team: [{species: "Mewtwo", moves: ['amnesia', 'psychic'], evs: {'spa': 255, 'spd': 255}, dvs: {'spa': 15, 'spd': 15}}]});
+		battle.setPlayer('p2', {team: [{species: "Slowbro", moves: ['amnesia', 'psychic', 'surf'], evs: {'spa': 255, 'spd': 255}, dvs: {'spa': 15, 'spd': 15}}]});
+		const mewtwo = battle.p1.active[0];
+		assert(mewtwo.storedStats['spa'] === 406);
+		battle.makeChoices();
+		battle.makeChoices();
+		assert(mewtwo.modifiedStats['spa'] === 999);
+		battle.makeChoices('move amnesia', 'move psychic');
+		assert(mewtwo.modifiedStats['spa'] === 1218);
+		// Mewtwo's Special has overflowed
+		battle.makeChoices('move psychic', 'move surf');
+		assert.fainted(mewtwo);
+	});
+});


### PR DESCRIPTION
This patches implements the stat down modifier overflow glitch (division by zero not implemented for obvious reasons):

https://www.youtube.com/watch?v=y2AOm7r39Jg

- Stats are no longer automatically clamped from above by 999. This clamping is applied only when stats are being raised by boosting.
- When a stat is boosted at 999 or unboosted at 1, the boost/unboost is followed by an unboost/boost of -/+1 to the stat, respectively. The stat remains at 999 or 1. For example, if a Mewtwo is at +4 Special with 999 Special and uses Amnesia, the final stat stage is +5, and the Special remains at 999. A hint message will display for the first time this occurs in a battle.
- When a stat is unboosted, the stat is no longer clamped at 999, which can cause the stat down modifier overflow glitch if the stat is 1024 or higher. We still avoid division by zero glitches by ensuring that the final defense used in the damage calculation is at least 1, even though it can be 0 on cart.
-  The parspeeddrop and brnattackdrop volatiles are removed since they don't actually do anything, but can be misleading for people reading the code.