### PR TITLE
Randomize gender in team validator instead of battle

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1179,6 +1179,10 @@ export class TeamValidator {
 			set.nature = 'Serious';
 		}
 
+		if (set.gender === '' && !species.gender) {
+			set.gender = ['M', 'F'][Math.floor(Math.random() * 2)];
+		}
+
 		for (const stat in set.evs) {
 			if (set.evs[stat as 'hp'] < 0) {
 				problems.push(`${name} has less than 0 ${allowAVs ? 'Awakening Values' : 'EVs'} in ${Dex.stats.names[stat as 'hp']}.`);


### PR DESCRIPTION
Mainly for #9832

~~Currently, the battle rng is advanced when randomly selecting genders when it is not specified by the set. This is being changed mainly due to the fact that logically, the battle rng shouldn't be advanced just for picking genders, but also so that `set.gender` can be changed to match the gender while not affecting rng if the battle gets reserialized.~~