### PR TITLE
Random Battles updates

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -259,7 +259,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Chloroblast", "Energy Ball", "Taunt", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Energy Ball", "Leaf Storm", "Taunt", "Thunder Wave", "Thunderbolt", "Volt Switch"],
                 "teraTypes": ["Grass"]
             },
             {
@@ -493,12 +493,12 @@
                 "teraTypes": ["Steel", "Fairy"]
             },
             {
-                "role": "Fast Attacker",
-                "movepool": ["Brave Bird", "Close Combat", "Dragon Dance", "Flare Blitz", "Psychic Fangs", "Swords Dance", "U-turn"],
-                "teraTypes": ["Fighting", "Fire"]
+                "role": "Setup Sweeper",
+                "movepool": ["Brave Bird", "Close Combat", "Flare Blitz", "Leech Life", "Psychic Fangs", "Swords Dance"],
+                "teraTypes": ["Fighting"]
             },
             {
-                "role": "Setup Sweeper",
+                "role": "Fast Bulky Setup",
                 "movepool": ["Aura Sphere", "Dazzling Gleam", "Earth Power", "Fire Blast", "Nasty Plot", "Psyshock", "Shadow Ball"],
                 "teraTypes": ["Psychic", "Fighting", "Fire", "Ghost", "Ground", "Fairy"]
             }
@@ -644,7 +644,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Fire Blast", "Hydro Pump", "Ice Beam", "Psychic", "Psyshock", "Trick", "Trick Room"],
+                "movepool": ["Fire Blast", "Hydro Pump", "Ice Beam", "Psychic", "Psyshock", "Trick Room"],
                 "teraTypes": ["Water", "Psychic"]
             }
         ]
@@ -1125,7 +1125,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Brave Bird", "Close Combat", "Double-Edge", "Quick Attack", "U-turn"],
-                "teraTypes": ["Fighting", "Flying"]
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -1290,7 +1290,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Extreme Speed", "Meteor Mash", "Stone Edge", "Swords Dance"],
-                "teraTypes": ["Normal", "Fighting", "Steel"]
+                "teraTypes": ["Normal"]
             },
             {
                 "role": "Setup Sweeper",
@@ -1494,8 +1494,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Dazzling Gleam", "Energy Ball", "Healing Wish", "Ice Beam", "Nasty Plot", "Psychic", "Thunderbolt", "Trick", "U-turn"],
+                "movepool": ["Dazzling Gleam", "Energy Ball", "Healing Wish", "Ice Beam", "Nasty Plot", "Psychic", "Thunderbolt", "U-turn"],
                 "teraTypes": ["Psychic", "Fairy", "Electric"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Encore", "Psychic", "Stealth Rock", "Thunder Wave", "Thunderbolt", "U-turn"],
+                "teraTypes": ["Electric"]
             }
         ]
     },
@@ -1519,7 +1524,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Draco Meteor", "Fire Blast", "Flash Cannon", "Stealth Rock", "Thunder Wave", "Thunderbolt", "Trick"],
+                "movepool": ["Draco Meteor", "Fire Blast", "Flash Cannon", "Stealth Rock", "Thunder Wave", "Thunderbolt"],
                 "teraTypes": ["Dragon", "Steel", "Fire"]
             }
         ]
@@ -2381,9 +2386,9 @@
                 "teraTypes": ["Normal"]
             },
             {
-                "role": "Fast Support",
-                "movepool": ["Defog", "Draco Meteor", "Flamethrower", "Hurricane", "Roost", "U-turn"],
-                "teraTypes": ["Fire"]
+                "role": "Bulky Attacker",
+                "movepool": ["Defog", "Draco Meteor", "Flamethrower", "Roost", "Taunt", "U-turn"],
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -2416,11 +2421,6 @@
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             },
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Dark Pulse", "Focus Blast", "Nasty Plot", "Psyshock"],
-                "teraTypes": ["Dark", "Fighting", "Psychic"]
-            },
-            {
                 "role": "Bulky Attacker",
                 "movepool": ["Focus Blast", "Gunk Shot", "Hyperspace Fury", "Psychic", "Trick"],
                 "teraTypes": ["Fighting", "Poison"]
@@ -2432,7 +2432,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Earth Power", "Flame Charge", "Flamethrower", "Sludge Bomb", "Steam Eruption"],
+                "movepool": ["Earth Power", "Flame Charge", "Flamethrower", "Haze", "Sludge Bomb", "Steam Eruption"],
                 "teraTypes": ["Water", "Fire", "Ground"]
             }
         ]
@@ -2911,7 +2911,7 @@
         "level": 87,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Megahorn", "No Retreat", "Poison Jab", "Rock Slide"],
                 "teraTypes": ["Fighting", "Ghost"]
             },
@@ -3147,7 +3147,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Close Combat", "Crunch", "Heavy Slam", "Icicle Crash", "Stomping Tantrum", "Swords Dance"],
+                "movepool": ["Close Combat", "Heavy Slam", "Icicle Crash", "Stomping Tantrum", "Swords Dance"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -4002,7 +4002,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Close Combat", "Leaf Blade", "Psyblade", "Swords Dance", "Wild Charge"],
+                "movepool": ["Close Combat", "Leaf Blade", "Psyblade", "Swords Dance"],
                 "teraTypes": ["Fighting"]
             },
             {
@@ -4092,7 +4092,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Gigaton Hammer", "Knock Off", "Play Rough", "Stealth Rock", "Thunder Wave"],
+                "movepool": ["Encore", "Gigaton Hammer", "Knock Off", "Play Rough", "Stealth Rock", "Thunder Wave"],
                 "teraTypes": ["Steel"]
             },
             {

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2387,7 +2387,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Defog", "Draco Meteor", "Flamethrower", "Roost", "Taunt", "U-turn"],
+                "movepool": ["Defog", "Draco Meteor", "Flamethrower", "Roost", "Taunt"],
                 "teraTypes": ["Steel"]
             }
         ]

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -460,13 +460,14 @@ export class RandomTeams {
 			this.incompatibleMoves(moves, movePool, Setup, pivotingMoves);
 		}
 		this.incompatibleMoves(moves, movePool, Setup, Hazards);
