### PR TITLE
Randomized format set updates

### DIFF
--- a/data/mods/gen3/random-sets.json
+++ b/data/mods/gen3/random-sets.json
@@ -1157,7 +1157,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["icebeam", "sleeptalk", "rest", "surf", "toxic"]
+                "movepool": ["icebeam", "rest", "sleeptalk", "surf", "toxic"]
             }
         ]
     },

--- a/data/mods/gen3/random-sets.json
+++ b/data/mods/gen3/random-sets.json
@@ -25,6 +25,10 @@
                 "role": "Setup Sweeper",
                 "movepool": ["bellydrum", "earthquake", "hiddenpowerflying", "rockslide", "substitute"],
                 "preferredTypes": ["Ground"]
+            },
+            {
+                "role": "Berry Sweeper",
+                "movepool": ["dragonclaw", "fireblast", "hiddenpowergrass", "substitute"]
             }
         ]
     },
@@ -288,6 +292,10 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["bulkup", "crosschop", "hiddenpowerghost", "rockslide", "substitute"]
+            },
+            {
+                "role": "Berry Sweeper",
+                "movepool": ["bulkup", "hiddenpowerghost", "reversal", "substitute"]
             }
         ]
     },
@@ -468,11 +476,12 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["brickbreak", "explosion", "fireblast", "haze", "hiddenpowerghost", "rest", "sludgebomb", "toxic"]
+                "movepool": ["explosion", "fireblast", "hiddenpowerground", "rest", "sludgebomb", "toxic"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["brickbreak", "curse", "hiddenpowerghost", "rest", "sludgebomb"]
+                "movepool": ["curse", "hiddenpowerground", "rest", "sludgebomb"]
             }
         ]
     },
@@ -1145,6 +1154,10 @@
             {
                 "role": "Staller",
                 "movepool": ["encore", "icebeam", "protect", "surf", "toxic"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["icebeam", "sleeptalk", "rest", "surf", "toxic"]
             }
         ]
     },
@@ -2088,6 +2101,10 @@
                 "role": "Setup Sweeper",
                 "movepool": ["brickbreak", "bulkup", "recover", "rockslide", "shadowball", "substitute"],
                 "preferredTypes": ["Ghost"]
+            },
+            {
+                "role": "Berry Sweeper",
+                "movepool": ["bulkup", "reversal", "shadowball", "substitute"]
             }
         ]
     },
@@ -2239,10 +2256,6 @@
             {
                 "role": "Staller",
                 "movepool": ["encore", "protect", "seismictoss", "shadowball", "substitute", "toxic"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["bodyslam", "focuspunch", "shadowball", "substitute"]
             },
             {
                 "role": "Bulky Support",

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -441,7 +441,6 @@ export class RandomGen3Teams extends RandomGen4Teams {
 		if (species.id === 'blissey') return 'Natural Cure';
 		if (species.id === 'heracross' && role === 'Berry Sweeper') return 'Swarm';
 		if (species.id === 'xatu') return 'Synchronize';
-		if (species.id === 'gardevoir') return 'Trace';
 
 		let abilityAllowed: Ability[] = [];
 		// Obtain a list of abilities that are allowed (not culled)

--- a/data/mods/gen4/random-sets.json
+++ b/data/mods/gen4/random-sets.json
@@ -2721,7 +2721,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["crosschop", "icepunch", "poisonjab", "substitute", "suckerpunch", "swordsdance"]
+                "movepool": ["crosschop", "earthquake", "poisonjab", "substitute", "suckerpunch", "swordsdance"]
             }
         ]
     },

--- a/data/mods/gen4/random-sets.json
+++ b/data/mods/gen4/random-sets.json
@@ -1790,8 +1790,12 @@
         "level": 85,
         "sets": [
             {
+                "role": "Wallbreaker",
+                "movepool": ["aquajet", "crunch", "earthquake", "hydropump", "icebeam"]
+            },
+            {
                 "role": "Fast Attacker",
-                "movepool": ["aquajet", "crunch", "earthquake", "hiddenpowergrass", "hydropump", "icebeam", "waterfall"]
+                "movepool": ["aquajet", "crunch", "earthquake", "icebeam", "waterfall"]
             }
         ]
     },

--- a/data/mods/gen4/random-sets.json
+++ b/data/mods/gen4/random-sets.json
@@ -2721,7 +2721,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["crosschop", "earthquake", "poisonjab", "substitute", "suckerpunch", "swordsdance"]
+                "movepool": ["crosschop", "earthquake", "icepunch", "poisonjab", "substitute", "suckerpunch", "swordsdance"]
             }
         ]
     },

--- a/data/mods/gen4/random-teams.ts
+++ b/data/mods/gen4/random-teams.ts
@@ -515,7 +515,6 @@ export class RandomGen4Teams extends RandomGen5Teams {
 
 		if (abilities.has('Guts') && !abilities.has('Quick Feet') && moves.has('facade')) return 'Guts';
 		if (abilities.has('Hydration') && moves.has('raindance') && moves.has('rest')) return 'Hydration';
-		if (abilities.has('Trace')) return 'Trace';
 
 		let abilityAllowed: Ability[] = [];
 		// Obtain a list of abilities that are allowed (not culled)
@@ -578,6 +577,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			}
 		}
 		if (moves.has('bellydrum')) return 'Sitrus Berry';
+		if (moves.has('waterspout')) return 'Choice Scarf';
 		if (ability === 'Magic Guard') return 'Life Orb';
 		if (moves.has('lightscreen') && moves.has('reflect')) return 'Light Clay';
 		if (moves.has('rest') && !moves.has('sleeptalk') && !['Natural Cure', 'Shed Skin'].includes(ability)) {

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -2762,7 +2762,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["drainpunch", "earthquake", "poisonjab", "substitute", "suckerpunch", "swordsdance"]
+                "movepool": ["drainpunch", "earthquake", "icepunch", "poisonjab", "substitute", "suckerpunch", "swordsdance"]
             }
         ]
     },

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -2762,7 +2762,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["drainpunch", "icepunch", "poisonjab", "substitute", "suckerpunch", "swordsdance"]
+                "movepool": ["drainpunch", "earthquake", "poisonjab", "substitute", "suckerpunch", "swordsdance"]
             }
         ]
     },

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -46,8 +46,12 @@
         "level": 93,
         "sets": [
             {
+                "role": "Setup Sweeper",
+                "movepool": ["bugbuzz", "quiverdance", "sleeppowder", "substitute"]
+            },
+            {
                 "role": "Bulky Setup",
-                "movepool": ["bugbuzz", "hiddenpowerrock", "psychic", "quiverdance", "sleeppowder", "substitute"]
+                "movepool": ["bugbuzz", "quiverdance", "roost", "sleeppowder"]
             }
         ]
     },
@@ -634,7 +638,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psyshock", "substitute"]
+                "movepool": ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psyshock"]
             }
         ]
     },

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -609,7 +609,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';
 		if (['spiritomb', 'vespiquen', 'weavile'].includes(species.id)) return 'Pressure';
 		if (species.id === 'druddigon') return 'Rough Skin';
