### PR TITLE
Fix battle only formes in Old Gens Monotype Random Battles

### DIFF
--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -2406,14 +2406,14 @@ export class RandomGen8Teams {
 	) {
 		const exclude = pokemonToExclude.map(p => toID(p.species));
 		const pokemonPool = [];
-		for (let species of this.dex.species.all()) {
+		for (const species of this.dex.species.all()) {
 			if (species.gen > this.gen || exclude.includes(species.id)) continue;
 			if (this.dex.currentMod === 'gen8bdsp' && species.gen > 4) continue;
 			if (isMonotype) {
 				if (!species.types.includes(type)) continue;
 				if (typeof species.battleOnly === 'string') {
-					species = this.dex.species.get(species.battleOnly);
-					if (!species.types.includes(type)) continue;
+					const baseSpecies = this.dex.species.get(species.battleOnly);
+					if (!baseSpecies.types.includes(type)) continue;
 				}
 			}
 			pokemonPool.push(species.id);


### PR DESCRIPTION
Fixes a bug which prevented battle-only formes from generating in pre-gen 9 Monotype Random Battles, even if both formes have the required type. Most notably, Megas couldn't generate in gens 6-7.