### PR TITLE
Random Battles updates

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -161,7 +161,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			}
 		},
 		name: "Anger Shell",
-		rating: 4,
+		rating: 3,
 		num: 271,
 	},
 	anticipation: {

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -4023,12 +4023,12 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Ruination", "Spikes", "Stealth Rock", "Throat Chop", "Whirlwind"],
-                "teraTypes": ["Ground", "Ghost"]
+                "teraTypes": ["Ground", "Ghost", "Poison"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Earthquake", "Heavy Slam", "Ruination", "Stone Edge", "Throat Chop"],
-                "teraTypes": ["Ground", "Fighting", "Steel"]
+                "teraTypes": ["Ground", "Fighting", "Steel", "Poison"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2402,7 +2402,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Defog", "Draco Meteor", "Flamethrower", "Hurricane", "Roost", "Taunt"],
+                "movepool": ["Defog", "Draco Meteor", "Flamethrower", "Roost", "Taunt"],
                 "teraTypes": ["Steel"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -123,9 +123,9 @@
                 "teraTypes": ["Ghost", "Water", "Fairy", "Steel"]
             },
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Bulk Up", "Close Combat", "Rage Fist", "Stone Edge"],
-                "teraTypes": ["Ghost", "Fighting", "Steel"]
+                "role": "Bulky Setup",
+                "movepool": ["Bulk Up", "Drain Punch", "Gunk Shot", "Rage Fist", "Stone Edge", "Taunt"],
+                "teraTypes": ["Ghost", "Water", "Fairy", "Steel"]
             }
         ]
     },
@@ -249,7 +249,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Explosion", "Foul Play", "Light Screen", "Taunt", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Explosion", "Foul Play", "Taunt", "Thunder Wave", "Thunderbolt", "Volt Switch"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -405,7 +405,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Air Slash", "Freeze-Dry", "Haze", "Hurricane", "Roost", "Substitute", "U-turn"],
-                "teraTypes": ["Flying", "Steel", "Ground", "Poison"]
+                "teraTypes": ["Flying", "Steel", "Ground"]
             }
         ]
     },
@@ -879,6 +879,16 @@
             }
         ]
     },
+    "vigoroth": {
+        "level": 88,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Slam", "Bulk Up", "Earthquake", "Slack Off", "Throat Chop"],
+                "teraTypes": ["Ghost", "Ground"]
+            }
+        ]
+    },
     "slaking": {
         "level": 85,
         "sets": [
@@ -935,7 +945,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Earthquake", "Gunk Shot", "Seed Bomb", "Swords Dance"],
-                "teraTypes": ["Poison", "Ground"]
+                "teraTypes": ["Poison", "Ground", "Grass", "Dark"]
             }
         ]
     },
@@ -1059,7 +1069,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Disable", "Earthquake", "Ice Beam", "Spikes", "Taunt"],
+                "movepool": ["Disable", "Earthquake", "Freeze-Dry", "Spikes", "Taunt"],
                 "teraTypes": ["Poison", "Steel", "Water", "Ground"]
             }
         ]
@@ -1371,11 +1381,6 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Flash Cannon", "Mirror Coat", "Thunderbolt", "Volt Switch"],
                 "teraTypes": ["Electric", "Water", "Flying"]
-            },
-            {
-                "role": "Tera Blast user",
-                "movepool": ["Flash Cannon", "Tera Blast", "Thunderbolt", "Volt Switch"],
-                "teraTypes": ["Water", "Fire"]
             }
         ]
     },
@@ -2047,13 +2052,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Defog", "Heat Wave", "Hurricane", "Psychic"],
-                "teraTypes": ["Psychic", "Flying"]
+                "movepool": ["Agility", "Heat Wave", "Hurricane", "Psychic"],
+                "teraTypes": ["Psychic", "Fairy", "Steel", "Fire"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Calm Mind", "Esper Wing", "Heat Wave", "Hurricane", "U-turn"],
-                "teraTypes": ["Psychic", "Flying"]
+                "movepool": ["Calm Mind", "Defog", "Esper Wing", "Heat Wave", "Hurricane", "U-turn"],
+                "teraTypes": ["Psychic", "Fairy", "Steel"]
             }
         ]
     },
