### PR TITLE
Refactor STAB (again)

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1877,15 +1877,17 @@ export const Formats: FormatList = [
 				baseDamage = this.battle.randomizer(baseDamage);
 
 				// STAB
-				const isTeraStellarBoosted = (pokemon.terastallized || pokemon.m.thirdType) === 'Stellar' &&
-					!pokemon.stellarBoostedTypes.includes(type);
-				if (move.forceSTAB || (type !== '???' &&
-					(pokemon.hasType(type) || (pokemon.terastallized && pokemon.getTypes(false, true).includes(type)) ||
-						isTeraStellarBoosted))) {
-					// The "???" type never gets STAB
-					// Not even if you Roost in Gen 4 and somehow manage to use
-					// Struggle in the same turn.
-					// (On second thought, it might be easier to get a MissingNo.)
+				// The "???" type never gets STAB
+				// Not even if you Roost in Gen 4 and somehow manage to use
+				// Struggle in the same turn.
+				// (On second thought, it might be easier to get a MissingNo.)
+				if (type !== '???') {
+					let stab: number | [number, number] = 1;
+
+					const isSTAB = move.forceSTAB || pokemon.hasType(type) || pokemon.getTypes(false, true).includes(type);
+					if (isSTAB) {
+						stab = 1.5;
+					}
 
 					// The Stellar tera type makes this incredibly confusing
 					// If the move's type does not match one of the user's base types,
@@ -1894,22 +1896,20 @@ export const Formats: FormatList = [
 					// If the move's type does match one of the user's base types,
 					// then the Stellar tera type applies a one-time 2x STAB boost for that type,
 					// and then goes back to using the regular 1.5x STAB boost for those types.
-
-					let stab: number | [number, number];
-					if (isTeraStellarBoosted) {
-						stab = pokemon.getTypes(false, true).includes(type) ? 2 : [4915, 4096];
-						if (pokemon.species.name !== 'Terapagos-Stellar') {
-							pokemon.stellarBoostedTypes.push(type);
+					if ((pokemon.terastallized || pokemon.m.thirdType) === 'Stellar') {
+						if (!pokemon.stellarBoostedTypes.includes(type)) {
+							stab = isSTAB ? 2 : [4915, 4096];
+							if (pokemon.species.name !== 'Terapagos-Stellar') {
+								pokemon.stellarBoostedTypes.push(type);
+							}
 						}
 					} else {
-						stab = move.stab || 1.5;
-						if (type === pokemon.terastallized && pokemon.getTypes(false, true).includes(type)) {
-							// In my defense, the game hardcodes the Adaptability check like this, too.
-							stab = stab === 2 ? 2.25 : 2;
-						} else if (pokemon.terastallized && type !== pokemon.terastallized) {
-							stab = 1.5;
+						if (pokemon.terastallized === type && pokemon.getTypes(false, true).includes(type)) {
+							stab = 2;
 						}
+						stab = this.battle.runEvent('ModifySTAB', pokemon, target, move, stab);
 					}
+
 					baseDamage = this.battle.modify(baseDamage, stab);
 				}
 

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -42,7 +42,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	},
 	adaptability: {
 		onModifySTAB(stab, source, target, move) {
-			if (source.hasType(move.type)) {
+			if (move.forceSTAB || source.hasType(move.type)) {
 				if (stab === 2) {
 					return 2.25;
 				}

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -41,8 +41,13 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		num: 0,
 	},
 	adaptability: {
-		onModifyMove(move) {
-			move.stab = 2;
+		onModifySTAB(stab, source, target, move) {
+			if (source.hasType(move.type)) {
+				if (stab === 2) {
+					return 2.25;
+				}
+				return 2;
+			}
 		},
 		flags: {},
 		name: "Adaptability",

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -388,7 +388,14 @@ export const Conditions: {[k: string]: ConditionData} = {
 			target.removeVolatile('Protect');
 			target.removeVolatile('Endure');
 
+			if (data.source.hasAbility('infiltrator') && this.gen >= 6) {
+				data.moveData.infiltrates = true;
+			}
+			if (data.source.hasAbility('normalize') && this.gen >= 6) {
+				data.moveData.type = 'Normal';
+			}
 			const hitMove = new this.dex.Move(data.moveData) as ActiveMove;
+
 			this.actions.trySpreadMoveHit([target], data.source, hitMove, true);
 			if (data.source.isActive && data.source.hasItem('lifeorb') && this.gen >= 5) {
 				this.singleEvent('AfterMoveSecondarySelf', data.source.getItem(), data.source.itemState, data.source, target, data.source.getItem());

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -388,17 +388,7 @@ export const Conditions: {[k: string]: ConditionData} = {
 			target.removeVolatile('Protect');
 			target.removeVolatile('Endure');
 
-			if (data.source.hasAbility('infiltrator') && this.gen >= 6) {
-				data.moveData.infiltrates = true;
-			}
-			if (data.source.hasAbility('normalize') && this.gen >= 6) {
-				data.moveData.type = 'Normal';
-			}
-			if (data.source.hasAbility('adaptability') && this.gen >= 6) {
-				data.moveData.stab = 2;
-			}
 			const hitMove = new this.dex.Move(data.moveData) as ActiveMove;
-
 			this.actions.trySpreadMoveHit([target], data.source, hitMove, true);
 			if (data.source.isActive && data.source.hasItem('lifeorb') && this.gen >= 5) {
 				this.singleEvent('AfterMoveSecondarySelf', data.source.getItem(), data.source.itemState, data.source, target, data.source.getItem());

--- a/data/mods/gen3/scripts.ts
+++ b/data/mods/gen3/scripts.ts
@@ -70,12 +70,17 @@ export const Scripts: ModdedBattleScriptsData = {
 			baseDamage = Math.floor(this.battle.runEvent('ModifyDamagePhase2', pokemon, target, move, baseDamage));
 
 			// STAB
-			if (move.forceSTAB || type !== '???' && pokemon.hasType(type)) {
-				// The "???" type never gets STAB
-				// Not even if you Roost in Gen 4 and somehow manage to use
-				// Struggle in the same turn.
-				// (On second thought, it might be easier to get a MissingNo.)
-				baseDamage = this.battle.modify(baseDamage, move.stab || 1.5);
+			// The "???" type never gets STAB
+			// Not even if you Roost in Gen 4 and somehow manage to use
+			// Struggle in the same turn.
+			// (On second thought, it might be easier to get a MissingNo.)
+			if (type !== '???') {
+				let stab: number | [number, number] = 1;
+				if (move.forceSTAB || pokemon.hasType(type)) {
+					stab = 1.5;
+				}
+				stab = this.battle.runEvent('ModifySTAB', pokemon, target, move, stab);
+				baseDamage = this.battle.modify(baseDamage, stab);
 			}
 			// types
 			let typeMod = target.runEffectiveness(move);

--- a/data/mods/gen4/scripts.ts
+++ b/data/mods/gen4/scripts.ts
@@ -47,12 +47,17 @@ export const Scripts: ModdedBattleScriptsData = {
 			baseDamage = this.battle.randomizer(baseDamage);
 
 			// STAB
-			if (move.forceSTAB || type !== '???' && pokemon.hasType(type)) {
-				// The "???" type never gets STAB
-				// Not even if you Roost in Gen 4 and somehow manage to use
-				// Struggle in the same turn.
-				// (On second thought, it might be easier to get a MissingNo.)
-				baseDamage = this.battle.modify(baseDamage, move.stab || 1.5);
+			// The "???" type never gets STAB
+			// Not even if you Roost in Gen 4 and somehow manage to use
+			// Struggle in the same turn.
+			// (On second thought, it might be easier to get a MissingNo.)
+			if (type !== '???') {
+				let stab: number | [number, number] = 1;
+				if (move.forceSTAB || pokemon.hasType(type)) {
+					stab = 1.5;
+				}
+				stab = this.battle.runEvent('ModifySTAB', pokemon, target, move, stab);
+				baseDamage = this.battle.modify(baseDamage, stab);
 			}
 			// types
 			let typeMod = target.runEffectiveness(move);

--- a/data/mods/gennext/abilities.ts
+++ b/data/mods/gennext/abilities.ts
@@ -644,7 +644,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	},
 	adaptability: {
 		inherit: true,
-		onModifyMove(move) {},
+		onModifySTAB() {},
 		onBasePower(power, attacker, defender, move) {
 			if (!attacker.hasType(move.type)) {
 				return this.chainModify(1.33);

--- a/data/mods/ssb/abilities.ts
+++ b/data/mods/ssb/abilities.ts
@@ -208,7 +208,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			if (attacker.species.name !== targetForme) attacker.formeChange(targetForme);
 		},
 		onModifySTAB(stab, source, target, move) {
-			if (source.hasType(move.type)) {
+			if (move.forceSTAB || source.hasType(move.type)) {
 				return 2;
 			}
 		},
@@ -1009,7 +1009,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		desc: "This Pokemon's moves that match one of its types have a same-type attack bonus of 2 instead of 1.5. If this Pokemon is at full HP, it survives one hit with at least 1 HP.",
 		shortDesc: "Adaptability + Sturdy.",
 		onModifySTAB(stab, source, target, move) {
-			if (source.hasType(move.type)) {
+			if (move.forceSTAB || source.hasType(move.type)) {
 				return 2;
 			}
 		},
@@ -1566,7 +1566,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		shortDesc: "Adaptability + Randomly changes to the type of one of its moves every turn.",
 		name: "Wild Magic Surge",
 		onModifySTAB(stab, source, target, move) {
-			if (source.hasType(move.type)) {
+			if (move.forceSTAB || source.hasType(move.type)) {
 				return 2;
 			}
 		},

--- a/data/mods/ssb/abilities.ts
+++ b/data/mods/ssb/abilities.ts
@@ -202,11 +202,15 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			this.add('-message', `aegii currently has a ${setType} oriented set.`);
 		},
 		onModifyMove(move, attacker, defender) {
-			move.stab = 2;
 			if (attacker.species.baseSpecies !== 'Aegislash' || attacker.transformed) return;
 			if (move.category === 'Status' && move.id !== 'kingsshield' && move.id !== 'reset') return;
 			const targetForme = (move.id === 'kingsshield' || move.id === 'reset' ? 'Aegislash' : 'Aegislash-Blade');
 			if (attacker.species.name !== targetForme) attacker.formeChange(targetForme);
+		},
+		onModifySTAB(stab, source, target, move) {
+			if (source.hasType(move.type)) {
+				return 2;
+			}
 		},
 		name: "Set the Stage",
 		gen: 8,
@@ -1004,8 +1008,10 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	deceiver: {
 		desc: "This Pokemon's moves that match one of its types have a same-type attack bonus of 2 instead of 1.5. If this Pokemon is at full HP, it survives one hit with at least 1 HP.",
 		shortDesc: "Adaptability + Sturdy.",
-		onModifyMove(move) {
-			move.stab = 2;
+		onModifySTAB(stab, source, target, move) {
+			if (source.hasType(move.type)) {
+				return 2;
+			}
 		},
 		onTryHit(pokemon, target, move) {
 			if (move.ohko) {
@@ -1559,8 +1565,10 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		desc: "Randomly changes this Pokemon's type at the end of every turn to the type of one of its moves; same-type attack bonus (STAB) is 2 instead of 1.5.",
 		shortDesc: "Adaptability + Randomly changes to the type of one of its moves every turn.",
 		name: "Wild Magic Surge",
-		onModifyMove(move) {
-			move.stab = 2;
+		onModifySTAB(stab, source, target, move) {
+			if (source.hasType(move.type)) {
+				return 2;
+			}
 		},
 		onResidual(pokemon) {
 			if (!pokemon.hp) return;

--- a/data/mods/vaporemons/abilities.ts
+++ b/data/mods/vaporemons/abilities.ts
@@ -1608,7 +1608,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	},
 	adaptability: {
 		onModifySTAB(stab, source, target, move) {
-			if (source.hasType(move.type)) {
+			if (move.forceSTAB || source.hasType(move.type)) {
 				if (move.type === source.teraType && source.baseSpecies.types.includes(source.teraType) &&
 					source.hasItem('terashard')) {
 					return 2.25;

--- a/data/mods/vaporemons/abilities.ts
+++ b/data/mods/vaporemons/abilities.ts
@@ -1607,12 +1607,13 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		num: 168,
 	},
 	adaptability: {
-		onModifyMove(move, pokemon) {
-			if (move.type === pokemon.teraType && pokemon.baseSpecies.types.includes(pokemon.teraType) &&
-				 pokemon.hasItem('terashard')) {
-				move.stab = 2.25;
-			} else {
-				move.stab = 2;
+		onModifySTAB(stab, source, target, move) {
+			if (source.hasType(move.type)) {
+				if (move.type === source.teraType && source.baseSpecies.types.includes(source.teraType) &&
+					source.hasItem('terashard')) {
+					return 2.25;
+				}
+				return 2;
 			}
 		},
 		name: "Adaptability",

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -1734,14 +1734,17 @@ export class BattleActions {
 		baseDamage = this.battle.randomizer(baseDamage);
 
 		// STAB
-		const isTeraStellarBoosted = pokemon.terastallized === 'Stellar' && !pokemon.stellarBoostedTypes.includes(type);
-		if (move.forceSTAB || (type !== '???' &&
-			(pokemon.hasType(type) || (pokemon.terastallized && pokemon.getTypes(false, true).includes(type)) ||
-				isTeraStellarBoosted))) {
-			// The "???" type never gets STAB
-			// Not even if you Roost in Gen 4 and somehow manage to use
-			// Struggle in the same turn.
-			// (On second thought, it might be easier to get a MissingNo.)
+		// The "???" type never gets STAB
+		// Not even if you Roost in Gen 4 and somehow manage to use
+		// Struggle in the same turn.
+		// (On second thought, it might be easier to get a MissingNo.)
+		if (type !== '???') {
+			let stab: number | [number, number] = 1;
+
+			const isSTAB = move.forceSTAB || pokemon.hasType(type) || pokemon.getTypes(false, true).includes(type);
+			if (isSTAB) {
+				stab = 1.5;
+			}
 
 			// The Stellar tera type makes this incredibly confusing
 			// If the move's type does not match one of the user's base types,
@@ -1750,22 +1753,20 @@ export class BattleActions {
 			// If the move's type does match one of the user's base types,
 			// then the Stellar tera type applies a one-time 2x STAB boost for that type,
 			// and then goes back to using the regular 1.5x STAB boost for those types.
-
-			let stab: number | [number, number];
-			if (isTeraStellarBoosted) {
-				stab = pokemon.getTypes(false, true).includes(type) ? 2 : [4915, 4096];
-				if (pokemon.species.name !== 'Terapagos-Stellar') {
-					pokemon.stellarBoostedTypes.push(type);
+			if (pokemon.terastallized === 'Stellar') {
+				if (!pokemon.stellarBoostedTypes.includes(type)) {
+					stab = isSTAB ? 2 : [4915, 4096];
+					if (pokemon.species.name !== 'Terapagos-Stellar') {
+						pokemon.stellarBoostedTypes.push(type);
+					}
 				}
 			} else {
-				stab = move.stab || 1.5;
-				if (type === pokemon.terastallized && pokemon.getTypes(false, true).includes(type)) {
-					// In my defense, the game hardcodes the Adaptability check like this, too.
-					stab = stab === 2 ? 2.25 : 2;
-				} else if (pokemon.terastallized && type !== pokemon.terastallized) {
-					stab = 1.5;
+				if (pokemon.terastallized === type && pokemon.getTypes(false, true).includes(type)) {
+					stab = 2;
 				}
+				stab = this.battle.runEvent('ModifySTAB', pokemon, target, move, stab);
 			}
+
 			baseDamage = this.battle.modify(baseDamage, stab);
 		}
 

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -65,6 +65,7 @@ export interface EventMethods {
 	onModifySpA?: CommonHandlers['ModifierSourceMove'];
 	onModifySpD?: CommonHandlers['ModifierMove'];
 	onModifySpe?: (this: Battle, spe: number, pokemon: Pokemon) => number | void;
+	onModifySTAB?: CommonHandlers['ModifierSourceMove'];
 	onModifyWeight?: (this: Battle, weighthg: number, pokemon: Pokemon) => number | void;
 	onMoveAborted?: CommonHandlers['VoidMove'];
 	onNegateImmunity?: ((this: Battle, pokemon: Pokemon, type: string) => boolean | void) | boolean;
@@ -164,6 +165,7 @@ export interface EventMethods {
 	onFoeModifySpA?: CommonHandlers['ModifierSourceMove'];
 	onFoeModifySpD?: CommonHandlers['ModifierMove'];
 	onFoeModifySpe?: (this: Battle, spe: number, pokemon: Pokemon) => number | void;
+	onFoeModifySTAB?: CommonHandlers['ModifierSourceMove'];
 	onFoeModifyType?: MoveEventMethods['onModifyType'];
 	onFoeModifyTarget?: MoveEventMethods['onModifyTarget'];
 	onFoeModifyWeight?: (this: Battle, weighthg: number, pokemon: Pokemon) => number | void;
@@ -262,6 +264,7 @@ export interface EventMethods {
 	onSourceModifySpA?: CommonHandlers['ModifierSourceMove'];
 	onSourceModifySpD?: CommonHandlers['ModifierMove'];
 	onSourceModifySpe?: (this: Battle, spe: number, pokemon: Pokemon) => number | void;
+	onSourceModifySTAB?: CommonHandlers['ModifierSourceMove'];
 	onSourceModifyType?: MoveEventMethods['onModifyType'];
 	onSourceModifyTarget?: MoveEventMethods['onModifyTarget'];
 	onSourceModifyWeight?: (this: Battle, weighthg: number, pokemon: Pokemon) => number | void;
@@ -362,6 +365,7 @@ export interface EventMethods {
 	onAnyModifySpA?: CommonHandlers['ModifierSourceMove'];
 	onAnyModifySpD?: CommonHandlers['ModifierMove'];
 	onAnyModifySpe?: (this: Battle, spe: number, pokemon: Pokemon) => number | void;
+	onAnyModifySTAB?: CommonHandlers['ModifierSourceMove'];
 	onAnyModifyType?: MoveEventMethods['onModifyType'];
 	onAnyModifyTarget?: MoveEventMethods['onModifyTarget'];
 	onAnyModifyWeight?: (this: Battle, weighthg: number, pokemon: Pokemon) => number | void;
@@ -451,6 +455,7 @@ export interface EventMethods {
 	onModifySpAPriority?: number;
 	onModifySpDPriority?: number;
 	onModifySpePriority?: number;
+	onModifySTABPriority?: number;
 	onModifyTypePriority?: number;
 	onModifyWeightPriority?: number;
 	onRedirectTargetPriority?: number;
@@ -527,6 +532,7 @@ export interface PokemonEventMethods extends EventMethods {
 	onAllyModifySpA?: CommonHandlers['ModifierSourceMove'];
 	onAllyModifySpD?: CommonHandlers['ModifierMove'];
 	onAllyModifySpe?: (this: Battle, spe: number, pokemon: Pokemon) => number | void;
+	onAllyModifySTAB?: CommonHandlers['ModifierSourceMove'];
 	onAllyModifyType?: MoveEventMethods['onModifyType'];
 	onAllyModifyTarget?: MoveEventMethods['onModifyTarget'];
 	onAllyModifyWeight?: (this: Battle, weighthg: number, pokemon: Pokemon) => number | void;

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -331,7 +331,6 @@ export interface ActiveMove extends MutableMove, RuinableMove {
 	selfDropped?: boolean;
 	selfSwitch?: 'copyvolatile' | 'shedtail' | boolean;
 	spreadHit?: boolean;
-	stab?: number;
 	statusRoll?: string;
 	totalDamage?: number | false;
 	typeChangerBoosted?: Effect;
@@ -466,8 +465,6 @@ export class DataMove extends BasicEffect implements Readonly<BasicEffect & Move
 	readonly forceSTAB: boolean;
 	/** True if it can't be copied with Sketch. */
 	readonly noSketch: boolean;
-	/** STAB multiplier (can be modified by other effects) (default 1.5). */
-	readonly stab?: number;
 
 	readonly volatileStatus?: ID;
 
@@ -511,7 +508,6 @@ export class DataMove extends BasicEffect implements Readonly<BasicEffect & Move
 		this.spreadHit = data.spreadHit || false;
 		this.forceSTAB = !!data.forceSTAB;
 		this.noSketch = !!data.noSketch;
-		this.stab = data.stab || undefined;
 		this.volatileStatus = typeof data.volatileStatus === 'string' ? (data.volatileStatus as ID) : undefined;
 
 		if (this.category !== 'Status' && !this.maxMove && this.id !== 'struggle') {


### PR DESCRIPTION
Originally was just trying to fix a bug with the pledge moves and tera stellar (combined pledge moves should always be boosted to 2x by tera stellar), but may have gotten a little carried away. Anyway, this changes the STAB code to much more closely resemble the actual STAB code from the games, and introduces a new `ModifySTAB` event to further improve the separation and readability of the Adaptability logic.