### PR TITLE
Randomized format set updates

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -2773,7 +2773,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			}
 		},
 		name: "Neutralizing Gas",
-		rating: 4,
+		rating: 3.5,
 		num: 256,
 	},
 	noguard: {

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -123,7 +123,7 @@
         "level": 88,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["encore", "focusblast", "grassknot", "hiddenpowerice", "nastyplot", "thunderbolt", "voltswitch"]
             }
         ]
@@ -179,7 +179,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["fireblast", "hiddenpowerice", "nastyplot", "solarbeam", "substitute", "willowisp"],
+                "movepool": ["fireblast", "hiddenpowerice", "hypnosis", "nastyplot", "solarbeam", "substitute", "willowisp"],
                 "preferredTypes": ["Grass"]
             }
         ]
@@ -628,8 +628,13 @@
         "level": 86,
         "sets": [
             {
+                "role": "Bulky Attacker",
+                "movepool": ["closecombat", "earthquake", "stealthrock", "stoneedge", "xscissor"],
+                "preferredTypes": ["Rock"]
+            },
+            {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "stealthrock", "stoneedge", "swordsdance", "xscissor"],
+                "movepool": ["closecombat", "earthquake", "quickattack", "stoneedge", "swordsdance", "xscissor"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -981,6 +986,10 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["aquajet", "doubleedge", "icepunch", "superpower", "waterfall"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["aquajet", "bellydrum", "return", "waterfall"]
             }
         ]
     },
@@ -1288,7 +1297,7 @@
         "level": 82,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["darkpulse", "fireblast", "hiddenpowergrass", "nastyplot", "suckerpunch"]
             }
         ]
@@ -1731,7 +1740,7 @@
         "level": 93,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Bulky Attacker",
                 "movepool": ["firefang", "ironhead", "stealthrock", "suckerpunch", "swordsdance", "thunderpunch"],
                 "preferredTypes": ["Fire"]
             }

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -3718,7 +3718,8 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["airslash", "energyball", "heatwave", "icebeam", "psychic", "psyshock"]
+                "movepool": ["airslash", "energyball", "heatwave", "icebeam", "psychic", "psyshock"],
+                "preferredTypes": ["Psychic"]
             },
             {
                 "role": "Staller",

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -635,7 +635,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["closecombat", "earthquake", "quickattack", "stoneedge", "swordsdance", "xscissor"],
-                "preferredTypes": ["Rock"]
+                "preferredTypes": ["Ground"]
             }
         ]
     },

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -546,7 +546,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		case 'Solar Power':
 			return (!counter.get('Special') || !teamDetails.sun);
 		case 'Sticky Hold':
-			return (species.id !== 'Accelgor');
+			return species.id !== 'accelgor';
 		case 'Sturdy':
 			return (!!counter.get('recoil') && !counter.get('recovery') || species.id === 'steelix' && !!counter.get('sheerforce'));
 		case 'Swarm':

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -545,6 +545,8 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			return !counter.get('setup');
 		case 'Solar Power':
 			return (!counter.get('Special') || !teamDetails.sun);
+		case 'Sticky Hold':
+			return (species.id !== 'Accelgor');
 		case 'Sturdy':
 			return (!!counter.get('recoil') && !counter.get('recovery') || species.id === 'steelix' && !!counter.get('sheerforce'));
 		case 'Swarm':
@@ -560,7 +562,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		case 'Torrent':
 			return !counter.get('Water');
 		case 'Unaware':
-			return (role !== 'Bulky Attacker' && role !== 'Bulky Setup');
+			return ((role !== 'Bulky Attacker' && role !== 'Bulky Setup') || species.id === 'swoobat');
 		case 'Water Absorb':
 			return moves.has('raindance') || ['Drizzle', 'Unaware', 'Volt Absorb'].some(abil => abilities.has(abil));
 		}
