### PR TITLE
Randomized format updates

### DIFF
--- a/data/mods/gen1/random-data.json
+++ b/data/mods/gen1/random-data.json
@@ -50,7 +50,7 @@
     "butterfree": {
         "level": 79,
         "moves": ["psychic", "sleeppowder", "stunspore"],
-        "exclusiveMoves": ["hyperbeam", "megadrain", "psywave", "substitute"]
+        "exclusiveMoves": ["doubleedge", "hyperbeam", "megadrain", "substitute"]
     },
     "beedrill": {
         "level": 87,
@@ -223,7 +223,7 @@
     "venonat": {
         "level": 88,
         "moves": ["psychic", "sleeppowder", "stunspore"],
-        "exclusiveMoves": ["doubleedge", "megadrain", "psywave"]
+        "exclusiveMoves": ["doubleedge", "megadrain"]
     },
     "venomoth": {
         "level": 73,

--- a/data/mods/gen1/random-teams.ts
+++ b/data/mods/gen1/random-teams.ts
@@ -122,6 +122,7 @@ export class RandomGen1Teams extends RandomGen2Teams {
 		// Now let's store what we are getting.
 		const typeCount: {[k: string]: number} = {};
 		const weaknessCount: {[k: string]: number} = {Electric: 0, Psychic: 0, Water: 0, Ice: 0, Ground: 0, Fire: 0};
+		let numMaxLevelPokemon = 0;
 
 		const pokemonPool = this.getPokemonPool(type, pokemon, isMonotype, Object.keys(this.randomData))[0];
 		while (pokemonPool.length && pokemon.length < this.maxTeamSize) {
@@ -171,6 +172,12 @@ export class RandomGen1Teams extends RandomGen2Teams {
 				continue;
 			}
 
+			// Limit one level 100 Pokemon
+			if (!this.adjustLevel && (this.getLevel(species) === 100) && numMaxLevelPokemon >= limitFactor) {
+				rejectedButNotInvalidPool.push(species.id);
+				continue;
+			}
+
 			// The set passes the limitations.
 			pokemon.push(this.randomSet(species));
 
@@ -188,6 +195,9 @@ export class RandomGen1Teams extends RandomGen2Teams {
 			for (const weakness of pokemonWeaknesses) {
 				weaknessCount[weakness]++;
 			}
+
+			// Increment level 100 counter
+			if (this.getLevel(species) === 100) numMaxLevelPokemon++;
 
 			// Ditto check
 			if (species.id === 'ditto') this.battleHasDitto = true;

--- a/data/mods/gen1/random-teams.ts
+++ b/data/mods/gen1/random-teams.ts
@@ -245,7 +245,7 @@ export class RandomGen1Teams extends RandomGen2Teams {
 			}
 		}
 
-		const level = this.adjustLevel || data.level || 80;
+		const level = this.getLevel(species);
 
 		const evs = {hp: 255, atk: 255, def: 255, spa: 255, spd: 255, spe: 255};
 		const ivs = {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30};

--- a/data/mods/gen2/random-data.json
+++ b/data/mods/gen2/random-data.json
@@ -226,7 +226,7 @@
         "moves": ["haze", "hiddenpowerflying", "rest", "surf", "thunder"]
     },
     "mewtwo": {
-        "moves": ["fireblast", "icebeam", "psychic", "recover", "thunderbolt", "thunderwave"]
+        "moves": ["flamethrower", "icebeam", "psychic", "recover", "thunder", "thunderbolt"]
     },
     "mew": {
         "moves": ["earthquake", "explosion", "rockslide", "softboiled", "swordsdance"]

--- a/data/mods/gen2/random-teams.ts
+++ b/data/mods/gen2/random-teams.ts
@@ -289,18 +289,7 @@ export class RandomGen2Teams extends RandomGen3Teams {
 			if (ivs.def === 28 || ivs.def === 24) ivs.hp -= 8;
 		}
 
-		const levelScale: {[k: string]: number} = {
-			PU: 77,
-			PUBL: 75,
-			NU: 73,
-			NUBL: 71,
-			UU: 69,
-			UUBL: 67,
-			OU: 65,
-			Uber: 61,
-		};
-
-		const level = this.adjustLevel || data.level || levelScale[species.tier] || 80;
+		const level = this.getLevel(species);
 
 		return {
 			name: species.name,

--- a/data/mods/gen3/random-sets.json
+++ b/data/mods/gen3/random-sets.json
@@ -1121,11 +1121,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["brickbreak", "doubleedge", "hiddenpowerghost", "hydropump", "return"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["brickbreak", "encore", "hiddenpowerghost", "hydropump", "rest", "return", "sleeptalk"],
+                "movepool": ["brickbreak", "doubleedge", "encore", "hiddenpowerghost", "hydropump", "rest", "return", "sleeptalk"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -2321,7 +2317,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["explosion", "hypnosis", "icebeam", "psychic", "toxic"]
+                "movepool": ["explosion", "hiddenpowerfire", "hypnosis", "icebeam", "psychic", "toxic"]
             }
         ]
     },

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -587,7 +587,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		// Get items
 		item = this.getItem(ability, types, moves, counter, teamDetails, species, isLead, preferredType, role);
 
-		const level = this.adjustLevel || this.randomSets[species.id]["level"] || (species.nfe ? 90 : 80);
+		const level = this.getLevel(species);
 
 		// We use a special variable to track Hidden Power
 		// so that we can check for all Hidden Powers at once

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -681,6 +681,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		const typeCount: {[k: string]: number} = {};
 		const typeWeaknesses: {[k: string]: number} = {};
 		const teamDetails: RandomTeamsTypes.TeamDetails = {};
+		let numMaxLevelPokemon = 0;
 
 		const pokemonList = (this.gen === 3) ? Object.keys(this.randomSets) : Object.keys(this.randomData);
 		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
@@ -730,6 +731,11 @@ export class RandomGen3Teams extends RandomGen4Teams {
 					}
 				}
 				if (skip) continue;
+
+				// Limit one level 100 Pokemon
+				if (!this.adjustLevel && (this.getLevel(species) === 100) && numMaxLevelPokemon >= limitFactor) {
+					continue;
+				}
 			}
 
 			// Okay, the set passes, add it to our team
@@ -758,6 +764,9 @@ export class RandomGen3Teams extends RandomGen4Teams {
 					typeWeaknesses[typeName]++;
 				}
 			}
+
+			// Increment level 100 counter
+			if (set.level === 100) numMaxLevelPokemon++;
 
 			// Update team details
 			if (set.ability === 'Drizzle' || set.moves.includes('raindance')) teamDetails.rain = 1;

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -407,7 +407,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			return (
 				// Relicanth always wants Swift Swim if it doesn't have Double-Edge
 				!moves.has('raindance') && !teamDetails.rain && !(species.id === 'relicanth' && !counter.get('recoil')) ||
-				!moves.has('raindance') && ['Rock Head', 'Water Absorb'].some(abil => abilities.has(abil))
+				!moves.has('raindance') && abilities.has('Water Absorb')
 			);
 		case 'Thick Fat':
 			return (species.id === 'snorlax' || (species.id === 'hariyama' && moves.has('sleeptalk')));
@@ -505,7 +505,10 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			return 'Choice Band';
 		}
 
