### PR TITLE
Refactor certain basePowerCallback default returns

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -5543,7 +5543,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-combine');
 				return 150;
 			}
-			return 80;
+			return move.basePower;
 		},
 		category: "Special",
 		name: "Fire Pledge",
@@ -7821,7 +7821,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-combine');
 				return 150;
 			}
-			return 80;
+			return move.basePower;
 		},
 		category: "Special",
 		name: "Grass Pledge",
@@ -19939,7 +19939,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			if (pokemon.terastallized === 'Stellar') {
 				return 100;
 			}
-			return 80;
+			return move.basePower;
 		},
 		category: "Special",
 		name: "Tera Blast",
@@ -21307,7 +21307,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-combine');
 				return 150;
 			}
-			return 80;
+			return move.basePower;
 		},
 		category: "Special",
 		name: "Water Pledge",


### PR DESCRIPTION
While not a bug per se, certain moves are hardcoded to return a value equal to move.basePower in basePowerCallback, which does not causes issues up until there is a discrepancy in move.basePower (e.g. https://www.smogon.com/forums/threads/fortemons.3713983/page-15#post-9917618) where moves are called at a base power its not. 