### PR TITLE
Gen 1: Minor corrections for stat down overflow

### DIFF
--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -839,7 +839,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				// Defense isn't checked on the cartridge, but we don't want those / 0 bugs on the sim.
 				defense = Math.floor(defense / 4) % 256;
 				if (defense === 0) {
-					this.battle.hint('Pokemon Showdown avoids division by zero by rounding defense up to 1.' +
+					this.battle.hint('Pokemon Showdown avoids division by zero by rounding defense up to 1. ' +
 						'In game, the battle would have crashed.');
 					defense = 1;
 				}

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -838,7 +838,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				// Defense isn't checked on the cartridge, but we don't want those / 0 bugs on the sim.
 				defense = Math.floor(defense / 4) % 256;
 				if (defense === 0) {
-					this.battle.hint('Pokemon Showdown avoids division by zero by rounding defense up to 1.' +
+					this.battle.hint('Pokemon Showdown avoids division by zero by rounding defense up to 1. ' +
 						'In game, the battle would have crashed.');
 					defense = 1;
 				}

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -808,7 +808,6 @@ export const Scripts: ModdedBattleScriptsData = {
 			if ((defType === 'def' && defender.volatiles['reflect']) || (defType === 'spd' && defender.volatiles['lightscreen'])) {
 				this.battle.debug('Screen doubling (Sp)Def');
 				defense *= 2;
-				defense = this.battle.clampIntRange(defense, 1, 1998);
 			}
 
 			// In the event of a critical hit, the offense and defense changes are ignored.
@@ -839,7 +838,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				// Defense isn't checked on the cartridge, but we don't want those / 0 bugs on the sim.
 				defense = Math.floor(defense / 4) % 256;
 				if (defense === 0) {
-					this.battle.hint('Pokemon Showdown avoids division by zero by rounding defense up to 1. ' +
+					this.battle.hint('Pokemon Showdown avoids division by zero by rounding defense up to 1.' +
 						'In game, the battle would have crashed.');
 					defense = 1;
 				}

--- a/test/sim/misc/statdownoverflow.js
+++ b/test/sim/misc/statdownoverflow.js
@@ -15,7 +15,6 @@ describe('[Gen 1] Stat Drop Overflow', function () {
 		battle.setPlayer('p1', {team: [{species: "Mewtwo", moves: ['amnesia', 'psychic'], evs: {'spa': 104, 'spd': 104}, ivs: {'spa': 3, 'spd': 3}}]});
 		battle.setPlayer('p2', {team: [{species: "Slowbro", moves: ['amnesia', 'psychic', 'surf'], evs: {'spa': 255, 'spd': 255}, dvs: {'spa': 15, 'spd': 15}}]});
 		const mewtwo = battle.p1.active[0];
-		console.log(mewtwo.storedStats['spa']);
 		assert(mewtwo.storedStats['spa'] === 341);
 		battle.makeChoices();
 		battle.makeChoices();


### PR DESCRIPTION
Fixes a couple little issues with the stat down overflow patch:
- Adds a space to the hint regarding div by 0
- Removes an unremoved console.log from the test
- Remove clamping for Reflect / Light Screen