### PR TITLE
Gen 6+7 Random Battle updates

### DIFF
--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -424,7 +424,7 @@
         "level": 97,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Setup Sweeper",
                 "movepool": ["bravebird", "knockoff", "leafblade", "return", "swordsdance"]
             }
         ]

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -253,10 +253,6 @@ export class RandomGen6Teams extends RandomGen7Teams {
 
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
 
-		if (!types.includes('Normal')) {
-			this.incompatibleMoves(moves, movePool, SETUP, 'Explosion');
-		}
-
 		if (!types.includes('Dark') && preferredType !== 'Dark') {
 			this.incompatibleMoves(moves, movePool, 'knockoff', ['pursuit', 'suckerpunch']);
 		}

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -2343,7 +2343,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["moonlight", "moonblast", "powergem", "psychic", "stealthrock", "toxic"]
+                "movepool": ["moonblast", "moonlight", "powergem", "psychic", "stealthrock", "toxic"]
             }
         ]
     },

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -526,7 +526,7 @@
         "level": 96,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Setup Sweeper",
                 "movepool": ["bravebird", "knockoff", "leafblade", "return", "swordsdance"]
             }
         ]

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -2881,8 +2881,9 @@
                 "movepool": ["closecombat", "grassknot", "machpunch", "overheat", "stealthrock"]
             },
             {
-                "role": "Setup Sweeper",
-                "movepool": ["fireblast", "focusblast", "grassknot", "nastyplot", "vacuumwave"]
+                "role": "Z-Move user",
+                "movepool": ["fireblast", "focusblast", "grassknot", "nastyplot", "vacuumwave"],
+                "preferredTypes": ["Fighting"]
             },
             {
                 "role": "Fast Attacker",

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -966,7 +966,8 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "doubleedge", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge"]
+                "movepool": ["defog", "doubleedge", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -8,7 +8,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["gigadrain", "hiddenpowerfire", "knockoff", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["earthquake", "energyball", "hiddenpowerfire", "knockoff", "sleeppowder", "sludgebomb", "synthesis"]
             }
         ]
     },
@@ -311,7 +311,7 @@
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["bugbuzz", "quiverdance", "sleeppowder", "sludgebomb", "substitute"],
+                "movepool": ["bugbuzz", "quiverdance", "roost", "sleeppowder", "sludgebomb"],
                 "preferredTypes": ["Bug"]
             }
         ]
@@ -372,7 +372,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "gunkshot", "icepunch", "stoneedge", "throatchop", "uturn"]
+                "movepool": ["closecombat", "earthquake", "gunkshot", "honeclaws", "icepunch", "stoneedge", "throatchop", "uturn"]
             }
         ]
     },
@@ -427,7 +427,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bulletpunch", "dynamicpunch", "knockoff", "stoneedge"]
+                "movepool": ["bulkup", "bulletpunch", "dynamicpunch", "knockoff", "stoneedge"],
+                "preferredTypes": ["Dark"]
             },
             {
                 "role": "AV Pivot",
@@ -436,7 +437,8 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["bulletpunch", "closecombat", "facade", "knockoff"]
+                "movepool": ["bulkup", "bulletpunch", "closecombat", "facade", "knockoff"],
+                "preferredTypes": ["Dark"]
             }
         ]
     },
@@ -489,8 +491,12 @@
         "level": 87,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Bulky Attacker",
                 "movepool": ["flareblitz", "highhorsepower", "morningsun", "wildcharge", "willowisp"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["flareblitz", "highhorsepower", "megahorn", "morningsun", "wildcharge"]
             }
         ]
     },
@@ -558,7 +564,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["curse", "explosion", "firepunch", "gunkshot", "haze", "icepunch", "poisonjab", "shadowsneak"],
+                "movepool": ["curse", "firepunch", "gunkshot", "haze", "icepunch", "poisonjab", "shadowsneak"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -744,7 +750,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["drainpunch", "earthquake", "fakeout", "return", "suckerpunch"]
+                "movepool": ["drainpunch", "doubleedge", "earthquake", "fakeout", "return", "suckerpunch"]
             },
             {
                 "role": "AV Pivot",
@@ -924,8 +930,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["facade", "flamecharge", "flareblitz", "quickattack", "superpower"],
-                "preferredTypes": ["Fighting"]
+                "movepool": ["facade", "flamecharge", "flareblitz", "quickattack", "superpower"]
             }
         ]
     },
