### PR TITLE
Randomized format set updates

### DIFF
--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -433,7 +433,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "painsplit", "shadowball", "sludgewave", "substitute", "trick", "willowisp"]
+                "movepool": ["focusblast", "painsplit", "shadowball", "sludgewave", "substitute", "trick", "willowisp"],
+                "preferredTypes": ["Fighting"]
             }
         ]
     },
@@ -2813,7 +2814,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["crosschop", "earthquake", "flamethrower", "icepunch", "voltswitch", "wildcharge"]
+                "movepool": ["crosschop", "earthquake", "flamethrower", "icepunch", "voltswitch", "wildcharge"],
+                "preferredTypes": ["Ice"]
             }
         ]
     },

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -775,8 +775,13 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			) ? 'Life Orb' : 'Leftovers';
 		}
 		// noStab moves that should reject Expert Belt
-		const noExpertBeltMoves = this.noStab.filter(moveid => ['Dragon', 'Normal', 'Poison'].includes(this.dex.moves.get(moveid).type));
-		const expertBeltReqs = !counter.get('Dragon') && !counter.get('Normal') && !counter.get('Poison') && noExpertBeltMoves.every(m => !moves.has(m));
+		const noExpertBeltMoves = (
+			this.noStab.filter(moveid => ['Dragon', 'Normal', 'Poison'].includes(this.dex.moves.get(moveid).type))
+		);
+		const expertBeltReqs = (
+			!counter.get('Dragon') && !counter.get('Normal') && !counter.get('Poison') &&
+			noExpertBeltMoves.every(m => !moves.has(m))
+		);
 		if (
 			!counter.get('Status') && expertBeltReqs &&
 			(moves.has('uturn') || moves.has('voltswitch') || role === 'Fast Attacker')

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -775,8 +775,8 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			) ? 'Life Orb' : 'Leftovers';
 		}
 		// noStab moves that should reject Expert Belt
-		const noExpertBeltMoves = this.noStab.filter(moveid => ['Dragon', 'Normal'].includes(this.dex.moves.get(moveid).type));
-		const expertBeltReqs = !counter.get('Dragon') && !counter.get('Normal') && noExpertBeltMoves.every(m => !moves.has(m));
+		const noExpertBeltMoves = this.noStab.filter(moveid => ['Dragon', 'Normal', 'Poison'].includes(this.dex.moves.get(moveid).type));
+		const expertBeltReqs = !counter.get('Dragon') && !counter.get('Normal') && !counter.get('Poison') && noExpertBeltMoves.every(m => !moves.has(m));
 		if (
 			!counter.get('Status') && expertBeltReqs &&
 			(moves.has('uturn') || moves.has('voltswitch') || role === 'Fast Attacker')

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -3178,7 +3178,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["crosschop", "earthquake", "flamethrower", "icepunch", "voltswitch", "wildcharge"]
+                "movepool": ["crosschop", "earthquake", "flamethrower", "icepunch", "voltswitch", "wildcharge"],
+                "preferredTypes": ["Ice"]
             }
         ]
     },

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -651,6 +651,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';
 		if (['dusknoir', 'vespiquen', 'wailord'].includes(species.id)) return 'Pressure';
 		if (species.id === 'druddigon' && role === 'Bulky Support') return 'Rough Skin';
+		if (species.id === 'pangoro' && !counter.get('ironfist')) return 'Scrappy';
 		if (species.id === 'stunfisk') return 'Static';
 		if (species.id === 'breloom') return 'Technician';
 		if (species.id === 'zangoose') return 'Toxic Boost';

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -3387,7 +3387,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["crosschop", "earthquake", "flamethrower", "icepunch", "voltswitch", "wildcharge"]
+                "movepool": ["crosschop", "earthquake", "flamethrower", "icepunch", "voltswitch", "wildcharge"],
+                "preferredTypes": ["Ice"]
             }
         ]
     },

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -847,6 +847,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		)) return 'Guts';
 
 		if (species.id === 'starmie') return role === 'Wallbreaker' ? 'Analytic' : 'Natural Cure';
