### PR TITLE
Gen 5-8 Random Battles: balance Zoroark's allowed levels

### DIFF
--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -965,6 +965,12 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			// Illusion shouldn't be in the last slot
 			if (species.name === 'Zoroark' && pokemon.length >= (this.maxTeamSize - 1)) continue;
 
+			// If Zoroark is in the team, ensure its level is balanced
+			if (pokemon.some(pkmn => pkmn.species === 'Zoroark') && pokemon.length >= (this.maxTeamSize - 1)) {
+				const level = this.adjustLevel || this.randomSets[species.id]["level"] || (species.nfe ? 90 : 80);
+				if ((level < 76 || level > 94) && !this.adjustLevel) continue;
+			}
+
 			// Dynamically scale limits for different team sizes. The default and minimum value is 1.
 			const limitFactor = Math.round(this.maxTeamSize / 6) || 1;
 			const tier = species.tier;

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1384,6 +1384,8 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				if (set.ability === 'Illusion') {
 					if (pokemon.length < 1) continue;
 					set.level = pokemon[pokemon.length - 1].level;
+					// Ensure its level is balanced
+					if ((set.level < 76 || set.level > 94) && !this.adjustLevel) continue;
 				}
 
 				// Okay, the set passes, add it to our team

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -2508,18 +2508,15 @@ export class RandomGen8Teams {
 
 			// Illusion shouldn't be on the last slot
 			if (species.name === 'Zoroark' && pokemon.length >= (this.maxTeamSize - 1)) continue;
-			// The sixth slot should not be very low level if a zoroark is present
+
+			// If Zoroark is in the team, ensure its level is balanced
 			// Also Zacian/Zamazenta/Eternatus are rejected as they make dynamax malfunction, regardless of level
-			if (
-				pokemon.some(pkmn => pkmn.name === 'Zoroark') &&
-				pokemon.length >= (this.maxTeamSize - 1) &&
-				(this.getLevel(species,
-							  isDoubles,
-							  this.dex.formats.getRuleTable(this.format).has('dynamaxclause')) < 72 &&
-				!this.adjustLevel ||
-				['Zacian', 'Zacian-Crowned', 'Zamazenta', 'Zamazenta-Crowned', 'Eternatus'].includes(species.name))
-			) {
-				continue;
+			if (pokemon.some(pkmn => pkmn.name === 'Zoroark') && pokemon.length >= (this.maxTeamSize - 1)) {
+				const level = this.getLevel(species, isDoubles, this.dex.formats.getRuleTable(this.format).has('dynamaxclause'));
+				if (
+					(level < 76 || level > 94) && !this.adjustLevel ||
+					['Zacian', 'Zacian-Crowned', 'Zamazenta', 'Zamazenta-Crowned', 'Eternatus'].includes(species.name)
+				) continue;
 			}
 
 			const types = species.types;


### PR DESCRIPTION
This limits Zoroark's allowed levels to 76-94 in Gen 5-8 Random Battles, which is the same range as in Gen 9.