### PR TITLE
Gen 1-2: Fix Mirror Move description

### DIFF
--- a/data/text/moves.ts
+++ b/data/text/moves.ts
@@ -4097,10 +4097,10 @@ export const MovesText: {[k: string]: MoveText} = {
 			desc: "The user uses the last move that successfully targeted the user. The copied move is used with no specific target. Fails if no move has targeted the user, if the move missed, failed, or had no effect on the user, or if the move cannot be copied by this move.",
 		},
 		gen2: {
-			desc: "The user uses the last move used by the target. Fails if the target has not made a move, or if the last move used was Metronome, Mimic, Mirror Move, Sketch, Sleep Talk, Transform, or any move the user knows.",
+			desc: "The user uses the last move used by the target. Fails if the target has not made a move since the user switched in, or if the last move used was Metronome, Mimic, Mirror Move, Sketch, Sleep Talk, Transform, or any move the user knows.",
 		},
 		gen1: {
-			desc: "The user uses the last move used by the target. Fails if the target has not made a move, or if the last move used was Mirror Move.",
+			desc: "The user uses the last move used by the target. Fails if the target has not made a move since the user switched in, or if the last move used was Mirror Move.",
 		},
 	},
 	mirrorshot: {


### PR DESCRIPTION
Corrects the description of Mirror Move in Gens 1-2. Mirror Move's behavior was fixed in the PR: https://github.com/smogon/pokemon-showdown/pull/9243