### PR TITLE
Randomized Format Spotlight: fix Sleep Clause

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1941,6 +1941,7 @@ export const Formats: FormatList = [
 
 		mod: 'randomroulette',
 		team: 'random',
+		ruleset: ['Obtainable', 'Sleep Clause Mod', 'HP Percentage Mod', 'Cancel Mod'],
 	},
 
 	// Randomized Metas


### PR DESCRIPTION
This ensures that Sleep Clause is always active in Random Roulette. 

There are some other issues with the format, but this is the most pressing currently.