### PR TITLE
Randomized format set updates

### DIFF
--- a/data/mods/gen1/random-data.json
+++ b/data/mods/gen1/random-data.json
@@ -9,8 +9,8 @@
     },
     "venusaur": {
         "level": 74,
-        "moves": ["hyperbeam", "sleeppowder", "swordsdance"],
-        "essentialMoves": ["bodyslam", "razorleaf"]
+        "moves": ["bodyslam", "razorleaf", "sleeppowder"],
+        "exclusiveMoves": ["hyperbeam", "swordsdance", "swordsdance"]
     },
     "charmander": {
         "level": 90,
@@ -340,8 +340,8 @@
     },
     "victreebel": {
         "level": 74,
-        "moves": ["bodyslam", "razorleaf", "sleeppowder", "stunspore"],
-        "comboMoves": ["bodyslam", "hyperbeam", "razorleaf", "swordsdance"]
+        "moves": ["bodyslam", "razorleaf", "sleeppowder"],
+        "exclusiveMoves": ["hyperbeam", "stunspore", "stunspore", "stunspore", "swordsdance", "swordsdance"]
     },
     "tentacool": {
         "level": 86,

--- a/data/mods/gen3/random-sets.json
+++ b/data/mods/gen3/random-sets.json
@@ -1119,7 +1119,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["brickbreak", "doubleedge", "encore", "hiddenpowerghost", "hydropump", "rest", "return", "sleeptalk"],
+                "movepool": ["brickbreak", "doubleedge", "hiddenpowerghost", "hydropump", "rest", "return", "sleeptalk"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -1185,6 +1185,10 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["hiddenpowerfire", "leechseed", "razorleaf", "synthesis", "toxic"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["hiddenpowerfire", "solarbeam", "sunnyday", "synthesis"]
             }
         ]
     },
@@ -1479,7 +1483,11 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["fireblast", "hiddenpowergrass", "rest", "sleeptalk", "toxic"]
+                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "rest", "sleeptalk", "toxic"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["fireblast", "flamethrower", "hiddenpowergrass", "protect", "toxic"]
             }
         ]
     },
@@ -1564,11 +1572,11 @@
         "sets": [
             {
                 "role": "Berry Sweeper",
-                "movepool": ["crunch", "fireblast", "flamethrower", "hiddenpowergrass", "substitute"]
+                "movepool": ["crunch", "fireblast", "hiddenpowergrass", "substitute"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["crunch", "fireblast", "flamethrower", "hiddenpowergrass", "pursuit", "willowisp"]
+                "movepool": ["crunch", "fireblast", "hiddenpowergrass", "pursuit", "willowisp"]
             }
         ]
     },

--- a/data/mods/gen4/random-sets.json
+++ b/data/mods/gen4/random-sets.json
@@ -256,7 +256,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "encore", "icepunch", "stoneedge", "uturn"]
+                "movepool": ["closecombat", "earthquake", "encore", "stoneedge", "uturn"],
+                "preferredTypes": ["Rock"]
             }
         ]
     },
@@ -307,7 +308,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bulkup", "bulletpunch", "dynamicpunch", "icepunch", "payback", "stoneedge"]
+                "movepool": ["bulkup", "bulletpunch", "dynamicpunch", "payback", "stoneedge"]
             }
         ]
     },
@@ -391,8 +392,8 @@
         "level": 91,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["icebeam", "protect", "rest", "sleeptalk", "surf", "toxic"]
+                "role": "Staller",
+                "movepool": ["icebeam", "protect", "surf", "toxic"]
             },
             {
                 "role": "Fast Attacker",
@@ -870,7 +871,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["nightshade", "roost", "toxic", "whirlwind"]
+                "movepool": ["airslash", "nightshade", "roost", "toxic", "whirlwind"]
             }
         ]
     },
@@ -1356,8 +1357,11 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "flareblitz", "hiddenpowergrass", "ironhead", "stoneedge"],
-                "preferredTypes": ["Normal"]
+                "movepool": ["extremespeed", "flareblitz", "ironhead", "stoneedge"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["extremespeed", "flareblitz", "hiddenpowergrass", "stoneedge"]
             }
         ]
     },
@@ -1419,7 +1423,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "leafstorm", "psychic", "recover", "stealthrock", "thunderwave", "uturn"]
+                "movepool": ["leafstorm", "psychic", "recover", "stealthrock", "thunderwave", "uturn"]
             },
             {
                 "role": "Setup Sweeper",
@@ -1474,9 +1478,8 @@
         "level": 93,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["crunch", "doubleedge", "firefang", "suckerpunch", "superfang", "taunt", "toxic"],
-                "preferredTypes": ["Fire"]
+                "role": "Bulky Support",
+                "movepool": ["crunch", "doubleedge", "firefang", "suckerpunch", "superfang", "taunt", "toxic"]
             }
         ]
     },
@@ -1614,8 +1617,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["doubleedge", "earthquake", "firepunch", "gigaimpact", "nightslash", "return"],
-                "preferredTypes": ["Ground"]
+                "movepool": ["doubleedge", "earthquake", "gigaimpact", "nightslash", "return"]
             }
         ]
     },
@@ -1680,10 +1682,6 @@
     "sableye": {
         "level": 99,
         "sets": [
-            {
-                "role": "Bulky Support",
-                "movepool": ["recover", "seismictoss", "taunt", "toxic", "willowisp"]
-            },
             {
                 "role": "Bulky Attacker",
                 "movepool": ["payback", "recover", "seismictoss", "toxic", "willowisp"]
@@ -2505,7 +2503,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["attackorder", "defendorder", "roost", "substitute", "toxic", "uturn"]
+                "movepool": ["hiddenpowerflying", "roost", "toxic", "uturn"]
             }
         ]
     },
@@ -2540,17 +2538,8 @@
         "level": 96,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["aromatherapy", "energyball", "hiddenpowerfire", "hiddenpowerground", "hiddenpowerrock", "synthesis", "toxic"]
-            }
-        ]
-    },
-    "cherrimsunshine": {
-        "level": 96,
-        "sets": [
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["hiddenpowerice", "solarbeam", "sunnyday", "weatherball"]
+                "role": "Staller",
+                "movepool": ["aromatherapy", "energyball", "hiddenpowerground", "leechseed", "synthesis", "toxic"]
             }
         ]
     },

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -506,6 +506,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 		if (species.id === 'jynx') return 'Forewarn';
 		if (species.id === 'arcanine') return 'Intimidate';
 		if (species.id === 'blissey') return 'Natural Cure';
+		if (species.id === 'octillery') return 'Sniper';
 		if (species.id === 'yanmega') return (role === 'Fast Attacker') ? 'Speed Boost' : 'Tinted Lens';
 		if (species.id === 'absol') return 'Super Luck';
 		if (species.id === 'lanturn') return 'Volt Absorb';

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -277,7 +277,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "honeclaws", "icepunch", "stoneedge", "uturn"]
+                "movepool": ["closecombat", "earthquake", "honeclaws", "stoneedge", "uturn"]
             }
         ]
     },
@@ -327,7 +327,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bulkup", "bulletpunch", "dynamicpunch", "icepunch", "payback", "stoneedge"],
+                "movepool": ["bulkup", "bulletpunch", "dynamicpunch", "payback", "stoneedge"],
                 "preferredTypes": ["Rock"]
             }
         ]
@@ -554,7 +554,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "megahorn", "stealthrock", "stoneedge", "toxic"]
+                "movepool": ["earthquake", "megahorn", "stealthrock", "stoneedge", "swordsdance", "toxic"]
             }
         ]
     },
@@ -1359,7 +1359,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "earthquake", "jumpkick", "megahorn", "suckerpunch"]
+                "movepool": ["doubleedge", "earthquake", "hypnosis", "jumpkick", "megahorn", "suckerpunch", "thunderwave"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -1426,8 +1427,11 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["bulldoze", "extremespeed", "flareblitz", "hiddenpowergrass", "stoneedge"],
-                "preferredTypes": ["Normal"]
+                "movepool": ["bulldoze", "extremespeed", "flareblitz", "stoneedge"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["extremespeed", "flareblitz", "hiddenpowergrass", "stoneedge"]
             }
         ]
     },
