### PR TITLE
Give Secret Sword the Slicing move flag

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -16284,7 +16284,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Secret Sword",
 		pp: 10,
 		priority: 0,
-		flags: {protect: 1, mirror: 1},
+		flags: {protect: 1, mirror: 1, slicing: 1},
 		secondary: null,
 		target: "normal",
 		type: "Fighting",


### PR DESCRIPTION
According to datamined move data, Secret Sword has the Slicing move flag, even though it isn't implemented in SV.
This reflects that here.