### PR TITLE
Random Battles: June 2023 level balancing

### DIFF
--- a/data/mods/gen1/random-data.json
+++ b/data/mods/gen1/random-data.json
@@ -16,27 +16,27 @@
         "essentialMove": "razorleaf"
     },
     "charmander": {
-        "level": 90,
+        "level": 91,
         "moves": ["bodyslam", "slash"],
         "essentialMove": "fireblast",
         "exclusiveMoves": ["counter", "seismictoss"],
         "comboMoves": ["bodyslam", "fireblast", "submission", "swordsdance"]
     },
     "charmeleon": {
-        "level": 81,
+        "level": 82,
         "moves": ["bodyslam", "slash"],
         "essentialMove": "fireblast",
         "exclusiveMoves": ["counter", "swordsdance"],
         "comboMoves": ["bodyslam", "fireblast", "submission", "swordsdance"]
     },
     "charizard": {
-        "level": 76,
+        "level": 75,
         "moves": ["bodyslam", "earthquake", "slash"],
         "essentialMove": "fireblast",
         "comboMoves": ["hyperbeam", "swordsdance"]
     },
     "squirtle": {
-        "level": 90,
+        "level": 91,
         "moves": ["blizzard", "hydropump", "seismictoss", "surf"],
         "exclusiveMoves": ["bodyslam", "counter"]
     },
@@ -56,23 +56,23 @@
         "exclusiveMoves": ["megadrain", "psywave"]
     },
     "beedrill": {
-        "level": 80,
+        "level": 82,
         "moves": ["megadrain", "swordsdance", "twineedle"],
         "exclusiveMoves": ["doubleedge", "doubleedge", "hyperbeam"],
         "comboMoves": ["agility", "hyperbeam", "swordsdance", "twineedle"]
     },
     "pidgey": {
-        "level": 91,
+        "level": 92,
         "moves": ["agility", "doubleedge", "skyattack"],
         "exclusiveMoves": ["mimic", "mirrormove", "reflect", "sandattack", "substitute", "quickattack", "toxic"]
     },
     "pidgeotto": {
-        "level": 82,
+        "level": 84,
         "moves": ["agility", "doubleedge", "skyattack"],
         "exclusiveMoves": ["mimic", "mirrormove", "reflect", "sandattack", "substitute", "quickattack", "toxic"]
     },
     "pidgeot": {
-        "level": 77,
+        "level": 78,
         "moves": ["agility", "doubleedge", "hyperbeam"],
         "exclusiveMoves": ["mimic", "mirrormove", "reflect", "sandattack", "skyattack", "skyattack", "substitute", "quickattack", "toxic"]
     },
@@ -88,7 +88,7 @@
         "essentialMove": "superfang"
     },
     "spearow": {
-        "level": 89,
+        "level": 90,
         "moves": ["agility", "doubleedge", "drillpeck"],
         "exclusiveMoves": ["leer", "mimic", "mirrormove", "substitute", "toxic"]
     },
@@ -97,11 +97,11 @@
         "moves": ["agility", "doubleedge", "drillpeck", "hyperbeam"]
     },
     "ekans": {
-        "level": 90,
+        "level": 91,
         "moves": ["bodyslam", "earthquake", "glare", "rockslide"]
     },
     "arbok": {
-        "level": 78,
+        "level": 79,
         "moves": ["earthquake", "glare", "hyperbeam"],
         "exclusiveMoves": ["bodyslam", "rockslide"]
     },
@@ -128,32 +128,32 @@
         "essentialMove": "earthquake"
     },
     "nidoranf": {
-        "level": 90,
+        "level": 92,
         "moves": ["blizzard", "bodyslam", "thunderbolt"],
         "exclusiveMoves": ["doubleedge", "doublekick"]
     },
     "nidorina": {
-        "level": 81,
+        "level": 82,
         "moves": ["blizzard", "bodyslam", "thunderbolt"],
         "exclusiveMoves": ["bubblebeam", "doubleedge", "doublekick"]
     },
     "nidoqueen": {
-        "level": 75,
+        "level": 74,
         "moves": ["blizzard", "bodyslam", "thunderbolt"],
         "essentialMove": "earthquake"
     },
     "nidoranm": {
-        "level": 90,
+        "level": 91,
         "moves": ["blizzard", "bodyslam", "thunderbolt"],
         "exclusiveMoves": ["doubleedge", "doublekick"]
     },
     "nidorino": {
-        "level": 81,
+        "level": 82,
         "moves": ["blizzard", "bodyslam", "thunderbolt"],
         "exclusiveMoves": ["bubblebeam", "doubleedge", "doublekick"]
     },
     "nidoking": {
-        "level": 75,
+        "level": 74,
         "moves": ["blizzard", "bodyslam"],
         "essentialMove": "earthquake",
         "exclusiveMoves": ["rockslide", "thunder", "thunderbolt"]
@@ -165,13 +165,13 @@
         "exclusiveMoves": ["counter", "psychic", "seismictoss", "sing", "sing"]
     },
     "clefable": {
-        "level": 77,
+        "level": 76,
         "moves": ["bodyslam", "thunderbolt", "thunderwave"],
         "essentialMove": "blizzard",
         "exclusiveMoves": ["counter", "hyperbeam", "psychic", "sing", "sing"]
     },
     "vulpix": {
-        "level": 90,
+        "level": 91,
         "moves": ["bodyslam", "confuseray", "fireblast"],
         "exclusiveMoves": ["flamethrower", "reflect", "substitute"]
     },
@@ -181,7 +181,7 @@
         "exclusiveMoves": ["flamethrower", "hyperbeam", "reflect", "substitute"]
     },
     "jigglypuff": {
-        "level": 88,
+        "level": 89,
         "moves": ["blizzard", "bodyslam", "seismictoss", "thunderwave"],
         "exclusiveMoves": ["counter", "sing"]
     },
@@ -191,7 +191,7 @@
         "exclusiveMoves": ["counter", "hyperbeam", "sing"]
     },
     "zubat": {
-        "level": 91,
+        "level": 94,
         "moves": ["confuseray", "doubleedge", "megadrain", "toxic"]
     },
     "golbat": {
@@ -233,7 +233,7 @@
         "exclusiveMoves": ["doubleedge", "megadrain", "psywave"]
     },
     "venomoth": {
-        "level": 75,
+        "level": 74,
         "moves": ["psychic", "sleeppowder", "stunspore"],
         "exclusiveMoves": ["doubleedge", "megadrain", "megadrain"]
     },
@@ -243,7 +243,7 @@
         "essentialMove": "earthquake"
     },
     "dugtrio": {
-        "level": 74,
+        "level": 73,
         "moves": ["bodyslam", "rockslide", "slash"],
         "essentialMove": "earthquake"
     },
@@ -282,7 +282,7 @@
         "exclusiveMoves": ["counter", "hyperbeam", "hyperbeam"]
     },
     "growlithe": {
-        "level": 90,
+        "level": 91,
         "moves": ["bodyslam", "fireblast", "flamethrower", "reflect"]
     },
     "arcanine": {
@@ -291,7 +291,7 @@
         "exclusiveMoves": ["flamethrower", "reflect"]
     },
     "poliwag": {
-        "level": 88,
+        "level": 87,
         "moves": ["blizzard", "surf"],
         "essentialMove": "amnesia",
         "exclusiveMoves": ["hypnosis", "hypnosis", "psychic"]
@@ -303,14 +303,14 @@
         "exclusiveMoves": ["counter", "hypnosis", "hypnosis", "psychic"]
     },
     "poliwrath": {
-        "level": 75,
+        "level": 74,
         "moves": ["blizzard", "bodyslam", "earthquake", "submission"],
         "essentialMove": "surf",
         "exclusiveMoves": ["hypnosis", "hypnosis", "psychic"],
         "comboMoves": ["amnesia", "blizzard"]
     },
     "abra": {
-        "level": 85,
+        "level": 84,
         "moves": ["psychic", "seismictoss", "thunderwave"],
         "exclusiveMoves": ["counter", "reflect"]
     },
@@ -320,12 +320,12 @@
         "exclusiveMoves": ["counter", "reflect", "reflect", "seismictoss", "seismictoss"]
     },
     "alakazam": {
-        "level": 68,
+        "level": 67,
         "moves": ["psychic", "recover", "thunderwave"],
         "exclusiveMoves": ["counter", "reflect", "reflect", "seismictoss", "seismictoss"]
     },
     "machop": {
-        "level": 89,
+        "level": 91,
         "moves": ["bodyslam", "earthquake", "submission"],
         "exclusiveMoves": ["counter", "rockslide", "rockslide"]
     },
@@ -380,7 +380,7 @@
         "moves": ["bodyslam", "earthquake", "explosion", "rockslide"]
     },
     "ponyta": {
-        "level": 87,
+        "level": 86,
         "moves": ["agility", "bodyslam", "fireblast", "reflect"]
     },
     "rapidash": {
@@ -388,7 +388,7 @@
         "moves": ["agility", "bodyslam", "fireblast", "hyperbeam"]
     },
     "slowpoke": {
-        "level": 88,
+        "level": 87,
         "moves": ["earthquake", "surf"],
         "essentialMove": "thunderwave",
         "exclusiveMoves": ["blizzard", "psychic", "rest"],
@@ -410,7 +410,7 @@
         "exclusiveMoves": ["doubleedge", "hyperbeam", "hyperbeam", "mimic", "substitute", "toxic"]
     },
     "farfetchd": {
-        "level": 79,
+        "level": 82,
         "moves": ["agility", "bodyslam", "swordsdance"],
         "essentialMove": "slash"
     },
@@ -419,7 +419,7 @@
         "moves": ["agility", "bodyslam", "doubleedge", "drillpeck"]
     },
     "dodrio": {
-        "level": 74,
+        "level": 73,
         "moves": ["agility", "bodyslam", "drillpeck", "hyperbeam"]
     },
     "seel": {
@@ -449,18 +449,18 @@
         "moves": ["blizzard", "doubleedge", "explosion", "surf"]
     },
     "cloyster": {
-        "level": 69,
+        "level": 71,
         "moves": ["blizzard", "explosion", "surf"],
         "exclusiveMoves": ["doubleedge", "hyperbeam", "hyperbeam"]
     },
     "gastly": {
-        "level": 85,
+        "level": 82,
         "moves": ["explosion", "megadrain", "nightshade", "psychic"],
         "essentialMove": "thunderbolt",
         "exclusiveMoves": ["confuseray", "hypnosis", "hypnosis"]
     },
     "haunter": {
-        "level": 73,
+        "level": 72,
         "moves": ["explosion", "megadrain", "nightshade", "psychic"],
         "essentialMove": "thunderbolt",
         "exclusiveMoves": ["confuseray", "hypnosis", "hypnosis"]
@@ -472,21 +472,21 @@
         "exclusiveMoves": ["confuseray", "hypnosis", "hypnosis"]
     },
     "onix": {
-        "level": 78,
+        "level": 79,
         "moves": ["bodyslam", "earthquake", "explosion", "rockslide"]
     },
     "drowzee": {
-        "level": 86,
+        "level": 84,
         "moves": ["hypnosis", "psychic", "thunderwave"],
         "exclusiveMoves": ["counter", "reflect", "rest", "seismictoss", "seismictoss"]
     },
     "hypno": {
-        "level": 71,
+        "level": 70,
         "moves": ["hypnosis", "psychic", "thunderwave"],
         "exclusiveMoves": ["counter", "reflect", "rest", "rest", "seismictoss", "seismictoss"]
     },
     "krabby": {
-        "level": 89,
+        "level": 90,
         "moves": ["blizzard", "bodyslam", "crabhammer", "swordsdance"]
     },
     "kingler": {
@@ -510,7 +510,7 @@
         "exclusiveMoves": ["doubleedge", "explosion", "explosion"]
     },
     "exeggutor": {
-        "level": 67,
+        "level": 66,
         "moves": ["explosion", "psychic", "sleeppowder"],
         "exclusiveMoves": ["doubleedge", "eggbomb", "hyperbeam", "megadrain", "megadrain", "stunspore", "stunspore", "stunspore"]
     },
@@ -519,27 +519,27 @@
         "moves": ["blizzard", "bodyslam", "earthquake", "seismictoss"]
     },
     "marowak": {
-        "level": 78,
+        "level": 79,
         "moves": ["blizzard", "bodyslam", "earthquake", "seismictoss"]
     },
     "hitmonlee": {
-        "level": 78,
+        "level": 79,
         "moves": ["bodyslam", "highjumpkick", "seismictoss"],
         "exclusiveMoves": ["counter", "counter", "meditate"]
     },
     "hitmonchan": {
-        "level": 80,
+        "level": 82,
         "moves": ["bodyslam", "seismictoss", "submission"],
         "exclusiveMoves": ["agility", "counter", "counter"]
     },
     "lickitung": {
-        "level": 79,
+        "level": 80,
         "moves": ["hyperbeam", "swordsdance"],
         "essentialMove": "bodyslam",
         "exclusiveMoves": ["blizzard", "earthquake", "earthquake", "earthquake"]
     },
     "koffing": {
-        "level": 88,
+        "level": 89,
         "moves": ["explosion", "fireblast", "sludge", "thunderbolt"]
     },
     "weezing": {
@@ -547,7 +547,7 @@
         "moves": ["explosion", "fireblast", "sludge", "thunderbolt"]
     },
     "rhyhorn": {
-        "level": 86,
+        "level": 85,
         "moves": ["bodyslam", "earthquake", "rockslide", "substitute"]
     },
     "rhydon": {
@@ -573,7 +573,7 @@
         "exclusiveMoves": ["counter", "rockslide", "rockslide", "surf"]
     },
     "horsea": {
-        "level": 88,
+        "level": 89,
         "moves": ["agility", "blizzard"],
         "essentialMove": "surf",
         "exclusiveMoves": ["doubleedge", "hydropump", "smokescreen"]
@@ -585,36 +585,36 @@
         "exclusiveMoves": ["doubleedge", "hydropump", "hyperbeam", "smokescreen"]
     },
     "goldeen": {
-        "level": 88,
+        "level": 89,
         "moves": ["agility", "blizzard", "doubleedge", "surf"]
     },
     "seaking": {
-        "level": 78,
+        "level": 79,
         "moves": ["blizzard", "doubleedge", "surf"],
         "exclusiveMoves": ["agility", "agility", "hyperbeam"]
     },
     "staryu": {
-        "level": 85,
+        "level": 83,
         "moves": ["blizzard", "thunderbolt", "thunderwave"],
         "essentialMove": "recover",
         "exclusiveMoves": ["hydropump", "surf", "surf"]
     },
     "starmie": {
-        "level": 68,
+        "level": 67,
         "moves": ["blizzard", "thunderbolt", "thunderwave"],
         "essentialMove": "recover",
         "exclusiveMoves": ["hydropump", "psychic", "surf", "surf"]
     },
     "mrmime": {
-        "level": 77,
+        "level": 76,
         "moves": ["psychic", "seismictoss", "thunderbolt", "thunderwave"]
     },
     "scyther": {
-        "level": 77,
+        "level": 78,
         "moves": ["agility", "hyperbeam", "slash", "swordsdance"]
     },
     "jynx": {
-        "level": 68,
+        "level": 67,
         "moves": ["blizzard", "lovelykiss", "psychic"],
         "exclusiveMoves": ["bodyslam", "counter", "counter", "mimic", "seismictoss"]
     },
@@ -643,7 +643,7 @@
         "exclusiveMoves": ["hydropump", "surf"]
     },
     "lapras": {
-        "level": 71,
+        "level": 70,
         "moves": ["bodyslam", "confuseray", "rest", "sing", "surf"],
         "essentialMove": "blizzard",
         "exclusiveMoves": ["thunderbolt", "thunderbolt"]
@@ -703,14 +703,14 @@
         "moves": ["doubleedge", "fireblast", "hyperbeam", "skyattack"]
     },
     "snorlax": {
-        "level": 68,
+        "level": 69,
         "moves": ["bodyslam", "rest", "selfdestruct", "thunderbolt"],
         "essentialMove": "amnesia",
         "exclusiveMoves": ["blizzard", "blizzard"],
         "comboMoves": ["bodyslam", "earthquake", "hyperbeam", "selfdestruct"]
     },
     "articuno": {
-        "level": 72,
+        "level": 71,
         "moves": ["agility", "hyperbeam", "icebeam", "mimic", "reflect"],
         "essentialMove": "blizzard",
         "comboMoves": ["icebeam", "reflect", "rest"]
@@ -725,12 +725,12 @@
         "exclusiveMoves": ["doubleedge", "reflect", "skyattack"]
     },
     "dratini": {
-        "level": 89,
+        "level": 90,
         "moves": ["bodyslam", "hyperbeam", "thunderbolt", "thunderwave"],
         "essentialMove": "blizzard"
     },
     "dragonair": {
-        "level": 80,
+        "level": 81,
         "moves": ["bodyslam", "hyperbeam", "thunderbolt", "thunderwave"],
         "essentialMove": "blizzard"
     },
