### PR TITLE
Update regex for extracting privileged messages

### DIFF
--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -257,7 +257,7 @@ export class ServerStream extends Streams.ObjectReadWriteStream<string> {
 			const roomChannel = this.roomChannels.get(roomid);
 			for (const [curSocketid, curSocket] of room) {
 				const channelid = roomChannel?.get(curSocketid) || 0;
-				if (!messages[channelid]) messages[channelid] = this.extractChannel(message, channelid);
+				if (!messages[channelid]) messages[channelid] = ServerStream.extractChannel(message, channelid);
 				curSocket.write(messages[channelid]!);
 			}
 		},
@@ -426,23 +426,23 @@ export class ServerStream extends Streams.ObjectReadWriteStream<string> {
 		console.log(`Test your server at http://${config.bindaddress === '0.0.0.0' ? 'localhost' : config.bindaddress}:${config.port}`);
 	}
 
-	extractChannel(message: string, channelid: -1 | ChannelID) {
+	static extractChannel(message: string, channelid: -1 | ChannelID) {
 		if (channelid === -1) {
 			// Grab all privileged messages
-			return message.replace(/\n\|split\|p[1234]\n([^\n]*)\n(?:[^\n]*)/g, '\n$1');
+			return message.replace(/(?:(?<=\n)|^)\|split\|p[1234]\n([^\n]*)\n(?:[^\n]*)/g, '$1').replace(/\n$/g, '');
 		}
 
 		// Grab privileged messages channel has access to
 		switch (channelid) {
-		case 1: message = message.replace(/\n\|split\|p1\n([^\n]*)\n(?:[^\n]*)/g, '\n$1'); break;
-		case 2: message = message.replace(/\n\|split\|p2\n([^\n]*)\n(?:[^\n]*)/g, '\n$1'); break;
-		case 3: message = message.replace(/\n\|split\|p3\n([^\n]*)\n(?:[^\n]*)/g, '\n$1'); break;
-		case 4: message = message.replace(/\n\|split\|p4\n([^\n]*)\n(?:[^\n]*)/g, '\n$1'); break;
+		case 1: message = message.replace(/(?:(?<=\n)|^)\|split\|p1\n([^\n]*)\n(?:[^\n]*)/g, '$1'); break;
+		case 2: message = message.replace(/(?:(?<=\n)|^)\|split\|p2\n([^\n]*)\n(?:[^\n]*)/g, '$1'); break;
+		case 3: message = message.replace(/(?:(?<=\n)|^)\|split\|p3\n([^\n]*)\n(?:[^\n]*)/g, '$1'); break;
+		case 4: message = message.replace(/(?:(?<=\n)|^)\|split\|p4\n([^\n]*)\n(?:[^\n]*)/g, '$1'); break;
 		}
 
 		// Discard remaining privileged messages
 		// Note: the last \n? is for privileged messages that are empty when non-privileged
-		return message.replace(/(?<=\n)\|split\|(?:[^\n]*)\n(?:[^\n]*)\n\n?/g, '');
+		return message.replace(/(?:(?<=\n)|^)\|split\|(?:[^\n]*)\n(?:[^\n]*)\n\n?(\n$)?/g, '').replace(/\n$/g, '');
 	}
 
 	/**

--- a/server/sockets.ts
+++ b/server/sockets.ts
@@ -442,7 +442,7 @@ export class ServerStream extends Streams.ObjectReadWriteStream<string> {
 
 		// Discard remaining privileged messages
 		// Note: the last \n? is for privileged messages that are empty when non-privileged
-		return message.replace(/\n\|split\|(?:[^\n]*)\n(?:[^\n]*)\n\n?/g, '\n');
+		return message.replace(/(?<=\n)\|split\|(?:[^\n]*)\n(?:[^\n]*)\n\n?/g, '');
 	}
 
 	/**

--- a/sim/battle-stream.ts
+++ b/sim/battle-stream.ts
@@ -86,9 +86,9 @@ export class BattleStream extends Streams.ObjectReadWriteStream<string> {
 			if (type === 'update') {
 				const channelMessages = extractChannelMessages(data);
 				if (this.replay === 'spectator') {
-					this.push(channelMessages.get(0)!.join('\n'));
+					this.push(channelMessages[0].join('\n'));
 				} else {
-					this.push(channelMessages.get(-1)!.join('\n'));
+					this.push(channelMessages[-1].join('\n'));
 				}
 			}
 			return;
@@ -287,12 +287,12 @@ export function getPlayerStreams(stream: BattleStream) {
 			switch (type) {
 			case 'update':
 				const channelMessages = extractChannelMessages(data);
-				streams.omniscient.push(channelMessages.get(-1)!.join('\n'));
-				streams.spectator.push(channelMessages.get(0)!.join('\n'));
-				streams.p1.push(channelMessages.get(1)!.join('\n'));
-				streams.p2.push(channelMessages.get(2)!.join('\n'));
-				streams.p3.push(channelMessages.get(3)!.join('\n'));
-				streams.p4.push(channelMessages.get(4)!.join('\n'));
+				streams.omniscient.push(channelMessages[-1].join('\n'));
+				streams.spectator.push(channelMessages[0].join('\n'));
+				streams.p1.push(channelMessages[1].join('\n'));
+				streams.p2.push(channelMessages[2].join('\n'));
+				streams.p3.push(channelMessages[3].join('\n'));
+				streams.p4.push(channelMessages[4].join('\n'));
 				break;
 			case 'sideupdate':
 				const [side, sideData] = splitFirst(data, `\n`);

--- a/sim/battle-stream.ts
+++ b/sim/battle-stream.ts
@@ -84,10 +84,11 @@ export class BattleStream extends Streams.ObjectReadWriteStream<string> {
 	pushMessage(type: string, data: string) {
 		if (this.replay) {
 			if (type === 'update') {
-				const channelMessages = extractChannelMessages(data);
 				if (this.replay === 'spectator') {
+					const channelMessages = extractChannelMessages(data, [0]);
 					this.push(channelMessages[0].join('\n'));
 				} else {
+					const channelMessages = extractChannelMessages(data, [-1]);
 					this.push(channelMessages[-1].join('\n'));
 				}
 			}
@@ -286,7 +287,7 @@ export function getPlayerStreams(stream: BattleStream) {
 			const [type, data] = splitFirst(chunk, `\n`);
 			switch (type) {
 			case 'update':
-				const channelMessages = extractChannelMessages(data);
+				const channelMessages = extractChannelMessages(data, [-1, 0, 1, 2, 3, 4]);
 				streams.omniscient.push(channelMessages[-1].join('\n'));
 				streams.spectator.push(channelMessages[0].join('\n'));
 				streams.p1.push(channelMessages[1].join('\n'));

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2921,20 +2921,20 @@ export class Battle {
 	static extractUpdateForSide(data: string, side: SideID | 'spectator' | 'omniscient' = 'spectator') {
 		if (side === 'omniscient') {
 			// Grab all secret data
-			return data.replace(/\n\|split\|p[1234]\n([^\n]*)\n(?:[^\n]*)/g, '\n$1');
+			return data.replace(/(?:(?<=\n)|^)\|split\|p[1234]\n([^\n]*)\n(?:[^\n]*)/g, '$1').replace(/\n$/g, '');
 		}
 
 		// Grab secret data side has access to
 		switch (side) {
-		case 'p1': data = data.replace(/\n\|split\|p1\n([^\n]*)\n(?:[^\n]*)/g, '\n$1'); break;
-		case 'p2': data = data.replace(/\n\|split\|p2\n([^\n]*)\n(?:[^\n]*)/g, '\n$1'); break;
-		case 'p3': data = data.replace(/\n\|split\|p3\n([^\n]*)\n(?:[^\n]*)/g, '\n$1'); break;
-		case 'p4': data = data.replace(/\n\|split\|p4\n([^\n]*)\n(?:[^\n]*)/g, '\n$1'); break;
+		case 'p1': data = data.replace(/(?:(?<=\n)|^)\|split\|p1\n([^\n]*)\n(?:[^\n]*)/g, '$1'); break;
+		case 'p2': data = data.replace(/(?:(?<=\n)|^)\|split\|p2\n([^\n]*)\n(?:[^\n]*)/g, '$1'); break;
+		case 'p3': data = data.replace(/(?:(?<=\n)|^)\|split\|p3\n([^\n]*)\n(?:[^\n]*)/g, '$1'); break;
+		case 'p4': data = data.replace(/(?:(?<=\n)|^)\|split\|p4\n([^\n]*)\n(?:[^\n]*)/g, '$1'); break;
 		}
 
 		// Discard remaining secret data
 		// Note: the last \n? is for secret data that are empty when shared
-		return data.replace(/(?<=\n)\|split\|(?:[^\n]*)\n(?:[^\n]*)\n\n?/g, '');
+		return data.replace(/(?:(?<=\n)|^)\|split\|(?:[^\n]*)\n(?:[^\n]*)\n\n?(\n$)?/g, '').replace(/\n$/g, '');
 	}
 
 	getDebugLog() {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2919,22 +2919,33 @@ export class Battle {
 	}
 
 	static extractUpdateForSide(data: string, side: SideID | 'spectator' | 'omniscient' = 'spectator') {
-		if (side === 'omniscient') {
-			// Grab all secret data
-			return data.replace(/(?:(?<=\n)|^)\|split\|p[1234]\n([^\n]*)\n(?:[^\n]*)/g, '$1').replace(/\n$/g, '');
+		const lines: (string | undefined)[] = data.split('\n');
+
+		for (let i = 0; i < lines.length - 2; i++) {
+			const line = lines[i];
+			if (!line) continue;
+
+			const splitMatch = /^\|split\|(p[1234])$/.exec(line);
+			if (!splitMatch) continue;
+
+			const [, player] = splitMatch;
+
+			const secretMessage = lines[i + 1]!; // Assume anything ahead of us is defined if the line is defined
+			const sharedMessage = lines[i + 2]!;
+			const hasPrivilege = (player === side) || (side === 'omniscient');
+
+			let channelMessage = sharedMessage;
+			if (hasPrivilege) channelMessage = secretMessage; // Expose secrets to matching players
+			const isEmptyChannelMessage = channelMessage.length === 0;
+
+			lines[i] = isEmptyChannelMessage ? undefined : channelMessage;
+			lines[i + 1] = undefined;
+			lines[i + 2] = undefined;
 		}
 
-		// Grab secret data side has access to
-		switch (side) {
-		case 'p1': data = data.replace(/(?:(?<=\n)|^)\|split\|p1\n([^\n]*)\n(?:[^\n]*)/g, '$1'); break;
-		case 'p2': data = data.replace(/(?:(?<=\n)|^)\|split\|p2\n([^\n]*)\n(?:[^\n]*)/g, '$1'); break;
-		case 'p3': data = data.replace(/(?:(?<=\n)|^)\|split\|p3\n([^\n]*)\n(?:[^\n]*)/g, '$1'); break;
-		case 'p4': data = data.replace(/(?:(?<=\n)|^)\|split\|p4\n([^\n]*)\n(?:[^\n]*)/g, '$1'); break;
-		}
-
-		// Discard remaining secret data
-		// Note: the last \n? is for secret data that are empty when shared
-		return data.replace(/(?:(?<=\n)|^)\|split\|(?:[^\n]*)\n(?:[^\n]*)\n\n?(\n$)?/g, '').replace(/\n$/g, '');
+		return lines
+			.filter((line) => line !== undefined)
+			.join('\n');
 	}
 
 	getDebugLog() {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2920,7 +2920,7 @@ export class Battle {
 	}
 
 	getDebugLog() {
-		const channelMessages = extractChannelMessages(this.log.join('\n'));
+		const channelMessages = extractChannelMessages(this.log.join('\n'), [-1]);
 		return channelMessages[-1].join('\n');
 	}
 

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2921,7 +2921,7 @@ export class Battle {
 
 	getDebugLog() {
 		const channelMessages = extractChannelMessages(this.log.join('\n'));
-		return (channelMessages.get(-1) || []).join('\n');
+		return channelMessages[-1].join('\n');
 	}
 
 	debugError(activity: string) {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2934,7 +2934,7 @@ export class Battle {
 
 		// Discard remaining secret data
 		// Note: the last \n? is for secret data that are empty when shared
-		return data.replace(/\n\|split\|(?:[^\n]*)\n(?:[^\n]*)\n\n?/g, '\n');
+		return data.replace(/(?<=\n)\|split\|(?:[^\n]*)\n(?:[^\n]*)\n\n?/g, '');
 	}
 
 	getDebugLog() {

--- a/test/server/sockets.js
+++ b/test/server/sockets.js
@@ -21,7 +21,7 @@ describe('ServerStream', function () {
 				'|-start|p3a: Hellfrog|ability: Flash Fire',
 				'|-start|p4a: Hellfrog|ability: Flash Fire',
 			].join('\n');
-			const actualChannelMessages = extractChannelMessages(messages);
+			const actualChannelMessages = extractChannelMessages(messages, [omniscientPlayer]);
 
 			assert.equal(actualChannelMessages[omniscientPlayer].join('\n'), messages);
 		});
@@ -33,7 +33,7 @@ describe('ServerStream', function () {
 				...createSplit(3, '|-start|p3a: Aerodactyl|ability: Pressure', ''),
 				...createSplit(4, '|-start|p4a: Aerodactyl|ability: Pressure', ''),
 			].join('\n');
-			const actualChannelMessages = extractChannelMessages(messages);
+			const actualChannelMessages = extractChannelMessages(messages, [omniscientPlayer]);
 
 			const expectedMessages = [
 				'|-start|p1a: Aerodactyl|ability: Pressure',
@@ -52,7 +52,7 @@ describe('ServerStream', function () {
 				...createSplit(3, '|-start|p3a: Aerodactyl|ability: Pressure', ''),
 				...createSplit(4, '|-start|p4a: Aerodactyl|ability: Pressure', ''),
 			].join('\n');
-			const actualChannelMessages = extractChannelMessages(expectedMessages);
+			const actualChannelMessages = extractChannelMessages(expectedMessages, [spectatorPlayer, 1, 2, 3, 4]);
 
 			for (const player of [1, 2, 3, 4]) {
 				const actualPlayerMessages = actualChannelMessages[player].join('\n');
@@ -72,7 +72,7 @@ describe('ServerStream', function () {
 				...createSplit(2, '|-start|p2a: Aerodactyl|ability: Pressure', ''),
 				'|-start|p2b: Hellfrog|ability: Flash Fire',
 			].join('\n');
-			const actualChannelMessages = extractChannelMessages(messages);
+			const actualChannelMessages = extractChannelMessages(messages, [omniscientPlayer, spectatorPlayer, 1, 2]);
 
 			const expectedOmniscientPlayerMessages = [
 				'|-start|p2b: Hellfrog|ability: Flash Fire',
@@ -98,7 +98,7 @@ describe('ServerStream', function () {
 			assert.equal(actualChannelMessages[omniscientPlayer].join('\n'), expectedOmniscientPlayerMessages);
 			assert.equal(actualChannelMessages[1].join('\n'), expectedPlayer1Messages);
 			assert.equal(actualChannelMessages[2].join('\n'), expectedPlayer2Messages);
-			assert.equal(actualChannelMessages[0].join('\n'), expectedSpectatorMessages);
+			assert.equal(actualChannelMessages[spectatorPlayer].join('\n'), expectedSpectatorMessages);
 		});
 
 		it('should return consecutive player-privileged messages for a player', function () {
@@ -107,7 +107,7 @@ describe('ServerStream', function () {
 				...createSplit(1, '|-start|p1b: Aerodactyl|ability: Pressure', ''),
 				...createSplit(1, '|-start|p1c: Aerodactyl|ability: Pressure', ''),
 			].join('\n');
-			const actualChannelMessages = extractChannelMessages(messages);
+			const actualChannelMessages = extractChannelMessages(messages, [omniscientPlayer, spectatorPlayer, 1]);
 
 			const expectedPlayerMessages = [
 				'|-start|p1a: Aerodactyl|ability: Pressure',
@@ -127,7 +127,7 @@ describe('ServerStream', function () {
 				...createSplit(3, '|-heal|p3a: Rhyperior|420/420', '|-heal|p3a: Rhyperior|100/100'),
 				...createSplit(4, '|-heal|p4a: Rhyperior|420/420', '|-heal|p4a: Rhyperior|100/100'),
 			].join('\n');
-			const actualChannelMessages = extractChannelMessages(messages);
+			const actualChannelMessages = extractChannelMessages(messages, [omniscientPlayer, spectatorPlayer, 1, 2, 3, 4]);
 
 			for (const player of [1, 2, 3, 4]) {
 				const expectedPlayerMessages = [
@@ -165,7 +165,7 @@ describe('ServerStream', function () {
 				...createSplit(2, '|-heal|p2a: Rhyperior|420/420', '|-heal|p2a: Rhyperior|100/100'),
 				...createSplit(2, '|-start|p2a: Aerodactyl|ability: Pressure', ''),
 			].join('\n');
-			const actualChannelMessages = extractChannelMessages(messages);
+			const actualChannelMessages = extractChannelMessages(messages, [omniscientPlayer, spectatorPlayer, 1, 2]);
 
 			const expectedOmniscientPlayerMessages = [
 				'|-heal|p1a: Rhyperior|420/420',
@@ -192,6 +192,30 @@ describe('ServerStream', function () {
 			assert.equal(actualChannelMessages[1].join('\n'), expectedPlayer1Messages);
 			assert.equal(actualChannelMessages[2].join('\n'), expectedPlayer2Messages);
 			assert.equal(actualChannelMessages[spectatorPlayer].join('\n'), expectedSpectatorMessages);
+		});
+
+		it('should not extract channel messages for unspecified channels', function () {
+			const messages = [
+				...createSplit(1, '|-heal|p1a: Rhyperior|420/420', '|-heal|p1a: Rhyperior|100/100'),
+				...createSplit(2, '|-heal|p2a: Rhyperior|420/420', '|-heal|p2a: Rhyperior|100/100'),
+				...createSplit(3, '|-heal|p3a: Rhyperior|420/420', '|-heal|p3a: Rhyperior|100/100'),
+				...createSplit(4, '|-heal|p4a: Rhyperior|420/420', '|-heal|p4a: Rhyperior|100/100'),
+			].join('\n');
+
+			const expectedOmniscientPlayerMessages = [
+				'|-heal|p1a: Rhyperior|420/420',
+				'|-heal|p2a: Rhyperior|420/420',
+				'|-heal|p3a: Rhyperior|420/420',
+				'|-heal|p4a: Rhyperior|420/420',
+			].join('\n');
+
+			const actualChannelMessages = extractChannelMessages(messages, [omniscientPlayer]);
+			assert.equal(actualChannelMessages[omniscientPlayer].join('\n'), expectedOmniscientPlayerMessages);
+			assert.equal(actualChannelMessages[1].join('\n'), '');
+			assert.equal(actualChannelMessages[2].join('\n'), '');
+			assert.equal(actualChannelMessages[3].join('\n'), '');
+			assert.equal(actualChannelMessages[4].join('\n'), '');
+			assert.equal(actualChannelMessages[spectatorPlayer].join('\n'), '');
 		});
 	});
 });

--- a/test/server/sockets.js
+++ b/test/server/sockets.js
@@ -23,7 +23,7 @@ describe('ServerStream', function () {
 			].join('\n');
 			const actualChannelMessages = extractChannelMessages(messages);
 
-			assert.equal(actualChannelMessages.get(omniscientPlayer).join('\n'), messages);
+			assert.equal(actualChannelMessages[omniscientPlayer].join('\n'), messages);
 		});
 
 		it('should return all privileged messages for an omniscient player', function () {
@@ -42,7 +42,7 @@ describe('ServerStream', function () {
 				'|-start|p4a: Aerodactyl|ability: Pressure',
 			].join('\n');
 
-			assert.equal(actualChannelMessages.get(omniscientPlayer).join('\n'), expectedMessages);
+			assert.equal(actualChannelMessages[omniscientPlayer].join('\n'), expectedMessages);
 		});
 
 		it('should return player-privileged messages for each player', function () {
@@ -55,14 +55,14 @@ describe('ServerStream', function () {
 			const actualChannelMessages = extractChannelMessages(expectedMessages);
 
 			for (const player of [1, 2, 3, 4]) {
-				const actualPlayerMessages = actualChannelMessages.get(player).join('\n');
+				const actualPlayerMessages = actualChannelMessages[player].join('\n');
 				const expectedPlayerMessages = [
 					`|-start|p${player}a: Aerodactyl|ability: Pressure`,
 				].join('\n');
 				assert.equal(actualPlayerMessages, expectedPlayerMessages);
 			}
 
-			assert.equal(actualChannelMessages.get(spectatorPlayer).join('\n'), '');
+			assert.equal(actualChannelMessages[spectatorPlayer].join('\n'), '');
 		});
 
 		it('should return privileged messages with non-privileged messages', function () {
@@ -95,10 +95,10 @@ describe('ServerStream', function () {
 				'|-start|p2b: Hellfrog|ability: Flash Fire',
 			].join('\n');
 
-			assert.equal(actualChannelMessages.get(omniscientPlayer).join('\n'), expectedOmniscientPlayerMessages);
-			assert.equal(actualChannelMessages.get(1).join('\n'), expectedPlayer1Messages);
-			assert.equal(actualChannelMessages.get(2).join('\n'), expectedPlayer2Messages);
-			assert.equal(actualChannelMessages.get(0).join('\n'), expectedSpectatorMessages);
+			assert.equal(actualChannelMessages[omniscientPlayer].join('\n'), expectedOmniscientPlayerMessages);
+			assert.equal(actualChannelMessages[1].join('\n'), expectedPlayer1Messages);
+			assert.equal(actualChannelMessages[2].join('\n'), expectedPlayer2Messages);
+			assert.equal(actualChannelMessages[0].join('\n'), expectedSpectatorMessages);
 		});
 
 		it('should return consecutive player-privileged messages for a player', function () {
@@ -115,9 +115,9 @@ describe('ServerStream', function () {
 				'|-start|p1c: Aerodactyl|ability: Pressure',
 			].join('\n');
 
-			assert.equal(actualChannelMessages.get(omniscientPlayer).join('\n'), expectedPlayerMessages);
-			assert.equal(actualChannelMessages.get(1).join('\n'), expectedPlayerMessages);
-			assert.equal(actualChannelMessages.get(spectatorPlayer).join('\n'), '');
+			assert.equal(actualChannelMessages[omniscientPlayer].join('\n'), expectedPlayerMessages);
+			assert.equal(actualChannelMessages[1].join('\n'), expectedPlayerMessages);
+			assert.equal(actualChannelMessages[spectatorPlayer].join('\n'), '');
 		});
 
 		it('should return shared messages for non-privileged players', function () {
@@ -137,7 +137,7 @@ describe('ServerStream', function () {
 					'|-heal|p4a: Rhyperior|100/100',
 				];
 				expectedPlayerMessages[player - 1] = `|-heal|p${player}a: Rhyperior|420/420`;
-				assert.equal(actualChannelMessages.get(player).join('\n'), expectedPlayerMessages.join('\n'));
+				assert.equal(actualChannelMessages[player].join('\n'), expectedPlayerMessages.join('\n'));
 			}
 
 			const expectedOmniscientPlayerMessages = [
@@ -154,8 +154,8 @@ describe('ServerStream', function () {
 				'|-heal|p4a: Rhyperior|100/100',
 			].join('\n');
 
-			assert.equal(actualChannelMessages.get(omniscientPlayer).join('\n'), expectedOmniscientPlayerMessages);
-			assert.equal(actualChannelMessages.get(spectatorPlayer).join('\n'), expectedSpectatorMessages);
+			assert.equal(actualChannelMessages[omniscientPlayer].join('\n'), expectedOmniscientPlayerMessages);
+			assert.equal(actualChannelMessages[spectatorPlayer].join('\n'), expectedSpectatorMessages);
 		});
 
 		it('should return messages made up of secret and shared messages', function () {
@@ -188,10 +188,10 @@ describe('ServerStream', function () {
 				'|-heal|p2a: Rhyperior|100/100',
 			].join('\n');
 
-			assert.equal(actualChannelMessages.get(omniscientPlayer).join('\n'), expectedOmniscientPlayerMessages);
-			assert.equal(actualChannelMessages.get(1).join('\n'), expectedPlayer1Messages);
-			assert.equal(actualChannelMessages.get(2).join('\n'), expectedPlayer2Messages);
-			assert.equal(actualChannelMessages.get(spectatorPlayer).join('\n'), expectedSpectatorMessages);
+			assert.equal(actualChannelMessages[omniscientPlayer].join('\n'), expectedOmniscientPlayerMessages);
+			assert.equal(actualChannelMessages[1].join('\n'), expectedPlayer1Messages);
+			assert.equal(actualChannelMessages[2].join('\n'), expectedPlayer2Messages);
+			assert.equal(actualChannelMessages[spectatorPlayer].join('\n'), expectedSpectatorMessages);
 		});
 	});
 });


### PR DESCRIPTION
# Overview
Fixes an issue where privileged information via `split` is leaked to spectators. Only observed occurneces happen in gen 3 due to Pressure's mechanics being the only message that doesn't have shared information and the data-stripping regex not handling it well.

## Replication
### Team (for both players)
```
Moltres @ Leftovers  
Ability: Pressure  
EVs: 48 HP  
IVs: 0 Atk  
- Agility  

Claydol @ Choice Band  
Ability: Levitate  
EVs: 56 HP / 252 Spe  
- Protect  
- Facade
```

### Actions
You need to separate clients. Two players and one spectator. When all clients are connected, one player should switch to Moltres and one should switch to Claydol.

## "Raw" Update
Un-processed message before `ServerStream#extractChannel` is applied:
```
|
|t:|1673213422
|split|p2
|switch|p2a: Moltres|Moltres|333/333
|switch|p2a: Moltres|Moltres|100/100
|split|p2
|-ability|p2a: Moltres|Pressure|[silent]

|split|p1
|switch|p1a: Claydol|Claydol|275/275
|switch|p1a: Claydol|Claydol|100/100
|
|upkeep
|turn|2
```

## Current client perspectives (without this PR's changes)
### P1 perspective (player switching in Claydol) [CORRECT]
```
|
|t:|1673213422
|switch|p2a: Moltres|Moltres|100/100
|switch|p1a: Claydol|Claydol|275/275
|
|upkeep
|turn|2
```

### P2 perspective (player switching in Moltres) [CORRECT]
```
|
|t:|1673213422
|switch|p2a: Moltres|Moltres|333/333
|-ability|p2a: Moltres|Pressure|[silent]
|switch|p1a: Claydol|Claydol|100/100
|
|upkeep
|turn|2
```

### Spectator perspective [LEAK]
```
|
|t:|1673213422
|switch|p2a: Moltres|Moltres|100/100
|split|p1
|switch|p1a: Claydol|Claydol|275/275
|switch|p1a: Claydol|Claydol|100/100
|
|upkeep
|turn|2
```



## Client perspectives with PR
### P1 perspective [CORRECT]
```
|
|t:|1673213422
|switch|p2a: Moltres|Moltres|100/100
|switch|p1a: Claydol|Claydol|275/275
|
|upkeep
|turn|2
```

### P2 perspective [CORRECT]
```
|
|t:|1673213422
|switch|p2a: Moltres|Moltres|333/333
|-ability|p2a: Moltres|Pressure|[silent]
|switch|p1a: Claydol|Claydol|100/100
|
|upkeep
|turn|2
```

### Spectator perspective [CORRECT]
```
|
|t:|1673213422
|switch|p2a: Moltres|Moltres|100/100
|switch|p1a: Claydol|Claydol|100/100
|
|upkeep
|turn|2
```

## Additional debugging/verification
The issues lie in the last regex being applied, so I've provided some basic samples to play around with regex either in-server or through something like https://regex101.com/ (using the substitution function is useful). Applying the old replace `replace(/\n\|split\|(?:[^\n]*)\n(?:[^\n]*)\n\n?/g, '\n')` doesn't capture all splits properly. Applying the new replace `replace(/(?<=\n)\|split\|(?:[^\n]*)\n(?:[^\n]*)\n\n?/g, '')` does.
### P1 perspective before enemy secrets are removed
```
|
|t:|1673213422
|switch|p2a: Moltres|Moltres|333/333
|-ability|p2a: Moltres|Pressure|[silent]
|split|p1
|switch|p1a: Claydol|Claydol|275/275
|switch|p1a: Claydol|Claydol|100/100
|
|upkeep
|turn|2
```
### P2 perspective before enemy secrets are removed
```
|
|t:|1673213422
|split|p2
|switch|p2a: Moltres|Moltres|333/333
|switch|p2a: Moltres|Moltres|100/100
|split|p2
|-ability|p2a: Moltres|Pressure|[silent]

|switch|p1a: Claydol|Claydol|275/275
|
|upkeep
|turn|2
```
### Spectator perspective before player secrets are removed
```
|
|t:|1673213422
|split|p2
|switch|p2a: Moltres|Moltres|333/333
|switch|p2a: Moltres|Moltres|100/100
|split|p2
|-ability|p2a: Moltres|Pressure|[silent]

|split|p1
|switch|p1a: Claydol|Claydol|275/275
|switch|p1a: Claydol|Claydol|100/100
|
|upkeep
|turn|2
```

Apologies for the large dump here, this was a weird edge case that was difficult to find by virtue of it being basically 100% Gen 3-specific from my observations. But it would likely occur again if any future gen introduced similar completely secret information.