### PR TITLE
Move Vikavolt to DUU

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -4266,7 +4266,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 	},
 	vikavolt: {
 		tier: "RU",
-		doublesTier: "DOU",
+		doublesTier: "DUU",
 		natDexTier: "RU",
 	},
 	vikavolttotem: {


### PR DESCRIPTION
Vikavolt should be DUU as per https://www.smogon.com/forums/threads/usage-based-tier-update-for-october-2023.3728796/post-9803994 and is currently erroneously listed as DOU

(edit to add Arcticblast requested this change)