### PR TITLE
Mix and Mega: Fix error message

### DIFF
--- a/data/mods/mixandmega/scripts.ts
+++ b/data/mods/mixandmega/scripts.ts
@@ -68,7 +68,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				pokemon.baseSpecies = rawSpecies;
 				pokemon.details = species.name + (pokemon.level === 100 ? '' : ', L' + pokemon.level) +
 					(pokemon.gender === '' ? '' : ', ' + pokemon.gender) + (pokemon.set.shiny ? ', shiny' : '');
-				pokemon.setAbility(species.abilities['0'], null, true);
+				pokemon.ability = species.abilities['0'];
 				pokemon.baseAbility = pokemon.ability;
 			}
 		}
@@ -121,7 +121,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				pokemon.baseSpecies = rawSpecies;
 				pokemon.details = species.name + (pokemon.level === 100 ? '' : ', L' + pokemon.level) +
 					(pokemon.gender === '' ? '' : ', ' + pokemon.gender) + (pokemon.set.shiny ? ', shiny' : '');
-				pokemon.setAbility(species.abilities['0'], null, true);
+				pokemon.ability = species.abilities['0'];
 				pokemon.baseAbility = pokemon.ability;
 
 				const behemothMove: {[k: string]: string} = {


### PR DESCRIPTION
The crash was because when an ability such as Protosynthesis, Quark Drive, or Slow Start ends, the pokemon tries to delete a volatile, showing a client error in the process (probably because the pokemon wasn't out?)