### PR TITLE
Gen 1 Thrash: Confusion from thrashing should be silently added

### DIFF
--- a/data/mods/gen1/scripts.ts
+++ b/data/mods/gen1/scripts.ts
@@ -326,7 +326,7 @@ export const Scripts: ModdedBattleScriptsData = {
 						// Confusion begins even if already confused.
 						// Remove lockedmove volatile when dealing with after move effects.
 						delete pokemon.volatiles['confusion'];
-						pokemon.addVolatile('confusion');
+						pokemon.addVolatile('confusion', pokemon, this.dex.conditions.get('lockedmove'));
 					}
 				} else {
 					pokemon.addVolatile('lockedmove', pokemon, move);

--- a/test/sim/moves/thrash.js
+++ b/test/sim/moves/thrash.js
@@ -19,7 +19,7 @@ describe('Thrash [Gen 1]', function () {
 		assert.equal(nidoking.volatiles['lockedmove'].time, 2);
 		battle.makeChoices();
 		battle.makeChoices();
-		assert(battle.log.some(line => line === '|-start|p1a: Nidoking|confusion|[silent]'));
+		assert(battle.log.includes('|-start|p1a: Nidoking|confusion|[silent]'));
 		assert(!nidoking.volatiles['lockedmove']);
 		assert(nidoking.volatiles['confusion']);
 	});
@@ -34,7 +34,7 @@ describe('Thrash [Gen 1]', function () {
 		battle.makeChoices();
 		battle.makeChoices();
 		battle.makeChoices();
-		assert(battle.log.some(line => line === '|-start|p1a: Nidoking|confusion|[silent]'));
+		assert(battle.log.includes('|-start|p1a: Nidoking|confusion|[silent]'));
 		assert(!nidoking.volatiles['lockedmove']);
 		assert(nidoking.volatiles['confusion']);
 	});

--- a/test/sim/moves/thrash.js
+++ b/test/sim/moves/thrash.js
@@ -19,6 +19,7 @@ describe('Thrash [Gen 1]', function () {
 		assert.equal(nidoking.volatiles['lockedmove'].time, 2);
 		battle.makeChoices();
 		battle.makeChoices();
+		assert(battle.log.some(line => line === '|-start|p1a: Nidoking|confusion|[silent]'));
 		assert(!nidoking.volatiles['lockedmove']);
 		assert(nidoking.volatiles['confusion']);
 	});
@@ -33,6 +34,7 @@ describe('Thrash [Gen 1]', function () {
 		battle.makeChoices();
 		battle.makeChoices();
 		battle.makeChoices();
+		assert(battle.log.some(line => line === '|-start|p1a: Nidoking|confusion|[silent]'));
 		assert(!nidoking.volatiles['lockedmove']);
 		assert(nidoking.volatiles['confusion']);
 	});


### PR DESCRIPTION
Confusion due to fatigue (after thrashing) was incorrectly and unintentionally made non-silent in the previous PR linked below. This fixes it, so that the confusion is once again silent.

https://github.com/smogon/pokemon-showdown/pull/9315