### PR TITLE
Randomized format set updates

### DIFF
--- a/data/mods/gen4/random-sets.json
+++ b/data/mods/gen4/random-sets.json
@@ -1381,7 +1381,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "stoneedge"]
             }
         ]
     },

--- a/data/mods/gen4/random-sets.json
+++ b/data/mods/gen4/random-sets.json
@@ -1085,7 +1085,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["explosion", "gyroball", "rapidspin", "spikes", "stealthrock", "toxicspikes"]
+                "movepool": ["explosion", "payback", "rapidspin", "spikes", "stealthrock", "toxicspikes"]
             }
         ]
     },

--- a/data/mods/gen4/random-sets.json
+++ b/data/mods/gen4/random-sets.json
@@ -92,7 +92,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aquatail", "crunch", "earthquake", "glare", "gunkshot", "poisonjab", "seedbomb", "switcheroo"],
+                "movepool": ["crunch", "earthquake", "glare", "gunkshot", "poisonjab", "seedbomb", "switcheroo"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -236,7 +236,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aerialace", "bite", "doubleedge", "fakeout", "hypnosis", "return", "seedbomb", "switcheroo", "taunt", "uturn"],
+                "movepool": ["bite", "doubleedge", "fakeout", "hypnosis", "return", "seedbomb", "taunt", "uturn"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -1824,7 +1824,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["focusblast", "healbell", "lightscreen", "psychic", "reflect", "thunderwave", "toxic"]
+                "movepool": ["focusblast", "healbell", "psychic", "thunderwave", "toxic"]
             },
             {
                 "role": "Bulky Attacker",
@@ -2319,7 +2319,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["lightscreen", "psychoboost", "reflect", "spikes", "stealthrock", "superpower", "taunt"]
+                "movepool": ["psychoboost", "spikes", "stealthrock", "superpower", "taunt"]
             }
         ]
     },
@@ -2745,7 +2745,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["blizzard", "earthquake", "focusblast", "hiddenpowerfire", "iceshard", "woodhammer"],
+                "movepool": ["blizzard", "earthquake", "focusblast", "iceshard", "woodhammer"],
                 "preferredTypes": ["Grass"]
             }
         ]
@@ -2939,7 +2939,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "icepunch", "painsplit", "shadowsneak", "trick", "willowisp"]
+                "movepool": ["earthquake", "icepunch", "painsplit", "shadowsneak", "trick", "willowisp"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Attacker",

--- a/data/mods/gen4/random-sets.json
+++ b/data/mods/gen4/random-sets.json
@@ -1381,7 +1381,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
             }
         ]
     },

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -39,7 +39,7 @@ const MOVE_PAIRS = [
 
 /** Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type */
 const PRIORITY_POKEMON = [
-	'cacturne', 'dusknoir', 'honchkrow', 'mamoswine', 'scizor', 'shedinja',
+	'cacturne', 'dusknoir', 'honchkrow', 'mamoswine', 'scizor', 'shedinja', 'shiftry',
 ];
 
 export class RandomGen4Teams extends RandomGen5Teams {

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -102,7 +102,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquatail", "coil", "earthquake", "glare", "gunkshot", "rest", "seedbomb", "suckerpunch"],
+                "movepool": ["aquatail", "coil", "earthquake", "glare", "gunkshot", "rest", "suckerpunch"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -248,7 +248,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aerialace", "bite", "doubleedge", "fakeout", "hypnosis", "return", "seedbomb", "switcheroo", "taunt", "uturn"]
+                "movepool": ["bite", "doubleedge", "fakeout", "hypnosis", "return", "seedbomb", "taunt", "uturn"],
+                "preferredTypes": ["Dark"]
             }
         ]
     },
@@ -474,7 +475,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["foulplay", "hiddenpowergrass", "hiddenpowerice", "signalbeam", "taunt", "thunderbolt", "voltswitch"]
+                "movepool": ["foulplay", "hiddenpowerice", "signalbeam", "taunt", "thunderbolt", "voltswitch"],
+                "preferredTypes": ["Ice"]
             },
             {
                 "role": "Fast Support",
@@ -904,10 +906,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["airslash", "heatwave", "hypervoice", "roost", "toxic", "whirlwind"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["nightshade", "roost", "toxic", "whirlwind"]
             }
         ]
     },
@@ -915,8 +913,8 @@
         "level": 100,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["encore", "lightscreen", "reflect", "roost", "toxic", "uturn"]
+                "role": "Staller",
+                "movepool": ["acrobatics", "encore", "focusblast", "knockoff", "roost", "toxic"]
             }
         ]
     },
@@ -934,7 +932,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bravebird", "heatwave", "roost", "superfang", "taunt", "toxic", "uturn"]
+                "movepool": ["bravebird", "hypnosis", "roost", "superfang", "taunt", "toxic", "uturn"]
             }
         ]
     },
@@ -1028,7 +1026,7 @@
             },
             {
                 "role": "Staller",
-                "movepool": ["acrobatics", "leechseed", "protect", "substitute"]
+                "movepool": ["acrobatics", "leechseed", "sleeppowder", "substitute"]
             }
         ]
     },
@@ -1127,7 +1125,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["gyroball", "rapidspin", "spikes", "stealthrock", "toxic", "voltswitch"]
+                "movepool": ["earthquake", "rapidspin", "spikes", "stealthrock", "toxic", "voltswitch"]
             }
         ]
     },
@@ -1211,7 +1209,7 @@
             },
             {
                 "role": "Staller",
-                "movepool": ["encore", "knockoff", "protect", "stealthrock", "toxic"]
+                "movepool": ["encore", "protect", "stealthrock", "toxic"]
             }
         ]
     },
@@ -1224,7 +1222,8 @@
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "megahorn", "nightslash", "stoneedge"]
+                "movepool": ["closecombat", "earthquake", "megahorn", "nightslash", "stoneedge"],
+                "preferredTypes": ["Rock"]
             }
         ]
     },
@@ -1607,7 +1606,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hurricane", "icebeam", "roost", "scald", "toxic", "uturn"]
+                "movepool": ["hurricane", "roost", "scald", "toxic", "uturn"]
             }
         ]
     },
@@ -1776,7 +1775,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "switcheroo", "thunderbolt", "voltswitch"],
+                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -1786,7 +1785,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"]
+                "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+                "preferredTypes": ["Ice"]
             }
         ]
     },
@@ -1795,7 +1795,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"]
+                "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+                "preferredTypes": ["Ice"]
             }
         ]
     },
@@ -1871,7 +1872,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["focusblast", "healbell", "lightscreen", "psychic", "reflect", "thunderwave", "toxic", "whirlwind"]
+                "movepool": ["focusblast", "healbell", "psychic", "thunderwave", "toxic", "whirlwind"]
             }
         ]
     },
@@ -1949,12 +1950,17 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthpower", "hiddenpowerrock", "icebeam", "moonlight", "psychic", "rockpolish"],
+                "movepool": ["earthpower", "icebeam", "moonlight", "psychic", "rockpolish"],
                 "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthpower", "hiddenpowerrock", "moonlight", "psychic", "stealthrock", "toxic"]
+                "movepool": ["earthpower", "hiddenpowerrock", "moonlight", "psychic", "stealthrock", "toxic"],
+                "preferredTypes": ["Psychic"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["calmmind", "earthpower", "moonlight", "psychic"]
             }
         ]
     },
@@ -2079,11 +2085,11 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "psychic", "recover", "signalbeam", "thunderwave", "toxic"]
+                "movepool": ["healbell", "hiddenpowerfighting", "psychic", "recover", "thunderwave", "toxic"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "psychic", "recover", "signalbeam"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "psychic", "recover", "signalbeam"]
             }
         ]
     },
@@ -2097,8 +2103,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["nightslash", "psychocut", "suckerpunch", "superpower", "swordsdance"],
-                "preferredTypes": ["Fighting"]
+                "movepool": ["nightslash", "suckerpunch", "superpower", "swordsdance"]
             }
         ]
     },
@@ -2347,7 +2352,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["lightscreen", "psychoboost", "reflect", "spikes", "stealthrock", "superpower", "taunt"]
+                "movepool": ["psychoboost", "spikes", "stealthrock", "superpower", "taunt"]
             }
         ]
     },
@@ -2572,7 +2577,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fakeout", "lowkick", "pursuit", "return", "switcheroo", "uturn"]
+                "movepool": ["fakeout", "lowkick", "pursuit", "return", "uturn"]
             }
         ]
     },
@@ -2581,7 +2586,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["acrobatics", "destinybond", "disable", "shadowball", "substitute", "thunderwave", "willowisp"]
+                "movepool": ["acrobatics", "destinybond", "disable", "shadowball", "substitute", "willowisp"]
             }
         ]
     },
@@ -2763,7 +2768,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["blizzard", "earthquake", "focusblast", "hiddenpowerfire", "iceshard", "woodhammer"],
+                "movepool": ["blizzard", "earthquake", "focusblast", "iceshard", "woodhammer"],
                 "preferredTypes": ["Grass"]
             }
         ]
