### PR TITLE
Validator: Identify moves learned only in a later gen as sketched in previous gens

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -2071,7 +2071,7 @@ export class TeamValidator {
 				} else if (move.gen > 7 && !canSketchPostGen7Moves) {
 					cantLearnReason = `can't be Sketched because it's a Gen ${move.gen} move and Sketch isn't available in Gen ${move.gen}.`;
 				} else {
-					if (!sources) sketch = true;
+					if (!sources || !moveSources.size()) sketch = true;
 					sources = learnset['sketch'].concat(sources || []);
 				}
 			}

--- a/test/sim/team-validator/misc.js
+++ b/test/sim/team-validator/misc.js
@@ -84,4 +84,11 @@ describe('Team Validator', function () {
 
 		assert.legalTeam(team, 'gen1ou');
 	});
+
+	it('should correctly enforce Shell Smash as a sketched move for Necturna prior to Gen 9', function () {
+		const team = [
+			{species: 'necturna', ability: 'forewarn', moves: ['shellsmash', 'vcreate'], evs: {hp: 1}},
+		];
+		assert.false.legalTeam(team, 'gen8cap');
+	});
 });


### PR DESCRIPTION
Previous logic caused Necturna to learn Shell Smash in previous gens without restriction because sources had a value, and thus any moves Necturna learned in future generations also passed the validator as "naturally learned" in previous generations. This seems to fix it but unsure if there is a better way.