### PR TITLE
Gen 1: Fix Bide's implementation

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1670,6 +1670,10 @@ export const Formats: FormatList = [
 					// in gen 1, fainting skips the rest of the turn
 					// residuals don't exist in gen 1
 					this.queue.clear();
+					// Fainting clears accumulated Bide damage
+					for (const pokemon of this.getAllActive()) {
+						if (pokemon.volatiles['bide']) pokemon.volatiles['bide'].damage = 0;
+					}
 				} else if (this.gen <= 3 && this.gameType === 'singles') {
 					// in gen 3 or earlier, fainting in singles skips to residuals
 					for (const pokemon of this.getAllActive()) {

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1672,7 +1672,11 @@ export const Formats: FormatList = [
 					this.queue.clear();
 					// Fainting clears accumulated Bide damage
 					for (const pokemon of this.getAllActive()) {
-						if (pokemon.volatiles['bide']) pokemon.volatiles['bide'].damage = 0;
+						if (pokemon.volatiles['bide'] && pokemon.volatiles['bide'].damage) {
+							pokemon.volatiles['bide'].damage = 0;
+							this.hint("Desync Clause Mod activated!");
+							this.hint("Bide's accumulated damage is reset to 0 when a Pokemon faints.");
+						}
 					}
 				} else if (this.gen <= 3 && this.gameType === 'singles') {
 					// in gen 3 or earlier, fainting in singles skips to residuals

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1675,7 +1675,7 @@ export const Formats: FormatList = [
 						if (pokemon.volatiles['bide'] && pokemon.volatiles['bide'].damage) {
 							pokemon.volatiles['bide'].damage = 0;
 							this.hint("Desync Clause Mod activated!");
-							this.hint("Bide's accumulated damage is reset to 0 when a Pokemon faints.");
+							this.hint("In Gen 1, Bide's accumulated damage is reset to 0 when a Pokemon faints.");
 						}
 					}
 				} else if (this.gen <= 3 && this.gameType === 'singles') {

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -36,22 +36,23 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		accuracy: true,
 		condition: {
 			onStart(pokemon) {
-				this.effectState.totalDamage = 0;
+				this.effectState.damage = 0;
 				this.effectState.time = this.random(2, 4);
 				this.add('-start', pokemon, 'Bide');
 			},
 			onBeforeMove(pokemon, t, move) {
-				this.effectState.totalDamage += this.lastDamage;
+				this.effectState.damage += this.lastDamage;
 				this.effectState.time--;
 				if (!this.effectState.time) {
 					this.add('-end', pokemon, 'Bide');
-					if (!this.effectState.totalDamage) {
+					if (!this.effectState.damage) {
 						this.debug("Bide failed because no damage was stored");
 						this.add('-fail', pokemon);
+						pokemon.removeVolatile('bide');
 						return false;
 					}
 					const target = this.getAtSlot(this.effectState.sourceSlot);
-					this.actions.moveHit(target, pokemon, move, {damage: this.effectState.totalDamage * 2} as ActiveMove);
+					this.actions.moveHit(target, pokemon, move, {damage: this.effectState.damage * 2} as ActiveMove);
 					pokemon.removeVolatile('bide');
 					return false;
 				}

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -35,16 +35,13 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		priority: 0,
 		accuracy: true,
 		condition: {
-			durationCallback(target, source, effect) {
-				return this.random(3, 5);
-			},
 			onStart(pokemon) {
 				this.effectState.totalDamage = 0;
+				this.effectState.time = this.random(3, 5);
 				this.add('-start', pokemon, 'Bide');
 			},
 			onHit(target, source, move) {
 				if (source && source !== target && move.category !== 'Physical' && move.category !== 'Special') {
-					const damage = this.effectState.totalDamage;
 					this.effectState.totalDamage += this.lastDamage;
 					this.effectState.sourceSlot = source.getSlot();
 				}
@@ -55,23 +52,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				this.effectState.totalDamage += this.lastDamage;
 				this.effectState.sourceSlot = source.getSlot();
 			},
-			onAfterSetStatus(status, pokemon) {
-				// Sleep, freeze, and partial trap will just pause duration.
-				if (pokemon.volatiles['flinch']) {
-					this.effectState.duration++;
-				} else if (pokemon.volatiles['partiallytrapped']) {
-					this.effectState.duration++;
-				} else {
-					switch (status.id) {
-					case 'slp':
-					case 'frz':
-						this.effectState.duration++;
-						break;
-					}
-				}
-			},
 			onBeforeMove(pokemon, t, move) {
-				if (this.effectState.duration === 1) {
+				this.effectState.time--;
+				if (!this.effectState.time) {
 					this.add('-end', pokemon, 'Bide');
 					if (!this.effectState.totalDamage) {
 						this.debug("Bide failed because no damage was taken");

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -41,10 +41,15 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				this.add('-start', pokemon, 'Bide');
 			},
 			onBeforeMove(pokemon, t, move) {
+				const currentMove = this.dex.getActiveMove('bide');
+				if (pokemon.volatiles['disable']?.move === 'bide') {
+					this.add('cant', pokemon, 'Disable', currentMove);
+					return false;
+				}
 				this.effectState.damage += this.lastDamage;
 				this.effectState.time--;
 				if (!this.effectState.time) {
-					this.add('-end', pokemon, 'Bide');
+					this.add('-end', pokemon, currentMove);
 					if (!this.effectState.damage) {
 						this.debug("Bide failed because no damage was stored");
 						this.add('-fail', pokemon);
@@ -52,22 +57,12 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 						return false;
 					}
 					const target = this.getRandomTarget(pokemon, 'Pound');
-					this.actions.moveHit(target, pokemon, move, {damage: this.effectState.damage * 2} as ActiveMove);
+					this.actions.moveHit(target, pokemon, currentMove, {damage: this.effectState.damage * 2} as ActiveMove);
 					pokemon.removeVolatile('bide');
 					return false;
 				}
 				this.add('-activate', pokemon, 'Bide');
 				return false;
-			},
-			onDisableMove(pokemon) {
-				if (!pokemon.hasMove('bide')) {
-					return;
-				}
-				for (const moveSlot of pokemon.moveSlots) {
-					if (moveSlot.id !== 'bide') {
-						pokemon.disableMove(moveSlot.id);
-					}
-				}
 			},
 		},
 		type: "???", // Will look as Normal but it's STAB-less

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -37,27 +37,16 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		condition: {
 			onStart(pokemon) {
 				this.effectState.totalDamage = 0;
-				this.effectState.time = this.random(3, 5);
+				this.effectState.time = this.random(2, 4);
 				this.add('-start', pokemon, 'Bide');
 			},
-			onHit(target, source, move) {
-				if (source && source !== target && move.category !== 'Physical' && move.category !== 'Special') {
-					this.effectState.totalDamage += this.lastDamage;
-					this.effectState.sourceSlot = source.getSlot();
-				}
-			},
-			onDamage(damage, target, source, move) {
-				if (!source || source.isAlly(target)) return;
-				if (!move || move.effectType !== 'Move') return;
-				this.effectState.totalDamage += this.lastDamage;
-				this.effectState.sourceSlot = source.getSlot();
-			},
 			onBeforeMove(pokemon, t, move) {
+				this.effectState.totalDamage += this.lastDamage;
 				this.effectState.time--;
 				if (!this.effectState.time) {
 					this.add('-end', pokemon, 'Bide');
 					if (!this.effectState.totalDamage) {
-						this.debug("Bide failed because no damage was taken");
+						this.debug("Bide failed because no damage was stored");
 						this.add('-fail', pokemon);
 						return false;
 					}

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -51,7 +51,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 						pokemon.removeVolatile('bide');
 						return false;
 					}
-					const target = this.getAtSlot(this.effectState.sourceSlot);
+					const target = this.getRandomTarget(pokemon, 'Pound');
 					this.actions.moveHit(target, pokemon, move, {damage: this.effectState.damage * 2} as ActiveMove);
 					pokemon.removeVolatile('bide');
 					return false;
@@ -801,6 +801,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				// Substitute, here we deliberately use the uncapped damage when tracking lastDamage etc.
 				// Also, multi-hit moves must always deal the same damage as the first hit for any subsequent hits
 				let uncappedDamage = move.hit > 1 ? this.lastDamage : this.actions.getDamage(source, target, move);
+				if (move.id === 'bide') uncappedDamage = source.volatiles['bide'].damage * 2;
 				if (!uncappedDamage && uncappedDamage !== 0) return null;
 				uncappedDamage = this.runEvent('SubDamage', target, source, move, uncappedDamage);
 				if (!uncappedDamage && uncappedDamage !== 0) return uncappedDamage;

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -34,33 +34,25 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		priority: 0,
 		accuracy: true,
-		ignoreEvasion: true,
 		condition: {
-			duration: 2,
 			durationCallback(target, source, effect) {
 				return this.random(3, 5);
 			},
 			onStart(pokemon) {
 				this.effectState.totalDamage = 0;
-				this.effectState.lastDamage = 0;
 				this.add('-start', pokemon, 'Bide');
 			},
 			onHit(target, source, move) {
 				if (source && source !== target && move.category !== 'Physical' && move.category !== 'Special') {
 					const damage = this.effectState.totalDamage;
-					this.effectState.totalDamage += damage;
-					this.effectState.lastDamage = damage;
+					this.effectState.totalDamage += this.lastDamage;
 					this.effectState.sourceSlot = source.getSlot();
 				}
 			},
 			onDamage(damage, target, source, move) {
 				if (!source || source.isAlly(target)) return;
 				if (!move || move.effectType !== 'Move') return;
-				if (!damage && this.effectState.lastDamage > 0) {
-					damage = this.effectState.totalDamage;
-				}
-				this.effectState.totalDamage += damage;
-				this.effectState.lastDamage = damage;
+				this.effectState.totalDamage += this.lastDamage;
 				this.effectState.sourceSlot = source.getSlot();
 			},
 			onAfterSetStatus(status, pokemon) {

--- a/data/mods/gen1stadium/moves.ts
+++ b/data/mods/gen1stadium/moves.ts
@@ -3,9 +3,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		priority: 0,
 		accuracy: true,
-		ignoreEvasion: true,
 		condition: {
-			duration: 2,
 			durationCallback(target, source, effect) {
 				return this.random(3, 5);
 			},

--- a/data/mods/gen2stadium2/scripts.ts
+++ b/data/mods/gen2stadium2/scripts.ts
@@ -545,6 +545,10 @@ export const Scripts: ModdedBattleScriptsData = {
 			// in gen 1, fainting skips the rest of the turn
 			// residuals don't exist in gen 1
 			this.queue.clear();
+			// Fainting clears accumulated Bide damage
+			for (const pokemon of this.getAllActive()) {
+				if (pokemon.volatiles['bide']) pokemon.volatiles['bide'].damage = 0;
+			}
 		} else if (this.gen <= 3 && this.gameType === 'singles') {
 			// in gen 3 or earlier, fainting in singles skips to residuals
 			for (const pokemon of this.getAllActive()) {

--- a/data/mods/gen2stadium2/scripts.ts
+++ b/data/mods/gen2stadium2/scripts.ts
@@ -547,7 +547,11 @@ export const Scripts: ModdedBattleScriptsData = {
 			this.queue.clear();
 			// Fainting clears accumulated Bide damage
 			for (const pokemon of this.getAllActive()) {
-				if (pokemon.volatiles['bide']) pokemon.volatiles['bide'].damage = 0;
+				if (pokemon.volatiles['bide'] && pokemon.volatiles['bide'].damage) {
+					pokemon.volatiles['bide'].damage = 0;
+					this.hint("Desync Clause Mod activated!");
+					this.hint("Bide's accumulated damage is reset to 0 when a Pokemon faints.");
+				}
 			}
 		} else if (this.gen <= 3 && this.gameType === 'singles') {
 			// in gen 3 or earlier, fainting in singles skips to residuals

--- a/data/mods/gen2stadium2/scripts.ts
+++ b/data/mods/gen2stadium2/scripts.ts
@@ -550,7 +550,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				if (pokemon.volatiles['bide'] && pokemon.volatiles['bide'].damage) {
 					pokemon.volatiles['bide'].damage = 0;
 					this.hint("Desync Clause Mod activated!");
-					this.hint("Bide's accumulated damage is reset to 0 when a Pokemon faints.");
+					this.hint("In Gen 1, Bide's accumulated damage is reset to 0 when a Pokemon faints.");
 				}
 			}
 		} else if (this.gen <= 3 && this.gameType === 'singles') {

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1125,7 +1125,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 	desyncclausemod: {
 		effectType: 'Rule',
 		name: 'Desync Clause Mod',
-		desc: 'If a desync would happen, the move fails instead. This rule currently covers Psywave and Counter.',
+		desc: 'If a desync would happen, the move fails instead. This rule currently covers Bide, Counter, and Psywave.',
 		onBegin() {
 			this.add('rule', 'Desync Clause Mod: Desyncs changed to move failure.');
 		},

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1956,7 +1956,7 @@ export class Battle {
 								if (pokemon.volatiles['bide'] && pokemon.volatiles['bide'].damage) {
 									pokemon.volatiles['bide'].damage = 0;
 									this.hint("Desync Clause Mod activated!");
-									this.hint("Bide's accumulated damage is reset to 0 when a Pokemon faints.");
+									this.hint("In Gen 1, Bide's accumulated damage is reset to 0 when a Pokemon faints.");
 								}
 							}
 						}
@@ -2344,7 +2344,7 @@ export class Battle {
 				if (pokemon.volatiles['bide'] && pokemon.volatiles['bide'].damage) {
 					pokemon.volatiles['bide'].damage = 0;
 					this.hint("Desync Clause Mod activated!");
-					this.hint("Bide's accumulated damage is reset to 0 when a Pokemon faints.");
+					this.hint("In Gen 1, Bide's accumulated damage is reset to 0 when a Pokemon faints.");
 				}
 			}
 		} else if (this.gen <= 3 && this.gameType === 'singles') {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1949,7 +1949,13 @@ export class Battle {
 					this.faintMessages(true);
 					if (this.gen <= 2) {
 						target.faint();
-						if (this.gen <= 1) this.queue.clear();
+						if (this.gen <= 1) {
+							this.queue.clear();
+							// Fainting clears accumulated Bide damage
+							for (const pokemon of this.getAllActive()) {
+								if (pokemon.volatiles['bide']) pokemon.volatiles['bide'].damage = 0;
+							}
+						}
 					}
 				}
 			}
@@ -2329,6 +2335,10 @@ export class Battle {
 			// in gen 1, fainting skips the rest of the turn
 			// residuals don't exist in gen 1
 			this.queue.clear();
+			// Fainting clears accumulated Bide damage
+			for (const pokemon of this.getAllActive()) {
+				if (pokemon.volatiles['bide']) pokemon.volatiles['bide'].damage = 0;
+			}
 		} else if (this.gen <= 3 && this.gameType === 'singles') {
 			// in gen 3 or earlier, fainting in singles skips to residuals
 			for (const pokemon of this.getAllActive()) {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -1953,7 +1953,11 @@ export class Battle {
 							this.queue.clear();
 							// Fainting clears accumulated Bide damage
 							for (const pokemon of this.getAllActive()) {
-								if (pokemon.volatiles['bide']) pokemon.volatiles['bide'].damage = 0;
+								if (pokemon.volatiles['bide'] && pokemon.volatiles['bide'].damage) {
+									pokemon.volatiles['bide'].damage = 0;
+									this.hint("Desync Clause Mod activated!");
+									this.hint("Bide's accumulated damage is reset to 0 when a Pokemon faints.");
+								}
 							}
 						}
 					}
@@ -2337,7 +2341,11 @@ export class Battle {
 			this.queue.clear();
 			// Fainting clears accumulated Bide damage
 			for (const pokemon of this.getAllActive()) {
-				if (pokemon.volatiles['bide']) pokemon.volatiles['bide'].damage = 0;
+				if (pokemon.volatiles['bide'] && pokemon.volatiles['bide'].damage) {
+					pokemon.volatiles['bide'].damage = 0;
+					this.hint("Desync Clause Mod activated!");
+					this.hint("Bide's accumulated damage is reset to 0 when a Pokemon faints.");
+				}
 			}
 		} else if (this.gen <= 3 && this.gameType === 'singles') {
 			// in gen 3 or earlier, fainting in singles skips to residuals

--- a/test/sim/moves/bide.js
+++ b/test/sim/moves/bide.js
@@ -107,4 +107,16 @@ describe('Bide [Gen 1]', function () {
 			assert.equal(aerodactyl.volatiles['bide'].time, 2);
 		}
 	});
+
+	it("Bide's duration is paused when disabled", function () {
+		battle = common.gen(1).createBattle({seed: [1, 1, 1, 0]});
+		battle.setPlayer('p1', {team: [{species: "Aerodactyl", moves: ['bide']}]});
+		battle.setPlayer('p2', {team: [{species: "Voltorb", moves: ['disable']}]});
+		const aerodactyl = battle.p1.active[0];
+		battle.makeChoices();
+		assert.equal(aerodactyl.volatiles['bide'].time, 3);
+		assert(aerodactyl.volatiles['disable'].time > 1);
+		battle.makeChoices();
+		assert.equal(aerodactyl.volatiles['bide'].time, 3);
+	});
 });

--- a/test/sim/moves/bide.js
+++ b/test/sim/moves/bide.js
@@ -53,4 +53,22 @@ describe('Bide [Gen 1]', function () {
 		assert(!aerodactyl.volatiles['bide']);
 		assert(!gyarados.volatiles['substitute']);
 	});
+
+	it("Bide can accumulate damage as the opponent switches or uses moves that don't reset lastDamage", function () {
+		battle = common.gen(1).createBattle({seed: [1, 1, 1, 1]});
+		battle.setPlayer('p1', {team: [{species: "Aerodactyl", moves: ['bide']}]});
+		battle.setPlayer('p2', {team: [
+			{species: "Gyarados", moves: ['dragonrage', 'splash']},
+			{species: 'Exeggutor', moves: ['barrage']},
+		]});
+		const aerodactyl = battle.p1.active[0];
+		battle.makeChoices();
+		assert.equal(aerodactyl.volatiles['bide'].time, 3);
+		battle.makeChoices('auto', 'move splash');
+		battle.makeChoices('auto', 'switch 2');
+		battle.makeChoices();
+		const exeggutor = battle.p2.active[0];
+		assert(!aerodactyl.volatiles['bide']);
+		assert.equal(exeggutor.maxhp - exeggutor.hp, 240);
+	});
 });

--- a/test/sim/moves/bide.js
+++ b/test/sim/moves/bide.js
@@ -95,4 +95,15 @@ describe('Bide [Gen 1]', function () {
 		assert(!aerodactyl.volatiles['bide']);
 		assert.fullHP(battle.p2.active[0]);
 	});
+
+	it("Bide's duration is paused when asleep or frozen", function () {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', {team: [{species: "Aerodactyl", moves: ['bide']}]});
+		battle.setPlayer('p2', {team: [{species: "Parasect", moves: ['spore']}]});
+		const aerodactyl = battle.p1.active[0];
+		for (let i = 0; i < 10; i++) {
+			battle.makeChoices();
+			assert.equal(aerodactyl.volatiles['bide'].time, 2);
+		}
+	});
 });

--- a/test/sim/moves/bide.js
+++ b/test/sim/moves/bide.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Bide [Gen 1]', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it("Two turn Bide", function () {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', {team: [{species: "Aerodactyl", moves: ['bide']}]});
+		battle.setPlayer('p2', {team: [{species: "Gyarados", moves: ['dragonrage']}]});
+		const aerodactyl = battle.p1.active[0];
+		const gyarados = battle.p2.active[0];
+		battle.makeChoices();
+		assert.equal(aerodactyl.volatiles['bide'].time, 2);
+		battle.makeChoices();
+		battle.makeChoices();
+		assert(!aerodactyl.volatiles['bide']);
+		assert.equal(gyarados.maxhp - gyarados.hp, 160);
+	});
+
+	it("Three turn Bide", function () {
+		battle = common.gen(1).createBattle({seed: [1, 1, 1, 1]});
+		battle.setPlayer('p1', {team: [{species: "Aerodactyl", moves: ['bide']}]});
+		battle.setPlayer('p2', {team: [{species: "Gyarados", moves: ['dragonrage']}]});
+		const aerodactyl = battle.p1.active[0];
+		const gyarados = battle.p2.active[0];
+		battle.makeChoices();
+		assert.equal(aerodactyl.volatiles['bide'].time, 3);
+		battle.makeChoices();
+		battle.makeChoices();
+		battle.makeChoices();
+		assert(!aerodactyl.volatiles['bide']);
+		assert.equal(gyarados.maxhp - gyarados.hp, 240);
+	});
+
+	it("Bide damage can hit a Substitute", function () {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', {team: [{species: "Aerodactyl", moves: ['bide', 'whirlwind']}]});
+		battle.setPlayer('p2', {team: [{species: "Gyarados", moves: ['dragonrage', 'substitute']}]});
+		const aerodactyl = battle.p1.active[0];
+		const gyarados = battle.p2.active[0];
+		battle.makeChoices('move whirlwind', 'move substitute');
+		battle.makeChoices();
+		assert.equal(aerodactyl.volatiles['bide'].time, 2);
+		battle.makeChoices();
+		battle.makeChoices();
+		assert(!aerodactyl.volatiles['bide']);
+		assert(!gyarados.volatiles['substitute']);
+	});
+});

--- a/test/sim/moves/bide.js
+++ b/test/sim/moves/bide.js
@@ -115,6 +115,7 @@ describe('Bide [Gen 1]', function () {
 		const aerodactyl = battle.p1.active[0];
 		battle.makeChoices();
 		assert.equal(aerodactyl.volatiles['bide'].time, 3);
+		assert(aerodactyl.volatiles['disable'].move === 'bide');
 		assert(aerodactyl.volatiles['disable'].time > 1);
 		battle.makeChoices();
 		assert.equal(aerodactyl.volatiles['bide'].time, 3);

--- a/test/sim/moves/bide.js
+++ b/test/sim/moves/bide.js
@@ -72,7 +72,7 @@ describe('Bide [Gen 1]', function () {
 		assert.equal(exeggutor.maxhp - exeggutor.hp, 240);
 	});
 
-	it("Bide's accumulated damage is zeroed when an enemy faints", function () {
+	it("Bide's accumulated damage is zeroed when an enemy faints (Desync Clause Mod)", function () {
 		battle = common.gen(1).createBattle();
 		battle.setPlayer('p1', {team: [{species: "Aerodactyl", moves: ['bide']}]});
 		battle.setPlayer('p2', {team: [
@@ -94,6 +94,7 @@ describe('Bide [Gen 1]', function () {
 		battle.makeChoices();
 		assert(!aerodactyl.volatiles['bide']);
 		assert.fullHP(battle.p2.active[0]);
+		assert(battle.log.some(line => line.includes('Desync Clause Mod activated')));
 	});
 
 	it("Bide's duration is paused when asleep or frozen", function () {

--- a/test/sim/moves/bide.js
+++ b/test/sim/moves/bide.js
@@ -71,4 +71,28 @@ describe('Bide [Gen 1]', function () {
 		assert(!aerodactyl.volatiles['bide']);
 		assert.equal(exeggutor.maxhp - exeggutor.hp, 240);
 	});
+
+	it("Bide's accumulated damage is zeroed when an enemy faints", function () {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', {team: [{species: "Aerodactyl", moves: ['bide']}]});
+		battle.setPlayer('p2', {team: [
+			{species: "Gyarados", moves: ['dragonrage', 'leer']},
+			{species: 'Exeggutor', moves: ['barrage']},
+		]});
+		const aerodactyl = battle.p1.active[0];
+		const exeggutor = battle.p2.pokemon[1];
+		// Exeggutor will faint when switched in
+		exeggutor.hp = 1;
+		exeggutor.setStatus('psn');
+		battle.makeChoices();
+		assert.equal(aerodactyl.volatiles['bide'].time, 2);
+		// Leer resets battle.lastDamage to 0
+		battle.makeChoices('auto', 'move leer');
+		battle.makeChoices('auto', 'switch 2');
+		battle.makeChoices();
+		assert.equal(aerodactyl.volatiles['bide'].time, 1);
+		battle.makeChoices();
+		assert(!aerodactyl.volatiles['bide']);
+		assert.fullHP(battle.p2.active[0]);
+	});
 });

--- a/test/sim/moves/bide.js
+++ b/test/sim/moves/bide.js
@@ -115,7 +115,7 @@ describe('Bide [Gen 1]', function () {
 		const aerodactyl = battle.p1.active[0];
 		battle.makeChoices();
 		assert.equal(aerodactyl.volatiles['bide'].time, 3);
-		assert(aerodactyl.volatiles['disable'].move === 'bide');
+		assert.equal(aerodactyl.volatiles['disable'].move, 'bide');
 		assert(aerodactyl.volatiles['disable'].time > 1);
 		battle.makeChoices();
 		assert.equal(aerodactyl.volatiles['bide'].time, 3);


### PR DESCRIPTION
This patch fixes many issues with the current implementation of Bide:

- Bide's damage accumulation is now done correctly: the stored damage is incremented (by battle.lastDamage) every time the Bide user 'moves', not when the Bide user gets hit. This includes just before unleashing Bide, and does not include the turn that Bide is used. This means the stored damage can increase if the opponent switches or uses a move that doesn't reset lastDamage (e.g. Teleport).
- Bide's duration is paused if the user is asleep, frozen, partially trapped or flinching (and Bide's damage does not accumulate in that turn).
- Bide can now hit an enemy Substitute.
- Bide's stored damage will be reset to 0 if an enemy faints. This situation can result in a desync on cart, so we invoke Desync Clause Mod.
- Bide can now be disabled when active. If Bide is disabled while active, Bide's duration will be paused until the disable is over (similar to sleep).

Sources: https://www.smogon.com/rb/articles/rby_mechanics_guide, assembly, and in-game testing.