### PR TITLE
Fix interaction of Court Change, Sticky Web, and Defiant or Competitive

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -626,9 +626,6 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	competitive: {
 		onAfterEachBoost(boost, target, source, effect) {
 			if (!source || target.isAlly(source)) {
-				if (effect.id === 'stickyweb') {
-					this.hint("Court Change Sticky Web counts as lowering your own Speed, and Competitive only affects stats lowered by foes.", true, source.side);
-				}
 				return;
 			}
 			let statsLowered = false;
@@ -887,9 +884,6 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	defiant: {
 		onAfterEachBoost(boost, target, source, effect) {
 			if (!source || target.isAlly(source)) {
-				if (effect.id === 'stickyweb') {
-					this.hint("Court Change Sticky Web counts as lowering your own Speed, and Defiant only affects stats lowered by foes.", true, source.side);
-				}
 				return;
 			}
 			let statsLowered = false;

--- a/data/mods/gen8/abilities.ts
+++ b/data/mods/gen8/abilities.ts
@@ -172,6 +172,24 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	},
 	competitive: {
 		inherit: true,
+		onAfterEachBoost(boost, target, source, effect) {
+			if (!source || target.isAlly(source)) {
+				if (effect.id === 'stickyweb') {
+					this.hint("In Gen 8, Court Change Sticky Web counts as lowering your own Speed, and Competitive only affects stats lowered by foes.", true, source.side);
+				}
+				return;
+			}
+			let statsLowered = false;
+			let i: BoostID;
+			for (i in boost) {
+				if (boost[i]! < 0) {
+					statsLowered = true;
+				}
+			}
+			if (statsLowered) {
+				this.boost({spa: 2}, target, target, null, false, true);
+			}
+		},
 		rating: 2.5,
 	},
 	compoundeyes: {
@@ -231,6 +249,24 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	},
 	defiant: {
 		inherit: true,
+		onAfterEachBoost(boost, target, source, effect) {
+			if (!source || target.isAlly(source)) {
+				if (effect.id === 'stickyweb') {
+					this.hint("In Gen 8, Court Change Sticky Web counts as lowering your own Speed, and Defiant only affects stats lowered by foes.", true, source.side);
+				}
+				return;
+			}
+			let statsLowered = false;
+			let i: BoostID;
+			for (i in boost) {
+				if (boost[i]! < 0) {
+					statsLowered = true;
+				}
+			}
+			if (statsLowered) {
+				this.boost({atk: 2}, target, target, null, false, true);
+			}
+		},
 		rating: 2.5,
 	},
 	deltastream: {

--- a/data/mods/gen8/moves.ts
+++ b/data/mods/gen8/moves.ts
@@ -529,6 +529,19 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	stickyweb: {
+		inherit: true,
+		condition: {
+			onSideStart(side) {
+				this.add('-sidestart', side, 'move: Sticky Web');
+			},
+			onEntryHazard(pokemon) {
+				if (!pokemon.isGrounded() || pokemon.hasItem('heavydutyboots')) return;
+				this.add('-activate', pokemon, 'move: Sticky Web');
+				this.boost({spe: -1}, pokemon, this.effectState.source, this.dex.getActiveMove('stickyweb'));
+			},
+		},
+	},
 	stormthrow: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -18612,7 +18612,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onEntryHazard(pokemon) {
 				if (!pokemon.isGrounded() || pokemon.hasItem('heavydutyboots')) return;
 				this.add('-activate', pokemon, 'move: Sticky Web');
-				this.boost({spe: -1}, pokemon, this.effectState.source, this.dex.getActiveMove('stickyweb'));
+				this.boost({spe: -1}, pokemon, pokemon.side.foe.active[0], this.dex.getActiveMove('stickyweb'));
 			},
 		},
 		secondary: null,

--- a/test/sim/abilities/defiant.js
+++ b/test/sim/abilities/defiant.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe(`Defiant`, function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it(`should raise the user's attack when lowered by an opponent`, function () {
+		battle = common.createBattle([[
+			{species: 'pawniard', ability: 'defiant', moves: ['sleeptalk', 'tackle']},
+		], [
+			{species: 'wynaut', moves: ['faketears', 'firelash', 'silktrap']},
+		]]);
+		battle.makeChoices('auto', 'move faketears');
+		battle.makeChoices('auto', 'move firelash');
+		battle.makeChoices('move tackle', 'move silktrap');
+
+		assert.statStage(battle.p1.active[0], 'atk', 6);
+	});
+
+	it(`should not raise the user's attack when lowered by itself or an ally`, function () {
+		battle = common.createBattle({gameType: 'doubles'}, [[
+			{species: 'pawniard', ability: 'defiant', moves: ['closecombat', 'sleeptalk']},
+			{species: 'wynaut', moves: ['faketears', 'firelash', 'silktrap']},
+		], [
+			{species: 'screamtail', moves: ['sleeptalk']},
+			{species: 'jigglypuff', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices('move sleeptalk, move firelash -1', 'auto');
+		battle.makeChoices('move closecombat 1, move faketears -1', 'auto');
+		battle.makeChoices('move closecombat -2, move silktrap', 'auto');
+
+		assert.statStage(battle.p1.active[0], 'atk', 0);
+	});
+});

--- a/test/sim/moves/courtchange.js
+++ b/test/sim/moves/courtchange.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe(`Court Change`, function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it(`should swap certain side conditions to the opponent's side and vice versa`, function () {
+		battle = common.createBattle([[
+			{species: 'wynaut', moves: ['sleeptalk', 'stealthrock', 'lightscreen']},
+		], [
+			{species: 'cinderace', moves: ['courtchange', 'tailwind', 'safeguard']},
+		]]);
+		battle.makeChoices('move stealthrock', 'move tailwind');
+		battle.makeChoices('move lightscreen', 'move safeguard');
+		battle.makeChoices('move sleeptalk', 'move courtchange');
+
+		assert(!!battle.p1.sideConditions['tailwind']);
+		assert(!!battle.p1.sideConditions['safeguard']);
+		assert(!!battle.p1.sideConditions['stealthrock']);
+		assert(!!battle.p2.sideConditions['lightscreen']);
+	});
+
+	it(`should allow Sticky Web to trigger Defiant when set by the Defiant user's team`, function () {
+		battle = common.createBattle([[
+			{species: 'cinderace', moves: ['courtchange', 'stickyweb', 'sleeptalk']},
+			{species: 'pawniard', ability: 'defiant', moves: ['sleeptalk']},
+		], [
+			{species: 'wynaut', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices('move stickyweb', 'auto');
+		battle.makeChoices('move courtchange', 'auto');
+		battle.makeChoices('switch 2', 'auto');
+
+		assert(!!battle.p1.sideConditions['stickyweb']);
+		assert.statStage(battle.p1.active[0], 'atk', 2);
+	});
+
+	it(`[Gen 8] should not allow Sticky Web to trigger Defiant when set by the Defiant user's team`, function () {
+		battle = common.gen(8).createBattle([[
+			{species: 'cinderace', moves: ['courtchange', 'stickyweb', 'sleeptalk']},
+			{species: 'pawniard', ability: 'defiant', moves: ['sleeptalk']},
+		], [
+			{species: 'wynaut', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices('move stickyweb', 'auto');
+		battle.makeChoices('move courtchange', 'auto');
+		battle.makeChoices('switch 2', 'auto');
+
+		assert(!!battle.p1.sideConditions['stickyweb']);
+		assert.statStage(battle.p1.active[0], 'atk', 0);
+	});
+});


### PR DESCRIPTION
Behavior changed in Gen 9 (at some point) to allow Sticky Web transferred back to the Sticky Web user's side to trigger Defiant/Competitive: https://www.smogon.com/forums/threads/behavior-of-court-change-and-sticky-web.3734837/. Previously in Gen 8, it would not trigger Defiant/Competitive.

It is not clear which of these 3 Game Freak changed to result in the changed behavior. I'm not sure if it's _always_ had this same behavior in Gen 9 or if it was only introduced in a patch recently. I basically just went with the route of reverting back to what we did before: https://github.com/smogon/pokemon-showdown/pull/6265, so it's modifying Sticky Web (and moving the now generation-specific hint).