### PR TITLE
Refactor Revival Blessing to be an action + fixes

### DIFF
--- a/sim/battle-queue.ts
+++ b/sim/battle-queue.ts
@@ -49,8 +49,8 @@ export interface MoveAction {
 /** A switch action */
 export interface SwitchAction {
 	/** action type */
-	choice: 'switch' | 'instaswitch';
-	order: 3 | 103;
+	choice: 'switch' | 'instaswitch' | 'revivalblessing';
+	order: 3 | 6 | 103;
 	/** priority of the action (lower first) */
 	priority: number;
 	/** speed of pokemon switching (higher first if priority tie) */
@@ -172,6 +172,7 @@ export class BattleQueue {
 				instaswitch: 3,
 				beforeTurn: 4,
 				beforeTurnMove: 5,
+				revivalblessing: 6,
 
 				runUnnerve: 100,
 				runSwitch: 101,

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2556,8 +2556,11 @@ export class Battle {
 		case 'revivalblessing':
 			action.pokemon.side.pokemonLeft++;
 			if (action.target.position < action.pokemon.side.active.length) {
-				action.target.isActive = true;
-				this.queue.cancelMove(action.target);
+				this.queue.addChoice({
+					choice: 'instaswitch',
+					pokemon: action.target,
+					target: action.target,
+				});
 			}
 			action.target.fainted = false;
 			action.target.faintQueued = false;

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2553,6 +2553,18 @@ export class Battle {
 				}
 			}
 			break;
+		case 'revivalblessing':
+			action.pokemon.side.pokemonLeft++;
+			if (action.target.position < action.pokemon.side.active.length) action.target.isActive = true;
+			action.target.fainted = false;
+			action.target.faintQueued = false;
+			action.target.subFainted = false;
+			action.target.status = '';
+			action.target.hp = 1; // Needed so hp functions works
+			action.target.sethp(action.pokemon.maxhp / 2);
+			this.add('-heal', action.target, action.target.getHealth, '[from] move: Revival Blessing');
+			action.pokemon.side.removeSlotCondition(action.pokemon, 'revivalblessing');
+			break;
 		case 'runUnnerve':
 			this.singleEvent('PreStart', action.pokemon.getAbility(), action.pokemon.abilityState, action.pokemon);
 			break;

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2555,7 +2555,10 @@ export class Battle {
 			break;
 		case 'revivalblessing':
 			action.pokemon.side.pokemonLeft++;
-			if (action.target.position < action.pokemon.side.active.length) action.target.isActive = true;
+			if (action.target.position < action.pokemon.side.active.length) {
+				action.target.isActive = true;
+				this.queue.cancelMove(action.target);
+			}
 			action.target.fainted = false;
 			action.target.faintQueued = false;
 			action.target.subFainted = false;

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -27,7 +27,7 @@ import {toID} from './dex';
 
 /** A single action that can be chosen. */
 export interface ChosenAction {
-	choice: 'move' | 'switch' | 'instaswitch' | 'team' | 'shift' | 'pass'; 	// action type
+	choice: 'move' | 'switch' | 'instaswitch' | 'revivalblessing' | 'team' | 'shift' | 'pass'; 	// action type
 	pokemon?: Pokemon; // the pokemon doing the action
 	targetLoc?: number; // relative location of the target to pokemon (move action only)
 	moveid: string; // a move to use (move action only)
@@ -201,6 +201,7 @@ export class Side {
 				return `move ${action.moveid}${details}`;
 			case 'switch':
 			case 'instaswitch':
+			case 'revivalblessing':
 				return `switch ${action.target!.position + 1}`;
 			case 'team':
 				return `team ${action.pokemon!.position + 1}`;
@@ -719,20 +720,15 @@ export class Side {
 			if (!targetPokemon.fainted) {
 				return this.emitChoiceError(`Can't switch: You have to pass to a fainted Pokémon`);
 			}
-			this.pokemonLeft++;
-			if (slot < this.active.length) targetPokemon.isActive = true;
-			targetPokemon.fainted = false;
-			targetPokemon.faintQueued = false;
-			targetPokemon.subFainted = false;
-			targetPokemon.status = '';
-			targetPokemon.hp = 1; // Needed so hp functions works
-			targetPokemon.sethp(targetPokemon.maxhp / 2);
-			this.battle.add('-heal', targetPokemon, targetPokemon.getHealth, '[from] move: Revival Blessing');
-			this.removeSlotCondition(pokemon, 'revivalblessing');
 			// Should always subtract, but stop at 0 to prevent errors.
 			this.choice.forcedSwitchesLeft = this.battle.clampIntRange(this.choice.forcedSwitchesLeft - 1, 0);
 			pokemon.switchFlag = false;
-			return this.choosePass();
+			this.choice.actions.push({
+				choice: 'revivalblessing',
+				pokemon,
+				target: targetPokemon,
+			} as ChosenAction);
+			return true;
 		}
 
 		if (targetPokemon.fainted) {

--- a/test/sim/moves/revivalblessing.js
+++ b/test/sim/moves/revivalblessing.js
@@ -56,6 +56,19 @@ describe('Revival Blessing', function () {
 		assert.equal(battle.p1.pokemonLeft, 2);
 	});
 
+	it(`should send the Pokemon back in immediately if in an active slot in Doubles`, () => {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'pawmot', ability: 'naturalcure', moves: ['revivalblessing']},
+			{species: 'shinx', ability: 'intimidate', moves: ['sleeptalk']},
+		], [
+			{species: 'mareep', ability: 'static', moves: ['sleeptalk']},
+			{species: 'chienpao', ability: 'noguard', moves: ['sheercold']},
+		]]);
+		battle.makeChoices('auto', 'move sleeptalk, move sheercold 2');
+		battle.makeChoices('switch 2', '');
+		assert.equal(battle.p2.active[0].boosts.atk, -2, "Intimidate should have activated again");
+	});
+
 	it(`shouldn't allow a fainted Pokemon to make its move the same turn after being revived`, () => {
 		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: 'pawmot', ability: 'naturalcure', moves: ['revivalblessing']},
@@ -64,7 +77,7 @@ describe('Revival Blessing', function () {
 			{species: 'mareep', ability: 'static', moves: ['sleeptalk']},
 			{species: 'chienpao', ability: 'swordofruin', moves: ['sheercold']},
 		]]);
-		battle.makeChoices('move revivalblessing, move doubleteam', 'move sleeptalk, move sheercold 2');
+		battle.makeChoices('auto', 'move sleeptalk, move sheercold 2');
 		battle.makeChoices('switch 2', '');
 		assert.equal(battle.p1.active[1].boosts.evasion, 0, "Lycanroc should not have used Double Team");
 	});

--- a/test/sim/moves/revivalblessing.js
+++ b/test/sim/moves/revivalblessing.js
@@ -55,4 +55,17 @@ describe('Revival Blessing', function () {
 		battle.makeChoices('switch corviknight', '');
 		assert.equal(battle.p1.pokemonLeft, 2);
 	});
+
+	it(`shouldn't allow a fainted Pokemon to make its move the same turn after being revived`, () => {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'pawmot', ability: 'naturalcure', moves: ['revivalblessing']},
+			{species: 'lycanrocmidnight', ability: 'noguard', item: 'laggingtail', moves: ['doubleteam']},
+		], [
+			{species: 'mareep', ability: 'static', moves: ['sleeptalk']},
+			{species: 'chienpao', ability: 'swordofruin', moves: ['sheercold']},
+		]]);
+		battle.makeChoices('move revivalblessing, move doubleteam', 'move sleeptalk, move sheercold 2');
+		battle.makeChoices('switch 2', '');
+		assert.equal(battle.p1.active[1].boosts.evasion, 0, "Lycanroc should not have used Double Team");
+	});
 });


### PR DESCRIPTION
* Pokemon revived in an active slot in Doubles should run a switch immediately
* Pokemon should not be able to make a move the same turn they fainted and were revived
* Fixes Revival Blessing choices not exporting to input log correctly