### PR TITLE
Fix Booster Energy interaction with the DLC2 Paradox Pokémon

### DIFF
--- a/data/items.ts
+++ b/data/items.ts
@@ -628,9 +628,9 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		onTakeItem(item, source) {
-			if (source.baseSpecies.tags.includes("Paradox") {
-				if (['Raging Bolt', 'Gouging Fire', 'Iron Boulder', 'Iron Crown'].includes(source.baseSpecies.baseSpecies)) {
-					this.hint("Raging Bolt, Gouging Fire, Iron Boulder and Iron Crown may lose Booster Energy through item-manipulating moves.");
+			if (source.baseSpecies.tags.includes("Paradox")) {
+				if (['Gouging Fire', 'Raging Bolt', 'Iron Boulder', 'Iron Crown'].includes(source.baseSpecies.baseSpecies)) {
+					this.hint("Gouging Fire, Iron Boulder, Iron Crown and Raging Bolt may lose Booster Energy through item-manipulating moves.");
 				} else {
 					return false;
 				}

--- a/data/items.ts
+++ b/data/items.ts
@@ -628,9 +628,12 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		onTakeItem(item, source) {
-			if (source.baseSpecies.tags.includes("Paradox") &&
-				!['Raging Bolt', 'Gouging Fire', 'Iron Boulder', 'Iron Crown'].includes(source.baseSpecies.baseSpecies)) {
-				return false;
+			if (source.baseSpecies.tags.includes("Paradox") {
+				if (['Raging Bolt', 'Gouging Fire', 'Iron Boulder', 'Iron Crown'].includes(source.baseSpecies.baseSpecies)) {
+					this.hint("Raging Bolt, Gouging Fire, Iron Boulder and Iron Crown may lose Booster Energy through item-manipulating moves.");
+				} else {
+					return false;
+				}
 			}
 			return true;
 		},

--- a/data/items.ts
+++ b/data/items.ts
@@ -629,7 +629,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		onTakeItem(item, source) {
 			if (source.baseSpecies.tags.includes("Paradox")) {
-				if (['Gouging Fire', 'Raging Bolt', 'Iron Boulder', 'Iron Crown'].includes(source.baseSpecies.baseSpecies)) {
+				if (['Gouging Fire', 'Iron Boulder', 'Iron Crown', 'Raging Bolt'].includes(source.baseSpecies.baseSpecies)) {
 					this.hint("Gouging Fire, Iron Boulder, Iron Crown and Raging Bolt may lose Booster Energy through item-manipulating moves.");
 				} else {
 					return false;

--- a/data/items.ts
+++ b/data/items.ts
@@ -628,13 +628,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		onTakeItem(item, source) {
-			if (source.baseSpecies.tags.includes("Paradox")) {
-				if (['Gouging Fire', 'Iron Boulder', 'Iron Crown', 'Raging Bolt'].includes(source.baseSpecies.baseSpecies)) {
-					this.hint("Gouging Fire, Iron Boulder, Iron Crown and Raging Bolt may lose Booster Energy through item-manipulating moves.");
-				} else {
-					return false;
-				}
-			}
+			if (source.baseSpecies.tags.includes("Paradox")) return false;
 			return true;
 		},
 		num: 1880,

--- a/data/items.ts
+++ b/data/items.ts
@@ -629,8 +629,11 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		onTakeItem(item, source) {
 			if (source.baseSpecies.tags.includes("Paradox")) {
-				if (!['Gouging Fire', 'Raging Bolt', 'Iron Boulder', 'Iron Crown'].includes(source.baseSpecies.baseSpecies)) return false;
-				this.hint("Gouging Fire, Iron Boulder, Iron Crown and Raging Bolt may lose Booster Energy through item-manipulating moves.");
+				if (['Gouging Fire', 'Raging Bolt', 'Iron Boulder', 'Iron Crown'].includes(source.baseSpecies.baseSpecies)) {
+					this.hint("Gouging Fire, Iron Boulder, Iron Crown and Raging Bolt may lose Booster Energy through item-manipulating moves.");
+				} else {
+					return false;
+				}
 			}
 			return true;
 		},

--- a/data/items.ts
+++ b/data/items.ts
@@ -629,11 +629,8 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		onTakeItem(item, source) {
 			if (source.baseSpecies.tags.includes("Paradox")) {
-				if (['Gouging Fire', 'Raging Bolt', 'Iron Boulder', 'Iron Crown'].includes(source.baseSpecies.baseSpecies)) {
-					this.hint("Gouging Fire, Iron Boulder, Iron Crown and Raging Bolt may lose Booster Energy through item-manipulating moves.");
-				} else {
-					return false;
-				}
+				if (!['Gouging Fire', 'Raging Bolt', 'Iron Boulder', 'Iron Crown'].includes(source.baseSpecies.baseSpecies)) return false;
+				this.hint("Gouging Fire, Iron Boulder, Iron Crown and Raging Bolt may lose Booster Energy through item-manipulating moves.");
 			}
 			return true;
 		},

--- a/data/items.ts
+++ b/data/items.ts
@@ -628,7 +628,10 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		onTakeItem(item, source) {
-			if (source.baseSpecies.tags.includes("Paradox")) return false;
+			if (source.baseSpecies.tags.includes("Paradox") &&
+				!['Raging Bolt', 'Gouging Fire', 'Iron Boulder', 'Iron Crown'].includes(source.baseSpecies.baseSpecies)) {
+				return false;
+			}
 			return true;
 		},
 		num: 1880,

--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -18344,7 +18344,6 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 3.5,
 		weightkg: 590,
 		color: "Brown",
-		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	ragingbolt: {
@@ -18357,7 +18356,6 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 5.2,
 		weightkg: 480,
 		color: "Yellow",
-		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	ironboulder: {
@@ -18370,7 +18368,6 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 1.5,
 		weightkg: 162.5,
 		color: "Gray",
-		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	ironcrown: {
@@ -18383,7 +18380,6 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 1.6,
 		weightkg: 156,
 		color: "Blue",
-		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	terapagos: {


### PR DESCRIPTION
I don't know if this will be fixed in a future patch, but the new Paradox Pokémon can lose Booster Energy through Knock Off, Trick, etc.

https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/page-49#post-9900134

We could also remove the Paradox tag from the Pokémon (this is how is coded in the cartridge), but I'm not sure if it will have other consequences.