### PR TITLE
Support hotpatching formats without reloading processes

### DIFF
--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -742,7 +742,7 @@ export const commands: Chat.ChatCommands = {
 				// respawn validator processes
 				void TeamValidatorAsync.PM.respawn();
 				// respawn simulator processes
-				void Rooms.PM.respawn();
+				void Rooms.PM.messageAll('RELOAD');
 				// respawn datasearch processes (crashes otherwise, since the Dex data in the PM can be out of date)
 				void Chat.plugins.datasearch?.PM?.respawn();
 				// broadcast the new formats list to clients

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1387,6 +1387,10 @@ export const PM = new ProcessManager.StreamProcessManager(module, () => new Room
 	if (message.startsWith(`SLOW\n`)) {
 		Monitor.slow(message.slice(5));
 	}
+}, message => {
+	if (message.startsWith('RELOAD')) {
+		BattleStream.recache();
+	}
 });
 
 if (!PM.isParentProcess) {

--- a/sim/battle-stream.ts
+++ b/sim/battle-stream.ts
@@ -12,7 +12,6 @@
 import {Streams, Utils} from '../lib';
 import {Teams} from './teams';
 import {Battle, extractChannelMessages} from './battle';
-
 /**
  * Like string.split(delimiter), but only recognizes the first `limit`
  * delimiters (default 1).
@@ -55,6 +54,14 @@ export class BattleStream extends Streams.ObjectReadWriteStream<string> {
 		this.replay = options.replay || false;
 		this.keepAlive = !!options.keepAlive;
 		this.battle = null;
+	}
+
+	static Battle = Battle;
+	static recache() {
+		// force a recaching when require is next called
+		require.cache = {};
+		require('module')._cache = {};
+		this.Battle = require('./battle').Battle;
 	}
 
 	_write(chunk: string) {
@@ -106,7 +113,7 @@ export class BattleStream extends Streams.ObjectReadWriteStream<string> {
 				if (t === 'end' && !this.keepAlive) this.pushEnd();
 			};
 			if (this.debug) options.debug = true;
-			this.battle = new Battle(options);
+			this.battle = new BattleStream.Battle(options);
 			break;
 		case 'player':
 			const [slot, optionsText] = splitFirst(message, ' ');


### PR DESCRIPTION
Should make it a lot easier to hotpatch formats consecutively, without worrying about memory from extra processes lying around. 

This will require a restart.