### PR TITLE
Remove unlinkUser

### DIFF
--- a/server/chat-plugins/hangman.ts
+++ b/server/chat-plugins/hangman.ts
@@ -45,6 +45,7 @@ try {
 const maxMistakes = 6;
 
 export class Hangman extends Rooms.SimpleRoomGame {
+	override readonly gameid = 'hangman' as ID;
 	gameNumber: number;
 	creator: ID;
 	word: string;
@@ -69,7 +70,6 @@ export class Hangman extends Rooms.SimpleRoomGame {
 
 		this.gameNumber = room.nextGameNumber();
 
-		this.gameid = 'hangman' as ID;
 		this.title = 'Hangman';
 		this.creator = user.id;
 		this.word = word;

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -176,41 +176,34 @@ export function writeStats(line: string) {
 }
 
 export class HelpTicket extends Rooms.SimpleRoomGame {
-	room: ChatRoom;
+	override readonly gameid = "helpticket" as ID;
+	override readonly allowRenames = true;
+	override room: ChatRoom;
 	ticket: TicketState;
 	claimQueue: string[];
-	involvedStaff: Set<ID>;
+	involvedStaff = new Set<ID>();
 	createTime: number;
 	activationTime: number;
-	emptyRoom: boolean;
-	firstClaimTime: number;
-	unclaimedTime: number;
+	emptyRoom = false;
+	firstClaimTime = 0;
+	unclaimedTime = 0;
 	lastUnclaimedStart: number;
-	closeTime: number;
-	resolution: 'unknown' | 'dead' | 'unresolved' | 'resolved';
-	result: TicketResult | null;
+	closeTime = 0;
+	resolution: 'unknown' | 'dead' | 'unresolved' | 'resolved' = 'unknown';
+	result: TicketResult | null = null;
 
 	constructor(room: ChatRoom, ticket: TicketState) {
 		super(room);
 		this.room = room;
 		this.room.settings.language = Users.get(ticket.creator)?.language || 'english' as ID;
 		this.title = `Help Ticket - ${ticket.type}`;
-		this.gameid = "helpticket" as ID;
-		this.allowRenames = true;
 		this.ticket = ticket;
 		this.claimQueue = [];
 
 		/* Stats */
-		this.involvedStaff = new Set();
 		this.createTime = Date.now();
 		this.activationTime = (ticket.active ? this.createTime : 0);
-		this.emptyRoom = false;
-		this.firstClaimTime = 0;
-		this.unclaimedTime = 0;
 		this.lastUnclaimedStart = (ticket.active ? this.createTime : 0);
-		this.closeTime = 0;
-		this.resolution = 'unknown';
-		this.result = null;
 	}
 
 	onJoin(user: User, connection: Connection) {
@@ -477,14 +470,11 @@ export class HelpTicket extends Rooms.SimpleRoomGame {
 		}
 
 		this.room.game = null;
-		// @ts-ignore
-		this.room = null;
+		(this.room as any) = null;
 		this.setEnded();
 		for (const player of this.players) player.destroy();
-		// @ts-ignore
-		this.players = null;
-		// @ts-ignore
-		this.playerTable = null;
+		(this.players as any) = null;
+		(this.playerTable as any) = null;
 	}
 	onChatMessage(message: string, user: User) {
 		HelpTicket.uploadReplaysFrom(message, user, user.connections[0]);

--- a/server/chat-plugins/helptickets.ts
+++ b/server/chat-plugins/helptickets.ts
@@ -479,9 +479,8 @@ export class HelpTicket extends Rooms.SimpleRoomGame {
 		this.room.game = null;
 		// @ts-ignore
 		this.room = null;
-		for (const player of this.players) {
-			player.destroy();
-		}
+		this.setEnded();
+		for (const player of this.players) player.destroy();
 		// @ts-ignore
 		this.players = null;
 		// @ts-ignore

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -231,6 +231,7 @@ class MafiaPlayer extends Rooms.RoomGamePlayer<Mafia> {
 }
 
 class Mafia extends Rooms.RoomGame<MafiaPlayer> {
+	override readonly gameid = 'mafia' as ID;
 	started: boolean;
 	theme: MafiaDataTheme | null;
 	hostid: ID;
@@ -275,7 +276,6 @@ class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 	constructor(room: ChatRoom, host: User) {
 		super(room);
 
-		this.gameid = 'mafia' as ID;
 		this.title = 'Mafia';
 		this.playerCap = 20;
 		this.allowRenames = false;

--- a/server/chat-plugins/mafia.ts
+++ b/server/chat-plugins/mafia.ts
@@ -280,7 +280,6 @@ class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 		this.playerCap = 20;
 		this.allowRenames = false;
 		this.started = false;
-		this.ended = false;
 
 		this.theme = null;
 
@@ -1016,6 +1015,12 @@ class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 		return this.hasPlurality;
 	}
 
+	override removePlayer(player: MafiaPlayer) {
+		delete this.playerTable[player.id];
+		player.updateHtmlRoom();
+		return super.removePlayer(player);
+	}
+
 	eliminate(toEliminate: string, ability: string) {
 		if (!(toEliminate in this.playerTable || toEliminate in this.dead)) return;
 		if (!this.started) {
@@ -1028,10 +1033,7 @@ class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 			if (this.requestedSub.includes(player.id)) {
 				this.requestedSub.splice(this.requestedSub.indexOf(player.id), 1);
 			}
-			delete this.playerTable[player.id];
-			this.playerCount--;
-			player.updateHtmlRoom();
-			player.destroy();
+			this.removePlayer(player);
 			return;
 		}
 		if (toEliminate in this.playerTable) {
@@ -1081,16 +1083,14 @@ class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 			}
 		}
 		this.clearVotes(player.id);
-		delete this.playerTable[player.id];
 		let subIndex = this.requestedSub.indexOf(player.id);
 		if (subIndex !== -1) this.requestedSub.splice(subIndex, 1);
 		subIndex = this.hostRequestedSub.indexOf(player.id);
 		if (subIndex !== -1) this.hostRequestedSub.splice(subIndex, 1);
 
-		this.playerCount--;
 		this.updateRoleString();
 		this.updatePlayers();
-		player.updateHtmlRoom();
+		this.removePlayer(player);
 	}
 
 	revealRole(user: User, toReveal: MafiaPlayer, revealAs: string) {
@@ -1758,7 +1758,7 @@ class Mafia extends Rooms.RoomGame<MafiaPlayer> {
 	}
 
 	end() {
-		this.ended = true;
+		this.setEnded();
 		this.sendHTML(this.roomWindow());
 		this.updatePlayers();
 		if (this.room.roomid === 'mafia' && this.started) {

--- a/server/chat-plugins/scavengers.ts
+++ b/server/chat-plugins/scavengers.ts
@@ -319,6 +319,7 @@ class ScavengerHuntDatabase {
 	}
 }
 export class ScavengerHunt extends Rooms.RoomGame<ScavengerHuntPlayer> {
+	override readonly gameid = 'scavengerhunt' as ID;
 	gameType: GameTypes;
 	joinedIps: string[];
 	startTime: number;
@@ -330,7 +331,6 @@ export class ScavengerHunt extends Rooms.RoomGame<ScavengerHuntPlayer> {
 	mods: {[k: string]: ModEvent[]};
 	staffHostId: string;
 	staffHostName: string;
-	gameid: ID;
 	scavGame: true;
 	timerEnd: number | null;
 	timer: NodeJS.Timer | null;
@@ -372,7 +372,6 @@ export class ScavengerHunt extends Rooms.RoomGame<ScavengerHuntPlayer> {
 		this.staffHostName = staffHost.name;
 		this.cacheUserIps(staffHost); // store it in case of host subbing
 
-		this.gameid = 'scavengerhunt' as ID;
 		this.title = 'Scavenger Hunt';
 		this.scavGame = true;
 

--- a/server/chat-plugins/trivia/trivia.ts
+++ b/server/chat-plugins/trivia/trivia.ts
@@ -364,7 +364,7 @@ class TriviaPlayer extends Rooms.RoomGamePlayer<Trivia> {
 }
 
 export class Trivia extends Rooms.RoomGame<TriviaPlayer> {
-	gameid: ID;
+	override readonly gameid = 'trivia' as ID;
 	kickedUsers: Set<string>;
 	canLateJoin: boolean;
 	game: TriviaGame;
@@ -383,7 +383,6 @@ export class Trivia extends Rooms.RoomGame<TriviaPlayer> {
 		isRandomMode = false, isSubGame = false, isRandomCategory = false,
 	) {
 		super(room, isSubGame);
-		this.gameid = 'trivia' as ID;
 		this.title = 'Trivia';
 		this.allowRenames = true;
 		this.playerCap = Number.MAX_SAFE_INTEGER;
@@ -1200,6 +1199,7 @@ export class TriumvirateModeTrivia extends Trivia {
  * which is a game of First mode trivia that ends after a specified interval.
  */
 export class Mastermind extends Rooms.SimpleRoomGame {
+	override readonly gameid = 'mastermind' as ID;
 	/** userid:score Map */
 	leaderboard: Map<ID, {score: number, hasLeft?: boolean}>;
 	phase: string;
@@ -1210,7 +1210,6 @@ export class Mastermind extends Rooms.SimpleRoomGame {
 		super(room);
 
 		this.leaderboard = new Map();
-		this.gameid = 'mastermind' as ID;
 		this.title = 'Mastermind';
 		this.allowRenames = true;
 		this.playerCap = Number.MAX_SAFE_INTEGER;

--- a/server/chat-plugins/uno.ts
+++ b/server/chat-plugins/uno.ts
@@ -535,7 +535,6 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 		if (this.autostartTimer) clearTimeout(this.autostartTimer);
 		this.sendToRoom(`|uhtmlchange|uno-${this.gameNumber}|<div class="infobox">The game of UNO has ended.</div>`, true);
 
-		// deallocate games for each player.
 		this.setEnded();
 		for (const player of this.players) player.destroy();
 		this.room.game = null;

--- a/server/chat-plugins/uno.ts
+++ b/server/chat-plugins/uno.ts
@@ -16,7 +16,7 @@ interface Card {
 	name: string;
 }
 
-const maxTime = 60; // seconds
+const MAX_TIME = 60; // seconds
 
 const rgbGradients: {[k in Color]: string} = {
 	Green: "rgba(0, 122, 0, 1), rgba(0, 185, 0, 0.9)",
@@ -80,58 +80,38 @@ function createDeck() {
 }
 
 export class UNO extends Rooms.RoomGame<UNOPlayer> {
-	playerCap: number;
-	allowRenames: boolean;
-	maxTime: number;
-	timer: NodeJS.Timer | null;
-	autostartTimer: NodeJS.Timer | null;
-	state: string;
-	currentPlayerid: ID;
-	deck: Card[];
-	discards: Card[];
-	topCard: Card | null;
-	awaitUno: string | null;
-	unoId: ID | null;
-	direction: number;
+	override readonly gameid = 'uno' as ID;
+	override title = 'UNO';
+	override readonly allowRenames = true;
+	override timer: NodeJS.Timer | null = null;
+	maxTime = MAX_TIME;
+	autostartTimer: NodeJS.Timer | null = null;
+	state: 'signups' | 'color' | 'play' | 'uno' = 'signups';
+	currentPlayer: UNOPlayer | null = null;
+	deck: Card[] = Utils.shuffle(createDeck());
+	discards: Card[] = [];
+	topCard: Card | null = null;
+	awaitUnoPlayer: UNOPlayer | null = null;
+	unoId: ID | null = null;
+	direction: 1 | -1 = 1;
 	suppressMessages: boolean;
-	spectators: {[k: string]: number};
-	isPlusFour: boolean;
+	spectators: {[k: string]: number} = Object.create(null);
+	isPlusFour = false;
 	gameNumber: number;
 
 	constructor(room: Room, cap: number, suppressMessages: boolean) {
 		super(room);
 
 		this.gameNumber = room.nextGameNumber();
-
 		this.playerCap = cap;
-		this.allowRenames = true;
-		this.maxTime = maxTime;
-		this.timer = null;
-		this.autostartTimer = null;
-
-		this.gameid = 'uno' as ID;
-		this.title = 'UNO';
-
-		this.state = 'signups';
-		this.currentPlayerid = '';
-		this.deck = Utils.shuffle(createDeck());
-		this.discards = [];
-		this.topCard = null;
-		this.awaitUno = null;
-		this.unoId = null;
-		this.isPlusFour = false;
-
-		this.direction = 1;
-
 		this.suppressMessages = suppressMessages || false;
-		this.spectators = Object.create(null);
 
 		this.sendToRoom(`|uhtml|uno-${this.gameNumber}|<div class="broadcast-blue"><p style="font-size: 14pt; text-align: center">A new game of <strong>UNO</strong> is starting!</p><p style="font-size: 9pt; text-align: center"><button class="button" name="send" value="/uno join"><strong>Join and play</strong></button> <button class="button" name="send" value="/uno spectate">Watch</button></p>${this.suppressMessages ? `<p style="font-size: 6pt; text-align: center">Game messages won't show up unless you're playing or watching.</p>` : ''}</div>`, true);
 	}
 
-	onUpdateConnection() {}
+	override onUpdateConnection() {}
 
-	onConnect(user: User, connection: Connection) {
+	override onConnect(user: User, connection: Connection) {
 		if (this.state === 'signups') {
 			connection.sendTo(
 				this.room,
@@ -168,8 +148,8 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 		this.onNextPlayer(); // determines the first player
 
 		// give cards to the players
-		for (const i in this.playerTable) {
-			this.playerTable[i].hand.push(...this.drawCard(7));
+		for (const player of this.players) {
+			player.hand.push(...this.drawCard(7));
 		}
 
 		// top card of the deck.
@@ -184,7 +164,7 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 		this.nextTurn(true);
 	}
 
-	joinGame(user: User) {
+	override joinGame(user: User) {
 		if (user.id in this.playerTable) {
 			throw new Chat.ErrorMessage("You have already joined the game of UNO.");
 		}
@@ -195,7 +175,7 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 		return false;
 	}
 
-	leaveGame(user: User) {
+	override leaveGame(user: User) {
 		if (!(user.id in this.playerTable)) return false;
 		if ((this.state === 'signups' && this.removePlayer(user)) || this.eliminate(user.id)) {
 			this.sendToRoom(`${user.name} has left the game of UNO.`);
@@ -211,38 +191,31 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 		return new UNOPlayer(user, this);
 	}
 
-	onRename(user: User, oldUserid: ID, isJoining: boolean, isForceRenamed: boolean) {
+	override onRename(user: User, oldUserid: ID, isJoining: boolean, isForceRenamed: boolean) {
 		if (!(oldUserid in this.playerTable) || user.id === oldUserid) return false;
 		if (!user.named && !isForceRenamed) {
 			user.games.delete(this.roomid);
 			user.updateSearch();
 			return; // dont set users to their guest accounts.
 		}
-		this.playerTable[user.id] = this.playerTable[oldUserid];
-		// only run if it's a rename that involves a change of userid
-		if (user.id !== oldUserid) delete this.playerTable[oldUserid];
-
-		// update the user's name information
-		this.playerTable[user.id].name = user.name;
-		this.playerTable[user.id].id = user.id;
-		if (this.awaitUno && this.awaitUno === oldUserid) this.awaitUno = user.id;
-
-		if (this.currentPlayerid === oldUserid) this.currentPlayerid = user.id;
+		this.renamePlayer(user, oldUserid);
 	}
 
-	eliminate(userid: ID) {
-		if (!(userid in this.playerTable)) return false;
+	eliminate(userid: ID | undefined) {
+		if (!userid) return null;
+		const player = this.playerTable[userid];
+		if (!player) return false;
 
-		const name = this.playerTable[userid].name;
+		const name = player.name;
 
 		if (this.playerCount === 2) {
-			this.removePlayer(this.playerTable[userid]);
-			this.onWin(this.playerTable[Object.keys(this.playerTable)[0]]);
+			this.removePlayer(player);
+			this.onWin(this.players[0]);
 			return name;
 		}
 
 		// handle current player...
-		const removingCurrentPlayer = userid === this.currentPlayerid;
+		const removingCurrentPlayer = player === this.currentPlayer;
 		if (removingCurrentPlayer) {
 			if (this.state === 'color') {
 				if (!this.topCard) {
@@ -254,18 +227,18 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 			}
 		}
 
-		if (this.awaitUno === userid) this.awaitUno = null;
+		if (this.awaitUnoPlayer === player) this.awaitUnoPlayer = null;
 		if (!this.topCard) {
 			throw new Chat.ErrorMessage(`Unable to disqualify ${name}.`);
 		}
 
 		// put that player's cards into the discard pile to prevent cards from being permanently lost
-		this.discards.push(...this.playerTable[userid].hand);
+		this.discards.push(...player.hand);
 
 		if (removingCurrentPlayer) {
 			this.onNextPlayer();
 		}
-		this.removePlayer(this.playerTable[userid]);
+		this.removePlayer(player);
 		if (removingCurrentPlayer) {
 			this.nextTurn(true);
 		}
@@ -277,8 +250,8 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 			this.room.add(msg).update();
 		} else {
 			// send to the players first
-			for (const i in this.playerTable) {
-				this.playerTable[i].sendRoom(msg);
+			for (const player of this.players) {
+				player.sendRoom(msg);
 			}
 
 			// send to spectators
@@ -291,15 +264,16 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 	}
 
 	getPlayers(showCards?: boolean): string {
-		let playerList = Object.keys(this.playerTable);
+		let playerList = this.players;
+		if (this.direction === -1) playerList = [...playerList].reverse();
+
 		if (!showCards) {
-			return playerList.sort().map(id => Utils.escapeHTML(this.playerTable[id].name)).join(', ');
+			return playerList.map(p => Utils.escapeHTML(p.name)).join(', ');
 		}
-		if (this.direction === -1) playerList = playerList.reverse();
 		let buf = `<ol style="padding-left:0;">`;
-		for (const playerid of playerList) {
-			buf += `<li${this.currentPlayerid === playerid ? ` style="font-weight:bold;"` : ''}>`;
-			buf += `${Utils.escapeHTML(this.playerTable[playerid].name)} (${this.playerTable[playerid].hand.length})`;
+		for (const player of playerList) {
+			buf += `<li${this.currentPlayer === player ? ` style="font-weight:bold;"` : ''}>`;
+			buf += `${Utils.escapeHTML(player.name)} (${player.hand.length})`;
 			buf += `</li>`;
 		}
 		buf += `</ol>`;
@@ -308,7 +282,7 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 
 	onAwaitUno() {
 		return new Promise<void>(resolve => {
-			if (!this.awaitUno) return resolve();
+			if (!this.awaitUnoPlayer) return resolve();
 
 			this.state = "uno";
 			// the throttle for sending messages is at 600ms for non-authed users,
@@ -326,7 +300,7 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 			if (!starting) this.onNextPlayer();
 
 			if (this.timer) clearTimeout(this.timer);
-			const player = this.playerTable[this.currentPlayerid];
+			const player = this.currentPlayer!;
 
 			this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|&|${player.name}'s turn.`);
 			this.state = 'play';
@@ -335,34 +309,28 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 
 			this.timer = setTimeout(() => {
 				this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|&|${player.name} has been automatically disqualified.`);
-				this.eliminate(this.currentPlayerid);
+				this.eliminate(player.id);
 			}, this.maxTime * 1000);
 		});
 	}
 
 	onNextPlayer() {
-		// if none is set
-		if (!this.currentPlayerid) {
-			const userList = Object.keys(this.playerTable);
-			this.currentPlayerid = userList[Math.floor(this.playerCount * Math.random())] as ID;
-		}
-
-		this.currentPlayerid = this.getNextPlayer();
+		this.currentPlayer = this.getNextPlayer();
 	}
 
 	getNextPlayer() {
-		const userList = Object.keys(this.playerTable);
+		// if none is set
+		this.currentPlayer ||= this.players[Math.floor(this.playerCount * Math.random())];
 
-		let player: ID = userList[(userList.indexOf(this.currentPlayerid) + this.direction)] as ID;
+		let player = this.players[this.players.indexOf(this.currentPlayer) + this.direction];
+		// wraparound
+		player ||= (this.direction === 1 ? this.players[0] : this.players[this.playerCount - 1]);
 
-		if (!player) {
-			player = toID(this.direction === 1 ? userList[0] : userList[this.playerCount - 1]);
-		}
 		return player;
 	}
 
 	onDraw(player: UNOPlayer) {
-		if (this.currentPlayerid !== player.id || this.state !== 'play') return false;
+		if (this.currentPlayer !== player || this.state !== 'play') return false;
 		if (player.cardLock) return true;
 
 		this.onCheckUno();
@@ -375,7 +343,7 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 	}
 
 	onPlay(player: UNOPlayer, cardName: string) {
-		if (this.currentPlayerid !== player.id || this.state !== 'play') return false;
+		if (this.currentPlayer !== player || this.state !== 'play') return false;
 
 		const card = player.hasCard(cardName);
 		if (!card) return "You do not have that card.";
@@ -408,7 +376,7 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 
 		// update the unoId here, so when the display is sent to the player when the play is made
 		if (player.hand.length === 1) {
-			this.awaitUno = player.id;
+			this.awaitUnoPlayer = player;
 			this.unoId = Math.floor(Math.random() * 100).toString() as ID;
 		}
 
@@ -439,32 +407,32 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 			break;
 		case 'Skip':
 			this.onNextPlayer();
-			this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|&|${this.playerTable[this.currentPlayerid].name}'s turn has been skipped.`);
+			this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|&|${this.currentPlayer!.name}'s turn has been skipped.`);
 			break;
 		case '+2':
 			this.onNextPlayer();
-			this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|&|${this.playerTable[this.currentPlayerid].name} has been forced to draw 2 cards.`);
-			this.onDrawCard(this.playerTable[this.currentPlayerid], 2);
+			this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|&|${this.currentPlayer!.name} has been forced to draw 2 cards.`);
+			this.onDrawCard(this.currentPlayer!, 2);
 			break;
 		case '+4':
-			this.playerTable[this.currentPlayerid].sendRoom(colorDisplay);
+			this.currentPlayer!.sendRoom(colorDisplay);
 			this.state = 'color';
 			// apply to the next in line, since the current player still has to choose the color
 			const next = this.getNextPlayer();
-			this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|&|${this.playerTable[next].name} has been forced to draw 4 cards.`);
-			this.onDrawCard(this.playerTable[next], 4);
+			this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|&|${next.name} has been forced to draw 4 cards.`);
+			this.onDrawCard(next, 4);
 			this.isPlusFour = true;
 			this.timer = setTimeout(() => {
-				this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|&|${this.playerTable[this.currentPlayerid].name} has been automatically disqualified.`);
-				this.eliminate(this.currentPlayerid);
+				this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|&|${this.currentPlayer!.name} has been automatically disqualified.`);
+				this.eliminate(this.currentPlayer!.id);
 			}, this.maxTime * 1000);
 			break;
 		case 'Wild':
-			this.playerTable[this.currentPlayerid].sendRoom(colorDisplay);
+			this.currentPlayer!.sendRoom(colorDisplay);
 			this.state = 'color';
 			this.timer = setTimeout(() => {
-				this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|&|${this.playerTable[this.currentPlayerid].name} has been automatically disqualified.`);
-				this.eliminate(this.currentPlayerid);
+				this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|&|${this.currentPlayer!.name} has been automatically disqualified.`);
+				this.eliminate(this.currentPlayer!.id);
 			}, this.maxTime * 1000);
 			break;
 		}
@@ -474,7 +442,7 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 	onSelectColor(player: UNOPlayer, color: Color) {
 		if (
 			!['Red', 'Blue', 'Green', 'Yellow'].includes(color) ||
-			player.id !== this.currentPlayerid ||
+			player !== this.currentPlayer ||
 			this.state !== 'color'
 		) {
 			return false;
@@ -531,28 +499,27 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 
 	onUno(player: UNOPlayer, unoId: ID) {
 		// uno id makes spamming /uno uno impossible
-		if (this.unoId !== unoId || player.id !== this.awaitUno) return false;
+		if (this.unoId !== unoId || player !== this.awaitUnoPlayer) return false;
 		this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|&|**UNO!** ${player.name} is down to their last card!`);
-		this.awaitUno = null;
+		this.awaitUnoPlayer = null;
 		this.unoId = null;
 	}
 
 	onCheckUno() {
-		if (this.awaitUno) {
-			// if the previous player hasn't hit UNO before the next player plays something, they are forced to draw 2 cards;
-			if (this.awaitUno !== this.currentPlayerid) {
-				this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|&|${this.playerTable[this.awaitUno].name} forgot to say UNO! and is forced to draw 2 cards.`);
-				this.onDrawCard(this.playerTable[this.awaitUno], 2);
-			}
-			this.awaitUno = null;
-			this.unoId = null;
+		if (!this.awaitUnoPlayer) return;
+		// if the previous player hasn't hit UNO before the next player plays something, they are forced to draw 2 cards;
+		if (this.awaitUnoPlayer !== this.currentPlayer) {
+			this.sendToRoom(`|c:|${Math.floor(Date.now() / 1000)}|&|${this.awaitUnoPlayer.name} forgot to say UNO! and is forced to draw 2 cards.`);
+			this.onDrawCard(this.awaitUnoPlayer, 2);
 		}
+		this.awaitUnoPlayer = null;
+		this.unoId = null;
 	}
 
 	onSendHand(user: User) {
-		if (!(user.id in this.playerTable) || this.state === 'signups') return false;
+		if (this.state === 'signups') return false;
 
-		this.playerTable[user.id].sendDisplay();
+		this.playerTable[user.id]?.sendDisplay();
 	}
 
 	onWin(player: UNOPlayer) {
@@ -563,16 +530,14 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 		this.destroy();
 	}
 
-	destroy() {
+	override destroy() {
 		if (this.timer) clearTimeout(this.timer);
 		if (this.autostartTimer) clearTimeout(this.autostartTimer);
 		this.sendToRoom(`|uhtmlchange|uno-${this.gameNumber}|<div class="infobox">The game of UNO has ended.</div>`, true);
 
 		// deallocate games for each player.
 		this.setEnded();
-		for (const i in this.playerTable) {
-			this.playerTable[i].destroy();
-		}
+		for (const player of this.players) player.destroy();
 		this.room.game = null;
 	}
 }
@@ -632,9 +597,9 @@ class UNOPlayer extends Rooms.RoomGamePlayer<UNO> {
 		// clear previous display and show new display
 		this.sendRoom("|uhtmlchange|uno-hand|");
 		this.sendRoom(
-			`|uhtml|uno-hand|<div style="border: 1px solid skyblue; padding: 0 0 5px 0"><table style="width: 100%; table-layout: fixed; border-radius: 3px"><tr><td colspan="4" rowspan="2" style="padding: 5px"><div style="overflow-x: auto; white-space: nowrap; width: 100%">${hand}</div></td>${this.game.currentPlayerid === this.id ? `<td colspan="2" style="padding: 5px 5px 0 5px">${top}</td></tr>` : ""}` +
+			`|uhtml|uno-hand|<div style="border: 1px solid skyblue; padding: 0 0 5px 0"><table style="width: 100%; table-layout: fixed; border-radius: 3px"><tr><td colspan="4" rowspan="2" style="padding: 5px"><div style="overflow-x: auto; white-space: nowrap; width: 100%">${hand}</div></td>${this.game.currentPlayer === this ? `<td colspan="2" style="padding: 5px 5px 0 5px">${top}</td></tr>` : ""}` +
 			`<tr><td colspan="2" style="vertical-align: top; padding: 0px 5px 5px 5px"><div style="overflow-y: scroll">${players}</div></td></tr></table>` +
-			`${this.game.currentPlayerid === this.id ? `<div style="text-align: center">${draw}${pass}<br />${uno}</div>` : ""}</div>`
+			`${this.game.currentPlayer === this ? `<div style="text-align: center">${draw}${pass}<br />${uno}</div>` : ""}</div>`
 		);
 	}
 }
@@ -744,7 +709,7 @@ export const commands: Chat.ChatCommands = {
 			game.maxTime = amount;
 			if (game.timer) clearTimeout(game.timer);
 			game.timer = setTimeout(() => {
-				game.eliminate(game.currentPlayerid);
+				game.eliminate(game.currentPlayer?.id);
 			}, amount * 1000);
 			this.addModAction(`${user.name} has set the UNO automatic disqualification timer to ${amount} seconds.`);
 			this.modlog('UNO TIMER', null, `${amount} seconds`);
@@ -824,9 +789,9 @@ export const commands: Chat.ChatCommands = {
 		pass(target, room, user) {
 			const game = this.requireGame(UNO);
 			if (!game) throw new Chat.ErrorMessage("There is no UNO game going on in this room right now.");
-			if (game.currentPlayerid !== user.id) throw new Chat.ErrorMessage("It is currently not your turn.");
 			const player: UNOPlayer | undefined = game.playerTable[user.id];
 			if (!player) throw new Chat.ErrorMessage(`You are not in the game of UNO.`);
+			if (game.currentPlayer !== player) throw new Chat.ErrorMessage("It is currently not your turn.");
 			if (!player.cardLock) throw new Chat.ErrorMessage("You cannot pass until you draw a card.");
 			if (game.state === 'color') throw new Chat.ErrorMessage("You cannot pass until you choose a color.");
 

--- a/server/chat-plugins/uno.ts
+++ b/server/chat-plugins/uno.ts
@@ -569,6 +569,7 @@ export class UNO extends Rooms.RoomGame<UNOPlayer> {
 		this.sendToRoom(`|uhtmlchange|uno-${this.gameNumber}|<div class="infobox">The game of UNO has ended.</div>`, true);
 
 		// deallocate games for each player.
+		this.setEnded();
 		for (const i in this.playerTable) {
 			this.playerTable[i].destroy();
 		}

--- a/server/chat-plugins/wifi.tsx
+++ b/server/chat-plugins/wifi.tsx
@@ -96,7 +96,9 @@ const gameidToGame: {[k: string]: Game} = {
 	sv: 'SV',
 };
 
-class Giveaway extends Rooms.SimpleRoomGame {
+abstract class Giveaway extends Rooms.SimpleRoomGame {
+	override readonly gameid = 'giveaway' as ID;
+	abstract type: string;
 	gaNumber: number;
 	host: User;
 	giver: User;
@@ -733,6 +735,7 @@ export class LotteryGiveaway extends Giveaway {
 }
 
 export class GTS extends Rooms.SimpleRoomGame {
+	override readonly gameid = 'gts' as ID;
 	gtsNumber: number;
 	room: Room;
 	giver: User;

--- a/server/chat-plugins/youtube.ts
+++ b/server/chat-plugins/youtube.ts
@@ -364,6 +364,7 @@ export const Twitch = new class {
 };
 
 export class GroupWatch extends Rooms.SimpleRoomGame {
+	override readonly gameid = 'groupwatch' as ID;
 	url: string;
 	info: VideoData;
 	started: number | null = null;
@@ -437,6 +438,7 @@ export class GroupWatch extends Rooms.SimpleRoomGame {
 }
 
 export class TwitchStream extends Rooms.SimpleRoomGame {
+	override readonly gameid = 'twitchstream' as ID;
 	started = false;
 	data: TwitchChannel;
 	constructor(room: Room, data: TwitchChannel) {

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -1357,6 +1357,7 @@ export class BestOfPlayer extends RoomGamePlayer<BestOfGame> {
 }
 
 export class BestOfGame extends RoomGame<BestOfPlayer> {
+	override readonly gameid = 'bestof' as ID;
 	override allowRenames = false;
 	bestOf: number;
 	format: Format;

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -144,23 +144,18 @@ export class RoomBattlePlayer extends RoomGamePlayer<RoomBattle> {
 			}
 		}
 	}
-	override unlinkUser() {
+	override destroy() {
 		const user = this.getUser();
 		if (user) {
-			for (const connection of user.connections) {
-				Sockets.channelMove(connection.worker, this.game.roomid, 0, connection.socketid);
-			}
-			user.games.delete(this.game.roomid);
-			user.updateSearch();
+			this.updateChannel(user, 0);
 		}
-		delete this.game.playerTable[this.id];
 		this.id = '';
 		this.knownActive = false;
 		this.active = false;
 	}
-	updateChannel(connections: Connection | User) {
-		for (const connection of connections.connections || [connections]) {
-			Sockets.channelMove(connection.worker, this.game.roomid, this.channelIndex, connection.socketid);
+	updateChannel(user: User | Connection, channel = this.channelIndex) {
+		for (const connection of (user.connections || [user])) {
+			Sockets.channelMove(connection.worker, this.game.roomid, channel, connection.socketid);
 		}
 	}
 }
@@ -746,7 +741,7 @@ export class RoomBattle extends RoomGame<RoomBattlePlayer> {
 			this.room.add(`|bigerror|The simulator process crashed. We've been notified and will fix this ASAP.`);
 			if (!disconnected) Monitor.crashlog(new Error(`Sim stream interrupted`), `A sim stream`);
 			this.started = true;
-			this.ended = true;
+			this.setEnded();
 			this.checkActive();
 		}
 	}
@@ -820,7 +815,7 @@ export class RoomBattle extends RoomGame<RoomBattlePlayer> {
 			this.inputLog = this.logData!.inputLog;
 			this.started = true;
 			if (!this.ended) {
-				this.ended = true;
+				this.setEnded();
 				void this.onEnd(this.logData!.winner);
 			}
 			this.checkActive();
@@ -878,7 +873,9 @@ export class RoomBattle extends RoomGame<RoomBattlePlayer> {
 		this.room.update();
 
 		// so it stops showing up in the users' games list
-		for (const player of this.players) player.unlinkUser();
+		for (const player of this.players) {
+			player.getUser()?.games.delete(this.roomid);
+		}
 	}
 	async logBattle(
 		p1score: number, p1rating: AnyObject | null = null, p2rating: AnyObject | null = null,
@@ -1035,10 +1032,10 @@ export class RoomBattle extends RoomGame<RoomBattlePlayer> {
 
 		this.room.add(`|-message|${player.name}${message || ' forfeited.'}`);
 		this.endType = 'forfeit';
-		// multi battles, they need to be removed, else they can do things like spam forfeit
 		if (this.playerCap > 2) {
 			player.sendRoom(`|request|null`);
-			this.removePlayer(player);
+			// multi battles, so they can't spam forfeit
+			this.updatePlayer(player, null);
 		}
 		void this.stream.write(`>forcelose ${player.slot}`);
 		return true;
@@ -1242,6 +1239,7 @@ export class RoomBattle extends RoomGame<RoomBattlePlayer> {
 	}
 
 	override destroy() {
+		this.setEnded();
 		for (const player of this.players) {
 			player.destroy();
 		}
@@ -1252,7 +1250,6 @@ export class RoomBattle extends RoomGame<RoomBattlePlayer> {
 		this.p3 = null!;
 		this.p4 = null!;
 
-		this.ended = true;
 		void this.stream.destroy();
 		if (this.active) {
 			Rooms.global.battleCount += -1;
@@ -1689,11 +1686,6 @@ export class BestOfGame extends RoomGame<BestOfPlayer> {
 		} else if (winner === p2) {
 			p1score = 0;
 		}
-		for (const player of this.players) {
-			const user = player.getUser();
-			player.unlinkUser();
-			user?.updateSearch();
-		}
 
 		const {rated, room} = this.games[this.games.length - 1];
 		const battle = room.battle;
@@ -1720,7 +1712,7 @@ export class BestOfGame extends RoomGame<BestOfPlayer> {
 	forfeitPlayer(loser: BestOfPlayer, message = '') {
 		this.winner = this.players.filter(p => p !== loser)[0];
 		this.room.add(`||${loser.name}${message || ' forfeited.'}`);
-		this.ended = true;
+		this.setEnded();
 		void this.onEnd(this.winner.id);
 		for (const {room} of this.games) {
 			if (!room.battle || room.battle.ended) continue;

--- a/server/room-game.ts
+++ b/server/room-game.ts
@@ -35,6 +35,9 @@ export class RoomGamePlayer<GameClass extends RoomGame = SimpleRoomGame> {
 	 * be in the user's game list.
 	 *
 	 * We intentionally don't hold a direct reference to the user.
+	 *
+	 * If modifying: remember to sync `this.game.playerTable` and
+	 * `this.getUser().games`.
 	 */
 	id: ID;
 	constructor(user: User | string | null, game: GameClass, num = 0) {
@@ -49,25 +52,13 @@ export class RoomGamePlayer<GameClass extends RoomGame = SimpleRoomGame> {
 			user.updateSearch();
 		}
 	}
-	unlinkUser() {
-		if (!this.id) return;
-		const user = Users.getExact(this.id);
-		if (user && !this.game.isSubGame) {
-			user.games.delete(this.game.roomid);
-			user.updateSearch();
-		}
-		delete this.game.playerTable[this.id];
-		this.id = '';
-	}
-	destroy() {
-		this.unlinkUser();
-	}
+	destroy() {}
 
 	toString() {
 		return this.id;
 	}
 	getUser() {
-		return (this.id && Users.getExact(this.id)) || null;
+		return this.id ? Users.getExact(this.id) : null;
 	}
 	send(data: string) {
 		this.getUser()?.send(data);
@@ -96,13 +87,17 @@ export abstract class RoomGame<PlayerClass extends RoomGamePlayer = RoomGamePlay
 	/**
 	 * userid:player table.
 	 *
-	 * Does not contain userless players: use playerList for the full list.
+	 * Does not contain userless players: use this.players for the full list.
+	 *
+	 * Not a source of truth. Should be kept in sync with
+	 * `Object.fromEntries(this.players.filter(p => p.id).map(p => [p.id, p]))`
 	 */
 	playerTable: {[userid: string]: PlayerClass} = Object.create(null);
 	players: PlayerClass[] = [];
 	playerCount = 0;
 	playerCap = 0;
-	ended = false;
+	/** should only be set by setEnded */
+	readonly ended: boolean = false;
 	/** Does `/guess` or `/choose` require the user to be able to talk? */
 	checkChat = false;
 	/**
@@ -123,6 +118,7 @@ export abstract class RoomGame<PlayerClass extends RoomGamePlayer = RoomGamePlay
 	}
 
 	destroy() {
+		this.setEnded();
 		if (this.isSubGame) {
 			this.room.subGame = null;
 		} else {
@@ -157,17 +153,33 @@ export abstract class RoomGame<PlayerClass extends RoomGamePlayer = RoomGamePlay
 
 	updatePlayer(player: PlayerClass, userOrName: User | string | null) {
 		if (!this.allowRenames) return;
+		this.setPlayerUser(player, userOrName);
+	}
+	setPlayerUser(player: PlayerClass, userOrName: User | string | null) {
+		if (this.ended) return;
+		if (player.id === toID(userOrName)) return;
 		if (player.id) {
 			delete this.playerTable[player.id];
+			const user = Users.getExact(player.id);
+			if (user) {
+				user.games.delete(this.roomid);
+				user.updateSearch();
+			}
 		}
 		if (userOrName) {
-			const user = typeof userOrName === 'string' ? {name: userOrName, id: toID(userOrName)} : userOrName;
-			player.id = user.id;
-			player.name = user.name;
+			const {name, id} = typeof userOrName === 'string' ? {name: userOrName, id: toID(userOrName)} : userOrName;
+			player.id = id;
+			player.name = name;
 			this.playerTable[player.id] = player;
-			this.room.auth.set(user.id, Users.PLAYER_SYMBOL);
+			this.room.auth.set(id, Users.PLAYER_SYMBOL);
+
+			const user = typeof userOrName === 'string' ? Users.getExact(id) : userOrName;
+			if (user) {
+				user.games.add(this.roomid);
+				user.updateSearch();
+			}
 		} else {
-			player.unlinkUser();
+			player.id = '';
 		}
 	}
 
@@ -180,10 +192,10 @@ export abstract class RoomGame<PlayerClass extends RoomGamePlayer = RoomGamePlay
 			player = this.playerTable[player.id];
 			if (!player) throw new Error("Player not found");
 		}
-		if (!this.allowRenames) return false;
+
+		this.setPlayerUser(player, null);
 		const playerIndex = this.players.indexOf(player);
 		if (playerIndex < 0) return false;
-		if (player.id) delete this.playerTable[player.id];
 		this.players.splice(playerIndex, 1);
 		player.destroy();
 		this.playerCount--;
@@ -198,6 +210,19 @@ export abstract class RoomGame<PlayerClass extends RoomGamePlayer = RoomGamePlay
 			this.playerTable[user.id].id = user.id;
 			this.playerTable[user.id].name = user.name;
 			delete this.playerTable[oldUserid];
+		}
+	}
+
+	setEnded() {
+		if (this.ended) return;
+		(this.ended as boolean) = true;
+		if (this.isSubGame) return;
+		for (const player of this.players) {
+			const user = player.getUser();
+			if (user) {
+				user.games.delete(this.roomid);
+				user.updateSearch();
+			}
 		}
 	}
 

--- a/server/room-game.ts
+++ b/server/room-game.ts
@@ -52,7 +52,9 @@ export class RoomGamePlayer<GameClass extends RoomGame = SimpleRoomGame> {
 			user.updateSearch();
 		}
 	}
-	destroy() {}
+	destroy() {
+		(this.game as any) = null;
+	}
 
 	toString() {
 		return this.id;
@@ -74,13 +76,13 @@ export class RoomGamePlayer<GameClass extends RoomGame = SimpleRoomGame> {
  * If you don't want to define your own player class, you should extend SimpleRoomGame.
  */
 export abstract class RoomGame<PlayerClass extends RoomGamePlayer = RoomGamePlayer> {
+	abstract gameid: ID;
 	roomid: RoomID;
 	/**
 	 * The room this roomgame is in. Rooms can have two RoomGames at a time,
 	 * which are available as `this.room.game === this` and `this.room.subGame === this`.
 	 */
 	room: Room;
-	gameid = 'game' as ID;
 	title = 'Game';
 	allowRenames = false;
 	isSubGame: boolean;
@@ -372,7 +374,7 @@ export abstract class RoomGame<PlayerClass extends RoomGamePlayer = RoomGamePlay
  *
  * A RoomGame without a custom player class. Gives a default implementation for makePlayer.
  */
-export class SimpleRoomGame extends RoomGame<RoomGamePlayer> {
+export abstract class SimpleRoomGame extends RoomGame<RoomGamePlayer> {
 	makePlayer(user: User | string | null, ...rest: any[]): RoomGamePlayer {
 		const num = this.players.length ? this.players[this.players.length - 1].num : 1;
 		return new RoomGamePlayer(user, this, num);

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1347,7 +1347,7 @@ export class GlobalRoomState {
 			room.battle.timer.stop();
 			const b = await this.serializeBattleRoom(room);
 			if (!b) continue;
-			await out.write(JSON.stringify(b) + '\n');
+			await out.writeLine(JSON.stringify(b));
 			count++;
 		}
 		await out.writeEnd();
@@ -1508,7 +1508,10 @@ export class GlobalRoomState {
 		return Config.rankList;
 	}
 
-	getBattles(/** formatfilter, elofilter, usernamefilter */ filter: string) {
+	/**
+	 * @param filter formatfilter, elofilter, usernamefilter
+	 */
+	getBattles(filter: string) {
 		const rooms: GameRoom[] = [];
 		const [formatFilter, eloFilterString, usernameFilter] = filter.split(',');
 		const eloFilter = +eloFilterString;

--- a/server/tournaments/generator-elimination.ts
+++ b/server/tournaments/generator-elimination.ts
@@ -341,7 +341,7 @@ export class Elimination {
 			}
 		}
 
-		user.unlinkUser();
+		user.game.updatePlayer(user, null);
 	}
 
 	getAvailableMatches() {
@@ -388,7 +388,7 @@ export class Elimination {
 		if (loser.losses === this.maxSubtrees) {
 			loser.isEliminated = true;
 			loser.sendRoom(`|tournament|update|{"isJoined":false}`);
-			loser.unlinkUser();
+			loser.game.updatePlayer(loser, null);
 		}
 
 		if (targetNode.parent) {

--- a/server/tournaments/generator-round-robin.ts
+++ b/server/tournaments/generator-round-robin.ts
@@ -129,7 +129,7 @@ export class RoundRobin {
 			this.totalPendingMatches--;
 		}
 
-		user.unlinkUser();
+		user.game.updatePlayer(user, null);
 	}
 
 	getAvailableMatches() {
@@ -167,11 +167,11 @@ export class RoundRobin {
 		if (this.matchesPerPlayer) {
 			if (p1.games === this.matchesPerPlayer) {
 				p1.sendRoom(`|tournament|update|{"isJoined":false}`);
-				p1.unlinkUser();
+				p1.game.updatePlayer(p1, null);
 			}
 			if (p2.games === this.matchesPerPlayer) {
 				p2.sendRoom(`|tournament|update|{"isJoined":false}`);
-				p2.unlinkUser();
+				p2.game.updatePlayer(p2, null);
 			}
 		}
 	}

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -85,6 +85,7 @@ export class TournamentPlayer extends Rooms.RoomGamePlayer<Tournament> {
 }
 
 export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
+	override readonly gameid = 'tournament' as ID;
 	readonly isTournament: true;
 	readonly completedMatches: Set<RoomID>;
 	/** Format ID not including custom rules */
@@ -122,7 +123,6 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 		playerCap: string | undefined, isRated: boolean, name: string | undefined
 	) {
 		super(room);
-		this.gameid = 'tournament' as ID;
 		const formatId = toID(format);
 
 		this.title = format.name + ' tournament';

--- a/server/tournaments/index.ts
+++ b/server/tournaments/index.ts
@@ -117,7 +117,6 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 	autoStartTimeout: number;
 	autoStartTimer: NodeJS.Timeout | null;
 
-	isEnded: boolean;
 	constructor(
 		room: ChatRoom, format: Format, generator: Generator,
 		playerCap: string | undefined, isRated: boolean, name: string | undefined
@@ -164,8 +163,6 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 		this.autoStartTimeout = Infinity;
 		this.autoStartTimer = null;
 
-		this.isEnded = false;
-
 		room.add(`|tournament|create|${this.baseFormat}|${generator.name}|${this.playerCap}${this.name === this.baseFormat ? `` : `|${this.name}`}`);
 		const update: {
 			format: string, teambuilderFormat?: string, generator: string,
@@ -191,10 +188,7 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 			const room = Rooms.get(roomid) as GameRoom;
 			if (room) room.tour = null;
 		}
-		for (const player of this.players) {
-			player.unlinkUser();
-		}
-		this.isEnded = true;
+		this.setEnded();
 		this.room.game = null;
 	}
 	getRemainingPlayers() {
@@ -292,7 +286,7 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 
 	updateFor(targetUser: User, connection?: Connection | User) {
 		if (!connection) connection = targetUser;
-		if (this.isEnded) return;
+		if (this.ended) return;
 
 		if ((!this.bracketUpdateTimer && this.isBracketInvalidated) ||
 			(this.isTournamentStarted && this.isAvailableMatchesInvalidated)) {
@@ -353,7 +347,7 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 	}
 
 	update() {
-		if (this.isEnded) return;
+		if (this.ended) return;
 		if (this.isBracketInvalidated) {
 			if (Date.now() < this.lastBracketUpdate + BRACKET_MINIMUM_UPDATE_INTERVAL) {
 				if (this.bracketUpdateTimer) clearTimeout(this.bracketUpdateTimer);
@@ -474,20 +468,13 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 	}
 
 	removeUser(userid: ID, output?: Chat.CommandContext) {
-		if (!(userid in this.playerTable)) {
+		const player = this.playerTable[userid];
+		if (!player) {
 			if (output) output.sendReply('|tournament|error|UserNotAdded');
 			return;
 		}
 
-		for (const player of this.players) {
-			if (player.id === userid) {
-				this.players.splice(this.players.indexOf(player), 1);
-				break;
-			}
-		}
-		this.playerTable[userid].destroy();
-		delete this.playerTable[userid];
-		this.playerCount--;
+		this.removePlayer(player);
 		const user = Users.get(userid);
 		this.room.add(`|tournament|leave|${user ? user.name : userid}`);
 		if (user) user.sendTo(this.room, '|tournament|update|{"isJoined":false}');
@@ -911,7 +898,7 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 				player.autoDisqualifyWarned = false;
 			}
 		}
-		if (!this.isEnded) this.autoDisqualifyTimer = setTimeout(() => this.runAutoDisqualify(), this.autoDisqualifyTimeout);
+		if (!this.ended) this.autoDisqualifyTimer = setTimeout(() => this.runAutoDisqualify(), this.autoDisqualifyTimeout);
 
 		if (output) output.sendReply("All available matches were checked for automatic disqualification.");
 	}
@@ -1134,7 +1121,7 @@ export class Tournament extends Rooms.RoomGame<TournamentPlayer> {
 	}
 	onBattleJoin(room: GameRoom, user: User) {
 		if (!room.p1 || !room.p2) return;
-		if (this.allowScouting || this.isEnded || user.latestIp === room.p1.latestIp || user.latestIp === room.p2.latestIp) {
+		if (this.allowScouting || this.ended || user.latestIp === room.p1.latestIp || user.latestIp === room.p2.latestIp) {
 			return;
 		}
 		if (user.can('makeroom')) return;

--- a/server/users.ts
+++ b/server/users.ts
@@ -339,9 +339,16 @@ export interface UserSettings {
 export class User extends Chat.MessageContext {
 	/** In addition to needing it to implement MessageContext, this is also nice for compatibility with Connection. */
 	readonly user: User;
+	/**
+	 * Not a source of truth - should always be in sync with
+	 * `[...Rooms.rooms.values()].filter(room => this.id in room.users)`
+	 */
 	readonly inRooms: Set<RoomID>;
 	/**
-	 * Set of room IDs
+	 * Not a source of truth - should always in sync with
+	 * `[...Rooms.rooms.values()].filter(`
+	 * `  room => room.game && this.id in room.game.playerTable && !room.game.ended`
+	 * `)`
 	 */
 	readonly games: Set<RoomID>;
 	mmrCache: {[format: string]: number};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
         "incremental": true,
         "allowUnreachableCode": false,
         "esModuleInterop": true,
+        "noImplicitOverride": false,
         "useDefineForClassFields": false
     },
     "types": ["node"],


### PR DESCRIPTION
This refactor removes `player.unlinkUser()` which was used for several unrelated use cases.

These have been split apart into:

- at the end of a game, `game.setEnded()` now clears `user.games`, while leaving `player.id` untouched
- when trying to change the user associated with the player, we now consistently use the higher-level `game.updatePlayer()`

There's a good chance this fixes the lagspikes currently affecting PS.