### PR TITLE
Fix Commander's interaction with Ability suppression

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -2720,7 +2720,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 					continue;
 				}
 				// Can't suppress a Tatsugiri inside of Dondozo already
-				if (!!target.volatiles['commanding']) {
+				if (target.volatiles['commanding']) {
 					continue;
 				}
 				if (target.illusion) {
@@ -3151,7 +3151,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (!this.effectState.target.hp) return;
 			const ability = target.getAbility();
 			const additionalBannedAbilities = [
-				'noability', 'flowergift', 'forecast', 'hungerswitch', 'illusion', 'imposter', 'neutralizinggas', 'powerofalchemy', 'receiver', 'trace', 'wonderguard',
+				'noability', 'commander', 'flowergift', 'forecast', 'hungerswitch', 'illusion', 'imposter', 'neutralizinggas', 'powerofalchemy', 'receiver', 'trace', 'wonderguard',
 			];
 			if (target.getAbility().isPermanent || additionalBannedAbilities.includes(target.ability)) return;
 			if (this.effectState.target.setAbility(ability)) {
@@ -3532,7 +3532,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (!this.effectState.target.hp) return;
 			const ability = target.getAbility();
 			const additionalBannedAbilities = [
-				'noability', 'flowergift', 'forecast', 'hungerswitch', 'illusion', 'imposter', 'neutralizinggas', 'powerofalchemy', 'receiver', 'trace', 'wonderguard',
+				'noability', 'commander', 'flowergift', 'forecast', 'hungerswitch', 'illusion', 'imposter', 'neutralizinggas', 'powerofalchemy', 'receiver', 'trace', 'wonderguard',
 			];
 			if (target.getAbility().isPermanent || additionalBannedAbilities.includes(target.ability)) return;
 			if (this.effectState.target.setAbility(ability)) {
@@ -4772,7 +4772,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 
 			const additionalBannedAbilities = [
 				// Zen Mode included here for compatability with Gen 5-6
-				'noability', 'flowergift', 'forecast', 'hungerswitch', 'illusion', 'imposter', 'neutralizinggas', 'powerofalchemy', 'receiver', 'trace', 'zenmode',
+				'noability', 'commander', 'flowergift', 'forecast', 'hungerswitch', 'illusion', 'imposter', 'neutralizinggas', 'powerofalchemy', 'receiver', 'trace', 'zenmode',
 			];
 			const possibleTargets = pokemon.adjacentFoes().filter(target => (
 				!target.getAbility().isPermanent && !additionalBannedAbilities.includes(target.ability)
@@ -4981,7 +4981,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	},
 	wanderingspirit: {
 		onDamagingHit(damage, target, source, move) {
-			const additionalBannedAbilities = ['hungerswitch', 'illusion', 'neutralizinggas', 'wonderguard'];
+			const additionalBannedAbilities = ['commander', 'hungerswitch', 'illusion', 'neutralizinggas', 'wonderguard'];
 			if (source.getAbility().isPermanent || additionalBannedAbilities.includes(source.ability) ||
 				target.volatiles['dynamax']
 			) {

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -592,7 +592,6 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				pokemon.removeVolatile('commanding');
 			}
 		},
-		isPermanent: true,
 		name: "Commander",
 		rating: 0,
 		num: 279,
@@ -2718,6 +2717,10 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			for (const target of this.getAllActive()) {
 				if (target.hasItem('Ability Shield')) {
 					this.add('-block', target, 'item: Ability Shield');
+					continue;
+				}
+				// Can't suppress a Tatsugiri inside of Dondozo already
+				if (!!target.volatiles['commanding']) {
 					continue;
 				}
 				if (target.illusion) {

--- a/data/mods/gen9predlc/abilities.ts
+++ b/data/mods/gen9predlc/abilities.ts
@@ -1,4 +1,8 @@
 export const Abilities: {[k: string]: ModdedAbilityData} = {
+	commander: {
+		inherit: true,
+		isPermanent: true,
+	},
 	hadronengine: {
 		inherit: true,
 		isPermanent: true,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -4863,7 +4863,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 
 			const additionalBannedSourceAbilities = [
 				// Zen Mode included here for compatability with Gen 5-6
-				'flowergift', 'forecast', 'hungerswitch', 'illusion', 'imposter', 'neutralizinggas', 'powerofalchemy', 'receiver', 'trace', 'zenmode',
+				'commander', 'flowergift', 'forecast', 'hungerswitch', 'illusion', 'imposter', 'neutralizinggas', 'powerofalchemy', 'receiver', 'trace', 'zenmode',
 			];
 			if (
 				target.ability === source.ability ||
@@ -15633,7 +15633,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 
 			const additionalBannedTargetAbilities = [
 				// Zen Mode included here for compatability with Gen 5-6
-				'flowergift', 'forecast', 'hungerswitch', 'illusion', 'imposter', 'neutralizinggas', 'powerofalchemy', 'receiver', 'trace', 'wonderguard', 'zenmode',
+				'commander', 'flowergift', 'forecast', 'hungerswitch', 'illusion', 'imposter', 'neutralizinggas', 'powerofalchemy', 'receiver', 'trace', 'wonderguard', 'zenmode',
 			];
 
 			if (target.getAbility().isPermanent || additionalBannedTargetAbilities.includes(target.ability) ||

--- a/test/sim/abilities/commander.js
+++ b/test/sim/abilities/commander.js
@@ -159,6 +159,7 @@ describe.only('Commander', function () {
 		battle = common.createBattle({gameType: 'doubles'}, [[
 			{species: 'shuckle', moves: ['sleeptalk']},
 			{species: 'weezing', ability: 'neutralizinggas', moves: ['sleeptalk']},
+			{species: 'wynaut', moves: ['sleeptalk']},
 		], [
 			{species: 'tatsugiri', ability: 'commander', moves: ['sleeptalk']},
 			{species: 'dondozo', moves: ['sleeptalk']},
@@ -167,6 +168,9 @@ describe.only('Commander', function () {
 
 		const dondozo = battle.p2.active[1];
 		assert.false(!!dondozo.volatiles['commanded']);
+
+		battle.makeChoices('move sleeptalk, switch 3', 'auto');
+		assert(!!dondozo.volatiles['commanded']);
 	});
 
 	it(`should not split apart Dondozo and Tatsugiri if Neutralizing Gas switches in`, function () {

--- a/test/sim/abilities/commander.js
+++ b/test/sim/abilities/commander.js
@@ -5,7 +5,7 @@ const common = require('./../../common');
 
 let battle;
 
-describe('Commander', function () {
+describe.only('Commander', function () {
 	afterEach(function () {
 		battle.destroy();
 	});
@@ -153,5 +153,56 @@ describe('Commander', function () {
 
 		const dondozo = battle.p4.active[0];
 		assert.false(!!dondozo.volatiles['commanded']);
+	});
+
+	it(`should prevent Dondozo and Tatsugiri from combining if Commander is suppressed`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'shuckle', moves: ['sleeptalk']},
+			{species: 'weezing', ability: 'neutralizinggas', moves: ['sleeptalk']},
+		], [
+			{species: 'tatsugiri', ability: 'commander', moves: ['sleeptalk']},
+			{species: 'dondozo', moves: ['sleeptalk']},
+			
+		]]);
+
+		const dondozo = battle.p2.active[1];
+		assert.false(!!dondozo.volatiles['commanded']);
+	});
+
+	it(`should not split apart Dondozo and Tatsugiri if Neutralizing Gas switches in`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'shuckle', moves: ['sleeptalk']},
+			{species: 'wynaut', moves: ['sleeptalk']},
+			{species: 'weezing', ability: 'neutralizinggas', moves: ['sleeptalk']},
+		], [
+			{species: 'tatsugiri', ability: 'commander', moves: ['dazzlinggleam']},
+			{species: 'dondozo', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices('switch 3, move sleeptalk', 'auto');
+		battle.makeChoices();
+
+		const dondozo = battle.p2.active[1];
+		assert(!!dondozo.volatiles['commanded']);
+
+		const shuckle = battle.p1.active[0];
+		assert.fullHP(shuckle, `Shuckle should have never taken damage from Dazzling Gleam`);
+	});
+
+	it.skip(`should activate after hazards run`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'regieleki', moves: ['toxicspikes']},
+			{species: 'registeel', moves: ['sleeptalk']},
+		], [
+			{species: 'shuckle', moves: ['uturn']},
+			{species: 'dondozo', moves: ['sleeptalk']},
+			{species: 'tatsugiri', ability: 'commander', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		battle.makeChoices();
+		const tatsugiri = battle.p2.pokemon[0];
+
+		assert(tatsugiri.status, 'psn');
 	});
 });

--- a/test/sim/abilities/commander.js
+++ b/test/sim/abilities/commander.js
@@ -5,7 +5,7 @@ const common = require('./../../common');
 
 let battle;
 
-describe.only('Commander', function () {
+describe('Commander', function () {
 	afterEach(function () {
 		battle.destroy();
 	});
@@ -163,7 +163,6 @@ describe.only('Commander', function () {
 		], [
 			{species: 'tatsugiri', ability: 'commander', moves: ['sleeptalk']},
 			{species: 'dondozo', moves: ['sleeptalk']},
-			
 		]]);
 
 		const dondozo = battle.p2.active[1];


### PR DESCRIPTION
As of DLC1, Commander can now be suppressed by Gastro Acid, Neutralizing Gas, etc. If a Pokemon with Neutralizing Gas switches in while the Tatsugiri and Dondozo are combined, they don't split apart. In addition, various other means of replacing Commander now work, though methods of giving Commander to something else do not. I've implemented all of these except Doodle, because apparently we don't implement additional banned Abilities for Doodle at all right now, so I'll want to do research to verify the full list (though it's almost certainly the same as the Role Play list).

Role Play (user) - works
Role Play (target) - fails
Skill Swap - fails
Entrainment (user) - fails
Entrainment (target) - works
Simple Beam - works
Worry Seed - works
Doodle (user) - works
Doodle (ally) - works
Doodle (target) - fails

Trace - fails
Power of Alchemy - fails
Mummy - works
Lingering Aroma - works
Wandering Spirit - fails