### PR TITLE
Random Battles: Improve ability generation

### DIFF
--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -313,21 +313,17 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			return species.types.includes('Ground');
 		case 'Overgrow':
 			return !counter.get('Grass');
+		case 'Rain Dish': case 'Swift Swim':
+			return !moves.has('raindance') && !teamDetails['rain'];
 		case 'Rock Head':
 			return !counter.get('recoil');
 		case 'Sand Veil':
 			return !teamDetails['sand'];
-		case 'Serene Grace':
-			return species.id === 'blissey';
 		case 'Soundproof': case 'Sturdy':
 			// Electrode prefers Static, and Sturdy is bad.
 			return true;
-		case 'Swift Swim':
-			return !moves.has('raindance') && !teamDetails['rain'];
 		case 'Swarm':
 			return !counter.get('Bug');
-		case 'Thick Fat':
-			return abilities.has('Immunity');
 		case 'Torrent':
 			return !counter.get('Water');
 		case 'Water Absorb':
@@ -335,6 +331,55 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		}
 
 		return false;
+	}
+
+
+	getAbility(
+		types: Set<string>,
+		moves: Set<string>,
+		abilities: Set<string>,
+		counter: MoveCounter,
+		movePool: string[],
+		teamDetails: RandomTeamsTypes.TeamDetails,
+		species: Species,
+	): string {
+		const abilityData = Array.from(abilities).map(a => this.dex.abilities.get(a));
+		Utils.sortBy(abilityData, abil => -abil.rating);
+
+		if (abilityData.length <= 1) return abilityData[0].name;
+
+		// Hard-code abilities here
+		if (species.id === 'snorlax') return 'Immunity';
+		if (species.id === 'blissey') return 'Natural Cure';
+
+		let abilityAllowed: Ability[] = [];
+		// Obtain a list of abilities that are allowed (not culled)
+		for (const ability of abilityData) {
+			if (ability.rating >= 1 && !this.shouldCullAbility(
+				ability.name, types, moves, abilities, counter, movePool, teamDetails, species
+			)) {
+				abilityAllowed.push(ability);
+			}
+		}
+
+		// If all abilities are rejected, re-allow all abilities
+		if (!abilityAllowed.length) {
+			for (const ability of abilityData) {
+				if (ability.rating > 0) abilityAllowed.push(ability);
+			}
+			if (!abilityAllowed.length) abilityAllowed = abilityData;
+		}
+
+		if (abilityAllowed.length === 1) return abilityAllowed[0].name;
+		// Sort abilities by rating with an element of randomness
+		if (abilityAllowed[0].rating <= abilityAllowed[1].rating) {
+			if (this.randomChance(1, 2)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
+		} else if (abilityAllowed[0].rating - 0.5 <= abilityAllowed[1].rating) {
+			if (this.randomChance(1, 3)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
+		}
+
+		// After sorting, choose the first ability
+		return abilityAllowed[0].name;
 	}
 
 	randomSet(species: string | Species, teamDetails: RandomTeamsTypes.TeamDetails = {}): RandomTeamsTypes.RandomSet {
@@ -507,30 +552,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			}
 		}
 
-		const abilityData = Array.from(abilities).map(a => this.dex.abilities.get(a)).filter(a => a.gen === 3);
-		Utils.sortBy(abilityData, abil => -abil.rating);
-		let ability0 = abilityData[0];
-		let ability1 = abilityData[1];
-		if (abilityData[1]) {
-			if (ability0.rating <= ability1.rating && this.randomChance(1, 2)) {
-				[ability0, ability1] = [ability1, ability0];
-			} else if (ability0.rating - 0.6 <= ability1.rating && this.randomChance(2, 3)) {
-				[ability0, ability1] = [ability1, ability0];
-			}
-			ability = ability0.name;
-
-			while (this.shouldCullAbility(ability, types, moves, abilities, counter, movePool, teamDetails, species)) {
-				if (ability === ability0.name && ability1.rating > 1) {
-					ability = ability1.name;
-				} else {
-					// Default to the highest rated ability if all are rejected
-					ability = abilityData[0].name;
-					break;
-				}
-			}
-		} else {
-			ability = abilityData[0].name;
-		}
+		ability = this.getAbility(types, moves, abilities, counter, movePool, teamDetails, species);
 
 		const item = this.getItem(ability, types, moves, counter, species);
 		const level = this.adjustLevel || data.level || (species.nfe ? 90 : 80);

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -309,8 +309,6 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			return !counter.get('inaccurate');
 		case 'Hustle':
 			return counter.get('Physical') < 2;
-		case 'Lightning Rod':
-			return species.types.includes('Ground');
 		case 'Overgrow':
 			return !counter.get('Grass');
 		case 'Rain Dish': case 'Swift Swim':
@@ -319,8 +317,8 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			return !counter.get('recoil');
 		case 'Sand Veil':
 			return !teamDetails['sand'];
-		case 'Soundproof': case 'Sturdy':
-			// Electrode prefers Static, and Sturdy is bad.
+		case 'Soundproof':
+			// Electrode prefers Static
 			return true;
 		case 'Swarm':
 			return !counter.get('Bug');

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -310,7 +310,11 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		case 'Limber':
 			return species.types.includes('Electric');
 		case 'Mold Breaker':
-			return (abilities.has('Adaptability') || moves.has('rest') && moves.has('sleeptalk'));
+			return (
+				abilities.has('Adaptability') ||
+				moves.has('rest') && moves.has('sleeptalk') ||
+				(abilities.has('Sheer Force') && !!counter.get('sheerforce'))
+			);
 		case 'Overgrow':
 			return !counter.get('Grass');
 		case 'Poison Heal':

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -349,6 +349,75 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		return false;
 	}
 
