### PR TITLE
Ability Shield: Add tests based on SV research thread

### DIFF
--- a/test/sim/items/abilityshield.js
+++ b/test/sim/items/abilityshield.js
@@ -141,5 +141,14 @@ describe('Ability Shield', function () {
 	//      moves/abilities triggered before the loss would not automatically trigger unless
 	//      used again.
 
-	// TODO skill swap interaction?
+	it.skip(`should protect the holder's ability against Skill Swap, even if used by the holder`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'shadowtag', item: 'abilityshield', moves: ['skill swap']},
+		], [
+			{species: 'weezinggalar', ability: 'levitate', moves: ['splash']},
+		]]);
+
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].ability, 'shadowtag', `Holder should retain ability`);
+	});
 });

--- a/test/sim/items/abilityshield.js
+++ b/test/sim/items/abilityshield.js
@@ -10,55 +10,7 @@ describe('Ability Shield', function () {
 		battle.destroy();
 	});
 
-	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9411146
-	it(`should bypass Neutralizing Gas`, function () {
-		battle = common.createBattle([[
-			{species: 'wynaut', ability: 'sturdy', item: 'abilityshield', moves: ['splash'], level: 5},
-		], [
-			{species: 'weezinggalar', ability: 'neutralizinggas', moves: ['shadowball']},
-		]]);
-
-		assert(battle.log.some(line => line.includes('Neutralizing Gas')), `Neutralizing Gas should trigger`);
-		assert(battle.log.some(line => line.includes('Ability Shield')), `Ability Shield should trigger a block message`);
-
-		battle.makeChoices();
-		assert.equal(battle.p1.active[0].hp, 1, `Holder should survive from sturdy`);
-	});
-
-	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9412194
-	it(`should bypass Mold Breaker`, function () {
-		battle = common.createBattle([[
-			{species: 'wynaut', ability: 'sturdy', item: 'abilityshield', moves: ['splash'], level: 5},
-		], [
-			{species: 'weezinggalar', ability: 'moldbreaker', moves: ['shadowball']},
-		]]);
-
-		// no logs in-game
-		assert(battle.log.every(line => !line.includes('Ability Shield')), `Ability Shield should trigger a block message`);
-
-		battle.makeChoices();
-		assert.equal(battle.p1.active[0].hp, 1, `Holder should survive from sturdy`);
-	});
-
-	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9403448
-	it(`should block Gastro Acid`, function () {
-		battle = common.createBattle([[
-			{species: 'wynaut', ability: 'sturdy', item: 'abilityshield', moves: ['splash'], level: 5},
-		], [
-			{species: 'weezinggalar', ability: 'levitate', moves: ['gastroacid', 'shadowball']},
-		]]);
-
-		battle.makeChoices('move splash', 'move gastroacid');
-
-		// TODO does it actually announce in game?
-		assert(battle.log.some(line => line.includes('Ability Shield')), `Ability Shield should trigger a block message`);
-
-		battle.makeChoices('move splash', 'move shadowball');
-
-		assert.equal(battle.p1.active[0].hp, 1, `Holder should survive from sturdy`);
-	});
-
-	it(`should block ability-changing moves`, function () {
+	it(`should protect the holder's ability against ability-changing moves`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', ability: 'shadowtag', item: 'abilityshield', moves: ['splash'], level: 5},
 		], [
@@ -70,7 +22,7 @@ describe('Ability Shield', function () {
 		assert.equal(battle.p1.active[0].ability, 'shadowtag', `Holder should retain ability`);
 	});
 
-	it(`should block ability-changing abilities`, function () {
+	it(`should protect the holder's ability against ability-changing abilities`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', ability: 'shadowtag', item: 'abilityshield', moves: ['tackle']},
 		], [
@@ -81,6 +33,113 @@ describe('Ability Shield', function () {
 		assert(battle.log.some(line => line.includes('Ability Shield')), `Ability Shield should trigger a block message`);
 		assert.equal(battle.p1.active[0].ability, 'shadowtag', `Holder should retain ability`);
 	});
+
+	it(`should only protect the holder`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'mummy', item: 'abilityshield', moves: ['splash']},
+		], [
+			{species: 'weezinggalar', ability: 'levitate', moves: ['tackle']},
+		]]);
+
+		battle.makeChoices();
+		assert(battle.log.every(line => !line.includes('Ability Shield')), `Ability Shield should not trigger a block message`);
+		assert.equal(battle.p2.active[0].ability, 'mummy', `Attacker should lose its ability`);
+	});
+
+	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9411146
+	it(`should protect the holder's ability against Neutralizing Gas`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'sturdy', item: 'abilityshield', moves: ['splash'], level: 5},
+		], [
+			{species: 'weezinggalar', ability: 'neutralizinggas', moves: ['shadowball']},
+		]]);
+
+		assert(battle.log.some(line => line.includes('Neutralizing Gas')), `Neutralizing Gas should trigger`);
+		assert(battle.log.some(line => line.includes('Ability Shield')), `Ability Shield should trigger a block message`);
+
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].hp, 1, `Holder should survive due to Sturdy`);
+	});
+
+	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9412194
+	it(`should protect the holder's ability against Mold Breaker`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'sturdy', item: 'abilityshield', moves: ['splash'], level: 5},
+		], [
+			{species: 'weezinggalar', ability: 'moldbreaker', moves: ['shadowball']},
+		]]);
+
+		assert(battle.log.every(line => !line.includes('Ability Shield')), `Ability Shield should not trigger a block message`);
+
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].hp, 1, `Holder should survive from sturdy`);
+	});
+
+	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9403448
+	it(`should protect the holder's ability against Gastro Acid`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'sturdy', item: 'abilityshield', moves: ['splash'], level: 5},
+		], [
+			{species: 'weezinggalar', ability: 'levitate', moves: ['gastroacid', 'shadowball']},
+		]]);
+
+		battle.makeChoices('move splash', 'move gastroacid');
+		assert(battle.log.some(line => line.includes('Ability Shield')), `Ability Shield should trigger a block message`);
+
+		battle.makeChoices('move splash', 'move shadowball');
+		assert.equal(battle.p1.active[0].hp, 1, `Holder should survive due to Sturdy`);
+	});
+
+	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9412999
+	it(`should not unsuppress the holder's ability if Ability Shield is acquired after Gastro Acid has been used`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'sturdy', moves: ['splash'], level: 5},
+		], [
+			{species: 'weezinggalar', ability: 'levitate', item: 'abilityshield', moves: ['gastroacid', 'trick', 'shadowball']},
+		]]);
+
+		battle.makeChoices('move splash', 'move gastroacid');
+		battle.makeChoices('move splash', 'move trick');
+		battle.makeChoices('move splash', 'move shadowball');
+		
+		assert(battle.p1.active[0].fainted, `Holder should not survive attack`);
+	});
+
+	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9412999
+	it(`should unsuppress the holder's ability if Ability Shield is acquired after Neutralizing Gas has come into effect`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'sturdy', moves: ['splash'], level: 5},
+		], [
+			{species: 'weezinggalar', ability: 'levitate', item: 'abilityshield', moves: ['gastroacid', 'trick', 'shadowball']},
+		]]);
+
+		battle.makeChoices('move splash', 'move gastroacid');
+		battle.makeChoices('move splash', 'move trick');
+		battle.makeChoices('move splash', 'move shadowball');
+
+		// TODO assert some sort of block message? I don't *think* there should be a message but not confirmed
+		
+		assert.equal(battle.p1.active[0].hp, 1, `Holder should survive due to Sturdy`);
+	});
+
+	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9412999
+	it(`should not be suppressed by Klutz`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'klutz', item: 'abilityshield', moves: ['tackle']},
+		], [
+			{species: 'weezinggalar', ability: 'mummy', moves: ['splash']},
+		]]);
+
+		battle.makeChoices();
+		assert(battle.log.some(line => line.includes('Ability Shield')), `Ability Shield should trigger a block message`);
+		assert.equal(battle.p1.active[0].ability, 'klutz', `Holder should retain ability`);
+	});
+
+	// TODO Tests for losing Ability Shield vs Neutralizing Gas/Mold Breaker/Gastro Acid? 
+	//      No confirmed research yet for these, but presumably Neutralizing Gas & Mold 
+	//      Breaker would start to apply again, whereas Gastro Acid & any other 
+	//      "triggered-once" moves/abilities triggered before the loss would not automatically
+	//      trigger unless used again.
 	
 	// TODO skill swap interaction?
 });

