### PR TITLE
Gens 2-3: Fix accuracy of moves

### DIFF
--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -514,6 +514,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	nightmare: {
 		inherit: true,
+		accuracy: 100,
 		condition: {
 			noCopy: true,
 			onStart(pokemon) {

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -512,7 +512,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	nightmare: {
 		inherit: true,
-		accuracy: 100,
 		condition: {
 			noCopy: true,
 			onStart(pokemon) {

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -415,7 +415,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	mindreader: {
 		inherit: true,
-		accuracy: 100,
 		onTryHit(target) {
 			if (target.volatiles['foresight'] || target.volatiles['lockon']) return false;
 		},

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -400,9 +400,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	meanlook: {
 		inherit: true,
-		accuracy: true,
-		ignoreAccuracy: undefined,
-		ignoreEvasion: undefined,
 		flags: {reflectable: 1, mirror: 1},
 	},
 	metronome: {
@@ -414,8 +411,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	mimic: {
 		inherit: true,
-		ignoreAccuracy: undefined,
-		ignoreEvasion: undefined,
+		accuracy: 100,
 		noSketch: true,
 	},
 	mindreader: {
@@ -542,6 +538,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				pokemon.removeVolatile('lockedmove');
 			}
 		},
+	},
+	painsplit: {
+		inherit: true,
+		accuracy: 100,
 	},
 	perishsong: {
 		inherit: true,
@@ -785,9 +785,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	spiderweb: {
 		inherit: true,
-		accuracy: true,
-		ignoreAccuracy: undefined,
-		ignoreEvasion: undefined,
 		flags: {reflectable: 1, mirror: 1},
 	},
 	spikes: {
@@ -958,12 +955,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		multiaccuracy: false,
 		multihit: [1, 3],
-	},
-	vitalthrow: {
-		inherit: true,
-		accuracy: true,
-		ignoreAccuracy: undefined,
-		ignoreEvasion: undefined,
 	},
 	whirlwind: {
 		inherit: true,

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -376,7 +376,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	lockon: {
 		inherit: true,
-		accuracy: true,
 		onTryHit(target) {
 			if (target.volatiles['foresight'] || target.volatiles['lockon']) return false;
 		},
@@ -543,12 +542,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				pokemon.removeVolatile('lockedmove');
 			}
 		},
-	},
-	painsplit: {
-		inherit: true,
-		accuracy: true,
-		ignoreAccuracy: undefined,
-		ignoreEvasion: undefined,
 	},
 	perishsong: {
 		inherit: true,

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -281,7 +281,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	foresight: {
 		inherit: true,
-		accuracy: 100,
 		onTryHit(target) {
 			if (target.volatiles['foresight']) return false;
 		},

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -118,12 +118,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		onModifyMove() { },
 	},
-	block: {
-		inherit: true,
-		accuracy: 100,
-		ignoreAccuracy: true,
-		ignoreEvasion: true,
-	},
 	brickbreak: {
 		inherit: true,
 		onTryHit(target, source) {
@@ -434,21 +428,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		accuracy: 100,
 	},
-	meanlook: {
-		inherit: true,
-		accuracy: 100,
-		ignoreAccuracy: true,
-		ignoreEvasion: true,
-	},
 	megadrain: {
 		inherit: true,
 		pp: 10,
-	},
-	mimic: {
-		inherit: true,
-		accuracy: 100,
-		ignoreAccuracy: true,
-		ignoreEvasion: true,
 	},
 	mirrorcoat: {
 		inherit: true,
@@ -516,12 +498,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		flags: {contact: 1, protect: 1, mirror: 1},
 	},
-	painsplit: {
-		inherit: true,
-		accuracy: 100,
-		ignoreAccuracy: true,
-		ignoreEvasion: true,
-	},
 	petaldance: {
 		inherit: true,
 		basePower: 70,
@@ -533,18 +509,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	rocksmash: {
 		inherit: true,
 		basePower: 20,
-	},
-	roleplay: {
-		inherit: true,
-		accuracy: 100,
-		ignoreAccuracy: true,
-		ignoreEvasion: true,
-	},
-	skillswap: {
-		inherit: true,
-		accuracy: 100,
-		ignoreAccuracy: true,
-		ignoreEvasion: true,
 	},
 	sleeptalk: {
 		inherit: true,
@@ -568,12 +532,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			}
 			this.actions.useMove(randomMove.move, pokemon);
 		},
-	},
-	spiderweb: {
-		inherit: true,
-		accuracy: 100,
-		ignoreAccuracy: true,
-		ignoreEvasion: true,
 	},
 	spite: {
 		inherit: true,
@@ -693,12 +651,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		pp: 10,
 	},
-	vitalthrow: {
-		inherit: true,
-		accuracy: 100,
-		ignoreAccuracy: true,
-		ignoreEvasion: true,
-	},
 	volttackle: {
 		inherit: true,
 		secondary: null,
@@ -729,12 +681,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			}
 			if (this.field.effectiveWeather()) move.basePower *= 2;
 		},
-	},
-	yawn: {
-		inherit: true,
-		accuracy: 100,
-		ignoreAccuracy: true,
-		ignoreEvasion: true,
 	},
 	zapcannon: {
 		inherit: true,

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -490,6 +490,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			return 60;
 		},
 	},
+	nightmare: {
+		inherit: true,
+		accuracy: true,
+	},
 	outrage: {
 		inherit: true,
 		basePower: 90,

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -371,6 +371,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 		},
 	},
+	foresight: {
+		inherit: true,
+		accuracy: 100,
+	},
 	furycutter: {
 		inherit: true,
 		onHit(target, source) {
@@ -493,6 +497,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	nightmare: {
 		inherit: true,
 		accuracy: true,
+	},
+	odorsleuth: {
+		inherit: true,
+		accuracy: 100,
 	},
 	outrage: {
 		inherit: true,

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -440,6 +440,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		accuracy: true,
 	},
+	mindreader: {
+		inherit: true,
+		accuracy: 100,
+	},
 	mirrorcoat: {
 		inherit: true,
 		condition: {

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -436,6 +436,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		pp: 10,
 	},
+	memento: {
+		inherit: true,
+		accuracy: true,
+	},
 	mirrorcoat: {
 		inherit: true,
 		condition: {


### PR DESCRIPTION
This patch fixes the accuracy of some moves for Gen 2-3:

It is important to list moves that don't check for accuracy as having true accuracy, even if they are listed in-game as having 100% accuracy. Otherwise other effects that can cause moves to miss (like BrightPowder) can come into play when they shouldn't. https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/page-84#post-9373204

Gen 2:
- Lock-On and Pain Split should have 100% accuracy (not true)
- Nightmare should have true accuracy (not 100%)
https://www.smogon.com/forums/threads/gen-2-ps-development-post-bugs-here.3524926/post-8557865

Gen 3:
- Block, Mean Look, Mimic, Pain Split, Role Play, Skill Swap, Spider Web, Vital Throw, and Yawn bypass accuracy checks, even though they are listed in-game as 100% accuracy. They should have true accuracy.
- Foresight, Odor Sleuth, and Mind Reader should have 100% accuracy (not true)
- Memento and Nightmare should have true accuracy (not 100%)
These were listed on Bulbapedia and confirmed via assembly and some in-game testing (obtaining misses for Foresight, Odor Sleuth, and Mind Reader after accuracy is lowered).