### PR TITLE
Random Battles updates

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -19,8 +19,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Nuzzle", "Play Rough", "Surf", "Volt Switch", "Volt Tackle"],
-                "teraTypes": ["Water", "Electric"]
+                "movepool": ["Fake Out", "Nuzzle", "Play Rough", "Surf", "Volt Switch", "Volt Tackle"],
+                "teraTypes": ["Water"]
             }
         ]
     },
@@ -49,7 +49,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Dazzling Gleam", "Flamethrower", "Light Screen", "Protect", "Reflect", "Stealth Rock", "Thunder Wave", "Wish"],
+                "movepool": ["Dazzling Gleam", "Fire Blast", "Light Screen", "Protect", "Reflect", "Stealth Rock", "Thunder Wave", "Wish"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -123,7 +123,7 @@
                 "teraTypes": ["Ghost", "Water", "Fairy", "Steel"]
             },
             {
-                "role": "Fast Attacker",
+                "role": "Bulky Attacker",
                 "movepool": ["Bulk Up", "Close Combat", "Rage Fist", "Stone Edge", "U-turn"],
                 "teraTypes": ["Ghost", "Fighting"]
             }
@@ -134,7 +134,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Close Combat", "Extreme Speed", "Flare Blitz", "Morning Sun", "Wild Charge", "Will-O-Wisp"],
+                "movepool": ["Close Combat", "Extreme Speed", "Flare Blitz", "Morning Sun", "Roar", "Wild Charge", "Will-O-Wisp"],
                 "teraTypes": ["Fighting", "Normal"]
             },
             {
@@ -416,7 +416,7 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Air Slash", "Calm Mind", "Freezing Glare", "Hurricane", "Recover"],
-                "teraTypes": ["Psychic"]
+                "teraTypes": ["Psychic", "Steel"]
             }
         ]
     },
@@ -646,7 +646,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Chilly Reception", "Psyshock", "Slack Off", "Surf", "Thunder Wave"],
-                "teraTypes": ["Water", "Fairy"]
+                "teraTypes": ["Water", "Fairy", "Dragon"]
             },
             {
                 "role": "Wallbreaker",
@@ -1196,7 +1196,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Clear Smog", "Earthquake", "Ice Beam", "Recover", "Stealth Rock", "Surf"],
-                "teraTypes": ["Ground", "Steel"]
+                "teraTypes": ["Ground", "Steel", "Poison"]
             }
         ]
     },
@@ -1933,7 +1933,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Giga Drain", "Sludge Bomb", "Spore", "Toxic"],
+                "movepool": ["Clear Smog", "Giga Drain", "Sludge Bomb", "Spore", "Toxic"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -2727,13 +2727,8 @@
         "level": 80,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["Body Press", "Brave Bird", "Bulk Up", "Roost"],
-                "teraTypes": ["Fighting"]
-            },
-            {
                 "role": "Bulky Attacker",
-                "movepool": ["Body Press", "Brave Bird", "Defog", "Roost", "U-turn"],
+                "movepool": ["Body Press", "Brave Bird", "Bulk Up", "Defog", "Roost"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -3385,6 +3380,16 @@
                 "role": "Bulky Support",
                 "movepool": ["Foul Play", "Hyper Voice", "Protect", "Wish"],
                 "teraTypes": ["Dark"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Future Sight", "Hyper Voice", "Protect", "Wish"],
+                "teraTypes": ["Ground", "Water", "Fairy"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Dazzling Gleam", "Earthquake", "Foul Play", "Future Sight", "Hyper Voice", "Psychic"],
+                "teraTypes": ["Dark"]
             }
         ]
     },
@@ -3403,8 +3408,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Curse", "Liquidation", "Rest", "Sleep Talk"],
-                "teraTypes": ["Water", "Fairy", "Ground"]
+                "movepool": ["Curse", "Liquidation", "Rest", "Sleep Talk", "Wave Crash"],
+                "teraTypes": ["Water", "Fairy", "Ground", "Dragon"]
             }
         ]
     },
