### PR TITLE
Randomized format set updates

### DIFF
--- a/data/mods/gen4/random-sets.json
+++ b/data/mods/gen4/random-sets.json
@@ -463,7 +463,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["explosion", "hiddenpowerice", "signalbeam", "taunt", "thunderbolt"]
+                "movepool": ["explosion", "hiddenpowerice", "signalbeam", "taunt", "thunderbolt"],
+                "preferredTypes": ["Ice"]
             }
         ]
     },
@@ -519,12 +520,11 @@
         "level": 86,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["fireblast", "haze", "painsplit", "sludgebomb", "thunderbolt", "willowisp"],
-                "preferredTypes": ["Fire"]
+                "role": "Bulky Support",
+                "movepool": ["fireblast", "haze", "painsplit", "sludgebomb", "willowisp"]
             },
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["fireblast", "rest", "sleeptalk", "sludgebomb"]
             }
         ]
@@ -1324,7 +1324,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "toxic"]
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"]
             },
             {
                 "role": "Bulky Support",
@@ -1712,8 +1712,8 @@
         "level": 87,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["flamethrower", "hiddenpowergrass", "hiddenpowerice", "overheat", "switcheroo", "thunderbolt"]
+                "role": "Wallbreaker",
+                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "switcheroo", "thunderbolt"]
             }
         ]
     },
@@ -2149,7 +2149,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "thunderwave", "toxic"]
+                "movepool": ["earthquake", "explosion", "rest", "stealthrock", "stoneedge", "thunderwave", "toxic"]
             },
             {
                 "role": "Bulky Support",
@@ -2223,7 +2223,7 @@
                 "movepool": ["icebeam", "surf", "thunder", "waterspout"]
             },
             {
-                "role": "Bulky Setup",
+                "role": "Bulky Support",
                 "movepool": ["calmmind", "icebeam", "rest", "sleeptalk", "surf", "thunder"]
             }
         ]
@@ -2320,7 +2320,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["earthquake", "rockpolish", "stoneedge", "swordsdance", "woodhammer"]
+                "movepool": ["earthquake", "rockpolish", "stoneedge", "woodhammer"]
             }
         ]
     },

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -479,6 +479,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			return !counter.get('recoil');
 		case 'Skill Link':
 			return !counter.get('skilllink');
+		case 'Swarm':
+			return !counter.get('Bug');
 		case 'Technician':
 			return !counter.get('technician');
 		}
@@ -615,7 +617,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			) ? 'Choice Scarf' : 'Choice Specs';
 		}
 		if (
-			counter.get('Special') === 3 && role === 'Fast Attacker' && moves.has('explosion') || moves.has('selfdestruct')
+			counter.get('Special') === 3 && role === 'Fast Attacker' && (moves.has('explosion') || moves.has('selfdestruct'))
 		) return 'Choice Scarf';
 		if (counter.get('Special') === 3 && moves.has('uturn')) return 'Choice Specs';
 		if (counter.get('Physical') === 4 && species.id !== 'jirachi' &&

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -161,7 +161,6 @@ export class RandomGen4Teams extends RandomGen5Teams {
 
 		// Develop additional move lists
 		const badWithSetup = ['healbell', 'pursuit', 'toxic'];
-		const statusInflictingMoves = ['stunspore', 'thunderwave', 'toxic', 'willowisp', 'yawn'];
 		// Nature Power is Earthquake this gen
 		const statusMoves = this.dex.moves.all()
 			.filter(move => move.category === 'Status')
@@ -190,9 +189,6 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			['gunkshot', 'poisonjab'],
 			['payback', 'pursuit'],
 
-			// Status move incompatibilities
-			[statusInflictingMoves, statusInflictingMoves],
-
 			// Assorted hardcodes go here:
 			// Manectric
 			['flamethrower', 'overheat'],
@@ -209,6 +205,11 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		];
 
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
+
+		const statusInflictingMoves = ['stunspore', 'thunderwave', 'toxic', 'willowisp', 'yawn'];
+		if (!abilities.has('Prankster') && role !== 'Staller') {
+			this.incompatibleMoves(moves, movePool, statusInflictingMoves, statusInflictingMoves);
+		}
 	}
 
 	// Generate random moveset for a given species, role, preferred type.

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -207,7 +207,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
 
 		const statusInflictingMoves = ['stunspore', 'thunderwave', 'toxic', 'willowisp', 'yawn'];
