### PR TITLE
Gen 8 Battle Factory: Remove banned Pokemon

### DIFF
--- a/data/mods/gen8/factory-sets.json
+++ b/data/mods/gen8/factory-sets.json
@@ -5164,17 +5164,6 @@
 				"moves": [["Rest"], ["Earthquake"], ["Heavy Slam"], ["Sleep Talk"]]
 			}]
 		},
-		"magby": {
-			"sets": [{
-				"species": "Magby",
-				"item": ["Berry Juice"],
-				"ability": ["Vital Spirit", "Flame Body"],
-				"evs": {"atk": 236, "spe": 252},
-				"ivs": {"hp": 29},
-				"nature": "Jolly",
-				"moves": [["Belly Drum"], ["Fire Punch"], ["Thunder Punch"], ["Mach Punch"]]
-			}]
-		},
 		"morelull": {
 			"sets": [{
 				"species": "Morelull",

--- a/data/mods/gen8/factory-sets.json
+++ b/data/mods/gen8/factory-sets.json
@@ -3365,25 +3365,6 @@
 				"moves": [["Iron Head"], ["Power Whip"], ["Rock Slide"], ["Stealth Rock"]]
 			}]
 		},
-		"indeedeef": {
-			"sets": [{
-				"species": "Indeedee-F",
-				"item": ["Choice Scarf", "Choice Specs"],
-				"ability": ["Psychic Surge"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Expanding Force"], ["Mystical Fire"], ["Dazzling Gleam"], ["Healing Wish", "Trick"]]
-			}, {
-				"species": "Indeedee-F",
-				"item": ["Heavy-Duty Boots", "Twisted Spoon"],
-				"ability": ["Psychic Surge"],
-				"evs": {"spa": 252, "spd": 4, "spe": 252},
-				"ivs": {"atk": 0},
-				"nature": "Timid",
-				"moves": [["Expanding Force"], ["Mystical Fire"], ["Dazzling Gleam"], ["Calm Mind"]]
-			}]
-		},
 		"salazzle": {
 			"sets": [{
 				"species": "Salazzle",
@@ -4004,30 +3985,6 @@
 				"ivs": {"atk": 0},
 				"nature": "Timid",
 				"moves": [["Moonblast"], ["Bug Buzz"], ["U-turn", "Switcheroo"], ["Psychic"]]
-			}]
-		},
-		"scrafty": {
-			"sets": [{
-				"species": "Scrafty",
-				"item": ["Leftovers"],
-				"ability": ["Shed Skin"],
-				"evs": {"hp": 252, "atk": 4, "spd": 252},
-				"nature": "Careful",
-				"moves": [["Knock Off"], ["Drain Punch"], ["Bulk Up"], ["Rest"]]
-			}, {
-				"species": "Scrafty",
-				"item": ["Lum Berry"],
-				"ability": ["Moxie"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Knock Off"], ["Close Combat"], ["Dragon Dance"], ["Iron Head"]]
-			}, {
-				"species": "Scrafty",
-				"item": ["Choice Band"],
-				"ability": ["Shed Skin"],
-				"evs": {"atk": 252, "def": 4, "spe": 252},
-				"nature": "Jolly",
-				"moves": [["Knock Off"], ["Close Combat"], ["Drain Punch"], ["Poison Jab"]]
 			}]
 		},
 		"archeops": {


### PR DESCRIPTION
Magby has been banned from LC, so removing it from BF.