### PR TITLE
Build: Generate sourcemaps

### DIFF
--- a/tools/build-utils.js
+++ b/tools/build-utils.js
@@ -44,6 +44,7 @@ exports.transpile = (decl) => {
 		outbase: '.',
 		format: 'cjs',
 		tsconfig: './tsconfig.json',
+		sourcemap: true,
 	});
 	fs.copyFileSync('./config/config-example.js', './dist/config/config-example.js');
 	copyOverDataJSON();


### PR DESCRIPTION
This is needed for debuggers to work

LMK if this should be made optional via environment variable