### PR TITLE
Gen 2-4 Random Battles updates

### DIFF
--- a/data/mods/gen2/random-teams.ts
+++ b/data/mods/gen2/random-teams.ts
@@ -120,7 +120,7 @@ export class RandomGen2Teams extends RandomGen3Teams {
 		species: Species,
 	) {
 		// First, the high-priority items
-		if (species.name === 'Ditto') return this.sample(['Metal Powder', 'Quick Claw']);
+		if (species.name === 'Ditto') return 'Metal Powder';
 		if (species.name === 'Farfetch\u2019d') return 'Stick';
 		if (species.name === 'Marowak') return 'Thick Club';
 		if (species.name === 'Pikachu') return 'Light Ball';

--- a/data/mods/gen4/formats-data.ts
+++ b/data/mods/gen4/formats-data.ts
@@ -1717,27 +1717,27 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "UUBL",
 	},
 	rotom: {
-		randomBattleMoves: ["hiddenpowerfighting", "hiddenpowerice", "painsplit", "shadowball", "substitute", "thunderbolt", "trick", "willowisp"],
+		randomBattleMoves: ["hiddenpowerfighting", "hiddenpowerfire", "shadowball", "thunderbolt", "trick"],
 		tier: "UU",
 	},
 	rotomheat: {
-		randomBattleMoves: ["hiddenpowerice", "overheat", "shadowball", "thunderbolt", "trick", "willowisp"],
+		randomBattleMoves: ["discharge", "lightscreen", "overheat", "painsplit", "reflect", "shadowball", "thunderbolt", "trick", "willowisp"],
 		tier: "OU",
 	},
 	rotomwash: {
-		randomBattleMoves: ["hiddenpowerice", "hydropump", "painsplit", "rest", "shadowball", "sleeptalk", "substitute", "thunderbolt", "trick", "willowisp"],
+		randomBattleMoves: ["discharge", "hydropump", "lightscreen", "reflect", "rest", "shadowball", "sleeptalk", "thunderbolt", "trick", "willowisp"],
 		tier: "OU",
 	},
 	rotomfrost: {
-		randomBattleMoves: ["blizzard", "painsplit", "rest", "shadowball", "sleeptalk", "substitute", "thunderbolt", "trick", "willowisp"],
+		randomBattleMoves: ["blizzard", "discharge", "lightscreen", "reflect", "rest", "shadowball", "sleeptalk", "thunderbolt", "trick", "willowisp"],
 		tier: "OU",
 	},
 	rotomfan: {
-		randomBattleMoves: ["airslash", "discharge", "hiddenpowerice", "painsplit", "rest", "shadowball", "sleeptalk", "substitute", "willowisp"],
+		randomBattleMoves: ["discharge", "lightscreen", "painsplit", "reflect", "rest", "shadowball", "sleeptalk", "thunderbolt", "willowisp"],
 		tier: "OU",
 	},
 	rotommow: {
-		randomBattleMoves: ["hiddenpowerice", "leafstorm", "shadowball", "thunderbolt", "trick", "willowisp"],
+		randomBattleMoves: ["discharge", "leafstorm", "lightscreen", "painsplit", "reflect", "shadowball", "thunderbolt", "trick", "willowisp"],
 		tier: "OU",
 	},
 	uxie: {

--- a/data/mods/gen4/formats-data.ts
+++ b/data/mods/gen4/formats-data.ts
@@ -559,7 +559,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NU",
 	},
 	espeon: {
-		randomBattleMoves: ["batonpass", "calmmind", "hiddenpowerground", "morningsun", "psychic", "shadowball", "substitute"],
+		randomBattleMoves: ["batonpass", "calmmind", "hiddenpowerfire", "morningsun", "psychic", "shadowball", "substitute"],
 		tier: "NUBL",
 	},
 	umbreon: {
@@ -1005,7 +1005,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	mightyena: {
-		randomBattleMoves: ["firefang", "return", "suckerpunch", "superfang", "taunt", "toxic"],
+		randomBattleMoves: ["crunch", "firefang", "suckerpunch", "superfang", "taunt", "toxic"],
 		tier: "NU",
 	},
 	zigzagoon: {
@@ -1113,7 +1113,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "(OU)",
 	},
 	shedinja: {
-		randomBattleMoves: ["shadowsneak", "suckerpunch", "swordsdance", "willowisp", "xscissor"],
+		randomBattleMoves: ["batonpass", "shadowsneak", "swordsdance", "willowisp", "xscissor"],
 		tier: "NU",
 	},
 	whismur: {
@@ -1130,7 +1130,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "LC",
 	},
 	hariyama: {
-		randomBattleMoves: ["bulletpunch", "closecombat", "fakeout", "focuspunch", "icepunch", "payback", "stoneedge", "substitute"],
+		randomBattleMoves: ["bulletpunch", "closecombat", "facade", "fakeout", "focuspunch", "icepunch", "payback", "stoneedge", "substitute"],
 		tier: "UU",
 	},
 	nosepass: {
@@ -1148,7 +1148,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NU",
 	},
 	sableye: {
-		randomBattleMoves: ["nightshade", "recover", "seismictoss", "taunt", "toxic", "willowisp"],
+		randomBattleMoves: ["recover", "seismictoss", "taunt", "toxic", "willowisp"],
 		tier: "NU",
 	},
 	mawile: {

--- a/data/mods/gen4/formats-data.ts
+++ b/data/mods/gen4/formats-data.ts
@@ -1192,7 +1192,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NU",
 	},
 	illumise: {
-		randomBattleMoves: ["bugbuzz", "encore", "hiddenpowerground", "hiddenpowerice", "thunderbolt", "uturn"],
+		randomBattleMoves: ["bugbuzz", "encore", "hiddenpowerground", "hiddenpowerice", "thunderbolt", "uturn", "wish"],
 		tier: "NU",
 	},
 	budew: {
@@ -1776,7 +1776,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		randomBattleMoves: ["aurasphere", "calmmind", "dracometeor", "dragonpulse", "hiddenpowerfire", "outrage", "shadowball", "shadowsneak", "substitute"],
 	},
 	cresselia: {
-		randomBattleMoves: ["calmmind", "hiddenpowerfire", "icebeam", "moonlight", "psychic", "substitute", "thunderwave", "toxic"],
+		randomBattleMoves: ["calmmind", "hiddenpowerfire", "icebeam", "lightscreen", "moonlight", "psychic", "reflect", "substitute", "thunderwave", "toxic"],
 		tier: "UUBL",
 	},
 	phione: {

--- a/data/mods/gen4/formats-data.ts
+++ b/data/mods/gen4/formats-data.ts
@@ -729,7 +729,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NFE",
 	},
 	ampharos: {
-		randomBattleMoves: ["discharge", "focusblast", "hiddenpowerice", "signalbeam", "substitute", "thunderbolt"],
+		randomBattleMoves: ["discharge", "focusblast", "healbell", "hiddenpowerice", "lightscreen", "reflect", "signalbeam", "thunderbolt"],
 		tier: "NU",
 	},
 	azurill: {

--- a/data/mods/gen4/formats-data.ts
+++ b/data/mods/gen4/formats-data.ts
@@ -886,7 +886,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "(OU)",
 	},
 	corsola: {
-		randomBattleMoves: ["recover", "reflect", "stealthrock", "surf", "toxic"],
+		randomBattleMoves: ["explosion", "recover", "stealthrock", "surf", "toxic"],
 		tier: "NU",
 	},
 	remoraid: {
@@ -1022,7 +1022,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NFE",
 	},
 	beautifly: {
-		randomBattleMoves: ["bugbuzz", "hiddenpowerground", "psychic", "stunspore", "uturn"],
+		randomBattleMoves: ["bugbuzz", "hiddenpowerground", "psychic", "uturn"],
 		tier: "NU",
 	},
 	cascoon: {
@@ -1359,7 +1359,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "(OU)",
 	},
 	tropius: {
-		randomBattleMoves: ["aerialace", "airslash", "earthquake", "energyball", "leafblade", "roost", "swordsdance", "toxic", "whirlwind"],
+		randomBattleMoves: ["aerialace", "curse", "dragondance", "earthquake", "leafblade", "leafstorm", "leechseed", "roost", "swordsdance", "toxic", "whirlwind"],
 		tier: "NU",
 	},
 	chingling: {
@@ -1579,7 +1579,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		tier: "NU",
 	},
 	mothim: {
-		randomBattleMoves: ["airslash", "bugbuzz", "hiddenpowerground", "roost", "shadowball", "uturn"],
+		randomBattleMoves: ["airslash", "bugbuzz", "hiddenpowerfighting", "hiddenpowerground", "shadowball", "uturn"],
 		tier: "NU",
 	},
 	combee: {

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -152,6 +152,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		case 'protect':
 			return {cull: (
 				['rest', 'softboiled'].some(m => moves.has(m)) ||
+				(!!counter.setupType && !moves.has('wish')) ||
 				!['Guts', 'Quick Feet', 'Speed Boost'].some(abil => abilities.has(abil)) &&
 				!['toxic', 'wish'].some(m => moves.has(m))
 			)};

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -295,8 +295,6 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			return {cull: moves.has('suckerpunch') && !types.has('Dark')};
 		case 'pursuit':
 			return {cull: !!counter.setupType || moves.has('payback')};
-		case 'suckerpunch':
-			return {cull: counter.damagingMoves.size < 3 && !moves.has('batonpass') && !types.has('Dark')};
 		case 'flashcannon':
 			return {cull: (moves.has('ironhead') || movePool.includes('ironhead')) && counter.setupType !== 'Special'};
 

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -19,7 +19,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		super(format, prng);
 		this.moveEnforcementCheckers = {
 			Bug: (movePool, moves, abilities, types, counter) => (
-				!counter.get('Bug') && (movePool.includes('bugbuzz') || movePool.includes('megahorn'))
+				(movePool.includes('bugbuzz') || movePool.includes('megahorn'))
 			),
 			Dark: (movePool, moves, abilities, types, counter) => (
 				!counter.get('damage') &&
@@ -156,9 +156,12 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			)};
 		case 'wish':
 			return {cull: (
+				!(moves.has('ironhead') && abilities.has('Serene Grace')) &&
+				(
 				!['batonpass', 'protect', 'uturn'].some(m => moves.has(m)) ||
 				moves.has('rest') ||
 				!!counter.get('speedsetup')
+				)
 			)};
 		case 'rapidspin':
 			return {cull: !!teamDetails.rapidSpin || (!!counter.setupType && counter.get('Physical') + counter.get('Special') < 2)};
@@ -193,7 +196,6 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			)};
 		case 'uturn':
 			return {cull: (
-				(types.has('Bug') && counter.get('stab') < 2 && counter.damagingMoves.size > 1) ||
 				(abilities.has('Speed Boost') && moves.has('protect')) ||
 				!!counter.setupType ||
 				!!counter.get('speedsetup') ||
@@ -204,6 +206,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		// Attacks:
 		case 'bodyslam': case 'slash':
 			return {cull: moves.has('facade') || moves.has('return')};
+		case 'bugbite':
+			return {cull: moves.has('uturn')};
 		case 'doubleedge':
 			return {cull: ['bodyslam', 'facade', 'return'].some(m => moves.has(m))};
 		case 'endeavor':
@@ -218,10 +222,13 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			return {cull: moves.has('thunderwave')};
 		case 'firepunch': case 'flamethrower':
 			return {cull: moves.has('fireblast') || moves.has('overheat') && !counter.setupType};
+		case 'flareblitz':
+			return {cull: moves.has('superpower') && !!counter.get('speedsetup')};
 		case 'lavaplume': case 'fireblast':
 			if (move.id === 'fireblast' && moves.has('lavaplume') && !counter.get('speedsetup')) return {cull: true};
 			if (move.id === 'lavaplume' && moves.has('fireblast') && counter.get('speedsetup')) return {cull: true};
-			if (moves.has('flareblitz') && counter.setupType !== 'Special') return {cull: true};
+			if (moves.has('flareblitz') && counter.setupType !== 'Special' &&
+				(!moves.has('superpower') || !counter.get('speedsetup'))) return {cull: true};
 			break;
 		case 'overheat':
 			return {cull: counter.setupType === 'Special' || ['batonpass', 'fireblast', 'flareblitz'].some(m => moves.has(m))};
@@ -267,7 +274,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		case 'seismictoss':
 			return {cull: moves.has('nightshade') || counter.get('Physical') + counter.get('Special') >= 1};
 		case 'superpower':
-			return {cull: moves.has('dragondance') || !!counter.get('speedsetup')};
+			return {cull: moves.has('dragondance') || !!counter.get('speedsetup') && !types.has('Fighting')};
 		case 'gunkshot':
 			return {cull: moves.has('poisonjab')};
 		case 'earthpower':
@@ -310,7 +317,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 				movePool.includes('spore')
 			)};
 		case 'substitute':
