### PR TITLE
Randomized format updates

### DIFF
--- a/data/mods/gen3/random-sets.json
+++ b/data/mods/gen3/random-sets.json
@@ -105,8 +105,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["batonpass", "doubleedge", "drillpeck", "hiddenpowerground", "quickattack", "return"],
-                "preferredTypes": ["Ground"]
+                "movepool": ["doubleedge", "drillpeck", "hiddenpowerground", "quickattack", "return"]
             }
         ]
     },
@@ -443,8 +442,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["batonpass", "doubleedge", "drillpeck", "hiddenpowerground", "quickattack", "return"],
-                "preferredTypes": ["Ground"]
+                "movepool": ["doubleedge", "drillpeck", "hiddenpowerground", "quickattack", "return"]
             },
             {
                 "role": "Berry Sweeper",
@@ -1330,7 +1328,11 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "explosion", "hiddenpowerbug", "hiddenpowersteel", "rapidspin", "spikes", "toxic"]
+                "movepool": ["earthquake", "hiddenpowerbug", "hiddenpowersteel", "rapidspin", "spikes", "toxic"]
+            },
+            {
+                "role": "Generalist",
+                "movepool": ["explosion", "hiddenpowerbug", "hiddenpowersteel", "rapidspin", "spikes", "toxic"]
             }
         ]
     },
@@ -1834,7 +1836,8 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["bellydrum", "hiddenpowerground", "return", "shadowball", "substitute"]
+                "movepool": ["bellydrum", "hiddenpowerground", "return", "shadowball", "substitute"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -2391,10 +2394,6 @@
         "level": 77,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["icebeam", "rest", "sleeptalk", "surf", "toxic"]
-            },
-            {
                 "role": "Staller",
                 "movepool": ["icebeam", "recover", "refresh", "surf", "toxic"]
             }
@@ -2454,7 +2453,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowerfire", "solarbeam", "sunnyday", "synthesis"]
+                "movepool": ["earthquake", "hiddenpowerflying", "swordsdance", "synthesis"]
             },
             {
                 "role": "Staller",
@@ -2475,8 +2474,13 @@
         "level": 88,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["batonpass", "hiddenpowerfighting", "quickattack", "shadowball", "swordsdance"]
+                "role": "Setup Sweeper",
+                "movepool": ["batonpass", "doubleedge", "hiddenpowerfighting", "quickattack", "shadowball", "swordsdance"],
+                "preferredTypes": ["Fighting", "Ghost"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["doubleedge", "hiddenpowerfighting", "quickattack", "shadowball"]
             }
         ]
     },

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -440,6 +440,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		if (species.id === 'arcanine') return 'Intimidate';
 		if (species.id === 'blissey') return 'Natural Cure';
 		if (species.id === 'heracross' && role === 'Berry Sweeper') return 'Swarm';
+		if (species.id === 'xatu') return 'Synchronize';
 		if (species.id === 'gardevoir') return 'Trace';
 
 		let abilityAllowed: Ability[] = [];

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -673,6 +673,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		const baseFormes: {[k: string]: number} = {};
 		const typeCount: {[k: string]: number} = {};
 		const typeWeaknesses: {[k: string]: number} = {};
+		const typeDoubleWeaknesses: {[k: string]: number} = {};
 		const teamDetails: RandomTeamsTypes.TeamDetails = {};
 		let numMaxLevelPokemon = 0;
 
@@ -707,12 +708,19 @@ export class RandomGen3Teams extends RandomGen4Teams {
 				}
 				if (skip) continue;
 
-				// Limit three weak to any type
+				// Limit three weak to any type, and one double weak to any type
 				for (const typeName of this.dex.types.names()) {
 					// it's weak to the type
 					if (this.dex.getEffectiveness(typeName, species) > 0) {
 						if (!typeWeaknesses[typeName]) typeWeaknesses[typeName] = 0;
 						if (typeWeaknesses[typeName] >= 3 * limitFactor) {
+							skip = true;
+							break;
+						}
+					}
+					if (this.dex.getEffectiveness(typeName, species) > 1) {
+						if (!typeDoubleWeaknesses[typeName]) typeDoubleWeaknesses[typeName] = 0;
+						if (typeDoubleWeaknesses[typeName] >= 1 * limitFactor) {
 							skip = true;
 							break;
 						}
@@ -750,6 +758,9 @@ export class RandomGen3Teams extends RandomGen4Teams {
 				// it's weak to the type
 				if (this.dex.getEffectiveness(typeName, species) > 0) {
 					typeWeaknesses[typeName]++;
+				}
+				if (this.dex.getEffectiveness(typeName, species) > 1) {
+					typeDoubleWeaknesses[typeName]++;
 				}
 			}
 

--- a/data/mods/gen4/random-sets.json
+++ b/data/mods/gen4/random-sets.json
@@ -8,7 +8,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["earthquake", "leafstorm", "sleeppowder", "sludgebomb", "synthesis"]
             }
         ]
     },
@@ -191,7 +191,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "energyball", "hiddenpowerfire", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["aromatherapy", "energyball", "hiddenpowerground", "sleeppowder", "sludgebomb", "synthesis"]
             },
             {
                 "role": "Setup Sweeper",
@@ -316,7 +316,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfire", "leafblade", "leafstorm", "sleeppowder", "sludgebomb", "suckerpunch"]
+                "movepool": ["hiddenpowerground", "leafblade", "leafstorm", "sleeppowder", "sludgebomb", "suckerpunch"]
             },
             {
                 "role": "Setup Sweeper",
@@ -409,7 +409,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["brickbreak", "curse", "explosion", "gunkshot", "icepunch", "payback", "poisonjab", "rest", "shadowsneak"]
+                "movepool": ["brickbreak", "curse", "explosion", "gunkshot", "icepunch", "payback", "poisonjab", "rest", "shadowsneak"],
+                "preferredTypes": ["Fighting"]
             }
         ]
     },
@@ -546,7 +547,7 @@
         "level": 93,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Setup Sweeper",
                 "movepool": ["icebeam", "megahorn", "raindance", "return", "waterfall"]
             }
         ]
@@ -877,8 +878,8 @@
         "level": 100,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["encore", "knockoff", "lightscreen", "reflect", "roost", "toxic", "uturn"]
+                "role": "Staller",
+                "movepool": ["encore", "focusblast", "hiddenpowerflying", "knockoff", "roost", "toxic"]
             },
             {
                 "role": "Fast Support",
@@ -932,7 +933,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["discharge", "focusblast", "healbell", "hiddenpowerice", "lightscreen", "reflect", "signalbeam", "thunderbolt", "toxic"]
+                "movepool": ["discharge", "focusblast", "healbell", "hiddenpowerice", "signalbeam", "thunderbolt", "toxic"]
             }
         ]
     },
@@ -1571,6 +1572,10 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["agility", "airslash", "batonpass", "bugbuzz", "hydropump", "roost"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["airslash", "bugbuzz", "hydropump", "roost", "stunspore", "toxic"]
             }
         ]
     },
@@ -1889,7 +1894,7 @@
                 "movepool": ["dragondance", "earthquake", "outrage", "roost"]
             },
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["dracometeor", "earthquake", "fireblast", "haze", "healbell", "roost", "toxic"]
             }
         ]
@@ -1920,6 +1925,10 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["batonpass", "calmmind", "earthpower", "psychic", "shadowball", "substitute"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["earthpower", "explosion", "psychic", "stealthrock", "toxic"]
             }
         ]
     },
