### PR TITLE
Inheritance: Fix Donor Clause

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -981,8 +981,11 @@ export const Formats: FormatList = [
 			for (const evoFamilies of evoFamilyLists) {
 				if (evoFamilies.length !== 1) continue;
 				const [familyId] = evoFamilies;
-				if (!(familyId in requiredFamilies)) requiredFamilies[familyId] = 1;
-				requiredFamilies[familyId]++;
+				if (!(familyId in requiredFamilies)) {
+					requiredFamilies[familyId] = 1;
+				} else {
+					requiredFamilies[familyId]++;
+				}
 				if (requiredFamilies[familyId] > 1) {
 					return [
 						`You are limited to up to one inheritance from each evolution family by the Donor Clause.`,


### PR DESCRIPTION
A piece of code always increments the donor's value after it gets initialized to 1, making it always reject. This should be able to fix it.