### PR TITLE
NatDex: Fix Revival Blessing + Pursuit interaction

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2695,12 +2695,12 @@ export class Battle {
 						reviveSwitch = true;
 						continue;
 					}
-				  pokemon.switchFlag = false;
+					pokemon.switchFlag = false;
 				}
 				if (!reviveSwitch) switches[i] = false;
 			} else if (switches[i]) {
 				for (const pokemon of this.sides[i].active) {
-					if (pokemon.switchFlag && !pokemon.skipBeforeSwitchOutEventFlag) {
+					if (pokemon.switchFlag && pokemon.switchFlag !== 'revivalblessing' && !pokemon.skipBeforeSwitchOutEventFlag) {
 						this.runEvent('BeforeSwitchOut', pokemon);
 						pokemon.skipBeforeSwitchOutEventFlag = true;
 						this.faintMessages(); // Pokemon may have fainted in BeforeSwitchOut


### PR DESCRIPTION
Old behavior: Pursuit would proc on a mon using Revival Blessing, if that mon had any unfainted allies

New behavior: Pursuit will not proc on Revival Blessing

I believe this is sensible, as Revival Blessing is not actually a switch.