### PR TITLE
/requestshow: Allow using comma in comments

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2521,7 +2521,8 @@ export const commands: Chat.ChatCommands = {
 		if (room.pendingApprovals?.has(user.id)) return this.errorReply('You have a request pending already.');
 		if (!toID(target)) return this.parse(`/help requestshow`);
 
-		let [link, comment] = target.split(',');
+		let [link, ...comments] = target.split(',');
+		const comment = comments.join(',').trim();
 		if (!/^https?:\/\//.test(link)) link = `https://${link}`;
 		link = encodeURI(link);
 		let dimensions;
@@ -2535,7 +2536,7 @@ export const commands: Chat.ChatCommands = {
 				throw new Chat.ErrorMessage('Invalid link.');
 			}
 		}
-		if (comment && this.checkChat(comment) !== comment.trim()) {
+		if (comment && this.checkChat(comment) !== comment) {
 			return this.errorReply(`You cannot use filtered words in comments.`);
 		}
 		if (!room.pendingApprovals) room.pendingApprovals = new Map();

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2521,8 +2521,7 @@ export const commands: Chat.ChatCommands = {
 		if (room.pendingApprovals?.has(user.id)) return this.errorReply('You have a request pending already.');
 		if (!toID(target)) return this.parse(`/help requestshow`);
 
-		let [link, ...comments] = target.split(',');
-		const comment = comments.join(',').trim();
+		let [link, comment] = this.splitOne(target);
 		if (!/^https?:\/\//.test(link)) link = `https://${link}`;
 		link = encodeURI(link);
 		let dimensions;


### PR DESCRIPTION
`[link, comment]` ignores latter comments splited by comma if the comment includes. Use `[link, ...comments]` to allow it.
Also fix #9541, comment should be trimed and stored to variable, not just checking