-		if (species.id === 'zebstrika') return (moves.has('wildcharge')) ? 'Sap Sipper' : 'Lightning Rod';
+		if (species.id === 'zebstrika') return moves.has('wildcharge') ? 'Sap Sipper' : 'Lightning Rod';
 		if (species.id === 'stoutland') return 'Scrappy';
 		if (species.id === 'octillery') return 'Sniper';
 		if (species.id === 'stunfisk') return 'Static';

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -609,11 +609,11 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';
 		if (['spiritomb', 'vespiquen', 'weavile'].includes(species.id)) return 'Pressure';
 		if (species.id === 'druddigon') return 'Rough Skin';
+		if (species.id === 'zebstrika') return (moves.has('wildcharge')) ? 'Sap Sipper' : 'Lightning Rod';
 		if (species.id === 'stoutland') return 'Scrappy';
 		if (species.id === 'octillery') return 'Sniper';
 		if (species.id === 'stunfisk') return 'Static';
 		if (species.id === 'zangoose') return 'Toxic Boost';
-		if (species.id === 'porygon2' || species.id === 'gardevoir') return 'Trace';
 
 		if (abilities.has('Harvest')) return 'Harvest';
 		if (abilities.has('Shed Skin') && moves.has('rest') && !moves.has('sleeptalk')) return 'Shed Skin';
@@ -699,6 +699,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			}
 		}
 		if (moves.has('bellydrum')) return 'Sitrus Berry';
+		if (moves.has('waterspout')) return 'Choice Scarf';
 		if (moves.has('shellsmash')) return 'White Herb';
 		if (moves.has('psychoshift')) return 'Flame Orb';
 		if (ability === 'Magic Guard' && role !== 'Bulky Support') {

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -910,7 +910,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		}
 
 		// Minimize confusion damage
-		if ((!counter.get('Physical') || counter.get('Physical') === 1 && moves.has('foulplay')) && !moves.has('transform')) {
+		if ((counter.get('Physical') || 0) <= 1 && moves.has('foulplay') && !moves.has('transform')) {
 			evs.atk = 0;
 			ivs.atk = hasHiddenPower ? (ivs.atk || 31) - 28 : 0;
 		}

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -910,7 +910,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		}
 
 		// Minimize confusion damage
-		if (!counter.get('Physical') && !moves.has('transform')) {
+		if ((!counter.get('Physical') || counter.get('Physical') === 1 && moves.has('foulplay')) && !moves.has('transform')) {
 			evs.atk = 0;
 			ivs.atk = hasHiddenPower ? (ivs.atk || 31) - 28 : 0;
 		}

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -163,7 +163,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["encore", "hiddenpowerice", "knockoff", "nastyplot", "nuzzle", "thunderbolt", "voltswitch"]
+                "movepool": ["encore", "hiddenpowerice", "knockoff", "nastyplot", "nuzzle", "thunderbolt", "voltswitch"],
+                "preferredTypes": ["Ice"]
             },
             {
                 "role": "Fast Attacker",
@@ -710,7 +711,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psyshock", "substitute"]
+                "movepool": ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psyshock"]
             }
         ]
     },
@@ -1954,7 +1955,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["firefang", "ironhead", "playrough", "suckerpunch", "swordsdance"]
+                "movepool": ["ironhead", "knockoff", "playrough", "suckerpunch", "swordsdance"]
             }
         ]
     },
@@ -2326,6 +2327,10 @@
                 "role": "Fast Support",
                 "movepool": ["drainpunch", "fakeout", "knockoff", "recover", "shadowsneak", "stealthrock", "suckerpunch"],
                 "preferredTypes": ["Fighting"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["drainpunch", "knockoff", "recover", "stealthrock", "thunderwave", "toxic"]
             }
         ]
     },
@@ -3131,7 +3136,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["drainpunch", "gunkshot", "icepunch", "substitute", "suckerpunch", "swordsdance"]
+                "movepool": ["drainpunch", "earthquake", "gunkshot", "knockoff", "substitute", "suckerpunch", "swordsdance"]
             }
         ]
     },
@@ -3381,8 +3386,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "haze", "icepunch", "painsplit", "shadowsneak", "willowisp"],
+                "movepool": ["earthquake", "haze", "icepunch", "painsplit", "shadowsneak", "toxic", "willowisp"],
                 "preferredTypes": ["Ground"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["earthquake", "protect", "shadowsneak", "toxic"]
             }
         ]
     },
@@ -4489,7 +4498,7 @@
         "level": 82,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["highjumpkick", "knockoff", "poisonjab", "stoneedge", "swordsdance", "uturn"],
                 "preferredTypes": ["Dark"]
             },
@@ -4880,7 +4889,11 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["energyball", "hurricane", "quiverdance", "sleeppowder", "substitute"]
+                "movepool": ["energyball", "hurricane", "quiverdance", "sleeppowder"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["bugbuzz", "hurricane", "quiverdance", "sleeppowder"]
             }
         ]
     },
@@ -5126,8 +5139,12 @@
         "level": 88,
         "sets": [
             {
-                "role": "Staller",
+                "role": "Bulky Support",
                 "movepool": ["protect", "recycle", "thunderbolt", "toxic"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["recycle", "substitute", "superfang", "thunderbolt", "toxic", "uturn"]
             }
         ]
     },
@@ -5154,7 +5171,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dazzlinggleam", "foulplay", "spikes", "thunderwave", "toxic"]
+                "movepool": ["dazzlinggleam", "foulplay", "spikes", "thunderwave"]
             },
             {
                 "role": "Bulky Attacker",

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -659,12 +659,12 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (species.id === 'muk') return 'Poison Touch';
 		if (['dusknoir', 'vespiquen'].includes(species.id)) return 'Pressure';
 		if (species.id === 'druddigon' && role === 'Bulky Support') return 'Rough Skin';
+		if (species.id === 'zebstrika') return (moves.has('wildcharge')) ? 'Sap Sipper' : 'Lightning Rod';
 		if (species.id === 'stoutland' || species.id === 'pangoro' && !counter.get('ironfist')) return 'Scrappy';
 		if (species.id === 'octillery') return 'Sniper';
 		if (species.id === 'stunfisk') return 'Static';
 		if (species.id === 'breloom') return 'Technician';
 		if (species.id === 'zangoose') return 'Toxic Boost';
-		if (species.id === 'porygon2' || species.id === 'gardevoir') return 'Trace';
 
 		if (abilities.has('Harvest') && (role === 'Bulky Support' || role === 'Staller')) return 'Harvest';
 		if (abilities.has('Regenerator') && role === 'AV Pivot') return 'Regenerator';
@@ -753,6 +753,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			}
 		}
 		if (moves.has('bellydrum')) return 'Sitrus Berry';
