### PR TITLE
Gen 9 Random Battle updates

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -564,7 +564,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Earthquake", "Head Smash", "Spikes", "Stealth Rock", "Sucker Punch", "Wood Hammer"],
+                "movepool": ["Earthquake", "Head Smash", "Stealth Rock", "Sucker Punch", "Wood Hammer"],
                 "teraTypes": ["Grass", "Rock"]
             }
         ]
@@ -626,11 +626,6 @@
                 "role": "Fast Attacker",
                 "movepool": ["Calm Mind", "Dazzling Gleam", "Morning Sun", "Psychic", "Shadow Ball", "Trick"],
                 "teraTypes": ["Fairy", "Psychic"]
-            },
-            {
-                "role": "Tera Blast user",
-                "movepool": ["Calm Mind", "Dazzling Gleam", "Morning Sun", "Psyshock", "Tera Blast"],
-                "teraTypes": ["Fighting", "Fire"]
             }
         ]
     },
@@ -2068,7 +2063,12 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Flash Cannon", "Freeze-Dry", "Haze", "Rapid Spin", "Recover"],
-                "teraTypes": ["Steel"]
+                "teraTypes": ["Poison", "Steel"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Ice Beam", "Rapid Spin", "Tera Blast", "Recover"],
+                "teraTypes": ["Electric"]
             }
         ]
     },
@@ -2212,7 +2212,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Body Press", "Leech Seed", "Spikes", "Spiky Shield", "Synthesis", "Wood Hammer"],
+                "movepool": ["Body Press", "Leech Seed", "Spikes", "Synthesis", "Wood Hammer"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
@@ -3527,7 +3527,7 @@
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["Flamethrower", "Giga Drain", "Leaf Storm", "Overheat"],
+                "movepool": ["Energy Ball", "Flamethrower", "Leaf Storm", "Overheat"],
                 "teraTypes": ["Fire", "Grass"]
             }
         ]
@@ -3747,18 +3747,18 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Body Press", "Curse", "Recover", "Stone Edge"],
-                "teraTypes": ["Dragon", "Fairy", "Fighting"]
+                "movepool": ["Body Press", "Curse", "Earthquake", "Recover", "Stone Edge"],
+                "teraTypes": ["Dragon", "Fairy"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Protect", "Recover", "Salt Cure"],
-                "teraTypes": ["Ghost"]
+                "teraTypes": ["Dragon", "Ghost"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Press", "Iron Defense", "Recover", "Salt Cure", "Stealth Rock"],
-                "teraTypes": ["Ghost"]
+                "teraTypes": ["Dragon", "Ghost"]
             }
         ]
     },
@@ -4082,7 +4082,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Energy Ball", "Knock Off", "Leech Seed", "Protect", "Ruination", "Stun Spore"],
+                "movepool": ["Giga Drain", "Knock Off", "Leech Seed", "Protect", "Ruination", "Stun Spore"],
                 "teraTypes": ["Poison"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2067,7 +2067,7 @@
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Ice Beam", "Rapid Spin", "Tera Blast", "Recover"],
+                "movepool": ["Ice Beam", "Rapid Spin", "Recover", "Tera Blast"],
                 "teraTypes": ["Electric"]
             }
         ]

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1417,7 +1417,7 @@ export class RandomTeams {
 		if (
 			['Fast Bulky Setup', 'Fast Attacker', 'Setup Sweeper', 'Wallbreaker'].some(m => role === m) &&
 			types.includes('Dark') && moves.has('suckerpunch') && !priorityPokemon.includes(species.id) &&
-			counter.get('setup') && counter.get('Dark')
+			counter.get('PhysicalSetup') && counter.get('Dark')
 		) return 'Black Glasses';
 		if (role === 'Fast Support' || role === 'Fast Bulky Setup') {
 			return (counter.get('Physical') + counter.get('Special') >= 3 && !moves.has('nuzzle')) ? 'Life Orb' : 'Leftovers';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1417,7 +1417,7 @@ export class RandomTeams {
 		if (
 			['Fast Bulky Setup', 'Fast Attacker', 'Setup Sweeper', 'Wallbreaker'].some(m => role === m) &&
 			types.includes('Dark') && moves.has('suckerpunch') && !priorityPokemon.includes(species.id) &&
-			counter.get('PhysicalSetup') && counter.get('Dark')
+			counter.get('physicalsetup') && counter.get('Dark')
 		) return 'Black Glasses';
 		if (role === 'Fast Support' || role === 'Fast Bulky Setup') {
 			return (counter.get('Physical') + counter.get('Special') >= 3 && !moves.has('nuzzle')) ? 'Life Orb' : 'Leftovers';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -512,7 +512,7 @@ export class RandomTeams {
 		this.incompatibleMoves(moves, movePool, Setup, Hazards);
 		this.incompatibleMoves(moves, movePool, Setup, ['defog', 'nuzzle', 'toxic', 'waterspout', 'yawn', 'haze']);
 		this.incompatibleMoves(moves, movePool, PhysicalSetup, PhysicalSetup);
-		this.incompatibleMoves(moves, movePool, SpecialSetup, ['suckerpunch', 'thunderwave']);
+		this.incompatibleMoves(moves, movePool, SpecialSetup, 'thunderwave');
 		this.incompatibleMoves(moves, movePool, 'substitute', pivotingMoves);
 		this.incompatibleMoves(moves, movePool, SpeedSetup, ['aquajet', 'rest', 'trickroom']);
 		this.incompatibleMoves(moves, movePool, 'curse', 'rapidspin');


### PR DESCRIPTION
Please merge this swiftly so the Gen 7 revamp can fix the one conflict this'll make.

-Espeon's Tera Blast user set was removed due to it underperforming in winrates.
-Cryogonal is gaining a Tera Blast user set. It will be Heavy-Duty Boots with Rapid Spin, Tera Blast Electric, Ice Beam, and Recover.

-Houndoom can get Sucker Punch + Nasty Plot again because the set's removal caused Houndoom's winrate to drop.

-Chesnaught: -Spiky Shield
-Wo-chien: -Energy Ball, +Giga Drain
-Scovillain: -Giga Drain, +Energy Ball
-Sudowoodo: -Spikes
-Cryogonal set 1: +Tera Poison
-Curse Garganacl: +Earthquake, -Tera Fighting
-Protect and Support Garganacl: +Tera Dragon