### PR TITLE
Announcements: Edit messages without notifying users

### DIFF
--- a/server/chat-plugins/announcements.ts
+++ b/server/chat-plugins/announcements.ts
@@ -145,6 +145,31 @@ export const commands: Chat.ChatCommands = {
 		},
 		endhelp: [`/announcement end - Ends a announcement and displays the results. Requires: % @ # &`],
 
+		htmledit: "edit",
+		edit(target,room,user, connection, cmd, message) {
+			room = this.requireRoom();
+			const supportHTML = cmd === 'htmledit';
+			if (!target) return this.parse('/help announcement edit');
+			target = target.trim();
+
+			const text = this.filter(target);
+			if (target !== text) return this.errorReply(this.tr`You are not allowed to use filtered words in announcements.`);
+
+			this.checkCan('minigame', null, room);
+			if (supportHTML) this.checkCan('declare', null, room);
+			this.checkChat();
+			if (!room.minorActivity) return this.errorReply(this.tr`There is no announcement in progress to edit.`);
+
+			const source = supportHTML ? this.checkHTML(Chat.collapseLineBreaksHTML(target)) : Chat.formatText(target, true);
+			var updatedAnnouncement = new Announcement(room, {source});
+			room.setMinorActivity(updatedAnnouncement, true);
+			
+			this.roomlog(`${user.name} used ${message}`);
+			this.modlog(`ANNOUNCEMENT EDIT`)
+			this.privateModAction(room.tr`The announcement was edited by ${user.name}.`)
+		},
+		edithelp: [`/announcement edit [announcement] - Edits an announcement without pinging users. Requies % @ # &`],
+
 		show: '',
 		display: '',
 		''(target, room, user, connection) {

--- a/server/chat-plugins/announcements.ts
+++ b/server/chat-plugins/announcements.ts
@@ -146,7 +146,7 @@ export const commands: Chat.ChatCommands = {
 		endhelp: [`/announcement end - Ends a announcement and displays the results. Requires: % @ # &`],
 
 		htmledit: "edit",
-		edit(target,room,user, connection, cmd, message) {
+		edit(target, room, user, connection, cmd, message) {
 			room = this.requireRoom();
 			const supportHTML = cmd === 'htmledit';
 			if (!target) return this.parse('/help announcement edit');
@@ -161,12 +161,11 @@ export const commands: Chat.ChatCommands = {
 			if (!room.minorActivity) return this.errorReply(this.tr`There is no announcement in progress to edit.`);
 
 			const source = supportHTML ? this.checkHTML(Chat.collapseLineBreaksHTML(target)) : Chat.formatText(target, true);
-			var updatedAnnouncement = new Announcement(room, {source});
+			const updatedAnnouncement = new Announcement(room, {source});
 			room.setMinorActivity(updatedAnnouncement, true);
-			
 			this.roomlog(`${user.name} used ${message}`);
-			this.modlog(`ANNOUNCEMENT EDIT`)
-			this.privateModAction(room.tr`The announcement was edited by ${user.name}.`)
+			this.modlog(`ANNOUNCEMENT EDIT`);
+			this.privateModAction(room.tr`The announcement was edited by ${user.name}.`);
 		},
 		edithelp: [`/announcement edit [announcement] - Edits an announcement without pinging users. Requies % @ # &`],
 


### PR DESCRIPTION
Updated /announcement to include a new edit/htmledit command, which will not ping users. 

https://www.smogon.com/forums/threads/allow-roomstaff-to-edit-room-announcements-without-having-to-ping-the-entire-room-every-time.3732092/