### PR TITLE
Fix ruleset interactions with Rayquaza-Mega

### DIFF
--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1805,7 +1805,7 @@ export class BattleActions {
 		const altForme = species.otherFormes && this.dex.species.get(species.otherFormes[0]);
 		const item = pokemon.getItem();
 		// Mega Rayquaza
-		if ((this.battle.gen <= 7 || this.battle.ruleTable.has('standardnatdex')) &&
+		if ((this.battle.gen <= 7 || this.battle.ruleTable.has('+pokemontag:past')) &&
 			altForme?.isMega && altForme?.requiredMove &&
 			pokemon.baseMoves.includes(toID(altForme.requiredMove)) && !item.zMove) {
 			return altForme.name;

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -813,6 +813,31 @@ export class DexFormats {
 
 		ruleTable.resolveNumbers(format, this.dex);
 
+		const canMegaEvo = this.dex.gen <= 7 || ruleTable.has('+pokemontag:past');
+		if (ruleTable.has('obtainableformes') && canMegaEvo) {
+			// Banning Rayquaza-Mega implicitly adds Mega Rayquaza Clause
+			const mray = this.dex.species.get('rayquazamega');
+			let mrayBanned = false;
+			const banReason = ruleTable.check('pokemon:' + mray.id);
+			if (banReason) {
+				mrayBanned = true;
+			} else if (banReason !== '') {
+				for (const ruleid of ruleTable.tagRules) {
+					if (ruleid.startsWith('*')) continue;
+					const tag = Tags[ruleid.slice(12)];
+					if (tag.speciesFilter?.(mray)) {
+						if (ruleid.startsWith('+')) break;
+						mrayBanned = true;
+						break;
+					}
+				}
+			}
+			if (mrayBanned) {
+				// note that already having an explicit MRay Clause in the ruleset is ok
+				ruleTable.set('megarayquazaclause', '');
+			}
+		}
+
 		for (const rule of ruleTable.keys()) {
 			if ("+*-!".includes(rule.charAt(0))) continue;
 			const subFormat = this.dex.formats.get(rule);

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -814,28 +814,13 @@ export class DexFormats {
 		ruleTable.resolveNumbers(format, this.dex);
 
 		const canMegaEvo = this.dex.gen <= 7 || ruleTable.has('+pokemontag:past');
-		if (ruleTable.has('obtainableformes') && canMegaEvo) {
+		if (ruleTable.has('obtainableformes') && canMegaEvo &&
+			ruleTable.isBannedSpecies(this.dex.species.get('rayquazamega')) &&
+			!ruleTable.isBannedSpecies(this.dex.species.get('rayquaza'))
+		) {
 			// Banning Rayquaza-Mega implicitly adds Mega Rayquaza Clause
-			const mray = this.dex.species.get('rayquazamega');
-			let mrayBanned = false;
-			const banReason = ruleTable.check('pokemon:' + mray.id);
-			if (banReason) {
-				mrayBanned = true;
-			} else if (banReason !== '') {
-				for (const ruleid of ruleTable.tagRules) {
-					if (ruleid.startsWith('*')) continue;
-					const tag = Tags[ruleid.slice(12)];
-					if (tag.speciesFilter?.(mray)) {
-						if (ruleid.startsWith('+')) break;
-						mrayBanned = true;
-						break;
-					}
-				}
-			}
-			if (mrayBanned) {
-				// note that already having an explicit MRay Clause in the ruleset is ok
-				ruleTable.set('megarayquazaclause', '');
-			}
+			// note that already having it explicitly in the ruleset is ok
+			ruleTable.set('megarayquazaclause', '');
 		}
 
 		for (const rule of ruleTable.keys()) {

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -393,7 +393,7 @@ export class TeamValidator {
 		}
 
 		if (ruleTable.has('obtainableformes')) {
-			const canMegaEvo = dex.gen <= 7 || ruleTable.has('standardnatdex');
+			const canMegaEvo = dex.gen <= 7 || ruleTable.has('+pokemontag:past');
 			if (item.megaEvolves === species.name) {
 				if (!item.megaStone) throw new Error(`Item ${item.name} has no base form for mega evolution`);
 				tierSpecies = dex.species.get(item.megaStone);
@@ -401,7 +401,8 @@ export class TeamValidator {
 				tierSpecies = dex.species.get('Groudon-Primal');
 			} else if (item.id === 'blueorb' && species.id === 'kyogre') {
 				tierSpecies = dex.species.get('Kyogre-Primal');
-			} else if (canMegaEvo && species.id === 'rayquaza' && set.moves.map(toID).includes('dragonascent' as ID)) {
+			} else if (canMegaEvo && species.id === 'rayquaza' && set.moves.map(toID).includes('dragonascent' as ID) &&
+					!ruleTable.has('megarayquazaclause')) {
 				tierSpecies = dex.species.get('Rayquaza-Mega');
 			} else if (item.id === 'rustedsword' && species.id === 'zacian') {
 				tierSpecies = dex.species.get('Zacian-Crowned');

--- a/test/sim/misc/megaevolution.js
+++ b/test/sim/misc/megaevolution.js
@@ -129,4 +129,60 @@ describe('Mega Evolution', function () {
 		battle.makeChoices('move protect mega', 'auto');
 		assert.equal(megaMon.status, '');
 	});
+
+	describe("Mega Rayquaza", () => {
+		const TEAMS = [[
+			{species: "Rayquaza", ability: 'airlock', moves: ['dragonascent'], evs: {hp: 1}},
+		], [
+			{species: "Rayquaza", ability: 'airlock', moves: ['protect'], evs: {hp: 1}},
+		]];
+
+		it('should be able to Mega Evolve iff it knows Dragon Ascent', () => {
+			battle = common.createBattle({formatid: 'gen6anythinggoes'}, TEAMS);
+			battle.makeChoices(); // team preview
+			battle.makeChoices('move 1 mega', 'auto');
+			assert.equal(battle.p1.active[0].species.name, "Rayquaza-Mega");
+			assert.throws(() => battle.choose('p2', 'move 1 mega'));
+		});
+
+		it('should be allowed to Mega Evolve in new gen formats allowing "Past" elements', () => {
+			battle = common.createBattle({formatid: 'gen9nationaldexag'}, TEAMS);
+			battle.makeChoices(); // team preview
+			battle.makeChoices('move 1 mega', 'auto');
+			assert.equal(battle.p1.active[0].species.name, "Rayquaza-Mega");
+
+			battle.destroy();
+			battle = common.createBattle({formatid: 'gen9natdexdraft'}, TEAMS);
+			battle.makeChoices();
+			battle.makeChoices('move 1 mega', 'auto');
+			assert.equal(battle.p1.active[0].species.name, "Rayquaza-Mega");
+
+			battle.destroy();
+			battle = common.createBattle({formatid: 'gen8anythinggoes@@@+past'}, TEAMS);
+			battle.makeChoices();
+			battle.makeChoices('move 1 mega', 'auto');
+			assert.equal(battle.p1.active[0].species.name, "Rayquaza-Mega");
+		});
+
+		function assertLegalButCantMega(formatid) {
+			assert.legalTeam(TEAMS[0], formatid);
+			battle = common.createBattle({formatid}, TEAMS);
+			battle.makeChoices(); // team preview
+			assert.throws(() => battle.choose('p1', 'move 1 mega'));
+		}
+
+		it('should not be allowed to Mega Evolve in formats that have the Mega Rayquaza Clause', () => {
+			assertLegalButCantMega('gen6ubers');
+			battle.destroy();
+			assertLegalButCantMega('gen9nationaldexubers');
+		});
+
+		it('should implicitly add the Mega Rayquaza Clause when Rayquaza-Mega is banned', () => {
+			assertLegalButCantMega('gen9nationaldexag@@@-rayquaza-mega');
+			battle.destroy();
+			assertLegalButCantMega('gen9nationaldexag@@@-mega');
+			battle.destroy();
+			assertLegalButCantMega('gen9nationaldexag@@@-ndag');
+		});
+	});
 });

--- a/test/sim/misc/megaevolution.js
+++ b/test/sim/misc/megaevolution.js
@@ -137,32 +137,12 @@ describe('Mega Evolution', function () {
 			{species: "Rayquaza", ability: 'airlock', moves: ['protect'], evs: {hp: 1}},
 		]];
 
-		it('should be able to Mega Evolve iff it knows Dragon Ascent', () => {
-			battle = common.createBattle({formatid: 'gen6anythinggoes'}, TEAMS);
+		function assertCanMega(formatid) {
+			battle = common.createBattle({formatid}, TEAMS);
 			battle.makeChoices(); // team preview
 			battle.makeChoices('move 1 mega', 'auto');
 			assert.equal(battle.p1.active[0].species.name, "Rayquaza-Mega");
-			assert.throws(() => battle.choose('p2', 'move 1 mega'));
-		});
-
-		it('should be allowed to Mega Evolve in new gen formats allowing "Past" elements', () => {
-			battle = common.createBattle({formatid: 'gen9nationaldexag'}, TEAMS);
-			battle.makeChoices(); // team preview
-			battle.makeChoices('move 1 mega', 'auto');
-			assert.equal(battle.p1.active[0].species.name, "Rayquaza-Mega");
-
-			battle.destroy();
-			battle = common.createBattle({formatid: 'gen9natdexdraft'}, TEAMS);
-			battle.makeChoices();
-			battle.makeChoices('move 1 mega', 'auto');
-			assert.equal(battle.p1.active[0].species.name, "Rayquaza-Mega");
-
-			battle.destroy();
-			battle = common.createBattle({formatid: 'gen8anythinggoes@@@+past'}, TEAMS);
-			battle.makeChoices();
-			battle.makeChoices('move 1 mega', 'auto');
-			assert.equal(battle.p1.active[0].species.name, "Rayquaza-Mega");
-		});
+		}
 
 		function assertLegalButCantMega(formatid) {
 			assert.legalTeam(TEAMS[0], formatid);
@@ -171,13 +151,27 @@ describe('Mega Evolution', function () {
 			assert.throws(() => battle.choose('p1', 'move 1 mega'));
 		}
 
+		it('should be able to Mega Evolve iff it knows Dragon Ascent', () => {
+			assertCanMega('gen6anythinggoes');
+			// battle continues
+			assert.throws(() => battle.choose('p2', 'move 1 mega'));
+		});
+
+		it('should be allowed to Mega Evolve in new gen formats allowing "Past" elements', () => {
+			assertCanMega('gen9nationaldexag');
+			battle.destroy();
+			assertCanMega('gen9natdexdraft');
+			battle.destroy();
+			assertCanMega('gen8anythinggoes@@@+past');
+		});
+
 		it('should not be allowed to Mega Evolve in formats that have the Mega Rayquaza Clause', () => {
 			assertLegalButCantMega('gen6ubers');
 			battle.destroy();
 			assertLegalButCantMega('gen9nationaldexubers');
 		});
 
-		it('should implicitly add the Mega Rayquaza Clause when Rayquaza-Mega is banned', () => {
+		it('should implicitly add the Mega Rayquaza Clause when banned', () => {
 			assertLegalButCantMega('gen9nationaldexag@@@-rayquaza-mega');
 			battle.destroy();
 			assertLegalButCantMega('gen9nationaldexag@@@-mega');

--- a/test/sim/misc/megaevolution.js
+++ b/test/sim/misc/megaevolution.js
@@ -183,6 +183,9 @@ describe('Mega Evolution', function () {
 			assertLegalButCantMega('gen9nationaldexag@@@-mega');
 			battle.destroy();
 			assertLegalButCantMega('gen9nationaldexag@@@-ndag');
+
+			// don't add it where unnecessary
+			assert.false(Dex.formats.getRuleTable(Dex.formats.get('gen5anythinggoes')).has('megarayquazaclause'));
 		});
 	});
 });


### PR DESCRIPTION
* Rayquaza's ability to Mega Evolve post-gen 7 now checks for "+Past" in the ruleset instead of "Standard NatDex". There are probably other cases of this hardcode that should be changed, but leave that for another PR.
  * NatDex Draft is now able to Mega Evolve Rayquaza
* Banning Rayquaza-Mega no longer implicitly bans Rayquaza + Dragon Ascent; the new behavior is to add an implicit Mega Rayquaza Clause
  * While this change is significant to many formats, tiering folk apparently prefer this if I understand correctly. If it becomes problematic in the future I am more than willing to make a Policy Review thread
  * This fixes Rayquaza validity in National Dex Ubers