-			return {cull: ['pursuit', 'rapidspin', 'rest', 'taunt'].some(m => moves.has(m))};
+			return {cull: ['lightscreen', 'pursuit', 'rapidspin', 'reflect', 'rest', 'taunt'].some(m => moves.has(m))};
 		case 'thunderwave':
 			return {cull: (
 				!!counter.setupType ||
@@ -489,6 +496,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		) {
 			return 'Focus Sash';
 		}
+		if (counter.get('Dark') >= 3) return 'Black Glasses';
 		if (counter.damagingMoves.size >= 4) {
 			return (
 				counter.get('Normal') || counter.get('Dragon') > 1 || moves.has('chargebeam') || moves.has('suckerpunch')

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -155,13 +155,11 @@ export class RandomGen4Teams extends RandomGen5Teams {
 				!['toxic', 'wish'].some(m => moves.has(m))
 			)};
 		case 'wish':
+			if (moves.has('ironhead') && abilities.has('Serene Grace')) return {cull: false};
 			return {cull: (
-				!(moves.has('ironhead') && abilities.has('Serene Grace')) &&
-				(
 				!['batonpass', 'protect', 'softboiled', 'uturn'].some(m => moves.has(m)) ||
 				moves.has('rest') ||
 				!!counter.get('speedsetup')
-				)
 			)};
 		case 'rapidspin':
 			return {cull: !!teamDetails.rapidSpin || (!!counter.setupType && counter.get('Physical') + counter.get('Special') < 2)};

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -157,9 +157,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 				!['toxic', 'wish'].some(m => moves.has(m))
 			)};
 		case 'wish':
