### PR TITLE
Implement opt-in Open Team Sheets

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -235,7 +235,7 @@ export const Formats: FormatList = [
 
 		mod: 'gen9',
 		gameType: 'doubles',
-		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer'],
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer', 'Open Team Sheets'],
 		banlist: ['Sub-Legendary'],
 	},
 	{

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -243,7 +243,7 @@ export const Formats: FormatList = [
 
 		mod: 'gen9',
 		gameType: 'doubles',
-		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer'],
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer', 'Open Team Sheets'],
 		banlist: ['Sub-Legendary', 'Paradox'],
 	},
 	{

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1614,6 +1614,22 @@ export const Rulesets: {[k: string]: FormatData} = {
 		name: 'Open Team Sheets',
 		desc: "Allows each player to see the Pok&eacute;mon and all non-stat information about them, before they choose their lead Pok&eacute;mon",
 		onTeamPreview() {
+			const msg = 'uhtml|ots|<button name="send" value="/acceptopenteamsheets" class="button"><strong>Accept Open Team Sheets</strong></button><button name="send" value="/rejectopenteamsheets" class="button"><strong>Deny Open Team Sheets</strong></button>';
+			for (const side of this.sides) {
+				this.addSplit(side.id, [msg]);
+			}
+		},
+		onBattleStart() {
+			for (const side of this.sides) {
+				this.addSplit(side.id, ['uhtmlchange|ots|']);
+			}
+		},
+	},
+	forceopenteamsheets: {
+		effectType: 'Rule',
+		name: 'Force Open Team Sheets',
+		desc: "Allows each player to see the Pok&eacute;mon and all non-stat information about them, before they choose their lead Pok&eacute;mon",
+		onTeamPreview() {
 			let buf = 'raw|';
 			for (const side of this.sides) {
 				buf += Utils.html`<div class="infobox" style="margin-top:5px"><details><summary>Open Team Sheet for ${side.name}</summary>${Teams.export(side.team, {hideStats: true})}</details></div>`;

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1614,7 +1614,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 		name: 'Open Team Sheets',
 		desc: "Allows each player to see the Pok&eacute;mon and all non-stat information about them, before they choose their lead Pok&eacute;mon",
 		onTeamPreview() {
-			const msg = 'uhtml|otsrequest|<button name="send" value="/acceptopenteamsheets" class="button"><strong>Accept Open Team Sheets</strong></button><button name="send" value="/rejectopenteamsheets" class="button"><strong>Deny Open Team Sheets</strong></button>';
+			const msg = 'uhtml|otsrequest|<button name="send" value="/acceptopenteamsheets" class="button" style="margin-right: 10px;"><strong>Accept Open Team Sheets</strong></button><button name="send" value="/rejectopenteamsheets" class="button" style="margin-top: 10px"><strong>Deny Open Team Sheets</strong></button>';
 			for (const side of this.sides) {
 				this.addSplit(side.id, [msg]);
 			}

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1614,14 +1614,14 @@ export const Rulesets: {[k: string]: FormatData} = {
 		name: 'Open Team Sheets',
 		desc: "Allows each player to see the Pok&eacute;mon and all non-stat information about them, before they choose their lead Pok&eacute;mon",
 		onTeamPreview() {
-			const msg = 'uhtml|ots|<button name="send" value="/acceptopenteamsheets" class="button"><strong>Accept Open Team Sheets</strong></button><button name="send" value="/rejectopenteamsheets" class="button"><strong>Deny Open Team Sheets</strong></button>';
+			const msg = 'uhtml|otsrequest|<button name="send" value="/acceptopenteamsheets" class="button"><strong>Accept Open Team Sheets</strong></button><button name="send" value="/rejectopenteamsheets" class="button"><strong>Deny Open Team Sheets</strong></button>';
 			for (const side of this.sides) {
 				this.addSplit(side.id, [msg]);
 			}
 		},
 		onBattleStart() {
 			for (const side of this.sides) {
-				this.addSplit(side.id, ['uhtmlchange|ots|']);
+				this.addSplit(side.id, ['uhtmlchange|otsrequest|']);
 			}
 		},
 	},

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -800,13 +800,13 @@ export const commands: Chat.ChatCommands = {
 			return this.errorReply(this.tr`You have already made your decision about agreeing to open team sheets.`);
 		}
 		player.wantsOpenTeamSheets = true;
-		player.sendRoom(Utils.html`|uhtmlchange|ots|`);
+		player.sendRoom(Utils.html`|uhtmlchange|otsrequest|`);
 
 		this.add(this.tr`${user.name} has agreed to open team sheets.`);
 		if (battle.players.every(curPlayer => curPlayer.wantsOpenTeamSheets)) {
-			let buf = '|raw|';
+			let buf = '|uhtml|ots|';
 			for (const curPlayer of battle.players) {
-				const team = await battle.getTeam(user);
+				const team = await battle.getTeam(curPlayer.id);
 				if (!team) continue;
 				buf += Utils.html`<div class="infobox" style="margin-top:5px"><details><summary>Open Team Sheet for ${curPlayer.name}</summary>${Teams.export(team, {hideStats: true})}</details></div>`;
 			}
@@ -837,7 +837,7 @@ export const commands: Chat.ChatCommands = {
 		}
 		player.wantsOpenTeamSheets = false;
 		for (const otherPlayer of battle.players) {
-			otherPlayer.sendRoom(Utils.html`|uhtmlchange|ots|`);
+			otherPlayer.sendRoom(Utils.html`|uhtmlchange|otsrequest|`);
 		}
 		return this.add(this.tr`${user.name} rejected open team sheets.`);
 	},

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -778,6 +778,71 @@ export const commands: Chat.ChatCommands = {
 		`!showset [number] - shows the set of the pokemon corresponding to that number (in original Team Preview order, not necessarily current order)`,
 	],
 
+	async acceptopenteamsheets(target, room, user, connection, cmd) {
+		room = this.requireRoom();
+		const battle = room.battle;
+		if (!battle) return this.errorReply(this.tr`Must be in a battle room.`);
+		const player = battle.playerTable[user.id];
+		if (!player) {
+			return this.errorReply(this.tr`Must be a player to agree to open team sheets.`);
+		}
+		const format = Dex.formats.get(battle.options.format);
+		if (!Dex.formats.getRuleTable(format).has('openteamsheets')) {
+			return this.errorReply(this.tr`This format does not allow requesting open team sheets. You can both manually agree to it by using !showteam hidestats.`);
+		}
+		if (battle.turn > 0) {
+			return this.errorReply(this.tr`You cannot agree to open team sheets after Team Preview. Each player can still show their own sheet by using this command: !showteam hidestats`);
+		}
+		if (battle.players.some(curPlayer => curPlayer.wantsOpenTeamSheets === false)) {
+			return this.errorReply(this.tr`An opponent has already rejected open team sheets.`);
+		}
+		if (player.wantsOpenTeamSheets !== null) {
+			return this.errorReply(this.tr`You have already made your decision about agreeing to open team sheets.`);
+		}
+		player.wantsOpenTeamSheets = true;
+		player.sendRoom(Utils.html`|uhtmlchange|ots|`);
+
+		this.add(this.tr`${user.name} has agreed to open team sheets.`);
+		if (battle.players.every(curPlayer => curPlayer.wantsOpenTeamSheets)) {
+			let buf = '|raw|';
+			for (const curPlayer of battle.players) {
+				const team = await battle.getTeam(user);
+				if (!team) continue;
+				buf += Utils.html`<div class="infobox" style="margin-top:5px"><details><summary>Open Team Sheet for ${curPlayer.name}</summary>${Teams.export(team, {hideStats: true})}</details></div>`;
+			}
+			for (const curPlayer of battle.players) {
+				curPlayer.sendRoom(buf);
+			}
+		}
+	},
+	acceptopenteamsheetshelp: [`/acceptopenteamsheets - Agrees to an open team sheet opportunity during Team Preview, where all information on a team except stats is shared with the opponent. Requires: \u2606`],
+
+	rejectopenteamsheets(target, room, user) {
+		room = this.requireRoom();
+		const battle = room.battle;
+		if (!battle) return this.errorReply(this.tr`Must be in a battle room.`);
+		const player = battle.playerTable[user.id];
+		if (!player) {
+			return this.errorReply(this.tr`Must be a player to reject open team sheets.`);
+		}
+		const format = Dex.formats.get(battle.options.format);
+		if (!Dex.formats.getRuleTable(format).has('openteamsheets')) {
+			return this.errorReply(this.tr`This format does not allow requesting open team sheets.`);
+		}
+		if (battle.turn > 0) {
+			return this.errorReply(this.tr`You cannot reject open team sheets after Team Preview.`);
+		}
+		if (player.wantsOpenTeamSheets !== null) {
+			return this.errorReply(this.tr`You have already made your decision about agreeing to open team sheets.`);
+		}
+		player.wantsOpenTeamSheets = false;
+		for (const otherPlayer of battle.players) {
+			otherPlayer.sendRoom(Utils.html`|uhtmlchange|ots|`);
+		}
+		return this.add(this.tr`${user.name} rejected open team sheets.`);
+	},
+	rejectopenteamsheetshelp: [`/rejectopenteamsheetshelp - Rejects an open team sheet opportunity during Team Preview, where all information on a team except stats is shared with the opponent. Requires: \u2606`],
+
 	acceptdraw: 'offertie',
 	accepttie: 'offertie',
 	offerdraw: 'offertie',

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -57,6 +57,7 @@ export class RoomBattlePlayer extends RoomGames.RoomGamePlayer<RoomBattle> {
 	readonly channelIndex: ChannelIndex;
 	request: BattleRequestTracker;
 	wantsTie: boolean;
+	wantsOpenTeamSheets: boolean | null;
 	active: boolean;
 	eliminated: boolean;
 	/**
@@ -111,6 +112,7 @@ export class RoomBattlePlayer extends RoomGames.RoomGamePlayer<RoomBattle> {
 
 		this.request = {rqid: 0, request: '', isWait: 'cantUndo', choice: ''};
 		this.wantsTie = false;
+		this.wantsOpenTeamSheets = null;
 		this.active = true;
 		this.eliminated = false;
 

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1305,8 +1305,8 @@ export class RoomBattle extends RoomGames.RoomGame<RoomBattlePlayer> {
 			}
 		}
 	}
-	async getTeam(user: User) {
-		const id = user.id;
+	async getTeam(user: User | ID) {
+		const id = typeof user === 'object' ? user.id : user;
 		const player = this.playerTable[id];
 		if (!player) return;
 		void this.stream.write(`>requestteam ${player.slot}`);

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1997,7 +1997,7 @@ export class GameRoom extends BasicRoom {
 
 		// This is only here because of an issue with private logs not getting resent
 		// when a user reloads on a battle and autojoins. This should be removed when that gets fixed.
-		(async () => {
+		void (async () => {
 			if (this.battle) {
 				const player = this.battle.playerTable[user.id];
 				if (player && this.battle.players.every(curPlayer => curPlayer.wantsOpenTeamSheets)) {

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1987,6 +1987,40 @@ export class GameRoom extends BasicRoom {
 		this.sendUser(connection, '|init|battle\n|title|' + this.title + '\n' + this.getLogForUser(user));
 		if (this.game && this.game.onConnect) this.game.onConnect(user, connection);
 	}
+	onJoin(user: User, connection: Connection) {
+		if (!user) return false; // ???
+		if (this.users[user.id]) return false;
+
+		if (user.named) {
+			this.reportJoin('j', user.getIdentityWithStatus(this), user);
+		}
+
+		// This is only here because of an issue with private logs not getting resent
+		// when a user reloads on a battle and autojoins. This should be removed when that gets fixed.
+		(async () => {
+			if (this.battle) {
+				const player = this.battle.playerTable[user.id];
+				if (player && this.battle.players.every(curPlayer => curPlayer.wantsOpenTeamSheets)) {
+					let buf = '|uhtml|ots|';
+					for (const curPlayer of this.battle.players) {
+						const team = await this.battle.getTeam(curPlayer.id);
+						if (!team) continue;
+						buf += Utils.html`<div class="infobox" style="margin-top:5px"><details><summary>Open Team Sheet for ${curPlayer.name}</summary>${Teams.export(team, {hideStats: true})}</details></div>`;
+					}
+					player.sendRoom(buf);
+				}
+			}
+		})();
+
+		this.users[user.id] = user;
+		this.userCount++;
+		this.checkAutoModchat(user);
+
+		this.minorActivity?.onConnect?.(user, connection);
+		this.game?.onJoin?.(user, connection);
+		Chat.runHandlers('onRoomJoin', this, user, connection);
+		return true;
+	}
 	/**
 	 * Sends this room's replay to the connection to be uploaded to the replay
 	 * server. To be clear, the replay goes:


### PR DESCRIPTION
WIP with major help from Karthik.

The announcement of open team sheets in VGC play was met with mixed reception. For various reasons, some players prefer closed team sheets, and some prefer open team sheets. It is undesirable to make two ladders, however, as that is likely to fracture the playerbase and probably be lopsided in favor of closed team sheets. The current solution is to make opting into OTS very easy, while also not being forced to reveal the player's OTS to spectators or in replays. Players can then choose to agree or not to agree to OTS.

The main issue with current implementation is that player-specific information (e.g. specific player damage, or in this case, uhtml with team sheet information) is not retained if a player happens to refresh during a game because of e.g. a bad connection. We may opt to refactor so the acceptance button prompts are also visible to spectators and just don't do anything when clicked, then change the uhtml "View Open Team Sheets" when both players have accepted.