@@ -748,7 +750,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		if (species.id === 'palkia') return 'Lustrous Orb';
 		if (moves.has('outrage') && counter.get('setup')) return 'Lum Berry';
 		if (
-			(ability === 'Rough Skin') || (species.id !== 'hooh' &&
+			(ability === 'Rough Skin') || (species.id !== 'hooh' && role !== 'Wallbreaker' &&
 			ability === 'Regenerator' && species.baseStats.hp + species.baseStats.def >= 180 && this.randomChance(1, 2))
 		) return 'Rocky Helmet';
 		if (['protect', 'substitute'].some(m => moves.has(m))) return 'Leftovers';

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -877,7 +877,9 @@ export class RandomGen5Teams extends RandomGen6Teams {
 
 		// Prepare optimal HP
 		const srImmunity = ability === 'Magic Guard';
-		const srWeakness = srImmunity ? 0 : this.dex.getEffectiveness('Rock', species);
+		let srWeakness = srImmunity ? 0 : this.dex.getEffectiveness('Rock', species);
+		// Crash damage move users want an odd HP to survive two misses
+		if (['highjumpkick', 'jumpkick'].some(m => moves.has(m))) srWeakness = 2;
 		while (evs.hp > 1) {
 			const hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
 			if (moves.has('substitute') && item === 'Sitrus Berry') {

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -2108,8 +2108,8 @@
                 "movepool": ["earthquake", "outrage", "stoneedge", "uturn"]
             },
             {
-                "role": "Bulky Attacker",
-                "movepool": ["defog", "dracometeor", "earthquake", "fireblast", "roost"]
+                "role": "Bulky Support",
+                "movepool": ["defog", "dracometeor", "earthquake", "roost", "uturn"]
             }
         ]
     },
@@ -2398,7 +2398,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["doubleedge", "earthquake", "headsmash", "stealthrock", "toxic", "waterfall"]
+                "movepool": ["earthquake", "headsmash", "stealthrock", "toxic", "waterfall"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["doubleedge", "earthquake", "headsmash", "rockpolish", "waterfall"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -2407,7 +2412,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["charm", "icebeam", "protect", "scald", "toxic"]
+                "movepool": ["charm", "protect", "scald", "toxic"]
             }
         ]
     },