-			if (moves.has('ironhead') && abilities.has('Serene Grace')) return {cull: false};
 			return {cull: (
-				!['batonpass', 'protect', 'softboiled', 'uturn'].some(m => moves.has(m)) ||
+				!['batonpass', 'ironhead', 'protect', 'softboiled', 'uturn'].some(m => moves.has(m)) ||
 				moves.has('rest') ||
 				!!counter.get('speedsetup')
 			)};

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -303,6 +303,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			return {cull: ['roar', 'taunt', 'whirlwind'].some(m => moves.has(m)) || restTalk};
 		case 'haze': case 'taunt':
 			return {cull: restTalk};
+		case 'healbell':
+			return {cull: moves.has('reflect') && moves.has('lightscreen')};
 		case 'leechseed': case 'painsplit':
 			return {cull: !!counter.setupType || !!counter.get('speedsetup') || moves.has('rest')};
 		case 'recover': case 'slackoff':

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -152,7 +152,6 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		case 'protect':
 			return {cull: (
 				['rest', 'softboiled'].some(m => moves.has(m)) ||
-				(!!counter.setupType && !moves.has('wish')) ||
 				!['Guts', 'Quick Feet', 'Speed Boost'].some(abil => abilities.has(abil)) &&
 				!['toxic', 'wish'].some(m => moves.has(m))
 			)};
