### PR TITLE
Add Paradox Pokemon tags

### DIFF
--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -18344,6 +18344,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 3.5,
 		weightkg: 590,
 		color: "Brown",
+		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	ragingbolt: {
@@ -18356,6 +18357,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 5.2,
 		weightkg: 480,
 		color: "Yellow",
+		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	ironboulder: {
@@ -18368,6 +18370,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 1.5,
 		weightkg: 162.5,
 		color: "Gray",
+		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	ironcrown: {
@@ -18380,6 +18383,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		heightm: 1.6,
 		weightkg: 156,
 		color: "Blue",
+		tags: ["Paradox"],
 		eggGroups: ["Undiscovered"],
 	},
 	terapagos: {


### PR DESCRIPTION
Tags for the most recently added Paradox Pokemon were not added, and caused issues such as Trick taking away Booster Energy for example.