### PR TITLE
Gens 1-4: fix bug where Transform users' stats get permanently altered

### DIFF
--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1205,7 +1205,6 @@ export class Pokemon {
 			if (this.modifiedStats) this.modifiedStats[statName] = pokemon.modifiedStats![statName]; // Gen 1: Copy modified stats.
 		}
 		this.moveSlots = [];
-		this.set.ivs = (this.battle.gen >= 5 ? this.set.ivs : pokemon.set.ivs);
 		this.hpType = (this.battle.gen >= 5 ? this.hpType : pokemon.hpType);
 		this.hpPower = (this.battle.gen >= 5 ? this.hpPower : pokemon.hpPower);
 		this.timesAttacked = pokemon.timesAttacked;


### PR DESCRIPTION
This fixes a bug in gens 1-4. If Pokemon 1 Transformed into another Pokemon with different IVs, switches out, and switches back in, it would incorrectly calculate its stats based on the second Pokemon's IVs, rather than its own IVs.

The intention of copying IVs is for Hidden Power typing and power, but those are copied separately already.

This fixes the issue raised here: https://github.com/smogon/pokemon-showdown/issues/9531