### PR TITLE
Fix Illusioned Tera Type not disappearing

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -1860,6 +1860,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		},
 		onEnd(pokemon) {
 			if (pokemon.illusion) {
+				pokemon.apparentType = pokemon.illusion.apparentType
 				this.debug('illusion cleared');
 				pokemon.illusion = null;
 				const details = pokemon.species.name + (pokemon.level === 100 ? '' : ', L' + pokemon.level) +


### PR DESCRIPTION
I'm not 100% satisfied with this solution because it causes a type change to appear on the real Pokemon that's the same as its base type, so it will still say "type changed." But I may as well submit it anyways while I try to figure it out, to allow other people to chime in.