### PR TITLE
Gen 8/9 Random Battle: Remove tier limits

### DIFF
--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -2439,7 +2439,6 @@ export class RandomGen8Teams {
 
 		const baseFormes: {[k: string]: number} = {};
 
-		const tierCount: {[k: string]: number} = {};
 		const typeCount: {[k: string]: number} = {};
 		const typeComboCount: {[k: string]: number} = {};
 		const typeWeaknesses: {[k: string]: number} = {};
@@ -2502,22 +2501,10 @@ export class RandomGen8Teams {
 				continue;
 			}
 
-			const tier = species.tier;
 			const types = species.types;
 			const typeCombo = types.slice().sort().join();
 			// Dynamically scale limits for different team sizes. The default and minimum value is 1.
 			const limitFactor = Math.round(this.maxTeamSize / 6) || 1;
-
-			// Limit one Pokemon per tier, two for Monotype
-			// This limitation is not applied to BD/SP team generation, because tiering for BD/SP is not yet complete,
-			// meaning that most Pokémon are in OU.
-			if (
-				this.dex.currentMod !== 'gen8bdsp' &&
-				(tierCount[tier] >= (this.forceMonotype || isMonotype ? 2 : 1) * limitFactor) &&
-				!this.randomChance(1, Math.pow(5, tierCount[tier]))
-			) {
-				continue;
-			}
 
 			if (!isMonotype && !this.forceMonotype) {
 				let skip = false;
@@ -2567,13 +2554,6 @@ export class RandomGen8Teams {
 
 			// Now that our Pokemon has passed all checks, we can increment our counters
 			baseFormes[species.baseSpecies] = 1;
-
-			// Increment tier counter
-			if (tierCount[tier]) {
-				tierCount[tier]++;
-			} else {
-				tierCount[tier] = 1;
-			}
 
 			// Increment type counters
 			for (const typeName of types) {

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1480,7 +1480,6 @@ export class RandomTeams {
 
 		const baseFormes: {[k: string]: number} = {};
 
-		const tierCount: {[k: string]: number} = {};
 		const typeCount: {[k: string]: number} = {};
 		const typeComboCount: {[k: string]: number} = {};
 		const typeWeaknesses: {[k: string]: number} = {};
@@ -1520,21 +1519,10 @@ export class RandomTeams {
 				continue;
 			}
 
-			const tier = species.tier;
 			const types = species.types;
 			const typeCombo = types.slice().sort().join();
 			// Dynamically scale limits for different team sizes. The default and minimum value is 1.
 			const limitFactor = Math.round(this.maxTeamSize / 6) || 1;
-
-			// Limit one Pokemon per tier, two for Monotype
-			// Disable this for now, since it is still a new gen
-			// Unless you want to have a lot of Ubers!
-			// if (
-			// 	(tierCount[tier] >= (this.forceMonotype || isMonotype ? 2 : 1) * limitFactor) &&
-			// 	!this.randomChance(1, Math.pow(5, tierCount[tier]))
-			// ) {
-			// 	continue;
-			// }
 
 			if (!isMonotype && !this.forceMonotype) {
 				let skip = false;
@@ -1597,13 +1585,6 @@ export class RandomTeams {
 
 			// Now that our Pokemon has passed all checks, we can increment our counters
 			baseFormes[species.baseSpecies] = 1;
-
-			// Increment tier counter
-			if (tierCount[tier]) {
-				tierCount[tier]++;
-			} else {
-				tierCount[tier] = 1;
-			}
 
 			// Increment type counters
 			for (const typeName of types) {


### PR DESCRIPTION
This implements a Random Battles Development Council decision to remove tier limits from formats that are sufficiently level balanced.

For now, this means removing them from Gen 8 Random Battles, and not applying them to Gen 9 Random Battles.

Approved by Random Battles staff, ready to be merged