### PR TITLE
Re-Evolution Mod: Exclude special Pokemon

### DIFF
--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -2236,7 +2236,8 @@ export const Rulesets: {[k: string]: FormatData} = {
 			const newSpecies = this.dex.deepClone(species);
 			const baseSpecies = this.dex.species.get(species.baseSpecies);
 			if (!newSpecies.prevo) {
-				if (!baseSpecies.prevo || newSpecies.id === 'greninjabond' || newSpecies.id === 'ursalunabloodmoon' || newSpecies.id ==='vivillonpokeball') return;
+				if (!baseSpecies.prevo || newSpecies.id === 'greninjabond' || newSpecies.id === 'ursalunabloodmoon'
+					 || newSpecies.id ==='vivillonpokeball') return;
 				const prevoSpecies = this.dex.species.get(baseSpecies.prevo);
 				let statid: StatID;
 				newSpecies.bst = 0;

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -2236,7 +2236,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 			const newSpecies = this.dex.deepClone(species);
 			const baseSpecies = this.dex.species.get(species.baseSpecies);
 			if (!newSpecies.prevo) {
-				if (!baseSpecies.prevo) return;
+				if (!baseSpecies.prevo || newSpecies.id === 'greninjabond' || newSpecies.id === 'ursalunabloodmoon' || newSpecies.id ==='vivillonpokeball') return;
 				const prevoSpecies = this.dex.species.get(baseSpecies.prevo);
 				let statid: StatID;
 				newSpecies.bst = 0;

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -2236,8 +2236,8 @@ export const Rulesets: {[k: string]: FormatData} = {
 			const newSpecies = this.dex.deepClone(species);
 			const baseSpecies = this.dex.species.get(species.baseSpecies);
 			if (!newSpecies.prevo) {
-				if (!baseSpecies.prevo || newSpecies.id === 'greninjabond' || newSpecies.id === 'ursalunabloodmoon'
-					 || newSpecies.id === 'vivillonpokeball') return;
+				if (!baseSpecies.prevo || newSpecies.id === 'greninjabond' || newSpecies.id === 'ursalunabloodmoon' ||
+					 newSpecies.id === 'vivillonpokeball') return;
 				const prevoSpecies = this.dex.species.get(baseSpecies.prevo);
 				let statid: StatID;
 				newSpecies.bst = 0;

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -2237,7 +2237,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 			const baseSpecies = this.dex.species.get(species.baseSpecies);
 			if (!newSpecies.prevo) {
 				if (!baseSpecies.prevo || newSpecies.id === 'greninjabond' || newSpecies.id === 'ursalunabloodmoon'
-					 || newSpecies.id ==='vivillonpokeball') return;
+					 || newSpecies.id === 'vivillonpokeball') return;
 				const prevoSpecies = this.dex.species.get(baseSpecies.prevo);
 				let statid: StatID;
 				newSpecies.bst = 0;


### PR DESCRIPTION
There is no way to evolve Frogadier/Ursaring/Spewpa into these forms, neither is possible to change the base form into them, so they have to be excluded.