### PR TITLE
Frantic Fusions: Change description

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -750,7 +750,7 @@ export const Formats: FormatList = [
 	},
 	{
 		name: "[Gen 9] Frantic Fusions",
-		desc: `Pok&eacute;mon nicknamed after another Pok&eacute;mon get their stats buffed by 1/4 of that Pok&eacute;mon's stats, barring HP, and access to their abilities.`,
+		desc: `Pok&eacute;mon nicknamed after another Pok&eacute;mon get their stats buffed by 1/4 of that Pok&eacute;mon's stats, barring HP, and access to one of their abilities.`,
 		threads: [
 			`&bullet; <a href="https://www.smogon.com/forums/threads/3725593/">Frantic Fusions</a>`,
 		],


### PR DESCRIPTION
Because apparently, everyone is chat believes this is like pokebilities.