### PR TITLE
Fix interaction of Pollen Puff and Heal Block

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -13775,10 +13775,23 @@ export const Moves: {[moveid: string]: MoveData} = {
 				move.infiltrates = true;
 			}
 		},
-		onHit(target, source) {
+		onTryMove(source, target, move) {
+			if (source.isAlly(target) && source.volatiles['healblock']) {
+				this.attrLastMove('[still]');
+				this.add('cant', source, 'move: Heal Block', move);
+				return false;
+			}
+		},
+		onHit(target, source, move) {
 			if (source.isAlly(target)) {
 				if (!this.heal(Math.floor(target.baseMaxhp * 0.5))) {
-					this.add('-immune', target);
+					if (target.volatiles['healblock'] && target.hp !== target.maxhp) {
+						this.attrLastMove('[still]');
+						// Wrong error message, correct one not supported yet
+						this.add('cant', source, 'move: Heal Block', move);
+					} else {
+						this.add('-immune', target);
+					}
 					return this.NOT_FAIL;
 				}
 			}

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -938,6 +938,9 @@ export class Pokemon {
 				if (!this.hasType('Ghost')) {
 					target = this.battle.dex.moves.get('curse').nonGhostTarget || moveSlot.target;
 				}
+			// Heal Block only prevents Pollen Puff from targeting an ally when the user has Heal Block
+			} else if (moveSlot.id === 'pollenpuff' && this.volatiles['healblock']) {
+				target = 'adjacentFoe';
 			}
 			let disabled = moveSlot.disabled;
 			if (this.volatiles['dynamax']) {

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -518,6 +518,10 @@ export class Side {
 			if (!this.battle.validTargetLoc(targetLoc, pokemon, targetType)) {
 				return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
 			}
+			// Heal Block only prevents Pollen Puff from targeting an ally when the user has Heal Block
+			if (move.id === 'pollenpuff' && pokemon.volatiles['healblock'] && targetLoc < 0 && !zMove) {
+				return this.emitChoiceError(`Can't move: ${pokemon.name} can't use ${move.name} because of Heal Block!`);
+			}
 		} else {
 			if (targetLoc) {
 				return this.emitChoiceError(`Can't move: You can't choose a target for ${move.name}`);

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -518,10 +518,6 @@ export class Side {
 			if (!this.battle.validTargetLoc(targetLoc, pokemon, targetType)) {
 				return this.emitChoiceError(`Can't move: Invalid target for ${move.name}`);
 			}
-			// Heal Block only prevents Pollen Puff from targeting an ally when the user has Heal Block
-			if (move.id === 'pollenpuff' && pokemon.volatiles['healblock'] && targetLoc < 0 && !zMove) {
-				return this.emitChoiceError(`Can't move: ${pokemon.name} can't use ${move.name} because of Heal Block!`);
-			}
 		} else {
 			if (targetLoc) {
 				return this.emitChoiceError(`Can't move: You can't choose a target for ${move.name}`);

--- a/test/sim/moves/pollenpuff.js
+++ b/test/sim/moves/pollenpuff.js
@@ -79,7 +79,6 @@ describe('Pollen Puff', function () {
 			battle.makeChoices();
 			battle.makeChoices('move pollenpuff -2, move sleeptalk', 'move healblock, move falseswipe 2');
 			assert.false.fullHP(battle.p1.active[1], `Roggenrola should not have healed from Pollen Puff`);
-			common.saveReplay(battle);
 		});
 
 		it(`should prevent the user from successfully using Pollen Puff into an ally if the user becomes affected by Heal Block mid-turn`, function () {

--- a/test/sim/moves/pollenpuff.js
+++ b/test/sim/moves/pollenpuff.js
@@ -39,45 +39,47 @@ describe('Pollen Puff', function () {
 		assert.false.fullHP(battle.p1.active[1]);
 	});
 
-	describe.skip(`interaction of Heal Block and Pollen Puff`, function () {
+	describe(`interaction of Heal Block and Pollen Puff`, function () {
 		it(`should prevent the user from targeting an ally with Pollen Puff while the user is affected by Heal Block`, function () {
 			battle = common.createBattle({gameType: 'doubles'}, [[
-				{species: 'wynaut', moves: ['sleeptalk', 'pollenpuff']},
+				{species: 'bunnelby', moves: ['sleeptalk', 'pollenpuff']},
 				{species: 'roggenrola', ability: 'magicbounce', moves: ['sleeptalk']},
 			], [
-				{species: 'wobbuffet', moves: ['healblock']},
+				{species: 'scolipede', moves: ['healblock']},
 				{species: 'lucario', moves: ['sleeptalk']},
 			]]);
 
-			battle.makeChoices('auto');
-			assert.false.cantMove(() => battle.choose('p1', 'move pollenpuff 1, move sleeptalk'), 'Wynaut', 'Pollen Puff');
-			assert.cantMove(() => battle.choose('p1', 'move pollenpuff -2, move sleeptalk'), 'Wynaut', 'Pollen Puff');
+			battle.makeChoices();
+			assert.cantMove(() => battle.choose('p1', 'move pollenpuff -2, move sleeptalk'), 'Bunnelby', 'Pollen Puff');
+			assert.false.cantMove(() => battle.choose('p1', 'move pollenpuff 1, move sleeptalk'), 'Bunnelby', 'Pollen Puff');
 		});
 
 		it(`should not prevent the user from targeting an ally with Z-Pollen Puff while the user is affected by Heal Block`, function () {
 			battle = common.createBattle({gameType: 'doubles'}, [[
-				{species: 'wynaut', item: 'buginiumz', moves: ['sleeptalk', 'pollenpuff']},
+				{species: 'bunnelby', item: 'buginiumz', moves: ['sleeptalk', 'pollenpuff']},
 				{species: 'roggenrola', ability: 'magicbounce', moves: ['sleeptalk']},
 			], [
-				{species: 'wobbuffet', moves: ['healblock']},
+				{species: 'scolipede', moves: ['healblock']},
 				{species: 'lucario', moves: ['sleeptalk']},
 			]]);
 
-			battle.makeChoices('auto');
-			assert.false.cantMove(() => battle.choose('p1', 'move pollenpuff -2, move sleeptalk'), 'Wynaut', 'Pollen Puff');
+			battle.makeChoices();
+			assert.false.cantMove(() => battle.choose('p1', 'move pollenpuff zmove -2, move sleeptalk'), 'Bunnelby', 'Pollen Puff');
 		});
 
 		it(`should not prevent the user from targeting an ally with Pollen Puff while the target is affected by Heal Block at move selection, but it should fail at move execution`, function () {
 			battle = common.createBattle({gameType: 'doubles'}, [[
-				{species: 'wynaut', ability: 'magicbounce', moves: ['pollenpuff']},
+				{species: 'wynaut', ability: 'magicbounce', moves: ['sleeptalk', 'pollenpuff']},
 				{species: 'roggenrola', moves: ['sleeptalk']},
 			], [
 				{species: 'wobbuffet', moves: ['healblock']},
 				{species: 'lucario', moves: ['falseswipe']},
 			]]);
 
+			battle.makeChoices();
 			battle.makeChoices('move pollenpuff -2, move sleeptalk', 'move healblock, move falseswipe 2');
 			assert.false.fullHP(battle.p1.active[1], `Roggenrola should not have healed from Pollen Puff`);
+			common.saveReplay(battle);
 		});
 
 		it(`should prevent the user from successfully using Pollen Puff into an ally if the user becomes affected by Heal Block mid-turn`, function () {
@@ -102,7 +104,7 @@ describe('Pollen Puff', function () {
 				{species: 'lucario', moves: ['sleeptalk']},
 			]]);
 
-			battle.makeChoices('move pollenpuff -2, move sleeptalk', 'auto');
+			battle.makeChoices('move pollenpuff zmove -2, move sleeptalk', 'auto');
 			assert.false.fullHP(battle.p1.active[1], `Roggenrola should have taken damage from Z-Pollen Puff`);
 		});
 	});

--- a/test/sim/moves/pollenpuff.js
+++ b/test/sim/moves/pollenpuff.js
@@ -50,8 +50,8 @@ describe('Pollen Puff', function () {
 			]]);
 
 			battle.makeChoices();
-			assert.cantMove(() => battle.choose('p1', 'move pollenpuff -2, move sleeptalk'), 'Bunnelby', 'Pollen Puff');
-			assert.false.cantMove(() => battle.choose('p1', 'move pollenpuff 1, move sleeptalk'), 'Bunnelby', 'Pollen Puff');
+			assert.cantMove(() => battle.choose('p1', 'move pollenpuff -2, move sleeptalk'));
+			assert.false.cantMove(() => battle.choose('p1', 'move pollenpuff 1, move sleeptalk'));
 		});
 
 		it(`should not prevent the user from targeting an ally with Z-Pollen Puff while the user is affected by Heal Block`, function () {
@@ -64,7 +64,7 @@ describe('Pollen Puff', function () {
 			]]);
 
 			battle.makeChoices();
-			assert.false.cantMove(() => battle.choose('p1', 'move pollenpuff zmove -2, move sleeptalk'), 'Bunnelby', 'Pollen Puff');
+			assert.false.cantMove(() => battle.choose('p1', 'move pollenpuff zmove -2, move sleeptalk'));
 		});
 
 		it(`should not prevent the user from targeting an ally with Pollen Puff while the target is affected by Heal Block at move selection, but it should fail at move execution`, function () {


### PR DESCRIPTION
Currently, Pollen Puff and Heal Block don't always interact correctly. Here's what it should do:

If the _user_ has Heal Block:
At move selection: cannot target ally with Pollen Puff
At move execution: "[POKEMON] can't use Pollen Puff because of Heal Block!", timing failure is around that of Primal weather causing Fire/Water moves to fail

If the _target_ has Heal Block:
At move selection: no restriction
At move execution: "[POKEMON] was prevented from healing due to Heal Block!", timing failure is after the full HP check

Right now, we don't support the generic "[POKEMON] was prevented from healing due to Heal Block!" message at all, and implementation looks difficult, so I may forgo that for now and save it for a future PR. It's relevant for things like Heal Pulse, Grassy Terrain recovery, and more in addition to Pollen Puff.