### PR TITLE
Fix Pursuit not triggering on revived Pokemon

### DIFF
--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2733,7 +2733,8 @@ export class Battle {
 				if (!reviveSwitch) switches[i] = false;
 			} else if (switches[i]) {
 				for (const pokemon of this.sides[i].active) {
-					if (pokemon.switchFlag && pokemon.switchFlag !== 'revivalblessing' && !pokemon.skipBeforeSwitchOutEventFlag) {
+					if (pokemon.hp && pokemon.switchFlag && pokemon.switchFlag !== 'revivalblessing' &&
+							!pokemon.skipBeforeSwitchOutEventFlag) {
 						this.runEvent('BeforeSwitchOut', pokemon);
 						pokemon.skipBeforeSwitchOutEventFlag = true;
 						this.faintMessages(); // Pokemon may have fainted in BeforeSwitchOut


### PR DESCRIPTION
Was caused by the `skipBeforeSwitchOutEventFlag` never being reset for fainted Pokemon. It shouldn't be set in the first place.

Bug report: https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-9751247

Inputs I used for testing:
```
>start {"formatid":"gen9customgame","seed":[58110,65317,35427,37487]}
>player p1 {"name":"Mathy","avatar":"#psstaffm","team":"Pawmot|||VoltAbsorb|RevivalBlessing,SleepTalk||1,,,,,||,0,,,,|||,,,,,Electric]Gholdengo|||GoodasGold|Memento,SleepTalk||1,,,,,||,0,,,,|||,,,,,Steel","rating":0}
>player p2 {"name":"Furret","avatar":"101","team":"Zigzagoon|||Pickup|Pursuit,SleepTalk||1,,,,,|||||,,,,,Normal","rating":0}
>p1 team 2, 1
>p2 team 1
>p1 move memento
>p2 move sleeptalk
>p1 switch 2
>p1 move revivalblessing
>p2 move pursuit
>p1 switch 2
>p1 switch 2
>p2 move pursuit
>p1 switch 2
>p2 move pursuit
```