### PR TITLE
Gen 9 Random Battles update

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -481,7 +481,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Aura Sphere", "Fire Blast", "Nasty Plot", "Psystrike", "Recover", "Shadow Ball"],
-                "teraTypes": ["Psychic", "Fighting", "Fire", "Ghost"]
+                "teraTypes": ["Psychic", "Fighting", "Fire"]
             }
         ]
     },
@@ -1880,7 +1880,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Agility", "Last Respects", "Psychic Fangs", "Wave Crash"],
+                "movepool": ["Aqua Jet", "Head Smash", "Last Respects", "Wave Crash"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -1890,7 +1890,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Agility", "Hydro Pump", "Ice Beam", "Last Respects"],
+                "movepool": ["Hydro Pump", "Ice Beam", "Last Respects", "Wave Crash"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -2683,7 +2683,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Agility", "Calm Mind", "Flash Cannon", "Fleur Cannon"],
+                "movepool": ["Calm Mind", "Flash Cannon", "Fleur Cannon", "Shift Gear"],
                 "teraTypes": ["Water", "Steel", "Fairy", "Flying"]
             },
             {
@@ -3489,7 +3489,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Muddy Water", "Slack Off", "Thunder Wave", "Thunderbolt", "Volt Switch"],
-                "teraTypes": ["Electric"]
+                "teraTypes": ["Electric", "Water"]
             }
         ]
     },
