### PR TITLE
Gen 1: Fix Bide selections

### DIFF
--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -64,6 +64,16 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				this.add('-activate', pokemon, 'Bide');
 				return false;
 			},
+			onDisableMove(pokemon) {
+				if (!pokemon.hasMove('bide')) {
+					return;
+				}
+				for (const moveSlot of pokemon.moveSlots) {
+					if (moveSlot.id !== 'bide') {
+						pokemon.disableMove(moveSlot.id);
+					}
+				}
+			},
 		},
 		type: "???", // Will look as Normal but it's STAB-less
 	},

--- a/test/sim/moves/bide.js
+++ b/test/sim/moves/bide.js
@@ -12,12 +12,18 @@ describe('Bide [Gen 1]', function () {
 
 	it("Two turn Bide", function () {
 		battle = common.gen(1).createBattle();
-		battle.setPlayer('p1', {team: [{species: "Aerodactyl", moves: ['bide']}]});
+		battle.setPlayer('p1', {team: [{species: "Aerodactyl", moves: ['bide', 'whirlwind']}]});
 		battle.setPlayer('p2', {team: [{species: "Gyarados", moves: ['dragonrage']}]});
 		const aerodactyl = battle.p1.active[0];
 		const gyarados = battle.p2.active[0];
 		battle.makeChoices();
 		assert.equal(aerodactyl.volatiles['bide'].time, 2);
+		// Bide is the only move that can be selected
+		const choices = aerodactyl.getMoveRequestData().moves;
+		assert.equal(choices[0].id, 'bide');
+		assert.false(choices[0].disabled);
+		assert.equal(choices[1].id, 'whirlwind');
+		assert(choices[1].disabled);
 		battle.makeChoices();
 		battle.makeChoices();
 		assert(!aerodactyl.volatiles['bide']);
@@ -110,12 +116,15 @@ describe('Bide [Gen 1]', function () {
 
 	it("Bide's duration is paused when disabled", function () {
 		battle = common.gen(1).createBattle({seed: [1, 1, 1, 0]});
-		battle.setPlayer('p1', {team: [{species: "Aerodactyl", moves: ['bide']}]});
+		battle.setPlayer('p1', {team: [{species: "Aerodactyl", moves: ['bide', 'whirlwind']}]});
 		battle.setPlayer('p2', {team: [{species: "Voltorb", moves: ['disable']}]});
 		const aerodactyl = battle.p1.active[0];
 		battle.makeChoices();
 		assert.equal(aerodactyl.volatiles['bide'].time, 3);
 		assert.equal(aerodactyl.volatiles['disable'].move, 'bide');
+		// Struggle is the choice
+		const choices = aerodactyl.getMoveRequestData().moves;
+		assert.equal(choices[0].id, 'struggle');
 		assert(aerodactyl.volatiles['disable'].time > 1);
 		battle.makeChoices();
 		assert.equal(aerodactyl.volatiles['bide'].time, 3);


### PR DESCRIPTION
This patch fixes Bide so that it restricts the choices of the Pokemon using it, by disabling the Pokemon's other choices. If a Bide user is disabled, its only choice will be Struggle.