### PR TITLE
Eating a berry after residual triggers Cud Chew

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -724,9 +724,6 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				pokemon.volatiles['cudchew'].berry = item;
 			}
 		},
-		onEnd(pokemon) {
-			delete pokemon.volatiles['cudchew'];
-		},
 		condition: {
 			noCopy: true,
 			duration: 2,
@@ -735,7 +732,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			},
 			onResidualOrder: 28,
 			onResidualSubOrder: 2,
-			onEnd(pokemon) {
+			onResidual(pokemon) {
 				if (pokemon.hp) {
 					const item = this.effectState.berry;
 					this.add('-activate', pokemon, 'ability: Cud Chew');
@@ -744,6 +741,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 						this.runEvent('EatItem', pokemon, null, null, item);
 					}
 					if (item.onEat) pokemon.ateBerry = true;
+					delete pokemon.volatiles['cudchew'];
 				}
 			},
 		},

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -2853,6 +2853,10 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 					delete target.volatiles['slowstart'];
 					this.add('-end', target, 'Slow Start', '[silent]');
 				}
+				if (target.volatiles['cudchew']) {
+					delete target.volatiles['cudchew'];
+					this.add('-end', target, 'Cud Chew', '[silent]');
+				}
 				if (strongWeathers.includes(target.getAbility().id)) {
 					this.singleEvent('End', this.dex.abilities.get(target.getAbility().id), target.abilityState, target, pokemon, 'neutralizinggas');
 				}

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -724,6 +724,9 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				pokemon.volatiles['cudchew'].berry = item;
 			}
 		},
+		onEnd(pokemon) {
+			delete pokemon.volatiles['cudchew'];
+		},
 		condition: {
 			noCopy: true,
 			duration: 2,

--- a/test/sim/abilities/cudchew.js
+++ b/test/sim/abilities/cudchew.js
@@ -12,13 +12,13 @@ describe('Cud Chew', function () {
 		battle = common.createBattle([[
 			{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', moves: ['sleeptalk']},
 		], [
-			{species: 'Ekans', moves: ['toxic']},
+			{species: 'Wynaut', ability: 'noguard', moves: ['toxic']},
 		]]);
-		battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'move toxic');
+		battle.makeChoices();
+      battle.makeChoices();
+      battle.makeChoices();
+      battle.makeChoices();
+      battle.makeChoices();
 		const tauros = battle.p1.active[0];
 		assert.notEqual(tauros.hp, 93, `Cud Chew should cause Sitrus Berry to restore HP twice if the activation was due to residual damage.`);
 	});
@@ -26,42 +26,33 @@ describe('Cud Chew', function () {
 	// need confirmation
 	it(`should not eat berry a second time if Neutralizing Gas is active`, function () {
 		battle = common.createBattle([
-			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', moves: ['sleeptalk']}],
-			[{species: 'Weezing-Galar', ability: 'neutralizinggas', moves: ['toxic']}, {species: 'Ekans', moves: ['sleeptalk']}],
+			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', evs: {hp: 4}, moves: ['bellydrum']}],
+			[{species: 'Weezing-Galar', ability: 'neutralizinggas', moves: ['toxic']}, {species: 'Wynaut', moves: ['sleeptalk']}],
 		]);
-		battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'switch 2');
+		battle.makeChoices();
+      battle.makeChoices('move bellydrum', 'switch 2');
 		const tauros = battle.p1.active[0];
       assert.equal(tauros.hp, 93, `Cud Chew should not cause Sitrus Berry to restore HP twice if Neutralizing Gas is active when eaten the first time.`);
 	});
 
 	it(`should not eat berry a second time if Neutralizing Gas becomes active`, function () {
 		battle = common.createBattle([
-			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', moves: ['sleeptalk']}],
-			[{species: 'Ekans', moves: ['toxic']},  {species: 'Weezing-Galar', ability: 'neutralizinggas', moves: ['sleeptalk']}],
+			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', evs: {hp: 4}, moves: ['bellydrum']}],
+			[{species: 'Wynaut', ability: 'noguard', moves: ['toxic']},  {species: 'Weezing-Galar', ability: 'neutralizinggas', moves: ['sleeptalk']}],
 		]);
-		battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'switch 2');
+		battle.makeChoices();
+      battle.makeChoices('move bellydrum', 'switch 2');
 		const tauros = battle.p1.active[0];
       assert.equal(tauros.hp, 93, `Cud Chew should not cause Sitrus Berry to restore HP twice if Neutralizing Gas becomes active on the second turn.`);
 	});
 
 	it.skip(`should not eat berry a second time if Unnerve becomes active`, function () {
 		battle = common.createBattle([
-			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', moves: ['sleeptalk']}],
-			[{species: 'Ekans', moves: ['toxic']},  {species: 'Tyranitar', ability: 'unnerve', moves: ['sleeptalk']}],
+			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', evs: {hp: 4}, moves: ['bellydrum']}],
+			[{species: 'Wynaut', abiltiy: 'noguard', moves: ['toxic']},  {species: 'Tyranitar', ability: 'unnerve', moves: ['sleeptalk']}],
 		]);
-		battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'switch 2');
+		battle.makeChoices();
+      battle.makeChoices('move bellydrum', 'switch 2');
 		const tauros = battle.p1.active[0];
       assert.equal(tauros.hp, 93, `Cud Chew should not cause Sitrus Berry to restore HP twice if Unnerve becomes active on the second turn.`);
 	});
