### PR TITLE
Gen 1-2 Random Battles update

### DIFF
--- a/data/mods/gen1/random-data.json
+++ b/data/mods/gen1/random-data.json
@@ -9,8 +9,8 @@
     },
     "venusaur": {
         "level": 73,
-        "moves": ["bodyslam", "hyperbeam", "razorleaf"],
-        "exclusiveMoves": ["sleeppowder", "swordsdance"]
+        "moves": ["hyperbeam", "sleeppowder", "swordsdance"],
+        "essentialMoves": ["bodyslam", "razorleaf"]
     },
     "charmander": {
         "level": 93,
@@ -54,9 +54,8 @@
     },
     "beedrill": {
         "level": 86,
-        "moves": ["agility", "doubleedge", "megadrain", "swordsdance"],
-        "essentialMoves": ["hyperbeam", "twineedle"],
-        "comboMoves": ["agility", "hyperbeam", "swordsdance", "twineedle"]
+        "moves": ["hyperbeam", "swordsdance", "twineedle"],
+        "exclusiveMoves": ["agility", "agility", "megadrain"]
     },
     "pidgey": {
         "level": 96,
@@ -234,12 +233,12 @@
     "diglett": {
         "level": 86,
         "moves": ["earthquake", "rockslide", "slash"],
-        "exclusiveMoves": ["bodyslam", "bodyslam", "substitute"]
+        "exclusiveMoves": ["bodyslam", "substitute"]
     },
     "dugtrio": {
         "level": 73,
         "moves": ["earthquake", "rockslide", "slash"],
-        "exclusiveMoves": ["bodyslam", "bodyslam", "substitute"]
+        "exclusiveMoves": ["bodyslam", "substitute"]
     },
     "meowth": {
         "level": 86,
@@ -441,20 +440,17 @@
     "gastly": {
         "level": 77,
         "moves": ["explosion", "explosion", "megadrain", "nightshade", "psychic", "psychic"],
-        "essentialMoves": ["thunderbolt"],
-        "exclusiveMoves": ["confuseray", "hypnosis", "hypnosis", "hypnosis"]
+        "essentialMoves": ["thunderbolt", "hypnosis"]
     },
     "haunter": {
         "level": 70,
         "moves": ["explosion", "explosion", "megadrain", "nightshade", "psychic", "psychic"],
-        "essentialMoves": ["thunderbolt"],
-        "exclusiveMoves": ["confuseray", "hypnosis", "hypnosis", "hypnosis"]
+        "essentialMoves": ["thunderbolt", "hypnosis"]
     },
     "gengar": {
         "level": 64,
         "moves": ["explosion", "explosion", "megadrain", "nightshade", "psychic", "psychic"],
-        "essentialMoves": ["thunderbolt"],
-        "exclusiveMoves": ["confuseray", "hypnosis", "hypnosis", "hypnosis"]
+        "essentialMoves": ["thunderbolt", "hypnosis"]
     },
     "onix": {
         "level": 81,
@@ -624,7 +620,7 @@
     },
     "lapras": {
         "level": 69,
-        "moves": ["bodyslam", "confuseray", "rest", "sing", "surf"],
+        "moves": ["bodyslam", "rest", "sing", "surf"],
         "essentialMoves": ["blizzard", "thunderbolt"]
     },
     "ditto": {
@@ -644,8 +640,8 @@
     },
     "jolteon": {
         "level": 69,
-        "moves": ["agility", "agility", "bodyslam", "bodyslam", "bodyslam", "doublekick", "pinmissile", "pinmissile"],
-        "essentialMoves": ["thunderbolt", "thunderwave"]
+        "moves": ["bodyslam", "thunderbolt", "thunderwave"],
+        "exclusiveMoves": ["agility", "agility", "doublekick", "pinmissile", "pinmissile"]
     },
     "flareon": {
         "level": 77,
@@ -721,9 +717,8 @@
     },
     "mewtwo": {
         "level": 57,
-        "moves": ["blizzard", "recover", "thunderbolt"],
-        "essentialMoves": ["amnesia", "psychic"],
-        "comboMoves": ["amnesia", "psychic", "recover", "thunderwave"]
+        "moves": ["amnesia", "psychic", "recover"],
+        "exclusiveMoves": ["blizzard", "thunderbolt", "thunderwave", "thunderwave"]
     },
     "mew": {
         "level": 63,

--- a/data/mods/gen2/random-teams.ts
+++ b/data/mods/gen2/random-teams.ts
@@ -284,6 +284,8 @@ export class RandomGen2Teams extends RandomGen3Teams {
 		}
 
 		const levelScale: {[k: string]: number} = {
+			PU: 77,
+			PUBL: 75,
 			NU: 73,
 			NUBL: 71,
 			UU: 69,


### PR DESCRIPTION
Gen 1:
-Venusaur is now Body Slam + Razor Leaf + 2/3 of Hyper Beam, Sleep Powder, and Swords Dance. Its overall rate of Sleep Powder increases from 50% to 66%.
-Beedrill will always roll Swords Dance, and its 4th move is a roll between Agility and Mega Drain. It will no longer get Double-Edge.
-Diglett and Dugtrio will now obtain Substitute 50% of the time, up from 33%.
-Ghosts and Lapras will no longer get Confuse Ray, since they have better alternative options.
-Jolteon will always roll Body Slam.
-Mewtwo will no longer get sets without Recover.

Gen 2:
-PU mons are now level 77, and PUBL are level 75. This is to accommodate the recent addition of GSC PU. (https://github.com/smogon/pokemon-showdown/commit/ed81f3c8ced678a9b33b064b115819ed8fd4ee32)