@@ -956,8 +961,12 @@
         "level": 85,
         "sets": [
             {
+                "role": "Bulky Attacker",
+                "movepool": ["defog", "earthquake", "roost", "stealthrock", "stoneedge", "taunt", "toxic"]
+            },
+            {
                 "role": "Fast Support",
-                "movepool": ["defog", "doubleedge", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge", "taunt"]
+                "movepool": ["defog", "doubleedge", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge"]
             }
         ]
     },
@@ -1099,7 +1108,7 @@
                 "preferredTypes": ["Ice"]
             },
             {
-                "role": "Wallbreaker",
+                "role": "Bulky Setup",
                 "movepool": ["aquajet", "crunch", "icepunch", "liquidation", "swordsdance"]
             }
         ]
@@ -1373,9 +1382,17 @@
         "level": 84,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["earthquake", "ironhead", "roar", "rockslide", "stealthrock", "toxic"],
                 "preferredTypes": ["Steel"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["earthquake", "heavyslam", "protect", "toxic"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["earthquake", "heavyslam", "roar", "stealthrock", "toxic"]
             }
         ]
     },
@@ -1481,7 +1498,7 @@
         "level": 91,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Staller",
                 "movepool": ["ancientpower", "lavaplume", "recover", "stealthrock", "toxic"]
             },
             {
@@ -1612,7 +1629,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["closecombat", "rapidspin", "stoneedge", "suckerpunch", "toxic"]
+                "movepool": ["closecombat", "earthquake", "rapidspin", "stoneedge", "suckerpunch", "toxic"]
             }
         ]
     },
@@ -1674,8 +1691,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hiddenpowergrass", "hydropump", "icebeam", "rest", "scald", "substitute"],
-                "preferredTypes": ["Ice"]
+                "movepool": ["calmmind", "hydropump", "icebeam", "rest", "scald", "substitute"]
             },
             {
                 "role": "Staller",
@@ -1692,7 +1708,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["crunch", "dragondance", "earthquake", "icepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
             }
         ]
     },
@@ -1701,7 +1717,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["crunch", "dragondance", "earthquake", "icepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
             }
         ]
     },
@@ -1746,7 +1762,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "focusblast", "gigadrain", "hiddenpowerfire", "hiddenpowerice", "leafstorm"]
+                "movepool": ["earthquake", "focusblast", "gigadrain", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "rockslide"]
             },
             {
                 "role": "Staller",
@@ -2056,10 +2072,6 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["firefang", "ironhead", "knockoff", "playrough", "suckerpunch", "swordsdance"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["focuspunch", "ironhead", "playrough", "substitute"]
             }
         ]
     },
@@ -2331,7 +2343,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "moonlight", "powergem", "psychic", "stealthrock", "toxic"]
+                "movepool": ["moonlight", "moonblast", "powergem", "psychic", "stealthrock", "toxic"]
             }
         ]
     },
@@ -2486,7 +2498,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "psychic", "recover", "shadowball", "signalbeam"]
+                "movepool": ["calmmind", "psychic", "recover", "signalbeam"]
             }
         ]
     },
@@ -2801,7 +2813,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "firepunch", "ironhead", "protect", "stealthrock", "toxic", "uturn", "wish"]
+                "movepool": ["bodyslam", "firepunch", "healingwish", "ironhead", "protect", "stealthrock", "toxic", "uturn", "wish"]
             },
             {
                 "role": "Z-Move user",
@@ -2883,7 +2895,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["knockoff", "protect", "scald", "stealthrock", "toxic"]
+                "movepool": ["defog", "knockoff", "protect", "scald", "stealthrock", "toxic"]
             },
             {
                 "role": "Bulky Support",
@@ -2956,7 +2968,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["crunch", "earthquake", "firepunch", "headsmash"]
+                "movepool": ["crunch", "earthquake", "firepunch", "headsmash", "superpower"]
             }
         ]
     },
