### PR TITLE
Hackmons Cup: Stop banning all natures when there are custom bans

### DIFF
--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -766,7 +766,6 @@ export class RandomGen8Teams {
 				}
 				// There is no 'nature:nonature' rule so do not constrain pool size
 			}
-
 		}
 
 		const randomN = this.randomNPokemon(this.maxTeamSize, this.forceMonotype, undefined,

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -745,29 +745,28 @@ export class RandomGen8Teams {
 		let naturePool: Nature[] = [];
 		if (doNaturesExist) {
 			if (!hasCustomBans) {
-				if (!hasCustomBans) {
-					naturePool = [...this.dex.natures.all()];
-				} else {
-					const hasAllNaturesBan = ruleTable.check('pokemontag:allnatures');
-					for (const nature of this.dex.natures.all()) {
-						let banReason = ruleTable.check('nature:' + nature.id);
-						if (banReason) continue;
-						if (banReason !== '' && nature.id) {
-							if (hasAllNaturesBan) continue;
-							if (nature.isNonstandard) {
-								banReason = ruleTable.check('pokemontag:' + toID(nature.isNonstandard));
-								if (banReason) continue;
-								if (banReason !== '' && nature.isNonstandard !== 'Unobtainable') {
-									if (hasNonexistentBan) continue;
-									if (!hasNonexistentWhitelist) continue;
-								}
+				naturePool = [...this.dex.natures.all()];
+			} else {
+				const hasAllNaturesBan = ruleTable.check('pokemontag:allnatures');
+				for (const nature of this.dex.natures.all()) {
+					let banReason = ruleTable.check('nature:' + nature.id);
+					if (banReason) continue;
+					if (banReason !== '' && nature.id) {
+						if (hasAllNaturesBan) continue;
+						if (nature.isNonstandard) {
+							banReason = ruleTable.check('pokemontag:' + toID(nature.isNonstandard));
+							if (banReason) continue;
+							if (banReason !== '' && nature.isNonstandard !== 'Unobtainable') {
+								if (hasNonexistentBan) continue;
+								if (!hasNonexistentWhitelist) continue;
 							}
 						}
-						naturePool.push(nature);
 					}
-					// There is no 'nature:nonature' rule so do not constrain pool size
+					naturePool.push(nature);
 				}
+				// There is no 'nature:nonature' rule so do not constrain pool size
 			}
+
 		}
 
 		const randomN = this.randomNPokemon(this.maxTeamSize, this.forceMonotype, undefined,

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -2009,8 +2009,6 @@ export class RandomTeams {
 				const hasAllNaturesBan = ruleTable.check('pokemontag:allnatures');
 				for (const nature of this.dex.natures.all()) {
 					let banReason = ruleTable.check('nature:' + nature.id);
-					console.log(banReason);
-					console.log(nature);
 					if (banReason) continue;
 					if (banReason !== '' && nature.id) {
 						if (hasAllNaturesBan) continue;
@@ -2028,7 +2026,6 @@ export class RandomTeams {
 				// There is no 'nature:nonature' rule so do not constrain pool size
 			}
 		}
-		console.log(naturePool);
 
 		const randomN = this.randomNPokemon(this.maxTeamSize, this.forceMonotype, undefined,
 			hasCustomBans ? ruleTable : undefined);

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -2004,30 +2004,31 @@ export class RandomTeams {
 		let naturePool: Nature[] = [];
 		if (doNaturesExist) {
 			if (!hasCustomBans) {
-				if (!hasCustomBans) {
-					naturePool = [...this.dex.natures.all()];
-				} else {
-					const hasAllNaturesBan = ruleTable.check('pokemontag:allnatures');
-					for (const nature of this.dex.natures.all()) {
-						let banReason = ruleTable.check('nature:' + nature.id);
-						if (banReason) continue;
-						if (banReason !== '' && nature.id) {
-							if (hasAllNaturesBan) continue;
-							if (nature.isNonstandard) {
-								banReason = ruleTable.check('pokemontag:' + toID(nature.isNonstandard));
-								if (banReason) continue;
-								if (banReason !== '' && nature.isNonstandard !== 'Unobtainable') {
-									if (hasNonexistentBan) continue;
-									if (!hasNonexistentWhitelist) continue;
-								}
+				naturePool = [...this.dex.natures.all()];
+			} else {
+				const hasAllNaturesBan = ruleTable.check('pokemontag:allnatures');
+				for (const nature of this.dex.natures.all()) {
+					let banReason = ruleTable.check('nature:' + nature.id);
+					console.log(banReason);
+					console.log(nature);
+					if (banReason) continue;
+					if (banReason !== '' && nature.id) {
+						if (hasAllNaturesBan) continue;
+						if (nature.isNonstandard) {
+							banReason = ruleTable.check('pokemontag:' + toID(nature.isNonstandard));
+							if (banReason) continue;
+							if (banReason !== '' && nature.isNonstandard !== 'Unobtainable') {
+								if (hasNonexistentBan) continue;
+								if (!hasNonexistentWhitelist) continue;
 							}
 						}
-						naturePool.push(nature);
 					}
-					// There is no 'nature:nonature' rule so do not constrain pool size
+					naturePool.push(nature);
 				}
+				// There is no 'nature:nonature' rule so do not constrain pool size
 			}
 		}
+		console.log(naturePool);
 
 		const randomN = this.randomNPokemon(this.maxTeamSize, this.forceMonotype, undefined,
 			hasCustomBans ? ruleTable : undefined);


### PR DESCRIPTION
Currently when generating a team for hackmonscup with any sort of custom ban, all natures get banned. This is because of a weird typo(?) that has persisted for a long time and affects all gens. The code checked the same condition twice in a row: `if (!hasCustomBans)` and the `else` was misplaced.

With the introduction of brokencup in  #9427 the check for custom bans changed so that the default gen9HC now has custom bans (specifically, it bans `'Nonexistent'`), so natures were accidentally removed from default HC. The bug always existed but was never noticed before.