### PR TITLE
Randomized format set updates

### DIFF
--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -548,15 +548,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		isLead = false
 	): RandomTeamsTypes.RandomSet {
 		species = this.dex.species.get(species);
-		let forme = species.name;
-
-		if (typeof species.battleOnly === 'string') {
-			// Only change the forme. The species has custom moves, and may have different typing and requirements.
-			forme = species.battleOnly;
-		}
-		if (species.cosmeticFormes) {
-			forme = this.sample([species.name].concat(species.cosmeticFormes));
-		}
+		const forme = this.getForme(species);
 		const sets = this.randomSets[species.id]["sets"];
 
 		const set = this.sampleIfArray(sets);

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -665,15 +665,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		isLead = false
 	): RandomTeamsTypes.RandomSet {
 		species = this.dex.species.get(species);
-		let forme = species.name;
-
-		if (typeof species.battleOnly === 'string') {
-			// Only change the forme. The species has custom moves, and may have different typing and requirements.
-			forme = species.battleOnly;
-		}
-		if (species.cosmeticFormes) {
-			forme = this.sample([species.name].concat(species.cosmeticFormes));
-		}
+		const forme = this.getForme(species);
 		const sets = this.randomSets[species.id]["sets"];
 		const possibleSets = [];
 		// Check if the Pokemon has a Spinner set

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -3671,15 +3671,6 @@
             }
         ]
     },
-    "basculinbluestriped": {
-        "level": 86,
-        "sets": [
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["aquajet", "crunch", "superpower", "waterfall", "zenheadbutt"]
-            }
-        ]
-    },
     "krookodile": {
         "level": 80,
         "sets": [

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -855,10 +855,10 @@ export class RandomGen5Teams extends RandomGen6Teams {
 
 		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
 		if (species.baseSpecies === 'Basculin') {
-			forme = 'Basculin' + this.sample(['', '-Blue-Striped'])
+			forme = 'Basculin' + this.sample(['', '-Blue-Striped']);
 		}
 		if (species.baseSpecies === 'Keldeo') {
-			forme = 'Keldeo' + this.sample(['', '-Resolute'])
+			forme = 'Keldeo' + this.sample(['', '-Resolute']);
 		}
 
 		// For Trick / Switcheroo

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -853,6 +853,14 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			item = this.getItem(ability, types, moves, counter, teamDetails, species, isLead, preferredType, role);
 		}
 
+		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
+		if (species.baseSpecies === 'Basculin') {
+			forme = 'Basculin' + this.sample(['', '-Blue-Striped'])
+		}
+		if (species.baseSpecies === 'Keldeo') {
+			forme = 'Keldeo' + this.sample(['', '-Resolute'])
+		}
+
 		// For Trick / Switcheroo
 		if (item === 'Leftovers' && types.includes('Poison')) {
 			item = 'Black Sludge';

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -799,15 +799,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		isLead = false
 	): RandomTeamsTypes.RandomSet {
 		species = this.dex.species.get(species);
-		let forme = species.name;
-
-		if (typeof species.battleOnly === 'string') {
-			// Only change the forme. The species has custom moves, and may have different typing and requirements.
-			forme = species.battleOnly;
-		}
-		if (species.cosmeticFormes) {
-			forme = this.sample([species.name].concat(species.cosmeticFormes));
-		}
+		const forme = this.getForme(species);
 		const sets = this.randomSets[species.id]["sets"];
 		const possibleSets = [];
 		// Check if the Pokemon has a Spinner set
@@ -851,14 +843,6 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		item = this.getPriorityItem(ability, types, moves, counter, teamDetails, species, isLead, preferredType, role);
 		if (item === undefined) {
 			item = this.getItem(ability, types, moves, counter, teamDetails, species, isLead, preferredType, role);
-		}
-
-		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
-		if (species.baseSpecies === 'Basculin') {
-			forme = 'Basculin' + this.sample(['', '-Blue-Striped']);
-		}
-		if (species.baseSpecies === 'Keldeo') {
-			forme = 'Keldeo' + this.sample(['', '-Resolute']);
 		}
 
 		// For Trick / Switcheroo

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -4086,15 +4086,6 @@
             }
         ]
     },
