### PR TITLE
Randomized format set updates

### DIFF
--- a/data/mods/gen3/random-sets.json
+++ b/data/mods/gen3/random-sets.json
@@ -1236,10 +1236,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["batonpass", "protect", "toxic", "wish"]
-            },
-            {
-                "role": "Generalist",
-                "movepool": ["batonpass", "meanlook", "moonlight", "toxic"]
             }
         ]
     },

--- a/data/mods/gen3/random-sets.json
+++ b/data/mods/gen3/random-sets.json
@@ -1843,7 +1843,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["hiddenpowerflying", "morningsun", "stunspore", "substitute", "toxic"]
+                "movepool": ["hiddenpowerfire", "morningsun", "psychic", "toxic"]
             }
         ]
     },

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -485,12 +485,12 @@ export class RandomGen3Teams extends RandomGen4Teams {
 	): string {
 		// First, the high-priority items
 		if (species.id === 'farfetchd') return 'Stick';
-		if (species.id === 'shuckle') return 'Leftovers';
 		if (species.id === 'latias' || species.id === 'latios') return 'Soul Dew';
 		if (species.id === 'linoone' && role === 'Setup Sweeper') return 'Silk Scarf';
 		if (species.id === 'marowak') return 'Thick Club';
 		if (species.id === 'pikachu') return 'Light Ball';
 		if (species.id === 'shedinja') return 'Lum Berry';
+		if (species.id === 'shuckle') return 'Leftovers';
 		if (species.id === 'unown') return counter.get('Physical') ? 'Choice Band' : 'Twisted Spoon';
 
 		if (moves.has('trick')) return 'Choice Band';

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -485,6 +485,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 	): string {
 		// First, the high-priority items
 		if (species.id === 'farfetchd') return 'Stick';
+		if (species.id === 'shuckle') return 'Leftovers';
 		if (species.id === 'latias' || species.id === 'latios') return 'Soul Dew';
 		if (species.id === 'linoone' && role === 'Setup Sweeper') return 'Silk Scarf';
 		if (species.id === 'marowak') return 'Thick Club';

--- a/data/mods/gen4/random-sets.json
+++ b/data/mods/gen4/random-sets.json
@@ -396,7 +396,7 @@
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["encore", "raindance", "rest", "surf", "toxic"]
+                "movepool": ["raindance", "rest", "surf", "toxic"]
             },
             {
                 "role": "Bulky Support",
@@ -827,8 +827,8 @@
         "level": 91,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["aromatherapy", "energyball", "leechseed", "lightscreen", "reflect", "synthesis", "toxic"]
+                "role": "Staller",
+                "movepool": ["aromatherapy", "earthquake", "energyball", "leechseed", "synthesis", "toxic"]
             }
         ]
     },
@@ -1076,7 +1076,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "hiddenpowerfighting", "hiddenpowerfire", "psychic", "substitute", "thunderbolt"]
+                "movepool": ["batonpass", "calmmind", "hiddenpowerfighting", "psychic", "substitute", "thunderbolt"]
             }
         ]
     },
@@ -1344,8 +1344,9 @@
                 "movepool": ["aurasphere", "hiddenpowerice", "shadowball", "thunderbolt"]
             },
             {
-                "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "calmmind", "hiddenpowerice", "substitute", "thunderbolt"]
+                "role": "Bulky Setup",
+                "movepool": ["aurasphere", "calmmind", "hiddenpowerice", "substitute", "thunderbolt"],
+                "preferredTypes": ["Ice"]
             }
         ]
     },
@@ -1514,7 +1515,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["energyball", "focusblast", "hydropump", "icebeam", "surf"]
+                "movepool": ["energyball", "hydropump", "icebeam", "surf"]
             }
         ]
     },
@@ -2432,7 +2433,7 @@
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "firepunch", "headsmash", "superpower", "zenheadbutt"]
+                "movepool": ["earthquake", "headsmash", "stoneedge", "superpower"]
             }
         ]
     },
@@ -2767,8 +2768,8 @@
                 "movepool": ["explosion", "flashcannon", "hiddenpowerfire", "hiddenpowerice", "thunderbolt"]
             },
             {
-                "role": "Bulky Support",
-                "movepool": ["hiddenpowerfighting", "hiddenpowerfire", "magnetrise", "substitute", "thunderbolt"]
+                "role": "Staller",
+                "movepool": ["hiddenpowerice", "protect", "thunderbolt", "toxic"]
             }
         ]
     },
@@ -3028,7 +3029,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "lightscreen", "psychic", "reflect", "stealthrock", "thunderwave", "uturn", "yawn"]
+                "movepool": ["healbell", "psychic", "stealthrock", "thunderwave", "uturn", "yawn"]
             }
         ]
     },
@@ -3154,7 +3155,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["hiddenpowerfighting", "lightscreen", "moonlight", "psychic", "reflect", "thunderwave", "toxic"]
+                "movepool": ["hiddenpowerfighting", "moonlight", "psychic", "thunderwave", "toxic"]
             }
         ]
     },

--- a/data/mods/gen4/random-sets.json
+++ b/data/mods/gen4/random-sets.json
@@ -2519,7 +2519,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquajet", "batonpass", "bulkup", "icepunch", "return", "substitute", "waterfall"]
+                "movepool": ["aquajet", "bulkup", "icepunch", "return", "substitute", "waterfall"]
             }
         ]
     },

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -562,7 +562,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		if (species.id === 'shedinja' || species.id === 'smeargle') return 'Focus Sash';
 		if (species.id === 'unown') return 'Choice Specs';
 		if (species.id === 'wobbuffet') return 'Custap Berry';
-		if (species.id === 'ditto') return 'Choice Scarf';
+		if (species.id === 'ditto' || (species.id === 'rampardos' && role === 'Fast Attacker')) return 'Choice Scarf';
 		if (ability === 'Poison Heal' || moves.has('facade')) return 'Toxic Orb';
 		if (ability === 'Speed Boost' && species.id === 'yanmega') return 'Life Orb';
 		if (['healingwish', 'switcheroo', 'trick'].some(m => moves.has(m))) {

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -874,7 +874,7 @@
         ]
     },
     "typhlosion": {
-        "level": 86,
+        "level": 82,
         "sets": [
             {
                 "role": "Fast Attacker",

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -1992,7 +1992,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["crunch", "dragondance", "substitute", "superpower", "waterfall"]
+                "movepool": ["crunch", "dragondance", "superpower", "waterfall"]
             }
         ]
     },

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -175,8 +175,13 @@
         "level": 80,
         "sets": [
             {
+                "role": "Bulky Setup",
+                "movepool": ["fireblast", "hypnosis", "nastyplot", "solarbeam", "willowisp"],
+                "preferredTypes": ["Grass"]
+            },
+            {
                 "role": "Setup Sweeper",
-                "movepool": ["fireblast", "hiddenpowerrock", "hypnosis", "nastyplot", "solarbeam", "substitute", "willowisp"],
+                "movepool": ["fireblast", "hiddenpowerrock", "nastyplot", "solarbeam", "substitute"],
                 "preferredTypes": ["Grass"]
             }
         ]
@@ -863,13 +868,13 @@
         "level": 91,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["aromatherapy", "dragontail", "gigadrain", "leechseed", "lightscreen", "reflect", "synthesis", "toxic"]
+                "role": "Staller",
+                "movepool": ["aromatherapy", "dragontail", "earthquake", "gigadrain", "leechseed", "synthesis", "toxic"]
             }
         ]
     },
     "typhlosion": {
-        "level": 82,
+        "level": 86,
         "sets": [
             {
                 "role": "Fast Attacker",
@@ -1116,7 +1121,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "hiddenpowerfighting", "hiddenpowerfire", "hypervoice", "psychic", "psyshock", "substitute", "thunderbolt"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "hypervoice", "psychic", "psyshock", "substitute", "thunderbolt"]
             }
         ]
     },
@@ -1405,8 +1410,9 @@
                 "movepool": ["aurasphere", "hiddenpowerice", "thunderbolt", "voltswitch"]
             },
             {
-                "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "calmmind", "hiddenpowerice", "substitute", "thunderbolt"]
+                "role": "Bulky Setup",
+                "movepool": ["aurasphere", "calmmind", "hiddenpowerice", "substitute", "thunderbolt"],
+                "preferredTypes": ["Ice"]
             }
         ]
     },
@@ -1575,7 +1581,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["focusblast", "gigadrain", "hydropump", "icebeam", "scald"]
+                "movepool": ["gigadrain", "hydropump", "icebeam", "scald"]
             }
         ]
     },
@@ -2454,12 +2460,12 @@
         "level": 90,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["crunch", "earthquake", "firepunch", "rockpolish", "rockslide"]
+                "role": "Setup Sweeper",
+                "movepool": ["earthquake", "firepunch", "rockpolish", "rockslide", "zenheadbutt"]
             },
             {
-                "role": "Bulky Attacker",
-                "movepool": ["crunch", "earthquake", "firepunch", "headsmash", "superpower"]
+                "role": "Fast Attacker",
+                "movepool": ["earthquake", "firepunch", "headsmash", "rockslide"]
             }
         ]
     },
