### PR TITLE
Gen 1: Fix Toxic-Haze interaction

### DIFF
--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -424,7 +424,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				if (pokemon.status === 'tox') {
 					pokemon.setStatus('psn');
 				}
-				// should only clear a specific set of volatiles and does clear the toxic counter
+				// should only clear a specific set of volatiles
+				// while technically the toxic counter shouldn't be cleared, the preserved toxic counter is never used again
+				// in-game, so it is equivalent to just clear it.
 				const silentHack = '|[silent]';
 				const silentHackVolatiles = ['disable', 'confusion'];
 				const hazeVolatiles: {[key: string]: string} = {

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -424,7 +424,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				if (pokemon.status === 'tox') {
 					pokemon.setStatus('psn');
 				}
-				// should only clear a specific set of volatiles and does not clear the toxic counter
+				// should only clear a specific set of volatiles and does clear the toxic counter
 				const silentHack = '|[silent]';
 				const silentHackVolatiles = ['disable', 'confusion'];
 				const hazeVolatiles: {[key: string]: string} = {
@@ -435,6 +435,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					'leechseed': 'move: Leech Seed',
 					'lightscreen': 'Light Screen',
 					'reflect': 'Reflect',
+					'residualdmg': 'Toxic counter',
 				};
 				for (const v in hazeVolatiles) {
 					if (!pokemon.removeVolatile(v)) {

--- a/test/sim/moves/haze.js
+++ b/test/sim/moves/haze.js
@@ -125,14 +125,16 @@ describe('Haze - RBY', function () {
 		assert.equal(battle.lastMove.name, 'Struggle');
 	});
 
-	it('should convert toxic poisoning to regular poisoning for the user and reset the toxic counter', function () {
+	it('should convert toxic poisoning to regular poisoning for the user and effectively reset the toxic counter', function () {
 		battle = common.gen(1).createBattle([
 			[{species: "Mew", moves: ['toxic']}],
 			[{species: "Abra", moves: ['haze']}],
 		]);
+		const abra = battle.p2.active[0];
 		battle.makeChoices();
-		assert.equal(battle.p2.active[0].status, 'psn');
-		assert.equal(battle.p2.active[0].volatiles.residualdmg, undefined);
+		assert.equal(abra.status, 'psn');
+		battle.makeChoices();
+		assert.equal(abra.maxhp - abra.hp, Math.floor(abra.maxhp / 16) * 2);
 	});
 
 	it('should not remove substitute from either side', function () {

--- a/test/sim/moves/haze.js
+++ b/test/sim/moves/haze.js
@@ -125,14 +125,14 @@ describe('Haze - RBY', function () {
 		assert.equal(battle.lastMove.name, 'Struggle');
 	});
 
-	it('should convert toxic poisoning to regular poisoning for the user but not reset the toxic counter', function () {
+	it('should convert toxic poisoning to regular poisoning for the user and reset the toxic counter', function () {
 		battle = common.gen(1).createBattle([
 			[{species: "Mew", moves: ['toxic']}],
 			[{species: "Abra", moves: ['haze']}],
 		]);
 		battle.makeChoices();
 		assert.equal(battle.p2.active[0].status, 'psn');
-		assert.equal(battle.p2.active[0].volatiles.residualdmg.counter, 1);
+		assert.equal(battle.p2.active[0].volatiles.residualdmg, undefined);
 	});
 
 	it('should not remove substitute from either side', function () {


### PR DESCRIPTION
This patches fixes the interaction between Toxic and Haze. After Haze is used, on cart, the previous Toxic counter is never referred to again. I simulate this behavior by making Haze remove the Toxic counter. While this is different to cart in implementation, it should be identical in result.