### PR TITLE
Fix Commander vs Transform and Eject items

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -567,7 +567,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	commander: {
 		onUpdate(pokemon) {
 			const ally = pokemon.allies()[0];
-			if (!ally || pokemon.species.baseSpecies !== 'Tatsugiri' || ally.species.baseSpecies !== 'Dondozo') {
+			if (!ally || pokemon.baseSpecies.baseSpecies !== 'Tatsugiri' || ally.baseSpecies.baseSpecies !== 'Dondozo') {
 				// Handle any edge cases
 				if (pokemon.getVolatile('commanding')) pokemon.removeVolatile('commanding');
 				return;

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -567,7 +567,8 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	commander: {
 		onUpdate(pokemon) {
 			const ally = pokemon.allies()[0];
-			if (!ally || pokemon.species.baseSpecies !== 'Tatsugiri' || ally.species.id !== 'dondozo') {
+			if (!ally || pokemon.species.baseSpecies !== 'Tatsugiri' || ally.species.id !== 'dondozo' ||
+				ally.transformed || pokemon.transformed) {
 				// Handle any edge cases
 				if (pokemon.getVolatile('commanding')) pokemon.removeVolatile('commanding');
 				return;

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -567,8 +567,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	commander: {
 		onUpdate(pokemon) {
 			const ally = pokemon.allies()[0];
-			if (!ally || pokemon.species.baseSpecies !== 'Tatsugiri' || ally.species.id !== 'dondozo' ||
-				ally.transformed || pokemon.transformed) {
+			if (!ally || pokemon.species.baseSpecies !== 'Tatsugiri' || ally.species.baseSpecies !== 'Dondozo') {
 				// Handle any edge cases
 				if (pokemon.getVolatile('commanding')) pokemon.removeVolatile('commanding');
 				return;

--- a/data/items.ts
+++ b/data/items.ts
@@ -1482,6 +1482,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		onAfterMoveSecondary(target, source, move) {
 			if (source && source !== target && target.hp && move && move.category !== 'Status' && !move.isFutureMove) {
 				if (!this.canSwitch(target.side) || target.forceSwitchFlag || target.beingCalledBack || target.isSkyDropped()) return;
+				if (target.volatiles['commanding'] || target.volatiles['commanded']) return;
 				for (const pokemon of this.getAllActive()) {
 					if (pokemon.switchFlag === true) return;
 				}
@@ -1514,6 +1515,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			if (eject) {
 				if (target.hp) {
 					if (!this.canSwitch(target.side)) return;
+					if (target.volatiles['commanding'] || target.volatiles['commanded']) return;
 					for (const pokemon of this.getAllActive()) {
 						if (pokemon.switchFlag === true) return;
 					}

--- a/test/sim/abilities/commander.js
+++ b/test/sim/abilities/commander.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Commander', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it(`should skip Tatsugiri's action while commanding`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'wynaut', moves: ['sleeptalk']},
+			{species: 'wobbuffet', moves: ['sleeptalk']},
+		], [
+			{species: 'tatsugiri', ability: 'commander', moves: ['swordsdance']},
+			{species: 'dondozo', moves: ['sleeptalk']},
+		]]);
+		assert.cantMove(() => battle.p2.choose('move swordsdance', 'move sleeptalk'));
+	});
+
+	it(`should not work if either Pokemon is Transformed`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'wynaut', moves: ['sleeptalk']},
+			{species: 'dondozo', moves: ['sleeptalk']},
+		], [
+			{species: 'tatsugiri', ability: 'commander', moves: ['sleeptalk']},
+			{species: 'mew', moves: ['transform']},
+		]]);
+
+		battle.makeChoices('auto', 'move sleeptalk, move transform 2');
+		const mewDondozo = battle.p2.active[1];
+		assert.false(!!mewDondozo.volatiles['commanding']);
+	});
+
+	it.skip(`should cause Tatsugiri to dodge all moves, including moves which normally bypass semi-invulnerability`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'machamp', ability: 'noguard', moves: ['closecombat']},
+			{species: 'seviper', moves: ['toxic']},
+		], [
+			{species: 'tatsugiri', ability: 'commander', moves: ['sleeptalk']},
+			{species: 'dondozo', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move closecombat 1, move toxic 1', 'auto');
+		console.log(battle.getDebugLog());
+
+		// Tatsugiri shouldn't be damaged from No Guard CC or Toxic
+		assert.fullHP(battle.p2.active[0]);
+
+		// It shouldn't redirect to Dondozo either
+		assert.fullHP(battle.p2.active[1]);
+	});
+
+	it(`should prevent all kinds of switchouts`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'wynaut', item: 'redcard', ability: 'noguard', moves: ['sleeptalk', 'tackle', 'dragontail']},
+			{species: 'gyarados', item: 'ejectbutton', ability: 'intimidate', moves: ['sleeptalk', 'trick', 'roar']},
+		], [
+			{species: 'tatsugiri', ability: 'commander', item: 'ejectpack', moves: ['sleeptalk']},
+			{species: 'dondozo', item: 'ejectpack', moves: ['sleeptalk', 'peck']},
+			{species: 'rufflet', moves: ['sleeptalk']},
+		]]);
+
+		const tatsugiri = battle.p2.active[0];
+		const dondozo = battle.p2.active[1];
+
+		assert.statStage(tatsugiri, 'atk', -1);
+		assert.holdsItem(tatsugiri);
+		assert.statStage(dondozo, 'atk', 1);
+		assert.holdsItem(dondozo);
+		assert.equal(battle.requestState, 'move', 'It should not have switched out on Eject Pack');
+
+		battle.makeChoices('move tackle 2, move trick 2', 'auto');
+		assert.holdsItem(dondozo);
+		assert.equal(battle.requestState, 'move', 'It should not have switched out on Eject Button');
+
+		battle.makeChoices('auto', 'move peck 1');
+		assert.false.holdsItem(battle.p1.active[0]);
+		assert.equal(battle.requestState, 'move', 'It should not have switched out on Red Card');
+
+		battle.makeChoices('move dragontail 2, move roar 2', 'auto');
+		assert.equal(battle.requestState, 'move', 'It should not have switched out on standard phazing moves');
+	});
+
+	it(`should cause Dondozo to stay commanded even if Tatsugiri faints`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'hypno', moves: ['sleeptalk']},
+			{species: 'shuckle', moves: ['sleeptalk']},
+		], [
+			{species: 'tatsugiri', ability: 'commander', item: 'toxicorb', moves: ['sleeptalk']},
+			{species: 'dondozo', moves: ['sleeptalk', 'orderup']},
+			{species: 'teddiursa', moves: ['sleeptalk']},
+			{species: 'tatsugiridroopy', ability: 'commander', moves: ['sleeptalk']},
+		]]);
+
+		// Kill turns for Toxic Orb to KO Tatsugiri
+		for (let i = 0; i < 7; i++) battle.makeChoices();
+		battle.makeChoices('', 'switch teddiursa');
+		assert.cantMove(() => battle.p2.choose('move sleeptalk, switch tatsugiri'));
+		battle.makeChoices('auto', 'switch tatsugiridroopy, move orderup 1');
+		assert.statStage(battle.p2.pokemon[1], 'atk', 3);
+	});
+
+	it(`should allow one Tatsugiri to occupy multiple Dondozo`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'wynaut', ability: 'noguard', moves: ['sheercold']},
+			{species: 'shuckle', moves: ['sleeptalk']},
+		], [
+			{species: 'tatsugiri', ability: 'commander', moves: ['sleeptalk']},
+			{species: 'dondozo', moves: ['sleeptalk']},
+			{species: 'dondozo', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move sheercold 2, move sleeptalk', 'auto');
+		battle.makeChoices('', 'switch 3');
+
+		const secondDondozo = battle.p2.active[1];
+		assert(!!secondDondozo.volatiles['commanded']);
+	});
+});

--- a/test/sim/abilities/commander.js
+++ b/test/sim/abilities/commander.js
@@ -45,7 +45,6 @@ describe('Commander', function () {
 		]]);
 
 		battle.makeChoices('move closecombat 1, move toxic 1', 'auto');
-		console.log(battle.getDebugLog());
 
 		// Tatsugiri shouldn't be damaged from No Guard CC or Toxic
 		assert.fullHP(battle.p2.active[0]);


### PR DESCRIPTION
Also added some basic tests for Commander. Apparently Toxic is done in a janky way (maybe it was changed because of the sure-hit Toxic glitch stuff?), so that currently fails but it has to do with Toxic, not Commander, so I think it's outside the scope of this PR.