### PR TITLE
Gen 4 Random Battles updates

### DIFF
--- a/data/mods/gen4/formats-data.ts
+++ b/data/mods/gen4/formats-data.ts
@@ -1306,7 +1306,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	claydol: {
-		randomBattleMoves: ["earthquake", "explosion", "icebeam", "lightscreen", "rapidspin", "reflect", "stealthrock"],
+		randomBattleMoves: ["earthquake", "explosion", "icebeam", "psychic", "rapidspin", "stealthrock"],
 		tier: "UU",
 	},
 	lileep: {

--- a/data/mods/gen4/formats-data.ts
+++ b/data/mods/gen4/formats-data.ts
@@ -190,7 +190,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NU",
 	},
 	dugtrio: {
-		randomBattleMoves: ["earthquake", "nightslash", "stoneedge", "substitute", "suckerpunch"],
+		randomBattleMoves: ["earthquake", "nightslash", "stealthrock", "stoneedge", "substitute", "suckerpunch"],
 		tier: "UU",
 	},
 	meowth: {
@@ -893,7 +893,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	octillery: {
-		randomBattleMoves: ["energyball", "fireblast", "icebeam", "substitute", "surf"],
+		randomBattleMoves: ["energyball", "fireblast", "icebeam", "surf", "thunderwave"],
 		tier: "NU",
 	},
 	delibird: {
@@ -1406,7 +1406,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NU",
 	},
 	relicanth: {
-		randomBattleMoves: ["aquatail", "doubleedge", "earthquake", "headsmash", "rockpolish", "stealthrock", "waterfall"],
+		randomBattleMoves: ["doubleedge", "earthquake", "headsmash", "rockpolish", "stealthrock", "waterfall"],
 		tier: "NU",
 	},
 	luvdisc: {

--- a/data/mods/gen4/formats-data.ts
+++ b/data/mods/gen4/formats-data.ts
@@ -1098,7 +1098,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	vigoroth: {
-		randomBattleMoves: ["bulkup", "earthquake", "encore", "focuspunch", "lowkick", "nightslash", "return", "slackoff", "substitute", "suckerpunch"],
+		randomBattleMoves: ["bulkup", "earthquake", "encore", "lowkick", "nightslash", "return", "slackoff", "substitute", "suckerpunch"],
 		tier: "NU",
 	},
 	slaking: {
@@ -1144,7 +1144,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	delcatty: {
-		randomBattleMoves: ["doubleedge", "healbell", "return", "sing", "thunderwave", "wish"],
+		randomBattleMoves: ["healbell", "protect", "return", "sing", "thunderwave", "wish"],
 		tier: "NU",
 	},
 	sableye: {
@@ -1688,7 +1688,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	drapion: {
-		randomBattleMoves: ["aquatail", "crunch", "earthquake", "icefang", "pursuit", "swordsdance", "taunt", "toxicspikes", "whirlwind"],
+		randomBattleMoves: ["aquatail", "crunch", "earthquake", "poisonjab", "pursuit", "swordsdance", "taunt", "toxicspikes", "whirlwind"],
 		tier: "UU",
 	},
 	croagunk: {
@@ -1761,7 +1761,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "Uber",
 	},
 	heatran: {
-		randomBattleMoves: ["dragonpulse", "earthpower", "explosion", "fireblast", "hiddenpowergrass", "lavaplume", "protect", "roar", "stealthrock", "substitute"],
+		randomBattleMoves: ["dragonpulse", "earthpower", "explosion", "fireblast", "hiddenpowergrass", "lavaplume", "protect", "roar", "stealthrock", "substitute", "toxic"],
 		tier: "OU",
 	},
 	regigigas: {
@@ -1776,7 +1776,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		randomBattleMoves: ["aurasphere", "calmmind", "dracometeor", "dragonpulse", "hiddenpowerfire", "outrage", "shadowball", "shadowsneak", "substitute"],
 	},
 	cresselia: {
-		randomBattleMoves: ["calmmind", "hiddenpowerfire", "icebeam", "lightscreen", "moonlight", "psychic", "reflect", "substitute", "thunderwave", "toxic"],
+		randomBattleMoves: ["calmmind", "hiddenpowerfire", "icebeam", "moonlight", "psychic", "thunderwave", "toxic"],
 		tier: "UUBL",
 	},
 	phione: {

--- a/data/mods/gen4/formats-data.ts
+++ b/data/mods/gen4/formats-data.ts
@@ -1604,7 +1604,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	cherrim: {
-		randomBattleMoves: ["aromatherapy", "energyball", "grasswhistle", "hiddenpowerfire", "hiddenpowerground", "synthesis"],
+		randomBattleMoves: ["aromatherapy", "energyball", "hiddenpowerfire", "hiddenpowerground", "synthesis", "toxic"],
 		tier: "NU",
 	},
 	cherrimsunshine: {

--- a/data/mods/gen4/formats-data.ts
+++ b/data/mods/gen4/formats-data.ts
@@ -87,6 +87,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NU",
 	},
 	pikachu: {
+		randomBattleMoves: ["grassknot", "hiddenpowerice", "substitute", "surf", "thunderbolt", "volttackle"],
 		tier: "NU",
 	},
 	raichu: {

--- a/data/mods/gen4/formats-data.ts
+++ b/data/mods/gen4/formats-data.ts
@@ -311,7 +311,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "OU",
 	},
 	farfetchd: {
-		randomBattleMoves: ["leafblade", "nightslash", "return", "slash", "swordsdance", "uturn"],
+		randomBattleMoves: ["leafblade", "nightslash", "return", "swordsdance", "uturn"],
 		tier: "NU",
 	},
 	doduo: {

--- a/data/mods/gen4/formats-data.ts
+++ b/data/mods/gen4/formats-data.ts
@@ -1776,7 +1776,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		randomBattleMoves: ["aurasphere", "calmmind", "dracometeor", "dragonpulse", "hiddenpowerfire", "outrage", "shadowball", "shadowsneak", "substitute"],
 	},
 	cresselia: {
-		randomBattleMoves: ["calmmind", "hiddenpowerfire", "icebeam", "moonlight", "psychic", "thunderwave", "toxic"],
+		randomBattleMoves: ["calmmind", "hiddenpowerfire", "icebeam", "moonlight", "psychic", "substitute", "thunderwave", "toxic"],
 		tier: "UUBL",
 	},
 	phione: {

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -22,10 +22,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 				!counter.get('Bug') && (movePool.includes('bugbuzz') || movePool.includes('megahorn'))
 			),
 			Dark: (movePool, moves, abilities, types, counter) => (
-				((!counter.get('Dark') || (counter.get('Dark') === 1 && moves.has('pursuit'))) &&
-				movePool.includes('suckerpunch') && counter.setupType !== 'Special') ||
-				(!counter.get('Dark') && types.has('Poison'))
-			),
+				(!counter.get('Dark') || (counter.get('Dark') < 2 && moves.has('pursuit') && movePool.includes('suckerpunch'))
+			)),
 			Dragon: (movePool, moves, abilities, types, counter) => !counter.get('Dragon'),
 			Electric: (movePool, moves, abilities, types, counter) => !counter.get('Electric'),
 			Fighting: (movePool, moves, abilities, types, counter) => (
@@ -287,7 +285,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		case 'dragonpulse':
 			return {cull: moves.has('dracometeor') || moves.has('outrage')};
 		case 'crunch': case 'nightslash':
-			return {cull: moves.has('suckerpunch')};
+			return {cull: moves.has('suckerpunch') && !types.has('Dark')};
 		case 'pursuit':
 			return {cull: !!counter.setupType || moves.has('payback')};
 		case 'flashcannon':

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -22,9 +22,9 @@ export class RandomGen4Teams extends RandomGen5Teams {
 				!counter.get('Bug') && (movePool.includes('bugbuzz') || movePool.includes('megahorn'))
 			),
 			Dark: (movePool, moves, abilities, types, counter) => (
-				(!counter.get('Dark') || (counter.get('Dark') === 1 && moves.has('pursuit'))) &&
-				movePool.includes('suckerpunch') &&
-				counter.setupType !== 'Special'
+				((!counter.get('Dark') || (counter.get('Dark') === 1 && moves.has('pursuit'))) &&
+				movePool.includes('suckerpunch') && counter.setupType !== 'Special') ||
+				!counter.get('Dark') && types.has('Poison')
 			),
 			Dragon: (movePool, moves, abilities, types, counter) => !counter.get('Dragon'),
 			Electric: (movePool, moves, abilities, types, counter) => !counter.get('Electric'),
@@ -82,8 +82,26 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			return {cull: counter.get('Physical') + counter.get('Special') < 4};
 		case 'focuspunch':
 			return {cull: !moves.has('substitute') || counter.damagingMoves.size < 2 || moves.has('hammerarm')};
+		case 'lightscreen':
+			if (movePool.length > 1) {
+				const screen = movePool.indexOf('reflect');
+				if (screen >= 0) {
+					this.fastPop(movePool, screen);
+					return {cull: true};
+				}
+			}
+			return {cull: false};
 		case 'raindance':
 			return {cull: abilities.has('Hydration') ? !moves.has('rest') : counter.get('Physical') + counter.get('Special') < 2};
+		case 'reflect':
+			if (movePool.length > 1) {
+				const screen = movePool.indexOf('lightscreen');
+				if (screen >= 0) {
+					this.fastPop(movePool, screen);
+					return {cull: true};
+				}
+			}
+			return {cull: false};
 		case 'refresh':
 			return {cull: !(moves.has('calmmind') && (moves.has('recover') || moves.has('roost')))};
 		case 'rest':
@@ -134,8 +152,9 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			return {cull: !!counter.setupType || moves.has('rest') || moves.has('substitute')};
 		case 'protect':
 			return {cull: (
-				!['Guts', 'Quick Feet', 'Speed Boost'].some(abil => abilities.has(abil)) ||
-				['rest', 'softboiled', 'toxic', 'wish'].some(m => moves.has(m))
+				['rest', 'softboiled'].some(m => moves.has(m)) ||
+				!['Guts', 'Quick Feet', 'Speed Boost'].some(abil => abilities.has(abil)) &&
+				!['toxic', 'wish'].some(m => moves.has(m))
 			)};
 		case 'wish':
 			return {cull: (
@@ -145,7 +164,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			)};
 		case 'rapidspin':
 			return {cull: !!teamDetails.rapidSpin || (!!counter.setupType && counter.get('Physical') + counter.get('Special') < 2)};
-		case 'reflect': case 'lightscreen': case 'fakeout':
+		case 'fakeout':
 			return {cull: !!counter.setupType || !!counter.get('speedsetup') || moves.has('substitute')};
 		case 'spikes':
 			return {cull: !!counter.setupType || !!counter.get('speedsetup') || moves.has('substitute')};
@@ -244,10 +263,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		case 'brickbreak': case 'closecombat': case 'crosschop': case 'lowkick':
 			return {cull: moves.has('substitute') && moves.has('focuspunch')};
 		case 'machpunch':
-			return {cull: (
-				counter.damagingMoves.size <= counter.get('Fighting') ||
-				(types.has('Fighting') && counter.get('stab') < 2 && !abilities.has('Technician'))
-			)};
+			return {cull: (counter.damagingMoves.size <= counter.get('Fighting'))};
 		case 'seismictoss':
 			return {cull: moves.has('nightshade') || counter.get('Physical') + counter.get('Special') >= 1};
 		case 'superpower':
@@ -262,8 +278,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			return {cull: moves.has('psychocut')};
 		case 'rockblast': case 'rockslide':
 			return {cull: moves.has('stoneedge')};
-		case 'shadowclaw':
-			return {cull: moves.has('shadowforce') || moves.has('suckerpunch') && !types.has('Ghost')};
+		case 'shadowclaw': case 'shadowsneak':
+			return {cull: moves.has('suckerpunch') && !types.has('Ghost')};
 		case 'dracometeor':
 			return {cull: moves.has('calmmind') || restTalk || (!!counter.setupType && counter.get('stab') < 2)};
 		case 'dragonclaw':
@@ -645,7 +661,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 					(move.category !== 'Status' || !move.flags.heal) &&
 					(move.category === 'Status' || !types.has(move.type) || (move.basePower && move.basePower < 40 && !move.multihit)) &&
 					// These moves cannot be rejected in favor of a forced move
-					!['judgment', 'sleeptalk'].includes(moveid) &&
+					!['judgment', 'lightscreen', 'reflect', 'sleeptalk'].includes(moveid) &&
 					// Setup-supported moves should only be rejected under specific circumstances
 					(counter.get('physicalsetup') + counter.get('specialsetup') < 2 && (
 						!counter.setupType || counter.setupType === 'Mixed' ||
@@ -659,7 +675,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 					const canRollForcedMoves = (
 						// These moves should always be rolled
 						movePool.includes('spore') || (!Array.from(moves).some(id => recoveryMoves.includes(id)) && (
-							movePool.includes('softboiled') ||
+							movePool.includes('softboiled') && !moves.has('explosion') ||
 							(species.baseSpecies === 'Arceus' && movePool.includes('recover'))
 						))
 					);

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -24,7 +24,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			Dark: (movePool, moves, abilities, types, counter) => (
 				((!counter.get('Dark') || (counter.get('Dark') === 1 && moves.has('pursuit'))) &&
 				movePool.includes('suckerpunch') && counter.setupType !== 'Special') ||
-				!counter.get('Dark') && types.has('Poison')
+				(!counter.get('Dark') && types.has('Poison'))
 			),
 			Dragon: (movePool, moves, abilities, types, counter) => !counter.get('Dragon'),
 			Electric: (movePool, moves, abilities, types, counter) => !counter.get('Electric'),

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -22,8 +22,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 				!counter.get('Bug') && (movePool.includes('bugbuzz') || movePool.includes('megahorn'))
 			),
 			Dark: (movePool, moves, abilities, types, counter) => (
-				(!counter.get('Dark') || (counter.get('Dark') < 2 && moves.has('pursuit') && movePool.includes('suckerpunch'))
-			)),
+				!counter.get('Dark') || (counter.get('Dark') < 2 && moves.has('pursuit') && movePool.includes('suckerpunch'))),
 			Dragon: (movePool, moves, abilities, types, counter) => !counter.get('Dragon'),
 			Electric: (movePool, moves, abilities, types, counter) => !counter.get('Electric'),
 			Fighting: (movePool, moves, abilities, types, counter) => (

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -362,7 +362,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		case 'Technician':
 			return !counter.get('technician') || moves.has('toxic');
 		case 'Tinted Lens':
-			return counter.get('damage') >= counter.damagingMoves.size;
+			return moves.has('protect');
 		case 'Torrent':
 			return !counter.get('Water');
 		}
@@ -383,6 +383,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		if (species.requiredItems) return this.sample(species.requiredItems);
 		if (species.name === 'Farfetch\u2019d') return 'Stick';
 		if (species.name === 'Marowak') return 'Thick Club';
+		if (species.name === 'Pikachu') return 'Light Ball';
 		if (species.name === 'Shedinja' || species.name === 'Smeargle') return 'Focus Sash';
 		if (species.name === 'Unown') return 'Choice Specs';
 		if (species.name === 'Wobbuffet') {

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -381,7 +381,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 	): string | undefined {
 		if (species.requiredItem) return species.requiredItem;
 		if (species.requiredItems) return this.sample(species.requiredItems);
-		if (species.name === 'Farfetch\u2019d') return 'Stick';
+		if (species.name === 'Farfetch\u2019d' && moves.has('swordsdance')) return 'Stick';
 		if (species.name === 'Marowak') return 'Thick Club';
 		if (species.name === 'Pikachu') return 'Light Ball';
 		if (species.name === 'Shedinja' || species.name === 'Smeargle') return 'Focus Sash';


### PR DESCRIPTION
Approved by Random Battles staff

- Adds Pikachu, with Light Ball
- many set changes
- Light Screen and Reflect should usually appear together, if they are both in a Pokemon's movepool
- Force Dark STAB on Drapion (Poison Jab has been added)
- fix Wish/Toxic interaction with Protect: they should usually appear together
- Fix Yanmega getting Protect with Leftovers and Tinted Lens
- Farfetch'd will get choiced item with 4 attacks
- Fix an issue that was preventing Hitmonlee and Hitmonchan from getting Mach Punch

https://discord.com/channels/294651453279174656/765617449202352208/1066780492285882529
