### PR TITLE
Gen 9 Random Battle: Fix STAB enforcement

### DIFF
--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -679,22 +679,21 @@ export class RandomTeams {
 		// Enforce STAB
 		for (const type of types) {
 			// Check if a STAB move of that type should be required
-			if (runEnforcementChecker(type)) {
-				const stabMoves = [];
-				for (const moveid of movePool) {
-					const move = this.dex.moves.get(moveid);
-					const moveType = this.getMoveType(move, species, abilities, teraType);
-					if (type === moveType &&
-						(move.basePower > 30 || move.multihit || move.basePowerCallback) &&
-						(!this.noStab.includes(moveid) || abilities.has('Technician') && moveid === 'machpunch')) {
-						stabMoves.push(moveid);
-					}
+			const stabMoves = [];
+			for (const moveid of movePool) {
+				const move = this.dex.moves.get(moveid);
+				const moveType = this.getMoveType(move, species, abilities, teraType);
+				if (type === moveType &&
+					(move.basePower > 30 || move.multihit || move.basePowerCallback) &&
+					(!this.noStab.includes(moveid) || abilities.has('Technician') && moveid === 'machpunch')) {
+					stabMoves.push(moveid);
 				}
-				if (stabMoves.length) {
-					const moveid = this.sample(stabMoves);
-					counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead, isDoubles,
-						movePool, teraType, role);
-				}
+			}
+			while (runEnforcementChecker(type)) {
+				if (!stabMoves.length) break;
+				const moveid = this.sampleNoReplace(stabMoves);
+				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead, isDoubles,
+					movePool, teraType, role);
 			}
 		}
 
@@ -704,10 +703,9 @@ export class RandomTeams {
 			for (const moveid of movePool) {
 				const move = this.dex.moves.get(moveid);
 				const moveType = this.getMoveType(move, species, abilities, teraType);
-				if (!this.noStab.includes(moveid) && (move.basePower > 30 || move.multihit || move.basePowerCallback)) {
-					if (types.includes(moveType)) {
-						stabMoves.push(moveid);
-					}
+				if (!this.noStab.includes(moveid) && (move.basePower > 30 || move.multihit || move.basePowerCallback) &&
+					types.includes(moveType)) {
+					stabMoves.push(moveid);
 				}
 			}
 			if (stabMoves.length) {

--- a/test/random-battles/gen9.js
+++ b/test/random-battles/gen9.js
@@ -3,7 +3,7 @@
  */
 'use strict';
 
-const {testTeam} = require('./tools');
+const {testTeam, testAlwaysHasMove} = require('./tools');
 const assert = require('../assert');
 const Teams = require('./../../dist/sim/teams').Teams;
 const Dex = require('./../../dist/sim/dex').Dex;
@@ -59,6 +59,10 @@ describe('[Gen 9] Random Battle', () => {
 				assert(!moves.size);
 			}
 		}
+	});
+
+	it("should always give Iron Bundle Freeze Dry", () => {
+		testAlwaysHasMove('ironbundle', options, 'freezedry');
 	});
 });
 

--- a/test/random-battles/gen9.js
+++ b/test/random-battles/gen9.js
@@ -61,7 +61,7 @@ describe('[Gen 9] Random Battle', () => {
 		}
 	});
 
-	it("should always give Iron Bundle Freeze Dry", () => {
+	it("should always give Iron Bundle Freeze-Dry", () => {
 		testAlwaysHasMove('ironbundle', options, 'freezedry');
 	});
 });


### PR DESCRIPTION
This allows more than one STAB move to be added if necessary. Most notably this makes Freeze Dry correctly forced on mons that have it and another Ice move.