### PR TITLE
Random Battles Updates

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1939,7 +1939,7 @@
         ]
     },
     "amoonguss": {
-        "level": 81,
+        "level": 82,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -2709,7 +2709,7 @@
         ]
     },
     "inteleon": {
-        "level": 86,
+        "level": 84,
         "sets": [
             {
                 "role": "Fast Attacker",

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -3974,7 +3974,7 @@
         ]
     },
     "chienpao": {
-        "level": 79,
+        "level": 78,
         "sets": [
             {
                 "role": "Fast Attacker",

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1051,7 +1051,7 @@
         ]
     },
     "tropius": {
-        "level": 85,
+        "level": 86,
         "sets": [
             {
                 "role": "Bulky Support",

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2644,7 +2644,7 @@
         ]
     },
     "mimikyu": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Setup Sweeper",

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -629,11 +629,6 @@
         "level": 85,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Dark Pulse", "Protect", "Wish"],
-                "teraTypes": ["Poison"]
-            },
-            {
                 "role": "Bulky Support",
                 "movepool": ["Foul Play", "Protect", "Thunder Wave", "Wish", "Yawn"],
                 "teraTypes": ["Poison"]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -775,7 +775,7 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["Destiny Bond", "Freeze-Dry", "Memento", "Rapid Spin", "Spikes"],
+                "movepool": ["Freeze-Dry", "Memento", "Rapid Spin", "Spikes"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -2433,7 +2433,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Leaf Blade", "Sucker Punch", "Swords Dance", "Synthesis", "Triple Arrows", "U-turn"],
+                "movepool": ["Defog", "Leaf Blade", "Sucker Punch", "Swords Dance", "Synthesis", "Triple Arrows", "U-turn"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -2468,7 +2468,7 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["Defog", "Hurricane", "Revelation Dance", "Roost", "U-turn"],
+                "movepool": ["Defog", "Hurricane", "Revelation Dance", "Roost"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -2483,7 +2483,7 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["Defog", "Hurricane", "Revelation Dance", "Roost", "U-turn"],
+                "movepool": ["Defog", "Hurricane", "Revelation Dance", "Roost"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -2498,7 +2498,7 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["Defog", "Hurricane", "Revelation Dance", "Roost", "U-turn"],
+                "movepool": ["Defog", "Hurricane", "Revelation Dance", "Roost"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -2513,7 +2513,7 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["Defog", "Hurricane", "Revelation Dance", "Roost", "U-turn"],
+                "movepool": ["Defog", "Hurricane", "Revelation Dance", "Roost"],
                 "teraTypes": ["Ghost"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2409,7 +2409,7 @@
         ]
     },
     "volcanion": {
-        "level": 83,
+        "level": 82,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -4069,7 +4069,7 @@
         ]
     },
     "toedscruel": {
-        "level": 87,
+        "level": 86,
         "sets": [
             {
                 "role": "Bulky Support",

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -15,7 +15,7 @@
         ]
     },
     "pikachu": {
-        "level": 88,
+        "level": 90,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -45,7 +45,7 @@
         ]
     },
     "wigglytuff": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -75,7 +75,7 @@
         ]
     },
     "dugtrioalola": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -95,7 +95,7 @@
         ]
     },
     "persianalola": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Fast Bulky Setup",
@@ -115,7 +115,7 @@
         ]
     },
     "annihilape": {
-        "level": 80,
+        "level": 78,
         "sets": [
             {
                 "role": "Fast Bulky Setup",
@@ -205,7 +205,7 @@
         ]
     },
     "cloyster": {
-        "level": 80,
+        "level": 78,
         "sets": [
             {
                 "role": "Tera Blast user",
@@ -220,7 +220,7 @@
         ]
     },
     "gengar": {
-        "level": 82,
+        "level": 80,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -270,7 +270,7 @@
         ]
     },
     "scyther": {
-        "level": 86,
+        "level": 84,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -340,7 +340,7 @@
         ]
     },
     "gyarados": {
-        "level": 82,
+        "level": 80,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -366,7 +366,7 @@
         ]
     },
     "vaporeon": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -376,7 +376,7 @@
         ]
     },
     "jolteon": {
-        "level": 86,
+        "level": 84,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -411,7 +411,7 @@
         ]
     },
     "articunogalar": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Fast Bulky Setup",