@@ -1489,7 +1493,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "leafstorm", "psychic", "recover", "stealthrock", "thunderwave", "uturn"]
+                "movepool": ["leafstorm", "psychic", "recover", "stealthrock", "thunderwave", "uturn"]
             },
             {
                 "role": "Bulky Setup",
@@ -1672,8 +1676,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "firepunch", "gigaimpact", "nightslash", "retaliate"],
-                "preferredTypes": ["Ground"]
+                "movepool": ["earthquake", "gigaimpact", "nightslash", "retaliate"]
             }
         ]
     },
@@ -1864,7 +1867,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "hiddenpowergrass", "lavaplume", "roar", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "lavaplume", "roar", "stealthrock", "toxic"]
             }
         ]
     },
@@ -1895,7 +1898,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["icepunch", "rapidspin", "return", "suckerpunch", "superpower"],
+                "movepool": ["feintattack", "rapidspin", "return", "suckerpunch", "superpower"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -3043,7 +3046,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["hiddenpowerfire", "hiddenpowerice", "leafstorm", "painsplit", "thunderbolt", "thunderwave", "trick", "voltswitch", "willowisp"]
+                "movepool": ["hiddenpowerice", "leafstorm", "painsplit", "thunderbolt", "thunderwave", "trick", "voltswitch", "willowisp"]
             }
         ]
     },
@@ -3480,7 +3483,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["crunch", "return", "superpower", "thunderwave", "wildcharge"]
+                "movepool": ["crunch", "return", "superpower", "thunderwave", "wildcharge"],
+                "preferredTypes": ["Fighting"]
             }
         ]
     },
@@ -3717,7 +3721,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["gigadrain", "hiddenpowerfire", "spikes", "suckerpunch", "toxic"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "spikes", "suckerpunch", "synthesis", "toxic"]
             },
             {
                 "role": "Staller",
@@ -4343,14 +4347,9 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["calmmind", "focusblast", "hypervoice", "psyshock", "uturn"]
-            }
-        ]
-    },
-    "meloettapirouette": {
-        "level": 80,
-        "sets": [
+            },
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["closecombat", "relicsong", "return", "shadowclaw"]
             }
         ]

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -502,7 +502,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			return !counter.get('inaccurate');
 		case 'Contrary': case 'Skill Link':
 			return !counter.get(toID(ability));
-		case 'Defiant': case 'Justified': case 'Moxie':
+		case 'Defiant': case 'Justified':
 			return !counter.get('Physical');
 		case 'Guts':
 			return (!moves.has('facade') && !moves.has('sleeptalk'));
@@ -524,6 +524,8 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			return (abilities.has('Tinted Lens') && role === 'Wallbreaker');
 		case 'Mold Breaker':
 			return (species.baseSpecies === 'Basculin' || species.id === 'rampardos');
+		case 'Moxie':
+			return (!counter.get('Physical') || moves.has('stealthrock'));
 		case 'Overgrow':
 			return !counter.get('Grass');
 		case 'Prankster':
@@ -605,6 +607,8 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';
 		if (['spiritomb', 'vespiquen', 'weavile'].includes(species.id)) return 'Pressure';
 		if (species.id === 'druddigon') return 'Rough Skin';
+		if (species.id === 'stoutland') return 'Scrappy';
+		if (species.id === 'octillery') return 'Sniper';
 		if (species.id === 'stunfisk') return 'Static';
 		if (species.id === 'zangoose') return 'Toxic Boost';
 		if (species.id === 'porygon2' || species.id === 'gardevoir') return 'Trace';
@@ -881,11 +885,11 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		if (['highjumpkick', 'jumpkick'].some(m => moves.has(m))) srWeakness = 2;
 		while (evs.hp > 1) {
 			const hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
-			if (moves.has('substitute')) {
+			if (moves.has('substitute') && !['Black Sludge', 'Leftovers'].includes(item)) {
 				if (item === 'Sitrus Berry') {
 					// Two Substitutes should activate Sitrus Berry
 					if (hp % 4 === 0) break;
-				} else if (!['Black Sludge', 'Leftovers'].includes(item)) {
+				} else {
 					// Should be able to use Substitute four times from full HP without fainting
 					if (hp % 4 > 0) break;
 				}

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -1560,7 +1560,7 @@
         ]
     },
     "entei": {
-        "level": 80,
+        "level": 78,
         "sets": [
             {
                 "role": "Wallbreaker",
@@ -3332,7 +3332,7 @@
         ]
     },
     "mamoswine": {
-        "level": 80,
+        "level": 78,
         "sets": [
             {
                 "role": "Wallbreaker",

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -1722,8 +1722,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["crunch", "irontail", "playrough", "suckerpunch"],
-                "preferredTypes": ["Fairy"]
+                "movepool": ["crunch", "irontail", "playrough", "suckerpunch"]
             }
         ]
     },

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -44,7 +44,11 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "fireblast", "focusblast", "roost", "solarbeam"]
+                "movepool": ["airslash", "fireblast", "roost", "solarbeam"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["dragonpulse", "fireblast", "roost", "solarbeam"]
             }
         ]
     },
@@ -298,7 +302,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "gunkshot", "honeclaws", "icepunch", "stoneedge", "uturn"]
+                "movepool": ["closecombat", "earthquake", "gunkshot", "honeclaws", "stoneedge", "uturn"]
             }
         ]
     },
@@ -321,7 +325,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "hydropump", "icepunch", "raindance"]
+                "movepool": ["focusblast", "icepunch", "raindance", "waterfall"]
             },
             {
                 "role": "Bulky Attacker",
@@ -363,8 +367,7 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["bulletpunch", "dynamicpunch", "icepunch", "knockoff", "stoneedge"],
-                "preferredTypes": ["Dark"]
+                "movepool": ["bulletpunch", "dynamicpunch", "knockoff", "stoneedge"]
             }
         ]
     },
@@ -608,7 +611,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "megahorn", "stealthrock", "stoneedge", "toxic"]
+                "movepool": ["earthquake", "megahorn", "stealthrock", "stoneedge", "swordsdance", "toxic"]
             }
         ]
     },
@@ -824,7 +827,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthpower", "hydropump", "icebeam", "shellsmash"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"]
             }
         ]
     },
@@ -870,7 +873,7 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["bodyslam", "crunch", "earthquake", "firepunch", "pursuit"]
+                "movepool": ["bodyslam", "crunch", "earthquake", "pursuit"]
             }
         ]
     },
@@ -1493,7 +1496,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "earthquake", "jumpkick", "megahorn", "suckerpunch"]
+                "movepool": ["doubleedge", "earthquake", "jumpkick", "megahorn", "suckerpunch", "thunderwave"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -1556,12 +1560,15 @@
         ]
     },
     "entei": {
-        "level": 78,
+        "level": 80,
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["bulldoze", "extremespeed", "flareblitz", "sacredfire", "stoneedge"],
-                "preferredTypes": ["Normal"]
+                "movepool": ["bulldoze", "extremespeed", "flareblitz", "sacredfire"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["extremespeed", "flareblitz", "sacredfire", "stoneedge"]
             }
         ]
     },
@@ -1632,7 +1639,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "leafstorm", "psychic", "recover", "stealthrock", "thunderwave", "uturn"]
+                "movepool": ["leafstorm", "psychic", "recover", "stealthrock", "thunderwave", "uturn"]
             },
             {
                 "role": "Bulky Setup",
@@ -1715,7 +1722,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["crunch", "firefang", "irontail", "playrough", "suckerpunch"],
+                "movepool": ["crunch", "irontail", "playrough", "suckerpunch"],
                 "preferredTypes": ["Fairy"]
             }
         ]
@@ -1781,7 +1788,7 @@
         "level": 83,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Fast Attacker",
                 "movepool": ["bravebird", "facade", "protect", "quickattack", "uturn"]
             }
         ]
@@ -1861,8 +1868,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "firepunch", "gigaimpact", "nightslash", "retaliate"],
-                "preferredTypes": ["Ground"]
+                "movepool": ["earthquake", "gigaimpact", "nightslash", "retaliate"]
             }
         ]
     },
