### PR TITLE
Random Battles updates

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2192,7 +2192,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Dark Pulse", "Grass Knot", "Gunk Shot", "Hydro Pump", "Ice Beam", "Spikes", "Toxic Spikes", "U-turn"],
+                "movepool": ["Dark Pulse", "Grass Knot", "Gunk Shot", "Hydro Pump", "Ice Beam", "Toxic Spikes", "U-turn"],
                 "teraTypes": ["Water", "Dark", "Poison"]
             }
         ]
@@ -3262,7 +3262,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Flower Trick", "Knock Off", "Spikes", "Thunder Punch", "Toxic Spikes", "U-turn"],
+                "movepool": ["Flower Trick", "Knock Off", "Thunder Punch", "Toxic Spikes", "U-turn"],
                 "teraTypes": ["Grass", "Dark"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -208,9 +208,9 @@
         "level": 78,
         "sets": [
             {
-                "role": "Tera Blast user",
-                "movepool": ["Icicle Spear", "Rock Blast", "Shell Smash", "Tera Blast"],
-                "teraTypes": ["Fire", "Ground"]
+                "role": "Fast Attacker",
+                "movepool": ["Drill Run", "Icicle Spear", "Rock Blast", "Shell Smash"],
+                "teraTypes": ["Ground"]
             },
             {
                 "role": "Setup Sweeper",
@@ -1274,7 +1274,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Draco Meteor", "Earthquake", "Fire Blast", "Stealth Rock", "Stone Edge"],
+                "movepool": ["Draco Meteor", "Earthquake", "Fire Blast", "Spikes", "Stealth Rock", "Stone Edge"],
                 "teraTypes": ["Ground", "Steel"]
             },
             {
@@ -1943,7 +1943,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Bitter Malice", "Flamethrower", "Focus Blast", "Hyper Voice", "Nasty Plot", "Shadow Ball", "Trick", "U-turn"],
-                "teraTypes": ["Normal"]
+                "teraTypes": ["Normal", "Fighting"]
             }
         ]
     },
@@ -3262,7 +3262,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Flower Trick", "Knock Off", "Thunder Punch", "Toxic Spikes", "U-turn"],
+                "movepool": ["Flower Trick", "Knock Off", "Spikes", "Thunder Punch", "Toxic Spikes", "U-turn"],
                 "teraTypes": ["Grass", "Dark"]
             }
         ]