@@ -486,7 +486,7 @@
         ]
     },
     "mew": {
-        "level": 80,
+        "level": 81,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -566,7 +566,7 @@
         ]
     },
     "jumpluff": {
-        "level": 88,
+        "level": 86,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -601,7 +601,7 @@
         ]
     },
     "clodsire": {
-        "level": 80,
+        "level": 81,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -616,7 +616,7 @@
         ]
     },
     "espeon": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -626,7 +626,7 @@
         ]
     },
     "umbreon": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -691,7 +691,7 @@
         ]
     },
     "dunsparce": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -731,7 +731,7 @@
         ]
     },
     "scizor": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -761,7 +761,7 @@
         ]
     },
     "ursaring": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -786,7 +786,7 @@
         ]
     },
     "houndoom": {
-        "level": 88,
+        "level": 86,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -811,7 +811,7 @@
         ]
     },
     "blissey": {
-        "level": 82,
+        "level": 84,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -821,7 +821,7 @@
         ]
     },
     "tyranitar": {
-        "level": 80,
+        "level": 81,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -886,7 +886,7 @@
         ]
     },
     "slaking": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -921,7 +921,7 @@
         ]
     },
     "medicham": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -946,7 +946,7 @@
         ]
     },
     "camerupt": {
-        "level": 88,
+        "level": 90,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -956,7 +956,7 @@
         ]
     },
     "torkoal": {
-        "level": 84,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1006,7 +1006,7 @@
         ]
     },
     "zangoose": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1051,7 +1051,7 @@
         ]
     },
     "tropius": {
-        "level": 88,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1061,7 +1061,7 @@
         ]
     },
     "glalie": {
-        "level": 80,
+        "level": 78,
         "sets": [
             {
                 "role": "Fast Support",
@@ -1181,7 +1181,7 @@
         ]
     },
     "floatzel": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1201,7 +1201,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Clear Smog", "Earthquake", "Ice Beam", "Recover", "Stealth Rock", "Surf"],
-                "teraTypes": ["Ground", "Steel", "Poison"]
+                "teraTypes": ["Steel", "Poison"]
             }
         ]
     },
@@ -1291,7 +1291,7 @@
         ]
     },
     "lucario": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1331,7 +1331,7 @@
         ]
     },
     "lumineon": {
-        "level": 88,
+        "level": 90,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1341,7 +1341,7 @@
         ]
     },
     "abomasnow": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1351,7 +1351,7 @@
         ]
     },
     "weavile": {
-        "level": 84,
+        "level": 83,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1361,7 +1361,7 @@
         ]
     },
     "sneasler": {
-        "level": 80,
+        "level": 78,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1401,7 +1401,7 @@
         ]
     },
     "glaceon": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -1606,7 +1606,7 @@
         ]
     },
     "cresselia": {
-        "level": 84,
+        "level": 82,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -1676,7 +1676,7 @@
         ]
     },
     "arceusfighting": {
-        "level": 70,
+        "level": 68,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -1756,7 +1756,7 @@
         ]
     },
     "arceuspsychic": {
-        "level": 70,
+        "level": 68,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -1811,7 +1811,7 @@
         ]
     },
     "samurotthisui": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1836,7 +1836,7 @@
         ]
     },
     "lilliganthisui": {
-        "level": 80,
+        "level": 81,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -1871,7 +1871,7 @@
         ]
     },
     "basculegion": {
-        "level": 76,
+        "level": 74,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1881,7 +1881,7 @@
         ]
     },
     "basculegionf": {
-        "level": 76,
+        "level": 74,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -1891,7 +1891,7 @@
         ]
     },
     "krookodile": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1939,7 +1939,7 @@
         ]
     },
     "amoonguss": {
-        "level": 80,
+        "level": 81,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -2014,7 +2014,7 @@
         ]
     },
     "braviaryhisui": {
-        "level": 80,
+        "level": 81,
         "sets": [
             {
                 "role": "Fast Support",
@@ -2109,7 +2109,7 @@
         ]
     },
     "landorustherian": {
-        "level": 80,
+        "level": 78,
         "sets": [
             {
                 "role": "Fast Support",
@@ -2124,7 +2124,7 @@
         ]
     },
     "meloetta": {
-        "level": 86,
+        "level": 84,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -2159,7 +2159,7 @@
         ]
     },
     "greninja": {
-        "level": 80,
+        "level": 81,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -2169,7 +2169,7 @@
         ]
     },
     "talonflame": {
-        "level": 84,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -2209,7 +2209,7 @@
         ]
     },
     "florges": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -2219,7 +2219,7 @@
         ]
     },
     "gogoat": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -2309,7 +2309,7 @@
         ]
     },
     "goodrahisui": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "AV Pivot",
