### PR TITLE
Gen 4 Random Battles hotfix

### DIFF
--- a/data/mods/gen4/random-data.json
+++ b/data/mods/gen4/random-data.json
@@ -141,7 +141,7 @@
     },
     "dewgong": {
         "level": 90,
-        "moves": ["encore", "icebeam", "rest", "sleeptalk", "surf", "toxic"]
+        "moves": ["encore", "icebeam", "raindance", "rest", "surf", "toxic"]
     },
     "muk": {
         "level": 88,


### PR DESCRIPTION
This reverts a change that was unintentionally included in the previous update https://github.com/smogon/pokemon-showdown/pull/9758 and resulted in some issues with set generation.