### PR TITLE
Randomized format set updates

### DIFF
--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -1592,7 +1592,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthpower", "gigadrain", "hiddenpowerfire", "leafstorm", "nastyplot", "psychic", "uturn"]
+                "movepool": ["earthpower", "gigadrain", "hiddenpowerfire", "leafstorm", "nastyplot", "psychic", "uturn"],
+                "preferredTypes": ["Psychic"]
             },
             {
                 "role": "Bulky Support",

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -1308,6 +1308,20 @@
             }
         ]
     },
+    "murkrow": {
+        "level": 90,
+        "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["bravebird", "defog", "haze", "pursuit", "roost", "thunderwave"]
+            },
+            {
+                "role": "Z-Move user",
+                "movepool": ["bravebird", "mirrormove", "protect", "suckerpunch"],
+                "preferredTypes": ["Flying"]
+            }
+        ]
+    },
     "slowking": {
         "level": 88,
         "sets": [
@@ -1742,7 +1756,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthpower", "gigadrain", "hiddenpowerfire", "leafstorm", "nastyplot", "psychic", "uturn"]
+                "movepool": ["earthpower", "gigadrain", "hiddenpowerfire", "leafstorm", "nastyplot", "psychic", "uturn"],
+                "preferredTypes": ["Psychic"]
             },
             {
                 "role": "Bulky Support",

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -409,7 +409,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Clear Smog", "Fire Blast", "Gunk Shot", "Protect", "Taunt", "Toxic", "Will-O-Wisp"],
+                "movepool": ["Clear Smog", "Fire Blast", "Gunk Shot", "Poison Gas", "Protect", "Taunt", "Will-O-Wisp"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -419,7 +419,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Fire Blast", "Gunk Shot", "Haze", "Protect", "Strange Steam", "Taunt", "Toxic", "Will-O-Wisp"],
+                "movepool": ["Fire Blast", "Gunk Shot", "Haze", "Poison Gas", "Protect", "Strange Steam", "Taunt", "Will-O-Wisp"],
                 "teraTypes": ["Dark", "Steel"]
             }
         ]
@@ -1369,8 +1369,8 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Precipice Blades", "Protect", "Stealth Rock", "Stone Edge", "Thunder Wave"],
-                "teraTypes": ["Steel"]
+                "movepool": ["Heat Crash", "Precipice Blades", "Protect", "Stone Edge", "Thunder Wave"],
+                "teraTypes": ["Fire"]
             },
             {
                 "role": "Doubles Bulky Setup",

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2054,7 +2054,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Draco Meteor", "Fire Blast", "Heavy Slam", "Stealth Rock", "Thunder Wave"],
+                "movepool": ["Draco Meteor", "Fire Blast", "Heavy Slam", "Stealth Rock", "Thunderbolt", "Thunder Wave"],
                 "teraTypes": ["Dragon", "Fire", "Steel"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -4566,7 +4566,7 @@
                 "teraTypes": ["Fighting"]
             },
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Support",
                 "movepool": ["Body Press", "Poltergeist", "Rest", "Sleep Talk"],
                 "teraTypes": ["Fighting"]
             },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -620,7 +620,7 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Calm Mind", "Freezing Glare", "Hurricane", "Recover"],
-                "teraTypes": ["Psychic", "Steel"]
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -1355,7 +1355,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Brave Bird", "Dragon Dance", "Earthquake", "Roost"],
-                "teraTypes": ["Flying", "Ground"]
+                "teraTypes": ["Ground", "Steel"]
             }
         ]
     },
@@ -1764,7 +1764,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Slack Off", "Stealth Rock", "Stone Edge", "Whirlwind", "Yawn"],
+                "movepool": ["Earthquake", "Roar", "Slack Off", "Stealth Rock", "Stone Edge"],
                 "teraTypes": ["Dragon", "Rock", "Steel"]
             }
         ]
@@ -1929,8 +1929,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Earthquake", "Leech Life", "Pain Split", "Poltergeist", "Shadow Sneak", "Trick"],
-                "teraTypes": ["Ghost"]
+                "movepool": ["Earthquake", "Ice Punch", "Leech Life", "Pain Split", "Poltergeist", "Shadow Sneak", "Trick"],
+                "teraTypes": ["Dark", "Ghost", "Ground"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Earthquake", "Haze", "Pain Split", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
+                "teraTypes": ["Dark", "Fairy"]
             }
         ]
     },
@@ -2049,7 +2054,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Draco Meteor", "Fire Blast", "Flash Cannon", "Stealth Rock", "Thunder Wave", "Thunderbolt"],
+                "movepool": ["Draco Meteor", "Fire Blast", "Heavy Slam", "Stealth Rock", "Thunder Wave"],
                 "teraTypes": ["Dragon", "Fire", "Steel"]
             }
         ]
