### PR TITLE
Gen 9 Random Battles updates

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2193,8 +2193,13 @@
         "level": 88,
         "sets": [
             {
+                "role": "Bulky Attacker",
+                "movepool": ["Night Shade", "Recover", "Spikes", "Stealth Rock", "Taunt"],
+                "teraTypes": ["Steel"]
+            },
+            {
                 "role": "Bulky Support",
-                "movepool": ["Knock Off", "Night Shade", "Recover", "Spikes", "Stealth Rock", "Taunt"],
+                "movepool": ["Knock Off", "Psychic Noise", "Recover", "Spikes", "Stealth Rock", "Teleport"],
                 "teraTypes": ["Steel"]
             },
             {
@@ -3898,9 +3903,14 @@
         "level": 77,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Dragon Dance", "Earth Power", "Icicle Spear", "Scale Shot"],
-                "teraTypes": ["Fairy", "Steel"]
+                "role": "Tera Blast user",
+                "movepool": ["Dragon Dance",  "Icicle Spear", "Scale Shot", "Tera Blast"],
+                "teraTypes": ["Ground"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Draco Meteor", "Earth Power", "Freeze-Dry", "Ice Beam", "Outrage"],
+                "teraTypes": ["Ground"]
             }
         ]
     },

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1145,7 +1145,7 @@ export class RandomTeams {
 		if (abilities.has('Guts') && (moves.has('facade') || moves.has('sleeptalk') || species.id === 'gurdurr')) return 'Guts';
 		if (species.id === 'copperajah' && moves.has('heavyslam')) return 'Heavy Metal';
 		if (species.id === 'jumpluff') return 'Infiltrator';
-		if (species.id === 'toucannon' && !counter.get('sheerforce') && !counter.get('skillink')) return 'Keen Eye';
+		if (species.id === 'toucannon' && !counter.get('sheerforce') && !counter.get('skilllink')) return 'Keen Eye';
 		if (species.id === 'reuniclus') return (role === 'AV Pivot') ? 'Regenerator' : 'Magic Guard';
 		if (species.id === 'smeargle') return 'Own Tempo';
 		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1150,7 +1150,7 @@ export class RandomTeams {
 		if (species.id === 'smeargle') return 'Own Tempo';
 		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it
 		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';
-		if (species.id === 'sandaconda' || species.id === 'scrafty' && moves.has('rest')) return 'Shed Skin';
+		if (species.id === 'sandaconda' || (species.id === 'scrafty' && moves.has('rest'))) return 'Shed Skin';
 		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';
 		if (species.id === 'ribombee') return 'Shield Dust';
 		if (species.id === 'dipplin') return 'Sticky Hold';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1150,7 +1150,7 @@ export class RandomTeams {
 		if (species.id === 'smeargle') return 'Own Tempo';
 		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it
 		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';
-		if (species.id === 'sandaconda' && moves.has('rest')) return 'Shed Skin';
+		if (species.id === 'sandaconda' || species.id === 'scrafty' && moves.has('rest')) return 'Shed Skin';
 		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';
 		if (species.id === 'ribombee') return 'Shield Dust';
 		if (species.id === 'dipplin') return 'Sticky Hold';


### PR DESCRIPTION
-Kyurem's sets have been adjusted: Tera Blast Ground has replaced Earth Power on the Dragon Dance set, and it now has a Wallbreaker set that is either mixed 4 attacks Boots or Choice Specs, depending on moves rolled.
-Deoxys-Defense has a new Psychic Noise variant of its support set with Knock Off and Teleport, while the Night Shade set no longer has Knock Off.
-Toucannon will no longer get Keen Eye Bullet Seed.
-Shed Skin now actually appears when it's supposed to and doesn't appear when it's not supposed to.