### PR TITLE
Old Gens Random Battles updates

### DIFF
--- a/data/mods/gen3/random-data.json
+++ b/data/mods/gen3/random-data.json
@@ -477,7 +477,7 @@
     },
     "corsola": {
         "level": 90,
-        "moves": ["calmmind", "confuseray", "icebeam", "recover", "surf", "toxic"]
+        "moves": ["calmmind", "icebeam", "recover", "surf", "toxic"]
     },
     "octillery": {
         "level": 88,

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -251,7 +251,8 @@ export class RandomGen5Teams extends RandomGen6Teams {
 				(moves.has('doubleedge') && !abilities.has('rockhead')) ||
 				['pursuit', 'rest', 'superpower', 'uturn', 'voltswitch'].some(m => moves.has(m)) ||
 				// Sceptile wants Swords Dance
-				(moves.has('acrobatics') && moves.has('earthquake'))
+				(moves.has('acrobatics') && moves.has('earthquake')) ||
+				movePool.includes('shiftgear')
 			)};
 		case 'thunderwave':
 			return {cull: (

--- a/data/mods/gen6/random-data.json
+++ b/data/mods/gen6/random-data.json
@@ -6,7 +6,7 @@
     },
     "venusaurmega": {
         "level": 80,
-        "moves": ["earthquake", "gigadrain", "hiddenpowerfire", "leechseed", "sludgebomb", "synthesis"],
+        "moves": ["earthquake", "gigadrain", "hiddenpowerfire", "sleeppowder", "sludgebomb", "synthesis"],
         "doublesMoves": ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "powerwhip", "protect", "sleeppowder", "sludgebomb"]
     },
     "charizardmegax": {
@@ -1696,7 +1696,7 @@
     },
     "arceusground": {
         "level": 76,
-        "moves": ["earthquake", "icebeam", "judgment", "recover", "stealthrock", "stoneedge", "swordsdance", "toxic"],
+        "moves": ["earthquake", "icebeam", "recover", "stealthrock", "stoneedge", "swordsdance", "toxic"],
         "doublesMoves": ["calmmind", "earthquake", "icebeam", "judgment", "protect", "recover", "rockslide", "stoneedge", "swordsdance"]
     },
     "arceusice": {
@@ -2380,7 +2380,7 @@
     },
     "yveltal": {
         "level": 76,
-        "moves": ["darkpulse", "foulplay", "oblivionwing", "roost", "suckerpunch", "taunt", "toxic", "uturn"],
+        "moves": ["darkpulse", "foulplay", "knockoff", "oblivionwing", "roost", "suckerpunch", "taunt", "toxic", "uturn"],
         "doublesMoves": ["darkpulse", "focusblast", "hurricane", "oblivionwing", "protect", "roost", "skydrop", "snarl", "suckerpunch", "taunt"]
     },
     "zygarde": {

--- a/data/mods/gen6/random-data.json
+++ b/data/mods/gen6/random-data.json
@@ -551,7 +551,7 @@
     },
     "wobbuffet": {
         "level": 82,
-        "moves": ["counter", "destinybond", "encore", "mirrorcoat", "safeguard"]
+        "moves": ["counter", "destinybond", "encore", "mirrorcoat"]
     },
     "girafarig": {
         "level": 88,
@@ -1551,7 +1551,7 @@
     },
     "rotomfrost": {
         "level": 88,
-        "moves": ["blizzard", "painsplit", "substitute", "thunderbolt", "trick", "voltswitch", "willowisp"],
+        "moves": ["blizzard", "painsplit", "thunderbolt", "trick", "voltswitch", "willowisp"],
         "doublesMoves": ["blizzard", "electroweb", "painsplit", "protect", "substitute", "thunderbolt", "trick", "voltswitch", "willowisp"]
     },
     "rotomfan": {
@@ -2075,7 +2075,7 @@
     },
     "durant": {
         "level": 84,
-        "moves": ["honeclaws", "ironhead", "stoneedge", "superpower", "xscissor"],
+        "moves": ["honeclaws", "ironhead", "rockslide", "superpower", "xscissor"],
         "doublesMoves": ["honeclaws", "ironhead", "protect", "rockslide", "superpower", "xscissor"]
     },
     "hydreigon": {
@@ -2395,7 +2395,7 @@
     },
     "dianciemega": {
         "level": 80,
-        "moves": ["calmmind", "diamondstorm", "earthpower", "hiddenpowerfire", "moonblast"],
+        "moves": ["calmmind", "diamondstorm", "earthpower", "hiddenpowerfire", "moonblast", "protect"],
         "doublesMoves": ["calmmind", "dazzlinggleam", "diamondstorm", "earthpower", "hiddenpowerfire", "moonblast", "protect", "psyshock"]
     },
     "hoopa": {

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -226,7 +226,8 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			return {cull: (
 				moves.has('rest') || screens || (!!counter.setupType && !moves.has('wish')) ||
 				(!['Guts', 'Harvest', 'Poison Heal', 'Quick Feet', 'Speed Boost'].some(abil => abilities.has(abil)) &&
-				!['leechseed', 'perishsong', 'toxic', 'wish'].some(m => moves.has(m)) && species.id !== 'sharpedomega')
+				!['leechseed', 'perishsong', 'toxic', 'wish'].some(m => moves.has(m)) &&
+				!['sharpedomega', 'dianciemega'].includes(species.id))
 			)};
 		case 'pursuit':
 			return {cull: (
@@ -642,9 +643,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (species.name === 'Shedinja' || species.name === 'Smeargle') return 'Focus Sash';
 		if (species.name === 'Unfezant' && counter.get('Physical') >= 2) return 'Scope Lens';
 		if (species.name === 'Unown') return 'Choice Specs';
-		if (species.name === 'Wobbuffet') {
-			return moves.has('destinybond') ? 'Custap Berry' : this.sample(['Leftovers', 'Sitrus Berry']);
-		}
+		if (species.name === 'Wobbuffet') return 'Custap Berry';
 		if (ability === 'Harvest') return 'Sitrus Berry';
 		if (ability === 'Imposter') return 'Choice Scarf';
 		if (moves.has('switcheroo') || moves.has('trick')) {
@@ -852,7 +851,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		}
 
 		// These moves can be used even if we aren't setting up to use them:
-		const SetupException = ['closecombat', 'diamondstorm', 'extremespeed', 'suckerpunch', 'superpower', 'dracometeor'];
+		const SetupException = ['closecombat', 'diamondstorm', 'extremespeed', 'suckerpunch', 'superpower'];
 
 		const moves = new Set<string>();
 		let counter: MoveCounter;

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -53,6 +53,10 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			),
 			Ice: (movePool, moves, abilities, types, counter) => !counter.get('Ice') && !abilities.has('Refrigerate'),
 			Normal: movePool => movePool.includes('facade'),
+			Poison: (movePool, moves, abilities, types, counter) => (
+				!counter.get('Poison') &&
+				(!!counter.setupType || abilities.has('Adaptability') || abilities.has('Sheer Force') || movePool.includes('gunkshot'))
+			),
 			Psychic: (movePool, moves, abilities, types, counter, species) => (
 				!!counter.get('Psychic') &&
 				!types.has('Flying') &&

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -492,10 +492,10 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		case 'safeguard':
 			return {cull: moves.has('destinybond')};
 		case 'substitute':
+			const moveBasedCull = ['copycat', 'dragondance', 'shiftgear'].some(m => movePool.includes(m));
 			return {cull: (
 				['dracometeor', 'pursuit', 'rest', 'taunt', 'uturn', 'voltswitch', 'whirlwind'].some(m => moves.has(m)) ||
-				(moves.has('leafstorm') && !abilities.has('Contrary')) ||
-				movePool.includes('copycat') || movePool.includes('dragondance')
+				(moves.has('leafstorm') && !abilities.has('Contrary')) || moveBasedCull
 			)};
 		}
 

--- a/data/mods/gen7/random-data.json
+++ b/data/mods/gen7/random-data.json
@@ -6,7 +6,7 @@
     },
     "venusaurmega": {
         "level": 82,
-        "moves": ["earthquake", "gigadrain", "hiddenpowerfire", "leechseed", "sludgebomb", "synthesis"],
+        "moves": ["earthquake", "gigadrain", "hiddenpowerfire", "sleeppowder", "sludgebomb", "synthesis"],
         "doublesMoves": ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "powerwhip", "protect", "sleeppowder", "sludgebomb"]
     },
     "charizard": {
@@ -1753,7 +1753,7 @@
     },
     "arceusground": {
         "level": 76,
-        "moves": ["earthquake", "icebeam", "judgment", "recover", "stealthrock", "stoneedge", "swordsdance", "toxic"],
+        "moves": ["earthquake", "icebeam", "recover", "stealthrock", "stoneedge", "swordsdance", "toxic"],
         "doublesMoves": ["calmmind", "earthquake", "icebeam", "judgment", "protect", "recover", "rockslide", "stoneedge", "swordsdance"]
     },
     "arceusice": {
@@ -2441,7 +2441,7 @@
     },
     "yveltal": {
         "level": 76,
-        "moves": ["darkpulse", "focusblast", "foulplay", "oblivionwing", "roost", "suckerpunch", "taunt", "toxic", "uturn"],
+        "moves": ["darkpulse", "focusblast", "foulplay", "knockoff", "oblivionwing", "roost", "suckerpunch", "taunt", "toxic", "uturn"],
         "doublesMoves": ["darkpulse", "heatwave", "oblivionwing", "protect", "roost", "skydrop", "snarl", "suckerpunch", "taunt"]
     },
     "zygarde": {

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1352,11 +1352,6 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		}
 
 		if (species.name === 'Genesect' && moves.has('technoblast')) forme = 'Genesect-Douse';