-    "basculinbluestriped": {
-        "level": 87,
-        "sets": [
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["aquajet", "crunch", "superpower", "waterfall", "zenheadbutt"]
-            }
-        ]
-    },
     "krookodile": {
         "level": 79,
         "sets": [

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -908,10 +908,10 @@ export class RandomGen6Teams extends RandomGen7Teams {
 
 		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
 		if (species.baseSpecies === 'Basculin') {
-			forme = 'Basculin' + this.sample(['', '-Blue-Striped'])
+			forme = 'Basculin' + this.sample(['', '-Blue-Striped']);
 		}
 		if (species.baseSpecies === 'Keldeo') {
-			forme = 'Keldeo' + this.sample(['', '-Resolute'])
+			forme = 'Keldeo' + this.sample(['', '-Resolute']);
 		}
 
 		// For Trick / Switcheroo

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -863,15 +863,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		isLead = false
 	): RandomTeamsTypes.RandomSet {
 		species = this.dex.species.get(species);
-		let forme = species.name;
-
-		if (typeof species.battleOnly === 'string') {
-			// Only change the forme. The species has custom moves, and may have different typing and requirements.
-			forme = species.battleOnly;
-		}
-		if (species.cosmeticFormes) {
-			forme = this.sample([species.name].concat(species.cosmeticFormes));
-		}
+		const forme = this.getForme(species);
 		const sets = this.randomSets[species.id]["sets"];
 		const possibleSets = [];
 		for (const set of sets) possibleSets.push(set);
@@ -904,14 +896,6 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		item = this.getPriorityItem(ability, types, moves, counter, teamDetails, species, isLead, preferredType, role);
 		if (item === undefined) {
 			item = this.getItem(ability, types, moves, counter, teamDetails, species, isLead, preferredType, role);
-		}
-
-		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
-		if (species.baseSpecies === 'Basculin') {
-			forme = 'Basculin' + this.sample(['', '-Blue-Striped']);
-		}
-		if (species.baseSpecies === 'Keldeo') {
-			forme = 'Keldeo' + this.sample(['', '-Resolute']);
 		}
 
 		// For Trick / Switcheroo

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -906,6 +906,14 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			item = this.getItem(ability, types, moves, counter, teamDetails, species, isLead, preferredType, role);
 		}
 
+		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
+		if (species.baseSpecies === 'Basculin') {
+			forme = 'Basculin' + this.sample(['', '-Blue-Striped'])
+		}
+		if (species.baseSpecies === 'Keldeo') {
+			forme = 'Keldeo' + this.sample(['', '-Resolute'])
+		}
+
 		// For Trick / Switcheroo
 		if (item === 'Leftovers' && types.includes('Poison')) {
 			item = 'Black Sludge';

--- a/data/mods/gen7/random-doubles-data.json
+++ b/data/mods/gen7/random-doubles-data.json
@@ -1160,9 +1160,6 @@
     "basculin": {
         "moves": ["aquajet", "icebeam", "liquidation", "muddywater", "protect", "superpower"]
     },
-    "basculinbluestriped": {
-        "moves": ["aquajet", "icebeam", "liquidation", "muddywater", "protect", "superpower"]
-    },
     "krookodile": {
         "moves": ["earthquake", "knockoff", "protect", "stoneedge", "superpower"]
     },

--- a/data/mods/gen7/random-doubles-teams.ts
+++ b/data/mods/gen7/random-doubles-teams.ts
@@ -1236,13 +1236,13 @@ export class RandomGen7DoublesTeams extends RandomGen8Teams {
 
 		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
 		if (species.baseSpecies === 'Basculin') {
-			forme = 'Basculin' + this.sample(['', '-Blue-Striped'])
+			forme = 'Basculin' + this.sample(['', '-Blue-Striped']);
 		}
 		if (species.baseSpecies === 'Keldeo') {
-			forme = 'Keldeo' + this.sample(['', '-Resolute'])
+			forme = 'Keldeo' + this.sample(['', '-Resolute']);
 		}
 		if (species.baseSpecies === 'Magearna') {
-			forme = 'Magearna' + this.sample(['', '-Original'])
+			forme = 'Magearna' + this.sample(['', '-Original']);
 		}
 
 		let level: number;

--- a/data/mods/gen7/random-doubles-teams.ts
+++ b/data/mods/gen7/random-doubles-teams.ts
@@ -1234,6 +1234,17 @@ export class RandomGen7DoublesTeams extends RandomGen8Teams {
 			item = 'Black Sludge';
 		}
 
+		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
+		if (species.baseSpecies === 'Basculin') {
+			forme = 'Basculin' + this.sample(['', '-Blue-Striped'])
+		}
+		if (species.baseSpecies === 'Keldeo') {
+			forme = 'Keldeo' + this.sample(['', '-Resolute'])
+		}
+		if (species.baseSpecies === 'Magearna') {
+			forme = 'Magearna' + this.sample(['', '-Original'])
+		}
+
 		let level: number;
 		if (this.adjustLevel) {
 			level = this.adjustLevel;

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -4343,15 +4343,6 @@
             }
         ]
     },
-    "basculinbluestriped": {
-        "level": 86,
-        "sets": [
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["aquajet", "crunch", "headsmash", "liquidation", "superpower"]
-            }
-        ]
-    },
     "krookodile": {
         "level": 81,
         "sets": [

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1196,13 +1196,13 @@ export class RandomGen7Teams extends RandomGen8Teams {
 
 		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
 		if (species.baseSpecies === 'Basculin') {
-			forme = 'Basculin' + this.sample(['', '-Blue-Striped'])
+			forme = 'Basculin' + this.sample(['', '-Blue-Striped']);
 		}
 		if (species.baseSpecies === 'Keldeo') {
-			forme = 'Keldeo' + this.sample(['', '-Resolute'])
+			forme = 'Keldeo' + this.sample(['', '-Resolute']);
 		}
 		if (species.baseSpecies === 'Magearna') {
-			forme = 'Magearna' + this.sample(['', '-Original'])
+			forme = 'Magearna' + this.sample(['', '-Original']);
 		}
 
 		// For Trick / Switcheroo

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1140,15 +1140,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		isLead = false
 	): RandomTeamsTypes.RandomSet {
 		species = this.dex.species.get(species);
-		let forme = species.name;
-
-		if (typeof species.battleOnly === 'string') {
-			// Only change the forme. The species has custom moves, and may have different typing and requirements.
-			forme = species.battleOnly;
-		}
-		if (species.cosmeticFormes) {
-			forme = this.sample([species.name].concat(species.cosmeticFormes));
-		}
+		const forme = this.getForme(species);
 		const sets = this.randomSets[species.id]["sets"];
 		const possibleSets = [];
 		// Check if the Pokemon has a Z-Move user set
@@ -1192,17 +1184,6 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		item = this.getPriorityItem(ability, types, moves, counter, teamDetails, species, isLead, preferredType, role);
 		if (item === undefined) {
 			item = this.getItem(ability, types, moves, counter, teamDetails, species, isLead, preferredType, role);
-		}
-
-		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
-		if (species.baseSpecies === 'Basculin') {
-			forme = 'Basculin' + this.sample(['', '-Blue-Striped']);
-		}
-		if (species.baseSpecies === 'Keldeo') {
-			forme = 'Keldeo' + this.sample(['', '-Resolute']);
-		}
-		if (species.baseSpecies === 'Magearna') {
-			forme = 'Magearna' + this.sample(['', '-Original']);
 		}
 
 		// For Trick / Switcheroo

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1194,6 +1194,17 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			item = this.getItem(ability, types, moves, counter, teamDetails, species, isLead, preferredType, role);
 		}
 
+		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
+		if (species.baseSpecies === 'Basculin') {
+			forme = 'Basculin' + this.sample(['', '-Blue-Striped'])
+		}
+		if (species.baseSpecies === 'Keldeo') {
+			forme = 'Keldeo' + this.sample(['', '-Resolute'])
+		}
+		if (species.baseSpecies === 'Magearna') {
+			forme = 'Magearna' + this.sample(['', '-Original'])
+		}
+
 		// For Trick / Switcheroo
 		if (item === 'Leftovers' && types.includes('Poison')) {
 			item = 'Black Sludge';

--- a/data/mods/gen8/random-data.json
+++ b/data/mods/gen8/random-data.json
@@ -1359,12 +1359,6 @@
         "doublesLevel": 86,
         "doublesMoves": ["flipturn", "liquidation", "muddywater", "protect", "superpower"]
     },
-    "basculinbluestriped": {
-        "level": 85,
-        "moves": ["aquajet", "crunch", "flipturn", "liquidation", "psychicfangs", "superpower"],
-        "doublesLevel": 86,
-        "doublesMoves": ["flipturn", "liquidation", "muddywater", "protect", "superpower"]
-    },
     "krookodile": {
         "level": 78,
         "moves": ["closecombat", "earthquake", "knockoff", "stealthrock", "stoneedge"],
@@ -1708,7 +1702,7 @@
         "doublesLevel": 72,
         "doublesMoves": ["dracometeor", "dragonpulse", "earthpower", "freezedry", "fusionflare", "icebeam", "protect", "roost"]
     },
-    "keldeoresolute": {
+    "keldeo": {
         "level": 77,
         "moves": ["airslash", "calmmind", "hydropump", "icywind", "scald", "secretsword", "substitute"],
         "doublesLevel": 82,
@@ -2329,12 +2323,6 @@
         "doublesLevel": 72,
         "doublesMoves": ["agility", "aurasphere", "dazzlinggleam", "flashcannon", "fleurcannon", "protect", "trick"]
     },
-    "magearnaoriginal": {
-        "level": 74,
-        "moves": ["agility", "calmmind", "flashcannon", "fleurcannon"],
-        "doublesLevel": 72,
-        "doublesMoves": ["agility", "aurasphere", "dazzlinggleam", "flashcannon", "fleurcannon", "protect", "trick"]
-    },
     "marshadow": {
         "level": 69,
         "moves": ["bulkup", "closecombat", "icepunch", "rocktomb", "shadowsneak", "spectralthief"],
@@ -2740,12 +2728,6 @@
         "moves": ["bulkup", "closecombat", "icepunch", "surgingstrikes", "uturn"]
     },
     "zarude": {
-        "level": 78,
-        "moves": ["bulkup", "closecombat", "darkestlariat", "junglehealing", "powerwhip", "uturn"],
-        "doublesLevel": 80,
-        "doublesMoves": ["closecombat", "darkestlariat", "junglehealing", "powerwhip", "protect"]
-    },
-    "zarudedada": {
         "level": 78,
         "moves": ["bulkup", "closecombat", "darkestlariat", "junglehealing", "powerwhip", "uturn"],
         "doublesLevel": 80,

--- a/data/mods/gen8/random-data.json
+++ b/data/mods/gen8/random-data.json
@@ -1702,7 +1702,7 @@
         "doublesLevel": 72,
         "doublesMoves": ["dracometeor", "dragonpulse", "earthpower", "freezedry", "fusionflare", "icebeam", "protect", "roost"]
     },
-    "keldeo": {
+    "keldeoresolute": {
         "level": 77,
         "moves": ["airslash", "calmmind", "hydropump", "icywind", "scald", "secretsword", "substitute"],
         "doublesLevel": 82,

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -2134,7 +2134,7 @@ export class RandomGen8Teams {
 		if (species.baseSpecies === 'Basculin') return 'Basculin' + this.sample(['', '-Blue-Striped']);
 		if (species.baseSpecies === 'Keldeo' && this.gen <= 7) return 'Keldeo' + this.sample(['', '-Resolute']);
 		if (species.baseSpecies === 'Magearna') return 'Magearna' + this.sample(['', '-Original']);
-		if (species.baseSpecies === 'Pikachu' && this.gen === 8) {
+		if (species.baseSpecies === 'Pikachu' && this.dex.currentMod === 'gen8') {
 			return 'Pikachu' + this.sample(
 				['', '-Original', '-Hoenn', '-Sinnoh', '-Unova', '-Kalos', '-Alola', '-Partner', '-World']
 			);

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -2122,6 +2122,28 @@ export class RandomGen8Teams {
 		return 80;
 	}
 
+	getForme(species: Species): string {
+		if (typeof species.battleOnly === 'string') {
+			// Only change the forme. The species has custom moves, and may have different typing and requirements.
+			return species.battleOnly;
+		}
+		if (species.cosmeticFormes) return this.sample([species.name].concat(species.cosmeticFormes));
+		if (species.name.endsWith('-Gmax')) return species.name.slice(0, -5);
+
+		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
+		if (species.baseSpecies === 'Basculin') return 'Basculin' + this.sample(['', '-Blue-Striped']);
+		if (species.baseSpecies === 'Keldeo' && this.gen <= 7) return 'Keldeo' + this.sample(['', '-Resolute']);
+		if (species.baseSpecies === 'Magearna') return 'Magearna' + this.sample(['', '-Original']);
+		if (species.baseSpecies === 'Pikachu' && this.gen === 8) {
+			return 'Pikachu' + this.sample(
+				['', '-Original', '-Hoenn', '-Sinnoh', '-Unova', '-Kalos', '-Alola', '-Partner', '-World']
+			);
+		}
+		if (species.baseSpecies === 'Polteageist') return 'Polteageist' + this.sample(['', '-Antique']);
+		if (species.baseSpecies === 'Zarude') return 'Zarude' + this.sample(['', '-Dada']);
+		return species.name;
+	}
+
 	randomSet(
 		species: string | Species,
 		teamDetails: RandomTeamsTypes.TeamDetails = {},
@@ -2130,20 +2152,8 @@ export class RandomGen8Teams {
 		isNoDynamax = false
 	): RandomTeamsTypes.RandomSet {
 		species = this.dex.species.get(species);
-		let forme = species.name;
-		let gmax = false;
-
-		if (typeof species.battleOnly === 'string') {
-			// Only change the forme. The species has custom moves, and may have different typing and requirements.
-			forme = species.battleOnly;
-		}
-		if (species.cosmeticFormes) {
-			forme = this.sample([species.name].concat(species.cosmeticFormes));
-		}
-		if (species.name.endsWith('-Gmax')) {
-			forme = species.name.slice(0, -5);
-			gmax = true;
-		}
+		const forme = this.getForme(species);
+		const gmax = species.name.endsWith('-Gmax');
 
 		const data = this.randomData[species.id];
 
@@ -2339,23 +2349,6 @@ export class RandomGen8Teams {
 		// For Trick / Switcheroo
 		if (item === 'Leftovers' && types.has('Poison')) {
 			item = 'Black Sludge';
-		}
-
-		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
-		if (species.baseSpecies === 'Basculin') {
-			forme = 'Basculin' + this.sample(['', '-Blue-Striped']);
-		}
-		if (species.baseSpecies === 'Magearna') {
-			forme = 'Magearna' + this.sample(['', '-Original']);
-		}
-		if (species.baseSpecies === 'Pikachu') {
-			forme = 'Pikachu' + this.sample(['', '-Original', '-Hoenn', '-Sinnoh', '-Unova', '-Kalos', '-Alola', '-Partner', '-World']);
-		}
-		if (species.baseSpecies === 'Polteageist') {
-			forme = 'Polteageist' + this.sample(['', '-Antique']);
-		}
-		if (species.baseSpecies === 'Zarude') {
-			forme = 'Zarude' + this.sample(['', '-Dada']);
 		}
 
 		const level: number = this.getLevel(species, isDoubles, isNoDynamax);

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -2131,16 +2131,16 @@ export class RandomGen8Teams {
 		if (species.name.endsWith('-Gmax')) return species.name.slice(0, -5);
 
 		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
+		if (['Magearna', 'Polteageist', 'Zarude'].includes(species.baseSpecies)) {
+			return this.sample([species.name].concat(species.otherFormes!));
+		}
 		if (species.baseSpecies === 'Basculin') return 'Basculin' + this.sample(['', '-Blue-Striped']);
 		if (species.baseSpecies === 'Keldeo' && this.gen <= 7) return 'Keldeo' + this.sample(['', '-Resolute']);
-		if (species.baseSpecies === 'Magearna') return 'Magearna' + this.sample(['', '-Original']);
 		if (species.baseSpecies === 'Pikachu' && this.dex.currentMod === 'gen8') {
 			return 'Pikachu' + this.sample(
 				['', '-Original', '-Hoenn', '-Sinnoh', '-Unova', '-Kalos', '-Alola', '-Partner', '-World']
 			);
 		}
-		if (species.baseSpecies === 'Polteageist') return 'Polteageist' + this.sample(['', '-Antique']);
-		if (species.baseSpecies === 'Zarude') return 'Zarude' + this.sample(['', '-Dada']);
 		return species.name;
 	}
 

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -2340,8 +2340,25 @@ export class RandomGen8Teams {
 		if (item === 'Leftovers' && types.has('Poison')) {
 			item = 'Black Sludge';
 		}
-		if (species.baseSpecies === 'Pikachu' && !gmax && this.dex.currentMod !== 'gen8bdsp') {
+
+		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
+		if (species.baseSpecies === 'Basculin') {
+			forme = 'Basculin' + this.sample(['', '-Blue-Striped'])
+		}
+		if (species.baseSpecies === 'Keldeo') {
+			forme = 'Keldeo' + this.sample(['', '-Resolute'])
+		}
+		if (species.baseSpecies === 'Magearna') {
+			forme = 'Magearna' + this.sample(['', '-Original'])
+		}
+		if (species.baseSpecies === 'Pikachu') {
 			forme = 'Pikachu' + this.sample(['', '-Original', '-Hoenn', '-Sinnoh', '-Unova', '-Kalos', '-Alola', '-Partner', '-World']);
+		}
+		if (species.baseSpecies === 'Polteageist') {
+			forme = 'Polteageist' + this.sample(['', '-Antique'])
+		}
+		if (species.baseSpecies === 'Zarude') {
+			forme = 'Zarude' + this.sample(['', '-Dada'])
 		}
 
 		const level: number = this.getLevel(species, isDoubles, isNoDynamax);

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -2345,9 +2345,6 @@ export class RandomGen8Teams {
 		if (species.baseSpecies === 'Basculin') {
 			forme = 'Basculin' + this.sample(['', '-Blue-Striped']);
 		}
-		if (species.baseSpecies === 'Keldeo') {
-			forme = 'Keldeo' + this.sample(['', '-Resolute']);
-		}
 		if (species.baseSpecies === 'Magearna') {
 			forme = 'Magearna' + this.sample(['', '-Original']);
 		}

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -2343,22 +2343,22 @@ export class RandomGen8Teams {
 
 		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
 		if (species.baseSpecies === 'Basculin') {
-			forme = 'Basculin' + this.sample(['', '-Blue-Striped'])
+			forme = 'Basculin' + this.sample(['', '-Blue-Striped']);
 		}
 		if (species.baseSpecies === 'Keldeo') {
-			forme = 'Keldeo' + this.sample(['', '-Resolute'])
+			forme = 'Keldeo' + this.sample(['', '-Resolute']);
 		}
 		if (species.baseSpecies === 'Magearna') {
-			forme = 'Magearna' + this.sample(['', '-Original'])
+			forme = 'Magearna' + this.sample(['', '-Original']);
 		}
 		if (species.baseSpecies === 'Pikachu') {
 			forme = 'Pikachu' + this.sample(['', '-Original', '-Hoenn', '-Sinnoh', '-Unova', '-Kalos', '-Alola', '-Partner', '-World']);
 		}
 		if (species.baseSpecies === 'Polteageist') {
-			forme = 'Polteageist' + this.sample(['', '-Antique'])
+			forme = 'Polteageist' + this.sample(['', '-Antique']);
 		}
 		if (species.baseSpecies === 'Zarude') {
-			forme = 'Zarude' + this.sample(['', '-Dada'])
+			forme = 'Zarude' + this.sample(['', '-Dada']);
 		}
 
 		const level: number = this.getLevel(species, isDoubles, isNoDynamax);

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -999,12 +999,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Encore", "Helping Hand", "Pollen Puff", "Rage Powder", "Sleep Powder", "Strength Sap", "Tailwind"],
-                "teraTypes": ["Steel"]
-            },
-            {
-                "role": "Bulky Protect",
-                "movepool": ["Acrobatics", "Protect", "Sleep Powder", "Tailwind"],
+                "movepool": ["Acrobatics", "Encore", "Helping Hand", "Pollen Puff", "Rage Powder", "Sleep Powder", "Strength Sap", "Tailwind"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -6073,13 +6068,13 @@
         "level": 75,
         "sets": [
             {
-                "role": "Offensive Protect",
+                "role": "Doubles Setup Sweeper",
                 "movepool": ["Malignant Chain", "Nasty Plot", "Protect", "Recover", "Shadow Ball"],
                 "teraTypes": ["Dark"]
             },
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Malignant Chain", "Parting Shot", "Poison Gas", "Protect", "Recover", "Shadow Ball"],
+                "movepool": ["Malignant Chain", "Parting Shot", "Poison Gas", "Protect", "Shadow Ball"],
                 "teraTypes": ["Dark"]
             }
         ]

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -3069,21 +3069,6 @@
             }
         ]
     },
-    "basculinbluestriped": {
-        "level": 87,
-        "sets": [
-            {
-                "role": "Doubles Wallbreaker",
-                "movepool": ["Aqua Jet", "Flip Turn", "Psychic Fangs", "Wave Crash"],
-                "teraTypes": ["Water"]
-            },
-            {
-                "role": "Offensive Protect",
-                "movepool": ["Aqua Jet", "Flip Turn", "Protect", "Wave Crash"],
-                "teraTypes": ["Water"]
-            }
-        ]
-    },
     "basculegion": {
         "level": 70,
         "sets": [
@@ -3584,7 +3569,7 @@
             }
         ]
     },
-    "keldeoresolute": {
+    "keldeo": {
         "level": 80,
         "sets": [
             {
@@ -5114,21 +5099,6 @@
             }
         ]
     },
-    "mausholdfour": {
-        "level": 80,
-        "sets": [
-            {
-                "role": "Doubles Setup Sweeper",
-                "movepool": ["Encore", "Population Bomb", "Protect", "Tidy Up"],
-                "teraTypes": ["Normal"]
-            },
-            {
-                "role": "Doubles Support",
-                "movepool": ["Encore", "Follow Me", "Helping Hand", "Population Bomb", "Protect", "Taunt", "Thunder Wave", "U-turn"],
-                "teraTypes": ["Ghost"]
-            }
-        ]
-    },
     "dachsbun": {
         "level": 90,
         "sets": [
@@ -5540,21 +5510,6 @@
         ]
     },
     "dudunsparce": {
-        "level": 86,
-        "sets": [
-            {
-                "role": "Bulky Protect",
-                "movepool": ["Earth Power", "Glare", "Hyper Drill", "Protect", "Tailwind"],
-                "teraTypes": ["Ghost", "Ground", "Normal"]
-            },
-            {
-                "role": "Doubles Bulky Attacker",
-                "movepool": ["Boomburst", "Earth Power", "Helping Hand", "Protect", "Tailwind"],
-                "teraTypes": ["Ghost", "Ground", "Normal"]
-            }
-        ]
-    },
-    "dudunsparcethreesegment": {
         "level": 86,
         "sets": [
             {

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -3564,7 +3564,7 @@
             }
         ]
     },
-    "keldeo": {
+    "keldeoresolute": {
         "level": 80,
         "sets": [
             {

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -6556,11 +6556,6 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Calm Mind", "Focus Blast", "Psyshock", "Tachyon Cutter", "Volt Switch"],
                 "teraTypes": ["Fighting", "Steel"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["Agility", "Focus Blast", "Psyshock", "Tachyon Cutter"],
-                "teraTypes": ["Fighting", "Steel"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -6110,12 +6110,12 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Iron Head", "Knock Off", "Outrage", "Roost"],
-                "teraTypes": ["Dark", "Dragon", "Ground", "Steel"]
+                "teraTypes": ["Dark", "Dragon", "Ground", "Poison", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Iron Head", "Knock Off", "Outrage", "U-turn"],
-                "teraTypes": ["Dark", "Dragon", "Poison", "Steel"]
+                "teraTypes": ["Dark", "Dragon", "Steel"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -3949,7 +3949,7 @@
             }
         ]
     },
-    "keldeo": {
+    "keldeoresolute": {
         "level": 79,
         "sets": [
             {

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1944,7 +1944,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Dragon Dance", "Earthquake", "Liquidation", "Stone Edge"],
+                "movepool": ["Dragon Dance", "Earthquake", "Stone Edge", "Waterfall"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2005,7 +2005,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Dazzling Gleam", "Psychic", "Psychic Noise", "Psyshock", "Recover"],
-                "teraTypes": ["Electric", "Fairy"]
+                "teraTypes": ["Electric", "Fairy", "Poison", "Steel"]
             }
         ]
     },
@@ -3630,12 +3630,12 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Dragon Dance", "Earthquake", "Iron Head", "Outrage"],
-                "teraTypes": ["Fighting", "Ground", "Steel"]
+                "teraTypes": ["Steel"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Close Combat", "Earthquake", "Iron Head", "Scale Shot", "Swords Dance"],
-                "teraTypes": ["Fighting", "Ground", "Steel"]
+                "teraTypes": ["Steel"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -3,11 +3,6 @@
         "level": 84,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Power Whip", "Sludge Bomb", "Sunny Day", "Weather Ball"],
-                "teraTypes": ["Fire"]
-            },
-            {
                 "role": "Bulky Support",
                 "movepool": ["Giga Drain", "Leech Seed", "Sleep Powder", "Sludge Bomb", "Substitute"],
                 "teraTypes": ["Steel", "Water"]
@@ -191,11 +186,6 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Giga Drain", "Leech Seed", "Sleep Powder", "Sludge Bomb", "Strength Sap"],
                 "teraTypes": ["Steel", "Water"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["Sludge Wave", "Solar Beam", "Sunny Day", "Weather Ball"],
-                "teraTypes": ["Fire"]
             }
         ]
     },
@@ -433,12 +423,12 @@
         "level": 92,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Fast Attacker",
                 "movepool": ["Encore", "Flip Turn", "Knock Off", "Surf", "Triple Axel"],
                 "teraTypes": ["Dragon", "Grass", "Ground", "Poison", "Steel"]
             },
             {
-                "role": "Bulky Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["Encore", "Flip Turn", "Hydro Pump", "Ice Beam", "Knock Off", "Surf"],
                 "teraTypes": ["Dragon", "Grass", "Ground", "Poison", "Steel"]
             }
@@ -460,7 +450,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Curse", "Drain Punch", "Gunk Shot", "Knock Off", "Poison Jab", "Rest"],
-                "teraTypes": ["Dark", "Fighting"]
+                "teraTypes": ["Dark"]
             }
         ]
     },
@@ -850,7 +840,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Brave Bird", "Bulk Up", "Close Combat", "Knock Off", "U-turn"],
-                "teraTypes": ["Fighting"]
+                "teraTypes": ["Dark", "Fighting"]
             }
         ]
     },
@@ -914,7 +904,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Brave Bird", "Close Combat", "Flare Blitz", "Knock Off", "Leech Life", "Psychic Fangs", "Swords Dance"],
+                "movepool": ["Close Combat", "Knock Off", "Leech Life", "Psychic Fangs", "Swords Dance"],
                 "teraTypes": ["Fighting"]
             },
             {
@@ -1275,7 +1265,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Destiny Bond", "Gunk Shot", "Spikes", "Taunt", "Thunder Wave", "Toxic Spikes", "Waterfall"],
-                "teraTypes": ["Dark", "Water"]
+                "teraTypes": ["Dark", "Grass"]
             }
         ]
     },
@@ -1429,13 +1419,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Ice Spinner", "Knock Off", "Rapid Spin", "Stealth Rock"],
+                "movepool": ["Earthquake", "Ice Shard", "Ice Spinner", "Knock Off", "Rapid Spin", "Stealth Rock"],
                 "teraTypes": ["Ghost", "Grass"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Earthquake", "Ice Shard", "Ice Spinner", "Knock Off", "Rapid Spin", "Stone Edge"],
-                "teraTypes": ["Dark", "Ice"]
             }
         ]
     },
@@ -2015,7 +2000,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Heal Bell", "Knock Off", "Psychic Noise", "Recover", "Thunder Wave"],
-                "teraTypes": ["Dark", "Electric", "Poison", "Steel"]
+                "teraTypes": ["Dark", "Poison", "Steel"]
             },
             {
                 "role": "Bulky Setup",
@@ -2030,7 +2015,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Disable", "Earthquake", "Freeze-Dry", "Spikes", "Taunt"],
-                "teraTypes": ["Ground", "Poison", "Steel", "Water"]
+                "teraTypes": ["Ghost", "Ground", "Water"]
             }
         ]
     },
@@ -2344,13 +2329,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Earthquake", "Fire Punch", "Head Smash", "Rock Slide"],
-                "teraTypes": ["Ground", "Rock"]
+                "movepool": ["Earthquake", "Head Smash", "Rock Slide", "Zen Headbutt"],
+                "teraTypes": ["Ground", "Psychic", "Rock"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Crunch", "Earthquake", "Fire Punch", "Rock Slide"],
-                "teraTypes": ["Dark", "Rock"]
+                "movepool": ["Earthquake", "Fire Punch", "Rock Slide", "Zen Headbutt"],
+                "teraTypes": ["Psychic", "Rock"]
             }
         ]
     },
@@ -2480,7 +2465,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Hypnosis", "Iron Head", "Psychic Noise", "Stealth Rock"],
-                "teraTypes": ["Electric", "Water"]
+                "teraTypes": ["Water"]
             },
             {
                 "role": "Bulky Setup",
@@ -2539,7 +2524,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Roar", "Slack Off", "Stealth Rock", "Stone Edge"],
+                "movepool": ["Earthquake", "Slack Off", "Stealth Rock", "Stone Edge", "Whirlwind"],
                 "teraTypes": ["Dragon", "Rock", "Steel"]
             }
         ]
@@ -2620,7 +2605,12 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Earthquake", "Ice Punch", "Megahorn", "Rock Polish", "Stone Edge"],
-                "teraTypes": ["Ground", "Rock"]
+                "teraTypes": ["Bug", "Ground", "Rock"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Dragon Tail", "Earthquake", "Ice Punch", "Megahorn", "Stone Edge"],
+                "teraTypes": ["Bug", "Dragon", "Grass", "Steel"]
             }
         ]
     },
