### PR TITLE
Gen 8 Random Battle: Fix lead bugs

### DIFF
--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -1723,11 +1723,7 @@ export class RandomGen8Teams {
 		if (moves.has('bellydrum') && moves.has('substitute')) return 'Salac Berry';
 
 		// Misc item generation logic
-		const HDBBetterThanEviolite = (
-			!isLead &&
-			this.dex.getEffectiveness('Rock', species) >= 2 &&
-			!isDoubles
-		);
+		const HDBBetterThanEviolite = this.dex.getEffectiveness('Rock', species) >= 2 && !isDoubles;
 		if (species.nfe && !HDBBetterThanEviolite) return 'Eviolite';
 
 		// Ability based logic and miscellaneous logic
@@ -2071,7 +2067,8 @@ export class RandomGen8Teams {
 				// Genesect-Douse should never reject Techno Blast
 				const moveIsRejectable = (
 					!(species.id === 'genesectdouse' && move.id === 'technoblast') &&
-					!(species.id === 'togekiss' && move.id === 'nastyplot') && (
+					!(species.id === 'togekiss' && move.id === 'nastyplot') && 
+					!(species.id === 'shuckle' && ['stealthrock', 'stickyweb'].includes(move.id)) && (
 						move.category === 'Status' ||
 						(!types.has(move.type) && move.id !== 'judgment') ||
 						(isLowBP && !move.multihit && !abilities.has('Technician'))
@@ -2101,7 +2098,7 @@ export class RandomGen8Teams {
 						(!isDoubles && runEnforcementChecker('recovery') && move.id !== 'stickyweb') ||
 						runEnforcementChecker('screens') ||
 						runEnforcementChecker('misc') ||
-						(isLead && runEnforcementChecker('lead')) ||
+						((isLead || species.id === 'shuckle') && runEnforcementChecker('lead')) ||
 						(moves.has('leechseed') && runEnforcementChecker('leechseed'))
 					) {
 						cull = true;

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -1723,8 +1723,12 @@ export class RandomGen8Teams {
 		if (moves.has('bellydrum') && moves.has('substitute')) return 'Salac Berry';
 
 		// Misc item generation logic
-		const HDBBetterThanEviolite = this.dex.getEffectiveness('Rock', species) >= 2 && !isDoubles;
-		if (species.nfe && !HDBBetterThanEviolite) return 'Eviolite';
+		const HDBBetterThanEviolite = (
+			!isDoubles &&
+			(!isLead || moves.has('uturn')) &&
+			this.dex.getEffectiveness('Rock', species) >= 2
+		);
+		if (species.nfe) return HDBBetterThanEviolite ? 'Heavy-Duty Boots' : 'Eviolite';
 
 		// Ability based logic and miscellaneous logic
 		if (species.name === 'Wobbuffet' || ['Cheek Pouch', 'Harvest', 'Ripen'].includes(ability)) return 'Sitrus Berry';
@@ -2067,7 +2071,7 @@ export class RandomGen8Teams {
 				// Genesect-Douse should never reject Techno Blast
 				const moveIsRejectable = (
 					!(species.id === 'genesectdouse' && move.id === 'technoblast') &&
-					!(species.id === 'togekiss' && move.id === 'nastyplot') && 
+					!(species.id === 'togekiss' && move.id === 'nastyplot') &&
 					!(species.id === 'shuckle' && ['stealthrock', 'stickyweb'].includes(move.id)) && (
 						move.category === 'Status' ||
 						(!types.has(move.type) && move.id !== 'judgment') ||

--- a/test/random-battles/gen8.js
+++ b/test/random-battles/gen8.js
@@ -133,10 +133,19 @@ describe('[Gen 8] Random Battle', () => {
 		testNotBothMoves('landorustherian', options, 'fly', 'stealthrock');
 	});
 
-	it('3 Attacks Scyther should get Heavy-Duty Boots', () => {
+	it('should give Scyther the correct item', () => {
 		testSet('scyther', options, set => {
-			if (set.moves.every(move => Dex.moves.get(move).category !== 'Status')) return;
-			assert.equal(set.item, 'Heavy-Duty Boots', `set=${JSON.stringify(set)}`);
+			let item;
+			if (set.moves.every(move => Dex.moves.get(move).category !== 'Status')) {
+				item = 'Choice Band';
+			} else if (set.moves.includes('uturn')) {
+				item = 'Heavy-Duty Boots';
+			} else {
+				// Test interface currently doesn't tell us if we're testing in the lead slot or not
+				// But FTR it should be Eviolite if it's the lead, Boots otherwise
+				return;
+			}
+			assert.equal(set.item, item, `set=${JSON.stringify(set)}`);
 		});
 	});
 

--- a/test/random-battles/gen8.js
+++ b/test/random-battles/gen8.js
@@ -97,6 +97,7 @@ describe('[Gen 8] Random Battle', () => {
 					set.moves.includes('stickyweb'),
 					`${pkmn} should always generate Sticky Web (generated moveset: ${set.moves})`
 				);
+				if (pkmn === 'shuckle') assert(set.moves.includes('stealthrock'));
 			});
 		}
 	});

--- a/test/random-battles/tools.js
+++ b/test/random-battles/tools.js
@@ -23,8 +23,10 @@ function testSet(pokemon, options, test) {
 	const isDoubles = options.isDoubles || (options.format && options.format.includes('doubles'));
 	const isDynamax = options.isDynamax || !(options.format && options.format.includes('nodmax'));
 	for (let i = 0; i < rounds; i++) {
+		// If undefined, test lead 1/6 of the time
+		const isLead = options.isLead === undefined ? i % 6 === 2 : options.isLead;
 		const generator = Teams.getGenerator(options.format, options.seed || [i, i, i, i]);
-		const set = generator.randomSet(pokemon, {}, options.isLead, isDoubles, isDynamax);
+		const set = generator.randomSet(pokemon, {}, isLead, isDoubles, isDynamax);
 		test(set);
 	}
 }


### PR DESCRIPTION
This pull request improves unit testing by including the Pokemon in the lead slot sometimes when isLead is not explicitly set. This revealed 2 bugs (heh), that are fixed as follows:

* Shuckle was not rolling Sticky Web in the lead slot as it was getting rejected in favor of Stealth Rock.
  * Now, Shuckle *always* runs *both* hazards.
* Scyther was jntended to run Heavy-Duty Boots if it had 3 attacks. However, in the lead position it was still being given Eviolite.
  * This was in fact intended; the test was assuming Scyther would never be the lead. However if it has U-Turn it should run Boots even if it's the lead, so the code and test were updated to reflect that.