### PR TITLE
`/fuse`: Fix argument parsing

### DIFF
--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -440,7 +440,7 @@ export const commands: Chat.ChatCommands = {
 		if (!toID(args[0]) && !toID(args[1])) return this.parse('/help franticfusions');
 		const {dex, targets} = this.splitFormat(target, true);
 		this.runBroadcast();
-		if (targets.length === 3) return this.parse('/help franticfusions');
+		if (targets.length > 2) return this.parse('/help franticfusions');
 		const species = Utils.deepClone(dex.species.get(targets[0]));
 		const fusion = dex.species.get(targets[1]);
 		if (!species.exists || species.gen > dex.gen) {

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -438,18 +438,11 @@ export const commands: Chat.ChatCommands = {
 	franticfusions(target, room, user, connection, cmd) {
 		const args = target.split(',');
 		if (!toID(args[0]) && !toID(args[1])) return this.parse('/help franticfusions');
+		const {dex, targets} = this.splitFormat(target, true);
 		this.runBroadcast();
-		const targetGen = parseInt(cmd[cmd.length - 1]);
-		if (targetGen && !args[2]) args[2] = `gen${targetGen}`;
-		let dex = Dex;
-		if (args[2] && toID(args[2]) in Dex.dexes) {
-			dex = Dex.dexes[toID(args[2])];
-		} else if (room?.battle) {
-			const format = Dex.formats.get(room.battle.format);
-			dex = Dex.mod(format.mod);
-		}
-		const species = Utils.deepClone(dex.species.get(args[0]));
-		const fusion = dex.species.get(args[1]);
+		if(targets.length === 3) return this.parse('/help franticfusions')
+		const species = Utils.deepClone(dex.species.get(targets[0]));
+		const fusion = dex.species.get(targets[1]);
 		if (!species.exists || species.gen > dex.gen) {
 			const monName = species.gen > dex.gen ? species.name : args[0].trim();
 			const additionalReason = species.gen > dex.gen ? ` in Generation ${dex.gen}` : ``;

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -440,7 +440,7 @@ export const commands: Chat.ChatCommands = {
 		if (!toID(args[0]) && !toID(args[1])) return this.parse('/help franticfusions');
 		const {dex, targets} = this.splitFormat(target, true);
 		this.runBroadcast();
-		if(targets.length === 3) return this.parse('/help franticfusions')
+		if (targets.length === 3) return this.parse('/help franticfusions');
 		const species = Utils.deepClone(dex.species.get(targets[0]));
 		const fusion = dex.species.get(targets[1]);
 		if (!species.exists || species.gen > dex.gen) {

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -438,6 +438,8 @@ export const commands: Chat.ChatCommands = {
 	franticfusions(target, room, user, connection, cmd) {
 		const args = target.split(',');
 		if (!toID(args[0]) && !toID(args[1])) return this.parse('/help franticfusions');
+		const targetGen = parseInt(cmd[cmd.length - 1]);
+		if (targetGen && !args[2]) target = `${target},gen${targetGen}`;
 		const {dex, targets} = this.splitFormat(target, true);
 		this.runBroadcast();
 		if (targets.length > 2) return this.parse('/help franticfusions');


### PR DESCRIPTION
The arg parsing ended up a bit weird after #9700, this is simpler and doesn't break on `/fuse pokemon, gen`

Current version
<img width="907" alt="image" src="https://github.com/smogon/pokemon-showdown/assets/47090312/f0189e84-8864-4101-8ec8-cca7c6eb2d2a">

Fix
<img width="658" alt="image" src="https://github.com/smogon/pokemon-showdown/assets/47090312/8d8bc9f5-9146-4087-9ff7-1dc669bc1b1a">
