### PR TITLE
Mix and Mega: Fix custom validation

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -821,7 +821,7 @@ export const Formats: FormatList = [
 				const natdex = this.ruleTable.has('standardnatdex');
 				if (natdex && item.id !== 'ultranecroziumz') continue;
 				const species = this.dex.species.get(set.species);
-				if (species.isNonstandard && !this.ruleTable.has(`+${this.toID(species.isNonstandard)}`)) {
+				if (species.isNonstandard && !this.ruleTable.has(`+pokemontag:${this.toID(species.isNonstandard)}`)) {
 					return [`${species.baseSpecies} does not exist in gen 9.`];
 				}
 				if (natdex && species.name.startsWith('Necrozma-') && item.id === 'ultranecroziumz') {


### PR DESCRIPTION
This if statement would always be true because the actual rule corresponding to isNonstandard properties has a `pokemontag:` prefix

e.g. +CAP is read as +pokemontag:cap