### PR TITLE
Gen 1: Implement Dig/Fly invulnerability glitch, partially fix charging moves and Mirror Move

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,5 @@
 {
-  "spec": ["test/main.js", "test/lib/**/*.js", "test/server/**/*.js", "test/sim/**/*.js", "test/tools/**/*.js", "test/random-battles/**/*.js"],
+  "spec": ["test/main.js", "test/sim/moves/mirrormove.js", "test/sim/misc/twoturnmoves.js"],
   "grep": "^((?!\\(slow\\)).)*$",
   "reporter": "dot",
   "ui": "bdd",

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,5 @@
 {
-  "spec": ["test/main.js", "test/sim/moves/mirrormove.js", "test/sim/misc/twoturnmoves.js"],
+  "spec": ["test/main.js", "test/lib/**/*.js", "test/server/**/*.js", "test/sim/**/*.js", "test/tools/**/*.js", "test/random-battles/**/*.js"],
   "grep": "^((?!\\(slow\\)).)*$",
   "reporter": "dot",
   "ui": "bdd",

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -145,6 +145,7 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 				this.directDamage(damage, pokemon, target);
 				pokemon.removeVolatile('bide');
 				pokemon.removeVolatile('twoturnmove');
+				pokemon.removeVolatile('invulnerability');
 				pokemon.removeVolatile('partialtrappinglock');
 				pokemon.removeVolatile('lockedmove');
 				return false;
@@ -282,6 +283,15 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 		},
 		onLockMove() {
 			return this.effectState.move;
+		},
+	},
+	invulnerability: {
+		// Fly/Dig
+		name: 'invulnerability',
+		onInvulnerability(target, source, move) {
+			if (move.id === 'swift' || move.id === 'transform') return true;
+			this.add('-message', 'The foe ' + target.name + ' can\'t be hit while invulnerable!');
+			return false;
 		},
 	},
 };

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -294,6 +294,7 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 		// Dig/Fly
 		name: 'invulnerability',
 		onInvulnerability(target, source, move) {
+			if (target === source) return true;
 			if (move.id === 'swift' || move.id === 'transform') return true;
 			this.add('-message', 'The foe ' + target.name + ' can\'t be hit while invulnerable!');
 			return false;

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -235,30 +235,4 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 			target.addVolatile('confusion');
 		},
 	},
-	stall: {
-		name: 'stall',
-		// Protect, Detect, Endure counter
-		duration: 2,
-		counterMax: 256,
-		onStart() {
-			this.effectState.counter = 2;
-		},
-		onStallMove() {
-			// this.effectState.counter should never be undefined here.
-			// However, just in case, use 1 if it is undefined.
-			const counter = this.effectState.counter || 1;
-			if (counter >= 256) {
-				// 2^32 - special-cased because Battle.random(n) can't handle n > 2^16 - 1
-				return (this.random() * 4294967296 < 1);
-			}
-			this.debug("Success chance: " + Math.round(100 / counter) + "%");
-			return this.randomChance(1, counter);
-		},
-		onRestart() {
-			if (this.effectState.counter < (this.effect as Condition).counterMax!) {
-				this.effectState.counter *= 2;
-			}
-			this.effectState.duration = 2;
-		},
-	},
 };

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -241,6 +241,7 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 		onStart(attacker, defender, effect) {
 			// ("attacker" is the Pokemon using the two turn move and the Pokemon this condition is being applied to)
 			this.effectState.move = effect.id;
+			this.effectState.sourceEffect = effect.sourceEffect;
 			attacker.addVolatile(effect.id);
 			// lastMoveTargetLoc is the location of the originally targeted slot before any redirection
 			// note that this is not updated for moves called by other moves

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -235,4 +235,41 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 			target.addVolatile('confusion');
 		},
 	},
