### PR TITLE
Prevent Commanded Dondozo from switching out through pivot moves

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -1084,7 +1084,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 40,
 		priority: 0,
 		flags: {},
-		onTryHit(target) {
+		onHit(target) {
 			if (!this.canSwitch(target.side) || target.volatiles['commanded']) {
 				this.attrLastMove('[still]');
 				this.add('-fail', target);
@@ -16476,7 +16476,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {},
 		volatileStatus: 'substitute',
 		onTryHit(source) {
-			if (!this.canSwitch(source.side)) {
+			if (!this.canSwitch(source.side) || source.volatiles['commanded']) {
 				this.add('-fail', source);
 				return this.NOT_FAIL;
 			}

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1271,7 +1271,7 @@ export class BattleActions {
 				this.battle.faint(source, source, move);
 			}
 			if (moveData.selfSwitch) {
-				if (this.battle.canSwitch(source.side)) {
+				if (this.battle.canSwitch(source.side) && !source.volatiles['commanded']) {
 					didSomething = true;
 				} else {
 					didSomething = this.combineResults(didSomething, false);
@@ -1291,7 +1291,7 @@ export class BattleActions {
 				}
 			}
 			this.battle.debug('move failed because it did nothing');
-		} else if (move.selfSwitch && source.hp) {
+		} else if (move.selfSwitch && source.hp && !source.volatiles['commanded']) {
 			source.switchFlag = move.id;
 		}
 


### PR DESCRIPTION
The sequel to #9387 

As seen here: https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/page-31#post-9538928

This also fixes the slight mechanics error regarding Baton Pass used to implement the previous Baton Pass with Commander failure.