@@ -3034,7 +3040,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "lightscreen", "psychic", "reflect", "stealthrock", "thunderwave", "uturn", "yawn"]
+                "movepool": ["healbell", "psychic", "stealthrock", "thunderwave", "uturn", "yawn"]
             }
         ]
     },
@@ -3676,7 +3682,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["crunch", "earthquake", "pursuit", "stealthrock", "stoneedge"]
+                "movepool": ["crunch", "earthquake", "pursuit", "stealthrock", "stoneedge", "superpower"]
             }
         ]
     },

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -598,7 +598,6 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		if (species.id === 'ninetales') return 'Drought';
 		if (species.id === 'gligar') return 'Immunity';
 		if (species.id === 'arcanine') return 'Intimidate';
-		if (species.id === 'rampardos' && role === 'Bulky Attacker') return 'Mold Breaker';
 		if (species.id === 'altaria') return 'Natural Cure';
 		if (species.id === 'mandibuzz') return 'Overcoat';
 		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it
@@ -698,6 +697,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		if (ability === 'Magic Guard' && role !== 'Bulky Support') {
 			return moves.has('counter') ? 'Focus Sash' : 'Life Orb';
 		}
+		if (species.id === 'rampardos' && role === 'Fast Attacker') return 'Choice Scarf';
 		if (ability === 'Sheer Force' && counter.get('sheerforce')) return 'Life Orb';
 		if (moves.has('acrobatics')) return 'Flying Gem';
 		if (species.id === 'hitmonlee' && ability === 'Unburden') return moves.has('fakeout') ? 'Normal Gem' : 'Fighting Gem';

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -2967,8 +2967,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fakeout", "knockoff", "return", "uturn"],
-                "preferredTypes": ["Dark"]
+                "movepool": ["fakeout", "knockoff", "return", "uturn"]
             }
         ]
     },

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -214,7 +214,11 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["fireblast", "hiddenpowerrock", "nastyplot", "solarbeam", "substitute", "willowisp"],
+                "movepool": ["fireblast", "hiddenpowerrock", "nastyplot", "solarbeam"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["fireblast", "nastyplot", "solarbeam", "substitute", "willowisp"],
                 "preferredTypes": ["Grass"]
             }
         ]
@@ -387,6 +391,10 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["earthquake", "explosion", "rockpolish", "stoneedge", "suckerpunch"]
             }
         ]
     },
@@ -563,6 +571,11 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["highjumpkick", "knockoff", "machpunch", "poisonjab", "rapidspin", "stoneedge"],
+                "preferredTypes": ["Dark"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["bulkup", "closecombat", "knockoff", "poisonjab", "stoneedge"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -846,7 +859,7 @@
         "level": 82,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Support",
                 "movepool": ["bodyslam", "crunch", "curse", "earthquake", "rest", "return", "sleeptalk"]
             },
             {
@@ -943,8 +956,8 @@
         "level": 89,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["aromatherapy", "dragontail", "gigadrain", "leechseed", "lightscreen", "reflect", "synthesis", "toxic"]
+                "role": "Staller",
+                "movepool": ["aromatherapy", "dragontail", "earthquake", "gigadrain", "leechseed", "synthesis", "toxic"]
             }
         ]
     },
@@ -1525,8 +1538,9 @@
                 "movepool": ["aurasphere", "hiddenpowerice", "thunderbolt", "voltswitch"]
             },
             {
-                "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "calmmind", "hiddenpowerice", "substitute", "thunderbolt"]
+                "role": "Bulky Setup",
+                "movepool": ["aurasphere", "calmmind", "hiddenpowerice", "substitute", "thunderbolt"],
+                "preferredTypes": ["Ice"]
             }
         ]
     },
@@ -1731,7 +1745,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["energyball", "focusblast", "hydropump", "icebeam", "scald"]
+                "movepool": ["energyball", "hydropump", "icebeam", "scald"]
             }
         ]
     },
@@ -2771,12 +2785,12 @@
         "level": 90,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["crunch", "earthquake", "firepunch", "rockpolish", "rockslide"]
+                "role": "Setup Sweeper",
+                "movepool": ["earthquake", "firepunch", "rockpolish", "rockslide", "zenheadbutt"]
             },
             {
-                "role": "Bulky Attacker",
-                "movepool": ["crunch", "earthquake", "firepunch", "headsmash", "superpower"]
+                "role": "Fast Attacker",
+                "movepool": ["earthquake", "firepunch", "headsmash", "rockslide"]
             }
         ]
     },
@@ -2953,7 +2967,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fakeout", "knockoff", "quickattack", "return", "suckerpunch", "uturn"],
+                "movepool": ["fakeout", "knockoff", "return", "uturn"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -3967,16 +3981,12 @@
         "level": 90,
         "sets": [
             {
+                "role": "Staller",
+                "movepool": ["dazzlinggleam", "protect", "toxic", "wish"]
+            },
+            {
                 "role": "Bulky Support",
-                "movepool": ["dazzlinggleam", "healbell", "protect", "toxic", "wish"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["dazzlinggleam", "fireblast", "knockoff", "protect", "wish"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["calmmind", "dazzlinggleam", "protect", "wish"]
+                "movepool": ["calmmind", "dazzlinggleam", "fireblast", "protect", "wish"]
             }
         ]
     },
@@ -4091,7 +4101,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "knockoff", "pursuit", "stealthrock", "stoneedge"]
+                "movepool": ["earthquake", "knockoff", "pursuit", "stealthrock", "stoneedge", "superpower"]
             }
         ]
     },
@@ -4372,7 +4382,7 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["acidspray", "flamethrower", "gigadrain", "hiddenpowerice", "knockoff", "superpower", "thunderbolt", "uturn"]
+                "movepool": ["flamethrower", "gigadrain", "hiddenpowerice", "knockoff", "superpower", "thunderbolt", "uturn"]
             }
         ]
     },
@@ -4582,7 +4592,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["closecombat", "ironhead", "stealthrock", "stoneedge", "swordsdance", "voltswitch"],
+                "movepool": ["closecombat", "ironhead", "stealthrock", "stoneedge", "swordsdance"],
                 "preferredTypes": ["Steel"]
             }
         ]
@@ -4882,6 +4892,10 @@
             {
                 "role": "Staller",
                 "movepool": ["moonblast", "protect", "toxic", "wish"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["calmmind", "hiddenpowerground", "moonblast", "synthesis"]
             }
         ]
     },

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -648,7 +648,6 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (species.id === 'lucariomega') return 'Justified';
 		if (species.id === 'gligar') return 'Immunity';
 		if (species.id === 'arcanine') return 'Intimidate';
-		if (species.id === 'rampardos' && role === 'Bulky Attacker') return 'Mold Breaker';
 		if (species.baseSpecies === 'Altaria') return 'Natural Cure';
 		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it
 		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';
@@ -760,6 +759,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (ability === 'Magic Guard' && role !== 'Bulky Support') {
 			return moves.has('counter') ? 'Focus Sash' : 'Life Orb';
 		}
+		if (species.id === 'rampardos' && role === 'Fast Attacker') return 'Choice Scarf';
 		if (ability === 'Sheer Force' && counter.get('sheerforce')) return 'Life Orb';
 		if (ability === 'Unburden') return 'Sitrus Berry';
 		if (moves.has('acrobatics')) return '';

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -208,7 +208,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			[SETUP, HAZARDS],
 			[SETUP, badWithSetup],
 			[PHYSICAL_SETUP, PHYSICAL_SETUP],
-			[SPEED_SETUP, ['quickattack', 'suckerpunch']],
+			[SPEED_SETUP, 'quickattack'],
 			['defog', HAZARDS],
 			[['fakeout', 'uturn'], ['switcheroo', 'trick']],
 			['substitute', PIVOT_MOVES],
@@ -761,7 +761,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		}
 		if (species.id === 'rampardos' && role === 'Fast Attacker') return 'Choice Scarf';
 		if (ability === 'Sheer Force' && counter.get('sheerforce')) return 'Life Orb';
-		if (ability === 'Unburden') return 'Sitrus Berry';
+		if (ability === 'Unburden') return (species.id === 'hitmonlee') ? 'White Herb' : 'Sitrus Berry';
 		if (moves.has('acrobatics')) return '';
 		if (moves.has('lightscreen') && moves.has('reflect')) return 'Light Clay';
 		if (moves.has('rest') && !moves.has('sleeptalk') && !['Hydration', 'Natural Cure', 'Shed Skin'].includes(ability)) {

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -261,7 +261,11 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["fireblast", "hiddenpowerrock", "nastyplot", "solarbeam", "substitute", "willowisp"],
+                "movepool": ["fireblast", "hiddenpowerrock", "nastyplot", "solarbeam"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["fireblast", "nastyplot", "solarbeam", "substitute", "willowisp"],
                 "preferredTypes": ["Grass"]
             }
         ]
@@ -480,6 +484,10 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "suckerpunch", "toxic"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["earthquake", "explosion", "rockpolish", "stoneedge", "suckerpunch"]
             }
         ]
     },