-		if (!abilities.has('Prankster') && role !== 'Staller') {
+		if (role !== 'Staller') {
 			this.incompatibleMoves(moves, movePool, statusInflictingMoves, statusInflictingMoves);
 		}
 	}

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -1380,7 +1380,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "toxic"]
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"]
             },
             {
                 "role": "Bulky Support",
@@ -1765,8 +1765,8 @@
         "level": 84,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["flamethrower", "hiddenpowergrass", "hiddenpowerice", "overheat", "switcheroo", "thunderbolt", "voltswitch"],
+                "role": "Wallbreaker",
+                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "switcheroo", "thunderbolt", "voltswitch"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -2255,7 +2255,7 @@
                 "movepool": ["icebeam", "surf", "thunder", "waterspout"]
             },
             {
-                "role": "Bulky Setup",
+                "role": "Bulky Support",
                 "movepool": ["calmmind", "icebeam", "rest", "sleeptalk", "surf", "thunder"]
             }
         ]
@@ -2347,7 +2347,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["earthquake", "rockpolish", "stoneedge", "swordsdance", "woodhammer"]
+                "movepool": ["earthquake", "rockpolish", "stoneedge", "woodhammer"]
             }
         ]
     },

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -545,7 +545,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "toxic"]
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"]
             },
             {
                 "role": "Bulky Support",

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -176,7 +176,6 @@ export class RandomGen5Teams extends RandomGen6Teams {
 
 		// Develop additional move lists
 		const badWithSetup = ['healbell', 'pursuit', 'toxic'];
-		const statusInflictingMoves = ['stunspore', 'thunderwave', 'toxic', 'willowisp', 'yawn'];
 		// Nature Power is Earthquake this gen
 		const statusMoves = this.dex.moves.all()
 			.filter(move => move.category === 'Status' && move.id !== 'naturepower')
@@ -200,9 +199,6 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			[['bodyslam', 'return'], ['bodyslam', 'doubleedge']],
 			[['gigadrain', 'leafstorm'], ['leafstorm', 'petaldance', 'powerwhip']],
 			[['drainpunch', 'focusblast'], ['closecombat', 'highjumpkick', 'superpower']],
-
-			// Status move incompatibilities
-			[statusInflictingMoves, statusInflictingMoves],
 
 			// Assorted hardcodes go here:
 			// Zebstrika
@@ -228,6 +224,11 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
 
 		if (species.id === 'dugtrio') this.incompatibleMoves(moves, movePool, statusMoves, 'memento');
+
+		const statusInflictingMoves = ['stunspore', 'thunderwave', 'toxic', 'willowisp', 'yawn'];
+		if (!abilities.has('Prankster') && role !== 'Staller') {
+			this.incompatibleMoves(moves, movePool, statusInflictingMoves, statusInflictingMoves);
+		}
 	}
 
 	// Generate random moveset for a given species, role, preferred type.

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -1499,7 +1499,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "toxic"]
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"]
             },
             {
                 "role": "Bulky Support",
@@ -1955,8 +1955,8 @@
         "level": 85,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["flamethrower", "hiddenpowergrass", "hiddenpowerice", "overheat", "switcheroo", "thunderbolt", "voltswitch"],
+                "role": "Wallbreaker",
+                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "switcheroo", "thunderbolt", "voltswitch"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -2663,7 +2663,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "rockpolish", "stoneedge", "swordsdance", "woodhammer"]
+                "movepool": ["earthquake", "rockpolish", "stoneedge", "woodhammer"]
             }
         ]
     },

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -593,7 +593,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "toxic"]
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"]
             },
             {
                 "role": "Bulky Support",

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -259,7 +259,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		}
 
 		const statusInflictingMoves = ['thunderwave', 'toxic', 'willowisp', 'yawn'];
