### PR TITLE
Update SV Fly Pikachu to allow both genders

### DIFF
--- a/data/learnsets.ts
+++ b/data/learnsets.ts
@@ -2537,7 +2537,7 @@ export const Learnsets: {[speciesid: string]: LearnsetData} = {
 			{generation: 8, level: 5, gender: "M", nature: "Serious", moves: ["celebrate", "playnice", "thundershock", "quickattack"], pokeball: "cherishball"},
 			{generation: 8, level: 21, gender: "M", nature: "Brave", moves: ["thunderbolt", "swift", "wish", "celebrate"], pokeball: "cherishball"},
 			{generation: 8, level: 25, isHidden: true, moves: ["sing", "encore", "celebrate", "electroball"], pokeball: "cherishball"},
-			{generation: 9, level: 5, gender: "M", moves: ["fly", "tailwhip", "thundershock", "quickattack"], pokeball: "pokeball"},
+			{generation: 9, level: 5, moves: ["fly", "tailwhip", "thundershock", "quickattack"], pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 1, level: 3},


### PR DESCRIPTION
The SV Fly Pikachu event was updated a couple days ago. Used to be male only and now can be female as well.

https://projectpokemon.org/home/files/file/4861-early-purchase-bonus-pikachu/