@@ -2849,8 +2839,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Encore", "Knock Off", "Light Screen", "Psychic", "Psychic Noise", "Reflect", "Stealth Rock", "Thunder Wave", "U-turn", "Yawn"],
-                "teraTypes": ["Dark", "Electric", "Steel"]
+                "movepool": ["Encore", "Knock Off", "Psychic", "Psychic Noise", "Stealth Rock", "Thunder Wave", "U-turn", "Yawn"],
+                "teraTypes": ["Dark", "Steel"]
             }
         ]
     },
@@ -2865,7 +2855,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Knock Off", "Psychic Noise", "Stealth Rock", "Thunder Wave", "U-turn"],
-                "teraTypes": ["Dark", "Electric", "Steel"]
+                "teraTypes": ["Dark", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
@@ -3134,8 +3124,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Earth Power", "Fire Blast", "Judgment", "Recover"],
-                "teraTypes": ["Fire", "Ground", "Steel"]
+                "movepool": ["Calm Mind", "Earth Power", "Judgment", "Recover"],
+                "teraTypes": ["Ground", "Steel"]
             }
         ]
     },
@@ -3404,7 +3394,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Hurricane", "Leech Seed", "Moonblast", "Substitute"],
+                "movepool": ["Encore", "Hurricane", "Leech Seed", "Moonblast", "Substitute"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3431,25 +3421,10 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Close Combat", "Ice Spinner", "Leaf Blade", "Sleep Powder", "Victory Dance"],
                 "teraTypes": ["Fighting"]
-            },
-            {
-                "role": "Fast Support",
-                "movepool": ["Close Combat", "Defog", "Ice Spinner", "Leaf Blade", "Sleep Powder"],
-                "teraTypes": ["Fighting"]
             }
         ]
     },
     "basculin": {
-        "level": 86,
-        "sets": [
-            {
-                "role": "Wallbreaker",
-                "movepool": ["Aqua Jet", "Double-Edge", "Flip Turn", "Wave Crash"],
-                "teraTypes": ["Water"]
-            }
-        ]
-    },
-    "basculinbluestriped": {
         "level": 86,
         "sets": [
             {
@@ -3533,14 +3508,9 @@
         "level": 83,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Bullet Seed", "Tail Slap", "Tidy Up", "Triple Axel"],
+                "role": "Fast Attacker",
+                "movepool": ["Bullet Seed", "Tail Slap", "Tidy Up", "Triple Axel", "U-turn"],
                 "teraTypes": ["Grass", "Ice", "Normal"]
-            },
-            {
-                "role": "Wallbreaker",
-                "movepool": ["Bullet Seed", "Knock Off", "Tail Slap", "Triple Axel", "U-turn"],
-                "teraTypes": ["Grass", "Normal"]
             }
         ]
     },