@@ -1000,7 +1008,7 @@
         "level": 84,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Support",
                 "movepool": ["bodyslam", "crunch", "curse", "earthquake", "rest", "return", "sleeptalk"]
             },
             {
@@ -1102,8 +1110,8 @@
         "level": 90,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["aromatherapy", "dragontail", "gigadrain", "leechseed", "lightscreen", "reflect", "synthesis", "toxic"]
+                "role": "Staller",
+                "movepool": ["aromatherapy", "dragontail", "earthquake", "gigadrain", "leechseed", "synthesis", "toxic"]
             }
         ]
     },
@@ -1680,8 +1688,9 @@
                 "movepool": ["aurasphere", "hiddenpowerice", "thunderbolt", "voltswitch"]
             },
             {
-                "role": "Setup Sweeper",
-                "movepool": ["aurasphere", "calmmind", "hiddenpowerice", "substitute", "thunderbolt"]
+                "role": "Bulky Setup",
+                "movepool": ["aurasphere", "calmmind", "hiddenpowerice", "substitute", "thunderbolt"],
+                "preferredTypes": ["Ice"]
             }
         ]
     },
@@ -1887,7 +1896,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["energyball", "focusblast", "hydropump", "icebeam", "scald"]
+                "movepool": ["energyball", "hydropump", "icebeam", "scald"]
             }
         ]
     },
@@ -2974,12 +2983,12 @@
         "level": 89,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["crunch", "earthquake", "firepunch", "rockpolish", "rockslide"]
+                "role": "Setup Sweeper",
+                "movepool": ["earthquake", "firepunch", "rockpolish", "rockslide", "zenheadbutt"]
             },
             {
-                "role": "Bulky Attacker",
-                "movepool": ["crunch", "earthquake", "firepunch", "headsmash", "superpower"]
+                "role": "Fast Attacker",
+                "movepool": ["earthquake", "firepunch", "headsmash", "rockslide"]
             }
         ]
     },
@@ -3152,7 +3161,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fakeout", "knockoff", "quickattack", "return", "stompingtantrum", "suckerpunch", "uturn"],
+                "movepool": ["fakeout", "knockoff", "return", "stompingtantrum", "uturn"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -4215,16 +4224,12 @@
         "level": 92,
         "sets": [
             {
+                "role": "Staller",
+                "movepool": ["dazzlinggleam", "protect", "toxic", "wish"]
+            },
+            {
                 "role": "Bulky Support",
-                "movepool": ["dazzlinggleam", "healbell", "protect", "toxic", "wish"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["dazzlinggleam", "fireblast", "knockoff", "protect", "wish"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["calmmind", "dazzlinggleam", "protect", "wish"]
+                "movepool": ["calmmind", "dazzlinggleam", "fireblast", "protect", "wish"]
             }
         ]
     },
@@ -4348,7 +4353,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "knockoff", "pursuit", "stealthrock", "stoneedge"]
+                "movepool": ["earthquake", "knockoff", "pursuit", "stealthrock", "stoneedge", "superpower"]
             }
         ]
     },
@@ -4635,7 +4640,7 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["acidspray", "flamethrower", "gigadrain", "hiddenpowerice", "knockoff", "superpower", "thunderbolt", "uturn"]
+                "movepool": ["flamethrower", "gigadrain", "hiddenpowerice", "knockoff", "superpower", "thunderbolt", "uturn"]
             }
         ]
     },
@@ -4849,8 +4854,8 @@
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["bugbuzz", "fireblast", "gigadrain", "hurricane", "quiverdance", "roost"],
-                "preferredTypes": ["Bug", "Fire", "Flying"]
+                "movepool": ["bugbuzz", "fireblast", "gigadrain", "quiverdance", "roost"],
+                "preferredTypes": ["Bug", "Fire"]
             }
         ]
     },
@@ -4859,7 +4864,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["closecombat", "ironhead", "stealthrock", "stoneedge", "swordsdance", "voltswitch"],
+                "movepool": ["closecombat", "ironhead", "stealthrock", "stoneedge", "swordsdance"],
                 "preferredTypes": ["Steel"]
             },
             {
@@ -5208,6 +5213,10 @@
             {
                 "role": "Staller",
                 "movepool": ["moonblast", "protect", "toxic", "wish"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["calmmind", "hiddenpowerground", "moonblast", "synthesis"]
             }
         ]
     },

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -6495,11 +6495,11 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulkup", "closecombat", "icepunch", "rocktomb", "shadowsneak", "spectralthief"]
+                "movepool": ["bulkup", "closecombat", "rocktomb", "shadowsneak", "spectralthief"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["bulkup", "closecombat", "icepunch", "rocktomb", "shadowsneak", "spectralthief"]
+                "movepool": ["bulkup", "closecombat", "rocktomb", "shadowsneak", "spectralthief"]
             }
         ]
     },

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -857,7 +857,6 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (species.id === 'arcanine') return 'Intimidate';
 		if (species.id === 'lucariomega') return 'Justified';
 		if (species.id === 'toucannon' && !counter.get('sheerforce') && !counter.get('skilllink')) return 'Keen Eye';
-		if (species.id === 'rampardos' && role === 'Bulky Attacker') return 'Mold Breaker';
 		if (species.baseSpecies === 'Altaria') return 'Natural Cure';
 		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it
 		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';
@@ -1004,6 +1003,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (ability === 'Magic Guard' && role !== 'Bulky Support') {
 			return moves.has('counter') ? 'Focus Sash' : 'Life Orb';
 		}
+		if (species.id === 'rampardos' && role === 'Fast Attacker') return 'Choice Scarf';
 		if (ability === 'Sheer Force' && counter.get('sheerforce')) return 'Life Orb';
 		if (ability === 'Unburden') return moves.has('closecombat') ? 'White Herb' : 'Sitrus Berry';
 		if (moves.has('acrobatics')) return '';

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -324,7 +324,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			[SETUP, HAZARDS],
 			[SETUP, badWithSetup],
 			[PHYSICAL_SETUP, PHYSICAL_SETUP],
-			[SPEED_SETUP, ['quickattack', 'suckerpunch']],
+			[SPEED_SETUP, 'quickattack'],
 			['defog', HAZARDS],
 			[['fakeout', 'uturn'], ['switcheroo', 'trick']],
 			['substitute', PIVOT_MOVES],

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -349,7 +349,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Fire Blast", "Heal Pulse", "Helping Hand", "Psyshock", "Scald", "Slack Off", "Trick Room"],
+                "movepool": ["Fire Blast", "Heal Pulse", "Helping Hand", "Psyshock", "Scald", "Trick Room"],
                 "teraTypes": ["Dark", "Grass"]
             },
             {
@@ -1069,7 +1069,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Chilly Reception", "Fire Blast", "Heal Pulse", "Helping Hand", "Psyshock", "Scald", "Slack Off", "Trick Room"],
+                "movepool": ["Fire Blast", "Heal Pulse", "Helping Hand", "Psyshock", "Scald", "Trick Room"],
                 "teraTypes": ["Dark", "Grass", "Steel"]
             },
             {
@@ -1929,7 +1929,7 @@
         "sets": [
             {
                 "role": "Offensive Protect",
-                "movepool": ["Extreme Speed", "Protect", "Psycho Boost", "Superpower"],
+                "movepool": ["Extreme Speed", "Knock Off", "Protect", "Psycho Boost", "Superpower"],
                 "teraTypes": ["Ghost", "Stellar"]
             }
         ]
@@ -3552,11 +3552,6 @@
     "kyuremblack": {
         "level": 75,
         "sets": [
-            {
-                "role": "Doubles Setup Sweeper",
-                "movepool": ["Dragon Dance", "Fusion Bolt", "Icicle Spear", "Scale Shot"],
-                "teraTypes": ["Electric"]
-            },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Dragon Dance", "Fusion Bolt", "Icicle Spear", "Protect"],

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -368,9 +368,14 @@
         "level": 92,
         "sets": [
             {
+                "role": "Setup Sweeper",
+                "movepool": ["Double-Edge", "Earthquake", "Explosion", "Stone Edge"],
+                "teraTypes": ["Flying", "Grass"]
+            },
+            {
                 "role": "Wallbreaker",
-                "movepool": ["Double-Edge", "Earthquake", "Explosion", "Rock Polish", "Stone Edge"],
-                "teraTypes": ["Ground"]
+                "movepool": ["Double-Edge", "Earthquake", "Explosion", "Stone Edge"],
+                "teraTypes": ["Electric", "Grass", "Ground"]
             }
         ]
     },
@@ -1349,7 +1354,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Brave Bird", "Drill Run", "Ice Shard", "Ice Spinner"],
+                "movepool": ["Brave Bird", "Drill Run", "Ice Shard", "Ice Spinner", "Spikes"],
                 "teraTypes": ["Flying", "Ground", "Ice"]
             },
             {

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -549,7 +549,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Giga Drain", "Psyshock", "Substitute"],
+                "movepool": ["Calm Mind", "Giga Drain", "Psychic", "Psyshock", "Substitute"],
                 "teraTypes": ["Steel"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -399,7 +399,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Fire Blast", "Psyshock", "Shell Side Arm", "Trick Room"],
+                "movepool": ["Fire Blast", "Psychic", "Shell Side Arm", "Trick Room"],
                 "teraTypes": ["Poison", "Psychic"]
             },
             {
@@ -3249,7 +3249,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Earth Power", "Judgment", "Recover", "Will-O-Wisp"],
+                "movepool": ["Earthquake", "Judgment", "Recover", "Will-O-Wisp"],
                 "teraTypes": ["Ghost"]
             },
             {

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -194,7 +194,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Bug Buzz", "Quiver Dance", "Sleep Powder", "Sludge Wave", "Substitute"],
+                "movepool": ["Bug Buzz", "Morning Sun", "Quiver Dance", "Sleep Powder", "Sludge Wave", "Substitute"],
                 "teraTypes": ["Bug", "Poison", "Steel", "Water"]
             }
         ]
@@ -379,7 +379,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Calm Mind", "Psyshock", "Scald", "Slack Off", "Thunder Wave"],
+                "movepool": ["Calm Mind", "Psychic Noise", "Psyshock", "Scald", "Slack Off", "Thunder Wave"],
                 "teraTypes": ["Fairy", "Water"]
             },
             {
@@ -399,7 +399,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Fire Blast", "Psyshock", "Sludge Bomb", "Trick", "Trick Room"],
+                "movepool": ["Fire Blast", "Psyshock", "Shell Side Arm", "Trick Room"],
                 "teraTypes": ["Poison", "Psychic"]
             },
             {
@@ -423,12 +423,12 @@
         "level": 92,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Bulky Attacker",
                 "movepool": ["Encore", "Flip Turn", "Knock Off", "Surf", "Triple Axel"],
                 "teraTypes": ["Dragon", "Grass", "Ground", "Poison", "Steel"]
             },
             {
-                "role": "Wallbreaker",
+                "role": "Bulky Support",
                 "movepool": ["Encore", "Flip Turn", "Hydro Pump", "Ice Beam", "Knock Off", "Surf"],
                 "teraTypes": ["Dragon", "Grass", "Ground", "Poison", "Steel"]
             }
