### PR TITLE
Randomized format set updates

### DIFF
--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -2156,7 +2156,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "facade", "knockoff", "quickattack", "swordsdance"]
+                "movepool": ["closecombat", "facade", "knockoff", "quickattack", "swordsdance"],
+                "preferredTypes": ["Dark"]
             }
         ]
     },

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -711,7 +711,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["bodyslam", "earthquake", "rockslide", "zenheadbutt"]
+                "movepool": ["bodyslam", "earthquake", "fireblast", "rockslide", "zenheadbutt"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Fast Attacker",
@@ -1634,7 +1635,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["fireblast", "hiddenpowerice", "highjumpkick", "knockoff", "protect"]
+                "movepool": ["fireblast", "highjumpkick", "knockoff", "protect", "stoneedge"]
             }
         ]
     },

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -4472,7 +4472,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "headcharge", "megahorn", "stoneedge", "superpower", "swordsdance"]
+                "movepool": ["earthquake", "headcharge", "stoneedge", "superpower", "swordsdance"]
             }
         ]
     },
@@ -4702,7 +4702,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dracometeor", "earthpower", "focusblast", "fusionflare", "icebeam", "roost"]
+                "movepool": ["dracometeor", "earthpower", "fusionflare", "icebeam", "roost"]
             }
         ]
     },

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -733,7 +733,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["crunch", "dragondance", "earthquake", "icefang", "substitute", "waterfall"]
+                "movepool": ["crunch", "dragondance", "earthquake", "substitute", "waterfall"]
             }
         ]
     },
@@ -1109,7 +1109,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthpower", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "sludgebomb"]
+                "movepool": ["earthpower", "hiddenpowerfire", "hiddenpowerice", "hiddenpowerrock", "leafstorm", "sludgebomb"]
             }
         ]
     },
@@ -1427,10 +1427,6 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["dracometeor", "hydropump", "icebeam", "raindance", "waterfall"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["dracometeor", "focusenergy", "hydropump", "icebeam"]
             }
         ]
     },
@@ -2013,10 +2009,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["bugbuzz", "encore", "roost", "thunderwave", "wish"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["bugbuzz", "charm", "encore", "roost", "substitute", "toxic"]
             }
         ]
     },
@@ -2658,11 +2650,11 @@
         "level": 87,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Support",
                 "movepool": ["earthquake", "stealthrock", "stoneedge", "synthesis", "woodhammer"]
             },
             {
-                "role": "Setup Sweeper",
+                "role": "Bulky Attacker",
                 "movepool": ["earthquake", "rockpolish", "stoneedge", "swordsdance", "woodhammer"]
             }
         ]
@@ -2853,7 +2845,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dazzlinggleam", "energyball", "healingwish", "hiddenpowerfire", "hiddenpowerground", "hiddenpowerrock"]
+                "movepool": ["dazzlinggleam", "energyball", "healingwish", "hiddenpowerfire", "hiddenpowerground", "hiddenpowerrock", "synthesis"]
             }
         ]
     },
@@ -3033,7 +3025,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bulletpunch", "closecombat", "extremespeed", "icepunch", "swordsdance"]
+                "movepool": ["bulletpunch", "closecombat", "icepunch", "swordsdance"]
             },
             {
                 "role": "Setup Sweeper",
@@ -3447,7 +3439,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthpower", "flashcannon", "lavaplume", "magmastorm", "roar", "stealthrock", "toxic"]
+                "movepool": ["earthpower", "flashcannon", "lavaplume", "magmastorm", "stealthrock", "taunt", "toxic"]
             },
             {
                 "role": "Staller",
@@ -4581,10 +4573,6 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "leafblade", "stoneedge", "swordsdance"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["calmmind", "focusblast", "gigadrain", "hiddenpowerrock"]
             }
         ]
     },
@@ -5221,7 +5209,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "extremespeed", "outrage", "substitute"]
+                "movepool": ["dragondance", "earthquake", "extremespeed", "glare", "outrage", "substitute"]
             }
         ]
     },

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -792,7 +792,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			) ? 'Choice Scarf' : 'Choice Specs';
 		}
 		if (counter.get('Special') === 3 && moves.has('uturn')) return 'Choice Specs';