@@ -740,14 +740,14 @@
         "essentialMove": "blizzard"
     },
     "mewtwo": {
-        "level": 59,
+        "level": 58,
         "moves": ["blizzard", "recover", "thunderbolt"],
         "essentialMove": "amnesia",
         "exclusiveMoves": ["psychic", "psychic"],
         "comboMoves": ["barrier", "rest"]
     },
     "mew": {
-        "level": 65,
+        "level": 66,
         "moves": ["blizzard", "earthquake", "thunderbolt", "thunderwave"],
         "essentialMove": "psychic",
         "exclusiveMoves": ["explosion", "softboiled", "softboiled"],

--- a/data/mods/gen3/random-data.json
+++ b/data/mods/gen3/random-data.json
@@ -12,7 +12,7 @@
         "moves": ["earthquake", "icebeam", "mirrorcoat", "rest", "roar", "sleeptalk", "surf", "toxic"]
     },
     "butterfree": {
-        "level": 92,
+        "level": 93,
         "moves": ["gigadrain", "hiddenpowerfire", "morningsun", "psychic", "sleeppowder", "stunspore", "toxic"]
     },
     "beedrill": {
@@ -32,7 +32,7 @@
         "moves": ["agility", "batonpass", "drillpeck", "hiddenpowerground", "quickattack", "return", "substitute"]
     },
     "arbok": {
-        "level": 90,
+        "level": 89,
         "moves": ["doubleedge", "earthquake", "hiddenpowerfire", "rest", "rockslide", "sleeptalk", "sludgebomb"]
     },
     "pikachu": {
@@ -136,7 +136,7 @@
         "moves": ["hiddenpowergrass", "hiddenpowerice", "rest", "sleeptalk", "thunderbolt", "toxic"]
     },
     "farfetchd": {
-        "level": 93,
+        "level": 94,
         "moves": ["agility", "batonpass", "hiddenpowerflying", "return", "swordsdance"]
     },
     "dodrio": {
@@ -200,11 +200,11 @@
         "moves": ["doubleedge", "earthquake", "megahorn", "rockslide", "substitute", "swordsdance"]
     },
     "tangela": {
-        "level": 90,
+        "level": 91,
         "moves": ["hiddenpowergrass", "leechseed", "morningsun", "sleeppowder", "stunspore"]
     },
     "kangaskhan": {
-        "level": 81,
+        "level": 80,
         "moves": ["earthquake", "fakeout", "focuspunch", "rest", "return", "shadowball", "substitute", "toxic"]
     },
     "seaking": {
@@ -228,7 +228,7 @@
         "moves": ["calmmind", "hiddenpowerfire", "icebeam", "lovelykiss", "psychic", "substitute"]
     },
     "electabuzz": {
-        "level": 84,
+        "level": 83,
         "moves": ["crosschop", "firepunch", "focuspunch", "hiddenpowergrass", "icepunch", "substitute", "thunderbolt"]
     },
     "magmar": {
@@ -240,15 +240,15 @@
         "moves": ["earthquake", "hiddenpowerbug", "return", "rockslide", "swordsdance"]
     },
     "tauros": {
-        "level": 79,
+        "level": 78,
         "moves": ["doubleedge", "earthquake", "hiddenpowerghost", "hiddenpowerrock", "return"]
     },
     "gyarados": {
-        "level": 78,
+        "level": 77,
         "moves": ["doubleedge", "dragondance", "earthquake", "hiddenpowerflying", "hydropump", "taunt"]
     },
     "lapras": {
-        "level": 82,
+        "level": 81,
         "moves": ["healbell", "icebeam", "rest", "sleeptalk", "surf", "thunderbolt", "toxic"]
     },
     "ditto": {
@@ -256,11 +256,11 @@
         "moves": ["transform"]
     },
     "vaporeon": {
-        "level": 82,
+        "level": 81,
         "moves": ["icebeam", "protect", "surf", "toxic", "wish"]
     },
     "jolteon": {
-        "level": 80,
+        "level": 79,
         "moves": ["batonpass", "hiddenpowerice", "substitute", "thunderbolt", "toxic", "wish"]
     },
     "flareon": {
@@ -276,11 +276,11 @@
         "moves": ["brickbreak", "doubleedge", "hiddenpowerground", "rockslide", "surf", "swordsdance"]
     },
     "aerodactyl": {
-        "level": 78,
+        "level": 77,
         "moves": ["doubleedge", "earthquake", "hiddenpowerflying", "rockslide", "substitute"]
     },
     "snorlax": {
-        "level": 77,
+        "level": 75,
         "moves": ["bodyslam", "curse", "earthquake", "rest", "return", "selfdestruct", "shadowball", "sleeptalk"]
     },
     "articuno": {
@@ -288,15 +288,15 @@
         "moves": ["healbell", "hiddenpowerfire", "icebeam", "protect", "rest", "roar", "sleeptalk", "toxic"]
     },
     "zapdos": {
-        "level": 78,
+        "level": 77,
         "moves": ["agility", "batonpass", "hiddenpowerice", "substitute", "thunderbolt", "thunderwave", "toxic"]
     },
     "moltres": {
-        "level": 80,
+        "level": 79,
         "moves": ["fireblast", "flamethrower", "hiddenpowergrass", "morningsun", "substitute", "toxic", "willowisp"]
     },
     "dragonite": {
-        "level": 81,
+        "level": 80,
         "moves": ["doubleedge", "dragondance", "earthquake", "flamethrower", "healbell", "hiddenpowerflying", "icebeam", "substitute"]
     },
     "mewtwo": {
@@ -312,7 +312,7 @@
         "moves": ["bodyslam", "hiddenpowergrass", "leechseed", "synthesis", "toxic"]
     },
     "typhlosion": {
-        "level": 82,
+        "level": 81,
         "moves": ["fireblast", "flamethrower", "focuspunch", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderpunch"]
     },
     "feraligatr": {
@@ -332,7 +332,7 @@
         "moves": ["agility", "batonpass", "lightscreen", "reflect", "silverwind", "swordsdance", "toxic"]
     },
     "ariados": {
-        "level": 91,
+        "level": 92,
         "moves": ["agility", "batonpass", "signalbeam", "sludgebomb", "spiderweb", "toxic"]
     },
     "crobat": {
@@ -340,7 +340,7 @@
         "moves": ["aerialace", "haze", "hiddenpowerground", "shadowball", "sludgebomb", "taunt", "toxic"]
     },
     "lanturn": {
-        "level": 84,
+        "level": 83,
         "moves": ["confuseray", "icebeam", "rest", "sleeptalk", "surf", "thunderbolt", "thunderwave", "toxic"]
     },
     "togetic": {
@@ -372,7 +372,7 @@
         "moves": ["hiddenpowergrass", "hypnosis", "icebeam", "rest", "surf", "toxic"]
     },
     "jumpluff": {
-        "level": 84,
+        "level": 85,
         "moves": ["encore", "hiddenpowerflying", "leechseed", "sleeppowder", "substitute", "toxic"]
     },
     "aipom": {
@@ -416,7 +416,7 @@
         "moves": ["hiddenpowerpsychic"]
     },
     "wobbuffet": {
-        "level": 78,
+        "level": 79,
         "moves": ["counter", "destinybond", "encore", "mirrorcoat"]
     },
     "girafarig": {
@@ -424,7 +424,7 @@
         "moves": ["agility", "batonpass", "calmmind", "psychic", "substitute", "thunderbolt", "thunderwave", "wish"]
     },
     "forretress": {
-        "level": 80,
+        "level": 81,
         "moves": ["earthquake", "explosion", "hiddenpowerbug", "rapidspin", "spikes", "toxic"]
     },
     "dunsparce": {
@@ -452,7 +452,7 @@
         "moves": ["agility", "batonpass", "hiddenpowerground", "hiddenpowerrock", "morningsun", "silverwind", "steelwing", "swordsdance"]
     },
     "shuckle": {
-        "level": 93,
+        "level": 94,
         "moves": ["encore", "rest", "toxic", "wrap"]
     },
     "heracross": {
@@ -460,11 +460,11 @@
         "moves": ["brickbreak", "focuspunch", "megahorn", "rest", "rockslide", "sleeptalk", "substitute", "swordsdance"]
     },
     "sneasel": {
-        "level": 84,
+        "level": 86,
         "moves": ["brickbreak", "doubleedge", "hiddenpowerflying", "shadowball", "substitute", "swordsdance"]
     },
     "ursaring": {
-        "level": 82,
+        "level": 81,
         "moves": ["earthquake", "focuspunch", "hiddenpowerghost", "return", "swordsdance"]
     },
     "magcargo": {
@@ -476,7 +476,7 @@
         "moves": ["doubleedge", "earthquake", "icebeam", "protect", "rockslide", "toxic"]
     },
     "corsola": {
-        "level": 92,
+        "level": 93,
         "moves": ["calmmind", "icebeam", "recover", "surf", "toxic"]
     },
     "octillery": {
@@ -504,7 +504,7 @@
         "moves": ["hiddenpowergrass", "hydropump", "icebeam", "raindance", "substitute", "surf"]
     },
     "donphan": {
-        "level": 82,
+        "level": 83,
         "moves": ["earthquake", "rapidspin", "rest", "rockslide", "sleeptalk", "toxic"]
     },
     "porygon2": {
@@ -528,15 +528,15 @@
         "moves": ["bodyslam", "curse", "earthquake", "healbell", "milkdrink", "toxic"]
     },
     "blissey": {
-        "level": 80,
+        "level": 79,
         "moves": ["aromatherapy", "calmmind", "icebeam", "seismictoss", "softboiled", "thunderbolt", "thunderwave", "toxic"]
     },
     "raikou": {
-        "level": 77,
+        "level": 76,
         "moves": ["calmmind", "crunch", "hiddenpowergrass", "hiddenpowerice", "rest", "sleeptalk", "substitute", "thunderbolt"]
     },
     "entei": {
-        "level": 81,
+        "level": 80,
         "moves": ["bodyslam", "calmmind", "fireblast", "flamethrower", "hiddenpowergrass", "hiddenpowerice", "solarbeam", "substitute", "sunnyday"]
     },
     "suicune": {
@@ -544,7 +544,7 @@
         "moves": ["calmmind", "icebeam", "rest", "sleeptalk", "substitute", "surf", "toxic"]
     },
     "tyranitar": {
-        "level": 78,
+        "level": 77,
         "moves": ["dragondance", "earthquake", "fireblast", "focuspunch", "hiddenpowerbug", "icebeam", "pursuit", "rockslide", "substitute"]
     },
     "lugia": {
@@ -556,7 +556,7 @@
         "moves": ["calmmind", "earthquake", "recover", "sacredfire", "substitute", "thunderbolt", "toxic"]
     },
     "celebi": {
-        "level": 77,
+        "level": 76,
         "moves": ["batonpass", "calmmind", "healbell", "hiddenpowergrass", "leechseed", "psychic", "recover"]
     },
     "sceptile": {
@@ -568,7 +568,7 @@
         "moves": ["endure", "fireblast", "hiddenpowerice", "reversal", "rockslide", "skyuppercut", "swordsdance", "thunderpunch"]
     },
     "swampert": {
-        "level": 80,
+        "level": 79,
         "moves": ["earthquake", "hydropump", "icebeam", "protect", "rest", "rockslide", "sleeptalk", "surf", "toxic"]
     },
     "mightyena": {
@@ -580,11 +580,11 @@
         "moves": ["bellydrum", "extremespeed", "flail", "hiddenpowerground", "shadowball", "substitute"]
     },
     "beautifly": {
-        "level": 94,
+        "level": 96,
         "moves": ["hiddenpowerbug", "hiddenpowerflying", "morningsun", "stunspore", "substitute", "toxic"]
     },
     "dustox": {
-        "level": 92,
+        "level": 93,
         "moves": ["hiddenpowerground", "lightscreen", "moonlight", "sludgebomb", "toxic", "whirlwind"]
     },
     "ludicolo": {
@@ -608,7 +608,7 @@
         "moves": ["calmmind", "firepunch", "hypnosis", "psychic", "substitute", "thunderbolt", "willowisp"]
     },
     "masquerain": {
-        "level": 90,
+        "level": 91,
         "moves": ["hydropump", "icebeam", "stunspore", "substitute", "toxic"]
     },
     "breloom": {
@@ -620,7 +620,7 @@
         "moves": ["brickbreak", "bulkup", "earthquake", "return", "shadowball", "slackoff"]
     },
     "slaking": {
-        "level": 81,
+        "level": 80,
         "moves": ["doubleedge", "earthquake", "focuspunch", "return", "shadowball"]
     },
     "ninjask": {
@@ -640,11 +640,11 @@
         "moves": ["bulkup", "crosschop", "fakeout", "hiddenpowerghost", "rest", "rockslide", "sleeptalk"]
     },
     "nosepass": {
-        "level": 91,
+        "level": 94,
         "moves": ["earthquake", "explosion", "rockslide", "thunderwave", "toxic"]
     },
     "delcatty": {
-        "level": 91,
+        "level": 92,
         "moves": ["batonpass", "doubleedge", "healbell", "thunderwave", "wish"]
     },
     "sableye": {
@@ -712,7 +712,7 @@
         "moves": ["calmmind", "firepunch", "icywind", "psychic", "substitute", "taunt"]
     },
     "spinda": {
-        "level": 93,
+        "level": 94,
         "moves": ["bodyslam", "encore", "focuspunch", "shadowball", "substitute", "teeterdance", "toxic"]
     },
     "flygon": {
@@ -732,7 +732,7 @@
         "moves": ["brickbreak", "quickattack", "return", "shadowball", "swordsdance"]
     },
     "seviper": {
-        "level": 90,
+        "level": 89,
         "moves": ["crunch", "doubleedge", "earthquake", "flamethrower", "hiddenpowergrass", "sludgebomb"]
     },
     "lunatone": {
@@ -764,11 +764,11 @@
         "moves": ["doubleedge", "earthquake", "hiddenpowerbug", "rockslide", "swordsdance"]
     },
     "milotic": {
-        "level": 79,
+        "level": 78,
         "moves": ["icebeam", "mirrorcoat", "recover", "surf", "toxic"]
     },
     "castform": {
-        "level": 90,
+        "level": 91,
         "moves": ["flamethrower", "icebeam", "substitute", "thunderbolt", "thunderwave"]
     },
     "kecleon": {
@@ -776,15 +776,15 @@
         "moves": ["brickbreak", "return", "shadowball", "thunderwave", "trick"]
     },
     "banette": {
-        "level": 85,
+        "level": 86,
         "moves": ["destinybond", "endure", "hiddenpowerfighting", "knockoff", "shadowball", "willowisp"]
     },
     "dusclops": {
-        "level": 85,
+        "level": 86,
         "moves": ["focuspunch", "icebeam", "painsplit", "rest", "shadowball", "sleeptalk", "substitute", "willowisp"]
     },
     "tropius": {
-        "level": 91,
+        "level": 92,
         "moves": ["hiddenpowerfire", "solarbeam", "sunnyday", "synthesis"]
     },
     "chimecho": {
@@ -792,11 +792,11 @@
         "moves": ["calmmind", "healbell", "hiddenpowerfire", "lightscreen", "psychic", "reflect", "toxic", "yawn"]
     },
     "absol": {
-        "level": 85,
+        "level": 86,
         "moves": ["batonpass", "hiddenpowerfighting", "quickattack", "shadowball", "swordsdance"]
     },
     "glalie": {
-        "level": 87,
+        "level": 86,
         "moves": ["earthquake", "explosion", "icebeam", "spikes", "toxic"]
     },
     "walrein": {
@@ -808,7 +808,7 @@
         "moves": ["doubleedge", "hiddenpowergrass", "hydropump", "icebeam", "raindance", "surf"]
     },
     "gorebyss": {
-        "level": 84,
+        "level": 85,
         "moves": ["hiddenpowerelectric", "hiddenpowergrass", "hydropump", "icebeam", "raindance", "surf"]
     },
     "relicanth": {
@@ -816,7 +816,7 @@
         "moves": ["doubleedge", "earthquake", "hiddenpowerflying", "rest", "rockslide", "sleeptalk", "toxic"]
     },
     "luvdisc": {
-        "level": 95,
+        "level": 96,
         "moves": ["icebeam", "protect", "substitute", "surf", "sweetkiss", "toxic"]
     },
     "salamence": {
@@ -824,7 +824,7 @@
         "moves": ["brickbreak", "dragondance", "earthquake", "fireblast", "hiddenpowerflying", "rockslide"]
     },
     "metagross": {
-        "level": 78,
+        "level": 77,
         "moves": ["agility", "earthquake", "explosion", "meteormash", "psychic", "rockslide"]
     },
     "regirock": {
@@ -848,11 +848,11 @@
         "moves": ["calmmind", "dragonclaw", "hiddenpowerfire", "psychic", "recover"]
     },
     "kyogre": {
-        "level": 69,
+        "level": 68,
         "moves": ["calmmind", "icebeam", "rest", "sleeptalk", "surf", "thunder"]
     },
     "groudon": {
-        "level": 72,
+        "level": 71,
         "moves": ["earthquake", "hiddenpowerbug", "overheat", "rockslide", "substitute", "swordsdance", "thunderwave"]
     },
     "rayquaza": {

--- a/data/mods/gen4/random-data.json
+++ b/data/mods/gen4/random-data.json
@@ -12,11 +12,11 @@
         "moves": ["icebeam", "rapidspin", "rest", "roar", "sleeptalk", "surf", "toxic"]
     },
     "butterfree": {
-        "level": 90,
+        "level": 91,
         "moves": ["bugbuzz", "safeguard", "sleeppowder", "stunspore", "uturn"]
     },
     "beedrill": {
-        "level": 92,
+        "level": 93,
         "moves": ["brickbreak", "poisonjab", "swordsdance", "toxicspikes", "uturn", "xscissor"]
     },
     "pidgeot": {
@@ -24,19 +24,19 @@
         "moves": ["bravebird", "doubleedge", "heatwave", "pursuit", "quickattack", "uturn"]
     },
     "raticate": {
-        "level": 88,
+        "level": 87,
         "moves": ["crunch", "facade", "protect", "suckerpunch", "swordsdance", "uturn"]
     },
     "fearow": {
-        "level": 88,
+        "level": 87,
         "moves": ["doubleedge", "drillpeck", "pursuit", "quickattack", "return", "uturn"]
     },
     "arbok": {
-        "level": 90,
+        "level": 91,
         "moves": ["aquatail", "crunch", "earthquake", "glare", "gunkshot", "poisonjab", "seedbomb", "switcheroo"]
     },
     "pikachu": {
-        "level": 88,
+        "level": 89,
         "moves": ["grassknot", "hiddenpowerice", "substitute", "surf", "thunderbolt", "volttackle"]
     },
     "raichu": {
@@ -44,11 +44,11 @@
         "moves": ["encore", "focusblast", "focuspunch", "grassknot", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"]
     },
     "sandslash": {
-        "level": 88,
+        "level": 89,
         "moves": ["earthquake", "nightslash", "rapidspin", "stealthrock", "stoneedge", "substitute", "swordsdance"]
     },
     "nidoqueen": {
-        "level": 87,
+        "level": 86,
         "moves": ["earthquake", "fireblast", "icebeam", "roar", "stealthrock", "toxicspikes"]
     },
     "nidoking": {
@@ -60,11 +60,11 @@
         "moves": ["calmmind", "doubleedge", "fireblast", "icebeam", "softboiled", "stealthrock", "thunderbolt"]
     },
     "ninetales": {
-        "level": 85,
+        "level": 84,
         "moves": ["energyball", "fireblast", "flamethrower", "hiddenpowerrock", "hypnosis", "nastyplot"]
     },
     "wigglytuff": {
-        "level": 88,
+        "level": 90,
         "moves": ["bodyslam", "doubleedge", "fireblast", "healbell", "protect", "seismictoss", "stealthrock", "thunderwave", "toxic", "wish"]
     },
     "vileplume": {
@@ -72,7 +72,7 @@
         "moves": ["energyball", "hiddenpowerfire", "moonlight", "sleeppowder", "sludgebomb", "solarbeam", "sunnyday"]
     },
     "parasect": {
-        "level": 93,
+        "level": 94,
         "moves": ["seedbomb", "spore", "stunspore", "synthesis", "xscissor"]
     },
     "venomoth": {
@@ -104,7 +104,7 @@
         "moves": ["brickbreak", "bulkup", "encore", "focuspunch", "icepunch", "rest", "sleeptalk", "substitute", "toxic", "waterfall"]
     },
     "alakazam": {
-        "level": 84,
+        "level": 83,
         "moves": ["encore", "focusblast", "hiddenpowerfire", "psychic", "shadowball", "signalbeam", "substitute", "trick"]
     },
     "machamp": {
@@ -124,7 +124,7 @@
         "moves": ["earthquake", "explosion", "hammerarm", "stealthrock", "stoneedge", "suckerpunch"]
     },
     "rapidash": {
-        "level": 87,
+        "level": 86,
         "moves": ["flareblitz", "hypnosis", "megahorn", "morningsun", "willowisp"]
     },
     "slowbro": {
@@ -152,11 +152,11 @@
         "moves": ["explosion", "iceshard", "rapidspin", "rockblast", "spikes", "surf", "toxicspikes"]
     },
     "gengar": {
-        "level": 80,
+        "level": 79,
         "moves": ["focusblast", "hiddenpowerfire", "hypnosis", "painsplit", "shadowball", "sludgebomb", "substitute", "thunderbolt", "trick"]
     },
     "hypno": {
-        "level": 89,
+        "level": 90,
         "moves": ["protect", "seismictoss", "thunderwave", "toxic", "wish"]
     },
     "kingler": {
@@ -208,11 +208,11 @@
         "moves": ["aerialace", "brickbreak", "bugbite", "pursuit", "quickattack", "roost", "swordsdance", "uturn"]
     },
     "jynx": {
-        "level": 85,
+        "level": 84,
         "moves": ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psychic", "substitute"]
     },
     "pinsir": {
-        "level": 87,
+        "level": 86,
         "moves": ["closecombat", "earthquake", "quickattack", "stealthrock", "stoneedge", "swordsdance", "xscissor"]
     },
     "tauros": {
@@ -224,7 +224,7 @@
         "moves": ["bounce", "dragondance", "earthquake", "icefang", "rest", "sleeptalk", "stoneedge", "waterfall"]
     },
     "lapras": {
-        "level": 88,
+        "level": 87,
         "moves": ["healbell", "hydropump", "icebeam", "surf", "thunderbolt", "toxic"]
     },
     "ditto": {
@@ -260,7 +260,7 @@
         "moves": ["bodyslam", "crunch", "curse", "earthquake", "firepunch", "pursuit", "rest", "return", "selfdestruct", "sleeptalk", "whirlwind"]
     },
     "articuno": {
-        "level": 85,
+        "level": 84,
         "moves": ["healbell", "icebeam", "roar", "roost", "substitute", "toxic"]
     },
     "zapdos": {
@@ -268,7 +268,7 @@
         "moves": ["heatwave", "hiddenpowergrass", "hiddenpowerice", "roost", "substitute", "thunderbolt", "toxic", "uturn"]
     },
     "moltres": {
-        "level": 84,
+        "level": 83,
         "moves": ["airslash", "fireblast", "flamethrower", "hiddenpowergrass", "roost", "substitute", "toxic", "uturn"]
     },
     "dragonite": {
@@ -288,7 +288,7 @@
         "moves": ["aromatherapy", "energyball", "leechseed", "lightscreen", "reflect", "synthesis", "toxic"]
     },
     "typhlosion": {
-        "level": 85,
+        "level": 84,
         "moves": ["eruption", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerrock"]
     },
     "feraligatr": {
@@ -296,19 +296,19 @@
         "moves": ["aquajet", "dragondance", "earthquake", "icepunch", "lowkick", "return", "swordsdance", "waterfall"]
     },
     "furret": {
-        "level": 90,
+        "level": 91,
         "moves": ["aquatail", "brickbreak", "doubleedge", "firepunch", "return", "shadowclaw", "suckerpunch", "trick", "uturn"]
     },
     "noctowl": {
-        "level": 93,
+        "level": 94,
         "moves": ["nightshade", "reflect", "roost", "toxic", "whirlwind"]
     },
     "ledian": {
-        "level": 95,
+        "level": 97,
         "moves": ["encore", "knockoff", "lightscreen", "reflect", "roost", "toxic", "uturn"]
     },
     "ariados": {
-        "level": 92,
+        "level": 93,
         "moves": ["bugbite", "poisonjab", "shadowsneak", "suckerpunch", "toxicspikes"]
     },
     "crobat": {
@@ -348,11 +348,11 @@
         "moves": ["bounce", "encore", "grassknot", "leechseed", "sleeppowder", "stunspore", "substitute", "toxic", "uturn"]
     },
     "sunflora": {
-        "level": 93,
+        "level": 94,
         "moves": ["earthpower", "hiddenpowerice", "leafstorm", "sludgebomb", "synthesis"]
     },
     "quagsire": {
-        "level": 88,
+        "level": 89,
         "moves": ["earthquake", "encore", "icepunch", "recover", "toxic", "waterfall", "yawn"]
     },
     "espeon": {
@@ -372,7 +372,7 @@
         "moves": ["hiddenpowerpsychic"]
     },
     "wobbuffet": {
-        "level": 79,
+        "level": 80,
         "moves": ["counter", "destinybond", "encore", "mirrorcoat"]
     },
     "girafarig": {
@@ -384,7 +384,7 @@
         "moves": ["earthquake", "explosion", "gyroball", "rapidspin", "spikes", "stealthrock", "toxicspikes"]
     },
     "dunsparce": {
-        "level": 90,
+        "level": 91,
         "moves": ["bite", "bodyslam", "earthquake", "headbutt", "rockslide", "roost", "thunderwave"]
     },
     "steelix": {
@@ -400,15 +400,15 @@
         "moves": ["destinybond", "explosion", "poisonjab", "spikes", "thunderwave", "toxicspikes", "waterfall"]
     },
     "scizor": {
-        "level": 80,
+        "level": 79,
         "moves": ["bugbite", "bulletpunch", "pursuit", "roost", "superpower", "swordsdance", "uturn"]
     },
     "shuckle": {
-        "level": 89,
+        "level": 90,
         "moves": ["encore", "knockoff", "rest", "stealthrock", "toxic"]
     },
     "heracross": {
-        "level": 82,
+        "level": 81,
         "moves": ["closecombat", "megahorn", "nightslash", "stoneedge", "substitute", "swordsdance"]
     },
     "ursaring": {
@@ -416,11 +416,11 @@
         "moves": ["closecombat", "crunch", "earthquake", "facade", "protect", "swordsdance"]
     },
     "magcargo": {
-        "level": 90,
+        "level": 91,
         "moves": ["fireblast", "hiddenpowerrock", "lavaplume", "recover", "stealthrock", "toxic", "willowisp"]
     },
     "corsola": {
-        "level": 91,
+        "level": 92,
         "moves": ["explosion", "recover", "stealthrock", "surf", "toxic"]
     },
     "octillery": {
@@ -460,7 +460,7 @@
         "moves": ["earthquake", "energyball", "hypnosis", "megahorn", "return", "suckerpunch"]
     },
     "smeargle": {
-        "level": 83,
+        "level": 85,
         "moves": ["counter", "spikes", "spore", "stealthrock", "uturn"]
     },
     "hitmontop": {
@@ -476,7 +476,7 @@
         "moves": ["aromatherapy", "flamethrower", "icebeam", "protect", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic", "wish"]
     },
     "raikou": {
-        "level": 78,
+        "level": 77,
         "moves": ["aurasphere", "calmmind", "hiddenpowerice", "shadowball", "thunderbolt"]
     },
     "entei": {
@@ -524,11 +524,11 @@
         "moves": ["bellydrum", "extremespeed", "seedbomb", "shadowclaw"]
     },
     "beautifly": {
-        "level": 91,
+        "level": 92,
         "moves": ["bugbuzz", "hiddenpowerground", "psychic", "uturn"]
     },
     "dustox": {
-        "level": 94,
+        "level": 96,
         "moves": ["bugbuzz", "protect", "roost", "toxic", "whirlwind"]
     },
     "ludicolo": {
@@ -544,7 +544,7 @@
         "moves": ["bravebird", "facade", "protect", "quickattack", "uturn"]
     },
     "pelipper": {
-        "level": 89,
+        "level": 90,
         "moves": ["airslash", "hiddenpowergrass", "hydropump", "roost", "surf", "toxic", "uturn"]
     },
     "gardevoir": {
@@ -552,7 +552,7 @@
         "moves": ["calmmind", "focusblast", "psychic", "shadowball", "taunt", "thunderbolt", "willowisp"]
     },
     "masquerain": {
-        "level": 92,
+        "level": 93,
         "moves": ["agility", "airslash", "batonpass", "bugbuzz", "hydropump", "roost"]
     },
     "breloom": {
@@ -572,11 +572,11 @@
         "moves": ["batonpass", "protect", "substitute", "swordsdance", "xscissor"]
     },
     "shedinja": {
-        "level": 89,
+        "level": 90,
         "moves": ["batonpass", "shadowsneak", "swordsdance", "willowisp", "xscissor"]
     },
     "exploud": {
-        "level": 88,
+        "level": 89,
         "moves": ["crunch", "earthquake", "fireblast", "icebeam", "return", "surf"]
     },
     "hariyama": {
@@ -584,15 +584,15 @@
         "moves": ["bulletpunch", "closecombat", "facade", "fakeout", "focuspunch", "icepunch", "payback", "stoneedge", "substitute"]
     },
     "delcatty": {
-        "level": 96,
+        "level": 97,
         "moves": ["healbell", "protect", "return", "thunderwave", "wish"]
     },
     "sableye": {
-        "level": 94,
+        "level": 95,
         "moves": ["recover", "seismictoss", "taunt", "toxic", "willowisp"]
     },
     "mawile": {
-        "level": 94,
+        "level": 95,
         "moves": ["batonpass", "focuspunch", "ironhead", "substitute", "suckerpunch", "swordsdance"]
     },
     "aggron": {
@@ -600,11 +600,11 @@
         "moves": ["aquatail", "earthquake", "headsmash", "icepunch", "lowkick", "rockpolish"]
     },
     "medicham": {
-        "level": 87,
+        "level": 86,
         "moves": ["bulletpunch", "fakeout", "highjumpkick", "icepunch", "psychocut", "thunderpunch", "trick"]
     },
     "manectric": {
-        "level": 88,
+        "level": 87,
         "moves": ["flamethrower", "hiddenpowergrass", "overheat", "switcheroo", "thunderbolt"]
     },
     "plusle": {
@@ -616,11 +616,11 @@
         "moves": ["batonpass", "encore", "hiddenpowerice", "nastyplot", "thunderbolt"]
     },
     "volbeat": {
-        "level": 92,
+        "level": 94,
         "moves": ["batonpass", "bugbuzz", "encore", "substitute", "tailglow"]
     },
     "illumise": {
-        "level": 90,
+        "level": 91,
         "moves": ["bugbuzz", "encore", "hiddenpowerground", "hiddenpowerice", "thunderbolt", "uturn", "wish"]
     },
     "swalot": {
@@ -660,7 +660,7 @@
         "moves": ["encore", "focuspunch", "lowkick", "seedbomb", "spikes", "substitute", "suckerpunch", "swordsdance"]
     },
     "altaria": {
-        "level": 85,
+        "level": 86,
         "moves": ["dragonclaw", "dragondance", "earthquake", "fireblast", "healbell", "outrage", "roost"]
     },
     "zangoose": {
@@ -716,7 +716,7 @@
         "moves": ["destinybond", "hiddenpowerfighting", "shadowclaw", "shadowsneak", "taunt", "thunderwave", "willowisp"]
     },
     "tropius": {
-        "level": 92,
+        "level": 93,
         "moves": ["aerialace", "curse", "dragondance", "earthquake", "leafblade", "leafstorm", "leechseed", "roost", "swordsdance", "toxic", "whirlwind"]
     },
     "chimecho": {
@@ -748,7 +748,7 @@
         "moves": ["doubleedge", "earthquake", "headsmash", "rockpolish", "stealthrock", "waterfall"]
     },
     "luvdisc": {
-        "level": 97,
+        "level": 98,
         "moves": ["icebeam", "protect", "surf", "sweetkiss", "toxic"]
     },
     "salamence": {
@@ -760,7 +760,7 @@
         "moves": ["agility", "bulletpunch", "earthquake", "explosion", "meteormash", "stealthrock", "zenheadbutt"]
     },
     "regirock": {
-        "level": 85,
+        "level": 84,
         "moves": ["earthquake", "explosion", "rest", "rockslide", "sleeptalk", "stealthrock", "thunderwave"]
     },
     "regice": {
@@ -768,7 +768,7 @@
         "moves": ["focusblast", "icebeam", "rest", "sleeptalk", "thunderbolt", "thunderwave"]
     },
     "registeel": {
-        "level": 83,
+        "level": 82,
         "moves": ["curse", "ironhead", "rest", "sleeptalk", "stealthrock", "thunderwave", "toxic"]
     },
     "latias": {
@@ -776,11 +776,11 @@
         "moves": ["calmmind", "dracometeor", "psychic", "roost"]
     },
     "latios": {
-        "level": 72,
+        "level": 71,
         "moves": ["calmmind", "dracometeor", "psychic", "roost"]
     },
     "kyogre": {
-        "level": 71,
+        "level": 70,
         "moves": ["calmmind", "icebeam", "rest", "sleeptalk", "surf", "thunder", "waterspout"]
     },
     "groudon": {
@@ -804,11 +804,11 @@
         "moves": ["extremespeed", "hiddenpowerfire", "icebeam", "psychoboost", "shadowball", "stealthrock", "superpower"]
     },
     "deoxysdefense": {
-        "level": 76,
+        "level": 77,
         "moves": ["recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"]
     },
     "deoxysspeed": {
-        "level": 77,
+        "level": 78,
         "moves": ["lightscreen", "psychoboost", "reflect", "spikes", "stealthrock", "superpower", "taunt"]
     },
     "torterra": {
@@ -828,11 +828,11 @@
         "moves": ["bravebird", "closecombat", "doubleedge", "pursuit", "quickattack", "return", "roost", "substitute", "uturn"]
     },
     "bibarel": {
-        "level": 92,
+        "level": 93,
         "moves": ["curse", "quickattack", "rest", "waterfall"]
     },
     "kricketune": {
-        "level": 96,
+        "level": 97,
         "moves": ["brickbreak", "nightslash", "return", "swordsdance", "xscissor"]
     },
     "luxray": {
@@ -852,11 +852,11 @@
         "moves": ["earthquake", "metalburst", "protect", "roar", "rockslide", "stealthrock", "toxic"]
     },
     "wormadam": {
-        "level": 94,
+        "level": 95,
         "moves": ["hiddenpowerice", "hiddenpowerrock", "leafstorm", "psychic", "signalbeam"]
     },
     "wormadamsandy": {
-        "level": 93,
+        "level": 94,
         "moves": ["earthquake", "rest", "sleeptalk", "toxic"]
     },
     "wormadamtrash": {
@@ -864,11 +864,11 @@
         "moves": ["gyroball", "protect", "stealthrock", "toxic"]
     },
     "mothim": {
-        "level": 88,
+        "level": 89,
         "moves": ["airslash", "bugbuzz", "hiddenpowerfighting", "hiddenpowerground", "shadowball", "uturn"]
     },
     "vespiquen": {
-        "level": 94,
+        "level": 95,
         "moves": ["attackorder", "defendorder", "protect", "roost", "substitute", "toxic"]
     },
     "pachirisu": {
@@ -880,11 +880,11 @@
         "moves": ["aquajet", "batonpass", "bulkup", "crunch", "icepunch", "return", "taunt", "waterfall"]
     },
     "cherrim": {
-        "level": 92,
+        "level": 93,
         "moves": ["aromatherapy", "energyball", "hiddenpowerfire", "hiddenpowerground", "synthesis", "toxic"]
     },
     "cherrimsunshine": {
-        "level": 92,
+        "level": 93,
         "moves": ["hiddenpowerice", "solarbeam", "sunnyday", "weatherball"]
     },
     "gastrodon": {
@@ -896,7 +896,7 @@
         "moves": ["fakeout", "lowkick", "payback", "pursuit", "return", "uturn"]
     },
     "drifblim": {
-        "level": 87,
+        "level": 86,
         "moves": ["calmmind", "hiddenpowerfighting", "rest", "shadowball", "substitute", "thunderbolt"]
     },
     "lopunny": {
@@ -904,7 +904,7 @@
         "moves": ["batonpass", "encore", "healingwish", "return", "substitute", "thunderwave", "toxic"]
     },
     "mismagius": {
-        "level": 83,
+        "level": 82,
         "moves": ["hiddenpowerfighting", "nastyplot", "painsplit", "shadowball", "substitute", "taunt", "thunderbolt", "trick", "willowisp"]
     },
     "honchkrow": {
@@ -916,7 +916,7 @@
         "moves": ["fakeout", "return", "shadowclaw", "suckerpunch", "taunt", "uturn"]
     },
     "skuntank": {
-        "level": 87,
+        "level": 86,
         "moves": ["crunch", "explosion", "fireblast", "poisonjab", "pursuit", "suckerpunch", "taunt"]
     },
     "bronzong": {
@@ -924,7 +924,7 @@
         "moves": ["earthquake", "explosion", "gyroball", "lightscreen", "payback", "reflect", "stealthrock", "toxic"]
     },
     "chatot": {
-        "level": 89,
+        "level": 90,
         "moves": ["encore", "heatwave", "hiddenpowergrass", "hypervoice", "nastyplot", "uturn"]
     },
     "spiritomb": {
@@ -932,7 +932,7 @@
         "moves": ["calmmind", "darkpulse", "hiddenpowerfighting", "rest", "sleeptalk", "willowisp"]
     },
     "garchomp": {
-        "level": 76,
+        "level": 75,
         "moves": ["dragonclaw", "earthquake", "fireblast", "outrage", "stealthrock", "stoneedge", "substitute", "swordsdance"]
     },
     "lucario": {
@@ -956,11 +956,11 @@
         "moves": ["powerwhip", "return", "sleeppowder", "substitute", "swordsdance", "synthesis"]
     },
     "lumineon": {
-        "level": 89,
+        "level": 90,
         "moves": ["hiddenpowerelectric", "hiddenpowergrass", "icebeam", "raindance", "surf", "uturn"]
     },
     "abomasnow": {
-        "level": 82,
+        "level": 83,
         "moves": ["blizzard", "earthquake", "energyball", "hiddenpowerfire", "iceshard", "leechseed", "substitute", "woodhammer"]
     },
     "weavile": {
@@ -980,7 +980,7 @@
         "moves": ["earthquake", "icepunch", "megahorn", "rockpolish", "stealthrock", "stoneedge"]
     },
     "tangrowth": {
-        "level": 84,
+        "level": 85,
         "moves": ["earthquake", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "powerwhip", "rockslide", "sleeppowder", "stunspore", "swordsdance", "synthesis"]
     },
     "electivire": {
@@ -992,7 +992,7 @@
         "moves": ["fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerice", "substitute", "thunderbolt"]
     },
     "togekiss": {
-        "level": 81,
+        "level": 80,
         "moves": ["airslash", "aurasphere", "fireblast", "healbell", "nastyplot", "roost", "thunderwave"]
     },
     "yanmega": {
@@ -1012,7 +1012,7 @@
         "moves": ["earthquake", "roost", "stealthrock", "stoneedge", "swordsdance", "taunt", "toxic", "uturn"]
     },
     "mamoswine": {
-        "level": 81,
+        "level": 80,
         "moves": ["earthquake", "endeavor", "iceshard", "stealthrock", "stoneedge", "superpower"]
     },
     "porygonz": {
@@ -1060,7 +1060,7 @@
         "moves": ["hiddenpowerfighting", "hiddenpowerfire", "shadowball", "thunderbolt", "trick"]
     },
     "uxie": {
-        "level": 82,
+        "level": 81,
         "moves": ["lightscreen", "psychic", "reflect", "stealthrock", "thunderwave", "uturn", "yawn"]
     },
     "mesprit": {
@@ -1076,7 +1076,7 @@
         "moves": ["aurasphere", "bulkup", "dracometeor", "dragonclaw", "earthquake", "fireblast", "outrage", "rest", "sleeptalk", "stealthrock", "thunderbolt", "toxic"]
     },
     "palkia": {
-        "level": 72,
+        "level": 71,
         "moves": ["aurasphere", "dracometeor", "fireblast", "hydropump", "spacialrend", "surf", "thunderbolt"]
     },
     "heatran": {
@@ -1084,7 +1084,7 @@
         "moves": ["dragonpulse", "earthpower", "explosion", "fireblast", "hiddenpowergrass", "lavaplume", "protect", "roar", "stealthrock", "substitute", "toxic"]
     },
     "regigigas": {
-        "level": 86,
+        "level": 85,
         "moves": ["confuseray", "earthquake", "firepunch", "return", "substitute", "thunderwave", "toxic"]
     },
     "giratinaorigin": {
@@ -1096,11 +1096,11 @@
         "moves": ["calmmind", "dragonpulse", "rest", "roar", "shadowball", "sleeptalk", "willowisp"]
     },
     "cresselia": {
-        "level": 81,
+        "level": 80,
         "moves": ["calmmind", "hiddenpowerfire", "icebeam", "lightscreen", "moonlight", "psychic", "reflect", "substitute", "thunderwave", "toxic"]
     },
     "phione": {
-        "level": 89,
+        "level": 90,
         "moves": ["icebeam", "raindance", "rest", "surf", "toxic"]
     },
     "manaphy": {

--- a/data/mods/gen5/random-data.json
+++ b/data/mods/gen5/random-data.json
@@ -1,10 +1,10 @@
 {
     "venusaur": {
-        "level": 83,
+        "level": 84,
         "moves": ["hiddenpowerfire", "hiddenpowerice", "leechseed", "naturepower", "powerwhip", "sleeppowder", "sludgebomb", "swordsdance", "synthesis"]
     },
     "charizard": {
-        "level": 86,
+        "level": 85,
         "moves": ["airslash", "dragonpulse", "fireblast", "focusblast", "hiddenpowergrass", "roost"]
     },
     "blastoise": {
@@ -12,11 +12,11 @@
         "moves": ["icebeam", "protect", "rapidspin", "scald", "toxic"]
     },
     "butterfree": {
-        "level": 91,
+        "level": 92,
         "moves": ["bugbuzz", "hiddenpowerrock", "psychic", "quiverdance", "sleeppowder", "substitute"]
     },
     "beedrill": {
-        "level": 93,
+        "level": 94,
         "moves": ["drillrun", "poisonjab", "tailwind", "toxicspikes", "uturn"]
     },
     "pidgeot": {
@@ -72,7 +72,7 @@
         "moves": ["aromatherapy", "gigadrain", "hiddenpowerfire", "leechseed", "sleeppowder", "sludgebomb", "synthesis"]
     },
     "parasect": {
-        "level": 91,
+        "level": 92,
         "moves": ["aromatherapy", "leechseed", "seedbomb", "spore", "stunspore", "synthesis", "xscissor"]
     },
     "venomoth": {
@@ -184,7 +184,7 @@
         "moves": ["bulkup", "closecombat", "drainpunch", "icepunch", "machpunch", "rapidspin", "stoneedge"]
     },
     "weezing": {
-        "level": 87,
+        "level": 88,
         "moves": ["fireblast", "haze", "painsplit", "sludgebomb", "willowisp"]
     },
     "rhydon": {
@@ -252,11 +252,11 @@
         "moves": ["facade", "flamecharge", "rest", "sleeptalk"]
     },
     "omastar": {
-        "level": 84,
+        "level": 83,
         "moves": ["hiddenpowergrass", "icebeam", "shellsmash", "spikes", "stealthrock", "surf"]
     },
     "kabutops": {
-        "level": 84,
+        "level": 85,
         "moves": ["aquajet", "rapidspin", "stealthrock", "stoneedge", "superpower", "swordsdance", "waterfall"]
     },
     "aerodactyl": {
@@ -268,11 +268,11 @@
         "moves": ["bodyslam", "crunch", "curse", "earthquake", "firepunch", "pursuit", "rest"]
     },
     "articuno": {
-        "level": 86,
+        "level": 85,
         "moves": ["hurricane", "icebeam", "roost", "substitute", "toxic"]
     },
     "zapdos": {
-        "level": 81,
+        "level": 80,
         "moves": ["heatwave", "hiddenpowerice", "roost", "substitute", "thunderbolt", "toxic", "uturn"]
     },
     "moltres": {
@@ -284,7 +284,7 @@
         "moves": ["dragondance", "outrage", "rest", "sleeptalk", "waterfall"]
     },
     "dragonite": {
-        "level": 78,
+        "level": 77,
         "moves": ["dragondance", "earthquake", "extremespeed", "firepunch", "outrage", "roost"]
     },
     "mewtwo": {
@@ -300,7 +300,7 @@
         "moves": ["aromatherapy", "dragontail", "gigadrain", "leechseed", "lightscreen", "reflect", "synthesis", "toxic"]
     },
     "typhlosion": {
-        "level": 84,
+        "level": 83,
         "moves": ["eruption", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerrock"]
     },
     "feraligatr": {
@@ -312,7 +312,7 @@
         "moves": ["aquatail", "doubleedge", "firepunch", "shadowclaw", "trick", "uturn"]
     },
     "noctowl": {
-        "level": 91,
+        "level": 92,
         "moves": ["airslash", "magiccoat", "nightshade", "roost", "toxic", "whirlwind"]
     },
     "ledian": {
@@ -324,7 +324,7 @@
         "moves": ["poisonjab", "suckerpunch", "toxicspikes", "xscissor"]
     },
     "crobat": {
-        "level": 82,
+        "level": 83,
         "moves": ["bravebird", "heatwave", "roost", "superfang", "taunt", "toxic", "uturn"]
     },
     "lanturn": {
@@ -332,15 +332,15 @@
         "moves": ["healbell", "icebeam", "scald", "thunderbolt", "thunderwave", "voltswitch"]
     },
     "xatu": {
-        "level": 82,
+        "level": 83,
         "moves": ["heatwave", "psychic", "roost", "thunderwave", "toxic", "uturn"]
     },
     "ampharos": {
-        "level": 86,
+        "level": 87,
         "moves": ["agility", "focusblast", "healbell", "hiddenpowergrass", "hiddenpowerice", "thunderbolt", "toxic", "voltswitch"]
     },
     "bellossom": {
-        "level": 90,
+        "level": 91,
         "moves": ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "leafstorm", "leechseed", "sleeppowder", "stunspore", "synthesis"]
     },
     "azumarill": {
@@ -360,7 +360,7 @@
         "moves": ["acrobatics", "encore", "energyball", "leechseed", "sleeppowder", "uturn"]
     },
     "sunflora": {
-        "level": 93,
+        "level": 94,
         "moves": ["earthpower", "encore", "gigadrain", "hiddenpowerrock", "solarbeam", "sunnyday"]
     },
     "quagsire": {
@@ -440,7 +440,7 @@
         "moves": ["hiddenpowerrock", "lavaplume", "recover", "stealthrock", "toxic"]
     },
     "corsola": {
-        "level": 90,
+        "level": 91,
         "moves": ["powergem", "recover", "scald", "stealthrock", "toxic"]
     },
     "octillery": {
@@ -456,7 +456,7 @@
         "moves": ["airslash", "hydropump", "icebeam", "raindance", "rest", "scald", "sleeptalk"]
     },
     "skarmory": {
-        "level": 80,
+        "level": 79,
         "moves": ["bravebird", "roost", "spikes", "stealthrock", "whirlwind"]
     },
     "houndoom": {
@@ -484,7 +484,7 @@
         "moves": ["memento", "spikes", "spore", "stealthrock", "whirlwind"]
     },
     "hitmontop": {
-        "level": 84,
+        "level": 85,
         "moves": ["closecombat", "machpunch", "rapidspin", "stoneedge", "suckerpunch", "toxic"]
     },
     "miltank": {
@@ -496,7 +496,7 @@
         "moves": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"]
     },
     "raikou": {
-        "level": 81,
+        "level": 80,
         "moves": ["aurasphere", "calmmind", "hiddenpowerice", "substitute", "thunderbolt", "voltswitch"]
     },
     "entei": {
@@ -540,11 +540,11 @@
         "moves": ["crunch", "facade", "firefang", "howl", "suckerpunch"]
     },
     "linoone": {
-        "level": 87,
+        "level": 86,
         "moves": ["bellydrum", "extremespeed", "seedbomb", "shadowclaw"]
     },
     "beautifly": {
-        "level": 93,
+        "level": 94,
         "moves": ["bugbuzz", "hiddenpowerground", "psychic", "quiverdance"]
     },
     "dustox": {
@@ -588,7 +588,7 @@
         "moves": ["earthquake", "nightslash", "pursuit", "retaliate", "return"]
     },
     "ninjask": {
-        "level": 86,
+        "level": 87,
         "moves": ["aerialace", "substitute", "swordsdance", "xscissor"]
     },
     "shedinja": {
@@ -604,15 +604,15 @@
         "moves": ["bulletpunch", "closecombat", "facade", "fakeout", "stoneedge"]
     },
     "delcatty": {
-        "level": 91,
+        "level": 92,
         "moves": ["doubleedge", "fakeout", "icebeam", "suckerpunch", "thunderwave"]
     },
     "sableye": {
-        "level": 84,
+        "level": 85,
         "moves": ["foulplay", "nightshade", "recover", "taunt", "willowisp"]
     },
     "mawile": {
-        "level": 90,
+        "level": 91,
         "moves": ["firefang", "ironhead", "stealthrock", "suckerpunch", "swordsdance"]
     },
     "aggron": {
@@ -644,7 +644,7 @@
         "moves": ["bugbuzz", "encore", "roost", "substitute", "thunderwave", "wish"]
     },
     "swalot": {
-        "level": 90,
+        "level": 91,
         "moves": ["earthquake", "encore", "painsplit", "protect", "sludgebomb", "toxic"]
     },
     "sharpedo": {
@@ -660,7 +660,7 @@
         "moves": ["earthquake", "hiddenpowergrass", "lavaplume", "roar", "stealthrock"]
     },
     "torkoal": {
-        "level": 86,
+        "level": 87,
         "moves": ["earthquake", "lavaplume", "protect", "rapidspin", "stealthrock", "toxic", "yawn"]
     },
     "grumpig": {
@@ -668,7 +668,7 @@
         "moves": ["focusblast", "healbell", "psychic", "shadowball", "thunderwave", "trick", "whirlwind"]
     },
     "spinda": {
-        "level": 95,
+        "level": 96,
         "moves": ["return", "suckerpunch", "superpower", "trickroom"]
     },
     "flygon": {
@@ -712,7 +712,7 @@
         "moves": ["earthquake", "icebeam", "psychic", "rapidspin", "stealthrock", "toxic"]
     },
     "cradily": {
-        "level": 86,
+        "level": 87,
         "moves": ["earthquake", "recover", "rockslide", "seedbomb", "stealthrock", "swordsdance", "toxic"]
     },
     "armaldo": {
@@ -724,11 +724,11 @@
         "moves": ["dragontail", "haze", "icebeam", "recover", "scald", "toxic"]
     },
     "castformsunny": {
-        "level": 100,
+        "level": 99,
         "moves": ["icebeam", "solarbeam", "sunnyday", "weatherball"]
     },
     "castformrainy": {
-        "level": 100,
+        "level": 99,
         "moves": ["icebeam", "raindance", "thunder", "weatherball"]
     },
     "kecleon": {
@@ -736,7 +736,7 @@
         "moves": ["foulplay", "recover", "stealthrock", "thunderwave", "toxic"]
     },
     "banette": {
-        "level": 90,
+        "level": 91,
         "moves": ["pursuit", "shadowclaw", "shadowsneak", "trick", "willowisp"]
     },
     "dusclops": {
@@ -768,7 +768,7 @@
         "moves": ["icebeam", "return", "shellsmash", "waterfall"]
     },
     "gorebyss": {
-        "level": 83,
+        "level": 82,
         "moves": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"]
     },
     "relicanth": {
@@ -780,7 +780,7 @@
         "moves": ["icebeam", "protect", "surf", "sweetkiss", "toxic"]
     },
     "salamence": {
-        "level": 80,
+        "level": 79,
         "moves": ["aquatail", "brickbreak", "dracometeor", "dragondance", "earthquake", "fireblast", "outrage", "roost"]
     },
     "metagross": {
@@ -800,11 +800,11 @@
         "moves": ["curse", "ironhead", "protect", "rest", "sleeptalk", "stealthrock", "toxic"]
     },
     "latias": {
-        "level": 75,
+        "level": 73,
         "moves": ["calmmind", "dracometeor", "psyshock", "roost"]
     },
     "latios": {
-        "level": 74,
+        "level": 73,
         "moves": ["calmmind", "dracometeor", "psyshock", "roost"]
     },
     "kyogre": {
@@ -832,7 +832,7 @@
         "moves": ["extremespeed", "hiddenpowerfire", "icebeam", "psychoboost", "stealthrock", "superpower"]
     },
     "deoxysdefense": {
-        "level": 80,
+        "level": 81,
         "moves": ["magiccoat", "recover", "seismictoss", "spikes", "taunt", "toxic"]
     },
     "deoxysspeed": {
@@ -860,7 +860,7 @@
         "moves": ["curse", "quickattack", "rest", "waterfall"]
     },
     "kricketune": {
-        "level": 96,
+        "level": 97,
         "moves": ["brickbreak", "bugbite", "nightslash", "return", "swordsdance"]
     },
     "luxray": {
@@ -880,7 +880,7 @@
         "moves": ["metalburst", "protect", "roar", "rockblast", "stealthrock", "toxic"]
     },
     "wormadam": {
-        "level": 95,
+        "level": 96,
         "moves": ["gigadrain", "hiddenpowerrock", "leafstorm", "protect", "signalbeam", "toxic"]
     },
     "wormadamsandy": {
@@ -896,7 +896,7 @@
         "moves": ["airslash", "bugbuzz", "hiddenpowerground", "quiverdance", "substitute"]
     },
     "vespiquen": {
-        "level": 94,
+        "level": 95,
         "moves": ["attackorder", "protect", "roost", "substitute", "toxic"]
     },
     "pachirisu": {
@@ -936,7 +936,7 @@
         "moves": ["bravebird", "heatwave", "pursuit", "roost", "substitute", "suckerpunch", "superpower"]
     },
     "purugly": {
-        "level": 88,
+        "level": 89,
         "moves": ["fakeout", "hypnosis", "return", "suckerpunch", "uturn"]
     },
     "skuntank": {
@@ -956,7 +956,7 @@
         "moves": ["calmmind", "darkpulse", "foulplay", "rest", "shadowsneak", "sleeptalk", "willowisp"]
     },
     "garchomp": {
-        "level": 77,
+        "level": 76,
         "moves": ["aquatail", "earthquake", "fireblast", "outrage", "stealthrock", "stoneedge", "swordsdance"]
     },
     "lucario": {
@@ -976,11 +976,11 @@
         "moves": ["drainpunch", "icepunch", "poisonjab", "substitute", "suckerpunch", "swordsdance"]
     },
     "carnivine": {
-        "level": 91,
+        "level": 92,
         "moves": ["leechseed", "powerwhip", "return", "sleeppowder", "substitute", "swordsdance"]
     },
     "lumineon": {
-        "level": 90,
+        "level": 89,
         "moves": ["icebeam", "protect", "scald", "toxic", "uturn"]
     },
     "abomasnow": {
@@ -1024,7 +1024,7 @@
         "moves": ["airslash", "bugbuzz", "hiddenpowerground", "protect", "uturn"]
     },
     "leafeon": {
-        "level": 90,
+        "level": 89,
         "moves": ["leafblade", "return", "swordsdance", "xscissor"]
     },
     "glaceon": {
@@ -1072,7 +1072,7 @@
         "moves": ["hiddenpowerice", "hydropump", "painsplit", "thunderbolt", "thunderwave", "trick", "voltswitch", "willowisp"]
     },
     "rotomfrost": {
-        "level": 87,
+        "level": 86,
         "moves": ["blizzard", "hiddenpowerfire", "painsplit", "substitute", "thunderbolt", "trick", "voltswitch", "willowisp"]
     },
     "rotomfan": {
@@ -1108,7 +1108,7 @@
         "moves": ["earthpower", "fireblast", "flashcannon", "hiddenpowerice", "lavaplume", "protect", "roar", "stealthrock", "toxic"]
     },
     "regigigas": {
-        "level": 86,
+        "level": 85,
         "moves": ["confuseray", "return", "rockslide", "substitute", "thunderwave"]
     },
     "giratinaorigin": {
@@ -1248,7 +1248,7 @@
         "moves": ["fireblast", "focusblast", "grassknot", "hiddenpowerrock", "nastyplot", "substitute"]
     },
     "simipour": {
-        "level": 87,
+        "level": 86,
         "moves": ["focusblast", "hiddenpowergrass", "hydropump", "icebeam", "nastyplot", "substitute"]
     },
     "musharna": {
@@ -1256,7 +1256,7 @@
         "moves": ["calmmind", "healbell", "hiddenpowerground", "moonlight", "psychic", "signalbeam", "toxic", "trickroom"]
     },
     "unfezant": {
-        "level": 90,
+        "level": 89,
         "moves": ["hypnosis", "pluck", "return", "roost", "tailwind", "uturn"]
     },
     "zebstrika": {
@@ -1276,7 +1276,7 @@
         "moves": ["earthquake", "ironhead", "rapidspin", "rockslide", "swordsdance"]
     },
     "audino": {
-        "level": 89,
+        "level": 90,
         "moves": ["doubleedge", "healbell", "magiccoat", "protect", "toxic", "wish"]
     },
     "conkeldurr": {
@@ -1292,7 +1292,7 @@
         "moves": ["bulkup", "icepunch", "payback", "rest", "sleeptalk", "stormthrow"]
     },
     "sawk": {
-        "level": 86,
+        "level": 85,
         "moves": ["bulkup", "closecombat", "earthquake", "icepunch", "stoneedge"]
     },
     "leavanny": {
@@ -1328,7 +1328,7 @@
         "moves": ["earthquake", "flareblitz", "rockslide", "superpower", "uturn"]
     },
     "maractus": {
-        "level": 90,
+        "level": 91,
         "moves": ["gigadrain", "hiddenpowerfire", "leechseed", "spikes", "toxic"]
     },
     "crustle": {
@@ -1344,7 +1344,7 @@
         "moves": ["cosmicpower", "psychoshift", "roost", "storedpower"]
     },
     "cofagrigus": {
-        "level": 84,
+        "level": 85,
         "moves": ["haze", "hiddenpowerfighting", "nastyplot", "painsplit", "shadowball", "trickroom", "willowisp"]
     },
     "carracosta": {
@@ -1352,7 +1352,7 @@
         "moves": ["aquajet", "earthquake", "icebeam", "shellsmash", "stealthrock", "stoneedge", "waterfall"]
     },
     "archeops": {
-        "level": 83,
+        "level": 82,
         "moves": ["acrobatics", "earthquake", "headsmash", "pluck", "roost", "stoneedge", "uturn"]
     },
     "garbodor": {
@@ -1411,7 +1411,7 @@
         "moves": ["bugbuzz", "gigadrain", "hiddenpowerice", "thunder", "voltswitch"]
     },
     "ferrothorn": {
-        "level": 79,
+        "level": 78,
         "moves": ["gyroball", "leechseed", "powerwhip", "protect", "spikes", "stealthrock", "toxic"]
     },
     "klinklang": {
@@ -1431,7 +1431,7 @@
         "moves": ["calmmind", "energyball", "fireblast", "hiddenpowerfighting", "shadowball", "substitute"]
     },
     "haxorus": {
-        "level": 79,
+        "level": 78,
         "moves": ["aquatail", "dragondance", "earthquake", "outrage", "superpower", "swordsdance"]
     },
     "beartic": {
@@ -1495,11 +1495,11 @@
         "moves": ["bugbuzz", "fierydance", "fireblast", "gigadrain", "hiddenpowerground", "quiverdance", "roost"]
     },
     "cobalion": {
-        "level": 80,
+        "level": 79,
         "moves": ["closecombat", "hiddenpowerice", "ironhead", "stealthrock", "stoneedge", "swordsdance", "taunt", "thunderwave", "voltswitch"]
     },
     "terrakion": {
-        "level": 79,
+        "level": 78,
         "moves": ["closecombat", "earthquake", "quickattack", "stealthrock", "stoneedge", "swordsdance"]
     },
     "virizion": {
@@ -1507,7 +1507,7 @@
         "moves": ["closecombat", "leafblade", "stoneedge", "swordsdance"]
     },
     "tornadus": {
-        "level": 82,
+        "level": 81,
         "moves": ["acrobatics", "bulkup", "focusblast", "heatwave", "hurricane", "superpower", "taunt", "uturn"]
     },
     "tornadustherian": {

--- a/data/mods/gen6/random-data.json
+++ b/data/mods/gen6/random-data.json
@@ -55,7 +55,7 @@
         "doublesMoves": ["bravebird", "doubleedge", "heatwave", "protect", "return", "tailwind", "uturn"]
     },
     "pidgeotmega": {
-        "level": 81,
+        "level": 80,
         "moves": ["defog", "heatwave", "hurricane", "roost", "uturn"],
         "doublesMoves": ["heatwave", "hurricane", "protect", "tailwind", "uturn"]
     },
@@ -70,7 +70,7 @@
         "doublesMoves": ["doubleedge", "drillpeck", "drillrun", "protect", "quickattack", "return", "uturn"]
     },
     "arbok": {
-        "level": 88,
+        "level": 89,
         "moves": ["aquatail", "coil", "earthquake", "gunkshot", "rest", "suckerpunch"],
         "doublesMoves": ["aquatail", "crunch", "earthquake", "gunkshot", "protect", "rest", "rockslide", "suckerpunch"]
     },
@@ -85,7 +85,7 @@
         "doublesMoves": ["encore", "extremespeed", "fakeout", "focusblast", "grassknot", "hiddenpowerice", "knockoff", "protect", "substitute", "thunderbolt"]
     },
     "sandslash": {
-        "level": 87,
+        "level": 88,
         "moves": ["earthquake", "knockoff", "rapidspin", "stealthrock", "stoneedge", "swordsdance", "toxic"],
         "doublesMoves": ["earthquake", "knockoff", "protect", "rockslide", "stoneedge", "swordsdance", "xscissor"]
     },
@@ -120,7 +120,7 @@
         "doublesMoves": ["dazzlinggleam", "gigadrain", "hiddenpowerfire", "moonblast", "protect", "sleeppowder", "sludgebomb", "stunspore"]
     },
     "parasect": {
-        "level": 91,
+        "level": 92,
         "moves": ["knockoff", "leechseed", "seedbomb", "spore", "substitute", "xscissor"],
         "doublesMoves": ["knockoff", "leechseed", "protect", "ragepowder", "seedbomb", "spore", "stunspore", "wideguard", "xscissor"]
     },
@@ -130,7 +130,7 @@
         "doublesMoves": ["bugbuzz", "gigadrain", "protect", "psychic", "quiverdance", "ragepowder", "roost", "sleeppowder", "sludgebomb", "substitute"]
     },
     "dugtrio": {
-        "level": 84,
+        "level": 85,
         "moves": ["earthquake", "reversal", "stealthrock", "stoneedge", "substitute", "suckerpunch"],
         "doublesMoves": ["earthquake", "protect", "rockslide", "stoneedge", "suckerpunch"]
     },
@@ -140,7 +140,7 @@
         "doublesMoves": ["fakeout", "feint", "hypnosis", "knockoff", "protect", "return", "taunt", "uturn"]
     },
     "golduck": {
-        "level": 88,
+        "level": 87,
         "moves": ["calmmind", "encore", "hydropump", "icebeam", "psyshock", "scald", "substitute"],
         "doublesMoves": ["encore", "focusblast", "hiddenpowergrass", "hydropump", "icebeam", "icywind", "protect", "psychic", "scald", "surf"]
     },
@@ -160,7 +160,7 @@
         "doublesMoves": ["bellydrum", "brickbreak", "earthquake", "encore", "icepunch", "protect", "rockslide", "waterfall"]
     },
     "alakazammega": {
-        "level": 82,
+        "level": 81,
         "moves": ["calmmind", "encore", "focusblast", "psychic", "psyshock", "shadowball", "substitute"],
         "doublesMoves": ["dazzlinggleam", "encore", "focusblast", "protect", "psychic", "psyshock", "shadowball", "substitute"]
     },
