### PR TITLE
Gen 9 Random Battle updates

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -5027,9 +5027,14 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["Brave Bird", "Gunk Shot", "Heat Wave", "Play Rough", "U-turn"],
-                "teraTypes": ["Flying", "Ground"]
+                "movepool": ["Beat Up", "Gunk Shot", "Heat Wave", "Play Rough", "U-turn"],
+                "teraTypes": ["Dark", "Steel", "Water"]
             },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Beat Up", "Double Kick", "Gunk Shot", "Play Rough", "Roost"],
+                "teraTypes": ["Dark", "Steel", "Water"]
+            }
             {
                 "role": "Tera Blast user",
                 "movepool": ["Gunk Shot", "Play Rough", "Swords Dance", "Tera Blast"],

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -5034,7 +5034,7 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Beat Up", "Double Kick", "Gunk Shot", "Play Rough", "Roost", "U-turn"],
                 "teraTypes": ["Dark", "Steel", "Water"]
-            }
+            },
             {
                 "role": "Tera Blast user",
                 "movepool": ["Gunk Shot", "Play Rough", "Swords Dance", "Tera Blast"],

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -439,7 +439,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Fire Blast", "Gunk Shot", "Pain Split", "Toxic Spikes", "Will-O-Wisp"],
+                "movepool": ["Fire Blast", "Gunk Shot", "Pain Split", "Sludge Bomb", "Toxic Spikes", "Will-O-Wisp"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -836,11 +836,6 @@
                 "role": "Wallbreaker",
                 "movepool": ["Dazzling Gleam", "Earth Power", "Leaf Storm", "Sludge Bomb"],
                 "teraTypes": ["Fairy", "Grass", "Ground", "Poison"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["Giga Drain", "Sludge Bomb", "Sunny Day", "Weather Ball"],
-                "teraTypes": ["Fire"]
             }
         ]
     },
@@ -1550,7 +1545,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Headlong Rush", "Shell Smash", "Stone Edge", "Wood Hammer"],
-                "teraTypes": ["Ground", "Water"]
+                "teraTypes": ["Ground", "Water", "Rock"]
             }
         ]
     },
@@ -5051,11 +5046,6 @@
                 "teraTypes": ["Grass"]
             },
             {
-                "role": "Wallbreaker",
-                "movepool": ["Knock Off", "Superpower", "U-turn", "Wood Hammer"],
-                "teraTypes": ["Grass"]
-            },
-            {
                 "role": "Setup Sweeper",
                 "movepool": ["Ivy Cudgel", "Knock Off", "Superpower", "Swords Dance"],
                 "teraTypes": ["Grass"]
@@ -5066,7 +5056,7 @@
         "level": 80,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Encore", "Ivy Cudgel", "Spikes", "Synthesis", "U-turn", "Wood Hammer"],
                 "teraTypes": ["Water"]
             },
@@ -5091,7 +5081,7 @@
         "level": 80,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Encore", "Ivy Cudgel", "Spikes", "Superpower", "Synthesis", "Wood Hammer"],
                 "teraTypes": ["Rock"]
             },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -5032,7 +5032,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Beat Up", "Double Kick", "Gunk Shot", "Play Rough", "Roost"],
