### PR TITLE
Gen 9 randomized format set updates

### DIFF
--- a/data/mods/potd/random-teams.ts
+++ b/data/mods/potd/random-teams.ts
@@ -31,7 +31,9 @@ export class RandomPOTDTeams extends RandomTeams {
 		const typeComboCount: {[k: string]: number} = {};
 		const typeWeaknesses: {[k: string]: number} = {};
 		const teamDetails: RandomTeamsTypes.TeamDetails = {};
-		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, isDoubles);
+
+		const pokemonList = isDoubles ? Object.keys(this.randomDoublesSets) : Object.keys(this.randomSets);
+		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
 
 		// Remove PotD from baseSpeciesPool
 		if (baseSpeciesPool.includes(potd.baseSpecies)) {
@@ -61,6 +63,10 @@ export class RandomPOTDTeams extends RandomTeams {
 			}
 			let species = this.sample(currentSpeciesPool);
 			if (!species.exists) continue;
+
+			// Limit to one of each species (Species Clause)
+			if (baseFormes[species.baseSpecies]) continue;
+
 			// Illusion shouldn't be on the last slot
 			if (species.baseSpecies === 'Zoroark' && pokemon.length >= (this.maxTeamSize - 1)) continue;
 

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -3407,7 +3407,7 @@
             },
             {
                 "role": "Doubles Support",
-                "movepool": ["Encore", "Follow Me", "Helping Hand", "Protect", "Super Fang", "Taunt", "Thunder Wave", "U-turn"],
+                "movepool": ["Encore", "Follow Me", "Helping Hand", "Population Bomb", "Protect", "Taunt", "Thunder Wave", "U-turn"],
                 "teraTypes": ["Ghost"]
             }
         ]

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -3567,7 +3567,7 @@
         "sets": [
             {
                 "role": "Offensive Protect",
-                "movepool": ["Crabhammer", "High Horsepower", "Knock Off", "Protect", "Rock Slide", "Substitute"],
+                "movepool": ["Crabhammer", "High Horsepower", "Knock Off", "Protect", "Rock Slide"],
                 "teraTypes": ["Dark", "Ground", "Water"]
             },
             {

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -414,7 +414,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Freeze-Dry", "Haze", "Hurricane", "Roost", "Substitute", "U-turn"],
+                "movepool": ["Brave Bird", "Freeze-Dry", "Haze", "Roost", "Substitute", "U-turn"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -529,7 +529,7 @@
         "sets": [
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Calm Mind", "Flamethrower", "Shadow Ball", "Substitute", "Will-O-Wisp"],
+                "movepool": ["Calm Mind", "Fire Blast", "Shadow Ball", "Substitute", "Will-O-Wisp"],
                 "teraTypes": ["Ghost"]
             },
             {
@@ -959,7 +959,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Encore", "Ice Beam", "Pain Split", "Protect", "Sludge Bomb", "Toxic", "Toxic Spikes"],
+                "movepool": ["Clear Smog", "Earthquake", "Encore", "Ice Beam", "Pain Split", "Protect", "Sludge Bomb", "Toxic", "Toxic Spikes"],
                 "teraTypes": ["Dark"]
             },
             {
@@ -1065,7 +1065,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Liquidation", "Stone Edge"],
-                "teraTypes": ["Ground", "Water"]
+                "teraTypes": ["Ground", "Steel"]
             }
         ]
     },
@@ -1225,7 +1225,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Crunch", "Ice Spinner", "Low Kick", "Wave Crash"],
-                "teraTypes": ["Dark", "Fighting", "Steel", "Water"]
+                "teraTypes": ["Dark", "Fighting", "Ice", "Steel", "Water"]
             }
         ]
     },
@@ -1408,7 +1408,7 @@
         "level": 84,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Support",
                 "movepool": ["Body Press", "Flash Cannon", "Mirror Coat", "Thunderbolt", "Volt Switch"],
                 "teraTypes": ["Electric", "Flying", "Water"]
             }
@@ -2204,6 +2204,11 @@
                 "role": "Fast Attacker",
                 "movepool": ["Calm Mind", "Focus Blast", "Hyper Voice", "Psyshock", "U-turn"],
                 "teraTypes": ["Fighting", "Normal", "Psychic"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Close Combat", "Psychic", "Relic Song", "Tera Blast"],
+                "teraTypes": ["Normal"]
             }
         ]
     },
@@ -2239,6 +2244,16 @@
                 "role": "Fast Attacker",
                 "movepool": ["Dark Pulse", "Grass Knot", "Gunk Shot", "Hydro Pump", "Ice Beam", "Toxic Spikes", "U-turn"],
                 "teraTypes": ["Dark", "Poison", "Water"]
+            }
+        ]
+    },
+    "greninjabond": {
+        "level": 81,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Dark Pulse", "Gunk Shot", "Hydro Pump", "Ice Beam"],
+                "teraTypes": ["Poison", "Water"]
             }
         ]
     },
@@ -2512,7 +2527,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Defog", "Leaf Blade", "Roost", "Sucker Punch", "Swords Dance", "Triple Arrows", "U-turn"],
+                "movepool": ["Defog", "Knock Off", "Leaf Blade", "Roost", "Sucker Punch", "Swords Dance", "Triple Arrows", "U-turn"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -2728,7 +2743,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Aura Sphere", "Flash Cannon", "Fleur Cannon", "Pain Split", "Spikes", "Volt Switch"],
-                "teraTypes": ["Fairy", "Fighting", "Steel", "Water"]
+                "teraTypes": ["Fairy", "Fighting", "Water"]
             },
             {
                 "role": "Bulky Setup",
@@ -2813,7 +2828,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Overheat", "Rapid Spin", "Spikes", "Stealth Rock", "Stone Edge", "Will-O-Wisp"],
-                "teraTypes": ["Water"]
+                "teraTypes": ["Ghost", "Grass", "Water"]
             }
         ]
     },