-		if (moves.has('dragondance') && ability !== 'Natural Cure' && !moves.has('healbell')) return 'Lum Berry';
+		if (
+			moves.has('dragondance') && ability !== 'Natural Cure' &&
+			!moves.has('healbell') && !moves.has('substitute')
+		) return 'Lum Berry';
 		if (moves.has('bellydrum')) return moves.has('substitute') ? 'Salac Berry' : 'Lum Berry';
 
 		if (moves.has('raindance') && counter.get('Special') >= 3) return 'Petaya Berry';

--- a/data/mods/gen4/random-sets.json
+++ b/data/mods/gen4/random-sets.json
@@ -989,8 +989,8 @@
                 "movepool": ["encore", "energyball", "sleeppowder", "stunspore", "toxic", "uturn"]
             },
             {
-                "role": "Staller",
-                "movepool": ["bounce", "leechseed", "substitute", "toxic"]
+                "role": "Fast Support",
+                "movepool": ["hiddenpowerflying", "leechseed", "protect", "substitute", "toxic"]
             }
         ]
     },
@@ -1076,7 +1076,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "hiddenpowerfire", "psychic", "substitute", "thunderbolt"]
+                "movepool": ["batonpass", "calmmind", "hiddenpowerfighting", "hiddenpowerfire", "psychic", "substitute", "thunderbolt"]
             }
         ]
     },
@@ -1225,6 +1225,10 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["bravebird", "roost", "spikes", "stealthrock", "whirlwind"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "toxic"]
             }
         ]
     },
@@ -1587,7 +1591,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bodyslam", "earthquake", "encore", "lowkick", "nightslash", "return", "slackoff", "suckerpunch"]
+                "movepool": ["bodyslam", "earthquake", "encore", "nightslash", "return", "slackoff", "suckerpunch"]
             },
             {
                 "role": "Bulky Setup",
@@ -1595,7 +1599,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bodyslam", "bulkup", "earthquake", "lowkick", "nightslash", "return", "suckerpunch"]
+                "movepool": ["bodyslam", "bulkup", "earthquake", "nightslash", "return", "suckerpunch"]
             }
         ]
     },
@@ -2119,7 +2123,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["charm", "protect", "surf", "toxic"]
+                "movepool": ["icebeam", "protect", "substitute", "surf", "toxic"]
             }
         ]
     },
@@ -3102,7 +3106,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["confuseray", "earthquake", "return", "substitute", "thunderwave"]
+                "movepool": ["earthquake", "return", "substitute", "thunderwave"]
             }
         ]
     },

--- a/data/mods/gen4/random-sets.json
+++ b/data/mods/gen4/random-sets.json
@@ -1771,6 +1771,10 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["earthquake", "encore", "explosion", "icebeam", "painsplit", "sludgebomb", "toxic", "yawn"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["earthquake", "protect", "sludgebomb", "toxic"]
             }
         ]
     },

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -724,7 +724,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			item = 'Black Sludge';
 		}
 
-		const level = this.adjustLevel || this.randomSets[species.id]["level"] || (species.nfe ? 90 : 80);
+		const level = this.getLevel(species);
 
 		// We use a special variable to track Hidden Power
 		// so that we can check for all Hidden Powers at once

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -1823,6 +1823,10 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["earthquake", "encore", "icebeam", "painsplit", "sludgebomb", "toxic", "yawn"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["earthquake", "protect", "sludgebomb", "toxic"]
             }
         ]
     },

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -176,7 +176,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["fireblast", "hiddenpowerice", "hypnosis", "nastyplot", "solarbeam", "substitute", "willowisp"],
+                "movepool": ["fireblast", "hiddenpowerrock", "hypnosis", "nastyplot", "solarbeam", "substitute", "willowisp"],
                 "preferredTypes": ["Grass"]
             }
         ]
@@ -214,6 +214,10 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["aromatherapy", "leechseed", "seedbomb", "spore", "stunspore", "xscissor"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["leechseed", "protect", "spore", "xscissor"]
             }
         ]
     },
@@ -1114,7 +1118,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "hiddenpowerfire", "hypervoice", "psychic", "psyshock", "substitute", "thunderbolt"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "hiddenpowerfire", "hypervoice", "psychic", "psyshock", "substitute", "thunderbolt"]
             }
         ]
     },
@@ -1288,6 +1292,10 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["bravebird", "roost", "spikes", "stealthrock", "whirlwind"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "toxic"]
             }
         ]
     },
@@ -2117,7 +2125,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["icebeam", "return", "shellsmash", "substitute", "suckerpunch", "waterfall"],
+                "movepool": ["icebeam", "return", "shellsmash", "suckerpunch", "waterfall"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -2127,8 +2135,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash", "substitute"],
-                "preferredTypes": ["Ice"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"]
             }
         ]
     },
