### PR TITLE
Add Terastallized indicator for fainted Pokemon

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2338,7 +2338,6 @@ export class Battle {
 				pokemon.illusion = null;
 				pokemon.isActive = false;
 				pokemon.isStarted = false;
-				delete pokemon.terastallized;
 				pokemon.side.faintedThisTurn = pokemon;
 				if (this.faintQueue.length >= faintQueueLeft) checkWin = true;
 			}
@@ -2589,6 +2588,7 @@ export class Battle {
 					target: action.target,
 				});
 			}
+			delete action.target.terastallized;
 			action.target.fainted = false;
 			action.target.faintQueued = false;
 			action.target.subFainted = false;

--- a/test/sim/moves/revivalblessing.js
+++ b/test/sim/moves/revivalblessing.js
@@ -82,4 +82,18 @@ describe('Revival Blessing', function () {
 		battle.makeChoices('switch 2', '');
 		assert.equal(battle.p1.active[1].boosts.evasion, 0, "Lycanroc should not have used Double Team");
 	});
+
+	it(`should not retain fainted Pokemon's Terastallization upon revival`, () => {
+		battle = common.createBattle([[
+			{species: 'corviknight', ability: 'runaway', moves: ['memento'], teraType: "Steel"},
+			{species: 'zoroark', ability: 'runaway', moves: ['revivalblessing']},
+		], [
+			{species: 'goodra', ability: 'gooey', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices('move memento terastallize', 'auto');
+		battle.makeChoices('switch zoroark', '');
+		battle.makeChoices('move revivalblessing', 'auto');
+		battle.makeChoices('switch corviknight', '');
+		assert.equal(battle.p1.pokemon[1].terastallized, undefined);
+	});
 });


### PR DESCRIPTION
Adjust `sim/battle.ts` to retain Terastallization after a Pokemon faints. Removes Terastallization when Pokemon is revived by Revival Blessing. Adds test case for Revival Blessing to handle this case.