### PR TITLE
VaporeMons: Open Baxcalibur Suspect Test, Nerf Meloetta-P, Ban Sleep, and Bugfixes

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -542,7 +542,7 @@ export const Formats: FormatList = [
 		],
 
 		mod: 'vaporemons',
-		ruleset: ['Standard', 'Terastal Clause', 'VaporeMons Mod'],
+		ruleset: ['Standard', 'Terastal Clause', 'VaporeMons Mod', 'Sleep Moves Clause', '!Sleep Clause Mod'],
 		banlist: ['Uber', 'AG', 'Arena Trap', 'Moody', 'Shadow Tag', 'King\'s Rock', 'Baton Pass', 'Last Respects', 'Shed Tail', 'Light Clay'],
 		onSwitchIn(pokemon) {
 			this.add('-start', pokemon, 'typechange', (pokemon.illusion || pokemon).getTypes(true).join('/'), '[silent]');

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -543,7 +543,7 @@ export const Formats: FormatList = [
 
 		mod: 'vaporemons',
 		ruleset: ['Standard', 'Terastal Clause', 'VaporeMons Mod', 'Sleep Moves Clause', '!Sleep Clause Mod'],
-		banlist: ['Uber', 'AG', 'Arena Trap', 'Moody', 'Shadow Tag', 'King\'s Rock', 'Baton Pass', 'Last Respects', 'Shed Tail', 'Light Clay'],
+		banlist: ['Uber', 'AG', 'Arena Trap', 'Moody', 'Shadow Tag', 'King\'s Rock', 'Baton Pass', 'Last Respects', 'Shed Tail', 'Light Clay', 'Fling + Segin Star Shard'],
 		onSwitchIn(pokemon) {
 			this.add('-start', pokemon, 'typechange', (pokemon.illusion || pokemon).getTypes(true).join('/'), '[silent]');
 		},

--- a/data/mods/vaporemons/formats-data.ts
+++ b/data/mods/vaporemons/formats-data.ts
@@ -1745,7 +1745,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	porygon2: {
-		tier: "rU",
+		tier: "RU",
 		doublesTier: "DOU",
 	},
 	porygonz: {

--- a/data/mods/vaporemons/formats-data.ts
+++ b/data/mods/vaporemons/formats-data.ts
@@ -60,7 +60,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	slowbro: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	slowbrogalar: {
@@ -144,7 +144,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	taurospaldeablaze: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	taurospaldeaaqua: {
@@ -308,11 +308,11 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	weavile: {
-		tier: "UU",
+		tier: "OU",
 		doublesTier: "DOU",
 	},
 	sneasler: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	ursaring: {
@@ -604,7 +604,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	samurotthisui: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	lilligant: {
@@ -740,7 +740,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	greninja: {
-		tier: "UU",
+		tier: "OU",
 		doublesTier: "DOU",
 	},
 	talonflame: {
@@ -1084,7 +1084,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	enamorus: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	enamorustherian: {
@@ -1092,7 +1092,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	meowscarada: {
-		tier: "UU",
+		tier: "OU",
 		doublesTier: "DOU",
 	},
 	skeledirge: {
@@ -1160,7 +1160,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	ceruledge: {
-		tier: "UU",
+		tier: "OU",
 		doublesTier: "DOU",
 	},
 	bellibolt: {
@@ -1308,7 +1308,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	baxcalibur: {
-		tier: "Uber",
+		tier: "OU",
 		doublesTier: "DOU",
 	},
 	gholdengo: {
@@ -1516,7 +1516,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	manaphy: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	shaymin: {
@@ -1656,10 +1656,10 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	terapagos: {
-		tier: "OU",
+		tier: "UU",
 	},
 	hydrapple: {
-		tier: "OU",
+		tier: "UU",
 	},
 	ragingbolt: {
 		tier: "OU",
@@ -1677,47 +1677,47 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		tier: "OU",
 	},
 	venusaur: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	blastoise: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	vileplume: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	bellossom: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	tentacruel: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	dodrio: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	dewgong: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	exeggutor: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	hitmonlee: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	hitmonchan: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	hitmontop: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	rhydon: {
@@ -1725,47 +1725,47 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	rhyperior: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	kingdra: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	electivire: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	magmortar: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	lapras: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	porygon2: {
-		tier: "RU",
+		tier: "rU",
 		doublesTier: "DOU",
 	},
 	porygonz: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	meganium: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	feraligatr: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	lanturn: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	granbull: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	skarmory: {
@@ -1773,19 +1773,19 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	smeargle: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	raikou: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	entei: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	suicune: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	lugia: {
@@ -1797,7 +1797,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	sceptile: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	combusken: {
@@ -1809,43 +1809,47 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	swampert: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	plusle: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	minun: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	flygon: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	metagross: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	regirock: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	regice: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	registeel: {
+		tier: "UU",
+		doublesTier: "DOU",
+	},
+	regigigas: {
 		tier: "OU",
 		doublesTier: "DOU",
 	},
 	latias: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	latios: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	deoxys: {
@@ -1857,7 +1861,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	deoxysdefense: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	deoxysspeed: {
@@ -1865,63 +1869,63 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	rampardos: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	bastiodon: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	serperior: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	emboar: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	zebstrika: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	excadrill: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	whimsicott: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	scrafty: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	cinccino: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	reuniclus: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	galvantula: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	golurk: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	cobalion: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	terrakion: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	virizion: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	reshiram: {
@@ -1949,39 +1953,39 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	meowstic: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	meowsticf: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	malamar: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	incineroar: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	primarina: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	toucannon: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	araquanid: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	comfey: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	minior: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	cosmog: {
@@ -2001,7 +2005,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	necrozma: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	necrozmaduskmane: {
@@ -2013,7 +2017,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	alcremie: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	duraludon: {
@@ -2021,7 +2025,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		doublesTier: "DOU",
 	},
 	exeggutoralola: {
-		tier: "OU",
+		tier: "UU",
 		doublesTier: "DOU",
 	},
 	revavroomcaph: {

--- a/data/mods/vaporemons/items.ts
+++ b/data/mods/vaporemons/items.ts
@@ -278,14 +278,14 @@ export const Items: {[itemid: string]: ModdedItemData} = {
 		},
 		onUpdate(pokemon) {
 			if (pokemon.moveThisTurnResult === false) {
-				this.boost({spe: 2});
+				this.boost({spe: 2, accuracy: 2});
 				pokemon.useItem();
 			}
 		},
 		// Item activation located in scripts.js
 		num: 1121,
 		gen: 8,
-		desc: "+2 Speed if the holder's move fails. Single use.",
+		desc: "+2 Speed & Accuracy if the holder's move fails. Single use.",
 	},
 	punchingglove: {
 		name: "Punching Glove",

--- a/data/mods/vaporemons/items.ts
+++ b/data/mods/vaporemons/items.ts
@@ -999,10 +999,12 @@ export const Items: {[itemid: string]: ModdedItemData} = {
 		spritenum: 624,
 		onTakeItem: false,
 		onSwitchIn(pokemon) {
-			this.add('-item', pokemon, 'Diancite Stone Fragment');
-			pokemon.setAbility('magicbounce', pokemon, true);
-			this.add('-activate', pokemon, 'ability: Magic Bounce');
-			this.boost({atk: 1, spa: 1, spe: 1});
+			if (pokemon.baseSpecies.name === 'Diancie') {
+				this.add('-item', pokemon, 'Diancite Stone Fragment');
+				pokemon.setAbility('magicbounce', pokemon, true);
+				this.add('-activate', pokemon, 'ability: Magic Bounce');
+				this.boost({atk: 1, spa: 1, spe: 1});
+			}
 		},
 		itemUser: ["Diancie"],
 		gen: 9,

--- a/data/mods/vaporemons/moves.ts
+++ b/data/mods/vaporemons/moves.ts
@@ -183,7 +183,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 			onEntryHazard(pokemon) {
 				if (pokemon.hasItem('heavydutyboots') || pokemon.hasAbility('overcoat') ||
-					 pokemon.hasItem('dancingshoes') || pokemon.hasItem('mantisclaw')) return;
+					 pokemon.hasItem('mantisclaw')) return;
 				const healAmounts = [0, 3]; // 1/8
 				this.heal(healAmounts[this.effectState.layers] * pokemon.maxhp / 24);
 			},
@@ -1528,7 +1528,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 			onEntryHazard(pokemon) {
 				if (pokemon.hasItem('heavydutyboots') || pokemon.hasAbility('overcoat') ||
-					 pokemon.hasItem('dancingshoes') || pokemon.hasItem('mantisclaw')) return;
+					 pokemon.hasItem('mantisclaw')) return;
 				const typeMod = this.clampIntRange(pokemon.runEffectiveness(this.dex.getActiveMove('stealthrock')), -6, 6);
 				if (pokemon.hasAbility('smelt')) {
 					const fireHazard = this.dex.getActiveMove('Stealth Rock');
@@ -1570,7 +1570,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onEntryHazard(pokemon) {
 				if (!pokemon.isGrounded()) return;
 				if (pokemon.hasItem('heavydutyboots') || pokemon.hasAbility('overcoat') ||
-					 pokemon.hasItem('dancingshoes') || pokemon.hasItem('mantisclaw')) return;
+					 pokemon.hasItem('mantisclaw')) return;
 				const damageAmounts = [0, 3, 4, 6]; // 1/8, 1/6, 1/4
 				this.damage(damageAmounts[this.effectState.layers] * pokemon.maxhp / 24);
 			},
@@ -1608,7 +1608,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					this.add('-sideend', pokemon.side, 'move: Toxic Spikes', '[of] ' + pokemon);
 					pokemon.side.removeSideCondition('toxicspikes');
 				} else if (pokemon.hasType('Steel') || pokemon.hasItem('heavydutyboots') ||
-							  pokemon.hasAbility('overcoat') || pokemon.hasItem('dancingshoes') || pokemon.hasItem('mantisclaw')) {
+							  pokemon.hasAbility('overcoat') || pokemon.hasItem('mantisclaw')) {
 					return;
 				} else if (this.effectState.layers >= 2) {
 					pokemon.trySetStatus('tox', pokemon.side.foe.active[0]);
@@ -1639,7 +1639,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			},
 			onEntryHazard(pokemon) {
 				if (!pokemon.isGrounded() || pokemon.hasItem('heavydutyboots') || pokemon.hasAbility('overcoat') ||
-					 pokemon.hasItem('dancingshoes') || pokemon.hasItem('mantisclaw')) return;
+					 pokemon.hasItem('mantisclaw')) return;
 				this.add('-activate', pokemon, 'move: Sticky Web');
 				this.boost({spe: -1}, pokemon, this.effectState.source, this.dex.getActiveMove('stickyweb'));
 			},

--- a/data/mods/vaporemons/scripts.ts
+++ b/data/mods/vaporemons/scripts.ts
@@ -23,6 +23,71 @@ export const Scripts: ModdedBattleScriptsData = {
 			);
 		},
 	},
+	actions: {
+		hitStepAccuracy(targets: Pokemon[], pokemon: Pokemon, move: ActiveMove) {
+			const hitResults = [];
+			for (const [i, target] of targets.entries()) {
+				this.battle.activeTarget = target;
+				// calculate true accuracy
+				let accuracy = move.accuracy;
+				if (move.ohko) { // bypasses accuracy modifiers
+					if (!target.isSemiInvulnerable()) {
+						accuracy = 30;
+						if (move.ohko === 'Ice' && this.battle.gen >= 7 && !pokemon.hasType('Ice')) {
+							accuracy = 20;
+						}
+						if (!target.volatiles['dynamax'] && pokemon.level >= target.level &&
+							(move.ohko === true || !target.hasType(move.ohko))) {
+							accuracy += (pokemon.level - target.level);
+						} else {
+							this.battle.add('-immune', target, '[ohko]');
+							hitResults[i] = false;
+							continue;
+						}
+					}
+				} else {
+					accuracy = this.battle.runEvent('ModifyAccuracy', target, pokemon, move, accuracy);
+					if (accuracy !== true) {
+						let boost = 0;
+						if (!move.ignoreAccuracy) {
+							const boosts = this.battle.runEvent('ModifyBoost', pokemon, null, null, {...pokemon.boosts});
+							boost = this.battle.clampIntRange(boosts['accuracy'], -6, 6);
+						}
+						if (!move.ignoreEvasion) {
+							const boosts = this.battle.runEvent('ModifyBoost', target, null, null, {...target.boosts});
+							boost = this.battle.clampIntRange(boost - boosts['evasion'], -6, 6);
+						}
+						if (boost > 0) {
+							accuracy = this.battle.trunc(accuracy * (3 + boost) / 3);
+						} else if (boost < 0) {
+							accuracy = this.battle.trunc(accuracy * 3 / (3 - boost));
+						}
+					}
+				}
+				if (move.alwaysHit || (move.id === 'toxic' && this.battle.gen >= 8 && pokemon.hasType('Poison')) ||
+						(move.target === 'self' && move.category === 'Status' && !target.isSemiInvulnerable())) {
+					accuracy = true; // bypasses ohko accuracy modifiers
+				} else {
+					accuracy = this.battle.runEvent('Accuracy', target, pokemon, move, accuracy);
+				}
+				if (accuracy !== true && !this.battle.randomChance(accuracy, 100)) {
+					if (move.smartTarget) {
+						move.smartTarget = false;
+					} else {
+						if (!move.spreadHit) this.battle.attrLastMove('[miss]');
+						this.battle.add('-miss', pokemon, target);
+					}
+					if (!move.ohko && pokemon.hasItem('blunderpolicy') && pokemon.useItem()) {
+						this.battle.boost({spe: 2, accuracy: 2}, pokemon);
+					}
+					hitResults[i] = false;
+					continue;
+				}
+				hitResults[i] = true;
+			}
+			return hitResults;
+		},
+	},
 	init() {
 		this.modData("Learnsets", "screamtail").learnset.dracometeor = ["9L1"];
 		this.modData("Learnsets", "screamtail").learnset.dragonpulse = ["9L1"];

--- a/data/mods/vaporemons/scripts.ts
+++ b/data/mods/vaporemons/scripts.ts
@@ -114,7 +114,6 @@ export const Scripts: ModdedBattleScriptsData = {
 		this.modData('Learnsets', 'avalugghisui').learnset.stoneaxe = ['9L1'];
 		this.modData('Learnsets', 'drednaw').learnset.stoneaxe = ['9L1'];
 		delete this.modData('Learnsets', 'regieleki').learnset.electroweb;
-		delete this.modData('Learnsets', 'meloetta').learnset.sing;
 		delete this.modData('Learnsets', 'meloetta').learnset.swordsdance;
 		delete this.modData('Learnsets', 'magnemite').learnset.electroweb;
 		delete this.modData('Learnsets', 'magnezone').learnset.electroweb;
@@ -281,7 +280,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		this.modData("Learnsets", "meloetta").learnset.axekick = ["9L1"];
 		this.modData("Learnsets", "meloetta").learnset.blazekick = ["9L1"];
 		this.modData("Learnsets", "meloetta").learnset.healbell = ["9L1"];
-		this.modData("Learnsets", "meloetta").learnset.megakick = ["9L1"];
+		this.modData("Learnsets", "meloetta").learnset.takedown = ["9L1"];
 		this.modData("Learnsets", "meloetta").learnset.rapidspin = ["9L1"];
 		this.modData("Learnsets", "meloetta").learnset.recover = ["9L1"];
 		this.modData("Learnsets", "meloetta").learnset.vacuumwave = ["9L1"];
@@ -1180,7 +1179,6 @@ export const Scripts: ModdedBattleScriptsData = {
 		this.modData("Learnsets", "snorlax").learnset.rollout = ["9L1"];
 		this.modData("Learnsets", "snorlax").learnset.slackoff = ["9L1"];
 		delete this.modData('Learnsets', 'sneasler').learnset.acrobatics;
-		delete this.modData('Learnsets', 'darkrai').learnset.hypnosis;
 		delete this.modData('Learnsets', 'darkrai').learnset.psychic;
 		delete this.modData('Learnsets', 'darkrai').learnset.nastyplot;
 		delete this.modData('Learnsets', 'mew').learnset.steelbeam;


### PR DESCRIPTION
New VaporeMons updates from [this post](https://www.smogon.com/forums/threads/vaporemons-slate-10-dlc2-vr-update-pet-mod-of-the-season.3722917/post-9949279), including the following:
- Unban of Baxcalibur for its Suspect Test
- Nerfs to Meloetta-Pirouette
- Removal of Sleep Clause and addition of Sleep Moves Clause
- Some Sleep-related nerf reversions
- Bugfix for Diancite Stone Fragment
- Updated tiering 