@@ -2074,6 +2079,11 @@
                 "role": "Fast Bulky Setup",
                 "movepool": ["Bug Buzz", "Fiery Dance", "Fire Blast", "Giga Drain", "Morning Sun", "Quiver Dance"],
                 "teraTypes": ["Fire", "Grass", "Water"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Bug Buzz", "Fiery Dance", "Fire Blast", "Giga Drain", "Quiver Dance", "Tera Blast"],
+                "teraTypes": ["Ground", "Water"]
             }
         ]
     },
@@ -2182,8 +2192,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Fire Blast", "Grass Knot", "Nasty Plot", "Psyshock", "Switcheroo"],
-                "teraTypes": ["Fire", "Psychic"]
+                "movepool": ["Fire Blast", "Focus Blast", "Grass Knot", "Nasty Plot", "Psyshock"],
+                "teraTypes": ["Fire", "Psychic", "Grass", "Fighting"]
             }
         ]
     },
@@ -2332,7 +2342,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Draco Meteor", "Earthquake", "Fire Blast", "Power Whip", "Sludge Bomb", "Thunderbolt"],
+                "movepool": ["Draco Meteor", "Dragon Tail", "Earthquake", "Fire Blast", "Power Whip", "Sludge Bomb", "Thunderbolt"],
                 "teraTypes": ["Dragon", "Ground", "Fire", "Grass", "Poison", "Electric"]
             }
         ]
@@ -2392,7 +2402,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Defog", "Draco Meteor", "Flamethrower", "Roost", "Taunt"],
+                "movepool": ["Defog", "Draco Meteor", "Flamethrower", "Hurricane", "Roost", "Taunt"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -2491,13 +2501,8 @@
         "level": 84,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Hurricane", "Quiver Dance", "Revelation Dance", "Roost", "Substitute"],
-                "teraTypes": ["Ground"]
-            },
-            {
-                "role": "Fast Support",
-                "movepool": ["Defog", "Hurricane", "Revelation Dance", "Roost"],
+                "role": "Bulky Attacker",
+                "movepool": ["Defog", "Hurricane", "Quiver Dance", "Revelation Dance", "Roost"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -2506,14 +2511,9 @@
         "level": 83,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Hurricane", "Quiver Dance", "Revelation Dance", "Roost", "Substitute"],
-                "teraTypes": ["Electric", "Ground"]
-            },
-            {
-                "role": "Fast Support",
-                "movepool": ["Defog", "Hurricane", "Revelation Dance", "Roost"],
-                "teraTypes": ["Electric"]
+                "role": "Bulky Attacker",
+                "movepool": ["Defog", "Hurricane", "Quiver Dance", "Revelation Dance", "Roost"],
+                "teraTypes": ["Ground"]
             }
         ]
     },
@@ -2521,13 +2521,8 @@
         "level": 86,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Hurricane", "Quiver Dance", "Revelation Dance", "Roost", "Substitute"],
-                "teraTypes": ["Ground"]
-            },
-            {
-                "role": "Fast Support",
-                "movepool": ["Defog", "Hurricane", "Revelation Dance", "Roost"],
+                "role": "Bulky Attacker",
+                "movepool": ["Defog", "Hurricane", "Quiver Dance", "Revelation Dance", "Roost"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -2536,14 +2531,9 @@
         "level": 84,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Hurricane", "Quiver Dance", "Revelation Dance", "Roost", "Substitute"],
+                "role": "Bulky Attacker",
+                "movepool": ["Defog", "Hurricane", "Quiver Dance", "Revelation Dance", "Roost"],
                 "teraTypes": ["Ghost", "Fighting"]
-            },
-            {
-                "role": "Fast Support",
-                "movepool": ["Defog", "Hurricane", "Revelation Dance", "Roost"],
-                "teraTypes": ["Ghost"]
             }
         ]
     },
