### PR TITLE
Gen 9 Random Battles updates

### DIFF
--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -186,6 +186,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Giga Drain", "Leech Seed", "Sleep Powder", "Sludge Bomb", "Strength Sap"],
                 "teraTypes": ["Steel", "Water"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Sludge Wave", "Solar Beam", "Sunny Day", "Weather Ball"],
+                "teraTypes": ["Fire"]
             }
         ]
     },
@@ -451,6 +456,11 @@
                 "role": "AV Pivot",
                 "movepool": ["Drain Punch", "Gunk Shot", "Ice Punch", "Knock Off", "Poison Jab", "Shadow Sneak"],
                 "teraTypes": ["Dark"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Curse", "Drain Punch", "Gunk Shot", "Knock Off", "Poison Jab", "Rest"],
+                "teraTypes": ["Dark", "Fighting"]
             }
         ]
     },
@@ -461,6 +471,11 @@
                 "role": "AV Pivot",
                 "movepool": ["Drain Punch", "Gunk Shot", "Ice Punch", "Knock Off", "Poison Jab", "Shadow Sneak"],
                 "teraTypes": ["Dark"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Curse", "Drain Punch", "Gunk Shot", "Knock Off", "Poison Jab", "Rest"],
+                "teraTypes": ["Dark", "Fighting"]
             }
         ]
     },
@@ -911,6 +926,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Dragon Tail", "Encore", "Energy Ball", "Knock Off", "Leech Seed", "Synthesis"],
                 "teraTypes": ["Poison", "Steel", "Water"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Earthquake", "Knock Off", "Petal Blizzard", "Swords Dance"],
+                "teraTypes": ["Ground", "Steel", "Water"]
             }
         ]
     },
@@ -1429,7 +1449,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Ceaseless Edge", "Lunar Dance", "Shed Tail", "Spore", "Sticky Web", "Stone Axe"],
+                "movepool": ["Ceaseless Edge", "Glare", "Lunar Dance", "Shed Tail", "Spore", "Sticky Web", "Stone Axe"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -1789,11 +1809,6 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Encore", "Roost", "Thunder Wave", "U-turn"],
-                "teraTypes": ["Steel", "Water"]
-            },
-            {
-                "role": "Bulky Attacker",
                 "movepool": ["Bug Buzz", "Encore", "Roost", "Thunder Wave"],
                 "teraTypes": ["Steel", "Water"]
             }
@@ -1911,6 +1926,11 @@
                 "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Flamethrower", "Giga Drain", "Glare", "Gunk Shot", "Knock Off", "Switcheroo"],
                 "teraTypes": ["Dark", "Fire", "Grass", "Ground", "Poison"]
+            },
+            {
+                "role": "Fast Bulky Setup",
+                "movepool": ["Swords Dance", "Earthquake", "Gunk Shot", "Trailblaze"],
+                "teraTypes": ["Grass", "Ground"]
             }
         ]
     },
@@ -2024,12 +2044,12 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Agility", "Earthquake", "Knock Off", "Meteor Mash", "Psychic Fangs"],
+                "movepool": ["Agility", "Earthquake", "Heavy Slam", "Knock Off", "Psychic Fangs"],
                 "teraTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Bullet Punch", "Earthquake", "Knock Off", "Meteor Mash", "Psychic Fangs", "Stealth Rock"],
+                "movepool": ["Bullet Punch", "Earthquake", "Heavy Slam", "Knock Off", "Psychic Fangs", "Stealth Rock"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -2170,12 +2190,12 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Extreme Speed", "Knock Off", "Psycho Boost", "Superpower"],
-                "teraTypes": ["Fighting", "Normal", "Psychic"]
+                "teraTypes": ["Fighting", "Normal", "Psychic", "Stellar"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Ice Beam", "Knock Off", "Psycho Boost", "Superpower"],
-                "teraTypes": ["Fighting", "Psychic"]
+                "teraTypes": ["Fighting", "Psychic", "Stellar"]
             }
         ]
     },
@@ -2185,12 +2205,12 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Extreme Speed", "Knock Off", "Psycho Boost", "Superpower"],
-                "teraTypes": ["Fighting", "Normal", "Psychic"]
+                "teraTypes": ["Fighting", "Normal", "Psychic", "Stellar"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Ice Beam", "Knock Off", "Psycho Boost", "Superpower"],
-                "teraTypes": ["Fighting", "Psychic"]
+                "teraTypes": ["Fighting", "Psychic", "Stellar"]
             }
         ]
     },
