### PR TITLE
Rooms: Only lockdown after restarts when battles crash

### DIFF
--- a/lib/crashlogger.ts
+++ b/lib/crashlogger.ts
@@ -12,7 +12,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 const CRASH_EMAIL_THROTTLE = 5 * 60 * 1000; // 5 minutes
-const LOCKDOWN_PERIOD = 30 * 60 * 1000; // 30 minutes
 
 const logPath = path.resolve(__dirname, '../logs/errors.txt');
 let lastCrashLog = 0;
@@ -83,11 +82,6 @@ export function crashlogger(
 		}, (err: Error | null) => {
 			if (err) console.error(`Error sending email: ${err}`);
 		});
-	}
-
-	if (process.uptime() * 1000 < LOCKDOWN_PERIOD) {
-		// lock down the server
-		return 'lockdown';
 	}
 
 	return null;


### PR DESCRIPTION
Doing this per Wob's approval. This is mostly a PR to see if anyone has a preference on how we do this or not. I chose to just send a `error` message back to the parent process (since that crashlogging is handled in the child) with the details of the error for logging if a restart is necessary, since I felt that was the simplest option.
Will merge in a day or so if no one has any opinions.