### PR TITLE
Randbats Stats: Properly check for winner

### DIFF
--- a/server/chat-plugins/randombattles/winrates.ts
+++ b/server/chat-plugins/randombattles/winrates.ts
@@ -176,7 +176,7 @@ async function collectStats(battle: RoomBattle, winner: ID, players: ID[]) {
 		for (const mon of mons) {
 			if (!formatData.mons[mon]) formatData.mons[mon] = {timesGenerated: 0, numWins: 0};
 			formatData.mons[mon].timesGenerated++;
-			if (toID(winner) === toID(p)) {
+			if (toID(winner) === toID(p.name)) {
 				formatData.mons[mon].numWins++;
 			}
 		}


### PR DESCRIPTION
upon further inspection, toID(p) apparently just returned an empty string. ``p.name`` accurately gives us a username we can compare to.


It is strongly suggested the data for January's randbats stats gets wiped when this is implemented.