@@ -446,11 +446,6 @@
                 "role": "AV Pivot",
                 "movepool": ["Drain Punch", "Gunk Shot", "Ice Punch", "Knock Off", "Poison Jab", "Shadow Sneak"],
                 "teraTypes": ["Dark"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["Curse", "Drain Punch", "Gunk Shot", "Knock Off", "Poison Jab", "Rest"],
-                "teraTypes": ["Dark"]
             }
         ]
     },
@@ -461,11 +456,6 @@
                 "role": "AV Pivot",
                 "movepool": ["Drain Punch", "Gunk Shot", "Ice Punch", "Knock Off", "Poison Jab", "Shadow Sneak"],
                 "teraTypes": ["Dark"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["Curse", "Drain Punch", "Gunk Shot", "Knock Off", "Poison Jab", "Rest"],
-                "teraTypes": ["Dark", "Fighting"]
             }
         ]
     },
@@ -549,12 +539,17 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Giga Drain", "Leech Seed", "Psychic Noise", "Sleep Powder", "Substitute"],
+                "movepool": ["Leech Seed", "Psychic", "Psychic Noise", "Sleep Powder", "Sludge Bomb", "Substitute"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Leech Seed", "Protect", "Psychic Noise", "Substitute"],
+                "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Giga Drain", "Psyshock", "Substitute"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -663,14 +658,9 @@
         "level": 84,
         "sets": [
             {
-                "role": "Fast Bulky Setup",
-                "movepool": ["Bulk Up", "Raging Bull", "Stone Edge", "Substitute"],
-                "teraTypes": ["Fighting", "Steel"]
-            },
-            {
                 "role": "Wallbreaker",
                 "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Iron Head", "Stone Edge", "Throat Chop"],
-                "teraTypes": ["Fighting"]
+                "teraTypes": ["Dark", "Fighting", "Steel"]
             }
         ]
     },
@@ -755,12 +745,12 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Flip Turn", "Ice Beam", "Protect", "Scald", "Wish"],
-                "teraTypes": ["Ghost", "Ground"]
+                "teraTypes": ["Ghost", "Ground", "Poison", "Steel"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Protect", "Scald", "Wish"],
-                "teraTypes": ["Ghost", "Ground"]
+                "teraTypes": ["Ghost", "Ground", "Poison", "Steel"]
             }
         ]
     },
@@ -989,7 +979,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Calm Mind", "Defog", "Hurricane", "Hyper Voice", "Roost"],
+                "movepool": ["Calm Mind", "Defog", "Hurricane", "Hyper Voice", "Nasty Plot", "Roost"],
                 "teraTypes": ["Ground", "Normal", "Steel"]
             }
         ]
@@ -1256,6 +1246,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Encore", "Play Rough", "Thunder Wave"],
                 "teraTypes": ["Ground"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Earthquake", "Play Rough", "Roar", "Thunder Wave"],
+                "teraTypes": ["Ground"]
             }
         ]
     },
@@ -1493,7 +1488,7 @@
                 "teraTypes": ["Water"]
             },
             {
-                "role": "Fast Attacker",
+                "role": "Bulky Attacker",
                 "movepool": ["Calm Mind", "Scald", "Shadow Ball", "Thunderbolt", "Volt Switch"],
                 "teraTypes": ["Electric", "Water"]
             }
@@ -1539,7 +1534,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Dragon Dance", "Earthquake", "Fire Punch", "Knock Off", "Stone Edge"],
+                "movepool": ["Dragon Dance", "Earthquake", "Ice Punch", "Knock Off", "Stone Edge"],
                 "teraTypes": ["Ghost", "Rock"]
             },
             {
@@ -1565,7 +1560,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Brave Bird", "Earthquake", "Recover", "Sacred Fire"],
-                "teraTypes": ["Ground"]
+                "teraTypes": ["Ground", "Steel"]
             }
         ]
     },
@@ -1848,8 +1843,13 @@
         "level": 88,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Wallbreaker",
                 "movepool": ["Earthquake", "Lava Plume", "Rapid Spin", "Solar Beam", "Stealth Rock", "Yawn"],
+                "teraTypes": ["Grass"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Lava Plume", "Rapid Spin", "Solar Beam", "Stealth Rock", "Yawn"],
                 "teraTypes": ["Dragon", "Grass"]
             }
         ]
@@ -1959,7 +1959,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Aqua Jet", "Crabhammer", "Knock Off", "Swords Dance"],
+                "movepool": ["Aqua Jet", "Crabhammer", "Dragon Dance", "Knock Off", "Swords Dance"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -2000,7 +2000,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Heal Bell", "Knock Off", "Psychic Noise", "Recover", "Thunder Wave"],
-                "teraTypes": ["Dark", "Poison", "Steel"]
+                "teraTypes": ["Dark", "Electric", "Poison", "Steel"]
             },
             {
                 "role": "Bulky Setup",
@@ -2022,11 +2022,6 @@
     "luvdisc": {
         "level": 100,
         "sets": [
-            {
-                "role": "Bulky Support",
-                "movepool": ["Charm", "Flip Turn", "Ice Beam", "Protect", "Surf", "Wish"],
-                "teraTypes": ["Dragon", "Ghost", "Poison"]
-            },
             {
                 "role": "Fast Support",
                 "movepool": ["Endeavor", "Substitute", "Surf", "Whirlpool"],
@@ -2329,8 +2324,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Earthquake", "Head Smash", "Rock Slide", "Zen Headbutt"],
-                "teraTypes": ["Ground", "Psychic", "Rock"]
+                "movepool": ["Earthquake", "Fire Punch", "Head Smash", "Rock Slide"],
+                "teraTypes": ["Ground", "Rock"]
             },
             {
                 "role": "Wallbreaker",
@@ -2419,12 +2414,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Air Slash", "Defog", "Shadow Ball", "Strength Sap", "Will-O-Wisp"],
-                "teraTypes": ["Fairy", "Ghost"]
-            },
-            {
-                "role": "Fast Bulky Setup",
-                "movepool": ["Air Slash", "Calm Mind", "Shadow Ball", "Strength Sap"],
+                "movepool": ["Air Slash", "Calm Mind", "Defog", "Shadow Ball", "Strength Sap"],
                 "teraTypes": ["Fairy", "Ghost"]
             }
         ]
@@ -2434,8 +2424,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Dazzling Gleam", "Energy Ball", "Mystical Fire", "Nasty Plot", "Shadow Ball", "Thunderbolt", "Trick"],
+                "movepool": ["Dazzling Gleam", "Energy Ball", "Mystical Fire", "Shadow Ball", "Thunderbolt", "Trick"],
                 "teraTypes": ["Electric", "Fairy", "Fire", "Ghost"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dazzling Gleam", "Mystical Fire", "Nasty Plot", "Shadow Ball", "Substitute", "Thunderbolt"],
+                "teraTypes": ["Electric", "Fairy"]
             }
         ]
     },