@@ -2291,7 +2300,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "hiddenpowerfire", "icebeam", "psychoboost", "shadowball", "stealthrock", "superpower"],
+                "movepool": ["extremespeed", "icebeam", "psychoboost", "shadowball", "stealthrock", "superpower"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -2301,7 +2310,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "hiddenpowerfire", "icebeam", "psychoboost", "shadowball", "superpower"],
+                "movepool": ["extremespeed", "icebeam", "psychoboost", "shadowball", "superpower"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -2419,7 +2428,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["energyball", "hiddenpowerfire", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"]
+                "movepool": ["energyball", "hiddenpowerground", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"]
             }
         ]
     },
@@ -3122,10 +3131,6 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["dracometeor", "earthquake", "hiddenpowerfire", "outrage", "shadowball", "shadowsneak", "willowisp"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["aurasphere", "calmmind", "dragonpulse", "substitute"]
             }
         ]
     },
@@ -3218,7 +3223,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "extremespeed", "recover", "shadowclaw", "swordsdance"]
+                "movepool": ["earthquake", "extremespeed", "recover", "shadowclaw", "swordsdance"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -632,7 +632,8 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		if (['batonpass', 'protect', 'substitute'].some(m => moves.has(m))) return 'Leftovers';
 		if (
 			role === 'Fast Support' && isLead && defensiveStatTotal < 255 && !counter.get('recovery') &&
-			(!counter.get('recoil') || ability === 'Rock Head')
+			(!counter.get('recoil') || ability === 'Rock Head') &&
+			(counter.get('hazards') || !moves.has('uturn'))
 		) return 'Focus Sash';
 
 		// Default Items

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -8,7 +8,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "hiddenpowerfire", "hiddenpowerice", "leafstorm", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["earthquake", "leafstorm", "sleeppowder", "sludgebomb", "synthesis"]
             }
         ]
     },
@@ -102,7 +102,11 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquatail", "coil", "earthquake", "glare", "gunkshot", "rest", "suckerpunch"],
+                "movepool": ["coil", "earthquake", "glare", "gunkshot", "suckerpunch"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["coil", "earthquake", "gunkshot", "rest", "suckerpunch"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -204,7 +208,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "gigadrain", "hiddenpowerfire", "leechseed", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["aromatherapy", "gigadrain", "hiddenpowerground", "leechseed", "sleeppowder", "sludgebomb", "synthesis"]
             }
         ]
     },
@@ -309,7 +313,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["counter", "focusblast", "hiddenpowerfire", "psychic", "psyshock", "shadowball"]
+                "movepool": ["counter", "focusblast", "psychic", "psyshock", "shadowball"]
             },
             {
                 "role": "Setup Sweeper",
@@ -333,7 +337,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfire", "powerwhip", "sleeppowder", "sludgebomb", "suckerpunch"]
+                "movepool": ["hiddenpowerground", "powerwhip", "sleeppowder", "sludgebomb", "suckerpunch"]
             },
             {
                 "role": "Setup Sweeper",
@@ -426,7 +430,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["brickbreak", "curse", "firepunch", "icepunch", "poisonjab", "rest", "shadowsneak"]
+                "movepool": ["brickbreak", "curse", "icepunch", "poisonjab", "rest", "shadowsneak"],
+                "preferredTypes": ["Fighting"]
             }
         ]
     },
@@ -562,7 +567,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["protect", "seismictoss", "toxic", "wish"]
+                "movepool": ["seismictoss", "softboiled", "toxic", "wish"]
             }
         ]
     },
@@ -725,10 +730,6 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["facade", "flamecharge", "protect", "superpower"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["lavaplume", "protect", "toxic", "wish"]
             }
         ]
     },
@@ -937,7 +938,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["bravebird", "heatwave", "roost", "superfang", "taunt", "toxic", "uturn"]
+                "movepool": ["bravebird", "heatwave", "hypnosis", "roost", "superfang", "taunt", "toxic", "uturn"]
             }
         ]
     },
@@ -1878,6 +1879,10 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["focusblast", "healbell", "psychic", "thunderwave", "toxic", "whirlwind"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "shadowball", "trick"]
             }
         ]
     },
@@ -1925,7 +1930,7 @@
                 "movepool": ["dragondance", "earthquake", "outrage", "roost"]
             },
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["dracometeor", "earthquake", "fireblast", "haze", "healbell", "roost", "toxic"]
             }
         ]
@@ -2117,7 +2122,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "explosion", "icebeam", "spikes", "taunt"]
+                "movepool": ["earthquake", "icebeam", "spikes", "superfang", "taunt"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -2328,7 +2334,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["darkpulse", "extremespeed", "hiddenpowerfire", "icebeam", "psychoboost", "stealthrock", "superpower"],
+                "movepool": ["darkpulse", "extremespeed", "icebeam", "psychoboost", "stealthrock", "superpower"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -2338,7 +2344,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["darkpulse", "extremespeed", "hiddenpowerfire", "icebeam", "psychoboost", "superpower"],
+                "movepool": ["darkpulse", "extremespeed", "icebeam", "psychoboost", "superpower"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -2452,7 +2458,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["gigadrain", "hiddenpowerfire", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"]
+                "movepool": ["gigadrain", "hiddenpowerground", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"]
             }
         ]
     },
@@ -3157,6 +3163,10 @@
         "level": 89,
         "sets": [
             {
+                "role": "Staller",
+                "movepool": ["raindance", "rest", "surf", "toxic"]
+            },
+            {
                 "role": "Bulky Support",
                 "movepool": ["healbell", "icebeam", "scald", "toxic", "uturn"]
             }
@@ -3208,7 +3218,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthquake", "extremespeed", "recover", "shadowclaw", "swordsdance"]
+                "movepool": ["earthquake", "extremespeed", "recover", "shadowclaw", "swordsdance"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -3332,6 +3343,10 @@
     "arceuspoison": {
         "level": 71,
         "sets": [
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["calmmind", "earthpower", "fireblast", "recover", "sludgebomb"]
+            },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["earthquake", "fireblast", "icebeam", "recover", "sludgebomb", "stealthrock", "willowisp"]
@@ -3651,7 +3666,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["encore", "gigadrain", "leechseed", "stunspore", "taunt", "toxic", "uturn"]
+                "movepool": ["encore", "gigadrain", "stunspore", "taunt", "toxic", "uturn"]
             },
             {
                 "role": "Staller",
@@ -3726,7 +3741,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["bulkup", "crunch", "drainpunch", "highjumpkick", "rest"]
+                "movepool": ["bulkup", "crunch", "drainpunch", "rest"]
             }
         ]
     },
@@ -3838,7 +3853,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hurricane", "icebeam", "raindance", "rest", "surf"]
+                "movepool": ["hurricane", "raindance", "rest", "surf"]
             }
         ]
     },
@@ -3885,7 +3900,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["clearsmog", "foulplay", "gigadrain", "hiddenpowerfire", "sludgebomb", "spore", "stunspore", "toxic"]
+                "movepool": ["clearsmog", "foulplay", "gigadrain", "hiddenpowerground", "sludgebomb", "spore", "stunspore", "toxic"]
             },
             {
                 "role": "Bulky Support",

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -384,7 +384,7 @@
                 "movepool": ["fireblast", "icebeam", "psyshock", "scald", "slackoff", "thunderwave", "toxic"]
             },
             {
-                "role": "Bulky Setup",
+                "role": "Staller",
                 "movepool": ["calmmind", "psyshock", "scald", "slackoff"]
             },
             {

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -8,7 +8,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "energyball", "hiddenpowerfire", "knockoff", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["earthquake", "energyball", "knockoff", "sleeppowder", "sludgebomb", "synthesis"]
             }
         ]
     },
@@ -17,7 +17,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "gigadrain", "hiddenpowerfire", "knockoff", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["earthquake", "gigadrain", "knockoff", "sleeppowder", "sludgebomb", "synthesis"]
             }
         ]
     },