@@ -2151,7 +2158,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["charm", "protect", "scald", "toxic"]
+                "movepool": ["icebeam", "protect", "scald", "substitute", "toxic"]
             }
         ]
     },
@@ -2561,7 +2568,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fakeout", "lowkick", "pursuit", "return", "seedbomb", "switcheroo", "uturn"]
+                "movepool": ["fakeout", "lowkick", "pursuit", "return", "switcheroo", "uturn"]
             }
         ]
     },
@@ -3092,7 +3099,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["confuseray", "earthquake", "return", "substitute", "thunderwave"]
+                "movepool": ["earthquake", "return", "substitute", "thunderwave"]
             }
         ]
     },
@@ -3517,7 +3524,7 @@
         "level": 86,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Support",
                 "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "superpower"]
             }
         ]
@@ -3576,6 +3583,10 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["earthquake", "scald", "sludgebomb", "stealthrock", "toxic"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["earthquake", "protect", "scald", "toxic"]
             }
         ]
     },
@@ -3884,7 +3895,7 @@
         "level": 86,
         "sets": [
             {
-                "role": "Staller",
+                "role": "Bulky Support",
                 "movepool": ["protect", "scald", "toxic", "wish"]
             }
         ]
@@ -3963,8 +3974,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "outrage", "superpower", "swordsdance"],
-                "preferredTypes": ["Ground"]
+                "movepool": ["dragondance", "earthquake", "outrage", "superpower"]
             }
         ]
     },
@@ -3992,7 +4002,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["bugbuzz", "encore", "focusblast", "gigadrain", "hiddenpowerrock", "spikes", "yawn"]
+                "movepool": ["bugbuzz", "encore", "focusblast", "gigadrain", "hiddenpowerground", "hiddenpowerrock", "spikes", "yawn"]
             }
         ]
     },

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -488,7 +488,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		role: RandomTeamsTypes.Role
 	): boolean {
 		switch (ability) {
-		case 'Flare Boost': case 'Gluttony': case 'Hyper Cutter': case 'Ice Body': case 'Moody': case 'Pickpocket':
+		case 'Flare Boost': case 'Gluttony': case 'Ice Body': case 'Moody': case 'Pickpocket':
 		case 'Pressure': case 'Sand Veil': case 'Sniper': case 'Snow Cloak': case 'Steadfast': case 'Unburden':
 			return true;
 		case 'Chlorophyll':
@@ -595,6 +595,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		) return 'Guts';
 		if (species.id === 'starmie') return role === 'Wallbreaker' ? 'Analytic' : 'Natural Cure';
 		if (species.id === 'ninetales') return 'Drought';
+		if (species.id === 'gligar') return 'Immunity';
 		if (species.id === 'arcanine') return 'Intimidate';
 		if (species.id === 'rampardos' && role === 'Bulky Attacker') return 'Mold Breaker';
 		if (species.id === 'altaria') return 'Natural Cure';

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -488,8 +488,8 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		role: RandomTeamsTypes.Role
 	): boolean {
 		switch (ability) {
-		case 'Flare Boost': case 'Gluttony': case 'Ice Body': case 'Moody': case 'Pickpocket':
-		case 'Pressure': case 'Sand Veil': case 'Sniper': case 'Snow Cloak': case 'Steadfast': case 'Unburden':
+		case 'Flare Boost': case 'Gluttony': case 'Ice Body': case 'Moody': case 'Pickpocket': case 'Pressure':
+		case 'Sand Veil': case 'Sniper': case 'Snow Cloak': case 'Steadfast': case 'Unburden':
 			return true;
 		case 'Chlorophyll':
 			// Petal Dance is for Lilligant

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -857,7 +857,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			item = 'Black Sludge';
 		}
 
-		const level = this.adjustLevel || this.randomSets[species.id]["level"] || (species.nfe ? 90 : 80);
+		const level = this.getLevel(species);
 
 		// We use a special variable to track Hidden Power
 		// so that we can check for all Hidden Powers at once

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -948,6 +948,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		const typeCount: {[k: string]: number} = {};
 		const typeWeaknesses: {[k: string]: number} = {};
 		const teamDetails: RandomTeamsTypes.TeamDetails = {};
+		let numMaxLevelPokemon = 0;
 
 		const pokemonList = Object.keys(this.randomSets);
 		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
@@ -996,6 +997,11 @@ export class RandomGen5Teams extends RandomGen6Teams {
 					}
 				}
 				if (skip) continue;
+
+				// Limit one level 100 Pokemon
+				if (!this.adjustLevel && (this.getLevel(species) === 100) && numMaxLevelPokemon >= limitFactor) {
+					continue;
+				}
 			}
 
 			const set = this.randomSet(species, teamDetails, pokemon.length === 0);
@@ -1025,6 +1031,9 @@ export class RandomGen5Teams extends RandomGen6Teams {
 					typeWeaknesses[typeName]++;
 				}
 			}
+
+			// Increment level 100 counter
+			if (set.level === 100) numMaxLevelPokemon++;
 
 			// Team details
 			if (set.ability === 'Snow Warning' || set.moves.includes('hail')) teamDetails.hail = 1;

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -214,7 +214,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["fireblast", "hiddenpowerice", "nastyplot", "solarbeam", "substitute", "willowisp"],
+                "movepool": ["fireblast", "hiddenpowerrock", "nastyplot", "solarbeam", "substitute", "willowisp"],
                 "preferredTypes": ["Grass"]
             }
         ]
@@ -948,7 +948,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["eruption", "fireblast", "focusblast", "hiddenpowergrass"]
+                "movepool": ["eruption", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerrock"]
             }
         ]
     },
@@ -1406,6 +1406,10 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["bravebird", "roost", "spikes", "stealthrock", "whirlwind"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "toxic"]
             }
         ]
     },