@@ -2465,7 +2460,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Hypnosis", "Iron Head", "Psychic Noise", "Stealth Rock"],
-                "teraTypes": ["Water"]
+                "teraTypes": ["Electric", "Water"]
             },
             {
                 "role": "Bulky Setup",
@@ -2500,7 +2495,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Fire Fang", "Scale Shot", "Stone Edge", "Swords Dance"],
-                "teraTypes": ["Dragon", "Ground"]
+                "teraTypes": ["Dragon", "Fire", "Ground"]
             }
         ]
     },
@@ -2623,8 +2618,8 @@
                 "teraTypes": ["Dark", "Electric", "Ground"]
             },
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Bulk Up", "Earthquake", "Ice Punch", "Supercell Slam"],
+                "role": "Bulky Setup",
+                "movepool": ["Bulk Up", "Earthquake", "Ice Punch", "Wild Charge"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -2689,7 +2684,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Knock Off", "Protect", "Stealth Rock", "Toxic Spikes", "U-turn"],
+                "movepool": ["Earthquake", "Knock Off", "Protect", "Stealth Rock", "Toxic", "Toxic Spikes", "U-turn"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -2840,7 +2835,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Knock Off", "Psychic", "Psychic Noise", "Stealth Rock", "Thunder Wave", "U-turn", "Yawn"],
-                "teraTypes": ["Dark", "Steel"]
+                "teraTypes": ["Dark", "Electric", "Steel"]
             }
         ]
     },
@@ -2855,7 +2850,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Knock Off", "Psychic Noise", "Stealth Rock", "Thunder Wave", "U-turn"],
-                "teraTypes": ["Dark", "Steel"]
+                "teraTypes": ["Dark", "Electric", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
@@ -2893,9 +2888,14 @@
         "level": 73,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Fast Attacker",
                 "movepool": ["Draco Meteor", "Fire Blast", "Flash Cannon", "Stealth Rock", "Thunder Wave"],
-                "teraTypes": ["Dragon", "Fairy", "Fire"]
+                "teraTypes": ["Dragon", "Fire", "Steel"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Draco Meteor", "Fire Blast", "Heavy Slam", "Stealth Rock", "Thunder Wave"],
+                "teraTypes": ["Dragon", "Fire", "Steel"]
             }
         ]
     },
@@ -2931,11 +2931,6 @@
                 "role": "Bulky Support",
                 "movepool": ["Earth Power", "Flash Cannon", "Lava Plume", "Magma Storm", "Stealth Rock"],
                 "teraTypes": ["Flying", "Grass", "Steel"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Earth Power", "Magma Storm", "Protect", "Will-O-Wisp"],
-                "teraTypes": ["Flying", "Grass"]
             }
         ]
     },
@@ -3135,7 +3130,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Cosmic Power", "Recover", "Stored Power"],
-                "teraTypes": ["Psychic", "Steel"]
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -3254,7 +3249,12 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Calm Mind", "Earth Power", "Judgment", "Recover", "Will-O-Wisp"],
+                "movepool": ["Earth Power", "Judgment", "Recover", "Will-O-Wisp"],
+                "teraTypes": ["Ghost"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Earth Power", "Judgment", "Recover"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -3264,7 +3264,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Ice Beam", "Judgment", "Recover", "Taunt", "Will-O-Wisp"],
+                "movepool": ["Calm Mind", "Ice Beam", "Judgment", "Recover", "Will-O-Wisp"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3410,7 +3410,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Alluring Voice", "Petal Dance", "Quiver Dance", "Sleep Powder"],
-                "teraTypes": ["Grass"]
+                "teraTypes": ["Fairy", "Grass"]
             }
         ]
     },
@@ -3579,6 +3579,11 @@
         "sets": [
             {
                 "role": "Bulky Support",
+                "movepool": ["Flip Turn", "Protect", "Scald", "Wish"],
+                "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Fast Support",
                 "movepool": ["Flip Turn", "Protect", "Scald", "Wish"],
                 "teraTypes": ["Steel"]
             }
@@ -3931,6 +3936,11 @@
                 "role": "Fast Attacker",
                 "movepool": ["Draco Meteor", "Earth Power", "Freeze-Dry", "Fusion Flare"],
                 "teraTypes": ["Dragon", "Fire"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Draco Meteor", "Freeze-Dry", "Fusion Flare", "Ice Beam"],
+                "teraTypes": ["Dragon", "Fire"]
             }
         ]
     },
@@ -4056,11 +4066,6 @@
                 "role": "Fast Attacker",
                 "movepool": ["Dark Pulse", "Fire Blast", "Hyper Voice", "Will-O-Wisp", "Work Up"],
                 "teraTypes": ["Fire"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["Fire Blast", "Hyper Voice", "Solar Beam", "Sunny Day"],
-                "teraTypes": ["Fire", "Grass"]
             }
         ]
     },
@@ -4129,7 +4134,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Draco Meteor", "Flip Turn", "Focus Blast", "Hydro Pump", "Sludge Bomb", "Toxic", "Toxic Spikes"],
+                "movepool": ["Draco Meteor", "Flip Turn", "Focus Blast", "Hydro Pump", "Sludge Wave", "Toxic", "Toxic Spikes"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -4510,7 +4515,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Knock Off", "Stealth Rock", "Stone Edge", "Sucker Punch", "Swords Dance"],
-                "teraTypes": ["Fighting", "Rock"]
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -4549,7 +4554,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Hydro Pump", "Leech Life", "Liquidation", "Mirror Coat", "Sticky Web"],
+                "movepool": ["Hydro Pump", "Liquidation", "Lunge", "Mirror Coat", "Sticky Web"],
                 "teraTypes": ["Ground", "Steel", "Water"]
             }
         ]
@@ -5004,7 +5009,7 @@
             },
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Bulk Up", "Crunch", "Rest", "Spirit Break", "Sucker Punch", "Throat Chop", "Thunder Wave"],
+                "movepool": ["Bulk Up", "Rest", "Spirit Break", "Sucker Punch", "Throat Chop", "Thunder Wave"],
                 "teraTypes": ["Dark", "Poison", "Steel"]
             },
             {
@@ -5029,12 +5034,12 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Alluring Voice", "Calm Mind", "Dazzling Gleam", "Psychic", "Psyshock", "Recover"],
+                "movepool": ["Alluring Voice", "Calm Mind", "Psychic", "Psyshock", "Recover"],
                 "teraTypes": ["Poison", "Steel"]
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Alluring Voice", "Calm Mind", "Dazzling Gleam", "Recover", "Tera Blast"],
+                "movepool": ["Alluring Voice", "Calm Mind", "Recover", "Tera Blast"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -5095,7 +5100,7 @@
             {
                 "role": "Tera Blast user",
                 "movepool": ["Belly Drum", "Ice Spinner", "Liquidation", "Substitute", "Tera Blast"],
-                "teraTypes": ["Ground"]
+                "teraTypes": ["Electric", "Ground"]
             }
         ]
     },
@@ -5250,6 +5255,11 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Aqua Jet", "Close Combat", "Ice Spinner", "Surging Strikes", "Swords Dance", "U-turn"],
+                "teraTypes": ["Water"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Close Combat", "Ice Spinner", "Surging Strikes", "Swords Dance"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -5436,11 +5446,6 @@
                 "role": "Bulky Setup",
                 "movepool": ["Agility", "Earth Power", "Moonblast", "Mystical Fire", "Superpower"],
                 "teraTypes": ["Ground"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["Calm Mind", "Draining Kiss", "Earth Power", "Iron Defense"],
-                "teraTypes": ["Fairy", "Ground", "Steel"]
             }
         ]
     },
@@ -5539,13 +5544,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Double Shock", "Ice Punch", "Revival Blessing", "Volt Switch"],
+                "movepool": ["Close Combat", "Double Shock", "Ice Punch", "Knock Off", "Nuzzle", "Revival Blessing"],
                 "teraTypes": ["Electric"]
-            },
-            {
-                "role": "Fast Support",
-                "movepool": ["Close Combat", "Ice Punch", "Knock Off", "Nuzzle", "Revival Blessing", "Thunder Punch"],
-                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -5574,7 +5574,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Dazzling Gleam", "Earth Power", "Energy Ball", "Hyper Voice", "Strength Sap"],
+                "movepool": ["Dazzling Gleam", "Earth Power", "Hyper Voice", "Leaf Storm", "Strength Sap"],
                 "teraTypes": ["Fairy", "Grass", "Ground"]
             },
             {
@@ -5719,12 +5719,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Poltergeist", "Power Whip", "Rapid Spin", "Spikes", "Strength Sap"],
-                "teraTypes": ["Fairy", "Steel", "Water"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["Leech Seed", "Poltergeist", "Power Whip", "Substitute"],
+                "movepool": ["Leech Seed", "Poltergeist", "Power Whip", "Rapid Spin", "Spikes", "Strength Sap", "Substitute"],
                 "teraTypes": ["Fairy", "Steel", "Water"]
             }
         ]