-		if (counter.get('Physical') === 4 && species.id !== 'jirachi' &&
+		if (counter.get('Physical') === 4 && species.id !== 'jirachi' && species.id !== 'spinda' &&
 			['dragontail', 'fakeout', 'flamecharge', 'nuzzle', 'rapidspin'].every(m => !moves.has(m))
 		) {
 			return (

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -4753,7 +4753,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "headcharge", "megahorn", "stoneedge", "superpower", "swordsdance"]
+                "movepool": ["earthquake", "headcharge", "stoneedge", "superpower", "swordsdance"]
             }
         ]
     },
@@ -5022,7 +5022,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dracometeor", "earthpower", "focusblast", "fusionflare", "icebeam", "roost"]
+                "movepool": ["dracometeor", "earthpower", "fusionflare", "icebeam", "roost"]
             }
         ]
     },

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -2309,7 +2309,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["closecombat", "facade", "knockoff", "quickattack", "swordsdance"]
+                "movepool": ["closecombat", "facade", "knockoff", "quickattack", "swordsdance"],
+                "preferredTypes": ["Dark"]
             }
         ]
     },

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -850,7 +850,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["bodyslam", "earthquake", "rockslide", "zenheadbutt"]
+                "movepool": ["bodyslam", "earthquake", "fireblast", "rockslide", "zenheadbutt"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Fast Attacker",
@@ -1785,7 +1786,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["fireblast", "hiddenpowerice", "highjumpkick", "knockoff", "protect"]
+                "movepool": ["fireblast", "highjumpkick", "knockoff", "protect", "stoneedge"]
             }
         ]
     },

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -877,7 +877,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["crunch", "dragondance", "earthquake", "icefang", "substitute", "waterfall"]
+                "movepool": ["crunch", "dragondance", "earthquake", "substitute", "waterfall"]
             }
         ]
     },
@@ -1272,7 +1272,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthpower", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "sludgebomb"]
+                "movepool": ["earthpower", "hiddenpowerfire", "hiddenpowerice", "hiddenpowerrock", "leafstorm", "sludgebomb"]
             }
         ]
     },
@@ -1577,10 +1577,6 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["dracometeor", "hydropump", "icebeam", "raindance", "waterfall"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["dracometeor", "focusenergy", "hydropump", "icebeam"]
             }
         ]
     },
@@ -2165,10 +2161,6 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["bugbuzz", "defog", "encore", "roost", "thunderwave", "wish"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["bugbuzz", "charm", "encore", "roost", "substitute", "toxic"]
             }
         ]
     },
@@ -2865,11 +2857,11 @@
         "level": 88,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Support",
                 "movepool": ["earthquake", "stealthrock", "stoneedge", "synthesis", "woodhammer"]
             },
             {
-                "role": "Setup Sweeper",
+                "role": "Bulky Attacker",
                 "movepool": ["earthquake", "rockpolish", "stoneedge", "swordsdance", "woodhammer"]
             }
         ]
@@ -3061,7 +3053,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dazzlinggleam", "energyball", "healingwish", "hiddenpowerfire", "hiddenpowerground", "hiddenpowerrock"]
+                "movepool": ["dazzlinggleam", "energyball", "healingwish", "hiddenpowerfire", "hiddenpowerground", "hiddenpowerrock", "synthesis"]
             }
         ]
     },
@@ -3670,7 +3662,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthpower", "flashcannon", "lavaplume", "magmastorm", "roar", "stealthrock", "toxic"]
+                "movepool": ["earthpower", "flashcannon", "lavaplume", "magmastorm", "stealthrock", "taunt", "toxic"]
             },
             {
                 "role": "Staller",

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -1164,7 +1164,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Bug Buzz", "Charm", "Encore", "Protect", "Thunder Wave"],
+                "movepool": ["Bug Buzz", "Encore", "Tailwind", "Thunder Wave"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -69,7 +69,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Ice Spinner", "Iron Head", "Rapid Spin", "Spikes", "Swords Dance"],
+                "movepool": ["Earthquake", "Ice Spinner", "Iron Head", "Knock Off", "Rapid Spin", "Spikes"],
                 "teraTypes": ["Flying", "Water"]
             },
             {
@@ -91,11 +91,6 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Calm Mind", "Fire Blast", "Moonblast", "Moonlight"],
                 "teraTypes": ["Fire"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["Cosmic Power", "Moonblast", "Moonlight", "Stored Power"],
-                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -633,9 +628,9 @@
         "level": 79,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["Heat Wave", "Hurricane", "Roost", "Thunderbolt", "U-turn"],
-                "teraTypes": ["Electric"]
+                "role": "Bulky Attacker",
+                "movepool": ["Discharge", "Heat Wave", "Hurricane", "Roost", "U-turn"],
+                "teraTypes": ["Electric", "Steel"]
             }
         ]
     },
