### PR TITLE
Gen3 sleeptalk cant call rest

### DIFF
--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -537,7 +537,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			for (const moveSlot of pokemon.moveSlots) {
 				const move = moveSlot.id;
 				const pp = moveSlot.pp;
-				const NoSleepTalk = ['assist', 'bide', 'focuspunch', 'metronome', 'mirrormove', 'sleeptalk', 'uproar'];
+				const NoSleepTalk = ['assist', 'bide', 'focuspunch', 'metronome', 'mirrormove', 'rest', 'sleeptalk', 'uproar'];
 				if (move && !(NoSleepTalk.includes(move) || this.dex.moves.get(move).flags['charge'])) {
 					moves.push({move: move, pp: pp});
 				}

--- a/test/sim/moves/sleeptalk.js
+++ b/test/sim/moves/sleeptalk.js
@@ -43,4 +43,27 @@ describe('Sleep Talk', function () {
 		assert.equal(breloom.hp, hp);
 		assert.equal(move.pp, move.maxpp - 2);
 	});
+
+	it('should not be able to choose rest in Gen 3 battles', function() {
+		battle = common.gen(3).createBattle([[
+			{species: 'snorlax', ability: 'noguard', moves: ['sleeptalk', 'rest']},
+		], [
+			{species: 'magikarp', moves: ['tackle', 'splash']},
+		]]);
+		const snorlax = battle.p1.active[0];
+		battle.makeChoices('move sleeptalk', 'move tackle');
+		assert.notEqual(snorlax.hp, snorlax.maxhp);
+
+		battle.makeChoices('move rest', 'move splash');
+		assert.fullHP(snorlax);
+		assert.equal(snorlax.status, 'slp');
+		snorlax.statusState.time = 6;
+
+		battle.makeChoices('move sleeptalk', 'move tackle');
+		assert.notEqual(snorlax.hp, snorlax.maxhp);
+		assert.equal(snorlax.status, 'slp');
+
+		assert(battle.log[battle.lastMoveLine + 1].startsWith('|-fail'));
+		assert.notEqual(battle.log[battle.lastMoveLine].split('|')[3], 'Rest')
+	});
 });


### PR DESCRIPTION
1. Added `'rest'` to `NoSleepTalk` array to ensure that sleep talk will never call rest in generation 3
2. Added unit test for generation 3 to ensure that sleep talk never calls rest even with missing HP.