### PR TITLE
Gen 3-7 Random Battle: Prepare for level balancing

### DIFF
--- a/data/mods/gen3/formats-data.ts
+++ b/data/mods/gen3/formats-data.ts
@@ -7,6 +7,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	venusaur: {
 		randomBattleMoves: ["curse", "earthquake", "hiddenpowerrock", "leechseed", "sleeppowder", "sludgebomb", "swordsdance", "synthesis"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	charmander: {
@@ -17,6 +18,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	charizard: {
 		randomBattleMoves: ["bellydrum", "dragondance", "earthquake", "fireblast", "hiddenpowerflying", "substitute"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	squirtle: {
@@ -27,6 +29,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	blastoise: {
 		randomBattleMoves: ["earthquake", "icebeam", "mirrorcoat", "rest", "roar", "sleeptalk", "surf", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	caterpie: {
@@ -37,6 +40,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	butterfree: {
 		randomBattleMoves: ["gigadrain", "hiddenpowerfire", "morningsun", "psychic", "sleeppowder", "stunspore", "toxic"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	weedle: {
@@ -47,6 +51,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	beedrill: {
 		randomBattleMoves: ["brickbreak", "doubleedge", "endure", "hiddenpowerbug", "sludgebomb", "swordsdance"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	pidgey: {
@@ -57,6 +62,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	pidgeot: {
 		randomBattleMoves: ["aerialace", "hiddenpowerground", "quickattack", "return", "substitute", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	rattata: {
@@ -64,6 +70,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	raticate: {
 		randomBattleMoves: ["endeavor", "hiddenpowerground", "quickattack", "return", "reversal", "shadowball", "substitute"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	spearow: {
@@ -71,6 +78,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	fearow: {
 		randomBattleMoves: ["agility", "batonpass", "drillpeck", "hiddenpowerground", "quickattack", "return", "substitute"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	ekans: {
@@ -78,6 +86,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	arbok: {
 		randomBattleMoves: ["doubleedge", "earthquake", "hiddenpowerfire", "rest", "rockslide", "sleeptalk", "sludgebomb"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	pichu: {
@@ -85,10 +94,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	pikachu: {
 		randomBattleMoves: ["hiddenpowerice", "substitute", "surf", "thunderbolt"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	raichu: {
 		randomBattleMoves: ["encore", "focuspunch", "hiddenpowergrass", "hiddenpowerice", "substitute", "surf", "thunderbolt", "thunderwave"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	sandshrew: {
@@ -96,6 +107,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sandslash: {
 		randomBattleMoves: ["earthquake", "hiddenpowerbug", "rapidspin", "rockslide", "swordsdance", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	nidoranf: {
@@ -106,6 +118,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	nidoqueen: {
 		randomBattleMoves: ["earthquake", "fireblast", "icebeam", "shadowball", "sludgebomb", "superpower"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	nidoranm: {
@@ -116,6 +129,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	nidoking: {
 		randomBattleMoves: ["earthquake", "fireblast", "icebeam", "megahorn", "sludgebomb", "substitute", "thunderbolt"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	cleffa: {
@@ -126,6 +140,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	clefable: {
 		randomBattleMoves: ["calmmind", "counter", "icebeam", "return", "shadowball", "softboiled", "thunderbolt", "thunderwave"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	vulpix: {
@@ -133,6 +148,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ninetales: {
 		randomBattleMoves: ["fireblast", "flamethrower", "hiddenpowergrass", "hypnosis", "substitute", "toxic", "willowisp"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	igglybuff: {
@@ -143,6 +159,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wigglytuff: {
 		randomBattleMoves: ["fireblast", "icebeam", "protect", "return", "thunderbolt", "toxic", "wish"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	zubat: {
@@ -153,6 +170,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	crobat: {
 		randomBattleMoves: ["aerialace", "haze", "hiddenpowerground", "shadowball", "sludgebomb", "taunt", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	oddish: {
@@ -163,10 +181,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vileplume: {
 		randomBattleMoves: ["aromatherapy", "hiddenpowerfire", "sleeppowder", "sludgebomb", "solarbeam", "sunnyday", "synthesis"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	bellossom: {
 		randomBattleMoves: ["hiddenpowergrass", "leechseed", "moonlight", "sleeppowder", "sludgebomb", "stunspore"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	paras: {
@@ -174,6 +194,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	parasect: {
 		randomBattleMoves: ["aromatherapy", "gigadrain", "hiddenpowerbug", "return", "spore", "stunspore", "swordsdance"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	venonat: {
@@ -181,6 +202,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	venomoth: {
 		randomBattleMoves: ["batonpass", "hiddenpowerground", "signalbeam", "sleeppowder", "sludgebomb", "substitute"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	diglett: {
@@ -188,6 +210,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dugtrio: {
 		randomBattleMoves: ["aerialace", "earthquake", "hiddenpowerbug", "rockslide", "substitute"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	meowth: {
@@ -195,6 +218,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	persian: {
 		randomBattleMoves: ["fakeout", "hiddenpowerground", "hypnosis", "irontail", "return", "shadowball", "substitute"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	psyduck: {
@@ -202,6 +226,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	golduck: {
 		randomBattleMoves: ["calmmind", "hiddenpowergrass", "hydropump", "hypnosis", "icebeam", "substitute", "surf"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	mankey: {
@@ -209,6 +234,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	primeape: {
 		randomBattleMoves: ["bulkup", "crosschop", "earthquake", "hiddenpowerghost", "rockslide", "substitute"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	growlithe: {
@@ -216,6 +242,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	arcanine: {
 		randomBattleMoves: ["extremespeed", "fireblast", "flamethrower", "hiddenpowergrass", "rest", "sleeptalk", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	poliwag: {
@@ -226,10 +253,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	poliwrath: {
 		randomBattleMoves: ["brickbreak", "bulkup", "hiddenpowerghost", "hydropump", "hypnosis", "icebeam", "substitute"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	politoed: {
 		randomBattleMoves: ["hiddenpowergrass", "hypnosis", "icebeam", "rest", "surf", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	abra: {
@@ -240,6 +269,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	alakazam: {
 		randomBattleMoves: ["calmmind", "encore", "firepunch", "icepunch", "psychic", "recover", "substitute"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	machop: {
@@ -250,6 +280,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	machamp: {
 		randomBattleMoves: ["bulkup", "crosschop", "earthquake", "hiddenpowerghost", "rest", "rockslide", "sleeptalk"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	bellsprout: {
@@ -260,6 +291,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	victreebel: {
 		randomBattleMoves: ["hiddenpowerfire", "sleeppowder", "sludgebomb", "solarbeam", "sunnyday"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	tentacool: {
@@ -267,6 +299,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	tentacruel: {
 		randomBattleMoves: ["gigadrain", "haze", "hydropump", "icebeam", "rapidspin", "surf", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	geodude: {
@@ -277,6 +310,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	golem: {
 		randomBattleMoves: ["doubleedge", "earthquake", "explosion", "hiddenpowerbug", "rockslide", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	ponyta: {
@@ -284,6 +318,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	rapidash: {
 		randomBattleMoves: ["fireblast", "hiddenpowergrass", "hiddenpowerrock", "substitute", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	slowpoke: {
@@ -291,10 +326,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	slowbro: {
 		randomBattleMoves: ["calmmind", "fireblast", "icebeam", "psychic", "rest", "sleeptalk", "surf", "thunderwave"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	slowking: {
 		randomBattleMoves: ["calmmind", "flamethrower", "icebeam", "psychic", "rest", "sleeptalk", "surf", "thunderwave"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	magnemite: {
@@ -302,10 +339,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	magneton: {
 		randomBattleMoves: ["hiddenpowergrass", "hiddenpowerice", "rest", "sleeptalk", "thunderbolt", "toxic"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	farfetchd: {
 		randomBattleMoves: ["agility", "batonpass", "hiddenpowerflying", "return", "swordsdance"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	doduo: {
@@ -313,6 +352,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dodrio: {
 		randomBattleMoves: ["drillpeck", "flail", "hiddenpowerground", "quickattack", "return", "substitute"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	seel: {
@@ -320,6 +360,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dewgong: {
 		randomBattleMoves: ["encore", "hiddenpowergrass", "icebeam", "rest", "sleeptalk", "surf", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	grimer: {
@@ -327,6 +368,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	muk: {
 		randomBattleMoves: ["brickbreak", "curse", "explosion", "fireblast", "hiddenpowerghost", "rest", "sludgebomb"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	shellder: {
@@ -334,6 +376,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cloyster: {
 		randomBattleMoves: ["explosion", "icebeam", "rapidspin", "spikes", "surf", "toxic"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	gastly: {
@@ -344,6 +387,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gengar: {
 		randomBattleMoves: ["destinybond", "explosion", "firepunch", "hypnosis", "icepunch", "substitute", "thunderbolt", "willowisp"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	onix: {
@@ -351,6 +395,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	steelix: {
 		randomBattleMoves: ["doubleedge", "earthquake", "explosion", "hiddenpowerrock", "irontail", "rest", "roar", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	drowzee: {
@@ -358,6 +403,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hypno: {
 		randomBattleMoves: ["batonpass", "calmmind", "firepunch", "hypnosis", "protect", "psychic", "toxic", "wish"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	krabby: {
@@ -365,6 +411,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kingler: {
 		randomBattleMoves: ["doubleedge", "hiddenpowerghost", "hiddenpowerground", "surf", "swordsdance"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	voltorb: {
@@ -372,6 +419,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	electrode: {
 		randomBattleMoves: ["explosion", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderbolt", "thunderwave", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	exeggcute: {
@@ -379,6 +427,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	exeggutor: {
 		randomBattleMoves: ["explosion", "gigadrain", "hiddenpowerfire", "hiddenpowerice", "leechseed", "psychic", "sleeppowder", "solarbeam", "sunnyday"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	cubone: {
@@ -386,6 +435,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	marowak: {
 		randomBattleMoves: ["bonemerang", "doubleedge", "earthquake", "rockslide", "swordsdance"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	tyrogue: {
@@ -393,18 +443,22 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hitmonlee: {
 		randomBattleMoves: ["bulkup", "earthquake", "hiddenpowerghost", "highjumpkick", "machpunch", "rockslide", "substitute"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	hitmonchan: {
 		randomBattleMoves: ["bulkup", "earthquake", "hiddenpowerghost", "machpunch", "rapidspin", "skyuppercut", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	hitmontop: {
 		randomBattleMoves: ["bulkup", "earthquake", "hiddenpowerghost", "highjumpkick", "machpunch", "rockslide", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	lickitung: {
 		randomBattleMoves: ["counter", "healbell", "protect", "return", "seismictoss", "toxic", "wish"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	koffing: {
@@ -412,6 +466,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	weezing: {
 		randomBattleMoves: ["explosion", "fireblast", "haze", "painsplit", "sludgebomb", "toxic", "willowisp"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	rhyhorn: {
@@ -419,6 +474,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	rhydon: {
 		randomBattleMoves: ["doubleedge", "earthquake", "megahorn", "rockslide", "substitute", "swordsdance"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	chansey: {
@@ -426,14 +482,17 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	blissey: {
 		randomBattleMoves: ["aromatherapy", "calmmind", "icebeam", "seismictoss", "softboiled", "thunderbolt", "thunderwave", "toxic"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	tangela: {
 		randomBattleMoves: ["hiddenpowergrass", "leechseed", "morningsun", "sleeppowder", "stunspore"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	kangaskhan: {
 		randomBattleMoves: ["earthquake", "fakeout", "focuspunch", "rest", "return", "shadowball", "substitute", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	horsea: {
@@ -444,6 +503,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kingdra: {
 		randomBattleMoves: ["hiddenpowergrass", "hydropump", "icebeam", "raindance", "substitute", "surf"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	goldeen: {
@@ -451,6 +511,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	seaking: {
 		randomBattleMoves: ["hiddenpowergrass", "hydropump", "icebeam", "megahorn", "raindance"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	staryu: {
@@ -458,18 +519,22 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	starmie: {
 		randomBattleMoves: ["hydropump", "icebeam", "psychic", "recover", "surf", "thunderbolt"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	mrmime: {
 		randomBattleMoves: ["barrier", "batonpass", "calmmind", "encore", "firepunch", "hypnosis", "psychic", "substitute", "thunderbolt"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	scyther: {
 		randomBattleMoves: ["aerialace", "batonpass", "hiddenpowerground", "hiddenpowerrock", "quickattack", "silverwind", "swordsdance"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	scizor: {
 		randomBattleMoves: ["agility", "batonpass", "hiddenpowerground", "hiddenpowerrock", "morningsun", "silverwind", "steelwing", "swordsdance"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	smoochum: {
@@ -477,6 +542,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	jynx: {
 		randomBattleMoves: ["calmmind", "hiddenpowerfire", "icebeam", "lovelykiss", "psychic", "substitute"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	elekid: {
@@ -484,6 +550,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	electabuzz: {
 		randomBattleMoves: ["crosschop", "firepunch", "focuspunch", "hiddenpowergrass", "icepunch", "substitute", "thunderbolt"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	magby: {
@@ -491,14 +558,17 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	magmar: {
 		randomBattleMoves: ["crosschop", "fireblast", "flamethrower", "hiddenpowergrass", "psychic", "substitute", "thunderpunch"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	pinsir: {
 		randomBattleMoves: ["earthquake", "hiddenpowerbug", "return", "rockslide", "swordsdance"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	tauros: {
 		randomBattleMoves: ["doubleedge", "earthquake", "hiddenpowerghost", "hiddenpowerrock", "return"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	magikarp: {
@@ -506,14 +576,17 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gyarados: {
 		randomBattleMoves: ["doubleedge", "dragondance", "earthquake", "hiddenpowerflying", "hydropump", "taunt"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	lapras: {
 		randomBattleMoves: ["healbell", "icebeam", "rest", "sleeptalk", "surf", "thunderbolt", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	ditto: {
 		randomBattleMoves: ["transform"],
+		randomBattleLevel: 100,
 		tier: "PU",
 	},
 	eevee: {
@@ -521,22 +594,27 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vaporeon: {
 		randomBattleMoves: ["icebeam", "protect", "surf", "toxic", "wish"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	jolteon: {
 		randomBattleMoves: ["batonpass", "hiddenpowerice", "substitute", "thunderbolt", "toxic", "wish"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	flareon: {
 		randomBattleMoves: ["doubleedge", "fireblast", "hiddenpowergrass", "protect", "shadowball", "toxic", "wish"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	espeon: {
 		randomBattleMoves: ["batonpass", "calmmind", "hiddenpowerfire", "morningsun", "psychic", "reflect"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	umbreon: {
 		randomBattleMoves: ["batonpass", "hiddenpowerdark", "protect", "toxic", "wish"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	porygon: {
@@ -544,6 +622,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	porygon2: {
 		randomBattleMoves: ["icebeam", "recover", "return", "thunderbolt", "thunderwave", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	omanyte: {
@@ -551,6 +630,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	omastar: {
 		randomBattleMoves: ["hiddenpowergrass", "hydropump", "icebeam", "raindance", "spikes", "surf"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	kabuto: {
@@ -558,26 +638,32 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kabutops: {
 		randomBattleMoves: ["brickbreak", "doubleedge", "hiddenpowerground", "rockslide", "surf", "swordsdance"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	aerodactyl: {
 		randomBattleMoves: ["doubleedge", "earthquake", "hiddenpowerflying", "rockslide", "substitute"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	snorlax: {
 		randomBattleMoves: ["bodyslam", "curse", "earthquake", "rest", "return", "selfdestruct", "shadowball", "sleeptalk"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	articuno: {
 		randomBattleMoves: ["healbell", "hiddenpowerfire", "icebeam", "protect", "rest", "roar", "sleeptalk", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	zapdos: {
 		randomBattleMoves: ["agility", "batonpass", "hiddenpowerice", "substitute", "thunderbolt", "thunderwave", "toxic"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	moltres: {
 		randomBattleMoves: ["fireblast", "flamethrower", "hiddenpowergrass", "morningsun", "substitute", "toxic", "willowisp"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	dratini: {
@@ -588,14 +674,17 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dragonite: {
 		randomBattleMoves: ["doubleedge", "dragondance", "earthquake", "flamethrower", "healbell", "hiddenpowerflying", "icebeam", "substitute"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	mewtwo: {
 		randomBattleMoves: ["calmmind", "flamethrower", "icebeam", "psychic", "recover", "substitute", "thunderbolt"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	mew: {
 		randomBattleMoves: ["calmmind", "explosion", "flamethrower", "icebeam", "psychic", "softboiled", "thunderbolt", "thunderwave", "transform"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	chikorita: {
@@ -606,6 +695,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	meganium: {
 		randomBattleMoves: ["bodyslam", "hiddenpowergrass", "leechseed", "synthesis", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	cyndaquil: {
@@ -616,6 +706,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	typhlosion: {
 		randomBattleMoves: ["fireblast", "flamethrower", "focuspunch", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderpunch"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	totodile: {
@@ -626,6 +717,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	feraligatr: {
 		randomBattleMoves: ["earthquake", "hiddenpowerflying", "hydropump", "rockslide", "swordsdance"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	sentret: {
@@ -633,6 +725,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	furret: {
 		randomBattleMoves: ["doubleedge", "quickattack", "return", "reversal", "shadowball", "substitute", "trick"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	hoothoot: {
@@ -640,6 +733,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	noctowl: {
 		randomBattleMoves: ["hypnosis", "psychic", "reflect", "toxic", "whirlwind"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	ledyba: {
@@ -647,6 +741,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ledian: {
 		randomBattleMoves: ["agility", "batonpass", "lightscreen", "reflect", "silverwind", "swordsdance", "toxic"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	spinarak: {
@@ -654,6 +749,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ariados: {
 		randomBattleMoves: ["agility", "batonpass", "signalbeam", "sludgebomb", "spiderweb", "toxic"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	chinchou: {
@@ -661,6 +757,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lanturn: {
 		randomBattleMoves: ["confuseray", "icebeam", "rest", "sleeptalk", "surf", "thunderbolt", "thunderwave", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	togepi: {
@@ -668,6 +765,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	togetic: {
 		randomBattleMoves: ["charm", "encore", "flamethrower", "seismictoss", "softboiled", "thunderwave", "toxic"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	natu: {
@@ -675,6 +773,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	xatu: {
 		randomBattleMoves: ["batonpass", "calmmind", "hiddenpowerfire", "psychic", "reflect", "wish"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	mareep: {
@@ -685,6 +784,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ampharos: {
 		randomBattleMoves: ["firepunch", "healbell", "hiddenpowergrass", "hiddenpowerice", "thunderbolt", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	azurill: {
@@ -695,10 +795,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	azumarill: {
 		randomBattleMoves: ["brickbreak", "encore", "hiddenpowerghost", "hydropump", "return"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	sudowoodo: {
 		randomBattleMoves: ["brickbreak", "doubleedge", "earthquake", "explosion", "rockslide", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	hoppip: {
@@ -709,10 +811,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	jumpluff: {
 		randomBattleMoves: ["encore", "hiddenpowerflying", "leechseed", "sleeppowder", "substitute", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	aipom: {
 		randomBattleMoves: ["batonpass", "doubleedge", "focuspunch", "shadowball", "substitute", "thunderwave"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	sunkern: {
@@ -720,10 +824,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sunflora: {
 		randomBattleMoves: ["hiddenpowerfire", "leechseed", "razorleaf", "synthesis", "toxic"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	yanma: {
 		randomBattleMoves: ["hiddenpowerflying", "hypnosis", "reversal", "shadowball", "substitute"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	wooper: {
@@ -731,18 +837,22 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	quagsire: {
 		randomBattleMoves: ["counter", "curse", "earthquake", "hiddenpowerrock", "icebeam", "rest", "surf", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	murkrow: {
 		randomBattleMoves: ["doubleedge", "drillpeck", "hiddenpowerfighting", "hiddenpowerground", "meanlook", "perishsong", "protect", "shadowball", "substitute"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	misdreavus: {
 		randomBattleMoves: ["calmmind", "hiddenpowerice", "meanlook", "perishsong", "protect", "substitute", "thunderbolt", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	unown: {
 		randomBattleMoves: ["hiddenpowerpsychic"],
+		randomBattleLevel: 100,
 		tier: "PU",
 	},
 	wynaut: {
@@ -750,10 +860,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wobbuffet: {
 		randomBattleMoves: ["counter", "destinybond", "encore", "mirrorcoat"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	girafarig: {
 		randomBattleMoves: ["agility", "batonpass", "calmmind", "psychic", "substitute", "thunderbolt", "thunderwave", "wish"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	pineco: {
@@ -761,14 +873,17 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	forretress: {
 		randomBattleMoves: ["earthquake", "explosion", "hiddenpowerbug", "rapidspin", "spikes", "toxic"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	dunsparce: {
 		randomBattleMoves: ["bodyslam", "curse", "headbutt", "rest", "rockslide", "shadowball", "thunderwave"],
+		randomBattleLevel: 80,
 		tier: "PUBL",
 	},
 	gligar: {
 		randomBattleMoves: ["earthquake", "hiddenpowerflying", "irontail", "quickattack", "rockslide", "substitute", "swordsdance"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	snubbull: {
@@ -776,22 +891,27 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	granbull: {
 		randomBattleMoves: ["bulkup", "earthquake", "healbell", "overheat", "rest", "return", "shadowball", "thunderwave"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	qwilfish: {
 		randomBattleMoves: ["destinybond", "hydropump", "selfdestruct", "shadowball", "sludgebomb", "spikes", "swordsdance"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	shuckle: {
 		randomBattleMoves: ["encore", "rest", "toxic", "wrap"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	heracross: {
 		randomBattleMoves: ["brickbreak", "focuspunch", "megahorn", "rest", "rockslide", "sleeptalk", "substitute", "swordsdance"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	sneasel: {
 		randomBattleMoves: ["brickbreak", "doubleedge", "hiddenpowerflying", "shadowball", "substitute", "swordsdance"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	teddiursa: {
@@ -799,6 +919,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ursaring: {
 		randomBattleMoves: ["earthquake", "focuspunch", "hiddenpowerghost", "return", "swordsdance"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	slugma: {
@@ -806,6 +927,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	magcargo: {
 		randomBattleMoves: ["fireblast", "hiddenpowergrass", "rest", "sleeptalk", "toxic", "yawn"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	swinub: {
@@ -813,10 +935,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	piloswine: {
 		randomBattleMoves: ["doubleedge", "earthquake", "icebeam", "protect", "rockslide", "toxic"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	corsola: {
 		randomBattleMoves: ["calmmind", "confuseray", "icebeam", "recover", "surf", "toxic"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	remoraid: {
@@ -824,18 +948,22 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	octillery: {
 		randomBattleMoves: ["fireblast", "hiddenpowergrass", "icebeam", "rockblast", "surf", "thunderwave"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	delibird: {
 		randomBattleMoves: ["aerialace", "focuspunch", "hiddenpowerground", "icebeam", "quickattack"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	mantine: {
 		randomBattleMoves: ["haze", "hiddenpowergrass", "icebeam", "raindance", "rest", "sleeptalk", "surf", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	skarmory: {
 		randomBattleMoves: ["drillpeck", "hiddenpowerground", "protect", "rest", "sleeptalk", "spikes", "toxic", "whirlwind"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	houndour: {
@@ -843,6 +971,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	houndoom: {
 		randomBattleMoves: ["crunch", "fireblast", "flamethrower", "hiddenpowergrass", "pursuit", "willowisp"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	phanpy: {
@@ -850,30 +979,37 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	donphan: {
 		randomBattleMoves: ["earthquake", "rapidspin", "rest", "rockslide", "sleeptalk", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	stantler: {
 		randomBattleMoves: ["earthquake", "hypnosis", "return", "shadowball", "thunderbolt"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	smeargle: {
 		randomBattleMoves: ["encore", "explosion", "spikes", "spore"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	miltank: {
 		randomBattleMoves: ["bodyslam", "curse", "earthquake", "healbell", "milkdrink", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	raikou: {
 		randomBattleMoves: ["calmmind", "crunch", "hiddenpowergrass", "hiddenpowerice", "rest", "sleeptalk", "substitute", "thunderbolt"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	entei: {
 		randomBattleMoves: ["bodyslam", "calmmind", "fireblast", "flamethrower", "hiddenpowergrass", "hiddenpowerice", "solarbeam", "substitute", "sunnyday"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	suicune: {
 		randomBattleMoves: ["calmmind", "icebeam", "rest", "sleeptalk", "substitute", "surf", "toxic"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	larvitar: {
@@ -884,18 +1020,22 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	tyranitar: {
 		randomBattleMoves: ["dragondance", "earthquake", "fireblast", "focuspunch", "hiddenpowerbug", "icebeam", "pursuit", "rockslide", "substitute"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	lugia: {
 		randomBattleMoves: ["aeroblast", "calmmind", "earthquake", "icebeam", "recover", "substitute", "thunderbolt", "toxic"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	hooh: {
 		randomBattleMoves: ["calmmind", "earthquake", "recover", "sacredfire", "substitute", "thunderbolt", "toxic"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	celebi: {
 		randomBattleMoves: ["batonpass", "calmmind", "healbell", "hiddenpowergrass", "leechseed", "psychic", "recover"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	treecko: {
@@ -906,6 +1046,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sceptile: {
 		randomBattleMoves: ["focuspunch", "hiddenpowerice", "leafblade", "leechseed", "substitute", "thunderpunch"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	torchic: {
@@ -916,6 +1057,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	blaziken: {
 		randomBattleMoves: ["endure", "fireblast", "hiddenpowerice", "reversal", "rockslide", "skyuppercut", "swordsdance", "thunderpunch"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	mudkip: {
@@ -926,6 +1068,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swampert: {
 		randomBattleMoves: ["earthquake", "hydropump", "icebeam", "protect", "rest", "rockslide", "sleeptalk", "surf", "toxic"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	poochyena: {
@@ -933,6 +1076,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mightyena: {
 		randomBattleMoves: ["crunch", "doubleedge", "healbell", "hiddenpowerfighting", "protect", "shadowball", "toxic"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	zigzagoon: {
@@ -940,6 +1084,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	linoone: {
 		randomBattleMoves: ["bellydrum", "extremespeed", "flail", "hiddenpowerground", "shadowball", "substitute"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	wurmple: {
@@ -950,6 +1095,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	beautifly: {
 		randomBattleMoves: ["hiddenpowerbug", "hiddenpowerflying", "morningsun", "stunspore", "substitute", "toxic"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	cascoon: {
@@ -957,6 +1103,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dustox: {
 		randomBattleMoves: ["hiddenpowerground", "lightscreen", "moonlight", "sludgebomb", "toxic", "whirlwind"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	lotad: {
@@ -967,6 +1114,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ludicolo: {
 		randomBattleMoves: ["hiddenpowergrass", "icebeam", "leechseed", "raindance", "substitute", "surf"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	seedot: {
@@ -977,6 +1125,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	shiftry: {
 		randomBattleMoves: ["brickbreak", "explosion", "shadowball", "swordsdance"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	taillow: {
@@ -984,6 +1133,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swellow: {
 		randomBattleMoves: ["aerialace", "doubleedge", "hiddenpowerfighting", "hiddenpowerground", "quickattack", "return"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	wingull: {
@@ -991,6 +1141,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	pelipper: {
 		randomBattleMoves: ["icebeam", "protect", "rest", "sleeptalk", "surf", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	ralts: {
@@ -1001,6 +1152,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gardevoir: {
 		randomBattleMoves: ["calmmind", "firepunch", "hypnosis", "psychic", "substitute", "thunderbolt", "willowisp"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	surskit: {
@@ -1008,6 +1160,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	masquerain: {
 		randomBattleMoves: ["hydropump", "icebeam", "stunspore", "substitute", "toxic"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	shroomish: {
@@ -1015,6 +1168,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	breloom: {
 		randomBattleMoves: ["focuspunch", "hiddenpowerghost", "hiddenpowerrock", "leechseed", "machpunch", "skyuppercut", "spore", "substitute", "swordsdance"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	slakoth: {
@@ -1022,10 +1176,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vigoroth: {
 		randomBattleMoves: ["brickbreak", "bulkup", "earthquake", "return", "shadowball", "slackoff"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	slaking: {
 		randomBattleMoves: ["doubleedge", "earthquake", "focuspunch", "return", "shadowball"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	nincada: {
@@ -1033,10 +1189,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ninjask: {
 		randomBattleMoves: ["aerialace", "batonpass", "hiddenpowerrock", "protect", "silverwind", "substitute", "swordsdance"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	shedinja: {
 		randomBattleMoves: ["agility", "batonpass", "hiddenpowerground", "shadowball", "silverwind", "toxic"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	whismur: {
@@ -1047,6 +1205,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	exploud: {
 		randomBattleMoves: ["earthquake", "flamethrower", "icebeam", "overheat", "return", "shadowball", "substitute"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	makuhita: {
@@ -1054,10 +1213,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hariyama: {
 		randomBattleMoves: ["bulkup", "crosschop", "fakeout", "hiddenpowerghost", "rest", "rockslide", "sleeptalk"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	nosepass: {
 		randomBattleMoves: ["earthquake", "explosion", "rockslide", "thunderwave", "toxic"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	skitty: {
@@ -1065,14 +1226,17 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	delcatty: {
 		randomBattleMoves: ["batonpass", "doubleedge", "healbell", "thunderwave", "wish"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	sableye: {
 		randomBattleMoves: ["knockoff", "recover", "seismictoss", "shadowball", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	mawile: {
 		randomBattleMoves: ["batonpass", "brickbreak", "focuspunch", "hiddenpowersteel", "rockslide", "substitute", "swordsdance", "toxic"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	aron: {
@@ -1083,6 +1247,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	aggron: {
 		randomBattleMoves: ["doubleedge", "earthquake", "focuspunch", "irontail", "rockslide", "substitute", "thunderwave", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	meditite: {
@@ -1090,6 +1255,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	medicham: {
 		randomBattleMoves: ["brickbreak", "bulkup", "recover", "rockslide", "shadowball", "substitute"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	electrike: {
@@ -1097,26 +1263,32 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	manectric: {
 		randomBattleMoves: ["crunch", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderbolt", "thunderwave"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	plusle: {
 		randomBattleMoves: ["agility", "batonpass", "encore", "hiddenpowergrass", "substitute", "thunderbolt", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	minun: {
 		randomBattleMoves: ["batonpass", "encore", "hiddenpowerice", "lightscreen", "substitute", "thunderbolt", "wish"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	volbeat: {
 		randomBattleMoves: ["batonpass", "icepunch", "tailglow", "thunderbolt"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	illumise: {
 		randomBattleMoves: ["batonpass", "encore", "icepunch", "substitute", "thunderwave", "wish"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	roselia: {
 		randomBattleMoves: ["aromatherapy", "gigadrain", "hiddenpowerfire", "spikes", "stunspore", "synthesis"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	gulpin: {
@@ -1124,6 +1296,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swalot: {
 		randomBattleMoves: ["encore", "explosion", "hiddenpowerground", "icebeam", "sludgebomb", "toxic", "yawn"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	carvanha: {
@@ -1131,6 +1304,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sharpedo: {
 		randomBattleMoves: ["crunch", "earthquake", "endure", "hiddenpowerflying", "hydropump", "icebeam", "return"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	wailmer: {
@@ -1138,6 +1312,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wailord: {
 		randomBattleMoves: ["hiddenpowergrass", "icebeam", "rest", "selfdestruct", "sleeptalk", "surf", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	numel: {
@@ -1145,10 +1320,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	camerupt: {
 		randomBattleMoves: ["earthquake", "explosion", "fireblast", "rest", "rockslide", "sleeptalk", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	torkoal: {
 		randomBattleMoves: ["explosion", "fireblast", "flamethrower", "hiddenpowergrass", "rest", "toxic", "yawn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	spoink: {
@@ -1156,10 +1333,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	grumpig: {
 		randomBattleMoves: ["calmmind", "firepunch", "icywind", "psychic", "substitute", "taunt"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	spinda: {
 		randomBattleMoves: ["bodyslam", "encore", "focuspunch", "shadowball", "substitute", "teeterdance", "toxic"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	trapinch: {
@@ -1170,6 +1349,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	flygon: {
 		randomBattleMoves: ["dragonclaw", "earthquake", "fireblast", "hiddenpowerbug", "rockslide", "substitute", "toxic"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	cacnea: {
@@ -1177,6 +1357,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cacturne: {
 		randomBattleMoves: ["focuspunch", "hiddenpowerdark", "leechseed", "needlearm", "spikes", "substitute", "thunderpunch"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	swablu: {
@@ -1184,22 +1365,27 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	altaria: {
 		randomBattleMoves: ["dragonclaw", "dragondance", "earthquake", "fireblast", "flamethrower", "haze", "hiddenpowerflying", "rest", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	zangoose: {
 		randomBattleMoves: ["brickbreak", "quickattack", "return", "shadowball", "swordsdance"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	seviper: {
 		randomBattleMoves: ["crunch", "doubleedge", "earthquake", "flamethrower", "hiddenpowergrass", "sludgebomb"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	lunatone: {
 		randomBattleMoves: ["batonpass", "calmmind", "explosion", "hypnosis", "icebeam", "psychic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	solrock: {
 		randomBattleMoves: ["earthquake", "explosion", "overheat", "reflect", "rockslide", "shadowball"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	barboach: {
@@ -1207,6 +1393,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	whiscash: {
 		randomBattleMoves: ["earthquake", "hiddenpowerbug", "icebeam", "rest", "rockslide", "sleeptalk", "spark", "surf", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	corphish: {
@@ -1214,6 +1401,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	crawdaunt: {
 		randomBattleMoves: ["brickbreak", "crunch", "doubleedge", "hiddenpowerghost", "icebeam", "surf"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	baltoy: {
@@ -1221,6 +1409,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	claydol: {
 		randomBattleMoves: ["earthquake", "explosion", "icebeam", "psychic", "rapidspin", "toxic"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	lileep: {
@@ -1228,6 +1417,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cradily: {
 		randomBattleMoves: ["barrier", "earthquake", "hiddenpowergrass", "mirrorcoat", "recover", "rockslide", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	anorith: {
@@ -1235,6 +1425,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	armaldo: {
 		randomBattleMoves: ["doubleedge", "earthquake", "hiddenpowerbug", "rockslide", "swordsdance"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	feebas: {
@@ -1242,10 +1433,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	milotic: {
 		randomBattleMoves: ["icebeam", "mirrorcoat", "recover", "surf", "toxic"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	castform: {
 		randomBattleMoves: ["flamethrower", "icebeam", "substitute", "thunderbolt", "thunderwave"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	castformsunny: {
@@ -1259,6 +1452,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kecleon: {
 		randomBattleMoves: ["brickbreak", "return", "shadowball", "thunderwave", "trick"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	shuppet: {
@@ -1266,6 +1460,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	banette: {
 		randomBattleMoves: ["destinybond", "endure", "hiddenpowerfighting", "knockoff", "shadowball", "willowisp"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	duskull: {
@@ -1273,18 +1468,22 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dusclops: {
 		randomBattleMoves: ["focuspunch", "icebeam", "painsplit", "rest", "shadowball", "sleeptalk", "substitute", "willowisp"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	tropius: {
 		randomBattleMoves: ["hiddenpowerfire", "solarbeam", "sunnyday", "synthesis"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	chimecho: {
 		randomBattleMoves: ["calmmind", "healbell", "hiddenpowerfire", "lightscreen", "psychic", "reflect", "toxic", "yawn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	absol: {
 		randomBattleMoves: ["batonpass", "hiddenpowerfighting", "quickattack", "shadowball", "swordsdance"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	snorunt: {
@@ -1292,6 +1491,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	glalie: {
 		randomBattleMoves: ["earthquake", "explosion", "icebeam", "spikes", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	spheal: {
@@ -1302,6 +1502,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	walrein: {
 		randomBattleMoves: ["encore", "hiddenpowergrass", "icebeam", "rest", "sleeptalk", "surf", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	clamperl: {
@@ -1309,18 +1510,22 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	huntail: {
 		randomBattleMoves: ["doubleedge", "hiddenpowergrass", "hydropump", "icebeam", "raindance", "surf"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	gorebyss: {
 		randomBattleMoves: ["hiddenpowerelectric", "hiddenpowergrass", "hydropump", "icebeam", "raindance", "surf"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	relicanth: {
 		randomBattleMoves: ["doubleedge", "earthquake", "hiddenpowerflying", "rest", "rockslide", "sleeptalk", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	luvdisc: {
 		randomBattleMoves: ["icebeam", "protect", "substitute", "surf", "sweetkiss", "toxic"],
+		randomBattleLevel: 90,
 		tier: "PU",
 	},
 	bagon: {
@@ -1331,6 +1536,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	salamence: {
 		randomBattleMoves: ["brickbreak", "dragondance", "earthquake", "fireblast", "hiddenpowerflying", "rockslide"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	beldum: {
@@ -1341,58 +1547,72 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	metagross: {
 		randomBattleMoves: ["agility", "earthquake", "explosion", "meteormash", "psychic", "rockslide"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	regirock: {
 		randomBattleMoves: ["curse", "earthquake", "explosion", "rest", "rockslide", "superpower", "thunderwave"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	regice: {
 		randomBattleMoves: ["explosion", "icebeam", "rest", "sleeptalk", "thunderbolt", "thunderwave", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	registeel: {
 		randomBattleMoves: ["rest", "seismictoss", "sleeptalk", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	latias: {
 		randomBattleMoves: ["calmmind", "dragonclaw", "hiddenpowerfire", "recover", "refresh", "toxic"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	latios: {
 		randomBattleMoves: ["calmmind", "dragonclaw", "hiddenpowerfire", "psychic", "recover", "thunderbolt"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	kyogre: {
 		randomBattleMoves: ["calmmind", "icebeam", "rest", "sleeptalk", "surf", "thunder"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	groudon: {
 		randomBattleMoves: ["earthquake", "hiddenpowerbug", "overheat", "rockslide", "substitute", "swordsdance", "thunderwave"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	rayquaza: {
 		randomBattleMoves: ["dragondance", "earthquake", "extremespeed", "hiddenpowerflying", "overheat", "rockslide"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	jirachi: {
 		randomBattleMoves: ["bodyslam", "calmmind", "firepunch", "icepunch", "protect", "psychic", "substitute", "thunderbolt", "wish"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	deoxys: {
 		randomBattleMoves: ["extremespeed", "firepunch", "icebeam", "psychoboost", "shadowball", "superpower"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	deoxysattack: {
 		randomBattleMoves: ["extremespeed", "firepunch", "psychoboost", "shadowball", "superpower"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	deoxysdefense: {
 		randomBattleMoves: ["nightshade", "recover", "spikes", "taunt", "toxic"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	deoxysspeed: {
 		randomBattleMoves: ["calmmind", "icebeam", "psychic", "recover", "spikes", "taunt", "toxic"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 };

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -540,7 +540,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			Ditto: 100, Unown: 100,
 		};
 		const tier = species.tier;
-		const level = this.adjustLevel || customScale[species.name] || levelScale[tier] || (species.nfe ? 90 : 80);
+		const level = this.adjustLevel || species.randomBattleLevel || customScale[species.name] || levelScale[tier] || (species.nfe ? 90 : 80);
 
 		// Prepare optimal HP
 		let hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -540,7 +540,11 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			Ditto: 100, Unown: 100,
 		};
 		const tier = species.tier;
-		const level = this.adjustLevel || species.randomBattleLevel || customScale[species.name] || levelScale[tier] || (species.nfe ? 90 : 80);
+		const level = this.adjustLevel ||
+					  species.randomBattleLevel ||
+					  customScale[species.name] ||
+					  levelScale[tier] ||
+					  (species.nfe ? 90 : 80);
 
 		// Prepare optimal HP
 		let hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -526,25 +526,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		}
 
 		const item = this.getItem(ability, types, moves, counter, species);
-		const levelScale: {[k: string]: number} = {
-			Uber: 76,
-			OU: 80,
-			UUBL: 82,
-			UU: 84,
-			NUBL: 86,
-			NU: 88,
-			PU: 90,
-			NFE: 90,
-		};
-		const customScale: {[k: string]: number} = {
-			Ditto: 100, Unown: 100,
-		};
-		const tier = species.tier;
-		const level = this.adjustLevel ||
-					  species.randomBattleLevel ||
-					  customScale[species.name] ||
-					  levelScale[tier] ||
-					  (species.nfe ? 90 : 80);
+		const level = this.adjustLevel || species.randomBattleLevel || (species.nfe ? 90 : 80);
 
 		// Prepare optimal HP
 		let hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);

--- a/data/mods/gen4/formats-data.ts
+++ b/data/mods/gen4/formats-data.ts
@@ -7,6 +7,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	venusaur: {
 		randomBattleMoves: ["earthquake", "hiddenpowerice", "leafstorm", "leechseed", "powerwhip", "sleeppowder", "sludgebomb", "swordsdance", "synthesis"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	charmander: {
@@ -17,6 +18,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	charizard: {
 		randomBattleMoves: ["airslash", "dragonpulse", "fireblast", "flamethrower", "hiddenpowergrass", "roost"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	squirtle: {
@@ -27,6 +29,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	blastoise: {
 		randomBattleMoves: ["icebeam", "rapidspin", "rest", "roar", "sleeptalk", "surf", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	caterpie: {
@@ -37,6 +40,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	butterfree: {
 		randomBattleMoves: ["bugbuzz", "safeguard", "sleeppowder", "stunspore", "uturn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	weedle: {
@@ -47,6 +51,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	beedrill: {
 		randomBattleMoves: ["brickbreak", "poisonjab", "swordsdance", "toxicspikes", "uturn", "xscissor"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	pidgey: {
@@ -57,6 +62,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	pidgeot: {
 		randomBattleMoves: ["bravebird", "doubleedge", "heatwave", "pursuit", "quickattack", "uturn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	rattata: {
@@ -64,6 +70,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	raticate: {
 		randomBattleMoves: ["crunch", "facade", "protect", "suckerpunch", "swordsdance", "uturn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	spearow: {
@@ -71,6 +78,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	fearow: {
 		randomBattleMoves: ["doubleedge", "drillpeck", "heatwave", "pursuit", "quickattack", "return", "uturn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	ekans: {
@@ -78,6 +86,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	arbok: {
 		randomBattleMoves: ["aquatail", "crunch", "earthquake", "glare", "gunkshot", "poisonjab", "seedbomb", "switcheroo"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	pichu: {
@@ -88,10 +97,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	pikachu: {
 		randomBattleMoves: ["grassknot", "hiddenpowerice", "substitute", "surf", "thunderbolt", "volttackle"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	raichu: {
 		randomBattleMoves: ["encore", "focusblast", "focuspunch", "grassknot", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	sandshrew: {
@@ -99,6 +110,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sandslash: {
 		randomBattleMoves: ["earthquake", "nightslash", "rapidspin", "stealthrock", "stoneedge", "substitute", "swordsdance"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	nidoranf: {
@@ -109,6 +121,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	nidoqueen: {
 		randomBattleMoves: ["earthquake", "fireblast", "icebeam", "roar", "stealthrock", "toxicspikes"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	nidoranm: {
@@ -119,6 +132,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	nidoking: {
 		randomBattleMoves: ["earthquake", "fireblast", "icebeam", "megahorn", "stealthrock", "suckerpunch", "thunderbolt"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	cleffa: {
@@ -129,6 +143,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	clefable: {
 		randomBattleMoves: ["calmmind", "doubleedge", "fireblast", "icebeam", "softboiled", "stealthrock", "thunderbolt"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	vulpix: {
@@ -136,6 +151,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ninetales: {
 		randomBattleMoves: ["energyball", "fireblast", "flamethrower", "hiddenpowerrock", "hypnosis", "nastyplot"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	igglybuff: {
@@ -146,6 +162,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wigglytuff: {
 		randomBattleMoves: ["bodyslam", "doubleedge", "fireblast", "healbell", "protect", "seismictoss", "stealthrock", "thunderwave", "toxic", "wish"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	zubat: {
@@ -156,6 +173,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	crobat: {
 		randomBattleMoves: ["bravebird", "heatwave", "nastyplot", "roost", "sludgebomb", "superfang", "taunt", "uturn"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	oddish: {
@@ -166,10 +184,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vileplume: {
 		randomBattleMoves: ["energyball", "hiddenpowerfire", "moonlight", "sleeppowder", "sludgebomb", "solarbeam", "sunnyday"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	bellossom: {
 		randomBattleMoves: ["hiddenpowerfire", "leafstorm", "moonlight", "sleeppowder", "sludgebomb", "solarbeam", "sunnyday"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	paras: {
@@ -177,6 +197,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	parasect: {
 		randomBattleMoves: ["seedbomb", "spore", "stunspore", "synthesis", "xscissor"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	venonat: {
@@ -184,6 +205,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	venomoth: {
 		randomBattleMoves: ["bugbuzz", "psychic", "roost", "sleeppowder", "stunspore", "substitute", "toxicspikes", "uturn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	diglett: {
@@ -191,6 +213,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dugtrio: {
 		randomBattleMoves: ["earthquake", "nightslash", "stealthrock", "stoneedge", "substitute", "suckerpunch"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	meowth: {
@@ -198,6 +221,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	persian: {
 		randomBattleMoves: ["bite", "fakeout", "hypnosis", "nastyplot", "return", "swift", "taunt", "uturn", "waterpulse"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	psyduck: {
@@ -205,6 +229,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	golduck: {
 		randomBattleMoves: ["calmmind", "encore", "hiddenpowergrass", "hydropump", "icebeam", "psychic", "surf"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	mankey: {
@@ -212,6 +237,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	primeape: {
 		randomBattleMoves: ["closecombat", "encore", "icepunch", "punishment", "stoneedge", "uturn"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	growlithe: {
@@ -219,6 +245,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	arcanine: {
 		randomBattleMoves: ["extremespeed", "flareblitz", "hiddenpowergrass", "morningsun", "thunderfang", "toxic", "willowisp"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	poliwag: {
@@ -229,10 +256,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	poliwrath: {
 		randomBattleMoves: ["brickbreak", "bulkup", "encore", "focuspunch", "icepunch", "rest", "sleeptalk", "substitute", "toxic", "waterfall"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	politoed: {
 		randomBattleMoves: ["encore", "focusblast", "hiddenpowergrass", "hydropump", "icebeam", "protect", "surf", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	abra: {
@@ -243,6 +272,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	alakazam: {
 		randomBattleMoves: ["encore", "focusblast", "hiddenpowerfire", "psychic", "shadowball", "signalbeam", "substitute", "trick"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	machop: {
@@ -253,6 +283,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	machamp: {
 		randomBattleMoves: ["bulkup", "bulletpunch", "dynamicpunch", "icepunch", "payback", "stoneedge", "substitute"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	bellsprout: {
@@ -263,6 +294,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	victreebel: {
 		randomBattleMoves: ["leafblade", "leafstorm", "sleeppowder", "sludgebomb", "solarbeam", "suckerpunch", "sunnyday", "weatherball"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	tentacool: {
@@ -270,6 +302,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	tentacruel: {
 		randomBattleMoves: ["hydropump", "icebeam", "rapidspin", "sludgebomb", "surf", "toxicspikes"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 	},
 	geodude: {
@@ -280,6 +313,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	golem: {
 		randomBattleMoves: ["earthquake", "explosion", "hammerarm", "stealthrock", "stoneedge", "suckerpunch"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	ponyta: {
@@ -287,6 +321,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	rapidash: {
 		randomBattleMoves: ["flareblitz", "hypnosis", "megahorn", "morningsun", "willowisp"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	slowpoke: {
@@ -294,10 +329,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	slowbro: {
 		randomBattleMoves: ["calmmind", "psychic", "rest", "slackoff", "sleeptalk", "surf", "thunderwave", "toxic", "trickroom"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	slowking: {
 		randomBattleMoves: ["icebeam", "nastyplot", "psychic", "slackoff", "surf", "thunderwave", "toxic", "trickroom"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	magnemite: {
@@ -308,10 +345,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	magnezone: {
 		randomBattleMoves: ["explosion", "flashcannon", "hiddenpowergrass", "hiddenpowerice", "magnetrise", "substitute", "thunderbolt"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	farfetchd: {
 		randomBattleMoves: ["heatwave", "leafblade", "nightslash", "return", "swordsdance", "uturn"],
+		randomBattleLevel: 100,
 		tier: "NU",
 	},
 	doduo: {
@@ -319,6 +358,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dodrio: {
 		randomBattleMoves: ["bravebird", "doubleedge", "pursuit", "quickattack", "return", "roost"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	seel: {
@@ -326,6 +366,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dewgong: {
 		randomBattleMoves: ["encore", "icebeam", "raindance", "rest", "surf", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	grimer: {
@@ -333,6 +374,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	muk: {
 		randomBattleMoves: ["brickbreak", "curse", "explosion", "gunkshot", "icepunch", "payback", "poisonjab", "rest", "shadowsneak", "sleeptalk"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	shellder: {
@@ -340,6 +382,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cloyster: {
 		randomBattleMoves: ["explosion", "iceshard", "rapidspin", "rockblast", "spikes", "surf", "toxicspikes"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	gastly: {
@@ -350,6 +393,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gengar: {
 		randomBattleMoves: ["focusblast", "hiddenpowerfire", "hypnosis", "painsplit", "shadowball", "sludgebomb", "substitute", "thunderbolt", "trick"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	onix: {
@@ -357,6 +401,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	steelix: {
 		randomBattleMoves: ["earthquake", "explosion", "gyroball", "roar", "stealthrock", "stoneedge", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	drowzee: {
@@ -364,6 +409,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hypno: {
 		randomBattleMoves: ["protect", "seismictoss", "thunderwave", "toxic", "wish"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	krabby: {
@@ -371,6 +417,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kingler: {
 		randomBattleMoves: ["agility", "crabhammer", "return", "superpower", "swordsdance", "xscissor"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	voltorb: {
@@ -378,6 +425,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	electrode: {
 		randomBattleMoves: ["explosion", "hiddenpowerice", "signalbeam", "taunt", "thunderbolt"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	exeggcute: {
@@ -385,6 +433,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	exeggutor: {
 		randomBattleMoves: ["explosion", "hiddenpowerfire", "leafstorm", "psychic", "sleeppowder", "solarbeam", "sunnyday", "synthesis"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	cubone: {
@@ -392,6 +441,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	marowak: {
 		randomBattleMoves: ["doubleedge", "earthquake", "firepunch", "substitute", "swordsdance", "thunderpunch"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	tyrogue: {
@@ -399,14 +449,17 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hitmonlee: {
 		randomBattleMoves: ["closecombat", "earthquake", "machpunch", "stoneedge", "substitute", "suckerpunch"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	hitmonchan: {
 		randomBattleMoves: ["bulkup", "closecombat", "drainpunch", "icepunch", "machpunch", "rapidspin", "stoneedge"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	hitmontop: {
 		randomBattleMoves: ["bulkup", "closecombat", "machpunch", "rapidspin", "stoneedge", "suckerpunch", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	lickitung: {
@@ -414,6 +467,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lickilicky: {
 		randomBattleMoves: ["aquatail", "bodyslam", "earthquake", "explosion", "healbell", "protect", "return", "wish"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	koffing: {
@@ -421,6 +475,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	weezing: {
 		randomBattleMoves: ["fireblast", "painsplit", "rest", "sleeptalk", "sludgebomb", "thunderbolt", "willowisp"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	rhyhorn: {
@@ -431,6 +486,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	rhyperior: {
 		randomBattleMoves: ["earthquake", "icepunch", "megahorn", "rockpolish", "stealthrock", "stoneedge"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	happiny: {
@@ -441,6 +497,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	blissey: {
 		randomBattleMoves: ["aromatherapy", "flamethrower", "icebeam", "protect", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic", "wish"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	tangela: {
@@ -448,10 +505,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	tangrowth: {
 		randomBattleMoves: ["earthquake", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "powerwhip", "rockslide", "sleeppowder", "stunspore", "swordsdance", "synthesis"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	kangaskhan: {
 		randomBattleMoves: ["doubleedge", "earthquake", "fakeout", "focuspunch", "hammerarm", "return", "substitute", "suckerpunch"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	horsea: {
@@ -462,6 +521,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kingdra: {
 		randomBattleMoves: ["dracometeor", "dragondance", "hydropump", "icebeam", "outrage", "rest", "sleeptalk", "substitute", "waterfall"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	goldeen: {
@@ -469,6 +529,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	seaking: {
 		randomBattleMoves: ["icebeam", "megahorn", "raindance", "return", "waterfall"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	staryu: {
@@ -476,6 +537,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	starmie: {
 		randomBattleMoves: ["hydropump", "icebeam", "psychic", "rapidspin", "recover", "surf", "thunderbolt"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	mimejr: {
@@ -483,14 +545,17 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mrmime: {
 		randomBattleMoves: ["batonpass", "encore", "focusblast", "nastyplot", "psychic", "shadowball", "substitute", "taunt", "thunderbolt"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	scyther: {
 		randomBattleMoves: ["aerialace", "brickbreak", "bugbite", "pursuit", "quickattack", "roost", "swordsdance", "uturn"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	scizor: {
 		randomBattleMoves: ["bugbite", "bulletpunch", "pursuit", "roost", "superpower", "swordsdance", "uturn"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	smoochum: {
@@ -498,6 +563,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	jynx: {
 		randomBattleMoves: ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psychic", "substitute"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	elekid: {
@@ -508,6 +574,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	electivire: {
 		randomBattleMoves: ["crosschop", "earthquake", "flamethrower", "hiddenpowergrass", "icepunch", "thunderbolt"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 	},
 	magby: {
@@ -518,14 +585,17 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	magmortar: {
 		randomBattleMoves: ["fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderbolt"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	pinsir: {
 		randomBattleMoves: ["closecombat", "earthquake", "quickattack", "stealthrock", "stoneedge", "swordsdance", "xscissor"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	tauros: {
 		randomBattleMoves: ["doubleedge", "earthquake", "payback", "pursuit", "return", "stoneedge"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	magikarp: {
@@ -533,14 +603,17 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gyarados: {
 		randomBattleMoves: ["bounce", "dragondance", "earthquake", "icefang", "rest", "sleeptalk", "stoneedge", "waterfall"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	lapras: {
 		randomBattleMoves: ["healbell", "hydropump", "icebeam", "surf", "thunderbolt", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	ditto: {
 		randomBattleMoves: ["transform"],
+		randomBattleLevel: 100,
 		tier: "NU",
 	},
 	eevee: {
@@ -548,30 +621,37 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vaporeon: {
 		randomBattleMoves: ["icebeam", "protect", "roar", "surf", "toxic", "wish"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 	},
 	jolteon: {
 		randomBattleMoves: ["batonpass", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderbolt", "yawn"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 	},
 	flareon: {
 		randomBattleMoves: ["fireblast", "hiddenpowergrass", "lavaplume", "protect", "superpower", "toxic", "wish"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	espeon: {
 		randomBattleMoves: ["batonpass", "calmmind", "hiddenpowerfire", "morningsun", "psychic", "shadowball", "substitute"],
+		randomBattleLevel: 86,
 		tier: "NUBL",
 	},
 	umbreon: {
 		randomBattleMoves: ["curse", "healbell", "moonlight", "payback", "protect", "toxic", "wish"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 	},
 	leafeon: {
 		randomBattleMoves: ["batonpass", "doubleedge", "healbell", "leafblade", "substitute", "swordsdance", "synthesis", "yawn"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	glaceon: {
 		randomBattleMoves: ["hiddenpowerfire", "hiddenpowerground", "icebeam", "protect", "shadowball", "toxic", "wish"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	porygon: {
@@ -579,10 +659,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	porygon2: {
 		randomBattleMoves: ["discharge", "icebeam", "recover", "toxic", "triattack"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	porygonz: {
 		randomBattleMoves: ["agility", "darkpulse", "hiddenpowerfighting", "icebeam", "nastyplot", "thunderbolt", "triattack", "trick"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	omanyte: {
@@ -590,6 +672,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	omastar: {
 		randomBattleMoves: ["earthpower", "hiddenpowergrass", "hydropump", "icebeam", "raindance", "spikes", "stealthrock", "surf"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	kabuto: {
@@ -597,10 +680,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kabutops: {
 		randomBattleMoves: ["aquajet", "rapidspin", "stealthrock", "stoneedge", "superpower", "swordsdance", "waterfall"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	aerodactyl: {
 		randomBattleMoves: ["earthquake", "rockslide", "roost", "stealthrock", "stoneedge", "taunt"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	munchlax: {
@@ -608,18 +693,22 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	snorlax: {
 		randomBattleMoves: ["bodyslam", "crunch", "curse", "earthquake", "firepunch", "pursuit", "rest", "return", "selfdestruct", "sleeptalk", "whirlwind"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 	},
 	articuno: {
 		randomBattleMoves: ["healbell", "icebeam", "roar", "roost", "substitute", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	zapdos: {
 		randomBattleMoves: ["heatwave", "hiddenpowergrass", "hiddenpowerice", "roost", "substitute", "thunderbolt", "toxic", "uturn"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	moltres: {
 		randomBattleMoves: ["airslash", "fireblast", "flamethrower", "hiddenpowergrass", "roost", "substitute", "toxic", "uturn"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	dratini: {
@@ -630,14 +719,17 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dragonite: {
 		randomBattleMoves: ["dracometeor", "dragonclaw", "dragondance", "earthquake", "extremespeed", "fireblast", "firepunch", "outrage", "roost", "superpower"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	mewtwo: {
 		randomBattleMoves: ["aurasphere", "calmmind", "fireblast", "icebeam", "psychic", "recover", "selfdestruct", "substitute", "taunt", "willowisp"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	mew: {
 		randomBattleMoves: ["aurasphere", "explosion", "flamethrower", "nastyplot", "psychic", "softboiled", "stealthrock", "taunt", "uturn", "willowisp"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	chikorita: {
@@ -648,6 +740,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	meganium: {
 		randomBattleMoves: ["aromatherapy", "energyball", "leechseed", "lightscreen", "reflect", "synthesis", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	cyndaquil: {
@@ -658,6 +751,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	typhlosion: {
 		randomBattleMoves: ["eruption", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerrock"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	totodile: {
@@ -668,6 +762,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	feraligatr: {
 		randomBattleMoves: ["aquajet", "dragondance", "earthquake", "icepunch", "lowkick", "return", "swordsdance", "waterfall"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	sentret: {
@@ -675,6 +770,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	furret: {
 		randomBattleMoves: ["aquatail", "brickbreak", "doubleedge", "firepunch", "return", "shadowclaw", "suckerpunch", "trick", "uturn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	hoothoot: {
@@ -682,6 +778,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	noctowl: {
 		randomBattleMoves: ["nightshade", "reflect", "roost", "toxic", "whirlwind"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	ledyba: {
@@ -689,6 +786,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ledian: {
 		randomBattleMoves: ["encore", "lightscreen", "reflect", "roost", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	spinarak: {
@@ -696,6 +794,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ariados: {
 		randomBattleMoves: ["bugbite", "poisonjab", "shadowsneak", "suckerpunch", "toxicspikes"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	chinchou: {
@@ -703,6 +802,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lanturn: {
 		randomBattleMoves: ["confuseray", "discharge", "healbell", "icebeam", "surf", "thunderwave", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	togepi: {
@@ -713,6 +813,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	togekiss: {
 		randomBattleMoves: ["airslash", "aurasphere", "fireblast", "healbell", "nastyplot", "roost", "thunderwave"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 	},
 	natu: {
@@ -720,6 +821,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	xatu: {
 		randomBattleMoves: ["calmmind", "grassknot", "heatwave", "hiddenpowerfighting", "psychic", "roost", "trick", "uturn", "wish"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	mareep: {
@@ -730,6 +832,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ampharos: {
 		randomBattleMoves: ["discharge", "focusblast", "healbell", "hiddenpowerice", "lightscreen", "reflect", "signalbeam", "thunderbolt"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	azurill: {
@@ -740,6 +843,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	azumarill: {
 		randomBattleMoves: ["aquajet", "doubleedge", "icepunch", "return", "superpower", "waterfall"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	bonsly: {
@@ -747,6 +851,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sudowoodo: {
 		randomBattleMoves: ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic", "woodhammer"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	hoppip: {
@@ -757,6 +862,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	jumpluff: {
 		randomBattleMoves: ["bounce", "encore", "grassknot", "leechseed", "sleeppowder", "stunspore", "substitute", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	aipom: {
@@ -764,6 +870,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ambipom: {
 		randomBattleMoves: ["fakeout", "lowkick", "payback", "pursuit", "return", "uturn"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	sunkern: {
@@ -771,6 +878,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sunflora: {
 		randomBattleMoves: ["earthpower", "hiddenpowerice", "leafstorm", "synthesis"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	yanma: {
@@ -778,6 +886,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	yanmega: {
 		randomBattleMoves: ["airslash", "bugbuzz", "hiddenpowerfire", "hiddenpowerground", "protect", "uturn"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	wooper: {
@@ -785,6 +894,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	quagsire: {
 		randomBattleMoves: ["earthquake", "encore", "icepunch", "recover", "toxic", "waterfall", "yawn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	murkrow: {
@@ -792,6 +902,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	honchkrow: {
 		randomBattleMoves: ["bravebird", "heatwave", "pursuit", "suckerpunch", "superpower"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	misdreavus: {
@@ -799,10 +910,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mismagius: {
 		randomBattleMoves: ["hiddenpowerfighting", "nastyplot", "painsplit", "shadowball", "substitute", "taunt", "thunderbolt", "trick", "willowisp"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	unown: {
 		randomBattleMoves: ["hiddenpowerpsychic"],
+		randomBattleLevel: 100,
 		tier: "NU",
 	},
 	wynaut: {
@@ -810,10 +923,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wobbuffet: {
 		randomBattleMoves: ["counter", "destinybond", "encore", "mirrorcoat"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	girafarig: {
 		randomBattleMoves: ["batonpass", "calmmind", "hiddenpowerfighting", "psychic", "thunderbolt"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	pineco: {
@@ -821,10 +936,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	forretress: {
 		randomBattleMoves: ["earthquake", "explosion", "gyroball", "rapidspin", "spikes", "stealthrock", "toxicspikes"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	dunsparce: {
 		randomBattleMoves: ["bite", "bodyslam", "headbutt", "rockslide", "roost", "thunderwave", "zenheadbutt"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	gligar: {
@@ -833,6 +950,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gliscor: {
 		randomBattleMoves: ["earthquake", "roost", "stealthrock", "stoneedge", "swordsdance", "taunt", "toxic", "uturn"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	snubbull: {
@@ -840,18 +958,22 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	granbull: {
 		randomBattleMoves: ["bodyslam", "closecombat", "crunch", "earthquake", "firepunch", "healbell", "return", "thunderwave", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	qwilfish: {
 		randomBattleMoves: ["destinybond", "explosion", "poisonjab", "spikes", "thunderwave", "toxicspikes", "waterfall"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	shuckle: {
 		randomBattleMoves: ["encore", "knockoff", "rest", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	heracross: {
 		randomBattleMoves: ["closecombat", "megahorn", "nightslash", "stoneedge", "substitute", "swordsdance"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	sneasel: {
@@ -859,6 +981,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	weavile: {
 		randomBattleMoves: ["icepunch", "iceshard", "lowkick", "nightslash", "pursuit", "swordsdance"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	teddiursa: {
@@ -866,6 +989,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ursaring: {
 		randomBattleMoves: ["closecombat", "crunch", "earthquake", "facade", "protect", "swordsdance"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	slugma: {
@@ -873,6 +997,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	magcargo: {
 		randomBattleMoves: ["fireblast", "hiddenpowerrock", "lavaplume", "recover", "stealthrock", "toxic", "willowisp"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	swinub: {
@@ -883,10 +1008,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mamoswine: {
 		randomBattleMoves: ["earthquake", "endeavor", "iceshard", "stealthrock", "stoneedge", "superpower"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 	},
 	corsola: {
 		randomBattleMoves: ["explosion", "recover", "stealthrock", "surf", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	remoraid: {
@@ -894,10 +1021,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	octillery: {
 		randomBattleMoves: ["energyball", "fireblast", "icebeam", "surf", "thunderwave"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	delibird: {
 		randomBattleMoves: ["aerialace", "brickbreak", "icepunch", "iceshard", "rapidspin", "seedbomb"],
+		randomBattleLevel: 100,
 		tier: "NU",
 	},
 	mantyke: {
@@ -905,10 +1034,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mantine: {
 		randomBattleMoves: ["rest", "sleeptalk", "surf", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	skarmory: {
 		randomBattleMoves: ["bravebird", "roost", "spikes", "stealthrock", "whirlwind"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	houndour: {
@@ -916,6 +1047,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	houndoom: {
 		randomBattleMoves: ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "suckerpunch"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	phanpy: {
@@ -923,30 +1055,37 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	donphan: {
 		randomBattleMoves: ["assurance", "earthquake", "iceshard", "rapidspin", "seedbomb", "stealthrock", "stoneedge"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	stantler: {
 		randomBattleMoves: ["earthquake", "energyball", "hypnosis", "megahorn", "return", "suckerpunch"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	smeargle: {
 		randomBattleMoves: ["counter", "spikes", "spore", "stealthrock", "uturn"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 	},
 	miltank: {
 		randomBattleMoves: ["bodyslam", "curse", "earthquake", "healbell", "milkdrink", "stealthrock"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	raikou: {
 		randomBattleMoves: ["aurasphere", "calmmind", "hiddenpowerice", "shadowball", "thunderbolt"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	entei: {
 		randomBattleMoves: ["extremespeed", "flareblitz", "hiddenpowergrass", "ironhead", "stoneedge"],
+		randomBattleLevel: 86,
 		tier: "NUBL",
 	},
 	suicune: {
 		randomBattleMoves: ["calmmind", "hiddenpowerelectric", "icebeam", "rest", "roar", "sleeptalk", "surf"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	larvitar: {
@@ -957,18 +1096,22 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	tyranitar: {
 		randomBattleMoves: ["crunch", "dragondance", "earthquake", "fireblast", "firepunch", "icebeam", "icepunch", "pursuit", "stealthrock", "stoneedge", "superpower"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	lugia: {
 		randomBattleMoves: ["aeroblast", "calmmind", "earthpower", "icebeam", "roost", "substitute", "toxic", "whirlwind"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	hooh: {
 		randomBattleMoves: ["bravebird", "earthquake", "punishment", "roost", "sacredfire", "substitute"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	celebi: {
 		randomBattleMoves: ["earthpower", "energyball", "hiddenpowerfire", "leafstorm", "leechseed", "nastyplot", "psychic", "recover", "stealthrock", "substitute", "thunderwave", "uturn"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	treecko: {
@@ -979,6 +1122,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sceptile: {
 		randomBattleMoves: ["earthquake", "energyball", "focusblast", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "leechseed", "substitute"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	torchic: {
@@ -989,6 +1133,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	blaziken: {
 		randomBattleMoves: ["agility", "fireblast", "flareblitz", "stoneedge", "superpower", "thunderpunch", "vacuumwave"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	mudkip: {
@@ -999,6 +1144,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swampert: {
 		randomBattleMoves: ["earthquake", "icebeam", "icepunch", "roar", "stealthrock", "stoneedge", "waterfall"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	poochyena: {
@@ -1006,6 +1152,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mightyena: {
 		randomBattleMoves: ["crunch", "firefang", "suckerpunch", "superfang", "taunt", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	zigzagoon: {
@@ -1013,6 +1160,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	linoone: {
 		randomBattleMoves: ["bellydrum", "extremespeed", "seedbomb", "shadowclaw"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	wurmple: {
@@ -1023,6 +1171,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	beautifly: {
 		randomBattleMoves: ["bugbuzz", "hiddenpowerground", "psychic", "uturn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	cascoon: {
@@ -1030,6 +1179,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dustox: {
 		randomBattleMoves: ["bugbuzz", "protect", "roost", "toxic", "whirlwind"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	lotad: {
@@ -1040,6 +1190,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ludicolo: {
 		randomBattleMoves: ["energyball", "icebeam", "leechseed", "raindance", "substitute", "surf"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	seedot: {
@@ -1050,6 +1201,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	shiftry: {
 		randomBattleMoves: ["darkpulse", "explosion", "hiddenpowerfire", "leafstorm", "lowkick", "seedbomb", "solarbeam", "suckerpunch", "sunnyday", "swordsdance"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	taillow: {
@@ -1057,6 +1209,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swellow: {
 		randomBattleMoves: ["bravebird", "facade", "protect", "quickattack", "uturn"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	wingull: {
@@ -1064,6 +1217,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	pelipper: {
 		randomBattleMoves: ["airslash", "hiddenpowergrass", "hydropump", "roost", "surf", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	ralts: {
@@ -1074,10 +1228,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gardevoir: {
 		randomBattleMoves: ["calmmind", "focusblast", "psychic", "shadowball", "taunt", "thunderbolt", "willowisp"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	gallade: {
 		randomBattleMoves: ["closecombat", "icepunch", "nightslash", "psychocut", "shadowsneak", "stoneedge", "swordsdance", "trick"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	surskit: {
@@ -1085,6 +1241,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	masquerain: {
 		randomBattleMoves: ["agility", "airslash", "batonpass", "bugbuzz", "hydropump", "roost"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	shroomish: {
@@ -1092,6 +1249,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	breloom: {
 		randomBattleMoves: ["facade", "focuspunch", "leechseed", "machpunch", "seedbomb", "spore", "stoneedge", "substitute", "swordsdance"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	slakoth: {
@@ -1099,10 +1257,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vigoroth: {
 		randomBattleMoves: ["bulkup", "earthquake", "encore", "lowkick", "nightslash", "return", "slackoff", "substitute", "suckerpunch"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	slaking: {
 		randomBattleMoves: ["doubleedge", "earthquake", "firepunch", "icepunch", "nightslash", "pursuit", "return"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	nincada: {
@@ -1110,10 +1270,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ninjask: {
 		randomBattleMoves: ["batonpass", "protect", "substitute", "swordsdance", "xscissor"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 	},
 	shedinja: {
 		randomBattleMoves: ["batonpass", "shadowsneak", "swordsdance", "willowisp", "xscissor"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	whismur: {
@@ -1124,6 +1286,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	exploud: {
 		randomBattleMoves: ["crunch", "earthquake", "fireblast", "icebeam", "return", "surf"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	makuhita: {
@@ -1131,6 +1294,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hariyama: {
 		randomBattleMoves: ["bulletpunch", "closecombat", "facade", "fakeout", "focuspunch", "icepunch", "payback", "stoneedge", "substitute"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	nosepass: {
@@ -1138,6 +1302,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	probopass: {
 		randomBattleMoves: ["earthpower", "powergem", "stealthrock", "thunderwave", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	skitty: {
@@ -1145,14 +1310,17 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	delcatty: {
 		randomBattleMoves: ["healbell", "protect", "return", "sing", "thunderwave", "wish"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	sableye: {
 		randomBattleMoves: ["recover", "seismictoss", "taunt", "toxic", "willowisp"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	mawile: {
 		randomBattleMoves: ["batonpass", "focuspunch", "ironhead", "substitute", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	aron: {
@@ -1163,6 +1331,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	aggron: {
 		randomBattleMoves: ["aquatail", "earthquake", "headsmash", "icepunch", "lowkick", "rockpolish"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	meditite: {
@@ -1170,6 +1339,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	medicham: {
 		randomBattleMoves: ["bulletpunch", "fakeout", "highjumpkick", "icepunch", "psychocut", "thunderpunch", "trick"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	electrike: {
@@ -1177,22 +1347,27 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	manectric: {
 		randomBattleMoves: ["flamethrower", "hiddenpowergrass", "overheat", "switcheroo", "thunderbolt"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	plusle: {
 		randomBattleMoves: ["batonpass", "encore", "hiddenpowerice", "nastyplot", "thunderbolt"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	minun: {
 		randomBattleMoves: ["batonpass", "encore", "hiddenpowerice", "nastyplot", "thunderbolt"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	volbeat: {
 		randomBattleMoves: ["batonpass", "bugbuzz", "encore", "substitute", "tailglow"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	illumise: {
 		randomBattleMoves: ["bugbuzz", "encore", "hiddenpowerground", "hiddenpowerice", "thunderbolt", "uturn", "wish"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	budew: {
@@ -1203,6 +1378,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	roserade: {
 		randomBattleMoves: ["energyball", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "rest", "sleeppowder", "sludgebomb", "spikes", "toxicspikes"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	gulpin: {
@@ -1210,6 +1386,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swalot: {
 		randomBattleMoves: ["earthquake", "encore", "explosion", "icebeam", "sludgebomb", "toxic", "yawn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	carvanha: {
@@ -1217,6 +1394,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sharpedo: {
 		randomBattleMoves: ["aquajet", "crunch", "earthquake", "hiddenpowergrass", "hydropump", "icebeam", "waterfall"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	wailmer: {
@@ -1224,6 +1402,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wailord: {
 		randomBattleMoves: ["hiddenpowergrass", "hydropump", "icebeam", "selfdestruct", "surf", "waterspout"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	numel: {
@@ -1231,10 +1410,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	camerupt: {
 		randomBattleMoves: ["earthpower", "earthquake", "explosion", "fireblast", "lavaplume", "rockpolish", "stealthrock", "stoneedge"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	torkoal: {
 		randomBattleMoves: ["earthquake", "explosion", "lavaplume", "rapidspin", "stealthrock", "toxic", "yawn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	spoink: {
@@ -1242,10 +1423,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	grumpig: {
 		randomBattleMoves: ["calmmind", "focusblast", "healbell", "psychic", "shadowball", "thunderwave", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	spinda: {
 		randomBattleMoves: ["bodyslam", "encore", "hypnosis", "seismictoss", "substitute", "teeterdance", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	trapinch: {
@@ -1256,6 +1439,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	flygon: {
 		randomBattleMoves: ["dragonclaw", "earthquake", "fireblast", "firepunch", "outrage", "roost", "stoneedge", "uturn"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	cacnea: {
@@ -1263,6 +1447,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cacturne: {
 		randomBattleMoves: ["encore", "focuspunch", "lowkick", "seedbomb", "spikes", "substitute", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	swablu: {
@@ -1270,22 +1455,27 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	altaria: {
 		randomBattleMoves: ["dragonclaw", "dragondance", "earthquake", "fireblast", "healbell", "outrage", "roost"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	zangoose: {
 		randomBattleMoves: ["closecombat", "quickattack", "return", "shadowclaw", "swordsdance"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	seviper: {
 		randomBattleMoves: ["aquatail", "darkpulse", "earthquake", "flamethrower", "sludgebomb", "suckerpunch", "switcheroo"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	lunatone: {
 		randomBattleMoves: ["batonpass", "calmmind", "earthpower", "psychic", "shadowball", "substitute"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	solrock: {
 		randomBattleMoves: ["earthquake", "explosion", "rockpolish", "stealthrock", "stoneedge", "zenheadbutt"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	barboach: {
@@ -1293,6 +1483,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	whiscash: {
 		randomBattleMoves: ["dragondance", "earthquake", "stoneedge", "waterfall"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	corphish: {
@@ -1300,6 +1491,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	crawdaunt: {
 		randomBattleMoves: ["crunch", "dragondance", "superpower", "waterfall", "xscissor"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	baltoy: {
@@ -1307,6 +1499,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	claydol: {
 		randomBattleMoves: ["earthquake", "explosion", "icebeam", "psychic", "rapidspin", "stealthrock"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	lileep: {
@@ -1314,6 +1507,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cradily: {
 		randomBattleMoves: ["curse", "earthquake", "recover", "rest", "rockslide", "seedbomb", "sleeptalk", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	anorith: {
@@ -1321,6 +1515,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	armaldo: {
 		randomBattleMoves: ["earthquake", "rapidspin", "rockpolish", "stealthrock", "stoneedge", "swordsdance", "toxic", "xscissor"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	feebas: {
@@ -1328,10 +1523,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	milotic: {
 		randomBattleMoves: ["haze", "icebeam", "recover", "rest", "sleeptalk", "surf", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	castform: {
 		randomBattleMoves: ["energyball", "fireblast", "icebeam", "shadowball", "thunderbolt"],
+		randomBattleLevel: 100,
 		tier: "NU",
 	},
 	castformsunny: {},
@@ -1339,6 +1536,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	castformsnowy: {},
 	kecleon: {
 		randomBattleMoves: ["aquatail", "recover", "return", "stealthrock", "thunderwave", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	shuppet: {
@@ -1346,6 +1544,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	banette: {
 		randomBattleMoves: ["destinybond", "hiddenpowerfighting", "shadowclaw", "shadowsneak", "taunt", "thunderwave", "willowisp"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	duskull: {
@@ -1356,10 +1555,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dusknoir: {
 		randomBattleMoves: ["earthquake", "focuspunch", "icebeam", "painsplit", "shadowsneak", "substitute", "willowisp"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 	},
 	tropius: {
 		randomBattleMoves: ["aerialace", "curse", "dragondance", "earthquake", "leafblade", "leafstorm", "leechseed", "roost", "swordsdance", "toxic", "whirlwind"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	chingling: {
@@ -1367,10 +1568,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	chimecho: {
 		randomBattleMoves: ["calmmind", "hiddenpowerfire", "psychic", "recover", "signalbeam", "thunderwave", "yawn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	absol: {
 		randomBattleMoves: ["nightslash", "psychocut", "pursuit", "suckerpunch", "superpower", "swordsdance"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	snorunt: {
@@ -1378,10 +1581,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	glalie: {
 		randomBattleMoves: ["earthquake", "explosion", "icebeam", "spikes", "taunt"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	froslass: {
 		randomBattleMoves: ["destinybond", "icebeam", "shadowball", "spikes", "taunt"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	spheal: {
@@ -1392,6 +1597,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	walrein: {
 		randomBattleMoves: ["encore", "icebeam", "protect", "rest", "roar", "sleeptalk", "surf", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	clamperl: {
@@ -1399,18 +1605,22 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	huntail: {
 		randomBattleMoves: ["doubleedge", "hiddenpowergrass", "hydropump", "icebeam", "raindance", "suckerpunch", "surf"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	gorebyss: {
 		randomBattleMoves: ["hiddenpowergrass", "hydropump", "icebeam", "raindance", "surf"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	relicanth: {
 		randomBattleMoves: ["doubleedge", "earthquake", "headsmash", "rockpolish", "stealthrock", "waterfall"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	luvdisc: {
 		randomBattleMoves: ["icebeam", "protect", "surf", "sweetkiss", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	bagon: {
@@ -1421,6 +1631,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	salamence: {
 		randomBattleMoves: ["dracometeor", "dragondance", "earthquake", "fireblast", "outrage", "roost"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	beldum: {
@@ -1431,58 +1642,72 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	metagross: {
 		randomBattleMoves: ["agility", "bulletpunch", "earthquake", "explosion", "meteormash", "stealthrock", "zenheadbutt"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	regirock: {
 		randomBattleMoves: ["earthquake", "explosion", "rest", "rockslide", "sleeptalk", "stealthrock", "thunderwave"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	regice: {
 		randomBattleMoves: ["focusblast", "icebeam", "rest", "sleeptalk", "thunderbolt", "thunderwave"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	registeel: {
 		randomBattleMoves: ["curse", "ironhead", "rest", "sleeptalk", "stealthrock", "thunderwave", "toxic"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	latias: {
 		randomBattleMoves: ["calmmind", "dragonpulse", "psychic", "refresh", "roost", "surf"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	latios: {
 		randomBattleMoves: ["calmmind", "dracometeor", "dragonpulse", "hiddenpowerfire", "psychic", "roost", "surf", "thunderbolt", "trick"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	kyogre: {
 		randomBattleMoves: ["calmmind", "icebeam", "rest", "sleeptalk", "surf", "thunder", "waterspout"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	groudon: {
 		randomBattleMoves: ["earthquake", "firepunch", "rockpolish", "stealthrock", "stoneedge", "swordsdance", "toxic"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	rayquaza: {
 		randomBattleMoves: ["dragonclaw", "dragondance", "earthquake", "extremespeed", "outrage", "overheat", "swordsdance"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	jirachi: {
 		randomBattleMoves: ["bodyslam", "calmmind", "firepunch", "flashcannon", "icepunch", "ironhead", "psychic", "stealthrock", "substitute", "thunderbolt", "uturn", "wish"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	deoxys: {
 		randomBattleMoves: ["extremespeed", "icebeam", "psychoboost", "spikes", "stealthrock", "superpower"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	deoxysattack: {
 		randomBattleMoves: ["extremespeed", "hiddenpowerfire", "icebeam", "psychoboost", "shadowball", "stealthrock", "superpower"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	deoxysdefense: {
 		randomBattleMoves: ["recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	deoxysspeed: {
 		randomBattleMoves: ["lightscreen", "psychoboost", "reflect", "spikes", "stealthrock", "superpower", "taunt"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	turtwig: {
@@ -1493,6 +1718,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	torterra: {
 		randomBattleMoves: ["earthquake", "leechseed", "roar", "rockpolish", "stealthrock", "stoneedge", "synthesis", "woodhammer"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	chimchar: {
@@ -1503,6 +1729,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	infernape: {
 		randomBattleMoves: ["closecombat", "flareblitz", "grassknot", "hiddenpowerice", "machpunch", "stealthrock", "stoneedge", "swordsdance", "uturn"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	piplup: {
@@ -1513,6 +1740,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	empoleon: {
 		randomBattleMoves: ["agility", "grassknot", "hiddenpowerelectric", "hydropump", "icebeam", "roar", "stealthrock", "surf"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	starly: {
@@ -1523,6 +1751,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	staraptor: {
 		randomBattleMoves: ["bravebird", "closecombat", "doubleedge", "pursuit", "quickattack", "return", "roost", "substitute", "uturn"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	bidoof: {
@@ -1530,6 +1759,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	bibarel: {
 		randomBattleMoves: ["curse", "quickattack", "rest", "waterfall"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	kricketot: {
@@ -1537,6 +1767,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kricketune: {
 		randomBattleMoves: ["brickbreak", "nightslash", "return", "swordsdance", "xscissor"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	shinx: {
@@ -1547,6 +1778,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	luxray: {
 		randomBattleMoves: ["crunch", "icefang", "protect", "roar", "superpower", "thunderbolt", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	cranidos: {
@@ -1554,6 +1786,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	rampardos: {
 		randomBattleMoves: ["earthquake", "firepunch", "icebeam", "rockpolish", "stoneedge", "zenheadbutt"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	shieldon: {
@@ -1561,6 +1794,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	bastiodon: {
 		randomBattleMoves: ["earthquake", "metalburst", "protect", "roar", "rockslide", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	burmy: {
@@ -1568,18 +1802,22 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wormadam: {
 		randomBattleMoves: ["hiddenpowerice", "hiddenpowerrock", "leafstorm", "psychic", "signalbeam"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	wormadamsandy: {
 		randomBattleMoves: ["earthquake", "rest", "sleeptalk", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	wormadamtrash: {
 		randomBattleMoves: ["gyroball", "protect", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	mothim: {
 		randomBattleMoves: ["airslash", "bugbuzz", "hiddenpowerfighting", "hiddenpowerground", "shadowball", "uturn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	combee: {
@@ -1587,10 +1825,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vespiquen: {
 		randomBattleMoves: ["attackorder", "defendorder", "protect", "roost", "substitute", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	pachirisu: {
 		randomBattleMoves: ["discharge", "lightscreen", "superfang", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	buizel: {
@@ -1598,6 +1838,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	floatzel: {
 		randomBattleMoves: ["aquajet", "batonpass", "bulkup", "crunch", "icepunch", "return", "taunt", "waterfall"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	cherubi: {
@@ -1605,16 +1846,19 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cherrim: {
 		randomBattleMoves: ["aromatherapy", "energyball", "hiddenpowerfire", "hiddenpowerground", "synthesis", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	cherrimsunshine: {
 		randomBattleMoves: ["hiddenpowerice", "solarbeam", "sunnyday", "weatherball"],
+		randomBattleLevel: 88,
 	},
 	shellos: {
 		tier: "LC",
 	},
 	gastrodon: {
 		randomBattleMoves: ["earthpower", "icebeam", "recover", "surf", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	drifloon: {
@@ -1622,6 +1866,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	drifblim: {
 		randomBattleMoves: ["calmmind", "hiddenpowerfighting", "rest", "shadowball", "substitute", "thunderbolt"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	buneary: {
@@ -1629,6 +1874,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lopunny: {
 		randomBattleMoves: ["batonpass", "encore", "healingwish", "return", "substitute", "thunderwave", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	glameow: {
@@ -1636,6 +1882,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	purugly: {
 		randomBattleMoves: ["fakeout", "return", "shadowclaw", "suckerpunch", "taunt", "uturn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	stunky: {
@@ -1643,6 +1890,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	skuntank: {
 		randomBattleMoves: ["crunch", "explosion", "fireblast", "poisonjab", "pursuit", "suckerpunch", "taunt"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	bronzor: {
@@ -1650,14 +1898,17 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	bronzong: {
 		randomBattleMoves: ["earthquake", "explosion", "gyroball", "hypnosis", "lightscreen", "payback", "reflect", "stealthrock"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	chatot: {
 		randomBattleMoves: ["encore", "heatwave", "hiddenpowergrass", "hypervoice", "nastyplot", "uturn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	spiritomb: {
 		randomBattleMoves: ["calmmind", "darkpulse", "hiddenpowerfighting", "rest", "sleeptalk", "willowisp"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	gible: {
@@ -1668,6 +1919,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	garchomp: {
 		randomBattleMoves: ["dragonclaw", "earthquake", "fireblast", "outrage", "stealthrock", "stoneedge", "substitute", "swordsdance"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	riolu: {
@@ -1675,6 +1927,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lucario: {
 		randomBattleMoves: ["agility", "closecombat", "crunch", "extremespeed", "icepunch", "stoneedge", "swordsdance"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	hippopotas: {
@@ -1682,6 +1935,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hippowdon: {
 		randomBattleMoves: ["earthquake", "icefang", "roar", "slackoff", "stealthrock", "stoneedge", "toxic"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	skorupi: {
@@ -1689,6 +1943,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	drapion: {
 		randomBattleMoves: ["aquatail", "crunch", "earthquake", "poisonjab", "pursuit", "swordsdance", "taunt", "toxicspikes", "whirlwind"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	croagunk: {
@@ -1696,10 +1951,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	toxicroak: {
 		randomBattleMoves: ["crosschop", "focuspunch", "icepunch", "substitute", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	carnivine: {
 		randomBattleMoves: ["powerwhip", "return", "sleeppowder", "substitute", "swordsdance", "synthesis"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	finneon: {
@@ -1707,6 +1964,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lumineon: {
 		randomBattleMoves: ["hiddenpowerelectric", "hiddenpowergrass", "icebeam", "raindance", "surf", "uturn"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	snover: {
@@ -1714,141 +1972,180 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	abomasnow: {
 		randomBattleMoves: ["blizzard", "earthquake", "energyball", "hiddenpowerfire", "iceshard", "leechseed", "substitute", "woodhammer"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	rotom: {
 		randomBattleMoves: ["hiddenpowerfighting", "hiddenpowerfire", "shadowball", "thunderbolt", "trick"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	rotomheat: {
 		randomBattleMoves: ["discharge", "lightscreen", "overheat", "painsplit", "reflect", "shadowball", "thunderbolt", "trick", "willowisp"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	rotomwash: {
 		randomBattleMoves: ["discharge", "hydropump", "lightscreen", "reflect", "rest", "shadowball", "sleeptalk", "thunderbolt", "trick", "willowisp"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	rotomfrost: {
 		randomBattleMoves: ["blizzard", "discharge", "lightscreen", "reflect", "rest", "shadowball", "sleeptalk", "thunderbolt", "trick", "willowisp"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	rotomfan: {
 		randomBattleMoves: ["discharge", "lightscreen", "painsplit", "reflect", "rest", "shadowball", "sleeptalk", "thunderbolt", "willowisp"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	rotommow: {
 		randomBattleMoves: ["discharge", "leafstorm", "lightscreen", "painsplit", "reflect", "shadowball", "thunderbolt", "trick", "willowisp"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	uxie: {
 		randomBattleMoves: ["lightscreen", "psychic", "reflect", "stealthrock", "thunderwave", "uturn", "yawn"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	mesprit: {
 		randomBattleMoves: ["calmmind", "hiddenpowerfire", "icebeam", "psychic", "stealthrock", "substitute", "thunderbolt", "thunderwave", "uturn"],
+		randomBattleLevel: 84,
 		tier: "UU",
 	},
 	azelf: {
 		randomBattleMoves: ["explosion", "fireblast", "flamethrower", "hiddenpowerfighting", "nastyplot", "psychic", "stealthrock", "thunderbolt", "uturn"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	dialga: {
 		randomBattleMoves: ["aurasphere", "bulkup", "dracometeor", "dragonclaw", "earthquake", "fireblast", "outrage", "rest", "sleeptalk", "stealthrock", "thunderbolt", "toxic"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	palkia: {
 		randomBattleMoves: ["aurasphere", "dracometeor", "fireblast", "hydropump", "spacialrend", "surf", "thunderbolt"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	heatran: {
 		randomBattleMoves: ["dragonpulse", "earthpower", "explosion", "fireblast", "hiddenpowergrass", "lavaplume", "protect", "roar", "stealthrock", "substitute", "toxic"],
+		randomBattleLevel: 80,
 		tier: "OU",
 	},
 	regigigas: {
 		randomBattleMoves: ["confuseray", "earthquake", "firepunch", "return", "substitute", "thunderwave", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	giratina: {
 		randomBattleMoves: ["calmmind", "dragonpulse", "rest", "roar", "shadowball", "sleeptalk", "willowisp"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	giratinaorigin: {
 		randomBattleMoves: ["aurasphere", "calmmind", "dracometeor", "dragonpulse", "hiddenpowerfire", "outrage", "shadowball", "shadowsneak", "substitute"],
+		randomBattleLevel: 76,
 	},
 	cresselia: {
 		randomBattleMoves: ["calmmind", "hiddenpowerfire", "icebeam", "lightscreen", "moonlight", "psychic", "reflect", "substitute", "thunderwave", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 	},
 	phione: {
 		randomBattleMoves: ["icebeam", "raindance", "rest", "surf", "toxic"],
+		randomBattleLevel: 88,
 		tier: "NU",
 	},
 	manaphy: {
 		randomBattleMoves: ["energyball", "icebeam", "surf", "tailglow"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	darkrai: {
 		randomBattleMoves: ["darkpulse", "darkvoid", "focusblast", "nastyplot", "substitute"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	shaymin: {
 		randomBattleMoves: ["earthpower", "hiddenpowerfire", "hiddenpowerice", "leechseed", "rest", "seedflare", "substitute"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 	},
 	shayminsky: {
 		randomBattleMoves: ["airslash", "earthpower", "hiddenpowerfire", "hiddenpowerice", "leechseed", "seedflare", "substitute"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 	},
 	arceus: {
 		randomBattleMoves: ["earthquake", "extremespeed", "recover", "shadowclaw", "swordsdance"],
+		randomBattleLevel: 74,
 		tier: "AG",
 	},
 	arceusbug: {
 		randomBattleMoves: ["calmmind", "earthpower", "icebeam", "judgment", "recover"],
+		randomBattleLevel: 74,
 	},
 	arceusdark: {
 		randomBattleMoves: ["calmmind", "focusblast", "judgment", "recover", "refresh"],
+		randomBattleLevel: 74,
 	},
 	arceusdragon: {
 		randomBattleMoves: ["calmmind", "flamethrower", "judgment", "recover", "refresh", "willowisp"],
+		randomBattleLevel: 74,
 	},
 	arceuselectric: {
 		randomBattleMoves: ["calmmind", "earthpower", "icebeam", "judgment", "recover"],
+		randomBattleLevel: 74,
 	},
 	arceusfighting: {
 		randomBattleMoves: ["calmmind", "darkpulse", "icebeam", "judgment", "recover"],
+		randomBattleLevel: 74,
 	},
 	arceusfire: {
 		randomBattleMoves: ["calmmind", "earthpower", "judgment", "recover", "thunderbolt"],
+		randomBattleLevel: 74,
 	},
 	arceusflying: {
 		randomBattleMoves: ["calmmind", "earthpower", "judgment", "recover", "refresh"],
+		randomBattleLevel: 74,
 	},
 	arceusghost: {
 		randomBattleMoves: ["calmmind", "focusblast", "judgment", "recover", "willowisp"],
+		randomBattleLevel: 74,
 	},
 	arceusgrass: {
 		randomBattleMoves: ["calmmind", "earthpower", "icebeam", "judgment", "recover", "thunderwave"],
+		randomBattleLevel: 74,
 	},
 	arceusground: {
 		randomBattleMoves: ["calmmind", "icebeam", "judgment", "recover", "thunderbolt"],
+		randomBattleLevel: 74,
 	},
 	arceusice: {
 		randomBattleMoves: ["calmmind", "earthpower", "flamethrower", "judgment", "recover", "thunderbolt"],
+		randomBattleLevel: 74,
 	},
 	arceuspoison: {
 		randomBattleMoves: ["calmmind", "earthpower", "judgment", "recover", "willowisp"],
+		randomBattleLevel: 74,
 	},
 	arceuspsychic: {
 		randomBattleMoves: ["calmmind", "focusblast", "judgment", "recover", "shadowball"],
+		randomBattleLevel: 74,
 	},
 	arceusrock: {
 		randomBattleMoves: ["calmmind", "earthpower", "judgment", "recover", "refresh", "willowisp"],
+		randomBattleLevel: 74,
 	},
 	arceussteel: {
 		randomBattleMoves: ["calmmind", "earthpower", "judgment", "recover", "willowisp"],
+		randomBattleLevel: 74,
 	},
 	arceuswater: {
 		randomBattleMoves: ["calmmind", "icebeam", "judgment", "recover", "refresh", "thunderbolt", "willowisp"],
+		randomBattleLevel: 74,
 	},
 };

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -823,7 +823,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		const customScale: {[k: string]: number} = {
 			Delibird: 100, Ditto: 100, 'Farfetch\u2019d': 100, Unown: 100, Castform: 100,
 		};
-		const level = this.adjustLevel || customScale[species.name] || levelScale[species.tier] || (species.nfe ? 90 : 80);
+		const level = this.adjustLevel || species.randomBattleLevel || customScale[species.name] || levelScale[species.tier] || (species.nfe ? 90 : 80);
 
 		// Prepare optimal HP
 		let hp = Math.floor(

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -823,7 +823,11 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		const customScale: {[k: string]: number} = {
 			Delibird: 100, Ditto: 100, 'Farfetch\u2019d': 100, Unown: 100, Castform: 100,
 		};
-		const level = this.adjustLevel || species.randomBattleLevel || customScale[species.name] || levelScale[species.tier] || (species.nfe ? 90 : 80);
+		const level = this.adjustLevel ||
+					  species.randomBattleLevel ||
+					  customScale[species.name] ||
+					  levelScale[species.tier] ||
+					  (species.nfe ? 90 : 80);
 
 		// Prepare optimal HP
 		let hp = Math.floor(

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -810,24 +810,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			item = 'Black Sludge';
 		}
 
-		const levelScale: {[k: string]: number} = {
-			AG: 74,
-			Uber: 76,
-			OU: 80,
-			'(OU)': 82,
-			UUBL: 82,
-			UU: 84,
-			NUBL: 86,
-			NU: 88,
-		};
-		const customScale: {[k: string]: number} = {
-			Delibird: 100, Ditto: 100, 'Farfetch\u2019d': 100, Unown: 100, Castform: 100,
-		};
-		const level = this.adjustLevel ||
-					  species.randomBattleLevel ||
-					  customScale[species.name] ||
-					  levelScale[species.tier] ||
-					  (species.nfe ? 90 : 80);
+		const level = this.adjustLevel || species.randomBattleLevel || (species.nfe ? 90 : 80);
 
 		// Prepare optimal HP
 		let hp = Math.floor(

--- a/data/mods/gen5/formats-data.ts
+++ b/data/mods/gen5/formats-data.ts
@@ -7,6 +7,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	venusaur: {
 		randomBattleMoves: ["hiddenpowerfire", "hiddenpowerice", "leechseed", "naturepower", "powerwhip", "sleeppowder", "sludgebomb", "swordsdance", "synthesis"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 		doublesTier: "DOU",
 	},
@@ -18,6 +19,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	charizard: {
 		randomBattleMoves: ["airslash", "dragonpulse", "fireblast", "focusblast", "hiddenpowergrass", "roost"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DOU",
 	},
@@ -30,6 +32,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	blastoise: {
 		randomBattleMoves: ["icebeam", "protect", "rapidspin", "scald", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -41,6 +44,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	butterfree: {
 		randomBattleMoves: ["bugbuzz", "hiddenpowerrock", "psychic", "quiverdance", "sleeppowder", "substitute"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -52,6 +56,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	beedrill: {
 		randomBattleMoves: ["drillrun", "poisonjab", "tailwind", "toxicspikes", "uturn"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -63,6 +68,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	pidgeot: {
 		randomBattleMoves: ["bravebird", "heatwave", "quickattack", "return", "roost", "uturn", "workup"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -71,6 +77,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	raticate: {
 		randomBattleMoves: ["crunch", "facade", "flamewheel", "suckerpunch", "swordsdance", "uturn"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -79,6 +86,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	fearow: {
 		randomBattleMoves: ["doubleedge", "drillpeck", "drillrun", "pursuit", "quickattack", "return", "roost", "uturn"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -87,6 +95,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	arbok: {
 		randomBattleMoves: ["aquatail", "coil", "earthquake", "glare", "gunkshot", "rest", "seedbomb", "suckerpunch"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -95,10 +104,12 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	pikachu: {
 		randomBattleMoves: ["extremespeed", "grassknot", "hiddenpowerice", "voltswitch", "volttackle"],
+		randomBattleLevel: 90,
 		tier: "NFE",
 	},
 	raichu: {
 		randomBattleMoves: ["encore", "focusblast", "grassknot", "hiddenpowerice", "nastyplot", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -107,6 +118,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sandslash: {
 		randomBattleMoves: ["earthquake", "rapidspin", "stealthrock", "stoneedge", "swordsdance", "xscissor"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -118,6 +130,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	nidoqueen: {
 		randomBattleMoves: ["earthpower", "fireblast", "icebeam", "sludgewave", "stealthrock", "toxicspikes"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -129,6 +142,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	nidoking: {
 		randomBattleMoves: ["earthpower", "fireblast", "icebeam", "sludgewave", "substitute", "superpower"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -140,6 +154,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	clefable: {
 		randomBattleMoves: ["calmmind", "doubleedge", "icebeam", "softboiled", "stealthrock", "thunderbolt", "thunderwave"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -148,6 +163,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ninetales: {
 		randomBattleMoves: ["fireblast", "nastyplot", "painsplit", "solarbeam", "substitute", "willowisp"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
@@ -159,6 +175,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wigglytuff: {
 		randomBattleMoves: ["doubleedge", "fireblast", "healbell", "protect", "stealthrock", "toxic", "wish"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -171,6 +188,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	crobat: {
 		randomBattleMoves: ["bravebird", "heatwave", "roost", "sludgebomb", "superfang", "taunt", "toxic", "uturn"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -182,11 +200,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vileplume: {
 		randomBattleMoves: ["aromatherapy", "gigadrain", "hiddenpowerfire", "leechseed", "sleeppowder", "sludgebomb", "synthesis"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
 	bellossom: {
 		randomBattleMoves: ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "leafstorm", "leechseed", "sleeppowder", "stunspore", "synthesis"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -195,6 +215,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	parasect: {
 		randomBattleMoves: ["aromatherapy", "leechseed", "seedbomb", "spore", "stunspore", "synthesis", "xscissor"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -203,6 +224,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	venomoth: {
 		randomBattleMoves: ["bugbuzz", "quiverdance", "roost", "sleeppowder", "substitute"],
+		randomBattleLevel: 84,
 		tier: "RUBL",
 		doublesTier: "DUU",
 	},
@@ -211,6 +233,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dugtrio: {
 		randomBattleMoves: ["aerialace", "earthquake", "stealthrock", "stoneedge"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 		doublesTier: "DUU",
 	},
@@ -219,6 +242,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	persian: {
 		randomBattleMoves: ["bite", "fakeout", "return", "switcheroo", "taunt", "uturn", "waterpulse"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -227,6 +251,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	golduck: {
 		randomBattleMoves: ["calmmind", "encore", "focusblast", "hydropump", "icebeam", "psyshock", "scald"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -235,6 +260,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	primeape: {
 		randomBattleMoves: ["closecombat", "honeclaws", "icepunch", "stoneedge", "uturn"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -243,6 +269,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	arcanine: {
 		randomBattleMoves: ["closecombat", "extremespeed", "flareblitz", "hiddenpowergrass", "morningsun", "wildcharge", "willowisp"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DOU",
 	},
@@ -254,11 +281,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	poliwrath: {
 		randomBattleMoves: ["circlethrow", "rest", "scald", "sleeptalk"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	politoed: {
 		randomBattleMoves: ["encore", "focusblast", "hiddenpowergrass", "hypnosis", "icebeam", "protect", "scald", "toxic"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
@@ -271,6 +300,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	alakazam: {
 		randomBattleMoves: ["calmmind", "encore", "focusblast", "psychic", "psyshock", "shadowball"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DUU",
 	},
@@ -282,6 +312,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	machamp: {
 		randomBattleMoves: ["bulkup", "bulletpunch", "dynamicpunch", "icepunch", "payback", "stoneedge"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -293,6 +324,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	victreebel: {
 		randomBattleMoves: ["powerwhip", "sleeppowder", "sludgebomb", "suckerpunch", "sunnyday", "weatherball"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -302,6 +334,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	tentacruel: {
 		randomBattleMoves: ["gigadrain", "icebeam", "protect", "rapidspin", "scald", "toxic", "toxicspikes"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DUU",
 	},
@@ -313,6 +346,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	golem: {
 		randomBattleMoves: ["earthquake", "explosion", "rockblast", "stealthrock", "suckerpunch", "toxic"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -321,6 +355,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	rapidash: {
 		randomBattleMoves: ["drillrun", "flareblitz", "megahorn", "morningsun", "wildcharge", "willowisp"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -329,11 +364,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	slowbro: {
 		randomBattleMoves: ["calmmind", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	slowking: {
 		randomBattleMoves: ["calmmind", "fireblast", "grassknot", "icebeam", "psychic", "slackoff", "surf", "trickroom"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -346,11 +383,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	magnezone: {
 		randomBattleMoves: ["flashcannon", "hiddenpowerfire", "thunderbolt", "toxic", "voltswitch"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DUU",
 	},
 	farfetchd: {
 		randomBattleMoves: ["bravebird", "leafblade", "quickattack", "return", "swordsdance"],
+		randomBattleLevel: 100,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -359,6 +398,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dodrio: {
 		randomBattleMoves: ["bravebird", "pursuit", "quickattack", "return", "roost"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -367,6 +407,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dewgong: {
 		randomBattleMoves: ["icebeam", "protect", "rest", "sleeptalk", "surf", "toxic"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -375,6 +416,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	muk: {
 		randomBattleMoves: ["brickbreak", "curse", "firepunch", "gunkshot", "icepunch", "poisonjab", "rest", "shadowsneak"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -383,6 +425,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cloyster: {
 		randomBattleMoves: ["hydropump", "iceshard", "iciclespear", "rapidspin", "rockblast", "shellsmash", "spikes"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
@@ -395,6 +438,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gengar: {
 		randomBattleMoves: ["focusblast", "shadowball", "sludgewave", "substitute", "trick", "willowisp"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
@@ -403,6 +447,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	steelix: {
 		randomBattleMoves: ["curse", "earthquake", "gyroball", "roar", "stealthrock", "stoneedge", "toxic"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -411,6 +456,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hypno: {
 		randomBattleMoves: ["foulplay", "protect", "psychic", "thunderwave", "toxic", "wish"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -419,6 +465,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kingler: {
 		randomBattleMoves: ["agility", "crabhammer", "return", "superpower", "swordsdance", "xscissor"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -427,6 +474,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	electrode: {
 		randomBattleMoves: ["foulplay", "hiddenpowergrass", "hiddenpowerice", "taunt", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -435,6 +483,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	exeggutor: {
 		randomBattleMoves: ["gigadrain", "hiddenpowerfire", "leechseed", "protect", "psychic", "sleeppowder", "substitute"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -443,6 +492,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	marowak: {
 		randomBattleMoves: ["bonemerang", "doubleedge", "earthquake", "firepunch", "stealthrock", "stoneedge"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -451,16 +501,19 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hitmonlee: {
 		randomBattleMoves: ["closecombat", "earthquake", "fakeout", "stoneedge", "suckerpunch"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	hitmonchan: {
 		randomBattleMoves: ["bulkup", "closecombat", "drainpunch", "icepunch", "machpunch", "rapidspin", "stoneedge"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	hitmontop: {
 		randomBattleMoves: ["closecombat", "machpunch", "rapidspin", "stoneedge", "suckerpunch", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DOU",
 	},
@@ -469,6 +522,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lickilicky: {
 		randomBattleMoves: ["bodyslam", "earthquake", "healbell", "powerwhip", "protect", "swordsdance", "toxic", "wish"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -477,6 +531,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	weezing: {
 		randomBattleMoves: ["fireblast", "haze", "painsplit", "sludgebomb", "willowisp"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -485,11 +540,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	rhydon: {
 		randomBattleMoves: ["earthquake", "megahorn", "stealthrock", "stoneedge", "toxic"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "NFE",
 	},
 	rhyperior: {
 		randomBattleMoves: ["earthquake", "icepunch", "megahorn", "rockpolish", "stoneedge"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -498,11 +555,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	chansey: {
 		randomBattleMoves: ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 		doublesTier: "NFE",
 	},
 	blissey: {
 		randomBattleMoves: ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 		doublesTier: "DUU",
 	},
@@ -512,11 +571,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	tangrowth: {
 		randomBattleMoves: ["earthquake", "hiddenpowerfire", "leechseed", "powerwhip", "rockslide", "sleeppowder", "synthesis"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	kangaskhan: {
 		randomBattleMoves: ["doubleedge", "earthquake", "fakeout", "focuspunch", "return", "substitute", "suckerpunch"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -528,6 +589,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kingdra: {
 		randomBattleMoves: ["dracometeor", "dragondance", "hiddenpowerelectric", "hydropump", "icebeam", "outrage", "raindance", "waterfall"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DOU",
 	},
@@ -536,6 +598,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	seaking: {
 		randomBattleMoves: ["drillrun", "icebeam", "megahorn", "return", "waterfall"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -544,6 +607,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	starmie: {
 		randomBattleMoves: ["hydropump", "icebeam", "psyshock", "rapidspin", "recover", "scald", "thunderbolt", "trick"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DUU",
 	},
@@ -552,16 +616,19 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mrmime: {
 		randomBattleMoves: ["encore", "focusblast", "nastyplot", "psychic", "substitute", "thunderbolt"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	scyther: {
 		randomBattleMoves: ["aerialace", "brickbreak", "bugbite", "quickattack", "roost", "swordsdance"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "NFE",
 	},
 	scizor: {
 		randomBattleMoves: ["bugbite", "bulletpunch", "pursuit", "roost", "superpower", "swordsdance", "uturn"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
@@ -570,6 +637,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	jynx: {
 		randomBattleMoves: ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psyshock", "substitute", "trick"],
+		randomBattleLevel: 86,
 		tier: "NUBL",
 		doublesTier: "DUU",
 	},
@@ -582,6 +650,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	electivire: {
 		randomBattleMoves: ["crosschop", "earthquake", "flamethrower", "icepunch", "voltswitch", "wildcharge"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DOU",
 	},
@@ -593,16 +662,19 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	magmortar: {
 		randomBattleMoves: ["fireblast", "focusblast", "hiddenpowergrass", "substitute", "thunderbolt"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	pinsir: {
 		randomBattleMoves: ["closecombat", "earthquake", "quickattack", "stealthrock", "stoneedge", "swordsdance", "xscissor"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
 	tauros: {
 		randomBattleMoves: ["doubleedge", "earthquake", "pursuit", "retaliate", "stoneedge"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -611,16 +683,19 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gyarados: {
 		randomBattleMoves: ["dragondance", "earthquake", "icefang", "stoneedge", "waterfall"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	lapras: {
 		randomBattleMoves: ["healbell", "hydropump", "icebeam", "substitute", "thunderbolt", "toxic"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
 	ditto: {
 		randomBattleMoves: ["transform"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -629,36 +704,43 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vaporeon: {
 		randomBattleMoves: ["icebeam", "protect", "roar", "scald", "toxic", "wish"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 		doublesTier: "DOU",
 	},
 	jolteon: {
 		randomBattleMoves: ["hiddenpowerice", "signalbeam", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 		doublesTier: "DOU",
 	},
 	flareon: {
 		randomBattleMoves: ["facade", "flamecharge", "rest", "sleeptalk"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	espeon: {
 		randomBattleMoves: ["calmmind", "hiddenpowerfire", "morningsun", "psychic", "psyshock", "signalbeam"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 		doublesTier: "DOU",
 	},
 	umbreon: {
 		randomBattleMoves: ["foulplay", "protect", "toxic", "wish"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	leafeon: {
 		randomBattleMoves: ["leafblade", "return", "swordsdance", "xscissor"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	glaceon: {
 		randomBattleMoves: ["hiddenpowerground", "icebeam", "protect", "shadowball", "toxic", "wish"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -667,11 +749,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	porygon2: {
 		randomBattleMoves: ["discharge", "icebeam", "recover", "toxic", "triattack"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "NFE",
 	},
 	porygonz: {
 		randomBattleMoves: ["agility", "darkpulse", "hiddenpowerfighting", "icebeam", "nastyplot", "thunderbolt", "triattack", "trick"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -680,6 +764,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	omastar: {
 		randomBattleMoves: ["hiddenpowergrass", "icebeam", "shellsmash", "spikes", "stealthrock", "surf"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -688,11 +773,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kabutops: {
 		randomBattleMoves: ["aquajet", "rapidspin", "stealthrock", "stoneedge", "superpower", "swordsdance", "waterfall"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	aerodactyl: {
 		randomBattleMoves: ["aquatail", "doubleedge", "earthquake", "roost", "stealthrock", "stoneedge", "taunt"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -701,21 +788,25 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	snorlax: {
 		randomBattleMoves: ["bodyslam", "crunch", "curse", "earthquake", "firepunch", "pursuit", "rest"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	articuno: {
 		randomBattleMoves: ["hurricane", "icebeam", "roost", "substitute", "toxic"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	zapdos: {
 		randomBattleMoves: ["heatwave", "hiddenpowerice", "roost", "substitute", "thunderbolt", "toxic", "uturn"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DOU",
 	},
 	moltres: {
 		randomBattleMoves: ["fireblast", "hiddenpowergrass", "hurricane", "roost", "substitute", "toxic", "uturn", "willowisp"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -724,20 +815,24 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dragonair: {
 		randomBattleMoves: ["dragondance", "outrage", "rest", "sleeptalk", "waterfall"],
+		randomBattleLevel: 90,
 		tier: "NFE",
 	},
 	dragonite: {
 		randomBattleMoves: ["dragondance", "earthquake", "extremespeed", "firepunch", "outrage", "roost"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	mewtwo: {
 		randomBattleMoves: ["aurasphere", "calmmind", "fireblast", "psystrike", "recover", "shadowball"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	mew: {
 		randomBattleMoves: ["aurasphere", "fireblast", "nastyplot", "psychic", "softboiled", "stealthrock", "taunt", "uturn", "willowisp"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -749,6 +844,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	meganium: {
 		randomBattleMoves: ["aromatherapy", "dragontail", "gigadrain", "leechseed", "lightscreen", "reflect", "synthesis", "toxic"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -760,6 +856,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	typhlosion: {
 		randomBattleMoves: ["eruption", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerrock"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -771,6 +868,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	feraligatr: {
 		randomBattleMoves: ["aquajet", "dragondance", "earthquake", "icepunch", "superpower", "swordsdance", "waterfall"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -779,6 +877,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	furret: {
 		randomBattleMoves: ["aquatail", "doubleedge", "firepunch", "shadowclaw", "trick", "uturn"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -787,6 +886,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	noctowl: {
 		randomBattleMoves: ["airslash", "magiccoat", "nightshade", "roost", "toxic", "whirlwind"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -795,6 +895,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ledian: {
 		randomBattleMoves: ["encore", "lightscreen", "reflect", "roost", "toxic", "uturn"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -803,6 +904,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ariados: {
 		randomBattleMoves: ["poisonjab", "suckerpunch", "toxicspikes", "xscissor"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -811,6 +913,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lanturn: {
 		randomBattleMoves: ["healbell", "icebeam", "scald", "thunderbolt", "thunderwave", "voltswitch"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -822,6 +925,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	togekiss: {
 		randomBattleMoves: ["airslash", "aurasphere", "nastyplot", "roost", "thunderwave"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DOU",
 	},
@@ -831,6 +935,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	xatu: {
 		randomBattleMoves: ["heatwave", "psychic", "roost", "thunderwave", "toxic", "uturn"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -842,6 +947,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ampharos: {
 		randomBattleMoves: ["agility", "focusblast", "healbell", "hiddenpowergrass", "hiddenpowerice", "thunderbolt", "toxic", "voltswitch"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -853,6 +959,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	azumarill: {
 		randomBattleMoves: ["aquajet", "doubleedge", "icepunch", "superpower", "waterfall"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -861,6 +968,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sudowoodo: {
 		randomBattleMoves: ["earthquake", "stealthrock", "stoneedge", "suckerpunch", "toxic", "woodhammer"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -872,6 +980,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	jumpluff: {
 		randomBattleMoves: ["acrobatics", "encore", "energyball", "leechseed", "sleeppowder", "uturn"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -880,6 +989,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ambipom: {
 		randomBattleMoves: ["fakeout", "lowkick", "pursuit", "return", "switcheroo", "uturn"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -888,6 +998,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sunflora: {
 		randomBattleMoves: ["earthpower", "encore", "gigadrain", "hiddenpowerrock", "solarbeam", "sunnyday"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -896,6 +1007,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	yanmega: {
 		randomBattleMoves: ["airslash", "bugbuzz", "hiddenpowerground", "protect", "uturn"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -904,16 +1016,19 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	quagsire: {
 		randomBattleMoves: ["earthquake", "encore", "recover", "scald", "toxic"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	murkrow: {
 		randomBattleMoves: ["foulplay", "roost", "taunt", "thunderwave", "toxic"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "NFE",
 	},
 	honchkrow: {
 		randomBattleMoves: ["bravebird", "heatwave", "pursuit", "roost", "substitute", "suckerpunch", "superpower"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -923,11 +1038,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mismagius: {
 		randomBattleMoves: ["hiddenpowerfighting", "nastyplot", "shadowball", "substitute", "taunt", "thunderbolt", "willowisp"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	unown: {
 		randomBattleMoves: ["hiddenpowerpsychic"],
+		randomBattleLevel: 100,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -936,11 +1053,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wobbuffet: {
 		randomBattleMoves: ["counter", "destinybond", "encore", "mirrorcoat"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 		doublesTier: "DUU",
 	},
 	girafarig: {
 		randomBattleMoves: ["calmmind", "hiddenpowerfire", "hypervoice", "psychic", "psyshock", "thunderbolt"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -949,21 +1068,25 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	forretress: {
 		randomBattleMoves: ["gyroball", "rapidspin", "spikes", "stealthrock", "toxic", "voltswitch"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DUU",
 	},
 	dunsparce: {
 		randomBattleMoves: ["bite", "bodyslam", "coil", "glare", "headbutt", "rockslide", "roost"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	gligar: {
 		randomBattleMoves: ["earthquake", "roost", "stealthrock", "taunt", "toxic", "uturn"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "NFE",
 	},
 	gliscor: {
 		randomBattleMoves: ["earthquake", "icefang", "protect", "roost", "substitute", "swordsdance", "taunt", "toxic"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
@@ -972,21 +1095,25 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	granbull: {
 		randomBattleMoves: ["closecombat", "crunch", "healbell", "return", "thunderwave", "toxic"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	qwilfish: {
 		randomBattleMoves: ["destinybond", "poisonjab", "spikes", "taunt", "thunderwave", "toxicspikes", "waterfall"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	shuckle: {
 		randomBattleMoves: ["encore", "protect", "stealthrock", "toxic", "wrap"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	heracross: {
 		randomBattleMoves: ["closecombat", "earthquake", "facade", "megahorn", "stoneedge"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -996,6 +1123,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	weavile: {
 		randomBattleMoves: ["icepunch", "iceshard", "lowkick", "nightslash", "pursuit", "swordsdance"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DOU",
 	},
@@ -1004,6 +1132,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ursaring: {
 		randomBattleMoves: ["closecombat", "crunch", "earthquake", "facade", "protect", "swordsdance"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -1012,6 +1141,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	magcargo: {
 		randomBattleMoves: ["hiddenpowerrock", "lavaplume", "recover", "stealthrock", "toxic"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1024,11 +1154,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mamoswine: {
 		randomBattleMoves: ["earthquake", "iceshard", "iciclecrash", "stealthrock", "superpower"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	corsola: {
 		randomBattleMoves: ["powergem", "recover", "scald", "stealthrock", "toxic"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1037,11 +1169,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	octillery: {
 		randomBattleMoves: ["energyball", "fireblast", "hydropump", "icebeam", "thunderwave"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	delibird: {
 		randomBattleMoves: ["aerialace", "icebeam", "iceshard", "rapidspin"],
+		randomBattleLevel: 100,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1050,11 +1184,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mantine: {
 		randomBattleMoves: ["airslash", "hydropump", "icebeam", "raindance", "rest", "scald", "sleeptalk"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
 	skarmory: {
 		randomBattleMoves: ["bravebird", "roost", "spikes", "stealthrock", "whirlwind"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DUU",
 	},
@@ -1063,6 +1199,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	houndoom: {
 		randomBattleMoves: ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "suckerpunch"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -1071,36 +1208,43 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	donphan: {
 		randomBattleMoves: ["earthquake", "headsmash", "iceshard", "rapidspin", "seedbomb", "stealthrock"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 		doublesTier: "DUU",
 	},
 	stantler: {
 		randomBattleMoves: ["doubleedge", "earthquake", "jumpkick", "megahorn", "suckerpunch"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	smeargle: {
 		randomBattleMoves: ["memento", "spikes", "spore", "stealthrock", "whirlwind"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	miltank: {
 		randomBattleMoves: ["bodyslam", "earthquake", "healbell", "milkdrink", "stealthrock", "toxic"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
 	raikou: {
 		randomBattleMoves: ["aurasphere", "calmmind", "hiddenpowerice", "substitute", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	entei: {
 		randomBattleMoves: ["bulldoze", "extremespeed", "flareblitz", "hiddenpowergrass", "stoneedge"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	suicune: {
 		randomBattleMoves: ["calmmind", "hiddenpowerelectric", "hydropump", "icebeam", "rest", "roar", "scald", "sleeptalk"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -1112,21 +1256,25 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	tyranitar: {
 		randomBattleMoves: ["crunch", "fireblast", "pursuit", "stealthrock", "stoneedge", "superpower"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	lugia: {
 		randomBattleMoves: ["aeroblast", "earthquake", "roost", "substitute", "toxic", "whirlwind"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	hooh: {
 		randomBattleMoves: ["bravebird", "earthquake", "roost", "sacredfire", "substitute", "toxic"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	celebi: {
 		randomBattleMoves: ["earthpower", "gigadrain", "hiddenpowerice", "leafstorm", "nastyplot", "psychic", "recover", "stealthrock", "uturn"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DUU",
 	},
@@ -1138,6 +1286,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sceptile: {
 		randomBattleMoves: ["acrobatics", "earthquake", "leafblade", "substitute", "swordsdance"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -1150,6 +1299,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	blaziken: {
 		randomBattleMoves: ["flareblitz", "highjumpkick", "protect", "stoneedge", "swordsdance"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DOU",
 	},
@@ -1161,6 +1311,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swampert: {
 		randomBattleMoves: ["earthquake", "icebeam", "protect", "roar", "scald", "stealthrock", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -1169,6 +1320,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mightyena: {
 		randomBattleMoves: ["crunch", "facade", "firefang", "howl", "suckerpunch"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1177,6 +1329,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	linoone: {
 		randomBattleMoves: ["bellydrum", "extremespeed", "seedbomb", "shadowclaw"],
+		randomBattleLevel: 88,
 		tier: "PUBL",
 		doublesTier: "DUU",
 	},
@@ -1188,6 +1341,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	beautifly: {
 		randomBattleMoves: ["bugbuzz", "hiddenpowerground", "psychic", "quiverdance"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1196,6 +1350,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dustox: {
 		randomBattleMoves: ["bugbuzz", "quiverdance", "roost", "sludgebomb"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1207,6 +1362,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ludicolo: {
 		randomBattleMoves: ["gigadrain", "hydropump", "icebeam", "raindance", "scald"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DOU",
 	},
@@ -1218,6 +1374,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	shiftry: {
 		randomBattleMoves: ["darkpulse", "hiddenpowerfire", "leafstorm", "naturepower", "seedbomb", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -1226,6 +1383,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swellow: {
 		randomBattleMoves: ["bravebird", "facade", "protect", "quickattack", "uturn"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -1234,6 +1392,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	pelipper: {
 		randomBattleMoves: ["hurricane", "icebeam", "roost", "scald", "tailwind", "toxic", "uturn"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1245,11 +1404,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gardevoir: {
 		randomBattleMoves: ["calmmind", "focusblast", "painsplit", "psychic", "substitute", "thunderbolt", "trick", "willowisp"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
 	gallade: {
 		randomBattleMoves: ["closecombat", "drainpunch", "nightslash", "substitute", "swordsdance", "trick", "zenheadbutt"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -1258,6 +1419,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	masquerain: {
 		randomBattleMoves: ["airslash", "bugbuzz", "hydropump", "quiverdance", "roost"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1266,6 +1428,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	breloom: {
 		randomBattleMoves: ["bulletseed", "machpunch", "spore", "stoneedge", "swordsdance"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
@@ -1274,11 +1437,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vigoroth: {
 		randomBattleMoves: ["bulkup", "earthquake", "return", "slackoff", "taunt", "toxic"],
+		randomBattleLevel: 88,
 		tier: "PUBL",
 		doublesTier: "NFE",
 	},
 	slaking: {
 		randomBattleMoves: ["earthquake", "nightslash", "pursuit", "retaliate", "return"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1287,11 +1452,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ninjask: {
 		randomBattleMoves: ["aerialace", "substitute", "swordsdance", "xscissor"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
 	shedinja: {
 		randomBattleMoves: ["shadowclaw", "shadowsneak", "swordsdance", "willowisp", "xscissor"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1303,6 +1470,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	exploud: {
 		randomBattleMoves: ["fireblast", "focusblast", "hypervoice", "lowkick", "surf"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1311,6 +1479,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hariyama: {
 		randomBattleMoves: ["bulletpunch", "closecombat", "facade", "fakeout", "stoneedge"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -1319,6 +1488,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	probopass: {
 		randomBattleMoves: ["earthpower", "powergem", "stealthrock", "toxic", "voltswitch"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -1327,16 +1497,19 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	delcatty: {
 		randomBattleMoves: ["doubleedge", "fakeout", "icebeam", "suckerpunch", "thunderwave"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	sableye: {
 		randomBattleMoves: ["foulplay", "nightshade", "recover", "taunt", "willowisp"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DOU",
 	},
 	mawile: {
 		randomBattleMoves: ["firefang", "ironhead", "stealthrock", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -1348,6 +1521,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	aggron: {
 		randomBattleMoves: ["aquatail", "earthquake", "headsmash", "heavyslam", "rockpolish", "stealthrock", "thunderwave"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -1356,6 +1530,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	medicham: {
 		randomBattleMoves: ["bulletpunch", "highjumpkick", "icepunch", "thunderpunch", "trick", "zenheadbutt"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -1364,26 +1539,31 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	manectric: {
 		randomBattleMoves: ["flamethrower", "hiddenpowerice", "overheat", "switcheroo", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	plusle: {
 		randomBattleMoves: ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	minun: {
 		randomBattleMoves: ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	volbeat: {
 		randomBattleMoves: ["bugbuzz", "encore", "roost", "thunderwave", "uturn"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
 	illumise: {
 		randomBattleMoves: ["bugbuzz", "encore", "roost", "substitute", "thunderwave", "wish"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1396,6 +1576,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	roserade: {
 		randomBattleMoves: ["gigadrain", "hiddenpowerfire", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -1404,6 +1585,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swalot: {
 		randomBattleMoves: ["earthquake", "encore", "painsplit", "protect", "sludgebomb", "toxic"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1412,6 +1594,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sharpedo: {
 		randomBattleMoves: ["crunch", "earthquake", "icebeam", "protect", "waterfall", "zenheadbutt"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -1420,6 +1603,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wailord: {
 		randomBattleMoves: ["hiddenpowergrass", "hydropump", "icebeam", "surf", "waterspout"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1428,11 +1612,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	camerupt: {
 		randomBattleMoves: ["earthquake", "hiddenpowergrass", "lavaplume", "roar", "stealthrock"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
 	torkoal: {
 		randomBattleMoves: ["earthquake", "lavaplume", "protect", "rapidspin", "stealthrock", "toxic", "yawn"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -1441,11 +1627,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	grumpig: {
 		randomBattleMoves: ["focusblast", "healbell", "psychic", "shadowball", "thunderwave", "trick", "whirlwind"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	spinda: {
 		randomBattleMoves: ["return", "suckerpunch", "superpower", "trickroom"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1457,6 +1645,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	flygon: {
 		randomBattleMoves: ["earthquake", "firepunch", "outrage", "roost", "stoneedge", "superpower", "uturn"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -1465,6 +1654,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cacturne: {
 		randomBattleMoves: ["drainpunch", "seedbomb", "spikes", "substitute", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -1473,26 +1663,31 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	altaria: {
 		randomBattleMoves: ["dracometeor", "dragondance", "earthquake", "fireblast", "healbell", "outrage", "roost"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
 	zangoose: {
 		randomBattleMoves: ["closecombat", "facade", "nightslash", "quickattack", "swordsdance"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
 	seviper: {
 		randomBattleMoves: ["earthquake", "flamethrower", "gigadrain", "sludgebomb", "suckerpunch", "switcheroo"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	lunatone: {
 		randomBattleMoves: ["earthpower", "hiddenpowerrock", "moonlight", "psychic", "stealthrock", "toxic"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	solrock: {
 		randomBattleMoves: ["explosion", "lightscreen", "morningsun", "reflect", "rockslide", "stealthrock", "willowisp"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1501,6 +1696,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	whiscash: {
 		randomBattleMoves: ["dragondance", "earthquake", "icebeam", "waterfall"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1509,6 +1705,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	crawdaunt: {
 		randomBattleMoves: ["crunch", "dragondance", "superpower", "waterfall"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -1517,6 +1714,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	claydol: {
 		randomBattleMoves: ["earthquake", "icebeam", "psychic", "rapidspin", "stealthrock", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -1525,6 +1723,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cradily: {
 		randomBattleMoves: ["earthquake", "recover", "rockslide", "seedbomb", "stealthrock", "swordsdance", "toxic"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -1533,6 +1732,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	armaldo: {
 		randomBattleMoves: ["aquatail", "earthquake", "rapidspin", "stealthrock", "stoneedge", "swordsdance", "xscissor"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -1541,6 +1741,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	milotic: {
 		randomBattleMoves: ["dragontail", "haze", "icebeam", "recover", "scald", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -1550,13 +1751,16 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	castformsunny: {
 		randomBattleMoves: ["icebeam", "solarbeam", "sunnyday", "weatherball"],
+		randomBattleLevel: 100,
 	},
 	castformrainy: {
 		randomBattleMoves: ["icebeam", "raindance", "thunder", "weatherball"],
+		randomBattleLevel: 100,
 	},
 	castformsnowy: {},
 	kecleon: {
 		randomBattleMoves: ["foulplay", "recover", "stealthrock", "thunderwave", "toxic"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1565,6 +1769,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	banette: {
 		randomBattleMoves: ["pursuit", "shadowclaw", "shadowsneak", "trick", "willowisp"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -1573,16 +1778,19 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dusclops: {
 		randomBattleMoves: ["nightshade", "rest", "sleeptalk", "willowisp"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "NFE",
 	},
 	dusknoir: {
 		randomBattleMoves: ["earthquake", "icepunch", "painsplit", "shadowsneak", "trick", "willowisp"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	tropius: {
 		randomBattleMoves: ["airslash", "leechseed", "protect", "substitute", "toxic"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1591,11 +1799,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	chimecho: {
 		randomBattleMoves: ["calmmind", "healingwish", "psychic", "recover", "shadowball", "toxic", "yawn"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	absol: {
 		randomBattleMoves: ["fireblast", "nightslash", "psychocut", "pursuit", "suckerpunch", "superpower", "swordsdance"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -1604,11 +1814,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	glalie: {
 		randomBattleMoves: ["earthquake", "explosion", "icebeam", "spikes", "taunt"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	froslass: {
 		randomBattleMoves: ["destinybond", "icebeam", "shadowball", "spikes", "taunt", "thunderwave"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 		doublesTier: "DUU",
 	},
@@ -1620,6 +1832,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	walrein: {
 		randomBattleMoves: ["encore", "icebeam", "protect", "roar", "surf", "toxic"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1628,21 +1841,25 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	huntail: {
 		randomBattleMoves: ["icebeam", "return", "shellsmash", "waterfall"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
 	gorebyss: {
 		randomBattleMoves: ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
 	relicanth: {
 		randomBattleMoves: ["doubleedge", "earthquake", "headsmash", "stealthrock", "waterfall"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
 	luvdisc: {
 		randomBattleMoves: ["icebeam", "protect", "surf", "sweetkiss", "toxic"],
+		randomBattleLevel: 100,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1654,6 +1871,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	salamence: {
 		randomBattleMoves: ["aquatail", "brickbreak", "dracometeor", "dragondance", "earthquake", "fireblast", "outrage", "roost"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
@@ -1666,71 +1884,85 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	metagross: {
 		randomBattleMoves: ["agility", "bulletpunch", "earthquake", "meteormash", "pursuit", "stealthrock", "zenheadbutt"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 		doublesTier: "DOU",
 	},
 	regirock: {
 		randomBattleMoves: ["drainpunch", "protect", "rockslide", "stealthrock", "thunderwave", "toxic"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
 	regice: {
 		randomBattleMoves: ["focusblast", "icebeam", "rest", "rockpolish", "sleeptalk", "thunderbolt"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
 	registeel: {
 		randomBattleMoves: ["curse", "ironhead", "protect", "rest", "sleeptalk", "stealthrock", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	latias: {
 		randomBattleMoves: ["calmmind", "dracometeor", "healingwish", "hiddenpowerfire", "psyshock", "roost", "surf"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 		doublesTier: "DUU",
 	},
 	latios: {
 		randomBattleMoves: ["dracometeor", "hiddenpowerfire", "psyshock", "roost", "surf", "trick"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	kyogre: {
 		randomBattleMoves: ["calmmind", "icebeam", "rest", "sleeptalk", "surf", "thunder", "waterspout"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	groudon: {
 		randomBattleMoves: ["earthquake", "firepunch", "stealthrock", "stoneedge", "swordsdance", "thunderwave"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	rayquaza: {
 		randomBattleMoves: ["dracometeor", "dragondance", "earthquake", "extremespeed", "outrage", "swordsdance", "vcreate"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	jirachi: {
 		randomBattleMoves: ["bodyslam", "firepunch", "icepunch", "ironhead", "substitute", "uturn", "wish"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DUber",
 	},
 	deoxys: {
 		randomBattleMoves: ["extremespeed", "hiddenpowerfire", "icebeam", "psychoboost", "stealthrock", "superpower"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUU",
 	},
 	deoxysattack: {
 		randomBattleMoves: ["extremespeed", "hiddenpowerfire", "icebeam", "psychoboost", "stealthrock", "superpower"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUU",
 	},
 	deoxysdefense: {
 		randomBattleMoves: ["magiccoat", "recover", "seismictoss", "spikes", "taunt", "toxic"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUU",
 	},
 	deoxysspeed: {
 		randomBattleMoves: ["icebeam", "lightscreen", "psychoboost", "reflect", "spikes", "stealthrock", "superpower", "taunt"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUU",
 	},
@@ -1742,6 +1974,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	torterra: {
 		randomBattleMoves: ["earthquake", "rockpolish", "stealthrock", "stoneedge", "synthesis", "woodhammer"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -1754,6 +1987,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	infernape: {
 		randomBattleMoves: ["closecombat", "flareblitz", "hiddenpowerice", "machpunch", "overheat", "swordsdance", "thunderpunch", "uturn"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 		doublesTier: "DOU",
 	},
@@ -1765,6 +1999,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	empoleon: {
 		randomBattleMoves: ["agility", "grassknot", "hydropump", "icebeam", "protect", "scald", "stealthrock", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -1776,6 +2011,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	staraptor: {
 		randomBattleMoves: ["bravebird", "closecombat", "doubleedge", "quickattack", "roost", "uturn"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 		doublesTier: "DUU",
 	},
@@ -1784,6 +2020,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	bibarel: {
 		randomBattleMoves: ["curse", "quickattack", "rest", "waterfall"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1792,6 +2029,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kricketune: {
 		randomBattleMoves: ["brickbreak", "bugbite", "nightslash", "return", "swordsdance"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1803,6 +2041,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	luxray: {
 		randomBattleMoves: ["crunch", "facade", "icefang", "superpower", "voltswitch", "wildcharge"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1811,6 +2050,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	rampardos: {
 		randomBattleMoves: ["crunch", "earthquake", "firepunch", "headsmash", "rockpolish", "superpower"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -1819,6 +2059,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	bastiodon: {
 		randomBattleMoves: ["metalburst", "protect", "roar", "rockblast", "stealthrock", "toxic"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -1827,21 +2068,25 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wormadam: {
 		randomBattleMoves: ["gigadrain", "hiddenpowerrock", "leafstorm", "protect", "signalbeam", "toxic"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	wormadamsandy: {
 		randomBattleMoves: ["earthquake", "protect", "rockblast", "stealthrock", "toxic"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	wormadamtrash: {
 		randomBattleMoves: ["ironhead", "protect", "stealthrock", "toxic"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	mothim: {
 		randomBattleMoves: ["airslash", "bugbuzz", "hiddenpowerground", "quiverdance", "substitute"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1850,11 +2095,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vespiquen: {
 		randomBattleMoves: ["attackorder", "protect", "roost", "substitute", "toxic"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	pachirisu: {
 		randomBattleMoves: ["protect", "superfang", "thunderwave", "toxic", "voltswitch"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1863,6 +2110,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	floatzel: {
 		randomBattleMoves: ["aquajet", "bulkup", "crunch", "icepunch", "switcheroo", "taunt", "waterfall"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -1871,6 +2119,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cherrim: {
 		randomBattleMoves: ["energyball", "healingwish", "hiddenpowerrock", "hiddenpowerfire", "naturepower"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1880,6 +2129,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gastrodon: {
 		randomBattleMoves: ["earthquake", "icebeam", "recover", "scald", "toxic"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
@@ -1888,6 +2138,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	drifblim: {
 		randomBattleMoves: ["acrobatics", "destinybond", "disable", "shadowball", "substitute", "willowisp"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -1896,6 +2147,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lopunny: {
 		randomBattleMoves: ["firepunch", "healingwish", "icepunch", "jumpkick", "return", "switcheroo", "thunderpunch"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1904,6 +2156,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	purugly: {
 		randomBattleMoves: ["fakeout", "hypnosis", "return", "suckerpunch", "uturn"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -1912,6 +2165,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	skuntank: {
 		randomBattleMoves: ["crunch", "fireblast", "poisonjab", "pursuit", "suckerpunch", "taunt"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -1921,16 +2175,19 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	bronzong: {
 		randomBattleMoves: ["earthquake", "hypnosis", "psychic", "stealthrock", "toxic"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DOU",
 	},
 	chatot: {
 		randomBattleMoves: ["chatter", "heatwave", "hiddenpowerground", "hypervoice", "nastyplot", "substitute", "uturn"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	spiritomb: {
 		randomBattleMoves: ["calmmind", "darkpulse", "foulplay", "rest", "shadowsneak", "sleeptalk", "willowisp"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -1943,6 +2200,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	garchomp: {
 		randomBattleMoves: ["aquatail", "earthquake", "fireblast", "outrage", "stealthrock", "stoneedge", "swordsdance"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
@@ -1952,6 +2210,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lucario: {
 		randomBattleMoves: ["closecombat", "crunch", "extremespeed", "icepunch", "swordsdance"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 		doublesTier: "DOU",
 	},
@@ -1960,6 +2219,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hippowdon: {
 		randomBattleMoves: ["earthquake", "slackoff", "stealthrock", "stoneedge", "toxic", "whirlwind"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 		doublesTier: "DUU",
 	},
@@ -1968,6 +2228,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	drapion: {
 		randomBattleMoves: ["aquatail", "crunch", "earthquake", "poisonjab", "pursuit", "swordsdance", "taunt", "toxicspikes"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -1976,11 +2237,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	toxicroak: {
 		randomBattleMoves: ["drainpunch", "icepunch", "poisonjab", "substitute", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	carnivine: {
 		randomBattleMoves: ["leechseed", "powerwhip", "return", "sleeppowder", "substitute", "swordsdance"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1989,6 +2252,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lumineon: {
 		randomBattleMoves: ["icebeam", "protect", "scald", "toxic", "uturn"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -1997,169 +2261,209 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	abomasnow: {
 		randomBattleMoves: ["blizzard", "earthquake", "hiddenpowerfire", "iceshard", "leechseed", "woodhammer"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DOU",
 	},
 	rotom: {
 		randomBattleMoves: ["hiddenpowerice", "painsplit", "shadowball", "substitute", "thunderbolt", "trick", "voltswitch", "willowisp"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	rotomheat: {
 		randomBattleMoves: ["hiddenpowergrass", "overheat", "painsplit", "thunderbolt", "thunderwave", "trick", "voltswitch", "willowisp"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	rotomwash: {
 		randomBattleMoves: ["hiddenpowerice", "hydropump", "painsplit", "thunderbolt", "thunderwave", "trick", "voltswitch", "willowisp"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	rotomfrost: {
 		randomBattleMoves: ["blizzard", "hiddenpowerfire", "painsplit", "substitute", "thunderbolt", "trick", "voltswitch", "willowisp"],
+		randomBattleLevel: 88,
 		tier: "PUBL",
 		doublesTier: "DUU",
 	},
 	rotomfan: {
 		randomBattleMoves: ["airslash", "painsplit", "substitute", "thunderbolt", "trick", "voltswitch", "willowisp"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
 	rotommow: {
 		randomBattleMoves: ["hiddenpowerfire", "leafstorm", "painsplit", "thunderbolt", "thunderwave", "trick", "voltswitch", "willowisp"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	uxie: {
 		randomBattleMoves: ["healbell", "lightscreen", "memento", "psychic", "reflect", "stealthrock", "thunderwave", "uturn", "yawn"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	mesprit: {
 		randomBattleMoves: ["calmmind", "hiddenpowerfire", "icebeam", "psychic", "stealthrock", "thunderbolt", "trick", "uturn"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	azelf: {
 		randomBattleMoves: ["energyball", "fireblast", "nastyplot", "psychic", "stealthrock", "taunt", "trick", "uturn"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	dialga: {
 		randomBattleMoves: ["aurasphere", "dracometeor", "dragontail", "fireblast", "stealthrock", "thunderbolt"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	palkia: {
 		randomBattleMoves: ["dracometeor", "dragontail", "fireblast", "hydropump", "spacialrend", "surf", "thunderbolt"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	heatran: {
 		randomBattleMoves: ["earthpower", "fireblast", "flashcannon", "hiddenpowerice", "lavaplume", "protect", "roar", "stealthrock", "toxic"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	regigigas: {
 		randomBattleMoves: ["confuseray", "return", "rockslide", "substitute", "thunderwave"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	giratina: {
 		randomBattleMoves: ["calmmind", "dragonpulse", "dragontail", "rest", "sleeptalk", "willowisp"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	giratinaorigin: {
 		randomBattleMoves: ["dracometeor", "earthquake", "hiddenpowerfire", "shadowsneak", "willowisp"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	cresselia: {
 		randomBattleMoves: ["calmmind", "hiddenpowerfighting", "moonlight", "psychic", "thunderwave", "toxic"],
+		randomBattleLevel: 84,
 		tier: "RUBL",
 		doublesTier: "DOU",
 	},
 	phione: {
 		randomBattleMoves: ["healbell", "icebeam", "scald", "toxic", "uturn"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	manaphy: {
 		randomBattleMoves: ["energyball", "icebeam", "surf", "tailglow"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUU",
 	},
 	darkrai: {
 		randomBattleMoves: ["darkpulse", "darkvoid", "focusblast", "nastyplot", "substitute"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUU",
 	},
 	shaymin: {
 		randomBattleMoves: ["earthpower", "hiddenpowerfire", "leechseed", "psychic", "rest", "seedflare"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	shayminsky: {
 		randomBattleMoves: ["airslash", "earthpower", "hiddenpowerfire", "hiddenpowerice", "leechseed", "seedflare", "substitute"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DOU",
 	},
 	arceus: {
 		randomBattleMoves: ["earthquake", "extremespeed", "recover", "shadowclaw", "swordsdance"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	arceusbug: {
 		randomBattleMoves: ["earthquake", "recover", "stoneedge", "swordsdance", "xscissor"],
+		randomBattleLevel: 76,
 	},
 	arceusdark: {
 		randomBattleMoves: ["calmmind", "judgment", "recover", "refresh"],
+		randomBattleLevel: 76,
 	},
 	arceusdragon: {
 		randomBattleMoves: ["earthquake", "extremespeed", "outrage", "recover", "swordsdance"],
+		randomBattleLevel: 76,
 	},
 	arceuselectric: {
 		randomBattleMoves: ["calmmind", "icebeam", "judgment", "recover"],
+		randomBattleLevel: 76,
 	},
 	arceusfighting: {
 		randomBattleMoves: ["calmmind", "darkpulse", "icebeam", "judgment", "recover"],
+		randomBattleLevel: 76,
 	},
 	arceusfire: {
 		randomBattleMoves: ["calmmind", "fireblast", "judgment", "recover", "thunderbolt"],
+		randomBattleLevel: 76,
 	},
 	arceusflying: {
 		randomBattleMoves: ["calmmind", "earthpower", "judgment", "recover", "substitute"],
+		randomBattleLevel: 76,
 	},
 	arceusghost: {
 		randomBattleMoves: ["calmmind", "focusblast", "judgment", "recover", "roar", "willowisp"],
+		randomBattleLevel: 76,
 	},
 	arceusgrass: {
 		randomBattleMoves: ["calmmind", "earthpower", "icebeam", "judgment", "recover", "thunderwave"],
+		randomBattleLevel: 76,
 	},
 	arceusground: {
 		randomBattleMoves: ["calmmind", "icebeam", "judgment", "recover", "willowisp"],
+		randomBattleLevel: 76,
 	},
 	arceusice: {
 		randomBattleMoves: ["calmmind", "fireblast", "icebeam", "recover", "thunderbolt"],
+		randomBattleLevel: 76,
 	},
 	arceuspoison: {
 		randomBattleMoves: ["flamethrower", "icebeam", "recover", "sludgebomb", "stealthrock", "willowisp"],
+		randomBattleLevel: 76,
 	},
 	arceuspsychic: {
 		randomBattleMoves: ["calmmind", "darkpulse", "focusblast", "judgment", "recover"],
+		randomBattleLevel: 76,
 	},
 	arceusrock: {
 		randomBattleMoves: ["earthquake", "recover", "stoneedge", "swordsdance"],
+		randomBattleLevel: 76,
 	},
 	arceussteel: {
 		randomBattleMoves: ["calmmind", "judgment", "recover", "thunderbolt", "willowisp"],
+		randomBattleLevel: 76,
 	},
 	arceuswater: {
 		randomBattleMoves: ["brickbreak", "extremespeed", "recover", "swordsdance", "waterfall"],
+		randomBattleLevel: 76,
 	},
 	victini: {
 		randomBattleMoves: ["blueflare", "boltstrike", "energyball", "focusblast", "glaciate", "trick", "uturn", "vcreate"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DOU",
 	},
@@ -2171,6 +2475,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	serperior: {
 		randomBattleMoves: ["calmmind", "dragonpulse", "gigadrain", "hiddenpowerfire", "leechseed", "substitute"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -2182,6 +2487,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	emboar: {
 		randomBattleMoves: ["earthquake", "fireblast", "flareblitz", "grassknot", "headsmash", "superpower", "wildcharge"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -2193,6 +2499,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	samurott: {
 		randomBattleMoves: ["aquajet", "grassknot", "icebeam", "megahorn", "superpower", "swordsdance", "waterfall"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -2201,6 +2508,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	watchog: {
 		randomBattleMoves: ["crunch", "hypnosis", "return", "substitute", "superfang", "swordsdance"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -2212,6 +2520,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	stoutland: {
 		randomBattleMoves: ["crunch", "return", "superpower", "thunderwave", "wildcharge"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -2220,6 +2529,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	liepard: {
 		randomBattleMoves: ["darkpulse", "encore", "hiddenpowerfire", "nastyplot", "thunderwave"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -2228,6 +2538,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	simisage: {
 		randomBattleMoves: ["focusblast", "gigadrain", "hiddenpowerrock", "leechseed", "nastyplot", "substitute"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -2236,6 +2547,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	simisear: {
 		randomBattleMoves: ["fireblast", "focusblast", "grassknot", "hiddenpowerrock", "nastyplot", "substitute"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -2244,6 +2556,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	simipour: {
 		randomBattleMoves: ["focusblast", "hiddenpowergrass", "hydropump", "icebeam", "nastyplot", "substitute"],
+		randomBattleLevel: 88,
 		tier: "PUBL",
 		doublesTier: "DUU",
 	},
@@ -2252,6 +2565,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	musharna: {
 		randomBattleMoves: ["calmmind", "healbell", "hiddenpowerground", "moonlight", "psychic", "signalbeam", "toxic", "trickroom"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -2263,6 +2577,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	unfezant: {
 		randomBattleMoves: ["hypnosis", "pluck", "return", "roost", "tailwind", "uturn"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -2271,6 +2586,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	zebstrika: {
 		randomBattleMoves: ["hiddenpowergrass", "overheat", "thunderbolt", "voltswitch", "wildcharge"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -2282,6 +2598,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gigalith: {
 		randomBattleMoves: ["earthquake", "explosion", "rockblast", "stealthrock", "stoneedge", "superpower"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -2290,6 +2607,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swoobat: {
 		randomBattleMoves: ["airslash", "calmmind", "heatwave", "roost", "storedpower"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -2298,11 +2616,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	excadrill: {
 		randomBattleMoves: ["earthquake", "ironhead", "rapidspin", "rockslide", "swordsdance"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	audino: {
 		randomBattleMoves: ["doubleedge", "healbell", "magiccoat", "protect", "toxic", "wish"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -2315,6 +2635,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	conkeldurr: {
 		randomBattleMoves: ["bulkup", "drainpunch", "icepunch", "machpunch", "thunderpunch"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
@@ -2326,16 +2647,19 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	seismitoad: {
 		randomBattleMoves: ["earthquake", "hydropump", "raindance", "sludgebomb", "stealthrock", "toxic"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
 	throh: {
 		randomBattleMoves: ["bulkup", "icepunch", "payback", "rest", "sleeptalk", "stormthrow"],
+		randomBattleLevel: 88,
 		tier: "PUBL",
 		doublesTier: "DUU",
 	},
 	sawk: {
 		randomBattleMoves: ["bulkup", "closecombat", "earthquake", "icepunch", "stoneedge"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -2347,6 +2671,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	leavanny: {
 		randomBattleMoves: ["leafblade", "swordsdance", "synthesis", "xscissor"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -2358,6 +2683,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	scolipede: {
 		randomBattleMoves: ["aquatail", "earthquake", "megahorn", "rockslide", "spikes", "swordsdance"],
+		randomBattleLevel: 86,
 		tier: "NUBL",
 		doublesTier: "DUU",
 	},
@@ -2366,6 +2692,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	whimsicott: {
 		randomBattleMoves: ["encore", "gigadrain", "leechseed", "stunspore", "taunt", "uturn"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DOU",
 	},
@@ -2374,16 +2701,19 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lilligant: {
 		randomBattleMoves: ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "petaldance", "quiverdance", "sleeppowder"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	basculin: {
 		randomBattleMoves: ["aquajet", "crunch", "superpower", "waterfall", "zenheadbutt"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
 	basculinbluestriped: {
 		randomBattleMoves: ["aquajet", "crunch", "superpower", "waterfall", "zenheadbutt"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -2396,6 +2726,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	krookodile: {
 		randomBattleMoves: ["crunch", "earthquake", "pursuit", "stealthrock", "stoneedge", "superpower"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -2404,11 +2735,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	darmanitan: {
 		randomBattleMoves: ["earthquake", "flareblitz", "rockslide", "superpower", "uturn"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	maractus: {
 		randomBattleMoves: ["gigadrain", "hiddenpowerfire", "leechseed", "spikes", "toxic"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -2418,6 +2751,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	crustle: {
 		randomBattleMoves: ["earthquake", "rockblast", "shellsmash", "spikes", "stealthrock", "stoneedge", "xscissor"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -2427,11 +2761,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	scrafty: {
 		randomBattleMoves: ["crunch", "dragondance", "highjumpkick", "icepunch", "zenheadbutt"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	sigilyph: {
 		randomBattleMoves: ["cosmicpower", "psychoshift", "roost", "storedpower"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -2440,6 +2776,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cofagrigus: {
 		randomBattleMoves: ["haze", "hiddenpowerfighting", "nastyplot", "painsplit", "shadowball", "trickroom", "willowisp"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -2448,6 +2785,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	carracosta: {
 		randomBattleMoves: ["aquajet", "earthquake", "icebeam", "shellsmash", "stealthrock", "stoneedge", "waterfall"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -2456,6 +2794,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	archeops: {
 		randomBattleMoves: ["acrobatics", "earthquake", "headsmash", "pluck", "roost", "stoneedge", "uturn"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -2464,6 +2803,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	garbodor: {
 		randomBattleMoves: ["drainpunch", "gunkshot", "haze", "painsplit", "spikes", "toxicspikes"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -2472,6 +2812,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	zoroark: {
 		randomBattleMoves: ["darkpulse", "flamethrower", "focusblast", "nastyplot", "uturn"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
@@ -2480,6 +2821,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cinccino: {
 		randomBattleMoves: ["bulletseed", "rockblast", "tailslap", "uturn"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -2492,6 +2834,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gothitelle: {
 		randomBattleMoves: ["calmmind", "hiddenpowerfighting", "psychic", "rest", "thunderbolt", "trick"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 		doublesTier: "DUU",
 	},
@@ -2504,6 +2847,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	reuniclus: {
 		randomBattleMoves: ["calmmind", "focusblast", "psychic", "recover", "shadowball", "trickroom"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
@@ -2512,6 +2856,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swanna: {
 		randomBattleMoves: ["hurricane", "icebeam", "raindance", "roost", "surf"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -2523,6 +2868,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vanilluxe: {
 		randomBattleMoves: ["autotomize", "explosion", "flashcannon", "hiddenpowerground", "icebeam"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -2531,11 +2877,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sawsbuck: {
 		randomBattleMoves: ["doubleedge", "hornleech", "megahorn", "naturepower", "return", "substitute", "swordsdance"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
 	emolga: {
 		randomBattleMoves: ["acrobatics", "encore", "roost", "thunderbolt", "toxic", "uturn"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
@@ -2544,6 +2892,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	escavalier: {
 		randomBattleMoves: ["ironhead", "megahorn", "pursuit", "return", "swordsdance"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -2552,6 +2901,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	amoonguss: {
 		randomBattleMoves: ["clearsmog", "gigadrain", "hiddenpowerfire", "spore", "stunspore", "synthesis"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DOU",
 	},
@@ -2560,11 +2910,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	jellicent: {
 		randomBattleMoves: ["icebeam", "recover", "scald", "shadowball", "toxic", "willowisp"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	alomomola: {
 		randomBattleMoves: ["protect", "scald", "toxic", "waterfall", "wish"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -2573,6 +2925,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	galvantula: {
 		randomBattleMoves: ["bugbuzz", "gigadrain", "hiddenpowerice", "thunder", "voltswitch"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -2582,6 +2935,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ferrothorn: {
 		randomBattleMoves: ["gyroball", "leechseed", "powerwhip", "protect", "spikes", "stealthrock", "toxic"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
@@ -2594,6 +2948,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	klinklang: {
 		randomBattleMoves: ["geargrind", "return", "shiftgear", "substitute", "wildcharge"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -2605,6 +2960,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	eelektross: {
 		randomBattleMoves: ["flamethrower", "gigadrain", "hiddenpowerice", "superpower", "thunderbolt", "uturn"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -2613,6 +2969,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	beheeyem: {
 		randomBattleMoves: ["hiddenpowerfighting", "psychic", "thunderbolt", "trick", "trickroom"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -2624,6 +2981,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	chandelure: {
 		randomBattleMoves: ["calmmind", "energyball", "fireblast", "hiddenpowerfighting", "shadowball", "substitute"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 		doublesTier: "DOU",
 	},
@@ -2636,6 +2994,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	haxorus: {
 		randomBattleMoves: ["aquatail", "dragondance", "earthquake", "outrage", "superpower", "swordsdance"],
+		randomBattleLevel: 82,
 		tier: "(OU)",
 		doublesTier: "DUU",
 	},
@@ -2644,11 +3003,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	beartic: {
 		randomBattleMoves: ["aquajet", "iciclecrash", "stoneedge", "superpower", "swordsdance"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	cryogonal: {
 		randomBattleMoves: ["hiddenpowerfire", "icebeam", "rapidspin", "recover", "toxic"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -2657,11 +3018,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	accelgor: {
 		randomBattleMoves: ["bugbuzz", "encore", "focusblast", "gigadrain", "hiddenpowerrock", "spikes", "yawn"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	stunfisk: {
 		randomBattleMoves: ["discharge", "earthpower", "foulplay", "rest", "scald", "sleeptalk", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		tier: "PU",
 		doublesTier: "DUU",
 	},
@@ -2670,11 +3033,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mienshao: {
 		randomBattleMoves: ["highjumpkick", "stoneedge", "substitute", "swordsdance", "uturn"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	druddigon: {
 		randomBattleMoves: ["dragontail", "earthquake", "glare", "outrage", "stealthrock", "suckerpunch", "superpower"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -2683,6 +3048,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	golurk: {
 		randomBattleMoves: ["drainpunch", "earthquake", "icepunch", "rockpolish", "shadowpunch", "stealthrock"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -2691,11 +3057,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	bisharp: {
 		randomBattleMoves: ["ironhead", "lowkick", "nightslash", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	bouffalant: {
 		randomBattleMoves: ["earthquake", "headcharge", "megahorn", "stoneedge", "swordsdance"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -2704,6 +3072,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	braviary: {
 		randomBattleMoves: ["bravebird", "bulkup", "return", "roost", "superpower", "uturn"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
@@ -2712,16 +3081,19 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mandibuzz: {
 		randomBattleMoves: ["bravebird", "foulplay", "roost", "taunt", "toxic", "whirlwind"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "DUU",
 	},
 	heatmor: {
 		randomBattleMoves: ["fireblast", "gigadrain", "suckerpunch", "superpower"],
+		randomBattleLevel: 90,
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	durant: {
 		randomBattleMoves: ["honeclaws", "ironhead", "rockslide", "superpower", "xscissor"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "DUU",
 	},
@@ -2734,6 +3106,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hydreigon: {
 		randomBattleMoves: ["darkpulse", "dracometeor", "flamethrower", "focusblast", "roost", "uturn"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
@@ -2742,81 +3115,97 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	volcarona: {
 		randomBattleMoves: ["bugbuzz", "fierydance", "fireblast", "gigadrain", "hiddenpowerground", "quiverdance", "roost"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	cobalion: {
 		randomBattleMoves: ["closecombat", "hiddenpowerice", "ironhead", "stealthrock", "stoneedge", "swordsdance", "taunt", "thunderwave", "voltswitch"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	terrakion: {
 		randomBattleMoves: ["closecombat", "earthquake", "quickattack", "stealthrock", "stoneedge", "swordsdance"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	virizion: {
 		randomBattleMoves: ["closecombat", "leafblade", "stoneedge", "swordsdance"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	tornadus: {
 		randomBattleMoves: ["acrobatics", "bulkup", "focusblast", "heatwave", "hurricane", "superpower", "taunt", "uturn"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	tornadustherian: {
 		randomBattleMoves: ["focusblast", "heatwave", "hurricane", "superpower", "uturn"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUU",
 	},
 	thundurus: {
 		randomBattleMoves: ["focusblast", "hiddenpowerice", "nastyplot", "thunderbolt", "thunderwave", "voltswitch"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DOU",
 	},
 	thundurustherian: {
 		randomBattleMoves: ["agility", "focusblast", "grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	reshiram: {
 		randomBattleMoves: ["blueflare", "dracometeor", "roost", "stoneedge", "tailwind"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	zekrom: {
 		randomBattleMoves: ["boltstrike", "dracometeor", "focusblast", "honeclaws", "outrage", "roost", "substitute", "voltswitch"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	landorus: {
 		randomBattleMoves: ["earthpower", "focusblast", "psychic", "rockpolish", "rockslide", "sludgewave"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUU",
 	},
 	landorustherian: {
 		randomBattleMoves: ["earthquake", "rockpolish", "stealthrock", "stoneedge", "superpower", "swordsdance", "uturn"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	kyurem: {
 		randomBattleMoves: ["dracometeor", "earthpower", "focusblast", "icebeam", "outrage", "roost", "substitute"],
+		randomBattleLevel: 82,
 		tier: "UUBL",
 		doublesTier: "DUU",
 	},
 	kyuremblack: {
 		randomBattleMoves: ["dragonclaw", "earthpower", "fusionbolt", "icebeam", "roost", "substitute"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	kyuremwhite: {
 		randomBattleMoves: ["dracometeor", "earthpower", "focusblast", "fusionflare", "icebeam", "roost", "substitute"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	keldeo: {
 		randomBattleMoves: ["calmmind", "hiddenpowergrass", "hydropump", "icywind", "scald", "secretsword", "substitute"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DUU",
 	},
@@ -2826,14 +3215,17 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	meloetta: {
 		randomBattleMoves: ["calmmind", "focusblast", "psychic", "shadowball", "uturn"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	meloettapirouette: {
 		randomBattleMoves: ["closecombat", "icepunch", "relicsong", "return", "shadowclaw"],
+		randomBattleLevel: 82,
 	},
 	genesect: {
 		randomBattleMoves: ["bugbuzz", "flamethrower", "icebeam", "ironhead", "rockpolish", "thunderbolt", "uturn"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DOU",
 	},

--- a/data/mods/gen5/formats-data.ts
+++ b/data/mods/gen5/formats-data.ts
@@ -2812,7 +2812,6 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	zoroark: {
 		randomBattleMoves: ["darkpulse", "flamethrower", "focusblast", "nastyplot", "uturn"],
-		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "DUU",
 	},

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -766,7 +766,11 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		const customScale: {[forme: string]: number} = {
 			'Castform-Rainy': 100, 'Castform-Sunny': 100, Delibird: 100, 'Farfetch\u2019d': 100, Luvdisc: 100, Unown: 100,
 		};
-		const level = this.adjustLevel || species.randomBattleLevel || customScale[species.name] || levelScale[species.tier] || (species.nfe ? 90 : 80);
+		const level = this.adjustLevel ||
+					  species.randomBattleLevel ||
+					  customScale[species.name] ||
+					  levelScale[species.tier] ||
+					  (species.nfe ? 90 : 80);
 
 		// Prepare optimal HP
 		const srWeakness = this.dex.getEffectiveness('Rock', species);

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -748,29 +748,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			item = 'Black Sludge';
 		}
 
-		const levelScale: {[tier: string]: number} = {
-			Uber: 76,
-			OU: 80,
-			'(OU)': 82,
-			UUBL: 82,
-			UU: 82,
-			RUBL: 84,
-			RU: 84,
-			NUBL: 86,
-			NU: 86,
-			'(NU)': 88,
-			PUBL: 88,
-			PU: 88,
-			'(PU)': 90,
-		};
-		const customScale: {[forme: string]: number} = {
-			'Castform-Rainy': 100, 'Castform-Sunny': 100, Delibird: 100, 'Farfetch\u2019d': 100, Luvdisc: 100, Unown: 100,
-		};
-		const level = this.adjustLevel ||
-					  species.randomBattleLevel ||
-					  customScale[species.name] ||
-					  levelScale[species.tier] ||
-					  (species.nfe ? 90 : 80);
+		const level = this.adjustLevel || species.randomBattleLevel || (species.nfe ? 90 : 80);
 
 		// Prepare optimal HP
 		const srWeakness = this.dex.getEffectiveness('Rock', species);

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -766,7 +766,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		const customScale: {[forme: string]: number} = {
 			'Castform-Rainy': 100, 'Castform-Sunny': 100, Delibird: 100, 'Farfetch\u2019d': 100, Luvdisc: 100, Unown: 100,
 		};
-		const level = this.adjustLevel || customScale[species.name] || levelScale[species.tier] || (species.nfe ? 90 : 80);
+		const level = this.adjustLevel || species.randomBattleLevel || customScale[species.name] || levelScale[species.tier] || (species.nfe ? 90 : 80);
 
 		// Prepare optimal HP
 		const srWeakness = this.dex.getEffectiveness('Rock', species);

--- a/data/mods/gen6/formats-data.ts
+++ b/data/mods/gen6/formats-data.ts
@@ -7,12 +7,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	venusaur: {
 		randomBattleMoves: ["gigadrain", "leechseed", "sleeppowder", "sludgebomb", "substitute"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "powerwhip", "protect", "sleeppowder", "sludgebomb"],
 		tier: "RU",
 		doublesTier: "DOU",
 	},
 	venusaurmega: {
 		randomBattleMoves: ["earthquake", "gigadrain", "hiddenpowerfire", "leechseed", "sludgebomb", "synthesis"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "powerwhip", "protect", "sleeppowder", "sludgebomb"],
 		tier: "OU",
 		doublesTier: "DOU",
@@ -25,18 +27,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	charizard: {
 		randomBattleMoves: ["airslash", "earthquake", "fireblast", "roost", "willowisp"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["airslash", "dragonpulse", "fireblast", "heatwave", "overheat", "protect", "roost", "tailwind"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	charizardmegax: {
 		randomBattleMoves: ["dragonclaw", "dragondance", "earthquake", "flareblitz", "roost", "willowisp"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dragonclaw", "dragondance", "earthquake", "flareblitz", "rockslide", "roost", "substitute"],
 		tier: "OU",
 		doublesTier: "(DUU)",
 	},
 	charizardmegay: {
 		randomBattleMoves: ["airslash", "dragonpulse", "fireblast", "focusblast", "roost", "solarbeam"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["airslash", "fireblast", "focusblast", "heatwave", "protect", "roost", "solarbeam"],
 		tier: "OU",
 		doublesTier: "DOU",
@@ -49,12 +54,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	blastoise: {
 		randomBattleMoves: ["dragontail", "icebeam", "rapidspin", "roar", "scald", "toxic"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["fakeout", "followme", "hydropump", "icebeam", "icywind", "muddywater", "protect", "scald", "waterspout"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	blastoisemega: {
 		randomBattleMoves: ["aurasphere", "darkpulse", "hydropump", "icebeam", "rapidspin", "scald"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["aurasphere", "darkpulse", "fakeout", "followme", "hydropump", "icebeam", "icywind", "muddywater", "protect", "scald"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -67,6 +74,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	butterfree: {
 		randomBattleMoves: ["bugbuzz", "energyball", "psychic", "quiverdance", "sleeppowder"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bugbuzz", "protect", "psychic", "quiverdance", "shadowball", "sleeppowder", "substitute"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -79,12 +87,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	beedrill: {
 		randomBattleMoves: ["endeavor", "knockoff", "poisonjab", "tailwind", "toxicspikes", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["brickbreak", "drillrun", "knockoff", "poisonjab", "protect", "stringshot", "uturn", "xscissor"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	beedrillmega: {
 		randomBattleMoves: ["drillrun", "knockoff", "poisonjab", "swordsdance", "uturn", "xscissor"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["drillrun", "knockoff", "poisonjab", "protect", "substitute", "uturn", "xscissor"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -97,12 +107,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	pidgeot: {
 		randomBattleMoves: ["bravebird", "defog", "heatwave", "return", "roost", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bravebird", "doubleedge", "heatwave", "protect", "return", "tailwind", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	pidgeotmega: {
 		randomBattleMoves: ["defog", "heatwave", "hurricane", "roost", "uturn"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["heatwave", "hurricane", "protect", "tailwind", "uturn"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
@@ -112,6 +124,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	raticate: {
 		randomBattleMoves: ["facade", "flamewheel", "protect", "suckerpunch", "swordsdance", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["crunch", "facade", "flamewheel", "protect", "suckerpunch", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -121,6 +134,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	fearow: {
 		randomBattleMoves: ["doubleedge", "drillpeck", "drillrun", "pursuit", "return", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["doubleedge", "drillpeck", "drillrun", "protect", "quickattack", "return", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -130,6 +144,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	arbok: {
 		randomBattleMoves: ["aquatail", "coil", "earthquake", "gunkshot", "rest", "suckerpunch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aquatail", "crunch", "earthquake", "gunkshot", "protect", "rest", "rockslide", "suckerpunch"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -139,6 +154,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	pikachu: {
 		randomBattleMoves: ["extremespeed", "grassknot", "hiddenpowerice", "knockoff", "voltswitch", "volttackle"],
+		randomBattleLevel: 90,
 		randomDoubleBattleMoves: ["brickbreak", "discharge", "encore", "extremespeed", "fakeout", "grassknot", "hiddenpowerice", "knockoff", "protect", "substitute", "thunderbolt", "voltswitch", "volttackle"],
 		tier: "NFE",
 	},
@@ -168,6 +184,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	raichu: {
 		randomBattleMoves: ["encore", "focusblast", "grassknot", "hiddenpowerice", "nastyplot", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["encore", "extremespeed", "fakeout", "focusblast", "grassknot", "hiddenpowerice", "knockoff", "protect", "substitute", "thunderbolt"],
 		tier: "PU",
 		doublesTier: "DOU",
@@ -177,6 +194,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sandslash: {
 		randomBattleMoves: ["earthquake", "knockoff", "rapidspin", "stealthrock", "stoneedge", "swordsdance", "toxic"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["earthquake", "knockoff", "protect", "rockslide", "stoneedge", "swordsdance", "xscissor"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -189,6 +207,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	nidoqueen: {
 		randomBattleMoves: ["earthpower", "fireblast", "icebeam", "sludgewave", "stealthrock", "toxicspikes"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthpower", "fireblast", "icebeam", "protect", "sludgebomb"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -201,6 +220,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	nidoking: {
 		randomBattleMoves: ["earthpower", "fireblast", "icebeam", "sludgewave", "substitute", "superpower"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthpower", "fireblast", "focusblast", "icebeam", "protect", "sludgebomb", "thunderbolt"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -214,6 +234,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	clefable: {
 		randomBattleMoves: ["calmmind", "fireblast", "moonblast", "softboiled", "stealthrock", "thunderwave"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dazzlinggleam", "fireblast", "followme", "lightscreen", "moonblast", "protect", "reflect", "safeguard", "softboiled", "thunderwave"],
 		tier: "OU",
 		doublesTier: "DUU",
@@ -223,6 +244,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ninetales: {
 		randomBattleMoves: ["fireblast", "hiddenpowerice", "nastyplot", "solarbeam", "substitute", "willowisp"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["fireblast", "heatwave", "protect", "solarbeam", "substitute", "willowisp"],
 		tier: "PU",
 		doublesTier: "DUU",
@@ -235,6 +257,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wigglytuff: {
 		randomBattleMoves: ["dazzlinggleam", "fireblast", "healbell", "lightscreen", "reflect", "stealthrock"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["dazzlinggleam", "fireblast", "hypervoice", "icebeam", "knockoff", "lightscreen", "protect", "reflect", "thunderwave"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -248,6 +271,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	crobat: {
 		randomBattleMoves: ["bravebird", "defog", "roost", "superfang", "taunt", "toxic", "uturn"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["bravebird", "crosspoison", "protect", "superfang", "tailwind", "taunt", "uturn"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -260,12 +284,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vileplume: {
 		randomBattleMoves: ["aromatherapy", "gigadrain", "hiddenpowerfire", "sleeppowder", "sludgebomb", "synthesis"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["dazzlinggleam", "gigadrain", "hiddenpowerfire", "moonblast", "protect", "sleeppowder", "sludgebomb", "stunspore"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	bellossom: {
 		randomBattleMoves: ["gigadrain", "hiddenpowerfire", "sleeppowder", "sunnyday", "synthesis"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["dazzlinggleam", "gigadrain", "hiddenpowerfire", "moonblast", "protect", "sleeppowder", "sludgebomb", "solarbeam", "stunspore", "sunnyday"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -275,6 +301,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	parasect: {
 		randomBattleMoves: ["knockoff", "leechseed", "seedbomb", "spore", "substitute", "xscissor"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["knockoff", "leechseed", "protect", "ragepowder", "seedbomb", "spore", "stunspore", "wideguard", "xscissor"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -284,6 +311,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	venomoth: {
 		randomBattleMoves: ["bugbuzz", "quiverdance", "sleeppowder", "sludgebomb", "substitute"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["bugbuzz", "gigadrain", "protect", "psychic", "quiverdance", "ragepowder", "roost", "sleeppowder", "sludgebomb", "substitute"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
@@ -293,6 +321,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dugtrio: {
 		randomBattleMoves: ["earthquake", "reversal", "stealthrock", "stoneedge", "substitute", "suckerpunch"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthquake", "protect", "rockslide", "stoneedge", "suckerpunch"],
 		tier: "(OU)",
 		doublesTier: "(DUU)",
@@ -302,6 +331,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	persian: {
 		randomBattleMoves: ["fakeout", "knockoff", "return", "taunt", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["fakeout", "feint", "hypnosis", "knockoff", "protect", "return", "taunt", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -311,6 +341,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	golduck: {
 		randomBattleMoves: ["calmmind", "encore", "hydropump", "icebeam", "psyshock", "scald", "substitute"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["encore", "focusblast", "hiddenpowergrass", "hydropump", "icebeam", "icywind", "protect", "psychic", "scald", "surf"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -320,6 +351,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	primeape: {
 		randomBattleMoves: ["closecombat", "earthquake", "encore", "gunkshot", "icepunch", "stoneedge", "uturn"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["closecombat", "earthquake", "icepunch", "poisonjab", "protect", "punishment", "rockslide", "stoneedge", "taunt", "uturn"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -329,6 +361,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	arcanine: {
 		randomBattleMoves: ["closecombat", "extremespeed", "flareblitz", "morningsun", "roar", "toxic", "wildcharge", "willowisp"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["closecombat", "extremespeed", "flareblitz", "protect", "snarl", "wildcharge", "willowisp"],
 		tier: "UU",
 		doublesTier: "DOU",
@@ -341,12 +374,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	poliwrath: {
 		randomBattleMoves: ["circlethrow", "focusblast", "hydropump", "icepunch", "raindance", "rest", "scald", "sleeptalk"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["bellydrum", "brickbreak", "earthquake", "encore", "icepunch", "protect", "rockslide", "waterfall"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	politoed: {
 		randomBattleMoves: ["encore", "icebeam", "protect", "rest", "scald", "toxic"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["encore", "focusblast", "helpinghand", "hiddenpowergrass", "hydropump", "hypnosis", "icebeam", "icywind", "protect", "scald"],
 		tier: "(PU)",
 		doublesTier: "DOU",
@@ -360,12 +395,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	alakazam: {
 		randomBattleMoves: ["focusblast", "hiddenpowerfire", "hiddenpowerice", "psychic", "psyshock", "shadowball"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["dazzlinggleam", "encore", "focusblast", "protect", "psychic", "psyshock", "shadowball", "substitute"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
 	},
 	alakazammega: {
 		randomBattleMoves: ["calmmind", "encore", "focusblast", "psychic", "psyshock", "shadowball", "substitute"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["dazzlinggleam", "encore", "focusblast", "protect", "psychic", "psyshock", "shadowball", "substitute"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
@@ -379,6 +416,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	machamp: {
 		randomBattleMoves: ["bulletpunch", "dynamicpunch", "heavyslam", "knockoff", "stoneedge", "substitute"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["bulletpunch", "dynamicpunch", "icepunch", "knockoff", "protect", "rockslide", "stoneedge", "wideguard"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -391,6 +429,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	victreebel: {
 		randomBattleMoves: ["knockoff", "powerwhip", "sleeppowder", "sludgebomb", "solarbeam", "suckerpunch", "sunnyday", "weatherball"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["growth", "knockoff", "powerwhip", "protect", "sleeppowder", "sludgebomb", "solarbeam", "suckerpunch", "sunnyday", "weatherball"],
 		tier: "PUBL",
 		doublesTier: "(DUU)",
@@ -400,6 +439,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	tentacruel: {
 		randomBattleMoves: ["acidspray", "knockoff", "rapidspin", "scald", "sludgebomb", "toxicspikes"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["acidspray", "dazzlinggleam", "gigadrain", "icebeam", "knockoff", "muddywater", "protect", "scald", "sludgebomb"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -412,6 +452,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	golem: {
 		randomBattleMoves: ["earthquake", "explosion", "stoneedge", "stealthrock", "suckerpunch", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "firepunch", "hammerarm", "protect", "rockslide", "stoneedge", "suckerpunch"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -421,6 +462,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	rapidash: {
 		randomBattleMoves: ["drillrun", "flareblitz", "morningsun", "wildcharge", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["drillrun", "flamecharge", "flareblitz", "hypnosis", "megahorn", "protect", "wildcharge", "willowisp"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -430,18 +472,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	slowbro: {
 		randomBattleMoves: ["fireblast", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["fireblast", "grassknot", "icebeam", "protect", "psychic", "psyshock", "scald", "slackoff", "thunderwave", "trickroom"],
 		tier: "OU",
 		doublesTier: "(DUU)",
 	},
 	slowbromega: {
 		randomBattleMoves: ["calmmind", "fireblast", "icebeam", "psyshock", "scald", "slackoff"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["fireblast", "grassknot", "icebeam", "protect", "psychic", "psyshock", "scald", "slackoff", "thunderwave", "trickroom"],
 		tier: "(OU)",
 		doublesTier: "(DUU)",
 	},
 	slowking: {
 		randomBattleMoves: ["dragontail", "fireblast", "icebeam", "nastyplot", "psychic", "psyshock", "scald", "slackoff", "thunderwave", "toxic", "trickroom"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["fireblast", "grassknot", "icebeam", "protect", "psychic", "psyshock", "scald", "slackoff", "thunderwave", "trickroom"],
 		tier: "RU",
 		doublesTier: "DUU",
@@ -455,12 +500,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	magnezone: {
 		randomBattleMoves: ["flashcannon", "hiddenpowerfire", "substitute", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["discharge", "electroweb", "flashcannon", "hiddenpowerfire", "hiddenpowerice", "protect", "substitute", "thunderbolt", "voltswitch"],
 		tier: "OU",
 		doublesTier: "(DUU)",
 	},
 	farfetchd: {
 		randomBattleMoves: ["bravebird", "knockoff", "leafblade", "return", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bravebird", "leafblade", "nightslash", "protect", "return", "swordsdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -470,6 +517,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dodrio: {
 		randomBattleMoves: ["bravebird", "doubleedge", "knockoff", "quickattack", "return", "roost"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bravebird", "doubleedge", "protect", "quickattack", "return"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -479,6 +527,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dewgong: {
 		randomBattleMoves: ["encore", "icebeam", "protect", "surf", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["encore", "fakeout", "icebeam", "perishsong", "protect", "surf", "toxic"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -488,6 +537,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	muk: {
 		randomBattleMoves: ["curse", "firepunch", "gunkshot", "icepunch", "memento", "poisonjab", "shadowsneak"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["brickbreak", "firepunch", "gunkshot", "icepunch", "poisonjab", "protect", "shadowsneak"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -497,6 +547,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cloyster: {
 		randomBattleMoves: ["hydropump", "iceshard", "iciclespear", "rapidspin", "rockblast", "shellsmash", "spikes"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["hydropump", "iciclespear", "protect", "razorshell", "rockblast", "shellsmash"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -510,12 +561,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gengar: {
 		randomBattleMoves: ["disable", "focusblast", "shadowball", "sludgewave", "substitute", "trick", "willowisp"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dazzlinggleam", "disable", "focusblast", "hypnosis", "protect", "shadowball", "sludgebomb", "substitute", "taunt", "willowisp"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	gengarmega: {
 		randomBattleMoves: ["destinybond", "disable", "focusblast", "perishsong", "protect", "shadowball", "sludgewave", "taunt"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["dazzlinggleam", "disable", "focusblast", "hypnosis", "protect", "shadowball", "sludgebomb", "substitute", "taunt", "willowisp"],
 		tier: "Uber",
 		doublesTier: "DOU",
@@ -525,12 +578,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	steelix: {
 		randomBattleMoves: ["earthquake", "ironhead", "roar", "rockslide", "stealthrock", "toxic"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["earthquake", "explosion", "ironhead", "protect", "rockslide", "stealthrock"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	steelixmega: {
 		randomBattleMoves: ["dragontail", "earthquake", "heavyslam", "roar", "stealthrock", "toxic"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["earthquake", "explosion", "heavyslam", "protect", "rockslide", "stealthrock"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
@@ -540,6 +595,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hypno: {
 		randomBattleMoves: ["foulplay", "protect", "psychic", "seismictoss", "thunderwave", "toxic", "wish"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["dazzlinggleam", "foulplay", "hypnosis", "protect", "psychic", "seismictoss", "thunderwave", "trickroom", "wish"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -549,6 +605,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kingler: {
 		randomBattleMoves: ["agility", "crabhammer", "knockoff", "rockslide", "superpower", "swordsdance", "xscissor"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["crabhammer", "knockoff", "protect", "rockslide", "substitute", "superpower", "wideguard", "xscissor"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -558,6 +615,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	electrode: {
 		randomBattleMoves: ["foulplay", "hiddenpowergrass", "hiddenpowerice", "signalbeam", "taunt", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["discharge", "foulplay", "hiddenpowerice", "protect", "taunt", "thunderwave", "voltswitch"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -567,6 +625,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	exeggutor: {
 		randomBattleMoves: ["gigadrain", "hiddenpowerfire", "leechseed", "psychic", "sleeppowder", "substitute"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["gigadrain", "hiddenpowerfire", "leechseed", "protect", "psychic", "psyshock", "sleeppowder", "substitute", "trickroom"],
 		tier: "PUBL",
 		doublesTier: "(DUU)",
@@ -576,6 +635,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	marowak: {
 		randomBattleMoves: ["bonemerang", "doubleedge", "earthquake", "knockoff", "stealthrock", "stoneedge", "substitute"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bonemerang", "doubleedge", "earthquake", "firepunch", "protect", "rockslide", "substitute", "swordsdance"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -585,18 +645,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hitmonlee: {
 		randomBattleMoves: ["fakeout", "highjumpkick", "knockoff", "machpunch", "poisonjab", "rapidspin", "stoneedge"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["blazekick", "earthquake", "fakeout", "highjumpkick", "knockoff", "machpunch", "protect", "rockslide", "wideguard"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	hitmonchan: {
 		randomBattleMoves: ["bulkup", "drainpunch", "firepunch", "icepunch", "machpunch", "rapidspin"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["drainpunch", "earthquake", "fakeout", "firepunch", "icepunch", "machpunch", "protect", "rockslide", "thunderpunch"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	hitmontop: {
 		randomBattleMoves: ["closecombat", "rapidspin", "stoneedge", "suckerpunch", "toxic"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["closecombat", "fakeout", "feint", "helpinghand", "machpunch", "suckerpunch", "wideguard"],
 		tier: "RU",
 		doublesTier: "DOU",
@@ -606,6 +669,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lickilicky: {
 		randomBattleMoves: ["bodyslam", "dragontail", "earthquake", "explosion", "healbell", "knockoff", "powerwhip", "protect", "swordsdance", "wish"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bodyslam", "dragontail", "earthquake", "explosion", "healbell", "knockoff", "powerwhip", "protect", "rockslide", "toxic", "wish"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -615,6 +679,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	weezing: {
 		randomBattleMoves: ["fireblast", "painsplit", "sludgebomb", "toxicspikes", "willowisp"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["explosion", "fireblast", "painsplit", "protect", "sludgebomb", "thunderbolt", "toxic", "willowisp"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -624,11 +689,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	rhydon: {
 		randomBattleMoves: ["earthquake", "megahorn", "stealthrock", "stoneedge", "toxic"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "NFE",
 	},
 	rhyperior: {
 		randomBattleMoves: ["dragontail", "earthquake", "icepunch", "megahorn", "rockpolish", "stoneedge"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["earthquake", "hammerarm", "megahorn", "protect", "rockslide", "stealthrock", "stoneedge"],
 		tier: "RU",
 		doublesTier: "DUU",
@@ -638,12 +705,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	chansey: {
 		randomBattleMoves: ["healbell", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic", "wish"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["aromatherapy", "helpinghand", "lightscreen", "protect", "seismictoss", "softboiled", "thunderwave", "toxic", "wish"],
 		tier: "OU",
 		doublesTier: "NFE",
 	},
 	blissey: {
 		randomBattleMoves: ["healbell", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["aromatherapy", "flamethrower", "helpinghand", "icebeam", "protect", "seismictoss", "softboiled", "thunderwave", "toxic", "wish"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -654,18 +723,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	tangrowth: {
 		randomBattleMoves: ["earthquake", "gigadrain", "hiddenpowerfire", "knockoff", "leafstorm", "rockslide", "sleeppowder", "synthesis"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["earthquake", "focusblast", "gigadrain", "hiddenpowerice", "knockoff", "leechseed", "powerwhip", "protect", "ragepowder", "sleeppowder"],
 		tier: "OU",
 		doublesTier: "(DUU)",
 	},
 	kangaskhan: {
 		randomBattleMoves: ["crunch", "drainpunch", "earthquake", "fakeout", "return", "suckerpunch"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["crunch", "doubleedge", "drainpunch", "earthquake", "fakeout", "protect", "return", "suckerpunch"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	kangaskhanmega: {
 		randomBattleMoves: ["crunch", "earthquake", "fakeout", "poweruppunch", "return", "seismictoss", "suckerpunch"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["crunch", "doubleedge", "drainpunch", "earthquake", "fakeout", "poweruppunch", "protect", "return", "suckerpunch"],
 		tier: "Uber",
 		doublesTier: "DOU",
@@ -678,6 +750,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kingdra: {
 		randomBattleMoves: ["dracometeor", "dragondance", "hydropump", "icebeam", "outrage", "raindance", "waterfall"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "focusenergy", "hydropump", "icebeam", "muddywater", "protect"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
@@ -687,6 +760,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	seaking: {
 		randomBattleMoves: ["drillrun", "icebeam", "knockoff", "megahorn", "raindance", "waterfall"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["drillrun", "icebeam", "icywind", "knockoff", "megahorn", "protect", "surf", "waterfall"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -696,6 +770,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	starmie: {
 		randomBattleMoves: ["hydropump", "icebeam", "psyshock", "rapidspin", "recover", "scald", "thunderbolt"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["hydropump", "icebeam", "protect", "psychic", "psyshock", "recover", "scald", "surf", "thunderbolt"],
 		tier: "OU",
 		doublesTier: "(DUU)",
@@ -705,24 +780,28 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mrmime: {
 		randomBattleMoves: ["dazzlinggleam", "encore", "focusblast", "healingwish", "nastyplot", "psyshock", "shadowball"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["dazzlinggleam", "encore", "fakeout", "hiddenpowerfighting", "icywind", "protect", "teeterdance", "thunderbolt", "thunderwave", "wideguard"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	scyther: {
 		randomBattleMoves: ["aerialace", "brickbreak", "bugbite", "knockoff", "quickattack", "roost", "swordsdance", "uturn"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["aerialace", "brickbreak", "bugbite", "feint", "knockoff", "protect", "quickattack", "swordsdance", "uturn"],
 		tier: "NU",
 		doublesTier: "NFE",
 	},
 	scizor: {
 		randomBattleMoves: ["bugbite", "bulletpunch", "defog", "knockoff", "pursuit", "roost", "superpower", "swordsdance", "uturn"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["bugbite", "bulletpunch", "feint", "knockoff", "protect", "roost", "superpower", "swordsdance", "uturn"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	scizormega: {
 		randomBattleMoves: ["bugbite", "bulletpunch", "defog", "knockoff", "roost", "superpower", "swordsdance", "uturn"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["bugbite", "bulletpunch", "feint", "knockoff", "protect", "roost", "superpower", "swordsdance", "uturn"],
 		tier: "OU",
 		doublesTier: "(DOU)",
@@ -732,6 +811,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	jynx: {
 		randomBattleMoves: ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psychic", "psyshock", "substitute", "trick"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["hiddenpowerfighting", "icebeam", "lovelykiss", "protect", "psychic", "psyshock", "shadowball", "substitute"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -744,6 +824,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	electivire: {
 		randomBattleMoves: ["crosschop", "earthquake", "flamethrower", "icepunch", "voltswitch", "wildcharge"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["crosschop", "earthquake", "flamethrower", "followme", "icepunch", "protect", "substitute", "wildcharge"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -756,24 +837,28 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	magmortar: {
 		randomBattleMoves: ["earthquake", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderbolt"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["fireblast", "focusblast", "followme", "heatwave", "hiddenpowergrass", "hiddenpowerice", "protect", "taunt", "thunderbolt", "willowisp"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	pinsir: {
 		randomBattleMoves: ["closecombat", "earthquake", "knockoff", "stealthrock", "stoneedge", "xscissor"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["closecombat", "earthquake", "protect", "rockslide", "substitute", "swordsdance", "xscissor"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	pinsirmega: {
 		randomBattleMoves: ["closecombat", "earthquake", "quickattack", "return", "swordsdance"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["closecombat", "earthquake", "feint", "protect", "quickattack", "return", "rockslide", "substitute", "swordsdance"],
 		tier: "OU",
 		doublesTier: "(DUU)",
 	},
 	tauros: {
 		randomBattleMoves: ["bodyslam", "doubleedge", "earthquake", "rockslide", "zenheadbutt"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["doubleedge", "earthquake", "protect", "return", "rockslide", "stoneedge", "zenheadbutt"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -783,24 +868,28 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gyarados: {
 		randomBattleMoves: ["bounce", "dragondance", "earthquake", "stoneedge", "substitute", "waterfall"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["bounce", "dragondance", "earthquake", "icefang", "protect", "stoneedge", "substitute", "taunt", "thunderwave", "waterfall"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	gyaradosmega: {
 		randomBattleMoves: ["crunch", "dragondance", "earthquake", "icefang", "substitute", "waterfall"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["bounce", "dragondance", "earthquake", "icefang", "protect", "stoneedge", "substitute", "taunt", "thunderwave", "waterfall"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
 	},
 	lapras: {
 		randomBattleMoves: ["freezedry", "healbell", "hydropump", "icebeam", "thunderbolt", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["healbell", "hydropump", "icebeam", "iceshard", "icywind", "protect", "substitute", "surf", "thunderbolt"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	ditto: {
 		randomBattleMoves: ["transform"],
+		randomBattleLevel: 88,
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
@@ -809,42 +898,49 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vaporeon: {
 		randomBattleMoves: ["healbell", "icebeam", "protect", "scald", "toxic", "wish"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["helpinghand", "hydropump", "icebeam", "muddywater", "protect", "scald", "toxic", "wish"],
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	jolteon: {
 		randomBattleMoves: ["hiddenpowerice", "shadowball", "signalbeam", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["helpinghand", "hiddenpowergrass", "hiddenpowerice", "protect", "signalbeam", "substitute", "thunderbolt", "voltswitch"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	flareon: {
 		randomBattleMoves: ["facade", "flamecharge", "flareblitz", "quickattack", "superpower"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["facade", "flamecharge", "flareblitz", "helpinghand", "protect", "superpower", "wish"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	espeon: {
 		randomBattleMoves: ["calmmind", "dazzlinggleam", "morningsun", "psychic", "psyshock", "shadowball", "substitute"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["dazzlinggleam", "helpinghand", "hiddenpowerfighting", "protect", "psychic", "psyshock", "shadowball", "substitute", "wish"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	umbreon: {
 		randomBattleMoves: ["foulplay", "healbell", "protect", "toxic", "wish"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["foulplay", "healbell", "helpinghand", "moonlight", "protect", "snarl", "wish"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	leafeon: {
 		randomBattleMoves: ["healbell", "knockoff", "leafblade", "swordsdance", "synthesis", "xscissor"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["helpinghand", "knockoff", "leafblade", "protect", "substitute", "swordsdance", "xscissor"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	glaceon: {
 		randomBattleMoves: ["healbell", "hiddenpowerground", "icebeam", "protect", "shadowball", "toxic", "wish"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["healbell", "helpinghand", "hiddenpowerground", "icebeam", "protect", "shadowball", "wish"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -854,12 +950,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	porygon2: {
 		randomBattleMoves: ["discharge", "icebeam", "recover", "toxic", "triattack"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["discharge", "icebeam", "protect", "recover", "shadowball", "triattack"],
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	porygonz: {
 		randomBattleMoves: ["agility", "darkpulse", "icebeam", "nastyplot", "thunderbolt", "triattack", "trick"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["agility", "darkpulse", "hiddenpowerfighting", "nastyplot", "protect", "triattack", "trick"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -869,6 +967,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	omastar: {
 		randomBattleMoves: ["earthpower", "hydropump", "icebeam", "shellsmash", "spikes", "stealthrock"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["earthpower", "hiddenpowerelectric", "hydropump", "icebeam", "muddywater", "protect", "shellsmash"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -878,18 +977,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kabutops: {
 		randomBattleMoves: ["aquajet", "knockoff", "rapidspin", "stoneedge", "swordsdance", "waterfall"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["aquajet", "knockoff", "protect", "rockslide", "stoneedge", "superpower", "swordsdance", "waterfall"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	aerodactyl: {
 		randomBattleMoves: ["defog", "doubleedge", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge", "taunt"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["aquatail", "earthquake", "icefang", "protect", "rockslide", "skydrop", "stoneedge", "tailwind", "taunt", "wideguard"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	aerodactylmega: {
 		randomBattleMoves: ["aerialace", "aquatail", "earthquake", "firefang", "honeclaws", "roost", "stoneedge"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["aerialace", "earthquake", "icefang", "ironhead", "protect", "rockslide", "skydrop", "stoneedge", "tailwind", "taunt", "wideguard"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -899,24 +1001,28 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	snorlax: {
 		randomBattleMoves: ["bodyslam", "crunch", "curse", "earthquake", "firepunch", "pursuit", "rest", "return", "sleeptalk", "whirlwind"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["bodyslam", "crunch", "curse", "earthquake", "firepunch", "icepunch", "protect", "return", "selfdestruct"],
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	articuno: {
 		randomBattleMoves: ["freezedry", "hurricane", "icebeam", "roost", "substitute", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["freezedry", "hurricane", "protect", "roost", "substitute", "tailwind"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	zapdos: {
 		randomBattleMoves: ["defog", "heatwave", "hiddenpowerice", "roost", "thunderbolt", "toxic", "uturn"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["discharge", "heatwave", "hiddenpowergrass", "hiddenpowerice", "protect", "tailwind", "thunderbolt"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	moltres: {
 		randomBattleMoves: ["fireblast", "hiddenpowergrass", "hurricane", "roost", "substitute", "toxic", "willowisp"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["airslash", "fireblast", "heatwave", "hiddenpowergrass", "hurricane", "protect", "roost", "substitute", "tailwind", "uturn", "willowisp"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
@@ -929,28 +1035,33 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dragonite: {
 		randomBattleMoves: ["dragondance", "earthquake", "extremespeed", "firepunch", "outrage", "roost"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dracometeor", "dragonclaw", "dragondance", "earthquake", "extremespeed", "firepunch", "protect", "roost", "skydrop", "substitute", "superpower"],
 		tier: "OU",
 		doublesTier: "(DUU)",
 	},
 	mewtwo: {
 		randomBattleMoves: ["aurasphere", "calmmind", "fireblast", "icebeam", "psystrike", "recover"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["aurasphere", "calmmind", "fireblast", "icebeam", "protect", "psystrike", "recover", "substitute", "taunt", "thunderbolt", "willowisp"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	mewtwomegax: {
 		randomBattleMoves: ["bulkup", "drainpunch", "icebeam", "stoneedge", "taunt", "zenheadbutt"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	mewtwomegay: {
 		randomBattleMoves: ["aurasphere", "calmmind", "fireblast", "icebeam", "psystrike", "recover", "shadowball", "taunt", "willowisp"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	mew: {
 		randomBattleMoves: ["aurasphere", "defog", "earthpower", "icebeam", "knockoff", "nastyplot", "psyshock", "roost", "stealthrock", "taunt", "willowisp"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["aurasphere", "fakeout", "fireblast", "helpinghand", "icebeam", "nastyplot", "protect", "psyshock", "roost", "tailwind", "taunt", "thunderbolt", "transform", "willowisp"],
 		tier: "OU",
 		doublesTier: "DUU",
@@ -963,6 +1074,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	meganium: {
 		randomBattleMoves: ["aromatherapy", "dragontail", "gigadrain", "leechseed", "lightscreen", "reflect", "synthesis", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aromatherapy", "dragontail", "gigadrain", "healpulse", "leechseed", "lightscreen", "petalblizzard", "protect", "reflect", "synthesis", "toxic"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -975,6 +1087,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	typhlosion: {
 		randomBattleMoves: ["eruption", "extrasensory", "fireblast", "focusblast", "hiddenpowergrass"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["eruption", "extrasensory", "fireblast", "focusblast", "heatwave", "hiddenpowergrass", "protect"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -987,6 +1100,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	feraligatr: {
 		randomBattleMoves: ["aquajet", "crunch", "dragondance", "earthquake", "icepunch", "swordsdance", "waterfall"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["aquajet", "crunch", "dragondance", "earthquake", "icepunch", "protect", "swordsdance", "waterfall"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -996,6 +1110,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	furret: {
 		randomBattleMoves: ["aquatail", "doubleedge", "firepunch", "knockoff", "trick", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["doubleedge", "firepunch", "followme", "helpinghand", "icepunch", "knockoff", "protect", "suckerpunch", "superfang", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1005,6 +1120,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	noctowl: {
 		randomBattleMoves: ["airslash", "defog", "nightshade", "roost", "toxic", "whirlwind"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "heatwave", "hypervoice", "hypnosis", "protect", "roost", "tailwind"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1014,6 +1130,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ledian: {
 		randomBattleMoves: ["knockoff", "lightscreen", "reflect", "roost", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bugbuzz", "encore", "knockoff", "lightscreen", "protect", "reflect", "tailwind", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1023,6 +1140,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ariados: {
 		randomBattleMoves: ["megahorn", "poisonjab", "stickyweb", "suckerpunch", "toxicspikes"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["megahorn", "poisonjab", "protect", "ragepowder", "stickyweb", "stringshot"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1032,6 +1150,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lanturn: {
 		randomBattleMoves: ["healbell", "hydropump", "icebeam", "scald", "thunderbolt", "thunderwave", "toxic", "voltswitch"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["discharge", "hiddenpowergrass", "hydropump", "icebeam", "protect", "scald", "surf", "thunderbolt", "thunderwave"],
 		tier: "NU",
 		doublesTier: "DUU",
@@ -1045,6 +1164,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	togekiss: {
 		randomBattleMoves: ["airslash", "aurasphere", "defog", "healbell", "nastyplot", "roost", "thunderwave"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["airslash", "dazzlinggleam", "followme", "nastyplot", "protect", "roost", "tailwind", "thunderwave"],
 		tier: "UUBL",
 		doublesTier: "DOU",
@@ -1054,6 +1174,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	xatu: {
 		randomBattleMoves: ["calmmind", "heatwave", "psychic", "roost", "thunderwave", "toxic", "uturn"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["grassknot", "heatwave", "lightscreen", "protect", "psychic", "reflect", "roost", "tailwind", "thunderwave", "uturn"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -1066,12 +1187,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ampharos: {
 		randomBattleMoves: ["focusblast", "healbell", "hiddenpowerice", "lightscreen", "reflect", "thunderbolt", "toxic", "voltswitch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["discharge", "dragonpulse", "focusblast", "hiddenpowergrass", "hiddenpowerice", "protect", "thunderbolt"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	ampharosmega: {
 		randomBattleMoves: ["agility", "dragonpulse", "focusblast", "healbell", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["discharge", "dragonpulse", "focusblast", "hiddenpowergrass", "hiddenpowerice", "protect", "thunderbolt"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -1084,6 +1207,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	azumarill: {
 		randomBattleMoves: ["aquajet", "bellydrum", "knockoff", "playrough", "superpower", "waterfall"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["aquajet", "bellydrum", "knockoff", "playrough", "protect", "superpower", "waterfall"],
 		tier: "OU",
 		doublesTier: "DOU",
@@ -1093,6 +1217,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sudowoodo: {
 		randomBattleMoves: ["earthquake", "stealthrock", "stoneedge", "suckerpunch", "toxic", "woodhammer"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "explosion", "helpinghand", "protect", "rockslide", "stealthrock", "stoneedge", "suckerpunch", "woodhammer"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1105,6 +1230,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	jumpluff: {
 		randomBattleMoves: ["acrobatics", "encore", "leechseed", "seedbomb", "sleeppowder", "substitute", "swordsdance", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["encore", "gigadrain", "helpinghand", "leechseed", "protect", "ragepowder", "sleeppowder", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1114,6 +1240,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ambipom: {
 		randomBattleMoves: ["fakeout", "knockoff", "lowkick", "return", "seedbomb", "switcheroo", "uturn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["doublehit", "fakeout", "icepunch", "knockoff", "lowkick", "protect", "return", "uturn"],
 		tier: "RU",
 		doublesTier: "DUU",
@@ -1123,6 +1250,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sunflora: {
 		randomBattleMoves: ["earthpower", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "sludgebomb"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthpower", "encore", "gigadrain", "hiddenpowerfire", "hiddenpowerice", "protect", "solarbeam", "sunnyday"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1132,6 +1260,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	yanmega: {
 		randomBattleMoves: ["airslash", "bugbuzz", "gigadrain", "protect", "uturn"],
+		randomBattleLevel: 84,
 		tier: "RUBL",
 		doublesTier: "(DUU)",
 	},
@@ -1140,6 +1269,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	quagsire: {
 		randomBattleMoves: ["earthquake", "encore", "icebeam", "recover", "scald", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["curse", "earthquake", "icepunch", "icywind", "protect", "rockslide", "scald", "waterfall", "yawn"],
 		tier: "PUBL",
 		doublesTier: "(DUU)",
@@ -1149,6 +1279,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	honchkrow: {
 		randomBattleMoves: ["bravebird", "heatwave", "pursuit", "roost", "suckerpunch", "superpower"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["bravebird", "heatwave", "protect", "roost", "substitute", "suckerpunch", "superpower"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
@@ -1159,12 +1290,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mismagius: {
 		randomBattleMoves: ["dazzlinggleam", "destinybond", "nastyplot", "painsplit", "shadowball", "substitute", "taunt", "thunderbolt", "willowisp"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["dazzlinggleam", "nastyplot", "protect", "shadowball", "substitute", "taunt", "thunderbolt", "willowisp"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	unown: {
 		randomBattleMoves: ["hiddenpowerpsychic"],
+		randomBattleLevel: 100,
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
@@ -1173,11 +1306,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wobbuffet: {
 		randomBattleMoves: ["counter", "destinybond", "encore", "mirrorcoat", "safeguard"],
+		randomBattleLevel: 82,
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	girafarig: {
 		randomBattleMoves: ["hypervoice", "nastyplot", "psychic", "psyshock", "substitute", "thunderbolt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["agility", "hypervoice", "nastyplot", "protect", "psychic", "psyshock", "thunderbolt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1187,23 +1322,27 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	forretress: {
 		randomBattleMoves: ["gyroball", "rapidspin", "spikes", "stealthrock", "toxic", "voltswitch"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["drillrun", "gyroball", "protect", "rockslide", "stealthrock", "toxic", "voltswitch"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	dunsparce: {
 		randomBattleMoves: ["bite", "bodyslam", "coil", "glare", "headbutt", "rockslide", "roost"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bite", "bodyslam", "coil", "glare", "headbutt", "protect", "rockslide"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	gligar: {
 		randomBattleMoves: ["defog", "earthquake", "knockoff", "roost", "stealthrock", "toxic", "uturn"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "NFE",
 	},
 	gliscor: {
 		randomBattleMoves: ["earthquake", "knockoff", "protect", "roost", "stealthrock", "taunt", "toxic", "uturn"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["earthquake", "knockoff", "protect", "stoneedge", "substitute", "tailwind", "taunt"],
 		tier: "OU",
 		doublesTier: "(DUU)",
@@ -1213,30 +1352,35 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	granbull: {
 		randomBattleMoves: ["crunch", "earthquake", "healbell", "playrough", "thunderwave"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["crunch", "earthquake", "playrough", "protect", "rockslide", "snarl", "thunderwave"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	qwilfish: {
 		randomBattleMoves: ["destinybond", "painsplit", "spikes", "taunt", "thunderwave", "toxicspikes", "waterfall"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["destinybond", "poisonjab", "protect", "swordsdance", "taunt", "thunderwave", "waterfall"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	shuckle: {
 		randomBattleMoves: ["encore", "knockoff", "stealthrock", "stickyweb", "toxic"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["encore", "guardsplit", "helpinghand", "knockoff", "powersplit", "stealthrock", "stickyweb", "toxic"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
 	},
 	heracross: {
 		randomBattleMoves: ["closecombat", "earthquake", "knockoff", "megahorn", "stoneedge", "swordsdance"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["closecombat", "earthquake", "knockoff", "megahorn", "protect", "stoneedge", "swordsdance"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	heracrossmega: {
 		randomBattleMoves: ["closecombat", "pinmissile", "rockblast", "substitute", "swordsdance"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["bulletseed", "closecombat", "earthquake", "knockoff", "pinmissile", "protect", "rockblast", "swordsdance"],
 		tier: "(OU)",
 		doublesTier: "(DUU)",
@@ -1247,6 +1391,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	weavile: {
 		randomBattleMoves: ["iceshard", "iciclecrash", "knockoff", "lowkick", "pursuit", "swordsdance"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["fakeout", "feint", "iceshard", "iciclecrash", "knockoff", "lowkick", "protect", "swordsdance", "taunt"],
 		tier: "OU",
 		doublesTier: "DOU",
@@ -1256,6 +1401,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ursaring: {
 		randomBattleMoves: ["closecombat", "crunch", "facade", "protect", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["closecombat", "crunch", "earthquake", "facade", "protect", "swordsdance"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -1265,6 +1411,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	magcargo: {
 		randomBattleMoves: ["ancientpower", "earthpower", "fireblast", "hiddenpowergrass", "lavaplume", "recover", "shellsmash", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["ancientpower", "earthpower", "fireblast", "heatwave", "hiddenpowergrass", "protect", "shellsmash", "stealthrock", "willowisp"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1278,12 +1425,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mamoswine: {
 		randomBattleMoves: ["earthquake", "iceshard", "iciclecrash", "knockoff", "stealthrock", "superpower"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthquake", "iceshard", "iciclecrash", "knockoff", "protect", "rockslide", "superpower"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	corsola: {
 		randomBattleMoves: ["powergem", "recover", "scald", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthpower", "icebeam", "icywind", "powergem", "protect", "scald", "stealthrock"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1293,12 +1442,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	octillery: {
 		randomBattleMoves: ["energyball", "fireblast", "gunkshot", "hydropump", "icebeam", "rockblast", "scald"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["chargebeam", "energyball", "fireblast", "hydropump", "icebeam", "protect", "surf"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	delibird: {
 		randomBattleMoves: ["destinybond", "freezedry", "icywind", "rapidspin", "spikes"],
+		randomBattleLevel: 100,
 		randomDoubleBattleMoves: ["aerialace", "brickbreak", "fakeout", "icepunch", "iceshard", "protect"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1308,12 +1459,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mantine: {
 		randomBattleMoves: ["airslash", "defog", "rest", "scald", "sleeptalk", "toxic"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["airslash", "helpinghand", "hydropump", "icebeam", "protect", "raindance", "scald", "surf", "tailwind", "wideguard"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	skarmory: {
 		randomBattleMoves: ["bravebird", "defog", "roost", "spikes", "stealthrock", "whirlwind"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["bravebird", "feint", "ironhead", "protect", "skydrop", "tailwind", "taunt"],
 		tier: "OU",
 		doublesTier: "(DUU)",
@@ -1323,12 +1476,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	houndoom: {
 		randomBattleMoves: ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "suckerpunch"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["darkpulse", "heatwave", "hiddenpowerfighting", "nastyplot", "protect", "suckerpunch"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	houndoommega: {
 		randomBattleMoves: ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "taunt"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["darkpulse", "heatwave", "hiddenpowergrass", "nastyplot", "protect", "taunt"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
@@ -1338,42 +1493,49 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	donphan: {
 		randomBattleMoves: ["earthquake", "iceshard", "knockoff", "rapidspin", "stealthrock", "stoneedge"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthquake", "iceshard", "knockoff", "protect", "rockslide", "stealthrock"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	stantler: {
 		randomBattleMoves: ["doubleedge", "earthquake", "jumpkick", "megahorn", "suckerpunch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "jumpkick", "megahorn", "protect", "return", "suckerpunch"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	smeargle: {
 		randomBattleMoves: ["destinybond", "spore", "stealthrock", "stickyweb", "whirlwind"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["fakeout", "followme", "helpinghand", "kingsshield", "spore", "tailwind", "transform", "wideguard"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	miltank: {
 		randomBattleMoves: ["bodyslam", "curse", "earthquake", "healbell", "milkdrink", "stealthrock", "toxic"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["bodyslam", "curse", "earthquake", "healbell", "helpinghand", "protect", "thunderwave"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	raikou: {
 		randomBattleMoves: ["aurasphere", "calmmind", "extrasensory", "hiddenpowerice", "substitute", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["calmmind", "extrasensory", "hiddenpowerice", "protect", "snarl", "substitute", "thunderbolt"],
 		tier: "(OU)",
 		doublesTier: "(DUU)",
 	},
 	entei: {
 		randomBattleMoves: ["bulldoze", "extremespeed", "flareblitz", "sacredfire", "stoneedge"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["bulldoze", "extremespeed", "flareblitz", "ironhead", "protect", "sacredfire", "stoneedge"],
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	suicune: {
 		randomBattleMoves: ["calmmind", "hiddenpowergrass", "icebeam", "rest", "scald", "sleeptalk"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["calmmind", "hiddenpowergrass", "hydropump", "icebeam", "protect", "scald", "snarl", "tailwind"],
 		tier: "UU",
 		doublesTier: "DOU",
@@ -1386,30 +1548,35 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	tyranitar: {
 		randomBattleMoves: ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "stealthrock", "stoneedge"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["crunch", "earthquake", "firepunch", "icepunch", "protect", "rockslide", "stealthrock", "stoneedge"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	tyranitarmega: {
 		randomBattleMoves: ["crunch", "dragondance", "earthquake", "icepunch", "stoneedge"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["crunch", "dragondance", "earthquake", "icepunch", "protect", "rockslide", "stoneedge"],
 		tier: "(OU)",
 		doublesTier: "(DOU)",
 	},
 	lugia: {
 		randomBattleMoves: ["aeroblast", "earthquake", "roost", "substitute", "toxic", "whirlwind"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["aeroblast", "calmmind", "icebeam", "protect", "psychic", "roost", "skydrop", "substitute", "tailwind"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	hooh: {
 		randomBattleMoves: ["bravebird", "earthquake", "roost", "sacredfire", "substitute", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["bravebird", "earthquake", "protect", "roost", "sacredfire", "skydrop", "substitute", "tailwind", "toxic"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	celebi: {
 		randomBattleMoves: ["earthpower", "gigadrain", "hiddenpowerfire", "leafstorm", "nastyplot", "psychic", "recover", "thunderwave", "uturn"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthpower", "gigadrain", "hiddenpowerfire", "leafstorm", "leechseed", "nastyplot", "protect", "psychic", "recover", "thunderwave", "uturn"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -1422,12 +1589,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sceptile: {
 		randomBattleMoves: ["focusblast", "gigadrain", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "leechseed", "substitute"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["focusblast", "gigadrain", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "protect", "substitute"],
 		tier: "NUBL",
 		doublesTier: "(DUU)",
 	},
 	sceptilemega: {
 		randomBattleMoves: ["dragonpulse", "earthquake", "focusblast", "gigadrain", "hiddenpowerfire", "leafblade", "outrage", "substitute", "swordsdance"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["dragonpulse", "focusblast", "gigadrain", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "protect", "substitute"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -1441,11 +1610,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	blaziken: {
 		randomBattleMoves: ["fireblast", "hiddenpowerice", "highjumpkick", "knockoff", "protect"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "(DUU)",
 	},
 	blazikenmega: {
 		randomBattleMoves: ["flareblitz", "highjumpkick", "knockoff", "protect", "stoneedge", "swordsdance"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "(DUU)",
 	},
@@ -1457,12 +1628,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swampert: {
 		randomBattleMoves: ["earthquake", "icebeam", "protect", "roar", "scald", "stealthrock", "toxic"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthquake", "icebeam", "icywind", "muddywater", "protect", "rockslide", "scald", "stealthrock", "waterfall", "wideguard"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	swampertmega: {
 		randomBattleMoves: ["earthquake", "icepunch", "raindance", "superpower", "waterfall"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthquake", "icepunch", "protect", "raindance", "superpower", "waterfall"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -1472,6 +1645,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mightyena: {
 		randomBattleMoves: ["crunch", "firefang", "irontail", "playrough", "suckerpunch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["crunch", "firefang", "playrough", "protect", "suckerpunch", "taunt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1481,6 +1655,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	linoone: {
 		randomBattleMoves: ["bellydrum", "extremespeed", "seedbomb", "shadowclaw"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bellydrum", "extremespeed", "protect", "seedbomb", "shadowclaw"],
 		tier: "PUBL",
 		doublesTier: "(DUU)",
@@ -1493,6 +1668,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	beautifly: {
 		randomBattleMoves: ["bugbuzz", "energyball", "hiddenpowerfighting", "psychic", "quiverdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aircutter", "bugbuzz", "gigadrain", "hiddenpowerrock", "protect", "quiverdance", "stringshot", "tailwind"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1502,6 +1678,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dustox: {
 		randomBattleMoves: ["bugbuzz", "defog", "quiverdance", "roost", "sludgebomb", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bugbuzz", "protect", "quiverdance", "shadowball", "sludgebomb", "stringshot", "strugglebug", "tailwind"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1514,6 +1691,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ludicolo: {
 		randomBattleMoves: ["focusblast", "gigadrain", "hydropump", "icebeam", "raindance", "scald"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["fakeout", "gigadrain", "hydropump", "icebeam", "protect", "raindance", "surf"],
 		tier: "NU",
 		doublesTier: "DOU",
@@ -1526,6 +1704,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	shiftry: {
 		randomBattleMoves: ["defog", "knockoff", "leafblade", "leafstorm", "lowkick", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["fakeout", "knockoff", "leafblade", "leafstorm", "lowkick", "protect", "suckerpunch", "swordsdance"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -1535,6 +1714,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swellow: {
 		randomBattleMoves: ["bravebird", "facade", "protect", "quickattack", "uturn"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["bravebird", "facade", "protect", "quickattack", "uturn"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -1544,6 +1724,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	pelipper: {
 		randomBattleMoves: ["defog", "hurricane", "knockoff", "roost", "scald", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["hurricane", "knockoff", "protect", "scald", "surf", "tailwind", "wideguard"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -1556,24 +1737,28 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gardevoir: {
 		randomBattleMoves: ["calmmind", "focusblast", "moonblast", "psychic", "shadowball", "substitute", "thunderbolt", "willowisp"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["dazzlinggleam", "focusblast", "helpinghand", "moonblast", "protect", "psyshock", "shadowball", "taunt", "thunderbolt", "trickroom", "willowisp"],
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	gardevoirmega: {
 		randomBattleMoves: ["calmmind", "focusblast", "hypervoice", "psyshock", "substitute", "taunt", "willowisp"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["calmmind", "focusblast", "hypervoice", "protect", "psyshock", "shadowball", "thunderbolt"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	gallade: {
 		randomBattleMoves: ["closecombat", "icepunch", "knockoff", "shadowsneak", "swordsdance", "trick", "zenheadbutt"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["closecombat", "drainpunch", "helpinghand", "icepunch", "knockoff", "protect", "shadowsneak", "stoneedge", "trick", "trickroom", "zenheadbutt"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	gallademega: {
 		randomBattleMoves: ["closecombat", "drainpunch", "knockoff", "substitute", "swordsdance", "zenheadbutt"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["closecombat", "drainpunch", "icepunch", "knockoff", "protect", "stoneedge", "swordsdance", "zenheadbutt"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
@@ -1583,6 +1768,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	masquerain: {
 		randomBattleMoves: ["airslash", "bugbuzz", "hydropump", "quiverdance", "stickyweb"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "bugbuzz", "hydropump", "protect", "quiverdance", "roost", "strugglebug", "tailwind"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1592,6 +1778,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	breloom: {
 		randomBattleMoves: ["bulletseed", "machpunch", "rocktomb", "spore", "swordsdance"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["bulletseed", "drainpunch", "helpinghand", "machpunch", "protect", "rocktomb", "spore"],
 		tier: "OU",
 		doublesTier: "DOU",
@@ -1605,6 +1792,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	slaking: {
 		randomBattleMoves: ["earthquake", "firepunch", "gigaimpact", "nightslash", "pursuit", "retaliate"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["doubleedge", "earthquake", "hammerarm", "nightslash", "retaliate", "rockslide"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1614,12 +1802,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ninjask: {
 		randomBattleMoves: ["aerialace", "nightslash", "swordsdance", "uturn", "xscissor"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aerialace", "nightslash", "protect", "swordsdance", "xscissor"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	shedinja: {
 		randomBattleMoves: ["shadowclaw", "shadowsneak", "swordsdance", "willowisp", "xscissor"],
+		randomBattleLevel: 88,
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
@@ -1631,6 +1821,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	exploud: {
 		randomBattleMoves: ["boomburst", "fireblast", "focusblast", "icebeam", "surf"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["boomburst", "fireblast", "focusblast", "hypervoice", "icebeam", "protect", "surf"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -1640,6 +1831,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hariyama: {
 		randomBattleMoves: ["bulkup", "bulletpunch", "closecombat", "icepunch", "knockoff", "stoneedge"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["bulletpunch", "closecombat", "fakeout", "helpinghand", "icepunch", "knockoff", "protect", "stoneedge", "wideguard"],
 		tier: "NU",
 		doublesTier: "DUU",
@@ -1649,6 +1841,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	probopass: {
 		randomBattleMoves: ["earthpower", "flashcannon", "stealthrock", "thunderwave", "toxic", "voltswitch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthpower", "helpinghand", "powergem", "protect", "stealthrock", "thunderwave", "voltswitch", "wideguard"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -1658,30 +1851,35 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	delcatty: {
 		randomBattleMoves: ["doubleedge", "fakeout", "healbell", "suckerpunch", "thunderwave", "wildcharge"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["doubleedge", "fakeout", "helpinghand", "playrough", "protect", "suckerpunch", "thunderwave", "wildcharge"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	sableye: {
 		randomBattleMoves: ["foulplay", "knockoff", "recover", "taunt", "toxic", "willowisp"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["fakeout", "foulplay", "helpinghand", "knockoff", "protect", "recover", "snarl", "taunt", "willowisp"],
 		tier: "RUBL",
 		doublesTier: "DUU",
 	},
 	sableyemega: {
 		randomBattleMoves: ["calmmind", "darkpulse", "recover", "shadowball", "willowisp"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["darkpulse", "fakeout", "knockoff", "protect", "shadowball", "willowisp"],
 		tier: "Uber",
 		doublesTier: "DUU",
 	},
 	mawile: {
 		randomBattleMoves: ["ironhead", "knockoff", "playrough", "stealthrock", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["firefang", "ironhead", "knockoff", "playrough", "protect", "substitute", "suckerpunch", "swordsdance"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	mawilemega: {
 		randomBattleMoves: ["firefang", "focuspunch", "ironhead", "knockoff", "playrough", "substitute", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["firefang", "ironhead", "knockoff", "playrough", "protect", "substitute", "suckerpunch", "swordsdance"],
 		tier: "Uber",
 		doublesTier: "(DUU)",
@@ -1694,12 +1892,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	aggron: {
 		randomBattleMoves: ["aquatail", "autotomize", "earthquake", "headsmash", "heavyslam", "stealthrock"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["aquatail", "earthquake", "headsmash", "heavyslam", "lowkick", "protect", "rockslide", "stealthrock"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	aggronmega: {
 		randomBattleMoves: ["earthquake", "heavyslam", "roar", "stoneedge", "stealthrock", "thunderwave", "toxic"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["aquatail", "earthquake", "heavyslam", "lowkick", "protect", "rockslide"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -1709,12 +1909,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	medicham: {
 		randomBattleMoves: ["bulletpunch", "drainpunch", "highjumpkick", "icepunch", "zenheadbutt"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["bulletpunch", "drainpunch", "fakeout", "highjumpkick", "icepunch", "protect", "zenheadbutt"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	medichammega: {
 		randomBattleMoves: ["fakeout", "highjumpkick", "icepunch", "thunderpunch", "zenheadbutt"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["bulletpunch", "drainpunch", "fakeout", "highjumpkick", "icepunch", "protect", "zenheadbutt"],
 		tier: "OU",
 		doublesTier: "(DUU)",
@@ -1724,36 +1926,42 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	manectric: {
 		randomBattleMoves: ["flamethrower", "hiddenpowergrass", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["flamethrower", "hiddenpowergrass", "hiddenpowerice", "overheat", "protect", "snarl", "thunderbolt", "voltswitch"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	manectricmega: {
 		randomBattleMoves: ["hiddenpowergrass", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["flamethrower", "hiddenpowergrass", "hiddenpowerice", "overheat", "protect", "snarl", "thunderbolt", "voltswitch"],
 		tier: "OU",
 		doublesTier: "(DUU)",
 	},
 	plusle: {
 		randomBattleMoves: ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["encore", "helpinghand", "hiddenpowerice", "nastyplot", "protect", "substitute", "thunderbolt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	minun: {
 		randomBattleMoves: ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["encore", "helpinghand", "hiddenpowerice", "nastyplot", "protect", "substitute", "thunderbolt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	volbeat: {
 		randomBattleMoves: ["encore", "roost", "tailwind", "thunderwave", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["encore", "helpinghand", "protect", "stringshot", "strugglebug", "tailwind", "thunderwave"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	illumise: {
 		randomBattleMoves: ["bugbuzz", "encore", "roost", "thunderwave", "uturn", "wish"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bugbuzz", "encore", "helpinghand", "protect", "tailwind", "thunderbolt", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1767,6 +1975,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	roserade: {
 		randomBattleMoves: ["gigadrain", "hiddenpowerfire", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["gigadrain", "hiddenpowerfire", "leafstorm", "protect", "sleeppowder", "sludgebomb"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -1776,6 +1985,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swalot: {
 		randomBattleMoves: ["earthquake", "encore", "icebeam", "painsplit", "sludgebomb", "toxic", "yawn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "encore", "gunkshot", "icebeam", "protect", "sludgebomb", "yawn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1785,12 +1995,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sharpedo: {
 		randomBattleMoves: ["crunch", "earthquake", "icebeam", "protect", "waterfall"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["crunch", "destinybond", "earthquake", "icebeam", "protect", "waterfall"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
 	},
 	sharpedomega: {
 		randomBattleMoves: ["crunch", "destinybond", "icefang", "protect", "waterfall", "zenheadbutt"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
@@ -1799,6 +2011,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wailord: {
 		randomBattleMoves: ["hiddenpowerfire", "hiddenpowergrass", "hydropump", "icebeam", "waterspout"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["hiddenpowerfire", "hiddenpowergrass", "hydropump", "icebeam", "protect", "waterspout"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1808,18 +2021,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	camerupt: {
 		randomBattleMoves: ["earthpower", "fireblast", "hiddenpowergrass", "lavaplume", "roar", "rockpolish", "stealthrock", "stoneedge"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthpower", "eruption", "fireblast", "heatwave", "hiddenpowergrass", "protect", "rockpolish"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	cameruptmega: {
 		randomBattleMoves: ["ancientpower", "earthpower", "fireblast", "stealthrock", "toxic", "willowisp"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["earthpower", "eruption", "fireblast", "heatwave", "protect", "rockslide"],
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	torkoal: {
 		randomBattleMoves: ["earthpower", "lavaplume", "rapidspin", "stealthrock", "yawn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthpower", "fireblast", "heatwave", "hiddenpowergrass", "protect", "shellsmash", "willowisp"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -1829,12 +2045,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	grumpig: {
 		randomBattleMoves: ["focusblast", "healbell", "lightscreen", "psychic", "reflect", "thunderwave", "toxic", "whirlwind"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["focusblast", "lightscreen", "protect", "psychic", "psyshock", "reflect", "taunt", "thunderwave", "trickroom"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	spinda: {
 		randomBattleMoves: ["icepunch", "rest", "return", "sleeptalk", "suckerpunch", "superpower"],
+		randomBattleLevel: 100,
 		randomDoubleBattleMoves: ["doubleedge", "fakeout", "protect", "return", "suckerpunch", "superpower", "trickroom"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1847,6 +2065,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	flygon: {
 		randomBattleMoves: ["defog", "earthquake", "fireblast", "outrage", "roost", "stoneedge", "uturn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["dragonclaw", "earthquake", "feint", "fireblast", "firepunch", "protect", "rockslide", "tailwind", "uturn"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -1856,6 +2075,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cacturne: {
 		randomBattleMoves: ["darkpulse", "drainpunch", "focusblast", "seedbomb", "spikes", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["drainpunch", "seedbomb", "spikyshield", "substitute", "suckerpunch", "swordsdance"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -1865,36 +2085,42 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	altaria: {
 		randomBattleMoves: ["dracometeor", "dragondance", "earthquake", "fireblast", "outrage", "roost", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["dracometeor", "dragonclaw", "dragondance", "earthquake", "fireblast", "protect", "tailwind"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	altariamega: {
 		randomBattleMoves: ["dragondance", "earthquake", "fireblast", "healbell", "hypervoice", "return", "roost"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["doubleedge", "dragonclaw", "dragondance", "earthquake", "fireblast", "protect", "return"],
 		tier: "UUBL",
 		doublesTier: "DUU",
 	},
 	zangoose: {
 		randomBattleMoves: ["closecombat", "facade", "knockoff", "quickattack", "swordsdance"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["closecombat", "facade", "knockoff", "protect", "quickattack"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	seviper: {
 		randomBattleMoves: ["darkpulse", "earthquake", "flamethrower", "gigadrain", "poisonjab", "sludgewave", "suckerpunch", "switcheroo"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aquatail", "earthquake", "flamethrower", "gigadrain", "glare", "poisonjab", "protect", "sludgebomb", "suckerpunch"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	lunatone: {
 		randomBattleMoves: ["ancientpower", "calmmind", "earthpower", "icebeam", "moonlight", "psychic", "rockpolish", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["ancientpower", "calmmind", "earthpower", "helpinghand", "icebeam", "moonlight", "protect", "psychic", "rockpolish", "trickroom"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	solrock: {
 		randomBattleMoves: ["explosion", "earthquake", "lightscreen", "morningsun", "reflect", "rockslide", "stealthrock", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["helpinghand", "protect", "rockslide", "stoneedge", "trickroom", "willowisp", "zenheadbutt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1904,6 +2130,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	whiscash: {
 		randomBattleMoves: ["dragondance", "earthquake", "stoneedge", "waterfall", "zenheadbutt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["dragondance", "earthquake", "protect", "stoneedge", "waterfall", "zenheadbutt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1913,6 +2140,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	crawdaunt: {
 		randomBattleMoves: ["aquajet", "crabhammer", "dragondance", "knockoff", "superpower", "swordsdance"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["aquajet", "crabhammer", "crunch", "dragondance", "knockoff", "protect", "superpower", "swordsdance"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -1922,6 +2150,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	claydol: {
 		randomBattleMoves: ["earthquake", "icebeam", "psychic", "rapidspin", "stealthrock", "toxic"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["earthpower", "earthquake", "icebeam", "protect", "psychic", "trickroom"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -1931,6 +2160,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cradily: {
 		randomBattleMoves: ["curse", "gigadrain", "recover", "rockslide", "seedbomb", "stealthrock", "toxic"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["curse", "earthquake", "protect", "recover", "rockslide", "seedbomb", "swordsdance"],
 		tier: "NU",
 		doublesTier: "DUU",
@@ -1940,6 +2170,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	armaldo: {
 		randomBattleMoves: ["earthquake", "knockoff", "rapidspin", "stealthrock", "stoneedge", "toxic", "xscissor"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["knockoff", "protect", "rockslide", "stoneedge", "stringshot", "swordsdance", "xscissor"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -1949,6 +2180,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	milotic: {
 		randomBattleMoves: ["dragontail", "icebeam", "recover", "rest", "scald", "sleeptalk", "toxic"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["dragontail", "hiddenpowergrass", "hydropump", "hypnosis", "icebeam", "protect", "recover", "scald"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -1959,15 +2191,19 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	castformsunny: {
 		randomBattleMoves: ["icebeam", "solarbeam", "sunnyday", "weatherball"],
+		randomBattleLevel: 100,
 	},
 	castformrainy: {
 		randomBattleMoves: ["hurricane", "raindance", "thunder", "weatherball"],
+		randomBattleLevel: 100,
 	},
 	castformsnowy: {
 		randomBattleMoves: ["blizzard", "fireblast", "hail", "thunderbolt"],
+		randomBattleLevel: 100,
 	},
 	kecleon: {
 		randomBattleMoves: ["drainpunch", "fakeout", "knockoff", "recover", "shadowsneak", "stealthrock", "suckerpunch"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["drainpunch", "fakeout", "knockoff", "protect", "recover", "shadowsneak", "suckerpunch", "trickroom"],
 		tier: "NU",
 		doublesTier: "DUU",
@@ -1977,12 +2213,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	banette: {
 		randomBattleMoves: ["destinybond", "knockoff", "shadowclaw", "shadowsneak", "suckerpunch", "taunt", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["knockoff", "protect", "shadowclaw", "shadowsneak", "suckerpunch", "willowisp"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	banettemega: {
 		randomBattleMoves: ["destinybond", "knockoff", "shadowclaw", "suckerpunch", "taunt", "willowisp"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["destinybond", "knockoff", "protect", "shadowclaw", "suckerpunch", "taunt", "willowisp"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -1995,12 +2233,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dusknoir: {
 		randomBattleMoves: ["earthquake", "icepunch", "painsplit", "shadowsneak", "substitute", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "helpinghand", "icepunch", "painsplit", "protect", "shadowsneak", "trickroom", "willowisp"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	tropius: {
 		randomBattleMoves: ["airslash", "gigadrain", "leechseed", "protect", "substitute", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "earthquake", "gigadrain", "hiddenpowerfire", "leechseed", "protect", "roost", "sunnyday", "tailwind"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2010,18 +2250,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	chimecho: {
 		randomBattleMoves: ["calmmind", "healbell", "healingwish", "psychic", "recover", "shadowball", "taunt", "yawn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["dazzlinggleam", "helpinghand", "protect", "psychic", "recover", "shadowball", "taunt", "thunderwave", "trickroom"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	absol: {
 		randomBattleMoves: ["knockoff", "playrough", "pursuit", "suckerpunch", "superpower", "swordsdance"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["fireblast", "knockoff", "playrough", "protect", "suckerpunch", "superpower", "swordsdance"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	absolmega: {
 		randomBattleMoves: ["icebeam", "knockoff", "playrough", "pursuit", "suckerpunch", "superpower", "swordsdance"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["fireblast", "knockoff", "playrough", "protect", "suckerpunch", "superpower", "swordsdance"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -2031,18 +2274,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	glalie: {
 		randomBattleMoves: ["earthquake", "explosion", "icebeam", "iceshard", "spikes", "superfang", "taunt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "icebeam", "iceshard", "protect", "taunt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	glaliemega: {
 		randomBattleMoves: ["earthquake", "explosion", "freezedry", "iceshard", "return", "spikes"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["crunch", "earthquake", "explosion", "freezedry", "iceshard", "protect", "return"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	froslass: {
 		randomBattleMoves: ["destinybond", "icebeam", "shadowball", "spikes", "taunt", "thunderwave"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["destinybond", "icebeam", "protect", "shadowball", "taunt", "thunderwave"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
@@ -2055,6 +2301,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	walrein: {
 		randomBattleMoves: ["icebeam", "protect", "roar", "superfang", "surf", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["icebeam", "icywind", "protect", "roar", "superfang", "surf"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2064,24 +2311,28 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	huntail: {
 		randomBattleMoves: ["icebeam", "shellsmash", "suckerpunch", "waterfall"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["icefang", "protect", "shellsmash", "suckerpunch", "waterfall"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	gorebyss: {
 		randomBattleMoves: ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["hiddenpowergrass", "icebeam", "protect", "shellsmash", "substitute", "surf"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	relicanth: {
 		randomBattleMoves: ["doubleedge", "earthquake", "headsmash", "stealthrock", "toxic", "waterfall"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["doubleedge", "earthquake", "headsmash", "protect", "rockslide", "waterfall"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	luvdisc: {
 		randomBattleMoves: ["icebeam", "protect", "scald", "sweetkiss", "toxic"],
+		randomBattleLevel: 100,
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
@@ -2093,12 +2344,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	salamence: {
 		randomBattleMoves: ["dracometeor", "dragonclaw", "dragondance", "earthquake", "fireblast", "outrage", "roost"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["dracometeor", "dragonclaw", "dragondance", "earthquake", "fireblast", "hydropump", "protect", "rockslide", "tailwind"],
 		tier: "UUBL",
 		doublesTier: "DUU",
 	},
 	salamencemega: {
 		randomBattleMoves: ["doubleedge", "dracometeor", "dragondance", "earthquake", "fireblast", "return", "roost"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["doubleedge", "dracometeor", "dragonclaw", "dragondance", "earthquake", "fireblast", "protect", "return"],
 		tier: "Uber",
 		doublesTier: "DOU",
@@ -2112,80 +2365,94 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	metagross: {
 		randomBattleMoves: ["agility", "bulletpunch", "earthquake", "explosion", "icepunch", "meteormash", "stealthrock", "thunderpunch", "zenheadbutt"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["bulletpunch", "earthquake", "explosion", "hammerarm", "icepunch", "meteormash", "protect", "thunderpunch", "zenheadbutt"],
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	metagrossmega: {
 		randomBattleMoves: ["agility", "earthquake", "hammerarm", "icepunch", "meteormash", "zenheadbutt"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["earthquake", "icepunch", "meteormash", "protect", "thunderpunch", "zenheadbutt"],
 		tier: "OU",
 		doublesTier: "DUU",
 	},
 	regirock: {
 		randomBattleMoves: ["curse", "drainpunch", "earthquake", "rest", "stealthrock", "stoneedge", "thunderwave", "toxic"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["curse", "drainpunch", "protect", "rockslide", "stealthrock", "stoneedge", "thunderwave"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	regice: {
 		randomBattleMoves: ["focusblast", "icebeam", "rest", "rockpolish", "sleeptalk", "thunderbolt", "thunderwave"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["focusblast", "icebeam", "icywind", "protect", "rockpolish", "thunderbolt", "thunderwave"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	registeel: {
 		randomBattleMoves: ["curse", "ironhead", "rest", "sleeptalk", "stealthrock", "toxic"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["curse", "ironhead", "protect", "rest", "seismictoss", "stealthrock", "thunderwave"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	latias: {
 		randomBattleMoves: ["defog", "dracometeor", "healingwish", "hiddenpowerfire", "psyshock", "roost"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dragonpulse", "healpulse", "helpinghand", "lightscreen", "protect", "psychic", "reflect", "tailwind"],
 		tier: "OU",
 		doublesTier: "(DUU)",
 	},
 	latiasmega: {
 		randomBattleMoves: ["calmmind", "dracometeor", "hiddenpowerfire", "psyshock", "roost", "surf"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dragonpulse", "healpulse", "helpinghand", "lightscreen", "protect", "psychic", "reflect", "tailwind"],
 		tier: "(OU)",
 		doublesTier: "(DUU)",
 	},
 	latios: {
 		randomBattleMoves: ["calmmind", "dracometeor", "hiddenpowerfire", "psyshock", "roost", "trick"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "hiddenpowerfire", "protect", "psyshock", "substitute", "surf", "tailwind", "thunderbolt", "trick"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	latiosmega: {
 		randomBattleMoves: ["calmmind", "dracometeor", "earthquake", "hiddenpowerfire", "psyshock", "roost"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "hiddenpowerfire", "protect", "psyshock", "substitute", "surf", "tailwind", "thunderbolt"],
 		tier: "(OU)",
 		doublesTier: "(DOU)",
 	},
 	kyogre: {
 		randomBattleMoves: ["icebeam", "originpulse", "scald", "thunder", "waterspout"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "icebeam", "muddywater", "originpulse", "protect", "rest", "sleeptalk", "thunder", "waterspout"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	kyogreprimal: {
 		randomBattleMoves: ["calmmind", "icebeam", "originpulse", "rest", "scald", "sleeptalk", "thunder"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "icebeam", "muddywater", "originpulse", "protect", "rest", "sleeptalk", "thunder", "waterspout"],
 	},
 	groudon: {
 		randomBattleMoves: ["earthquake", "firepunch", "lavaplume", "roar", "stealthrock", "stoneedge", "thunderwave", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["dragonclaw", "firepunch", "precipiceblades", "protect", "rockpolish", "rockslide", "stoneedge", "swordsdance"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	groudonprimal: {
 		randomBattleMoves: ["dragontail", "firepunch", "lavaplume", "precipiceblades", "rockpolish", "stealthrock", "stoneedge", "swordsdance"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["firepunch", "lavaplume", "overheat", "precipiceblades", "protect", "rockpolish", "rockslide", "stoneedge", "swordsdance"],
 	},
 	rayquaza: {
 		randomBattleMoves: ["dracometeor", "dragonascent", "dragonclaw", "dragondance", "earthquake", "extremespeed", "outrage", "vcreate"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["dracometeor", "dragonclaw", "dragondance", "earthquake", "extremespeed", "protect", "tailwind", "vcreate"],
 		tier: "Uber",
 		doublesTier: "DUber",
@@ -2197,30 +2464,35 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	jirachi: {
 		randomBattleMoves: ["bodyslam", "firepunch", "icepunch", "ironhead", "stealthrock", "substitute", "toxic", "uturn", "wish"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["bodyslam", "followme", "helpinghand", "icywind", "ironhead", "protect", "thunderwave", "trickroom", "uturn", "zenheadbutt"],
 		tier: "OU",
 		doublesTier: "DUber",
 	},
 	deoxys: {
 		randomBattleMoves: ["extremespeed", "firepunch", "knockoff", "psychoboost", "spikes", "stealthrock", "superpower", "taunt"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["extremespeed", "firepunch", "icebeam", "knockoff", "protect", "psychoboost", "psyshock", "superpower", "thunderbolt"],
 		tier: "Uber",
 		doublesTier: "(DUU)",
 	},
 	deoxysattack: {
 		randomBattleMoves: ["extremespeed", "firepunch", "icebeam", "knockoff", "psychoboost", "stealthrock", "superpower"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["extremespeed", "firepunch", "icebeam", "knockoff", "protect", "psychoboost", "superpower", "thunderbolt"],
 		tier: "Uber",
 		doublesTier: "(DUU)",
 	},
 	deoxysdefense: {
 		randomBattleMoves: ["knockoff", "recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["lightscreen", "protect", "recover", "reflect", "seismictoss", "stealthrock", "taunt", "trickroom"],
 		tier: "Uber",
 		doublesTier: "(DUU)",
 	},
 	deoxysspeed: {
 		randomBattleMoves: ["knockoff", "magiccoat", "psychoboost", "spikes", "stealthrock", "superpower", "taunt"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["icebeam", "knockoff", "lightscreen", "protect", "psychoboost", "reflect", "superpower", "taunt"],
 		tier: "Uber",
 		doublesTier: "(DUU)",
@@ -2233,6 +2505,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	torterra: {
 		randomBattleMoves: ["earthquake", "rockpolish", "stealthrock", "stoneedge", "synthesis", "woodhammer"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["earthquake", "protect", "rockpolish", "rockslide", "stoneedge", "wideguard", "woodhammer"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -2246,6 +2519,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	infernape: {
 		randomBattleMoves: ["closecombat", "fireblast", "flareblitz", "grassknot", "machpunch", "stealthrock", "stoneedge", "uturn"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["closecombat", "fakeout", "feint", "flareblitz", "grassknot", "heatwave", "machpunch", "protect", "stoneedge", "taunt", "thunderpunch", "uturn"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -2259,6 +2533,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	empoleon: {
 		randomBattleMoves: ["defog", "flashcannon", "grassknot", "hydropump", "icebeam", "roar", "scald", "stealthrock", "toxic"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["flashcannon", "grassknot", "hiddenpowerelectric", "icebeam", "icywind", "protect", "scald", "surf"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -2271,6 +2546,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	staraptor: {
 		randomBattleMoves: ["bravebird", "closecombat", "doubleedge", "quickattack", "uturn"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["bravebird", "closecombat", "doubleedge", "protect", "quickattack", "tailwind", "uturn"],
 		tier: "UUBL",
 		doublesTier: "DUU",
@@ -2280,6 +2556,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	bibarel: {
 		randomBattleMoves: ["curse", "quickattack", "rest", "return", "stealthrock", "waterfall"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["curse", "protect", "quickattack", "rest", "return", "waterfall"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2289,6 +2566,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kricketune: {
 		randomBattleMoves: ["endeavor", "knockoff", "stickyweb", "taunt", "toxic", "xscissor"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bugbite", "knockoff", "protect", "stickyweb", "taunt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2301,6 +2579,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	luxray: {
 		randomBattleMoves: ["crunch", "facade", "icefang", "superpower", "voltswitch", "wildcharge"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["crunch", "facade", "icefang", "protect", "superpower", "voltswitch", "wildcharge"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2310,6 +2589,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	rampardos: {
 		randomBattleMoves: ["crunch", "earthquake", "firepunch", "headsmash", "rockpolish", "rockslide"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["crunch", "earthquake", "headsmash", "protect", "rockslide", "stoneedge", "zenheadbutt"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -2319,6 +2599,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	bastiodon: {
 		randomBattleMoves: ["metalburst", "protect", "roar", "rockblast", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["guardsplit", "metalburst", "protect", "stealthrock", "stoneedge", "wideguard"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2328,24 +2609,28 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wormadam: {
 		randomBattleMoves: ["gigadrain", "hiddenpowerrock", "protect", "signalbeam", "synthesis", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["gigadrain", "hiddenpowerice", "hiddenpowerrock", "leafstorm", "protect", "signalbeam", "stringshot"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	wormadamsandy: {
 		randomBattleMoves: ["earthquake", "protect", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "protect", "rockblast", "stringshot", "suckerpunch"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	wormadamtrash: {
 		randomBattleMoves: ["flashcannon", "protect", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["flashcannon", "protect", "stringshot", "strugglebug"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	mothim: {
 		randomBattleMoves: ["airslash", "bugbuzz", "energyball", "quiverdance", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "bugbuzz", "gigadrain", "protect", "quiverdance", "roost"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2355,12 +2640,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vespiquen: {
 		randomBattleMoves: ["infestation", "protect", "roost", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["attackorder", "healorder", "protect", "stringshot", "strugglebug", "tailwind"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	pachirisu: {
 		randomBattleMoves: ["nuzzle", "superfang", "thunderbolt", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["followme", "helpinghand", "nuzzle", "protect", "superfang", "thunderbolt", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2370,6 +2657,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	floatzel: {
 		randomBattleMoves: ["aquajet", "brickbreak", "bulkup", "icepunch", "substitute", "taunt", "waterfall"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aquajet", "crunch", "icepunch", "protect", "raindance", "switcheroo", "taunt", "waterfall"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -2379,6 +2667,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cherrim: {
 		randomBattleMoves: ["dazzlinggleam", "energyball", "healingwish", "hiddenpowerfire", "hiddenpowerice", "synthesis"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["gigadrain", "protect", "solarbeam", "sunnyday", "weatherball"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2391,6 +2680,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gastrodon: {
 		randomBattleMoves: ["clearsmog", "earthquake", "icebeam", "recover", "scald", "toxic"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["earthpower", "icebeam", "icywind", "muddywater", "protect", "recover", "scald"],
 		tier: "NU",
 		doublesTier: "DOU",
@@ -2400,6 +2690,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	drifblim: {
 		randomBattleMoves: ["acrobatics", "destinybond", "hex", "shadowball", "substitute", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["destinybond", "hiddenpowerfighting", "hypnosis", "protect", "shadowball", "substitute", "thunderbolt", "willowisp"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -2409,12 +2700,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lopunny: {
 		randomBattleMoves: ["healingwish", "highjumpkick", "icepunch", "return", "switcheroo"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["encore", "fakeout", "firepunch", "highjumpkick", "icepunch", "protect", "return", "switcheroo"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	lopunnymega: {
 		randomBattleMoves: ["fakeout", "highjumpkick", "icepunch", "return", "substitute"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["encore", "fakeout", "highjumpkick", "icepunch", "protect", "return"],
 		tier: "OU",
 		doublesTier: "(DUU)",
@@ -2424,6 +2717,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	purugly: {
 		randomBattleMoves: ["fakeout", "knockoff", "quickattack", "return", "suckerpunch", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["fakeout", "knockoff", "protect", "quickattack", "return", "suckerpunch", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2433,6 +2727,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	skuntank: {
 		randomBattleMoves: ["crunch", "defog", "fireblast", "poisonjab", "pursuit", "suckerpunch", "taunt"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["crunch", "fireblast", "playrough", "poisonjab", "protect", "snarl", "suckerpunch", "taunt"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -2442,18 +2737,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	bronzong: {
 		randomBattleMoves: ["earthquake", "explosion", "ironhead", "lightscreen", "reflect", "stealthrock", "toxic"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["earthquake", "explosion", "gyroball", "lightscreen", "protect", "reflect", "trickroom"],
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	chatot: {
 		randomBattleMoves: ["boomburst", "chatter", "heatwave", "hiddenpowerground", "nastyplot", "substitute", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["boomburst", "chatter", "encore", "heatwave", "hypervoice", "nastyplot", "protect", "substitute", "uturn"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	spiritomb: {
 		randomBattleMoves: ["calmmind", "darkpulse", "psychic", "pursuit", "rest", "shadowsneak", "sleeptalk", "willowisp"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["darkpulse", "foulplay", "icywind", "painsplit", "protect", "shadowsneak", "snarl", "willowisp"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -2467,12 +2765,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	garchomp: {
 		randomBattleMoves: ["dragonclaw", "earthquake", "fireblast", "firefang", "outrage", "stealthrock", "stoneedge", "swordsdance"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dragonclaw", "earthquake", "protect", "rockslide", "stoneedge", "substitute", "swordsdance"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	garchompmega: {
 		randomBattleMoves: ["dracometeor", "earthquake", "fireblast", "outrage", "stoneedge", "swordsdance"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dragonclaw", "earthquake", "fireblast", "protect", "rockslide", "stoneedge", "substitute", "swordsdance"],
 		tier: "(OU)",
 		doublesTier: "(DOU)",
@@ -2482,12 +2782,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lucario: {
 		randomBattleMoves: ["aurasphere", "closecombat", "crunch", "darkpulse", "extremespeed", "flashcannon", "icepunch", "nastyplot", "swordsdance", "vacuumwave"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["aurasphere", "bulletpunch", "closecombat", "crunch", "darkpulse", "extremespeed", "flashcannon", "followme", "icepunch", "protect", "vacuumwave"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	lucariomega: {
 		randomBattleMoves: ["aurasphere", "bulletpunch", "closecombat", "crunch", "darkpulse", "flashcannon", "icepunch", "nastyplot", "swordsdance"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["aurasphere", "bulletpunch", "closecombat", "crunch", "darkpulse", "extremespeed", "flashcannon", "followme", "icepunch", "protect", "vacuumwave"],
 		tier: "Uber",
 		doublesTier: "(DUU)",
@@ -2497,6 +2799,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hippowdon: {
 		randomBattleMoves: ["earthquake", "slackoff", "stealthrock", "stoneedge", "toxic", "whirlwind"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["earthquake", "protect", "rockslide", "slackoff", "stealthrock", "stoneedge"],
 		tier: "OU",
 		doublesTier: "DUU",
@@ -2506,6 +2809,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	drapion: {
 		randomBattleMoves: ["earthquake", "knockoff", "poisonjab", "pursuit", "swordsdance", "taunt", "toxicspikes", "whirlwind"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["aquatail", "earthquake", "knockoff", "poisonjab", "protect", "snarl", "swordsdance", "taunt"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -2515,12 +2819,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	toxicroak: {
 		randomBattleMoves: ["drainpunch", "gunkshot", "icepunch", "substitute", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["drainpunch", "fakeout", "gunkshot", "icepunch", "knockoff", "protect", "substitute", "suckerpunch", "swordsdance"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	carnivine: {
 		randomBattleMoves: ["knockoff", "powerwhip", "return", "sleeppowder", "substitute", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["knockoff", "leechseed", "powerwhip", "protect", "ragepowder", "return", "sleeppowder", "substitute", "swordsdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2530,6 +2836,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lumineon: {
 		randomBattleMoves: ["defog", "icebeam", "scald", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["icebeam", "protect", "raindance", "surf", "tailwind", "toxic", "uturn"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -2539,216 +2846,258 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	abomasnow: {
 		randomBattleMoves: ["blizzard", "earthquake", "focuspunch", "gigadrain", "iceshard", "leechseed", "substitute", "woodhammer"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["blizzard", "earthquake", "focusblast", "gigadrain", "iceshard", "protect", "woodhammer"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	abomasnowmega: {
 		randomBattleMoves: ["blizzard", "earthquake", "gigadrain", "hiddenpowerfire", "iceshard", "woodhammer"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["blizzard", "earthquake", "focusblast", "gigadrain", "iceshard", "protect", "woodhammer"],
 		tier: "RUBL",
 		doublesTier: "DUU",
 	},
 	rotom: {
 		randomBattleMoves: ["hiddenpowerice", "painsplit", "shadowball", "substitute", "thunderbolt", "trick", "voltswitch", "willowisp"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["electroweb", "hiddenpowerice", "painsplit", "protect", "shadowball", "substitute", "thunderbolt", "trick", "voltswitch", "willowisp"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	rotomheat: {
 		randomBattleMoves: ["hiddenpowerice", "overheat", "painsplit", "thunderbolt", "voltswitch", "willowisp"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["electroweb", "hiddenpowerice", "overheat", "painsplit", "protect", "substitute", "thunderbolt", "voltswitch", "willowisp"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	rotomwash: {
 		randomBattleMoves: ["hydropump", "painsplit", "thunderbolt", "trick", "voltswitch", "willowisp"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["electroweb", "hiddenpowergrass", "hiddenpowerice", "hydropump", "painsplit", "protect", "substitute", "thunderbolt", "trick", "voltswitch", "willowisp"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	rotomfrost: {
 		randomBattleMoves: ["blizzard", "painsplit", "substitute", "thunderbolt", "trick", "voltswitch", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["blizzard", "electroweb", "painsplit", "protect", "substitute", "thunderbolt", "trick", "voltswitch", "willowisp"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	rotomfan: {
 		randomBattleMoves: ["airslash", "painsplit", "thunderbolt", "voltswitch", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "discharge", "electroweb", "hiddenpowerice", "painsplit", "protect", "substitute", "thunderbolt", "voltswitch", "willowisp"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	rotommow: {
 		randomBattleMoves: ["hiddenpowerfire", "hiddenpowerice", "leafstorm", "thunderbolt", "trick", "voltswitch"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["electroweb", "hiddenpowerfire", "leafstorm", "painsplit", "protect", "substitute", "thunderbolt", "trick", "voltswitch", "willowisp"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	uxie: {
 		randomBattleMoves: ["healbell", "knockoff", "psychic", "stealthrock", "thunderwave", "uturn", "yawn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["healbell", "helpinghand", "protect", "psyshock", "skillswap", "stealthrock", "thunderbolt", "thunderwave", "uturn", "yawn"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	mesprit: {
 		randomBattleMoves: ["calmmind", "energyball", "healingwish", "hiddenpowerfire", "icebeam", "psychic", "psyshock", "signalbeam", "stealthrock", "uturn"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["calmmind", "helpinghand", "icebeam", "knockoff", "protect", "psychic", "substitute", "thunderbolt", "trick", "uturn"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	azelf: {
 		randomBattleMoves: ["dazzlinggleam", "explosion", "fireblast", "knockoff", "nastyplot", "psyshock", "stealthrock", "taunt"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dazzlinggleam", "fireblast", "icepunch", "knockoff", "nastyplot", "protect", "psychic", "taunt", "thunderbolt", "uturn", "zenheadbutt"],
 		tier: "OU",
 		doublesTier: "(DUU)",
 	},
 	dialga: {
 		randomBattleMoves: ["dracometeor", "fireblast", "flashcannon", "roar", "stealthrock", "thunderbolt", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["aurasphere", "dracometeor", "dragonpulse", "earthpower", "fireblast", "flashcannon", "protect", "thunderbolt"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	palkia: {
 		randomBattleMoves: ["dracometeor", "dragontail", "fireblast", "hydropump", "spacialrend", "thunderwave"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["dracometeor", "fireblast", "hydropump", "protect", "spacialrend", "surf", "thunderbolt"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	heatran: {
 		randomBattleMoves: ["earthpower", "fireblast", "flashcannon", "lavaplume", "protect", "roar", "stealthrock", "toxic"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["earthpower", "eruption", "heatwave", "protect", "substitute", "willowisp"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	regigigas: {
 		randomBattleMoves: ["confuseray", "drainpunch", "knockoff", "return", "substitute", "thunderwave"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "icywind", "knockoff", "return", "rockslide", "substitute", "thunderwave", "wideguard"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	giratina: {
 		randomBattleMoves: ["dragonpulse", "dragontail", "rest", "roar", "shadowball", "sleeptalk", "willowisp"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "dragonpulse", "dragontail", "icywind", "protect", "shadowball", "tailwind", "willowisp"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	giratinaorigin: {
 		randomBattleMoves: ["defog", "dracometeor", "dragontail", "earthquake", "shadowball", "shadowsneak", "toxic", "willowisp"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["aurasphere", "calmmind", "dracometeor", "dragonpulse", "earthquake", "hiddenpowerfire", "protect", "shadowball", "shadowsneak", "substitute", "tailwind", "willowisp"],
 	},
 	cresselia: {
 		randomBattleMoves: ["calmmind", "icebeam", "moonblast", "moonlight", "psychic", "psyshock", "substitute", "thunderwave", "toxic"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["helpinghand", "icebeam", "icywind", "lightscreen", "moonblast", "moonlight", "protect", "psyshock", "reflect", "skillswap", "thunderwave", "trickroom"],
 		tier: "UU",
 		doublesTier: "DOU",
 	},
 	phione: {
 		randomBattleMoves: ["healbell", "icebeam", "knockoff", "scald", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["helpinghand", "icebeam", "icywind", "protect", "raindance", "rest", "scald", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	manaphy: {
 		randomBattleMoves: ["energyball", "icebeam", "surf", "tailglow"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["energyball", "helpinghand", "icebeam", "icywind", "protect", "scald", "surf", "tailglow"],
 		tier: "OU",
 		doublesTier: "(DUU)",
 	},
 	darkrai: {
 		randomBattleMoves: ["darkpulse", "darkvoid", "focusblast", "nastyplot", "sludgebomb", "substitute"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["darkpulse", "focusblast", "nastyplot", "protect", "snarl", "substitute"],
 		tier: "Uber",
 		doublesTier: "(DUU)",
 	},
 	shaymin: {
 		randomBattleMoves: ["airslash", "earthpower", "leechseed", "psychic", "rest", "seedflare", "substitute"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["airslash", "earthpower", "hiddenpowerfire", "leechseed", "protect", "rest", "seedflare", "substitute", "tailwind"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
 	},
 	shayminsky: {
 		randomBattleMoves: ["airslash", "earthpower", "hiddenpowerice", "leechseed", "seedflare", "substitute"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["airslash", "earthpower", "hiddenpowerice", "leechseed", "protect", "rest", "seedflare", "substitute", "tailwind"],
 		tier: "Uber",
 		doublesTier: "DOU",
 	},
 	arceus: {
 		randomBattleMoves: ["earthquake", "extremespeed", "recover", "shadowclaw", "swordsdance"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["earthquake", "extremespeed", "protect", "recover", "shadowclaw", "swordsdance"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	arceusbug: {
 		randomBattleMoves: ["earthquake", "ironhead", "recover", "stoneedge", "swordsdance", "xscissor"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["earthquake", "ironhead", "protect", "recover", "stoneedge", "swordsdance", "xscissor"],
 	},
 	arceusdark: {
 		randomBattleMoves: ["calmmind", "fireblast", "judgment", "recover", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "focusblast", "judgment", "protect", "recover", "safeguard", "snarl", "willowisp"],
 	},
 	arceusdragon: {
 		randomBattleMoves: ["defog", "earthquake", "extremespeed", "fireblast", "judgment", "outrage", "recover", "swordsdance", "willowisp"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["dragonclaw", "earthquake", "extremespeed", "protect", "recover", "swordsdance"],
 	},
 	arceuselectric: {
 		randomBattleMoves: ["calmmind", "earthpower", "icebeam", "judgment", "recover"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "icebeam", "judgment", "protect", "recover"],
 	},
 	arceusfairy: {
 		randomBattleMoves: ["calmmind", "defog", "earthpower", "judgment", "recover", "toxic", "willowisp"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "earthpower", "judgment", "protect", "recover", "thunderbolt", "willowisp"],
 	},
 	arceusfighting: {
 		randomBattleMoves: ["calmmind", "icebeam", "judgment", "recover", "shadowball", "stoneedge"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "icebeam", "judgment", "protect", "recover", "shadowball", "willowisp"],
 	},
 	arceusfire: {
 		randomBattleMoves: ["calmmind", "fireblast", "icebeam", "recover", "thunderbolt"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "heatwave", "judgment", "protect", "recover", "thunderbolt", "willowisp"],
 	},
 	arceusflying: {
 		randomBattleMoves: ["calmmind", "earthpower", "fireblast", "judgment", "recover", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "judgment", "protect", "recover", "safeguard", "substitute", "tailwind"],
 	},
 	arceusghost: {
 		randomBattleMoves: ["brickbreak", "defog", "extremespeed", "judgment", "recover", "shadowclaw", "shadowforce", "swordsdance", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["brickbreak", "calmmind", "focusblast", "judgment", "protect", "recover", "shadowforce", "swordsdance", "willowisp"],
 	},
 	arceusgrass: {
 		randomBattleMoves: ["calmmind", "fireblast", "icebeam", "judgment", "recover"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "earthpower", "icebeam", "judgment", "protect", "recover", "safeguard", "thunderwave"],
 	},
 	arceusground: {
 		randomBattleMoves: ["earthquake", "icebeam", "judgment", "recover", "stealthrock", "stoneedge", "swordsdance", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "earthquake", "icebeam", "judgment", "protect", "recover", "rockslide", "stoneedge", "swordsdance"],
 	},
 	arceusice: {
 		randomBattleMoves: ["calmmind", "fireblast", "judgment", "recover", "thunderbolt"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "focusblast", "icywind", "judgment", "protect", "recover", "thunderbolt"],
 	},
 	arceuspoison: {
 		randomBattleMoves: ["calmmind", "defog", "fireblast", "icebeam", "recover", "sludgebomb"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "earthpower", "heatwave", "judgment", "protect", "recover", "sludgebomb", "willowisp"],
 	},
 	arceuspsychic: {
 		randomBattleMoves: ["calmmind", "fireblast", "icebeam", "judgment", "recover", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "focusblast", "judgment", "protect", "psyshock", "recover", "willowisp"],
 	},
 	arceusrock: {
 		randomBattleMoves: ["earthquake", "judgment", "recover", "stealthrock", "stoneedge", "swordsdance", "willowisp"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["earthquake", "protect", "recover", "rockslide", "stoneedge", "swordsdance"],
 	},
 	arceussteel: {
 		randomBattleMoves: ["defog", "earthquake", "ironhead", "judgment", "recover", "roar", "stoneedge", "swordsdance", "willowisp"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "judgment", "protect", "recover", "willowisp"],
 	},
 	arceuswater: {
 		randomBattleMoves: ["calmmind", "defog", "icebeam", "judgment", "recover", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "fireblast", "icebeam", "icywind", "judgment", "protect", "recover", "surf"],
 	},
 	victini: {
 		randomBattleMoves: ["blueflare", "boltstrike", "energyball", "glaciate", "uturn", "vcreate", "zenheadbutt"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["blueflare", "boltstrike", "focusblast", "protect", "psychic", "uturn", "vcreate"],
 		tier: "UUBL",
 		doublesTier: "DUU",
@@ -2761,6 +3110,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	serperior: {
 		randomBattleMoves: ["dragonpulse", "glare", "hiddenpowerfire", "leafstorm", "leechseed", "substitute"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dragonpulse", "hiddenpowerfire", "leafstorm", "protect", "substitute", "taunt"],
 		tier: "OU",
 		doublesTier: "(DUU)",
@@ -2773,6 +3123,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	emboar: {
 		randomBattleMoves: ["fireblast", "flareblitz", "grassknot", "headsmash", "suckerpunch", "superpower", "wildcharge"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["flamecharge", "flareblitz", "headsmash", "heatwave", "protect", "rockslide", "superpower", "wildcharge"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -2785,6 +3136,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	samurott: {
 		randomBattleMoves: ["aquajet", "grassknot", "hydropump", "icebeam", "megahorn", "superpower", "swordsdance", "waterfall"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["aquajet", "helpinghand", "hiddenpowergrass", "hydropump", "icebeam", "protect", "scald", "taunt"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -2794,6 +3146,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	watchog: {
 		randomBattleMoves: ["hypnosis", "knockoff", "return", "substitute", "superfang", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["hypnosis", "knockoff", "protect", "return", "substitute", "superfang", "swordsdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2806,6 +3159,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	stoutland: {
 		randomBattleMoves: ["crunch", "icefang", "return", "superpower", "wildcharge"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["crunch", "icefang", "protect", "return", "superpower", "wildcharge"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -2815,6 +3169,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	liepard: {
 		randomBattleMoves: ["copycat", "encore", "knockoff", "playrough", "substitute", "thunderwave", "uturn"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["encore", "fakeout", "knockoff", "playrough", "protect", "substitute", "suckerpunch", "thunderwave", "uturn"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -2824,6 +3179,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	simisage: {
 		randomBattleMoves: ["focusblast", "gigadrain", "hiddenpowerice", "knockoff", "leafstorm", "nastyplot", "substitute", "superpower"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["focusblast", "gigadrain", "helpinghand", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "nastyplot", "protect", "substitute", "synthesis", "taunt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2833,6 +3189,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	simisear: {
 		randomBattleMoves: ["fireblast", "focusblast", "grassknot", "hiddenpowerrock", "nastyplot", "substitute"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["fireblast", "focusblast", "grassknot", "heatwave", "hiddenpowerground", "nastyplot", "protect", "substitute", "taunt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2842,6 +3199,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	simipour: {
 		randomBattleMoves: ["focusblast", "hydropump", "icebeam", "nastyplot", "substitute"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["helpinghand", "hydropump", "icebeam", "nastyplot", "protect", "substitute", "surf", "taunt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2851,6 +3209,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	musharna: {
 		randomBattleMoves: ["calmmind", "healbell", "moonlight", "psychic", "psyshock", "signalbeam", "thunderwave"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["healbell", "helpinghand", "hiddenpowerfighting", "moonlight", "protect", "psychic", "psyshock", "signalbeam", "thunderwave", "trickroom"],
 		tier: "PUBL",
 		doublesTier: "(DUU)",
@@ -2863,6 +3222,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	unfezant: {
 		randomBattleMoves: ["hypnosis", "nightslash", "pluck", "return", "roost", "tailwind", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["nightslash", "pluck", "protect", "return", "roost", "tailwind", "taunt", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2872,6 +3232,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	zebstrika: {
 		randomBattleMoves: ["hiddenpowergrass", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch", "wildcharge"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["hiddenpowergrass", "overheat", "protect", "voltswitch", "wildcharge"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -2884,6 +3245,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gigalith: {
 		randomBattleMoves: ["earthquake", "explosion", "stealthrock", "stoneedge", "superpower"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["autotomize", "earthquake", "explosion", "protect", "rockslide", "stealthrock", "stoneedge", "superpower", "wideguard"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2893,6 +3255,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swoobat: {
 		randomBattleMoves: ["airslash", "calmmind", "heatwave", "roost", "storedpower"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "calmmind", "gigadrain", "heatwave", "protect", "psychic", "tailwind"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2902,18 +3265,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	excadrill: {
 		randomBattleMoves: ["earthquake", "ironhead", "rapidspin", "rockslide", "swordsdance"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["drillrun", "earthquake", "ironhead", "protect", "rockslide", "substitute", "swordsdance"],
 		tier: "OU",
 		doublesTier: "DUU",
 	},
 	audino: {
 		randomBattleMoves: ["doubleedge", "encore", "healbell", "knockoff", "protect", "toxic", "wish"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["doubleedge", "healbell", "healpulse", "helpinghand", "lightscreen", "protect", "reflect", "thunderwave", "trickroom"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	audinomega: {
 		randomBattleMoves: ["calmmind", "dazzlinggleam", "fireblast", "healbell", "protect", "wish"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["dazzlinggleam", "healbell", "healpulse", "helpinghand", "hypervoice", "protect", "thunderwave", "trickroom"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -2927,6 +3293,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	conkeldurr: {
 		randomBattleMoves: ["bulkup", "drainpunch", "facade", "icepunch", "knockoff", "machpunch"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["drainpunch", "icepunch", "knockoff", "machpunch", "protect", "wideguard"],
 		tier: "UUBL",
 		doublesTier: "DOU",
@@ -2939,18 +3306,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	seismitoad: {
 		randomBattleMoves: ["earthquake", "hydropump", "knockoff", "raindance", "scald", "sludgebomb", "stealthrock", "toxic"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["earthquake", "hiddenpowerelectric", "hydropump", "icywind", "muddywater", "protect", "sludgebomb"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	throh: {
 		randomBattleMoves: ["bulkup", "circlethrow", "icepunch", "knockoff", "rest", "sleeptalk", "stormthrow"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["circlethrow", "helpinghand", "icepunch", "knockoff", "protect", "stormthrow", "wideguard"],
 		tier: "PUBL",
 		doublesTier: "(DUU)",
 	},
 	sawk: {
 		randomBattleMoves: ["bulkup", "closecombat", "earthquake", "icepunch", "knockoff", "poisonjab"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["closecombat", "icepunch", "knockoff", "protect", "rockslide"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -2963,6 +3333,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	leavanny: {
 		randomBattleMoves: ["knockoff", "leafblade", "stickyweb", "swordsdance", "xscissor"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["leafblade", "poisonjab", "protect", "stickyweb", "swordsdance", "xscissor"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -2975,6 +3346,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	scolipede: {
 		randomBattleMoves: ["earthquake", "megahorn", "poisonjab", "protect", "rockslide", "spikes", "swordsdance", "toxicspikes"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["aquatail", "megahorn", "poisonjab", "protect", "rockslide", "substitute", "superpower", "swordsdance"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
@@ -2984,6 +3356,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	whimsicott: {
 		randomBattleMoves: ["encore", "energyball", "leechseed", "memento", "moonblast", "stunspore", "tailwind", "taunt", "toxic", "uturn"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["dazzlinggleam", "encore", "gigadrain", "helpinghand", "leechseed", "moonblast", "protect", "stunspore", "substitute", "tailwind", "taunt", "uturn"],
 		tier: "UU",
 		doublesTier: "DOU",
@@ -2993,18 +3366,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lilligant: {
 		randomBattleMoves: ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "petaldance", "quiverdance", "sleeppowder"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["gigadrain", "helpinghand", "hiddenpowerfire", "hiddenpowerice", "hiddenpowerrock", "petaldance", "protect", "quiverdance", "sleeppowder"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	basculin: {
 		randomBattleMoves: ["aquajet", "crunch", "superpower", "waterfall", "zenheadbutt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aquajet", "crunch", "doubleedge", "protect", "superpower", "waterfall"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	basculinbluestriped: {
 		randomBattleMoves: ["aquajet", "crunch", "superpower", "waterfall", "zenheadbutt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aquajet", "crunch", "doubleedge", "protect", "superpower", "waterfall"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -3017,6 +3393,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	krookodile: {
 		randomBattleMoves: ["earthquake", "knockoff", "pursuit", "stealthrock", "stoneedge", "superpower"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthquake", "knockoff", "protect", "stoneedge", "superpower"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -3026,12 +3403,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	darmanitan: {
 		randomBattleMoves: ["earthquake", "flareblitz", "rockslide", "superpower", "uturn"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthquake", "firepunch", "flareblitz", "protect", "rockslide", "superpower", "uturn"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	maractus: {
 		randomBattleMoves: ["gigadrain", "hiddenpowerfire", "leechseed", "spikes", "spikyshield", "suckerpunch", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["gigadrain", "grassyterrain", "helpinghand", "hiddenpowerfire", "leechseed", "spikyshield", "suckerpunch"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3041,6 +3420,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	crustle: {
 		randomBattleMoves: ["earthquake", "shellsmash", "spikes", "stealthrock", "stoneedge", "xscissor"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "protect", "rockslide", "shellsmash", "stoneedge", "xscissor"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -3050,12 +3430,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	scrafty: {
 		randomBattleMoves: ["bulkup", "dragondance", "drainpunch", "highjumpkick", "icepunch", "knockoff", "rest"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["drainpunch", "fakeout", "icepunch", "knockoff", "protect", "stoneedge"],
 		tier: "RU",
 		doublesTier: "DOU",
 	},
 	sigilyph: {
 		randomBattleMoves: ["cosmicpower", "psychoshift", "roost", "storedpower"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["airslash", "energyball", "heatwave", "icebeam", "protect", "psyshock", "shadowball", "tailwind"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -3065,6 +3447,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cofagrigus: {
 		randomBattleMoves: ["haze", "hiddenpowerfighting", "nastyplot", "painsplit", "shadowball", "toxicspikes", "trickroom", "willowisp"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["hiddenpowerfighting", "nastyplot", "painsplit", "protect", "shadowball", "trickroom", "willowisp"],
 		tier: "RU",
 		doublesTier: "DUU",
@@ -3074,6 +3457,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	carracosta: {
 		randomBattleMoves: ["aquajet", "earthquake", "hydropump", "shellsmash", "stoneedge"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aquajet", "earthquake", "protect", "rockslide", "shellsmash", "stoneedge", "waterfall", "wideguard"],
 		tier: "PUBL",
 		doublesTier: "(DUU)",
@@ -3083,6 +3467,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	archeops: {
 		randomBattleMoves: ["acrobatics", "aquatail", "earthquake", "endeavor", "headsmash", "stoneedge", "uturn"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["acrobatics", "earthquake", "protect", "rockslide", "stoneedge", "tailwind", "taunt", "uturn"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -3092,6 +3477,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	garbodor: {
 		randomBattleMoves: ["drainpunch", "gunkshot", "haze", "painsplit", "spikes", "toxic", "toxicspikes"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["drainpunch", "explosion", "gunkshot", "painsplit", "protect", "rockblast", "seedbomb"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -3101,6 +3487,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	zoroark: {
 		randomBattleMoves: ["darkpulse", "flamethrower", "focusblast", "nastyplot", "sludgebomb", "trick"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["darkpulse", "flamethrower", "focusblast", "knockoff", "nastyplot", "protect", "suckerpunch", "uturn"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
@@ -3110,6 +3497,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cinccino: {
 		randomBattleMoves: ["bulletseed", "knockoff", "rockblast", "tailslap", "uturn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["aquatail", "bulletseed", "knockoff", "protect", "rockblast", "tailslap", "uturn"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -3122,6 +3510,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gothitelle: {
 		randomBattleMoves: ["calmmind", "hiddenpowerfighting", "psychic", "rest", "sleeptalk", "toxic"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["energyball", "healpulse", "hiddenpowerfighting", "lightscreen", "protect", "psychic", "psyshock", "reflect", "shadowball", "taunt", "thunderbolt", "trickroom"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3134,6 +3523,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	reuniclus: {
 		randomBattleMoves: ["calmmind", "focusblast", "psychic", "psyshock", "recover", "shadowball", "trickroom"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["energyball", "focusblast", "helpinghand", "hiddenpowerfire", "protect", "psychic", "psyshock", "shadowball", "trickroom"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -3143,6 +3533,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swanna: {
 		randomBattleMoves: ["airslash", "defog", "hurricane", "icebeam", "raindance", "roost", "scald"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "hurricane", "icebeam", "protect", "raindance", "roost", "scald", "surf", "tailwind"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -3155,6 +3546,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vanilluxe: {
 		randomBattleMoves: ["autotomize", "explosion", "flashcannon", "freezedry", "hiddenpowerground", "icebeam"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["autotomize", "flashcannon", "freezedry", "hiddenpowerground", "icebeam", "protect", "taunt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3164,12 +3556,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sawsbuck: {
 		randomBattleMoves: ["hornleech", "jumpkick", "return", "substitute", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["hornleech", "jumpkick", "protect", "return", "substitute", "swordsdance", "synthesis"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	emolga: {
 		randomBattleMoves: ["acrobatics", "encore", "knockoff", "roost", "thunderbolt", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "encore", "helpinghand", "protect", "roost", "substitute", "tailwind", "thunderbolt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3179,6 +3573,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	escavalier: {
 		randomBattleMoves: ["drillrun", "ironhead", "knockoff", "megahorn", "pursuit", "swordsdance"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["drillrun", "ironhead", "knockoff", "megahorn", "protect", "swordsdance"],
 		tier: "RU",
 		doublesTier: "DUU",
@@ -3188,6 +3583,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	amoonguss: {
 		randomBattleMoves: ["foulplay", "gigadrain", "hiddenpowerfire", "sludgebomb", "spore", "synthesis"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["gigadrain", "hiddenpowerfire", "protect", "ragepowder", "sludgebomb", "spore", "stunspore", "synthesis"],
 		tier: "OU",
 		doublesTier: "DOU",
@@ -3197,12 +3593,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	jellicent: {
 		randomBattleMoves: ["icebeam", "recover", "scald", "shadowball", "taunt", "toxic", "willowisp"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["icebeam", "icywind", "protect", "recover", "scald", "shadowball", "trickroom", "waterspout", "willowisp"],
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	alomomola: {
 		randomBattleMoves: ["knockoff", "protect", "scald", "toxic", "wish"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["helpinghand", "icywind", "knockoff", "protect", "scald", "wideguard", "wish"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -3212,6 +3610,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	galvantula: {
 		randomBattleMoves: ["bugbuzz", "gigadrain", "hiddenpowerice", "stickyweb", "thunder", "voltswitch"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["bugbuzz", "gigadrain", "hiddenpowerice", "protect", "stickyweb", "thunder", "voltswitch"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -3222,6 +3621,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ferrothorn: {
 		randomBattleMoves: ["gyroball", "knockoff", "leechseed", "powerwhip", "protect", "spikes", "stealthrock"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["gyroball", "knockoff", "leechseed", "powerwhip", "protect", "stealthrock"],
 		tier: "OU",
 		doublesTier: "DOU",
@@ -3234,6 +3634,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	klinklang: {
 		randomBattleMoves: ["geargrind", "return", "shiftgear", "substitute", "wildcharge"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["geargrind", "protect", "return", "shiftgear", "wildcharge"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -3246,6 +3647,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	eelektross: {
 		randomBattleMoves: ["flamethrower", "gigadrain", "hiddenpowerice", "knockoff", "superpower", "thunderbolt", "uturn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["flamethrower", "gigadrain", "knockoff", "protect", "thunderbolt", "uturn", "voltswitch"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -3255,6 +3657,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	beheeyem: {
 		randomBattleMoves: ["hiddenpowerfighting", "nastyplot", "psychic", "psyshock", "signalbeam", "thunderbolt", "trick", "trickroom"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["hiddenpowerfighting", "nastyplot", "protect", "psychic", "recover", "signalbeam", "thunderbolt", "trick", "trickroom"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -3267,6 +3670,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	chandelure: {
 		randomBattleMoves: ["calmmind", "energyball", "fireblast", "hiddenpowerground", "painsplit", "shadowball", "substitute", "trick"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["energyball", "heatwave", "hiddenpowerice", "overheat", "protect", "shadowball", "trick"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -3279,6 +3683,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	haxorus: {
 		randomBattleMoves: ["dragondance", "earthquake", "outrage", "poisonjab", "swordsdance"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["dragonclaw", "dragondance", "earthquake", "poisonjab", "protect", "substitute", "swordsdance"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -3288,12 +3693,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	beartic: {
 		randomBattleMoves: ["aquajet", "iciclecrash", "nightslash", "stoneedge", "superpower", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aquajet", "iciclecrash", "nightslash", "protect", "stoneedge", "superpower", "swordsdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	cryogonal: {
 		randomBattleMoves: ["freezedry", "haze", "hiddenpowerground", "icebeam", "rapidspin", "recover", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["freezedry", "hiddenpowerground", "icebeam", "icywind", "protect", "recover", "reflect"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -3303,12 +3710,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	accelgor: {
 		randomBattleMoves: ["bugbuzz", "encore", "energyball", "focusblast", "hiddenpowerrock", "spikes", "yawn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["bugbuzz", "encore", "focusblast", "gigadrain", "hiddenpowerrock", "protect", "sludgebomb", "yawn"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	stunfisk: {
 		randomBattleMoves: ["discharge", "earthpower", "foulplay", "rest", "sleeptalk", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["discharge", "earthpower", "electroweb", "protect", "scald", "stealthrock"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -3318,12 +3727,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mienshao: {
 		randomBattleMoves: ["fakeout", "highjumpkick", "knockoff", "poisonjab", "stoneedge", "swordsdance", "uturn"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["drainpunch", "fakeout", "feint", "highjumpkick", "knockoff", "protect", "stoneedge", "swordsdance", "uturn", "wideguard"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	druddigon: {
 		randomBattleMoves: ["dragontail", "earthquake", "firepunch", "glare", "gunkshot", "outrage", "stealthrock", "suckerpunch", "taunt"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["dragonclaw", "earthquake", "firepunch", "glare", "protect", "suckerpunch", "superpower", "thunderpunch"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -3333,6 +3744,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	golurk: {
 		randomBattleMoves: ["dynamicpunch", "earthquake", "icepunch", "rockpolish", "shadowpunch", "stealthrock", "stoneedge"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["dynamicpunch", "earthquake", "icepunch", "protect", "rockpolish", "shadowpunch", "stoneedge"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -3343,12 +3755,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	bisharp: {
 		randomBattleMoves: ["ironhead", "knockoff", "lowkick", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["brickbreak", "ironhead", "knockoff", "protect", "substitute", "suckerpunch", "swordsdance"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	bouffalant: {
 		randomBattleMoves: ["earthquake", "headcharge", "megahorn", "stoneedge", "superpower", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "headcharge", "megahorn", "protect", "stoneedge", "superpower", "swordsdance"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -3358,6 +3772,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	braviary: {
 		randomBattleMoves: ["bravebird", "bulkup", "return", "roost", "substitute", "superpower", "uturn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["bravebird", "bulkup", "protect", "return", "rockslide", "roost", "skydrop", "superpower", "tailwind", "uturn"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -3368,18 +3783,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mandibuzz: {
 		randomBattleMoves: ["bravebird", "defog", "foulplay", "roost", "taunt", "toxic", "uturn"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["bravebird", "knockoff", "protect", "roost", "snarl", "tailwind", "taunt", "uturn"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	heatmor: {
 		randomBattleMoves: ["fireblast", "gigadrain", "knockoff", "suckerpunch", "superpower"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["fireblast", "focusblast", "gigadrain", "heatwave", "protect", "suckerpunch"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	durant: {
 		randomBattleMoves: ["honeclaws", "ironhead", "stoneedge", "superpower", "xscissor"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["honeclaws", "ironhead", "protect", "rockslide", "superpower", "xscissor"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
@@ -3392,6 +3810,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hydreigon: {
 		randomBattleMoves: ["darkpulse", "dracometeor", "fireblast", "flashcannon", "roost", "superpower", "uturn"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["darkpulse", "dracometeor", "dragonpulse", "earthpower", "fireblast", "flashcannon", "protect", "roost", "superpower", "tailwind", "uturn"],
 		tier: "UU",
 		doublesTier: "DOU",
@@ -3401,96 +3820,112 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	volcarona: {
 		randomBattleMoves: ["bugbuzz", "fierydance", "fireblast", "gigadrain", "hiddenpowerice", "quiverdance", "roost"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["bugbuzz", "fierydance", "fireblast", "gigadrain", "heatwave", "hiddenpowerice", "protect", "quiverdance", "ragepowder", "roost", "tailwind", "willowisp"],
 		tier: "UUBL",
 		doublesTier: "DUU",
 	},
 	cobalion: {
 		randomBattleMoves: ["closecombat", "ironhead", "stealthrock", "stoneedge", "substitute", "swordsdance", "taunt", "voltswitch"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["closecombat", "ironhead", "protect", "stoneedge", "substitute", "swordsdance", "thunderwave"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	terrakion: {
 		randomBattleMoves: ["closecombat", "earthquake", "quickattack", "stoneedge", "substitute", "swordsdance"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["closecombat", "earthquake", "protect", "rockslide", "stoneedge", "substitute"],
 		tier: "UUBL",
 		doublesTier: "DOU",
 	},
 	virizion: {
 		randomBattleMoves: ["closecombat", "leafblade", "stoneedge", "swordsdance"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["closecombat", "leafblade", "protect", "stoneedge", "swordsdance", "synthesis", "taunt"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	tornadus: {
 		randomBattleMoves: ["acrobatics", "bulkup", "knockoff", "rest", "sleeptalk", "superpower", "tailwind"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["airslash", "focusblast", "heatwave", "hurricane", "protect", "skydrop", "substitute", "superpower", "tailwind", "taunt", "uturn"],
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	tornadustherian: {
 		randomBattleMoves: ["heatwave", "hurricane", "knockoff", "superpower", "taunt", "uturn"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["airslash", "focusblast", "heatwave", "hurricane", "protect", "skydrop", "tailwind", "taunt", "uturn"],
 		tier: "OU",
 		doublesTier: "(DUU)",
 	},
 	thundurus: {
 		randomBattleMoves: ["focusblast", "hiddenpowerflying", "hiddenpowerice", "knockoff", "nastyplot", "substitute", "taunt", "thunderbolt", "thunderwave"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["focusblast", "hiddenpowerflying", "hiddenpowerice", "knockoff", "nastyplot", "protect", "substitute", "taunt", "thunderbolt", "thunderwave"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	thundurustherian: {
 		randomBattleMoves: ["focusblast", "hiddenpowerflying", "hiddenpowerice", "nastyplot", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["focusblast", "hiddenpowerflying", "hiddenpowerice", "nastyplot", "protect", "thunderbolt", "voltswitch"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
 	},
 	reshiram: {
 		randomBattleMoves: ["blueflare", "dracometeor", "earthpower", "roost", "stoneedge", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["blueflare", "dracometeor", "dragonpulse", "flamecharge", "heatwave", "protect", "roost", "tailwind"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	zekrom: {
 		randomBattleMoves: ["boltstrike", "dracometeor", "dragonclaw", "honeclaws", "outrage", "roost", "substitute", "voltswitch"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["boltstrike", "dracometeor", "dragonclaw", "fusionbolt", "honeclaws", "protect", "roost", "substitute", "tailwind", "voltswitch"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	landorus: {
 		randomBattleMoves: ["calmmind", "earthpower", "focusblast", "knockoff", "psychic", "rockpolish", "rockslide", "sludgewave", "stealthrock"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["earthpower", "focusblast", "hiddenpowerice", "protect", "psychic", "rockslide", "sludgebomb"],
 		tier: "Uber",
 		doublesTier: "(DUU)",
 	},
 	landorustherian: {
 		randomBattleMoves: ["earthquake", "rockpolish", "stealthrock", "stoneedge", "superpower", "swordsdance", "uturn"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["earthquake", "knockoff", "protect", "rockslide", "stoneedge", "superpower", "uturn"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	kyurem: {
 		randomBattleMoves: ["dracometeor", "earthpower", "focusblast", "icebeam", "outrage", "roost", "substitute"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "earthpower", "focusblast", "glaciate", "icebeam", "protect", "roost", "substitute"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
 	},
 	kyuremblack: {
 		randomBattleMoves: ["dragonclaw", "earthpower", "fusionbolt", "icebeam", "outrage", "roost", "substitute"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dragonclaw", "earthpower", "fusionbolt", "honeclaws", "icebeam", "protect", "roost", "substitute"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	kyuremwhite: {
 		randomBattleMoves: ["dracometeor", "earthpower", "focusblast", "fusionflare", "icebeam", "roost", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "earthpower", "focusblast", "fusionflare", "icebeam", "protect", "roost"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	keldeo: {
 		randomBattleMoves: ["calmmind", "hiddenpowerelectric", "hydropump", "icywind", "scald", "secretsword", "substitute"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["hiddenpowerelectric", "hiddenpowerflying", "hydropump", "icywind", "protect", "secretsword", "substitute", "surf", "taunt"],
 		tier: "OU",
 		doublesTier: "DOU",
@@ -3501,16 +3936,19 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	meloetta: {
 		randomBattleMoves: ["calmmind", "focusblast", "hypervoice", "psyshock", "shadowball", "trick", "uturn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["calmmind", "focusblast", "hypervoice", "protect", "psyshock", "shadowball", "thunderbolt"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	meloettapirouette: {
 		randomBattleMoves: ["closecombat", "knockoff", "relicsong", "return"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["closecombat", "knockoff", "protect", "relicsong", "return"],
 	},
 	genesect: {
 		randomBattleMoves: ["blazekick", "extremespeed", "flamethrower", "icebeam", "ironhead", "shiftgear", "technoblast", "thunderbolt", "uturn"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["blazekick", "bugbuzz", "extremespeed", "flamethrower", "icebeam", "ironhead", "protect", "shiftgear", "thunderbolt", "uturn"],
 		tier: "Uber",
 		doublesTier: "DUU",
@@ -3539,6 +3977,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	chesnaught: {
 		randomBattleMoves: ["drainpunch", "leechseed", "spikes", "spikyshield", "synthesis", "woodhammer"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["hammerarm", "leechseed", "rockslide", "spikyshield", "stoneedge", "synthesis", "woodhammer"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -3551,6 +3990,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	delphox: {
 		randomBattleMoves: ["calmmind", "fireblast", "grassknot", "psyshock", "shadowball", "switcheroo"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["calmmind", "dazzlinggleam", "fireblast", "grassknot", "heatwave", "protect", "psyshock", "shadowball", "switcheroo"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -3563,6 +4003,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	greninja: {
 		randomBattleMoves: ["gunkshot", "hydropump", "icebeam", "spikes", "taunt", "toxicspikes", "uturn"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["darkpulse", "hydropump", "icebeam", "matblock", "protect", "surf", "taunt", "uturn"],
 		tier: "Uber",
 		doublesTier: "(DUU)",
@@ -3572,6 +4013,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	diggersby: {
 		randomBattleMoves: ["agility", "earthquake", "knockoff", "quickattack", "return", "swordsdance", "uturn", "wildcharge"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthquake", "protect", "quickattack", "return", "uturn", "wildcharge"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
@@ -3585,6 +4027,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	talonflame: {
 		randomBattleMoves: ["bravebird", "flareblitz", "roost", "swordsdance", "tailwind", "uturn", "willowisp"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["bravebird", "flareblitz", "protect", "roost", "swordsdance", "tailwind", "taunt", "uturn", "willowisp"],
 		tier: "OU",
 		doublesTier: "DOU",
@@ -3597,6 +4040,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vivillon: {
 		randomBattleMoves: ["energyball", "hurricane", "quiverdance", "sleeppowder", "substitute"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["bugbuzz", "hurricane", "protect", "quiverdance", "roost", "sleeppowder"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -3606,6 +4050,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	pyroar: {
 		randomBattleMoves: ["darkpulse", "fireblast", "hypervoice", "solarbeam", "sunnyday", "willowisp"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["fireblast", "hypervoice", "protect", "solarbeam", "sunnyday", "willowisp"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -3618,12 +4063,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	floetteeternal: {
 		randomBattleMoves: ["hiddenpowerfire", "hiddenpowerground", "lightofruin", "moonblast", "psychic"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["aromatherapy", "calmmind", "dazzlinggleam", "lightofruin", "protect", "psychic", "wish"],
 		isNonstandard: "Unobtainable",
 		tier: "Illegal",
 	},
 	florges: {
 		randomBattleMoves: ["aromatherapy", "calmmind", "moonblast", "protect", "synthesis", "toxic", "wish"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["aromatherapy", "calmmind", "dazzlinggleam", "moonblast", "protect", "psychic", "wish"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -3633,6 +4080,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gogoat: {
 		randomBattleMoves: ["bulkup", "earthquake", "hornleech", "leechseed", "milkdrink", "rockslide", "substitute"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["brickbreak", "bulkup", "earthquake", "hornleech", "leechseed", "milkdrink", "protect", "rockslide"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3642,12 +4090,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	pangoro: {
 		randomBattleMoves: ["drainpunch", "gunkshot", "icepunch", "knockoff", "partingshot", "superpower"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["circlethrow", "crunch", "earthquake", "hammerarm", "icepunch", "partingshot", "poisonjab", "protect"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
 	},
 	furfrou: {
 		randomBattleMoves: ["cottonguard", "rest", "return", "substitute", "suckerpunch", "thunderwave", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["cottonguard", "protect", "return", "snarl", "suckerpunch", "thunderwave", "uturn", "wildcharge"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3657,12 +4107,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	meowstic: {
 		randomBattleMoves: ["healbell", "lightscreen", "psychic", "reflect", "thunderwave", "toxic", "yawn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["fakeout", "lightscreen", "protect", "psychic", "reflect", "safeguard", "thunderwave"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	meowsticf: {
 		randomBattleMoves: ["calmmind", "energyball", "psychic", "psyshock", "shadowball", "thunderbolt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["darkpulse", "energyball", "fakeout", "helpinghand", "protect", "psyshock", "signalbeam", "thunderbolt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3672,18 +4124,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	doublade: {
 		randomBattleMoves: ["ironhead", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["ironhead", "protect", "rockslide", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"],
 		tier: "UU",
 		doublesTier: "NFE",
 	},
 	aegislash: {
 		randomBattleMoves: ["flashcannon", "hiddenpowerice", "kingsshield", "shadowball", "shadowsneak"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["flashcannon", "hiddenpowerice", "kingsshield", "shadowball", "shadowsneak"],
 		tier: "Uber",
 		doublesTier: "DOU",
 	},
 	aegislashblade: {
 		randomBattleMoves: ["ironhead", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["ironhead", "kingsshield", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"],
 	},
 	spritzee: {
@@ -3691,6 +4146,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	aromatisse: {
 		randomBattleMoves: ["aromatherapy", "moonblast", "protect", "toxic", "wish"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["aromatherapy", "healpulse", "moonblast", "protect", "thunderbolt", "trickroom", "wish"],
 		tier: "RU",
 		doublesTier: "DUU",
@@ -3700,6 +4156,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	slurpuff: {
 		randomBattleMoves: ["bellydrum", "drainpunch", "playrough", "return"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["bellydrum", "dazzlinggleam", "drainpunch", "flamethrower", "playrough", "protect", "psychic", "return", "surf"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
@@ -3709,6 +4166,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	malamar: {
 		randomBattleMoves: ["knockoff", "psychocut", "rest", "sleeptalk", "superpower"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["knockoff", "protect", "psychocut", "rockslide", "superpower", "trickroom"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -3718,6 +4176,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	barbaracle: {
 		randomBattleMoves: ["crosschop", "earthquake", "razorshell", "shellsmash", "stealthrock", "stoneedge"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["crosschop", "earthquake", "protect", "razorshell", "rockslide", "shellsmash"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -3727,6 +4186,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dragalge: {
 		randomBattleMoves: ["dracometeor", "dragonpulse", "focusblast", "hiddenpowerfire", "scald", "sludgewave", "toxicspikes"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "focusblast", "hiddenpowerfire", "protect", "scald", "sludgebomb"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
@@ -3736,6 +4196,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	clawitzer: {
 		randomBattleMoves: ["aurasphere", "darkpulse", "icebeam", "scald", "uturn", "waterpulse"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["aurasphere", "darkpulse", "helpinghand", "icebeam", "muddywater", "protect", "uturn", "waterpulse"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -3745,6 +4206,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	heliolisk: {
 		randomBattleMoves: ["darkpulse", "hiddenpowerice", "hypervoice", "raindance", "surf", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["darkpulse", "hiddenpowerice", "protect", "raindance", "surf", "thunder", "thunderbolt", "voltswitch"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -3754,6 +4216,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	tyrantrum: {
 		randomBattleMoves: ["dragonclaw", "dragondance", "earthquake", "headsmash", "outrage", "stealthrock", "superpower"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["dragonclaw", "dragondance", "earthquake", "firefang", "headsmash", "icefang", "protect", "rockslide"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
@@ -3763,30 +4226,35 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	aurorus: {
 		randomBattleMoves: ["ancientpower", "blizzard", "earthpower", "freezedry", "hypervoice", "stealthrock", "thunderwave"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["ancientpower", "flashcannon", "freezedry", "hypervoice", "icywind", "protect", "thunderwave"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	sylveon: {
 		randomBattleMoves: ["calmmind", "hiddenpowerfire", "hypervoice", "protect", "psyshock", "wish"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["calmmind", "helpinghand", "hiddenpowerground", "hypervoice", "protect", "psyshock", "shadowball", "wish"],
 		tier: "UU",
 		doublesTier: "DOU",
 	},
 	hawlucha: {
 		randomBattleMoves: ["acrobatics", "highjumpkick", "roost", "stoneedge", "substitute", "swordsdance"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["encore", "highjumpkick", "protect", "skydrop", "stoneedge", "swordsdance", "uturn"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
 	},
 	dedenne: {
 		randomBattleMoves: ["grassknot", "hiddenpowerice", "nuzzle", "recycle", "substitute", "thunderbolt", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["grassknot", "helpinghand", "hiddenpowerice", "nuzzle", "protect", "thunderbolt", "uturn", "voltswitch"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	carbink: {
 		randomBattleMoves: ["explosion", "lightscreen", "moonblast", "powergem", "reflect", "stealthrock"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["explosion", "lightscreen", "moonblast", "powergem", "protect", "reflect", "trickroom"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3799,12 +4267,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	goodra: {
 		randomBattleMoves: ["dracometeor", "dragontail", "earthquake", "fireblast", "powerwhip", "sludgebomb", "thunderbolt"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "fireblast", "focusblast", "icebeam", "muddywater", "protect", "thunderbolt"],
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	klefki: {
 		randomBattleMoves: ["foulplay", "lightscreen", "playrough", "reflect", "spikes", "thunderwave", "toxic"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["dazzlinggleam", "flashcannon", "lightscreen", "playrough", "protect", "reflect", "safeguard", "substitute", "thunderwave"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -3814,6 +4284,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	trevenant: {
 		randomBattleMoves: ["earthquake", "hornleech", "rest", "rockslide", "shadowclaw", "trickroom", "woodhammer"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "hornleech", "leechseed", "protect", "rockslide", "shadowclaw", "trickroom", "willowisp", "woodhammer"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -3832,24 +4303,28 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gourgeist: {
 		randomBattleMoves: ["leechseed", "seedbomb", "shadowsneak", "substitute", "synthesis", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["explosion", "leechseed", "painsplit", "phantomforce", "protect", "seedbomb", "shadowsneak", "willowisp"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	gourgeistsmall: {
 		randomBattleMoves: ["leechseed", "seedbomb", "shadowsneak", "substitute", "synthesis", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["explosion", "leechseed", "painsplit", "phantomforce", "protect", "seedbomb", "shadowsneak", "willowisp"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	gourgeistlarge: {
 		randomBattleMoves: ["leechseed", "seedbomb", "shadowsneak", "substitute", "synthesis", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["explosion", "leechseed", "painsplit", "phantomforce", "protect", "seedbomb", "shadowsneak", "trickroom", "willowisp"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	gourgeistsuper: {
 		randomBattleMoves: ["leechseed", "seedbomb", "shadowsneak", "substitute", "synthesis", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["explosion", "leechseed", "painsplit", "phantomforce", "protect", "seedbomb", "shadowsneak", "trickroom", "willowisp"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -3859,6 +4334,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	avalugg: {
 		randomBattleMoves: ["avalanche", "earthquake", "rapidspin", "recover", "roar", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["avalanche", "earthquake", "protect", "recover"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -3868,54 +4344,63 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	noivern: {
 		randomBattleMoves: ["boomburst", "dracometeor", "flamethrower", "hurricane", "roost", "switcheroo", "taunt", "uturn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["airslash", "boomburst", "dracometeor", "dragonpulse", "flamethrower", "focusblast", "hurricane", "protect", "roost", "switcheroo", "tailwind", "taunt", "uturn"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
 	},
 	xerneas: {
 		randomBattleMoves: ["focusblast", "geomancy", "hiddenpowerfire", "moonblast", "psyshock", "thunderbolt"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["closecombat", "dazzlinggleam", "focusblast", "geomancy", "hiddenpowerfire", "protect", "psyshock", "rockslide", "thunder", "thunderbolt"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	yveltal: {
 		randomBattleMoves: ["darkpulse", "foulplay", "oblivionwing", "roost", "suckerpunch", "taunt", "toxic", "uturn"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["darkpulse", "focusblast", "hurricane", "oblivionwing", "protect", "roost", "skydrop", "snarl", "suckerpunch", "taunt"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	zygarde: {
 		randomBattleMoves: ["dragondance", "earthquake", "extremespeed", "glare", "outrage", "stoneedge"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["coil", "dragondance", "extremespeed", "glare", "landswrath", "protect", "rockslide", "stoneedge"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
 	},
 	diancie: {
 		randomBattleMoves: ["diamondstorm", "earthpower", "hiddenpowerfire", "lightscreen", "moonblast", "reflect", "stealthrock"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["calmmind", "dazzlinggleam", "diamondstorm", "lightscreen", "moonblast", "protect", "psychic", "reflect", "safeguard", "substitute"],
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	dianciemega: {
 		randomBattleMoves: ["calmmind", "diamondstorm", "earthpower", "hiddenpowerfire", "moonblast"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["calmmind", "dazzlinggleam", "diamondstorm", "earthpower", "hiddenpowerfire", "moonblast", "protect", "psyshock"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	hoopa: {
 		randomBattleMoves: ["focusblast", "nastyplot", "psyshock", "shadowball", "trick"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["focusblast", "hyperspacehole", "protect", "psychic", "shadowball", "trickroom"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	hoopaunbound: {
 		randomBattleMoves: ["darkpulse", "drainpunch", "focusblast", "gunkshot", "hyperspacefury", "nastyplot", "psychic", "substitute", "trick", "zenheadbutt"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["darkpulse", "drainpunch", "focusblast", "gunkshot", "hyperspacefury", "icepunch", "protect", "psychic", "zenheadbutt"],
 		tier: "Uber",
 		doublesTier: "DOU",
 	},
 	volcanion: {
 		randomBattleMoves: ["earthpower", "fireblast", "hiddenpowerice", "sludgewave", "steameruption", "substitute", "superpower"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["earthquake", "heatwave", "protect", "rockslide", "sludgebomb", "steameruption", "substitute"],
 		tier: "OU",
 		doublesTier: "DOU",

--- a/data/mods/gen6/formats-data.ts
+++ b/data/mods/gen6/formats-data.ts
@@ -3487,7 +3487,6 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	zoroark: {
 		randomBattleMoves: ["darkpulse", "flamethrower", "focusblast", "nastyplot", "sludgebomb", "trick"],
-		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["darkpulse", "flamethrower", "focusblast", "knockoff", "nastyplot", "protect", "suckerpunch", "uturn"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -1087,21 +1087,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			item = 'Black Sludge';
 		}
 
-		const levelScale: {[k: string]: number} = {
-			uber: 76, ou: 80, uu: 82, ru: 84, nu: 86, pu: 88,
-		};
-		const customScale: {[k: string]: number} = {
-			// Banned Ability
-			Dugtrio: 82, Gothitelle: 82, Ninetales: 84, Politoed: 84, Wobbuffet: 82,
-			// Holistic judgement
-			'Castform-Rainy': 100, 'Castform-Snowy': 100, 'Castform-Sunny': 100, Delibird: 100, 'Genesect-Douse': 80, Luvdisc: 100, Spinda: 100, Unown: 100,
-		};
-		const tier = toID(species.tier).replace('bl', '');
-		const level = this.adjustLevel ||
-					  species.randomBattleLevel ||
-					  customScale[species.name] ||
-					  levelScale[tier] ||
-					  (species.nfe ? 90 : 80);
+		const level = this.adjustLevel || species.randomBattleLevel || (species.nfe ? 90 : 80);
 
 		// Prepare optimal HP
 		const srWeakness = this.dex.getEffectiveness('Rock', species);

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -1097,7 +1097,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			'Castform-Rainy': 100, 'Castform-Snowy': 100, 'Castform-Sunny': 100, Delibird: 100, 'Genesect-Douse': 80, Luvdisc: 100, Spinda: 100, Unown: 100,
 		};
 		const tier = toID(species.tier).replace('bl', '');
-		const level = this.adjustLevel || customScale[species.name] || levelScale[tier] || (species.nfe ? 90 : 80);
+		const level = this.adjustLevel || species.randomBattleLevel || customScale[species.name] || levelScale[tier] || (species.nfe ? 90 : 80);
 
 		// Prepare optimal HP
 		const srWeakness = this.dex.getEffectiveness('Rock', species);

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -1097,7 +1097,11 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			'Castform-Rainy': 100, 'Castform-Snowy': 100, 'Castform-Sunny': 100, Delibird: 100, 'Genesect-Douse': 80, Luvdisc: 100, Spinda: 100, Unown: 100,
 		};
 		const tier = toID(species.tier).replace('bl', '');
-		const level = this.adjustLevel || species.randomBattleLevel || customScale[species.name] || levelScale[tier] || (species.nfe ? 90 : 80);
+		const level = this.adjustLevel ||
+					  species.randomBattleLevel ||
+					  customScale[species.name] ||
+					  levelScale[tier] ||
+					  (species.nfe ? 90 : 80);
 
 		// Prepare optimal HP
 		const srWeakness = this.dex.getEffectiveness('Rock', species);

--- a/data/mods/gen7/formats-data.ts
+++ b/data/mods/gen7/formats-data.ts
@@ -3594,7 +3594,6 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	zoroark: {
 		randomBattleMoves: ["darkpulse", "flamethrower", "focusblast", "nastyplot", "sludgebomb", "trick"],
-		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["darkpulse", "flamethrower", "focusblast", "knockoff", "nastyplot", "protect", "suckerpunch", "uturn"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",

--- a/data/mods/gen7/formats-data.ts
+++ b/data/mods/gen7/formats-data.ts
@@ -7,12 +7,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	venusaur: {
 		randomBattleMoves: ["gigadrain", "leechseed", "sleeppowder", "sludgebomb", "substitute"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "powerwhip", "protect", "sleeppowder", "sludgebomb"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	venusaurmega: {
 		randomBattleMoves: ["earthquake", "gigadrain", "hiddenpowerfire", "leechseed", "sludgebomb", "synthesis"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "powerwhip", "protect", "sleeppowder", "sludgebomb"],
 		tier: "UUBL",
 		doublesTier: "DUU",
@@ -25,18 +27,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	charizard: {
 		randomBattleMoves: ["airslash", "earthquake", "fireblast", "holdhands", "roost"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "fireblast", "focusblast", "heatwave", "holdhands", "protect", "roost"],
 		tier: "PUBL",
 		doublesTier: "(DUU)",
 	},
 	charizardmegax: {
 		randomBattleMoves: ["dragonclaw", "dragondance", "earthquake", "flareblitz", "roost", "willowisp"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dragonclaw", "dragondance", "flareblitz", "rockslide", "roost", "thunderpunch"],
 		tier: "OU",
 		doublesTier: "(DUU)",
 	},
 	charizardmegay: {
 		randomBattleMoves: ["airslash", "dragonpulse", "fireblast", "focusblast", "roost", "solarbeam"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["airslash", "fireblast", "focusblast", "heatwave", "protect", "solarbeam"],
 		tier: "OU",
 		doublesTier: "DOU",
@@ -49,12 +54,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	blastoise: {
 		randomBattleMoves: ["dragontail", "icebeam", "rapidspin", "roar", "scald", "toxic"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["fakeout", "followme", "icywind", "muddywater", "protect", "rapidspin", "scald"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	blastoisemega: {
 		randomBattleMoves: ["aurasphere", "darkpulse", "icebeam", "rapidspin", "waterpulse"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["aurasphere", "darkpulse", "fakeout", "icebeam", "muddywater", "protect", "waterpulse"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -67,6 +74,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	butterfree: {
 		randomBattleMoves: ["airslash", "bugbuzz", "energyball", "quiverdance", "sleeppowder"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "bugbuzz", "protect", "quiverdance", "sleeppowder"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -79,12 +87,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	beedrill: {
 		randomBattleMoves: ["endeavor", "knockoff", "poisonjab", "tailwind", "toxicspikes", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["knockoff", "poisonjab", "protect", "tailwind", "toxicspikes", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	beedrillmega: {
 		randomBattleMoves: ["drillrun", "knockoff", "poisonjab", "swordsdance", "uturn", "xscissor"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["drillrun", "knockoff", "poisonjab", "protect", "uturn", "xscissor"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -97,12 +107,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	pidgeot: {
 		randomBattleMoves: ["bravebird", "defog", "heatwave", "return", "roost", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bravebird", "doubleedge", "heatwave", "protect", "return", "tailwind", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	pidgeotmega: {
 		randomBattleMoves: ["defog", "heatwave", "hurricane", "roost", "uturn"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["heatwave", "hurricane", "protect", "tailwind", "uturn"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -115,12 +127,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	raticate: {
 		randomBattleMoves: ["facade", "protect", "stompingtantrum", "suckerpunch", "swordsdance", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["crunch", "facade", "protect", "stompingtantrum", "suckerpunch", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	raticatealola: {
 		randomBattleMoves: ["doubleedge", "knockoff", "return", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["doubleedge", "knockoff", "protect", "suckerpunch", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -134,6 +148,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	fearow: {
 		randomBattleMoves: ["doubleedge", "drillpeck", "drillrun", "pursuit", "return", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["doubleedge", "drillpeck", "drillrun", "protect", "quickattack", "return", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -143,6 +158,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	arbok: {
 		randomBattleMoves: ["aquatail", "coil", "earthquake", "gunkshot", "rest", "suckerpunch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aquatail", "coil", "gunkshot", "protect", "stompingtantrum", "suckerpunch"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -152,6 +168,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	pikachu: {
 		randomBattleMoves: ["extremespeed", "grassknot", "hiddenpowerice", "irontail", "knockoff", "voltswitch", "volttackle"],
+		randomBattleLevel: 90,
 		randomDoubleBattleMoves: ["encore", "fakeout", "grassknot", "hiddenpowerice", "knockoff", "protect", "voltswitch", "volttackle"],
 		tier: "NFE",
 	},
@@ -185,12 +202,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	raichu: {
 		randomBattleMoves: ["encore", "focusblast", "grassknot", "hiddenpowerice", "nastyplot", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["encore", "fakeout", "focusblast", "grassknot", "hiddenpowerice", "protect", "thunderbolt", "voltswitch"],
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	raichualola: {
 		randomBattleMoves: ["focusblast", "nastyplot", "psyshock", "surf", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["fakeout", "grassknot", "nastyplot", "protect", "psyshock", "thunderbolt", "voltswitch"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -203,12 +222,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sandslash: {
 		randomBattleMoves: ["earthquake", "knockoff", "rapidspin", "stealthrock", "stoneedge", "swordsdance", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "knockoff", "protect", "stealthrock", "stoneedge", "swordsdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	sandslashalola: {
 		randomBattleMoves: ["earthquake", "iciclecrash", "ironhead", "knockoff", "rapidspin", "stealthrock", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["drillrun", "iciclecrash", "ironhead", "protect", "swordsdance"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -221,6 +242,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	nidoqueen: {
 		randomBattleMoves: ["earthpower", "fireblast", "icebeam", "sludgewave", "stealthrock", "toxicspikes"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["earthpower", "icebeam", "protect", "sludgebomb", "stealthrock"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -233,6 +255,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	nidoking: {
 		randomBattleMoves: ["earthpower", "fireblast", "icebeam", "sludgewave", "substitute", "superpower"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthpower", "fireblast", "icebeam", "protect", "sludgebomb"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -246,6 +269,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	clefable: {
 		randomBattleMoves: ["calmmind", "fireblast", "moonblast", "softboiled", "stealthrock", "thunderwave"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dazzlinggleam", "fireblast", "followme", "helpinghand", "moonblast", "protect", "softboiled", "thunderwave"],
 		tier: "OU",
 		doublesTier: "DUU",
@@ -258,12 +282,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ninetales: {
 		randomBattleMoves: ["fireblast", "hiddenpowerice", "nastyplot", "solarbeam", "substitute", "willowisp"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["fireblast", "heatwave", "nastyplot", "protect", "solarbeam", "willowisp"],
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	ninetalesalola: {
 		randomBattleMoves: ["auroraveil", "blizzard", "freezedry", "hiddenpowerfire", "moonblast", "nastyplot"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["auroraveil", "blizzard", "encore", "freezedry", "hiddenpowerfire", "moonblast", "protect"],
 		tier: "UUBL",
 		doublesTier: "DOU",
@@ -276,6 +302,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wigglytuff: {
 		randomBattleMoves: ["dazzlinggleam", "fireblast", "healbell", "lightscreen", "reflect", "stealthrock"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["dazzlinggleam", "fireblast", "hypervoice", "protect", "stealthrock", "thunderwave"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -289,6 +316,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	crobat: {
 		randomBattleMoves: ["bravebird", "defog", "roost", "superfang", "taunt", "toxic", "uturn"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["bravebird", "protect", "superfang", "tailwind", "taunt", "uturn"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -301,12 +329,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vileplume: {
 		randomBattleMoves: ["aromatherapy", "gigadrain", "hiddenpowerfire", "sleeppowder", "sludgebomb", "strengthsap"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["energyball", "hiddenpowerfire", "protect", "sleeppowder", "sludgebomb", "strengthsap"],
 		tier: "NUBL",
 		doublesTier: "(DUU)",
 	},
 	bellossom: {
 		randomBattleMoves: ["gigadrain", "hiddenpowerground", "moonblast", "quiverdance", "sleeppowder", "strengthsap"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["energyball", "moonblast", "quiverdance", "sleeppowder", "strengthsap"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -316,6 +346,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	parasect: {
 		randomBattleMoves: ["knockoff", "leechlife", "leechseed", "seedbomb", "spore", "substitute"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["knockoff", "leechlife", "leechseed", "protect", "ragepowder", "seedbomb", "spore", "wideguard"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -325,6 +356,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	venomoth: {
 		randomBattleMoves: ["bugbuzz", "quiverdance", "sleeppowder", "sludgebomb", "substitute"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["bugbuzz", "protect", "quiverdance", "ragepowder", "sleeppowder", "sludgebomb"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
@@ -337,12 +369,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dugtrio: {
 		randomBattleMoves: ["earthquake", "reversal", "stealthrock", "stoneedge", "substitute", "suckerpunch"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthquake", "protect", "rockslide", "stoneedge", "suckerpunch"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	dugtrioalola: {
 		randomBattleMoves: ["earthquake", "ironhead", "stealthrock", "stoneedge", "substitute", "suckerpunch", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "ironhead", "protect", "rockslide", "stoneedge", "suckerpunch"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -355,12 +389,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	persian: {
 		randomBattleMoves: ["fakeout", "knockoff", "return", "taunt", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["fakeout", "hypnosis", "knockoff", "protect", "return", "taunt", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	persianalola: {
 		randomBattleMoves: ["darkpulse", "hypnosis", "nastyplot", "powergem", "thunderbolt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["fakeout", "foulplay", "hiddenpowerfighting", "icywind", "partingshot", "protect", "snarl"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -370,6 +406,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	golduck: {
 		randomBattleMoves: ["calmmind", "encore", "hydropump", "icebeam", "psyshock", "scald", "substitute"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["calmmind", "encore", "focusblast", "hydropump", "icebeam", "protect", "scald"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -379,6 +416,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	primeape: {
 		randomBattleMoves: ["closecombat", "earthquake", "gunkshot", "icepunch", "stoneedge", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["closecombat", "icepunch", "poisonjab", "protect", "rockslide", "stompingtantrum", "stoneedge", "taunt", "uturn"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -388,6 +426,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	arcanine: {
 		randomBattleMoves: ["closecombat", "extremespeed", "flareblitz", "morningsun", "roar", "toxic", "wildcharge", "willowisp"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["closecombat", "extremespeed", "flareblitz", "protect", "snarl", "wildcharge", "willowisp"],
 		tier: "RU",
 		doublesTier: "DUU",
@@ -400,12 +439,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	poliwrath: {
 		randomBattleMoves: ["circlethrow", "focusblast", "hydropump", "icepunch", "raindance", "rest", "scald", "sleeptalk"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["circlethrow", "encore", "icywind", "protect", "scald", "superpower", "toxic"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	politoed: {
 		randomBattleMoves: ["encore", "icebeam", "protect", "rest", "scald", "toxic"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["encore", "helpinghand", "hypnosis", "icywind", "protect", "scald"],
 		tier: "(PU)",
 		doublesTier: "DOU",
@@ -418,12 +459,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	alakazam: {
 		randomBattleMoves: ["focusblast", "hiddenpowerfire", "psychic", "psyshock", "shadowball"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["dazzlinggleam", "encore", "focusblast", "protect", "psychic", "shadowball"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
 	},
 	alakazammega: {
 		randomBattleMoves: ["calmmind", "encore", "focusblast", "psychic", "psyshock", "shadowball", "substitute"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["calmmind", "encore", "focusblast", "protect", "psychic", "shadowball"],
 		tier: "OU",
 		doublesTier: "(DUU)",
@@ -436,6 +479,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	machamp: {
 		randomBattleMoves: ["bulletpunch", "closecombat", "dynamicpunch", "facade", "knockoff", "stoneedge"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["bulletpunch", "closecombat", "facade", "knockoff", "protect", "stoneedge", "wideguard"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -448,6 +492,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	victreebel: {
 		randomBattleMoves: ["hiddenpowerfire", "poisonjab", "powerwhip", "sleeppowder", "sludgebomb", "strengthsap", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["growth", "knockoff", "powerwhip", "protect", "sleeppowder", "sludgebomb", "solarbeam", "suckerpunch", "sunnyday", "weatherball"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -457,6 +502,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	tentacruel: {
 		randomBattleMoves: ["acidspray", "knockoff", "rapidspin", "scald", "sludgebomb", "toxicspikes"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["acidspray", "knockoff", "muddywater", "protect", "rapidspin", "scald", "sludgebomb"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -475,12 +521,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	golem: {
 		randomBattleMoves: ["earthquake", "explosion", "rockblast", "stealthrock", "suckerpunch", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "protect", "rockslide", "stealthrock", "stoneedge", "suckerpunch"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	golemalola: {
 		randomBattleMoves: ["earthquake", "firepunch", "stealthrock", "stoneedge", "wildcharge"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["doubleedge", "protect", "rockslide", "stealthrock", "stompingtantrum", "stoneedge"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -490,6 +538,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	rapidash: {
 		randomBattleMoves: ["flareblitz", "highhorsepower", "morningsun", "wildcharge", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["flareblitz", "highhorsepower", "hypnosis", "protect", "wildcharge", "willowisp"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -499,18 +548,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	slowbro: {
 		randomBattleMoves: ["fireblast", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["protect", "psychic", "psyshock", "scald", "slackoff", "thunderwave", "toxic"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	slowbromega: {
 		randomBattleMoves: ["calmmind", "fireblast", "psyshock", "scald", "slackoff"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["fireblast", "icebeam", "protect", "psychic", "psyshock", "scald", "slackoff", "trickroom"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
 	},
 	slowking: {
 		randomBattleMoves: ["dragontail", "fireblast", "icebeam", "nastyplot", "psyshock", "scald", "slackoff", "thunderwave", "toxic", "trickroom"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["fireblast", "protect", "psychic", "psyshock", "scald", "trickroom"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -524,12 +576,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	magnezone: {
 		randomBattleMoves: ["flashcannon", "hiddenpowerfire", "substitute", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["electroweb", "flashcannon", "hiddenpowerfire", "protect", "thunderbolt", "voltswitch"],
 		tier: "OU",
 		doublesTier: "(DUU)",
 	},
 	farfetchd: {
 		randomBattleMoves: ["bravebird", "knockoff", "leafblade", "return", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bravebird", "knockoff", "leafblade", "protect", "return", "swordsdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -539,6 +593,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dodrio: {
 		randomBattleMoves: ["bravebird", "jumpkick", "knockoff", "quickattack", "return", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bravebird", "knockoff", "protect", "quickattack", "return", "swordsdance"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -548,6 +603,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dewgong: {
 		randomBattleMoves: ["encore", "icebeam", "perishsong", "protect", "surf", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["encore", "fakeout", "helpinghand", "icebeam", "icywind", "liquidation", "protect", "toxic"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -560,12 +616,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	muk: {
 		randomBattleMoves: ["curse", "firepunch", "gunkshot", "icepunch", "memento", "poisonjab", "shadowsneak"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["firepunch", "gunkshot", "icepunch", "poisonjab", "protect", "shadowsneak"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	mukalola: {
 		randomBattleMoves: ["curse", "firepunch", "gunkshot", "icepunch", "knockoff", "poisonjab", "pursuit", "shadowsneak"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["gunkshot", "knockoff", "poisonjab", "protect", "shadowsneak", "snarl", "stoneedge"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -575,6 +633,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cloyster: {
 		randomBattleMoves: ["hydropump", "iciclespear", "rapidspin", "rockblast", "shellsmash", "spikes"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["hydropump", "iciclespear", "protect", "rockblast", "shellsmash"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -588,12 +647,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gengar: {
 		randomBattleMoves: ["disable", "focusblast", "painsplit", "shadowball", "sludgewave", "substitute", "willowisp"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["focusblast", "protect", "shadowball", "sludgebomb", "taunt", "willowisp"],
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	gengarmega: {
 		randomBattleMoves: ["destinybond", "disable", "focusblast", "perishsong", "protect", "shadowball", "sludgewave", "taunt"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["disable", "focusblast", "hypnosis", "protect", "shadowball", "sludgebomb", "willowisp"],
 		tier: "Uber",
 		doublesTier: "DUber",
@@ -603,12 +664,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	steelix: {
 		randomBattleMoves: ["earthquake", "ironhead", "roar", "rockslide", "stealthrock", "toxic"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["earthquake", "headsmash", "heavyslam", "protect", "stealthrock", "wideguard"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	steelixmega: {
 		randomBattleMoves: ["dragontail", "earthquake", "heavyslam", "roar", "stealthrock", "toxic"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthquake", "heavyslam", "protect", "rockslide", "stealthrock"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -618,6 +681,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hypno: {
 		randomBattleMoves: ["foulplay", "protect", "psychic", "seismictoss", "thunderwave", "toxic", "wish"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["hypnosis", "protect", "psychic", "seismictoss", "thunderwave"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -627,6 +691,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kingler: {
 		randomBattleMoves: ["agility", "knockoff", "liquidation", "rockslide", "superpower", "swordsdance", "xscissor"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["agility", "knockoff", "liquidation", "protect", "rockslide", "wideguard", "xscissor"],
 		tier: "PUBL",
 		doublesTier: "(DUU)",
@@ -636,6 +701,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	electrode: {
 		randomBattleMoves: ["foulplay", "hiddenpowergrass", "hiddenpowerice", "signalbeam", "taunt", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["foulplay", "protect", "taunt", "thunderbolt", "thunderwave", "voltswitch"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -645,12 +711,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	exeggutor: {
 		randomBattleMoves: ["gigadrain", "hiddenpowerfire", "leechseed", "psychic", "sleeppowder", "substitute"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["energyball", "hiddenpowerfire", "leechseed", "protect", "psychic", "sleeppowder", "substitute", "trickroom"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	exeggutoralola: {
 		randomBattleMoves: ["dracometeor", "flamethrower", "gigadrain", "leafstorm", "trickroom"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["dracometeor", "dragonhammer", "flamethrower", "leafstorm", "protect", "trickroom", "woodhammer"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -660,12 +728,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	marowak: {
 		randomBattleMoves: ["bonemerang", "doubleedge", "earthquake", "knockoff", "stealthrock", "stoneedge", "substitute"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bonemerang", "doubleedge", "firepunch", "protect", "rockslide", "stealthrock", "swordsdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	marowakalola: {
 		randomBattleMoves: ["bonemerang", "flamecharge", "flareblitz", "shadowbone", "stoneedge", "substitute", "willowisp"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["bonemerang", "flareblitz", "protect", "shadowbone", "stoneedge", "willowisp"],
 		tier: "RU",
 		doublesTier: "DUU",
@@ -679,18 +749,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hitmonlee: {
 		randomBattleMoves: ["highjumpkick", "knockoff", "machpunch", "poisonjab", "rapidspin", "stoneedge"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["closecombat", "fakeout", "knockoff", "machpunch", "protect", "rockslide"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	hitmonchan: {
 		randomBattleMoves: ["bulkup", "drainpunch", "icepunch", "machpunch", "rapidspin", "stoneedge"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["drainpunch", "fakeout", "firepunch", "icepunch", "machpunch", "protect"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	hitmontop: {
 		randomBattleMoves: ["closecombat", "rapidspin", "stoneedge", "suckerpunch", "toxic"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["closecombat", "fakeout", "feint", "helpinghand", "machpunch", "rapidspin", "suckerpunch", "wideguard"],
 		tier: "NU",
 		doublesTier: "DUU",
@@ -700,6 +773,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lickilicky: {
 		randomBattleMoves: ["bodyslam", "dragontail", "earthquake", "explosion", "healbell", "knockoff", "powerwhip", "protect", "swordsdance", "wish"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bodyslam", "dragontail", "explosion", "knockoff", "powerwhip", "protect", "stompingtantrum"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -709,6 +783,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	weezing: {
 		randomBattleMoves: ["fireblast", "painsplit", "sludgebomb", "toxicspikes", "willowisp"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["fireblast", "painsplit", "protect", "sludgebomb", "toxicspikes", "willowisp"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -718,11 +793,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	rhydon: {
 		randomBattleMoves: ["earthquake", "megahorn", "stealthrock", "stoneedge", "toxic"],
+		randomBattleLevel: 86,
 		tier: "NU",
 		doublesTier: "NFE",
 	},
 	rhyperior: {
 		randomBattleMoves: ["dragontail", "earthquake", "icepunch", "megahorn", "rockpolish", "stoneedge"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["earthquake", "icepunch", "megahorn", "protect", "rockslide", "stealthrock", "stoneedge"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -732,12 +809,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	chansey: {
 		randomBattleMoves: ["healbell", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic", "wish"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["helpinghand", "protect", "seismictoss", "softboiled", "thunderwave", "toxic"],
 		tier: "OU",
 		doublesTier: "NFE",
 	},
 	blissey: {
 		randomBattleMoves: ["healbell", "seismictoss", "softboiled", "stealthrock", "toxic"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["helpinghand", "protect", "seismictoss", "softboiled", "thunderwave", "toxic"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -748,18 +827,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	tangrowth: {
 		randomBattleMoves: ["earthquake", "gigadrain", "hiddenpowerfire", "knockoff", "leafstorm", "rockslide", "sleeppowder", "synthesis"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["earthquake", "focusblast", "gigadrain", "hiddenpowerice", "knockoff", "leechseed", "powerwhip", "protect", "ragepowder", "sleeppowder"],
 		tier: "OU",
 		doublesTier: "(DUU)",
 	},
 	kangaskhan: {
 		randomBattleMoves: ["crunch", "drainpunch", "earthquake", "fakeout", "return", "suckerpunch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["crunch", "doubleedge", "drainpunch", "earthquake", "fakeout", "protect", "return", "suckerpunch"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	kangaskhanmega: {
 		randomBattleMoves: ["bodyslam", "crunch", "fakeout", "seismictoss", "suckerpunch"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["drainpunch", "earthquake", "fakeout", "poweruppunch", "protect", "return", "suckerpunch"],
 		tier: "Uber",
 		doublesTier: "DUber",
@@ -772,6 +854,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kingdra: {
 		randomBattleMoves: ["dracometeor", "hydropump", "icebeam", "raindance", "waterfall"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "hydropump", "icebeam", "muddywater", "protect", "raindance"],
 		tier: "NUBL",
 		doublesTier: "DOU",
@@ -781,6 +864,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	seaking: {
 		randomBattleMoves: ["drillrun", "icebeam", "knockoff", "megahorn", "raindance", "waterfall"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["drillrun", "icywind", "knockoff", "megahorn", "protect", "waterfall"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -790,6 +874,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	starmie: {
 		randomBattleMoves: ["hydropump", "icebeam", "psyshock", "rapidspin", "recover", "scald", "thunderbolt"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["hydropump", "icebeam", "protect", "psychic", "psyshock", "scald", "thunderbolt"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -799,24 +884,28 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mrmime: {
 		randomBattleMoves: ["dazzlinggleam", "encore", "focusblast", "healingwish", "nastyplot", "psyshock", "shadowball"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["dazzlinggleam", "encore", "fakeout", "followme", "hiddenpowerfighting", "icywind", "protect", "psychic", "thunderbolt", "thunderwave", "wideguard"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	scyther: {
 		randomBattleMoves: ["aerialace", "brickbreak", "bugbite", "knockoff", "roost", "swordsdance", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aerialace", "brickbreak", "bugbite", "feint", "knockoff", "protect", "swordsdance", "uturn"],
 		tier: "PU",
 		doublesTier: "NFE",
 	},
 	scizor: {
 		randomBattleMoves: ["bugbite", "bulletpunch", "knockoff", "pursuit", "superpower", "swordsdance", "uturn"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["bugbite", "bulletpunch", "feint", "knockoff", "protect", "superpower", "swordsdance", "uturn"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	scizormega: {
 		randomBattleMoves: ["bugbite", "bulletpunch", "defog", "knockoff", "roost", "superpower", "swordsdance", "uturn"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["bugbite", "bulletpunch", "feint", "knockoff", "protect", "roost", "superpower", "swordsdance", "uturn"],
 		tier: "OU",
 		doublesTier: "DUU",
@@ -826,6 +915,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	jynx: {
 		randomBattleMoves: ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psychic", "psyshock", "substitute", "trick"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["focusblast", "icebeam", "lovelykiss", "nastyplot", "protect", "psychic", "psyshock"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -838,6 +928,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	electivire: {
 		randomBattleMoves: ["crosschop", "earthquake", "flamethrower", "icepunch", "voltswitch", "wildcharge"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["crosschop", "flamethrower", "followme", "icepunch", "protect", "stompingtantrum", "wildcharge"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -850,24 +941,28 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	magmortar: {
 		randomBattleMoves: ["earthquake", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderbolt"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["fireblast", "followme", "heatwave", "hiddenpowergrass", "hiddenpowerice", "protect", "taunt", "thunderbolt", "willowisp"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	pinsir: {
 		randomBattleMoves: ["closecombat", "earthquake", "knockoff", "stealthrock", "stoneedge", "xscissor"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["closecombat", "feint", "knockoff", "protect", "rockslide", "xscissor"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	pinsirmega: {
 		randomBattleMoves: ["closecombat", "earthquake", "quickattack", "return", "swordsdance"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["closecombat", "feint", "protect", "quickattack", "return", "rockslide", "swordsdance"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
 	},
 	tauros: {
 		randomBattleMoves: ["bodyslam", "doubleedge", "earthquake", "rockslide", "zenheadbutt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["doubleedge", "protect", "return", "rockslide", "stompingtantrum", "stoneedge", "zenheadbutt"],
 		tier: "PUBL",
 		doublesTier: "(DUU)",
@@ -877,24 +972,28 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gyarados: {
 		randomBattleMoves: ["bounce", "dragondance", "earthquake", "stoneedge", "substitute", "waterfall"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["bounce", "dragondance", "protect", "stoneedge", "thunderwave", "waterfall"],
 		tier: "UUBL",
 		doublesTier: "DUU",
 	},
 	gyaradosmega: {
 		randomBattleMoves: ["crunch", "dragondance", "earthquake", "icefang", "substitute", "waterfall"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["crunch", "dragondance", "icefang", "protect", "taunt", "thunderwave", "waterfall"],
 		tier: "OU",
 		doublesTier: "DUU",
 	},
 	lapras: {
 		randomBattleMoves: ["freezedry", "healbell", "hydropump", "icebeam", "protect", "thunderbolt", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["freezedry", "helpinghand", "hydropump", "iceshard", "icywind", "protect"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	ditto: {
 		randomBattleMoves: ["transform"],
+		randomBattleLevel: 88,
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
@@ -903,42 +1002,49 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vaporeon: {
 		randomBattleMoves: ["icebeam", "protect", "roar", "scald", "toxic", "wish"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["helpinghand", "icywind", "muddywater", "protect", "scald", "toxic"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	jolteon: {
 		randomBattleMoves: ["hiddenpowerice", "shadowball", "signalbeam", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["helpinghand", "hiddenpowergrass", "hiddenpowerice", "protect", "signalbeam", "thunderbolt", "voltswitch"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	flareon: {
 		randomBattleMoves: ["facade", "flamecharge", "flareblitz", "quickattack", "superpower"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["facade", "flamecharge", "flareblitz", "protect", "superpower"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	espeon: {
 		randomBattleMoves: ["calmmind", "dazzlinggleam", "morningsun", "psychic", "psyshock", "shadowball"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["calmmind", "dazzlinggleam", "helpinghand", "protect", "psychic", "shadowball"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	umbreon: {
 		randomBattleMoves: ["foulplay", "protect", "toxic", "wish"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["foulplay", "helpinghand", "moonlight", "protect", "snarl"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	leafeon: {
 		randomBattleMoves: ["healbell", "knockoff", "leafblade", "swordsdance", "synthesis", "xscissor"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["helpinghand", "knockoff", "leafblade", "protect", "swordsdance", "xscissor"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	glaceon: {
 		randomBattleMoves: ["healbell", "hiddenpowerground", "icebeam", "protect", "shadowball", "toxic", "wish"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["helpinghand", "hiddenpowerground", "icebeam", "protect", "toxic"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -948,12 +1054,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	porygon2: {
 		randomBattleMoves: ["discharge", "icebeam", "recover", "toxic", "triattack"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["allyswitch", "icebeam", "protect", "recover", "thunderbolt", "thunderwave", "triattack"],
 		tier: "RU",
 		doublesTier: "DOU",
 	},
 	porygonz: {
 		randomBattleMoves: ["icebeam", "nastyplot", "shadowball", "thunderbolt", "triattack", "trick"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["darkpulse", "icebeam", "nastyplot", "protect", "thunderbolt", "triattack", "trick"],
 		tier: "UUBL",
 		doublesTier: "DUU",
@@ -963,6 +1071,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	omastar: {
 		randomBattleMoves: ["earthpower", "hydropump", "icebeam", "shellsmash", "spikes", "stealthrock"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthpower", "hiddenpowerelectric", "hydropump", "icebeam", "muddywater", "protect", "shellsmash"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -972,18 +1081,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kabutops: {
 		randomBattleMoves: ["aquajet", "knockoff", "liquidation", "rapidspin", "stoneedge", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aquajet", "knockoff", "liquidation", "protect", "rockslide", "stoneedge", "swordsdance"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	aerodactyl: {
 		randomBattleMoves: ["defog", "doubleedge", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge", "taunt"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["earthquake", "protect", "rockslide", "skydrop", "stoneedge", "tailwind", "wideguard"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	aerodactylmega: {
 		randomBattleMoves: ["aerialace", "aquatail", "earthquake", "firefang", "honeclaws", "roost", "stoneedge"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["aquatail", "protect", "rockslide", "skydrop", "stoneedge", "tailwind", "wideguard"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -993,24 +1105,28 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	snorlax: {
 		randomBattleMoves: ["bodyslam", "crunch", "curse", "earthquake", "firepunch", "pursuit", "rest", "return", "sleeptalk"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["bodyslam", "crunch", "curse", "highhorsepower", "protect", "rest", "return"],
 		tier: "RU",
 		doublesTier: "DUber",
 	},
 	articuno: {
 		randomBattleMoves: ["freezedry", "hurricane", "roost", "substitute", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["freezedry", "hurricane", "protect", "roost", "tailwind"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	zapdos: {
 		randomBattleMoves: ["defog", "discharge", "heatwave", "hiddenpowerice", "roost", "toxic", "uturn"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["heatwave", "hiddenpowergrass", "hiddenpowerice", "protect", "roost", "tailwind", "thunderbolt"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	moltres: {
 		randomBattleMoves: ["fireblast", "hurricane", "roost", "substitute", "toxic", "willowisp"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["airslash", "fireblast", "heatwave", "hurricane", "protect", "tailwind", "uturn", "willowisp"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -1023,30 +1139,35 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dragonite: {
 		randomBattleMoves: ["dragondance", "earthquake", "extremespeed", "firepunch", "fly", "outrage"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["dragonclaw", "dragondance", "extremespeed", "firepunch", "fly", "protect", "roost", "superpower"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
 	},
 	mewtwo: {
 		randomBattleMoves: ["aurasphere", "calmmind", "fireblast", "icebeam", "psystrike", "recover"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["aurasphere", "calmmind", "fireblast", "icebeam", "protect", "psystrike"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	mewtwomegax: {
 		randomBattleMoves: ["bulkup", "drainpunch", "icebeam", "stoneedge", "taunt", "zenheadbutt"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["bulkup", "drainpunch", "icebeam", "stoneedge", "taunt", "zenheadbutt"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	mewtwomegay: {
 		randomBattleMoves: ["aurasphere", "calmmind", "fireblast", "icebeam", "psystrike", "recover", "shadowball"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["aurasphere", "calmmind", "fireblast", "icebeam", "psystrike", "taunt", "willowisp"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	mew: {
 		randomBattleMoves: ["aurasphere", "defog", "earthpower", "icebeam", "knockoff", "nastyplot", "psyshock", "roost", "stealthrock", "taunt", "willowisp"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["fakeout", "fireblast", "helpinghand", "icebeam", "protect", "psyshock", "roost", "tailwind", "taunt", "transform", "willowisp"],
 		tier: "UU",
 		doublesTier: "DOU",
@@ -1059,6 +1180,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	meganium: {
 		randomBattleMoves: ["aromatherapy", "dragontail", "gigadrain", "leechseed", "lightscreen", "reflect", "synthesis", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["dragontail", "energyball", "healpulse", "leafstorm", "leechseed", "protect", "toxic"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1071,6 +1193,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	typhlosion: {
 		randomBattleMoves: ["eruption", "extrasensory", "fireblast", "focusblast", "hiddenpowergrass"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["eruption", "extrasensory", "focusblast", "heatwave", "hiddenpowergrass"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -1083,6 +1206,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	feraligatr: {
 		randomBattleMoves: ["aquajet", "crunch", "dragondance", "earthquake", "icepunch", "liquidation", "swordsdance"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["aquajet", "crunch", "dragondance", "icepunch", "liquidation", "protect"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -1092,6 +1216,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	furret: {
 		randomBattleMoves: ["aquatail", "doubleedge", "firepunch", "knockoff", "trick", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["doubleedge", "followme", "helpinghand", "knockoff", "protect", "superfang", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1101,6 +1226,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	noctowl: {
 		randomBattleMoves: ["airslash", "defog", "heatwave", "hurricane", "hypervoice", "roost", "whirlwind"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "heatwave", "hypervoice", "hypnosis", "protect", "roost", "tailwind"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1110,6 +1236,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ledian: {
 		randomBattleMoves: ["knockoff", "lightscreen", "reflect", "roost", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bugbuzz", "encore", "knockoff", "lightscreen", "protect", "reflect", "tailwind", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1119,6 +1246,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ariados: {
 		randomBattleMoves: ["megahorn", "poisonjab", "stickyweb", "suckerpunch", "toxicspikes"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["megahorn", "poisonjab", "protect", "ragepowder", "stickyweb", "toxicthread"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1128,6 +1256,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lanturn: {
 		randomBattleMoves: ["healbell", "hiddenpowergrass", "hydropump", "icebeam", "scald", "toxic", "voltswitch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["icebeam", "protect", "scald", "thunderbolt", "thunderwave", "toxic"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -1140,6 +1269,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	togekiss: {
 		randomBattleMoves: ["airslash", "aurasphere", "defog", "healbell", "nastyplot", "roost", "thunderwave"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["airslash", "dazzlinggleam", "followme", "nastyplot", "protect", "roost", "tailwind", "thunderwave"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -1149,6 +1279,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	xatu: {
 		randomBattleMoves: ["calmmind", "heatwave", "psychic", "roost", "thunderwave", "toxic", "uturn"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["heatwave", "protect", "psychic", "roost", "tailwind", "thunderwave", "uturn"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -1161,12 +1292,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ampharos: {
 		randomBattleMoves: ["focusblast", "healbell", "hiddenpowerice", "lightscreen", "reflect", "thunderbolt", "toxic", "voltswitch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["focusblast", "hiddenpowergrass", "hiddenpowerice", "protect", "thunderbolt", "thunderwave"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	ampharosmega: {
 		randomBattleMoves: ["agility", "dragonpulse", "focusblast", "healbell", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["dragonpulse", "focusblast", "hiddenpowergrass", "hiddenpowerice", "protect", "thunderbolt"],
 		tier: "RU",
 		doublesTier: "DUU",
@@ -1179,6 +1312,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	azumarill: {
 		randomBattleMoves: ["aquajet", "bellydrum", "knockoff", "liquidation", "playrough", "superpower"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["aquajet", "knockoff", "liquidation", "playrough", "protect", "superpower"],
 		tier: "OU",
 		doublesTier: "DUU",
@@ -1188,6 +1322,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sudowoodo: {
 		randomBattleMoves: ["earthquake", "headsmash", "stealthrock", "suckerpunch", "toxic", "woodhammer"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["headsmash", "helpinghand", "protect", "stealthrock", "stompingtantrum", "suckerpunch", "woodhammer"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1200,6 +1335,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	jumpluff: {
 		randomBattleMoves: ["acrobatics", "encore", "leechseed", "seedbomb", "sleeppowder", "strengthsap", "substitute", "swordsdance", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["encore", "energyball", "helpinghand", "leechseed", "protect", "ragepowder", "sleeppowder", "strengthsap", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1209,6 +1345,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ambipom: {
 		randomBattleMoves: ["fakeout", "knockoff", "lowkick", "return", "seedbomb", "switcheroo", "uturn"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["fakeout", "icepunch", "knockoff", "lowkick", "protect", "return", "uturn"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -1218,6 +1355,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sunflora: {
 		randomBattleMoves: ["earthpower", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "sludgebomb"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthpower", "encore", "energyball", "helpinghand", "hiddenpowerfire", "protect", "solarbeam", "sunnyday"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1227,6 +1365,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	yanmega: {
 		randomBattleMoves: ["airslash", "bugbuzz", "gigadrain", "protect", "uturn"],
+		randomBattleLevel: 84,
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
@@ -1235,6 +1374,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	quagsire: {
 		randomBattleMoves: ["earthquake", "encore", "icebeam", "recover", "scald", "toxic"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthquake", "icywind", "protect", "recover", "scald", "toxic"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
@@ -1244,6 +1384,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	honchkrow: {
 		randomBattleMoves: ["bravebird", "heatwave", "pursuit", "roost", "suckerpunch", "superpower"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["bravebird", "heatwave", "protect", "roost", "suckerpunch", "superpower"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -1253,12 +1394,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mismagius: {
 		randomBattleMoves: ["dazzlinggleam", "destinybond", "nastyplot", "painsplit", "shadowball", "substitute", "taunt", "thunderbolt", "willowisp"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["dazzlinggleam", "nastyplot", "protect", "shadowball", "taunt", "thunderbolt", "willowisp"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	unown: {
 		randomBattleMoves: ["hiddenpowerpsychic"],
+		randomBattleLevel: 100,
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
@@ -1267,12 +1410,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wobbuffet: {
 		randomBattleMoves: ["counter", "destinybond", "encore", "mirrorcoat"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["charm", "counter", "encore", "mirrorcoat"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	girafarig: {
 		randomBattleMoves: ["hypervoice", "nastyplot", "psychic", "psyshock", "substitute", "thunderbolt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["hypervoice", "nastyplot", "protect", "psychic", "psyshock", "thunderbolt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1282,23 +1427,27 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	forretress: {
 		randomBattleMoves: ["gyroball", "rapidspin", "spikes", "stealthrock", "toxic", "voltswitch"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["gyroball", "protect", "stealthrock", "toxic", "voltswitch"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	dunsparce: {
 		randomBattleMoves: ["bite", "bodyslam", "coil", "glare", "headbutt", "rockslide", "roost"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bite", "bodyslam", "coil", "glare", "headbutt", "protect", "rockslide"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	gligar: {
 		randomBattleMoves: ["defog", "earthquake", "knockoff", "roost", "stealthrock", "toxic", "uturn"],
+		randomBattleLevel: 82,
 		tier: "UU",
 		doublesTier: "NFE",
 	},
 	gliscor: {
 		randomBattleMoves: ["earthquake", "knockoff", "protect", "roost", "stealthrock", "taunt", "toxic", "uturn"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["earthquake", "facade", "knockoff", "protect", "tailwind", "taunt"],
 		tier: "OU",
 		doublesTier: "(DUU)",
@@ -1308,30 +1457,35 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	granbull: {
 		randomBattleMoves: ["crunch", "earthquake", "healbell", "playrough", "thunderwave"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["playrough", "protect", "snarl", "stompingtantrum", "thunderwave"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	qwilfish: {
 		randomBattleMoves: ["destinybond", "liquidation", "painsplit", "spikes", "taunt", "thunderwave", "toxicspikes"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["destinybond", "liquidation", "poisonjab", "protect", "swordsdance", "taunt", "thunderwave"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	shuckle: {
 		randomBattleMoves: ["encore", "knockoff", "stealthrock", "stickyweb", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["encore", "guardsplit", "helpinghand", "knockoff", "stealthrock", "stickyweb", "toxic"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	heracross: {
 		randomBattleMoves: ["closecombat", "facade", "knockoff", "megahorn", "stoneedge", "swordsdance"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["closecombat", "facade", "knockoff", "megahorn", "protect", "swordsdance"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
 	},
 	heracrossmega: {
 		randomBattleMoves: ["closecombat", "pinmissile", "rockblast", "substitute", "swordsdance"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["bulletseed", "closecombat", "knockoff", "pinmissile", "protect", "rockblast", "swordsdance"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
@@ -1342,6 +1496,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	weavile: {
 		randomBattleMoves: ["iceshard", "iciclecrash", "knockoff", "lowkick", "pursuit", "swordsdance"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["fakeout", "iceshard", "iciclecrash", "knockoff", "lowkick", "protect", "swordsdance"],
 		tier: "UUBL",
 		doublesTier: "DUU",
@@ -1351,6 +1506,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ursaring: {
 		randomBattleMoves: ["closecombat", "crunch", "facade", "protect", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["closecombat", "crunch", "facade", "protect", "swordsdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1360,6 +1516,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	magcargo: {
 		randomBattleMoves: ["ancientpower", "earthpower", "fireblast", "hiddenpowergrass", "lavaplume", "recover", "shellsmash", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthpower", "fireblast", "heatwave", "incinerate", "protect", "stealthrock", "willowisp"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1373,12 +1530,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mamoswine: {
 		randomBattleMoves: ["earthquake", "endeavor", "iceshard", "iciclecrash", "knockoff", "stealthrock", "superpower"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthquake", "iceshard", "iciclecrash", "knockoff", "protect", "rockslide", "superpower"],
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	corsola: {
 		randomBattleMoves: ["powergem", "recover", "scald", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["icywind", "powergem", "protect", "scald", "stealthrock", "toxic"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1388,12 +1547,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	octillery: {
 		randomBattleMoves: ["energyball", "fireblast", "gunkshot", "hydropump", "icebeam", "rockblast", "scald"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["energyball", "fireblast", "hydropump", "icebeam", "protect"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	delibird: {
 		randomBattleMoves: ["destinybond", "freezedry", "icywind", "rapidspin", "spikes"],
+		randomBattleLevel: 100,
 		randomDoubleBattleMoves: ["aerialace", "brickbreak", "fakeout", "icepunch", "iceshard", "protect"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1403,12 +1564,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mantine: {
 		randomBattleMoves: ["airslash", "defog", "roost", "scald", "toxic"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["defog", "helpinghand", "protect", "scald", "tailwind", "toxic", "wideguard"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	skarmory: {
 		randomBattleMoves: ["bravebird", "roost", "spikes", "stealthrock", "whirlwind"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["bravebird", "feint", "ironhead", "protect", "skydrop", "stealthrock", "tailwind", "taunt"],
 		tier: "OU",
 		doublesTier: "(DUU)",
@@ -1418,12 +1581,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	houndoom: {
 		randomBattleMoves: ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "suckerpunch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["darkpulse", "heatwave", "nastyplot", "protect", "suckerpunch"],
 		tier: "PUBL",
 		doublesTier: "(DUU)",
 	},
 	houndoommega: {
 		randomBattleMoves: ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "taunt"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["darkpulse", "heatwave", "hiddenpowergrass", "nastyplot", "protect", "taunt"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
@@ -1433,42 +1598,49 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	donphan: {
 		randomBattleMoves: ["earthquake", "iceshard", "knockoff", "rapidspin", "stealthrock", "stoneedge"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["earthquake", "iceshard", "knockoff", "protect", "rapidspin", "rockslide", "stealthrock"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	stantler: {
 		randomBattleMoves: ["doubleedge", "earthquake", "jumpkick", "megahorn", "suckerpunch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "jumpkick", "megahorn", "protect", "return", "suckerpunch"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	smeargle: {
 		randomBattleMoves: ["destinybond", "spore", "stealthrock", "stickyweb", "whirlwind"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["fakeout", "followme", "helpinghand", "kingsshield", "spore", "stickyweb", "tailwind", "transform", "wideguard"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	miltank: {
 		randomBattleMoves: ["bodyslam", "curse", "earthquake", "healbell", "milkdrink", "stealthrock", "toxic"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["bodyslam", "curse", "helpinghand", "milkdrink", "protect", "stompingtantrum", "thunderwave"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	raikou: {
 		randomBattleMoves: ["aurasphere", "calmmind", "hiddenpowerice", "substitute", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["calmmind", "hiddenpowerice", "protect", "snarl", "thunderbolt"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	entei: {
 		randomBattleMoves: ["extremespeed", "flareblitz", "sacredfire", "stompingtantrum", "stoneedge"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["extremespeed", "flareblitz", "protect", "sacredfire", "stompingtantrum", "stoneedge"],
 		tier: "RUBL",
 		doublesTier: "DUU",
 	},
 	suicune: {
 		randomBattleMoves: ["calmmind", "hiddenpowergrass", "icebeam", "rest", "scald", "sleeptalk"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["icebeam", "scald", "snarl", "tailwind", "toxic"],
 		tier: "UU",
 		doublesTier: "DOU",
@@ -1481,30 +1653,35 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	tyranitar: {
 		randomBattleMoves: ["crunch", "earthquake", "fireblast", "icebeam", "pursuit", "stealthrock", "stoneedge"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["crunch", "fireblast", "icebeam", "protect", "rockslide", "stealthrock", "stompingtantrum", "stoneedge"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	tyranitarmega: {
 		randomBattleMoves: ["crunch", "dragondance", "earthquake", "icepunch", "stoneedge"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["crunch", "dragondance", "earthquake", "icepunch", "protect", "rockslide", "stoneedge"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	lugia: {
 		randomBattleMoves: ["aeroblast", "earthquake", "roost", "substitute", "toxic", "whirlwind"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["aeroblast", "protect", "psychic", "roost", "skydrop", "tailwind", "toxic"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	hooh: {
 		randomBattleMoves: ["bravebird", "defog", "earthquake", "roost", "sacredfire", "substitute", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["bravebird", "earthpower", "protect", "roost", "sacredfire", "skydrop", "tailwind", "toxic"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	celebi: {
 		randomBattleMoves: ["earthpower", "gigadrain", "hiddenpowerfire", "leafstorm", "nastyplot", "psychic", "recover", "thunderwave", "uturn"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthpower", "energyball", "nastyplot", "protect", "psychic", "recover", "thunderwave", "uturn"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -1517,12 +1694,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sceptile: {
 		randomBattleMoves: ["focusblast", "gigadrain", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "leechseed", "substitute"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["energyball", "focusblast", "hiddenpowerfire", "hiddenpowerice", "protect"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	sceptilemega: {
 		randomBattleMoves: ["dragonpulse", "earthquake", "focusblast", "gigadrain", "hiddenpowerfire", "leafblade", "outrage", "substitute", "swordsdance"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["dragonpulse", "energyball", "focusblast", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "protect"],
 		tier: "RU",
 		doublesTier: "DUU",
@@ -1535,11 +1714,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	blaziken: {
 		randomBattleMoves: ["fireblast", "hiddenpowerice", "highjumpkick", "knockoff", "protect"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "(DUU)",
 	},
 	blazikenmega: {
 		randomBattleMoves: ["flareblitz", "highjumpkick", "knockoff", "protect", "stoneedge", "swordsdance"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUU",
 	},
@@ -1551,12 +1732,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swampert: {
 		randomBattleMoves: ["earthquake", "icebeam", "protect", "roar", "scald", "stealthrock", "toxic"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthquake", "icywind", "muddywater", "protect", "scald", "stealthrock", "wideguard"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	swampertmega: {
 		randomBattleMoves: ["earthquake", "icepunch", "raindance", "superpower", "waterfall"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["earthquake", "icepunch", "protect", "raindance", "waterfall"],
 		tier: "OU",
 		doublesTier: "DOU",
@@ -1566,6 +1749,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mightyena: {
 		randomBattleMoves: ["crunch", "firefang", "irontail", "playrough", "suckerpunch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["crunch", "firefang", "playrough", "protect", "suckerpunch", "taunt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1575,6 +1759,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	linoone: {
 		randomBattleMoves: ["bellydrum", "extremespeed", "shadowclaw", "stompingtantrum"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["bellydrum", "extremespeed", "protect", "shadowclaw", "stompingtantrum"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
@@ -1587,6 +1772,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	beautifly: {
 		randomBattleMoves: ["bugbuzz", "energyball", "hiddenpowerfighting", "psychic", "quiverdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aircutter", "bugbuzz", "protect", "quiverdance", "stringshot", "tailwind"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1596,6 +1782,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dustox: {
 		randomBattleMoves: ["bugbuzz", "defog", "quiverdance", "roost", "sludgebomb", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bugbuzz", "protect", "sludgebomb", "stringshot", "strugglebug", "tailwind"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1608,6 +1795,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ludicolo: {
 		randomBattleMoves: ["focusblast", "gigadrain", "hydropump", "icebeam", "raindance", "scald"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["fakeout", "gigadrain", "hydropump", "icebeam", "protect", "raindance"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -1620,6 +1808,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	shiftry: {
 		randomBattleMoves: ["defog", "knockoff", "leafstorm", "lowkick", "seedbomb", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["fakeout", "knockoff", "leafblade", "leafstorm", "protect", "suckerpunch", "swordsdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1629,6 +1818,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swellow: {
 		randomBattleMoves: ["bravebird", "facade", "protect", "quickattack", "uturn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["bravebird", "facade", "protect", "quickattack", "uturn"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -1638,6 +1828,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	pelipper: {
 		randomBattleMoves: ["defog", "hurricane", "hydropump", "knockoff", "roost", "scald", "uturn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["hurricane", "protect", "scald", "tailwind", "uturn", "wideguard"],
 		tier: "OU",
 		doublesTier: "DOU",
@@ -1650,24 +1841,28 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gardevoir: {
 		randomBattleMoves: ["calmmind", "focusblast", "moonblast", "psychic", "shadowball", "substitute", "thunderbolt", "willowisp"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["dazzlinggleam", "focusblast", "helpinghand", "moonblast", "protect", "psyshock"],
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	gardevoirmega: {
 		randomBattleMoves: ["calmmind", "focusblast", "hypervoice", "psyshock", "substitute", "taunt", "willowisp"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["calmmind", "focusblast", "hypervoice", "protect", "psyshock"],
 		tier: "UUBL",
 		doublesTier: "DOU",
 	},
 	gallade: {
 		randomBattleMoves: ["bulkup", "closecombat", "drainpunch", "icepunch", "knockoff", "shadowsneak", "substitute", "zenheadbutt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["closecombat", "helpinghand", "icepunch", "knockoff", "protect", "shadowsneak", "trick", "zenheadbutt"],
 		tier: "PUBL",
 		doublesTier: "(DUU)",
 	},
 	gallademega: {
 		randomBattleMoves: ["closecombat", "icepunch", "knockoff", "swordsdance", "zenheadbutt"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["closecombat", "drainpunch", "icepunch", "knockoff", "protect", "swordsdance", "zenheadbutt"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
@@ -1677,6 +1872,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	masquerain: {
 		randomBattleMoves: ["airslash", "bugbuzz", "hydropump", "quiverdance", "stickyweb"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "bugbuzz", "hydropump", "protect", "quiverdance", "stickyweb", "strugglebug", "tailwind"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1686,6 +1882,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	breloom: {
 		randomBattleMoves: ["bulletseed", "machpunch", "rocktomb", "spore", "swordsdance"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["bulletseed", "machpunch", "protect", "rocktomb", "spore"],
 		tier: "UUBL",
 		doublesTier: "DUU",
@@ -1698,6 +1895,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	slaking: {
 		randomBattleMoves: ["earthquake", "firepunch", "gigaimpact", "nightslash", "pursuit", "retaliate"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["doubleedge", "earthquake", "hammerarm", "nightslash", "retaliate", "rockslide"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1707,12 +1905,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ninjask: {
 		randomBattleMoves: ["aerialace", "dig", "leechlife", "nightslash", "swordsdance", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aerialace", "dig", "leechlife", "protect", "swordsdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	shedinja: {
 		randomBattleMoves: ["shadowclaw", "shadowsneak", "swordsdance", "willowisp", "xscissor"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["allyswitch", "protect", "shadowsneak", "swordsdance", "willowisp", "xscissor"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1725,6 +1925,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	exploud: {
 		randomBattleMoves: ["boomburst", "fireblast", "focusblast", "icebeam", "surf"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["boomburst", "fireblast", "focusblast", "hypervoice", "icebeam", "protect"],
 		tier: "NUBL",
 		doublesTier: "(DUU)",
@@ -1734,6 +1935,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hariyama: {
 		randomBattleMoves: ["bulkup", "bulletpunch", "closecombat", "icepunch", "knockoff", "stoneedge"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["bulletpunch", "closecombat", "facade", "fakeout", "helpinghand", "knockoff", "protect", "wideguard"],
 		tier: "NU",
 		doublesTier: "DUU",
@@ -1743,6 +1945,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	probopass: {
 		randomBattleMoves: ["earthpower", "flashcannon", "stealthrock", "thunderwave", "toxic", "voltswitch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["flashcannon", "helpinghand", "powergem", "protect", "stealthrock", "thunderwave", "wideguard"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1752,30 +1955,35 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	delcatty: {
 		randomBattleMoves: ["doubleedge", "fakeout", "healbell", "suckerpunch", "thunderwave", "wildcharge"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["doubleedge", "fakeout", "helpinghand", "protect", "suckerpunch", "thunderwave"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	sableye: {
 		randomBattleMoves: ["foulplay", "recover", "taunt", "toxic", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["fakeout", "foulplay", "helpinghand", "protect", "recover", "snarl", "taunt", "willowisp"],
 		tier: "PU",
 		doublesTier: "DUU",
 	},
 	sableyemega: {
 		randomBattleMoves: ["calmmind", "darkpulse", "recover", "shadowball", "willowisp"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["fakeout", "knockoff", "protect", "recover", "shadowball", "willowisp"],
 		tier: "OU",
 		doublesTier: "DUU",
 	},
 	mawile: {
 		randomBattleMoves: ["ironhead", "knockoff", "playrough", "stealthrock", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["ironhead", "knockoff", "playrough", "protect", "suckerpunch", "swordsdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	mawilemega: {
 		randomBattleMoves: ["firefang", "focuspunch", "ironhead", "knockoff", "playrough", "substitute", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["ironhead", "knockoff", "playrough", "protect", "suckerpunch", "swordsdance"],
 		tier: "OU",
 		doublesTier: "DUU",
@@ -1788,12 +1996,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	aggron: {
 		randomBattleMoves: ["aquatail", "earthquake", "headsmash", "heavyslam", "rockpolish", "stealthrock"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["headsmash", "heavyslam", "protect", "stealthrock", "stompingtantrum"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	aggronmega: {
 		randomBattleMoves: ["earthquake", "heavyslam", "roar", "stealthrock", "stoneedge", "thunderwave", "toxic"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["heavyslam", "protect", "rockslide", "stealthrock", "stompingtantrum", "toxic"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -1803,12 +2013,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	medicham: {
 		randomBattleMoves: ["bulletpunch", "drainpunch", "highjumpkick", "icepunch", "zenheadbutt"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["bulletpunch", "drainpunch", "fakeout", "highjumpkick", "icepunch", "protect", "zenheadbutt"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	medichammega: {
 		randomBattleMoves: ["fakeout", "highjumpkick", "icepunch", "thunderpunch", "zenheadbutt"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["bulletpunch", "drainpunch", "fakeout", "highjumpkick", "icepunch", "protect", "zenheadbutt"],
 		tier: "OU",
 		doublesTier: "(DUU)",
@@ -1818,36 +2030,42 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	manectric: {
 		randomBattleMoves: ["flamethrower", "hiddenpowergrass", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["flamethrower", "hiddenpowergrass", "hiddenpowerice", "protect", "snarl", "switcheroo", "thunderbolt", "voltswitch"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	manectricmega: {
 		randomBattleMoves: ["hiddenpowergrass", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["flamethrower", "hiddenpowergrass", "hiddenpowerice", "protect", "snarl", "thunderbolt", "voltswitch"],
 		tier: "UU",
 		doublesTier: "DOU",
 	},
 	plusle: {
 		randomBattleMoves: ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["encore", "helpinghand", "hiddenpowerice", "nastyplot", "protect", "thunderbolt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	minun: {
 		randomBattleMoves: ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["encore", "helpinghand", "hiddenpowerice", "nastyplot", "protect", "thunderbolt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	volbeat: {
 		randomBattleMoves: ["defog", "encore", "roost", "tailwind", "thunderwave", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["encore", "helpinghand", "protect", "stringshot", "strugglebug", "tailwind", "thunderwave", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	illumise: {
 		randomBattleMoves: ["bugbuzz", "defog", "encore", "roost", "thunderwave", "uturn", "wish"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bugbuzz", "encore", "helpinghand", "protect", "tailwind", "thunderwave"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1861,6 +2079,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	roserade: {
 		randomBattleMoves: ["gigadrain", "hiddenpowerfire", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["gigadrain", "hiddenpowerfire", "leafstorm", "protect", "sleeppowder", "sludgebomb"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -1870,6 +2089,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swalot: {
 		randomBattleMoves: ["earthquake", "encore", "icebeam", "painsplit", "sludgebomb", "toxic", "yawn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["encore", "icebeam", "poisongas", "protect", "sludgebomb", "yawn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1879,12 +2099,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sharpedo: {
 		randomBattleMoves: ["crunch", "earthquake", "icebeam", "protect", "waterfall"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["crunch", "icebeam", "liquidation", "protect", "psychicfangs"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
 	},
 	sharpedomega: {
 		randomBattleMoves: ["crunch", "destinybond", "icefang", "protect", "psychicfangs", "waterfall"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["crunch", "icefang", "liquidation", "protect", "psychicfangs"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -1894,6 +2116,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wailord: {
 		randomBattleMoves: ["hiddenpowerfire", "hiddenpowergrass", "hydropump", "icebeam", "waterspout"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["hiddenpowerfire", "hiddenpowergrass", "hydropump", "icebeam", "waterspout"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1903,18 +2126,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	camerupt: {
 		randomBattleMoves: ["earthpower", "fireblast", "hiddenpowergrass", "lavaplume", "roar", "rockpolish", "stealthrock", "stoneedge"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthpower", "fireblast", "heatwave", "incinerate", "protect", "stealthrock"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	cameruptmega: {
 		randomBattleMoves: ["ancientpower", "earthpower", "fireblast", "stealthrock", "toxic", "willowisp"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["earthpower", "fireblast", "heatwave", "protect", "rockslide"],
 		tier: "NUBL",
 		doublesTier: "DOU",
 	},
 	torkoal: {
 		randomBattleMoves: ["earthpower", "fireblast", "lavaplume", "rapidspin", "shellsmash", "solarbeam", "stealthrock", "yawn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["earthpower", "fireblast", "heatwave", "protect", "solarbeam", "willowisp"],
 		tier: "(PU)",
 		doublesTier: "DUU",
@@ -1924,12 +2150,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	grumpig: {
 		randomBattleMoves: ["focusblast", "healbell", "lightscreen", "psychic", "reflect", "thunderwave", "toxic", "whirlwind"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["focusblast", "lightscreen", "protect", "psychic", "reflect", "taunt", "thunderwave"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	spinda: {
 		randomBattleMoves: ["encore", "return", "rockslide", "superpower"],
+		randomBattleLevel: 100,
 		randomDoubleBattleMoves: ["fakeout", "protect", "return", "suckerpunch", "superpower", "trickroom"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1942,6 +2170,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	flygon: {
 		randomBattleMoves: ["defog", "dragondance", "earthquake", "firepunch", "outrage", "roost", "uturn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["dragonclaw", "dragondance", "earthquake", "fireblast", "protect", "tailwind", "uturn"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -1951,6 +2180,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cacturne: {
 		randomBattleMoves: ["darkpulse", "drainpunch", "focusblast", "gigadrain", "seedbomb", "spikes", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["drainpunch", "seedbomb", "spikyshield", "substitute", "suckerpunch", "swordsdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1960,36 +2190,42 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	altaria: {
 		randomBattleMoves: ["defog", "dracometeor", "earthquake", "fireblast", "roost", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["dracometeor", "dragonclaw", "fireblast", "protect", "tailwind"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	altariamega: {
 		randomBattleMoves: ["dragondance", "earthquake", "fireblast", "healbell", "return", "roost"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["doubleedge", "dragondance", "earthquake", "fireblast", "protect", "return"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	zangoose: {
 		randomBattleMoves: ["closecombat", "facade", "knockoff", "quickattack", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["closecombat", "facade", "knockoff", "protect", "quickattack"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	seviper: {
 		randomBattleMoves: ["darkpulse", "earthquake", "flamethrower", "gigadrain", "poisonjab", "sludgewave", "suckerpunch", "switcheroo", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aquatail", "earthquake", "flamethrower", "gigadrain", "glare", "poisonjab", "protect", "sludgebomb", "suckerpunch"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	lunatone: {
 		randomBattleMoves: ["earthpower", "icebeam", "moonblast", "moonlight", "powergem", "psychic", "rockpolish", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthpower", "helpinghand", "powergem", "protect", "psychic", "trickroom"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	solrock: {
 		randomBattleMoves: ["earthquake", "morningsun", "rockslide", "stealthrock", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["helpinghand", "protect", "rockslide", "stealthrock", "stoneedge", "willowisp", "zenheadbutt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -1999,6 +2235,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	whiscash: {
 		randomBattleMoves: ["dragondance", "earthquake", "stoneedge", "waterfall", "zenheadbutt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["dragondance", "earthquake", "protect", "stoneedge", "waterfall", "zenheadbutt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2008,6 +2245,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	crawdaunt: {
 		randomBattleMoves: ["aquajet", "crabhammer", "dragondance", "knockoff", "superpower", "swordsdance"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["aquajet", "crabhammer", "dragondance", "knockoff", "protect", "superpower", "swordsdance"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -2017,6 +2255,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	claydol: {
 		randomBattleMoves: ["earthquake", "icebeam", "psychic", "rapidspin", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["allyswitch", "earthpower", "protect", "rapidspin", "stealthrock", "toxic"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -2026,6 +2265,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cradily: {
 		randomBattleMoves: ["curse", "gigadrain", "recover", "rockslide", "seedbomb", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["gigadrain", "protect", "recover", "rockslide", "stealthrock", "stringshot", "toxic"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2035,6 +2275,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	armaldo: {
 		randomBattleMoves: ["earthquake", "knockoff", "rapidspin", "stealthrock", "stoneedge", "toxic", "xscissor"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["knockoff", "protect", "rockslide", "stoneedge", "stringshot", "swordsdance", "xscissor"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2044,6 +2285,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	milotic: {
 		randomBattleMoves: ["dragontail", "icebeam", "recover", "scald", "toxic"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["hypnosis", "icywind", "protect", "recover", "scald"],
 		tier: "RU",
 		doublesTier: "DOU",
@@ -2054,15 +2296,19 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	castformsunny: {
 		randomBattleMoves: ["fireblast", "icebeam", "solarbeam", "sunnyday"],
+		randomBattleLevel: 100,
 	},
 	castformrainy: {
 		randomBattleMoves: ["hurricane", "hydropump", "raindance", "thunder"],
+		randomBattleLevel: 100,
 	},
 	castformsnowy: {
 		randomBattleMoves: ["blizzard", "fireblast", "hail", "thunderbolt"],
+		randomBattleLevel: 100,
 	},
 	kecleon: {
 		randomBattleMoves: ["drainpunch", "fakeout", "knockoff", "recover", "shadowsneak", "stealthrock", "suckerpunch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["drainpunch", "fakeout", "knockoff", "protect", "shadowsneak", "trickroom"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2072,12 +2318,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	banette: {
 		randomBattleMoves: ["destinybond", "knockoff", "shadowclaw", "shadowsneak", "suckerpunch", "taunt", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["knockoff", "protect", "shadowclaw", "shadowsneak", "willowisp"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	banettemega: {
 		randomBattleMoves: ["destinybond", "knockoff", "shadowclaw", "suckerpunch", "taunt", "willowisp"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["destinybond", "knockoff", "protect", "shadowclaw", "suckerpunch", "taunt", "willowisp"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -2090,12 +2338,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dusknoir: {
 		randomBattleMoves: ["earthquake", "icepunch", "painsplit", "shadowsneak", "substitute", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["allyswitch", "helpinghand", "icepunch", "painsplit", "protect", "shadowsneak", "trickroom", "willowisp"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	tropius: {
 		randomBattleMoves: ["airslash", "gigadrain", "leechseed", "protect", "substitute", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "gigadrain", "leechseed", "protect", "roost", "tailwind"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2105,18 +2355,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	chimecho: {
 		randomBattleMoves: ["calmmind", "healbell", "healingwish", "psychic", "recover", "shadowball", "taunt", "yawn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["helpinghand", "protect", "psychic", "recover", "taunt", "thunderwave", "trickroom"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	absol: {
 		randomBattleMoves: ["knockoff", "playrough", "pursuit", "suckerpunch", "superpower", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["knockoff", "playrough", "protect", "suckerpunch", "superpower", "swordsdance"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	absolmega: {
 		randomBattleMoves: ["icebeam", "knockoff", "playrough", "pursuit", "suckerpunch", "superpower", "swordsdance"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["fireblast", "knockoff", "playrough", "protect", "suckerpunch", "superpower", "swordsdance"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
@@ -2126,18 +2379,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	glalie: {
 		randomBattleMoves: ["earthquake", "explosion", "icebeam", "iceshard", "spikes", "superfang", "taunt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "freezedry", "icebeam", "iceshard", "protect", "taunt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	glaliemega: {
 		randomBattleMoves: ["earthquake", "explosion", "freezedry", "iceshard", "return", "spikes"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["earthquake", "explosion", "freezedry", "iceshard", "protect", "return"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	froslass: {
 		randomBattleMoves: ["destinybond", "icebeam", "shadowball", "spikes", "taunt", "thunderwave"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["destinybond", "icebeam", "protect", "shadowball", "taunt", "thunderwave", "willowisp"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -2150,6 +2406,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	walrein: {
 		randomBattleMoves: ["icebeam", "protect", "roar", "superfang", "surf", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["brine", "icywind", "protect", "superfang"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2159,24 +2416,28 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	huntail: {
 		randomBattleMoves: ["icebeam", "shellsmash", "suckerpunch", "waterfall"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["icebeam", "protect", "shellsmash", "suckerpunch", "waterfall"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	gorebyss: {
 		randomBattleMoves: ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["hiddenpowergrass", "hydropump", "icebeam", "protect", "shellsmash"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	relicanth: {
 		randomBattleMoves: ["doubleedge", "earthquake", "headsmash", "stealthrock", "toxic", "waterfall"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["doubleedge", "earthquake", "headsmash", "protect", "rockslide", "waterfall"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	luvdisc: {
 		randomBattleMoves: ["icebeam", "protect", "scald", "sweetkiss", "toxic"],
+		randomBattleLevel: 100,
 		randomDoubleBattleMoves: ["healpulse", "icebeam", "icywind", "protect", "scald", "sweetkiss", "toxic"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2189,12 +2450,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	salamence: {
 		randomBattleMoves: ["dragondance", "earthquake", "fireblast", "fly", "outrage", "roost"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["dracometeor", "dragonclaw", "dragondance", "earthquake", "fireblast", "fly", "protect", "tailwind"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
 	},
 	salamencemega: {
 		randomBattleMoves: ["doubleedge", "dracometeor", "dragondance", "earthquake", "fireblast", "return", "roost"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["doubleedge", "dracometeor", "dragonclaw", "dragondance", "earthquake", "fireblast", "protect", "return"],
 		tier: "Uber",
 		doublesTier: "DOU",
@@ -2207,84 +2470,98 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	metagross: {
 		randomBattleMoves: ["agility", "bulletpunch", "earthquake", "explosion", "icepunch", "meteormash", "stealthrock", "thunderpunch", "zenheadbutt"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["agility", "bulletpunch", "icepunch", "meteormash", "protect", "stompingtantrum", "thunderpunch", "zenheadbutt"],
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	metagrossmega: {
 		randomBattleMoves: ["agility", "earthquake", "hammerarm", "icepunch", "meteormash", "zenheadbutt"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["icepunch", "meteormash", "protect", "stompingtantrum", "thunderpunch", "zenheadbutt"],
 		tier: "Uber",
 		doublesTier: "DOU",
 	},
 	regirock: {
 		randomBattleMoves: ["curse", "drainpunch", "rest", "rockslide", "stealthrock", "stoneedge", "thunderwave", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["curse", "drainpunch", "protect", "rest", "rockslide", "stealthrock", "stoneedge", "thunderwave"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	regice: {
 		randomBattleMoves: ["focusblast", "icebeam", "rest", "rockpolish", "sleeptalk", "thunderbolt", "thunderwave"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["icebeam", "icywind", "protect", "rockpolish", "thunderbolt", "thunderwave"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	registeel: {
 		randomBattleMoves: ["curse", "ironhead", "rest", "sleeptalk", "stealthrock", "toxic"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["curse", "ironhead", "protect", "rest", "seismictoss", "stealthrock", "thunderwave"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	latias: {
 		randomBattleMoves: ["dracometeor", "healingwish", "hiddenpowerfire", "psychic", "trick"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["dracometeor", "healpulse", "helpinghand", "protect", "psyshock", "tailwind"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	latiasmega: {
 		randomBattleMoves: ["calmmind", "defog", "dracometeor", "psyshock", "roost", "surf"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dragonpulse", "healpulse", "helpinghand", "protect", "psychic", "tailwind"],
 		tier: "OU",
 		doublesTier: "(DUU)",
 	},
 	latios: {
 		randomBattleMoves: ["dracometeor", "hiddenpowerfire", "psyshock", "surf", "thunderbolt", "trick"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "hiddenpowerfire", "protect", "psyshock", "tailwind", "trick"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
 	},
 	latiosmega: {
 		randomBattleMoves: ["calmmind", "dracometeor", "hiddenpowerfire", "psyshock", "roost"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "hiddenpowerfire", "protect", "psyshock", "tailwind"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
 	},
 	kyogre: {
 		randomBattleMoves: ["icebeam", "originpulse", "scald", "thunder", "waterspout"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "icebeam", "originpulse", "protect", "thunder", "waterspout"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	kyogreprimal: {
 		randomBattleMoves: ["calmmind", "icebeam", "originpulse", "rest", "scald", "sleeptalk", "thunder"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "icebeam", "originpulse", "protect", "thunder"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	groudon: {
 		randomBattleMoves: ["dragonclaw", "earthquake", "firepunch", "lavaplume", "roar", "stealthrock", "stoneedge", "thunderwave"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["firepunch", "precipiceblades", "protect", "rockpolish", "rockslide", "stoneedge", "swordsdance"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	groudonprimal: {
 		randomBattleMoves: ["firepunch", "lavaplume", "precipiceblades", "rockpolish", "stealthrock", "stoneedge", "swordsdance"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["firepunch", "precipiceblades", "protect", "rockpolish", "rockslide", "stoneedge", "swordsdance"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	rayquaza: {
 		randomBattleMoves: ["dracometeor", "dragonascent", "dragondance", "earthquake", "extremespeed", "outrage", "vcreate"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["dracometeor", "dragonclaw", "dragondance", "earthquake", "extremespeed", "protect", "tailwind", "vcreate"],
 		tier: "Uber",
 		doublesTier: "DUber",
@@ -2296,30 +2573,35 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	jirachi: {
 		randomBattleMoves: ["bodyslam", "firepunch", "ironhead", "stealthrock", "substitute", "toxic", "uturn", "wish"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["bodyslam", "followme", "helpinghand", "icywind", "ironhead", "protect", "thunderwave", "uturn"],
 		tier: "OU",
 		doublesTier: "DUber",
 	},
 	deoxys: {
 		randomBattleMoves: ["extremespeed", "firepunch", "icebeam", "knockoff", "psychoboost", "stealthrock", "superpower"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["extremespeed", "firepunch", "icebeam", "knockoff", "protect", "psychoboost", "superpower"],
 		tier: "Uber",
 		doublesTier: "(DUU)",
 	},
 	deoxysattack: {
 		randomBattleMoves: ["extremespeed", "firepunch", "icebeam", "knockoff", "psychoboost", "superpower"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["extremespeed", "firepunch", "icebeam", "knockoff", "protect", "psychoboost", "superpower"],
 		tier: "Uber",
 		doublesTier: "DUU",
 	},
 	deoxysdefense: {
 		randomBattleMoves: ["knockoff", "recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["lightscreen", "protect", "recover", "reflect", "seismictoss", "stealthrock", "taunt", "trickroom"],
 		tier: "Uber",
 		doublesTier: "(DUU)",
 	},
 	deoxysspeed: {
 		randomBattleMoves: ["knockoff", "magiccoat", "psychoboost", "spikes", "stealthrock", "superpower", "taunt"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["knockoff", "lightscreen", "protect", "psychoboost", "reflect", "superpower", "taunt"],
 		tier: "Uber",
 		doublesTier: "(DUU)",
@@ -2332,6 +2614,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	torterra: {
 		randomBattleMoves: ["earthquake", "rockpolish", "stealthrock", "stoneedge", "synthesis", "woodhammer"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "protect", "rockpolish", "rockslide", "stoneedge", "wideguard", "woodhammer"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2344,6 +2627,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	infernape: {
 		randomBattleMoves: ["closecombat", "fireblast", "flareblitz", "focusblast", "grassknot", "nastyplot", "stealthrock", "stoneedge", "swordsdance", "uturn", "vacuumwave"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["closecombat", "fakeout", "feint", "flareblitz", "grassknot", "heatwave", "protect", "stoneedge", "taunt", "uturn"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -2356,6 +2640,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	empoleon: {
 		randomBattleMoves: ["defog", "flashcannon", "grassknot", "hydropump", "icebeam", "roar", "scald", "stealthrock", "toxic"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["defog", "flashcannon", "grassknot", "icywind", "protect", "scald"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -2368,6 +2653,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	staraptor: {
 		randomBattleMoves: ["bravebird", "closecombat", "doubleedge", "quickattack", "uturn"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["bravebird", "closecombat", "doubleedge", "protect", "quickattack", "tailwind", "uturn"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
@@ -2377,6 +2663,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	bibarel: {
 		randomBattleMoves: ["aquajet", "liquidation", "quickattack", "return", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aquajet", "liquidation", "quickattack", "return", "swordsdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2386,6 +2673,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kricketune: {
 		randomBattleMoves: ["endeavor", "knockoff", "leechlife", "stickyweb", "taunt", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["knockoff", "leechlife", "protect", "stickyweb", "taunt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2398,6 +2686,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	luxray: {
 		randomBattleMoves: ["crunch", "facade", "icefang", "superpower", "voltswitch", "wildcharge"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["crunch", "helpinghand", "icefang", "protect", "superpower", "voltswitch", "wildcharge"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2407,6 +2696,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	rampardos: {
 		randomBattleMoves: ["crunch", "earthquake", "firepunch", "headsmash", "rockpolish", "rockslide"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["crunch", "earthquake", "headsmash", "protect", "rockslide", "stoneedge", "zenheadbutt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2416,6 +2706,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	bastiodon: {
 		randomBattleMoves: ["metalburst", "protect", "roar", "rockblast", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["guardsplit", "metalburst", "protect", "stealthrock", "stoneedge", "wideguard"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2425,24 +2716,28 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wormadam: {
 		randomBattleMoves: ["bugbuzz", "gigadrain", "hiddenpowerrock", "leafstorm", "quiverdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bugbuzz", "gigadrain", "leafstorm", "protect", "stringshot"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	wormadamsandy: {
 		randomBattleMoves: ["earthquake", "protect", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "protect", "rockblast", "stringshot", "suckerpunch"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	wormadamtrash: {
 		randomBattleMoves: ["flashcannon", "protect", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bugbuzz", "flashcannon", "protect", "stringshot", "strugglebug", "suckerpunch"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	mothim: {
 		randomBattleMoves: ["airslash", "bugbuzz", "energyball", "quiverdance", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "bugbuzz", "energyball", "protect", "quiverdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2452,12 +2747,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vespiquen: {
 		randomBattleMoves: ["infestation", "protect", "roost", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["attackorder", "healorder", "protect", "stringshot", "strugglebug", "tailwind"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	pachirisu: {
 		randomBattleMoves: ["nuzzle", "superfang", "thunderbolt", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["followme", "helpinghand", "nuzzle", "protect", "superfang", "thunderbolt", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2467,6 +2764,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	floatzel: {
 		randomBattleMoves: ["aquajet", "brickbreak", "bulkup", "icepunch", "liquidation", "substitute", "taunt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aquajet", "icepunch", "liquidation", "protect", "switcheroo", "taunt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2476,11 +2774,13 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cherrim: {
 		randomBattleMoves: ["dazzlinggleam", "energyball", "healingwish", "hiddenpowerfire", "synthesis"],
+		randomBattleLevel: 88,
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	cherrimsunshine: {
 		randomBattleMoves: ["gigadrain", "hiddenpowerice", "solarbeam", "sunnyday", "weatherball"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["gigadrain", "helpinghand", "solarbeam", "sunnyday", "weatherball"],
 	},
 	shellos: {
@@ -2488,6 +2788,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gastrodon: {
 		randomBattleMoves: ["earthquake", "icebeam", "recover", "scald", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthpower", "icywind", "muddywater", "protect", "recover", "scald"],
 		tier: "PU",
 		doublesTier: "DOU",
@@ -2497,6 +2798,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	drifblim: {
 		randomBattleMoves: ["acrobatics", "destinybond", "hex", "shadowball", "substitute", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["acrobatics", "destinybond", "hypnosis", "protect", "shadowball", "thunderbolt", "willowisp"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2506,12 +2808,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lopunny: {
 		randomBattleMoves: ["highjumpkick", "icepunch", "return", "switcheroo"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["encore", "fakeout", "firepunch", "helpinghand", "protect", "return", "switcheroo", "thunderwave"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	lopunnymega: {
 		randomBattleMoves: ["fakeout", "highjumpkick", "icepunch", "return", "substitute"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["encore", "fakeout", "highjumpkick", "icepunch", "protect", "return"],
 		tier: "OU",
 		doublesTier: "DUU",
@@ -2521,6 +2825,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	purugly: {
 		randomBattleMoves: ["fakeout", "knockoff", "quickattack", "return", "suckerpunch", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["fakeout", "knockoff", "protect", "quickattack", "return", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2530,6 +2835,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	skuntank: {
 		randomBattleMoves: ["crunch", "defog", "fireblast", "poisonjab", "pursuit", "suckerpunch", "taunt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["crunch", "fireblast", "poisonjab", "protect", "snarl", "suckerpunch", "taunt"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -2539,18 +2845,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	bronzong: {
 		randomBattleMoves: ["earthquake", "explosion", "ironhead", "lightscreen", "reflect", "stealthrock", "toxic"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["earthquake", "explosion", "gyroball", "lightscreen", "protect", "reflect", "trickroom"],
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	chatot: {
 		randomBattleMoves: ["boomburst", "chatter", "heatwave", "hiddenpowerground", "nastyplot", "substitute", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["boomburst", "chatter", "encore", "heatwave", "hypervoice", "nastyplot", "protect", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	spiritomb: {
 		randomBattleMoves: ["calmmind", "darkpulse", "psychic", "pursuit", "rest", "shadowsneak", "sleeptalk", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["foulplay", "icywind", "protect", "shadowsneak", "snarl", "willowisp"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -2563,12 +2872,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	garchomp: {
 		randomBattleMoves: ["dragonclaw", "earthquake", "fireblast", "firefang", "outrage", "stealthrock", "stoneedge", "swordsdance"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dragonclaw", "earthquake", "protect", "rockslide", "stoneedge", "swordsdance"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	garchompmega: {
 		randomBattleMoves: ["dracometeor", "earthquake", "fireblast", "outrage", "stoneedge", "swordsdance"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dragonclaw", "earthquake", "fireblast", "protect", "rockslide", "stoneedge", "swordsdance"],
 		tier: "(OU)",
 		doublesTier: "(DOU)",
@@ -2578,12 +2889,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lucario: {
 		randomBattleMoves: ["aurasphere", "closecombat", "crunch", "darkpulse", "extremespeed", "flashcannon", "meteormash", "nastyplot", "swordsdance", "vacuumwave"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["closecombat", "darkpulse", "extremespeed", "icepunch", "meteormash", "protect"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	lucariomega: {
 		randomBattleMoves: ["aurasphere", "closecombat", "extremespeed", "flashcannon", "icepunch", "meteormash", "nastyplot", "swordsdance", "vacuumwave"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["closecombat", "darkpulse", "extremespeed", "icepunch", "meteormash", "protect", "swordsdance"],
 		tier: "Uber",
 		doublesTier: "(DUU)",
@@ -2593,6 +2906,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hippowdon: {
 		randomBattleMoves: ["earthquake", "slackoff", "stealthrock", "stoneedge", "toxic", "whirlwind"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthquake", "protect", "rockslide", "slackoff", "stealthrock", "stoneedge", "whirlwind"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -2602,6 +2916,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	drapion: {
 		randomBattleMoves: ["aquatail", "earthquake", "knockoff", "poisonjab", "pursuit", "swordsdance", "taunt", "toxicspikes", "whirlwind"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["aquatail", "knockoff", "poisonjab", "protect", "snarl", "swordsdance", "taunt"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -2611,12 +2926,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	toxicroak: {
 		randomBattleMoves: ["drainpunch", "gunkshot", "icepunch", "substitute", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["drainpunch", "fakeout", "gunkshot", "icepunch", "protect", "suckerpunch", "swordsdance"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	carnivine: {
 		randomBattleMoves: ["knockoff", "powerwhip", "return", "sleeppowder", "substitute", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["knockoff", "powerwhip", "protect", "ragepowder", "return", "sleeppowder", "swordsdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2626,6 +2943,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lumineon: {
 		randomBattleMoves: ["defog", "icebeam", "scald", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["defog", "icebeam", "protect", "scald", "tailwind", "toxic", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2635,216 +2953,258 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	abomasnow: {
 		randomBattleMoves: ["blizzard", "earthquake", "focuspunch", "gigadrain", "iceshard", "leechseed", "substitute", "woodhammer"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["blizzard", "earthquake", "gigadrain", "iceshard", "protect", "woodhammer"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	abomasnowmega: {
 		randomBattleMoves: ["blizzard", "earthquake", "gigadrain", "hiddenpowerfire", "iceshard", "woodhammer"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["blizzard", "earthquake", "gigadrain", "iceshard", "protect", "woodhammer"],
 		tier: "NU",
 		doublesTier: "DUU",
 	},
 	rotom: {
 		randomBattleMoves: ["hiddenpowerice", "painsplit", "shadowball", "substitute", "thunderbolt", "trick", "voltswitch", "willowisp"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["electroweb", "hiddenpowerice", "protect", "shadowball", "thunderbolt", "trick", "voltswitch", "willowisp"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	rotomheat: {
 		randomBattleMoves: ["hiddenpowerice", "overheat", "painsplit", "thunderbolt", "voltswitch", "willowisp"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["electroweb", "overheat", "protect", "thunderbolt", "voltswitch", "willowisp"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	rotomwash: {
 		randomBattleMoves: ["defog", "hydropump", "painsplit", "thunderbolt", "trick", "voltswitch", "willowisp"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["electroweb", "hydropump", "protect", "thunderbolt", "trick", "voltswitch", "willowisp"],
 		tier: "OU",
 		doublesTier: "DUU",
 	},
 	rotomfrost: {
 		randomBattleMoves: ["blizzard", "painsplit", "thunderbolt", "trick", "voltswitch", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["blizzard", "electroweb", "protect", "thunderbolt", "trick", "voltswitch", "willowisp"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	rotomfan: {
 		randomBattleMoves: ["airslash", "defog", "painsplit", "thunderbolt", "voltswitch", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "electroweb", "protect", "thunderbolt", "voltswitch", "willowisp"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	rotommow: {
 		randomBattleMoves: ["hiddenpowerfire", "hiddenpowerice", "leafstorm", "thunderbolt", "trick", "voltswitch"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["electroweb", "hiddenpowerfire", "leafstorm", "protect", "thunderbolt", "trick", "voltswitch", "willowisp"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	uxie: {
 		randomBattleMoves: ["healbell", "knockoff", "psychic", "stealthrock", "thunderwave", "uturn", "yawn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["helpinghand", "knockoff", "protect", "psychic", "stealthrock", "thunderwave", "uturn", "yawn"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	mesprit: {
 		randomBattleMoves: ["calmmind", "energyball", "healingwish", "hiddenpowerfire", "icebeam", "psychic", "psyshock", "signalbeam", "stealthrock", "uturn"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["calmmind", "helpinghand", "icebeam", "knockoff", "protect", "psychic", "thunderbolt", "trick", "uturn"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	azelf: {
 		randomBattleMoves: ["dazzlinggleam", "explosion", "fireblast", "knockoff", "nastyplot", "psyshock", "stealthrock", "taunt"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["fireblast", "knockoff", "nastyplot", "protect", "psychic", "taunt", "thunderbolt", "uturn"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	dialga: {
 		randomBattleMoves: ["dracometeor", "fireblast", "flashcannon", "roar", "stealthrock", "thunderbolt", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "earthpower", "fireblast", "flashcannon", "protect", "thunderbolt"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	palkia: {
 		randomBattleMoves: ["dracometeor", "fireblast", "hydropump", "spacialrend", "thunderwave"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["dracometeor", "fireblast", "hydropump", "protect", "spacialrend", "thunderbolt"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	heatran: {
 		randomBattleMoves: ["earthpower", "flashcannon", "lavaplume", "magmastorm", "protect", "roar", "stealthrock", "toxic"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["earthpower", "flashcannon", "heatwave", "protect", "willowisp"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	regigigas: {
 		randomBattleMoves: ["confuseray", "drainpunch", "knockoff", "return", "substitute", "thunderwave"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["icywind", "knockoff", "return", "substitute", "thunderwave", "wideguard"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	giratina: {
 		randomBattleMoves: ["calmmind", "dragonpulse", "rest", "roar", "shadowball", "sleeptalk", "willowisp"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "dragonpulse", "dragontail", "protect", "shadowball", "tailwind", "willowisp"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	giratinaorigin: {
 		randomBattleMoves: ["defog", "dracometeor", "earthquake", "hex", "shadowsneak", "thunderwave", "willowisp"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "protect", "shadowball", "shadowsneak", "tailwind", "willowisp"],
 	},
 	cresselia: {
 		randomBattleMoves: ["calmmind", "icebeam", "moonblast", "moonlight", "psychic", "psyshock", "substitute", "thunderwave", "toxic"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["allyswitch", "helpinghand", "icywind", "moonblast", "moonlight", "protect", "psyshock", "thunderwave", "trickroom"],
 		tier: "RU",
 		doublesTier: "DOU",
 	},
 	phione: {
 		randomBattleMoves: ["healbell", "icebeam", "knockoff", "scald", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["helpinghand", "icywind", "protect", "scald", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	manaphy: {
 		randomBattleMoves: ["energyball", "icebeam", "surf", "tailglow"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["energyball", "helpinghand", "icebeam", "protect", "scald", "surf", "tailglow"],
 		tier: "OU",
 		doublesTier: "(DUU)",
 	},
 	darkrai: {
 		randomBattleMoves: ["darkpulse", "focusblast", "hypnosis", "nastyplot", "sludgebomb", "trick"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["darkpulse", "focusblast", "nastyplot", "protect", "sludgebomb", "snarl"],
 		tier: "Uber",
 		doublesTier: "DUU",
 	},
 	shaymin: {
 		randomBattleMoves: ["airslash", "earthpower", "leechseed", "psychic", "rest", "seedflare", "substitute"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["airslash", "earthpower", "leechseed", "protect", "rest", "seedflare", "substitute", "tailwind"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	shayminsky: {
 		randomBattleMoves: ["airslash", "earthpower", "hiddenpowerice", "leechseed", "seedflare", "substitute"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["airslash", "earthpower", "hiddenpowerice", "protect", "rest", "seedflare", "tailwind"],
 		tier: "Uber",
 		doublesTier: "DUU",
 	},
 	arceus: {
 		randomBattleMoves: ["earthquake", "extremespeed", "recover", "shadowclaw", "swordsdance"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["earthquake", "extremespeed", "protect", "recover", "shadowclaw", "swordsdance"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	arceusbug: {
 		randomBattleMoves: ["earthquake", "ironhead", "recover", "stoneedge", "swordsdance", "xscissor"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["earthquake", "ironhead", "protect", "recover", "stoneedge", "swordsdance", "xscissor"],
 	},
 	arceusdark: {
 		randomBattleMoves: ["calmmind", "fireblast", "judgment", "recover", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "focusblast", "judgment", "protect", "recover", "snarl", "willowisp"],
 	},
 	arceusdragon: {
 		randomBattleMoves: ["defog", "earthquake", "extremespeed", "fireblast", "judgment", "outrage", "recover", "swordsdance", "willowisp"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["dragonclaw", "earthquake", "extremespeed", "protect", "recover", "swordsdance"],
 	},
 	arceuselectric: {
 		randomBattleMoves: ["calmmind", "earthpower", "icebeam", "judgment", "recover"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "icebeam", "judgment", "protect", "recover"],
 	},
 	arceusfairy: {
 		randomBattleMoves: ["calmmind", "defog", "earthpower", "judgment", "recover", "toxic", "willowisp"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "defog", "earthpower", "judgment", "protect", "recover", "thunderbolt", "willowisp"],
 	},
 	arceusfighting: {
 		randomBattleMoves: ["calmmind", "icebeam", "judgment", "recover", "roar", "shadowball", "stoneedge"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "icebeam", "judgment", "protect", "recover", "shadowball", "willowisp"],
 	},
 	arceusfire: {
 		randomBattleMoves: ["calmmind", "fireblast", "icebeam", "recover", "roar", "thunderbolt"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "heatwave", "judgment", "protect", "recover", "thunderbolt", "willowisp"],
 	},
 	arceusflying: {
 		randomBattleMoves: ["calmmind", "earthpower", "fireblast", "judgment", "recover", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "earthpower", "judgment", "protect", "recover", "tailwind"],
 	},
 	arceusghost: {
 		randomBattleMoves: ["brickbreak", "defog", "extremespeed", "judgment", "recover", "shadowclaw", "shadowforce", "swordsdance", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["brickbreak", "calmmind", "focusblast", "judgment", "protect", "recover", "shadowforce", "swordsdance", "willowisp"],
 	},
 	arceusgrass: {
 		randomBattleMoves: ["calmmind", "fireblast", "icebeam", "judgment", "recover"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "heatwave", "icebeam", "judgment", "protect", "recover", "thunderwave"],
 	},
 	arceusground: {
 		randomBattleMoves: ["earthquake", "icebeam", "judgment", "recover", "stealthrock", "stoneedge", "swordsdance", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "earthquake", "icebeam", "judgment", "protect", "recover", "rockslide", "stoneedge", "swordsdance"],
 	},
 	arceusice: {
 		randomBattleMoves: ["calmmind", "fireblast", "judgment", "recover", "thunderbolt"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "focusblast", "icywind", "judgment", "protect", "recover", "thunderbolt"],
 	},
 	arceuspoison: {
 		randomBattleMoves: ["calmmind", "defog", "fireblast", "icebeam", "recover", "sludgebomb"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "earthpower", "heatwave", "judgment", "protect", "recover", "sludgebomb", "willowisp"],
 	},
 	arceuspsychic: {
 		randomBattleMoves: ["calmmind", "fireblast", "icebeam", "judgment", "recover", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "focusblast", "judgment", "protect", "psyshock", "recover", "willowisp"],
 	},
 	arceusrock: {
 		randomBattleMoves: ["earthquake", "judgment", "recover", "stealthrock", "stoneedge", "swordsdance", "willowisp"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["earthquake", "protect", "recover", "rockslide", "stoneedge", "swordsdance"],
 	},
 	arceussteel: {
 		randomBattleMoves: ["defog", "earthquake", "ironhead", "judgment", "recover", "roar", "stoneedge", "swordsdance", "willowisp"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "earthpower", "judgment", "protect", "recover", "willowisp"],
 	},
 	arceuswater: {
 		randomBattleMoves: ["calmmind", "defog", "icebeam", "judgment", "recover", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["calmmind", "fireblast", "icebeam", "icywind", "judgment", "protect", "recover", "surf"],
 	},
 	victini: {
 		randomBattleMoves: ["blueflare", "boltstrike", "focusblast", "grassknot", "uturn", "vcreate", "zenheadbutt"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["blueflare", "boltstrike", "protect", "psychic", "uturn", "vcreate"],
 		tier: "OU",
 		doublesTier: "DOU",
@@ -2857,6 +3217,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	serperior: {
 		randomBattleMoves: ["dragonpulse", "glare", "hiddenpowerfire", "leafstorm", "leechseed", "substitute"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dragonpulse", "hiddenpowerfire", "leafstorm", "protect", "taunt"],
 		tier: "OU",
 		doublesTier: "(DUU)",
@@ -2869,6 +3230,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	emboar: {
 		randomBattleMoves: ["fireblast", "flareblitz", "grassknot", "headsmash", "suckerpunch", "superpower", "wildcharge"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["flareblitz", "headsmash", "heatwave", "protect", "rockslide", "superpower", "wildcharge"],
 		tier: "NUBL",
 		doublesTier: "(DUU)",
@@ -2881,6 +3243,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	samurott: {
 		randomBattleMoves: ["aquajet", "grassknot", "hydropump", "icebeam", "liquidation", "megahorn", "sacredsword", "swordsdance"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["aquajet", "helpinghand", "hiddenpowergrass", "hydropump", "icebeam", "protect", "scald", "taunt"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -2890,6 +3253,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	watchog: {
 		randomBattleMoves: ["hypnosis", "knockoff", "return", "substitute", "superfang", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["hypnosis", "knockoff", "protect", "return", "superfang", "swordsdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2902,6 +3266,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	stoutland: {
 		randomBattleMoves: ["crunch", "icefang", "return", "superpower", "wildcharge"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["crunch", "protect", "return", "superpower", "wildcharge"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -2911,6 +3276,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	liepard: {
 		randomBattleMoves: ["copycat", "encore", "knockoff", "playrough", "substitute", "thunderwave", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["encore", "fakeout", "knockoff", "playrough", "protect", "suckerpunch", "thunderwave", "uturn"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -2920,6 +3286,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	simisage: {
 		randomBattleMoves: ["focusblast", "gigadrain", "hiddenpowerice", "knockoff", "leafstorm", "nastyplot", "substitute", "superpower"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["focusblast", "gigadrain", "helpinghand", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "nastyplot", "spikyshield", "taunt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2929,6 +3296,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	simisear: {
 		randomBattleMoves: ["fireblast", "focusblast", "grassknot", "hiddenpowerrock", "nastyplot", "substitute"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["fireblast", "focusblast", "grassknot", "heatwave", "nastyplot", "protect", "taunt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2938,6 +3306,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	simipour: {
 		randomBattleMoves: ["focusblast", "hydropump", "icebeam", "nastyplot", "substitute"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["helpinghand", "hydropump", "icebeam", "nastyplot", "protect", "taunt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2947,6 +3316,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	musharna: {
 		randomBattleMoves: ["calmmind", "healbell", "moonlight", "psychic", "psyshock", "signalbeam", "thunderwave"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["helpinghand", "hypnosis", "moonlight", "protect", "psychic", "signalbeam", "thunderwave", "trickroom"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -2959,6 +3329,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	unfezant: {
 		randomBattleMoves: ["hypnosis", "nightslash", "pluck", "return", "roost", "tailwind", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["nightslash", "pluck", "protect", "return", "roost", "tailwind", "taunt", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2968,6 +3339,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	zebstrika: {
 		randomBattleMoves: ["hiddenpowergrass", "overheat", "thunderbolt", "voltswitch", "wildcharge"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["hiddenpowergrass", "overheat", "protect", "voltswitch", "wildcharge"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2980,6 +3352,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gigalith: {
 		randomBattleMoves: ["earthquake", "explosion", "stealthrock", "stoneedge", "superpower"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["protect", "rockslide", "stealthrock", "stompingtantrum", "stoneedge", "superpower", "wideguard"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -2989,6 +3362,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swoobat: {
 		randomBattleMoves: ["airslash", "calmmind", "heatwave", "roost", "storedpower"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "calmmind", "heatwave", "protect", "psychic", "tailwind"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -2998,18 +3372,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	excadrill: {
 		randomBattleMoves: ["earthquake", "ironhead", "rapidspin", "rockslide", "swordsdance"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["drillrun", "earthquake", "ironhead", "protect", "rockslide", "swordsdance"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	audino: {
 		randomBattleMoves: ["doubleedge", "encore", "healbell", "protect", "toxic", "wish"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["healpulse", "helpinghand", "hypervoice", "protect", "thunderwave", "trickroom"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	audinomega: {
 		randomBattleMoves: ["calmmind", "dazzlinggleam", "fireblast", "healbell", "protect", "wish"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["dazzlinggleam", "healpulse", "helpinghand", "hypervoice", "protect", "thunderwave", "trickroom"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -3023,6 +3400,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	conkeldurr: {
 		randomBattleMoves: ["bulkup", "drainpunch", "facade", "knockoff", "machpunch"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["drainpunch", "facade", "knockoff", "machpunch", "protect"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
@@ -3035,18 +3413,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	seismitoad: {
 		randomBattleMoves: ["earthquake", "hydropump", "knockoff", "raindance", "scald", "sludgewave", "stealthrock", "toxic"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["earthquake", "hydropump", "muddywater", "protect", "raindance", "sludgebomb"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	throh: {
 		randomBattleMoves: ["bulkup", "circlethrow", "icepunch", "knockoff", "rest", "sleeptalk", "stormthrow"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["circlethrow", "helpinghand", "icepunch", "knockoff", "protect", "stormthrow"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	sawk: {
 		randomBattleMoves: ["bulkup", "closecombat", "earthquake", "icepunch", "knockoff", "poisonjab", "stoneedge"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["closecombat", "icepunch", "knockoff", "protect", "rockslide"],
 		tier: "PUBL",
 		doublesTier: "(DUU)",
@@ -3059,6 +3440,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	leavanny: {
 		randomBattleMoves: ["knockoff", "leafblade", "stickyweb", "swordsdance", "xscissor"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["leafblade", "protect", "stickyweb", "swordsdance", "xscissor"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3071,6 +3453,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	scolipede: {
 		randomBattleMoves: ["earthquake", "megahorn", "poisonjab", "protect", "spikes", "swordsdance", "toxicspikes"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["aquatail", "megahorn", "poisonjab", "protect", "rockslide", "superpower", "swordsdance"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
@@ -3080,6 +3463,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	whimsicott: {
 		randomBattleMoves: ["defog", "encore", "leechseed", "memento", "moonblast", "stunspore", "tailwind", "taunt", "toxic", "uturn"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["dazzlinggleam", "defog", "encore", "gigadrain", "helpinghand", "leechseed", "moonblast", "protect", "stunspore", "substitute", "tailwind", "taunt", "uturn"],
 		tier: "NU",
 		doublesTier: "DOU",
@@ -3089,18 +3473,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lilligant: {
 		randomBattleMoves: ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "petaldance", "quiverdance", "sleeppowder"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["gigadrain", "helpinghand", "hiddenpowerfire", "hiddenpowerice", "hiddenpowerrock", "petaldance", "protect", "quiverdance", "sleeppowder"],
 		tier: "PUBL",
 		doublesTier: "(DUU)",
 	},
 	basculin: {
 		randomBattleMoves: ["aquajet", "crunch", "headsmash", "liquidation", "superpower"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aquajet", "icebeam", "liquidation", "muddywater", "protect", "superpower"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	basculinbluestriped: {
 		randomBattleMoves: ["aquajet", "crunch", "headsmash", "liquidation", "superpower"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aquajet", "icebeam", "liquidation", "muddywater", "protect", "superpower"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3113,6 +3500,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	krookodile: {
 		randomBattleMoves: ["earthquake", "knockoff", "pursuit", "stealthrock", "stoneedge", "superpower"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthquake", "knockoff", "protect", "stoneedge", "superpower"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -3122,12 +3510,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	darmanitan: {
 		randomBattleMoves: ["earthquake", "flareblitz", "rockslide", "superpower", "uturn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["earthquake", "flareblitz", "protect", "rockslide", "superpower", "uturn"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
 	},
 	maractus: {
 		randomBattleMoves: ["gigadrain", "hiddenpowerfire", "leechseed", "spikes", "spikyshield", "suckerpunch", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["energyball", "helpinghand", "hiddenpowerfire", "leechseed", "spikyshield", "suckerpunch"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3137,6 +3527,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	crustle: {
 		randomBattleMoves: ["earthquake", "shellsmash", "spikes", "stealthrock", "stoneedge", "xscissor"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "protect", "rockslide", "shellsmash", "stoneedge", "xscissor"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3146,12 +3537,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	scrafty: {
 		randomBattleMoves: ["bulkup", "dragondance", "drainpunch", "highjumpkick", "icepunch", "knockoff", "rest"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["drainpunch", "fakeout", "icepunch", "knockoff", "protect", "superfang"],
 		tier: "NU",
 		doublesTier: "DOU",
 	},
 	sigilyph: {
 		randomBattleMoves: ["airslash", "calmmind", "heatwave", "icebeam", "psychic", "psyshock", "roost"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["airslash", "calmmind", "heatwave", "protect", "psyshock", "tailwind"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -3161,6 +3554,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cofagrigus: {
 		randomBattleMoves: ["haze", "hiddenpowerfighting", "nastyplot", "painsplit", "shadowball", "toxicspikes", "trickroom", "willowisp"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["hiddenpowerfighting", "nastyplot", "protect", "shadowball", "trickroom", "willowisp"],
 		tier: "NUBL",
 		doublesTier: "DUU",
@@ -3170,6 +3564,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	carracosta: {
 		randomBattleMoves: ["aquajet", "earthquake", "liquidation", "shellsmash", "stoneedge"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aquajet", "earthquake", "liquidation", "protect", "rockslide", "shellsmash", "stoneedge", "wideguard"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -3179,6 +3574,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	archeops: {
 		randomBattleMoves: ["acrobatics", "aquatail", "earthquake", "endeavor", "headsmash", "stoneedge", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["acrobatics", "earthpower", "protect", "rockslide", "stoneedge", "tailwind", "taunt", "uturn"],
 		tier: "PUBL",
 		doublesTier: "(DUU)",
@@ -3188,6 +3584,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	garbodor: {
 		randomBattleMoves: ["gunkshot", "haze", "painsplit", "spikes", "stompingtantrum", "toxic", "toxicspikes"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["drainpunch", "gunkshot", "painsplit", "protect", "toxicspikes"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -3197,6 +3594,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	zoroark: {
 		randomBattleMoves: ["darkpulse", "flamethrower", "focusblast", "nastyplot", "sludgebomb", "trick"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["darkpulse", "flamethrower", "focusblast", "knockoff", "nastyplot", "protect", "suckerpunch", "uturn"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
@@ -3206,6 +3604,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	cinccino: {
 		randomBattleMoves: ["bulletseed", "knockoff", "rockblast", "tailslap", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bulletseed", "knockoff", "protect", "rockblast", "tailslap", "uturn"],
 		tier: "PUBL",
 		doublesTier: "(DUU)",
@@ -3218,6 +3617,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gothitelle: {
 		randomBattleMoves: ["charm", "confide", "rest", "taunt"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["charm", "healpulse", "protect", "psychic", "shadowball", "taunt", "thunderbolt", "trickroom"],
 		tier: "(PU)",
 		doublesTier: "DOU",
@@ -3230,6 +3630,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	reuniclus: {
 		randomBattleMoves: ["calmmind", "focusblast", "psychic", "psyshock", "recover", "shadowball", "trickroom"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["focusblast", "helpinghand", "protect", "psychic", "shadowball", "trickroom"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
@@ -3239,6 +3640,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	swanna: {
 		randomBattleMoves: ["bravebird", "defog", "hurricane", "icebeam", "raindance", "roost", "scald"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["bravebird", "hurricane", "icebeam", "protect", "scald", "tailwind"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3251,6 +3653,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vanilluxe: {
 		randomBattleMoves: ["autotomize", "blizzard", "explosion", "flashcannon", "freezedry", "hiddenpowerground"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["autotomize", "blizzard", "flashcannon", "freezedry", "hiddenpowerground", "protect", "taunt"],
 		tier: "NUBL",
 		doublesTier: "(DUU)",
@@ -3260,12 +3663,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	sawsbuck: {
 		randomBattleMoves: ["hornleech", "jumpkick", "return", "substitute", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["hornleech", "jumpkick", "protect", "return", "swordsdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	emolga: {
 		randomBattleMoves: ["acrobatics", "encore", "knockoff", "roost", "thunderbolt", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "encore", "helpinghand", "protect", "roost", "tailwind", "thunderbolt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3275,6 +3680,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	escavalier: {
 		randomBattleMoves: ["drillrun", "ironhead", "knockoff", "megahorn", "pursuit", "swordsdance"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["drillrun", "ironhead", "knockoff", "megahorn", "protect", "swordsdance"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -3284,6 +3690,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	amoonguss: {
 		randomBattleMoves: ["clearsmog", "foulplay", "gigadrain", "hiddenpowerfire", "sludgebomb", "spore", "synthesis"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["gigadrain", "hiddenpowerfire", "protect", "ragepowder", "sludgebomb", "spore", "stunspore"],
 		tier: "UU",
 		doublesTier: "DOU",
@@ -3293,12 +3700,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	jellicent: {
 		randomBattleMoves: ["icebeam", "recover", "scald", "shadowball", "taunt", "toxic", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["icywind", "protect", "recover", "scald", "shadowball", "trickroom", "willowisp"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	alomomola: {
 		randomBattleMoves: ["knockoff", "protect", "scald", "toxic", "wish"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["helpinghand", "icywind", "knockoff", "protect", "scald", "wideguard"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -3308,6 +3717,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	galvantula: {
 		randomBattleMoves: ["bugbuzz", "gigadrain", "hiddenpowerice", "stickyweb", "thunder", "voltswitch"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["bugbuzz", "energyball", "hiddenpowerice", "protect", "stickyweb", "thunder", "voltswitch"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -3318,6 +3728,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ferrothorn: {
 		randomBattleMoves: ["gyroball", "leechseed", "powerwhip", "protect", "spikes", "stealthrock"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["gyroball", "knockoff", "leechseed", "powerwhip", "protect", "stealthrock"],
 		tier: "OU",
 		doublesTier: "DOU",
@@ -3330,6 +3741,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	klinklang: {
 		randomBattleMoves: ["geargrind", "return", "shiftgear", "substitute", "wildcharge"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["geargrind", "protect", "return", "shiftgear", "wildcharge"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -3342,6 +3754,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	eelektross: {
 		randomBattleMoves: ["flamethrower", "gigadrain", "hiddenpowerice", "knockoff", "superpower", "thunderbolt", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["flamethrower", "gigadrain", "knockoff", "protect", "thunderbolt", "uturn", "voltswitch"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -3351,6 +3764,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	beheeyem: {
 		randomBattleMoves: ["hiddenpowerfighting", "nastyplot", "psychic", "psyshock", "signalbeam", "thunderbolt", "trick", "trickroom"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["hiddenpowerfighting", "protect", "psychic", "recover", "signalbeam", "thunderbolt", "trick", "trickroom"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3363,6 +3777,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	chandelure: {
 		randomBattleMoves: ["calmmind", "energyball", "fireblast", "hiddenpowerground", "shadowball", "substitute", "trick"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["energyball", "heatwave", "overheat", "protect", "shadowball", "trick"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -3375,6 +3790,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	haxorus: {
 		randomBattleMoves: ["dragondance", "earthquake", "outrage", "poisonjab", "swordsdance", "taunt"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["dragonclaw", "dragondance", "earthquake", "poisonjab", "protect", "swordsdance", "taunt"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -3384,12 +3800,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	beartic: {
 		randomBattleMoves: ["aquajet", "iciclecrash", "nightslash", "stoneedge", "superpower", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["aquajet", "iciclecrash", "protect", "stoneedge", "superpower", "swordsdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	cryogonal: {
 		randomBattleMoves: ["freezedry", "haze", "hiddenpowerground", "icebeam", "rapidspin", "recover", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["freezedry", "hiddenpowerground", "icebeam", "icywind", "protect", "recover"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -3399,12 +3817,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	accelgor: {
 		randomBattleMoves: ["bugbuzz", "encore", "energyball", "focusblast", "hiddenpowerrock", "spikes", "toxicspikes", "yawn"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["bugbuzz", "encore", "energyball", "focusblast", "hiddenpowerrock", "protect", "sludgebomb", "yawn"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	stunfisk: {
 		randomBattleMoves: ["discharge", "earthpower", "rest", "scald", "sleeptalk", "stealthrock", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["discharge", "earthpower", "electroweb", "protect", "scald", "stealthrock"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3414,12 +3834,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mienshao: {
 		randomBattleMoves: ["fakeout", "highjumpkick", "knockoff", "poisonjab", "stoneedge", "swordsdance", "uturn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["drainpunch", "fakeout", "feint", "highjumpkick", "knockoff", "protect", "stoneedge", "swordsdance", "uturn"],
 		tier: "RUBL",
 		doublesTier: "DUU",
 	},
 	druddigon: {
 		randomBattleMoves: ["dragontail", "earthquake", "firepunch", "glare", "gunkshot", "outrage", "stealthrock", "suckerpunch"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["dragonclaw", "earthquake", "firepunch", "glare", "protect", "suckerpunch", "superpower", "thunderpunch"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -3429,6 +3851,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	golurk: {
 		randomBattleMoves: ["dynamicpunch", "earthquake", "icepunch", "rockpolish", "shadowpunch", "stealthrock"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["dynamicpunch", "earthquake", "icepunch", "protect", "rockpolish", "shadowpunch", "stoneedge"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -3438,12 +3861,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	bisharp: {
 		randomBattleMoves: ["ironhead", "knockoff", "lowkick", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["ironhead", "knockoff", "protect", "suckerpunch", "swordsdance"],
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	bouffalant: {
 		randomBattleMoves: ["earthquake", "headcharge", "megahorn", "stoneedge", "superpower", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["headcharge", "megahorn", "protect", "stompingtantrum", "stoneedge", "superpower", "swordsdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3453,6 +3878,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	braviary: {
 		randomBattleMoves: ["bravebird", "bulkup", "return", "roost", "substitute", "superpower", "uturn"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["bravebird", "protect", "return", "skydrop", "superpower", "tailwind", "uturn"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -3462,18 +3888,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mandibuzz: {
 		randomBattleMoves: ["bravebird", "defog", "foulplay", "roost", "taunt", "toxic", "uturn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["bravebird", "knockoff", "protect", "roost", "snarl", "tailwind", "taunt", "uturn"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	heatmor: {
 		randomBattleMoves: ["fireblast", "focusblast", "gigadrain", "knockoff", "suckerpunch"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["firelash", "gigadrain", "incinerate", "protect", "suckerpunch", "superpower"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	durant: {
 		randomBattleMoves: ["honeclaws", "ironhead", "rockslide", "superpower", "xscissor"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["honeclaws", "ironhead", "protect", "rockslide", "superpower", "xscissor"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
@@ -3486,6 +3915,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	hydreigon: {
 		randomBattleMoves: ["darkpulse", "dracometeor", "earthpower", "fireblast", "flashcannon", "roost", "superpower", "uturn"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["darkpulse", "dracometeor", "fireblast", "flashcannon", "protect", "tailwind", "uturn"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -3495,96 +3925,112 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	volcarona: {
 		randomBattleMoves: ["bugbuzz", "fierydance", "fireblast", "gigadrain", "hiddenpowerground", "quiverdance", "roost"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["bugbuzz", "fierydance", "gigadrain", "heatwave", "protect", "quiverdance", "tailwind"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	cobalion: {
 		randomBattleMoves: ["closecombat", "ironhead", "stealthrock", "stoneedge", "swordsdance", "voltswitch"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["closecombat", "ironhead", "protect", "stoneedge", "swordsdance", "thunderwave"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	terrakion: {
 		randomBattleMoves: ["closecombat", "earthquake", "quickattack", "stealthrock", "stoneedge", "swordsdance"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["closecombat", "protect", "rockslide", "stompingtantrum", "stoneedge", "taunt"],
 		tier: "UU",
 		doublesTier: "DOU",
 	},
 	virizion: {
 		randomBattleMoves: ["closecombat", "leafblade", "stoneedge", "swordsdance"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["closecombat", "leafblade", "protect", "stoneedge", "swordsdance", "taunt"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	tornadus: {
 		randomBattleMoves: ["defog", "grassknot", "heatwave", "hurricane", "superpower", "tailwind", "uturn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["heatwave", "hurricane", "protect", "skydrop", "superpower", "tailwind", "taunt", "uturn"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
 	},
 	tornadustherian: {
 		randomBattleMoves: ["heatwave", "hurricane", "knockoff", "superpower", "taunt", "uturn"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["heatwave", "hurricane", "protect", "skydrop", "tailwind", "taunt", "uturn"],
 		tier: "OU",
 		doublesTier: "(DUU)",
 	},
 	thundurus: {
 		randomBattleMoves: ["focusblast", "hiddenpowerflying", "hiddenpowerice", "knockoff", "nastyplot", "substitute", "taunt", "thunderbolt", "thunderwave"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["focusblast", "hiddenpowerflying", "hiddenpowerice", "knockoff", "nastyplot", "protect", "taunt", "thunderbolt", "thunderwave"],
 		tier: "UUBL",
 		doublesTier: "DUU",
 	},
 	thundurustherian: {
 		randomBattleMoves: ["focusblast", "hiddenpowerflying", "hiddenpowerice", "nastyplot", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["focusblast", "hiddenpowerflying", "hiddenpowerice", "nastyplot", "protect", "thunderbolt", "voltswitch"],
 		tier: "UUBL",
 		doublesTier: "DUU",
 	},
 	reshiram: {
 		randomBattleMoves: ["blueflare", "dracometeor", "dragonpulse", "flamecharge", "roost", "stoneedge", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["blueflare", "dracometeor", "dragonpulse", "flamecharge", "heatwave", "protect", "roost", "tailwind"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	zekrom: {
 		randomBattleMoves: ["boltstrike", "dracometeor", "dragonclaw", "honeclaws", "outrage", "roost", "substitute", "voltswitch"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["boltstrike", "dracometeor", "dragonclaw", "honeclaws", "protect", "roost", "tailwind"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	landorus: {
 		randomBattleMoves: ["calmmind", "earthpower", "focusblast", "knockoff", "psychic", "rockpolish", "rockslide", "sludgewave", "stealthrock"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["earthpower", "focusblast", "hiddenpowerice", "protect", "psychic", "rockslide", "sludgebomb"],
 		tier: "Uber",
 		doublesTier: "DUU",
 	},
 	landorustherian: {
 		randomBattleMoves: ["earthquake", "fly", "rockpolish", "stealthrock", "stoneedge", "superpower", "swordsdance", "uturn"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["earthquake", "fly", "knockoff", "protect", "rockslide", "stoneedge", "superpower", "swordsdance", "uturn"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	kyurem: {
 		randomBattleMoves: ["dracometeor", "earthpower", "focusblast", "icebeam", "outrage", "roost", "substitute"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "earthpower", "glaciate", "icebeam", "protect", "roost"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
 	},
 	kyuremblack: {
 		randomBattleMoves: ["dragonclaw", "earthpower", "fusionbolt", "icebeam", "outrage", "roost", "substitute"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dragonclaw", "earthpower", "fusionbolt", "icebeam", "protect", "roost"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	kyuremwhite: {
 		randomBattleMoves: ["dracometeor", "earthpower", "focusblast", "fusionflare", "icebeam", "roost", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "earthpower", "fusionflare", "icebeam", "protect", "roost"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	keldeo: {
 		randomBattleMoves: ["calmmind", "hiddenpowerelectric", "hiddenpowerflying", "hydropump", "icywind", "scald", "secretsword", "substitute"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["calmmind", "hiddenpowerelectric", "hiddenpowerflying", "hydropump", "icywind", "protect", "secretsword", "taunt"],
 		tier: "OU",
 		doublesTier: "(DUU)",
@@ -3595,16 +4041,19 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	meloetta: {
 		randomBattleMoves: ["calmmind", "focusblast", "hypervoice", "psyshock", "shadowball", "trick", "uturn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["calmmind", "focusblast", "hypervoice", "protect", "psyshock", "shadowball"],
 		tier: "RUBL",
 		doublesTier: "(DUU)",
 	},
 	meloettapirouette: {
 		randomBattleMoves: ["closecombat", "knockoff", "relicsong", "return"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["closecombat", "knockoff", "protect", "relicsong", "return"],
 	},
 	genesect: {
 		randomBattleMoves: ["blazekick", "extremespeed", "flamethrower", "icebeam", "ironhead", "shiftgear", "technoblast", "thunderbolt", "uturn"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["bugbuzz", "extremespeed", "flamethrower", "icebeam", "ironhead", "protect", "technoblast", "thunderbolt", "uturn"],
 		tier: "Uber",
 		doublesTier: "DOU",
@@ -3633,6 +4082,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	chesnaught: {
 		randomBattleMoves: ["drainpunch", "leechseed", "spikes", "spikyshield", "synthesis", "woodhammer"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["hammerarm", "leechseed", "rockslide", "spikyshield", "stoneedge", "woodhammer"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -3645,6 +4095,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	delphox: {
 		randomBattleMoves: ["calmmind", "fireblast", "grassknot", "psyshock", "shadowball", "switcheroo"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["calmmind", "fireblast", "grassknot", "heatwave", "protect", "psyshock", "switcheroo"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -3657,12 +4108,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	greninja: {
 		randomBattleMoves: ["gunkshot", "hydropump", "icebeam", "spikes", "taunt", "toxicspikes", "uturn"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["darkpulse", "gunkshot", "hydropump", "icebeam", "matblock", "protect", "taunt", "uturn"],
 		tier: "OU",
 		doublesTier: "DUU",
 	},
 	greninjaash: {
 		randomBattleMoves: ["darkpulse", "hydropump", "icebeam", "uturn", "watershuriken"],
+		randomBattleLevel: 80,
 		tier: "OU",
 		doublesTier: "DUU",
 	},
@@ -3671,6 +4124,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	diggersby: {
 		randomBattleMoves: ["agility", "earthquake", "knockoff", "quickattack", "return", "swordsdance", "uturn", "wildcharge"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthquake", "knockoff", "protect", "quickattack", "return", "uturn"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
@@ -3683,6 +4137,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	talonflame: {
 		randomBattleMoves: ["bravebird", "flareblitz", "overheat", "roost", "swordsdance", "uturn", "willowisp"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["bravebird", "flareblitz", "protect", "roost", "swordsdance", "tailwind", "taunt", "uturn", "willowisp"],
 		tier: "RUBL",
 		doublesTier: "DUU",
@@ -3695,6 +4150,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vivillon: {
 		randomBattleMoves: ["energyball", "hurricane", "quiverdance", "sleeppowder", "substitute"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["bugbuzz", "hurricane", "protect", "quiverdance", "sleeppowder"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -3712,6 +4168,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	pyroar: {
 		randomBattleMoves: ["darkpulse", "fireblast", "hypervoice", "solarbeam", "sunnyday", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["fireblast", "hypervoice", "protect", "solarbeam", "sunnyday", "willowisp"],
 		tier: "PUBL",
 		doublesTier: "(DUU)",
@@ -3724,12 +4181,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	floetteeternal: {
 		randomBattleMoves: ["hiddenpowerfire", "hiddenpowerground", "lightofruin", "moonblast", "psychic"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["calmmind", "dazzlinggleam", "hiddenpowerfire", "lightofruin", "protect", "psychic"],
 		isNonstandard: "Unobtainable",
 		tier: "Illegal",
 	},
 	florges: {
 		randomBattleMoves: ["aromatherapy", "defog", "moonblast", "protect", "synthesis", "toxic", "wish"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["calmmind", "dazzlinggleam", "defog", "helpinghand", "moonblast", "protect", "psychic"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -3739,6 +4198,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gogoat: {
 		randomBattleMoves: ["bulkup", "earthquake", "hornleech", "leechseed", "milkdrink", "rockslide", "substitute"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["brickbreak", "bulkup", "earthquake", "hornleech", "leechseed", "milkdrink", "protect", "rockslide"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3748,12 +4208,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	pangoro: {
 		randomBattleMoves: ["bulletpunch", "drainpunch", "icepunch", "knockoff", "superpower", "swordsdance"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["gunkshot", "hammerarm", "icepunch", "knockoff", "partingshot", "protect"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	furfrou: {
 		randomBattleMoves: ["cottonguard", "rest", "return", "substitute", "suckerpunch", "thunderwave", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["cottonguard", "protect", "return", "snarl", "thunderwave", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3763,12 +4225,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	meowstic: {
 		randomBattleMoves: ["healbell", "lightscreen", "psychic", "reflect", "thunderwave", "toxic", "yawn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["fakeout", "lightscreen", "protect", "psychic", "reflect", "thunderwave"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	meowsticf: {
 		randomBattleMoves: ["calmmind", "energyball", "psychic", "psyshock", "shadowball", "thunderbolt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["darkpulse", "energyball", "fakeout", "helpinghand", "nastyplot", "protect", "psychic", "thunderbolt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3778,18 +4242,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	doublade: {
 		randomBattleMoves: ["ironhead", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["ironhead", "protect", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"],
 		tier: "UU",
 		doublesTier: "NFE",
 	},
 	aegislash: {
 		randomBattleMoves: ["flashcannon", "hiddenpowerice", "kingsshield", "shadowball", "shadowsneak", "toxic"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["flashcannon", "hiddenpowerice", "kingsshield", "shadowball", "shadowsneak"],
 		tier: "Uber",
 		doublesTier: "DOU",
 	},
 	aegislashblade: {
 		randomBattleMoves: ["ironhead", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["ironhead", "kingsshield", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"],
 	},
 	spritzee: {
@@ -3797,6 +4264,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	aromatisse: {
 		randomBattleMoves: ["calmmind", "moonblast", "rest", "sleeptalk", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["healpulse", "moonblast", "protect", "thunderbolt", "trickroom"],
 		tier: "PUBL",
 		doublesTier: "(DUU)",
@@ -3806,6 +4274,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	slurpuff: {
 		randomBattleMoves: ["bellydrum", "drainpunch", "playrough", "return"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["bellydrum", "drainpunch", "playrough", "protect", "return"],
 		tier: "NUBL",
 		doublesTier: "(DUU)",
@@ -3815,6 +4284,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	malamar: {
 		randomBattleMoves: ["happyhour", "knockoff", "psychocut", "rest", "sleeptalk", "superpower"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["knockoff", "protect", "psychocut", "rockslide", "superpower", "trickroom"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -3824,6 +4294,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	barbaracle: {
 		randomBattleMoves: ["earthquake", "liquidation", "lowkick", "shellsmash", "stoneedge"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["crosschop", "liquidation", "protect", "rockslide", "shellsmash"],
 		tier: "NUBL",
 		doublesTier: "(DUU)",
@@ -3833,6 +4304,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	dragalge: {
 		randomBattleMoves: ["dracometeor", "dragonpulse", "focusblast", "hiddenpowerfire", "scald", "sludgewave", "toxicspikes"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "focusblast", "hiddenpowerfire", "protect", "scald", "sludgebomb"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -3842,6 +4314,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	clawitzer: {
 		randomBattleMoves: ["aurasphere", "darkpulse", "icebeam", "scald", "uturn", "waterpulse"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["aurasphere", "darkpulse", "helpinghand", "icebeam", "muddywater", "protect", "uturn", "waterpulse"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -3851,6 +4324,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	heliolisk: {
 		randomBattleMoves: ["darkpulse", "hiddenpowerice", "hypervoice", "raindance", "surf", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["darkpulse", "grassknot", "hypervoice", "protect", "thunderbolt", "voltswitch"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -3860,6 +4334,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	tyrantrum: {
 		randomBattleMoves: ["dragonclaw", "dragondance", "earthquake", "headsmash", "outrage", "stealthrock", "superpower"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["dragonclaw", "dragondance", "earthquake", "headsmash", "protect", "rockslide"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -3869,30 +4344,35 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	aurorus: {
 		randomBattleMoves: ["ancientpower", "blizzard", "earthpower", "freezedry", "hypervoice", "stealthrock", "thunderwave"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["ancientpower", "earthpower", "freezedry", "hypervoice", "icywind", "protect", "thunderwave"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	sylveon: {
 		randomBattleMoves: ["calmmind", "hiddenpowerfire", "hypervoice", "protect", "psyshock", "wish"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["helpinghand", "hiddenpowerground", "hypervoice", "protect", "psyshock", "shadowball"],
 		tier: "UU",
 		doublesTier: "DUU",
 	},
 	hawlucha: {
 		randomBattleMoves: ["acrobatics", "highjumpkick", "skyattack", "substitute", "swordsdance"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["acrobatics", "encore", "highjumpkick", "protect", "swordsdance"],
 		tier: "OU",
 		doublesTier: "(DUU)",
 	},
 	dedenne: {
 		randomBattleMoves: ["protect", "recycle", "thunderbolt", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["eerieimpulse", "helpinghand", "nuzzle", "recycle", "superfang", "thunderbolt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	carbink: {
 		randomBattleMoves: ["explosion", "lightscreen", "moonblast", "powergem", "reflect", "stealthrock"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["explosion", "lightscreen", "moonblast", "protect", "reflect", "stealthrock", "trickroom"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3905,12 +4385,14 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	goodra: {
 		randomBattleMoves: ["dracometeor", "dragontail", "earthquake", "fireblast", "powerwhip", "sludgebomb", "thunderbolt"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "fireblast", "muddywater", "powerwhip", "protect", "thunderbolt"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	klefki: {
 		randomBattleMoves: ["dazzlinggleam", "foulplay", "magnetrise", "spikes", "thunderwave", "toxic"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["dazzlinggleam", "foulplay", "lightscreen", "playrough", "protect", "reflect", "thunderwave"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -3920,6 +4402,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	trevenant: {
 		randomBattleMoves: ["earthquake", "hornleech", "rockslide", "shadowclaw", "trickroom", "woodhammer"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["hornleech", "leechseed", "protect", "rockslide", "shadowclaw", "trickroom", "willowisp", "woodhammer"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3938,24 +4421,28 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gourgeist: {
 		randomBattleMoves: ["leechseed", "seedbomb", "shadowsneak", "substitute", "synthesis", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["leechseed", "phantomforce", "protect", "seedbomb", "shadowsneak", "willowisp"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	gourgeistsmall: {
 		randomBattleMoves: ["leechseed", "seedbomb", "shadowsneak", "substitute", "synthesis", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["leechseed", "phantomforce", "protect", "seedbomb", "shadowsneak", "willowisp"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	gourgeistlarge: {
 		randomBattleMoves: ["leechseed", "seedbomb", "shadowsneak", "substitute", "synthesis", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["leechseed", "phantomforce", "protect", "seedbomb", "shadowsneak", "trickroom", "willowisp"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	gourgeistsuper: {
 		randomBattleMoves: ["leechseed", "seedbomb", "shadowsneak", "substitute", "synthesis", "willowisp"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["leechseed", "phantomforce", "protect", "seedbomb", "shadowsneak", "trickroom", "willowisp"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3965,6 +4452,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	avalugg: {
 		randomBattleMoves: ["avalanche", "earthquake", "rapidspin", "recover", "roar", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["avalanche", "earthquake", "protect", "recover"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -3974,30 +4462,35 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	noivern: {
 		randomBattleMoves: ["boomburst", "dracometeor", "flamethrower", "hurricane", "roost", "switcheroo", "taunt", "uturn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["dracometeor", "flamethrower", "hurricane", "protect", "switcheroo", "tailwind", "taunt", "uturn"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	xerneas: {
 		randomBattleMoves: ["focusblast", "geomancy", "hiddenpowerfire", "moonblast", "psyshock", "thunderbolt"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["closecombat", "dazzlinggleam", "focusblast", "geomancy", "hiddenpowerfire", "protect", "psyshock", "rockslide", "thunderbolt"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	yveltal: {
 		randomBattleMoves: ["darkpulse", "focusblast", "foulplay", "oblivionwing", "roost", "suckerpunch", "taunt", "toxic", "uturn"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["darkpulse", "heatwave", "oblivionwing", "protect", "roost", "skydrop", "snarl", "suckerpunch", "taunt"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	zygarde: {
 		randomBattleMoves: ["dragondance", "extremespeed", "outrage", "substitute", "thousandarrows"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["coil", "dragondance", "extremespeed", "glare", "protect", "rockslide", "stoneedge", "thousandarrows"],
 		tier: "Uber",
 		doublesTier: "DOU",
 	},
 	zygarde10: {
 		randomBattleMoves: ["coil", "extremespeed", "irontail", "outrage", "thousandarrows"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["dragondance", "extremespeed", "irontail", "protect", "thousandarrows"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -4008,30 +4501,35 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	diancie: {
 		randomBattleMoves: ["diamondstorm", "earthpower", "lightscreen", "moonblast", "reflect", "stealthrock"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["calmmind", "dazzlinggleam", "diamondstorm", "earthpower", "moonblast", "protect"],
 		tier: "RU",
 		doublesTier: "DOU",
 	},
 	dianciemega: {
 		randomBattleMoves: ["calmmind", "diamondstorm", "earthpower", "hiddenpowerfire", "moonblast"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["calmmind", "dazzlinggleam", "diamondstorm", "earthpower", "hiddenpowerfire", "moonblast", "protect", "psyshock"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	hoopa: {
 		randomBattleMoves: ["focusblast", "nastyplot", "psyshock", "shadowball", "trick"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["focusblast", "hyperspacehole", "protect", "shadowball", "trickroom"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	hoopaunbound: {
 		randomBattleMoves: ["darkpulse", "drainpunch", "focusblast", "gunkshot", "hyperspacefury", "icepunch", "nastyplot", "psychic", "substitute", "trick", "zenheadbutt"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["darkpulse", "drainpunch", "focusblast", "gunkshot", "hyperspacefury", "icepunch", "protect", "psychic", "zenheadbutt"],
 		tier: "UUBL",
 		doublesTier: "DOU",
 	},
 	volcanion: {
 		randomBattleMoves: ["earthpower", "fireblast", "sludgebomb", "steameruption", "substitute", "superpower"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["earthpower", "heatwave", "protect", "sludgebomb", "steameruption"],
 		tier: "UU",
 		doublesTier: "DOU",
@@ -4044,6 +4542,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	decidueye: {
 		randomBattleMoves: ["leafblade", "roost", "shadowsneak", "spiritshackle", "swordsdance", "uturn"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["bravebird", "leafblade", "protect", "spiritshackle", "suckerpunch"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -4056,6 +4555,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	incineroar: {
 		randomBattleMoves: ["darkestlariat", "earthquake", "fakeout", "flareblitz", "knockoff", "uturn"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["fakeout", "flareblitz", "knockoff", "snarl", "taunt", "uturn", "willowisp"],
 		tier: "NU",
 		doublesTier: "DOU",
@@ -4068,6 +4568,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	primarina: {
 		randomBattleMoves: ["energyball", "hiddenpowerfire", "hydropump", "moonblast", "psychic", "scald"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["hypervoice", "icebeam", "moonblast", "protect", "psychic"],
 		tier: "UU",
 		doublesTier: "(DUU)",
@@ -4080,6 +4581,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	toucannon: {
 		randomBattleMoves: ["beakblast", "boomburst", "brickbreak", "bulletseed", "roost"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["beakblast", "bulletseed", "protect", "rockblast", "tailwind"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -4089,6 +4591,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	gumshoos: {
 		randomBattleMoves: ["crunch", "earthquake", "firepunch", "return", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["crunch", "protect", "return", "superfang", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -4105,6 +4608,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	vikavolt: {
 		randomBattleMoves: ["agility", "bugbuzz", "energyball", "hiddenpowerice", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["bugbuzz", "hiddenpowerice", "protect", "stringshot", "thunderbolt", "voltswitch"],
 		tier: "NU",
 		doublesTier: "DUU",
@@ -4118,30 +4622,35 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	crabominable: {
 		randomBattleMoves: ["closecombat", "earthquake", "icehammer", "stoneedge"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["closecombat", "earthquake", "icehammer", "protect", "stoneedge", "wideguard"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	oricorio: {
 		randomBattleMoves: ["calmmind", "hurricane", "revelationdance", "roost", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "hurricane", "protect", "revelationdance", "tailwind"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	oricoriopompom: {
 		randomBattleMoves: ["calmmind", "hurricane", "revelationdance", "roost", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "hurricane", "protect", "revelationdance", "tailwind"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	oricoriopau: {
 		randomBattleMoves: ["calmmind", "hurricane", "revelationdance", "roost", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "hurricane", "protect", "revelationdance", "tailwind"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	oricoriosensu: {
 		randomBattleMoves: ["calmmind", "hurricane", "revelationdance", "roost", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["airslash", "hurricane", "protect", "revelationdance", "tailwind"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -4151,6 +4660,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	ribombee: {
 		randomBattleMoves: ["bugbuzz", "hiddenpowerfire", "moonblast", "quiverdance", "roost", "stickyweb"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["moonblast", "pollenpuff", "protect", "quiverdance", "stickyweb"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -4167,18 +4677,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lycanroc: {
 		randomBattleMoves: ["accelerock", "drillrun", "firefang", "stoneedge", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["accelerock", "crunch", "firefang", "protect", "stoneedge", "taunt"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	lycanrocmidnight: {
 		randomBattleMoves: ["firepunch", "stealthrock", "stoneedge", "suckerpunch", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["protect", "stoneedge", "suckerpunch", "swordsdance", "taunt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	lycanrocdusk: {
 		randomBattleMoves: ["accelerock", "drillrun", "firefang", "return", "stoneedge", "swordsdance"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["accelerock", "drillrun", "firefang", "protect", "rockslide", "stoneedge"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -4189,6 +4702,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	wishiwashischool: {
 		randomBattleMoves: ["earthquake", "hiddenpowergrass", "hydropump", "icebeam", "scald"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["earthquake", "endeavor", "helpinghand", "hiddenpowergrass", "hydropump", "icebeam", "protect"],
 	},
 	mareanie: {
@@ -4196,6 +4710,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	toxapex: {
 		randomBattleMoves: ["banefulbunker", "haze", "recover", "scald", "toxicspikes"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["banefulbunker", "haze", "recover", "scald", "toxicspikes", "wideguard"],
 		tier: "OU",
 		doublesTier: "(DUU)",
@@ -4205,6 +4720,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mudsdale: {
 		randomBattleMoves: ["closecombat", "earthquake", "heavyslam", "rockslide", "stealthrock"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["closecombat", "heavyslam", "highhorsepower", "protect", "rockslide"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -4214,6 +4730,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	araquanid: {
 		randomBattleMoves: ["liquidation", "lunge", "mirrorcoat", "stickyweb", "toxic"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["liquidation", "lunge", "protect", "stickyweb", "wideguard"],
 		tier: "RU",
 		doublesTier: "DUU",
@@ -4227,6 +4744,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	lurantis: {
 		randomBattleMoves: ["hiddenpowerice", "knockoff", "leafstorm", "superpower", "synthesis"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["hiddenpowerice", "knockoff", "leafstorm", "protect", "superpower"],
 		tier: "PU",
 		doublesTier: "(DUU)",
@@ -4240,6 +4758,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	shiinotic: {
 		randomBattleMoves: ["gigadrain", "leechseed", "moonblast", "spore", "strengthsap"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["gigadrain", "leechseed", "moonblast", "protect", "spore", "strengthsap"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
@@ -4249,6 +4768,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	salazzle: {
 		randomBattleMoves: ["fireblast", "hiddenpowergrass", "nastyplot", "sludgewave"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["encore", "fakeout", "flamethrower", "hiddenpowergrass", "hiddenpowerground", "protect", "sludgebomb", "taunt"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -4262,6 +4782,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	bewear: {
 		randomBattleMoves: ["doubleedge", "hammerarm", "icepunch", "return", "shadowclaw", "swordsdance"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["doubleedge", "hammerarm", "icepunch", "protect", "wideguard"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -4274,24 +4795,28 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	tsareena: {
 		randomBattleMoves: ["highjumpkick", "knockoff", "powerwhip", "rapidspin", "synthesis", "uturn"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["feint", "knockoff", "playrough", "powerwhip", "protect", "uturn"],
 		tier: "RU",
 		doublesTier: "DUU",
 	},
 	comfey: {
 		randomBattleMoves: ["aromatherapy", "drainingkiss", "synthesis", "toxic", "uturn"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["drainingkiss", "floralhealing", "taunt", "toxic", "uturn"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	oranguru: {
 		randomBattleMoves: ["focusblast", "nastyplot", "psyshock", "thunderbolt", "trickroom"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["foulplay", "instruct", "protect", "psychic", "trickroom"],
 		tier: "(PU)",
 		doublesTier: "DUU",
 	},
 	passimian: {
 		randomBattleMoves: ["closecombat", "earthquake", "gunkshot", "knockoff", "rockslide", "uturn"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["closecombat", "knockoff", "protect", "rockslide", "taunt", "uturn"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -4301,6 +4826,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	golisopod: {
 		randomBattleMoves: ["aquajet", "firstimpression", "knockoff", "liquidation", "spikes"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["aquajet", "firstimpression", "leechlife", "liquidation", "protect", "wideguard"],
 		tier: "RU",
 		doublesTier: "(DUU)",
@@ -4310,131 +4836,153 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	palossand: {
 		randomBattleMoves: ["earthpower", "shadowball", "shoreup", "stealthrock", "toxic"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["earthpower", "protect", "shadowball", "shoreup", "stealthrock", "toxic"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	pyukumuku: {
 		randomBattleMoves: ["block", "recover", "soak", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["counter", "helpinghand", "lightscreen", "memento", "reflect"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	typenull: {
 		randomBattleMoves: ["rest", "return", "sleeptalk", "swordsdance", "uturn"],
+		randomBattleLevel: 88,
 		tier: "(PU)",
 		doublesTier: "NFE",
 	},
 	silvally: {
 		randomBattleMoves: ["crunch", "doubleedge", "flamecharge", "flamethrower", "icebeam", "ironhead", "return", "swordsdance", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["crunch", "doubleedge", "explosion", "flamecharge", "icebeam", "partingshot", "protect", "swordsdance", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	silvallybug: {
 		randomBattleMoves: ["defog", "flamethrower", "icebeam", "thunderbolt", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["flamethrower", "icebeam", "protect", "thunderbolt", "thunderwave", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	silvallydark: {
 		randomBattleMoves: ["flamecharge", "ironhead", "multiattack", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["icebeam", "multiattack", "partingshot", "protect", "snarl", "thunderwave", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	silvallydragon: {
 		randomBattleMoves: ["dracometeor", "flamecharge", "flamethrower", "icebeam", "ironhead", "multiattack", "swordsdance", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["flamethrower", "icebeam", "multiattack", "partingshot", "protect", "thunderwave", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	silvallyelectric: {
 		randomBattleMoves: ["flamethrower", "icebeam", "multiattack", "partingshot", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["icebeam", "partingshot", "protect", "snarl", "thunderbolt", "thunderwave", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	silvallyfairy: {
 		randomBattleMoves: ["flamethrower", "multiattack", "partingshot", "rockslide", "thunderwave"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["flamethrower", "icebeam", "multiattack", "partingshot", "protect", "thunderwave", "uturn"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	silvallyfighting: {
 		randomBattleMoves: ["flamecharge", "ironhead", "multiattack", "shadowclaw", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["flamecharge", "multiattack", "protect", "rockslide", "swordsdance"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	silvallyfire: {
 		randomBattleMoves: ["defog", "icebeam", "multiattack", "thunderbolt", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["flamethrower", "icebeam", "protect", "snarl", "thunderbolt", "thunderwave", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	silvallyflying: {
 		randomBattleMoves: ["flamethrower", "ironhead", "multiattack", "partingshot", "thunderwave"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["flamecharge", "ironhead", "multiattack", "partingshot", "protect", "swordsdance", "thunderwave", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	silvallyghost: {
 		randomBattleMoves: ["flamethrower", "icebeam", "multiattack", "partingshot", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["icebeam", "multiattack", "partingshot", "protect", "uturn"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	silvallygrass: {
 		randomBattleMoves: ["flamethrower", "icebeam", "multiattack", "partingshot", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["flamethrower", "icebeam", "multiattack", "partingshot", "protect", "thunderwave", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	silvallyground: {
 		randomBattleMoves: ["flamecharge", "multiattack", "rockslide", "swordsdance"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["flamecharge", "icebeam", "multiattack", "protect", "rockslide", "swordsdance", "thunderbolt"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	silvallyice: {
 		randomBattleMoves: ["flamethrower", "multiattack", "thunderbolt", "toxic", "uturn"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["icebeam", "partingshot", "protect", "thunderbolt", "thunderwave", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	silvallypoison: {
 		randomBattleMoves: ["flamethrower", "icebeam", "multiattack", "partingshot", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["flamethrower", "icebeam", "multiattack", "partingshot", "protect", "thunderwave", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	silvallypsychic: {
 		randomBattleMoves: ["flamethrower", "multiattack", "partingshot", "rockslide", "thunderwave"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["flamethrower", "multiattack", "partingshot", "protect", "thunderwave", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	silvallyrock: {
 		randomBattleMoves: ["flamethrower", "grasspledge", "multiattack", "partingshot", "toxic"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["flamethrower", "icebeam", "partingshot", "protect", "rockslide", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	silvallysteel: {
 		randomBattleMoves: ["crunch", "defog", "flamethrower", "multiattack", "thunderbolt"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["flamecharge", "multiattack", "partingshot", "protect", "rockslide", "swordsdance", "uturn"],
 		tier: "NU",
 		doublesTier: "(DUU)",
 	},
 	silvallywater: {
 		randomBattleMoves: ["defog", "icebeam", "multiattack", "partingshot", "thunderbolt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["flamethrower", "icebeam", "multiattack", "partingshot", "protect", "thunderbolt", "thunderwave", "uturn"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	minior: {
 		randomBattleMoves: ["acrobatics", "earthquake", "powergem", "shellsmash"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["acrobatics", "earthquake", "powergem", "protect", "shellsmash"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -4442,18 +4990,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	miniormeteor: {},
 	komala: {
 		randomBattleMoves: ["earthquake", "playrough", "return", "suckerpunch", "uturn", "woodhammer"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["playrough", "protect", "return", "shadowclaw", "suckerpunch", "swordsdance", "uturn", "woodhammer"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	turtonator: {
 		randomBattleMoves: ["dracometeor", "dragonpulse", "dragontail", "earthquake", "explosion", "fireblast", "shellsmash"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "fireblast", "protect", "shellsmash"],
 		tier: "(PU)",
 		doublesTier: "(DUU)",
 	},
 	togedemaru: {
 		randomBattleMoves: ["ironhead", "nuzzle", "spikyshield", "uturn", "wish", "zingzap"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["encore", "fakeout", "ironhead", "nuzzle", "spikyshield", "uturn", "zingzap"],
 		tier: "NU",
 		doublesTier: "DUU",
@@ -4464,6 +5015,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	mimikyu: {
 		randomBattleMoves: ["playrough", "shadowclaw", "shadowsneak", "swordsdance", "taunt"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["playrough", "protect", "shadowclaw", "shadowsneak", "swordsdance", "willowisp"],
 		tier: "UU",
 		doublesTier: "DUU",
@@ -4475,18 +5027,21 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	mimikyubustedtotem: {},
 	bruxish: {
 		randomBattleMoves: ["aquajet", "crunch", "icefang", "liquidation", "psychicfangs", "swordsdance"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["aquajet", "crunch", "liquidation", "protect", "psychicfangs", "swordsdance"],
 		tier: "NUBL",
 		doublesTier: "DUU",
 	},
 	drampa: {
 		randomBattleMoves: ["dracometeor", "dragonpulse", "fireblast", "glare", "hypervoice", "roost", "thunderbolt"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "fireblast", "glare", "hypervoice", "protect", "roost"],
 		tier: "PU",
 		doublesTier: "(DUU)",
 	},
 	dhelmise: {
 		randomBattleMoves: ["anchorshot", "earthquake", "knockoff", "powerwhip", "rapidspin", "synthesis"],
+		randomBattleLevel: 86,
 		randomDoubleBattleMoves: ["anchorshot", "knockoff", "powerwhip", "protect", "rapidspin"],
 		tier: "NU",
 		doublesTier: "(DUU)",
@@ -4499,6 +5054,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	kommoo: {
 		randomBattleMoves: ["clangingscales", "closecombat", "dragondance", "outrage", "poisonjab"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["clangingscales", "closecombat", "dragondance", "poisonjab"],
 		tier: "OU",
 		doublesTier: "DOU",
@@ -4509,24 +5065,28 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	tapukoko: {
 		randomBattleMoves: ["bravebird", "dazzlinggleam", "defog", "naturesmadness", "thunderbolt", "uturn"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dazzlinggleam", "hiddenpowerice", "naturesmadness", "protect", "skydrop", "taunt", "thunderbolt", "uturn"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	tapulele: {
 		randomBattleMoves: ["calmmind", "focusblast", "hiddenpowerfire", "moonblast", "psychic", "psyshock"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["dazzlinggleam", "focusblast", "moonblast", "protect", "psychic", "taunt"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	tapubulu: {
 		randomBattleMoves: ["bulkup", "hornleech", "megahorn", "stoneedge", "superpower", "woodhammer"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["hornleech", "naturesmadness", "protect", "stoneedge", "superpower", "woodhammer"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	tapufini: {
 		randomBattleMoves: ["calmmind", "hydropump", "icebeam", "moonblast", "scald", "taunt"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["healpulse", "moonblast", "muddywater", "naturesmadness", "protect", "swagger", "taunt"],
 		tier: "OU",
 		doublesTier: "DOU",
@@ -4539,72 +5099,84 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	solgaleo: {
 		randomBattleMoves: ["earthquake", "flareblitz", "morningsun", "stoneedge", "sunsteelstrike", "zenheadbutt"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["flareblitz", "morningsun", "protect", "sunsteelstrike", "wideguard", "zenheadbutt"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	lunala: {
 		randomBattleMoves: ["calmmind", "focusblast", "moonblast", "moongeistbeam", "psyshock", "roost"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["moonblast", "moongeistbeam", "protect", "psychic", "roost", "wideguard"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	nihilego: {
 		randomBattleMoves: ["grassknot", "powergem", "sludgewave", "stealthrock", "thunderbolt", "toxicspikes"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["grassknot", "hiddenpowerice", "powergem", "protect", "sludgebomb", "thunderbolt"],
 		tier: "UU",
 		doublesTier: "(DUU)",
 	},
 	buzzwole: {
 		randomBattleMoves: ["drainpunch", "earthquake", "leechlife", "poisonjab", "stoneedge", "superpower"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["drainpunch", "icepunch", "leechlife", "poisonjab", "protect", "superpower"],
 		tier: "UUBL",
 		doublesTier: "(DUU)",
 	},
 	pheromosa: {
 		randomBattleMoves: ["highjumpkick", "icebeam", "poisonjab", "throatchop", "uturn"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["bugbuzz", "highjumpkick", "icebeam", "poisonjab", "protect", "speedswap", "uturn"],
 		tier: "Uber",
 		doublesTier: "DUU",
 	},
 	xurkitree: {
 		randomBattleMoves: ["dazzlinggleam", "electricterrain", "energyball", "hiddenpowerice", "thunderbolt", "voltswitch"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["energyball", "hiddenpowerice", "hypnosis", "protect", "tailglow", "thunderbolt"],
 		tier: "UUBL",
 		doublesTier: "DUU",
 	},
 	celesteela: {
 		randomBattleMoves: ["airslash", "autotomize", "earthquake", "fireblast", "heavyslam", "leechseed", "protect"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["earthquake", "fireblast", "heavyslam", "leechseed", "protect", "wideguard"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	kartana: {
 		randomBattleMoves: ["knockoff", "leafblade", "sacredsword", "smartstrike", "swordsdance"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["knockoff", "leafblade", "protect", "sacredsword", "smartstrike", "swordsdance"],
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	guzzlord: {
 		randomBattleMoves: ["dracometeor", "earthquake", "fireblast", "heavyslam", "knockoff"],
+		randomBattleLevel: 88,
 		randomDoubleBattleMoves: ["dracometeor", "fireblast", "knockoff", "protect", "wideguard"],
 		tier: "PUBL",
 		doublesTier: "(DUU)",
 	},
 	necrozma: {
 		randomBattleMoves: ["calmmind", "heatwave", "moonlight", "photongeyser", "stealthrock"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["calmmind", "earthpower", "heatwave", "moonlight", "photongeyser"],
 		tier: "RU",
 		doublesTier: "(DUU)",
 	},
 	necrozmaduskmane: {
 		randomBattleMoves: ["autotomize", "earthquake", "knockoff", "photongeyser", "sunsteelstrike", "swordsdance"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["earthquake", "knockoff", "photongeyser", "rockslide", "sunsteelstrike", "swordsdance"],
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
 	necrozmadawnwings: {
 		randomBattleMoves: ["calmmind", "heatwave", "moongeistbeam", "photongeyser", "powergem", "trickroom"],
+		randomBattleLevel: 76,
 		tier: "Uber",
 		doublesTier: "DUber",
 	},
@@ -4614,6 +5186,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	magearna: {
 		randomBattleMoves: ["calmmind", "flashcannon", "fleurcannon", "focusblast", "ironhead", "shiftgear", "thunderbolt"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["aurasphere", "dazzlinggleam", "flashcannon", "fleurcannon", "protect", "trickroom", "voltswitch"],
 		tier: "OU",
 		doublesTier: "DUber",
@@ -4624,6 +5197,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	marshadow: {
 		randomBattleMoves: ["bulkup", "closecombat", "icepunch", "rocktomb", "shadowsneak", "spectralthief"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["bulkup", "closecombat", "icepunch", "protect", "shadowsneak", "spectralthief"],
 		tier: "Uber",
 		doublesTier: "DUber",
@@ -4633,24 +5207,28 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	},
 	naganadel: {
 		randomBattleMoves: ["dracometeor", "dragonpulse", "fireblast", "nastyplot", "sludgewave", "uturn"],
+		randomBattleLevel: 76,
 		randomDoubleBattleMoves: ["dracometeor", "dragonpulse", "fireblast", "protect", "sludgebomb", "tailwind", "uturn"],
 		tier: "Uber",
 		doublesTier: "DUU",
 	},
 	stakataka: {
 		randomBattleMoves: ["earthquake", "gyroball", "stealthrock", "stoneedge", "superpower", "trickroom"],
+		randomBattleLevel: 84,
 		randomDoubleBattleMoves: ["earthquake", "gyroball", "rockslide", "stealthrock", "stoneedge", "superpower", "trickroom"],
 		tier: "RUBL",
 		doublesTier: "DOU",
 	},
 	blacephalon: {
 		randomBattleMoves: ["calmmind", "explosion", "fireblast", "hiddenpowerice", "shadowball", "trick"],
+		randomBattleLevel: 80,
 		randomDoubleBattleMoves: ["fireblast", "heatwave", "hiddenpowerice", "protect", "shadowball", "willowisp"],
 		tier: "OU",
 		doublesTier: "DUU",
 	},
 	zeraora: {
 		randomBattleMoves: ["closecombat", "grassknot", "hiddenpowerice", "knockoff", "plasmafists", "voltswitch", "workup"],
+		randomBattleLevel: 82,
 		randomDoubleBattleMoves: ["closecombat", "fakeout", "grassknot", "hiddenpowerice", "knockoff", "plasmafists", "protect", "voltswitch"],
 		tier: "UU",
 		doublesTier: "DOU",

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1367,6 +1367,11 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		let level: number;
 		if (this.adjustLevel) {
 			level = this.adjustLevel;
+		} else if (!isDoubles && species.randomBattleLevel) {
+			// Use explicit level if we got it
+			level = species.randomBattleLevel;
+		} else if (isDoubles && species.randomDoubleBattleLevel) {
+			level = species.randomDoubleBattleLevel;
 		} else if (!isDoubles) {
 			const levelScale: {[k: string]: number} = {uber: 76, ou: 80, uu: 82, ru: 84, nu: 86, pu: 88};
 			const customScale: {[k: string]: number} = {


### PR DESCRIPTION
This makes all levels in gens 3-7 Random Battles explicit the way they are in gen8. That is, every set should have a level attached to it in formats-data.ts.

This will make it much easier to interact with for level balancing scripts we will likely soon start using. Although no final decision has been made, it seems likely that winrate balancing will soon commence for gens 3-7.

Currently, levels are decided by tier-scaling, modified bst-scaling and hard-coded exceptions.

To be clear: this PR does not change functionality.