### PR TITLE
Fix Gen3 Rest Sleep Talk interaction

### DIFF
--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -527,6 +527,25 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		pp: 20,
 	},
+	rest: {
+		 inherit: true,
+		 OnTry (source) {
+			 if (source.status === 'slp') {
+				 this.add('-fail', pokemon, 'slp');
+				 return null;
+			 }
+
+			 if (source.hp === source.maxhp) {
+				 this.add('-fail', source, 'heal');
+				 return null;
+			 }
+
+			 if (source.hasAbility(['insomnia', 'vitalspirit'])) {
+				 this.add('-fail', source, '[from] ability: ' + source.getAbility().name, '[of] ' + source);
+				 return null;
+			 }
+		 }
+	},
 	rocksmash: {
 		inherit: true,
 		basePower: 20,
@@ -540,7 +559,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		onHit(pokemon) {
 			const moves = [];
 			for (const moveSlot of pokemon.moveSlots) {
-				const moveid = moveSlot.id;
+			const moveid = moveSlot.id;
 				const pp = moveSlot.pp;
 				const move = this.dex.moves.get(moveid);
 				if (moveid && !move.flags['nosleeptalk'] && !move.flags['charge']) {


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-9106563

Added fail message to the OnTry function of the move Rest if user is currently asleep. This is probably an issue due to the tryMoveHit function being modified in the gen3 scripts file