### PR TITLE
Random Battles updates

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1141,7 +1141,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Brick Break", "Pounce", "Sticky Web", "Taunt"],
-                "teraTypes": ["Bug", "Ghost"]
+                "teraTypes": ["Ghost"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1174,7 +1174,7 @@
         "level": 94,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "AV Pivot",
                 "movepool": ["Nuzzle", "Super Fang", "Thunderbolt", "U-turn"],
                 "teraTypes": ["Flying"]
             }

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -19,7 +19,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Fake Out", "Nuzzle", "Play Rough", "Surf", "Volt Switch", "Volt Tackle"],
+                "movepool": ["Fake Out", "Play Rough", "Surf", "Volt Switch", "Volt Tackle"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -510,8 +510,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Eruption", "Flamethrower", "Focus Blast", "Overheat"],
-                "teraTypes": ["Fire"]
+                "movepool": ["Eruption", "Fire Blast", "Focus Blast", "Shadow Ball"],
+                "teraTypes": ["Fire", "Ghost"]
             }
         ]
     },
@@ -781,7 +781,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Freeze-Dry", "Memento", "Rapid Spin", "Spikes"],
-                "teraTypes": ["Ice", "Ghost"]
+                "teraTypes": ["Ghost"]
             }
         ]
     },
@@ -791,7 +791,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dark Pulse", "Fire Blast", "Flamethrower", "Nasty Plot", "Sludge Bomb", "Sucker Punch"],
-                "teraTypes": ["Dark", "Fire", "Poison"]
+                "teraTypes": ["Dark", "Poison"]
             }
         ]
     },
@@ -841,7 +841,12 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Hurricane", "Hydro Pump", "Ice Beam", "Knock Off", "Roost", "Surf", "U-turn"],
-                "teraTypes": ["Water"]
+                "teraTypes": ["Water", "Ground"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Hurricane", "Hydro Pump", "Ice Beam", "Surf", "U-turn"],
+                "teraTypes": ["Water", "Flying"]
             }
         ]
     },
@@ -1566,7 +1571,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earth Power", "Flash Cannon", "Lava Plume", "Magma Storm", "Stealth Rock"],
-                "teraTypes": ["Flying", "Grass", "Fire", "Steel"]
+                "teraTypes": ["Flying", "Grass", "Steel"]
             }
         ]
     },
@@ -1790,7 +1795,7 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["Grass Knot", "Hydro Pump", "Ice Beam", "Knock Off", "Megahorn", "Sacred Sword"],
+                "movepool": ["Aqua Jet", "Grass Knot", "Hydro Pump", "Ice Beam", "Knock Off", "Megahorn", "Sacred Sword"],
                 "teraTypes": ["Water", "Dark"]
             },
             {
@@ -3308,7 +3313,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Memento", "Spikes", "Sticky Web", "Toxic Spikes", "U-turn"],
+                "movepool": ["Circle Throw", "Memento", "Spikes", "Sticky Web", "Toxic Spikes"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -3368,8 +3373,8 @@
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Dazzling Gleam", "Lumina Crash", "Shadow Ball", "Tera Blast"],
-                "teraTypes": ["Fighting"]
+                "movepool": ["Dazzling Gleam", "Lumina Crash", "Roost", "Tera Blast"],
+                "teraTypes": ["Fire"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2574,7 +2574,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Defog", "Leaf Storm", "Pollen Puff", "Synthesis"],
-                "teraTypes": ["Grass"]
+                "teraTypes": ["Steel", "Water"]
             }
         ]
     },
@@ -2773,7 +2773,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Apple Acid", "Dragon Pulse", "Leech Seed", "Recover"],
+                "movepool": ["Apple Acid", "Draco Meteor", "Dragon Pulse", "Leech Seed", "Recover"],
                 "teraTypes": ["Grass", "Steel"]
             }
         ]
