### PR TITLE
Random Battles: Level balancing 2023-05

### DIFF
--- a/data/mods/gen1/random-data.json
+++ b/data/mods/gen1/random-data.json
@@ -16,37 +16,37 @@
         "essentialMove": "razorleaf"
     },
     "charmander": {
-        "level": 88,
+        "level": 90,
         "moves": ["bodyslam", "slash"],
         "essentialMove": "fireblast",
         "exclusiveMoves": ["counter", "seismictoss"],
         "comboMoves": ["bodyslam", "fireblast", "submission", "swordsdance"]
     },
     "charmeleon": {
-        "level": 80,
+        "level": 81,
         "moves": ["bodyslam", "slash"],
         "essentialMove": "fireblast",
         "exclusiveMoves": ["counter", "swordsdance"],
         "comboMoves": ["bodyslam", "fireblast", "submission", "swordsdance"]
     },
     "charizard": {
-        "level": 77,
+        "level": 76,
         "moves": ["bodyslam", "earthquake", "slash"],
         "essentialMove": "fireblast",
         "comboMoves": ["hyperbeam", "swordsdance"]
     },
     "squirtle": {
-        "level": 88,
+        "level": 90,
         "moves": ["blizzard", "hydropump", "seismictoss", "surf"],
         "exclusiveMoves": ["bodyslam", "counter"]
     },
     "wartortle": {
-        "level": 80,
+        "level": 82,
         "moves": ["blizzard", "bodyslam", "hydropump", "surf"],
         "exclusiveMoves": ["counter", "rest", "seismictoss"]
     },
     "blastoise": {
-        "level": 77,
+        "level": 76,
         "moves": ["blizzard", "bodyslam", "hydropump", "surf"],
         "exclusiveMoves": ["earthquake", "rest"]
     },
@@ -56,18 +56,18 @@
         "exclusiveMoves": ["megadrain", "psywave"]
     },
     "beedrill": {
-        "level": 77,
+        "level": 80,
         "moves": ["megadrain", "swordsdance", "twineedle"],
         "exclusiveMoves": ["doubleedge", "doubleedge", "hyperbeam"],
         "comboMoves": ["agility", "hyperbeam", "swordsdance", "twineedle"]
     },
     "pidgey": {
-        "level": 88,
+        "level": 91,
         "moves": ["agility", "doubleedge", "skyattack"],
         "exclusiveMoves": ["mimic", "mirrormove", "reflect", "sandattack", "substitute", "quickattack", "toxic"]
     },
     "pidgeotto": {
-        "level": 80,
+        "level": 82,
         "moves": ["agility", "doubleedge", "skyattack"],
         "exclusiveMoves": ["mimic", "mirrormove", "reflect", "sandattack", "substitute", "quickattack", "toxic"]
     },
@@ -77,7 +77,7 @@
         "exclusiveMoves": ["mimic", "mirrormove", "reflect", "sandattack", "skyattack", "skyattack", "substitute", "quickattack", "toxic"]
     },
     "rattata": {
-        "level": 88,
+        "level": 89,
         "moves": ["blizzard", "bodyslam"],
         "essentialMove": "superfang",
         "exclusiveMoves": ["thunderbolt", "thunderbolt", "quickattack"]
@@ -88,20 +88,20 @@
         "essentialMove": "superfang"
     },
     "spearow": {
-        "level": 88,
+        "level": 89,
         "moves": ["agility", "doubleedge", "drillpeck"],
         "exclusiveMoves": ["leer", "mimic", "mirrormove", "substitute", "toxic"]
     },
     "fearow": {
-        "level": 77,
+        "level": 76,
         "moves": ["agility", "doubleedge", "drillpeck", "hyperbeam"]
     },
     "ekans": {
-        "level": 88,
+        "level": 90,
         "moves": ["bodyslam", "earthquake", "glare", "rockslide"]
     },
     "arbok": {
-        "level": 77,
+        "level": 78,
         "moves": ["earthquake", "glare", "hyperbeam"],
         "exclusiveMoves": ["bodyslam", "rockslide"]
     },
@@ -112,7 +112,7 @@
         "exclusiveMoves": ["agility", "bodyslam", "seismictoss", "thunder"]
     },
     "raichu": {
-        "level": 76,
+        "level": 75,
         "moves": ["surf", "thunderwave"],
         "essentialMove": "thunderbolt",
         "exclusiveMoves": ["agility", "bodyslam", "hyperbeam", "seismictoss", "thunder"]
@@ -128,32 +128,32 @@
         "essentialMove": "earthquake"
     },
     "nidoranf": {
-        "level": 88,
+        "level": 90,
         "moves": ["blizzard", "bodyslam", "thunderbolt"],
         "exclusiveMoves": ["doubleedge", "doublekick"]
     },
     "nidorina": {
-        "level": 80,
+        "level": 81,
         "moves": ["blizzard", "bodyslam", "thunderbolt"],
         "exclusiveMoves": ["bubblebeam", "doubleedge", "doublekick"]
     },
     "nidoqueen": {
-        "level": 77,
+        "level": 75,
         "moves": ["blizzard", "bodyslam", "thunderbolt"],
         "essentialMove": "earthquake"
     },
     "nidoranm": {
-        "level": 88,
+        "level": 90,
         "moves": ["blizzard", "bodyslam", "thunderbolt"],
         "exclusiveMoves": ["doubleedge", "doublekick"]
     },
     "nidorino": {
-        "level": 80,
+        "level": 81,
         "moves": ["blizzard", "bodyslam", "thunderbolt"],
         "exclusiveMoves": ["bubblebeam", "doubleedge", "doublekick"]
     },
     "nidoking": {
-        "level": 77,
+        "level": 75,
         "moves": ["blizzard", "bodyslam"],
         "essentialMove": "earthquake",
         "exclusiveMoves": ["rockslide", "thunder", "thunderbolt"]
@@ -171,12 +171,12 @@
         "exclusiveMoves": ["counter", "hyperbeam", "psychic", "sing", "sing"]
     },
     "vulpix": {
-        "level": 88,
+        "level": 90,
         "moves": ["bodyslam", "confuseray", "fireblast"],
         "exclusiveMoves": ["flamethrower", "reflect", "substitute"]
     },
     "ninetales": {
-        "level": 77,
+        "level": 76,
         "moves": ["bodyslam", "confuseray", "fireblast"],
         "exclusiveMoves": ["flamethrower", "hyperbeam", "reflect", "substitute"]
     },
@@ -191,11 +191,11 @@
         "exclusiveMoves": ["counter", "hyperbeam", "sing"]
     },
     "zubat": {
-        "level": 88,
+        "level": 91,
         "moves": ["confuseray", "doubleedge", "megadrain", "toxic"]
     },
     "golbat": {
-        "level": 77,
+        "level": 79,
         "moves": ["confuseray", "doubleedge", "hyperbeam", "megadrain"]
     },
     "oddish": {
@@ -233,7 +233,7 @@
         "exclusiveMoves": ["doubleedge", "megadrain", "psywave"]
     },
     "venomoth": {
-        "level": 77,
+        "level": 75,
         "moves": ["psychic", "sleeppowder", "stunspore"],
         "exclusiveMoves": ["doubleedge", "megadrain", "megadrain"]
     },
@@ -248,7 +248,7 @@
         "essentialMove": "earthquake"
     },
     "meowth": {
-        "level": 88,
+        "level": 87,
         "moves": ["bodyslam", "bubblebeam"],
         "essentialMove": "slash",
         "exclusiveMoves": ["thunder", "thunderbolt"]
@@ -272,7 +272,7 @@
         "exclusiveMoves": ["bodyslam", "hydropump", "rest", "seismictoss"]
     },
     "mankey": {
-        "level": 88,
+        "level": 89,
         "moves": ["bodyslam", "rockslide", "submission"],
         "exclusiveMoves": ["counter", "megakick"]
     },
@@ -282,7 +282,7 @@
         "exclusiveMoves": ["counter", "hyperbeam", "hyperbeam"]
     },
     "growlithe": {
-        "level": 88,
+        "level": 90,
         "moves": ["bodyslam", "fireblast", "flamethrower", "reflect"]
     },
     "arcanine": {
@@ -303,19 +303,19 @@
         "exclusiveMoves": ["counter", "hypnosis", "hypnosis", "psychic"]
     },
     "poliwrath": {
-        "level": 76,
+        "level": 75,
         "moves": ["blizzard", "bodyslam", "earthquake", "submission"],
         "essentialMove": "surf",
         "exclusiveMoves": ["hypnosis", "hypnosis", "psychic"],
         "comboMoves": ["amnesia", "blizzard"]
     },
     "abra": {
-        "level": 88,
+        "level": 85,
         "moves": ["psychic", "seismictoss", "thunderwave"],
         "exclusiveMoves": ["counter", "reflect"]
     },
     "kadabra": {
-        "level": 74,
+        "level": 73,
         "moves": ["psychic", "recover", "thunderwave"],
         "exclusiveMoves": ["counter", "reflect", "reflect", "seismictoss", "seismictoss"]
     },
@@ -325,12 +325,12 @@
         "exclusiveMoves": ["counter", "reflect", "reflect", "seismictoss", "seismictoss"]
     },
     "machop": {
-        "level": 88,
+        "level": 89,
         "moves": ["bodyslam", "earthquake", "submission"],
         "exclusiveMoves": ["counter", "rockslide", "rockslide"]
     },
     "machoke": {
-        "level": 80,
+        "level": 81,
         "moves": ["bodyslam", "earthquake", "submission"],
         "exclusiveMoves": ["counter", "rockslide", "rockslide"]
     },
@@ -340,7 +340,7 @@
         "exclusiveMoves": ["counter", "hyperbeam", "rockslide", "rockslide"]
     },
     "bellsprout": {
-        "level": 88,
+        "level": 89,
         "moves": ["doubleedge", "sleeppowder", "stunspore", "swordsdance"],
         "essentialMove": "razorleaf"
     },
@@ -356,7 +356,7 @@
         "comboMoves": ["hyperbeam", "swordsdance"]
     },
     "tentacool": {
-        "level": 88,
+        "level": 86,
         "moves": ["barrier", "hydropump", "surf"],
         "essentialMove": "blizzard",
         "exclusiveMoves": ["megadrain", "megadrain"],
@@ -376,11 +376,11 @@
         "moves": ["bodyslam", "earthquake", "explosion", "rockslide"]
     },
     "golem": {
-        "level": 77,
+        "level": 76,
         "moves": ["bodyslam", "earthquake", "explosion", "rockslide"]
     },
     "ponyta": {
-        "level": 88,
+        "level": 87,
         "moves": ["agility", "bodyslam", "fireblast", "reflect"]
     },
     "rapidash": {
@@ -410,7 +410,7 @@
         "exclusiveMoves": ["doubleedge", "hyperbeam", "hyperbeam", "mimic", "substitute", "toxic"]
     },
     "farfetchd": {
-        "level": 77,
+        "level": 79,
         "moves": ["agility", "bodyslam", "swordsdance"],
         "essentialMove": "slash"
     },
@@ -433,7 +433,7 @@
         "exclusiveMoves": ["hyperbeam", "mimic", "rest", "rest"]
     },
     "grimer": {
-        "level": 88,
+        "level": 89,
         "moves": ["bodyslam", "sludge"],
         "essentialMove": "explosion",
         "exclusiveMoves": ["fireblast", "megadrain", "megadrain", "screech"]
@@ -445,48 +445,48 @@
         "exclusiveMoves": ["fireblast", "hyperbeam", "megadrain", "megadrain"]
     },
     "shellder": {
-        "level": 88,
+        "level": 90,
         "moves": ["blizzard", "doubleedge", "explosion", "surf"]
     },
     "cloyster": {
-        "level": 68,
+        "level": 69,
         "moves": ["blizzard", "explosion", "surf"],
         "exclusiveMoves": ["doubleedge", "hyperbeam", "hyperbeam"]
     },
     "gastly": {
-        "level": 88,
+        "level": 85,
         "moves": ["explosion", "megadrain", "nightshade", "psychic"],
         "essentialMove": "thunderbolt",
         "exclusiveMoves": ["confuseray", "hypnosis", "hypnosis"]
     },
     "haunter": {
-        "level": 74,
+        "level": 73,
         "moves": ["explosion", "megadrain", "nightshade", "psychic"],
         "essentialMove": "thunderbolt",
         "exclusiveMoves": ["confuseray", "hypnosis", "hypnosis"]
     },
     "gengar": {
-        "level": 68,
+        "level": 65,
         "moves": ["explosion", "megadrain", "nightshade", "psychic"],
         "essentialMove": "thunderbolt",
         "exclusiveMoves": ["confuseray", "hypnosis", "hypnosis"]
     },
     "onix": {
-        "level": 77,
+        "level": 78,
         "moves": ["bodyslam", "earthquake", "explosion", "rockslide"]
     },
     "drowzee": {
-        "level": 88,
+        "level": 86,
         "moves": ["hypnosis", "psychic", "thunderwave"],
         "exclusiveMoves": ["counter", "reflect", "rest", "seismictoss", "seismictoss"]
     },
     "hypno": {
-        "level": 74,
+        "level": 71,
         "moves": ["hypnosis", "psychic", "thunderwave"],
         "exclusiveMoves": ["counter", "reflect", "rest", "rest", "seismictoss", "seismictoss"]
     },
     "krabby": {
-        "level": 88,
+        "level": 89,
         "moves": ["blizzard", "bodyslam", "crabhammer", "swordsdance"]
     },
     "kingler": {
@@ -510,7 +510,7 @@
         "exclusiveMoves": ["doubleedge", "explosion", "explosion"]
     },
     "exeggutor": {
-        "level": 68,
+        "level": 67,
         "moves": ["explosion", "psychic", "sleeppowder"],
         "exclusiveMoves": ["doubleedge", "eggbomb", "hyperbeam", "megadrain", "megadrain", "stunspore", "stunspore", "stunspore"]
     },
@@ -519,21 +519,21 @@
         "moves": ["blizzard", "bodyslam", "earthquake", "seismictoss"]
     },
     "marowak": {
-        "level": 77,
+        "level": 78,
         "moves": ["blizzard", "bodyslam", "earthquake", "seismictoss"]
     },
     "hitmonlee": {
-        "level": 77,
+        "level": 78,
         "moves": ["bodyslam", "highjumpkick", "seismictoss"],
         "exclusiveMoves": ["counter", "counter", "meditate"]
     },
     "hitmonchan": {
-        "level": 77,
+        "level": 80,
         "moves": ["bodyslam", "seismictoss", "submission"],
         "exclusiveMoves": ["agility", "counter", "counter"]
     },
     "lickitung": {
-        "level": 77,
+        "level": 79,
         "moves": ["hyperbeam", "swordsdance"],
         "essentialMove": "bodyslam",
         "exclusiveMoves": ["blizzard", "earthquake", "earthquake", "earthquake"]
@@ -547,7 +547,7 @@
         "moves": ["explosion", "fireblast", "sludge", "thunderbolt"]
     },
     "rhyhorn": {
-        "level": 88,
+        "level": 86,
         "moves": ["bodyslam", "earthquake", "rockslide", "substitute"]
     },
     "rhydon": {
@@ -589,12 +589,12 @@
         "moves": ["agility", "blizzard", "doubleedge", "surf"]
     },
     "seaking": {
-        "level": 77,
+        "level": 78,
         "moves": ["blizzard", "doubleedge", "surf"],
         "exclusiveMoves": ["agility", "agility", "hyperbeam"]
     },
     "staryu": {
-        "level": 88,
+        "level": 85,
         "moves": ["blizzard", "thunderbolt", "thunderwave"],
         "essentialMove": "recover",
         "exclusiveMoves": ["hydropump", "surf", "surf"]
@@ -638,12 +638,12 @@
         "exclusiveMoves": ["blizzard", "blizzard", "blizzard", "thunderbolt"]
     },
     "gyarados": {
-        "level": 74,
+        "level": 73,
         "moves": ["blizzard", "bodyslam", "hyperbeam", "thunderbolt"],
         "exclusiveMoves": ["hydropump", "surf"]
     },
     "lapras": {
-        "level": 74,
+        "level": 71,
         "moves": ["bodyslam", "confuseray", "rest", "sing", "surf"],
         "essentialMove": "blizzard",
         "exclusiveMoves": ["thunderbolt", "thunderbolt"]
@@ -710,7 +710,7 @@
         "comboMoves": ["bodyslam", "earthquake", "hyperbeam", "selfdestruct"]
     },
     "articuno": {
-        "level": 74,
+        "level": 72,
         "moves": ["agility", "hyperbeam", "icebeam", "mimic", "reflect"],
         "essentialMove": "blizzard",
         "comboMoves": ["icebeam", "reflect", "rest"]
@@ -720,12 +720,12 @@
         "moves": ["agility", "drillpeck", "thunderbolt", "thunderwave"]
     },
     "moltres": {
-        "level": 77,
+        "level": 75,
         "moves": ["agility", "fireblast", "hyperbeam"],
         "exclusiveMoves": ["doubleedge", "reflect", "skyattack"]
     },
     "dratini": {
-        "level": 88,
+        "level": 89,
         "moves": ["bodyslam", "hyperbeam", "thunderbolt", "thunderwave"],
         "essentialMove": "blizzard"
     },
