### PR TITLE
Sharing is Caring: Fix Mechanics and Booster Energy

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1764,7 +1764,7 @@ export const Formats: FormatList = [
 		getSharedItems(pokemon) {
 			const items = new Set<string>();
 			for (const ally of pokemon.side.pokemon) {
-				if (!ally.item) continue;
+				if (!ally.item || ally.fainted) continue;
 				items.add(ally.item);
 			}
 			items.delete(pokemon.item);

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -3305,7 +3305,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		condition: {
 			noCopy: true,
 			onStart(pokemon, source, effect) {
-				if (effect?.id === 'boosterenergy') {
+				if (effect?.name === 'Booster Energy') {
 					this.effectState.fromBooster = true;
 					this.add('-activate', pokemon, 'ability: Protosynthesis', '[fromitem]');
 				} else {
@@ -3439,7 +3439,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		condition: {
 			noCopy: true,
 			onStart(pokemon, source, effect) {
-				if (effect?.id === 'boosterenergy') {
+				if (effect?.name === 'Booster Energy') {
 					this.effectState.fromBooster = true;
 					this.add('-activate', pokemon, 'ability: Quark Drive', '[fromitem]');
 				} else {


### PR DESCRIPTION
Does the following:

> 6. Fainting a Pokemon removes an item from play

- This mechanic is now honored, which was mistakenly left out.

- Fixes a bug where a shared Booster Energy was not being properly registered as an item boost, which causes any weather/terrain change for a mon to lose its booster energy. 