@@ -2957,7 +2962,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "icepunch", "painsplit", "shadowsneak", "trick", "willowisp"]
+                "movepool": ["earthquake", "icepunch", "painsplit", "shadowsneak", "trick", "willowisp"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -3394,11 +3400,11 @@
                 "movepool": ["aromatherapy", "dragonpulse", "gigadrain", "glare", "hiddenpowerfire", "leechseed", "substitute"]
             },
             {
-                "role": "Bulky Setup",
+                "role": "Setup Sweeper",
                 "movepool": ["calmmind", "dragonpulse", "gigadrain", "hiddenpowerfire", "substitute"]
             },
             {
-                "role": "Setup Sweeper",
+                "role": "Wallbreaker",
                 "movepool": ["aquatail", "leafblade", "return", "swordsdance"]
             }
         ]
@@ -3498,11 +3504,11 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "hiddenpowerground", "moonlight", "psychic", "signalbeam", "thunderwave", "toxic"]
+                "movepool": ["healbell", "hiddenpowerfighting", "moonlight", "psychic", "signalbeam", "thunderwave", "toxic"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hiddenpowerground", "moonlight", "psyshock", "signalbeam"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "moonlight", "psyshock", "signalbeam"]
             }
         ]
     },
@@ -3520,7 +3526,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowergrass", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch", "wildcharge"]
+                "movepool": ["hiddenpowerice", "overheat", "thunderbolt", "voltswitch", "wildcharge"]
             }
         ]
     },
@@ -3676,7 +3682,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["crunch", "earthquake", "pursuit", "stealthrock", "stoneedge", "superpower"]
+                "movepool": ["crunch", "earthquake", "pursuit", "stealthrock", "stoneedge"]
             }
         ]
     },
@@ -3698,7 +3704,7 @@
             },
             {
                 "role": "Staller",
-                "movepool": ["gigadrain", "leechseed", "protect", "toxic"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "leechseed", "protect"]
             }
         ]
     },
@@ -3778,7 +3784,7 @@
         "level": 88,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["drainpunch", "gunkshot", "haze", "painsplit", "spikes", "toxicspikes"]
             }
         ]
@@ -4028,8 +4034,12 @@
                 "preferredTypes": ["Flying"]
             },
             {
-                "role": "Wallbreaker",
+                "role": "Fast Attacker",
                 "movepool": ["fakeout", "highjumpkick", "stoneedge", "uturn"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["drainpunch", "highjumpkick", "stoneedge", "uturn"]
             }
         ]
     },
@@ -4115,7 +4125,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["honeclaws", "ironhead", "rockslide", "superpower", "xscissor"]
+                "movepool": ["honeclaws", "ironhead", "rockslide", "superpower", "xscissor"],
+                "preferredTypes": ["Fighting"]
             }
         ]
     },

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -1446,7 +1446,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "stoneedge"]
             }
         ]
     },
@@ -3851,7 +3851,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["autotomize", "explosion", "flashcannon", "hiddenpowerground", "icebeam"]
+                "movepool": ["autotomize", "explosion", "flashcannon", "hiddenpowerground", "icebeam"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -1446,7 +1446,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
             }
         ]
     },

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -1775,8 +1775,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"],
-                "preferredTypes": ["Fire"]
+                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"]
             }
         ]
     },

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -3580,6 +3580,10 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["bulkup", "drainpunch", "icepunch", "machpunch", "thunderpunch"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["drainpunch", "icepunch", "machpunch", "thunderpunch"]
             }
         ]
     },

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -2961,7 +2961,7 @@
         "level": 85,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["earthquake", "icepunch", "painsplit", "shadowsneak", "trick", "willowisp"],
                 "preferredTypes": ["Ground"]
             }

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -932,7 +932,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bravebird", "hypnosis", "roost", "superfang", "taunt", "toxic", "uturn"]
+                "movepool": ["bravebird", "heatwave", "roost", "superfang", "taunt", "toxic", "uturn"]
             }
         ]
     },

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -2577,7 +2577,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fakeout", "lowkick", "pursuit", "return", "uturn"]
+                "movepool": ["fakeout", "lowkick", "payback", "pursuit", "return", "uturn"]
             }
         ]
     },

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -48,7 +48,7 @@ const MOVE_PAIRS = [
 
 /** Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type */
 const PRIORITY_POKEMON = [
-	'bisharp', 'breloom', 'cacturne', 'dusknoir', 'honchkrow', 'scizor', 'shedinja',
+	'bisharp', 'breloom', 'cacturne', 'dusknoir', 'honchkrow', 'scizor', 'shedinja', 'shiftry',
 ];
 
 export class RandomGen5Teams extends RandomGen6Teams {

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -198,6 +198,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			[['bodyslam', 'return'], ['bodyslam', 'doubleedge']],
 			[['gigadrain', 'leafstorm'], ['leafstorm', 'petaldance', 'powerwhip']],
 			[['drainpunch', 'focusblast'], ['closecombat', 'highjumpkick', 'superpower']],
+			['payback', 'pursuit'],
 
 			// Assorted hardcodes go here:
 			// Zebstrika

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -533,7 +533,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		case 'Synchronize':
 			return (counter.get('Status') < 2 || !!counter.get('recoil'));
 		case 'Regenerator':
-			return ((species.id === 'mienshao' && role !== 'Wallbreaker') || species.id === 'reuniclus');
+			return ((species.id === 'mienshao' && role !== 'Fast Attacker') || species.id === 'reuniclus');
 		case 'Reckless': case 'Rock Head':
 			return !counter.get('recoil');
 		case 'Sand Force': case 'Sand Rush':

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -3340,7 +3340,7 @@
         "level": 89,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["earthquake", "haze", "icepunch", "painsplit", "shadowsneak", "willowisp"],
                 "preferredTypes": ["Ground"]
             }

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -1985,7 +1985,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"]
+                "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+                "preferredTypes": ["Ice"]
             },
             {
                 "role": "Bulky Attacker",
@@ -1998,7 +1999,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"]
+                "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+                "preferredTypes": ["Ice"]
             },
             {
                 "role": "Bulky Attacker",

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -270,7 +270,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aerialace", "doubleedge", "fakeout", "gunkshot", "knockoff", "return", "seedbomb", "taunt", "uturn"],
+                "movepool": ["doubleedge", "fakeout", "gunkshot", "knockoff", "return", "seedbomb", "taunt", "uturn"],
                 "preferredTypes": ["Dark"]
             },
             {
@@ -528,7 +528,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["foulplay", "hiddenpowergrass", "hiddenpowerice", "signalbeam", "taunt", "thunderbolt", "voltswitch"]
+                "movepool": ["foulplay", "hiddenpowerice", "signalbeam", "taunt", "thunderbolt", "voltswitch"],
+                "preferredTypes": ["Ice"]
             },
             {
                 "role": "Fast Support",
@@ -783,7 +784,11 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerice", "shadowball", "signalbeam", "thunderbolt", "voltswitch"]
+                "movepool": ["hiddenpowerice", "shadowball", "thunderbolt", "voltswitch"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["hiddenpowerice", "signalbeam", "thunderbolt", "voltswitch"]
             }
         ]
     },
@@ -988,10 +993,6 @@
     "ledian": {
         "level": 100,
         "sets": [
-            {
-                "role": "Bulky Support",
-                "movepool": ["knockoff", "lightscreen", "reflect", "roost", "toxic", "uturn"]
-            },
             {
                 "role": "Staller",
                 "movepool": ["encore", "knockoff", "roost", "toxic", "uturn"]
@@ -1965,7 +1966,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "switcheroo", "thunderbolt", "voltswitch"],
+                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -1975,7 +1976,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowergrass", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"]
+                "movepool": ["hiddenpowerice", "overheat", "thunderbolt", "voltswitch"]
             }
         ]
     },
@@ -2099,7 +2100,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["focusblast", "healbell", "lightscreen", "psychic", "reflect", "thunderwave", "toxic", "whirlwind"]
+                "movepool": ["focusblast", "healbell", "psychic", "thunderwave", "toxic", "whirlwind"]
             }
         ]
     },
@@ -2338,7 +2339,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["knockoff", "playrough", "pursuit", "suckerpunch", "superpower", "swordsdance"]
+                "movepool": ["knockoff", "playrough", "pursuit", "suckerpunch", "superpower", "swordsdance"],
+                "preferredTypes": ["Fairy"]
             }
         ]
     },
@@ -2347,11 +2349,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fireblast", "knockoff", "playrough", "protect", "pursuit", "suckerpunch", "superpower"]
+                "movepool": ["fireblast", "knockoff", "playrough", "protect", "pursuit", "suckerpunch", "superpower"],
+                "preferredTypes": ["Fairy"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["knockoff", "playrough", "suckerpunch", "superpower", "swordsdance"]
+                "movepool": ["knockoff", "playrough", "suckerpunch", "superpower", "swordsdance"],
+                "preferredTypes": ["Fairy"]
             }
         ]
     },