@@ -735,12 +735,12 @@
         "essentialMove": "blizzard"
     },
     "dragonite": {
-        "level": 74,
+        "level": 73,
         "moves": ["bodyslam", "hyperbeam", "thunderbolt", "thunderwave"],
         "essentialMove": "blizzard"
     },
     "mewtwo": {
-        "level": 62,
+        "level": 59,
         "moves": ["blizzard", "recover", "thunderbolt"],
         "essentialMove": "amnesia",
         "exclusiveMoves": ["psychic", "psychic"],

--- a/data/mods/gen3/random-data.json
+++ b/data/mods/gen3/random-data.json
@@ -8,7 +8,7 @@
         "moves": ["bellydrum", "dragondance", "earthquake", "fireblast", "hiddenpowerflying", "substitute"]
     },
     "blastoise": {
-        "level": 84,
+        "level": 83,
         "moves": ["earthquake", "icebeam", "mirrorcoat", "rest", "roar", "sleeptalk", "surf", "toxic"]
     },
     "butterfree": {
@@ -20,7 +20,7 @@
         "moves": ["brickbreak", "doubleedge", "endure", "hiddenpowerbug", "sludgebomb", "swordsdance"]
     },
     "pidgeot": {
-        "level": 88,
+        "level": 87,
         "moves": ["aerialace", "hiddenpowerground", "quickattack", "return", "substitute", "toxic"]
     },
     "raticate": {
@@ -52,7 +52,7 @@
         "moves": ["earthquake", "fireblast", "icebeam", "shadowball", "sludgebomb", "superpower"]
     },
     "nidoking": {
-        "level": 84,
+        "level": 83,
         "moves": ["earthquake", "fireblast", "icebeam", "megahorn", "sludgebomb", "substitute", "thunderbolt"]
     },
     "clefable": {
@@ -72,7 +72,7 @@
         "moves": ["aromatherapy", "hiddenpowerfire", "sleeppowder", "sludgebomb", "solarbeam", "sunnyday", "synthesis"]
     },
     "parasect": {
-        "level": 92,
+        "level": 93,
         "moves": ["aromatherapy", "gigadrain", "hiddenpowerbug", "return", "spore", "stunspore", "swordsdance"]
     },
     "venomoth": {
@@ -84,7 +84,7 @@
         "moves": ["aerialace", "earthquake", "hiddenpowerbug", "rockslide", "substitute"]
     },
     "persian": {
-        "level": 84,
+        "level": 85,
         "moves": ["fakeout", "hiddenpowerground", "hypnosis", "irontail", "return", "shadowball", "substitute"]
     },
     "golduck": {
@@ -136,7 +136,7 @@
         "moves": ["hiddenpowergrass", "hiddenpowerice", "rest", "sleeptalk", "thunderbolt", "toxic"]
     },
     "farfetchd": {
-        "level": 92,
+        "level": 93,
         "moves": ["agility", "batonpass", "hiddenpowerflying", "return", "swordsdance"]
     },
     "dodrio": {
@@ -204,7 +204,7 @@
         "moves": ["hiddenpowergrass", "leechseed", "morningsun", "sleeppowder", "stunspore"]
     },
     "kangaskhan": {
-        "level": 82,
+        "level": 81,
         "moves": ["earthquake", "fakeout", "focuspunch", "rest", "return", "shadowball", "substitute", "toxic"]
     },
     "seaking": {
@@ -212,7 +212,7 @@
         "moves": ["hiddenpowergrass", "hydropump", "icebeam", "megahorn", "raindance"]
     },
     "starmie": {
-        "level": 78,
+        "level": 77,
         "moves": ["hydropump", "icebeam", "psychic", "recover", "surf", "thunderbolt"]
     },
     "mrmime": {
@@ -300,7 +300,7 @@
         "moves": ["doubleedge", "dragondance", "earthquake", "flamethrower", "healbell", "hiddenpowerflying", "icebeam", "substitute"]
     },
     "mewtwo": {
-        "level": 70,
+        "level": 67,
         "moves": ["calmmind", "flamethrower", "icebeam", "psychic", "recover", "substitute", "thunderbolt"]
     },
     "mew": {
@@ -332,7 +332,7 @@
         "moves": ["agility", "batonpass", "lightscreen", "reflect", "silverwind", "swordsdance", "toxic"]
     },
     "ariados": {
-        "level": 90,
+        "level": 91,
         "moves": ["agility", "batonpass", "signalbeam", "sludgebomb", "spiderweb", "toxic"]
     },
     "crobat": {
@@ -396,11 +396,11 @@
         "moves": ["batonpass", "calmmind", "hiddenpowerfire", "morningsun", "psychic", "reflect"]
     },
     "umbreon": {
-        "level": 82,
+        "level": 83,
         "moves": ["batonpass", "hiddenpowerdark", "protect", "toxic", "wish"]
     },
     "murkrow": {
-        "level": 89,
+        "level": 90,
         "moves": ["doubleedge", "drillpeck", "hiddenpowerfighting", "hiddenpowerground", "meanlook", "perishsong", "protect", "shadowball", "substitute"]
     },
     "slowking": {
@@ -420,7 +420,7 @@
         "moves": ["counter", "destinybond", "encore", "mirrorcoat"]
     },
     "girafarig": {
-        "level": 84,
+        "level": 85,
         "moves": ["agility", "batonpass", "calmmind", "psychic", "substitute", "thunderbolt", "thunderwave", "wish"]
     },
     "forretress": {
@@ -452,7 +452,7 @@
         "moves": ["agility", "batonpass", "hiddenpowerground", "hiddenpowerrock", "morningsun", "silverwind", "steelwing", "swordsdance"]
     },
     "shuckle": {
-        "level": 92,
+        "level": 93,
         "moves": ["encore", "rest", "toxic", "wrap"]
     },
     "heracross": {
@@ -484,7 +484,7 @@
         "moves": ["fireblast", "hiddenpowergrass", "icebeam", "rockblast", "surf", "thunderwave"]
     },
     "delibird": {
-        "level": 92,
+        "level": 93,
         "moves": ["aerialace", "focuspunch", "hiddenpowerground", "icebeam", "quickattack"]
     },
     "mantine": {
@@ -520,11 +520,11 @@
         "moves": ["encore", "explosion", "spikes", "spore"]
     },
     "hitmontop": {
-        "level": 84,
+        "level": 85,
         "moves": ["bulkup", "earthquake", "hiddenpowerghost", "highjumpkick", "machpunch", "rockslide", "toxic"]
     },
     "miltank": {
-        "level": 81,
+        "level": 79,
         "moves": ["bodyslam", "curse", "earthquake", "healbell", "milkdrink", "toxic"]
     },
     "blissey": {
@@ -548,11 +548,11 @@
         "moves": ["dragondance", "earthquake", "fireblast", "focuspunch", "hiddenpowerbug", "icebeam", "pursuit", "rockslide", "substitute"]
     },
     "lugia": {
-        "level": 73,
+        "level": 72,
         "moves": ["aeroblast", "calmmind", "earthquake", "icebeam", "recover", "substitute", "thunderbolt", "toxic"]
     },
     "hooh": {
-        "level": 74,
+        "level": 73,
         "moves": ["calmmind", "earthquake", "recover", "sacredfire", "substitute", "thunderbolt", "toxic"]
     },
     "celebi": {
@@ -580,7 +580,7 @@
         "moves": ["bellydrum", "extremespeed", "flail", "hiddenpowerground", "shadowball", "substitute"]
     },
     "beautifly": {
-        "level": 93,
+        "level": 94,
         "moves": ["hiddenpowerbug", "hiddenpowerflying", "morningsun", "stunspore", "substitute", "toxic"]
     },
     "dustox": {
@@ -612,11 +612,11 @@
         "moves": ["hydropump", "icebeam", "stunspore", "substitute", "toxic"]
     },
     "breloom": {
-        "level": 82,
+        "level": 83,
         "moves": ["focuspunch", "hiddenpowerghost", "hiddenpowerrock", "leechseed", "machpunch", "skyuppercut", "spore", "substitute", "swordsdance"]
     },
     "vigoroth": {
-        "level": 87,
+        "level": 86,
         "moves": ["brickbreak", "bulkup", "earthquake", "return", "shadowball", "slackoff"]
     },
     "slaking": {
@@ -652,7 +652,7 @@
         "moves": ["knockoff", "recover", "seismictoss", "shadowball", "toxic"]
     },
     "mawile": {
-        "level": 92,
+        "level": 93,
         "moves": ["batonpass", "brickbreak", "focuspunch", "hiddenpowersteel", "rockslide", "substitute", "swordsdance", "toxic"]
     },
     "aggron": {
@@ -680,7 +680,7 @@
         "moves": ["batonpass", "icepunch", "tailglow", "thunderbolt"]
     },
     "illumise": {
-        "level": 91,
+        "level": 92,
         "moves": ["batonpass", "encore", "icepunch", "substitute", "thunderwave", "wish"]
     },
     "roselia": {
@@ -712,7 +712,7 @@
         "moves": ["calmmind", "firepunch", "icywind", "psychic", "substitute", "taunt"]
     },
     "spinda": {
-        "level": 92,
+        "level": 93,
         "moves": ["bodyslam", "encore", "focuspunch", "shadowball", "substitute", "teeterdance", "toxic"]
     },
     "flygon": {
@@ -728,7 +728,7 @@
         "moves": ["dragonclaw", "dragondance", "earthquake", "fireblast", "flamethrower", "haze", "hiddenpowerflying", "rest", "toxic"]
     },
     "zangoose": {
-        "level": 82,
+        "level": 81,
         "moves": ["brickbreak", "quickattack", "return", "shadowball", "swordsdance"]
     },
     "seviper": {
@@ -772,7 +772,7 @@
         "moves": ["flamethrower", "icebeam", "substitute", "thunderbolt", "thunderwave"]
     },
     "kecleon": {
-        "level": 88,
+        "level": 89,
         "moves": ["brickbreak", "return", "shadowball", "thunderwave", "trick"]
     },
     "banette": {
@@ -784,7 +784,7 @@
         "moves": ["focuspunch", "icebeam", "painsplit", "rest", "shadowball", "sleeptalk", "substitute", "willowisp"]
     },
     "tropius": {
-        "level": 90,
+        "level": 91,
         "moves": ["hiddenpowerfire", "solarbeam", "sunnyday", "synthesis"]
     },
     "chimecho": {
@@ -816,15 +816,15 @@
         "moves": ["doubleedge", "earthquake", "hiddenpowerflying", "rest", "rockslide", "sleeptalk", "toxic"]
     },
     "luvdisc": {
-        "level": 94,
+        "level": 95,
         "moves": ["icebeam", "protect", "substitute", "surf", "sweetkiss", "toxic"]
     },
     "salamence": {
-        "level": 77,
+        "level": 76,
         "moves": ["brickbreak", "dragondance", "earthquake", "fireblast", "hiddenpowerflying", "rockslide"]
     },
     "metagross": {
-        "level": 79,
+        "level": 78,
         "moves": ["agility", "earthquake", "explosion", "meteormash", "psychic", "rockslide"]
     },
     "regirock": {
@@ -832,7 +832,7 @@
         "moves": ["curse", "earthquake", "explosion", "rest", "rockslide", "superpower", "thunderwave"]
     },
     "regice": {
-        "level": 82,
+        "level": 81,
         "moves": ["explosion", "icebeam", "rest", "sleeptalk", "thunderbolt", "thunderwave", "toxic"]
     },
     "registeel": {
@@ -848,7 +848,7 @@
         "moves": ["calmmind", "dragonclaw", "hiddenpowerfire", "psychic", "recover"]
     },
     "kyogre": {
-        "level": 70,
+        "level": 69,
         "moves": ["calmmind", "icebeam", "rest", "sleeptalk", "surf", "thunder"]
     },
     "groudon": {
@@ -856,7 +856,7 @@
         "moves": ["earthquake", "hiddenpowerbug", "overheat", "rockslide", "substitute", "swordsdance", "thunderwave"]
     },
     "rayquaza": {
-        "level": 73,
+        "level": 72,
         "moves": ["dragondance", "earthquake", "extremespeed", "hiddenpowerflying", "overheat", "rockslide"]
     },
     "jirachi": {
@@ -868,7 +868,7 @@
         "moves": ["extremespeed", "firepunch", "icebeam", "psychoboost", "shadowball", "superpower"]
     },
     "deoxysattack": {
-        "level": 75,
+        "level": 74,
         "moves": ["extremespeed", "firepunch", "psychoboost", "shadowball", "superpower"]
     },
     "deoxysdefense": {

--- a/data/mods/gen4/random-data.json
+++ b/data/mods/gen4/random-data.json
@@ -4,7 +4,7 @@
         "moves": ["earthquake", "hiddenpowerice", "leafstorm", "leechseed", "powerwhip", "sleeppowder", "sludgebomb", "swordsdance", "synthesis"]
     },
     "charizard": {
-        "level": 85,
+        "level": 84,
         "moves": ["airslash", "dragonpulse", "fireblast", "flamethrower", "hiddenpowergrass", "roost"]
     },
     "blastoise": {
@@ -40,7 +40,7 @@
         "moves": ["grassknot", "hiddenpowerice", "substitute", "surf", "thunderbolt", "volttackle"]
     },
     "raichu": {
-        "level": 88,
+        "level": 87,
         "moves": ["encore", "focusblast", "focuspunch", "grassknot", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"]
     },
     "sandslash": {
@@ -60,7 +60,7 @@
         "moves": ["calmmind", "doubleedge", "fireblast", "icebeam", "softboiled", "stealthrock", "thunderbolt"]
     },
     "ninetales": {
-        "level": 86,
+        "level": 85,
         "moves": ["energyball", "fireblast", "flamethrower", "hiddenpowerrock", "hypnosis", "nastyplot"]
     },
     "wigglytuff": {
@@ -72,7 +72,7 @@
         "moves": ["energyball", "hiddenpowerfire", "moonlight", "sleeppowder", "sludgebomb", "solarbeam", "sunnyday"]
     },
     "parasect": {
-        "level": 92,
+        "level": 93,
         "moves": ["leechseed", "seedbomb", "spore", "stunspore", "synthesis", "xscissor"]
     },
     "venomoth": {
@@ -96,7 +96,7 @@
         "moves": ["closecombat", "encore", "icepunch", "punishment", "stoneedge", "uturn"]
     },
     "arcanine": {
-        "level": 84,
+        "level": 83,
         "moves": ["extremespeed", "flareblitz", "hiddenpowergrass", "morningsun", "thunderfang", "toxic", "willowisp"]
     },
     "poliwrath": {
@@ -156,7 +156,7 @@
         "moves": ["focusblast", "hiddenpowerfire", "hypnosis", "painsplit", "shadowball", "sludgebomb", "substitute", "thunderbolt", "trick"]
     },
     "hypno": {
-        "level": 88,
+        "level": 89,
         "moves": ["protect", "seismictoss", "thunderwave", "toxic", "wish"]
     },
     "kingler": {
@@ -168,7 +168,7 @@
         "moves": ["explosion", "hiddenpowerice", "signalbeam", "taunt", "thunderbolt"]
     },
     "exeggutor": {
-        "level": 85,
+        "level": 86,
         "moves": ["explosion", "hiddenpowerfire", "leafstorm", "psychic", "sleeppowder", "solarbeam", "sunnyday", "synthesis"]
     },
     "marowak": {
@@ -208,7 +208,7 @@
         "moves": ["aerialace", "brickbreak", "bugbite", "pursuit", "quickattack", "roost", "swordsdance", "uturn"]
     },
     "jynx": {
-        "level": 86,
+        "level": 85,
         "moves": ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psychic", "substitute"]
     },
     "pinsir": {
@@ -216,7 +216,7 @@
         "moves": ["closecombat", "earthquake", "quickattack", "stealthrock", "stoneedge", "swordsdance", "xscissor"]
     },
     "tauros": {
-        "level": 82,
+        "level": 81,
         "moves": ["doubleedge", "earthquake", "payback", "pursuit", "return", "stoneedge"]
     },
     "gyarados": {
@@ -240,7 +240,7 @@
         "moves": ["batonpass", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderbolt", "yawn"]
     },
     "flareon": {
-        "level": 91,
+        "level": 92,
         "moves": ["fireblast", "hiddenpowergrass", "lavaplume", "protect", "superpower", "toxic", "wish"]
     },
     "omastar": {
@@ -256,11 +256,11 @@
         "moves": ["earthquake", "rockslide", "roost", "stealthrock", "stoneedge", "taunt"]
     },
     "snorlax": {
-        "level": 82,
+        "level": 81,
         "moves": ["bodyslam", "crunch", "curse", "earthquake", "firepunch", "pursuit", "rest", "return", "selfdestruct", "sleeptalk", "whirlwind"]
     },
     "articuno": {
-        "level": 86,
+        "level": 85,
         "moves": ["healbell", "icebeam", "roar", "roost", "substitute", "toxic"]
     },
     "zapdos": {
@@ -272,7 +272,7 @@
         "moves": ["airslash", "fireblast", "flamethrower", "hiddenpowergrass", "roost", "substitute", "toxic", "uturn"]
     },
     "dragonite": {
-        "level": 80,
+        "level": 79,
         "moves": ["dracometeor", "dragonclaw", "dragondance", "earthquake", "extremespeed", "fireblast", "firepunch", "outrage", "roost", "superpower"]
     },
     "mewtwo": {
@@ -284,7 +284,7 @@
         "moves": ["aurasphere", "explosion", "flamethrower", "nastyplot", "psychic", "softboiled", "stealthrock", "taunt", "uturn", "willowisp"]
     },
     "meganium": {
-        "level": 88,
+        "level": 89,
         "moves": ["aromatherapy", "energyball", "leechseed", "lightscreen", "reflect", "synthesis", "toxic"]
     },
     "typhlosion": {
@@ -300,11 +300,11 @@
         "moves": ["aquatail", "brickbreak", "doubleedge", "firepunch", "return", "shadowclaw", "suckerpunch", "trick", "uturn"]
     },
     "noctowl": {
-        "level": 92,
+        "level": 93,
         "moves": ["nightshade", "reflect", "roost", "toxic", "whirlwind"]
     },
     "ledian": {
-        "level": 93,
+        "level": 95,
         "moves": ["encore", "knockoff", "lightscreen", "reflect", "roost", "toxic", "uturn"]
     },
     "ariados": {
@@ -336,7 +336,7 @@
         "moves": ["aquajet", "doubleedge", "icepunch", "return", "superpower", "waterfall"]
     },
     "sudowoodo": {
-        "level": 89,
+        "level": 90,
         "moves": ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic", "woodhammer"]
     },
     "politoed": {
@@ -348,7 +348,7 @@
         "moves": ["bounce", "encore", "grassknot", "leechseed", "sleeppowder", "stunspore", "substitute", "toxic", "uturn"]
     },
     "sunflora": {
-        "level": 91,
+        "level": 93,
         "moves": ["earthpower", "hiddenpowerice", "leafstorm", "sludgebomb", "synthesis"]
     },
     "quagsire": {
@@ -356,11 +356,11 @@
         "moves": ["earthquake", "encore", "icepunch", "recover", "toxic", "waterfall", "yawn"]
     },
     "espeon": {
-        "level": 85,
+        "level": 83,
         "moves": ["batonpass", "calmmind", "hiddenpowerfire", "morningsun", "psychic", "shadowball", "substitute"]
     },
     "umbreon": {
-        "level": 82,
+        "level": 83,
         "moves": ["curse", "healbell", "moonlight", "payback", "protect", "toxic", "wish"]
     },
     "slowking": {
@@ -372,11 +372,11 @@
         "moves": ["hiddenpowerpsychic"]
     },
     "wobbuffet": {
-        "level": 78,
+        "level": 79,
         "moves": ["counter", "destinybond", "encore", "mirrorcoat"]
     },
     "girafarig": {
-        "level": 90,
+        "level": 91,
         "moves": ["batonpass", "calmmind", "hiddenpowerfighting", "psychic", "thunderbolt"]
     },
     "forretress": {
@@ -416,7 +416,7 @@
         "moves": ["closecombat", "crunch", "earthquake", "facade", "protect", "swordsdance"]
     },
     "magcargo": {
-        "level": 89,
+        "level": 90,
         "moves": ["fireblast", "hiddenpowerrock", "lavaplume", "recover", "stealthrock", "toxic", "willowisp"]
     },
     "corsola": {
@@ -452,7 +452,7 @@
         "moves": ["assurance", "earthquake", "iceshard", "rapidspin", "seedbomb", "stealthrock", "stoneedge"]
     },
     "porygon2": {
-        "level": 87,
+        "level": 86,
         "moves": ["discharge", "icebeam", "recover", "toxic", "triattack"]
     },
     "stantler": {
@@ -488,7 +488,7 @@
         "moves": ["calmmind", "hiddenpowerelectric", "icebeam", "rest", "roar", "sleeptalk", "surf"]
     },
     "tyranitar": {
-        "level": 80,
+        "level": 79,
         "moves": ["crunch", "dragondance", "earthquake", "fireblast", "firepunch", "icebeam", "icepunch", "pursuit", "stealthrock", "stoneedge", "superpower"]
     },
     "lugia": {
@@ -516,7 +516,7 @@
         "moves": ["earthquake", "icebeam", "icepunch", "roar", "stealthrock", "stoneedge", "waterfall"]
     },
     "mightyena": {
-        "level": 89,
+        "level": 90,
         "moves": ["crunch", "firefang", "suckerpunch", "superfang", "taunt", "toxic"]
     },
     "linoone": {
@@ -528,7 +528,7 @@
         "moves": ["bugbuzz", "hiddenpowerground", "psychic", "uturn"]
     },
     "dustox": {
-        "level": 92,
+        "level": 94,
         "moves": ["bugbuzz", "protect", "roost", "toxic", "whirlwind"]
     },
     "ludicolo": {
@@ -540,7 +540,7 @@
         "moves": ["darkpulse", "explosion", "hiddenpowerfire", "leafstorm", "lowkick", "seedbomb", "solarbeam", "suckerpunch", "sunnyday", "swordsdance"]
     },
     "swellow": {
-        "level": 84,
+        "level": 83,
         "moves": ["bravebird", "facade", "protect", "quickattack", "uturn"]
     },
     "pelipper": {
@@ -548,11 +548,11 @@
         "moves": ["airslash", "hiddenpowergrass", "hydropump", "roost", "surf", "toxic", "uturn"]
     },
     "gardevoir": {
-        "level": 88,
+        "level": 87,
         "moves": ["calmmind", "focusblast", "psychic", "shadowball", "taunt", "thunderbolt", "willowisp"]
     },
     "masquerain": {
-        "level": 90,
+        "level": 92,
         "moves": ["agility", "airslash", "batonpass", "bugbuzz", "hydropump", "roost"]
     },
     "breloom": {
@@ -564,7 +564,7 @@
         "moves": ["bulkup", "earthquake", "encore", "lowkick", "nightslash", "return", "slackoff", "substitute", "suckerpunch"]
     },
     "slaking": {
-        "level": 86,
+        "level": 85,
         "moves": ["doubleedge", "earthquake", "firepunch", "icepunch", "nightslash", "pursuit", "return"]
     },
     "ninjask": {
@@ -584,19 +584,19 @@
         "moves": ["bulletpunch", "closecombat", "facade", "fakeout", "focuspunch", "icepunch", "payback", "stoneedge", "substitute"]
     },
     "delcatty": {
-        "level": 94,
+        "level": 96,
         "moves": ["healbell", "protect", "return", "sing", "thunderwave", "wish"]
     },
     "sableye": {
-        "level": 93,
+        "level": 94,
         "moves": ["recover", "seismictoss", "taunt", "toxic", "willowisp"]
     },
     "mawile": {
-        "level": 92,
+        "level": 94,
         "moves": ["batonpass", "focuspunch", "ironhead", "substitute", "suckerpunch", "swordsdance"]
     },
     "aggron": {
-        "level": 85,
+        "level": 86,
         "moves": ["aquatail", "earthquake", "headsmash", "icepunch", "lowkick", "rockpolish"]
     },
     "medicham": {
@@ -616,7 +616,7 @@
         "moves": ["batonpass", "encore", "hiddenpowerice", "nastyplot", "thunderbolt"]
     },
     "volbeat": {
-        "level": 91,
+        "level": 92,
         "moves": ["batonpass", "bugbuzz", "encore", "substitute", "tailglow"]
     },
     "illumise": {
@@ -664,7 +664,7 @@
         "moves": ["dragonclaw", "dragondance", "earthquake", "fireblast", "healbell", "outrage", "roost"]
     },
     "zangoose": {
-        "level": 87,
+        "level": 86,
         "moves": ["closecombat", "quickattack", "return", "shadowclaw", "swordsdance"]
     },
     "seviper": {
@@ -672,7 +672,7 @@
         "moves": ["aquatail", "darkpulse", "earthquake", "flamethrower", "sludgebomb", "suckerpunch", "switcheroo"]
     },
     "lunatone": {
-        "level": 90,
+        "level": 91,
         "moves": ["batonpass", "calmmind", "earthpower", "psychic", "shadowball", "substitute"]
     },
     "solrock": {
@@ -708,7 +708,7 @@
         "moves": ["energyball", "fireblast", "icebeam", "shadowball", "thunderbolt"]
     },
     "kecleon": {
-        "level": 90,
+        "level": 91,
         "moves": ["aquatail", "recover", "return", "stealthrock", "thunderwave", "toxic"]
     },
     "banette": {
@@ -716,11 +716,11 @@
         "moves": ["destinybond", "hiddenpowerfighting", "shadowclaw", "shadowsneak", "taunt", "thunderwave", "willowisp"]
     },
     "tropius": {
-        "level": 91,
+        "level": 92,
         "moves": ["aerialace", "curse", "dragondance", "earthquake", "leafblade", "leafstorm", "leechseed", "roost", "swordsdance", "toxic", "whirlwind"]
     },
     "chimecho": {
-        "level": 91,
+        "level": 92,
         "moves": ["calmmind", "hiddenpowerfire", "psychic", "recover", "signalbeam", "thunderwave", "yawn"]
     },
     "absol": {
@@ -736,7 +736,7 @@
         "moves": ["encore", "icebeam", "protect", "rest", "roar", "sleeptalk", "surf", "toxic"]
     },
     "huntail": {
-        "level": 88,
+        "level": 89,
         "moves": ["doubleedge", "hiddenpowergrass", "hydropump", "icebeam", "raindance", "suckerpunch", "surf"]
     },
     "gorebyss": {
@@ -748,7 +748,7 @@
         "moves": ["doubleedge", "earthquake", "headsmash", "rockpolish", "stealthrock", "waterfall"]
     },
     "luvdisc": {
-        "level": 94,
+        "level": 97,
         "moves": ["icebeam", "protect", "surf", "sweetkiss", "toxic"]
     },
     "salamence": {
@@ -760,11 +760,11 @@
         "moves": ["agility", "bulletpunch", "earthquake", "explosion", "meteormash", "stealthrock", "zenheadbutt"]
     },
     "regirock": {
-        "level": 86,
+        "level": 85,
         "moves": ["earthquake", "explosion", "rest", "rockslide", "sleeptalk", "stealthrock", "thunderwave"]
     },
     "regice": {
-        "level": 84,
+        "level": 83,
         "moves": ["focusblast", "icebeam", "rest", "sleeptalk", "thunderbolt", "thunderwave"]
     },
     "registeel": {
@@ -772,7 +772,7 @@
         "moves": ["curse", "ironhead", "rest", "sleeptalk", "stealthrock", "thunderwave", "toxic"]
     },
     "latias": {
-        "level": 74,
+        "level": 71,
         "moves": ["calmmind", "dracometeor", "psychic", "roost"]
     },
     "latios": {
@@ -792,7 +792,7 @@
         "moves": ["dragonclaw", "dragondance", "earthquake", "extremespeed", "outrage", "overheat", "swordsdance"]
     },
     "jirachi": {
-        "level": 77,
+        "level": 76,
         "moves": ["bodyslam", "calmmind", "firepunch", "flashcannon", "icepunch", "ironhead", "psychic", "stealthrock", "substitute", "thunderbolt", "uturn", "wish"]
     },
     "deoxys": {
@@ -812,7 +812,7 @@
         "moves": ["lightscreen", "psychoboost", "reflect", "spikes", "stealthrock", "superpower", "taunt"]
     },
     "torterra": {
-        "level": 85,
+        "level": 86,
         "moves": ["earthquake", "leechseed", "roar", "rockpolish", "stealthrock", "stoneedge", "synthesis", "woodhammer"]
     },
     "infernape": {
@@ -828,11 +828,11 @@
         "moves": ["bravebird", "closecombat", "doubleedge", "pursuit", "quickattack", "return", "roost", "substitute", "uturn"]
     },
     "bibarel": {
-        "level": 91,
+        "level": 92,
         "moves": ["curse", "quickattack", "rest", "waterfall"]
     },
     "kricketune": {
-        "level": 93,
+        "level": 96,
         "moves": ["brickbreak", "nightslash", "return", "swordsdance", "xscissor"]
     },
     "luxray": {
@@ -844,19 +844,19 @@
         "moves": ["energyball", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "rest", "sleeppowder", "sludgebomb", "spikes", "toxicspikes"]
     },
     "rampardos": {
-        "level": 88,
+        "level": 89,
         "moves": ["earthquake", "firepunch", "icebeam", "rockpolish", "stoneedge", "zenheadbutt"]
     },
     "bastiodon": {
-        "level": 88,
+        "level": 89,
         "moves": ["earthquake", "metalburst", "protect", "roar", "rockslide", "stealthrock", "toxic"]
     },
     "wormadam": {
-        "level": 93,
+        "level": 94,
         "moves": ["hiddenpowerice", "hiddenpowerrock", "leafstorm", "psychic", "signalbeam"]
     },
     "wormadamsandy": {
-        "level": 92,
+        "level": 93,
         "moves": ["earthquake", "rest", "sleeptalk", "toxic"]
     },
     "wormadamtrash": {
@@ -868,11 +868,11 @@
         "moves": ["airslash", "bugbuzz", "hiddenpowerfighting", "hiddenpowerground", "shadowball", "uturn"]
     },
     "vespiquen": {
-        "level": 93,
+        "level": 94,
         "moves": ["attackorder", "defendorder", "protect", "roost", "substitute", "toxic"]
     },
     "pachirisu": {
-        "level": 91,
+        "level": 94,
         "moves": ["discharge", "lightscreen", "superfang", "toxic", "uturn"]
     },
     "floatzel": {
@@ -880,11 +880,11 @@
         "moves": ["aquajet", "batonpass", "bulkup", "crunch", "icepunch", "return", "taunt", "waterfall"]
     },
     "cherrim": {
-        "level": 91,
+        "level": 92,
         "moves": ["aromatherapy", "energyball", "hiddenpowerfire", "hiddenpowerground", "synthesis", "toxic"]
     },
     "cherrimsunshine": {
-        "level": 91,
+        "level": 92,
         "moves": ["hiddenpowerice", "solarbeam", "sunnyday", "weatherball"]
     },
     "gastrodon": {
@@ -952,7 +952,7 @@
         "moves": ["crosschop", "focuspunch", "icepunch", "substitute", "suckerpunch", "swordsdance"]
     },
     "carnivine": {
-        "level": 91,
+        "level": 93,
         "moves": ["powerwhip", "return", "sleeppowder", "substitute", "swordsdance", "synthesis"]
     },
     "lumineon": {
@@ -988,7 +988,7 @@
         "moves": ["crosschop", "earthquake", "flamethrower", "hiddenpowergrass", "icepunch", "thunderbolt"]
     },
     "magmortar": {
-        "level": 87,
+        "level": 85,
         "moves": ["fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderbolt"]
     },
     "togekiss": {
@@ -1012,7 +1012,7 @@
         "moves": ["earthquake", "roost", "stealthrock", "stoneedge", "swordsdance", "taunt", "toxic", "uturn"]
     },
     "mamoswine": {
-        "level": 82,
+        "level": 81,
         "moves": ["earthquake", "endeavor", "iceshard", "stealthrock", "stoneedge", "superpower"]
     },
     "porygonz": {
@@ -1048,7 +1048,7 @@
         "moves": ["blizzard", "discharge", "lightscreen", "reflect", "rest", "shadowball", "sleeptalk", "thunderbolt", "trick", "willowisp"]
     },
     "rotomfan": {
-        "level": 80,
+        "level": 79,
         "moves": ["discharge", "lightscreen", "painsplit", "reflect", "rest", "shadowball", "sleeptalk", "thunderbolt", "willowisp"]
     },
     "rotommow": {
@@ -1060,7 +1060,7 @@
         "moves": ["hiddenpowerfighting", "hiddenpowerfire", "shadowball", "thunderbolt", "trick"]
     },
     "uxie": {
-        "level": 83,
+        "level": 82,
         "moves": ["lightscreen", "psychic", "reflect", "stealthrock", "thunderwave", "uturn", "yawn"]
     },
     "mesprit": {
@@ -1068,7 +1068,7 @@
         "moves": ["calmmind", "hiddenpowerfire", "icebeam", "psychic", "stealthrock", "substitute", "thunderbolt", "thunderwave", "uturn"]
     },
     "azelf": {
-        "level": 80,
+        "level": 78,
         "moves": ["explosion", "fireblast", "flamethrower", "hiddenpowerfighting", "nastyplot", "psychic", "stealthrock", "thunderbolt", "uturn"]
     },
     "dialga": {
@@ -1080,11 +1080,11 @@
         "moves": ["aurasphere", "dracometeor", "fireblast", "hydropump", "spacialrend", "surf", "thunderbolt"]
     },
     "heatran": {
-        "level": 79,
+        "level": 78,
         "moves": ["dragonpulse", "earthpower", "explosion", "fireblast", "hiddenpowergrass", "lavaplume", "protect", "roar", "stealthrock", "substitute", "toxic"]
     },
     "regigigas": {
-        "level": 87,
+        "level": 86,
         "moves": ["confuseray", "earthquake", "firepunch", "return", "substitute", "thunderwave", "toxic"]
     },
     "giratinaorigin": {
@@ -1100,7 +1100,7 @@
         "moves": ["calmmind", "hiddenpowerfire", "icebeam", "lightscreen", "moonlight", "psychic", "reflect", "substitute", "thunderwave", "toxic"]
     },
     "phione": {
-        "level": 88,
+        "level": 89,
         "moves": ["icebeam", "raindance", "rest", "surf", "toxic"]
     },
     "manaphy": {
@@ -1108,7 +1108,7 @@
         "moves": ["energyball", "icebeam", "surf", "tailglow"]
     },
     "darkrai": {
-        "level": 72,
+        "level": 71,
         "moves": ["darkpulse", "darkvoid", "focusblast", "nastyplot", "substitute"]
     },
     "shaymin": {

--- a/data/mods/gen5/random-data.json
+++ b/data/mods/gen5/random-data.json
@@ -12,7 +12,7 @@
         "moves": ["icebeam", "protect", "rapidspin", "scald", "toxic"]
     },
     "butterfree": {
-        "level": 90,
+        "level": 91,
         "moves": ["bugbuzz", "hiddenpowerrock", "psychic", "quiverdance", "sleeppowder", "substitute"]
     },
     "beedrill": {
@@ -32,7 +32,7 @@
         "moves": ["doubleedge", "drillpeck", "drillrun", "pursuit", "quickattack", "return", "roost", "uturn"]
     },
     "arbok": {
-        "level": 90,
+        "level": 91,
         "moves": ["aquatail", "coil", "earthquake", "glare", "gunkshot", "rest", "seedbomb", "suckerpunch"]
     },
     "pikachu": {
@@ -40,7 +40,7 @@
         "moves": ["extremespeed", "grassknot", "hiddenpowerice", "voltswitch", "volttackle"]
     },
     "raichu": {
-        "level": 90,
+        "level": 89,
         "moves": ["encore", "focusblast", "grassknot", "hiddenpowerice", "nastyplot", "thunderbolt", "voltswitch"]
     },
     "sandslash": {
@@ -172,7 +172,7 @@
         "moves": ["gigadrain", "hiddenpowerfire", "leechseed", "protect", "psychic", "sleeppowder", "substitute"]
     },
     "marowak": {
-        "level": 90,
+        "level": 89,
         "moves": ["bonemerang", "doubleedge", "earthquake", "firepunch", "stealthrock", "stoneedge"]
     },
     "hitmonlee": {
@@ -216,7 +216,7 @@
         "moves": ["aerialace", "brickbreak", "bugbite", "quickattack", "roost", "swordsdance"]
     },
     "jynx": {
-        "level": 86,
+        "level": 85,
         "moves": ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psyshock", "substitute", "trick"]
     },
     "pinsir": {
@@ -288,11 +288,11 @@
         "moves": ["dragondance", "earthquake", "extremespeed", "firepunch", "outrage", "roost"]
     },
     "mewtwo": {
-        "level": 72,
+        "level": 71,
         "moves": ["aurasphere", "calmmind", "fireblast", "psystrike", "recover", "shadowball"]
     },
     "mew": {
-        "level": 81,
+        "level": 80,
         "moves": ["aurasphere", "fireblast", "nastyplot", "psychic", "softboiled", "stealthrock", "taunt", "uturn", "willowisp"]
     },
     "meganium": {
@@ -316,11 +316,11 @@
         "moves": ["airslash", "magiccoat", "nightshade", "roost", "toxic", "whirlwind"]
     },
     "ledian": {
-        "level": 94,
+        "level": 97,
         "moves": ["encore", "lightscreen", "reflect", "roost", "toxic", "uturn"]
     },
     "ariados": {
-        "level": 93,
+        "level": 94,
         "moves": ["poisonjab", "suckerpunch", "toxicspikes", "xscissor"]
     },
     "crobat": {
@@ -360,7 +360,7 @@
         "moves": ["acrobatics", "encore", "energyball", "leechseed", "sleeppowder", "uturn"]
     },
     "sunflora": {
-        "level": 92,
+        "level": 93,
         "moves": ["earthpower", "encore", "gigadrain", "hiddenpowerrock", "solarbeam", "sunnyday"]
     },
     "quagsire": {
@@ -388,7 +388,7 @@
         "moves": ["hiddenpowerpsychic"]
     },
     "wobbuffet": {
-        "level": 84,
+        "level": 85,
         "moves": ["counter", "destinybond", "encore", "mirrorcoat"]
     },
     "girafarig": {
@@ -428,7 +428,7 @@
         "moves": ["encore", "knockoff", "protect", "stealthrock", "toxic"]
     },
     "heracross": {
-        "level": 82,
+        "level": 81,
         "moves": ["closecombat", "earthquake", "facade", "megahorn", "stoneedge"]
     },
     "ursaring": {
@@ -488,7 +488,7 @@
         "moves": ["closecombat", "machpunch", "rapidspin", "stoneedge", "suckerpunch", "toxic"]
     },
     "miltank": {
-        "level": 85,
+        "level": 84,
         "moves": ["bodyslam", "earthquake", "healbell", "milkdrink", "stealthrock", "toxic"]
     },
     "blissey": {
@@ -512,7 +512,7 @@
         "moves": ["crunch", "fireblast", "pursuit", "stealthrock", "stoneedge", "superpower"]
     },
     "lugia": {
-        "level": 75,
+        "level": 74,
         "moves": ["aeroblast", "earthquake", "roost", "substitute", "toxic", "whirlwind"]
     },
     "hooh": {
@@ -580,11 +580,11 @@
         "moves": ["bulletseed", "machpunch", "spore", "stoneedge", "swordsdance"]
     },
     "vigoroth": {
-        "level": 88,
+        "level": 87,
         "moves": ["bulkup", "earthquake", "return", "slackoff", "taunt", "toxic"]
     },
     "slaking": {
-        "level": 88,
+        "level": 86,
         "moves": ["earthquake", "nightslash", "pursuit", "retaliate", "return"]
     },
     "ninjask": {
@@ -616,7 +616,7 @@
         "moves": ["firefang", "ironhead", "stealthrock", "suckerpunch", "swordsdance"]
     },
     "aggron": {
-        "level": 84,
+        "level": 85,
         "moves": ["aquatail", "earthquake", "headsmash", "heavyslam", "rockpolish", "stealthrock", "thunderwave"]
     },
     "medicham": {
@@ -636,7 +636,7 @@
         "moves": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"]
     },
     "volbeat": {
-        "level": 89,
+        "level": 90,
         "moves": ["bugbuzz", "encore", "roost", "thunderwave", "uturn"]
     },
     "illumise": {
@@ -668,7 +668,7 @@
         "moves": ["focusblast", "healbell", "psychic", "shadowball", "thunderwave", "trick", "whirlwind"]
     },
     "spinda": {
-        "level": 93,
+        "level": 95,
         "moves": ["return", "suckerpunch", "superpower", "trickroom"]
     },
     "flygon": {
@@ -676,11 +676,11 @@
         "moves": ["earthquake", "firepunch", "outrage", "roost", "stoneedge", "superpower", "uturn"]
     },
     "cacturne": {
-        "level": 86,
+        "level": 87,
         "moves": ["drainpunch", "seedbomb", "spikes", "substitute", "suckerpunch", "swordsdance"]
     },
     "altaria": {
-        "level": 86,
+        "level": 87,
         "moves": ["dracometeor", "dragondance", "earthquake", "fireblast", "healbell", "outrage", "roost"]
     },
     "zangoose": {
@@ -736,11 +736,11 @@
         "moves": ["foulplay", "recover", "stealthrock", "thunderwave", "toxic"]
     },
     "banette": {
-        "level": 89,
+        "level": 90,
         "moves": ["pursuit", "shadowclaw", "shadowsneak", "trick", "willowisp"]
     },
     "dusclops": {
-        "level": 83,
+        "level": 84,
         "moves": ["nightshade", "rest", "sleeptalk", "willowisp"]
     },
     "tropius": {
@@ -764,11 +764,11 @@
         "moves": ["encore", "icebeam", "protect", "roar", "surf", "toxic"]
     },
     "huntail": {
-        "level": 87,
+        "level": 86,
         "moves": ["icebeam", "return", "shellsmash", "waterfall"]
     },
     "gorebyss": {
-        "level": 85,
+        "level": 83,
         "moves": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"]
     },
     "relicanth": {
@@ -784,7 +784,7 @@
         "moves": ["aquatail", "brickbreak", "dracometeor", "dragondance", "earthquake", "fireblast", "outrage", "roost"]
     },
     "metagross": {
-        "level": 82,
+        "level": 81,
         "moves": ["agility", "bulletpunch", "earthquake", "meteormash", "pursuit", "stealthrock", "zenheadbutt"]
     },
     "regirock": {
@@ -800,7 +800,7 @@
         "moves": ["curse", "ironhead", "protect", "rest", "sleeptalk", "stealthrock", "toxic"]
     },
     "latias": {
-        "level": 76,
+        "level": 75,
         "moves": ["calmmind", "dracometeor", "psyshock", "roost"]
     },
     "latios": {
@@ -828,7 +828,7 @@
         "moves": ["extremespeed", "hiddenpowerfire", "icebeam", "psychoboost", "stealthrock", "superpower"]
     },
     "deoxysattack": {
-        "level": 75,
+        "level": 74,
         "moves": ["extremespeed", "hiddenpowerfire", "icebeam", "psychoboost", "stealthrock", "superpower"]
     },
     "deoxysdefense": {
@@ -860,7 +860,7 @@
         "moves": ["curse", "quickattack", "rest", "waterfall"]
     },
     "kricketune": {
-        "level": 95,
+        "level": 96,
         "moves": ["brickbreak", "bugbite", "nightslash", "return", "swordsdance"]
     },
     "luxray": {
@@ -868,11 +868,11 @@
         "moves": ["crunch", "facade", "icefang", "superpower", "voltswitch", "wildcharge"]
     },
     "roserade": {
-        "level": 82,
+        "level": 83,
         "moves": ["gigadrain", "hiddenpowerfire", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"]
     },
     "rampardos": {
-        "level": 88,
+        "level": 89,
         "moves": ["crunch", "earthquake", "firepunch", "headsmash", "rockpolish", "superpower"]
     },
     "bastiodon": {
@@ -880,7 +880,7 @@
         "moves": ["metalburst", "protect", "roar", "rockblast", "stealthrock", "toxic"]
     },
     "wormadam": {
-        "level": 94,
+        "level": 95,
         "moves": ["gigadrain", "hiddenpowerrock", "leafstorm", "protect", "signalbeam", "toxic"]
     },
     "wormadamsandy": {
@@ -892,15 +892,15 @@
         "moves": ["ironhead", "protect", "stealthrock", "toxic"]
     },
     "mothim": {
-        "level": 91,
+        "level": 92,
         "moves": ["airslash", "bugbuzz", "hiddenpowerground", "quiverdance", "substitute"]
     },
     "vespiquen": {
-        "level": 93,
+        "level": 94,
         "moves": ["attackorder", "protect", "roost", "substitute", "toxic"]
     },
     "pachirisu": {
-        "level": 90,
+        "level": 91,
         "moves": ["protect", "superfang", "thunderwave", "toxic", "voltswitch"]
     },
     "floatzel": {
@@ -984,7 +984,7 @@
         "moves": ["icebeam", "protect", "scald", "toxic", "uturn"]
     },
     "abomasnow": {
-        "level": 82,
+        "level": 83,
         "moves": ["blizzard", "earthquake", "hiddenpowerfire", "iceshard", "leechseed", "woodhammer"]
     },
     "weavile": {
@@ -1068,7 +1068,7 @@
         "moves": ["hiddenpowergrass", "overheat", "painsplit", "thunderbolt", "thunderwave", "trick", "voltswitch", "willowisp"]
     },
     "rotomwash": {
-        "level": 80,
+        "level": 81,
         "moves": ["hiddenpowerice", "hydropump", "painsplit", "thunderbolt", "thunderwave", "trick", "voltswitch", "willowisp"]
     },
     "rotomfrost": {
@@ -1096,11 +1096,11 @@
         "moves": ["energyball", "fireblast", "nastyplot", "psychic", "stealthrock", "taunt", "trick", "uturn"]
     },
     "dialga": {
-        "level": 73,
+        "level": 72,
         "moves": ["aurasphere", "dracometeor", "dragontail", "fireblast", "stealthrock", "thunderbolt"]
     },
     "palkia": {
-        "level": 75,
+        "level": 74,
         "moves": ["dracometeor", "dragontail", "fireblast", "hydropump", "spacialrend", "surf", "thunderbolt"]
     },
     "heatran": {
@@ -1112,11 +1112,11 @@
         "moves": ["confuseray", "return", "rockslide", "substitute", "thunderwave"]
     },
     "giratinaorigin": {
-        "level": 76,
+        "level": 75,
         "moves": ["dracometeor", "earthquake", "hiddenpowerfire", "shadowsneak", "willowisp"]
     },
     "giratina": {
-        "level": 74,
+        "level": 73,
         "moves": ["calmmind", "dragonpulse", "dragontail", "rest", "sleeptalk", "willowisp"]
     },
     "cresselia": {
@@ -1140,7 +1140,7 @@
         "moves": ["earthpower", "hiddenpowerfire", "leechseed", "psychic", "rest", "seedflare"]
     },
     "shayminsky": {
-        "level": 75,
+        "level": 74,
         "moves": ["airslash", "earthpower", "hiddenpowerfire", "hiddenpowerice", "leechseed", "seedflare", "substitute"]
     },
     "arceus": {
@@ -1212,7 +1212,7 @@
         "moves": ["brickbreak", "extremespeed", "recover", "swordsdance", "waterfall"]
     },
     "victini": {
-        "level": 82,
+        "level": 81,
         "moves": ["blueflare", "boltstrike", "energyball", "focusblast", "glaciate", "trick", "uturn", "vcreate"]
     },
     "serperior": {
@@ -1248,7 +1248,7 @@
         "moves": ["fireblast", "focusblast", "grassknot", "hiddenpowerrock", "nastyplot", "substitute"]
     },
     "simipour": {
-        "level": 88,
+        "level": 87,
         "moves": ["focusblast", "hiddenpowergrass", "hydropump", "icebeam", "nastyplot", "substitute"]
     },
     "musharna": {
@@ -1276,7 +1276,7 @@
         "moves": ["earthquake", "ironhead", "rapidspin", "rockslide", "swordsdance"]
     },
     "audino": {
-        "level": 88,
+        "level": 89,
         "moves": ["doubleedge", "healbell", "magiccoat", "protect", "toxic", "wish"]
     },
     "conkeldurr": {
@@ -1328,7 +1328,7 @@
         "moves": ["earthquake", "flareblitz", "rockslide", "superpower", "uturn"]
     },
     "maractus": {
-        "level": 89,
+        "level": 90,
         "moves": ["gigadrain", "hiddenpowerfire", "leechseed", "spikes", "toxic"]
     },
     "crustle": {
@@ -1344,7 +1344,7 @@
         "moves": ["cosmicpower", "psychoshift", "roost", "storedpower"]
     },
     "cofagrigus": {
-        "level": 83,
+        "level": 84,
         "moves": ["haze", "hiddenpowerfighting", "nastyplot", "painsplit", "shadowball", "trickroom", "willowisp"]
     },
     "carracosta": {
@@ -1367,7 +1367,7 @@
         "moves": ["bulletseed", "rockblast", "tailslap", "uturn"]
     },
     "gothitelle": {
-        "level": 85,
+        "level": 86,
         "moves": ["calmmind", "hiddenpowerfighting", "psychic", "rest", "thunderbolt", "trick"]
     },
     "reuniclus": {
@@ -1407,11 +1407,11 @@
         "moves": ["protect", "scald", "toxic", "waterfall", "wish"]
     },
     "galvantula": {
-        "level": 84,
+        "level": 83,
         "moves": ["bugbuzz", "gigadrain", "hiddenpowerice", "thunder", "voltswitch"]
     },
     "ferrothorn": {
-        "level": 80,
+        "level": 79,
         "moves": ["gyroball", "leechseed", "powerwhip", "protect", "spikes", "stealthrock", "toxic"]
     },
     "klinklang": {
@@ -1495,7 +1495,7 @@
         "moves": ["bugbuzz", "fierydance", "fireblast", "gigadrain", "hiddenpowerground", "quiverdance", "roost"]
     },
     "cobalion": {
-        "level": 81,
+        "level": 80,
         "moves": ["closecombat", "hiddenpowerice", "ironhead", "stealthrock", "stoneedge", "swordsdance", "taunt", "thunderwave", "voltswitch"]
     },
     "terrakion": {
@@ -1547,7 +1547,7 @@
         "moves": ["dragonclaw", "earthpower", "fusionbolt", "icebeam", "roost", "substitute"]
     },
     "kyuremwhite": {
-        "level": 75,
+        "level": 74,
         "moves": ["dracometeor", "earthpower", "focusblast", "fusionflare", "icebeam", "roost", "substitute"]
     },
     "keldeo": {
@@ -1563,7 +1563,7 @@
         "moves": ["closecombat", "icepunch", "relicsong", "return", "shadowclaw"]
     },
     "genesect": {
-        "level": 76,
+        "level": 75,
         "moves": ["bugbuzz", "flamethrower", "icebeam", "ironhead", "rockpolish", "thunderbolt", "uturn"]
     }
 }

--- a/data/mods/gen6/random-data.json
+++ b/data/mods/gen6/random-data.json
@@ -10,7 +10,7 @@
         "doublesMoves": ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "powerwhip", "protect", "sleeppowder", "sludgebomb"]
     },
     "charizardmegax": {
-        "level": 79,
+        "level": 78,
         "moves": ["dragonclaw", "dragondance", "earthquake", "flareblitz", "roost", "willowisp"],
         "doublesMoves": ["dragonclaw", "dragondance", "earthquake", "flareblitz", "rockslide", "roost", "substitute"]
     },