@@ -3712,8 +3712,8 @@
         "level": 86,
         "sets": [
             {
-                "role": "AV Pivot",
-                "movepool": ["Gunk Shot", "Knock Off", "Super Fang", "U-turn"],
+                "role": "Bulky Attacker",
+                "movepool": ["Gunk Shot", "Knock Off", "Super Fang", "Switcheroo", "U-turn"],
                 "teraTypes": ["Dark"]
             },
             {
@@ -3722,9 +3722,9 @@
                 "teraTypes": ["Dark"]
             },
             {
-                "role": "Wallbreaker",
-                "movepool": ["Gunk Shot", "Knock Off", "Switcheroo", "U-turn"],
-                "teraTypes": ["Poison", "Dark"]
+                "role": "Bulky Support",
+                "movepool": ["Encore", "Gunk Shot", "Knock Off", "Parting Shot"],
+                "teraTypes": ["Dark"]
             }
         ]
     },

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -881,7 +881,7 @@ export class RandomTeams {
 		case 'Intimidate':
 			if (abilities.has('Hustle')) return true;
 			if (abilities.has('Sheer Force') && !!counter.get('sheerforce')) return true;
-			return (abilities.has('Stakeout') || moves.has('substitute'));
+			return (abilities.has('Stakeout'));
 		case 'Iron Fist':
 			return !counter.ironFist;
 		case 'Justified':
@@ -969,7 +969,8 @@ export class RandomTeams {
 		if (species.id === 'arcaninehisui') return 'Rock Head';
 		if (species.id === 'staraptor') return 'Reckless';
 		if (species.id === 'enamorus' && moves.has('calmmind')) return 'Cute Charm';
-		if (abilities.has('Corrosion') && moves.has('toxic') && this.randomChance(1, 2)) return 'Corrosion';
+		if (abilities.has('Corrosion') && moves.has('toxic') && !moves.has('earthpower')) return 'Corrosion';
+		if (abilities.has('Cud Chew') && moves.has('substitute')) return 'Cud Chew';
 		if (abilities.has('Guts') && (moves.has('facade') || moves.has('sleeptalk'))) return 'Guts';
 		if (abilities.has('Harvest') && moves.has('substitute')) return 'Harvest';
 		if (abilities.has('Serene Grace') && moves.has('headbutt')) return 'Serene Grace';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -463,7 +463,6 @@ export class RandomTeams {
 		if (species.id !== "scyther" && species.id !== "scizor") {
 			this.incompatibleMoves(moves, movePool, Setup, pivotingMoves);
 		}
-		this.incompatibleMoves(moves, movePool, ['switcheroo', 'trick'], 'superfang');
 		this.incompatibleMoves(moves, movePool, Setup, Hazards);
 		this.incompatibleMoves(moves, movePool, Setup, ['defog', 'nuzzle', 'toxic', 'waterspout', 'yawn']);
 		this.incompatibleMoves(moves, movePool, PhysicalSetup, PhysicalSetup);
@@ -501,8 +500,8 @@ export class RandomTeams {
 		// This space reserved for assorted hardcodes that otherwise make little sense out of context
 		// Landorus
 		this.incompatibleMoves(moves, movePool, 'nastyplot', 'rockslide');
-		// Persian and Seviper
-		this.incompatibleMoves(moves, movePool, 'switcheroo', ['fakeout', 'suckerpunch']);
+		// Persian and Grafaiai
+		this.incompatibleMoves(moves, movePool, 'switcheroo', ['fakeout', 'superfang']);
 		// Beartic
 		this.incompatibleMoves(moves, movePool, 'snowscape', 'swordsdance');
 		// Cryogonal

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -463,6 +463,7 @@ export class RandomTeams {
 		if (species.id !== "scyther" && species.id !== "scizor") {
 			this.incompatibleMoves(moves, movePool, Setup, pivotingMoves);
 		}
+		this.incompatibleMoves(moves, movePool, ['switcheroo', 'trick'], 'superfang');
 		this.incompatibleMoves(moves, movePool, Setup, Hazards);
 		this.incompatibleMoves(moves, movePool, Setup, ['defog', 'nuzzle', 'toxic', 'waterspout', 'yawn']);
 		this.incompatibleMoves(moves, movePool, PhysicalSetup, PhysicalSetup);


### PR DESCRIPTION
-Corrosion will now generate specifically when Glimmora has Toxic and lacks coverage for Steel-types.
-Pelipper now has a Choice Specs set.
-Espathra's Tera Blast set is now Life Orb Roost + Tera Fire.
-Grafaiai's offensive sets were combined into one movepool, Super Fang cannot generate with Switcheroo, and an Encore + Parting Shot set was added.
-Several other minor updates to sets and tera types.
-Cud Chew code was made more simple and futureproofed.
