### PR TITLE
Computer-Generated Teams: Fix weakness counter incrementing too soon

### DIFF
--- a/data/cg-teams.ts
+++ b/data/cg-teams.ts
@@ -265,11 +265,17 @@ export default class TeamGenerator {
 				if (stats.typeWeaknesses[type.name] === undefined) {
 					stats.typeWeaknesses[type.name] = 0;
 				}
-				stats.typeWeaknesses[type.name]++;
-				if (stats.typeWeaknesses[type.name] > MAX_WEAK_TO_SAME_TYPE) {
+				if (stats.typeWeaknesses[type.name] >= MAX_WEAK_TO_SAME_TYPE) {
 					// too many weaknesses to this type
 					return false;
 				}
+			}
+		}
+		// species passes; increment counters
+		for (const type of this.dex.types.all()) {
+			const effectiveness = this.dex.getEffectiveness(type.name, species.types);
+			if (effectiveness === 1) {
+				stats.typeWeaknesses[type.name]++;
 			}
 		}
 		return true;


### PR DESCRIPTION
The weakness counter to prevent having 4+ mons weak to the same type is currently incrementing while still checking. This can cause types to be already incremented before the species is rejected because of another type, thus incorrectly increasing the counter. In the worst (rare!) case this leads to teams being generated with too many weaknesses as there is no more room to reject any.