### PR TITLE
Update Evasion Items Clause description

### DIFF
--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -843,7 +843,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 	evasionitemsclause: {
 		effectType: 'ValidatorRule',
 		name: 'Evasion Items Clause',
-		desc: "Bans moves that lower the accuracy of moves used against the user",
+		desc: "Bans items that lower the accuracy of moves used against the user",
 		banlist: ['Bright Powder', 'Lax Incense'],
 		onBegin() {
 			this.add('rule', 'Evasion Items Clause: Evasion items are banned');


### PR DESCRIPTION
Fixed a typo in which the Evasion Items Clause description stated that it banned moves