@@ -2319,7 +2339,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Body Press", "Iron Defense", "Rest", "Stone Edge"],
+                "movepool": ["Body Press", "Foul Play", "Iron Defense", "Rest"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -3916,6 +3936,11 @@
                 "role": "Wallbreaker",
                 "movepool": ["Draco Meteor", "Earth Power", "Freeze-Dry", "Ice Beam", "Outrage"],
                 "teraTypes": ["Ground"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Earth Power", "Freeze-Dry", "Protect", "Substitute"],
+                "teraTypes": ["Fairy", "Poison", "Steel"]
             }
         ]
     },
@@ -4049,7 +4074,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Dark Pulse", "Fire Blast", "Hyper Voice", "Will-O-Wisp", "Work Up"],
+                "movepool": ["Dark Pulse", "Fire Blast", "Hyper Voice", "Taunt", "Will-O-Wisp", "Work Up"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -4443,8 +4468,8 @@
         "level": 83,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Defog", "Hurricane", "Quiver Dance", "Revelation Dance", "Roost"],
+                "role": "Setup Sweeper",
+                "movepool": ["Hurricane", "Quiver Dance", "Revelation Dance", "Roost"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -4489,7 +4514,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Accelerock", "Close Combat", "Crunch", "Drill Run", "Psychic Fangs", "Stealth Rock", "Stone Edge", "Swords Dance", "Taunt"],
+                "movepool": ["Accelerock", "Close Combat", "Crunch", "Psychic Fangs", "Stealth Rock", "Stone Edge", "Swords Dance", "Taunt"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -4980,17 +5005,17 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Light Screen", "Parting Shot", "Reflect", "Spirit Break", "Thunder Wave"],
-                "teraTypes": ["Fairy"]
+                "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Bulk Up", "Rest", "Spirit Break", "Sucker Punch", "Throat Chop", "Thunder Wave"],
-                "teraTypes": ["Dark"]
+                "teraTypes": ["Dark", "Poison", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Parting Shot", "Spirit Break", "Sucker Punch", "Taunt", "Thunder Wave"],
-                "teraTypes": ["Fairy"]
+                "teraTypes": ["Poison", "Steel"]
             }
         ]
     },
@@ -5136,11 +5161,6 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Body Press", "Draco Meteor", "Flash Cannon", "Iron Defense", "Stealth Rock", "Thunder Wave"],
                 "teraTypes": ["Fighting"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["Dragon Tail", "Flash Cannon", "Rest", "Sleep Talk"],
-                "teraTypes": ["Fairy", "Water"]
             }
         ]
     },
@@ -5819,8 +5839,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Brave Bird", "Hone Claws", "Knock Off", "Stone Edge", "Sucker Punch", "U-turn"],
+                "movepool": ["Brave Bird", "Knock Off", "Roost", "Stone Edge", "Sucker Punch", "U-turn"],
                 "teraTypes": ["Rock"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Brave Bird", "Knock Off", "Roost", "Stealth Rock", "Sucker Punch", "U-turn"],
+                "teraTypes": ["Dark", "Steel"]
             }
         ]
     },
@@ -6259,13 +6284,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Ruination", "Spikes", "Stealth Rock", "Throat Chop", "Whirlwind"],
+                "movepool": ["Earthquake", "Spikes", "Stealth Rock", "Throat Chop", "Whirlwind"],
                 "teraTypes": ["Ghost", "Ground", "Poison"]
             },
             {
-                "role": "AV Pivot",
-                "movepool": ["Body Press", "Earthquake", "Heavy Slam", "Ruination", "Stone Edge", "Throat Chop"],
-                "teraTypes": ["Fighting", "Ground", "Poison", "Steel"]
+                "role": "Bulky Attacker",
+                "movepool": ["Earthquake", "Heavy Slam", "Ruination", "Spikes", "Stealth Rock", "Throat Chop"],
+                "teraTypes": ["Ghost", "Poison", "Steel"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1928,7 +1928,7 @@
                 "teraTypes": ["Dark", "Fire", "Grass", "Ground", "Poison"]
             },
             {
-                "role": "Fast Bulky Setup",
+                "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Gunk Shot", "Swords Dance", "Trailblaze"],
                 "teraTypes": ["Grass", "Ground"]
             }
