### PR TITLE
Gen 9 Random Battles fixes

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1538,7 +1538,7 @@
         "level": 79,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Bulky Support",
                 "movepool": ["Body Slam", "Fire Punch", "Healing Wish", "Iron Head", "Protect", "U-turn", "Wish"],
                 "teraTypes": ["Water"]
             }
@@ -1558,12 +1558,12 @@
         "level": 82,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Grass Knot", "Gunk Shot", "Knock Off", "Mach Punch", "Overheat", "Stone Edge"],
                 "teraTypes": ["Dark", "Fighting", "Fire"]
             },
             {
-                "role": "Fast Attacker",
+                "role": "Fast Support",
                 "movepool": ["Close Combat", "Flare Blitz", "Gunk Shot", "Knock Off", "Mach Punch", "Stone Edge", "Swords Dance", "U-turn"],
                 "teraTypes": ["Dark", "Fighting", "Fire"]
             }
@@ -2023,7 +2023,7 @@
         "level": 83,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Bulky Support",
                 "movepool": ["Encore", "Knock Off", "Light Screen", "Psychic", "Reflect", "Stealth Rock", "Thunder Wave", "U-turn", "Yawn"],
                 "teraTypes": ["Electric", "Steel"]
             }
@@ -3293,7 +3293,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Moonblast", "Sticky Web", "Stun Spore", "U-turn"],
-                "teraTypes": ["Fighting", "Ghost"]
+                "teraTypes": ["Ghost"]
             },
             {
                 "role": "Tera Blast user",
@@ -4491,7 +4491,7 @@
         "level": 83,
         "sets": [
             {
-                "role": "Setup Sweeper",
+                "role": "Fast Attacker",
                 "movepool": ["Gunk Shot", "High Horsepower", "Iron Head", "Shift Gear"],
                 "teraTypes": ["Ground"]
             },
@@ -5061,7 +5061,7 @@
                 "teraTypes": ["Water"]
             },
             {
-                "role": "Wallbreaker",
+                "role": "Setup Sweeper",
                 "movepool": ["Ivy Cudgel", "Knock Off", "Play Rough", "Swords Dance", "Wood Hammer"],
                 "teraTypes": ["Water"]
             }

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2712,13 +2712,18 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["High Jump Kick", "Knock Off", "Poison Jab", "Stone Edge", "Swords Dance", "U-turn"],
+                "movepool": ["High Jump Kick", "Knock Off", "Poison Jab", "Stone Edge", "U-turn"],
                 "teraTypes": ["Dark"]
             },
             {
                 "role": "AV Pivot",
                 "movepool": ["Close Combat", "Fake Out", "Knock Off", "U-turn"],
                 "teraTypes": ["Dark", "Steel"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Close Combat", "Knock Off", "Poison Jab", "Stone Edge", "Swords Dance"],
+                "teraTypes": ["Dark"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -69,7 +69,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Ice Spinner", "Rapid Spin", "Spikes", "Swords Dance"],
+                "movepool": ["Earthquake", "Ice Spinner", "Iron Head", "Rapid Spin", "Spikes", "Swords Dance"],
                 "teraTypes": ["Flying", "Water"]
             },
             {

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -839,7 +839,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Energy Ball", "Sludge Bomb", "Sunny Day", "Weather Ball"],
+                "movepool": ["Giga Drain", "Sludge Bomb", "Sunny Day", "Weather Ball"],
                 "teraTypes": ["Fire"]
             }
         ]

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -560,7 +560,7 @@ export class RandomTeams {
 			['toxic', 'clearsmog'],
 			// Chansey and Blissey
 			['healbell', 'stealthrock'],
-			// Azelf
+			// Azelf and Zoroarks
 			['trick', 'uturn'],
 		];
 

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -560,8 +560,6 @@ export class RandomTeams {
 			['toxic', 'clearsmog'],
 			// Chansey and Blissey
 			['healbell', 'stealthrock'],
-			// Mesprit
-			['healingwish', 'uturn'],
 			// Azelf
 			['trick', 'uturn'],
 		];
@@ -580,6 +578,7 @@ export class RandomTeams {
 		if (species.baseSpecies === 'Dudunsparce') this.incompatibleMoves(moves, movePool, 'earthpower', 'shadowball');
 		if (species.id === 'jirachi') this.incompatibleMoves(moves, movePool, 'bodyslam', 'healingwish');
 		if (species.baseSpecies !== 'Basculin') this.incompatibleMoves(moves, movePool, 'aquajet', 'flipturn');
+		if (species.id === 'mesprit') this.incompatibleMoves(moves, movePool, 'healingwish', 'uturn');
 	}
 
 	// Checks for and removes incompatible moves, starting with the first move in movesA.
@@ -793,7 +792,10 @@ export class RandomTeams {
 			for (const moveid of movePool) {
 				const move = this.dex.moves.get(moveid);
 				const moveType = this.getMoveType(move, species, abilities, teraType);
-				if (types.includes(moveType) && move.priority > 0 && (move.basePower || move.basePowerCallback)) {
+				if (
+					types.includes(moveType) && (move.priority > 0 || (moveid === 'grassyglide' && abilities.has('Grassy Surge'))) &&
+					(move.basePower || move.basePowerCallback)
+				) {
 					priorityMoves.push(moveid);
 				}
 			}
@@ -990,9 +992,9 @@ export class RandomTeams {
 		role: RandomTeamsTypes.Role,
 	): boolean {
 		if ([
-			'Armor Tail', 'Battle Bond', 'Early Bird', 'Flare Boost', 'Gluttony', 'Harvest', 'Hydration', 'Ice Body', 'Immunity',
-			'Marvel Scale', 'Moody', 'Neutralizing Gas', 'Own Tempo', 'Pressure', 'Quick Feet', 'Rain Dish', 'Sand Veil', 'Snow Cloak',
-			'Steadfast', 'Steam Engine',
+			'Armor Tail', 'Battle Bond', 'Early Bird', 'Flare Boost', 'Galvanize', 'Gluttony', 'Harvest', 'Hydration', 'Ice Body', 'Immunity',
+			'Marvel Scale', 'Misty Surge', 'Moody', 'Neutralizing Gas', 'Own Tempo', 'Pressure', 'Quick Feet', 'Rain Dish', 'Sand Veil',
+			'Snow Cloak', 'Steadfast', 'Steam Engine',
 		].includes(ability)) return true;
 
 		switch (ability) {
@@ -1015,7 +1017,7 @@ export class RandomTeams {
 			return (species.id === 'magcargo' && role === 'Setup Sweeper');
 		case 'Flash Fire':
 			return (
-				['Flame Body', 'Intimidate', 'Rock Head', 'Weak Armor'].some(m => abilities.has(m)) &&
+				['Drought', 'Flame Body', 'Intimidate', 'Rock Head', 'Weak Armor'].some(m => abilities.has(m)) &&
 				this.dex.getEffectiveness('Fire', species) < 0
 			);
 		case 'Guts':
@@ -1042,6 +1044,8 @@ export class RandomTeams {
 			return (!counter.get('Physical') || moves.has('stealthrock'));
 		case 'Natural Cure':
 			return species.id === 'pawmot';
+		case 'Overcoat': case 'Sweet Veil':
+			return types.includes('Grass');
 		case 'Overgrow':
 			return !counter.get('Grass');
 		case 'Prankster':
@@ -1076,8 +1080,6 @@ export class RandomTeams {
 			return !!counter.get('recoil');
 		case 'Swarm':
 			return (!counter.get('Bug') || !!counter.get('recovery'));
-		case 'Sweet Veil':
-			return types.includes('Grass');
 		case 'Swift Swim':
 			return (!moves.has('raindance') && !teamDetails.rain);
 		case 'Synchronize':
@@ -1087,7 +1089,7 @@ export class RandomTeams {
 		case 'Tinted Lens':
 			const hbraviaryCase = (species.id === 'braviaryhisui' && (role === 'Setup Sweeper' || role === 'Doubles Wallbreaker'));
 			const yanmegaCase = (species.id === 'yanmega' && role === 'Tera Blast user');
-			return (yanmegaCase || hbraviaryCase);
+			return (yanmegaCase || hbraviaryCase || species.id === 'illumise');
 		case 'Unaware':
 			return (species.id === 'clefable' && role !== 'Bulky Support');
 		case 'Unburden':
@@ -1096,7 +1098,7 @@ export class RandomTeams {
 			if (abilities.has('Iron Fist') && counter.ironFist >= 2) return true;
 			return (this.dex.getEffectiveness('Electric', species) < -1);
 		case 'Water Absorb':
-			return (species.id === 'quagsire' || moves.has('raindance'));
+			return (species.id === 'politoed' || species.id === 'quagsire' || moves.has('raindance'));
 		case 'Weak Armor':
 			return (moves.has('shellsmash') && species.id !== 'magcargo');
 		}
@@ -1125,6 +1127,7 @@ export class RandomTeams {
 		// Hard-code abilities here
 		if (species.id === 'arcaninehisui') return 'Rock Head';
 		if (species.id === 'scovillain') return 'Chlorophyll';
+		if (species.id === 'golemalola' && moves.has('doubleedge')) return 'Galvanize';
 		if (abilities.has('Guts') && (moves.has('facade') || moves.has('sleeptalk') || species.id === 'gurdurr')) return 'Guts';
 		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';
 		if (species.id === 'breloom') return 'Technician';
@@ -1274,15 +1277,13 @@ export class RandomTeams {
 				return (counter.get('Physical') > counter.get('Special')) ? 'Choice Band' : 'Choice Specs';
 			}
 		}
+		if (species.id === 'scyther') return (isLead && !moves.has('uturn')) ? 'Eviolite' : 'Heavy-Duty Boots';
+		if (species.nfe || species.id === 'dipplin') return 'Eviolite';
 		if (ability === 'Poison Heal') return 'Toxic Orb';
 		if ((ability === 'Guts' || moves.has('facade')) && !moves.has('sleeptalk')) {
 			return (types.includes('Fire') || ability === 'Toxic Boost') ? 'Toxic Orb' : 'Flame Orb';
 		}
-		if (
-			(ability === 'Sheer Force' && counter.get('sheerforce'))
-		) {
-			return 'Life Orb';
-		}
+		if (ability === 'Sheer Force' && counter.get('sheerforce')) return 'Life Orb';
 		if (ability === 'Anger Shell') return this.sample(['Rindo Berry', 'Passho Berry', 'Scope Lens', 'Sitrus Berry']);
 		if (moves.has('courtchange')) return 'Heavy-Duty Boots';
 		if (moves.has('populationbomb')) return 'Wide Lens';
@@ -1298,8 +1299,6 @@ export class RandomTeams {
 		) {
 			return 'Chesto Berry';
 		}
-		if (species.id === 'scyther') return (isLead && !moves.has('uturn')) ? 'Eviolite' : 'Heavy-Duty Boots';
-		if (species.nfe || species.id === 'dipplin') return 'Eviolite';
 		if (
 			this.dex.getEffectiveness('Rock', species) >= 2 && (!types.includes('Flying') || !isDoubles)
 		) return 'Heavy-Duty Boots';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1127,6 +1127,7 @@ export class RandomTeams {
 		// Hard-code abilities here
 		if (species.id === 'arcaninehisui') return 'Rock Head';
 		if (species.id === 'scovillain') return 'Chlorophyll';
+		if (species.id === 'empoleon') return 'Competitive';
 		if (species.id === 'golemalola' && moves.has('doubleedge')) return 'Galvanize';
 		if (abilities.has('Guts') && (moves.has('facade') || moves.has('sleeptalk') || species.id === 'gurdurr')) return 'Guts';
 		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';


### PR DESCRIPTION
-Galvanize and Magnet Pull are now split by set on Golem-Alola.
-Illumise will always get Prankster.
-Jirachi can now get Healing Wish and U-turn together, and will no longer get Life Orb since it is now Bulky Support.
-Ninetales will always get Drought.
-Politoed will always get Drizzle.
-Weezing-Galar will no longer get Misty Surge, and hence always get Levitate.
-Setup Revavroom is now Fast Attacker, so that it gets Life Orb.
-Uxie is now Bulky Support, to prevent Life Orb.
-Gurdurr will now get Eviolite, not Flame Orb
-Ogerpon-Wellspring's non-support set is now Setup Sweeper, to enforce Swords Dance.
-Empoleon will always be Competitive

-Infernape's mixed Wallbreaker set is now Fast Attacker so that Mach Punch is not enforced; the physical set's role is now Fast Support, which is functionally identical to its previous role
-Leavanny will no longer get Overcoat, since Grass types are immune to powder moves.
-Fast Support Ribombee: -tera fighting
-Bulky Support Sandslash-Alola: +ironhead
-Sunny Day Sunflora: -energyball, +gigadrain
-Mienshao set split: move Swords Dance to a new set with Close Combat, so Reckless HJK is choice only

Technical:
-Grassy Glide is treated as a priority STAB move and hence enforced on Wallbreaker Rillaboom.