### PR TITLE
Tournaments: Hide toolbox for players who has ended all battle

### DIFF
--- a/server/tournaments/generator-round-robin.ts
+++ b/server/tournaments/generator-round-robin.ts
@@ -164,6 +164,16 @@ export class RoundRobin {
 		match.result = result;
 		match.score = score.slice(0);
 		this.totalPendingMatches--;
+		if (this.matchesPerPlayer) {
+			if (p1.games === this.matchesPerPlayer) {
+				p1.sendRoom(`|tournament|update|{"isJoined":false}`);
+				p1.unlinkUser();
+			}
+			if (p2.games === this.matchesPerPlayer) {
+				p2.sendRoom(`|tournament|update|{"isJoined":false}`);
+				p2.unlinkUser();
+			}
+		}
 	}
 
 	isTournamentEnded() {

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -304,7 +304,7 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 			return;
 		}
 		const possiblePlayer = this.playerTable[targetUser.id];
-		let isJoined: boolean = false;
+		let isJoined = false;
 		if (possiblePlayer) {
 			if (this.generator.name === "Elimination") {
 				isJoined = !possiblePlayer.isEliminated && !possiblePlayer.isDisqualified;
@@ -314,8 +314,9 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 				} else if ((this.generator as RoundRobin)?.matchesPerPlayer) {
 					isJoined = possiblePlayer.games !== (this.generator as RoundRobin).matchesPerPlayer;
 				}
-			}
-			else isJoined = true;
+			} else {
+                isJoined = true;
+            }
 		}
 		const update: {
 			format: string, teambuilderFormat?: string, generator: string,

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -315,8 +315,8 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 					isJoined = possiblePlayer.games !== (this.generator as RoundRobin).matchesPerPlayer;
 				}
 			} else {
-                isJoined = true;
-            }
+				isJoined = true;
+			}
 		}
 		const update: {
 			format: string, teambuilderFormat?: string, generator: string,

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -303,7 +303,20 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 			);
 			return;
 		}
-		const isJoined = targetUser.id in this.playerTable;
+		const possiblePlayer = this.playerTable[targetUser.id];
+		let isJoined: boolean = false;
+		if (possiblePlayer) {
+			if (this.generator.name === "Elimination") {
+				isJoined = !possiblePlayer.isEliminated && !possiblePlayer.isDisqualified;
+			} else if (this.generator.name === "Round Robin") {
+				if (possiblePlayer.isDisqualified) {
+					isJoined = !possiblePlayer.isDisqualified;
+				} else if ((this.generator as RoundRobin)?.matchesPerPlayer) {
+					isJoined = possiblePlayer.games !== (this.generator as RoundRobin).matchesPerPlayer;
+				}
+			}
+			else isJoined = true;
+		}
 		const update: {
 			format: string, teambuilderFormat?: string, generator: string,
 			isStarted: boolean, isJoined: boolean, bracketData: AnyObject,

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -306,9 +306,9 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 		const possiblePlayer = this.playerTable[targetUser.id];
 		let isJoined = false;
 		if (possiblePlayer) {
-			if (this.generator.name === "Elimination") {
+			if (this.generator.name.includes("Elimination")) {
 				isJoined = !possiblePlayer.isEliminated && !possiblePlayer.isDisqualified;
-			} else if (this.generator.name === "Round Robin") {
+			} else if (this.generator.name.includes("Round Robin")) {
 				if (possiblePlayer.isDisqualified) {
 					isJoined = !possiblePlayer.isDisqualified;
 				} else if ((this.generator as RoundRobin)?.matchesPerPlayer) {


### PR DESCRIPTION
This PR has 2 changes:
・ Hide toolbox when eliminated players reconnected
・ Hide toolbox if the player have ended all battles in Round Robin