@@ -296,6 +295,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			return {cull: moves.has('suckerpunch') && !types.has('Dark')};
 		case 'pursuit':
 			return {cull: !!counter.setupType || moves.has('payback')};
+		case 'suckerpunch':
+			return {cull: counter.damagingMoves.size < 3 && !moves.has('batonpass') && !types.has('Dark')};
 		case 'flashcannon':
 			return {cull: (moves.has('ironhead') || movePool.includes('ironhead')) && counter.setupType !== 'Special'};
 

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -103,7 +103,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		case 'refresh':
 			return {cull: !(moves.has('calmmind') && (moves.has('recover') || moves.has('roost')))};
 		case 'rest':
-			return {cull: movePool.includes('sleeptalk') || (abilities.has('Hydration') && !moves.has('raindance'))};
+			return {cull: movePool.includes('sleeptalk') || (abilities.has('Hydration') && !moves.has('raindance')) ||
+				moves.has('reflect') && moves.has('lightscreen')};
 		case 'sleeptalk':
 			if (movePool.length > 1) {
 				const rest = movePool.indexOf('rest');
@@ -242,7 +243,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		case 'chargebeam':
 			return {cull: moves.has('thunderbolt') && counter.get('Special') < 3};
 		case 'discharge':
-			return {cull: moves.has('thunderbolt')};
+			return {cull: moves.has('thunderbolt') || moves.has('shadowball')};
 		case 'energyball':
 			return {cull: (
 				moves.has('woodhammer') ||

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -305,6 +305,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		case 'haze': case 'taunt':
 			return {cull: restTalk};
 		case 'healbell':
+			// Ampharos doesn't want both
 			return {cull: moves.has('reflect') && moves.has('lightscreen')};
 		case 'leechseed': case 'painsplit':
 			return {cull: !!counter.setupType || !!counter.get('speedsetup') || moves.has('rest')};

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -158,7 +158,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			return {cull: (
 				!(moves.has('ironhead') && abilities.has('Serene Grace')) &&
 				(
-				!['batonpass', 'protect', 'uturn'].some(m => moves.has(m)) ||
+				!['batonpass', 'protect', 'softboiled', 'uturn'].some(m => moves.has(m)) ||
 				moves.has('rest') ||
 				!!counter.get('speedsetup')
 				)
@@ -247,7 +247,6 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			return {cull: moves.has('thunderbolt')};
 		case 'energyball':
 			return {cull: (
-				moves.has('leafblade') ||
 				moves.has('woodhammer') ||
 				(moves.has('sunnyday') && moves.has('solarbeam')) ||
 				(moves.has('leafstorm') && counter.get('Physical') + counter.get('Special') < 4)
@@ -259,6 +258,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 				!!counter.setupType ||
 				moves.has('batonpass') ||
 				moves.has('powerwhip') ||
+				moves.has('leafblade') ||
 				(moves.has('sunnyday') && moves.has('solarbeam'))
 			)};
 		case 'solarbeam':

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -22,7 +22,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 				!counter.get('Bug') && (movePool.includes('bugbuzz') || movePool.includes('megahorn'))
 			),
 			Dark: (movePool, moves, abilities, types, counter) => (
-				!counter.get('Dark') || (counter.get('Dark') < 2 && moves.has('pursuit') && movePool.includes('suckerpunch'))),
+				!counter.get('damage') &&
+				(!counter.get('Dark') || (counter.get('Dark') < 2 && moves.has('pursuit') && movePool.includes('suckerpunch')))),
 			Dragon: (movePool, moves, abilities, types, counter) => !counter.get('Dragon'),
 			Electric: (movePool, moves, abilities, types, counter) => !counter.get('Electric'),
 			Fighting: (movePool, moves, abilities, types, counter) => (
@@ -207,6 +208,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			return {cull: ['bodyslam', 'facade', 'return'].some(m => moves.has(m))};
 		case 'endeavor':
 			return {cull: !isLead};
+		case 'facade':
+			return {cull: moves.has('substitute')};
 		case 'headbutt':
 			return {cull: !moves.has('bodyslam') && !moves.has('thunderwave')};
 		case 'judgment': case 'swift':
@@ -374,6 +377,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			return counter.get('Status') < 2;
 		case 'Technician':
 			return !counter.get('technician') || moves.has('toxic');
+		case 'Thick Fat':
+			return (moves.has('facade') || moves.has('fakeout')) && abilities.has('Guts');
 		case 'Tinted Lens':
 			return moves.has('protect');
 		case 'Torrent':

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -1007,7 +1007,8 @@ export class RandomGen8Teams {
 		} else if (counter.setupType === 'Physical') {
 			if (
 				(categories['Physical'] < 2 && (!counter.get('stab') || !counter.get('physicalpool'))) &&
-				!(moves.has('rest') && moves.has('sleeptalk'))
+				!(moves.has('rest') && moves.has('sleeptalk')) &&
+				!moves.has('batonpass')
 			) {
 				counter.setupType = '';
 			}
@@ -1015,7 +1016,8 @@ export class RandomGen8Teams {
 			if (
 				(categories['Special'] < 2 && (!counter.get('stab') || !counter.get('specialpool'))) &&
 				!(moves.has('rest') && moves.has('sleeptalk')) &&
-				!(moves.has('wish') && moves.has('protect'))
+				!(moves.has('wish') && moves.has('protect')) &&
+				!moves.has('batonpass')
 			) {
 				counter.setupType = '';
 			}


### PR DESCRIPTION
Gen 2 changes: Ditto will always get Metal Powder as its item
Gen 2-4 changes: Allow setup moves to appear with fewer attacks if Baton Pass is in the set

Gen 4 changes:
Many movepool and set generation tweaks, outlined in the two links below from Random Battles Auth:

https://discord.com/channels/294651453279174656/765617449202352208/1068574416675557460
https://discord.com/channels/294651453279174656/765617449202352208/1068864345888530532