### PR TITLE
National Dex: Tag Gimmighoul as LC

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -5675,6 +5675,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 	},
 	gimmighoul: {
 		tier: "LC",
+		natDexTier: "LC",
 	},
 	gholdengo: {
 		tier: "OU",


### PR DESCRIPTION
Requested by R8 over Discord. 

![image](https://github.com/smogon/pokemon-showdown/assets/2375161/4643f754-b1d3-4124-84e1-7300fdc657df)

This fixes a niche issue where despite Gimmighoul being legal in National Dex, the Roaming form was not. I am not 100% sure if this is the correct implementation, if you would prefer I do the method where I add the form as you would a mega i.e.

![image](https://github.com/smogon/pokemon-showdown/assets/2375161/1e199013-932f-49c1-876d-a6609bdc443b)

I can change it, but this seemed like the right way to me. I checked the validator locally and it does fix the problem either way, let me know what the preference is.