### PR TITLE
Random Battles updates

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -609,7 +609,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Haze", "Poison Jab", "Recover", "Spikes", "Toxic", "Toxic Spikes"],
+                "movepool": ["Earthquake", "Haze", "Poison Jab", "Recover", "Stealth Rock", "Toxic", "Toxic Spikes"],
                 "teraTypes": ["Ground", "Flying", "Steel"]
             }
         ]
@@ -1039,7 +1039,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Liquidation", "Spikes", "Stealth Rock", "Stone Edge"],
+                "movepool": ["Earthquake", "Hydro Pump", "Ice Beam", "Spikes", "Stealth Rock"],
                 "teraTypes": ["Ground", "Steel"]
             },
             {
@@ -3943,7 +3943,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Close Combat", "Drain Punch", "Fake Out", "Heavy Slam", "Ice Punch", "Thunder Punch", "Volt Switch", "Wild Charge"],
-                "teraTypes": ["Electric"]
+                "teraTypes": ["Electric", "Fighting"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -510,7 +510,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Eruption", "Fire Blast", "Focus Blast", "Shadow Ball"],
-                "teraTypes": ["Fire", "Ghost"]
+                "teraTypes": ["Fire", "Fighting"]
             }
         ]
     },
@@ -2528,7 +2528,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Defog", "Hurricane", "Quiver Dance", "Revelation Dance", "Roost"],
-                "teraTypes": ["Ground"]
+                "teraTypes": ["Ground", "Fighting"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -190,7 +190,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Fire Punch", "Gunk Shot", "Haze", "Ice Punch", "Shadow Sneak", "Toxic", "Toxic Spikes"],
-                "teraTypes": ["Poison", "Dark"]
+                "teraTypes": ["Dragon", "Dark"]
             }
         ]
     },
@@ -405,7 +405,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Air Slash", "Freeze-Dry", "Haze", "Hurricane", "Roost", "Substitute", "U-turn"],
-                "teraTypes": ["Flying", "Steel", "Ground"]
+                "teraTypes": ["Steel", "Ground"]
             }
         ]
     },
@@ -738,8 +738,8 @@
                 "teraTypes": ["Steel"]
             },
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Bullet Punch", "Close Combat", "Pounce", "Swords Dance"],
+                "role": "Fast Attacker",
+                "movepool": ["Bullet Punch", "Close Combat", "Pounce", "Swords Dance", "U-turn"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1338,7 +1338,7 @@
         "level": 92,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Fast Support",
                 "movepool": ["Dazzling Gleam", "Encore", "Hydro Pump", "Ice Beam", "U-turn"],
                 "teraTypes": ["Water", "Fairy"]
             }
@@ -1588,7 +1588,7 @@
         "level": 75,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Fast Support",
                 "movepool": ["Dragon Tail", "Rest", "Shadow Ball", "Sleep Talk", "Will-O-Wisp"],
                 "teraTypes": ["Ghost", "Fairy"]
             },
@@ -1596,6 +1596,11 @@
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Dragon Pulse", "Rest", "Sleep Talk"],
                 "teraTypes": ["Dragon", "Fairy"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Defog", "Dragon Tail", "Rest", "Shadow Ball", "Will-O-Wisp"],
+                "teraTypes": ["Ghost", "Fairy"]
             }
         ]
     },
@@ -2277,8 +2282,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Draco Meteor", "Focus Blast", "Sludge Bomb", "Thunderbolt", "Toxic", "Toxic Spikes"],
-                "teraTypes": ["Dragon", "Electric", "Fighting"]
+                "movepool": ["Draco Meteor", "Focus Blast", "Hydro Pump", "Sludge Bomb", "Toxic", "Toxic Spikes"],
+                "teraTypes": ["Water", "Fighting"]
             }
         ]
     },
@@ -2387,7 +2392,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Avalanche", "Body Press", "Curse", "Recover", "Stone Edge"],
+                "movepool": ["Avalanche", "Body Press", "Rapid Spin", "Recover", "Stone Edge"],
                 "teraTypes": ["Poison", "Flying"]
             }
         ]
@@ -2422,7 +2427,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Focus Blast", "Nasty Plot", "Psyshock", "Shadow Ball", "Substitute", "Trick"],
+                "movepool": ["Focus Blast", "Nasty Plot", "Psyshock", "Shadow Ball", "Trick"],
                 "teraTypes": ["Psychic", "Ghost", "Fighting"]
             }
         ]
