### PR TITLE
Add tests for Gen 9 Random Battle

### DIFF
--- a/test/random-battles/gen9.js
+++ b/test/random-battles/gen9.js
@@ -43,10 +43,10 @@ describe('[Gen 9] Random Battle', () => {
 						const stealthRock = Math.floor(i / 2) % 2;
 						const stickyWeb = Math.floor(i / 4) % 2;
 						teamDetails = {'defog': defog, 'stealthRock': stealthRock, 'stickyWeb': stickyWeb};
-						for (let i = 0; i < rounds; i++) {
+						for (let j = 0; j < rounds; j++) {
 							// randomMoveset() deletes moves from the movePool, so create a copy
 							const movePoolCopy = [...movePool];
-							const teraType = teraTypes[i % teraTypes.length];
+							const teraType = teraTypes[j % teraTypes.length];
 							const moveSet = generator.randomMoveset(types, abilities, teamDetails, species, false, false, movePoolCopy, teraType, role);
 							if (moveSet.has(move)) {
 								moveObtained = true;

--- a/test/random-battles/gen9.js
+++ b/test/random-battles/gen9.js
@@ -39,7 +39,7 @@ describe('[Gen 9] Random Battle', () => {
 					const defog = i % 2;
 					const stealthRock = Math.floor(i / 2) % 2;
 					const stickyWeb = Math.floor(i / 4) % 2;
-					teamDetails = {'defog': defog, 'stealthRock': stealthRock, 'stickyWeb': stickyWeb};
+					teamDetails = {defog, stealthRock, stickyWeb};
 					for (let j = 0; j < rounds; j++) {
 						// randomMoveset() deletes moves from the movepool, so recreate it every time
 						const movePool = set.movepool.map(m => dex.moves.get(m).id);

--- a/test/random-battles/gen9.js
+++ b/test/random-battles/gen9.js
@@ -15,7 +15,7 @@ describe('[Gen 9] Random Battle', () => {
 
 	it('all Pokemon should have 4 moves, except for Ditto (slow)', function () {
 		// This test takes more than 2000ms
-		testTeam(options, team => {
+		testTeam({...options, rounds: 100}, team => {
 			for (const pokemon of team) assert(pokemon.name === 'Ditto' || pokemon.moves.length === 4);
 		});
 	});

--- a/test/random-battles/gen9.js
+++ b/test/random-battles/gen9.js
@@ -31,32 +31,26 @@ describe('[Gen 9] Random Battle', () => {
 			if (species.unreleasedHidden) abilities.delete(species.abilities.H);
 			for (const set of sets) {
 				const role = set.role;
-				const movePool = set.movepool.map(m => dex.moves.get(m).id);
+				const moves = new Set(set.movepool.map(m => dex.moves.get(m).id));
 				const teraTypes = set.teraTypes;
-				// Every move in the movePool should be obtainable
-				for (const move of movePool) {
-					let moveObtained = false;
-					let teamDetails = {};
-					// Go through all possible teamDetails combinations, if necessary
-					for (let i = 0; i < 8; i++) {
-						const defog = i % 2;
-						const stealthRock = Math.floor(i / 2) % 2;
-						const stickyWeb = Math.floor(i / 4) % 2;
-						teamDetails = {'defog': defog, 'stealthRock': stealthRock, 'stickyWeb': stickyWeb};
-						for (let j = 0; j < rounds; j++) {
-							// randomMoveset() deletes moves from the movePool, so create a copy
-							const movePoolCopy = [...movePool];
-							const teraType = teraTypes[j % teraTypes.length];
-							const moveSet = generator.randomMoveset(types, abilities, teamDetails, species, false, false, movePoolCopy, teraType, role);
-							if (moveSet.has(move)) {
-								moveObtained = true;
-								break;
-							}
-						}
-						if (moveObtained) break;
+				let teamDetails = {};
+				// Go through all possible teamDetails combinations, if necessary
+				for (let i = 0; i < 8; i++) {
+					const defog = i % 2;
+					const stealthRock = Math.floor(i / 2) % 2;
+					const stickyWeb = Math.floor(i / 4) % 2;
+					teamDetails = {'defog': defog, 'stealthRock': stealthRock, 'stickyWeb': stickyWeb};
+					for (let j = 0; j < rounds; j++) {
+						// randomMoveset() deletes moves from the movepool, so recreate it every time
+						const movePool = set.movepool.map(m => dex.moves.get(m).id);
+						const teraType = teraTypes[j % teraTypes.length];
+						const moveSet = generator.randomMoveset(types, abilities, teamDetails, species, false, false, movePool, teraType, role);
+						for (const move of moveSet) moves.delete(move);
+						if (!moves.size) break;
 					}
-					assert(moveObtained);
+					if (!moves.size) break;
 				}
+				assert(!moves.size);
 			}
 		}
 	});

--- a/test/random-battles/gen9.js
+++ b/test/random-battles/gen9.js
@@ -1,0 +1,63 @@
+/**
+ * Tests for Gen 9 randomized formats
+ */
+'use strict';
+
+const {testTeam} = require('./tools');
+const assert = require('../assert');
+const Teams = require('./../../sim/teams').Teams;
+const Dex = require('./../../sim/dex').Dex;
+
+describe('[Gen 9] Random Battle', () => {
+	const options = {format: 'gen9randombattle'};
+	const setsJSON = require(`../../data/random-sets.json`);
+	const dex = Dex.forFormat(options.format);
+
+	it('all Pokemon should have 4 moves, except for Ditto (slow)', function () {
+		// This test takes more than 2000ms
+		testTeam(options, team => {
+			for (const pokemon of team) assert(pokemon.name === 'Ditto' || pokemon.moves.length === 4);
+		});
+	});
+
+	it('all moves on all sets should be obtainable (slow)', function () {
+		const generator = Teams.getGenerator(options.format);
+		const rounds = 100;
+		for (const pokemon of Object.keys(setsJSON)) {
+			const species = dex.species.get(pokemon);
+			const sets = setsJSON[pokemon]["sets"];
+			const types = species.types;
+			const abilities = new Set(Object.values(species.abilities));
+			if (species.unreleasedHidden) abilities.delete(species.abilities.H);
+			for (const set of sets) {
+				const role = set.role;
+				const movePool = set.movepool.map(m => dex.moves.get(m).id);
+				const teraTypes = set.teraTypes;
+				// Every move in the movePool should be obtainable
+				for (const move of movePool) {
+					let moveObtained = false;
+					let teamDetails = {};
+					// Go through all possible teamDetails combinations, if necessary
+					for (let i = 0; i < 8; i++) {
+						const defog = i % 2;
+						const stealthRock = Math.floor(i / 2) % 2;
+						const stickyWeb = Math.floor(i / 4) % 2;
+						teamDetails = {'defog': defog, 'stealthRock': stealthRock, 'stickyWeb': stickyWeb};
+						for (let i = 0; i < rounds; i++) {
+							// randomMoveset() deletes moves from the movePool, so create a copy
+							const movePoolCopy = [...movePool];
+							const teraType = teraTypes[i % teraTypes.length];
+							const moveSet = generator.randomMoveset(types, abilities, teamDetails, species, false, false, movePoolCopy, teraType, role);
+							if (moveSet.has(move)) {
+								moveObtained = true;
+								break;
+							}
+						}
+						if (moveObtained) break;
+					}
+					assert(moveObtained);
+				}
+			}
+		}
+	});
+});


### PR DESCRIPTION
This adds two tests for Gen 9 Random Battle:

1. Checks that every Pokemon gets a moveset with 4 moves (except Ditto). 
2. Checks that every move on every set is obtainable. Some moves are only obtainable with a non-default teamDetails (for example, Cryogonal only gets Haze if the team has a hazard remover), so we consider all possible relevant teamDetails. This looks like it would take a long time, but the move is usually obtained after only a few moveset generations, and as soon as we obtain the move, we can stop and move on to the next move. On my local machine this test took about 500ms, though I've marked it as slow to future-proof.