### PR TITLE
Tournaments: Shuffle loser bracket seeds

### DIFF
--- a/server/tournaments/generator-elimination.ts
+++ b/server/tournaments/generator-elimination.ts
@@ -245,6 +245,7 @@ export class Elimination {
 			for (const depth in matchesByDepth) {
 				if (depth === '0') continue;
 				const matchesThisDepth = matchesByDepth[depth];
+				Utils.shuffle(matchesThisDepth);
 				let n = 0;
 				for (; n < matchesThisDepth.length - 1; n += 2) {
 					// Replace old leaf with:


### PR DESCRIPTION
Currently, the losers' bracket is seeded in the same order as the winners' bracket. This too often results in players being matched up with the same opponent they had in the winners' bracket. Shuffling the seeds at each level will keep this from happening as often.