### PR TITLE
Gen 9 Random Battles updates

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -809,7 +809,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Encore", "Focus Blast", "Hydro Pump", "Hypnosis", "Ice Beam", "Rest", "Surf"],
+                "movepool": ["Encore", "Focus Blast", "Haze", "Hydro Pump", "Hypnosis", "Ice Beam", "Rest", "Surf"],
                 "teraTypes": ["Steel"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -809,7 +809,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Encore", "Focus Blast", "Haze", "Hydro Pump", "Hypnosis", "Ice Beam", "Rest", "Surf"],
+                "movepool": ["Encore", "Haze", "Hydro Pump", "Hypnosis", "Ice Beam", "Rest", "Surf"],
                 "teraTypes": ["Steel"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -439,7 +439,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Fire Blast", "Pain Split", "Sludge Bomb", "Toxic Spikes", "Will-O-Wisp"],
+                "movepool": ["Fire Blast", "Gunk Shot", "Pain Split", "Toxic Spikes", "Will-O-Wisp"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -449,7 +449,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Defog", "Fire Blast", "Pain Split", "Sludge Bomb", "Strange Steam", "Will-O-Wisp"],
+                "movepool": ["Defog", "Fire Blast", "Gunk Shot", "Pain Split", "Strange Steam", "Will-O-Wisp"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3609,6 +3609,11 @@
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Glare", "Rest", "Stealth Rock", "Stone Edge"],
                 "teraTypes": ["Dragon", "Water"]
+            },
+            {
+                "role": "Fast Bulky Setup",
+                "movepool": ["Coil", "Earthquake", "Rock Blast", "Scale Shot"],
+                "teraTypes": ["Dragon"]
             }
         ]
     },
@@ -4987,7 +4992,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Draco Meteor", "Dragon Tail", "Giga Drain", "Leaf Storm", "Recover", "Sucker Punch"],
+                "movepool": ["Draco Meteor", "Dragon Tail", "Giga Drain", "Recover", "Sucker Punch"],
                 "teraTypes": ["Steel"]
             }
         ]

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1063,7 +1063,7 @@ export class RandomTeams {
 		case 'Seed Sower':
 			return role === 'Bulky Support';
 		case 'Shed Skin':
-			return species.id === 'seviper';
+			return species.id === 'seviper' || species.id === 'arbok';
 		case 'Sheer Force':
 			const braviaryCase = (species.id === 'braviaryhisui' && (role === 'Wallbreaker' || role === 'Bulky Protect'));
 			const abilitiesCase = (abilities.has('Guts') || abilities.has('Sharpness'));


### PR DESCRIPTION
These will slow down soon. Sorry for the update flood.

-Arbok now always has Intimidate and doesn't get Shed Skin. Whoops!

-Third Sandaconda set: Fast Bulky Setup with Loaded Dice Scale Shot + Rock Blast and Tera Dragon.

-Dipplin: -Leaf Storm
-Politoed: -Focus Blast, +Haze; Politoed now always gets Ice Beam
-Weezing and Galarian Weezing: -Sludge Bomb, +Gunk Shot (they have higher Attack)