@@ -1898,7 +1904,7 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["bulletpunch", "closecombat", "heavyslam", "icepunch", "knockoff", "stoneedge"],
+                "movepool": ["bulletpunch", "closecombat", "heavyslam", "knockoff", "stoneedge"],
                 "preferredTypes": ["Dark"]
             },
             {
@@ -2099,7 +2105,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "fireblast", "hiddenpowergrass", "rockpolish", "stoneedge"]
+                "movepool": ["earthquake", "fireblast", "rockpolish", "stoneedge"]
             },
             {
                 "role": "Bulky Support",
@@ -2139,7 +2145,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icepunch", "rest", "return", "sleeptalk", "suckerpunch", "superpower"],
+                "movepool": ["feintattack", "rest", "return", "sleeptalk", "suckerpunch", "superpower"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -2200,7 +2206,7 @@
         "level": 85,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Fast Attacker",
                 "movepool": ["closecombat", "facade", "knockoff", "quickattack", "swordsdance"],
                 "preferredTypes": ["Dark"]
             }
@@ -2252,7 +2258,7 @@
         "level": 83,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Fast Attacker",
                 "movepool": ["aquajet", "crabhammer", "dragondance", "knockoff", "superpower"]
             },
             {
@@ -2394,7 +2400,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "explosion", "freezedry", "spikes", "superfang", "taunt"]
+                "movepool": ["earthquake", "freezedry", "spikes", "superfang", "taunt"]
             }
         ]
     },
@@ -2402,7 +2408,7 @@
         "level": 82,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Fast Attacker",
                 "movepool": ["earthquake", "explosion", "freezedry", "iceshard", "return", "spikes"],
                 "preferredTypes": ["Ground"]
             }
@@ -2727,11 +2733,11 @@
         "level": 80,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Fast Attacker",
                 "movepool": ["closecombat", "grassknot", "machpunch", "overheat", "stealthrock"]
             },
             {
-                "role": "Fast Attacker",
+                "role": "Fast Support",
                 "movepool": ["closecombat", "flareblitz", "machpunch", "stoneedge", "swordsdance", "uturn"]
             }
         ]
@@ -2893,7 +2899,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquajet", "bulkup", "icepunch", "lowkick", "substitute", "taunt", "waterfall"],
+                "movepool": ["aquajet", "bulkup", "icepunch", "lowkick", "substitute", "waterfall"],
                 "preferredTypes": ["Ice"]
             },
             {
@@ -3326,15 +3332,11 @@
         ]
     },
     "mamoswine": {
-        "level": 78,
+        "level": 80,
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "iceshard", "iciclecrash", "stealthrock"]
-            },
-            {
-                "role": "Fast Attacker",
-                "movepool": ["earthquake", "iceshard", "iciclecrash", "knockoff", "superpower"]
+                "movepool": ["earthquake", "iceshard", "iciclecrash", "knockoff", "stealthrock"]
             }
         ]
     },
@@ -3520,8 +3522,9 @@
         "level": 82,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["drainpunch", "knockoff", "return", "substitute", "thunderwave"]
+                "role": "Bulky Attacker",
+                "movepool": ["drainpunch", "knockoff", "return", "substitute", "thunderwave"],
+                "preferredTypes": ["Dark"]
             }
         ]
     },
@@ -3816,7 +3819,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "defog", "icebeam", "judgment", "recover", "toxic", "willowisp"]
+                "movepool": ["calmmind", "icebeam", "judgment", "recover", "toxic", "willowisp"]
             }
         ]
     },
@@ -3829,7 +3832,8 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["boltstrike", "energyball", "focusblast", "psychic", "uturn", "vcreate"]
+                "movepool": ["boltstrike", "energyball", "focusblast", "glaciate", "psychic", "uturn", "vcreate"],
+                "preferredTypes": ["Electric"]
             }
         ]
     },
@@ -3851,7 +3855,7 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["fireblast", "grassknot", "suckerpunch", "superpower", "wildcharge"]
+                "movepool": ["flareblitz", "grassknot", "suckerpunch", "superpower", "wildcharge"]
             }
         ]
     },
@@ -4061,7 +4065,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulkup", "closecombat", "earthquake", "icepunch", "knockoff", "poisonjab", "stoneedge"],
+                "movepool": ["bulkup", "closecombat", "earthquake", "knockoff", "poisonjab", "stoneedge"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -4146,7 +4150,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["gigadrain", "hiddenpowerfire", "knockoff", "spikes", "suckerpunch", "toxic"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "knockoff", "spikes", "suckerpunch", "synthesis", "toxic"]
             },
             {
                 "role": "Staller",
@@ -4788,14 +4792,9 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["calmmind", "focusblast", "hypervoice", "psyshock", "uturn"]
-            }
-        ]
-    },
-    "meloettapirouette": {
-        "level": 82,
-        "sets": [
+            },
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["closecombat", "knockoff", "relicsong", "return"]
             }
         ]
@@ -4968,7 +4967,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "darkpulse", "energyball", "psychic", "psyshock", "signalbeam", "thunderbolt"]
+                "movepool": ["calmmind", "darkpulse", "psychic", "psyshock", "signalbeam", "thunderbolt"]
             }
         ]
     },
@@ -5048,7 +5047,11 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "focusblast", "hiddenpowerfire", "scald", "sludgewave", "toxicspikes"]
+                "movepool": ["dracometeor", "focusblast", "sludgewave", "toxicspikes"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["dracometeor", "dragonpulse", "focusblast", "sludgewave"]
             }
         ]
     },
@@ -5287,7 +5290,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["drainpunch", "gunkshot", "hyperspacefury", "icepunch", "trick", "zenheadbutt"],
+                "movepool": ["drainpunch", "gunkshot", "hyperspacefury", "trick", "zenheadbutt"],
                 "preferredTypes": ["Psychic"]
             },
             {

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -352,7 +352,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		}
 
 		// Enforce STAB priority