--- a/test/sim/items/abilityshield.js
+++ b/test/sim/items/abilityshield.js
@@ -10,6 +10,7 @@ describe('Ability Shield', function () {
 		battle.destroy();
 	});
 
+	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9411146
 	it(`should bypass Neutralizing Gas`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', ability: 'sturdy', item: 'abilityshield', moves: ['splash'], level: 5},
@@ -24,6 +25,7 @@ describe('Ability Shield', function () {
 		assert.equal(battle.p1.active[0].hp, 1, `Holder should survive from sturdy`);
 	});
 
+	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9412194
 	it(`should bypass Mold Breaker`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', ability: 'sturdy', item: 'abilityshield', moves: ['splash'], level: 5},
@@ -31,10 +33,14 @@ describe('Ability Shield', function () {
 			{species: 'weezinggalar', ability: 'moldbreaker', moves: ['shadowball']},
 		]]);
 
+		// no logs in-game
+		assert(battle.log.every(line => !line.includes('Ability Shield')), `Ability Shield should trigger a block message`);
+
 		battle.makeChoices();
 		assert.equal(battle.p1.active[0].hp, 1, `Holder should survive from sturdy`);
 	});
 
+	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9403448
 	it(`should block Gastro Acid`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', ability: 'sturdy', item: 'abilityshield', moves: ['splash'], level: 5},
@@ -72,51 +78,9 @@ describe('Ability Shield', function () {
 		]]);
 
 		battle.makeChoices();