@@ -3428,7 +3428,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Future Sight", "Hyper Voice", "Protect", "Wish"],
-                "teraTypes": ["Ground", "Water", "Fairy"]
+                "teraTypes": ["Ground", "Water", "Fairy", "Normal"]
             },
             {
                 "role": "AV Pivot",
@@ -3849,6 +3849,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Earth Power", "Spikes", "Stealth Rock", "Thunder Wave", "Thunderbolt", "Volt Switch"],
                 "teraTypes": ["Electric", "Ground"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Earth Power", "Tera Blast", "Thunderbolt", "Volt Switch"],
+                "teraTypes": ["Flying", "Ice"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2192,7 +2192,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Dark Pulse", "Grass Knot", "Gunk Shot", "Hydro Pump", "Ice Beam", "Toxic Spikes", "U-turn"],
+                "movepool": ["Dark Pulse", "Grass Knot", "Gunk Shot", "Hydro Pump", "Ice Beam", "Spikes", "Toxic Spikes", "U-turn"],
                 "teraTypes": ["Water", "Dark", "Poison"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -3488,7 +3488,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Dazzling Gleam", "Earth Power", "Energy Ball", "Hyper Voice", "Strength Sap"],
-                "teraTypes": ["Grass", "Fairy"]
+                "teraTypes": ["Grass", "Fairy", "Ground"]
             },
             {
                 "role": "Bulky Support",

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -173,7 +173,6 @@ export class RandomTeams {
 			Ice: (movePool, moves, abilities, types, counter) => (movePool.includes('freezedry') || !counter.get('Ice')),
 			Normal: (movePool, moves, abilities, types, counter) => {
 				if (movePool.includes('boomburst') || movePool.includes('hypervoice')) return true;
-				return (!counter.get('Normal') && movePool.includes('futuresight'));
 			},
 			Poison: (movePool, moves, abilities, types, counter) => {
 				if (types.includes('Ground')) return false;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -171,9 +171,7 @@ export class RandomTeams {
 			),
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
 			Ice: (movePool, moves, abilities, types, counter) => (movePool.includes('freezedry') || !counter.get('Ice')),
-			Normal: (movePool, moves, abilities, types, counter) => {
-				return (movePool.includes('boomburst') || movePool.includes('hypervoice'));
-			},
+			Normal: (movePool, moves, abilities, types, counter) => (movePool.includes('boomburst') || movePool.includes('hypervoice'));,
 			Poison: (movePool, moves, abilities, types, counter) => {
 				if (types.includes('Ground')) return false;
 				return !counter.get('Poison');

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -171,7 +171,7 @@ export class RandomTeams {
 			),
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
 			Ice: (movePool, moves, abilities, types, counter) => (movePool.includes('freezedry') || !counter.get('Ice')),
-			Normal: (movePool, moves, abilities, types, counter) => (movePool.includes('boomburst') || movePool.includes('hypervoice')),
+			Normal: (movePool, moves, types, counter) => (movePool.includes('boomburst') || movePool.includes('hypervoice')),
 			Poison: (movePool, moves, abilities, types, counter) => {
 				if (types.includes('Ground')) return false;
 				return !counter.get('Poison');

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -172,7 +172,7 @@ export class RandomTeams {
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
 			Ice: (movePool, moves, abilities, types, counter) => (movePool.includes('freezedry') || !counter.get('Ice')),
 			Normal: (movePool, moves, abilities, types, counter) => {
-				if (movePool.includes('boomburst') || movePool.includes('hypervoice')) return true;
+				return (movePool.includes('boomburst') || movePool.includes('hypervoice'));
 			},
 			Poison: (movePool, moves, abilities, types, counter) => {
 				if (types.includes('Ground')) return false;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -171,7 +171,7 @@ export class RandomTeams {
 			),
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
 			Ice: (movePool, moves, abilities, types, counter) => (movePool.includes('freezedry') || !counter.get('Ice')),
-			Normal: (movePool, moves, abilities, types, counter) => (movePool.includes('boomburst') || movePool.includes('hypervoice'));,
+			Normal: (movePool, moves, abilities, types, counter) => (movePool.includes('boomburst') || movePool.includes('hypervoice')),
 			Poison: (movePool, moves, abilities, types, counter) => {
 				if (types.includes('Ground')) return false;
 				return !counter.get('Poison');

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -172,7 +172,7 @@ export class RandomTeams {
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
 			Ice: (movePool, moves, abilities, types, counter) => (movePool.includes('freezedry') || !counter.get('Ice')),
 			Normal: (movePool, moves, abilities, types, counter) => {
-				if (movePool.includes('boomburst')) return true;
+				if (movePool.includes('boomburst') || movePool.includes('hypervoice')) return true;
 				return (!counter.get('Normal') && movePool.includes('futuresight'));
 			},
 			Poison: (movePool, moves, abilities, types, counter) => {
@@ -970,6 +970,7 @@ export class RandomTeams {
 		if (abilities.has('Technician') && counter.get('technician')) return 'Technician';
 		if (abilities.has('Own Tempo') && moves.has('petaldance')) return 'Own Tempo';
 		if (abilities.has('Slush Rush') && moves.has('snowscape')) return 'Slush Rush';
+		if (abilities.has('Soundproof') && moves.has('substitute')) return 'Soundproof';
 
 		let abilityAllowed: Ability[] = [];
 		// Obtain a list of abilities that are allowed (not culled)


### PR DESCRIPTION
-Substitute users will always get Soundproof when possible (Hisuian Electrode)
-Garchomp can get Spikes now.
-Farigiraf has gained Tera Normal on its Future Sight WishTect set.
-Cloyster is no longer a Tera Blast user, and instead uses Tera Ground Drill Run.
-Hyper Voice will now always appear on Normal-types that can run it.
-Arboliva now gets Ground Tera as an option to compensate for forced Hyper Voice decreasing the rate of Earth Power.
-Hisuian Zoroark can now also use Tera Fighting, and will get Focus Blast more often.
-Sandy Shocks can now run a Choice item Tera Blast set. It is Tera Flying or Ice.