@@ -20,7 +20,7 @@
         "doublesMoves": ["airslash", "dragonpulse", "fireblast", "heatwave", "overheat", "protect", "roost", "tailwind"]
     },
     "charizardmegay": {
-        "level": 79,
+        "level": 78,
         "moves": ["airslash", "dragonpulse", "fireblast", "focusblast", "roost", "solarbeam"],
         "doublesMoves": ["airslash", "fireblast", "focusblast", "heatwave", "protect", "roost", "solarbeam"]
     },
@@ -120,7 +120,7 @@
         "doublesMoves": ["dazzlinggleam", "gigadrain", "hiddenpowerfire", "moonblast", "protect", "sleeppowder", "sludgebomb", "stunspore"]
     },
     "parasect": {
-        "level": 90,
+        "level": 91,
         "moves": ["knockoff", "leechseed", "seedbomb", "spore", "substitute", "xscissor"],
         "doublesMoves": ["knockoff", "leechseed", "protect", "ragepowder", "seedbomb", "spore", "stunspore", "wideguard", "xscissor"]
     },
@@ -130,7 +130,7 @@
         "doublesMoves": ["bugbuzz", "gigadrain", "protect", "psychic", "quiverdance", "ragepowder", "roost", "sleeppowder", "sludgebomb", "substitute"]
     },
     "dugtrio": {
-        "level": 83,
+        "level": 84,
         "moves": ["earthquake", "reversal", "stealthrock", "stoneedge", "substitute", "suckerpunch"],
         "doublesMoves": ["earthquake", "protect", "rockslide", "stoneedge", "suckerpunch"]
     },
