### PR TITLE
Gen 9 Random Battle Teal Mask update

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -4042,7 +4042,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Blood Moon", "Calm Mind", "Earth Power", "Moonlight", "Yawn"],
+                "movepool": ["Blood Moon", "Calm Mind", "Earth Power", "Moonlight"],
                 "teraTypes": ["Ghost", "Normal", "Poison"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -5087,7 +5087,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Ivy Cudgel", "Superpower", "Swrods Dance", "Wood Hammer"],
+                "movepool": ["Ivy Cudgel", "Superpower", "Swords Dance", "Wood Hammer"],
                 "teraTypes": ["Rock"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -14,12 +14,22 @@
             }
         ]
     },
+    "arbok": {
+        "level": 90,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Earthquake", "Glare", "Gunk Shot", "Knock Off", "Sucker Punch", "Toxic Spikes"],
+                "teraTypes": ["Dark", "Ground"]
+            }
+        ]
+    },
     "pikachu": {
         "level": 93,
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Fake Out", "Play Rough", "Surf", "Volt Switch", "Volt Tackle"],
+                "movepool": ["Fake Out", "Knock Off", "Play Rough", "Surf", "Volt Switch", "Volt Tackle"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -41,6 +51,81 @@
                 "role": "Fast Attacker",
                 "movepool": ["Focus Blast", "Grass Knot", "Nasty Plot", "Psychic", "Psyshock", "Surf", "Thunderbolt", "Volt Switch"],
                 "teraTypes": ["Fighting", "Grass", "Water"]
+            }
+        ]
+    },
+    "sandslash": {
+        "level": 88,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Earthquake", "Knock Off", "Rapid Spin", "Spikes", "Stone Edge", "Swords Dance"],
+                "teraTypes": ["Dragon", "Steel", "Water"]
+            }
+        ]
+    },
+    "sandslashalola": {
+        "level": 88,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Earthquake", "Ice Spinner", "Rapid Spin", "Spikes", "Swords Dance"],
+                "teraTypes": ["Flying", "Water"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Earthquake", "Ice Shard", "Ice Spinner", "Knock Off", "Swords Dance"],
+                "teraTypes": ["Ground"]
+            }
+        ]
+    },
+    "clefable": {
+        "level": 80,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Flamethrower", "Knock Off", "Moonblast", "Moonlight", "Stealth Rock", "Thunder Wave"],
+                "teraTypes": ["Fire", "Steel"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Calm Mind", "Fire Blast", "Moonblast", "Moonlight"],
+                "teraTypes": ["Fire"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Cosmic Power", "Moonblast", "Moonlight", "Stored Power"],
+                "teraTypes": ["Steel"]
+            }
+        ]
+    },
+    "ninetales": {
+        "level": 84,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Fire Blast", "Nasty Plot", "Psyshock", "Solar Beam"],
+                "teraTypes": ["Fire", "Grass"]
+            }
+        ]
+    },
+    "ninetalesalola": {
+        "level": 84,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Aurora Veil", "Blizzard", "Encore", "Moonblast"],
+                "teraTypes": ["Steel", "Water"]
+            },
+            {
+                "role": "Fast Bulky Setup",
+                "movepool": ["Aurora Veil", "Blizzard", "Moonblast", "Nasty Plot"],
+                "teraTypes": ["Steel", "Water"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Blizzard", "Moonblast", "Nasty Plot", "Tera Blast"],
+                "teraTypes": ["Ground"]
             }
         ]
     },
@@ -89,7 +174,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Aerial Ace", "Bite", "Body Slam", "Fake Out", "Foul Play", "Gunk Shot", "Switcheroo", "U-turn"],
+                "movepool": ["Aerial Ace", "Body Slam", "Fake Out", "Gunk Shot", "Knock Off", "Switcheroo", "U-turn"],
                 "teraTypes": ["Flying", "Normal", "Poison"]
             }
         ]
@@ -154,17 +239,87 @@
             }
         ]
     },
+    "poliwrath": {
+        "level": 88,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Close Combat", "Knock Off", "Liquidation", "Rain Dance"],
+                "teraTypes": ["Dark", "Fighting", "Water"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Circle Throw", "Close Combat", "Knock Off", "Liquidation"],
+                "teraTypes": ["Dark", "Fighting", "Steel"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bulk Up", "Drain Punch", "Ice Punch", "Knock Off", "Liquidation", "Poison Jab"],
+                "teraTypes": ["Fighting", "Steel", "Water"]
+            }
+        ]
+    },
+    "victreebel": {
+        "level": 90,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Poison Jab", "Power Whip", "Sucker Punch", "Swords Dance"],
+                "teraTypes": ["Dark", "Grass"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Knock Off", "Power Whip", "Sleep Powder", "Sludge Bomb", "Strength Sap", "Sucker Punch"],
+                "teraTypes": ["Grass", "Steel"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Power Whip", "Sludge Bomb", "Sunny Day", "Weather Ball"],
+                "teraTypes": ["Fire"]
+            }
+        ]
+    },
+    "golem": {
+        "level": 88,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Earthquake", "Explosion", "Rock Polish", "Stone Edge"],
+                "teraTypes": ["Grass", "Steel", "Ground"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earthquake", "Explosion", "Stealth Rock", "Stone Edge"],
+                "teraTypes": ["Grass"]
+            }
+        ]
+    },
+    "golemalola": {
+        "level": 88,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earthquake", "Stealth Rock", "Stone Edge", "Volt Switch", "Wild Charge"],
+                "teraTypes": ["Ground"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Double-Edge", "Earthquake", "Explosion", "Rock Polish", "Stone Edge"],
+                "teraTypes": ["Ground"]
+            }
+        ]
+    },
     "slowbro": {
         "level": 84,
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Calm Mind", "Psyshock", "Slack Off", "Surf", "Thunder Wave"],
+                "movepool": ["Calm Mind", "Psyshock", "Scald", "Slack Off", "Thunder Wave"],
                 "teraTypes": ["Fairy", "Water"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["Body Press", "Fire Blast", "Future Sight", "Ice Beam", "Psychic", "Surf"],
+                "movepool": ["Body Press", "Fire Blast", "Future Sight", "Ice Beam", "Psychic", "Scald"],
                 "teraTypes": ["Fighting", "Water"]
             }
         ]
@@ -188,9 +343,9 @@
         "level": 88,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["Drain Punch", "Gunk Shot", "Haze", "Ice Punch", "Shadow Sneak", "Toxic", "Toxic Spikes"],
-                "teraTypes": ["Dark", "Dragon"]
+                "role": "Bulky Attacker",
+                "movepool": ["Drain Punch", "Gunk Shot", "Haze", "Ice Punch", "Knock Off", "Shadow Sneak", "Toxic", "Toxic Spikes"],
+                "teraTypes": ["Dark"]
             }
         ]
     },
@@ -239,7 +394,12 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Encore", "Focus Blast", "Foul Play", "Light Screen", "Psychic", "Reflect", "Thunder Wave"],
+                "movepool": ["Encore", "Knock Off", "Light Screen", "Psychic", "Reflect", "Thunder Wave", "Toxic"],
+                "teraTypes": ["Dark", "Steel"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Focus Blast", "Protect", "Psychic", "Toxic"],
                 "teraTypes": ["Dark", "Steel"]
             }
         ]
@@ -274,17 +434,37 @@
             }
         ]
     },
+    "weezing": {
+        "level": 86,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Fire Blast", "Pain Split", "Sludge Bomb", "Toxic Spikes", "Will-O-Wisp"],
+                "teraTypes": ["Steel"]
+            }
+        ]
+    },
+    "weezinggalar": {
+        "level": 86,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Defog", "Fire Blast", "Pain Split", "Sludge Bomb", "Strange Steam", "Will-O-Wisp"],
+                "teraTypes": ["Steel"]
+            }
+        ]
+    },
     "scyther": {
         "level": 84,
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Aerial Ace", "Close Combat", "Pounce", "Swords Dance"],
+                "movepool": ["Bug Bite", "Close Combat", "Dual Wingbeat", "Swords Dance"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["Aerial Ace", "Close Combat", "Defog", "U-turn"],
+                "movepool": ["Close Combat", "Dual Wingbeat", "Defog", "U-turn"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -299,7 +479,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Close Combat", "Double-Edge", "Earthquake", "Stone Edge"],
+                "movepool": ["Close Combat", "Double-Edge", "Earthquake", "Lash Out", "Stone Edge"],
                 "teraTypes": ["Fighting", "Ground", "Normal"]
             }
         ]
@@ -314,7 +494,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Iron Head", "Stone Edge"],
+                "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Iron Head", "Lash Out", "Stone Edge"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -379,7 +559,12 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Calm Mind", "Ice Beam", "Protect", "Surf", "Wish"],
+                "movepool": ["Flip Turn", "Ice Beam", "Protect", "Scald", "Wish"],
+                "teraTypes": ["Ghost", "Ground"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Protect", "Scald", "Wish"],
                 "teraTypes": ["Ghost", "Ground"]
             }
         ]
@@ -406,6 +591,21 @@
                 "role": "Wallbreaker",
                 "movepool": ["Facade", "Flare Blitz", "Quick Attack", "Trailblaze", "Will-O-Wisp"],
                 "teraTypes": ["Normal"]
+            }
+        ]
+    },
+    "snorlax": {
+        "level": 82,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Slam", "Curse", "Rest", "Sleep Talk"],
+                "teraTypes": ["Fairy", "Poison"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Slam", "Crunch", "Curse", "Earthquake", "Rest"],
+                "teraTypes": ["Ground", "Poison"]
             }
         ]
     },
@@ -444,7 +644,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Brave Bird", "Bulk Up", "Close Combat", "Stomping Tantrum", "U-turn"],
+                "movepool": ["Brave Bird", "Bulk Up", "Close Combat", "Knock Off", "U-turn"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -455,7 +655,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Brave Bird", "Fire Blast", "Roost", "U-turn", "Will-O-Wisp"],
-                "teraTypes": ["Fire", "Ground"]
+                "teraTypes": ["Dragon", "Ground"]
             }
         ]
     },
@@ -463,7 +663,7 @@
         "level": 80,
         "sets": [
             {
-                "role": "Fast Bulky Setup",
+                "role": "Bulky Setup",
                 "movepool": ["Agility", "Fiery Wrath", "Hurricane", "Nasty Plot", "Rest"],
                 "teraTypes": ["Dark"]
             }
@@ -499,12 +699,12 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Encore", "Psychic", "Stealth Rock", "Taunt", "Toxic Spikes", "U-turn", "Will-O-Wisp"],
+                "movepool": ["Encore", "Knock Off", "Psychic", "Stealth Rock", "Taunt", "Toxic Spikes", "U-turn", "Will-O-Wisp"],
                 "teraTypes": ["Fairy", "Steel"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Brave Bird", "Close Combat", "Flare Blitz", "Leech Life", "Psychic Fangs", "Swords Dance"],
+                "movepool": ["Brave Bird", "Close Combat", "Flare Blitz", "Knock Off", "Leech Life", "Psychic Fangs", "Swords Dance"],
                 "teraTypes": ["Fighting"]
             },
             {
@@ -539,6 +739,36 @@
             }
         ]
     },
+    "furret": {
+        "level": 91,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Brick Break", "Double-Edge", "Knock Off", "Tidy Up", "U-turn"],
+                "teraTypes": ["Ghost", "Normal"]
+            }
+        ]
+    },
+    "noctowl": {
+        "level": 91,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Defog", "Haze", "Heat Wave", "Hurricane", "Roost"],
+                "teraTypes": ["Steel"]
+            }
+        ]
+    },
+    "ariados": {
+        "level": 89,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Knock Off", "Megahorn", "Poison Jab", "Sticky Web", "Sucker Punch", "Toxic Spikes"],
+                "teraTypes": ["Ghost", "Steel"]
+            }
+        ]
+    },
     "ampharos": {
         "level": 88,
         "sets": [
@@ -554,7 +784,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Aqua Jet", "Ice Spinner", "Liquidation", "Play Rough", "Superpower"],
+                "movepool": ["Aqua Jet", "Ice Spinner", "Knock Off", "Liquidation", "Play Rough", "Superpower"],
                 "teraTypes": ["Water"]
             },
             {
@@ -571,6 +801,16 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Head Smash", "Stealth Rock", "Sucker Punch", "Wood Hammer"],
                 "teraTypes": ["Grass", "Rock"]
+            }
+        ]
+    },
+    "politoed": {
+        "level": 88,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Encore", "Focus Blast", "Hydro Pump", "Hypnosis", "Ice Beam", "Rest", "Surf"],
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -596,6 +836,11 @@
                 "role": "Wallbreaker",
                 "movepool": ["Dazzling Gleam", "Earth Power", "Leaf Storm", "Sludge Bomb"],
                 "teraTypes": ["Fairy", "Grass", "Ground", "Poison"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Energy Ball", "Sludge Bomb", "Sunny Day", "Weather Ball"],
+                "teraTypes": ["Fire"]
             }
         ]
     },