+		if (moves.has('waterspout')) return 'Choice Scarf';
 		if (moves.has('geomancy') || moves.has('skyattack')) return 'Power Herb';
 		if (moves.has('shellsmash')) {
 			return (ability === 'Solid Rock' && !!counter.get('priority')) ? 'Weakness Policy' : 'White Herb';

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -913,7 +913,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 
 		// Minimize confusion damage
 		if (
-			(!counter.get('Physical') || counter.get('Physical') === 1 && moves.has('foulplay')) &&
+			(counter.get('Physical') || 0) <= 1 && moves.has('foulplay') &&
 			!moves.has('copycat') && !moves.has('transform')
 		) {
 			evs.atk = 0;

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -912,7 +912,10 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		const level = this.getLevel(species);
 
 		// Minimize confusion damage
-		if (!counter.get('Physical') && !moves.has('copycat') && !moves.has('transform')) {
+		if (
+			(!counter.get('Physical') || counter.get('Physical') === 1 && moves.has('foulplay')) &&
+			!moves.has('copycat') && !moves.has('transform')
+		) {
 			evs.atk = 0;
 			ivs.atk = 0;
 		}

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -659,7 +659,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (species.id === 'muk') return 'Poison Touch';
 		if (['dusknoir', 'vespiquen'].includes(species.id)) return 'Pressure';
 		if (species.id === 'druddigon' && role === 'Bulky Support') return 'Rough Skin';
-		if (species.id === 'zebstrika') return (moves.has('wildcharge')) ? 'Sap Sipper' : 'Lightning Rod';
+		if (species.id === 'zebstrika') return moves.has('wildcharge') ? 'Sap Sipper' : 'Lightning Rod';
 		if (species.id === 'stoutland' || species.id === 'pangoro' && !counter.get('ironfist')) return 'Scrappy';
 		if (species.id === 'octillery') return 'Sniper';
 		if (species.id === 'stunfisk') return 'Static';

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -6052,10 +6052,6 @@
         "level": 87,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["crunch", "explosion", "flamethrower", "icebeam", "return", "surf", "uturn"]
-            },
-            {
                 "role": "Setup Sweeper",
                 "movepool": ["crunch", "doubleedge", "explosion", "flamecharge", "ironhead", "return", "swordsdance"],
                 "preferredTypes": ["Dark"]
@@ -6067,7 +6063,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "icebeam", "thunderbolt", "uturn"]
+                "movepool": ["defog", "flamethrower", "icebeam", "thunderbolt", "toxic", "uturn"]
             }
         ]
     },
@@ -6085,11 +6081,11 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "dracometeor", "flamethrower", "ironhead", "partingshot"]
+                "movepool": ["defog", "dracometeor", "flamethrower", "ironhead", "partingshot", "toxic", "uturn"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["flamecharge", "ironhead", "multiattack", "swordsdance"]
+                "movepool": ["flamecharge", "ironhead", "outrage", "swordsdance"]
             }
         ]
     },
@@ -6098,7 +6094,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic"],
+                "movepool": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic", "uturn"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -6108,7 +6104,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "multiattack", "partingshot", "rockslide", "thunderwave"]
+                "movepool": ["defog", "flamethrower", "multiattack", "partingshot", "surf", "toxic", "uturn"]
             }
         ]
     },
@@ -6117,7 +6113,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "shadowball", "toxic"]
+                "movepool": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "shadowball", "toxic", "uturn"]
             },
             {
                 "role": "Setup Sweeper",
@@ -6131,7 +6127,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "icebeam", "multiattack", "surf", "thunderbolt", "toxic", "uturn"]
+                "movepool": ["defog", "icebeam", "multiattack", "partingshot", "surf", "thunderbolt", "toxic", "uturn"]
             }
         ]
     },
@@ -6140,7 +6136,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "ironhead", "multiattack", "partingshot", "thunderwave"]
+                "movepool": ["defog", "flamethrower", "ironhead", "multiattack", "partingshot", "toxic", "uturn"]
             }
         ]
     },
@@ -6149,7 +6145,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic"]
+                "movepool": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic", "uturn"]
             },
             {
                 "role": "Setup Sweeper",
@@ -6162,7 +6158,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic"]
+                "movepool": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic", "uturn"]
             }
         ]
     },
@@ -6171,7 +6167,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic"]
+                "movepool": ["defog", "flamethrower", "icebeam", "multiattack", "partingshot", "toxic", "uturn"]
             },
             {
                 "role": "Setup Sweeper",
@@ -6184,7 +6180,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "multiattack", "thunderbolt", "toxic", "uturn"],
+                "movepool": ["defog", "flamethrower", "multiattack", "partingshot", "thunderbolt", "toxic", "uturn"],
                 "preferredTypes": ["Electric"]
             }
         ]
@@ -6194,7 +6190,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "grasspledge", "multiattack", "partingshot", "surf", "toxic"]
+                "movepool": ["defog", "flamethrower", "multiattack", "partingshot", "surf", "toxic", "uturn"]
             }
         ]
     },
@@ -6203,7 +6199,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "multiattack", "toxic", "uturn"]
+                "movepool": ["defog", "flamethrower", "multiattack", "partingshot", "toxic", "uturn"]
             }
         ]
     },
@@ -6212,7 +6208,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "grasspledge", "multiattack", "partingshot", "toxic"]
+                "movepool": ["defog", "flamethrower", "grasspledge", "multiattack", "partingshot", "toxic", "uturn"]
             }
         ]
     },
@@ -6221,7 +6217,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "flamethrower", "multiattack", "partingshot", "thunderbolt", "toxic"]
+                "movepool": ["defog", "flamethrower", "multiattack", "partingshot", "thunderbolt", "toxic", "uturn"]
             }
         ]
     },
@@ -6230,7 +6226,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["defog", "icebeam", "multiattack", "partingshot", "thunderbolt"]
+                "movepool": ["defog", "icebeam", "multiattack", "partingshot", "thunderbolt", "toxic", "uturn"]
             }
         ]
     },

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -1555,7 +1555,7 @@
                 "movepool": ["ancientpower", "lavaplume", "recover", "stealthrock", "toxic"]
             },
             {
-                "role": "Z-Move User",
+                "role": "Z-Move user",
                 "movepool": ["ancientpower", "earthpower", "fireblast", "shellsmash"],
                 "preferredTypes": ["Fire", "Rock"]
             }

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -28,6 +28,10 @@
                 "role": "Z-Move user",
                 "movepool": ["airslash", "earthquake", "fireblast", "holdhands", "roost"],
                 "preferredTypes": ["Normal"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["airslash", "earthquake", "fireblast", "roost", "willowisp"]
             }
         ]
     },
@@ -181,7 +185,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["encore", "hiddenpowerice", "knockoff", "nastyplot", "nuzzle", "thunderbolt", "voltswitch"]
+                "movepool": ["encore", "hiddenpowerice", "knockoff", "nastyplot", "nuzzle", "thunderbolt", "voltswitch"],
+                "preferredTypes": ["Ice"]
             },
             {
                 "role": "Fast Attacker",
@@ -859,7 +864,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psyshock", "substitute"]
+                "movepool": ["focusblast", "icebeam", "lovelykiss", "nastyplot", "psyshock"]
             }
         ]
     },
