### PR TITLE
Don't try to lint excluded files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,9 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-        
+
     - run: npm ci
-    
+
     - name: Determine which files to lint (if pull request)
       if: ${{ github.event_name == 'pull_request' }}
       id: changed-files
@@ -43,6 +43,15 @@ jobs:
           ./server/**/*.tsx
           ./sim/**/*.ts
           ./tools/set-import/*.ts
+        files_ignore: |
+          ./logs/
+          ./node_modules/
+          ./dist/
+          ./data/**/learnsets.ts
+          ./tools/set-import/importer.js
+          ./tools/set-import/sets
+          ./tools/modlog/converter.js
+          ./server/global-variables.d.ts
 
     - name: Determine whether test/sim or test/random-battles need to run (if pull request)
       if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,13 @@ jobs:
       uses: tj-actions/changed-files@v35
       with:
         files: |
-          **/*.js
-          **/*.ts
-          **/*.tsx
+          ./config/*.ts
+          ./data/**/*.ts
+          ./lib/*.ts
+          ./server/**/*.ts
+          ./server/**/*.tsx
+          ./sim/**/*.ts
+          ./tools/set-import/*.ts
 
     - name: Determine whether test/sim or test/random-battles need to run (if pull request)
       if: ${{ github.event_name == 'pull_request' }}

--- a/data/learnsets.ts
+++ b/data/learnsets.ts
@@ -15,7 +15,6 @@ export const Learnsets: {[speciesid: string]: LearnsetData} = {
 			megapunch: ["3L1"],
 			psychic: ["3L1"],
 			rage: ["3L1"],
-
 			razorwind: ["3L1"],
 			rest: ["3L1"],
 			seismictoss: ["3L1"],

--- a/data/learnsets.ts
+++ b/data/learnsets.ts
@@ -15,6 +15,7 @@ export const Learnsets: {[speciesid: string]: LearnsetData} = {
 			megapunch: ["3L1"],
 			psychic: ["3L1"],
 			rage: ["3L1"],
+
 			razorwind: ["3L1"],
 			rest: ["3L1"],
 			seismictoss: ["3L1"],


### PR DESCRIPTION
We're currently getting this warning when changing lint-excluded files, because we were explicitly marking that file to be linted. This fix is working locally with [act](https://github.com/nektos/act), hopefully also works on the real CI too

```
/home/runner/work/pokemon-showdown/pokemon-showdown/data/learnsets.ts
  0:0  warning  File ignored because of a matching ignore pattern. Use "--no-ignore" to override
```

The files specified on the CI workflow come from `.eslintrc.json`