### PR TITLE
Fix interaction of Pollen Puff and Rage Fist

### DIFF
--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -975,7 +975,7 @@ export class BattleActions {
 		for (const [i, target] of targetsCopy.entries()) {
 			if (target && pokemon !== target) {
 				target.gotAttacked(move, moveDamage[i] as number | false | undefined, pokemon);
-				if (move.category !== 'Status') {
+				if (typeof moveDamage[i] === 'number') {
 					target.timesAttacked += hit - 1;
 				}
 			}

--- a/test/sim/moves/pollenpuff.js
+++ b/test/sim/moves/pollenpuff.js
@@ -25,4 +25,17 @@ describe('Pollen Puff', function () {
 		// -1/2 from Super Fang, -1/4 from Sub, +1/2 from Pollen Puff, damaged Sub.
 		assert.equal(lucario.hp, lucario.maxhp - Math.floor(lucario.maxhp / 4));
 	});
+
+	it(`should not heal a Pokemon if they have natural type immunity to Pollen Puff`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: "Wynaut", ability: 'normalize', moves: ['pollenpuff']},
+			{species: "Froslass", moves: ['bellydrum']},
+		], [
+			{species: "Wobbuffet", moves: ['sleeptalk']},
+			{species: "Lucario", moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('move pollenpuff -2, move bellydrum', 'auto');
+		assert.false.fullHP(battle.p1.active[1]);
+	});
 });

--- a/test/sim/moves/ragefist.js
+++ b/test/sim/moves/ragefist.js
@@ -10,46 +10,66 @@ describe.only('Rage Fist', function () {
 		battle.destroy();
 	});
 