-		if (!abilities.has('Prankster')) {
+		if (!abilities.has('Prankster') && role !== 'Staller') {
 			this.incompatibleMoves(moves, movePool, statusInflictingMoves, statusInflictingMoves);
 		}
 

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -2129,8 +2129,8 @@
         "level": 88,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["flamethrower", "hiddenpowergrass", "hiddenpowerice", "overheat", "switcheroo", "thunderbolt", "voltswitch"],
+                "role": "Wallbreaker",
+                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "switcheroo", "thunderbolt", "voltswitch"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -2866,7 +2866,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "rockpolish", "stoneedge", "swordsdance", "woodhammer"]
+                "movepool": ["earthquake", "rockpolish", "stoneedge", "woodhammer"]
             }
         ]
     },

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -1158,7 +1158,7 @@
         "level": 91,
         "sets": [
             {
-                "role": "Doubles Bulky Setup",
+                "role": "Doubles Support",
                 "movepool": ["Encore", "Lunge", "Tailwind", "Thunder Wave"],
                 "teraTypes": ["Steel", "Water"]
             }

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -1160,7 +1160,7 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Encore", "Lunge", "Tailwind", "Thunder Wave"],
-                "teraTypes": ["Ghost"]
+                "teraTypes": ["Steel", "Water"]
             }
         ]
     },

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -380,7 +380,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Foul Play", "Helping Hand", "Light Screen", "Taunt", "Thunder Wave", "Thunderbolt", "Volt Switch"],
-                "teraTypes": ["Dark", "Flying"]
+                "teraTypes": ["Flying"]
             },
             {
                 "role": "Tera Blast user",
@@ -764,7 +764,7 @@
         "sets": [
             {
                 "role": "Choice Item user",
-                "movepool": ["Earth Power", "Hydro Pump", "Ice Beam", "Muddy Water"],
+                "movepool": ["Hydro Pump", "Ice Beam", "Muddy Water", "Weather Ball"],
                 "teraTypes": ["Water"]
             },
             {
@@ -964,7 +964,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Brave Bird", "Fake Out", "Helping Hand", "Icy Wind", "Memento", "Tailwind"],
+                "movepool": ["Brave Bird", "Fake Out", "Helping Hand", "Icy Wind", "Tailwind"],
                 "teraTypes": ["Steel"]
             },
             {
@@ -1159,7 +1159,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Setup",
-                "movepool": ["Baton Pass", "Bug Buzz", "Tail Glow", "Tailwind"],
+                "movepool": ["Encore", "Lunge", "Tailwind", "Thunder Wave"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -1739,7 +1739,7 @@
         "sets": [
             {
                 "role": "Bulky Protect",
-                "movepool": ["Dual Wingbeat", "High Horsepower", "Knock Off", "Protect", "Stealth Rock", "Toxic"],
+                "movepool": ["Dual Wingbeat", "High Horsepower", "Knock Off", "Protect", "Toxic", "Toxic Spikes"],
                 "teraTypes": ["Water"]
             },
             {
@@ -1979,7 +1979,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Aura Sphere", "Destiny Bond", "Draco Meteor", "Shadow Force", "Will-O-Wisp"],
+                "movepool": ["Aura Sphere", "Draco Meteor", "Poltergeist", "Shadow Force", "Will-O-Wisp"],
                 "teraTypes": ["Dragon", "Fairy", "Ghost", "Poison"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2973,7 +2973,7 @@
                 "teraTypes": ["Steel", "Water"]
             },
             {
-                "role": "Bulky Setup",
+                "role": "Fast Bulky Setup",
                 "movepool": ["Body Press", "Iron Defense", "Synthesis", "Trailblaze"],
                 "teraTypes": ["Steel"]
             }

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -3129,13 +3129,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Body Press", "Moonblast", "Power Gem", "Spikes", "Stealth Rock"],
+                "movepool": ["Body Press", "Light Screen", "Moonblast", "Power Gem", "Reflect", "Spikes", "Stealth Rock"],
                 "teraTypes": ["Fighting"]
             },
             {
-                "role": "Bulky Support",
-                "movepool": ["Body Press", "Light Screen", "Moonblast", "Reflect", "Stealth Rock"],
-                "teraTypes": ["Steel", "Water"]
+                "role": "Fast Bulky Setup",
+                "movepool": ["Body Press", "Iron Defense", "Moonblast", "Rest", "Rock Polish"],
+                "teraTypes": ["Fighting"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -749,7 +749,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Brick Break", "Double-Edge", "Knock Off", "Trick", "U-turn"],
+                "movepool": ["Double-Edge", "Knock Off", "Trick", "U-turn"],
                 "teraTypes": ["Ghost", "Normal"]
             },
             {

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -19,8 +19,13 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Earthquake", "Glare", "Gunk Shot", "Knock Off", "Toxic Spikes"],
+                "movepool": ["Earthquake", "Glare", "Gunk Shot", "Knock Off", "Sucker Punch", "Toxic Spikes"],
                 "teraTypes": ["Dark", "Ground"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Coil", "Earthquake", "Gunk Shot", "Sucker Punch", "Trailblaze"],
+                "teraTypes": ["Ground"]
             }
         ]
     },
@@ -720,7 +725,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Eruption", "Fire Blast", "Focus Blast", "Shadow Ball"],
-                "teraTypes": ["Fighting", "Fire"]
+                "teraTypes": ["Fire"]
             }
         ]
     },
@@ -729,13 +734,13 @@
         "sets": [
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Calm Mind", "Fire Blast", "Shadow Ball", "Substitute", "Will-O-Wisp"],
-                "teraTypes": ["Ghost"]
+                "movepool": ["Calm Mind", "Fire Blast", "Focus Blast", "Shadow Ball", "Substitute", "Will-O-Wisp"],
+                "teraTypes": ["Fighting", "Fire", "Ghost"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["Eruption", "Fire Blast", "Focus Blast", "Shadow Ball"],
-                "teraTypes": ["Fire", "Ghost"]
+                "teraTypes": ["Fire"]
             }
         ]
     },
@@ -744,7 +749,12 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Brick Break", "Double-Edge", "Knock Off", "Tidy Up", "U-turn"],
+                "movepool": ["Brick Break", "Double-Edge", "Knock Off", "Trick", "U-turn"],
+                "teraTypes": ["Ghost", "Normal"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Brick Break", "Double-Edge", "Knock Off", "Tidy Up"],
                 "teraTypes": ["Ghost", "Normal"]
             }
         ]