+	twoturnmove: {
+		// Skull Bash, SolarBeam, Sky Drop...
+		name: 'twoturnmove',
+		duration: 2,
+		onStart(attacker, defender, effect) {
+			// ("attacker" is the Pokemon using the two turn move and the Pokemon this condition is being applied to)
+			this.effectState.move = effect.id;
+			attacker.addVolatile(effect.id);
+			// lastMoveTargetLoc is the location of the originally targeted slot before any redirection
+			// note that this is not updated for moves called by other moves
+			// i.e. if Dig is called by Metronome, lastMoveTargetLoc will still be the user's location
+			let moveTargetLoc: number = attacker.lastMoveTargetLoc!;
+			if (effect.sourceEffect && this.dex.moves.get(effect.id).target !== 'self') {
+				// this move was called by another move such as Metronome
+				// and needs a random target to be determined this turn
+				// it will already have one by now if there is any valid target
+				// but if there isn't one we need to choose a random slot now
+				if (defender.fainted) {
+					defender = this.sample(attacker.foes(true));
+				}
+				moveTargetLoc = attacker.getLocOf(defender);
+			}
+			attacker.volatiles[effect.id].targetLoc = moveTargetLoc;
+			this.attrLastMove('[still]');
+			// Run side-effects normally associated with hitting (e.g., Protean, Libero)
+			this.runEvent('PrepareHit', attacker, defender, effect);
+		},
+		onEnd(target) {
+			target.removeVolatile(this.effectState.move);
+		},
+		onLockMove() {
+			return this.effectState.move;
+		},
+		onMoveAborted(pokemon) {
+			pokemon.removeVolatile('twoturnmove');
+		},
+	},
 };

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -38,7 +38,12 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 			if (this.randomChance(63, 256)) {
 				this.add('cant', pokemon, 'par');
 				pokemon.removeVolatile('bide');
-				pokemon.removeVolatile('twoturnmove');
+				if (pokemon.removeVolatile('twoturnmove')) {
+					if (pokemon.volatiles['invulnerability']) {
+						this.hint(`In Gen 1, when a Dig/Fly user is fully paralyzed while semi-invulnerable, ` +
+						`it will remain semi-invulnerable until it switches out or fully executes Dig/Fly`, true);
+					}
+				}
 				pokemon.removeVolatile('partialtrappinglock');
 				pokemon.removeVolatile('lockedmove');
 				return false;

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -230,7 +230,6 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 	twoturnmove: {
 		// Skull Bash, Solar Beam, ...
 		name: 'twoturnmove',
-		duration: 2,
 		onStart(attacker, defender, effect) {
 			// ("attacker" is the Pokemon using the two turn move and the Pokemon this condition is being applied to)
 			this.effectState.move = effect.id;
@@ -259,9 +258,6 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 		},
 		onLockMove() {
 			return this.effectState.move;
-		},
-		onMoveAborted(pokemon) {
-			pokemon.removeVolatile('twoturnmove');
 		},
 	},
 };

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -242,28 +242,7 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 			// ("attacker" is the Pokemon using the two turn move and the Pokemon this condition is being applied to)
 			this.effectState.move = effect.id;
 			this.effectState.sourceEffect = effect.sourceEffect;
-			attacker.addVolatile(effect.id);
-			// lastMoveTargetLoc is the location of the originally targeted slot before any redirection
-			// note that this is not updated for moves called by other moves
-			// i.e. if Dig is called by Metronome, lastMoveTargetLoc will still be the user's location
-			let moveTargetLoc: number = attacker.lastMoveTargetLoc!;
-			if (effect.sourceEffect && this.dex.moves.get(effect.id).target !== 'self') {
-				// this move was called by another move such as Metronome
-				// and needs a random target to be determined this turn
-				// it will already have one by now if there is any valid target
-				// but if there isn't one we need to choose a random slot now
-				if (defender.fainted) {
-					defender = this.sample(attacker.foes(true));
-				}
-				moveTargetLoc = attacker.getLocOf(defender);
-			}
-			attacker.volatiles[effect.id].targetLoc = moveTargetLoc;
 			this.attrLastMove('[still]');
-			// Run side-effects normally associated with hitting (e.g., Protean, Libero)
-			this.runEvent('PrepareHit', attacker, defender, effect);
-		},
-		onEnd(target) {
-			target.removeVolatile(this.effectState.move);
 		},
 		onLockMove() {
 			return this.effectState.move;

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -224,32 +224,10 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 		onStart() {},
 	},
 	lockedmove: {
-		// Thrash, Petal Dance...
-		name: 'lockedmove',
+		// Outrage, Thrash, Petal Dance...
+		inherit: true,
 		durationCallback() {
 			return this.random(3, 5);
-		},
-		onResidual(target) {
-			if ((target.lastMove && target.lastMove.id === 'struggle') || target.status === 'slp') {
-				// don't lock, and bypass confusion for calming
-				delete target.volatiles['lockedmove'];
-			}
-		},
-		onStart(target, source, effect) {
-			this.effectState.move = effect.id;
-		},
-		onLockMove(pokemon) {
-			return this.effectState.move;
-		},
-		onMoveAborted(pokemon) {
-			delete pokemon.volatiles['lockedmove'];
-		},
-		onBeforeTurn(pokemon) {
-			const move = this.dex.moves.get(this.effectState.move);
-			if (move.id) {
-				this.debug('Forcing into ' + move.id);
-				this.queue.changeAction(pokemon, {choice: 'move', moveid: move.id});
-			}
 		},
 		onEnd(target) {
 			// Confusion begins even if already confused

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -291,7 +291,7 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 		},
 	},
 	invulnerability: {
-		// Fly/Dig
+		// Dig/Fly
 		name: 'invulnerability',
 		onInvulnerability(target, source, move) {
 			if (move.id === 'swift' || move.id === 'transform') return true;

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -39,10 +39,6 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 				this.add('cant', pokemon, 'par');
 				pokemon.removeVolatile('bide');
 				pokemon.removeVolatile('twoturnmove');
-				pokemon.removeVolatile('fly');
-				pokemon.removeVolatile('dig');
-				pokemon.removeVolatile('solarbeam');
-				pokemon.removeVolatile('skullbash');
 				pokemon.removeVolatile('partialtrappinglock');
 				return false;
 			}
@@ -148,10 +144,6 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 				this.directDamage(damage, pokemon, target);
 				pokemon.removeVolatile('bide');
 				pokemon.removeVolatile('twoturnmove');
-				pokemon.removeVolatile('fly');
-				pokemon.removeVolatile('dig');
-				pokemon.removeVolatile('solarbeam');
-				pokemon.removeVolatile('skullbash');
 				pokemon.removeVolatile('partialtrappinglock');
 				return false;
 			}
