### PR TITLE
DPP DOU: Update ruleset

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2589,7 +2589,6 @@ export const Formats: FormatList = [
 
 		mod: 'gen4',
 		gameType: 'doubles',
-		searchShow: false,
 		ruleset: ['Standard', '!Sleep Clause Mod'],
 		banlist: ['AG', 'Uber', 'Soul Dew', 'Dark Void'],
 		unbanlist: ['Garchomp', 'Latios', 'Manaphy', 'Mew', 'Salamence', 'Wobbuffet', 'Wynaut'],

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2585,14 +2585,14 @@ export const Formats: FormatList = [
 	},
 	{
 		name: "[Gen 4] Doubles OU",
-		threads: [`&bullet; <a href="https://www.smogon.com/forums/threads/3618411/">DPP Doubles</a>`],
+		threads: [`&bullet; <a href="https://www.smogon.com/forums/threads/3717286/">DPP Doubles</a>`],
 
 		mod: 'gen4',
 		gameType: 'doubles',
 		searchShow: false,
-		ruleset: ['[Gen 4] OU', '!Freeze Clause Mod'],
-		banlist: ['Explosion'],
-		unbanlist: ['Garchomp', 'Latias', 'Latios', 'Manaphy', 'Mew', 'Salamence', 'Wobbuffet', 'Wynaut', 'Swagger'],
+		ruleset: ['Standard', '!Sleep Clause Mod'],
+		banlist: ['AG', 'Uber', 'Soul Dew', 'Dark Void'],
+		unbanlist: ['Garchomp', 'Latios', 'Manaphy', 'Mew', 'Salamence', 'Wobbuffet', 'Wynaut'],
 	},
 	{
 		name: "[Gen 3] Doubles OU",


### PR DESCRIPTION
Also updates [thread link](https://www.smogon.com/forums/threads/dpp-doubles-ou.3717286/post-9528605). Doubles OU tier leaders have signed off on the changes.

- Removes Sleep Clause (and bans Dark Void)
- Removes Sand Veil / Snow Cloak bans
- Removes Arena Trap ban
- Removes Baton Pass ban
- Removes Explosion ban