### PR TITLE
Ubers UU: Update bans

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -413,7 +413,7 @@ export const Formats: FormatList = [
 			'Kingambit', 'Koraidon', 'Kyogre', 'Kyurem-Black', 'Miraidon', 'Necrozma-Dusk-Mane', 'Rayquaza', 'Ribombee', 'Skeledirge',
 			'Ting-Lu', 'Zacian-Crowned',
 			// Ubers UUBL
-			'Arceus-Fire', 'Arceus-Flying', 'Arceus-Ghost', 'Arceus-Steel', 'Arceus-Water', 'Necrozma-Dawn-Wings', 'Shaymin-Sky', 'Zekrom',
+			'Arceus-Fire', 'Arceus-Flying', 'Arceus-Steel', 'Arceus-Water', 'Zekrom',
 		],
 	},
 	{


### PR DESCRIPTION
https://www.smogon.com/forums/threads/shaymin-sky-necrozma-dawn-wings-and-arceus-ghost-have-all-been-unbanned.3740378/