### PR TITLE
Mafia: Prevent incorrect alignment.

### DIFF
--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -1481,7 +1481,7 @@ class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 				}
 			}
 			// 'Innocent Discard' causes chosen role to become Town, when discarded.
-			if (this.playerTable[p].IDEA.choices.includes('Innocent Discard')) player.role.alignment = 'town';
+			if (player.IDEA.choices.includes('Innocent Discard')) player.role.alignment = 'town';
 		}
 		this.IDEA.discardsHTML = `<b>Discards:</b><br />`;
 		for (const p of Object.keys(this.playerTable).sort()) {

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -1480,6 +1480,8 @@ class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 					}
 				}
 			}
+			// 'Innocent Discard' causes chosen role to become Town, when discarded.
+			if (this.playerTable[p].IDEA.choices.includes('Innocent Discard')) player.role.alignment = 'town';
 		}
 		this.IDEA.discardsHTML = `<b>Discards:</b><br />`;
 		for (const p of Object.keys(this.playerTable).sort()) {


### PR DESCRIPTION
A new theme includes a role that can change someone's alignment to Town when discarded.