-		if (!isDoubles && species.id === 'pikachu') {
-			const pikachuForme = this.sample(['', '-Original', '-Hoenn', '-Sinnoh', '-Unova', '-Kalos', '-Alola', '-Partner']);
-			forme = `Pikachu${pikachuForme}`;
-			if (forme !== 'Pikachu') ability = 'Static';
-		}
 
 		if (
 			!moves.has('photongeyser') &&
@@ -1460,11 +1455,6 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			ivs.spa = 0;
 		}
 
-		if (['gyroball', 'metalburst', 'trickroom'].some(m => moves.has(m))) {
-			evs.spe = 0;
-			ivs.spe = 0;
-		}
-
 		// Fix IVs for non-Bottle Cap-able sets
 		if (hasHiddenPower && level < 100) {
 			let hpType;
@@ -1477,6 +1467,11 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			for (iv in HPivs) {
 				ivs[iv] = HPivs[iv]!;
 			}
+		}
+
+		if (['gyroball', 'metalburst', 'trickroom'].some(m => moves.has(m))) {
+			evs.spe = 0;
+			ivs.spe = (hasHiddenPower && level < 100) ? ivs.spe - 30 : 0;
 		}
 
 		return {

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -574,11 +574,12 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				(moves.has('wish') && (moves.has('protect') || movePool.includes('protect')))
 			)};
 		case 'substitute':
