### PR TITLE
Refactor learnset checking

### DIFF
--- a/data/cg-teams.ts
+++ b/data/cg-teams.ts
@@ -179,7 +179,7 @@ export default class TeamGenerator {
 				pairedMove &&
 				!alreadyHavePairedMove &&
 				// We don't check movePool because sometimes paired moves are bad.
-				this.dex.species.getLearnset(species.id)?.[pairedMove]
+				this.dex.species.getLearnsetData(species.id).learnset?.[pairedMove]
 			) {
 				moves.push(this.dex.moves.get(pairedMove));
 				movePool.splice(movePool.indexOf(pairedMove), 1);

--- a/data/cg-teams.ts
+++ b/data/cg-teams.ts
@@ -140,37 +140,7 @@ export default class TeamGenerator {
 
 		const moves: Move[] = [];
 
-		let learnset = this.dex.species.getLearnset(species.id);
-		let movePool: string[] = [];
-		let learnsetSpecies = species;
-		if (!learnset || species.id === 'gastrodoneast') {
-			learnsetSpecies = this.dex.species.get(species.baseSpecies);
-			learnset = this.dex.species.getLearnset(learnsetSpecies.id);
-		}
-		if (learnset) {
-			movePool = Object.keys(learnset).filter(
-				moveid => learnset![moveid].find(learned => learned.startsWith('9'))
-			);
-		}
-		if (learnset && learnsetSpecies === species && species.changesFrom) {
-			const changesFrom = this.dex.species.get(species.changesFrom);
-			learnset = this.dex.species.getLearnset(changesFrom.id);
-			for (const moveid in learnset) {
-				if (!movePool.includes(moveid) && learnset[moveid].some(source => source.startsWith('9'))) {
-					movePool.push(moveid);
-				}
-			}
-		}
-		const evoRegion = learnsetSpecies.evoRegion;
-		while (learnsetSpecies.prevo) {
-			learnsetSpecies = this.dex.species.get(learnsetSpecies.prevo);
-			for (const moveid in learnset) {
-				if (!movePool.includes(moveid) &&
-					learnset[moveid].some(source => source.startsWith('9') && !evoRegion)) {
-					movePool.push(moveid);
-				}
-			}
-		}
+		let movePool: string[] = [...this.dex.species.getMovePool(species.id)];
 		if (!movePool.length) throw new Error(`No moves for ${species.id}`);
 
 		// Consider either the top 15 moves or top 30% of moves, whichever is greater.

--- a/data/mods/gen1/random-teams.ts
+++ b/data/mods/gen1/random-teams.ts
@@ -27,7 +27,6 @@ export class RandomGen1Teams extends RandomGen2Teams {
 
 		for (const pokemon of randomN) {
 			const species = this.dex.species.get(pokemon);
-			let learnset = this.dex.species.getLearnset(species.id);
 
 			// Level balance: calculate directly from stats rather than using some silly lookup table.
 			const mbstmin = 1307;
@@ -82,31 +81,12 @@ export class RandomGen1Teams extends RandomGen2Teams {
 
 			// Four random unique moves from movepool. don't worry about "attacking" or "viable".
 			// Since Gens 1 and 2 learnsets are shared, we need to weed out Gen 2 moves.
-			const pool = new Set<string>();
-			if (learnset) {
-				for (const move in learnset) {
-					if (this.dex.moves.get(move).gen !== 1) continue;
-					if (learnset[move].some(learned => learned.startsWith('1'))) {
-						pool.add(move);
-					}
-				}
-			}
-			let learnsetSpecies = species;
-			for (let i = 0; i < 2 && learnsetSpecies.prevo; i++) {
-				learnsetSpecies = this.dex.species.get(learnsetSpecies.prevo);
-				learnset = this.dex.species.getLearnset(learnsetSpecies.id);
-				for (const move in learnset) {
-					if (this.dex.moves.get(move).gen !== 1) continue;
-					if (learnset[move].some(learned => learned.startsWith('1'))) {
-						pool.add(move);
-					}
-				}
-			}
+			const pool = [...this.dex.species.getMovePool(species.id)];
 
 			team.push({
 				name: species.baseSpecies,
 				species: species.name,
-				moves: this.multipleSamplesNoReplace(Array.from(pool), 4),
+				moves: this.multipleSamplesNoReplace(pool, 4),
 				gender: false,
 				ability: 'No Ability',
 				evs: evs,

--- a/data/mods/gen2/random-teams.ts
+++ b/data/mods/gen2/random-teams.ts
@@ -148,7 +148,7 @@ export class RandomGen2Teams extends RandomGen3Teams {
 		species = this.dex.species.get(species);
 
 		const data = this.randomData[species.id];
-		const movePool = (data.moves || Object.keys(this.dex.species.getLearnset(species.id)!)).slice();
+		const movePool: string[] = [...(data.moves || this.dex.species.getMovePool(species.id))];
 		const rejectedPool: string[] = [];
 		const moves = new Set<string>();
 

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -397,7 +397,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 
 		if (typeof species.battleOnly === 'string') forme = species.battleOnly;
 
-		const movePool = (data.moves || Object.keys(this.dex.species.getLearnset(species.id)!)).slice();
+		const movePool: string[] = [...(data.moves || this.dex.species.getMovePool(species.id))];
 		const rejectedPool = [];
 		const moves = new Set<string>();
 		let ability = '';

--- a/data/mods/gen7/random-doubles-teams.ts
+++ b/data/mods/gen7/random-doubles-teams.ts
@@ -998,8 +998,7 @@ export class RandomGen7DoublesTeams extends RandomGen8Teams {
 
 		const data = this.randomDoublesData[species.id];
 
-		const randMoves = data.moves;
-		const movePool = (randMoves || Object.keys(Dex.species.getLearnset(species.id)!)).slice();
+		const movePool: string[] = [...(data.moves || this.dex.species.getMovePool(species.id))];
 		if (this.format.gameType === 'multi') {
 			// Random Multi Battle uses doubles move pools, but Ally Switch fails in multi battles
 			const allySwitch = movePool.indexOf('allyswitch');

--- a/data/mods/gen7letsgo/random-teams.ts
+++ b/data/mods/gen7letsgo/random-teams.ts
@@ -127,7 +127,7 @@ export class RandomLetsGoTeams extends RandomGen8Teams {
 
 		const data = this.randomData[species.id];
 
-		const movePool = (data.moves || Object.keys(this.dex.species.getLearnset(species.id)!)).slice();
+		const movePool: string[] = [...(data.moves || this.dex.species.getMovePool(species.id))];
 		const types = new Set(species.types);
 
 		const moves = new Set<string>();

--- a/data/mods/mixandmega/random-teams.ts
+++ b/data/mods/mixandmega/random-teams.ts
@@ -52,43 +52,11 @@ export class RandomMnMTeams extends RandomTeams {
 			// Four random unique moves from the movepool
 			let pool = ['struggle'];
 			if (forme === 'Smeargle') {
-				pool = this.dex.moves
-					.all()
+				pool = this.dex.moves.all()
 					.filter(move => !(move.isNonstandard || move.isZ || move.isMax || move.realMove))
 					.map(m => m.id);
 			} else {
-				const formes = ['gastrodoneast', 'pumpkaboosuper', 'zygarde10'];
-				let learnset = this.dex.species.getLearnset(species.id);
-				let learnsetSpecies = species;
-				if (formes.includes(species.id) || !learnset) {
-					learnsetSpecies = this.dex.species.get(species.baseSpecies);
-					learnset = this.dex.species.getLearnset(learnsetSpecies.id);
-				}
-				if (learnset) {
-					pool = Object.keys(learnset).filter(
-						moveid => learnset![moveid].find(learned => learned.startsWith(String(this.gen)))
-					);
-				}
-				if (learnset && learnsetSpecies === species && species.changesFrom) {
-					learnset = this.dex.species.getLearnset(toID(species.changesFrom));
-					for (const moveid in learnset) {
-						if (!pool.includes(moveid) && learnset[moveid].some(source => source.startsWith(String(this.gen)))) {
-							pool.push(moveid);
-						}
-					}
-				}
-				const evoRegion = learnsetSpecies.evoRegion && learnsetSpecies.gen !== this.gen;
-				for (let i = 0; i < 2 && learnsetSpecies.prevo; i++) {
-					learnsetSpecies = this.dex.species.get(learnsetSpecies.prevo);
-					learnset = this.dex.species.getLearnset(learnsetSpecies.id);
-					for (const moveid in learnset) {
-						if (!pool.includes(moveid) && learnset[moveid].some(
-							source => source.startsWith(String(this.gen)) && (!evoRegion || source.charAt(1) === 'E')
-						)) {
-							pool.push(moveid);
-						}
-					}
-				}
+				pool = [...this.dex.species.getMovePool(species.id)];
 			}
 
 			const moves = this.multipleSamplesNoReplace(pool, this.maxMoveCount);

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1913,43 +1913,11 @@ export class RandomTeams {
 			// Four random unique moves from the movepool
 			let pool = ['struggle'];
 			if (forme === 'Smeargle') {
-				pool = this.dex.moves
-					.all()
+				pool = this.dex.moves.all()
 					.filter(move => !(move.isNonstandard || move.isZ || move.isMax || move.realMove))
 					.map(m => m.id);
 			} else {
-				const formes = ['gastrodoneast', 'pumpkaboosuper', 'zygarde10'];
-				let learnset = this.dex.species.getLearnset(species.id);
-				let learnsetSpecies = species;
-				if (formes.includes(species.id) || !learnset) {
-					learnsetSpecies = this.dex.species.get(species.baseSpecies);
-					learnset = this.dex.species.getLearnset(learnsetSpecies.id);
-				}
-				if (learnset) {
-					pool = Object.keys(learnset).filter(
-						moveid => learnset![moveid].find(learned => learned.startsWith(String(this.gen)))
-					);
-				}
-				if (learnset && learnsetSpecies === species && species.changesFrom) {
-					learnset = this.dex.species.getLearnset(toID(species.changesFrom));
-					for (const moveid in learnset) {
-						if (!pool.includes(moveid) && learnset[moveid].some(source => source.startsWith(String(this.gen)))) {
-							pool.push(moveid);
-						}
-					}
-				}
-				const evoRegion = learnsetSpecies.evoRegion && learnsetSpecies.gen !== this.gen;
-				for (let i = 0; i < 2 && learnsetSpecies.prevo; i++) {
-					learnsetSpecies = this.dex.species.get(learnsetSpecies.prevo);
-					learnset = this.dex.species.getLearnset(learnsetSpecies.id);
-					for (const moveid in learnset) {
-						if (!pool.includes(moveid) && learnset[moveid].some(
-							source => source.startsWith(String(this.gen)) && (!evoRegion || source.charAt(1) === 'E')
-						)) {
-							pool.push(moveid);
-						}
-					}
-				}
+				pool = [...this.dex.species.getMovePool(species.id)];
 			}
 
 			const moves = this.multipleSamplesNoReplace(pool, this.maxMoveCount);
@@ -2063,8 +2031,7 @@ export class RandomTeams {
 			for (const species of speciesPool) {
 				if (species.isNonstandard && species.isNonstandard !== 'Unobtainable') continue;
 				if (requireMoves) {
-					const hasMovesInCurrentGen = Object.values(this.dex.species.getLearnset(species.id) || {})
-						.some(sources => sources.some(source => source.startsWith('9')));
+					const hasMovesInCurrentGen = this.dex.species.getMovePool(species.id).size;
 					if (!hasMovesInCurrentGen) continue;
 				}
 				if (requiredType && !species.types.includes(requiredType)) continue;

--- a/server/chat-commands/admin.ts
+++ b/server/chat-commands/admin.ts
@@ -129,7 +129,7 @@ export const commands: Chat.ChatCommands = {
 			return this.errorReply(`The PotD is already set to ${species.name}`);
 		}
 		if (!species.exists) return this.errorReply(`Pokemon "${target}" not found.`);
-		if (!Dex.species.getLearnset(species.id)) {
+		if (!Dex.species.getFullLearnset(species.id).length) {
 			return this.errorReply(`That Pokemon has no learnset and cannot be used as the PotD.`);
 		}
 		Config.potd = species.id;
@@ -986,7 +986,7 @@ export const commands: Chat.ChatCommands = {
 			Object.entries(Dex.data.Learnsets).map(([id, entry]) => (
 				`\t${id}: {learnset: {\n` +
 				Utils.sortBy(
-					Object.entries(Dex.species.getLearnsetData(id as ID)),
+					Object.entries(Dex.species.getLearnsetData(id as ID).learnset!),
 					([moveid]) => moveid
 				).map(([moveid, sources]) => (
 					`\t\t${moveid}: ["` + sources.join(`", "`) + `"],\n`

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -1780,47 +1780,12 @@ function runMovesearch(target: string, cmd: string, canAll: boolean, message: st
 		};
 	}
 
-	const getFullLearnsetOfPokemon = (species: Species, natDex: boolean) => {
-		let usedSpecies: Species = Utils.deepClone(species);
-		let usedSpeciesLearnset: LearnsetData = Utils.deepClone(mod.species.getLearnset(usedSpecies.id));
-		if (!usedSpeciesLearnset) {
-			usedSpecies = Utils.deepClone(mod.species.get(usedSpecies.baseSpecies));
-			usedSpeciesLearnset = Utils.deepClone(mod.species.getLearnset(usedSpecies.id) || {});
-		}
-		const lsetData = new Set<string>();
-		for (const move in usedSpeciesLearnset) {
-			const learnset = mod.species.getLearnset(usedSpecies.id);
-			if (!learnset) break;
-			const sources = learnset[move];
-			for (const learned of sources) {
-				const sourceGen = parseInt(learned.charAt(0));
-				if (sourceGen <= mod.gen && (mod.gen < 9 || sourceGen >= 9 || natDex)) lsetData.add(move);
-			}
-		}
-
-		while (usedSpecies.prevo) {
-			usedSpecies = Utils.deepClone(mod.species.get(usedSpecies.prevo));
-			usedSpeciesLearnset = Utils.deepClone(mod.species.getLearnset(usedSpecies.id));
-			for (const move in usedSpeciesLearnset) {
-				const learnset = mod.species.getLearnset(usedSpecies.id);
-				if (!learnset) break;
-				const sources = learnset[move];
-				for (const learned of sources) {
-					const sourceGen = parseInt(learned.charAt(0));
-					if (sourceGen <= mod.gen && (mod.gen < 9 || sourceGen === 9 || natDex)) lsetData.add(move);
-				}
-			}
-		}
-
-		return lsetData;
-	};
-
 	// Since we assume we have no target mons at first
 	// then the valid moveset we can search is the set of all moves.
-	const validMoves = new Set(Object.keys(mod.data.Moves));
+	const validMoves = new Set(Object.keys(mod.data.Moves)) as Set<ID>;
 	for (const mon of targetMons) {
 		const species = mod.species.get(mon.name);
-		const lsetData = getFullLearnsetOfPokemon(species, !!nationalSearch);
+		const lsetData = mod.species.getMovePool(species.id, !!nationalSearch);
 		// This pokemon's learnset needs to be excluded, so we perform a difference operation
 		// on the valid moveset and this pokemon's moveset.
 		if (mon.shouldBeExcluded) {

--- a/sim/dex-species.ts
+++ b/sim/dex-species.ts
@@ -330,14 +330,16 @@ export class Learnset {
 	readonly eventData?: EventInfo[];
 	readonly encounters?: EventInfo[];
 	readonly exists: boolean;
+	readonly species: Species;
 
-	constructor(data: AnyObject) {
+	constructor(data: AnyObject, species: Species) {
 		this.exists = true;
 		this.effectType = 'Learnset';
 		this.learnset = data.learnset || undefined;
 		this.eventOnly = !!data.eventOnly;
 		this.eventData = data.eventData || undefined;
 		this.encounters = data.encounters || undefined;
+		this.species = species;
 	}
 }
 
@@ -527,13 +529,111 @@ export class DexSpecies {
 		return this.getLearnsetData(id).learnset;
 	}
 
+	getMovePool(id: ID, isNatDex = false): Set<ID> {
+		let eggMovesOnly = false;
+		let maxGen = this.dex.gen;
+		const movePool = new Set<ID>();
+		for (const {species, learnset} of this.getFullLearnset(id)) {
+			for (const moveid in learnset) {
+				if (eggMovesOnly) {
+					if (learnset[moveid].some(source => source.startsWith('9E'))) {
+						movePool.add(moveid as ID);
+					}
+				} else if (maxGen >= 9) {
+					// Pokemon Home now strips learnsets on withdrawal
+					if (isNatDex || learnset[moveid].some(source => source.startsWith('9'))) {
+						movePool.add(moveid as ID);
+					}
+				} else {
+					if (learnset[moveid].some(source => parseInt(source.charAt(0)) <= maxGen)) {
+						movePool.add(moveid as ID);
+					}
+				}
+				if (species.evoRegion) {
+					// species can only evolve in this gen, so prevo can't have any moves
+					// from after that gen
+					if (this.dex.gen >= 9) eggMovesOnly = true;
+					if (this.dex.gen === 8 && species.evoRegion === 'Alola') maxGen = 7;
+				}
+			}
+		}
+		return movePool;
+	}
+
+	getFullLearnset(id: ID): (Learnset & {learnset: NonNullable<Learnset['learnset']>})[] {
+		const originalSpecies = this.get(id);
+		let species: Species | null = originalSpecies;
+		const out: (Learnset & {learnset: NonNullable<Learnset['learnset']>})[] = [];
+		const alreadyChecked: {[k: string]: boolean} = {};
+
+		while (species?.name && !alreadyChecked[species.id]) {
+			alreadyChecked[species.id] = true;
+			const learnset = this.getLearnsetData(species.id);
+			if (learnset.learnset) {
+				out.push(learnset as any);
+				species = this.learnsetParent(species);
+				continue;
+			}
+
+			// no learnset
+			if ((species.changesFrom || species.baseSpecies) !== species.name) {
+				// forme without its own learnset
+				species = this.get(species.changesFrom || species.baseSpecies);
+				// warning: formes with their own learnset, like Wormadam, should NOT
+				// inherit from their base forme unless they're freely switchable
+				continue;
+			}
+			if (species.isNonstandard) {
+				// It's normal for a nonstandard species not to have learnset data
+
+				// Formats should replace the `Obtainable Moves` rule if they want to
+				// allow pokemon without learnsets.
+				return out;
+			}
+			if (species.prevo && this.getLearnsetData(toID(species.prevo)).learnset) {
+				species = this.get(toID(species.prevo));
+				continue;
+			}
+
+			// should never happen
+			throw new Error(`Species with no learnset data: ${species.id}`);
+		}
+
+		return out;
+	}
+
+	learnsetParent(species: Species) {
+		// Own Tempo Rockruff and Battle Bond Greninja are special event formes
+		// that are visually indistinguishable from their base forme but have
+		// different learnsets. To prevent a leak, we make them show up as their
+		// base forme, but hardcode their learnsets into Rockruff-Dusk and
+		// Greninja-Ash
+		if (['Gastrodon', 'Pumpkaboo', 'Sinistea', 'Tatsugiri'].includes(species.baseSpecies) && species.forme) {
+			return this.get(species.baseSpecies);
+		} else if (species.name === 'Lycanroc-Dusk') {
+			return this.get('Rockruff-Dusk');
+		} else if (species.name === 'Greninja-Bond') {
+			return null;
+		} else if (species.prevo) {
+			// there used to be a check for Hidden Ability here, but apparently it's unnecessary
+			// Shed Skin Pupitar can definitely evolve into Unnerve Tyranitar
+			species = this.get(species.prevo);
+			if (species.gen > Math.max(2, this.dex.gen)) return null;
+			return species;
+		} else if (species.changesFrom && species.baseSpecies !== 'Kyurem') {
+			// For Pokemon like Rotom and Necrozma whose movesets are extensions are their base formes
+			return this.get(species.changesFrom);
+		}
+		return null;
+	}
+
 	getLearnsetData(id: ID): Learnset {
 		let learnsetData = this.learnsetCache.get(id);
 		if (learnsetData) return learnsetData;
 		if (!this.dex.data.Learnsets.hasOwnProperty(id)) {
-			return new Learnset({exists: false});
+			return new Learnset({exists: false}, this.get(id));
 		}
-		learnsetData = new Learnset(this.dex.data.Learnsets[id]);
+		learnsetData = new Learnset(this.dex.data.Learnsets[id], this.get(id));
 		this.learnsetCache.set(id, this.dex.deepFreeze(learnsetData));
 		return learnsetData;
 	}

--- a/sim/dex-species.ts
+++ b/sim/dex-species.ts
@@ -525,10 +525,6 @@ export class DexSpecies {
 		return species;
 	}
 
-	getLearnset(id: ID): Learnset['learnset'] {
-		return this.getLearnsetData(id).learnset;
-	}
-
 	getMovePool(id: ID, isNatDex = false): Set<ID> {
 		let eggMovesOnly = false;
 		let maxGen = this.dex.gen;
@@ -627,6 +623,12 @@ export class DexSpecies {
 		return null;
 	}
 
+	/**
+	 * Gets the raw learnset data for the species.
+	 *
+	 * In practice, if you're trying to figure out what moves a pokemon learns,
+	 * you probably want to `getFullLearnset` or `getMovePool` instead.
+	 */
 	getLearnsetData(id: ID): Learnset {
 		let learnsetData = this.learnsetCache.get(id);
 		if (learnsetData) return learnsetData;

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1428,8 +1428,7 @@ export class TeamValidator {
 	 */
 	fatherCanLearn(baseSpecies: Species, species: Species, moves: ID[], eggGen: number, pokemonBlacklist: ID[],
 		noRecurse: boolean | undefined) {
-		let learnset = this.dex.species.getLearnset(species.id);
-		if (!learnset) return false;
+		if (!this.dex.species.getLearnset(species.id)) return false;
 
 		if (species.id === 'smeargle') return true;
 		const canBreedWithSmeargle = species.eggGroups.includes('Field');
@@ -1437,12 +1436,10 @@ export class TeamValidator {
 		const allEggSources = new PokemonSources();
 		allEggSources.sourcesBefore = eggGen;
 		for (const move of moves) {
-			let curSpecies: Species | null = species;
 			const eggSources = new PokemonSources();
-			while (curSpecies) {
+			for (const {learnset, species: curSpecies} of this.dex.species.getFullLearnset(species.id)) {
 				const eggPokemon = curSpecies.prevo ? curSpecies.id : '';
-				learnset = this.dex.species.getLearnset(curSpecies.id);
-				if (learnset && learnset[move]) {
+				if (learnset[move]) {
 					for (const moveSource of learnset[move]) {
 						if (eggGen > 8 && parseInt(moveSource.charAt(0)) <= 8) continue;
 						if (parseInt(moveSource.charAt(0)) > eggGen) continue;
@@ -1461,7 +1458,6 @@ export class TeamValidator {
 					}
 				}
 				if (eggSources.sourcesBefore === eggGen) break;
-				curSpecies = this.learnsetParent(curSpecies);
 			}
 
 			if (eggSources.sourcesBefore === eggGen) continue;
@@ -2232,7 +2228,7 @@ export class TeamValidator {
 		if (dex.gen < 8 || this.format.mod === 'gen8dlc1') return null;
 		if (!pokemonGoData) {
 			// Handles forms and evolutions not obtainable from Pokemon GO
-			const otherSpecies = this.learnsetParent(species);
+			const otherSpecies = this.dex.species.learnsetParent(species);
 			// If a Pokemon is somehow not obtainable from Pokemon GO and it must be leveled up to be evolved,
 			// validation for the game should stop because it's more optimal to get the Pokemon outside of the game
 			if (otherSpecies && !species.evoLevel) {
@@ -2339,8 +2335,8 @@ export class TeamValidator {
 	/** Returns null if you can learn the move, or a string explaining why you can't learn it */
 	checkCanLearn(
 		move: Move,
-		s: Species,
-		setSources = this.allSources(s),
+		originalSpecies: Species,
+		setSources = this.allSources(originalSpecies),
 		set: Partial<PokemonSet> = {}
 	): string | null {
 		const dex = this.dex;
@@ -2348,12 +2344,10 @@ export class TeamValidator {
 
 		move = dex.moves.get(move);
 		const moveid = move.id;
-		const baseSpecies = dex.species.get(s);
-		let species: Species | null = baseSpecies;
+		const baseSpecies = dex.species.get(originalSpecies);
 
 		const format = this.format;
 		const ruleTable = dex.formats.getRuleTable(format);
-		const alreadyChecked: {[k: string]: boolean} = {};
 		const level = set.level || 100;
 
 		let cantLearnReason = null;
@@ -2385,40 +2379,25 @@ export class TeamValidator {
 		const canSketchPostGen7Moves = ruleTable.has('sketchpostgen7moves') || this.dex.currentMod === 'gen8bdsp';
 
 		let tradebackEligible = false;
-		while (species?.name && !alreadyChecked[species.id]) {
-			alreadyChecked[species.id] = true;
-			if (dex.gen <= 2 && species.gen === 1) tradebackEligible = true;
-			let learnset = dex.species.getLearnset(species.id);
-			if (!learnset) {
-				if ((species.changesFrom || species.baseSpecies) !== species.name) {
-					// forme without its own learnset
-					species = dex.species.get(species.changesFrom || species.baseSpecies);
-					// warning: formes with their own learnset, like Wormadam, should NOT
-					// inherit from their base forme unless they're freely switchable
-					continue;
-				}
-				if (species.isNonstandard) {
-					// It's normal for a nonstandard species not to have learnset data
+		const fullLearnset = dex.species.getFullLearnset(originalSpecies.id);
+		if (!fullLearnset.length) {
+			// It's normal for a nonstandard species not to have learnset data
 
-					// Formats should replace the `Obtainable Moves` rule if they want to
-					// allow pokemon without learnsets.
-					return ` can't learn any moves at all.`;
-				}
-				if (species.prevo && dex.species.getLearnset(toID(species.prevo))) {
-					learnset = dex.species.getLearnset(toID(species.prevo));
-					continue;
-				}
-				// should never happen
-				throw new Error(`Species with no learnset data: ${species.id}`);
-			}
-			const checkingPrevo = species.baseSpecies !== s.baseSpecies;
+			// Formats should replace the `Obtainable Moves` rule if they want to
+			// allow pokemon without learnsets.
+			return ` can't learn any moves at all.`;
+		}
+
+		for (const {species, learnset} of fullLearnset) {
+			if (dex.gen <= 2 && species.gen === 1) tradebackEligible = true;
+			const checkingPrevo = species.baseSpecies !== originalSpecies.baseSpecies;
 			if (checkingPrevo && !moveSources.size()) {
 				if (!setSources.babyOnly || !species.prevo) {
 					babyOnly = species.id;
 				}
 			}
 
-			let sources = learnset[moveid];
+			let sources = learnset[moveid] || [];
 			if (moveid === 'sketch') {
 				sketch = true;
 			} else if (learnset['sketch']) {
@@ -2427,185 +2406,182 @@ export class TeamValidator {
 				} else if (move.gen > 7 && !canSketchPostGen7Moves) {
 					cantLearnReason = `can't be Sketched because it's a Gen ${move.gen} move and Sketch isn't available in Gen ${move.gen}.`;
 				} else {
-					if (!sources || !moveSources.size()) sketch = true;
-					sources = learnset['sketch'].concat(sources || []);
+					if (!sources.length || !moveSources.size()) sketch = true;
+					sources = [...learnset['sketch'], ...sources];
 				}
 			}
 
-			if (typeof sources === 'string') sources = [sources];
-			if (sources) {
-				for (let learned of sources) {
-					// Every `learned` represents a single way a pokemon might
-					// learn a move. This can be handled one of several ways:
-					// `continue`
-					//   means we can't learn it
-					// `return null`
-					//   means we can learn it with no restrictions
-					//   (there's a way to just teach any pokemon of this species
-					//   the move in the current gen, like a TM.)
-					// `moveSources.add(source)`
-					//   means we can learn it only if obtained that exact way described
-					//   in source
-					// `moveSources.addGen(learnedGen)`
-					//   means we can learn it only if obtained at or before learnedGen
-					//   (i.e. get the pokemon however you want, transfer to that gen,
-					//   teach it, and transfer it to the current gen.)
+			for (let learned of sources) {
+				// Every `learned` represents a single way a pokemon might
+				// learn a move. This can be handled one of several ways:
+				// `continue`
+				//   means we can't learn it
+				// `return null`
+				//   means we can learn it with no restrictions
+				//   (there's a way to just teach any pokemon of this species
+				//   the move in the current gen, like a TM.)
+				// `moveSources.add(source)`
+				//   means we can learn it only if obtained that exact way described
+				//   in source
+				// `moveSources.addGen(learnedGen)`
+				//   means we can learn it only if obtained at or before learnedGen
+				//   (i.e. get the pokemon however you want, transfer to that gen,
+				//   teach it, and transfer it to the current gen.)
 
-					const learnedGen = parseInt(learned.charAt(0));
-					if (learnedGen < this.minSourceGen) {
-						if (!cantLearnReason) {
-							cantLearnReason = `can't be transferred from Gen ${learnedGen} to ${this.minSourceGen}.`;
-						}
+				const learnedGen = parseInt(learned.charAt(0));
+				if (learnedGen < this.minSourceGen) {
+					if (!cantLearnReason) {
+						cantLearnReason = `can't be transferred from Gen ${learnedGen} to ${this.minSourceGen}.`;
+					}
+					continue;
+				}
+				if (noFutureGen && learnedGen > dex.gen) {
+					if (!cantLearnReason) {
+						cantLearnReason = `can't be transferred from Gen ${learnedGen} to ${dex.gen}.`;
+					}
+					continue;
+				}
+
+				// redundant
+				if (learnedGen <= moveSources.sourcesBefore) continue;
+
+				if (
+					baseSpecies.evoRegion === 'Alola' && checkingPrevo && learnedGen >= 8 &&
+					(dex.gen < 9 || learned.charAt(1) !== 'E')
+				) {
+					cantLearnReason = `is from a ${species.name} that can't be transferred to USUM to evolve into ${baseSpecies.name}.`;
+					continue;
+				}
+
+				const canUseAbilityPatch = dex.gen >= 8 && format.mod !== 'gen8dlc1';
+				if (
+					learnedGen < 7 && setSources.isHidden && !canUseAbilityPatch &&
+					!dex.mod('gen' + learnedGen).species.get(baseSpecies.name).abilities['H']
+				) {
+					cantLearnReason = `can only be learned in gens without Hidden Abilities.`;
+					continue;
+				}
+
+				const ability = dex.abilities.get(set.ability);
+				if (dex.gen < 6 && ability.gen > learnedGen && !checkingPrevo) {
+					// You can evolve a transfered mon to reroll for its new Ability.
+					cantLearnReason = `is learned in gen ${learnedGen}, but the Ability ${ability.name} did not exist then.`;
+					continue;
+				}
+
+				if (!species.isNonstandard) {
+					// HMs can't be transferred
+					if (dex.gen >= 4 && learnedGen <= 3 && [
+						'cut', 'fly', 'surf', 'strength', 'flash', 'rocksmash', 'waterfall', 'dive',
+					].includes(moveid)) {
+						cantLearnReason = `can't be transferred from Gen 3 to 4 because it's an HM move.`;
 						continue;
 					}
-					if (noFutureGen && learnedGen > dex.gen) {
-						if (!cantLearnReason) {
-							cantLearnReason = `can't be transferred from Gen ${learnedGen} to ${dex.gen}.`;
-						}
+					if (dex.gen >= 5 && learnedGen <= 4 && [
+						'cut', 'fly', 'surf', 'strength', 'rocksmash', 'waterfall', 'rockclimb',
+					].includes(moveid)) {
+						cantLearnReason = `can't be transferred from Gen 4 to 5 because it's an HM move.`;
 						continue;
 					}
+					// Defog and Whirlpool can't be transferred together
+					if (dex.gen >= 5 && ['defog', 'whirlpool'].includes(moveid) && learnedGen <= 4) blockedHM = true;
+				}
 
-					// redundant
-					if (learnedGen <= moveSources.sourcesBefore) continue;
-
-					if (
-						baseSpecies.evoRegion === 'Alola' && checkingPrevo && learnedGen >= 8 &&
-						(dex.gen < 9 || learned.charAt(1) !== 'E')
-					) {
-						cantLearnReason = `is from a ${species.name} that can't be transferred to USUM to evolve into ${baseSpecies.name}.`;
+				if (learned.charAt(1) === 'L') {
+					// special checking for level-up moves
+					if (level >= parseInt(learned.substr(2)) || learnedGen === 7) {
+						// we're past the required level to learn it
+						// (gen 7 level-up moves can be relearnered at any level)
+						// falls through to LMT check below
+					} else if (level >= 5 && learnedGen === 3 && species.canHatch) {
+						// Pomeg Glitch
+						learned = learnedGen + 'Epomeg';
+					} else if ((!species.gender || species.gender === 'F') &&
+						learnedGen >= 2 && species.canHatch && !setSources.isFromPokemonGo) {
+						// available as egg move
+						learned = learnedGen + 'Eany';
+						// falls through to E check below
+					} else {
+						// this move is unavailable, skip it
+						cantLearnReason = `is learned at level ${parseInt(learned.substr(2))}.`;
 						continue;
 					}
+				}
 
-					const canUseAbilityPatch = dex.gen >= 8 && format.mod !== 'gen8dlc1';
-					if (
-						learnedGen < 7 && setSources.isHidden && !canUseAbilityPatch &&
-						!dex.mod('gen' + learnedGen).species.get(baseSpecies.name).abilities['H']
-					) {
-						cantLearnReason = `can only be learned in gens without Hidden Abilities.`;
-						continue;
-					}
-
-					const ability = dex.abilities.get(set.ability);
-					if (dex.gen < 6 && ability.gen > learnedGen && !checkingPrevo) {
-						// You can evolve a transfered mon to reroll for its new Ability.
-						cantLearnReason = `is learned in gen ${learnedGen}, but the Ability ${ability.name} did not exist then.`;
-						continue;
-					}
-
-					if (!species.isNonstandard) {
-						// HMs can't be transferred
-						if (dex.gen >= 4 && learnedGen <= 3 && [
-							'cut', 'fly', 'surf', 'strength', 'flash', 'rocksmash', 'waterfall', 'dive',
-						].includes(moveid)) {
-							cantLearnReason = `can't be transferred from Gen 3 to 4 because it's an HM move.`;
-							continue;
-						}
-						if (dex.gen >= 5 && learnedGen <= 4 && [
-							'cut', 'fly', 'surf', 'strength', 'rocksmash', 'waterfall', 'rockclimb',
-						].includes(moveid)) {
-							cantLearnReason = `can't be transferred from Gen 4 to 5 because it's an HM move.`;
-							continue;
-						}
-						// Defog and Whirlpool can't be transferred together
-						if (dex.gen >= 5 && ['defog', 'whirlpool'].includes(moveid) && learnedGen <= 4) blockedHM = true;
-					}
-
-					if (learned.charAt(1) === 'L') {
-						// special checking for level-up moves
-						if (level >= parseInt(learned.substr(2)) || learnedGen === 7) {
-							// we're past the required level to learn it
-							// (gen 7 level-up moves can be relearnered at any level)
-							// falls through to LMT check below
-						} else if (level >= 5 && learnedGen === 3 && species.canHatch) {
-							// Pomeg Glitch
-							learned = learnedGen + 'Epomeg';
-						} else if ((!species.gender || species.gender === 'F') &&
-							learnedGen >= 2 && species.canHatch && !setSources.isFromPokemonGo) {
-							// available as egg move
-							learned = learnedGen + 'Eany';
-							// falls through to E check below
-						} else {
-							// this move is unavailable, skip it
-							cantLearnReason = `is learned at level ${parseInt(learned.substr(2))}.`;
-							continue;
-						}
-					}
-
-					// Gen 8+ egg moves can be taught to any pokemon from any source
-					if (learnedGen >= 8 && learned.charAt(1) === 'E' && learned.slice(1) !== 'Eany' &&
-						learned.slice(1) !== 'Epomeg' || 'LMTR'.includes(learned.charAt(1))) {
-						if (learnedGen === dex.gen && learned.charAt(1) !== 'R') {
-							// current-gen level-up, TM or tutor moves:
-							//   always available
-							if (!(learnedGen >= 8 && learned.charAt(1) === 'E') && babyOnly) {
-								if (setSources.isFromPokemonGo && species.evoLevel) {
-									cantLearnReason = `is from a prevo, which is incompatible with its Pokemon GO origin.`;
-									continue;
-								} else {
-									setSources.babyOnly = babyOnly;
-								}
-							}
-							if (!moveSources.moveEvoCarryCount) return null;
-						}
-						// past-gen level-up, TM, or tutor moves:
-						//   available as long as the source gen was or was before this gen
-						if (learned.charAt(1) === 'R') {
-							moveSources.restrictedMove = moveid;
-						}
-						limit1 = false;
-						moveSources.addGen(learnedGen);
-					} else if (learned.charAt(1) === 'E') {
-						// egg moves:
-						//   only if hatched from an egg
-						let limitedEggMove: ID | null | undefined = undefined;
-						if (learned.slice(1) === 'Eany') {
-							if (species.gender === 'F') {
-								limitedEggMove = move.id;
-								moveSources.levelUpEggMoves = [move.id];
+				// Gen 8+ egg moves can be taught to any pokemon from any source
+				if (learnedGen >= 8 && learned.charAt(1) === 'E' && learned.slice(1) !== 'Eany' &&
+					learned.slice(1) !== 'Epomeg' || 'LMTR'.includes(learned.charAt(1))) {
+					if (learnedGen === dex.gen && learned.charAt(1) !== 'R') {
+						// current-gen level-up, TM or tutor moves:
+						//   always available
+						if (!(learnedGen >= 8 && learned.charAt(1) === 'E') && babyOnly) {
+							if (setSources.isFromPokemonGo && species.evoLevel) {
+								cantLearnReason = `is from a prevo, which is incompatible with its Pokemon GO origin.`;
+								continue;
 							} else {
-								limitedEggMove = null;
+								setSources.babyOnly = babyOnly;
 							}
-						} else if (learned.slice(1) === 'Epomeg') {
-							// Pomeg glitched moves have to be from an egg but since they aren't true egg moves,
-							// there should be no breeding restrictions
-							moveSources.pomegEggMoves = [move.id];
-						} else if (learnedGen < 6) {
-							limitedEggMove = move.id;
 						}
-						learned = learnedGen + 'E' + (species.prevo ? species.id : '');
-						if (tradebackEligible && learnedGen === 2 && move.gen <= 1) {
-							// can tradeback
-							moveSources.add('1ET' + learned.slice(2), limitedEggMove);
-						}
-						moveSources.add(learned, limitedEggMove);
-					} else if (learned.charAt(1) === 'S') {
-						// event moves:
-						//   only if that was the source
-						// Event Pokémon:
-						// 	Available as long as the past gen can get the Pokémon and then trade it back.
-						if (tradebackEligible && learnedGen === 2 && move.gen <= 1) {
-							// can tradeback
-							moveSources.add('1ST' + learned.slice(2) + ' ' + species.id);
-						}
-						moveSources.add(learned + ' ' + species.id);
-						const eventLearnset = dex.species.getLearnsetData(species.id);
-						if (eventLearnset.eventData?.[parseInt(learned.charAt(2))].emeraldEventEgg && learnedGen === 3) {
-							moveSources.pomegEventEgg = learned + ' ' + species.id;
-						}
-					} else if (learned.charAt(1) === 'D') {
-						// DW moves:
-						//   only if that was the source
-						moveSources.add(learned + species.id);
-						moveSources.dreamWorldMoveCount++;
-					} else if (learned.charAt(1) === 'V' && this.minSourceGen < learnedGen) {
-						// Virtual Console or Let's Go transfer moves:
-						//   only if that was the source
-						if (learned === '8V' && setSources.isFromPokemonGo && babyOnly && species.evoLevel) {
-							cantLearnReason = `is from a prevo, which is incompatible with its Pokemon GO origin.`;
-							continue;
-						}
-						moveSources.add(learned);
+						if (!moveSources.moveEvoCarryCount) return null;
 					}
+					// past-gen level-up, TM, or tutor moves:
+					//   available as long as the source gen was or was before this gen
+					if (learned.charAt(1) === 'R') {
+						moveSources.restrictedMove = moveid;
+					}
+					limit1 = false;
+					moveSources.addGen(learnedGen);
+				} else if (learned.charAt(1) === 'E') {
+					// egg moves:
+					//   only if hatched from an egg
+					let limitedEggMove: ID | null | undefined = undefined;
+					if (learned.slice(1) === 'Eany') {
+						if (species.gender === 'F') {
+							limitedEggMove = move.id;
+							moveSources.levelUpEggMoves = [move.id];
+						} else {
+							limitedEggMove = null;
+						}
+					} else if (learned.slice(1) === 'Epomeg') {
+						// Pomeg glitched moves have to be from an egg but since they aren't true egg moves,
+						// there should be no breeding restrictions
+						moveSources.pomegEggMoves = [move.id];
+					} else if (learnedGen < 6) {
+						limitedEggMove = move.id;
+					}
+					learned = learnedGen + 'E' + (species.prevo ? species.id : '');
+					if (tradebackEligible && learnedGen === 2 && move.gen <= 1) {
+						// can tradeback
+						moveSources.add('1ET' + learned.slice(2), limitedEggMove);
+					}
+					moveSources.add(learned, limitedEggMove);
+				} else if (learned.charAt(1) === 'S') {
+					// event moves:
+					//   only if that was the source
+					// Event Pokémon:
+					// 	Available as long as the past gen can get the Pokémon and then trade it back.
+					if (tradebackEligible && learnedGen === 2 && move.gen <= 1) {
+						// can tradeback
+						moveSources.add('1ST' + learned.slice(2) + ' ' + species.id);
+					}
+					moveSources.add(learned + ' ' + species.id);
+					const eventLearnset = dex.species.getLearnsetData(species.id);
+					if (eventLearnset.eventData?.[parseInt(learned.charAt(2))].emeraldEventEgg && learnedGen === 3) {
+						moveSources.pomegEventEgg = learned + ' ' + species.id;
+					}
+				} else if (learned.charAt(1) === 'D') {
+					// DW moves:
+					//   only if that was the source
+					moveSources.add(learned + species.id);
+					moveSources.dreamWorldMoveCount++;
+				} else if (learned.charAt(1) === 'V' && this.minSourceGen < learnedGen) {
+					// Virtual Console or Let's Go transfer moves:
+					//   only if that was the source
+					if (learned === '8V' && setSources.isFromPokemonGo && babyOnly && species.evoLevel) {
+						cantLearnReason = `is from a prevo, which is incompatible with its Pokemon GO origin.`;
+						continue;
+					}
+					moveSources.add(learned);
 				}
 			}
 			if (ruleTable.has('mimicglitch') && species.gen < 5) {
@@ -2636,9 +2612,6 @@ export class TeamValidator {
 					moveSources.moveEvoCarryCount = 1;
 				}
 			}
-
-			// also check to see if the mon's prevo or freely switchable formes can learn this move
-			species = this.learnsetParent(species);
 		}
 
 		if (limit1 && sketch) {
@@ -2660,7 +2633,7 @@ export class TeamValidator {
 		}
 		setSources.restrictiveMoves.push(move.name);
 
-		const checkedSpecies = babyOnly ? species : baseSpecies;
+		const checkedSpecies = babyOnly ? fullLearnset[fullLearnset.length - 1].species : baseSpecies;
 		if (checkedSpecies && setSources.isFromPokemonGo &&
 			(setSources.pokemonGoSource === 'purified' || checkedSpecies.id === 'mew')) {
 			// Pokemon that cannot be sent from Pokemon GO to Let's Go can only access Let's Go moves through HOME
@@ -2715,31 +2688,6 @@ export class TeamValidator {
 		}
 
 		if (babyOnly) setSources.babyOnly = babyOnly;
-		return null;
-	}
-
-	learnsetParent(species: Species) {
-		// Own Tempo Rockruff and Battle Bond Greninja are special event formes
-		// that are visually indistinguishable from their base forme but have
-		// different learnsets. To prevent a leak, we make them show up as their
-		// base forme, but hardcode their learnsets into Rockruff-Dusk and
-		// Greninja-Ash
-		if (['Gastrodon', 'Pumpkaboo', 'Sinistea', 'Tatsugiri'].includes(species.baseSpecies) && species.forme) {
-			return this.dex.species.get(species.baseSpecies);
-		} else if (species.name === 'Lycanroc-Dusk') {
-			return this.dex.species.get('Rockruff-Dusk');
-		} else if (species.name === 'Greninja-Bond') {
-			return null;
-		} else if (species.prevo) {
-			// there used to be a check for Hidden Ability here, but apparently it's unnecessary
-			// Shed Skin Pupitar can definitely evolve into Unnerve Tyranitar
-			species = this.dex.species.get(species.prevo);
-			if (species.gen > Math.max(2, this.dex.gen)) return null;
-			return species;
-		} else if (species.changesFrom && species.baseSpecies !== 'Kyurem') {
-			// For Pokemon like Rotom and Necrozma whose movesets are extensions are their base formes
-			return this.dex.species.get(species.changesFrom);
-		}
 		return null;
 	}
 

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1391,7 +1391,7 @@ export class TeamValidator {
 			// father must be male
 			if (father.gender === 'N' || father.gender === 'F') continue;
 			// can't inherit from dex entries with no learnsets
-			if (!dex.species.getLearnset(father.id)) continue;
+			if (!dex.species.getLearnsetData(father.id).learnset) continue;
 			// something is clearly wrong if its only possible father is itself
 			// (exceptions: ExtremeSpeed Dragonite, Self-destruct Snorlax)
 			if (pokemonBlacklist.includes(father.id) && !['dragonite', 'snorlax'].includes(father.id)) continue;
@@ -1428,7 +1428,7 @@ export class TeamValidator {
 	 */
 	fatherCanLearn(baseSpecies: Species, species: Species, moves: ID[], eggGen: number, pokemonBlacklist: ID[],
 		noRecurse: boolean | undefined) {
-		if (!this.dex.species.getLearnset(species.id)) return false;
+		if (!this.dex.species.getLearnsetData(species.id).learnset) return false;
 
 		if (species.id === 'smeargle') return true;
 		const canBreedWithSmeargle = species.eggGroups.includes('Field');

--- a/test/sim/dex.js
+++ b/test/sim/dex.js
@@ -6,14 +6,14 @@ describe('Mod loader', function () {
 	it('should work fine in any order', function () {
 		{
 			const Dex = require('./../../dist/sim/dex').Dex;
-			assert.equal(Dex.mod('gen2').species.getLearnset('nidoking').bubblebeam.join(','), '1M');
+			assert.equal(Dex.mod('gen2').species.getLearnsetData('nidoking').learnset.bubblebeam.join(','), '1M');
 			assert.equal(Dex.mod('gen2').moves.get('crunch').secondaries[0].boosts.def, undefined);
 		}
 		{
 			const Dex = require('./../../dist/sim/dex').Dex;
-			Dex.mod('gen2').species.getLearnset('nidoking');
+			Dex.mod('gen2').species.getLearnsetData('nidoking');
 			Dex.mod('gen4').moves.get('crunch');
-			assert.equal(Dex.mod('gen2').species.getLearnset('nidoking').bubblebeam.join(','), '1M');
+			assert.equal(Dex.mod('gen2').species.getLearnsetData('nidoking').learnset.bubblebeam.join(','), '1M');
 			assert.equal(Dex.mod('gen2').moves.get('crunch').secondaries[0].boosts.def, undefined);
 		}
 	});


### PR DESCRIPTION
After seeing fifty different ways we use `getLearnset`, most of which are just "haphazardly assemble a movepool", I decided to write `getFullLearnset` and `getMovePool`, which centralizes the implementations and prevents weird bugs like https://github.com/smogon/pokemon-showdown/commit/9713dc6db5c040a7abdf3dd088675543ae7e2827 which we spent two years trying to figure out.