### PR TITLE
Randomized format set updates

### DIFF
--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -745,6 +745,10 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["drainpunch", "earthquake", "fakeout", "return", "suckerpunch"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["drainpunch", "earthquake", "fakeout", "return", "suckerpunch"]
             }
         ]
     },
@@ -1091,7 +1095,12 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquajet", "crunch", "dragondance", "earthquake", "icepunch", "liquidation", "swordsdance"],
+                "movepool": ["crunch", "dragondance", "earthquake", "icepunch", "liquidation"],
+                "preferredTypes": ["Ice"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["aquajet", "icepunch", "liquidation", "swordsdance"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -1123,8 +1132,12 @@
         "level": 97,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["defog", "knockoff", "lightscreen", "reflect", "roost", "toxic", "uturn"]
+                "role": "Bulky Support",
+                "movepool": ["knockoff", "lightscreen", "reflect", "roost", "toxic", "uturn"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["defog", "encore", "knockoff", "roost", "toxic", "uturn"]
             }
         ]
     },
@@ -1240,7 +1253,7 @@
                 "movepool": ["acrobatics", "leechseed", "strengthsap", "substitute"]
             },
             {
-                "role": "Fast Support",
+                "role": "Bulky Attacker",
                 "movepool": ["acrobatics", "encore", "sleeppowder", "strengthsap", "toxic", "uturn"]
             }
         ]
@@ -2228,7 +2241,7 @@
         "sets": [
             {
                 "role": "Z-Move user",
-                "movepool": ["encore", "return", "suckerpunch", "superpower"],
+                "movepool": ["encore", "feintattack", "return", "suckerpunch", "superpower"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -3094,8 +3107,8 @@
         "level": 86,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["dazzlinggleam", "painsplit", "shadowball", "substitute", "taunt", "willowisp"]
+                "role": "Bulky Attacker",
+                "movepool": ["dazzlinggleam", "painsplit", "shadowball", "taunt", "willowisp"]
             },
             {
                 "role": "Wallbreaker",
@@ -3352,7 +3365,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "gigadrain", "hiddenpowerfire", "knockoff", "leafstorm", "leechseed", "rockslide", "sleeppowder", "synthesis"]
+                "movepool": ["earthquake", "hiddenpowerfire", "knockoff", "leafstorm", "leechseed", "powerwhip", "rockslide", "sleeppowder", "synthesis"]
             },
             {
                 "role": "AV Pivot",
@@ -3746,7 +3759,7 @@
         "level": 84,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Fast Support",
                 "movepool": ["airslash", "earthpower", "leechseed", "rest", "seedflare", "substitute"],
                 "preferredTypes": ["Flying"]
             }
@@ -4806,7 +4819,7 @@
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["bugbuzz", "fireblast", "gigadrain", "hiddenpowerrock", "hurricane", "quiverdance", "roost"],
+                "movepool": ["bugbuzz", "fireblast", "gigadrain", "hurricane", "quiverdance", "roost"],
                 "preferredTypes": ["Bug", "Fire", "Flying"]
             }
         ]
@@ -5230,6 +5243,10 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["ironhead", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["ironhead", "sacredsword", "shadowclaw", "shadowsneak", "toxic"]
             }
         ]
     },

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -118,7 +118,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			Fighting: (movePool, moves, abilities, types, counter) => !counter.get('Fighting'),
 			Fire: (movePool, moves, abilities, types, counter) => !counter.get('Fire'),
 			Flying: (movePool, moves, abilities, types, counter, species) => (
-				!counter.get('Flying') && ['aerodactylmega', 'charizardmega', 'mantine'].every(m => species.id !== m) &&
+				!counter.get('Flying') && ['aerodactylmega', 'charizardmegay', 'mantine'].every(m => species.id !== m) &&
 				!movePool.includes('hiddenpowerflying')
 			),
 			Ghost: (movePool, moves, abilities, types, counter) => !counter.get('Ghost'),
@@ -359,8 +359,8 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			['destinybond', 'whirlwind'],
 			// Liepard
 			['copycat', 'uturn'],
