### PR TITLE
Fix local ladders inputing bad entries on load

### DIFF
--- a/server/ladders-local.ts
+++ b/server/ladders-local.ts
@@ -64,7 +64,7 @@ export class LadderStore {
 		try {
 			const data = await FS('config/ladders/' + this.formatid + '.tsv').readIfExists();
 			const ladder: LadderRow[] = [];
-			for (const dataLine of data.split('\n')) {
+			for (const dataLine of data.split('\n').slice(1)) {
 				const line = dataLine.trim();
 				if (!line) continue;
 				const row = line.split('\t');


### PR DESCRIPTION
Caused by #4516 where the behavior of skipping the first line of the tsv ladder file was accidentally removed.