@@ -190,7 +190,7 @@
         "doublesMoves": ["earthquake", "firepunch", "hammerarm", "protect", "rockslide", "stoneedge", "suckerpunch"]
     },
     "rapidash": {
-        "level": 88,
+        "level": 87,
         "moves": ["drillrun", "flareblitz", "morningsun", "wildcharge", "willowisp"],
         "doublesMoves": ["drillrun", "flamecharge", "flareblitz", "hypnosis", "megahorn", "protect", "wildcharge", "willowisp"]
     },
@@ -200,12 +200,12 @@
         "doublesMoves": ["fireblast", "grassknot", "icebeam", "protect", "psychic", "psyshock", "scald", "slackoff", "thunderwave", "trickroom"]
     },
     "slowbromega": {
-        "level": 81,
+        "level": 82,
         "moves": ["calmmind", "fireblast", "icebeam", "psyshock", "scald", "slackoff"],
         "doublesMoves": ["fireblast", "grassknot", "icebeam", "protect", "psychic", "psyshock", "scald", "slackoff", "thunderwave", "trickroom"]
     },
     "farfetchd": {
-        "level": 95,
+        "level": 96,
         "moves": ["bravebird", "knockoff", "leafblade", "return", "swordsdance"],
         "doublesMoves": ["bravebird", "leafblade", "nightslash", "protect", "return", "swordsdance"]
     },
