### PR TITLE
Randomized Format Spotlight: don't lower Attack EVs/IVs

### DIFF
--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1636,7 +1636,7 @@ export class RandomTeams {
 			) return false;
 			return move.category !== 'Physical' || move.id === 'bodypress' || move.id === 'foulplay';
 		});
-		if (noAttackStatMoves && !moves.has('transform')) {
+		if (noAttackStatMoves && !moves.has('transform') && this.format.mod !== 'partnersincrime') {
 			evs.atk = 0;
 			ivs.atk = 0;
 		}


### PR DESCRIPTION
Since Pokemon share moves in Partners in Crime, Pokemon can use physical moves even if their original set is all special.

Ready to merge at any time.