### PR TITLE
Gen 1: Fix battle log for charging moves, add hint for stat overflow

### DIFF
--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -148,11 +148,12 @@ export const Scripts: ModdedBattleScriptsData = {
 				(!pokemon.volatiles['partialtrappinglock'] || pokemon.volatiles['partialtrappinglock'].locked !== target))
 			) {
 				pokemon.deductPP(move, null, target);
-			} else if (pokemon.volatiles['twoturnmove']) {
-				// Two-turn moves like Sky Attack deduct PP on their second turn.
-				pokemon.deductPP(pokemon.volatiles['twoturnmove'].originalMove, null, target);
 			} else {
 				sourceEffect = move;
+				if (pokemon.volatiles['twoturnmove']) {
+					// Two-turn moves like Sky Attack deduct PP on their second turn.
+					pokemon.deductPP(pokemon.volatiles['twoturnmove'].originalMove, null, target);
+				}
 			}
 			if (pokemon.volatiles['partialtrappinglock'] && target !== pokemon.volatiles['partialtrappinglock'].locked) {
 				const moveSlot = pokemon.moveSlots.find(ms => ms.id === move.id);

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -842,6 +842,9 @@ export const Scripts: ModdedBattleScriptsData = {
 			// When either attack or defense are higher than 256, both are divided by 4.
 			// If that's still over 256, it rolls over (%256), which is what causes rollover bugs.
 			if (attack >= 256 || defense >= 256) {
+				if (attack >= 1024 || defense >= 1024) {
+					this.battle.hint("In Gen 1, a stat will roll over to a small number if it is larger than 1024.");
+				}
 				attack = this.battle.clampIntRange(Math.floor(attack / 4) % 256, 1);
 				// Defense isn't checked on the cartridge, but we don't want those / 0 bugs on the sim.
 				defense = Math.floor(defense / 4) % 256;


### PR DESCRIPTION
This fixes the battle log so that the second turn of a two-turn move will include "[from]<move>", e.g. "[from]Skull Bash". This was unintentionally removed in https://github.com/smogon/pokemon-showdown/pull/9243.

Edit: also adds a hint for stat overflow in Gen 1