@@ -240,7 +240,7 @@
         "doublesMoves": ["dazzlinggleam", "disable", "focusblast", "hypnosis", "protect", "shadowball", "sludgebomb", "substitute", "taunt", "willowisp"]
     },
     "hypno": {
-        "level": 88,
+        "level": 89,
         "moves": ["foulplay", "protect", "psychic", "seismictoss", "thunderwave", "toxic", "wish"],
         "doublesMoves": ["dazzlinggleam", "foulplay", "hypnosis", "protect", "psychic", "seismictoss", "thunderwave", "trickroom", "wish"]
     },
@@ -265,7 +265,7 @@
         "doublesMoves": ["bonemerang", "doubleedge", "earthquake", "firepunch", "protect", "rockslide", "substitute", "swordsdance"]
     },
     "hitmonlee": {
-        "level": 84,
+        "level": 85,
         "moves": ["fakeout", "highjumpkick", "knockoff", "machpunch", "poisonjab", "rapidspin", "stoneedge"],
         "doublesMoves": ["blazekick", "earthquake", "fakeout", "highjumpkick", "knockoff", "machpunch", "protect", "rockslide", "wideguard"]
     },
@@ -284,7 +284,7 @@
         "moves": ["earthquake", "megahorn", "stealthrock", "stoneedge", "toxic"]
     },
     "chansey": {
-        "level": 82,
+        "level": 83,
         "moves": ["healbell", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic", "wish"],
         "doublesMoves": ["aromatherapy", "helpinghand", "lightscreen", "protect", "seismictoss", "softboiled", "thunderwave", "toxic", "wish"]
     },
@@ -344,7 +344,7 @@
         "doublesMoves": ["bounce", "dragondance", "earthquake", "icefang", "protect", "stoneedge", "substitute", "taunt", "thunderwave", "waterfall"]
     },
     "gyaradosmega": {
-        "level": 78,
+        "level": 77,
         "moves": ["crunch", "dragondance", "earthquake", "icefang", "substitute", "waterfall"],
         "doublesMoves": ["bounce", "dragondance", "earthquake", "icefang", "protect", "stoneedge", "substitute", "taunt", "thunderwave", "waterfall"]
     },
@@ -354,11 +354,11 @@
         "doublesMoves": ["healbell", "hydropump", "icebeam", "iceshard", "icywind", "protect", "substitute", "surf", "thunderbolt"]
     },
     "ditto": {
-        "level": 85,
+        "level": 84,
         "moves": ["transform"]
     },
     "vaporeon": {
-        "level": 82,
+        "level": 83,
         "moves": ["healbell", "icebeam", "protect", "scald", "toxic", "wish"],
         "doublesMoves": ["helpinghand", "hydropump", "icebeam", "muddywater", "protect", "scald", "toxic", "wish"]
     },
@@ -451,17 +451,17 @@
         "doublesMoves": ["aquajet", "crunch", "dragondance", "earthquake", "icepunch", "protect", "swordsdance", "waterfall"]
     },
     "furret": {
-        "level": 88,
+        "level": 89,
         "moves": ["aquatail", "doubleedge", "firepunch", "knockoff", "trick", "uturn"],
         "doublesMoves": ["doubleedge", "firepunch", "followme", "helpinghand", "icepunch", "knockoff", "protect", "suckerpunch", "superfang", "uturn"]
     },
     "noctowl": {
-        "level": 90,
+        "level": 91,
         "moves": ["airslash", "defog", "nightshade", "roost", "toxic", "whirlwind"],
         "doublesMoves": ["airslash", "heatwave", "hypervoice", "hypnosis", "protect", "roost", "tailwind"]
     },
     "ledian": {
-        "level": 94,
+        "level": 95,
         "moves": ["knockoff", "lightscreen", "reflect", "roost", "toxic", "uturn"],
         "doublesMoves": ["bugbuzz", "encore", "knockoff", "lightscreen", "protect", "reflect", "tailwind", "uturn"]
     },
@@ -521,7 +521,7 @@
         "doublesMoves": ["encore", "gigadrain", "helpinghand", "leechseed", "protect", "ragepowder", "sleeppowder", "uturn"]
     },
     "sunflora": {
-        "level": 92,
+        "level": 93,
         "moves": ["earthpower", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "sludgebomb"],
         "doublesMoves": ["earthpower", "encore", "gigadrain", "hiddenpowerfire", "hiddenpowerice", "protect", "solarbeam", "sunnyday"]
     },
@@ -541,7 +541,7 @@
         "doublesMoves": ["foulplay", "healbell", "helpinghand", "moonlight", "protect", "snarl", "wish"]
     },
     "slowking": {
-        "level": 84,
+        "level": 85,
         "moves": ["dragontail", "fireblast", "icebeam", "nastyplot", "psychic", "psyshock", "scald", "slackoff", "thunderwave", "toxic", "trickroom"],
         "doublesMoves": ["fireblast", "grassknot", "icebeam", "protect", "psychic", "psyshock", "scald", "slackoff", "thunderwave", "trickroom"]
     },
@@ -559,7 +559,7 @@
         "doublesMoves": ["agility", "hypervoice", "nastyplot", "protect", "psychic", "psyshock", "thunderbolt"]
     },
     "forretress": {
-        "level": 82,
+        "level": 83,
         "moves": ["gyroball", "rapidspin", "spikes", "stealthrock", "toxic", "voltswitch"],
         "doublesMoves": ["drillrun", "gyroball", "protect", "rockslide", "stealthrock", "toxic", "voltswitch"]
     },
@@ -583,7 +583,7 @@
         "doublesMoves": ["earthquake", "explosion", "heavyslam", "protect", "rockslide", "stealthrock"]
     },
     "granbull": {
-        "level": 85,
+        "level": 86,
         "moves": ["crunch", "earthquake", "healbell", "playrough", "thunderwave"],
         "doublesMoves": ["crunch", "earthquake", "playrough", "protect", "rockslide", "snarl", "thunderwave"]
     },
@@ -608,7 +608,7 @@
         "doublesMoves": ["encore", "guardsplit", "helpinghand", "knockoff", "powersplit", "stealthrock", "stickyweb", "toxic"]
     },
     "heracross": {
-        "level": 82,
+        "level": 81,
         "moves": ["closecombat", "earthquake", "knockoff", "megahorn", "stoneedge", "swordsdance"],
         "doublesMoves": ["closecombat", "earthquake", "knockoff", "megahorn", "protect", "stoneedge", "swordsdance"]
     },
@@ -623,17 +623,17 @@
         "doublesMoves": ["closecombat", "crunch", "earthquake", "facade", "protect", "swordsdance"]
     },
     "magcargo": {
-        "level": 89,
+        "level": 90,
         "moves": ["ancientpower", "earthpower", "fireblast", "hiddenpowergrass", "lavaplume", "recover", "shellsmash", "stealthrock", "toxic"],
         "doublesMoves": ["ancientpower", "earthpower", "fireblast", "heatwave", "hiddenpowergrass", "protect", "shellsmash", "stealthrock", "willowisp"]
     },
     "corsola": {
-        "level": 91,
+        "level": 92,
         "moves": ["powergem", "recover", "scald", "stealthrock", "toxic"],
         "doublesMoves": ["earthpower", "icebeam", "icywind", "powergem", "protect", "scald", "stealthrock"]
     },
     "octillery": {
-        "level": 88,
+        "level": 89,
         "moves": ["energyball", "fireblast", "gunkshot", "hydropump", "icebeam", "rockblast", "scald"],
         "doublesMoves": ["chargebeam", "energyball", "fireblast", "hydropump", "icebeam", "protect", "surf"]
     },
@@ -643,7 +643,7 @@
         "doublesMoves": ["aerialace", "brickbreak", "fakeout", "icepunch", "iceshard", "protect"]
     },
     "mantine": {
-        "level": 88,
+        "level": 89,
         "moves": ["airslash", "defog", "rest", "scald", "sleeptalk", "toxic"],
         "doublesMoves": ["airslash", "helpinghand", "hydropump", "icebeam", "protect", "raindance", "scald", "surf", "tailwind", "wideguard"]
     },
@@ -688,7 +688,7 @@
         "doublesMoves": ["fakeout", "followme", "helpinghand", "kingsshield", "spore", "tailwind", "transform", "wideguard"]
     },
     "hitmontop": {
-        "level": 85,
+        "level": 86,
         "moves": ["closecombat", "rapidspin", "stoneedge", "suckerpunch", "toxic"],
         "doublesMoves": ["closecombat", "fakeout", "feint", "helpinghand", "machpunch", "suckerpunch", "wideguard"]
     },
@@ -708,7 +708,7 @@
         "doublesMoves": ["calmmind", "extrasensory", "hiddenpowerice", "protect", "snarl", "substitute", "thunderbolt"]
     },
     "entei": {
-        "level": 80,
+        "level": 79,
         "moves": ["bulldoze", "extremespeed", "flareblitz", "sacredfire", "stoneedge"],
         "doublesMoves": ["bulldoze", "extremespeed", "flareblitz", "ironhead", "protect", "sacredfire", "stoneedge"]
     },
@@ -781,12 +781,12 @@
         "doublesMoves": ["bellydrum", "extremespeed", "protect", "seedbomb", "shadowclaw"]
     },
     "beautifly": {
-        "level": 91,
+        "level": 92,
         "moves": ["bugbuzz", "energyball", "hiddenpowerfighting", "psychic", "quiverdance"],
         "doublesMoves": ["aircutter", "bugbuzz", "gigadrain", "hiddenpowerrock", "protect", "quiverdance", "stringshot", "tailwind"]
     },
     "dustox": {
-        "level": 88,
+        "level": 89,
         "moves": ["bugbuzz", "defog", "quiverdance", "roost", "sludgebomb", "uturn"],
         "doublesMoves": ["bugbuzz", "protect", "quiverdance", "shadowball", "sludgebomb", "stringshot", "strugglebug", "tailwind"]
     },
@@ -801,12 +801,12 @@
         "doublesMoves": ["fakeout", "knockoff", "leafblade", "leafstorm", "lowkick", "protect", "suckerpunch", "swordsdance"]
     },
     "swellow": {
-        "level": 85,
+        "level": 84,
         "moves": ["bravebird", "facade", "protect", "quickattack", "uturn"],
         "doublesMoves": ["bravebird", "facade", "protect", "quickattack", "uturn"]
     },
     "pelipper": {
-        "level": 89,
+        "level": 91,
         "moves": ["defog", "hurricane", "knockoff", "roost", "scald", "toxic", "uturn"],
         "doublesMoves": ["hurricane", "knockoff", "protect", "scald", "surf", "tailwind", "wideguard"]
     },
@@ -831,7 +831,7 @@
         "doublesMoves": ["bulletseed", "drainpunch", "helpinghand", "machpunch", "protect", "rocktomb", "spore"]
     },
     "slaking": {
-        "level": 84,
+        "level": 83,
         "moves": ["earthquake", "firepunch", "gigaimpact", "nightslash", "pursuit", "retaliate"],
         "doublesMoves": ["doubleedge", "earthquake", "hammerarm", "nightslash", "retaliate", "rockslide"]
     },
@@ -855,7 +855,7 @@
         "doublesMoves": ["bulletpunch", "closecombat", "fakeout", "helpinghand", "icepunch", "knockoff", "protect", "stoneedge", "wideguard"]
     },
     "delcatty": {
-        "level": 90,
+        "level": 91,
         "moves": ["doubleedge", "fakeout", "healbell", "suckerpunch", "thunderwave", "wildcharge"],
         "doublesMoves": ["doubleedge", "fakeout", "helpinghand", "playrough", "protect", "suckerpunch", "thunderwave", "wildcharge"]
     },
@@ -895,7 +895,7 @@
         "doublesMoves": ["bulletpunch", "drainpunch", "fakeout", "highjumpkick", "icepunch", "protect", "zenheadbutt"]
     },
     "medichammega": {
-        "level": 80,
+        "level": 79,
         "moves": ["fakeout", "highjumpkick", "icepunch", "thunderpunch", "zenheadbutt"],
         "doublesMoves": ["bulletpunch", "drainpunch", "fakeout", "highjumpkick", "icepunch", "protect", "zenheadbutt"]
     },
@@ -910,12 +910,12 @@
         "doublesMoves": ["flamethrower", "hiddenpowergrass", "hiddenpowerice", "overheat", "protect", "snarl", "thunderbolt", "voltswitch"]
     },
     "plusle": {
-        "level": 88,
+        "level": 89,
         "moves": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
         "doublesMoves": ["encore", "helpinghand", "hiddenpowerice", "nastyplot", "protect", "substitute", "thunderbolt"]
     },
     "minun": {
-        "level": 88,
+        "level": 89,
         "moves": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
         "doublesMoves": ["encore", "helpinghand", "hiddenpowerice", "nastyplot", "protect", "substitute", "thunderbolt"]
     },
@@ -925,7 +925,7 @@
         "doublesMoves": ["encore", "helpinghand", "protect", "stringshot", "strugglebug", "tailwind", "thunderwave"]
     },
     "illumise": {
-        "level": 89,
+        "level": 90,
         "moves": ["bugbuzz", "encore", "roost", "thunderwave", "uturn", "wish"],
         "doublesMoves": ["bugbuzz", "encore", "helpinghand", "protect", "tailwind", "thunderbolt", "uturn"]
     },
@@ -954,7 +954,7 @@
         "doublesMoves": ["earthpower", "eruption", "fireblast", "heatwave", "hiddenpowergrass", "protect", "rockpolish"]
     },
     "cameruptmega": {
-        "level": 84,
+        "level": 85,
         "moves": ["ancientpower", "earthpower", "fireblast", "stealthrock", "toxic", "willowisp"],
         "doublesMoves": ["earthpower", "eruption", "fireblast", "heatwave", "protect", "rockslide"]
     },
