### PR TITLE
Fortemons: Restrict Tera Blast

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -728,7 +728,7 @@ export const Formats: FormatList = [
 		],
 		restricted: [
 			'Dynamic Punch', 'Flail', 'Flip Turn', 'Fury Cutter', 'Grass Knot', 'Grassy Glide', 'Hard Press', 'Heavy Slam', 'Heat Crash',
-			'Inferno', 'Low Kick', 'Nuzzle', 'Power Trip', 'Reversal', 'Spit Up', 'Stored Power', 'Tera Blast', 'Volt Switch', 'Zap Cannon',
+			'Inferno', 'Low Kick', 'Nuzzle', 'Power Trip', 'Reversal', 'Tera Blast', 'Spit Up', 'Stored Power', 'Volt Switch', 'Zap Cannon',
 		],
 		onValidateTeam(team) {
 			const itemTable = new Set<string>();


### PR DESCRIPTION
Tera Blast is bugged and changes the BP of moves even when you dont tera, so lets restrict the move for now, terastal clause is in effect anyway, so there is no need to fix this right now  https://www.smogon.com/forums/threads/fortemons.3713983/page-15#post-9917618 replay https://replay.pokemonshowdown.com/gen9fortemons-2025537671