### PR TITLE
Fix uploading public replays on side servers

### DIFF
--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -2084,7 +2084,7 @@ export class GameRoom extends BasicRoom {
 			players: battle.players.map(p => p.name).join(','),
 			format: format.name,
 			rating, // will probably do nothing
-			hidden,
+			hidden: hidden === 0 ? '' : hidden,
 			inputlog: battle.inputLog?.join('\n') || undefined,
 			password,
 		});


### PR DESCRIPTION
A regression(?) was caused in the commit 6b42b4f6b2d6369b19a265f36bdd9061734407d5, which started sending `'0'` instead of `''` for public replays. This would get evaluated as a truthy value on the loginserver side, which caused all public replays to become private upon uploading.