@@ -3634,8 +3604,8 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["Acid Spray", "Close Combat", "Flamethrower", "Giga Drain", "Knock Off", "Thunderbolt", "U-turn"],
-                "teraTypes": ["Poison"]
+                "movepool": ["Close Combat", "Flamethrower", "Giga Drain", "Knock Off", "Thunderbolt", "U-turn"],
+                "teraTypes": ["Poison", "Steel"]
             }
         ]
     },
@@ -3819,7 +3789,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Close Combat", "Earthquake", "Iron Head", "Stone Edge"],
+                "movepool": ["Close Combat", "Earthquake", "Quick Attack", "Stone Edge"],
                 "teraTypes": ["Fighting", "Ground"]
             }
         ]
@@ -3979,7 +3949,7 @@
             }
         ]
     },
-    "keldeoresolute": {
+    "keldeo": {
         "level": 79,
         "sets": [
             {
@@ -4540,7 +4510,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Knock Off", "Stealth Rock", "Stone Edge", "Sucker Punch", "Swords Dance"],
-                "teraTypes": ["Fighting"]
+                "teraTypes": ["Fighting", "Rock"]
             }
         ]
     },
@@ -4595,7 +4565,7 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Knock Off", "Leaf Storm", "Leech Life", "Superpower"],
-                "teraTypes": ["Fighting"]
+                "teraTypes": ["Fighting", "Steel", "Water"]
             }
         ]
     },