@@ -1550,8 +1555,9 @@
                 "movepool": ["ancientpower", "lavaplume", "recover", "stealthrock", "toxic"]
             },
             {
-                "role": "Setup Sweeper",
-                "movepool": ["ancientpower", "earthpower", "fireblast", "hiddenpowergrass", "shellsmash"]
+                "role": "Z-Move User",
+                "movepool": ["ancientpower", "earthpower", "fireblast", "shellsmash"],
+                "preferredTypes": ["Fire", "Rock"]
             }
         ]
     },
@@ -1659,7 +1665,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "earthquake", "jumpkick", "megahorn", "suckerpunch", "throatchop"],
+                "movepool": ["doubleedge", "earthquake", "jumpkick", "megahorn", "suckerpunch", "throatchop", "thunderwave"],
                 "preferredTypes": ["Ground"]
             }
         ]
@@ -2127,7 +2133,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["firefang", "ironhead", "knockoff", "playrough", "suckerpunch", "swordsdance"]
+                "movepool": ["ironhead", "knockoff", "playrough", "suckerpunch", "swordsdance"]
             }
         ]
     },
@@ -2500,6 +2506,10 @@
                 "role": "Fast Support",
                 "movepool": ["drainpunch", "fakeout", "knockoff", "recover", "shadowsneak", "stealthrock", "suckerpunch"],
                 "preferredTypes": ["Fighting"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["drainpunch", "knockoff", "recover", "stealthrock", "thunderwave", "toxic"]
             }
         ]
     },
@@ -3342,7 +3352,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["drainpunch", "gunkshot", "icepunch", "substitute", "suckerpunch", "swordsdance"]
+                "movepool": ["drainpunch", "earthquake", "gunkshot", "knockoff", "substitute", "suckerpunch", "swordsdance"]
             }
         ]
     },
@@ -3597,8 +3607,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "haze", "icepunch", "painsplit", "shadowsneak", "willowisp"],
+                "movepool": ["earthquake", "haze", "icepunch", "painsplit", "shadowsneak", "toxic", "willowisp"],
                 "preferredTypes": ["Ground"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["earthquake", "protect", "shadowsneak", "toxic"]
             }
         ]
     },
@@ -4578,7 +4592,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hornleech", "jumpkick", "return", "substitute", "swordsdance"],
+                "movepool": ["headbutt", "hornleech", "jumpkick", "return", "substitute", "swordsdance"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -4764,7 +4778,7 @@
         "level": 84,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["highjumpkick", "knockoff", "poisonjab", "stoneedge", "swordsdance", "uturn"],
                 "preferredTypes": ["Dark"]
             },
@@ -5208,7 +5222,11 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["energyball", "hurricane", "quiverdance", "sleeppowder", "substitute"]
+                "movepool": ["energyball", "hurricane", "quiverdance", "sleeppowder"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["bugbuzz", "hurricane", "quiverdance", "sleeppowder"]
             }
         ]
     },
@@ -5465,8 +5483,12 @@
         "level": 90,
         "sets": [
             {
-                "role": "Staller",
+                "role": "Bulky Support",
                 "movepool": ["protect", "recycle", "thunderbolt", "toxic"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["recycle", "substitute", "superfang", "thunderbolt", "toxic", "uturn"]
             }
         ]
     },
@@ -5493,7 +5515,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["dazzlinggleam", "foulplay", "spikes", "thunderwave", "toxic"]
+                "movepool": ["dazzlinggleam", "foulplay", "spikes", "thunderwave"]
             },
             {
                 "role": "Bulky Attacker",
@@ -5901,7 +5923,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["gigadrain", "leechseed", "moonblast", "spore", "strengthsap"]
+                "movepool": ["gigadrain", "hiddenpowerground", "leechseed", "moonblast", "spore", "strengthsap"]
             }
         ]
     },
@@ -5956,6 +5978,10 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["calmmind", "drainingkiss", "gigadrain", "hiddenpowerground"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["calmmind", "drainingkiss", "gigadrain", "hiddenpowerground"]
             }
         ]
     },
@@ -5964,7 +5990,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["focusblast", "nastyplot", "naturepower", "psychic", "psyshock", "thunderbolt", "trickroom"]
+                "movepool": ["focusblast", "nastyplot", "naturepower", "psychic", "psyshock", "thunderbolt", "trick"]
             }
         ]
     },
@@ -6337,7 +6363,11 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "focusblast", "hiddenpowerfire", "moonblast", "psychic", "psyshock"]
+                "movepool": ["focusblast", "moonblast", "psychic", "psyshock"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["calmmind", "focusblast", "moonblast", "psychic", "psyshock"]
             }
         ]
     },
@@ -6533,7 +6563,7 @@
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["aurasphere", "fleurcannon", "ironhead", "shiftgear", "thunderbolt"],
+                "movepool": ["aurasphere", "fleurcannon", "ironhead", "shiftgear"],
                 "preferredTypes": ["Fairy", "Steel"]
             }
         ]

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -4105,11 +4105,6 @@
             {
                 "role": "Fast Support",
                 "movepool": ["defog", "dragonpulse", "glare", "hiddenpowerfire", "leafstorm", "leechseed", "substitute"]
-            },
-            {
-                "role": "Z-Move user",
-                "movepool": ["glare", "hiddenpowerfire", "hyperbeam", "leafstorm"],
-                "preferredTypes": ["Normal"]
             }
         ]
     },

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -872,7 +872,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (['dusknoir', 'raikou', 'suicune', 'vespiquen'].includes(species.id)) return 'Pressure';
 		if (species.id === 'tsareena') return 'Queenly Majesty';
 		if (species.id === 'druddigon' && role === 'Bulky Support') return 'Rough Skin';
-		if (species.id === 'zebstrika') return (moves.has('wildcharge')) ? 'Sap Sipper' : 'Lightning Rod';
+		if (species.id === 'zebstrika') return moves.has('wildcharge') ? 'Sap Sipper' : 'Lightning Rod';
 		if (species.id === 'stoutland' || species.id === 'pangoro' && !counter.get('ironfist')) return 'Scrappy';
 		if (species.baseSpecies === 'sawsbuck' && moves.has('headbutt')) return 'Serene Grace';
 		if (species.id === 'octillery') return 'Sniper';

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1203,7 +1203,10 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		const level = this.getLevel(species);
 
 		// Minimize confusion damage
