### PR TITLE
Github Actions: Perform selective eslint & testing for PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,8 @@ jobs:
           
     - run: npm ci
     
-    - name: Get all changed *.js, *.ts & *.tsx file(s)
+    - name: Determine which files to lint (if pull request)
+      if: ${{ github.event_name == 'pull_request' }}
       id: changed-files
       uses: tj-actions/changed-files@v35
       with:
@@ -45,11 +46,8 @@ jobs:
           **/*.ts
           **/*.tsx
 
-    - name: What files where changed?
-      run: |
-        echo ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
-
-    - name: Detect changed directories
+    - name: Determine whether test/sim or test/random-battles need to run (if pull request)
+      if: ${{ github.event_name == 'pull_request' }}
       id: changed-directories
       uses: tj-actions/changed-files@v35
       with:
@@ -59,14 +57,14 @@ jobs:
           sim/**
 
     - name: Run selective lint & neccessary tests (if pull request)
-      run: npm run full-test-ci
       if: ${{ github.event_name == 'pull_request' }}
+      run: npm run full-test-ci
       env:
         CI: true
         FILES: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
         SKIPSIMTESTS: ${{ steps.changed-directories.outputs.all_changed_and_modified_files == '' }}
 
-    - name: Run full lint & test (if pushing to master)
+    - name: Run full lint & test (if push to master)
       run: npm run full-test
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,12 +49,22 @@ jobs:
       run: |
         echo ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
 
-    - name: Run selective lint & full test (if pull request)
+    - name: Detect changed directories
+      id: changed-directories
+      uses: tj-actions/changed-files@v35
+      with:
+        files: |
+          config/formats.ts
+          data/**
+          sim/**
+
+    - name: Run selective lint & neccessary tests (if pull request)
       run: npm run full-test-ci
       if: ${{ github.event_name == 'pull_request' }}
       env:
         CI: true
         FILES: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
+        SKIPSIMTESTS: ${{ steps.changed-directories.outputs.all_changed_and_modified_files == '' }}
 
     - name: Run full lint & test (if pushing to master)
       run: npm run full-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,15 +17,47 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
     - uses: actions/checkout@v2
+    
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: Zarel/setup-node@patch-1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npm run full-test
+        cache: 'npm'
+        
+    - name: Cache node_modules or restore if already cached
+      uses: actions/cache@v3
+      with:
+        path: 'node_modules'
+        key: ${{ runner.os }}-node-${{ matrix.node-version }}-modules-${{ hashFiles('package-lock.json') }}
+          
+    - run: npm install && npm list
+    
+    - name: Get all changed *.js, *.ts & *.tsx file(s)
+      id: changed-files
+      uses: tj-actions/changed-files@v35
+      with:
+        files: |
+          **/*.js
+          **/*.ts
+          **/*.tsx
+
+    - name: What files where changed?
+      run: |
+        echo ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
+
+    - name: Run selective lint & full test (if pull request)
+      run: npm run full-test-ci
+      if: ${{ github.event_name == 'pull_request' }}
+      env:
+        CI: true
+        FILES: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
+
+    - name: Run full lint & test (if pushing to master)
+      run: npm run full-test
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
       env:
         CI: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,12 +28,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
         
-    - name: Cache node_modules or restore if already cached
-      uses: actions/cache@v3
-      with:
-        path: 'node_modules'
-        key: ${{ runner.os }}-node-${{ matrix.node-version }}-modules-${{ hashFiles('package-lock.json') }}
-          
     - run: npm ci
     
     - name: Determine which files to lint (if pull request)

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test": "mocha",
     "posttest": "npm run tsc",
     "full-test": "npm run lint && npm run tsc && mocha --timeout 8000 --forbid-only -g \".*\"",
+    "full-test-ci": "eslint ${FILES} --max-warnings 0 && npm run tsc && mocha --timeout 8000 --forbid-only -g \".*\"",
     "postinstall": "npm run build"
   },
   "bin": "./pokemon-showdown",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test": "mocha",
     "posttest": "npm run tsc",
     "full-test": "npm run lint && npm run tsc && mocha --timeout 8000 --forbid-only -g \".*\"",
-    "full-test-ci": "eslint ${FILES} --max-warnings 0 && npm run tsc && (([ \"$SKIPSIMTESTS\" = true ] && echo 'NOTE: Skipping tests in test/sim and test/random-battles ...'  && mocha --timeout 8000 --forbid-only --exclude \"test/{sim,random-battles}/**\") || mocha --timeout 8000 --forbid-only)",
+    "full-test-ci": "eslint ${FILES} --max-warnings 0 && npm run tsc && (([ \"$SKIPSIMTESTS\" = true ] && mocha --timeout 8000 --forbid-only -g \".*\" --exclude \"test/{sim,random-battles}/**\") || mocha --timeout 8000 --forbid-only -g \".*\")",
     "postinstall": "npm run build postinstall"
   },
   "bin": "./pokemon-showdown",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test": "mocha",
     "posttest": "npm run tsc",
     "full-test": "npm run lint && npm run tsc && mocha --timeout 8000 --forbid-only -g \".*\"",
-    "full-test-ci": "eslint ${FILES} --max-warnings 0 && npm run tsc && mocha --timeout 8000 --forbid-only -g \".*\"",
+    "full-test-ci": "eslint ${FILES} --max-warnings 0 && npm run tsc && (([ \"$SKIPSIMTESTS\" = true ] && echo 'NOTE: Skipping tests in test/sim and test/random-battles ...'  && mocha --timeout 8000 --forbid-only --exclude \"test/{sim,random-battles}/**\") || mocha --timeout 8000 --forbid-only)",
     "postinstall": "npm run build postinstall"
   },
   "bin": "./pokemon-showdown",


### PR DESCRIPTION
A few potential optimizations to the Github Actions job that could be worth trying out, if desired

1. Use [actions/cache@v3](https://github.com/actions/cache) to create a Github-hosted, immutable cache entry that stores a specified directory (in this case, `node_modules`). A new entry is created whenever `package-lock.json` is updated or a new `node-version` is specified in the action itself. Old entries are auto-evicted from the cache after a few days of inactivity or due to lack of space. Similar to what is done [here](https://github.com/prettier/eslint-config-prettier/blob/main/.github/workflows/check.yml), saves about a minute in the `npm install` step once cached
2. Use [tj-actions/changed-files@v35](https://github.com/tj-actions/changed-files) to fetch all changed/modified js, ts & tsx files in a PR, and use eslint only on those. If there's a push to master (force push or PR merge), a full lint is run instead. Saves 1-2 minutes for smaller PRs

The remaining large chunk of time is in `tsc` + `mocha` (~6-8m), mainly `mocha`. The runners on Github Actions also seem to vary quite a lot in performance in general between runs, but idk how much we can do about that

Examples:
1. [push-to-master](https://github.com/im-tofa/pokemon-showdown/actions/runs/4638042638/jobs/8207490831)
2. [pull request](https://github.com/im-tofa/pokemon-showdown/actions/runs/4638087164/jobs/8207571092?pr=2)

NOTE: I bumped the node version in Github Actions to `16.x` since I couldn't figure out why `14.x` won't pass `tsc` (happened in `master` as well). I'll change it back to `14.x` after someone who knows more is able to fix it in master