### PR TITLE
Fix interaction between Tera Blast and Unaware

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -10696,7 +10696,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {},
 		onModifyMove(move, pokemon) {
-			if (pokemon.getStat('atk', false, true) > pokemon.getStat('spa', false, true)) move.category = 'Physical';
+			const unModifiedAtk = pokemon.getStat('atk', false, true, true);
+			const unModifiedSpAtk = pokemon.getStat('spa', false, true, true);
+			if (unModifiedAtk > unModifiedSpAtk) move.category = 'Physical';
 		},
 		ignoreAbility: true,
 		isZ: "ultranecroziumz",
@@ -13786,7 +13788,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
 		onModifyMove(move, pokemon) {
-			if (pokemon.getStat('atk', false, true) > pokemon.getStat('spa', false, true)) move.category = 'Physical';
+			const unModifiedAtk = pokemon.getStat('atk', false, true, true);
+			const unModifiedSpAtk = pokemon.getStat('spa', false, true, true);
+			if (unModifiedAtk > unModifiedSpAtk) move.category = 'Physical';
 		},
 		ignoreAbility: true,
 		secondary: null,
@@ -16815,10 +16819,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		},
 		onModifyMove(move, pokemon, target) {
 			if (!target) return;
-			const atk = pokemon.getStat('atk', false, true);
-			const spa = pokemon.getStat('spa', false, true);
-			const def = target.getStat('def', false, true);
-			const spd = target.getStat('spd', false, true);
+			const atk = pokemon.getStat('atk', false, true, true);
+			const spa = pokemon.getStat('spa', false, true, true);
+			const def = target.getStat('def', false, true, true);
+			const spd = target.getStat('spd', false, true, true);
 			const physical = Math.floor(Math.floor(Math.floor(Math.floor(2 * pokemon.level / 5 + 2) * 90 * atk) / def) / 50);
 			const special = Math.floor(Math.floor(Math.floor(Math.floor(2 * pokemon.level / 5 + 2) * 90 * spa) / spd) / 50);
 			if (physical > special || (physical === special && this.random(2) === 0)) {
@@ -19955,20 +19959,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 		},
 		onModifyMove(move, pokemon) {
 			if (!pokemon.terastallized) return;
-
-			// When checking the attacker's stats to determine move category, ignore abilities that
-			// change the stat stage boosts at calculation time. This will not ignore abilities whose
-			// stat stage changes have already been applied to the boost table.
-			const originalIgnoreAbility = move.ignoreAbility;
-			move.ignoreAbility = true;
-			const unModifiedAtk = pokemon.getStat('atk', false, true);
-			const unModifiedSpAtk = pokemon.getStat('spa', false, true);
-			// Reset the move so that the target's abilities will be applied in damage calculation.
-			move.ignoreAbility = originalIgnoreAbility;
+			const unModifiedAtk = pokemon.getStat('atk', false, true, true);
+			const unModifiedSpAtk = pokemon.getStat('spa', false, true, true);
 			if (unModifiedAtk > unModifiedSpAtk) {
 				move.category = 'Physical';
 			}
-
 			if (pokemon.terastallized === 'Stellar') {
 				move.self = {boosts: {atk: -1, spa: -1}};
 			}

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -19954,9 +19954,21 @@ export const Moves: {[moveid: string]: MoveData} = {
 			}
 		},
 		onModifyMove(move, pokemon) {
-			if (pokemon.terastallized && pokemon.getStat('atk', false, true) > pokemon.getStat('spa', false, true)) {
+			if (!pokemon.terastallized) return;
+
+			// When checking the attacker's stats to determine move category, ignore abilities that
+			// change the stat stage boosts at calculation time. This will not ignore abilities whose
+			// stat stage changes have already been applied to the boost table.
+			const originalIgnoreAbility = move.ignoreAbility;
+			move.ignoreAbility = true;
+			const unModifiedAtk = pokemon.getStat('atk', false, true);
+			const unModifiedSpAtk = pokemon.getStat('spa', false, true);
+			// Reset the move so that the target's abilities will be applied in damage calculation.
+			move.ignoreAbility = originalIgnoreAbility;
+			if (unModifiedAtk > unModifiedSpAtk) {
 				move.category = 'Physical';
 			}
+
 			if (pokemon.terastallized === 'Stellar') {
 				move.self = {boosts: {atk: -1, spa: -1}};
 			}

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -561,7 +561,7 @@ export class Pokemon {
 		return this.battle.modify(stat, (modifier || 1));
 	}
 
-	getStat(statName: StatIDExceptHP, unboosted?: boolean, unmodified?: boolean) {
+	getStat(statName: StatIDExceptHP, ignoreBoosts?: boolean, ignoreModifiers?: boolean, ignoreBoostModifiers?: boolean) {
 		statName = toID(statName) as StatIDExceptHP;
 		// @ts-ignore - type checking prevents 'hp' from being passed, but we're paranoid
 		if (statName === 'hp') throw new Error("Please read `maxhp` directly");
@@ -571,7 +571,7 @@ export class Pokemon {
 
 		// Download ignores Wonder Room's effect, but this results in
 		// stat stages being calculated on the opposite defensive stat
-		if (unmodified && 'wonderroom' in this.battle.field.pseudoWeather) {
+		if (ignoreModifiers && 'wonderroom' in this.battle.field.pseudoWeather) {
 			if (statName === 'def') {
 				statName = 'spd';
 			} else if (statName === 'spd') {
@@ -580,8 +580,11 @@ export class Pokemon {
 		}
 
 		// stat boosts
-		if (!unboosted) {
-			const boosts = this.battle.runEvent('ModifyBoost', this, null, null, {...this.boosts});
+		if (!ignoreBoosts) {
+			let boosts = {...this.boosts};
+			if (!ignoreBoostModifiers) {
+				boosts = this.battle.runEvent('ModifyBoost', this, null, null, boosts);
+			}
 			let boost = boosts[statName];
 			const boostTable = [1, 1.5, 2, 2.5, 3, 3.5, 4];
 			if (boost > 6) boost = 6;
@@ -594,7 +597,7 @@ export class Pokemon {
 		}
 
 		// stat modifier effects
-		if (!unmodified) {
+		if (!ignoreModifiers) {
 			const statTable: {[s in StatIDExceptHP]: string} = {atk: 'Atk', def: 'Def', spa: 'SpA', spd: 'SpD', spe: 'Spe'};
 			stat = this.battle.runEvent('Modify' + statTable[statName], this, null, null, stat);
 		}

--- a/test/sim/moves/lightthatburnsthesky.js
+++ b/test/sim/moves/lightthatburnsthesky.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+describe('Light That Burns The Sky', function () {
+	it(`should be a special attack when base stats are tied`, function () {
+		const battle = common.createBattle([[
+			// Regidrago has equal base attack and special attack stats.
+			{species: 'regidrago', ability: 'dragonsmaw', moves: ['lightthatburnsthesky']},
+		], [
+			{species: 'regirock', ability: 'clearbody', moves: ['protect']},
+		]]);
+		battle.makeChoices('move lightthatburnsthesky', 'move protect');
+
+		assert.equal(battle.p1.pokemon[0].lastMove.category, 'Special');
+	});
+
+	it(`should be a physical attack with higher attack stat`, function () {
+		const battle = common.createBattle([[
+			// Regidrago has equal base attack and special attack stats.
+			{species: 'regidrago', ability: 'dragonsmaw', moves: ['lightthatburnsthesky', 'dragondance']},
+		], [
+			{species: 'regirock', ability: 'clearbody', moves: ['protect']},
+		]]);
+		// Dragon Dance boosts Regidrago's attack stat.
+		battle.makeChoices('move dragondance', 'move protect');
+		battle.makeChoices('move lightthatburnsthesky', 'move protect');
+
+		assert.equal(battle.p1.pokemon[0].lastMove.category, 'Physical');
+	});
+
+	it(`should be a physical attack with higher attack stat even if target ignores stat changes`, function () {
+		const battle = common.createBattle([[
+			// Regidrago has equal base attack and special attack stats.
+			{species: 'regidrago', ability: 'dragonsmaw', moves: ['lightthatburnsthesky', 'dragondance']},
+		], [
+			// Dondozo's Unaware should not affect the move's category.
+			{species: 'dondozo', ability: 'unaware', moves: ['splash']},
+		]]);
+		// Dragon Dance boosts Regidrago's attack stat.
+		battle.makeChoices('move dragondance', 'move splash');
+		battle.makeChoices('move lightthatburnsthesky', 'move splash');
+
+		assert.equal(battle.p1.pokemon[0].lastMove.category, 'Physical');
+	});
+});

--- a/test/sim/moves/photongeyser.js
+++ b/test/sim/moves/photongeyser.js
@@ -96,4 +96,19 @@ describe(`Photon Geyser`, function () {
 		battle.makeChoices();
 		assert.fainted(battle.p2.active[0]);
 	});
+
+	it(`should be a physical attack with higher attack stat even if target ignores stat changes`, function () {
+		battle = common.createBattle([[
+			// Regidrago has equal base attack and special attack stats.
+			{species: 'regidrago', ability: 'dragonsmaw', moves: ['photongeyser', 'dragondance']},
+		], [
+			// Dondozo's Unaware should not affect the move's category.
+			{species: 'dondozo', ability: 'unaware', moves: ['splash']},
+		]]);
+		// Dragon Dance boosts Regidrago's attack stat.
+		battle.makeChoices('move dragondance', 'move splash');
+		battle.makeChoices('move photongeyser', 'move splash');
+
+		assert.equal(battle.p1.pokemon[0].lastMove.category, 'Physical');
+	});
 });

--- a/test/sim/moves/shellsidearm.js
+++ b/test/sim/moves/shellsidearm.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+describe('Shell Side Arm', function () {
+	it(`should be a special attack if that is forecasted to damage the target more`, function () {
+		const battle = common.createBattle([[
+			// Regidrago has equal base attack and special attack stats.
+			{species: 'regidrago', ability: 'dragonsmaw', moves: ['shellsidearm', 'splash']},
+		], [
+			// Shuckle has equal base defense and special defense stats.
+			{species: 'shuckle', ability: 'sturdy', moves: ['protect', 'growl']},
+		]]);
+		// Growl lowers Regidrago's attack stat.
+		battle.makeChoices('move splash', 'move growl');
+		battle.makeChoices('move shellsidearm', 'move protect');
+
+		assert.equal(battle.p1.pokemon[0].lastMove.category, 'Special');
+	});
+
+	it(`should be a physical attack if that is forecasted to damage the target moreshould be a physical attack with higher attack stat`, function () {
+		const battle = common.createBattle([[
+			// Regidrago has equal base attack and special attack stats.
+			{species: 'regidrago', ability: 'dragonsmaw', moves: ['shellsidearm', 'dragondance']},
+		], [
+			// Shuckle has equal base defense and special defense stats.
+			{species: 'shuckle', ability: 'sturdy', moves: ['protect']},
+		]]);
+		// Dragon Dance boosts Regidrago's attack stat.
+		battle.makeChoices('move dragondance', 'move protect');
+		battle.makeChoices('move shellsidearm', 'move protect');
+
+		assert.equal(battle.p1.pokemon[0].lastMove.category, 'Physical');
+	});
+
+	it(`should be a physical attack if that is forecasted to damage the target more even if target ignores stat changes`, function () {
+		const battle = common.createBattle([[
+			// Regidrago has equal base attack and special attack stats.
+			{species: 'regidrago', ability: 'dragonsmaw', moves: ['shellsidearm', 'dragondance']},
+		], [
+			// Shuckle has equal base defense and special defense stats.
+			// Shuckle's Unaware should not affect the move's category.
+			{species: 'shuckle', ability: 'unaware', moves: ['protect']},
+		]]);
+		// Dragon Dance boosts Regidrago's attack stat.
+		battle.makeChoices('move dragondance', 'move protect');
+		battle.makeChoices('move shellsidearm', 'move protect');
+
+		assert.equal(battle.p1.pokemon[0].lastMove.category, 'Physical');
+	});
+});

--- a/test/sim/moves/terablast.js
+++ b/test/sim/moves/terablast.js
@@ -45,7 +45,7 @@ describe('Tera Blast', function () {
 		assert.equal(battle.p1.pokemon[0].lastMove.category, 'Special');
 	});
 
-	it(`should be a special attack when terastallized even if target ignores stat changes`, function () {
+	it(`should be a physical attack when terastallized with higher attack stat even if target ignores stat changes`, function () {
 		const battle = common.createBattle([[
 			// Regidrago has equal base attack and special attack stats.
 			{species: 'regidrago', ability: 'dragonsmaw', moves: ['terablast', 'dragondance']},

--- a/test/sim/moves/terablast.js
+++ b/test/sim/moves/terablast.js
@@ -45,8 +45,7 @@ describe('Tera Blast', function () {
 		assert.equal(battle.p1.pokemon[0].lastMove.category, 'Special');
 	});
 
-	// Skipped until https://github.com/smogon/pokemon-showdown/issues/9381 is fixed.
-	it.skip(`should be a special attack when terastallized even if target ignores stat changes`, function () {
+	it(`should be a special attack when terastallized even if target ignores stat changes`, function () {
 		const battle = common.createBattle([[
 			// Regidrago has equal base attack and special attack stats.
 			{species: 'regidrago', ability: 'dragonsmaw', moves: ['terablast', 'dragondance']},


### PR DESCRIPTION
## Summary

Fixes issue #9381.

- **Conditions:**
  - The attacking Pokemon uses Tera Blast. 
  - The attacking Pokemon is terastallized.
  - The attacking Pokemon has boosted their attack stat to be higher than their special attack stat.
  - The defending Pokemon has the ability Unaware.
- **Expected Behavior:** Tera Blast should be a physical attack.
- **Actual Behavior:** Tera Blast is a special attack.

Also applied similar logic fixes to:

- [x] Tera Blast
- [x] Light That Burns the Sky
- [x] Photon Geyser
- [x] Shell Side Arm 

## Solution

Adds a new parameter to `Pokemon.getStat()` called `ignoreBoostModifiers` which, if true, skips `runEvent('ModifyBoost')` to avoid effects that modify stat stage boosts at damage calculation time.

By adding a new parameter, callers can opt-in to this behavior and we only opt-in for the four moves in the standard format that need this fix.

## Open Questions

1. For Shell Side Arm, should all stats be checked without considering boost modifiers? Is Shell Side Arm meant to be "unaware of Unaware?" Should some stats be checked with Unaware included in the calculation, like the target's defense and special defense?
2. Should the conditions created by Foresight and Miracle Eye apply their boost modifiers when checking the stats of these four moves or are they only necessary at damage calculation time? These are the only standard format moves that apply the `ModifyBoost` handlers.
3. Should we avoid breaking the behavior of a Pokemon with Simple using one of these moves? Or is it not necessary to maintain strict backwards compatibility for the other formats? If we want to maintain the behavior how might we support that? Should we create a new event type?

## Future Work

These tasks could be saved for future pull requests:

- Apply this fix to the moves and rules in the non-standard formats.
- Add a unit test to verify that Unaware was used in the damage calculation even though it did not affect the move category. I was not sure how to test this meaningfully since I could not find a clear output property. We could test the damage level in cases where that value is stable.

## Appendix

This new parameter skips event handlers that derive from the `ModifyBoost` event. As far as I can tell, that means it potentially affects interactions with these moves and abilities. Standard format entities are bolded.

- **Unaware (Ability)**
- **Foresight (Move)**
- **Miracle Eye (Move)**
- Foresight (Move, Gen 2)
- Simple (Ability, Gen 4)
- Unaware (Ability, Full Potential)
- Carefree (Ability, Super Staff Bros)
- Old Manpa (Ability, Super Staff Bros)
- Ghost Spores (Ability, Super Staff Bros)
- Plausible Deniability (Ability, Super Staff Bros)
- Hacked Corrosion (Ability, Super Staff Bros)
- True Grit (Ability, Super Staff Bros)
- Unaware (Ability, Super Staff Bros)
- Billo/Unaware (Condition, Super Staff Bros)

As far as I can tell, these are the moves and abilities that check a stat with boosts applied but not stat modifiers. These would be candidates for using the new parameter. Standard format entities are bolded.

- **Light That Burns the Sky (Move)**
- **Photon Geyser (Move)**
- **Shell Side Arm (Move)**
- **Tera Blast (Move)**
- **Strength Sap (Move)** - Only checks the target's attack stat, which would not be altered by Unaware. 
- Belly Drum (Move, Gen 2)
- Swagger (Move, Gen 2)
- Belly Drum (Move, Gen 2 Stadium 2)
- Tera Blast (Move, [Gen 9] Tera Donation Format)
- Light That Burns the Sky (Move, Category Swap Mod Ruleset)
- Photon Geyser (Move, Category Swap Mod Ruleset)
- Shell Side Arm (Move, Category Swap Mod Ruleset)
- Tera Blast (Move, VaporeMons)
- BURN IT DOWN! (Ability, Super Staff Bros)
- Bane Terrain (Move, Super Staff Bros)
- Soul Siphon (Move, Super Staff Bros)
- Integer Overflow (Move, Super Staff Bros)
- Homunculus's Vanity (Move, Super Staff Bros)
