### PR TITLE
Gen 9 randomized format set updates

### DIFF
--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -3157,7 +3157,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Covet", "Double-Edge", "Helping Hand", "Protect", "Yawn"],
+                "movepool": ["Double-Edge", "Helping Hand", "Protect", "Thief", "Yawn"],
                 "teraTypes": ["Ghost", "Normal"]
             }
         ]
@@ -3167,7 +3167,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Covet", "Double-Edge", "Helping Hand", "Protect", "Yawn"],
+                "movepool": ["Double-Edge", "Helping Hand", "Protect", "Thief", "Yawn"],
                 "teraTypes": ["Ghost", "Normal"]
             }
         ]

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -2102,7 +2102,7 @@
             }
         ]
     },
-    "greninja": {
+    "greninjabond": {
         "level": 82,
         "sets": [
             {
@@ -2184,6 +2184,11 @@
                 "role": "Choice Item user",
                 "movepool": ["Aura Sphere", "Dark Pulse", "Dragon Pulse", "Muddy Water", "U-turn"],
                 "teraTypes": ["Dark", "Dragon", "Fighting"]
+            },
+            {
+                "role": "Doubles Bulky Attacker",
+                "movepool": ["Aura Sphere", "Dark Pulse", "Heal Pulse", "Muddy Water", "Protect"],
+                "teraTypes": ["Dark", "Fighting"]
             }
         ]
     },
@@ -3626,7 +3631,7 @@
                 "teraTypes": ["Fairy", "Steel"]
             },
             {
-                "role": "Bulky Protect",
+                "role": "Doubles Bulky Setup",
                 "movepool": ["Make It Rain", "Nasty Plot", "Protect", "Shadow Ball"],
                 "teraTypes": ["Steel", "Water"]
             }
@@ -3672,7 +3677,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Disable", "Encore", "Helping Hand", "Howl", "Play Rough", "Stealth Rock", "Thunder Wave"],
+                "movepool": ["Dazzling Gleam", "Disable", "Encore", "Helping Hand", "Howl", "Play Rough", "Stealth Rock", "Thunder Wave"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3772,7 +3777,7 @@
             },
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["Dragon Dance", "Ice Punch", "Protect", "Rock Slide", "Stomping Tantrum", "Stone Edge", "Wild Charge"],
+                "movepool": ["Dragon Dance", "Ice Punch", "Protect", "Rock Slide", "Stomping Tantrum", "Wild Charge"],
                 "teraTypes": ["Grass", "Rock"]
             }
         ]
@@ -3896,7 +3901,7 @@
         "level": 80,
         "sets": [
             {
-                "role": "Offensive Protect",
+                "role": "Doubles Setup Sweeper",
                 "movepool": ["Bitter Blade", "Close Combat", "Protect", "Shadow Sneak", "Swords Dance"],
                 "teraTypes": ["Fighting", "Fire", "Grass"]
             }

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -68,7 +68,7 @@
         "level": 84,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Fast Support",
                 "movepool": ["Earthquake", "Memento", "Stealth Rock", "Stone Edge", "Sucker Punch", "Swords Dance"],
                 "teraTypes": ["Dark", "Fairy", "Flying", "Ghost", "Ground"]
             }
@@ -814,8 +814,8 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Earthquake", "Gunk Shot", "Ice Shard", "Ice Spinner", "Knock Off", "Rapid Spin", "Stone Edge"],
-                "teraTypes": ["Dark", "Ice", "Poison"]
+                "movepool": ["Earthquake", "Ice Shard", "Ice Spinner", "Knock Off", "Rapid Spin", "Stone Edge"],
+                "teraTypes": ["Dark", "Ice"]
             }
         ]
     },
@@ -1065,7 +1065,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Hydro Pump", "Ice Beam", "Spikes", "Stealth Rock"],
-                "teraTypes": ["Ground", "Steel"]
+                "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Setup Sweeper",
@@ -1248,7 +1248,7 @@
         "level": 86,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Bulky Support",
                 "movepool": ["Air Slash", "Defog", "Shadow Ball", "Strength Sap", "Will-O-Wisp"],
                 "teraTypes": ["Fairy", "Ghost"]
             },
@@ -1638,7 +1638,7 @@
         "level": 74,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Fast Attacker",
                 "movepool": ["Defog", "Draco Meteor", "Dragon Tail", "Earthquake", "Outrage", "Shadow Ball", "Shadow Sneak", "Will-O-Wisp"],
                 "teraTypes": ["Dragon", "Ghost"]
             }
