### PR TITLE
Fix Tera Shift not updating Terapagos's HP

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -4873,6 +4873,13 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (pokemon.species.forme !== 'Terastal') {
 				this.add('-activate', pokemon, 'ability: Tera Shift');
 				pokemon.formeChange('Terapagos-Terastal', this.effect, true);
+				pokemon.baseMaxhp = Math.floor(Math.floor(
+					2 * pokemon.species.baseStats['hp'] + pokemon.set.ivs['hp'] + Math.floor(pokemon.set.evs['hp'] / 4) + 100
+				) * pokemon.level / 100 + 10);
+				const newMaxHP = pokemon.baseMaxhp;
+				pokemon.hp = newMaxHP - (pokemon.maxhp - pokemon.hp);
+				pokemon.maxhp = newMaxHP;
+				this.add('-heal', pokemon, pokemon.getHealth, '[silent]');
 			}
 		},
 		flags: {failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, cantsuppress: 1, notransform: 1},


### PR DESCRIPTION
Tera Shift does not update Terapagos to its correct HP stat on transforming. It should jump from 90 base HP as the base form to 95 HP as Terastal form. We have similar behavior in place for Stellar Terapagos and Zygarde-Complete.

This fix works, but I'm not sure why we have to do it in the first place. Wouldn't it be better to have the stat update happen in the formeChange function? We'd run into the same problem the next time another form change that modifies base HP happens.