### PR TITLE
Random Battles updates

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -968,9 +968,9 @@
         "level": 87,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Lava Plume", "Rapid Spin", "Solar Beam", "Stealth Rock", "Yawn"],
-                "teraTypes": ["Dragon", "Fire"]
+                "teraTypes": ["Dragon", "Grass"]
             }
         ]
     },
@@ -1140,7 +1140,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Brave Bird", "Close Combat", "Double-Edge", "Quick Attack", "U-turn"],
-                "teraTypes": ["Fighting"]
+                "teraTypes": ["Fighting", "Flying"]
             }
         ]
     },
@@ -1280,7 +1280,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Dark Pulse", "Rest", "Sleep Talk"],
-                "teraTypes": ["Dark", "Steel"]
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -1696,11 +1696,6 @@
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Cosmic Power", "Recover", "Stored Power"],
                 "teraTypes": ["Steel", "Psychic"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["Calm Mind", "Judgment", "Recover", "Shadow Ball"],
-                "teraTypes": ["Steel", "Ghost"]
             }
         ]
     },
@@ -2003,7 +1998,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Coil", "Drain Punch", "Fire Punch", "Liquidation", "Wild Charge"],
-                "teraTypes": ["Electric", "Fighting"]
+                "teraTypes": ["Fighting"]
             },
             {
                 "role": "AV Pivot",
@@ -2347,7 +2342,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Draco Meteor", "Dragon Tail", "Earthquake", "Fire Blast", "Power Whip", "Sludge Bomb", "Thunderbolt"],
+                "movepool": ["Draco Meteor", "Earthquake", "Fire Blast", "Power Whip", "Sludge Bomb", "Thunderbolt"],
                 "teraTypes": ["Dragon", "Ground", "Fire", "Grass", "Poison", "Electric"]
             }
         ]
@@ -2928,7 +2923,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Discharge", "Hydro Pump", "Spikes", "Sucker Punch", "Toxic Spikes"],
-                "teraTypes": ["Electric", "Water"]
+                "teraTypes": ["Ghost", "Water"]
             }
         ]
     },
@@ -3267,13 +3262,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Flame Charge", "Roar", "Shadow Ball", "Slack Off", "Torch Song"],
-                "teraTypes": ["Ghost", "Water", "Fairy"]
+                "movepool": ["Flame Charge", "Shadow Ball", "Slack Off", "Torch Song"],
+                "teraTypes": ["Fire", "Water"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Hex", "Slack Off", "Torch Song", "Will-O-Wisp"],
-                "teraTypes": ["Ghost", "Water", "Fairy"]
+                "teraTypes": ["Ghost", "Water"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1590,7 +1590,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Dragon Tail", "Rest", "Shadow Ball", "Sleep Talk", "Will-O-Wisp"],
-                "teraTypes": ["Ghost"]
+                "teraTypes": ["Ghost", "Fairy"]
             },
             {
                 "role": "Bulky Setup",

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1595,7 +1595,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Dragon Pulse", "Rest", "Sleep Talk"],
-                "teraTypes": ["Dragon"]
+                "teraTypes": ["Dragon", "Fairy"]
             }
         ]
     },

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1637,7 +1637,7 @@ export class RandomTeams {
 			}
 			if (set.moves.includes('stealthrock') || set.moves.includes('stoneaxe')) teamDetails.stealthRock = 1;
 			if (set.moves.includes('stickyweb')) teamDetails.stickyWeb = 1;
-			if (set.moves.includes('defog') || set.moves.includes('tidyup')) teamDetails.defog = 1;
+			if (set.moves.includes('defog')) teamDetails.defog = 1;
 			if (set.moves.includes('rapidspin') || set.moves.includes('mortalspin')) teamDetails.rapidSpin = 1;
 			if (set.moves.includes('auroraveil') || (set.moves.includes('reflect') && set.moves.includes('lightscreen'))) {
 				teamDetails.screens = 1;


### PR DESCRIPTION
Changes pending council review; ready to merge Sunday.

-Dragon Tail was removed from Goodra because statistical analysis showed that it was made worse.
-Calm Mind Arceus-Fighting was removed because statistical analysis showed that it was made worse.
-Staraptor no longer always has Close Combat, and it can now run Tera Flying, because statistical analysis showed that forcing Tera Fighting made Staraptor worse.
-Skeledirge's recent changes were reverted because statistical analysis showed it was made worse.

-Torkoal: -Tera Fire, +Tera Grass; Its role is now Bulky Attacker. This forces Solarbeam with Tera Grass, but it prevents Lava Plume + Rapid Spin + Stealth Rock + Yawn Torkoal from existing.
-Coil Eelektross: -Tera Electric; it now always has Drain Punch.
-CM Spiritomb: -Tera Dark
-Pincurchin: -Tera Electric, +Tera Ghost
-Giratina: +Tera Fairy

-Tidy Up Maushold will no longer prevent other hazard removers from generating.