### PR TITLE
Fix crash in Monotype Random Battles

### DIFF
--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -2420,9 +2420,9 @@ export class RandomGen8Teams {
 		pokemonToExclude: RandomTeamsTypes.RandomSet[] = [],
 		isMonotype = false,
 		pokemonList: string[]
-	): [{[k: string]: ID[]}, string[]] {
+	): [{[k: string]: string[]}, string[]] {
 		const exclude = pokemonToExclude.map(p => toID(p.species));
-		const pokemonPool: {[k: string]: ID[]} = {};
+		const pokemonPool: {[k: string]: string[]} = {};
 		const baseSpeciesPool = [];
 		for (const pokemon of pokemonList) {
 			let species = this.dex.species.get(pokemon);
@@ -2436,9 +2436,9 @@ export class RandomGen8Teams {
 			}
 
 			if (species.baseSpecies in pokemonPool) {
-				pokemonPool[species.baseSpecies].push(species.id);
+				pokemonPool[species.baseSpecies].push(pokemon);
 			} else {
-				pokemonPool[species.baseSpecies] = [species.id];
+				pokemonPool[species.baseSpecies] = [pokemon];
 			}
 		}
 		// Include base species 1x if 1-3 formes, 2x if 4-6 formes, 3x if 7+ formes

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1720,9 +1720,9 @@ export class RandomTeams {
 		pokemonToExclude: RandomTeamsTypes.RandomSet[] = [],
 		isMonotype = false,
 		pokemonList: string[]
-	): [{[k: string]: ID[]}, string[]] {
+	): [{[k: string]: string[]}, string[]] {
 		const exclude = pokemonToExclude.map(p => toID(p.species));
-		const pokemonPool: {[k: string]: ID[]} = {};
+		const pokemonPool: {[k: string]: string[]} = {};
 		const baseSpeciesPool = [];
 		for (const pokemon of pokemonList) {
 			let species = this.dex.species.get(pokemon);
@@ -1736,9 +1736,9 @@ export class RandomTeams {
 			}
 
 			if (species.baseSpecies in pokemonPool) {
-				pokemonPool[species.baseSpecies].push(species.id);
+				pokemonPool[species.baseSpecies].push(pokemon);
 			} else {
-				pokemonPool[species.baseSpecies] = [species.id];
+				pokemonPool[species.baseSpecies] = [pokemon];
 			}
 		}
 		// Include base species 1x if 1-3 formes, 2x if 4-6 formes, 3x if 7+ formes


### PR DESCRIPTION
Fixes the bug that can cause crashes with Monotype Random Battles, that was inadvertently introduced in https://github.com/smogon/pokemon-showdown/pull/10138.