### PR TITLE
Gen 1: Fix Thrash and Rage mechanics

### DIFF
--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -236,6 +236,9 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 				this.queue.changeAction(pokemon, {choice: 'move', moveid: move.id});
 			}
 		},
+		onSourceAccuracy() {
+			return (this.effectState.accuracy + 0.5) * 100 / 255;
+		},
 	},
 	twoturnmove: {
 		// Skull Bash, Solar Beam, ...

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -224,15 +224,38 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 		onStart() {},
 	},
 	lockedmove: {
+		// Thrash and Petal Dance.
+		name: 'lockedmove',
 		// Outrage, Thrash, Petal Dance...
-		inherit: true,
 		durationCallback() {
 			return this.random(3, 5);
+		},
+		onResidual(target) {
+			if ((target.lastMove && target.lastMove.id === 'struggle') || target.status === 'slp') {
+				// don't lock, and bypass confusion for calming
+				delete target.volatiles['lockedmove'];
+			}
+		},
+		onStart(target, source, effect) {
+			this.effectState.move = effect.id;
 		},
 		onEnd(target) {
 			// Confusion begins even if already confused
 			delete target.volatiles['confusion'];
 			target.addVolatile('confusion');
+		},
+		onLockMove(pokemon) {
+			return this.effectState.move;
+		},
+		onMoveAborted(pokemon) {
+			delete pokemon.volatiles['lockedmove'];
+		},
+		onBeforeTurn(pokemon) {
+			const move = this.dex.moves.get(this.effectState.move);
+			if (move.id) {
+				this.debug('Forcing into ' + move.id);
+				this.queue.changeAction(pokemon, {choice: 'move', moveid: move.id});
+			}
 		},
 	},
 	twoturnmove: {

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -221,12 +221,9 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 	lockedmove: {
 		// Thrash and Petal Dance.
 		name: 'lockedmove',
-		// Outrage, Thrash, Petal Dance...
-		durationCallback() {
-			return this.random(3, 5);
-		},
 		onStart(target, source, effect) {
 			this.effectState.move = effect.id;
+			this.effectState.time = this.random(2, 4);
 		},
 		onEnd(target) {
 			// Confusion begins even if already confused
@@ -241,6 +238,12 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 			if (move.id) {
 				this.debug('Forcing into ' + move.id);
 				this.queue.changeAction(pokemon, {choice: 'move', moveid: move.id});
+			}
+		},
+		onBeforeMove(pokemon, t, move) {
+			this.effectState.time--;
+			if (!this.effectState.time) {
+				pokemon.removeVolatile('lockedmove');
 			}
 		},
 	},

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -236,9 +236,6 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 				this.queue.changeAction(pokemon, {choice: 'move', moveid: move.id});
 			}
 		},
-		onBeforeMove() {
-			this.effectState.time--;
-		},
 	},
 	twoturnmove: {
 		// Skull Bash, Solar Beam, ...

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -225,11 +225,6 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 			this.effectState.move = effect.id;
 			this.effectState.time = this.random(2, 4);
 		},
-		onEnd(target) {
-			// Confusion begins even if already confused
-			delete target.volatiles['confusion'];
-			target.addVolatile('confusion');
-		},
 		onLockMove() {
 			return this.effectState.move;
 		},
@@ -240,10 +235,13 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 				this.queue.changeAction(pokemon, {choice: 'move', moveid: move.id});
 			}
 		},
-		onBeforeMove(pokemon, t, move) {
+		onBeforeMove(pokemon) {
 			this.effectState.time--;
 			if (!this.effectState.time) {
 				pokemon.removeVolatile('lockedmove');
+				// Confusion begins even if already confused
+				delete pokemon.volatiles['confusion'];
+				pokemon.addVolatile('confusion');
 			}
 		},
 	},

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -236,9 +236,6 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 				this.queue.changeAction(pokemon, {choice: 'move', moveid: move.id});
 			}
 		},