@@ -2884,7 +2888,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fakeout", "knockoff", "lowkick", "return", "switcheroo", "uturn"],
+                "movepool": ["fakeout", "knockoff", "lowkick", "return", "uturn"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -3335,7 +3339,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "haze", "icepunch", "painsplit", "shadowsneak", "willowisp"]
+                "movepool": ["earthquake", "haze", "icepunch", "painsplit", "shadowsneak", "willowisp"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -3913,7 +3918,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowergrass", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch", "wildcharge"]
+                "movepool": ["hiddenpowerice", "overheat", "thunderbolt", "voltswitch", "wildcharge"]
             }
         ]
     },
@@ -4094,7 +4099,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "knockoff", "pursuit", "stealthrock", "stoneedge", "superpower"]
+                "movepool": ["earthquake", "knockoff", "pursuit", "stealthrock", "stoneedge"]
             }
         ]
     },
@@ -4116,7 +4121,7 @@
             },
             {
                 "role": "Staller",
-                "movepool": ["gigadrain", "leechseed", "spikyshield", "toxic"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "leechseed", "spikyshield"]
             }
         ]
     },
@@ -4546,7 +4551,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["honeclaws", "ironhead", "rockslide", "superpower", "xscissor"]
+                "movepool": ["honeclaws", "ironhead", "rockslide", "superpower", "xscissor"],
+                "preferredTypes": ["Fighting"]
             }
         ]
     },

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -1566,7 +1566,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
             }
         ]
     },
@@ -1575,7 +1575,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
             }
         ]
     },

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -1966,8 +1966,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"],
-                "preferredTypes": ["Fire"]
+                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"]
             }
         ]
     },

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -1566,7 +1566,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "stoneedge"]
             }
         ]
     },
@@ -1575,7 +1575,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "stoneedge"]
             }
         ]
     },
@@ -4272,11 +4272,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["autotomize", "explosion", "flashcannon", "freezedry", "hiddenpowerground", "icebeam", "toxic"]
+                "movepool": ["autotomize", "explosion", "flashcannon", "freezedry", "hiddenpowerground", "icebeam", "toxic"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["explosion", "flashcannon", "freezedry", "hiddenpowerground", "icebeam"]
+                "movepool": ["explosion", "flashcannon", "freezedry", "hiddenpowerground", "icebeam"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -2131,8 +2131,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"],
-                "preferredTypes": ["Fire"]
+                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"]
             }
         ]
     },

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -1721,7 +1721,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
             }
         ]
     },
@@ -1730,7 +1730,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
             }
         ]
     },

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -1721,7 +1721,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "stoneedge"]
             }
         ]
     },
@@ -1730,7 +1730,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "icepunch", "stoneedge"]
+                "movepool": ["crunch", "dragondance", "earthquake", "firepunch", "stoneedge"]
             }
         ]
     },
@@ -4530,11 +4530,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["autotomize", "blizzard", "explosion", "flashcannon", "freezedry", "hiddenpowerground"]
+                "movepool": ["autotomize", "blizzard", "explosion", "flashcannon", "freezedry", "hiddenpowerground"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["blizzard", "explosion", "flashcannon", "freezedry", "hiddenpowerground"]
+                "movepool": ["blizzard", "explosion", "flashcannon", "freezedry", "hiddenpowerground"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -340,7 +340,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aerialace", "doubleedge", "fakeout", "gunkshot", "knockoff", "return", "seedbomb", "taunt", "uturn"],
+                "movepool": ["doubleedge", "fakeout", "gunkshot", "knockoff", "return", "seedbomb", "taunt", "uturn"],
                 "preferredTypes": ["Dark"]
             },
             {
@@ -355,6 +355,11 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["darkpulse", "hiddenpowerfighting", "hypnosis", "nastyplot", "powergem", "thunderbolt"]
+            },
+            {
+                "role": "Z-Move user",
+                "movepool": ["darkpulse", "hiddenpowerfighting", "hypnosis", "nastyplot", "powergem", "thunderbolt"],
+                "preferredTypes": ["Dark"]
             }
         ]
     },
@@ -645,7 +650,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["foulplay", "hiddenpowergrass", "hiddenpowerice", "signalbeam", "taunt", "thunderbolt", "voltswitch"]
+                "movepool": ["foulplay", "hiddenpowerice", "signalbeam", "taunt", "thunderbolt", "voltswitch"],
+                "preferredTypes": ["Ice"]
             },
             {
                 "role": "Fast Support",
@@ -927,7 +933,11 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowerice", "shadowball", "signalbeam", "thunderbolt", "voltswitch"]
+                "movepool": ["hiddenpowerice", "shadowball", "thunderbolt", "voltswitch"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["hiddenpowerice", "signalbeam", "thunderbolt", "voltswitch"]
             }
         ]
     },
@@ -2121,7 +2131,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "switcheroo", "thunderbolt", "voltswitch"],
+                "movepool": ["flamethrower", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"],
                 "preferredTypes": ["Fire"]
             }
         ]
@@ -2131,7 +2141,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowergrass", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch"]
+                "movepool": ["hiddenpowerice", "overheat", "thunderbolt", "voltswitch"]
             }
         ]
     },
@@ -2251,7 +2261,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["focusblast", "healbell", "lightscreen", "psychic", "reflect", "thunderwave", "toxic", "whirlwind"]
+                "movepool": ["focusblast", "healbell", "psychic", "thunderwave", "toxic", "whirlwind"]
             }
         ]
     },
@@ -2498,7 +2508,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["knockoff", "playrough", "pursuit", "suckerpunch", "superpower", "swordsdance"]
+                "movepool": ["knockoff", "playrough", "pursuit", "suckerpunch", "superpower", "swordsdance"],
+                "preferredTypes": ["Fairy"]
             }
         ]
     },
@@ -2507,11 +2518,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fireblast", "knockoff", "playrough", "pursuit", "suckerpunch", "superpower"]
+                "movepool": ["fireblast", "knockoff", "playrough", "pursuit", "suckerpunch", "superpower"],
+                "preferredTypes": ["Fairy"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["knockoff", "playrough", "suckerpunch", "superpower", "swordsdance"]
+                "movepool": ["knockoff", "playrough", "suckerpunch", "superpower", "swordsdance"],
+                "preferredTypes": ["Fairy"]
             }
         ]
     },
@@ -3074,7 +3087,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fakeout", "knockoff", "lowkick", "return", "switcheroo", "uturn"],
+                "movepool": ["fakeout", "knockoff", "lowkick", "return", "uturn"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -3535,7 +3548,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "haze", "icepunch", "painsplit", "shadowsneak", "willowisp"]
+                "movepool": ["earthquake", "haze", "icepunch", "painsplit", "shadowsneak", "willowisp"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -4042,7 +4056,7 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["fireblast", "grassknot", "suckerpunch", "superpower", "wildcharge"]
+                "movepool": ["flareblitz", "grassknot", "suckerpunch", "superpower", "wildcharge"]
             }
         ]
     },
@@ -4152,7 +4166,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["hiddenpowergrass", "hiddenpowerice", "overheat", "thunderbolt", "voltswitch", "wildcharge"]
+                "movepool": ["hiddenpowerice", "overheat", "thunderbolt", "voltswitch", "wildcharge"]
             }
         ]
     },
@@ -4342,7 +4356,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "knockoff", "pursuit", "stealthrock", "stoneedge", "superpower"]
+                "movepool": ["earthquake", "knockoff", "pursuit", "stealthrock", "stoneedge"]
             }
         ]
     },
@@ -4364,7 +4378,7 @@
             },
             {
                 "role": "Staller",
-                "movepool": ["gigadrain", "leechseed", "spikyshield", "toxic"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerice", "leechseed", "spikyshield"]
             }
         ]
     },
@@ -4809,7 +4823,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["honeclaws", "ironhead", "rockslide", "superpower", "xscissor"]
+                "movepool": ["honeclaws", "ironhead", "rockslide", "superpower", "xscissor"],
+                "preferredTypes": ["Fighting"]
             }
         ]
     },

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -3549,7 +3549,7 @@
         "level": 88,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["earthquake", "haze", "icepunch", "painsplit", "shadowsneak", "willowisp"],
                 "preferredTypes": ["Ground"]
             }

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -2150,7 +2150,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"]
+                "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+                "preferredTypes": ["Ice"]
             }
         ]
     },