@@ -155,7 +155,7 @@
         "doublesMoves": ["closecombat", "extremespeed", "flareblitz", "protect", "snarl", "wildcharge", "willowisp"]
     },
     "poliwrath": {
-        "level": 86,
+        "level": 87,
         "moves": ["circlethrow", "focusblast", "hydropump", "icepunch", "raindance", "rest", "scald", "sleeptalk"],
         "doublesMoves": ["bellydrum", "brickbreak", "earthquake", "encore", "icepunch", "protect", "rockslide", "waterfall"]
     },
@@ -205,7 +205,7 @@
         "doublesMoves": ["fireblast", "grassknot", "icebeam", "protect", "psychic", "psyshock", "scald", "slackoff", "thunderwave", "trickroom"]
     },
     "farfetchd": {
-        "level": 93,
+        "level": 95,
         "moves": ["bravebird", "knockoff", "leafblade", "return", "swordsdance"],
         "doublesMoves": ["bravebird", "leafblade", "nightslash", "protect", "return", "swordsdance"]
     },
@@ -255,7 +255,7 @@
         "doublesMoves": ["discharge", "foulplay", "hiddenpowerice", "protect", "taunt", "thunderwave", "voltswitch"]
     },
     "exeggutor": {
-        "level": 89,
+        "level": 90,
         "moves": ["gigadrain", "hiddenpowerfire", "leechseed", "psychic", "sleeppowder", "substitute"],
         "doublesMoves": ["gigadrain", "hiddenpowerfire", "leechseed", "protect", "psychic", "psyshock", "sleeppowder", "substitute", "trickroom"]
     },
