### PR TITLE
Gen 9 randomized format set updates

### DIFF
--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -1424,7 +1424,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Draco Meteor", "Fire Blast", "Heavy Slam", "Protect", "Trick Room"],
+                "movepool": ["Draco Meteor", "Fire Blast", "Heavy Slam", "Protect", "Thunder Wave"],
                 "teraTypes": ["Dragon", "Fire", "Flying", "Steel"]
             }
         ]
@@ -1434,7 +1434,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Draco Meteor", "Fire Blast", "Flash Cannon", "Protect", "Trick Room"],
+                "movepool": ["Draco Meteor", "Fire Blast", "Flash Cannon", "Protect", "Thunder Wave"],
                 "teraTypes": ["Dragon", "Fire", "Flying"]
             }
         ]
@@ -1825,6 +1825,11 @@
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Dark Pulse", "Flamethrower", "Focus Blast", "Protect", "Sludge Bomb"],
                 "teraTypes": ["Poison"]
+            },
+            {
+                "role": "Offensive Protect",
+                "movepool": ["Flamethrower", "Focus Blast", "Knock Off", "Protect", "Sludge Bomb"],
+                "teraTypes": ["Poison"]
             }
         ]
     },
@@ -2017,7 +2022,7 @@
             },
             {
                 "role": "Doubles Support",
-                "movepool": ["Foul Play", "Protect", "Snarl", "Taunt", "Thunder Wave", "Thunderbolt"],
+                "movepool": ["Grass Knot", "Protect", "Snarl", "Taunt", "Thunder Wave", "Thunderbolt"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3667,7 +3672,7 @@
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
-                "movepool": ["Earth Power", "Protect", "Spikes", "Stealth Rock", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Earth Power", "Protect", "Stealth Rock", "Thunderbolt", "Volt Switch"],
                 "teraTypes": ["Electric", "Grass", "Ground"]
             },
             {
@@ -3682,7 +3687,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Dazzling Gleam", "Disable", "Encore", "Helping Hand", "Howl", "Play Rough", "Stealth Rock", "Thunder Wave"],
+                "movepool": ["Disable", "Encore", "Helping Hand", "Howl", "Play Rough", "Stealth Rock", "Thunder Wave"],
                 "teraTypes": ["Steel"]
             }
         ]

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -3672,7 +3672,7 @@
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
-                "movepool": ["Earth Power", "Protect", "Stealth Rock", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Earth Power", "Protect", "Spikes", "Stealth Rock", "Thunderbolt", "Volt Switch"],
                 "teraTypes": ["Electric", "Grass", "Ground"]
             },
             {

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -689,8 +689,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Body Press", "Iron Head", "Rapid Spin", "Spikes", "Stealth Rock", "Volt Switch"],
+                "movepool": ["Iron Head", "Rapid Spin", "Stealth Rock", "Toxic Spikes", "Volt Switch"],
                 "teraTypes": ["Water"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Press", "Iron Head", "Rapid Spin", "Spikes", "Stealth Rock"],
+                "teraTypes": ["Fighting", "Water"]
             }
         ]
     },
@@ -2507,7 +2512,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Defog", "Leaf Blade", "Sucker Punch", "Swords Dance", "Synthesis", "Triple Arrows", "U-turn"],
+                "movepool": ["Defog", "Leaf Blade", "Roost", "Sucker Punch", "Swords Dance", "Triple Arrows", "U-turn"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3872,8 +3877,8 @@
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Earth Power", "Tera Blast", "Thunderbolt", "Volt Switch"],
-                "teraTypes": ["Flying", "Ice"]
+                "movepool": ["Earth Power", "Sunny Day", "Tera Blast", "Thunderbolt"],
+                "teraTypes": ["Fire"]
             }
         ]
     },
@@ -3882,7 +3887,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Dazzling Gleam", "Encore", "Play Rough", "Protect", "Thunder Wave", "Wish"],
+                "movepool": ["Encore", "Play Rough", "Protect", "Thunder Wave", "Wish"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3917,8 +3922,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Crunch", "Dragon Dance", "Earthquake", "Outrage", "Roost"],
-                "teraTypes": ["Dark", "Dragon", "Ground"]
+                "movepool": ["Crunch", "Dragon Dance", "Earthquake", "Iron Head", "Outrage", "Roost"],
+                "teraTypes": ["Dark", "Dragon", "Ground", "Steel"]
             },
             {
                 "role": "Bulky Attacker",

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -121,8 +121,7 @@ const noLeadPokemon = [
 	'Basculegion', 'Houndstone', 'Rillaboom', 'Zacian', 'Zamazenta',
 ];
 const doublesNoLeadPokemon = [
-	'Basculegion', 'Flutter Mane', 'Houndstone', 'Iron Bundle', 'Iron Jugulis', 'Iron Leaves', 'Iron Moth',
-	'Iron Thorns', 'Sandy Shocks', 'Roaring Moon', 'Walking Wake', 'Zacian', 'Zamazenta',
+	'Basculegion', 'Houndstone', 'Roaring Moon', 'Zacian', 'Zamazenta',
 ];
 
 function sereneGraceBenefits(move: Move) {

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -121,7 +121,8 @@ const noLeadPokemon = [
 	'Basculegion', 'Houndstone', 'Rillaboom', 'Zacian', 'Zamazenta',
 ];
 const doublesNoLeadPokemon = [
-	'Basculegion', 'Houndstone', 'Zacian', 'Zamazenta',
+	'Basculegion', 'Flutter Mane', 'Houndstone', 'Iron Bundle', 'Iron Jugulis', 'Iron Leaves', 'Iron Moth',
+	'Iron Thorns', 'Sandy Shocks', 'Roaring Moon', 'Walking Wake', 'Zacian', 'Zamazenta',
 ];
 
 function sereneGraceBenefits(move: Move) {
@@ -517,7 +518,6 @@ export class RandomTeams {
 		this.incompatibleMoves(moves, movePool, 'curse', 'rapidspin');
 		this.incompatibleMoves(moves, movePool, 'dragondance', 'dracometeor');
 		this.incompatibleMoves(moves, movePool, 'healingwish', 'uturn');
-		this.incompatibleMoves(moves, movePool, 'dazzlinggleam', ['howl', 'playrough']);
 
 
 		// These attacks are redundant with each other


### PR DESCRIPTION
Changes marked with an * help our long-term goal of reducing the rate of choice items.

**Gen 9 Random Battle:**
-Tera Blast User Sandy Shocks has been changed to a Life Orb Tera Fire Sunny Day set. *

-Forretress has a new set split (and by extension, it now can get sets without Rapid Spin again rarely, sorry!):
Set 1: Bulky Support, iron head/rapid spin/volt switch/stealth rock/toxic spikes
Set 2: Bulky Attacker, iron head/body press/rapid spin/stealth rock/spikes, +tera fighting in addition to water

-Hisuian Decidueye: -Synthesis, +Roost
-Setup Sweeper Roaring Moon: +Iron Head, +Tera Steel
-Scream Tail: -Dazzling Gleam (this is not due to any balance reason, but instead to simplify the code because doubles scream tail will not be using Dazzling Gleam anymore either)

**Gen 9 Random Doubles Battle:**
-Roaring Moon can no longer be generated in the lead two slots; it's an objectively poor lead due to always being Booster Energy Tailwind Acrobatics.

-Zoroark has gained a second set with an Offensive Protect role that runs Knock Off over Dark Pulse. *

-Scream Tail: -Dazzling Gleam
-Dialga and Dialga-Origin: -Trick Room, +Thunder Wave
-Support Thundurus: -Foul Play, +Grass Knot