### PR TITLE
Gen 2-7 Random Battles: add limit of 3 Pokemon weak to each type

### DIFF
--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -589,6 +589,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		const tierCount: {[k: string]: number} = {};
 		const typeCount: {[k: string]: number} = {};
 		const typeComboCount: {[k: string]: number} = {};
+		const typeWeaknesses: {[k: string]: number} = {};
 		const teamDetails: RandomTeamsTypes.TeamDetails = {};
 
 		const pokemonPool = this.getPokemonPool(type, pokemon, isMonotype);
@@ -625,6 +626,19 @@ export class RandomGen3Teams extends RandomGen4Teams {
 				}
 				if (skip) continue;
 
+				// Limit three weak to any type
+				for (const typeName of this.dex.types.names()) {
+					// it's weak to the type
+					if (this.dex.getEffectiveness(typeName, species) > 0) {
+						if (!typeWeaknesses[typeName]) typeWeaknesses[typeName] = 0;
+						if (typeWeaknesses[typeName] >= 3 * limitFactor) {
+							skip = true;
+							break;
+						}
+					}
+				}
+				if (skip) continue;
+
 				// Limit one of any type combination
 				if (!this.forceMonotype && typeComboCount[typeCombo] >= 1 * limitFactor) continue;
 			}
@@ -655,6 +669,14 @@ export class RandomGen3Teams extends RandomGen4Teams {
 				typeComboCount[typeCombo]++;
 			} else {
 				typeComboCount[typeCombo] = 1;
+			}
+
+			// Increment weakness counter
+			for (const typeName of this.dex.types.names()) {
+				// it's weak to the type
+				if (this.dex.getEffectiveness(typeName, species) > 0) {
+					typeWeaknesses[typeName]++;
+				}
 			}
 
 			// Updateeam details

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -811,6 +811,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		const tierCount: {[k: string]: number} = {};
 		const typeCount: {[k: string]: number} = {};
 		const typeComboCount: {[k: string]: number} = {};
+		const typeWeaknesses: {[k: string]: number} = {};
 		const teamDetails: RandomTeamsTypes.TeamDetails = {};
 
 		const pokemonPool = this.getPokemonPool(type, pokemon, isMonotype);
@@ -859,6 +860,19 @@ export class RandomGen5Teams extends RandomGen6Teams {
 					}
 				}
 				if (skip) continue;
+
+				// Limit three weak to any type
+				for (const typeName of this.dex.types.names()) {
+					// it's weak to the type
+					if (this.dex.getEffectiveness(typeName, species) > 0) {
+						if (!typeWeaknesses[typeName]) typeWeaknesses[typeName] = 0;
+						if (typeWeaknesses[typeName] >= 3 * limitFactor) {
+							skip = true;
+							break;
+						}
+					}
+				}
+				if (skip) continue;
 			}
 
 			// Limit one of any type combination, two in Monotype
@@ -903,6 +917,14 @@ export class RandomGen5Teams extends RandomGen6Teams {
 				typeComboCount[typeCombo]++;
 			} else {
 				typeComboCount[typeCombo] = 1;
+			}
+
+			// Increment weakness counter
+			for (const typeName of this.dex.types.names()) {
+				// it's weak to the type
+				if (this.dex.getEffectiveness(typeName, species) > 0) {
+					typeWeaknesses[typeName]++;
+				}
 			}
 
 			// Team details

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1480,6 +1480,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		const tierCount: {[k: string]: number} = {};
 		const typeCount: {[k: string]: number} = {};
 		const typeComboCount: {[k: string]: number} = {};
+		const typeWeaknesses: {[k: string]: number} = {};
 		const teamDetails: RandomTeamsTypes.TeamDetails = {};
 
 		// We make at most two passes through the potential Pokemon pool when creating a team - if the first pass doesn't
@@ -1554,6 +1555,19 @@ export class RandomGen7Teams extends RandomGen8Teams {
 							}
 						}
 						if (skip) continue;
+
+						// Limit three weak to any type
+						for (const typeName of this.dex.types.names()) {
+							// it's weak to the type
+							if (this.dex.getEffectiveness(typeName, species) > 0) {
+								if (!typeWeaknesses[typeName]) typeWeaknesses[typeName] = 0;
+								if (typeWeaknesses[typeName] >= 3 * limitFactor) {
+									skip = true;
+									break;
+								}
+							}
+						}
+						if (skip) continue;
 					}
 
 					// Limit one of any type combination, two in Monotype
@@ -1606,6 +1620,14 @@ export class RandomGen7Teams extends RandomGen8Teams {
 					typeComboCount[typeCombo]++;
 				} else {
 					typeComboCount[typeCombo] = 1;
+				}
+
+				// Increment weakness counter
+				for (const typeName of this.dex.types.names()) {
+					// it's weak to the type
+					if (this.dex.getEffectiveness(typeName, species) > 0) {
+						typeWeaknesses[typeName]++;
+					}
 				}
 
 				// Track what the team has


### PR DESCRIPTION
Approved by Random Battles staff

Adds the limit of 3 Pokemon per team weak to a single type to Gens 2-7. The limit is already present in Gens 8 and 9. Several million teams have been generated for each gen with no issue.

https://discord.com/channels/294651453279174656/763039178211721236/1063173009399091210