### PR TITLE
Gen 9 randomized format set updates

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -1415,7 +1415,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (move?.type === 'Flying' && pokemon.hp === pokemon.maxhp) return priority + 1;
 		},
 		name: "Gale Wings",
-		rating: 2.5,
+		rating: 1.5,
 		num: 177,
 	},
 	galvanize: {

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -2073,7 +2073,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Calm Mind", "Focus Blast", "Hyper Voice", "Protect", "Psychic", "U-turn"],
-                "teraTypes": ["Dark", "Normal", "Psychic"]
+                "teraTypes": ["Fighting", "Normal", "Psychic"]
             },
             {
                 "role": "Tera Blast user",

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -246,6 +246,11 @@
                 "role": "Doubles Support",
                 "movepool": ["Foul Play", "Helping Hand", "Light Screen", "Taunt", "Thunder Wave", "Thunderbolt", "Volt Switch"],
                 "teraTypes": ["Dark", "Flying"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Protect", "Tera Blast", "Thunderbolt", "Volt Switch"],
+                "teraTypes": ["Ice"]
             }
         ]
     },
@@ -1095,7 +1100,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Aqua Jet", "Crunch", "Ice Spinner", "Protect", "Wave Crash"],
-                "teraTypes": ["Fire", "Steel", "Water"]
+                "teraTypes": ["Water"]
             }
         ]
     },
@@ -1832,7 +1837,7 @@
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Hyper Voice", "Protect", "Shadow Ball", "Tera Blast"],
+                "movepool": ["Bitter Malice", "Hyper Voice", "Protect", "Tera Blast"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -2083,12 +2088,12 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Body Press", "Leech Seed", "Spiky Shield", "Wood Hammer"],
-                "teraTypes": ["Rock", "Steel"]
+                "teraTypes": ["Fire", "Rock", "Steel", "Water"]
             },
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Body Press", "Iron Defense", "Synthesis", "Wood Hammer"],
-                "teraTypes": ["Rock", "Steel"]
+                "teraTypes": ["Fire", "Rock", "Steel", "Water"]
             }
         ]
     },
@@ -3601,7 +3606,7 @@
         "level": 86,
         "sets": [
             {
-                "role": "Choice Item user",
+                "role": "Doubles Wallbreaker",
                 "movepool": ["Crunch", "Fire Fang", "Play Rough", "Psychic Fangs", "Wild Charge"],
                 "teraTypes": ["Fairy"]
             }

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -414,7 +414,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Air Slash", "Freeze-Dry", "Haze", "Hurricane", "Roost", "Substitute", "U-turn"],
+                "movepool": ["Freeze-Dry", "Haze", "Hurricane", "Roost", "Substitute", "U-turn"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -424,7 +424,7 @@
         "sets": [
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Air Slash", "Calm Mind", "Freezing Glare", "Hurricane", "Recover"],
+                "movepool": ["Calm Mind", "Freezing Glare", "Hurricane", "Recover"],
                 "teraTypes": ["Psychic", "Steel"]
             }
         ]
@@ -553,13 +553,8 @@
         "level": 82,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["Aqua Jet", "Belly Drum", "Liquidation", "Play Rough"],
-                "teraTypes": ["Water"]
-            },
-            {
                 "role": "Bulky Attacker",
-                "movepool": ["Aqua Jet", "Ice Spinner", "Liquidation", "Play Rough", "Superpower"],
+                "movepool": ["Aqua Jet", "Belly Drum", "Ice Spinner", "Liquidation", "Play Rough", "Superpower"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -1324,7 +1319,7 @@
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["Earthquake", "Fire Fang", "Outrage", "Stone Edge", "Swords Dance"],
+                "movepool": ["Earthquake", "Outrage", "Poison Jab", "Stone Edge", "Swords Dance"],
                 "teraTypes": ["Dragon", "Ground"]
             }
         ]
@@ -2402,7 +2397,12 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Dazzling Gleam", "Magnet Rise", "Play Rough", "Spikes", "Thunder Wave"],
+                "movepool": ["Magnet Rise", "Play Rough", "Spikes", "Thunder Wave"],
+                "teraTypes": ["Water"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Dazzling Gleam", "Foul Play", "Spikes", "Thunder Wave"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -2852,7 +2852,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Aqua Jet", "Close Combat", "Crunch", "Liquidation", "Poison Jab", "Psychic Fangs"],
+                "movepool": ["Aqua Jet", "Close Combat", "Crunch", "Poison Jab", "Psychic Fangs", "Waterfall"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -3468,7 +3468,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Curse", "Rest", "Sleep Talk", "Wave Crash"],
-                "teraTypes": ["Dragon", "Fairy", "Ground"]
+                "teraTypes": ["Dragon", "Fairy"]
             }
         ]
     },
