### PR TITLE
Monotype LC: Update bans

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -514,7 +514,7 @@ export const Formats: FormatList = [
 		mod: 'gen9',
 		searchShow: false,
 		ruleset: ['Standard', 'Same Type Clause', 'Little Cup', 'Terastal Clause'],
-		banlist: ['Damp Rock', 'Focus Band', 'Heat Rock', 'Icy Rock', 'Quick Claw'],
+		banlist: ['Aipom', 'Basculin-White-Striped', 'Cutiefly', 'Dunsparce', 'Flittle', 'Gastly', 'Girafarig', 'Gligar', 'Meditite', 'Misdreavus', 'Murkrow', 'Qwilfish-Hisui', 'Rufflet', 'Scyther', 'Sneasel', 'Sneasel-Hisui', 'Stantler', 'Yanma', 'Moody', 'Baton Pass', 'Damp Rock', 'Focus Band', 'Heat Rock', 'Icy Rock', 'Quick Claw'],
 		unbanlist: ['Diglett', 'Growlithe-Hisui', 'Vulpix', 'Vulpix-Alola'],
 	},
 

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -513,8 +513,8 @@ export const Formats: FormatList = [
 
 		mod: 'gen9',
 		searchShow: false,
-		ruleset: ['Standard', 'Same Type Clause', 'Little Cup', 'Terastal Clause'],
-		banlist: ['Aipom', 'Basculin-White-Striped', 'Cutiefly', 'Dunsparce', 'Flittle', 'Gastly', 'Girafarig', 'Gligar', 'Meditite', 'Misdreavus', 'Murkrow', 'Qwilfish-Hisui', 'Rufflet', 'Scyther', 'Sneasel', 'Sneasel-Hisui', 'Stantler', 'Yanma', 'Moody', 'Baton Pass', 'Damp Rock', 'Focus Band', 'Heat Rock', 'Icy Rock', 'Quick Claw'],
+		ruleset: ['[Gen 9] LC', 'Same Type Clause', 'Terastal Clause'],
+		banlist: ['Damp Rock', 'Focus Band', 'Heat Rock', 'Icy Rock', 'Quick Claw'],
 		unbanlist: ['Diglett', 'Growlithe-Hisui', 'Vulpix', 'Vulpix-Alola'],
 	},
 


### PR DESCRIPTION
Added base LC bans on top of Mono LC specific bans, since LC rule just sets levels to 5 without adding the LC banlist