### PR TITLE
Random Battles updates

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -225,7 +225,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Focus Blast", "Nasty Plot", "Shadow Ball", "Sludge Bomb", "Trick"],
-                "teraTypes": ["Ghost"]
+                "teraTypes": ["Ghost", "Fighting"]
             },
             {
                 "role": "Fast Attacker",
@@ -809,6 +809,16 @@
             }
         ]
     },
+    "chansey": {
+        "level": 84,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Heal Bell", "Seismic Toss", "Soft-Boiled", "Stealth Rock", "Thunder Wave"],
+                "teraTypes": ["Steel", "Fairy", "Ghost", "Poison"]
+            }
+        ]
+    },
     "blissey": {
         "level": 84,
         "sets": [
@@ -1133,9 +1143,14 @@
         "level": 72,
         "sets": [
             {
+                "role": "Setup Sweeper",
+                "movepool": ["Dragon Ascent", "Dragon Dance", "Earthquake", "Outrage"],
+                "teraTypes": ["Flying"]
+            },
+            {
                 "role": "Fast Attacker",
-                "movepool": ["Dragon Ascent", "Dragon Dance", "Earthquake", "Extreme Speed", "Swords Dance", "U-turn"],
-                "teraTypes": ["Flying", "Normal"]
+                "movepool": ["Dragon Ascent", "Earthquake", "Extreme Speed", "Swords Dance", "U-turn"],
+                "teraTypes": ["Normal"]
             }
         ]
     },
@@ -1859,7 +1874,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Aqua Jet", "Ceaseless Edge", "Razor Shell", "Sucker Punch", "Swords Dance", "X-Scissor"],
+                "movepool": ["Aqua Jet", "Ceaseless Edge", "Razor Shell", "Sacred Sword", "Sucker Punch", "Swords Dance"],
                 "teraTypes": ["Water", "Dark"]
             }
         ]
@@ -2061,7 +2076,7 @@
         "level": 84,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Setup Sweeper",
                 "movepool": ["Agility", "Heat Wave", "Hurricane", "Psychic"],
                 "teraTypes": ["Psychic", "Fairy", "Steel", "Fire"]
             },
@@ -2161,7 +2176,7 @@
         "level": 78,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Bulky Support",
                 "movepool": ["Earthquake", "Stealth Rock", "Stone Edge", "Taunt", "U-turn"],
                 "teraTypes": ["Ground"]
             },
@@ -2907,12 +2922,12 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Close Combat", "Megahorn", "No Retreat", "Poison Jab", "Rock Slide"],
-                "teraTypes": ["Fighting", "Ghost"]
+                "movepool": ["Close Combat", "Iron Head", "Megahorn", "No Retreat", "Rock Slide"],
+                "teraTypes": ["Fighting", "Ghost", "Steel"]
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Close Combat", "No Retreat", "Poison Jab", "Tera Blast"],
+                "movepool": ["Close Combat", "Iron Head", "No Retreat", "Tera Blast"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -2973,7 +2988,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Calm Mind", "Dazzling Gleam", "Healing Wish", "Hyper Voice", "Psychic", "Psyshock", "Shadow Ball"],
-                "teraTypes": ["Psychic"]
+                "teraTypes": ["Psychic", "Fairy"]
             }
         ]
     },
@@ -2983,7 +2998,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Calm Mind", "Dazzling Gleam", "Healing Wish", "Hyper Voice", "Psychic", "Psyshock", "Shadow Ball"],
-                "teraTypes": ["Psychic"]
+                "teraTypes": ["Psychic", "Fairy"]
             }
         ]
     },
@@ -3358,7 +3373,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Axe Kick", "First Impression", "Leech Life", "Sucker Punch"],
-                "teraTypes": ["Bug"]
+                "teraTypes": ["Bug", "Fighting"]
             },
             {
                 "role": "Fast Attacker",
@@ -3951,9 +3966,14 @@
         "level": 80,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "AV Pivot",
                 "movepool": ["Close Combat", "Drain Punch", "Fake Out", "Heavy Slam", "Ice Punch", "Thunder Punch", "Volt Switch", "Wild Charge"],
                 "teraTypes": ["Electric", "Fighting"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Close Combat", "Drain Punch", "Ice Punch", "Swords Dance", "Wild Charge"],
+                "teraTypes": ["Flying", "Fighting", "Steel"]
             }
         ]
     },
@@ -4031,7 +4051,7 @@
                 "teraTypes": ["Ground", "Ghost", "Poison"]
             },
             {
-                "role": "Bulky Attacker",
+                "role": "AV Pivot",
                 "movepool": ["Body Press", "Earthquake", "Heavy Slam", "Ruination", "Stone Edge", "Throat Chop"],
                 "teraTypes": ["Ground", "Fighting", "Steel", "Poison"]
             }