@@ -4128,7 +4133,8 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["airslash", "energyball", "heatwave", "icebeam", "psychic", "psyshock"]
+                "movepool": ["airslash", "energyball", "heatwave", "icebeam", "psychic", "psyshock"],
+                "preferredTypes": ["Psychic"]
             },
             {
                 "role": "Staller",
@@ -4598,7 +4604,7 @@
         "level": 79,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Fast Support",
                 "movepool": ["heatwave", "hurricane", "knockoff", "superpower", "taunt", "uturn"]
             }
         ]

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -937,7 +937,9 @@ export class RandomGen6Teams extends RandomGen7Teams {
 
 		// Prepare optimal HP
 		const srImmunity = ability === 'Magic Guard';
-		const srWeakness = srImmunity ? 0 : this.dex.getEffectiveness('Rock', species);
+		let srWeakness = srImmunity ? 0 : this.dex.getEffectiveness('Rock', species);
+		// Crash damage move users want an odd HP to survive two misses
+		if (['highjumpkick', 'jumpkick'].some(m => moves.has(m))) srWeakness = 2;
 		while (evs.hp > 1) {
 			const hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
 			if (moves.has('substitute') && item === 'Sitrus Berry') {

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -2590,7 +2590,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["doubleedge", "earthquake", "headsmash", "stealthrock", "toxic", "waterfall"]
+                "movepool": ["earthquake", "headsmash", "stealthrock", "toxic", "waterfall"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["doubleedge", "earthquake", "headsmash", "rockpolish", "waterfall"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -2599,7 +2604,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["charm", "icebeam", "protect", "scald", "toxic"]
+                "movepool": ["charm", "protect", "scald", "toxic"]
             }
         ]
     },
@@ -4408,7 +4413,8 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["airslash", "energyball", "heatwave", "icebeam", "psychic", "psyshock"]
+                "movepool": ["airslash", "energyball", "heatwave", "icebeam", "psychic", "psyshock"],
+                "preferredTypes": ["Psychic"]
             }
         ]
     },

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1198,7 +1198,9 @@ export class RandomGen7Teams extends RandomGen8Teams {
 
 		// Prepare optimal HP
 		const srImmunity = ability === 'Magic Guard';
-		const srWeakness = srImmunity ? 0 : this.dex.getEffectiveness('Rock', species);
+		let srWeakness = srImmunity ? 0 : this.dex.getEffectiveness('Rock', species);
+		// Crash damage move users want an odd HP to survive two misses
+		if (['highjumpkick', 'jumpkick'].some(m => moves.has(m))) srWeakness = 2;
 		while (evs.hp > 1) {
 			const hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
 			if (moves.has('substitute') && (item === 'Sitrus Berry' || (ability === 'Power Construct' && item !== 'Leftovers'))) {

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -163,7 +163,9 @@ export class RandomGen7Teams extends RandomGen8Teams {
 
 		// Iterate through all moves we've chosen so far and keep track of what they do:
 		for (const moveid of moves) {
-			const move = this.dex.moves.get(moveid);
+			let move = this.dex.moves.get(moveid);
+			// Nature Power calls Earthquake in Gen 5
+			if (this.gen === 5 && moveid === 'naturepower') move = this.dex.moves.get('earthquake');
 
 			const moveType = this.getMoveType(move, species, abilities, preferredType);
 			if (move.damage || move.damageCallback) {

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -175,7 +175,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				categories[move.category]++;
 			}
 			// Moves that have a low base power:
-			if (moveid === 'lowkick' || (move.basePower && move.basePower <= 60 && moveid !== 'rapidspin')) {
+			if (moveid === 'lowkick' || (move.basePower && move.basePower <= 60 && !['nuzzle', 'rapidspin'].includes(moveid))) {
 				counter.add('technician');
 			}
 			// Moves that hit up to 5 times:

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -144,7 +144,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Dazzling Gleam", "Disable", "Encore", "Fire Blast", "Heal Pulse", "Helping Hand", "Icy Wind", "Stealth Rock", "Thunder Wave"],
+                "movepool": ["Dazzling Gleam", "Disable", "Encore", "Fire Blast", "Heal Pulse", "Helping Hand", "Icy Wind", "Thunder Wave"],
                 "teraTypes": ["Fire", "Steel"]
             }
         ]
@@ -324,7 +324,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Drain Punch", "Gunk Shot", "Haze", "Helping Hand", "Ice Punch", "Knock Off", "Poison Gas", "Poison Jab", "Shadow Sneak", "Toxic Spikes"],
+                "movepool": ["Drain Punch", "Gunk Shot", "Haze", "Helping Hand", "Ice Punch", "Knock Off", "Poison Gas", "Poison Jab", "Shadow Sneak"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -919,7 +919,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Bullet Punch", "Close Combat", "Defog", "Tailwind", "U-turn"],
+                "movepool": ["Bullet Punch", "Close Combat", "Tailwind", "U-turn"],
                 "teraTypes": ["Fire", "Water"]
             },
             {
@@ -1009,7 +1009,7 @@
             },
             {
                 "role": "Doubles Support",
-                "movepool": ["Fire Blast", "High Horsepower", "Icy Wind", "Knock Off", "Protect", "Rock Slide", "Stealth Rock", "Stone Edge"],
+                "movepool": ["Fire Blast", "High Horsepower", "Icy Wind", "Knock Off", "Protect", "Rock Slide", "Stone Edge"],
                 "teraTypes": ["Flying", "Steel"]
             }
         ]
@@ -1224,7 +1224,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Brave Bird", "Defog", "Draco Meteor", "Fire Blast", "Helping Hand", "Roost", "Tailwind", "Will-O-Wisp"],
+                "movepool": ["Brave Bird", "Draco Meteor", "Fire Blast", "Helping Hand", "Roost", "Tailwind", "Will-O-Wisp"],
                 "teraTypes": ["Steel"]
             },
             {
@@ -1399,7 +1399,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Iron Head", "Life Dew", "Protect", "Stealth Rock", "Thunder Wave", "U-turn"],
+                "movepool": ["Iron Head", "Life Dew", "Protect", "Thunder Wave", "U-turn"],
                 "teraTypes": ["Dark", "Water"]
             },
             {
@@ -1944,7 +1944,7 @@
         "sets": [
             {
                 "role": "Bulky Protect",
-                "movepool": ["Earth Power", "Flash Cannon", "Heat Wave", "Protect", "Stealth Rock"],
+                "movepool": ["Earth Power", "Flash Cannon", "Heat Wave", "Protect"],
                 "teraTypes": ["Fire", "Grass", "Steel"]
             },
             {
@@ -1964,7 +1964,7 @@
             },
             {
                 "role": "Doubles Support",
-                "movepool": ["Defog", "Dragon Tail", "Icy Wind", "Rest", "Shadow Ball", "Will-O-Wisp"],
+                "movepool": ["Dragon Tail", "Icy Wind", "Rest", "Shadow Ball", "Will-O-Wisp"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -2154,7 +2154,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Icy Wind", "Judgment", "Recover", "Snarl", "Stealth Rock", "Tailwind", "Taunt", "Will-O-Wisp"],
+                "movepool": ["Icy Wind", "Judgment", "Recover", "Snarl", "Tailwind", "Taunt", "Will-O-Wisp"],
                 "teraTypes": ["Fire", "Grass"]
             }
         ]
@@ -2199,7 +2199,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Icy Wind", "Judgment", "Recover", "Snarl", "Stealth Rock", "Tailwind", "Taunt", "Will-O-Wisp"],
+                "movepool": ["Icy Wind", "Judgment", "Recover", "Snarl", "Tailwind", "Taunt", "Will-O-Wisp"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -2369,7 +2369,7 @@
         "sets": [
             {
                 "role": "Offensive Protect",
-                "movepool": ["Gunk Shot", "High Horsepower", "Knock Off", "Protect", "Stealth Rock", "Stone Edge", "Taunt"],
+                "movepool": ["Gunk Shot", "High Horsepower", "Knock Off", "Protect", "Stone Edge", "Taunt"],
                 "teraTypes": ["Dark", "Ground", "Poison"]
             },
             {
@@ -2422,7 +2422,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Brave Bird", "Defog", "Hydro Pump", "Knock Off", "Protect", "Tailwind"],
+                "movepool": ["Brave Bird", "Hydro Pump", "Knock Off", "Protect", "Tailwind"],
                 "teraTypes": ["Ground"]
             },
             {
@@ -3387,7 +3387,7 @@
         "sets": [
             {
                 "role": "Bulky Protect",
-                "movepool": ["Brave Bird", "Defog", "Protect", "Surf", "Tailwind"],
+                "movepool": ["Brave Bird", "Protect", "Surf", "Tailwind"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -3467,7 +3467,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Close Combat", "Fake Out", "Helping Hand", "Iron Head", "Knock Off", "Stealth Rock", "U-turn"],
+                "movepool": ["Close Combat", "Fake Out", "Helping Hand", "Iron Head", "Knock Off", "U-turn"],
                 "teraTypes": ["Fighting", "Steel"]
             },
             {
@@ -3987,7 +3987,7 @@
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
-                "movepool": ["Earth Power", "Energy Ball", "Hyper Voice", "Pollen Puff", "Protect"],
+                "movepool": ["Earth Power", "Energy Ball", "Hyper Voice", "Pollen Puff", "Protect", "Strength Sap"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -4427,7 +4427,7 @@
         "sets": [
             {
                 "role": "Doubles Fast Attacker",
-                "movepool": ["Earth Power", "Protect", "Spikes", "Stealth Rock", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Earth Power", "Protect", "Stealth Rock", "Thunderbolt", "Volt Switch"],
                 "teraTypes": ["Electric", "Grass", "Ground"]
             },
             {
@@ -4726,8 +4726,8 @@
         "level": 79,
         "sets": [
             {
-                "role": "Doubles Bulky Setup",
-                "movepool": ["Bulk Up", "Drain Punch", "Gunk Shot", "Knock Off"],
+                "role": "Doubles Bulky Attacker",
+                "movepool": ["Bulk Up", "Drain Punch", "Gunk Shot", "Knock Off", "Snarl"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -4772,7 +4772,7 @@
             },
             {
                 "role": "Doubles Support",
-                "movepool": ["Follow Me", "Horn Leech", "Knock Off", "Spikes", "Spiky Shield"],
+                "movepool": ["Follow Me", "Horn Leech", "Knock Off", "Spiky Shield"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -4787,7 +4787,7 @@
             },
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["Ivy Cudgel", "Spiky Shield", "Swords Dance", "Wood Hammer"],
+                "movepool": ["Horn Leech", "Ivy Cudgel", "Power Whip", "Spiky Shield", "Swords Dance"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -4802,7 +4802,7 @@
             },
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["Ivy Cudgel", "Spiky Shield", "Swords Dance", "Wood Hammer"],
+                "movepool": ["Horn Leech", "Ivy Cudgel", "Power Whip", "Spiky Shield", "Swords Dance"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -4817,7 +4817,7 @@
             },
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["Ivy Cudgel", "Power Whip", "Spiky Shield", "Swords Dance"],
+                "movepool": ["Horn Leech", "Ivy Cudgel", "Power Whip", "Spiky Shield", "Swords Dance"],
                 "teraTypes": ["Rock"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1461,6 +1461,11 @@
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Heal Bell", "Knock Off", "Psychic", "Recover", "Taunt", "Thunder Wave"],
                 "teraTypes": ["Electric", "Poison", "Steel"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Dazzling Gleam", "Psychic", "Psyshock", "Recover"],
+                "teraTypes": ["Electric", "Fairy"]
             }
         ]
     },
@@ -2064,8 +2069,13 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Encore", "Knock Off", "Psychic", "Stealth Rock", "Thunder Wave", "Thunderbolt", "U-turn"],
-                "teraTypes": ["Electric"]
+                "movepool": ["Encore", "Knock Off", "Psychic", "Stealth Rock", "Thunder Wave", "U-turn"],
+                "teraTypes": ["Dark", "Electric", "Steel"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Drain Punch", "Ice Beam", "Knock Off", "Psychic", "Thunder Wave", "Thunderbolt", "U-turn"],
+                "teraTypes": ["Dark", "Fighting"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -904,7 +904,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Fire Blast", "Hydro Pump", "Ice Beam", "Psychic", "Psyshock", "Slack Off", "Trick Room"],
+                "movepool": ["Fire Blast", "Hydro Pump", "Ice Beam", "Psyshock", "Slack Off", "Trick Room"],
                 "teraTypes": ["Psychic"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -341,6 +341,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Drain Punch", "Gunk Shot", "Haze", "Ice Punch", "Knock Off", "Shadow Sneak", "Toxic", "Toxic Spikes"],
                 "teraTypes": ["Dark"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Drain Punch", "Gunk Shot", "Ice Punch", "Knock Off", "Shadow Sneak"],
+                "teraTypes": ["Dark"]
             }
         ]
     },
@@ -751,6 +756,11 @@
                 "role": "Bulky Support",
                 "movepool": ["Defog", "Haze", "Heat Wave", "Hurricane", "Roost"],
                 "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Hurricane", "Hyper Voice", "Roost"],
+                "teraTypes": ["Ground", "Normal", "Steel"]
             }
         ]
     },
@@ -839,7 +849,12 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Ice Beam", "Liquidation", "Recover", "Spikes", "Toxic"],
+                "movepool": ["Earthquake", "Ice Beam", "Recover", "Spikes", "Toxic"],
+                "teraTypes": ["Fairy", "Poison", "Steel"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earthquake", "Liquidation", "Recover", "Spikes", "Toxic"],
                 "teraTypes": ["Fairy", "Poison", "Steel"]
             }
         ]
@@ -889,8 +904,8 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Fire Blast", "Hydro Pump", "Ice Beam", "Psychic", "Psyshock", "Trick Room"],
-                "teraTypes": ["Psychic", "Water"]
+                "movepool": ["Fire Blast", "Hydro Pump", "Ice Beam", "Psychic", "Psyshock", "Slack Off", "Trick Room"],
+                "teraTypes": ["Psychic"]
             }
         ]
     },
@@ -1556,6 +1571,11 @@
                 "role": "Fast Support",
                 "movepool": ["Close Combat", "Flare Blitz", "Gunk Shot", "Knock Off", "Mach Punch", "Stone Edge", "Swords Dance", "U-turn"],
                 "teraTypes": ["Dark", "Fighting", "Fire"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Aura Sphere", "Fire Blast", "Grass Knot", "Nasty Plot", "Vacuum Wave"],
+                "teraTypes": ["Fighting", "Fire", "Grass"]
             }
         ]
     },
@@ -1621,6 +1641,11 @@
                 "role": "AV Pivot",
                 "movepool": ["Nuzzle", "Super Fang", "Thunderbolt", "U-turn"],
                 "teraTypes": ["Flying"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Encore", "Super Fang", "Thunderbolt", "U-turn"],
+                "teraTypes": ["Flying"]
             }
         ]
     },
@@ -1642,6 +1667,11 @@
     "gastrodon": {
         "level": 85,
         "sets": [
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Clear Smog", "Earth Power", "Ice Beam", "Recover", "Stealth Rock"],
+                "teraTypes": ["Poison", "Steel"]
+            },
             {
                 "role": "Bulky Support",
                 "movepool": ["Clear Smog", "Earthquake", "Ice Beam", "Recover", "Stealth Rock", "Surf"],
@@ -1906,6 +1936,11 @@
                 "role": "Fast Attacker",
                 "movepool": ["Leaf Blade", "Night Slash", "Psycho Cut", "Sacred Sword", "Swords Dance"],
                 "teraTypes": ["Dark", "Fighting", "Grass"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Agility", "Night Slash", "Psycho Cut", "Sacred Sword"],
+                "teraTypes": ["Dark", "Fighting"]
             }
         ]
     },
@@ -3419,6 +3454,11 @@
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Earthquake", "Gunk Shot", "Knock Off", "Rock Slide", "U-turn"],
                 "teraTypes": ["Dark"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bulk Up", "Drain Punch", "Gunk Shot", "Knock Off"],
+                "teraTypes": ["Dark", "Poison", "Steel"]
             }
         ]
     },
@@ -3584,6 +3624,11 @@
                 "role": "Fast Attacker",
                 "movepool": ["Dragon Dance", "Grav Apple", "Outrage", "Sucker Punch", "U-turn"],
                 "teraTypes": ["Dragon", "Grass"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Dragon Dance", "Grav Apple", "Outrage", "Tera Blast"],
+                "teraTypes": ["Fire"]
             }
         ]
     },
@@ -3678,6 +3723,11 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Draining Kiss", "Mystical Fire", "Psychic", "Psyshock"],
+                "teraTypes": ["Fairy", "Steel"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Draining Kiss", "Mystical Fire", "Nuzzle", "Psychic"],
                 "teraTypes": ["Fairy", "Steel"]
             }
         ]
