### PR TITLE
Computer-Generated Teams: Prevent duplicate moves

### DIFF
--- a/data/cg-teams.ts
+++ b/data/cg-teams.ts
@@ -164,6 +164,9 @@ export default class TeamGenerator {
 		}
 		if (!movePool.length) throw new Error(`No moves for ${species.id}`);
 
+		// Remove duplicate moves
+		movePool = [...new Set(movePool)];
+
 		// Consider either the top 15 moves or top 30% of moves, whichever is greater.
 		const numberOfMovesToConsider = Math.min(movePool.length, Math.max(15, Math.trunc(movePool.length * 0.3)));
 		let movePoolIsTrimmed = false;


### PR DESCRIPTION
It's possible currently to get the same move twice on a mon. For example: https://replay.pokemonshowdown.com/gen9computergeneratedteams-1744282911

By deduplicating the movepool before moveset generation we can prevent this. If some but not all moves are duplicates, this also prevents duplicated moves from having artificially doubles weights.