@@ -964,12 +964,12 @@
         "doublesMoves": ["earthpower", "fireblast", "heatwave", "hiddenpowergrass", "protect", "shellsmash", "willowisp"]
     },
     "grumpig": {
-        "level": 89,
+        "level": 90,
         "moves": ["focusblast", "healbell", "lightscreen", "psychic", "reflect", "thunderwave", "toxic", "whirlwind"],
         "doublesMoves": ["focusblast", "lightscreen", "protect", "psychic", "psyshock", "reflect", "taunt", "thunderwave", "trickroom"]
     },
     "spinda": {
-        "level": 99,
+        "level": 98,
         "moves": ["icepunch", "rest", "return", "sleeptalk", "suckerpunch", "superpower"],
         "doublesMoves": ["doubleedge", "fakeout", "protect", "return", "suckerpunch", "superpower", "trickroom"]
     },
@@ -999,12 +999,12 @@
         "doublesMoves": ["closecombat", "facade", "knockoff", "protect", "quickattack"]
     },
     "seviper": {
-        "level": 88,
+        "level": 89,
         "moves": ["darkpulse", "earthquake", "flamethrower", "gigadrain", "poisonjab", "sludgewave", "suckerpunch", "switcheroo"],
         "doublesMoves": ["aquatail", "earthquake", "flamethrower", "gigadrain", "glare", "poisonjab", "protect", "sludgebomb", "suckerpunch"]
     },
     "lunatone": {
-        "level": 89,
+        "level": 90,
         "moves": ["ancientpower", "calmmind", "earthpower", "icebeam", "moonlight", "psychic", "rockpolish", "stealthrock", "toxic"],
         "doublesMoves": ["ancientpower", "calmmind", "earthpower", "helpinghand", "icebeam", "moonlight", "protect", "psychic", "rockpolish", "trickroom"]
     },
@@ -1066,7 +1066,7 @@
         "doublesMoves": ["knockoff", "protect", "shadowclaw", "shadowsneak", "suckerpunch", "willowisp"]
     },
     "banettemega": {
-        "level": 85,
+        "level": 86,
         "moves": ["destinybond", "knockoff", "shadowclaw", "suckerpunch", "taunt", "willowisp"],
         "doublesMoves": ["destinybond", "knockoff", "protect", "shadowclaw", "suckerpunch", "taunt", "willowisp"]
     },
@@ -1096,7 +1096,7 @@
         "doublesMoves": ["earthquake", "icebeam", "iceshard", "protect", "taunt"]
     },
     "glaliemega": {
-        "level": 84,
+        "level": 83,
         "moves": ["earthquake", "explosion", "freezedry", "iceshard", "return", "spikes"],
         "doublesMoves": ["crunch", "earthquake", "explosion", "freezedry", "iceshard", "protect", "return"]
     },
@@ -1111,7 +1111,7 @@
         "doublesMoves": ["icefang", "protect", "shellsmash", "suckerpunch", "waterfall"]
     },
     "gorebyss": {
-        "level": 86,
+        "level": 85,
         "moves": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"],
         "doublesMoves": ["hiddenpowergrass", "icebeam", "protect", "shellsmash", "substitute", "surf"]
     },
@@ -1125,7 +1125,7 @@
         "moves": ["icebeam", "protect", "scald", "sweetkiss", "toxic"]
     },
     "salamence": {
-        "level": 80,
+        "level": 79,
         "moves": ["dracometeor", "dragonclaw", "dragondance", "earthquake", "fireblast", "outrage", "roost"],
         "doublesMoves": ["dracometeor", "dragonclaw", "dragondance", "earthquake", "fireblast", "hydropump", "protect", "rockslide", "tailwind"]
     },
@@ -1140,7 +1140,7 @@
         "doublesMoves": ["bulletpunch", "earthquake", "explosion", "hammerarm", "icepunch", "meteormash", "protect", "thunderpunch", "zenheadbutt"]
     },
     "metagrossmega": {
-        "level": 78,
+        "level": 77,
         "moves": ["agility", "earthquake", "hammerarm", "icepunch", "meteormash", "zenheadbutt"],
         "doublesMoves": ["earthquake", "icepunch", "meteormash", "protect", "thunderpunch", "zenheadbutt"]
     },
@@ -1160,7 +1160,7 @@
         "doublesMoves": ["curse", "ironhead", "protect", "rest", "seismictoss", "stealthrock", "thunderwave"]
     },
     "latiasmega": {
-        "level": 80,
+        "level": 79,
         "moves": ["calmmind", "dracometeor", "hiddenpowerfire", "psyshock", "roost", "surf"],
         "doublesMoves": ["dragonpulse", "healpulse", "helpinghand", "lightscreen", "protect", "psychic", "reflect", "tailwind"]
     },
@@ -1170,7 +1170,7 @@
         "doublesMoves": ["dragonpulse", "healpulse", "helpinghand", "lightscreen", "protect", "psychic", "reflect", "tailwind"]
     },
     "latiosmega": {
-        "level": 80,
+        "level": 79,
         "moves": ["calmmind", "dracometeor", "earthquake", "hiddenpowerfire", "psyshock", "roost"],
         "doublesMoves": ["dracometeor", "dragonpulse", "hiddenpowerfire", "protect", "psyshock", "substitute", "surf", "tailwind", "thunderbolt"]
     },
@@ -1180,7 +1180,7 @@
         "doublesMoves": ["dracometeor", "dragonpulse", "hiddenpowerfire", "protect", "psyshock", "substitute", "surf", "tailwind", "thunderbolt", "trick"]
     },
     "kyogre": {
-        "level": 71,
+        "level": 70,
         "moves": ["icebeam", "originpulse", "scald", "thunder", "waterspout"],
         "doublesMoves": ["calmmind", "icebeam", "muddywater", "originpulse", "protect", "rest", "sleeptalk", "thunder", "waterspout"]
     },
@@ -1225,12 +1225,12 @@
         "doublesMoves": ["extremespeed", "firepunch", "icebeam", "knockoff", "protect", "psychoboost", "superpower", "thunderbolt"]
     },
     "deoxysdefense": {
-        "level": 79,
+        "level": 81,
         "moves": ["knockoff", "recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"],
         "doublesMoves": ["lightscreen", "protect", "recover", "reflect", "seismictoss", "stealthrock", "taunt", "trickroom"]
     },
     "deoxysspeed": {
-        "level": 79,
+        "level": 80,
         "moves": ["knockoff", "magiccoat", "psychoboost", "spikes", "stealthrock", "superpower", "taunt"],
         "doublesMoves": ["icebeam", "knockoff", "lightscreen", "protect", "psychoboost", "reflect", "superpower", "taunt"]
     },
@@ -1240,7 +1240,7 @@
         "doublesMoves": ["earthquake", "protect", "rockpolish", "rockslide", "stoneedge", "wideguard", "woodhammer"]
     },
     "infernape": {
-        "level": 82,
+        "level": 81,
         "moves": ["closecombat", "fireblast", "flareblitz", "grassknot", "machpunch", "stealthrock", "stoneedge", "uturn"],
         "doublesMoves": ["closecombat", "fakeout", "feint", "flareblitz", "grassknot", "heatwave", "machpunch", "protect", "stoneedge", "taunt", "thunderpunch", "uturn"]
     },
@@ -1260,7 +1260,7 @@
         "doublesMoves": ["curse", "protect", "quickattack", "rest", "return", "waterfall"]
     },
     "kricketune": {
-        "level": 89,
+        "level": 90,
         "moves": ["endeavor", "knockoff", "stickyweb", "taunt", "toxic", "xscissor"],
         "doublesMoves": ["bugbite", "knockoff", "protect", "stickyweb", "taunt"]
     },
@@ -1285,7 +1285,7 @@
         "doublesMoves": ["guardsplit", "metalburst", "protect", "stealthrock", "stoneedge", "wideguard"]
     },
     "wormadam": {
-        "level": 95,
+        "level": 96,
         "moves": ["gigadrain", "hiddenpowerground", "hiddenpowerrock", "protect", "signalbeam", "synthesis", "toxic"],
         "doublesMoves": ["gigadrain", "hiddenpowerice", "hiddenpowerrock", "leafstorm", "protect", "signalbeam", "stringshot"]
     },
@@ -1320,7 +1320,7 @@
         "doublesMoves": ["aquajet", "crunch", "icepunch", "protect", "raindance", "switcheroo", "taunt", "waterfall"]
     },
     "cherrim": {
-        "level": 89,
+        "level": 90,
         "moves": ["dazzlinggleam", "energyball", "healingwish", "hiddenpowerfire", "hiddenpowerice", "synthesis"],
         "doublesMoves": ["gigadrain", "protect", "solarbeam", "sunnyday", "weatherball"]
     },
@@ -1338,7 +1338,7 @@
         "doublesMoves": ["doublehit", "fakeout", "icepunch", "knockoff", "lowkick", "protect", "return", "uturn"]
     },
     "drifblim": {
-        "level": 88,
+        "level": 87,
         "moves": ["acrobatics", "destinybond", "hex", "shadowball", "substitute", "willowisp"],
         "doublesMoves": ["destinybond", "hiddenpowerfighting", "hypnosis", "protect", "shadowball", "substitute", "thunderbolt", "willowisp"]
     },
@@ -1348,12 +1348,12 @@
         "doublesMoves": ["encore", "fakeout", "firepunch", "highjumpkick", "icepunch", "protect", "return", "switcheroo"]
     },
     "lopunnymega": {
-        "level": 80,
+        "level": 79,
         "moves": ["fakeout", "highjumpkick", "icepunch", "return", "substitute"],
         "doublesMoves": ["encore", "fakeout", "highjumpkick", "icepunch", "protect", "return"]
     },
     "mismagius": {
-        "level": 86,
+        "level": 85,
         "moves": ["dazzlinggleam", "destinybond", "nastyplot", "painsplit", "shadowball", "substitute", "taunt", "thunderbolt", "willowisp"],
         "doublesMoves": ["dazzlinggleam", "nastyplot", "protect", "shadowball", "substitute", "taunt", "thunderbolt", "willowisp"]
     },
@@ -1388,12 +1388,12 @@
         "doublesMoves": ["darkpulse", "foulplay", "icywind", "painsplit", "protect", "shadowsneak", "snarl", "willowisp"]
     },
     "garchomp": {
-        "level": 78,
+        "level": 77,
         "moves": ["dragonclaw", "earthquake", "fireblast", "firefang", "outrage", "stealthrock", "stoneedge", "swordsdance"],
         "doublesMoves": ["dragonclaw", "earthquake", "protect", "rockslide", "stoneedge", "substitute", "swordsdance"]
     },
     "garchompmega": {
-        "level": 80,
+        "level": 79,
         "moves": ["dracometeor", "earthquake", "fireblast", "outrage", "stoneedge", "swordsdance"],
         "doublesMoves": ["dragonclaw", "earthquake", "fireblast", "protect", "rockslide", "stoneedge", "substitute", "swordsdance"]
     },
@@ -1403,12 +1403,12 @@
         "doublesMoves": ["aurasphere", "bulletpunch", "closecombat", "crunch", "darkpulse", "extremespeed", "flashcannon", "followme", "icepunch", "protect", "vacuumwave"]
     },
     "lucariomega": {
-        "level": 77,
+        "level": 78,
         "moves": ["aurasphere", "bulletpunch", "closecombat", "crunch", "darkpulse", "flashcannon", "icepunch", "nastyplot", "swordsdance"],
         "doublesMoves": ["aurasphere", "bulletpunch", "closecombat", "crunch", "darkpulse", "extremespeed", "flashcannon", "followme", "icepunch", "protect", "vacuumwave"]
     },
     "hippowdon": {
-        "level": 80,
+        "level": 81,
         "moves": ["earthquake", "slackoff", "stealthrock", "stoneedge", "toxic", "whirlwind"],
         "doublesMoves": ["earthquake", "protect", "rockslide", "slackoff", "stealthrock", "stoneedge"]
     },
@@ -1448,7 +1448,7 @@
         "doublesMoves": ["fakeout", "feint", "iceshard", "iciclecrash", "knockoff", "lowkick", "protect", "swordsdance", "taunt"]
     },
     "magnezone": {
-        "level": 82,
+        "level": 83,
         "moves": ["flashcannon", "hiddenpowerfire", "substitute", "thunderbolt", "voltswitch"],
         "doublesMoves": ["discharge", "electroweb", "flashcannon", "hiddenpowerfire", "hiddenpowerice", "protect", "substitute", "thunderbolt", "voltswitch"]
     },
@@ -1483,7 +1483,7 @@
         "doublesMoves": ["airslash", "dazzlinggleam", "followme", "nastyplot", "protect", "roost", "tailwind", "thunderwave"]
     },
     "yanmega": {
-        "level": 83,
+        "level": 82,
         "moves": ["airslash", "bugbuzz", "gigadrain", "protect", "uturn"]
     },
     "leafeon": {
@@ -1502,7 +1502,7 @@
         "doublesMoves": ["earthquake", "knockoff", "protect", "stoneedge", "substitute", "tailwind", "taunt"]
     },
     "mamoswine": {
-        "level": 79,
+        "level": 78,
         "moves": ["earthquake", "iceshard", "iciclecrash", "knockoff", "stealthrock", "superpower"],
         "doublesMoves": ["earthquake", "iceshard", "iciclecrash", "knockoff", "protect", "rockslide", "superpower"]
     },
@@ -1522,7 +1522,7 @@
         "doublesMoves": ["closecombat", "drainpunch", "icepunch", "knockoff", "protect", "stoneedge", "swordsdance", "zenheadbutt"]
     },
     "probopass": {
-        "level": 88,
+        "level": 89,
         "moves": ["earthpower", "flashcannon", "stealthrock", "thunderwave", "toxic", "voltswitch"],
         "doublesMoves": ["earthpower", "helpinghand", "powergem", "protect", "stealthrock", "thunderwave", "voltswitch", "wideguard"]
     },
@@ -1557,7 +1557,7 @@
         "doublesMoves": ["blizzard", "electroweb", "painsplit", "protect", "substitute", "thunderbolt", "trick", "voltswitch", "willowisp"]
     },
     "rotomfan": {
-        "level": 87,
+        "level": 86,
         "moves": ["airslash", "painsplit", "thunderbolt", "voltswitch", "willowisp"],
         "doublesMoves": ["airslash", "discharge", "electroweb", "hiddenpowerice", "painsplit", "protect", "substitute", "thunderbolt", "voltswitch", "willowisp"]
     },
@@ -1567,7 +1567,7 @@
         "doublesMoves": ["electroweb", "hiddenpowerfire", "leafstorm", "painsplit", "protect", "substitute", "thunderbolt", "trick", "voltswitch", "willowisp"]
     },
     "uxie": {
-        "level": 83,
+        "level": 82,
         "moves": ["healbell", "knockoff", "psychic", "stealthrock", "thunderwave", "uturn", "yawn"],
         "doublesMoves": ["healbell", "helpinghand", "protect", "psyshock", "skillswap", "stealthrock", "thunderbolt", "thunderwave", "uturn", "yawn"]
     },
@@ -1582,7 +1582,7 @@
         "doublesMoves": ["dazzlinggleam", "fireblast", "icepunch", "knockoff", "nastyplot", "protect", "psychic", "taunt", "thunderbolt", "uturn", "zenheadbutt"]
     },
     "dialga": {
-        "level": 76,
+        "level": 75,
         "moves": ["dracometeor", "fireblast", "flashcannon", "roar", "stealthrock", "thunderbolt", "toxic"],
         "doublesMoves": ["aurasphere", "dracometeor", "dragonpulse", "earthpower", "fireblast", "flashcannon", "protect", "thunderbolt"]
     },
@@ -1597,7 +1597,7 @@
         "doublesMoves": ["earthpower", "eruption", "heatwave", "protect", "substitute", "willowisp"]
     },
     "regigigas": {
-        "level": 84,
+        "level": 83,
         "moves": ["confuseray", "drainpunch", "knockoff", "return", "substitute", "thunderwave"],
         "doublesMoves": ["earthquake", "icywind", "knockoff", "return", "rockslide", "substitute", "thunderwave", "wideguard"]
     },
@@ -1627,7 +1627,7 @@
         "doublesMoves": ["energyball", "helpinghand", "icebeam", "icywind", "protect", "scald", "surf", "tailglow"]
     },
     "darkrai": {
-        "level": 74,
+        "level": 73,
         "moves": ["darkpulse", "darkvoid", "focusblast", "nastyplot", "sludgebomb", "substitute"],
         "doublesMoves": ["darkpulse", "focusblast", "nastyplot", "protect", "snarl", "substitute"]
     },
@@ -1642,97 +1642,97 @@
         "doublesMoves": ["airslash", "earthpower", "hiddenpowerice", "leechseed", "protect", "rest", "seedflare", "substitute", "tailwind"]
     },
     "arceus": {
-        "level": 73,
+        "level": 72,
         "moves": ["earthquake", "extremespeed", "recover", "shadowclaw", "swordsdance"],
         "doublesMoves": ["earthquake", "extremespeed", "protect", "recover", "shadowclaw", "swordsdance"]
     },
     "arceusbug": {
-        "level": 73,
+        "level": 72,
         "moves": ["calmmind", "earthpower", "fireblast", "judgment", "recover"],
         "doublesMoves": ["earthquake", "ironhead", "protect", "recover", "stoneedge", "swordsdance", "xscissor"]
     },
     "arceusdark": {
-        "level": 73,
+        "level": 72,
         "moves": ["calmmind", "fireblast", "judgment", "recover", "toxic"],
         "doublesMoves": ["calmmind", "focusblast", "judgment", "protect", "recover", "safeguard", "snarl", "willowisp"]
     },
     "arceusdragon": {
-        "level": 73,
+        "level": 72,
         "moves": ["defog", "earthquake", "extremespeed", "fireblast", "judgment", "outrage", "recover", "swordsdance", "willowisp"],
         "doublesMoves": ["dragonclaw", "earthquake", "extremespeed", "protect", "recover", "swordsdance"]
     },
     "arceuselectric": {
-        "level": 73,
+        "level": 72,
         "moves": ["calmmind", "earthpower", "icebeam", "judgment", "recover"],
         "doublesMoves": ["calmmind", "icebeam", "judgment", "protect", "recover"]
     },
     "arceusfairy": {
-        "level": 73,
+        "level": 72,
         "moves": ["calmmind", "defog", "earthpower", "judgment", "recover", "toxic", "willowisp"],
         "doublesMoves": ["calmmind", "earthpower", "judgment", "protect", "recover", "thunderbolt", "willowisp"]
     },
     "arceusfighting": {
-        "level": 73,
+        "level": 72,
         "moves": ["calmmind", "icebeam", "judgment", "recover", "shadowball", "stoneedge"],
         "doublesMoves": ["calmmind", "icebeam", "judgment", "protect", "recover", "shadowball", "willowisp"]
     },
     "arceusfire": {
-        "level": 73,
+        "level": 72,
         "moves": ["calmmind", "fireblast", "icebeam", "recover", "thunderbolt"],
         "doublesMoves": ["calmmind", "heatwave", "judgment", "protect", "recover", "thunderbolt", "willowisp"]
     },
     "arceusflying": {
-        "level": 73,
+        "level": 72,
         "moves": ["calmmind", "earthpower", "fireblast", "judgment", "recover", "toxic"],
         "doublesMoves": ["calmmind", "judgment", "protect", "recover", "safeguard", "substitute", "tailwind"]
     },
     "arceusghost": {
-        "level": 73,
+        "level": 72,
         "moves": ["brickbreak", "defog", "extremespeed", "judgment", "recover", "shadowclaw", "shadowforce", "swordsdance", "toxic"],
         "doublesMoves": ["brickbreak", "calmmind", "focusblast", "judgment", "protect", "recover", "shadowforce", "swordsdance", "willowisp"]
     },
     "arceusgrass": {
-        "level": 73,
+        "level": 72,
         "moves": ["calmmind", "fireblast", "icebeam", "judgment", "recover"],
         "doublesMoves": ["calmmind", "earthpower", "icebeam", "judgment", "protect", "recover", "safeguard", "thunderwave"]
     },
     "arceusground": {
-        "level": 73,
+        "level": 72,
         "moves": ["earthquake", "icebeam", "recover", "stealthrock", "stoneedge", "swordsdance", "toxic"],
         "doublesMoves": ["calmmind", "earthquake", "icebeam", "judgment", "protect", "recover", "rockslide", "stoneedge", "swordsdance"]
     },
     "arceusice": {
-        "level": 73,
+        "level": 72,
         "moves": ["calmmind", "fireblast", "judgment", "recover", "thunderbolt"],
         "doublesMoves": ["calmmind", "focusblast", "icywind", "judgment", "protect", "recover", "thunderbolt"]
     },
     "arceuspoison": {
-        "level": 73,
+        "level": 72,
         "moves": ["calmmind", "defog", "fireblast", "icebeam", "recover", "sludgebomb"],
         "doublesMoves": ["calmmind", "earthpower", "heatwave", "judgment", "protect", "recover", "sludgebomb", "willowisp"]
     },
     "arceuspsychic": {
-        "level": 73,
+        "level": 72,
         "moves": ["calmmind", "fireblast", "icebeam", "judgment", "recover", "toxic"],
         "doublesMoves": ["calmmind", "focusblast", "judgment", "protect", "psyshock", "recover", "willowisp"]
     },
     "arceusrock": {
-        "level": 73,
+        "level": 72,
         "moves": ["earthquake", "judgment", "recover", "stealthrock", "stoneedge", "swordsdance", "willowisp"],
         "doublesMoves": ["earthquake", "protect", "recover", "rockslide", "stoneedge", "swordsdance"]
     },
     "arceussteel": {
-        "level": 73,
+        "level": 72,
         "moves": ["defog", "earthquake", "ironhead", "judgment", "recover", "roar", "stoneedge", "swordsdance", "willowisp"],
         "doublesMoves": ["calmmind", "judgment", "protect", "recover", "willowisp"]
     },
     "arceuswater": {
-        "level": 73,
+        "level": 72,
         "moves": ["calmmind", "defog", "icebeam", "judgment", "recover", "toxic"],
         "doublesMoves": ["calmmind", "fireblast", "icebeam", "icywind", "judgment", "protect", "recover", "surf"]
     },
     "victini": {
-        "level": 81,
+        "level": 80,
         "moves": ["blueflare", "boltstrike", "energyball", "glaciate", "uturn", "vcreate", "zenheadbutt"],
         "doublesMoves": ["blueflare", "boltstrike", "focusblast", "protect", "psychic", "uturn", "vcreate"]
     },
@@ -1777,7 +1777,7 @@
         "doublesMoves": ["fireblast", "focusblast", "grassknot", "heatwave", "hiddenpowerground", "nastyplot", "protect", "substitute", "taunt"]
     },
     "simipour": {
-        "level": 88,
+        "level": 87,
         "moves": ["focusblast", "hydropump", "icebeam", "nastyplot", "substitute"],
         "doublesMoves": ["helpinghand", "hydropump", "icebeam", "nastyplot", "protect", "substitute", "surf", "taunt"]
     },
@@ -1802,7 +1802,7 @@
         "doublesMoves": ["autotomize", "earthquake", "explosion", "protect", "rockslide", "stealthrock", "stoneedge", "superpower", "wideguard"]
     },
     "swoobat": {
-        "level": 88,
+        "level": 87,
         "moves": ["airslash", "calmmind", "heatwave", "roost", "storedpower"],
         "doublesMoves": ["airslash", "calmmind", "gigadrain", "heatwave", "protect", "psychic", "tailwind"]
     },
@@ -1852,7 +1852,7 @@
         "doublesMoves": ["aquatail", "megahorn", "poisonjab", "protect", "rockslide", "substitute", "superpower", "swordsdance"]
     },
     "whimsicott": {
-        "level": 83,
+        "level": 84,
         "moves": ["encore", "energyball", "leechseed", "memento", "moonblast", "stunspore", "tailwind", "taunt", "toxic", "uturn"],
         "doublesMoves": ["dazzlinggleam", "encore", "gigadrain", "helpinghand", "leechseed", "moonblast", "protect", "stunspore", "substitute", "tailwind", "taunt", "uturn"]
     },
