### PR TITLE
Prevent groupchat hosts from muting themselves

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -643,9 +643,9 @@ exports.grouplist = [
 		globalGroupInPersonalRoom: '@',
 
 		announce: true,
-		warn: '\u2605u',
+		warn: true,
 		kick: true,
-		mute: '\u2605u',
+		mute: true,
 		lock: true,
 		forcerename: true,
 		timer: true,


### PR DESCRIPTION
https://www.smogon.com/forums/threads/mutes-in-groupchats.3734293/

This also prevents global drivers and moderators from muting the host of a groupchat, but based on the history of config-example.js, this appears to be more of an oversight than an intended feature. I can't speak for global staff, but it doesn't seem like a useful feature now due to groupchats being restricted to trusted users.