@@ -69,13 +60,10 @@ describe('Cud Chew', function () {
 	it(`should not eat berry a second time if Cud Chew ability is lost or suppressed`, function () {
 		battle = common.createBattle([
 			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', moves: ['sleeptalk']}],
-			[{species: 'Ekans', moves: ['toxic', 'worryseed']}],
+			[{species: 'Wynaut', ability: 'noguard', moves: ['toxic', 'worryseed']}],
 		]);
-		battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'move toxic');
-      battle.makeChoices('move sleeptalk', 'move worryseed');
+		battle.makeChoices();
+      battle.makeChoices('move bellydrum', 'move worryseed');
 		const tauros = battle.p1.active[0];
       assert.equal(tauros.hp, 93, `Cud Chew should not cause Sitrus Berry to restore HP twice if Cud Chew is lost or suppressed.`);
 	});

--- a/test/sim/abilities/cudchew.js
+++ b/test/sim/abilities/cudchew.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const assert = require('../../assert');
+const common = require('../../common');
+
+let battle;
+
+describe('Cud Chew', function () {
+	afterEach(() => battle.destroy());
+
+	it(`should eat berry a second time when taking residual damage`, function () {
+		battle = common.createBattle([
+			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', moves: ['sleeptalk']}],
+			[{species: 'Ekans', moves: ['toxic']},  {species: 'Weezing-Galar', ability: 'neutralizinggas', moves: ['sleeptalk']}],
+		]);
+		battle.makeChoices('move sleeptalk', 'move toxic');
+        battle.makeChoices('move sleeptalk', 'move toxic');
+        battle.makeChoices('move sleeptalk', 'move toxic');
+        battle.makeChoices('move sleeptalk', 'move toxic');
+        battle.makeChoices('move sleeptalk', 'move toxic');
+		const tauros = battle.p1.active[0];
+		assert.notEqual(tauros.hp, 93, `Cud Chew should cause Sitrus Berry to restore HP twice if the activation was due to residual damage.`);
+	});
+
+	it(`should not eat berry a second time if Neutralizing Gas becomes active`, function () {
+		battle = common.createBattle([
+			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', moves: ['sleeptalk']}],
+			[{species: 'Ekans', moves: ['toxic']},  {species: 'Weezing-Galar', ability: 'neutralizinggas', moves: ['sleeptalk']}],
+		]);
+		battle.makeChoices('move sleeptalk', 'move toxic');
+        battle.makeChoices('move sleeptalk', 'move toxic');
+        battle.makeChoices('move sleeptalk', 'move toxic');
+        battle.makeChoices('move sleeptalk', 'move toxic');
+        battle.makeChoices('move sleeptalk', 'switch 2');
+		const tauros = battle.p1.active[0];
+        assert.equal(tauros.hp, 93, `Cud Chew should not cause Sitrus Berry to restore HP twice if Neutralizing Gas becomes active on the second turn.`);
+	});
+
+});

--- a/test/sim/abilities/cudchew.js
+++ b/test/sim/abilities/cudchew.js
@@ -23,15 +23,15 @@ describe('Cud Chew', function () {
 	});
 
 	// need confirmation
-	it.skip(`should not eat berry a second time if Neutralizing Gas is active`, function () {
+	it(`should not eat berry a second time if Neutralizing Gas is active`, function () {
 		battle = common.createBattle([
 			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', moves: ['sleeptalk']}],
 			[{species: 'Weezing-Galar', ability: 'neutralizinggas', moves: ['toxic']}, {species: 'Ekans', moves: ['sleeptalk']}],
 		]);
 		battle.makeChoices('move sleeptalk', 'move toxic');
-        battle.makeChoices('move sleeptalk', 'move toxic');
-        battle.makeChoices('move sleeptalk', 'move toxic');
-        battle.makeChoices('move sleeptalk', 'move toxic');
+      battle.makeChoices('move sleeptalk', 'move toxic');
+      battle.makeChoices('move sleeptalk', 'move toxic');
+      battle.makeChoices('move sleeptalk', 'move toxic');
       battle.makeChoices('move sleeptalk', 'switch 2');
 		const tauros = battle.p1.active[0];
       assert.equal(tauros.hp, 93, `Cud Chew should not cause Sitrus Berry to restore HP twice if Neutralizing Gas is active when eaten the first time.`);
@@ -51,7 +51,7 @@ describe('Cud Chew', function () {
       assert.equal(tauros.hp, 93, `Cud Chew should not cause Sitrus Berry to restore HP twice if Neutralizing Gas becomes active on the second turn.`);
 	});
 
-	it(`should not eat berry a second time if Unnerve becomes active`, function () {
+	it.skip(`should not eat berry a second time if Unnerve becomes active`, function () {
 		battle = common.createBattle([
 			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', moves: ['sleeptalk']}],
 			[{species: 'Ekans', moves: ['toxic']},  {species: 'Tyranitar', ability: 'unnerve', moves: ['sleeptalk']}],

--- a/test/sim/abilities/cudchew.js
+++ b/test/sim/abilities/cudchew.js
@@ -22,6 +22,21 @@ describe('Cud Chew', function () {
 		assert.notEqual(tauros.hp, 93, `Cud Chew should cause Sitrus Berry to restore HP twice if the activation was due to residual damage.`);
 	});
 
+	// need confirmation
+	it.skip(`should not eat berry a second time if Neutralizing Gas is active`, function () {
+		battle = common.createBattle([
+			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', moves: ['sleeptalk']}],
+			[{species: 'Weezing-Galar', ability: 'neutralizinggas', moves: ['toxic']}, {species: 'Ekans', moves: ['sleeptalk']}],
+		]);
+		battle.makeChoices('move sleeptalk', 'move toxic');
+        battle.makeChoices('move sleeptalk', 'move toxic');
+        battle.makeChoices('move sleeptalk', 'move toxic');
+        battle.makeChoices('move sleeptalk', 'move toxic');
+      battle.makeChoices('move sleeptalk', 'switch 2');
+		const tauros = battle.p1.active[0];
+      assert.equal(tauros.hp, 93, `Cud Chew should not cause Sitrus Berry to restore HP twice if Neutralizing Gas is active when eaten the first time.`);
+	});
+
 	it(`should not eat berry a second time if Neutralizing Gas becomes active`, function () {
 		battle = common.createBattle([
 			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', moves: ['sleeptalk']}],
@@ -34,6 +49,34 @@ describe('Cud Chew', function () {
       battle.makeChoices('move sleeptalk', 'switch 2');
 		const tauros = battle.p1.active[0];
       assert.equal(tauros.hp, 93, `Cud Chew should not cause Sitrus Berry to restore HP twice if Neutralizing Gas becomes active on the second turn.`);
+	});
+
+	it(`should not eat berry a second time if Unnerve becomes active`, function () {
+		battle = common.createBattle([
+			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', moves: ['sleeptalk']}],
+			[{species: 'Ekans', moves: ['toxic']},  {species: 'Tyranitar', ability: 'unnerve', moves: ['sleeptalk']}],
+		]);
+		battle.makeChoices('move sleeptalk', 'move toxic');
+      battle.makeChoices('move sleeptalk', 'move toxic');
+      battle.makeChoices('move sleeptalk', 'move toxic');
+      battle.makeChoices('move sleeptalk', 'move toxic');
+      battle.makeChoices('move sleeptalk', 'switch 2');
+		const tauros = battle.p1.active[0];
+      assert.equal(tauros.hp, 93, `Cud Chew should not cause Sitrus Berry to restore HP twice if Unnerve becomes active on the second turn.`);
+	});
+
+	it(`should not eat berry a second time if Cud Chew ability is lost or suppressed`, function () {
+		battle = common.createBattle([
+			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', moves: ['sleeptalk']}],
+			[{species: 'Ekans', moves: ['toxic', 'worryseed']}],
+		]);
+		battle.makeChoices('move sleeptalk', 'move toxic');
+      battle.makeChoices('move sleeptalk', 'move toxic');
+      battle.makeChoices('move sleeptalk', 'move toxic');
+      battle.makeChoices('move sleeptalk', 'move toxic');
+      battle.makeChoices('move sleeptalk', 'move worryseed');
+		const tauros = battle.p1.active[0];
+      assert.equal(tauros.hp, 93, `Cud Chew should not cause Sitrus Berry to restore HP twice if Cud Chew is lost or suppressed.`);
 	});
 
 });

--- a/test/sim/abilities/cudchew.js
+++ b/test/sim/abilities/cudchew.js
@@ -9,10 +9,11 @@ describe('Cud Chew', function () {
 	afterEach(() => battle.destroy());
 
 	it(`should eat berry a second time when taking residual damage`, function () {
-		battle = common.createBattle([
-			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', moves: ['sleeptalk']}],
-			[{species: 'Ekans', moves: ['toxic']},  {species: 'Weezing-Galar', ability: 'neutralizinggas', moves: ['sleeptalk']}],
-		]);
+		battle = common.createBattle([[
+			{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', moves: ['sleeptalk']},
+		], [
+			{species: 'Ekans', moves: ['toxic']},
+		]]);
 		battle.makeChoices('move sleeptalk', 'move toxic');
       battle.makeChoices('move sleeptalk', 'move toxic');
       battle.makeChoices('move sleeptalk', 'move toxic');

--- a/test/sim/abilities/cudchew.js
+++ b/test/sim/abilities/cudchew.js
@@ -14,36 +14,41 @@ describe('Cud Chew', function () {
 		], [
 			{species: 'Wynaut', ability: 'noguard', moves: ['toxic']},
 		]]);
+      const tauros = battle.p1.active[0];
 		battle.makeChoices();
       battle.makeChoices();
       battle.makeChoices();
       battle.makeChoices();
+      assert.false.holdsItem(tauros);
       battle.makeChoices();
-		const tauros = battle.p1.active[0];
-		assert.notEqual(tauros.hp, 93, `Cud Chew should cause Sitrus Berry to restore HP twice if the activation was due to residual damage.`);
+		assert.equal(tauros.hp, 165);
 	});
 
 	// need confirmation
 	it(`should not eat berry a second time if Neutralizing Gas is active`, function () {
 		battle = common.createBattle([
 			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', evs: {hp: 4}, moves: ['bellydrum']}],
-			[{species: 'Weezing-Galar', ability: 'neutralizinggas', moves: ['toxic']}, {species: 'Wynaut', moves: ['sleeptalk']}],
+			[{species: 'Weezing-Galar', ability: 'neutralizinggas', moves: ['sleeptalk']}, {species: 'Wynaut', moves: ['sleeptalk']}],
 		]);
+      const tauros = battle.p1.active[0];
 		battle.makeChoices();
+      assert.false.holdsItem(tauros);
+      const taurosVolatiles = battle.p1.active[0].volatiles;
+      assert.false('cudchew' in taurosVolatiles);
       battle.makeChoices('move bellydrum', 'switch 2');
-		const tauros = battle.p1.active[0];
-      assert.equal(tauros.hp, 93, `Cud Chew should not cause Sitrus Berry to restore HP twice if Neutralizing Gas is active when eaten the first time.`);
+      assert.equal(tauros.hp, 219, `Cud Chew should not cause Sitrus Berry to restore HP twice if Neutralizing Gas is active when eaten the first time.`);
 	});
 
 	it(`should not eat berry a second time if Neutralizing Gas becomes active`, function () {
 		battle = common.createBattle([
 			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', evs: {hp: 4}, moves: ['bellydrum']}],
-			[{species: 'Wynaut', ability: 'noguard', moves: ['toxic']},  {species: 'Weezing-Galar', ability: 'neutralizinggas', moves: ['sleeptalk']}],
+			[{species: 'Wynaut', ability: 'noguard', moves: ['sleeptalk']},  {species: 'Weezing-Galar', ability: 'neutralizinggas', moves: ['sleeptalk']}],
 		]);
+      const tauros = battle.p1.active[0];
 		battle.makeChoices();
+      assert.false.holdsItem(tauros);
       battle.makeChoices('move bellydrum', 'switch 2');
-		const tauros = battle.p1.active[0];
-      assert.equal(tauros.hp, 93, `Cud Chew should not cause Sitrus Berry to restore HP twice if Neutralizing Gas becomes active on the second turn.`);
+      assert.equal(tauros.hp, 292, `Cud Chew should not cause Sitrus Berry to restore HP twice if Neutralizing Gas becomes active on the second turn.`);
 	});
 
 	it.skip(`should not eat berry a second time if Unnerve becomes active`, function () {
@@ -51,21 +56,23 @@ describe('Cud Chew', function () {
 			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', evs: {hp: 4}, moves: ['bellydrum']}],
 			[{species: 'Wynaut', abiltiy: 'noguard', moves: ['toxic']},  {species: 'Tyranitar', ability: 'unnerve', moves: ['sleeptalk']}],
 		]);
+      const tauros = battle.p1.active[0];
 		battle.makeChoices();
-      battle.makeChoices('move bellydrum', 'switch 2');
-		const tauros = battle.p1.active[0];
+      assert.false.holdsItem(tauros);
+      battle.makeChoices('move bellydrum', 'switch 2')
       assert.equal(tauros.hp, 93, `Cud Chew should not cause Sitrus Berry to restore HP twice if Unnerve becomes active on the second turn.`);
 	});
 
 	it(`should not eat berry a second time if Cud Chew ability is lost or suppressed`, function () {
 		battle = common.createBattle([
-			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', moves: ['sleeptalk']}],
+			[{species: 'Tauros-Paldea-Combat', ability: 'cudchew', item: 'sitrusberry', evs: {hp: 4}, moves: ['bellydrum']}],
 			[{species: 'Wynaut', ability: 'noguard', moves: ['toxic', 'worryseed']}],
 		]);
+      const tauros = battle.p1.active[0];
 		battle.makeChoices();
+      assert.false.holdsItem(tauros);
       battle.makeChoices('move bellydrum', 'move worryseed');
-		const tauros = battle.p1.active[0];
-      assert.equal(tauros.hp, 93, `Cud Chew should not cause Sitrus Berry to restore HP twice if Cud Chew is lost or suppressed.`);
+      assert.equal(tauros.hp, 238, `Cud Chew should not cause Sitrus Berry to restore HP twice if Cud Chew is lost or suppressed.`);
 	});
 
 });

--- a/test/sim/abilities/cudchew.js
+++ b/test/sim/abilities/cudchew.js
@@ -14,10 +14,10 @@ describe('Cud Chew', function () {
 			[{species: 'Ekans', moves: ['toxic']},  {species: 'Weezing-Galar', ability: 'neutralizinggas', moves: ['sleeptalk']}],
 		]);
 		battle.makeChoices('move sleeptalk', 'move toxic');
-        battle.makeChoices('move sleeptalk', 'move toxic');
-        battle.makeChoices('move sleeptalk', 'move toxic');
-        battle.makeChoices('move sleeptalk', 'move toxic');
-        battle.makeChoices('move sleeptalk', 'move toxic');
+      battle.makeChoices('move sleeptalk', 'move toxic');
+      battle.makeChoices('move sleeptalk', 'move toxic');
+      battle.makeChoices('move sleeptalk', 'move toxic');
+      battle.makeChoices('move sleeptalk', 'move toxic');
 		const tauros = battle.p1.active[0];
 		assert.notEqual(tauros.hp, 93, `Cud Chew should cause Sitrus Berry to restore HP twice if the activation was due to residual damage.`);
 	});
@@ -28,12 +28,12 @@ describe('Cud Chew', function () {
 			[{species: 'Ekans', moves: ['toxic']},  {species: 'Weezing-Galar', ability: 'neutralizinggas', moves: ['sleeptalk']}],
 		]);
 		battle.makeChoices('move sleeptalk', 'move toxic');
-        battle.makeChoices('move sleeptalk', 'move toxic');
-        battle.makeChoices('move sleeptalk', 'move toxic');
-        battle.makeChoices('move sleeptalk', 'move toxic');
-        battle.makeChoices('move sleeptalk', 'switch 2');
+      battle.makeChoices('move sleeptalk', 'move toxic');
+      battle.makeChoices('move sleeptalk', 'move toxic');
+      battle.makeChoices('move sleeptalk', 'move toxic');
+      battle.makeChoices('move sleeptalk', 'switch 2');
 		const tauros = battle.p1.active[0];
-        assert.equal(tauros.hp, 93, `Cud Chew should not cause Sitrus Berry to restore HP twice if Neutralizing Gas becomes active on the second turn.`);
+      assert.equal(tauros.hp, 93, `Cud Chew should not cause Sitrus Berry to restore HP twice if Neutralizing Gas becomes active on the second turn.`);
 	});
 
 });


### PR DESCRIPTION
Cud Chew is currently set to trigger (including removing the activation flag) during the "onEnd" event, occurring prior to the "onResidual" flag (and thus, not queuing up the eaten berry if the berry's trigger is HP loss from a residual effect such as Toxic).

Moving the effect from onEnd to onResidual, and including the volatile flag removal there instead, allows Cud Chew to work as intended.

Fixes https://www.smogon.com/forums/threads/bug-report-mechanics.3736886/