@@ -3149,6 +3161,10 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["earthquake", "ironhead", "lightscreen", "psychic", "reflect", "stealthrock", "toxic"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["earthquake", "ironhead", "protect", "psychic", "toxic"]
             }
         ]
     },
@@ -3201,7 +3217,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dracometeor", "earthquake", "fireblast", "stealthrock", "stoneedge", "toxic"]
+                "movepool": ["dracometeor", "earthquake", "fireblast", "stealthrock", "stoneedge"]
             },
             {
                 "role": "Setup Sweeper",
@@ -3274,11 +3290,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["defog", "knockoff", "powerwhip", "sleeppowder", "synthesis", "toxic"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["knockoff", "powerwhip", "return", "sleeppowder", "swordsdance"],
-                "preferredTypes": ["Dark"]
             }
         ]
     },
@@ -3337,7 +3348,8 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["bodyslam", "dragontail", "earthquake", "explosion", "knockoff", "powerwhip"]
+                "movepool": ["bodyslam", "dragontail", "earthquake", "explosion", "knockoff", "powerwhip"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Setup",
@@ -3368,7 +3380,7 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["earthquake", "knockoff", "leafstorm", "powerwhip", "rockslide", "sludgebomb"]
+                "movepool": ["earthquake", "gigadrain", "knockoff", "powerwhip", "rockslide", "sludgebomb"]
             }
         ]
     },
@@ -3525,7 +3537,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "icepunch", "painsplit", "shadowsneak", "substitute", "willowisp"]
+                "movepool": ["earthquake", "haze", "icepunch", "painsplit", "shadowsneak", "willowisp"]
             }
         ]
     },
@@ -3637,7 +3649,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "fireblast", "flashcannon", "roar", "stealthrock", "thunderbolt", "toxic"]
+                "movepool": ["dracometeor", "dragontail", "fireblast", "flashcannon", "stealthrock", "thunderbolt", "toxic"]
             }
         ]
     },
@@ -3945,8 +3957,12 @@
         "level": 72,
         "sets": [
             {
+                "role": "Bulky Setup",
+                "movepool": ["calmmind", "earthpower", "fireblast", "judgment", "recover"]
+            },
+            {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "fireblast", "icebeam", "judgment", "recover", "toxic", "willowisp"]
+                "movepool": ["defog", "earthquake", "fireblast", "judgment", "recover", "toxic", "willowisp"]
             }
         ]
     },

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -750,7 +750,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["drainpunch", "doubleedge", "earthquake", "fakeout", "return", "suckerpunch"]
+                "movepool": ["doubleedge", "drainpunch", "earthquake", "fakeout", "return", "suckerpunch"]
             },
             {
                 "role": "AV Pivot",

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -798,7 +798,8 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		case 'Solar Power':
 			return (!counter.get('Special') || !teamDetails.sun || !!species.isMega);
 		case 'Sturdy':
-			return (!!counter.get('recoil') && !counter.get('recovery') || species.id === 'steelix');
+			return (!!counter.get('recoil') && !counter.get('recovery') ||
+				(species.id === 'steelix' && role === 'Wallbreaker'));
 		case 'Swarm':
 			return (!counter.get('Bug') || !!species.isMega);
 		case 'Technician':

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -118,7 +118,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			Fighting: (movePool, moves, abilities, types, counter) => !counter.get('Fighting'),
 			Fire: (movePool, moves, abilities, types, counter) => !counter.get('Fire'),
 			Flying: (movePool, moves, abilities, types, counter, species) => (
-				!counter.get('Flying') && ['aerodactylmega', 'charizardmegay', 'mantine'].every(m => species.id !== m) &&
+				!counter.get('Flying') && !['aerodactylmega', 'charizardmegay', 'mantine'].includes(species.id) &&
 				!movePool.includes('hiddenpowerflying')
 			),
 			Ghost: (movePool, moves, abilities, types, counter) => !counter.get('Ghost'),
@@ -361,6 +361,8 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			['copycat', 'uturn'],
 			// Spinda and Seviper
 			[['feintattack', 'switcheroo'], 'suckerpunch'],
+			// Jirachi
+			['bodyslam', 'healingwish'],
 		];
 
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
@@ -779,7 +781,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		case 'Scrappy':
 			return !types.has('Normal');
 		case 'Serene Grace':