-
 		assert(battle.log.some(line => line.includes('Ability Shield')), `Ability Shield should trigger a block message`);
 		assert.equal(battle.p1.active[0].ability, 'shadowtag', `Holder should retain ability`);
 	});
 	
 	// TODO skill swap interaction?
-
-	// it(`should not activate on the opponent's moves`, function () {
-	// 	battle = common.createBattle([[
-	// 		{species: 'wynaut', item: 'punchingglove', moves: ['sleeptalk']},
-	// 	], [
-	// 		{species: 'happiny', moves: ['lunge']},
-	// 	]]);
-	// 	battle.makeChoices();
-	// 	assert.statStage(battle.p1.active[0], 'atk', -1, `Attack should be lowered`);
-	// });
-
-	// // https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9406865
-	// it(`should stop Pickpocket`, function () {
-	// 	battle = common.createBattle([[
-	// 		{species: 'wynaut', item: 'punchingglove', moves: ['bulletpunch']},
-	// 	], [
-	// 		{species: 'weavile', ability: 'pickpocket', moves: ['sleeptalk']},
-	// 	]]);
-	// 	battle.makeChoices();
-	// 	assert.equal(battle.p1.active[0].item, 'punchingglove', `Attacker should not lose their item`);
-	// 	assert.false.holdsItem(battle.p2.active[0], `Target should not steal Punching Glove`);
-	// });
-
-	// // https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9406865
-	// it(`should block against Protecting effects with a contact side effect`, function () {
-	// 	battle = common.createBattle([[
-	// 		{species: 'wynaut', item: 'punchingglove', moves: ['sleeptalk', 'bulletpunch']},
-	// 	], [
-	// 		{species: 'aggron', moves: ['sleeptalk', 'banefulbunker', 'obstruct', 'spikyshield']},
-	// 	]]);
-	// 	battle.makeChoices('move bulletpunch', 'move banefulbunker');
-	// 	battle.makeChoices();
-	// 	battle.makeChoices('move bulletpunch', 'move obstruct');
-	// 	battle.makeChoices();
-	// 	battle.makeChoices('move bulletpunch', 'move spikyshield');
-	// 	battle.makeChoices();
-	// 	const wynaut = battle.p1.active[0];
-	// 	assert.equal(wynaut.status, '', `Wynaut should not have been poisoned by Baneful Bunker`);
-	// 	assert.statStage(wynaut, 'def', 0, `Wynaut's Defense should not have been lowered by Obstruct`);
-	// 	assert.fullHP(wynaut, `Wynaut should not have lost HP from Spiky Shield`);
-	// });
 });

