### PR TITLE
Gen 9 Random Doubles Battle updates

### DIFF
--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -10,12 +10,12 @@
         ]
     },
     "pikachu": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Doubles Support",
                 "movepool": ["Encore", "Fake Out", "Grass Knot", "Protect", "Volt Tackle"],
-                "teraTypes": ["Electric", "Water"]
+                "teraTypes": ["Electric", "Grass"]
             }
         ]
     },
@@ -25,7 +25,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Encore", "Fake Out", "Grass Knot", "Nuzzle", "Thunderbolt"],
-                "teraTypes": ["Electric", "Water"]
+                "teraTypes": ["Electric", "Grass"]
             },
             {
                 "role": "Tera Blast user",
@@ -70,7 +70,7 @@
         ]
     },
     "dugtrio": {
-        "level": 84,
+        "level": 85,
         "sets": [
             {
                 "role": "Offensive Protect",
@@ -140,7 +140,7 @@
         ]
     },
     "arcanine": {
-        "level": 84,
+        "level": 83,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -160,7 +160,7 @@
         ]
     },
     "slowbro": {
-        "level": 84,
+        "level": 85,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -175,7 +175,7 @@
         ]
     },
     "slowbrogalar": {
-        "level": 84,
+        "level": 85,
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
@@ -189,13 +189,13 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Gunk Shot", "Haze", "Helping Hand", "Ice Punch", "Poison Gas", "Poison Jab", "Rock Tomb", "Shadow Sneak", "Toxic Spikes"],
+                "movepool": ["Drain Punch", "Gunk Shot", "Haze", "Helping Hand", "Ice Punch", "Poison Gas", "Poison Jab", "Rock Tomb", "Shadow Sneak", "Toxic Spikes"],
                 "teraTypes": ["Dark"]
             }
         ]
     },
     "mukalola": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -205,7 +205,7 @@
         ]
     },
     "cloyster": {
-        "level": 80,
+        "level": 82,
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
@@ -230,7 +230,7 @@
         ]
     },
     "hypno": {
-        "level": 90,
+        "level": 92,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -270,7 +270,7 @@
         ]
     },
     "tauros": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Choice Item user",
@@ -350,7 +350,7 @@
         ]
     },
     "vaporeon": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -375,7 +375,7 @@
         ]
     },
     "flareon": {
-        "level": 86,
+        "level": 87,
         "sets": [
             {
                 "role": "Offensive Protect",
@@ -385,7 +385,7 @@
         ]
     },
     "articuno": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -395,7 +395,7 @@
         ]
     },
     "articunogalar": {
-        "level": 86,
+        "level": 87,
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
@@ -405,7 +405,7 @@
         ]
     },
     "zapdos": {
-        "level": 82,
+        "level": 80,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -420,7 +420,7 @@
         ]
     },
     "zapdosgalar": {
-        "level": 82,
+        "level": 81,
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
@@ -430,7 +430,7 @@
         ]
     },
     "moltres": {
-        "level": 84,
+        "level": 83,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -440,7 +440,7 @@
         ]
     },
     "moltresgalar": {
-        "level": 82,
+        "level": 78,
         "sets": [
             {
                 "role": "Doubles Bulky Setup",
@@ -490,7 +490,7 @@
         ]
     },
     "typhlosion": {
-        "level": 88,
+        "level": 83,
         "sets": [
             {
                 "role": "Choice Item user",
@@ -500,7 +500,7 @@
         ]
     },
     "typhlosionhisui": {
-        "level": 86,
+        "level": 83,
         "sets": [
             {
                 "role": "Choice Item user",
@@ -530,7 +530,7 @@
         ]
     },
     "sudowoodo": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
@@ -565,7 +565,7 @@
         ]
     },
     "quagsire": {
-        "level": 84,
+        "level": 85,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -575,11 +575,11 @@
         ]
     },
     "clodsire": {
-        "level": 80,
+        "level": 82,
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Gunk Shot", "Helping Hand", "Recover", "Stomping Tantrum", "Toxic", "Toxic Spikes"],
+                "movepool": ["Gunk Shot", "Helping Hand", "Recover", "Stealth Rock", "Stomping Tantrum", "Toxic Spikes"],
                 "teraTypes": ["Flying", "Ground", "Steel"]
             }
         ]