@@ -3752,7 +3752,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Body Press", "Recover", "Salt Cure", "Stealth Rock", "Stone Edge"],
+                "movepool": ["Body Press", "Iron Defense", "Recover", "Salt Cure", "Stealth Rock"],
                 "teraTypes": ["Ghost"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2403,7 +2403,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Dazzling Gleam", "Foul Play", "Spikes", "Thunder Wave"],
-                "teraTypes": ["Water"]
+                "teraTypes": ["Flying", "Water"]
             }
         ]
     },

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1538,7 +1538,10 @@ export class RandomTeams {
 				if (hp % 2 === 0) break;
 			} else {
 				// Maximize number of Stealth Rock switch-ins
-				if (srWeakness <= 0 || hp % (4 / srWeakness) > 0 || ['Leftovers', 'Life Orb', 'Sitrus Berry'].includes(item)) break;
+				if (srWeakness <= 0 || ability === 'Regenerator' || ['Leftovers', 'Life Orb'].includes(item)) break;
+				if (item !== 'Sitrus Berry' && hp % (4 / srWeakness) > 0) break;
+				// Minimise number of Stealth Rock switch-ins to activate Sitrus Berry
+				if (item === 'Sitrus Berry' && hp % (4 / srWeakness) === 0) break;
 			}
 			evs.hp -= 4;
 		}

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -568,7 +568,7 @@ export class RandomTeams {
 		// Amoonguss, though this can work well as a general rule later
 		this.incompatibleMoves(moves, movePool, 'toxic', 'clearsmog');
 		// Dudunsparce
-		if (species.id === 'dudunsparce') this.incompatibleMoves(moves, movePool, 'earthpower', 'shadowball');
+		if (species.baseSpecies === 'Dudunsparce') this.incompatibleMoves(moves, movePool, 'earthpower', 'shadowball');
 		// Luvdisc
 		if (species.id === 'luvdisc' && !isDoubles) {
 			this.incompatibleMoves(moves, movePool, 'charm', ['icebeam', 'icywind']);

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1123,6 +1123,7 @@ export class RandomTeams {
 			if (species.id === 'bellibolt') return 'Electromorphosis';
 			if (species.id === 'armarouge') return 'Flash Fire';
 			if (species.baseSpecies === 'Maushold' && role === 'Doubles Support') return 'Friend Guard';
+			if (species.id === 'talonflame') return 'Gale Wings';
 			if (species.id === 'tropius') return 'Harvest';
 			if (species.id === 'blissey') return 'Healer';
 			if (species.id === 'dragonite' || species.id === 'lucario') return 'Inner Focus';
@@ -1537,7 +1538,7 @@ export class RandomTeams {
 				if (hp % 2 === 0) break;
 			} else {
 				// Maximize number of Stealth Rock switch-ins
-				if (srWeakness <= 0 || hp % (4 / srWeakness) > 0 || ['Leftovers', 'Life Orb'].includes(item)) break;
+				if (srWeakness <= 0 || hp % (4 / srWeakness) > 0 || ['Leftovers', 'Life Orb', 'Sitrus Berry'].includes(item)) break;
 			}
 			evs.hp -= 4;
 		}


### PR DESCRIPTION
**Gen 9 Random Battle:**
-Bulky Support Garganacl: -Stone Edge, +Iron Defense (in other words, Iron Defense Salt Cure now exists. Iron Defense will never generate alongside Stealth Rock. Council decision.)
-Klefki now has a set split. One set has Play Rough and Magnet Rise, while the other has Dazzling Gleam and Foul Play. This fixes the rare bug of getting two fairy moves on Klefki. The Foul Play set will also have Tera Flying as an option.
-Azumarill's sets were fused into one; the only functional difference is that now Belly Drum exists 33% of the time instead of 50%.
-Talonflame will now get Gale Wings 33% of the time instead of 66% of the time (its ability rating was lowered).
-Barraskewda: -Liquidation, +Waterfall
-Setup Sweeper Garchomp: -Fire Fang, +Poison Jab
-Articuno and Articuno-Galar: -Air Slash
-Dondozo: -Tera Ground
-Dudunsparce-Threesegment will no longer get Roost 3 attacks.

**Gen 9 Random Doubles Battle:**
-Electrode now has a Tera Blast user set, with Tera Blast Ice, Thunderbolt, Volt Switch, and Protect. This is because it's objectively better at using Tera Blast than Regieleki, and we have that, so why not.
-Sitrus Berry Delibird _should_ now activate its Sitrus Berry on switching into Stealth Rock.
-Sitrus Berry users will activate their berries in time with Stealth Rock switch-ins in general now, and Regenerator Pokemon will not have their HP optimized for stealth rock reduction.
-Talonflame will now always have Gale Wings in Doubles.
-Mabosstiff: Role changed to Doubles Wallbreaker; as a result, it no longer gets Choice Scarf.
-Tera Blast Hisuian Zoroark: -Shadow Ball, +Bitter Malice
-Chesnaught: +Tera Fire, +Tera Water (both sets)
-Floatzel: -Tera Fire, -Tera Steel (now only Water)
-Meloetta: -Tera Dark, +Tera Fighting