### PR TITLE
Add selfdestruct property to Final Gambit

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -5300,6 +5300,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			pokemon.faint();
 			return damage;
 		},
+		selfdestruct: "ifHit",
 		category: "Special",
 		name: "Final Gambit",
 		pp: 5,


### PR DESCRIPTION
There are 7 moves in Pokemon that sacrifice the user.
Each one has a `selfdestruct` property that is either `always` or `ifHit` except Final Gambit.

Final Gambit does not need the `selfdestruct` property to work, but with it, it is much more consistent to check if a move sacrifices its user.

If you want to know if a random move sacrifices its user you have to use
```javascript
if(move.selfdestruct == "always" || (move.selfdestruct == "ifHit" || move.name == "finalgambit") && move.hit))
```
Forgetting to implement an extra check for Final Gambit is easy.  

---
Giving Final Gambit the `selfdestruct` property solves this problem
```javascript
if(move.selfdestruct == "always" || move.selfdestruct == "ifHit" && move.hit)
```