@@ -615,7 +615,7 @@
         ]
     },
     "slowking": {
-        "level": 84,
+        "level": 85,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -630,7 +630,7 @@
         ]
     },
     "slowkinggalar": {
-        "level": 82,
+        "level": 85,
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
@@ -640,11 +640,11 @@
         ]
     },
     "forretress": {
-        "level": 84,
+        "level": 86,
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Helping Hand", "Iron Head", "Rapid Spin", "Stealth Rock", "Toxic Spikes"],
+                "movepool": ["Bug Bite", "Rapid Spin", "Stealth Rock", "Toxic Spikes", "Volt Switch"],
                 "teraTypes": ["Fire", "Water"]
             }
         ]
@@ -656,6 +656,16 @@
                 "role": "Doubles Support",
                 "movepool": ["Gunk Shot", "Icy Wind", "Taunt", "Thunder Wave", "Toxic Spikes", "Waterfall"],
                 "teraTypes": ["Grass"]
+            }
+        ]
+    },
+    "qwilfishhisui": {
+        "level": 86,
+        "sets": [
+            {
+                "role": "Doubles Bulky Attacker",
+                "movepool": ["Crunch", "Gunk Shot", "Icy Wind", "Toxic Spikes"],
+                "teraTypes": ["Flying"]
             }
         ]
     },
@@ -735,7 +745,7 @@
         ]
     },
     "blissey": {
-        "level": 84,
+        "level": 86,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -745,7 +755,7 @@
         ]
     },
     "tyranitar": {
-        "level": 80,
+        "level": 81,
         "sets": [
             {
                 "role": "Doubles Bulky Setup",
@@ -770,7 +780,7 @@
         ]
     },
     "gardevoir": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Choice Item user",
@@ -805,7 +815,7 @@
         ]
     },
     "slaking": {
-        "level": 86,
+        "level": 87,
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
@@ -830,7 +840,7 @@
         ]
     },
     "sableye": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -855,7 +865,7 @@
         ]
     },
     "swalot": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -900,7 +910,7 @@
         ]
     },
     "cacturne": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Offensive Protect",
@@ -910,11 +920,16 @@
         ]
     },
     "altaria": {
-        "level": 86,
+        "level": 88,
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Brave Bird", "Defog", "Draco Meteor", "Fire Blast", "Helping Hand", "Protect", "Roost", "Tailwind", "Will-O-Wisp"],
+                "movepool": ["Brave Bird", "Defog", "Draco Meteor", "Fire Blast", "Helping Hand", "Roost", "Tailwind", "Will-O-Wisp"],
+                "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Bulky Protect",
+                "movepool": ["Brave Bird", "Protect", "Roost", "Will-O-Wisp"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -930,7 +945,7 @@
         ]
     },
     "seviper": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Offensive Protect",
@@ -950,7 +965,7 @@
         ]
     },
     "banette": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
@@ -960,7 +975,7 @@
         ]
     },
     "tropius": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -990,7 +1005,7 @@
         ]
     },
     "salamence": {
-        "level": 82,
+        "level": 81,
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
@@ -1000,7 +1015,7 @@
         ]
     },
     "kyogre": {
-        "level": 72,
+        "level": 68,
         "sets": [
             {
                 "role": "Choice Item user",
@@ -1010,7 +1025,7 @@
         ]
     },
     "groudon": {
-        "level": 74,
+        "level": 73,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -1050,12 +1065,12 @@
             {
                 "role": "Choice Item user",
                 "movepool": ["Brave Bird", "Close Combat", "Double-Edge", "Final Gambit"],
-                "teraTypes": ["Fighting", "Flying"]
+                "teraTypes": ["Fighting", "Flying", "Normal"]
             }
         ]
     },
     "kricketune": {
-        "level": 95,
+        "level": 97,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -1075,7 +1090,7 @@
         ]
     },
     "vespiquen": {
-        "level": 94,
+        "level": 95,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -1165,11 +1180,16 @@
         ]
     },
     "spiritomb": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Foul Play", "Helping Hand", "Icy Wind", "Shadow Sneak", "Snarl", "Trick Room", "Will-O-Wisp"],
+                "movepool": ["Foul Play", "Helping Hand", "Icy Wind", "Shadow Sneak", "Will-O-Wisp"],
+                "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Doubles Bulky Attacker",
+                "movepool": ["Foul Play", "Snarl", "Trick Room", "Will-O-Wisp"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1190,7 +1210,7 @@
         ]
     },
     "lucario": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Offensive Protect",
