### PR TITLE
Refactor self-disabling moves

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -1223,7 +1223,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1},
-		// Move disabling implemented in Battle#nextTurn in sim/battle.js
+		onDisableMove(pokemon) {
+			if (!pokemon.ateBerry) pokemon.disableMove('belch');
+		},
 		secondary: null,
 		target: "normal",
 		type: "Poison",
@@ -6615,7 +6617,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		// Move disabling implemented in Battle#nextTurn in sim/battle.ts
+		onDisableMove(pokemon) {
+			if (pokemon.lastMove?.id === 'gigatonhammer') pokemon.disableMove('gigatonhammer');
+		},
 		secondary: null,
 		target: "normal",
 		type: "Steel",
@@ -18571,7 +18575,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {snatch: 1},
-		// Move disabling implemented in Battle#nextTurn in sim/battle.ts
+		onDisableMove(pokemon) {
+			if (!pokemon.getItem().isBerry) pokemon.disableMove('stuffcheeks');
+		},
 		onTry(source) {
 			const item = source.getItem();
 			if (item.isBerry && source.eatItem(true)) {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1459,9 +1459,9 @@ export class Battle {
 					moveSlot.disabledSource = '';
 				}
 				this.runEvent('DisableMove', pokemon);
-				if (!pokemon.ateBerry) pokemon.disableMove('belch');
-				if (!pokemon.getItem().isBerry) pokemon.disableMove('stuffcheeks');
-				if (pokemon.lastMove?.id === 'gigatonhammer') pokemon.disableMove('gigatonhammer');
+				for (const moveSlot of pokemon.moveSlots) {
+					this.singleEvent('DisableMove', this.dex.getActiveMove(moveSlot.id), null, pokemon);
+				}
 
 				// If it was an illusion, it's not any more
 				if (pokemon.getLastAttackedBy() && this.gen >= 7) pokemon.knownType = true;

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -91,6 +91,8 @@ export interface MoveEventMethods {
 	damageCallback?: (this: Battle, pokemon: Pokemon, target: Pokemon) => number | false;
 	priorityChargeCallback?: (this: Battle, pokemon: Pokemon) => void;
 
+	onDisableMove?: (this: Battle, pokemon: Pokemon) => void;
+
 	onAfterHit?: CommonHandlers['VoidSourceMove'];
 	onAfterSubDamage?: (this: Battle, damage: number, target: Pokemon, source: Pokemon, move: ActiveMove) => void;
 	onAfterMoveSecondarySelf?: CommonHandlers['VoidSourceMove'];

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1492,7 +1492,7 @@ export class Pokemon {
 		for (const moveSlot of this.moveSlots) {
 			if (moveSlot.id === moveid && moveSlot.disabled !== true) {
 				moveSlot.disabled = (isHidden || true);
-				moveSlot.disabledSource = (sourceEffect?.fullname || moveSlot.move);
+				moveSlot.disabledSource = (sourceEffect?.name || moveSlot.move);
 			}
 		}
 	}


### PR DESCRIPTION
This allows moves to define their own onDisableMove callback, which replaces the hardcoded cases in Battle#nextTurn.