+			const moveBasedCull = ['copycat', 'dragondance', 'shiftgear'].some(m => movePool.includes(m));
 			return {cull: (
 				moves.has('dracometeor') ||
 				(moves.has('leafstorm') && !abilities.has('Contrary')) ||
 				['encore', 'pursuit', 'rest', 'taunt', 'uturn', 'voltswitch', 'whirlwind'].some(m => moves.has(m)) ||
-				movePool.includes('copycat') || movePool.includes('dragondance')
+				moveBasedCull
 			)};
 		case 'powersplit':
 			return {cull: moves.has('guardsplit')};

--- a/data/mods/gen8/random-data.json
+++ b/data/mods/gen8/random-data.json
@@ -232,9 +232,7 @@
     },
     "kingler": {
         "level": 84,
-        "moves": ["agility", "liquidation", "rockslide", "superpower", "swordsdance", "xscissor"],
-        "doublesLevel": 86,
-        "doublesMoves": ["agility", "knockoff", "liquidation", "protect", "superpower", "xscissor"]
+        "moves": ["agility", "liquidation", "rockslide", "superpower", "swordsdance", "xscissor"]
     },
     "kinglergmax": {
         "doublesLevel": 86,
@@ -719,7 +717,7 @@
         "level": 80,
         "moves": ["earthquake", "flipturn", "icebeam", "protect", "scald", "stealthrock", "toxic"],
         "doublesLevel": 86,
-        "doublesMoves": ["highhorsepower", "icywind", "liquidation", "muddywater", "protect", "stealthrock", "wideguard"]
+        "doublesMoves": ["highhorsepower", "icywind", "muddywater", "protect", "stealthrock", "wideguard"]
     },
     "linoone": {
         "level": 84,
@@ -1328,7 +1326,7 @@
         "level": 86,
         "moves": ["bulkup", "circlethrow", "icepunch", "knockoff", "rest", "sleeptalk", "stormthrow"],
         "doublesLevel": 86,
-        "doublesMoves": ["facade", "knockoff", "protect", "stoneedge", "stormthrow", "wideguard"]
+        "doublesMoves": ["facade", "knockoff", "protect", "stormthrow", "wideguard"]
     },
     "sawk": {
         "level": 86,


### PR DESCRIPTION
Gen 8 Doubles:
- Kingler will always be G-Max Foamburst
- Swampert will get Muddy Water instead of Liquidation
- Stone Edge is unobtainable on Throh, so it is removed

Gen 3:
- Corsola will no longer get Confuse Ray

Gen 5-7:
- Klinklang will always get Shift Gear

Gen 6-7:
- Venusaur-Mega -Leech Seed +Sleep Powder
- Arceus-Ground -Judgment
- Yveltal +Knock Off

Gen 6:
- Wobbuffet -Safeguard
- Rotom-Frost -Substitute
- Durant -Stone Edge +Rock Slide
- Diancie-Mega +Protect
- add Poison STAB enforcement, same as gen 7
- Draco Meteor will no longer appear with physical setup

Gen 7:
- Pikachu will always get Lightning Rod
- Pokemon with Trick Room + Hidden Power will get minimal Speed IVs