### PR TITLE
Fix Poison Touch's interaction with Pledge Rainbow

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -3014,17 +3014,15 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 38,
 	},
 	poisontouch: {
-		// upokecenter says this is implemented as an added secondary effect
-		onModifyMove(move) {
-			if (!move?.flags['contact'] || move.target === 'self') return;
-			if (!move.secondaries) {
-				move.secondaries = [];
+		onSourceDamagingHit(damage, target, source, move) {
+			// Despite not being a secondary, Shield Dust / Covert Cloak block Poison Touch's effect
+			if (target.hasAbility('shielddust') || target.hasItem('covertcloak')) return;
+
+			if (this.checkMoveMakesContact(move, target, source)) {
+				if (this.randomChance(3, 10)) {
+					target.trySetStatus('psn', source);
+				}
 			}
-			move.secondaries.push({
-				chance: 30,
-				status: 'psn',
-				ability: this.dex.abilities.get('poisontouch'),
-			});
 		},
 		name: "Poison Touch",
 		rating: 2,

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -3017,7 +3017,6 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		onSourceDamagingHit(damage, target, source, move) {
 			// Despite not being a secondary, Shield Dust / Covert Cloak block Poison Touch's effect
 			if (target.hasAbility('shielddust') || target.hasItem('covertcloak')) return;
-
 			if (this.checkMoveMakesContact(move, target, source)) {
 				if (this.randomChance(3, 10)) {
 					target.trySetStatus('psn', source);

--- a/data/mods/gen7pokebilities/abilities.ts
+++ b/data/mods/gen7pokebilities/abilities.ts
@@ -35,12 +35,6 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			}
 		},
 	},
-	poisontouch: {
-		inherit: true,
-		// Activate after Sheer Force to make interaction determistic. The ordering for this ability is
-		// an arbitary decision, but is modelled on Stench, which is reflective of on-cart behaviour.
-		onModifyMovePriority: -1,
-	},
 	powerofalchemy: {
 		inherit: true,
 		onAllyFaint(ally) {

--- a/data/mods/pokebilities/abilities.ts
+++ b/data/mods/pokebilities/abilities.ts
@@ -92,12 +92,6 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			}
 		},
 	},
-	poisontouch: {
-		inherit: true,
-		// Activate after Sheer Force to make interaction determistic. The ordering for this ability is
-		// an arbitary decision, but is modelled on Stench, which is reflective of on-cart behaviour.
-		onModifyMovePriority: -1,
-	},
 	powerofalchemy: {
 		inherit: true,
 		onAllyFaint(ally) {

--- a/test/sim/abilities/poisontouch.js
+++ b/test/sim/abilities/poisontouch.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe(`Poison Touch`, function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it(`should poison targets if the user damages the target with a contact move`, function () {
+		battle = common.createBattle({forceRandomChance: true}, [[
+			{species: 'Wynaut', ability: 'poisontouch', moves: ['falseswipe']},
+		], [
+			{species: 'Shuckle', moves: ['falseswipe']},
+		]]);
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].status, '', `Wynaut should not be poisoned`);
+		assert.equal(battle.p2.active[0].status, 'psn', `Shuckle should be poisoned`);
+	});
+
+	it(`should not poison targets behind a Substitute or holding Covert Cloak`, function () {
+		battle = common.createBattle({forceRandomChance: true}, [[
+			{species: 'Wynaut', ability: 'poisontouch', moves: ['falseswipe']},
+		], [
+			{species: 'Shuckle', ability: 'prankster', moves: ['substitute']},
+			{species: 'Regirock', item: 'covertcloak', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		assert.equal(battle.p2.active[0].status, '', `Shuckle should not be poisoned`);
+
+		battle.makeChoices('auto', 'switch 2');
+		assert.equal(battle.p2.active[0].status, '', `Regirock should not be poisoned`);
+	});
+
+	it(`should poison independently of and after regular secondary status effects`, function () {
+		battle = common.createBattle({forceRandomChance: true}, [[
+			{species: 'Wynaut', ability: 'poisontouch', moves: ['nuzzle']},
+		], [
+			{species: 'Shuckle', item: 'lumberry', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		const shuckle = battle.p2.active[0];
+		assert.equal(shuckle.status, 'psn');
+		assert.false.holdsItem(shuckle);
+	});
+
+	it(`should poison before Mummy takes over the user's Ability`, function () {
+		battle = common.createBattle({forceRandomChance: true}, [[
+			{species: 'Wynaut', ability: 'poisontouch', moves: ['falseswipe']},
+		], [
+			{species: 'Shuckle', ability: 'mummy', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].ability, 'mummy');
+		assert.equal(battle.p2.active[0].status, 'psn');
+	});
+
+	it(`should not poison itself with contact moves that aren't hitting other Pokemon`, function () {
+		battle = common.createBattle({forceRandomChance: true}, [[
+			{species: 'Wynaut', ability: 'poisontouch', moves: ['bide']},
+		], [
+			{species: 'Shuckle', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices();
+		battle.makeChoices();
+		battle.makeChoices();
+		battle.makeChoices();
+		assert.equal(battle.p1.active[0].status, '');
+	});
+
+	it(`should not have a 60% chance to poison if Pledge Rainbow is active`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'wynaut', ability: 'poisontouch', moves: ['falseswipe', 'waterpledge']},
+			{species: 'wobbuffet', moves: ['sleeptalk', 'firepledge']},
+		], [
+			{species: 'pyukumuku', moves: ['sleeptalk']},
+			{species: 'feebas', moves: ['sleeptalk']},
+		]]);
+
+		battle.onEvent('ModifyMove', battle.format, -99, function (move) {
+			if (move.id === 'falseswipe') {
+				// If False Swipe had a psn secondary, it would have a 60% chance to activate
+				assert.equal(move.secondaries, null);
+			}
+		});
+
+		battle.makeChoices('move waterpledge 1, move firepledge 1', 'auto');
+		battle.makeChoices('move falseswipe 1, move sleeptalk', 'auto');
+	});
+});


### PR DESCRIPTION
Previously, Poison Touch was being treated as adding a secondary effect; it does not actually do that. If the target has Substitute or is protected by Covert Cloak / Shield Dust, it won't trigger which is similar, but it is not doubled by Pledge Rainbow.

This changes behavior in some mods that allowed multiple Abilities (?), but if you had both Sheer Force and Poison Touch somehow, Poison Touch would still activate.