-		this.incompatibleMoves(moves, movePool, Setup, ['defog', 'nuzzle', 'toxic', 'waterspout', 'yawn']);
+		this.incompatibleMoves(moves, movePool, Setup, ['defog', 'nuzzle', 'toxic', 'waterspout', 'yawn', 'haze']);
 		this.incompatibleMoves(moves, movePool, PhysicalSetup, PhysicalSetup);
 		this.incompatibleMoves(moves, movePool, SpecialSetup, 'thunderwave');
 		this.incompatibleMoves(moves, movePool, 'substitute', pivotingMoves);
 		this.incompatibleMoves(moves, movePool, SpeedSetup, ['aquajet', 'rest', 'trickroom']);
 		this.incompatibleMoves(moves, movePool, 'curse', 'rapidspin');
 		this.incompatibleMoves(moves, movePool, 'dragondance', 'dracometeor');
+		this.incompatibleMoves(moves, movePool, 'healingwish', 'uturn');
 
 
 		// These attacks are redundant with each other
@@ -1040,7 +1041,9 @@ export class RandomTeams {
 		if (species.id === 'regieleki') return 'Magnet';
 		if (species.id === 'pincurchin') return 'Shuca Berry';
 		if (species.id === 'cyclizar' && role === 'Fast Attacker') return 'Choice Scarf';
-		if (species.id === 'lokix' && role === 'Wallbreaker') return 'Life Orb';
+		if (species.id === 'lokix') {
+			return (role === 'Fast Attacker') ? 'Silver Powder' : 'Life Orb';
+		}
 		if (species.id === 'toxtricity' && moves.has('shiftgear')) return 'Throat Spray';
 		if (species.baseSpecies === 'Magearna' && role === 'Tera Blast user') return 'Weakness Policy';
 		if (moves.has('lastrespects')) return 'Choice Scarf';
@@ -1205,7 +1208,7 @@ export class RandomTeams {
 		if (
 			role === 'Fast Support' && isLead &&
 			!counter.get('recovery') && !counter.get('recoil') && !moves.has('protect') &&
-			(species.baseStats.hp + species.baseStats.def + species.baseStats.spd) < 300
+			(species.baseStats.hp + species.baseStats.def + species.baseStats.spd) < 258
 		) return 'Focus Sash';
 		if (
 			role !== 'Fast Attacker' && role !== 'Tera Blast user' && ability !== 'Levitate' &&
@@ -1578,7 +1581,9 @@ export class RandomTeams {
 
 			// Track what the team has
 			if (set.ability === 'Drizzle' || set.moves.includes('raindance')) teamDetails.rain = 1;
-			if (set.ability === 'Drought' || set.moves.includes('sunnyday')) teamDetails.sun = 1;
+			if (set.ability === 'Drought' || set.ability === 'Orichalcum Pulse' || set.moves.includes('sunnyday')) {
+				teamDetails.sun = 1;
+			}
 			if (set.ability === 'Sand Stream') teamDetails.sand = 1;
 			if (set.ability === 'Snow Warning' || set.moves.includes('snowscape') || set.moves.includes('chillyreception')) {
 				teamDetails.snow = 1;


### PR DESCRIPTION
yes i'm aware it's 3-11 shut up

An effort to reduce the frequency of choice items in the format is being executed. Hopefully some of the changes here will help with the frequency of getting 3+ choiced pokemon in a game. Changes made with this goal in mind are marked with an asterisk (*)

-Volcanion will now get Haze, and therefore Boots. It will not generate Haze with Flame Charge. *
-Iron Thorns and Landorus-Therian will no longer get Focus Sash.
-Iron Leaves will now always get Psyblade on its Swords Dance set (Wild Charge was removed)
-Lokix no longer gets Boots. Instead, the U-turn set gets Silver Powder, while the other sets get Life Orb.
-Slowking, Mesprit, and Dialga no longer get Trick, but can still get Choice items at a lower rate than previously. *
-Mesprit can no longer get both Healing Wish and U-turn on the same set. *
-Choice item Falinks no longer exists. *
-Hisuian Electrode now has Leaf Storm instead of Chloroblast; now, not all sets will have Energy Ball.
-Glastrier does not need Crunch. *
-Hoopa-Unbound was deemed ineffective with Nasty Plot, so its fully special set was removed.
-Tinkaton can now use Encore.
-Physical Lucario now only has Normal tera, which forces all sets to have Extreme Speed.
-Staraptor now only has Fighting tera, which forces all sets to have Close Combat.
-Orichalcum Pulse now counts as having sun, so you will now get sun-synergistic abilities like Chlorophyll on your team with Koraidon when available.
-Physical Mew now always has Swords Dance and no longer runs Choice items or Dragon Dance. It has also gained Leech Life and will always have Close Combat. *
-Bulky Support Mesprit now exists as a second set. *
-Noivern's Fast Support set has become a Tera Steel Bulky Attacker set with no Hurricane; it will now always have Roost on this set and will have Defog more often than before.