-		if (['Bulky Attacker', 'Bulky Setup'].includes(role) || this.priorityPokemon.includes(species.id)) {
+		if (['Bulky Attacker', 'Bulky Setup', 'Wallbreaker'].includes(role) || this.priorityPokemon.includes(species.id)) {
 			const priorityMoves = [];
 			for (const moveid of movePool) {
 				const move = this.dex.moves.get(moveid);
@@ -544,7 +544,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			return !counter.get('inaccurate');
 		case 'Contrary': case 'Skill Link': case 'Strong Jaw':
 			return !counter.get(toID(ability));
-		case 'Defiant': case 'Justified': case 'Moxie':
+		case 'Defiant': case 'Justified':
 			return !counter.get('Physical');
 		case 'Guts':
 			return (!moves.has('facade') && !moves.has('sleeptalk'));
@@ -566,6 +566,8 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			return (abilities.has('Tinted Lens') && role === 'Wallbreaker');
 		case 'Mold Breaker':
 			return (species.baseSpecies === 'Basculin' || species.id === 'pangoro' || abilities.has('Sheer Force'));
+		case 'Moxie':
+			return (!counter.get('Physical') || moves.has('stealthrock') || (!!species.isMega && abilities.has('Intimidate')));
 		case 'Oblivious': case 'Prankster':
 			return (!counter.get('Status') || (species.id === 'tornadus' && moves.has('bulkup')));
 		case 'Overcoat':
@@ -655,14 +657,14 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (species.id === 'muk') return 'Poison Touch';
 		if (['dusknoir', 'vespiquen'].includes(species.id)) return 'Pressure';
 		if (species.id === 'druddigon' && role === 'Bulky Support') return 'Rough Skin';
-		if (species.id === 'pangoro' && !counter.get('ironfist')) return 'Scrappy';
+		if (species.id === 'stoutland' || species.id === 'pangoro' && !counter.get('ironfist')) return 'Scrappy';
+		if (species.id === 'octillery') return 'Sniper';
 		if (species.id === 'stunfisk') return 'Static';
 		if (species.id === 'breloom') return 'Technician';
 		if (species.id === 'zangoose') return 'Toxic Boost';
 		if (species.id === 'porygon2' || species.id === 'gardevoir') return 'Trace';
 
 		if (abilities.has('Harvest') && (role === 'Bulky Support' || role === 'Staller')) return 'Harvest';
-		if (abilities.has('Moxie') && (counter.get('Physical') > 3)) return 'Moxie';
 		if (abilities.has('Regenerator') && role === 'AV Pivot') return 'Regenerator';
 		if (abilities.has('Shed Skin') && moves.has('rest') && !moves.has('sleeptalk')) return 'Shed Skin';
 		if (abilities.has('Sniper') && moves.has('focusenergy')) return 'Sniper';
@@ -939,11 +941,11 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (['highjumpkick', 'jumpkick'].some(m => moves.has(m))) srWeakness = 2;
 		while (evs.hp > 1) {
 			const hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
-			if (moves.has('substitute')) {
+			if (moves.has('substitute') && !['Black Sludge', 'Leftovers'].includes(item)) {
 				if (item === 'Sitrus Berry') {
 					// Two Substitutes should activate Sitrus Berry
 					if (hp % 4 === 0) break;
-				} else if (!['Black Sludge', 'Leftovers'].includes(item)) {
+				} else {
 					// Should be able to use Substitute four times from full HP without fainting
 					if (hp % 4 > 0) break;
 				}

--- a/data/mods/gen7/abilities.ts
+++ b/data/mods/gen7/abilities.ts
@@ -35,10 +35,6 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		rating: 1,
 		onTryBoost() {},
 	},
-	intimidate: {
-		inherit: true,
-		rating: 4,
-	},
 	moody: {
 		inherit: true,
 		onResidual(pokemon) {

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -1886,8 +1886,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["crunch", "irontail", "playrough", "suckerpunch"],
-                "preferredTypes": ["Fairy"]
+                "movepool": ["crunch", "irontail", "playrough", "suckerpunch"]
             }
         ]
     },

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -45,7 +45,11 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["airslash", "fireblast", "focusblast", "roost", "solarbeam"]
+                "movepool": ["airslash", "fireblast", "roost", "solarbeam"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["dragonpulse", "fireblast", "roost", "solarbeam"]
             }
         ]
     },
@@ -382,7 +386,12 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "gunkshot", "honeclaws", "icepunch", "stoneedge", "throatchop", "uturn"]
+                "movepool": ["closecombat", "earthquake", "gunkshot", "stoneedge", "throatchop", "uturn"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["closecombat", "earthquake", "gunkshot", "honeclaws", "stoneedge", "throatchop"],
+                "preferredTypes": ["Rock"]
             }
         ]
     },
@@ -405,7 +414,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "hydropump", "icepunch", "raindance"]
+                "movepool": ["focusblast", "icepunch", "raindance", "waterfall"]
             },
             {
                 "role": "Bulky Attacker",
@@ -447,8 +456,7 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["bulletpunch", "dynamicpunch", "icepunch", "knockoff", "stoneedge"],
-                "preferredTypes": ["Dark"]
+                "movepool": ["bulletpunch", "dynamicpunch", "knockoff", "stoneedge"]
             },
             {
                 "role": "Wallbreaker",
@@ -752,7 +760,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "megahorn", "stealthrock", "stoneedge", "toxic"]
+                "movepool": ["earthquake", "megahorn", "stealthrock", "stoneedge", "swordsdance", "toxic"]
             }
         ]
     },
@@ -761,7 +769,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "toxic"]
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"]
             },
             {
                 "role": "Bulky Support",
@@ -973,7 +981,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["earthpower", "hydropump", "icebeam", "shellsmash"]
+                "movepool": ["hiddenpowergrass", "hydropump", "icebeam", "shellsmash"]
             }
         ]
     },
@@ -1024,7 +1032,7 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["bodyslam", "crunch", "earthquake", "firepunch", "pursuit", "return"]
+                "movepool": ["bodyslam", "crunch", "earthquake", "pursuit", "return"]
             },
             {
                 "role": "Bulky Setup",
@@ -1651,7 +1659,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "earthquake", "jumpkick", "megahorn", "suckerpunch"]
+                "movepool": ["doubleedge", "earthquake", "jumpkick", "megahorn", "suckerpunch", "throatchop"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -1691,7 +1700,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "toxic"]
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"]
             },
             {
                 "role": "Bulky Support",
@@ -1718,8 +1727,11 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "flareblitz", "sacredfire", "stompingtantrum", "stoneedge"],
-                "preferredTypes": ["Normal"]
+                "movepool": ["extremespeed", "flareblitz", "sacredfire", "stompingtantrum"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["extremespeed", "flareblitz", "sacredfire", "stoneedge"]
             }
         ]
     },
@@ -1790,7 +1802,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "leafstorm", "psychic", "recover", "stealthrock", "thunderwave", "uturn"]
+                "movepool": ["leafstorm", "psychic", "recover", "stealthrock", "thunderwave", "uturn"]
             },
             {
                 "role": "Z-Move user",
@@ -1874,7 +1886,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["crunch", "firefang", "irontail", "playrough", "suckerpunch"],
+                "movepool": ["crunch", "irontail", "playrough", "suckerpunch"],
                 "preferredTypes": ["Fairy"]
             }
         ]
@@ -1940,11 +1952,11 @@
         "level": 83,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Fast Attacker",
                 "movepool": ["bravebird", "facade", "protect", "quickattack", "uturn"]
             },
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["boomburst", "heatwave", "hurricane", "uturn"]
             }
         ]
@@ -2024,8 +2036,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthquake", "firepunch", "gigaimpact", "nightslash", "retaliate"],
-                "preferredTypes": ["Ground"]
+                "movepool": ["earthquake", "gigaimpact", "nightslash", "retaliate"]
             }
         ]
     },
@@ -2066,7 +2077,7 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["bulletpunch", "closecombat", "heavyslam", "icepunch", "knockoff", "stoneedge"],
+                "movepool": ["bulletpunch", "closecombat", "heavyslam", "knockoff", "stoneedge"],
                 "preferredTypes": ["Dark"]
             },
             {
@@ -2081,7 +2092,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["doubleedge", "fakeout", "healbell", "stompingtantrum", "suckerpunch", "thunderwave", "toxic"]
+                "movepool": ["doubleedge", "fakeout", "healbell", "shadowball", "stompingtantrum", "thunderwave", "toxic"]
             }
         ]
     },
@@ -2263,7 +2274,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "fireblast", "hiddenpowergrass", "rockpolish", "stoneedge"]
+                "movepool": ["earthquake", "fireblast", "rockpolish", "stoneedge"]
             },
             {
                 "role": "Bulky Support",
@@ -2303,7 +2314,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["icepunch", "rest", "return", "sleeptalk", "suckerpunch", "superpower"],
+                "movepool": ["feintattack", "rest", "return", "sleeptalk", "suckerpunch", "superpower"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -2365,7 +2376,7 @@
         "level": 87,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Fast Attacker",
                 "movepool": ["closecombat", "facade", "knockoff", "quickattack", "swordsdance"],
                 "preferredTypes": ["Dark"]
             }
@@ -2421,7 +2432,7 @@
         "level": 85,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Fast Attacker",
                 "movepool": ["aquajet", "crabhammer", "dragondance", "knockoff", "superpower"]
             },
             {
@@ -2563,7 +2574,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "explosion", "freezedry", "spikes", "superfang", "taunt"]
+                "movepool": ["earthquake", "freezedry", "spikes", "superfang", "taunt"]
             }
         ]
     },
@@ -2571,7 +2582,7 @@
         "level": 84,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Fast Attacker",
                 "movepool": ["earthquake", "explosion", "freezedry", "iceshard", "return", "spikes"],
                 "preferredTypes": ["Ground"]
             }
@@ -2921,7 +2932,7 @@
         "level": 81,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Fast Attacker",
                 "movepool": ["closecombat", "grassknot", "machpunch", "overheat", "stealthrock"]
             },
             {
@@ -2930,7 +2941,7 @@
                 "preferredTypes": ["Fighting"]
             },
             {
-                "role": "Fast Attacker",
+                "role": "Fast Support",
                 "movepool": ["closecombat", "flareblitz", "machpunch", "stoneedge", "swordsdance", "uturn"]
             }
         ]
