### PR TITLE
Fix Go legality in formats without obtainablemoves

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -823,11 +823,11 @@ export class TeamValidator {
 		}
 
 		// Attempt move validation again after verifying Pokemon GO origin
-		if (setSources.isFromPokemonGo) {
+		if (ruleTable.has('obtainablemoves') && setSources.isFromPokemonGo) {
 			setSources.restrictiveMoves = [];
 			setSources.sources = ['8V'];
 			setSources.sourcesBefore = 0;
-			if (moveProblems && !moveProblems.length && ruleTable.has('obtainablemoves')) {
+			if (moveProblems && !moveProblems.length) {
 				problems.push(...this.validateMoves(outOfBattleSpecies, set.moves, setSources, set, name,
 					moveLegalityWhitelist));
 			}

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -716,8 +716,9 @@ export class TeamValidator {
 			}
 		}
 
-		const moveProblems = this.validateMoves(outOfBattleSpecies, set.moves, setSources, set, name, moveLegalityWhitelist);
+		let moveProblems;
 		if (ruleTable.has('obtainablemoves')) {
+			moveProblems = this.validateMoves(outOfBattleSpecies, set.moves, setSources, set, name, moveLegalityWhitelist);
 			problems.push(...moveProblems);
 		}
 
@@ -805,17 +806,6 @@ export class TeamValidator {
 			}
 		}
 
-		// Attempt move validation again after verifying Pokemon GO origin
-		if (setSources.isFromPokemonGo) {
-			setSources.restrictiveMoves = [];
-			setSources.sources = ['8V'];
-			setSources.sourcesBefore = 0;
-			if (!moveProblems.length && ruleTable.has('obtainablemoves')) {
-				problems.push(...this.validateMoves(outOfBattleSpecies, set.moves, setSources, set, name,
-					moveLegalityWhitelist));
-			}
-		}
-
 		// Hardcoded forced validation for Pokemon GO
 		const pokemonGoOnlySpecies = ['meltan', 'melmetal', 'gimmighoulroaming'];
 		if (ruleTable.has('obtainablemisc') && (pokemonGoOnlySpecies.includes(species.id))) {
@@ -830,6 +820,17 @@ export class TeamValidator {
 
 		if (ruleTable.isBanned('nonexistent')) {
 			problems.push(...this.validateStats(set, species, setSources, pokemonGoProblems));
+		}
+
+		// Attempt move validation again after verifying Pokemon GO origin
+		if (setSources.isFromPokemonGo) {
+			setSources.restrictiveMoves = [];
+			setSources.sources = ['8V'];
+			setSources.sourcesBefore = 0;
+			if (moveProblems && !moveProblems.length && ruleTable.has('obtainablemoves')) {
+				problems.push(...this.validateMoves(outOfBattleSpecies, set.moves, setSources, set, name,
+					moveLegalityWhitelist));
+			}
 		}
 
 		if (ruleTable.has('obtainablemoves')) {


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-9727878 This was happening as a result of move sources being generated for all formats rather than only ones that check for move legality.

In addition, I noticed that my implementation allowed Gen 6+ legendaries to get away with illegal moves if their only Pokemon GO identifier was having less than three perfect IVs; now the code should be performing legality checks only after all identifiers are checked.