@@ -3796,7 +3846,7 @@
         "level": 86,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Fast Support",
                 "movepool": ["Aura Wheel", "Parting Shot", "Protect", "Rapid Spin"],
                 "teraTypes": ["Dark", "Electric"]
             },
@@ -4142,7 +4192,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Body Press", "Body Slam", "Lash Out", "Stuff Cheeks"],
+                "movepool": ["Body Press", "Body Slam", "Stuff Cheeks", "Thief"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4152,7 +4202,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Body Press", "Body Slam", "Lash Out", "Stuff Cheeks"],
+                "movepool": ["Body Press", "Body Slam", "Stuff Cheeks", "Thief"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4514,11 +4564,6 @@
                 "role": "Fast Attacker",
                 "movepool": ["Gunk Shot", "High Horsepower", "Iron Head", "Shift Gear"],
                 "teraTypes": ["Ground"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Gunk Shot", "Haze", "Parting Shot", "Spin Out", "Toxic", "Toxic Spikes"],
-                "teraTypes": ["Water"]
             }
         ]
     },
@@ -5019,6 +5064,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Draco Meteor", "Dragon Tail", "Giga Drain", "Recover", "Sucker Punch"],
                 "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Dragon Pulse", "Giga Drain", "Growth", "Recover"],
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -5049,6 +5099,11 @@
                 "role": "Fast Attacker",
                 "movepool": ["Focus Blast", "Nasty Plot", "Psyshock", "Sludge Wave", "U-turn"],
                 "teraTypes": ["Fighting", "Poison"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Fake Out", "Psychic", "Psyshock", "Sludge Wave", "U-turn"],
+                "teraTypes": ["Dark"]
             }
         ]
     },
