### PR TITLE
Linecount: Fix displaying total lines for user pages

### DIFF
--- a/server/chat-plugins/chatlog.ts
+++ b/server/chat-plugins/chatlog.ts
@@ -615,20 +615,17 @@ export abstract class Searcher {
 			buf += LogViewer.error(`Logs for month '${month}' do not exist on room ${roomid}.`);
 			return buf;
 		} else if (user) {
-			let total = 0;
-			for (const day in results) {
-				if (isNaN(results[day][user])) continue;
-				total += results[day][user];
-			}
-			buf += `<br />Total linecount: ${total}<hr />`;
-			buf += '<ol>';
+			buf += '<hr /><ol>';
 			const sortedDays = Utils.sortBy(Object.keys(results), day => ({reverse: day}));
+			let total = 0;
 			for (const day of sortedDays) {
 				const dayResults = results[day][user];
 				if (isNaN(dayResults)) continue;
+				total += dayResults;
 				buf += `<li>[<a roomid="view-chatlog-${roomid}--${day}">${day}</a>]: `;
 				buf += `${Chat.count(dayResults, 'lines')}</li>`;
 			}
+			buf = buf.replace('{total}', `${total}`);
 		} else {
 			buf += '<hr /><ol>';
 			// squish the results together


### PR DESCRIPTION
Currently, `Total lines: {total}` shows up with the {total} template still remaining when viewing linecounts of a specific user, with a separate `Total linecount: X` actually displaying the total. This change will now use the bolded text at the top to display the total to be uniform with the other total line display, and also gets rid of an extra iteration that was previously used to get the total lines for a user.