@@ -236,7 +228,7 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 		},
 	},
 	twoturnmove: {
-		// Skull Bash, SolarBeam, Sky Drop...
+		// Skull Bash, Solar Beam, ...
 		name: 'twoturnmove',
 		duration: 2,
 		onStart(attacker, defender, effect) {

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -209,21 +209,15 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	dig: {
 		inherit: true,
 		basePower: 100,
-		condition: {
-			duration: 2,
-			onLockMove: 'dig',
-			onInvulnerability(target, source, move) {
-				if (move.id === 'swift' || move.id === 'transform') return true;
-				this.add('-message', 'The foe ' + target.name + ' can\'t be hit underground!');
-				return false;
-			},
-		},
+		condition: {},
 		onTryMove(attacker, defender, move) {
 			if (attacker.removeVolatile('twoturnmove')) {
+				attacker.removeVolatile('invulnerability');
 				return;
 			}
 			this.add('-prepare', attacker, move.name);
 			attacker.addVolatile('twoturnmove', defender);
+			attacker.addVolatile('invulnerability', defender);
 			return null;
 		},
 	},
@@ -328,21 +322,15 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	fly: {
 		inherit: true,
-		condition: {
-			duration: 2,
-			onLockMove: 'fly',
-			onInvulnerability(target, source, move) {
-				if (move.id === 'swift' || move.id === 'transform') return true;
-				this.add('-message', 'The foe ' + target.name + ' can\'t be hit while flying!');
-				return false;
-			},
-		},
+		condition: {},
 		onTryMove(attacker, defender, move) {
 			if (attacker.removeVolatile('twoturnmove')) {
+				attacker.removeVolatile('invulnerability');
 				return;
 			}
 			this.add('-prepare', attacker, move.name);
 			attacker.addVolatile('twoturnmove', defender);
+			attacker.addVolatile('invulnerability', defender);
 			return null;
 		},
 	},

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -258,6 +258,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				}
 				if (move.id === this.effectState.move) {
 					this.add('cant', pokemon, 'Disable', move);
+					pokemon.removeVolatile('twoturnmove');
 					return false;
 				}
 			},

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -223,9 +223,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				return;
 			}
 			this.add('-prepare', attacker, move.name);
-			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
-				return;
-			}
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
 		},
@@ -345,9 +342,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				return;
 			}
 			this.add('-prepare', attacker, move.name);
-			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
-				return;
-			}
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
 		},
@@ -622,9 +616,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				return;
 			}
 			this.add('-prepare', attacker, move.name);
-			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
-				return;
-			}
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
 		},
@@ -719,9 +710,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				return;
 			}
 			this.add('-prepare', attacker, move.name);
-			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
-				return;
-			}
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
 		},
@@ -733,9 +721,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				return;
 			}
 			this.add('-prepare', attacker, move.name);
-			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
-				return;
-			}
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
 		},
@@ -758,9 +743,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				return;
 			}
 			this.add('-prepare', attacker, move.name);
-			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
-				return;
-			}
 			attacker.addVolatile('twoturnmove', defender);
 			return null;
 		},

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -217,14 +217,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				this.add('-message', 'The foe ' + target.name + ' can\'t be hit underground!');
 				return false;
 			},
-			onDamage(damage, target, source, move) {
-				if (!move || move.effectType !== 'Move') return;
-				if (!source) return;
-				if (move.id === 'earthquake') {
-					this.add('-message', 'The foe ' + target.name + ' can\'t be hit underground!');
-					return null;
-				}
-			},
 		},
 	},
 	disable: {
@@ -335,14 +327,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				if (move.id === 'swift' || move.id === 'transform') return true;
 				this.add('-message', 'The foe ' + target.name + ' can\'t be hit while flying!');
 				return false;
-			},
-			onDamage(damage, target, source, move) {
-				if (!move || move.effectType !== 'Move') return;
-				if (!source || source.isAlly(target)) return;
-				if (move.id === 'gust' || move.id === 'thunder') {
-					this.add('-message', 'The foe ' + target.name + ' can\'t be hit while flying!');
-					return null;
-				}
 			},
 		},
 	},

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -218,6 +218,17 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				return false;
 			},
 		},
+		onTryMove(attacker, defender, move) {
+			if (attacker.removeVolatile('twoturnmove')) {
+				return;
+			}
+			this.add('-prepare', attacker, move.name);
+			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
+				return;
+			}
+			attacker.addVolatile('twoturnmove', defender);
+			return null;
+		},
 	},
 	disable: {
 		num: 50,
@@ -328,6 +339,17 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				this.add('-message', 'The foe ' + target.name + ' can\'t be hit while flying!');
 				return false;
 			},
