### PR TITLE
Unban Battle Bond from Gen 9 National Dex UU

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2282,7 +2282,7 @@ export const Formats: FormatList = [
 
 		mod: 'gen9',
 		ruleset: ['[Gen 9] National Dex', 'Terastal Clause'],
-		banlist: ['ND OU', 'ND UUBL', 'Battle Bond', 'Drizzle', 'Drought', 'Light Clay'],
+		banlist: ['ND OU', 'ND UUBL', 'Drizzle', 'Drought', 'Light Clay'],
 	},
 	{
 		name: "[Gen 9] National Dex RU",


### PR DESCRIPTION
Battle Bond was banned as a temporary fix to an issue where Battle Bond Greninja was able to circumvent Greninja's ban with no way to fix it other than this. Greninja is unbanned so this point is now moot.