### PR TITLE
Old Gens Random Battles updates

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2101,7 +2101,7 @@ export const Formats: FormatList = [
 
 		mod: 'gen7',
 		team: 'random',
-		ruleset: ['Obtainable', 'Sleep Clause Mod', 'HP Percentage Mod', 'Cancel Mod', 'Mega Rayquaza Clause'],
+		ruleset: ['Obtainable', 'Sleep Clause Mod', 'HP Percentage Mod', 'Cancel Mod'],
 	},
 	{
 		name: "[Gen 7] Random Doubles Battle",
@@ -2157,7 +2157,7 @@ export const Formats: FormatList = [
 
 		mod: 'gen6',
 		team: 'random',
-		ruleset: ['Obtainable', 'Sleep Clause Mod', 'HP Percentage Mod', 'Cancel Mod', 'Mega Rayquaza Clause'],
+		ruleset: ['Obtainable', 'Sleep Clause Mod', 'HP Percentage Mod', 'Cancel Mod'],
 	},
 	{
 		name: "[Gen 6] Battle Factory",

--- a/data/mods/gen1/random-teams.ts
+++ b/data/mods/gen1/random-teams.ts
@@ -133,7 +133,7 @@ export class RandomGen1Teams extends RandomGen2Teams {
 
 		// Now let's store what we are getting.
 		const typeCount: {[k: string]: number} = {};
-		const weaknessCount: {[k: string]: number} = {Electric: 0, Psychic: 0, Water: 0, Ice: 0, Ground: 0};
+		const weaknessCount: {[k: string]: number} = {Electric: 0, Psychic: 0, Water: 0, Ice: 0, Ground: 0, Fire: 0};
 		let uberCount = 0;
 		let nuCount = 0;
 
@@ -361,6 +361,18 @@ export class RandomGen1Teams extends RandomGen2Teams {
 				if (hp % 4 !== 0) break;
 				evs.hp -= 4;
 			}
+		}
+
+		// Minimize confusion damage
+		const noAttackStatMoves = [...moves].every(m => {
+			const move = this.dex.moves.get(m);
+			if (move.damageCallback || move.damage) return true;
+			return move.category !== 'Physical';
+		});
+		if (noAttackStatMoves && !moves.has('mimic') && !moves.has('transform')) {
+			evs.atk = 0;
+			// We don't want to lower the HP DV/IV
+			ivs.atk = 2;
 		}
 
 		return {

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -318,8 +318,8 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			return !teamDetails['sand'];
 		case 'Serene Grace':
 			return species.id === 'blissey';
-		case 'Sturdy':
-			// Sturdy is bad.
+		case 'Soundproof': case 'Sturdy':
+			// Electrode prefers Static, and Sturdy is bad.
 			return true;
 		case 'Swift Swim':
 			return !moves.has('raindance') && !teamDetails['rain'];

--- a/data/mods/gen4/random-data.json
+++ b/data/mods/gen4/random-data.json
@@ -73,7 +73,7 @@
     },
     "parasect": {
         "level": 88,
-        "moves": ["seedbomb", "spore", "stunspore", "synthesis", "xscissor"]
+        "moves": ["leechseed", "seedbomb", "spore", "stunspore", "synthesis", "xscissor"]
     },
     "venomoth": {
         "level": 88,
@@ -305,7 +305,7 @@
     },
     "ledian": {
         "level": 88,
-        "moves": ["encore", "lightscreen", "reflect", "roost", "toxic", "uturn"]
+        "moves": ["encore", "knockoff", "lightscreen", "reflect", "roost", "toxic", "uturn"]
     },
     "ariados": {
         "level": 88,
@@ -349,7 +349,7 @@
     },
     "sunflora": {
         "level": 88,
-        "moves": ["earthpower", "hiddenpowerice", "leafstorm", "synthesis"]
+        "moves": ["earthpower", "hiddenpowerice", "leafstorm", "sludgebomb", "synthesis"]
     },
     "quagsire": {
         "level": 88,
@@ -385,7 +385,7 @@
     },
     "dunsparce": {
         "level": 88,
-        "moves": ["bite", "bodyslam", "headbutt", "rockslide", "roost", "thunderwave", "zenheadbutt"]
+        "moves": ["bite", "bodyslam", "earthquake", "headbutt", "rockslide", "roost", "thunderwave"]
     },
     "steelix": {
         "level": 84,
@@ -648,8 +648,8 @@
         "moves": ["calmmind", "focusblast", "healbell", "psychic", "shadowball", "thunderwave", "toxic"]
     },
     "spinda": {
-        "level": 88,
-        "moves": ["bodyslam", "encore", "hypnosis", "seismictoss", "substitute", "teeterdance", "toxic"]
+        "level": 100,
+        "moves": ["bodyslam", "encore", "shadowball", "teeterdance", "toxic"]
     },
     "flygon": {
         "level": 80,
@@ -1089,7 +1089,7 @@
     },
     "giratinaorigin": {
         "level": 76,
-        "moves": ["aurasphere", "calmmind", "dracometeor", "dragonpulse", "hiddenpowerfire", "outrage", "shadowball", "shadowsneak", "substitute"]
+        "moves": ["aurasphere", "calmmind", "dracometeor", "dragonpulse", "outrage", "shadowball", "shadowsneak", "substitute", "willowisp"]
     },
     "giratina": {
         "level": 76,

--- a/data/mods/gen5/random-data.json
+++ b/data/mods/gen5/random-data.json
@@ -425,7 +425,7 @@
     },
     "shuckle": {
         "level": 90,
-        "moves": ["encore", "protect", "stealthrock", "toxic", "wrap"]
+        "moves": ["encore", "knockoff", "protect", "stealthrock", "toxic"]
     },
     "heracross": {
         "level": 82,

--- a/data/mods/gen6/random-data.json
+++ b/data/mods/gen6/random-data.json
@@ -76,7 +76,7 @@
     },
     "pikachu": {
         "level": 90,
-        "moves": ["extremespeed", "grassknot", "hiddenpowerice", "knockoff", "voltswitch", "volttackle"],
+        "moves": ["extremespeed", "grassknot", "hiddenpowerice", "knockoff", "surf", "voltswitch", "volttackle"],
         "doublesMoves": ["brickbreak", "discharge", "encore", "extremespeed", "fakeout", "grassknot", "hiddenpowerice", "knockoff", "protect", "substitute", "thunderbolt", "voltswitch", "volttackle"]
     },
     "raichu": {
@@ -186,7 +186,7 @@
     },
     "golem": {
         "level": 88,
-        "moves": ["earthquake", "explosion", "stoneedge", "stealthrock", "suckerpunch", "toxic"],
+        "moves": ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic"],
         "doublesMoves": ["earthquake", "firepunch", "hammerarm", "protect", "rockslide", "stoneedge", "suckerpunch"]
     },
     "rapidash": {
@@ -1201,10 +1201,12 @@
     },
     "rayquaza": {
         "level": 76,
-        "moves": ["dracometeor", "dragonascent", "dragonclaw", "dragondance", "earthquake", "extremespeed", "outrage", "vcreate"],
+        "moves": ["dracometeor", "dragonclaw", "dragondance", "earthquake", "extremespeed", "outrage", "vcreate"],
         "doublesMoves": ["dracometeor", "dragonclaw", "dragondance", "earthquake", "extremespeed", "protect", "tailwind", "vcreate"]
     },
     "rayquazamega": {
+        "level": 67,
+        "moves": ["dragonascent", "dragondance", "earthquake", "extremespeed", "vcreate"],
         "doublesMoves": ["dragonascent", "dragonclaw", "dragondance", "earthquake", "extremespeed", "protect", "swordsdance", "vcreate"]
     },
     "jirachi": {

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -21,6 +21,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 				!counter.get('Dragon') &&
 				!abilities.has('Aerilate') &&
 				!abilities.has('Pixilate') &&
+				!moves.has('dragonascent') &&
 				!moves.has('rest') &&
 				!moves.has('sleeptalk')
 			),
@@ -513,7 +514,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		species: Species
 	): boolean {
 		switch (ability) {
-		case 'Flare Boost': case 'Gluttony': case 'Moody': case 'Snow Cloak': case 'Steadfast':
+		case 'Flare Boost': case 'Gluttony': case 'Moody': case 'Snow Cloak': case 'Steadfast': case 'Magician':
 			return true;
 		case 'Contrary': case 'Iron Fist': case 'Skill Link': case 'Strong Jaw':
 			return !counter.get(toID(ability));

--- a/data/mods/gen7/random-data.json
+++ b/data/mods/gen7/random-data.json
@@ -81,7 +81,7 @@
     },
     "pikachu": {
         "level": 90,
-        "moves": ["extremespeed", "grassknot", "hiddenpowerice", "irontail", "knockoff", "voltswitch", "volttackle"],
+        "moves": ["extremespeed", "grassknot", "hiddenpowerice", "knockoff", "surf", "voltswitch", "volttackle"],
         "doublesMoves": ["encore", "fakeout", "grassknot", "hiddenpowerice", "knockoff", "protect", "voltswitch", "volttackle"]
     },
     "raichu": {
@@ -216,7 +216,7 @@
     },
     "golem": {
         "level": 88,
-        "moves": ["earthquake", "explosion", "rockblast", "stealthrock", "suckerpunch", "toxic"],
+        "moves": ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic"],
         "doublesMoves": ["earthquake", "protect", "rockslide", "stealthrock", "stoneedge", "suckerpunch"]
     },
     "golemalola": {
@@ -1257,10 +1257,12 @@
     },
     "rayquaza": {
         "level": 76,
-        "moves": ["dracometeor", "dragonascent", "dragondance", "earthquake", "extremespeed", "outrage", "vcreate"],
+        "moves": ["dracometeor", "dragondance", "earthquake", "extremespeed", "outrage", "vcreate"],
         "doublesMoves": ["dracometeor", "dragonclaw", "dragondance", "earthquake", "extremespeed", "protect", "tailwind", "vcreate"]
     },
     "rayquazamega": {
+        "level": 67,
+        "moves": ["dragonascent", "dragondance", "earthquake", "extremespeed", "vcreate"],
         "doublesMoves": ["dragonascent", "dragonclaw", "dragondance", "earthquake", "extremespeed", "protect", "swordsdance", "vcreate"]
     },
     "jirachi": {

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -47,7 +47,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			Dragon: (movePool, moves, abilities, types, counter) => (
 				!counter.get('Dragon') &&
 				!abilities.has('Aerilate') && !abilities.has('Pixilate') &&
-				!moves.has('fly') && !moves.has('rest') && !moves.has('sleeptalk')
+				!moves.has('dragonascent') && !moves.has('fly') && !moves.has('rest') && !moves.has('sleeptalk')
 			),
 			Electric: (movePool, moves, abilities, types, counter) => !counter.get('Electric') || movePool.includes('thunder'),
 			Fairy: (movePool, moves, abilities, types, counter) => (
@@ -605,7 +605,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 	): boolean {
 		switch (ability) {
 		case 'Battle Bond': case 'Dazzling': case 'Flare Boost': case 'Hyper Cutter':
-		case 'Ice Body': case 'Innards Out': case 'Moody': case 'Steadfast':
+		case 'Ice Body': case 'Innards Out': case 'Moody': case 'Steadfast': case 'Magician':
 			return true;
 		case 'Aerilate': case 'Galvanize': case 'Pixilate': case 'Refrigerate':
 			return !counter.get('Normal');
@@ -657,8 +657,6 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			return !counter.get('sound');
 		case 'Magic Guard': case 'Speed Boost':
 			return (abilities.has('Tinted Lens') && (!counter.get('Status') || moves.has('uturn')));
-		case 'Magician':
-			return moves.has('switcheroo');
 		case 'Magnet Pull':
 			return (!!counter.get('Normal') || !types.has('Electric') && !moves.has('earthpower'));
 		case 'Mold Breaker':
@@ -1657,7 +1655,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				}
 
 				// Track what the team has
-				if (item.megaStone) hasMega = true;
+				if (item.megaStone || species.name === 'Rayquaza-Mega') hasMega = true;
 				if (item.zMove) teamDetails.zMove = 1;
 				if (set.ability === 'Snow Warning' || set.moves.includes('hail')) teamDetails.hail = 1;
 				if (set.moves.includes('raindance') || set.ability === 'Drizzle' && !item.onPrimal) teamDetails.rain = 1;


### PR DESCRIPTION
Gen 1: 
- limit teams to 2 Fire weaknesses
- Pokemon with no Physical attacks (and no Mimic or Transform) will get minimal Attack EVs/DVs

Gen 3: Electrode wants Static rather than Soundproof

Gen 4:
- some set updates, mostly for mons with low winrate, see the pin in the gen 4 channel
- set Spinda to level 100

Gen 5: Replace Wrap with Knock Off on Shuckle

Gen 6-7:
- Add Mega-Rayquaza, at level 67 in both gens
- A couple minor set changes, including removing Dragon Ascent from regular Rayquaza
- Delphox wants Blaze rather than Magician