### PR TITLE
Gen8 BF/BSSF updates

### DIFF
--- a/data/mods/gen8/bss-factory-sets.json
+++ b/data/mods/gen8/bss-factory-sets.json
@@ -40,7 +40,6 @@
         "ability": ["Static"],
         "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {"atk": 0},
         "moves": [["Hurricane"], ["Thunderbolt"], ["Heat Wave"], ["Roost", "Steel Wing"]]
       },
       {
@@ -256,7 +255,7 @@
         "species": "Dracozolt",
         "item": ["Life Orb"],
         "ability": ["Hustle"],
-        "evs": {"atk": 252, "spa": 4, "spe": 252},
+        "evs": {"atk": 252, "spd": 4, "spe": 252},
         "nature": "Jolly",
         "moves": [["Bolt Beak"], ["Outrage"], ["Aerial Ace"], ["Fire Fang", "Low Kick"]]
       }
@@ -342,7 +341,15 @@
         "ability": ["Infiltrator"],
         "evs": {"atk": 252, "spa": 4, "spe": 252},
         "nature": "Naive",
-        "moves": [["Dragon Darts"], ["Phantom Force", "Hex"], ["Dragon Dance"], ["Will-O-Wisp", "Thunder Wave"]]
+        "moves": [["Dragon Darts"], ["Hex"], ["Dragon Dance"], ["Will-O-Wisp", "Thunder Wave"]]
+      },
+      {
+        "species": "Dragapult",
+        "item": ["Focus Sash"],
+        "ability": ["Infiltrator"],
+        "evs": {"atk": 252, "def": 4, "spe": 252},
+        "nature": "Jolly",
+        "moves": [["Dragon Darts"], ["Phantom Force"], ["Dragon Dance"], ["Will-O-Wisp", "Thunder Wave"]]
       },
       {
         "species": "Dragapult",
@@ -666,7 +673,6 @@
         "ability": ["Beast Boost"],
         "evs": {"spa": 252, "spd": 4, "spe": 252},
         "nature": "Timid",
-        "ivs": {"atk": 0},
         "moves": [["Sludge Wave"], ["Draco Meteor"], ["Fire Blast"], ["U-turn"]]
       }
     ]
@@ -1766,7 +1772,15 @@
         "ability": ["Levitate"],
         "evs": {"hp": 252, "def": 252, "spe": 4},
         "nature": "Bold",
-        "moves": [["Stealth Rock"], ["Yawn"], ["Memento"], ["Trick Room", "U-turn"]]
+        "moves": [["Stealth Rock"], ["Yawn"], ["Memento"], ["Trick Room"]]
+      },
+      {
+        "species": "Uxie",
+        "item": ["Sitrus Berry", "Mental Herb"],
+        "ability": ["Levitate"],
+        "evs": {"hp": 252, "def": 252, "spe": 4},
+        "nature": "Impish",
+        "moves": [["Stealth Rock"], ["Yawn"], ["Memento"], ["U-turn"]]
       }
     ]
   },
@@ -1908,7 +1922,16 @@
         "ability": ["Sap Sipper"],
         "evs": {"hp": 252, "def": 4, "spa": 252},
         "nature": "Modest",
-        "moves": [["Dragon Pulse", "Draco Meteor"], ["Flamethrower"], ["Acid Spray"], ["Thunderbolt", "Power Whip"]]
+        "moves": [["Dragon Pulse", "Draco Meteor"], ["Flamethrower"], ["Acid Spray"], ["Power Whip"]]
+      },
+      {
+        "species": "Goodra",
+        "item": ["Assault Vest"],
+        "ability": ["Sap Sipper"],
+        "evs": {"hp": 252, "def": 4, "spa": 252},
+        "ivs": {"atk": 0},
+        "nature": "Modest",
+        "moves": [["Dragon Pulse", "Draco Meteor"], ["Flamethrower"], ["Acid Spray"], ["Thunderbolt"]]
       }
     ]
   },
@@ -1989,7 +2012,7 @@
         "ability": ["Magic Bounce"],
         "evs": {"hp": 252, "def": 252, "spa": 4},
         "nature": "Bold",
-        "ivs": {"atk": 0, "spe": 0},
+        "ivs": {"atk": 0},
         "moves": [["Psyshock"], ["Draining Kiss"], ["Giga Drain"], ["Calm Mind"]]
       }
     ]
@@ -2216,7 +2239,7 @@
         "ability": ["Infiltrator"],
         "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Quiet",
-        "ivs": {"atk": 0},
+        "ivs": {"atk": 0, "spe": 0},
         "moves": [["Flamethrower", "Overheat"], ["Shadow Ball"], ["Trick Room"], ["Memento"]]
       },
       {
@@ -2644,7 +2667,6 @@
         "ability": ["Light Metal"],
         "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Modest",
-        "ivs": {"atk": 0},
         "moves": [["Draco Meteor"], ["Flash Cannon"], ["Thunderbolt"], ["Rock Tomb"]]
       },
       {

--- a/data/mods/gen8/bss-factory-sets.json
+++ b/data/mods/gen8/bss-factory-sets.json
@@ -2711,7 +2711,6 @@
         "ability": ["Quick Draw"],
         "evs": {"hp": 252, "spa": 252, "spd": 4},
         "nature": "Modest",
-        "ivs": {"atk": 0},
         "moves": [["Shell Side Arm"], ["Psyshock", "Expanding Force"], ["Flamethrower"], ["Nasty Plot"]]
       }
     ]

--- a/data/mods/gen8/factory-sets.json
+++ b/data/mods/gen8/factory-sets.json
@@ -4651,7 +4651,7 @@
 				"item": ["Eviolite"],
 				"ability": ["Magic Guard"],
 				"evs": {"hp": 252, "def": 4, "spd": 252},
-				"nature": "Bold",
+				"nature": "Calm",
 				"moves": [["Moonblast"], ["Soft-Boiled"], ["Stealth Rock"], ["Knock Off"]]
 			}]
 		},

--- a/data/mods/gen8/factory-sets.json
+++ b/data/mods/gen8/factory-sets.json
@@ -5077,7 +5077,7 @@
 				"species": "Mareanie",
 				"item": ["Eviolite"],
 				"ability": ["Regenerator"],
-				"evs": {"hp": 116, "atk": 12, "def": 180, "spa": 12, "spd": 100, "spe": 180},
+				"evs": {"hp": 116, "atk": 12, "def": 180, "spa": 12, "spd": 180},
 				"nature": "Bold",
 				"moves": [["Knock Off"], ["Scald"], ["Sludge Bomb"], ["Recover"]]
 			}]


### PR DESCRIPTION
Some very minor IV/EV fixes in BSSF, mostly adding/removing Attack IVs for sets with(out) physical attacks.

Also fixes two wrong sets in BF, one of which is an illegal set with 100 to many EVs presumably made because of a silly error.

Changes mosly proposed by longhiep, briefly discussed by rands auth: https://discord.com/channels/294651453279174656/1018980144146292770/1075470786997014668