@@ -3088,13 +3099,18 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquajet", "bulkup", "icepunch", "liquidation", "lowkick", "substitute", "taunt"],
+                "movepool": ["aquajet", "bulkup", "icepunch", "liquidation", "lowkick", "substitute"],
                 "preferredTypes": ["Ice"]
             },
             {
                 "role": "Fast Attacker",
                 "movepool": ["aquajet", "crunch", "icepunch", "liquidation", "lowkick"],
                 "preferredTypes": ["Ice"]
+            },
+            {
+                "role": "Z-Move user",
+                "movepool": ["bulkup", "icepunch", "liquidation", "lowkick"],
+                "preferredTypes": ["Fighting"]
             }
         ]
     },
@@ -3148,7 +3164,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["healingwish", "highjumpkick", "icepunch", "return", "switcheroo"]
+                "movepool": ["brutalswing", "healingwish", "highjumpkick", "return", "switcheroo"]
             }
         ]
     },
@@ -3291,7 +3307,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["closecombat", "extremespeed", "icepunch", "meteormash", "swordsdance"]
+                "movepool": ["closecombat", "extremespeed", "meteormash", "swordsdance"]
             },
             {
                 "role": "Setup Sweeper",
@@ -3531,11 +3547,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "iceshard", "iciclecrash", "stealthrock"]
-            },
-            {
-                "role": "Fast Attacker",
-                "movepool": ["earthquake", "iceshard", "iciclecrash", "knockoff", "superpower"]
+                "movepool": ["earthquake", "iceshard", "iciclecrash", "knockoff", "stealthrock"]
             }
         ]
     },
@@ -3731,8 +3743,9 @@
         "level": 86,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["drainpunch", "knockoff", "return", "substitute", "thunderwave"]
+                "role": "Bulky Attacker",
+                "movepool": ["drainpunch", "knockoff", "return", "substitute", "thunderwave"],
+                "preferredTypes": ["Dark"]
             }
         ]
     },
@@ -4050,7 +4063,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "defog", "icebeam", "judgment", "recover", "toxic", "willowisp"]
+                "movepool": ["calmmind", "icebeam", "judgment", "recover", "toxic"]
             }
         ]
     },
@@ -4063,7 +4076,8 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["boltstrike", "energyball", "focusblast", "psychic", "uturn", "vcreate"]
+                "movepool": ["boltstrike", "energyball", "focusblast", "glaciate", "psychic", "uturn", "vcreate"],
+                "preferredTypes": ["Electric"]
             },
             {
                 "role": "Z-Move user",
@@ -4315,7 +4329,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bulkup", "closecombat", "earthquake", "icepunch", "knockoff", "poisonjab", "stoneedge"],
+                "movepool": ["bulkup", "closecombat", "earthquake", "knockoff", "poisonjab", "stoneedge"],
                 "preferredTypes": ["Dark"]
             }
         ]
@@ -4400,7 +4414,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["gigadrain", "hiddenpowerfire", "knockoff", "spikes", "suckerpunch", "toxic"]
+                "movepool": ["gigadrain", "hiddenpowerfire", "knockoff", "spikes", "suckerpunch", "synthesis", "toxic"]
             },
             {
                 "role": "Staller",
@@ -5096,14 +5110,9 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["calmmind", "focusblast", "hypervoice", "psyshock", "uturn"]
-            }
-        ]
-    },
-    "meloettapirouette": {
-        "level": 82,
-        "sets": [
+            },
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["closecombat", "knockoff", "relicsong", "return"]
             }
         ]
@@ -5291,7 +5300,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "darkpulse", "energyball", "psychic", "psyshock", "signalbeam", "thunderbolt"]
+                "movepool": ["calmmind", "darkpulse", "psychic", "psyshock", "signalbeam", "thunderbolt"]
             }
         ]
     },
@@ -5372,7 +5381,11 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dracometeor", "focusblast", "hiddenpowerfire", "scald", "sludgewave", "toxicspikes"]
+                "movepool": ["dracometeor", "focusblast", "sludgewave", "toxicspikes"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["dracometeor", "dragonpulse", "focusblast", "sludgewave"]
             }
         ]
     },
@@ -5637,7 +5650,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["drainpunch", "gunkshot", "hyperspacefury", "icepunch", "trick", "zenheadbutt"],
+                "movepool": ["drainpunch", "gunkshot", "hyperspacefury", "trick", "zenheadbutt"],
                 "preferredTypes": ["Psychic"]
             },
             {
@@ -5705,7 +5718,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["crunch", "earthquake", "firepunch", "return", "uturn"]
+                "movepool": ["crunch", "earthquake", "return", "uturn"]
             }
         ]
     },
@@ -5912,8 +5925,11 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["doubleedge", "icepunch", "return", "shadowclaw", "superpower", "swordsdance"],
-                "preferredTypes": ["Normal"]
+                "movepool": ["doubleedge", "return", "shadowclaw", "superpower", "swordsdance"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["doubleedge", "drainpunch", "shadowclaw", "superpower"]
             },
             {
                 "role": "Bulky Setup",
@@ -5939,7 +5955,7 @@
                 "movepool": ["aromatherapy", "defog", "drainingkiss", "synthesis", "toxic", "uturn"]
             },
             {
-                "role": "Setup Sweeper",
+                "role": "Bulky Setup",
                 "movepool": ["calmmind", "drainingkiss", "gigadrain", "hiddenpowerground"]
             }
         ]
@@ -6248,11 +6264,11 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["drainpunch", "playrough", "shadowclaw", "shadowsneak", "swordsdance", "taunt"]
+                "movepool": ["drainpunch", "playrough", "shadowclaw", "shadowsneak", "swordsdance"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["drainpunch", "playrough", "shadowclaw", "shadowsneak", "swordsdance", "taunt"]
+                "movepool": ["drainpunch", "playrough", "shadowclaw", "shadowsneak", "swordsdance"]
             }
         ]
     },

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -375,7 +375,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		}
 
 		const statusInflictingMoves = ['thunderwave', 'toxic', 'willowisp', 'yawn'];
-		if (!abilities.has('Prankster')) {
+		if (!abilities.has('Prankster') && role !== 'Staller') {
 			this.incompatibleMoves(moves, movePool, statusInflictingMoves, statusInflictingMoves);
 		}
 
@@ -535,7 +535,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		}
 
 		// Enforce STAB priority
