### PR TITLE
Improvements to room FAQs and repeats

### DIFF
--- a/server/chat-plugins/repeats.ts
+++ b/server/chat-plugins/repeats.ts
@@ -93,7 +93,7 @@ export const Repeats = new class {
 				this.clearRepeats(targetRoom);
 				return;
 			}
-			const topic = toID(getAlias(room.roomid, repeat.id) || repeat.id);
+			const topic = getAlias(room.roomid, repeat.id) || repeat.id;
 			const repeatedPhrase = repeat.faq ?
 				visualizeFaq(roomFaqs[targetRoom.roomid][topic]) : Chat.formatText(phrase, true);
 			const formattedText = repeat.isHTML ? phrase : repeatedPhrase;
@@ -138,7 +138,7 @@ export const pages: Chat.PageTable = {
 		html += `<table><tr><th>${this.tr`Identifier`}</th><th>${this.tr`Phrase`}</th><th>${this.tr`Raw text`}</th><th>${this.tr`Interval`}</th><th>${this.tr`Action`}</th>`;
 		for (const repeat of room.settings.repeats) {
 			const minutes = repeat.interval / (repeat.isByMessages ? 1 : 60 * 1000);
-			const topic = toID(getAlias(room.roomid, repeat.id) || repeat.id);
+			const topic = getAlias(room.roomid, repeat.id) || repeat.id;
 			const repeatText = repeat.faq ? roomFaqs[room.roomid][topic].source : repeat.phrase;
 			const phrase = repeat.faq ? visualizeFaq(roomFaqs[room.roomid][topic]) :
 				repeat.isHTML ? repeat.phrase : Chat.formatText(repeatText, true);

--- a/server/chat-plugins/repeats.ts
+++ b/server/chat-plugins/repeats.ts
@@ -93,9 +93,8 @@ export const Repeats = new class {
 				this.clearRepeats(targetRoom);
 				return;
 			}
-			const topic = getAlias(room.roomid, repeat.id) || repeat.id;
 			const repeatedPhrase = repeat.faq ?
-				visualizeFaq(roomFaqs[targetRoom.roomid][topic]) : Chat.formatText(phrase, true);
+				visualizeFaq(roomFaqs[targetRoom.roomid][repeat.id]) : Chat.formatText(phrase, true);
 			const formattedText = repeat.isHTML ? phrase : repeatedPhrase;
 			targetRoom.add(`|uhtml|repeat-${repeat.id}|<div class="infobox">${formattedText}</div>`);
 			targetRoom.update();
@@ -138,9 +137,8 @@ export const pages: Chat.PageTable = {
 		html += `<table><tr><th>${this.tr`Identifier`}</th><th>${this.tr`Phrase`}</th><th>${this.tr`Raw text`}</th><th>${this.tr`Interval`}</th><th>${this.tr`Action`}</th>`;
 		for (const repeat of room.settings.repeats) {
 			const minutes = repeat.interval / (repeat.isByMessages ? 1 : 60 * 1000);
-			const topic = getAlias(room.roomid, repeat.id) || repeat.id;
-			const repeatText = repeat.faq ? roomFaqs[room.roomid][topic].source : repeat.phrase;
-			const phrase = repeat.faq ? visualizeFaq(roomFaqs[room.roomid][topic]) :
+			const repeatText = repeat.faq ? roomFaqs[room.roomid][repeat.id].source : repeat.phrase;
+			const phrase = repeat.faq ? visualizeFaq(roomFaqs[room.roomid][repeat.id]) :
 				repeat.isHTML ? repeat.phrase : Chat.formatText(repeatText, true);
 			html += `<tr><td>${repeat.id}</td><td>${phrase}</td><td>${Chat.getReadmoreCodeBlock(repeatText)}</td><td>${repeat.isByMessages ? this.tr`every ${minutes} chat message(s)` : this.tr`every ${minutes} minute(s)`}</td>`;
 			html += `<td><button class="button" name="send" value="/msgroom ${room.roomid},/removerepeat ${repeat.id}">${this.tr`Remove`}</button></td>`;
@@ -222,7 +220,7 @@ export const commands: Chat.ChatCommands = {
 		if (!roomFaqs[room.roomid]) {
 			throw new Chat.ErrorMessage(`This room has no FAQs.`);
 		}
-		topic = toID(topic);
+		topic = toID(getAlias(room.roomid, topic) || topic);
 		const faq = roomFaqs[room.roomid][topic];
 		if (!faq) {
 			throw new Chat.ErrorMessage(`Invalid topic.`);

--- a/server/chat-plugins/repeats.ts
+++ b/server/chat-plugins/repeats.ts
@@ -93,8 +93,9 @@ export const Repeats = new class {
 				this.clearRepeats(targetRoom);
 				return;
 			}
+			const topic = toID(getAlias(room.roomid, repeat.id) || repeat.id);
 			const repeatedPhrase = repeat.faq ?
-				visualizeFaq(roomFaqs[targetRoom.roomid][repeat.id]) : Chat.formatText(phrase, true);
+				visualizeFaq(roomFaqs[targetRoom.roomid][topic]) : Chat.formatText(phrase, true);
 			const formattedText = repeat.isHTML ? phrase : repeatedPhrase;
 			targetRoom.add(`|uhtml|repeat-${repeat.id}|<div class="infobox">${formattedText}</div>`);
 			targetRoom.update();
@@ -137,8 +138,9 @@ export const pages: Chat.PageTable = {
 		html += `<table><tr><th>${this.tr`Identifier`}</th><th>${this.tr`Phrase`}</th><th>${this.tr`Raw text`}</th><th>${this.tr`Interval`}</th><th>${this.tr`Action`}</th>`;
 		for (const repeat of room.settings.repeats) {
 			const minutes = repeat.interval / (repeat.isByMessages ? 1 : 60 * 1000);
-			const repeatText = repeat.faq ? roomFaqs[room.roomid][repeat.id].source : repeat.phrase;
-			const phrase = repeat.faq ? visualizeFaq(roomFaqs[room.roomid][repeat.id]) :
+			const topic = toID(getAlias(room.roomid, repeat.id) || repeat.id);
+			const repeatText = repeat.faq ? roomFaqs[room.roomid][topic].source : repeat.phrase;
+			const phrase = repeat.faq ? visualizeFaq(roomFaqs[room.roomid][topic]) :
 				repeat.isHTML ? repeat.phrase : Chat.formatText(repeatText, true);
 			html += `<tr><td>${repeat.id}</td><td>${phrase}</td><td>${Chat.getReadmoreCodeBlock(repeatText)}</td><td>${repeat.isByMessages ? this.tr`every ${minutes} chat message(s)` : this.tr`every ${minutes} minute(s)`}</td>`;
 			html += `<td><button class="button" name="send" value="/msgroom ${room.roomid},/removerepeat ${repeat.id}">${this.tr`Remove`}</button></td>`;
@@ -220,7 +222,7 @@ export const commands: Chat.ChatCommands = {
 		if (!roomFaqs[room.roomid]) {
 			throw new Chat.ErrorMessage(`This room has no FAQs.`);
 		}
-		topic = toID(getAlias(room.roomid, topic) || topic);
+		topic = toID(topic);
 		const faq = roomFaqs[room.roomid][topic];
 		if (!faq) {
 			throw new Chat.ErrorMessage(`Invalid topic.`);

--- a/server/chat-plugins/room-faqs.ts
+++ b/server/chat-plugins/room-faqs.ts
@@ -111,16 +111,24 @@ export const commands: Chat.ChatCommands = {
 		if (!(roomFaqs[room.roomid] && roomFaqs[room.roomid][topic])) return this.errorReply("Invalid topic.");
 		if (
 			room.settings.repeats?.length &&
-			room.settings.repeats.filter(x => x.faq && x.id === (getAlias(room!.roomid, topic) || topic)).length
+			room.settings.repeats.filter(x => x.faq && x.id === topic).length
 		) {
-			this.parse(`/msgroom ${room.roomid},/removerepeat ${getAlias(room.roomid, topic) || topic}`);
+			this.parse(`/msgroom ${room.roomid},/removerepeat ${topic}`);
 		}
-		delete roomFaqs[room.roomid][topic];
 		Object.keys(roomFaqs[room.roomid]).filter(
 			val => getAlias(room!.roomid, val) === topic
 		).map(
-			val => delete roomFaqs[room!.roomid][val]
+			val => {
+				delete roomFaqs[room!.roomid][val];
+				if (
+					room?.settings.repeats?.length &&
+					room.settings.repeats.filter(x => x.faq && x.id === val).length
+				) {
+					this.parse(`/msgroom ${room.roomid},/removerepeat ${val}`);
+				}
+			}
 		);
+		delete roomFaqs[room.roomid][topic];
 		if (!Object.keys(roomFaqs[room.roomid]).length) delete roomFaqs[room.roomid];
 		saveRoomFaqs();
 		this.privateModAction(`${user.name} removed the FAQ for '${topic}'`);
@@ -136,6 +144,7 @@ export const commands: Chat.ChatCommands = {
 
 		if (!(alias && topic)) return this.parse('/help roomfaq');
 		if (alias.length > 25) return this.errorReply("FAQ topics should not exceed 25 characters.");
+		if (alias === topic) return this.errorReply("You cannot make the alias have the same name as the topic.");
 
 		if (!(roomFaqs[room.roomid] && topic in roomFaqs[room.roomid])) {
 			return this.errorReply(`The topic ${topic} was not found in this room's faq list.`);

--- a/server/chat-plugins/room-faqs.ts
+++ b/server/chat-plugins/room-faqs.ts
@@ -116,8 +116,8 @@ export const commands: Chat.ChatCommands = {
 			this.parse(`/msgroom ${room.roomid},/removerepeat ${topic}`);
 		}
 		for (const alias of Object.keys(roomFaqs[room.roomid])) {
-			if (getAlias(room!.roomid, alias) === topic) {
-				delete roomFaqs[room!.roomid][alias];
+			if (getAlias(room.roomid, alias) === topic) {
+				delete roomFaqs[room.roomid][alias];
 				if (
 					room.settings.repeats?.length &&
 					room.settings.repeats.filter(x => x.faq && x.id === alias).length

--- a/server/chat-plugins/room-faqs.ts
+++ b/server/chat-plugins/room-faqs.ts
@@ -115,20 +115,17 @@ export const commands: Chat.ChatCommands = {
 		) {
 			this.parse(`/msgroom ${room.roomid},/removerepeat ${topic}`);
 		}
-		Object.keys(roomFaqs[room.roomid]).filter(
-			val => getAlias(room!.roomid, val) === topic
-		).map(
-			val => {
-				delete roomFaqs[room!.roomid][val];
+		for (const alias of Object.keys(roomFaqs[room.roomid])) {
+			if (getAlias(room!.roomid, alias) === topic) {
+				delete roomFaqs[room!.roomid][alias];
 				if (
-					room?.settings.repeats?.length &&
-					room.settings.repeats.filter(x => x.faq && x.id === val).length
+					room.settings.repeats?.length &&
+					room.settings.repeats.filter(x => x.faq && x.id === alias).length
 				) {
-					this.parse(`/msgroom ${room.roomid},/removerepeat ${val}`);
+					this.parse(`/msgroom ${room.roomid},/removerepeat ${alias}`);
 				}
-				return true;
 			}
-		);
+		}
 		delete roomFaqs[room.roomid][topic];
 		if (!Object.keys(roomFaqs[room.roomid]).length) delete roomFaqs[room.roomid];
 		saveRoomFaqs();

--- a/server/chat-plugins/room-faqs.ts
+++ b/server/chat-plugins/room-faqs.ts
@@ -115,18 +115,12 @@ export const commands: Chat.ChatCommands = {
 		) {
 			this.parse(`/msgroom ${room.roomid},/removerepeat ${topic}`);
 		}
-		for (const alias of Object.keys(roomFaqs[room.roomid])) {
-			if (getAlias(room.roomid, alias) === topic) {
-				delete roomFaqs[room.roomid][alias];
-				if (
-					room.settings.repeats?.length &&
-					room.settings.repeats.filter(x => x.faq && x.id === alias).length
-				) {
-					this.parse(`/msgroom ${room.roomid},/removerepeat ${alias}`);
-				}
-			}
-		}
 		delete roomFaqs[room.roomid][topic];
+		Object.keys(roomFaqs[room.roomid]).filter(
+			val => getAlias(room!.roomid, val) === topic
+		).map(
+			val => delete roomFaqs[room!.roomid][val]
+		);
 		if (!Object.keys(roomFaqs[room.roomid]).length) delete roomFaqs[room.roomid];
 		saveRoomFaqs();
 		this.privateModAction(`${user.name} removed the FAQ for '${topic}'`);
@@ -143,6 +137,9 @@ export const commands: Chat.ChatCommands = {
 		if (!(alias && topic)) return this.parse('/help roomfaq');
 		if (alias.length > 25) return this.errorReply("FAQ topics should not exceed 25 characters.");
 		if (alias === topic) return this.errorReply("You cannot make the alias have the same name as the topic.");
+		if (roomFaqs[room.roomid][alias] && !roomFaqs[room.roomid][alias].alias) {
+			return this.errorReply("You cannot overwrite an existing topic with an alias; please delete the topic first.");
+		}
 
 		if (!(roomFaqs[room.roomid] && topic in roomFaqs[room.roomid])) {
 			return this.errorReply(`The topic ${topic} was not found in this room's faq list.`);

--- a/server/chat-plugins/room-faqs.ts
+++ b/server/chat-plugins/room-faqs.ts
@@ -126,6 +126,7 @@ export const commands: Chat.ChatCommands = {
 				) {
 					this.parse(`/msgroom ${room.roomid},/removerepeat ${val}`);
 				}
+				return true;
 			}
 		);
 		delete roomFaqs[room.roomid][topic];


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-9451198 I tested this on a local server running the most recent version of Pokemon Showdown, so while I never caused a crash on the main server, the bug still exists there.

- Removed /rfaq alias check when setting a topic to repeat. If a /rfaq alias is set to repeat, the text of the topic the alias is set for is displayed, rather than the topic's ID.
- If a /rfaq is deleted, repeats linked to it or one of its aliases will also be deleted, preventing a crash caused by trying to display a nonexistent topic. Originally supported for just topics, but support for aliases was added, which the lack of support for is what caused crashes.
- A separate problem, but the ability to set a topic as an alias of itself has been removed. Because this is possible, you can have a topic which is registered in the server, but does not appear at all if you type /rfaq.

While it seems like it wasn't intended for /rfaq aliases to be used for repeats, since there's a way to get around it, might as well just work with it instead of trying to prevent it.