@@ -2159,7 +2160,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"]
+                "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
+                "preferredTypes": ["Ice"]
             }
         ]
     },

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -1794,12 +1794,12 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Bullet Punch", "Hammer Arm", "Knock Off", "Meteor Mash", "Psychic Fangs", "Stomping Tantrum"],
+                "movepool": ["Bullet Punch", "Hammer Arm", "Heavy Slam", "Knock Off", "Psychic Fangs", "Stomping Tantrum"],
                 "teraTypes": ["Dark", "Steel", "Water"]
             },
             {
                 "role": "Doubles Bulky Setup",
-                "movepool": ["Agility", "Brick Break", "Knock Off", "Meteor Mash", "Protect", "Psychic Fangs"],
+                "movepool": ["Agility", "Brick Break", "Heavy Slam", "Knock Off", "Protect", "Psychic Fangs"],
                 "teraTypes": ["Dragon"]
             }
         ]

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -3981,6 +3981,11 @@
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Brave Bird", "Bullet Seed", "Protect", "Tailwind"],
                 "teraTypes": ["Grass", "Steel"]
+            },
+            {
+                "role": "Bulky Protect",
+                "movepool": ["Beak Blast", "Bullet Seed", "Knock Off", "Protect"],
+                "teraTypes": ["Grass", "Steel"]
             }
         ]
     },
@@ -5219,8 +5224,8 @@
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["Bitter Blade", "Close Combat", "Poltergeist", "Protect", "Shadow Sneak", "Swords Dance"],
-                "teraTypes": ["Fighting", "Fire", "Ghost", "Grass"]
+                "movepool": ["Bitter Blade", "Poltergeist", "Protect", "Shadow Sneak", "Swords Dance"],
+                "teraTypes": ["Fire", "Ghost", "Grass"]
             }
         ]
     },

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -5870,12 +5870,12 @@
             {
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Close Combat", "Leaf Blade", "Protect", "Swords Dance"],
-                "teraTypes": ["Fighting", "Fire", "Psychic"]
+                "teraTypes": ["Fighting", "Fire", "Poison"]
             },
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Close Combat", "Leaf Blade", "Psyblade", "Wild Charge"],
-                "teraTypes": ["Fighting", "Fire", "Poison"]
+                "teraTypes": ["Fighting", "Fire", "Psychic"]
             }
         ]
     },

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -5700,7 +5700,7 @@
             {
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Close Combat", "Drain Punch", "Fake Out", "Ice Punch", "Volt Switch", "Wild Charge"],
-                "teraTypes": ["Electric", "Fighting", "Fire"]
+                "teraTypes": ["Electric", "Fire"]
             },
             {
                 "role": "Bulky Protect",

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -378,11 +378,6 @@
         "level": 92,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Earthquake", "Stealth Rock", "Stone Edge", "Volt Switch", "Wild Charge"],
-                "teraTypes": ["Ground"]
-            },
-            {
                 "role": "Wallbreaker",
                 "movepool": ["Double-Edge", "Earthquake", "Explosion", "Rock Polish", "Stone Edge"],
                 "teraTypes": ["Ground"]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -394,7 +394,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Calm Mind", "Psychic Noise", "Psyshock", "Scald", "Slack Off", "Thunder Wave"],
+                "movepool": ["Calm Mind", "Psyshock", "Scald", "Slack Off", "Thunder Wave"],
                 "teraTypes": ["Fairy", "Water"]
             },
             {

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2045,7 +2045,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Endeavor", "Substitute", "Surf", "Whirlpool"],
-                "teraTypes": ["Dragon", "Ghost", "Poison"]
+                "teraTypes": ["Ghost"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1560,7 +1560,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Fire Blast", "Ice Beam", "Knock Off", "Stealth Rock", "Stone Edge", "Thunder Wave"],
-                "teraTypes": ["Poison", "Rock"]
+                "teraTypes": ["Ghost", "Rock"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -6618,7 +6618,7 @@
                 "teraTypes": ["Stellar"]
             },
             {
-                "role": "Fast Bulky Setup",
+                "role": "Setup Sweeper",
                 "movepool": ["Calm Mind", "Earth Power", "Rapid Spin", "Rest", "Tera Starstorm"],
                 "teraTypes": ["Stellar"]
             }

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -41,6 +41,11 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Hydro Pump", "Ice Beam", "Shell Smash"],
                 "teraTypes": ["Ground", "Steel", "Water"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Hydro Pump", "Ice Beam", "Shell Smash", "Tera Blast"],
+                "teraTypes": ["Electric", "Grass"]
             }
         ]
     },
@@ -174,7 +179,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Alluring Voice", "Fire Blast", "Knock Off", "Protect", "Stealth Rock", "Thunder Wave", "Wish"],
+                "movepool": ["Alluring Voice", "Dazzling Gleam", "Fire Blast", "Knock Off", "Protect", "Stealth Rock", "Thunder Wave", "Wish"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -233,9 +238,14 @@
         "level": 93,
         "sets": [
             {
+                "role": "Wallbreaker",
+                "movepool": ["Double-Edge", "Gunk Shot", "Knock Off", "Switcheroo", "U-turn"],
+                "teraTypes": ["Normal", "Poison"]
+            },
+            {
                 "role": "Fast Attacker",
-                "movepool": ["Aerial Ace", "Double-Edge", "Fake Out", "Gunk Shot", "Knock Off", "Switcheroo", "U-turn"],
-                "teraTypes": ["Flying", "Normal", "Poison"]
+                "movepool": ["Double-Edge", "Fake Out", "Knock Off", "U-turn"],
+                "teraTypes": ["Normal"]
             }
         ]
     },
@@ -358,14 +368,9 @@
         "level": 87,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["Earthquake", "Explosion", "Rock Polish", "Stone Edge"],
-                "teraTypes": ["Grass", "Ground", "Steel"]
-            },
-            {
                 "role": "Bulky Attacker",
-                "movepool": ["Earthquake", "Explosion", "Stealth Rock", "Stone Edge"],
-                "teraTypes": ["Grass"]
+                "movepool": ["Earthquake", "Explosion", "Rock Polish", "Stealth Rock", "Stone Edge"],
+                "teraTypes": ["Grass", "Ground", "Steel"]
             }
         ]
     },
@@ -559,7 +564,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Leech Seed", "Psychic Noise", "Sleep Powder", "Sludge Bomb", "Substitute"],
+                "movepool": ["Giga Drain", "Leech Seed", "Psychic Noise", "Sleep Powder", "Substitute"],
                 "teraTypes": ["Steel"]
             },
             {
@@ -741,6 +746,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Freeze-Dry", "Rest", "Sleep Talk", "Sparkling Aria"],
                 "teraTypes": ["Dragon", "Ghost", "Ground", "Poison", "Steel"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dragon Dance", "Earthquake", "Freeze-Dry", "Waterfall"],
+                "teraTypes": ["Ground"]
             }
         ]
     },
@@ -1441,6 +1451,11 @@
                 "role": "Bulky Support",
                 "movepool": ["Discharge", "Ice Beam", "Recover", "Tri Attack"],
                 "teraTypes": ["Electric", "Ghost", "Poison"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Recover", "Shadow Ball", "Tera Blast", "Thunder Wave"],
+                "teraTypes": ["Fairy", "Fighting"]
             }
         ]
     },
@@ -1449,7 +1464,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Ceaseless Edge", "Glare", "Lunar Dance", "Shed Tail", "Spore", "Sticky Web", "Stone Axe"],
+                "movepool": ["Ceaseless Edge", "Lunar Dance", "Spore", "Sticky Web", "Stone Axe"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -1586,6 +1601,11 @@
                 "role": "Fast Support",
                 "movepool": ["Focus Blast", "Giga Drain", "Leech Seed", "Substitute"],
                 "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Earthquake", "Leaf Blade", "Rock Slide", "Swords Dance"],
+                "teraTypes": ["Rock"]
             }
         ]
     },
@@ -1619,7 +1639,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Play Rough", "Poison Fang", "Sucker Punch", "Taunt", "Throat Chop"],
+                "movepool": ["Crunch", "Play Rough", "Poison Fang", "Sucker Punch", "Taunt", "Throat Chop"],
                 "teraTypes": ["Fairy", "Poison"]
             }
         ]
@@ -1839,7 +1859,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Lava Plume", "Roar", "Stealth Rock"],
+                "movepool": ["Earthquake", "Fire Blast", "Roar", "Stealth Rock", "Will-O-Wisp"],
                 "teraTypes": ["Grass", "Water"]
             }
         ]
@@ -1979,7 +1999,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Gunk Shot", "Poltergeist", "Shadow Sneak", "Swords Dance", "Thunder Wave", "Will-O-Wisp"],
+                "movepool": ["Gunk Shot", "Poltergeist", "Shadow Sneak", "Swords Dance", "Thunder Wave"],
                 "teraTypes": ["Ghost", "Poison"]
             }
         ]
@@ -2025,6 +2045,11 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Charm", "Flip Turn", "Ice Beam", "Protect", "Surf", "Wish"],
+                "teraTypes": ["Dragon", "Ghost", "Poison"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Endeavor", "Substitute", "Surf", "Whirlpool"],
                 "teraTypes": ["Dragon", "Ghost", "Poison"]
             }
         ]
