### PR TITLE
Fix some HTML escaping in best-of rooms

### DIFF
--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1434,7 +1434,7 @@ export class BestOfGame extends RoomGames.RoomGame {
 		).update();
 		this.updateDisplay();
 		this.room.add(`|html|<h2>Game ${this.games.length}</h2>`);
-		this.room.add(`|html|<a href="/${battle.roomid}">${battle.title}</a>`);
+		this.room.add(Utils.html`|html|<a href="/${battle.roomid}">${battle.title}</a>`);
 		this.room.update();
 	}
 	updateDisplay() {
@@ -1554,7 +1554,7 @@ export class BestOfGame extends RoomGames.RoomGame {
 		this.games[this.games.length - 1].winner = isTie ? '' : winnerid;
 
 		this.room.add(
-			`|html|${winnerid ? `${this.name(winnerid)} won game ${this.games.length}!` : `Game ${this.games.length} was a tie`}`
+			Utils.html`|html|${winnerid ? `${this.name(winnerid)} won game ${this.games.length}!` : `Game ${this.games.length} was a tie`}`
 		).update();
 		for (const k in this.wins) {
 			if (this.wins[k as 'p1' | 'p2'] >= this.winThreshold) {
@@ -1571,9 +1571,8 @@ export class BestOfGame extends RoomGames.RoomGame {
 		for (const userid in room.battle.playerTable) {
 			const player = room.battle.playerTable[userid];
 			player.id = userid as ID; // re-link users so that we can use timer properly
-			const name = Utils.escapeHTML(this.name(userid));
 			const button = `|c|&|/uhtml prompt-${userid},<button class="button notifying" name="send" value="${cmd}">I'm ready!</button>`;
-			const prompt = `|c|&|/log Are you ready for game ${this.games.length + 1}, ${name}?`;
+			const prompt = `|c|&|/log Are you ready for game ${this.games.length + 1}, ${this.name(userid)}?`;
 			player.sendRoom(prompt);
 			player.sendRoom(button);
 			// send it to the main room as well, in case they x out of the old one


### PR DESCRIPTION
This fixes a very minor issue where usernames with a ``<`` character would cause some areas to be interpreted as HTML (the "won game x" text and the link to the specific game). I didn't take a screenshot, but also fixes the prompt where the player is asked if they're ready for the next game from being double escaped.

<details>
<summary>Before</summary>
<img src="https://github.com/smogon/pokemon-showdown/assets/23667022/b24a4802-f154-4b06-81d3-66a664a0a12e">
</details>

<details>
<summary>After</summary>
<img src="https://github.com/smogon/pokemon-showdown/assets/23667022/6f22bc94-3805-4445-ba98-911ee3a707ab">
</details>