@@ -2384,7 +2388,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["icebeam", "return", "shellsmash", "substitute", "suckerpunch", "waterfall"],
+                "movepool": ["icebeam", "return", "shellsmash", "suckerpunch", "waterfall"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -2394,8 +2398,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash", "substitute"],
-                "preferredTypes": ["Ice"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"]
             }
         ]
     },
@@ -2418,7 +2421,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["charm", "protect", "scald", "toxic"]
+                "movepool": ["icebeam", "protect", "scald", "substitute", "toxic"]
             }
         ]
     },
@@ -2525,7 +2528,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "defog", "dracometeor", "hiddenpowerfire", "psyshock", "roost"]
+                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"]
             }
         ]
     },
@@ -2543,7 +2546,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "dracometeor", "hiddenpowerfire", "psyshock", "roost"]
+                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"]
             }
         ]
     },
@@ -2877,7 +2880,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fakeout", "knockoff", "lowkick", "return", "seedbomb", "switcheroo", "uturn"],
+                "movepool": ["fakeout", "knockoff", "lowkick", "return", "switcheroo", "uturn"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -3467,7 +3470,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["confuseray", "drainpunch", "knockoff", "return", "substitute", "thunderwave"]
+                "movepool": ["drainpunch", "knockoff", "return", "substitute", "thunderwave"]
             }
         ]
     },
@@ -3806,7 +3809,7 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["aquajet", "grassknot", "hydropump", "icebeam", "knockoff", "megahorn", "superpower"]
+                "movepool": ["aquajet", "grassknot", "hydropump", "icebeam", "knockoff", "megahorn", "scald", "superpower"]
             },
             {
                 "role": "Fast Attacker",
@@ -3914,7 +3917,7 @@
         "level": 83,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Support",
                 "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "superpower"]
             }
         ]
@@ -3990,6 +3993,10 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["earthquake", "knockoff", "scald", "stealthrock", "toxic"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["earthquake", "protect", "scald", "toxic"]
             }
         ]
     },
@@ -4393,7 +4400,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "outrage", "poisonjab", "swordsdance", "taunt"],
+                "movepool": ["dragondance", "earthquake", "outrage", "poisonjab", "taunt"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -4422,7 +4429,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["bugbuzz", "encore", "energyball", "focusblast", "hiddenpowerrock", "spikes", "yawn"]
+                "movepool": ["bugbuzz", "encore", "energyball", "focusblast", "hiddenpowerground", "hiddenpowerrock", "spikes", "yawn"]
             }
         ]
     },
@@ -4751,7 +4758,7 @@
         "level": 82,
         "sets": [
             {
-                "role": "AV Pivot",
+                "role": "Fast Attacker",
                 "movepool": ["closecombat", "knockoff", "relicsong", "return"]
             }
         ]
@@ -4911,7 +4918,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "lightscreen", "psychic", "reflect", "thunderwave", "toxic", "yawn"]
+                "movepool": ["healbell", "lightscreen", "psychic", "reflect", "signalbeam", "thunderwave", "toxic", "yawn"]
             }
         ]
     },
@@ -5121,7 +5128,7 @@
             },
             {
                 "role": "Staller",
-                "movepool": ["leechseed", "protect", "shadowclaw", "substitute"]
+                "movepool": ["earthquake", "hornleech", "protect", "toxic"]
             }
         ]
     },
@@ -5194,10 +5201,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["foulplay", "knockoff", "oblivionwing", "roost", "suckerpunch", "taunt", "toxic", "uturn"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["darkpulse", "focusblast", "knockoff", "oblivionwing", "suckerpunch", "uturn"]
             }
         ]
     },

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -2029,6 +2029,10 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["earthquake", "encore", "icebeam", "painsplit", "sludgebomb", "toxic", "yawn"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["earthquake", "protect", "sludgebomb", "toxic"]
             }
         ]
     },

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -527,7 +527,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		role: RandomTeamsTypes.Role
 	): boolean {
 		switch (ability) {
-		case 'Flare Boost': case 'Gluttony': case 'Harvest': case 'Hyper Cutter': case 'Ice Body': case 'Magician':
+		case 'Flare Boost': case 'Gluttony': case 'Harvest': case 'Ice Body': case 'Magician':
 		case 'Moody': case 'Pressure': case 'Sand Veil': case 'Sniper': case 'Snow Cloak': case 'Steadfast':
 			return true;
 		case 'Aerilate': case 'Pixilate': case 'Refrigerate':
@@ -643,12 +643,16 @@ export class RandomGen6Teams extends RandomGen7Teams {
 
 		if (species.id === 'starmie') return role === 'Wallbreaker' ? 'Analytic' : 'Natural Cure';
 		if (species.id === 'ninetales') return 'Drought';
+		if (species.id === 'pinsirmega') return 'Hyper Cutter';
 		if (species.id === 'ninjask' || species.id === 'seviper') return 'Infiltrator';
+		if (species.id === 'lucariomega') return 'Justified';
+		if (species.id === 'gligar') return 'Immunity';
 		if (species.id === 'arcanine') return 'Intimidate';
 		if (species.id === 'rampardos' && role === 'Bulky Attacker') return 'Mold Breaker';
 		if (species.baseSpecies === 'Altaria') return 'Natural Cure';
 		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it
 		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';
+		if (species.id === 'muk') return 'Poison Touch';
 		if (['dusknoir', 'vespiquen'].includes(species.id)) return 'Pressure';
 		if (species.id === 'druddigon' && role === 'Bulky Support') return 'Rough Skin';
 		if (species.id === 'pangoro' && !counter.get('ironfist')) return 'Scrappy';

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -911,7 +911,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			item = 'Black Sludge';
 		}
 
-		const level = this.adjustLevel || this.randomSets[species.id]["level"] || (species.nfe ? 90 : 80);
+		const level = this.getLevel(species);
 
 		// Minimize confusion damage
 		if (!counter.get('Physical') && !moves.has('copycat') && !moves.has('transform')) {

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -261,7 +261,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["fireblast", "hiddenpowerice", "nastyplot", "solarbeam", "substitute", "willowisp"],
+                "movepool": ["fireblast", "hiddenpowerrock", "nastyplot", "solarbeam", "substitute", "willowisp"],
                 "preferredTypes": ["Grass"]
             }
         ]
@@ -1102,7 +1102,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["eruption", "fireblast", "focusblast", "hiddenpowergrass"]
+                "movepool": ["eruption", "fireblast", "focusblast", "hiddenpowergrass", "hiddenpowerrock"]
             }
         ]
     },