@@ -3839,7 +3839,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Light Screen", "Play Rough", "Protect", "Reflect", "Thunder Wave", "Wish"],
-                "teraTypes": ["Fairy", "Steel"]
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -4033,7 +4033,7 @@
         "sets": [
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Calm Mind", "Dragon Pulse", "Electro Drift", "Substitute"],
+                "movepool": ["Calm Mind", "Draco Meteor", "Electro Drift", "Substitute"],
                 "teraTypes": ["Electric"]
             },
             {

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -106,7 +106,7 @@ const MovePairs = [
 
 // Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type
 const PriorityPokemon = [
-	'banette', 'breloom', 'brutebonnet', 'cacturne', 'giratinaorigin', 'mimikyu', 'lycanrocdusk', 'scizor'
+	'banette', 'breloom', 'brutebonnet', 'cacturne', 'giratinaorigin', 'mimikyu', 'lycanrocdusk', 'scizor',
 ];
 
 function sereneGraceBenefits(move: Move) {

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -105,7 +105,7 @@ const MovePairs = [
 ];
 
 function sereneGraceBenefits(move: Move) {
-	return move.secondary?.chance && move.secondary.chance >= 20 && move.secondary.chance < 100;
+	return move.secondary?.chance && move.secondary.chance > 20 && move.secondary.chance < 100;
 }
 
 export class RandomTeams {
@@ -880,7 +880,7 @@ export class RandomTeams {
 		case 'Hustle':
 			return (counter.get('Physical') < 2);
 		case 'Infiltrator':
-			return (moves.has('rest') && moves.has('sleeptalk')) || (isDoubles && abilities.has('Clear Body'));
+			return (isDoubles && abilities.has('Clear Body'));
 		case 'Insomnia':
 			return (role === 'Wallbreaker');
 		case 'Intimidate':
@@ -1055,7 +1055,8 @@ export class RandomTeams {
 		if (species.id === 'cyclizar' && role === 'Fast Attacker') return 'Choice Scarf';
 		if (species.id === 'lokix' && role === 'Wallbreaker') return 'Life Orb';
 		if (species.id === 'toxtricity' && moves.has('shiftgear')) return 'Throat Spray';
-		if (species.baseSpecies === 'Magearna' && moves.has('shiftgear')) return 'Weakness Policy';
+		if (species.baseSpecies === 'Magearna' && role === 'Tera Blast user') return 'Weakness Policy';
+		if (moves.has('lastrespects')) return 'Choice Scarf';
 		if (ability === 'Imposter' || (species.id === 'magnezone' && moves.has('bodypress'))) return 'Choice Scarf';
 		if (moves.has('bellydrum') && moves.has('substitute')) return 'Salac Berry';
 		if (

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -906,6 +906,8 @@ export class RandomTeams {
 			return (abilities.has('Sharpness') || abilities.has('Unburden'));
 		case 'Moxie':
 			return (!counter.get('Physical') || moves.has('stealthrock'));
+		case 'Natural Cure':
+			return species.id === 'pawmot';
 		case 'Overgrow':
 			return !counter.get('Grass');
 		case 'Prankster':

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -106,7 +106,7 @@ const MovePairs = [
 
 // Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type
 const PriorityPokemon = [
-	'banette', 'breloom', 'brutebonnet', 'cacturne', 'giratinaorigin', 'mimikyu', 'lycanrocdusk', 'scizor',
+	'banette', 'breloom', 'brutebonnet', 'cacturne', 'giratinaorigin', 'lycanrocdusk', 'mimikyu', 'scizor',
 ];
 
 function sereneGraceBenefits(move: Move) {

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -105,7 +105,9 @@ const MovePairs = [
 ];
 
 // Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type
-const PriorityPokemon = ['banette', 'breloom', 'brutebonnet', 'cacturne', 'giratinaorigin', 'mimikyu', 'lycanrocdusk', 'scizor']
+const PriorityPokemon = [
+	'banette', 'breloom', 'brutebonnet', 'cacturne', 'giratinaorigin', 'mimikyu', 'lycanrocdusk', 'scizor'
+];
 
 function sereneGraceBenefits(move: Move) {
 	return move.secondary?.chance && move.secondary.chance > 20 && move.secondary.chance < 100;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -88,7 +88,7 @@ const Setup = [
 const NoStab = [
 	'accelerock', 'aquajet', 'beakblast', 'bounce', 'breakingswipe', 'chatter', 'chloroblast', 'clearsmog', 'dragontail', 'eruption',
 	'explosion', 'fakeout', 'flamecharge', 'flipturn', 'iceshard', 'icywind', 'incinerate', 'machpunch', 'meteorbeam',
-	'mortalspin', 'pluck', 'pursuit', 'quickattack', 'rapidspin', 'reversal', 'saltcure', 'selfdestruct', 'shadowsneak',
+	'mortalspin', 'pluck', 'pursuit', 'quickattack', 'rapidspin', 'reversal', 'selfdestruct', 'shadowsneak',
 	'skydrop', 'snarl', 'steelbeam', 'suckerpunch', 'uturn', 'watershuriken', 'vacuumwave', 'voltswitch', 'waterspout',
 ];
 // Hazard-setting moves
@@ -609,7 +609,37 @@ export class RandomTeams {
 				movePool, teraType, role);
 		}
 
-		// Add other moves you really want to have, e.g. STAB, recovery, setup, depending on role.
+		// Add other moves you really want to have, e.g. STAB, recovery, setup.
+
+		// Enforce Facade if Guts is a possible ability
+		if (movePool.includes('facade') && abilities.has('Guts')) {
+			counter = this.addMove('facade', moves, types, abilities, teamDetails, species, isLead, isDoubles,
+				movePool, teraType, role);
+		}
+
+		// Enforce Sticky Web
+		if (movePool.includes('stickyweb')) {
+			counter = this.addMove('stickyweb', moves, types, abilities, teamDetails, species, isLead, isDoubles,
+				movePool, teraType, role);
+		}
+
+		// Enforce Revival Blessing
+		if (movePool.includes('revivalblessing')) {
+			counter = this.addMove('revivalblessing', moves, types, abilities, teamDetails, species, isLead, isDoubles,
+				movePool, teraType, role);
+		}
+
+		// Enforce Salt Cure
+		if (movePool.includes('saltcure')) {
+			counter = this.addMove('saltcure', moves, types, abilities, teamDetails, species, isLead, isDoubles,
+				movePool, teraType, role);
+		}
+
+		// Enforce Toxic on Grafaiai
+		if (movePool.includes('toxic') && species.id === 'grafaiai') {
+			counter = this.addMove('toxic', moves, types, abilities, teamDetails, species, isLead, isDoubles,
+				movePool, teraType, role);
+		}
 
 		// Enforce STAB
 		for (const type of types) {
@@ -686,30 +716,6 @@ export class RandomTeams {
 				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead, isDoubles,
 					movePool, teraType, role);
 			}
-		}
-
-		// Enforce Facade if Guts is a possible ability
-		if (movePool.includes('facade') && abilities.has('Guts')) {
-			counter = this.addMove('facade', moves, types, abilities, teamDetails, species, isLead, isDoubles,
-				movePool, teraType, role);
-		}
-
-		// Enforce Sticky Web
-		if (movePool.includes('stickyweb')) {
-			counter = this.addMove('stickyweb', moves, types, abilities, teamDetails, species, isLead, isDoubles,
-				movePool, teraType, role);
-		}
-
-		// Enforce Revival Blessing
-		if (movePool.includes('revivalblessing')) {
-			counter = this.addMove('revivalblessing', moves, types, abilities, teamDetails, species, isLead, isDoubles,
-				movePool, teraType, role);
-		}
-
-		// Enforce Toxic on Grafaiai
-		if (movePool.includes('toxic') && species.id === 'grafaiai') {
-			counter = this.addMove('toxic', moves, types, abilities, teamDetails, species, isLead, isDoubles,
-				movePool, teraType, role);
 		}
 
 		// Enforce recovery


### PR DESCRIPTION
- Some minor tera type and movepool updates, including giving all Pokemon with Last Respects a fixed Choice Scarf set
- Salt Cure now counts as STAB, and is an enforced move
- Created a list of Pokemon called PriorityPokemon, which have STAB priority enforced, and the STAB priority counts as regular (and tera, if appropriate) STAB even if it is in the noSTAB list. (For example, Breloom has Mach Punch enforced, and this counts as Fighting STAB, so Close Combat is not required).

https://discord.com/channels/294651453279174656/1041098998624288990/1052446471615684689