### PR TITLE
Gens 4-7 and BDSP Random Battles tweaks

### DIFF
--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -57,6 +57,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			),
 			Guts: (movePool, moves, abilities, types) => types.has('Normal') && movePool.includes('facade'),
 			'Slow Start': movePool => movePool.includes('substitute'),
+			protect: movePool => movePool.includes('wish'),
+			wish: movePool => movePool.includes('protect'),
 		};
 	}
 	shouldCullMove(
@@ -157,9 +159,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			)};
 		case 'wish':
 			return {cull: (
-				!['batonpass', 'ironhead', 'moonlight', 'protect', 'softboiled', 'uturn'].some(m => moves.has(m)) ||
-				moves.has('rest') ||
-				!!counter.get('speedsetup')
+				!['batonpass', 'ironhead', 'moonlight', 'protect', 'softboiled', 'uturn'].some(m => moves.has(m)) &&
+				!movePool.includes('protect')
 			)};
 		case 'moonlight':
 			return {cull: (moves.has('wish') && moves.has('protect'))};
@@ -716,6 +717,9 @@ export class RandomGen4Teams extends RandomGen5Teams {
 						}
 						for (const abil of abilities) {
 							if (runEnforcementChecker(abil)) cull = true;
+						}
+						for (const move of moves) {
+							if (runEnforcementChecker(move)) cull = true;
 						}
 					}
 				}

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -163,7 +163,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 				!movePool.includes('protect')
 			)};
 		case 'moonlight':
-			return {cull: (moves.has('wish') && moves.has('protect'))};
+			return {cull: (moves.has('wish') && (moves.has('protect') || movePool.includes('protect')))};
 		case 'rapidspin':
 			return {cull: !!teamDetails.rapidSpin || (!!counter.setupType && counter.get('Physical') + counter.get('Special') < 2)};
 		case 'fakeout':

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -718,8 +718,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 						for (const abil of abilities) {
 							if (runEnforcementChecker(abil)) cull = true;
 						}
-						for (const move of moves) {
-							if (runEnforcementChecker(move)) cull = true;
+						for (const m of moves) {
+							if (runEnforcementChecker(m)) cull = true;
 						}
 					}
 				}

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -217,8 +217,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			return {cull: moves.has('substitute')};
 		case 'headbutt':
 			return {cull: !moves.has('bodyslam') && !moves.has('thunderwave')};
-		case 'judgment': case 'swift':
-			return {cull: counter.setupType !== 'Special' && counter.get('stab') > 1};
+		case 'swift':
+			return {cull: counter.setupType !== 'Special'};
 		case 'quickattack':
 			return {cull: moves.has('thunderwave')};
 		case 'firepunch': case 'flamethrower':

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -439,14 +439,14 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		if (counter.setupType && moves.has('outrage')) return 'Lum Berry';
 		if (this.dex.getEffectiveness('Ground', species) >= 2 && ability !== 'Levitate') return 'Air Balloon';
 		if (counter.get('Dark') >= 3) return 'Black Glasses';
+		if (species.name === 'Palkia' && (moves.has('dracometeor') || moves.has('spacialrend'))) {
+			return 'Lustrous Orb';
+		}
 		if (
 			types.has('Poison') ||
 			['bodyslam', 'dragontail', 'protect', 'scald', 'sleeptalk', 'substitute'].some(m => moves.has(m))
 		) {
 			return 'Leftovers';
-		}
-		if (species.name === 'Palkia' && (moves.has('dracometeor') || moves.has('spacialrend')) && moves.has('hydropump')) {
-			return 'Lustrous Orb';
 		}
 		if (counter.damagingMoves.size >= 4 && ability !== 'Sturdy') {
 			return moves.has('uturn') ? 'Expert Belt' : 'Life Orb';

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -27,7 +27,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 				!counter.get('Flying') && (types.has('Normal') || abilities.has('Serene Grace'))
 			),
 			Ghost: (movePool, moves, abilities, types, counter) => !types.has('Dark') && !counter.get('Ghost'),
-			Grass: movePool => movePool.includes('hornleech') || movePool.includes('seedflare'),
+			Grass: movePool => (['hornleech', 'seedflare', 'woodhammer'].some(m => movePool.includes(m))),
 			Ground: (movePool, moves, abilities, types, counter) => (
 				!counter.get('Ground') && !moves.has('rest') && !moves.has('sleeptalk')
 			),

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -470,7 +470,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			return {cull: (
 				['dracometeor', 'pursuit', 'rest', 'taunt', 'uturn', 'voltswitch', 'whirlwind'].some(m => moves.has(m)) ||
 				(moves.has('leafstorm') && !abilities.has('Contrary')) ||
-				movePool.includes('copycat')
+				movePool.includes('copycat') || movePool.includes('dragondance')
 			)};
 		}
 

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -382,7 +382,12 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		case 'extremespeed':
 			return {cull: counter.setupType !== 'Physical' && moves.has('vacuumwave')};
 		case 'hiddenpower':
-			return {cull: moves.has('rest') || !counter.get('stab') && counter.damagingMoves.size < 2};
+			return {cull: (
+				moves.has('rest') ||
+				(!counter.get('stab') && counter.damagingMoves.size < 2) ||
+				// Force Moonblast on Special-setup Fairies
+				(counter.setupType === 'Special' && types.has('Fairy') && movePool.includes('moonblast'))
+			)};
 		case 'hypervoice':
 			return {cull: moves.has('blizzard') || moves.has('return')};
 		case 'judgment':

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -413,7 +413,10 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		case 'psychic':
 			return {cull: moves.has('psyshock')};
 		case 'psychocut': case 'zenheadbutt':
