### PR TITLE
Fix copycat dancer interaction

### DIFF
--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -328,7 +328,9 @@ export class BattleActions {
 				if (this.battle.faintMessages()) break;
 				if (dancer.fainted) continue;
 				this.battle.add('-activate', dancer, 'ability: Dancer');
-				const dancersTarget = !target!.isAlly(dancer) && pokemon.isAlly(dancer) ? target! : pokemon;
+				const dancersTarget = !this.battle.activeTarget!.isAlly(dancer) && pokemon.isAlly(dancer) ?
+					this.battle.activeTarget! :
+					pokemon;
 				const dancersTargetLoc = dancer.getLocOf(dancersTarget);
 				this.runMove(move.id, dancer, dancersTargetLoc, this.dex.abilities.get('dancer'), undefined, true);
 			}

--- a/test/sim/abilities/dancer.js
+++ b/test/sim/abilities/dancer.js
@@ -148,7 +148,7 @@ describe('Dancer', function () {
 
 	it('should adopt the target selected by copycat', function () {
 		battle = common.createBattle({gameType: 'doubles'}, [[
-			{species: 'oricoriop', ability: 'dancer', moves: ['revelationdance']},
+			{species: 'oricoriopau', ability: 'dancer', moves: ['revelationdance']},
 			{species: 'flamigo', moves: ['copycat']},
 		], [
 			{species: 'fletchinder', level: 1, moves: ['sleeptalk']},

--- a/test/sim/abilities/dancer.js
+++ b/test/sim/abilities/dancer.js
@@ -146,7 +146,7 @@ describe('Dancer', function () {
 		assert(!opponentNotTargetedByAlly.hurtThisTurn);
 	});
 
-	it('should fail if dance is a result of copycat and there is no enemy to target', function () {
+	it('should adopt the target selected by copycat', function () {
 		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: 'oricoriop', ability: 'dancer', moves: ['revelationdance']},
 			{species: 'flamigo', moves: ['copycat']},

--- a/test/sim/abilities/dancer.js
+++ b/test/sim/abilities/dancer.js
@@ -145,4 +145,16 @@ describe('Dancer', function () {
 		assert(!allyTargetingOpponent.hurtThisTurn);
 		assert(!opponentNotTargetedByAlly.hurtThisTurn);
 	});
+
+	it('should fail if dance is a result of copycat and there is no enemy to target', function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'oricoriop', ability: 'dancer', moves: ['revelationdance']},
+			{species: 'flamigo', moves: ['copycat']},
+		], [
+			{species: 'fletchinder', level: 1, moves: ['sleeptalk']},
+			{species: 'fletchinder', level: 1, moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		assert(!battle.p1.active[1].hurtThisTurn);
+	});
 });


### PR DESCRIPTION
Previously, when copycat selected a dance move, a dancer would then target the pokemon that used copycat instead of copycat's inner move's target.

Correct interaction verified in game: https://twitter.com/WeedleTwineedle/status/1601925296898592770