### PR TITLE
Add Freedom Cup

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -245,6 +245,16 @@ export const Formats: FormatList = [
 		banlist: ['Walking Wake', 'Iron Leaves'],
 	},
 	{
+		name: "[Gen 9] Freedom Cup",
+		threads: [
+			`&bullet; <a href="https://www.smogon.com/forums/threads/3722982/">Freedom Cup Tournament Thread</a>`,
+		],
+
+		mod: 'gen9',
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 9'],
+		banlist: ['Walking Wake', 'Iron Leaves'],
+	},
+	{
 		name: "[Gen 9] Custom Game",
 
 		mod: 'gen9',
@@ -501,16 +511,6 @@ export const Formats: FormatList = [
 		mod: 'gen8joltemons',
 		team: 'random',
 		ruleset: ['Dynamax Clause', 'Obtainable', 'Species Clause', 'HP Percentage Mod', 'Cancel Mod', 'Sleep Clause Mod', 'Mega Data Mod', 'Z-Move Clause'],
-	},
-	{
-		name: "[Gen 9] Freedom Cup",
-		threads: [
-			`&bullet; <a href="https://www.smogon.com/forums/threads/3722982/">Freedom Cup Tournament Thread</a>`,
-		],
-
-		mod: 'gen9',
-		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 9'],
-		banlist: ['Walking Wake', 'Iron Leaves'],
 	},
 	{
 		name: "[Gen 6] NEXT OU",

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -503,6 +503,16 @@ export const Formats: FormatList = [
 		ruleset: ['Dynamax Clause', 'Obtainable', 'Species Clause', 'HP Percentage Mod', 'Cancel Mod', 'Sleep Clause Mod', 'Mega Data Mod', 'Z-Move Clause'],
 	},
 	{
+		name: "[Gen 9] Freedom Cup",
+		threads: [
+			`&bullet; <a href="https://www.smogon.com/forums/threads/3722982/">Freedom Cup Tournament Thread</a>`,
+		],
+
+		mod: 'gen9',
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 9'],
+		banlist: ['Walking Wake', 'Iron Leaves'],
+	},
+	{
 		name: "[Gen 6] NEXT OU",
 		threads: [
 			`&bullet; <a href="https://www.smogon.com/forums/threads/3476151/">Gen-NEXT Development Thread</a>`,


### PR DESCRIPTION
To go live June 15th 11:59:59 pm. See https://www.smogon.com/forums/threads/1000-ladder-tour-freedom-cup-playing-competitive-pokemon-how-the-pokemon-company-intended.3722982/

The only thing left for the format is debating where we want it to live. Currently, it's in Pet Mods, but doesn't mod any actual game mechanics. SV Singles or Other Metagames would be the other candidates.