### PR TITLE
Partners in Crime: Update thread and alias for Gen 9

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -838,7 +838,7 @@ export const Formats: FormatList = [
 		name: "[Gen 9] Partners in Crime",
 		desc: `Doubles-based metagame where both active ally Pok&eacute;mon share abilities and moves.`,
 		threads: [
-			`&bullet; <a href="https://www.smogon.com/forums/threads/3706080/">Partners in Crime</a>`,
+			`&bullet; <a href="https://www.smogon.com/forums/threads/3710997/">Partners in Crime</a>`,
 		],
 
 		mod: 'partnersincrime',

--- a/data/aliases.ts
+++ b/data/aliases.ts
@@ -35,7 +35,7 @@ export const Aliases: {[alias: string]: string} = {
 	gen8aaa: "[Gen 8] Almost Any Ability",
 	stab: "[Gen 9] STABmons",
 	gg: "[Gen 9] Godly Gift",
-	pic: "[Gen 8] Partners in Crime",
+	pic: "[Gen 9] Partners in Crime",
 	camo: "[Gen 8] Camomons",
 	ffa: "[Gen 8] Free-For-All",
 	ts: "[Gen 8] Tier Shift",


### PR DESCRIPTION
I forgot to do this in my prior pull request when I was updating everything to gen 9. oops.