### PR TITLE
Fix species validation check for Let's Go Megas

### DIFF
--- a/data/mods/gen7letsgo/scripts.ts
+++ b/data/mods/gen7letsgo/scripts.ts
@@ -1,3 +1,15 @@
+function checkMegaForme(this: BattleActions, species: Species, forme: string) {
+	const baseSpecies = this.dex.species.get(species.baseSpecies);
+	const altForme = this.dex.species.get(`${baseSpecies.name}-${forme}`);
+	if (
+		altForme.exists && !this.battle.ruleTable.isBannedSpecies(altForme) &&
+		!this.battle.ruleTable.isBanned('pokemontag:mega')
+	) {
+		return altForme.name;
+	}
+	return null;
+}
+
 export const Scripts: ModdedBattleScriptsData = {
 	inherit: 'gen7',
 	init() {
@@ -9,37 +21,13 @@ export const Scripts: ModdedBattleScriptsData = {
 	},
 	actions: {
 		canMegaEvo(pokemon) {
-			const species = pokemon.baseSpecies;
-			const altForme = this.dex.species.get(species.otherFormes?.find(f => f.endsWith('-Mega')));
-			if (
-				altForme.exists && !this.battle.ruleTable.check(`pokemon:${altForme.id}`) &&
-				!this.battle.ruleTable.check('pokemontag:mega')
-			) {
-				return altForme.name;
-			}
-			return null;
+			return checkMegaForme.call(this, pokemon.baseSpecies, 'Mega');
 		},
 		canMegaEvoX(pokemon) {
-			const species = pokemon.baseSpecies;
-			const altForme = this.dex.species.get(species.otherFormes?.find(f => f.endsWith('-Mega-X')));
-			if (
-				altForme.exists && !this.battle.ruleTable.check(`pokemon:${altForme.id}`) &&
-				!this.battle.ruleTable.check('pokemontag:mega')
-			) {
-				return altForme.name;
-			}
-			return null;
+			return checkMegaForme.call(this, pokemon.baseSpecies, 'Mega-X');
 		},
 		canMegaEvoY(pokemon) {
-			const species = pokemon.baseSpecies;
-			const altForme = this.dex.species.get(species.otherFormes?.find(f => f.endsWith('-Mega-Y')));
-			if (
-				altForme.exists && !this.battle.ruleTable.check(`pokemon:${altForme.id}`) &&
-				!this.battle.ruleTable.check('pokemontag:mega')
-			) {
-				return altForme.name;
-			}
-			return null;
+			return checkMegaForme.call(this, pokemon.baseSpecies, 'Mega-Y');
 		},
 		runMegaEvo(pokemon) {
 			const speciesid = pokemon.canMegaEvo || pokemon.canMegaEvoX || pokemon.canMegaEvoY;

--- a/data/mods/gen7letsgo/scripts.ts
+++ b/data/mods/gen7letsgo/scripts.ts
@@ -1,9 +1,9 @@
-function checkMegaForme(this: BattleActions, species: Species, forme: string) {
-	const baseSpecies = this.dex.species.get(species.baseSpecies);
-	const altForme = this.dex.species.get(`${baseSpecies.name}-${forme}`);
+function checkMegaForme(species: Species, forme: string, battle: Battle) {
+	const baseSpecies = battle.dex.species.get(species.baseSpecies);
+	const altForme = battle.dex.species.get(`${baseSpecies.name}-${forme}`);
 	if (
-		altForme.exists && !this.battle.ruleTable.isBannedSpecies(altForme) &&
-		!this.battle.ruleTable.isBanned('pokemontag:mega')
+		altForme.exists && !battle.ruleTable.isBannedSpecies(altForme) &&
+		!battle.ruleTable.isBanned('pokemontag:mega')
 	) {
 		return altForme.name;
 	}
@@ -21,13 +21,13 @@ export const Scripts: ModdedBattleScriptsData = {
 	},
 	actions: {
 		canMegaEvo(pokemon) {
-			return checkMegaForme.call(this, pokemon.baseSpecies, 'Mega');
+			return checkMegaForme(pokemon.baseSpecies, 'Mega', this.battle);
 		},
 		canMegaEvoX(pokemon) {
-			return checkMegaForme.call(this, pokemon.baseSpecies, 'Mega-X');
+			return checkMegaForme(pokemon.baseSpecies, 'Mega-X', this.battle);
 		},
 		canMegaEvoY(pokemon) {
-			return checkMegaForme.call(this, pokemon.baseSpecies, 'Mega-Y');
+			return checkMegaForme(pokemon.baseSpecies, 'Mega-Y', this.battle);
 		},
 		runMegaEvo(pokemon) {
 			const speciesid = pokemon.canMegaEvo || pokemon.canMegaEvoX || pokemon.canMegaEvoY;


### PR DESCRIPTION
Forgot to account for tags. Right now if you were to challenge someone with `gen7letsgoou @@@ -ou` you would still be able to mega evolve into Zard X.