@@ -1313,7 +1308,7 @@
         "level": 88,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Fast Support",
                 "movepool": ["Earthquake", "Lava Plume", "Rapid Spin", "Solar Beam", "Stealth Rock", "Yawn"],
                 "teraTypes": ["Dragon", "Grass"]
             }
@@ -3426,9 +3421,9 @@
         "level": 89,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["Body Slam", "Earthquake", "Knock Off", "Play Rough", "Rapid Spin", "Sucker Punch", "Superpower", "U-turn", "Wood Hammer"],
-                "teraTypes": ["Fairy", "Fighting", "Grass", "Ground"]
+                "teraTypes": ["Dark", "Fairy", "Fighting", "Grass", "Ground"]
             }
         ]
     },
@@ -3498,7 +3493,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Acrobatics", "Grassy Glide", "High Horsepower", "Knock Off", "Swords Dance", "Wood Hammer"],
-                "teraTypes": ["Flying", "Grass"]
+                "teraTypes": ["Grass"]
             },
             {
                 "role": "Wallbreaker",
@@ -3954,6 +3949,11 @@
                 "role": "Tera Blast user",
                 "movepool": ["Dragon Claw", "Dragon Dance", "Earthquake", "Tera Blast"],
                 "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Draco Meteor", "Dragon Energy", "Earthquake", "Outrage"],
+                "teraTypes": ["Dragon"]
             }
         ]
     },
