### PR TITLE
DPP UU: Re-Ban Baton Pass

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -4624,8 +4624,8 @@ export const Formats: FormatList = [
 
 		mod: 'gen4',
 		searchShow: false,
-		ruleset: ['[Gen 4] OU', '!Baton Pass Stat Trap Clause', '!Freeze Clause Mod'],
-		banlist: ['OU', 'UUBL'],
+		ruleset: ['[Gen 4] OU', '!Freeze Clause Mod'],
+		banlist: ['OU', 'UUBL', 'Baton Pass'],
 		unbanlist: ['Arena Trap', 'Quick Claw', 'Swagger'],
 	},
 	{


### PR DESCRIPTION
Mentioned in Smogcord by someone, confirmed by Aislinn, was seemingly unbanned due to the change in DPP OU's tiering
