### PR TITLE
Frantic Fusions: Don't hide nicknames when locked

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -377,9 +377,10 @@ export class TeamValidator {
 				problems = problems.concat(setProblems);
 			}
 			if (options.removeNicknames) {
+				const useCrossSpeciesNicknames = format.name.includes('Cross Evolution') || ruleTable.has('franticfusionsmod');
 				const species = dex.species.get(set.species);
 				let crossSpecies: Species;
-				if (format.name === '[Gen 9] Cross Evolution' && (crossSpecies = dex.species.get(set.name)).exists) {
+				if (useCrossSpeciesNicknames && (crossSpecies = dex.species.get(set.name)).exists) {
 					set.name = crossSpecies.name;
 				} else {
 					set.name = species.baseSpecies;


### PR DESCRIPTION
(only if the pokemon is named after another mon obviously)