### PR TITLE
Implement proper Origin forme mechanics

### DIFF
--- a/data/items.ts
+++ b/data/items.ts
@@ -64,9 +64,6 @@ export const Items: {[itemid: string]: ItemData} = {
 	adamantcrystal: {
 		name: "Adamant Crystal",
 		spritenum: 0, // TODO
-		fling: {
-			basePower: 60,
-		},
 		onTakeItem(item, pokemon, source) {
 			if ((source && source.baseSpecies.num === 483) || pokemon.baseSpecies.num === 483) {
 				return false;
@@ -2333,9 +2330,6 @@ export const Items: {[itemid: string]: ItemData} = {
 	griseouscore: {
 		name: "Griseous Core",
 		spritenum: 0, // TODO
-		fling: {
-			basePower: 60,
-		},
 		onTakeItem(item, pokemon, source) {
 			if ((source && source.baseSpecies.num === 487) || pokemon.baseSpecies.num === 487) {
 				return false;
@@ -3229,9 +3223,6 @@ export const Items: {[itemid: string]: ItemData} = {
 	lustrousglobe: {
 		name: "Lustrous Globe",
 		spritenum: 0, // TODO
-		fling: {
-			basePower: 60,
-		},
 		onTakeItem(item, pokemon, source) {
 			if ((source && source.baseSpecies.num === 484) || pokemon.baseSpecies.num === 484) {
 				return false;

--- a/data/items.ts
+++ b/data/items.ts
@@ -61,6 +61,24 @@ export const Items: {[itemid: string]: ItemData} = {
 		num: 545,
 		gen: 5,
 	},
+	adamantcrystal: {
+		name: "Adamant Crystal",
+		spritenum: 0, // TODO
+		fling: {
+			basePower: 60,
+		},
+		onTakeItem(item, pokemon, source) {
+			if ((source && source.baseSpecies.num === 483) || pokemon.baseSpecies.num === 483) {
+				return false;
+			}
+			return true;
+		},
+		forcedForme: "Dialga-Origin",
+		itemUser: ["Dialga-Origin"],
+		num: 1777,
+		gen: 8,
+		isNonstandard: "Unobtainable",
+	},
 	adamantorb: {
 		name: "Adamant Orb",
 		spritenum: 4,
@@ -69,7 +87,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		onBasePowerPriority: 15,
 		onBasePower(basePower, user, target, move) {
-			if (move && user.baseSpecies.name === 'Dialga' && (move.type === 'Steel' || move.type === 'Dragon')) {
+			if (move && user.baseSpecies.num === 483 && (move.type === 'Steel' || move.type === 'Dragon')) {
 				return this.chainModify([4915, 4096]);
 			}
 		},
@@ -2312,6 +2330,24 @@ export const Items: {[itemid: string]: ItemData} = {
 		num: 286,
 		gen: 4,
 	},
+	griseouscore: {
+		name: "Griseous Core",
+		spritenum: 0, // TODO
+		fling: {
+			basePower: 60,
+		},
+		onTakeItem(item, pokemon, source) {
+			if ((source && source.baseSpecies.num === 487) || pokemon.baseSpecies.num === 487) {
+				return false;
+			}
+			return true;
+		},
+		forcedForme: "Giratina-Origin",
+		itemUser: ["Giratina-Origin"],
+		num: 1779,
+		gen: 8,
+		isNonstandard: "Unobtainable",
+	},
 	griseousorb: {
 		name: "Griseous Orb",
 		spritenum: 180,
@@ -2324,14 +2360,7 @@ export const Items: {[itemid: string]: ItemData} = {
 				return this.chainModify([4915, 4096]);
 			}
 		},
-		onTakeItem(item, pokemon, source) {
-			if ((source && source.baseSpecies.num === 487) || pokemon.baseSpecies.num === 487) {
-				return false;
-			}
-			return true;
-		},
-		forcedForme: "Giratina-Origin",
-		itemUser: ["Giratina-Origin"],
+		itemUser: ["Giratina"],
 		num: 112,
 		gen: 4,
 		isNonstandard: "Unobtainable",
@@ -3197,6 +3226,24 @@ export const Items: {[itemid: string]: ItemData} = {
 		gen: 2,
 		isPokeball: true,
 	},
+	lustrousglobe: {
+		name: "Lustrous Globe",
+		spritenum: 0, // TODO
+		fling: {
+			basePower: 60,
+		},
+		onTakeItem(item, pokemon, source) {
+			if ((source && source.baseSpecies.num === 484) || pokemon.baseSpecies.num === 484) {
+				return false;
+			}
+			return true;
+		},
+		forcedForme: "Palkia-Origin",
+		itemUser: ["Palkia-Origin"],
+		num: 1778,
+		gen: 8,
+		isNonstandard: "Unobtainable",
+	},
 	lustrousorb: {
 		name: "Lustrous Orb",
 		spritenum: 265,
@@ -3205,7 +3252,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		onBasePowerPriority: 15,
 		onBasePower(basePower, user, target, move) {
-			if (move && user.baseSpecies.name === 'Palkia' && (move.type === 'Water' || move.type === 'Dragon')) {
+			if (move && user.baseSpecies.num === 484 && (move.type === 'Water' || move.type === 'Dragon')) {
 				return this.chainModify([4915, 4096]);
 			}
 		},

--- a/data/items.ts
+++ b/data/items.ts
@@ -65,7 +65,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		name: "Adamant Crystal",
 		spritenum: 0, // TODO
 		onTakeItem(item, pokemon, source) {
-			if ((source && source.baseSpecies.num === 483) || pokemon.baseSpecies.num === 483) {
+			if (source?.baseSpecies.num === 483 || pokemon.baseSpecies.num === 483) {
 				return false;
 			}
 			return true;
@@ -2331,7 +2331,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		name: "Griseous Core",
 		spritenum: 0, // TODO
 		onTakeItem(item, pokemon, source) {
-			if ((source && source.baseSpecies.num === 487) || pokemon.baseSpecies.num === 487) {
+			if (source?.baseSpecies.num === 487 || pokemon.baseSpecies.num === 487) {
 				return false;
 			}
 			return true;
@@ -3224,7 +3224,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		name: "Lustrous Globe",
 		spritenum: 0, // TODO
 		onTakeItem(item, pokemon, source) {
-			if ((source && source.baseSpecies.num === 484) || pokemon.baseSpecies.num === 484) {
+			if (source?.baseSpecies.num === 484 || pokemon.baseSpecies.num === 484) {
 				return false;
 			}
 			return true;

--- a/data/items.ts
+++ b/data/items.ts
@@ -63,7 +63,13 @@ export const Items: {[itemid: string]: ItemData} = {
 	},
 	adamantcrystal: {
 		name: "Adamant Crystal",
-		spritenum: 0, // TODO
+		spritenum: 4, // TODO
+		onBasePowerPriority: 15,
+		onBasePower(basePower, user, target, move) {
+			if (user.baseSpecies.num === 483 && (move.type === 'Steel' || move.type === 'Dragon')) {
+				return this.chainModify([4915, 4096]);
+			}
+		},
 		onTakeItem(item, pokemon, source) {
 			if (source?.baseSpecies.num === 483 || pokemon.baseSpecies.num === 483) {
 				return false;
@@ -84,7 +90,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		onBasePowerPriority: 15,
 		onBasePower(basePower, user, target, move) {
-			if (move && user.baseSpecies.num === 483 && (move.type === 'Steel' || move.type === 'Dragon')) {
+			if (user.baseSpecies.num === 483 && (move.type === 'Steel' || move.type === 'Dragon')) {
 				return this.chainModify([4915, 4096]);
 			}
 		},
@@ -2329,7 +2335,13 @@ export const Items: {[itemid: string]: ItemData} = {
 	},
 	griseouscore: {
 		name: "Griseous Core",
-		spritenum: 0, // TODO
+		spritenum: 180, // TODO
+		onBasePowerPriority: 15,
+		onBasePower(basePower, user, target, move) {
+			if (user.baseSpecies.num === 487 && (move.type === 'Ghost' || move.type === 'Dragon')) {
+				return this.chainModify([4915, 4096]);
+			}
+		},
 		onTakeItem(item, pokemon, source) {
 			if (source?.baseSpecies.num === 487 || pokemon.baseSpecies.num === 487) {
 				return false;
@@ -3222,7 +3234,13 @@ export const Items: {[itemid: string]: ItemData} = {
 	},
 	lustrousglobe: {
 		name: "Lustrous Globe",
-		spritenum: 0, // TODO
+		spritenum: 265, // TODO
+		onBasePowerPriority: 15,
+		onBasePower(basePower, user, target, move) {
+			if (user.baseSpecies.num === 484 && (move.type === 'Water' || move.type === 'Dragon')) {
+				return this.chainModify([4915, 4096]);
+			}
+		},
 		onTakeItem(item, pokemon, source) {
 			if (source?.baseSpecies.num === 484 || pokemon.baseSpecies.num === 484) {
 				return false;
@@ -3243,7 +3261,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		onBasePowerPriority: 15,
 		onBasePower(basePower, user, target, move) {
-			if (move && user.baseSpecies.num === 484 && (move.type === 'Water' || move.type === 'Dragon')) {
+			if (user.baseSpecies.num === 484 && (move.type === 'Water' || move.type === 'Dragon')) {
 				return this.chainModify([4915, 4096]);
 			}
 		},

--- a/data/mods/gen8/items.ts
+++ b/data/mods/gen8/items.ts
@@ -127,7 +127,7 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 		onTakeItem(item, pokemon, source) {
-			if ((source && source.baseSpecies.num === 487) || pokemon.baseSpecies.num === 487) {
+			if (source?.baseSpecies.num === 487 || pokemon.baseSpecies.num === 487) {
 				return false;
 			}
 			return true;

--- a/data/mods/gen8/items.ts
+++ b/data/mods/gen8/items.ts
@@ -1,4 +1,8 @@
 export const Items: {[k: string]: ModdedItemData} = {
+	adamantcrystal: {
+		inherit: true,
+		isNonstandard: "Future",
+	},
 	adamantorb: {
 		inherit: true,
 		isNonstandard: null,
@@ -115,9 +119,21 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	griseouscore: {
+		inherit: true,
+		isNonstandard: "Future",
+	},
 	griseousorb: {
 		inherit: true,
 		isNonstandard: null,
+		onTakeItem(item, pokemon, source) {
+			if ((source && source.baseSpecies.num === 487) || pokemon.baseSpecies.num === 487) {
+				return false;
+			}
+			return true;
+		},
+		forcedForme: "Giratina-Origin",
+		itemUser: ["Giratina-Origin"],
 	},
 	groundmemory: {
 		inherit: true,
@@ -142,6 +158,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 	leek: {
 		inherit: true,
 		isNonstandard: null,
+	},
+	lustrousglobe: {
+		inherit: true,
+		isNonstandard: "Future",
 	},
 	lustrousorb: {
 		inherit: true,

--- a/data/mods/gen8/pokedex.ts
+++ b/data/mods/gen8/pokedex.ts
@@ -19,6 +19,10 @@ export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 		inherit: true,
 		abilities: {0: "Steadfast", H: "Justified"},
 	},
+	giratinaorigin: {
+		inherit: true,
+		requiredItem: "Griseous Orb",
+	},
 	cresselia: {
 		inherit: true,
 		baseStats: {hp: 120, atk: 70, def: 120, spa: 75, spd: 130, spe: 85},

--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -8590,6 +8590,8 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 850,
 		color: "White",
 		eggGroups: ["Undiscovered"],
+		requiredItem: "Adamant Crystal",
+		changesFrom: "Dialga",
 		gen: 8,
 	},
 	palkia: {
@@ -8620,6 +8622,8 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 660,
 		color: "Purple",
 		eggGroups: ["Undiscovered"],
+		requiredItem: "Lustrous Globe",
+		changesFrom: "Palkia",
 		gen: 8,
 	},
 	heatran: {
@@ -8676,7 +8680,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		weightkg: 650,
 		color: "Black",
 		eggGroups: ["Undiscovered"],
-		requiredItem: "Griseous Orb",
+		requiredItem: "Griseous Core",
 		changesFrom: "Giratina",
 	},
 	cresselia: {

--- a/data/text/items.ts
+++ b/data/text/items.ts
@@ -17,6 +17,10 @@ export const ItemsText: {[k: string]: ItemText} = {
 		name: "Absorb Bulb",
 		desc: "Raises holder's Sp. Atk by 1 stage if hit by a Water-type attack. Single use.",
 	},
+	adamantcrystal: {
+		name: "Adamant Crystal",
+		desc: "If held by a Dialga, its Steel- and Dragon-type attacks have 1.2x power.",
+	},
 	adamantorb: {
 		name: "Adamant Orb",
 		desc: "If held by a Dialga, its Steel- and Dragon-type attacks have 1.2x power.",
@@ -721,6 +725,10 @@ export const ItemsText: {[k: string]: ItemText} = {
 		name: "Grip Claw",
 		desc: "Holder's partial-trapping moves always last 7 turns.",
 	},
+	griseouscore: {
+		name: "Griseous Core",
+		desc: "If held by a Giratina, its Ghost- and Dragon-type attacks have 1.2x power.",
+	},
 	griseousorb: {
 		name: "Griseous Orb",
 		desc: "If held by a Giratina, its Ghost- and Dragon-type attacks have 1.2x power.",
@@ -1007,6 +1015,10 @@ export const ItemsText: {[k: string]: ItemText} = {
 	lureball: {
 		name: "Lure Ball",
 		desc: "A Poke Ball for catching Pokemon hooked by a Rod when fishing.",
+	},
+	lustrousglobe: {
+		name: "Lustrous Globe",
+		desc: "If held by a Palkia, its Water- and Dragon-type attacks have 1.2x power.",
 	},
 	lustrousorb: {
 		name: "Lustrous Orb",


### PR DESCRIPTION
- Added the Adamant Crystal, Lustrous Globe, and Griseous Core, which are all required to be held by their respective Origin formes
- The Griseous Orb is now Identical to the other Orbs, providing a power boost to base Giratina and is able to be knocked off

This definitely would affect metagames like randbats, which currently has the origin formes holding items like Choice Specs and Choice Scarf, so this would be a pretty big nerf to them. ~~This is also a direct nerf to Giratina Origin, as it can no longer get the power boost from Griseous Orb while still being locked to one item.~~ I don't think there's much of an argument to not implement this since we usually try to follow cart mechanics as much as possible, but I just thought that some might not want this change with it affecting certain metagames too much despite being mechanics that could (with a very low chance) be changed with an update or DLC.