@@ -639,7 +884,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Foul Play", "Protect", "Thunder Wave", "Wish", "Yawn"],
+                "movepool": ["Foul Play", "Protect", "Toxic", "Wish"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -649,7 +894,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Chilly Reception", "Psyshock", "Slack Off", "Surf", "Thunder Wave"],
+                "movepool": ["Chilly Reception", "Psyshock", "Scald", "Slack Off", "Thunder Wave"],
                 "teraTypes": ["Dragon", "Fairy", "Water"]
             },
             {
@@ -744,12 +989,17 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Bullet Punch", "Close Combat", "Defog", "U-turn"],
+                "movepool": ["Bullet Punch", "Close Combat", "Defog", "Knock Off", "U-turn"],
                 "teraTypes": ["Dragon", "Steel"]
             },
             {
-                "role": "Fast Attacker",
-                "movepool": ["Bullet Punch", "Close Combat", "Pounce", "Swords Dance", "U-turn"],
+                "role": "Setup Sweeper",
+                "movepool": ["Bug Bite", "Bullet Punch", "Close Combat", "Knock Off", "Swords Dance"],
+                "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Bullet Punch", "Close Combat", "Knock Off", "U-turn"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -759,12 +1009,12 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Close Combat", "Facade", "Throat Chop", "Trailblaze"],
+                "movepool": ["Close Combat", "Facade", "Knock Off", "Trailblaze"],
                 "teraTypes": ["Normal"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Earthquake", "Megahorn", "Stone Edge", "Throat Chop"],
+                "movepool": ["Close Combat", "Earthquake", "Knock Off", "Megahorn", "Stone Edge"],
                 "teraTypes": ["Bug", "Fighting", "Rock"]
             }
         ]
@@ -776,6 +1026,21 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Body Slam", "Crunch", "Earthquake", "Rest", "Sleep Talk"],
                 "teraTypes": ["Ghost", "Ground"]
+            }
+        ]
+    },
+    "magcargo": {
+        "level": 91,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Earth Power", "Fire Blast", "Power Gem", "Shell Smash"],
+                "teraTypes": ["Dragon", "Grass"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Lava Plume", "Power Gem", "Recover", "Stealth Rock", "Yawn"],
+                "teraTypes": ["Dragon", "Grass"]
             }
         ]
     },
@@ -844,13 +1109,58 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Crunch", "Dragon Dance", "Earthquake", "Fire Punch", "Stone Edge"],
+                "movepool": ["Dragon Dance", "Earthquake", "Fire Punch", "Knock Off", "Stone Edge"],
                 "teraTypes": ["Ghost", "Rock"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Crunch", "Earthquake", "Fire Blast", "Ice Beam", "Stealth Rock", "Stone Edge", "Thunder Wave"],
+                "movepool": ["Earthquake", "Fire Blast", "Ice Beam", "Knock Off", "Stealth Rock", "Stone Edge", "Thunder Wave"],
                 "teraTypes": ["Poison", "Rock"]
+            }
+        ]
+    },
+    "mightyena": {
+        "level": 94,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Crunch", "Play Rough", "Poison Fang", "Sucker Punch", "Taunt"],
+                "teraTypes": ["Fairy", "Poison"]
+            }
+        ]
+    },
+    "ludicolo": {
+        "level": 89,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Giga Drain", "Hydro Pump", "Ice Beam", "Rain Dance"],
+                "teraTypes": ["Grass", "Steel", "Water"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Giga Drain", "Hydro Pump", "Ice Beam", "Leaf Storm"],
+                "teraTypes": ["Grass", "Water"]
+            }
+        ]
+    },
+    "shiftry": {
+        "level": 86,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Defog", "Knock Off", "Leaf Storm", "Sucker Punch", "Will-O-Wisp"],
+                "teraTypes": ["Dark", "Poison"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Dark Pulse", "Giga Drain", "Heat Wave", "Leaf Storm", "Nasty Plot", "Vacuum Wave"],
+                "teraTypes": ["Fire", "Grass"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Knock Off", "Leaf Blade", "Low Kick", "Tailwind"],
+                "teraTypes": ["Dark", "Fighting"]
             }
         ]
     },
@@ -909,7 +1219,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Body Slam", "Bulk Up", "Earthquake", "Slack Off", "Throat Chop"],
+                "movepool": ["Body Slam", "Bulk Up", "Earthquake", "Knock Off", "Slack Off"],
                 "teraTypes": ["Ghost", "Ground"]
             }
         ]
@@ -919,7 +1229,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Body Slam", "Earthquake", "Giga Impact", "Throat Chop"],
+                "movepool": ["Body Slam", "Earthquake", "Giga Impact", "Knock Off"],
                 "teraTypes": ["Ghost", "Ground", "Normal"]
             }
         ]
@@ -959,18 +1269,38 @@
             }
         ]
     },
+    "volbeat": {
+        "level": 90,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Encore", "Roost", "Thunder Wave", "U-turn"],
+                "teraTypes": ["Steel", "Water"]
+            }
+        ]
+    },
+    "illumise": {
+        "level": 91,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Encore", "Roost", "Thunder Wave", "U-turn"],
+                "teraTypes": ["Steel", "Water"]
+            }
+        ]
+    },
     "swalot": {
         "level": 90,
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Clear Smog", "Earthquake", "Encore", "Ice Beam", "Pain Split", "Protect", "Sludge Bomb", "Toxic", "Toxic Spikes"],
+                "movepool": ["Clear Smog", "Earthquake", "Encore", "Ice Beam", "Knock Off", "Pain Split", "Protect", "Sludge Bomb", "Toxic", "Toxic Spikes"],
                 "teraTypes": ["Dark"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Earthquake", "Gunk Shot", "Seed Bomb", "Swords Dance"],
-                "teraTypes": ["Dark", "Grass", "Ground", "Poison"]
+                "movepool": ["Earthquake", "Gunk Shot", "Knock Off", "Swords Dance"],
+                "teraTypes": ["Dark", "Ground", "Poison"]
             }
         ]
     },
@@ -1013,8 +1343,8 @@
         "level": 92,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["Dark Pulse", "Focus Blast", "Leaf Storm", "Sucker Punch", "Toxic Spikes"],
+                "role": "Wallbreaker",
+                "movepool": ["Focus Blast", "Knock Off", "Leaf Storm", "Sucker Punch", "Toxic Spikes"],
                 "teraTypes": ["Dark", "Grass", "Poison"]
             },
             {
@@ -1044,7 +1374,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Facade", "Night Slash", "Quick Attack", "Swords Dance"],
+                "movepool": ["Close Combat", "Facade", "Knock Off", "Quick Attack", "Swords Dance"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -1054,8 +1384,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Earthquake", "Flamethrower", "Giga Drain", "Glare", "Gunk Shot", "Switcheroo"],
-                "teraTypes": ["Fire", "Grass", "Ground", "Poison"]
+                "movepool": ["Earthquake", "Flamethrower", "Giga Drain", "Glare", "Gunk Shot", "Knock Off", "Switcheroo"],
+                "teraTypes": ["Dark", "Fire", "Grass", "Ground", "Poison"]
             }
         ]
     },
@@ -1074,13 +1404,38 @@
             }
         ]
     },
+    "crawdaunt": {
+        "level": 84,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Aqua Jet", "Close Combat", "Crabhammer", "Dragon Dance", "Knock Off"],
+                "teraTypes": ["Fighting"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Aqua Jet", "Crabhammer", "Knock Off", "Swords Dance"],
+                "teraTypes": ["Water"]
+            }
+        ]
+    },
+    "milotic": {
+        "level": 84,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Dragon Tail", "Flip Turn", "Haze", "Ice Beam", "Recover", "Scald"],
+                "teraTypes": ["Dragon", "Steel"]
+            }
+        ]
+    },
     "banette": {
         "level": 93,
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Gunk Shot", "Knock Off", "Shadow Claw", "Shadow Sneak", "Swords Dance", "Thunder Wave", "Will-O-Wisp"],
-                "teraTypes": ["Dark", "Poison"]
+                "movepool": ["Gunk Shot", "Poltergeist", "Shadow Sneak", "Swords Dance", "Thunder Wave", "Will-O-Wisp"],
+                "teraTypes": ["Ghost", "Poison"]
             }
         ]
     },
@@ -1091,6 +1446,16 @@
                 "role": "Bulky Support",
                 "movepool": ["Air Slash", "Leech Seed", "Protect", "Substitute"],
                 "teraTypes": ["Steel"]
+            }
+        ]
+    },
+    "chimecho": {
+        "level": 92,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Encore", "Heal Bell", "Knock Off", "Psychic", "Recover", "Taunt", "Thunder Wave"],
+                "teraTypes": ["Electric", "Poison", "Steel"]
             }
         ]
     },
@@ -1109,7 +1474,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Charm", "Ice Beam", "Icy Wind", "Protect", "Surf", "Wish"],
+                "movepool": ["Charm", "Flip Turn", "Protect", "Surf", "Wish"],
                 "teraTypes": ["Dragon", "Ghost"]
             }
         ]
@@ -1139,13 +1504,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Lava Plume", "Precipice Blades", "Spikes", "Stealth Rock", "Stone Edge", "Thunder Wave"],
-                "teraTypes": ["Dragon", "Fire", "Ghost", "Water"]
+                "movepool": ["Heat Crash", "Precipice Blades", "Roar", "Spikes", "Stealth Rock", "Stone Edge", "Thunder Wave", "Will-O-Wisp"],
+                "teraTypes": ["Fire"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Fire Punch", "Precipice Blades", "Stone Edge", "Swords Dance", "Thunder Wave"],
-                "teraTypes": ["Fire", "Ground"]
+                "movepool": ["Heat Crash", "Precipice Blades", "Stone Edge", "Swords Dance", "Thunder Wave"],
+                "teraTypes": ["Fire"]
             }
         ]
     },
@@ -1161,6 +1526,61 @@
                 "role": "Fast Attacker",
                 "movepool": ["Dragon Ascent", "Earthquake", "Extreme Speed", "Swords Dance", "U-turn"],
                 "teraTypes": ["Normal"]
+            },
+            {
+                "role": "Fast Bulky Setup",
+                "movepool": ["Dragon Ascent", "Earthquake", "Scale Shot", "Swords Dance"],
+                "teraTypes": ["Dragon", "Flying"]
+            }
+        ]
+    },
+    "jirachi": {
+        "level": 79,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Body Slam", "Fire Punch", "Healing Wish", "Iron Head", "Protect", "U-turn", "Wish"],
+                "teraTypes": ["Water"]
+            }
+        ]
+    },
+    "torterra": {
+        "level": 82,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Headlong Rush", "Shell Smash", "Stone Edge", "Wood Hammer"],
+                "teraTypes": ["Ground", "Water"]
+            }
+        ]
+    },
+    "infernape": {
+        "level": 82,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Close Combat", "Grass Knot", "Gunk Shot", "Knock Off", "Mach Punch", "Overheat", "Stone Edge"],
+                "teraTypes": ["Dark", "Fighting", "Fire"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Close Combat", "Flare Blitz", "Gunk Shot", "Knock Off", "Mach Punch", "Stone Edge", "Swords Dance", "U-turn"],
+                "teraTypes": ["Dark", "Fighting", "Fire"]
+            }
+        ]
+    },
+    "empoleon": {
+        "level": 82,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Flip Turn", "Ice Beam", "Knock Off", "Roost", "Stealth Rock", "Surf", "Yawn"],
+                "teraTypes": ["Flying", "Grass"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Flash Cannon", "Flip Turn", "Grass Knot", "Hydro Pump", "Ice Beam", "Knock Off"],
+                "teraTypes": ["Flying", "Grass"]
             }
         ]
     },
@@ -1179,7 +1599,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Brick Break", "Pounce", "Sticky Web", "Taunt"],
+                "movepool": ["Knock Off", "Pounce", "Sticky Web", "Taunt"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -1224,7 +1644,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Aqua Jet", "Crunch", "Ice Spinner", "Low Kick", "Wave Crash"],
+                "movepool": ["Crunch", "Flip Turn", "Ice Spinner", "Low Kick", "Wave Crash"],
                 "teraTypes": ["Water"]
             },
             {
@@ -1241,6 +1661,16 @@
                 "role": "Bulky Support",
                 "movepool": ["Clear Smog", "Earthquake", "Ice Beam", "Recover", "Stealth Rock", "Surf"],
                 "teraTypes": ["Poison", "Steel"]
+            }
+        ]
+    },
+    "ambipom": {
+        "level": 87,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Double Hit", "Fake Out", "Knock Off", "Low Kick", "Switcheroo", "U-turn"],
+                "teraTypes": ["Normal"]
             }
         ]
     },
@@ -1284,7 +1714,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Crunch", "Fire Blast", "Gunk Shot", "Sucker Punch", "Taunt", "Toxic Spikes"],
+                "movepool": ["Fire Blast", "Gunk Shot", "Knock Off", "Sucker Punch", "Taunt", "Toxic Spikes"],
                 "teraTypes": ["Dark", "Poison"]
             }
         ]
@@ -1303,9 +1733,9 @@
         "level": 90,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["Foul Play", "Pain Split", "Shadow Sneak", "Sucker Punch", "Will-O-Wisp"],
-                "teraTypes": ["Dark"]
+                "role": "Bulky Attacker",
+                "movepool": ["Foul Play", "Pain Split", "Poltergeist", "Shadow Sneak", "Sucker Punch", "Will-O-Wisp"],
+                "teraTypes": ["Dark", "Ghost"]
             },
             {
                 "role": "Bulky Setup",
@@ -1323,8 +1753,8 @@
                 "teraTypes": ["Ground", "Steel"]
             },
             {
-                "role": "Fast Attacker",
-                "movepool": ["Earthquake", "Outrage", "Poison Jab", "Stone Edge", "Swords Dance"],
+                "role": "Setup Sweeper",
+                "movepool": ["Earthquake", "Fire Fang", "Scale Shot", "Stone Edge", "Swords Dance"],
                 "teraTypes": ["Dragon", "Ground"]
             }
         ]
