### PR TITLE
Gen 4 Doubles OU: Ban Snow Cloak

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3648,8 +3648,8 @@ export const Formats: FormatList = [
 		mod: 'gen4',
 		gameType: 'doubles',
 		// searchShow: false,
-		ruleset: ['Standard'],
-		banlist: ['AG', 'Uber', 'Soul Dew', 'Dark Void', 'Sand Veil'],
+		ruleset: ['Standard', 'Evasion Abilities Clause'],
+		banlist: ['AG', 'Uber', 'Soul Dew', 'Dark Void'],
 		unbanlist: ['Manaphy', 'Mew', 'Salamence', 'Wobbuffet', 'Wynaut'],
 	},
 


### PR DESCRIPTION
https://www.smogon.com/forums/threads/dpp-doubles-ou.3717286/page-4#post-9899140

Snow cloak was banned, simplifying ruleset to be evasion abilities clause now that both are banned