-			return {cull: (moves.has('psychic') || moves.has('psyshock')) && counter.setupType !== 'Physical'};
+			return {cull: (
+				((moves.has('psychic') || moves.has('psyshock')) && counter.setupType !== 'Physical') ||
+				(abilities.has('Contrary') && !counter.setupType && !!counter.get('physicalpool'))
+			)};
 		case 'psyshock':
 			const psychic = movePool.indexOf('psychic');
 			if (psychic >= 0) this.fastPop(movePool, psychic);

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -266,7 +266,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 				!abilities.has('Regenerator') &&
 				!movePool.includes('protect') &&
 				!['ironhead', 'protect', 'spikyshield', 'uturn'].some(m => moves.has(m))
-			)}
+			)};
 
 		// Bit redundant to have both
 		// Attacks:
@@ -974,8 +974,8 @@ export class RandomGen6Teams extends RandomGen7Teams {
 								cull = true;
 							}
 						}
-						for (const move of moves) {
-							if (runEnforcementChecker(move)) {
+						for (const m of moves) {
+							if (runEnforcementChecker(m)) {
 								cull = true;
 							}
 						}

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -764,6 +764,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (species.name === 'Palkia' && (moves.has('dracometeor') || moves.has('spacialrend')) && moves.has('hydropump')) {
 			return 'Lustrous Orb';
 		}
+		if (species.types.includes('Normal') && moves.has('fakeout') && counter.get('Normal') >= 2) return 'Silk Scarf';
 		if (counter.damagingMoves.size >= 4) {
 			return (counter.get('Dragon') || moves.has('suckerpunch') || counter.get('Normal')) ? 'Life Orb' : 'Expert Belt';
 		}

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -329,7 +329,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				!abilities.has('Regenerator') &&
 				!movePool.includes('protect') &&
 				!['ironhead', 'protect', 'spikyshield', 'uturn'].some(m => moves.has(m))
-			)}
+			)};
 
 		// Bit redundant to have both
 		// Attacks:
@@ -1227,8 +1227,8 @@ export class RandomGen7Teams extends RandomGen8Teams {
 								cull = true;
 							}
 						}
-						for (const move of moves) {
-							if (runEnforcementChecker(move)) {
+						for (const m of moves) {
+							if (runEnforcementChecker(m)) {
 								cull = true;
 							}
 						}

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -566,7 +566,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				moves.has('dracometeor') ||
 				(moves.has('leafstorm') && !abilities.has('Contrary')) ||
 				['encore', 'pursuit', 'rest', 'taunt', 'uturn', 'voltswitch', 'whirlwind'].some(m => moves.has(m)) ||
-				movePool.includes('copycat')
+				movePool.includes('copycat') || movePool.includes('dragondance')
 			)};
 		case 'powersplit':
 			return {cull: moves.has('guardsplit')};

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -989,6 +989,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (species.name === 'Palkia' && (moves.has('dracometeor') || moves.has('spacialrend')) && moves.has('hydropump')) {
 			return 'Lustrous Orb';
 		}
+		if (species.types.includes('Normal') && moves.has('fakeout') && counter.get('Normal') >= 2) return 'Silk Scarf';
 		if (counter.damagingMoves.size >= 4) {
 			return (counter.get('Dragon') || moves.has('suckerpunch') || counter.get('Normal')) ? 'Life Orb' : 'Expert Belt';
 		}

--- a/data/mods/gen8bdsp/formats-data.ts
+++ b/data/mods/gen8bdsp/formats-data.ts
@@ -1691,7 +1691,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	jirachi: {
 		tier: "OU",
 		doublesTier: "DUU",
-		randomBattleMoves: ["healingwish", "stealthrock", "thunderwave", "uturn", "zenheadbutt"],
+		randomBattleMoves: ["calmmind", "dazzlinggleam", "flashcannon", "psychic", "shadowball", "thunderbolt", "uturn"],
 	},
 	deoxys: {
 		tier: "Uber",


### PR DESCRIPTION
Do not hotpatch until Sunday

Gen 4: Persian will get Return instead of Swift on sets without Nasty Plot.

Gen 5: 
- enforce Wood Hammer on Grass-types (Abomasnow and Torterra),
- non-choiced Palkia will get Lustrous Orb if it has Draco Meteor or Spacial Rend.

Gens 4, 6, 7: Improve Wish/Protect enforcement. Most Pokemon with Wish and Protect in their movepool won't get Protect without Wish, and Wish will generally appear more often on them.

Gen 6: Diancie-Mega will always get Moonblast, and Malamar will always get Superpower.

Gens 6-7: 
- Gyarados and Mega-Gyarados won't get Substitute unless they also have Dragon Dance,
- Normal-types with Fake Out and another Normal-type attack will get Silk Scarf.

BDSP: Change Jirachi's set

This shouldn't cause any merge conflicts with https://github.com/smogon/pokemon-showdown/pull/9386, since it only affects set generation.

https://discord.com/channels/294651453279174656/763039178211721236/1072086345469665303
https://discord.com/channels/294651453279174656/809413252517462026/1076614689947127848
https://discord.com/channels/294651453279174656/908560260753657888/1076927616315039897