### PR TITLE
Add descriptions for new moves

### DIFF
--- a/data/text/moves.ts
+++ b/data/text/moves.ts
@@ -3081,6 +3081,11 @@ export const MovesText: {[k: string]: MoveText} = {
 		name: "Hydro Pump",
 		shortDesc: "No additional effect.",
 	},
+	hydrosteam: {
+		name: "Hydro Steam",
+		desc: "This attack has its power multiplied by 1.5 while the weather is Sunny Day. Damage reduction for water type moves during Sunny Day is ignored.",
+		shortDesc: "x1.5 power in sunlight."
+	},
 	hydrovortex: {
 		name: "Hydro Vortex",
 		shortDesc: "Power is equal to the base move's Z-Power.",
@@ -4764,6 +4769,11 @@ export const MovesText: {[k: string]: MoveText} = {
 		name: "Psybeam",
 		desc: "Has a 10% chance to confuse the target.",
 		shortDesc: "10% chance to confuse the target.",
+	},
+	psyblade: {
+		name: "Psyblade",
+		desc: "This attack has its power multiplied by 1.5 while the user is affected by Electric Terrain.",
+		shortDesc: "x1.5 power in Electric Terain."
 	},
 	psychup: {
 		name: "Psych Up",

--- a/data/text/moves.ts
+++ b/data/text/moves.ts
@@ -3084,7 +3084,7 @@ export const MovesText: {[k: string]: MoveText} = {
 	hydrosteam: {
 		name: "Hydro Steam",
 		desc: "This attack has its power multiplied by 1.5 while the weather is Sunny Day. Damage reduction for water type moves during Sunny Day is ignored.",
-		shortDesc: "x1.5 power in sunlight."
+		shortDesc: "x1.5 power in sunlight.",
 	},
 	hydrovortex: {
 		name: "Hydro Vortex",
@@ -4773,7 +4773,7 @@ export const MovesText: {[k: string]: MoveText} = {
 	psyblade: {
 		name: "Psyblade",
 		desc: "This attack has its power multiplied by 1.5 while the user is affected by Electric Terrain.",
-		shortDesc: "x1.5 power in Electric Terain."
+		shortDesc: "x1.5 power in Electric Terain.",
 	},
 	psychup: {
 		name: "Psych Up",


### PR DESCRIPTION
Tried to keep them in line with the general structure and phrasing of other move descriptions.  
Other weather-related moves' long description also specify how the move is affected by Primal weathers. 
I don't know how Hydro Steam is affected by Desolate Land, but I assume it gets nullified still. Regardless I chose to avoid mentioning this weather.