@@ -5781,11 +5776,6 @@
                 "role": "Bulky Support",
                 "movepool": ["Bug Buzz", "Earth Power", "Psychic", "Revival Blessing", "Trick Room"],
                 "teraTypes": ["Steel"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["Bug Buzz", "Calm Mind", "Earth Power", "Psychic", "Psyshock", "Recover"],
-                "teraTypes": ["Ground", "Steel", "Water"]
             }
         ]
     },
@@ -5841,11 +5831,6 @@
                 "role": "Bulky Support",
                 "movepool": ["Brave Bird", "Knock Off", "Roost", "Stealth Rock", "Sucker Punch", "U-turn"],
                 "teraTypes": ["Dark", "Steel"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["Brave Bird", "Hone Claws", "Stone Edge", "Sucker Punch"],
-                "teraTypes": ["Rock"]
             }
         ]
     },
@@ -5875,7 +5860,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Draco Meteor", "Knock Off", "Rapid Spin", "Shed Tail", "Taunt"],
-                "teraTypes": ["Dragon", "Ghost", "Steel"]
+                "teraTypes": ["Dragon", "Fairy", "Ghost", "Steel"]
             }
         ]
     },
@@ -5885,7 +5870,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Coil", "Iron Tail", "Rest"],
-                "teraTypes": ["Electric", "Fighting"]
+                "teraTypes": ["Electric", "Fighting", "Ghost"]
             },
             {
                 "role": "Bulky Support",
@@ -5899,7 +5884,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Earth Power", "Energy Ball", "Mortal Spin", "Power Gem", "Sludge Wave", "Spikes", "Stealth Rock", "Toxic"],
+                "movepool": ["Earth Power", "Mortal Spin", "Power Gem", "Sludge Wave", "Spikes", "Stealth Rock", "Toxic"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -6288,8 +6273,13 @@
         "level": 72,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["Crunch", "Ice Shard", "Icicle Crash", "Sacred Sword", "Sucker Punch", "Swords Dance", "Throat Chop"],
+                "role": "Wallbreaker",
+                "movepool": ["Crunch", "Ice Shard", "Icicle Crash", "Sacred Sword", "Throat Chop"],
+                "teraTypes": ["Dark", "Fighting", "Ice"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Ice Shard", "Icicle Crash", "Sacred Sword", "Sucker Punch", "Swords Dance", "Throat Chop"],
                 "teraTypes": ["Dark", "Fighting", "Ice"]
             }
         ]
@@ -6354,7 +6344,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Dragon Pulse", "Dragon Tail", "Giga Drain", "Infestation", "Recover", "Sucker Punch"],
+                "movepool": ["Dragon Pulse", "Dragon Tail", "Giga Drain", "Recover", "Sucker Punch"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -6498,7 +6488,7 @@
                 "teraTypes": ["Steel"]
             },
             {
-                "role": "Bulky Setup",
+                "role": "Fast Bulky Setup",
                 "movepool": ["Earth Power", "Fickle Beam", "Giga Drain", "Nasty Plot", "Recover"],
                 "teraTypes": ["Steel"]
             },
@@ -6530,7 +6520,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Calm Mind", "Dragon Pulse", "Thunderbolt", "Thunderclap"],
-                "teraTypes": ["Electric"]
+                "teraTypes": ["Electric", "Fairy"]
             }
         ]
     },
