### PR TITLE
Add New Online Competition : Paldea Prologue

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -259,6 +259,26 @@ export const Formats: FormatList = [
 		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer', 'Open Team Sheets'],
 		banlist: ['Sub-Legendary'],
 	},
+    {
+        name: "[Gen 9] Paldea Prologue",
+
+        mod: 'gen9',
+        gameType: 'doubles',
+        ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer'],
+        onValidateTeam(team) {
+            const RESTRICTED_LEGENDS = [
+                'Koraidon', 'Miraidon',
+            ];
+            let restrictedCount = 0;
+            for (const set of team) {
+                const species = this.dex.getSpecies(set.species);
+                if (RESTRICTED_LEGENDS.includes(species.baseSpecies)) restrictedCount++;
+            }
+            if (restrictedCount > 1) {
+                return [`You are limited to one restricted legend.`, `(You have ${restrictedCount} restricted legends.)`];
+            }
+        },
+    },
 	{
 		name: "[Gen 9] Doubles Custom Game",
 

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -264,20 +264,7 @@ export const Formats: FormatList = [
 
         mod: 'gen9',
         gameType: 'doubles',
-        ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer'],
-        onValidateTeam(team) {
-            const RESTRICTED_LEGENDS = [
-                'Koraidon', 'Miraidon',
-            ];
-            let restrictedCount = 0;
-            for (const set of team) {
-                const species = this.dex.getSpecies(set.species);
-                if (RESTRICTED_LEGENDS.includes(species.baseSpecies)) restrictedCount++;
-            }
-            if (restrictedCount > 1) {
-                return [`You are limited to one restricted legend.`, `(You have ${restrictedCount} restricted legends.)`];
-            }
-        },
+        ruleset: ['Limit One Restricted', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer'],
     },
 	{
 		name: "[Gen 9] Doubles Custom Game",

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -264,8 +264,8 @@ export const Formats: FormatList = [
 
 		mod: 'gen9',
 		gameType: 'doubles',
-		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer'],
-		restricted: ['Limit One Restricted'],
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer', 'Limit One Restricted'],
+		restricted: ['Restricted Legendary'],
 	},
 	{
 		name: "[Gen 9] Doubles Custom Game",

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -259,13 +259,14 @@ export const Formats: FormatList = [
 		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer', 'Open Team Sheets'],
 		banlist: ['Sub-Legendary'],
 	},
-    {
-        name: "[Gen 9] Paldea Prologue",
+	{
+		name: "[Gen 9] Paldea Prologue",
 
-        mod: 'gen9',
-        gameType: 'doubles',
-        ruleset: ['Limit One Restricted', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer'],
-    },
+		mod: 'gen9',
+		gameType: 'doubles',
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer'],
+		restricted: ['Limit One Restricted'],
+	},
 	{
 		name: "[Gen 9] Doubles Custom Game",
 


### PR DESCRIPTION
I would like to add a new online competition: "Paldea Prologue" to our format. The official tournament outline is as follows.
https://sv-news.pokemon.co.jp/en/page/39.html

This is the first revision I am implementing, so please point out any bad parts.