### PR TITLE
National Dex Ubers: Fix Dragon Ascent preventing Rayquaza from using Terastal

### DIFF
--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1213,7 +1213,11 @@ export const Rulesets: {[k: string]: FormatData} = {
 		onBegin() {
 			this.add('rule', 'Mega Rayquaza Clause: You cannot mega evolve Rayquaza');
 			for (const pokemon of this.getAllPokemon()) {
-				if (pokemon.species.id === 'rayquaza') pokemon.canMegaEvo = null;
+				if (pokemon.species.id === 'rayquaza') {
+					pokemon.canMegaEvo = null;
+					// ability to terastal was determined before the clause activated, causing incorrect behavior
+					pokemon.canTerastallize = this.actions.canTerastallize(pokemon);
+				}
 			}
 		},
 	},


### PR DESCRIPTION
Currently Rayquaza cannot Terastal while knowing Dragon Ascent in National Dex Ubers, even though it cannot Mega Evolve thanks to Mega Rayquaza Clause. 

Because Terastal is handled through a field rather than a method, MRC's failure to update it caused inconsistent behavior. This resolves the inconsistency with gen 8 implementation behavior (Rayquaza was able to dynamax under MRC); as such, Rayquaza should be able to use Terastal when using Dragon Ascent under MRC.

This resolves https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-9441141