### PR TITLE
Syrup Bomb fixes

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -417,7 +417,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (source && target === source) return;
 			if (boost.def && boost.def < 0) {
 				delete boost.def;
-				if (!(effect as ActiveMove).secondaries && !['octolock', 'syrupbomb'].includes(effect.id)) {
+				if (!(effect as ActiveMove).secondaries && effect.id !== 'octolock') {
 					this.add("-fail", target, "unboost", "Defense", "[from] ability: Big Pecks", "[of] " + target);
 				}
 			}

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -417,7 +417,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (source && target === source) return;
 			if (boost.def && boost.def < 0) {
 				delete boost.def;
-				if (!(effect as ActiveMove).secondaries && effect.id !== 'octolock') {
+				if (!(effect as ActiveMove).secondaries && !['octolock', 'syrupbomb'].includes(effect.id)) {
 					this.add("-fail", target, "unboost", "Defense", "[from] ability: Big Pecks", "[of] " + target);
 				}
 			}
@@ -497,7 +497,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 					showMsg = true;
 				}
 			}
-			if (showMsg && !(effect as ActiveMove).secondaries && effect.id !== 'octolock') {
+			if (showMsg && !(effect as ActiveMove).secondaries && !['octolock', 'syrupbomb'].includes(effect.id)) {
 				this.add("-fail", target, "unboost", "[from] ability: Clear Body", "[of] " + target);
 			}
 		},
@@ -1433,7 +1433,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 					showMsg = true;
 				}
 			}
-			if (showMsg && !(effect as ActiveMove).secondaries && effect.id !== 'octolock') {
+			if (showMsg && !(effect as ActiveMove).secondaries && !['octolock', 'syrupbomb'].includes(effect.id)) {
 				this.add("-fail", target, "unboost", "[from] ability: Full Metal Body", "[of] " + target);
 			}
 		},
@@ -5136,7 +5136,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 					showMsg = true;
 				}
 			}
-			if (showMsg && !(effect as ActiveMove).secondaries && effect.id !== 'octolock') {
+			if (showMsg && !(effect as ActiveMove).secondaries && !['octolock', 'syrupbomb'].includes(effect.id)) {
 				this.add("-fail", target, "unboost", "[from] ability: White Smoke", "[of] " + target);
 			}
 		},

--- a/data/items.ts
+++ b/data/items.ts
@@ -1032,7 +1032,7 @@ export const Items: {[itemid: string]: ItemData} = {
 					showMsg = true;
 				}
 			}
-			if (showMsg && !(effect as ActiveMove).secondaries && effect.id !== 'octolock') {
+			if (showMsg && !(effect as ActiveMove).secondaries && !['octolock', 'syrupbomb'].includes(effect.id)) {
 				this.add('-fail', target, 'unboost', '[from] item: Clear Amulet', '[of] ' + target);
 			}
 		},

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -19247,7 +19247,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {protect: 1, mirror: 1, bullet: 1},
 		condition: {
 			noCopy: true,
-			duration: 3,
+			duration: 4,
 			onStart(pokemon) {
 				this.add('-start', pokemon, 'Syrup Bomb');
 			},
@@ -19256,7 +19256,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.boost({spe: -1});
 			},
 			onEnd(pokemon) {
-				this.add('-end', pokemon, 'Syrup Bomb');
+				this.add('-end', pokemon, 'Syrup Bomb', '[silent]');
 			},
 		},
 		secondary: {

--- a/test/sim/moves/syrupbomb.js
+++ b/test/sim/moves/syrupbomb.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe('Syrup Bomb', function () {
+    afterEach(function () {
+        battle.destroy();
+    });
+
+    it(`should lower the opponent's Speed for 3 turns, but not remove its volatile until after 4 turns`, function () {
+        battle = common.createBattle([[
+            {species: 'Wynaut', ability: 'noguard', moves: ['syrupbomb']},
+        ], [
+            {species: 'Applin', moves: ['sleeptalk']},
+        ]]);
+
+        for (let i = 0; i < 3; i++) battle.makeChoices();
+        const applin = battle.p2.active[0];
+        assert.statStage(applin, 'spe', -3);
+        assert(applin.volatiles['syrupbomb'], `Applin should have the Syrup Bomb volatile for another turn`);
+
+        battle.makeChoices();
+        assert.statStage(applin, 'spe', -3);
+        assert.false(applin.volatiles['syrupbomb'], `Applin should no longer have the Syrup Bomb volatile`);
+    });
+});


### PR DESCRIPTION
- Fix duration (was only dropping speed for 2 turns)
- End the volatile silently on client
- Remove Clear Amulet (and similar effects) messages when blocking the speed drop