### PR TITLE
Fix Greninja-Bond with exhaustive runner

### DIFF
--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1061,7 +1061,6 @@ export class Pokemon {
 	getSwitchRequestData(forAlly?: boolean) {
 		const entry: AnyObject = {
 			ident: this.fullname,
-			species: this.species.name,
 			details: this.details,
 			condition: this.getHealth().secret,
 			active: (this.position < this.side.active.length),

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -1061,6 +1061,7 @@ export class Pokemon {
 	getSwitchRequestData(forAlly?: boolean) {
 		const entry: AnyObject = {
 			ident: this.fullname,
+			species: this.species.name,
 			details: this.details,
 			condition: this.getHealth().secret,
 			active: (this.position < this.side.active.length),

--- a/sim/tools/exhaustive-runner.ts
+++ b/sim/tools/exhaustive-runner.ts
@@ -114,8 +114,7 @@ export class ExhaustiveRunner {
 
 	private createPools(dex: typeof Dex): Pools {
 		return {
-			pokemon: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Pokedex, p => dex.species.get(p),
-				(_, p) => (p.name !== 'Pichu-Spiky-eared' && p.name.substr(0, 8) !== 'Pikachu-')), this.prng),
+			pokemon: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Pokedex, p => dex.species.get(p)), this.prng),
 			items: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Items, i => dex.items.get(i)), this.prng),
 			abilities: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Abilities, a => dex.abilities.get(a)), this.prng),
 			moves: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Moves, m => dex.moves.get(m),
@@ -434,7 +433,7 @@ class CoordinatedPlayerAI extends RandomPlayerAI {
 	private choosePokemon(choices: {slot: number, pokemon: AnyObject}[]) {
 		// Prefer to choose a Pokemon that has a species/ability/item/move we haven't seen yet.
 		for (const {slot, pokemon} of choices) {
-			const species = toID(pokemon.details.split(',')[0]);
+			const species = toID(pokemon.species);
 			if (!this.pools.pokemon.wasUsed(species) ||
 					!this.pools.abilities.wasUsed(pokemon.baseAbility) ||
 					!this.pools.items.wasUsed(pokemon.item) ||

--- a/sim/tools/exhaustive-runner.ts
+++ b/sim/tools/exhaustive-runner.ts
@@ -114,7 +114,8 @@ export class ExhaustiveRunner {
 
 	private createPools(dex: typeof Dex): Pools {
 		return {
-			pokemon: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Pokedex, p => dex.species.get(p)), this.prng),
+			pokemon: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Pokedex, p => dex.species.get(p),
+				(_, p) => (p.name !== 'Pichu-Spiky-eared' && p.name.substr(0, 8) !== 'Pikachu-')), this.prng),
 			items: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Items, i => dex.items.get(i)), this.prng),
 			abilities: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Abilities, a => dex.abilities.get(a)), this.prng),
 			moves: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Moves, m => dex.moves.get(m),

--- a/sim/tools/exhaustive-runner.ts
+++ b/sim/tools/exhaustive-runner.ts
@@ -114,8 +114,9 @@ export class ExhaustiveRunner {
 
 	private createPools(dex: typeof Dex): Pools {
 		return {
-			pokemon: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Pokedex, p => dex.species.get(p),
-				(_, p) => (p.name !== 'Pichu-Spiky-eared' && p.name.substr(0, 8) !== 'Pikachu-')), this.prng),
+			pokemon: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Pokedex, p => dex.species.get(p), (_, p) =>
+				(p.name !== 'Pichu-Spiky-eared' && p.name.substr(0, 8) !== 'Pikachu-') && p.name !== 'Greninja-Bond'),
+			this.prng),
 			items: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Items, i => dex.items.get(i)), this.prng),
 			abilities: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Abilities, a => dex.abilities.get(a)), this.prng),
 			moves: new Pool(ExhaustiveRunner.onlyValid(dex.gen, dex.data.Moves, m => dex.moves.get(m),
@@ -434,7 +435,7 @@ class CoordinatedPlayerAI extends RandomPlayerAI {
 	private choosePokemon(choices: {slot: number, pokemon: AnyObject}[]) {
 		// Prefer to choose a Pokemon that has a species/ability/item/move we haven't seen yet.
 		for (const {slot, pokemon} of choices) {
-			const species = toID(pokemon.species);
+			const species = toID(pokemon.details.split(',')[0]);
 			if (!this.pools.pokemon.wasUsed(species) ||
 					!this.pools.abilities.wasUsed(pokemon.baseAbility) ||
 					!this.pools.items.wasUsed(pokemon.item) ||


### PR DESCRIPTION
Currently, exhaustive runner looks at the species as defined by details information provided in pokemon.ts#getSwitchRequestData. However, Greninja-Bond (and any later edits to Zygarde or Rockruff) can't send its form in details, because it's visually indistinguishable from regular Greninja. There are a few solutions to this:

- Hardcode exceptions to skip over Greninja-Bond, etc.
- Add species name to pokemon.ts#getSwitchRequestData

This approach goes with the latter. I assume you would always know your own species at all times. Maybe there's an argument that you wouldn't always know your ally's species in a Multi Battle, but 1) we don't support multi battle hackmons where you could even theoretically bring a regular Greninja with Battle Bond, 2) I think it's a reasonable assumption that partner players in a Multi Battle should always know species names of their allies. (Hopefully I am not mistaken on what this function in fact does).

In testing, I was not able to remove the Pikachu / Pichu hardcodes when stress-testing by looping through 30 different RNG seeds. Battles would crash saying the player couldn't pass but needed to switch in a Pokemon.