### PR TITLE
Gen 8 Battle Factory: Remove Darmanitan-Galar's Choice Band set

### DIFF
--- a/data/mods/gen8/factory-sets.json
+++ b/data/mods/gen8/factory-sets.json
@@ -416,15 +416,8 @@
 				"evs": {"atk": 252, "spd": 4, "spe": 252},
 				"nature": "Jolly",
 				"moves": [["Icicle Crash"], ["Flare Blitz"], ["U-turn"], ["Earthquake", "Rock Slide"]]
-			}, {
-				"species": "Darmanitan-Galar",
-				"item": ["Choice Band"],
-				"ability": ["Gorilla Tactics"],
-				"evs": {"atk": 252, "spd": 4, "spe": 252},
-				"nature": ["Jolly", "Adamant"],
-				"moves": [["Icicle Crash"], ["Flare Blitz"], ["U-turn", "Rock Slide"], ["Earthquake"]]
 			}]
-		},
+    },
 		"weavile": {
 			"sets": [{
 				"species": "Weavile",

--- a/data/mods/gen8/factory-sets.json
+++ b/data/mods/gen8/factory-sets.json
@@ -417,7 +417,7 @@
 				"nature": "Jolly",
 				"moves": [["Icicle Crash"], ["Flare Blitz"], ["U-turn"], ["Earthquake", "Rock Slide"]]
 			}]
-    },
+		},
 		"weavile": {
 			"sets": [{
 				"species": "Weavile",


### PR DESCRIPTION
Credentials: https://cdn.discordapp.com/attachments/1042959218208157696/1067534457160089731/image.png (i am "lost wind's elegy")

Darm-G's firepower is just fine with scarf; there aren't many (if any?) relevant 1hkos or 2hkos you miss out on compared to band. The only one I can think of is missing out on the OHKO vs Sp. Def Necrozma Dusk Mane, and nobody's leaving their NDM in anyway + you probably have like 12 other things to deal with it.

Without scarf, however, you miss out on really good source of offensive checking and revenge killing potential. Scarf outspeeds huge threats like non scarf Yveltal, Eternatus, Calyrex-Shadow, etc. 

What sparks had to say about band darm in proper SS Ubers: sparks — Today at 1:53 PM
not really but with band building needs to be more focused cos the speed over the 90s and etern etc is insane with scarf

sparks — Today at 1:54 PM
while with band you're very much focused on "how to take out ndm and capitalize while not being weak to ho"

As a secondary factor, it would make Ubers in BF a lot better. Currently you have to not only win the coinflip of what move Darm clicks but also the coinflip of what item it is. Both of these are more or less up to random chance.