@@ -2409,7 +2409,7 @@
         ]
     },
     "volcanion": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -2434,7 +2434,7 @@
         ]
     },
     "decidueyehisui": {
-        "level": 86,
+        "level": 88,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -2464,7 +2464,7 @@
         ]
     },
     "oricorio": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2479,7 +2479,7 @@
         ]
     },
     "oricoriopompom": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2494,7 +2494,7 @@
         ]
     },
     "oricoriopau": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2509,7 +2509,7 @@
         ]
     },
     "oricoriosensu": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2574,7 +2574,7 @@
         ]
     },
     "lurantis": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -2639,7 +2639,7 @@
         ]
     },
     "komala": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -2659,7 +2659,7 @@
         ]
     },
     "bruxish": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -2684,7 +2684,7 @@
         ]
     },
     "rillaboom": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2744,7 +2744,7 @@
         ]
     },
     "drednaw": {
-        "level": 82,
+        "level": 80,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2829,7 +2829,7 @@
         ]
     },
     "polteageist": {
-        "level": 82,
+        "level": 80,
         "sets": [
             {
                 "role": "Tera Blast user",
@@ -2904,7 +2904,7 @@
         ]
     },
     "frosmoth": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Tera Blast user",
@@ -2929,7 +2929,7 @@
         ]
     },
     "eiscue": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2989,7 +2989,7 @@
         ]
     },
     "zacian": {
-        "level": 70,
+        "level": 71,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -2999,7 +2999,7 @@
         ]
     },
     "zaciancrowned": {
-        "level": 68,
+        "level": 69,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -3049,7 +3049,7 @@
         ]
     },
     "urshifu": {
-        "level": 76,
+        "level": 77,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3059,7 +3059,7 @@
         ]
     },
     "urshifurapidstrike": {
-        "level": 80,
+        "level": 79,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3069,7 +3069,7 @@
         ]
     },
     "zarude": {
-        "level": 86,
+        "level": 82,
         "sets": [
             {
                 "role": "Fast Bulky Setup",
@@ -3099,7 +3099,7 @@
         ]
     },
     "regidrago": {
-        "level": 84,
+        "level": 83,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3124,7 +3124,7 @@
         ]
     },
     "spectrier": {
-        "level": 76,
+        "level": 75,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -3159,7 +3159,7 @@
         ]
     },
     "calyrexshadow": {
-        "level": 68,
+        "level": 67,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3169,7 +3169,7 @@
         ]
     },
     "wyrdeer": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3179,7 +3179,7 @@
         ]
     },
     "kleavor": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3199,7 +3199,7 @@
         ]
     },
     "enamorus": {
-        "level": 82,
+        "level": 81,
         "sets": [
             {
                 "role": "Tera Blast user",
@@ -3234,7 +3234,7 @@
         ]
     },
     "skeledirge": {
-        "level": 80,
+        "level": 81,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3249,7 +3249,7 @@
         ]
     },
     "quaquaval": {
-        "level": 80,
+        "level": 79,
         "sets": [
             {
                 "role": "Fast Support",
@@ -3264,7 +3264,7 @@
         ]
     },
     "oinkologne": {
-        "level": 88,
+        "level": 90,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -3274,7 +3274,7 @@
         ]
     },
     "oinkolognef": {
-        "level": 88,
+        "level": 90,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -3284,7 +3284,7 @@
         ]
     },
     "dudunsparce": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -3299,7 +3299,7 @@
         ]
     },
     "dudunsparcethreesegment": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -3354,7 +3354,7 @@
         ]
     },
     "houndstone": {
-        "level": 76,
+        "level": 74,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3364,7 +3364,7 @@
         ]
     },
     "espathra": {
-        "level": 80,
+        "level": 79,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -3384,7 +3384,7 @@
         ]
     },
     "farigiraf": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -3404,7 +3404,7 @@
         ]
     },
     "wugtrio": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3439,7 +3439,7 @@
         ]
     },
     "palafin": {
-        "level": 76,
+        "level": 77,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3449,7 +3449,7 @@
         ]
     },
     "arboliva": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3464,7 +3464,7 @@
         ]
     },
     "scovillain": {
-        "level": 80,
+        "level": 76,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3474,7 +3474,7 @@
         ]
     },
     "bellibolt": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3484,7 +3484,7 @@
         ]
     },
     "revavroom": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Tera Blast user",
