### PR TITLE
Automodchat: Don't reset timer on disconnections

### DIFF
--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1063,7 +1063,7 @@ export abstract class BasicRoom {
 			if (!time || time < 5) {
 				throw new Error(`Invalid time setting for automodchat (${Utils.visualize(this.settings.autoModchat)})`);
 			}
-			if (this.modchatTimer) clearTimeout(this.modchatTimer);
+			if (this.modchatTimer) return;
 			this.modchatTimer = setTimeout(() => {
 				if (!this.settings.autoModchat) return;
 				const {rank} = this.settings.autoModchat;
@@ -1080,6 +1080,7 @@ export abstract class BasicRoom {
 				// automodchat will always exist
 				this.settings.autoModchat.active = oldSetting || true;
 				this.saveSettings();
+				this.modchatTimer = null;
 			}, time * 60 * 1000);
 		}
 	}


### PR DESCRIPTION
Currently we restart the timer every time we check for automodchat, which means that any regular user could stop automodchat just by joining and leaving more often than the time designed to trigger it.