@@ -237,7 +237,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "gigadrain", "hiddenpowerfire", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["aromatherapy", "gigadrain", "hiddenpowerground", "sleeppowder", "sludgebomb", "synthesis"]
             }
         ]
     },
@@ -334,7 +334,12 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["counter", "focusblast", "hiddenpowerfire", "psychic", "psyshock", "shadowball"]
+                "movepool": ["counter", "focusblast", "psychic", "psyshock", "shadowball"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["calmmind", "encore", "focusblast", "psychic", "psyshock", "shadowball", "substitute"],
+                "preferredTypes": ["Fighting"]
             }
         ]
     },
@@ -368,7 +373,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfire", "knockoff", "powerwhip", "sleeppowder", "sludgebomb", "suckerpunch"]
+                "movepool": ["hiddenpowerground", "knockoff", "powerwhip", "sleeppowder", "sludgebomb", "suckerpunch"]
             },
             {
                 "role": "Setup Sweeper",
@@ -616,7 +621,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["protect", "seismictoss", "toxic", "wish"]
+                "movepool": ["seismictoss", "softboiled", "toxic", "wish"]
             }
         ]
     },
@@ -999,7 +1004,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["airslash", "defog", "heatwave", "hypervoice", "roost", "whirlwind"]
+                "movepool": ["airslash", "defog", "hypervoice", "roost", "toxic", "whirlwind"]
             }
         ]
     },
@@ -1008,7 +1013,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["encore", "knockoff", "roost", "toxic", "uturn"]
+                "movepool": ["encore", "focusblast", "knockoff", "roost", "toxic"],
+                "preferredTypes": ["Dark"]
             }
         ]
     },
@@ -1563,7 +1569,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hydropump", "icebeam", "rest", "scald", "substitute"]
+                "movepool": ["calmmind", "icebeam", "rest", "scald", "substitute"]
             },
             {
                 "role": "Staller",
@@ -1719,7 +1725,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bugbuzz", "energyball", "hiddenpowerfighting", "psychic", "quiverdance"]
+                "movepool": ["aircutter", "bugbuzz", "hiddenpowerground", "quiverdance"]
             }
         ]
     },
@@ -2242,7 +2248,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquajet", "crabhammer", "knockoff", "swordsdance"]
+                "movepool": ["aquajet", "crabhammer", "dragondance", "knockoff", "swordsdance"]
             }
         ]
     },
@@ -2626,7 +2632,16 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["dracometeor", "dragondance", "earthquake", "extremespeed", "outrage", "vcreate"]
+                "movepool": ["dracometeor", "earthquake", "extremespeed", "outrage", "vcreate"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["dragondance", "earthquake", "extremespeed", "outrage", "vcreate"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["earthquake", "extremespeed", "outrage", "swordsdance", "vcreate"],
+                "preferredTypes": ["Normal"]
             }
         ]
     },
@@ -2777,7 +2792,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["gigadrain", "hiddenpowerfire", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"]
+                "movepool": ["gigadrain", "hiddenpowerground", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"]
             }
         ]
     },
@@ -3127,8 +3142,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["blizzard", "earthquake", "focusblast", "gigadrain", "iceshard", "woodhammer"],
-                "preferredTypes": ["Grass"]
+                "movepool": ["blizzard", "earthquake", "gigadrain", "iceshard", "woodhammer"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -3137,7 +3152,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["blizzard", "earthquake", "focusblast", "gigadrain", "iceshard", "woodhammer"]
+                "movepool": ["blizzard", "earthquake", "gigadrain", "iceshard", "woodhammer"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -3246,7 +3262,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "bugbuzz", "gigadrain", "protect"]
+                "movepool": ["airslash", "bugbuzz", "hiddenpowerground", "protect"]
             },
             {
                 "role": "Wallbreaker",
@@ -3461,7 +3477,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "dragontail", "fireblast", "flashcannon", "stealthrock", "thunderbolt", "toxic"]
+                "movepool": ["dracometeor", "dragontail", "fireblast", "flashcannon", "stealthrock", "thunderbolt", "toxic"],
+                "preferredTypes": ["Fire"]
             }
         ]
     },
@@ -4047,7 +4064,7 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["healbell", "knockoff", "leafblade", "stickyweb", "xscissor"]
+                "movepool": ["knockoff", "leafblade", "stickyweb", "toxic", "xscissor"]
             }
         ]
     },
@@ -4141,11 +4158,11 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "highjumpkick", "icepunch", "knockoff", "poisonjab"]
+                "movepool": ["dragondance", "highjumpkick", "ironhead", "knockoff"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["bulkup", "drainpunch", "highjumpkick", "knockoff", "rest"]
+                "movepool": ["bulkup", "drainpunch", "knockoff", "rest"]
             }
         ]
     },
@@ -4250,10 +4267,6 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["focusblast", "psychic", "psyshock", "shadowball", "trickroom"]
-            },
-            {
-                "role": "AV Pivot",
-                "movepool": ["focusblast", "futuresight", "knockoff", "psychic", "shadowball"]
             }
         ]
     },
@@ -4262,7 +4275,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "defog", "icebeam", "roost", "scald"]
+                "movepool": ["bravebird", "defog", "roost", "scald", "toxic"]
             }
         ]
     },
@@ -4314,7 +4327,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["clearsmog", "foulplay", "gigadrain", "hiddenpowerfire", "sludgebomb", "spore"]
+                "movepool": ["clearsmog", "foulplay", "gigadrain", "hiddenpowerground", "sludgebomb", "spore"]
             },
             {
                 "role": "Bulky Support",
@@ -4348,7 +4361,7 @@
         "level": 80,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["bugbuzz", "gigadrain", "hiddenpowerice", "stickyweb", "thunder", "voltswitch"],
                 "preferredTypes": ["Bug"]
             }
@@ -4902,8 +4915,8 @@
         "level": 89,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["bulkup", "earthquake", "hornleech", "milkdrink"]
+                "role": "Bulky Attacker",
+                "movepool": ["bulkup", "earthquake", "hornleech", "milkdrink", "toxic"]
             }
         ]
     },
@@ -4944,7 +4957,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "energyball", "psychic", "psyshock", "shadowball", "signalbeam", "thunderbolt"]
+                "movepool": ["calmmind", "darkpulse", "energyball", "psychic", "psyshock", "signalbeam", "thunderbolt"]
             }
         ]
     },
@@ -5235,7 +5248,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["diamondstorm", "earthpower", "healbell", "lightscreen", "moonblast", "reflect", "stealthrock", "toxic"]
+                "movepool": ["diamondstorm", "earthpower", "healbell", "moonblast", "stealthrock", "toxic"]
             }
         ]
     },
@@ -5244,11 +5257,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["diamondstorm", "earthpower", "hiddenpowerfire", "moonblast", "protect"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["calmmind", "diamondstorm", "earthpower", "hiddenpowerfire", "moonblast"]
+                "movepool": ["calmmind", "diamondstorm", "earthpower", "moonblast", "protect"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -938,9 +938,14 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (['highjumpkick', 'jumpkick'].some(m => moves.has(m))) srWeakness = 2;
 		while (evs.hp > 1) {
 			const hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
-			if (moves.has('substitute') && item === 'Sitrus Berry') {
-				// Two Substitutes should activate Sitrus Berry
-				if (hp % 4 === 0) break;
+			if (moves.has('substitute')) {
+				if (item === 'Sitrus Berry') {
+					// Two Substitutes should activate Sitrus Berry
+					if (hp % 4 === 0) break;
+				} else if (!['Black Sludge', 'Leftovers'].includes(item)) {
+					// Should be able to use Substitute four times from full HP without fainting
+					if (hp % 4 > 0) break;
+				}
 			} else if (moves.has('bellydrum') && item === 'Sitrus Berry') {
 				// Belly Drum should activate Sitrus Berry
 				if (hp % 2 === 0) break;

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -8,7 +8,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "energyball", "hiddenpowerfire", "knockoff", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["earthquake", "energyball", "knockoff", "sleeppowder", "sludgebomb", "synthesis"]
             }
         ]
     },
@@ -17,7 +17,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "gigadrain", "hiddenpowerfire", "knockoff", "sleeppowder", "sludgebomb", "synthesis"]
+                "movepool": ["earthquake", "gigadrain", "knockoff", "sleeppowder", "sludgebomb", "synthesis"]
             }
         ]
     },
