### PR TITLE
Fix itemsearch when specifying both gen and show all

### DIFF
--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -395,7 +395,7 @@ export const commands: Chat.ChatCommands = {
 		if (!target) return this.parse('/help itemsearch');
 		target = target.slice(0, 300);
 		const targetGen = parseInt(cmd[cmd.length - 1]);
-		if (targetGen) target += ` maxgen${targetGen}`;
+		if (targetGen) target = `maxgen${targetGen} ` + target;
 
 		const response = await runSearch({
 			target,

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -395,7 +395,7 @@ export const commands: Chat.ChatCommands = {
 		if (!target) return this.parse('/help itemsearch');
 		target = target.slice(0, 300);
 		const targetGen = parseInt(cmd[cmd.length - 1]);
-		if (targetGen) target = `maxgen${targetGen} ` + target;
+		if (targetGen) target = `maxgen${targetGen} ${target}`;
 
 		const response = await runSearch({
 			target,


### PR DESCRIPTION
https://www.smogon.com/forums/threads/itemsearch-behavior-with-generation-arguments.3734394/

Appending maxgen to the end meant ``all`` wasn't being parsed correctly, and itemsearch was looking for the literal string "all"