+		if (species.id === 'drampa' && moves.has('roost')) return 'Berserk';
 		if (species.id === 'ninetales') return 'Drought';
 		if (species.id === 'talonflame' && role === 'Z-Move user') return 'Gale Wings';
 		if (species.id === 'golemalola' && moves.has('return')) return 'Galvanize';
@@ -862,6 +863,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		) return 'Pressure';
 		if (species.id === 'tsareena') return 'Queenly Majesty';
 		if (species.id === 'druddigon' && role === 'Bulky Support') return 'Rough Skin';
+		if (species.id === 'pangoro' && !counter.get('ironfist')) return 'Scrappy';
 		if (species.id === 'kommoo' && role === 'Z-Move user') return 'Soundproof';
 		if (species.id === 'stunfisk') return 'Static';
 		if (species.id === 'breloom') return 'Technician';

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -244,8 +244,13 @@
         "sets": [
             {
                 "role": "Choice Item user",
-                "movepool": ["Close Combat", "Extreme Speed", "Flare Blitz", "Head Smash", "Wild Charge"],
+                "movepool": ["Extreme Speed", "Flare Blitz", "Rock Slide", "Stone Edge"],
                 "teraTypes": ["Fire", "Normal", "Rock"]
+            },
+            {
+                "role": "Bulky Protect",
+                "movepool": ["Flare Blitz", "Morning Sun", "Protect", "Rock Slide", "Will-O-Wisp"],
+                "teraTypes": ["Fire", "Grass", "Rock"]
             }
         ]
     },
@@ -2864,7 +2869,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Setup",
-                "movepool": ["Body Press", "Iron Defense", "Moonblast", "Stealth Rock"],
+                "movepool": ["Body Press", "Iron Defense", "Moonblast", "Trick Room"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4366,11 +4371,6 @@
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Hyper Voice", "Nasty Plot", "Protect", "Psychic", "Psyshock", "Trick Room"],
                 "teraTypes": ["Fairy"]
-            },
-            {
-                "role": "Tera Blast user",
-                "movepool": ["Nasty Plot", "Psychic", "Psyshock", "Tera Blast", "Trick Room"],
-                "teraTypes": ["Fairy"]
             }
         ]
     },
@@ -4397,6 +4397,11 @@
     "kingambit": {
         "level": 78,
         "sets": [
+            {
+                "role": "Doubles Bulky Setup",
+                "movepool": ["Iron Head", "Protect", "Sucker Punch", "Swords Dance"],
+                "teraTypes": ["Dark", "Fire", "Flying"]
+            },
             {
                 "role": "Bulky Protect",
                 "movepool": ["Iron Head", "Kowtow Cleave", "Protect", "Sucker Punch"],

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -430,7 +430,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Explosion", "Foul Play", "Taunt", "Thunder Wave", "Thunderbolt", "Volt Switch"],
-                "teraTypes": ["Electric", "Dark"]
+                "teraTypes": ["Dark", "Electric"]
             },
             {
                 "role": "Tera Blast user",

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -46,6 +46,11 @@
                 "role": "Fast Support",
                 "movepool": ["Encore", "Focus Blast", "Grass Knot", "Nasty Plot", "Nuzzle", "Surf", "Thunderbolt", "Volt Switch"],
                 "teraTypes": ["Grass", "Water"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Encore", "Focus Blast", "Nasty Plot", "Surf", "Tera Blast", "Thunderbolt"],
+                "teraTypes": ["Ice"]
             }
         ]
     },
@@ -134,7 +139,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Dazzling Gleam", "Fire Blast", "Light Screen", "Protect", "Reflect", "Stealth Rock", "Thunder Wave", "Wish"],
+                "movepool": ["Dazzling Gleam", "Fire Blast", "Knock Off", "Protect", "Stealth Rock", "Thunder Wave", "Wish"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -193,9 +198,14 @@
         "level": 90,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Fast Bulky Setup",
                 "movepool": ["Encore", "Grass Knot", "Hydro Pump", "Ice Beam", "Nasty Plot", "Psyshock"],
                 "teraTypes": ["Water"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Flip Turn", "Grass Knot", "Hydro Pump", "Ice Beam", "Nasty Plot"],
+                "teraTypes": ["Grass", "Water"]
             }
         ]
     },