--- a/test/sim/items/abilityshield.js
+++ b/test/sim/items/abilityshield.js
@@ -143,7 +143,7 @@ describe('Ability Shield', function () {
 
 	it.skip(`should protect the holder's ability against Skill Swap, even if used by the holder`, function () {
 		battle = common.createBattle([[
-			{species: 'wynaut', ability: 'shadowtag', item: 'abilityshield', moves: ['skill swap']},
+			{species: 'wynaut', ability: 'shadowtag', item: 'abilityshield', moves: ['skillswap']},
 		], [
 			{species: 'weezinggalar', ability: 'levitate', moves: ['splash']},
 		]]);

--- a/test/sim/items/abilityshield.js
+++ b/test/sim/items/abilityshield.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const assert = require('../../assert');
+const common = require('../../common');
+
+let battle;
+
+describe('Ability Shield', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it(`should bypass Neutralizing Gas`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'sturdy', item: 'abilityshield', moves: ['splash'], level: 5},
+		], [
+			{species: 'weezinggalar', ability: 'neutralizinggas', moves: ['shadowball']},
+		]]);
+
+		assert(battle.log.some(line => line.includes('Neutralizing Gas')), `Neutralizing Gas should trigger`);
+		assert(battle.log.some(line => line.includes('Ability Shield')), `Ability Shield should trigger a block message`);
+
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].hp, 1, `Holder should survive from sturdy`);
+	});
+
+	it(`should bypass Mold Breaker`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'sturdy', item: 'abilityshield', moves: ['splash'], level: 5},
+		], [
+			{species: 'weezinggalar', ability: 'moldbreaker', moves: ['shadowball']},
+		]]);
+
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].hp, 1, `Holder should survive from sturdy`);
+	});
+
+	it(`should block Gastro Acid`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'sturdy', item: 'abilityshield', moves: ['splash'], level: 5},
+		], [
+			{species: 'weezinggalar', ability: 'levitate', moves: ['gastroacid', 'shadowball']},
+		]]);
+
+		battle.makeChoices('move splash', 'move gastroacid');
+
+		// TODO does it actually announce in game?
+		assert(battle.log.some(line => line.includes('Ability Shield')), `Ability Shield should trigger a block message`);
+
+		battle.makeChoices('move splash', 'move shadowball');
+
+		assert.equal(battle.p1.active[0].hp, 1, `Holder should survive from sturdy`);
+	});
+
+	it(`should block ability-changing moves`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'shadowtag', item: 'abilityshield', moves: ['splash'], level: 5},
+		], [
+			{species: 'weezinggalar', ability: 'levitate', moves: ['worryseed']},
+		]]);
+
+		battle.makeChoices();
+		assert(battle.log.some(line => line.includes('Ability Shield')), `Ability Shield should trigger a block message`);
+		assert.equal(battle.p1.active[0].ability, 'shadowtag', `Holder should retain ability`);
+	});
+
+	it(`should block ability-changing abilities`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'shadowtag', item: 'abilityshield', moves: ['tackle']},
+		], [
+			{species: 'weezinggalar', ability: 'mummy', moves: ['splash']},
+		]]);
+
+		battle.makeChoices();
+
+		assert(battle.log.some(line => line.includes('Ability Shield')), `Ability Shield should trigger a block message`);
+		assert.equal(battle.p1.active[0].ability, 'shadowtag', `Holder should retain ability`);
+	});
+	
+	// TODO skill swap interaction?
+
+	// it(`should not activate on the opponent's moves`, function () {
+	// 	battle = common.createBattle([[
+	// 		{species: 'wynaut', item: 'punchingglove', moves: ['sleeptalk']},
+	// 	], [
+	// 		{species: 'happiny', moves: ['lunge']},
+	// 	]]);
+	// 	battle.makeChoices();
+	// 	assert.statStage(battle.p1.active[0], 'atk', -1, `Attack should be lowered`);
+	// });
+
+	// // https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9406865
+	// it(`should stop Pickpocket`, function () {
+	// 	battle = common.createBattle([[
+	// 		{species: 'wynaut', item: 'punchingglove', moves: ['bulletpunch']},
+	// 	], [
+	// 		{species: 'weavile', ability: 'pickpocket', moves: ['sleeptalk']},
+	// 	]]);
+	// 	battle.makeChoices();
+	// 	assert.equal(battle.p1.active[0].item, 'punchingglove', `Attacker should not lose their item`);
+	// 	assert.false.holdsItem(battle.p2.active[0], `Target should not steal Punching Glove`);
+	// });
+
+	// // https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9406865
+	// it(`should block against Protecting effects with a contact side effect`, function () {
+	// 	battle = common.createBattle([[
+	// 		{species: 'wynaut', item: 'punchingglove', moves: ['sleeptalk', 'bulletpunch']},
+	// 	], [
+	// 		{species: 'aggron', moves: ['sleeptalk', 'banefulbunker', 'obstruct', 'spikyshield']},
+	// 	]]);
+	// 	battle.makeChoices('move bulletpunch', 'move banefulbunker');
+	// 	battle.makeChoices();
+	// 	battle.makeChoices('move bulletpunch', 'move obstruct');
+	// 	battle.makeChoices();
+	// 	battle.makeChoices('move bulletpunch', 'move spikyshield');
+	// 	battle.makeChoices();
+	// 	const wynaut = battle.p1.active[0];
+	// 	assert.equal(wynaut.status, '', `Wynaut should not have been poisoned by Baneful Bunker`);
+	// 	assert.statStage(wynaut, 'def', 0, `Wynaut's Defense should not have been lowered by Obstruct`);
+	// 	assert.fullHP(wynaut, `Wynaut should not have lost HP from Spiky Shield`);
+	// });
+});