@@ -1862,17 +1862,17 @@
         "doublesMoves": ["gigadrain", "helpinghand", "hiddenpowerfire", "hiddenpowerice", "hiddenpowerrock", "petaldance", "protect", "quiverdance", "sleeppowder"]
     },
     "basculin": {
-        "level": 88,
+        "level": 87,
         "moves": ["aquajet", "crunch", "superpower", "waterfall", "zenheadbutt"],
         "doublesMoves": ["aquajet", "crunch", "doubleedge", "protect", "superpower", "waterfall"]
     },
     "basculinbluestriped": {
-        "level": 88,
+        "level": 87,
         "moves": ["aquajet", "crunch", "superpower", "waterfall", "zenheadbutt"],
         "doublesMoves": ["aquajet", "crunch", "doubleedge", "protect", "superpower", "waterfall"]
     },
     "krookodile": {
-        "level": 82,
+        "level": 81,
         "moves": ["earthquake", "knockoff", "pursuit", "stealthrock", "stoneedge", "superpower"],
         "doublesMoves": ["earthquake", "knockoff", "protect", "stoneedge", "superpower"]
     },
@@ -1882,12 +1882,12 @@
         "doublesMoves": ["earthquake", "firepunch", "flareblitz", "protect", "rockslide", "superpower", "uturn"]
     },
     "maractus": {
-        "level": 89,
+        "level": 90,
         "moves": ["gigadrain", "hiddenpowerfire", "leechseed", "spikes", "spikyshield", "suckerpunch", "toxic"],
         "doublesMoves": ["gigadrain", "grassyterrain", "helpinghand", "hiddenpowerfire", "leechseed", "spikyshield", "suckerpunch"]
     },
     "crustle": {
-        "level": 86,
+        "level": 85,
         "moves": ["earthquake", "shellsmash", "spikes", "stealthrock", "stoneedge", "xscissor"],
         "doublesMoves": ["earthquake", "protect", "rockslide", "shellsmash", "stoneedge", "xscissor"]
     },
@@ -1902,7 +1902,7 @@
         "doublesMoves": ["airslash", "energyball", "heatwave", "icebeam", "protect", "psyshock", "shadowball", "tailwind"]
     },
     "cofagrigus": {
-        "level": 84,
+        "level": 85,
         "moves": ["haze", "hiddenpowerfighting", "nastyplot", "painsplit", "shadowball", "toxicspikes", "trickroom", "willowisp"],
         "doublesMoves": ["hiddenpowerfighting", "nastyplot", "painsplit", "protect", "shadowball", "trickroom", "willowisp"]
     },
@@ -1931,7 +1931,7 @@
         "doublesMoves": ["aquatail", "bulletseed", "knockoff", "protect", "rockblast", "tailslap", "uturn"]
     },
     "gothitelle": {
-        "level": 82,
+        "level": 83,
         "moves": ["calmmind", "hiddenpowerfighting", "psychic", "rest", "sleeptalk", "toxic"],
         "doublesMoves": ["energyball", "healpulse", "hiddenpowerfighting", "lightscreen", "protect", "psychic", "psyshock", "reflect", "shadowball", "taunt", "thunderbolt", "trickroom"]
     },
@@ -1966,7 +1966,7 @@
         "doublesMoves": ["drillrun", "ironhead", "knockoff", "megahorn", "protect", "swordsdance"]
     },
     "amoonguss": {
-        "level": 82,
+        "level": 83,
         "moves": ["foulplay", "gigadrain", "hiddenpowerfire", "sludgebomb", "spore", "synthesis"],
         "doublesMoves": ["gigadrain", "hiddenpowerfire", "protect", "ragepowder", "sludgebomb", "spore", "stunspore", "synthesis"]
     },
@@ -2011,7 +2011,7 @@
         "doublesMoves": ["energyball", "heatwave", "hiddenpowerice", "overheat", "protect", "shadowball", "trick"]
     },
     "haxorus": {
-        "level": 79,
+        "level": 78,
         "moves": ["dragondance", "earthquake", "outrage", "poisonjab", "swordsdance"],
         "doublesMoves": ["dragonclaw", "dragondance", "earthquake", "poisonjab", "protect", "substitute", "swordsdance"]
     },
@@ -2096,7 +2096,7 @@
         "doublesMoves": ["closecombat", "ironhead", "protect", "stoneedge", "substitute", "swordsdance", "thunderwave"]
     },
     "terrakion": {
-        "level": 80,
+        "level": 79,
         "moves": ["closecombat", "earthquake", "quickattack", "stoneedge", "substitute", "swordsdance"],
         "doublesMoves": ["closecombat", "earthquake", "protect", "rockslide", "stoneedge", "substitute"]
     },
@@ -2111,7 +2111,7 @@
         "doublesMoves": ["airslash", "focusblast", "heatwave", "hurricane", "protect", "skydrop", "substitute", "superpower", "tailwind", "taunt", "uturn"]
     },
     "tornadustherian": {
-        "level": 80,
+        "level": 79,
         "moves": ["heatwave", "hurricane", "knockoff", "superpower", "taunt", "uturn"],
         "doublesMoves": ["airslash", "focusblast", "heatwave", "hurricane", "protect", "skydrop", "tailwind", "taunt", "uturn"]
     },
@@ -2146,12 +2146,12 @@
         "doublesMoves": ["earthquake", "knockoff", "protect", "rockslide", "stoneedge", "superpower", "uturn"]
     },
     "kyurem": {
-        "level": 80,
+        "level": 79,
         "moves": ["dracometeor", "earthpower", "focusblast", "icebeam", "outrage", "roost", "substitute"],
         "doublesMoves": ["dracometeor", "dragonpulse", "earthpower", "focusblast", "glaciate", "icebeam", "protect", "roost", "substitute"]
     },
     "kyuremblack": {
-        "level": 79,
+        "level": 78,
         "moves": ["dragonclaw", "earthpower", "fusionbolt", "icebeam", "outrage", "roost", "substitute"],
         "doublesMoves": ["dragonclaw", "earthpower", "fusionbolt", "honeclaws", "icebeam", "protect", "roost", "substitute"]
     },
@@ -2161,17 +2161,17 @@
         "doublesMoves": ["dracometeor", "dragonpulse", "earthpower", "focusblast", "fusionflare", "icebeam", "protect", "roost"]
     },
     "keldeo": {
-        "level": 80,
+        "level": 79,
         "moves": ["calmmind", "hiddenpowerelectric", "hydropump", "icywind", "scald", "secretsword", "substitute"],
         "doublesMoves": ["hiddenpowerelectric", "hiddenpowerflying", "hydropump", "icywind", "protect", "secretsword", "substitute", "surf", "taunt"]
     },
     "meloetta": {
-        "level": 83,
+        "level": 82,
         "moves": ["calmmind", "focusblast", "hypervoice", "psyshock", "shadowball", "trick", "uturn"],
         "doublesMoves": ["calmmind", "focusblast", "hypervoice", "protect", "psyshock", "shadowball", "thunderbolt"]
     },
     "meloettapirouette": {
-        "level": 83,
+        "level": 82,
         "moves": ["closecombat", "knockoff", "relicsong", "return"],
         "doublesMoves": ["closecombat", "knockoff", "protect", "relicsong", "return"]
     },
@@ -2181,7 +2181,7 @@
         "doublesMoves": ["blazekick", "bugbuzz", "extremespeed", "flamethrower", "icebeam", "ironhead", "protect", "shiftgear", "thunderbolt", "uturn"]
     },
     "chesnaught": {
-        "level": 83,
+        "level": 84,
         "moves": ["drainpunch", "leechseed", "spikes", "spikyshield", "synthesis", "woodhammer"],
         "doublesMoves": ["hammerarm", "leechseed", "rockslide", "spikyshield", "stoneedge", "synthesis", "woodhammer"]
     },
@@ -2191,7 +2191,7 @@
         "doublesMoves": ["calmmind", "dazzlinggleam", "fireblast", "grassknot", "heatwave", "protect", "psyshock", "shadowball", "switcheroo"]
     },
     "greninja": {
-        "level": 77,
+        "level": 78,
         "moves": ["gunkshot", "hydropump", "icebeam", "spikes", "taunt", "toxicspikes", "uturn"],
         "doublesMoves": ["darkpulse", "hydropump", "icebeam", "matblock", "protect", "surf", "taunt", "uturn"]
     },
@@ -2231,12 +2231,12 @@
         "doublesMoves": ["brickbreak", "bulkup", "earthquake", "hornleech", "leechseed", "milkdrink", "protect", "rockslide"]
     },
     "pangoro": {
-        "level": 84,
+        "level": 85,
         "moves": ["drainpunch", "gunkshot", "icepunch", "knockoff", "partingshot", "superpower"],
         "doublesMoves": ["circlethrow", "crunch", "earthquake", "hammerarm", "icepunch", "partingshot", "poisonjab", "protect"]
     },
     "furfrou": {
-        "level": 87,
+        "level": 86,
         "moves": ["cottonguard", "rest", "return", "substitute", "suckerpunch", "thunderwave", "toxic", "uturn"],
         "doublesMoves": ["cottonguard", "protect", "return", "snarl", "suckerpunch", "thunderwave", "uturn", "wildcharge"]
     },
@@ -2301,7 +2301,7 @@
         "doublesMoves": ["darkpulse", "hiddenpowerice", "protect", "raindance", "surf", "thunder", "thunderbolt", "voltswitch"]
     },
     "tyrantrum": {
-        "level": 84,
+        "level": 83,
         "moves": ["dragonclaw", "dragondance", "earthquake", "headsmash", "outrage", "stealthrock", "superpower"],
         "doublesMoves": ["dragonclaw", "dragondance", "earthquake", "firefang", "headsmash", "icefang", "protect", "rockslide"]
     },
@@ -2316,7 +2316,7 @@
         "doublesMoves": ["calmmind", "helpinghand", "hiddenpowerground", "hypervoice", "protect", "psyshock", "shadowball", "wish"]
     },
     "hawlucha": {
-        "level": 82,
+        "level": 81,
         "moves": ["acrobatics", "highjumpkick", "roost", "stoneedge", "substitute", "swordsdance"],
         "doublesMoves": ["encore", "highjumpkick", "protect", "skydrop", "stoneedge", "swordsdance", "uturn"]
     },
@@ -2336,7 +2336,7 @@
         "doublesMoves": ["dracometeor", "dragonpulse", "fireblast", "focusblast", "icebeam", "muddywater", "protect", "thunderbolt"]
     },
     "klefki": {
-        "level": 82,
+        "level": 83,
         "moves": ["foulplay", "lightscreen", "playrough", "reflect", "spikes", "thunderwave", "toxic"],
         "doublesMoves": ["dazzlinggleam", "flashcannon", "lightscreen", "playrough", "protect", "reflect", "safeguard", "substitute", "thunderwave"]
     },
@@ -2381,7 +2381,7 @@
         "doublesMoves": ["closecombat", "dazzlinggleam", "focusblast", "geomancy", "hiddenpowerfire", "protect", "psyshock", "rockslide", "thunder", "thunderbolt"]
     },
     "yveltal": {
-        "level": 73,
+        "level": 72,
         "moves": ["darkpulse", "foulplay", "knockoff", "oblivionwing", "roost", "suckerpunch", "taunt", "toxic", "uturn"],
         "doublesMoves": ["darkpulse", "focusblast", "hurricane", "oblivionwing", "protect", "roost", "skydrop", "snarl", "suckerpunch", "taunt"]
     },

--- a/data/mods/gen7/random-data.json
+++ b/data/mods/gen7/random-data.json
@@ -30,7 +30,7 @@
         "doublesMoves": ["fakeout", "followme", "icywind", "muddywater", "protect", "rapidspin", "scald"]
     },
     "blastoisemega": {
-        "level": 84,
+        "level": 83,
         "moves": ["aurasphere", "darkpulse", "icebeam", "rapidspin", "waterpulse"],
         "doublesMoves": ["aurasphere", "darkpulse", "fakeout", "icebeam", "muddywater", "protect", "waterpulse"]
     },
@@ -45,7 +45,7 @@
         "doublesMoves": ["knockoff", "poisonjab", "protect", "tailwind", "toxicspikes", "uturn"]
     },
     "beedrillmega": {
-        "level": 81,
+        "level": 80,
         "moves": ["drillrun", "knockoff", "poisonjab", "swordsdance", "uturn", "xscissor"],
         "doublesMoves": ["drillrun", "knockoff", "poisonjab", "protect", "uturn", "xscissor"]
     },
@@ -80,7 +80,7 @@
         "doublesMoves": ["aquatail", "coil", "gunkshot", "protect", "stompingtantrum", "suckerpunch"]
     },
     "pikachu": {
-        "level": 92,
+        "level": 93,
         "moves": ["extremespeed", "grassknot", "hiddenpowerice", "knockoff", "surf", "voltswitch", "volttackle"],
         "doublesMoves": ["encore", "fakeout", "grassknot", "hiddenpowerice", "knockoff", "protect", "voltswitch", "volttackle"]
     },
@@ -120,7 +120,7 @@
         "doublesMoves": ["dazzlinggleam", "fireblast", "followme", "helpinghand", "moonblast", "protect", "softboiled", "thunderwave"]
     },
     "ninetales": {
-        "level": 84,
+        "level": 85,
         "moves": ["fireblast", "hiddenpowerice", "nastyplot", "solarbeam", "substitute", "willowisp"],
         "doublesMoves": ["fireblast", "heatwave", "nastyplot", "protect", "solarbeam", "willowisp"]
     },
@@ -140,7 +140,7 @@
         "doublesMoves": ["energyball", "hiddenpowerfire", "protect", "sleeppowder", "sludgebomb", "strengthsap"]
     },
     "parasect": {
-        "level": 91,
+        "level": 92,
         "moves": ["knockoff", "leechlife", "leechseed", "seedbomb", "spore", "substitute"],
         "doublesMoves": ["knockoff", "leechlife", "leechseed", "protect", "ragepowder", "seedbomb", "spore", "wideguard"]
     },
@@ -160,12 +160,12 @@
         "doublesMoves": ["earthquake", "ironhead", "protect", "rockslide", "stoneedge", "suckerpunch"]
     },
     "persian": {
-        "level": 88,
+        "level": 89,
         "moves": ["fakeout", "knockoff", "return", "taunt", "uturn"],
         "doublesMoves": ["fakeout", "hypnosis", "knockoff", "protect", "return", "taunt", "uturn"]
     },
     "persianalola": {
-        "level": 87,
+        "level": 86,
         "moves": ["darkpulse", "hypnosis", "nastyplot", "powergem", "thunderbolt"],
         "doublesMoves": ["fakeout", "foulplay", "hiddenpowerfighting", "icywind", "partingshot", "protect", "snarl"]
     },
@@ -210,7 +210,7 @@
         "doublesMoves": ["growth", "knockoff", "powerwhip", "protect", "sleeppowder", "sludgebomb", "solarbeam", "suckerpunch", "sunnyday", "weatherball"]
     },
     "tentacruel": {
-        "level": 82,
+        "level": 83,
         "moves": ["acidspray", "knockoff", "rapidspin", "scald", "sludgebomb", "toxicspikes"],
         "doublesMoves": ["acidspray", "knockoff", "muddywater", "protect", "rapidspin", "scald", "sludgebomb"]
     },
@@ -245,7 +245,7 @@
         "doublesMoves": ["bravebird", "knockoff", "leafblade", "protect", "return", "swordsdance"]
     },
     "dodrio": {
-        "level": 86,
+        "level": 85,
         "moves": ["bravebird", "jumpkick", "knockoff", "quickattack", "return", "swordsdance"],
         "doublesMoves": ["bravebird", "knockoff", "protect", "quickattack", "return", "swordsdance"]
     },
@@ -310,7 +310,7 @@
         "doublesMoves": ["bonemerang", "doubleedge", "firepunch", "protect", "rockslide", "stealthrock", "swordsdance"]
     },
     "marowakalola": {
-        "level": 84,
+        "level": 85,
         "moves": ["bonemerang", "flamecharge", "flareblitz", "shadowbone", "stoneedge", "substitute", "willowisp"],
         "doublesMoves": ["bonemerang", "flareblitz", "protect", "shadowbone", "stoneedge", "willowisp"]
     },
@@ -364,7 +364,7 @@
         "doublesMoves": ["dazzlinggleam", "encore", "fakeout", "followme", "hiddenpowerfighting", "icywind", "protect", "psychic", "thunderbolt", "thunderwave", "wideguard"]
     },
     "scyther": {
-        "level": 87,
+        "level": 86,
         "moves": ["aerialace", "brickbreak", "bugbite", "knockoff", "roost", "swordsdance", "uturn"],
         "doublesMoves": ["aerialace", "brickbreak", "bugbite", "feint", "knockoff", "protect", "swordsdance", "uturn"]
     },
@@ -374,17 +374,17 @@
         "doublesMoves": ["focusblast", "icebeam", "lovelykiss", "nastyplot", "protect", "psychic", "psyshock"]
     },
     "pinsir": {
-        "level": 87,
+        "level": 86,
         "moves": ["closecombat", "earthquake", "knockoff", "stealthrock", "stoneedge", "xscissor"],
         "doublesMoves": ["closecombat", "feint", "knockoff", "protect", "rockslide", "xscissor"]
     },
     "pinsirmega": {
-        "level": 78,
+        "level": 77,
         "moves": ["closecombat", "earthquake", "quickattack", "return", "swordsdance"],
         "doublesMoves": ["closecombat", "feint", "protect", "quickattack", "return", "rockslide", "swordsdance"]
     },
     "tauros": {
-        "level": 87,
+        "level": 86,
         "moves": ["bodyslam", "doubleedge", "earthquake", "rockslide", "zenheadbutt"],
         "doublesMoves": ["doubleedge", "protect", "return", "rockslide", "stompingtantrum", "stoneedge", "zenheadbutt"]
     },
@@ -404,7 +404,7 @@
         "doublesMoves": ["freezedry", "helpinghand", "hydropump", "iceshard", "icywind", "protect"]
     },
     "ditto": {
-        "level": 86,
+        "level": 85,
         "moves": ["transform"]
     },
     "vaporeon": {
@@ -418,7 +418,7 @@
         "doublesMoves": ["helpinghand", "hiddenpowergrass", "hiddenpowerice", "protect", "signalbeam", "thunderbolt", "voltswitch"]
     },
     "flareon": {
-        "level": 88,
+        "level": 87,
         "moves": ["facade", "flamecharge", "flareblitz", "quickattack", "superpower"],
         "doublesMoves": ["facade", "flamecharge", "flareblitz", "protect", "superpower"]
     },
@@ -433,12 +433,12 @@
         "doublesMoves": ["aquajet", "knockoff", "liquidation", "protect", "rockslide", "stoneedge", "swordsdance"]
     },
     "aerodactyl": {
-        "level": 86,
+        "level": 85,
         "moves": ["defog", "doubleedge", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge", "taunt"],
         "doublesMoves": ["earthquake", "protect", "rockslide", "skydrop", "stoneedge", "tailwind", "wideguard"]
     },
     "aerodactylmega": {
-        "level": 81,
+        "level": 80,
         "moves": ["aerialace", "aquatail", "earthquake", "firefang", "honeclaws", "roost", "stoneedge"],
         "doublesMoves": ["aquatail", "protect", "rockslide", "skydrop", "stoneedge", "tailwind", "wideguard"]
     },
@@ -473,12 +473,12 @@
         "doublesMoves": ["aurasphere", "calmmind", "fireblast", "icebeam", "protect", "psystrike"]
     },
     "mewtwomegax": {
-        "level": 72,
+        "level": 71,
         "moves": ["bulkup", "drainpunch", "icebeam", "stoneedge", "taunt", "zenheadbutt"],
         "doublesMoves": ["bulkup", "drainpunch", "icebeam", "stoneedge", "taunt", "zenheadbutt"]
     },
     "mewtwomegay": {
-        "level": 72,
+        "level": 71,
         "moves": ["aurasphere", "calmmind", "fireblast", "icebeam", "psystrike", "recover", "shadowball"],
         "doublesMoves": ["aurasphere", "calmmind", "fireblast", "icebeam", "psystrike", "taunt", "willowisp"]
     },
@@ -503,7 +503,7 @@
         "doublesMoves": ["aquajet", "crunch", "dragondance", "icepunch", "liquidation", "protect"]
     },
     "furret": {
-        "level": 90,
+        "level": 91,
         "moves": ["aquatail", "doubleedge", "firepunch", "knockoff", "trick", "uturn"],
         "doublesMoves": ["doubleedge", "followme", "helpinghand", "knockoff", "protect", "superfang", "uturn"]
     },
@@ -513,7 +513,7 @@
         "doublesMoves": ["airslash", "heatwave", "hypervoice", "hypnosis", "protect", "roost", "tailwind"]
     },
     "ledian": {
-        "level": 92,
+        "level": 95,
         "moves": ["knockoff", "lightscreen", "reflect", "roost", "toxic", "uturn"],
         "doublesMoves": ["bugbuzz", "encore", "knockoff", "lightscreen", "protect", "reflect", "tailwind", "uturn"]
     },
@@ -568,12 +568,12 @@
         "doublesMoves": ["encore", "helpinghand", "hypnosis", "icywind", "protect", "scald"]
     },
     "jumpluff": {
-        "level": 88,
+        "level": 89,
         "moves": ["acrobatics", "encore", "leechseed", "seedbomb", "sleeppowder", "strengthsap", "substitute", "swordsdance", "toxic", "uturn"],
         "doublesMoves": ["encore", "energyball", "helpinghand", "leechseed", "protect", "ragepowder", "sleeppowder", "strengthsap", "uturn"]
     },
     "sunflora": {
-        "level": 91,
+        "level": 92,
         "moves": ["earthpower", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "sludgebomb"],
         "doublesMoves": ["earthpower", "encore", "energyball", "helpinghand", "hiddenpowerfire", "protect", "solarbeam", "sunnyday"]
     },
@@ -593,7 +593,7 @@
         "doublesMoves": ["foulplay", "helpinghand", "moonlight", "protect", "snarl"]
     },
     "slowking": {
-        "level": 86,
+        "level": 87,
         "moves": ["dragontail", "fireblast", "icebeam", "nastyplot", "psyshock", "scald", "slackoff", "thunderwave", "toxic", "trickroom"],
         "doublesMoves": ["fireblast", "protect", "psychic", "psyshock", "scald", "trickroom"]
     },
@@ -626,7 +626,7 @@
         "moves": ["defog", "earthquake", "knockoff", "roost", "stealthrock", "toxic", "uturn"]
     },
     "steelix": {
-        "level": 86,
+        "level": 85,
         "moves": ["earthquake", "ironhead", "roar", "rockslide", "stealthrock", "toxic"],
         "doublesMoves": ["earthquake", "headsmash", "heavyslam", "protect", "stealthrock", "wideguard"]
     },
@@ -656,7 +656,7 @@
         "doublesMoves": ["bugbite", "bulletpunch", "feint", "knockoff", "protect", "roost", "superpower", "swordsdance", "uturn"]
     },
     "shuckle": {
-        "level": 88,
+        "level": 87,
         "moves": ["encore", "knockoff", "stealthrock", "stickyweb", "toxic"],
         "doublesMoves": ["encore", "guardsplit", "helpinghand", "knockoff", "stealthrock", "stickyweb", "toxic"]
     },
@@ -671,7 +671,7 @@
         "doublesMoves": ["bulletseed", "closecombat", "knockoff", "pinmissile", "protect", "rockblast", "swordsdance"]
     },
     "ursaring": {
-        "level": 86,
+        "level": 85,
         "moves": ["closecombat", "crunch", "facade", "protect", "swordsdance"],
         "doublesMoves": ["closecombat", "crunch", "facade", "protect", "swordsdance"]
     },
@@ -681,7 +681,7 @@
         "doublesMoves": ["earthpower", "fireblast", "heatwave", "incinerate", "protect", "stealthrock", "willowisp"]
     },
     "corsola": {
-        "level": 91,
+        "level": 92,
         "moves": ["powergem", "recover", "scald", "stealthrock", "toxic"],
         "doublesMoves": ["icywind", "powergem", "protect", "scald", "stealthrock", "toxic"]
     },
@@ -761,7 +761,7 @@
         "doublesMoves": ["calmmind", "hiddenpowerice", "protect", "snarl", "thunderbolt"]
     },
     "entei": {
-        "level": 82,
+        "level": 81,
         "moves": ["extremespeed", "flareblitz", "sacredfire", "stompingtantrum", "stoneedge"],
         "doublesMoves": ["extremespeed", "flareblitz", "protect", "sacredfire", "stompingtantrum", "stoneedge"]
     },