-			// Seviper
-			['switcheroo', 'suckerpunch'],
+			// Spinda and Seviper
+			[['feintattack', 'switcheroo'], 'suckerpunch'],
 		];
 
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
@@ -716,8 +716,8 @@ export class RandomGen7Teams extends RandomGen8Teams {
 	): boolean {
 		switch (ability) {
 		case 'Battle Bond': case 'Dazzling': case 'Flare Boost': case 'Gluttony': case 'Harvest': case 'Hyper Cutter':
-		case 'Ice Body': case 'Innards Out': case 'Liquid Voice': case 'Magician': case 'Moody': case 'Sand Veil':
-		case 'Snow Cloak': case 'Steadfast': case 'Weak Armor':
+		case 'Ice Body': case 'Innards Out': case 'Liquid Voice': case 'Magician': case 'Moody': case 'Pressure':
+		case 'Sand Veil': case 'Snow Cloak': case 'Steadfast': case 'Weak Armor':
 			return true;
 		case 'Aerilate': case 'Galvanize': case 'Pixilate': case 'Refrigerate':
 			return ['doubleedge', 'hypervoice', 'return'].every(m => !moves.has(m));
@@ -768,7 +768,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			return !counter.get('Grass');
 		case 'Power Construct':
 			return species.forme === '10%';
-		case 'Pressure': case 'Synchronize':
+		case 'Synchronize':
 			return (counter.get('Status') < 2 || !!counter.get('recoil') || !!species.isMega);
 		case 'Regenerator':
 			return species.id === 'mienshao' || species.id === 'reuniclus';
@@ -850,6 +850,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (species.id === 'golemalola' && moves.has('return')) return 'Galvanize';
 		if (species.id === 'raticatealola') return 'Hustle';
 		if (species.id === 'ninjask' || species.id === 'seviper') return 'Infiltrator';
+		if (species.id === 'arcanine') return 'Intimidate';
 		if (species.id === 'rampardos' && role === 'Bulky Attacker') return 'Mold Breaker';
 		if (species.baseSpecies === 'Altaria') return 'Natural Cure';
 		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it
@@ -865,6 +866,9 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (abilities.has('Gluttony') && (moves.has('recycle') || moves.has('bellydrum'))) return 'Gluttony';
 		if (abilities.has('Harvest') && (role === 'Bulky Support' || role === 'Staller')) return 'Harvest';
 		if (abilities.has('Moxie') && (counter.get('Physical') > 3 || moves.has('bounce'))) return 'Moxie';
+		if (
+			['articuno', 'dusknoir', 'raikou', 'suicune', 'vespiquen', 'wailord'].some(m => species.id === m)
+		) return 'Pressure';
 		if (abilities.has('Regenerator') && role === 'AV Pivot') return 'Regenerator';
 		if (abilities.has('Shed Skin') && moves.has('rest') && !moves.has('sleeptalk')) return 'Shed Skin';
 		if (abilities.has('Sniper') && moves.has('focusenergy')) return 'Sniper';
@@ -1059,7 +1063,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (['protect', 'spikyshield', 'substitute'].some(m => moves.has(m))) return 'Leftovers';
 		if (
 			this.dex.getEffectiveness('Ground', species) >= 2 &&
-			ability !== 'Levitate'
+			ability !== 'Levitate' && species.id !== 'golemalola'
 		) {
 			return 'Air Balloon';
 		}
@@ -1203,7 +1207,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				if (hp % 2 === 0) break;
 			} else {
 				// Maximize number of Stealth Rock switch-ins
-				if (srWeakness <= 0 || ability === 'Regenerator' || ['Leftovers', 'Life Orb'].includes(item)) break;
+				if (srWeakness <= 0 || ability === 'Regenerator' || ['Black Sludge', 'Leftovers', 'Life Orb'].includes(item)) break;
 				if (item !== 'Sitrus Berry' && hp % (4 / srWeakness) > 0) break;
 				// Minimise number of Stealth Rock switch-ins to activate Sitrus Berry
 				if (item === 'Sitrus Berry' && hp % (4 / srWeakness) === 0) break;

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -114,7 +114,7 @@
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
-                "movepool": ["Encore", "Grass Knot", "Hydro Pump", "Ice Beam", "Icy Wind", "Psyshock"],
+                "movepool": ["Encore", "Grass Knot", "Hydro Pump", "Ice Beam", "Icy Wind", "Protect", "Psyshock"],
                 "teraTypes": ["Grass", "Water"]
             },
             {
@@ -144,8 +144,8 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Extreme Speed", "Flare Blitz", "Howl", "Morning Sun", "Snarl", "Will-O-Wisp"],
-                "teraTypes": ["Fire", "Steel", "Water"]
+                "movepool": ["Close Combat", "Extreme Speed", "Flare Blitz", "Howl", "Morning Sun", "Snarl", "Will-O-Wisp"],
+                "teraTypes": ["Fighting", "Normal", "Steel", "Water"]
             }
         ]
     },
