### PR TITLE
Implement Open Team Sheets rule

### DIFF
--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1577,9 +1577,8 @@ export const Rulesets: {[k: string]: FormatData} = {
 		desc: "Allows each player to see the Pok&eacute;mon and all non-stat information about them, before they choose their lead Pok&eacute;mon",
 		onTeamPreview() {
 			let buf = 'raw|';
-			const hideStats = true;
 			for (const side of this.sides) {
-				const resultString = Utils.escapeHTML(Teams.export(side.team, {hideStats}));
+				const resultString = Utils.escapeHTML(Teams.export(side.team, {hideStats: true}));
 				buf += `<div class="infobox" style="margin-top:5px"><details><summary>Open Team Sheet for ${side.name}</summary>${resultString}</details></div>`;
 			}
 			this.add(buf);

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1570,6 +1570,20 @@ export const Rulesets: {[k: string]: FormatData} = {
 			this.makeRequest('teampreview');
 		},
 	},
+	openteamsheets: {
+		effectType: 'Rule',
+		name: 'Open Team Sheets',
+		desc: "Allows each player to see the Pok&eacute;mon and all non-stat information about them, before they choose their lead Pok&eacute;mon",
+		onTeamPreview() {
+			let buf = 'raw|';
+			const hideStats = true;
+			for (const side of this.sides) {
+				const resultString = Utils.escapeHTML(Teams.export(side.team, {hideStats}));
+				buf += `<div class="infobox" style="margin-top:5px"><details><summary>Open Team Sheet for ${side.name}</summary>${resultString}</details></div>`;
+			}
+			this.add(buf);
+		},
+	},
 	aaarestrictedabilities: {
 		effectType: 'ValidatorRule',
 		name: 'AAA Restricted Abilities',

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -2,6 +2,7 @@
 
 import {Utils} from "../lib";
 import {Pokemon} from "../sim/pokemon";
+import {Teams} from "../sim/teams";
 
 // The list of formats is stored in config/formats.js
 export const Rulesets: {[k: string]: FormatData} = {

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1578,8 +1578,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 		onTeamPreview() {
 			let buf = 'raw|';
 			for (const side of this.sides) {
-				const resultString = Utils.escapeHTML(Teams.export(side.team, {hideStats: true}));
-				buf += `<div class="infobox" style="margin-top:5px"><details><summary>Open Team Sheet for ${side.name}</summary>${resultString}</details></div>`;
+				buf += Utils.html`<div class="infobox" style="margin-top:5px"><details><summary>Open Team Sheet for ${side.name}</summary>${Teams.export(side.team, {hideStats: true})}</details></div>`;
 			}
 			this.add(buf);
 		},


### PR DESCRIPTION
VGC has announced open team sheets as the standard for in-person play. Open team sheet = all information about the Pokemon, except stats. ``Teams.export()`` can already do this with an optional ``hideStats`` argument (thanks past me!).

I am not sure about the Teams import at the top of the file, or if it should be done inside the rule.

Opinions on design are also appreciated:
![image](https://user-images.githubusercontent.com/23667022/206777333-e84b7861-cde3-4d67-bc6c-badbd8af2826.png)
![image](https://user-images.githubusercontent.com/23667022/206777542-51056572-f5ba-4912-8d00-34956799767e.png)