@@ -1306,20 +1306,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["foulplay", "healbell", "moonlight", "toxic"]
-            }
-        ]
-    },
-    "murkrow": {
-        "level": 92,
-        "sets": [
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["bravebird", "defog", "haze", "pursuit", "roost", "thunderwave"]
-            },
-            {
-                "role": "Z-Move user",
-                "movepool": ["bravebird", "mirrormove", "protect", "suckerpunch"],
-                "preferredTypes": ["Flying"]
             }
         ]
     },
@@ -1566,6 +1552,10 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["bravebird", "roost", "spikes", "stealthrock", "whirlwind"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["bravebird", "roost", "spikes", "stealthrock", "toxic"]
             }
         ]
     },
@@ -2558,7 +2548,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["icebeam", "return", "shellsmash", "substitute", "suckerpunch", "waterfall"],
+                "movepool": ["icebeam", "return", "shellsmash", "suckerpunch", "waterfall"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -2568,8 +2558,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash", "substitute"],
-                "preferredTypes": ["Ice"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"]
             }
         ]
     },
@@ -2592,7 +2581,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["charm", "protect", "scald", "toxic"]
+                "movepool": ["icebeam", "protect", "scald", "substitute", "toxic"]
             }
         ]
     },
@@ -2713,7 +2702,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "defog", "dracometeor", "hiddenpowerfire", "psyshock", "roost"]
+                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"]
             }
         ]
     },
@@ -2736,7 +2725,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "dracometeor", "hiddenpowerfire", "psyshock", "roost"]
+                "movepool": ["calmmind", "dracometeor", "psyshock", "roost"]
             }
         ]
     },
@@ -3081,7 +3070,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fakeout", "knockoff", "lowkick", "return", "seedbomb", "switcheroo", "uturn"],
+                "movepool": ["fakeout", "knockoff", "lowkick", "return", "switcheroo", "uturn"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -3686,7 +3675,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["confuseray", "drainpunch", "knockoff", "return", "substitute", "thunderwave"]
+                "movepool": ["drainpunch", "knockoff", "return", "substitute", "thunderwave"]
             }
         ]
     },
@@ -4058,7 +4047,7 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["aquajet", "grassknot", "hydropump", "icebeam", "knockoff", "megahorn", "sacredsword"]
+                "movepool": ["aquajet", "grassknot", "hydropump", "icebeam", "knockoff", "megahorn", "sacredsword", "scald"]
             },
             {
                 "role": "Fast Attacker",
@@ -4167,7 +4156,7 @@
         "level": 83,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Support",
                 "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "superpower"]
             }
         ]
@@ -4248,6 +4237,10 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["earthquake", "knockoff", "scald", "stealthrock", "toxic"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["earthquake", "protect", "scald", "toxic"]
             }
         ]
     },
@@ -4661,12 +4654,12 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "outrage", "poisonjab", "swordsdance", "taunt"],
+                "movepool": ["dragondance", "earthquake", "outrage", "poisonjab", "taunt"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["dragondance", "earthquake", "outrage", "poisonjab", "swordsdance"],
+                "movepool": ["dragondance", "earthquake", "outrage", "poisonjab"],
                 "preferredTypes": ["Dragon"]
             }
         ]
@@ -4695,7 +4688,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["bugbuzz", "encore", "energyball", "focusblast", "hiddenpowerrock", "spikes", "toxicspikes", "yawn"]
+                "movepool": ["bugbuzz", "encore", "energyball", "focusblast", "hiddenpowerground", "hiddenpowerrock", "spikes", "toxicspikes", "yawn"]
             }
         ]
     },
@@ -5067,7 +5060,7 @@
         "level": 83,
         "sets": [
             {
-                "role": "AV Pivot",
+                "role": "Fast Attacker",
                 "movepool": ["closecombat", "knockoff", "relicsong", "return"]
             }
         ]
@@ -5242,7 +5235,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "lightscreen", "psychic", "reflect", "thunderwave", "toxic", "yawn"]
+                "movepool": ["healbell", "lightscreen", "psychic", "reflect", "signalbeam", "thunderwave", "toxic", "yawn"]
             }
         ]
     },
@@ -5458,7 +5451,7 @@
             },
             {
                 "role": "Staller",
-                "movepool": ["leechseed", "protect", "shadowclaw", "substitute"]
+                "movepool": ["earthquake", "hornleech", "protect", "toxic"]
             }
         ]
     },
@@ -5535,10 +5528,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["foulplay", "knockoff", "oblivionwing", "roost", "suckerpunch", "taunt", "toxic", "uturn"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["darkpulse", "focusblast", "knockoff", "oblivionwing", "suckerpunch", "uturn"]
             }
         ]
     },