--- a/test/sim/items/abilityshield.js
+++ b/test/sim/items/abilityshield.js
@@ -173,6 +173,29 @@ describe('Ability Shield', function () {
 		assert.statStage(battle.p2.active[0], 'atk', 0);
 	});
 
+	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9414273
+	it(`should not trigger holder's Trace`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'trace', item: 'abilityshield', moves: ['splash']},
+		], [
+			{species: 'weezinggalar', ability: 'levitate', moves: ['splash']},
+		]]);
+
+		assert.notEqual(battle.p1.active[0].ability, 'levitate', `Holder should not trace ability`);
+	});
+
+	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9414273
+	it.skip(`should not trigger holder's Trace even after losing the item`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'trace', item: 'abilityshield', moves: ['splash']},
+		], [
+			{species: 'weezinggalar', ability: 'levitate', moves: ['trick']},
+		]]);
+
+		battle.makeChoices();
+		assert.notEqual(battle.p1.active[0].ability, 'levitate', `Holder should not trace ability`);
+	});
+
 	// TODO Add future tests for losing Ability Shield vs Neutralizing Gas/Mold Breaker/Gastro Acid?
 	//
 	//      No confirmed research yet for these, but presumably Neutralizing Gas & Mold

--- a/test/sim/items/abilityshield.js
+++ b/test/sim/items/abilityshield.js
@@ -47,7 +47,7 @@ describe('Ability Shield', function () {
 	});
 
 	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9411146
