### PR TITLE
Gen 2 Random Battle updates

### DIFF
--- a/data/mods/gen2/random-data.json
+++ b/data/mods/gen2/random-data.json
@@ -196,7 +196,7 @@
         "moves": ["growth", "rest", "sleeptalk", "surf"]
     },
     "jolteon": {
-        "moves": ["batonpass", "growth", "hiddenpowerice", "substitute", "thunderbolt", "thunderwave"]
+        "moves": ["batonpass", "growth", "hiddenpowerice", "substitute", "thunderbolt"]
     },
     "flareon": {
         "moves": ["batonpass", "doubleedge", "fireblast", "growth", "hiddenpowergrass"]
@@ -211,7 +211,7 @@
         "moves": ["ancientpower", "curse", "earthquake", "hiddenpowerflying", "rest", "whirlwind"]
     },
     "snorlax": {
-        "moves": ["curse", "doubleedge", "earthquake", "fireblast", "lovelykiss", "rest", "return", "sleeptalk"]
+        "moves": ["curse", "doubleedge", "earthquake", "lovelykiss", "rest", "return", "sleeptalk"]
     },
     "articuno": {
         "moves": ["hiddenpowerelectric", "icebeam", "rest", "sleeptalk", "toxic"]

--- a/server/chat-plugins/randombattles/winrates.ts
+++ b/server/chat-plugins/randombattles/winrates.ts
@@ -165,7 +165,6 @@ async function collectStats(battle: RoomBattle, winner: ID, players: ID[]) {
 		// may need to be raised again if doubles ladder takes off
 		eloFloor = 1300;
 	}
-	console.log(eloFloor);
 	if (!formatData || battle.rated < eloFloor) return;
 	checkRollover();
 	for (const p of players) {

--- a/server/chat-plugins/randombattles/winrates.ts
+++ b/server/chat-plugins/randombattles/winrates.ts
@@ -156,12 +156,16 @@ async function collectStats(battle: RoomBattle, winner: ID, players: ID[]) {
 	const formatData = stats.formats[battle.format];
 	let eloFloor = stats.elo;
 	const format = Dex.formats.get(battle.format);
-	if (format.mod !== `gen${Dex.gen}`) {
+	if (format.mod === 'gen2') {
+		// ladder is inactive, so use a lower threshold
+		eloFloor = 1150;
+	} else if (format.mod !== `gen${Dex.gen}`) {
 		eloFloor = 1300;
 	} else if (format.gameType === 'doubles') {
 		// may need to be raised again if doubles ladder takes off
 		eloFloor = 1300;
 	}
+	console.log(eloFloor);
 	if (!formatData || battle.rated < eloFloor) return;
 	checkRollover();
 	for (const p of players) {


### PR DESCRIPTION
-Jolteon: -thunderwave
-Snorlax: -fireblast

Also reduces the rating threshold for winrate collection to 1150, since the Gen 2 Random Battle ladder is less active.