-		onSourceAccuracy() {
-			return (this.effectState.accuracy + 0.5) * 100 / 255;
-		},
 	},
 	twoturnmove: {
 		// Skull Bash, Solar Beam, ...

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -224,6 +224,7 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 		onStart(target, source, effect) {
 			this.effectState.move = effect.id;
 			this.effectState.time = this.random(2, 4);
+			this.effectState.accuracy = 255;
 		},
 		onLockMove() {
 			return this.effectState.move;

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -199,11 +199,6 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 			const duration = this.sample([2, 2, 2, 3, 3, 3, 4, 5]);
 			return duration;
 		},
-		onResidual(target) {
-			if (target.lastMove && target.lastMove.id === 'struggle' || target.status === 'slp') {
-				delete target.volatiles['partialtrappinglock'];
-			}
-		},
 		onStart(target, source, effect) {
 			this.effectState.move = effect.id;
 		},
@@ -230,12 +225,6 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 		durationCallback() {
 			return this.random(3, 5);
 		},
-		onResidual(target) {
-			if ((target.lastMove && target.lastMove.id === 'struggle') || target.status === 'slp') {
-				// don't lock, and bypass confusion for calming
-				delete target.volatiles['lockedmove'];
-			}
-		},
 		onStart(target, source, effect) {
 			this.effectState.move = effect.id;
 		},
@@ -244,11 +233,8 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 			delete target.volatiles['confusion'];
 			target.addVolatile('confusion');
 		},
-		onLockMove(pokemon) {
+		onLockMove() {
 			return this.effectState.move;
-		},
-		onMoveAborted(pokemon) {
-			delete pokemon.volatiles['lockedmove'];
 		},
 		onBeforeTurn(pokemon) {
 			const move = this.dex.moves.get(this.effectState.move);

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -235,14 +235,8 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 				this.queue.changeAction(pokemon, {choice: 'move', moveid: move.id});
 			}
 		},
-		onBeforeMove(pokemon) {
+		onBeforeMove() {
 			this.effectState.time--;
-			if (!this.effectState.time) {
-				pokemon.removeVolatile('lockedmove');
-				// Confusion begins even if already confused
-				delete pokemon.volatiles['confusion'];
-				pokemon.addVolatile('confusion');
-			}
 		},
 	},
 	twoturnmove: {

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -603,6 +603,9 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					this.boost({atk: 1});
 				}
 			},
