### PR TITLE
Fix help text in approvallog

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2623,7 +2623,7 @@ export const commands: Chat.ChatCommands = {
 		room = this.requireRoom();
 		return this.parse(`/sl approved showing media from, ${room.roomid}`);
 	},
-	approvalloghelp: [`/approvallog - View a log of past media approvals in the current room. Requires: % @ # &`],
+	approvalloghelp: [`/approvallog - View a log of past media approvals in the current room. Requires: &`],
 
 	viewapprovals(target, room, user) {
 		room = this.requireRoom();


### PR DESCRIPTION
Changed requires % @ # & > &

https://www.smogon.com/forums/threads/wrong-help-text-in-approvallog.3736518/