### PR TITLE
Gen 9 Random Battles: Tera Blast shouldn't lower Attack EVs/IVs in most situations

### DIFF
--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1296,7 +1296,7 @@ export class RandomTeams {
 			}
 		}
 		let ability = '';
-		let item = undefined;
+		let item: string | undefined = undefined;
 
 		const evs = {hp: 85, atk: 85, def: 85, spa: 85, spd: 85, spe: 85};
 		const ivs = {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31};
@@ -1354,7 +1354,7 @@ export class RandomTeams {
 		const noAttackStatMoves = [...moves].every(m => {
 			const move = this.dex.moves.get(m);
 			if (move.damageCallback || move.damage) return true;
-			if (move.id === 'shellsidearm') return false;
+			if (['shellsidearm', 'terablast'].includes(move.id) && item !== 'Choice Specs') return false;
 			return move.category !== 'Physical' || move.id === 'bodypress' || move.id === 'foulplay';
 		});
 		if (noAttackStatMoves && !moves.has('transform')) {


### PR DESCRIPTION
Tera Blast will no longer allow Attack EVs/IVs to be lowered, unless the Pokemon has Choice Specs. Affects Pokemon like Shift Gear Magearna.

https://discord.com/channels/294651453279174656/1041098998624288990/1080482521256570932