### PR TITLE
Randomized format set updates

### DIFF
--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -5130,10 +5130,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["leechseed", "phantomforce", "substitute", "willowisp"]
             }
         ]
     },
@@ -5143,10 +5139,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["leechseed", "phantomforce", "substitute", "willowisp"]
             }
         ]
     },
@@ -5156,10 +5148,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["leechseed", "phantomforce", "substitute", "willowisp"]
             }
         ]
     },
@@ -5169,10 +5157,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["leechseed", "phantomforce", "substitute", "willowisp"]
             }
         ]
     },

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -5467,10 +5467,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["leechseed", "phantomforce", "substitute", "willowisp"]
             }
         ]
     },
@@ -5480,10 +5476,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["leechseed", "phantomforce", "substitute", "willowisp"]
             }
         ]
     },
@@ -5493,10 +5485,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["leechseed", "phantomforce", "substitute", "willowisp"]
             }
         ]
     },
@@ -5506,10 +5494,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["seedbomb", "shadowsneak", "synthesis", "willowisp"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["leechseed", "phantomforce", "substitute", "willowisp"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -19,7 +19,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Earthquake", "Glare", "Gunk Shot", "Knock Off", "Sucker Punch", "Toxic Spikes"],
+                "movepool": ["Earthquake", "Glare", "Gunk Shot", "Knock Off", "Toxic Spikes"],
                 "teraTypes": ["Dark", "Ground"]
             }
         ]
@@ -331,6 +331,11 @@
                 "role": "Wallbreaker",
                 "movepool": ["Fire Blast", "Psyshock", "Sludge Bomb", "Trick", "Trick Room"],
                 "teraTypes": ["Poison", "Psychic"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Earthquake", "Fire Blast", "Psychic", "Shell Side Arm", "Slack Off", "Thunder Wave"],
+                "teraTypes": ["Dark", "Ground", "Poison"]
             }
         ]
     },
@@ -475,11 +480,6 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Body Slam", "Close Combat", "Earthquake", "Rock Slide", "Zen Headbutt"],
-                "teraTypes": ["Fighting", "Ground", "Normal"]
-            },
-            {
-                "role": "Wallbreaker",
-                "movepool": ["Close Combat", "Double-Edge", "Earthquake", "Lash Out", "Stone Edge"],
                 "teraTypes": ["Fighting", "Ground", "Normal"]
             }
         ]
@@ -1465,7 +1465,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Heal Bell", "Knock Off", "Psychic", "Recover", "Taunt", "Thunder Wave"],
-                "teraTypes": ["Electric", "Poison", "Steel"]
+                "teraTypes": ["Dark", "Electric", "Poison", "Steel"]
             },
             {
                 "role": "Bulky Setup",
@@ -1500,7 +1500,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Dual Wingbeat", "Earthquake", "Outrage", "Roost"],
-                "teraTypes": ["Dragon", "Flying", "Ground"]
+                "teraTypes": ["Dragon", "Ground", "Steel"]
             }
         ]
     },
@@ -1554,7 +1554,17 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Body Slam", "Fire Punch", "Healing Wish", "Iron Head", "Protect", "Stealth Rock", "U-turn", "Wish"],
+                "movepool": ["Body Slam", "Future Sight", "Iron Head", "Protect", "Wish"],
+                "teraTypes": ["Water"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Body Slam", "Drain Punch", "Energy Ball", "Fire Punch", "Iron Head", "Psychic", "U-turn"],
+                "teraTypes": ["Fighting", "Water"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Fire Punch", "Healing Wish", "Iron Head", "Protect", "Stealth Rock", "U-turn", "Wish"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -2179,7 +2189,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Defog", "Draco Meteor", "Dragon Tail", "Earthquake", "Outrage", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
+                "movepool": ["Defog", "Draco Meteor", "Dragon Tail", "Earthquake", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
                 "teraTypes": ["Dragon", "Ghost"]
             }
         ]
@@ -2768,7 +2778,7 @@
         "level": 83,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["High Jump Kick", "Knock Off", "Poison Jab", "Stone Edge", "U-turn"],
                 "teraTypes": ["Dark"]
             },
@@ -3055,7 +3065,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Draco Meteor", "Flip Turn", "Focus Blast", "Hydro Pump", "Sludge Bomb", "Toxic", "Toxic Spikes"],
-                "teraTypes": ["Fighting", "Water"]
+                "teraTypes": ["Water"]
             }
         ]
     },
