### PR TITLE
Gen 8 BSS Factory: Implement proper sampling

### DIFF
--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -3045,30 +3045,25 @@ export class RandomGen8Teams {
 			levitate: ['Ground'],
 		};
 
-		while (pokemonPool.length && pokemon.length < this.maxTeamSize) {
-			// Weighted random sampling
-			let maxUsage = 0;
-			const sets: {[k: string]: number} = {};
-			for (const specie of pokemonPool) {
-				if (teamData.baseFormes[this.dex.species.get(specie).baseSpecies]) continue; // Species Clause
-				const usage: number = this.randomBSSFactorySets[specie].usage;
-				sets[specie] = usage + maxUsage;
-				maxUsage += usage;
-			}
+		/**
+		 * Weighted random shuffle
+		 * Uses the fact that for two uniform variables x1 and x2, x1^(1/w1) is larger than x2^(1/w2)
+		 * with probability equal to w1/(w1+w2), which is what we want. See e.g. here https://arxiv.org/pdf/1012.0256.pdf,
+		 * original paper is behind a paywall.
+		 */
+		let shuffledSpecies = [];
+		for (const speciesName of pokemonPool) {
+			let sortObject = {speciesName: speciesName, score: Math.pow(this.prng.next(),1/this.randomBSSFactorySets[speciesName].usage)};
+			shuffledSpecies.push(sortObject);
+		}
+		shuffledSpecies.sort((a,b)=>a.score-b.score);
 
-			const usage = this.random(1, maxUsage);
-			let last = 0;
-			let specie;
-			for (const key of Object.keys(sets)) {
-				 if (usage > last && usage <= sets[key]) {
-					 specie = key;
-					 break;
-				 }
-				 last = sets[key];
-			}
-
+		while (shuffledSpecies.length && pokemon.length < this.maxTeamSize) {
+			// repeated popping from weighted shuffle is equivalent to repeated weighted sampling without replacement
+			let specie = shuffledSpecies.pop()!.speciesName
 			const species = this.dex.species.get(specie);
 			if (!species.exists) continue;
+
 			if (this.forceMonotype && !species.types.includes(this.forceMonotype)) continue;
 
 			// Limit to one of each species (Species Clause)
@@ -3151,7 +3146,7 @@ export class RandomGen8Teams {
 				}
 			}
 		}
-		if (pokemon.length < this.maxTeamSize) return this.randomBSSFactoryTeam(side, ++depth);
+		if (!teamData.forceResult && pokemon.length < this.maxTeamSize) return this.randomBSSFactoryTeam(side, ++depth);
 
 		// Quality control
 		if (!teamData.forceResult) {

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -3029,8 +3029,6 @@ export class RandomGen8Teams {
 			typeCount: {}, typeComboCount: {}, baseFormes: {}, has: {}, forceResult: forceResult,
 			weaknesses: {}, resistances: {},
 		};
-		const requiredMoveFamilies: string[] = [];
-		const requiredMoves: {[k: string]: string} = {};
 		const weatherAbilitiesSet: {[k: string]: string} = {
 			drizzle: 'raindance',
 			drought: 'sunnyday',
@@ -3123,9 +3121,6 @@ export class RandomGen8Teams {
 				} else {
 					teamData.has[moveId] = 1;
 				}
-				if (moveId in requiredMoves) {
-					teamData.has[requiredMoves[moveId]] = 1;
-				}
 			}
 
 			for (const typeName of this.dex.types.names()) {
@@ -3150,9 +3145,6 @@ export class RandomGen8Teams {
 
 		// Quality control we cannot afford for non-monotype
 		if (!teamData.forceResult && !this.forceMonotype) {
-			for (const requiredFamily of requiredMoveFamilies) {
-				if (!teamData.has[requiredFamily]) return this.randomBSSFactoryTeam(side, ++depth);
-			}
 			for (const type in teamData.weaknesses) {
 				if (teamData.weaknesses[type] >= 3) return this.randomBSSFactoryTeam(side, ++depth);
 			}

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -3049,16 +3049,19 @@ export class RandomGen8Teams {
 		 * with probability equal to w1/(w1+w2), which is what we want. See e.g. here https://arxiv.org/pdf/1012.0256.pdf,
 		 * original paper is behind a paywall.
 		 */
-		let shuffledSpecies = [];
+		const shuffledSpecies = [];
 		for (const speciesName of pokemonPool) {
-			let sortObject = {speciesName: speciesName, score: Math.pow(this.prng.next(),1/this.randomBSSFactorySets[speciesName].usage)};
+			const sortObject = {
+				speciesName: speciesName,
+				score: Math.pow(this.prng.next(), 1 / this.randomBSSFactorySets[speciesName].usage),
+			};
 			shuffledSpecies.push(sortObject);
 		}
-		shuffledSpecies.sort((a,b)=>a.score-b.score);
+		shuffledSpecies.sort((a, b) => a.score - b.score);
 
 		while (shuffledSpecies.length && pokemon.length < this.maxTeamSize) {
 			// repeated popping from weighted shuffle is equivalent to repeated weighted sampling without replacement
-			let specie = shuffledSpecies.pop()!.speciesName
+			const specie = shuffledSpecies.pop()!.speciesName;
 			const species = this.dex.species.get(specie);
 			if (!species.exists) continue;
 

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -3148,8 +3148,8 @@ export class RandomGen8Teams {
 		}
 		if (!teamData.forceResult && pokemon.length < this.maxTeamSize) return this.randomBSSFactoryTeam(side, ++depth);
 
-		// Quality control
-		if (!teamData.forceResult) {
+		// Quality control we cannot afford for non-monotype
+		if (!teamData.forceResult && !this.forceMonotype) {
 			for (const requiredFamily of requiredMoveFamilies) {
 				if (!teamData.has[requiredFamily]) return this.randomBSSFactoryTeam(side, ++depth);
 			}

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -3146,7 +3146,7 @@ export class RandomGen8Teams {
 		}
 		if (!teamData.forceResult && pokemon.length < this.maxTeamSize) return this.randomBSSFactoryTeam(side, ++depth);
 
-		// Quality control we cannot afford for non-monotype
+		// Quality control we cannot afford for monotype
 		if (!teamData.forceResult && !this.forceMonotype) {
 			for (const type in teamData.weaknesses) {
 				if (teamData.weaknesses[type] >= 3) return this.randomBSSFactoryTeam(side, ++depth);


### PR DESCRIPTION
Implements proper weighted sampling to prevent infinite loops. Now, forcing a monotype rock team will instead of crashing provide a team, albeit possibly with fewer than 6 mons.

Removes weakness constraints on team generation under monotype rules as they are essentially impossible, forcing generation to always go to the maximum depth.

Finally, removes some unused code relating to required moves (which was an empty list of moves).