### PR TITLE
Random Battles updates

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -660,7 +660,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Chilly Reception", "Fire Blast", "Psyshock", "Slack Off", "Sludge Bomb", "Thunder Wave", "Toxic"],
+                "movepool": ["Chilly Reception", "Fire Blast", "Psyshock", "Slack Off", "Sludge Bomb", "Thunder Wave"],
                 "teraTypes": ["Poison", "Dark"]
             },
             {
@@ -871,7 +871,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Bug Buzz", "Hurricane", "Hydro Pump", "Ice Beam", "Sticky Web", "Stun Spore", "U-turn"],
-                "teraTypes": ["Flying"]
+                "teraTypes": ["Ground", "Steel"]
             }
         ]
     },
@@ -1076,7 +1076,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Charm", "Ice Beam", "Protect", "Surf", "Wish"],
-                "teraTypes": ["Water"]
+                "teraTypes": ["Dragon", "Ghost"]
             }
         ]
     },
@@ -1104,9 +1104,9 @@
         "level": 74,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Lava Plume", "Precipice Blades", "Spikes", "Stealth Rock", "Stone Edge", "Thunder Wave"],
-                "teraTypes": ["Ground", "Fire"]
+                "teraTypes": ["Fire", "Dragon", "Water", "Ghost"]
             },
             {
                 "role": "Bulky Setup",
@@ -1540,7 +1540,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Draco Meteor", "Fire Blast", "Flash Cannon", "Stealth Rock", "Thunder Wave", "Thunderbolt"],
+                "movepool": ["Draco Meteor", "Fire Blast", "Flash Cannon", "Stealth Rock", "Thunder Wave"],
                 "teraTypes": ["Dragon", "Steel", "Fire"]
             }
         ]
@@ -1548,6 +1548,11 @@
     "palkia": {
         "level": 76,
         "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Draco Meteor", "Fire Blast", "Hydro Pump", "Spacial Rend"],
+                "teraTypes": ["Dragon", "Water"]
+            },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Draco Meteor", "Fire Blast", "Hydro Pump", "Spacial Rend", "Thunder Wave"],
@@ -1559,8 +1564,8 @@
         "level": 76,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["Draco Meteor", "Fire Blast", "Hydro Pump", "Spacial Rend"],
+                "role": "Bulky Attacker",
+                "movepool": ["Draco Meteor", "Fire Blast", "Hydro Pump", "Spacial Rend", "Thunder Wave"],
                 "teraTypes": ["Dragon", "Water"]
             }
         ]
@@ -1870,7 +1875,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Agility", "Aqua Jet", "Last Respects", "Psychic Fangs", "Wave Crash"],
+                "movepool": ["Agility", "Last Respects", "Psychic Fangs", "Wave Crash"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -3234,7 +3239,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Flame Charge", "Shadow Ball", "Slack Off", "Torch Song"],
-                "teraTypes": ["Fire"]
+                "teraTypes": ["Fire", "Water"]
             },
             {
                 "role": "Bulky Support",
@@ -3284,7 +3289,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Glare", "Headbutt", "Roost"],
-                "teraTypes": ["Normal", "Ghost", "Ground"]
+                "teraTypes": ["Ghost", "Ground"]
             },
             {
                 "role": "Bulky Setup",
@@ -3299,12 +3304,12 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Glare", "Headbutt", "Roost"],
-                "teraTypes": ["Normal", "Ghost", "Ground"]
+                "teraTypes": ["Ghost", "Ground"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Boomburst", "Calm Mind", "Earth Power", "Roost", "Thunder"],
-                "teraTypes": ["Normal"]
+                "teraTypes": ["Normal", "Ghost"]
             }
         ]
     },