@@ -293,7 +293,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["aromatherapy", "gigadrain", "hiddenpowerfire", "sleeppowder", "sludgebomb", "strengthsap"]
+                "movepool": ["aromatherapy", "gigadrain", "hiddenpowerground", "sleeppowder", "sludgebomb", "strengthsap"]
             }
         ]
     },
@@ -418,7 +418,12 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["counter", "focusblast", "hiddenpowerfire", "psychic", "psyshock", "shadowball"]
+                "movepool": ["counter", "focusblast", "psychic", "psyshock", "shadowball"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["calmmind", "encore", "focusblast", "psychic", "psyshock", "shadowball", "substitute"],
+                "preferredTypes": ["Fighting"]
             }
         ]
     },
@@ -461,7 +466,7 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["hiddenpowerfire", "knockoff", "powerwhip", "sleeppowder", "sludgebomb", "strengthsap", "suckerpunch"]
+                "movepool": ["hiddenpowerground", "knockoff", "powerwhip", "sleeppowder", "sludgebomb", "strengthsap", "suckerpunch"]
             },
             {
                 "role": "Fast Attacker",
@@ -760,7 +765,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["protect", "seismictoss", "toxic", "wish"]
+                "movepool": ["seismictoss", "softboiled", "toxic", "wish"]
             }
         ]
     },
@@ -1157,7 +1162,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "heatwave", "hurricane", "hypervoice", "roost", "whirlwind"]
+                "movepool": ["defog", "hurricane", "hypervoice", "roost", "toxic", "whirlwind"]
             }
         ]
     },
@@ -1232,8 +1237,12 @@
         "level": 87,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["gigadrain", "hiddenpowerfire", "moonblast", "quiverdance", "sleeppowder", "strengthsap"]
+                "role": "Bulky Attacker",
+                "movepool": ["gigadrain", "moonblast", "quiverdance", "strengthsap"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["gigadrain", "hiddenpowerfire", "hiddenpowerrock", "quiverdance", "strengthsap"]
             },
             {
                 "role": "Z-Move user",
@@ -1713,7 +1722,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hydropump", "icebeam", "rest", "scald", "substitute"]
+                "movepool": ["calmmind", "icebeam", "rest", "scald", "substitute"]
             },
             {
                 "role": "Staller",
@@ -1870,7 +1879,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bugbuzz", "energyball", "hiddenpowerfighting", "psychic", "quiverdance"]
+                "movepool": ["aircutter", "bugbuzz", "hiddenpowerground", "quiverdance"]
             }
         ]
     },
@@ -2280,11 +2289,8 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icepunch", "return", "suckerpunch", "superpower"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["protect", "rest", "return", "sleeptalk", "superpower", "wish"]
+                "movepool": ["icepunch", "rest", "return", "sleeptalk", "suckerpunch", "superpower"],
+                "preferredTypes": ["Fighting"]
             }
         ]
     },
@@ -2406,7 +2412,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquajet", "crabhammer", "knockoff", "swordsdance"]
+                "movepool": ["aquajet", "crabhammer", "dragondance", "knockoff", "swordsdance"]
             }
         ]
     },
@@ -2808,13 +2814,18 @@
         "level": 72,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["dracometeor", "dragondance", "earthquake", "extremespeed", "outrage", "vcreate"]
-            },
-            {
                 "role": "Z-Move user",
                 "movepool": ["dragonascent", "dragondance", "earthquake", "extremespeed", "vcreate"],
                 "preferredTypes": ["Flying"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["dragondance", "earthquake", "extremespeed", "outrage", "vcreate"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["earthquake", "extremespeed", "outrage", "swordsdance", "vcreate"],
+                "preferredTypes": ["Normal"]
             }
         ]
     },
@@ -2975,7 +2986,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["gigadrain", "hiddenpowerfire", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"]
+                "movepool": ["gigadrain", "hiddenpowerground", "leafstorm", "sleeppowder", "sludgebomb", "spikes", "synthesis", "toxicspikes"]
             }
         ]
     },
@@ -3327,8 +3338,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["blizzard", "earthquake", "focusblast", "gigadrain", "iceshard", "woodhammer"],
-                "preferredTypes": ["Grass"]
+                "movepool": ["blizzard", "earthquake", "gigadrain", "iceshard", "woodhammer"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -3337,7 +3348,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["blizzard", "earthquake", "focusblast", "gigadrain", "iceshard", "woodhammer"]
+                "movepool": ["blizzard", "earthquake", "gigadrain", "iceshard", "woodhammer"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -3446,7 +3458,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "bugbuzz", "gigadrain", "protect"]
+                "movepool": ["airslash", "bugbuzz", "hiddenpowerground", "protect"]
             },
             {
                 "role": "Wallbreaker",
@@ -3671,7 +3683,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "dragontail", "fireblast", "flashcannon", "stealthrock", "thunderbolt", "toxic"]
+                "movepool": ["dracometeor", "dragontail", "fireblast", "flashcannon", "stealthrock", "thunderbolt", "toxic"],
+                "preferredTypes": ["Fire"]
             }
         ]
     },
@@ -4300,7 +4313,7 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["healbell", "knockoff", "leafblade", "stickyweb", "xscissor"]
+                "movepool": ["knockoff", "leafblade", "stickyweb", "toxic", "xscissor"]
             }
         ]
     },
@@ -4394,11 +4407,11 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "highjumpkick", "icepunch", "knockoff", "poisonjab"]
+                "movepool": ["dragondance", "highjumpkick", "ironhead", "knockoff"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["bulkup", "drainpunch", "highjumpkick", "knockoff", "rest"]
+                "movepool": ["bulkup", "drainpunch", "knockoff", "rest"]
             }
         ]
     },
@@ -4499,10 +4512,6 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["focusblast", "psychic", "psyshock", "shadowball", "trickroom"]
-            },
-            {
-                "role": "AV Pivot",
-                "movepool": ["focusblast", "futuresight", "knockoff", "psychic", "shadowball"]
             }
         ]
     },
@@ -4511,11 +4520,11 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bravebird", "defog", "icebeam", "roost", "scald"]
+                "movepool": ["bravebird", "defog", "roost", "scald", "toxic"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["hurricane", "icebeam", "raindance", "rest", "scald"],
+                "movepool": ["hurricane", "raindance", "rest", "scald"],
                 "preferredTypes": ["Water"]
             }
         ]
@@ -4568,7 +4577,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["clearsmog", "foulplay", "gigadrain", "hiddenpowerfire", "sludgebomb", "spore"]
+                "movepool": ["clearsmog", "foulplay", "gigadrain", "sludgebomb", "spore", "stompingtantrum"]
             },
             {
                 "role": "Bulky Support",
@@ -4602,7 +4611,7 @@
         "level": 82,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["bugbuzz", "gigadrain", "hiddenpowerice", "stickyweb", "thunder", "voltswitch"],
                 "preferredTypes": ["Bug"]
             }
