### PR TITLE
Fix Gen 9 Monotype Random Battle type check

### DIFF
--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1390,20 +1390,28 @@ export class RandomTeams {
 		const baseSpeciesPool: string[] = [];
 		if (isDoubles) {
 			for (const pokemon of Object.keys(this.randomDoublesSets)) {
-				const species = this.dex.species.get(pokemon);
+				let species = this.dex.species.get(pokemon);
 				if (species.gen > this.gen || exclude.includes(species.id)) continue;
 				if (isMonotype) {
 					if (!species.types.includes(type)) continue;
+					if (typeof species.battleOnly === 'string') {
+						species = this.dex.species.get(species.battleOnly);
+						if (!species.types.includes(type)) continue;
+					}
 				}
 				pokemonPool.push(pokemon);
 				if (!baseSpeciesPool.includes(species.baseSpecies)) baseSpeciesPool.push(species.baseSpecies);
 			}
 		} else {
 			for (const pokemon of Object.keys(this.randomSets)) {
-				const species = this.dex.species.get(pokemon);
+				let species = this.dex.species.get(pokemon);
 				if (species.gen > this.gen || exclude.includes(species.id)) continue;
 				if (isMonotype) {
 					if (!species.types.includes(type)) continue;
+					if (typeof species.battleOnly === 'string') {
+						species = this.dex.species.get(species.battleOnly);
+						if (!species.types.includes(type)) continue;
+					}
 				}
 				pokemonPool.push(pokemon);
 				if (!baseSpeciesPool.includes(species.baseSpecies)) baseSpeciesPool.push(species.baseSpecies);

--- a/test/random-battles/gen9.js
+++ b/test/random-battles/gen9.js
@@ -55,3 +55,13 @@ describe('[Gen 9] Random Battle', () => {
 		}
 	});
 });
+
+describe('[Gen 9] Monotype Random Battle', () => {
+	const options = {format: 'gen9monotyperandombattle'};
+
+	it('all Pokemon should share a common type', function () {
+		testTeam({...options, rounds: 100}, team => {
+			assert.legalTeam(team, 'gen9customgame@@@sametypeclause');
+		});
+	});
+});


### PR DESCRIPTION
This copies over some code from gen 8 random battles for checking the types of 'battle only' species, that was previously omitted from the gen 9 code.