-		if (['Bulky Attacker', 'Bulky Setup'].includes(role) || this.priorityPokemon.includes(species.id)) {
+		if (['Bulky Attacker', 'Bulky Setup', 'Wallbreaker'].includes(role) || this.priorityPokemon.includes(species.id)) {
 			const priorityMoves = [];
 			for (const moveid of movePool) {
 				const move = this.dex.moves.get(moveid);
@@ -735,7 +735,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			return (!counter.get('inaccurate') || moves.has('shadowpunch'));
 		case 'Contrary': case 'Skill Link': case 'Strong Jaw':
 			return !counter.get(toID(ability));
-		case 'Defiant': case 'Justified': case 'Moxie':
+		case 'Defiant': case 'Justified':
 			return !counter.get('Physical');
 		case 'Guts':
 			return (!moves.has('facade') && !moves.has('sleeptalk'));
@@ -764,6 +764,8 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				species.baseSpecies === 'Basculin' || species.id === 'pangoro' || species.id === 'pinsirmega' ||
 				abilities.has('Sheer Force')
 			);
+		case 'Moxie':
+			return (!counter.get('Physical') || moves.has('stealthrock') || (!!species.isMega && abilities.has('Intimidate')));
 		case 'Oblivious': case 'Prankster':
 			return (!counter.get('Status') || (species.id === 'tornadus' && moves.has('bulkup')));
 		case 'Overcoat':
@@ -863,12 +865,11 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it
 		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';
 		if (species.id === 'muk') return 'Poison Touch';
-		if (
-			['dusknoir', 'raikou', 'suicune', 'vespiquen'].includes(species.id)
-		) return 'Pressure';
+		if (['dusknoir', 'raikou', 'suicune', 'vespiquen'].includes(species.id)) return 'Pressure';
 		if (species.id === 'tsareena') return 'Queenly Majesty';
 		if (species.id === 'druddigon' && role === 'Bulky Support') return 'Rough Skin';
-		if (species.id === 'pangoro' && !counter.get('ironfist')) return 'Scrappy';
+		if (species.id === 'stoutland' || species.id === 'pangoro' && !counter.get('ironfist')) return 'Scrappy';
+		if (species.id === 'octillery') return 'Sniper';
 		if (species.id === 'kommoo' && role === 'Z-Move user') return 'Soundproof';
 		if (species.id === 'stunfisk') return 'Static';
 		if (species.id === 'breloom') return 'Technician';
@@ -877,7 +878,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 
 		if (abilities.has('Gluttony') && (moves.has('recycle') || moves.has('bellydrum'))) return 'Gluttony';
 		if (abilities.has('Harvest') && (role === 'Bulky Support' || role === 'Staller')) return 'Harvest';
-		if (abilities.has('Moxie') && (counter.get('Physical') > 3 || moves.has('bounce'))) return 'Moxie';
+		if (abilities.has('Moxie') && (moves.has('bounce') || moves.has('fly'))) return 'Moxie';
 		if (abilities.has('Regenerator') && role === 'AV Pivot') return 'Regenerator';
 		if (abilities.has('Shed Skin') && moves.has('rest') && !moves.has('sleeptalk')) return 'Shed Skin';
 		if (abilities.has('Sniper') && moves.has('focusenergy')) return 'Sniper';
@@ -1235,11 +1236,11 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (['highjumpkick', 'jumpkick'].some(m => moves.has(m))) srWeakness = 2;
 		while (evs.hp > 1) {
 			const hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
-			if (moves.has('substitute')) {
-				if (item === 'Sitrus Berry' || (ability === 'Power Construct' && item !== 'Leftovers')) {
+			if (moves.has('substitute') && !['Black Sludge', 'Leftovers'].includes(item)) {
+				if (item === 'Sitrus Berry' || ability === 'Power Construct') {
 					// Two Substitutes should activate Sitrus Berry or Power Construct
 					if (hp % 4 === 0) break;
-				} else if (!['Black Sludge', 'Leftovers'].includes(item)) {
+				} else {
 					// Should be able to use Substitute four times from full HP without fainting
 					if (hp % 4 > 0) break;
 				}

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -1874,7 +1874,7 @@
             },
             {
                 "role": "Doubles Bulky Setup",
-                "movepool": ["Heat Crash", "Precipice Blades", "Stone Edge", "Swords Dance"],
+                "movepool": ["Heat Crash", "Precipice Blades", "Protect", "Stone Edge", "Swords Dance"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -2195,7 +2195,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Helping Hand", "High Horsepower", "Slack Off", "Stealth Rock", "Stone Edge", "Whirlwind"],
-                "teraTypes": ["Rock", "Steel"]
+                "teraTypes": ["Dragon", "Rock", "Steel", "Water"]
             }
         ]
     },

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -3699,8 +3699,8 @@
         "sets": [
             {
                 "role": "Offensive Protect",
-                "movepool": ["Alluring Voice", "Protect", "Psychic", "Shadow Ball", "Thunderbolt"],
-                "teraTypes": ["Electric", "Fairy"]
+                "movepool": ["Alluring Voice", "Dark Pulse", "Protect", "Psychic", "Thunderbolt"],
+                "teraTypes": ["Dark", "Electric", "Fairy"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -4813,11 +4813,6 @@
         "level": 76,
         "sets": [
             {
-                "role": "Tera Blast user",
-                "movepool": ["Moongeist Beam", "Photon Geyser", "Tera Blast", "Trick Room"],
-                "teraTypes": ["Fairy"]
-            },
-            {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Moongeist Beam", "Moonlight", "Photon Geyser"],
                 "teraTypes": ["Dark", "Fairy"]
@@ -6076,6 +6071,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Close Combat", "Crunch", "Seed Bomb", "Spore", "Sucker Punch"],
                 "teraTypes": ["Dark", "Fighting"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Bullet Seed", "Crunch", "Seed Bomb", "Spore", "Stun Spore", "Synthesis"],
+                "teraTypes": ["Fairy", "Poison"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -868,12 +868,12 @@
         "level": 74,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Dragon Dance", "Earthquake", "Extreme Speed", "Fire Punch", "Outrage"],
-                "teraTypes": ["Normal"]
+                "role": "Bulky Setup",
+                "movepool": ["Dragon Dance", "Earthquake", "Outrage", "Roost"],
+                "teraTypes": ["Ground", "Steel"]
             },
             {
-                "role": "Bulky Setup",
+                "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Iron Head", "Outrage"],
                 "teraTypes": ["Steel"]
             },
@@ -1130,12 +1130,12 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Curse", "Earthquake", "Gunk Shot", "Recover"],
-                "teraTypes": ["Flying", "Ground", "Steel"]
+                "teraTypes": ["Flying", "Steel"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Gunk Shot", "Poison Jab", "Recover", "Stealth Rock", "Toxic", "Toxic Spikes"],
-                "teraTypes": ["Flying", "Ground", "Steel"]
+                "teraTypes": ["Flying", "Steel"]
             }
         ]
     },
@@ -1240,7 +1240,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Slam", "Coil", "Earthquake", "Roost"],
-                "teraTypes": ["Ground"]
+                "teraTypes": ["Ghost", "Ground"]
             }
         ]
     },
@@ -1649,8 +1649,8 @@
             },
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Dark Pulse", "Giga Drain", "Heat Wave", "Leaf Storm", "Nasty Plot", "Vacuum Wave"],
-                "teraTypes": ["Fire", "Grass"]
+                "movepool": ["Knock Off", "Leaf Blade", "Sucker Punch", "Swords Dance"],
+                "teraTypes": ["Dark", "Poison"]
             },
             {
                 "role": "Setup Sweeper",
@@ -2441,6 +2441,11 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Dazzling Gleam", "Mystical Fire", "Nasty Plot", "Shadow Ball", "Substitute", "Thunderbolt"],
                 "teraTypes": ["Electric", "Fairy"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Nasty Plot", "Shadow Ball", "Substitute", "Tera Blast"],
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -2469,7 +2474,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Hypnosis", "Iron Head", "Psychic Noise", "Stealth Rock"],
+                "movepool": ["Earthquake", "Hypnosis", "Iron Head", "Psychic", "Psychic Noise", "Stealth Rock"],
                 "teraTypes": ["Electric", "Water"]
             },
             {
@@ -2758,13 +2763,13 @@
         "level": 88,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["Earthquake", "Ice Punch", "Leech Life", "Pain Split", "Poltergeist", "Shadow Sneak", "Trick"],
-                "teraTypes": ["Dark", "Ghost", "Ground"]
+                "role": "Bulky Attacker",
+                "movepool": ["Brick Break", "Earthquake", "Leech Life", "Pain Split", "Poltergeist", "Shadow Sneak", "Trick"],
+                "teraTypes": ["Fighting", "Ghost", "Ground"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Pain Split", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
+                "movepool": ["Brick Break", "Pain Split", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
                 "teraTypes": ["Dark", "Fairy"]
             }
         ]
@@ -2844,7 +2849,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Encore", "Knock Off", "Psychic", "Psychic Noise", "Stealth Rock", "Thunder Wave", "U-turn", "Yawn"],
+                "movepool": ["Encore", "Knock Off", "Psychic Noise", "Stealth Rock", "Thunder Wave", "U-turn", "Yawn"],
                 "teraTypes": ["Dark", "Electric", "Steel"]
             }
         ]
@@ -3109,7 +3114,12 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Fire Blast", "Judgment", "Sludge Bomb"],
+                "movepool": ["Dragon Dance", "Earthquake", "Gunk Shot", "Outrage"],
+                "teraTypes": ["Ground", "Poison"]
+            },
+            {
+                "role": "Fast Bulky Setup",
+                "movepool": ["Calm Mind", "Fire Blast", "Judgment", "Recover", "Sludge Bomb"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -3150,6 +3160,11 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Extreme Speed", "Flare Blitz", "Recover", "Swords Dance"],
+                "teraTypes": ["Fire", "Ground"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Dragon Dance", "Earthquake", "Flare Blitz", "Recover"],
                 "teraTypes": ["Fire", "Ground"]
             },
             {
@@ -3211,6 +3226,11 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Extreme Speed", "Stone Edge", "Swords Dance"],
                 "teraTypes": ["Normal"]
+            },
+            {
+                "role": "Fast Bulky Setup",
+                "movepool": ["Dragon Dance", "Earthquake", "Recover", "Stone Edge"],
+                "teraTypes": ["Ground", "Steel"]
             }
         ]
     },
@@ -3251,6 +3271,11 @@
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Earth Power", "Fire Blast", "Judgment", "Recover"],
                 "teraTypes": ["Dragon", "Ground"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dragon Dance", "Earthquake", "Recover", "Stone Edge", "Swords Dance"],
+                "teraTypes": ["Ground"]
             }
         ]
     },