@@ -5824,7 +5813,7 @@
         "level": 84,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Support",
                 "movepool": ["closecombat", "earthquake", "heavyslam", "rockslide", "stealthrock"]
             }
         ]

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -2181,6 +2181,10 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["earthquake", "encore", "icebeam", "painsplit", "sludgebomb", "toxic", "yawn"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["earthquake", "protect", "sludgebomb", "toxic"]
             }
         ]
     },

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1117,6 +1117,8 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		// Gen 2 still uses tier-based levelling
 		if (this.gen === 2) {
 			const levelScale: {[k: string]: number} = {
+				ZU: 81,
+				ZUBL: 79,
 				PU: 77,
 				PUBL: 75,
 				NU: 73,

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1104,7 +1104,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 
 	getLevel(
 		species: Species,
-	) : number {
+	): number {
 		// level set by rules
 		if (this.adjustLevel) return this.adjustLevel;
 		if (this.gen >= 3) {
@@ -1315,6 +1315,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		const typeComboCount: {[k: string]: number} = {};
 		const typeWeaknesses: {[k: string]: number} = {};
 		const teamDetails: RandomTeamsTypes.TeamDetails = {};
+		let numMaxLevelPokemon = 0;
 
 		// We make at most two passes through the potential Pokemon pool when creating a team - if the first pass doesn't
 		// result in a team of six Pokemon we perform a second iteration relaxing as many restrictions as possible.
@@ -1399,6 +1400,11 @@ export class RandomGen7Teams extends RandomGen8Teams {
 							if (!typeWeaknesses['Freeze-Dry']) typeWeaknesses['Freeze-Dry'] = 0;
 							if (typeWeaknesses['Freeze-Dry'] >= 4 * limitFactor) continue;
 						}
+
+						// Limit one level 100 Pokemon
+						if (!this.adjustLevel && (this.getLevel(species) === 100) && numMaxLevelPokemon >= limitFactor) {
+							continue;
+						}
 					}
 
 					// Limit three of any type combination in Monotype
@@ -1450,6 +1456,9 @@ export class RandomGen7Teams extends RandomGen8Teams {
 					}
 				}
 				if (weakToFreezeDry) typeWeaknesses['Freeze-Dry']++;
+
+				// Increment level 100 counter
+				if (set.level === 100) numMaxLevelPokemon++;
 
 				// Track what the team has
 				if (item.megaStone || species.name === 'Rayquaza-Mega') hasMega = true;

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1102,6 +1102,38 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		return 'Leftovers';
 	}
 
+	getLevel(
+		species: Species,
+	) : number {
+		// level set by rules
+		if (this.adjustLevel) return this.adjustLevel;
+		if (this.gen >= 3) {
+			// Revamped generations use random-sets.json
+			const sets = this.randomSets[species.id];
+			if (sets.level) return sets.level;
+		} else {
+			// Other generations use random-data.json
+			const data = this.randomData[species.id];
+			if (data.level) return data.level;
+		}
+		// Gen 2 still uses tier-based levelling
+		if (this.gen === 2) {
+			const levelScale: {[k: string]: number} = {
+				PU: 77,
+				PUBL: 75,
+				NU: 73,
+				NUBL: 71,
+				UU: 69,
+				UUBL: 67,
+				OU: 65,
+				Uber: 61,
+			};
+			if (levelScale[species.tier]) return levelScale[species.tier];
+		}
+		// Default to 80
+		return 80;
+	}
+
 	randomSet(
 		species: string | Species,
 		teamDetails: RandomTeamsTypes.TeamDetails = {},
@@ -1167,7 +1199,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			item = 'Black Sludge';
 		}
 
-		const level = this.adjustLevel || this.randomSets[species.id]["level"] || (species.nfe ? 90 : 80);
+		const level = this.getLevel(species);
 
 		// Minimize confusion damage
 		if (!counter.get('Physical') && !moves.has('copycat') && !moves.has('transform')) {

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1102,9 +1102,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		return 'Leftovers';
 	}
 
-	getLevel(
-		species: Species,
-	): number {
+	getLevel(species: Species): number {
 		// level set by rules
 		if (this.adjustLevel) return this.adjustLevel;
 		if (this.gen >= 3) {

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -760,7 +760,8 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			return (abilities.has('Tinted Lens') && role === 'Wallbreaker');
 		case 'Mold Breaker':
 			return (
-				species.baseSpecies === 'Basculin' || species.id === 'pangoro' || abilities.has('Sheer Force')
+				species.baseSpecies === 'Basculin' || species.id === 'pangoro' || species.id === 'pinsirmega' ||
+				abilities.has('Sheer Force')
 			);
 		case 'Oblivious': case 'Prankster':
 			return (!counter.get('Status') || (species.id === 'tornadus' && moves.has('bulkup')));
@@ -854,11 +855,13 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (species.id === 'raticatealola') return 'Hustle';
 		if (species.id === 'ninjask' || species.id === 'seviper') return 'Infiltrator';
 		if (species.id === 'arcanine') return 'Intimidate';
+		if (species.id === 'lucariomega') return 'Justified';
 		if (species.id === 'toucannon' && !counter.get('sheerforce') && !counter.get('skilllink')) return 'Keen Eye';
 		if (species.id === 'rampardos' && role === 'Bulky Attacker') return 'Mold Breaker';
 		if (species.baseSpecies === 'Altaria') return 'Natural Cure';
 		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it
 		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';
+		if (species.id === 'muk') return 'Poison Touch';
 		if (
 			['dusknoir', 'raikou', 'suicune', 'vespiquen'].includes(species.id)
 		) return 'Pressure';

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -2463,6 +2463,7 @@ export class RandomGen8Teams {
 		const typeComboCount: {[k: string]: number} = {};
 		const typeWeaknesses: {[k: string]: number} = {};
 		const teamDetails: RandomTeamsTypes.TeamDetails = {};
+		let numMaxLevelPokemon = 0;
 
 		const pokemonList = [];
 		for (const poke of Object.keys(this.randomData)) {
@@ -2535,6 +2536,12 @@ export class RandomGen8Teams {
 					if (!typeWeaknesses['Freeze-Dry']) typeWeaknesses['Freeze-Dry'] = 0;
 					if (typeWeaknesses['Freeze-Dry'] >= 4 * limitFactor) continue;
 				}
+
+				// Limit one level 100 Pokemon
+				if (
+					!this.adjustLevel && numMaxLevelPokemon >= limitFactor &&
+					(this.getLevel(species, isDoubles, this.dex.formats.getRuleTable(this.format).has('dynamaxclause')) === 100)
+				) continue;
 			}
 
 			// Limit three of any type combination in Monotype
@@ -2576,6 +2583,9 @@ export class RandomGen8Teams {
 				}
 			}
 			if (weakToFreezeDry) typeWeaknesses['Freeze-Dry']++;
+
+			// Increment level 100 counter
+			if (set.level === 100) numMaxLevelPokemon++;
 
 			// Track what the team has
 			if (set.ability === 'Drizzle' || set.moves.includes('raindance')) teamDetails.rain = 1;

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -1274,7 +1274,12 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Baneful Bunker", "Burning Bulwark", "Decorate", "Fake Out", "Ruination", "Silk Trap", "Spiky Shield"],
+                "movepool": ["Decorate", "Fake Out", "Follow Me", "Pollen Puff", "Tailwind"],
+                "teraTypes": ["Ghost"]
+            },
+            {
+                "role": "Doubles Bulky Attacker",
+                "movepool": ["Decorate", "Fake Out", "Follow Me", "Tailwind"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -1460,7 +1465,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Hurricane", "Hydro Pump", "Muddy Water", "Tailwind", "Wide Guard"],
-                "teraTypes": ["Ground"]
+                "teraTypes": ["Ground", "Steel"]
             }
         ]
     },

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -493,7 +493,6 @@ export class RandomTeams {
 				// In order of decreasing generalizability
 				[SPEED_CONTROL, SPEED_CONTROL],
 				[HAZARDS, HAZARDS],
-				[PROTECT_MOVES, PROTECT_MOVES],
 				['rockslide', 'stoneedge'],
 				[SETUP, ['fakeout', 'helpinghand']],
 				[PROTECT_MOVES, 'wideguard'],
@@ -902,16 +901,11 @@ export class RandomTeams {
 			}
 		}
 
-		// Enforce redirecting moves, or Fake Out if no redirecting move
+		// Enforce redirecting moves and Fake Out on Doubles Support
 		if (role === 'Doubles Support') {
-			const redirectMoves = movePool.filter(moveid => ['followme', 'ragepowder'].includes(moveid));
-			if (redirectMoves.length) {
-				const moveid = this.sample(redirectMoves);
-				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead, isDoubles,
-					movePool, teraType, role);
-			} else {
-				if (movePool.includes('fakeout')) {
-					counter = this.addMove('fakeout', moves, types, abilities, teamDetails, species, isLead, isDoubles,
+			for (const moveid of ['fakeout', 'followme', 'ragepowder']) {
+				if (movePool.includes(moveid)) {
+					counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead, isDoubles,
 						movePool, teraType, role);
 				}
 			}
@@ -1038,7 +1032,7 @@ export class RandomTeams {
 			return (!moves.has('facade') && !moves.has('sleeptalk'));
 		case 'Hustle':
 			// some of this is just for Delibird in singles/doubles
-			return (counter.get('Physical') < 2 || moves.has('fakeout') || moves.has('rapidspin'));
+			return (!counter.get('Physical') || moves.has('fakeout') || moves.has('rapidspin'));
 		case 'Infiltrator':
 			return (isDoubles && abilities.has('Clear Body'));
 		case 'Insomnia':
@@ -1159,13 +1153,14 @@ export class RandomTeams {
 		if (species.id === 'jumpluff') return 'Infiltrator';
 		if (species.id === 'toucannon' && !counter.get('skilllink')) return 'Keen Eye';
 		if (species.id === 'reuniclus') return (role === 'AV Pivot') ? 'Regenerator' : 'Magic Guard';
-		if (species.id === 'smeargle') return 'Own Tempo';
+		if (species.id === 'smeargle' && !counter.get('technician')) return 'Own Tempo';
 		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it
 		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';
 		if (species.id === 'zebstrika') return (moves.has('wildcharge')) ? 'Sap Sipper' : 'Lightning Rod';
 		if (species.id === 'sandaconda' || (species.id === 'scrafty' && moves.has('rest'))) return 'Shed Skin';
 		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';
 		if (species.id === 'ribombee') return 'Shield Dust';
+		if (species.id === 'cinccino') return (role === 'Wallbreaker') ? 'Skill Link' : 'Technician';
 		if (species.id === 'dipplin') return 'Sticky Hold';
 		if (species.id === 'breloom') return 'Technician';
 		if (species.id === 'shiftry' && moves.has('tailwind')) return 'Wind Rider';
@@ -1184,7 +1179,6 @@ export class RandomTeams {
 			if (abilities.has('Own Tempo') && moves.has('petaldance')) return 'Own Tempo';
 			if (abilities.has('Slush Rush') && moves.has('snowscape')) return 'Slush Rush';
 			if (abilities.has('Soundproof') && (moves.has('substitute') || counter.get('setup'))) return 'Soundproof';
-			if (species.id === 'cinccino') return (role === 'Setup Sweeper') ? 'Technician' : 'Skill Link';
 			if (species.id === 'porygon2') return 'Trace';
 		}
 
@@ -1327,7 +1321,7 @@ export class RandomTeams {
 		if (species.id === 'reuniclus' && ability === 'Magic Guard') return 'Life Orb';
 		if (moves.has('bellydrum') && moves.has('substitute')) return 'Salac Berry';
 		if (
-			['Cheek Pouch', 'Cud Chew', 'Harvest'].some(m => ability === m) ||
+			['Cheek Pouch', 'Cud Chew', 'Harvest', 'Ripen'].some(m => ability === m) ||
 			moves.has('bellydrum') || moves.has('filletaway')
 		) {
 			return 'Sitrus Berry';
@@ -1353,8 +1347,8 @@ export class RandomTeams {
 		if (moves.has('courtchange')) return 'Heavy-Duty Boots';
 		if (moves.has('populationbomb')) return 'Wide Lens';
 		if (
-			moves.has('scaleshot') ||
-			(counter.get('setup') && ((species.id === 'torterra' && !isDoubles) || species.id === 'cinccino'))
+			moves.has('scaleshot') || (species.id === 'torterra' && !isDoubles) ||
+			(species.id === 'cinccino' && role !== 'Wallbreaker')
 		) return 'Loaded Dice';
 		if (ability === 'Unburden') {
 			return (moves.has('closecombat') || moves.has('leafstorm')) ? 'White Herb' : 'Sitrus Berry';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1763,6 +1763,7 @@ export class RandomTeams {
 		const typeComboCount: {[k: string]: number} = {};
 		const typeWeaknesses: {[k: string]: number} = {};
 		const teamDetails: RandomTeamsTypes.TeamDetails = {};
+		let numMaxLevelPokemon = 0;
 
 		const pokemonList = isDoubles ? Object.keys(this.randomDoublesSets) : Object.keys(this.randomSets);
 		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
@@ -1826,6 +1827,11 @@ export class RandomTeams {
 					if (!typeWeaknesses['Freeze-Dry']) typeWeaknesses['Freeze-Dry'] = 0;
 					if (typeWeaknesses['Freeze-Dry'] >= 4 * limitFactor) continue;
 				}
+
+				// Limit one level 100 Pokemon
+				if (!this.adjustLevel && (this.getLevel(species, isDoubles) === 100) && numMaxLevelPokemon >= limitFactor) {
+					continue;
+				}
 			}
 
 			// Limit three of any type combination in Monotype
@@ -1882,6 +1888,9 @@ export class RandomTeams {
 				}
 			}
 			if (weakToFreezeDry) typeWeaknesses['Freeze-Dry']++;
+
+			// Increment level 100 counter
+			if (set.level === 100) numMaxLevelPokemon++;
 
 			// Track what the team has
 			if (set.ability === 'Drizzle' || set.moves.includes('raindance')) teamDetails.rain = 1;


### PR DESCRIPTION
Implements a limit of one level 100 Pokemon per team in all generations. Council decision. Also, set updates for doubles and old gens.

**Gen 9 Random Doubles**:
-Smeargle now runs Fake Out + Follow Me + two of Decorate/Pollen Puff/Tailwind, split into two sets since Pollen Puff is enforced by default. It also now gets Technician as its ability. The incompatibility between protect moves is no longer needed, so it has been removed.
-Pelipper: +Tera Steel
-Cinccino is now Loaded Dice and Technician as intended.
-Flapple now gets Ripen and Sitrus Berry on its non-Tera Blast user set, and gets Hustle and Clear Amulet on its Tera Blast user set.

**Old Gens**:
-Butterfree and Venonat no longer run Psywave. Butterfree can now get Double-Edge. (Gen 1)
-Mewtwo no longer runs Fire Blast and Thunder Wave; they have been replaced by Flamethrower and Thunder. (Gen 2)
-ZU and ZUBL mons have been set to level 81 and 79 respectively, to accommodate new tiers. (Gen 2)
-Azumarill's sets have been combined, ensuring that sets with 4 attacks are always Choice Band. (Gen 3)
-Lunatone now runs HP Fire on its non-setup set, as well as its Calm Mind set. (Gen 3)
-Relicanth now always gets Swift Swim on sets without Double-Edge, since Rock Head is useless. (Gen 3)
-Dragon Dance + Substitute now generates Leftovers instead of Lum Berry. (Gen 3)

-Luvdisc: -Charm, +Ice Beam, +Substitute. (gens 4-7)
-Skarmory runs a new Staller set with Brave Bird, Roost, Toxic, and Stealth Rock/Spikes. (gens 4-7)
-Regigigas: -Confuse Ray, since its other moves are more valuable. (gens 4-7)
-Swalot runs a new Staller set with Sludge Bomb, Earthquake, Toxic, and Protect. (gens 4-7)
-Jumpluff's SubSeed set: -Bounce, +HP Flying, +Protect. Its role has been changed to Fast Support, so its 4th move is now a roll between Protect and Toxic. (Gen 4)
-Vigoroth: -Low Kick, since Earthquake is better coverage and more reliable. (Gen 4)
-Girafarig: +HP Fighting. (gens 4-5)

-Parasect runs a new Staller set with Spore, X-Scissor, Leech Seed, and Protect. (Gen 5)
-Alomomola's role has been changed from Staller to Bulky Support, allowing it to get Rocky Helmet as its item. (Gen 5)
-Ninetales: -HP Ice, +HP Rock. (gens 5-7)
-Gorebyss and Huntail: -Substitute. (gens 5-7)
-Ambipom: -Seed Bomb. (gens 5-7)
-Gigalith's role has been changed from Bulky Attacker to Bulky Support, to increase the chance of Stealth Rock and decrease Choice Band while rolling the same sets. (gens 5-7)
-Seismitoad runs a new Staller set with Earthquake, Scald, Toxic, and Protect. (gens 5-7)
-Haxorus: -Swords Dance. Its setup move is now always Dragon Dance. (gens 5-7)
-Accelgor: +HP Ground. (gens 5-7)
-Kingler can now obtain Hyper Cutter on sets without a Sheer Force boosted move. (gens 5-6)

-Pinsir-Mega is now always Hyper Cutter (gen 6) or Moxie (gen 7) as its base ability. Mold Breaker isn't very useful.
-Lucario-Mega is now always Justified, even on its special set. Bluffing sets was considered more valuable than having flinch immunity in the non-mega forme.
-Typhlosion: +HP Rock. (gens 6-7)
-Latias-Mega and Latios-Mega now run fixed sets with Draco Meteor, Psyshock, Calm Mind, and Roost. (gens 6-7)
-AV Pivot Samurott: +Scald. (gens 6-7)
-Meloetta-Pirouette's role has been changed from AV Pivot to Fast Attacker, so it now gets Life Orb. (gens 6-7)
-Meowstic (male): +Signal Beam, so that it can do something to Dark-types. (gens 6-7)
-Trevenant's Staller set has been changed: it is now Horn Leech, Earthquake, Toxic, and Protect. (gens 6-7)
-Yveltal's non-Roost AV set has been removed. (gens 6-7)
-Muk is now always Poison Touch. (gens 6-7)

-Murkrow has been removed from Gen 7 Random Battle. Council decision.
-Mudsdale's role has been changed from Bulky Attacker to Bulky Support, to increase the chance of Stealth Rock and decrease Choice Band while rolling the same sets. (Gen 7)