### PR TITLE
Challenge Cup: Allow newer Pokemon to generate

### DIFF
--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -2047,9 +2047,7 @@ export class RandomTeams {
 		// Picks `n` random pokemon--no repeats, even among formes
 		// Also need to either normalize for formes or select formes at random
 		// Unreleased are okay but no CAP
-		const last = [0, 151, 251, 386, 493, 649, 721, 807, 898, 1010][this.gen];
-
-		if (n <= 0 || n > last) throw new Error(`n must be a number between 1 and ${last} (got ${n})`);
+		
 		if (requiredType && !this.dex.types.get(requiredType).exists) {
 			throw new Error(`"${requiredType}" is not a valid type.`);
 		}
@@ -2071,7 +2069,6 @@ export class RandomTeams {
 				if (minSourceGen && species.gen < minSourceGen) continue;
 				const num = species.num;
 				if (num <= 0 || pool.includes(num)) continue;
-				if (num > last) break;
 				pool.push(num);
 			}
 		} else {


### PR DESCRIPTION
Newer mons (such as Fezandipiti) could not be generated in challenge cup. Turns out that was because the species pool generation was capped at a hardcoded maximum dexnumber that was never updated.

The removed error at the start is unneeded because it throws an error at the end anyway if it can't find N Pokemon.
The removed break at the end is also unneeded, as its only purpose is to disallow mons above the cap, but they should already be disallowed by another rule (such as isNonstandard). Furthermore, it's not used at all with custom rulesets.