### PR TITLE
Monotype Random Battles: adjust type combination limit

### DIFF
--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -886,6 +886,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			const set = this.randomSet(species, teamDetails, pokemon.length === 0);
 
 			const types = species.types;
+			let typeCombo = types.slice().sort().join();
 
 			if (!isMonotype && !this.forceMonotype) {
 				// Limit two of any type
@@ -910,16 +911,15 @@ export class RandomGen5Teams extends RandomGen6Teams {
 					}
 				}
 				if (skip) continue;
-			}
 
-			// Limit one of any type combination, two in Monotype
-			let typeCombo = types.slice().sort().join();
-			if (set.ability === 'Drought' || set.ability === 'Drizzle' || set.ability === 'Sand Stream') {
-				// Drought, Drizzle and Sand Stream don't count towards the type combo limit
-				typeCombo = set.ability;
-				if (typeCombo in typeComboCount) continue;
-			} else if (!this.forceMonotype) {
-				if (typeComboCount[typeCombo] >= (isMonotype ? 2 : 1) * limitFactor) continue;
+				// Limit one of any type combination
+				if (set.ability === 'Drought' || set.ability === 'Drizzle' || set.ability === 'Sand Stream') {
+					// Drought, Drizzle and Sand Stream don't count towards the type combo limit
+					typeCombo = set.ability;
+					if (typeCombo in typeComboCount) continue;
+				} else {
+					if (typeComboCount[typeCombo] >= 1 * limitFactor) continue;
+				}
 			}
 
 			// Okay, the set passes, add it to our team

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1626,8 +1626,8 @@ export class RandomGen7Teams extends RandomGen8Teams {
 						if (skip) continue;
 					}
 
-					// Limit one of any type combination, two in Monotype
-					if (!this.forceMonotype && typeComboCount[typeCombo] >= (isMonotype ? 2 : 1) * limitFactor) continue;
+					// Limit one of any type combination, three in Monotype
+					if (!this.forceMonotype && typeComboCount[typeCombo] >= (isMonotype ? 3 : 1) * limitFactor) continue;
 				}
 
 				const set = this.randomSet(

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -2556,8 +2556,8 @@ export class RandomGen8Teams {
 				if (skip) continue;
 			}
 
-			// Limit one of any type combination, two in Monotype
-			if (!this.forceMonotype && typeComboCount[typeCombo] >= (isMonotype ? 2 : 1) * limitFactor) continue;
+			// Limit one of any type combination, three in Monotype
+			if (!this.forceMonotype && typeComboCount[typeCombo] >= (isMonotype ? 3 : 1) * limitFactor) continue;
 
 			// The Pokemon of the Day
 			if (potd?.exists && (pokemon.length === 1 || this.maxTeamSize === 1)) species = potd;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1718,8 +1718,8 @@ export class RandomTeams {
 				if (skip) continue;
 			}
 
-			// Limit one of any type combination, two in Monotype
-			if (!this.forceMonotype && typeComboCount[typeCombo] >= (isMonotype ? 2 : 1) * limitFactor) continue;
+			// Limit one of any type combination, three in Monotype
+			if (!this.forceMonotype && typeComboCount[typeCombo] >= (isMonotype ? 3 : 1) * limitFactor) continue;
 
 			// The Pokemon of the Day
 			if (potd?.exists && (pokemon.length === 1 || this.maxTeamSize === 1)) species = potd;


### PR DESCRIPTION
In Gens 4-5, this fully removes the type combination limit for Monotype Random Battles, since some types have very few possible type combinations. This should fix the infrequent crash that can occur while generating teams.

In Gens 6-9, the type combination limit has been increased from 2 to 3. The previous limit of 2 was too restrictive and could lead to problems with team generation.