@@ -5589,16 +5559,6 @@
             }
         ]
     },
-    "mausholdfour": {
-        "level": 76,
-        "sets": [
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["Bite", "Encore", "Population Bomb", "Tidy Up"],
-                "teraTypes": ["Normal"]
-            }
-        ]
-    },
     "dachsbun": {
         "level": 91,
         "sets": [
@@ -5800,7 +5760,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Flamethrower", "Leech Seed", "Protect", "Substitute"],
-                "teraTypes": ["Steel", "Water"]
+                "teraTypes": ["Steel"]
             },
             {
                 "role": "Fast Attacker",
@@ -6048,28 +6008,18 @@
         "level": 82,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Support",
                 "movepool": ["Earthquake", "Glare", "Headbutt", "Roost"],
                 "teraTypes": ["Ghost", "Ground"]
             },
             {
-                "role": "Bulky Support",
-                "movepool": ["Boomburst", "Calm Mind", "Earth Power", "Roost", "Shadow Ball"],
+                "role": "Bulky Attacker",
+                "movepool": ["Boomburst", "Calm Mind", "Earth Power", "Roost"],
                 "teraTypes": ["Ghost"]
-            }
-        ]
-    },
-    "dudunsparcethreesegment": {
-        "level": 82,
-        "sets": [
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Earthquake", "Glare", "Headbutt", "Roost"],
-                "teraTypes": ["Ghost", "Ground"]
             },
             {
-                "role": "Bulky Support",
-                "movepool": ["Boomburst", "Calm Mind", "Earth Power", "Roost", "Shadow Ball"],
+                "role": "Bulky Setup",
+                "movepool": ["Boomburst", "Calm Mind", "Roost", "Shadow Ball"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -6165,7 +6115,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Iron Head", "Knock Off", "Outrage", "U-turn"],
-                "teraTypes": ["Dark", "Dragon", "Steel"]
+                "teraTypes": ["Dark", "Dragon", "Poison", "Steel"]
             }
         ]
     },
