### PR TITLE
Fix more SV item legality

### DIFF
--- a/data/items.ts
+++ b/data/items.ts
@@ -5615,7 +5615,7 @@ export const Items: {[itemid: string]: ItemData} = {
 	},
 	strangeball: {
 		name: "Strange Ball",
-		spritenum: 465,
+		spritenum: 303, // TODO
 		num: 1785,
 		gen: 8,
 		isPokeball: true,

--- a/data/items.ts
+++ b/data/items.ts
@@ -450,6 +450,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 1111,
 		gen: 8,
+		isNonstandard: "Past",
 	},
 	bigroot: {
 		name: "Big Root",
@@ -584,6 +585,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		onEat: false,
 		num: 165,
 		gen: 3,
+		isNonstandard: "Past",
 	},
 	blunderpolicy: {
 		name: "Blunder Policy",
@@ -1028,6 +1030,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 1112,
 		gen: 8,
+		isNonstandard: "Past",
 	},
 	cobaberry: {
 		name: "Coba Berry",
@@ -1631,15 +1634,6 @@ export const Items: {[itemid: string]: ItemData} = {
 		gen: 7,
 		isNonstandard: "Past",
 	},
-	energypowder: {
-		name: "Energy Powder",
-		spritenum: 123,
-		fling: {
-			basePower: 30,
-		},
-		num: 34,
-		gen: 2,
-	},
 	enigmaberry: {
 		name: "Enigma Berry",
 		spritenum: 124,
@@ -1944,6 +1938,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 1113,
 		gen: 8,
+		isNonstandard: "Past",
 	},
 	flyinggem: {
 		name: "Flying Gem",
@@ -2076,7 +2071,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		onFractionalPriority: -0.1,
 		num: 316,
 		gen: 4,
-		isNonstandard: "Unobtainable",
+		isNonstandard: "Past",
 	},
 	galaricacuff: {
 		name: "Galarica Cuff",
@@ -2086,7 +2081,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 1582,
 		gen: 8,
-		isNonstandard: "Past",
+		isNonstandard: "Unobtainable",
 	},
 	galaricawreath: {
 		name: "Galarica Wreath",
@@ -2096,7 +2091,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 1592,
 		gen: 8,
-		isNonstandard: "Past",
+		isNonstandard: "Unobtainable",
 	},
 	galladite: {
 		name: "Galladite",
@@ -2958,7 +2953,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 255,
 		gen: 3,
-		isNonstandard: "Unobtainable",
+		isNonstandard: "Past",
 	},
 	leafstone: {
 		name: "Leaf Stone",
@@ -3142,6 +3137,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 1110,
 		gen: 8,
+		isNonstandard: "Past",
 	},
 	lucarionite: {
 		name: "Lucarionite",
@@ -3300,6 +3296,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 215,
 		gen: 3,
+		isNonstandard: "Past",
 	},
 	magmarizer: {
 		name: "Magmarizer",
@@ -3309,6 +3306,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 323,
 		gen: 4,
+		isNonstandard: "Past",
 	},
 	magnet: {
 		name: "Magnet",
@@ -3564,6 +3562,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		itemUser: ["Ditto"],
 		num: 257,
 		gen: 2,
+		isNonstandard: "Past",
 	},
 	metronome: {
 		name: "Metronome",
@@ -3937,7 +3936,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 314,
 		gen: 4,
-		isNonstandard: "Unobtainable",
+		isNonstandard: "Past",
 	},
 	oldamber: {
 		name: "Old Amber",
@@ -4156,6 +4155,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		onEat: false,
 		num: 168,
 		gen: 3,
+		isNonstandard: "Past",
 	},
 	pinsirite: {
 		name: "Pinsirite",
@@ -4551,6 +4551,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		itemUser: ["Ditto"],
 		num: 274,
 		gen: 4,
+		isNonstandard: "Past",
 	},
 	rabutaberry: {
 		name: "Rabuta Berry",
@@ -4711,6 +4712,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 1115,
 		gen: 8,
+		isNonstandard: "Past",
 	},
 	rindoberry: {
 		name: "Rindo Berry",
@@ -4774,7 +4776,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 315,
 		gen: 4,
-		isNonstandard: "Unobtainable",
+		isNonstandard: "Past",
 	},
 	rockmemory: {
 		name: "Rock Memory",
@@ -4866,7 +4868,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 318,
 		gen: 4,
-		isNonstandard: "Unobtainable",
+		isNonstandard: "Past",
 	},
 	roseliberry: {
 		name: "Roseli Berry",
@@ -4970,6 +4972,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		num: 5,
 		gen: 1,
 		isPokeball: true,
+		isNonstandard: "Unobtainable",
 	},
 	safetygoggles: {
 		name: "Safety Goggles",
@@ -5087,7 +5090,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 254,
 		gen: 3,
-		isNonstandard: "Unobtainable",
+		isNonstandard: "Past",
 	},
 	sharpbeak: {
 		name: "Sharp Beak",
@@ -5451,6 +5454,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		num: 499,
 		gen: 2,
 		isPokeball: true,
+		isNonstandard: "Unobtainable",
 	},
 	starfberry: {
 		name: "Starf Berry",
@@ -5492,6 +5496,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 1114,
 		gen: 8,
+		isNonstandard: "Past",
 	},
 	steelixite: {
 		name: "Steelixite",
@@ -5608,6 +5613,14 @@ export const Items: {[itemid: string]: ItemData} = {
 		gen: 4,
 		isNonstandard: "Unobtainable",
 	},
+	strangeball: {
+		name: "Strange Ball",
+		spritenum: 465,
+		num: 1785,
+		gen: 8,
+		isPokeball: true,
+		isNonstandard: "Unobtainable",
+	},
 	strawberrysweet: {
 		name: "Strawberry Sweet",
 		spritenum: 704,
@@ -5616,6 +5629,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 1109,
 		gen: 8,
+		isNonstandard: "Past",
 	},
 	sunstone: {
 		name: "Sun Stone",
@@ -7002,7 +7016,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 317,
 		gen: 4,
-		isNonstandard: "Unobtainable",
+		isNonstandard: "Past",
 	},
 	weaknesspolicy: {
 		name: "Weakness Policy",

--- a/data/mods/gen7/items.ts
+++ b/data/mods/gen7/items.ts
@@ -72,6 +72,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	blukberry: {
+		inherit: true,
+		isNonstandard: "Unobtainable",
+	},
 	buggem: {
 		inherit: true,
 		isNonstandard: "Unobtainable",
@@ -438,6 +442,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 	pikashuniumz: {
 		inherit: true,
 		isNonstandard: null,
+	},
+	pinapberry: {
+		inherit: true,
+		isNonstandard: "Unobtainable",
 	},
 	pinsirite: {
 		inherit: true,

--- a/data/mods/gen8/items.ts
+++ b/data/mods/gen8/items.ts
@@ -11,6 +11,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	berrysweet: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	bugmemory: {
 		inherit: true,
 		isNonstandard: null,
@@ -20,6 +24,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		isNonstandard: null,
 	},
 	chilldrive: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	cloversweet: {
 		inherit: true,
 		isNonstandard: null,
 	},
@@ -76,6 +84,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		isNonstandard: null,
 	},
 	firememory: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	flowersweet: {
 		inherit: true,
 		isNonstandard: null,
 	},
@@ -159,6 +171,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	lovesweet: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	lustrousglobe: {
 		inherit: true,
 		isNonstandard: "Future",
@@ -167,7 +183,19 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	machobrace: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	magmarizer: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	marangaberry: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	metalpowder: {
 		inherit: true,
 		isNonstandard: null,
 	},
@@ -199,7 +227,15 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	quickpowder: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	reapercloth: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	ribbonsweet: {
 		inherit: true,
 		isNonstandard: null,
 	},
@@ -231,6 +267,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	safariball: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	seaincense: {
 		inherit: true,
 		isNonstandard: null,
@@ -243,9 +283,25 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	sportball: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	starsweet: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	strawberrysweet: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	steelmemory: {
 		inherit: true,
 		isNonstandard: null,
+	},
+	strangeball: {
+		inherit: true,
+		isNonstandard: "Future",
 	},
 	thickclub: {
 		inherit: true,

--- a/data/mods/gen8bdsp/items.ts
+++ b/data/mods/gen8bdsp/items.ts
@@ -27,6 +27,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: "Past",
 	},
+	blukberry: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	blunderpolicy: {
 		inherit: true,
 		isNonstandard: "Past",
@@ -256,9 +260,17 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: "Past",
 	},
+	nanabberry: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	normalgem: {
 		inherit: true,
 		isNonstandard: "Past",
+	},
+	pinapberry: {
+		inherit: true,
+		isNonstandard: null,
 	},
 	plumefossil: {
 		inherit: true,
@@ -281,6 +293,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		isNonstandard: "Past",
 	},
 	razorfang: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	razzberry: {
 		inherit: true,
 		isNonstandard: null,
 	},
@@ -361,6 +377,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 		isNonstandard: "Past",
 	},
 	stoneplate: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	strangeball: {
 		inherit: true,
 		isNonstandard: null,
 	},
@@ -799,6 +819,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 	weaknesspolicy: {
 		inherit: true,
 		isNonstandard: "Past",
+	},
+	wepearberry: {
+		inherit: true,
+		isNonstandard: null,
 	},
 	whippeddream: {
 		inherit: true,

--- a/data/text/items.ts
+++ b/data/text/items.ts
@@ -483,13 +483,6 @@ export const ItemsText: {[k: string]: ItemText} = {
 		name: "Electrium Z",
 		desc: "If holder has an Electric move, this item allows it to use an Electric Z-Move.",
 	},
-	energypowder: {
-		name: "Energy Powder",
-		desc: "Restores 60 HP to one Pokemon.",
-		gen6: {
-			desc: "Restores 50 HP to one Pokemon but lowers Happiness.",
-		},
-	},
 	enigmaberry: {
 		name: "Enigma Berry",
 		desc: "Restores 1/4 max HP after holder is hit by a supereffective move. Single use.",


### PR DESCRIPTION
The following items are now correctly marked as unobtainable:
Safari Ball
Sport Ball
Galarica Cuff
Galarica Wreath
Strange Ball

The following items are now correctly marked as past:
Bluk Berry
Pinap Berry
Macho Brace
Sea Incense
Lax Incense
Metal Powder
Quick Powder
Odd Incense
Rock Incense
Full Incense
Wave Incense
Rose Incense
Magmarizer
Strawberry Sweet
Love Sweet
Berry Sweet
Clover Sweet
Flower Sweet
Star Sweet
Ribbon Sweet

In addition, I added the new Strange Ball item (consistent with us having other unobtainable Poke Balls) and removed Energy Powder. I don't see why we had Energy Powder and no other healing items; it doesn't have a unique Fling BP like Rare Bone or some sort of "special significance" like Bottle Cap. If we still want it I can add it back, but idk why we would need it lol