### PR TITLE
Update VGC/BSS ladders

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -409,7 +409,7 @@ export const Formats: FormatList = [
 		mod: 'gen9',
 		gameType: 'doubles',
 		challengeShow: false,
-		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 9', 'VGC Timer', 'Force Open Team Sheets, Best of = 3'],
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 9', 'VGC Timer', 'Force Open Team Sheets', 'Best of = 3'],
 		banlist: ['Walking Wake', 'Iron Leaves'],
 	},
 	{

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -409,7 +409,7 @@ export const Formats: FormatList = [
 		mod: 'gen9',
 		gameType: 'doubles',
 		challengeShow: false,
-		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 9', 'VGC Timer', 'Force Open Team Sheets'],
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 9', 'VGC Timer', 'Force Open Team Sheets, Best of = 3'],
 		banlist: ['Walking Wake', 'Iron Leaves'],
 	},
 	{

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -283,16 +283,10 @@ export const Formats: FormatList = [
 		],
 	},
 	{
-		name: "[Gen 9] Battle Stadium Singles Regulation C",
-
-		mod: 'gen9predlc',
-		searchShow: false,
-		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer'],
-	},
-	{
 		name: "[Gen 9] Battle Stadium Singles Regulation D",
 
 		mod: 'gen9predlc',
+		searchShow: false,
 		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 9', 'VGC Timer'],
 		banlist: ['Walking Wake', 'Iron Leaves'],
 	},
@@ -300,7 +294,6 @@ export const Formats: FormatList = [
 		name: "[Gen 9] Battle Stadium Singles Regulation E",
 
 		mod: 'gen9',
-		searchShow: false,
 		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 9', 'VGC Timer'],
 		banlist: ['Walking Wake', 'Iron Leaves'],
 	},
@@ -394,18 +387,11 @@ export const Formats: FormatList = [
 		],
 	},
 	{
-		name: "[Gen 9] VGC 2023 Regulation C",
-
-		mod: 'gen9predlc',
-		gameType: 'doubles',
-		searchShow: false,
-		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Paldea Pokedex', 'Min Source Gen = 9', 'VGC Timer', 'Open Team Sheets'],
-	},
-	{
 		name: "[Gen 9] VGC 2023 Regulation D",
 
 		mod: 'gen9predlc',
 		gameType: 'doubles',
+		searchShow: false,
 		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 9', 'VGC Timer', 'Open Team Sheets'],
 		banlist: ['Walking Wake', 'Iron Leaves'],
 	},
@@ -415,6 +401,15 @@ export const Formats: FormatList = [
 		mod: 'gen9',
 		gameType: 'doubles',
 		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 9', 'VGC Timer', 'Open Team Sheets'],
+		banlist: ['Walking Wake', 'Iron Leaves'],
+	},
+	{
+		name: "[Gen 9] VGC 2023 Regulation E (Bo3)",
+
+		mod: 'gen9',
+		gameType: 'doubles',
+		challengeShow: false,
+		ruleset: ['Flat Rules', '!! Adjust Level = 50', 'Min Source Gen = 9', 'VGC Timer', 'Force Open Team Sheets'],
 		banlist: ['Walking Wake', 'Iron Leaves'],
 	},
 	{


### PR DESCRIPTION
- Removes Reg C formats
- Removes Reg D ladders
- Enables Reg E ladder for BSS
- Adds new best-of-three ladder for VGC with forced open team sheets

Edit: this can be merged at any time now.