### PR TITLE
VGC/BSS: Add Series 2

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -140,11 +140,19 @@ export const Formats: FormatList = [
 		banlist: ['Crucibellite'],
 	},
 	{
+		name: "[Gen 9] Battle Stadium Singles Series 2",
+
+		mod: 'gen9',
+		searchShow: false,
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer'],
+		banlist: ['Sub-Legendary'],
+	},
+	{
 		name: "[Gen 9] Battle Stadium Singles Series 1",
 
 		mod: 'gen9',
 		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer'],
-		banlist: ['Sub-Legendary'],
+		banlist: ['Sub-Legendary', 'Paradox'],
 	},
 	{
 		name: "[Gen 9] Custom Game",
@@ -223,12 +231,20 @@ export const Formats: FormatList = [
 		banlist: ['Koraidon', 'Miraidon', 'Commander', 'Focus Sash', 'King\'s Rock', 'Ally Switch', 'Final Gambit', 'Moody', 'Perish Song', 'Swagger'],
 	},
 	{
-		name: "[Gen 9] VGC 2023 Series 1",
+		name: "[Gen 9] VGC 2023 Series 2",
 
 		mod: 'gen9',
 		gameType: 'doubles',
 		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer'],
 		banlist: ['Sub-Legendary'],
+	},
+	{
+		name: "[Gen 9] VGC 2023 Series 1",
+
+		mod: 'gen9',
+		gameType: 'doubles',
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer'],
+		banlist: ['Sub-Legendary', 'Paradox'],
 	},
 	{
 		name: "[Gen 9] Doubles Custom Game",

--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -17662,7 +17662,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 2.2,
 		weightkg: 320,
 		color: "Purple",
-		tags: ["Sub-Legendary", "Paradox"],
+		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	screamtail: {
@@ -17675,7 +17675,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 1.2,
 		weightkg: 8,
 		color: "Pink",
-		tags: ["Sub-Legendary", "Paradox"],
+		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	brutebonnet: {
@@ -17688,7 +17688,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 1.2,
 		weightkg: 21,
 		color: "Gray",
-		tags: ["Sub-Legendary", "Paradox"],
+		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	fluttermane: {
@@ -17701,7 +17701,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 1.4,
 		weightkg: 4,
 		color: "Gray",
-		tags: ["Sub-Legendary", "Paradox"],
+		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	slitherwing: {
@@ -17714,7 +17714,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 3.2,
 		weightkg: 92,
 		color: "Red",
-		tags: ["Sub-Legendary", "Paradox"],
+		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	sandyshocks: {
@@ -17727,7 +17727,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 2.3,
 		weightkg: 60,
 		color: "Gray",
-		tags: ["Sub-Legendary", "Paradox"],
+		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	irontreads: {
@@ -17740,7 +17740,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 0.9,
 		weightkg: 240,
 		color: "Gray",
-		tags: ["Sub-Legendary", "Paradox"],
+		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	ironbundle: {
@@ -17753,7 +17753,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 0.6,
 		weightkg: 11,
 		color: "Red",
-		tags: ["Sub-Legendary", "Paradox"],
+		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	ironhands: {
@@ -17766,7 +17766,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 1.8,
 		weightkg: 380.7,
 		color: "Gray",
-		tags: ["Sub-Legendary", "Paradox"],
+		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	ironjugulis: {
@@ -17779,7 +17779,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 1.3,
 		weightkg: 111,
 		color: "Blue",
-		tags: ["Sub-Legendary", "Paradox"],
+		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	ironmoth: {
@@ -17792,7 +17792,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 1.2,
 		weightkg: 36,
 		color: "Yellow",
-		tags: ["Sub-Legendary", "Paradox"],
+		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	ironthorns: {
@@ -17805,7 +17805,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 1.6,
 		weightkg: 303,
 		color: "Green",
-		tags: ["Sub-Legendary", "Paradox"],
+		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	frigibax: {
@@ -17955,7 +17955,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 2,
 		weightkg: 380,
 		color: "Green",
-		tags: ["Sub-Legendary", "Paradox"],
+		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	ironvaliant: {
@@ -17968,7 +17968,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 1.4,
 		weightkg: 35,
 		color: "White",
-		tags: ["Sub-Legendary", "Paradox"],
+		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	koraidon: {


### PR DESCRIPTION
Also refactors Paradox Pokemon to not count as Sub-Legendary, since we have the tag for Paradox Pokemon now and it was just an assumption they were classified as Sub-Legendary.