@@ -3614,7 +3639,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Coil", "Drain Punch", "Fire Punch", "Knock Off", "Liquidation", "Supercell Slam"],
+                "movepool": ["Coil", "Drain Punch", "Fire Punch", "Knock Off", "Supercell Slam"],
                 "teraTypes": ["Fighting"]
             },
             {
@@ -3921,11 +3946,6 @@
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Stealth Rock", "Stone Edge", "Taunt", "U-turn"],
                 "teraTypes": ["Ground", "Water"]
-            },
-            {
-                "role": "Tera Blast user",
-                "movepool": ["Earthquake", "Stone Edge", "Swords Dance", "Tera Blast"],
-                "teraTypes": ["Flying"]
             }
         ]
     },
@@ -3996,6 +4016,11 @@
                 "role": "Fast Attacker",
                 "movepool": ["Calm Mind", "Focus Blast", "Hyper Voice", "Psyshock", "U-turn"],
                 "teraTypes": ["Fighting", "Normal", "Psychic"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Close Combat", "Knock Off", "Relic Song", "Triple Axel"],
+                "teraTypes": ["Dark", "Fighting"]
             }
         ]
     },
@@ -4064,12 +4089,12 @@
         "sets": [
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Bug Buzz", "Energy Ball", "Hurricane", "Quiver Dance", "Sleep Powder", "Substitute"],
+                "movepool": ["Bug Buzz", "Energy Ball", "Hurricane", "Quiver Dance", "Sleep Powder"],
                 "teraTypes": ["Flying"]
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Hurricane", "Quiver Dance", "Sleep Powder", "Substitute", "Tera Blast"],
+                "movepool": ["Hurricane", "Quiver Dance", "Sleep Powder", "Tera Blast"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -4384,7 +4409,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Bulk Up", "Flare Blitz", "Knock Off", "Trailblaze"],
+                "movepool": ["Flare Blitz", "Knock Off", "Swords Dance", "Trailblaze"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -5019,7 +5044,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Parting Shot", "Spirit Break", "Taunt", "Throat Chop", "Thunder Wave"],
+                "movepool": ["Parting Shot", "Spirit Break", "Sucker Punch", "Taunt", "Thunder Wave"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -5585,7 +5610,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Hyper Voice", "Leech Seed", "Protect", "Substitute"],
-                "teraTypes": ["Water"]
+                "teraTypes": ["Poison", "Water"]
             }
         ]
     },
@@ -5694,7 +5719,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Crunch", "Fire Fang", "Play Rough", "Psychic Fangs", "Wild Charge"],
+                "movepool": ["Crunch", "Play Rough", "Psychic Fangs", "Retaliate", "Wild Charge"],
                 "teraTypes": ["Dark", "Fairy"]
             }
         ]
