### PR TITLE
Add Illusion Level Mod to Gen 9 Random Doubles

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -326,7 +326,7 @@ export const Formats: FormatList = [
 		mod: 'gen9',
 		gameType: 'doubles',
 		team: 'random',
-		ruleset: ['PotD', 'Obtainable', 'Species Clause', 'HP Percentage Mod', 'Cancel Mod'],
+		ruleset: ['PotD', 'Obtainable', 'Species Clause', 'HP Percentage Mod', 'Cancel Mod', 'Illusion Level Mod'],
 	},
 	{
 		name: "[Gen 9] Doubles OU",


### PR DESCRIPTION
fixes an oversight in https://github.com/smogon/pokemon-showdown/pull/9859