### PR TITLE
Terastal information is no longer sent to the client for Pokemon that cannot terastallize.

### DIFF
--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1085,7 +1085,7 @@ export class Pokemon {
 			entry.commanding = !!this.volatiles['commanding'] && !this.fainted;
 			entry.reviving = this.isActive && !!this.side.slotConditions[this.position]['revivalblessing'];
 		}
-		if (this.battle.gen === 9) {
+		if (this.battle.gen === 9 && this.canTerastallize) {
 			entry.teraType = this.teraType;
 			entry.terastallized = this.terastallized || '';
 		}


### PR DESCRIPTION
This includes: 

* when terastal has already been used 
* when terastal is banned 
* when terastal is unusuable due to other mechanics (natdex) 

This should also resolve smogon/pokemon-showdown-client#2086