### PR TITLE
Fix Volbeat Dizzy Punch Lunge legality issue

### DIFF
--- a/data/learnsets.ts
+++ b/data/learnsets.ts
@@ -37666,6 +37666,10 @@ export const Learnsets: {[speciesid: string]: LearnsetData} = {
 			waterpulse: ["7T", "6T", "4M", "3M"],
 			zenheadbutt: ["7T", "7L33", "6T", "6L33", "5T", "5L37", "4T", "4L37"],
 		},
+		eventData: [
+			{generation: 7, level: 1, moves: ["batonpass", "bugbuzz", "dizzypunch", "encore", "seismictoss", "silverwind", "trick"]},
+			{generation: 7, level: 1, moves: ["batonpass", "bugbuzz", "encore", "lunge", "seismictoss", "silverwind", "trick"]},
+		],
 	},
 	illumise: {
 		learnset: {


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/page-68#post-9063784

added two different sets of level 1 movesets with each excluding one of the illegal moves (I presume this is how it's meant to be done)