### PR TITLE
Modern Gen 2: Fix Move Validation + Do Not Use: Unban Capsakid & Snorunt

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -498,13 +498,13 @@ export const Formats: FormatList = [
 		banlist: ['Huge Power', 'Pure Power', 'Shadow Tag', 'Arena Trap', 'Baton Pass', 'Moody', 'Dewpider', 'Smeargle', 'Zigzagoon-Base', 'Flittle', 'Nidoran-M', 'Wingull', 'Wishiwashi'],
 		onBegin() {
 			this.add('-message', `Welcome to Do Not Use!`);
-			this.add('-message', `This is a metagame where only Pokemon with less than 280 BST are allowed, plus Unown and Luvdisc!`);
+			this.add('-message', `This is a metagame where only Pokemon with less than 280 BST are allowed, plus a select few others!`);
 			this.add('-message', `You can find our thread and metagame resources here:`);
 			this.add('-message', `https://www.smogon.com/forums/threads/3734326/`);
 		},
 		onValidateSet(set) {
 			const species = this.dex.species.get(set.species);
-			if (species.bst > 280 && !['Luvdisc', 'Unown'].includes(species.baseSpecies)) {
+			if (species.bst > 280 && !['Luvdisc', 'Unown', 'Capsakid', 'Snorunt'].includes(species.baseSpecies)) {
 				return [`Only Pok\u00e9mon with a BST of 280 or lower are allowed.`, `(${species.name}'s BST is ${species.bst}.)`];
 			}
 		},

--- a/data/mods/moderngen2/scripts.ts
+++ b/data/mods/moderngen2/scripts.ts
@@ -6,7 +6,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		for (const i in this.data.Moves) {
 			if (this.data.Moves[i].num! >= 252) this.modData('Moves', i).gen = 2;
 			const illegalities = ['Past', 'LGPE', 'Unobtainable'];
-			if (illegalities.includes(this.data.Moves[i].isNonstandard)) this.modData('Moves', i).isNonstandard = null;
+			if (illegalities.includes(this.data.Moves[i].isNonstandard!)) this.modData('Moves', i).isNonstandard = null;
 			if (this.data.Moves[i].category === 'Status') continue;
 			const newCategory = specialTypes.includes(this.data.Moves[i].type) ? 'Special' : 'Physical';
 			if (newCategory !== this.data.Moves[i].category) {

--- a/data/mods/moderngen2/scripts.ts
+++ b/data/mods/moderngen2/scripts.ts
@@ -5,7 +5,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		const specialTypes = ['Fire', 'Water', 'Grass', 'Ice', 'Electric', 'Dark', 'Psychic', 'Dragon'];
 		for (const i in this.data.Moves) {
 			if (this.data.Moves[i].num! >= 252) this.modData('Moves', i).gen = 2;
-			if (this.data.Moves[i].isNonstandard === 'Past') this.modData('Moves', i).isNonstandard = null;
+			if (['Past', 'LGPE'].includes(this.data.Moves[i].isNonstandard)) this.modData('Moves', i).isNonstandard = null;
 			if (this.data.Moves[i].category === 'Status') continue;
 			const newCategory = specialTypes.includes(this.data.Moves[i].type) ? 'Special' : 'Physical';
 			if (newCategory !== this.data.Moves[i].category) {

--- a/data/mods/moderngen2/scripts.ts
+++ b/data/mods/moderngen2/scripts.ts
@@ -5,7 +5,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		const specialTypes = ['Fire', 'Water', 'Grass', 'Ice', 'Electric', 'Dark', 'Psychic', 'Dragon'];
 		for (const i in this.data.Moves) {
 			if (this.data.Moves[i].num! >= 252) this.modData('Moves', i).gen = 2;
-			if (['Past', 'LGPE'].includes(this.data.Moves[i].isNonstandard)) this.modData('Moves', i).isNonstandard = null;
+			if (['Past', 'LGPE', 'Unobtainable'].includes(this.data.Moves[i].isNonstandard)) this.modData('Moves', i).isNonstandard = null;
 			if (this.data.Moves[i].category === 'Status') continue;
 			const newCategory = specialTypes.includes(this.data.Moves[i].type) ? 'Special' : 'Physical';
 			if (newCategory !== this.data.Moves[i].category) {

--- a/data/mods/moderngen2/scripts.ts
+++ b/data/mods/moderngen2/scripts.ts
@@ -5,7 +5,8 @@ export const Scripts: ModdedBattleScriptsData = {
 		const specialTypes = ['Fire', 'Water', 'Grass', 'Ice', 'Electric', 'Dark', 'Psychic', 'Dragon'];
 		for (const i in this.data.Moves) {
 			if (this.data.Moves[i].num! >= 252) this.modData('Moves', i).gen = 2;
-			if (['Past', 'LGPE', 'Unobtainable'].includes(this.data.Moves[i].isNonstandard)) this.modData('Moves', i).isNonstandard = null;
+			const illegalities = ['Past', 'LGPE', 'Unobtainable'];
+			if (illegalities.includes(this.data.Moves[i].isNonstandard)) this.modData('Moves', i).isNonstandard = null;
 			if (this.data.Moves[i].category === 'Status') continue;
 			const newCategory = specialTypes.includes(this.data.Moves[i].type) ? 'Special' : 'Physical';
 			if (newCategory !== this.data.Moves[i].category) {

--- a/data/mods/moderngen2/scripts.ts
+++ b/data/mods/moderngen2/scripts.ts
@@ -6,7 +6,9 @@ export const Scripts: ModdedBattleScriptsData = {
 		for (const i in this.data.Moves) {
 			if (this.data.Moves[i].num! >= 252) this.modData('Moves', i).gen = 2;
 			const illegalities = ['Past', 'LGPE', 'Unobtainable'];
-			if (illegalities.includes(this.data.Moves[i].isNonstandard!)) this.modData('Moves', i).isNonstandard = null;
+			if (this.data.Moves[i].isNonstandard && illegalities.includes(this.data.Moves[i].isNonstandard)) {
+				this.modData('Moves', i).isNonstandard = null;
+			}
 			if (this.data.Moves[i].category === 'Status') continue;
 			const newCategory = specialTypes.includes(this.data.Moves[i].type) ? 'Special' : 'Physical';
 			if (newCategory !== this.data.Moves[i].category) {

--- a/data/mods/moderngen2/scripts.ts
+++ b/data/mods/moderngen2/scripts.ts
@@ -6,7 +6,7 @@ export const Scripts: ModdedBattleScriptsData = {
 		for (const i in this.data.Moves) {
 			if (this.data.Moves[i].num! >= 252) this.modData('Moves', i).gen = 2;
 			const illegalities = ['Past', 'LGPE', 'Unobtainable'];
-			if (this.data.Moves[i].isNonstandard && illegalities.includes(this.data.Moves[i].isNonstandard)) {
+			if (this.data.Moves[i].isNonstandard && illegalities.includes(this.data.Moves[i].isNonstandard as string)) {
 				this.modData('Moves', i).isNonstandard = null;
 			}
 			if (this.data.Moves[i].category === 'Status') continue;


### PR DESCRIPTION
One last validation fix for Modern Gen 2, making moves that were illegal in the gen they were introduced legal (namely Double Iron Bash, Thousand Waves, and Thousand Arrows).