### PR TITLE
Hackmons Cup and Challenge Cup: Make TRs and Balls much less likely

### DIFF
--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -791,7 +791,7 @@ export class RandomTeams {
 				do {
 					itemData = this.sampleNoReplace(itemPool);
 					item = itemData?.name;
-					isBadItem = !(item === "Light Ball") && item.endsWith("Ball") || item.startsWith("TR");
+					isBadItem = item !== "Light Ball" && item.endsWith("Ball") || item.startsWith("TR");
 				} while (isBadItem && this.randomChance(19, 20) && itemPool.length > this.maxTeamSize);
 			}
 

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -386,7 +386,7 @@ export class RandomTeams {
 				do {
 					item = this.sample(items).name;
 					isIllegalItem = this.dex.items.get(item).gen > this.gen || this.dex.items.get(item).isNonstandard;
-					isBadItem = item.endsWith("Ball") || item.startsWith("TR");
+					isBadItem = !(item === "Light Ball") && item.endsWith("Ball") || item.startsWith("TR");
 				} while (isIllegalItem || (isBadItem && this.randomChance(19, 20)));
 			}
 
@@ -791,7 +791,7 @@ export class RandomTeams {
 				do {
 					itemData = this.sampleNoReplace(itemPool);
 					item = itemData?.name;
-					isBadItem = item.endsWith("Ball") || item.startsWith("TR");
+					isBadItem = !(item === "Light Ball") && item.endsWith("Ball") || item.startsWith("TR");
 				} while (isBadItem && this.randomChance(19, 20) && itemPool.length > this.maxTeamSize);
 			}
 

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -386,7 +386,7 @@ export class RandomTeams {
 				do {
 					item = this.sample(items).name;
 					isIllegalItem = this.dex.items.get(item).gen > this.gen || this.dex.items.get(item).isNonstandard;
-					isBadItem = !(item === "Light Ball") && item.endsWith("Ball") || item.startsWith("TR");
+					isBadItem = item.endsWith("Ball") || item.startsWith("TR") && item !== "Light Ball";
 				} while (isIllegalItem || (isBadItem && this.randomChance(19, 20)));
 			}
 
@@ -791,7 +791,7 @@ export class RandomTeams {
 				do {
 					itemData = this.sampleNoReplace(itemPool);
 					item = itemData?.name;
-					isBadItem = item !== "Light Ball" && item.endsWith("Ball") || item.startsWith("TR");
+					isBadItem = item.endsWith("Ball") || item.startsWith("TR") && item !== "Light Ball";
 				} while (isBadItem && this.randomChance(19, 20) && itemPool.length > this.maxTeamSize);
 			}
 

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -386,7 +386,7 @@ export class RandomTeams {
 				do {
 					item = this.sample(items).name;
 					isIllegalItem = this.dex.items.get(item).gen > this.gen || this.dex.items.get(item).isNonstandard;
-					isBadItem = item.endsWith("Ball") || item.startsWith("TR") && item !== "Light Ball";
+					isBadItem = (item.endsWith("Ball") || item.startsWith("TR")) && item !== "Light Ball";
 				} while (isIllegalItem || (isBadItem && this.randomChance(19, 20)));
 			}
 
@@ -791,7 +791,7 @@ export class RandomTeams {
 				do {
 					itemData = this.sampleNoReplace(itemPool);
 					item = itemData?.name;
-					isBadItem = item.endsWith("Ball") || item.startsWith("TR") && item !== "Light Ball";
+					isBadItem = (item.endsWith("Ball") || item.startsWith("TR")) && item !== "Light Ball";
 				} while (isBadItem && this.randomChance(19, 20) && itemPool.length > this.maxTeamSize);
 			}
 

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -791,7 +791,7 @@ export class RandomTeams {
 				do {
 					itemData = this.sampleNoReplace(itemPool);
 					item = itemData?.name;
-					isBadItem = (item.endsWith("Ball") || item.startsWith("TR")) && item !== "Light Ball";
+					isBadItem = item.startsWith("TR") || item.endsWith("Ball") && item !== "Light Ball";
 				} while (isBadItem && this.randomChance(19, 20) && itemPool.length > this.maxTeamSize);
 			}
 

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -380,10 +380,14 @@ export class RandomTeams {
 
 			// Random legal item
 			let item = '';
+			let isIllegalItem;
+			let isBadItem;
 			if (this.gen >= 2) {
 				do {
 					item = this.sample(items).name;
-				} while (this.dex.items.get(item).gen > this.gen || this.dex.items.get(item).isNonstandard);
+					isIllegalItem = this.dex.items.get(item).gen > this.gen || this.dex.items.get(item).isNonstandard;
+					isBadItem = item.endsWith("Ball") || item.startsWith("TR");
+				} while (isIllegalItem || (isBadItem && this.randomChance(19, 20)));
 			}
 
 			// Make sure forme is legal
@@ -781,9 +785,14 @@ export class RandomTeams {
 			// Random unique item
 			let item = '';
 			let itemData;
+			let isBadItem;
 			if (doItemsExist) {
-				itemData = this.sampleNoReplace(itemPool);
-				item = itemData?.name;
+				// We discard TRs and Balls with 95% probability because of their otherwise overwhelming presence
+				do {
+					itemData = this.sampleNoReplace(itemPool);
+					item = itemData?.name;
+					isBadItem = item.endsWith("Ball") || item.startsWith("TR");
+				} while (isBadItem && this.randomChance(19, 20) && itemPool.length > this.maxTeamSize);
 			}
 
 			// Random unique ability

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -386,7 +386,7 @@ export class RandomTeams {
 				do {
 					item = this.sample(items).name;
 					isIllegalItem = this.dex.items.get(item).gen > this.gen || this.dex.items.get(item).isNonstandard;
-					isBadItem = item.startsWith("TR") || item.endsWith("Ball") && item !== "Light Ball";
+					isBadItem = item.startsWith("TR") || this.dex.items.get(item).isPokeball;
 				} while (isIllegalItem || (isBadItem && this.randomChance(19, 20)));
 			}
 
@@ -791,7 +791,7 @@ export class RandomTeams {
 				do {
 					itemData = this.sampleNoReplace(itemPool);
 					item = itemData?.name;
-					isBadItem = item.startsWith("TR") || item.endsWith("Ball") && item !== "Light Ball";
+					isBadItem = item.startsWith("TR") || itemData.isPokeball;
 				} while (isBadItem && this.randomChance(19, 20) && itemPool.length > this.maxTeamSize);
 			}
 

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -386,7 +386,7 @@ export class RandomTeams {
 				do {
 					item = this.sample(items).name;
 					isIllegalItem = this.dex.items.get(item).gen > this.gen || this.dex.items.get(item).isNonstandard;
-					isBadItem = (item.endsWith("Ball") || item.startsWith("TR")) && item !== "Light Ball";
+					isBadItem = item.startsWith("TR") || item.endsWith("Ball") && item !== "Light Ball";
 				} while (isIllegalItem || (isBadItem && this.randomChance(19, 20)));
 			}
 


### PR DESCRIPTION
In unmodded gen9 HC there are 355 legal items, more than a third of which are Balls or TRs. That makes them annoyingly common as they do nothing, and are also generally uninteresting (especially the TRs). We do want to retain the possibility of rolling any item, but we also want to dramatically scale back their relative probability. Hence, these are now rejected with 95% probability (subject to having enough items in the pool in HC).

Link to relevant discussion in Rands Auth Discord: https://discord.com/channels/294651453279174656/1041098998624288990/1050162709448110091