### PR TITLE
Helptickets: Add /ticketban and /unticketban

### DIFF
--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -2992,7 +2992,7 @@ export const commands: Chat.ChatCommands = {
 			`/helpticket public [user], [date] - Makes the ticket logs for the [user] on the [date] public to staff. Requires: &`,
 		],
 	},
-	
+
 	tb: 'ticketban',
 	unticketban: 'ticketban',
 	ticketban(target, room, user, connection, cmd) {

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -2992,13 +2992,13 @@ export const commands: Chat.ChatCommands = {
 			`/helpticket public [user], [date] - Makes the ticket logs for the [user] on the [date] public to staff. Requires: &`,
 		],
 	},
-
+	
 	tb: 'ticketban',
 	unticketban: 'ticketban',
 	ticketban(target, room, user, connection, cmd) {
 		return this.parse(`/helpticket ${cmd} ${target}`);
 	},
-	
+
 	helptickethelp: [
 		`/helpticket create - Creates a new ticket, requesting help from global staff.`,
 		`/helpticket list - Lists all tickets. Requires: % @ &`,

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -2994,12 +2994,9 @@ export const commands: Chat.ChatCommands = {
 	},
 
 	tb: 'ticketban',
-	ticketban(target, room, user) {
-		return this.parse(`/helpticket ban ${target}`);
-	},
-
-	unticketban(target, room, user) {
-		return this.parse(`/helpticket unban ${target}`);
+	unticketban: 'ticketban',
+	ticketban(target, room, user, connection, cmd) {
+		return this.parse(`/helpticket ${cmd} ${target}`);
 	},
 	
 	helptickethelp: [

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -2992,6 +2992,16 @@ export const commands: Chat.ChatCommands = {
 			`/helpticket public [user], [date] - Makes the ticket logs for the [user] on the [date] public to staff. Requires: &`,
 		],
 	},
+
+	tb: 'ticketban',
+	ticketban(target, room, user) {
+		return this.parse(`/helpticket ban ${target}`);
+	},
+
+	unticketban(target, room, user) {
+		return this.parse(`/helpticket unban ${target}`);
+	},
+	
 	helptickethelp: [
 		`/helpticket create - Creates a new ticket, requesting help from global staff.`,
 		`/helpticket list - Lists all tickets. Requires: % @ &`,


### PR DESCRIPTION
Add ```/ticketban``` and ```/unticketban``` as an alias of``` /helpticket ban``` and ```/helpticket unban``` respectively.   

This was [suggested by Kennedy around a month ago](https://www.smogon.com/forums/threads/staff-suggestions-bugs.3514540/post-9649827) and it seemed like a fairly popular one since a number of staff members have mentioned that they have used ```/ticketban``` in place of ```/helpticket``` ban before. It would be convenient to have these aliases.