### PR TITLE
Random Battles updates

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -300,7 +300,7 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Bulk Up", "Raging Bull", "Stone Edge", "Substitute"],
-                "teraTypes": ["Fighting"]
+                "teraTypes": ["Fighting", "Steel"]
             },
             {
                 "role": "Wallbreaker",
@@ -315,7 +315,7 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Bulk Up", "Close Combat", "Raging Bull", "Substitute"],
-                "teraTypes": ["Fire"]
+                "teraTypes": ["Water"]
             },
             {
                 "role": "Wallbreaker",
@@ -330,7 +330,7 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Bulk Up", "Close Combat", "Liquidation", "Substitute"],
-                "teraTypes": ["Water"]
+                "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Wallbreaker",
@@ -735,7 +735,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Bullet Punch", "Close Combat", "Defog", "U-turn"],
-                "teraTypes": ["Steel"]
+                "teraTypes": ["Dragon", "Steel"]
             },
             {
                 "role": "Fast Attacker",
@@ -879,8 +879,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Bullet Seed", "Close Combat", "Mach Punch", "Rock Tomb", "Spore", "Swords Dance"],
-                "teraTypes": ["Fighting"]
+                "movepool": ["Bullet Seed", "Mach Punch", "Rock Tomb", "Spore", "Swords Dance"],
+                "teraTypes": ["Fighting", "Rock"]
             }
         ]
     },
@@ -960,7 +960,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Lava Plume", "Stealth Rock", "Yawn"],
-                "teraTypes": ["Water"]
+                "teraTypes": ["Grass", "Water"]
             }
         ]
     },
@@ -1174,7 +1174,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Air Slash", "Roost", "Spikes", "Toxic", "Toxic Spikes", "U-turn"],
+                "movepool": ["Air Slash", "Hurricane", "Roost", "Spikes", "Toxic", "Toxic Spikes", "U-turn"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1320,7 +1320,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Slack Off", "Stealth Rock", "Stone Edge", "Whirlwind", "Yawn"],
-                "teraTypes": ["Fairy", "Rock", "Steel"]
+                "teraTypes": ["Dragon", "Rock", "Steel"]
             }
         ]
     },
@@ -1943,7 +1943,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Dark Pulse", "Flamethrower", "Focus Blast", "Nasty Plot", "Sludge Bomb", "Trick", "U-turn"],
+                "movepool": ["Dark Pulse", "Flamethrower", "Focus Blast", "Nasty Plot", "Psychic", "Sludge Bomb", "Trick", "U-turn"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -2406,9 +2406,9 @@
                 "teraTypes": ["Normal"]
             },
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Defog", "Draco Meteor", "Flamethrower", "Roost", "Taunt"],
-                "teraTypes": ["Steel"]
+                "role": "Fast Support",
+                "movepool": ["Defog", "Draco Meteor", "Flamethrower", "Hurricane", "Roost", "U-turn"],
+                "teraTypes": ["Fire"]
             }
         ]
     },
@@ -2998,7 +2998,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Draco Meteor", "Fire Blast", "Shadow Ball", "Thunderbolt", "U-turn"],
-                "teraTypes": ["Ghost", "Dragon"]
+                "teraTypes": ["Fire", "Ghost"]
             },
             {
                 "role": "Tera Blast user",
@@ -3247,7 +3247,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Flower Trick", "Knock Off", "Thunder Punch", "Toxic Spikes", "U-turn"],
+                "movepool": ["Flower Trick", "Knock Off", "Play Rough", "Toxic Spikes", "U-turn"],
                 "teraTypes": ["Grass", "Dark"]
             }
         ]