@@ -1389,8 +1819,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Ice Shard", "Ice Spinner", "Low Kick", "Night Slash", "Swords Dance"],
-                "teraTypes": ["Fighting", "Ice"]
+                "movepool": ["Ice Shard", "Ice Spinner", "Knock Off", "Low Kick", "Swords Dance"],
+                "teraTypes": ["Dark", "Fighting", "Ice"]
             }
         ]
     },
@@ -1399,7 +1829,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Dire Claw", "Gunk Shot", "Night Slash", "U-turn"],
+                "movepool": ["Close Combat", "Dire Claw", "Gunk Shot", "Lash Out", "U-turn"],
                 "teraTypes": ["Dark", "Fighting"]
             },
             {
@@ -1419,13 +1849,28 @@
             }
         ]
     },
+    "yanmega": {
+        "level": 84,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Air Slash", "Bug Buzz", "Giga Drain", "U-turn"],
+                "teraTypes": ["Bug"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Air Slash", "Bug Buzz", "Protect", "Tera Blast"],
+                "teraTypes": ["Ground"]
+            }
+        ]
+    },
     "leafeon": {
         "level": 88,
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Double-Edge", "Leaf Blade", "Substitute", "Swords Dance", "Synthesis", "X-Scissor"],
-                "teraTypes": ["Normal"]
+                "movepool": ["Double-Edge", "Knock Off", "Leaf Blade", "Substitute", "Swords Dance", "Synthesis"],
+                "teraTypes": ["Dark", "Normal"]
             }
         ]
     },
@@ -1439,6 +1884,36 @@
             }
         ]
     },
+    "gliscor": {
+        "level": 82,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Earthquake", "Protect", "Substitute", "Toxic"],
+                "teraTypes": ["Water"]
+            },
+            {
+                "role": "Fast Bulky Setup",
+                "movepool": ["Dual Wingbeat", "Earthquake", "Facade", "Swords Dance"],
+                "teraTypes": ["Normal"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Earthquake", "Knock Off", "Protect", "Stealth Rock", "Toxic Spikes", "U-turn"],
+                "teraTypes": ["Water"]
+            }
+        ]
+    },
+    "mamoswine": {
+        "level": 82,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Earthquake", "Ice Shard", "Icicle Crash", "Knock Off", "Stealth Rock"],
+                "teraTypes": ["Ground", "Ice"]
+            }
+        ]
+    },
     "gallade": {
         "level": 82,
         "sets": [
@@ -1449,12 +1924,37 @@
             }
         ]
     },
+    "probopass": {
+        "level": 88,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Press", "Flash Cannon", "Iron Defense", "Power Gem", "Rest"],
+                "teraTypes": ["Fighting"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Press", "Flash Cannon", "Power Gem", "Stealth Rock", "Thunder Wave", "Volt Switch"],
+                "teraTypes": ["Fighting"]
+            }
+        ]
+    },
+    "dusknoir": {
+        "level": 86,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Earthquake", "Leech Life", "Pain Split", "Poltergeist", "Shadow Sneak", "Trick"],
+                "teraTypes": ["Ghost"]
+            }
+        ]
+    },
     "froslass": {
         "level": 87,
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Destiny Bond", "Ice Beam", "Shadow Ball", "Spikes", "Taunt", "Will-O-Wisp"],
+                "movepool": ["Destiny Bond", "Ice Beam", "Poltergeist", "Spikes", "Taunt", "Will-O-Wisp"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -1524,7 +2024,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Encore", "Light Screen", "Psychic", "Reflect", "Stealth Rock", "Thunder Wave", "U-turn", "Yawn"],
+                "movepool": ["Encore", "Knock Off", "Light Screen", "Psychic", "Reflect", "Stealth Rock", "Thunder Wave", "U-turn", "Yawn"],
                 "teraTypes": ["Electric", "Steel"]
             }
         ]
@@ -1539,7 +2039,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Encore", "Psychic", "Stealth Rock", "Thunder Wave", "Thunderbolt", "U-turn"],
+                "movepool": ["Encore", "Knock Off", "Psychic", "Stealth Rock", "Thunder Wave", "Thunderbolt", "U-turn"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -1549,7 +2049,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Explosion", "Fire Blast", "Psychic", "Stealth Rock", "Taunt", "U-turn"],
+                "movepool": ["Explosion", "Fire Blast", "Knock Off", "Psychic", "Stealth Rock", "Taunt", "U-turn"],
                 "teraTypes": ["Fire", "Psychic"]
             },
             {
@@ -1639,7 +2139,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Defog", "Draco Meteor", "Dragon Tail", "Earthquake", "Outrage", "Shadow Ball", "Shadow Sneak", "Will-O-Wisp"],
+                "movepool": ["Defog", "Draco Meteor", "Dragon Tail", "Earthquake", "Outrage", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
                 "teraTypes": ["Dragon", "Ghost"]
             }
         ]
@@ -1651,6 +2151,71 @@
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Moonblast", "Moonlight", "Psyshock", "Thunderbolt"],
                 "teraTypes": ["Electric", "Fairy", "Poison", "Steel"]
+            }
+        ]
+    },
+    "phione": {
+        "level": 88,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Rest", "Scald", "Sleep Talk", "Take Heart"],
+                "teraTypes": ["Dragon", "Steel"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Grass Knot", "Ice Beam", "Scald", "Take Heart"],
+                "teraTypes": ["Grass", "Steel"]
+            }
+        ]
+    },
+    "manaphy": {
+        "level": 80,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Energy Ball", "Hydro Pump", "Ice Beam", "Surf", "Tail Glow"],
+                "teraTypes": ["Grass", "Steel", "Water"]
+            }
+        ]
+    },
+    "darkrai": {
+        "level": 76,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dark Pulse", "Focus Blast", "Hypnosis", "Nasty Plot", "Sludge Bomb", "Substitute"],
+                "teraTypes": ["Poison"]
+            }
+        ]
+    },
+    "shaymin": {
+        "level": 84,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Air Slash", "Earth Power", "Rest", "Seed Flare"],
+                "teraTypes": ["Grass", "Ground", "Steel"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Air Slash", "Leech Seed", "Seed Flare", "Substitute"],
+                "teraTypes": ["Steel"]
+            }
+        ]
+    },
+    "shayminsky": {
+        "level": 76,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Air Slash", "Dazzling Gleam", "Earth Power", "Seed Flare"],
+                "teraTypes": ["Flying", "Grass"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Air Slash", "Leech Seed", "Seed Flare", "Substitute"],
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -1869,7 +2434,7 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["Aqua Jet", "Grass Knot", "Hydro Pump", "Ice Beam", "Knock Off", "Megahorn", "Sacred Sword"],
+                "movepool": ["Aqua Jet", "Flip Turn", "Grass Knot", "Hydro Pump", "Ice Beam", "Knock Off", "Megahorn", "Sacred Sword"],
                 "teraTypes": ["Dark", "Water"]
             },
             {
@@ -1884,8 +2449,43 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Aqua Jet", "Ceaseless Edge", "Razor Shell", "Sacred Sword", "Sucker Punch", "Swords Dance"],
+                "movepool": ["Ceaseless Edge", "Flip Turn", "Razor Shell", "Sacred Sword", "Sucker Punch", "Swords Dance"],
                 "teraTypes": ["Dark", "Water"]
+            }
+        ]
+    },
+    "gurdurr": {
+        "level": 85,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Bulk Up", "Defog", "Drain Punch", "Knock Off", "Mach Punch"],
+                "teraTypes": ["Steel"]
+            }
+        ]
+    },
+    "conkeldurr": {
+        "level": 80,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Close Combat", "Facade", "Knock Off", "Mach Punch"],
+                "teraTypes": ["Normal"]
+            }
+        ]
+    },
+    "leavanny": {
+        "level": 88,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Knock Off", "Leaf Blade", "Lunge", "Sticky Web"],
+                "teraTypes": ["Ghost", "Rock"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Knock Off", "Leaf Blade", "Lunge", "Swords Dance"],
+                "teraTypes": ["Dark", "Rock"]
             }
         ]
     },
@@ -1924,7 +2524,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Aqua Jet", "Crunch", "Head Smash", "Psychic Fangs", "Wave Crash"],
+                "movepool": ["Aqua Jet", "Crunch", "Flip Turn", "Head Smash", "Psychic Fangs", "Wave Crash"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -1934,7 +2534,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Aqua Jet", "Crunch", "Head Smash", "Psychic Fangs", "Wave Crash"],
+                "movepool": ["Aqua Jet", "Crunch", "Flip Turn", "Head Smash", "Psychic Fangs", "Wave Crash"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -1944,7 +2544,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Aqua Jet", "Head Smash", "Last Respects", "Wave Crash"],
+                "movepool": ["Aqua Jet", "Flip Turn", "Last Respects", "Wave Crash"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -1954,7 +2554,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Hydro Pump", "Ice Beam", "Last Respects", "Wave Crash"],
+                "movepool": ["Flip Turn", "Hydro Pump", "Last Respects", "Wave Crash"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -1964,7 +2564,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Bulk Up", "Crunch", "Earthquake", "Gunk Shot", "Stealth Rock", "Stone Edge"],
+                "movepool": ["Bulk Up", "Earthquake", "Gunk Shot", "Knock Off", "Stealth Rock", "Stone Edge"],
                 "teraTypes": ["Ground", "Poison"]
             }
         ]
@@ -1997,12 +2597,22 @@
             }
         ]
     },
+    "swanna": {
+        "level": 88,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Brave Bird", "Defog", "Hydro Pump", "Knock Off", "Roost"],
+                "teraTypes": ["Ground"]
+            }
+        ]
+    },
     "sawsbuck": {
         "level": 88,
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Double-Edge", "Headbutt", "Horn Leech", "Stomping Tantrum", "Swords Dance"],
+                "movepool": ["Double-Edge", "Headbutt", "High Horsepower", "Horn Leech", "Swords Dance"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -2022,7 +2632,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Body Slam", "Liquidation", "Mirror Coat", "Protect", "Wish"],
+                "movepool": ["Flip Turn", "Protect", "Scald", "Wish"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -2032,13 +2642,28 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Coil", "Drain Punch", "Fire Punch", "Liquidation", "Wild Charge"],
+                "movepool": ["Coil", "Drain Punch", "Fire Punch", "Knock Off", "Liquidation", "Wild Charge"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["Acid Spray", "Close Combat", "Flamethrower", "Giga Drain", "Thunderbolt", "U-turn"],
+                "movepool": ["Acid Spray", "Close Combat", "Flamethrower", "Giga Drain", "Knock Off", "Thunderbolt", "U-turn"],
                 "teraTypes": ["Poison"]
+            }
+        ]
+    },
+    "chandelure": {
+        "level": 82,
+        "sets": [
+            {
+                "role": "Fast Bulky Setup",
+                "movepool": ["Calm Mind", "Energy Ball", "Fire Blast", "Shadow Ball", "Substitute"],
+                "teraTypes": ["Fire", "Ghost", "Grass"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Energy Ball", "Fire Blast", "Shadow Ball", "Trick"],
+                "teraTypes": ["Fire", "Ghost", "Grass"]
             }
         ]
     },
@@ -2046,8 +2671,13 @@
         "level": 77,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Dragon Dance", "Earthquake", "Iron Head", "Outrage"],
+                "teraTypes": ["Fighting", "Ground", "Steel"]
+            },
+            {
+                "role": "Fast Bulky Setup",
+                "movepool": ["Close Combat", "Earthquake", "Iron Head", "Scale Shot", "Swords Dance"],
                 "teraTypes": ["Fighting", "Ground", "Steel"]
             }
         ]
@@ -2077,6 +2707,21 @@
             }
         ]
     },
+    "mienshao": {
+        "level": 84,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["High Jump Kick", "Knock Off", "Poison Jab", "Stone Edge", "Swords Dance", "U-turn"],
+                "teraTypes": ["Dark"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Close Combat", "Fake Out", "Knock Off", "U-turn"],
+                "teraTypes": ["Dark", "Steel"]
+            }
+        ]
+    },
     "braviary": {
         "level": 86,
         "sets": [
@@ -2099,6 +2744,21 @@
                 "role": "Wallbreaker",
                 "movepool": ["Calm Mind", "Defog", "Esper Wing", "Heat Wave", "Hurricane", "U-turn"],
                 "teraTypes": ["Fairy", "Psychic", "Steel"]
+            }
+        ]
+    },
+    "mandibuzz": {
+        "level": 84,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Defog", "Foul Play", "Roost", "Toxic", "U-turn"],
+                "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Brave Bird", "Defog", "Foul Play", "Knock Off", "Roost", "Toxic"],
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -2144,6 +2804,11 @@
                 "role": "Fast Attacker",
                 "movepool": ["Bleakwind Storm", "Focus Blast", "Grass Knot", "Heat Wave", "Nasty Plot", "U-turn"],
                 "teraTypes": ["Fire", "Flying"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Bleakwind Storm", "Heat Wave", "Knock Off", "U-turn"],
+                "teraTypes": ["Dark", "Fire", "Flying"]
             }
         ]
     },
@@ -2152,7 +2817,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Focus Blast", "Grass Knot", "Nasty Plot", "Sludge Bomb", "Taunt", "Thunder Wave", "Thunderbolt", "U-turn"],
+                "movepool": ["Focus Blast", "Grass Knot", "Knock Off", "Nasty Plot", "Sludge Bomb", "Taunt", "Thunder Wave", "Thunderbolt", "U-turn"],
                 "teraTypes": ["Electric", "Grass"]
             },
             {
@@ -2209,11 +2874,6 @@
                 "role": "Fast Attacker",
                 "movepool": ["Calm Mind", "Focus Blast", "Hyper Voice", "Psyshock", "U-turn"],
                 "teraTypes": ["Fighting", "Normal", "Psychic"]
-            },
-            {
-                "role": "Tera Blast user",
-                "movepool": ["Close Combat", "Psychic", "Relic Song", "Tera Blast"],
-                "teraTypes": ["Normal"]
             }
         ]
     },
