### PR TITLE
Randomized Format Spotlight: fix clauses and visual bugs

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1940,7 +1940,6 @@ export const Formats: FormatList = [
 
 		mod: 'randomroulette',
 		team: 'random',
-		ruleset: ['Obtainable', 'Sleep Clause Mod', 'HP Percentage Mod', 'Cancel Mod'],
 	},
 
 	// Randomized Metas

--- a/data/mods/randomroulette/scripts.ts
+++ b/data/mods/randomroulette/scripts.ts
@@ -16,6 +16,25 @@ export const Scripts: ModdedBattleScriptsData = {
 		if (this.actions.dex.data.Scripts.actions) Object.assign(this.actions, this.actions.dex.data.Scripts.actions);
 		if (format.actions) Object.assign(this.actions, format.actions);
 
+		for (const i in this.dex.data.Scripts) {
+			const entry = this.dex.data.Scripts[i];
+			if (typeof entry === 'function') (this as any)[i] = entry;
+		}
+
+		for (const rule of this.ruleTable.keys()) {
+			if ('+*-!'.includes(rule.charAt(0))) continue;
+			const subFormat = this.dex.formats.get(rule);
+			if (subFormat.exists) {
+				const hasEventHandler = Object.keys(subFormat).some(
+					// skip event handlers that are handled elsewhere
+					val => val.startsWith('on') && ![
+						'onBegin', 'onTeamPreview', 'onBattleStart', 'onValidateRule', 'onValidateTeam', 'onChangeSet', 'onValidateSet',
+					].includes(val)
+				);
+				if (hasEventHandler) this.field.addPseudoWeather(rule);
+			}
+		}
+
 		// Generate teams using the format
 		for (const side of this.sides) {
 			this.teamGenerator.setSeed(PRNG.generateSeed());


### PR DESCRIPTION
This fixes some bugs with Random Roulette:
- Sleep and Freeze Clauses will now be applied depending on the format (specifically, Gen 1 and 2 Random Battles will now have Freeze Clause, and all formats have Sleep Clause). This replaces the emergency measure yesterday which blanket applied Sleep Clause but did not fix Freeze Clause https://github.com/smogon/pokemon-showdown/pull/9628.
- Gen 1 had some visual bugs where boosts did not appear on the Pokemon, this should fix them.

(This is ready to merge)