@@ -6270,7 +6220,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Calm Mind", "Close Combat", "Moonblast", "Psychic"],
-                "teraTypes": ["Fairy", "Fighting"]
+                "teraTypes": ["Fairy", "Fighting", "Steel"]
             }
         ]
     },
@@ -6605,6 +6555,11 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Calm Mind", "Focus Blast", "Psyshock", "Tachyon Cutter", "Volt Switch"],
+                "teraTypes": ["Fighting", "Steel"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Agility", "Focus Blast", "Psyshock", "Tachyon Cutter"],
                 "teraTypes": ["Fighting", "Steel"]
             }
         ]

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1466,7 +1466,7 @@ export class RandomTeams {
 		if (types.includes('Normal') && moves.has('fakeout')) return 'Silk Scarf';
 		if (
 			species.id !== 'jirachi' && (counter.get('Physical') >= 4) &&
-			['fakeout', 'firstimpression', 'flamecharge', 'rapidspin', 'ruination', 'superfang'].every(m => !moves.has(m))
+			['dragontail', 'fakeout', 'firstimpression', 'flamecharge', 'rapidspin'].every(m => !moves.has(m))
 		) {
 			const scarfReqs = (
 				role !== 'Wallbreaker' &&

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1159,12 +1159,10 @@ export class RandomTeams {
 		if (species.id === 'toucannon' && !counter.get('skilllink')) return 'Keen Eye';
 		if (species.id === 'reuniclus') return 'Magic Guard';
 		if (species.id === 'smeargle' && !counter.get('technician')) return 'Own Tempo';
-		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it
-		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';
 		if (species.id === 'zebstrika') return (moves.has('wildcharge')) ? 'Sap Sipper' : 'Lightning Rod';
 		if (species.id === 'sandaconda' || (species.id === 'scrafty' && moves.has('rest'))) return 'Shed Skin';
 		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';
-		if (species.id === 'cinccino') return (role === 'Wallbreaker') ? 'Skill Link' : 'Technician';
+		if (species.id === 'cinccino') return 'Technician';
 		if (species.id === 'dipplin') return 'Sticky Hold';
 		if (species.id === 'breloom') return 'Technician';
 		if (species.id === 'shiftry' && moves.has('tailwind')) return 'Wind Rider';
@@ -1352,7 +1350,7 @@ export class RandomTeams {
 		if (moves.has('populationbomb')) return 'Wide Lens';
 		if (
 			moves.has('scaleshot') || (species.id === 'torterra' && !isDoubles) ||
-			(species.id === 'cinccino' && role !== 'Wallbreaker')
+			(species.id === 'cinccino')
 		) return 'Loaded Dice';
 		if (ability === 'Unburden') {
 			return (moves.has('closecombat') || moves.has('leafstorm')) ? 'White Herb' : 'Sitrus Berry';
@@ -1500,6 +1498,7 @@ export class RandomTeams {
 		}
 		if (species.id === 'golem') return (counter.get('speedsetup')) ? 'Weakness Policy' : 'Custap Berry';
 		if (species.id === 'urshifurapidstrike') return 'Punching Glove';
+		if (species.id === 'latias' || species.id === 'latios') return 'Soul Dew';
 		if (species.id === 'palkia') return 'Lustrous Orb';
 		if (moves.has('substitute')) return 'Leftovers';
 		if (moves.has('stickyweb') && species.id !== 'araquanid' && isLead) return 'Focus Sash';
@@ -1520,7 +1519,7 @@ export class RandomTeams {
 			)
 		) return 'Rocky Helmet';
 		if (moves.has('outrage')) return 'Lum Berry';
-		if (moves.has('protect')) return 'Leftovers';
+		if (moves.has('protect') && ability !== 'Speed Boost') return 'Leftovers';
 		if (
 			role === 'Fast Support' && isLead &&
 			!counter.get('recovery') && !counter.get('recoil') &&
@@ -1638,8 +1637,33 @@ export class RandomTeams {
 			}
 		}
 
+		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
+		if (species.baseSpecies === 'Basculin') {
+			forme = 'Basculin' + this.sample(['', '-Blue-Striped'])
+		}
+		if (species.baseSpecies === 'Dudunsparce') {
+			forme = 'Dudunsparce' + this.sample(['', '-Three-Segment'])
+		}
+		if (species.baseSpecies === 'Keldeo') {
+			forme = 'Keldeo' + this.sample(['', '-Resolute'])
+		}
+		if (species.baseSpecies === 'Magearna') {
+			forme = 'Magearna' + this.sample(['', '-Original'])
+		}
+		if (species.baseSpecies === 'Maushold') {
+			forme = 'Maushold' + this.sample(['', '-Four'])
+		}
 		if (species.baseSpecies === 'Pikachu') {
 			forme = 'Pikachu' + this.sample(['', '-Original', '-Hoenn', '-Sinnoh', '-Unova', '-Kalos', '-Alola', '-Partner', '-World']);
+		}
+		if (species.baseSpecies === 'Polteageist') {
+			forme = 'Polteageist' + this.sample(['', '-Antique'])
+		}
+		if (species.baseSpecies === 'Sinistcha') {
+			forme = 'Sinistcha' + this.sample(['', '-Masterpiece'])
+		}
+		if (species.baseSpecies === 'Zarude') {
+			forme = 'Zarude' + this.sample(['', '-Dada'])
 		}
 
 		// Get level

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1577,18 +1577,15 @@ export class RandomTeams {
 		if (species.cosmeticFormes) return this.sample([species.name].concat(species.cosmeticFormes));
 
 		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
+		if (['Dudunsparce', 'Magearna', 'Maushold', 'Polteageist', 'Sinistcha', 'Zarude'].includes(species.baseSpecies)) {
+			return this.sample([species.name].concat(species.otherFormes!));
+		}
 		if (species.baseSpecies === 'Basculin') return 'Basculin' + this.sample(['', '-Blue-Striped']);
-		if (species.baseSpecies === 'Dudunsparce') return 'Dudunsparce' + this.sample(['', '-Three-Segment']);
-		if (species.baseSpecies === 'Magearna') return 'Magearna' + this.sample(['', '-Original']);
-		if (species.baseSpecies === 'Maushold') return 'Maushold' + this.sample(['', '-Four']);
 		if (species.baseSpecies === 'Pikachu') {
 			return 'Pikachu' + this.sample(
 				['', '-Original', '-Hoenn', '-Sinnoh', '-Unova', '-Kalos', '-Alola', '-Partner', '-World']
 			);
 		}
-		if (species.baseSpecies === 'Polteageist') return 'Polteageist' + this.sample(['', '-Antique']);
-		if (species.baseSpecies === 'Sinistcha') return 'Sinistcha' + this.sample(['', '-Masterpiece']);
-		if (species.baseSpecies === 'Zarude') return 'Zarude' + this.sample(['', '-Dada']);
 		return species.name;
 	}
 

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1161,9 +1161,8 @@ export class RandomTeams {
 		if (species.id === 'zebstrika') return (moves.has('wildcharge')) ? 'Sap Sipper' : 'Lightning Rod';
 		if (species.id === 'sandaconda' || (species.id === 'scrafty' && moves.has('rest'))) return 'Shed Skin';
 		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';
-		if (species.id === 'cinccino') return 'Technician';
 		if (species.id === 'dipplin') return 'Sticky Hold';
-		if (species.id === 'breloom') return 'Technician';
+		if (species.id === 'breloom' || species.id === 'cinccino') return 'Technician';
 		if (species.id === 'shiftry' && moves.has('tailwind')) return 'Wind Rider';
 
 		// singles
@@ -1348,8 +1347,7 @@ export class RandomTeams {
 		if (moves.has('courtchange')) return 'Heavy-Duty Boots';
 		if (moves.has('populationbomb')) return 'Wide Lens';
 		if (
-			moves.has('scaleshot') || (species.id === 'torterra' && !isDoubles) ||
-			(species.id === 'cinccino')
+			moves.has('scaleshot') || (species.id === 'torterra' && !isDoubles) || species.id === 'cinccino'
 		) return 'Loaded Dice';
 		if (ability === 'Unburden') {
 			return (moves.has('closecombat') || moves.has('leafstorm')) ? 'White Herb' : 'Sitrus Berry';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1639,31 +1639,31 @@ export class RandomTeams {
 
 		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
 		if (species.baseSpecies === 'Basculin') {
-			forme = 'Basculin' + this.sample(['', '-Blue-Striped'])
+			forme = 'Basculin' + this.sample(['', '-Blue-Striped']);
 		}
 		if (species.baseSpecies === 'Dudunsparce') {
-			forme = 'Dudunsparce' + this.sample(['', '-Three-Segment'])
+			forme = 'Dudunsparce' + this.sample(['', '-Three-Segment']);
 		}
 		if (species.baseSpecies === 'Keldeo') {
-			forme = 'Keldeo' + this.sample(['', '-Resolute'])
+			forme = 'Keldeo' + this.sample(['', '-Resolute']);
 		}
 		if (species.baseSpecies === 'Magearna') {
-			forme = 'Magearna' + this.sample(['', '-Original'])
+			forme = 'Magearna' + this.sample(['', '-Original']);
 		}
 		if (species.baseSpecies === 'Maushold') {
-			forme = 'Maushold' + this.sample(['', '-Four'])
+			forme = 'Maushold' + this.sample(['', '-Four']);
 		}
 		if (species.baseSpecies === 'Pikachu') {
 			forme = 'Pikachu' + this.sample(['', '-Original', '-Hoenn', '-Sinnoh', '-Unova', '-Kalos', '-Alola', '-Partner', '-World']);
 		}
 		if (species.baseSpecies === 'Polteageist') {
-			forme = 'Polteageist' + this.sample(['', '-Antique'])
+			forme = 'Polteageist' + this.sample(['', '-Antique']);
 		}
 		if (species.baseSpecies === 'Sinistcha') {
-			forme = 'Sinistcha' + this.sample(['', '-Masterpiece'])
+			forme = 'Sinistcha' + this.sample(['', '-Masterpiece']);
 		}
 		if (species.baseSpecies === 'Zarude') {
-			forme = 'Zarude' + this.sample(['', '-Dada'])
+			forme = 'Zarude' + this.sample(['', '-Dada']);
 		}
 
 		// Get level

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -590,7 +590,6 @@ export class RandomTeams {
 			this.incompatibleMoves(moves, movePool, ['charm', 'flipturn', 'icebeam'], ['charm', 'flipturn']);
 		}
 		if (species.id === "cyclizar") this.incompatibleMoves(moves, movePool, 'taunt', 'knockoff');
-		if (species.baseSpecies === 'Dudunsparce') this.incompatibleMoves(moves, movePool, 'earthpower', 'shadowball');
 		if (species.id === 'mesprit') this.incompatibleMoves(moves, movePool, 'healingwish', 'uturn');
 	}
 

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1569,6 +1569,29 @@ export class RandomTeams {
 		return tierScale[tier] || 80;
 	}
 
+	getForme(species: Species): string {
+		if (typeof species.battleOnly === 'string') {
+			// Only change the forme. The species has custom moves, and may have different typing and requirements.
+			return species.battleOnly;
+		}
+		if (species.cosmeticFormes) return this.sample([species.name].concat(species.cosmeticFormes));
+
+		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
+		if (species.baseSpecies === 'Basculin') return 'Basculin' + this.sample(['', '-Blue-Striped']);
+		if (species.baseSpecies === 'Dudunsparce') return 'Dudunsparce' + this.sample(['', '-Three-Segment']);
+		if (species.baseSpecies === 'Magearna') return 'Magearna' + this.sample(['', '-Original']);
+		if (species.baseSpecies === 'Maushold') return 'Maushold' + this.sample(['', '-Four']);
+		if (species.baseSpecies === 'Pikachu') {
+			return 'Pikachu' + this.sample(
+				['', '-Original', '-Hoenn', '-Sinnoh', '-Unova', '-Kalos', '-Alola', '-Partner', '-World']
+			);
+		}
+		if (species.baseSpecies === 'Polteageist') return 'Polteageist' + this.sample(['', '-Antique']);
+		if (species.baseSpecies === 'Sinistcha') return 'Sinistcha' + this.sample(['', '-Masterpiece']);
+		if (species.baseSpecies === 'Zarude') return 'Zarude' + this.sample(['', '-Dada']);
+		return species.name;
+	}
+
 	randomSet(
 		s: string | Species,
 		teamDetails: RandomTeamsTypes.TeamDetails = {},
@@ -1576,15 +1599,7 @@ export class RandomTeams {
 		isDoubles = false
 	): RandomTeamsTypes.RandomSet {
 		const species = this.dex.species.get(s);
-		let forme = species.name;
-
-		if (typeof species.battleOnly === 'string') {
-			// Only change the forme. The species has custom moves, and may have different typing and requirements.
-			forme = species.battleOnly;
-		}
-		if (species.cosmeticFormes) {
-			forme = this.sample([species.name].concat(species.cosmeticFormes));
-		}
+		const forme = this.getForme(species);
 		const sets = (this as any)[`random${isDoubles ? 'Doubles' : ''}Sets`][species.id]["sets"];
 		const possibleSets = [];
 
@@ -1632,32 +1647,6 @@ export class RandomTeams {
 			} else {
 				item = this.getItem(ability, types, moves, counter, teamDetails, species, isLead, teraType, role);
 			}
-		}
-
-		// Consolidate mostly-cosmetic formes, at least for the purposes of Random Battles
-		if (species.baseSpecies === 'Basculin') {
-			forme = 'Basculin' + this.sample(['', '-Blue-Striped']);
-		}
-		if (species.baseSpecies === 'Dudunsparce') {
-			forme = 'Dudunsparce' + this.sample(['', '-Three-Segment']);
-		}
-		if (species.baseSpecies === 'Magearna') {
-			forme = 'Magearna' + this.sample(['', '-Original']);
-		}
-		if (species.baseSpecies === 'Maushold') {
-			forme = 'Maushold' + this.sample(['', '-Four']);
-		}
-		if (species.baseSpecies === 'Pikachu') {
-			forme = 'Pikachu' + this.sample(['', '-Original', '-Hoenn', '-Sinnoh', '-Unova', '-Kalos', '-Alola', '-Partner', '-World']);
-		}
-		if (species.baseSpecies === 'Polteageist') {
-			forme = 'Polteageist' + this.sample(['', '-Antique']);
-		}
-		if (species.baseSpecies === 'Sinistcha') {
-			forme = 'Sinistcha' + this.sample(['', '-Masterpiece']);
-		}
-		if (species.baseSpecies === 'Zarude') {
-			forme = 'Zarude' + this.sample(['', '-Dada']);
 		}
 
 		// Get level

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1643,9 +1643,6 @@ export class RandomTeams {
 		if (species.baseSpecies === 'Dudunsparce') {
 			forme = 'Dudunsparce' + this.sample(['', '-Three-Segment']);
 		}
-		if (species.baseSpecies === 'Keldeo') {
-			forme = 'Keldeo' + this.sample(['', '-Resolute']);
-		}
 		if (species.baseSpecies === 'Magearna') {
 			forme = 'Magearna' + this.sample(['', '-Original']);
 		}

--- a/server/chat-plugins/randombattles/index.ts
+++ b/server/chat-plugins/randombattles/index.ts
@@ -193,6 +193,8 @@ function getLevel(species: string | Species, format: string | Format): number {
 	// Only formats where levels are not all manually assigned should be copied here
 	case 'gen2randombattle':
 		const levelScale: {[k: string]: number} = {
+			ZU: 81,
+			ZUBL: 79,
 			PU: 77,
 			PUBL: 75,
 			NU: 73,

--- a/server/chat-plugins/randombattles/winrates.ts
+++ b/server/chat-plugins/randombattles/winrates.ts
@@ -96,6 +96,10 @@ function getSpeciesName(set: PokemonSet, format: Format) {
 		return 'Keldeo';
 	} else if (species === "Zarude-Dada") {
 		return 'Zarude';
+	} else if (species === 'Polteageist-Antique') {
+		return 'Polteageist';
+	} else if (species === 'Sinistcha-Masterpiece') {
+		return 'Sinistcha';
 	} else if (species === "Squawkabilly-Blue") {
 		return "Squawkabilly";
 	} else if (species === "Squawkabilly-White") {


### PR DESCRIPTION
All Gens:
Keldeo (in gens 5-7), Dudunsparce, Maushold, Polteageist, Sinistcha, Basculin (red and blue), Magearna, and Zarude now all roll randomly between their effectively cosmetic formes in Random Battles and no longer have their cosmetic formes show up in the /randbats command.

Gen 9 Random Battle:
(_*_) - This change reduces the rate of Choice items

-Blaziken no longer gets Leftovers. Oops!
-Cinccino no longer gets Skill Link Choice Band, and instead now is a 50% roll between Loaded Dice Technician Tidy Up and Loaded Dice Technician U-turn. (_*_)
-Dewgong's roles have been changed to delete Assault Vest Dewgong. It is now 100% Heavy-Duty Boots.
-Latias and Latios now get Soul Dew instead of Life Orb and Leftovers. Choice Specs Latios still exists as normal.
-Rhyperior now has a second Bulky Attacker set with Assault Vest and Choice Band, and Tera Bug has been added to its Rock Polish set.
-Donphan's Bulky Attacker set has been removed and Ice Shard has been added to Bulky Support. Donphan no longer gets Choice Band unless the team already has hazard removal. (_*_)
-Venusaur and Vileplume no longer run Sunny Day sets.
-In order to increase code simplicity, Dudunsparce's Calm Mind set has been split into two, one for each coverage move. This means Calm Mind is now 2/3rds of Dudunsparces.
-Fast Support Hisuian Lilligant has been removed. It is now entirely Victory Dance.
-Rampardos now has Zen Headbutt and Tera Psychic on both sets. It no longer runs Fire Punch on Choice Scarf and no longer runs Crunch or Tera Dark on Life Orb.
-Haxorus is now only Tera Steel and now always gets Iron Head.
-SubSeed Whimsicott: +Encore (can roll over Hurricane)
-Arceus-Fairy: -Fire Blast, -Tera Fire
-Physical Mew: -Flare Blitz, -Brave Bird (last move is now a roll between Knock Off and Leech Life)
-Uxie: -Screens
-Dragon Dance Whiscash: -Liquidation, +Waterfall
-Hippowdon: -Roar, +Whirlwind (again)
-AV Pivot Eelektross: -Acid Spray, +Tera Steel
-Choice Band Terrakion: -Iron Head, +Quick Attack (previous change reverted due to winrates)
-Bulky Setup Chimecho: +Tera Poison, +Tera Steel
-AV Pivot Lurantis: +Tera Steel, +Tera Water
-Calm Mind Iron Valiant: +Tera Steel
-Lycanroc-Midnight: +Tera Rock
-Glalie: -Tera Steel, -Tera Poison, +Tera Ghost
-Zapdos-Galar: +Tera Dark
-Support Mesprit, Uxie, Support Bronzong, Support Chimecho: -Tera Electric
-SubSeed Scovillain: -Tera Water
-Curse Muk: -Tera Fighting
-Qwilfish: -Tera Water, +Tera Grass
-Setup Sweeper Roaring Moon: +Tera Poison
-Removed no-longer-necessary hardcodes involving Cinccino, Ambipom, and Dudunsparce

Gen 9 Random Doubles:
-Jumpluff's former Acrobatics set has been removed. Its Doubles Support set now has Acrobatics.
-Pecharunt's first set is now Doubles Setup Sweeper, and its second set no longer has Recover. As such, Protect + Recover Pecharunt no longer exists.

Gen 2:
ZU and ZUBL Pokemon now have levels associated with their tiers