### PR TITLE
Serializes tournament player cap updates as number instead of string

### DIFF
--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -1564,10 +1564,10 @@ const commands: Chat.ChatCommands = {
 					if (Config.tourdefaultplayercap && tournament.playerCap > Config.tourdefaultplayercap) {
 						Monitor.log(`[TourMonitor] Room ${tournament.room.roomid} starting a tour over default cap (${tournament.playerCap})`);
 					}
-					room.send(`|tournament|update|{"playerCap": "${playerCap}"}`);
+					room.send(`|tournament|update|${JSON.stringify({playerCap})}`);
 				} else if (tournament.playerCap && !playerCap) {
 					tournament.playerCap = 0;
-					room.send(`|tournament|update|{"playerCap": "${playerCap}"}`);
+					room.send(`|tournament|update|${JSON.stringify({playerCap})}`);
 				}
 				const capNote = (tournament.playerCap ? ' with a player cap of ' + tournament.playerCap : '');
 				this.privateModAction(`${user.name} set tournament type to ${generator.name}${capNote}.`);
@@ -1619,7 +1619,7 @@ const commands: Chat.ChatCommands = {
 				this.modlog('TOUR PLAYERCAP', null, tournament.playerCap.toString());
 				this.sendReply(`Tournament cap set to ${tournament.playerCap}.`);
 			}
-			room.send(`|tournament|update|{"playerCap": "${tournament.playerCap}"}`);
+			room.send(`|tournament|update|${JSON.stringify({playerCap: tournament.playerCap})}`);
 		},
 		end: 'delete',
 		stop: 'delete',


### PR DESCRIPTION
No reason it shouldn't expose this value as a number as it's already done that way [here](https://github.com/MrSableye/pokemon-showdown/blob/5c2d1b6b1c84901069079a1bfc65babedb01e43a/server/tournaments/index.ts#L177).

This change doesn't affect the client since it doesn't actually consume `playerCap` changes to my understanding. This is just a consistency change for alternate clients. There really isn't risk to breaking alternative clients either as they should already be able to handle both strings and numbers if they're already properly handling SD's protocol.