@@ -3437,7 +3437,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Curse", "Liquidation", "Rest", "Sleep Talk", "Wave Crash"],
+                "movepool": ["Curse", "Rest", "Sleep Talk", "Wave Crash"],
                 "teraTypes": ["Fairy", "Ground", "Dragon"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2998,7 +2998,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Draco Meteor", "Fire Blast", "Shadow Ball", "Thunderbolt", "U-turn"],
-                "teraTypes": ["Fire", "Ghost"]
+                "teraTypes": ["Dragon", "Fire", "Ghost"]
             },
             {
                 "role": "Tera Blast user",

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -356,8 +356,8 @@ export class RandomTeams {
 			if (move.multihit && Array.isArray(move.multihit) && move.multihit[1] === 5) counter.add('skilllink');
 			if (move.recoil || move.hasCrashDamage) counter.add('recoil');
 			if (move.drain) counter.add('drain');
-			// Moves which have a base power, but aren't super-weak:
-			if (move.category !== 'Status') {
+			// Moves which have a base power:
+			if (move.basePower || move.basePowerCallback) {
 				if (!this.noStab.includes(moveid) || priorityPokemon.includes(species.id) && move.priority > 0) {
 					counter.add(moveType);
 					if (types.includes(moveType)) counter.stabCounter++;
@@ -679,7 +679,7 @@ export class RandomTeams {
 			for (const moveid of movePool) {
 				const move = this.dex.moves.get(moveid);
 				const moveType = this.getMoveType(move, species, abilities, teraType);
-				if (types.includes(moveType) && move.priority > 0 && move.category !== 'Status') {
+				if (types.includes(moveType) && move.priority > 0 && (move.basePower || move.basePowerCallback)) {
 					priorityMoves.push(moveid);
 				}
 			}
@@ -697,7 +697,7 @@ export class RandomTeams {
 			for (const moveid of movePool) {
 				const move = this.dex.moves.get(moveid);
 				const moveType = this.getMoveType(move, species, abilities, teraType);
-				if (type === moveType && move.category !== 'Status' && !this.noStab.includes(moveid)) {
+				if (!this.noStab.includes(moveid) && (move.basePower || move.basePowerCallback) && type === moveType) {
 					stabMoves.push(moveid);
 				}
 			}
@@ -715,7 +715,7 @@ export class RandomTeams {
 			for (const moveid of movePool) {
 				const move = this.dex.moves.get(moveid);
 				const moveType = this.getMoveType(move, species, abilities, teraType);
-				if (!this.noStab.includes(moveid) && move.category !== 'Status' && types.includes(moveType)) {
+				if (!this.noStab.includes(moveid) && (move.basePower || move.basePowerCallback) && types.includes(moveType)) {
 					stabMoves.push(moveid);
 				}
 			}
@@ -732,7 +732,7 @@ export class RandomTeams {
 			for (const moveid of movePool) {
 				const move = this.dex.moves.get(moveid);
 				const moveType = this.getMoveType(move, species, abilities, teraType);
-				if (!this.noStab.includes(moveid) && move.category !== 'Status' && teraType === moveType) {
+				if (!this.noStab.includes(moveid) && (move.basePower || move.basePowerCallback) && teraType === moveType) {
 					stabMoves.push(moveid);
 				}
 			}
@@ -782,7 +782,7 @@ export class RandomTeams {
 				for (const moveid of movePool) {
 					const move = this.dex.moves.get(moveid);
 					const moveType = this.getMoveType(move, species, abilities, teraType);
-					if (!this.noStab.includes(moveid) && move.category !== 'Status') {
+					if (!this.noStab.includes(moveid) && (move.basePower || move.basePowerCallback)) {
 						if (currentAttackType !== moveType) coverageMoves.push(moveid);
 					}
 				}
@@ -800,7 +800,7 @@ export class RandomTeams {
 			const attackingMoves = [];
 			for (const moveid of movePool) {
 				const move = this.dex.moves.get(moveid);
-				if (!this.noStab.includes(moveid) && move.category !== 'Status') attackingMoves.push(moveid);
+				if (!this.noStab.includes(moveid) && (move.basePower || move.basePowerCallback)) attackingMoves.push(moveid);
 			}
 			if (attackingMoves.length) {
 				const moveid = this.sample(attackingMoves);


### PR DESCRIPTION
Changes pending council review; ready to merge Sunday.
edit: ready to merge

-changed Noivern's support set back to Fast Support, because statistical analysis showed that it was made worse.
-Dondozo: -Liquidation
-Zoroark: +Psychic
-Meowscarada: -Thunder Punch, +Play Rough
-Vespiquen: +Hurricane (50/50 with Air Slash)
-Breloom: -Close Combat, +Tera Rock (no longer runs Choice Band)
-Fast Bulky Setup Tauros-Combat: +Tera Steel
-Fast Bulky Setup Tauros-Blaze: -Tera Fire, +Tera Water
-Fast Bulky Setup Tauros-Aqua: +Tera Steel
-Specs Dragapult: +Tera Fire
-Hippowdon: -Tera Fairy, +Tera Dragon
-Support Scizor: +Tera Dragon
-Camerupt: +Tera Grass

Technical:
-Set damage moves shouldn't count as moves of that type (e.g. Ruination no longer counts as a Dark type attack).