### PR TITLE
Gen IX: Fix Curse targeting behavior

### DIFF
--- a/data/mods/gen8/moves.ts
+++ b/data/mods/gen8/moves.ts
@@ -121,6 +121,11 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	curse: {
+		inherit: true,
+		onModifyTarget() {},
+		target: "randomNormal",
+	},
 	decorate: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -3288,6 +3288,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {bypasssub: 1},
 		volatileStatus: 'curse',
+		onModifyTarget(targetRelayVar, source, target, move) {
+			if (targetRelayVar.target.isAlly(source)) {
+				move.target = 'randomNormal';
+			}
+		},
 		onModifyMove(move, source, target) {
 			if (!source.hasType('Ghost')) {
 				move.target = move.nonGhostTarget as MoveTarget;
@@ -3315,7 +3320,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			},
 		},
 		secondary: null,
-		target: "randomNormal",
+		target: "normal",
 		nonGhostTarget: "self",
 		type: "Ghost",
 		zMove: {effect: 'curse'},

--- a/test/sim/moves/curse.js
+++ b/test/sim/moves/curse.js
@@ -30,17 +30,6 @@ describe('Curse', function () {
 		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'normal');
 	});
 
-	it(`should request the Ghost target after the user becomes Ghost`, function () {
-		battle = common.createBattle([[
-			{species: 'Rapidash', moves: ['curse']},
-		], [
-			{species: 'Trevenant', moves: ['trickortreat']},
-		]]);
-		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'self');
-		battle.makeChoices();
-		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'normal');
-	});
-
 	it(`should not request a target after the user stops being Ghost`, function () {
 		battle = common.createBattle([[
 			{species: 'Gengar', moves: ['curse']},

--- a/test/sim/moves/curse.js
+++ b/test/sim/moves/curse.js
@@ -16,7 +16,7 @@ describe('Curse', function () {
 		], [
 			{species: 'Caterpie', moves: ['sleeptalk']},
 		]]);
-		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'randomNormal');
+		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'normal');
 	});
 
 	it(`should request the Ghost target after the user becomes Ghost`, function () {
@@ -27,7 +27,7 @@ describe('Curse', function () {
 		]]);
 		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'self');
 		battle.makeChoices();
-		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'randomNormal');
+		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'normal');
 	});
 
 	it(`should request the Ghost target after the user becomes Ghost`, function () {
@@ -38,7 +38,7 @@ describe('Curse', function () {
 		]]);
 		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'self');
 		battle.makeChoices();
-		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'randomNormal');
+		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'normal');
 	});
 
 	it(`should not request a target after the user stops being Ghost`, function () {
@@ -47,7 +47,7 @@ describe('Curse', function () {
 		], [
 			{species: 'Jellicent', moves: ['soak']},
 		]]);
-		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'randomNormal');
+		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'normal');
 		battle.makeChoices();
 		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'self');
 	});
