### PR TITLE
Random Battles minor bug fixes

### DIFF
--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -909,8 +909,8 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			evs.hp -= 4;
 		}
 
-		// Minimize confusion damage
-		if ((counter.get('Physical') || 0) <= 1 && moves.has('foulplay') && !moves.has('transform')) {
+		// Minimize confusion damage, including if Foul Play is its only physical attack
+		if ((!counter.get('Physical') || (counter.get('Physical') <= 1 && moves.has('foulplay'))) && !moves.has('transform')) {
 			evs.atk = 0;
 			ivs.atk = hasHiddenPower ? (ivs.atk || 31) - 28 : 0;
 		}

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -6,7 +6,7 @@ import {toID} from '../../../sim/dex';
 
 // Moves that restore HP:
 const RECOVERY_MOVES = [
-	'healorder', 'milkdrink', 'moonlight', 'morningsun', 'recover', 'roost', 'slackoff', 'softboiled', 'synthesis',
+	'healorder', 'milkdrink', 'moonlight', 'morningsun', 'recover', 'recycle', 'roost', 'slackoff', 'softboiled', 'synthesis',
 ];
 // Moves that boost Attack:
 const PHYSICAL_SETUP = [
@@ -911,9 +911,9 @@ export class RandomGen6Teams extends RandomGen7Teams {
 
 		const level = this.getLevel(species);
 
-		// Minimize confusion damage
+		// Minimize confusion damage, including if Foul Play is its only physical attack
 		if (
-			(counter.get('Physical') || 0) <= 1 && moves.has('foulplay') &&
+			(!counter.get('Physical') || (counter.get('Physical') <= 1 && moves.has('foulplay'))) &&
 			!moves.has('copycat') && !moves.has('transform')
 		) {
 			evs.atk = 0;

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -874,7 +874,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (species.id === 'druddigon' && role === 'Bulky Support') return 'Rough Skin';
 		if (species.id === 'zebstrika') return moves.has('wildcharge') ? 'Sap Sipper' : 'Lightning Rod';
 		if (species.id === 'stoutland' || species.id === 'pangoro' && !counter.get('ironfist')) return 'Scrappy';
-		if (species.baseSpecies === 'sawsbuck' && moves.has('headbutt')) return 'Serene Grace';
+		if (species.baseSpecies === 'Sawsbuck' && moves.has('headbutt')) return 'Serene Grace';
 		if (species.id === 'octillery') return 'Sniper';
 		if (species.id === 'kommoo' && role === 'Z-Move user') return 'Soundproof';
 		if (species.id === 'stunfisk') return 'Static';
@@ -1203,9 +1203,9 @@ export class RandomGen7Teams extends RandomGen8Teams {
 
 		const level = this.getLevel(species);
 
-		// Minimize confusion damage
+		// Minimize confusion damage, including if Foul Play is its only physical attack
 		if (
-			(counter.get('Physical') || 0) <= 1 && moves.has('foulplay') &&
+			(!counter.get('Physical') || (counter.get('Physical') <= 1 && moves.has('foulplay'))) &&
 			!moves.has('copycat') && !moves.has('transform')
 		) {
 			evs.atk = 0;


### PR DESCRIPTION
Fixes some minor oversights/bugs in the most recent Random Battles update:
-In Gen 5-7, Pokemon with no physical attacks, or Foul Play as its only physical attack, will get min Attack EVs/IVs
-In Gen 6, Recycle now counts as a recovery move as intended (affects Dedenne)
-In Gen 7, Sawsbuck will always get Serene Grace with Headbutt