### PR TITLE
Fix Stellar-type interactions with type-changing moves and abilities

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -530,6 +530,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		onAfterMoveSecondary(target, source, move) {
 			if (!target.hp) return;
 			const type = move.type;
+			if (type === 'Stellar') return;
 			if (
 				target.isActive && move.effectType === 'Move' && move.category !== 'Status' &&
 				type !== '???' && !target.hasType(type)

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -2853,7 +2853,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 30,
 		priority: 0,
 		flags: {snatch: 1},
-		onHit(target) {
+		onHit(target, source) {
+			if (source.terastallized === 'Stellar') return false;
 			const type = this.dex.moves.get(target.moveSlots[0].id).type;
 			if (target.hasType(type) || !target.setType(type)) return false;
 			this.add('-start', target, 'typechange', type);
@@ -2874,11 +2875,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {bypasssub: 1},
 		onHit(target, source) {
-			if (!target.lastMoveUsed) {
-				return false;
-			}
+			if (!target.lastMoveUsed) return false;
+			if (source.terastallized === 'Stellar') return false;
 			const possibleTypes = [];
 			const attackType = target.lastMoveUsed.type;
+			if (attackType === 'Stellar') return false;
 			for (const type of this.dex.types.names()) {
 				if (source.hasType(type)) continue;
 				const typeCheck = this.dex.types.get(type).damageTaken[attackType];
@@ -6304,7 +6305,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1, allyanim: 1},
 		onHit(target) {
-			if (target.hasType('Grass')) return false;
+			if (target.hasType('Grass') || target.terastallized === 'Stellar') return false;
 			if (!target.addType('Grass')) return false;
 			this.add('-start', target, 'typeadd', 'Grass', '[from] move: Forest\'s Curse');
 		},

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -17845,6 +17845,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1, allyanim: 1},
 		onHit(target) {
+			if (target.terastallized === 'Stellar') return false;
 			if (target.getTypes().join() === 'Water' || !target.setType('Water')) {
 				// Soak should animate even when it fails.
 				// Returning false would suppress the animation.


### PR DESCRIPTION
1. Conversion 2

https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9901763

> Conversion 2 fails if the user was most recently hit by a Stellar Tera Blast.

2. Color Change

https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9900489

> Color Change is simply not triggered at all if the user is hit by Stellar Tera Blast. The least interesting outcome, but also the least complex. Showdown currently does incorrectly change the Color Change Pokemon into a Stellar Type, notably.