@@ -108,6 +108,37 @@ describe('Curse', function () {
 		battle.makeChoices();
 		assert.equal(gengar.hp, gengar.maxhp - Math.floor(gengar.maxhp / 2));
 		assert.equal(caterpie.hp, caterpie.maxhp - curseResidual * 2);
+	});
+
+	it(`should target either random opponent if the target is an ally`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'Wynaut', moves: ['sleeptalk']},
+			{species: 'Gengar', moves: ['curse']},
+		], [
+			{species: 'Caterpie', moves: ['sleeptalk']},
+			{species: 'Metapod', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices('move sleeptalk, move curse -1', 'auto');
+
+		const wynaut = battle.p1.active[0];
+		const caterpie = battle.p2.active[0];
+		const metapod = battle.p2.active[1];
+		assert.fullHP(wynaut);
+		assert(caterpie.maxhp !== caterpie.hp || metapod.maxhp !== metapod.hp, `Either Caterpie or Metapod should have lost HP from Curse`);
+	});
+
+	it(`[Gen 7] should target the ally if the target is an ally`, function () {
+		battle = common.gen(7).createBattle({gameType: 'doubles'}, [[
+			{species: 'Wynaut', moves: ['sleeptalk']},
+			{species: 'Gengar', moves: ['curse']},
+		], [
+			{species: 'Caterpie', moves: ['sleeptalk']},
+			{species: 'Metapod', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices('move sleeptalk, move curse -1', 'auto');
+
+		const wynaut = battle.p1.active[0];
+		assert.false.fullHP(wynaut);
 	});
 });
 

--- a/test/sim/moves/curse.js
+++ b/test/sim/moves/curse.js
@@ -10,82 +10,104 @@ describe('Curse', function () {
 		battle.destroy();
 	});
 
-	it('should request the Ghost target if the user is a known Ghost', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Gengar", ability: 'levitate', item: '', moves: ['curse']}]});
-		battle.setPlayer('p2', {team: [{species: "Caterpie", ability: 'shedskin', item: '', moves: ['stringshot']}]});
+	it(`should request the Ghost target if the user is a known Ghost`, function () {
+		battle = common.createBattle([[
+			{species: 'Gengar', moves: ['curse']},
+		], [
+			{species: 'Caterpie', moves: ['sleeptalk']},
+		]]);
 		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'randomNormal');
 	});
 
-	it('should request the Ghost target after the user becomes Ghost', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Rapidash", ability: 'levitate', item: '', moves: ['curse']}]});
-		battle.setPlayer('p2', {team: [{species: "Trevenant", ability: 'shedskin', item: 'laggingtail', moves: ['trickortreat']}]});
-
+	it(`should request the Ghost target after the user becomes Ghost`, function () {
+		battle = common.createBattle([[
+			{species: 'Rapidash', moves: ['curse']},
+		], [
+			{species: 'Trevenant', item: 'laggingtail', moves: ['trickortreat']},
+		]]);
 		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'self');
-		battle.makeChoices('auto', 'auto');
+		battle.makeChoices();
 		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'randomNormal');
 	});
 
-	it('should not request a target after the user stops being Ghost', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Gengar", ability: 'levitate', item: '', moves: ['curse']}]});
-		battle.setPlayer('p2', {team: [{species: "Jellicent", ability: 'waterabsorb', item: '', moves: ['soak']}]});
-
+	it(`should request the Ghost target after the user becomes Ghost`, function () {
+		battle = common.createBattle([[
+			{species: 'Rapidash', moves: ['curse']},
+		], [
+			{species: 'Trevenant', moves: ['trickortreat']},
+		]]);
+		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'self');
+		battle.makeChoices();
 		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'randomNormal');
-		battle.makeChoices('auto', 'auto');
+	});
+
+	it(`should not request a target after the user stops being Ghost`, function () {
+		battle = common.createBattle([[
+			{species: 'Gengar', moves: ['curse']},
+		], [
+			{species: 'Jellicent', moves: ['soak']},
+		]]);
+		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'randomNormal');
+		battle.makeChoices();
 		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'self');
 	});
 
-	it('should not request a target if the user is a known non-Ghost', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Blastoise", ability: 'torrent', item: '', moves: ['curse']}]});
-		battle.setPlayer('p2', {team: [{species: "Caterpie", ability: 'shedskin', item: '', moves: ['stringshot']}]});
+	it(`should not request a target if the user is a known non-Ghost`, function () {
+		battle = common.createBattle([[
+			{species: 'Blastoise', moves: ['curse']},
+		], [
+			{species: 'Caterpie', moves: ['sleeptalk']},
+		]]);
 		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'self');
 	});
 
