### PR TITLE
Gen 9 Random Battle: Improve handling of lead slot

### DIFF
--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1566,8 +1566,6 @@ export class RandomTeams {
 				pokemon.push(set);
 			}
 
-			// Okay, the set passes, add it to our team
-			pokemon.push(set);
 			if (pokemon.length === this.maxTeamSize) {
 				// Set Zoroark's level to be the same as the last Pokemon
 				const illusion = teamDetails.illusion;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -110,7 +110,7 @@ const priorityPokemon = [
 ];
 
 /** Pokemon who should never be in the lead slot */
-const NoLeadPokemon = [
+const noLeadPokemon = [
 	'Basculegion', 'Houndstone', 'Zacian', 'Zamazenta',
 ];
 

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -359,7 +359,7 @@ export class RandomTeams {
 			if (move.drain) counter.add('drain');
 			// Moves which have a base power, but aren't super-weak:
 			if (move.basePower > 30 || move.multihit || move.basePowerCallback) {
-				if (!this.noStab.includes(moveid) || PriorityPokemon.includes(species.id) && move.priority > 0) {
+				if (!this.noStab.includes(moveid) || priorityPokemon.includes(species.id) && move.priority > 0) {
 					counter.add(moveType);
 					if (types.includes(moveType)) counter.stabCounter++;
 					if (teraType === moveType) counter.add('stabtera');
@@ -664,7 +664,7 @@ export class RandomTeams {
 		}
 
 		// Enforce STAB priority
-		if (role === 'Bulky Attacker' || role === 'Bulky Setup' || PriorityPokemon.includes(species.id)) {
+		if (role === 'Bulky Attacker' || role === 'Bulky Setup' || priorityPokemon.includes(species.id)) {
 			const priorityMoves = [];
 			for (const moveid of movePool) {
 				const move = this.dex.moves.get(moveid);
@@ -1551,7 +1551,7 @@ export class RandomTeams {
 			let set: RandomTeamsTypes.RandomSet;
 
 			if (!generatedLead) {
-				if (NoLeadPokemon.includes(species.baseSpecies)) {
+				if (noLeadPokemon.includes(species.baseSpecies)) {
 					if (pokemon.length + 1 === this.maxTeamSize) continue;
 					set = this.randomSet(species, teamDetails, false, isDoubles);
 					pokemon.push(set);

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -105,7 +105,7 @@ const MovePairs = [
 ];
 
 /** Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type */
-const PriorityPokemon = [
+const priorityPokemon = [
 	'banette', 'breloom', 'brutebonnet', 'cacturne', 'giratinaorigin', 'lycanrocdusk', 'mimikyu', 'scizor',
 ];
 


### PR DESCRIPTION
Previously, Pokemon that shouldn't be put in the lead slot were simply skipped. Now they are still added, but a different lead is chosen on the next iteration and inserted in front.