### PR TITLE
Shorten official format names

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -194,7 +194,7 @@ export const Formats: FormatList = [
 		banlist: ['Crucibellite'],
 	},
 	{
-		name: "[Gen 9] Battle Stadium Singles Regulation D",
+		name: "[Gen 9] BSS Regulation D",
 
 		mod: 'gen9predlc',
 		searchShow: false,
@@ -203,7 +203,7 @@ export const Formats: FormatList = [
 		banlist: ['Walking Wake', 'Iron Leaves'],
 	},
 	{
-		name: "[Gen 9] Battle Stadium Singles Regulation E",
+		name: "[Gen 9] BSS Regulation E",
 
 		mod: 'gen9dlc1',
 		bestOfDefault: true,
@@ -211,7 +211,7 @@ export const Formats: FormatList = [
 		banlist: ['Walking Wake', 'Iron Leaves'],
 	},
 	{
-		name: "[Gen 9] BSS Reg F",
+		name: "[Gen 9] BSS Regulation F",
 
 		mod: 'gen9',
 		searchShow: false,
@@ -321,7 +321,7 @@ export const Formats: FormatList = [
 		banlist: ['Basculin-White-Striped', 'Dunsparce', 'Gligar', 'Murkrow', 'Qwilfish-Hisui', 'Scyther', 'Sneasel', 'Sneasel-Hisui', 'Vulpix', 'Vulpix-Alola', 'Yanma'],
 	},
 	{
-		name: "[Gen 9] VGC 2023 Regulation D",
+		name: "[Gen 9] VGC Regulation D",
 
 		mod: 'gen9predlc',
 		gameType: 'doubles',
@@ -331,7 +331,7 @@ export const Formats: FormatList = [
 		banlist: ['Walking Wake', 'Iron Leaves'],
 	},
 	{
-		name: "[Gen 9] VGC 2023 Regulation E",
+		name: "[Gen 9] VGC Regulation E",
 
 		mod: 'gen9dlc1',
 		gameType: 'doubles',
@@ -340,7 +340,7 @@ export const Formats: FormatList = [
 		banlist: ['Walking Wake', 'Iron Leaves'],
 	},
 	{
-		name: "[Gen 9] VGC 2023 Regulation E (Bo3)",
+		name: "[Gen 9] VGC Regulation E (Bo3)",
 
 		mod: 'gen9dlc1',
 		gameType: 'doubles',
@@ -349,7 +349,7 @@ export const Formats: FormatList = [
 		banlist: ['Walking Wake', 'Iron Leaves'],
 	},
 	{
-		name: "[Gen 9] VGC 2024 Reg F",
+		name: "[Gen 9] VGC Regulation F",
 
 		mod: 'gen9',
 		gameType: 'doubles',
@@ -358,7 +358,7 @@ export const Formats: FormatList = [
 		banlist: [],
 	},
 	{
-		name: "[Gen 9] VGC 2024 Reg F (Bo3)",
+		name: "[Gen 9] VGC Regulation F (Bo3)",
 
 		mod: 'gen9',
 		gameType: 'doubles',

--- a/tools/set-import/importer.ts
+++ b/tools/set-import/importer.ts
@@ -46,7 +46,7 @@ export const TIERS = new Set([
 	// UGH
 	'battlestadiumsinglesseries2', 'battlestadiumsinglesregulationc',
 	//
-	'vgc2016', 'vgc2017', 'vgc2018', 'vgc2019ultraseries', 'vgc2020', 'vgc2023regulatione', 'vgc', '1v1',
+	'vgc2016', 'vgc2017', 'vgc2018', 'vgc2019ultraseries', 'vgc2020', 'vgcregulatione', 'vgc', '1v1',
 	'anythinggoes', 'nationaldexag', 'almostanyability', 'balancedhackmons',
 	'letsgoou', 'monotype', 'purehackmons', 'nationaldexmonotype',
 ]);
@@ -402,7 +402,7 @@ const SMOGON = {
 	vgc17: 'vgc2017',
 	vgc18: 'vgc2018',
 	vgc19: 'vgc2019ultraseries',
-	vgc24regulatione: 'vgc2023regulatione',
+	vgcregulatione: 'vgcregulatione',
 	// bssseries1: 'battlestadiumsinglesseries1', // ?
 	bssseries2: 'battlestadiumsinglesseries2',
 } as unknown as {[id: string]: ID};


### PR DESCRIPTION
re: [Original Discord message](https://discord.com/channels/630837856075513856/630973468409856020/1174623272348946523)

As is, the names for official cartridge formats are kind of long - so long that some of them get cut off!
![image](https://github.com/smogon/pokemon-showdown/assets/154213846/8814f27a-02bc-429c-877a-6e5d46647123)

The main way I aim to fix this is to completely remove the year from BSS/VGC format names, and shorten "Battle Stadium Singles" to "BSS".

As DaWoblefet says [**here**](https://discord.com/channels/630837856075513856/630973468409856020/1174696102755307560), cartridge formats were originally named this way because they used to function this way - the format would be the same for the entire year, thus making the year necessary in distinguishing between formats. However, now that Sword/Shield and Scarlet/Violet have roatating formats, the year has become less and less meaningful.

Shortening to BSS is less important, but just as meaningful. Most players know what BSS is by now, and those that don't will have had to ask anyways ("whats BSS" vs "whats battle stadium singles").

Preview of what both of these changes would look like: 
![image](https://github.com/smogon/pokemon-showdown/assets/154213846/aec98d67-7525-4afb-abed-3604134e3c2c)

TLDR: Specifying the generation and regulation letter are more than enough to distinguish between different BSS/VGC formats without including the year.

--i totally understand if importer.ts can't/shouldn't be changed, since that has to do with something more than just showdown