@@ -2932,7 +2922,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Discharge", "Liquidation", "Spikes", "Sucker Punch", "Toxic Spikes"],
+                "movepool": ["Discharge", "Hydro Pump", "Spikes", "Sucker Punch", "Toxic Spikes"],
                 "teraTypes": ["Electric", "Water"]
             }
         ]
@@ -3272,13 +3262,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Flame Charge", "Shadow Ball", "Slack Off", "Torch Song"],
-                "teraTypes": ["Fire", "Water"]
+                "movepool": ["Flame Charge", "Roar", "Shadow Ball", "Slack Off", "Torch Song"],
+                "teraTypes": ["Ghost", "Water", "Fairy"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Hex", "Slack Off", "Torch Song", "Will-O-Wisp"],
-                "teraTypes": ["Ghost", "Water"]
+                "teraTypes": ["Ghost", "Water", "Fairy"]
             }
         ]
     },
@@ -3352,7 +3342,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Circle Throw", "Memento", "Spikes", "Sticky Web", "Toxic Spikes"],
+                "movepool": ["Circle Throw", "Spikes", "Sticky Web", "Toxic Spikes", "U-turn"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -3428,7 +3418,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Future Sight", "Hyper Voice", "Protect", "Wish"],
-                "teraTypes": ["Ground", "Water", "Fairy", "Normal"]
+                "teraTypes": ["Ground", "Water", "Fairy"]
             },
             {
                 "role": "AV Pivot",
@@ -3617,13 +3607,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Draco Meteor", "Rapid Spin", "Shed Tail", "Taunt"],
-                "teraTypes": ["Dragon"]
-            },
-            {
-                "role": "Fast Attacker",
-                "movepool": ["Double-Edge", "Draco Meteor", "Knock Off", "Shed Tail"],
-                "teraTypes": ["Normal", "Dragon"]
+                "movepool": ["Draco Meteor", "Knock Off", "Rapid Spin", "Shed Tail", "Taunt"],
+                "teraTypes": ["Dragon", "Steel", "Ghost"]
             }
         ]
     },
@@ -3717,7 +3702,12 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Crabhammer", "High Horsepower", "Knock Off", "Stealth Rock", "Stone Edge", "Swords Dance"],
+                "movepool": ["Crabhammer", "High Horsepower", "Knock Off", "Stealth Rock", "Stone Edge"],
+                "teraTypes": ["Water", "Ground", "Dark", "Rock"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Crabhammer", "High Horsepower", "Knock Off", "Stone Edge", "Swords Dance"],
                 "teraTypes": ["Water", "Ground", "Dark", "Rock"]
             }
         ]