-		if (!counter.get('Physical') && !moves.has('copycat') && !moves.has('transform')) {
+		if (
+			(!counter.get('Physical') || counter.get('Physical') === 1 && moves.has('foulplay')) &&
+			!moves.has('copycat') && !moves.has('transform')
+		) {
 			evs.atk = 0;
 			ivs.atk = 0;
 		}

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -1205,7 +1205,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 
 		// Minimize confusion damage
 		if (
-			(!counter.get('Physical') || counter.get('Physical') === 1 && moves.has('foulplay')) &&
+			(counter.get('Physical') || 0) <= 1 && moves.has('foulplay') &&
 			!moves.has('copycat') && !moves.has('transform')
 		) {
 			evs.atk = 0;

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -322,6 +322,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		const incompatiblePairs = [
 			// These moves don't mesh well with other aspects of the set
 			[statusMoves, ['healingwish', 'memento', 'switcheroo', 'trick']],
+			[PIVOT_MOVES, PIVOT_MOVES],
 			[SETUP, PIVOT_MOVES],
 			[SETUP, HAZARDS],
 			[SETUP, badWithSetup],

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -337,7 +337,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			// These attacks are redundant with each other
 			['psychic', 'psyshock'],
 			['scald', ['hydropump', 'originpulse', 'waterpulse']],
-			['return', ['bodyslam', 'doubleedge']],
+			['return', ['bodyslam', 'doubleedge', 'headbutt']],
 			[['fierydance', 'firelash', 'lavaplume'], ['fireblast', 'magmastorm']],
 			[['flamethrower', 'flareblitz'], ['fireblast', 'overheat']],
 			['hornleech', 'woodhammer'],
@@ -870,13 +870,15 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (['dusknoir', 'raikou', 'suicune', 'vespiquen'].includes(species.id)) return 'Pressure';
 		if (species.id === 'tsareena') return 'Queenly Majesty';
 		if (species.id === 'druddigon' && role === 'Bulky Support') return 'Rough Skin';
+		if (species.id === 'zebstrika') return (moves.has('wildcharge')) ? 'Sap Sipper' : 'Lightning Rod';
 		if (species.id === 'stoutland' || species.id === 'pangoro' && !counter.get('ironfist')) return 'Scrappy';
+		if (species.baseSpecies === 'sawsbuck' && moves.has('headbutt')) return 'Serene Grace';
 		if (species.id === 'octillery') return 'Sniper';
 		if (species.id === 'kommoo' && role === 'Z-Move user') return 'Soundproof';
 		if (species.id === 'stunfisk') return 'Static';
 		if (species.id === 'breloom') return 'Technician';
 		if (species.id === 'zangoose') return 'Toxic Boost';
-		if (species.id === 'porygon2' || species.id === 'gardevoir') return 'Trace';
+		if (counter.get('setup') && (species.id === 'magcargo' || species.id === 'kabutops')) return 'Weak Armor';
 
 		if (abilities.has('Gluttony') && (moves.has('recycle') || moves.has('bellydrum'))) return 'Gluttony';
 		if (abilities.has('Harvest') && (role === 'Bulky Support' || role === 'Staller')) return 'Harvest';
@@ -885,7 +887,6 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (abilities.has('Shed Skin') && moves.has('rest') && !moves.has('sleeptalk')) return 'Shed Skin';
 		if (abilities.has('Sniper') && moves.has('focusenergy')) return 'Sniper';
 		if (abilities.has('Unburden') && ['acrobatics', 'bellydrum', 'closecombat'].some(m => moves.has(m))) return 'Unburden';
-		if (abilities.has('Weak Armor') && types.has('Water') && counter.get('setup')) return 'Weak Armor';
 
 		let abilityAllowed: Ability[] = [];
 		// Obtain a list of abilities that are allowed (not culled)
@@ -998,6 +999,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				return 'Sitrus Berry';
 			}
 		}
+		if (moves.has('waterspout')) return 'Choice Scarf';
 		if (moves.has('geomancy') || moves.has('skyattack')) return 'Power Herb';
 		if (moves.has('shellsmash')) {
 			return (ability === 'Solid Rock' && !!counter.get('priority')) ? 'Weakness Policy' : 'White Herb';
@@ -1347,14 +1349,6 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				}
 				const species = this.sample(currentSpeciesPool);
 
-				if (this.gen === 7) {
-					// If the team has a Z-Move user, reject Pokemon that only have the Z-Move user role
-					if (
-						this.randomSets[species.id]["sets"].length === 1 &&
-						this.randomSets[species.id]["sets"][0]["role"] === 'Z-Move user' &&
-						teamDetails.zMove
-					) continue;
-				}
 				if (!species.exists) continue;
 
 				// Limit to one of each species (Species Clause)

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -313,8 +313,9 @@ export class RandomGen7Teams extends RandomGen8Teams {
 
 		// Develop additional move lists
 		const badWithSetup = ['defog', 'dragontail', 'haze', 'healbell', 'nuzzle', 'pursuit', 'rapidspin', 'toxic'];
+		// Nature Power is Tri Attack this gen
 		const statusMoves = this.dex.moves.all()
-			.filter(move => move.category === 'Status')
+			.filter(move => move.category === 'Status' && move.id !== 'naturepower')
 			.map(move => move.id);
 
 		// General incompatibilities

--- a/data/mods/gen8/abilities.ts
+++ b/data/mods/gen8/abilities.ts
@@ -1108,7 +1108,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	},
 	trace: {
 		inherit: true,
-		rating: 2.5,
+		rating: 3,
 	},
 	transistor: {
 		inherit: true,

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -4769,13 +4769,8 @@
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["Behemoth Bash", "Body Press", "Coaching", "Iron Defense", "Protect"],
+                "movepool": ["Body Press", "Coaching", "Heavy Slam", "Iron Defense", "Protect", "Snarl", "Wide Guard"],
                 "teraTypes": ["Fighting", "Fire", "Steel"]
-            },
-            {
-                "role": "Doubles Bulky Attacker",
-                "movepool": ["Body Press", "Iron Defense", "Protect", "Snarl", "Wide Guard"],
-                "teraTypes": ["Fighting", "Fire"]
             }
         ]
     },

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -4,7 +4,7 @@
         "sets": [
             {
                 "role": "Offensive Protect",
-                "movepool": ["Earth Power", "Knock Off", "Leaf Storm", "Protect", "Sludge Bomb"],
+                "movepool": ["Earth Power", "Giga Drain", "Knock Off", "Leaf Storm", "Protect", "Sludge Bomb"],
                 "teraTypes": ["Dark", "Water"]
             }
         ]
@@ -1491,6 +1491,16 @@
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Bullet Seed", "Close Combat", "Mach Punch", "Protect", "Rock Tomb", "Spore"],
                 "teraTypes": ["Fighting"]
+            }
+        ]
+    },
+    "vigoroth": {
+        "level": 90,
+        "sets": [
+            {
+                "role": "Doubles Bulky Attacker",
+                "movepool": ["After You", "Double-Edge", "Encore", "Icy Wind", "Knock Off", "Slack Off", "Thunder Wave"],
+                "teraTypes": ["Ghost"]
             }
         ]
     },
@@ -3684,7 +3694,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Charm", "Fake Out", "Helping Hand", "Light Screen", "Psychic", "Reflect"],
+                "movepool": ["Fake Out", "Fake Tears", "Helping Hand", "Light Screen", "Psychic", "Reflect"],
                 "teraTypes": ["Dark", "Steel"]
             },
             {
@@ -5044,7 +5054,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Bug Bite", "Circle Throw", "Knock Off", "Sticky Web", "String Shot", "U-turn"],
+                "movepool": ["Circle Throw", "Knock Off", "Lunge", "Sticky Web", "String Shot", "U-turn"],
                 "teraTypes": ["Water"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -26,6 +26,11 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Flare Blitz", "Outrage", "Swords Dance"],
                 "teraTypes": ["Dragon", "Ground"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Air Slash", "Fire Blast", "Solar Beam", "Sunny Day"],
+                "teraTypes": ["Fire", "Grass"]
             }
         ]
     },
