### PR TITLE
Remove Terapago-Terastal and -Stellar forms from formats-data

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -5666,16 +5666,6 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 		natDexTier: "OU",
 	},
-	terapagosterastal: {
-		tier: "OU",
-		doublesTier: "DOU",
-		natDexTier: "OU",
-	},
-	terapagosstellar: {
-		tier: "OU",
-		doublesTier: "DOU",
-		natDexTier: "OU",
-	},
 	pecharunt: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",


### PR DESCRIPTION
Isn't this simpler? The data from Terapagos propagates to its Terastal and Stellar forms. Since both are battle-only (and moveset independent), it doesn't make sense to separate them. This is the same case as Palafin and Palafin-Hero.