### PR TITLE
Send Open Team Sheets to client in packed format

### DIFF
--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1712,17 +1712,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 		desc: "Allows each player to see the Pok&eacute;mon and all non-stat information about them, before they choose their lead Pok&eacute;mon",
 		mutuallyExclusiveWith: 'openteamsheets',
 		onTeamPreview() {
-			let buf = 'raw|';
-			for (const side of this.sides) {
-				buf += Utils.html`<div class="infobox" style="margin-top:5px"><details><summary>Open Team Sheet for ${side.name}</summary>${Teams.export(side.team, {hideStats: true})}</details></div>`;
-			}
-			if (this.rated === true) {
-				for (const side of this.sides) {
-					this.addSplit(side.id, [buf]);
-				}
-			} else {
-				this.add(buf);
-			}
+			this.showOpenTeamSheets(this.rated === true);
 		},
 	},
 	aaarestrictedabilities: {

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -2,7 +2,6 @@
 
 import {Utils} from "../lib";
 import {Pokemon} from "../sim/pokemon";
-import {Teams} from "../sim/teams";
 
 // The list of formats is stored in config/formats.js
 export const Rulesets: {[k: string]: FormatData} = {

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1694,6 +1694,11 @@ export const Rulesets: {[k: string]: FormatData} = {
 		name: 'Open Team Sheets',
 		desc: "Allows each player to see the Pok&eacute;mon and all non-stat information about them, before they choose their lead Pok&eacute;mon",
 		mutuallyExclusiveWith: 'forceopenteamsheets',
+		onValidateRule() {
+			if (!(this.ruleTable.has('teampreview') || this.ruleTable.has('teamtypepreview'))) {
+				throw new Error(`The "Open Team Sheets" rule${this.ruleTable.blame('openteamsheets')} requires Team Preview.`);
+			}
+		},
 		onTeamPreview() {
 			const msg = 'uhtml|otsrequest|<button name="send" value="/acceptopenteamsheets" class="button" style="margin-right: 10px;"><strong>Accept Open Team Sheets</strong></button><button name="send" value="/rejectopenteamsheets" class="button" style="margin-top: 10px"><strong>Deny Open Team Sheets</strong></button>';
 			for (const side of this.sides) {
@@ -1711,6 +1716,11 @@ export const Rulesets: {[k: string]: FormatData} = {
 		name: 'Force Open Team Sheets',
 		desc: "Allows each player to see the Pok&eacute;mon and all non-stat information about them, before they choose their lead Pok&eacute;mon",
 		mutuallyExclusiveWith: 'openteamsheets',
+		onValidateRule() {
+			if (!(this.ruleTable.has('teampreview') || this.ruleTable.has('teamtypepreview'))) {
+				throw new Error(`The "Force Open Team Sheets" rule${this.ruleTable.blame('forceopenteamsheets')} requires Team Preview.`);
+			}
+		},
 		onTeamPreview() {
 			this.showOpenTeamSheets(this.rated === true);
 		},

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -784,7 +784,7 @@ export const commands: Chat.ChatCommands = {
 		game.confirmReady(user.id);
 	},
 
-	async acceptopenteamsheets(target, room, user, connection, cmd) {
+	acceptopenteamsheets(target, room, user, connection, cmd) {
 		room = this.requireRoom();
 		const battle = room.battle;
 		if (!battle) return this.errorReply(this.tr`Must be in a battle room.`);

--- a/server/chat-commands/core.ts
+++ b/server/chat-commands/core.ts
@@ -810,15 +810,7 @@ export const commands: Chat.ChatCommands = {
 
 		this.add(this.tr`${user.name} has agreed to open team sheets.`);
 		if (battle.players.every(curPlayer => curPlayer.wantsOpenTeamSheets)) {
-			let buf = '|uhtml|ots|';
-			for (const curPlayer of battle.players) {
-				const team = await battle.getTeam(curPlayer.id);
-				if (!team) continue;
-				buf += Utils.html`<div class="infobox" style="margin-top:5px"><details><summary>Open Team Sheet for ${curPlayer.name}</summary>${Teams.export(team, {hideStats: true})}</details></div>`;
-			}
-			for (const curPlayer of battle.players) {
-				curPlayer.sendRoom(buf);
-			}
+			void battle.stream.write('>show-openteamsheets');
 		}
 	},
 	acceptopenteamsheetshelp: [`/acceptopenteamsheets - Agrees to an open team sheet opportunity during Team Preview, where all information on a team except stats is shared with the opponent. Requires: \u2606`],

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -2014,23 +2014,6 @@ export class GameRoom extends BasicRoom {
 			this.reportJoin('j', user.getIdentityWithStatus(this), user);
 		}
 
-		// This is only here because of an issue with private logs not getting resent
-		// when a user reloads on a battle and autojoins. This should be removed when that gets fixed.
-		void (async () => {
-			if (this.battle) {
-				const player = this.battle.playerTable[user.id];
-				if (player && this.battle.players.every(curPlayer => curPlayer.wantsOpenTeamSheets)) {
-					let buf = '|uhtml|ots|';
-					for (const curPlayer of this.battle.players) {
-						const team = await this.battle.getTeam(curPlayer.id);
-						if (!team) continue;
-						buf += Utils.html`<div class="infobox" style="margin-top:5px"><details><summary>Open Team Sheet for ${curPlayer.name}</summary>${Teams.export(team, {hideStats: true})}</details></div>`;
-					}
-					player.sendRoom(buf);
-				}
-			}
-		})();
-
 		this.users[user.id] = user;
 		this.userCount++;
 		this.checkAutoModchat(user);

--- a/sim/battle-stream.ts
+++ b/sim/battle-stream.ts
@@ -224,6 +224,9 @@ export class BattleStream extends Streams.ObjectReadWriteStream<string> {
 			const team = Teams.pack(side.team);
 			this.push(`requesteddata\n${team}`);
 			break;
+		case 'show-openteamsheets':
+			this.battle!.showOpenTeamSheets(this.battle!.rated === true);
+			break;
 		case 'version':
 		case 'version-origin':
 			break;

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -3008,7 +3008,7 @@ export class Battle {
 				// Only display Hidden Power type if the Pokemon has Hidden Power
 				// This is based on how team sheets were written in past VGC formats
 				if (!set.moves.some(m => this.dex.moves.get(m).id === 'hiddenpower')) delete newSet.hpType;
-				// This is mainly done so the client doesn't flag Zacian/Zamazenta as illusions
+				// This is done so the client doesn't flag Zacian/Zamazenta as illusions
 				// when they use their signature move
 				if ((toID(set.species) === 'zacian' && toID(set.item) === 'rustedsword') ||
 					(toID(set.species) === 'zamazenta' && toID(set.item) === 'rustedshield')) {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -3019,7 +3019,7 @@ export class Battle {
 					}
 				}
 				return newSet;
-			})
+			});
 			if (hideFromSpectators) {
 				for (const s of this.sides) {
 					this.addSplit(s.id, ['showteam', side.id, Teams.pack(team)]);

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2998,13 +2998,27 @@ export class Battle {
 		if (this.turn !== 0) return;
 		for (const side of this.sides) {
 			const team = side.team.map(set => {
-				return {
+				const newSet = {
 					...set,
 					shiny: false,
 					evs: null!,
 					ivs: null!,
 					nature: '',
 				};
+				// This is mainly done so the client doesn't flag Zacian/Zamazenta as illusions
+				// when they use their signature move
+				if ((toID(newSet.species) === 'zacian' && toID(newSet.item) === 'rustedsword') ||
+					(toID(newSet.species) === 'zamazenta' && toID(newSet.item) === 'rustedshield')) {
+					newSet.species = Dex.species.get(set.species + 'crowned').name;
+					const crowned: {[k: string]: string} = {
+						'Zacian-Crowned': 'behemothblade', 'Zamazenta-Crowned': 'behemothbash',
+					};
+					const ironHead = newSet.moves.map(toID).indexOf('ironhead' as ID);
+					if (ironHead >= 0) {
+						newSet.moves[ironHead] = crowned[newSet.species];
+					}
+				}
+				return newSet;
 			})
 			if (hideFromSpectators) {
 				for (const s of this.sides) {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2994,6 +2994,28 @@ export class Battle {
 		return team as PokemonSet[];
 	}
 
+	showOpenTeamSheets(hideFromSpectators = false) {
+		if (this.turn !== 0) return;
+		for (const side of this.sides) {
+			const team = side.team.map(set => {
+				return {
+					...set,
+					shiny: false,
+					evs: null!,
+					ivs: null!,
+					nature: '',
+				};
+			})
+			if (hideFromSpectators) {
+				for (const s of this.sides) {
+					this.addSplit(s.id, ['showteam', side.id, Teams.pack(team)]);
+				}
+			} else {
+				this.add('showteam', side.id, Teams.pack(team));
+			}
+		}
+	}
+
 	setPlayer(slot: SideID, options: PlayerOptions) {
 		let side;
 		let didSomething = true;

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -3005,15 +3005,18 @@ export class Battle {
 					ivs: null!,
 					nature: '',
 				};
+				// Only display Hidden Power type if the Pokemon has Hidden Power
+				// This is based on how team sheets were written in past VGC formats
+				if (!set.moves.some(m => this.dex.moves.get(m).id === 'hiddenpower')) delete newSet.hpType;
 				// This is mainly done so the client doesn't flag Zacian/Zamazenta as illusions
 				// when they use their signature move
-				if ((toID(newSet.species) === 'zacian' && toID(newSet.item) === 'rustedsword') ||
-					(toID(newSet.species) === 'zamazenta' && toID(newSet.item) === 'rustedshield')) {
+				if ((toID(set.species) === 'zacian' && toID(set.item) === 'rustedsword') ||
+					(toID(set.species) === 'zamazenta' && toID(set.item) === 'rustedshield')) {
 					newSet.species = Dex.species.get(set.species + 'crowned').name;
 					const crowned: {[k: string]: string} = {
 						'Zacian-Crowned': 'behemothblade', 'Zamazenta-Crowned': 'behemothbash',
 					};
-					const ironHead = newSet.moves.map(toID).indexOf('ironhead' as ID);
+					const ironHead = set.moves.map(toID).indexOf('ironhead' as ID);
 					if (ironHead >= 0) {
 						newSet.moves[ironHead] = crowned[newSet.species];
 					}

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1058,6 +1058,9 @@ export class TeamValidator {
 				set.ivs = TeamValidator.fillStats(dex.types.get(set.hpType).HPivs, 31);
 			}
 		}
+		if (!set.hpType && set.moves.some(m => dex.moves.get(m).id === 'hiddenpower')) {
+			set.hpType = dex.getHiddenPower(set.ivs).type;
+		}
 
 		const cantBreedNorEvolve = (species.eggGroups[0] === 'Undiscovered' && !species.prevo && !species.nfe);
 		const isLegendary = (cantBreedNorEvolve && !species.tags.includes('Paradox') && ![


### PR DESCRIPTION
Meant to supersede #9605

This is meant to do the same thing as the previous behavior but with a much cleaner (imo) implementation. Instead of modifying `poke`, this uses a new `showteam` protocol that sends the OTS in a packed format to the client. The client will then unpack the given team, handle clearing/readding the pokemon, populate the tooltips, and display the paste in the battle chat.