@@ -5224,8 +5233,8 @@
         "level": 89,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["bulkup", "earthquake", "hornleech", "milkdrink"]
+                "role": "Bulky Attacker",
+                "movepool": ["bulkup", "earthquake", "hornleech", "milkdrink", "toxic"]
             }
         ]
     },
@@ -5266,7 +5275,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "energyball", "psychic", "psyshock", "shadowball", "signalbeam", "thunderbolt"]
+                "movepool": ["calmmind", "darkpulse", "energyball", "psychic", "psyshock", "signalbeam", "thunderbolt"]
             }
         ]
     },
@@ -5585,7 +5594,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["diamondstorm", "earthpower", "healbell", "lightscreen", "moonblast", "reflect", "stealthrock", "toxic"]
+                "movepool": ["diamondstorm", "earthpower", "healbell", "moonblast", "stealthrock", "toxic"]
             }
         ]
     },
@@ -5594,11 +5603,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["diamondstorm", "earthpower", "hiddenpowerfire", "moonblast", "stealthrock"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["calmmind", "earthpower", "hiddenpowerfire", "moonblast", "powergem"]
+                "movepool": ["calmmind", "diamondstorm", "earthpower", "moonblast", "stealthrock"]
             }
         ]
     },
@@ -5781,11 +5786,11 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["firepunch", "stealthrock", "stoneedge", "suckerpunch", "swordsdance"]
+                "movepool": ["stealthrock", "stompingtantrum", "stoneedge", "suckerpunch", "swordsdance"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["firepunch", "stoneedge", "suckerpunch", "swordsdance"]
+                "movepool": ["stompingtantrum", "stoneedge", "suckerpunch", "swordsdance"]
             }
         ]
     },
@@ -5890,9 +5895,13 @@
         "level": 85,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Bulky Attacker",
                 "movepool": ["doubleedge", "icepunch", "return", "shadowclaw", "superpower", "swordsdance"],
                 "preferredTypes": ["Normal"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["bulkup", "doubleedge", "drainpunch", "return", "shadowclaw"]
             }
         ]
     },
@@ -5924,7 +5933,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["focusblast", "nastyplot", "psyshock", "thunderbolt", "trickroom"]
+                "movepool": ["focusblast", "nastyplot", "naturepower", "psychic", "psyshock", "thunderbolt", "trickroom"]
             }
         ]
     },
@@ -6265,12 +6274,12 @@
         "sets": [
             {
                 "role": "Z-Move user",
-                "movepool": ["clangingscales", "closecombat", "dragondance", "poisonjab"],
+                "movepool": ["clangingscales", "closecombat", "dragondance", "ironhead"],
                 "preferredTypes": ["Dragon"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["closecombat", "dragondance", "outrage", "poisonjab"]
+                "movepool": ["closecombat", "dragondance", "ironhead", "outrage"]
             }
         ]
     },
@@ -6311,7 +6320,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hydropump", "icebeam", "moonblast", "scald", "taunt"]
+                "movepool": ["calmmind", "hydropump", "icebeam", "moonblast", "surf", "taunt"]
             }
         ]
     },
@@ -6359,7 +6368,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["drainpunch", "earthquake", "leechlife", "poisonjab", "stoneedge", "superpower"]
+                "movepool": ["drainpunch", "earthquake", "ironhead", "leechlife", "stoneedge", "superpower"]
             },
             {
                 "role": "Bulky Attacker",
@@ -6464,11 +6473,11 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["autotomize", "calmmind", "heatwave", "moongeistbeam", "photongeyser", "powergem"]
+                "movepool": ["autotomize", "calmmind", "heatwave", "moongeistbeam", "photongeyser", "signalbeam"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["autotomize", "calmmind", "heatwave", "moongeistbeam", "photongeyser", "powergem"]
+                "movepool": ["autotomize", "calmmind", "heatwave", "moongeistbeam", "photongeyser", "signalbeam"]
             }
         ]
     },

--- a/data/mods/gen8/random-teams.ts
+++ b/data/mods/gen8/random-teams.ts
@@ -2472,6 +2472,7 @@ export class RandomGen8Teams {
 		const typeCount: {[k: string]: number} = {};
 		const typeComboCount: {[k: string]: number} = {};
 		const typeWeaknesses: {[k: string]: number} = {};
+		const typeDoubleWeaknesses: {[k: string]: number} = {};
 		const teamDetails: RandomTeamsTypes.TeamDetails = {};
 		let numMaxLevelPokemon = 0;
 
@@ -2523,12 +2524,19 @@ export class RandomGen8Teams {
 				}
 				if (skip) continue;
 
-				// Limit three weak to any type
+				// Limit three weak to any type, and one double weak to any type
 				for (const typeName of this.dex.types.names()) {
 					// it's weak to the type
 					if (this.dex.getEffectiveness(typeName, species) > 0) {
 						if (!typeWeaknesses[typeName]) typeWeaknesses[typeName] = 0;
 						if (typeWeaknesses[typeName] >= 3 * limitFactor) {
+							skip = true;
+							break;
+						}
+					}
+					if (this.dex.getEffectiveness(typeName, species) > 1) {
+						if (!typeDoubleWeaknesses[typeName]) typeDoubleWeaknesses[typeName] = 0;
+						if (typeDoubleWeaknesses[typeName] >= 1 * limitFactor) {
 							skip = true;
 							break;
 						}
@@ -2585,6 +2593,9 @@ export class RandomGen8Teams {
 				// it's weak to the type
 				if (this.dex.getEffectiveness(typeName, species) > 0) {
 					typeWeaknesses[typeName]++;
+				}
+				if (this.dex.getEffectiveness(typeName, species) > 1) {
+					typeDoubleWeaknesses[typeName]++;
 				}
 			}
 			if (weakToFreezeDry) typeWeaknesses['Freeze-Dry']++;

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -804,7 +804,7 @@
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Draco Meteor", "Fire Punch", "Low Kick", "Roost", "Tailwind", "Tera Blast"],
+                "movepool": ["Draco Meteor", "Fire Punch", "Low Kick", "Tailwind", "Tera Blast"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -1028,7 +1028,7 @@
         "level": 87,
         "sets": [
             {
-                "role": "Doubles Support",
+                "role": "Doubles Bulky Attacker",
                 "movepool": ["Gunk Shot", "Helping Hand", "High Horsepower", "Recover", "Toxic Spikes"],
                 "teraTypes": ["Flying", "Ground", "Steel"]
             }
@@ -2509,7 +2509,7 @@
             },
             {
                 "role": "Choice Item user",
-                "movepool": ["Ice Beam", "Mystical Power", "Psychic", "Thunderbolt", "U-turn"],
+                "movepool": ["Ice Beam", "Psychic", "Thunderbolt", "U-turn"],
                 "teraTypes": ["Electric", "Psychic"]
             }
         ]
@@ -2801,6 +2801,11 @@
                 "role": "Doubles Setup Sweeper",
                 "movepool": ["Brick Break", "Extreme Speed", "Phantom Force", "Swords Dance"],
                 "teraTypes": ["Ghost", "Normal"]
+            },
+            {
+                "role": "Doubles Bulky Setup",
+                "movepool": ["Calm Mind", "Dazzling Gleam", "Focus Blast", "Judgment", "Recover"],
+                "teraTypes": ["Fairy", "Fighting"]
             }
         ]
     },
@@ -3400,12 +3405,12 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Close Combat", "High Horsepower", "Rock Slide", "Stone Edge"],
-                "teraTypes": ["Fighting", "Ghost", "Rock", "Water"]
+                "teraTypes": ["Fighting", "Ghost", "Rock"]
             },
             {
                 "role": "Offensive Protect",
                 "movepool": ["Close Combat", "High Horsepower", "Protect", "Rock Slide"],
-                "teraTypes": ["Fighting", "Ghost", "Rock", "Water"]
+                "teraTypes": ["Fighting", "Ghost", "Rock"]
             }
         ]
     },
