### PR TITLE
Random Battle fixes

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -661,7 +661,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Chilly Reception", "Fire Blast", "Psyshock", "Slack Off", "Sludge Bomb", "Thunder Wave", "Toxic"],
-                "teraTypes": ["Poison", "Psychic"]
+                "teraTypes": ["Poison", "Dark"]
             },
             {
                 "role": "AV Pivot",

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1561,7 +1561,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earth Power", "Flash Cannon", "Lava Plume", "Magma Storm", "Protect", "Stealth Rock"],
-                "teraTypes": ["Flying"]
+                "teraTypes": ["Flying", "Grass", "Fire", "Steel"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -119,7 +119,7 @@
         "sets": [
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Bulk Up", "Drain Punch", "Rage Fist", "Substitute"],
+                "movepool": ["Bulk Up", "Drain Punch", "Rage Fist", "Rest"],
                 "teraTypes": ["Ghost", "Water"]
             },
             {
@@ -2544,7 +2544,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Chilling Water", "Haze", "Recover", "Toxic", "Toxic Spikes"],
-                "teraTypes": ["Steel"]
+                "teraTypes": ["Steel", "Flying", "Grass", "Fairy"]
             }
         ]
     },
@@ -2574,7 +2574,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Flamethrower", "Protect", "Substitute", "Toxic"],
-                "teraTypes": ["Water"]
+                "teraTypes": ["Water", "Flying"]
             }
         ]
     },
@@ -2992,8 +2992,8 @@
         "level": 68,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["Behemoth Blade", "Close Combat", "Crunch", "Play Rough", "Psychic Fangs", "Swords Dance", "Wild Charge"],
+                "role": "Setup Sweeper",
+                "movepool": ["Behemoth Blade", "Close Combat", "Play Rough", "Swords Dance"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -3682,7 +3682,7 @@
         "level": 80,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Fast Support",
                 "movepool": ["Earth Power", "Mortal Spin", "Power Gem", "Sludge Wave", "Spikes", "Stealth Rock", "Toxic"],
                 "teraTypes": ["Water"]
             }

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1435,7 +1435,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Discharge", "Hydro Pump", "Nasty Plot", "Pain Split", "Trick", "Volt Switch", "Will-O-Wisp"],
+                "movepool": ["Discharge", "Hydro Pump", "Nasty Plot", "Trick", "Volt Switch", "Will-O-Wisp"],
                 "teraTypes": ["Water"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -596,7 +596,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Ice Beam", "Liquidation", "Recover", "Spikes", "Toxic"],
-                "teraTypes": ["Poison"]
+                "teraTypes": ["Poison", "Steel", "Ground", "Fairy"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -444,7 +444,7 @@
         "level": 84,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Bulky Attacker",
                 "movepool": ["Brave Bird", "Fire Blast", "Roost", "U-turn", "Will-O-Wisp"],
                 "teraTypes": ["Fire"]
             }
@@ -1016,7 +1016,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Flamethrower", "Giga Drain", "Gunk Shot", "Sucker Punch", "Switcheroo"],
-                "teraTypes": ["Ground", "Fire", "Poison", "Dark", "Grass"]
+                "teraTypes": ["Ground", "Fire", "Poison", "Grass"]
             }
         ]
     },
@@ -1041,7 +1041,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Gunk Shot", "Knock Off", "Shadow Claw", "Shadow Sneak", "Swords Dance", "Will-O-Wisp"],
-                "teraTypes": ["Dark"]
+                "teraTypes": ["Poison", "Dark"]
             }
         ]
     },
@@ -1170,7 +1170,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Encore", "Nuzzle", "Super Fang", "U-turn"],
+                "movepool": ["Nuzzle", "Super Fang", "Thunderbolt", "U-turn"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -2314,7 +2314,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Foul Play", "Magnet Rise", "Play Rough", "Spikes", "Thunder Wave"],
-                "teraTypes": ["Flying"]
+                "teraTypes": ["Water"]
             }
         ]
     },
