### PR TITLE
Send revealed set information in 'poke' messages

### DIFF
--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -778,7 +778,7 @@ export const commands: Chat.ChatCommands = {
 		`!showset [number] - shows the set of the pokemon corresponding to that number (in original Team Preview order, not necessarily current order)`,
 	],
 
-	async acceptopenteamsheets(target, room, user, connection, cmd) {
+	acceptopenteamsheets(target, room, user, connection, cmd) {
 		room = this.requireRoom();
 		const battle = room.battle;
 		if (!battle) return this.errorReply(this.tr`Must be in a battle room.`);
@@ -804,15 +804,7 @@ export const commands: Chat.ChatCommands = {
 
 		this.add(this.tr`${user.name} has agreed to open team sheets.`);
 		if (battle.players.every(curPlayer => curPlayer.wantsOpenTeamSheets)) {
-			let buf = '|uhtml|ots|';
-			for (const curPlayer of battle.players) {
-				const team = await battle.getTeam(curPlayer.id);
-				if (!team) continue;
-				buf += Utils.html`<div class="infobox" style="margin-top:5px"><details><summary>Open Team Sheet for ${curPlayer.name}</summary>${Teams.export(team, {hideStats: true})}</details></div>`;
-			}
-			for (const curPlayer of battle.players) {
-				curPlayer.sendRoom(buf);
-			}
+			battle.forceOpenTeamSheets();
 		}
 	},
 	acceptopenteamsheetshelp: [`/acceptopenteamsheets - Agrees to an open team sheet opportunity during Team Preview, where all information on a team except stats is shared with the opponent. Requires: \u2606`],

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1088,6 +1088,10 @@ export class RoomBattle extends RoomGames.RoomGame<RoomBattlePlayer> {
 		return true;
 	}
 
+	forceOpenTeamSheets() {
+		void this.stream.write(`>force-openteamsheets`);
+	}
+
 	/**
 	 * playerOpts should be empty only if importing an inputlog
 	 * (so the player isn't recreated)

--- a/sim/battle-stream.ts
+++ b/sim/battle-stream.ts
@@ -224,6 +224,13 @@ export class BattleStream extends Streams.ObjectReadWriteStream<string> {
 			const team = Teams.pack(side.team);
 			this.push(`requesteddata\n${team}`);
 			break;
+		case 'force-openteamsheets':
+			this.battle!.showOpenTeamSheets();
+			if (this.battle!.turn === 0) {
+				// update display and reset lead choices
+				this.battle!.makeRequest('teampreview');
+			}
+			break;
 		case 'version':
 		case 'version-origin':
 			break;

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2989,6 +2989,49 @@ export class Battle {
 		return team as PokemonSet[];
 	}
 
+	showOpenTeamSheets(visibleToSpectators?: boolean) {
+		let buf = 'raw|';
+		const inTeamPreview = this.turn === 0;
+		for (const side of this.sides) {
+			buf += Utils.html`<div class="infobox" style="margin-top:5px"><details><summary>Open Team Sheet for ${side.name}</summary>${Teams.export(side.team, {hideStats: true})}</details></div>`;
+		}
+		if (visibleToSpectators) {
+			this.add(buf);
+			if (inTeamPreview) this.add('clearpoke');
+		} else {
+			for (const side of this.sides) {
+				this.addSplit(side.id, [buf]);
+				if (inTeamPreview) this.addSplit(side.id, ['clearpoke']);
+			}
+		}
+		if (!inTeamPreview) return;
+		for (const pokemon of this.getAllPokemon()) {
+			let details = pokemon.details;
+			let setNotes = `[name] ${pokemon.name}`;
+			const moveList = pokemon.getMoveList(true);
+			if (pokemon.item) setNotes += `|[item] ${pokemon.item}`;
+			if (pokemon.ability) setNotes += `|[ability] ${pokemon.ability}`;
+			if (pokemon.canTerastallize) setNotes += `|[teraType] ${pokemon.teraType}`;
+			if (pokemon.species.id === 'zacian' && pokemon.item === 'rustedsword') {
+				const ironHead = moveList.indexOf('ironhead');
+				if (ironHead >= 0) moveList[ironHead] = 'behemothblade';
+				details = details.replace('Zacian', 'Zacian-Crowned');
+			} else if (pokemon.species.id === 'zamazenta' && pokemon.item === 'rustedshield') {
+				const ironHead = moveList.indexOf('ironhead');
+				if (ironHead >= 0) moveList[ironHead] = 'behemothbash';
+				details = details.replace('Zamazenta', 'Zamazenta-Crowned');
+			}
+			setNotes += `|[moveList] ${moveList.join(';')}`;
+			if (visibleToSpectators) {
+				this.add('poke', pokemon.side.id, details, setNotes);
+			} else {
+				for (const side of this.sides) {
+					this.addSplit(side.id, ['poke', pokemon.side.id, details, setNotes]);
+				}
+			}
+		}
+	}
+
 	setPlayer(slot: SideID, options: PlayerOptions) {
 		let side;
 		let didSomething = true;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1060,6 +1060,19 @@ export class Pokemon {
 		return data;
 	}
 
+	getMoveList(forAlly?: boolean) {
+		return this[forAlly ? 'baseMoves' : 'moves'].map(move => {
+			if (move === 'hiddenpower') {
+				return move + toID(this.hpType) + (this.battle.gen < 6 ? '' : this.hpPower);
+			}
+			if (move === 'frustration' || move === 'return') {
+				const basePowerCallback = this.battle.dex.moves.get(move).basePowerCallback as (pokemon: Pokemon) => number;
+				return move + basePowerCallback(this);
+			}
+			return move;
+		});
+	}
+
 	getSwitchRequestData(forAlly?: boolean) {
 		const entry: AnyObject = {
 			ident: this.fullname,
@@ -1073,16 +1086,7 @@ export class Pokemon {
 				spd: this.baseStoredStats['spd'],
 				spe: this.baseStoredStats['spe'],
 			},
-			moves: this[forAlly ? 'baseMoves' : 'moves'].map(move => {
-				if (move === 'hiddenpower') {
-					return move + toID(this.hpType) + (this.battle.gen < 6 ? '' : this.hpPower);
-				}
-				if (move === 'frustration' || move === 'return') {
-					const basePowerCallback = this.battle.dex.moves.get(move).basePowerCallback as (pokemon: Pokemon) => number;
-					return move + basePowerCallback(this);
-				}
-				return move;
-			}),
+			moves: this.getMoveList(forAlly),
 			baseAbility: this.baseAbility,
 			item: this.item,
 			pokeball: this.pokeball,


### PR DESCRIPTION
Related to smogon/pokemon-showdown-client#2127

Sends information for open team sheets via a new method of `Battle`, 
including data for the client's Pokemon properties as kwArgs in `|poke|` messages.