### PR TITLE
Partners in Crime: Fix bugs

### DIFF
--- a/data/mods/partnersincrime/abilities.ts
+++ b/data/mods/partnersincrime/abilities.ts
@@ -39,12 +39,12 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			const sortedActive = this.getAllActive();
 			this.speedSort(sortedActive);
 			for (const pokemon of sortedActive) {
+				if (pokemon.m.innate) {
+					if (!pokemon.volatiles[pokemon.m.innate]) pokemon.addVolatile(pokemon.m.innate, pokemon);
+				}
 				if (pokemon !== source) {
 					// Will be suppressed by Pokemon#ignoringAbility if needed
 					this.singleEvent('Start', pokemon.getAbility(), pokemon.abilityState, pokemon);
-				}
-				if (pokemon.m.innate) {
-					if (!pokemon.volatiles[pokemon.m.innate]) pokemon.addVolatile(pokemon.m.innate, pokemon);
 				}
 			}
 		},

--- a/data/mods/partnersincrime/scripts.ts
+++ b/data/mods/partnersincrime/scripts.ts
@@ -81,6 +81,13 @@ export const Scripts: ModdedBattleScriptsData = {
 					moveSlot.disabled = false;
 					moveSlot.disabledSource = '';
 				}
+				if (pokemon.volatiles['encore']) {
+					// Encore check happens earlier than PiC move swapping, so end encore here.
+					const encoredMove = pokemon.volatiles['encore'].move;
+					if (!pokemon.moves.includes(encoredMove)) {
+						pokemon.removeVolatile('encore');
+					}
+				}
 				this.runEvent('DisableMove', pokemon);
 				for (const moveSlot of pokemon.moveSlots) {
 					const activeMove = this.dex.getActiveMove(moveSlot.id);


### PR DESCRIPTION
Fixes a bug where Encore can force a pokemon to get locked into a move it no longer has, and fixes a bug where innates do not get applied before abilities starting up again in Neutralizing Gas.