@@ -1205,7 +1225,7 @@
         ]
     },
     "hippowdon": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -1235,7 +1255,7 @@
         ]
     },
     "abomasnow": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -1275,7 +1295,7 @@
         ]
     },
     "leafeon": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
@@ -1285,7 +1305,7 @@
         ]
     },
     "glaceon": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
@@ -1310,7 +1330,7 @@
         ]
     },
     "froslass": {
-        "level": 86,
+        "level": 87,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -1370,7 +1390,7 @@
         ]
     },
     "rotommow": {
-        "level": 84,
+        "level": 85,
         "sets": [
             {
                 "role": "Bulky Protect",
@@ -1465,7 +1485,7 @@
         ]
     },
     "heatran": {
-        "level": 80,
+        "level": 79,
         "sets": [
             {
                 "role": "Bulky Protect",
@@ -1535,7 +1555,7 @@
         ]
     },
     "arceusdark": {
-        "level": 72,
+        "level": 71,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -1555,7 +1575,7 @@
         ]
     },
     "arceuselectric": {
-        "level": 72,
+        "level": 71,
         "sets": [
             {
                 "role": "Doubles Bulky Setup",
@@ -1685,7 +1705,7 @@
         ]
     },
     "arceussteel": {
-        "level": 72,
+        "level": 73,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -1755,7 +1775,7 @@
         ]
     },
     "lilliganthisui": {
-        "level": 80,
+        "level": 81,
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
@@ -1848,22 +1868,17 @@
         ]
     },
     "gothitelle": {
-        "level": 80,
+        "level": 82,
         "sets": [
             {
                 "role": "Doubles Support",
                 "movepool": ["Fake Out", "Heal Pulse", "Helping Hand", "Protect", "Psychic", "Trick Room"],
                 "teraTypes": ["Dark", "Steel"]
-            },
-            {
-                "role": "Choice Item user",
-                "movepool": ["Heal Pulse", "Hypnosis", "Psychic", "Trick"],
-                "teraTypes": ["Dark", "Steel"]
             }
         ]
     },
     "sawsbuck": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
@@ -1873,7 +1888,7 @@
         ]
     },
     "amoonguss": {
-        "level": 80,
+        "level": 81,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -1883,7 +1898,7 @@
         ]
     },
     "alomomola": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -1903,7 +1918,7 @@
         ]
     },
     "haxorus": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Offensive Protect",
@@ -1913,7 +1928,7 @@
         ]
     },
     "beartic": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Offensive Protect",
@@ -1933,7 +1948,7 @@
         ]
     },
     "braviary": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Offensive Protect",
@@ -1943,7 +1958,7 @@
         ]
     },
     "braviaryhisui": {
-        "level": 80,
+        "level": 82,
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
@@ -1973,7 +1988,7 @@
         ]
     },
     "volcarona": {
-        "level": 80,
+        "level": 79,
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
@@ -1988,7 +2003,7 @@
         ]
     },
     "tornadus": {
-        "level": 82,
+        "level": 81,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -1998,7 +2013,7 @@
         ]
     },
     "tornadustherian": {
-        "level": 80,
+        "level": 79,
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
@@ -2058,7 +2073,7 @@
         ]
     },
     "landorustherian": {
-        "level": 80,
+        "level": 79,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -2073,7 +2088,7 @@
         ]
     },
     "meloetta": {
-        "level": 86,
+        "level": 83,
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
@@ -2103,12 +2118,12 @@
         ]
     },
     "delphox": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Fire Blast", "Heat Wave", "Nasty Plot", "Protect", "Psyshock"],
-                "teraTypes": ["Fire", "Psychic", "Steel", "Water"]
+                "teraTypes": ["Fire"]
             }
         ]
     },
@@ -2143,7 +2158,7 @@
         ]
     },
     "pyroar": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Offensive Protect",
@@ -2178,7 +2193,7 @@
         ]
     },
     "dragalge": {
-        "level": 84,
+        "level": 85,
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
@@ -2203,7 +2218,7 @@
         ]
     },
     "sylveon": {
-        "level": 82,
+        "level": 81,
         "sets": [
             {
                 "role": "Bulky Protect",
@@ -2258,7 +2273,7 @@
         ]
     },
     "goodrahisui": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -2268,7 +2283,7 @@
         ]
     },
     "klefki": {
-        "level": 84,
+        "level": 83,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -2283,7 +2298,7 @@
         ]
     },
     "avalugg": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Bulky Protect",