+                "movepool": ["Beat Up", "Double Kick", "Gunk Shot", "Play Rough", "Roost", "U-turn"],
                 "teraTypes": ["Dark", "Steel", "Water"]
             }
             {

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1545,7 +1545,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Headlong Rush", "Shell Smash", "Stone Edge", "Wood Hammer"],
-                "teraTypes": ["Ground", "Water", "Rock"]
+                "teraTypes": ["Ground", "Rock", "Water"]
             }
         ]
     },

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1850,7 +1850,7 @@ export class RandomTeams {
 			if (set.moves.includes('auroraveil') || (set.moves.includes('reflect') && set.moves.includes('lightscreen'))) {
 				teamDetails.screens = 1;
 			}
-			if (set.role === 'Tera Blast user' || species.name.startsWith("Ogerpon")) teamDetails.teraBlast = 1;
+			if (set.role === 'Tera Blast user' || species.baseSpecies === "Ogerpon") teamDetails.teraBlast = 1;
 		}
 		if (pokemon.length < this.maxTeamSize && pokemon.length < 12) { // large teams sometimes cannot be built
 			throw new Error(`Could not build a random team for ${this.format} (seed=${seed})`);

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1291,7 +1291,7 @@ export class RandomTeams {
 		if (moves.has('scaleshot')) return 'Loaded Dice';
 		if (moves.has('stuffcheeks')) return this.randomChance(1, 2) ? 'Liechi Berry' : 'Salac Berry';
 		if (ability === 'Unburden') return moves.has('closecombat') ? 'White Herb' : 'Sitrus Berry';
-		if (moves.has('shellsmash')) return 'White Herb';
+		if (moves.has('shellsmash') && ability !== 'Weak Armor') return 'White Herb';
 		if (moves.has('acrobatics') && ability !== 'Protosynthesis') return ability === 'Grassy Surge' ? 'Grassy Seed' : '';
 		if (moves.has('auroraveil') || moves.has('lightscreen') && moves.has('reflect')) return 'Light Clay';
 		if (
@@ -1424,6 +1424,7 @@ export class RandomTeams {
 			return 'Assault Vest';
 		}
 		if (counter.get('speedsetup') && role === 'Bulky Setup') return 'Weakness Policy';
+		if (species.id === 'golem') return 'Custap Berry';
 		if (species.id === 'urshifurapidstrike') return 'Punching Glove';
 		if (species.id === 'palkia') return 'Lustrous Orb';
 		if (moves.has('substitute') || ability === 'Moody') return 'Leftovers';
@@ -1709,6 +1710,9 @@ export class RandomTeams {
 			// Limit to one of each species (Species Clause)
 			if (baseFormes[species.baseSpecies]) continue;
 
+			// Treat Ogerpon formes like the Tera Blast user role; reject if team has one already
+			if (species.baseSpecies === 'Ogerpon' && teamDetails.teraBlast) continue;
+
 			// Illusion shouldn't be on the last slot
 			if (species.baseSpecies === 'Zoroark' && pokemon.length >= (this.maxTeamSize - 1)) continue;
 
@@ -1846,7 +1850,7 @@ export class RandomTeams {
 			if (set.moves.includes('auroraveil') || (set.moves.includes('reflect') && set.moves.includes('lightscreen'))) {
 				teamDetails.screens = 1;
 			}
-			if (set.role === 'Tera Blast user') teamDetails.teraBlast = 1;
+			if (set.role === 'Tera Blast user' || species.name.startsWith("Ogerpon")) teamDetails.teraBlast = 1;
 		}
 		if (pokemon.length < this.maxTeamSize && pokemon.length < 12) { // large teams sometimes cannot be built
 			throw new Error(`Could not build a random team for ${this.format} (seed=${seed})`);

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -534,7 +534,7 @@ export class RandomTeams {
 			['fireblast', ['fierydance', 'flamethrower']],
 			['lavaplume', 'magmastorm'],
 			['thunderpunch', 'wildcharge'],
-			['gunkshot', ['direclaw', 'poisonjab']],
+			['gunkshot', ['direclaw', 'poisonjab', 'sludgebomb']],
 			['aurasphere', 'focusblast'],
 			['closecombat', 'drainpunch'],
 			['bugbite', 'pounce'],


### PR DESCRIPTION
-Ogerpon is now treated, functionally, as a Tera Blast user. It rejects other Tera Blast user roles, and is rejected itself if the team has a Tera Blast user.

-Fezandipiti's sets have been overhauled. Its AV Pivot set now has Beat Up over Brave Bird with Tera Dark/Steel/Water. It also now has a Bulky Attacker set with Roost, Gunk Shot, Play Rough, and Beat Up/Double Kick/U-turn with the same teras as above.

-Sunny Day Sunflora was removed. We tried. We can't do better than specs.
-Wallbreaker (Choice Band Wood Hammer) Ogerpon was removed.
-Ogerpon-Wellspring and Cornerstone's Fast Support roles were changed to Bulky Attacker; this means their non-Swords Dance sets will always have Synthesis now.
-Stealth Rock Golem now runs a Custap Berry.
-Weak Armor Shell Smash Magcargo now runs Heavy-Duty Boots.
-Regular Weezing now has a 50/50 chance of running either Sludge Bomb or Gunk Shot.
-Torterra: +Tera Rock