+			onSourceAccuracy() {
+				return (this.effectState.accuracy + 0.5) * 100 / 255;
+			},
 		},
 	},
 	razorleaf: {

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -592,7 +592,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		},
 		condition: {
 			// Rage lock
-			duration: 255,
 			onStart(target, source, effect) {
 				this.effectState.move = 'rage';
 			},

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -594,6 +594,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			// Rage lock
 			onStart(target, source, effect) {
 				this.effectState.move = 'rage';
+				this.effectState.accuracy = 255;
 			},
 			onLockMove: 'rage',
 			onHit(target, source, move) {

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -552,6 +552,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		ignoreImmunity: true,
 		basePower: 1,
 	},
+	petaldance: {
+		inherit: true,
+		onMoveFail() {},
+	},
 	poisonsting: {
 		inherit: true,
 		secondary: {
@@ -881,6 +885,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		ignoreImmunity: true,
 		basePower: 1,
+	},
+	thrash: {
+		inherit: true,
+		onMoveFail() {},
 	},
 	thunder: {
 		inherit: true,

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -603,9 +603,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					this.boost({atk: 1});
 				}
 			},
-			onSourceAccuracy() {
-				return (this.effectState.accuracy + 0.5) * 100 / 255;
-			},
 		},
 	},
 	razorleaf: {

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -201,7 +201,6 @@ export const Scripts: ModdedBattleScriptsData = {
 					(!pokemon.side.foe.active[0]?.lastMove || pokemon.side.foe.active[0].lastMove?.id === 'mirrormove')) {
 					// The move is our 'final' move (a failed Mirror Move, or any move that isn't Metronome or Mirror Move).
 					pokemon.side.lastMove = move;
-					this.battle.singleEvent('AfterMove', move, null, pokemon, target, move);
 
 					// If target fainted
 					if (target && target.hp <= 0) {

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -207,7 +207,6 @@ export const Scripts: ModdedBattleScriptsData = {
 						// We remove recharge
 						if (pokemon.volatiles['mustrecharge']) pokemon.removeVolatile('mustrecharge');
 						delete pokemon.volatiles['partialtrappinglock'];
-						pokemon.removeVolatile('twoturnmove');
 					} else if (pokemon.hp) {
 						this.battle.runEvent('AfterMoveSelf', pokemon, target, move);
 					}

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -384,14 +384,23 @@ export const Scripts: ModdedBattleScriptsData = {
 			const boostTable = [25, 28, 33, 40, 50, 66, 100, 150, 200, 250, 300, 350, 400];
 			if (accuracy !== true) {
 				accuracy = Math.floor(accuracy * 255 / 100);
-				// Check also for accuracy modifiers.
-				if (!move.ignoreAccuracy) {
-					accuracy = Math.floor(accuracy * (boostTable[pokemon.boosts.accuracy + 6] / 100));
+				// Rage and Thrash/Petal Dance accuracy bug
+				if (pokemon.volatiles['lockedmove']) accuracy = pokemon.volatiles['lockedmove'].accuracy;
+				if (pokemon.volatiles['rage']) accuracy = pokemon.volatiles['rage'].accuracy;
+
+				// This line is just to satisfy TypeScript, accuracy should never be true at this point
+				if (accuracy !== true) {
+					// Check also for accuracy modifiers.
+					if (!move.ignoreAccuracy) {
+						accuracy = Math.floor(accuracy * (boostTable[pokemon.boosts.accuracy + 6] / 100));
+					}
+					if (!move.ignoreEvasion) {
+						accuracy = Math.floor(accuracy * (boostTable[-target.boosts.evasion + 6] / 100));
+					}
+					accuracy = this.battle.clampIntRange(accuracy, 1, 255);
 				}
-				if (!move.ignoreEvasion) {
-					accuracy = Math.floor(accuracy * (boostTable[-target.boosts.evasion + 6] / 100));
-				}
-				accuracy = Math.min(accuracy, 255);
+				if (pokemon.volatiles['lockedmove']) pokemon.volatiles['lockedmove'].accuracy = accuracy;
+				if (pokemon.volatiles['rage']) pokemon.volatiles['rage'].accuracy = accuracy;
 			}
 			accuracy = this.battle.runEvent('Accuracy', target, pokemon, move, accuracy);
 			// Moves that target the user do not suffer from the 1/256 miss chance.

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -128,8 +128,6 @@ export const Scripts: ModdedBattleScriptsData = {
 			this.battle.setActiveMove(move, pokemon, target);
 
 			if (pokemon.moveThisTurn || !this.battle.runEvent('BeforeMove', pokemon, target, move)) {
-				// Rampage moves end without causing confusion
-				delete pokemon.volatiles['lockedmove'];
 				this.battle.clearActiveMove(true);
 				// This is only run for sleep.
 				this.battle.runEvent('AfterMoveSelf', pokemon, target, move);

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -384,27 +384,21 @@ export const Scripts: ModdedBattleScriptsData = {
 			// Calculate true accuracy for gen 1, which uses 0-255.
 			// Gen 1 uses the same boost table for accuracy and evasiveness as every other stat
 			const boostTable = [25, 28, 33, 40, 50, 66, 100, 150, 200, 250, 300, 350, 400];
+			accuracy = this.battle.runEvent('Accuracy', target, pokemon, move, accuracy);
 			if (accuracy !== true) {
 				accuracy = Math.floor(accuracy * 255 / 100);
-				// Rage and Thrash/Petal Dance accuracy bug
-				if (pokemon.volatiles['lockedmove']) accuracy = pokemon.volatiles['lockedmove'].accuracy;
-				if (pokemon.volatiles['rage']) accuracy = pokemon.volatiles['rage'].accuracy;
-
-				// This line is just to satisfy TypeScript, accuracy should never be true at this point
-				if (accuracy !== true) {
-					// Check also for accuracy modifiers.
-					if (!move.ignoreAccuracy) {
-						accuracy = Math.floor(accuracy * (boostTable[pokemon.boosts.accuracy + 6] / 100));
-					}
-					if (!move.ignoreEvasion) {
-						accuracy = Math.floor(accuracy * (boostTable[-target.boosts.evasion + 6] / 100));
-					}
-					accuracy = this.battle.clampIntRange(accuracy, 1, 255);
+				// Check also for accuracy modifiers.
+				if (!move.ignoreAccuracy) {
+					accuracy = Math.floor(accuracy * (boostTable[pokemon.boosts.accuracy + 6] / 100));
 				}
+				if (!move.ignoreEvasion) {
+					accuracy = Math.floor(accuracy * (boostTable[-target.boosts.evasion + 6] / 100));
+				}
+				accuracy = this.battle.clampIntRange(accuracy, 1, 255);
+				// Store the accuracy for Rage and Thrash/Petal Dance accuracy bug
 				if (pokemon.volatiles['lockedmove']) pokemon.volatiles['lockedmove'].accuracy = accuracy;
 				if (pokemon.volatiles['rage']) pokemon.volatiles['rage'].accuracy = accuracy;
 			}
-			accuracy = this.battle.runEvent('Accuracy', target, pokemon, move, accuracy);
 			// Moves that target the user do not suffer from the 1/256 miss chance.
 			if (move.target === 'self' && accuracy !== true) accuracy++;
 			// 1/256 chance of missing always, no matter what. Besides the aforementioned exceptions.

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -320,6 +320,20 @@ export const Scripts: ModdedBattleScriptsData = {
 		tryMoveHit(target, pokemon, move) {
 			let damage: number | false | undefined = 0;
 
+			// Deal with Thrashing effect here
+			if (move?.self?.volatileStatus === 'lockedmove') {
+				if (pokemon.volatiles['lockedmove']) {
+					if (!pokemon.volatiles['lockedmove'].time) {
+						pokemon.removeVolatile('lockedmove');
+						// Confusion begins even if already confused
+						delete pokemon.volatiles['confusion'];
+						pokemon.addVolatile('confusion');
+					}
+				} else {
+					pokemon.addVolatile('lockedmove', pokemon, move);
+				}
+			}
+
 			// First, check if the target is semi-invulnerable
 			let hitResult = this.battle.runEvent('Invulnerability', target, pokemon, move);
 			if (hitResult === false) {
@@ -649,7 +663,8 @@ export const Scripts: ModdedBattleScriptsData = {
 
 			// Here's where self effects are applied.
 			const doSelf = (targetHadSub && targetHasSub) || !targetHadSub;
-			if (moveData.self && (doSelf || moveData.self.volatileStatus === 'partialtrappinglock')) {
+			if (moveData.self && (moveData.self.volatileStatus !== 'lockedmove') &&
+				(doSelf || moveData.self.volatileStatus === 'partialtrappinglock')) {
 				this.moveHit(pokemon, pokemon, move, moveData.self, isSecondary, true);
 			}
 

--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -384,21 +384,27 @@ export const Scripts: ModdedBattleScriptsData = {
 			// Calculate true accuracy for gen 1, which uses 0-255.
 			// Gen 1 uses the same boost table for accuracy and evasiveness as every other stat
 			const boostTable = [25, 28, 33, 40, 50, 66, 100, 150, 200, 250, 300, 350, 400];
-			accuracy = this.battle.runEvent('Accuracy', target, pokemon, move, accuracy);
 			if (accuracy !== true) {
 				accuracy = Math.floor(accuracy * 255 / 100);
-				// Check also for accuracy modifiers.
-				if (!move.ignoreAccuracy) {
-					accuracy = Math.floor(accuracy * (boostTable[pokemon.boosts.accuracy + 6] / 100));
+				// Rage and Thrash/Petal Dance accuracy bug
+				if (pokemon.volatiles['lockedmove']) accuracy = pokemon.volatiles['lockedmove'].accuracy;
+				if (pokemon.volatiles['rage']) accuracy = pokemon.volatiles['rage'].accuracy;
+
+				// This line is just to satisfy TypeScript, accuracy should never be true at this point
+				if (accuracy !== true) {
+					// Check also for accuracy modifiers.
+					if (!move.ignoreAccuracy) {
+						accuracy = Math.floor(accuracy * (boostTable[pokemon.boosts.accuracy + 6] / 100));
+					}
+					if (!move.ignoreEvasion) {
+						accuracy = Math.floor(accuracy * (boostTable[-target.boosts.evasion + 6] / 100));
+					}
+					accuracy = this.battle.clampIntRange(accuracy, 1, 255);
 				}
-				if (!move.ignoreEvasion) {
-					accuracy = Math.floor(accuracy * (boostTable[-target.boosts.evasion + 6] / 100));
-				}
-				accuracy = this.battle.clampIntRange(accuracy, 1, 255);
-				// Store the accuracy for Rage and Thrash/Petal Dance accuracy bug
 				if (pokemon.volatiles['lockedmove']) pokemon.volatiles['lockedmove'].accuracy = accuracy;
 				if (pokemon.volatiles['rage']) pokemon.volatiles['rage'].accuracy = accuracy;
 			}
+			accuracy = this.battle.runEvent('Accuracy', target, pokemon, move, accuracy);
 			// Moves that target the user do not suffer from the 1/256 miss chance.
 			if (move.target === 'self' && accuracy !== true) accuracy++;
 			// 1/256 chance of missing always, no matter what. Besides the aforementioned exceptions.

--- a/data/mods/gen1stadium/moves.ts
+++ b/data/mods/gen1stadium/moves.ts
@@ -161,7 +161,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		},
 		condition: {
 			// Rage lock
-			duration: 255,
 			onStart(target, source, effect) {
 				this.effectState.move = 'rage';
 			},

--- a/test/sim/moves/rage.js
+++ b/test/sim/moves/rage.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Rage [Gen 1]', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it("Rage accuracy bug", function () {
+		battle = common.gen(1).createBattle({seed: [1, 1, 1, 0]});
+		battle.setPlayer('p1', {team: [{species: "Nidoking", moves: ['rage']}]});
+		battle.setPlayer('p2', {team: [{species: "Aerodactyl", moves: ['doubleteam']}]});
+		const nidoking = battle.p1.active[0];
+		battle.makeChoices();
+		assert.equal(nidoking.volatiles['rage'].accuracy, 255);
+		battle.makeChoices();
+		assert.equal(nidoking.volatiles['rage'].accuracy, 127);
+		assert(battle.log.some(line => line.includes('-miss|p1a: Nidoking')));
+	});
+});

--- a/test/sim/moves/thrash.js
+++ b/test/sim/moves/thrash.js
@@ -88,4 +88,16 @@ describe('Thrash [Gen 1]', function () {
 		battle.makeChoices();
 		assert.equal(nidoking.volatiles['lockedmove'].time, 3);
 	});
+
+	it("Thrash accuracy bug", function () {
+		battle = common.gen(1).createBattle({seed: [1, 1, 1, 1]});
+		battle.setPlayer('p1', {team: [{species: "Nidoking", moves: ['thrash']}]});
+		battle.setPlayer('p2', {team: [{species: "Aerodactyl", moves: ['doubleteam']}]});
+		const nidoking = battle.p1.active[0];
+		battle.makeChoices();
+		assert.equal(nidoking.volatiles['lockedmove'].accuracy, 168);
+		battle.makeChoices();
+		assert.equal(nidoking.volatiles['lockedmove'].accuracy, 84);
+		assert(battle.log.some(line => line.includes('-miss|p1a: Nidoking')));
+	});
 });

--- a/test/sim/moves/thrash.js
+++ b/test/sim/moves/thrash.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Thrash [Gen 1]', function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it("Three turn Thrash", function () {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', {team: [{species: "Nidoking", moves: ['thrash']}]});
+		battle.setPlayer('p2', {team: [{species: "Golem", moves: ['splash']}]});
+		const nidoking = battle.p1.active[0];
+		battle.makeChoices();
+		assert.equal(nidoking.volatiles['lockedmove'].time, 2);
+		battle.makeChoices();
+		battle.makeChoices();
+		assert(!nidoking.volatiles['lockedmove']);
+		assert(nidoking.volatiles['confusion']);
+	});
+
+	it("Four turn Thrash", function () {
+		battle = common.gen(1).createBattle({seed: [1, 1, 1, 1]});
+		battle.setPlayer('p1', {team: [{species: "Nidoking", moves: ['thrash']}]});
+		battle.setPlayer('p2', {team: [{species: "Golem", moves: ['splash']}]});
+		const nidoking = battle.p1.active[0];
+		battle.makeChoices();
+		assert.equal(nidoking.volatiles['lockedmove'].time, 3);
+		battle.makeChoices();
+		battle.makeChoices();
+		battle.makeChoices();
+		assert(!nidoking.volatiles['lockedmove']);
+		assert(nidoking.volatiles['confusion']);
+	});
+
+	it("Thrash locks the user in, even if it targets a semi-invulnerable foe", function () {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', {team: [{species: "Nidoking", moves: ['thrash']}]});
+		battle.setPlayer('p2', {team: [{species: "Aerodactyl", moves: ['fly']}]});
+		const nidoking = battle.p1.active[0];
+		battle.makeChoices();
+		assert(nidoking.volatiles['lockedmove']);
+	});
+
+	it("Thrash locks the user in, even if it targets a Ghost type", function () {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', {team: [{species: "Nidoking", moves: ['thrash']}]});
+		battle.setPlayer('p2', {team: [{species: "Gengar", moves: ['splash']}]});
+		const nidoking = battle.p1.active[0];
+		battle.makeChoices();
+		assert(nidoking.volatiles['lockedmove']);
+	});
+});

--- a/test/sim/moves/thrash.js
+++ b/test/sim/moves/thrash.js
@@ -54,4 +54,15 @@ describe('Thrash [Gen 1]', function () {
 		battle.makeChoices();
 		assert(nidoking.volatiles['lockedmove']);
 	});
+
+	it("Thrash locks the user in, even if it targets and breaks a Substitute", function () {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', {team: [{species: "Nidoking", moves: ['thrash']}]});
+		battle.setPlayer('p2', {team: [{species: "Alakazam", moves: ['substitute']}]});
+		const nidoking = battle.p1.active[0];
+		const alakazam = battle.p2.active[0];
+		battle.makeChoices();
+		assert(nidoking.volatiles['lockedmove']);
+		assert(alakazam.subFainted);
+	});
 });

--- a/test/sim/moves/thrash.js
+++ b/test/sim/moves/thrash.js
@@ -76,4 +76,16 @@ describe('Thrash [Gen 1]', function () {
 			assert.equal(nidoking.volatiles['lockedmove'].time, 2);
 		}
 	});
+
+	it("Thrash is paused when disabled", function () {
+		battle = common.gen(1).createBattle({seed: [1, 1, 1, 1]});
+		battle.setPlayer('p1', {team: [{species: "Nidoking", moves: ['thrash']}]});
+		battle.setPlayer('p2', {team: [{species: "Golem", moves: ['disable']}]});
+		const nidoking = battle.p1.active[0];
+		battle.makeChoices();
+		assert.equal(nidoking.volatiles['lockedmove'].time, 3);
+		assert(nidoking.volatiles['disable'].time > 1);
+		battle.makeChoices();
+		assert.equal(nidoking.volatiles['lockedmove'].time, 3);
+	});
 });

--- a/test/sim/moves/thrash.js
+++ b/test/sim/moves/thrash.js
@@ -65,4 +65,15 @@ describe('Thrash [Gen 1]', function () {
 		assert(nidoking.volatiles['lockedmove']);
 		assert(alakazam.subFainted);
 	});
+
+	it("Thrash is paused when asleep or frozen", function () {
+		battle = common.gen(1).createBattle();
+		battle.setPlayer('p1', {team: [{species: "Nidoking", moves: ['thrash']}]});
+		battle.setPlayer('p2', {team: [{species: "Parasect", moves: ['spore']}]});
+		const nidoking = battle.p1.active[0];
+		for (let i = 0; i < 10; i++) {
+			battle.makeChoices();
+			assert.equal(nidoking.volatiles['lockedmove'].time, 2);
+		}
+	});
 });


### PR DESCRIPTION
This patch fixes thrashing moves' mechanics in Gen 1:

- Thrash will now lock the player in no matter what. Previously it would not lock the player if the move hits and breaks a substitute.
- Thrash is now paused when the user is asleep, frozen, flinching, or partially trapped.
- Thrash is now paused when the user has Thrash disabled.

It also implements the Thrash and Rage accuracy bug: https://www.youtube.com/watch?v=NC5gbJeExbs