-			return (!counter.get('serenegrace') || species.name === 'Blissey');
+			return !counter.get('serenegrace');
 		case 'Sheer Force':
 			return (
 				!counter.get('sheerforce') ||
@@ -855,6 +857,9 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (species.baseSpecies === 'Altaria') return 'Natural Cure';
 		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it
 		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';
+		if (
+			['dusknoir', 'raikou', 'suicune', 'vespiquen', 'wailord'].includes(species.id)
+		) return 'Pressure';
 		if (species.id === 'tsareena') return 'Queenly Majesty';
 		if (species.id === 'druddigon' && role === 'Bulky Support') return 'Rough Skin';
 		if (species.id === 'kommoo' && role === 'Z-Move user') return 'Soundproof';
@@ -866,9 +871,6 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (abilities.has('Gluttony') && (moves.has('recycle') || moves.has('bellydrum'))) return 'Gluttony';
 		if (abilities.has('Harvest') && (role === 'Bulky Support' || role === 'Staller')) return 'Harvest';
 		if (abilities.has('Moxie') && (counter.get('Physical') > 3 || moves.has('bounce'))) return 'Moxie';
-		if (
-			['dusknoir', 'raikou', 'suicune', 'vespiquen', 'wailord'].includes(species.id)
-		) return 'Pressure';
 		if (abilities.has('Regenerator') && role === 'AV Pivot') return 'Regenerator';
 		if (abilities.has('Shed Skin') && moves.has('rest') && !moves.has('sleeptalk')) return 'Shed Skin';
 		if (abilities.has('Sniper') && moves.has('focusenergy')) return 'Sniper';
@@ -1060,7 +1062,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			(ability === 'Rough Skin') || (species.id !== 'hooh' &&
 			ability === 'Regenerator' && species.baseStats.hp + species.baseStats.def >= 180 && this.randomChance(1, 2))
 		) return 'Rocky Helmet';
