### PR TITLE
Fix Mycelium Might and Quick Claw interaction

### DIFF
--- a/data/items.ts
+++ b/data/items.ts
@@ -4518,7 +4518,8 @@ export const Items: {[itemid: string]: ItemData} = {
 	},
 	quickclaw: {
 		onFractionalPriorityPriority: -2,
-		onFractionalPriority(priority, pokemon) {
+		onFractionalPriority(priority, pokemon, target, move) {
+			if (move.status && pokemon.hasAbility("myceliummight")) return;
 			if (priority <= 0 && this.randomChance(1, 5)) {
 				this.add('-activate', pokemon, 'item: Quick Claw');
 				return 0.1;

--- a/data/items.ts
+++ b/data/items.ts
@@ -4519,7 +4519,7 @@ export const Items: {[itemid: string]: ItemData} = {
 	quickclaw: {
 		onFractionalPriorityPriority: -2,
 		onFractionalPriority(priority, pokemon, target, move) {
-			if (move.status && pokemon.hasAbility("myceliummight")) return;
+			if (move.category === "Status" && pokemon.hasAbility("myceliummight")) return;
 			if (priority <= 0 && this.randomChance(1, 5)) {
 				this.add('-activate', pokemon, 'item: Quick Claw');
 				return 0.1;

--- a/test/sim/abilities/myceliummight.js
+++ b/test/sim/abilities/myceliummight.js
@@ -19,7 +19,7 @@ describe("Mycelium Might", function () {
 		battle.makeChoices();
 		assert.false.fullHP(battle.p2.active[0]);
 	});
-	it.only("should never trigger your own quick claw if using a status move", function () {
+	it("should never trigger your own quick claw if using a status move", function () {
 		battle = common.createBattle({forceRandomChance: true}, [[
 			{species: "Bonsly", ability: 'myceliummight', item: 'quickclaw', moves: ['spore']},
 		], [
@@ -28,7 +28,7 @@ describe("Mycelium Might", function () {
 		battle.makeChoices();
 		assert.false.fullHP(battle.p1.active[0]);
 	});
-	it.only("should be able to trigger your own quick claw if using a non-status move", function () {
+	it("should be able to trigger your own quick claw if using a non-status move", function () {
 		battle = common.createBattle({forceRandomChance: true}, [[
 			{species: "Bonsly", ability: 'myceliummight', item: 'quickclaw', moves: ['tackle']},
 		], [

--- a/test/sim/abilities/myceliummight.js
+++ b/test/sim/abilities/myceliummight.js
@@ -19,4 +19,22 @@ describe("Mycelium Might", function () {
 		battle.makeChoices();
 		assert.false.fullHP(battle.p2.active[0]);
 	});
+	it("should never trigger your own quick claw if using a status move", function () {
+		battle = common.createBattle({seed: [3, 1, 1, 1]}, [[
+			{species: "Bonsly", ability: 'myceliummight', item: 'quickclaw', moves: ['spore']},
+		], [
+			{species: "Regieleki", moves: ['falseswipe']},
+		]]);
+		battle.makeChoices();
+		assert.false.fullHP(battle.p1.active[0]);
+	});
+	it("should be able to trigger your own quick claw if using a non-status move", function () {
+		battle = common.createBattle({seed: [3, 1, 1, 1]}, [[
+			{species: "Bonsly", ability: 'myceliummight', item: 'quickclaw', moves: ['tackle']},
+		], [
+			{species: "Regieleki", moves: ['spore']},
+		]]);
+		battle.makeChoices();
+		assert.false.fullHP(battle.p2.active[0]);
+	});
 });

--- a/test/sim/abilities/myceliummight.js
+++ b/test/sim/abilities/myceliummight.js
@@ -19,8 +19,8 @@ describe("Mycelium Might", function () {
 		battle.makeChoices();
 		assert.false.fullHP(battle.p2.active[0]);
 	});
-	it("should never trigger your own quick claw if using a status move", function () {
-		battle = common.createBattle({seed: [3, 1, 1, 1]}, [[
+	it.only("should never trigger your own quick claw if using a status move", function () {
+		battle = common.createBattle({forceRandomChance: true}, [[
 			{species: "Bonsly", ability: 'myceliummight', item: 'quickclaw', moves: ['spore']},
 		], [
 			{species: "Regieleki", moves: ['falseswipe']},
@@ -28,8 +28,8 @@ describe("Mycelium Might", function () {
 		battle.makeChoices();
 		assert.false.fullHP(battle.p1.active[0]);
 	});
-	it("should be able to trigger your own quick claw if using a non-status move", function () {
-		battle = common.createBattle({seed: [3, 1, 1, 1]}, [[
+	it.only("should be able to trigger your own quick claw if using a non-status move", function () {
+		battle = common.createBattle({forceRandomChance: true}, [[
 			{species: "Bonsly", ability: 'myceliummight', item: 'quickclaw', moves: ['tackle']},
 		], [
 			{species: "Regieleki", moves: ['spore']},


### PR DESCRIPTION
Quick claw can no longer boost status moves that had lower priority because of mycelium might.

https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/page-108#post-9509334

Added some tests too with a fixed seed