### PR TITLE
Update Smogon package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3117,9 +3117,9 @@
       }
     },
     "node_modules/smogon": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/smogon/-/smogon-2.2.2.tgz",
-      "integrity": "sha512-o/xTJTEej7gbb93bCNWSjppo++Sg96fPCNIu1xt9IcWoKOViCfEcMvbofG+0KX08P0iOBzOY9MWGbSFPjTSzXw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/smogon/-/smogon-3.0.0.tgz",
+      "integrity": "sha512-F+Yo6yXqidabdvMqyI6rrXKejBMl0OOmgGyk5dctqeJx9fFmFUnK3bzkdUG/eaXX0S8m4hUb+WqieiHlAiQgUQ==",
       "dev": true
     },
     "node_modules/sockjs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@typescript-eslint/parser": "^5.8.0",
         "eslint": "^8.5.0",
         "mocha": "^8.2.0",
-        "smogon": "^2.2.1",
+        "smogon": "^3.0.0",
         "typescript": "^5.0.4"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@typescript-eslint/parser": "^5.8.0",
     "eslint": "^8.5.0",
     "mocha": "^8.2.0",
-    "smogon": "^2.2.1",
+    "smogon": "^3.0.0",
     "typescript": "^5.0.4"
   }
 }


### PR DESCRIPTION
This fixes a bug detailed here: https://www.smogon.com/forums/threads/bug-reports-v4-read-original-post-before-posting.3663703/post-9796082 that causes the set import buttons for some tiers (gen9ru, gen3lc are examples) to not appear.