### PR TITLE
Speed up Random Battles species selection

### DIFF
--- a/data/mods/gen1/random-teams.ts
+++ b/data/mods/gen1/random-teams.ts
@@ -125,7 +125,6 @@ export class RandomGen1Teams extends RandomGen2Teams {
 		let numMaxLevelPokemon = 0;
 
 		const pokemonPool = Object.keys(this.getPokemonPool(type, pokemon, isMonotype, Object.keys(this.randomData))[0]);
-
 		while (pokemonPool.length && pokemon.length < this.maxTeamSize) {
 			const species = this.dex.species.get(this.sampleNoReplace(pokemonPool));
 			if (!species.exists) continue;

--- a/data/mods/gen1/random-teams.ts
+++ b/data/mods/gen1/random-teams.ts
@@ -124,7 +124,8 @@ export class RandomGen1Teams extends RandomGen2Teams {
 		const weaknessCount: {[k: string]: number} = {Electric: 0, Psychic: 0, Water: 0, Ice: 0, Ground: 0, Fire: 0};
 		let numMaxLevelPokemon = 0;
 
-		const pokemonPool = this.getPokemonPool(type, pokemon, isMonotype, Object.keys(this.randomData))[0];
+		const pokemonPool = Object.keys(this.getPokemonPool(type, pokemon, isMonotype, Object.keys(this.randomData))[0]);
+
 		while (pokemonPool.length && pokemon.length < this.maxTeamSize) {
 			const species = this.dex.species.get(this.sampleNoReplace(pokemonPool));
 			if (!species.exists) continue;

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -689,7 +689,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		while (shuffledBaseSpecies.length && pokemon.length < this.maxTeamSize) {
 			// repeated popping from weighted shuffle is equivalent to repeated weighted sampling without replacement
 			const baseSpecies = shuffledBaseSpecies.pop()!.baseSpecies;
-			const species = this.dex.species.get(this.sample(pokemonPool[baseSpecies].speciesArray));
+			const species = this.dex.species.get(this.sample(pokemonPool[baseSpecies]));
 			if (!species.exists) continue;
 
 			// Limit to one of each species (Species Clause)

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -684,15 +684,12 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		let numMaxLevelPokemon = 0;
 
 		const pokemonList = (this.gen === 3) ? Object.keys(this.randomSets) : Object.keys(this.randomData);
-		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
-		while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
-			const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
-			const currentSpeciesPool: Species[] = [];
-			for (const poke of pokemonPool) {
-				const species = this.dex.species.get(poke);
-				if (species.baseSpecies === baseSpecies) currentSpeciesPool.push(species);
-			}
-			const species = this.sample(currentSpeciesPool);
+		const [pokemonPool, shuffledBaseSpecies] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
+
+		while (shuffledBaseSpecies.length && pokemon.length < this.maxTeamSize) {
+			// repeated popping from weighted shuffle is equivalent to repeated weighted sampling without replacement
+			const baseSpecies = shuffledBaseSpecies.pop()!.baseSpecies;
+			const species = this.dex.species.get(this.sample(pokemonPool[baseSpecies].speciesArray));
 			if (!species.exists) continue;
 
 			// Limit to one of each species (Species Clause)

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -684,11 +684,10 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		let numMaxLevelPokemon = 0;
 
 		const pokemonList = (this.gen === 3) ? Object.keys(this.randomSets) : Object.keys(this.randomData);
-		const [pokemonPool, shuffledBaseSpecies] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
+		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
 
-		while (shuffledBaseSpecies.length && pokemon.length < this.maxTeamSize) {
-			// repeated popping from weighted shuffle is equivalent to repeated weighted sampling without replacement
-			const baseSpecies = shuffledBaseSpecies.pop()!.baseSpecies;
+		while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
+			const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
 			const species = this.dex.species.get(this.sample(pokemonPool[baseSpecies]));
 			if (!species.exists) continue;
 

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -685,7 +685,6 @@ export class RandomGen3Teams extends RandomGen4Teams {
 
 		const pokemonList = (this.gen === 3) ? Object.keys(this.randomSets) : Object.keys(this.randomData);
 		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
-
 		while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
 			const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
 			const species = this.dex.species.get(this.sample(pokemonPool[baseSpecies]));

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -957,7 +957,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		while (shuffledBaseSpecies.length && pokemon.length < this.maxTeamSize) {
 			// repeated popping from weighted shuffle is equivalent to repeated weighted sampling without replacement
 			const baseSpecies = shuffledBaseSpecies.pop()!.baseSpecies;
-			const species = this.dex.species.get(this.sample(pokemonPool[baseSpecies].speciesArray));
+			const species = this.dex.species.get(this.sample(pokemonPool[baseSpecies]));
 			if (!species.exists) continue;
 
 			// Limit to one of each species (Species Clause)

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -952,15 +952,12 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		let numMaxLevelPokemon = 0;
 
 		const pokemonList = Object.keys(this.randomSets);
-		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
-		while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
-			const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
-			const currentSpeciesPool: Species[] = [];
-			for (const poke of pokemonPool) {
-				const species = this.dex.species.get(poke);
-				if (species.baseSpecies === baseSpecies) currentSpeciesPool.push(species);
-			}
-			const species = this.sample(currentSpeciesPool);
+		const [pokemonPool, shuffledBaseSpecies] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
+
+		while (shuffledBaseSpecies.length && pokemon.length < this.maxTeamSize) {
+			// repeated popping from weighted shuffle is equivalent to repeated weighted sampling without replacement
+			const baseSpecies = shuffledBaseSpecies.pop()!.baseSpecies;
+			const species = this.dex.species.get(this.sample(pokemonPool[baseSpecies].speciesArray));
 			if (!species.exists) continue;
 
 			// Limit to one of each species (Species Clause)

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -952,11 +952,10 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		let numMaxLevelPokemon = 0;
 
 		const pokemonList = Object.keys(this.randomSets);
-		const [pokemonPool, shuffledBaseSpecies] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
+		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
 
-		while (shuffledBaseSpecies.length && pokemon.length < this.maxTeamSize) {
-			// repeated popping from weighted shuffle is equivalent to repeated weighted sampling without replacement
-			const baseSpecies = shuffledBaseSpecies.pop()!.baseSpecies;
+		while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
+			const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
 			const species = this.dex.species.get(this.sample(pokemonPool[baseSpecies]));
 			if (!species.exists) continue;
 

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -953,7 +953,6 @@ export class RandomGen5Teams extends RandomGen6Teams {
 
 		const pokemonList = Object.keys(this.randomSets);
 		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
-
 		while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
 			const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
 			const species = this.dex.species.get(this.sample(pokemonPool[baseSpecies]));

--- a/data/mods/gen7/random-doubles-teams.ts
+++ b/data/mods/gen7/random-doubles-teams.ts
@@ -1367,11 +1367,10 @@ export class RandomGen7DoublesTeams extends RandomGen8Teams {
 			if (pokemon.length >= this.maxTeamSize) break;
 
 			const pokemonList = Object.keys(this.randomDoublesData);
-			const [pokemonPool, shuffledBaseSpecies] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
+			const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
 
-			while (shuffledBaseSpecies.length && pokemon.length < this.maxTeamSize) {
-				// repeated popping from weighted shuffle is equivalent to repeated weighted sampling without replacement
-				const baseSpecies = shuffledBaseSpecies.pop()!.baseSpecies;
+			while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
+				const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
 				const currentSpeciesPool: Species[] = [];
 				// Check if the base species has a mega forme available
 				let canMega = false;

--- a/data/mods/gen7/random-doubles-teams.ts
+++ b/data/mods/gen7/random-doubles-teams.ts
@@ -1367,25 +1367,25 @@ export class RandomGen7DoublesTeams extends RandomGen8Teams {
 			if (pokemon.length >= this.maxTeamSize) break;
 
 			const pokemonList = Object.keys(this.randomDoublesData);
-			const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
-			while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
-				const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
+			const [pokemonPool, shuffledBaseSpecies] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
+
+			while (shuffledBaseSpecies.length && pokemon.length < this.maxTeamSize) {
+				// repeated popping from weighted shuffle is equivalent to repeated weighted sampling without replacement
+				const baseSpecies = shuffledBaseSpecies.pop()!.baseSpecies;
 				const currentSpeciesPool: Species[] = [];
 				// Check if the base species has a mega forme available
 				let canMega = false;
-				for (const poke of pokemonPool) {
+				for (const poke of pokemonPool[baseSpecies].speciesArray) {
 					const species = this.dex.species.get(poke);
-					if (!hasMega && species.baseSpecies === baseSpecies && species.isMega) canMega = true;
+					if (!hasMega && species.isMega) canMega = true;
 				}
-				for (const poke of pokemonPool) {
+				for (const poke of pokemonPool[baseSpecies].speciesArray) {
 					const species = this.dex.species.get(poke);
-					if (species.baseSpecies === baseSpecies) {
-						// Prevent multiple megas
-						if (hasMega && species.isMega) continue;
-						// Prevent base forme, if a mega is available
-						if (canMega && !species.isMega) continue;
-						currentSpeciesPool.push(species);
-					}
+					// Prevent multiple megas
+					if (hasMega && species.isMega) continue;
+					// Prevent base forme, if a mega is available
+					if (canMega && !species.isMega) continue;
+					currentSpeciesPool.push(species);
 				}
 				const species = this.sample(currentSpeciesPool);
 				if (!species.exists) continue;

--- a/data/mods/gen7/random-doubles-teams.ts
+++ b/data/mods/gen7/random-doubles-teams.ts
@@ -1368,7 +1368,6 @@ export class RandomGen7DoublesTeams extends RandomGen8Teams {
 
 			const pokemonList = Object.keys(this.randomDoublesData);
 			const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
-
 			while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
 				const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
 				const currentSpeciesPool: Species[] = [];

--- a/data/mods/gen7/random-doubles-teams.ts
+++ b/data/mods/gen7/random-doubles-teams.ts
@@ -1375,11 +1375,11 @@ export class RandomGen7DoublesTeams extends RandomGen8Teams {
 				const currentSpeciesPool: Species[] = [];
 				// Check if the base species has a mega forme available
 				let canMega = false;
-				for (const poke of pokemonPool[baseSpecies].speciesArray) {
+				for (const poke of pokemonPool[baseSpecies]) {
 					const species = this.dex.species.get(poke);
 					if (!hasMega && species.isMega) canMega = true;
 				}
-				for (const poke of pokemonPool[baseSpecies].speciesArray) {
+				for (const poke of pokemonPool[baseSpecies]) {
 					const species = this.dex.species.get(poke);
 					// Prevent multiple megas
 					if (hasMega && species.isMega) continue;

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1323,11 +1323,10 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			if (pokemon.length >= this.maxTeamSize) break;
 
 			const pokemonList = Object.keys(this.randomSets);
-			const [pokemonPool, shuffledBaseSpecies] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
+			const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
 
-			while (shuffledBaseSpecies.length && pokemon.length < this.maxTeamSize) {
-				// repeated popping from weighted shuffle is equivalent to repeated weighted sampling without replacement
-				const baseSpecies = shuffledBaseSpecies.pop()!.baseSpecies;
+			while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
+				const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
 				const currentSpeciesPool: Species[] = [];
 				// Check if the base species has a mega forme available
 				let canMega = false;

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1324,7 +1324,6 @@ export class RandomGen7Teams extends RandomGen8Teams {
 
 			const pokemonList = Object.keys(this.randomSets);
 			const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
-
 			while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
 				const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
 				const currentSpeciesPool: Species[] = [];

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1323,25 +1323,25 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			if (pokemon.length >= this.maxTeamSize) break;
 
 			const pokemonList = Object.keys(this.randomSets);
-			const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
-			while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
-				const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
+			const [pokemonPool, shuffledBaseSpecies] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
+
+			while (shuffledBaseSpecies.length && pokemon.length < this.maxTeamSize) {
+				// repeated popping from weighted shuffle is equivalent to repeated weighted sampling without replacement
+				const baseSpecies = shuffledBaseSpecies.pop()!.baseSpecies;
 				const currentSpeciesPool: Species[] = [];
 				// Check if the base species has a mega forme available
 				let canMega = false;
-				for (const poke of pokemonPool) {
+				for (const poke of pokemonPool[baseSpecies].speciesArray) {
 					const species = this.dex.species.get(poke);
-					if (!hasMega && species.baseSpecies === baseSpecies && species.isMega) canMega = true;
+					if (!hasMega && species.isMega) canMega = true;
 				}
-				for (const poke of pokemonPool) {
+				for (const poke of pokemonPool[baseSpecies].speciesArray) {
 					const species = this.dex.species.get(poke);
-					if (species.baseSpecies === baseSpecies) {
-						// Prevent multiple megas
-						if (hasMega && species.isMega) continue;
-						// Prevent base forme, if a mega is available
-						if (canMega && !species.isMega) continue;
-						currentSpeciesPool.push(species);
-					}
+					// Prevent multiple megas
+					if (hasMega && species.isMega) continue;
+					// Prevent base forme, if a mega is available
+					if (canMega && !species.isMega) continue;
+					currentSpeciesPool.push(species);
 				}
 				const species = this.sample(currentSpeciesPool);
 

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1331,11 +1331,11 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				const currentSpeciesPool: Species[] = [];
 				// Check if the base species has a mega forme available
 				let canMega = false;
-				for (const poke of pokemonPool[baseSpecies].speciesArray) {
+				for (const poke of pokemonPool[baseSpecies]) {
 					const species = this.dex.species.get(poke);
 					if (!hasMega && species.isMega) canMega = true;
 				}
-				for (const poke of pokemonPool[baseSpecies].speciesArray) {
+				for (const poke of pokemonPool[baseSpecies]) {
 					const species = this.dex.species.get(poke);
 					// Prevent multiple megas
 					if (hasMega && species.isMega) continue;

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -2475,7 +2475,6 @@ export class RandomGen8Teams {
 			}
 		}
 		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
-
 		while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
 			const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
 			let species = this.dex.species.get(this.sample(pokemonPool[baseSpecies]));

--- a/data/mods/potd/random-teams.ts
+++ b/data/mods/potd/random-teams.ts
@@ -33,12 +33,9 @@ export class RandomPOTDTeams extends RandomTeams {
 		const teamDetails: RandomTeamsTypes.TeamDetails = {};
 
 		const pokemonList = isDoubles ? Object.keys(this.randomDoublesSets) : Object.keys(this.randomSets);
-		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
-
-		// Remove PotD from baseSpeciesPool
-		if (baseSpeciesPool.includes(potd.baseSpecies)) {
-			this.fastPop(baseSpeciesPool, baseSpeciesPool.indexOf(potd.baseSpecies));
-		}
+		const [pokemonPool, shuffledBaseSpecies] = this.getPokemonPool(
+			type, pokemon, isMonotype, pokemonList.filter(m => this.dex.species.get(m).baseSpecies !== potd.baseSpecies)
+		);
 
 		// Add PotD to type counts
 		for (const typeName of potd.types) {
@@ -54,14 +51,10 @@ export class RandomPOTDTeams extends RandomTeams {
 			}
 		}
 
-		while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
-			const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
-			const currentSpeciesPool: Species[] = [];
-			for (const poke of pokemonPool) {
-				const species = this.dex.species.get(poke);
-				if (species.baseSpecies === baseSpecies) currentSpeciesPool.push(species);
-			}
-			let species = this.sample(currentSpeciesPool);
+		while (shuffledBaseSpecies.length && pokemon.length < this.maxTeamSize) {
+			// repeated popping from weighted shuffle is equivalent to repeated weighted sampling without replacement
+			const baseSpecies = shuffledBaseSpecies.pop()!.baseSpecies;
+			let species = this.dex.species.get(this.sample(pokemonPool[baseSpecies].speciesArray));
 			if (!species.exists) continue;
 
 			// Limit to one of each species (Species Clause)

--- a/data/mods/potd/random-teams.ts
+++ b/data/mods/potd/random-teams.ts
@@ -54,7 +54,7 @@ export class RandomPOTDTeams extends RandomTeams {
 		while (shuffledBaseSpecies.length && pokemon.length < this.maxTeamSize) {
 			// repeated popping from weighted shuffle is equivalent to repeated weighted sampling without replacement
 			const baseSpecies = shuffledBaseSpecies.pop()!.baseSpecies;
-			let species = this.dex.species.get(this.sample(pokemonPool[baseSpecies].speciesArray));
+			let species = this.dex.species.get(this.sample(pokemonPool[baseSpecies]));
 			if (!species.exists) continue;
 
 			// Limit to one of each species (Species Clause)

--- a/data/mods/potd/random-teams.ts
+++ b/data/mods/potd/random-teams.ts
@@ -33,7 +33,7 @@ export class RandomPOTDTeams extends RandomTeams {
 		const teamDetails: RandomTeamsTypes.TeamDetails = {};
 
 		const pokemonList = isDoubles ? Object.keys(this.randomDoublesSets) : Object.keys(this.randomSets);
-		const [pokemonPool, shuffledBaseSpecies] = this.getPokemonPool(
+		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(
 			type, pokemon, isMonotype, pokemonList.filter(m => this.dex.species.get(m).baseSpecies !== potd.baseSpecies)
 		);
 
@@ -51,9 +51,8 @@ export class RandomPOTDTeams extends RandomTeams {
 			}
 		}
 
-		while (shuffledBaseSpecies.length && pokemon.length < this.maxTeamSize) {
-			// repeated popping from weighted shuffle is equivalent to repeated weighted sampling without replacement
-			const baseSpecies = shuffledBaseSpecies.pop()!.baseSpecies;
+		while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
+			const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
 			let species = this.dex.species.get(this.sample(pokemonPool[baseSpecies]));
 			if (!species.exists) continue;
 

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1778,7 +1778,6 @@ export class RandomTeams {
 		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
 
 		let leadsRemaining = this.format.gameType === 'doubles' ? 2 : 1;
-
 		while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
 			const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
 			let species = this.dex.species.get(this.sample(pokemonPool[baseSpecies]));

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1716,7 +1716,7 @@ export class RandomTeams {
 		pokemonToExclude: RandomTeamsTypes.RandomSet[] = [],
 		isMonotype = false,
 		pokemonList: string[]
-	): [{[k: string]: {count: number, speciesArray: ID[]}}, {baseSpecies: string, score: number}[]] {
+	): [{[k: string]: ID[]}, {baseSpecies: string, score: number}[]] {
 		const exclude = pokemonToExclude.map(p => toID(p.species));
 		const pokemonPool: {[k: string]: ID[]} = {};
 		const shuffledBaseSpecies = [];
@@ -1740,7 +1740,7 @@ export class RandomTeams {
 		// Include base species 1x if 1-3 formes, 2x if 4-6 formes, 3x if 7+ formes
 		for (const baseSpecies of Object.keys(pokemonPool)) {
 			// Squawkabilly has 4 formes, but only 2 functionally different formes, so only include it 1x
-			let weight = baseSpecies === 'Squawkabilly` ? 1 : Math.min(Math.ceil(pokemonPool[baseSpecies].count / 3), 3);
+			const weight = (baseSpecies === 'Squawkabilly') ? 1 : Math.min(Math.ceil(pokemonPool[baseSpecies].length / 3), 3);
 
 			/**
 			 * Weighted random shuffle

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1716,11 +1716,10 @@ export class RandomTeams {
 		pokemonToExclude: RandomTeamsTypes.RandomSet[] = [],
 		isMonotype = false,
 		pokemonList: string[]
-	) {
+	): [{[k: string]: {count: number, speciesArray: ID[]}}, {baseSpecies: string, score: number}[]] {
 		const exclude = pokemonToExclude.map(p => toID(p.species));
-		const pokemonPool = [];
-		const baseSpeciesPool = [];
-		const baseSpeciesCount: {[k: string]: number} = {};
+		const pokemonPool: {[k: string]: {count: number, speciesArray: ID[]}} = {};
+		const shuffledBaseSpecies = [];
 		for (const pokemon of pokemonList) {
 			let species = this.dex.species.get(pokemon);
 			if (exclude.includes(species.id)) continue;
@@ -1731,18 +1730,37 @@ export class RandomTeams {
 					if (!species.types.includes(type)) continue;
 				}
 			}
-			pokemonPool.push(pokemon);
-			baseSpeciesCount[species.baseSpecies] = (baseSpeciesCount[species.baseSpecies] || 0) + 1;
-		}
-		// Include base species 1x if 1-3 formes, 2x if 4-6 formes, 3x if 7+ formes
-		for (const baseSpecies of Object.keys(baseSpeciesCount)) {
-			for (let i = 0; i < Math.min(Math.ceil(baseSpeciesCount[baseSpecies] / 3), 3); i++) {
-				baseSpeciesPool.push(baseSpecies);
-				// Squawkabilly has 4 formes, but only 2 functionally different formes, so only include it 1x
-				if (baseSpecies === 'Squawkabilly') break;
+
+			if (species.baseSpecies in pokemonPool) {
+				pokemonPool[species.baseSpecies].count++;
+				pokemonPool[species.baseSpecies].speciesArray.push(species.id);
+			} else {
+				pokemonPool[species.baseSpecies] = {count: 1, speciesArray: [species.id]};
 			}
 		}
-		return [pokemonPool, baseSpeciesPool];
+		// Include base species 1x if 1-3 formes, 2x if 4-6 formes, 3x if 7+ formes
+		for (const baseSpecies of Object.keys(pokemonPool)) {
+			// Squawkabilly has 4 formes, but only 2 functionally different formes, so only include it 1x
+			if (baseSpecies === 'Squawkabilly') {
+				pokemonPool[baseSpecies].count = 1;
+			} else {
+				pokemonPool[baseSpecies].count = Math.min(Math.ceil(pokemonPool[baseSpecies].count / 3), 3);
+			}
+
+			/**
+			 * Weighted random shuffle
+			 * Uses the fact that for two uniform variables x1 and x2, x1^(1/w1) is larger than x2^(1/w2)
+			 * with probability equal to w1/(w1+w2), which is what we want. See e.g. here https://arxiv.org/pdf/1012.0256.pdf,
+			 * original paper is behind a paywall.
+			 */
+			const sortObject = {
+				baseSpecies: baseSpecies,
+				score: Math.pow(this.prng.next(), 1 / pokemonPool[baseSpecies].count),
+			};
+			shuffledBaseSpecies.push(sortObject);
+		}
+		shuffledBaseSpecies.sort((a, b) => a.score - b.score);
+		return [pokemonPool, shuffledBaseSpecies];
 	}
 
 	randomSets: {[species: string]: RandomTeamsTypes.RandomSpeciesData} = require('./random-sets.json');
@@ -1774,17 +1792,14 @@ export class RandomTeams {
 		let numMaxLevelPokemon = 0;
 
 		const pokemonList = isDoubles ? Object.keys(this.randomDoublesSets) : Object.keys(this.randomSets);
-		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
+		const [pokemonPool, shuffledBaseSpecies] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
 
 		let leadsRemaining = this.format.gameType === 'doubles' ? 2 : 1;
-		while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
-			const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
-			const currentSpeciesPool: Species[] = [];
-			for (const poke of pokemonPool) {
-				const species = this.dex.species.get(poke);
-				if (species.baseSpecies === baseSpecies) currentSpeciesPool.push(species);
-			}
-			let species = this.sample(currentSpeciesPool);
+
+		while (shuffledBaseSpecies.length && pokemon.length < this.maxTeamSize) {
+			// repeated popping from weighted shuffle is equivalent to repeated weighted sampling without replacement
+			const baseSpecies = shuffledBaseSpecies.pop()!.baseSpecies;
+			let species = this.dex.species.get(this.sample(pokemonPool[baseSpecies].speciesArray));
 			if (!species.exists) continue;
 
 			// Limit to one of each species (Species Clause)

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1718,7 +1718,7 @@ export class RandomTeams {
 		pokemonList: string[]
 	): [{[k: string]: {count: number, speciesArray: ID[]}}, {baseSpecies: string, score: number}[]] {
 		const exclude = pokemonToExclude.map(p => toID(p.species));
-		const pokemonPool: {[k: string]: {count: number, speciesArray: ID[]}} = {};
+		const pokemonPool: {[k: string]: ID[]} = {};
 		const shuffledBaseSpecies = [];
 		for (const pokemon of pokemonList) {
 			let species = this.dex.species.get(pokemon);
@@ -1732,20 +1732,15 @@ export class RandomTeams {
 			}
 
 			if (species.baseSpecies in pokemonPool) {
-				pokemonPool[species.baseSpecies].count++;
-				pokemonPool[species.baseSpecies].speciesArray.push(species.id);
+				pokemonPool[species.baseSpecies].push(species.id);
 			} else {
-				pokemonPool[species.baseSpecies] = {count: 1, speciesArray: [species.id]};
+				pokemonPool[species.baseSpecies] = [species.id];
 			}
 		}
 		// Include base species 1x if 1-3 formes, 2x if 4-6 formes, 3x if 7+ formes
 		for (const baseSpecies of Object.keys(pokemonPool)) {
 			// Squawkabilly has 4 formes, but only 2 functionally different formes, so only include it 1x
-			if (baseSpecies === 'Squawkabilly') {
-				pokemonPool[baseSpecies].count = 1;
-			} else {
-				pokemonPool[baseSpecies].count = Math.min(Math.ceil(pokemonPool[baseSpecies].count / 3), 3);
-			}
+			let weight = baseSpecies === 'Squawkabilly` ? 1 : Math.min(Math.ceil(pokemonPool[baseSpecies].count / 3), 3);
 
 			/**
 			 * Weighted random shuffle
@@ -1755,7 +1750,7 @@ export class RandomTeams {
 			 */
 			const sortObject = {
 				baseSpecies: baseSpecies,
-				score: Math.pow(this.prng.next(), 1 / pokemonPool[baseSpecies].count),
+				score: Math.pow(this.prng.next(), 1 / weight),
 			};
 			shuffledBaseSpecies.push(sortObject);
 		}
@@ -1799,7 +1794,7 @@ export class RandomTeams {
 		while (shuffledBaseSpecies.length && pokemon.length < this.maxTeamSize) {
 			// repeated popping from weighted shuffle is equivalent to repeated weighted sampling without replacement
 			const baseSpecies = shuffledBaseSpecies.pop()!.baseSpecies;
-			let species = this.dex.species.get(this.sample(pokemonPool[baseSpecies].speciesArray));
+			let species = this.dex.species.get(this.sample(pokemonPool[baseSpecies]));
 			if (!species.exists) continue;
 
 			// Limit to one of each species (Species Clause)

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1716,10 +1716,10 @@ export class RandomTeams {
 		pokemonToExclude: RandomTeamsTypes.RandomSet[] = [],
 		isMonotype = false,
 		pokemonList: string[]
-	): [{[k: string]: ID[]}, {baseSpecies: string, score: number}[]] {
+	): [{[k: string]: ID[]}, string[]] {
 		const exclude = pokemonToExclude.map(p => toID(p.species));
 		const pokemonPool: {[k: string]: ID[]} = {};
-		const shuffledBaseSpecies = [];
+		const baseSpeciesPool = [];
 		for (const pokemon of pokemonList) {
 			let species = this.dex.species.get(pokemon);
 			if (exclude.includes(species.id)) continue;
@@ -1741,21 +1741,9 @@ export class RandomTeams {
 		for (const baseSpecies of Object.keys(pokemonPool)) {
 			// Squawkabilly has 4 formes, but only 2 functionally different formes, so only include it 1x
 			const weight = (baseSpecies === 'Squawkabilly') ? 1 : Math.min(Math.ceil(pokemonPool[baseSpecies].length / 3), 3);
-
-			/**
-			 * Weighted random shuffle
-			 * Uses the fact that for two uniform variables x1 and x2, x1^(1/w1) is larger than x2^(1/w2)
-			 * with probability equal to w1/(w1+w2), which is what we want. See e.g. here https://arxiv.org/pdf/1012.0256.pdf,
-			 * original paper is behind a paywall.
-			 */
-			const sortObject = {
-				baseSpecies: baseSpecies,
-				score: Math.pow(this.prng.next(), 1 / weight),
-			};
-			shuffledBaseSpecies.push(sortObject);
+			for (let i = 0; i < weight; i++) baseSpeciesPool.push(baseSpecies);
 		}
-		shuffledBaseSpecies.sort((a, b) => a.score - b.score);
-		return [pokemonPool, shuffledBaseSpecies];
+		return [pokemonPool, baseSpeciesPool];
 	}
 
 	randomSets: {[species: string]: RandomTeamsTypes.RandomSpeciesData} = require('./random-sets.json');
@@ -1787,13 +1775,12 @@ export class RandomTeams {
 		let numMaxLevelPokemon = 0;
 
 		const pokemonList = isDoubles ? Object.keys(this.randomDoublesSets) : Object.keys(this.randomSets);
-		const [pokemonPool, shuffledBaseSpecies] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
+		const [pokemonPool, baseSpeciesPool] = this.getPokemonPool(type, pokemon, isMonotype, pokemonList);
 
 		let leadsRemaining = this.format.gameType === 'doubles' ? 2 : 1;
 
-		while (shuffledBaseSpecies.length && pokemon.length < this.maxTeamSize) {
-			// repeated popping from weighted shuffle is equivalent to repeated weighted sampling without replacement
-			const baseSpecies = shuffledBaseSpecies.pop()!.baseSpecies;
+		while (baseSpeciesPool.length && pokemon.length < this.maxTeamSize) {
+			const baseSpecies = this.sampleNoReplace(baseSpeciesPool);
 			let species = this.dex.species.get(this.sample(pokemonPool[baseSpecies]));
 			if (!species.exists) continue;
 


### PR DESCRIPTION
This refactors species selection in Random Battles to be more efficient. 

Previously, after selecting a base species, it goes through the entire array of species to record the ones with the corresponding base species, then chooses one of them randomly.

Now, `getPokemonPool()` outputs an object `pokemonPool` which records, for each base species, the list of species with that base species. Instead of checking every species, it now just samples from the list corresponding to the base species.

This approach is significantly faster and keeps the appearance rates standardization from https://github.com/smogon/pokemon-showdown/pull/9708.

My local testing shows that this speeds up overall team generation by around 20% for Gen 9 Random Battle and 50% for Gen 7 Random Battle.