### PR TITLE
Gen 9 Randbats: Council Decisions

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1055,12 +1055,12 @@
         ]
     },
     "glalie": {
-        "level": 78,
+        "level": 97,
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Disable", "Earthquake", "Freeze-Dry", "Protect", "Substitute"],
-                "teraTypes": ["Poison", "Steel", "Water"]
+                "movepool": ["Disable", "Earthquake", "Ice Beam", "Spikes", "Taunt"],
+                "teraTypes": ["Poison", "Steel", "Water", "Ground"]
             }
         ]
     },
@@ -3498,12 +3498,17 @@
         ]
     },
     "scovillain": {
-        "level": 76,
+        "level": 90,
         "sets": [
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Flamethrower", "Leech Seed", "Protect", "Substitute"],
                 "teraTypes": ["Steel", "Water"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Flamethrower", "Giga Drain", "Leaf Storm", "Overheat"],
+                "teraTypes": ["Fire", "Grass"]
             }
         ]
     },

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -487,6 +487,7 @@ export class RandomTeams {
 
 		// These status moves are redundant with each other
 		this.incompatibleMoves(moves, movePool, ['taunt', 'strengthsap'], 'encore');
+		this.incompatibleMoves(moves, movePool, 'taunt', 'disable');
 		this.incompatibleMoves(moves, movePool, 'toxic', 'willowisp');
 		this.incompatibleMoves(moves, movePool, ['thunderwave', 'toxic', 'willowisp'], 'toxicspikes');
 		this.incompatibleMoves(moves, movePool, 'thunderwave', 'yawn');
@@ -833,7 +834,7 @@ export class RandomTeams {
 	): boolean {
 		if ([
 			'Armor Tail', 'Battle Bond', 'Early Bird', 'Flare Boost', 'Gluttony', 'Harvest', 'Hydration', 'Ice Body', 'Immunity',
-			'Own Tempo', 'Pressure', 'Quick Feet', 'Rain Dish', 'Sand Veil', 'Snow Cloak', 'Steadfast', 'Steam Engine',
+			'Moody', 'Own Tempo', 'Pressure', 'Quick Feet', 'Rain Dish', 'Sand Veil', 'Snow Cloak', 'Steadfast', 'Steam Engine',
 		].includes(ability)) return true;
 
 		switch (ability) {
@@ -956,6 +957,7 @@ export class RandomTeams {
 		// Hard-code abilities here
 		if (species.id === 'arcaninehisui') return 'Rock Head';
 		if (species.id === 'staraptor') return 'Reckless';
+		if (species.id === 'scovillain') return 'Chlorophyll';
 		if (species.id === 'vespiquen') return 'Pressure';
 		if (species.id === 'enamorus' && moves.has('calmmind')) return 'Cute Charm';
 		if (species.id === 'cetitan' && role === 'Wallbreaker') return 'Sheer Force';
@@ -1471,11 +1473,21 @@ export class RandomTeams {
 			// Illusion shouldn't be on the last slot
 			if (species.baseSpecies === 'Zoroark' && pokemon.length >= (this.maxTeamSize - 1)) continue;
 
-			// If Zoroark is in the team, the sixth slot should not be a Pokemon with extremely low level
+			// If Zoroark is in the team, ensure its level is balanced
+			// Level range differs for each forme of Zoroark
 			if (
-				pokemon.some(pkmn => pkmn.name === 'Zoroark') &&
+				pokemon.some(pkmn => pkmn.species === 'Zoroark') &&
 				pokemon.length >= (this.maxTeamSize - 1) &&
-				this.getLevel(species, isDoubles) < 72 &&
+				(this.getLevel(species, isDoubles) < 76 || this.getLevel(species, isDoubles) > 94) &&
+				!this.adjustLevel
+			) {
+				continue;
+			}
+
+			if (
+				pokemon.some(pkmn => pkmn.species === 'Zoroark-Hisui') &&
+				pokemon.length >= (this.maxTeamSize - 1) &&
+				(this.getLevel(species, isDoubles) < 72 || this.getLevel(species, isDoubles) > 86) &&
 				!this.adjustLevel
 			) {
 				continue;


### PR DESCRIPTION
-Remove Moody from the format, effective April 1. Glalie will be a bad Spikes set at level 97, and Scovillain will be either subseed or Choice item at random at level 90.

-Balance the levels of Zoroark and Hisuian Zoroark further by adding a maximum level for the sixth slot when a Zoroark is generated. In addition, level balance the Zoroarks separately from each other.

This is part 1 of this week's update - part 2 will consist of monthly level balancing and will be done by Chains of Markov.