@@ -218,8 +218,8 @@
         "level": 82,
         "sets": [
             {
-                "role": "Doubles Support",
-                "movepool": ["Clear Smog", "Encore", "Protect", "Shadow Ball", "Sludge Bomb"],
+                "role": "Offensive Protect",
+                "movepool": ["Encore", "Protect", "Shadow Ball", "Sludge Bomb"],
                 "teraTypes": ["Ghost"]
             },
             {
@@ -364,7 +364,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Fake Tears", "Helping Hand", "Shadow Ball", "Thunder Wave", "Thunderbolt"],
+                "movepool": ["Fake Tears", "Helping Hand", "Protect", "Shadow Ball", "Thunder Wave", "Thunderbolt"],
                 "teraTypes": ["Flying", "Ghost"]
             },
             {
@@ -389,7 +389,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Freeze-Dry", "Hurricane", "Ice Beam", "Protect", "Roost", "Tailwind"],
+                "movepool": ["Brave Bird", "Freeze-Dry", "Ice Beam", "Protect", "Roost", "Tailwind"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -684,7 +684,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Bullet Punch", "Close Combat", "Defog", "Feint", "Tailwind", "U-turn"],
+                "movepool": ["Bullet Punch", "Close Combat", "Defog", "Tailwind", "U-turn"],
                 "teraTypes": ["Fire", "Water"]
             },
             {
@@ -2032,11 +2032,11 @@
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["Grass Knot", "Nasty Plot", "Sludge Bomb", "Wildbolt Storm"],
+                "movepool": ["Grass Knot", "Nasty Plot", "Protect", "Wildbolt Storm"],
                 "teraTypes": ["Electric", "Grass"]
             },
             {
-                "role": "Doubles Support",
+                "role": "Offensive Protect",
                 "movepool": ["Grass Knot", "Protect", "Snarl", "Taunt", "Thunder Wave", "Thunderbolt"],
                 "teraTypes": ["Steel"]
             }
@@ -2286,13 +2286,8 @@
         "level": 83,
         "sets": [
             {
-                "role": "Doubles Bulky Attacker",
-                "movepool": ["Dazzling Gleam", "Foul Play", "Spikes", "Thunder Wave"],
-                "teraTypes": ["Flying", "Water"]
-            },
-            {
                 "role": "Doubles Support",
-                "movepool": ["Dazzling Gleam", "Light Screen", "Reflect", "Thunder Wave"],
+                "movepool": ["Dazzling Gleam", "Foul Play", "Light Screen", "Reflect", "Spikes", "Thunder Wave"],
                 "teraTypes": ["Flying", "Water"]
             }
         ]
@@ -2526,8 +2521,8 @@
         "level": 86,
         "sets": [
             {
-                "role": "Doubles Bulky Attacker",
-                "movepool": ["Encore", "Fake Out", "Fire Blast", "Incinerate", "Poison Gas", "Protect", "Sludge Bomb"],
+                "role": "Doubles Fast Attacker",
+                "movepool": ["Encore", "Fake Out", "Fire Blast", "Heat Wave", "Incinerate", "Poison Gas", "Protect", "Sludge Bomb"],
                 "teraTypes": ["Fire", "Flying", "Water"]
             }
         ]
@@ -3037,7 +3032,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Close Combat", "Icicle Crash", "Protect", "Stomping Tantrum"],
+                "movepool": ["Close Combat", "Heavy Slam", "Icicle Crash", "Protect", "Stomping Tantrum"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -733,11 +733,6 @@
         "level": 86,
         "sets": [
             {
-                "role": "Doubles Bulky Attacker",
-                "movepool": ["High Horsepower", "Ice Spinner", "Knock Off", "Rapid Spin", "Stealth Rock"],
-                "teraTypes": ["Dark"]
-            },
-            {
                 "role": "Doubles Support",
                 "movepool": ["High Horsepower", "Ice Shard", "Knock Off", "Rapid Spin", "Stone Edge"],
                 "teraTypes": ["Dragon", "Water"]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1441,6 +1441,11 @@
                 "role": "Fast Attacker",
                 "movepool": ["Leaf Blade", "Night Slash", "Psycho Cut", "Sacred Sword", "Swords Dance"],
                 "teraTypes": ["Dark", "Fighting", "Grass"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Agility", "Night Slash", "Psycho Cut", "Sacred Sword"],
+                "teraTypes": ["Dark", "Fighting"]
             }
         ]
     },
@@ -3868,7 +3873,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Ice Spinner", "Rapid Spin"],
-                "teraTypes": ["Fighting", "Ground"]
+                "teraTypes": ["Ground", "Steel"]
             },
             {
                 "role": "Bulky Attacker",

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -764,6 +764,11 @@ export class RandomTeams {
 				counter = this.addMove('tailwind', moves, types, abilities, teamDetails, species, isLead, isDoubles,
 					movePool, teraType, role);
 			}
+			// Enforce Thunder Wave on Prankster users as well
+			if (movePool.includes('thunderwave') && abilities.has('Prankster')) {
+				counter = this.addMove('thunderwave', moves, types, abilities, teamDetails, species, isLead, isDoubles,
+					movePool, teraType, role);
+			}
 		}
 
 		// Enforce STAB priority
@@ -1118,6 +1123,7 @@ export class RandomTeams {
 			if (species.id === 'altaria') return 'Cloud Nine';
 			if (species.id === 'bellibolt') return 'Electromorphosis';
 			if (species.id === 'armarouge') return 'Flash Fire';
+			if (species.id === 'florges') return 'Flower Veil';
 			if (species.baseSpecies === 'Maushold' && role === 'Doubles Support') return 'Friend Guard';
 			if (species.id === 'talonflame') return 'Gale Wings';
 			if (species.id === 'tropius') return 'Harvest';
@@ -1127,7 +1133,6 @@ export class RandomTeams {
 			if (species.id === 'flapple' || (species.id === 'appletun' && this.randomChance(1, 2))) return 'Ripen';
 			if (species.id === 'gumshoos') return 'Strong Jaw';
 			if (species.id === 'magnezone') return 'Sturdy';
-			if (species.id === 'florges') return 'Symbiosis';
 			if (species.id === 'oranguru' || abilities.has('Pressure') && abilities.has('Telepathy')) return 'Telepathy';
 			if (species.id === 'drifblim') return 'Unburden';
 			if (abilities.has('Intimidate')) return 'Intimidate';
@@ -1318,12 +1323,13 @@ export class RandomTeams {
 		) {
 			return (scarfReqs) ? 'Choice Scarf' : 'Choice Specs';
 		}
-		if ((role === 'Bulky Protect' && counter.get('setup')) || moves.has('substitute')) return 'Leftovers';
+		if (
+			(role === 'Bulky Protect' && counter.get('setup')) || moves.has('substitute') || species.id === 'eternatus'
+		) return 'Leftovers';
 		if (species.id === 'sylveon') return 'Pixie Plate';
-		if ((species.id === 'sneasler' || species.id === 'toxicroak') && moves.has('fakeout')) return 'Clear Amulet';
 		if (
 			(offensiveRole || (role === 'Tera Blast user' && species.baseStats.spe >= 80 && !moves.has('trickroom'))) &&
-			(!moves.has('fakeout') || role === 'Doubles Wallbreaker') &&
+			!moves.has('fakeout') && !moves.has('incinerate') &&
 			(!moves.has('uturn') || types.includes('Bug') || species.baseStats.atk >= 120 || ability === 'Libero') &&
 			(!moves.has('icywind') || species.id === 'ironbundle')
 		) {
@@ -1331,6 +1337,16 @@ export class RandomTeams {
 				(ability === 'Quark Drive' || ability === 'Protosynthesis') &&
 				['firstimpression', 'uturn', 'voltswitch'].every(m => !moves.has(m)) && species.id !== 'ironvaliant'
 			) ? 'Booster Energy' : 'Life Orb';
+		}
+		if (isLead && (species.id === 'glimmora' ||
+			(['Doubles Fast Attacker', 'Doubles Wallbreaker', 'Offensive Protect'].some(m => role === m) &&
+			species.baseStats.hp + species.baseStats.def + species.baseStats.spd <= 230))
+		) return 'Focus Sash';
+		if (
+			['Doubles Fast Attacker', 'Doubles Wallbreaker', 'Offensive Protect'].some(m => role === m) &&
+			moves.has('fakeout') || moves.has('incinerate')
+		) {
+			return (this.dex.getEffectiveness('Rock', species) >= 1) ? 'Heavy-Duty Boots' : 'Clear Amulet';
 		}
 		if (!counter.get('Status')) return 'Assault Vest';
 		if (species.id === 'pawmot') return 'Leppa Berry';


### PR DESCRIPTION
* --> decreases choice item frequency

Gen 9 Random Battle:
-Gallade now has a second Setup Sweeper set with Agility. *
-Bulky Setup Great Tusk: -Tera Fighting, +Tera Steel.

Gen 9 Random Doubles Battle:
-Pokemon with offensively-inclined roles and moves that don't want Life Orb (e.g. fake out, incinerate) now get Focus Sash in the lead slot, and if not in the lead slot, they get Heavy-Duty Boots or Clear Amulet depending on if they are weak to Rock.
-Glimmora now gets Focus Sash in the lead slot.
-Eternatus now gets Leftovers.
-Protect is now forced on Prankster users. Thus:
--Klefki's sets were fused together, due to a lack of need to split them anymore.
--Thundurus's Support set was changed to Bulky Protect.
-Support Gengar was changed to Offensive Protect, and Clear Smog was removed. It now gets a Life Orb.
-Salazzle: +Heat Wave, role changed to Doubles Fast Attacker. It can now get Focus Sash, Heavy-Duty Boots, and Life Orb as its potential items.
-Donphan's Bulky Attacker set was removed. It now only runs Assault Vest.
-Arcanine: +Close Combat, -Tera Fire, +Tera Normal, +Tera Fighting, role changed to Bulky Attacker. Arcanine can now qualify for Assault Vest.
-Setup Sweeper Thundurus: -Sludge Bomb, +Protect
-Fast Attacker Golduck: +Protect
-Support Jolteon: +Protect
-Articuno: -Hurricane, +Brave Bird
-Support Scizor: -Feint

Gen 7 Random Battle:
-Feraligatr now has a set split: one set with Swords Dance and Aqua Jet, and one set with Dragon Dance and no Aqua Jet.
-Ledian now has a set split: one set with screens and no Defog or Encore, and one set with enforced Toxic with Encore and Defog as options.
-Doublade now has a second set: Staller, with Toxic instead of Swords Dance.
-Kangaskhan now has a second set: AV Pivot, with the same moves as its other set.
-Bulky Support Mismagius was changed to Bulky Attacker; it will now always get Dazzling Gleam. It also no longer runs Substitute.
-Fast Support Jumpluff was changed to Bulky Attacker to enforce Strength Sap.
-Shaymin's role was changed to Fast Support; it can now run a Life Orb when it isn't SubSeed.
-Arcanine is now always Intimidate.
-Mega Charizard Y will no longer always get Air Slash.
-Pressure will now only and always exist on Articuno, Dusknoir, Raikou, Suicune, Vespiquen, and Wailord.
-Autotomize Alolan Golem will now get a Life Orb instead of an Air Balloon.
-Black Sludge is now treated like Leftovers in HP EV calculation.
-Spinda can now sometimes roll Feint Attack instead of Sucker Punch.
-Bulky Attacker Tangrowth: -Giga Drain, +Power Whip
-Z-Move Volcarona: -HP Rock