### PR TITLE
Gen 1: Fix some more Counter inaccuracies

### DIFF
--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -557,6 +557,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			if (!foe?.lastMove || foe.lastMove.id === 'mirrormove') {
 				return false;
 			}
+			pokemon.side.lastSelectedMove = foe.lastMove.id;
 			this.actions.useMove(foe.lastMove.id, pokemon);
 		},
 	},

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -850,6 +850,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 						this.damage(Math.round(uncappedDamage * move.recoil[0] / move.recoil[1]), source, target, 'recoil');
 					}
 					if (move.drain) {
+						const amount = this.clampIntRange(Math.floor(uncappedDamage * move.drain[0] / move.drain[1]), 1);
+						this.lastDamage = amount;
 						this.heal(Math.ceil(uncappedDamage * move.drain[0] / move.drain[1]), source, target, 'drain');
 					}
 					if (move.secondary?.volatileStatus === 'confusion') {

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -847,7 +847,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				// Drain/recoil/secondary effect confusion do not happen if the substitute breaks
 				if (target.volatiles['substitute']) {
 					if (move.recoil) {
-						this.damage(this.clampIntRange(Math.floor(uncappedDamage * move.recoil[0] / move.recoil[1]), 1), source, target, 'recoil');
+						this.damage(this.clampIntRange(Math.floor(uncappedDamage * move.recoil[0] / move.recoil[1]), 1)
+							, source, target, 'recoil');
 					}
 					if (move.drain) {
 						const amount = this.clampIntRange(Math.floor(uncappedDamage * move.drain[0] / move.drain[1]), 1);

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -847,12 +847,12 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				// Drain/recoil/secondary effect confusion do not happen if the substitute breaks
 				if (target.volatiles['substitute']) {
 					if (move.recoil) {
-						this.damage(Math.round(uncappedDamage * move.recoil[0] / move.recoil[1]), source, target, 'recoil');
+						this.damage(this.clampIntRange(Math.floor(uncappedDamage * move.recoil[0] / move.recoil[1]), 1), source, target, 'recoil');
 					}
 					if (move.drain) {
 						const amount = this.clampIntRange(Math.floor(uncappedDamage * move.drain[0] / move.drain[1]), 1);
 						this.lastDamage = amount;
-						this.heal(Math.ceil(uncappedDamage * move.drain[0] / move.drain[1]), source, target, 'drain');
+						this.heal(amount, source, target, 'drain');
 					}
 					if (move.secondary?.volatileStatus === 'confusion') {
 						const secondary = move.secondary;

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -100,8 +100,6 @@ export const Scripts: ModdedBattleScriptsData = {
 				(!pokemon.volatiles['partialtrappinglock'] || pokemon.volatiles['partialtrappinglock'].locked !== target)
 			) {
 				pokemon.deductPP(move, null, target);
-				// On gen 1 moves are stored when they are chosen and a PP is deducted.
-				pokemon.lastMove = move;
 			} else {
 				sourceEffect = move;
 			}
@@ -144,6 +142,7 @@ export const Scripts: ModdedBattleScriptsData = {
 					(!pokemon.side.foe.active[0]?.lastMove || pokemon.side.foe.active[0].lastMove?.id === 'mirrormove')) {
 					// The move is our 'final' move (a failed Mirror Move, or any move that isn't Metronome or Mirror Move).
 					pokemon.side.lastMove = move;
+					pokemon.lastMove = move;
 					this.battle.singleEvent('AfterMove', move, null, pokemon, target, move);
 
 					// If target fainted

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -101,7 +101,6 @@ export const Scripts: ModdedBattleScriptsData = {
 			) {
 				pokemon.deductPP(move, null, target);
 				// On gen 1 moves are stored when they are chosen and a PP is deducted.
-				pokemon.side.lastMove = move;
 				pokemon.lastMove = move;
 			} else {
 				sourceEffect = move;
@@ -144,6 +143,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				if (move.id !== 'mirrormove' ||
 					(!pokemon.side.foe.active[0]?.lastMove || pokemon.side.foe.active[0].lastMove?.id === 'mirrormove')) {
 					// The move is our 'final' move (a failed Mirror Move, or any move that isn't Metronome or Mirror Move).
+					pokemon.side.lastMove = move;
 					this.battle.singleEvent('AfterMove', move, null, pokemon, target, move);
 
 					// If target fainted

--- a/data/mods/gen1stadium/moves.ts
+++ b/data/mods/gen1stadium/moves.ts
@@ -264,7 +264,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				// Drain/recoil does not happen if the substitute breaks
 				if (target.volatiles['substitute']) {
 					if (move.recoil) {
-						this.damage(Math.round(damage * move.recoil[0] / move.recoil[1]), source, target, 'recoil');
+						this.damage(this.clampIntRange(Math.floor(damage * move.recoil[0] / move.recoil[1]), 1), source, target, 'recoil');
 					}
 				}
 				this.runEvent('AfterSubDamage', target, source, move, damage);

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -90,7 +90,6 @@ export const Scripts: ModdedBattleScriptsData = {
 				(!pokemon.volatiles['partialtrappinglock'] || pokemon.volatiles['partialtrappinglock'].locked !== target)
 			) {
 				pokemon.deductPP(move, null, target);
-				pokemon.lastMove = move;
 			} else {
 				sourceEffect = move;
 			}
@@ -126,6 +125,7 @@ export const Scripts: ModdedBattleScriptsData = {
 					(!pokemon.side.foe.active[0]?.lastMove || pokemon.side.foe.active[0].lastMove?.id === 'mirrormove')) {
 					// The move is our 'final' move (a failed Mirror Move, or any move that isn't Metronome or Mirror Move).
 					pokemon.side.lastMove = move;
+					pokemon.lastMove = move;
 					this.battle.singleEvent('AfterMove', move, null, pokemon, target, move);
 
 					// If target fainted

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -90,7 +90,6 @@ export const Scripts: ModdedBattleScriptsData = {
 				(!pokemon.volatiles['partialtrappinglock'] || pokemon.volatiles['partialtrappinglock'].locked !== target)
 			) {
 				pokemon.deductPP(move, null, target);
-				pokemon.side.lastMove = move;
 				pokemon.lastMove = move;
 			} else {
 				sourceEffect = move;
@@ -126,6 +125,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				if (move.id !== 'mirrormove' ||
 					(!pokemon.side.foe.active[0]?.lastMove || pokemon.side.foe.active[0].lastMove?.id === 'mirrormove')) {
 					// The move is our 'final' move (a failed Mirror Move, or any move that isn't Metronome or Mirror Move).
+					pokemon.side.lastMove = move;
 					this.battle.singleEvent('AfterMove', move, null, pokemon, target, move);
 
 					// If target fainted

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -11888,6 +11888,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				randomMove = this.sample(moves).id;
 			}
 			if (!randomMove) return false;
+			source.side.lastSelectedMove = this.toID(randomMove);
 			this.actions.useMove(randomMove, target);
 		},
 		secondary: null,

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1925,6 +1925,8 @@ export class Battle {
 				}
 				if (this.gen <= 4 && effect.drain && source) {
 					const amount = this.clampIntRange(Math.floor(targetDamage * effect.drain[0] / effect.drain[1]), 1);
+					// Draining can be countered in gen 1
+					if (this.gen <= 1) this.lastDamage = amount;
 					this.heal(amount, source, target, 'drain');
 				}
 				if (this.gen > 4 && effect.drain && source) {
@@ -1978,21 +1980,25 @@ export class Battle {
 
 		// In Gen 1 BUT NOT STADIUM, Substitute also takes confusion and HJK recoil damage
 		if (this.gen <= 1 && this.dex.currentMod !== 'gen1stadium' &&
-			['confusion', 'jumpkick', 'highjumpkick'].includes(effect.id) && target.volatiles['substitute']) {
-			const hint = "In Gen 1, if a Pokemon with a Substitute hurts itself due to confusion or Jump Kick/Hi Jump Kick recoil and the target";
-			if (source?.volatiles['substitute']) {
-				source.volatiles['substitute'].hp -= damage;
-				if (source.volatiles['substitute'].hp <= 0) {
-					source.removeVolatile('substitute');
-					source.subFainted = true;
+			['confusion', 'jumpkick', 'highjumpkick'].includes(effect.id)) {
+			// Confusion and recoil damage can be countered
+			this.lastDamage = damage;
+			if (target.volatiles['substitute']) {
+				const hint = "In Gen 1, if a Pokemon with a Substitute hurts itself due to confusion or Jump Kick/Hi Jump Kick recoil and the target";
+				if (source?.volatiles['substitute']) {
+					source.volatiles['substitute'].hp -= damage;
+					if (source.volatiles['substitute'].hp <= 0) {
+						source.removeVolatile('substitute');
+						source.subFainted = true;
+					} else {
+						this.add('-activate', source, 'Substitute', '[damage]');
+					}
+					this.hint(hint + " has a Substitute, the target's Substitute takes the damage.");
+					return damage;
 				} else {
-					this.add('-activate', source, 'Substitute', '[damage]');
+					this.hint(hint + " does not have a Substitute there is no damage dealt.");
+					return 0;
 				}
-				this.hint(hint + " has a Substitute, the target's Substitute takes the damage.");
-				return damage;
-			} else {
-				this.hint(hint + " does not have a Substitute there is no damage dealt.");
-				return 0;
 			}
 		}
 

--- a/test/sim/moves/counter.js
+++ b/test/sim/moves/counter.js
@@ -273,4 +273,43 @@ describe('Counter', function () {
 		battle.makeChoices('move counter', 'move bodyslam');
 		assert.false.fullHP(battle.p2.active[0]);
 	});
+
+	it(`[Gen 1] (High) Jump Kick recoil can be countered`, function () {
+		battle = common.gen(1).createBattle([[
+			{species: 'Gengar', moves: ['counter']},
+		], [
+			{species: 'Hitmonlee', moves: ['highjumpkick']},
+		]]);
+		battle.makeChoices();
+		const hitmonlee = battle.p2.active[0];
+		assert.equal(hitmonlee.maxhp - hitmonlee.hp, 3);
+	});
+
+	it(`[Gen 1] confusion damage can be countered`, function () {
+		battle = common.gen(1).createBattle({seed: [1, 0, 0, 0]}, [[
+			{species: 'Gengar', moves: ['confuseray', 'counter']},
+		], [
+			{species: 'Alakazam', moves: ['seismictoss']},
+		]]);
+		battle.makeChoices();
+		battle.makeChoices('move counter', 'move seismictoss');
+		const alakazam = battle.p2.active[0];
+		assert.false.fullHP(alakazam);
+		// Confusion damage was countered, not Seismic Toss
+		assert.false.equal(alakazam.maxhp - alakazam.hp, 200);
+	});
+
+	it(`[Gen 1] draining can be countered`, function () {
+		battle = common.gen(1).createBattle({seed: [1, 0, 0, 0]}, [[
+			{species: 'Gengar', moves: ['megadrain', 'counter']},
+		], [
+			{species: 'Alakazam', moves: ['seismictoss']},
+			{species: 'Exeggutor', moves: ['barrage']},
+		]]);
+		battle.makeChoices();
+		battle.makeChoices('move counter', 'switch 2');
+		const gengar = battle.p1.active[0];
+		const exeggutor = battle.p2.active[0];
+		assert.equal(exeggutor.maxhp - exeggutor.hp, (gengar.hp - (gengar.maxhp - 100)) * 2);
+	});
 });

--- a/test/sim/moves/counter.js
+++ b/test/sim/moves/counter.js
@@ -312,4 +312,16 @@ describe('Counter', function () {
 		const exeggutor = battle.p2.active[0];
 		assert.equal(exeggutor.maxhp - exeggutor.hp, (gengar.hp - (gengar.maxhp - 100)) * 2);
 	});
+
+	it(`[Gen 1] Mirror Move can be countered when it calls a counterable move`, function () {
+		battle = common.gen(1).createBattle({seed: [1, 0, 0, 0]}, [[
+			{species: 'Pidgeot', moves: ['mirrormove']},
+		], [
+			{species: 'Alakazam', moves: ['seismictoss', 'counter']},
+		]]);
+		battle.makeChoices();
+		battle.makeChoices('move mirrormove', 'move counter');
+		const pidgeot = battle.p1.active[0];
+		assert.equal(pidgeot.maxhp - pidgeot.hp, 300);
+	});
 });

--- a/test/sim/moves/counter.js
+++ b/test/sim/moves/counter.js
@@ -314,7 +314,7 @@ describe('Counter', function () {
 	});
 
 	it(`[Gen 1] Mirror Move can be countered when it calls a counterable move`, function () {
-		battle = common.gen(1).createBattle({seed: [1, 0, 0, 0]}, [[
+		battle = common.gen(1).createBattle([[
 			{species: 'Pidgeot', moves: ['mirrormove']},
 		], [
 			{species: 'Alakazam', moves: ['seismictoss', 'counter']},


### PR DESCRIPTION
This patch fixes some Counter inaccuracies:

- Draining, (Hi) Jump Kick recoil, and confusion damage update Battle.lastDamage (i.e. the healing/damage can be countered).
- Counter CAN work against counterable moves called by Metronome or Mirror Move.

Also, fixes rounding recoil/drain against substitutes, they should be rounded down.