@@ -3284,6 +3299,11 @@
                 "role": "Fast Support",
                 "movepool": ["Flower Trick", "Knock Off", "Play Rough", "Toxic Spikes", "U-turn"],
                 "teraTypes": ["Dark", "Grass"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Flower Trick", "Hone Claws", "Knock Off", "Play Rough", "Toxic Spikes"],
+                "teraTypes": ["Dark", "Fairy", "Grass"]
             }
         ]
     },
@@ -3874,11 +3894,6 @@
                 "role": "Fast Support",
                 "movepool": ["Earth Power", "Spikes", "Stealth Rock", "Thunder Wave", "Thunderbolt", "Volt Switch"],
                 "teraTypes": ["Electric", "Grass", "Ground"]
-            },
-            {
-                "role": "Tera Blast user",
-                "movepool": ["Earth Power", "Sunny Day", "Tera Blast", "Thunderbolt"],
-                "teraTypes": ["Fire"]
             }
         ]
     },
@@ -4008,7 +4023,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Dragon Dance", "Earthquake", "Ice Punch", "Stone Edge", "Wild Charge"],
-                "teraTypes": ["Ground", "Rock"]
+                "teraTypes": ["Grass", "Ground", "Rock"]
             }
         ]
     },

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1614,6 +1614,8 @@ export class RandomTeams {
 		for (const baseSpecies of Object.keys(baseSpeciesCount)) {
 			for (let i = 0; i < Math.min(Math.ceil(baseSpeciesCount[baseSpecies] / 3), 3); i++) {
 				baseSpeciesPool.push(baseSpecies);
+				// Squawkabilly has 4 formes, but only 2 functionally different formes, so only include it 1x
+				if (baseSpecies === 'Squawkabilly') break;
 			}
 		}
 		return [pokemonPool, baseSpeciesPool];

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1658,6 +1658,10 @@ export class RandomTeams {
 			}
 			let species = this.sample(currentSpeciesPool);
 			if (!species.exists) continue;
+
+			// Limit to one of each species (Species Clause)
+			if (baseFormes[species.baseSpecies]) continue;
+
 			// Illusion shouldn't be on the last slot
 			if (species.baseSpecies === 'Zoroark' && pokemon.length >= (this.maxTeamSize - 1)) continue;
 

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -485,73 +485,96 @@ export class RandomTeams {
 		}
 
 		if (isDoubles) {
-			// In order of decreasing generalizability
-			this.incompatibleMoves(moves, movePool, SPEED_CONTROL, SPEED_CONTROL);
-			this.incompatibleMoves(moves, movePool, HAZARDS, HAZARDS);
-			this.incompatibleMoves(moves, movePool, 'rockslide', 'stoneedge');
-			this.incompatibleMoves(moves, movePool, SETUP, ['fakeout', 'helpinghand']);
-			this.incompatibleMoves(moves, movePool, PROTECT_MOVES, 'wideguard');
-			this.incompatibleMoves(moves, movePool, ['fierydance', 'fireblast'], 'heatwave');
-			this.incompatibleMoves(moves, movePool, 'dazzlinggleam', ['fleurcannon', 'moonblast']);
-			this.incompatibleMoves(moves, movePool, 'poisongas', 'toxicspikes');
-			this.incompatibleMoves(moves, movePool, RECOVERY_MOVES, 'healpulse');
-			this.incompatibleMoves(moves, movePool, 'haze', ['icywind', 'rocktomb']);
-			this.incompatibleMoves(moves, movePool, 'disable', 'encore');
-			this.incompatibleMoves(moves, movePool, 'freezedry', 'icebeam');
-			this.incompatibleMoves(moves, movePool, 'bodyslam', 'doubleedge');
-			this.incompatibleMoves(moves, movePool, 'energyball', 'leafstorm');
-			this.incompatibleMoves(moves, movePool, 'earthpower', 'sandsearstorm');
-			this.incompatibleMoves(moves, movePool, 'drumbeating', 'woodhammer');
-			this.incompatibleMoves(moves, movePool, 'boomburst', 'hyperdrill');
+			const doublesIncompatiblePairs = [
+				// In order of decreasing generalizability
+				[SPEED_CONTROL, SPEED_CONTROL],
+				[HAZARDS, HAZARDS],
+				['rockslide', 'stoneedge'],
+				[SETUP, ['fakeout', 'helpinghand']],
+				[PROTECT_MOVES, 'wideguard'],
+				[['fierydance', 'fireblast'], 'heatwave'],
+				['dazzlinggleam', ['fleurcannon', 'moonblast']],
+				['poisongas', 'toxicspikes'],
+				[RECOVERY_MOVES, 'healpulse'],
+				['haze', ['icywind', 'rocktomb']],
+				['disable', 'encore'],
+				['freezedry', 'icebeam'],
+				['bodyslam', 'doubleedge'],
+				['energyball', 'leafstorm'],
+				['earthpower', 'sandsearstorm'],
+				['drumbeating', 'woodhammer'],
+				['boomburst', 'hyperdrill'],
+			];
+
+			for (const pair of doublesIncompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
 
 			if (role !== 'Offensive Protect') {
 				this.incompatibleMoves(moves, movePool, PROTECT_MOVES, 'uturn');
 			}
 		}
 
-		// These moves don't mesh well with other aspects of the set
-		this.incompatibleMoves(moves, movePool, statusMoves, ['healingwish', 'switcheroo', 'trick']);
-		this.incompatibleMoves(moves, movePool, SETUP, PIVOT_MOVES);
-		this.incompatibleMoves(moves, movePool, SETUP, HAZARDS);
-		this.incompatibleMoves(moves, movePool, SETUP, ['defog', 'nuzzle', 'toxic', 'waterspout', 'yawn', 'haze']);
-		this.incompatibleMoves(moves, movePool, PHYSICAL_SETUP, PHYSICAL_SETUP);
-		this.incompatibleMoves(moves, movePool, SPECIAL_SETUP, 'thunderwave');
-		this.incompatibleMoves(moves, movePool, 'substitute', PIVOT_MOVES);
-		this.incompatibleMoves(moves, movePool, SPEED_SETUP, ['aquajet', 'rest', 'trickroom']);
-		this.incompatibleMoves(moves, movePool, 'curse', 'rapidspin');
-		this.incompatibleMoves(moves, movePool, 'dragondance', 'dracometeor');
-		this.incompatibleMoves(moves, movePool, 'healingwish', 'uturn');
+		// General incompatibilities
+		const incompatiblePairs = [
+			// These moves don't mesh well with other aspects of the set
+			[statusMoves, ['healingwish', 'switcheroo', 'trick']],
+			[SETUP, PIVOT_MOVES],
+			[SETUP, HAZARDS],
+			[SETUP, ['defog', 'nuzzle', 'toxic', 'waterspout', 'yawn', 'haze']],
+			[PHYSICAL_SETUP, PHYSICAL_SETUP],
+			[SPECIAL_SETUP, 'thunderwave'],
+			['substitute', PIVOT_MOVES],
+			[SPEED_SETUP, ['aquajet', 'rest', 'trickroom']],
+			['curse', 'rapidspin'],
+			['dragondance', 'dracometeor'],
+			['healingwish', 'uturn'],
 
+			// These attacks are redundant with each other
+			['psychic', 'psyshock'],
+			['surf', 'hydropump'],
+			['liquidation', 'wavecrash'],
+			[['airslash', 'bravebird', 'hurricane'], ['airslash', 'bravebird', 'hurricane']],
+			[['knockoff', 'bite'], 'foulplay'],
+			['doubleedge', 'headbutt'],
+			['fireblast', ['fierydance', 'flamethrower']],
+			['lavaplume', 'magmastorm'],
+			['thunderpunch', 'wildcharge'],
+			['gunkshot', ['direclaw', 'poisonjab']],
+			['aurasphere', 'focusblast'],
+			['closecombat', 'drainpunch'],
+			['bugbite', 'pounce'],
+			['bittermalice', 'shadowball'],
+			[['dragonpulse', 'spacialrend'], 'dracometeor'],
 
-		// These attacks are redundant with each other
-		this.incompatibleMoves(moves, movePool, 'psychic', 'psyshock');
-		this.incompatibleMoves(moves, movePool, 'surf', 'hydropump');
-		this.incompatibleMoves(moves, movePool, 'liquidation', 'wavecrash');
-		this.incompatibleMoves(moves, movePool, ['airslash', 'bravebird', 'hurricane'], ['airslash', 'bravebird', 'hurricane']);
-		this.incompatibleMoves(moves, movePool, ['knockoff', 'bite'], 'foulplay');
-		this.incompatibleMoves(moves, movePool, 'doubleedge', 'headbutt');
-		this.incompatibleMoves(moves, movePool, 'fireblast', ['fierydance', 'flamethrower']);
-		this.incompatibleMoves(moves, movePool, 'lavaplume', 'magmastorm');
-		this.incompatibleMoves(moves, movePool, 'thunderpunch', 'wildcharge');
-		this.incompatibleMoves(moves, movePool, 'gunkshot', ['direclaw', 'poisonjab']);
-		this.incompatibleMoves(moves, movePool, 'aurasphere', 'focusblast');
-		this.incompatibleMoves(moves, movePool, 'closecombat', 'drainpunch');
-		this.incompatibleMoves(moves, movePool, 'bugbite', 'pounce');
-		this.incompatibleMoves(moves, movePool, 'bittermalice', 'shadowball');
-		this.incompatibleMoves(moves, movePool, ['dragonpulse', 'spacialrend'], 'dracometeor');
+			// These status moves are redundant with each other
+			['taunt', 'disable'],
+			['toxic', 'willowisp'],
+			[['thunderwave', 'toxic', 'willowisp'], 'toxicspikes'],
+			['thunderwave', 'yawn'],
+
+			// This space reserved for assorted hardcodes that otherwise make little sense out of context
+			// Landorus
+			['nastyplot', 'rockslide'],
+			// Persian
+			['switcheroo', 'fakeout'],
+			// Beartic
+			['snowscape', 'swordsdance'],
+			// Magnezone
+			['bodypress', 'mirrorcoat'],
+			// Amoonguss, though this can work well as a general rule later
+			['toxic', 'clearsmog'],
+			// Chansey and Blissey
+			['healbell', 'stealthrock'],
+		];
+
+		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
+
 		if (!types.includes('Ice')) {
 			this.incompatibleMoves(moves, movePool, 'icebeam', 'icywind');
 		}
 
-
-		// These status moves are redundant with each other
 		if (!isDoubles) {
 			this.incompatibleMoves(moves, movePool, ['taunt', 'strengthsap'], 'encore');
 		}
-		this.incompatibleMoves(moves, movePool, 'taunt', 'disable');
-		this.incompatibleMoves(moves, movePool, 'toxic', 'willowisp');
-		this.incompatibleMoves(moves, movePool, ['thunderwave', 'toxic', 'willowisp'], 'toxicspikes');
-		this.incompatibleMoves(moves, movePool, 'thunderwave', 'yawn');
 
 		// This space reserved for assorted hardcodes that otherwise make little sense out of context
 		if (species.id === "dugtrio") {
@@ -560,24 +583,12 @@ export class RandomTeams {
 		if (species.id === "cyclizar") {
 			this.incompatibleMoves(moves, movePool, 'taunt', 'knockoff');
 		}
-		// Landorus
-		this.incompatibleMoves(moves, movePool, 'nastyplot', 'rockslide');
-		// Persian
-		this.incompatibleMoves(moves, movePool, 'switcheroo', 'fakeout');
-		// Beartic
-		this.incompatibleMoves(moves, movePool, 'snowscape', 'swordsdance');
-		// Magnezone
-		this.incompatibleMoves(moves, movePool, 'bodypress', 'mirrorcoat');
-		// Amoonguss, though this can work well as a general rule later
-		this.incompatibleMoves(moves, movePool, 'toxic', 'clearsmog');
 		// Dudunsparce
 		if (species.baseSpecies === 'Dudunsparce') this.incompatibleMoves(moves, movePool, 'earthpower', 'shadowball');
 		// Luvdisc
 		if (species.id === 'luvdisc' && !isDoubles) {
 			this.incompatibleMoves(moves, movePool, 'charm', ['icebeam', 'icywind']);
 		}
-		// Chansey and Blissey
-		this.incompatibleMoves(moves, movePool, 'healbell', 'stealthrock');
 	}
 
 	// Checks for and removes incompatible moves, starting with the first move in movesA.

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -971,7 +971,7 @@ export class RandomTeams {
 		role: RandomTeamsTypes.Role,
 	): boolean {
 		if ([
-			'Armor Tail', 'Early Bird', 'Flare Boost', 'Gluttony', 'Harvest', 'Hydration', 'Ice Body', 'Immunity',
+			'Armor Tail', 'Battle Bond', 'Early Bird', 'Flare Boost', 'Gluttony', 'Harvest', 'Hydration', 'Ice Body', 'Immunity',
 			'Moody', 'Own Tempo', 'Pressure', 'Quick Feet', 'Rain Dish', 'Sand Veil', 'Snow Cloak', 'Steadfast', 'Steam Engine',
 		].includes(ability)) return true;
 
@@ -979,8 +979,6 @@ export class RandomTeams {
 		// Abilities which are primarily useful for certain moves
 		case 'Contrary': case 'Serene Grace': case 'Skill Link': case 'Strong Jaw':
 			return !counter.get(toID(ability));
-		case 'Battle Bond':
-			return !isDoubles;
 		case 'Chlorophyll':
 			return (!moves.has('sunnyday') && !teamDetails.sun && species.id !== 'lilligant');
 		case 'Cloud Nine':
@@ -1014,6 +1012,8 @@ export class RandomTeams {
 			return !counter.ironFist;
 		case 'Justified':
 			return !counter.get('Physical');
+		case 'Libero': case 'Protean':
+			return role === 'Offensive Protect' || (species.id === 'meowscarada' && role === 'Fast Attacker');
 		case 'Mold Breaker':
 			return (abilities.has('Sharpness') || abilities.has('Unburden'));
 		case 'Moxie':
@@ -1024,8 +1024,6 @@ export class RandomTeams {
 			return !counter.get('Grass');
 		case 'Prankster':
 			return !counter.get('Status');
-		case 'Protean':
-			return role === 'Offensive Protect';
 		case 'Reckless':
 			return !counter.get('recoil');
 		case 'Rock Head':
@@ -1377,7 +1375,9 @@ export class RandomTeams {
 			);
 			return (scarfReqs && this.randomChance(1, 2)) ? 'Choice Scarf' : 'Choice Specs';
 		}
-		if (!counter.get('Status') && role !== 'Fast Attacker' && role !== 'Wallbreaker') return 'Assault Vest';
+		if (!counter.get('Status') && !['Fast Attacker', 'Wallbreaker', 'Tera Blast user'].includes(role)) {
+			return 'Assault Vest';
+		}
 		if (counter.get('speedsetup') && this.dex.getEffectiveness('Ground', species) < 1) return 'Weakness Policy';
 		if (species.id === 'urshifurapidstrike') return 'Punching Glove';
 		if (species.id === 'palkia') return 'Lustrous Orb';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -55,60 +55,60 @@ type MoveEnforcementChecker = (
 ) => boolean;
 
 // Moves that restore HP:
-const RecoveryMove = [
+const RECOVERY_MOVES = [
 	'healorder', 'milkdrink', 'moonlight', 'morningsun', 'recover', 'roost', 'shoreup', 'slackoff', 'softboiled', 'strengthsap', 'synthesis',
 ];
 // Moves that drop stats:
-const ContraryMoves = [
+const CONTRARY_MOVES = [
 	'armorcannon', 'closecombat', 'leafstorm', 'makeitrain', 'overheat', 'spinout', 'superpower', 'vcreate',
 ];
 // Moves that boost Attack:
-const PhysicalSetup = [
+const PHYSICAL_SETUP = [
 	'bellydrum', 'bulkup', 'coil', 'curse', 'dragondance', 'honeclaws', 'howl', 'meditate', 'poweruppunch', 'swordsdance', 'tidyup', 'victorydance',
 ];
 // Moves which boost Special Attack:
-const SpecialSetup = [
+const SPECIAL_SETUP = [
 	'calmmind', 'chargebeam', 'geomancy', 'nastyplot', 'quiverdance', 'tailglow', 'torchsong',
 ];
 // Moves that boost Attack AND Special Attack:
-const MixedSetup = [
+const MIXED_SETUP = [
 	'clangoroussoul', 'growth', 'happyhour', 'holdhands', 'noretreat', 'shellsmash', 'workup',
 ];
 // Some moves that only boost Speed:
-const SpeedSetup = [
+const SPEED_SETUP = [
 	'agility', 'autotomize', 'rockpolish',
 ];
 // Conglomerate for ease of access
-const Setup = [
+const SETUP = [
 	'acidarmor', 'agility', 'autotomize', 'bellydrum', 'bulkup', 'calmmind', 'coil', 'curse', 'dragondance', 'flamecharge',
 	'growth', 'honeclaws', 'howl', 'irondefense', 'meditate', 'nastyplot', 'noretreat', 'poweruppunch', 'quiverdance', 'rockpolish',
 	'shellsmash', 'shiftgear', 'swordsdance', 'tailglow', 'tidyup', 'trailblaze', 'workup', 'victorydance',
 ];
-const SpeedControl = [
+const SPEED_CONTROL = [
 	'electroweb', 'glare', 'icywind', 'lowsweep', 'quash', 'rocktomb', 'stringshot', 'tailwind', 'thunderwave', 'trickroom',
 ];
 // Moves that shouldn't be the only STAB moves:
-const NoStab = [
+const NO_STAB = [
 	'accelerock', 'aquajet', 'beakblast', 'bounce', 'breakingswipe', 'bulletpunch', 'chatter', 'chloroblast', 'clearsmog', 'covet',
 	'dragontail', 'electroweb', 'eruption', 'explosion', 'fakeout', 'feint', 'flamecharge', 'flipturn', 'iceshard', 'icywind', 'incinerate',
 	'machpunch', 'meteorbeam', 'mortalspin', 'nuzzle', 'pluck', 'pursuit', 'quickattack', 'rapidspin', 'reversal', 'selfdestruct',
 	'shadowsneak', 'skydrop', 'snarl', 'strugglebug', 'suckerpunch', 'uturn', 'watershuriken', 'vacuumwave', 'voltswitch', 'waterspout',
 ];
 // Hazard-setting moves
-const Hazards = [
+const HAZARDS = [
 	'spikes', 'stealthrock', 'stickyweb', 'toxicspikes',
 ];
 // Protect and its variants
-const ProtectMove = [
+const PROTECT_MOVES = [
 	'banefulbunker', 'protect', 'spikyshield',
 ];
 // Moves that switch the user out
-const PivotingMoves = [
+const PIVOT_MOVES = [
 	'chillyreception', 'flipturn', 'partingshot', 'shedtail', 'teleport', 'uturn', 'voltswitch',
 ];
 
 // Moves that should be paired together when possible
-const MovePairs = [
+const MOVE_PAIRS = [
 	['lightscreen', 'reflect'],
 	['sleeptalk', 'rest'],
 	['protect', 'wish'],
@@ -116,15 +116,15 @@ const MovePairs = [
 ];
 
 /** Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type */
-const priorityPokemon = [
+const PRIORITY_POKEMON = [
 	'banette', 'breloom', 'brutebonnet', 'cacturne', 'ceruledge', 'honchkrow', 'lycanrocdusk', 'mimikyu', 'scizor',
 ];
 
 /** Pokemon who should never be in the lead slot */
-const noLeadPokemon = [
+const NO_LEAD_POKEMON = [
 	'Basculegion', 'Houndstone', 'Rillaboom', 'Zacian', 'Zamazenta',
 ];
-const doublesNoLeadPokemon = [
+const DOUBLES_NO_LEAD_POKEMON = [
 	'Basculegion', 'Houndstone', 'Roaring Moon', 'Zacian', 'Zamazenta',
 ];
 
@@ -155,7 +155,7 @@ export class RandomTeams {
 		format = Dex.formats.get(format);
 		this.dex = Dex.forFormat(format);
 		this.gen = this.dex.gen;
-		this.noStab = NoStab;
+		this.noStab = NO_STAB;
 
 		const ruleTable = Dex.formats.getRuleTable(format);
 		this.maxTeamSize = ruleTable.maxTeamSize;
@@ -373,7 +373,7 @@ export class RandomTeams {
 			if (move.drain) counter.add('drain');
 			// Moves which have a base power:
 			if (move.basePower || move.basePowerCallback) {
-				if (!this.noStab.includes(moveid) || priorityPokemon.includes(species.id) && move.priority > 0) {
+				if (!this.noStab.includes(moveid) || PRIORITY_POKEMON.includes(species.id) && move.priority > 0) {
 					counter.add(moveType);
 					if (types.includes(moveType)) counter.stabCounter++;
 					if (teraType === moveType) counter.add('stabtera');
@@ -397,14 +397,14 @@ export class RandomTeams {
 			if (move.accuracy && move.accuracy !== true && move.accuracy < 90) counter.add('inaccurate');
 
 			// Moves that change stats:
-			if (RecoveryMove.includes(moveid)) counter.add('recovery');
-			if (ContraryMoves.includes(moveid)) counter.add('contrary');
-			if (PhysicalSetup.includes(moveid)) counter.add('physicalsetup');
-			if (SpecialSetup.includes(moveid)) counter.add('specialsetup');
-			if (MixedSetup.includes(moveid)) counter.add('mixedsetup');
-			if (SpeedSetup.includes(moveid)) counter.add('speedsetup');
-			if (Setup.includes(moveid)) counter.add('setup');
-			if (Hazards.includes(moveid)) counter.add('hazards');
+			if (RECOVERY_MOVES.includes(moveid)) counter.add('recovery');
+			if (CONTRARY_MOVES.includes(moveid)) counter.add('contrary');
+			if (PHYSICAL_SETUP.includes(moveid)) counter.add('physicalsetup');
+			if (SPECIAL_SETUP.includes(moveid)) counter.add('specialsetup');
+			if (MIXED_SETUP.includes(moveid)) counter.add('mixedsetup');
+			if (SPEED_SETUP.includes(moveid)) counter.add('speedsetup');
+			if (SETUP.includes(moveid)) counter.add('setup');
+			if (HAZARDS.includes(moveid)) counter.add('hazards');
 		}
 
 		counter.set('Physical', Math.floor(categories['Physical']));
@@ -430,7 +430,7 @@ export class RandomTeams {
 		// If we have two unfilled moves and only one unpaired move, cull the unpaired move.
 		if (moves.size === this.maxMoveCount - 2) {
 			const unpairedMoves = [...movePool];
-			for (const pair of MovePairs) {
+			for (const pair of MOVE_PAIRS) {
 				if (movePool.includes(pair[0]) && movePool.includes(pair[1])) {
 					this.fastPop(unpairedMoves, unpairedMoves.indexOf(pair[0]));
 					this.fastPop(unpairedMoves, unpairedMoves.indexOf(pair[1]));
@@ -443,7 +443,7 @@ export class RandomTeams {
 
 		// These moves are paired, and shouldn't appear if there is not room for them both.
 		if (moves.size === this.maxMoveCount - 1) {
-			for (const pair of MovePairs) {
+			for (const pair of MOVE_PAIRS) {
 				if (movePool.includes(pair[0]) && movePool.includes(pair[1])) {
 					this.fastPop(movePool, movePool.indexOf(pair[0]));
 					this.fastPop(movePool, movePool.indexOf(pair[1]));
@@ -486,15 +486,15 @@ export class RandomTeams {
 
 		if (isDoubles) {
 			// In order of decreasing generalizability
-			this.incompatibleMoves(moves, movePool, SpeedControl, SpeedControl);
-			this.incompatibleMoves(moves, movePool, Hazards, Hazards);
+			this.incompatibleMoves(moves, movePool, SPEED_CONTROL, SPEED_CONTROL);
+			this.incompatibleMoves(moves, movePool, HAZARDS, HAZARDS);
 			this.incompatibleMoves(moves, movePool, 'rockslide', 'stoneedge');
-			this.incompatibleMoves(moves, movePool, Setup, ['fakeout', 'helpinghand']);
-			this.incompatibleMoves(moves, movePool, ProtectMove, 'wideguard');
+			this.incompatibleMoves(moves, movePool, SETUP, ['fakeout', 'helpinghand']);
+			this.incompatibleMoves(moves, movePool, PROTECT_MOVES, 'wideguard');
 			this.incompatibleMoves(moves, movePool, ['fierydance', 'fireblast'], 'heatwave');
 			this.incompatibleMoves(moves, movePool, 'dazzlinggleam', ['fleurcannon', 'moonblast']);
 			this.incompatibleMoves(moves, movePool, 'poisongas', 'toxicspikes');
-			this.incompatibleMoves(moves, movePool, RecoveryMove, 'healpulse');
+			this.incompatibleMoves(moves, movePool, RECOVERY_MOVES, 'healpulse');
 			this.incompatibleMoves(moves, movePool, 'haze', ['icywind', 'rocktomb']);
 			this.incompatibleMoves(moves, movePool, 'disable', 'encore');
 			this.incompatibleMoves(moves, movePool, 'freezedry', 'icebeam');
@@ -505,19 +505,19 @@ export class RandomTeams {
 			this.incompatibleMoves(moves, movePool, 'boomburst', 'hyperdrill');
 
 			if (role !== 'Offensive Protect') {
-				this.incompatibleMoves(moves, movePool, ProtectMove, 'uturn');
+				this.incompatibleMoves(moves, movePool, PROTECT_MOVES, 'uturn');
 			}
 		}
 
 		// These moves don't mesh well with other aspects of the set
 		this.incompatibleMoves(moves, movePool, statusMoves, ['healingwish', 'switcheroo', 'trick']);
-		this.incompatibleMoves(moves, movePool, Setup, PivotingMoves);
-		this.incompatibleMoves(moves, movePool, Setup, Hazards);
-		this.incompatibleMoves(moves, movePool, Setup, ['defog', 'nuzzle', 'toxic', 'waterspout', 'yawn', 'haze']);
-		this.incompatibleMoves(moves, movePool, PhysicalSetup, PhysicalSetup);
-		this.incompatibleMoves(moves, movePool, SpecialSetup, 'thunderwave');
-		this.incompatibleMoves(moves, movePool, 'substitute', PivotingMoves);
-		this.incompatibleMoves(moves, movePool, SpeedSetup, ['aquajet', 'rest', 'trickroom']);
+		this.incompatibleMoves(moves, movePool, SETUP, PIVOT_MOVES);
+		this.incompatibleMoves(moves, movePool, SETUP, HAZARDS);
+		this.incompatibleMoves(moves, movePool, SETUP, ['defog', 'nuzzle', 'toxic', 'waterspout', 'yawn', 'haze']);
+		this.incompatibleMoves(moves, movePool, PHYSICAL_SETUP, PHYSICAL_SETUP);
+		this.incompatibleMoves(moves, movePool, SPECIAL_SETUP, 'thunderwave');
+		this.incompatibleMoves(moves, movePool, 'substitute', PIVOT_MOVES);
+		this.incompatibleMoves(moves, movePool, SPEED_SETUP, ['aquajet', 'rest', 'trickroom']);
 		this.incompatibleMoves(moves, movePool, 'curse', 'rapidspin');
 		this.incompatibleMoves(moves, movePool, 'dragondance', 'dracometeor');
 		this.incompatibleMoves(moves, movePool, 'healingwish', 'uturn');
@@ -772,7 +772,7 @@ export class RandomTeams {
 		}
 
 		// Enforce STAB priority
-		if (['Bulky Attacker', 'Bulky Setup', 'Doubles Wallbreaker'].includes(role) || priorityPokemon.includes(species.id)) {
+		if (['Bulky Attacker', 'Bulky Setup', 'Doubles Wallbreaker'].includes(role) || PRIORITY_POKEMON.includes(species.id)) {
 			const priorityMoves = [];
 			for (const moveid of movePool) {
 				const move = this.dex.moves.get(moveid);
@@ -843,7 +843,7 @@ export class RandomTeams {
 
 		// Enforce recovery
 		if (['Bulky Support', 'Bulky Attacker', 'Bulky Setup'].includes(role)) {
-			const recoveryMoves = movePool.filter(moveid => RecoveryMove.includes(moveid));
+			const recoveryMoves = movePool.filter(moveid => RECOVERY_MOVES.includes(moveid));
 			if (recoveryMoves.length) {
 				const moveid = this.sample(recoveryMoves);
 				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead, isDoubles,
@@ -854,14 +854,14 @@ export class RandomTeams {
 		// Enforce setup
 		if (role.includes('Setup') || role === 'Tera Blast user') {
 			// First, try to add a non-Speed setup move
-			const nonSpeedSetupMoves = movePool.filter(moveid => Setup.includes(moveid) && !SpeedSetup.includes(moveid));
+			const nonSpeedSetupMoves = movePool.filter(moveid => SETUP.includes(moveid) && !SPEED_SETUP.includes(moveid));
 			if (nonSpeedSetupMoves.length) {
 				const moveid = this.sample(nonSpeedSetupMoves);
 				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead, isDoubles,
 					movePool, teraType, role);
 			} else {
 				// No non-Speed setup moves, so add any (Speed) setup move
-				const setupMoves = movePool.filter(moveid => Setup.includes(moveid));
+				const setupMoves = movePool.filter(moveid => SETUP.includes(moveid));
 				if (setupMoves.length) {
 					const moveid = this.sample(setupMoves);
 					counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead, isDoubles,
@@ -887,7 +887,7 @@ export class RandomTeams {
 
 		// Enforce Protect
 		if (role.includes('Protect')) {
-			const protectMoves = movePool.filter(moveid => ProtectMove.includes(moveid));
+			const protectMoves = movePool.filter(moveid => PROTECT_MOVES.includes(moveid));
 			if (protectMoves.length) {
 				const moveid = this.sample(protectMoves);
 				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead, isDoubles,
@@ -946,7 +946,7 @@ export class RandomTeams {
 			const moveid = this.sample(movePool);
 			counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead, isDoubles,
 				movePool, teraType, role);
-			for (const pair of MovePairs) {
+			for (const pair of MOVE_PAIRS) {
 				if (moveid === pair[0] && movePool.includes(pair[1])) {
 					counter = this.addMove(pair[1], moves, types, abilities, teamDetails, species, isLead, isDoubles,
 						movePool, teraType, role);
@@ -1419,7 +1419,7 @@ export class RandomTeams {
 		if (species.id === 'pawmot' && moves.has('nuzzle')) return 'Leppa Berry';
 		if (
 			['Fast Bulky Setup', 'Fast Attacker', 'Setup Sweeper', 'Wallbreaker'].some(m => role === m) &&
-			types.includes('Dark') && moves.has('suckerpunch') && !priorityPokemon.includes(species.id) &&
+			types.includes('Dark') && moves.has('suckerpunch') && !PRIORITY_POKEMON.includes(species.id) &&
 			counter.get('physicalsetup') && counter.get('Dark')
 		) return 'Black Glasses';
 		if (role === 'Fast Support' || role === 'Fast Bulky Setup') {
@@ -1725,8 +1725,8 @@ export class RandomTeams {
 
 			if (leadsRemaining) {
 				if (
-					isDoubles && doublesNoLeadPokemon.includes(species.baseSpecies) ||
-					!isDoubles && noLeadPokemon.includes(species.baseSpecies)
+					isDoubles && DOUBLES_NO_LEAD_POKEMON.includes(species.baseSpecies) ||
+					!isDoubles && NO_LEAD_POKEMON.includes(species.baseSpecies)
 				) {
 					if (pokemon.length + leadsRemaining === this.maxTeamSize) continue;
 					set = this.randomSet(species, teamDetails, false, isDoubles);

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -508,9 +508,7 @@ export class RandomTeams {
 
 			for (const pair of doublesIncompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
 
-			if (role !== 'Offensive Protect') {
-				this.incompatibleMoves(moves, movePool, PROTECT_MOVES, 'uturn');
-			}
+			if (role !== 'Offensive Protect') this.incompatibleMoves(moves, movePool, PROTECT_MOVES, 'uturn');
 		}
 
 		// General incompatibilities
@@ -568,27 +566,15 @@ export class RandomTeams {
 
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
 
-		if (!types.includes('Ice')) {
-			this.incompatibleMoves(moves, movePool, 'icebeam', 'icywind');
-		}
+		if (!types.includes('Ice')) this.incompatibleMoves(moves, movePool, 'icebeam', 'icywind');
 
-		if (!isDoubles) {
-			this.incompatibleMoves(moves, movePool, ['taunt', 'strengthsap'], 'encore');
-		}
+		if (!isDoubles) this.incompatibleMoves(moves, movePool, ['taunt', 'strengthsap'], 'encore');
 
 		// This space reserved for assorted hardcodes that otherwise make little sense out of context
-		if (species.id === "dugtrio") {
-			this.incompatibleMoves(moves, movePool, statusMoves, 'memento');
-		}
-		if (species.id === "cyclizar") {
-			this.incompatibleMoves(moves, movePool, 'taunt', 'knockoff');
-		}
-		// Dudunsparce
+		if (species.id === "dugtrio") this.incompatibleMoves(moves, movePool, statusMoves, 'memento');
+		if (species.id === "cyclizar") this.incompatibleMoves(moves, movePool, 'taunt', 'knockoff');
 		if (species.baseSpecies === 'Dudunsparce') this.incompatibleMoves(moves, movePool, 'earthpower', 'shadowball');
-		// Luvdisc
-		if (species.id === 'luvdisc' && !isDoubles) {
-			this.incompatibleMoves(moves, movePool, 'charm', ['icebeam', 'icywind']);
-		}
+		if (species.id === 'luvdisc' && !isDoubles) this.incompatibleMoves(moves, movePool, 'charm', ['icebeam', 'icywind']);
 	}
 
 	// Checks for and removes incompatible moves, starting with the first move in movesA.

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -33,13 +33,11 @@ interface BattleFactorySet {
 }
 export class MoveCounter extends Utils.Multiset<string> {
 	damagingMoves: Set<Move>;
-	stabCounter: number;
 	ironFist: number;
 
 	constructor() {
 		super();
 		this.damagingMoves = new Set();
-		this.stabCounter = 0;
 		this.ironFist = 0;
 	}
 
@@ -375,7 +373,7 @@ export class RandomTeams {
 			if (move.basePower || move.basePowerCallback) {
 				if (!this.noStab.includes(moveid) || PRIORITY_POKEMON.includes(species.id) && move.priority > 0) {
 					counter.add(moveType);
-					if (types.includes(moveType)) counter.stabCounter++;
+					if (types.includes(moveType)) counter.add('stab');
 					if (teraType === moveType) counter.add('stabtera');
 					counter.damagingMoves.add(move);
 				}
@@ -822,7 +820,7 @@ export class RandomTeams {
 		}
 
 		// If no STAB move was added, add a STAB move
-		if (!counter.stabCounter) {
+		if (!counter.get('stab')) {
 			const stabMoves = [];
 			for (const moveid of movePool) {
 				const move = this.dex.moves.get(moveid);


### PR DESCRIPTION
Changes marked with an * help to reduce the frequency of choice items.

**Gen 9 Random Battle:**
-add Battle Bond Greninja with Dark Pulse/Gunk Shot/Hydro Pump/Ice Beam, Tera Poison/Water. It is Fast Attacker and gets Life Orb. Council decision. *
-add Overgrow Meowscarada second set: Fast Attacker, Flower Trick/Hone Claws/Knock Off/Play Rough/Toxic Spikes, Tera Grass/Dark/Fairy. It gets Life Orb. Council decision. *

-Sandy Shocks: remove Tera Blast user set, due to its significant winrate drop
-Meloetta: add Tera Blast user set, with Close Combat, Relic Song, Psychic, and Tera Normal. It gets Life Orb. It's the same set that it runs in doubles. *
-Magnezone: role change to Bulky Support, to lower Scarf to 50% *
-Decidueye-Hisui: +Knock Off
-Bulky Attacker Magearna: -Tera Steel
-Bulky Setup Floatzel: +Tera Ice
-Articuno: -Hurricane, +Brave Bird
-Bulky Setup Iron Thorns: +Tera Grass
-Bulky Support Swalot: +Clear Smog
-Coalossal: +Tera Ghost, +Tera Grass
-Setup Sweeper Whiscash: +Tera Steel, -Tera Water
-Setup Typhlosion-Hisui: -Flamethrower, +Fire Blast

**Gen 9 Random Doubles Battle:**
-Doubles Support Maushold-Four: -Super Fang, +Population Bomb. This fixes an oversight in the last doubles update, when we changed Maushold's set but not this forme.
-Cinderace (Offensive Protect) will now get Blaze as its ability, instead of Libero.
-Offensive Protect Klawf: -Substitute

Technical:
-SNAKE_CASE for top-level constants
-Arrayification of incompatible-moves
-Appearance rate of formes (https://github.com/smogon/pokemon-showdown/pull/9708)
-Remove the numerical STAB counter, as the number is not used anywhere. Instead, just track `'stab'` in the move counter.