### PR TITLE
Old Gens Random Battles updates

### DIFF
--- a/data/mods/gen3/random-data.json
+++ b/data/mods/gen3/random-data.json
@@ -873,7 +873,7 @@
     },
     "deoxysdefense": {
         "level": 76,
-        "moves": ["nightshade", "recover", "spikes", "taunt", "toxic"]
+        "moves": ["recover", "seismictoss", "spikes", "taunt", "toxic"]
     },
     "deoxysspeed": {
         "level": 76,

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -326,6 +326,8 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			return !moves.has('raindance') && !teamDetails['rain'];
 		case 'Swarm':
 			return !counter.get('Bug');
+		case 'Thick Fat':
+			return abilities.has('Immunity');
 		case 'Torrent':
 			return !counter.get('Water');
 		case 'Water Absorb':

--- a/data/mods/gen4/random-data.json
+++ b/data/mods/gen4/random-data.json
@@ -29,7 +29,7 @@
     },
     "fearow": {
         "level": 88,
-        "moves": ["doubleedge", "drillpeck", "heatwave", "pursuit", "quickattack", "return", "uturn"]
+        "moves": ["doubleedge", "drillpeck", "pursuit", "quickattack", "return", "uturn"]
     },
     "arbok": {
         "level": 90,
@@ -73,7 +73,7 @@
     },
     "parasect": {
         "level": 93,
-        "moves": ["leechseed", "seedbomb", "spore", "stunspore", "synthesis", "xscissor"]
+        "moves": ["seedbomb", "spore", "stunspore", "synthesis", "xscissor"]
     },
     "venomoth": {
         "level": 87,
@@ -281,7 +281,7 @@
     },
     "mew": {
         "level": 76,
-        "moves": ["aurasphere", "explosion", "flamethrower", "nastyplot", "psychic", "softboiled", "stealthrock", "taunt", "uturn", "willowisp"]
+        "moves": ["aurasphere", "batonpass", "explosion", "flamethrower", "nastyplot", "psychic", "softboiled", "stealthrock", "taunt", "uturn", "willowisp"]
     },
     "meganium": {
         "level": 89,
@@ -501,7 +501,7 @@
     },
     "celebi": {
         "level": 80,
-        "moves": ["earthpower", "energyball", "hiddenpowerfire", "leafstorm", "leechseed", "nastyplot", "psychic", "recover", "stealthrock", "substitute", "thunderwave", "uturn"]
+        "moves": ["batonpass", "earthpower", "energyball", "hiddenpowerfire", "leafstorm", "leechseed", "nastyplot", "psychic", "recover", "stealthrock", "substitute", "thunderwave", "uturn"]
     },
     "sceptile": {
         "level": 84,
@@ -585,7 +585,7 @@
     },
     "delcatty": {
         "level": 96,
-        "moves": ["healbell", "protect", "return", "sing", "thunderwave", "wish"]
+        "moves": ["healbell", "protect", "return", "thunderwave", "wish"]
     },
     "sableye": {
         "level": 94,
@@ -921,7 +921,7 @@
     },
     "bronzong": {
         "level": 80,
-        "moves": ["earthquake", "explosion", "gyroball", "hypnosis", "lightscreen", "payback", "reflect", "stealthrock"]
+        "moves": ["earthquake", "explosion", "gyroball", "lightscreen", "payback", "reflect", "stealthrock", "toxic"]
     },
     "chatot": {
         "level": 89,
@@ -1037,23 +1037,23 @@
     },
     "rotomheat": {
         "level": 79,
-        "moves": ["discharge", "lightscreen", "overheat", "painsplit", "reflect", "shadowball", "thunderbolt", "trick", "willowisp"]
+        "moves": ["lightscreen", "overheat", "painsplit", "reflect", "shadowball", "thunderbolt", "trick", "willowisp"]
     },
     "rotomwash": {
         "level": 80,
-        "moves": ["discharge", "hydropump", "lightscreen", "reflect", "rest", "shadowball", "sleeptalk", "thunderbolt", "trick", "willowisp"]
+        "moves": ["hydropump", "lightscreen", "reflect", "rest", "shadowball", "sleeptalk", "thunderbolt", "trick", "willowisp"]
     },
     "rotomfrost": {
         "level": 80,
-        "moves": ["blizzard", "discharge", "lightscreen", "reflect", "rest", "shadowball", "sleeptalk", "thunderbolt", "trick", "willowisp"]
+        "moves": ["blizzard", "lightscreen", "reflect", "rest", "shadowball", "sleeptalk", "thunderbolt", "trick", "willowisp"]
     },
     "rotomfan": {
         "level": 79,
-        "moves": ["discharge", "lightscreen", "painsplit", "reflect", "rest", "shadowball", "sleeptalk", "thunderbolt", "willowisp"]
+        "moves": ["lightscreen", "painsplit", "reflect", "rest", "shadowball", "sleeptalk", "thunderbolt", "willowisp"]
     },
     "rotommow": {
         "level": 80,
-        "moves": ["discharge", "leafstorm", "lightscreen", "painsplit", "reflect", "shadowball", "thunderbolt", "trick", "willowisp"]
+        "moves": ["leafstorm", "lightscreen", "painsplit", "reflect", "shadowball", "thunderbolt", "trick", "willowisp"]
     },
     "rotom": {
         "level": 84,

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -247,7 +247,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		case 'chargebeam':
 			return {cull: moves.has('thunderbolt') && counter.get('Special') < 3};
 		case 'discharge':
-			return {cull: moves.has('thunderbolt') || moves.has('shadowball')};
+			return {cull: moves.has('thunderbolt')};
 		case 'energyball':
 			return {cull: (
 				moves.has('woodhammer') ||

--- a/data/mods/gen5/random-data.json
+++ b/data/mods/gen5/random-data.json
@@ -325,7 +325,7 @@
     },
     "crobat": {
         "level": 82,
-        "moves": ["bravebird", "heatwave", "roost", "sludgebomb", "superfang", "taunt", "toxic", "uturn"]
+        "moves": ["bravebird", "heatwave", "roost", "superfang", "taunt", "toxic", "uturn"]
     },
     "lanturn": {
         "level": 84,

--- a/data/mods/gen6/random-data.json
+++ b/data/mods/gen6/random-data.json
@@ -624,7 +624,7 @@
     },
     "magcargo": {
         "level": 89,
-        "moves": ["ancientpower", "lavaplume", "recover", "stealthrock", "toxic"],
+        "moves": ["ancientpower", "earthpower", "fireblast", "hiddenpowergrass", "lavaplume", "recover", "shellsmash", "stealthrock", "toxic"],
         "doublesMoves": ["ancientpower", "earthpower", "fireblast", "heatwave", "hiddenpowergrass", "protect", "shellsmash", "stealthrock", "willowisp"]
     },
     "corsola": {

--- a/data/mods/gen6/random-data.json
+++ b/data/mods/gen6/random-data.json
@@ -166,7 +166,7 @@
     },
     "alakazam": {
         "level": 82,
-        "moves": ["focusblast", "hiddenpowerfire", "hiddenpowerice", "psychic", "psyshock", "shadowball"],
+        "moves": ["counter", "focusblast", "hiddenpowerfire", "hiddenpowerice", "psychic", "psyshock", "shadowball"],
         "doublesMoves": ["dazzlinggleam", "encore", "focusblast", "protect", "psychic", "psyshock", "shadowball", "substitute"]
     },
     "machamp": {
@@ -565,7 +565,7 @@
     },
     "dunsparce": {
         "level": 88,
-        "moves": ["bite", "bodyslam", "coil", "glare", "headbutt", "rockslide", "roost"],
+        "moves": ["bite", "bodyslam", "coil", "earthquake", "glare", "headbutt", "roost"],
         "doublesMoves": ["bite", "bodyslam", "coil", "glare", "headbutt", "protect", "rockslide"]
     },
     "gligar": {
@@ -624,7 +624,7 @@
     },
     "magcargo": {
         "level": 89,
-        "moves": ["ancientpower", "earthpower", "fireblast", "hiddenpowergrass", "lavaplume", "recover", "shellsmash", "stealthrock", "toxic"],
+        "moves": ["ancientpower", "lavaplume", "recover", "stealthrock", "toxic"],
         "doublesMoves": ["ancientpower", "earthpower", "fireblast", "heatwave", "hiddenpowergrass", "protect", "shellsmash", "stealthrock", "willowisp"]
     },
     "corsola": {
@@ -960,7 +960,7 @@
     },
     "torkoal": {
         "level": 88,
-        "moves": ["earthpower", "lavaplume", "rapidspin", "stealthrock", "yawn"],
+        "moves": ["earthquake", "lavaplume", "rapidspin", "stealthrock", "yawn"],
         "doublesMoves": ["earthpower", "fireblast", "heatwave", "hiddenpowergrass", "protect", "shellsmash", "willowisp"]
     },
     "grumpig": {
@@ -1216,7 +1216,7 @@
     },
     "deoxys": {
         "level": 77,
-        "moves": ["extremespeed", "firepunch", "knockoff", "psychoboost", "spikes", "stealthrock", "superpower", "taunt"],
+        "moves": ["extremespeed", "firepunch", "icebeam", "knockoff", "psychoboost", "stealthrock", "superpower"],
         "doublesMoves": ["extremespeed", "firepunch", "icebeam", "knockoff", "protect", "psychoboost", "psyshock", "superpower", "thunderbolt"]
     },
     "deoxysattack": {
@@ -1286,7 +1286,7 @@
     },
     "wormadam": {
         "level": 95,
-        "moves": ["gigadrain", "hiddenpowerrock", "protect", "signalbeam", "synthesis", "toxic"],
+        "moves": ["gigadrain", "hiddenpowerground", "hiddenpowerrock", "protect", "signalbeam", "synthesis", "toxic"],
         "doublesMoves": ["gigadrain", "hiddenpowerice", "hiddenpowerrock", "leafstorm", "protect", "signalbeam", "stringshot"]
     },
     "wormadamsandy": {
@@ -1424,7 +1424,7 @@
     },
     "carnivine": {
         "level": 92,
-        "moves": ["knockoff", "powerwhip", "return", "sleeppowder", "substitute", "swordsdance"],
+        "moves": ["defog", "knockoff", "powerwhip", "return", "sleeppowder", "substitute", "swordsdance"],
         "doublesMoves": ["knockoff", "leechseed", "powerwhip", "protect", "ragepowder", "return", "sleeppowder", "substitute", "swordsdance"]
     },
     "lumineon": {
@@ -2052,7 +2052,7 @@
     },
     "bisharp": {
         "level": 80,
-        "moves": ["ironhead", "knockoff", "lowkick", "suckerpunch", "swordsdance"],
+        "moves": ["ironhead", "knockoff", "suckerpunch", "swordsdance"],
         "doublesMoves": ["brickbreak", "ironhead", "knockoff", "protect", "substitute", "suckerpunch", "swordsdance"]
     },
     "bouffalant": {
@@ -2197,7 +2197,7 @@
     },
     "diggersby": {
         "level": 82,
-        "moves": ["agility", "earthquake", "knockoff", "quickattack", "return", "swordsdance", "uturn", "wildcharge"],
+        "moves": ["agility", "earthquake", "knockoff", "quickattack", "return", "swordsdance", "uturn"],
         "doublesMoves": ["earthquake", "protect", "quickattack", "return", "uturn", "wildcharge"]
     },
     "talonflame": {
@@ -2412,7 +2412,7 @@
     },
     "volcanion": {
         "level": 80,
-        "moves": ["earthpower", "fireblast", "hiddenpowerice", "sludgewave", "steameruption", "substitute", "superpower"],
+        "moves": ["defog", "earthpower", "fireblast", "hiddenpowerice", "sludgewave", "steameruption", "substitute", "superpower"],
         "doublesMoves": ["earthquake", "heatwave", "protect", "rockslide", "sludgebomb", "steameruption", "substitute"]
     }
 }

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -228,7 +228,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			const screens = moves.has('lightscreen') && moves.has('reflect');
 			return {cull: (
 				moves.has('rest') || screens || (!!counter.setupType && !moves.has('wish')) ||
-				(!['Guts', 'Harvest', 'Poison Heal', 'Quick Feet', 'Speed Boost'].some(abil => abilities.has(abil)) &&
+				(!['Guts', 'Harvest', 'Quick Feet', 'Speed Boost'].some(abil => abilities.has(abil)) &&
 				!['leechseed', 'perishsong', 'toxic', 'wish'].some(m => moves.has(m)) &&
 				!['sharpedomega', 'dianciemega'].includes(species.id))
 			)};
@@ -679,12 +679,10 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if ((ability === 'Guts' || moves.has('facade')) && !moves.has('sleeptalk')) {
 			return moves.has('drainpunch') ? 'Flame Orb' : 'Toxic Orb';
 		}
-		if (
-			(ability === 'Magic Guard' && counter.damagingMoves.size > 1) ||
-			(ability === 'Sheer Force' && !!counter.get('sheerforce'))
-		) {
-			return 'Life Orb';
+		if (ability === 'Magic Guard' && counter.damagingMoves.size > 1) {
+			return moves.has('counter') ? 'Focus Sash' : 'Life Orb';
 		}
+		if (ability === 'Sheer Force' && counter.get('sheerforce')) return 'Life Orb';
 		if (moves.has('psychoshift')) return 'Flame Orb';
 		if (ability === 'Poison Heal') return 'Toxic Orb';
 		if (ability === 'Unburden') {

--- a/data/mods/gen7/random-data.json
+++ b/data/mods/gen7/random-data.json
@@ -677,7 +677,7 @@
     },
     "magcargo": {
         "level": 90,
-        "moves": ["ancientpower", "lavaplume", "recover", "stealthrock", "toxic"],
+        "moves": ["ancientpower", "earthpower", "fireblast", "hiddenpowergrass", "lavaplume", "recover", "shellsmash", "stealthrock", "toxic"],
         "doublesMoves": ["earthpower", "fireblast", "heatwave", "incinerate", "protect", "stealthrock", "willowisp"]
     },
     "corsola": {

--- a/data/mods/gen7/random-data.json
+++ b/data/mods/gen7/random-data.json
@@ -191,7 +191,7 @@
     },
     "alakazam": {
         "level": 82,
-        "moves": ["focusblast", "hiddenpowerfire", "psychic", "psyshock", "shadowball"],
+        "moves": ["counter", "focusblast", "hiddenpowerfire", "psychic", "psyshock", "shadowball"],
         "doublesMoves": ["dazzlinggleam", "encore", "focusblast", "protect", "psychic", "shadowball"]
     },
     "alakazammega": {
@@ -618,7 +618,7 @@
     },
     "dunsparce": {
         "level": 91,
-        "moves": ["bite", "bodyslam", "coil", "glare", "headbutt", "rockslide", "roost"],
+        "moves": ["bite", "bodyslam", "coil", "earthquake", "glare", "headbutt", "roost"],
         "doublesMoves": ["bite", "bodyslam", "coil", "glare", "headbutt", "protect", "rockslide"]
     },
     "gligar": {
@@ -677,7 +677,7 @@
     },
     "magcargo": {
         "level": 90,
-        "moves": ["ancientpower", "earthpower", "fireblast", "hiddenpowergrass", "lavaplume", "recover", "shellsmash", "stealthrock", "toxic"],
+        "moves": ["ancientpower", "lavaplume", "recover", "stealthrock", "toxic"],
         "doublesMoves": ["earthpower", "fireblast", "heatwave", "incinerate", "protect", "stealthrock", "willowisp"]
     },
     "corsola": {
@@ -850,7 +850,7 @@
     },
     "shiftry": {
         "level": 88,
-        "moves": ["defog", "knockoff", "leafstorm", "lowkick", "seedbomb", "suckerpunch", "swordsdance"],
+        "moves": ["defog", "knockoff", "leafblade", "leafstorm", "lowkick", "suckerpunch", "swordsdance"],
         "doublesMoves": ["fakeout", "knockoff", "leafblade", "leafstorm", "protect", "suckerpunch", "swordsdance"]
     },
     "swellow": {
@@ -1015,7 +1015,7 @@
     },
     "torkoal": {
         "level": 84,
-        "moves": ["earthpower", "fireblast", "lavaplume", "rapidspin", "shellsmash", "solarbeam", "stealthrock", "yawn"],
+        "moves": ["earthquake", "lavaplume", "rapidspin", "solarbeam", "stealthrock", "yawn"],
         "doublesMoves": ["earthpower", "fireblast", "heatwave", "protect", "solarbeam", "willowisp"]
     },
     "grumpig": {
@@ -1025,7 +1025,7 @@
     },
     "spinda": {
         "level": 100,
-        "moves": ["encore", "return", "rockslide", "superpower"],
+        "moves": ["encore", "return", "suckerpunch", "superpower"],
         "doublesMoves": ["fakeout", "protect", "return", "suckerpunch", "superpower", "trickroom"]
     },
     "flygon": {
@@ -1342,7 +1342,7 @@
     },
     "wormadam": {
         "level": 92,
-        "moves": ["bugbuzz", "gigadrain", "hiddenpowerrock", "leafstorm", "quiverdance"],
+        "moves": ["bugbuzz", "gigadrain", "hiddenpowerground", "hiddenpowerrock", "leafstorm", "quiverdance"],
         "doublesMoves": ["bugbuzz", "gigadrain", "leafstorm", "protect", "stringshot"]
     },
     "wormadamsandy": {
@@ -1381,7 +1381,6 @@
     },
     "cherrimsunshine": {
         "level": 92,
-        "moves": ["gigadrain", "hiddenpowerice", "solarbeam", "sunnyday", "weatherball"],
         "doublesMoves": ["gigadrain", "helpinghand", "solarbeam", "sunnyday", "weatherball"]
     },
     "gastrodon": {
@@ -1481,7 +1480,7 @@
     },
     "carnivine": {
         "level": 92,
-        "moves": ["knockoff", "powerwhip", "return", "sleeppowder", "substitute", "swordsdance"],
+        "moves": ["defog", "knockoff", "powerwhip", "return", "sleeppowder", "substitute", "swordsdance"],
         "doublesMoves": ["knockoff", "powerwhip", "protect", "ragepowder", "return", "sleeppowder", "swordsdance"]
     },
     "lumineon": {
@@ -2109,7 +2108,7 @@
     },
     "bisharp": {
         "level": 82,
-        "moves": ["ironhead", "knockoff", "lowkick", "suckerpunch", "swordsdance"],
+        "moves": ["ironhead", "knockoff", "suckerpunch", "swordsdance"],
         "doublesMoves": ["ironhead", "knockoff", "protect", "suckerpunch", "swordsdance"]
     },
     "bouffalant": {
@@ -2478,12 +2477,12 @@
     },
     "volcanion": {
         "level": 82,
-        "moves": ["earthpower", "fireblast", "sludgebomb", "steameruption", "substitute", "superpower"],
+        "moves": ["defog", "earthpower", "fireblast", "sludgebomb", "steameruption", "substitute", "superpower"],
         "doublesMoves": ["earthpower", "heatwave", "protect", "sludgebomb", "steameruption"]
     },
     "decidueye": {
         "level": 86,
-        "moves": ["leafblade", "roost", "shadowsneak", "spiritshackle", "swordsdance", "uturn"],
+        "moves": ["defog", "leafblade", "roost", "shadowsneak", "spiritshackle", "swordsdance", "uturn"],
         "doublesMoves": ["bravebird", "leafblade", "protect", "spiritshackle", "suckerpunch"]
     },
     "incineroar": {
@@ -2578,7 +2577,7 @@
     },
     "lurantis": {
         "level": 90,
-        "moves": ["hiddenpowerice", "knockoff", "leafstorm", "superpower", "synthesis"],
+        "moves": ["defog", "hiddenpowerice", "knockoff", "leafstorm", "superpower", "synthesis"],
         "doublesMoves": ["hiddenpowerice", "knockoff", "leafstorm", "protect", "superpower"]
     },
     "shiinotic": {
@@ -2603,7 +2602,7 @@
     },
     "comfey": {
         "level": 86,
-        "moves": ["aromatherapy", "drainingkiss", "synthesis", "toxic", "uturn"],
+        "moves": ["aromatherapy", "defog", "drainingkiss", "synthesis", "toxic", "uturn"],
         "doublesMoves": ["drainingkiss", "floralhealing", "taunt", "toxic", "uturn"]
     },
     "oranguru": {
@@ -2657,12 +2656,12 @@
     },
     "silvallyelectric": {
         "level": 87,
-        "moves": ["flamethrower", "icebeam", "multiattack", "partingshot", "toxic"],
+        "moves": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic"],
         "doublesMoves": ["icebeam", "partingshot", "protect", "snarl", "thunderbolt", "thunderwave", "uturn"]
     },
     "silvallyfairy": {
         "level": 87,
-        "moves": ["flamethrower", "multiattack", "partingshot", "rockslide", "thunderwave"],
+        "moves": ["defog", "flamethrower", "multiattack", "partingshot", "rockslide", "thunderwave"],
         "doublesMoves": ["flamethrower", "icebeam", "multiattack", "partingshot", "protect", "thunderwave", "uturn"]
     },
     "silvallyfighting": {
@@ -2677,17 +2676,17 @@
     },
     "silvallyflying": {
         "level": 87,
-        "moves": ["flamethrower", "ironhead", "multiattack", "partingshot", "thunderwave"],
+        "moves": ["defog", "flamethrower", "ironhead", "multiattack", "partingshot", "thunderwave"],
         "doublesMoves": ["flamecharge", "ironhead", "multiattack", "partingshot", "protect", "swordsdance", "thunderwave", "uturn"]
     },
     "silvallyghost": {
         "level": 87,
-        "moves": ["flamethrower", "icebeam", "multiattack", "partingshot", "toxic"],
+        "moves": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic"],
         "doublesMoves": ["icebeam", "multiattack", "partingshot", "protect", "uturn"]
     },
     "silvallygrass": {
         "level": 87,
-        "moves": ["flamethrower", "icebeam", "multiattack", "partingshot", "toxic"],
+        "moves": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic"],
         "doublesMoves": ["flamethrower", "icebeam", "multiattack", "partingshot", "protect", "thunderwave", "uturn"]
     },
     "silvallyground": {
@@ -2697,22 +2696,22 @@
     },
     "silvallyice": {
         "level": 87,
-        "moves": ["flamethrower", "multiattack", "thunderbolt", "toxic", "uturn"],
+        "moves": ["defog", "flamethrower", "multiattack", "thunderbolt", "toxic", "uturn"],
         "doublesMoves": ["icebeam", "partingshot", "protect", "thunderbolt", "thunderwave", "uturn"]
     },
     "silvallypoison": {
         "level": 87,
-        "moves": ["flamethrower", "icebeam", "multiattack", "partingshot", "toxic"],
+        "moves": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic"],
         "doublesMoves": ["flamethrower", "icebeam", "multiattack", "partingshot", "protect", "thunderwave", "uturn"]
     },
     "silvallypsychic": {
         "level": 87,
-        "moves": ["flamethrower", "multiattack", "partingshot", "rockslide", "thunderwave"],
+        "moves": ["defog", "flamethrower", "multiattack", "partingshot", "rockslide", "thunderwave"],
         "doublesMoves": ["flamethrower", "multiattack", "partingshot", "protect", "thunderwave", "uturn"]
     },
     "silvallyrock": {
         "level": 87,
-        "moves": ["flamethrower", "grasspledge", "multiattack", "partingshot", "toxic"],
+        "moves": ["defog", "flamethrower", "grasspledge", "multiattack", "partingshot", "toxic"],
         "doublesMoves": ["flamethrower", "icebeam", "partingshot", "protect", "rockslide", "uturn"]
     },
     "silvallysteel": {
@@ -2757,7 +2756,7 @@
     },
     "drampa": {
         "level": 89,
-        "moves": ["dracometeor", "dragonpulse", "fireblast", "glare", "hypervoice", "roost", "thunderbolt"],
+        "moves": ["defog", "dracometeor", "dragonpulse", "fireblast", "glare", "hypervoice", "roost", "thunderbolt"],
         "doublesMoves": ["dracometeor", "dragonpulse", "fireblast", "glare", "hypervoice", "protect", "roost"]
     },
     "dhelmise": {

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -272,7 +272,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			);
 			const singlesCondition = (
 				(counter.setupType && !moves.has('wish')) ||
-				(!['Guts', 'Harvest', 'Poison Heal', 'Quick Feet', 'Speed Boost'].some(abil => abilities.has(abil)) &&
+				(!['Guts', 'Harvest', 'Quick Feet', 'Speed Boost'].some(abil => abilities.has(abil)) &&
 				!['leechseed', 'perishsong', 'toxic', 'wish'].some(m => moves.has(m)) &&
 				species.id !== 'sharpedomega')
 			);
@@ -436,8 +436,6 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				(isDoubles && moves.has('energyball')) ||
 				(counter.get('Grass') > 1 && !!counter.setupType)
 			)};
-		case 'seedbomb':
-			return {cull: moves.has('leafstorm') || isDoubles && moves.has('gigadrain')};
 		case 'solarbeam':
 			return {cull: (
 				(!abilities.has('Drought') && !moves.has('sunnyday')) ||
@@ -784,12 +782,10 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if ((ability === 'Guts' || moves.has('facade')) && !moves.has('sleeptalk')) {
 			return (types.has('Fire') || ability === 'Quick Feet' || ability === 'Toxic Boost') ? 'Toxic Orb' : 'Flame Orb';
 		}
-		if (
-			(ability === 'Magic Guard' && counter.damagingMoves.size > 1) ||
-			(ability === 'Sheer Force' && counter.get('sheerforce'))
-		) {
-			return 'Life Orb';
+		if (ability === 'Magic Guard' && counter.damagingMoves.size > 1) {
+			return moves.has('counter') ? 'Focus Sash' : 'Life Orb';
 		}
+		if (ability === 'Sheer Force' && counter.get('sheerforce')) return 'Life Orb';
 		if (ability === 'Unburden') return moves.has('fakeout') ? 'Normal Gem' : 'Sitrus Berry';
 		if (moves.has('acrobatics')) return '';
 		if (moves.has('electricterrain') || ability === 'Electric Surge' && moves.has('thunderbolt')) return 'Electrium Z';
@@ -1546,7 +1542,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				case 'Aegislash': case 'Basculin': case 'Gourgeist': case 'Groudon': case 'Kyogre': case 'Meloetta':
 					if (this.randomChance(1, 2)) continue;
 					break;
-				case 'Cherrim': case 'Greninja':
+				case 'Greninja':
 					if (this.gen >= 7 && this.randomChance(1, 2)) continue;
 					break;
 				}


### PR DESCRIPTION
Gen 3:
-Deoxys-Defense: -Night Shade +Seismic Toss
-Snorlax now gets Immunity as its ability instead of Thick Fat

Gen 4:
-Fearow: -Heat Wave
-Parasect: -Leech Seed
-Mew, Celebi: +Baton Pass
-Delcatty: -Sing
-Bronzong: -Hypnosis, +Toxic
-Rotom formes: -Discharge

Gen 5:
-Crobat: -Sludge Bomb

Gen 6:
-Torkoal: -Earth Power, +Earthquake
-Deoxys: -Spikes, -Taunt, +Ice Beam (removes Leftovers Deoxys)
-Diggersby: -Wild Charge

Gen 6-7:
-Alakazam: +Counter, get Focus Sash with Counter
-Dunsparce: -Rock Slide, +Earthquake
-Wormadam: +Hidden Power Ground
-Carnivine, Volcanion: +Defog
-Bisharp: -Low Kick
-Gliscor will get Protect less often, and only alongside Toxic

Gen 7:
-Shiftry -Seed Bomb, +Leaf Blade
-Torkoal -Earth Power, -Fire Blast, -Shell Smash +Earthquake
-Spinda -Rock Slide +Sucker Punch
-Remove Cherrim-Sunshine
-Add Defog to the following: Silvally (Electric, Fairy, Flying, Ghost, Grass, Ice, Poison, Psychic, Rock), Oricorio (All Formes), Lurantis, Drampa, Decidueye, Comfey