@@ -2222,7 +2882,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Body Press", "Leech Seed", "Spikes", "Synthesis", "Wood Hammer"],
+                "movepool": ["Body Press", "Knock Off", "Leech Seed", "Spikes", "Synthesis", "Wood Hammer"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
@@ -2332,7 +2992,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Draco Meteor", "Focus Blast", "Hydro Pump", "Sludge Bomb", "Toxic", "Toxic Spikes"],
+                "movepool": ["Draco Meteor", "Flip Turn", "Focus Blast", "Hydro Pump", "Sludge Bomb", "Toxic", "Toxic Spikes"],
                 "teraTypes": ["Fighting", "Water"]
             }
         ]
@@ -2373,7 +3033,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Dazzling Gleam", "Nuzzle", "Super Fang", "Thunderbolt", "U-turn"],
-                "teraTypes": ["Electric"]
+                "teraTypes": ["Electric", "Flying"]
             }
         ]
     },
@@ -2396,9 +3056,9 @@
         "level": 85,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Draco Meteor", "Earthquake", "Fire Blast", "Power Whip", "Sludge Bomb", "Thunderbolt"],
-                "teraTypes": ["Dragon", "Electric", "Fire", "Grass", "Ground", "Poison"]
+                "role": "AV Pivot",
+                "movepool": ["Draco Meteor", "Earthquake", "Fire Blast", "Knock Off", "Power Whip", "Scald", "Sludge Bomb", "Thunderbolt"],
+                "teraTypes": ["Dragon", "Electric", "Fire", "Grass", "Ground", "Poison", "Water"]
             }
         ]
     },
@@ -2407,7 +3067,7 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["Draco Meteor", "Dragon Tail", "Earthquake", "Fire Blast", "Heavy Slam", "Hydro Pump", "Thunderbolt"],
+                "movepool": ["Draco Meteor", "Dragon Tail", "Earthquake", "Fire Blast", "Heavy Slam", "Hydro Pump", "Knock Off", "Thunderbolt"],
                 "teraTypes": ["Dragon", "Electric", "Fire", "Ground", "Steel", "Water"]
             },
             {
@@ -2429,6 +3089,21 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Dazzling Gleam", "Foul Play", "Spikes", "Thunder Wave"],
                 "teraTypes": ["Flying", "Water"]
+            }
+        ]
+    },
+    "trevenant": {
+        "level": 86,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Drain Punch", "Horn Leech", "Poltergeist", "Trick Room", "Wood Hammer"],
+                "teraTypes": ["Fighting"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Leech Seed", "Poltergeist", "Protect", "Substitute"],
+                "teraTypes": ["Dark", "Fairy", "Steel"]
             }
         ]
     },
@@ -2522,7 +3197,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Leaf Blade", "Shadow Sneak", "Spirit Shackle", "Swords Dance"],
+                "movepool": ["Leaf Blade", "Poltergeist", "Shadow Sneak", "Swords Dance"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -2542,8 +3217,23 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Body Slam", "Crunch", "Earthquake", "Psychic Fangs", "U-turn"],
+                "movepool": ["Body Slam", "Earthquake", "Knock Off", "Psychic Fangs", "U-turn"],
                 "teraTypes": ["Ground"]
+            }
+        ]
+    },
+    "vikavolt": {
+        "level": 84,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Agility", "Bug Buzz", "Energy Ball", "Thunderbolt", "Volt Switch"],
+                "teraTypes": ["Electric"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Bug Buzz", "Energy Ball", "Sticky Web", "Thunderbolt", "Volt Switch"],
+                "teraTypes": ["Electric"]
             }
         ]
     },
@@ -2552,7 +3242,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Close Combat", "Drain Punch", "Earthquake", "Gunk Shot", "Ice Hammer"],
+                "movepool": ["Close Combat", "Drain Punch", "Earthquake", "Gunk Shot", "Ice Hammer", "Knock Off"],
                 "teraTypes": ["Fighting", "Ground"]
             }
         ]
@@ -2597,6 +3287,21 @@
             }
         ]
     },
+    "ribombee": {
+        "level": 82,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Moonblast", "Sticky Web", "Stun Spore", "U-turn"],
+                "teraTypes": ["Fighting", "Ghost"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Bug Buzz", "Moonblast", "Quiver Dance", "Tera Blast"],
+                "teraTypes": ["Ground"]
+            }
+        ]
+    },
     "lycanroc": {
         "level": 86,
         "sets": [
@@ -2612,7 +3317,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Psychic Fangs", "Stealth Rock", "Stone Edge", "Swords Dance"],
+                "movepool": ["Close Combat", "Knock Off", "Psychic Fangs", "Stealth Rock", "Stone Edge", "Swords Dance"],
                 "teraTypes": ["Fighting", "Rock"]
             }
         ]
@@ -2652,8 +3357,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Defog", "Leaf Storm", "Pollen Puff", "Synthesis"],
-                "teraTypes": ["Steel", "Water"]
+                "movepool": ["Defog", "Knock Off", "Leaf Storm", "Superpower", "Synthesis"],
+                "teraTypes": ["Fighting"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Knock Off", "Leaf Storm", "Leech Life", "Superpower"],
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -2672,7 +3382,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["High Jump Kick", "Play Rough", "Power Whip", "Rapid Spin", "Synthesis", "U-turn"],
+                "movepool": ["High Jump Kick", "Knock Off", "Power Whip", "Rapid Spin", "Synthesis", "U-turn"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -2717,8 +3427,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Body Slam", "Earthquake", "Gunk Shot", "Play Rough", "Rapid Spin", "Sucker Punch", "Superpower", "U-turn", "Wood Hammer"],
-                "teraTypes": ["Fairy", "Fighting", "Grass", "Ground", "Poison"]
+                "movepool": ["Body Slam", "Earthquake", "Knock Off", "Play Rough", "Rapid Spin", "Sucker Punch", "Superpower", "U-turn", "Wood Hammer"],
+                "teraTypes": ["Fairy", "Fighting", "Grass", "Ground"]
             }
         ]
     },
@@ -2737,8 +3447,28 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Aqua Jet", "Crunch", "Ice Fang", "Psychic Fangs", "Swords Dance", "Wave Crash"],
+                "movepool": ["Aqua Jet", "Crunch", "Flip Turn", "Ice Fang", "Psychic Fangs", "Swords Dance", "Wave Crash"],
                 "teraTypes": ["Dark", "Psychic"]
+            }
+        ]
+    },
+    "kommoo": {
+        "level": 80,
+        "sets": [
+            {
+                "role": "Fast Bulky Setup",
+                "movepool": ["Clanging Scales", "Clangorous Soul", "Close Combat", "Iron Head"],
+                "teraTypes": ["Dragon", "Steel"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Close Combat", "Iron Head", "Scale Shot", "Swords Dance"],
+                "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Boomburst", "Clanging Scales", "Close Combat", "Poison Jab", "Stealth Rock"],
+                "teraTypes": ["Normal"]
             }
         ]
     },
@@ -2767,12 +3497,12 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Acrobatics", "Knock Off", "Stomping Tantrum", "Swords Dance", "Wood Hammer"],
+                "movepool": ["Acrobatics", "Grassy Glide", "High Horsepower", "Knock Off", "Swords Dance", "Wood Hammer"],
                 "teraTypes": ["Flying", "Grass"]
             },
             {
-                "role": "Fast Attacker",
-                "movepool": ["Knock Off", "Stomping Tantrum", "U-turn", "Wood Hammer"],
+                "role": "Wallbreaker",
+                "movepool": ["Grassy Glide", "High Horsepower", "Knock Off", "U-turn", "Wood Hammer"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -2792,7 +3522,12 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Dark Pulse", "Hydro Pump", "Ice Beam", "Surf", "U-turn"],
+                "movepool": ["Dark Pulse", "Hydro Pump", "Ice Beam", "U-turn"],
+                "teraTypes": ["Water"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Hydro Pump", "Ice Beam", "Scald", "U-turn"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -2802,7 +3537,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Body Slam", "Crunch", "Earthquake", "Fire Fang", "Psychic Fangs", "Swords Dance"],
+                "movepool": ["Body Slam", "Earthquake", "Fire Fang", "Knock Off", "Psychic Fangs", "Swords Dance"],
                 "teraTypes": ["Ground", "Psychic"]
             }
         ]
@@ -2872,12 +3607,22 @@
             }
         ]
     },
+    "cramorant": {
+        "level": 86,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Brave Bird", "Defog", "Roost", "Surf"],
+                "teraTypes": ["Ground"]
+            }
+        ]
+    },
     "barraskewda": {
         "level": 82,
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Aqua Jet", "Close Combat", "Crunch", "Poison Jab", "Psychic Fangs", "Waterfall"],
+                "movepool": ["Close Combat", "Crunch", "Flip Turn", "Poison Jab", "Psychic Fangs", "Waterfall"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2887,7 +3632,12 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Boomburst", "Overdrive", "Shift Gear", "Sludge Bomb", "Toxic Spikes", "Volt Switch"],
+                "movepool": ["Boomburst", "Overdrive", "Sludge Bomb", "Toxic Spikes", "Volt Switch"],
+                "teraTypes": ["Normal"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Boomburst", "Gunk Shot", "Overdrive", "Shift Gear"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -2942,7 +3692,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Close Combat", "Crunch", "Iron Head", "Stealth Rock", "U-turn"],
+                "movepool": ["Close Combat", "Iron Head", "Knock Off", "Stealth Rock", "U-turn"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]
@@ -2952,13 +3702,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Close Combat", "Iron Head", "Megahorn", "No Retreat", "Rock Slide"],
-                "teraTypes": ["Fighting", "Ghost", "Steel"]
-            },
-            {
-                "role": "Tera Blast user",
-                "movepool": ["Close Combat", "Iron Head", "No Retreat", "Tera Blast"],
-                "teraTypes": ["Ghost"]
+                "movepool": ["Close Combat", "Iron Head", "Knock Off", "No Retreat"],
+                "teraTypes": ["Dark", "Fighting", "Ghost", "Steel"]
             }
         ]
     },
@@ -2967,7 +3712,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Discharge", "Hydro Pump", "Spikes", "Sucker Punch", "Toxic Spikes"],
+                "movepool": ["Discharge", "Scald", "Spikes", "Sucker Punch", "Toxic Spikes"],
                 "teraTypes": ["Ghost", "Water"]
             }
         ]
@@ -2992,8 +3737,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Earthquake", "Heavy Slam", "Rock Polish", "Stealth Rock", "Stone Edge"],
-                "teraTypes": ["Ground", "Steel"]
+                "movepool": ["Earthquake", "Heat Crash", "Rock Polish", "Stealth Rock", "Stone Edge"],
+                "teraTypes": ["Fire", "Ground"]
             }
         ]
     },
@@ -3032,6 +3777,21 @@
             }
         ]
     },
+    "morpeko": {
+        "level": 86,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Aura Wheel", "Parting Shot", "Protect", "Rapid Spin"],
+                "teraTypes": ["Poison"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Aura Wheel", "Knock Off",  "Protect", "Rapid Spin"],
+                "teraTypes": ["Dark", "Poison"]
+            }
+        ]
+    },
     "copperajah": {
         "level": 86,
         "sets": [
@@ -3039,6 +3799,11 @@
                 "role": "Wallbreaker",
                 "movepool": ["Earthquake", "Iron Head", "Play Rough", "Rock Slide", "Stealth Rock", "Superpower"],
                 "teraTypes": ["Fairy", "Steel"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earthquake", "Heat Crash", "Heavy Slam", "Knock Off", "Stone Edge", "Superpower"],
+                "teraTypes": ["Fire", "Steel"]
             }
         ]
     },
@@ -3142,12 +3907,12 @@
         "sets": [
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Close Combat", "Crunch", "Power Whip", "Swords Dance", "Synthesis"],
+                "movepool": ["Close Combat", "Knock Off", "Power Whip", "Swords Dance", "Synthesis"],
                 "teraTypes": ["Dark", "Fighting", "Grass"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Crunch", "Power Whip", "U-turn"],
+                "movepool": ["Close Combat", "Knock Off", "Power Whip", "U-turn"],
                 "teraTypes": ["Dark", "Fighting", "Grass"]
             }
         ]
@@ -3187,8 +3952,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Close Combat", "Heavy Slam", "Icicle Crash", "Stomping Tantrum", "Swords Dance"],
-                "teraTypes": ["Fighting", "Steel"]
+                "movepool": ["Close Combat", "Heavy Slam", "High Horsepower", "Icicle Crash", "Swords Dance"],
+                "teraTypes": ["Fighting", "Ground", "Steel"]
             }
         ]
     },
@@ -3221,9 +3986,14 @@
         "level": 72,
         "sets": [
             {
+                "role": "Bulky Setup",
+                "movepool": ["Agility", "Close Combat", "Glacial Lance", "High Horsepower"],
+                "teraTypes": ["Fighting", "Ground"]
+            },
+            {
                 "role": "Wallbreaker",
-                "movepool": ["Agility", "Close Combat", "Glacial Lance", "Stomping Tantrum", "Trick Room", "Zen Headbutt"],
-                "teraTypes": ["Fighting"]
+                "movepool": ["Close Combat", "Glacial Lance", "High Horsepower", "Trick Room", "Zen Headbutt"],
+                "teraTypes": ["Fighting", "Ground"]
             }
         ]
     },
