### PR TITLE
National Dex: Move Politoed to RU

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -495,7 +495,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 	politoed: {
 		tier: "OU",
 		doublesTier: "DOU",
-		natDexTier: "UU",
+		natDexTier: "RU",
 	},
 	abra: {
 		isNonstandard: "Past",


### PR DESCRIPTION
This was mistakenly changed in the DLC update from what I can see, it should be in NDRU according to their council + usage update.

https://www.smogon.com/forums/threads/usage-based-tier-update-for-september-2023.3727155/