@@ -6563,13 +6553,13 @@
         "level": 75,
         "sets": [
             {
-                "role": "Bulky Setup",
+                "role": "Setup Sweeper",
                 "movepool": ["Calm Mind", "Dark Pulse", "Rapid Spin", "Rest", "Tera Starstorm"],
                 "teraTypes": ["Stellar"]
             },
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Calm Mind", "Earth Power", "Rapid Spin", "Rest", "Tera Starstorm"],
+                "role": "Fast Bulky Setup",
+                "movepool": ["Calm Mind", "Earth Power", "Rest", "Rock Polish", "Tera Starstorm"],
                 "teraTypes": ["Stellar"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2413,7 +2413,7 @@
         "level": 86,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Air Slash", "Calm Mind", "Defog", "Shadow Ball", "Strength Sap"],
                 "teraTypes": ["Fairy", "Ghost"]
             }

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1944,7 +1944,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Dragon Dance", "Earthquake", "Stone Edge", "Waterfall"],
+                "movepool": ["Dragon Dance", "Earthquake", "Liquidation", "Stone Edge"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -4401,11 +4401,6 @@
                 "role": "Bulky Support",
                 "movepool": ["Beak Blast", "Boomburst", "Bullet Seed", "Knock Off", "Roost", "U-turn"],
                 "teraTypes": ["Steel"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["Brave Bird", "Bullet Seed", "Flame Charge", "Swords Dance"],
-                "teraTypes": ["Grass", "Steel"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -5865,12 +5865,12 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Coil", "Iron Tail", "Rest"],
-                "teraTypes": ["Electric", "Fighting", "Ghost"]
+                "teraTypes": ["Electric", "Fighting"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Press", "Iron Head", "Rest", "Shed Tail", "Spikes", "Stealth Rock"],
-                "teraTypes": ["Electric", "Poison"]
+                "teraTypes": ["Electric", "Ghost", "Poison"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -4480,7 +4480,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Hurricane", "Quiver Dance", "Revelation Dance", "Roost"],
-                "teraTypes": ["Fighting", "Ghost", "Ground"]
+                "teraTypes": ["Fighting", "Ghost"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -369,7 +369,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Double-Edge", "Earthquake", "Explosion", "Stone Edge"],
+                "movepool": ["Double-Edge", "Earthquake", "Rock Polish", "Stone Edge"],
                 "teraTypes": ["Flying", "Grass"]
             },
             {

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -590,9 +590,6 @@ export class RandomTeams {
 		if (!abilities.has('Prankster')) this.incompatibleMoves(moves, movePool, 'thunderwave', 'yawn');
 
 		// This space reserved for assorted hardcodes that otherwise make little sense out of context
-		if (species.id === 'luvdisc') {
-			this.incompatibleMoves(moves, movePool, ['charm', 'flipturn', 'icebeam'], ['charm', 'flipturn']);
-		}
 		if (species.id === 'cyclizar') this.incompatibleMoves(moves, movePool, 'taunt', 'knockoff');
 		if (species.id === 'mesprit') this.incompatibleMoves(moves, movePool, 'healingwish', 'uturn');
 		if (species.id === 'camerupt') this.incompatibleMoves(moves, movePool, 'roar', 'willowisp');

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1347,9 +1347,7 @@ export class RandomTeams {
 		if (species.id === 'reuniclus' || (ability === 'Sheer Force' && counter.get('sheerforce'))) return 'Life Orb';
 		if (ability === 'Anger Shell') return this.sample(['Rindo Berry', 'Passho Berry', 'Scope Lens', 'Sitrus Berry']);
 		if (moves.has('dragondance') && isDoubles) return 'Clear Amulet';
-		if (
-			counter.get('skilllink') && ability !== 'Skill Link' && species.id !== 'breloom'
-		) return 'Loaded Dice';
+		if (counter.get('skilllink') && ability !== 'Skill Link' && species.id !== 'breloom') return 'Loaded Dice';
 		if (ability === 'Unburden') {
 			return (moves.has('closecombat') || moves.has('leafstorm')) ? 'White Herb' : 'Sitrus Berry';
 		}

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -483,7 +483,7 @@ export class RandomTeams {
 			if (movePool.includes('rapidspin')) this.fastPop(movePool, movePool.indexOf('rapidspin'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
-		if (teamDetails.toxicSpikes && teamDetails.toxicSpikes) {
+		if (teamDetails.toxicSpikes) {
 			if (movePool.includes('toxicspikes')) this.fastPop(movePool, movePool.indexOf('toxicspikes'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
@@ -1488,7 +1488,7 @@ export class RandomTeams {
 		if (counter.get('speedsetup') && role === 'Bulky Setup') return 'Weakness Policy';
 		if (
 			!counter.get('Status') &&
-			(!['Fast Attacker', 'Wallbreaker', 'Tera Blast user'].includes(role))
+			!['Fast Attacker', 'Wallbreaker', 'Tera Blast user'].includes(role)
 		) {
 			return 'Assault Vest';
 		}

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -483,7 +483,7 @@ export class RandomTeams {
 			if (movePool.includes('rapidspin')) this.fastPop(movePool, movePool.indexOf('rapidspin'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
-		if (teamDetails.toxicSpikes && teamDetails.toxicSpikes >= 2) {
+		if (teamDetails.toxicSpikes && teamDetails.toxicSpikes) {
 			if (movePool.includes('toxicspikes')) this.fastPop(movePool, movePool.indexOf('toxicspikes'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
@@ -593,8 +593,9 @@ export class RandomTeams {
 		if (species.id === 'luvdisc') {
 			this.incompatibleMoves(moves, movePool, ['charm', 'flipturn', 'icebeam'], ['charm', 'flipturn']);
 		}
-		if (species.id === "cyclizar") this.incompatibleMoves(moves, movePool, 'taunt', 'knockoff');
+		if (species.id === 'cyclizar') this.incompatibleMoves(moves, movePool, 'taunt', 'knockoff');
 		if (species.id === 'mesprit') this.incompatibleMoves(moves, movePool, 'healingwish', 'uturn');
+		if (species.id === 'camerupt') this.incompatibleMoves(moves, movePool, 'roar', 'willowisp');
 	}
 
 	// Checks for and removes incompatible moves, starting with the first move in movesA.
@@ -1056,7 +1057,7 @@ export class RandomTeams {
 		case 'Lightning Rod':
 			return species.id === 'rhyperior';
 		case 'Mold Breaker':
-			return (['Pickpocket', 'Sharpness', 'Sheer Force', 'Unburden'].some(m => abilities.has(m)));
+			return (['Sharpness', 'Sheer Force', 'Unburden'].some(m => abilities.has(m)));
 		case 'Moxie':
 			return (!counter.get('Physical') || moves.has('stealthrock'));
 		case 'Natural Cure':
@@ -1309,7 +1310,8 @@ export class RandomTeams {
 		if (species.id === 'pikachu') return 'Light Ball';
 		if (species.id === 'regieleki') return 'Magnet';
 		if (species.id === 'smeargle') return 'Focus Sash';
-		if (species.id === 'froslass') return 'Wide Lens';
+		if (species.id === 'froslass' || moves.has('populationbomb')) return 'Wide Lens';
+		if (counter.get('Status') && (species.name === 'Latias' || species.name === 'Latios')) return 'Soul Dew';
 		if (moves.has('clangoroussoul') || (species.id === 'toxtricity' && moves.has('shiftgear'))) return 'Throat Spray';
 		if (
 			(species.baseSpecies === 'Magearna' && role === 'Tera Blast user') ||
@@ -1321,8 +1323,7 @@ export class RandomTeams {
 			(species.id === 'magnezone' && moves.has('bodypress') && !isDoubles)
 		) return 'Choice Scarf';
 		if (species.id === 'rampardos' && (role === 'Fast Attacker' || isDoubles)) return 'Choice Scarf';
-		if (species.id === 'reuniclus') return 'Life Orb';
-		if (species.id === 'luvdisc' && moves.has('substitute')) return 'Heavy-Duty Boots';
+		if (species.id === 'luvdisc' || moves.has('courtchange')) return 'Heavy-Duty Boots';
 		if (moves.has('bellydrum') && moves.has('substitute')) return 'Salac Berry';
 		if (
 			['Cheek Pouch', 'Cud Chew', 'Harvest', 'Ripen'].some(m => ability === m) ||
@@ -1346,12 +1347,11 @@ export class RandomTeams {
 		if ((ability === 'Guts' || moves.has('facade')) && !moves.has('sleeptalk')) {
 			return (types.includes('Fire') || ability === 'Toxic Boost') ? 'Toxic Orb' : 'Flame Orb';
 		}
-		if (ability === 'Sheer Force' && counter.get('sheerforce')) return 'Life Orb';
+		if (species.id === 'reuniclus' || (ability === 'Sheer Force' && counter.get('sheerforce'))) return 'Life Orb';
 		if (ability === 'Anger Shell') return this.sample(['Rindo Berry', 'Passho Berry', 'Scope Lens', 'Sitrus Berry']);
-		if (moves.has('courtchange')) return 'Heavy-Duty Boots';
-		if (moves.has('populationbomb')) return 'Wide Lens';
+		if (moves.has('dragondance') && isDoubles) return 'Clear Amulet';
 		if (
-			moves.has('scaleshot') || (species.id === 'torterra' && !isDoubles) || species.id === 'cinccino'
+			counter.get('skilllink') && ability !== 'Skill Link' && species.id !== 'breloom'
 		) return 'Loaded Dice';
 		if (ability === 'Unburden') {
 			return (moves.has('closecombat') || moves.has('leafstorm')) ? 'White Herb' : 'Sitrus Berry';
@@ -1398,7 +1398,6 @@ export class RandomTeams {
 		if (
 			moves.has('flipturn') && moves.has('protect') && (moves.has('aquajet') || (moves.has('jetpunch')))
 		) return 'Mystic Water';
-		if (moves.has('dragondance')) return 'Clear Amulet';
 		if (moves.has('waterspout')) return 'Choice Scarf';
 		if (counter.get('speedsetup') && role === 'Doubles Bulky Setup') return 'Weakness Policy';
 		if (species.id === 'toxapex') return 'Binding Band';
@@ -1423,7 +1422,6 @@ export class RandomTeams {
 		) {
 			return (scarfReqs) ? 'Choice Scarf' : 'Choice Specs';
 		}
-		if (species.name === 'Latias' || species.name === 'Latios') return 'Soul Dew';
 		if (
 			(role === 'Bulky Protect' && counter.get('setup')) || moves.has('substitute') ||
 			species.id === 'eternatus'
@@ -1493,13 +1491,11 @@ export class RandomTeams {
 		if (counter.get('speedsetup') && role === 'Bulky Setup') return 'Weakness Policy';
 		if (
 			!counter.get('Status') &&
-			(moves.has('rapidspin') || !['Fast Attacker', 'Wallbreaker', 'Tera Blast user'].includes(role))
+			(!['Fast Attacker', 'Wallbreaker', 'Tera Blast user'].includes(role))
 		) {
 			return 'Assault Vest';
 		}
 		if (species.id === 'golem') return (counter.get('speedsetup')) ? 'Weakness Policy' : 'Custap Berry';
-		if (species.id === 'urshifurapidstrike') return 'Punching Glove';
-		if (species.id === 'latias' || species.id === 'latios') return 'Soul Dew';
 		if (species.id === 'palkia') return 'Lustrous Orb';
 		if (moves.has('substitute')) return 'Leftovers';
 		if (moves.has('stickyweb') && species.id !== 'araquanid' && isLead) return 'Focus Sash';
@@ -1919,9 +1915,7 @@ export class RandomTeams {
 			if (set.moves.includes('spikes') || set.moves.includes('ceaselessedge')) {
 				teamDetails.spikes = (teamDetails.spikes || 0) + 1;
 			}
-			if (set.moves.includes('toxicspikes') || set.ability === 'Toxic Debris') {
-				teamDetails.toxicSpikes = (teamDetails.toxicSpikes || 0) + 1;
-			}
+			if (set.moves.includes('toxicspikes') || set.ability === 'Toxic Debris') teamDetails.toxicSpikes = 1;
 			if (set.moves.includes('stealthrock') || set.moves.includes('stoneaxe')) teamDetails.stealthRock = 1;
 			if (set.moves.includes('stickyweb')) teamDetails.stickyWeb = 1;
 			if (set.moves.includes('defog')) teamDetails.defog = 1;

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1308,7 +1308,6 @@ export class RandomTeams {
 		if (species.id === 'regieleki') return 'Magnet';
 		if (species.id === 'smeargle') return 'Focus Sash';
 		if (species.id === 'froslass' || moves.has('populationbomb')) return 'Wide Lens';
-		if (counter.get('Status') && (species.name === 'Latias' || species.name === 'Latios')) return 'Soul Dew';
 		if (moves.has('clangoroussoul') || (species.id === 'toxtricity' && moves.has('shiftgear'))) return 'Throat Spray';
 		if (
 			(species.baseSpecies === 'Magearna' && role === 'Tera Blast user') ||
@@ -1338,6 +1337,7 @@ export class RandomTeams {
 				return (counter.get('Physical') > counter.get('Special')) ? 'Choice Band' : 'Choice Specs';
 			}
 		}
+		if (counter.get('Status') && (species.name === 'Latias' || species.name === 'Latios')) return 'Soul Dew';
 		if (species.id === 'scyther' && !isDoubles) return (isLead && !moves.has('uturn')) ? 'Eviolite' : 'Heavy-Duty Boots';
 		if (species.nfe) return 'Eviolite';
 		if (ability === 'Poison Heal') return 'Toxic Orb';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1518,8 +1518,7 @@ export class RandomTeams {
 			(species.baseStats.hp + species.baseStats.def + species.baseStats.spd) < 258
 		) return 'Focus Sash';
 		if (
-			!['Fast Attacker', 'Wallbreaker', 'Tera Blast user'].includes(role) && ability !== 'Levitate' &&
-			this.dex.getEffectiveness('Ground', species) >= 2
+			!counter.get('setup') && ability !== 'Levitate' && this.dex.getEffectiveness('Ground', species) >= 2
 		) return 'Air Balloon';
 		if (['Bulky Attacker', 'Bulky Support', 'Bulky Setup'].some(m => role === (m))) return 'Leftovers';
 		if (species.id === 'pawmot' && moves.has('nuzzle')) return 'Leppa Berry';


### PR DESCRIPTION
Big update!

**Gen 9 Random Battle:**
-Teams will now have at most one Toxic Spikes user.

New sets, set merges, and set splits:
-Chien-Pao has a set split: Wallbreaker Choice Band with Ice Shard + Sacred Sword + Icicle Crash + Throat Chop/Crunch, and Setup Sweeper with SD + Icicle Crash + Throat Chop + Ice Shard/Sucker Punch/Sacred Sword.
-Exeggutor has a new third set: Bulky Setup, with Calm Mind, Psyshock/Psychic, Giga Drain, and Substitute.
-Mismagius has a set split: Wallbreaker Choice Specs as normal without Nasty Plot, and Setup Sweeper with Tera Electric/Fairy, Nasty Plot + Shadow Ball + Tbolt/Dgleam + Mystical Fire/Substitute/Tbolt/Dgleam. Runs Leftovers with Substitute, and Life Orb otherwise. This decreases the rate of Specs Mismagius.
-Alolan Golem has a set split to give it better Tera Types. Setup Sweeper (Rock Polish LO) will have Tera Grass/Flying, while Wallbreaker (Choice Band) will have Tera Electric/Grass/Ground.
-Alomomola now has a second set of Fast Support that runs Heavy-Duty Boots but is otherwise identical.
-Dialga-Origin now has a second set that's identical aside from having Heavy Slam over Flash Cannon.
-Torkoal now has a set split: Wallbreaker with the same moves as usual, and Bulky Support with all the same moves except Earthquake. Only Bulky Support has Tera Dragon as an option. In effect, this increases the rate of Rapid Spin and deletes Assault Vest Torkoal.
-Granbull now has a second set with Roar over Encore.
-Kyurem-White now has a second set with Ice Beam over Earth Power.
-Earth Power Terapagos: -Rapid Spin, +Rock Polish. Role changed to Fast Bulky Setup to make this work on a technical level. Rock Polish will only generate with Calm Mind + Earth Power + Tera Starstorm and will get Leftovers.
-Setup Sweeper Electivire's role changed to Bulky Setup to give Leftovers; -Supercell Slam, +Wild Charge
-Setup Sweeper Raikou is now Bulky Setup to prevent Life Orb Raikou.
-Urshifu-Rapid-Strike is no longer hardcoded to have Punching Glove with Swords Dance. Now, it has two sets: one can get choice items and Life Orb, and the other can get Leftovers and is only SD + Ice Spinner + STABs. Aqua Jet and choice items are now half as common as before on it as a result.
-Arceus-Steel now has a set split between Calm Mind and Will-O-Wisp. It can no longer get both at once and will always have a ground move. Will-O-Wisp has Earthquake.
-Drifblim's sets have been merged for simplicity. Drifblim will no longer get Will-O-Wisp ever, and will instead always be Calm Mind if you have a hazard remover on the team already.
-Brambleghast's sets have been merged for simplicity. This has no functional change aside from slightly changing the chances to get SubSeed (I haven't done the math)
-Pawmot's sets have been merged. It now always runs Double Shock Tera Electric and no longer runs Volt Switch, Thunder Punch, or Focus Sash. All other moves and items still exist as normal.
-Iron Defense 3 attacks Probopass now runs Leftovers instead of Air Balloon.

Reversions of previous updates due to winrates: (written as: these changes are what are happening now)
-Tinkaton now has Mold Breaker again.
-Hydrapple can now run Life Orb 3 attacks Nasty Plot again (role changed back to Fast Bulky Setup)
-Slowbro's Bulky Support set now has Psychic Noise again.
-Dialga-Origin: -Tera Fairy, +Tera Steel (also in place for the new set)
-Tera Electric readded to Uxie, Bulky Support Mesprit, Bulky Support Bronzong, and Bulky Support Chimecho.
-Curse Muk and Curse Alolan Muk no longer exist.
-Dewgong now runs Assault Vest again sometimes.
-Rabsca no longer runs Calm Mind and now always runs Revival Blessing again.
-Toucannon no longer runs Swords Dance + Flame Charge.
-Pyroar no longer runs SunnyBeam.
-Heatran no longer runs its Leftovers Protect set.
-Bombirdier once again no longer runs Hone Claws.
-Choice Scarf Rampardos: -Tera Psychic, -Zen Headbutt, +Fire Punch
-Lycanroc-Midnight: -Tera rock
-Alcremie: -Dazzling Gleam
-Dipplin: -Infestation
-Grimmsnarl: -Crunch
-Oricorio-Sensu: -Tera Ground
-DD Whiscash: -Waterfall, +Liquidation
-Exeggutor: -Giga Drain, +Sludge Bomb, +Psychic
-Camerupt will now always get Stealth Rock again, but still has Will-O-Wisp and Fire Blast in its movepool over Lava Plume. Camerupt will still not generate as a second Stealth Rock setter.


Other removals:
-Choice Specs Galarian Slowbro no longer exists. (Wallbreaker: -Trick, -Sludge Bomb, +Shell Side Arm, -Psyshock, +Psychic)
-Draining Kiss CM Iron Defense Enamorus-Therian no longer exists.
-Cud Chew SubBU Tauros-Paldea-Combat no longer exists.
-WishTect Luvdisc no longer exists.
-Choice Scarf and Choice Specs Glimmora no longer exist (-Energy Ball)

Move and Tera Type changes:
-Hazards Gliscor: +Toxic
-Hustle Delibird: +Spikes
-Seed Sower Arboliva: -Energy Ball, +Leaf Storm
-Setup Sweeper (Aqua Jet) Crawdaunt: +Dragon Dance (as a roll with Swords Dance)
-Arceus-Water: -Taunt, +Calm Mind
-DD Tyranitar: -Fire Punch, +Ice Punch
-Dragalge: -Sludge Bomb, +Sludge Wave
-Araquanid: -Leech Life, +Lunge
-Noctowl: +Nasty Plot
-Arceus-Fighting: -Tera Psychic
-Venomoth: +Morning Sun
-Wallbreaker Tauros-Combat: +Tera Dark, +Tera Steel
-Cyclizar: +Tera Fairy
-Calm Mind Raging Bolt: +Tera Fairy
-non-Tera Blast Lilligant: +Tera Fairy
-Tera Blast Eiscue: +Tera Electric (as a roll with Ground)
-Ho-Oh: +Tera Steel
-Setup Sweeper Garchomp: +Tera Fire
-Vaporeon: +Tera Steel, +Tera Poison
-Orthworm: +Tera Ghost

Technical:
-Several pieces of item code were combined when reasonable and sanitized.
-Hardcodes removed for Urshifu and Luvdisc.
-Loaded Dice code was refactored to use multi-hit moves in general and not just Scale Shot to determine the item, to decrease the number of necessary Loaded Dice hardcodes.
-Doubles Clear Amulet code moved up in the priority list to better work with the new Loaded Dice code.
-Air Balloon code simplified significantly; no longer uses roles, and instead just exempts any setup move users from having Air Balloon.
-Revavroom's role changed to Setup Sweeper to be more face-value accurate given the above Air Balloon exemptions no longer require it to be Fast Attacker. No functional difference.

**Gen 9 Random Doubles:**
-Tinkaton is now Mold Breaker again.
-Slowking: -Slack Off, -Chilly Reception
-Slowbro: -Slack Off
-Deoxys-Attack: +Knock Off
-Scale Shot Loaded Dice Kyurem-Black no longer exists.

**Old Gens**
-In Gens 4-7, Rampardos now runs a Choice Scarf Fast Attacker set with two rock moves (Sheer Force with Fire Punch and Rock Slide in 5-7, Mold Breaker with Superpower and Stone Edge in 4), and a Setup Sweeper set with Rock Polish, Zen Headbutt, and no Crunch.
-In gens 4-7, Raikou no longer runs Life Orb on Calm Mind + 3 attacks sets, and Raikou also now always gets Hidden Power Ice.
-In gens 4-7, Meganium no longer runs dual screens, can now roll Earthquake, and always has Toxic.
-In gens 4-7, Ludicolo no longer runs Focus Blast.
-In gens 5-7, Ninetales now gets Leftovers when it only has two attacks.
-In gens 5-7, Krookodile now gets Choice Scarf and Superpower again.
-In gens 6-7, Cobalion no longer runs Volt Switch or Assault Vest.
-In gens 6-7, Snorlax can now sometimes run Curse + RestTalk.
-In gens 6-7, Purugly no longer runs Quick Attack or Sucker Punch.
-In gens 6-7, Eelektross no longer runs Acid Spray.
-In gens 6-7, Golem now has a second set of Rock Polish + Weakness Policy.
-In gens 4-5, Girafarig no longer runs HP Fire.
-In gens 4-5, Uxie no longer runs dual screens.
-In gen 7, Z-Move user Volcarona no longer runs Hurricane or Flyinium Z.
-In gen 7, Marshadow no longer runs Ice Punch. Choice Band sets now always have Shadow Sneak.
-In gen 6, Hitmonlee now runs a Bulk Up Unburden White Herb Close Combat set.
-In gen 5, Crawdaunt no longer runs Substitute
-In gen 4, Dewgong no longer runs Encore on its Hydration set.
-In gen 4, Cresselia no longer runs dual screens.
-In gen 4, Floatzel no longer runs Baton Pass.
-In gen 4, Magnezone now runs Toxic + Protect + HP Ice instead of Substitute + Magnet Rise + HP Fighting/Fire.
-In gen 3, Umbreon no longer runs its Mean Look set.
-In gen 3, Shuckle now runs Leftovers.
-In gen 3, Beautifly now always runs Psychic + HP Fire + Morning Sun + Toxic