@@ -3478,7 +3483,7 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["Gunk Shot", "Parting Shot", "Spin Out", "Toxic", "Toxic Spikes"],
+                "movepool": ["Gunk Shot", "Haze", "Parting Shot", "Spin Out", "Toxic", "Toxic Spikes"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -3553,7 +3558,7 @@
         "sets": [
             {
                 "role": "Tera Blast user",
-                "movepool": ["Dragon Pulse", "Hydro Pump", "Nasty Plot", "Tera Blast"],
+                "movepool": ["Draco Meteor", "Dragon Pulse", "Hydro Pump", "Nasty Plot", "Tera Blast"],
                 "teraTypes": ["Fire"]
             },
             {
@@ -3920,11 +3925,6 @@
                 "role": "Fast Attacker",
                 "movepool": ["Encore", "Flip Turn", "Freeze-Dry", "Hydro Pump", "Ice Beam", "Substitute"],
                 "teraTypes": ["Water", "Ice"]
-            },
-            {
-                "role": "Tera Blast user",
-                "movepool": ["Flip Turn", "Freeze-Dry", "Hydro Pump", "Tera Blast"],
-                "teraTypes": ["Electric"]
             }
         ]
     },
@@ -3948,8 +3948,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Body Press", "Earthquake", "Ruination", "Spikes", "Stealth Rock", "Throat Chop"],
-                "teraTypes": ["Ground", "Fighting", "Ghost"]
+                "movepool": ["Earthquake", "Ruination", "Spikes", "Stealth Rock", "Throat Chop", "Whirlwind"],
+                "teraTypes": ["Ground", "Ghost"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Press", "Earthquake", "Heavy Slam", "Ruination", "Stone Edge", "Throat Chop"],
+                "teraTypes": ["Ground", "Fighting", "Steel"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2233,7 +2233,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Aura Sphere", "Dark Pulse", "Dragon Pulse", "Hydro Pump", "U-turn"],
+                "movepool": ["Aura Sphere", "Dark Pulse", "Dragon Pulse", "U-turn", "Water Pulse"],
                 "teraTypes": ["Dark", "Dragon", "Fighting"]
             }
         ]

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -165,7 +165,10 @@ export class RandomTeams {
 			),
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
 			Ice: (movePool, moves, abilities, types, counter) => !counter.get('Ice'),
-			Normal: (movePool, moves, abilities, types, counter) => (movePool.includes('boomburst')),
+			Normal: (movePool, moves, abilities, types, counter) => {
+				if (movePool.includes('boomburst')) return true;
+				return (!counter.get('Normal') && movePool.includes('futuresight'));
+			},
 			Poison: (movePool, moves, abilities, types, counter) => {
 				if (types.includes('Ground')) return false;
 				return !counter.get('Poison');
@@ -177,7 +180,7 @@ export class RandomTeams {
 			},
 			Rock: (movePool, moves, abilities, types, counter, species) => !counter.get('Rock') && species.baseStats.atk >= 80,
 			Steel: (movePool, moves, abilities, types, counter, species) => {
-				if (species.baseStats.atk < 95) return false;
+				if (species.baseStats.atk < 95 && !movePool.includes('makeitrain')) return false;
 				return !counter.get('Steel');
 			},
 			Water: (movePool, moves, abilities, types, counter, species) => {
@@ -507,6 +510,8 @@ export class RandomTeams {
 		}
 		// Magnezone
 		this.incompatibleMoves(moves, movePool, magnezoneMoves, magnezoneMoves);
+		// Amoonguss, though this can work well as a general rule later
+		this.incompatibleMoves(moves, movePool, 'toxic', 'clearsmog');
 	}
 
 	// Checks for and removes incompatible moves, starting with the first move in movesA.


### PR DESCRIPTION
- Pikachu will now always get Surf
- Annihilape will no longer get Life Orb
- Clear Smog and Toxic cannot be on the same set; this is important for Amoonguss
- Normal-types will always get a Normal-type STAB attack if they can roll Future Sight; this is important for Farigiraf
- Iron Bundle is no longer capable of using Tera Blast
- Farigiraf now has a Future Sight + WishTect set and an AV set.
- Ting-Lu now has a separate set that can run Choice Band or Assault Vest.
- Gholdengo will now always run Make It Rain
- Several other misc. set changes

These changes were approved by the Random Battles room staff.