@@ -2314,7 +2319,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Focus Blast", "Hex", "Recover", "Will-O-Wisp"],
+                "movepool": ["Focus Blast", "Judgment", "Recover", "Will-O-Wisp"],
                 "teraTypes": ["Fighting", "Normal"]
             },
             {
@@ -2525,22 +2530,27 @@
         ]
     },
     "basculegion": {
-        "level": 68,
+        "level": 86,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["Aqua Jet", "Flip Turn", "Last Respects", "Wave Crash"],
-                "teraTypes": ["Ghost"]
+                "role": "AV Pivot",
+                "movepool": ["Aqua Jet", "Flip Turn", "Shadow Ball", "Wave Crash"],
+                "teraTypes": ["Water"]
             }
         ]
     },
     "basculegionf": {
-        "level": 69,
+        "level": 85,
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Flip Turn", "Hydro Pump", "Last Respects", "Wave Crash"],
-                "teraTypes": ["Ghost"]
+                "movepool": ["Flip Turn", "Hydro Pump", "Ice Beam", "Shadow Ball"],
+                "teraTypes": ["Water"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Flip Turn", "Hydro Pump", "Shadow Ball", "Wave Crash"],
+                "teraTypes": ["Water"]
             }
         ]
     },
@@ -3092,13 +3102,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Drain Punch", "Horn Leech", "Poltergeist", "Trick Room", "Wood Hammer"],
+                "movepool": ["Drain Punch", "Horn Leech", "Poltergeist", "Rest", "Trick Room", "Wood Hammer"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Leech Seed", "Poltergeist", "Protect", "Substitute"],
-                "teraTypes": ["Dark", "Fairy", "Steel"]
+                "movepool": ["Drain Punch", "Poltergeist", "Protect", "Toxic"],
+                "teraTypes": ["Dark", "Fairy", "Fighting", "Steel"]
             }
         ]
     },
@@ -3118,7 +3128,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Avalanche", "Body Press", "Rapid Spin", "Recover", "Stone Edge"],
-                "teraTypes": ["Flying", "Poison"]
+                "teraTypes": ["Flying", "Ghost", "Poison"]
             }
         ]
     },
@@ -4458,7 +4468,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Encore", "Gigaton Hammer", "Knock Off", "Play Rough", "Stealth Rock", "Thunder Wave"],
-                "teraTypes": ["Steel"]
+                "teraTypes": ["Water"]
             },
             {
                 "role": "Setup Sweeper",
@@ -4548,12 +4558,22 @@
         ]
     },
     "houndstone": {
-        "level": 73,
+        "level": 87,
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Body Press", "Last Respects", "Trick", "Will-O-Wisp"],
-                "teraTypes": ["Ghost"]
+                "movepool": ["Body Press", "Poltergeist", "Roar", "Shadow Sneak", "Trick", "Will-O-Wisp"],
+                "teraTypes": ["Fighting"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Press", "Poltergeist", "Rest", "Sleep Talk"],
+                "teraTypes": ["Fighting"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Body Press", "Play Rough", "Poltergeist", "Shadow Sneak"],
+                "teraTypes": ["Fairy", "Fighting"]
             }
         ]
     },
