### PR TITLE
WIP: Tournaments: Add support for swiss-style tournaments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "edmonds-blossom": "^1.0.0",
         "esbuild": "^0.16.10",
         "preact": "^10.5.15",
         "preact-render-to-string": "^5.1.19",
@@ -1095,6 +1096,11 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
+    },
+    "node_modules/edmonds-blossom": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/edmonds-blossom/-/edmonds-blossom-1.0.0.tgz",
+      "integrity": "sha512-wz18RgLg21nW4afc80d080fZuAjiaePfSoHje56aOiH8mO6O5Mc/VAv7s8bCBJkxsks37e0cYTS0dNirsQ4/rg=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.11.9",
   "main": "dist/sim/index.js",
   "dependencies": {
+    "edmonds-blossom": "^1.0.0",
     "esbuild": "^0.16.10",
     "preact": "^10.5.15",
     "preact-render-to-string": "^5.1.19",

--- a/server/tournaments/generator-round-robin.ts
+++ b/server/tournaments/generator-round-robin.ts
@@ -7,6 +7,10 @@ interface Match {
 import {Utils} from '../../lib/utils';
 import type {TournamentPlayer} from './index';
 
+function usersToNames(users: TournamentPlayer[]) {
+	return users.map(user => user.name);
+}
+
 export class RoundRobin {
 	readonly name: string;
 	readonly isDrawingSupported: boolean;
@@ -35,8 +39,8 @@ export class RoundRobin {
 		return {
 			type: 'table',
 			tableHeaders: {
-				cols: players.slice(0),
-				rows: players.slice(0),
+				cols: usersToNames(players.slice(0)),
+				rows: usersToNames(players.slice(0)),
 			},
 			tableContents: players.map(
 				(p1, row) => players.map((p2, col) => {
@@ -45,6 +49,7 @@ export class RoundRobin {
 
 					return {
 						state: 'unavailable',
+						type: 'matchCell',
 					};
 				})
 			),
@@ -56,8 +61,8 @@ export class RoundRobin {
 		return {
 			type: 'table',
 			tableHeaders: {
-				cols: players.slice(0),
-				rows: players.slice(0),
+				cols: usersToNames(players.slice(0)),
+				rows: usersToNames(players.slice(0)),
 			},
 			tableContents: players.map(
 				(p1, row) => players.map((p2, col) => {
@@ -68,6 +73,7 @@ export class RoundRobin {
 
 					const cell: any = {
 						state: match.state,
+						type: 'matchCell',
 					};
 					if (match.state === 'finished' && match.score) {
 						cell.result = match.result;

--- a/server/tournaments/generator-round-robin.ts
+++ b/server/tournaments/generator-round-robin.ts
@@ -6,10 +6,7 @@ interface Match {
 
 import {Utils} from '../../lib/utils';
 import type {TournamentPlayer} from './index';
-
-function usersToNames(users: TournamentPlayer[]) {
-	return users.map(user => user.name);
-}
+import {usersToNames} from './index';
 
 export class RoundRobin {
 	readonly name: string;
@@ -53,7 +50,6 @@ export class RoundRobin {
 					};
 				})
 			),
-			scores: players.map(player => 0),
 		};
 	}
 	getBracketData() {

--- a/server/tournaments/generator-round-robin.ts
+++ b/server/tournaments/generator-round-robin.ts
@@ -5,8 +5,7 @@ interface Match {
 }
 
 import {Utils} from '../../lib/utils';
-import type {TournamentPlayer} from './index';
-import {usersToNames} from './index';
+import {TournamentPlayer, usersToNames} from './index';
 
 export class RoundRobin {
 	readonly name: string;
@@ -50,6 +49,7 @@ export class RoundRobin {
 					};
 				})
 			),
+			scores: players.map(player => 0),
 		};
 	}
 	getBracketData() {

--- a/server/tournaments/generator-swiss.ts
+++ b/server/tournaments/generator-swiss.ts
@@ -110,7 +110,9 @@ export class Swiss {
 
 	getAvailableMatches() {
 		if (!this.isBracketFrozen) return 'BracketNotFrozen';
-		const matches = this.matches.filter(match => !match.p1.tournamentPlayer.isBusy && !match.p2?.tournamentPlayer.isBusy).flatMap(match => match.p2 ? [[match.p1.tournamentPlayer, match.p2.tournamentPlayer]] : []);
+		const matches = this.matches
+			.filter(match => !match.p1.tournamentPlayer.isBusy && !match.p2?.tournamentPlayer.isBusy)
+			.flatMap(match => match.p2 ? [[match.p1.tournamentPlayer, match.p2.tournamentPlayer]] : []);
 		return matches;
 	}
 

--- a/server/tournaments/generator-swiss.ts
+++ b/server/tournaments/generator-swiss.ts
@@ -184,8 +184,6 @@ export class Swiss {
 				rows: rowHeaders,
 			},
 			tableContents: swissData,
-			// TODO(delete this)
-			scores: this.players.map(player => 0),
 		};
 	}
 

--- a/server/tournaments/generator-swiss.ts
+++ b/server/tournaments/generator-swiss.ts
@@ -236,8 +236,8 @@ export class Swiss {
 			if (index1 > index2) {
 				continue;
 			}
-			const swissPlayer1 = this.players[index1];
-			const swissPlayer2 = this.players[index2];
+			const swissPlayer1 = nonDQedPlayers[index1];
+			const swissPlayer2 = nonDQedPlayers[index2];
 			this.matches.push({
 				p1: this.players[index1],
 				p2: this.players[index2],

--- a/server/tournaments/generator-swiss.ts
+++ b/server/tournaments/generator-swiss.ts
@@ -1,0 +1,271 @@
+const blossom = require('edmonds-blossom');
+
+function createNameCell(name: string) {
+	return {
+		name: name,
+		type: "nameCell",
+	};
+}
+const winPoints = 1;
+
+import {Utils} from '../../lib/utils';
+import {TournamentPlayer} from './index';
+
+class SwissPlayer {
+	tournamentPlayer: TournamentPlayer;
+	playersAlreadyPlayed: SwissPlayer[];
+	byesReceived: number;
+	constructor(player: TournamentPlayer) {
+		this.tournamentPlayer = player;
+		this.playersAlreadyPlayed = [];
+		this.byesReceived = 0;
+	}
+}
+
+interface Match {
+	p1: SwissPlayer;
+	p2: SwissPlayer | null;
+	state: string;
+	score?: number[];
+	result?: string;
+	isByeMatch: boolean;
+}
+
+export class Swiss {
+	readonly isDrawingSupported: boolean;
+	readonly name: string;
+	rounds: number;
+	curRound: number;
+	players: SwissPlayer[];
+	matches: Match[];
+	isBracketFrozen: boolean;
+	totalPendingMatches: number;
+	byePlayers: number[];
+	constructor(numRounds: string) {
+		this.isDrawingSupported = true;
+		this.players = [];
+		this.matches = [];
+		const intNumRounds = Utils.parseExactInt(numRounds);
+		this.rounds = intNumRounds ? intNumRounds : 5;
+		this.name = this.rounds + "-Round Swiss";
+		this.rounds = 5;
+		this.curRound = 0;
+		this.isBracketFrozen = false;
+		this.totalPendingMatches = 0;
+		this.byePlayers = [];
+	}
+
+	setMatchResult([p1, p2]: [TournamentPlayer, TournamentPlayer], result: string, score: number[]) {
+		if (!this.isBracketFrozen) return 'BracketNotFrozen';
+		if (!['win', 'loss', 'draw'].includes(result)) return 'InvalidMatchResult';
+
+		const curMatch = this.matches.find(match =>
+			match.p2 &&
+			((match.p1.tournamentPlayer === p1 && match.p2.tournamentPlayer === p2) ||
+			(match.p1.tournamentPlayer === p2 && match.p2.tournamentPlayer === p1)));
+		if (curMatch === undefined) return 'InvalidMatch';
+		curMatch.state = 'finished';
+		curMatch.result = result;
+		curMatch.score = score.slice(0);
+		this.totalPendingMatches--;
+		if (this.totalPendingMatches === 0 && this.curRound < this.rounds) {
+			this.generateNextRoundPairings();
+		}
+	}
+
+	getSwissPlayer(tournamentPlayer: TournamentPlayer) {
+		return this.players.find(player => player.tournamentPlayer === tournamentPlayer);
+	}
+
+	isTournamentEnded() {
+		return this.players.filter(player => !player.tournamentPlayer.isDisqualified).length < 2 ||
+		(this.curRound === this.rounds && this.totalPendingMatches === 0);
+	}
+
+	disqualifyUser(user: TournamentPlayer) {
+		if (!this.isBracketFrozen) return 'BracketNotFrozen';
+
+		const player = this.getSwissPlayer(user);
+
+		const match = this.matches.find(innerMatch => innerMatch.p1 === player || innerMatch.p2 === player);
+		if (!match) return 'InvalidUser';
+		if (match.state !== 'finished' && match.p2) {
+			match.state = 'finished';
+			if (match.p1.tournamentPlayer === user) {
+				match.result = 'loss';
+				match.score = [0, 1];
+				match.p2.tournamentPlayer.score += 1;
+			} else {
+				match.result = 'win';
+				match.score = [1, 0];
+				match.p1.tournamentPlayer.score += 1;
+			}
+			this.totalPendingMatches--;
+		}
+
+		user.unlinkUser();
+		if (this.totalPendingMatches === 0 && this.curRound < this.rounds) {
+			this.generateNextRoundPairings();
+		}
+	}
+
+	getAvailableMatches() {
+		if (!this.isBracketFrozen) return 'BracketNotFrozen';
+		const matches = this.matches.flatMap(match => match.p2 ? [[match.p1.tournamentPlayer, match.p2.tournamentPlayer]] : []);
+		return matches;
+	}
+
+	getPendingBracketData(players: TournamentPlayer[]) {
+		return this.getPlayerListWithScores(players);
+	}
+
+	getPlayerListWithScores(players: TournamentPlayer[]) {
+		const playerNames = players.map(player => [createNameCell(player.name)]);
+		return {
+			type: 'table',
+			tableHeaders: {
+				cols: ["Players"],
+				rows: players.map((player, row) => row + 1),
+			},
+			tableContents: playerNames,
+			scores: players.map(player => player.score),
+		};
+	}
+
+	getResults() {
+		// TODO: Add tiebreak calculation
+		if (!this.isTournamentEnded()) return 'TournamentNotEnded';
+		const sortedScores = Utils.sortBy([...this.players], p => -p.tournamentPlayer.score);
+		const results: TournamentPlayer[][] = [];
+		for (const player of sortedScores) {
+			results.push([player.tournamentPlayer]);
+		}
+		return results;
+	}
+
+	getBracketData() {
+		if (this.isTournamentEnded()) {
+			return this.getPlayerListWithScores(this.players.map(player => player.tournamentPlayer));
+		}
+		const swissData = [];
+		const rowHeaders = [];
+		for (let i = 0; i < this.matches.length; i++) {
+			const match = this.matches[i];
+			const row = [];
+			row.push(createNameCell(match.p1.tournamentPlayer.name));
+			row.push(createNameCell(match.p1.tournamentPlayer.score.toString()));
+			if (match.p2) {
+				row.push(createNameCell(match.p2.tournamentPlayer.name));
+				row.push(createNameCell(match.p2.tournamentPlayer.score.toString()));
+			} else {
+				row.push(createNameCell("Bye"));
+				row.push(createNameCell(""));
+			}
+
+			const cell: any = {
+				state: match.state,
+				type: 'matchCell',
+			};
+			if (match.state === 'finished' && match.score) {
+				cell.result = match.result;
+				cell.score = match.score.slice(0);
+			}
+			row.push(cell);
+			swissData.push(row);
+			rowHeaders.push("Match " + (i + 1).toString());
+		}
+
+		return {
+			type: 'table',
+			tableHeaders: {
+				cols: ["Player 1", "Score", "Player 2", "Score", "Status"],
+				rows: rowHeaders,
+			},
+			tableContents: swissData,
+		};
+	}
+
+	freezeBracket(players: TournamentPlayer[]) {
+		this.isBracketFrozen = true;
+		this.players = players.map(player => new SwissPlayer(player));
+		this.generateNextRoundPairings();
+	}
+
+	generateNextRoundPairings() {
+		let byePlayer = null;
+		const nonDQedPlayers = this.players.filter(player => !player.tournamentPlayer.isDisqualified);
+		if (nonDQedPlayers.length % 2 === 1) {
+			// Give a bye to the lowest-ranked player that has not received a bye yet.
+			// If there are multiple, choose one at random.
+			const minByes = Math.min(...nonDQedPlayers.map(player => player.byesReceived));
+			const playersWithMinByes = nonDQedPlayers.filter(player => player.byesReceived === minByes);
+			const minScoreAmongstPlayersWithMinByes = Math.min(...playersWithMinByes.map(player => player.tournamentPlayer.score));
+			const playersWithMinScore = playersWithMinByes.filter(
+				player => player.tournamentPlayer.score === minScoreAmongstPlayersWithMinByes
+			);
+			byePlayer = Utils.shuffle(playersWithMinScore)[0];
+		}
+		this.matches = [];
+		const maxPossiblePoints = (this.curRound + 1) * winPoints;
+		const possiblePairs: number[][] = [];
+		for (let p1 = 0; p1 < this.players.length; p1++) {
+			const swissPlayer1 = this.players[p1];
+			if (swissPlayer1 === byePlayer || swissPlayer1.tournamentPlayer.isDisqualified) continue;
+			for (let p2 = 0; p2 < this.players.length; p2++) {
+				const swissPlayer2 = this.players[p2];
+				if (swissPlayer2 === byePlayer || swissPlayer2.tournamentPlayer.isDisqualified) continue;
+				if (p1 < p2) {
+					const match = [p1, p2];
+					if (swissPlayer1.playersAlreadyPlayed.includes(swissPlayer2)) {
+						match.push(0);
+					} else {
+						// We want a higher value for players with the same score so that blossom functions properly
+						match.push(maxPossiblePoints - Math.abs(swissPlayer1.tournamentPlayer.score - swissPlayer2.tournamentPlayer.score));
+					}
+					possiblePairs.push(match);
+				}
+			}
+		}
+
+		const rawPairings = blossom(possiblePairs);
+		for (let index1 = 0; index1 < rawPairings.length; index1++) {
+			const index2 = rawPairings[index1];
+			if (index1 > index2) {
+				continue;
+			}
+			const swissPlayer1 = this.players[index1];
+			const swissPlayer2 = this.players[index2];
+			this.matches.push({
+				p1: this.players[index1],
+				p2: this.players[index2],
+				state: 'available',
+				isByeMatch: false,
+			});
+			swissPlayer1.playersAlreadyPlayed.push(swissPlayer2);
+			swissPlayer2.playersAlreadyPlayed.push(swissPlayer1);
+		}
+
+		this.matches.sort((a, b) => this.getPlayerScore(b) - this.getPlayerScore(a));
+		this.totalPendingMatches = this.matches.length;
+		// The bye match should always go on the bottom
+		if (byePlayer) {
+			this.matches.push({
+				p1: byePlayer,
+				p2: null,
+				state: 'finished',
+				isByeMatch: true,
+				score: [1, 0],
+			});
+			byePlayer.tournamentPlayer.score += 1;
+		}
+		this.curRound++;
+	}
+
+	getPlayerScore(match: Match) {
+		if (match.p2) {
+			return match.p1.tournamentPlayer.score + match.p2.tournamentPlayer.score;
+		} else {
+			return match.p1.tournamentPlayer.score;
+		}
+	}
+}

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -385,10 +385,10 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 	}
 
 	addUser(user: User, output: Chat.CommandContext) {
-		/*if (!user.named) {
+		if (!user.named) {
 			output.sendReply('|tournament|error|UserNotNamed');
 			return;
-		}*/
+		}
 
 		if (user.id in this.playerTable) {
 			output.sendReply('|tournament|error|UserAlreadyAdded');
@@ -1106,63 +1106,6 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 				return "Scouting is banned: tournament players can't watch other tournament battles.";
 			}
 		}
-	}
-
-	devBattleWin(winnerid: ID, loserid: ID) {
-		const p1 = this.playerTable[winnerid];
-		const p2 = this.playerTable[loserid];
-		const winner = this.playerTable[winnerid];
-		const score = [1, 0];
-
-		let result: 'win' | 'loss' | 'draw' = 'draw';
-		if (p1 === winner) {
-			p1.score += 1;
-			p1.wins += 1;
-			p2.losses += 1;
-			result = 'win';
-		} else if (p2 === winner) {
-			p2.score += 1;
-			p2.wins += 1;
-			p1.losses += 1;
-			result = 'loss';
-		}
-
-		p1.isBusy = false;
-		p2.isBusy = false;
-		p1.inProgressMatch = null;
-
-		this.isBracketInvalidated = true;
-		this.isAvailableMatchesInvalidated = true;
-
-		if (result === 'draw' && !this.generator.isDrawingSupported) {
-			//this.room.add(`|tournament|battleend|${p1.name}|${p2.name}|${result}|${score.join(',')}|fail|${room.roomid}`);
-
-			if (this.autoDisqualifyTimeout !== Infinity) this.runAutoDisqualify();
-			this.update();
-			return this.room.update();
-		}
-		if (result === 'draw') {
-			p1.score += 0.5;
-			p2.score += 0.5;
-		}
-		p1.games += 1;
-		p2.games += 1;
-		if (!(p1.isDisqualified || p2.isDisqualified)) {
-			// If a player was disqualified, handle the results there
-			const error = this.generator.setMatchResult([p1, p2], result as 'win' | 'loss', score);
-			if (error) {
-				// Should never happen
-				return this.room.add(`Unexpected ${error} from setMatchResult([${winnerid}, ${loserid}], ${result}, ${score}) in devBattleWin(${winnerid}, ${loserid}). Please report this to an admin.`).update();
-			}
-		}
-
-		if (this.generator.isTournamentEnded()) {
-			this.onTournamentEnd();
-		} else {
-			if (this.autoDisqualifyTimeout !== Infinity) this.runAutoDisqualify();
-			this.update();
-		}
-		this.room.update();
 	}
 	onBattleWin(room: GameRoom, winnerid: ID) {
 		if (this.completedMatches.has(room.roomid)) return;

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -604,6 +604,7 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 					if (pendingChallenge || inProgressMatch) {
 						for (const [c, cell] of row.entries()) {
 							if (!cell || cell.namedCell) continue;
+
 							if (pendingChallenge && data.tableHeaders.cols[c] === pendingChallenge.to) {
 								cell.state = 'challenging';
 							}

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -43,7 +43,7 @@ const TournamentGenerators = {
 	swiss: Swiss,
 };
 
-function usersToNames(users: TournamentPlayer[]) {
+export function usersToNames(users: TournamentPlayer[]) {
 	return users.map(user => user.name);
 }
 
@@ -385,10 +385,10 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 	}
 
 	addUser(user: User, output: Chat.CommandContext) {
-		if (!user.named) {
+		/*if (!user.named) {
 			output.sendReply('|tournament|error|UserNotNamed');
 			return;
-		}
+		}*/
 
 		if (user.id in this.playerTable) {
 			output.sendReply('|tournament|error|UserAlreadyAdded');
@@ -1107,7 +1107,7 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 			}
 		}
 	}
-	/*
+
 	devBattleWin(winnerid: ID, loserid: ID) {
 		const p1 = this.playerTable[winnerid];
 		const p2 = this.playerTable[loserid];
@@ -1135,7 +1135,7 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 		this.isAvailableMatchesInvalidated = true;
 
 		if (result === 'draw' && !this.generator.isDrawingSupported) {
-			this.room.add(`|tournament|battleend|${p1.name}|${p2.name}|${result}|${score.join(',')}|fail|${room.roomid}`);
+			//this.room.add(`|tournament|battleend|${p1.name}|${p2.name}|${result}|${score.join(',')}|fail|${room.roomid}`);
 
 			if (this.autoDisqualifyTimeout !== Infinity) this.runAutoDisqualify();
 			this.update();
@@ -1163,7 +1163,7 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 			this.update();
 		}
 		this.room.update();
-	}*/
+	}
 	onBattleWin(room: GameRoom, winnerid: ID) {
 		if (this.completedMatches.has(room.roomid)) return;
 		this.completedMatches.add(room.roomid);

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -1,6 +1,7 @@
 
 import {Elimination} from './generator-elimination';
 import {RoundRobin} from './generator-round-robin';
+import {Swiss} from './generator-swiss';
 import {Utils} from '../../lib';
 import {SampleTeams, teamData} from '../chat-plugins/sample-teams';
 import {PRNG} from '../../sim/prng';
@@ -20,7 +21,7 @@ export interface TournamentRoomSettings {
 	blockRecents?: boolean;
 }
 
-type Generator = RoundRobin | Elimination;
+type Generator = RoundRobin | Elimination | Swiss;
 
 const BRACKET_MINIMUM_UPDATE_INTERVAL = 2 * 1000;
 const AUTO_DISQUALIFY_WARNING_TIMEOUT = 30 * 1000;
@@ -39,6 +40,7 @@ const TournamentGenerators = {
 	__proto__: null,
 	roundrobin: RoundRobin,
 	elimination: Elimination,
+	swiss: Swiss,
 };
 
 function usersToNames(users: TournamentPlayer[]) {
@@ -601,8 +603,7 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 					const inProgressMatch = data.tableHeaders.rows[r].inProgressMatch;
 					if (pendingChallenge || inProgressMatch) {
 						for (const [c, cell] of row.entries()) {
-							if (!cell) continue;
-
+							if (!cell || cell.namedCell) continue;
 							if (pendingChallenge && data.tableHeaders.cols[c] === pendingChallenge.to) {
 								cell.state = 'challenging';
 							}
@@ -615,8 +616,6 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 					}
 				}
 			}
-			data.tableHeaders.cols = usersToNames(data.tableHeaders.cols);
-			data.tableHeaders.rows = usersToNames(data.tableHeaders.rows);
 		}
 		return data;
 	}
@@ -1108,6 +1107,63 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 			}
 		}
 	}
+	/*
+	devBattleWin(winnerid: ID, loserid: ID) {
+		const p1 = this.playerTable[winnerid];
+		const p2 = this.playerTable[loserid];
+		const winner = this.playerTable[winnerid];
+		const score = [1, 0];
+
+		let result: 'win' | 'loss' | 'draw' = 'draw';
+		if (p1 === winner) {
+			p1.score += 1;
+			p1.wins += 1;
+			p2.losses += 1;
+			result = 'win';
+		} else if (p2 === winner) {
+			p2.score += 1;
+			p2.wins += 1;
+			p1.losses += 1;
+			result = 'loss';
+		}
+
+		p1.isBusy = false;
+		p2.isBusy = false;
+		p1.inProgressMatch = null;
+
+		this.isBracketInvalidated = true;
+		this.isAvailableMatchesInvalidated = true;
+
+		if (result === 'draw' && !this.generator.isDrawingSupported) {
+			this.room.add(`|tournament|battleend|${p1.name}|${p2.name}|${result}|${score.join(',')}|fail|${room.roomid}`);
+
+			if (this.autoDisqualifyTimeout !== Infinity) this.runAutoDisqualify();
+			this.update();
+			return this.room.update();
+		}
+		if (result === 'draw') {
+			p1.score += 0.5;
+			p2.score += 0.5;
+		}
+		p1.games += 1;
+		p2.games += 1;
+		if (!(p1.isDisqualified || p2.isDisqualified)) {
+			// If a player was disqualified, handle the results there
+			const error = this.generator.setMatchResult([p1, p2], result as 'win' | 'loss', score);
+			if (error) {
+				// Should never happen
+				return this.room.add(`Unexpected ${error} from setMatchResult([${winnerid}, ${loserid}], ${result}, ${score}) in devBattleWin(${winnerid}, ${loserid}). Please report this to an admin.`).update();
+			}
+		}
+
+		if (this.generator.isTournamentEnded()) {
+			this.onTournamentEnd();
+		} else {
+			if (this.autoDisqualifyTimeout !== Infinity) this.runAutoDisqualify();
+			this.update();
+		}
+		this.room.update();
+	}*/
 	onBattleWin(room: GameRoom, winnerid: ID) {
 		if (this.completedMatches.has(room.roomid)) return;
 		this.completedMatches.add(room.roomid);
@@ -1207,7 +1263,7 @@ function getGenerator(generator: string | undefined) {
 	case 'elim': generator = 'elimination'; break;
 	case 'rr': generator = 'roundrobin'; break;
 	}
-	return TournamentGenerators[generator as 'elimination' | 'roundrobin'];
+	return TournamentGenerators[generator as 'elimination' | 'roundrobin' | 'swiss'];
 }
 
 function createTournamentGenerator(

--- a/server/users.ts
+++ b/server/users.ts
@@ -276,7 +276,9 @@ export class Connection {
 	}
 
 	send(data: string) {
-		Sockets.socketSend(this.worker, this.socketid, data);
+		try {
+			Sockets.socketSend(this.worker, this.socketid, data);
+		} catch (e) {}
 		Monitor.countNetworkUse(data.length);
 	}
 

--- a/server/users.ts
+++ b/server/users.ts
@@ -276,9 +276,7 @@ export class Connection {
 	}
 
 	send(data: string) {
-		try {
-			Sockets.socketSend(this.worker, this.socketid, data);
-		} catch (e) {}
+		Sockets.socketSend(this.worker, this.socketid, data);
 		Monitor.countNetworkUse(data.length);
 	}
 


### PR DESCRIPTION
Add swiss-style tournaments as an option (instead of round robin or elimination). This was asked for a long time ago (https://github.com/smogon/pokemon-showdown/issues/2205) and is approved in the forum suggestions (https://www.smogon.com/forums/threads/add-swiss-as-a-valid-tour-format.3658511/#post-8328188). Am also planning on adding support for bo3 for all types of tours but that will happen after this. It's still a bit in-progress, but wanted to make sure the general idea was good before I do the more complicated stuff.

Algorithm: 
Does roughly what https://www.npmjs.com/package/swiss-pairing does (Edmonds Blossom algorithm). In practice, with 1000 entrants, takes a few seconds to pair (![image](https://user-images.githubusercontent.com/22896712/235388182-8f869fe5-9414-40c3-ac5a-096e041486dc.png)). Assuming this algorithm is okay, I plan on reimplementing Edmonds Blossom on our side (so the dependency this PR currently adds will not be there in the final version), but wanted to ensure it was okay first as it is a bit complicated. This should functionally do the same thing as normal Swiss pairings (pair within the same score group and avoid rematches), though the weighting procedure might need some adjustments.

Screenshots (all of these lists are scrollable):
Signups:
![image](https://user-images.githubusercontent.com/22896712/235387651-274f5225-f257-4586-9515-1ad7d145fd52.png)
In-Progress:
![image](https://user-images.githubusercontent.com/22896712/235387813-b52c1648-d76c-49ec-8661-40095b0ba637.png)
Finished:
![image](https://user-images.githubusercontent.com/22896712/235387857-4f08c7ae-3fe0-42fa-b139-1cd7fd023f3f.png)

Very minimal client-side changes at the moment since I'm not great at those.