@@ -2169,7 +2194,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Body Slam", "Doom Desire", "Iron Head", "Protect", "Wish"],
+                "movepool": ["Body Slam", "Iron Head", "Protect", "Wish"],
                 "teraTypes": ["Water"]
             },
             {
@@ -2190,12 +2215,12 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Extreme Speed", "Knock Off", "Psycho Boost", "Superpower"],
-                "teraTypes": ["Fighting", "Normal", "Psychic", "Stellar"]
+                "teraTypes": ["Fighting", "Normal", "Psychic"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Ice Beam", "Knock Off", "Psycho Boost", "Superpower"],
-                "teraTypes": ["Fighting", "Psychic", "Stellar"]
+                "teraTypes": ["Fighting", "Psychic"]
             }
         ]
     },
@@ -2205,12 +2230,12 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Extreme Speed", "Knock Off", "Psycho Boost", "Superpower"],
-                "teraTypes": ["Fighting", "Normal", "Psychic", "Stellar"]
+                "teraTypes": ["Fighting", "Normal", "Psychic"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Ice Beam", "Knock Off", "Psycho Boost", "Superpower"],
-                "teraTypes": ["Fighting", "Psychic", "Stellar"]
+                "teraTypes": ["Fighting", "Psychic"]
             }
         ]
     },
@@ -2219,7 +2244,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Night Shade", "Recover", "Spikes", "Stealth Rock", "Taunt"],
+                "movepool": ["Cosmic Power", "Night Shade", "Recover", "Spikes", "Stealth Rock", "Taunt"],
                 "teraTypes": ["Steel"]
             },
             {
@@ -2230,7 +2255,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Dark Pulse", "Focus Blast", "Psychic", "Psychic Noise", "Psyshock", "Recover"],
-                "teraTypes": ["Dark", "Steel"]
+                "teraTypes": ["Dark", "Fighting", "Steel"]
             }
         ]
     },
@@ -2299,7 +2324,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Knock Off", "Pounce", "Sticky Web", "Taunt"],
+                "movepool": ["Knock Off", "Pounce", "Sticky Web", "Swords Dance", "Taunt"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -2399,7 +2424,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Double-Edge", "Knock Off", "Low Kick", "Switcheroo", "Triple Axel", "U-turn"],
+                "movepool": ["Double-Edge", "Knock Off", "Low Kick", "Triple Axel", "U-turn"],
                 "teraTypes": ["Ice", "Normal"]
             },
             {
@@ -2678,11 +2703,6 @@
                 "teraTypes": ["Water"]
             },
             {
-                "role": "Fast Bulky Setup",
-                "movepool": ["Dual Wingbeat", "Earthquake", "Facade", "Swords Dance"],
-                "teraTypes": ["Normal"]
-            },
-            {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Knock Off", "Protect", "Stealth Rock", "Toxic Spikes", "U-turn"],
                 "teraTypes": ["Water"]
@@ -2880,7 +2900,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Draco Meteor", "Fire Blast", "Heavy Slam", "Stealth Rock", "Thunder Wave", "Thunderbolt"],
-                "teraTypes": ["Dragon", "Fire", "Steel"]
+                "teraTypes": ["Dragon", "Fire", "Flying", "Steel"]
             }
         ]
     },
@@ -2890,7 +2910,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Draco Meteor", "Fire Blast", "Flash Cannon", "Stealth Rock", "Thunder Wave"],
-                "teraTypes": ["Dragon", "Fire", "Steel"]
+                "teraTypes": ["Dragon", "Fairy", "Fire"]
             }
         ]
     },
@@ -2926,6 +2946,11 @@
                 "role": "Bulky Support",
                 "movepool": ["Earth Power", "Flash Cannon", "Lava Plume", "Magma Storm", "Stealth Rock"],
                 "teraTypes": ["Flying", "Grass", "Steel"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Earth Power", "Magma Storm", "Protect", "Will-O-Wisp"],
+                "teraTypes": ["Flying", "Grass"]
             }
         ]
     },
@@ -3546,11 +3571,6 @@
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Focus Blast", "Psychic", "Psyshock", "Recover", "Shadow Ball"],
                 "teraTypes": ["Fighting", "Steel"]
-            },
-            {
-                "role": "AV Pivot",
-                "movepool": ["Focus Blast", "Future Sight", "Knock Off", "Psychic Noise", "Shadow Ball"],
-                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -3804,7 +3824,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Close Combat", "Earthquake", "Quick Attack", "Stone Edge"],
+                "movepool": ["Close Combat", "Earthquake", "Iron Head", "Stone Edge"],
                 "teraTypes": ["Fighting", "Ground"]
             }
         ]
@@ -3936,11 +3956,6 @@
                 "role": "Wallbreaker",
                 "movepool": ["Draco Meteor", "Earth Power", "Freeze-Dry", "Ice Beam", "Outrage"],
                 "teraTypes": ["Ground"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["Earth Power", "Freeze-Dry", "Protect", "Substitute"],
-                "teraTypes": ["Fairy", "Poison", "Steel"]
             }
         ]
     },
@@ -4074,8 +4089,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Dark Pulse", "Fire Blast", "Hyper Voice", "Taunt", "Will-O-Wisp", "Work Up"],
+                "movepool": ["Dark Pulse", "Fire Blast", "Hyper Voice", "Will-O-Wisp", "Work Up"],
                 "teraTypes": ["Fire"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Fire Blast", "Hyper Voice", "Solar Beam", "Sunny Day"],
+                "teraTypes": ["Fire", "Grass"]
             }
         ]
     },
@@ -4294,7 +4314,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Body Press", "Diamond Storm", "Earth Power", "Moonblast", "Stealth Rock"],
+                "movepool": ["Body Press", "Diamond Storm", "Earth Power", "Moonblast", "Rock Polish", "Stealth Rock"],
                 "teraTypes": ["Fighting"]
             },
             {
@@ -4374,7 +4394,7 @@
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Earthquake", "Knock Off", "Overheat", "Parting Shot", "Will-O-Wisp"],
+                "movepool": ["Close Combat", "Earthquake", "Flare Blitz", "Knock Off", "Parting Shot", "Will-O-Wisp"],
                 "teraTypes": ["Fighting", "Water"]
             },
             {
@@ -4411,6 +4431,11 @@
                 "role": "Bulky Support",
                 "movepool": ["Beak Blast", "Boomburst", "Bullet Seed", "Knock Off", "Roost", "U-turn"],
                 "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Brave Bird", "Bullet Seed", "Flame Charge", "Swords Dance"],
+                "teraTypes": ["Grass", "Steel"]
             }
         ]
     },
@@ -4485,7 +4510,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Hurricane", "Quiver Dance", "Revelation Dance", "Roost"],
-                "teraTypes": ["Fighting", "Ghost"]
+                "teraTypes": ["Fighting", "Ghost", "Ground"]
             }
         ]
     },
@@ -4494,7 +4519,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Moonblast", "Sticky Web", "Stun Spore", "U-turn"],
+                "movepool": ["Moonblast", "Psychic Noise", "Sticky Web", "Stun Spore", "U-turn"],
                 "teraTypes": ["Ghost"]
             },
             {
@@ -4559,7 +4584,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Hydro Pump", "Leech Life", "Liquidation", "Sticky Web"],
+                "movepool": ["Hydro Pump", "Leech Life", "Liquidation", "Mirror Coat", "Sticky Web"],
                 "teraTypes": ["Ground", "Steel", "Water"]
             }
         ]
@@ -4649,8 +4674,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Earth Power", "Hypnosis", "Shadow Ball", "Shore Up", "Stealth Rock"],
-                "teraTypes": ["Water"]
+                "movepool": ["Earth Power", "Shadow Ball", "Shore Up", "Sludge Bomb", "Stealth Rock"],
+                "teraTypes": ["Poison", "Water"]
             }
         ]
     },
@@ -4668,9 +4693,14 @@
         "level": 89,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["Body Slam", "Double-Edge", "Earthquake", "Knock Off", "Play Rough", "Rapid Spin", "Sucker Punch", "Superpower", "U-turn", "Wood Hammer"],
-                "teraTypes": ["Dark", "Fairy", "Fighting", "Grass", "Ground"]
+                "role": "Fast Attacker",
+                "movepool": ["Double-Edge", "Earthquake", "Knock Off", "Sucker Punch", "Superpower", "U-turn", "Wood Hammer"],
+                "teraTypes": ["Dark", "Fighting", "Grass", "Ground"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Body Slam", "Earthquake", "Knock Off", "Rapid Spin", "Sucker Punch", "U-turn"],
+                "teraTypes": ["Dark", "Ghost"]
             }
         ]
     },
