### PR TITLE
Gen 1 Challenge Cup: Fix pokemon getting the same move twice

### DIFF
--- a/data/mods/gen1/random-teams.ts
+++ b/data/mods/gen1/random-teams.ts
@@ -82,12 +82,12 @@ export class RandomGen1Teams extends RandomGen2Teams {
 
 			// Four random unique moves from movepool. don't worry about "attacking" or "viable".
 			// Since Gens 1 and 2 learnsets are shared, we need to weed out Gen 2 moves.
-			const pool: string[] = [];
+			const pool = new Set<string>();
 			if (learnset) {
 				for (const move in learnset) {
 					if (this.dex.moves.get(move).gen !== 1) continue;
 					if (learnset[move].some(learned => learned.startsWith('1'))) {
-						pool.push(move);
+						pool.add(move);
 					}
 				}
 			}
@@ -98,17 +98,15 @@ export class RandomGen1Teams extends RandomGen2Teams {
 				for (const move in learnset) {
 					if (this.dex.moves.get(move).gen !== 1) continue;
 					if (learnset[move].some(learned => learned.startsWith('1'))) {
-						pool.push(move);
+						pool.add(move);
 					}
 				}
 			}
-			// Remove duplicates from the pool that were added by pre-evos' movesets
-			const deduplicatedPool: string[] = [...new Set(pool)];
 
 			team.push({
 				name: species.baseSpecies,
 				species: species.name,
-				moves: this.multipleSamplesNoReplace(deduplicatedPool, 4),
+				moves: this.multipleSamplesNoReplace(Array.from(pool), 4),
 				gender: false,
 				ability: 'No Ability',
 				evs: evs,

--- a/data/mods/gen1/random-teams.ts
+++ b/data/mods/gen1/random-teams.ts
@@ -102,11 +102,13 @@ export class RandomGen1Teams extends RandomGen2Teams {
 					}
 				}
 			}
-
+			// Remove duplicates from the pool that were added by pre-evos' movesets
+			const deduplicatedPool: string[] = [... new Set(pool)];
+			
 			team.push({
 				name: species.baseSpecies,
 				species: species.name,
-				moves: this.multipleSamplesNoReplace(pool, 4),
+				moves: this.multipleSamplesNoReplace(deduplicatedPool, 4),
 				gender: false,
 				ability: 'No Ability',
 				evs: evs,

--- a/data/mods/gen1/random-teams.ts
+++ b/data/mods/gen1/random-teams.ts
@@ -103,8 +103,8 @@ export class RandomGen1Teams extends RandomGen2Teams {
 				}
 			}
 			// Remove duplicates from the pool that were added by pre-evos' movesets
-			const deduplicatedPool: string[] = [... new Set(pool)];
-			
+			const deduplicatedPool: string[] = [...new Set(pool)];
+
 			team.push({
 				name: species.baseSpecies,
 				species: species.name,


### PR DESCRIPTION
After the addition of pre-evo movesets the movepool was not deduplicated leading to double moves (and an uneven weighting of moves though that's harder to notice and thus got no complaints).

This fix deduplicates after making the complete pool instead of checking whether each added move is a duplicate before adding it because that's a lot faster.