### PR TITLE
Fix mocha for paths with whitespace

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('child_process').execSync('node ' + __dirname + "/../build");
+require('child_process').execSync('node "' + __dirname + '/../build"');
 const path = require('path');
 const fs = require('fs');
 


### PR DESCRIPTION
Adding quotes around the path in a command line command make it work with whitespace in the path.

I thought "User Files" was a default directory in Windows, but now I'm thinking I may have put the whitespace there myself which would make me very silly. Regardless, this fix should help some people (including me).