-	it('should increase BP by 50 when user hit', function () {
-		battle = common.createBattle([
-			[{species: 'Primeape', ability: 'vitalspirit', moves: ['ragefist']}],
-			[{species: 'Umbreon', ability: 'shellarmor', moves: ['tackle']}],
-		]);
+	it(`should increase BP by 50 each time the user is hit`, function () {
+		battle = common.createBattle([[
+			{species: 'Primeape', moves: ['ragefist']},
+		], [
+			{species: 'Umbreon', ability: 'shellarmor', moves: ['tackle']},
+		]]);
 		battle.makeChoices();
-		let rageFistDamage = battle.p2.active[0].maxhp - battle.p2.active[0].hp;
+		const umbreon = battle.p2.active[0];
+		let rageFistDamage = umbreon.maxhp - umbreon.hp;
 		assert.bounded(rageFistDamage, [17, 21]);
+
 		battle.makeChoices();
-		rageFistDamage = battle.p2.active[0].maxhp - rageFistDamage - battle.p2.active[0].hp;
+		rageFistDamage = umbreon.maxhp - rageFistDamage - umbreon.hp;
 		assert.bounded(rageFistDamage, [34, 41]);
+
+		battle.makeChoices();
+		rageFistDamage = umbreon.maxhp - rageFistDamage - umbreon.hp;
+		assert.bounded(rageFistDamage, [52, 61]);
 	});
 
-	it('should not increase BP after being hit by status moves', function () {
-		battle = common.createBattle([
-			[{species: 'Primeape', ability: 'vitalspirit', moves: ['ragefist']}],
-			[{species: 'Umbreon', ability: 'shellarmor', moves: ['taunt']}],
-		]);
+	it(`should not increase BP after being hit by status moves`, function () {
+		battle = common.createBattle([[
+			{species: 'Primeape', moves: ['ragefist']},
+		], [
+			{species: 'Umbreon', ability: 'shellarmor', moves: ['tackle']},
+		]]);
+
 		battle.makeChoices();
-		let rageFistDamage = battle.p2.active[0].maxhp - battle.p2.active[0].hp;
+		const umbreon = battle.p2.active[0];
+		let rageFistDamage = umbreon.maxhp - umbreon.hp;
 		assert.bounded(rageFistDamage, [17, 21]);
+
 		battle.makeChoices();
-		rageFistDamage = battle.p2.active[0].maxhp - rageFistDamage - battle.p2.active[0].hp;
+		rageFistDamage = umbreon.maxhp - rageFistDamage - umbreon.hp;
 		assert.bounded(rageFistDamage, [17, 21]);
 	});
 
-	it('should increase BP after each hit of multi-hit moves', function () {
-		battle = common.createBattle([
-			[{species: 'Primeape', ability: 'vitalspirit', moves: ['sleeptalk', 'ragefist']}],
-			[{species: 'Umbreon', ability: 'shellarmor', moves: ['doublehit', 'sleeptalk']},
-			]]);
+	it(`should increase BP after each hit of multi-hit moves`, function () {
+		battle = common.createBattle([[
+			{species: 'Primeape', moves: ['sleeptalk', 'ragefist']},
+		], [
+			{species: 'Umbreon', ability: 'shellarmor', moves: ['doublehit', 'sleeptalk']},
+		]]);
+
 		battle.makeChoices();
 		battle.makeChoices('move ragefist', 'move sleeptalk');
-		assert.bounded(battle.p2.active[0].maxhp - battle.p2.active[0].hp, [52, 61]);
+		const umbreon = battle.p2.active[0];
+		assert.bounded(umbreon.maxhp - umbreon.hp, [52, 61]);
 	});
 
-	it('should use user\'s own number of times hit when called by another move', function () {
-		battle = common.createBattle([[{species: 'Primeape', ability: 'vitalspirit', moves: ['ragefist']}], [{species: 'Umbreon', moves: ['copycat']}]]);
+	it(`should use user's own number of times hit when called by another move`, function () {
+		battle = common.createBattle([[
+			{species: 'Primeape', moves: ['ragefist']},
+		], [
+			{species: 'Umbreon', ability: 'shellarmor', moves: ['copycat']},
+		]]);
+
 		battle.makeChoices();
-		assert.bounded(battle.p1.active[0].maxhp - battle.p1.active[0].hp, [77, 91]);
+		const primeape = battle.p1.active[0];
+		assert.bounded(primeape.maxhp - primeape.hp, [77, 91]);
 	});
 
 	it(`should not increase BP when healed by an ally's Pollen Puff`, function () {

--- a/test/sim/moves/ragefist.js
+++ b/test/sim/moves/ragefist.js
@@ -5,7 +5,7 @@ const common = require('./../../common');
 
 let battle;
 
-describe.only('Rage Fist', function () {
+describe('Rage Fist', function () {
 	afterEach(function () {
 		battle.destroy();
 	});

--- a/test/sim/moves/ragefist.js
+++ b/test/sim/moves/ragefist.js
@@ -19,22 +19,18 @@ describe('Rage Fist', function () {
 		battle.makeChoices();
 		const umbreon = battle.p2.active[0];
 		let rageFistDamage = umbreon.maxhp - umbreon.hp;
-		assert.bounded(rageFistDamage, [17, 21]);
+		assert.bounded(rageFistDamage, [17, 21], `Rage Fist should be 50 BP`);
 
 		battle.makeChoices();
 		rageFistDamage = umbreon.maxhp - rageFistDamage - umbreon.hp;
-		assert.bounded(rageFistDamage, [34, 41]);
-
-		battle.makeChoices();
-		rageFistDamage = umbreon.maxhp - rageFistDamage - umbreon.hp;
-		assert.bounded(rageFistDamage, [52, 61]);
+		assert.bounded(rageFistDamage, [34, 41], `Rage Fist should be 100 BP`);
 	});
 
 	it(`should not increase BP after being hit by status moves`, function () {
 		battle = common.createBattle([[
 			{species: 'Primeape', moves: ['ragefist']},
 		], [
-			{species: 'Umbreon', ability: 'shellarmor', moves: ['tackle']},
+			{species: 'Umbreon', ability: 'shellarmor', moves: ['taunt']},
 		]]);
 
 		battle.makeChoices();
@@ -74,7 +70,7 @@ describe('Rage Fist', function () {
 
 	it(`should not increase BP when the user's Substitute is damaged or broken`, function () {
 		battle = common.createBattle([[
-			{species: 'Primeape', ability: 'shellarmor', moves: ['substitute', 'ragefist']},
+			{species: 'Primeape', moves: ['substitute', 'ragefist']},
 		], [
 			{species: 'Umbreon', ability: 'shellarmor', moves: ['dragonrage', 'sleeptalk']},
 		]]);

--- a/test/sim/moves/ragefist.js
+++ b/test/sim/moves/ragefist.js
@@ -72,6 +72,20 @@ describe.only('Rage Fist', function () {
 		assert.bounded(primeape.maxhp - primeape.hp, [77, 91]);
 	});
 
+	it(`should not increase BP when the user's Substitute is damaged or broken`, function () {
+		battle = common.createBattle([[
+			{species: 'Primeape', ability: 'shellarmor', moves: ['substitute', 'ragefist']},
+		], [
+			{species: 'Umbreon', ability: 'shellarmor', moves: ['dragonrage', 'sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		battle.makeChoices();
+
+		const primeape = battle.p1.active[0];
+		assert.equal(primeape.timesAttacked, 0);
+	});
+
 	it(`should not increase BP when healed by an ally's Pollen Puff`, function () {
 		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: 'Wynaut', moves: ['pollenpuff']},

--- a/test/sim/moves/ragefist.js
+++ b/test/sim/moves/ragefist.js
@@ -5,7 +5,7 @@ const common = require('./../../common');
 
 let battle;
 
-describe('Rage Fist', function () {
+describe.only('Rage Fist', function () {
 	afterEach(function () {
 		battle.destroy();
 	});
@@ -50,5 +50,22 @@ describe('Rage Fist', function () {
 		battle = common.createBattle([[{species: 'Primeape', ability: 'vitalspirit', moves: ['ragefist']}], [{species: 'Umbreon', moves: ['copycat']}]]);
 		battle.makeChoices();
 		assert.bounded(battle.p1.active[0].maxhp - battle.p1.active[0].hp, [77, 91]);
+	});
+
+	it(`should not increase BP when healed by an ally's Pollen Puff`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Wynaut', moves: ['pollenpuff']},
+			{species: 'Annihilape', moves: ['sleeptalk', 'bellydrum']},
+		], [
+			{species: 'Wobbuffet', moves: ['sleeptalk']},
+			{species: 'Lucario', moves: ['sleeptalk']},
+		]]);
+
+		const annihilape = battle.p1.active[1];
+		battle.makeChoices('move pollenpuff -2, move sleeptalk', 'auto');
+		assert.equal(annihilape.timesAttacked, 0, `timesAttacked should not have incremented after a full HP Pollen Puff`);
+
+		battle.makeChoices('move pollenpuff -2, move bellydrum', 'auto');
+		assert.equal(annihilape.timesAttacked, 0, `timesAttacked should not have incremented after a not-full HP Pollen Puff`);
 	});
 });


### PR DESCRIPTION
Instead of checking if the move is a status move, check if the move actually dealt damage (that is, it's actually a number and not a boolean like Pollen Puff is here). I also cleaned up the Rage Fist test formatting and snuck in an additional Rage Fist test for Substitute, in addition to a test for Pollen Puff's interaction with type immunities.