-		if (['protect', 'spikyshield', 'substitute'].some(m => moves.has(m))) return 'Leftovers';
+		if (['kingsshield', 'protect', 'spikyshield', 'substitute'].some(m => moves.has(m))) return 'Leftovers';
 		if (
 			this.dex.getEffectiveness('Ground', species) >= 2 &&
 			ability !== 'Levitate' && species.id !== 'golemalola'

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -367,10 +367,6 @@ export class RandomGen7Teams extends RandomGen8Teams {
 
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
 
-		if (!types.includes('Normal')) {
-			this.incompatibleMoves(moves, movePool, SETUP, 'explosion');
-		}
-
 		if (!types.includes('Dark') && preferredType !== 'Dark') {
 			this.incompatibleMoves(moves, movePool, 'knockoff', ['pursuit', 'suckerpunch']);
 		}

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -368,7 +368,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
 
 		if (!types.includes('Normal')) {
-			this.incompatibleMoves(moves, movePool, SETUP, 'Explosion');
+			this.incompatibleMoves(moves, movePool, SETUP, 'explosion');
 		}
 
 		if (!types.includes('Dark') && preferredType !== 'Dark') {


### PR DESCRIPTION
All instances of "PT" refer to the "preferred type" system; a Pokemon with a preferred type will always generate with a move of that type. It will be referred to by the aforementioned "PT" shorthand in the rest of this pull request.

These changes are largely to align Gen 7's set optimization with that of the newly-revamped Gen 6 Random Battle when reasonable. After this update, the only differences between generations 6 and 7 of Random Battle will involve actual generational mechanic, movepool, and stat changes.

**Role additions/changes/removals:**
-Steelix now has three sets: 
--Wallbreaker, which is the Sheer Force Life Orb set unchanged
--Staller, which is Sturdy Leftovers with Earthquake, Heavy Slam, Toxic, and Protect
--Bulky Support, which is Sturdy Leftovers with Earthquake and any 3 of Heavy Slam/Toxic/Roar/Stealth Rock

-Arceus-Psychic has a set split: 
--Bulky Setup with CM + Recover + Judgment + Fire Blast/Earth Power
--Bulky Attacker with Recover + Judgment + Earthquake/Fire Blast + Willowisp/Toxic/Defog/the other of Earthquake/Fire Blast

-Bronzong has a set split: 
--Bulky Support, unchanged
-- Staller, with Toxic + Protect + any 2 of Iron Head/Psychic/Earthquake

-Aerodactyl has a set split:
--Bulky Attacker with Stone Edge + Earthquake + Roost + Defog/Taunt/Toxic/Stealth Rock and Leftovers
--Fast Support with Stone Edge + Earthquake + (almost) any 2 of Defog/Doubleedge/Pursuit/Stealth Rock/Roost, with Leftovers/Focus Sash/Life Orb/Choice Band depending on moves and team position

-Rapidash has a set split:
--Bulky Attacker with Flare Blitz + Morning Sun + any 2 of High Horsepower/Wild Charge/Will-O-Wisp and a Leftovers (new)
--Wallbreaker with Flare Blitz + any 3 of Morning Sun/High Horsepower/Wild Charge/Megahorn, with Life Orb or a Choice Band (new)

-Infernape: Setup Sweeper changed to Z-Move user (Fightinium Z)
-Farfetch'd: Fast Attacker changed to Setup Sweeper (forces Swords Dance) (DONE IN BOTH GENS 6 AND 7)
-Magcargo's Bulky Support changed to Staller (forces Toxic)
-Feraligatr's Wallbreaker changed to Bulky Setup (forces Aqua Jet and Swords Dance)
-Bulky Attacker (SubPunch) Mega Mawile has been removed.
-Setup Sweeper Carnivine has been removed.


**Item changes:**
-King's Shield Aegislash will now generate Leftovers instead of Life Orb.
-Jirachi: +Healing Wish; Healing Wish cannot generate with Body Slam; Choice Scarf Jirachi now exists.
-Dialga: -Roar, +Dragon Tail; Dialga can now run Assault Vest
-Primeape: +Hone Claws; Primeape can now run Life Orb

**Move changes:**
-Dusknoir: -Substitute, +Haze
-Staller Empoleon: +Defog
-Bulky Attacker Rampardos (the Mold Breaker one): +Superpower
-Fast Attacker Sceptile: +Rock Slide
-Bulky Support Mega Garchomp: -Toxic
-Hitmontop: +Earthquake
-Bulky Setup Suicune: -Hidden Power Grass; -PT Ice (no longer necessary in order to force Ice Beam)
-Dragon Dance Tyranitar and Mega Tyranitar: +Fire Punch
-Bulky Support Lunatone: -Ice Beam, +Moonblast
-AV Pivot Tangrowth: -Leaf Storm, +Giga Drain
-Bulky Attacker and Wallbreaker Machamp: +Bulk Up, +PT Dark
-Muk: -Explosion
-Bulky Attacker Venusaur: -Giga Drain, +Earthquake, +Energy Ball
-Bulky Support Kangaskhan: +Double-Edge
-Bulky Setup Chimecho: -Shadow Ball
-Z-Move user Venomoth: -Substitute, +Roost

**Preferred Type changes:**
-AV Pivot Lickilicky: +PT Ground
-Flareon: -PT Fighting (not necessary in order to force Superpower)


**Technical changes:**
-remove unnecessary blissey rejection for serene grace
-remove unnecessary hardcode for explosion now that muk doesn't have it (DONE IN BOTH GENS 6 AND 7)
-move pressure enforcement to species-specific section of ability enforcement code
-flying STAB enforcement's species list changed from .every to .includes