### PR TITLE
Randbats Stats: Properly deal with ties

### DIFF
--- a/server/chat-plugins/randombattles/winrates.ts
+++ b/server/chat-plugins/randombattles/winrates.ts
@@ -167,7 +167,7 @@ async function collectStats(battle: RoomBattle, winner: ID, players: ID[]) {
 		// may need to be raised again if doubles ladder takes off
 		eloFloor = 1300;
 	}
-	if (!formatData || battle.rated < eloFloor) return;
+	if (!formatData || battle.rated < eloFloor || !winner) return;
 	checkRollover();
 	for (const p of battle.players) {
 		const team = await battle.getPlayerTeam(p);


### PR DESCRIPTION
Messing around with winrates I found that they were consistently slightly below 50% on average. @livid-washed then pointed out that that could be due to ties.

With this fix, ties should no longer appear in the winrates. This is surprisingly important, as for example gen 4 winrates averaged around 49.6% for some months. This does not seem like a lot, but causes significant upward pressure to the levels in balancing, which is highly undesirable.