@@ -2562,7 +2567,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Accelerock", "Close Combat", "Crunch", "Drill Run", "Psychic Fangs", "Stone Edge", "Swords Dance"],
+                "movepool": ["Accelerock", "Close Combat", "Crunch", "Psychic Fangs", "Stone Edge", "Swords Dance"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2732,7 +2737,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Air Slash", "Dark Pulse", "Hydro Pump", "Ice Beam", "Surf", "U-turn"],
+                "movepool": ["Dark Pulse", "Hydro Pump", "Ice Beam", "Surf", "U-turn"],
                 "teraTypes": ["Water"]
             },
             {
@@ -2758,7 +2763,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Brave Bird", "Bulk Up", "Defog", "Roost"],
-                "teraTypes": ["Fighting"]
+                "teraTypes": ["Fighting", "Dragon"]
             }
         ]
     },
@@ -3207,7 +3212,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Crunch", "Facade", "Headlong Rush", "Protect", "Swords Dance"],
+                "movepool": ["Crunch", "Facade", "Headlong Rush","Swords Dance", "Trailblaze"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -3241,7 +3246,7 @@
         "level": 79,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Fast Support",
                 "movepool": ["Flower Trick", "Knock Off", "Thunder Punch", "Toxic Spikes", "U-turn"],
                 "teraTypes": ["Grass", "Dark"]
             }
@@ -3681,7 +3686,7 @@
         "level": 83,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Fast Attacker",
                 "movepool": ["Brave Bird", "Close Combat", "Swords Dance", "Throat Chop", "U-turn"],
                 "teraTypes": ["Fighting"]
             }
@@ -3741,12 +3746,12 @@
                 "teraTypes": ["Dark"]
             },
             {
-                "role": "Fast Support",
+                "role": "Bulky Support",
                 "movepool": ["Encore", "Knock Off", "Protect", "Substitute", "Toxic"],
                 "teraTypes": ["Dark"]
             },
             {
-                "role": "Bulky Support",
+                "role": "Fast Support",
                 "movepool": ["Encore", "Gunk Shot", "Knock Off", "Parting Shot"],
                 "teraTypes": ["Dark"]
             }
@@ -3776,12 +3781,12 @@
         "level": 88,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Fast Support",
                 "movepool": ["Power Whip", "Rapid Spin", "Shadow Sneak", "Spikes", "Strength Sap"],
                 "teraTypes": ["Steel", "Water", "Fairy"]
             },
             {
-                "role": "Fast Support",
+                "role": "Bulky Support",
                 "movepool": ["Leech Seed", "Phantom Force", "Power Whip", "Substitute"],
                 "teraTypes": ["Steel", "Water", "Fairy"]
             }
@@ -3831,9 +3836,9 @@
         "level": 80,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Fast Support",
                 "movepool": ["Earth Power", "Spikes", "Stealth Rock", "Thunder Wave", "Thunderbolt", "Volt Switch"],