@@ -4786,6 +4816,11 @@
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Moongeist Beam", "Moonlight", "Photon Geyser"],
                 "teraTypes": ["Dark", "Fairy"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Brick Break", "Dragon Dance", "Moongeist Beam", "Photon Geyser"],
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -4849,8 +4884,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Body Slam", "Double-Edge", "Earthquake", "Knock Off", "Psychic Fangs", "Swords Dance"],
-                "teraTypes": ["Ground", "Psychic"]
+                "movepool": ["Body Slam", "Double-Edge", "Earthquake", "Knock Off", "Swords Dance"],
+                "teraTypes": ["Ghost", "Ground"]
             }
         ]
     },
@@ -4905,7 +4940,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Apple Acid", "Draco Meteor", "Dragon Pulse", "Leech Seed", "Recover"],
-                "teraTypes": ["Grass", "Steel"]
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -4918,7 +4953,7 @@
                 "teraTypes": ["Dragon", "Steel"]
             },
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Glare", "Rest", "Stealth Rock", "Stone Edge"],
                 "teraTypes": ["Dragon", "Water"]
             },
@@ -5004,7 +5039,7 @@
             },
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Bulk Up", "Rest", "Spirit Break", "Sucker Punch", "Throat Chop", "Thunder Wave"],
+                "movepool": ["Bulk Up", "Crunch", "Rest", "Spirit Break", "Sucker Punch", "Throat Chop", "Thunder Wave"],
                 "teraTypes": ["Dark", "Poison", "Steel"]
             },
             {
@@ -5029,12 +5064,12 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Alluring Voice", "Calm Mind", "Psychic", "Psyshock", "Recover"],
+                "movepool": ["Alluring Voice", "Calm Mind", "Dazzling Gleam", "Psychic", "Psyshock", "Recover"],
                 "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Alluring Voice", "Calm Mind", "Recover", "Tera Blast"],
+                "movepool": ["Alluring Voice", "Calm Mind", "Dazzling Gleam", "Recover", "Tera Blast"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -5389,7 +5424,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Facade", "Headlong Rush", "Swords Dance", "Throat Chop", "Trailblaze"],
+                "movepool": ["Crunch", "Facade", "Headlong Rush", "Swords Dance", "Throat Chop", "Trailblaze"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -5401,6 +5436,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Blood Moon", "Calm Mind", "Earth Power", "Moonlight"],
                 "teraTypes": ["Ghost", "Normal", "Poison"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Blood Moon", "Calm Mind", "Moonlight", "Vacuum Wave"],
+                "teraTypes": ["Fighting", "Ghost", "Normal", "Poison"]
             }
         ]
     },
@@ -5409,8 +5449,8 @@
         "sets": [
             {
                 "role": "Tera Blast user",
-                "movepool": ["Play Rough", "Superpower", "Tera Blast", "Zen Headbutt"],
-                "teraTypes": ["Flying"]
+                "movepool": ["Moonblast", "Play Rough", "Superpower", "Tera Blast"],
+                "teraTypes": ["Stellar"]
             },
             {
                 "role": "Fast Bulky Setup",
@@ -5633,11 +5673,6 @@
         "level": 81,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["Body Press", "Curse", "Earthquake", "Recover", "Stone Edge"],
-                "teraTypes": ["Dragon", "Fairy"]
-            },
-            {
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Protect", "Recover", "Salt Cure"],
                 "teraTypes": ["Dragon", "Ghost"]
@@ -5656,6 +5691,11 @@
                 "role": "Wallbreaker",
                 "movepool": ["Armor Cannon", "Aura Sphere", "Energy Ball", "Focus Blast", "Psyshock"],
                 "teraTypes": ["Fighting", "Fire", "Grass", "Psychic"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Armor Cannon", "Energy Ball", "Meteor Beam", "Psyshock"],
+                "teraTypes": ["Fire", "Grass"]
             }
         ]
     },
@@ -5738,7 +5778,7 @@
         "level": 87,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Support",
                 "movepool": ["Earth Power", "Giga Drain", "Knock Off", "Leaf Storm", "Rapid Spin", "Spore", "Toxic"],
                 "teraTypes": ["Water"]
             }
@@ -5786,6 +5826,11 @@
                 "role": "Bulky Support",
                 "movepool": ["Bug Buzz", "Earth Power", "Psychic", "Revival Blessing", "Trick Room"],
                 "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Bug Buzz", "Calm Mind", "Earth Power", "Psychic", "Psyshock", "Recover"],
+                "teraTypes": ["Ground", "Steel", "Water"]
             }
         ]
     },
@@ -5841,6 +5886,11 @@
                 "role": "Bulky Support",
                 "movepool": ["Brave Bird", "Knock Off", "Roost", "Stealth Rock", "Sucker Punch", "U-turn"],
                 "teraTypes": ["Dark", "Steel"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Brave Bird", "Hone Claws", "Stone Edge", "Sucker Punch"],
+                "teraTypes": ["Rock"]
             }
         ]
     },
@@ -6105,7 +6155,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Earthquake", "First Impression", "Flare Blitz", "U-turn", "Wild Charge"],
-                "teraTypes": ["Bug", "Electric", "Fighting"]
+                "teraTypes": ["Bug", "Electric", "Fighting", "Fire"]
             }
         ]
     },
@@ -6294,7 +6344,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Ice Shard", "Icicle Crash", "Sacred Sword", "Sucker Punch", "Swords Dance", "Throat Chop"],
+                "movepool": ["Crunch", "Ice Shard", "Icicle Crash", "Sacred Sword", "Sucker Punch", "Swords Dance", "Throat Chop"],
                 "teraTypes": ["Dark", "Fighting", "Ice"]
             }
         ]
@@ -6359,7 +6409,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Dragon Pulse", "Dragon Tail", "Giga Drain", "Recover", "Sucker Punch"],
+                "movepool": ["Dragon Pulse", "Dragon Tail", "Giga Drain", "Infestation", "Recover", "Sucker Punch"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -6503,7 +6553,7 @@
                 "teraTypes": ["Steel"]
             },
             {
-                "role": "Fast Bulky Setup",
+                "role": "Bulky Setup",
                 "movepool": ["Earth Power", "Fickle Beam", "Giga Drain", "Nasty Plot", "Recover"],
                 "teraTypes": ["Steel"]
             },