@@ -3728,16 +3718,16 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Curse", "Recover", "Stone Edge"],
-                "teraTypes": ["Fighting"]
+                "teraTypes": ["Fighting", "Fairy", "Dragon"]
             },
             {
-                "role": "AV Pivot",
-                "movepool": ["Avalanche", "Body Press", "Salt Cure", "Stone Edge"],
+                "role": "Bulky Attacker",
+                "movepool": ["Earthquake", "Protect", "Recover", "Salt Cure"],
                 "teraTypes": ["Ghost"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Avalanche", "Body Press", "Recover", "Salt Cure", "Stealth Rock", "Stone Edge"],
+                "movepool": ["Body Press", "Recover", "Salt Cure", "Stealth Rock", "Stone Edge"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -3818,7 +3808,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Make It Rain", "Recover", "Shadow Ball", "Thunder Wave"],
-                "teraTypes": ["Dark", "Water"]
+                "teraTypes": ["Dark", "Water", "Steel"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -89,7 +89,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Aerial Ace", "Body Slam", "Fake Out", "Foul Play", "Gunk Shot", "Switcheroo", "U-turn"],
+                "movepool": ["Aerial Ace", "Bite", "Body Slam", "Fake Out", "Foul Play", "Gunk Shot", "Switcheroo", "U-turn"],
                 "teraTypes": ["Normal", "Poison", "Flying"]
             }
         ]

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -64,7 +64,7 @@ const ContraryMoves = [
 ];
 // Moves that boost Attack:
 const PhysicalSetup = [
-	'bellydrum', 'bulkup', 'coil', 'curse', 'dragondance', 'honeclaws', 'howl', 'meditate', 'poweruppunch', 'swordsdance', 'tidyup',
+	'bellydrum', 'bulkup', 'coil', 'curse', 'dragondance', 'honeclaws', 'howl', 'meditate', 'poweruppunch', 'swordsdance', 'tidyup', 'victorydance',
 ];
 // Moves which boost Special Attack:
 const SpecialSetup = [
@@ -82,7 +82,7 @@ const SpeedSetup = [
 const Setup = [
 	'acidarmor', 'agility', 'autotomize', 'bellydrum', 'bulkup', 'calmmind', 'coil', 'curse', 'dragondance', 'flamecharge',
 	'growth', 'honeclaws', 'howl', 'irondefense', 'meditate', 'nastyplot', 'noretreat', 'poweruppunch', 'quiverdance', 'rockpolish',
-	'shellsmash', 'shiftgear', 'swordsdance', 'tailglow', 'tidyup', 'trailblaze', 'workup',
+	'shellsmash', 'shiftgear', 'swordsdance', 'tailglow', 'tidyup', 'trailblaze', 'workup', 'victorydance',
 ];
 // Moves that shouldn't be the only STAB moves:
 const NoStab = [
@@ -104,9 +104,14 @@ const MovePairs = [
 	['leechseed', 'protect'],
 ];
 
-// Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type
-const PriorityPokemon = [
+/** Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type */
+const priorityPokemon = [
 	'banette', 'breloom', 'brutebonnet', 'cacturne', 'giratinaorigin', 'lycanrocdusk', 'mimikyu', 'scizor',
+];
+
+/** Pokemon who should never be in the lead slot */
+const noLeadPokemon = [
+	'Basculegion', 'Houndstone', 'Rillaboom', 'Zacian', 'Zamazenta',
 ];
 
 function sereneGraceBenefits(move: Move) {
@@ -354,7 +359,7 @@ export class RandomTeams {
 			if (move.drain) counter.add('drain');
 			// Moves which have a base power, but aren't super-weak:
 			if (move.basePower > 30 || move.multihit || move.basePowerCallback) {
-				if (!this.noStab.includes(moveid) || PriorityPokemon.includes(species.id) && move.priority > 0) {
+				if (!this.noStab.includes(moveid) || priorityPokemon.includes(species.id) && move.priority > 0) {
 					counter.add(moveType);
 					if (types.includes(moveType)) counter.stabCounter++;
 					if (teraType === moveType) counter.add('stabtera');
@@ -439,16 +444,26 @@ export class RandomTeams {
 			.map(move => move.id);
 
 		// Team-based move culls
+		if (teamDetails.stickyWeb) {
+			if (movePool.includes('stickyweb')) this.fastPop(movePool, movePool.indexOf('stickyweb'));
+			if (moves.size + movePool.length <= this.maxMoveCount) return;
+		}
 		if (teamDetails.stealthRock) {
 			if (movePool.includes('stealthrock')) this.fastPop(movePool, movePool.indexOf('stealthrock'));
+			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
-		if (moves.size + movePool.length <= this.maxMoveCount) return;
 		if (teamDetails.defog || teamDetails.rapidSpin) {
 			if (movePool.includes('defog')) this.fastPop(movePool, movePool.indexOf('defog'));
 			if (movePool.includes('rapidspin')) this.fastPop(movePool, movePool.indexOf('rapidspin'));
+			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
-		if (teamDetails.stickyWeb) {
-			if (movePool.includes('stickyweb')) this.fastPop(movePool, movePool.indexOf('stickyweb'));
+		if (teamDetails.toxicSpikes && teamDetails.toxicSpikes >= 2) {
+			if (movePool.includes('toxicspikes')) this.fastPop(movePool, movePool.indexOf('toxicspikes'));
+			if (moves.size + movePool.length <= this.maxMoveCount) return;
+		}
+		if (teamDetails.spikes && teamDetails.spikes >= 2) {
+			if (movePool.includes('spikes')) this.fastPop(movePool, movePool.indexOf('spikes'));
+			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
 
 		// These moves don't mesh well with other aspects of the set
@@ -495,6 +510,9 @@ export class RandomTeams {
 		// This space reserved for assorted hardcodes that otherwise make little sense out of context
 		if (species.id === "dugtrio") {
 			this.incompatibleMoves(moves, movePool, statusMoves, 'memento');
+		}
+		if (species.id === "cyclizar") {
+			this.incompatibleMoves(moves, movePool, 'taunt', 'knockoff');
 		}
 		// Landorus
 		this.incompatibleMoves(moves, movePool, 'nastyplot', 'rockslide');
@@ -659,7 +677,7 @@ export class RandomTeams {
 		}
 
 		// Enforce STAB priority
-		if (role === 'Bulky Attacker' || role === 'Bulky Setup' || PriorityPokemon.includes(species.id)) {
+		if (role === 'Bulky Attacker' || role === 'Bulky Setup' || priorityPokemon.includes(species.id)) {
 			const priorityMoves = [];
 			for (const moveid of movePool) {
 				const move = this.dex.moves.get(moveid);
@@ -906,8 +924,6 @@ export class RandomTeams {
 			return abilities.has('Torrent');
 		case 'Solar Power':
 			return (!teamDetails.sun || !counter.get('Special'));
-		case 'Stakeout':
-			return (counter.damagingMoves.size < 1);
 		case 'Sturdy':
 			return !!counter.get('recoil');
 		case 'Swarm':
@@ -961,6 +977,7 @@ export class RandomTeams {
 		if (species.id === 'vespiquen') return 'Pressure';
 		if (species.id === 'enamorus' && moves.has('calmmind')) return 'Cute Charm';
 		if (species.id === 'cetitan' && role === 'Wallbreaker') return 'Sheer Force';
+		if (species.id === 'klawf' && role === 'Setup Sweeper') return 'Anger Shell';
 		if (abilities.has('Cud Chew') && moves.has('substitute')) return 'Cud Chew';
 		if (abilities.has('Guts') && (moves.has('facade') || moves.has('sleeptalk'))) return 'Guts';
 		if (abilities.has('Harvest') && moves.has('substitute')) return 'Harvest';
@@ -1040,7 +1057,6 @@ export class RandomTeams {
 		if (species.id === 'pikachu') return 'Light Ball';
 		if (species.id === 'regieleki') return 'Magnet';
 		if (species.id === 'pincurchin') return 'Shuca Berry';
-		if (species.id === 'cyclizar' && role === 'Fast Attacker') return 'Choice Scarf';
 		if (species.id === 'lokix') {
 			return (role === 'Fast Attacker') ? 'Silver Powder' : 'Life Orb';
 		}
@@ -1071,6 +1087,7 @@ export class RandomTeams {
 		) {
 			return 'Life Orb';
 		}
+		if (ability === 'Anger Shell') return this.sample(['Rindo Berry', 'Passho Berry', 'Scope Lens', 'Sitrus Berry']);
 		if (moves.has('shellsmash')) return 'White Herb';
 		if (moves.has('populationbomb')) return 'Wide Lens';
 		if (moves.has('courtchange')) return 'Heavy-Duty Boots';
@@ -1190,7 +1207,7 @@ export class RandomTeams {
 		if (moves.has('substitute') || ability === 'Moody') return 'Leftovers';
 		if (moves.has('stickyweb') && isLead) return 'Focus Sash';
 		if (
-			!teamDetails.defog && !teamDetails.rapidSpin &&
+			((!teamDetails.defog && !teamDetails.rapidSpin) || (!counter.get('setup') && role !== 'Wallbreaker')) &&
 			this.dex.getEffectiveness('Rock', species) >= 1
 		) return 'Heavy-Duty Boots';
 		if (
@@ -1461,6 +1478,8 @@ export class RandomTeams {
 		const typeWeaknesses: {[k: string]: number} = {};
 		const teamDetails: RandomTeamsTypes.TeamDetails = {};
 		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, isDoubles);
+
+		let generatedLead = false;
 		while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
 			const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
 			const currentSpeciesPool: Species[] = [];
@@ -1492,9 +1511,6 @@ export class RandomTeams {
 			) {
 				continue;
 			}
-
-			// Pokemon with Last Respects, Intrepid Sword, and Dauntless Shield shouldn't be leading
-			if (['Basculegion', 'Houndstone', 'Zacian', 'Zamazenta'].includes(species.baseSpecies) && !pokemon.length) continue;
 
 			const tier = species.tier;
 			const types = species.types;
@@ -1544,10 +1560,24 @@ export class RandomTeams {
 			// The Pokemon of the Day
 			if (potd?.exists && (pokemon.length === 1 || this.maxTeamSize === 1)) species = potd;
 
-			const set = this.randomSet(species, teamDetails, pokemon.length === 0, isDoubles);
+			let set: RandomTeamsTypes.RandomSet;
 
-			// Okay, the set passes, add it to our team
-			pokemon.push(set);
+			if (!generatedLead) {
+				if (noLeadPokemon.includes(species.baseSpecies)) {
+					if (pokemon.length + 1 === this.maxTeamSize) continue;
+					set = this.randomSet(species, teamDetails, false, isDoubles);
+					pokemon.push(set);
+				} else {
+					set = this.randomSet(species, teamDetails, true, isDoubles);
+					pokemon.unshift(set);
+					generatedLead = true;
+					if (typeof teamDetails.illusion === 'number') teamDetails.illusion++;
+				}
+			} else {
+				set = this.randomSet(species, teamDetails, false, isDoubles);
+				pokemon.push(set);
+			}
+
 			if (pokemon.length === this.maxTeamSize) {
 				// Set Zoroark's level to be the same as the last Pokemon
 				const illusion = teamDetails.illusion;
@@ -1598,15 +1628,16 @@ export class RandomTeams {
 			if (set.ability === 'Snow Warning' || set.moves.includes('snowscape') || set.moves.includes('chillyreception')) {
 				teamDetails.snow = 1;
 			}
-			if (set.moves.includes('spikes')) teamDetails.spikes = (teamDetails.spikes || 0) + 1;
-			if (set.moves.includes('stealthrock')) teamDetails.stealthRock = 1;
+			if (set.moves.includes('spikes') || set.moves.includes('ceaselessedge')) {
+				teamDetails.spikes = (teamDetails.spikes || 0) + 1;
+			}
+			if (set.moves.includes('toxicspikes') || set.ability === 'Toxic Debris') {
+				teamDetails.toxicSpikes = (teamDetails.toxicSpikes || 0) + 1;
+			}
+			if (set.moves.includes('stealthrock') || set.moves.includes('stoneaxe')) teamDetails.stealthRock = 1;
 			if (set.moves.includes('stickyweb')) teamDetails.stickyWeb = 1;
-			if (set.moves.includes('stoneaxe')) teamDetails.stealthRock = 1;
-			if (set.moves.includes('toxicspikes')) teamDetails.toxicSpikes = 1;
-			if (set.moves.includes('defog')) teamDetails.defog = 1;
-			if (set.moves.includes('rapidspin')) teamDetails.rapidSpin = 1;
-			if (set.moves.includes('mortalspin')) teamDetails.rapidSpin = 1;
-			if (set.moves.includes('tidyup')) teamDetails.rapidSpin = 1;
+			if (set.moves.includes('defog') || set.moves.includes('tidyup')) teamDetails.defog = 1;
+			if (set.moves.includes('rapidspin') || set.moves.includes('mortalspin')) teamDetails.rapidSpin = 1;
 			if (set.moves.includes('auroraveil') || (set.moves.includes('reflect') && set.moves.includes('lightscreen'))) {
 				teamDetails.screens = 1;
 			}

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -487,7 +487,7 @@ export class RandomTeams {
 		this.incompatibleMoves(moves, movePool, 'surf', 'hydropump');
 		this.incompatibleMoves(moves, movePool, 'liquidation', 'wavecrash');
 		this.incompatibleMoves(moves, movePool, ['airslash', 'bravebird', 'hurricane'], ['airslash', 'bravebird', 'hurricane']);
-		this.incompatibleMoves(moves, movePool, 'knockoff', 'foulplay');
+		this.incompatibleMoves(moves, movePool, ['knockoff', 'bite'], 'foulplay');
 		this.incompatibleMoves(moves, movePool, 'doubleedge', 'headbutt');
 		this.incompatibleMoves(moves, movePool, 'fireblast', ['fierydance', 'flamethrower']);
 		this.incompatibleMoves(moves, movePool, 'lavaplume', 'magmastorm');


### PR DESCRIPTION
Passes /npm test locally.

This pull request is ready to merge and I'd appreciate if it was live by today.

This is a large update.

-Pokemon prevented from being leads will no longer be less common than other Pokemon who can be leads. (Code ported from @MathyFurret's recent PR, which is still unmerged. Credit goes to him if this gets merged first.)
-Tera Blast Magnezone, and by extension Specs Magnezone, will no longer exist.
-Tera Blast Ground/Water Volcarona now exists.
-Swords Dance Swalot: +Tera Grass.
-Electrode: -Light Screen.
-Spidops: -Memento, +U-turn; Insomnia no longer generates.
-Glalie: -Ice Beam, +Freeze Dry.
-Articuno: -Tera Poison, because statistical analysis showed this addition was detrimental.
-Farigiraf: -Tera Normal, because statistical analysis showed this addition was detrimental.
-Gholdengo: +Steel Tera again, because statistical analysis showed that its removal didn't help its winrate.
-Teams will no longer have more than two Spikes or Toxic Spikes users, in most scenarios. Credit goes to @livid-washed for this code.
-Annihilape's second set will be improved. Close Combat is being replaced with Drain Punch, Tera Types now match those of the Rest set, and Gunk Shot and Taunt are new fourth move options.
-Choice Scarf Cyclizar will no longer exist, but the Heavy-Duty Boots set can now sometimes run Knock Off over Taunt. Also, it can now get Steel and Ghost Tera Types.
-Assault Vest Garganacl is being replaced with Salt Cure + Protect Garganacl.
-Bulky Support Garganacl: -Avalanche
-Curse Garganacl: +Tera Fairy, Dragon
-Skeledirge: +Roar, +; Flame Charge Skeledirge is now less common as a result. The Teras on both sets are now Ghost/Water/Fairy.
-Delphox: -Switcheroo, +Focus Blast, +Tera Grass, +Tera Fighting; Choice Specs can now exist.
-Klawf now has a separate Swords Dance set. It will run Anger Shell only, with Rindo Berry, Passho Berry, Sitrus Berry, or Scope Lens at random as its item. Its previous set will now always be Regenerator and does not have Swords Dance.
-Vigoroth will now exist in Random Battles. It will start at level 88, with Bulk Up, Slack Off, Body Slam, and one of Earthquake or Throat Chop, with Ground or Ghost Tera Types.
-Pincurchin: -Liquidation, +Hydro Pump
-Rillaboom will no longer generate as a lead.
-Oricorio formes will no longer run Substitute, and their sets were fused so that they will no longer generate as a second Defogger on a team when the team already has a Defogger. This slightly increases the frequency of Quiver Dance.
-Setup Sweeper Hisuian Lilligant will now always have Victory Dance. Whoops!
-Sheer Force Hisuian Braviary: -Defog, -Tera Flying, +Agility, +Tera Steel/Fairy/Fire
-Tinted Lens Hisuian Braviary: -Tera Flying, +Defog, +Tera Steel/Fairy; Choice Specs and Calm Mind will be slightly less common as a result.
-Unless they have setup moves or a Wallbreaker role, Pokemon will now still get Heavy-Duty Boots if the team has hazard removal. No more Air Balloon Coalossal, for instance.
-Ting-Lu: +Tera Poison
-Persian: +Bite; Bite and Foul Play will not generate together.
