### PR TITLE
Fix /randpoke and /randmove not finding newer moves in old rooms

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -180,7 +180,11 @@ export const commands: Chat.ChatCommands = {
 			}
 		}
 		if (!qty) targetsBuffer.push("random1");
-
+		const defaultFormat = this.extractFormat(room?.settings.defaultFormat || room?.battle?.format);
+		if (!target.includes('mod=')) {
+			const dex = defaultFormat.dex;
+			if (dex) targetsBuffer.push(`mod=${dex.currentMod}`);
+		}
 		const response = await runSearch({
 			target: targetsBuffer.join(","),
 			cmd: 'randmove',
@@ -227,7 +231,11 @@ export const commands: Chat.ChatCommands = {
 			}
 		}
 		if (!qty) targetsBuffer.push("random1");
-
+		const defaultFormat = this.extractFormat(room?.settings.defaultFormat || room?.battle?.format);
+		if (!target.includes('mod=')) {
+			const dex = defaultFormat.dex;
+			if (dex) targetsBuffer.push(`mod=${dex.currentMod}`);
+		}
 		const response = await runSearch({
 			target: targetsBuffer.join(","),
 			cmd: 'randpoke',


### PR DESCRIPTION
https://www.smogon.com/forums/threads/randpoke-pokemon-not-found-in-old-gen-battles.3733420/

Mathy's fix basically