### PR TITLE
Gen 1 Random Battles updates

### DIFF
--- a/data/mods/gen1/random-data.json
+++ b/data/mods/gen1/random-data.json
@@ -7,8 +7,7 @@
     },
     "ivysaur": {
         "level": 80,
-        "moves": ["bodyslam", "sleeppowder", "swordsdance"],
-        "essentialMoves": ["razorleaf"]
+        "moves": ["bodyslam", "razorleaf", "sleeppowder", "swordsdance"]
     },
     "venusaur": {
         "level": 74,
@@ -84,8 +83,7 @@
     },
     "raticate": {
         "level": 77,
-        "moves": ["blizzard", "bodyslam", "hyperbeam"],
-        "essentialMoves": ["superfang"]
+        "moves": ["blizzard", "bodyslam", "hyperbeam", "superfang"]
     },
     "spearow": {
         "level": 90,
@@ -119,8 +117,7 @@
     },
     "sandshrew": {
         "level": 88,
-        "moves": ["bodyslam", "rockslide", "swordsdance"],
-        "essentialMoves": ["earthquake"]
+        "moves": ["bodyslam", "earthquake", "rockslide", "swordsdance"]
     },
     "sandslash": {
         "level": 77,
@@ -200,14 +197,12 @@
     },
     "oddish": {
         "level": 88,
-        "moves": ["doubleedge", "sleeppowder"],
-        "essentialMoves": ["megadrain"],
+        "moves": ["doubleedge", "megadrain", "sleeppowder"],
         "exclusiveMoves": ["stunspore", "stunspore", "swordsdance"]
     },
     "gloom": {
         "level": 80,
-        "moves": ["doubleedge", "sleeppowder"],
-        "essentialMoves": ["megadrain"],
+        "moves": ["doubleedge", "megadrain", "sleeppowder"],
         "exclusiveMoves": ["stunspore", "stunspore", "swordsdance"]
     },
     "vileplume": {
@@ -249,14 +244,12 @@
     },
     "meowth": {
         "level": 87,
-        "moves": ["bodyslam", "bubblebeam"],
-        "essentialMoves": ["slash"],
+        "moves": ["bodyslam", "bubblebeam", "slash"],
         "exclusiveMoves": ["thunder", "thunderbolt"]
     },
     "persian": {
         "level": 74,
-        "moves": ["bodyslam", "bubblebeam"],
-        "essentialMoves": ["slash"],
+        "moves": ["bodyslam", "bubblebeam", "slash"],
         "exclusiveMoves": ["hyperbeam", "hyperbeam", "thunder", "thunderbolt"]
     },
     "psyduck": {
@@ -351,9 +344,8 @@
     },
     "victreebel": {
         "level": 74,
-        "moves": ["bodyslam", "sleeppowder", "stunspore"],
-        "essentialMoves": ["razorleaf"],
-        "comboMoves": ["hyperbeam", "swordsdance"]
+        "moves": ["bodyslam", "razorleaf", "sleeppowder", "stunspore"],
+        "comboMoves": ["bodyslam", "hyperbeam", "razorleaf", "swordsdance"]
     },
     "tentacool": {
         "level": 85,
@@ -411,8 +403,7 @@
     },
     "farfetchd": {
         "level": 83,
-        "moves": ["agility", "bodyslam", "swordsdance"],
-        "essentialMoves": ["slash"]
+        "moves": ["agility", "bodyslam", "slash", "swordsdance"]
     },
     "doduo": {
         "level": 88,
@@ -534,8 +525,7 @@
     },
     "lickitung": {
         "level": 80,
-        "moves": ["hyperbeam", "swordsdance"],
-        "essentialMoves": ["bodyslam"],
+        "moves": ["bodyslam", "hyperbeam", "swordsdance"],
         "exclusiveMoves": ["blizzard", "earthquake", "earthquake", "earthquake"]
     },
     "koffing": {
@@ -574,14 +564,12 @@
     },
     "horsea": {
         "level": 89,
-        "moves": ["agility", "blizzard"],
-        "essentialMoves": ["surf"],
+        "moves": ["agility", "blizzard", "surf"],
         "exclusiveMoves": ["doubleedge", "hydropump", "smokescreen"]
     },
     "seadra": {
         "level": 77,
-        "moves": ["agility", "blizzard"],
-        "essentialMoves": ["surf"],
+        "moves": ["agility", "blizzard", "surf"],
         "exclusiveMoves": ["doubleedge", "hydropump", "hyperbeam", "smokescreen"]
     },
     "goldeen": {
@@ -645,8 +633,7 @@
     "lapras": {
         "level": 69,
         "moves": ["bodyslam", "confuseray", "rest", "sing", "surf"],
-        "essentialMoves": ["blizzard"],
-        "exclusiveMoves": ["thunderbolt", "thunderbolt"]
+        "essentialMoves": ["blizzard", "thunderbolt"]
     },
     "ditto": {
         "level": 100,
@@ -660,8 +647,7 @@
     },
     "vaporeon": {
         "level": 74,
-        "moves": ["blizzard", "rest"],
-        "essentialMoves": ["surf"],
+        "moves": ["blizzard", "rest", "surf"],
         "exclusiveMoves": ["bodyslam", "hydropump", "mimic"]
     },
     "jolteon": {
@@ -675,14 +661,13 @@
     },
     "porygon": {
         "level": 77,
-        "moves": ["blizzard", "thunderwave"],
-        "essentialMoves": ["recover"],
+        "moves": ["blizzard", "recover", "thunderwave"],
         "exclusiveMoves": ["doubleedge", "psychic", "thunderbolt", "triattack"]
     },
     "omanyte": {
         "level": 88,
-        "moves": ["bodyslam", "hydropump", "rest", "surf"],
-        "essentialMoves": ["blizzard"]
+        "moves": ["blizzard", "bodyslam", "rest"],
+        "exclusiveMoves": ["hydropump", "surf"]
     },
     "omastar": {
         "level": 74,

--- a/data/mods/gen1/random-data.json
+++ b/data/mods/gen1/random-data.json
@@ -2,37 +2,37 @@
     "bulbasaur": {
         "level": 88,
         "moves": ["bodyslam", "sleeppowder"],
-        "essentialMove": "razorleaf",
+        "essentialMoves": ["razorleaf"],
         "exclusiveMoves": ["megadrain", "swordsdance", "swordsdance"]
     },
     "ivysaur": {
         "level": 80,
         "moves": ["bodyslam", "sleeppowder", "swordsdance"],
-        "essentialMove": "razorleaf"
+        "essentialMoves": ["razorleaf"]
     },
     "venusaur": {
         "level": 74,
         "moves": ["bodyslam", "hyperbeam", "sleeppowder", "swordsdance"],
-        "essentialMove": "razorleaf"
+        "essentialMoves": ["razorleaf"]
     },
     "charmander": {
         "level": 91,
         "moves": ["bodyslam", "slash"],
-        "essentialMove": "fireblast",
+        "essentialMoves": ["fireblast"],
         "exclusiveMoves": ["counter", "seismictoss"],
         "comboMoves": ["bodyslam", "fireblast", "submission", "swordsdance"]
     },
     "charmeleon": {
         "level": 82,
         "moves": ["bodyslam", "slash"],
-        "essentialMove": "fireblast",
+        "essentialMoves": ["fireblast"],
         "exclusiveMoves": ["counter", "swordsdance"],
         "comboMoves": ["bodyslam", "fireblast", "submission", "swordsdance"]
     },
     "charizard": {
         "level": 74,
         "moves": ["bodyslam", "earthquake", "slash"],
-        "essentialMove": "fireblast",
+        "essentialMoves": ["fireblast"],
         "comboMoves": ["hyperbeam", "swordsdance"]
     },
     "squirtle": {
@@ -79,13 +79,13 @@
     "rattata": {
         "level": 90,
         "moves": ["blizzard", "bodyslam"],
-        "essentialMove": "superfang",
+        "essentialMoves": ["superfang"],
         "exclusiveMoves": ["thunderbolt", "thunderbolt", "quickattack"]
     },
     "raticate": {
         "level": 77,
         "moves": ["blizzard", "bodyslam", "hyperbeam"],
-        "essentialMove": "superfang"
+        "essentialMoves": ["superfang"]
     },
     "spearow": {
         "level": 90,
@@ -108,24 +108,24 @@
     "pikachu": {
         "level": 88,
         "moves": ["surf", "thunderwave"],
-        "essentialMove": "thunderbolt",
+        "essentialMoves": ["thunderbolt"],
         "exclusiveMoves": ["agility", "bodyslam", "seismictoss", "thunder"]
     },
     "raichu": {
         "level": 75,
         "moves": ["surf", "thunderwave"],
-        "essentialMove": "thunderbolt",
+        "essentialMoves": ["thunderbolt"],
         "exclusiveMoves": ["agility", "bodyslam", "hyperbeam", "seismictoss", "thunder"]
     },
     "sandshrew": {
         "level": 88,
         "moves": ["bodyslam", "rockslide", "swordsdance"],
-        "essentialMove": "earthquake"
+        "essentialMoves": ["earthquake"]
     },
     "sandslash": {
         "level": 77,
         "moves": ["bodyslam", "rockslide", "swordsdance"],
-        "essentialMove": "earthquake"
+        "essentialMoves": ["earthquake"]
     },
     "nidoranf": {
         "level": 93,
@@ -140,7 +140,7 @@
     "nidoqueen": {
         "level": 74,
         "moves": ["blizzard", "bodyslam", "thunderbolt"],
-        "essentialMove": "earthquake"
+        "essentialMoves": ["earthquake"]
     },
     "nidoranm": {
         "level": 92,
@@ -155,19 +155,19 @@
     "nidoking": {
         "level": 73,
         "moves": ["blizzard", "bodyslam"],
-        "essentialMove": "earthquake",
+        "essentialMoves": ["earthquake"],
         "exclusiveMoves": ["rockslide", "thunder", "thunderbolt"]
     },
     "clefairy": {
         "level": 88,
         "moves": ["bodyslam", "thunderbolt", "thunderwave"],
-        "essentialMove": "blizzard",
+        "essentialMoves": ["blizzard"],
         "exclusiveMoves": ["counter", "psychic", "seismictoss", "sing", "sing"]
     },
     "clefable": {
         "level": 75,
         "moves": ["bodyslam", "thunderbolt", "thunderwave"],
-        "essentialMove": "blizzard",
+        "essentialMoves": ["blizzard"],
         "exclusiveMoves": ["counter", "hyperbeam", "psychic", "sing", "sing"]
     },
     "vulpix": {
@@ -201,30 +201,30 @@
     "oddish": {
         "level": 88,
         "moves": ["doubleedge", "sleeppowder"],
-        "essentialMove": "megadrain",
+        "essentialMoves": ["megadrain"],
         "exclusiveMoves": ["stunspore", "stunspore", "swordsdance"]
     },
     "gloom": {
         "level": 80,
         "moves": ["doubleedge", "sleeppowder"],
-        "essentialMove": "megadrain",
+        "essentialMoves": ["megadrain"],
         "exclusiveMoves": ["stunspore", "stunspore", "swordsdance"]
     },
     "vileplume": {
         "level": 77,
         "moves": ["bodyslam", "sleeppowder", "stunspore", "swordsdance"],
-        "essentialMove": "megadrain"
+        "essentialMoves": ["megadrain"]
     },
     "paras": {
         "level": 89,
         "moves": ["bodyslam", "megadrain"],
-        "essentialMove": "spore",
+        "essentialMoves": ["spore"],
         "exclusiveMoves": ["growth", "slash", "stunspore", "stunspore", "swordsdance"]
     },
     "parasect": {
         "level": 78,
         "moves": ["bodyslam", "megadrain"],
-        "essentialMove": "spore",
+        "essentialMoves": ["spore"],
         "exclusiveMoves": ["growth", "hyperbeam", "slash", "stunspore", "stunspore", "swordsdance"]
     },
     "venonat": {
@@ -240,35 +240,35 @@
     "diglett": {
         "level": 88,
         "moves": ["bodyslam", "rockslide", "slash"],
-        "essentialMove": "earthquake"
+        "essentialMoves": ["earthquake"]
     },
     "dugtrio": {
         "level": 73,
         "moves": ["bodyslam", "rockslide", "slash"],
-        "essentialMove": "earthquake"
+        "essentialMoves": ["earthquake"]
     },
     "meowth": {
         "level": 87,
         "moves": ["bodyslam", "bubblebeam"],
-        "essentialMove": "slash",
+        "essentialMoves": ["slash"],
         "exclusiveMoves": ["thunder", "thunderbolt"]
     },
     "persian": {
         "level": 74,
         "moves": ["bodyslam", "bubblebeam"],
-        "essentialMove": "slash",
+        "essentialMoves": ["slash"],
         "exclusiveMoves": ["hyperbeam", "hyperbeam", "thunder", "thunderbolt"]
     },
     "psyduck": {
         "level": 88,
         "moves": ["amnesia", "blizzard"],
-        "essentialMove": "surf",
+        "essentialMoves": ["surf"],
         "exclusiveMoves": ["bodyslam", "hydropump", "rest", "seismictoss"]
     },
     "golduck": {
         "level": 75,
         "moves": ["amnesia", "blizzard"],
-        "essentialMove": "surf",
+        "essentialMoves": ["surf"],
         "exclusiveMoves": ["bodyslam", "hydropump", "rest", "seismictoss"]
     },
     "mankey": {
@@ -293,19 +293,19 @@
     "poliwag": {
         "level": 86,
         "moves": ["blizzard", "surf"],
-        "essentialMove": "amnesia",
+        "essentialMoves": ["amnesia"],
         "exclusiveMoves": ["hypnosis", "hypnosis", "psychic"]
     },
     "poliwhirl": {
         "level": 76,
         "moves": ["blizzard", "surf"],
-        "essentialMove": "amnesia",
+        "essentialMoves": ["amnesia"],
         "exclusiveMoves": ["counter", "hypnosis", "hypnosis", "psychic"]
     },
     "poliwrath": {
         "level": 74,
         "moves": ["blizzard", "bodyslam", "earthquake", "submission"],
-        "essentialMove": "surf",
+        "essentialMoves": ["surf"],
         "exclusiveMoves": ["hypnosis", "hypnosis", "psychic"],
         "comboMoves": ["amnesia", "blizzard"]
     },
@@ -342,30 +342,30 @@
     "bellsprout": {
         "level": 89,
         "moves": ["doubleedge", "sleeppowder", "stunspore", "swordsdance"],
-        "essentialMove": "razorleaf"
+        "essentialMoves": ["razorleaf"]
     },
     "weepinbell": {
         "level": 80,
         "moves": ["doubleedge", "sleeppowder", "stunspore", "swordsdance"],
-        "essentialMove": "razorleaf"
+        "essentialMoves": ["razorleaf"]
     },
     "victreebel": {
         "level": 74,
         "moves": ["bodyslam", "sleeppowder", "stunspore"],
-        "essentialMove": "razorleaf",
+        "essentialMoves": ["razorleaf"],
         "comboMoves": ["hyperbeam", "swordsdance"]
     },
     "tentacool": {
         "level": 85,
         "moves": ["barrier", "hydropump", "surf"],
-        "essentialMove": "blizzard",
+        "essentialMoves": ["blizzard"],
         "exclusiveMoves": ["megadrain", "megadrain"],
         "comboMoves": ["hydropump", "surf"]
     },
     "tentacruel": {
         "level": 73,
         "moves": ["blizzard", "hydropump", "hyperbeam", "surf"],
-        "essentialMove": "swordsdance"
+        "essentialMoves": ["swordsdance"]
     },
     "geodude": {
         "level": 88,
@@ -390,7 +390,7 @@
     "slowpoke": {
         "level": 87,
         "moves": ["earthquake", "surf"],
-        "essentialMove": "thunderwave",
+        "essentialMoves": ["thunderwave"],
         "exclusiveMoves": ["blizzard", "psychic", "rest"],
         "comboMoves": ["amnesia", "surf"]
     },
@@ -412,7 +412,7 @@
     "farfetchd": {
         "level": 83,
         "moves": ["agility", "bodyslam", "swordsdance"],
-        "essentialMove": "slash"
+        "essentialMoves": ["slash"]
     },
     "doduo": {
         "level": 88,
@@ -435,13 +435,13 @@
     "grimer": {
         "level": 90,
         "moves": ["bodyslam", "sludge"],
-        "essentialMove": "explosion",
+        "essentialMoves": ["explosion"],
         "exclusiveMoves": ["fireblast", "megadrain", "megadrain", "screech"]
     },
     "muk": {
         "level": 77,
         "moves": ["bodyslam", "sludge"],
-        "essentialMove": "explosion",
+        "essentialMoves": ["explosion"],
         "exclusiveMoves": ["fireblast", "hyperbeam", "megadrain", "megadrain"]
     },
     "shellder": {
@@ -456,19 +456,19 @@
     "gastly": {
         "level": 80,
         "moves": ["explosion", "megadrain", "nightshade", "psychic"],
-        "essentialMove": "thunderbolt",
+        "essentialMoves": ["thunderbolt"],
         "exclusiveMoves": ["confuseray", "hypnosis", "hypnosis"]
     },
     "haunter": {
         "level": 72,
         "moves": ["explosion", "megadrain", "nightshade", "psychic"],
-        "essentialMove": "thunderbolt",
+        "essentialMoves": ["thunderbolt"],
         "exclusiveMoves": ["confuseray", "hypnosis", "hypnosis"]
     },
     "gengar": {
         "level": 64,
         "moves": ["explosion", "megadrain", "nightshade", "psychic"],
-        "essentialMove": "thunderbolt",
+        "essentialMoves": ["thunderbolt"],
         "exclusiveMoves": ["confuseray", "hypnosis", "hypnosis"]
     },
     "onix": {
@@ -506,7 +506,7 @@
     "exeggcute": {
         "level": 77,
         "moves": ["sleeppowder", "stunspore"],
-        "essentialMove": "psychic",
+        "essentialMoves": ["psychic"],
         "exclusiveMoves": ["doubleedge", "explosion", "explosion"]
     },
     "exeggutor": {
@@ -535,7 +535,7 @@
     "lickitung": {
         "level": 80,
         "moves": ["hyperbeam", "swordsdance"],
-        "essentialMove": "bodyslam",
+        "essentialMoves": ["bodyslam"],
         "exclusiveMoves": ["blizzard", "earthquake", "earthquake", "earthquake"]
     },
     "koffing": {
@@ -558,13 +558,13 @@
     "chansey": {
         "level": 68,
         "moves": ["icebeam", "thunderwave"],
-        "essentialMove": "softboiled",
+        "essentialMoves": ["softboiled"],
         "exclusiveMoves": ["counter", "reflect", "seismictoss", "sing", "thunderbolt", "thunderbolt", "thunderbolt"]
     },
     "tangela": {
         "level": 74,
         "moves": ["bodyslam", "sleeppowder"],
-        "essentialMove": "megadrain",
+        "essentialMoves": ["megadrain"],
         "exclusiveMoves": ["growth", "stunspore", "stunspore", "stunspore", "swordsdance", "swordsdance"]
     },
     "kangaskhan": {
@@ -575,13 +575,13 @@
     "horsea": {
         "level": 89,
         "moves": ["agility", "blizzard"],
-        "essentialMove": "surf",
+        "essentialMoves": ["surf"],
         "exclusiveMoves": ["doubleedge", "hydropump", "smokescreen"]
     },
     "seadra": {
         "level": 77,
         "moves": ["agility", "blizzard"],
-        "essentialMove": "surf",
+        "essentialMoves": ["surf"],
         "exclusiveMoves": ["doubleedge", "hydropump", "hyperbeam", "smokescreen"]
     },
     "goldeen": {
@@ -596,13 +596,13 @@
     "staryu": {
         "level": 82,
         "moves": ["blizzard", "thunderbolt", "thunderwave"],
-        "essentialMove": "recover",
+        "essentialMoves": ["recover"],
         "exclusiveMoves": ["hydropump", "surf", "surf"]
     },
     "starmie": {
         "level": 67,
         "moves": ["blizzard", "thunderbolt", "thunderwave"],
-        "essentialMove": "recover",
+        "essentialMoves": ["recover"],
         "exclusiveMoves": ["hydropump", "psychic", "surf", "surf"]
     },
     "mrmime": {
@@ -645,7 +645,7 @@
     "lapras": {
         "level": 69,
         "moves": ["bodyslam", "confuseray", "rest", "sing", "surf"],
-        "essentialMove": "blizzard",
+        "essentialMoves": ["blizzard"],
         "exclusiveMoves": ["thunderbolt", "thunderbolt"]
     },
     "ditto": {
@@ -655,13 +655,13 @@
     "eevee": {
         "level": 88,
         "moves": ["doubleedge", "quickattack", "reflect"],
-        "essentialMove": "bodyslam",
+        "essentialMoves": ["bodyslam"],
         "exclusiveMoves": ["bide", "mimic", "sandattack", "tailwhip"]
     },
     "vaporeon": {
         "level": 74,
         "moves": ["blizzard", "rest"],
-        "essentialMove": "surf",
+        "essentialMoves": ["surf"],
         "exclusiveMoves": ["bodyslam", "hydropump", "mimic"]
     },
     "jolteon": {
@@ -676,13 +676,13 @@
     "porygon": {
         "level": 77,
         "moves": ["blizzard", "thunderwave"],
-        "essentialMove": "recover",
+        "essentialMoves": ["recover"],
         "exclusiveMoves": ["doubleedge", "psychic", "thunderbolt", "triattack"]
     },
     "omanyte": {
         "level": 88,
         "moves": ["bodyslam", "hydropump", "rest", "surf"],
-        "essentialMove": "blizzard"
+        "essentialMoves": ["blizzard"]
     },
     "omastar": {
         "level": 74,
@@ -705,14 +705,14 @@
     "snorlax": {
         "level": 69,
         "moves": ["bodyslam", "rest", "selfdestruct", "thunderbolt"],
-        "essentialMove": "amnesia",
+        "essentialMoves": ["amnesia"],
         "exclusiveMoves": ["blizzard", "blizzard"],
         "comboMoves": ["bodyslam", "earthquake", "hyperbeam", "selfdestruct"]
     },
     "articuno": {
         "level": 71,
         "moves": ["agility", "hyperbeam", "icebeam", "mimic", "reflect"],
-        "essentialMove": "blizzard",
+        "essentialMoves": ["blizzard"],
         "comboMoves": ["icebeam", "reflect", "rest"]
     },
     "zapdos": {
@@ -727,29 +727,29 @@
     "dratini": {
         "level": 91,
         "moves": ["bodyslam", "hyperbeam", "thunderbolt", "thunderwave"],
-        "essentialMove": "blizzard"
+        "essentialMoves": ["blizzard"]
     },
     "dragonair": {
         "level": 81,
         "moves": ["bodyslam", "hyperbeam", "thunderbolt", "thunderwave"],
-        "essentialMove": "blizzard"
+        "essentialMoves": ["blizzard"]
     },
     "dragonite": {
         "level": 73,
         "moves": ["bodyslam", "hyperbeam", "thunderbolt", "thunderwave"],
-        "essentialMove": "blizzard"
+        "essentialMoves": ["blizzard"]
     },
     "mewtwo": {
         "level": 58,
         "moves": ["blizzard", "recover", "thunderbolt"],
-        "essentialMove": "amnesia",
+        "essentialMoves": ["amnesia"],
         "exclusiveMoves": ["psychic", "psychic"],
         "comboMoves": ["barrier", "rest"]
     },
     "mew": {
         "level": 66,
         "moves": ["blizzard", "earthquake", "thunderbolt", "thunderwave"],
-        "essentialMove": "psychic",
+        "essentialMoves": ["psychic"],
         "exclusiveMoves": ["explosion", "softboiled", "softboiled"],
         "comboMoves": ["earthquake", "hyperbeam", "swordsdance"]
     }

--- a/data/mods/gen1/random-data.json
+++ b/data/mods/gen1/random-data.json
@@ -1,9 +1,7 @@
 {
     "bulbasaur": {
         "level": 88,
-        "moves": ["bodyslam", "sleeppowder"],
-        "essentialMoves": ["razorleaf"],
-        "exclusiveMoves": ["megadrain", "swordsdance", "swordsdance"]
+        "moves": ["bodyslam", "razorleaf", "sleeppowder", "swordsdance"]
     },
     "ivysaur": {
         "level": 80,
@@ -11,75 +9,78 @@
     },
     "venusaur": {
         "level": 74,
-        "moves": ["bodyslam", "hyperbeam", "sleeppowder", "swordsdance"],
-        "essentialMoves": ["razorleaf"]
+        "moves": ["bodyslam", "hyperbeam", "razorleaf"],
+        "exclusiveMoves": ["sleeppowder", "swordsdance"]
     },
     "charmander": {
         "level": 91,
-        "moves": ["bodyslam", "slash"],
-        "essentialMoves": ["fireblast"],
-        "exclusiveMoves": ["counter", "seismictoss"],
+        "moves": ["counter", "seismictoss", "seismictoss", "slash", "slash"],
+        "essentialMoves": ["bodyslam", "fireblast"],
         "comboMoves": ["bodyslam", "fireblast", "submission", "swordsdance"]
     },
     "charmeleon": {
         "level": 82,
-        "moves": ["bodyslam", "slash"],
-        "essentialMoves": ["fireblast"],
-        "exclusiveMoves": ["counter", "swordsdance"],
+        "moves": ["counter", "seismictoss", "seismictoss", "slash", "slash"],
+        "essentialMoves": ["bodyslam", "fireblast"],
         "comboMoves": ["bodyslam", "fireblast", "submission", "swordsdance"]
     },
     "charizard": {
         "level": 74,
-        "moves": ["bodyslam", "earthquake", "slash"],
-        "essentialMoves": ["fireblast"],
-        "comboMoves": ["hyperbeam", "swordsdance"]
+        "moves": ["bodyslam", "earthquake", "fireblast", "slash"],
+        "comboMoves": ["earthquake", "fireblast", "hyperbeam", "swordsdance"]
     },
     "squirtle": {
         "level": 91,
-        "moves": ["blizzard", "hydropump", "seismictoss", "surf"],
-        "exclusiveMoves": ["bodyslam", "counter"]
+        "moves": ["bodyslam", "counter"],
+        "essentialMoves": ["blizzard", "seismictoss"],
+        "exclusiveMoves": ["hydropump", "surf", "surf"]
     },
     "wartortle": {
         "level": 83,
-        "moves": ["blizzard", "bodyslam", "hydropump", "surf"],
-        "exclusiveMoves": ["counter", "rest", "seismictoss"]
+        "moves": ["counter", "rest", "seismictoss"],
+        "essentialMoves": ["blizzard", "bodyslam"],
+        "exclusiveMoves": ["hydropump", "surf", "surf"]
     },
     "blastoise": {
         "level": 76,
-        "moves": ["blizzard", "bodyslam", "hydropump", "surf"],
-        "exclusiveMoves": ["earthquake", "rest"]
+        "moves": ["earthquake", "rest"],
+        "essentialMoves": ["blizzard", "bodyslam"],
+        "exclusiveMoves": ["hydropump", "surf", "surf"]
     },
     "butterfree": {
         "level": 78,
         "moves": ["psychic", "sleeppowder", "stunspore"],
-        "exclusiveMoves": ["megadrain", "psywave"]
+        "exclusiveMoves": ["hyperbeam", "megadrain", "psywave", "substitute"]
     },
     "beedrill": {
         "level": 84,
-        "moves": ["megadrain", "swordsdance", "twineedle"],
-        "exclusiveMoves": ["doubleedge", "doubleedge", "hyperbeam"],
+        "moves": ["agility", "doubleedge", "megadrain", "swordsdance"],
+        "essentialMoves": ["hyperbeam", "twineedle"],
         "comboMoves": ["agility", "hyperbeam", "swordsdance", "twineedle"]
     },
     "pidgey": {
         "level": 93,
-        "moves": ["agility", "doubleedge", "skyattack"],
-        "exclusiveMoves": ["mimic", "mirrormove", "reflect", "sandattack", "substitute", "quickattack", "toxic"]
+        "moves": ["mimic", "mirrormove", "sandattack", "substitute"],
+        "essentialMoves": ["agility", "doubleedge"],
+        "exclusiveMoves": ["quickattack", "skyattack"],
+        "comboMoves": ["agility", "doubleedge", "quickattack", "skyattack"]
     },
     "pidgeotto": {
         "level": 85,
-        "moves": ["agility", "doubleedge", "skyattack"],
-        "exclusiveMoves": ["mimic", "mirrormove", "reflect", "sandattack", "substitute", "quickattack", "toxic"]
+        "moves": ["mimic", "mirrormove", "sandattack", "substitute"],
+        "essentialMoves": ["agility", "doubleedge"],
+        "exclusiveMoves": ["quickattack", "skyattack"],
+        "comboMoves": ["agility", "doubleedge", "quickattack", "skyattack"]
     },
     "pidgeot": {
         "level": 78,
         "moves": ["agility", "doubleedge", "hyperbeam"],
-        "exclusiveMoves": ["mimic", "mirrormove", "reflect", "sandattack", "skyattack", "skyattack", "substitute", "quickattack", "toxic"]
+        "exclusiveMoves": ["mimic", "mirrormove", "reflect", "sandattack", "skyattack", "skyattack", "substitute", "quickattack", "quickattack", "quickattack"]
     },
     "rattata": {
         "level": 90,
-        "moves": ["blizzard", "bodyslam"],
-        "essentialMoves": ["superfang"],
-        "exclusiveMoves": ["thunderbolt", "thunderbolt", "quickattack"]
+        "moves": ["blizzard", "bodyslam", "superfang"],
+        "exclusiveMoves": ["doubleedge", "thunderbolt", "thunderbolt", "thunderbolt", "quickattack", "quickattack"]
     },
     "raticate": {
         "level": 77,
@@ -88,7 +89,7 @@
     "spearow": {
         "level": 90,
         "moves": ["agility", "doubleedge", "drillpeck"],
-        "exclusiveMoves": ["leer", "mimic", "mirrormove", "substitute", "toxic"]
+        "exclusiveMoves": ["leer", "mimic", "mirrormove", "substitute"]
     },
     "fearow": {
         "level": 76,
@@ -101,19 +102,17 @@
     "arbok": {
         "level": 80,
         "moves": ["earthquake", "glare", "hyperbeam"],
-        "exclusiveMoves": ["bodyslam", "rockslide"]
+        "exclusiveMoves": ["bodyslam", "rockslide", "rockslide"]
     },
     "pikachu": {
         "level": 88,
-        "moves": ["surf", "thunderwave"],
-        "essentialMoves": ["thunderbolt"],
-        "exclusiveMoves": ["agility", "bodyslam", "seismictoss", "thunder"]
+        "moves": ["surf", "thunderbolt", "thunderwave"],
+        "exclusiveMoves": ["agility", "bodyslam", "seismictoss", "seismictoss", "thunder"]
     },
     "raichu": {
         "level": 75,
-        "moves": ["surf", "thunderwave"],
-        "essentialMoves": ["thunderbolt"],
-        "exclusiveMoves": ["agility", "bodyslam", "hyperbeam", "seismictoss", "thunder"]
+        "moves": ["surf", "thunderbolt", "thunderwave"],
+        "exclusiveMoves": ["agility", "bodyslam", "hyperbeam", "hyperbeam", "seismictoss", "thunder"]
     },
     "sandshrew": {
         "level": 88,
@@ -121,8 +120,8 @@
     },
     "sandslash": {
         "level": 77,
-        "moves": ["bodyslam", "rockslide", "swordsdance"],
-        "essentialMoves": ["earthquake"]
+        "moves": ["bodyslam", "earthquake", "rockslide"],
+        "exclusiveMoves": ["slash", "swordsdance", "swordsdance", "swordsdance"]
     },
     "nidoranf": {
         "level": 93,
@@ -136,8 +135,8 @@
     },
     "nidoqueen": {
         "level": 74,
-        "moves": ["blizzard", "bodyslam", "thunderbolt"],
-        "essentialMoves": ["earthquake"]
+        "moves": ["blizzard", "earthquake", "thunderbolt"],
+        "exclusiveMoves": ["bodyslam", "bodyslam", "substitute"]
     },
     "nidoranm": {
         "level": 92,
@@ -151,36 +150,37 @@
     },
     "nidoking": {
         "level": 73,
-        "moves": ["blizzard", "bodyslam"],
-        "essentialMoves": ["earthquake"],
-        "exclusiveMoves": ["rockslide", "thunder", "thunderbolt"]
+        "moves": ["rockslide", "thunderbolt", "thunderbolt"],
+        "essentialMoves": ["blizzard", "earthquake"],
+        "exclusiveMoves": ["bodyslam", "bodyslam", "substitute"]
     },
     "clefairy": {
         "level": 88,
-        "moves": ["bodyslam", "thunderbolt", "thunderwave"],
-        "essentialMoves": ["blizzard"],
-        "exclusiveMoves": ["counter", "psychic", "seismictoss", "sing", "sing"]
+        "moves": ["bodyslam", "bodyslam", "seismictoss", "thunderbolt"],
+        "essentialMoves": ["blizzard", "thunderwave"],
+        "exclusiveMoves": ["blizzard", "blizzard", "counter", "psychic", "sing", "sing"]
     },
     "clefable": {
         "level": 75,
-        "moves": ["bodyslam", "thunderbolt", "thunderwave"],
+        "moves": ["bodyslam", "bodyslam", "thunderbolt", "thunderwave", "thunderwave"],
         "essentialMoves": ["blizzard"],
-        "exclusiveMoves": ["counter", "hyperbeam", "psychic", "sing", "sing"]
+        "exclusiveMoves": ["blizzard", "counter", "hyperbeam", "hyperbeam", "psychic", "sing", "sing"]
     },
     "vulpix": {
         "level": 92,
         "moves": ["bodyslam", "confuseray", "fireblast"],
-        "exclusiveMoves": ["flamethrower", "reflect", "substitute"]
+        "exclusiveMoves": ["flamethrower", "flamethrower", "quickattack", "reflect", "substitute", "substitute"]
     },
     "ninetales": {
         "level": 76,
         "moves": ["bodyslam", "confuseray", "fireblast"],
-        "exclusiveMoves": ["flamethrower", "hyperbeam", "reflect", "substitute"]
+        "exclusiveMoves": ["flamethrower", "hyperbeam", "reflect", "substitute", "substitute"]
     },
     "jigglypuff": {
         "level": 89,
-        "moves": ["blizzard", "bodyslam", "seismictoss", "thunderwave"],
-        "exclusiveMoves": ["counter", "sing"]
+        "moves": ["blizzard", "bodyslam", "seismictoss"],
+        "essentialMoves": ["thunderwave"],
+        "exclusiveMoves": ["counter", "sing", "thunderwave"]
     },
     "wigglytuff": {
         "level": 77,
@@ -189,7 +189,8 @@
     },
     "zubat": {
         "level": 97,
-        "moves": ["confuseray", "doubleedge", "megadrain", "toxic"]
+        "moves": ["confuseray", "doubleedge", "megadrain"],
+        "exclusiveMoves": ["substitute", "substitute", "wingattack"]
     },
     "golbat": {
         "level": 79,
@@ -207,20 +208,18 @@
     },
     "vileplume": {
         "level": 77,
-        "moves": ["bodyslam", "sleeppowder", "stunspore", "swordsdance"],
-        "essentialMoves": ["megadrain"]
+        "moves": ["bodyslam", "megadrain", "sleeppowder"],
+        "exclusiveMoves": ["stunspore", "stunspore", "swordsdance"]
     },
     "paras": {
         "level": 89,
-        "moves": ["bodyslam", "megadrain"],
-        "essentialMoves": ["spore"],
-        "exclusiveMoves": ["growth", "slash", "stunspore", "stunspore", "swordsdance"]
+        "moves": ["bodyslam", "megadrain", "spore"],
+        "exclusiveMoves": ["stunspore", "stunspore", "swordsdance"]
     },
     "parasect": {
         "level": 78,
-        "moves": ["bodyslam", "megadrain"],
-        "essentialMoves": ["spore"],
-        "exclusiveMoves": ["growth", "hyperbeam", "slash", "stunspore", "stunspore", "swordsdance"]
+        "moves": ["bodyslam", "megadrain", "spore"],
+        "exclusiveMoves": ["hyperbeam", "slash", "stunspore", "stunspore", "stunspore", "swordsdance", "swordsdance"]
     },
     "venonat": {
         "level": 88,
@@ -230,17 +229,17 @@
     "venomoth": {
         "level": 74,
         "moves": ["psychic", "sleeppowder", "stunspore"],
-        "exclusiveMoves": ["doubleedge", "megadrain", "megadrain"]
+        "exclusiveMoves": ["doubleedge", "megadrain"]
     },
     "diglett": {
         "level": 88,
-        "moves": ["bodyslam", "rockslide", "slash"],
-        "essentialMoves": ["earthquake"]
+        "moves": ["earthquake", "rockslide", "slash"],
+        "exclusiveMoves": ["bodyslam", "bodyslam", "substitute"]
     },
     "dugtrio": {
         "level": 73,
-        "moves": ["bodyslam", "rockslide", "slash"],
-        "essentialMoves": ["earthquake"]
+        "moves": ["earthquake", "rockslide", "slash"],
+        "exclusiveMoves": ["bodyslam", "bodyslam", "substitute"]
     },
     "meowth": {
         "level": 87,
@@ -254,58 +253,56 @@
     },
     "psyduck": {
         "level": 88,
-        "moves": ["amnesia", "blizzard"],
-        "essentialMoves": ["surf"],
-        "exclusiveMoves": ["bodyslam", "hydropump", "rest", "seismictoss"]
+        "moves": ["amnesia", "blizzard", "surf"],
+        "exclusiveMoves": ["bodyslam", "hydropump", "rest", "seismictoss", "seismictoss"]
     },
     "golduck": {
         "level": 75,
-        "moves": ["amnesia", "blizzard"],
-        "essentialMoves": ["surf"],
-        "exclusiveMoves": ["bodyslam", "hydropump", "rest", "seismictoss"]
+        "moves": ["amnesia", "blizzard", "surf"],
+        "exclusiveMoves": ["bodyslam", "hydropump", "rest", "rest", "seismictoss"]
     },
     "mankey": {
         "level": 89,
         "moves": ["bodyslam", "rockslide", "submission"],
-        "exclusiveMoves": ["counter", "megakick"]
+        "exclusiveMoves": ["counter", "lowkick", "megakick"]
     },
     "primeape": {
         "level": 78,
-        "moves": ["bodyslam", "rockslide", "submission"],
-        "exclusiveMoves": ["counter", "hyperbeam", "hyperbeam"]
+        "moves": ["rockslide", "rockslide", "rockslide", "thunderbolt"],
+        "essentialMoves": ["bodyslam", "submission"],
+        "exclusiveMoves": ["counter", "lowkick", "hyperbeam", "hyperbeam"]
     },
     "growlithe": {
         "level": 92,
-        "moves": ["bodyslam", "fireblast", "flamethrower", "reflect"]
+        "moves": ["agility", "flamethrower", "reflect"],
+        "essentialMoves": ["bodyslam", "fireblast"]
     },
     "arcanine": {
         "level": 76,
         "moves": ["bodyslam", "fireblast", "hyperbeam"],
-        "exclusiveMoves": ["flamethrower", "reflect"]
+        "exclusiveMoves": ["agility", "agility", "flamethrower", "flamethrower", "reflect", "rest"]
     },
     "poliwag": {
         "level": 86,
-        "moves": ["blizzard", "surf"],
-        "essentialMoves": ["amnesia"],
-        "exclusiveMoves": ["hypnosis", "hypnosis", "psychic"]
+        "moves": ["amnesia", "blizzard", "surf"],
+        "exclusiveMoves": ["hypnosis", "hypnosis", "hypnosis", "psychic"]
     },
     "poliwhirl": {
         "level": 76,
-        "moves": ["blizzard", "surf"],
-        "essentialMoves": ["amnesia"],
-        "exclusiveMoves": ["counter", "hypnosis", "hypnosis", "psychic"]
+        "moves": ["amnesia", "blizzard", "surf"],
+        "exclusiveMoves": ["counter", "hypnosis", "hypnosis", "hypnosis", "psychic"]
     },
     "poliwrath": {
         "level": 74,
         "moves": ["blizzard", "bodyslam", "earthquake", "submission"],
         "essentialMoves": ["surf"],
-        "exclusiveMoves": ["hypnosis", "hypnosis", "psychic"],
+        "exclusiveMoves": ["hypnosis", "hypnosis", "hypnosis", "psychic"],
         "comboMoves": ["amnesia", "blizzard"]
     },
     "abra": {
         "level": 83,
         "moves": ["psychic", "seismictoss", "thunderwave"],
-        "exclusiveMoves": ["counter", "reflect"]
+        "exclusiveMoves": ["counter", "reflect", "substitute"]
     },
     "kadabra": {
         "level": 73,
@@ -330,17 +327,17 @@
     "machamp": {
         "level": 77,
         "moves": ["bodyslam", "earthquake", "submission"],
-        "exclusiveMoves": ["counter", "hyperbeam", "rockslide", "rockslide"]
+        "exclusiveMoves": ["counter", "hyperbeam", "hyperbeam", "rockslide", "rockslide"]
     },
     "bellsprout": {
         "level": 89,
-        "moves": ["doubleedge", "sleeppowder", "stunspore", "swordsdance"],
-        "essentialMoves": ["razorleaf"]
+        "moves": ["doubleedge", "razorleaf", "sleeppowder"],
+        "exclusiveMoves": ["stunspore", "stunspore", "swordsdance"]
     },
     "weepinbell": {
         "level": 80,
-        "moves": ["doubleedge", "sleeppowder", "stunspore", "swordsdance"],
-        "essentialMoves": ["razorleaf"]
+        "moves": ["doubleedge", "razorleaf", "sleeppowder"],
+        "exclusiveMoves": ["stunspore", "stunspore", "swordsdance"]
     },
     "victreebel": {
         "level": 74,
@@ -349,15 +346,13 @@
     },
     "tentacool": {
         "level": 85,
-        "moves": ["barrier", "hydropump", "surf"],
-        "essentialMoves": ["blizzard"],
-        "exclusiveMoves": ["megadrain", "megadrain"],
-        "comboMoves": ["hydropump", "surf"]
+        "moves": ["blizzard", "megadrain", "surf"],
+        "exclusiveMoves": ["barrier", "hydropump", "hydropump"]
     },
     "tentacruel": {
         "level": 73,
-        "moves": ["blizzard", "hydropump", "hyperbeam", "surf"],
-        "essentialMoves": ["swordsdance"]
+        "moves": ["blizzard", "hyperbeam", "swordsdance"],
+        "exclusiveMoves": ["hydropump", "hydropump", "surf"]
     },
     "geodude": {
         "level": 88,
@@ -373,7 +368,8 @@
     },
     "ponyta": {
         "level": 86,
-        "moves": ["agility", "bodyslam", "fireblast", "reflect"]
+        "moves": ["agility", "bodyslam", "fireblast"],
+        "exclusiveMoves": ["reflect", "reflect", "reflect", "stomp", "substitute", "substitute"]
     },
     "rapidash": {
         "level": 77,
@@ -381,25 +377,26 @@
     },
     "slowpoke": {
         "level": 87,
-        "moves": ["earthquake", "surf"],
-        "essentialMoves": ["thunderwave"],
-        "exclusiveMoves": ["blizzard", "psychic", "rest"],
-        "comboMoves": ["amnesia", "surf"]
+        "moves": ["blizzard", "psychic", "rest"],
+        "essentialMoves": ["surf", "thunderwave"],
+        "exclusiveMoves": ["amnesia", "earthquake", "earthquake"],
+        "comboMoves": ["amnesia", "rest", "surf", "thunderwave"]
     },
     "slowbro": {
         "level": 68,
-        "moves": ["amnesia", "surf", "thunderwave"],
-        "exclusiveMoves": ["blizzard", "psychic", "rest", "rest"]
+        "moves": ["blizzard", "psychic", "surf"],
+        "essentialMoves": ["amnesia", "thunderwave"],
+        "comboMoves": ["amnesia", "rest", "surf", "thunderwave"]
     },
     "magnemite": {
         "level": 88,
         "moves": ["thunder", "thunderbolt", "thunderwave"],
-        "exclusiveMoves": ["doubleedge", "mimic", "substitute", "toxic"]
+        "exclusiveMoves": ["doubleedge", "doubleedge", "mimic", "rest"]
     },
     "magneton": {
         "level": 77,
         "moves": ["thunder", "thunderbolt", "thunderwave"],
-        "exclusiveMoves": ["doubleedge", "hyperbeam", "hyperbeam", "mimic", "substitute", "toxic"]
+        "exclusiveMoves": ["doubleedge", "hyperbeam", "hyperbeam", "mimic", "rest"]
     },
     "farfetchd": {
         "level": 83,
@@ -415,25 +412,22 @@
     },
     "seel": {
         "level": 88,
-        "moves": ["blizzard", "bodyslam", "surf"],
-        "exclusiveMoves": ["mimic", "rest"]
+        "moves": ["blizzard", "bodyslam", "rest", "surf"]
     },
     "dewgong": {
         "level": 74,
         "moves": ["blizzard", "bodyslam", "surf"],
-        "exclusiveMoves": ["hyperbeam", "mimic", "rest", "rest"]
+        "exclusiveMoves": ["hyperbeam", "rest", "rest", "rest"]
     },
     "grimer": {
         "level": 90,
-        "moves": ["bodyslam", "sludge"],
-        "essentialMoves": ["explosion"],
-        "exclusiveMoves": ["fireblast", "megadrain", "megadrain", "screech"]
+        "moves": ["fireblast", "fireblast", "megadrain", "sludge", "sludge", "sludge", "thunderbolt"],
+        "essentialMoves": ["bodyslam", "explosion"]
     },
     "muk": {
         "level": 77,
-        "moves": ["bodyslam", "sludge"],
-        "essentialMoves": ["explosion"],
-        "exclusiveMoves": ["fireblast", "hyperbeam", "megadrain", "megadrain"]
+        "moves": ["fireblast", "fireblast", "hyperbeam", "megadrain", "megadrain", "sludge", "sludge", "sludge", "thunderbolt"],
+        "essentialMoves": ["bodyslam", "explosion"]
     },
     "shellder": {
         "level": 90,
@@ -446,21 +440,21 @@
     },
     "gastly": {
         "level": 80,
-        "moves": ["explosion", "megadrain", "nightshade", "psychic"],
+        "moves": ["explosion", "explosion", "megadrain", "nightshade", "psychic", "psychic"],
         "essentialMoves": ["thunderbolt"],
-        "exclusiveMoves": ["confuseray", "hypnosis", "hypnosis"]
+        "exclusiveMoves": ["confuseray", "hypnosis", "hypnosis", "hypnosis"]
     },
     "haunter": {
         "level": 72,
-        "moves": ["explosion", "megadrain", "nightshade", "psychic"],
+        "moves": ["explosion", "explosion", "megadrain", "nightshade", "psychic", "psychic"],
         "essentialMoves": ["thunderbolt"],
-        "exclusiveMoves": ["confuseray", "hypnosis", "hypnosis"]
+        "exclusiveMoves": ["confuseray", "hypnosis", "hypnosis", "hypnosis"]
     },
     "gengar": {
         "level": 64,
-        "moves": ["explosion", "megadrain", "nightshade", "psychic"],
+        "moves": ["explosion", "explosion", "megadrain", "nightshade", "psychic", "psychic"],
         "essentialMoves": ["thunderbolt"],
-        "exclusiveMoves": ["confuseray", "hypnosis", "hypnosis"]
+        "exclusiveMoves": ["confuseray", "hypnosis", "hypnosis", "hypnosis"]
     },
     "onix": {
         "level": 81,
@@ -478,7 +472,8 @@
     },
     "krabby": {
         "level": 90,
-        "moves": ["blizzard", "bodyslam", "crabhammer", "swordsdance"]
+        "moves": ["bodyslam", "crabhammer", "swordsdance"],
+        "exclusiveMoves": ["blizzard", "blizzard", "blizzard", "stomp"]
     },
     "kingler": {
         "level": 77,
@@ -487,23 +482,21 @@
     "voltorb": {
         "level": 88,
         "moves": ["explosion", "thunderbolt", "thunderwave"],
-        "exclusiveMoves": ["screech", "thunder", "toxic"]
+        "exclusiveMoves": ["takedown", "thunder"]
     },
     "electrode": {
         "level": 77,
         "moves": ["explosion", "thunderbolt", "thunderwave"],
-        "exclusiveMoves": ["hyperbeam", "screech", "thunder", "toxic"]
+        "exclusiveMoves": ["hyperbeam", "hyperbeam", "takedown", "thunder", "thunder"]
     },
     "exeggcute": {
         "level": 77,
-        "moves": ["sleeppowder", "stunspore"],
-        "essentialMoves": ["psychic"],
-        "exclusiveMoves": ["doubleedge", "explosion", "explosion"]
+        "moves": ["explosion", "psychic", "sleeppowder", "stunspore"]
     },
     "exeggutor": {
         "level": 66,
         "moves": ["explosion", "psychic", "sleeppowder"],
-        "exclusiveMoves": ["doubleedge", "eggbomb", "hyperbeam", "megadrain", "megadrain", "stunspore", "stunspore", "stunspore"]
+        "exclusiveMoves": ["doubleedge", "hyperbeam", "megadrain", "stunspore", "stunspore", "stunspore"]
     },
     "cubone": {
         "level": 88,
@@ -516,12 +509,12 @@
     "hitmonlee": {
         "level": 80,
         "moves": ["bodyslam", "highjumpkick", "seismictoss"],
-        "exclusiveMoves": ["counter", "counter", "meditate"]
+        "exclusiveMoves": ["counter", "counter", "meditate", "megakick", "rollingkick"]
     },
     "hitmonchan": {
         "level": 83,
         "moves": ["bodyslam", "seismictoss", "submission"],
-        "exclusiveMoves": ["agility", "counter", "counter"]
+        "exclusiveMoves": ["agility", "agility", "counter", "counter", "megakick"]
     },
     "lickitung": {
         "level": 80,
@@ -542,19 +535,16 @@
     },
     "rhydon": {
         "level": 68,
-        "moves": ["bodyslam", "earthquake", "rockslide"],
-        "exclusiveMoves": ["hyperbeam", "substitute", "substitute"]
+        "moves": ["bodyslam", "earthquake", "rockslide", "substitute"]
     },
     "chansey": {
         "level": 68,
-        "moves": ["icebeam", "thunderwave"],
-        "essentialMoves": ["softboiled"],
+        "moves": ["icebeam", "softboiled", "thunderwave"],
         "exclusiveMoves": ["counter", "reflect", "seismictoss", "sing", "thunderbolt", "thunderbolt", "thunderbolt"]
     },
     "tangela": {
         "level": 74,
-        "moves": ["bodyslam", "sleeppowder"],
-        "essentialMoves": ["megadrain"],
+        "moves": ["bodyslam", "megadrain", "sleeppowder"],
         "exclusiveMoves": ["growth", "stunspore", "stunspore", "stunspore", "swordsdance", "swordsdance"]
     },
     "kangaskhan": {
@@ -578,8 +568,8 @@
     },
     "seaking": {
         "level": 79,
-        "moves": ["blizzard", "doubleedge", "surf"],
-        "exclusiveMoves": ["agility", "agility", "hyperbeam"]
+        "moves": ["agility", "doubleedge", "hyperbeam"],
+        "essentialMoves": ["blizzard", "surf"]
     },
     "staryu": {
         "level": 82,
@@ -589,7 +579,7 @@
     },
     "starmie": {
         "level": 67,
-        "moves": ["blizzard", "thunderbolt", "thunderwave"],
+        "moves": ["blizzard", "psychic", "thunderbolt", "thunderwave", "thunderwave"],
         "essentialMoves": ["recover"],
         "exclusiveMoves": ["hydropump", "psychic", "surf", "surf"]
     },
@@ -604,20 +594,22 @@
     "jynx": {
         "level": 67,
         "moves": ["blizzard", "lovelykiss", "psychic"],
-        "exclusiveMoves": ["bodyslam", "counter", "counter", "mimic", "seismictoss"]
+        "exclusiveMoves": ["bodyslam", "counter", "counter", "seismictoss", "substitute"]
     },
     "electabuzz": {
         "level": 74,
-        "moves": ["psychic", "seismictoss", "thunderbolt", "thunderwave"]
+        "moves": ["psychic", "thunderbolt", "thunderwave"],
+        "exclusiveMoves": ["hyperbeam", "seismictoss", "seismictoss", "seismictoss"]
     },
     "magmar": {
         "level": 77,
         "moves": ["bodyslam", "confuseray", "fireblast"],
-        "exclusiveMoves": ["hyperbeam", "psychic"]
+        "exclusiveMoves": ["hyperbeam", "psychic", "seismictoss"]
     },
     "pinsir": {
         "level": 78,
-        "moves": ["bodyslam", "hyperbeam", "swordsdance"],
+        "moves": ["bodyslam", "bodyslam", "slash"],
+        "essentialMoves": ["hyperbeam", "swordsdance"],
         "exclusiveMoves": ["seismictoss", "submission", "submission"]
     },
     "tauros": {
@@ -627,8 +619,8 @@
     },
     "gyarados": {
         "level": 73,
-        "moves": ["blizzard", "bodyslam", "hyperbeam", "thunderbolt"],
-        "exclusiveMoves": ["hydropump", "surf"]
+        "moves": ["blizzard", "bodyslam", "bodyslam", "hyperbeam", "thunderbolt"],
+        "exclusiveMoves": ["hydropump", "surf", "surf"]
     },
     "lapras": {
         "level": 69,
@@ -641,19 +633,19 @@
     },
     "eevee": {
         "level": 88,
-        "moves": ["doubleedge", "quickattack", "reflect"],
+        "moves": ["doubleedge", "doubleedge", "quickattack", "quickattack", "reflect"],
         "essentialMoves": ["bodyslam"],
-        "exclusiveMoves": ["bide", "mimic", "sandattack", "tailwhip"]
+        "exclusiveMoves": ["sandattack", "tailwhip"]
     },
     "vaporeon": {
         "level": 74,
         "moves": ["blizzard", "rest", "surf"],
-        "exclusiveMoves": ["bodyslam", "hydropump", "mimic"]
+        "exclusiveMoves": ["acidarmor", "bodyslam", "bodyslam", "bodyslam", "hydropump", "mimic"]
     },
     "jolteon": {
         "level": 68,
-        "moves": ["bodyslam", "thunderbolt", "thunderwave"],
-        "exclusiveMoves": ["agility", "agility", "doublekick", "pinmissile", "pinmissile"]
+        "moves": ["agility", "agility", "bodyslam", "bodyslam", "bodyslam", "doublekick", "pinmissile", "pinmissile"],
+        "essentialMoves": ["thunderbolt", "thunderwave"]
     },
     "flareon": {
         "level": 77,
@@ -671,12 +663,14 @@
     },
     "omastar": {
         "level": 74,
-        "moves": ["blizzard", "hydropump", "seismictoss", "surf"],
-        "exclusiveMoves": ["bodyslam", "rest"]
+        "moves": ["bodyslam", "rest", "seismictoss"],
+        "essentialMoves": ["blizzard"],
+        "exclusiveMoves": ["hydropump", "surf"]
     },
     "kabuto": {
         "level": 88,
-        "moves": ["blizzard", "bodyslam", "slash", "surf"]
+        "moves": ["blizzard", "bodyslam", "slash"],
+        "exclusiveMoves": ["hydropump", "surf", "surf"]
     },
     "kabutops": {
         "level": 77,
@@ -685,20 +679,21 @@
     },
     "aerodactyl": {
         "level": 74,
-        "moves": ["doubleedge", "fireblast", "hyperbeam", "skyattack"]
+        "moves": ["doubleedge", "fireblast", "hyperbeam"],
+        "exclusiveMoves": ["agility", "skyattack", "skyattack"]
     },
     "snorlax": {
         "level": 69,
-        "moves": ["bodyslam", "rest", "selfdestruct", "thunderbolt"],
-        "essentialMoves": ["amnesia"],
-        "exclusiveMoves": ["blizzard", "blizzard"],
+        "moves": ["bodyslam", "thunderbolt"],
+        "essentialMoves": ["amnesia", "blizzard"],
+        "exclusiveMoves": ["rest", "selfdestruct"],
         "comboMoves": ["bodyslam", "earthquake", "hyperbeam", "selfdestruct"]
     },
     "articuno": {
         "level": 71,
-        "moves": ["agility", "hyperbeam", "icebeam", "mimic", "reflect"],
-        "essentialMoves": ["blizzard"],
-        "comboMoves": ["icebeam", "reflect", "rest"]
+        "moves": ["agility", "blizzard", "hyperbeam"],
+        "exclusiveMoves": ["icebeam", "mimic", "reflect"],
+        "comboMoves": ["blizzard", "icebeam", "reflect", "rest"]
     },
     "zapdos": {
         "level": 68,
@@ -707,35 +702,32 @@
     "moltres": {
         "level": 75,
         "moves": ["agility", "fireblast", "hyperbeam"],
-        "exclusiveMoves": ["doubleedge", "reflect", "skyattack"]
+        "exclusiveMoves": ["doubleedge", "doubleedge", "doubleedge", "reflect"]
     },
     "dratini": {
         "level": 91,
-        "moves": ["bodyslam", "hyperbeam", "thunderbolt", "thunderwave"],
-        "essentialMoves": ["blizzard"]
+        "moves": ["bodyslam", "hyperbeam", "thunderbolt", "thunderbolt"],
+        "essentialMoves": ["blizzard", "thunderwave"]
     },
     "dragonair": {
         "level": 81,
-        "moves": ["bodyslam", "hyperbeam", "thunderbolt", "thunderwave"],
-        "essentialMoves": ["blizzard"]
+        "moves": ["bodyslam", "hyperbeam", "thunderbolt", "thunderbolt"],
+        "essentialMoves": ["blizzard", "thunderwave"]
     },
     "dragonite": {
         "level": 73,
-        "moves": ["bodyslam", "hyperbeam", "thunderbolt", "thunderwave"],
+        "moves": ["bodyslam", "hyperbeam", "thunderbolt", "thunderwave", "thunderwave"],
         "essentialMoves": ["blizzard"]
     },
     "mewtwo": {
         "level": 58,
         "moves": ["blizzard", "recover", "thunderbolt"],
-        "essentialMoves": ["amnesia"],
-        "exclusiveMoves": ["psychic", "psychic"],
-        "comboMoves": ["barrier", "rest"]
+        "essentialMoves": ["amnesia", "psychic"],
+        "comboMoves": ["amnesia", "psychic", "recover", "thunderwave"]
     },
     "mew": {
         "level": 66,
-        "moves": ["blizzard", "earthquake", "thunderbolt", "thunderwave"],
-        "essentialMoves": ["psychic"],
-        "exclusiveMoves": ["explosion", "softboiled", "softboiled"],
-        "comboMoves": ["earthquake", "hyperbeam", "swordsdance"]
+        "moves": ["blizzard", "blizzard", "earthquake", "explosion", "explosion", "thunderbolt"],
+        "essentialMoves": ["psychic", "softboiled", "thunderwave"]
     }
 }

--- a/data/mods/gen1/random-teams.ts
+++ b/data/mods/gen1/random-teams.ts
@@ -1,6 +1,5 @@
 import RandomGen2Teams from '../gen2/random-teams';
 import {Utils} from '../../../lib';
-import {MoveCounter} from '../gen8/random-teams';
 
 interface HackmonsCupEntry {
 	types: string[];
@@ -248,29 +247,6 @@ export class RandomGen1Teams extends RandomGen2Teams {
 		return pokemon;
 	}
 
-	shouldCullMove(move: Move, types: Set<string>, moves: Set<string>, counter: MoveCounter): {cull: boolean} {
-		switch (move.id) {
-		// bit redundant to have both, but neither particularly better than the other
-		case 'hydropump':
-			return {cull: moves.has('surf')};
-		case 'surf':
-			return {cull: moves.has('hydropump')};
-
-		// other redundancies that aren't handled within the movesets themselves
-		case 'selfdestruct':
-			return {cull: moves.has('rest')};
-		case 'rest':
-			return {cull: moves.has('selfdestruct')};
-		case 'sharpen': case 'swordsdance':
-			return {cull: counter.get('Special') > counter.get('Physical') || !counter.get('Physical') || moves.has('growth')};
-		case 'growth':
-			return {cull: counter.get('Special') < counter.get('Physical') || !counter.get('Special') || moves.has('swordsdance')};
-		case 'poisonpowder': case 'stunspore': case 'sleeppowder': case 'toxic':
-			return {cull: counter.get('Status') > 1};
-		}
-		return {cull: false};
-	}
-
 	/**
 	 * Random set generation for Gen 1 Random Battles.
 	 */
@@ -281,14 +257,6 @@ export class RandomGen1Teams extends RandomGen2Teams {
 		const data = this.randomData[species.id];
 		const movePool = data.moves?.slice() || [];
 		const moves = new Set<string>();
-		const types = new Set(species.types);
-
-		const counter = new MoveCounter();
-
-		// Moves that boost Attack:
-		const PhysicalSetup = ['swordsdance', 'sharpen'];
-		// Moves which boost Special Attack:
-		const SpecialSetup = ['amnesia', 'growth'];
 
 		// Either add all moves or add none
 		if (data.comboMoves && data.comboMoves.length <= this.maxMoveCount && this.randomChance(1, 2)) {
@@ -303,8 +271,9 @@ export class RandomGen1Teams extends RandomGen2Teams {
 
 		// Add the mandatory moves.
 		if (moves.size < this.maxMoveCount && data.essentialMoves) {
-			while (moves.size < this.maxMoveCount && data.essentialMoves.length) {
-				moves.add(this.sampleNoReplace(data.essentialMoves));
+			for (const moveid of data.essentialMoves) {
+				moves.add(moveid);
+				if (moves.size === this.maxMoveCount) break;
 			}
 		}
 
@@ -314,26 +283,6 @@ export class RandomGen1Teams extends RandomGen2Teams {
 				const moveid = this.sampleNoReplace(movePool);
 				moves.add(moveid);
 			}
-
-			// Only do move choosing if we have backup moves in the pool...
-			if (movePool.length) {
-				for (const setMoveid of moves) {
-					const move = this.dex.moves.get(setMoveid);
-					const moveid = move.id;
-					if (!move.damage && !move.damageCallback) counter.add(move.category);
-					if (PhysicalSetup.includes(moveid)) counter.add('physicalsetup');
-					if (SpecialSetup.includes(moveid)) counter.add('specialsetup');
-				}
-
-				for (const moveid of moves) {
-					const move = this.dex.moves.get(moveid);
-					if (this.shouldCullMove(move, types, moves, counter).cull) {
-						moves.delete(moveid);
-						break;
-					}
-					counter.add(move.category);
-				}
-			} // End of the check for more than 4 moves on moveset.
 		}
 
 		const level = this.adjustLevel || data.level || 80;
@@ -362,10 +311,14 @@ export class RandomGen1Teams extends RandomGen2Teams {
 			ivs.atk = 2;
 		}
 
+		// shuffle moves to add more randomness to camomons
+		const shuffledMoves = Array.from(moves);
+		this.prng.shuffle(shuffledMoves);
+
 		return {
 			name: species.name,
 			species: species.name,
-			moves: Array.from(moves),
+			moves: shuffledMoves,
 			ability: 'No Ability',
 			evs,
 			ivs,

--- a/data/mods/gen1/random-teams.ts
+++ b/data/mods/gen1/random-teams.ts
@@ -10,7 +10,7 @@ interface HackmonsCupEntry {
 interface Gen1RandomBattleSpecies {
 	level?: number;
 	moves?: ID[];
-	essentialMove?: ID;
+	essentialMoves?: ID[];
 	exclusiveMoves?: ID[];
 	comboMoves?: ID[];
 }
@@ -301,9 +301,11 @@ export class RandomGen1Teams extends RandomGen2Teams {
 			moves.add(this.sample(data.exclusiveMoves));
 		}
 
-		// Add the mandatory move. SD Mew and Amnesia Snorlax are exceptions.
-		if (moves.size < this.maxMoveCount && data.essentialMove) {
-			moves.add(data.essentialMove);
+		// Add the mandatory moves.
+		if (moves.size < this.maxMoveCount && data.essentialMoves) {
+			while (moves.size < this.maxMoveCount && data.essentialMoves.length) {
+				moves.add(this.sampleNoReplace(data.essentialMoves));
+			}
 		}
 
 		while (moves.size < this.maxMoveCount && movePool.length) {
@@ -324,12 +326,8 @@ export class RandomGen1Teams extends RandomGen2Teams {
 				}
 
 				for (const moveid of moves) {
-					if (moveid === data.essentialMove) continue;
 					const move = this.dex.moves.get(moveid);
-					if (
-						(!data.essentialMove || moveid !== data.essentialMove) &&
-						this.shouldCullMove(move, types, moves, counter).cull
-					) {
+					if (this.shouldCullMove(move, types, moves, counter).cull) {
 						moves.delete(moveid);
 						break;
 					}

--- a/server/chat-plugins/randombattles/index.ts
+++ b/server/chat-plugins/randombattles/index.ts
@@ -182,10 +182,6 @@ function getRBYMoves(species: string | Species) {
 	const data = getData(species, 'gen1randombattle');
 	if (!data) return false;
 	let buf = ``;
-	if (data.moves) {
-		buf += `<br/><b>Randomized moves</b>: `;
-		buf += data.moves.map(formatMove).sort().join(", ");
-	}
 	if (data.comboMoves) {
 		buf += `<br/><b>Combo moves</b>: `;
 		buf += data.comboMoves.map(formatMove).sort().join(", ");
@@ -197,6 +193,10 @@ function getRBYMoves(species: string | Species) {
 	if (data.essentialMoves) {
 		buf += `<br/><b>Essential move${Chat.plural(data.essentialMoves)}</b>: `;
 		buf += data.essentialMoves.map(formatMove).sort().join(", ");
+	}
+	if (data.moves) {
+		buf += `<br/><b>Randomized moves</b>: `;
+		buf += data.moves.map(formatMove).sort().join(", ");
 	}
 	if (
 		!data.moves && !data.comboMoves &&

--- a/server/chat-plugins/randombattles/index.ts
+++ b/server/chat-plugins/randombattles/index.ts
@@ -194,9 +194,9 @@ function getRBYMoves(species: string | Species) {
 		buf += `<br/><b>Exclusive moves</b>: `;
 		buf += data.exclusiveMoves.map(formatMove).sort().join(", ");
 	}
-	if (data.essentialMove) {
-		buf += `<br/><b>Essential move</b>: `;
-		buf += formatMove(data.essentialMove);
+	if (data.essentialMoves) {
+		buf += `<br/><b>Essential move${Chat.plural(data.essentialMoves)}</b>: `;
+		buf += data.essentialMoves.map(formatMove).sort().join(", ");
 	}
 	if (
 		!data.moves && !data.comboMoves &&


### PR DESCRIPTION
This is a significant overhaul of Gen 1 Random Battles sets, in consultation with many highly experienced players.

The structure of moveset generation remains basically the same. The only difference is that `essentialMove` has been replaced with the array `essentialMoves` so that more than one move can be guaranteed.