@@ -899,8 +909,8 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Fire Blast", "Hydro Pump", "Ice Beam", "Psyshock", "Slack Off", "Trick Room"],
-                "teraTypes": ["Psychic"]
+                "movepool": ["Fire Blast", "Hydro Pump", "Ice Beam", "Psychic", "Psyshock", "Trick Room"],
+                "teraTypes": ["Psychic", "Water"]
             }
         ]
     },
@@ -1048,9 +1058,9 @@
         "level": 100,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["Brave Bird", "Drill Run", "Ice Shard", "Ice Spinner"],
-                "teraTypes": ["Flying", "Ground", "Ice"]
+                "role": "Wallbreaker",
+                "movepool": ["Brave Bird", "Drill Run", "Foul Play", "Ice Shard", "Ice Spinner"],
+                "teraTypes": ["Dark", "Flying", "Ground", "Ice"]
             },
             {
                 "role": "Fast Support",
@@ -1154,7 +1164,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Dark Pulse", "Heat Wave", "Leaf Storm", "Nasty Plot", "Vacuum Wave"],
+                "movepool": ["Dark Pulse", "Giga Drain", "Heat Wave", "Leaf Storm", "Nasty Plot", "Vacuum Wave"],
                 "teraTypes": ["Fire", "Grass"]
             },
             {
@@ -1384,7 +1394,17 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Facade", "Knock Off", "Quick Attack", "Swords Dance"],
+                "movepool": ["Close Combat", "Facade", "Knock Off", "Swords Dance"],
+                "teraTypes": ["Normal"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Close Combat", "Facade", "Knock Off", "Quick Attack"],
+                "teraTypes": ["Normal"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Facade", "Knock Off", "Quick Attack", "Swords Dance"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -1591,11 +1611,6 @@
                 "role": "Fast Support",
                 "movepool": ["Close Combat", "Flare Blitz", "Gunk Shot", "Knock Off", "Mach Punch", "Stone Edge", "Swords Dance", "U-turn"],
                 "teraTypes": ["Dark", "Fighting", "Fire"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["Aura Sphere", "Fire Blast", "Grass Knot", "Nasty Plot", "Vacuum Wave"],
-                "teraTypes": ["Fighting", "Fire", "Grass"]
             }
         ]
     },
@@ -1934,7 +1949,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Knock Off", "Protect", "Stealth Rock", "Toxic Spikes", "U-turn"],
+                "movepool": ["Earthquake", "Knock Off", "Protect", "Spikes", "Toxic Spikes", "U-turn"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -3221,6 +3236,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Diamond Storm", "Earth Power", "Moonblast", "Stealth Rock"],
                 "teraTypes": ["Fighting"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Diamond Storm", "Draining Kiss", "Earth Power"],
+                "teraTypes": ["Fairy", "Water"]
             }
         ]
     },
