### PR TITLE
Fix egg move validation for female-only Pokemon

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -87,6 +87,10 @@ export class PokemonSources {
 	 */
 	tradebackLimitedEggMoves?: ID[] | null;
 	/**
+	 * Tracks level up egg moves for female-only Pokemon
+	 */
+	levelUpEggMoves?: ID[] | null;
+	/**
 	 * Moves that can be learned via Pomeg glitch and does not require a
 	 * particular parent to learn
 	 */
@@ -241,6 +245,13 @@ export class PokemonSources {
 				this.tradebackLimitedEggMoves.push(...other.tradebackLimitedEggMoves);
 			}
 		}
+		if (other.levelUpEggMoves) {
+			if (!this.levelUpEggMoves) {
+				this.levelUpEggMoves = other.levelUpEggMoves;
+			} else {
+				this.levelUpEggMoves.push(...other.levelUpEggMoves);
+			}
+		}
 		if (other.pomegEggMoves) {
 			if (!this.pomegEggMoves) {
 				this.pomegEggMoves = other.pomegEggMoves;
@@ -248,7 +259,7 @@ export class PokemonSources {
 				this.pomegEggMoves.push(...other.pomegEggMoves);
 			}
 		}
-		if (this.possiblyLimitedEggMoves) {
+		if (this.possiblyLimitedEggMoves && !this.sourcesBefore) {
 			const eggSources = this.sources.filter(source => source.charAt(1) === 'E');
 			let minEggGen = parseInt(eggSources[0]);
 			for (const source of eggSources) {
@@ -1331,7 +1342,7 @@ export class TeamValidator {
 		const fathers: ID[] = [];
 		// Gen 6+ don't have egg move incompatibilities
 		// (except for certain cases with baby Pokemon not handled here)
-		if (!getAll && eggGen >= 6 && species.gender !== 'F') return true;
+		if (!getAll && eggGen >= 6 && !setSources.levelUpEggMoves) return true;
 
 		let eggMoves = setSources.limitedEggMoves;
 		if (eggGen === 3) eggMoves = eggMoves?.filter(eggMove => !setSources.pomegEggMoves?.includes(eggMove));
@@ -1341,7 +1352,8 @@ export class TeamValidator {
 			// which aren't limited and so aren't in `limitedEggMoves`
 			return getAll ? ['*'] : true;
 		}
-		if (!getAll && eggMoves.length <= 1 && species.gender !== 'F') return true;
+		if (!getAll && eggMoves.length <= 1 && !setSources.levelUpEggMoves) return true;
+		if (setSources.levelUpEggMoves && eggGen >= 6) eggMoves = setSources.levelUpEggMoves;
 
 		// gen 1 eggs come from gen 2 breeding
 		const dex = this.dex.gen === 1 ? this.dex.mod('gen2') : this.dex;
@@ -2543,6 +2555,7 @@ export class TeamValidator {
 						if (learned.slice(1) === 'Eany') {
 							if (species.gender === 'F') {
 								limitedEggMove = move.id;
+								moveSources.levelUpEggMoves = [move.id];
 							} else {
 								limitedEggMove = null;
 							}

--- a/test/sim/team-validator/breeding.js
+++ b/test/sim/team-validator/breeding.js
@@ -163,7 +163,7 @@ describe('Team Validator', function () {
 		assert.false.legalTeam(team, 'gen5ou');
 	});
 
-	it.skip("should disallow low-level female-only Pokemon with illegal (level up) egg moves/egg move combinations", function () {
+	it("should disallow low-level female-only Pokemon with illegal (level up) egg moves/egg move combinations", function () {
 		team = [
 			{species: 'tinkatink', level: 5, ability: 'moldbreaker', moves: ['brutalswing'], evs: {hp: 1}},
 		];

--- a/test/sim/team-validator/breeding.js
+++ b/test/sim/team-validator/breeding.js
@@ -165,7 +165,7 @@ describe('Team Validator', function () {
 
 	it.skip("should disallow low-level female-only Pokemon with illegal (level up) egg moves/egg move combinations", function () {
 		team = [
-			{species: 'tinkatink', level: 5, ability: 'moldbreaker', moves: ['knockoff'], evs: {hp: 1}},
+			{species: 'tinkatink', level: 5, ability: 'moldbreaker', moves: ['brutalswing'], evs: {hp: 1}},
 		];
 		assert.false.legalTeam(team, 'gen9lc');
 
@@ -205,7 +205,7 @@ describe('Team Validator', function () {
 
 	it("should disallow illegal egg move combinations containing past gen universal moves", function () {
 		team = [
-			{species: 'salamence', ability: 'intimidate', moves: ['defensecurl', 'thrash'], evs: {hp: 1}},
+			{species: 'salamence', ability: 'intimidate', moves: ['defensecurl', 'thrash', 'dragonrage', 'dragonrush'], evs: {hp: 1}},
 		];
 		assert.false.legalTeam(team, 'gen5ou');
 	});


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-9789995

This also fixes a test for a set that was assumed to be illegal but should pass as legal, as well as updating a test for a set that is now legal thanks to DLC.