### PR TITLE
Gen 9 Random Battles updates

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -4540,7 +4540,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Hydro Pump", "Leech Life", "Liquidation", "Sticky Web"],
-                "teraTypes": ["Water"]
+                "teraTypes": ["Ground", "Steel", "Water"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2303,12 +2303,12 @@
         "level": 89,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Fire Punch", "Head Smash", "Rock Slide"],
                 "teraTypes": ["Ground", "Rock"]
             },
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["Crunch", "Earthquake", "Fire Punch", "Rock Slide"],
                 "teraTypes": ["Dark", "Rock"]
             }

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -74,7 +74,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Encore", "Focus Blast", "Grass Knot", "Nasty Plot", "Nuzzle", "Surf", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Alluring Voice", "Encore", "Focus Blast", "Grass Knot", "Nasty Plot", "Nuzzle", "Surf", "Thunderbolt", "Volt Switch"],
                 "teraTypes": ["Grass", "Water"]
             },
             {
@@ -89,8 +89,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Focus Blast", "Grass Knot", "Nasty Plot", "Psychic", "Psyshock", "Surf", "Thunderbolt", "Volt Switch"],
-                "teraTypes": ["Fighting", "Grass", "Water"]
+                "movepool": ["Alluring Voice", "Focus Blast", "Grass Knot", "Psychic", "Psyshock", "Surf", "Thunderbolt", "Volt Switch"],
+                "teraTypes": ["Fairy", "Fighting", "Grass", "Water"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Alluring Voice", "Focus Blast", "Grass Knot", "Nasty Plot", "Psyshock", "Surf", "Thunderbolt"],
+                "teraTypes": ["Fairy", "Fighting", "Grass", "Water"]
             }
         ]
     },
@@ -730,7 +735,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Transform"],
-                "teraTypes": ["Bug", "Dark", "Dragon", "Electric", "Fairy", "Fighting", "Fire", "Flying", "Ghost", "Grass", "Ground", "Ice", "Normal", "Poison", "Psychic", "Rock", "Steel", "Water"]
+                "teraTypes": ["Stellar"]
             }
         ]
     },
@@ -2659,7 +2664,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Knock Off", "Protect", "Spikes", "Toxic Spikes", "U-turn"],
+                "movepool": ["Earthquake", "Knock Off", "Protect", "Stealth Rock", "Toxic Spikes", "U-turn"],
                 "teraTypes": ["Water"]
             }
         ]

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1304,7 +1304,7 @@ export class RandomTeams {
 			ability === 'Imposter' ||
 			(species.id === 'magnezone' && moves.has('bodypress') && !isDoubles)
 		) return 'Choice Scarf';
-		if (species.id === 'rampardos' && role === 'Wallbreaker') return 'Choice Scarf';
+		if (species.id === 'rampardos' && role === 'Fast Attacker') return 'Choice Scarf';
 		if (species.id === 'reuniclus' && ability === 'Magic Guard') return 'Life Orb';
 		if (moves.has('bellydrum') && moves.has('substitute')) return 'Salac Berry';
 		if (

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -87,7 +87,7 @@ const SPEED_CONTROL = [
 ];
 // Moves that shouldn't be the only STAB moves:
 const NO_STAB = [
-	'accelerock', 'aquajet', 'beakblast', 'bounce', 'breakingswipe', 'bulletpunch', 'chatter', 'chloroblast', 'clearsmog', 'covet',
+	'accelerock', 'aquajet', 'bounce', 'breakingswipe', 'bulletpunch', 'chatter', 'chloroblast', 'clearsmog', 'covet',
 	'dragontail', 'doomdesire', 'electroweb', 'eruption', 'explosion', 'fakeout', 'feint', 'flamecharge', 'flipturn', 'futuresight',
 	'grassyglide', 'iceshard', 'icywind', 'incinerate', 'machpunch', 'meteorbeam', 'mortalspin', 'nuzzle', 'pluck', 'pursuit', 'quickattack',
 	'rapidspin', 'reversal', 'selfdestruct', 'shadowsneak', 'skydrop', 'snarl', 'strugglebug', 'suckerpunch', 'uturn', 'watershuriken',
@@ -911,7 +911,7 @@ export class RandomTeams {
 		}
 
 		// Enforce Protect
-		if (role.includes('Protect') || species.id === 'gliscor') {
+		if (role.includes('Protect')) {
 			const protectMoves = movePool.filter(moveid => PROTECT_MOVES.includes(moveid));
 			if (protectMoves.length) {
 				const moveid = this.sample(protectMoves);
@@ -1139,6 +1139,7 @@ export class RandomTeams {
 		if (species.id === 'florges') return 'Flower Veil';
 		if (species.id === 'scovillain') return 'Chlorophyll';
 		if (species.id === 'empoleon') return 'Competitive';
+		if (species.id === 'swampert' && !counter.get('Water') && !moves.has('flipturn')) return 'Damp';
 		if (species.id === 'dodrio') return 'Early Bird';
 		if (species.id === 'chandelure') return 'Flash Fire';
 		if (species.id === 'golemalola' && moves.has('doubleedge')) return 'Galvanize';
@@ -1303,7 +1304,7 @@ export class RandomTeams {
 			ability === 'Imposter' ||
 			(species.id === 'magnezone' && moves.has('bodypress') && !isDoubles)
 		) return 'Choice Scarf';
-		if (species.id === 'rampardos' && role === 'Wallbreaker') return 'Choice Band';
+		if (species.id === 'rampardos' && role === 'Wallbreaker') return 'Choice Scarf';
 		if (species.id === 'reuniclus' && ability === 'Magic Guard') return 'Life Orb';
 		if (moves.has('bellydrum') && moves.has('substitute')) return 'Salac Berry';
 		if (


### PR DESCRIPTION
This will be the last update until level balancing.

-Ditto is now Tera Stellar always. The meme will be missed.
-Raichu now has Alluring Voice on its support set.
-Alolan Raichu now has Alluring Voice and Tera Fairy as options. Its sets have also been split to make Nasty Plot always have Psyshock over Psychic.
-Gliscor's third set no longer has Protect enforcement or Spikes, because enforcing Protect and adding Spikes lowered Gliscor's win rate somehow.
-Toucannon now always has Beak Blast.
-Rampardos now gets Choice Scarf instead of Choice Band, and its roles have been switched with each other to make more face-value sense.
-Swampert now gets Damp when it does not have a Water move.
-Araquanid: +Tera Steel, +Tera Ground