@@ -2246,7 +2246,7 @@
         "level": 84,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Brave Bird", "Defog", "Overheat", "Roost", "Taunt", "U-turn", "Will-O-Wisp"],
                 "teraTypes": ["Ground", "Water"]
             },
@@ -2342,7 +2342,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Acrobatics", "Brave Bird", "Close Combat", "Stone Edge", "Swords Dance"],
+                "movepool": ["Acrobatics", "Brave Bird", "Close Combat", "Encore", "Stone Edge", "Swords Dance"],
                 "teraTypes": ["Fighting", "Flying"]
             }
         ]
@@ -2402,7 +2402,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Magnet Rise", "Play Rough", "Spikes", "Thunder Wave"],
+                "movepool": ["Dazzling Gleam", "Magnet Rise", "Play Rough", "Spikes", "Thunder Wave"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -2411,7 +2411,7 @@
         "level": 86,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Support",
                 "movepool": ["Avalanche", "Body Press", "Curse", "Rapid Spin", "Recover"],
                 "teraTypes": ["Fighting"]
             }
@@ -3187,7 +3187,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Calm Mind", "Encore", "Giga Drain", "Leech Seed", "Psyshock"],
+                "movepool": ["Calm Mind", "Encore", "Giga Drain", "Leech Seed", "Psychic", "Psyshock"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3882,7 +3882,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Encore", "Play Rough", "Protect", "Thunder Wave", "Wish"],
+                "movepool": ["Dazzling Gleam", "Encore", "Play Rough", "Protect", "Thunder Wave", "Wish"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3946,7 +3946,7 @@
         "level": 77,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Support",
                 "movepool": ["Earthquake", "Iron Head", "Knock Off", "Rapid Spin", "Stealth Rock", "Volt Switch"],
                 "teraTypes": ["Ground", "Steel"]
             }
@@ -4161,7 +4161,7 @@
         "level": 86,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Earth Power", "Giga Drain", "Knock Off", "Leaf Storm", "Rapid Spin", "Spore", "Toxic"],
                 "teraTypes": ["Water"]
             }

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -3317,7 +3317,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Body Press", "Body Slam", "Stomping Tantrum", "Stuff Cheeks"],
+                "movepool": ["Body Press", "Body Slam", "Stuff Cheeks", "Thief"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -3327,7 +3327,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Body Press", "Body Slam", "Stomping Tantrum", "Stuff Cheeks"],
+                "movepool": ["Body Press", "Body Slam", "Stuff Cheeks", "Thief"],
                 "teraTypes": ["Fighting"]
             }
         ]

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1288,7 +1288,8 @@ export class RandomTeams {
 			['Doubles Fast Attacker', 'Doubles Wallbreaker', 'Doubles Setup Sweeper', 'Offensive Protect'].some(m => role === m)
 		);
 
