### PR TITLE
Randomized format set updates

### DIFF
--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -9,10 +9,6 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "sleeppowder", "sludgebomb", "synthesis"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["earthquake", "powerwhip", "sleeppowder", "swordsdance", "synthesis"]
             }
         ]
     },
@@ -2579,7 +2575,7 @@
         "level": 90,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["healingwish", "icepunch", "jumpkick", "return", "switcheroo"]
             }
         ]

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -2893,7 +2893,7 @@
         "level": 88,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["healingwish", "highjumpkick", "icepunch", "return", "switcheroo"]
             }
         ]
@@ -4150,7 +4150,7 @@
                 "movepool": ["haze", "painsplit", "shadowball", "toxicspikes", "willowisp"]
             },
             {
-                "role": "Wallbreaker",
+                "role": "Bulky Setup",
                 "movepool": ["hiddenpowerfighting", "nastyplot", "shadowball", "trickroom"]
             }
         ]

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -2094,7 +2094,7 @@
         "level": 97,
         "sets": [
             {
-                "role": "Bulky Setup",
+                "role": "Staller",
                 "movepool": ["icepunch", "rest", "return", "sleeptalk", "suckerpunch", "superpower"],
                 "preferredTypes": ["Fighting"]
             }

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -762,7 +762,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (moves.has('rest') && !moves.has('sleeptalk') && !['Hydration', 'Natural Cure', 'Shed Skin'].includes(ability)) {
 			return 'Chesto Berry';
 		}
-		if (role === 'Staller' || species.id === 'spinda') return 'Leftovers';
+		if (role === 'Staller') return 'Leftovers';
 	}
 
 	getItem(

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -762,7 +762,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (moves.has('rest') && !moves.has('sleeptalk') && !['Hydration', 'Natural Cure', 'Shed Skin'].includes(ability)) {
 			return 'Chesto Berry';
 		}
-		if (role === 'Staller') return 'Leftovers';
+		if (role === 'Staller' || species.id === 'spinda') return 'Leftovers';
 	}
 
 	getItem(
@@ -793,7 +793,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			) ? 'Choice Scarf' : 'Choice Specs';
 		}
 		if (counter.get('Special') === 3 && moves.has('uturn')) return 'Choice Specs';
-		if (counter.get('Physical') === 4 && species.id !== 'jirachi' && species.id !== 'spinda' &&
+		if (counter.get('Physical') === 4 && species.id !== 'jirachi' &&
 			['dragontail', 'fakeout', 'flamecharge', 'nuzzle', 'rapidspin'].every(m => !moves.has(m))
 		) {
 			return (

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -3115,7 +3115,7 @@
         "level": 88,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["healingwish", "highjumpkick", "icepunch", "return", "switcheroo"]
             }
         ]
@@ -4426,7 +4426,7 @@
                 "movepool": ["haze", "painsplit", "shadowball", "toxicspikes", "willowisp"]
             },
             {
-                "role": "Wallbreaker",
+                "role": "Bulky Setup",
                 "movepool": ["hiddenpowerfighting", "nastyplot", "shadowball", "trickroom"]
             }
         ]

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -2155,7 +2155,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Icy Wind", "Judgment", "Recover", "Snarl", "Tailwind", "Taunt", "Will-O-Wisp"],
-                "teraTypes": ["Fire", "Grass"]
+                "teraTypes": ["Fire", "Steel"]
             }
         ]
     },