+
+	getAbility(
+		types: Set<string>,
+		moves: Set<string>,
+		abilities: Set<string>,
+		counter: MoveCounter,
+		movePool: string[],
+		teamDetails: RandomTeamsTypes.TeamDetails,
+		species: Species,
+	): string {
+		const abilityData = Array.from(abilities).map(a => this.dex.abilities.get(a));
+		Utils.sortBy(abilityData, abil => -abil.rating);
+
+		if (abilityData.length <= 1) return abilityData[0].name;
+
+		// Hard-code abilities here
+		if (abilities.has('Guts') && moves.has('facade') && (!abilities.has('Quick Feet') || !counter.setupType)) return 'Guts';
+		if (abilities.has('Prankster') && counter.get('Status') > 1) return 'Prankster';
+		if (abilities.has('Quick Feet') && moves.has('facade')) return 'Quick Feet';
+		if (abilities.has('Swift Swim') && moves.has('raindance')) return 'Swift Swim';
+		if (species.name === 'Altaria') return 'Natural Cure';
+		// Mandibuzz doesn't want Weak Armor
+		if (species.name === 'Mandibuzz') return this.sample(['Big Pecks', 'Overcoat']);
+
+		let abilityAllowed: Ability[] = [];
+		// Obtain a list of abilities that are allowed (not culled)
+		for (const ability of abilityData) {
+			if (ability.rating >= 1 && !this.shouldCullAbility(
+				ability.name, types, moves, abilities, counter, movePool, teamDetails, species
+			)) {
+				abilityAllowed.push(ability);
+			}
+		}
+
+		// If all abilities are rejected, re-allow all abilities
+		if (!abilityAllowed.length) {
+			for (const ability of abilityData) {
+				if (ability.rating > 0) abilityAllowed.push(ability);
+			}
+			if (!abilityAllowed.length) abilityAllowed = abilityData;
+		}
+
+		if (abilityAllowed.length === 1) return abilityAllowed[0].name;
+		// Sort abilities by rating with an element of randomness
+		// All three abilities can be chosen
+		if (abilityAllowed[2] && abilityAllowed[0].rating - 0.5 <= abilityAllowed[2].rating) {
+			if (abilityAllowed[1].rating <= abilityAllowed[2].rating) {
+				if (this.randomChance(1, 2)) [abilityAllowed[1], abilityAllowed[2]] = [abilityAllowed[2], abilityAllowed[1]];
+			} else {
+				if (this.randomChance(1, 3)) [abilityAllowed[1], abilityAllowed[2]] = [abilityAllowed[2], abilityAllowed[1]];
+			}
+			if (abilityAllowed[0].rating <= abilityAllowed[1].rating) {
+				if (this.randomChance(2, 3)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
+			} else {
+				if (this.randomChance(1, 2)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
+			}
+		} else {
+			// Third ability cannot be chosen
+			if (abilityAllowed[0].rating <= abilityAllowed[1].rating) {
+				if (this.randomChance(1, 2)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
+			} else if (abilityAllowed[0].rating - 0.5 <= abilityAllowed[1].rating) {
+				if (this.randomChance(1, 3)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
+			}
+		}
+
+		// After sorting, choose the first ability
+		return abilityAllowed[0].name;
+	}
+
 	getHighPriorityItem(
 		ability: string,
 		types: Set<string>,
@@ -701,49 +770,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			}
 		}
 
-
-		const abilityData = Array.from(abilities).map(a => this.dex.abilities.get(a));
-		Utils.sortBy(abilityData, abil => -abil.rating);
-
-		if (abilityData.length > 1) {
-			// Sort abilities by rating with an element of randomness
-			if (abilityData[2] && abilityData[1].rating <= abilityData[2].rating && this.randomChance(1, 2)) {
-				[abilityData[1], abilityData[2]] = [abilityData[2], abilityData[1]];
-			}
-			if (abilityData[0].rating <= abilityData[1].rating) {
-				if (this.randomChance(1, 2)) [abilityData[0], abilityData[1]] = [abilityData[1], abilityData[0]];
-			} else if (abilityData[0].rating - 0.6 <= abilityData[1].rating) {
-				if (this.randomChance(2, 3)) [abilityData[0], abilityData[1]] = [abilityData[1], abilityData[0]];
-			}
-
-			// Start with the first abiility and work our way through, culling as we go
-			ability = abilityData[0].name;
-
-
-			while (this.shouldCullAbility(ability, types, moves, abilities, counter, movePool, teamDetails, species)) {
-				if (ability === abilityData[0].name && abilityData[1].rating >= 1) {
-					ability = abilityData[1].name;
-				} else if (ability === abilityData[1].name && abilityData[2] && abilityData[2].rating >= 1) {
-					ability = abilityData[2].name;
-				} else {
-					ability = abilityData[0].name;
-					break;
-				}
-			}
-
-			if (abilities.has('Guts') && moves.has('facade') && (ability !== 'Quick Feet' || !counter.setupType)) {
-				ability = 'Guts';
-			} else if (abilities.has('Prankster') && counter.get('Status') > 1) {
-				ability = 'Prankster';
-			} else if (abilities.has('Quick Feet') && moves.has('facade')) {
-				ability = 'Quick Feet';
-			} else if (abilities.has('Swift Swim') && moves.has('raindance')) {
-				ability = 'Swift Swim';
-			}
-			if (species.name === 'Altaria') ability = 'Natural Cure';
-		} else {
-			ability = abilityData[0].name;
-		}
+		ability = this.getAbility(types, moves, abilities, counter, movePool, teamDetails, species);
 
 		let item = this.getHighPriorityItem(ability, types, moves, counter, teamDetails, species, isLead);
 		if (item === undefined) {

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -284,7 +284,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		case 'Analytic': case 'Download': case 'Hyper Cutter':
 			return species.nfe;
 		case 'Chlorophyll': case 'Solar Power':
-			return (!moves.has('sunnyday') && !teamDetails.sun);
+			return (abilities.has('Harvest') || (!moves.has('sunnyday') && !teamDetails.sun));
 		case 'Compound Eyes': case 'No Guard':
 			return !counter.get('inaccurate');
 		case 'Contrary': case 'Iron Fist': case 'Skill Link':

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -279,8 +279,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		species: Species
 	): boolean {
 		switch (ability) {
-		case 'Anger Point': case 'Gluttony': case 'Keen Eye': case 'Moody':
-		case 'Sand Veil': case 'Snow Cloak': case 'Steadfast': case 'Weak Armor':
+		case 'Anger Point': case 'Gluttony': case 'Moody': case 'Sand Veil': case 'Snow Cloak': case 'Steadfast':
 			return true;
 		case 'Analytic': case 'Download': case 'Hyper Cutter':
 			return species.nfe;

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -531,7 +531,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			return species.nfe;
 		case 'Battle Armor': case 'Sturdy':
 			return (!!counter.get('recoil') && !counter.get('recovery'));
-		case 'Chlorophyll': case 'Leaf Guard':
+		case 'Chlorophyll':
 			return (
 				species.baseStats.spe > 100 ||
 				abilities.has('Harvest') ||
@@ -622,8 +622,6 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			return (!!species.isMega || abilities.has('Prankster') || !counter.setupType && !moves.has('acrobatics'));
 		case 'Water Absorb':
 			return (moves.has('raindance') || ['Drizzle', 'Unaware', 'Volt Absorb'].some(a => abilities.has(a)));
-		case 'Weak Armor':
-			return counter.setupType !== 'Physical';
 		}
 
 		return false;

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -598,7 +598,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		case 'Simple':
 			return (!counter.setupType && !moves.has('flamecharge'));
 		case 'Solar Power':
-			return (!counter.get('Special') || !teamDetails.sun || !!species.isMega);
+			return (!counter.get('Special') || abilities.has('Harvest') || !teamDetails.sun || !!species.isMega);
 		case 'Speed Boost':
 			return moves.has('uturn');
 		case 'Swarm':

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -629,6 +629,83 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		return false;
 	}
 
+
+	getAbility(
+		types: Set<string>,
+		moves: Set<string>,
+		abilities: Set<string>,
+		counter: MoveCounter,
+		movePool: string[],
+		teamDetails: RandomTeamsTypes.TeamDetails,
+		species: Species,
+	): string {
+		if (species.battleOnly && !species.requiredAbility) {
+			abilities = new Set(Object.values(this.dex.species.get(species.battleOnly as string).abilities));
+		}
+		const abilityData = Array.from(abilities).map(a => this.dex.abilities.get(a));
+		Utils.sortBy(abilityData, abil => -abil.rating);
+
+		if (abilityData.length <= 1) return abilityData[0].name;
+
+		// Hard-code abilities here
+		if (
+			abilities.has('Guts') &&
+			!abilities.has('Quick Feet') &&
+			(moves.has('facade') || moves.has('protect') || (moves.has('rest') && moves.has('sleeptalk')))
+		) return 'Guts';
+		if (abilities.has('Moxie') && counter.get('Physical') > 3) return 'Moxie';
+		if (species.name === 'Ambipom' && !counter.get('technician')) {
+			// If it doesn't qualify for Technician, Skill Link is useless on it
+			return 'Pickup';
+		}
+		if (species.name === 'Lopunny' && moves.has('switcheroo') && this.randomChance(2, 3)) return 'Klutz';
+		if (species.baseSpecies === 'Altaria') return 'Natural Cure';
+
+		let abilityAllowed: Ability[] = [];
+		// Obtain a list of abilities that are allowed (not culled)
+		for (const ability of abilityData) {
+			if (ability.rating >= 1 && !this.shouldCullAbility(
+				ability.name, types, moves, abilities, counter, movePool, teamDetails, species
+			)) {
+				abilityAllowed.push(ability);
+			}
+		}
+
+		// If all abilities are rejected, re-allow all abilities
+		if (!abilityAllowed.length) {
+			for (const ability of abilityData) {
+				if (ability.rating > 0) abilityAllowed.push(ability);
+			}
+			if (!abilityAllowed.length) abilityAllowed = abilityData;
+		}
+
+		if (abilityAllowed.length === 1) return abilityAllowed[0].name;
+		// Sort abilities by rating with an element of randomness
+		// All three abilities can be chosen
+		if (abilityAllowed[2] && abilityAllowed[0].rating - 0.5 <= abilityAllowed[2].rating) {
+			if (abilityAllowed[1].rating <= abilityAllowed[2].rating) {
+				if (this.randomChance(1, 2)) [abilityAllowed[1], abilityAllowed[2]] = [abilityAllowed[2], abilityAllowed[1]];
+			} else {
+				if (this.randomChance(1, 3)) [abilityAllowed[1], abilityAllowed[2]] = [abilityAllowed[2], abilityAllowed[1]];
+			}
+			if (abilityAllowed[0].rating <= abilityAllowed[1].rating) {
+				if (this.randomChance(2, 3)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
+			} else {
+				if (this.randomChance(1, 2)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
+			}
+		} else {
+			// Third ability cannot be chosen
+			if (abilityAllowed[0].rating <= abilityAllowed[1].rating) {
+				if (this.randomChance(1, 2)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
+			} else if (abilityAllowed[0].rating - 0.5 <= abilityAllowed[1].rating) {
+				if (this.randomChance(1, 3)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
+			}
+		}
+
+		// After sorting, choose the first ability
+		return abilityAllowed[0].name;
+	}
+
 	getHighPriorityItem(
 		ability: string,
 		types: Set<string>,
@@ -1064,54 +1141,8 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (species.battleOnly && !species.requiredAbility) {
 			abilities = new Set(Object.values(this.dex.species.get(species.battleOnly as string).abilities));
 		}
-		const abilityData = [...abilities].map(a => this.dex.abilities.get(a));
-		Utils.sortBy(abilityData, abil => -abil.rating);
 
-		if (abilityData.length > 1) {
-			// Sort abilities by rating with an element of randomness
-			if (abilityData[2] && abilityData[1].rating <= abilityData[2].rating && this.randomChance(1, 2)) {
-				[abilityData[1], abilityData[2]] = [abilityData[2], abilityData[1]];
-			}
-			if (abilityData[0].rating <= abilityData[1].rating && this.randomChance(1, 2)) {
-				[abilityData[0], abilityData[1]] = [abilityData[1], abilityData[0]];
-			} else if (abilityData[0].rating - 0.6 <= abilityData[1].rating && this.randomChance(2, 3)) {
-				[abilityData[0], abilityData[1]] = [abilityData[1], abilityData[0]];
-			}
-
-			// Start with the first abiility and work our way through, culling as we go
-			ability = abilityData[0].name;
-
-			while (this.shouldCullAbility(ability, types, moves, abilities, counter, movePool, teamDetails, species)) {
-				if (ability === abilityData[0].name && abilityData[1].rating >= 1) {
-					ability = abilityData[1].name;
-				} else if (ability === abilityData[1].name && abilityData[2] && abilityData[2].rating >= 1) {
-					ability = abilityData[2].name;
-				} else {
-					// Default to the highest rated ability if all are rejected
-					ability = abilityData[0].name;
-					break;
-				}
-			}
-
-			if (
-				abilities.has('Guts') &&
-				ability !== 'Quick Feet' &&
-				(moves.has('facade') || moves.has('protect') || (moves.has('rest') && moves.has('sleeptalk')))
-			) {
-				ability = 'Guts';
-			} else if (abilities.has('Moxie') && counter.get('Physical') > 3) {
-				ability = 'Moxie';
-			}
-			if (species.name === 'Ambipom' && !counter.get('technician')) {
-				// If it doesn't qualify for Technician, Skill Link is useless on it
-				ability = 'Pickup';
-			} else if (species.name === 'Lopunny' && moves.has('switcheroo') && this.randomChance(2, 3)) {
-				ability = 'Klutz';
-			}
-			if (species.name === 'Altaria') ability = 'Natural Cure';
-		} else {
-			ability = abilityData[0].name;
-		}
+		ability = this.getAbility(types, moves, abilities, counter, movePool, teamDetails, species);
 
 		let item = this.getHighPriorityItem(ability, types, moves, counter, teamDetails, species, isLead);
 		if (item === undefined) item = this.getMediumPriorityItem(ability, moves, counter, species, false, isLead);

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -693,7 +693,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		case 'Simple':
 			return (!counter.setupType && !moves.has('flamecharge'));
 		case 'Solar Power':
-			return (!counter.get('Special') || !teamDetails.sun || !!species.isMega);
+			return (!counter.get('Special') || abilities.has('Harvest') || !teamDetails.sun || !!species.isMega);
 		case 'Swarm':
 			return (!counter.get('Bug') || !!species.isMega);
 		case 'Sweet Veil':

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -722,6 +722,91 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		return false;
 	}
 
+
+	getAbility(
+		types: Set<string>,
+		moves: Set<string>,
+		abilities: Set<string>,
+		counter: MoveCounter,
+		movePool: string[],
+		teamDetails: RandomTeamsTypes.TeamDetails,
+		species: Species,
+		isDoubles: boolean,
+	): string {
+		if (species.battleOnly && !species.requiredAbility) {
+			abilities = new Set(Object.values(this.dex.species.get(species.battleOnly as string).abilities));
+		}
+		const abilityData = Array.from(abilities).map(a => this.dex.abilities.get(a));
+		Utils.sortBy(abilityData, abil => -abil.rating);
+
+		if (abilityData.length <= 1) return abilityData[0].name;
+
+		// Hard-code abilities here
+		if (
+			abilities.has('Guts') &&
+			!abilities.has('Quick Feet') &&
+			(moves.has('facade') || (moves.has('protect') && !isDoubles) || (moves.has('sleeptalk') && moves.has('rest')))
+		) return 'Guts';
+		if (abilities.has('Moxie') && (counter.get('Physical') > 3 || moves.has('bounce')) && !isDoubles) return 'Moxie';
+		if (isDoubles) {
+			if (abilities.has('Intimidate') && !(species.battleOnly)) return 'Intimidate';
+			if (abilities.has('Guts')) return 'Guts';
+			if (abilities.has('Storm Drain')) return 'Storm Drain';
+			if (abilities.has('Harvest')) return 'Harvest';
+			if (abilities.has('Unburden') && !abilities.has('Prankster') && !species.isMega) return 'Unburden';
+		}
+		if (species.name === 'Ambipom' && !counter.get('technician')) {
+			// If it doesn't qualify for Technician, Skill Link is useless on it
+			return 'Pickup';
+		}
+		if (species.name === 'Raticate-Alola') return 'Hustle';
+		if (species.baseSpecies === 'Altaria') return 'Natural Cure';
+
+		let abilityAllowed: Ability[] = [];
+		// Obtain a list of abilities that are allowed (not culled)
+		for (const ability of abilityData) {
+			if (ability.rating >= 1 && !this.shouldCullAbility(
+				ability.name, types, moves, abilities, counter, movePool, teamDetails, species, isDoubles
+			)) {
+				abilityAllowed.push(ability);
+			}
+		}
+
+		// If all abilities are rejected, re-allow all abilities
+		if (!abilityAllowed.length) {
+			for (const ability of abilityData) {
+				if (ability.rating > 0) abilityAllowed.push(ability);
+			}
+			if (!abilityAllowed.length) abilityAllowed = abilityData;
+		}
+
+		if (abilityAllowed.length === 1) return abilityAllowed[0].name;
+		// Sort abilities by rating with an element of randomness
+		// All three abilities can be chosen
+		if (abilityAllowed[2] && abilityAllowed[0].rating - 0.5 <= abilityAllowed[2].rating) {
+			if (abilityAllowed[1].rating <= abilityAllowed[2].rating) {
+				if (this.randomChance(1, 2)) [abilityAllowed[1], abilityAllowed[2]] = [abilityAllowed[2], abilityAllowed[1]];
+			} else {
+				if (this.randomChance(1, 3)) [abilityAllowed[1], abilityAllowed[2]] = [abilityAllowed[2], abilityAllowed[1]];
+			}
+			if (abilityAllowed[0].rating <= abilityAllowed[1].rating) {
+				if (this.randomChance(2, 3)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
+			} else {
+				if (this.randomChance(1, 2)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
+			}
+		} else {
+			// Third ability cannot be chosen
+			if (abilityAllowed[0].rating <= abilityAllowed[1].rating) {
+				if (this.randomChance(1, 2)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
+			} else if (abilityAllowed[0].rating - 0.5 <= abilityAllowed[1].rating) {
+				if (this.randomChance(1, 3)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
+			}
+		}
+
+		// After sorting, choose the first ability
+		return abilityAllowed[0].name;
+	}
+
 	getHighPriorityItem(
 		ability: string,
 		types: Set<string>,
@@ -1294,59 +1379,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		const battleOnly = species.battleOnly && !species.requiredAbility;
 		const baseSpecies: Species = battleOnly ? this.dex.species.get(species.battleOnly as string) : species;
 
-		const abilityData = Object.values(baseSpecies.abilities).map(a => this.dex.abilities.get(a));
-		Utils.sortBy(abilityData, abil => -abil.rating);
-
-		if (abilityData[1]) {
-			// Sort abilities by rating with an element of randomness
-			if (abilityData[2] && abilityData[1].rating <= abilityData[2].rating && this.randomChance(1, 2)) {
-				[abilityData[1], abilityData[2]] = [abilityData[2], abilityData[1]];
-			}
-			if (abilityData[0].rating <= abilityData[1].rating && this.randomChance(1, 2)) {
-				[abilityData[0], abilityData[1]] = [abilityData[1], abilityData[0]];
-			} else if (abilityData[0].rating - 0.6 <= abilityData[1].rating && this.randomChance(2, 3)) {
-				[abilityData[0], abilityData[1]] = [abilityData[1], abilityData[0]];
-			}
-			ability = abilityData[0].name;
-
-			while (this.shouldCullAbility(
-				ability, types, moves, abilities, counter, movePool, teamDetails, species, isDoubles
-			)) {
-				if (ability === abilityData[0].name && abilityData[1].rating >= 1) {
-					ability = abilityData[1].name;
-				} else if (ability === abilityData[1].name && abilityData[2] && abilityData[2].rating >= 1) {
-					ability = abilityData[2].name;
-				} else {
-					// Default to the highest rated ability if all are rejected
-					ability = abilityData[0].name;
-					break;
-				}
-			}
-
-			if (
-				abilities.has('Guts') &&
-				ability !== 'Quick Feet' &&
-				(moves.has('facade') || (moves.has('protect') && !isDoubles) || (moves.has('sleeptalk') && moves.has('rest')))
-			) {
-				ability = 'Guts';
-			} else if (abilities.has('Moxie') && (counter.get('Physical') > 3 || moves.has('bounce')) && !isDoubles) {
-				ability = 'Moxie';
-			} else if (isDoubles) {
-				if (abilities.has('Intimidate') && !battleOnly) ability = 'Intimidate';
-				if (abilities.has('Guts') && ability !== 'Intimidate') ability = 'Guts';
-				if (abilities.has('Storm Drain')) ability = 'Storm Drain';
-				if (abilities.has('Harvest')) ability = 'Harvest';
-				if (abilities.has('Unburden') && ability !== 'Prankster' && !species.isMega) ability = 'Unburden';
-			}
-			if (species.name === 'Ambipom' && !counter.get('technician')) {
-				// If it doesn't qualify for Technician, Skill Link is useless on it
-				ability = 'Pickup';
-			}
-			if (species.name === 'Raticate-Alola') ability = 'Hustle';
-			if (species.name === 'Altaria') ability = 'Natural Cure';
-		} else {
-			ability = abilityData[0].name;
-		}
+		ability = this.getAbility(types, moves, abilities, counter, movePool, teamDetails, species, isDoubles);
 
 		if (species.name === 'Genesect' && moves.has('technoblast')) forme = 'Genesect-Douse';
 

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -614,7 +614,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			return species.nfe;
 		case 'Battle Armor': case 'Sturdy':
 			return (!!counter.get('recoil') && !counter.get('recovery'));
-		case 'Chlorophyll': case 'Leaf Guard':
+		case 'Chlorophyll':
 			return (
 				species.baseStats.spe > 100 ||
 				abilities.has('Harvest') ||

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -749,7 +749,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		) return 'Guts';
 		if (abilities.has('Moxie') && (counter.get('Physical') > 3 || moves.has('bounce')) && !isDoubles) return 'Moxie';
 		if (isDoubles) {
-			if (abilities.has('Intimidate') && !species.battleOnly) return 'Intimidate';
+			if (abilities.has('Intimidate')) return 'Intimidate';
 			if (abilities.has('Guts')) return 'Guts';
 			if (abilities.has('Storm Drain')) return 'Storm Drain';
 			if (abilities.has('Harvest')) return 'Harvest';

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -749,7 +749,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		) return 'Guts';
 		if (abilities.has('Moxie') && (counter.get('Physical') > 3 || moves.has('bounce')) && !isDoubles) return 'Moxie';
 		if (isDoubles) {
-			if (abilities.has('Intimidate') && !(species.battleOnly)) return 'Intimidate';
+			if (abilities.has('Intimidate') && !species.battleOnly) return 'Intimidate';
 			if (abilities.has('Guts')) return 'Guts';
 			if (abilities.has('Storm Drain')) return 'Storm Drain';
 			if (abilities.has('Harvest')) return 'Harvest';

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -1681,6 +1681,101 @@ export class RandomGen8Teams {
 		return false;
 	}
 
+
+	getAbility(
+		types: Set<string>,
+		moves: Set<string>,
+		abilities: Set<string>,
+		counter: MoveCounter,
+		movePool: string[],
+		teamDetails: RandomTeamsTypes.TeamDetails,
+		species: Species,
+		isDoubles: boolean,
+		isNoDynamax: boolean
+	): string {
+		const abilityData = Array.from(abilities).map(a => this.dex.abilities.get(a));
+		Utils.sortBy(abilityData, abil => -abil.rating);
+
+		if (abilityData.length <= 1) return abilityData[0].name;
+
+		// Hard-code abilities here
+
+		// Lopunny, and other Facade users, don't want Limber, even if other abilities are poorly rated,
+		// since paralysis would arguably be good for them.
+		if (species.id === 'lopunny' && moves.has('facade')) return 'Cute Charm';
+		if (species.id === 'copperajahgmax') return 'Heavy Metal';
+		if (abilities.has('Guts') &&
+			// for Ursaring in BDSP
+			!abilities.has('Quick Feet') && (
+			species.id === 'gurdurr' || species.id === 'throh' ||
+			moves.has('facade') || (moves.has('rest') && moves.has('sleeptalk'))
+		)) return 'Guts';
+		if (abilities.has('Moxie') && (counter.get('Physical') > 3 || moves.has('bounce')) && !isDoubles) return 'Moxie';
+
+		if (isDoubles) {
+			if (abilities.has('Competitive') && !abilities.has('Shadow Tag') && !abilities.has('Strong Jaw')) return 'Competitive';
+			if (abilities.has('Friend Guard')) return 'Friend Guard';
+			if (abilities.has('Gluttony') && moves.has('recycle')) return 'Gluttony';
+			if (abilities.has('Guts')) return 'Guts';
+			if (abilities.has('Harvest')) return 'Harvest';
+			if (abilities.has('Healer') && (
+				abilities.has('Natural Cure') ||
+				(abilities.has('Aroma Veil') && this.randomChance(1, 2))
+			)) return 'Healer';
+			if (abilities.has('Intimidate')) return 'Intimidate';
+			if (species.id === 'lopunny') return 'Klutz';
+			if (abilities.has('Magic Guard') && !abilities.has('Unaware')) return 'Magic Guard';
+			if (abilities.has('Ripen')) return 'Ripen';
+			if (abilities.has('Stalwart')) return 'Stalwart';
+			if (abilities.has('Storm Drain')) return 'Storm Drain';
+			if (abilities.has('Telepathy') && (abilities.has('Pressure') || abilities.has('Analytic'))) return 'Telepathy';
+		}
+
+		let abilityAllowed: Ability[] = [];
+		// Obtain a list of abilities that are allowed (not culled)
+		for (const ability of abilityData) {
+			if (ability.rating >= 1 && !this.shouldCullAbility(
+				ability.name, types, moves, abilities, counter, movePool, teamDetails, species, isDoubles, isNoDynamax
+			)) {
+				abilityAllowed.push(ability);
+			}
+		}
+
+		// If all abilities are rejected, re-allow all abilities
+		if (!abilityAllowed.length) {
+			for (const ability of abilityData) {
+				if (ability.rating > 0) abilityAllowed.push(ability);
+			}
+			if (!abilityAllowed.length) abilityAllowed = abilityData;
+		}
+
+		if (abilityAllowed.length === 1) return abilityAllowed[0].name;
+		// Sort abilities by rating with an element of randomness
+		// All three abilities can be chosen
+		if (abilityAllowed[2] && abilityAllowed[0].rating - 0.5 <= abilityAllowed[2].rating) {
+			if (abilityAllowed[1].rating <= abilityAllowed[2].rating) {
+				if (this.randomChance(1, 2)) [abilityAllowed[1], abilityAllowed[2]] = [abilityAllowed[2], abilityAllowed[1]];
+			} else {
+				if (this.randomChance(1, 3)) [abilityAllowed[1], abilityAllowed[2]] = [abilityAllowed[2], abilityAllowed[1]];
+			}
+			if (abilityAllowed[0].rating <= abilityAllowed[1].rating) {
+				if (this.randomChance(2, 3)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
+			} else {
+				if (this.randomChance(1, 2)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
+			}
+		} else {
+			// Third ability cannot be chosen
+			if (abilityAllowed[0].rating <= abilityAllowed[1].rating) {
+				if (this.randomChance(1, 2)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
+			} else if (abilityAllowed[0].rating - 0.5 <= abilityAllowed[1].rating) {
+				if (this.randomChance(1, 3)) [abilityAllowed[0], abilityAllowed[1]] = [abilityAllowed[1], abilityAllowed[0]];
+			}
+		}
+
+		// After sorting, choose the first ability
+		return abilityAllowed[0].name;
+	}
+
 	getHighPriorityItem(
 		ability: string,
 		types: Set<string>,
@@ -2233,78 +2328,7 @@ export class RandomGen8Teams {
 			}
 		}
 
-		const abilityData = Array.from(abilities).map(a => this.dex.abilities.get(a));
-		Utils.sortBy(abilityData, abil => -abil.rating);
-
-		if (abilityData[1]) {
-			// Sort abilities by rating with an element of randomness
-			if (abilityData[2] && abilityData[1].rating <= abilityData[2].rating && this.randomChance(1, 2)) {
-				[abilityData[1], abilityData[2]] = [abilityData[2], abilityData[1]];
-			}
-			if (abilityData[0].rating <= abilityData[1].rating) {
-				if (this.randomChance(1, 2)) [abilityData[0], abilityData[1]] = [abilityData[1], abilityData[0]];
-			} else if (abilityData[0].rating - 0.6 <= abilityData[1].rating) {
-				if (this.randomChance(2, 3)) [abilityData[0], abilityData[1]] = [abilityData[1], abilityData[0]];
-			}
-
-			// Start with the first abiility and work our way through, culling as we go
-			ability = abilityData[0].name;
-			let rejectAbility = false;
-			do {
-				rejectAbility = this.shouldCullAbility(
-					ability, types, moves, abilities, counter, movePool, teamDetails, species, isDoubles, isNoDynamax
-				);
-
-				if (rejectAbility) {
-					// Lopunny, and other Facade users, don't want Limber, even if other abilities are poorly rated,
-					// since paralysis would arguably be good for them.
-					const limberFacade = moves.has('facade') && ability === 'Limber';
-
-					if (ability === abilityData[0].name && (abilityData[1].rating >= 1 || limberFacade)) {
-						ability = abilityData[1].name;
-					} else if (ability === abilityData[1].name && abilityData[2] && (abilityData[2].rating >= 1 || limberFacade)) {
-						ability = abilityData[2].name;
-					} else {
-						// Default to the highest rated ability if all are rejected
-						ability = abilityData[0].name;
-						rejectAbility = false;
-					}
-				}
-			} while (rejectAbility);
-
-			// Hardcoded abilities for certain contexts
-			if (forme === 'Copperajah' && gmax) {
-				ability = 'Heavy Metal';
-			} else if (abilities.has('Guts') &&
-				// for Ursaring in BDSP
-				!abilities.has('Quick Feet') && (
-				species.id === 'gurdurr' || species.id === 'throh' ||
-				moves.has('facade') || (moves.has('rest') && moves.has('sleeptalk'))
-			)) {
-				ability = 'Guts';
-			} else if (abilities.has('Moxie') && (counter.get('Physical') > 3 || moves.has('bounce')) && !isDoubles) {
-				ability = 'Moxie';
-			} else if (isDoubles) {
-				if (abilities.has('Competitive') && ability !== 'Shadow Tag' && ability !== 'Strong Jaw') ability = 'Competitive';
-				if (abilities.has('Friend Guard')) ability = 'Friend Guard';
-				if (abilities.has('Gluttony') && moves.has('recycle')) ability = 'Gluttony';
-				if (abilities.has('Guts')) ability = 'Guts';
-				if (abilities.has('Harvest')) ability = 'Harvest';
-				if (abilities.has('Healer') && (
-					abilities.has('Natural Cure') ||
-					(abilities.has('Aroma Veil') && this.randomChance(1, 2))
-				)) ability = 'Healer';
-				if (abilities.has('Intimidate')) ability = 'Intimidate';
-				if (abilities.has('Klutz') && ability === 'Limber') ability = 'Klutz';
-				if (abilities.has('Magic Guard') && ability !== 'Friend Guard' && ability !== 'Unaware') ability = 'Magic Guard';
-				if (abilities.has('Ripen')) ability = 'Ripen';
-				if (abilities.has('Stalwart')) ability = 'Stalwart';
-				if (abilities.has('Storm Drain')) ability = 'Storm Drain';
-				if (abilities.has('Telepathy') && (ability === 'Pressure' || abilities.has('Analytic'))) ability = 'Telepathy';
-			}
-		} else {
-			ability = abilityData[0].name;
-		}
+		ability = this.getAbility(types, moves, abilities, counter, movePool, teamDetails, species, isDoubles, isNoDynamax);
 
 		if (species.requiredItems) {
 			item = this.sample(species.requiredItems);

--- a/data/mods/gen8bdsp/random-teams.ts
+++ b/data/mods/gen8bdsp/random-teams.ts
@@ -623,6 +623,8 @@ export class RandomBDSPTeams extends RandomGen8Teams {
 			return (species.id === 'omastar' && (moves.has('spikes') || moves.has('stealthrock')));
 		case 'Sniper':
 			return counter.get('Water') > 1 && !moves.has('focusenergy');
+		case 'Solar Power':
+			return (!teamDetails.sun || abilities.has('Harvest'));
 		case 'Speed Boost':
 			return moves.has('uturn');
 		case 'Sturdy':

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1149,8 +1149,13 @@ export class RandomTeams {
 			}
 		}
 
-		// If all abilities are culled, re-allow all
-		if (!abilityAllowed.length) abilityAllowed = abilityData;
+		// If all abilities are rejected, re-allow all abilities
+		if (!abilityAllowed.length) {
+			for (const ability of abilityData) {
+				if (ability.rating > 0) abilityAllowed.push(ability);
+			}
+			if (!abilityAllowed.length) abilityAllowed = abilityData;
+		}
 
 		if (abilityAllowed.length === 1) return abilityAllowed[0].name;
 		// Sort abilities by rating with an element of randomness


### PR DESCRIPTION
This update improves and fixes some bugs with ability generation in Random Battles:
- In Gen 9, abilities rated 0 can no longer be randomly selected over abilities rated 0.5. This currently has no effect on functionality; it is for future-proofing and code accuracy.
- In Gens 3-8, this fixes a bug where higher rated abilities are sometimes generated less commonly than lower rated abilities. Now, higher rated abilities will be preferred by default. 
- In Gens 3-8, ability generation has been refactored into a `getAbility()` function to improve code readability. Some unnecessary ability rejections have been removed. This has no effect on functionality.

The update also makes some minor ability adjustments, outlined below:
- In Gens 3-4, Ludicolo will get Swift Swim rather than Rain Dish on sets without Rain Dance
- In Gen 4, Jynx will always get Forewarn, since Oblivious is useless on Jynx
- In Gen 5, Mandibuzz will never get Weak Armor since it is deemed to be a detrimental ability
- In Gen 5, Sheer Force will be chosen over Mold Breaker if it has a move boosted by Sheer Force
- In Gens 5-7, Tropius will always get Harvest with sun support.