### PR TITLE
Gen 1: Recovery moves *do* work in some cases when HP is 255 below Max HP

### DIFF
--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -627,9 +627,15 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		heal: null,
 		onHit(target) {
 			if (target.hp === target.maxhp) return false;
-			// Fail when health is 255 or 511 less than max
-			if (target.hp === (target.maxhp - 255) || target.hp === (target.maxhp - 511) || target.hp === target.maxhp) {
-				this.hint("In Gen 1, recovery moves fail if (user's maximum HP - user's current HP + 1) is divisible by 256.");
+			// Fail when health is 255 or 511 less than max, unless it is divisible by 256
+			if (
+				target.hp === target.maxhp ||
+				((target.hp === (target.maxhp - 255) || target.hp === (target.maxhp - 511)) && target.hp % 256 !== 0)
+			) {
+				this.hint(
+					"In Gen 1, recovery moves fail if (user's maximum HP - user's current HP + 1) is divisible by 256, " +
+					"unless the current hp is also divisible by 256."
+				);
 				return false;
 			}
 			this.heal(Math.floor(target.maxhp / 2), target, target);
@@ -664,9 +670,15 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		onTry() {},
 		onHit(target, source, move) {
 			if (target.hp === target.maxhp) return false;
-			// Fail when health is 255 or 511 less than max
-			if (target.hp === (target.maxhp - 255) || target.hp === (target.maxhp - 511)) {
-				this.hint("In Gen 1, recovery moves fail if (user's maximum HP - user's current HP + 1) is divisible by 256.");
+			// Fail when health is 255 or 511 less than max, unless it is divisible by 256
+			if (
+				target.hp === target.maxhp ||
+				((target.hp === (target.maxhp - 255) || target.hp === (target.maxhp - 511)) && target.hp % 256 !== 0)
+			) {
+				this.hint(
+					"In Gen 1, recovery moves fail if (user's maximum HP - user's current HP + 1) is divisible by 256, " +
+					"unless the current hp is also divisible by 256."
+				);
 				return false;
 			}
 			if (!target.setStatus('slp', source, move)) return false;
@@ -762,9 +774,15 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		heal: null,
 		onHit(target) {
 			if (target.hp === target.maxhp) return false;
-			// Fail when health is 255 or 511 less than max
-			if (target.hp === (target.maxhp - 255) || target.hp === (target.maxhp - 511) || target.hp === target.maxhp) {
-				this.hint("In Gen 1, recovery moves fail if (user's maximum HP - user's current HP + 1) is divisible by 256.");
+			// Fail when health is 255 or 511 less than max, unless it is divisible by 256
+			if (
+				target.hp === target.maxhp ||
+				((target.hp === (target.maxhp - 255) || target.hp === (target.maxhp - 511)) && target.hp % 256 !== 0)
+			) {
+				this.hint(
+					"In Gen 1, recovery moves fail if (user's maximum HP - user's current HP + 1) is divisible by 256, " +
+					"unless the current hp is also divisible by 256."
+				);
 				return false;
 			}
 			this.heal(Math.floor(target.maxhp / 2), target, target);


### PR DESCRIPTION
I was digging into the decomp and discovered this absolutely *meta shaking* oversight for Gen 1.

There is a known bug which causes Rest, Recover, etc. to fail to heal when the user's current HP is exactly 255 or 511 less than its max HP. Smogon accounts for this and checks for that condition for the Gen 1 moves Rest, Recover, and Softboiled, and shows a nice warning.

I was trying to understand the reason for this being 255 and not 256, so I dug into the assembly and figured it out (StackOverflow investigation [here](https://stackoverflow.com/questions/69195926/trying-to-figure-out-why-a-certain-pokemon-red-blue-glitch-occurs-why-do-the-pr/76470195#76470195)). The how isn't important here, though. The important thing is that the subtraction will NOT produce an erroneous "failed" result if the "high byte" of the current HP and max HP match each other. This can happen if the difference is 255 or 511, but the current HP value itself is 256 or 512. I have verified this myself with a hacked chansey on emulator, which I damaged to specific values using poison ticks in the overworld.

This *obviously* needs to be fixed *immediately* - imagine how many times *each day* someone tries to heal their massively underleveled Chansey that only has 511 max HP and sees the popup taunting them: `"In Gen 1, recovery moves fail if (user's maximum HP - user's current HP + 1) is divisible by 256."` When IN FACTUAL TRUTH they should be comfortably shrugging off Body Slams for days. /sarcasm

On a more serious note - Snorlax only has 523 max HP, and it wouldn't be entirely insane for someone to drop it to 511 if they felt threatened by the risk of failing Rest. Probably not common though...