@@ -3364,7 +3384,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Moonblast", "Psychic", "Sticky Web", "Stun Spore", "U-turn"],
+                "movepool": ["Moonblast", "Sticky Web", "Stun Spore", "U-turn"],
                 "teraTypes": ["Ghost"]
             },
             {
@@ -3568,13 +3588,8 @@
         "level": 81,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Acrobatics", "Grassy Glide", "High Horsepower", "Knock Off", "Swords Dance", "Wood Hammer"],
-                "teraTypes": ["Grass"]
-            },
-            {
                 "role": "Wallbreaker",
-                "movepool": ["Grassy Glide", "High Horsepower", "Knock Off", "U-turn", "Wood Hammer"],
+                "movepool": ["Grassy Glide", "High Horsepower", "Knock Off", "Swords Dance", "U-turn", "Wood Hammer"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -4386,11 +4401,6 @@
                 "role": "Wallbreaker",
                 "movepool": ["Armor Cannon", "Aura Sphere", "Energy Ball", "Focus Blast", "Psyshock"],
                 "teraTypes": ["Fighting", "Fire", "Grass", "Psychic"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["Armor Cannon", "Aura Sphere", "Calm Mind", "Energy Ball", "Psyshock"],
-                "teraTypes": ["Fighting", "Fire", "Grass"]
             }
         ]
     },