@@ -2318,7 +2333,7 @@
         ]
     },
     "diancie": {
-        "level": 84,
+        "level": 81,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -2358,7 +2373,7 @@
         ]
     },
     "volcanion": {
-        "level": 82,
+        "level": 79,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -2388,7 +2403,7 @@
         ]
     },
     "gumshoos": {
-        "level": 90,
+        "level": 91,
         "sets": [
             {
                 "role": "Choice Item user",
@@ -2428,7 +2443,7 @@
         ]
     },
     "oricoriopau": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Bulky Protect",
@@ -2438,7 +2453,7 @@
         ]
     },
     "oricoriosensu": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Bulky Protect",
@@ -2448,7 +2463,7 @@
         ]
     },
     "lycanroc": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Offensive Protect",
@@ -2478,7 +2493,7 @@
         ]
     },
     "toxapex": {
-        "level": 88,
+        "level": 91,
         "sets": [
             {
                 "role": "Bulky Protect",
@@ -2488,7 +2503,7 @@
         ]
     },
     "mudsdale": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -2528,7 +2543,7 @@
         ]
     },
     "oranguru": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -2538,7 +2553,7 @@
         ]
     },
     "passimian": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Choice Item user",
@@ -2573,7 +2588,7 @@
         ]
     },
     "mimikyu": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
@@ -2633,7 +2648,7 @@
         ]
     },
     "inteleon": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Choice Item user",
@@ -2677,13 +2692,13 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Fire Blast", "Heat Wave", "Incinerate", "Protect", "Stealth Rock", "Stone Edge", "Will-O-Wisp"],
+                "movepool": ["Fire Blast", "Heat Wave", "Incinerate", "Protect", "Rapid Spin", "Stealth Rock", "Stone Edge", "Will-O-Wisp"],
                 "teraTypes": ["Water"]
             }
         ]
     },
     "flapple": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -2693,7 +2708,7 @@
         ]
     },
     "appletun": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -2748,7 +2763,7 @@
         ]
     },
     "polteageist": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Tera Blast user",
@@ -2813,7 +2828,7 @@
         ]
     },
     "pincurchin": {
-        "level": 94,
+        "level": 96,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -2833,7 +2848,7 @@
         ]
     },
     "stonjourner": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
@@ -2863,7 +2878,7 @@
         ]
     },
     "indeedeef": {
-        "level": 84,
+        "level": 85,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -2908,7 +2923,7 @@
         ]
     },
     "zaciancrowned": {
-        "level": 68,
+        "level": 67,
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
@@ -3008,7 +3023,7 @@
         ]
     },
     "regidrago": {
-        "level": 78,
+        "level": 76,
         "sets": [
             {
                 "role": "Choice Item user",
@@ -3018,7 +3033,7 @@
         ]
     },
     "glastrier": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -3043,7 +3058,7 @@
         ]
     },
     "calyrex": {
-        "level": 90,
+        "level": 91,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -3053,7 +3068,7 @@
         ]
     },
     "calyrexice": {
-        "level": 74,
+        "level": 70,
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
@@ -3063,7 +3078,7 @@
         ]
     },
     "calyrexshadow": {
-        "level": 66,
+        "level": 65,
         "sets": [
             {
                 "role": "Offensive Protect",
@@ -3073,7 +3088,7 @@
         ]
     },
     "wyrdeer": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -3163,7 +3178,7 @@
         ]
     },
     "oinkologne": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -3173,7 +3188,7 @@
         ]
     },
     "oinkolognef": {
-        "level": 88,
+        "level": 89,
         "sets": [
             {
                 "role": "Doubles Support",
@@ -3183,7 +3198,7 @@
         ]
     },
     "dudunsparce": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Bulky Protect",
@@ -3203,17 +3218,17 @@
         ]
     },
     "spidops": {
-        "level": 95,
+        "level": 99,
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Circle Throw", "Sticky Web", "String Shot", "Taunt", "U-turn"],
+                "movepool": ["Bug Bite", "Circle Throw", "Sticky Web", "String Shot", "U-turn"],
                 "teraTypes": ["Water"]
             }
         ]
     },
     "lokix": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Offensive Protect",