@@ -314,7 +314,7 @@
         "doublesMoves": ["dazzlinggleam", "encore", "fakeout", "hiddenpowerfighting", "icywind", "protect", "teeterdance", "thunderbolt", "thunderwave", "wideguard"]
     },
     "scyther": {
-        "level": 86,
+        "level": 85,
         "moves": ["aerialace", "brickbreak", "bugbite", "knockoff", "quickattack", "roost", "swordsdance", "uturn"],
         "doublesMoves": ["aerialace", "brickbreak", "bugbite", "feint", "knockoff", "protect", "quickattack", "swordsdance", "uturn"]
     },
@@ -339,7 +339,7 @@
         "doublesMoves": ["doubleedge", "earthquake", "protect", "return", "rockslide", "stoneedge", "zenheadbutt"]
     },
     "gyarados": {
-        "level": 80,
+        "level": 79,
         "moves": ["bounce", "dragondance", "earthquake", "stoneedge", "substitute", "waterfall"],
         "doublesMoves": ["bounce", "dragondance", "earthquake", "icefang", "protect", "stoneedge", "substitute", "taunt", "thunderwave", "waterfall"]
     },
@@ -363,7 +363,7 @@
         "doublesMoves": ["helpinghand", "hydropump", "icebeam", "muddywater", "protect", "scald", "toxic", "wish"]
     },
     "jolteon": {
-        "level": 83,
+        "level": 82,
         "moves": ["hiddenpowerice", "shadowball", "signalbeam", "thunderbolt", "voltswitch"],
         "doublesMoves": ["helpinghand", "hiddenpowergrass", "hiddenpowerice", "protect", "signalbeam", "substitute", "thunderbolt", "voltswitch"]
     },
@@ -373,7 +373,7 @@
         "doublesMoves": ["facade", "flamecharge", "flareblitz", "helpinghand", "protect", "superpower", "wish"]
     },
     "omastar": {
-        "level": 86,
+        "level": 85,
         "moves": ["earthpower", "hydropump", "icebeam", "shellsmash", "spikes", "stealthrock"],
         "doublesMoves": ["earthpower", "hiddenpowerelectric", "hydropump", "icebeam", "muddywater", "protect", "shellsmash"]
     },
@@ -456,12 +456,12 @@
         "doublesMoves": ["doubleedge", "firepunch", "followme", "helpinghand", "icepunch", "knockoff", "protect", "suckerpunch", "superfang", "uturn"]
     },
     "noctowl": {
-        "level": 89,
+        "level": 90,
         "moves": ["airslash", "defog", "nightshade", "roost", "toxic", "whirlwind"],
         "doublesMoves": ["airslash", "heatwave", "hypervoice", "hypnosis", "protect", "roost", "tailwind"]
     },
     "ledian": {
-        "level": 93,
+        "level": 94,
         "moves": ["knockoff", "lightscreen", "reflect", "roost", "toxic", "uturn"],
         "doublesMoves": ["bugbuzz", "encore", "knockoff", "lightscreen", "protect", "reflect", "tailwind", "uturn"]
     },
@@ -481,7 +481,7 @@
         "doublesMoves": ["discharge", "hiddenpowergrass", "hydropump", "icebeam", "protect", "scald", "surf", "thunderbolt", "thunderwave"]
     },
     "xatu": {
-        "level": 86,
+        "level": 87,
         "moves": ["calmmind", "heatwave", "psychic", "roost", "thunderwave", "toxic", "uturn"],
         "doublesMoves": ["grassknot", "heatwave", "lightscreen", "protect", "psychic", "reflect", "roost", "tailwind", "thunderwave", "uturn"]
     },
@@ -496,7 +496,7 @@
         "doublesMoves": ["discharge", "dragonpulse", "focusblast", "hiddenpowergrass", "hiddenpowerice", "protect", "thunderbolt"]
     },
     "bellossom": {
-        "level": 89,
+        "level": 90,
         "moves": ["gigadrain", "hiddenpowerfire", "sleeppowder", "sunnyday", "synthesis"],
         "doublesMoves": ["dazzlinggleam", "gigadrain", "hiddenpowerfire", "moonblast", "protect", "sleeppowder", "sludgebomb", "solarbeam", "stunspore", "sunnyday"]
     },
@@ -521,7 +521,7 @@
         "doublesMoves": ["encore", "gigadrain", "helpinghand", "leechseed", "protect", "ragepowder", "sleeppowder", "uturn"]
     },
     "sunflora": {
-        "level": 91,
+        "level": 92,
         "moves": ["earthpower", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "sludgebomb"],
         "doublesMoves": ["earthpower", "encore", "gigadrain", "hiddenpowerfire", "hiddenpowerice", "protect", "solarbeam", "sunnyday"]
     },
@@ -628,7 +628,7 @@
         "doublesMoves": ["ancientpower", "earthpower", "fireblast", "heatwave", "hiddenpowergrass", "protect", "shellsmash", "stealthrock", "willowisp"]
     },
     "corsola": {
-        "level": 90,
+        "level": 91,
         "moves": ["powergem", "recover", "scald", "stealthrock", "toxic"],
         "doublesMoves": ["earthpower", "icebeam", "icywind", "powergem", "protect", "scald", "stealthrock"]
     },
@@ -658,7 +658,7 @@
         "doublesMoves": ["darkpulse", "heatwave", "hiddenpowerfighting", "nastyplot", "protect", "suckerpunch"]
     },
     "houndoommega": {
-        "level": 82,
+        "level": 81,
         "moves": ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "taunt"],
         "doublesMoves": ["darkpulse", "heatwave", "hiddenpowergrass", "nastyplot", "protect", "taunt"]
     },
@@ -688,7 +688,7 @@
         "doublesMoves": ["fakeout", "followme", "helpinghand", "kingsshield", "spore", "tailwind", "transform", "wideguard"]
     },
     "hitmontop": {
-        "level": 84,
+        "level": 85,
         "moves": ["closecombat", "rapidspin", "stoneedge", "suckerpunch", "toxic"],
         "doublesMoves": ["closecombat", "fakeout", "feint", "helpinghand", "machpunch", "suckerpunch", "wideguard"]
     },
@@ -781,7 +781,7 @@
         "doublesMoves": ["bellydrum", "extremespeed", "protect", "seedbomb", "shadowclaw"]
     },
     "beautifly": {
-        "level": 90,
+        "level": 91,
         "moves": ["bugbuzz", "energyball", "hiddenpowerfighting", "psychic", "quiverdance"],
         "doublesMoves": ["aircutter", "bugbuzz", "gigadrain", "hiddenpowerrock", "protect", "quiverdance", "stringshot", "tailwind"]
     },
@@ -816,7 +816,7 @@
         "doublesMoves": ["dazzlinggleam", "focusblast", "helpinghand", "moonblast", "protect", "psyshock", "shadowball", "taunt", "thunderbolt", "trickroom", "willowisp"]
     },
     "gardevoirmega": {
-        "level": 80,
+        "level": 79,
         "moves": ["calmmind", "focusblast", "hypervoice", "psyshock", "substitute", "taunt", "willowisp"],
         "doublesMoves": ["calmmind", "focusblast", "hypervoice", "protect", "psyshock", "shadowball", "thunderbolt"]
     },
@@ -831,7 +831,7 @@
         "doublesMoves": ["bulletseed", "drainpunch", "helpinghand", "machpunch", "protect", "rocktomb", "spore"]
     },
     "slaking": {
-        "level": 85,
+        "level": 84,
         "moves": ["earthquake", "firepunch", "gigaimpact", "nightslash", "pursuit", "retaliate"],
         "doublesMoves": ["doubleedge", "earthquake", "hammerarm", "nightslash", "retaliate", "rockslide"]
     },
@@ -925,7 +925,7 @@
         "doublesMoves": ["encore", "helpinghand", "protect", "stringshot", "strugglebug", "tailwind", "thunderwave"]
     },
     "illumise": {
-        "level": 88,
+        "level": 89,
         "moves": ["bugbuzz", "encore", "roost", "thunderwave", "uturn", "wish"],
         "doublesMoves": ["bugbuzz", "encore", "helpinghand", "protect", "tailwind", "thunderbolt", "uturn"]
     },
@@ -1004,7 +1004,7 @@
         "doublesMoves": ["aquatail", "earthquake", "flamethrower", "gigadrain", "glare", "poisonjab", "protect", "sludgebomb", "suckerpunch"]
     },
     "lunatone": {
-        "level": 88,
+        "level": 89,
         "moves": ["ancientpower", "calmmind", "earthpower", "icebeam", "moonlight", "psychic", "rockpolish", "stealthrock", "toxic"],
         "doublesMoves": ["ancientpower", "calmmind", "earthpower", "helpinghand", "icebeam", "moonlight", "protect", "psychic", "rockpolish", "trickroom"]
     },
@@ -1056,7 +1056,7 @@
         "moves": ["blizzard", "fireblast", "hail", "thunderbolt"]
     },
     "kecleon": {
-        "level": 86,
+        "level": 87,
         "moves": ["drainpunch", "fakeout", "knockoff", "recover", "shadowsneak", "stealthrock", "suckerpunch"],
         "doublesMoves": ["drainpunch", "fakeout", "knockoff", "protect", "recover", "shadowsneak", "suckerpunch", "trickroom"]
     },
@@ -1076,7 +1076,7 @@
         "doublesMoves": ["airslash", "earthquake", "gigadrain", "hiddenpowerfire", "leechseed", "protect", "roost", "sunnyday", "tailwind"]
     },
     "chimecho": {
-        "level": 90,
+        "level": 91,
         "moves": ["calmmind", "healbell", "healingwish", "knockoff", "psychic", "recover", "shadowball", "taunt", "toxic", "yawn"],
         "doublesMoves": ["dazzlinggleam", "helpinghand", "protect", "psychic", "recover", "shadowball", "taunt", "thunderwave", "trickroom"]
     },
@@ -1111,7 +1111,7 @@
         "doublesMoves": ["icefang", "protect", "shellsmash", "suckerpunch", "waterfall"]
     },
     "gorebyss": {
-        "level": 87,
+        "level": 86,
         "moves": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"],
         "doublesMoves": ["hiddenpowergrass", "icebeam", "protect", "shellsmash", "substitute", "surf"]
     },
@@ -1125,7 +1125,7 @@
         "moves": ["icebeam", "protect", "scald", "sweetkiss", "toxic"]
     },
     "salamence": {
-        "level": 81,
+        "level": 80,
         "moves": ["dracometeor", "dragonclaw", "dragondance", "earthquake", "fireblast", "outrage", "roost"],
         "doublesMoves": ["dracometeor", "dragonclaw", "dragondance", "earthquake", "fireblast", "hydropump", "protect", "rockslide", "tailwind"]
     },
@@ -1135,7 +1135,7 @@
         "doublesMoves": ["doubleedge", "dracometeor", "dragonclaw", "dragondance", "earthquake", "fireblast", "protect", "return"]
     },
     "metagross": {
-        "level": 82,
+        "level": 81,
         "moves": ["agility", "bulletpunch", "earthquake", "explosion", "icepunch", "meteormash", "stealthrock", "thunderpunch", "zenheadbutt"],
         "doublesMoves": ["bulletpunch", "earthquake", "explosion", "hammerarm", "icepunch", "meteormash", "protect", "thunderpunch", "zenheadbutt"]
     },
@@ -1180,7 +1180,7 @@
         "doublesMoves": ["dracometeor", "dragonpulse", "hiddenpowerfire", "protect", "psyshock", "substitute", "surf", "tailwind", "thunderbolt", "trick"]
     },
     "kyogre": {
-        "level": 72,
+        "level": 71,
         "moves": ["icebeam", "originpulse", "scald", "thunder", "waterspout"],
         "doublesMoves": ["calmmind", "icebeam", "muddywater", "originpulse", "protect", "rest", "sleeptalk", "thunder", "waterspout"]
     },
@@ -1195,7 +1195,7 @@
         "doublesMoves": ["dragonclaw", "firepunch", "precipiceblades", "protect", "rockpolish", "rockslide", "stoneedge", "swordsdance"]
     },
     "groudonprimal": {
-        "level": 71,
+        "level": 68,
         "moves": ["dragontail", "firepunch", "lavaplume", "precipiceblades", "rockpolish", "stealthrock", "stoneedge", "swordsdance"],
         "doublesMoves": ["firepunch", "lavaplume", "overheat", "precipiceblades", "protect", "rockpolish", "rockslide", "stoneedge", "swordsdance"]
     },
@@ -1215,7 +1215,7 @@
         "doublesMoves": ["bodyslam", "followme", "helpinghand", "icywind", "ironhead", "protect", "thunderwave", "trickroom", "uturn", "zenheadbutt"]
     },
     "deoxys": {
-        "level": 76,
+        "level": 77,
         "moves": ["extremespeed", "firepunch", "knockoff", "psychoboost", "spikes", "stealthrock", "superpower", "taunt"],
         "doublesMoves": ["extremespeed", "firepunch", "icebeam", "knockoff", "protect", "psychoboost", "psyshock", "superpower", "thunderbolt"]
     },
@@ -1225,7 +1225,7 @@
         "doublesMoves": ["extremespeed", "firepunch", "icebeam", "knockoff", "protect", "psychoboost", "superpower", "thunderbolt"]
     },
     "deoxysdefense": {
-        "level": 78,
+        "level": 79,
         "moves": ["knockoff", "recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"],
         "doublesMoves": ["lightscreen", "protect", "recover", "reflect", "seismictoss", "stealthrock", "taunt", "trickroom"]
     },
@@ -1260,7 +1260,7 @@
         "doublesMoves": ["curse", "protect", "quickattack", "rest", "return", "waterfall"]
     },
     "kricketune": {
-        "level": 88,
+        "level": 89,
         "moves": ["endeavor", "knockoff", "stickyweb", "taunt", "toxic", "xscissor"],
         "doublesMoves": ["bugbite", "knockoff", "protect", "stickyweb", "taunt"]
     },
@@ -1285,7 +1285,7 @@
         "doublesMoves": ["guardsplit", "metalburst", "protect", "stealthrock", "stoneedge", "wideguard"]
     },
     "wormadam": {
-        "level": 93,
+        "level": 95,
         "moves": ["gigadrain", "hiddenpowerrock", "protect", "signalbeam", "synthesis", "toxic"],
         "doublesMoves": ["gigadrain", "hiddenpowerice", "hiddenpowerrock", "leafstorm", "protect", "signalbeam", "stringshot"]
     },
@@ -1300,12 +1300,12 @@
         "doublesMoves": ["flashcannon", "protect", "stringshot", "strugglebug"]
     },
     "mothim": {
-        "level": 89,
+        "level": 90,
         "moves": ["airslash", "bugbuzz", "energyball", "quiverdance", "uturn"],
         "doublesMoves": ["airslash", "bugbuzz", "gigadrain", "protect", "quiverdance", "roost"]
     },
     "vespiquen": {
-        "level": 93,
+        "level": 94,
         "moves": ["airslash", "defog", "roost", "toxic", "uturn"],
         "doublesMoves": ["attackorder", "healorder", "protect", "stringshot", "strugglebug", "tailwind"]
     },
@@ -1383,12 +1383,12 @@
         "doublesMoves": ["boomburst", "chatter", "encore", "heatwave", "hypervoice", "nastyplot", "protect", "substitute", "uturn"]
     },
     "spiritomb": {
-        "level": 85,
+        "level": 87,
         "moves": ["calmmind", "darkpulse", "psychic", "pursuit", "rest", "shadowsneak", "sleeptalk", "willowisp"],
         "doublesMoves": ["darkpulse", "foulplay", "icywind", "painsplit", "protect", "shadowsneak", "snarl", "willowisp"]
     },
     "garchomp": {
-        "level": 79,
+        "level": 78,
         "moves": ["dragonclaw", "earthquake", "fireblast", "firefang", "outrage", "stealthrock", "stoneedge", "swordsdance"],
         "doublesMoves": ["dragonclaw", "earthquake", "protect", "rockslide", "stoneedge", "substitute", "swordsdance"]
     },
@@ -1423,7 +1423,7 @@
         "doublesMoves": ["drainpunch", "fakeout", "gunkshot", "icepunch", "knockoff", "protect", "substitute", "suckerpunch", "swordsdance"]
     },
     "carnivine": {
-        "level": 90,
+        "level": 92,
         "moves": ["knockoff", "powerwhip", "return", "sleeppowder", "substitute", "swordsdance"],
         "doublesMoves": ["knockoff", "leechseed", "powerwhip", "protect", "ragepowder", "return", "sleeppowder", "substitute", "swordsdance"]
     },
