### PR TITLE
Gen 8 BSS Factory: Ignore Force Monotype

### DIFF
--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -3069,7 +3069,7 @@ export class RandomGen8Teams {
 
 			const species = this.dex.species.get(specie);
 			if (!species.exists) continue;
-			if (this.forceMonotype && !species.types.includes(this.forceMonotype)) continue;
+			// if (this.forceMonotype && !species.types.includes(this.forceMonotype)) continue;
 
 			// Limit to one of each species (Species Clause)
 			if (teamData.baseFormes[species.baseSpecies]) continue;


### PR DESCRIPTION
same behavior as Gen 8 Factory. trying to support it just causes an infinite loop. if someone wants to salvage this in the future please rewrite it to not be infinite