### PR TITLE
Gen4: Brick break now breaks reflect when hitting ghosts

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -1830,6 +1830,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 			pokemon.side.removeSideCondition('lightscreen');
 			pokemon.side.removeSideCondition('auroraveil');
 		},
+		onAfterMove(source, target, move) {
+			if (this.gen === 4) { // In gen 4, brick break removes screens even on inmunity
+				target.side.removeSideCondition('reflect');
+				target.side.removeSideCondition('lightscreen');
+			}
+		},
 		secondary: null,
 		target: "normal",
 		type: "Fighting",

--- a/test/sim/moves/brickbreak.js
+++ b/test/sim/moves/brickbreak.js
@@ -38,7 +38,7 @@ describe('Brick Break', function () {
 		assert(battle.p2.sideConditions['reflect']);
 	});
 
-	it.skip('should break Reflect when used against a Ghost-type in Gen 4 or earlier', function () {
+	it('should break Reflect when used against a Ghost-type in Gen 4 or earlier', function () {
 		battle = common.gen(4).createBattle([[
 			{species: "mew", moves: ['brickbreak', 'splash']},
 		], [


### PR DESCRIPTION
https://github.com/smogon/pokemon-showdown/projects/3#card-61615516

This fix is a bit awkward, but I couldn't find any weird side effects. It's the same way Order Up worked before #9429 