@@ -1443,7 +1443,7 @@
         "doublesMoves": ["blizzard", "earthquake", "focusblast", "gigadrain", "iceshard", "protect", "woodhammer"]
     },
     "weavile": {
-        "level": 80,
+        "level": 79,
         "moves": ["iceshard", "iciclecrash", "knockoff", "lowkick", "pursuit", "swordsdance"],
         "doublesMoves": ["fakeout", "feint", "iceshard", "iciclecrash", "knockoff", "lowkick", "protect", "swordsdance", "taunt"]
     },
@@ -1463,7 +1463,7 @@
         "doublesMoves": ["earthquake", "hammerarm", "megahorn", "protect", "rockslide", "stealthrock", "stoneedge"]
     },
     "tangrowth": {
-        "level": 83,
+        "level": 84,
         "moves": ["earthquake", "gigadrain", "hiddenpowerfire", "knockoff", "leafstorm", "rockslide", "sleeppowder", "synthesis"],
         "doublesMoves": ["earthquake", "focusblast", "gigadrain", "hiddenpowerice", "knockoff", "leechseed", "powerwhip", "protect", "ragepowder", "sleeppowder"]
     },
@@ -1502,7 +1502,7 @@
         "doublesMoves": ["earthquake", "knockoff", "protect", "stoneedge", "substitute", "tailwind", "taunt"]
     },
     "mamoswine": {
-        "level": 80,
+        "level": 79,
         "moves": ["earthquake", "iceshard", "iciclecrash", "knockoff", "stealthrock", "superpower"],
         "doublesMoves": ["earthquake", "iceshard", "iciclecrash", "knockoff", "protect", "rockslide", "superpower"]
     },
@@ -1517,7 +1517,7 @@
         "doublesMoves": ["closecombat", "drainpunch", "helpinghand", "icepunch", "knockoff", "protect", "shadowsneak", "stoneedge", "trick", "trickroom", "zenheadbutt"]
     },
     "gallademega": {
-        "level": 81,
+        "level": 80,
         "moves": ["closecombat", "drainpunch", "knockoff", "substitute", "swordsdance", "zenheadbutt"],
         "doublesMoves": ["closecombat", "drainpunch", "icepunch", "knockoff", "protect", "stoneedge", "swordsdance", "zenheadbutt"]
     },
@@ -1597,7 +1597,7 @@
         "doublesMoves": ["earthpower", "eruption", "heatwave", "protect", "substitute", "willowisp"]
     },
     "regigigas": {
-        "level": 85,
+        "level": 84,
         "moves": ["confuseray", "drainpunch", "knockoff", "return", "substitute", "thunderwave"],
         "doublesMoves": ["earthquake", "icywind", "knockoff", "return", "rockslide", "substitute", "thunderwave", "wideguard"]
     },
@@ -1622,7 +1622,7 @@
         "doublesMoves": ["helpinghand", "icebeam", "icywind", "protect", "raindance", "rest", "scald", "uturn"]
     },
     "manaphy": {
-        "level": 79,
+        "level": 78,
         "moves": ["energyball", "icebeam", "surf", "tailglow"],
         "doublesMoves": ["energyball", "helpinghand", "icebeam", "icywind", "protect", "scald", "surf", "tailglow"]
     },
@@ -1752,7 +1752,7 @@
         "doublesMoves": ["aquajet", "helpinghand", "hiddenpowergrass", "hydropump", "icebeam", "protect", "scald", "taunt"]
     },
     "watchog": {
-        "level": 89,
+        "level": 90,
         "moves": ["hypnosis", "knockoff", "return", "substitute", "superfang", "swordsdance"],
         "doublesMoves": ["hypnosis", "knockoff", "protect", "return", "substitute", "superfang", "swordsdance"]
     },
@@ -1797,7 +1797,7 @@
         "doublesMoves": ["hiddenpowergrass", "overheat", "protect", "voltswitch", "wildcharge"]
     },
     "gigalith": {
-        "level": 86,
+        "level": 85,
         "moves": ["earthquake", "explosion", "stealthrock", "stoneedge", "superpower"],
         "doublesMoves": ["autotomize", "earthquake", "explosion", "protect", "rockslide", "stealthrock", "stoneedge", "superpower", "wideguard"]
     },
@@ -1887,7 +1887,7 @@
         "doublesMoves": ["gigadrain", "grassyterrain", "helpinghand", "hiddenpowerfire", "leechseed", "spikyshield", "suckerpunch"]
     },
     "crustle": {
-        "level": 87,
+        "level": 86,
         "moves": ["earthquake", "shellsmash", "spikes", "stealthrock", "stoneedge", "xscissor"],
         "doublesMoves": ["earthquake", "protect", "rockslide", "shellsmash", "stoneedge", "xscissor"]
     },
@@ -1986,7 +1986,7 @@
         "doublesMoves": ["bugbuzz", "gigadrain", "hiddenpowerice", "protect", "stickyweb", "thunder", "voltswitch"]
     },
     "ferrothorn": {
-        "level": 80,
+        "level": 79,
         "moves": ["gyroball", "knockoff", "leechseed", "powerwhip", "protect", "spikes", "stealthrock"],
         "doublesMoves": ["gyroball", "knockoff", "leechseed", "powerwhip", "protect", "stealthrock"]
     },
@@ -2011,7 +2011,7 @@
         "doublesMoves": ["energyball", "heatwave", "hiddenpowerice", "overheat", "protect", "shadowball", "trick"]
     },
     "haxorus": {
-        "level": 80,
+        "level": 79,
         "moves": ["dragondance", "earthquake", "outrage", "poisonjab", "swordsdance"],
         "doublesMoves": ["dragonclaw", "dragondance", "earthquake", "poisonjab", "protect", "substitute", "swordsdance"]
     },
@@ -2026,7 +2026,7 @@
         "doublesMoves": ["freezedry", "hiddenpowerground", "icebeam", "icywind", "protect", "recover", "reflect"]
     },
     "accelgor": {
-        "level": 84,
+        "level": 85,
         "moves": ["bugbuzz", "encore", "energyball", "focusblast", "hiddenpowerrock", "spikes", "yawn"],
         "doublesMoves": ["bugbuzz", "encore", "focusblast", "gigadrain", "hiddenpowerrock", "protect", "sludgebomb", "yawn"]
     },
@@ -2076,7 +2076,7 @@
         "doublesMoves": ["fireblast", "focusblast", "gigadrain", "heatwave", "protect", "suckerpunch"]
     },
     "durant": {
-        "level": 82,
+        "level": 81,
         "moves": ["honeclaws", "ironhead", "rockslide", "superpower", "xscissor"],
         "doublesMoves": ["honeclaws", "ironhead", "protect", "rockslide", "superpower", "xscissor"]
     },
@@ -2091,7 +2091,7 @@
         "doublesMoves": ["bugbuzz", "fierydance", "fireblast", "gigadrain", "heatwave", "hiddenpowerice", "protect", "quiverdance", "ragepowder", "roost", "tailwind", "willowisp"]
     },
     "cobalion": {
-        "level": 81,
+        "level": 80,
         "moves": ["closecombat", "ironhead", "stealthrock", "stoneedge", "substitute", "swordsdance", "taunt", "voltswitch"],
         "doublesMoves": ["closecombat", "ironhead", "protect", "stoneedge", "substitute", "swordsdance", "thunderwave"]
     },
@@ -2141,7 +2141,7 @@
         "doublesMoves": ["earthpower", "focusblast", "hiddenpowerice", "protect", "psychic", "rockslide", "sludgebomb"]
     },
     "landorustherian": {
-        "level": 80,
+        "level": 79,
         "moves": ["earthquake", "rockpolish", "stealthrock", "stoneedge", "superpower", "swordsdance", "uturn"],
         "doublesMoves": ["earthquake", "knockoff", "protect", "rockslide", "stoneedge", "superpower", "uturn"]
     },
@@ -2176,7 +2176,7 @@
         "doublesMoves": ["closecombat", "knockoff", "protect", "relicsong", "return"]
     },
     "genesect": {
-        "level": 76,
+        "level": 75,
         "moves": ["blazekick", "extremespeed", "flamethrower", "icebeam", "ironhead", "shiftgear", "technoblast", "thunderbolt", "uturn"],
         "doublesMoves": ["blazekick", "bugbuzz", "extremespeed", "flamethrower", "icebeam", "ironhead", "protect", "shiftgear", "thunderbolt", "uturn"]
     },
@@ -2221,7 +2221,7 @@
         "doublesMoves": ["aromatherapy", "calmmind", "dazzlinggleam", "lightofruin", "protect", "psychic", "wish"]
     },
     "florges": {
-        "level": 82,
+        "level": 83,
         "moves": ["aromatherapy", "calmmind", "moonblast", "protect", "synthesis", "toxic", "wish"],
         "doublesMoves": ["aromatherapy", "calmmind", "dazzlinggleam", "moonblast", "protect", "psychic", "wish"]
     },
@@ -2256,17 +2256,17 @@
         "doublesMoves": ["ironhead", "protect", "rockslide", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"]
     },
     "aegislash": {
-        "level": 77,
+        "level": 78,
         "moves": ["flashcannon", "hiddenpowerice", "kingsshield", "shadowball", "shadowsneak"],
         "doublesMoves": ["flashcannon", "hiddenpowerice", "kingsshield", "shadowball", "shadowsneak"]
     },
     "aegislashblade": {
-        "level": 77,
+        "level": 78,
         "moves": ["ironhead", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"],
         "doublesMoves": ["ironhead", "kingsshield", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"]
     },
     "aromatisse": {
-        "level": 86,
+        "level": 87,
         "moves": ["aromatherapy", "moonblast", "protect", "toxic", "wish"],
         "doublesMoves": ["aromatherapy", "healpulse", "moonblast", "protect", "thunderbolt", "trickroom", "wish"]
     },
@@ -2276,12 +2276,12 @@
         "doublesMoves": ["bellydrum", "dazzlinggleam", "drainpunch", "flamethrower", "playrough", "protect", "psychic", "return", "surf"]
     },
     "malamar": {
-        "level": 84,
+        "level": 83,
         "moves": ["knockoff", "psychocut", "rest", "sleeptalk", "superpower"],
         "doublesMoves": ["knockoff", "protect", "psychocut", "rockslide", "superpower", "trickroom"]
     },
     "barbaracle": {
-        "level": 86,
+        "level": 85,
         "moves": ["crosschop", "earthquake", "razorshell", "shellsmash", "stealthrock", "stoneedge"],
         "doublesMoves": ["crosschop", "earthquake", "protect", "razorshell", "rockslide", "shellsmash"]
     },
@@ -2341,7 +2341,7 @@
         "doublesMoves": ["dazzlinggleam", "flashcannon", "lightscreen", "playrough", "protect", "reflect", "safeguard", "substitute", "thunderwave"]
     },
     "trevenant": {
-        "level": 88,
+        "level": 89,
         "moves": ["earthquake", "hornleech", "rest", "rockslide", "shadowclaw", "trickroom", "woodhammer"],
         "doublesMoves": ["earthquake", "hornleech", "leechseed", "protect", "rockslide", "shadowclaw", "trickroom", "willowisp", "woodhammer"]
     },
@@ -2366,7 +2366,7 @@
         "doublesMoves": ["explosion", "leechseed", "painsplit", "phantomforce", "protect", "seedbomb", "shadowsneak", "trickroom", "willowisp"]
     },
     "avalugg": {
-        "level": 88,
+        "level": 89,
         "moves": ["avalanche", "earthquake", "rapidspin", "recover", "roar", "toxic"],
         "doublesMoves": ["avalanche", "earthquake", "protect", "recover"]
     },
@@ -2376,17 +2376,17 @@
         "doublesMoves": ["airslash", "boomburst", "dracometeor", "dragonpulse", "flamethrower", "focusblast", "hurricane", "protect", "roost", "switcheroo", "tailwind", "taunt", "uturn"]
     },
     "xerneas": {
-        "level": 70,
+        "level": 67,
         "moves": ["focusblast", "geomancy", "hiddenpowerfire", "moonblast", "psyshock", "thunderbolt"],
         "doublesMoves": ["closecombat", "dazzlinggleam", "focusblast", "geomancy", "hiddenpowerfire", "protect", "psyshock", "rockslide", "thunder", "thunderbolt"]
     },
     "yveltal": {
-        "level": 74,
+        "level": 73,
         "moves": ["darkpulse", "foulplay", "knockoff", "oblivionwing", "roost", "suckerpunch", "taunt", "toxic", "uturn"],
         "doublesMoves": ["darkpulse", "focusblast", "hurricane", "oblivionwing", "protect", "roost", "skydrop", "snarl", "suckerpunch", "taunt"]
     },
     "zygarde": {
-        "level": 79,
+        "level": 78,
         "moves": ["dragondance", "earthquake", "extremespeed", "glare", "outrage", "stoneedge"],
         "doublesMoves": ["coil", "dragondance", "extremespeed", "glare", "landswrath", "protect", "rockslide", "stoneedge"]
     },

--- a/data/mods/gen7/random-data.json
+++ b/data/mods/gen7/random-data.json
@@ -135,7 +135,7 @@
         "doublesMoves": ["dazzlinggleam", "fireblast", "hypervoice", "protect", "stealthrock", "thunderwave"]
     },
     "vileplume": {
-        "level": 86,
+        "level": 87,
         "moves": ["aromatherapy", "gigadrain", "hiddenpowerfire", "sleeppowder", "sludgebomb", "strengthsap"],
         "doublesMoves": ["energyball", "hiddenpowerfire", "protect", "sleeppowder", "sludgebomb", "strengthsap"]
     },
@@ -215,7 +215,7 @@
         "doublesMoves": ["acidspray", "knockoff", "muddywater", "protect", "rapidspin", "scald", "sludgebomb"]
     },
     "golem": {
-        "level": 88,
+        "level": 87,
         "moves": ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic"],
         "doublesMoves": ["earthquake", "protect", "rockslide", "stealthrock", "stoneedge", "suckerpunch"]
     },
@@ -240,7 +240,7 @@
         "doublesMoves": ["fireblast", "icebeam", "protect", "psychic", "psyshock", "scald", "slackoff", "trickroom"]
     },
     "farfetchd": {
-        "level": 93,
+        "level": 94,
         "moves": ["bravebird", "knockoff", "leafblade", "return", "swordsdance"],
         "doublesMoves": ["bravebird", "knockoff", "leafblade", "protect", "return", "swordsdance"]
     },
@@ -265,7 +265,7 @@
         "doublesMoves": ["gunkshot", "knockoff", "poisonjab", "protect", "shadowsneak", "snarl", "stoneedge"]
     },
     "cloyster": {
-        "level": 83,
+        "level": 82,
         "moves": ["hydropump", "iciclespear", "rapidspin", "rockblast", "shellsmash", "spikes"],
         "doublesMoves": ["hydropump", "iciclespear", "protect", "rockblast", "shellsmash"]
     },
@@ -280,7 +280,7 @@
         "doublesMoves": ["disable", "focusblast", "hypnosis", "protect", "shadowball", "sludgebomb", "willowisp"]
     },
     "hypno": {
-        "level": 89,
+        "level": 90,
         "moves": ["foulplay", "protect", "psychic", "seismictoss", "thunderwave", "toxic", "wish"],
         "doublesMoves": ["hypnosis", "protect", "psychic", "seismictoss", "thunderwave"]
     },
@@ -334,7 +334,7 @@
         "moves": ["earthquake", "megahorn", "stealthrock", "stoneedge", "toxic"]
     },
     "chansey": {
-        "level": 83,
+        "level": 84,
         "moves": ["healbell", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic", "wish"],
         "doublesMoves": ["helpinghand", "protect", "seismictoss", "softboiled", "thunderwave", "toxic"]
     },
@@ -349,7 +349,7 @@
         "doublesMoves": ["drainpunch", "earthquake", "fakeout", "poweruppunch", "protect", "return", "suckerpunch"]
     },
     "seaking": {
-        "level": 89,
+        "level": 90,
         "moves": ["drillrun", "icebeam", "knockoff", "megahorn", "raindance", "waterfall"],
         "doublesMoves": ["drillrun", "icywind", "knockoff", "megahorn", "protect", "waterfall"]
     },
@@ -379,7 +379,7 @@
         "doublesMoves": ["closecombat", "feint", "knockoff", "protect", "rockslide", "xscissor"]
     },
     "pinsirmega": {
-        "level": 80,
+        "level": 78,
         "moves": ["closecombat", "earthquake", "quickattack", "return", "swordsdance"],
         "doublesMoves": ["closecombat", "feint", "protect", "quickattack", "return", "rockslide", "swordsdance"]
     },
@@ -389,7 +389,7 @@
         "doublesMoves": ["doubleedge", "protect", "return", "rockslide", "stompingtantrum", "stoneedge", "zenheadbutt"]
     },
     "gyarados": {
-        "level": 79,
+        "level": 78,
         "moves": ["bounce", "dragondance", "earthquake", "stoneedge", "substitute", "waterfall"],
         "doublesMoves": ["bounce", "dragondance", "protect", "stoneedge", "thunderwave", "waterfall"]
     },
@@ -404,7 +404,7 @@
         "doublesMoves": ["freezedry", "helpinghand", "hydropump", "iceshard", "icywind", "protect"]
     },
     "ditto": {
-        "level": 87,
+        "level": 86,
         "moves": ["transform"]
     },
     "vaporeon": {
@@ -448,7 +448,7 @@
         "doublesMoves": ["bodyslam", "crunch", "curse", "highhorsepower", "protect", "rest", "return"]
     },
     "articuno": {
-        "level": 88,
+        "level": 87,
         "moves": ["freezedry", "hurricane", "roost", "substitute", "toxic"],
         "doublesMoves": ["freezedry", "hurricane", "protect", "roost", "tailwind"]
     },
