### PR TITLE
Update BSS/VGC Regulation C formats

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -205,6 +205,7 @@ export const Formats: FormatList = [
 		name: "[Gen 9] Battle Stadium Singles Series 2",
 
 		mod: 'gen9',
+		searchShow: false,
 		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer'],
 		banlist: ['Sub-Legendary'],
 	},
@@ -212,7 +213,6 @@ export const Formats: FormatList = [
 		name: "[Gen 9] Battle Stadium Singles Regulation C",
 
 		mod: 'gen9',
-		searchShow: false,
 		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer'],
 	},
 	{
@@ -294,6 +294,7 @@ export const Formats: FormatList = [
 		name: "[Gen 9] VGC 2023 Series 2",
 
 		mod: 'gen9',
+		searchShow: false,
 		gameType: 'doubles',
 		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer', 'Open Team Sheets'],
 		banlist: ['Sub-Legendary'],


### PR DESCRIPTION
Removes Series 2 ladder for both, Regulation C is now default ladder for BSS.