@@ -1144,7 +1149,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Alluring Voice", "Calm Mind", "Morning Sun", "Psychic", "Shadow Ball", "Trick"],
+                "movepool": ["Alluring Voice", "Calm Mind", "Morning Sun", "Psychic", "Psyshock", "Shadow Ball", "Trick"],
                 "teraTypes": ["Fairy", "Psychic"]
             }
         ]
@@ -2266,6 +2271,11 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Bullet Seed", "Headlong Rush", "Rock Blast", "Shell Smash"],
                 "teraTypes": ["Grass", "Ground", "Rock", "Water"]
+            },
+            {
+                "role": "Fast Bulky Setup",
+                "movepool": ["Headlong Rush", "Shell Smash", "Stone Edge", "Wood Hammer"],
+                "teraTypes": ["Ground", "Rock", "Water"]
             }
         ]
     },
@@ -2290,6 +2300,11 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Flip Turn", "Ice Beam", "Knock Off", "Roost", "Stealth Rock", "Surf", "Yawn"],
+                "teraTypes": ["Flying", "Grass"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Grass Knot", "Ice Beam", "Roost", "Surf"],
                 "teraTypes": ["Flying", "Grass"]
             }
         ]
@@ -2749,7 +2764,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Body Press", "Flash Cannon", "Iron Defense", "Power Gem", "Rest"],
+                "movepool": ["Body Press", "Flash Cannon", "Iron Defense", "Power Gem", "Rest", "Thunder Wave"],
                 "teraTypes": ["Fighting"]
             },
             {
@@ -2764,12 +2779,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Brick Break", "Earthquake", "Leech Life", "Pain Split", "Poltergeist", "Shadow Sneak", "Trick"],
-                "teraTypes": ["Fighting", "Ghost", "Ground"]
+                "movepool": ["Earthquake", "Leech Life", "Pain Split", "Poltergeist", "Shadow Sneak", "Trick"],
+                "teraTypes": ["Ghost", "Ground"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Brick Break", "Pain Split", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
+                "movepool": ["Earthquake", "Pain Split", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
                 "teraTypes": ["Dark", "Fairy"]
             }
         ]
@@ -3075,7 +3090,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Earthquake", "Extreme Speed", "Recover", "Shadow Claw", "Swords Dance"],
-                "teraTypes": ["Normal"]
+                "teraTypes": ["Ghost", "Normal"]
             }
         ]
     },
@@ -3099,8 +3114,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Fire Blast", "Judgment", "Recover", "Sludge Bomb"],
-                "teraTypes": ["Fire", "Ghost", "Poison"]
+                "movepool": ["Calm Mind", "Dazzling Gleam", "Judgment", "Recover", "Sludge Bomb"],
+                "teraTypes": ["Fairy", "Poison"]
             }
         ]
     },
@@ -3163,14 +3178,14 @@
                 "teraTypes": ["Fire", "Ground"]
             },
             {
-                "role": "Bulky Setup",
+                "role": "Fast Bulky Setup",
                 "movepool": ["Dragon Dance", "Earthquake", "Flare Blitz", "Recover"],
                 "teraTypes": ["Fire", "Ground"]
             },
             {
-                "role": "Fast Bulky Setup",
-                "movepool": ["Calm Mind", "Earth Power", "Ice Beam", "Judgment", "Recover", "Thunderbolt"],
-                "teraTypes": ["Electric", "Ground"]
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Earth Power", "Energy Ball", "Judgment", "Recover"],
+                "teraTypes": ["Grass", "Ground"]
             }
         ]
     },
@@ -3250,7 +3265,12 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Flare Blitz", "Gunk Shot", "Liquidation", "Recover", "Swords Dance"],
-                "teraTypes": ["Fire", "Ground", "Water"]
+                "teraTypes": ["Ground"]
+            },
+            {
+                "role": "Fast Bulky Setup",
+                "movepool": ["Earthquake", "Extreme Speed", "Gunk Shot", "Swords Dance"],
+                "teraTypes": ["Ground", "Normal"]
             }
         ]
     },
@@ -3369,7 +3389,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["High Horsepower", "Overheat", "Volt Switch", "Wild Charge"],
+                "movepool": ["High Horsepower", "Overheat", "Supercell Slam", "Volt Switch"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -3400,7 +3420,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Close Combat", "Facade", "Knock Off", "Mach Punch"],
-                "teraTypes": ["Fighting", "Normal"]
+                "teraTypes": ["Normal"]
             }
         ]
     },
@@ -3439,7 +3459,7 @@
         "sets": [
             {
                 "role": "Tera Blast user",
-                "movepool": ["Alluring Voice", "Giga Drain", "Quiver Dance", "Sleep Powder", "Tera Blast"],
+                "movepool": ["Giga Drain", "Pollen Puff", "Quiver Dance", "Sleep Powder", "Tera Blast"],
                 "teraTypes": ["Fire", "Rock"]
             },
             {
@@ -3523,7 +3543,7 @@
         "level": 84,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["Dark Pulse", "Flamethrower", "Focus Blast", "Nasty Plot", "Psychic", "Sludge Bomb", "Trick", "U-turn"],
                 "teraTypes": ["Poison"]
             }
@@ -4639,7 +4659,7 @@
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Calm Mind", "Draining Kiss", "Giga Drain", "Tera Blast"],
+                "movepool": ["Calm Mind", "Draining Kiss", "Giga Drain", "Synthesis", "Tera Blast"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -5490,12 +5510,12 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Flame Charge", "Shadow Ball", "Slack Off", "Torch Song"],
-                "teraTypes": ["Fire", "Water"]
+                "teraTypes": ["Fairy", "Water"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Hex", "Slack Off", "Torch Song", "Will-O-Wisp"],
-                "teraTypes": ["Ghost", "Water"]
+                "teraTypes": ["Fairy", "Ghost", "Water"]
             }
         ]
     },
@@ -5580,7 +5600,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Bite", "Encore", "Population Bomb", "Tidy Up"],
-                "teraTypes": ["Normal"]
+                "teraTypes": ["Ghost", "Normal"]
             }
         ]
     },