@@ -463,22 +463,22 @@
         "doublesMoves": ["airslash", "fireblast", "heatwave", "hurricane", "protect", "tailwind", "uturn", "willowisp"]
     },
     "dragonite": {
-        "level": 78,
+        "level": 76,
         "moves": ["dragondance", "earthquake", "extremespeed", "firepunch", "fly", "outrage"],
         "doublesMoves": ["dragonclaw", "dragondance", "extremespeed", "firepunch", "fly", "protect", "roost", "superpower"]
     },
     "mewtwo": {
-        "level": 75,
+        "level": 74,
         "moves": ["aurasphere", "calmmind", "fireblast", "icebeam", "psystrike", "recover"],
         "doublesMoves": ["aurasphere", "calmmind", "fireblast", "icebeam", "protect", "psystrike"]
     },
     "mewtwomegax": {
-        "level": 73,
+        "level": 72,
         "moves": ["bulkup", "drainpunch", "icebeam", "stoneedge", "taunt", "zenheadbutt"],
         "doublesMoves": ["bulkup", "drainpunch", "icebeam", "stoneedge", "taunt", "zenheadbutt"]
     },
     "mewtwomegay": {
-        "level": 73,
+        "level": 72,
         "moves": ["aurasphere", "calmmind", "fireblast", "icebeam", "psystrike", "recover", "shadowball"],
         "doublesMoves": ["aurasphere", "calmmind", "fireblast", "icebeam", "psystrike", "taunt", "willowisp"]
     },
@@ -488,7 +488,7 @@
         "doublesMoves": ["fakeout", "fireblast", "helpinghand", "icebeam", "protect", "psyshock", "roost", "tailwind", "taunt", "transform", "willowisp"]
     },
     "meganium": {
-        "level": 88,
+        "level": 89,
         "moves": ["aromatherapy", "dragontail", "gigadrain", "leechseed", "lightscreen", "reflect", "synthesis", "toxic"],
         "doublesMoves": ["dragontail", "energyball", "healpulse", "leafstorm", "leechseed", "protect", "toxic"]
     },
@@ -503,17 +503,17 @@
         "doublesMoves": ["aquajet", "crunch", "dragondance", "icepunch", "liquidation", "protect"]
     },
     "furret": {
-        "level": 89,
+        "level": 90,
         "moves": ["aquatail", "doubleedge", "firepunch", "knockoff", "trick", "uturn"],
         "doublesMoves": ["doubleedge", "followme", "helpinghand", "knockoff", "protect", "superfang", "uturn"]
     },
     "noctowl": {
-        "level": 90,
+        "level": 91,
         "moves": ["airslash", "defog", "heatwave", "hurricane", "hypervoice", "roost", "whirlwind"],
         "doublesMoves": ["airslash", "heatwave", "hypervoice", "hypnosis", "protect", "roost", "tailwind"]
     },
     "ledian": {
-        "level": 91,
+        "level": 92,
         "moves": ["knockoff", "lightscreen", "reflect", "roost", "toxic", "uturn"],
         "doublesMoves": ["bugbuzz", "encore", "knockoff", "lightscreen", "protect", "reflect", "tailwind", "uturn"]
     },
@@ -533,7 +533,7 @@
         "doublesMoves": ["icebeam", "protect", "scald", "thunderbolt", "thunderwave", "toxic"]
     },
     "xatu": {
-        "level": 87,
+        "level": 88,
         "moves": ["calmmind", "heatwave", "psychic", "roost", "thunderwave", "toxic", "uturn"],
         "doublesMoves": ["heatwave", "protect", "psychic", "roost", "tailwind", "thunderwave", "uturn"]
     },
@@ -563,7 +563,7 @@
         "doublesMoves": ["headsmash", "helpinghand", "protect", "stealthrock", "stompingtantrum", "suckerpunch", "woodhammer"]
     },
     "politoed": {
-        "level": 84,
+        "level": 85,
         "moves": ["encore", "icebeam", "protect", "rest", "scald", "toxic"],
         "doublesMoves": ["encore", "helpinghand", "hypnosis", "icywind", "protect", "scald"]
     },
@@ -573,7 +573,7 @@
         "doublesMoves": ["encore", "energyball", "helpinghand", "leechseed", "protect", "ragepowder", "sleeppowder", "strengthsap", "uturn"]
     },
     "sunflora": {
-        "level": 90,
+        "level": 91,
         "moves": ["earthpower", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "sludgebomb"],
         "doublesMoves": ["earthpower", "encore", "energyball", "helpinghand", "hiddenpowerfire", "protect", "solarbeam", "sunnyday"]
     },
@@ -617,7 +617,7 @@
         "doublesMoves": ["gyroball", "protect", "stealthrock", "toxic", "voltswitch"]
     },
     "dunsparce": {
-        "level": 90,
+        "level": 91,
         "moves": ["bite", "bodyslam", "coil", "glare", "headbutt", "rockslide", "roost"],
         "doublesMoves": ["bite", "bodyslam", "coil", "glare", "headbutt", "protect", "rockslide"]
     },
@@ -676,17 +676,17 @@
         "doublesMoves": ["closecombat", "crunch", "facade", "protect", "swordsdance"]
     },
     "magcargo": {
-        "level": 89,
+        "level": 90,
         "moves": ["ancientpower", "earthpower", "fireblast", "hiddenpowergrass", "lavaplume", "recover", "shellsmash", "stealthrock", "toxic"],
         "doublesMoves": ["earthpower", "fireblast", "heatwave", "incinerate", "protect", "stealthrock", "willowisp"]
     },
     "corsola": {
-        "level": 90,
+        "level": 91,
         "moves": ["powergem", "recover", "scald", "stealthrock", "toxic"],
         "doublesMoves": ["icywind", "powergem", "protect", "scald", "stealthrock", "toxic"]
     },
     "octillery": {
-        "level": 89,
+        "level": 90,
         "moves": ["energyball", "fireblast", "gunkshot", "hydropump", "icebeam", "rockblast", "scald"],
         "doublesMoves": ["energyball", "fireblast", "hydropump", "icebeam", "protect"]
     },
@@ -711,7 +711,7 @@
         "doublesMoves": ["darkpulse", "heatwave", "nastyplot", "protect", "suckerpunch"]
     },
     "houndoommega": {
-        "level": 84,
+        "level": 83,
         "moves": ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "taunt"],
         "doublesMoves": ["darkpulse", "heatwave", "hiddenpowergrass", "nastyplot", "protect", "taunt"]
     },
@@ -834,7 +834,7 @@
         "doublesMoves": ["bellydrum", "extremespeed", "protect", "shadowclaw", "stompingtantrum"]
     },
     "beautifly": {
-        "level": 90,
+        "level": 91,
         "moves": ["bugbuzz", "energyball", "hiddenpowerfighting", "psychic", "quiverdance"],
         "doublesMoves": ["aircutter", "bugbuzz", "protect", "quiverdance", "stringshot", "tailwind"]
     },
@@ -879,12 +879,12 @@
         "doublesMoves": ["airslash", "bugbuzz", "hydropump", "protect", "quiverdance", "stickyweb", "strugglebug", "tailwind"]
     },
     "breloom": {
-        "level": 82,
+        "level": 83,
         "moves": ["bulletseed", "machpunch", "rocktomb", "spore", "swordsdance"],
         "doublesMoves": ["bulletseed", "machpunch", "protect", "rocktomb", "spore"]
     },
     "slaking": {
-        "level": 86,
+        "level": 85,
         "moves": ["earthquake", "firepunch", "gigaimpact", "nightslash", "pursuit", "retaliate"],
         "doublesMoves": ["doubleedge", "earthquake", "hammerarm", "nightslash", "retaliate", "rockslide"]
     },
@@ -909,7 +909,7 @@
         "doublesMoves": ["bulletpunch", "closecombat", "facade", "fakeout", "helpinghand", "knockoff", "protect", "wideguard"]
     },
     "delcatty": {
-        "level": 92,
+        "level": 93,
         "moves": ["doubleedge", "fakeout", "healbell", "suckerpunch", "thunderwave", "wildcharge"],
         "doublesMoves": ["doubleedge", "fakeout", "helpinghand", "protect", "suckerpunch", "thunderwave"]
     },
@@ -964,7 +964,7 @@
         "doublesMoves": ["flamethrower", "hiddenpowergrass", "hiddenpowerice", "protect", "snarl", "thunderbolt", "voltswitch"]
     },
     "plusle": {
-        "level": 89,
+        "level": 90,
         "moves": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
         "doublesMoves": ["encore", "helpinghand", "hiddenpowerice", "nastyplot", "protect", "thunderbolt"]
     },
@@ -974,12 +974,12 @@
         "doublesMoves": ["encore", "helpinghand", "hiddenpowerice", "nastyplot", "protect", "thunderbolt"]
     },
     "volbeat": {
-        "level": 88,
+        "level": 89,
         "moves": ["defog", "encore", "roost", "tailwind", "thunderwave", "uturn"],
         "doublesMoves": ["encore", "helpinghand", "protect", "stringshot", "strugglebug", "tailwind", "thunderwave", "uturn"]
     },
     "illumise": {
-        "level": 90,
+        "level": 91,
         "moves": ["bugbuzz", "defog", "encore", "roost", "thunderwave", "uturn", "wish"],
         "doublesMoves": ["bugbuzz", "encore", "helpinghand", "protect", "tailwind", "thunderwave"]
     },
@@ -1029,7 +1029,7 @@
         "doublesMoves": ["fakeout", "protect", "return", "suckerpunch", "superpower", "trickroom"]
     },
     "flygon": {
-        "level": 84,
+        "level": 83,
         "moves": ["defog", "dragondance", "earthquake", "firepunch", "outrage", "roost", "uturn"],
         "doublesMoves": ["dragonclaw", "dragondance", "earthquake", "fireblast", "protect", "tailwind", "uturn"]
     },
@@ -1054,7 +1054,7 @@
         "doublesMoves": ["closecombat", "facade", "knockoff", "protect", "quickattack"]
     },
     "seviper": {
-        "level": 89,
+        "level": 90,
         "moves": ["darkpulse", "earthquake", "flamethrower", "gigadrain", "poisonjab", "sludgewave", "suckerpunch", "switcheroo", "swordsdance"],
         "doublesMoves": ["aquatail", "earthquake", "flamethrower", "gigadrain", "glare", "poisonjab", "protect", "sludgebomb", "suckerpunch"]
     },
@@ -1131,7 +1131,7 @@
         "doublesMoves": ["airslash", "gigadrain", "leechseed", "protect", "roost", "tailwind"]
     },
     "chimecho": {
-        "level": 90,
+        "level": 91,
         "moves": ["calmmind", "defog", "healbell", "healingwish", "knockoff", "psychic", "recover", "shadowball", "taunt", "toxic", "yawn"],
         "doublesMoves": ["helpinghand", "protect", "psychic", "recover", "taunt", "thunderwave", "trickroom"]
     },
@@ -1161,7 +1161,7 @@
         "doublesMoves": ["brine", "icywind", "protect", "superfang"]
     },
     "huntail": {
-        "level": 86,
+        "level": 85,
         "moves": ["icebeam", "shellsmash", "suckerpunch", "waterfall"],
         "doublesMoves": ["icebeam", "protect", "shellsmash", "suckerpunch", "waterfall"]
     },
@@ -1181,7 +1181,7 @@
         "doublesMoves": ["healpulse", "icebeam", "icywind", "protect", "scald", "sweetkiss", "toxic"]
     },
     "salamence": {
-        "level": 79,
+        "level": 78,
         "moves": ["dragondance", "earthquake", "fireblast", "fly", "outrage", "roost"],
         "doublesMoves": ["dracometeor", "dragonclaw", "dragondance", "earthquake", "fireblast", "fly", "protect", "tailwind"]
     },
@@ -1231,12 +1231,12 @@
         "doublesMoves": ["dracometeor", "dragonpulse", "hiddenpowerfire", "protect", "psyshock", "tailwind", "trick"]
     },
     "latiosmega": {
-        "level": 82,
+        "level": 81,
         "moves": ["calmmind", "dracometeor", "hiddenpowerfire", "psyshock", "roost"],
         "doublesMoves": ["dracometeor", "dragonpulse", "hiddenpowerfire", "protect", "psyshock", "tailwind"]
     },
     "kyogre": {
-        "level": 72,
+        "level": 71,
         "moves": ["icebeam", "originpulse", "scald", "thunder", "waterspout"],
         "doublesMoves": ["calmmind", "icebeam", "originpulse", "protect", "thunder", "waterspout"]
     },
@@ -1251,12 +1251,12 @@
         "doublesMoves": ["firepunch", "precipiceblades", "protect", "rockpolish", "rockslide", "stoneedge", "swordsdance"]
     },
     "groudonprimal": {
-        "level": 71,
+        "level": 70,
         "moves": ["firepunch", "lavaplume", "precipiceblades", "rockpolish", "stealthrock", "stoneedge", "swordsdance"],
         "doublesMoves": ["firepunch", "precipiceblades", "protect", "rockpolish", "rockslide", "stoneedge", "swordsdance"]
     },
     "rayquaza": {
-        "level": 75,
+        "level": 74,
         "moves": ["dracometeor", "dragondance", "earthquake", "extremespeed", "outrage", "vcreate"],
         "doublesMoves": ["dracometeor", "dragonclaw", "dragondance", "earthquake", "extremespeed", "protect", "tailwind", "vcreate"]
     },
@@ -1281,12 +1281,12 @@
         "doublesMoves": ["extremespeed", "firepunch", "icebeam", "knockoff", "protect", "psychoboost", "superpower"]
     },
     "deoxysdefense": {
-        "level": 81,
+        "level": 82,
         "moves": ["knockoff", "recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"],
         "doublesMoves": ["lightscreen", "protect", "recover", "reflect", "seismictoss", "stealthrock", "taunt", "trickroom"]
     },
     "deoxysspeed": {
-        "level": 79,
+        "level": 80,
         "moves": ["knockoff", "magiccoat", "psychoboost", "spikes", "stealthrock", "superpower", "taunt"],
         "doublesMoves": ["knockoff", "lightscreen", "protect", "psychoboost", "reflect", "superpower", "taunt"]
     },
@@ -1356,7 +1356,7 @@
         "doublesMoves": ["bugbuzz", "flashcannon", "protect", "stringshot", "strugglebug", "suckerpunch"]
     },
     "mothim": {
-        "level": 89,
+        "level": 91,
         "moves": ["airslash", "bugbuzz", "energyball", "quiverdance", "uturn"],
         "doublesMoves": ["airslash", "bugbuzz", "energyball", "protect", "quiverdance"]
     },
@@ -1376,11 +1376,11 @@
         "doublesMoves": ["aquajet", "icepunch", "liquidation", "protect", "switcheroo", "taunt"]
     },
     "cherrim": {
-        "level": 91,
+        "level": 92,
         "moves": ["dazzlinggleam", "energyball", "healingwish", "hiddenpowerfire", "synthesis"]
     },
     "cherrimsunshine": {
-        "level": 91,
+        "level": 92,
         "moves": ["gigadrain", "hiddenpowerice", "solarbeam", "sunnyday", "weatherball"],
         "doublesMoves": ["gigadrain", "helpinghand", "solarbeam", "sunnyday", "weatherball"]
     },
@@ -1445,7 +1445,7 @@
         "doublesMoves": ["foulplay", "icywind", "protect", "shadowsneak", "snarl", "willowisp"]
     },
     "garchomp": {
-        "level": 80,
+        "level": 79,
         "moves": ["dragonclaw", "earthquake", "fireblast", "firefang", "outrage", "stealthrock", "stoneedge", "swordsdance"],
         "doublesMoves": ["dragonclaw", "earthquake", "protect", "rockslide", "stoneedge", "swordsdance"]
     },
@@ -1520,7 +1520,7 @@
         "doublesMoves": ["earthquake", "icepunch", "megahorn", "protect", "rockslide", "stealthrock", "stoneedge"]
     },
     "tangrowth": {
-        "level": 84,
+        "level": 86,
         "moves": ["earthquake", "gigadrain", "hiddenpowerfire", "knockoff", "leafstorm", "rockslide", "sleeppowder", "synthesis"],
         "doublesMoves": ["earthquake", "focusblast", "gigadrain", "hiddenpowerice", "knockoff", "leechseed", "powerwhip", "protect", "ragepowder", "sleeppowder"]
     },
@@ -1634,7 +1634,7 @@
         "doublesMoves": ["calmmind", "helpinghand", "icebeam", "knockoff", "protect", "psychic", "thunderbolt", "trick", "uturn"]
     },
     "azelf": {
-        "level": 82,
+        "level": 83,
         "moves": ["dazzlinggleam", "explosion", "fireblast", "knockoff", "nastyplot", "psyshock", "stealthrock", "taunt"],
         "doublesMoves": ["fireblast", "knockoff", "nastyplot", "protect", "psychic", "taunt", "thunderbolt", "uturn"]
     },
@@ -1669,7 +1669,7 @@
         "doublesMoves": ["calmmind", "dragonpulse", "dragontail", "protect", "shadowball", "tailwind", "willowisp"]
     },
     "cresselia": {
-        "level": 84,
+        "level": 83,
         "moves": ["calmmind", "icebeam", "moonblast", "moonlight", "psychic", "psyshock", "substitute", "thunderwave", "toxic"],
         "doublesMoves": ["allyswitch", "helpinghand", "icywind", "moonblast", "moonlight", "protect", "psyshock", "thunderwave", "trickroom"]
     },
@@ -1679,7 +1679,7 @@
         "doublesMoves": ["helpinghand", "icywind", "protect", "scald", "uturn"]
     },
     "manaphy": {
-        "level": 80,
+        "level": 79,
         "moves": ["energyball", "icebeam", "surf", "tailglow"],
         "doublesMoves": ["energyball", "helpinghand", "icebeam", "protect", "scald", "surf", "tailglow"]
     },
