### PR TITLE
Fixed typo in scripts.ts

### DIFF
--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -690,7 +690,7 @@ export const Scripts: ModdedBattleScriptsData = {
 				defense = target.getStat(defType, true);
 			}
 
-			// When either attack or defense are higher than 256, they are both divided by 4 and moded by 256.
+			// When either attack or defense is higher than 256, they are both divided by 4 and moded by 256.
 			// This is what cuases the rollover bugs.
 			if (attack >= 256 || defense >= 256) {
 				attack = this.battle.clampIntRange(Math.floor(attack / 4) % 256, 1);

--- a/data/mods/gen1stadium/scripts.ts
+++ b/data/mods/gen1stadium/scripts.ts
@@ -691,7 +691,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			}
 
 			// When either attack or defense are higher than 256, they are both divided by 4 and moded by 256.
-			// This is what cuases the roll over bugs.
+			// This is what cuases the rollover bugs.
 			if (attack >= 256 || defense >= 256) {
 				attack = this.battle.clampIntRange(Math.floor(attack / 4) % 256, 1);
 				// Defense isn't checked on the cartridge, but we don't want those / 0 bugs on the sim.


### PR DESCRIPTION
Fixed the typo suggested in [this](https://github.com/smogon/pokemon-showdown/pull/9871) PR. Left the other obvious typo alone as it's already suggested in the linked PR. 

Also resolved grammar in above line ('attack or defense' denotes singular, therefore used 'is' instead of 'are').