### PR TITLE
Normalize Terapagos level scaling in Challenge Cup

### DIFF
--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1985,6 +1985,8 @@ export class RandomTeams {
 			let stats = species.baseStats;
 			// If Wishiwashi, use the school-forme's much higher stats
 			if (species.baseSpecies === 'Wishiwashi') stats = Dex.species.get('wishiwashischool').baseStats;
+			// If Terapagos, use Terastal-forme's stats
+			if (species.baseSpecies === 'Terapagos') stats = Dex.species.get('terapagosterastal').baseStats;
 
 			// Modified base stat total assumes 31 IVs, 85 EVs in every stat
 			let mbst = (stats["hp"] * 2 + 31 + 21 + 100) + 10;


### PR DESCRIPTION
Terapagos's level scaling in Challenge Cup is based on its base form's BST 450 instead of the 600 it actually makes use of in all practical senses. This leads to it being quite a bit higher leveled than similarly situated Pokémon.

This approach is simple and has precedent already for Wishiwashi.