### PR TITLE
Randomized format team generation updates

### DIFF
--- a/data/mods/gen1/random-teams.ts
+++ b/data/mods/gen1/random-teams.ts
@@ -118,14 +118,10 @@ export class RandomGen1Teams extends RandomGen2Teams {
 
 		/** Pokémon that are not wholly incompatible with the team, but still pretty bad */
 		const rejectedButNotInvalidPool: string[] = [];
-		const nuTiers = ['UU', 'UUBL', 'NFE', 'LC', 'NU'];
-		const uuTiers = ['NFE', 'UU', 'UUBL', 'NU'];
 
 		// Now let's store what we are getting.
 		const typeCount: {[k: string]: number} = {};
 		const weaknessCount: {[k: string]: number} = {Electric: 0, Psychic: 0, Water: 0, Ice: 0, Ground: 0, Fire: 0};
-		let uberCount = 0;
-		let nuCount = 0;
 
 		const pokemonPool = this.getPokemonPool(type, pokemon, isMonotype, Object.keys(this.randomData))[0];
 		while (pokemonPool.length && pokemon.length < this.maxTeamSize) {
@@ -140,33 +136,12 @@ export class RandomGen1Teams extends RandomGen2Teams {
 			// Dynamically scale limits for different team sizes. The default and minimum value is 1.
 			const limitFactor = Math.round(this.maxTeamSize / 6) || 1;
 
-			const tier = species.tier;
-			switch (tier) {
-			case 'LC':
-			case 'NFE':
-				// Don't add pre-evo mon if already 4 or more non-OUs
-				// Regardless, pre-evo mons are slightly less common.
-				if (nuCount >= 4 * limitFactor || this.randomChance(1, 3)) continue;
-				break;
-			case 'Uber':
-				// Only allow a single Uber.
-				if (uberCount >= 1 * limitFactor) continue;
-				break;
-			default:
-				// OUs are fine. Otherwise 50% chance to skip mon if already 4 or more non-OUs.
-				if (uuTiers.includes(tier) && pokemonPool.length > 1 && (nuCount >= 4 * limitFactor && this.randomChance(1, 2))) {
-					continue;
-				}
-			}
-
 			let skip = false;
 
 			if (!isMonotype && !this.forceMonotype) {
-				// Limit 2 of any type as well. Diversity and minor weakness count.
-				// The second of a same type has halved chance of being added.
+				// Limit two of any type
 				for (const typeName of species.types) {
-					if (typeCount[typeName] >= 2 * limitFactor ||
-						(typeCount[typeName] >= 1 * limitFactor && this.randomChance(1, 2) && pokemonPool.length > 1)) {
+					if (typeCount[typeName] >= 2 * limitFactor) {
 						skip = true;
 						break;
 					}
@@ -179,7 +154,7 @@ export class RandomGen1Teams extends RandomGen2Teams {
 			}
 
 			// We need a weakness count of spammable attacks to avoid being swept by those.
-			// Spammable attacks are: Thunderbolt, Psychic, Surf, Blizzard, Earthquake.
+			// Spammable attacks are: Thunderbolt, Psychic, Surf, Blizzard, Earthquake, Fire Blast.
 			const pokemonWeaknesses = [];
 			for (const typeName in weaknessCount) {
 				const increaseCount = this.dex.getImmunity(typeName, species) && this.dex.getEffectiveness(typeName, species) > 0;
@@ -212,13 +187,6 @@ export class RandomGen1Teams extends RandomGen2Teams {
 			// Weakness counter.
 			for (const weakness of pokemonWeaknesses) {
 				weaknessCount[weakness]++;
-			}
-
-			// Increment tier bias counters.
-			if (tier === 'Uber') {
-				uberCount++;
-			} else if (nuTiers.includes(tier)) {
-				nuCount++;
 			}
 
 			// Ditto check

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -944,9 +944,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		const type = this.forceMonotype || this.sample(typePool);
 
 		const baseFormes: {[k: string]: number} = {};
-		const tierCount: {[k: string]: number} = {};
 		const typeCount: {[k: string]: number} = {};
-		const typeComboCount: {[k: string]: number} = {};
 		const typeWeaknesses: {[k: string]: number} = {};
 		const teamDetails: RandomTeamsTypes.TeamDetails = {};
 
@@ -970,13 +968,8 @@ export class RandomGen5Teams extends RandomGen6Teams {
 
 			// Dynamically scale limits for different team sizes. The default and minimum value is 1.
 			const limitFactor = Math.round(this.maxTeamSize / 6) || 1;
-			const tier = species.tier;
-
-			// Limit two Pokemon per tier
-			if (this.gen === 5 && !isMonotype && !this.forceMonotype && tierCount[tier] >= 2 * limitFactor) continue;
 
 			const types = species.types;
-			const typeCombo = types.slice().sort().join();
 
 			if (!isMonotype && !this.forceMonotype) {
 				let skip = false;
@@ -1002,9 +995,6 @@ export class RandomGen5Teams extends RandomGen6Teams {
 					}
 				}
 				if (skip) continue;
-
-				// Limit one of any type combination
-				if (typeComboCount[typeCombo] >= 1 * limitFactor) continue;
 			}
 
 			const set = this.randomSet(species, teamDetails, pokemon.length === 0);
@@ -1018,13 +1008,6 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			// Now that our Pokemon has passed all checks, we can increment our counters
 			baseFormes[species.baseSpecies] = 1;
 
-			// Increment tier counter
-			if (tierCount[tier]) {
-				tierCount[tier]++;
-			} else {
-				tierCount[tier] = 1;
-			}
-
 			// Increment type counters
 			for (const typeName of types) {
 				if (typeName in typeCount) {
@@ -1032,11 +1015,6 @@ export class RandomGen5Teams extends RandomGen6Teams {
 				} else {
 					typeCount[typeName] = 1;
 				}
-			}
-			if (typeCombo in typeComboCount) {
-				typeComboCount[typeCombo]++;
-			} else {
-				typeComboCount[typeCombo] = 1;
 			}
 
 			// Increment weakness counter

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -2498,6 +2498,10 @@ export class RandomGen8Teams {
 
 			const types = species.types;
 			const typeCombo = types.slice().sort().join();
+			const weakToFreezeDry = (
+				this.dex.getEffectiveness('Ice', species) > 0 ||
+				(this.dex.getEffectiveness('Ice', species) > -2 && types.includes('Water'))
+			);
 			// Dynamically scale limits for different team sizes. The default and minimum value is 1.
 			const limitFactor = Math.round(this.maxTeamSize / 6) || 1;
 
@@ -2525,10 +2529,16 @@ export class RandomGen8Teams {
 					}
 				}
 				if (skip) continue;
+
+				// Limit four weak to Freeze-Dry
+				if (weakToFreezeDry) {
+					if (!typeWeaknesses['Freeze-Dry']) typeWeaknesses['Freeze-Dry'] = 0;
+					if (typeWeaknesses['Freeze-Dry'] >= 4 * limitFactor) continue;
+				}
 			}
 
-			// Limit one of any type combination, three in Monotype
-			if (!this.forceMonotype && typeComboCount[typeCombo] >= (isMonotype ? 3 : 1) * limitFactor) continue;
+			// Limit three of any type combination in Monotype
+			if (!this.forceMonotype && isMonotype && (typeComboCount[typeCombo] >= 3 * limitFactor)) continue;
 
 			// The Pokemon of the Day
 			if (potd?.exists && (pokemon.length === 1 || this.maxTeamSize === 1)) species = potd;
@@ -2565,6 +2575,7 @@ export class RandomGen8Teams {
 					typeWeaknesses[typeName]++;
 				}
 			}
+			if (weakToFreezeDry) typeWeaknesses['Freeze-Dry']++;
 
 			// Track what the team has
 			if (set.ability === 'Drizzle' || set.moves.includes('raindance')) teamDetails.rain = 1;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1795,6 +1795,10 @@ export class RandomTeams {
 
 			const types = species.types;
 			const typeCombo = types.slice().sort().join();
+			const weakToFreezeDry = (
+				this.dex.getEffectiveness('Ice', species) > 0 ||
+				(this.dex.getEffectiveness('Ice', species) > -2 && types.includes('Water'))
+			);
 			// Dynamically scale limits for different team sizes. The default and minimum value is 1.
 			const limitFactor = Math.round(this.maxTeamSize / 6) || 1;
 
@@ -1822,10 +1826,16 @@ export class RandomTeams {
 					}
 				}
 				if (skip) continue;
+
+				// Limit four weak to Freeze-Dry
+				if (weakToFreezeDry) {
+					if (!typeWeaknesses['Freeze-Dry']) typeWeaknesses['Freeze-Dry'] = 0;
+					if (typeWeaknesses['Freeze-Dry'] >= 4 * limitFactor) continue;
+				}
 			}
 
-			// Limit one of any type combination, three in Monotype
-			if (!this.forceMonotype && typeComboCount[typeCombo] >= (isMonotype ? 3 : 1) * limitFactor) continue;
+			// Limit three of any type combination in Monotype
+			if (!this.forceMonotype && isMonotype && (typeComboCount[typeCombo] >= 3 * limitFactor)) continue;
 
 			// The Pokemon of the Day
 			if (potd?.exists && (pokemon.length === 1 || this.maxTeamSize === 1)) species = potd;
@@ -1877,6 +1887,7 @@ export class RandomTeams {
 					typeWeaknesses[typeName]++;
 				}
 			}
+			if (weakToFreezeDry) typeWeaknesses['Freeze-Dry']++;
 
 			// Track what the team has
 			if (set.ability === 'Drizzle' || set.moves.includes('raindance')) teamDetails.rain = 1;


### PR DESCRIPTION
This implements several changes to team generation.

-Removes the limit of one Pokemon per unique type combination in gens 4-9. (They were removed for gens 2-3 in https://github.com/smogon/pokemon-showdown/pull/10056). This means it is now possible to get, for example, Kyogre and Barraskewda on the same team. Monotype will still have a limit of three Pokemon of a type combination in gens 6-9.
-Implements a limit of four Pokemon weak to Freeze-Dry in gens 6-9. Testing has shown that its effect on team generation is negligible.
-Removes tier limits from gens 5, 6, and 7, since they no longer have Pokemon consistently attaining a winrate over 53%.
-Removes tier limits and the soft type cap from gen 1.