@@ -3267,6 +4037,16 @@
             }
         ]
     },
+    "ursalunabloodmoon": {
+        "level": 79,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Blood Moon", "Calm Mind", "Earth Power", "Moonlight", "Yawn"],
+                "teraTypes": ["Ghost", "Normal", "Poison"]
+            }
+        ]
+    },
     "enamorus": {
         "level": 79,
         "sets": [
@@ -3304,11 +4084,6 @@
                 "role": "Fast Support",
                 "movepool": ["Flower Trick", "Knock Off", "Play Rough", "Toxic Spikes", "U-turn"],
                 "teraTypes": ["Dark", "Grass"]
-            },
-            {
-                "role": "Fast Attacker",
-                "movepool": ["Flower Trick", "Hone Claws", "Knock Off", "Play Rough", "Toxic Spikes"],
-                "teraTypes": ["Dark", "Fairy", "Grass"]
             }
         ]
     },
@@ -3332,12 +4107,12 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Aqua Step", "Close Combat", "Ice Spinner", "Rapid Spin", "Roost", "U-turn"],
+                "movepool": ["Aqua Step", "Close Combat", "Knock Off", "Rapid Spin", "Roost", "U-turn"],
                 "teraTypes": ["Fighting", "Water"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Aqua Step", "Close Combat", "Ice Spinner", "Roost", "Swords Dance"],
+                "movepool": ["Aqua Step", "Close Combat", "Ice Spinner", "Knock Off", "Roost", "Swords Dance"],
                 "teraTypes": ["Fighting", "Water"]
             }
         ]
@@ -3347,7 +4122,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Body Press", "Body Slam", "Stuff Cheeks", "Thief"],
+                "movepool": ["Body Press", "Body Slam", "Lash Out", "Stuff Cheeks"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -3357,38 +4132,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Body Press", "Body Slam", "Stuff Cheeks", "Thief"],
+                "movepool": ["Body Press", "Body Slam", "Lash Out", "Stuff Cheeks"],
                 "teraTypes": ["Fighting"]
-            }
-        ]
-    },
-    "dudunsparce": {
-        "level": 82,
-        "sets": [
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Earthquake", "Glare", "Headbutt", "Roost"],
-                "teraTypes": ["Ghost", "Ground"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["Boomburst", "Calm Mind", "Earth Power", "Roost", "Shadow Ball"],
-                "teraTypes": ["Ghost"]
-            }
-        ]
-    },
-    "dudunsparcethreesegment": {
-        "level": 82,
-        "sets": [
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Earthquake", "Glare", "Headbutt", "Roost"],
-                "teraTypes": ["Ghost", "Ground"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["Boomburst", "Calm Mind", "Earth Power", "Roost", "Shadow Ball"],
-                "teraTypes": ["Ghost"]
             }
         ]
     },
@@ -3397,7 +4142,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Circle Throw", "Spikes", "Sticky Web", "Toxic Spikes", "U-turn"],
+                "movepool": ["Circle Throw", "Knock Off", "Spikes", "Sticky Web", "Toxic Spikes", "U-turn"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -3412,188 +4157,28 @@
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["Axe Kick", "First Impression", "Sucker Punch", "U-turn"],
+                "movepool": ["First Impression", "Knock Off", "Sucker Punch", "U-turn"],
                 "teraTypes": ["Bug"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Leech Life", "Sucker Punch", "Swords Dance", "Throat Chop"],
+                "movepool": ["Knock Off", "Leech Life", "Sucker Punch", "Swords Dance"],
                 "teraTypes": ["Dark"]
             }
         ]
     },
-    "rabsca": {
-        "level": 90,
-        "sets": [
-            {
-                "role": "Bulky Support",
-                "movepool": ["Bug Buzz", "Earth Power", "Psychic", "Revival Blessing", "Trick Room"],
-                "teraTypes": ["Steel"]
-            }
-        ]
-    },
-    "houndstone": {
-        "level": 73,
-        "sets": [
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Body Press", "Last Respects", "Trick", "Will-O-Wisp"],
-                "teraTypes": ["Ghost"]
-            }
-        ]
-    },
-    "espathra": {
+    "pawmot": {
         "level": 80,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["Dazzling Gleam", "Lumina Crash", "Shadow Ball", "U-turn"],
-                "teraTypes": ["Fairy", "Ghost", "Psychic"]
-            },
-            {
-                "role": "Fast Bulky Setup",
-                "movepool": ["Calm Mind", "Dazzling Gleam", "Protect", "Roost", "Stored Power", "Substitute"],
-                "teraTypes": ["Fairy"]
-            },
-            {
-                "role": "Tera Blast user",
-                "movepool": ["Dazzling Gleam", "Lumina Crash", "Roost", "Tera Blast"],
-                "teraTypes": ["Fighting", "Fire"]
-            }
-        ]
-    },
-    "farigiraf": {
-        "level": 90,
-        "sets": [
-            {
-                "role": "Bulky Support",
-                "movepool": ["Foul Play", "Hyper Voice", "Protect", "Wish"],
-                "teraTypes": ["Dark"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Future Sight", "Hyper Voice", "Protect", "Wish"],
-                "teraTypes": ["Fairy", "Ground", "Water"]
-            },
-            {
-                "role": "AV Pivot",
-                "movepool": ["Dazzling Gleam", "Earthquake", "Foul Play", "Future Sight", "Hyper Voice", "Psychic"],
-                "teraTypes": ["Dark"]
-            }
-        ]
-    },
-    "wugtrio": {
-        "level": 90,
-        "sets": [
-            {
                 "role": "Fast Attacker",
-                "movepool": ["Aqua Jet", "Liquidation", "Memento", "Stomping Tantrum", "Sucker Punch", "Throat Chop"],
-                "teraTypes": ["Dark", "Water"]
-            }
-        ]
-    },
-    "dondozo": {
-        "level": 78,
-        "sets": [
-            {
-                "role": "Bulky Setup",
-                "movepool": ["Curse", "Rest", "Sleep Talk", "Wave Crash"],
-                "teraTypes": ["Dragon", "Fairy"]
-            }
-        ]
-    },
-    "veluza": {
-        "level": 84,
-        "sets": [
-            {
-                "role": "Fast Attacker",
-                "movepool": ["Aqua Cutter", "Aqua Jet", "Night Slash", "Psycho Cut"],
-                "teraTypes": ["Water"]
+                "movepool": ["Close Combat", "Double Shock", "Ice Punch", "Revival Blessing", "Volt Switch"],
+                "teraTypes": ["Electric"]
             },
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Aqua Cutter", "Fillet Away", "Night Slash", "Psycho Cut"],
-                "teraTypes": ["Dark", "Psychic", "Water"]
-            }
-        ]
-    },
-    "palafin": {
-        "level": 77,
-        "sets": [
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Bulk Up", "Close Combat", "Flip Turn", "Ice Punch", "Jet Punch", "Wave Crash"],
-                "teraTypes": ["Fighting", "Water"]
-            }
-        ]
-    },
-    "arboliva": {
-        "level": 90,
-        "sets": [
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Dazzling Gleam", "Earth Power", "Energy Ball", "Hyper Voice", "Strength Sap"],
-                "teraTypes": ["Fairy", "Grass", "Ground"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["Hyper Voice", "Leech Seed", "Protect", "Substitute"],
-                "teraTypes": ["Water"]
-            }
-        ]
-    },
-    "scovillain": {
-        "level": 91,
-        "sets": [
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Flamethrower", "Leech Seed", "Protect", "Substitute"],
-                "teraTypes": ["Steel", "Water"]
-            },
-            {
-                "role": "Fast Attacker",
-                "movepool": ["Energy Ball", "Flamethrower", "Leaf Storm", "Overheat"],
-                "teraTypes": ["Fire", "Grass"]
-            }
-        ]
-    },
-    "bellibolt": {
-        "level": 85,
-        "sets": [
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Muddy Water", "Slack Off", "Thunder Wave", "Thunderbolt", "Volt Switch"],
-                "teraTypes": ["Electric", "Water"]
-            }
-        ]
-    },
-    "revavroom": {
-        "level": 83,
-        "sets": [
-            {
-                "role": "Tera Blast user",
-                "movepool": ["Gunk Shot", "Iron Head", "Shift Gear", "Tera Blast"],
-                "teraTypes": ["Ground", "Water"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Gunk Shot", "Haze", "Parting Shot", "Spin Out", "Toxic", "Toxic Spikes"],
-                "teraTypes": ["Water"]
-            }
-        ]
-    },
-    "orthworm": {
-        "level": 87,
-        "sets": [
-            {
-                "role": "Bulky Setup",
-                "movepool": ["Body Press", "Coil", "Iron Tail", "Rest"],
-                "teraTypes": ["Electric", "Fighting"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["Body Press", "Iron Head", "Rest", "Shed Tail", "Spikes", "Stealth Rock"],
-                "teraTypes": ["Electric", "Poison"]
+                "role": "Fast Support",
+                "movepool": ["Close Combat", "Ice Punch", "Knock Off", "Nuzzle", "Revival Blessing", "Thunder Punch"],
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -3617,88 +4202,28 @@
             }
         ]
     },
-    "cetitan": {
-        "level": 82,
+    "dachsbun": {
+        "level": 90,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["Earthquake", "Ice Shard", "Icicle Crash", "Liquidation", "Play Rough"],
-                "teraTypes": ["Fairy", "Water"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["Belly Drum", "Earthquake", "Ice Shard", "Icicle Crash"],
-                "teraTypes": ["Ice"]
+                "role": "Bulky Support",
+                "movepool": ["Body Press", "Play Rough", "Protect", "Wish"],
+                "teraTypes": ["Steel"]
             }
         ]
     },
-    "baxcalibur": {
-        "level": 75,
+    "arboliva": {
+        "level": 90,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["Earthquake", "Glaive Rush", "Ice Shard", "Icicle Crash"],
-                "teraTypes": ["Dragon", "Ground"]
+                "role": "Bulky Attacker",
+                "movepool": ["Dazzling Gleam", "Earth Power", "Energy Ball", "Hyper Voice", "Strength Sap"],
+                "teraTypes": ["Fairy", "Grass", "Ground"]
             },
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Dragon Dance", "Earthquake", "Glaive Rush", "Icicle Crash"],
-                "teraTypes": ["Dragon", "Ground"]
-            }
-        ]
-    },
-    "tatsugiri": {
-        "level": 86,
-        "sets": [
-            {
-                "role": "Fast Support",
-                "movepool": ["Draco Meteor", "Hydro Pump", "Nasty Plot", "Rapid Spin", "Surf"],
+                "role": "Bulky Support",
+                "movepool": ["Hyper Voice", "Leech Seed", "Protect", "Substitute"],
                 "teraTypes": ["Water"]
-            }
-        ]
-    },
-    "cyclizar": {
-        "level": 83,
-        "sets": [
-            {
-                "role": "Fast Support",
-                "movepool": ["Draco Meteor", "Knock Off", "Rapid Spin", "Shed Tail", "Taunt"],
-                "teraTypes": ["Dragon", "Ghost", "Steel"]
-            }
-        ]
-    },
-    "pawmot": {
-        "level": 80,
-        "sets": [
-            {
-                "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Double Shock", "Ice Punch", "Revival Blessing", "Volt Switch"],
-                "teraTypes": ["Electric"]
-            },
-            {
-                "role": "Fast Support",
-                "movepool": ["Close Combat", "Ice Punch", "Nuzzle", "Revival Blessing", "Thunder Punch"],
-                "teraTypes": ["Fighting"]
-            }
-        ]
-    },
-    "kilowattrel": {
-        "level": 83,
-        "sets": [
-            {
-                "role": "Fast Support",
-                "movepool": ["Hurricane", "Roost", "Thunder Wave", "Thunderbolt", "U-turn"],
-                "teraTypes": ["Electric", "Flying"]
-            }
-        ]
-    },
-    "bombirdier": {
-        "level": 85,
-        "sets": [
-            {
-                "role": "Fast Attacker",
-                "movepool": ["Brave Bird", "Hone Claws", "Knock Off", "Stone Edge", "Sucker Punch", "U-turn"],
-                "teraTypes": ["Rock"]
             }
         ]
     },
@@ -3742,31 +4267,6 @@
             }
         ]
     },
-    "flamigo": {
-        "level": 83,
-        "sets": [
-            {
-                "role": "Fast Attacker",
-                "movepool": ["Brave Bird", "Close Combat", "Swords Dance", "Throat Chop", "U-turn"],
-                "teraTypes": ["Fighting"]
-            }
-        ]
-    },
-    "klawf": {
-        "level": 90,
-        "sets": [
-            {
-                "role": "Fast Attacker",
-                "movepool": ["Crabhammer", "High Horsepower", "Knock Off", "Stealth Rock", "Stone Edge"],
-                "teraTypes": ["Dark", "Ground", "Rock", "Water"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["Crabhammer", "High Horsepower", "Knock Off", "Stone Edge", "Swords Dance"],
-                "teraTypes": ["Dark", "Ground", "Rock", "Water"]
-            }
-        ]
-    },
     "garganacl": {
         "level": 81,
         "sets": [
@@ -3787,13 +4287,53 @@
             }
         ]
     },
