### PR TITLE
Gen 2-4 and Gen 8 Random Battles updates

### DIFF
--- a/data/mods/gen2/random-data.json
+++ b/data/mods/gen2/random-data.json
@@ -15,7 +15,7 @@
         "moves": ["agility", "hiddenpowerground", "sludgebomb", "substitute", "swordsdance"]
     },
     "pidgeot": {
-        "moves": ["curse", "hiddenpowerground", "reflect", "rest", "return", "sleeptalk", "toxic", "whirlwind"]
+        "moves": ["curse", "hiddenpowerground", "rest", "return", "sleeptalk", "toxic", "whirlwind"]
     },
     "raticate": {
         "moves": ["irontail", "rest", "return", "sleeptalk", "superfang"]
@@ -126,7 +126,7 @@
         "moves": ["hiddenpowerground", "rest", "return", "surf", "swordsdance"]
     },
     "electrode": {
-        "moves": ["explosion", "hiddenpowerice", "lightscreen", "reflect", "thunderbolt", "thunderwave"]
+        "moves": ["explosion", "hiddenpowerice", "thunderbolt", "thunderwave"]
     },
     "exeggutor": {
         "moves": ["explosion", "gigadrain", "hiddenpowerfire", "psychic", "sleeppowder", "stunspore", "synthesis"]
@@ -193,7 +193,7 @@
         "moves": ["transform"]
     },
     "vaporeon": {
-        "moves": ["growth", "hiddenpowerelectric", "icebeam", "rest", "sleeptalk", "surf"]
+        "moves": ["growth", "rest", "sleeptalk", "surf"]
     },
     "jolteon": {
         "moves": ["batonpass", "growth", "hiddenpowerice", "substitute", "thunderbolt", "thunderwave"]
@@ -223,7 +223,7 @@
         "moves": ["fireblast", "hiddenpowergrass", "rest", "sleeptalk", "sunnyday"]
     },
     "dragonite": {
-        "moves": ["haze", "hiddenpowerflying", "icebeam", "lightscreen", "reflect", "rest", "thunder"]
+        "moves": ["haze", "hiddenpowerflying", "rest", "surf", "thunder"]
     },
     "mewtwo": {
         "moves": ["fireblast", "icebeam", "psychic", "recover", "thunderbolt", "thunderwave"]
@@ -232,7 +232,7 @@
         "moves": ["earthquake", "explosion", "rockslide", "softboiled", "swordsdance"]
     },
     "meganium": {
-        "moves": ["hiddenpowerfire", "leechseed", "lightscreen", "razorleaf", "reflect", "synthesis"]
+        "moves": ["bodyslam", "earthquake", "swordsdance", "synthesis"]
     },
     "typhlosion": {
         "moves": ["earthquake", "fireblast", "rest", "sleeptalk", "thunderpunch"]
@@ -244,7 +244,7 @@
         "moves": ["curse", "doubleedge", "rest", "shadowball", "sleeptalk", "surf"]
     },
     "noctowl": {
-        "moves": ["hypnosis", "nightshade", "reflect", "thief", "toxic", "whirlwind"]
+        "moves": ["hypnosis", "nightshade", "thief", "toxic", "whirlwind"]
     },
     "ledian": {
         "moves": ["agility", "barrier", "batonpass", "lightscreen"]
@@ -253,7 +253,7 @@
         "moves": ["batonpass", "curse", "sludgebomb", "spiderweb"]
     },
     "crobat": {
-        "moves": ["gigadrain", "haze", "hiddenpowerground", "rest", "whirlwind", "wingattack"]
+        "moves": ["gigadrain", "haze", "hiddenpowerground", "rest", "toxic", "wingattack"]
     },
     "lanturn": {
         "moves": ["icebeam", "raindance", "rest", "sleeptalk", "surf", "thunder"]
@@ -265,7 +265,7 @@
         "moves": ["drillpeck", "haze", "psychic", "rest", "sleeptalk", "thief"]
     },
     "ampharos": {
-        "moves": ["firepunch", "hiddenpowerice", "lightscreen", "reflect", "rest", "sleeptalk", "thunderbolt", "thunderwave"]
+        "moves": ["firepunch", "hiddenpowerice", "rest", "sleeptalk", "thunderbolt", "thunderwave"]
     },
     "bellossom": {
         "moves": ["hiddenpowerfire", "leechseed", "moonlight", "razorleaf", "sleeppowder", "stunspore"]
@@ -277,7 +277,7 @@
         "moves": ["curse", "earthquake", "rest", "rockslide", "selfdestruct", "sleeptalk"]
     },
     "politoed": {
-        "moves": ["growth", "hiddenpowerelectric", "icebeam", "lovelykiss", "rest", "sleeptalk", "surf"]
+        "moves": ["growth", "rest", "sleeptalk", "surf"]
     },
     "jumpluff": {
         "moves": ["encore", "gigadrain", "hiddenpowerflying", "leechseed", "sleeppowder", "stunspore"]
@@ -321,7 +321,7 @@
         "moves": ["crunch", "curse", "earthquake", "psychic", "rest", "return", "thunderbolt"]
     },
     "forretress": {
-        "moves": ["doubleedge", "explosion", "hiddenpowerbug", "rapidspin", "reflect", "spikes", "toxic"]
+        "moves": ["doubleedge", "explosion", "hiddenpowerbug", "rapidspin", "spikes", "toxic"]
     },
     "dunsparce": {
         "moves": ["curse", "flamethrower", "rest", "return", "sleeptalk", "thunder", "thunderbolt"]
@@ -402,7 +402,7 @@
         "moves": ["flamethrower", "healbell", "icebeam", "present", "sing", "softboiled", "toxic"]
     },
     "raikou": {
-        "moves": ["crunch", "hiddenpowerice", "reflect", "rest", "roar", "sleeptalk", "thunder", "thunderbolt"]
+        "moves": ["crunch", "hiddenpowerice", "rest", "roar", "sleeptalk", "thunder", "thunderbolt"]
     },
     "entei": {
         "moves": ["fireblast", "hiddenpowerrock", "return", "solarbeam", "sunnyday"]

--- a/data/mods/gen2/random-teams.ts
+++ b/data/mods/gen2/random-teams.ts
@@ -14,7 +14,9 @@ export class RandomGen2Teams extends RandomGen3Teams {
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
 			Ice: (movePool, moves, abilities, types, counter) => !counter.get('Ice'),
 			Normal: (movePool, moves, abilities, types, counter) => !counter.get('Normal') && counter.setupType === 'Physical',
-			Psychic: (movePool, moves, abilities, types, counter) => !counter.get('Psychic') && types.has('Grass'),
+			Psychic: (movePool, moves, abilities, types, counter) => (
+				!counter.get('Psychic') && (types.has('Grass') || types.has('Ice'))
+			),
 			Rock: (movePool, moves, abilities, types, counter, species) => !counter.get('Rock') && species.baseStats.atk > 60,
 			Water: (movePool, moves, abilities, types, counter) => !counter.get('Water'),
 		};
@@ -58,8 +60,6 @@ export class RandomGen2Teams extends RandomGen3Teams {
 			return {cull: !!counter.setupType};
 		case 'haze':
 			return {cull: !!counter.setupType || restTalk};
-		case 'reflect': case 'lightscreen':
-			return {cull: !!counter.setupType || moves.has('rest')};
 
 		// Ineffective to have both
 		case 'doubleedge':

--- a/data/mods/gen3/random-data.json
+++ b/data/mods/gen3/random-data.json
@@ -245,7 +245,7 @@
     },
     "gyarados": {
         "level": 76,
-        "moves": ["doubleedge", "dragondance", "earthquake", "hiddenpowerflying", "hydropump", "taunt"]
+        "moves": ["doubleedge", "dragondance", "earthquake", "hiddenpowerflying", "hydropump"]
     },
     "lapras": {
         "level": 81,
@@ -325,7 +325,7 @@
     },
     "noctowl": {
         "level": 91,
-        "moves": ["hypnosis", "psychic", "reflect", "toxic", "whirlwind"]
+        "moves": ["hiddenpowerfire", "hypnosis", "psychic", "reflect", "toxic", "whirlwind"]
     },
     "ledian": {
         "level": 94,
@@ -401,7 +401,7 @@
     },
     "murkrow": {
         "level": 90,
-        "moves": ["doubleedge", "drillpeck", "hiddenpowerfighting", "hiddenpowerground", "meanlook", "perishsong", "protect", "shadowball", "substitute"]
+        "moves": ["doubleedge", "drillpeck", "hiddenpowerfighting", "hiddenpowerground", "shadowball", "substitute"]
     },
     "slowking": {
         "level": 84,
@@ -585,7 +585,7 @@
     },
     "dustox": {
         "level": 93,
-        "moves": ["hiddenpowerground", "lightscreen", "moonlight", "sludgebomb", "toxic", "whirlwind"]
+        "moves": ["hiddenpowerground", "moonlight", "sludgebomb", "toxic", "whirlwind"]
     },
     "ludicolo": {
         "level": 82,
@@ -625,7 +625,7 @@
     },
     "ninjask": {
         "level": 84,
-        "moves": ["aerialace", "batonpass", "hiddenpowerrock", "protect", "silverwind", "substitute", "swordsdance"]
+        "moves": ["aerialace", "batonpass", "protect", "silverwind", "substitute", "swordsdance"]
     },
     "shedinja": {
         "level": 91,
@@ -733,7 +733,7 @@
     },
     "seviper": {
         "level": 89,
-        "moves": ["crunch", "doubleedge", "earthquake", "flamethrower", "hiddenpowergrass", "sludgebomb"]
+        "moves": ["crunch", "earthquake", "flamethrower", "hiddenpowergrass", "sludgebomb"]
     },
     "lunatone": {
         "level": 84,
@@ -769,7 +769,7 @@
     },
     "castform": {
         "level": 91,
-        "moves": ["flamethrower", "icebeam", "substitute", "thunderbolt", "thunderwave"]
+        "moves": ["flamethrower", "icebeam", "return", "substitute", "thunderbolt", "thunderwave"]
     },
     "kecleon": {
         "level": 90,
@@ -857,7 +857,7 @@
     },
     "rayquaza": {
         "level": 72,
-        "moves": ["dragondance", "earthquake", "extremespeed", "hiddenpowerflying", "overheat", "rockslide"]
+        "moves": ["dragondance", "earthquake", "extremespeed", "hiddenpowerflying", "rockslide"]
     },
     "jirachi": {
         "level": 75,

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -68,7 +68,8 @@ export class RandomGen3Teams extends RandomGen4Teams {
 				cull: (
 					counter.setupType !== 'Special' ||
 					(counter.get('Special') + counter.get('specialpool') < 2 && !moves.has('batonpass') &&
-					!moves.has('refresh') && !restTalk)
+					!moves.has('refresh') && !restTalk) ||
+					!counter.get('Special')
 				),
 				isSetup: true,
 			};

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -458,7 +458,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 				const requiresStab = (
 					!counter.get('stab') &&
 					!moves.has('seismictoss') && !moves.has('nightshade') &&
-					species.id !== 'castform' && species.id !== 'umbreon' &&
+					species.id !== 'umbreon' &&
 					// If a Flying-type has Psychic, it doesn't need STAB
 					!(moves.has('psychic') && types.has('Flying')) &&
 					!(types.has('Ghost') && species.baseStats.spa > species.baseStats.atk) &&

--- a/data/mods/gen4/random-data.json
+++ b/data/mods/gen4/random-data.json
@@ -13,7 +13,7 @@
     },
     "butterfree": {
         "level": 93,
-        "moves": ["bugbuzz", "safeguard", "sleeppowder", "stunspore", "uturn"]
+        "moves": ["bugbuzz", "sleeppowder", "stunspore", "uturn"]
     },
     "beedrill": {
         "level": 96,
@@ -21,7 +21,7 @@
     },
     "pidgeot": {
         "level": 88,
-        "moves": ["bravebird", "doubleedge", "heatwave", "pursuit", "quickattack", "uturn"]
+        "moves": ["bravebird", "doubleedge", "heatwave", "pursuit", "quickattack", "return", "roost", "uturn"]
     },
     "raticate": {
         "level": 86,
@@ -69,7 +69,7 @@
     },
     "vileplume": {
         "level": 88,
-        "moves": ["energyball", "hiddenpowerfire", "moonlight", "sleeppowder", "sludgebomb", "solarbeam", "sunnyday"]
+        "moves": ["energyball", "hiddenpowerfire", "moonlight", "sleeppowder", "sludgebomb"]
     },
     "parasect": {
         "level": 95,
@@ -141,7 +141,7 @@
     },
     "dewgong": {
         "level": 90,
-        "moves": ["encore", "icebeam", "raindance", "rest", "surf", "toxic"]
+        "moves": ["encore", "icebeam", "rest", "sleeptalk", "surf", "toxic"]
     },
     "muk": {
         "level": 88,
@@ -169,7 +169,7 @@
     },
     "exeggutor": {
         "level": 87,
-        "moves": ["explosion", "hiddenpowerfire", "leafstorm", "psychic", "sleeppowder", "solarbeam", "sunnyday", "synthesis"]
+        "moves": ["explosion", "hiddenpowerfire", "leafstorm", "psychic", "sleeppowder", "synthesis"]
     },
     "marowak": {
         "level": 88,
@@ -329,7 +329,7 @@
     },
     "bellossom": {
         "level": 90,
-        "moves": ["hiddenpowerfire", "leafstorm", "moonlight", "sleeppowder", "sludgebomb", "solarbeam", "sunnyday"]
+        "moves": ["hiddenpowerfire", "leafstorm", "moonlight", "sleeppowder", "sludgebomb"]
     },
     "azumarill": {
         "level": 84,
@@ -389,7 +389,7 @@
     },
     "steelix": {
         "level": 84,
-        "moves": ["earthquake", "explosion", "gyroball", "roar", "stealthrock", "stoneedge", "toxic"]
+        "moves": ["earthquake", "explosion", "ironhead", "roar", "stealthrock", "stoneedge", "toxic"]
     },
     "granbull": {
         "level": 88,
@@ -581,7 +581,7 @@
     },
     "hariyama": {
         "level": 84,
-        "moves": ["bulletpunch", "closecombat", "facade", "fakeout", "focuspunch", "icepunch", "payback", "stoneedge", "substitute"]
+        "moves": ["bulletpunch", "closecombat", "facade", "fakeout", "icepunch", "payback", "stoneedge"]
     },
     "delcatty": {
         "level": 98,
@@ -849,7 +849,7 @@
     },
     "bastiodon": {
         "level": 91,
-        "moves": ["earthquake", "metalburst", "protect", "roar", "rockslide", "stealthrock", "toxic"]
+        "moves": ["metalburst", "protect", "roar", "rockslide", "stealthrock", "toxic"]
     },
     "wormadam": {
         "level": 97,
@@ -861,7 +861,7 @@
     },
     "wormadamtrash": {
         "level": 87,
-        "moves": ["gyroball", "protect", "stealthrock", "toxic"]
+        "moves": ["flashcannon", "protect", "stealthrock", "toxic"]
     },
     "mothim": {
         "level": 91,
@@ -873,7 +873,7 @@
     },
     "pachirisu": {
         "level": 96,
-        "moves": ["discharge", "lightscreen", "superfang", "toxic", "uturn"]
+        "moves": ["discharge", "superfang", "toxic", "uturn"]
     },
     "floatzel": {
         "level": 86,
@@ -921,7 +921,7 @@
     },
     "bronzong": {
         "level": 80,
-        "moves": ["earthquake", "explosion", "gyroball", "lightscreen", "payback", "reflect", "stealthrock", "toxic"]
+        "moves": ["earthquake", "explosion", "ironhead", "lightscreen", "payback", "reflect", "stealthrock", "toxic"]
     },
     "chatot": {
         "level": 91,
@@ -941,7 +941,7 @@
     },
     "hippowdon": {
         "level": 80,
-        "moves": ["earthquake", "icefang", "roar", "slackoff", "stealthrock", "stoneedge", "toxic"]
+        "moves": ["earthquake", "roar", "slackoff", "stealthrock", "stoneedge", "toxic"]
     },
     "drapion": {
         "level": 84,
@@ -949,7 +949,7 @@
     },
     "toxicroak": {
         "level": 84,
-        "moves": ["crosschop", "focuspunch", "icepunch", "substitute", "suckerpunch", "swordsdance"]
+        "moves": ["crosschop", "icepunch", "substitute", "suckerpunch", "swordsdance"]
     },
     "carnivine": {
         "level": 94,
@@ -1029,7 +1029,7 @@
     },
     "dusknoir": {
         "level": 84,
-        "moves": ["earthquake", "focuspunch", "icebeam", "painsplit", "shadowsneak", "substitute", "willowisp"]
+        "moves": ["earthquake", "focuspunch", "icepunch", "painsplit", "shadowsneak", "substitute", "willowisp"]
     },
     "froslass": {
         "level": 82,

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -43,7 +43,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			),
 			Ground: (movePool, moves, abilities, types, counter) => !counter.get('Ground'),
 			Ice: (movePool, moves, abilities, types, counter) => (
-				!counter.get('Ice') && (!types.has('Water') || !counter.get('Water'))
+				(!counter.get('Ice') && (!types.has('Water') || !counter.get('Water'))) || movePool.includes('blizzard')
 			),
 			Rock: (movePool, moves, abilities, types, counter) => (
 				!counter.get('Rock') && (movePool.includes('headsmash') || movePool.includes('stoneedge'))
@@ -83,7 +83,10 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		case 'eruption': case 'waterspout':
 			return {cull: counter.get('Physical') + counter.get('Special') < 4};
 		case 'focuspunch':
-			return {cull: !moves.has('substitute') || counter.damagingMoves.size < 2 || moves.has('hammerarm')};
+			return {cull: (
+				!moves.has('substitute') || counter.damagingMoves.size < 2 ||
+				moves.has('hammerarm') || moves.has('focusblast')
+			)};
 		case 'lightscreen':
 			if (movePool.length > 1) {
 				const screen = movePool.indexOf('reflect');

--- a/data/mods/gen8/abilities.ts
+++ b/data/mods/gen8/abilities.ts
@@ -579,7 +579,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	},
 	mirrorarmor: {
 		inherit: true,
-		rating: 2,
+		rating: 2.5,
 	},
 	mistysurge: {
 		inherit: true,

--- a/data/mods/gen8/random-data.json
+++ b/data/mods/gen8/random-data.json
@@ -292,7 +292,7 @@
     },
     "chansey": {
         "level": 84,
-        "moves": ["healbell", "seismictoss", "softboiled", "stealthrock", "toxic"]
+        "moves": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "toxic"]
     },
     "kangaskhan": {
         "level": 85,


### PR DESCRIPTION
Gen 2:
-Enforce Psychic on Jynx
-Noctowl -Reflect
-Forretress -Reflect
-Raikou -Reflect
-Pidgeot -Reflect
-Electrode -Light Screen, -Reflect
-Ampharos -Light Screen, -Reflect
-Dragonite -Ice Beam, -Reflect, -Light Screen, +Surf
-Vaporeon Surf / ResTalk / Growth
-Politoed Surf / ResTalk / Growth
-Crobat -Whirlwind, +Toxic
-Meganium Body Slam / Synthesis / Swords Dance / Earthquake

Gen 3:
-Castform: +return
-Fix Girafarig being able to generate without Psychic
-Dustox: -lightscreen
-Ninjask: -hiddenpowerrock
-Gyarados: -taunt
-Rayquaza: -overheat
-Seviper: -doubleedge
-Noctowl: +hiddenpowerfire
-Murkrow: -meanlook, -perishsong, -protect

Gen 4:
-Hippowdon: -icefang
-Dusknoir: -icebeam, +icepunch
-Bronzong and Steelix: -gyroball, +ironhead
-Wormadam-Trash: -gyroball, +flashcannon
-Prevent focus punch + focus blast on Raichu
-Toxicroak: -focuspunch
-Hariyama: -focuspunch, -substitute
-Enforce Blizzard on Abomasnow
-Pachirisu: -lightscreen
-Bastiodon: -earthquake
-Pidgeot: +roost, +return
-Butterfree: -safeguard
-Remove sunnybeam from Vileplume, Exeggutor, Bellossom

Gen 8:
-Chansey: -healbell, +aromatherapy
-Prevent Unnerve Corviknight, by increasing Mirror Armor's ability rating