@@ -3238,7 +3253,7 @@
         ]
     },
     "houndstone": {
-        "level": 78,
+        "level": 77,
         "sets": [
             {
                 "role": "Choice Item user",
@@ -3252,7 +3267,7 @@
         "sets": [
             {
                 "role": "Offensive Protect",
-                "movepool": ["Dazzling Gleam", "Lumina Crash", "Protect", "Shadow Ball"],
+                "movepool": ["Baton Pass", "Dazzling Gleam", "Lumina Crash", "Protect", "Shadow Ball"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -3283,7 +3298,7 @@
         ]
     },
     "dondozo": {
-        "level": 84,
+        "level": 85,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -3333,7 +3348,7 @@
         ]
     },
     "bellibolt": {
-        "level": 88,
+        "level": 85,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -3343,7 +3358,7 @@
         ]
     },
     "revavroom": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -3377,7 +3392,7 @@
             },
             {
                 "role": "Doubles Support",
-                "movepool": ["Encore", "Follow Me", "Helping Hand", "Protect", "Super Fang", "Taunt", "Thunder Wave", "U-turn"],
+                "movepool": ["Encore", "Follow Me", "Helping Hand", "Population Bomb", "Protect", "Taunt", "Thunder Wave", "U-turn"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -3398,7 +3413,7 @@
         ]
     },
     "cetitan": {
-        "level": 88,
+        "level": 86,
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
@@ -3408,7 +3423,7 @@
         ]
     },
     "baxcalibur": {
-        "level": 81,
+        "level": 80,
         "sets": [
             {
                 "role": "Choice Item user",
@@ -3423,7 +3438,7 @@
         ]
     },
     "tatsugiri": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -3453,7 +3468,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Double-Edge", "Draco Meteor", "Knock Off", "Shed Tail"],
-                "teraTypes": ["Dark", "Dragon", "Normal", "Poison"]
+                "teraTypes": ["Dragon", "Fire", "Normal", "Poison"]
             }
         ]
     },
