### PR TITLE
Frantic Fusions: Fix validation errors

### DIFF
--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -2545,7 +2545,6 @@ export const Rulesets: {[k: string]: FormatData} = {
 		effectType: 'Rule',
 		name: "Frantic Fusions Mod",
 		desc: `Pok&eacute;mon nicknamed after another Pok&eacute;mon get their stats buffed by 1/4 of that Pok&eacute;mon's stats, barring HP, and access to their abilities.`,
-		ruleset: ['!Obtainable Abilities'],
 		onBegin() {
 			this.add('rule', 'Frantic Fusions Mod: Pok\u00e9mon nicknamed after another Pok\u00e9mon get buffed stats and more abilities.');
 		},

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -896,7 +896,8 @@ export class TeamValidator {
 			// nickname is the name of a species
 			if (nameSpecies.baseSpecies === species.baseSpecies) {
 				set.name = species.baseSpecies;
-			} else if (nameSpecies.name !== species.name && nameSpecies.name !== species.baseSpecies && ruleTable.has('nicknameclause')) {
+			} else if (nameSpecies.name !== species.name && nameSpecies.name !== species.baseSpecies &&
+          ruleTable.has('nicknameclause')) {
 				// nickname species doesn't match actual species
 				// Nickname Clause
 				problems.push(`${name} must not be nicknamed a different Pokémon species than what it actually is.`);

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -896,7 +896,7 @@ export class TeamValidator {
 			// nickname is the name of a species
 			if (nameSpecies.baseSpecies === species.baseSpecies) {
 				set.name = species.baseSpecies;
-			} else if (nameSpecies.name !== species.name && nameSpecies.name !== species.baseSpecies) {
+			} else if (nameSpecies.name !== species.name && nameSpecies.name !== species.baseSpecies && ruleTable.has('nicknameclause')) {
 				// nickname species doesn't match actual species
 				// Nickname Clause
 				problems.push(`${name} must not be nicknamed a different Pokémon species than what it actually is.`);

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -896,8 +896,8 @@ export class TeamValidator {
 			// nickname is the name of a species
 			if (nameSpecies.baseSpecies === species.baseSpecies) {
 				set.name = species.baseSpecies;
-			} else if (nameSpecies.name !== species.name && nameSpecies.name !== species.baseSpecies &&
-          ruleTable.has('nicknameclause')) {
+			} else if (nameSpecies.name !== species.name &&
+				nameSpecies.name !== species.baseSpecies && ruleTable.has('nicknameclause')) {
 				// nickname species doesn't match actual species
 				// Nickname Clause
 				problems.push(`${name} must not be nicknamed a different Pokémon species than what it actually is.`);


### PR DESCRIPTION
Automatically including !obtainable abilities seems to be a source of the errors, but also Nickname Clause doesn't turn "off" when removed in a part of the hardcode, allowing nickname clause to be removed fixes that issue about nicknaming pokemon in ruleset mods