@@ -5092,12 +5092,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Encore", "Ivy Cudgel", "Spikes", "Superpower", "Synthesis", "Wood Hammer"],
+                "movepool": ["Encore", "Ivy Cudgel", "Power Whip", "Spikes", "Superpower", "Synthesis"],
                 "teraTypes": ["Rock"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Ivy Cudgel", "Superpower", "Swords Dance", "Wood Hammer"],
+                "movepool": ["Ivy Cudgel", "Power Whip", "Superpower", "Swords Dance"],
                 "teraTypes": ["Rock"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2577,7 +2577,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Dark Pulse", "Focus Blast", "Psychic", "Thunderbolt", "Trick"],
+                "movepool": ["Calm Mind", "Dark Pulse", "Focus Blast", "Psychic", "Thunderbolt"],
                 "teraTypes": ["Dark", "Electric", "Fairy", "Flying", "Ghost", "Ground", "Psychic", "Steel"]
             },
             {

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -3312,8 +3312,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Knock Off", "Psychic Fangs", "Stealth Rock", "Stone Edge", "Swords Dance"],
-                "teraTypes": ["Fighting", "Rock"]
+                "movepool": ["Close Combat", "Knock Off", "Stealth Rock", "Stone Edge", "Sucker Punch", "Swords Dance"],
+                "teraTypes": ["Fighting"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2576,8 +2576,13 @@
         "level": 88,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Calm Mind", "Dark Pulse", "Psychic", "Thunderbolt", "Trick"],
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Dark Pulse", "Focus Blast", "Psychic", "Thunderbolt", "Trick"],
+                "teraTypes": ["Dark", "Electric", "Fairy", "Flying", "Ghost", "Ground", "Psychic", "Steel"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Dark Pulse", "Focus Blast", "Psychic", "Trick"],
                 "teraTypes": ["Dark", "Electric", "Fairy", "Flying", "Ghost", "Ground", "Psychic", "Steel"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2578,12 +2578,12 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Dark Pulse", "Focus Blast", "Psychic", "Thunderbolt"],
-                "teraTypes": ["Dark", "Electric", "Fairy", "Flying", "Ghost", "Ground", "Psychic", "Steel"]
+                "teraTypes": ["Dark", "Electric", "Fairy", "Fighting", "Flying", "Ghost", "Ground", "Psychic", "Steel"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dark Pulse", "Focus Blast", "Psychic", "Trick"],
-                "teraTypes": ["Dark", "Electric", "Fairy", "Flying", "Ghost", "Ground", "Psychic", "Steel"]
+                "teraTypes": ["Dark", "Fairy", "Fighting", "Flying", "Ghost", "Ground", "Psychic", "Steel"]
             }
         ]
     },

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1266,10 +1266,9 @@ export class RandomTeams {
 		if (role === 'AV Pivot') return 'Assault Vest';
 		if (species.id === 'pikachu') return 'Light Ball';
 		if (species.id === 'regieleki') return 'Magnet';
-		if (species.id === 'ursalunabloodmoon') return 'Silk Scarf';
 		if (moves.has('clangoroussoul') || (species.id === 'toxtricity' && moves.has('shiftgear'))) return 'Throat Spray';
 		if (species.baseSpecies === 'Magearna' && role === 'Tera Blast user') return 'Weakness Policy';
-		if (moves.has('lastrespects')) return 'Choice Scarf';
+		if (moves.has('lastrespects') || moves.has('dragonenergy')) return 'Choice Scarf';
 		if (
 			ability === 'Imposter' ||
 			(species.id === 'magnezone' && moves.has('bodypress') && !isDoubles)
@@ -1340,14 +1339,10 @@ export class RandomTeams {
 			['Doubles Fast Attacker', 'Doubles Wallbreaker', 'Doubles Setup Sweeper', 'Offensive Protect'].some(m => role === m)
 		);
 
+		if (species.id === 'ursalunabloodmoon') return 'Silk Scarf';
 		if (moves.has('covet')) return 'Normal Gem';
-		if (moves.has('thief')) return '';
-		if (moves.has('iciclespear') && ability !== 'Skill Link') return 'Loaded Dice';
 		if (species.id === 'calyrexice') return 'Weakness Policy';
-		if (
-			(['dragonenergy', 'waterspout'].some(m => moves.has(m))) &&
-			counter.get('Physical') + counter.get('Special') === 4
-		) return 'Choice Scarf';
+		if (moves.has('waterspout')) return 'Choice Scarf';
 		if (role === 'Choice Item user') {
 			if (scarfReqs || (counter.get('Physical') < 4 && counter.get('Special') < 3 && !moves.has('memento'))) {
 				return 'Choice Scarf';
@@ -1434,7 +1429,10 @@ export class RandomTeams {
 			);
 			return (scarfReqs && this.randomChance(1, 2)) ? 'Choice Scarf' : 'Choice Specs';
 		}
-		if (!counter.get('Status') && !['Fast Attacker', 'Wallbreaker', 'Tera Blast user'].includes(role)) {
+		if (
+			!counter.get('Status') &&
+			(moves.has('rapidspin') || !['Fast Attacker', 'Wallbreaker', 'Tera Blast user'].includes(role))
+		) {
 			return 'Assault Vest';
 		}
 		if (counter.get('speedsetup') && role === 'Bulky Setup') return 'Weakness Policy';
@@ -1450,7 +1448,7 @@ export class RandomTeams {
 		if (
 			(moves.has('chillyreception') || (
 				role === 'Fast Support' &&
-				['defog', 'partingshot', 'mortalspin', 'rapidspin', 'uturn', 'voltswitch'].some(m => moves.has(m)) &&
+				[...PIVOT_MOVES, 'defog', 'mortalspin', 'rapidspin'].some(m => moves.has(m)) &&
 				!types.includes('Flying') && ability !== 'Levitate'
 			))
 		) return 'Heavy-Duty Boots';
@@ -1621,7 +1619,8 @@ export class RandomTeams {
 		}
 
 		if (
-			moves.has('gyroball') || moves.has('trickroom') || (moves.has('flipturn') && moves.has('wish') && moves.has('scald'))
+			moves.has('gyroball') || moves.has('trickroom') ||
+			([...PIVOT_MOVES].some(m => moves.has(m)) && moves.has('wish') && species.baseStats.spe <= 70)
 		) {
 			evs.spe = 0;
 			ivs.spe = 0;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1314,6 +1314,7 @@ export class RandomTeams {
 			return 'Chesto Berry';
 		}
 		if (
+			species.id !== 'yanmega' &&
 			this.dex.getEffectiveness('Rock', species) >= 2 && (!types.includes('Flying') || !isDoubles)
 		) return 'Heavy-Duty Boots';
 	}

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1620,7 +1620,7 @@ export class RandomTeams {
 
 		if (
 			moves.has('gyroball') || moves.has('trickroom') ||
-			([...PIVOT_MOVES].some(m => moves.has(m)) && moves.has('wish') && species.baseStats.spe <= 70)
+			(PIVOT_MOVES.some(m => moves.has(m)) && moves.has('wish') && species.baseStats.spe <= 70)
 		) {
 			evs.spe = 0;
 			ivs.spe = 0;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1131,6 +1131,7 @@ export class RandomTeams {
 		if (species.id === 'arcaninehisui') return 'Rock Head';
 		if (species.id === 'scovillain') return 'Chlorophyll';
 		if (species.id === 'empoleon') return 'Competitive';
+		if (species.id === 'chandelure') return 'Flash Fire';
 		if (species.id === 'golemalola' && moves.has('doubleedge')) return 'Galvanize';
 		if (abilities.has('Guts') && (moves.has('facade') || moves.has('sleeptalk') || species.id === 'gurdurr')) return 'Guts';
 		if (species.id === 'copperajah' && moves.has('heavyslam')) return 'Heavy Metal';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1158,7 +1158,7 @@ export class RandomTeams {
 			if (species.id === 'farigiraf') return 'Armor Tail';
 			if (species.id === 'dragapult') return 'Clear Body';
 			if (species.id === 'altaria') return 'Cloud Nine';
-			if (species.id === 'armarouge' || species.id === 'chandelure') return 'Flash Fire';
+			if (species.id === 'armarouge') return 'Flash Fire';
 			if (species.id === 'florges') return 'Flower Veil';
 			if (
 				species.id === 'clefairy' ||


### PR DESCRIPTION
Gen 9 Random Battle:

-Gothitelle now has a set split: one Bulky Setup Calm Mind set, and one Choice Scarf Trick Fast Attacker set. Newly, both have Focus Blast.
-Tinted Lens Yanmega now actually gets Choice Specs.
-Choice Scarf Dragon Energy Regidrago now exists as a third set.
-Ogerpon-Cornerstone: -Wood Hammer, +Power Whip (because of Sturdy)
-Zapdos: +Tera Steel, -Thunderbolt, +Discharge, role changed to Bulky Attacker (now always gets Roost; no more Specs)
-Komala: +Tera Dark, no longer gets Choice Scarf.
-Ursaluna-Bloodmoon no longer gets Silk Scarf. That was an accident.
-Support Alolan Sandslash: -Swords Dance, +Knock Off
-Cosmic Power Clefable was removed.
-Even if the team already has a hazard remover, Cyclizar will get Heavy-Duty Boots.
-Rillaboom: -Tera Flying
-Torkoal's role changed to Fast Support (yes, i know) so that it can get Tera Dragon Lava Plume + Rapid Spin + Stealth Rock + Yawn as a possible set.
-Lycanroc-Midnight: -Psychic Fangs, -Tera Rock, +Sucker Punch; now always gets Close Combat.

Technical: 
-Speed reduction code has been generalized to include all pivot moves + wish + a speed stat at or below 70, instead of just being Wish + Flip Turn + Scald.
-Fast Support boots code now checks for all pivot moves, and not just specific ones.
-The Wallbreaker role now does not prevent Assault Vest with Rapid Spin.
-Dragon Energy gives a Choice Scarf.
-Removed some unnecessary Doubles item code.

Gen 9 Random Doubles:
-Illumise is now a fixed set of Encore + Bug Buzz + Tailwind + Thunder Wave.

Gens 6+7 Random Battle:
-Bulky Setup Kingdra (Critdra) was removed.
-Staller Illumise (the Substitute one) was removed.
-Torterra's roles were changed so its setup set gets Leftovers instead of a Life Orb.
-Sunflora: +HP Rock
-Mega Gyarados: -Ice Fang
-Cherrim: +Synthesis (and therefore Life Orb)
-Heatran: -Roar, +Taunt
-Kyurem-White: -Focus Blast
-Bouffalant: -Megahorn
-Sheer Force Tauros: +Fire Blast, +Preferred Type Ground (always gets Earthquake)
-Blaziken: -HP Ice, +Stone Edge
-Zangoose: +Preferred Type Dark (always gets Knock Off)

Gen 6 Random Battle specifically:
-Physical Mega Lucario: -Extreme Speed
-Spinda will no longer get Choice Band.
-Calm Mind Virizion was removed.
-Zygarde: +Glare