-    "glimmora": {
-        "level": 77,
+    "armarouge": {
+        "level": 81,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Armor Cannon", "Aura Sphere", "Energy Ball", "Focus Blast", "Psyshock"],
+                "teraTypes": ["Fighting", "Fire", "Grass", "Psychic"]
+            }
+        ]
+    },
+    "ceruledge": {
+        "level": 78,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Bitter Blade", "Close Combat", "Poltergeist", "Shadow Sneak", "Swords Dance"],
+                "teraTypes": ["Fighting", "Fire", "Ghost"]
+            }
+        ]
+    },
+    "bellibolt": {
+        "level": 85,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Muddy Water", "Slack Off", "Thunderbolt", "Toxic", "Volt Switch"],
+                "teraTypes": ["Electric", "Water"]
+            }
+        ]
+    },
+    "kilowattrel": {
+        "level": 83,
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Earth Power", "Energy Ball", "Mortal Spin", "Power Gem", "Sludge Wave", "Spikes", "Stealth Rock", "Toxic"],
-                "teraTypes": ["Ground"]
+                "movepool": ["Hurricane", "Roost", "Thunder Wave", "Thunderbolt", "U-turn"],
+                "teraTypes": ["Electric", "Flying"]
+            }
+        ]
+    },
+    "mabosstiff": {
+        "level": 85,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Crunch", "Fire Fang", "Play Rough", "Psychic Fangs", "Wild Charge"],
+                "teraTypes": ["Dark", "Fairy"]
             }
         ]
     },
@@ -3817,53 +4357,308 @@
             }
         ]
     },
-    "dachsbun": {
-        "level": 90,
-        "sets": [
-            {
-                "role": "Bulky Support",
-                "movepool": ["Body Press", "Play Rough", "Protect", "Wish"],
-                "teraTypes": ["Steel"]
-            }
-        ]
-    },
-    "mabosstiff": {
-        "level": 85,
-        "sets": [
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Crunch", "Fire Fang", "Play Rough", "Psychic Fangs", "Wild Charge"],
-                "teraTypes": ["Dark", "Fairy"]
-            }
-        ]
-    },
     "brambleghast": {
         "level": 88,
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Power Whip", "Rapid Spin", "Shadow Sneak", "Spikes", "Strength Sap"],
+                "movepool": ["Poltergeist", "Power Whip", "Rapid Spin", "Spikes", "Strength Sap"],
                 "teraTypes": ["Fairy", "Steel", "Water"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Leech Seed", "Phantom Force", "Power Whip", "Substitute"],
+                "movepool": ["Leech Seed", "Poltergeist", "Power Whip", "Substitute"],
                 "teraTypes": ["Fairy", "Steel", "Water"]
             }
         ]
     },
-    "gholdengo": {
-        "level": 77,
+    "toedscruel": {
+        "level": 86,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earth Power", "Giga Drain", "Knock Off", "Leaf Storm", "Rapid Spin", "Spore", "Toxic"],
+                "teraTypes": ["Water"]
+            }
+        ]
+    },
+    "klawf": {
+        "level": 90,
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Focus Blast", "Make It Rain", "Nasty Plot", "Recover", "Shadow Ball", "Trick"],
-                "teraTypes": ["Ghost", "Steel"]
+                "movepool": ["Crabhammer", "High Horsepower", "Knock Off", "Stealth Rock", "Stone Edge"],
+                "teraTypes": ["Dark", "Ground", "Rock", "Water"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Crabhammer", "High Horsepower", "Knock Off", "Stone Edge", "Swords Dance"],
+                "teraTypes": ["Dark", "Ground", "Rock", "Water"]
+            }
+        ]
+    },
+    "scovillain": {
+        "level": 91,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Flamethrower", "Leech Seed", "Protect", "Substitute"],
+                "teraTypes": ["Steel", "Water"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Energy Ball", "Flamethrower", "Leaf Storm", "Overheat"],
+                "teraTypes": ["Fire", "Grass"]
+            }
+        ]
+    },
+    "rabsca": {
+        "level": 90,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Bug Buzz", "Earth Power", "Psychic", "Revival Blessing", "Trick Room"],
+                "teraTypes": ["Steel"]
+            }
+        ]
+    },
+    "espathra": {
+        "level": 80,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Dazzling Gleam", "Lumina Crash", "Shadow Ball", "U-turn"],
+                "teraTypes": ["Fairy", "Ghost", "Psychic"]
+            },
+            {
+                "role": "Fast Bulky Setup",
+                "movepool": ["Calm Mind", "Dazzling Gleam", "Protect", "Roost", "Stored Power", "Substitute"],
+                "teraTypes": ["Fairy"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Dazzling Gleam", "Lumina Crash", "Roost", "Tera Blast"],
+                "teraTypes": ["Fighting", "Fire"]
+            }
+        ]
+    },
+    "tinkaton": {
+        "level": 82,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Encore", "Gigaton Hammer", "Knock Off", "Play Rough", "Stealth Rock", "Thunder Wave"],
+                "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Gigaton Hammer", "Knock Off", "Play Rough", "Swords Dance"],
+                "teraTypes": ["Steel"]
+            }
+        ]
+    },
+    "wugtrio": {
+        "level": 90,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Aqua Jet", "Liquidation", "Memento", "Stomping Tantrum", "Sucker Punch", "Throat Chop"],
+                "teraTypes": ["Dark", "Water"]
+            }
+        ]
+    },
+    "bombirdier": {
+        "level": 85,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Brave Bird", "Hone Claws", "Knock Off", "Stone Edge", "Sucker Punch", "U-turn"],
+                "teraTypes": ["Rock"]
+            }
+        ]
+    },
+    "palafin": {
+        "level": 77,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Bulk Up", "Close Combat", "Flip Turn", "Ice Punch", "Jet Punch", "Wave Crash"],
+                "teraTypes": ["Fighting", "Water"]
+            }
+        ]
+    },
+    "revavroom": {
+        "level": 83,
+        "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Gunk Shot", "High Horsepower", "Iron Head", "Shift Gear"],
+                "teraTypes": ["Ground"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Make It Rain", "Recover", "Shadow Ball", "Thunder Wave"],
-                "teraTypes": ["Dark", "Steel", "Water"]
+                "movepool": ["Gunk Shot", "Haze", "Parting Shot", "Spin Out", "Toxic", "Toxic Spikes"],
+                "teraTypes": ["Water"]
+            }
+        ]
+    },
+    "cyclizar": {
+        "level": 83,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Draco Meteor", "Knock Off", "Rapid Spin", "Shed Tail", "Taunt"],
+                "teraTypes": ["Dragon", "Ghost", "Steel"]
+            }
+        ]
+    },
+    "orthworm": {
+        "level": 87,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Press", "Coil", "Iron Tail", "Rest"],
+                "teraTypes": ["Electric", "Fighting"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Body Press", "Iron Head", "Rest", "Shed Tail", "Spikes", "Stealth Rock"],
+                "teraTypes": ["Electric", "Poison"]
+            }
+        ]
+    },
+    "glimmora": {
+        "level": 77,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Earth Power", "Energy Ball", "Mortal Spin", "Power Gem", "Sludge Wave", "Spikes", "Stealth Rock", "Toxic"],
+                "teraTypes": ["Ground"]
+            }
+        ]
+    },
+    "houndstone": {
+        "level": 73,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Press", "Last Respects", "Trick", "Will-O-Wisp"],
+                "teraTypes": ["Ghost"]
+            }
+        ]
+    },
+    "flamigo": {
+        "level": 83,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Brave Bird", "Close Combat", "Swords Dance", "Throat Chop", "U-turn"],
+                "teraTypes": ["Fighting"]
+            }
+        ]
+    },
+    "cetitan": {
+        "level": 82,
+        "sets": [
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Earthquake", "Ice Shard", "Icicle Crash", "Liquidation", "Play Rough"],
+                "teraTypes": ["Fairy", "Water"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Belly Drum", "Earthquake", "Ice Shard", "Icicle Crash"],
+                "teraTypes": ["Ice"]
+            }
+        ]
+    },
+    "veluza": {
+        "level": 84,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Aqua Cutter", "Aqua Jet", "Flip Turn", "Night Slash", "Psycho Cut"],
+                "teraTypes": ["Water"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Aqua Cutter", "Fillet Away", "Night Slash", "Psycho Cut"],
+                "teraTypes": ["Dark", "Psychic", "Water"]
+            }
+        ]
+    },
+    "dondozo": {
+        "level": 78,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Curse", "Rest", "Sleep Talk", "Wave Crash"],
+                "teraTypes": ["Dragon", "Fairy"]
+            }
+        ]
+    },
+    "tatsugiri": {
+        "level": 86,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Draco Meteor", "Hydro Pump", "Nasty Plot", "Rapid Spin", "Surf"],
+                "teraTypes": ["Water"]
+            }
+        ]
+    },
+    "farigiraf": {
+        "level": 90,
+        "sets": [
+            {
+                "role": "Bulky Support",
+                "movepool": ["Foul Play", "Hyper Voice", "Protect", "Wish"],
+                "teraTypes": ["Dark"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Future Sight", "Hyper Voice", "Protect", "Wish"],
+                "teraTypes": ["Fairy", "Ground", "Water"]
+            }
+        ]
+    },
+    "dudunsparce": {
+        "level": 82,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earthquake", "Glare", "Headbutt", "Roost"],
+                "teraTypes": ["Ghost", "Ground"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Boomburst", "Calm Mind", "Earth Power", "Roost", "Shadow Ball"],
+                "teraTypes": ["Ghost"]
+            }
+        ]
+    },
+    "dudunsparcethreesegment": {
+        "level": 82,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earthquake", "Glare", "Headbutt", "Roost"],
+                "teraTypes": ["Ghost", "Ground"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Boomburst", "Calm Mind", "Earth Power", "Roost", "Shadow Ball"],
+                "teraTypes": ["Ghost"]
+            }
+        ]
+    },
+    "kingambit": {
+        "level": 74,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Iron Head", "Kowtow Cleave", "Sucker Punch", "Swords Dance"],
+                "teraTypes": ["Dark", "Flying"]
             }
         ]
     },
@@ -3942,12 +4737,12 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Crunch", "Dragon Dance", "Earthquake", "Iron Head", "Outrage", "Roost"],
+                "movepool": ["Dragon Dance", "Earthquake", "Iron Head", "Knock Off", "Outrage", "Roost"],
                 "teraTypes": ["Dark", "Dragon", "Ground", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Crunch", "Iron Head", "Outrage", "U-turn"],
+                "movepool": ["Iron Head", "Knock Off", "Outrage", "U-turn"],
                 "teraTypes": ["Dark", "Dragon", "Steel"]
             }
         ]
@@ -4072,6 +4867,41 @@
             }
         ]
     },
+    "baxcalibur": {
+        "level": 75,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Earthquake", "Glaive Rush", "Ice Shard", "Icicle Crash"],
+                "teraTypes": ["Dragon", "Ground"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dragon Dance", "Earthquake", "Glaive Rush", "Icicle Crash"],
+                "teraTypes": ["Dragon", "Ground"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Earthquake", "Icicle Spear", "Scale Shot", "Swords Dance"],
+                "teraTypes": ["Dragon", "Ground"]
+            }
+        ]
+    },
+    "gholdengo": {
+        "level": 77,
+        "sets": [
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Focus Blast", "Make It Rain", "Nasty Plot", "Recover", "Shadow Ball", "Trick"],
+                "teraTypes": ["Ghost", "Steel"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Make It Rain", "Recover", "Shadow Ball", "Thunder Wave"],
+                "teraTypes": ["Dark", "Steel", "Water"]
+            }
+        ]
+    },
     "tinglu": {
         "level": 78,
         "sets": [
@@ -4147,58 +4977,118 @@
             }
         ]
     },
-    "tinkaton": {
-        "level": 82,
+    "dipplin": {
+        "level": 92,
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Encore", "Gigaton Hammer", "Knock Off", "Play Rough", "Stealth Rock", "Thunder Wave"],
-                "teraTypes": ["Steel"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["Gigaton Hammer", "Knock Off", "Play Rough", "Swords Dance"],
+                "movepool": ["Draco Meteor", "Dragon Tail", "Giga Drain", "Leaf Storm", "Recover", "Sucker Punch"],
                 "teraTypes": ["Steel"]
             }
         ]
     },
-    "armarouge": {
-        "level": 81,
+    "sinistcha": {
+        "level": 84,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["Armor Cannon", "Aura Sphere", "Energy Ball", "Focus Blast", "Psyshock"],
-                "teraTypes": ["Fighting", "Fire", "Grass", "Psychic"]
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Matcha Gotcha", "Shadow Ball", "Strength Sap"],
+                "teraTypes": ["Steel"]
             }
         ]
     },
-    "ceruledge": {
+    "okidogi": {
+        "level": 80,
+        "sets": [
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bulk Up", "Drain Punch", "Gunk Shot", "Knock Off"],
+                "teraTypes": ["Dark"]
+            }
+        ]
+    },
+    "munkidori": {
         "level": 78,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Bitter Blade", "Close Combat", "Shadow Sneak", "Swords Dance"],
-                "teraTypes": ["Fighting", "Fire"]
+                "role": "Fast Attacker",
+                "movepool": ["Focus Blast", "Nasty Plot", "Psyshock", "Sludge Wave", "U-turn"],
+                "teraTypes": ["Fighting", "Poison"]
             }
         ]
     },