-	it(`should protect the holder's ability against Neutralizing Gas`, function () {
+	it.skip(`should protect the holder's ability against Neutralizing Gas`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', ability: 'sturdy', item: 'abilityshield', moves: ['splash'], level: 5},
 		], [
@@ -62,7 +62,7 @@ describe('Ability Shield', function () {
 	});
 
 	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9412194
-	it(`should protect the holder's ability against Mold Breaker`, function () {
+	it.skip(`should protect the holder's ability against Mold Breaker`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', ability: 'sturdy', item: 'abilityshield', moves: ['splash'], level: 5},
 		], [
@@ -76,7 +76,7 @@ describe('Ability Shield', function () {
 	});
 
 	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9403448
-	it(`should protect the holder's ability against Gastro Acid`, function () {
+	it.skip(`should protect the holder's ability against Gastro Acid`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', ability: 'sturdy', item: 'abilityshield', moves: ['splash'], level: 5},
 		], [
@@ -106,7 +106,7 @@ describe('Ability Shield', function () {
 	});
 
 	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9412999
-	it(`should unsuppress the holder's ability if Ability Shield is acquired after Neutralizing Gas has come into effect`, function () {
+	it.skip(`should unsuppress the holder's ability if Ability Shield is acquired after Neutralizing Gas has come into effect`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', ability: 'sturdy', moves: ['splash'], level: 5},
 		], [
@@ -123,7 +123,7 @@ describe('Ability Shield', function () {
 	});
 
 	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9412999
-	it(`should not be suppressed by Klutz`, function () {
+	it.skip(`should not be suppressed by Klutz`, function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', ability: 'klutz', item: 'abilityshield', moves: ['tackle']},
 		], [

--- a/test/sim/items/abilityshield.js
+++ b/test/sim/items/abilityshield.js
@@ -150,5 +150,6 @@ describe('Ability Shield', function () {
 
 		battle.makeChoices();
 		assert.equal(battle.p1.active[0].ability, 'shadowtag', `Holder should retain ability`);
+		assert.equal(battle.p2.active[0].ability, 'levitate', `Opponent should retain ability`);
 	});
 });

--- a/test/sim/items/abilityshield.js
+++ b/test/sim/items/abilityshield.js
@@ -12,7 +12,7 @@ describe('Ability Shield', function () {
 
 	it(`should protect the holder's ability against ability-changing moves`, function () {
 		battle = common.createBattle([[
-			{species: 'wynaut', ability: 'shadowtag', item: 'abilityshield', moves: ['splash'], level: 5},
+			{species: 'wynaut', ability: 'shadowtag', item: 'abilityshield', moves: ['splash']},
 		], [
 			{species: 'weezinggalar', ability: 'levitate', moves: ['worryseed']},
 		]]);
@@ -110,10 +110,9 @@ describe('Ability Shield', function () {
 		battle = common.createBattle([[
 			{species: 'wynaut', ability: 'sturdy', moves: ['splash'], level: 5},
 		], [
-			{species: 'weezinggalar', ability: 'levitate', item: 'abilityshield', moves: ['gastroacid', 'trick', 'shadowball']},
+			{species: 'weezinggalar', ability: 'neutralizinggas', item: 'abilityshield', moves: ['trick', 'shadowball']},
 		]]);
 
-		battle.makeChoices('move splash', 'move gastroacid');
 		battle.makeChoices('move splash', 'move trick');
 		battle.makeChoices('move splash', 'move shadowball');
 
@@ -135,11 +134,13 @@ describe('Ability Shield', function () {
 		assert.equal(battle.p1.active[0].ability, 'klutz', `Holder should retain ability`);
 	});
 
+	// TODO Tests for unsuppressing abilities like Intimidate (should they re-trigger)? Or perhaps already covered by current Neutralizing Gas tests?
+
 	// TODO Tests for losing Ability Shield vs Neutralizing Gas/Mold Breaker/Gastro Acid? 
 	//      No confirmed research yet for these, but presumably Neutralizing Gas & Mold 
-	//      Breaker would start to apply again, whereas Gastro Acid & any other 
-	//      "triggered-once" moves/abilities triggered before the loss would not automatically
-	//      trigger unless used again.
+	//      Breaker would start to apply again, whereas Gastro Acid or other "triggered-once" 
+	//      moves/abilities triggered before the loss would not automatically trigger unless 
+	//      used again.
 	
 	// TODO skill swap interaction?
 });

--- a/test/sim/items/abilityshield.js
+++ b/test/sim/items/abilityshield.js
@@ -101,7 +101,6 @@ describe('Ability Shield', function () {
 		battle.makeChoices('move splash', 'move gastroacid');
 		battle.makeChoices('move splash', 'move trick');
 		battle.makeChoices('move splash', 'move shadowball');
-		
 		assert(battle.p1.active[0].fainted, `Holder should not survive attack`);
 	});
 
@@ -116,8 +115,8 @@ describe('Ability Shield', function () {
 		battle.makeChoices('move splash', 'move trick');
 		battle.makeChoices('move splash', 'move shadowball');
 
-		// TODO assert some sort of block message? I don't *think* there should be a message but not confirmed
-		
+		// TODO assert some sort of block message as well? I don't *think* there should be a message but not confirmed
+
 		assert.equal(battle.p1.active[0].hp, 1, `Holder should survive due to Sturdy`);
 	});
 
@@ -136,11 +135,11 @@ describe('Ability Shield', function () {
 
 	// TODO Tests for unsuppressing abilities like Intimidate (should they re-trigger)? Or perhaps already covered by current Neutralizing Gas tests?
 
-	// TODO Tests for losing Ability Shield vs Neutralizing Gas/Mold Breaker/Gastro Acid? 
-	//      No confirmed research yet for these, but presumably Neutralizing Gas & Mold 
-	//      Breaker would start to apply again, whereas Gastro Acid or other "triggered-once" 
-	//      moves/abilities triggered before the loss would not automatically trigger unless 
+	// TODO Tests for losing Ability Shield vs Neutralizing Gas/Mold Breaker/Gastro Acid?
+	//      No confirmed research yet for these, but presumably Neutralizing Gas & Mold
+	//      Breaker would start to apply again, whereas Gastro Acid or other "triggered-once"
+	//      moves/abilities triggered before the loss would not automatically trigger unless
 	//      used again.
-	
+
 	// TODO skill swap interaction?
 });

--- a/test/sim/items/abilityshield.js
+++ b/test/sim/items/abilityshield.js
@@ -115,8 +115,6 @@ describe('Ability Shield', function () {
 		battle.makeChoices('move splash', 'move trick');
 		battle.makeChoices('move splash', 'move shadowball');
 
-		// TODO assert some sort of block message as well? I don't *think* there should be a message but not confirmed
-
 		assert.equal(battle.p1.active[0].hp, 1, `Holder should survive due to Sturdy`);
 	});
 
@@ -141,6 +139,9 @@ describe('Ability Shield', function () {
 		]]);
 
 		battle.makeChoices();
+
+		// assert logs?
+
 		assert.equal(battle.p1.active[0].ability, 'shadowtag', `Holder should retain ability`);
 		assert.equal(battle.p2.active[0].ability, 'levitate', `Opponent should retain ability`);
 	});
@@ -153,13 +154,27 @@ describe('Ability Shield', function () {
 		]]);
 
 		battle.makeChoices();
+
+		// assert logs?
+
 		assert.equal(battle.p1.active[0].ability, 'shadowtag', `Holder should retain ability`);
 		assert.equal(battle.p2.active[0].ability, 'levitate', `Opponent should retain ability`);
 	});
 
-	// TODO Tests for unsuppressing abilities like Intimidate (should they re-trigger)? Or perhaps already covered by current Neutralizing Gas tests?
+	// https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9413916
+	it(`should not trigger holder's Intimidate if Ability Shield is acquired after entrance, while Neutralizing Gas is in effect`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'intimidate', moves: ['splash']},
+		], [
+			{species: 'weezinggalar', ability: 'neutralizinggas', item: 'abilityshield', moves: ['trick']},
+		]]);
 
-	// TODO Tests for losing Ability Shield vs Neutralizing Gas/Mold Breaker/Gastro Acid?
+		battle.makeChoices();
+		assert.statStage(battle.p2.active[0], 'atk', 0);
+	});
+
+	// TODO Add future tests for losing Ability Shield vs Neutralizing Gas/Mold Breaker/Gastro Acid?
+	//
 	//      No confirmed research yet for these, but presumably Neutralizing Gas & Mold
 	//      Breaker would start to apply again, whereas Gastro Acid or other "triggered-once"
 	//      moves/abilities triggered before the loss would not automatically trigger unless

--- a/test/sim/items/abilityshield.js
+++ b/test/sim/items/abilityshield.js
@@ -133,13 +133,17 @@ describe('Ability Shield', function () {
 		assert.equal(battle.p1.active[0].ability, 'klutz', `Holder should retain ability`);
 	});
 
-	// TODO Tests for unsuppressing abilities like Intimidate (should they re-trigger)? Or perhaps already covered by current Neutralizing Gas tests?
+	it(`should protect the holder's ability against Skill Swap`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', ability: 'shadowtag', item: 'abilityshield', moves: ['splash']},
+		], [
+			{species: 'weezinggalar', ability: 'levitate', moves: ['skillswap']},
+		]]);
 
-	// TODO Tests for losing Ability Shield vs Neutralizing Gas/Mold Breaker/Gastro Acid?
-	//      No confirmed research yet for these, but presumably Neutralizing Gas & Mold
-	//      Breaker would start to apply again, whereas Gastro Acid or other "triggered-once"
-	//      moves/abilities triggered before the loss would not automatically trigger unless
-	//      used again.
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].ability, 'shadowtag', `Holder should retain ability`);
+		assert.equal(battle.p2.active[0].ability, 'levitate', `Opponent should retain ability`);
+	});
 
 	it.skip(`should protect the holder's ability against Skill Swap, even if used by the holder`, function () {
 		battle = common.createBattle([[
@@ -152,4 +156,12 @@ describe('Ability Shield', function () {
 		assert.equal(battle.p1.active[0].ability, 'shadowtag', `Holder should retain ability`);
 		assert.equal(battle.p2.active[0].ability, 'levitate', `Opponent should retain ability`);
 	});
+
+	// TODO Tests for unsuppressing abilities like Intimidate (should they re-trigger)? Or perhaps already covered by current Neutralizing Gas tests?
+
+	// TODO Tests for losing Ability Shield vs Neutralizing Gas/Mold Breaker/Gastro Acid?
+	//      No confirmed research yet for these, but presumably Neutralizing Gas & Mold
+	//      Breaker would start to apply again, whereas Gastro Acid or other "triggered-once"
+	//      moves/abilities triggered before the loss would not automatically trigger unless
+	//      used again.
 });


### PR DESCRIPTION
I have commented a link to the particular post for tests that were based on results from the SV mechanics research thread! Not all of them pass with the current implementation; the failing tests are suppressed with `.skip` for the time being.

The first three tests were based on my understanding and are technically not confirmed in the thread, but I believe they document the general consensus of how the item works.