### PR TITLE
BDSP Random Battles updates

### DIFF
--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -2260,7 +2260,9 @@ export class RandomGen8Teams {
 			// Hardcoded abilities for certain contexts
 			if (forme === 'Copperajah' && gmax) {
 				ability = 'Heavy Metal';
-			} else if (abilities.has('Guts') && (
+			} else if (abilities.has('Guts') &&
+				// for Ursaring in BDSP
+				!abilities.has('Quick Feet') && (
 				species.id === 'gurdurr' || species.id === 'throh' ||
 				moves.has('facade') || (moves.has('rest') && moves.has('sleeptalk'))
 			)) {

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -2020,7 +2020,9 @@ export class RandomGen8Teams {
 				PUBL: 87,
 				PU: 88, "(PU)": 88, NFE: 88,
 			};
-			const customScale: {[k: string]: number} = {delibird: 100, dugtrio: 76, glalie: 76, luvdisc: 100, spinda: 100, unown: 100};
+			const customScale: {[k: string]: number} = {
+				delibird: 100, dugtrio: 76, glalie: 76, luvdisc: 100, spinda: 100, unown: 100,
+			};
 
 			return customScale[species.id] || tierScale[species.tier] || 80;
 		}

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -2020,7 +2020,7 @@ export class RandomGen8Teams {
 				PUBL: 87,
 				PU: 88, "(PU)": 88, NFE: 88,
 			};
-			const customScale: {[k: string]: number} = {delibird: 100, glalie: 76, luvdisc: 100, spinda: 100, unown: 100};
+			const customScale: {[k: string]: number} = {delibird: 100, dugtrio: 76, glalie: 76, luvdisc: 100, spinda: 100, unown: 100};
 
 			return customScale[species.id] || tierScale[species.tier] || 80;
 		}

--- a/data/mods/gen8bdsp/formats-data.ts
+++ b/data/mods/gen8bdsp/formats-data.ts
@@ -1816,7 +1816,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	wormadamtrash: {
 		tier: "PU",
 		doublesTier: "DUU",
-		randomBattleMoves: ["bugbuzz", "flashcannon", "gigadrain", "quiverdance", "stealthrock"],
+		randomBattleMoves: ["bugbuzz", "flashcannon", "gigadrain", "quiverdance"],
 	},
 	mothim: {
 		tier: "PU",

--- a/data/mods/gen8bdsp/random-teams.ts
+++ b/data/mods/gen8bdsp/random-teams.ts
@@ -310,7 +310,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 			if (
 				!isDoubles &&
 				counter.get('Status') < 2 &&
-				['Speed Boost', 'Moody'].every(m => !abilities.has(m))
+				['Guts', 'Quick Feet', 'Speed Boost', 'Moody'].every(m => !abilities.has(m))
 			) return {cull: true};
 			if (movePool.includes('leechseed') || (movePool.includes('toxic') && !moves.has('wish'))) return {cull: true};
 			if (isDoubles && (
@@ -337,7 +337,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 				['rest', 'substitute', 'trickroom', 'teleport'].some(m => moves.has(m)),
 			};
 		case 'stickyweb':
-			return {cull: counter.setupType === 'Special' || !!teamDetails.stickyWeb};
+			return {cull: !!teamDetails.stickyWeb};
 		case 'taunt':
 			return {cull: moves.has('encore') || moves.has('nastyplot') || moves.has('swordsdance')};
 		case 'thunderwave': case 'voltswitch':
@@ -449,11 +449,11 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 				movePool.includes('spikes'),
 			};
 		case 'stoneedge':
-			const gutsCullCondition = abilities.has('Guts') && (!moves.has('dynamicpunch') || moves.has('spikes'));
+			const machampCullCondition = species.id === 'machamp' && !moves.has('dynamicpunch');
 			const rockSlidePlusStatusPossible = counter.get('Status') && movePool.includes('rockslide');
 			const otherRockMove = moves.has('rockblast') || moves.has('rockslide');
 			const lucarioCull = species.id === 'lucario' && !!counter.setupType;
-			return {cull: gutsCullCondition || (!isDoubles && rockSlidePlusStatusPossible) || otherRockMove || lucarioCull};
+			return {cull: machampCullCondition || (!isDoubles && rockSlidePlusStatusPossible) || otherRockMove || lucarioCull};
 		case 'shadowball':
 			return {cull:
 				(isDoubles && moves.has('phantomforce')) ||
@@ -533,7 +533,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 		isDoubles: boolean,
 	): boolean {
 		if ([
-			'Flare Boost', 'Hydration', 'Ice Body', 'Immunity', 'Insomnia', 'Quick Feet', 'Rain Dish',
+			'Flare Boost', 'Hydration', 'Ice Body', 'Immunity', 'Insomnia', 'Rain Dish',
 			'Snow Cloak', 'Steadfast',
 		].includes(ability)) return true;
 
@@ -566,7 +566,8 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 		case 'Gluttony':
 			return !moves.has('bellydrum');
 		case 'Guts':
-			return (!moves.has('facade') && !moves.has('sleeptalk') && !species.nfe);
+			return (!moves.has('facade') && !moves.has('sleeptalk') && !species.nfe ||
+				abilities.has('Quick Feet') && !!counter.setupType);
 		case 'Harvest':
 			return (abilities.has('Frisk') && !isDoubles);
 		case 'Hustle': case 'Inner Focus':

--- a/data/mods/gen8bdsp/random-teams.ts
+++ b/data/mods/gen8bdsp/random-teams.ts
@@ -223,6 +223,8 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 			// Registeel would otherwise get Curse sets without Rest, which are very bad generally
 			return {cull: species.id !== 'registeel' && (movePool.includes('sleeptalk') || bulkySetup)};
 		case 'sleeptalk':
+			// Milotic always wants RestTalk
+			if (species.id === 'milotic') return {cull: false};
 			if (moves.has('stealthrock') || !moves.has('rest')) return {cull: true};
 			if (movePool.length > 1 && !abilities.has('Contrary')) {
 				const rest = movePool.indexOf('rest');
@@ -356,6 +358,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 			return {cull: (
 				!!counter.get('speedsetup') ||
 				(counter.setupType && !bugSwordsDanceCase) ||
+				(abilities.has('Speed Boost') && moves.has('protect')) ||
 				(isDoubles && moves.has('leechlife'))
 			)};
 
@@ -400,6 +403,9 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 			);
 			const preferThunderWave = movePool.includes('thunderwave') && types.has('Electric');
 			return {cull: betterIceMove || preferThunderWave || movePool.includes('bodyslam')};
+		// Milotic always wants RestTalk
+		case 'icebeam':
+			return {cull: moves.has('dragontail')};
 		case 'bodypress':
 			const pressIncompatible = ['shellsmash', 'mirrorcoat', 'whirlwind'].some(m => moves.has(m));
 			return {cull: pressIncompatible || counter.setupType === 'Special'};
@@ -435,7 +441,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 		case 'psyshock':
 			return {cull: moves.has('psychic')};
 		case 'bugbuzz':
-			return {cull: moves.has('uturn') && !counter.setupType};
+			return {cull: moves.has('uturn') && !counter.setupType && !abilities.has('Tinted Lens')};
 		case 'leechlife':
 			return {cull:
 				(isDoubles && moves.has('lunge')) ||
@@ -611,6 +617,8 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 			return (species.id === 'omastar' && (moves.has('spikes') || moves.has('stealthrock')));
 		case 'Sniper':
 			return counter.get('Water') > 1 && !moves.has('focusenergy');
+		case 'Speed Boost':
+			return moves.has('uturn');
 		case 'Sturdy':
 			return (moves.has('bulkup') || !!counter.get('recoil') || abilities.has('Solid Rock'));
 		case 'Swarm':
@@ -620,7 +628,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 				'Intimidate', 'Rock Head', 'Water Absorb',
 			].some(m => abilities.has(m));
 			const noSwimIfNoRain = !moves.has('raindance') && [
-				'Cloud Nine', 'Lightning Rod', 'Intimidate', 'Rock Head', 'Sturdy', 'Water Absorb', 'Weak Armor',
+				'Cloud Nine', 'Lightning Rod', 'Intimidate', 'Rock Head', 'Sturdy', 'Water Absorb', 'Water Veil', 'Weak Armor',
 			].some(m => abilities.has(m));
 			return teamDetails.rain ? neverWantsSwim : noSwimIfNoRain;
 		case 'Synchronize':

--- a/data/mods/gen8bdsp/random-teams.ts
+++ b/data/mods/gen8bdsp/random-teams.ts
@@ -603,6 +603,8 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 			return !counter.get('Status');
 		case 'Pressure':
 			return (!!counter.setupType || counter.get('Status') < 2 || isDoubles);
+		case 'Quick Feet':
+			return (!moves.has('facade'));
 		case 'Reckless':
 			return !counter.get('recoil') || moves.has('curse');
 		case 'Rock Head':

--- a/data/mods/gen8bdsp/random-teams.ts
+++ b/data/mods/gen8bdsp/random-teams.ts
@@ -43,6 +43,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 		if (ability === 'Guts' && counter.get('Physical') > 2) {
 			return types.has('Fire') ? 'Toxic Orb' : 'Flame Orb';
 		}
+		if (ability === 'Quick Feet' && moves.has('facade')) return 'Toxic Orb';
 		if (ability === 'Toxic Boost' || ability === 'Poison Heal') return 'Toxic Orb';
 		if (ability === 'Magic Guard' && counter.damagingMoves.size > 1) {
 			return moves.has('counter') ? 'Focus Sash' : 'Life Orb';

--- a/data/mods/gen8bdsp/random-teams.ts
+++ b/data/mods/gen8bdsp/random-teams.ts
@@ -577,7 +577,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 			return (moves.has('rest') && moves.has('sleeptalk')) || (isDoubles && abilities.has('Clear Body'));
 		case 'Intimidate':
 			if (species.id === 'salamence' && moves.has('dragondance')) return true;
-			return ['bodyslam', 'bounce', 'tripleaxel'].some(m => moves.has(m));
+			return ['bodyslam', 'bounce', 'rockclimb', 'tripleaxel'].some(m => moves.has(m));
 		case 'Iron Fist':
 			return (counter.get('ironfist') < 2 || moves.has('dynamicpunch'));
 		case 'Justified':

--- a/data/mods/gen8bdsp/random-teams.ts
+++ b/data/mods/gen8bdsp/random-teams.ts
@@ -604,7 +604,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 		case 'Pressure':
 			return (!!counter.setupType || counter.get('Status') < 2 || isDoubles);
 		case 'Quick Feet':
-			return (!moves.has('facade'));
+			return !moves.has('facade');
 		case 'Reckless':
 			return !counter.get('recoil') || moves.has('curse');
 		case 'Rock Head':

--- a/data/mods/gen8bdsp/random-teams.ts
+++ b/data/mods/gen8bdsp/random-teams.ts
@@ -100,7 +100,7 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 			return (scarfReqs && this.randomChance(2, 3)) ? 'Choice Scarf' : 'Choice Band';
 		}
 		if (moves.has('sunnyday')) return 'Heat Rock';
-		if (counter.get('Special') >= 4 && !moves.has('uturn')) {
+		if (counter.get('Special') >= 4 || (counter.get('Special') >= 3 && moves.has('uturn'))) {
 			const scarfReqs = (
 				species.baseStats.spa >= 100 &&
 				species.baseStats.spe >= 60 && species.baseStats.spe <= 108 &&


### PR DESCRIPTION
Approved by Random Battles staff

This makes the following changes to BDSP rands:
- Floatzel gets Water Veil as its ability if the team doesn't has rain
- Milotic always gets Rest and Sleep Talk
- Dugtrio gets Uber levelling
- Yanmega can roll Tinted Lens, not just Speed Boost
- Raticate and Ursaring can get Protect to activate their abilities
- Ursaring can get Quick Feet as its ability, and always has Quick Feet if it has Swords Dance
- Masquerain can get Sticky Web
- Heracross and Hariyama can get Stone Edge
- removes Stealth Rock from Wormadam-Trash since it is incompatible with Quiver Dance
- Pokemon with 3 Special attacks + U-Turn get Choice Specs/Scarf as their item
- Tauros gets Life Orb and Sheer Force to complement its moveset

https://discord.com/channels/294651453279174656/908560260753657888/913005102468567061
https://discord.com/channels/294651453279174656/908560260753657888/1067582371836203109