@@ -5097,7 +5152,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Ivy Cudgel", "Knock Off", "Play Rough", "Swords Dance", "Wood Hammer"],
+                "movepool": ["Horn Leech", "Ivy Cudgel", "Knock Off", "Play Rough", "Power Whip", "Swords Dance"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -5107,7 +5162,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Ivy Cudgel", "Knock Off", "Stomping Tantrum", "Swords Dance", "Wood Hammer"],
+                "movepool": ["Horn Leech", "Ivy Cudgel", "Knock Off", "Power Whip", "Stomping Tantrum", "Swords Dance"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -5122,7 +5177,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Ivy Cudgel", "Power Whip", "Superpower", "Swords Dance"],
+                "movepool": ["Horn Leech", "Ivy Cudgel", "Power Whip", "Superpower", "Swords Dance"],
                 "teraTypes": ["Rock"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2055,7 +2055,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Knock Off", "Light Screen", "Psychic", "Reflect", "Stealth Rock", "Thunder Wave", "U-turn", "Yawn"],
-                "teraTypes": ["Electric", "Steel"]
+                "teraTypes": ["Dark", "Electric", "Steel"]
             }
         ]
     },
@@ -2085,7 +2085,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Explosion", "Fire Blast", "Knock Off", "Psychic", "Stealth Rock", "Taunt", "U-turn"],
-                "teraTypes": ["Fire", "Psychic"]
+                "teraTypes": ["Dark", "Fire", "Psychic"]
             },
             {
                 "role": "Fast Attacker",

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1596,7 +1596,9 @@ export class RandomTeams {
 
 		// Prepare optimal HP
 		const srImmunity = ability === 'Magic Guard' || item === 'Heavy-Duty Boots';
-		const srWeakness = srImmunity ? 0 : this.dex.getEffectiveness('Rock', species);
+		let srWeakness = srImmunity ? 0 : this.dex.getEffectiveness('Rock', species);
+		// Crash damage move users want an odd HP to survive two misses
+		if (['axekick', 'highjumpkick', 'jumpkick'].some(m => moves.has(m))) srWeakness = 2;
 		while (evs.hp > 1) {
 			const hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
 			if ((moves.has('substitute') && ['Sitrus Berry', 'Salac Berry'].includes(item))) {

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -203,10 +203,7 @@ export class RandomTeams {
 				!counter.get('Steel') &&
 				(isDoubles || species.baseStats.atk > 95 || movePool.includes('gigatonhammer') || movePool.includes('makeitrain'))
 			),
-			Water: (movePool, moves, abilities, types, counter, species) => {
-				if (types.includes('Ground')) return false;
-				return !counter.get('Water');
-			},
+			Water: (movePool, moves, abilities, types, counter, species) => !counter.get('Water'),
 		};
 	}
 
@@ -529,6 +526,7 @@ export class RandomTeams {
 			['surf', 'hydropump'],
 			['liquidation', 'wavecrash'],
 			['gigadrain', 'leafstorm'],
+			['powerwhip', 'hornleech'],
 			[['airslash', 'bravebird', 'hurricane'], ['airslash', 'bravebird', 'hurricane']],
 			['knockoff', 'foulplay'],
 			['doubleedge', 'headbutt'],
@@ -994,8 +992,8 @@ export class RandomTeams {
 	): boolean {
 		if ([
 			'Armor Tail', 'Battle Bond', 'Early Bird', 'Flare Boost', 'Galvanize', 'Gluttony', 'Harvest', 'Hydration', 'Ice Body', 'Immunity',
-			'Marvel Scale', 'Misty Surge', 'Moody', 'Own Tempo', 'Pressure', 'Quick Feet', 'Rain Dish', 'Sand Veil', 'Sniper',
-			'Snow Cloak', 'Steadfast', 'Steam Engine',
+			'Misty Surge', 'Moody', 'Own Tempo', 'Pressure', 'Quick Feet', 'Rain Dish', 'Sand Veil', 'Sniper', 'Snow Cloak', 'Steadfast',
+			'Steam Engine',
 		].includes(ability)) return true;
 
 		switch (ability) {
@@ -1039,6 +1037,8 @@ export class RandomTeams {
 			return !counter.get('Physical');
 		case 'Libero': case 'Protean':
 			return role === 'Offensive Protect' || (species.id === 'meowscarada' && role === 'Fast Attacker');
+		case 'Marvel Scale':
+			return isDoubles;
 		case 'Mold Breaker':
 			return (abilities.has('Sharpness') || abilities.has('Unburden'));
 		case 'Moxie':
@@ -1046,7 +1046,7 @@ export class RandomTeams {
 		case 'Natural Cure':
 			return species.id === 'pawmot';
 		case 'Neutralizing Gas':
-			return !isDoubles;
+			return (!isDoubles && species.id === 'weezing');
 		case 'Overcoat': case 'Sweet Veil':
 			return types.includes('Grass');
 		case 'Overgrow':
@@ -1077,6 +1077,8 @@ export class RandomTeams {
 			return (!teamDetails.sun || !counter.get('Special'));
 		case 'Speed Boost':
 			return (species.id === 'yanmega' && !moves.has('protect'));
+		case 'Sticky Hold':
+			return (species.id === 'muk');
 		case 'Sturdy':
 			return !!counter.get('recoil');
 		case 'Swarm':


### PR DESCRIPTION
This update is special for a few formats for a few different reasons. Please don't merge until Sunday.

**Generations 5, 6, 7, and 9**
-High Jump Kick users will now always be able to miss twice from full health without dying.

**Gen 9 Random Battle:**
This update contains many experimental changes that we will track via win rates in the next half-month, intended mainly to increase set variety and reduce Choice item frequency. Changes marked with * reduce Choice Item rate.

-Galarian Weezing now gets Neutralizing Gas 50% of the time.
-Milotic now gets Marvel Scale 50% of the time.
-Add Bulky Setup Dipplin: Dragon Pulse, Growth, Recover, Giga Drain. Tera Steel.
-Morpeko set 1's role changed to Fast Support, which gives it Heavy-Duty Boots.
-Add Bulky Setup Noctowl: Calm Mind, Hyper Voice, Hurricane, Roost. Tera Normal/Ground/Steel.
-remove Bulky Attacker Revavroom.
-Add Tera Blast Fire Dragon Dance Flapple.
-Wallbreaker Slowking: +Slack Off, -Psychic, -Tera Water (Psyshock is now forced) *
-add AV Pivot Munkidori: Fake Out Psychic Psyshock Sludge Wave U-turn, Tera Dark *
-Swords Dance masked Ogerpon formes: Grass move is now a roll between Horn Leech and Power Whip. Support sets and base Ogerpon remain unchanged.
-add AV Pivot Muk, consisting of its current set minus Haze, Toxic, and Toxic Spikes. Tera Dark. *
-Muk is now always Poison Touch.
-add Fast Support Pachirisu: Super Fang, Encore, Thunderbolt, U-turn. gets Heavy-Duty Boots. Tera Flying.
-add Bulky Setup Passimian: Drain Punch, Bulk Up, Knock Off, Gunk Shot. Tera Steel/Dark/Poison.
-add AV Pivot Hatterene: Psychic, Draining Kiss, Mystical Fire, Nuzzle, Tera Steel/Fairy. *
-Add Setup Sweeper Gallade: Agility, Sacred Sword, Psycho Cut, Night Slash. Tera Dark/Fighting. Gets Life Orb. *
-Water/Ground types with Water moves in their movepool now always get Water moves. As a result:
--Support Whiscash now always gets Hydro Pump
--Quagsire now has two sets: a Bulky Attacker set with Liquidation and no Ice Beam, and a Bulky Support set with Ice Beam and no Liquidation.
--Gastrodon now has two sets: a Bulky Support set with Surf and Earthquake (the current one), and a Bulky Attacker set with Earth Power and no Surf.
-Oinkologne M and F: -Lash Out, +Thief, by popular demand.
-add Setup Sweeper Infernape: Nasty Plot, Aura Sphere, Fire Blast, Vacuum Wave, Grass Knot. Tera Fire/Grass/Fighting. *
-Bulky Support Mesprit: +Tera Steel, +Tera Dark, -Thunderbolt
-add Bulky Support Mesprit: Drain Punch, Knock Off, Psychic, Ice Beam, Thunderbolt, Thunder Wave, U-turn. Tera Dark/Fighting. Gets Assault Vest or Leftovers.
-add Bulky Setup Chimecho: Calm Mind, Dazzling Gleam, Psychic, Psyshock, Recover. Tera Electric/Fairy, with Leftovers.
-Support Azelf and Uxie: +Tera Dark

**Gen 9 Random Doubles:**
This update is special because we've completely given up on having a decent amount of hazard removal in the format, and we're also reducing entry hazard distribution to compensate for us not tryharding to force Defog onto stuff as much.

-Wigglytuff, Tyranitar, Jirachi, all Arceus formes, Krookodile, Perrserker, Heatran: -Stealth Rock
-Scizor, Altaria, Giratina, Swanna, Cramorant: -Defog
-Ogerpon, Sandy Shocks: -Spikes
-Muk: -Toxic Spikes
-Arboliva: +Strength Sap
-Okidogi: +Snarl, role changed to Doubles Bulky Attacker (now gets Assault Vest sometimes)

**Gen 6+7 Random Battle**
-Luvdisc: -Ice Beam
-Wallbreaker Sigilyph now always gets a Psychic move.
-Relicanth now runs its Gen 5 set split minus Yawn, allowing Life Orb Rock Polish to exist.

**Gen 6 Random Battle**
-Flygon's Bulky Attacker set was changed to Bulky Support to enforce Defog when the team does not have removal. Its backup move when the team has removal already was changed from Fire Blast to U-turn.
-Tornadus-Therian's role was changed to Fast Support; it can now get Assault Vest.

**Gen 5 Random Battle**
Gen 5's first post-revamp update!

-Pinsir set split: Bulky Attacker with Stealth Rock, and Fast Attacker with Quick Attack and Swords Dance. Fast Attacker will always get Earthquake.
-Raichu no longer gets Choice Scarf.
-Ninetales: +Hypnosis
-Belly Drum Azumarill now exists, with Return as its coverage move.
-Houndoom no longer gets Expert Belt.
-Wallbreaker Sigilyph now always gets a Psychic move.
-Mawile now gets Leftovers instead of Life Orb if it gets Intimidate.
-Smeargle no longer gets Technician.
-Bugfix: Nature Power now well and truly counts as Earthquake when counting attacks for move generation.