@@ -6004,7 +6009,7 @@
             },
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Breaking Swipe", "Draco Meteor", "Thunderbolt", "Thunderclap"],
+                "movepool": ["Draco Meteor", "Electroweb", "Snarl", "Thunderbolt", "Thunderclap"],
                 "teraTypes": ["Electric", "Fairy", "Grass"]
             },
             {

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -3785,7 +3785,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Aura Sphere", "Calm Mind", "Flash Cannon", "Focus Blast", "Vacuum Wave"],
-                "teraTypes": ["Ghost", "Fighting", "Water"]
+                "teraTypes": ["Fighting", "Ghost", "Water"]
             },
             {
                 "role": "Bulky Support",

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -20,7 +20,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Earthquake", "Flamethrower", "Focus Blast", "Hurricane", "Will-O-Wisp"],
-                "teraTypes": ["Fire", "Ground", "Water"]
+                "teraTypes": ["Dragon", "Fire", "Ground"]
             },
             {
                 "role": "Setup Sweeper",
@@ -855,7 +855,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Agility", "Fiery Wrath", "Hurricane", "Nasty Plot", "Rest"],
-                "teraTypes": ["Dark"]
+                "teraTypes": ["Dark", "Steel"]
             }
         ]
     },
@@ -895,7 +895,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Knock Off", "Psychic", "Stealth Rock", "Taunt", "Toxic Spikes", "U-turn", "Will-O-Wisp"],
-                "teraTypes": ["Fairy", "Steel"]
+                "teraTypes": ["Dark", "Fairy", "Steel"]
             },
             {
                 "role": "Setup Sweeper",
@@ -954,8 +954,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Aqua Jet", "Earthquake", "Ice Punch", "Liquidation", "Swords Dance"],
-                "teraTypes": ["Water"]
+                "movepool": ["Aqua Jet", "Crunch", "Ice Punch", "Liquidation", "Swords Dance"],
+                "teraTypes": ["Dark", "Dragon", "Steel", "Water"]
             },
             {
                 "role": "Setup Sweeper",
@@ -1130,11 +1130,11 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Curse", "Earthquake", "Gunk Shot", "Recover"],
-                "teraTypes": ["Flying", "Ground"]
+                "teraTypes": ["Flying", "Ground", "Steel"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Poison Jab", "Recover", "Stealth Rock", "Toxic", "Toxic Spikes"],
+                "movepool": ["Earthquake", "Gunk Shot", "Poison Jab", "Recover", "Stealth Rock", "Toxic", "Toxic Spikes"],
                 "teraTypes": ["Flying", "Ground", "Steel"]
             }
         ]
@@ -1664,12 +1664,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Hurricane", "Hydro Pump", "Ice Beam", "Knock Off", "Roost", "Surf", "U-turn"],
+                "movepool": ["Hurricane", "Hydro Pump", "Knock Off", "Roost", "Surf", "U-turn"],
                 "teraTypes": ["Ground", "Water"]
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Hurricane", "Hydro Pump", "Ice Beam", "Surf", "U-turn"],
+                "movepool": ["Hurricane", "Hydro Pump", "Surf", "U-turn"],
                 "teraTypes": ["Flying", "Water"]
             }
         ]
@@ -1695,7 +1695,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Bug Buzz", "Hurricane", "Hydro Pump", "Ice Beam", "Sticky Web", "Stun Spore", "U-turn"],
-                "teraTypes": ["Ground", "Steel"]
+                "teraTypes": ["Ground", "Steel", "Water"]
             }
         ]
     },
@@ -1744,7 +1744,7 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["Bullet Punch", "Close Combat", "Headlong Rush", "Heavy Slam", "Knock Off"],
+                "movepool": ["Bullet Punch", "Close Combat", "Headlong Rush", "Heavy Slam", "Knock Off", "Stone Edge"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -2004,8 +2004,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Encore", "Heal Bell", "Knock Off", "Psychic Noise", "Recover", "Thunder Wave"],
-                "teraTypes": ["Dark", "Electric", "Poison", "Steel"]
+                "movepool": ["Dazzling Gleam", "Encore", "Heal Bell", "Knock Off", "Psychic Noise", "Recover", "Thunder Wave"],
+                "teraTypes": ["Dark", "Electric", "Fairy", "Poison", "Steel"]
             },
             {
                 "role": "Bulky Setup",
@@ -2128,9 +2128,14 @@
         "level": 71,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Calm Mind", "Ice Beam", "Origin Pulse", "Thunder", "Water Spout"],
+                "role": "Fast Attacker",
+                "movepool": ["Ice Beam", "Origin Pulse", "Thunder", "Water Spout"],
                 "teraTypes": ["Water"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Ice Beam", "Origin Pulse", "Thunder"],
+                "teraTypes": ["Dragon", "Electric", "Steel"]
             }
         ]
     },
@@ -2494,7 +2499,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Earthquake", "Fire Blast", "Outrage", "Spikes", "Stealth Rock", "Stone Edge"],
+                "movepool": ["Earthquake", "Outrage", "Spikes", "Stealth Rock", "Stone Edge"],
                 "teraTypes": ["Ground", "Steel"]
             },
             {
@@ -2514,7 +2519,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Aura Sphere", "Dark Pulse", "Flash Cannon", "Focus Blast", "Nasty Plot", "Vacuum Wave"],
+                "movepool": ["Dark Pulse", "Flash Cannon", "Focus Blast", "Nasty Plot", "Vacuum Wave"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2980,7 +2985,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Defog", "Draco Meteor", "Dragon Tail", "Earthquake", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
-                "teraTypes": ["Dragon", "Ghost"]
+                "teraTypes": ["Dragon", "Fairy", "Ghost", "Steel"]
             }
         ]
     },
@@ -3144,8 +3149,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Earthquake", "Extreme Speed", "Flare Blitz", "Liquidation", "Recover", "Swords Dance"],
-                "teraTypes": ["Fire", "Ground", "Water"]
+                "movepool": ["Earthquake", "Extreme Speed", "Flare Blitz", "Recover", "Swords Dance"],
+                "teraTypes": ["Fire", "Ground"]
             },
             {
                 "role": "Fast Bulky Setup",
@@ -3779,7 +3784,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Aura Sphere", "Calm Mind", "Flash Cannon", "Vacuum Wave"],
+                "movepool": ["Aura Sphere", "Calm Mind", "Flash Cannon", "Focus Blast", "Vacuum Wave"],
                 "teraTypes": ["Fighting"]
             },
             {
@@ -3820,7 +3825,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Bleakwind Storm", "Focus Blast", "Grass Knot", "Heat Wave", "Nasty Plot", "U-turn"],
-                "teraTypes": ["Fire", "Flying"]
+                "teraTypes": ["Fighting", "Fire", "Flying"]
             }
         ]
     },
@@ -3830,7 +3835,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Bleakwind Storm", "Focus Blast", "Grass Knot", "Heat Wave", "Nasty Plot", "U-turn"],
-                "teraTypes": ["Fire", "Flying"]
+                "teraTypes": ["Fighting", "Fire", "Flying"]
             },
             {
                 "role": "AV Pivot",
@@ -4040,7 +4045,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Brave Bird", "Defog", "Overheat", "Roost", "Taunt", "U-turn", "Will-O-Wisp"],
-                "teraTypes": ["Ground", "Water"]
+                "teraTypes": ["Dragon", "Ground"]
             },
             {
                 "role": "Tera Blast user",
@@ -4094,8 +4099,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Bulk Up", "Earthquake", "Horn Leech", "Milk Drink"],
-                "teraTypes": ["Ground"]
+                "movepool": ["Bulk Up", "Earthquake", "Horn Leech", "Milk Drink", "Rock Slide"],
+                "teraTypes": ["Ground", "Water"]
             }
         ]
     },
