### PR TITLE
Fix rule EV Limit = 0

### DIFF
--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -212,7 +212,8 @@ export class RuleTable extends Map<string, string> {
 		this.defaultLevel = Number(this.valueRules.get('defaultlevel')) || 0;
 		this.adjustLevel = Number(this.valueRules.get('adjustlevel')) || null;
 		this.adjustLevelDown = Number(this.valueRules.get('adjustleveldown')) || null;
-		this.evLimit = Number(this.valueRules.get('evlimit')) || null;
+		this.evLimit = Number(this.valueRules.get('evlimit'));
+		if (isNaN(this.evLimit)) this.evLimit = null;
 
 		if (this.valueRules.get('pickedteamsize') === 'Auto') {
 			this.pickedTeamSize = (


### PR DESCRIPTION
I was doing a mod with 0 EVs and found this bug.
The old code would convert 0 to null, allowing infinite EVs instead of zero.

There are many ways to do this, feel free to change it.