@@ -5090,11 +5100,6 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Draco Meteor", "Dragon Tail", "Giga Drain", "Recover", "Sucker Punch"],
-                "teraTypes": ["Steel"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["Dragon Pulse", "Giga Drain", "Growth", "Recover"],
                 "teraTypes": ["Steel"]
             }
         ]

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1130,7 +1130,6 @@ export class RandomTeams {
 		if (species.id === 'golemalola' && moves.has('doubleedge')) return 'Galvanize';
 		if (abilities.has('Guts') && (moves.has('facade') || moves.has('sleeptalk') || species.id === 'gurdurr')) return 'Guts';
 		if (species.id === 'copperajah' && moves.has('heavyslam')) return 'Heavy Metal';
-		if (species.id === 'ariados') return 'Insomnia';
 		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';
 		if (species.id === 'ribombee') return 'Shield Dust';
 		if (species.id === 'dipplin') return 'Sticky Hold';
@@ -1165,6 +1164,7 @@ export class RandomTeams {
 			if (species.id === 'conkeldurr' && role === 'Doubles Wallbreaker') return 'Guts';
 			if (species.id === 'tropius' || species.id === 'trevenant') return 'Harvest';
 			if (species.id === 'dragonite' || species.id === 'lucario') return 'Inner Focus';
+			if (species.id === 'ariados') return 'Insomnia';
 			if (species.id === 'kommoo') return this.sample(['Overcoat', 'Soundproof']);
 			if (species.id === 'barraskewda') return 'Propeller Tail';
 			if (species.id === 'flapple' || (species.id === 'appletun' && this.randomChance(1, 2))) return 'Ripen';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -74,7 +74,7 @@ const MIXED_SETUP = [
 ];
 // Some moves that only boost Speed:
 const SPEED_SETUP = [
-	'agility', 'autotomize', 'rockpolish',
+	'agility', 'autotomize', 'rockpolish', 'trailblaze',
 ];
 // Conglomerate for ease of access
 const SETUP = [
@@ -994,10 +994,7 @@ export class RandomTeams {
 		case 'Contrary': case 'Serene Grace': case 'Skill Link': case 'Strong Jaw':
 			return !counter.get(toID(ability));
 		case 'Chlorophyll':
-			return (
-				!moves.has('sunnyday') && !teamDetails.sun &&
-				species.id !== 'lilligant' && species.id !== 'jumpluff'
-			);
+			return (!moves.has('sunnyday') && !teamDetails.sun && species.id !== 'lilligant');
 		case 'Cloud Nine':
 			return (species.id !== 'golduck');
 		case 'Competitive':
@@ -1130,6 +1127,7 @@ export class RandomTeams {
 		if (species.id === 'golemalola' && moves.has('doubleedge')) return 'Galvanize';
 		if (abilities.has('Guts') && (moves.has('facade') || moves.has('sleeptalk') || species.id === 'gurdurr')) return 'Guts';
 		if (species.id === 'copperajah' && moves.has('heavyslam')) return 'Heavy Metal';
+		if (species.id === 'jumpluff') return 'Infiltrator';
 		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';
 		if (species.id === 'ribombee') return 'Shield Dust';
 		if (species.id === 'dipplin') return 'Sticky Hold';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1041,7 +1041,7 @@ export class RandomTeams {
 		case 'Natural Cure':
 			return species.id === 'pawmot';
 		case 'Neutralizing Gas':
-			return (!isDoubles);
+			return !isDoubles;
 		case 'Overcoat': case 'Sweet Veil':
 			return types.includes('Grass');
 		case 'Overgrow':

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -120,7 +120,7 @@ const PRIORITY_POKEMON = [
 
 /** Pokemon who should never be in the lead slot */
 const NO_LEAD_POKEMON = [
-	'Rillaboom', 'Zacian', 'Zamazenta',
+	'Zacian', 'Zamazenta',
 ];
 const DOUBLES_NO_LEAD_POKEMON = [
 	'Basculegion', 'Houndstone', 'Roaring Moon', 'Zacian', 'Zamazenta',

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -896,7 +896,7 @@ export class RandomTeams {
 		}
 
 		// Enforce Protect
-		if (role.includes('Protect')) {
+		if (role.includes('Protect') || species.id === 'gliscor') {
 			const protectMoves = movePool.filter(moveid => PROTECT_MOVES.includes(moveid));
 			if (protectMoves.length) {
 				const moveid = this.sample(protectMoves);
@@ -985,8 +985,8 @@ export class RandomTeams {
 	): boolean {
 		if ([
 			'Armor Tail', 'Battle Bond', 'Early Bird', 'Flare Boost', 'Galvanize', 'Gluttony', 'Harvest', 'Hydration', 'Ice Body', 'Immunity',
-			'Misty Surge', 'Moody', 'Own Tempo', 'Pressure', 'Quick Feet', 'Rain Dish', 'Sand Veil', 'Sniper', 'Snow Cloak', 'Steadfast',
-			'Steam Engine',
+			'Marvel Scale', 'Misty Surge', 'Moody', 'Own Tempo', 'Pressure', 'Quick Feet', 'Rain Dish', 'Sand Veil', 'Sniper', 'Snow Cloak',
+			'Steadfast', 'Steam Engine',
 		].includes(ability)) return true;
 
 		switch (ability) {
@@ -994,7 +994,10 @@ export class RandomTeams {
 		case 'Contrary': case 'Serene Grace': case 'Skill Link': case 'Strong Jaw':
 			return !counter.get(toID(ability));
 		case 'Chlorophyll':
-			return (!moves.has('sunnyday') && !teamDetails.sun && species.id !== 'lilligant');
+			return (
+				!moves.has('sunnyday') && !teamDetails.sun &&
+				species.id !== 'lilligant' && species.id !== 'jumpluff'
+			);
 		case 'Cloud Nine':
 			return (species.id !== 'golduck');
 		case 'Competitive':
@@ -1031,8 +1034,6 @@ export class RandomTeams {
 			return !counter.get('Physical');
 		case 'Libero': case 'Protean':
 			return role === 'Offensive Protect' || (species.id === 'meowscarada' && role === 'Fast Attacker');
-		case 'Marvel Scale':
-			return isDoubles;
 		case 'Mold Breaker':
 			return (abilities.has('Sharpness') || abilities.has('Unburden'));
 		case 'Moxie':
@@ -1040,7 +1041,7 @@ export class RandomTeams {
 		case 'Natural Cure':
 			return species.id === 'pawmot';
 		case 'Neutralizing Gas':
-			return (!isDoubles && species.id === 'weezing');
+			return (!isDoubles);
 		case 'Overcoat': case 'Sweet Veil':
 			return types.includes('Grass');
 		case 'Overgrow':
@@ -1078,7 +1079,7 @@ export class RandomTeams {
 		case 'Swarm':
 			return (!counter.get('Bug') || !!counter.get('recovery'));
 		case 'Swift Swim':
-			return (!moves.has('raindance') && !teamDetails.rain);
+			return (abilities.has('Intimidate') || (!moves.has('raindance') && !teamDetails.rain));
 		case 'Synchronize':
 			return (species.id !== 'umbreon' && species.id !== 'rabsca');
 		case 'Technician':
@@ -1131,6 +1132,7 @@ export class RandomTeams {
 		if (species.id === 'copperajah' && moves.has('heavyslam')) return 'Heavy Metal';
 		if (species.id === 'ariados') return 'Insomnia';
 		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';
+		if (species.id === 'ribombee') return 'Shield Dust';
 		if (species.id === 'dipplin') return 'Sticky Hold';
 		if (species.id === 'breloom') return 'Technician';
 		if (species.id === 'shiftry' && moves.has('tailwind')) return 'Wind Rider';
@@ -1166,7 +1168,6 @@ export class RandomTeams {
 			if (species.id === 'kommoo') return this.sample(['Overcoat', 'Soundproof']);
 			if (species.id === 'barraskewda') return 'Propeller Tail';
 			if (species.id === 'flapple' || (species.id === 'appletun' && this.randomChance(1, 2))) return 'Ripen';
-			if (species.id === 'ribombee') return 'Shield Dust';
 			if (species.id === 'gumshoos') return 'Strong Jaw';
 			if (species.id === 'magnezone') return 'Sturdy';
 			if (species.id === 'clefable' && role === 'Doubles Support') return 'Unaware';
@@ -1447,10 +1448,7 @@ export class RandomTeams {
 		if (species.id === 'palkia') return 'Lustrous Orb';
 		if (moves.has('substitute') || ability === 'Moody') return 'Leftovers';
 		if (moves.has('stickyweb') && isLead) return 'Focus Sash';
-		if (
-			((!teamDetails.defog && !teamDetails.rapidSpin) || (!counter.get('setup') && role !== 'Wallbreaker')) &&
-			this.dex.getEffectiveness('Rock', species) >= 1
-		) return 'Heavy-Duty Boots';
+		if (this.dex.getEffectiveness('Rock', species) >= 1) return 'Heavy-Duty Boots';
 		if (
 			(moves.has('chillyreception') || (
 				role === 'Fast Support' &&
@@ -1490,7 +1488,7 @@ export class RandomTeams {
 			role === 'Tera Blast user' && species.baseSpecies === 'Florges'
 		) return 'Leftovers';
 		if (
-			['flamecharge', 'rapidspin'].every(m => !moves.has(m)) &&
+			['flamecharge', 'rapidspin', 'trailblaze'].every(m => !moves.has(m)) &&
 			['Fast Attacker', 'Setup Sweeper', 'Tera Blast user', 'Wallbreaker'].some(m => role === (m))
 		) return 'Life Orb';
 		return 'Leftovers';


### PR DESCRIPTION
Gen 9 Random Battle:
-Rock-weak Pokemon will now get Heavy-Duty Boots even with hazard removal on the team. (Council decision)
-Zangoose has been split into three fixed sets solely so that it always gets Knock Off.
-Furret's sets have been split; Tidy Up as it was before, and Choice Band with the addition of Trick over Brick Break.
-Carbink's sets have been fused together. Dual Screens Carbink will no longer generate as a second screens setter, but its fourth move will always be Body Press.
-Carbink has a new second set: Iron Defense, Moonblast, Body Press, and Rock Polish/Rest. Gets Chesto with Rest and Leftovers with Rock Polish.
-Arbok now has a Setup Sweeper set with Coil, Gunk Shot, Earthquake, and Sucker Punch/Trailblaze. Trailblaze gives Leftovers, Sucker gives Life Orb. Tera Ground.
-Diancie now has a Bulky Setup set with Calm Mind, Diamond Storm, Draining Kiss, and Earth Power. Tera Fairy/Water.
-Rillaboom no longer gets Acrobatics Grassy Seed, and also now always gets Grassy Glide on Swords Dance. Rillaboom can now be a lead again.
-Bulky Support Gliscor: -Stealth Rock, +Spikes; it also now always gets Protect on this set.
-Hustle Delibird: +Foul Play, +Tera Dark, role changed to Wallbreaker to force Ice Shard.
-Ribombee now always gets Shield Dust.
-Qwilfish, Hisuian Qwilfish, Overqwil, and Jumpluff will no longer get weather speed boosting abilities ever.
-Calm Mind Typhlosion-Hisui: +Tera Fire, +Tera Fighting, +Focus Blast
-Eruption Typhlosions are now only Tera Fire.
There are a lot of changes we made that caused the Pokemon's winrates to decrease, so we're doing the following now to revert them:
--Remove Psychic Ribombee
--Remove Marvel Scale Milotic
--Remove Neutralizing Gas Galarian Weezing
--Remove Growth Dipplin
--Remove Calm Mind Armarouge
--Readd Sucker Punch to Arbok
--Remove Slack Off from Wallbreaker Slowking, and readd Psychic and Tera Water.
--Readd Giga Drain to special Shiftry
--Remove Nasty Plot Infernape

Doubles:
-Delibird: -Memento
-Giratina-O: -Destiny Bond, +Poltergeist
-Choice Item Politoed: -Earth Power, +Weather Ball
-Volbeat now runs a copy of Illumise's set but with Lunge instead of Bug Buzz. No more TailPass.
-Electrode: -Tera Dark

Old Gens:
-Add Thunder Wave to Staller Blissey/Chansey, and allow Thunder Wave + Toxic on the Staller role. (gens 4-6)
-Torterra: -Swords Dance (gens 4-7)
-Manectric: -HP Grass, role changed to Wallbreaker to enforce Choice Specs (gens 4-7)
-Kyogre: Bulky Setup changed to Bulky Support; you can now get RestTalk 2 attacks. (Gens 4 and 5)
-Ledian no longer gets Swarm with no bug moves (Gen 4)
-Bulky Attacker Regirock: +Rest (Gen 4)
-Snorlax no longer gets Choice Scarf (Gen 4)
-Electrode now always gets HP Ice (Gen 4)
-Weezing's roles have been swapped, and the set with all the attacks now no longer gets Thunderbolt and doesn't always get Fire Blast anymore. (Gen 4)