-	it('should not request a target if the user is an unknown non-Ghost', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Blastoise", ability: 'torrent', item: '', moves: ['curse', 'reflecttype']}]});
-		battle.setPlayer('p2', {team: [
-			{species: "Zoroark", ability: 'illusion', item: '', moves: ['nastyplot']},
-			{species: "Gengar", ability: 'levitate', item: '', moves: ['spite']},
-		]});
-		battle.makeChoices('move reflecttype', 'auto'); // Reflect Type!
+	it(`should not request a target if the user is an unknown non-Ghost`, function () {
+		battle = common.createBattle([[
+			{species: 'Blastoise', moves: ['curse', 'reflecttype']},
+		], [
+			{species: 'Zoroark', ability: 'illusion', moves: ['sleeptalk']},
+			{species: 'Gengar', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices('move reflecttype', 'auto');
 
 		assert.deepEqual(battle.p1.active[0].getTypes(), ["Dark"]); // Copied Zoroark's type instead of Gengar's
 		assert.equal(battle.p1.active[0].getMoveRequestData().moves[0].target, 'self');
 	});
 
-	it('should curse a non-Ghost user with Protean', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Greninja", ability: 'protean', item: '', moves: ['curse', 'spite']}]});
-		battle.setPlayer('p2', {team: [{species: "Caterpie", ability: 'shedskin', item: '', moves: ['stringshot']}]});
-
-		battle.makeChoices('auto', 'auto');
-		const hps = [battle.p1.active[0].hp, battle.p2.active[0].hp];
-		assert.notEqual(hps[0], battle.p1.active[0].maxhp); // Curse user cut its HP down + residual damage
-		assert.equal(hps[1], battle.p2.active[0].maxhp); // Foe unaffected
+	it(`should curse a non-Ghost user with Protean`, function () {
+		battle = common.createBattle([[
+			{species: 'Greninja', ability: 'protean', moves: ['curse', 'spite']},
+		], [
+			{species: 'Caterpie', moves: ['sleeptalk']},
+		]]);
+		const greninja = battle.p1.active[0];
+		const caterpie = battle.p2.active[0];
+		const curseResidual = Math.floor(greninja.maxhp / 4);
+		battle.makeChoices();
+		assert.equal(greninja.hp, greninja.maxhp - Math.floor(greninja.maxhp / 2) - curseResidual, `Greninja should have Cursed itself`);
+		assert.fullHP(caterpie);
 
 		battle.makeChoices('move spite', 'auto');
-		assert.notEqual(hps[0], battle.p1.active[0].hp); // Curse user is hurt by residual damage
-		assert.equal(hps[1], battle.p2.active[0].hp); // Foe unaffected
+		assert.equal(greninja.hp, greninja.maxhp - Math.floor(greninja.maxhp / 2) - curseResidual * 2, `Greninja should have taken Curse damage again`);
+		assert.fullHP(caterpie);
 	});
 
-	it('should curse the target if a Ghost user has Protean', function () {
-		battle = common.createBattle();
-		battle.setPlayer('p1', {team: [{species: "Gengar", ability: 'protean', item: '', moves: ['curse', 'spite']}]});
-		battle.setPlayer('p2', {team: [{species: "Caterpie", ability: 'shedskin', item: '', moves: ['stringshot']}]});
+	it(`should curse the target if a Ghost user has Protean`, function () {
+		battle = common.createBattle([[
+			{species: 'Gengar', ability: 'protean', moves: ['curse']},
+		], [
+			{species: 'Caterpie', moves: ['sleeptalk']},
+		]]);
+		const gengar = battle.p1.active[0];
+		const caterpie = battle.p2.active[0];
+		const curseResidual = Math.floor(caterpie.maxhp / 4);
+		battle.makeChoices();
+		assert.equal(gengar.hp, gengar.maxhp - Math.floor(gengar.maxhp / 2));
+		assert.equal(caterpie.hp, caterpie.maxhp - curseResidual);
 
-		battle.makeChoices('auto', 'auto');
-		const hps = [battle.p1.active[0].hp, battle.p2.active[0].hp];
-		assert.notEqual(hps[0], battle.p1.active[0].maxhp); // Curse user cut its HP down
-		assert.notEqual(hps[1], battle.p2.active[0].maxhp); // Curse residual damage
-
-		battle.makeChoices('move spite', 'auto');
-		// Check residual damage
-		assert.equal(hps[0], battle.p1.active[0].hp); // Curse user unaffected
-		assert.notEqual(hps[1], battle.p2.active[0].hp); // Curse residual damage
+		battle.makeChoices();
+		assert.equal(gengar.hp, gengar.maxhp - Math.floor(gengar.maxhp / 2));
+		assert.equal(caterpie.hp, caterpie.maxhp - curseResidual * 2);
 	});
 });
 


### PR DESCRIPTION
In Gen 9, Ghost-type Curse can now be targeted at either opponent or an ally. However, if Curse is targeted at an ally, it instead selects either opponent randomly instead. I used the ``ModifyTarget`` handler to accomplish this, but I'm not sure if I've done everything quite right with it, so reviews are appreciated.