@@ -349,12 +359,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Drain Punch", "Gunk Shot", "Haze", "Ice Punch", "Knock Off", "Shadow Sneak", "Toxic", "Toxic Spikes"],
+                "movepool": ["Drain Punch", "Gunk Shot", "Haze", "Ice Punch", "Knock Off", "Poison Jab", "Shadow Sneak", "Toxic", "Toxic Spikes"],
                 "teraTypes": ["Dark"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["Drain Punch", "Gunk Shot", "Ice Punch", "Knock Off", "Shadow Sneak"],
+                "movepool": ["Drain Punch", "Gunk Shot", "Ice Punch", "Knock Off", "Poison Jab", "Shadow Sneak"],
                 "teraTypes": ["Dark"]
             }
         ]
@@ -404,7 +414,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Encore", "Knock Off", "Light Screen", "Psychic", "Reflect", "Thunder Wave", "Toxic"],
+                "movepool": ["Encore", "Knock Off", "Psychic", "Thunder Wave", "Toxic"],
                 "teraTypes": ["Dark", "Steel"]
             },
             {
@@ -420,7 +430,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Explosion", "Foul Play", "Taunt", "Thunder Wave", "Thunderbolt", "Volt Switch"],
-                "teraTypes": ["Electric"]
+                "teraTypes": ["Electric", "Dark"]
             },
             {
                 "role": "Tera Blast user",
@@ -683,6 +693,11 @@
                 "teraTypes": ["Normal"]
             },
             {
+                "role": "Bulky Setup",
+                "movepool": ["Dragon Dance", "Earthquake", "Iron Head", "Outrage"],
+                "teraTypes": ["Steel"]
+            },
+            {
                 "role": "Tera Blast user",
                 "movepool": ["Dragon Dance", "Earthquake", "Outrage", "Tera Blast"],
                 "teraTypes": ["Flying"]
@@ -693,9 +708,14 @@
         "level": 72,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Setup Sweeper",
                 "movepool": ["Aura Sphere", "Dark Pulse", "Fire Blast", "Nasty Plot", "Psystrike", "Recover"],
                 "teraTypes": ["Dark", "Fighting", "Fire", "Psychic"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Aura Sphere", "Dark Pulse", "Focus Blast", "Psystrike", "Recover"],
+                "teraTypes": ["Dark", "Fighting", "Psychic"]
             }
         ]
     },
@@ -846,6 +866,11 @@
                 "role": "Wallbreaker",
                 "movepool": ["Dazzling Gleam", "Earth Power", "Leaf Storm", "Sludge Bomb"],
                 "teraTypes": ["Fairy", "Grass", "Ground", "Poison"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Earth Power", "Solar Beam", "Sunny Day", "Weather Ball"],
+                "teraTypes": ["Fire"]
             }
         ]
     },
@@ -936,6 +961,11 @@
                 "role": "Bulky Setup",
                 "movepool": ["Dazzling Gleam", "Nasty Plot", "Psychic", "Psyshock", "Shadow Ball", "Thunderbolt"],
                 "teraTypes": ["Electric", "Fairy", "Psychic"]
+            },
+            {
+                "role": "Fast Bulky Setup",
+                "movepool": ["Hyper Voice", "Nasty Plot", "Psyshock", "Thunderbolt"],
+                "teraTypes": ["Electric", "Normal"]
             }
         ]
     },
@@ -1230,7 +1260,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Slam", "Bulk Up", "Earthquake", "Knock Off", "Slack Off"],
-                "teraTypes": ["Ghost", "Ground", "Poison"]
+                "teraTypes": ["Ghost", "Ground"]
             }
         ]
     },
@@ -1313,9 +1343,14 @@
         "level": 90,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["Clear Smog", "Earthquake", "Encore", "Ice Beam", "Knock Off", "Pain Split", "Protect", "Sludge Bomb", "Toxic", "Toxic Spikes"],