-    "toedscruel": {
-        "level": 86,
+    "fezandipiti": {
+        "level": 80,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Earth Power", "Giga Drain", "Knock Off", "Leaf Storm", "Rapid Spin", "Spore", "Toxic"],
+                "role": "AV Pivot",
+                "movepool": ["Brave Bird", "Gunk Shot", "Heat Wave", "Play Rough", "U-turn"],
+                "teraTypes": ["Flying", "Ground"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Gunk Shot", "Play Rough", "Swords Dance", "Tera Blast"],
+                "teraTypes": ["Ground"]
+            }
+        ]
+    },
+    "ogerpon": {
+        "level": 80,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Ivy Cudgel", "Knock Off", "Spikes", "Superpower", "Synthesis", "U-turn"],
+                "teraTypes": ["Grass"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Knock Off", "Superpower", "U-turn", "Wood Hammer"],
+                "teraTypes": ["Grass"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Ivy Cudgel", "Knock Off", "Superpower", "Swords Dance"],
+                "teraTypes": ["Grass"]
+            }
+        ]
+    },
+    "ogerponwellspring": {
+        "level": 80,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Encore", "Ivy Cudgel", "Spikes", "Synthesis", "U-turn", "Wood Hammer"],
+                "teraTypes": ["Water"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Ivy Cudgel", "Knock Off", "Play Rough", "Swords Dance", "Wood Hammer"],
                 "teraTypes": ["Water"]
             }
         ]
     },