@@ -6568,13 +6618,13 @@
         "level": 74,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["Calm Mind", "Rapid Spin", "Tera Starstorm", "Tri Attack"],
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Dark Pulse", "Rapid Spin", "Rest", "Tera Starstorm"],
                 "teraTypes": ["Stellar"]
             },
             {
-                "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Rest", "Sleep Talk", "Tera Starstorm"],
+                "role": "Fast Bulky Setup",
+                "movepool": ["Calm Mind", "Earth Power", "Rapid Spin", "Rest", "Tera Starstorm"],
                 "teraTypes": ["Stellar"]
             }
         ]

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1083,7 +1083,8 @@ export class RandomTeams {
 		case 'Sheer Force':
 			const braviaryCase = (species.id === 'braviaryhisui' && (role === 'Wallbreaker' || role === 'Bulky Protect'));
 			const abilitiesCase = (abilities.has('Guts') || abilities.has('Sharpness'));
-			return (!counter.get('sheerforce') || moves.has('bellydrum') || braviaryCase || abilitiesCase);
+			const movesCase = (moves.has('bellydrum') || moves.has('flamecharge'));
+			return (!counter.get('sheerforce') || braviaryCase || abilitiesCase || movesCase);
 		case 'Slush Rush':
 			return !teamDetails.snow;
 		case 'Solar Power':

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1156,7 +1156,7 @@ export class RandomTeams {
 		if (species.id === 'copperajah' && moves.has('heavyslam')) return 'Heavy Metal';
 		if (species.id === 'jumpluff') return 'Infiltrator';
 		if (species.id === 'toucannon' && !counter.get('skilllink')) return 'Keen Eye';
-		if (species.id === 'reuniclus') return (role === 'AV Pivot') ? 'Regenerator' : 'Magic Guard';
+		if (species.id === 'reuniclus') return 'Magic Guard';
 		if (species.id === 'smeargle' && !counter.get('technician')) return 'Own Tempo';
 		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it
 		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1658,6 +1658,9 @@ export class RandomTeams {
 			} else if ((moves.has('bellydrum') || moves.has('filletaway')) && (item === 'Sitrus Berry' || ability === 'Gluttony')) {
 				// Belly Drum should activate Sitrus Berry
 				if (hp % 2 === 0) break;
+			} else if (moves.has('substitute') && moves.has('endeavor')) {
+				// Luvdisc should be able to Substitute down to very low HP
+				if (hp % 4 > 0) break;
 			} else {
 				// Maximize number of Stealth Rock switch-ins
 				if (srWeakness <= 0 || ability === 'Regenerator' || ['Leftovers', 'Life Orb'].includes(item)) break;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -89,9 +89,9 @@ const SPEED_CONTROL = [
 const NO_STAB = [
 	'accelerock', 'aquajet', 'bounce', 'breakingswipe', 'bulletpunch', 'chatter', 'chloroblast', 'clearsmog', 'covet',
 	'dragontail', 'doomdesire', 'electroweb', 'eruption', 'explosion', 'fakeout', 'feint', 'flamecharge', 'flipturn', 'futuresight',
-	'grassyglide', 'iceshard', 'icywind', 'incinerate', 'machpunch', 'meteorbeam', 'mortalspin', 'nuzzle', 'pluck', 'pursuit', 'quickattack',
-	'rapidspin', 'reversal', 'selfdestruct', 'shadowsneak', 'skydrop', 'snarl', 'strugglebug', 'suckerpunch', 'uturn', 'watershuriken',
-	'vacuumwave', 'voltswitch', 'waterspout',
+	'grassyglide', 'iceshard', 'icywind', 'incinerate', 'infestation', 'machpunch', 'meteorbeam', 'mortalspin', 'nuzzle', 'pluck', 'pursuit',
+	'quickattack', 'rapidspin', 'reversal', 'selfdestruct', 'shadowsneak', 'skydrop', 'snarl', 'strugglebug', 'suckerpunch', 'uturn',
+	'vacuumwave', 'voltswitch', 'watershuriken', 'waterspout',
 ];
 // Hazard-setting moves
 const HAZARDS = [
@@ -122,7 +122,7 @@ const PRIORITY_POKEMON = [
 
 /** Pokemon who should never be in the lead slot */
 const NO_LEAD_POKEMON = [
-	'Iron Boulder', 'Zacian', 'Zamazenta',
+	'Iron Boulder', 'Slither Wing', 'Zacian', 'Zamazenta',
 ];
 const DOUBLES_NO_LEAD_POKEMON = [
 	'Basculegion', 'Houndstone', 'Roaring Moon', 'Zacian', 'Zamazenta',
@@ -571,6 +571,8 @@ export class RandomTeams {
 			['healbell', 'stealthrock'],
 			// Azelf and Zoroarks
 			['trick', 'uturn'],
+			// Araquanid
+			['mirrorcoat', 'hydropump'],
 		];
 
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
@@ -1001,8 +1003,8 @@ export class RandomTeams {
 	): boolean {
 		if ([
 			'Armor Tail', 'Battle Bond', 'Early Bird', 'Flare Boost', 'Galvanize', 'Gluttony', 'Harvest', 'Hydration', 'Ice Body', 'Immunity',
-			'Liquid Voice', 'Marvel Scale', 'Misty Surge', 'Moody', 'Own Tempo', 'Pressure', 'Quick Feet', 'Rain Dish', 'Sand Veil', 'Shed Skin',
-			'Sniper', 'Snow Cloak', 'Steadfast', 'Steam Engine',
+			'Liquid Voice', 'Marvel Scale', 'Misty Surge', 'Moody', 'Pressure', 'Quick Feet', 'Rain Dish', 'Sand Veil', 'Shed Skin',
+			'Sniper', 'Snow Cloak', 'Steadfast', 'Steam Engine', 'Sweet Veil',
 		].includes(ability)) return true;
 
 		switch (ability) {
@@ -1051,17 +1053,19 @@ export class RandomTeams {
 		case 'Lightning Rod':
 			return species.id === 'rhyperior';
 		case 'Mold Breaker':
-			return (abilities.has('Sharpness') || abilities.has('Unburden') || abilities.has('Sheer Force'));
+			return (['Pickpocket', 'Sharpness', 'Sheer Force', 'Unburden'].some(m => abilities.has(m)));
 		case 'Moxie':
 			return (!counter.get('Physical') || moves.has('stealthrock'));
 		case 'Natural Cure':
 			return species.id === 'pawmot';
 		case 'Neutralizing Gas':
 			return !isDoubles;
-		case 'Overcoat': case 'Sweet Veil':
+		case 'Overcoat':
 			return types.includes('Grass');
 		case 'Overgrow':
 			return !counter.get('Grass');
+		case 'Own Tempo':
+			return (!isDoubles || (counter.get('Special')) > 1);
 		case 'Prankster':
 			return (!counter.get('Status') || (species.id === 'grafaiai' && role === 'Setup Sweeper'));
 		case 'Reckless':
@@ -1105,7 +1109,7 @@ export class RandomTeams {
 		case 'Unaware':
 			return (species.id === 'clefable' && role !== 'Bulky Support');
 		case 'Unburden':
-			return (abilities.has('Prankster') || !counter.get('setup'));
+			return (abilities.has('Prankster') || !counter.get('setup') || species.id === 'sceptile');
 		case 'Vital Spirit':
 			// Magmar and Electabuzz want their contact status abilities in Doubles
 			return (species.nfe && isDoubles);
@@ -1159,7 +1163,6 @@ export class RandomTeams {
 		if (species.id === 'zebstrika') return (moves.has('wildcharge')) ? 'Sap Sipper' : 'Lightning Rod';
 		if (species.id === 'sandaconda' || (species.id === 'scrafty' && moves.has('rest'))) return 'Shed Skin';
 		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';
-		if (species.id === 'ribombee') return 'Shield Dust';
 		if (species.id === 'cinccino') return (role === 'Wallbreaker') ? 'Skill Link' : 'Technician';
 		if (species.id === 'dipplin') return 'Sticky Hold';
 		if (species.id === 'breloom') return 'Technician';
@@ -1179,7 +1182,6 @@ export class RandomTeams {
 			if (abilities.has('Own Tempo') && moves.has('petaldance')) return 'Own Tempo';
 			if (abilities.has('Slush Rush') && moves.has('snowscape')) return 'Slush Rush';
 			if (abilities.has('Soundproof') && (moves.has('substitute') || counter.get('setup'))) return 'Soundproof';
-			if (species.id === 'porygon2') return 'Trace';
 		}
 
 		// doubles, multi, and ffa
@@ -1318,7 +1320,8 @@ export class RandomTeams {
 			(species.id === 'magnezone' && moves.has('bodypress') && !isDoubles)
 		) return 'Choice Scarf';
 		if (species.id === 'rampardos' && (role === 'Fast Attacker' || isDoubles)) return 'Choice Scarf';
-		if (species.id === 'reuniclus' && ability === 'Magic Guard') return 'Life Orb';
+		if (species.id === 'reuniclus') return 'Life Orb';
+		if (species.id === 'luvdisc' && moves.has('substitute')) return 'Heavy-Duty Boots';
 		if (moves.has('bellydrum') && moves.has('substitute')) return 'Salac Berry';
 		if (
 			['Cheek Pouch', 'Cud Chew', 'Harvest', 'Ripen'].some(m => ability === m) ||
@@ -1494,7 +1497,7 @@ export class RandomTeams {
 		) {
 			return 'Assault Vest';
 		}
-		if (species.id === 'golem') return 'Custap Berry';
+		if (species.id === 'golem') return (counter.get('speedsetup')) ? 'Weakness Policy' : 'Custap Berry';
 		if (species.id === 'urshifurapidstrike') return 'Punching Glove';
 		if (species.id === 'palkia') return 'Lustrous Orb';
 		if (moves.has('substitute')) return 'Leftovers';
@@ -1516,9 +1519,10 @@ export class RandomTeams {
 			)
 		) return 'Rocky Helmet';
 		if (moves.has('outrage')) return 'Lum Berry';
+		if (moves.has('protect')) return 'Leftovers';
 		if (
 			role === 'Fast Support' && isLead &&
-			!counter.get('recovery') && !counter.get('recoil') && !moves.has('protect') &&
+			!counter.get('recovery') && !counter.get('recoil') &&
 			(species.baseStats.hp + species.baseStats.def + species.baseStats.spd) < 258
 		) return 'Focus Sash';
 		if (

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -78,9 +78,9 @@ const SPEED_SETUP = [
 ];
 // Conglomerate for ease of access
 const SETUP = [
-	'acidarmor', 'agility', 'autotomize', 'bellydrum', 'bulkup', 'calmmind', 'clangoroussoul', 'coil', 'curse', 'dragondance',
-	'flamecharge', 'growth', 'honeclaws', 'howl', 'irondefense', 'meditate', 'nastyplot', 'noretreat', 'poweruppunch', 'quiverdance',
-	'rockpolish', 'shellsmash', 'shiftgear', 'swordsdance', 'tailglow', 'tidyup', 'trailblaze', 'workup', 'victorydance',
+	'acidarmor', 'agility', 'autotomize', 'bellydrum', 'bulkup', 'calmmind', 'clangoroussoul', 'coil', 'cosmicpower', 'curse',
+	'dragondance', 'flamecharge', 'growth', 'honeclaws', 'howl', 'irondefense', 'meditate', 'nastyplot', 'noretreat', 'poweruppunch',
+	'quiverdance', 'rockpolish', 'shellsmash', 'shiftgear', 'swordsdance', 'tailglow', 'tidyup', 'trailblaze', 'workup', 'victorydance',
 ];
 const SPEED_CONTROL = [
 	'electroweb', 'glare', 'icywind', 'lowsweep', 'quash', 'rocktomb', 'stringshot', 'tailwind', 'thunderwave', 'trickroom',


### PR DESCRIPTION
This is a big one. We've been waiting for this for a while. It was delayed due to some fuckery with win rates, but we're ready now.

**Gen 9 Random Battle**
-Teams will no longer get multiple Sticky Web users. In order to accomplish this:
--Araquanid can now run Mirror Coat over Hydro Pump sometimes. If the team has a webs setter already, it will run both Mirror Coat and Hydro Pump with an Assault Vest.
--Kricketune now runs Swords Dance over Sticky Web on its current set if the team has a webs setter already. Swords Dance Kricketune will not exist otherwise.
--Ribombee's Sticky Web set can now run Psychic Noise. If the team has a webs setter already, it will run Moonblast + Psychic Noise + Stun Spore + U-turn.

-Teams will, under the vast majority of scenarios, no longer get multiple Stealth Rock users. In order to accomplish this:
--Golem's two sets have been fused together. Aside from tera types on the Stealth Rock set now matching that of Rock Polish, this presents no functional difference.
--Camerupt now runs Fire Blast and Will-O-Wisp instead of Lava Plume. Yes, this means it sometimes doesn't have Stealth Rock.

Removals and Reversions:
-Curse Stone Edge Garganacl no longer exists (Council decision).
-Assault Vest Regenerator Reuniclus no longer exists.
-Magnet Pull Alolan Golem no longer exists.
-Swords Dance Gliscor no longer exists.
-SubTect Kyurem no longer exists, as it performed poorly in win rate analysis.
-Slither Wing can no longer be a lead, which prevents Leftovers and Weakness Policy from generating on it (Council decision).
-Deoxys and Deoxys-Attack no longer run Tera Stellar, as they performed poorly in win rate analysis.
-Smeargle no longer runs Shed Tail or Glare, because it decreased in win rate despite gaining a level.
-Hydrapple now has Bulky Setup instead of Fast Bulky Setup, meaning it no longer gets Nasty Plot 3 Attacks Life Orb.
-Pyroar no longer runs Taunt, because it performed poorly in win rate analysis.
-Sweet Veil Alcremie no longer exists.
-Calm Mind Slowbro: -Psychic Noise
-Banette: -Will-O-Wisp
-Jirachi: -Doom Desire
-Ambipom: -Switcheroo
-Appletun: -Tera Grass

New Additions and Changes:
-Alcremie and Wigglytuff now roll between Alluring Voice and Dazzling Gleam.
-Grimmsnarl, Chien-Pao, Mightyena, and Ursaluna now roll between Crunch and Throat Chop.
-Sceptile now runs a third set of Setup Sweeper with Swords Dance, Leaf Blade, Earthquake, and Rock Slide with Tera Rock.
-Ursaluna-Bloodmoon now runs a second set with Vacuum Wave and no Earth Power.
-Toucannon now runs a second set with Swords Dance, Flame Charge, Brave Bird, and Bullet Seed.
-Luvdisc now runs a second set of Substitute, Endeavor, Surf, and Whirlpool with Heavy-Duty Boots.
-Heatran now runs a second set of Protect, Magma Storm, Will-O-Wisp, and Earth Power with Leftovers.
-Pyroar now runs a second set of Sunny Day, Fire Blast, Solar Beam, and Hyper Voice with Tera Fire/Grass.
-Armarouge now runs a second set of Power Herb with Meteor Beam, Armor Cannon, Energy Ball, and Psyshock with Tera Fire/Grass.
-Bombirdier now runs a third set of Heavy-Duty Boots with Hone Claws, Sucker Punch, Stone Edge, and Brave Bird with Tera Rock.
-Lapras now runs a third set of Heavy-Duty Boots with Dragon Dance, Earthquake, Waterfall, and Freeze-Dry with Tera Ground.
-Necrozma-Dawn-Wings now runs a third set of Life Orb with Dragon Dance, Moongeist Beam, Photon Geyser, and Brick Break with Tera Fighting.
-Rabsca now runs a second set of Calm Mind + Recover, without Revival Blessing.
-Komala's sets have been split and revamped such that AV always runs Body Slam and Choice items always run Double-Edge. Choice Scarf exists again. Coverage moves have been optimized significantly.
-Persian's sets have been split and revamped such that Fake Out always runs U-turn and Aerial Ace no longer exists.
-Terapagos now runs Calm Mind, Tera Starstorm, Dark Pulse/Earth Power, and Rest/Rapid Spin. It has no other sets anymore.
-Blastoise now runs a new Tera Blast Electric/Grass set.
-Porygon2 now runs a new Tera Blast Fighting/Fairy set with Shadow Ball and Thunder Wave. It is now also always Download.
-Tera Blast Enamorus now runs Tera Stellar with Moonblast, Play Rough, Superpower, and Tera Blast. Play Rough will not be removed from this set.
-Tinkaton now runs Pickpocket.
-Sandaconda's Bulky Support set was changed to Bulky Attacker to prevent mono-Earthquake sets.
-Toedscruel's Bulky Attacker set was changed to Bulky Support to force Rapid Spin.
-Night Shade Deoxys-Defense: +Cosmic Power
-Calm Mind Deoxys-Defense: +Tera Fighting
-Choice Band Terrakion: -Quick Attack, +Iron Head
-Palossand: -Hypnosis, +Sludge Bomb, +Tera Poison
-Fast Attacker Incineroar: -Overheat, +Flare Blitz
-Bulky Support Exeggutor: -Sludge Bomb, +Giga Drain
-Bulky Attacker Diancie: +Rock Polish (DOES NOT GIVE WEAKNESS POLICY)
-Greedent: -Psychic Fangs, -Tera Psychic, +Tera Ghost
-Dipplin: +Infestation
-Slither Wing: +Tera Fire
-Dialga: +Tera Flying
-Dialga-Origin: -Tera Steel, +Tera Fairy
-Support Tyranitar: -Tera Poison, +Tera Ghost
-Oricorio-Sensu: +Tera Ground

**Gen 9 Random Doubles**
-Sweet Veil Alcremie no longer exists.
-Tinkaton now runs Own Tempo or Pickpocket, weighted 2:1 towards Own Tempo.
-Toucannon now runs a second set with Beak Blast and Knock Off over Brave Bird and Tailwind.
-Iron Hands: -Tera Fighting
-Metagross now runs Heavy Slam over Meteor Mash.
-Iron Leaves now has the correct tera types on the correct sets.
-Ceruledge: -Close Combat

**Old Gens**
-All instances of Hidden Power Grass have been removed from Electric-types. This includes Electrode, Zebstrika, and Mega Manectric.
-Switcheroo was removed from Manectric in all gens in which it gets Volt Switch.
-Jolteon's sets were adjusted in gens 5-7 s.t. it always gets Volt Switch.
-Switcheroo was removed from Ambipom in all gens 4-7.
-Screens were removed from Grumpig in all gens 4-7.
-Superpower was removed from Krookodile in all gens 5-7.
-Staller Maractus had Toxic removed in favor of HP Fire/Ice in gens 5-7.
-Screens was removed from Deoxys-Speed in gens 4-5.
-Durant now always gets Superpower in gens 5-7.
-Electrode's first set now always gets HP Ice in gens 5-7.
-Dusknoir now always gets Earthquake in gens 4-7.
-Shiftry now always gets Sucker Punch and doesn't always get Dark Pulse in gens 4-5.
-Plusle and Minun will now always have HP Ice in gens 5-7.
-Vanilluxe will now always have HP Ground in gens 5-7.
-Ledian no longer runs Screens in gen 5-6. Its set was changed in 5 to look more like its Gen 7 set, with Acrobatics, Knock Off, and Focus Blast.
-Switcheroo and Aerial Ace were removed from all oldgens where Persian had them.
-Arbok lost Seed Bomb in gen 5 and Aqua Tail in gen 4 in favor of the other one.
-Chimecho was changed to include HP Fighting in Gen 5, to match Gen 4.
-Abomasnow no longer gets HP Fire in gen 5.
-Gen 5 Mienshao now can run Choice Band.
-Forretress now runs Earthquake over Gyro Ball in gen 5 and Payback over Gyro Ball in Gen 4.
-Calm Mind 3 attacks Serperior now runs Life Orb in gen 5.
-Lunatone now always has Psychic in gen 5 and can no longer run Choice Specs.
-Swords Dance Absol no longer runs Psycho Cut in gen 5.
-Drifblim no longer runs Thunder Wave in gen 5.
-Garbodor now always gets Drain Punch in gen 5.
-Moxie Heracross now always gets Stone Edge in gen 5.
-Ambipom now runs Payback in Gen 5.
-Jumpluff now gets Sleep Powder instead of Protect on its Staller set in gen 5.
-Night Shade Noctowl no longer exists in Gen 5.
-Ice Beam Pelipper no longer exists in Gen 5.
-Conkeldurr can now get Choice Band in Gen 5.