@@ -5889,7 +5914,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Earth Power", "Mortal Spin", "Power Gem", "Sludge Wave", "Spikes", "Stealth Rock", "Toxic"],
+                "movepool": ["Earth Power", "Mortal Spin", "Power Gem", "Sludge Wave", "Spikes", "Stealth Rock"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -6029,17 +6054,17 @@
         "sets": [
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Ice Spinner", "Rapid Spin"],
+                "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Rapid Spin", "Stone Edge"],
                 "teraTypes": ["Ground", "Steel"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Ice Spinner", "Rapid Spin"],
+                "movepool": ["Bulk Up", "Close Combat", "Earthquake", "Rapid Spin", "Stone Edge"],
                 "teraTypes": ["Ground", "Steel"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Close Combat", "Headlong Rush", "Ice Spinner", "Knock Off", "Rapid Spin", "Stealth Rock"],
+                "movepool": ["Close Combat", "Headlong Rush", "Ice Spinner", "Knock Off", "Rapid Spin", "Stealth Rock", "Stone Edge"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -6111,6 +6136,11 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Iron Head", "Knock Off", "Outrage", "Roost"],
                 "teraTypes": ["Dark", "Dragon", "Ground", "Poison", "Steel"]
+            },
+            {
+                "role": "Fast Bulky Setup",
+                "movepool": ["Acrobatics", "Dragon Dance", "Iron Head", "Knock Off", "Outrage"],
+                "teraTypes": ["Flying", "Steel"]
             },
             {
                 "role": "Bulky Attacker",

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -6075,7 +6075,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Bullet Seed", "Crunch", "Seed Bomb", "Spore", "Stun Spore", "Synthesis"],
-                "teraTypes": ["Fairy", "Poison"]
+                "teraTypes": ["Poison"]
             }
         ]
     },

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1314,15 +1314,15 @@ export class RandomTeams {
 			(species.baseSpecies === 'Magearna' && role === 'Tera Blast user') ||
 			species.id === 'necrozmaduskmane' || (species.id === 'calyrexice' && isDoubles)
 		) return 'Weakness Policy';
-		if (moves.has('lastrespects') || moves.has('dragonenergy')) return 'Choice Scarf';
+		if (['dragonenergy', 'lastrespects', 'waterspout'].some(m => moves.has(m))) return 'Choice Scarf';
 		if (
 			ability === 'Imposter' ||
 			(species.id === 'magnezone' && moves.has('bodypress') && !isDoubles)
 		) return 'Choice Scarf';
 		if (species.id === 'rampardos' && (role === 'Fast Attacker' || isDoubles)) return 'Choice Scarf';
 		if (
-			species.id === 'luvdisc' || moves.has('courtchange') ||
-			(species.id === 'terapagos' && !moves.has('rest'))
+			moves.has('courtchange') ||
+			!isDoubles && (species.id === 'luvdisc' || (species.id === 'terapagos' && !moves.has('rest')))
 		) return 'Heavy-Duty Boots';
 		if (moves.has('bellydrum') && moves.has('substitute')) return 'Salac Berry';
 		if (
@@ -1397,7 +1397,6 @@ export class RandomTeams {
 		if (
 			moves.has('flipturn') && moves.has('protect') && (moves.has('aquajet') || (moves.has('jetpunch')))
 		) return 'Mystic Water';
-		if (moves.has('waterspout')) return 'Choice Scarf';
 		if (counter.get('speedsetup') && role === 'Doubles Bulky Setup') return 'Weakness Policy';
 		if (species.id === 'toxapex') return 'Binding Band';
 		if (moves.has('blizzard') && ability !== 'Snow Warning' && !teamDetails.snow) return 'Blunder Policy';
@@ -1483,7 +1482,7 @@ export class RandomTeams {
 				role !== 'Wallbreaker' &&
 				species.baseStats.spa >= 100 &&
 				species.baseStats.spe >= 60 && species.baseStats.spe <= 108 &&
-				ability !== 'Speed Boost' && ability !== 'Tinted Lens' && !counter.get('Physical')
+				ability !== 'Speed Boost' && ability !== 'Tinted Lens' && !counter.get('Physical') && !counter.get('priority')
 			);
 			return (scarfReqs && this.randomChance(1, 2)) ? 'Choice Scarf' : 'Choice Specs';
 		}

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -577,6 +577,8 @@ export class RandomTeams {
 			['trick', 'uturn'],
 			// Araquanid
 			['mirrorcoat', 'hydropump'],
+			// Brute Bonnet
+			['bulletseed', 'seedbomb'],
 		];
 
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);


### PR DESCRIPTION
**Gen 9 Random Battle:**
-Add Meloetta-Pirouette: Wallbreaker with Relic Song, Close Combat, Knock Off, and Triple Axel, Tera Dark/Fighting.
-Vivillon: -Substitute (both sets)
-Nasty Plot Shiftry has been removed and replaced with a Swords Dance set with Knock Off, Leaf Blade, and Sucker Punch, Tera Dark/Poison.
-Glimmora: -Toxic
-Mabosstiff: -Fire Fang, +Retaliate
-Uxie: -Psychic
-Great Tusk: setup sets: -Ice spinner, +Stone Edge; Bulky Support: +Stone Edge
-Roaring Moon: added Fast Bulky Setup, Booster Energy with Acrobatics/Iron Head and Tera Flying/Steel.
-Dusknoir now runs Brick Break in both sets, replacing Earthquake in Bulky Support and Ice Punch in the other set. It no longer gets Life Orb, and instead gets Leftovers when rolling 3 attacks + Pain Split. The Bulky Attacker set (previously Wallbreaker) now runs Tera Fighting.
-Coil Eelektross: -Liquidation
-Landorus-Therian: removed Swords Dance TBU.
-Tera Blast (Fighting) Mismagius has been added with Shadow Ball, Nasty Plot and Substitute.
-Special attackers will no longer obtain Choice Scarf with a priority move. This affects Vacuum Wave Keldeo.
-Dunsparce: +Tera Ghost
-Support Bronzong: +Psychic
-CM Arceus-Dragon: +Recover, change to Fast Bulky Setup
-Dragonite no longer runs Tera Normal Extreme Speed; the set has been replaced by a Dragon Dance set with Roost and Tera Ground/Steel.
-Arceus-Dragon now runs a Dragon Dance set with Outrage, Earthquake, Gunk Shot, Tera Ground/Poison.
-Arceus-Ground now runs a Dragon Dance set with Earthquake, Stone Edge, Recover, Tera Ground/Steel.
-Arceus-Fire now runs a Dragon Dance set with Flare Blitz, Earthquake, Recover, Tera Fire/Ground.
-Arceus-Rock now runs a Dragon Dance/Swords Dance set with Stone Edge, Earthquake, Recover, Tera Ground.
-Subseed Arboliva: +Tera Poison
-Clodsire: -Tera Ground (both sets)
-Setup Incineroar: -Bulk Up, +Swords Dance
-Kyogre no longer runs Choice Specs; Fast Attacker is always Choice Scarf.
-Bulky Attacker Grimmsnarl: -Throat Chop, +Sucker Punch (due to winrate analysis).
-Removed TBU Necrozma-Dawn-Wings (setdev workshop)
-added Bulky Support Brute Bonnet with Crunch, Synthesis, Seed Bomb/Bullet Seed, and Spore/Stun Spore with Tera Poison. It generates Loaded Dice with Bullet Seed (setdev workshop)

**Gen 9 Random Doubles Battle:**
-Luvdisc and Terapagos no longer get Heavy-Duty Boots (bug fix)
-Setup Groudon: +Protect
-Hippowdon: +Tera Dragon/Water
-Meowstic-F: -Shadow Ball, +Dark Pulse, +Tera Dark

**Gens 4-7 Random Battle:**
-Octillery is always Sniper
-Celebi: -Heal Bell
-Primeape and Machamp: -Ice Punch
-Slaking: -Fire Punch

**Gens 5-7 Random Battle:**
-Intimidate's ability rating has been reduced from 4 to 3.5, like in later gens. This allows Intimidate and Moxie to naturally roll with each other, and removes the necessity of some Moxie hardcodes.
-Moxie is no longer forced on choiced sets, allowing Mightyena to roll Intimidate. It is prevented on Stealth Rock Krookodile and Mega Salamence/Gyarados, which will always be Intimidate.
-Stoutland is always Scrappy and always runs Superpower.
-Rhydon: +Swords Dance.
-Spinda: -Ice Punch, +Feint Attack
-Fast Support Maractus: +Synthesis
-Camerupt: -HP Grass

**Gens 6-7 Random Battle:**
-The Wallbreaker role now enforces STAB priority; current Wallbreakers that would be adversely impacted have had their roles changed accordingly.
-Mamoswine now runs its Gen 9 set: Wallbreaker with Earthquake, Icicle Crash, Ice Shard, Knock Off, and Stealth Rock.
-Dragalge has been split into two sets: Leftovers with Toxic Spikes, and Choice Specs, both of which have Focus Blast guaranteed. The Choice Specs set has Dragon Pulse as its 4th move.
-Rain Dance Poliwrath: -Hydro Pump, +Waterfall
-Mightyena: -Fire Fang
-AV Victini: +Glaciate; Bolt Strike is enforced
-Meowstic-F: -Energy Ball
-Hariyama, Sawk: -Ice Punch
-Glalie: -Explosion
-Arceus-Water: -Defog
-Entei has been set split so that it always has Sacred Fire.
-Regigigas always runs Knock Off, ensuring that it isn't walled by Ghost-types.
-Floatzel: -Taunt
-Omastar: -Earth Power, +HP Grass
-Charizard-Mega-Y now has Fire Blast, Roost and Solar Beam always; its 4th move is a roll between Air Slash and Dragon Pulse.
-Hoopa-Unbound: -Ice Punch

**Gen 7 Random Battle:**
-Delcatty: -Sucker Punch, +Shadow Ball
-Gumshoos: -Fire Punch
-Mimikyu: -Taunt
-Lucario-Mega: -Ice Punch
-Primeape has been set split so that Hone Claws will always have Stone Edge.
-Staller Blissey/Chansey: +Thunder Wave
-Bewear has been set split so that it always runs Shadow Claw.
-Lopunny: -Ice Punch, +Brutal Swing
-Arceus-Water: -wisp
-added Z-Fighting Floatzel with Bulk Up, Liquidation, Ice Punch, and Low Kick.
-Calm Mind Comfey now runs Leftovers instead of Life Orb.
-Stantler: +Throat Chop, +Thunder Wave, always runs Earthquake.

**Gen 6 Random Battle:**
-AV Emboar: -Fire Blast, +Flare Blitz
-Stantler: +Thunder Wave, always runs Earthquake

**Gen 4-5 Random Battle:**
-Entei has been set split so that it always runs Flare Blitz, Extreme Speed, and Stone Edge. Its 4th move is either HP Grass (Life Orb), or a physical attack (Choice Band).

**Gen 5 Random Battle:**
-AV Emboar: -Fire Blast, +Flare Blitz
-Stantler: +Hypnosis, +Thunder Wave, always runs Earthquake
-Rotom-Mow: -HP Fire

**Gen 4 Random Battle:**
-Noctowl: +Air Slash
-Cherrim now runs its Staller set like in Gens 6-7. Cherrim-Sunshine has been removed.
-Dewgong no longer runs Rest + Sleep Talk.
-Mightyena no longer has Sucker Punch or Fire Fang enforced.
-Vespiquen now runs its Gen 5 set, with HP Flying instead of Air Slash.
-Sableye always runs Payback and no longer runs Taunt.

**Gen 3 Random Battle:**
-Magcargo now rolls between Fire Blast and Flamethrower for its STAB. It also runs a Staller set with HP Grass, Toxic, and Protect.
-Sunflora now runs a Sunny Day set with Solar Beam, HP Fire, and Synthesis.
-Azumarill no longer runs Encore.
-Houndoom no longer runs Flamethrower and always runs Fire Blast.

**Gen 1 Random Battle:**
-Venusaur and Victreebel's sets have been adjusted so that they always run Sleep Powder.

Technical:
-Fixed a bug which resulted in Substitute users with Leftovers/Black Sludge having reduced HP EVs in Gens 5-7.
-In Gens 5-7, Meloetta-Pirouette's sets are now included under the Meloetta species.