+		},
+		onTryMove(attacker, defender, move) {
+			if (attacker.removeVolatile('twoturnmove')) {
+				return;
+			}
+			this.add('-prepare', attacker, move.name);
+			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
+				return;
+			}
+			attacker.addVolatile('twoturnmove', defender);
+			return null;
 		},
 	},
 	focusenergy: {
@@ -595,6 +617,17 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		critRatio: 1,
 		target: "normal",
+		onTryMove(attacker, defender, move) {
+			if (attacker.removeVolatile('twoturnmove')) {
+				return;
+			}
+			this.add('-prepare', attacker, move.name);
+			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
+				return;
+			}
+			attacker.addVolatile('twoturnmove', defender);
+			return null;
+		},
 	},
 	recover: {
 		inherit: true,
@@ -682,7 +715,21 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	skullbash: {
 		inherit: true,
 		onTryMove(attacker, defender, move) {
-			if (attacker.removeVolatile(move.id)) {
+			if (attacker.removeVolatile('twoturnmove')) {
+				return;
+			}
+			this.add('-prepare', attacker, move.name);
+			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
+				return;
+			}
+			attacker.addVolatile('twoturnmove', defender);
+			return null;
+		},
+	},
+	skyattack: {
+		inherit: true,
+		onTryMove(attacker, defender, move) {
+			if (attacker.removeVolatile('twoturnmove')) {
 				return;
 			}
 			this.add('-prepare', attacker, move.name);
@@ -702,6 +749,20 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		secondary: {
 			chance: 40,
 			status: 'psn',
+		},
+	},
+	solarbeam: {
+		inherit: true,
+		onTryMove(attacker, defender, move) {
+			if (attacker.removeVolatile('twoturnmove')) {
+				return;
+			}
+			this.add('-prepare', attacker, move.name);
+			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
+				return;
+			}
+			attacker.addVolatile('twoturnmove', defender);
+			return null;
 		},
 	},
 	sonicboom: {

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -144,8 +144,10 @@ export const Scripts: ModdedBattleScriptsData = {
 			let lockedMove = this.battle.runEvent('LockMove', pokemon);
 			if (lockedMove === true) lockedMove = false;
 			if (
-				!lockedMove &&
-				(!pokemon.volatiles['partialtrappinglock'] || pokemon.volatiles['partialtrappinglock'].locked !== target)
+				// Two-turn moves like Sky Attack deduct PP on their second turn if they are not called by another move.
+				(pokemon.volatiles['twoturnmove'] && pokemon.volatiles['twoturnmove'].sourceEffect === move.id) ||
+				(!TWO_TURN_MOVES.includes(move.id) && !lockedMove &&
+				(!pokemon.volatiles['partialtrappinglock'] || pokemon.volatiles['partialtrappinglock'].locked !== target))
 			) {
 				pokemon.deductPP(move, null, target);
 			} else {

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -128,8 +128,6 @@ export const Scripts: ModdedBattleScriptsData = {
 			this.battle.setActiveMove(move, pokemon, target);
 
 			if (pokemon.moveThisTurn || !this.battle.runEvent('BeforeMove', pokemon, target, move)) {
-				// Prevent invulnerability from persisting until the turn ends.
-				pokemon.removeVolatile('twoturnmove');
 				// Rampage moves end without causing confusion
 				delete pokemon.volatiles['lockedmove'];
 				this.battle.clearActiveMove(true);

--- a/data/mods/gen1jpn/conditions.ts
+++ b/data/mods/gen1jpn/conditions.ts
@@ -1,0 +1,11 @@
+export const Conditions: {[k: string]: ModdedConditionData} = {
+	invulnerability: {
+		// Dig/Fly
+		name: 'invulnerability',
+		onInvulnerability(target, source, move) {
+			if ((move.id === 'swift' && target.volatiles['substitute']) || move.id === 'transform') return true;
+			this.add('-message', 'The foe ' + target.name + ' can\'t be hit while invulnerable!');
+			return false;
+		},
+	},
+};

--- a/data/mods/gen1jpn/conditions.ts
+++ b/data/mods/gen1jpn/conditions.ts
@@ -3,6 +3,7 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 		// Dig/Fly
 		name: 'invulnerability',
 		onInvulnerability(target, source, move) {
+			if (target === source) return true;
 			if ((move.id === 'swift' && target.volatiles['substitute']) || move.id === 'transform') return true;
 			this.add('-message', 'The foe ' + target.name + ' can\'t be hit while invulnerable!');
 			return false;

--- a/data/mods/gen1jpn/moves.ts
+++ b/data/mods/gen1jpn/moves.ts
@@ -10,30 +10,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			status: 'frz',
 		},
 	},
-	dig: {
-		inherit: true,
-		condition: {
-			duration: 2,
-			onLockMove: 'dig',
-			onInvulnerability(target, source, move) {
-				if ((move.id === 'swift' && target.volatiles['substitute']) || move.id === 'transform') return true;
-				this.add('-message', `The foe ${target.name} can't be hit underground!`);
-				return false;
-			},
-		},
-	},
-	fly: {
-		inherit: true,
-		condition: {
-			duration: 2,
-			onLockMove: 'fly',
-			onInvulnerability(target, source, move) {
-				if ((move.id === 'swift' && target.volatiles['substitute']) || move.id === 'transform') return true;
-				this.add('-message', `The foe ${target.name} can't be hit while flying!`);
-				return false;
-			},
-		},
-	},
 	substitute: {
 		inherit: true,
 		condition: {

--- a/data/mods/gen1jpn/moves.ts
+++ b/data/mods/gen1jpn/moves.ts
@@ -20,14 +20,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				this.add('-message', `The foe ${target.name} can't be hit underground!`);
 				return false;
 			},
-			onDamage(damage, target, source, move) {
-				if (!move || move.effectType !== 'Move') return;
-				if (!source) return;
-				if (move.id === 'earthquake') {
-					this.add('-message', `The foe ${target.name} can't be hit underground!`);
-					return null;
-				}
-			},
 		},
 	},
 	fly: {
@@ -39,14 +31,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				if ((move.id === 'swift' && target.volatiles['substitute']) || move.id === 'transform') return true;
 				this.add('-message', `The foe ${target.name} can't be hit while flying!`);
 				return false;
-			},
-			onDamage(damage, target, source, move) {
-				if (!move || move.effectType !== 'Move') return;
-				if (!source || source.side === target.side) return;
-				if (move.id === 'gust' || move.id === 'thunder') {
-					this.add('-message', `The foe ${target.name} can't be hit while flying!`);
-					return null;
-				}
 			},
 		},
 	},

--- a/data/mods/gen1stadium/conditions.ts
+++ b/data/mods/gen1stadium/conditions.ts
@@ -24,12 +24,9 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 			if (this.randomChance(63, 256)) {
 				this.add('cant', pokemon, 'par');
 				pokemon.removeVolatile('bide');
-				pokemon.removeVolatile('lockedmovee');
+				pokemon.removeVolatile('lockedmove');
 				pokemon.removeVolatile('twoturnmove');
-				pokemon.removeVolatile('fly');
-				pokemon.removeVolatile('dig');
-				pokemon.removeVolatile('solarbeam');
-				pokemon.removeVolatile('skullbash');
+				pokemon.removeVolatile('invulnerability');
 				pokemon.removeVolatile('partialtrappinglock');
 				return false;
 			}

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -181,8 +181,12 @@ export class BattleActions {
 			this.battle.runEvent('SwitchIn', pokemon);
 		}
 
-		if (this.battle.gen <= 2 && !pokemon.side.faintedThisTurn && pokemon.draggedIn !== this.battle.turn) {
-			this.battle.runEvent('AfterSwitchInSelf', pokemon);
+		if (this.battle.gen <= 2) {
+			// pokemon.lastMove is reset for all Pokemon on the field after a switch. This affects Mirror Move.
+			for (const poke of this.battle.getAllActive()) poke.lastMove = null;
+			if (!pokemon.side.faintedThisTurn && pokemon.draggedIn !== this.battle.turn) {
+				this.battle.runEvent('AfterSwitchInSelf', pokemon);
+			}
 		}
 		if (!pokemon.hp) return false;
 		pokemon.isStarted = true;

--- a/test/sim/misc/twoturnmoves.js
+++ b/test/sim/misc/twoturnmoves.js
@@ -35,6 +35,19 @@ describe('Two Turn Moves [Gen 1]', function () {
 		}
 	});
 
+	it(`two-turn move ends if it fails due to Disable`, function () {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', {team: [{species: "Aerodactyl", moves: ['skyattack']}]});
+		battle.setPlayer('p2', {team: [{species: "Drowzee", moves: ['disable']}]});
+		const aerodactyl = battle.p1.active[0];
+		battle.makeChoices();
+		assert(aerodactyl.volatiles['disable'].time > 1);
+		assert(aerodactyl.volatiles['twoturnmove']);
+		battle.makeChoices();
+		assert(battle.log.some(line => line.includes('|cant|p1a: Aerodactyl|Disable|Sky Attack')));
+		assert(!aerodactyl.volatiles['twoturnmove']);
+	});
+
 	it(`Fly/Dig dodges all attacks except for Swift, Transform, and Bide`, function () {
 		battle = common.gen(1).createBattle();
 		battle.setPlayer('p1', {team: [{species: "Aerodactyl", moves: ['fly']}]});

--- a/test/sim/misc/twoturnmoves.js
+++ b/test/sim/misc/twoturnmoves.js
@@ -53,13 +53,14 @@ describe('Two Turn Moves [Gen 1]', function () {
 		assert(!aerodactyl.volatiles['twoturnmove']);
 	});
 
-	it(`[Gen 1] does not use PP in its attacking turn if called by Metronome or Mirror Move`, function () {
+	it(`[Gen 1] if called by Metronome or Mirror Move, the calling move uses PP in the attacking turn`, function () {
 		battle = common.gen(1).createBattle({seed: [0, 1, 0, 1]});
 		battle.setPlayer('p1', {team: [{species: 'blastoise', moves: ['metronome', 'skullbash']}]});
 		battle.setPlayer('p2', {team: [{species: 'golem', moves: ['defensecurl']}]});
 		const blastoise = battle.p1.active[0];
 		battle.makeChoices();
 		assert(battle.log.some(line => line.includes('|move|p1a: Blastoise|Skull Bash||[from]Metronome|[still]')));
+		assert.equal(blastoise.moveSlots[0].pp, 16);
 		battle.makeChoices();
 		assert.equal(blastoise.moveSlots[0].pp, 15);
 		// Skull Bash still has all its PP, even though Metronome called Skull Bash

--- a/test/sim/misc/twoturnmoves.js
+++ b/test/sim/misc/twoturnmoves.js
@@ -10,16 +10,19 @@ describe('Two Turn Moves [Gen 1]', function () {
 		battle.destroy();
 	});
 
-	it(`charges the first turn, and does damage the second turn`, function () {
+	it(`charges the first turn, does damage and uses PP the second turn`, function () {
 		battle = common.gen(1).createBattle();
 		battle.setPlayer('p1', {team: [{species: "Venusaur", moves: ['solarbeam']}]});
 		battle.setPlayer('p2', {team: [{species: "Parasect", moves: ['swordsdance']}]});
 		const venusaur = battle.p1.active[0];
 		const parasect = battle.p2.active[0];
+		assert.equal(venusaur.moveSlots[0].pp, 16);
 		battle.makeChoices();
 		assert(venusaur.volatiles['twoturnmove']);
+		assert.equal(venusaur.moveSlots[0].pp, 16);
 		assert.fullHP(parasect);
 		battle.makeChoices();
+		assert.equal(venusaur.moveSlots[0].pp, 15);
 		assert.false(venusaur.volatiles['twoturnmove']);
 		assert.false.fullHP(parasect);
 	});
@@ -32,10 +35,11 @@ describe('Two Turn Moves [Gen 1]', function () {
 		for (let i = 0; i < 10; i++) {
 			battle.makeChoices();
 			assert(aerodactyl.volatiles['twoturnmove']);
+			assert.equal(aerodactyl.moveSlots[0].pp, 8);
 		}
 	});
 
-	it(`two-turn move ends if it fails due to Disable`, function () {
+	it(`two-turn move ends if it fails due to Disable, does not use PP`, function () {
 		battle = common.gen(1).createBattle();
 		battle.setPlayer('p1', {team: [{species: "Aerodactyl", moves: ['skyattack']}]});
 		battle.setPlayer('p2', {team: [{species: "Drowzee", moves: ['disable']}]});
@@ -45,10 +49,24 @@ describe('Two Turn Moves [Gen 1]', function () {
 		assert(aerodactyl.volatiles['twoturnmove']);
 		battle.makeChoices();
 		assert(battle.log.some(line => line.includes('|cant|p1a: Aerodactyl|Disable|Sky Attack')));
+		assert.equal(aerodactyl.moveSlots[0].pp, 8);
 		assert(!aerodactyl.volatiles['twoturnmove']);
 	});
 
-	it(`Fly/Dig dodges all attacks except for Swift, Transform, and Bide`, function () {
+	it(`[Gen 1] does not use PP in its attacking turn if called by Metronome or Mirror Move`, function () {
+		battle = common.gen(1).createBattle({seed: [0, 1, 0, 1]});
+		battle.setPlayer('p1', {team: [{species: 'blastoise', moves: ['metronome', 'skullbash']}]});
+		battle.setPlayer('p2', {team: [{species: 'golem', moves: ['defensecurl']}]});
+		const blastoise = battle.p1.active[0];
+		battle.makeChoices();
+		assert(battle.log.some(line => line.includes('|move|p1a: Blastoise|Skull Bash||[from]Metronome|[still]')));
+		battle.makeChoices();
+		assert.equal(blastoise.moveSlots[0].pp, 15);
+		// Skull Bash still has all its PP, even though Metronome called Skull Bash
+		assert.equal(blastoise.moveSlots[1].pp, 24);
+	});
+
+	it(`Dig/Fly dodges all attacks except for Swift, Transform, and Bide`, function () {
 		battle = common.gen(1).createBattle();
 		battle.setPlayer('p1', {team: [{species: "Aerodactyl", moves: ['fly']}]});
 		battle.setPlayer('p2', {team: [{species: "Pidgeot", moves: ['gust']}]});

--- a/test/sim/misc/twoturnmoves.js
+++ b/test/sim/misc/twoturnmoves.js
@@ -46,7 +46,7 @@ describe('Two Turn Moves [Gen 1]', function () {
 		assert.false.fullHP(battle.p1.active[0]);
 	});
 
-	it(`Fly/Dig invulnerability glitch`, function () {
+	it(`Dig/Fly invulnerability glitch`, function () {
 		battle = common.gen(1).createBattle({seed: [0, 0, 0, 1]});
 		battle.setPlayer('p1', {team: [{species: "Electrode", moves: ['thunderwave', 'swift', 'thunderbolt']}]});
 		battle.setPlayer('p2', {team: [{species: "Pidgeot", moves: ['fly', 'gust']}]});

--- a/test/sim/misc/twoturnmoves.js
+++ b/test/sim/misc/twoturnmoves.js
@@ -65,6 +65,5 @@ describe('Two Turn Moves [Gen 1]', function () {
 		battle.makeChoices('move swift', 'move gust');
 		assert.false.fullHP(pidgeot);
 		assert(pidgeot.volatiles['invulnerability']);
-		console.log(battle.getDebugLog());
 	});
 });

--- a/test/sim/misc/twoturnmoves.js
+++ b/test/sim/misc/twoturnmoves.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Two Turn Moves [Gen 1]', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it(`charges the first turn, and does damage the second turn`, function () {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', {team: [{species: "Venusaur", moves: ['solarbeam']}]});
+		battle.setPlayer('p2', {team: [{species: "Parasect", moves: ['swordsdance']}]});
+		const venusaur = battle.p1.active[0];
+		const parasect = battle.p2.active[0];
+		battle.makeChoices();
+		assert(venusaur.volatiles['twoturnmove']);
+		assert.fullHP(parasect);
+		battle.makeChoices();
+		assert.false(venusaur.volatiles['twoturnmove']);
+		assert.false.fullHP(parasect);
+	});
+
+	it(`move is paused when asleep or frozen`, function () {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', {team: [{species: "Aerodactyl", moves: ['skyattack']}]});
+		battle.setPlayer('p2', {team: [{species: "Parasect", moves: ['spore']}]});
+		const aerodactyl = battle.p1.active[0];
+		for (let i = 0; i < 10; i++) {
+			battle.makeChoices();
+			assert(aerodactyl.volatiles['twoturnmove']);
+		}
+		assert(true);
+	});
+});

--- a/test/sim/misc/twoturnmoves.js
+++ b/test/sim/misc/twoturnmoves.js
@@ -33,6 +33,38 @@ describe('Two Turn Moves [Gen 1]', function () {
 			battle.makeChoices();
 			assert(aerodactyl.volatiles['twoturnmove']);
 		}
-		assert(true);
+	});
+
+	it(`Fly/Dig dodges all attacks except for Swift, Transform, and Bide`, function () {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', {team: [{species: "Aerodactyl", moves: ['fly']}]});
+		battle.setPlayer('p2', {team: [{species: "Pidgeot", moves: ['gust']}]});
+		battle.makeChoices();
+		assert(battle.log.some(line => line.includes("Aerodactyl can't be hit")));
+		assert.fullHP(battle.p1.active[0]);
+		battle.makeChoices();
+		assert.false.fullHP(battle.p1.active[0]);
+	});
+
+	it(`Fly/Dig invulnerability glitch`, function () {
+		battle = common.gen(1).createBattle({seed: [0, 0, 0, 1]});
+		battle.setPlayer('p1', {team: [{species: "Electrode", moves: ['thunderwave', 'swift', 'thunderbolt']}]});
+		battle.setPlayer('p2', {team: [{species: "Pidgeot", moves: ['fly', 'gust']}]});
+		const pidgeot = battle.p2.active[0];
+		battle.makeChoices();
+		assert(pidgeot.volatiles['twoturnmove']);
+		assert(pidgeot.volatiles['invulnerability']);
+		battle.makeChoices();
+		assert(!pidgeot.volatiles['twoturnmove']);
+		assert(pidgeot.volatiles['invulnerability']);
+		// Pidgeot dodges almost all moves
+		battle.makeChoices('move thunderbolt', 'move gust');
+		assert.fullHP(pidgeot);
+		assert(pidgeot.volatiles['invulnerability']);
+		// Pidgeot can still be hit by Swift
+		battle.makeChoices('move swift', 'move gust');
+		assert.false.fullHP(pidgeot);
+		assert(pidgeot.volatiles['invulnerability']);
+		console.log(battle.getDebugLog());
 	});
 });

--- a/test/sim/moves/mirrormove.js
+++ b/test/sim/moves/mirrormove.js
@@ -58,7 +58,6 @@ describe('Mirror Move [Gen 1]', function () {
 		assert.false(fearow.volatiles['twoturnmove']);
 		battle.makeChoices();
 		assert(fearow.volatiles['twoturnmove']);
-		battle.makeChoices();
 	});
 
 	it(`[Gen 1] Mirror Move should not copy Metronome if Metronome calls a regular move`, function () {

--- a/test/sim/moves/mirrormove.js
+++ b/test/sim/moves/mirrormove.js
@@ -31,4 +31,40 @@ describe('Mirror Move [Gen 1]', function () {
 		battle.choose('p2', 'switch exeggutor');
 		assert.false.cantMove(() => battle.choose('p1', 'move tackle'));
 	});
+
+	it(`[Gen 1] Mirror Move should fail when used by a Pokemon that has not seen the opponent use an attack`, function () {
+		battle = common.gen(1).createBattle({seed: [0, 0, 0, 1]}, [[
+			{species: 'slowbro', moves: ['thunderwave']},
+			{species: 'fearow', moves: ['mirrormove']},
+		], [
+			{species: 'chansey', moves: ['seismictoss']},
+		]]);
+		battle.makeChoices();
+		battle.makeChoices('switch 2', 'auto');
+		// Chansey is fully paralysed
+		assert.fullHP(battle.p1.active[0]);
+		battle.makeChoices();
+		assert.fullHP(battle.p2.active[0]);
+	});
+});
+
+describe('Mirror Move [Gen 2]', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it(`[Gen 2] Mirror Move should fail when used by a Pokemon that has not seen the opponent use an attack`, function () {
+		battle = common.gen(2).createBattle({seed: [1, 0, 0, 0]}, [[
+			{species: 'slowbro', moves: ['thunderwave']},
+			{species: 'fearow', moves: ['mirrormove']},
+		], [
+			{species: 'chansey', moves: ['seismictoss']},
+		]]);
+		battle.makeChoices();
+		battle.makeChoices('switch 2', 'auto');
+		// Chansey is fully paralysed
+		assert.fullHP(battle.p1.active[0]);
+		battle.makeChoices();
+		assert.fullHP(battle.p2.active[0]);
+	});
 });

--- a/test/sim/moves/mirrormove.js
+++ b/test/sim/moves/mirrormove.js
@@ -46,6 +46,41 @@ describe('Mirror Move [Gen 1]', function () {
 		battle.makeChoices();
 		assert.fullHP(battle.p2.active[0]);
 	});
+
+	it(`[Gen 1] Mirror Move should not copy the charging turn of a two-turn attack`, function () {
+		battle = common.gen(1).createBattle([[
+			{species: 'fearow', moves: ['mirrormove']},
+		], [
+			{species: 'dugtrio', moves: ['dig']},
+		]]);
+		const fearow = battle.p1.active[0];
+		battle.makeChoices();
+		assert.false(fearow.volatiles['twoturnmove']);
+		battle.makeChoices();
+		assert(fearow.volatiles['twoturnmove']);
+		battle.makeChoices();
+	});
+
+	it(`[Gen 1] Mirror Move should not copy Metronome if Metronome calls a regular move`, function () {
+		battle = common.gen(1).createBattle({seed: [0, 0, 0, 1]}, [[
+			{species: 'fearow', moves: ['mirrormove']},
+		], [
+			{species: 'alakazam', moves: ['metronome']},
+		]]);
+		battle.makeChoices();
+		assert.false(battle.log.some(line => line.includes('|move|p1a: Fearow|Metronome|p1a: Fearow|[from]Mirror Move')));
+	});
+
+	it(`[Gen 1] Mirror Move should copy Metronome if Metronome calls a two-turn move`, function () {
+		battle = common.gen(1).createBattle({seed: [0, 1, 0, 1]}, [[
+			{species: 'fearow', moves: ['mirrormove']},
+		], [
+			{species: 'alakazam', moves: ['metronome']},
+		]]);
+		battle.makeChoices();
+		assert(battle.p2.active[0].volatiles['twoturnmove']);
+		assert(battle.log.some(line => line.includes('|move|p1a: Fearow|Metronome|p1a: Fearow|[from]Mirror Move')));
+	});
 });
 
 describe('Mirror Move [Gen 2]', function () {

--- a/test/sim/moves/mirrormove.js
+++ b/test/sim/moves/mirrormove.js
@@ -12,7 +12,7 @@ describe('Mirror Move [Gen 1]', function () {
 
 	it(`[Gen 1] Mirror Move'd Hyper Beam should force a recharge turn after not KOing a Pokemon`, function () {
 		battle = common.gen(1).createBattle([[
-			{species: 'fearow', moves: ['mirrormove', 'tackle']},
+			{species: 'golem', moves: ['mirrormove', 'tackle']},
 		], [
 			{species: 'aerodactyl', moves: ['hyperbeam']},
 		]]);


### PR DESCRIPTION
This patch does a few things:
- pokemon.lastMove is reset to null whenever a switch is made. This ensures that Mirror Move fails when used by a newly switched in Pokemon, against an enemy that has not attacked since the switch.
- The charging turn of a two-turn move does not update pokemon.lastMove. In particular, Mirror Move will use the previous move made by the enemy (or fail if there was no previous move). If the enemy's Metronome calls a two-turn move, Mirror Move will call Metronome.
- Two-turn moves are paused if the Pokemon using the two-turn move is put to sleep, frozen, flinched, or partially trapped. The Pokemon cannot switch.
- Two-turn moves end if they fail because they are disabled.
- Two-turn moves only use PP in the attacking turn, not the charging turn.
- If a two-turn move is called by Metronome or Mirror Move, the calling move uses PP only in the attacking turn.
- Introduce a new 'invulnerability' (semi-invulnerability) volatile for Gen 1, associated with Dig and Fly.
- Dig/Fly invulnerability glitch: if a Pokemon gets fully paralyzed while semi-invulnerable, it will remain semi-invulnerable until it switches out or fully executes a Dig/Fly.

This should close the other PR relating to Dig/Fly glitch: https://github.com/smogon/pokemon-showdown/pull/8882/files