-                "teraTypes": ["Electric", "Ground"]
+                "teraTypes": ["Electric", "Ground", "Bug"]
             },
             {
                 "role": "Tera Blast user",
@@ -3912,7 +3917,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Earthquake", "Iron Head", "Knock Off", "Rapid Spin", "Stealth Rock", "Stone Edge", "Volt Switch"],
+                "movepool": ["Earthquake", "Iron Head", "Knock Off", "Rapid Spin", "Stealth Rock", "Volt Switch"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -4131,8 +4136,8 @@
         "level": 76,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["Iron Head", "Kowtow Cleave", "Stealth Rock", "Sucker Punch", "Swords Dance"],
+                "role": "Bulky Attacker",
+                "movepool": ["Iron Head", "Kowtow Cleave", "Sucker Punch", "Swords Dance"],
                 "teraTypes": ["Dark", "Flying"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -3516,7 +3516,7 @@
                 "teraTypes": ["Water", "Ground"]
             },
             {
-                "role": "Fast Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Gunk Shot", "Haze", "Parting Shot", "Spin Out", "Toxic", "Toxic Spikes"],
                 "teraTypes": ["Water"]
             }

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1222,7 +1222,7 @@ export class RandomTeams {
 		if (moves.has('outrage')) return 'Lum Berry';
 		if (
 			(species.id === 'garchomp' && role === 'Fast Support') || (
-				ability === 'Regenerator' && role === 'Bulky Support' &&
+				ability === 'Regenerator' && (role === 'Bulky Support' || role === 'Bulky Attacker') &&
 				(species.baseStats.hp + species.baseStats.def) >= 180 && this.randomChance(1, 2)
 			)
 		) return 'Rocky Helmet';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -88,7 +88,7 @@ const Setup = [
 const NoStab = [
 	'accelerock', 'aquajet', 'beakblast', 'bounce', 'breakingswipe', 'chatter', 'chloroblast', 'clearsmog', 'dragontail', 'eruption',
 	'explosion', 'fakeout', 'flamecharge', 'flipturn', 'iceshard', 'icywind', 'incinerate', 'machpunch', 'meteorbeam',
-	'mortalspin', 'pluck', 'pursuit', 'quickattack', 'rapidspin', 'reversal', 'selfdestruct', 'shadowsneak',
+	'mortalspin', 'nuzzle', 'pluck', 'pursuit', 'quickattack', 'rapidspin', 'reversal', 'selfdestruct', 'shadowsneak',
 	'skydrop', 'snarl', 'suckerpunch', 'uturn', 'watershuriken', 'vacuumwave', 'voltswitch', 'waterspout',
 ];
 // Hazard-setting moves
@@ -344,7 +344,6 @@ export class RandomTeams {
 			if (move.damage || move.damageCallback) {
 				// Moves that do a set amount of damage:
 				counter.add('damage');
-				counter.damagingMoves.add(move);
 			} else {
 				// Are Physical/Special/Status moves:
 				categories[move.category]++;
@@ -358,11 +357,12 @@ export class RandomTeams {
 			if (move.recoil || move.hasCrashDamage) counter.add('recoil');
 			if (move.drain) counter.add('drain');
 			// Moves which have a base power, but aren't super-weak:
-			if (move.basePower > 30 || move.multihit || move.basePowerCallback) {
+			if (move.category !== 'Status') {
 				if (!this.noStab.includes(moveid) || priorityPokemon.includes(species.id) && move.priority > 0) {
 					counter.add(moveType);
 					if (types.includes(moveType)) counter.stabCounter++;
 					if (teraType === moveType) counter.add('stabtera');
+					counter.damagingMoves.add(move);
 				}
 				if (move.flags['bite']) counter.add('strongjaw');
 				if (move.flags['punch']) counter.ironFist++;
@@ -370,7 +370,6 @@ export class RandomTeams {
 				if (move.priority > 0 || (moveid === 'grassyglide' && abilities.has('Grassy Surge'))) {
 					counter.add('priority');
 				}
-				counter.damagingMoves.add(move);
 			}
 			// Moves with secondary effects:
 			if (move.secondary || move.hasSheerForce) {
@@ -468,9 +467,7 @@ export class RandomTeams {
 
 		// These moves don't mesh well with other aspects of the set
 		this.incompatibleMoves(moves, movePool, statusMoves, ['healingwish', 'switcheroo', 'trick']);
-		if (species.id !== "scyther" && species.id !== "scizor") {
-			this.incompatibleMoves(moves, movePool, Setup, pivotingMoves);
-		}
+		this.incompatibleMoves(moves, movePool, Setup, pivotingMoves);
 		this.incompatibleMoves(moves, movePool, Setup, Hazards);
 		this.incompatibleMoves(moves, movePool, Setup, ['defog', 'nuzzle', 'toxic', 'waterspout', 'yawn', 'haze']);
 		this.incompatibleMoves(moves, movePool, PhysicalSetup, PhysicalSetup);
@@ -700,9 +697,7 @@ export class RandomTeams {
 			for (const moveid of movePool) {
 				const move = this.dex.moves.get(moveid);
 				const moveType = this.getMoveType(move, species, abilities, teraType);
-				if (type === moveType &&
-					(move.basePower > 30 || move.multihit || move.basePowerCallback) &&
-					(!this.noStab.includes(moveid) || abilities.has('Technician') && moveid === 'machpunch')) {
+				if (type === moveType && move.category !== 'Status' && !this.noStab.includes(moveid)) {
 					stabMoves.push(moveid);
 				}
 			}
@@ -720,8 +715,7 @@ export class RandomTeams {
 			for (const moveid of movePool) {
 				const move = this.dex.moves.get(moveid);
 				const moveType = this.getMoveType(move, species, abilities, teraType);
-				if (!this.noStab.includes(moveid) && (move.basePower > 30 || move.multihit || move.basePowerCallback) &&
-					types.includes(moveType)) {
+				if (!this.noStab.includes(moveid) && move.category !== 'Status' && types.includes(moveType)) {
 					stabMoves.push(moveid);
 				}
 			}
@@ -738,10 +732,8 @@ export class RandomTeams {
 			for (const moveid of movePool) {
 				const move = this.dex.moves.get(moveid);
 				const moveType = this.getMoveType(move, species, abilities, teraType);
-				if (!this.noStab.includes(moveid) && (move.basePower > 30 || move.multihit || move.basePowerCallback)) {
-					if (teraType === moveType) {
-						stabMoves.push(moveid);
-					}
+				if (!this.noStab.includes(moveid) && move.category !== 'Status' && teraType === moveType) {
+					stabMoves.push(moveid);
 				}
 			}
 			if (stabMoves.length) {
@@ -784,21 +776,14 @@ export class RandomTeams {
 		if (!['AV Pivot', 'Fast Support', 'Bulky Support'].includes(role)) {
 			if (counter.damagingMoves.size <= 1) {
 				// Find the type of the current attacking move
-				let currentAttackType: string;
-				for (const moveid of moves) {
-					const move = this.dex.moves.get(moveid);
-					if (move.basePower > 30 || move.multihit || move.basePowerCallback) {
-						const moveType = this.getMoveType(move, species, abilities, teraType);
-						currentAttackType = moveType;
-					}
-				}
+				const currentAttackType = counter.damagingMoves.values().next().value.type;
 				// Choose an attacking move that is of different type to the current single attack
 				const coverageMoves = [];
 				for (const moveid of movePool) {
 					const move = this.dex.moves.get(moveid);
 					const moveType = this.getMoveType(move, species, abilities, teraType);
-					if (!this.noStab.includes(moveid) && (move.basePower > 30 || move.multihit || move.basePowerCallback)) {
-						if (currentAttackType! !== moveType) coverageMoves.push(moveid);
+					if (!this.noStab.includes(moveid) && move.category !== 'Status') {
+						if (currentAttackType !== moveType) coverageMoves.push(moveid);
 					}
 				}
 				if (coverageMoves.length) {
@@ -806,6 +791,21 @@ export class RandomTeams {
 					counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead, isDoubles,
 						movePool, teraType, role);
 				}
+			}
+		}
+
+		// Enforce a move not on the noSTAB list
+		if (!counter.damagingMoves.size) {
+			// Choose an attacking move
+			const attackingMoves = [];
+			for (const moveid of movePool) {
+				const move = this.dex.moves.get(moveid);
+				if (!this.noStab.includes(moveid) && move.category !== 'Status') attackingMoves.push(moveid);
+			}
+			if (attackingMoves.length) {
+				const moveid = this.sample(attackingMoves);
+				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead, isDoubles,
+					movePool, teraType, role);
 			}
 		}
 
@@ -1211,16 +1211,20 @@ export class RandomTeams {
 			this.dex.getEffectiveness('Rock', species) >= 1
 		) return 'Heavy-Duty Boots';
 		if (
-			role === 'Fast Support' &&
-			['defog', 'rapidspin', 'uturn', 'voltswitch'].some(m => moves.has(m)) &&
-			!types.includes('Flying') && ability !== 'Levitate'
+			(moves.has('chillyreception') || (
+				role === 'Fast Support' &&
+				['defog', 'partingshot', 'mortalspin', 'rapidspin', 'uturn', 'voltswitch'].some(m => moves.has(m)) &&
+				!types.includes('Flying') && ability !== 'Levitate'
+			))
 		) return 'Heavy-Duty Boots';
 
 		// Low Priority
 		if (moves.has('outrage')) return 'Lum Berry';
 		if (
-			(species.id === 'garchomp' && role === 'Fast Support') ||
-			(ability === 'Regenerator' && types.includes('Water') && species.baseStats.def >= 110 && this.randomChance(1, 3))
+			(species.id === 'garchomp' && role === 'Fast Support') || (
+				ability === 'Regenerator' && role === 'Bulky Support' &&
+				(species.baseStats.hp + species.baseStats.def) >= 180 && this.randomChance(1, 2)
+			)
 		) return 'Rocky Helmet';
 		if (
 			role === 'Fast Support' && isLead &&
@@ -1234,9 +1238,12 @@ export class RandomTeams {
 		if (['Bulky Attacker', 'Bulky Support', 'Bulky Setup'].some(m => role === (m))) return 'Leftovers';
 		if (species.id === 'pawmot' && moves.has('nuzzle')) return 'Leppa Berry';
 		if (role === 'Fast Support' || role === 'Fast Bulky Setup') {
-			return (counter.damagingMoves.size >= 3 && !moves.has('nuzzle')) ? 'Life Orb' : 'Leftovers';
+			return (counter.get('Physical') + counter.get('Special') >= 3 && !moves.has('nuzzle')) ? 'Life Orb' : 'Leftovers';
 		}
-		if (role === 'Tera Blast user' && counter.get('recovery') && counter.damagingMoves.size < 3) return 'Leftovers';
+		if (
+			role === 'Tera Blast user' && counter.get('recovery') &&
+			counter.get('Physical') + counter.get('Special') < 3
+		) return 'Leftovers';
 		if (
 			['flamecharge', 'rapidspin'].every(m => !moves.has(m)) &&
 			['Fast Attacker', 'Setup Sweeper', 'Tera Blast user', 'Wallbreaker'].some(m => role === (m))


### PR DESCRIPTION
As usual for the first week of the month, there's a lot of changes!

We have another goal in mind with many of our small changes: increasing how well teams can deal with hazards. Changes made to help with that goal are marked with an asterisk (*).

-Giratina now has a third set; its first set is now Fast Support instead of Bulky Support (no functional change), and the new set is Bulky Support featuring Defog, Dragon Tail, Will-O-Wisp, Shadow Ball, and Rest, without Sleep Talk. This set will run either a Chesto Berry or Leftovers, depending on whether or not it gets Rest.*
-Iron Treads: -Stone Edge (and therefore no longer runs Choice items)*
-Kingambit: -Stealth Rock; role changed to Bulky Attacker to give it Leftovers instead of Life Orb*
-Flamigo: Role changed to Fast Attacker; it can now get Choice Scarf.
-Sandy Shocks set 1: +Tera Bug, Role changed to Fast Support to give it Heavy-Duty Boots with Volt Switch*
-Meowscarada: Role changed to Fast Support to give it Heavy-Duty Boots on U-turn/Toxic Spikes/Knock Off/Flower Trick sets. Life Orb and Choice Band will still exist.*
-Lumineon: Role changed to Fast Support to give it Heavy-Duty Boots on U-turn + Encore sets. Life Orb and Choice Specs will still exist.*
-Brambleghast: The roles for its two sets have been switched, which allows Brambleghast to get Heavy-Duty Boots with Rapid Spin, though it will no longer always run Strength Sap on that set.*
-Grafaiai: The roles for its second and third set have been switched, which allows Parting Shot Grafaiai to get Heavy-Duty Boots.*
-Chilly Reception and Mortal Spin now grant Heavy-Duty Boots. Assault Vest Glimmora will continue to exist on Mortal Spin + 3 other attacks sets.*
-Alomomola and Amoonguss now have a 50% chance to run Rocky Helmet instead of Leftovers. Slowbro and Toxapex now have a 50% chance as well, up from 33%.
-Scyther will no longer get Swords Dance + U-turn together.
-Spidops will now always run Circle Throw.

-Avalugg-Hisui: -Curse, +Rapid Spin*
-Lycanroc-Dusk: -Drill Run
-Ursaluna: -Protect, +Trailblaze
-Inteleon set 1: -Air Slash
-Clodsire set 2: -Spikes, +Stealth Rock*
-Whiscash set 1: -Liquidation, -Stone Edge, +Hydro Pump, +Ice Beam
-Hoopa: -Substitute (and therefore it will no longer run Leftovers)
-Scizor set 2: +U-turn, role changed to Fast Attacker (and therefore Scizor will now be 50% Defog, 25% Swords Dance, and 25% Choice Band.)
-Dragalge: -Thunderbolt, Tera Elec, and Tera Dragon, +Hydro Pump and Tera Water
-Articuno: -Tera Flying
-Muk: -Tera Poison, +Tera Dragon
-Corviknight: +Tera dragon
-Iron Hands: +Tera Fighting
-Oricorio-Pa'u: +Tera Fighting
-Typhlosion: -Tera Ghost, +Tera Fighting

Technical (thanks to Livid Washed for the following):
-one move from the noStab list is now enforced at the very minimum. This is important for Grafaiai and Doubles.
-the "damagingMoves" counter has been refactored to reduce unnecessary code, and Nuzzle was moved to noStab to compensate.