### PR TITLE
Showevo: Exclude special Pokemon

### DIFF
--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -826,7 +826,8 @@ export const commands: Chat.ChatCommands = {
 		}
 		if (!evo.prevo) {
 			const evoBaseSpecies = Dex.species.get(evo.baseSpecies);
-			if (!evoBaseSpecies.prevo || targetid === 'greninjabond' || targetid === 'ursalunabloodmoon' || targetid === 'vivillonpokeball') throw new Chat.ErrorMessage(`Error: ${evoBaseSpecies.name} is not an evolution.`);
+			if (!evoBaseSpecies.prevo || targetid === 'greninjabond' || targetid === 'ursalunabloodmoon' || targetid === 'vivillonpokeball')
+				throw new Chat.ErrorMessage(`Error: ${evoBaseSpecies.name} is not an evolution.`);
 			const prevoSpecies = Dex.species.get(evoBaseSpecies.prevo);
 			const deltas = Utils.deepClone(evo);
 		    if (!isReEvo) {

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -826,8 +826,10 @@ export const commands: Chat.ChatCommands = {
 		}
 		if (!evo.prevo) {
 			const evoBaseSpecies = Dex.species.get(evo.baseSpecies);
-			if (!evoBaseSpecies.prevo || targetid === 'greninjabond' || targetid === 'ursalunabloodmoon' || targetid === 'vivillonpokeball')
+			if (!evoBaseSpecies.prevo || targetid === 'greninjabond' || targetid === 'ursalunabloodmoon' ||
+				 targetid === 'vivillonpokeball') {
 				throw new Chat.ErrorMessage(`Error: ${evoBaseSpecies.name} is not an evolution.`);
+			}
 			const prevoSpecies = Dex.species.get(evoBaseSpecies.prevo);
 			const deltas = Utils.deepClone(evo);
 		    if (!isReEvo) {

--- a/server/chat-plugins/othermetas.ts
+++ b/server/chat-plugins/othermetas.ts
@@ -826,7 +826,7 @@ export const commands: Chat.ChatCommands = {
 		}
 		if (!evo.prevo) {
 			const evoBaseSpecies = Dex.species.get(evo.baseSpecies);
-			if (!evoBaseSpecies.prevo) throw new Chat.ErrorMessage(`Error: ${evoBaseSpecies.name} is not an evolution.`);
+			if (!evoBaseSpecies.prevo || targetid === 'greninjabond' || targetid === 'ursalunabloodmoon' || targetid === 'vivillonpokeball') throw new Chat.ErrorMessage(`Error: ${evoBaseSpecies.name} is not an evolution.`);
 			const prevoSpecies = Dex.species.get(evoBaseSpecies.prevo);
 			const deltas = Utils.deepClone(evo);
 		    if (!isReEvo) {


### PR DESCRIPTION
There is no way to evolve Frogadier/Ursaring/Spewpa into these forms, neither is possible to change the base form into them, so they have to be excluded.