@@ -4620,7 +4625,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Focus Blast", "Hyper Voice", "Nasty Plot", "Psyshock", "Thunderbolt", "Trick"],
-                "teraTypes": ["Electric", "Fighting", "Psychic"]
+                "teraTypes": ["Electric", "Fighting", "Normal", "Psychic"]
             }
         ]
     },
@@ -4884,7 +4889,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Overheat", "Rapid Spin", "Spikes", "Stealth Rock", "Stone Edge", "Will-O-Wisp"],
+                "movepool": ["Flamethrower", "Overheat", "Rapid Spin", "Spikes", "Stealth Rock", "Stone Edge", "Will-O-Wisp"],
                 "teraTypes": ["Ghost", "Grass", "Water"]
             }
         ]
@@ -5006,11 +5011,6 @@
                 "role": "Bulky Support",
                 "movepool": ["Light Screen", "Parting Shot", "Reflect", "Spirit Break", "Thunder Wave"],
                 "teraTypes": ["Poison", "Steel"]
-            },
-            {
-                "role": "Fast Bulky Setup",
-                "movepool": ["Bulk Up", "Rest", "Spirit Break", "Sucker Punch", "Throat Chop", "Thunder Wave"],
-                "teraTypes": ["Dark", "Poison", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
@@ -5219,7 +5219,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Behemoth Bash", "Body Press", "Crunch", "Iron Defense", "Stone Edge"],
+                "movepool": ["Body Press", "Crunch", "Heavy Slam", "Iron Defense", "Stone Edge"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -5245,7 +5245,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Close Combat", "Poison Jab", "Sucker Punch", "Swords Dance", "U-turn", "Wicked Blow"],
-                "teraTypes": ["Dark", "Fighting"]
+                "teraTypes": ["Dark", "Fighting", "Poison"]
             }
         ]
     },
@@ -6023,6 +6023,11 @@
         "level": 77,
         "sets": [
             {
+                "role": "Fast Bulky Setup",
+                "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Ice Spinner", "Rapid Spin"],
+                "teraTypes": ["Ground", "Steel"]
+            },
+            {
                 "role": "Bulky Setup",
                 "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Ice Spinner", "Rapid Spin"],
                 "teraTypes": ["Ground", "Steel"]
@@ -6061,6 +6066,11 @@
                 "role": "Bulky Support",
                 "movepool": ["Encore", "Play Rough", "Protect", "Thunder Wave", "Wish"],
                 "teraTypes": ["Poison", "Steel"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Dazzling Gleam", "Encore", "Protect", "Thunder Wave", "Wish"],
+                "teraTypes": ["Poison", "Steel"]
             }
         ]
     },
@@ -6078,7 +6088,7 @@
         "level": 81,
         "sets": [
             {
-                "role": "Bulky Setup",
+                "role": "Fast Bulky Setup",
                 "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Flame Charge", "Leech Life", "Wild Charge"],
                 "teraTypes": ["Electric", "Fighting"]
             },
@@ -6178,7 +6188,7 @@
                 "teraTypes": ["Grass", "Water"]
             },
             {
-                "role": "Bulky Setup",
+                "role": "Fast Bulky Setup",
                 "movepool": ["Dragon Dance", "Earthquake", "Ice Punch", "Stone Edge", "Wild Charge"],
                 "teraTypes": ["Grass", "Ground", "Rock"]
             }
@@ -6506,6 +6516,11 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Heat Crash", "Outrage"],
                 "teraTypes": ["Ground"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Dragon Dance", "Heat Crash", "Morning Sun", "Outrage"],
+                "teraTypes": ["Fairy"]
             }
         ]
     },
@@ -6518,7 +6533,7 @@
                 "teraTypes": ["Electric"]
             },
             {
-                "role": "Bulky Attacker",
+                "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Dragon Pulse", "Thunderbolt", "Thunderclap"],
                 "teraTypes": ["Electric", "Fairy"]
             }