@@ -4967,7 +4987,12 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Collision Course", "Flare Blitz", "Outrage", "Swords Dance", "U-turn"],
+                "movepool": ["Collision Course", "Flare Blitz", "Outrage", "U-turn"],
+                "teraTypes": ["Fire"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Collision Course", "Flare Blitz", "Scale Shot", "Swords Dance"],
                 "teraTypes": ["Fire"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2054,7 +2054,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Draco Meteor", "Fire Blast", "Heavy Slam", "Stealth Rock", "Thunderbolt", "Thunder Wave"],
+                "movepool": ["Draco Meteor", "Fire Blast", "Heavy Slam", "Stealth Rock", "Thunder Wave", "Thunderbolt"],
                 "teraTypes": ["Dragon", "Fire", "Steel"]
             }
         ]

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -120,7 +120,7 @@ const PRIORITY_POKEMON = [
 
 /** Pokemon who should never be in the lead slot */
 const NO_LEAD_POKEMON = [
-	'Basculegion', 'Houndstone', 'Rillaboom', 'Zacian', 'Zamazenta',
+	'Rillaboom', 'Zacian', 'Zamazenta',
 ];
 const DOUBLES_NO_LEAD_POKEMON = [
 	'Basculegion', 'Houndstone', 'Roaring Moon', 'Zacian', 'Zamazenta',
@@ -199,10 +199,10 @@ export class RandomTeams {
 				return abilities.has('Psychic Surge') || types.includes('Fire') || types.includes('Electric') || types.includes('Fighting');
 			},
 			Rock: (movePool, moves, abilities, types, counter, species) => !counter.get('Rock') && species.baseStats.atk >= 80,
-			Steel: (movePool, moves, abilities, types, counter, species, teamDetails, isLead, isDoubles) => {
-				if (!isDoubles && species.baseStats.atk <= 95 && !movePool.includes('makeitrain')) return false;
-				return !counter.get('Steel');
-			},
+			Steel: (movePool, moves, abilities, types, counter, species, teamDetails, isLead, isDoubles) => (
+				!counter.get('Steel') &&
+				(isDoubles || species.baseStats.atk > 95 || movePool.includes('gigatonhammer') || movePool.includes('makeitrain'))
+			),
 			Water: (movePool, moves, abilities, types, counter, species) => {
 				if (types.includes('Ground')) return false;
 				return !counter.get('Water');
@@ -492,7 +492,7 @@ export class RandomTeams {
 				[PROTECT_MOVES, 'wideguard'],
 				[['fierydance', 'fireblast'], 'heatwave'],
 				['dazzlinggleam', ['fleurcannon', 'moonblast']],
-				['poisongas', 'toxicspikes'],
+				['poisongas', ['toxicspikes', 'willowisp']],
 				[RECOVERY_MOVES, 'healpulse'],
 				['lifedew', 'healpulse'],
 				['haze', 'icywind'],
@@ -1146,7 +1146,7 @@ export class RandomTeams {
 			if (species.id === 'enamorus' && moves.has('calmmind')) return 'Cute Charm';
 			if (species.id === 'klawf' && role === 'Setup Sweeper') return 'Anger Shell';
 			if (abilities.has('Cud Chew') && moves.has('substitute')) return 'Cud Chew';
-			if (abilities.has('Harvest') && moves.has('substitute')) return 'Harvest';
+			if (abilities.has('Harvest') && (moves.has('protect') || moves.has('substitute'))) return 'Harvest';
 			if (abilities.has('Serene Grace') && moves.has('headbutt')) return 'Serene Grace';
 			if (abilities.has('Own Tempo') && moves.has('petaldance')) return 'Own Tempo';
 			if (abilities.has('Slush Rush') && moves.has('snowscape')) return 'Slush Rush';
@@ -1289,7 +1289,7 @@ export class RandomTeams {
 		if (['healingwish', 'switcheroo', 'trick'].some(m => moves.has(m))) {
 			if (
 				species.baseStats.spe >= 60 && species.baseStats.spe <= 108 &&
-				role !== 'Wallbreaker' && role !== 'Doubles Wallbreaker'
+				role !== 'Wallbreaker' && role !== 'Doubles Wallbreaker' && !counter.get('priority')
 			) {
 				return 'Choice Scarf';
 			} else {


### PR DESCRIPTION
**Gen 9 Random Battle:**
-Bulky Attacker Tinkaton: -tera steel, +tera water, enforce Gigaton Hammer
-Avalugg-Hisui: +tera ghost
-Wallbreaker Trevenant: +rest
-Bulky Support Trevenant: -leechseed, -substitute, +drainpunch, +toxic, +tera fighting
-Wallbreaker Dusknoir: +icepunch, +tera ground, +tera dark
-add Dusknoir set 2: Bulky Support, polter sneak eq haze split wisp, tera dark/fairy
-Koraidon set split: set 1 is the current choiced set, set 2 is swords dance with scale shot over outrage
-Bulky Support Arceus-Ghost: -hex, +judgment
-Hippowdon: -yawn, -whirlwind, +roar
-Setup Altaria: -tera flying, +tera steel
-Dialga: -tbolt, -flashcannon, +heavyslam
-Articuno-Galar: -tera psychic

-prevent priority + trick from giving scarf (trick houndstone will be band)
-allow lead Houndstone and Basculegion
-Houndstone: level 87
Set 1: Bulky Attacker, poltergeist body press shadow sneak and a roll between trick/wisp/roar, tera fighting
Set 2: Bulky Support, resttalk polter press, tera fighting
Set 3: AV Pivot, polter press sneak play rough. tera fighting/fairy.

-Basculegion-F: level 85, tera water only
Set 1: Wallbreaker with hydro pump, flip turn, ice beam, shadow ball.
Set 2: AV Pivot with wave crash, hydro pump, flip turn, and shadow ball.

-Bascu-M: Level 86, tera water only
AV Pivot with wave crash, aqua jet, shadow ball, and flip turn.

**Gen 9 Random Doubles Battle:**
-Doubles Bulky Attacker Groudon: -stealthrock, +heatcrash, tera fire only
-Weezing and Weezing-Galar: -toxic, +poisongas; poison gas incompatible with wisp

**Gen 7 Random Battle:**
-Add Murkrow at level 90
Set 1: Z-Mirror Move (+2 attack, uses the Z move of the mirrored move), Brave Bird, Sucker Punch, Protect.
Set 2: Bulky Attacker. Brave Bird + Roost + Thunder Wave + random roll between Haze, Pursuit, and Defog

**Gen 6+7 Random Battle:**
-Fast Attacker Celebi now always gets Psychic.