-		if (moves.has('covet')) return (moves.has('fakeout')) ? 'Normal Gem' : '';
+		if (moves.has('covet')) return 'Normal Gem';
+		if (moves.has('thief')) return '';
 		if (moves.has('iciclespear') && ability !== 'Skill Link') return 'Loaded Dice';
 		if (species.id === 'calyrexice') return 'Weakness Policy';
 		if (

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1407,22 +1407,21 @@ export class RandomTeams {
 		) return 'Air Balloon';
 		if (['Bulky Attacker', 'Bulky Support', 'Bulky Setup'].some(m => role === (m))) return 'Leftovers';
 		if (species.id === 'pawmot' && moves.has('nuzzle')) return 'Leppa Berry';
+		if (
+			['Fast Bulky Setup', 'Fast Attacker', 'Setup Sweeper', 'Wallbreaker'].some(m => role === (m)) &&
+			types.includes('Dark') && moves.has('suckerpunch') && !priorityPokemon.includes(species.id) &&
+			counter.get('setup') && counter.get('Dark')
+		) return 'Black Glasses';
 		if (role === 'Fast Support' || role === 'Fast Bulky Setup') {
 			return (counter.get('Physical') + counter.get('Special') >= 3 && !moves.has('nuzzle')) ? 'Life Orb' : 'Leftovers';
 		}
 		if (
-			role === 'Tera Blast user' && counter.get('recovery') &&
-			counter.get('Physical') + counter.get('Special') < 3
+			role === 'Tera Blast user' && species.baseSpecies === 'florges'
 		) return 'Leftovers';
 		if (
 			['flamecharge', 'rapidspin'].every(m => !moves.has(m)) &&
 			['Fast Attacker', 'Setup Sweeper', 'Tera Blast user', 'Wallbreaker'].some(m => role === (m))
-		) {
-			return (
-				types.includes('Dark') && moves.has('suckerpunch') && !priorityPokemon.includes(species.id) &&
-				counter.get('setup') && counter.get('Dark')
-			) ? 'Black Glasses' : 'Life Orb';
-		}
+		) return 'Life Orb';
 		return 'Leftovers';
 	}
 

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1416,7 +1416,7 @@ export class RandomTeams {
 			return (counter.get('Physical') + counter.get('Special') >= 3 && !moves.has('nuzzle')) ? 'Life Orb' : 'Leftovers';
 		}
 		if (
-			role === 'Tera Blast user' && species.baseSpecies === 'florges'
+			role === 'Tera Blast user' && species.baseSpecies === 'Florges'
 		) return 'Leftovers';
 		if (
 			['flamecharge', 'rapidspin'].every(m => !moves.has(m)) &&

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1408,7 +1408,7 @@ export class RandomTeams {
 		if (['Bulky Attacker', 'Bulky Support', 'Bulky Setup'].some(m => role === (m))) return 'Leftovers';
 		if (species.id === 'pawmot' && moves.has('nuzzle')) return 'Leppa Berry';
 		if (
-			['Fast Bulky Setup', 'Fast Attacker', 'Setup Sweeper', 'Wallbreaker'].some(m => role === (m)) &&
+			['Fast Bulky Setup', 'Fast Attacker', 'Setup Sweeper', 'Wallbreaker'].some(m => role === m) &&
 			types.includes('Dark') && moves.has('suckerpunch') && !priorityPokemon.includes(species.id) &&
 			counter.get('setup') && counter.get('Dark')
 		) return 'Black Glasses';


### PR DESCRIPTION
Changes intended to increase the frequency of hazard removal are marked with *.

**Gen 9 Random Battle:**

-Dugtrio's role is now Fast Support; non-Choice Band variants can now be Focus Sash in the lead slot.
-Houndoom will no longer get Nasty Plot + Sucker Punch.
-Scream Tail and Klefki: +Dazzling Gleam; Dazzling Gleam and Play Rough will not generate together.
-Bulky Support Whiscash: -Tera Ground, +Tera Poison
-Bulky Attacker Donphan: -Tera Poison, -Gunk Shot *
-Calyrex: +Psychic, because statistical analysis showed removing Psychic to be deeply bad for its effectiveness.
-Hawlucha: +Encore

-Dark-types will generate Black Glasses if they have ALL of the following on the set:
--Sucker Punch
--Another Dark move
--Setup
--A role that would otherwise give it Life Orb under these conditions
(Functionally, this affects Urshifu, Grimmsnarl, Samurott-Hisui, and Chien-Pao if the team has hazard removal)

-Pokemon with the Bulky Support role will now always get Defog or Rapid Spin if possible, unless the team already has hazard removal. * As a result:
--Cryogonal now no longer always has Flash Cannon and can sometimes get Haze + Rapid Spin.
--Drifblim Set 1 is now Bulky Support, to be included in this new rule *
--Avalugg is now Bulky Support, to be included in this new rule (and Curse will now only exist with removal on the team) *
--Iron Treads is now Bulky Support, to be included in this new rule *
--Toedscruel is now Bulky Attacker, to be **dis**cluded from this new rule
--Giratina-Origin is now Fast Attacker, to be **dis**cluded from this new rule
--Talonflame is now Bulky Attacker, to be **dis**cluded from this new rule

**Gen 9 Random Doubles**:
-Ceruledge now always has Swords Dance and does not always have Protect.
-Clawitzer has gained a Doubles Bulky Attacker set of Dark Pulse, Aura Sphere, Heal Pulse, Muddy Water, and Protect, with a Sitrus Berry.
-Gholdengo's role was changed to Doubles Bulky Setup, which gives it a Sitrus Berry.
-Prankster users (Tornadus and Murkrow) will now always have Tailwind.
-Scream Tail now has Dazzling Gleam; Dazzling Gleam will not generate with either Howl or Play Rough.
-Battle Bond now actually works on Greninja.
-Persian with Covet will now get a Normal Gem. Please use Fake Out first, it doesn't steal items if you normal gem the Covet.
-Dragon Dance Iron Thorns no longer has Stone Edge.