@@ -3732,11 +3742,6 @@
     "hatterene": {
         "level": 87,
         "sets": [
-            {
-                "role": "Wallbreaker",
-                "movepool": ["Dazzling Gleam", "Mystical Fire", "Psychic", "Psyshock", "Trick", "Trick Room"],
-                "teraTypes": ["Fairy", "Fire", "Psychic"]
-            },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Draining Kiss", "Mystical Fire", "Psychic", "Psyshock"],
@@ -4438,11 +4443,6 @@
                 "teraTypes": ["Dark"]
             },
             {
-                "role": "Bulky Support",
-                "movepool": ["Encore", "Knock Off", "Protect", "Substitute", "Toxic"],
-                "teraTypes": ["Dark"]
-            },
-            {
                 "role": "Fast Support",
                 "movepool": ["Encore", "Gunk Shot", "Knock Off", "Parting Shot"],
                 "teraTypes": ["Dark"]
@@ -4501,6 +4501,11 @@
                 "role": "Fast Attacker",
                 "movepool": ["Energy Ball", "Flamethrower", "Leaf Storm", "Overheat"],
                 "teraTypes": ["Fire", "Grass"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Energy Ball", "Fire Blast", "Stomping Tantrum", "Sunny Day"],
+                "teraTypes": ["Fire", "Grass", "Ground"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1553,18 +1553,18 @@
         "level": 79,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Fast Support",
                 "movepool": ["Body Slam", "Future Sight", "Iron Head", "Protect", "Wish"],
                 "teraTypes": ["Water"]
             },
             {
-                "role": "AV Pivot",
-                "movepool": ["Body Slam", "Drain Punch", "Energy Ball", "Fire Punch", "Iron Head", "Psychic", "U-turn"],
+                "role": "Bulky Attacker",
+                "movepool": ["Body Slam", "Drain Punch", "Energy Ball", "Fire Punch", "Iron Head", "Psychic", "Stealth Rock", "U-turn"],
                 "teraTypes": ["Fighting", "Water"]
             },
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Fire Punch", "Healing Wish", "Iron Head", "Protect", "Stealth Rock", "U-turn", "Wish"],
+                "role": "Bulky Support",
+                "movepool": ["Fire Punch", "Healing Wish", "Iron Head", "Protect", "U-turn", "Wish"],
                 "teraTypes": ["Water"]
             }
         ]

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1354,7 +1354,7 @@ export class RandomTeams {
 			return (counter.get('Physical') >= 3) ? 'Choice Band' : 'Choice Specs';
 		}
 		if (moves.has('blizzard') && ability !== 'Snow Warning' && !teamDetails.snow) return 'Blunder Policy';
-		if (counter.get('Physical') >= 4 &&
+		if (counter.get('Physical') >= 4 && species.id !== 'jirachi' &&
 			['fakeout', 'feint', 'firstimpression', 'rapidspin', 'suckerpunch'].every(m => !moves.has(m)) &&
 			(moves.has('flipturn') || moves.has('uturn') || role === 'Doubles Wallbreaker')
 		) {

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1354,7 +1354,7 @@ export class RandomTeams {
 			return (counter.get('Physical') >= 3) ? 'Choice Band' : 'Choice Specs';
 		}
 		if (moves.has('blizzard') && ability !== 'Snow Warning' && !teamDetails.snow) return 'Blunder Policy';
-		if (counter.get('Physical') >= 4 && species.id !== 'jirachi' &&
+		if (counter.get('Physical') >= 4 &&
 			['fakeout', 'feint', 'firstimpression', 'rapidspin', 'suckerpunch'].every(m => !moves.has(m)) &&
 			(moves.has('flipturn') || moves.has('uturn') || role === 'Doubles Wallbreaker')
 		) {
@@ -1411,7 +1411,8 @@ export class RandomTeams {
 	): string {
 		if (types.includes('Normal') && moves.has('fakeout')) return 'Silk Scarf';
 		if (
-			(counter.get('Physical') >= 4 || (counter.get('Physical') >= 3 && moves.has('memento'))) &&
+			species.id !== 'jirachi' && (counter.get('Physical') >= 4 ||
+			(counter.get('Physical') >= 3 && moves.has('memento'))) &&
 			['fakeout', 'firstimpression', 'flamecharge', 'rapidspin', 'ruination', 'superfang'].every(m => !moves.has(m))
 		) {
 			const scarfReqs = (

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -170,10 +170,7 @@ export class RandomTeams {
 		this.moveEnforcementCheckers = {
 			Bug: (movePool) => (movePool.includes('megahorn') || movePool.includes('xscissor')),
 			Dark: (movePool, moves, abilities, types, counter) => !counter.get('Dark'),
-			Dragon: (movePool, moves, abilities, types, counter, species, teamDetails, isLead, isDoubles) => (
-				!counter.get('Dragon') &&
-				(!movePool.includes('dualwingbeat') || isDoubles)
-			),
+			Dragon: (movePool, moves, abilities, types, counter) => !counter.get('Dragon'),
 			Electric: (movePool, moves, abilities, types, counter) => !counter.get('Electric'),
 			Fairy: (movePool, moves, abilities, types, counter) => !counter.get('Fairy'),
 			Fighting: (movePool, moves, abilities, types, counter) => !counter.get('Fighting'),
@@ -196,7 +193,7 @@ export class RandomTeams {
 			Psychic: (movePool, moves, abilities, types, counter) => {
 				if (counter.get('Psychic')) return false;
 				if (movePool.includes('calmmind') || movePool.includes('psychicfangs')) return true;
-				return abilities.has('Psychic Surge') || types.includes('Fire') || types.includes('Electric') || types.includes('Fighting');
+				return abilities.has('Psychic Surge') || ['Electric', 'Fighting', 'Fire', 'Poison'].some(m => types.includes(m));
 			},
 			Rock: (movePool, moves, abilities, types, counter, species) => !counter.get('Rock') && species.baseStats.atk >= 80,
 			Steel: (movePool, moves, abilities, types, counter, species, teamDetails, isLead, isDoubles) => (
@@ -579,7 +576,6 @@ export class RandomTeams {
 		if (species.id === "dugtrio") this.incompatibleMoves(moves, movePool, statusMoves, 'memento');
 		if (species.id === "cyclizar") this.incompatibleMoves(moves, movePool, 'taunt', 'knockoff');
 		if (species.baseSpecies === 'Dudunsparce') this.incompatibleMoves(moves, movePool, 'earthpower', 'shadowball');
-		if (species.id === 'jirachi') this.incompatibleMoves(moves, movePool, 'bodyslam', 'healingwish');
 		if (species.id === 'mesprit') this.incompatibleMoves(moves, movePool, 'healingwish', 'uturn');
 	}
 
@@ -732,12 +728,6 @@ export class RandomTeams {
 		// Enforce Salt Cure
 		if (movePool.includes('saltcure')) {
 			counter = this.addMove('saltcure', moves, types, abilities, teamDetails, species, isLead, isDoubles,
-				movePool, teraType, role);
-		}
-
-		// Enforce Toxic on Grafaiai
-		if (movePool.includes('toxic') && species.id === 'grafaiai') {
-			counter = this.addMove('toxic', moves, types, abilities, teamDetails, species, isLead, isDoubles,
 				movePool, teraType, role);
 		}
 
@@ -1060,7 +1050,7 @@ export class RandomTeams {
 		case 'Reckless':
 			return !counter.get('recoil');
 		case 'Regenerator':
-			return (species.id === 'mienshao' && role === 'Fast Attacker');
+			return (species.id === 'mienshao' && role === 'Wallbreaker');
 		case 'Rock Head':
 			return !counter.get('recoil');
 		case 'Sand Force': case 'Sand Rush':
@@ -1139,10 +1129,12 @@ export class RandomTeams {
 		if (species.id === 'golemalola' && moves.has('doubleedge')) return 'Galvanize';
 		if (abilities.has('Guts') && (moves.has('facade') || moves.has('sleeptalk') || species.id === 'gurdurr')) return 'Guts';
 		if (species.id === 'copperajah' && moves.has('heavyslam')) return 'Heavy Metal';
+		if (species.id === 'ariados') return 'Insomnia';
 		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';
+		if (species.id === 'ribombee') return 'Shield Dust';
+		if (species.id === 'dipplin') return 'Sticky Hold';
 		if (species.id === 'breloom') return 'Technician';
 		if (species.id === 'shiftry' && moves.has('tailwind')) return 'Wind Rider';
-		if (species.id === 'dipplin') return 'Sticky Hold';
 
 		// singles
 		if (!isDoubles) {
@@ -1175,7 +1167,6 @@ export class RandomTeams {
 			if (species.id === 'kommoo') return this.sample(['Overcoat', 'Soundproof']);
 			if (species.id === 'barraskewda') return 'Propeller Tail';
 			if (species.id === 'flapple' || (species.id === 'appletun' && this.randomChance(1, 2))) return 'Ripen';
-			if (species.id === 'ribombee') return 'Shield Dust';
 			if (species.id === 'gumshoos') return 'Strong Jaw';
 			if (species.id === 'magnezone') return 'Sturdy';
 			if (species.id === 'clefable' && role === 'Doubles Support') return 'Unaware';
@@ -1420,8 +1411,7 @@ export class RandomTeams {
 	): string {
 		if (types.includes('Normal') && moves.has('fakeout')) return 'Silk Scarf';
 		if (
-			species.id !== 'jirachi' && (counter.get('Physical') >= 4 ||
-			(counter.get('Physical') >= 3 && moves.has('memento'))) &&
+			(counter.get('Physical') >= 4 || (counter.get('Physical') >= 3 && moves.has('memento'))) &&
 			['fakeout', 'firstimpression', 'flamecharge', 'rapidspin', 'ruination', 'superfang'].every(m => !moves.has(m))
 		) {
 			const scarfReqs = (

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1131,7 +1131,6 @@ export class RandomTeams {
 		if (species.id === 'copperajah' && moves.has('heavyslam')) return 'Heavy Metal';
 		if (species.id === 'ariados') return 'Insomnia';
 		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';
-		if (species.id === 'ribombee') return 'Shield Dust';
 		if (species.id === 'dipplin') return 'Sticky Hold';
 		if (species.id === 'breloom') return 'Technician';
 		if (species.id === 'shiftry' && moves.has('tailwind')) return 'Wind Rider';
@@ -1167,6 +1166,7 @@ export class RandomTeams {
 			if (species.id === 'kommoo') return this.sample(['Overcoat', 'Soundproof']);
 			if (species.id === 'barraskewda') return 'Propeller Tail';
 			if (species.id === 'flapple' || (species.id === 'appletun' && this.randomChance(1, 2))) return 'Ripen';
+			if (species.id === 'ribombee') return 'Shield Dust';
 			if (species.id === 'gumshoos') return 'Strong Jaw';
 			if (species.id === 'magnezone') return 'Sturdy';
 			if (species.id === 'clefable' && role === 'Doubles Support') return 'Unaware';


### PR DESCRIPTION
Merge Sunday.

Changes marked with a _*_ decrease the rate of choice items.

-Remove Toxic Grafaiai.
-Remove the Intimidate Choice Band Tauros set. It is now always Sheer Force. _*_
-Add Sunny Day Scovillain. It will be Boots unless the team has hazard removal, and runs Eball over Solarbeam due to wanting to have the flexibility to not require using Sunny Day. _*_
-Jirachi now has three sets:
--Fast Support with Iron Head, WishTect, and Body Slam or Future Sight. Tera Water.
--Bulky Attacker with all the attacks Jirachi previously had, plus Psychic, Energy Ball, Stealth Rock, and Drain Punch. Tera Water/Fighting. Gets Assault Vest always when not Stealth Rock.
--Bulky Support with Iron Head, Fire Punch, U-turn, WishTect, and Healing Wish; Healing Wish will get Scarf. Tera Water.
-remove Wallbreaker Hatterene entirely. (No longer gets Specs or Life Orb) _*_
-add Slack Off Bulky Attacker Glowbro. Tera Ground/Dark/Poison. STABs + Slack Off + Earthquake/Fire Blast/Thunder Wave. _*_
-Psychic moves are now forced on Poison/Psychic types.
-Mienshao no longer gets Choice Scarf at all; the Reckless set is now always Choice Band (role changed to Wallbreaker)
-Giratina-O: -Outrage
-Salamence: -Tera Flying, +Tera Steel; Outrage is now forced on it.
-Bulky Support Chimecho: +Tera Dark
-Dragalge: -Tera Fighting (now always has Hydro Pump)
-ACTUALLY FOR REAL THIS TIME Ariados should always be Insomnia.
-Arbok: -Sucker Punch; no longer gets Choice Band. _*_

Gens 6/7 Random Battle:
-Gourgeist formes will no longer run SubSeed sets.