### PR TITLE
Transforming into Pokemon with the same ability (Gen 5+)

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -157,7 +157,6 @@ import {formatText, linkRegex, stripFormatting} from './chat-formatter';
 
 // @ts-ignore no typedef available
 import ProbeModule = require('probe-image-size');
-import {Monitor} from './monitor';
 const probe: (url: string) => Promise<{width: number, height: number}> = ProbeModule;
 
 const EMOJI_REGEX = /[\p{Emoji_Modifier_Base}\p{Emoji_Presentation}\uFE0F]/u;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1776,7 +1776,7 @@ export class Pokemon {
 		}
 		this.ability = ability.id;
 		this.abilityState = {id: ability.id, target: this};
-		if (ability.id && this.battle.gen > 3) {
+		if (ability.id && this.battle.gen > 3 && !(oldAbility === ability.id && this.battle.gen > 4)) {
 			this.battle.singleEvent('Start', ability, this.abilityState, this, source);
 		}
 		this.abilityOrder = this.battle.abilityOrder++;

--- a/test/sim/moves/transform.js
+++ b/test/sim/moves/transform.js
@@ -81,7 +81,7 @@ describe('Transform', function () {
 		assert.statStage(battle.p2.active[0], 'atk', -1);
 	});
 
-	it.skip(`should copy, but not activate the target's Ability if it is the same as the user's pre-Transform`, function () {
+	it(`should copy, but not activate the target's Ability if it is the same as the user's pre-Transform`, function () {
 		battle = common.createBattle([[
 			{species: 'Ditto', ability: 'intimidate', moves: ['transform']},
 		], [


### PR DESCRIPTION
This pull request is in response to [this card](https://github.com/smogon/pokemon-showdown/projects/3#card-85843016). 

> In Gen 5+, Transforming with an entrance Ability (e.g. Intimidate) into a Pokemon with the same entrance Ability will not reactivate the Ability.

This behavior has been implemented through an additional check in setAbility. The corresponding test in `test/sim/moves/transform.js` is now passing.