@@ -3288,7 +3288,7 @@
                 "teraTypes": ["Fire"]
             },
             {
-                "role": "Fast Bulky Setup",
+                "role": "Setup Sweeper",
                 "movepool": ["Bulk Up", "Drain Punch", "Flare Blitz", "Trailblaze"],
                 "teraTypes": ["Fighting", "Grass"]
             }

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -4411,11 +4411,6 @@
                 "role": "Bulky Support",
                 "movepool": ["Beak Blast", "Boomburst", "Bullet Seed", "Knock Off", "Roost", "U-turn"],
                 "teraTypes": ["Steel"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Beak Blast", "Boomburst", "Flash Cannon", "Heat Wave", "Roost"],
-                "teraTypes": ["Normal"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1929,7 +1929,7 @@
             },
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Swords Dance", "Earthquake", "Gunk Shot", "Trailblaze"],
+                "movepool": ["Earthquake", "Gunk Shot", "Swords Dance", "Trailblaze"],
                 "teraTypes": ["Grass", "Ground"]
             }
         ]

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -122,7 +122,7 @@ const PRIORITY_POKEMON = [
 
 /** Pokemon who should never be in the lead slot */
 const NO_LEAD_POKEMON = [
-	'Zacian', 'Zamazenta',
+	'Iron Boulder', 'Zacian', 'Zamazenta',
 ];
 const DOUBLES_NO_LEAD_POKEMON = [
 	'Basculegion', 'Houndstone', 'Roaring Moon', 'Zacian', 'Zamazenta',
@@ -1137,6 +1137,7 @@ export class RandomTeams {
 
 		// Hard-code abilities here
 		if (species.id === 'florges') return 'Flower Veil';
+		if (species.id === 'bombirdier' && !counter.get('Rock')) return 'Big Pecks';
 		if (species.id === 'scovillain') return 'Chlorophyll';
 		if (species.id === 'empoleon') return 'Competitive';
 		if (species.id === 'swampert' && !counter.get('Water') && !moves.has('flipturn')) return 'Damp';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1147,7 +1147,7 @@ export class RandomTeams {
 		if (abilities.has('Guts') && (moves.has('facade') || moves.has('sleeptalk') || species.id === 'gurdurr')) return 'Guts';
 		if (species.id === 'copperajah' && moves.has('heavyslam')) return 'Heavy Metal';
 		if (species.id === 'jumpluff') return 'Infiltrator';
-		if (species.id === 'toucannon' && !counter.get('sheerforce') && !counter.get('skilllink')) return 'Keen Eye';
+		if (species.id === 'toucannon' && !counter.get('skilllink')) return 'Keen Eye';
 		if (species.id === 'reuniclus') return (role === 'AV Pivot') ? 'Regenerator' : 'Magic Guard';
 		if (species.id === 'smeargle') return 'Own Tempo';
 		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it


### PR DESCRIPTION
End-month changes. Level balancing to come soon. Either merge this ASAP or after we handle whatever conflicts.

Changes marked with _*_ reduce the rate of choice items.
Changes marked with _^_ were performed after consultation with the Random Battles PS! room as part of the Set Development Workshop room project.

-Iron Boulder will no longer be a lead, and will therefore no longer get Leftovers. (Council decision)
-Vileplume now has a second set of Setup Sweeper with Sunny Day Tera Fire Weather Ball and a Life Orb.
-Muk and Alolan Muk now have an additional set of Bulky Setup with Curse, Knock Off, Gunk Shot/Poison Jab, Drain Punch, and Rest, with Leftovers or a Chesto Berry. _*_
-Kyurem now has an additional set of Bulky Setup with Substitute + Protect + Earth Power + Freeze Dry, with Leftovers. _*_
-Seviper now has an additional set of Fast Bulky Setup with Swords Dance, Trailblaze, Earthquake, and Gunk Shot, with Leftovers. Tera Ground/Grass. _*_
-Meganium now has a second set of Setup Sweeper with Swords Dance, Earthquake, Knock Off, and Petal Blizzard, with a Life Orb. _^_
-Bombirdier's sets have been revamped. The preexisting set now has Roost instead of Hone Claws, and it has gained a second set of Bulky Support that **does not have Stone Edge**. I do not know why everyone wanted this outcome in particular. _^_ _*_
-Ting Lu's second set has been changed to Bulky Attacker; as such:
--Set 1: -Ruination (to prevent too much set overlap, and also to prevent Ruination + Whirlwind hazardless)
--Set 2: -Tera Fighting, -Tera Ground, -Stone Edge, -Body Press, +Tera Ghost, +Spikes, +Stealth Rock 
--the rate of Assault Vest has been lowered to around 10%

-U-turn Illumise no longer exists.
-RestTalk Duraludon no longer exists.
-Sheer Force Life Orb Toucannon no longer exists.

-Lycanroc (Midday): -Drill Run _*_
-Bastiodon: -Stone Edge, +Foul Play
-Smeargle: +Glare
-All Grimmsnarl sets: -Tera Fairy, +Tera Poison, +Tera Steel
-Oricorio-Pom-Pom: -Defog
-All Metagross sets: -Meteor Mash, +Heavy Slam
-Deoxys and Deoxys-Attack: +Tera Stellar to both sets
-Pyroar: +Taunt