### PR TITLE
Chat commands: Add support for /dt9

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -848,6 +848,7 @@ export const commands: Chat.ChatCommands = {
 	dt6: 'details',
 	dt7: 'details',
 	dt8: 'details',
+	dt9: 'details',
 	details(target) {
 		if (!target) return this.parse('/help details');
 		this.run('data');


### PR DESCRIPTION
`/dt9` is not quite the same as `/dt`, as `/dt` defaults to the gen of the game you're in. Also, `/help dt` indicates that `/dt9` should be supported.