### PR TITLE
[Gen 3] Hustle reduces accuracy of moves by type

### DIFF
--- a/data/mods/gen3/abilities.ts
+++ b/data/mods/gen3/abilities.ts
@@ -55,6 +55,15 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		inherit: true,
 		flags: {},
 	},
+	hustle: {
+		inherit: true,
+		onSourceModifyAccuracy(accuracy, target, source, move) {
+			const physicalTypes = ['Normal', 'Fighting', 'Flying', 'Poison', 'Ground', 'Rock', 'Bug', 'Ghost', 'Steel'];
+			if (move.category === 'Physical' || physicalTypes.includes(move.type)) {
+				return this.chainModify([3277, 4096]);
+			}
+		},
+	},
 	intimidate: {
 		inherit: true,
 		onStart(pokemon) {

--- a/data/mods/gen3/abilities.ts
+++ b/data/mods/gen3/abilities.ts
@@ -59,7 +59,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		inherit: true,
 		onSourceModifyAccuracy(accuracy, target, source, move) {
 			const physicalTypes = ['Normal', 'Fighting', 'Flying', 'Poison', 'Ground', 'Rock', 'Bug', 'Ghost', 'Steel'];
-			if (move.category === 'Physical' || physicalTypes.includes(move.type)) {
+			if (physicalTypes.includes(move.type) && typeof accuracy === 'number') {
 				return this.chainModify([3277, 4096]);
 			}
 		},


### PR DESCRIPTION
Recognizing that keeping `move.category === 'Physical'` MIGHT be redundant.

https://www.smogon.com/forums/threads/gen-3-hustle-should-affect-status-moves-accuracy.3735326/
In Gen 3, Hustle reduces the accuracy of physical-typed Status category moves.