### PR TITLE
Gen 1: Fix more Counter bugs

### DIFF
--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -837,7 +837,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				// NOTE: In future generations the damage is capped to the remaining HP of the
 				// Substitute, here we deliberately use the uncapped damage when tracking lastDamage etc.
 				// Also, multi-hit moves must always deal the same damage as the first hit for any subsequent hits
-				let uncappedDamage = move.hit > 1 ? source.lastDamage : this.actions.getDamage(source, target, move);
+				let uncappedDamage = move.hit > 1 ? this.lastDamage : this.actions.getDamage(source, target, move);
 				if (!uncappedDamage && uncappedDamage !== 0) return null;
 				uncappedDamage = this.runEvent('SubDamage', target, source, move, uncappedDamage);
 				if (!uncappedDamage && uncappedDamage !== 0) return uncappedDamage;

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -763,6 +763,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	sonicboom: {
 		inherit: true,
 		ignoreImmunity: true,
+		basePower: 1,
 	},
 	softboiled: {
 		inherit: true,

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -226,7 +226,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			if (!lastMoveIsCounterable && !lastSelectedMoveIsCounterable) {
 				this.debug("Gen 1 Counter: last move was not Counterable");
 				this.add('-fail', pokemon);
-				this.lastDamage = 0;
 				return false;
 			}
 			if (this.lastDamage <= 0) {
@@ -237,7 +236,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			if (!lastMoveIsCounterable || !lastSelectedMoveIsCounterable) {
 				this.hint("Desync Clause Mod activated!");
 				this.add('-fail', pokemon);
-				this.lastDamage = 0;
 				return false;
 			}
 

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -226,6 +226,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			if (!lastMoveIsCounterable && !lastSelectedMoveIsCounterable) {
 				this.debug("Gen 1 Counter: last move was not Counterable");
 				this.add('-fail', pokemon);
+				this.lastDamage = 0;
 				return false;
 			}
 			if (this.lastDamage <= 0) {
@@ -236,6 +237,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			if (!lastMoveIsCounterable || !lastSelectedMoveIsCounterable) {
 				this.hint("Desync Clause Mod activated!");
 				this.add('-fail', pokemon);
+				this.lastDamage = 0;
 				return false;
 			}
 

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -839,7 +839,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				if (!uncappedDamage && uncappedDamage !== 0) return null;
 				uncappedDamage = this.runEvent('SubDamage', target, source, move, uncappedDamage);
 				if (!uncappedDamage && uncappedDamage !== 0) return uncappedDamage;
-				source.lastDamage = uncappedDamage;
 				this.lastDamage = uncappedDamage;
 				target.volatiles['substitute'].hp -= uncappedDamage > target.volatiles['substitute'].hp ?
 					target.volatiles['substitute'].hp : uncappedDamage;

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -281,7 +281,8 @@ export const Scripts: ModdedBattleScriptsData = {
 			const neverDamageMoves = [
 				'conversion', 'haze', 'mist', 'focusenergy', 'confuseray', 'supersonic', 'transform', 'lightscreen', 'reflect', 'substitute', 'mimic', 'leechseed', 'splash', 'softboiled', 'recover', 'rest', 'teleport',
 			];
-			if (move.id !== 'counter' &&
+			if (
+				move.id !== 'counter' &&
 				(move.category !== 'Status' || (move.status && !['psn', 'tox', 'par'].includes(move.status))) &&
 				!neverDamageMoves.includes(move.id)
 			) {

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -387,6 +387,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				this.battle.add('-miss', pokemon);
 				if (accuracy === 255) this.battle.hint("In Gen 1, moves with 100% accuracy can still miss 1/256 of the time.");
 				damage = false;
+				this.battle.lastDamage = 0;
 			}
 
 			// If damage is 0 and not false it means it didn't miss, let's calc.

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -276,20 +276,19 @@ export const Scripts: ModdedBattleScriptsData = {
 				this.battle.add('-notarget');
 				return true;
 			}
-			damage = this.tryMoveHit(target, pokemon, move);
-
-			// Store 0 damage for last damage if move failed.
-			// This only happens on moves that don't deal damage but call GetDamageVarsForPlayerAttack (disassembly).
+			// Store 0 damage for last damage.
+			// This only happens on moves that call GetDamageVarsForPlayerAttack (disassembly).
 			const neverDamageMoves = [
-				'conversion', 'haze', 'mist', 'focusenergy', 'confuseray', 'supersonic', 'transform', 'lightscreen', 'reflect', 'substitute', 'mimic', 'leechseed', 'splash', 'softboiled', 'recover', 'rest',
+				'conversion', 'haze', 'mist', 'focusenergy', 'confuseray', 'supersonic', 'transform', 'lightscreen', 'reflect', 'substitute', 'mimic', 'leechseed', 'splash', 'softboiled', 'recover', 'rest', 'teleport',
 			];
-			if (
-				!damage && damage !== 0 &&
+			if (move.id !== 'counter' &&
 				(move.category !== 'Status' || (move.status && !['psn', 'tox', 'par'].includes(move.status))) &&
 				!neverDamageMoves.includes(move.id)
 			) {
 				this.battle.lastDamage = 0;
 			}
+
+			damage = this.tryMoveHit(target, pokemon, move);
 
 			// Disable and Selfdestruct/Explosion boost rage, regardless of whether they miss/fail.
 			if (target.boosts.atk < 6 && (move.selfdestruct || move.id === 'disable') && target.volatiles['rage']) {

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -539,7 +539,6 @@ export const Scripts: ModdedBattleScriptsData = {
 				if (damage && damage > target.hp) {
 					damage = target.hp;
 				}
-
 				if ((damage || damage === 0) && !target.fainted) {
 					damage = this.battle.damage(damage, target, pokemon, move);
 					if (!(damage || damage === 0)) return false;

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -135,7 +135,6 @@ export const Scripts: ModdedBattleScriptsData = {
 					return;
 				}
 			}
-			pokemon.lastDamage = 0;
 			let lockedMove = this.battle.runEvent('LockMove', pokemon);
 			if (lockedMove === true) lockedMove = false;
 			if (
@@ -392,7 +391,6 @@ export const Scripts: ModdedBattleScriptsData = {
 
 			// If damage is 0 and not false it means it didn't miss, let's calc.
 			if (damage !== false) {
-				pokemon.lastDamage = 0;
 				if (move.multihit) {
 					let hits = move.multihit;
 					if (Array.isArray(hits)) {

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -536,6 +536,10 @@ export const Scripts: ModdedBattleScriptsData = {
 				// basically, these values have the same meanings as they do for event
 				// handlers.
 
+				if (damage && damage > target.hp) {
+					damage = target.hp;
+				}
+
 				if ((damage || damage === 0) && !target.fainted) {
 					damage = this.battle.damage(damage, target, pokemon, move);
 					if (!(damage || damage === 0)) return false;
@@ -896,7 +900,6 @@ export const Scripts: ModdedBattleScriptsData = {
 			if (damage > 1) {
 				damage *= this.battle.random(217, 256);
 				damage = Math.floor(damage / 255);
-				if (damage > target.hp && !target.volatiles['substitute']) damage = target.hp;
 			}
 
 			// And we are done.

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -650,7 +650,7 @@ export const Scripts: ModdedBattleScriptsData = {
 
 			// Now we can save the partial trapping damage.
 			if (pokemon.volatiles['partialtrappinglock']) {
-				pokemon.volatiles['partialtrappinglock'].damage = pokemon.lastDamage;
+				pokemon.volatiles['partialtrappinglock'].damage = this.battle.lastDamage;
 			}
 
 			// Apply move secondaries.

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -276,7 +276,6 @@ export const Scripts: ModdedBattleScriptsData = {
 				return true;
 			}
 			// Store 0 damage for last damage.
-			// This only happens on moves that call GetDamageVarsForPlayerAttack (disassembly).
 			const neverDamageMoves = [
 				'conversion', 'haze', 'mist', 'focusenergy', 'confuseray', 'supersonic', 'transform', 'lightscreen', 'reflect', 'substitute', 'mimic', 'leechseed', 'splash', 'softboiled', 'recover', 'rest', 'teleport',
 			];

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -704,7 +704,7 @@ export const Scripts: ModdedBattleScriptsData = {
 
 			// Is it an OHKO move?
 			if (move.ohko) {
-				return target.maxhp;
+				return 65535;
 			}
 
 			// We edit the damage through move's damage callback if necessary.

--- a/data/mods/gen1jpn/moves.ts
+++ b/data/mods/gen1jpn/moves.ts
@@ -79,7 +79,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				// NOTE: In future generations the damage is capped to the remaining HP of the
 				// Substitute, here we deliberately use the uncapped damage when tracking lastDamage etc.
 				// Also, multi-hit moves must always deal the same damage as the first hit for any subsequent hits
-				let uncappedDamage = move.hit > 1 ? source.lastDamage : this.actions.getDamage(source, target, move);
+				let uncappedDamage = move.hit > 1 ? this.lastDamage : this.actions.getDamage(source, target, move);
 				if (!uncappedDamage && uncappedDamage !== 0) return null;
 				uncappedDamage = this.runEvent('SubDamage', target, source, move, uncappedDamage);
 				if (!uncappedDamage && uncappedDamage !== 0) return uncappedDamage;

--- a/data/mods/gen1jpn/moves.ts
+++ b/data/mods/gen1jpn/moves.ts
@@ -83,7 +83,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				if (!uncappedDamage && uncappedDamage !== 0) return null;
 				uncappedDamage = this.runEvent('SubDamage', target, source, move, uncappedDamage);
 				if (!uncappedDamage && uncappedDamage !== 0) return uncappedDamage;
-				source.lastDamage = uncappedDamage;
 				this.lastDamage = uncappedDamage;
 				target.volatiles['substitute'].hp -= uncappedDamage > target.volatiles['substitute'].hp ?
 					target.volatiles['substitute'].hp : uncappedDamage;

--- a/data/mods/gen1stadium/moves.ts
+++ b/data/mods/gen1stadium/moves.ts
@@ -104,6 +104,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			if (!lastMoveThisTurn) {
 				this.debug("Stadium 1 Counter: last move was not this turn");
 				this.add('-fail', pokemon);
+				this.lastDamage = 0;
 				return false;
 			}
 
@@ -112,6 +113,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			if (!lastMoveThisTurnIsCounterable) {
 				this.debug(`Stadium 1 Counter: last move ${lastMoveThisTurn.name} was not Counterable`);
 				this.add('-fail', pokemon);
+				this.lastDamage = 0;
 				return false;
 			}
 			if (this.lastDamage <= 0) {

--- a/data/mods/gen1stadium/moves.ts
+++ b/data/mods/gen1stadium/moves.ts
@@ -104,7 +104,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			if (!lastMoveThisTurn) {
 				this.debug("Stadium 1 Counter: last move was not this turn");
 				this.add('-fail', pokemon);
-				this.lastDamage = 0;
 				return false;
 			}
 
@@ -113,7 +112,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			if (!lastMoveThisTurnIsCounterable) {
 				this.debug(`Stadium 1 Counter: last move ${lastMoveThisTurn.name} was not Counterable`);
 				this.add('-fail', pokemon);
-				this.lastDamage = 0;
 				return false;
 			}
 			if (this.lastDamage <= 0) {

--- a/data/mods/gen1stadium/moves.ts
+++ b/data/mods/gen1stadium/moves.ts
@@ -255,7 +255,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				damage = this.runEvent('SubDamage', target, source, move, damage);
 				if (!damage && damage !== 0) return damage;
 				target.volatiles['substitute'].hp -= damage;
-				source.lastDamage = damage;
 				this.lastDamage = damage;
 				if (target.volatiles['substitute'].hp <= 0) {
 					this.debug('Substitute broke');

--- a/data/mods/gen1stadium/moves.ts
+++ b/data/mods/gen1stadium/moves.ts
@@ -248,6 +248,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				}
 				if (move.volatileStatus && target === source) return;
 				let damage = this.actions.getDamage(source, target, move);
+				if (damage && damage > target.volatiles['substitute'].hp) {
+					damage = target.volatiles['substitute'].hp;
+				}
 				if (!damage && damage !== 0) return null;
 				damage = this.runEvent('SubDamage', target, source, move, damage);
 				if (!damage && damage !== 0) return damage;

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -206,20 +206,20 @@ export const Scripts: ModdedBattleScriptsData = {
 				this.battle.add('-notarget');
 				return true;
 			}
-			damage = this.tryMoveHit(target, pokemon, move);
-
-			// Store 0 damage for last damage if move failed.
+			// Store 0 damage for last damage.
 			// This only happens on moves that don't deal damage but call GetDamageVarsForPlayerAttack (disassembly).
 			const neverDamageMoves = [
-				'conversion', 'haze', 'mist', 'focusenergy', 'confuseray', 'supersonic', 'transform', 'lightscreen', 'reflect', 'substitute', 'mimic', 'leechseed', 'splash', 'softboiled', 'recover', 'rest',
+				'conversion', 'haze', 'mist', 'focusenergy', 'confuseray', 'supersonic', 'transform', 'lightscreen', 'reflect', 'substitute', 'mimic', 'leechseed', 'splash', 'softboiled', 'recover', 'rest', 'teleport',
 			];
 			if (
-				!damage && damage !== 0 &&
+				move.id !== 'counter' &&
 				(move.category !== 'Status' || (move.status && !['psn', 'tox', 'par'].includes(move.status))) &&
 				!neverDamageMoves.includes(move.id)
 			) {
 				this.battle.lastDamage = 0;
 			}
+
+			damage = this.tryMoveHit(target, pokemon, move);
 
 			// Go ahead with results of the used move.
 			if (damage === false) {

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -550,7 +550,7 @@ export const Scripts: ModdedBattleScriptsData = {
 
 			// Is it an OHKO move?
 			if (move.ohko) {
-				return target.maxhp;
+				return 65535;
 			}
 
 			// We edit the damage through move's damage callback if necessary.

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -206,7 +206,6 @@ export const Scripts: ModdedBattleScriptsData = {
 				return true;
 			}
 			// Store 0 damage for last damage.
-			// This only happens on moves that don't deal damage but call GetDamageVarsForPlayerAttack (disassembly).
 			const neverDamageMoves = [
 				'conversion', 'haze', 'mist', 'focusenergy', 'confuseray', 'supersonic', 'transform', 'lightscreen', 'reflect', 'substitute', 'mimic', 'leechseed', 'splash', 'softboiled', 'recover', 'rest', 'teleport',
 			];

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -503,7 +503,7 @@ export const Scripts: ModdedBattleScriptsData = {
 
 			// Now we can save the partial trapping damage.
 			if (pokemon.volatiles['partialtrappinglock']) {
-				pokemon.volatiles['partialtrappinglock'].damage = pokemon.lastDamage;
+				pokemon.volatiles['partialtrappinglock'].damage = this.battle.lastDamage;
 			}
 
 			// Apply move secondaries.

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -82,7 +82,6 @@ export const Scripts: ModdedBattleScriptsData = {
 					return;
 				}
 			}
-			pokemon.lastDamage = 0;
 			let lockedMove = this.battle.runEvent('LockMove', pokemon);
 			if (lockedMove === true) lockedMove = false;
 			if (
@@ -311,7 +310,6 @@ export const Scripts: ModdedBattleScriptsData = {
 
 			// If damage is 0 and not false it means it didn't miss, let's calc.
 			if (damage !== false) {
-				pokemon.lastDamage = 0;
 				if (move.multihit) {
 					let hits = move.multihit;
 					if (Array.isArray(hits)) {

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -306,6 +306,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				this.battle.attrLastMove('[miss]');
 				this.battle.add('-miss', pokemon);
 				damage = false;
+				this.battle.lastDamage = 0;
 			}
 
 			// If damage is 0 and not false it means it didn't miss, let's calc.

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -426,6 +426,9 @@ export const Scripts: ModdedBattleScriptsData = {
 				let didSomething = false;
 
 				damage = this.getDamage(pokemon, target, moveData);
+				if (damage && damage > target.hp) {
+					damage = target.hp;
+				}
 				if ((damage || damage === 0) && !target.fainted) {
 					damage = this.battle.damage(damage, target, pokemon, move);
 					if (!(damage || damage === 0)) return false;
@@ -748,10 +751,6 @@ export const Scripts: ModdedBattleScriptsData = {
 			if (damage > 1) {
 				damage *= this.battle.random(217, 256);
 				damage = Math.floor(damage / 255);
-				if (damage > target.hp && !target.volatiles['substitute']) damage = target.hp;
-				if (target.volatiles['substitute'] && damage > target.volatiles['substitute'].hp) {
-					damage = target.volatiles['substitute'].hp;
-				}
 			}
 
 			// We are done, this is the final damage.

--- a/test/sim/moves/counter.js
+++ b/test/sim/moves/counter.js
@@ -324,4 +324,14 @@ describe('Counter', function () {
 		const pidgeot = battle.p1.active[0];
 		assert.equal(pidgeot.maxhp - pidgeot.hp, 300);
 	});
+
+	it(`[Gen 1] Moves with unique damage calculation don't overdamage a target with less HP`, function () {
+		battle = common.gen(1).createBattle([[
+			{species: 'Gengar', moves: ['seismictoss']},
+		], [
+			{species: 'Abra', moves: ['teleport'], level: 5},
+		]]);
+		battle.makeChoices();
+		assert(battle.lastDamage < 100);
+	});
 });


### PR DESCRIPTION
This patch fixes many counter bugs:
- Sonic Boom can now be countered (previously it couldn't).
- OHKO moves do 65535 damage (matters if OHKO move hits a sub and gets Countered).
- Reducing damage to target.hp when damage > target.hp is now done outside getDamage: this ensures that moves that return early in getDamage, like Seismic Toss, OHKO moves, etc., still get their damage reduced when they OHKO a lower HP enemy, hence ensuring that Counter in the future doesn't do more damage than it should.
- Metronome calling Counter will always fail, as it should. This is done by zeroing battle.lastDamage for most moves (including Metronome) before calling tryMoveHit. For regular damaging moves, this makes no difference, since we would previously zero it after tryMoveHit only if the move misses/fails. Here, we zero it first and then set it to something non-zero if the attack is successful and does damage.
- If a move misses, battle.lastDamage is set to 0.

We also remove parts of the code relating to pokemon.lastDamage, which is never used in Gen 1.