-    "kingambit": {
-        "level": 74,
+    "ogerponhearthflame": {
+        "level": 80,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Iron Head", "Kowtow Cleave", "Sucker Punch", "Swords Dance"],
-                "teraTypes": ["Dark", "Flying"]
+                "role": "Setup Sweeper",
+                "movepool": ["Ivy Cudgel", "Knock Off", "Stomping Tantrum", "Swords Dance", "Wood Hammer"],
+                "teraTypes": ["Fire"]
+            }
+        ]
+    },
+    "ogerponcornerstone": {
+        "level": 80,
+        "sets": [
+            {
+                "role": "Fast Support",
+                "movepool": ["Encore", "Ivy Cudgel", "Spikes", "Superpower", "Synthesis", "Wood Hammer"],
+                "teraTypes": ["Rock"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Ivy Cudgel", "Superpower", "Swrods Dance", "Wood Hammer"],
+                "teraTypes": ["Rock"]
             }
         ]
     }

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -285,7 +285,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Earthquake", "Explosion", "Rock Polish", "Stone Edge"],
-                "teraTypes": ["Grass", "Steel", "Ground"]
+                "teraTypes": ["Grass", "Ground", "Steel"]
             },
             {
                 "role": "Bulky Attacker",

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -464,7 +464,7 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["Close Combat", "Dual Wingbeat", "Defog", "U-turn"],
+                "movepool": ["Close Combat", "Defog", "Dual Wingbeat", "U-turn"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4978,7 +4978,7 @@
         ]
     },
     "dipplin": {
-        "level": 92,
+        "level": 86,
         "sets": [
             {
                 "role": "Bulky Attacker",

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1096,7 +1096,7 @@ export class RandomTeams {
 			if (abilities.has('Iron Fist') && counter.ironFist >= 2) return true;
 			return (this.dex.getEffectiveness('Electric', species) < -1);
 		case 'Water Absorb':
-			return species.id === 'quagsire';
+			return (species.id === 'quagsire' || moves.has('raindance'));
 		case 'Weak Armor':
 			return (moves.has('shellsmash') && species.id !== 'magcargo');
 		}
@@ -1277,7 +1277,6 @@ export class RandomTeams {
 			return (types.includes('Fire') || ability === 'Toxic Boost') ? 'Toxic Orb' : 'Flame Orb';
 		}
 		if (
-			(ability === 'Magic Guard' && counter.damagingMoves.size > 1) ||
 			(ability === 'Sheer Force' && counter.get('sheerforce'))
 		) {
 			return 'Life Orb';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -88,8 +88,8 @@ const SPEED_CONTROL = [
 // Moves that shouldn't be the only STAB moves:
 const NO_STAB = [
 	'accelerock', 'aquajet', 'beakblast', 'bounce', 'breakingswipe', 'bulletpunch', 'chatter', 'chloroblast', 'clearsmog', 'covet',
-	'dragontail', 'electroweb', 'eruption', 'explosion', 'fakeout', 'feint', 'flamecharge', 'flipturn', 'iceshard', 'icywind', 'incinerate',
-	'machpunch', 'meteorbeam', 'mortalspin', 'nuzzle', 'pluck', 'pursuit', 'quickattack', 'rapidspin', 'reversal', 'selfdestruct',
+	'dragontail', 'electroweb', 'eruption', 'explosion', 'fakeout', 'feint', 'flamecharge', 'flipturn', 'grassyglide', 'iceshard', 'icywind',
+	'incinerate', 'machpunch', 'meteorbeam', 'mortalspin', 'nuzzle', 'pluck', 'pursuit', 'quickattack', 'rapidspin', 'reversal', 'selfdestruct',
 	'shadowsneak', 'skydrop', 'snarl', 'strugglebug', 'suckerpunch', 'uturn', 'watershuriken', 'vacuumwave', 'voltswitch', 'waterspout',
 ];
 // Hazard-setting moves
@@ -115,7 +115,7 @@ const MOVE_PAIRS = [
 
 /** Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type */
 const PRIORITY_POKEMON = [
-	'banette', 'breloom', 'brutebonnet', 'cacturne', 'ceruledge', 'honchkrow', 'lycanrocdusk', 'mimikyu', 'scizor',
+	'breloom', 'brutebonnet', 'honchkrow', 'lycanrocdusk', 'mimikyu', 'scizor',
 ];
 
 /** Pokemon who should never be in the lead slot */
@@ -522,14 +522,15 @@ export class RandomTeams {
 			[SPEED_SETUP, ['aquajet', 'rest', 'trickroom']],
 			['curse', 'rapidspin'],
 			['dragondance', 'dracometeor'],
-			['healingwish', 'uturn'],
 
 			// These attacks are redundant with each other
 			['psychic', 'psyshock'],
 			['surf', 'hydropump'],
+			['flipturn', 'aquajet'],
 			['liquidation', 'wavecrash'],
+			['gigadrain', 'leafstorm'],
 			[['airslash', 'bravebird', 'hurricane'], ['airslash', 'bravebird', 'hurricane']],
-			[['knockoff', 'bite'], 'foulplay'],
+			['knockoff', 'foulplay'],
 			['doubleedge', 'headbutt'],
 			['fireblast', ['fierydance', 'flamethrower']],
 			['lavaplume', 'magmastorm'],
@@ -543,13 +544,13 @@ export class RandomTeams {
 
 			// These status moves are redundant with each other
 			['taunt', 'disable'],
-			['toxic', 'willowisp'],
+			['toxic', ['willowisp', 'thunderwave']],
 			[['thunderwave', 'toxic', 'willowisp'], 'toxicspikes'],
 			['thunderwave', 'yawn'],
 
 			// This space reserved for assorted hardcodes that otherwise make little sense out of context
-			// Landorus
-			['nastyplot', 'rockslide'],
+			// Landorus and Thundurus
+			['nastyplot', ['rockslide', 'knockoff']],
 			// Persian
 			['switcheroo', 'fakeout'],
 			// Beartic
@@ -560,6 +561,10 @@ export class RandomTeams {
 			['toxic', 'clearsmog'],
 			// Chansey and Blissey
 			['healbell', 'stealthrock'],
+			// Mesprit
+			['healingwish', 'uturn'],
+			// Azelf
+			['trick', 'uturn'],
 		];
 
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
@@ -568,11 +573,13 @@ export class RandomTeams {
 
 		if (!isDoubles) this.incompatibleMoves(moves, movePool, ['taunt', 'strengthsap'], 'encore');
 
+		if (!types.includes('Dark') && teraType !== 'Dark') this.incompatibleMoves(moves, movePool, 'knockoff', 'suckerpunch')
+
 		// This space reserved for assorted hardcodes that otherwise make little sense out of context
 		if (species.id === "dugtrio") this.incompatibleMoves(moves, movePool, statusMoves, 'memento');
 		if (species.id === "cyclizar") this.incompatibleMoves(moves, movePool, 'taunt', 'knockoff');
 		if (species.baseSpecies === 'Dudunsparce') this.incompatibleMoves(moves, movePool, 'earthpower', 'shadowball');
-		if (species.id === 'luvdisc' && !isDoubles) this.incompatibleMoves(moves, movePool, 'charm', ['icebeam', 'icywind']);
+		if (species.id === 'jirachi') this.incompatibleMoves(moves, movePool, 'bodyslam', 'healingwish');
 	}
 
 	// Checks for and removes incompatible moves, starting with the first move in movesA.
@@ -635,6 +642,12 @@ export class RandomTeams {
 			if (species.name.endsWith("Combat")) return "Fighting";
 			if (species.name.endsWith("Blaze")) return "Fire";
 			if (species.name.endsWith("Aqua")) return "Water";
+		}
+
+		if (move.name === "Ivy Cudgel" && species.name.startsWith("Ogerpon")) {
+			if (species.name.endsWith("Wellspring")) return "Water";
+			if (species.name.endsWith("Hearthflame")) return "Fire";
+			if (species.name.endsWith("Cornerstone")) return "Rock";
 		}
 
 		const moveType = move.type;
@@ -772,7 +785,7 @@ export class RandomTeams {
 		}
 
 		// Enforce STAB priority
-		if (['Bulky Attacker', 'Bulky Setup', 'Doubles Wallbreaker'].includes(role) || PRIORITY_POKEMON.includes(species.id)) {
+		if (['Bulky Attacker', 'Bulky Setup', 'Wallbreaker', 'Doubles Wallbreaker'].includes(role) || PRIORITY_POKEMON.includes(species.id)) {
 			const priorityMoves = [];
 			for (const moveid of movePool) {
 				const move = this.dex.moves.get(moveid);
@@ -975,7 +988,8 @@ export class RandomTeams {
 	): boolean {
 		if ([
 			'Armor Tail', 'Battle Bond', 'Early Bird', 'Flare Boost', 'Gluttony', 'Harvest', 'Hydration', 'Ice Body', 'Immunity',
-			'Moody', 'Own Tempo', 'Pressure', 'Quick Feet', 'Rain Dish', 'Sand Veil', 'Snow Cloak', 'Steadfast', 'Steam Engine',
+			'Marvel Scale', 'Moody', 'Neutralizing Gas', 'Own Tempo', 'Pressure', 'Quick Feet', 'Rain Dish', 'Sand Veil', 'Snow Cloak',
+			'Steadfast', 'Steam Engine',
 		].includes(ability)) return true;
 
 		switch (ability) {
@@ -994,6 +1008,8 @@ export class RandomTeams {
 			return abilities.has('Infiltrator');
 		case 'Defiant':
 			return (!counter.get('Physical') || (abilities.has('Prankster') && (moves.has('thunderwave') || moves.has('taunt'))));
+		case 'Flame Body':
+			return (species.id === 'magcargo' && role === 'Setup Sweeper')
 		case 'Flash Fire':
 			return (
 				['Flame Body', 'Intimidate', 'Rock Head', 'Weak Armor'].some(m => abilities.has(m)) &&
@@ -1029,6 +1045,8 @@ export class RandomTeams {
 			return !counter.get('Status');
 		case 'Reckless':
 			return !counter.get('recoil');
+		case 'Regenerator':
+			return (species.id === 'mienshao' && role === 'Fast Attacker');
 		case 'Rock Head':
 			return !counter.get('recoil');
 		case 'Sand Force': case 'Sand Rush':
@@ -1049,6 +1067,8 @@ export class RandomTeams {
 			return abilities.has('Torrent');
 		case 'Solar Power':
 			return (!teamDetails.sun || !counter.get('Special'));
+		case 'Speed Boost':
+			return (species.id === 'yanmega' && role === 'Wallbreaker');
 		case 'Sturdy':
 			return !!counter.get('recoil');
 		case 'Swarm':
@@ -1062,7 +1082,11 @@ export class RandomTeams {
 		case 'Technician':
 			return (!counter.get('technician') || abilities.has('Punk Rock') || abilities.has('Fur Coat'));
 		case 'Tinted Lens':
-			return (species.id === 'braviaryhisui' && (role === 'Setup Sweeper' || role === 'Doubles Wallbreaker'));
+			const hbraviaryCase = (species.id === 'braviaryhisui' && (role === 'Setup Sweeper' || role === 'Doubles Wallbreaker'));
+			const yanmegaCase = (species.id === 'yanmega' && role === 'Tera Blast user')
+			return (yanmegaCase || hbraviaryCase);
+		case 'Unaware':
+			return (species.id === 'clefable' && role !== 'Bulky Support');
 		case 'Unburden':
 			return (abilities.has('Prankster') || !counter.get('setup'));
 		case 'Volt Absorb':
@@ -1071,7 +1095,7 @@ export class RandomTeams {
 		case 'Water Absorb':
 			return species.id === 'quagsire';
 		case 'Weak Armor':
-			return moves.has('shellsmash');
+			return (moves.has('shellsmash') && species.id !== 'magcargo');
 		}
 
 		return false;
@@ -1098,9 +1122,10 @@ export class RandomTeams {
 		// Hard-code abilities here
 		if (species.id === 'arcaninehisui') return 'Rock Head';
 		if (species.id === 'scovillain') return 'Chlorophyll';
-		if (abilities.has('Guts') && (moves.has('facade') || moves.has('sleeptalk'))) return 'Guts';
+		if (abilities.has('Guts') && (moves.has('facade') || moves.has('sleeptalk') || species.id === 'gurdurr')) return 'Guts';
 		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';
 		if (species.id === 'breloom') return 'Technician';
+		if (species.id === 'shiftry' && moves.has('tailwind')) return 'Wind Rider';
 
 		if (!isDoubles) {
 			if (species.id === 'hypno') return 'Insomnia';
@@ -1108,12 +1133,14 @@ export class RandomTeams {
 			if (species.id === 'vespiquen') return 'Pressure';
 			if (species.id === 'enamorus' && moves.has('calmmind')) return 'Cute Charm';
 			if (species.id === 'klawf' && role === 'Setup Sweeper') return 'Anger Shell';
+			if (species.id === 'copperajah' && role === 'Bulky Attacker') return 'Heavy Metal';
 			if (abilities.has('Cud Chew') && moves.has('substitute')) return 'Cud Chew';
 			if (abilities.has('Harvest') && moves.has('substitute')) return 'Harvest';
 			if (abilities.has('Serene Grace') && moves.has('headbutt')) return 'Serene Grace';
 			if (abilities.has('Own Tempo') && moves.has('petaldance')) return 'Own Tempo';
 			if (abilities.has('Slush Rush') && moves.has('snowscape')) return 'Slush Rush';
-			if (abilities.has('Soundproof') && moves.has('substitute')) return 'Soundproof';
+			if (abilities.has('Soundproof') && (moves.has('substitute') || moves.has('clangoroussoul'))) return 'Soundproof';
+			
 		}
 
 		if (isDoubles) {
@@ -1220,7 +1247,7 @@ export class RandomTeams {
 		if (role === 'AV Pivot') return 'Assault Vest';
 		if (species.id === 'pikachu') return 'Light Ball';
 		if (species.id === 'regieleki') return 'Magnet';
-		if (species.id === 'toxtricity' && moves.has('shiftgear')) return 'Throat Spray';
+		if (moves.has('clangoroussoul') || (species.id === 'toxtricity' && moves.has('shiftgear'))) return 'Throat Spray';
 		if (species.baseSpecies === 'Magearna' && role === 'Tera Blast user') return 'Weakness Policy';
 		if (moves.has('lastrespects')) return 'Choice Scarf';
 		if (
@@ -1256,6 +1283,7 @@ export class RandomTeams {
 		if (ability === 'Anger Shell') return this.sample(['Rindo Berry', 'Passho Berry', 'Scope Lens', 'Sitrus Berry']);
 		if (moves.has('courtchange')) return 'Heavy-Duty Boots';
 		if (moves.has('populationbomb')) return 'Wide Lens';
+		if (moves.has('scaleshot')) return 'Loaded Dice';
 		if (moves.has('stuffcheeks')) return this.randomChance(1, 2) ? 'Liechi Berry' : 'Salac Berry';
 		if (ability === 'Unburden') return moves.has('closecombat') ? 'White Herb' : 'Sitrus Berry';
 		if (moves.has('shellsmash')) return 'White Herb';
@@ -1267,6 +1295,7 @@ export class RandomTeams {
 		) {
 			return 'Chesto Berry';
 		}
+		if (ability === 'Poison Heal') return 'Toxic Orb';
 		if (species.id === 'scyther') return (isLead && !moves.has('uturn')) ? 'Eviolite' : 'Heavy-Duty Boots';
 		if (species.nfe) return 'Eviolite';
 		if (
@@ -1365,7 +1394,7 @@ export class RandomTeams {
 		role: RandomTeamsTypes.Role,
 	): string {
 		if (
-			(counter.get('Physical') >= 4 ||
+			species.id !== 'jirachi' && (counter.get('Physical') >= 4 ||
 			(counter.get('Physical') >= 3 && moves.has('memento'))) &&
 			['fakeout', 'firstimpression', 'flamecharge', 'rapidspin', 'ruination', 'superfang'].every(m => !moves.has(m))
 		) {
@@ -1392,7 +1421,7 @@ export class RandomTeams {
 		if (!counter.get('Status') && !['Fast Attacker', 'Wallbreaker', 'Tera Blast user'].includes(role)) {
 			return 'Assault Vest';
 		}
-		if (counter.get('speedsetup') && this.dex.getEffectiveness('Ground', species) < 1) return 'Weakness Policy';
+		if (counter.get('speedsetup') && role === 'Bulky Setup') return 'Weakness Policy';
 		if (species.id === 'urshifurapidstrike') return 'Punching Glove';
 		if (species.id === 'palkia') return 'Lustrous Orb';
 		if (moves.has('substitute') || ability === 'Moody') return 'Leftovers';
@@ -1423,7 +1452,7 @@ export class RandomTeams {
 			(species.baseStats.hp + species.baseStats.def + species.baseStats.spd) < 258
 		) return 'Focus Sash';
 		if (
-			role !== 'Fast Attacker' && role !== 'Tera Blast user' && ability !== 'Levitate' &&
+			!['Fast Attacker', 'Wallbreaker', 'Tera Blast user'].includes(role) && ability !== 'Levitate' &&
 			this.dex.getEffectiveness('Ground', species) >= 2
 		) return 'Air Balloon';
 		if (['Bulky Attacker', 'Bulky Support', 'Bulky Setup'].some(m => role === (m))) return 'Leftovers';
@@ -1574,7 +1603,7 @@ export class RandomTeams {
 			ivs.atk = 0;
 		}
 
-		if (moves.has('gyroball') || moves.has('trickroom')) {
+		if (moves.has('gyroball') || moves.has('trickroom') || (moves.has('flipturn') && moves.has('wish') && moves.has('scald'))) {
 			evs.spe = 0;
 			ivs.spe = 0;
 		}

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1129,6 +1129,7 @@ export class RandomTeams {
 		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';
 		if (species.id === 'breloom') return 'Technician';
 		if (species.id === 'shiftry' && moves.has('tailwind')) return 'Wind Rider';
+		if (species.id === 'dipplin') return 'Sticky Hold';
 
 		if (!isDoubles) {
 			if (species.id === 'hypno') return 'Insomnia';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -526,7 +526,6 @@ export class RandomTeams {
 			// These attacks are redundant with each other
 			['psychic', 'psyshock'],
 			['surf', 'hydropump'],
-			['flipturn', 'aquajet'],
 			['liquidation', 'wavecrash'],
 			['gigadrain', 'leafstorm'],
 			[['airslash', 'bravebird', 'hurricane'], ['airslash', 'bravebird', 'hurricane']],
@@ -580,6 +579,7 @@ export class RandomTeams {
 		if (species.id === "cyclizar") this.incompatibleMoves(moves, movePool, 'taunt', 'knockoff');
 		if (species.baseSpecies === 'Dudunsparce') this.incompatibleMoves(moves, movePool, 'earthpower', 'shadowball');
 		if (species.id === 'jirachi') this.incompatibleMoves(moves, movePool, 'bodyslam', 'healingwish');
+		if (species.baseSpecies !== 'basculin') this.incompatibleMoves(moves, movePool, 'aquajet', 'flipturn');
 	}
 
 	// Checks for and removes incompatible moves, starting with the first move in movesA.
@@ -1298,7 +1298,7 @@ export class RandomTeams {
 		}
 		if (ability === 'Poison Heal') return 'Toxic Orb';
 		if (species.id === 'scyther') return (isLead && !moves.has('uturn')) ? 'Eviolite' : 'Heavy-Duty Boots';
-		if (species.nfe) return 'Eviolite';
+		if (species.nfe || species.id === 'dipplin') return 'Eviolite';
 		if (
 			this.dex.getEffectiveness('Rock', species) >= 2 && (!types.includes('Flying') || !isDoubles)
 		) return 'Heavy-Duty Boots';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -573,7 +573,7 @@ export class RandomTeams {
 
 		if (!isDoubles) this.incompatibleMoves(moves, movePool, ['taunt', 'strengthsap'], 'encore');
 
-		if (!types.includes('Dark') && teraType !== 'Dark') this.incompatibleMoves(moves, movePool, 'knockoff', 'suckerpunch')
+		if (!types.includes('Dark') && teraType !== 'Dark') this.incompatibleMoves(moves, movePool, 'knockoff', 'suckerpunch');
 
 		// This space reserved for assorted hardcodes that otherwise make little sense out of context
 		if (species.id === "dugtrio") this.incompatibleMoves(moves, movePool, statusMoves, 'memento');
@@ -785,7 +785,10 @@ export class RandomTeams {
 		}
 
 		// Enforce STAB priority
-		if (['Bulky Attacker', 'Bulky Setup', 'Wallbreaker', 'Doubles Wallbreaker'].includes(role) || PRIORITY_POKEMON.includes(species.id)) {
+		if (
+			['Bulky Attacker', 'Bulky Setup', 'Wallbreaker', 'Doubles Wallbreaker'].includes(role) ||
+			PRIORITY_POKEMON.includes(species.id)
+		) {
 			const priorityMoves = [];
 			for (const moveid of movePool) {
 				const move = this.dex.moves.get(moveid);
@@ -1009,7 +1012,7 @@ export class RandomTeams {
 		case 'Defiant':
 			return (!counter.get('Physical') || (abilities.has('Prankster') && (moves.has('thunderwave') || moves.has('taunt'))));
 		case 'Flame Body':
-			return (species.id === 'magcargo' && role === 'Setup Sweeper')
+			return (species.id === 'magcargo' && role === 'Setup Sweeper');
 		case 'Flash Fire':
 			return (
 				['Flame Body', 'Intimidate', 'Rock Head', 'Weak Armor'].some(m => abilities.has(m)) &&
@@ -1083,7 +1086,7 @@ export class RandomTeams {
 			return (!counter.get('technician') || abilities.has('Punk Rock') || abilities.has('Fur Coat'));
 		case 'Tinted Lens':
 			const hbraviaryCase = (species.id === 'braviaryhisui' && (role === 'Setup Sweeper' || role === 'Doubles Wallbreaker'));
-			const yanmegaCase = (species.id === 'yanmega' && role === 'Tera Blast user')
+			const yanmegaCase = (species.id === 'yanmega' && role === 'Tera Blast user');
 			return (yanmegaCase || hbraviaryCase);
 		case 'Unaware':
 			return (species.id === 'clefable' && role !== 'Bulky Support');
@@ -1140,7 +1143,6 @@ export class RandomTeams {
 			if (abilities.has('Own Tempo') && moves.has('petaldance')) return 'Own Tempo';
 			if (abilities.has('Slush Rush') && moves.has('snowscape')) return 'Slush Rush';
 			if (abilities.has('Soundproof') && (moves.has('substitute') || moves.has('clangoroussoul'))) return 'Soundproof';
-			
 		}
 
 		if (isDoubles) {
@@ -1603,7 +1605,9 @@ export class RandomTeams {
 			ivs.atk = 0;
 		}
 
-		if (moves.has('gyroball') || moves.has('trickroom') || (moves.has('flipturn') && moves.has('wish') && moves.has('scald'))) {
+		if (
+			moves.has('gyroball') || moves.has('trickroom') || (moves.has('flipturn') && moves.has('wish') && moves.has('scald'))
+		) {
 			evs.spe = 0;
 			ivs.spe = 0;
 		}

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -579,7 +579,7 @@ export class RandomTeams {
 		if (species.id === "cyclizar") this.incompatibleMoves(moves, movePool, 'taunt', 'knockoff');
 		if (species.baseSpecies === 'Dudunsparce') this.incompatibleMoves(moves, movePool, 'earthpower', 'shadowball');
 		if (species.id === 'jirachi') this.incompatibleMoves(moves, movePool, 'bodyslam', 'healingwish');
-		if (species.baseSpecies !== 'basculin') this.incompatibleMoves(moves, movePool, 'aquajet', 'flipturn');
+		if (species.baseSpecies !== 'Basculin') this.incompatibleMoves(moves, movePool, 'aquajet', 'flipturn');
 	}
 
 	// Checks for and removes incompatible moves, starting with the first move in movesA.


### PR DESCRIPTION
This is untested. Please do not merge without reviewing.

Changes are too numerous to list in a timely manner, but I will do so as quickly as possible.


**Technical:**
-Gen 9 Pokemon were reordered into dex order, aside from a couple stragglers here and there. They were not even remotely in dex order before and it bothered me.
-Luvdisc hardcode removed due to no longer being necessary.
-Persian Bite incompatibility rmeoved due to no longer being necessary.
-Ivy Cudgel is recognized as the type it is.

**Generation rules:**
-Poison Heal grants a Toxic Orb.
-Reckless will generate with HJK on mienshao and Regenerator will generate otherwise
-Unaware will only generate on 50% of Bulky support clefables
-Flip turn and Aqua Jet will not generate together, unless you're Basculin
-Wallbreaker role now forces STAB priority. Affects several new Pokemon, as well as a couple of others like Cacturne and Wet Tauros.


**New Pokemon:**
-Arbok: Fast Support featuring Glare. No Coil.
-Sandslash: Bulky Support with enforced Rapid Spin and possible Swords Dance.
-Alolan Sandslash: Rapid Spin Miniature Mamoswine, and Swords Dance Miniature Mamoswine. No steel move on either.
-Clefable: CM LO, Cosmic Power Stored Power, and Bulky Support. Only the latter can get Unaware.
-Ninetales: Plot.
-Alolan Ninetales: Set 1 Veil. Set 2 Veil Plot. Set 3 Tera Blast Ground Plot.
-Poliwrath: Rain Dance LO, AV Circle Throw, and Bulk Up Drain Punch.
-Victreebel: Sunny Day Weather Ball, Swords Dance, and Mixed LO.
-Golem: Weakness Policy Rock Polish, and Rocks Boom.
-Alolan Golem: Galvanize Wallbreaker, and Fat Magnet Pull.
-Weezing: just normal weezing
-Galarian Weezing: forced defog, no tspikes.


**Set Updates (Major):**
-Hypno split to Toxic + Protect + Focus Blast and Knock Off + no Protect or Focus Blast

**Set Updates (Minor):**
-Pikachu, Persian, Muk, Hypno: +Knock Off, -Bad Dark Moves
-Slowbro, Slowking, Vaporeon: Scald over Surf
-Scyther: Dual Wingbeat and Bug Bite