### PR TITLE
Keep Random Roulette as a challenge only format

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2100,6 +2100,14 @@ export const Formats: FormatList = [
 			pokemon.m.innates = undefined;
 		},
 	},
+	{
+		name: "[Gen 9] Random Roulette",
+		desc: `Random Battles in a random generation! [Gen 1] Random Battle - [Gen 9] Random Battle.`,
+
+		mod: 'randomroulette',
+		team: 'random',
+		searchShow: false,
+	},
 
 	// Randomized Metas
 	///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This re-adds Random Roulette as a challenge format as mentioned here: https://github.com/smogon/pokemon-showdown/pull/9739#pullrequestreview-1606184042.

I kept it in the same section (Randomized Format Spotlight). If you'd prefer it somewhere else, or for the format to not show while challenging, I'd be fine with that.