### PR TITLE
Fix "Opponent withdrew" message to ignore nicknames when requested.

### DIFF
--- a/data/text/default.ts
+++ b/data/text/default.ts
@@ -14,7 +14,7 @@ export const DefaultText: {[k: string]: DefaultText} = {
 		turn: "== Turn [NUMBER] ==",
 		switchIn: "[TRAINER] sent out [FULLNAME]!",
 		switchInOwn: "Go! [FULLNAME]!",
-		switchOut: "[TRAINER] withdrew [NICKNAME]!",
+		switchOut: "[TRAINER] withdrew [FULLNAME]!",
 		switchOutOwn: "[NICKNAME], come back!",
 		drag: "[FULLNAME] was dragged out!",
 		faint: "[POKEMON] fainted!",


### PR DESCRIPTION
- Changed "withdrew" message to use FULLNAME instead of NICKNAME

When ignoring nicknames, the "Opponent withdrew [pokemon]" sentence still used the nickname, which is confusing.