@@ -6074,7 +6094,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Bullet Seed", "Crunch", "Seed Bomb", "Spore", "Stun Spore", "Synthesis"],
+                "movepool": ["Bullet Seed", "Crunch", "Seed Bomb", "Spore", "Stun Spore", "Sucker Punch", "Synthesis"],
                 "teraTypes": ["Poison"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2069,12 +2069,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Body Press", "Iron Defense", "Rest", "Stealth Rock", "Stone Edge", "Thunder Wave"],
+                "movepool": ["Body Press", "Iron Defense", "Stealth Rock", "Stone Edge", "Thunder Wave"],
                 "teraTypes": ["Fighting"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Body Press", "Curse", "Rest", "Stone Edge"],
+                "movepool": ["Body Press", "Curse", "Iron Defense", "Rest", "Stone Edge"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -3365,7 +3365,7 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Aqua Jet", "Flip Turn", "Grass Knot", "Hydro Pump", "Ice Beam", "Knock Off", "Megahorn", "Sacred Sword"],
-                "teraTypes": ["Dark", "Water"]
+                "teraTypes": ["Dark", "Grass", "Water"]
             },
             {
                 "role": "Setup Sweeper",

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -6409,7 +6409,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Dragon Pulse", "Dragon Tail", "Giga Drain", "Recover", "Sucker Punch"],
+                "movepool": ["Dragon Pulse", "Dragon Tail", "Giga Drain", "Recover"],
                 "teraTypes": ["Steel"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -4773,11 +4773,6 @@
                 "teraTypes": ["Dark", "Fighting"]
             },
             {
-                "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Flare Blitz", "Knock Off", "Psychic Fangs", "Sunsteel Strike"],
-                "teraTypes": ["Dark", "Fighting"]
-            },
-            {
                 "role": "Bulky Attacker",
                 "movepool": ["Close Combat", "Flare Blitz", "Knock Off", "Morning Sun", "Psychic Fangs", "Sunsteel Strike"],
                 "teraTypes": ["Water"]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -535,7 +535,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Energy Ball", "Leaf Storm", "Taunt", "Thunder Wave", "Thunderbolt", "Volt Switch"],
-                "teraTypes": ["Grass"]
+                "teraTypes": ["Electric", "Grass"]
             },
             {
                 "role": "Fast Support",

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1166,7 +1166,7 @@ export class RandomTeams {
 		if (species.id === 'toucannon' && !counter.get('skilllink')) return 'Keen Eye';
 		if (species.id === 'reuniclus') return 'Magic Guard';
 		if (species.id === 'smeargle' && !counter.get('technician')) return 'Own Tempo';
-		if (species.id === 'zebstrika') return (moves.has('thunderbolt')) ? 'Lightning Rod' : 'Sap Sipper';
+		if (species.id === 'zebstrika') return moves.has('thunderbolt') ? 'Lightning Rod' : 'Sap Sipper';
 		if (species.id === 'sandaconda' || (species.id === 'scrafty' && moves.has('rest'))) return 'Shed Skin';
 		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';
 		if (species.id === 'charizard' && moves.has('sunnyday')) return 'Solar Power';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1169,6 +1169,7 @@ export class RandomTeams {
 		if (species.id === 'zebstrika') return (moves.has('thunderbolt')) ? 'Lightning Rod' : 'Sap Sipper';
 		if (species.id === 'sandaconda' || (species.id === 'scrafty' && moves.has('rest'))) return 'Shed Skin';
 		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';
+		if (species.id === 'charizard' && moves.has('sunnyday')) return 'Solar Power';
 		if (species.id === 'dipplin') return 'Sticky Hold';
 		if (species.id === 'breloom' || species.id === 'cinccino') return 'Technician';
 		if (species.id === 'shiftry' && moves.has('tailwind')) return 'Wind Rider';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1102,7 +1102,10 @@ export class RandomTeams {
 		case 'Swarm':
 			return (!counter.get('Bug') || !!counter.get('recovery'));
 		case 'Swift Swim':
-			return (abilities.has('Intimidate') || (!moves.has('raindance') && !teamDetails.rain));
+			return (
+				abilities.has('Intimidate') || (!moves.has('raindance') && !teamDetails.rain) ||
+				(species.id === 'drednaw' && moves.has('crunch'))
+			);
 		case 'Synchronize':
 			return (species.id !== 'umbreon' && species.id !== 'rabsca');
 		case 'Technician':
@@ -1163,7 +1166,7 @@ export class RandomTeams {
 		if (species.id === 'toucannon' && !counter.get('skilllink')) return 'Keen Eye';
 		if (species.id === 'reuniclus') return 'Magic Guard';
 		if (species.id === 'smeargle' && !counter.get('technician')) return 'Own Tempo';
-		if (species.id === 'zebstrika') return (moves.has('wildcharge')) ? 'Sap Sipper' : 'Lightning Rod';
+		if (species.id === 'zebstrika') return (moves.has('thunderbolt')) ? 'Lightning Rod' : 'Sap Sipper';
 		if (species.id === 'sandaconda' || (species.id === 'scrafty' && moves.has('rest'))) return 'Shed Skin';
 		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';
 		if (species.id === 'dipplin') return 'Sticky Hold';
@@ -1322,6 +1325,7 @@ export class RandomTeams {
 			(species.id === 'magnezone' && moves.has('bodypress') && !isDoubles)
 		) return 'Choice Scarf';
 		if (species.id === 'rampardos' && (role === 'Fast Attacker' || isDoubles)) return 'Choice Scarf';
+		if (species.id === 'palkia' && counter.get('Special') < 4) return 'Lustrous Orb';
 		if (
 			moves.has('courtchange') ||
 			!isDoubles && (species.id === 'luvdisc' || (species.id === 'terapagos' && !moves.has('rest')))
@@ -1478,13 +1482,13 @@ export class RandomTeams {
 		}
 		if (
 			(counter.get('Special') >= 4) ||
-			(counter.get('Special') >= 3 && ['flipturn', 'partingshot', 'uturn'].some(m => moves.has(m)))
+			(counter.get('Special') >= 3 && ['flipturn', 'uturn'].some(m => moves.has(m)))
 		) {
 			const scarfReqs = (
 				role !== 'Wallbreaker' &&
 				species.baseStats.spa >= 100 &&
 				species.baseStats.spe >= 60 && species.baseStats.spe <= 108 &&
-				ability !== 'Speed Boost' && ability !== 'Tinted Lens' && !counter.get('Physical') && !counter.get('priority')
+				ability !== 'Speed Boost' && ability !== 'Tinted Lens' && !moves.has('uturn') && !counter.get('priority')
 			);
 			return (scarfReqs && this.randomChance(1, 2)) ? 'Choice Scarf' : 'Choice Specs';
 		}
@@ -1496,7 +1500,6 @@ export class RandomTeams {
 			return 'Assault Vest';
 		}
 		if (species.id === 'golem') return (counter.get('speedsetup')) ? 'Weakness Policy' : 'Custap Berry';
-		if (species.id === 'palkia') return 'Lustrous Orb';
 		if (moves.has('substitute')) return 'Leftovers';
 		if (moves.has('stickyweb') && species.id !== 'araquanid' && isLead) return 'Focus Sash';
 		if (this.dex.getEffectiveness('Rock', species) >= 1) return 'Heavy-Duty Boots';


### PR DESCRIPTION
**Gen 9 Random Battle:**

-Torterra now once again has an additional set with White Herb, Wood Hammer, and Stone Edge.
-Charizard now has a third set: Sunny Day, Fire Blast, Solar Beam, and Air Slash with Solar Power. It won't always be using Sunny Day with this set, but when it does it will be very, very strong.
-Calm Mind Arceus-Fire now always has Recover, and rolls between Energy Ball and Earth Power for coverage.
-Arceus-Poison now always has Earthquake, only runs Tera Ground on its original set, and has a new second set of Swords Dance, Earthquake, Extreme Speed, and Gunk Shot with Tera Ground/Normal.
-Empoleon now runs a second set of Bulky Attacker, with Roost, Grass Knot, Ice Beam, and Surf with Leftovers.
-Regirock now always has either Stealth Rock or Setup, similarly to Registeel.
-Crunch Drednaw will no longer generate Swift Swim with a rain-setting teammate.
-Solgaleo no longer has a Fast Attacker set and therefore no longer runs Choice Scarf or Choice Band.
-Keldeo now once again can roll Choice Scarf, with Flip Turn + Secret Sword + Hydro Pump + Air Slash. Achieved by allowing Flip Turn to generate Choice Scarf on special attackers, when previously it could only give Specs.
-Arceus-Dark: -Tera Fire, -Tera Ghost, -Fire Blast, +Dazzling Gleam
-Zebstrika: -Wild Charge, +Supercell Slam
-Tera Blast Comfey: +Synthesis
-Dipplin: -Sucker Punch
-Setup Probopass: +Thunder Wave
-Espeon: +Psyshock
-Maushold: +Tera Ghost
-Arceus (Normal): +Tera Ghost
-AV Samurott: +Tera Grass
-Fast Attacker Electrode-Hisui: +Tera Electric
-Skeledirge: -Tera Fire on Flame Charge, +Tera Fairy on both sets
-Conkeldurr: -Tera Fighting
-Dusknoir no longer runs Brick Break (and once again runs Earthquake on its support set) due to statistical analysis of previous changes.
-Brute Bonnet's new Synthesis set now always runs Sucker Punch and does not always run Crunch, due to statistical analysis of previous changes.
-Tera Blast Lilligant now runs Pollen Puff instead of Alluring Voice again due to statistical analysis of previous changes.

**Gen 9 Random Doubles:**
-Vigoroth now exists. It is level 90, and runs Double-Edge, Knock Off, and any two of Encore, Slack Off, Icy Wind/Thunder Wave, and After You (!)
-Spidops: -Bug Bite, +Lunge
-Venusaur: +Giga Drain (roll with Leaf Storm)
-Palkia now runs Lustrous Orb when it isn't Choice Specs.
-Zamazenta-Crowned's sets have been merged, and it now runs Heavy Slam instead of Behemoth Bash. Sets without a Steel move no longer exist.

**Old Gens:**
-In Gens 4-7, Wailord and Kyogre now always run Choice Scarf when they have Water Spout.
-In Gens 4-7, Porygon2 now runs Download 66% of the time.
-In Gens 4-7, Toxicroak now runs Earthquake. In Gens 6-7, it also now runs Knock Off sometimes and no longer runs Ice Punch.
-In Gens 5-7, Zebstrika now always gets Sap Sipper with Wild Charge and Lightning Rod with Thunderbolt.
-In Gens 5-7, Jynx no longer runs Substitute.
-In Gens 5-7, Pokemon with Foul Play as their only attack will get minimum Attack investment.
-In Gens 6-7, Dedenne now has a Staller set with Recycle, Thunderbolt, Toxic, and any one of Substitute, Super Fang, or U-turn.
-In Gens 6-7, Mienshao's Reckless set no longer runs Choice Scarf, in favor of more Choice Band.
-In Gens 6-7, Dusknoir now sometimes runs Toxic on its Bulky Attacker set and has an additional Staller set of Shadow Sneak + EQ + Toxic + Protect.
-In Gens 6-7, Fast Support Raichu now always has Hidden Power Ice.
-In Gens 6-7, Kecleon now has a second set of Drain Punch, Knock Off, Recover, and Toxic/Stealth Rock/Thunder Wave with Leftovers.
-In Gens 6-7, Mega Mawile no longer runs Fire Fang. In Gen 6, it also now runs Knock Off sometimes.
-In Gens 6-7, Klefki now always runs Spikes and never has Toxic.
-In Gens 6-7, Vivillon now always runs Sleep Powder and never runs Substitute.
-In Gen 7, Z-Move Magearna no longer runs Thunderbolt.
-In Gen 7, Oranguru now runs Trick instead of Trick Room.
-In Gen 7, Omastar no longer runs Weak Armor.
-In Gen 7, Shell Smash Magcargo now runs Weak Armor and Firium/Rockium Z.
-In Gen 7, Charizard now has an additional non-Z-Move set of Bulky Attacker with Fire Blast, Air Slash, Roost, Earthquake, and Will-O-Wisp. Code relating to Pokemon with only Z-Move user sets has been removed as a result.
-In Gen 7, Shiinotic now sometimes runs Hidden Power Ground.
-In Gen 7, Tapu Lele's set has been split into a Choice item set with both Psychic and Psyshock and a Calm Mind set. Neither set runs Hidden Power Fire, and both sets always have Focus Blast.
-In Gen 7, Comfey now once again has a Life Orb Calm Mind set, but this time in addition to the Leftovers one. The sets are identical moves-wise.
-In Gen 7, Sawsbuck now runs Headbutt sometimes, and will get Serene Grace when it does so. Headbutt will not generate with Return.
-In Gen 7, all Support Silvally sets now run Toxic, Parting Shot, and U-turn, and no longer run Thunder Wave. Parting Shot and U-turn do not generate together. Parting Shot is not present on Silvally-Bug.
-In Gen 7, Silvally-Poison no longer runs Grass Pledge.
-In Gen 7, Silvally-Fairy now runs Surf instead of Rock Slide.
-In Gen 7, Swords Dance Silvally-Dragon now runs Outrage instead of Multi-Attack.
-In Gen 7, Silvally (Normal) no longer runs Choice items or Assault Vest (its Bulky Attacker set is gone)
-In Gen 7, Z-Hyper Beam Serperior no longer exists.
-In Gen 5, Butterfree now always runs Sleep Powder, only runs Bug Buzz for an attack, and is a 50/50 roll between Substitute and Roost.
-In Gen 4, Sharpedo now has a set split between Waterfall and Hydro Pump and no longer runs Hidden Power Grass.
-In Gen 3, Muk now runs Hidden Power Ground instead of Hidden Power Ghost and Brick Break. Its Wallbreaker set always has Hidden Power Ground. It no longer runs Haze. Its Curse set now always has Rest.
-In Gen 3, Politoed now runs a third set of RestTalk + Surf + Ice Beam/Toxic.
-In Gen 3, Spinda no longer runs SubPunch.
-In Gen 3, Charizard now has a Berry Sweeper set with Dragon Claw, Fire Blast, HP Grass, Substitute, and a Petaya Berry.
-In Gen 3, Medicham now has a Berry Sweeper set with Substitute, Reversal, Bulk Up, and Shadow Ball with a Salac Berry.
-In Gen 3, Primeape now has a Berry Sweeper set with Substitute, Reversal, Bulk Up, and Hidden Power Ghost with a Salac Berry.