### PR TITLE
`/requestshow`: Fix comments

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2517,7 +2517,7 @@ export const commands: Chat.ChatCommands = {
 		if (!room.settings.requestShowEnabled) {
 			return this.errorReply(`Media approvals are disabled in this room.`);
 		}
-		if (this.checkCan('show', null, room)) return this.errorReply(`Use !show instead.`);
+		if (user.can('showmedia', null, room, '/show')) return this.errorReply(`Use !show instead.`);
 		if (room.pendingApprovals?.has(user.id)) return this.errorReply('You have a request pending already.');
 		if (!toID(target)) return this.parse(`/help requestshow`);
 

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2517,7 +2517,7 @@ export const commands: Chat.ChatCommands = {
 		if (!room.settings.requestShowEnabled) {
 			return this.errorReply(`Media approvals are disabled in this room.`);
 		}
-		if (user.can('showmedia', null, room, '/show')) return this.errorReply(`Use !show instead.`);
+		if (this.checkCan('show', null, room)) return this.errorReply(`Use !show instead.`);
 		if (room.pendingApprovals?.has(user.id)) return this.errorReply('You have a request pending already.');
 		if (!toID(target)) return this.parse(`/help requestshow`);
 
@@ -2535,7 +2535,7 @@ export const commands: Chat.ChatCommands = {
 				throw new Chat.ErrorMessage('Invalid link.');
 			}
 		}
-		if (comment && this.checkChat(comment) !== comment) {
+		if (comment && this.checkChat(comment) !== comment.trim()) {
 			return this.errorReply(`You cannot use filtered words in comments.`);
 		}
 		if (!room.pendingApprovals) room.pendingApprovals = new Map();


### PR DESCRIPTION
### Fix permissions

At first, `user.can('showmedia', null, room, '/show')` return the user has a rank which voice or higher. if `!show` disallowed for some rank and the rank was voice and higher, they could not use  both of `!show` and `/requestshow`.
By using `Chat.checkCan('show', null, room)`, we could solve this problem. if the user could not use `!show`, they could use `/requestshow`.

### Fix comments
If the comment starts/ends with spaces, the comment was caught by `Chat.checkChat()`. Solved this by triming spaces.