### PR TITLE
Move Gyarados-Mega to NatDex UUBL

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -1023,7 +1023,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 	gyaradosmega: {
 		isNonstandard: "Past",
 		tier: "Illegal",
-		natDexTier: "OU",
+		natDexTier: "UUBL",
 	},
 	lapras: {
 		tier: "OU",


### PR DESCRIPTION
https://www.smogon.com/forums/threads/usage-based-tier-update-for-december-2023.3732046/post-9878673

Mega Gyarados should have dropped from OU in National Dex with 3.281% usage.