@@ -3514,7 +3514,7 @@
         ]
     },
     "maushold": {
-        "level": 80,
+        "level": 78,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -3524,7 +3524,7 @@
         ]
     },
     "mausholdfour": {
-        "level": 80,
+        "level": 78,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -3549,7 +3549,7 @@
         ]
     },
     "baxcalibur": {
-        "level": 80,
+        "level": 81,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3669,7 +3669,7 @@
         ]
     },
     "flamigo": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -3679,7 +3679,7 @@
         ]
     },
     "klawf": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3689,7 +3689,7 @@
         ]
     },
     "garganacl": {
-        "level": 80,
+        "level": 81,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -3719,7 +3719,7 @@
         ]
     },
     "grafaiai": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3739,7 +3739,7 @@
         ]
     },
     "dachsbun": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -3759,7 +3759,7 @@
         ]
     },
     "brambleghast": {
-        "level": 84,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -3789,7 +3789,7 @@
         ]
     },
     "greattusk": {
-        "level": 80,
+        "level": 81,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -3824,7 +3824,7 @@
         ]
     },
     "screamtail": {
-        "level": 86,
+        "level": 84,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -3859,7 +3859,7 @@
         ]
     },
     "roaringmoon": {
-        "level": 80,
+        "level": 78,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -3919,7 +3919,7 @@
         ]
     },
     "ironthorns": {
-        "level": 84,
+        "level": 85,
         "sets": [
             {
                 "role": "Fast Support",
@@ -3944,7 +3944,7 @@
         ]
     },
     "ironvaliant": {
-        "level": 80,
+        "level": 79,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -3974,7 +3974,7 @@
         ]
     },
     "chienpao": {
-        "level": 80,
+        "level": 79,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3984,7 +3984,7 @@
         ]
     },
     "wochien": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -4009,7 +4009,7 @@
         ]
     },
     "koraidon": {
-        "level": 72,
+        "level": 70,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -4019,7 +4019,7 @@
         ]
     },
     "miraidon": {
-        "level": 70,
+        "level": 68,
         "sets": [
             {
                 "role": "Fast Bulky Setup",
@@ -4034,7 +4034,7 @@
         ]
     },
     "tinkaton": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -4069,7 +4069,7 @@
         ]
     },
     "toedscruel": {
-        "level": 86,
+        "level": 87,
         "sets": [
             {
                 "role": "Bulky Support",

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1836,7 +1836,7 @@
         ]
     },
     "lilliganthisui": {
-        "level": 81,
+        "level": 80,
         "sets": [
             {
                 "role": "Setup Sweeper",

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -3789,7 +3789,7 @@
         ]
     },
     "greattusk": {
-        "level": 81,
+        "level": 80,
         "sets": [
             {
                 "role": "Bulky Setup",

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -3549,7 +3549,7 @@
         ]
     },
     "baxcalibur": {
-        "level": 81,
+        "level": 80,
         "sets": [
             {
                 "role": "Fast Attacker",

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -3349,7 +3349,7 @@
         ]
     },
     "houndstone": {
-        "level": 74,
+        "level": 76,
         "sets": [
             {
                 "role": "Bulky Attacker",

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -494,7 +494,6 @@ export class RandomTeams {
 		this.incompatibleMoves(moves, movePool, 'toxic', 'willowisp');
 		this.incompatibleMoves(moves, movePool, ['thunderwave', 'toxic', 'willowisp'], 'toxicspikes');
 		this.incompatibleMoves(moves, movePool, 'thunderwave', 'yawn');
-		this.incompatibleMoves(moves, movePool, 'memento', 'destinybond');
 
 		// This space reserved for assorted hardcodes that otherwise make little sense out of context
 		if (species.id === "dugtrio") {


### PR DESCRIPTION
We have been advised by Annika that objective winrates are unlikely to be procured before Random Battles Team Tournament starts. The reason for this is that attempting to collect winrates results in either Showdown's function being reduced or extremely inaccurate winrates. Annika does not know why this is the case. Subjective level balancing is being implemented as an emergency measure.

Aside from that: 
Tera Ground will no longer appear on Gastrodon
Calm Mind Umbreon will no longer exist
Oricorio will get Defog more often
Hisuian Decidueye will now get Defog
Delibird's suicide move will be changed, again, due to bugged sets.