+                "role": "Bulky Attacker",
+                "movepool": ["Clear Smog", "Earthquake", "Encore", "Ice Beam", "Knock Off", "Pain Split", "Sludge Bomb", "Toxic Spikes"],
                 "teraTypes": ["Dark"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Earthquake", "Protect", "Sludge Bomb", "Toxic"],
+                "teraTypes": ["Ground"]
             },
             {
                 "role": "Bulky Setup",
@@ -1769,8 +1804,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Hypnosis", "Iron Head", "Light Screen", "Psychic", "Reflect", "Stealth Rock"],
+                "movepool": ["Earthquake", "Hypnosis", "Iron Head", "Psychic", "Stealth Rock"],
                 "teraTypes": ["Electric", "Water"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Press", "Iron Defense", "Iron Head", "Psychic", "Rest"],
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -1869,7 +1909,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Ice Shard", "Ice Spinner", "Knock Off", "Low Kick", "Swords Dance"],
+                "movepool": ["Ice Shard", "Icicle Crash", "Knock Off", "Low Kick", "Swords Dance"],
                 "teraTypes": ["Dark", "Fighting", "Ice"]
             }
         ]
@@ -2449,7 +2489,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Earthquake", "Flare Blitz", "Gunk Shot", "Liquidation", "Recover", "Swords Dance"],
+                "movepool": ["Dragon Dance", "Earthquake", "Flare Blitz", "Gunk Shot", "Liquidation", "Recover", "Swords Dance"],
                 "teraTypes": ["Fire", "Ground", "Water"]
             }
         ]
@@ -2969,7 +3009,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Body Press", "Knock Off", "Leech Seed", "Spikes", "Synthesis", "Wood Hammer"],
+                "movepool": ["Body Press", "Knock Off", "Spikes", "Synthesis", "Wood Hammer"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
@@ -3129,7 +3169,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Body Press", "Light Screen", "Moonblast", "Power Gem", "Reflect", "Spikes", "Stealth Rock"],
+                "movepool": ["Body Press", "Moonblast", "Power Gem", "Spikes", "Stealth Rock"],
                 "teraTypes": ["Fighting"]
             },
             {
@@ -4428,7 +4468,7 @@
         "level": 83,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Hurricane", "Roost", "Thunder Wave", "Thunderbolt", "U-turn"],
                 "teraTypes": ["Electric", "Flying"]
             }
@@ -4679,7 +4719,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Belly Drum", "Earthquake", "Ice Shard", "Icicle Crash"],
+                "movepool": ["Belly Drum", "Earthquake", "Ice Shard", "Ice Spinner"],
                 "teraTypes": ["Ice"]
             }
         ]
