### PR TITLE
Gen 2 Random Battles updates

### DIFF
--- a/data/mods/gen2/random-data.json
+++ b/data/mods/gen2/random-data.json
@@ -45,7 +45,7 @@
         "moves": ["bellydrum", "encore", "fireblast", "moonlight", "return", "shadowball"]
     },
     "ninetales": {
-        "moves": ["confuseray", "fireblast", "hiddenpowergrass", "hypnosis", "sunnyday"]
+        "moves": ["fireblast", "hiddenpowergrass", "rest", "sleeptalk", "toxic"]
     },
     "wigglytuff": {
         "moves": ["bodyslam", "charm", "curse", "doubleedge", "fireblast", "rest", "sleeptalk", "thunderwave"]
@@ -96,10 +96,10 @@
         "moves": ["bodyslam", "fireblast", "hiddenpowergrass", "hypnosis", "sunnyday"]
     },
     "slowbro": {
-        "moves": ["fireblast", "psychic", "rest", "sleeptalk", "surf", "thunderwave", "toxic"]
+        "moves": ["flamethrower", "icebeam", "psychic", "rest", "sleeptalk", "surf", "thunderwave"]
     },
     "magneton": {
-        "moves": ["hiddenpowerice", "substitute", "thunderbolt", "thunderwave"]
+        "moves": ["hiddenpowerice", "rest", "sleeptalk", "thunderbolt"]
     },
     "farfetchd": {
         "moves": ["agility", "batonpass", "return", "swordsdance"]
@@ -108,7 +108,7 @@
         "moves": ["doubleedge", "drillpeck", "hiddenpowerground", "rest", "substitute"]
     },
     "dewgong": {
-        "moves": ["bodyslam", "encore", "icebeam", "rest", "sleeptalk", "surf", "toxic"]
+        "moves": ["encore", "icebeam", "rest", "sleeptalk", "surf", "toxic"]
     },
     "muk": {
         "moves": ["curse", "explosion", "fireblast", "hiddenpowerground", "sludgebomb"]
@@ -120,7 +120,7 @@
         "moves": ["destinybond", "explosion", "firepunch", "hypnosis", "icepunch", "thunderbolt"]
     },
     "hypno": {
-        "moves": ["hypnosis", "lightscreen", "psychic", "reflect", "seismictoss", "thunderwave"]
+        "moves": ["psychic", "rest", "seismictoss", "sleeptalk", "thunderwave", "toxic"]
     },
     "kingler": {
         "moves": ["hiddenpowerground", "rest", "return", "surf", "swordsdance"]
@@ -144,10 +144,10 @@
         "moves": ["bodyslam", "earthquake", "fireblast", "rest", "sleeptalk", "swordsdance"]
     },
     "weezing": {
-        "moves": ["explosion", "fireblast", "hiddenpowergrass", "painsplit", "sludgebomb", "thunder"]
+        "moves": ["explosion", "fireblast", "hiddenpowerice", "painsplit", "sludgebomb", "thunder"]
     },
     "rhydon": {
-        "moves": ["curse", "earthquake", "fireblast", "rest", "roar", "rockslide", "sleeptalk", "zapcannon"]
+        "moves": ["curse", "earthquake", "rest", "roar", "rockslide", "sleeptalk"]
     },
     "tangela": {
         "moves": ["gigadrain", "growth", "hiddenpowerice", "sleeppowder", "synthesis"]
@@ -186,7 +186,7 @@
         "moves": ["bodyslam", "doubleedge", "hiddenpowerflying", "hydropump", "rest", "sleeptalk", "thunder"]
     },
     "lapras": {
-        "moves": ["icebeam", "rest", "sing", "sleeptalk", "surf", "thunder", "thunderbolt", "toxic"]
+        "moves": ["icebeam", "rest", "sleeptalk", "surf", "thunderbolt", "toxic"]
     },
     "ditto": {
         "level": 83,
@@ -196,10 +196,10 @@
         "moves": ["growth", "hiddenpowerelectric", "icebeam", "rest", "sleeptalk", "surf"]
     },
     "jolteon": {
-        "moves": ["batonpass", "growth", "hiddenpowerice", "hiddenpowerwater", "substitute", "thunderbolt", "thunderwave"]
+        "moves": ["batonpass", "growth", "hiddenpowerice", "substitute", "thunderbolt", "thunderwave"]
     },
     "flareon": {
-        "moves": ["batonpass", "doubleedge", "fireblast", "growth", "hiddenpowergrass", "zapcannon"]
+        "moves": ["batonpass", "doubleedge", "fireblast", "growth", "hiddenpowergrass"]
     },
     "omastar": {
         "moves": ["hiddenpowerelectric", "icebeam", "rest", "sleeptalk", "surf"]
@@ -208,7 +208,7 @@
         "moves": ["ancientpower", "hiddenpowerground", "return", "submission", "surf", "swordsdance"]
     },
     "aerodactyl": {
-        "moves": ["ancientpower", "curse", "earthquake", "hiddenpowerflying", "reflect", "whirlwind"]
+        "moves": ["ancientpower", "curse", "earthquake", "hiddenpowerflying", "rest", "whirlwind"]
     },
     "snorlax": {
         "moves": ["curse", "doubleedge", "earthquake", "fireblast", "lovelykiss", "rest", "return", "sleeptalk"]
@@ -229,7 +229,7 @@
         "moves": ["fireblast", "icebeam", "psychic", "recover", "thunderbolt", "thunderwave"]
     },
     "mew": {
-        "moves": ["earthquake", "explosion", "psychic", "shadowball", "softboiled", "submission", "swordsdance"]
+        "moves": ["earthquake", "explosion", "rockslide", "softboiled", "swordsdance"]
     },
     "meganium": {
         "moves": ["hiddenpowerfire", "leechseed", "lightscreen", "razorleaf", "reflect", "synthesis"]
@@ -259,16 +259,16 @@
         "moves": ["icebeam", "raindance", "rest", "sleeptalk", "surf", "thunder"]
     },
     "togetic": {
-        "moves": ["fireblast", "solarbeam", "sunnyday", "zapcannon"]
+        "moves": ["curse", "doubleedge", "rest", "sleeptalk"]
     },
     "xatu": {
-        "moves": ["drillpeck", "haze", "hiddenpowergrass", "hiddenpowerwater", "psychic", "rest", "sleeptalk", "thief"]
+        "moves": ["drillpeck", "haze", "psychic", "rest", "sleeptalk", "thief"]
     },
     "ampharos": {
         "moves": ["firepunch", "hiddenpowerice", "lightscreen", "reflect", "rest", "sleeptalk", "thunderbolt", "thunderwave"]
     },
     "bellossom": {
-        "moves": ["doubleedge", "hiddenpowerfire", "leechseed", "moonlight", "razorleaf", "sleeppowder", "stunspore"]
+        "moves": ["hiddenpowerfire", "leechseed", "moonlight", "razorleaf", "sleeppowder", "stunspore"]
     },
     "azumarill": {
         "moves": ["perishsong", "rest", "surf", "whirlpool"]
@@ -280,19 +280,19 @@
         "moves": ["growth", "hiddenpowerelectric", "icebeam", "lovelykiss", "rest", "sleeptalk", "surf"]
     },
     "jumpluff": {
-        "moves": ["gigadrain", "hiddenpowerice", "hiddenpowerwater", "leechseed", "sleeppowder", "stunspore"]
+        "moves": ["encore", "gigadrain", "hiddenpowerflying", "leechseed", "sleeppowder", "stunspore"]
     },
     "aipom": {
         "moves": ["agility", "batonpass", "curse", "return", "shadowball"]
     },
     "sunflora": {
-        "moves": ["growth", "hiddenpowerfire", "hiddenpowerwater", "razorleaf", "synthesis"]
+        "moves": ["growth", "hiddenpowerfire", "hiddenpowerice", "razorleaf", "synthesis"]
     },
     "yanma": {
         "moves": ["gigadrain", "hiddenpowerbug", "hiddenpowerflying", "return", "screech", "thief"]
     },
     "quagsire": {
-        "moves": ["bellydrum", "bodyslam", "earthquake", "rest", "surf"]
+        "moves": ["bellydrum", "earthquake", "hiddenpowerrock", "rest", "sleeptalk", "surf"]
     },
     "espeon": {
         "moves": ["batonpass", "bite", "growth", "hiddenpowerfire", "morningsun", "psychic", "substitute"]
@@ -304,7 +304,7 @@
         "moves": ["drillpeck", "haze", "hiddenpowerdark", "hiddenpowerfire", "pursuit", "thief", "toxic"]
     },
     "slowking": {
-        "moves": ["fireblast", "psychic", "rest", "sleeptalk", "surf", "thunderwave", "toxic"]
+        "moves": ["flamethrower", "icebeam", "psychic", "rest", "sleeptalk", "surf", "thunderwave"]
     },
     "misdreavus": {
         "moves": ["meanlook", "painsplit", "perishsong", "psychic", "shadowball", "thief", "thunderbolt"]
@@ -345,7 +345,7 @@
         "moves": ["defensecurl", "rest", "rollout", "toxic"]
     },
     "heracross": {
-        "moves": ["curse", "earthquake", "megahorn", "rest", "seismictoss", "sleeptalk"]
+        "moves": ["curse", "earthquake", "megahorn", "rest", "sleeptalk"]
     },
     "sneasel": {
         "moves": ["icebeam", "moonlight", "return", "screech", "shadowball", "thief"]
@@ -357,7 +357,7 @@
         "moves": ["curse", "earthquake", "fireblast", "rest", "rockslide", "sleeptalk"]
     },
     "piloswine": {
-        "moves": ["ancientpower", "bodyslam", "curse", "earthquake", "icebeam", "rest", "sleeptalk"]
+        "moves": ["ancientpower", "curse", "earthquake", "icebeam", "rest", "sleeptalk"]
     },
     "corsola": {
         "moves": ["curse", "recover", "rockslide", "surf", "toxic"]
@@ -387,10 +387,10 @@
         "moves": ["curse", "doubleedge", "icebeam", "recover", "return", "thunderbolt", "thunderwave"]
     },
     "stantler": {
-        "moves": ["confuseray", "curse", "earthquake", "rest", "return", "sleeptalk"]
+        "moves": ["curse", "earthquake", "rest", "return", "sleeptalk"]
     },
     "smeargle": {
-        "moves": ["agility", "batonpass", "spikes", "spore"]
+        "moves": ["agility", "batonpass", "spiderweb", "spikes", "spore", "swordsdance"]
     },
     "hitmontop": {
         "moves": ["curse", "hiddenpowerghost", "highjumpkick", "rest", "sleeptalk"]
@@ -402,13 +402,13 @@
         "moves": ["flamethrower", "healbell", "icebeam", "present", "sing", "softboiled", "toxic"]
     },
     "raikou": {
-        "moves": ["crunch", "hiddenpowerice", "hiddenpowerwater", "reflect", "rest", "roar", "sleeptalk", "thunder", "thunderbolt"]
+        "moves": ["crunch", "hiddenpowerice", "reflect", "rest", "roar", "sleeptalk", "thunder", "thunderbolt"]
     },
     "entei": {
         "moves": ["fireblast", "hiddenpowerrock", "return", "solarbeam", "sunnyday"]
     },
     "suicune": {
-        "moves": ["hiddenpowerelectric", "icebeam", "rest", "roar", "sleeptalk", "surf", "toxic"]
+        "moves": ["icebeam", "rest", "roar", "sleeptalk", "surf", "toxic"]
     },
     "tyranitar": {
         "moves": ["crunch", "curse", "earthquake", "fireblast", "pursuit", "rest", "roar", "rockslide", "surf"]

--- a/data/mods/gen2/random-teams.ts
+++ b/data/mods/gen2/random-teams.ts
@@ -37,16 +37,17 @@ export class RandomGen2Teams extends RandomGen3Teams {
 			return {
 				cull: (
 					(counter.setupType !== 'Physical' || counter.get('physicalsetup') > 1) ||
-					(!counter.get('Physical') || counter.damagingMoves.size < 2 && !moves.has('batonpass') && !moves.has('sleeptalk'))
+					(!counter.get('Physical') || counter.damagingMoves.size < 2 && !moves.has('batonpass') && !moves.has('sleeptalk')) ||
+					(move.id === 'bellydrum' && moves.has('sleeptalk'))
 				),
 				isSetup: true,
 			};
 
 		// Not very useful without their supporting moves
 		case 'batonpass':
-			return {cull: !counter.setupType && !counter.get('speedsetup') && !moves.has('meanlook')};
-		case 'meanlook':
-			return {cull: movePool.includes('perishsong')};
+			return {cull: !counter.setupType && !counter.get('speedsetup') && !moves.has('meanlook') && !moves.has('spiderweb')};
+		case 'meanlook': case 'spiderweb':
+			return {cull: movePool.includes('perishsong') || movePool.includes('batonpass')};
 		case 'nightmare':
 			return {cull: !moves.has('lovelykiss') && !moves.has('sleeppowder')};
 		case 'swagger':
@@ -81,8 +82,6 @@ export class RandomGen2Teams extends RandomGen3Teams {
 			return {cull: moves.has('swordsdance') && movePool.includes('sludgebomb')};
 		case 'icebeam':
 			return {cull: moves.has('dragonbreath')};
-		case 'seismictoss':
-			return {cull: moves.has('rest') || moves.has('sleeptalk')};
 		case 'destinybond':
 			return {cull: moves.has('explosion')};
 		case 'pursuit':
@@ -93,7 +92,7 @@ export class RandomGen2Teams extends RandomGen3Teams {
 			return {cull: types.has('Ground') && movePool.includes('earthquake')};
 
 		// Status and illegal move rejections
-		case 'confuseray': case 'encore': case 'roar': case 'whirlwind':
+		case 'encore': case 'roar': case 'whirlwind':
 			return {cull: restTalk};
 		case 'lovelykiss':
 			return {cull: ['healbell', 'moonlight', 'morningsun', 'sleeptalk'].some(m => moves.has(m))};
@@ -202,7 +201,7 @@ export class RandomGen2Teams extends RandomGen3Teams {
 				const moveIsRejectable = (
 					(move.category !== 'Status' || !move.flags.heal) &&
 					// These moves cannot be rejected in favor of a forced move
-					!['batonpass', 'sleeptalk', 'spikes', 'sunnyday'].includes(move.id) &&
+					!['batonpass', 'sleeptalk', 'spikes', 'spore', 'sunnyday'].includes(move.id) &&
 					(move.category === 'Status' || !types.has(move.type) || (move.basePower && move.basePower < 40))
 				);
 
@@ -221,7 +220,7 @@ export class RandomGen2Teams extends RandomGen3Teams {
 						// Sunny Day + Solar Beam should be selected together
 						(moves.has('sunnyday') && movePool.includes('solarbeam') ||
 						(moves.has('solarbeam') && movePool.includes('sunnyday'))) ||
-						['milkdrink', 'recover', 'spore'].some(m => movePool.includes(m))
+						['milkdrink', 'recover', 'spikes', 'spore'].some(m => movePool.includes(m))
 					) {
 						cull = true;
 					} else {


### PR DESCRIPTION
Thanks MrSoup for your suggestions! This is ready to merge.

-Make Spikes forced, unless the team already has it
-Magneton: Rest / Sleep Talk / Thunderbolt / HP Ice
-Hypno: -Reflect, -Light Screen, -Hypnosis, +Rest, +Sleep Talk, +Toxic 
-Ninetales: -Confuse Ray, -Hypnosis, -Sunny Day, +Rest, +Sleep Talk, +Toxic 
-Slowtwins: -Toxic, -Fire Blast, +Flamethrower, +Ice Beam
-Heracross: -Seismic Toss
-Stantler: -Confuse Ray
-Suicune: -HP Electric
-Dewgong: -Body Slam
-Lapras: -Sing -Thunder
-Quagsire: -Body Slam, +HP Rock, +Sleep Talk, Belly Drum incompatible with Sleep Talk
-Piloswine: -Body Slam
-Rhydon: -Zap Cannon, -Fire Blast
-Jumpluff: -HP Ice, -HP Water, +Encore, +HP Flying 
-Flareon: -Zap Cannon
-Togetic: Rest / Sleep Talk / Curse / Double-Edge
-Aerodactyl: -Reflect, +Rest
-Bellossom: -Double-Edge
-Smeargle: +Spider Web, +Swords Dance, Baton Pass/Spikes/Spore are forced
-Mew: Swords Dance / Explosion / Soft-Boiled / Rock Slide / Earthquake
-Raikou: -HP Water
-Jolteon: -HP Water
-Sunflora: -HP Water, +HP Ice
-Xatu: -HP Water, -HP Grass
-Weezing: -HP Grass, +HP Ice