### PR TITLE
Fix Wind Rider and Wind Power

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -4988,6 +4988,12 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 193,
 	},
 	windpower: {
+		onStart(pokemon) {
+			if (pokemon.side.sideConditions['tailwind']) {
+				this.add('-activate', pokemon, 'ability: Wind Power', '[move] Tailwind');
+				pokemon.addVolatile('charge');
+			}
+		},
 		onDamagingHit(damage, target, source, move) {
 			if (move.flags['wind']) {
 				this.add('-activate', target, 'ability: Wind Power', '[move] ' + move.name);
@@ -5006,6 +5012,11 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 277,
 	},
 	windrider: {
+		onStart(pokemon) {
+			if (pokemon.side.sideConditions['tailwind']) {
+				this.boost({atk: 1}, pokemon, pokemon, this.dex.abilities.get('windrider'), true);
+			}
+		},
 		onTryHit(target, source, move) {
 			if (target !== source && move.flags['wind']) {
 				if (!this.boost({atk: 1})) {

--- a/test/sim/abilities/windrider.js
+++ b/test/sim/abilities/windrider.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const common = require('../../common');
+const assert = require('../../assert');
+
+let battle;
+
+describe("Wind Rider", () => {
+	afterEach(() => {
+		battle.destroy();
+	});
+
+	it("should boost the Pokemon's Attack when Tailwind starts", () => {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Brambleghast', ability: 'windrider', moves: ['sleeptalk']},
+			{species: 'Pelipper', ability: 'keeneye', moves: ['tailwind']},
+		], [
+			{species: 'Mareep', ability: 'static', moves: ['sleeptalk']},
+			{species: 'Lechonk', ability: 'gluttony', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].boosts.atk, 1);
+	});
+
+	it("should boost the Pokemon's Attack when it switches into Tailwind", () => {
+		battle = common.createBattle([[
+			{species: 'Pelipper', ability: 'keeneye', moves: ['tailwind']},
+			{species: 'Brambleghast', ability: 'windrider', moves: ['sleeptalk']},
+		], [
+			{species: 'Lechonk', ability: 'gluttony', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		battle.makeChoices('switch 2', 'auto');
+		assert.equal(battle.p1.active[0].boosts.atk, 1);
+	});
+});


### PR DESCRIPTION
They should activate if the Pokemon switches in on Tailwind, as well