### PR TITLE
Prevent Commanded Dondozo from switching out through Baton Pass

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -1118,8 +1118,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 40,
 		priority: 0,
 		flags: {},
-		onHit(target) {
-			if (!this.canSwitch(target.side)) {
+		onTryHit(target) {
+			if (!this.canSwitch(target.side) || target.volatiles['commanded']) {
 				this.attrLastMove('[still]');
 				this.add('-fail', target);
 				return this.NOT_FAIL;


### PR DESCRIPTION
One of the things from DarkFE's recent Commander mechanics post in the research thread. I am not sure how many other moves (Teleport, Chilly Reception, etc.) this applies to.