@@ -3583,7 +3598,7 @@
         ]
     },
     "grafaiai": {
-        "level": 86,
+        "level": 87,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -3633,7 +3648,7 @@
         ]
     },
     "gholdengo": {
-        "level": 80,
+        "level": 79,
         "sets": [
             {
                 "role": "Choice Item user",
@@ -3648,17 +3663,17 @@
         ]
     },
     "greattusk": {
-        "level": 80,
+        "level": 81,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Close Combat", "Earthquake", "Headlong Rush", "Ice Spinner", "Knock Off", "Rapid Spin", "Stone Edge"],
+                "movepool": ["Close Combat", "Earthquake", "Headlong Rush", "Ice Spinner", "Knock Off", "Protect", "Rapid Spin", "Rock Slide"],
                 "teraTypes": ["Fire", "Ground"]
             }
         ]
     },
     "brutebonnet": {
-        "level": 82,
+        "level": 81,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -3693,7 +3708,7 @@
         ]
     },
     "fluttermane": {
-        "level": 78,
+        "level": 76,
         "sets": [
             {
                 "role": "Offensive Protect",
@@ -3718,7 +3733,7 @@
         ]
     },
     "roaringmoon": {
-        "level": 80,
+        "level": 79,
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
@@ -3738,7 +3753,7 @@
         ]
     },
     "ironmoth": {
-        "level": 82,
+        "level": 81,
         "sets": [
             {
                 "role": "Offensive Protect",
@@ -3753,7 +3768,7 @@
         ]
     },
     "ironhands": {
-        "level": 80,
+        "level": 79,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -3768,7 +3783,7 @@
         ]
     },
     "ironjugulis": {
-        "level": 84,
+        "level": 82,
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
@@ -3778,7 +3793,7 @@
         ]
     },
     "ironthorns": {
-        "level": 86,
+        "level": 85,
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
@@ -3793,7 +3808,7 @@
         ]
     },
     "ironbundle": {
-        "level": 80,
+        "level": 79,
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
@@ -3823,7 +3838,7 @@
         ]
     },
     "chienpao": {
-        "level": 80,
+        "level": 79,
         "sets": [
             {
                 "role": "Offensive Protect",
@@ -3833,7 +3848,7 @@
         ]
     },
     "wochien": {
-        "level": 82,
+        "level": 83,
         "sets": [
             {
                 "role": "Bulky Protect",
@@ -3843,7 +3858,7 @@
         ]
     },
     "chiyu": {
-        "level": 80,
+        "level": 78,
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
@@ -3858,7 +3873,7 @@
         ]
     },
     "koraidon": {
-        "level": 70,
+        "level": 69,
         "sets": [
             {
                 "role": "Choice Item user",
@@ -3868,7 +3883,7 @@
         ]
     },
     "miraidon": {
-        "level": 68,
+        "level": 67,
         "sets": [
             {
                 "role": "Offensive Protect",
@@ -3943,7 +3958,7 @@
         ]
     },
     "walkingwake": {
-        "level": 80,
+        "level": 79,
         "sets": [
             {
                 "role": "Doubles Wallbreaker",

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -395,7 +395,7 @@
         ]
     },
     "articunogalar": {
-        "level": 87,
+        "level": 85,
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
@@ -630,7 +630,7 @@
         ]
     },
     "slowkinggalar": {
-        "level": 85,
+        "level": 83,
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
@@ -3208,7 +3208,7 @@
         ]
     },
     "dudunsparcethreesegment": {
-        "level": 88,
+        "level": 87,
         "sets": [
             {
                 "role": "Bulky Protect",

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -484,6 +484,7 @@ export class RandomTeams {
 		if (isDoubles) {
 			// In order of decreasing generalizability
 			this.incompatibleMoves(moves, movePool, SpeedControl, SpeedControl);
+			this.incompatibleMoves(moves, movePool, Hazards, Hazards);
 			this.incompatibleMoves(moves, movePool, 'rockslide', 'stoneedge');
 			this.incompatibleMoves(moves, movePool, Setup, ['fakeout', 'helpinghand']);
 			this.incompatibleMoves(moves, movePool, ProtectMove, 'wideguard');
@@ -760,8 +761,8 @@ export class RandomTeams {
 				counter = this.addMove('fakeout', moves, types, abilities, teamDetails, species, isLead, isDoubles,
 					movePool, teraType, role);
 			}
-			// Enforce Tailwind on Prankster users
-			if (movePool.includes('tailwind') && abilities.has('Prankster')) {
+			// Enforce Tailwind on Prankster and Gale Wings users
+			if (movePool.includes('tailwind') && (abilities.has('Prankster') || abilities.has('Gale Wings'))) {
 				counter = this.addMove('tailwind', moves, types, abilities, teamDetails, species, isLead, isDoubles,
 					movePool, teraType, role);
 			}


### PR DESCRIPTION
This update contains the first Gen 9 Random Doubles level balancing patch, based on the winrates visible in "/rwr gen9randomdoublesbattle". As a result, please have this merged and patched before the rollover of the month, if possible.

This update also contains the following changes:
-Hisuian Qwilfish is being added at level 86. It will have Crunch, Gunk Shot, Icy Wind, and Toxic Spikes, with Tera Flying. (council decision)

-Spiritomb has gained a set split:
--The pre-existing set but minus Trick Room and Snarl
--Doubles Bulky Attacker, with Foul Play, Trick Room, Snarl, and Will-O-Wisp.

-Altaria has gained a set split:
--The pre-existing set but minus Protect
--Bulky Protect, with Brave Bird, Roost, Protect, and Will-O-Wisp.

-Choice Scarf Gothitelle (and therefore Hypnosis Gothitelle) are being removed entirely in an attempt to salvage its extremely low win rate.

-Talonflame will now always have Tailwind.
-Pokemon will now never have more than one entry hazard at once if given the option.

-Friend Guard Maushold: -Super Fang, +Population Bomb (it also now gets Wide Lens)
-Muk: +Drain Punch
-Coalossal: +Rapid Spin
-Spidops: -Taunt, +Bug Bite (it will always have Bug Bite)
-Clodsire: +Stealth Rock, -Toxic
-Espathra: +Baton Pass
-Great Tusk: +Protect, +Rock Slide, -Stone Edge (it can now get Sitrus Berry)
-Forretress: -Iron Head, -Helping Hand, +Bug Bite, +Volt Switch

-Cyclizar Set 2: -Tera Dark, +Tera Fire
-Choice Scarf Staraptor: +Tera Normal
-Pikachu and Raichu Set 1: -Tera Water, +Tera Grass
-Delphox is now only Tera Fire.

