### PR TITLE
Add new testing API extending /evalbattle scope

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -14,6 +14,14 @@ function capitalize(word) {
 }
 
 /**
+ * @typedef TestContext
+ * @prop {Sim.Battle} battle - Simulated battle
+ * @prop {Sim.Side} [key: SideID] - Sides: p1, p2...
+ * @prop {Sim.Pokemon} [key: PokemonSlot] - Pokemon: p1a, p1b, p2a...
+ * @prop {Sim.Pokemon} [key: string]
+ */
+
+/**
  * The default random number generator seed used if one is not given.
  */
 const DEFAULT_SEED = [0x09917, 0x06924, 0x0e1c8, 0x06af0];
@@ -110,6 +118,34 @@ class TestTools {
 		}
 
 		return new Sim.Battle(battleOptions);
+	}
+
+	/**
+	 * Creates a new Battle and returns it.
+	 *
+	 * @param {Object} [options]
+	 * @param {Team[]} [teams]
+	 * @returns {TestContext} Test context.
+	 */
+	testCtx(options, teams) {
+		const battle = this.createBattle(options, teams);
+		const ctx = {battle};
+		const bySpecies = new Map();
+		for (const side of battle.sides) {
+			ctx[side.id] = side;
+			for (const [i, pokemon] of side.pokemon.entries()) {
+				ctx[`${side.id}${String.fromCharCode(97 + i)}`] = pokemon;
+				if (bySpecies.has(pokemon.species.id)) {
+					bySpecies.set(pokemon.species.id, null);
+				} else {
+					bySpecies.set(pokemon.species.id, pokemon);
+				}
+			}
+		}
+		for (const [speciesId, pokemon] of bySpecies) {
+			if (pokemon) ctx[speciesId] = pokemon;
+		}
+		return ctx;
 	}
 
 	/**

--- a/test/sim/abilities/berserk.js
+++ b/test/sim/abilities/berserk.js
@@ -3,41 +3,39 @@
 const assert = require('./../../assert');
 const common = require('./../../common');
 
-let battle;
+let ctx;
 
 describe('Berserk', function () {
 	afterEach(function () {
-		battle.destroy();
+		ctx.battle.destroy();
 	});
 
 	it(`should activate prior to healing from Sitrus Berry`, function () {
-		battle = common.createBattle([[
+		const {battle, drampa} = ctx = common.testCtx([[
 			{species: 'drampa', item: 'sitrusberry', ability: 'berserk', evs: {hp: 4}, moves: ['sleeptalk']},
 		], [
 			{species: 'wynaut', ability: 'compoundeyes', moves: ['superfang']},
 		]]);
 
 		battle.makeChoices();
-		const drampa = battle.p1.active[0];
 		assert.statStage(drampa, 'spa', 1);
 		assert.equal(drampa.hp, Math.floor(drampa.maxhp / 2) + Math.floor(drampa.maxhp / 4));
 	});
 
 	it(`should not activate prior to healing from Sitrus Berry after a multi-hit move`, function () {
-		battle = common.createBattle([[
+		const {battle, drampa} = ctx = common.testCtx([[
 			{species: 'drampa', item: 'sitrusberry', ability: 'berserk', evs: {hp: 4}, moves: ['sleeptalk']},
 		], [
 			{species: 'wynaut', ability: 'parentalbond', moves: ['seismictoss']},
 		]]);
 
 		battle.makeChoices();
-		const drampa = battle.p1.active[0];
 		assert.statStage(drampa, 'spa', 0);
 		assert.equal(drampa.hp, drampa.maxhp - 200 + Math.floor(drampa.maxhp / 4));
 	});
 
 	it(`should not activate below 50% HP if it was damaged by Dragon Darts`, function () {
-		battle = common.createBattle({gameType: 'doubles'}, [[
+		const {battle, drampa} = ctx = common.testCtx({gameType: 'doubles'}, [[
 			{species: 'drampa', ability: 'berserk', evs: {hp: 4}, moves: ['sleeptalk']},
 			{species: 'togedemaru', ability: 'compoundeyes', moves: ['superfang']},
 		], [
@@ -46,7 +44,6 @@ describe('Berserk', function () {
 		]]);
 
 		battle.makeChoices('move sleeptalk, move superfang -1', 'auto');
-		const drampa = battle.p1.active[0];
 		assert.statStage(drampa, 'spa', 1);
 	});
 });

--- a/test/sim/abilities/dancer.js
+++ b/test/sim/abilities/dancer.js
@@ -3,34 +3,32 @@
 const assert = require('./../../assert');
 const common = require('./../../common');
 
-let battle;
+let ctx;
 
 describe('Dancer', function () {
 	afterEach(function () {
-		battle.destroy();
+		ctx.battle.destroy();
 	});
 
 	it('should only copy dance moves used by other Pokemon', function () {
-		battle = common.createBattle([[
+		const {battle, p1a, p2a} = ctx = common.testCtx([[
 			{species: 'Oricorio', ability: 'dancer', moves: ['swordsdance']},
 		], [
 			{species: 'Oricorio', ability: 'dancer', moves: ['howl']},
 		]]);
 		battle.makeChoices('move swordsdance', 'move howl');
-		assert.statStage(battle.p1.active[0], 'atk', 2);
-		assert.statStage(battle.p2.active[0], 'atk', 3);
+		assert.statStage(p1a, 'atk', 2);
+		assert.statStage(p2a, 'atk', 3);
 	});
 
 	it('should activate in order of lowest to highest raw speed', function () {
-		battle = common.createBattle({gameType: 'doubles'}, [[
+		const {battle, p1b: fastDancer, p2a: wwDanceSource, p2b: foeDancer} = ctx = common.testCtx({gameType: 'doubles'}, [[
 			{species: 'Shedinja', level: 98, ability: 'dancer', item: 'focussash', moves: ['sleeptalk']},
 			{species: 'Shedinja', level: 99, ability: 'dancer', moves: ['sleeptalk']},
 		], [
 			{species: 'Shedinja', ability: 'wonderguard', moves: ['fierydance']},
 			{species: 'Shedinja', ability: 'dancer', moves: ['sleeptalk']},
 		]]);
-		const [, fastDancer] = battle.p1.active;
-		const [wwDanceSource, foeDancer] = battle.p2.active;
 		fastDancer.boostBy({spe: 6});
 		battle.makeChoices('move sleeptalk, move sleeptalk', 'move fierydance 1, move sleeptalk');
 		assert.fainted(wwDanceSource);
@@ -38,15 +36,13 @@ describe('Dancer', function () {
 	});
 
 	it('should activate in order of lowest to highest raw speed inside Trick Room', function () {
-		battle = common.createBattle({gameType: 'doubles'}, [[
+		const {battle, p1b: fastDancer, p2a: wwDanceSource, p2b: foeDancer} = ctx = common.testCtx({gameType: 'doubles'}, [[
 			{species: 'Shedinja', level: 98, ability: 'dancer', item: 'focussash', moves: ['sleeptalk']},
 			{species: 'Shedinja', level: 99, ability: 'dancer', moves: ['sleeptalk']},
 		], [
 			{species: 'Shedinja', ability: 'wonderguard', moves: ['fierydance', 'trickroom']},
 			{species: 'Shedinja', ability: 'dancer', moves: ['sleeptalk']},
 		]]);
-		const [, fastDancer] = battle.p1.active;
-		const [wwDanceSource, foeDancer] = battle.p2.active;
 		fastDancer.boostBy({spe: 6});
 		battle.makeChoices('move sleeptalk, move sleeptalk', 'move trickroom, move sleeptalk');
 		battle.makeChoices('move sleeptalk, move sleeptalk', 'move fierydance 1, move sleeptalk');
@@ -56,41 +52,39 @@ describe('Dancer', function () {
 
 	it('should not copy a move that failed or was blocked by Protect', function () {
 		// hardcoded to RNG seed
-		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
+		const {battle, p1a, p1b, p2a, p2b} = ctx = common.testCtx({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
 			{species: 'Oricorio', level: 98, ability: 'dancer', item: 'laggingtail', moves: ['dragondance', 'protect', 'teeterdance']},
 			{species: 'Oricorio', level: 99, ability: 'dancer', moves: ['featherdance']},
 		], [
 			{species: 'Oricorio', ability: 'dancer', moves: ['fierydance', 'protect', 'teeterdance']},
 			{species: 'Shedinja', ability: 'wonderguard', moves: ['finalgambit']},
 		]]);
-		const [p1active, p2active] = [battle.p1.active, battle.p2.active];
 		battle.resetRNG();
-		p1active[0].boostBy({atk: 6, spe: 6});
-		p2active[0].boostBy({atk: -6});
-		p2active[1].boostBy({spe: 6});
+		p1a.boostBy({atk: 6, spe: 6});
+		p2a.boostBy({atk: -6});
+		p2b.boostBy({spe: 6});
 		battle.makeChoices('move dragondance, move featherdance 1', 'move fierydance -2, move finalgambit 1');
-		assert.fullHP(p2active[0]);
-		assert.statStage(p1active[0], 'atk', 6);
-		assert.statStage(p1active[1], 'atk', 0);
-		assert.statStage(p2active[0], 'atk', -6);
-		assert.statStage(p2active[0], 'spe', 0);
+		assert.fullHP(p2a);
+		assert.statStage(p1a, 'atk', 6);
+		assert.statStage(p1b, 'atk', 0);
+		assert.statStage(p2a, 'atk', -6);
+		assert.statStage(p2a, 'spe', 0);
 		// Next turn
 		battle.makeChoices('move dragondance, move featherdance 1', 'move protect');
-		assert.statStage(p1active[0], 'atk', 6);
-		assert.statStage(p1active[1], 'atk', 0);
+		assert.statStage(p1a, 'atk', 6);
+		assert.statStage(p1b, 'atk', 0);
 		// Next turn: Teeter Dance should be copied as long as it hits one thing
 		battle.makeChoices('move protect, move featherdance 1', 'move teeterdance');
 		// Next turn: Teeter Dance should NOT be copied if everything it hits is already confused
-		assert.constant(() => p1active[0].volatiles['confusion'], () => battle.makeChoices('move teeterdance, move featherdance 1', 'move fierydance 1'));
+		assert.constant(() => p1a.volatiles['confusion'], () => battle.makeChoices('move teeterdance, move featherdance 1', 'move fierydance 1'));
 	});
 
 	it('should not copy a move that missed', function () {
-		battle = common.createBattle({gameType: 'singles', seed: [1, 2, 3, 4]}, [[
+		const {battle, p1a: failDanceSource, p2a: evadesPokemon} = ctx = common.testCtx({gameType: 'singles', seed: [1, 2, 3, 4]}, [[
 			{species: 'Oricorio', ability: 'dancer', item: 'choicescarf', moves: ['revelationdance']},
 		], [
 			{species: 'Oricorio', ability: 'dancer', item: 'brightpowder', moves: ['dig']},
 		]]);
-		const [failDanceSource, evadesPokemon] = [battle.p1.active[0], battle.p2.active[0]];
 		failDanceSource.boostBy({accuracy: -6});
 		evadesPokemon.boostBy({evasion: 6});
 		battle.makeChoices('move revelationdance', 'move dig');
@@ -100,17 +94,16 @@ describe('Dancer', function () {
 	});
 
 	it('should copy a move that hit, but did 0 damage', function () {
-		battle = common.createBattle([[
+		const {battle, p1a: dancer} = ctx = common.testCtx([[
 			{species: 'Oricorio', ability: 'dancer', moves: ['fierydance']},
 		], [
 			{species: 'Shedinja', ability: 'dancer', item: 'focussash', moves: ['meanlook']},
 		]]);
-		const dancer = battle.p1.active[0];
 		assert.hurts(dancer, () => battle.makeChoices('move fierydance', 'move meanlook'));
 	});
 
 	it('should not activate if the holder fainted', function () {
-		battle = common.createBattle([[
+		const {battle} = ctx = common.testCtx([[
 			{species: 'Oricoriopompom', ability: 'dancer', moves: ['revelationdance']},
 		], [
 			{species: 'oricorio', ability: 'dancer', level: 1, moves: ['sleeptalk']},
@@ -121,7 +114,7 @@ describe('Dancer', function () {
 	});
 
 	it('should target the user of a Dance move unless it was an ally attacking an opponent', function () {
-		battle = common.createBattle({gameType: 'doubles'}, [[
+		const {battle, p1a, p1b, p2a, p2b} = ctx = common.testCtx({gameType: 'doubles'}, [[
 			{species: 'Oricorio', level: 98, ability: 'dancer', item: 'laggingtail', moves: ['sleeptalk', 'protect', 'teeterdance']},
 			{species: 'Oricorio', level: 99, ability: 'heatproof', moves: ['fierydance', 'sleeptalk']},
 		], [
@@ -129,27 +122,27 @@ describe('Dancer', function () {
 			{species: 'Suicune', ability: 'heatproof', moves: ['sleeptalk']},
 		]]);
 
-		const opponentTargetingAlly = battle.p2.active[0];
+		const opponentTargetingAlly = p2a;
 		assert.hurts(opponentTargetingAlly, () => battle.makeChoices('move sleeptalk, move sleeptalk', 'move fierydance 2, move sleeptalk'));
 
-		const opponentTargetingOpponent = battle.p2.active[0];
+		const opponentTargetingOpponent = p2a;
 		assert.hurts(opponentTargetingOpponent, () => battle.makeChoices('move sleeptalk, move sleeptalk', 'move fierydance -2, move sleeptalk'));
 
-		const allyTargetingDancer = battle.p1.active[1];
+		const allyTargetingDancer = p1b;
 		assert.hurts(allyTargetingDancer, () => battle.makeChoices('move sleeptalk, move fierydance -1', 'move sleeptalk, move sleeptalk'));
 
-		const allyTargetingOpponent = battle.p1.active[1];
+		const allyTargetingOpponent = p1b;
 		const allyHP = allyTargetingOpponent.hp;
-		const opponentTargetedByAlly = battle.p2.active[1];
-		const opponentNotTargetedByAlly = battle.p2.active[0];
+		const opponentTargetedByAlly = p2b;
+		const opponentNotTargetedByAlly = p2a;
 		const opponentHP = opponentNotTargetedByAlly.hp;
 		assert.hurts(opponentTargetedByAlly, () => battle.makeChoices('move sleeptalk, move fierydance 2', 'move sleeptalk, move sleeptalk'));
 		assert.equal(allyTargetingOpponent.hp, allyHP);
 		assert.equal(opponentNotTargetedByAlly.hp, opponentHP);
 	});
 
-	it('should adopt the target selected by copycat', function () {
-		battle = common.createBattle({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
+	it.only('should adopt the target selected by copycat', function () {
+		const {battle, flamigo, fletchinder, squawkabilly} = ctx = common.testCtx({gameType: 'doubles', seed: [1, 2, 3, 4]}, [[
 			{species: 'oricoriopau', ability: 'dancer', moves: ['featherdance']},
 			{species: 'flamigo', moves: ['copycat']},
 		], [
@@ -157,8 +150,6 @@ describe('Dancer', function () {
 			{species: 'squawkabilly', level: 1, moves: ['sleeptalk']},
 		]]);
 		battle.makeChoices('move featherdance 1, move copycat', 'auto');
-		const flamigo = battle.p1.active[1];
-		const [fletchinder, squawkabilly] = battle.p2.active;
 		assert.equal(flamigo.boosts.atk, 0);
 		assert.equal(fletchinder.boosts.atk, -2);
 		assert.equal(squawkabilly.boosts.atk, -4);


### PR DESCRIPTION
- Support for ``p1``, ``p2``, ``p1a``, ``p1b``...
- Support for fast access to specific Pokémon via their species ids.