@@ -776,17 +776,17 @@
         "doublesMoves": ["crunch", "fireblast", "icebeam", "protect", "rockslide", "stealthrock", "stompingtantrum", "stoneedge"]
     },
     "tyranitarmega": {
-        "level": 79,
+        "level": 78,
         "moves": ["crunch", "dragondance", "earthquake", "icepunch", "stoneedge"],
         "doublesMoves": ["crunch", "dragondance", "earthquake", "icepunch", "protect", "rockslide", "stoneedge"]
     },
     "lugia": {
-        "level": 76,
+        "level": 75,
         "moves": ["aeroblast", "earthquake", "roost", "substitute", "toxic", "whirlwind"],
         "doublesMoves": ["aeroblast", "protect", "psychic", "roost", "skydrop", "tailwind", "toxic"]
     },
     "hooh": {
-        "level": 75,
+        "level": 74,
         "moves": ["bravebird", "defog", "earthquake", "roost", "sacredfire", "substitute", "toxic"],
         "doublesMoves": ["bravebird", "earthpower", "protect", "roost", "sacredfire", "skydrop", "tailwind", "toxic"]
     },
@@ -806,7 +806,7 @@
         "doublesMoves": ["dragonpulse", "energyball", "focusblast", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "protect"]
     },
     "blaziken": {
-        "level": 77,
+        "level": 78,
         "moves": ["fireblast", "hiddenpowerice", "highjumpkick", "knockoff", "protect"]
     },
     "blazikenmega": {
@@ -834,7 +834,7 @@
         "doublesMoves": ["bellydrum", "extremespeed", "protect", "shadowclaw", "stompingtantrum"]
     },
     "beautifly": {
-        "level": 91,
+        "level": 93,
         "moves": ["bugbuzz", "energyball", "hiddenpowerfighting", "psychic", "quiverdance"],
         "doublesMoves": ["aircutter", "bugbuzz", "protect", "quiverdance", "stringshot", "tailwind"]
     },
@@ -849,7 +849,7 @@
         "doublesMoves": ["fakeout", "gigadrain", "hydropump", "icebeam", "protect", "raindance"]
     },
     "shiftry": {
-        "level": 88,
+        "level": 89,
         "moves": ["defog", "knockoff", "leafblade", "leafstorm", "lowkick", "suckerpunch", "swordsdance"],
         "doublesMoves": ["fakeout", "knockoff", "leafblade", "leafstorm", "protect", "suckerpunch", "swordsdance"]
     },
@@ -884,7 +884,7 @@
         "doublesMoves": ["bulletseed", "machpunch", "protect", "rocktomb", "spore"]
     },
     "slaking": {
-        "level": 85,
+        "level": 84,
         "moves": ["earthquake", "firepunch", "gigaimpact", "nightslash", "pursuit", "retaliate"],
         "doublesMoves": ["doubleedge", "earthquake", "hammerarm", "nightslash", "retaliate", "rockslide"]
     },
@@ -904,7 +904,7 @@
         "doublesMoves": ["boomburst", "fireblast", "focusblast", "hypervoice", "icebeam", "protect"]
     },
     "hariyama": {
-        "level": 86,
+        "level": 87,
         "moves": ["bulkup", "bulletpunch", "closecombat", "icepunch", "knockoff", "stoneedge"],
         "doublesMoves": ["bulletpunch", "closecombat", "facade", "fakeout", "helpinghand", "knockoff", "protect", "wideguard"]
     },
@@ -959,17 +959,17 @@
         "doublesMoves": ["flamethrower", "hiddenpowergrass", "hiddenpowerice", "protect", "snarl", "switcheroo", "thunderbolt", "voltswitch"]
     },
     "manectricmega": {
-        "level": 82,
+        "level": 81,
         "moves": ["hiddenpowergrass", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"],
         "doublesMoves": ["flamethrower", "hiddenpowergrass", "hiddenpowerice", "protect", "snarl", "thunderbolt", "voltswitch"]
     },
     "plusle": {
-        "level": 90,
+        "level": 91,
         "moves": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
         "doublesMoves": ["encore", "helpinghand", "hiddenpowerice", "nastyplot", "protect", "thunderbolt"]
     },
     "minun": {
-        "level": 90,
+        "level": 91,
         "moves": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
         "doublesMoves": ["encore", "helpinghand", "hiddenpowerice", "nastyplot", "protect", "thunderbolt"]
     },
@@ -979,7 +979,7 @@
         "doublesMoves": ["encore", "helpinghand", "protect", "stringshot", "strugglebug", "tailwind", "thunderwave", "uturn"]
     },
     "illumise": {
-        "level": 91,
+        "level": 93,
         "moves": ["bugbuzz", "defog", "encore", "roost", "thunderwave", "uturn", "wish"],
         "doublesMoves": ["bugbuzz", "encore", "helpinghand", "protect", "tailwind", "thunderwave"]
     },
@@ -1009,7 +1009,7 @@
         "doublesMoves": ["earthpower", "fireblast", "heatwave", "incinerate", "protect", "stealthrock"]
     },
     "cameruptmega": {
-        "level": 87,
+        "level": 88,
         "moves": ["ancientpower", "earthpower", "fireblast", "stealthrock", "toxic", "willowisp"],
         "doublesMoves": ["earthpower", "fireblast", "heatwave", "protect", "rockslide"]
     },
@@ -1019,7 +1019,7 @@
         "doublesMoves": ["earthpower", "fireblast", "heatwave", "protect", "solarbeam", "willowisp"]
     },
     "grumpig": {
-        "level": 88,
+        "level": 89,
         "moves": ["focusblast", "healbell", "lightscreen", "psychic", "reflect", "thunderwave", "toxic", "whirlwind"],
         "doublesMoves": ["focusblast", "lightscreen", "protect", "psychic", "reflect", "taunt", "thunderwave"]
     },
@@ -1074,7 +1074,7 @@
         "doublesMoves": ["dragondance", "earthquake", "protect", "stoneedge", "waterfall", "zenheadbutt"]
     },
     "crawdaunt": {
-        "level": 82,
+        "level": 83,
         "moves": ["aquajet", "crabhammer", "dragondance", "knockoff", "superpower", "swordsdance"],
         "doublesMoves": ["aquajet", "crabhammer", "dragondance", "knockoff", "protect", "superpower", "swordsdance"]
     },
@@ -1116,7 +1116,7 @@
         "doublesMoves": ["drainpunch", "fakeout", "knockoff", "protect", "shadowsneak", "trickroom"]
     },
     "banette": {
-        "level": 90,
+        "level": 91,
         "moves": ["destinybond", "knockoff", "shadowclaw", "shadowsneak", "suckerpunch", "taunt", "willowisp"],
         "doublesMoves": ["knockoff", "protect", "shadowclaw", "shadowsneak", "willowisp"]
     },
@@ -1141,7 +1141,7 @@
         "doublesMoves": ["knockoff", "playrough", "protect", "suckerpunch", "superpower", "swordsdance"]
     },
     "absolmega": {
-        "level": 83,
+        "level": 82,
         "moves": ["icebeam", "knockoff", "playrough", "pursuit", "suckerpunch", "superpower", "swordsdance"],
         "doublesMoves": ["fireblast", "knockoff", "playrough", "protect", "suckerpunch", "superpower", "swordsdance"]
     },
@@ -1161,17 +1161,17 @@
         "doublesMoves": ["brine", "icywind", "protect", "superfang"]
     },
     "huntail": {
-        "level": 85,
+        "level": 84,
         "moves": ["icebeam", "shellsmash", "suckerpunch", "waterfall"],
         "doublesMoves": ["icebeam", "protect", "shellsmash", "suckerpunch", "waterfall"]
     },
     "gorebyss": {
-        "level": 85,
+        "level": 84,
         "moves": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"],
         "doublesMoves": ["hiddenpowergrass", "hydropump", "icebeam", "protect", "shellsmash"]
     },
     "relicanth": {
-        "level": 88,
+        "level": 87,
         "moves": ["doubleedge", "earthquake", "headsmash", "stealthrock", "toxic", "waterfall"],
         "doublesMoves": ["doubleedge", "earthquake", "headsmash", "protect", "rockslide", "waterfall"]
     },
@@ -1181,12 +1181,12 @@
         "doublesMoves": ["healpulse", "icebeam", "icywind", "protect", "scald", "sweetkiss", "toxic"]
     },
     "salamence": {
-        "level": 78,
+        "level": 77,
         "moves": ["dragondance", "earthquake", "fireblast", "fly", "outrage", "roost"],
         "doublesMoves": ["dracometeor", "dragonclaw", "dragondance", "earthquake", "fireblast", "fly", "protect", "tailwind"]
     },
     "salamencemega": {
-        "level": 74,
+        "level": 73,
         "moves": ["doubleedge", "dracometeor", "dragondance", "earthquake", "fireblast", "return", "roost"],
         "doublesMoves": ["doubleedge", "dracometeor", "dragonclaw", "dragondance", "earthquake", "fireblast", "protect", "return"]
     },
@@ -1206,7 +1206,7 @@
         "doublesMoves": ["curse", "drainpunch", "protect", "rest", "rockslide", "stealthrock", "stoneedge", "thunderwave"]
     },
     "regice": {
-        "level": 88,
+        "level": 87,
         "moves": ["focusblast", "icebeam", "rest", "rockpolish", "sleeptalk", "thunderbolt", "thunderwave"],
         "doublesMoves": ["icebeam", "icywind", "protect", "rockpolish", "thunderbolt", "thunderwave"]
     },
@@ -1241,7 +1241,7 @@
         "doublesMoves": ["calmmind", "icebeam", "originpulse", "protect", "thunder", "waterspout"]
     },
     "kyogreprimal": {
-        "level": 74,
+        "level": 73,
         "moves": ["calmmind", "icebeam", "originpulse", "rest", "scald", "sleeptalk", "thunder"],
         "doublesMoves": ["calmmind", "icebeam", "originpulse", "protect", "thunder"]
     },
@@ -1251,7 +1251,7 @@
         "doublesMoves": ["firepunch", "precipiceblades", "protect", "rockpolish", "rockslide", "stoneedge", "swordsdance"]
     },
     "groudonprimal": {
-        "level": 70,
+        "level": 69,
         "moves": ["firepunch", "lavaplume", "precipiceblades", "rockpolish", "stealthrock", "stoneedge", "swordsdance"],
         "doublesMoves": ["firepunch", "precipiceblades", "protect", "rockpolish", "rockslide", "stoneedge", "swordsdance"]
     },
@@ -1281,12 +1281,12 @@
         "doublesMoves": ["extremespeed", "firepunch", "icebeam", "knockoff", "protect", "psychoboost", "superpower"]
     },
     "deoxysdefense": {
-        "level": 82,
+        "level": 83,
         "moves": ["knockoff", "recover", "seismictoss", "spikes", "stealthrock", "taunt", "toxic"],
         "doublesMoves": ["lightscreen", "protect", "recover", "reflect", "seismictoss", "stealthrock", "taunt", "trickroom"]
     },
     "deoxysspeed": {
-        "level": 80,
+        "level": 81,
         "moves": ["knockoff", "magiccoat", "psychoboost", "spikes", "stealthrock", "superpower", "taunt"],
         "doublesMoves": ["knockoff", "lightscreen", "protect", "psychoboost", "reflect", "superpower", "taunt"]
     },
@@ -1306,7 +1306,7 @@
         "doublesMoves": ["defog", "flashcannon", "grassknot", "icywind", "protect", "scald"]
     },
     "staraptor": {
-        "level": 82,
+        "level": 81,
         "moves": ["bravebird", "closecombat", "doubleedge", "quickattack", "uturn"],
         "doublesMoves": ["bravebird", "closecombat", "doubleedge", "protect", "quickattack", "tailwind", "uturn"]
     },
@@ -1316,7 +1316,7 @@
         "doublesMoves": ["aquajet", "liquidation", "quickattack", "return", "swordsdance"]
     },
     "kricketune": {
-        "level": 88,
+        "level": 89,
         "moves": ["endeavor", "knockoff", "leechlife", "stickyweb", "taunt", "toxic"],
         "doublesMoves": ["knockoff", "leechlife", "protect", "stickyweb", "taunt"]
     },
@@ -1341,7 +1341,7 @@
         "doublesMoves": ["guardsplit", "metalburst", "protect", "stealthrock", "stoneedge", "wideguard"]
     },
     "wormadam": {
-        "level": 92,
+        "level": 93,
         "moves": ["bugbuzz", "gigadrain", "hiddenpowerground", "hiddenpowerrock", "leafstorm", "quiverdance"],
         "doublesMoves": ["bugbuzz", "gigadrain", "leafstorm", "protect", "stringshot"]
     },
@@ -1351,7 +1351,7 @@
         "doublesMoves": ["earthquake", "protect", "rockblast", "stringshot", "suckerpunch"]
     },
     "wormadamtrash": {
-        "level": 88,
+        "level": 87,
         "moves": ["flashcannon", "protect", "stealthrock", "toxic"],
         "doublesMoves": ["bugbuzz", "flashcannon", "protect", "stringshot", "strugglebug", "suckerpunch"]
     },
@@ -1361,12 +1361,12 @@
         "doublesMoves": ["airslash", "bugbuzz", "energyball", "protect", "quiverdance"]
     },
     "vespiquen": {
-        "level": 90,
+        "level": 91,
         "moves": ["airslash", "defog", "roost", "toxic", "uturn"],
         "doublesMoves": ["attackorder", "healorder", "protect", "stringshot", "strugglebug", "tailwind"]
     },
     "pachirisu": {
-        "level": 89,
+        "level": 90,
         "moves": ["nuzzle", "superfang", "thunderbolt", "toxic", "uturn"],
         "doublesMoves": ["followme", "helpinghand", "nuzzle", "protect", "superfang", "thunderbolt", "uturn"]
     },
@@ -1429,7 +1429,7 @@
         "doublesMoves": ["crunch", "fireblast", "poisonjab", "protect", "snarl", "suckerpunch", "taunt"]
     },
     "bronzong": {
-        "level": 84,
+        "level": 85,
         "moves": ["earthquake", "explosion", "ironhead", "lightscreen", "reflect", "stealthrock", "toxic"],
         "doublesMoves": ["earthquake", "explosion", "gyroball", "lightscreen", "protect", "reflect", "trickroom"]
     },
@@ -1439,7 +1439,7 @@
         "doublesMoves": ["boomburst", "chatter", "encore", "heatwave", "hypervoice", "nastyplot", "protect", "uturn"]
     },
     "spiritomb": {
-        "level": 90,
+        "level": 91,
         "moves": ["calmmind", "darkpulse", "psychic", "pursuit", "rest", "shadowsneak", "sleeptalk", "willowisp"],
         "doublesMoves": ["foulplay", "icywind", "protect", "shadowsneak", "snarl", "willowisp"]
     },
@@ -1454,7 +1454,7 @@
         "doublesMoves": ["dragonclaw", "earthquake", "fireblast", "protect", "rockslide", "stoneedge", "swordsdance"]
     },
     "lucario": {
-        "level": 82,
+        "level": 83,
         "moves": ["aurasphere", "closecombat", "crunch", "darkpulse", "extremespeed", "flashcannon", "meteormash", "nastyplot", "swordsdance", "vacuumwave"],
         "doublesMoves": ["closecombat", "darkpulse", "extremespeed", "icepunch", "meteormash", "protect"]
     },
@@ -1499,7 +1499,7 @@
         "doublesMoves": ["blizzard", "earthquake", "gigadrain", "iceshard", "protect", "woodhammer"]
     },
     "weavile": {
-        "level": 81,
+        "level": 80,
         "moves": ["iceshard", "iciclecrash", "knockoff", "lowkick", "pursuit", "swordsdance"],
         "doublesMoves": ["fakeout", "iceshard", "iciclecrash", "knockoff", "lowkick", "protect", "swordsdance"]
     },
@@ -1519,7 +1519,7 @@
         "doublesMoves": ["earthquake", "icepunch", "megahorn", "protect", "rockslide", "stealthrock", "stoneedge"]
     },
     "tangrowth": {
-        "level": 86,
+        "level": 87,
         "moves": ["earthquake", "gigadrain", "hiddenpowerfire", "knockoff", "leafstorm", "rockslide", "sleeppowder", "synthesis"],
         "doublesMoves": ["earthquake", "focusblast", "gigadrain", "hiddenpowerice", "knockoff", "leechseed", "powerwhip", "protect", "ragepowder", "sleeppowder"]
     },
@@ -1568,12 +1568,12 @@
         "doublesMoves": ["darkpulse", "icebeam", "nastyplot", "protect", "thunderbolt", "triattack", "trick"]
     },
     "gallade": {
-        "level": 88,
+        "level": 87,
         "moves": ["bulkup", "closecombat", "drainpunch", "icepunch", "knockoff", "shadowsneak", "substitute", "zenheadbutt"],
         "doublesMoves": ["closecombat", "helpinghand", "icepunch", "knockoff", "protect", "shadowsneak", "trick", "zenheadbutt"]
     },
     "gallademega": {
-        "level": 80,
+        "level": 78,
         "moves": ["closecombat", "icepunch", "knockoff", "swordsdance", "zenheadbutt"],
         "doublesMoves": ["closecombat", "drainpunch", "icepunch", "knockoff", "protect", "swordsdance", "zenheadbutt"]
     },
@@ -1598,12 +1598,12 @@
         "doublesMoves": ["electroweb", "hiddenpowerice", "protect", "shadowball", "thunderbolt", "trick", "voltswitch", "willowisp"]
     },
     "rotomheat": {
-        "level": 82,
+        "level": 83,
         "moves": ["hiddenpowerice", "overheat", "painsplit", "thunderbolt", "voltswitch", "willowisp"],
         "doublesMoves": ["electroweb", "overheat", "protect", "thunderbolt", "voltswitch", "willowisp"]
     },
     "rotomwash": {
-        "level": 81,
+        "level": 82,
         "moves": ["defog", "hydropump", "painsplit", "thunderbolt", "trick", "voltswitch", "willowisp"],
         "doublesMoves": ["electroweb", "hydropump", "protect", "thunderbolt", "trick", "voltswitch", "willowisp"]
     },
@@ -1613,7 +1613,7 @@
         "doublesMoves": ["blizzard", "electroweb", "protect", "thunderbolt", "trick", "voltswitch", "willowisp"]
     },
     "rotomfan": {
-        "level": 87,
+        "level": 86,
         "moves": ["airslash", "defog", "painsplit", "thunderbolt", "voltswitch", "willowisp"],
         "doublesMoves": ["airslash", "electroweb", "protect", "thunderbolt", "voltswitch", "willowisp"]
     },
@@ -1698,92 +1698,92 @@
         "doublesMoves": ["airslash", "earthpower", "hiddenpowerice", "protect", "rest", "seedflare", "tailwind"]
     },
     "arceus": {
-        "level": 74,
+        "level": 73,
         "moves": ["earthquake", "extremespeed", "recover", "shadowclaw", "swordsdance"],
         "doublesMoves": ["earthquake", "extremespeed", "protect", "recover", "shadowclaw", "swordsdance"]
     },
     "arceusbug": {
-        "level": 74,
+        "level": 73,
         "moves": ["calmmind", "earthpower", "fireblast", "judgment", "recover"],
         "doublesMoves": ["earthquake", "ironhead", "protect", "recover", "stoneedge", "swordsdance", "xscissor"]
     },
     "arceusdark": {
-        "level": 74,
+        "level": 73,
         "moves": ["calmmind", "fireblast", "judgment", "recover", "toxic"],
         "doublesMoves": ["calmmind", "focusblast", "judgment", "protect", "recover", "snarl", "willowisp"]
     },
     "arceusdragon": {
-        "level": 74,
+        "level": 73,
         "moves": ["defog", "earthquake", "extremespeed", "fireblast", "judgment", "outrage", "recover", "swordsdance", "willowisp"],
         "doublesMoves": ["dragonclaw", "earthquake", "extremespeed", "protect", "recover", "swordsdance"]
     },
     "arceuselectric": {
-        "level": 74,
+        "level": 73,
         "moves": ["calmmind", "earthpower", "icebeam", "judgment", "recover"],
         "doublesMoves": ["calmmind", "icebeam", "judgment", "protect", "recover"]
     },
     "arceusfairy": {
-        "level": 74,
+        "level": 73,
         "moves": ["calmmind", "defog", "earthpower", "judgment", "recover", "toxic", "willowisp"],
         "doublesMoves": ["calmmind", "defog", "earthpower", "judgment", "protect", "recover", "thunderbolt", "willowisp"]
     },
     "arceusfighting": {
-        "level": 74,
+        "level": 73,
         "moves": ["calmmind", "icebeam", "judgment", "recover", "roar", "shadowball", "stoneedge"],
         "doublesMoves": ["calmmind", "icebeam", "judgment", "protect", "recover", "shadowball", "willowisp"]
     },
     "arceusfire": {
-        "level": 74,
+        "level": 73,
         "moves": ["calmmind", "fireblast", "icebeam", "recover", "roar", "thunderbolt"],
         "doublesMoves": ["calmmind", "heatwave", "judgment", "protect", "recover", "thunderbolt", "willowisp"]
     },
     "arceusflying": {
-        "level": 74,
+        "level": 73,
         "moves": ["calmmind", "earthpower", "fireblast", "judgment", "recover", "toxic"],
         "doublesMoves": ["calmmind", "earthpower", "judgment", "protect", "recover", "tailwind"]
     },
     "arceusghost": {
-        "level": 74,
+        "level": 73,
         "moves": ["brickbreak", "defog", "extremespeed", "judgment", "recover", "shadowclaw", "shadowforce", "swordsdance", "toxic"],
         "doublesMoves": ["brickbreak", "calmmind", "focusblast", "judgment", "protect", "recover", "shadowforce", "swordsdance", "willowisp"]
     },
     "arceusgrass": {
-        "level": 74,
+        "level": 73,
         "moves": ["calmmind", "fireblast", "icebeam", "judgment", "recover"],
         "doublesMoves": ["calmmind", "heatwave", "icebeam", "judgment", "protect", "recover", "thunderwave"]
     },
     "arceusground": {
-        "level": 74,
+        "level": 73,
         "moves": ["earthquake", "icebeam", "recover", "stealthrock", "stoneedge", "swordsdance", "toxic"],
         "doublesMoves": ["calmmind", "earthquake", "icebeam", "judgment", "protect", "recover", "rockslide", "stoneedge", "swordsdance"]
     },
     "arceusice": {
-        "level": 74,
+        "level": 73,
         "moves": ["calmmind", "fireblast", "judgment", "recover", "thunderbolt"],
         "doublesMoves": ["calmmind", "focusblast", "icywind", "judgment", "protect", "recover", "thunderbolt"]
     },
     "arceuspoison": {
-        "level": 74,
+        "level": 73,
         "moves": ["calmmind", "defog", "fireblast", "icebeam", "recover", "sludgebomb"],
         "doublesMoves": ["calmmind", "earthpower", "heatwave", "judgment", "protect", "recover", "sludgebomb", "willowisp"]
     },
     "arceuspsychic": {
-        "level": 74,
+        "level": 73,
         "moves": ["calmmind", "fireblast", "icebeam", "judgment", "recover", "toxic"],
         "doublesMoves": ["calmmind", "focusblast", "judgment", "protect", "psyshock", "recover", "willowisp"]
     },
     "arceusrock": {
-        "level": 74,
+        "level": 73,
         "moves": ["earthquake", "judgment", "recover", "stealthrock", "stoneedge", "swordsdance", "willowisp"],
         "doublesMoves": ["earthquake", "protect", "recover", "rockslide", "stoneedge", "swordsdance"]
     },
     "arceussteel": {
-        "level": 74,
+        "level": 73,
         "moves": ["defog", "earthquake", "ironhead", "judgment", "recover", "roar", "stoneedge", "swordsdance", "willowisp"],
         "doublesMoves": ["calmmind", "earthpower", "judgment", "protect", "recover", "willowisp"]
     },
     "arceuswater": {
-        "level": 74,
+        "level": 73,
         "moves": ["calmmind", "defog", "icebeam", "judgment", "recover", "toxic"],
         "doublesMoves": ["calmmind", "fireblast", "icebeam", "icywind", "judgment", "protect", "recover", "surf"]
     },