@@ -2619,7 +2619,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earth Power", "Hypnosis", "Shadow Ball", "Shore Up", "Stealth Rock"],
-                "teraTypes": ["Ghost", "Ground"]
+                "teraTypes": ["Water"]
             }
         ]
     },
@@ -3292,9 +3292,9 @@
         "level": 88,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Body Slam", "Coil", "Earthquake", "Roost"],
-                "teraTypes": ["Ground"]
+                "role": "Bulky Support",
+                "movepool": ["Earthquake", "Glare", "Headbutt", "Roost"],
+                "teraTypes": ["Normal", "Ghost", "Ground"]
             },
             {
                 "role": "Bulky Setup",
@@ -3309,7 +3309,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Memento", "Spikes", "Sticky Web", "Toxic Spikes", "U-turn"],
-                "teraTypes": ["Bug"]
+                "teraTypes": ["Ghost"]
             }
         ]
     },
@@ -3334,7 +3334,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earth Power", "Psychic", "Recover", "Revival Blessing", "Trick Room"],
-                "teraTypes": ["Bug"]
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -3358,8 +3358,8 @@
             },
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Calm Mind", "Dazzling Gleam", "Protect", "Stored Power", "Substitute"],
-                "teraTypes": ["Psychic"]
+                "movepool": ["Calm Mind", "Dazzling Gleam", "Protect", "Roost", "Stored Power", "Substitute"],
+                "teraTypes": ["Psychic", "Fairy"]
             },
             {
                 "role": "Tera Blast user",
@@ -3439,11 +3439,11 @@
         ]
     },
     "scovillain": {
-        "level": 78,
+        "level": 80,
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Flamethrower", "Leech Seed", "Protect", "Seed Bomb", "Substitute"],
+                "movepool": ["Flamethrower", "Leech Seed", "Protect", "Substitute"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -4037,9 +4037,9 @@
         "level": 86,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Bulky Support",
                 "movepool": ["Earth Power", "Giga Drain", "Knock Off", "Rapid Spin", "Spikes", "Spore", "Toxic", "Toxic Spikes"],
-                "teraTypes": ["Ground"]
+                "teraTypes": ["Ground", "Water"]
             }
         ]
     },

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -842,8 +842,8 @@ export class RandomTeams {
 		role: string,
 	): boolean {
 		if ([
-			'Flare Boost', 'Gluttony', 'Hydration', 'Ice Body', 'Immunity', 'Insomnia', 'Own Tempo',
-			'Quick Feet', 'Rain Dish', 'Snow Cloak', 'Steadfast', 'Steam Engine',
+			'Battle Bond', 'Flare Boost', 'Gluttony', 'Hydration', 'Ice Body', 'Immunity', 'Insomnia',
+			'Own Tempo', 'Quick Feet', 'Rain Dish', 'Snow Cloak', 'Steadfast', 'Steam Engine'
 		].includes(ability)) return true;
 
 		switch (ability) {
@@ -864,7 +864,7 @@ export class RandomTeams {
 		case 'Defiant':
 			return (!counter.get('Physical') || (abilities.has('Prankster') && (moves.has('thunderwave') || moves.has('taunt'))));
 		case 'Flash Fire':
-			return (species.id !== 'houndoom' && this.dex.getEffectiveness('Fire', species) >= 1);
+			return (species.id !== 'houndoom' && this.dex.getEffectiveness('Fire', species) < 0);
 		case 'Guts':
 			return (!moves.has('facade') && !moves.has('sleeptalk'));
 		case 'Harvest':

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1204,7 +1204,10 @@ export class RandomTeams {
 		if (role === 'Fast Support' || role === 'Fast Bulky Setup') {
 			return (counter.damagingMoves.size >= 3) ? 'Life Orb' : 'Leftovers';
 		}
-		if (['Fast Attacker', 'Setup Sweeper', 'Tera Blast user', 'Wallbreaker'].some(m => role === (m))) return 'Life Orb';
+		if (
+			['flamecharge', 'rapidspin', 'trailblaze'].every(m => !moves.has(m)) &&
+			['Fast Attacker', 'Setup Sweeper', 'Tera Blast user', 'Wallbreaker'].some(m => role === (m))
+		) return 'Life Orb';
 		if (isDoubles) return 'Sitrus Berry';
 		return 'Leftovers';
 	}

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -87,9 +87,9 @@ const Setup = [
 // Moves that shouldn't be the only STAB moves:
 const NoStab = [
 	'accelerock', 'aquajet', 'beakblast', 'bounce', 'breakingswipe', 'chatter', 'chloroblast', 'clearsmog', 'dragontail', 'eruption',
-	'explosion', 'fakeout', 'flamecharge', 'flipturn', 'iceshard', 'icywind', 'incinerate', 'machpunch',
-	'meteorbeam', 'mortalspin', 'pluck', 'pursuit', 'quickattack', 'reversal', 'saltcure', 'selfdestruct', 'shadowsneak', 'skydrop',
-	'snarl', 'steelbeam', 'suckerpunch', 'uturn', 'watershuriken', 'vacuumwave', 'voltswitch', 'waterspout',
+	'explosion', 'fakeout', 'flamecharge', 'flipturn', 'iceshard', 'icywind', 'incinerate', 'machpunch', 'meteorbeam',
+	'mortalspin', 'pluck', 'pursuit', 'quickattack', 'rapidspin', 'reversal', 'saltcure', 'selfdestruct', 'shadowsneak',
+	'skydrop', 'snarl', 'steelbeam', 'suckerpunch', 'uturn', 'watershuriken', 'vacuumwave', 'voltswitch', 'waterspout',
 ];
 // Hazard-setting moves
 const Hazards = [
@@ -473,7 +473,6 @@ export class RandomTeams {
 		this.incompatibleMoves(moves, movePool, 'psychic', 'psyshock');
 		this.incompatibleMoves(moves, movePool, 'surf', 'hydropump');
 		this.incompatibleMoves(moves, movePool, 'wavecrash', 'liquidation');
-		this.incompatibleMoves(moves, movePool, 'freezedry', 'icebeam');
 		this.incompatibleMoves(moves, movePool, ['airslash', 'bravebird', 'hurricane'], ['airslash', 'bravebird', 'hurricane']);
 		this.incompatibleMoves(moves, movePool, 'knockoff', 'foulplay');
 		this.incompatibleMoves(moves, movePool, 'doubleedge', 'headbutt');
@@ -882,7 +881,7 @@ export class RandomTeams {
 		case 'Justified':
 			return !counter.get('Physical');
 		case 'Mold Breaker':
-			return abilities.has('Sharpness');
+			return (abilities.has('Sharpness') || abilities.has('Unburden'));
 		case 'Moxie':
 			return (!counter.get('Physical') || moves.has('stealthrock'));
 		case 'Overgrow':
@@ -1188,10 +1187,6 @@ export class RandomTeams {
 		// Low Priority
 		if (moves.has('outrage')) return 'Lum Berry';
 		if (
-			role !== 'Fast Attacker' && role !== 'Tera Blast user' &&
-			this.dex.getEffectiveness('Ground', species) >= 2
-		) return 'Air Balloon';
-		if (
 			(species.id === 'garchomp' && role === 'Fast Support') ||
 			(ability === 'Regenerator' && types.includes('Water') && species.baseStats.def >= 110 && this.randomChance(1, 3))
 		) return 'Rocky Helmet';
@@ -1200,6 +1195,10 @@ export class RandomTeams {
 			!counter.get('recovery') && !counter.get('recoil') &&
 			(species.baseStats.hp + species.baseStats.def + species.baseStats.spd) < 300
 		) return 'Focus Sash';
+		if (
+			role !== 'Fast Attacker' && role !== 'Tera Blast user' &&
+			this.dex.getEffectiveness('Ground', species) >= 2
+		) return 'Air Balloon';
 		if (['Bulky Attacker', 'Bulky Support', 'Bulky Setup'].some(m => role === (m))) return 'Leftovers';
 		if (role === 'Fast Support' || role === 'Fast Bulky Setup') {
 			return (counter.damagingMoves.size >= 3) ? 'Life Orb' : 'Leftovers';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -841,7 +841,7 @@ export class RandomTeams {
 		role: string,
 	): boolean {
 		if ([
-			'Battle Bond', 'Flare Boost', 'Gluttony', 'Hydration', 'Ice Body', 'Immunity', 'Insomnia',
+			'Battle Bond', 'Flare Boost', 'Gluttony', 'Hydration', 'Ice Body', 'Immunity',
 			'Own Tempo', 'Quick Feet', 'Rain Dish', 'Snow Cloak', 'Steadfast', 'Steam Engine',
 		].includes(ability)) return true;
 
@@ -872,6 +872,8 @@ export class RandomTeams {
 			return (counter.get('Physical') < 2);
 		case 'Infiltrator':
 			return (moves.has('rest') && moves.has('sleeptalk')) || (isDoubles && abilities.has('Clear Body'));
+		case 'Insomnia':
+			return (role === 'Wallbreaker');
 		case 'Intimidate':
 			if (abilities.has('Hustle')) return true;
 			if (abilities.has('Sheer Force') && !!counter.get('sheerforce')) return true;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1032,7 +1032,12 @@ export class RandomTeams {
 			return this.sample(species.requiredItems);
 		}
 		if (role === 'AV Pivot') return 'Assault Vest';
-		if (role === 'Bulky Setup' && (ability === 'Quark Drive' || ability === 'Protosynthesis')) return 'Booster Energy';
+		if (
+			!isLead && role === 'Bulky Setup' &&
+			(ability === 'Quark Drive' || ability === 'Protosynthesis')
+		) {
+			return 'Booster Energy';
+		}
 		if (species.id === 'pikachu') return 'Light Ball';
 		if (species.id === 'regieleki') return 'Magnet';
 		if (ability === 'Imposter' || (species.id === 'magnezone' && moves.has('bodypress'))) return 'Choice Scarf';
@@ -1458,8 +1463,8 @@ export class RandomTeams {
 				continue;
 			}
 
-			// Pokemon with Last Respects shouldn't be leading
-			if (['Basculegion', 'Houndstone'].includes(species.baseSpecies) && !pokemon.length) continue;
+			// Pokemon with Last Respects, Intrepid Sword, and Dauntless Shield shouldn't be leading
+			if (['Basculegion', 'Houndstone', 'Zacian', 'Zamazenta'].includes(species.baseSpecies) && !pokemon.length) continue;
 
 			const tier = species.tier;
 			const types = species.types;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -843,7 +843,7 @@ export class RandomTeams {
 	): boolean {
 		if ([
 			'Battle Bond', 'Flare Boost', 'Gluttony', 'Hydration', 'Ice Body', 'Immunity', 'Insomnia',
-			'Own Tempo', 'Quick Feet', 'Rain Dish', 'Snow Cloak', 'Steadfast', 'Steam Engine'
+			'Own Tempo', 'Quick Feet', 'Rain Dish', 'Snow Cloak', 'Steadfast', 'Steam Engine',
 		].includes(ability)) return true;
 
 		switch (ability) {


### PR DESCRIPTION
- prevent Battle Bond Greninja
- Prevent Flash Fire on a lot of Fire-types
- Remove Pain Split from Rotom-W
- Prevent Life Orb Trailblaze, Rapid Spin, and Flame Charge