@@ -3387,7 +3387,7 @@
         "sets": [
             {
                 "role": "Bulky Protect",
-                "movepool": ["Brave Bird", "Protect", "Surf", "Tailwind"],
+                "movepool": ["Brave Bird", "Protect", "Roost", "Surf", "Tailwind"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -4232,12 +4232,12 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Gunk Shot", "Haze", "Parting Shot", "Poison Gas", "Spin Out", "Taunt"],
+                "movepool": ["Gunk Shot", "Haze", "Iron Head", "Parting Shot", "Poison Gas", "Taunt"],
                 "teraTypes": ["Flying", "Water"]
             },
             {
                 "role": "Doubles Fast Attacker",
-                "movepool": ["Gunk Shot", "High Horsepower", "Protect", "Shift Gear", "Spin Out"],
+                "movepool": ["Gunk Shot", "High Horsepower", "Iron Head", "Protect", "Shift Gear"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -4407,7 +4407,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Close Combat", "Earthquake", "Headlong Rush", "Ice Spinner", "Knock Off", "Protect", "Rapid Spin", "Rock Slide"],
+                "movepool": ["Close Combat", "Headlong Rush", "Ice Spinner", "Knock Off", "Protect", "Rapid Spin", "Rock Slide"],
                 "teraTypes": ["Fire", "Ground"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1291,6 +1291,11 @@
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Roost", "Thunder Wave", "U-turn"],
                 "teraTypes": ["Steel", "Water"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Bug Buzz", "Encore", "Roost", "Thunder Wave"],
+                "teraTypes": ["Steel", "Water"]
             }
         ]
     },
@@ -2563,8 +2568,8 @@
         "level": 87,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Aqua Jet", "Crunch", "Flip Turn", "Head Smash", "Psychic Fangs", "Wave Crash"],
+                "role": "Wallbreaker",
+                "movepool": ["Aqua Jet", "Double-Edge", "Flip Turn", "Wave Crash"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -2573,8 +2578,8 @@
         "level": 87,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Aqua Jet", "Crunch", "Flip Turn", "Head Smash", "Psychic Fangs", "Wave Crash"],
+                "role": "Wallbreaker",
+                "movepool": ["Aqua Jet", "Double-Edge", "Flip Turn", "Wave Crash"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -4072,7 +4077,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Close Combat", "Glacial Lance", "High Horsepower", "Trick Room", "Zen Headbutt"],
+                "movepool": ["Close Combat", "Glacial Lance", "High Horsepower", "Trick Room"],
                 "teraTypes": ["Fighting", "Ground"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1225,7 +1225,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Slam", "Bulk Up", "Earthquake", "Knock Off", "Slack Off"],
-                "teraTypes": ["Ghost", "Ground"]
+                "teraTypes": ["Ghost", "Ground", "Poison"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -400,7 +400,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Focus Blast", "Protect", "Psychic", "Toxic"],
-                "teraTypes": ["Dark", "Steel"]
+                "teraTypes": ["Dark", "Fighting", "Steel"]
             }
         ]
     },
@@ -1159,7 +1159,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Dark Pulse", "Giga Drain", "Heat Wave", "Leaf Storm", "Nasty Plot", "Vacuum Wave"],
+                "movepool": ["Dark Pulse", "Heat Wave", "Leaf Storm", "Nasty Plot", "Vacuum Wave"],
                 "teraTypes": ["Fire", "Grass"]
             },
             {
@@ -1349,7 +1349,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Focus Blast", "Knock Off", "Leaf Storm", "Sucker Punch", "Toxic Spikes"],
+                "movepool": ["Focus Blast", "Knock Off", "Leaf Storm", "Spikes", "Sucker Punch", "Toxic Spikes"],
                 "teraTypes": ["Dark", "Grass", "Poison"]
             },
             {
@@ -1974,8 +1974,13 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Haze", "Pain Split", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
+                "movepool": ["Earthquake", "Pain Split", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
                 "teraTypes": ["Dark", "Fairy"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Earthquake", "Leech Life", "Poltergeist", "Trick Room"],
+                "teraTypes": ["Dark", "Ghost", "Ground"]
             }
         ]
     },
@@ -2198,7 +2203,7 @@
                 "teraTypes": ["Dragon", "Steel"]
             },
             {
-                "role": "Setup Sweeper",
+                "role": "Bulky Attacker",
                 "movepool": ["Grass Knot", "Ice Beam", "Scald", "Take Heart"],
                 "teraTypes": ["Grass", "Steel"]
             }
@@ -3257,12 +3262,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Knock Off", "Leaf Blade", "Roost", "Sucker Punch", "Swords Dance", "Triple Arrows", "U-turn"],
-                "teraTypes": ["Steel"]
-            },
-            {
-                "role": "Fast Support",
-                "movepool": ["Defog", "Leaf Blade", "Roost", "Triple Arrows"],
+                "movepool": ["Defog", "Knock Off", "Leaf Blade", "Roost", "Sucker Punch", "Swords Dance", "Triple Arrows", "U-turn"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3381,7 +3381,7 @@
         "level": 80,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["Accelerock", "Close Combat", "Crunch", "Psychic Fangs", "Stone Edge", "Swords Dance"],
                 "teraTypes": ["Fighting"]
             }

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -525,6 +525,7 @@ export class RandomTeams {
 			['psychic', 'psyshock'],
 			['surf', 'hydropump'],
 			['liquidation', 'wavecrash'],
+			['aquajet', 'flipturn'],
 			['gigadrain', 'leafstorm'],
 			['powerwhip', 'hornleech'],
 			[['airslash', 'bravebird', 'hurricane'], ['airslash', 'bravebird', 'hurricane']],
@@ -576,7 +577,6 @@ export class RandomTeams {
 		if (species.id === "cyclizar") this.incompatibleMoves(moves, movePool, 'taunt', 'knockoff');
 		if (species.baseSpecies === 'Dudunsparce') this.incompatibleMoves(moves, movePool, 'earthpower', 'shadowball');
 		if (species.id === 'jirachi') this.incompatibleMoves(moves, movePool, 'bodyslam', 'healingwish');
-		if (species.baseSpecies !== 'Basculin') this.incompatibleMoves(moves, movePool, 'aquajet', 'flipturn');
 		if (species.id === 'mesprit') this.incompatibleMoves(moves, movePool, 'healingwish', 'uturn');
 	}
 

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -115,7 +115,7 @@ const MOVE_PAIRS = [
 
 /** Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type */
 const PRIORITY_POKEMON = [
-	'breloom', 'brutebonnet', 'honchkrow', 'lycanrocdusk', 'mimikyu', 'scizor',
+	'breloom', 'brutebonnet', 'honchkrow', 'mimikyu', 'scizor',
 ];
 
 /** Pokemon who should never be in the lead slot */
@@ -1168,7 +1168,7 @@ export class RandomTeams {
 			if (species.id === 'conkeldurr' && role === 'Doubles Wallbreaker') return 'Guts';
 			if (species.id === 'tropius' || species.id === 'trevenant') return 'Harvest';
 			if (species.id === 'dragonite' || species.id === 'lucario') return 'Inner Focus';
-			if (species.id === 'kommoo') return 'Overcoat';
+			if (species.id === 'kommoo') return this.sample(['Overcoat', 'Soundproof']);
 			if (species.id === 'barraskewda') return 'Propeller Tail';
 			if (species.id === 'flapple' || (species.id === 'appletun' && this.randomChance(1, 2))) return 'Ripen';
 			if (species.id === 'ribombee') return 'Shield Dust';


### PR DESCRIPTION
Merge sometime on the weekend, if possible.

Gen 9 Random Battle:
-Phione: Setup Sweeper changed role to Bulky Attacker (it now gets Leftovers instead of Life Orb)
-Bulky Support Dusknoir: -Haze
-Add Dusknoir set 3: Setup Sweeper, with Trick Room, Poltergeist, Leech Life, and Earthquake. Same teras as Wallbreaker.
-Toxic Hypno: +Tera Fighting
-Remove Hisuian Decidueye's second set, and readd Defog to set 1, due to the addition of Boots Defog causing a significant win rate drop.
-Special Shiftry: -Giga Drain
-Lycanroc-Dusk's role changed to Wallbreaker and priority-STAB Pokemon status removed (confusing, I know, but all this does is force Stone Edge while keeping Accelerock forced)
-Wallbreaker Cacturne: +Spikes
-add Illumise set 2: Bulky Attacker, with Bug Buzz over U-turn and no other differences.
-Wallbreaker Calyrex-Ice: -Zen Headbutt (no longer gets Choice Band, now always gets Close Combat and High Horsepower)
-Basculins: -all coverage moves, +Double-Edge, role changed to Wallbreaker (hits all Water immunities, and it now always gets Flip Turn)
-Ariados should actually always get Insomnia now for real this time hopefully.

Gen 9 Random Doubles:
-Great Tusk: -Earthquake
-Revavroom (both sets): -Spin Out, +Iron Head
-Cramorant: +Roost
-Due to the above singles change, Lycanroc-Dusk now always has Rock Slide and does not always have Accelerock.
-Kommo-o now has a 50/50 roll between Soundproof and Overcoat.
-Arceus-Grass: -Tera Grass, +Tera Steel

Gens 5-7 Random Battle:
-All 3: Lopunny's role changed to Wallbreaker to prevent Choice Scarf from generating on it.
-Gens 6 and 7: Trick Room Cofragrigus's role was changed to Bulky Setup; it now gets Leftovers instead of Life Orb.
-Gen 6: Spinda's role changed so that it now always gets Leftovers.
-Gen 5: the Swords Dance Venusaur set was removed.