### PR TITLE
CI: Ensure that selective linting takes all PR commits into consideration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 100 # assumes PR/push to master is no larger than 100 commits. Other solutions are needlessly complex.
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3


### PR DESCRIPTION
The CI pipeline for PRs only triggers on the latest pushed commit. With the old selective linting, only changes in _that_ commit would be linted. 

Fetching the 100 most recent commits (at most) _on the PR branch_ ensures selective linting and testing takes all PR commits into account.

The change does not impact merge/push-to-master, since testing/linting is not selective in that case and performance impact is minimal (added ~0-1s to the checkout step).