@@ -1808,7 +1808,7 @@
         "doublesMoves": ["aquajet", "helpinghand", "hiddenpowergrass", "hydropump", "icebeam", "protect", "scald", "taunt"]
     },
     "watchog": {
-        "level": 91,
+        "level": 92,
         "moves": ["hypnosis", "knockoff", "return", "substitute", "superfang", "swordsdance"],
         "doublesMoves": ["hypnosis", "knockoff", "protect", "return", "superfang", "swordsdance"]
     },
@@ -1818,7 +1818,7 @@
         "doublesMoves": ["crunch", "protect", "return", "superpower", "wildcharge"]
     },
     "liepard": {
-        "level": 89,
+        "level": 90,
         "moves": ["copycat", "encore", "knockoff", "playrough", "substitute", "thunderwave", "uturn"],
         "doublesMoves": ["encore", "fakeout", "knockoff", "playrough", "protect", "suckerpunch", "thunderwave", "uturn"]
     },
@@ -1863,12 +1863,12 @@
         "doublesMoves": ["airslash", "calmmind", "heatwave", "protect", "psychic", "tailwind"]
     },
     "excadrill": {
-        "level": 80,
+        "level": 81,
         "moves": ["earthquake", "ironhead", "rapidspin", "rockslide", "swordsdance"],
         "doublesMoves": ["drillrun", "earthquake", "ironhead", "protect", "rockslide", "swordsdance"]
     },
     "audino": {
-        "level": 90,
+        "level": 91,
         "moves": ["doubleedge", "encore", "healbell", "protect", "toxic", "wish"],
         "doublesMoves": ["healpulse", "helpinghand", "hypervoice", "protect", "thunderwave", "trickroom"]
     },
@@ -1908,7 +1908,7 @@
         "doublesMoves": ["aquatail", "megahorn", "poisonjab", "protect", "rockslide", "superpower", "swordsdance"]
     },
     "whimsicott": {
-        "level": 86,
+        "level": 87,
         "moves": ["defog", "encore", "leechseed", "memento", "moonblast", "stunspore", "tailwind", "taunt", "toxic", "uturn"],
         "doublesMoves": ["dazzlinggleam", "defog", "encore", "gigadrain", "helpinghand", "leechseed", "moonblast", "protect", "stunspore", "substitute", "tailwind", "taunt", "uturn"]
     },
@@ -1938,17 +1938,17 @@
         "doublesMoves": ["earthquake", "flareblitz", "protect", "rockslide", "superpower", "uturn"]
     },
     "maractus": {
-        "level": 90,
+        "level": 91,
         "moves": ["gigadrain", "hiddenpowerfire", "leechseed", "spikes", "spikyshield", "suckerpunch", "toxic"],
         "doublesMoves": ["energyball", "helpinghand", "hiddenpowerfire", "leechseed", "spikyshield", "suckerpunch"]
     },
     "crustle": {
-        "level": 84,
+        "level": 83,
         "moves": ["earthquake", "shellsmash", "spikes", "stealthrock", "stoneedge", "xscissor"],
         "doublesMoves": ["earthquake", "protect", "rockslide", "shellsmash", "stoneedge", "xscissor"]
     },
     "scrafty": {
-        "level": 86,
+        "level": 85,
         "moves": ["bulkup", "dragondance", "drainpunch", "highjumpkick", "icepunch", "knockoff", "rest"],
         "doublesMoves": ["drainpunch", "fakeout", "icepunch", "knockoff", "protect", "superfang"]
     },
@@ -1968,12 +1968,12 @@
         "doublesMoves": ["aquajet", "earthquake", "liquidation", "protect", "rockslide", "shellsmash", "stoneedge", "wideguard"]
     },
     "archeops": {
-        "level": 87,
+        "level": 86,
         "moves": ["acrobatics", "aquatail", "earthquake", "endeavor", "headsmash", "stoneedge", "uturn"],
         "doublesMoves": ["acrobatics", "earthpower", "protect", "rockslide", "stoneedge", "tailwind", "taunt", "uturn"]
     },
     "garbodor": {
-        "level": 87,
+        "level": 88,
         "moves": ["gunkshot", "haze", "painsplit", "spikes", "stompingtantrum", "toxic", "toxicspikes"],
         "doublesMoves": ["drainpunch", "gunkshot", "painsplit", "protect", "toxicspikes"]
     },
@@ -1982,7 +1982,7 @@
         "doublesMoves": ["darkpulse", "flamethrower", "focusblast", "knockoff", "nastyplot", "protect", "suckerpunch", "uturn"]
     },
     "cinccino": {
-        "level": 87,
+        "level": 86,
         "moves": ["bulletseed", "knockoff", "rockblast", "tailslap", "uturn"],
         "doublesMoves": ["bulletseed", "knockoff", "protect", "rockblast", "tailslap", "uturn"]
     },
@@ -2017,7 +2017,7 @@
         "doublesMoves": ["airslash", "encore", "helpinghand", "protect", "roost", "tailwind", "thunderbolt"]
     },
     "escavalier": {
-        "level": 84,
+        "level": 85,
         "moves": ["drillrun", "ironhead", "knockoff", "megahorn", "pursuit", "swordsdance"],
         "doublesMoves": ["drillrun", "ironhead", "knockoff", "megahorn", "protect", "swordsdance"]
     },
@@ -2032,12 +2032,12 @@
         "doublesMoves": ["icywind", "protect", "recover", "scald", "shadowball", "trickroom", "willowisp"]
     },
     "alomomola": {
-        "level": 84,
+        "level": 85,
         "moves": ["knockoff", "protect", "scald", "toxic", "wish"],
         "doublesMoves": ["helpinghand", "icywind", "knockoff", "protect", "scald", "wideguard"]
     },
     "galvantula": {
-        "level": 84,
+        "level": 83,
         "moves": ["bugbuzz", "gigadrain", "hiddenpowerice", "stickyweb", "thunder", "voltswitch"],
         "doublesMoves": ["bugbuzz", "energyball", "hiddenpowerice", "protect", "stickyweb", "thunder", "voltswitch"]
     },
@@ -2067,7 +2067,7 @@
         "doublesMoves": ["energyball", "heatwave", "overheat", "protect", "shadowball", "trick"]
     },
     "haxorus": {
-        "level": 81,
+        "level": 80,
         "moves": ["dragondance", "earthquake", "outrage", "poisonjab", "swordsdance", "taunt"],
         "doublesMoves": ["dragonclaw", "dragondance", "earthquake", "poisonjab", "protect", "swordsdance", "taunt"]
     },
@@ -2192,7 +2192,7 @@
         "doublesMoves": ["boltstrike", "dracometeor", "dragonclaw", "honeclaws", "protect", "roost", "tailwind"]
     },
     "landorus": {
-        "level": 77,
+        "level": 78,
         "moves": ["calmmind", "earthpower", "focusblast", "knockoff", "psychic", "rockpolish", "rockslide", "sludgewave", "stealthrock"],
         "doublesMoves": ["earthpower", "focusblast", "hiddenpowerice", "protect", "psychic", "rockslide", "sludgebomb"]
     },
@@ -2207,7 +2207,7 @@
         "doublesMoves": ["dracometeor", "dragonpulse", "earthpower", "glaciate", "icebeam", "protect", "roost"]
     },
     "kyuremblack": {
-        "level": 80,
+        "level": 79,
         "moves": ["dragonclaw", "earthpower", "fusionbolt", "icebeam", "outrage", "roost", "substitute"],
         "doublesMoves": ["dragonclaw", "earthpower", "fusionbolt", "icebeam", "protect", "roost"]
     },
@@ -2261,7 +2261,7 @@
         "doublesMoves": ["earthquake", "knockoff", "protect", "quickattack", "return", "uturn"]
     },
     "talonflame": {
-        "level": 84,
+        "level": 83,
         "moves": ["bravebird", "flareblitz", "overheat", "roost", "swordsdance", "uturn", "willowisp"],
         "doublesMoves": ["bravebird", "flareblitz", "protect", "roost", "swordsdance", "tailwind", "taunt", "uturn", "willowisp"]
     },
@@ -2276,7 +2276,7 @@
         "doublesMoves": ["fireblast", "hypervoice", "protect", "solarbeam", "sunnyday", "willowisp"]
     },
     "floetteeternal": {
-        "level": 80,
+        "level": 81,
         "moves": ["hiddenpowerfire", "hiddenpowerground", "lightofruin", "moonblast", "psychic"],
         "doublesMoves": ["calmmind", "dazzlinggleam", "hiddenpowerfire", "lightofruin", "protect", "psychic"]
     },
@@ -2311,7 +2311,7 @@
         "doublesMoves": ["darkpulse", "energyball", "fakeout", "helpinghand", "nastyplot", "protect", "psychic", "thunderbolt"]
     },
     "doublade": {
-        "level": 82,
+        "level": 83,
         "moves": ["ironhead", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"],
         "doublesMoves": ["ironhead", "protect", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"]
     },
@@ -2326,12 +2326,12 @@
         "doublesMoves": ["ironhead", "kingsshield", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"]
     },
     "aromatisse": {
-        "level": 90,
+        "level": 91,
         "moves": ["calmmind", "moonblast", "rest", "sleeptalk", "toxic"],
         "doublesMoves": ["healpulse", "moonblast", "protect", "thunderbolt", "trickroom"]
     },
     "slurpuff": {
-        "level": 81,
+        "level": 80,
         "moves": ["bellydrum", "drainpunch", "playrough", "return"],
         "doublesMoves": ["bellydrum", "drainpunch", "playrough", "protect", "return"]
     },
@@ -2396,7 +2396,7 @@
         "doublesMoves": ["dracometeor", "dragonpulse", "fireblast", "muddywater", "powerwhip", "protect", "thunderbolt"]
     },
     "klefki": {
-        "level": 82,
+        "level": 83,
         "moves": ["dazzlinggleam", "foulplay", "magnetrise", "spikes", "thunderwave", "toxic"],
         "doublesMoves": ["dazzlinggleam", "foulplay", "lightscreen", "playrough", "protect", "reflect", "thunderwave"]
     },
@@ -2436,7 +2436,7 @@
         "doublesMoves": ["dracometeor", "flamethrower", "hurricane", "protect", "switcheroo", "tailwind", "taunt", "uturn"]
     },
     "xerneas": {
-        "level": 68,
+        "level": 67,
         "moves": ["focusblast", "geomancy", "hiddenpowerfire", "moonblast", "psyshock", "thunderbolt"],
         "doublesMoves": ["closecombat", "dazzlinggleam", "focusblast", "geomancy", "hiddenpowerfire", "protect", "psyshock", "rockslide", "thunderbolt"]
     },
@@ -2451,7 +2451,7 @@
         "doublesMoves": ["coil", "dragondance", "extremespeed", "glare", "protect", "rockslide", "stoneedge", "thousandarrows"]
     },
     "zygarde10": {
-        "level": 84,
+        "level": 83,
         "moves": ["coil", "extremespeed", "irontail", "outrage", "thousandarrows"],
         "doublesMoves": ["dragondance", "extremespeed", "irontail", "protect", "thousandarrows"]
     },
@@ -2556,7 +2556,7 @@
         "doublesMoves": ["accelerock", "drillrun", "firefang", "protect", "rockslide", "stoneedge"]
     },
     "wishiwashischool": {
-        "level": 88,
+        "level": 87,
         "moves": ["earthquake", "hiddenpowergrass", "hydropump", "icebeam", "scald"],
         "doublesMoves": ["earthquake", "endeavor", "helpinghand", "hiddenpowergrass", "hydropump", "icebeam", "protect"]
     },
@@ -2576,12 +2576,12 @@
         "doublesMoves": ["liquidation", "lunge", "protect", "stickyweb", "wideguard"]
     },
     "lurantis": {
-        "level": 90,
+        "level": 91,
         "moves": ["defog", "hiddenpowerice", "knockoff", "leafstorm", "superpower", "synthesis"],
         "doublesMoves": ["hiddenpowerice", "knockoff", "leafstorm", "protect", "superpower"]
     },
     "shiinotic": {
-        "level": 88,
+        "level": 89,
         "moves": ["gigadrain", "leechseed", "moonblast", "spore", "strengthsap"],
         "doublesMoves": ["gigadrain", "leechseed", "moonblast", "protect", "spore", "strengthsap"]
     },
@@ -2601,7 +2601,7 @@
         "doublesMoves": ["feint", "knockoff", "playrough", "powerwhip", "protect", "uturn"]
     },
     "comfey": {
-        "level": 86,
+        "level": 87,
         "moves": ["aromatherapy", "defog", "drainingkiss", "synthesis", "toxic", "uturn"],
         "doublesMoves": ["drainingkiss", "floralhealing", "taunt", "toxic", "uturn"]
     },
@@ -2631,7 +2631,7 @@
         "doublesMoves": ["counter", "helpinghand", "lightscreen", "memento", "reflect"]
     },
     "typenull": {
-        "level": 86,
+        "level": 85,
         "moves": ["rest", "return", "sleeptalk", "swordsdance", "uturn"]
     },
     "silvally": {
@@ -2725,7 +2725,7 @@
         "doublesMoves": ["flamethrower", "icebeam", "multiattack", "partingshot", "protect", "thunderbolt", "thunderwave", "uturn"]
     },
     "minior": {
-        "level": 82,
+        "level": 81,
         "moves": ["acrobatics", "earthquake", "powergem", "shellsmash"],
         "doublesMoves": ["acrobatics", "earthquake", "powergem", "protect", "shellsmash"]
     },
@@ -2745,7 +2745,7 @@
         "doublesMoves": ["encore", "fakeout", "ironhead", "nuzzle", "spikyshield", "uturn", "zingzap"]
     },
     "mimikyu": {
-        "level": 78,
+        "level": 77,
         "moves": ["playrough", "shadowclaw", "shadowsneak", "swordsdance", "taunt"],
         "doublesMoves": ["playrough", "protect", "shadowclaw", "shadowsneak", "swordsdance", "willowisp"]
     },
@@ -2755,7 +2755,7 @@
         "doublesMoves": ["aquajet", "crunch", "liquidation", "protect", "psychicfangs", "swordsdance"]
     },
     "drampa": {
-        "level": 89,
+        "level": 90,
         "moves": ["defog", "dracometeor", "dragonpulse", "fireblast", "glare", "hypervoice", "roost", "thunderbolt"],
         "doublesMoves": ["dracometeor", "dragonpulse", "fireblast", "glare", "hypervoice", "protect", "roost"]
     },
@@ -2775,7 +2775,7 @@
         "doublesMoves": ["dazzlinggleam", "hiddenpowerice", "naturesmadness", "protect", "skydrop", "taunt", "thunderbolt", "uturn"]
     },
     "tapulele": {
-        "level": 80,
+        "level": 79,
         "moves": ["calmmind", "focusblast", "hiddenpowerfire", "moonblast", "psychic", "psyshock"],
         "doublesMoves": ["dazzlinggleam", "focusblast", "moonblast", "protect", "psychic", "taunt"]
     },
@@ -2805,7 +2805,7 @@
         "doublesMoves": ["grassknot", "hiddenpowerice", "powergem", "protect", "sludgebomb", "thunderbolt"]
     },
     "buzzwole": {
-        "level": 80,
+        "level": 79,
         "moves": ["drainpunch", "earthquake", "leechlife", "poisonjab", "stoneedge", "superpower"],
         "doublesMoves": ["drainpunch", "icepunch", "leechlife", "poisonjab", "protect", "superpower"]
     },
@@ -2815,7 +2815,7 @@
         "doublesMoves": ["bugbuzz", "highjumpkick", "icebeam", "poisonjab", "protect", "speedswap", "uturn"]
     },
     "xurkitree": {
-        "level": 82,
+        "level": 81,
         "moves": ["dazzlinggleam", "electricterrain", "energyball", "hiddenpowerice", "thunderbolt", "voltswitch"],
         "doublesMoves": ["energyball", "hiddenpowerice", "hypnosis", "protect", "tailglow", "thunderbolt"]
     },
@@ -2840,12 +2840,12 @@
         "doublesMoves": ["calmmind", "earthpower", "heatwave", "moonlight", "photongeyser"]
     },
     "necrozmaduskmane": {
-        "level": 71,
+        "level": 70,
         "moves": ["autotomize", "earthquake", "knockoff", "photongeyser", "sunsteelstrike", "swordsdance"],
         "doublesMoves": ["earthquake", "knockoff", "photongeyser", "rockslide", "sunsteelstrike", "swordsdance"]
     },
     "necrozmadawnwings": {
-        "level": 73,
+        "level": 72,
         "moves": ["calmmind", "heatwave", "moongeistbeam", "photongeyser", "powergem", "trickroom"]
     },
     "magearna": {
@@ -2874,7 +2874,7 @@
         "doublesMoves": ["fireblast", "heatwave", "hiddenpowerice", "protect", "shadowball", "willowisp"]
     },
     "zeraora": {
-        "level": 81,
+        "level": 80,
         "moves": ["closecombat", "grassknot", "hiddenpowerice", "knockoff", "plasmafists", "voltswitch", "workup"],
         "doublesMoves": ["closecombat", "fakeout", "grassknot", "hiddenpowerice", "knockoff", "plasmafists", "protect", "voltswitch"]
     }

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -45,7 +45,7 @@
         ]
     },
     "wigglytuff": {
-        "level": 95,
+        "level": 96,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -195,7 +195,7 @@
         ]
     },
     "mukalola": {
-        "level": 83,
+        "level": 82,
         "sets": [
             {
                 "role": "AV Pivot",
@@ -450,7 +450,7 @@
         ]
     },
     "moltres": {
-        "level": 82,
+        "level": 81,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -575,7 +575,7 @@
         ]
     },
     "jumpluff": {
-        "level": 86,
+        "level": 87,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -755,7 +755,7 @@
         ]
     },
     "heracross": {
-        "level": 82,
+        "level": 81,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -1095,7 +1095,7 @@
         ]
     },
     "glalie": {
-        "level": 94,
+        "level": 95,
         "sets": [
             {
                 "role": "Fast Support",
@@ -1115,7 +1115,7 @@
         ]
     },
     "salamence": {
-        "level": 78,
+        "level": 77,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -1175,7 +1175,7 @@
         ]
     },
     "kricketune": {
-        "level": 97,
+        "level": 98,
         "sets": [
             {
                 "role": "Fast Support",
@@ -1235,7 +1235,7 @@
         ]
     },
     "gastrodon": {
-        "level": 84,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -1385,7 +1385,7 @@
         ]
     },
     "weavile": {
-        "level": 83,
+        "level": 82,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1395,7 +1395,7 @@
         ]
     },
     "sneasler": {
-        "level": 76,
+        "level": 75,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1450,7 +1450,7 @@
         ]
     },
     "froslass": {
-        "level": 86,
+        "level": 87,
         "sets": [
             {
                 "role": "Fast Support",
@@ -1560,7 +1560,7 @@
         ]
     },
     "dialga": {
-        "level": 75,
+        "level": 74,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -1635,7 +1635,7 @@
         ]
     },
     "giratinaorigin": {
-        "level": 74,
+        "level": 73,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1880,7 +1880,7 @@
         ]
     },
     "samurotthisui": {
-        "level": 78,
+        "level": 77,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -2028,7 +2028,7 @@
         ]
     },
     "eelektross": {
-        "level": 86,
+        "level": 87,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -2133,7 +2133,7 @@
         ]
     },
     "tornadustherian": {
-        "level": 80,
+        "level": 79,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -2488,7 +2488,7 @@
         ]
     },
     "decidueye": {
-        "level": 86,
+        "level": 87,
         "sets": [
             {
                 "role": "Fast Support",
@@ -2513,7 +2513,7 @@
         ]
     },
     "gumshoos": {
-        "level": 94,
+        "level": 95,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -2763,7 +2763,7 @@
         ]
     },
     "inteleon": {
-        "level": 82,
+        "level": 81,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3128,7 +3128,7 @@
         ]
     },
     "regieleki": {
-        "level": 77,
+        "level": 78,
         "sets": [
             {
                 "role": "Fast Support",
@@ -3183,7 +3183,7 @@
         ]
     },
     "calyrex": {
-        "level": 92,
+        "level": 93,
         "sets": [
             {
                 "role": "Bulky Support",
@@ -3463,7 +3463,7 @@
         ]
     },
     "dondozo": {
-        "level": 79,
+        "level": 78,
         "sets": [
             {
                 "role": "Bulky Setup",
@@ -3498,7 +3498,7 @@
         ]
     },
     "arboliva": {
-        "level": 89,
+        "level": 90,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -3618,7 +3618,7 @@
         ]
     },
     "tatsugiri": {
-        "level": 85,
+        "level": 86,
         "sets": [
             {
                 "role": "Fast Support",
@@ -3663,7 +3663,7 @@
         ]
     },
     "bombirdier": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -3723,7 +3723,7 @@
         ]
     },
     "klawf": {
-        "level": 89,
+        "level": 90,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -4033,7 +4033,7 @@
         ]
     },
     "ironleaves": {
-        "level": 81,
+        "level": 80,
         "sets": [
             {
                 "role": "Setup Sweeper",
@@ -4063,7 +4063,7 @@
         ]
     },
     "chienpao": {
-        "level": 73,
+        "level": 72,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -4108,7 +4108,7 @@
         ]
     },
     "miraidon": {
-        "level": 66,
+        "level": 65,
         "sets": [
             {
                 "role": "Fast Bulky Setup",
@@ -4123,7 +4123,7 @@
         ]
     },
     "tinkaton": {
-        "level": 83,
+        "level": 82,
         "sets": [
             {
                 "role": "Bulky Attacker",
@@ -4138,7 +4138,7 @@
         ]
     },
     "armarouge": {
-        "level": 82,
+        "level": 81,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -4168,7 +4168,7 @@
         ]
     },
     "kingambit": {
-        "level": 75,
+        "level": 74,
         "sets": [
             {
                 "role": "Bulky Attacker",

--- a/server/chat-plugins/randombattles/winrates.ts
+++ b/server/chat-plugins/randombattles/winrates.ts
@@ -159,7 +159,8 @@ async function collectStats(battle: RoomBattle, winner: ID, players: ID[]) {
 	if (format.mod !== `gen${Dex.gen}`) {
 		eloFloor = 1300;
 	} else if (format.gameType === 'doubles') {
-		eloFloor = 1400;
+		// may need to be raised again if doubles ladder takes off
+		eloFloor = 1300;
 	}
 	if (!formatData || battle.rated < eloFloor) return;
 	checkRollover();

--- a/server/chat-plugins/randombattles/winrates.ts
+++ b/server/chat-plugins/randombattles/winrates.ts
@@ -90,6 +90,8 @@ function getSpeciesName(set: PokemonSet, format: Format) {
 		return 'Dudunsparce';
 	} else if (species === "Maushold-Four") {
 		return 'Maushold';
+	} else if (species === "Greninja-Bond") {
+		return 'Greninja';
 	} else if (species === "Squawkabilly-Blue") {
 		return "Squawkabilly";
 	} else if (species === "Squawkabilly-White") {

--- a/server/chat-plugins/randombattles/winrates.ts
+++ b/server/chat-plugins/randombattles/winrates.ts
@@ -92,6 +92,10 @@ function getSpeciesName(set: PokemonSet, format: Format) {
 		return 'Maushold';
 	} else if (species === "Greninja-Bond") {
 		return 'Greninja';
+	} else if (species === "Keldeo-Resolute") {
+		return 'Keldeo';
+	} else if (species === "Zarude-Dada") {
+		return 'Zarude';
 	} else if (species === "Squawkabilly-Blue") {
 		return "Squawkabilly";
 	} else if (species === "Squawkabilly-White") {


### PR DESCRIPTION
Monthly balance patch for Random Battles, ideally merged before the month rolls over but I understand that may be difficult with how late I am.

Includes harmonization of Greninja formes for gathering purposes, which is needed for gen7.
Also harmonizes Keldeo(-Resolute) and Zarude(-Dada), which are new with the gathering of gen8 data.

Lowers Elo threshold for randdubs winrates because the ladder is still very low right now and we'd prefer to start balancing ASAP.