@@ -5034,7 +5074,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Crunch", "Ice Shard", "Ice Spinner", "Sacred Sword", "Sucker Punch", "Swords Dance"],
+                "movepool": ["Crunch", "Ice Shard", "Icicle Crash", "Sacred Sword", "Sucker Punch", "Swords Dance"],
                 "teraTypes": ["Dark", "Fighting", "Ice"]
             }
         ]

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1120,7 +1120,7 @@ export class RandomTeams {
 		if (abilityData.length <= 1) return abilityData[0].name;
 
 		// Hard-code abilities here
-		if (species.id === 'arcaninehisui') return 'Rock Head';
+		if (species.id === 'florges') return 'Flower Veil';
 		if (species.id === 'scovillain') return 'Chlorophyll';
 		if (species.id === 'empoleon') return 'Competitive';
 		if (species.id === 'chandelure') return 'Flash Fire';
@@ -1138,6 +1138,7 @@ export class RandomTeams {
 		if (!isDoubles) {
 			if (species.id === 'hypno') return 'Insomnia';
 			if (species.id === 'staraptor') return 'Reckless';
+			if (species.id === 'arcaninehisui') return 'Rock Head';
 			if (species.id === 'vespiquen') return 'Pressure';
 			if (species.id === 'enamorus' && moves.has('calmmind')) return 'Cute Charm';
 			if (species.id === 'klawf' && role === 'Setup Sweeper') return 'Anger Shell';
@@ -1176,7 +1177,6 @@ export class RandomTeams {
 
 			// just doubles and multi
 			if (this.format.gameType !== 'freeforall') {
-				if (species.id === 'florges') return 'Flower Veil';
 				if (
 					species.id === 'clefairy' ||
 					(species.baseSpecies === 'Maushold' && role === 'Doubles Support')


### PR DESCRIPTION
Probably last update until DLC2. Will contain level balancing at some point in the next 24 hours. Please merge and patch as close to month-turnover as possible.

Changes marked with (_*_) reduce the rate of choice items.

**Gen 9 Random Battle:**
-Swalot's sets have been adjusted: alongside the Swords Dance set, it now has a set that's Toxic + Protect + EQ + Sludge Bomb with Tera Ground, and a Bulky Attacker set that's Sludge Bomb + Knock Off + any 2 other moves that Swalot's old support set used to get except Toxic or Protect, with Tera Dark. ...It makes more sense if you see it.
-Golduck's sets have been adjusted: its old set's role was changed to Fast Bulky Setup to enforce Nasty Plot and allow Leftovers on Encore + Nasty Plot + 2 attacks, and it has gained a new Fast Attacker set that's Grass Knot + Hydro Pump + Ice Beam + Flip Turn or Nasty Plot with Tera Grass or Water. This second set will either get Life Orb or Choice Specs depending on its fourth move.
-Mewtwo's sets have been adjusted: its old set's role was changed to Setup Sweeper to enforce Nasty Plot, and it has gained a new Fast Attacker set that's Psystrike + Dark Pulse + Recover + Aura Sphere or Focus Blast with a Life Orb. Yes, this means Specs Mewtwo is gone. (_*_)
-Bronzong's sets have been adjusted: its old set no longer has dual screens, and it now has a Bulky Setup set with Iron Defense + Body Press + any two of Iron Head, Psychic, and Rest. Leftovers with 3 attacks, Chesto with Rest.
-Dragonite has a new Tera Steel Iron Head Dragon Dance set. (_*_)
-Girafarig has a new Hyper Voice Nasty Plot set with Tera Normal/Electric.
-Raichu has a new Tera Blast Ice Nasty Plot set. (_*_)
-We're trying Sunny Day Sunflora one more time, but this time with Solarbeam and Earth Power instead of Energy Ball and Sludge Bomb. It's probably not going to work, but it's not like Sunflora really has anything to lose by trying. We'll revert if it's bad. (_*_)

-Florges is now Flower Veil even in Singles, as a nice bonus to all the Mayhem players out there.
-Kilowattrel is now Bulky Attacker instead of Fast Support; functionally, this means it now always gets Roost.

-Dual Screens has been removed from everything except Grimmsnarl and Uxie. This means it's gone from Bronzong, Hypno, Wigglytuff, and Carbink. No strong reason other than that screens isn't really that good on most of these mons and cutting them down as much as we can means fewer complaints about having multiple screens setters on a team.
-Wigglytuff: +Knock Off
-Chesnaught: -Leech Seed
-Muk (both sets): +Poison Jab
-Arceus-Poison: +Dragon Dance (all other physical Arceus sets have Extreme Speed)
-Weavile and Chien-Pao: -Ice Spinner, +Icicle Crash
-Belly Drum Cetitan: -Icicle Crash, +Ice Spinner
-Fast Support Electrode: +Tera Dark
-Vigoroth: -Tera Poison (after a long time, we've ultimately deduced that its winrate lowered after we added Tera Poison to it)


**Gen 9 Random Doubles:**
-Hisuian Arcanine is now always Intimidate. It has one Choice Band set with Rock Slide, Flare Blitz, Stone Edge, and Extreme Speed, and one Sitrus Berry Bulky Protect set with Protect, Flare Blitz, Rock Slide, and one of Will-O-Wisp and Morning Sun.
-Tera Blast Farigiraf was removed.
-Kingambit now has a Swords Dance set with Protect, Iron Head, and Sucker Punch.

**Old Gens**
-In gens 5, 6, and 7, Electrode now always gets Ice Punch.
-In Gens 6 and 7, Pangoro now always gets Scrappy if it does not have any punching moves.
-In Gen 5, Pokemon with Poison-type moves now cannot generate Expert Belt.
-In Gen 5, Gengar now always gets Focus Blast.