@@ -3369,7 +3374,7 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Calm Mind", "Dazzling Gleam", "Protect", "Roost", "Stored Power", "Substitute"],
-                "teraTypes": ["Psychic", "Fairy"]
+                "teraTypes": ["Fairy"]
             },
             {
                 "role": "Tera Blast user",
@@ -3499,12 +3504,12 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Coil", "Iron Tail", "Rest"],
-                "teraTypes": ["Steel", "Fighting", "Electric"]
+                "teraTypes": ["Fighting", "Electric"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Press", "Iron Head", "Rest", "Shed Tail", "Spikes", "Stealth Rock"],
-                "teraTypes": ["Steel", "Electric"]
+                "teraTypes": ["Electric", "Poison"]
             }
         ]
     },
@@ -3838,8 +3843,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Flare Blitz", "Leech Life", "Wild Charge", "Will-O-Wisp"],
-                "teraTypes": ["Fighting", "Electric", "Fire"]
+                "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Leech Life", "Wild Charge", "Will-O-Wisp"],
+                "teraTypes": ["Fighting", "Electric"]
             },
             {
                 "role": "Fast Attacker",

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -176,7 +176,7 @@ export class RandomTeams {
 			Psychic: (movePool, moves, abilities, types, counter) => {
 				if (counter.get('Psychic')) return false;
 				if (movePool.includes('calmmind') || movePool.includes('psychicfangs') || movePool.includes('psychocut')) return true;
-				return abilities.has('Psychic Surge') || types.includes('Fire');
+				return abilities.has('Psychic Surge') || types.includes('Fire') || types.includes('Electric');
 			},
 			Rock: (movePool, moves, abilities, types, counter, species) => !counter.get('Rock') && species.baseStats.atk >= 80,
 			Steel: (movePool, moves, abilities, types, counter, species) => {
@@ -872,7 +872,7 @@ export class RandomTeams {
 			return (species.id !== 'houndoom' && this.dex.getEffectiveness('Fire', species) < 0);
 		case 'Guts':
 			return (!moves.has('facade') && !moves.has('sleeptalk'));
-		case 'Hustle': case 'Inner Focus':
+		case 'Hustle':
 			return (counter.get('Physical') < 2);
 		case 'Infiltrator':
 			return (moves.has('rest') && moves.has('sleeptalk')) || (isDoubles && abilities.has('Clear Body'));
@@ -973,6 +973,7 @@ export class RandomTeams {
 		if (abilities.has('Cud Chew') && moves.has('substitute')) return 'Cud Chew';
 		if (abilities.has('Guts') && (moves.has('facade') || moves.has('sleeptalk'))) return 'Guts';
 		if (abilities.has('Harvest') && moves.has('substitute')) return 'Harvest';
+		if (abilities.has('Insomnia') && species.id === 'hypno') return 'Insomnia';
 		if (abilities.has('Serene Grace') && moves.has('headbutt')) return 'Serene Grace';
 		if (abilities.has('Technician') && counter.get('technician')) return 'Technician';
 		if (abilities.has('Own Tempo') && moves.has('petaldance')) return 'Own Tempo';
@@ -1073,7 +1074,7 @@ export class RandomTeams {
 		}
 		if (moves.has('shellsmash')) return 'White Herb';
 		if (moves.has('populationbomb')) return 'Wide Lens';
-		if (moves.has('stuffcheeks')) return 'Salac Berry';
+		if (moves.has('stuffcheeks')) return this.randomChance(1, 2) ? 'Liechi Berry' : 'Salac Berry';
 		if (ability === 'Unburden') return moves.has('closecombat') ? 'White Herb' : 'Sitrus Berry';
 		if (moves.has('acrobatics')) return ability === 'Grassy Surge' ? 'Grassy Seed' : '';
 		if (moves.has('auroraveil') || moves.has('lightscreen') && moves.has('reflect')) return 'Light Clay';
@@ -1188,6 +1189,7 @@ export class RandomTeams {
 		if (species.id === 'urshifurapidstrike') return 'Punching Glove';
 		if (species.id === 'lokix' && role === 'Wallbreaker') return 'Life Orb';
 		if (species.id === 'toxtricity' && moves.has('shiftgear')) return 'Throat Spray';
+		if (species.id === 'Palkia') return 'Lustrous Orb';
 		if (moves.has('substitute') || ability === 'Moody') return 'Leftovers';
 		if (
 			!teamDetails.defog && !teamDetails.rapidSpin &&
@@ -1582,6 +1584,7 @@ export class RandomTeams {
 			if (set.moves.includes('spikes')) teamDetails.spikes = (teamDetails.spikes || 0) + 1;
 			if (set.moves.includes('stealthrock')) teamDetails.stealthRock = 1;
 			if (set.moves.includes('stickyweb')) teamDetails.stickyWeb = 1;
+			if (set.moves.includes('stoneaxe')) teamDetails.stealthRock = 1;
 			if (set.moves.includes('toxicspikes')) teamDetails.toxicSpikes = 1;
 			if (set.moves.includes('defog')) teamDetails.defog = 1;
 			if (set.moves.includes('rapidspin')) teamDetails.rapidSpin = 1;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -848,8 +848,8 @@ export class RandomTeams {
 		role: string,
 	): boolean {
 		if ([
-			'Armor Tail', 'Battle Bond', 'Flare Boost', 'Gluttony', 'Harvest', 'Hydration', 'Ice Body',
-			'Immunity', 'Own Tempo', 'Quick Feet', 'Rain Dish', 'Snow Cloak', 'Steadfast', 'Steam Engine',
+			'Armor Tail', 'Battle Bond', 'Early Bird', 'Flare Boost', 'Gluttony', 'Harvest', 'Hydration', 'Ice Body',
+			'Immunity', 'Own Tempo', 'Pressure', 'Quick Feet', 'Rain Dish', 'Snow Cloak', 'Steadfast', 'Steam Engine',
 		].includes(ability)) return true;
 
 		switch (ability) {
@@ -894,8 +894,6 @@ export class RandomTeams {
 			return !counter.get('Grass');
 		case 'Prankster':
 			return !counter.get('Status');
-		case 'Pressure':
-			return (!!counter.get('setup') || counter.get('Status') < 2 || isDoubles);
 		case 'Reckless':
 			return !counter.get('recoil');
 		case 'Rock Head':
@@ -916,7 +914,7 @@ export class RandomTeams {
 		case 'Slush Rush':
 			return !teamDetails.snow;
 		case 'Solar Power':
-			return (!teamDetails.sun);
+			return (!teamDetails.sun || !counter.get('Special'));
 		case 'Stakeout':
 			return (counter.damagingMoves.size < 1);
 		case 'Sturdy':

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -972,6 +972,7 @@ export class RandomTeams {
 		if (abilities.has('Guts') && (moves.has('facade') || moves.has('sleeptalk'))) return 'Guts';
 		if (abilities.has('Harvest') && moves.has('substitute')) return 'Harvest';
 		if (abilities.has('Insomnia') && species.id === 'hypno') return 'Insomnia';
+		if (abilities.has('Pressure') && role === 'Bulky Setup') return 'Pressure';
 		if (abilities.has('Serene Grace') && moves.has('headbutt')) return 'Serene Grace';
 		if (abilities.has('Technician') && counter.get('technician')) return 'Technician';
 		if (abilities.has('Own Tempo') && moves.has('petaldance')) return 'Own Tempo';


### PR DESCRIPTION
-Lucario will now get Inner Focus on the special set.
-Groudon will now always get at least two attacks.
-Palkia and Dialga's Origin formes now hold legal items, and their sets have been changed as such.
-Palkia can now run Choice items.
-Palkia can now run Lustrous Orb.
-Alolan Raichu will now always run a Psychic move.
-Stone Axe counts as having a Stealth Rock user and will prevent future Pokemon from generating Stealth Rock.
-Oinkologne can now run a Liechi Berry sometimes.
-Charizard will no longer get Solar Power on physical sets.
-Spiritomb now always runs Pressure on its Bulky Setup set.
-Sunflora now always runs Chlorophyll because Early Bird is now always rejected.
-Several minor set updates.
