### PR TITLE
Challenge Cup: Fix monotype and recurring bug with new Pokemon

### DIFF
--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -610,9 +610,9 @@ export class RandomGen8Teams {
 		const formes: string[][] = [];
 		for (const species of speciesPool) {
 			if (!(species.num in hasDexNumber)) continue;
-			if (requiredType && !species.types.includes(requiredType)) continue;
 			if (isNotCustom && (species.gen > this.gen ||
 				(species.isNonstandard && species.isNonstandard !== 'Unobtainable'))) continue;
+			if (requiredType && !species.types.includes(requiredType)) continue;
 			if (!formes[hasDexNumber[species.num]]) formes[hasDexNumber[species.num]] = [];
 			formes[hasDexNumber[species.num]].push(species.name);
 		}

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -533,9 +533,6 @@ export class RandomGen8Teams {
 		// Picks `n` random pokemon--no repeats, even among formes
 		// Also need to either normalize for formes or select formes at random
 		// Unreleased are okay but no CAP
-		const last = [0, 151, 251, 386, 493, 649, 721, 807, 898, 1010][this.gen];
-
-		if (n <= 0 || n > last) throw new Error(`n must be a number between 1 and ${last} (got ${n})`);
 		if (requiredType && !this.dex.types.get(requiredType).exists) {
 			throw new Error(`"${requiredType}" is not a valid type.`);
 		}
@@ -556,7 +553,6 @@ export class RandomGen8Teams {
 				if (minSourceGen && species.gen < minSourceGen) continue;
 				const num = species.num;
 				if (num <= 0 || pool.includes(num)) continue;
-				if (num > last) break;
 				pool.push(num);
 			}
 		} else {
@@ -614,6 +610,7 @@ export class RandomGen8Teams {
 		const formes: string[][] = [];
 		for (const species of speciesPool) {
 			if (!(species.num in hasDexNumber)) continue;
+			if (requiredType && !species.types.includes(requiredType)) continue;
 			if (isNotCustom && (species.gen > this.gen ||
 				(species.isNonstandard && species.isNonstandard !== 'Unobtainable'))) continue;
 			if (!formes[hasDexNumber[species.num]]) formes[hasDexNumber[species.num]] = [];

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -2092,7 +2092,6 @@ export class RandomTeams {
 		const formes: string[][] = [];
 		for (const species of speciesPool) {
 			if (!(species.num in hasDexNumber)) continue;
-			if (requiredType && !species.types.includes(requiredType)) continue;
 			if (isNotCustom && (species.gen > this.gen ||
 				(species.isNonstandard && species.isNonstandard !== 'Unobtainable'))) continue;
 			if (requiredType && !species.types.includes(requiredType)) continue;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -2015,9 +2015,6 @@ export class RandomTeams {
 		// Picks `n` random pokemon--no repeats, even among formes
 		// Also need to either normalize for formes or select formes at random
 		// Unreleased are okay but no CAP
-		const last = [0, 151, 251, 386, 493, 649, 721, 807, 898, 1017][this.gen];
-
-		if (n <= 0 || n > last) throw new Error(`n must be a number between 1 and ${last} (got ${n})`);
 		if (requiredType && !this.dex.types.get(requiredType).exists) {
 			throw new Error(`"${requiredType}" is not a valid type.`);
 		}
@@ -2038,7 +2035,6 @@ export class RandomTeams {
 				if (minSourceGen && species.gen < minSourceGen) continue;
 				const num = species.num;
 				if (num <= 0 || pool.includes(num)) continue;
-				if (num > last) break;
 				pool.push(num);
 			}
 		} else {
@@ -2096,6 +2092,7 @@ export class RandomTeams {
 		const formes: string[][] = [];
 		for (const species of speciesPool) {
 			if (!(species.num in hasDexNumber)) continue;
+			if (requiredType && !species.types.includes(requiredType)) continue;
 			if (isNotCustom && (species.gen > this.gen ||
 				(species.isNonstandard && species.isNonstandard !== 'Unobtainable'))) continue;
 			if (requiredType && !species.types.includes(requiredType)) continue;


### PR DESCRIPTION
Two changes:

1. Removes the hardcoded gen boundaries for dex numbers. I know this was rejected earlier in #9940, but I believe that to be in error, presumably because there was an active bug and so there was some rush. The only line it was used in was 559 (in the gen8 file), and that never triggered. Any Pokemon that are from a future gen already have the `isNonstandard` property `future`, and thus get filtered out in line 550. Furthermore, you would also not want it to trigger because the Pokemon are not guaranteed to come in dexnumber order. Indeed, generating a gen2CC team gives me 201, 350 and 479 first though I have no idea why. The break never triggers, but if it would team generation would fail entirely. The reason to remove it is that it requires an easy-to-forget edit when new Pokemon drop.
2. Fixes monotype for multiforme mons. The way this function works is by generating 6 random dex numbers (filtered to only include legal ones), and then generate all formes of each dexnumber to pick one from each of the 6. The generation of formes did not check for monotype, allowing for example old Sandshrew in monotype Ice, because Alolan Sandshrew is Ice type.

There was another bug in the movepool checker that accidentally had a hardcoded gen (9), giving lots of errors in older gens, but that was fixed already (sniped!) in #9951.