@@ -4137,7 +4157,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Earth Power", "Giga Drain", "Knock Off", "Leaf Storm", "Rapid Spin", "Spore", "Toxic"],
+                "movepool": ["Earth Power", "Knock Off", "Leaf Storm", "Rapid Spin", "Spore", "Toxic"],
                 "teraTypes": ["Water"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -4157,7 +4157,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Earth Power", "Knock Off", "Leaf Storm", "Rapid Spin", "Spore", "Toxic"],
+                "movepool": ["Earth Power", "Giga Drain", "Knock Off", "Leaf Storm", "Rapid Spin", "Spore", "Toxic"],
                 "teraTypes": ["Water"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -810,7 +810,7 @@
         ]
     },
     "chansey": {
-        "level": 84,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Support",

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -106,7 +106,7 @@ const MovePairs = [
 
 /** Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type */
 const priorityPokemon = [
-	'banette', 'breloom', 'brutebonnet', 'cacturne', 'giratinaorigin', 'lycanrocdusk', 'mimikyu', 'scizor',
+	'banette', 'breloom', 'brutebonnet', 'cacturne', 'lycanrocdusk', 'mimikyu', 'scizor',
 ];
 
 /** Pokemon who should never be in the lead slot */
@@ -156,7 +156,7 @@ export class RandomTeams {
 		this.prng = prng && !Array.isArray(prng) ? prng : new PRNG(prng);
 
 		this.moveEnforcementCheckers = {
-			Bug: (movePool) => movePool.includes('megahorn'),
+			Bug: (movePool) => (movePool.includes('megahorn') || movePool.includes('xscissor')),
 			Dark: (movePool, moves, abilities, types, counter) => !counter.get('Dark'),
 			Dragon: (movePool, moves, abilities, types, counter) => (
 				!counter.get('Dragon') &&
@@ -949,7 +949,7 @@ export class RandomTeams {
 		case 'Technician':
 			return (!counter.get('technician') || abilities.has('Punk Rock'));
 		case 'Tinted Lens':
-			return (species.id === 'braviaryhisui' && role === 'Fast Support');
+			return (species.id === 'braviaryhisui' && role === 'Setup Sweeper');
 		case 'Unburden':
 			return (abilities.has('Prankster') || !counter.get('setup'));
 		case 'Volt Absorb':

--- a/tools/set-import/importer.ts
+++ b/tools/set-import/importer.ts
@@ -48,7 +48,7 @@ export const TIERS = new Set([
 	//
 	'vgc2016', 'vgc2017', 'vgc2018', 'vgc2019ultraseries', 'vgc2020', '1v1',
 	'anythinggoes', 'nationaldexag', 'almostanyability', 'balancedhackmons',
-	'letsgoou', 'monotype', 'purehackmons', 'nationaldexmonotype'
+	'letsgoou', 'monotype', 'purehackmons', 'nationaldexmonotype',
 ]);
 const FORMATS = new Map<ID, {gen: GenerationNum, format: Format}>();
 const VALIDATORS = new Map<ID, TeamValidator>();


### PR DESCRIPTION
Changes meant to reduce the frequency of choice items are marked with a *

don't mind the importer thing

-Giratina-Origin will no longer have forced Shadow Sneak, but will now have forced Shadow Ball.
-Kleavor will now always have X-Scissor.

-Agility Sheer Force Hisuian Braviary's set was renamed to "Setup Sweeper" to better reflect its role.
-Landorus-T's support set was changed to a "Bulky Support" role, which removes Life Orb from it and gives it only Leftovers.
-Ting-Lu: Set 2 was changed to an "AV Pivot" role, removing Choice Band. *
-Iron Hands: Set 1 was changed to an "AV Pivot role, removing Choice Band. *
-Iron Hands is also gaining a second set: Bulky Attacker with Swords Dance. It will get Leftovers.
-Chansey is being added. It will have Blissey's old set with Heal Bell added.
-Rayquaza set split: *
--Setup Sweeper, with Tera Flying Dragon Ascent / Outrage / Earthquake / DD. Gets Boots.
--Fast Attacker, with Tera Normal SD / ESpeed / Dragon Ascent / Earthquake / U-turn. Can get Boots or Choice Band.

Hisuian Samurott: -X-Scissor, +Sacred Sword
Falinks: -Poison Jab, +Iron Head, +Tera Steel on the non-Tera Blast set
Both Indeedees: +Tera Fairy
Gengar's Nasty Plot set: +Tera Fighting
Life Orb 4 Attacks Lokix: +Tera Fighting