### PR TITLE
Ban Baton Pass and Substitute in ADV ZU

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -5154,7 +5154,7 @@ export const Formats: FormatList = [
 		mod: 'gen3',
 		searchShow: false,
 		ruleset: ['Standard', 'Baton Pass Stat Clause'],
-		banlist: ['Uber', 'OU', 'UUBL', 'UU', 'NUBL', 'NU', 'PUBL', 'PU', 'ZUBL'],
+		banlist: ['Uber', 'OU', 'UUBL', 'UU', 'NUBL', 'NU', 'PUBL', 'PU', 'ZUBL', 'Baton Pass + Substitute'],
 	},
 	{
 		name: "[Gen 3] LC",


### PR DESCRIPTION
Banning Baton Pass and Substitute in ADV ZU.
I was told to implement this by Zpice, runner up in last ADV ZU tourney.

Proof on smogon thread: https://www.smogon.com/forums/threads/roa-spotlight-tournament-adv-zu-finals-won-by-pokology.3730648/post-9881068

<img width="1028" alt="Screenshot 2023-12-18 at 8 20 40 PM" src="https://github.com/smogon/pokemon-showdown/assets/13453363/9f41ea50-32f2-4a29-bd99-6182e913b230">