@@ -1839,7 +1839,7 @@
         "doublesMoves": ["helpinghand", "hydropump", "icebeam", "nastyplot", "protect", "taunt"]
     },
     "musharna": {
-        "level": 88,
+        "level": 89,
         "moves": ["calmmind", "healbell", "moonlight", "psychic", "psyshock", "signalbeam", "thunderwave"],
         "doublesMoves": ["helpinghand", "hypnosis", "moonlight", "protect", "psychic", "signalbeam", "thunderwave", "trickroom"]
     },
@@ -1874,7 +1874,7 @@
         "doublesMoves": ["healpulse", "helpinghand", "hypervoice", "protect", "thunderwave", "trickroom"]
     },
     "audinomega": {
-        "level": 91,
+        "level": 92,
         "moves": ["calmmind", "dazzlinggleam", "fireblast", "healbell", "protect", "wish"],
         "doublesMoves": ["dazzlinggleam", "healpulse", "helpinghand", "hypervoice", "protect", "thunderwave", "trickroom"]
     },
@@ -1974,7 +1974,7 @@
         "doublesMoves": ["acrobatics", "earthpower", "protect", "rockslide", "stoneedge", "tailwind", "taunt", "uturn"]
     },
     "garbodor": {
-        "level": 86,
+        "level": 87,
         "moves": ["gunkshot", "haze", "painsplit", "spikes", "stompingtantrum", "toxic", "toxicspikes"],
         "doublesMoves": ["drainpunch", "gunkshot", "painsplit", "protect", "toxicspikes"]
     },
@@ -2023,7 +2023,7 @@
         "doublesMoves": ["drillrun", "ironhead", "knockoff", "megahorn", "protect", "swordsdance"]
     },
     "amoonguss": {
-        "level": 83,
+        "level": 84,
         "moves": ["clearsmog", "foulplay", "gigadrain", "hiddenpowerfire", "sludgebomb", "spore", "synthesis"],
         "doublesMoves": ["gigadrain", "hiddenpowerfire", "protect", "ragepowder", "sludgebomb", "spore", "stunspore"]
     },
@@ -2148,12 +2148,12 @@
         "doublesMoves": ["bugbuzz", "fierydance", "gigadrain", "heatwave", "protect", "quiverdance", "tailwind"]
     },
     "cobalion": {
-        "level": 81,
+        "level": 80,
         "moves": ["closecombat", "ironhead", "stealthrock", "stoneedge", "swordsdance", "voltswitch"],
         "doublesMoves": ["closecombat", "ironhead", "protect", "stoneedge", "swordsdance", "thunderwave"]
     },
     "terrakion": {
-        "level": 80,
+        "level": 79,
         "moves": ["closecombat", "earthquake", "quickattack", "stealthrock", "stoneedge", "swordsdance"],
         "doublesMoves": ["closecombat", "protect", "rockslide", "stompingtantrum", "stoneedge", "taunt"]
     },
@@ -2198,7 +2198,7 @@
         "doublesMoves": ["earthpower", "focusblast", "hiddenpowerice", "protect", "psychic", "rockslide", "sludgebomb"]
     },
     "landorustherian": {
-        "level": 80,
+        "level": 79,
         "moves": ["earthquake", "fly", "rockpolish", "stealthrock", "stoneedge", "superpower", "swordsdance", "uturn"],
         "doublesMoves": ["earthquake", "fly", "knockoff", "protect", "rockslide", "stoneedge", "superpower", "swordsdance", "uturn"]
     },
@@ -2238,7 +2238,7 @@
         "doublesMoves": ["bugbuzz", "extremespeed", "flamethrower", "icebeam", "ironhead", "protect", "technoblast", "thunderbolt", "uturn"]
     },
     "chesnaught": {
-        "level": 84,
+        "level": 85,
         "moves": ["drainpunch", "leechseed", "spikes", "spikyshield", "synthesis", "woodhammer"],
         "doublesMoves": ["hammerarm", "leechseed", "rockslide", "spikyshield", "stoneedge", "woodhammer"]
     },
@@ -2287,7 +2287,7 @@
         "doublesMoves": ["calmmind", "dazzlinggleam", "defog", "helpinghand", "moonblast", "protect", "psychic"]
     },
     "gogoat": {
-        "level": 88,
+        "level": 89,
         "moves": ["bulkup", "earthquake", "hornleech", "leechseed", "milkdrink", "rockslide", "substitute"],
         "doublesMoves": ["brickbreak", "bulkup", "earthquake", "hornleech", "leechseed", "milkdrink", "protect", "rockslide"]
     },
@@ -2317,17 +2317,17 @@
         "doublesMoves": ["ironhead", "protect", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"]
     },
     "aegislash": {
-        "level": 77,
+        "level": 78,
         "moves": ["flashcannon", "hiddenpowerice", "kingsshield", "shadowball", "shadowsneak", "toxic"],
         "doublesMoves": ["flashcannon", "hiddenpowerice", "kingsshield", "shadowball", "shadowsneak"]
     },
     "aegislashblade": {
-        "level": 77,
+        "level": 78,
         "moves": ["ironhead", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"],
         "doublesMoves": ["ironhead", "kingsshield", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"]
     },
     "aromatisse": {
-        "level": 89,
+        "level": 90,
         "moves": ["calmmind", "moonblast", "rest", "sleeptalk", "toxic"],
         "doublesMoves": ["healpulse", "moonblast", "protect", "thunderbolt", "trickroom"]
     },
@@ -2337,7 +2337,7 @@
         "doublesMoves": ["bellydrum", "drainpunch", "playrough", "protect", "return"]
     },
     "malamar": {
-        "level": 83,
+        "level": 82,
         "moves": ["happyhour", "knockoff", "psychocut", "rest", "sleeptalk", "superpower"],
         "doublesMoves": ["knockoff", "protect", "psychocut", "rockslide", "superpower", "trickroom"]
     },
@@ -2372,12 +2372,12 @@
         "doublesMoves": ["ancientpower", "earthpower", "freezedry", "hypervoice", "icywind", "protect", "thunderwave"]
     },
     "sylveon": {
-        "level": 84,
+        "level": 85,
         "moves": ["calmmind", "hiddenpowerfire", "hypervoice", "protect", "psyshock", "wish"],
         "doublesMoves": ["helpinghand", "hiddenpowerground", "hypervoice", "protect", "psyshock", "shadowball"]
     },
     "hawlucha": {
-        "level": 80,
+        "level": 79,
         "moves": ["acrobatics", "highjumpkick", "skyattack", "substitute", "swordsdance"],
         "doublesMoves": ["acrobatics", "encore", "highjumpkick", "protect", "swordsdance"]
     },
@@ -2437,17 +2437,17 @@
         "doublesMoves": ["dracometeor", "flamethrower", "hurricane", "protect", "switcheroo", "tailwind", "taunt", "uturn"]
     },
     "xerneas": {
-        "level": 70,
+        "level": 68,
         "moves": ["focusblast", "geomancy", "hiddenpowerfire", "moonblast", "psyshock", "thunderbolt"],
         "doublesMoves": ["closecombat", "dazzlinggleam", "focusblast", "geomancy", "hiddenpowerfire", "protect", "psyshock", "rockslide", "thunderbolt"]
     },
     "yveltal": {
-        "level": 75,
+        "level": 74,
         "moves": ["darkpulse", "focusblast", "foulplay", "knockoff", "oblivionwing", "roost", "suckerpunch", "taunt", "toxic", "uturn"],
         "doublesMoves": ["darkpulse", "heatwave", "oblivionwing", "protect", "roost", "skydrop", "snarl", "suckerpunch", "taunt"]
     },
     "zygarde": {
-        "level": 73,
+        "level": 72,
         "moves": ["dragondance", "extremespeed", "outrage", "substitute", "thousandarrows"],
         "doublesMoves": ["coil", "dragondance", "extremespeed", "glare", "protect", "rockslide", "stoneedge", "thousandarrows"]
     },
@@ -2487,7 +2487,7 @@
         "doublesMoves": ["bravebird", "leafblade", "protect", "spiritshackle", "suckerpunch"]
     },
     "incineroar": {
-        "level": 85,
+        "level": 84,
         "moves": ["darkestlariat", "earthquake", "fakeout", "flareblitz", "knockoff", "uturn"],
         "doublesMoves": ["fakeout", "flareblitz", "knockoff", "snarl", "taunt", "uturn", "willowisp"]
     },
@@ -2567,7 +2567,7 @@
         "doublesMoves": ["banefulbunker", "haze", "recover", "scald", "toxicspikes", "wideguard"]
     },
     "mudsdale": {
-        "level": 86,
+        "level": 85,
         "moves": ["closecombat", "earthquake", "heavyslam", "rockslide", "stealthrock"],
         "doublesMoves": ["closecombat", "heavyslam", "highhorsepower", "protect", "rockslide"]
     },
@@ -2597,7 +2597,7 @@
         "doublesMoves": ["doubleedge", "hammerarm", "icepunch", "protect", "wideguard"]
     },
     "tsareena": {
-        "level": 85,
+        "level": 86,
         "moves": ["highjumpkick", "knockoff", "powerwhip", "rapidspin", "synthesis", "uturn"],
         "doublesMoves": ["feint", "knockoff", "playrough", "powerwhip", "protect", "uturn"]
     },
@@ -2632,7 +2632,7 @@
         "doublesMoves": ["counter", "helpinghand", "lightscreen", "memento", "reflect"]
     },
     "typenull": {
-        "level": 87,
+        "level": 86,
         "moves": ["rest", "return", "sleeptalk", "swordsdance", "uturn"]
     },
     "silvally": {
@@ -2746,7 +2746,7 @@
         "doublesMoves": ["encore", "fakeout", "ironhead", "nuzzle", "spikyshield", "uturn", "zingzap"]
     },
     "mimikyu": {
-        "level": 79,
+        "level": 78,
         "moves": ["playrough", "shadowclaw", "shadowsneak", "swordsdance", "taunt"],
         "doublesMoves": ["playrough", "protect", "shadowclaw", "shadowsneak", "swordsdance", "willowisp"]
     },
@@ -2756,7 +2756,7 @@
         "doublesMoves": ["aquajet", "crunch", "liquidation", "protect", "psychicfangs", "swordsdance"]
     },
     "drampa": {
-        "level": 88,
+        "level": 89,
         "moves": ["dracometeor", "dragonpulse", "fireblast", "glare", "hypervoice", "roost", "thunderbolt"],
         "doublesMoves": ["dracometeor", "dragonpulse", "fireblast", "glare", "hypervoice", "protect", "roost"]
     },
@@ -2771,7 +2771,7 @@
         "doublesMoves": ["clangingscales", "closecombat", "dragondance", "poisonjab"]
     },
     "tapukoko": {
-        "level": 79,
+        "level": 78,
         "moves": ["bravebird", "dazzlinggleam", "defog", "naturesmadness", "thunderbolt", "uturn"],
         "doublesMoves": ["dazzlinggleam", "hiddenpowerice", "naturesmadness", "protect", "skydrop", "taunt", "thunderbolt", "uturn"]
     },
@@ -2796,7 +2796,7 @@
         "doublesMoves": ["flareblitz", "morningsun", "protect", "sunsteelstrike", "wideguard", "zenheadbutt"]
     },
     "lunala": {
-        "level": 75,
+        "level": 74,
         "moves": ["calmmind", "focusblast", "moonblast", "moongeistbeam", "psyshock", "roost"],
         "doublesMoves": ["moonblast", "moongeistbeam", "protect", "psychic", "roost", "wideguard"]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -115,7 +115,7 @@
         ]
     },
     "annihilape": {
-        "level": 77,
+        "level": 76,
         "sets": [
             {
                 "role": "Fast Bulky Setup",
@@ -235,7 +235,7 @@
         ]
     },
     "hypno": {
-        "level": 94,
+        "level": 95,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -505,7 +505,7 @@
         ]
     },
     "typhlosion": {
-        "level": 85,
+        "level": 84,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -515,7 +515,7 @@
         ]
     },
     "typhlosionhisui": {
-        "level": 84,
+        "level": 83,
         "sets": [
             {
                 "role": "Fast Bulky Setup",
@@ -555,7 +555,7 @@
         ]
     },
     "sudowoodo": {
-        "level": 92,
+        "level": 93,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -580,7 +580,7 @@
         ]
     },
     "sunflora": {
-        "level": 99,
+        "level": 100,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -635,7 +635,7 @@
         ]
     },
     "slowking": {
-        "level": 86,
+        "level": 87,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -730,7 +730,7 @@
         ]
     },
     "scizor": {
-        "level": 81,
+        "level": 80,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -820,7 +820,7 @@
         ]
     },
     "tyranitar": {
-        "level": 81,
+        "level": 80,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -885,7 +885,7 @@
         ]
     },
     "vigoroth": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -905,7 +905,7 @@
         ]
     },
     "hariyama": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -930,7 +930,7 @@
         ]
     },
     "medicham": {
-        "level": 85,
+        "level": 86,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -975,7 +975,7 @@
         ]
     },
     "grumpig": {
-        "level": 91,
+        "level": 92,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1015,7 +1015,7 @@
         ]
     },
     "zangoose": {
-        "level": 85,
+        "level": 86,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1145,7 +1145,7 @@
         ]
     },
     "kricketune": {
-        "level": 96,
+        "level": 97,
         "sets": [
             {
                 "role": "Fast Support",
@@ -1170,7 +1170,7 @@
         ]
     },
     "vespiquen": {
-        "level": 97,
+        "level": 98,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1410,7 +1410,7 @@
         ]
     },
     "gallade": {
-        "level": 83,
+        "level": 82,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1490,7 +1490,7 @@
         ]
     },
     "uxie": {
-        "level": 84,
+        "level": 83,
         "sets": [
             {
                 "role": "Fast Support",
@@ -1565,7 +1565,7 @@
         ]
     },
     "palkiaorigin": {
-        "level": 73,
+        "level": 72,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1660,7 +1660,7 @@
         ]
     },
     "arceusdragon": {
-        "level": 70,
+        "level": 71,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -1825,7 +1825,7 @@
         ]
     },
     "arceuswater": {
-        "level": 70,
+        "level": 71,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1850,7 +1850,7 @@
         ]
     },
     "samurotthisui": {
-        "level": 79,
+        "level": 78,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1910,7 +1910,7 @@
         ]
     },
     "basculegion": {
-        "level": 69,
+        "level": 68,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -2298,7 +2298,7 @@
         ]
     },
     "sylveon": {
-        "level": 83,
+        "level": 84,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -2308,7 +2308,7 @@
         ]
     },
     "hawlucha": {
-        "level": 82,
+        "level": 81,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -2483,7 +2483,7 @@
         ]
     },
     "gumshoos": {
-        "level": 93,
+        "level": 94,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -2563,7 +2563,7 @@
         ]
     },
     "lycanrocdusk": {
-        "level": 82,
+        "level": 81,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -2808,7 +2808,7 @@
         ]
     },
     "sandaconda": {
-        "level": 85,
+        "level": 84,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -2913,7 +2913,7 @@
         ]
     },
     "pincurchin": {
-        "level": 95,
+        "level": 96,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -2938,7 +2938,7 @@
         ]
     },
     "stonjourner": {
-        "level": 90,
+        "level": 91,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -2993,7 +2993,7 @@
         ]
     },
     "dragapult": {
-        "level": 78,
+        "level": 77,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3212,7 +3212,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Crunch", "Facade", "Headlong Rush","Swords Dance", "Trailblaze"],
+                "movepool": ["Crunch", "Facade", "Headlong Rush", "Swords Dance", "Trailblaze"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -3293,7 +3293,7 @@
         ]
     },
     "oinkolognef": {
-        "level": 92,
+        "level": 93,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -3333,7 +3333,7 @@
         ]
     },
     "spidops": {
-        "level": 94,
+        "level": 95,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -3483,7 +3483,7 @@
         ]
     },
     "scovillain": {
-        "level": 90,
+        "level": 91,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3523,7 +3523,7 @@
         ]
     },
     "orthworm": {
-        "level": 86,
+        "level": 87,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -3653,7 +3653,7 @@
         ]
     },
     "squawkabillywhite": {
-        "level": 89,
+        "level": 90,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -3673,7 +3673,7 @@
         ]
     },
     "squawkabillyyellow": {
-        "level": 89,
+        "level": 90,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -3708,7 +3708,7 @@
         ]
     },
     "garganacl": {
-        "level": 82,
+        "level": 81,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -3768,7 +3768,7 @@
         ]
     },
     "mabosstiff": {
-        "level": 84,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -4063,7 +4063,7 @@
         ]
     },
     "koraidon": {
-        "level": 66,
+        "level": 65,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -4133,7 +4133,7 @@
         ]
     },
     "kingambit": {
-        "level": 76,
+        "level": 75,
         "sets": [
             {
                 "role": "Bulky Attacker",

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1513,7 +1513,7 @@ export class RandomTeams {
 			if (
 				pokemon.some(pkmn => pkmn.species === 'Zoroark-Hisui') &&
 				pokemon.length >= (this.maxTeamSize - 1) &&
-				(this.getLevel(species, isDoubles) < 72 || this.getLevel(species, isDoubles) > 86) &&
+				(this.getLevel(species, isDoubles) < 72 || this.getLevel(species, isDoubles) > 84) &&
 				!this.adjustLevel
 			) {
 				continue;


### PR DESCRIPTION
Winrate-based level balancing for this month, documented in a smogpost [here](https://www.smogon.com/forums/threads/random-battles-level-balancing.3721211/).
For the first time this month, Gen 1 is included.
As always, preferably merge this close to the month rollover so that June's stats are based on these new levels. Thank you!