@@ -6533,7 +6548,7 @@
                 "teraTypes": ["Fighting"]
             },
             {
-                "role": "Bulky Setup",
+                "role": "Fast Bulky Setup",
                 "movepool": ["Close Combat", "Mighty Cleave", "Swords Dance", "Zen Headbutt"],
                 "teraTypes": ["Fighting"]
             }

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -3785,7 +3785,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Aura Sphere", "Calm Mind", "Flash Cannon", "Focus Blast", "Vacuum Wave"],
-                "teraTypes": ["Fighting"]
+                "teraTypes": ["Ghost", "Fighting", "Water"]
             },
             {
                 "role": "Bulky Support",


### PR DESCRIPTION
In Gens 2-9, teams will no longer have multiple Pokemon 4x weak to the same type. Council decision.

**Gen 9 Random Battle**:
-Paradox Pokemon now get Booster Energy with the Fast Bulky Setup role, instead of the Bulky Setup role. All Booster Energy sets have been adjusted to the Fast Bulky Setup role. On Paradox Pokemon, this role can not generate in the lead slot. Iron Boulder and Slither Wing can now be leads. Raging Bolt's Calm Mind set is now Bulky Setup.
-Great Tusk now has a Bulky Setup set, identical to its Fast Bulky Setup Set, except it gets Leftovers instead of Booster Energy as its item and can generate in the lead slot.

-Gouging Fire now has a second set with Morning Sun instead of Earthquake, and Tera Fairy instead of Tera Ground.
-Bulk Up Grimmsnarl has been removed.
-Black Glasses has been deleted from the format.
-Scream Tail now runs a second set with Dazzling Gleam instead of Play Rough.
-Kyogre's set has been split between choiced and Calm Mind. The Calm Mind set now runs Tera Dragon/Electric/Steel.
-Pokemon with Hustle and setup now run wide lens 50% of the time. This affects Flapple and Lilligant-Hisui.

Move and Tera Type changes:
-Urshifu: +Tera Poison.
-Bulky Support Chimecho: +Dazzling Gleam, +Tera Fairy.
-Swords Dance Feraligatr: -Earthquake, +Crunch, +Tera Dark/Dragon/Steel.
-Pelipper: -Ice Beam (both sets).
-Arceus-Fire: -Liquidation, -Tera Water.
-Bulky Support Mew: +Tera Dark.
-Coalossal: +Flamethrower, roll with Overheat.
-AV Hariyama: +Stone Edge.
-Bulky Support Clodsire: +Gunk Shot, incompatible with Poison Jab.
-Setup Clodsire: +Tera Steel.
-Bulky Attacker Talonflame and Fast Attacker Charizard: -Tera Water, +Tera Dragon.
-Gogoat: +Tera Water, +Rock Slide.
-Moltres-Galar: +Tera Steel.
-Tornadus and Fast Attacker Tornadus-Therian: +Tera Fighting.
-Wallbreaker Oranguru: +Tera Normal.
-Fast Support Masquerain: +Tera Water.
-Zamazenta-Crowned: -Behemoth Bash, +Heavy Slam.
-Giratina-Origin: +Tera Fairy/Steel.
-Fast Support Garchomp: -Fire Blast.
-Calm Mind Cobalion: +Focus Blast, roll with Aura Sphere. +Tera Ghost/Water.
-Nasty Plot Lucario: -Aura Sphere. It now always runs Focus Blast.

**Gen 9 Random Doubles Battle**:
-Dragonite: -Roost.
-Clodsire's role has been changed to Doubles Bulky Attacker, ensuring that it always runs Gunk Shot.
-Mesprit: -Mystical Power.
-Arceus-Ghost now runs a Calm Mind set with Judgment, Dazzling Gleam, Focus Blast, and Recover, with Tera Fairy/Fighting.
-Terrakion: -Tera Water.
-AV Raging Bolt: -Breaking Swipe, +Electroweb, +Snarl. It always runs Thunderclap and doesn't always run Thunderbolt.
-Sets with Iron Defense now get Leftovers by default.
-Kilowattrel's ability is now always Competitive and it no longer gets Volt Absorb.

**Old Gens**:
-In Gens 4-7, Grass/Poison types no longer run HP fire and instead run HP ground or a superior Ground move.
-In Gens 5-7, Substitute users that don't have Leftovers can use Substitute 4 times from full HP without fainting.
-In Gens 5-7, Alakazam's Fast Attacker set no longer runs HP fire, ensuring that it always has Counter and Focus Sash.
-In Gens 5-7, Chansey's Bulky Support (Wish) set now runs Softboiled instead of Protect.
-In Gens 5-7, Bulk Up Scrafty always runs Drain Punch and no longer runs High Jump Kick.
-In Gens 6-7, Alakazam now has a second set with Calm Mind and Life Orb, identical to what it runs in Gen 5.
-In Gens 6-7, Noctowl no longer runs Heat Wave and instead runs Toxic.
-In Gens 6-7, Suicune no longer runs Hydro Pump and always runs Scald.
-In Gens 6-7, Beautifly now runs a fixed set of Quiver Dance, Bug Buzz, Air Cutter, and HP ground.
-In Gens 6-7, Crawdaunt can now get Aqua Jet + Dragon Dance.
-In Gens 6-7, Abomasnow and Mega Abomasnow will always have Blizzard + Ice Shard + Earthquake + a grass move. Focus Blast has been removed.
-In Gens 6-7, Speed Boost Yanmega now runs HP ground instead of Giga Drain.
-In Gens 6-7,  Dialga now always runs Fire Blast.
-In Gens 6-7, Sticky Web Leavanny now runs Toxic and no longer runs Heal Bell.
-In Gens 6-7, Dragon Dance Scrafty always has Iron Head as its 4th move. It no longer runs Ice Punch or Poison Jab.
-In Gens 6-7, AV Pivot Reuniclus has been removed.
-In Gens 6-7, Swanna no longer runs Ice Beam. It has been replaced by Toxic on the Bulky Attacker set.
-In Gens 6-7, Galvantula can no longer obtain Choice Scarf.
-In Gens 6-7, Gogoat can now run Toxic, which is a roll with Bulk Up.
-In Gens 6-7, Meowstic-F now runs Dark Pulse instead of Shadow Ball.
-In Gens 6-7, Diancie no longer runs dual screens.
-In Gens 6-7, Mega-Diancie no longer runs Hidden Power Fire and always runs Earth Power. In Gen 7, it no longer runs Power Gem and always runs Diamond Storm. In both gens, its sets have been merged, since the set splits are no longer necessary.
-In Gen 7, Bellossom's sets have been split and roles modified so that sets with coverage can now be rolled even if the team doesn't have a Z-move user. HP rock is now a possible coverage move.
-In Gen 7, Spinda no longer runs WishTect. Its sets have been merged.
-In Gen 7, Rayquaza now only runs setup sets. This ensures that it will always get Z-move user with Dragon Ascent unless the team already has a Z-move user. When the team already has a Z-move user, it will either run Swords Dance or Dragon Dance.
-In Gen 7, Lycanroc-Midnight now runs Stomping Tantrum instead of Fire Punch.
-In Gen 7, Bewear now runs Leftovers instead of Life Orb on its sets with Swords Dance. A second set has been added with Bulk Up, Drain Punch, Shadow Claw, and Return/Double-Edge.
-In Gen 7, Oranguru now runs Nature Power (Tri Attack) and Psychic.
-In Gen 7, Tapu Fini no longer runs Scald and instead runs Surf.
-In Gen 7, Kommo-o and Buzzwole now run Iron Head instead of Poison Jab.
-In Gen 7, Necrozma-Dawn-Wings now runs Signal Beam instead of Power Gem.
-In Gen 6, Ledian now runs a Staller set similar to Gen 7, but with Knock Off as its main attack.
-In Gen 6, Rayquaza now runs the same sets as in Gen 5. It runs mixed Life Orb, Choice Band, Dragon Dance and Swords Dance.

-In Gens 4-5, Venusaur no longer runs HP ice.
-In Gens 4-5, Muk always runs Brick Break. In Gen 5, Muk no longer runs Fire Punch.
-In Gens 4-5, Altaria's Bulky Support role has been changed to Bulky Attacker, to ensure it runs a coverage move.
-In Gens 4-5, Deoxys and Deoxys-Attack no longer run HP Fire.
-In Gens 4-5, Arceus-Normal now always runs Earthquake.
-In Gens 4-5, Pokemon with a pivoting move can no longer obtain Focus Sash, unless they have a hazard move.
-In Gen 5, Arbok's sets have been updated to obtain more appropriate items. It still always runs Coil, Gunk Shot, and Earthquake. It can run Glare or Sucker Punch with Life Orb, or Rest or Sucker Punch with Leftovers.
-In Gen 5, Flareon no longer runs WishTect with Lava Plume and is always Guts with Toxic Orb.
-In Gen 5, Crobat now runs Hypnosis.
-In Gen 5, Grumpig now runs a Wallbreaker set with Psychic/Psyshock, Focus Blast, Shadow Ball, Calm Mind, and Trick.
-In Gen 5, Glalie no longer runs Explosion and runs Super Fang. It will always run Earthquake.
-In Gen 5, Phione now runs a Rain Dance Hydration set with Damp Rock.
-In Gen 5, Arceus-Poison can now run a Calm Mind set.
-In Gen 5, Whimsicott's Fast Support set no longer runs Leech Seed.
-In Gen 5, Swanna's Rain Dance set no longer runs Ice Beam and always runs Rest.
-In Gen 5, Jumpluff and Crobat no longer run Infiltrator, since it is only useful for ignoring screens and there are no screen setters in the format.
-In Gen 5, Slowbro's Calm Mind set now has the Staller role, to ensure it always gets Leftovers.

-In Gen 4, Seaking now always runs Rain Dance.
-In Gen 4, Ampharos no longer runs dual screens.
-In Gen 4, Ledian's non-Baton Pass set has been modified to be a Staller set like in later generations, with HP Flying as the STAB move.
-In Gen 4, Masquerain now runs a Bulky Support set with Air Slash, Bug Buzz, Hydro Pump, Roost, Stun Spore, and Toxic.
-In Gen 4, Lunatone now runs a Bulky Support set with Psychic, Earth Power, Explosion, Stealth Rock, and Toxic.
-In Gen 4, Giratina-O no longer runs its Substitute + Calm Mind set.

-In Gen 3, Choice Band Dodrio and Fearow no longer run Baton Pass and always have Quick Attack.
-In Gen 3, Absol now runs Double-Edge on both its setup and Choice Band sets, and no longer runs Baton Pass on Choice Band.
-In Gen 3, Forretress will no longer get Choice Band. This is done via a set split ensuring it always has a status move.
-In Gen 3, Linoone's Bulky Setup set will always have HP ground.
-In Gen 3, Milotic no longer runs a RestTalk set. 
-In Gen 3, Tropius no longer runs Sunny Day; the set has been replaced by Swords Dance.
-In Gen 3, Xatu's ability is now always Synchronize.