### PR TITLE
Gen 9 Random Battle: improve moves test

### DIFF
--- a/test/random-battles/gen9.js
+++ b/test/random-battles/gen9.js
@@ -35,15 +35,21 @@ describe('[Gen 9] Random Battle', () => {
 				const teraTypes = set.teraTypes;
 				let teamDetails = {};
 				// Go through all possible teamDetails combinations, if necessary
-				for (let i = 0; i < 8; i++) {
-					const defog = i % 2;
-					const stealthRock = Math.floor(i / 2) % 2;
-					const stickyWeb = Math.floor(i / 4) % 2;
-					teamDetails = {defog, stealthRock, stickyWeb};
-					for (let j = 0; j < rounds; j++) {
+				for (let j = 0; j < rounds; j++) {
+					// Generate a moveset as the lead, teamDetails is always empty for this
+					const teraType = teraTypes[j % teraTypes.length];
+					const movePool = set.movepool.map(m => dex.moves.get(m).id);
+					const moveSet = generator.randomMoveset(types, abilities, {}, species, true, false, movePool, teraType, role);
+					for (const move of moveSet) moves.delete(move);
+					if (!moves.size) break;
+					// Generate a moveset for each combination of relevant teamDetails
+					for (let i = 0; i < 8; i++) {
+						const defog = i % 2;
+						const stealthRock = Math.floor(i / 2) % 2;
+						const stickyWeb = Math.floor(i / 4) % 2;
+						teamDetails = {defog, stealthRock, stickyWeb};
 						// randomMoveset() deletes moves from the movepool, so recreate it every time
 						const movePool = set.movepool.map(m => dex.moves.get(m).id);
-						const teraType = teraTypes[j % teraTypes.length];
 						const moveSet = generator.randomMoveset(types, abilities, teamDetails, species, false, false, movePool, teraType, role);
 						for (const move of moveSet) moves.delete(move);
 						if (!moves.size) break;


### PR DESCRIPTION
This improves the moves test for gen 9 random battle:
- iterate over rounds in the outer loop, and different teamDetails in the inner loop. This should speed up the test for situations where a move can only be obtained with non-default teamDetails.
- Add a set generation for leads, future-proofing for situations where a move can only be obtained in the lead slot.