### PR TITLE
fix sim/README.md hyperlink

### DIFF
--- a/COMMANDLINE.md
+++ b/COMMANDLINE.md
@@ -47,7 +47,7 @@ Note: Commands that ask for a team want the team in [packed team format](./sim/T
 - Simulates a battle, taking input to stdin and writing output to stdout
 
   Using Pokémon Showdown as a command-line simulator is documented at:
-  [sim/README.md](./README.md)
+  [sim/README.md](./sim/README.md)
 
 `./pokemon-showdown json-team`
 


### PR DESCRIPTION
The `sim/RADME.md` text have a hyperlink directing to the root `README.md` instead of the simulation one.

This PR fixes the embedded hyperlink.