### PR TITLE
Gen 3 Random Battle: Add levels for new PU tier

### DIFF
--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -531,10 +531,11 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			UU: 84,
 			NUBL: 86,
 			NU: 88,
+			PU: 90,
 			NFE: 90,
 		};
 		const customScale: {[k: string]: number} = {
-			Ditto: 99, Unown: 99,
+			Ditto: 100, Unown: 100,
 		};
 		const tier = species.tier;
 		const level = this.adjustLevel || customScale[species.name] || levelScale[tier] || (species.nfe ? 90 : 80);


### PR DESCRIPTION
The new gen3 PU tier made the now-PU mons level 80, as that's the default. Created a new level tier for PU at level 90, and while there upped Ditto and Unown from 99 to 100, as we don't actually have a policy of no lvl100 mons.