### PR TITLE
Refactor desc. in non-autoconfirmed error messages

### DIFF
--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2771,7 +2771,10 @@ export const commands: Chat.ChatCommands = {
 		if (Monitor.countNetRequests(connection.ip)) {
 			return this.errorReply(`You are using this command too quickly. Wait a bit and try again.`);
 		}
-		if (!user.autoconfirmed) return this.errorReply(`Only autoconfirmed users can use this command. Autoconfirmed users have won at least one rated battle and been registered for one week or longer`);
+		if (!user.autoconfirmed) {
+			return this.errorReply(`Only autoconfirmed users can use this command. ` +
+		`Autoconfirmed users have won at least one rated battle and been registered for one week or longer`);
+		}
 		target = toID(target);
 		if (!target) target = user.id;
 		let rawResult;

--- a/server/chat-commands/info.ts
+++ b/server/chat-commands/info.ts
@@ -2771,7 +2771,7 @@ export const commands: Chat.ChatCommands = {
 		if (Monitor.countNetRequests(connection.ip)) {
 			return this.errorReply(`You are using this command too quickly. Wait a bit and try again.`);
 		}
-		if (!user.autoconfirmed) return this.errorReply(`Only autoconfirmed users can use this command.`);
+		if (!user.autoconfirmed) return this.errorReply(`Only autoconfirmed users can use this command. Autoconfirmed users have won at least one rated battle and been registered for one week or longer`);
 		target = toID(target);
 		if (!target) target = user.id;
 		let rawResult;

--- a/server/chat-plugins/friends.ts
+++ b/server/chat-plugins/friends.ts
@@ -158,7 +158,10 @@ export const Friends = new class {
 	checkCanUse(context: Chat.CommandContext | Chat.PageContext) {
 		const user = context.user;
 		if (!user.autoconfirmed) {
-			throw new Chat.ErrorMessage(context.tr`You must be autoconfirmed to use the friends feature.`);
+			throw new Chat.ErrorMessage(context.tr(
+				`You must be autoconfirmed to use the friends feature ` +
+				`(autoconfirmed users have won at least one rated battle and been registered for one week or longer).`
+			));
 		}
 		if (user.locked || user.namelocked || user.semilocked || user.permalocked) {
 			throw new Chat.ErrorMessage(`You are locked, and so cannot use the friends feature.`);

--- a/server/chat-plugins/teams.ts
+++ b/server/chat-plugins/teams.ts
@@ -349,7 +349,12 @@ export const TeamsHandler = new class {
 			err("You cannot currently use the teams database.");
 		}
 		if (user.locked || user.semilocked) err("You cannot use the teams database while locked.");
-		if (!user.autoconfirmed) err("You must be autoconfirmed to use the teams database.");
+		if (!user.autoconfirmed) {
+			err(
+				"You must be autoconfirmed to use the teams database " +
+				"(autoconfirmed users have won at least one rated battle and been registered for one week or longer)."
+			);
+		}
 	}
 	async count(user: string | User) {
 		const id = toID(user);

--- a/server/chat-plugins/wifi.tsx
+++ b/server/chat-plugins/wifi.tsx
@@ -413,7 +413,8 @@ export class QuestionGiveaway extends Giveaway {
 		tid = toID(tid);
 		if (isNaN(parseInt(tid)) || tid.length < 5 || tid.length > 6) throw new Chat.ErrorMessage("Invalid TID");
 		if (!targetUser.autoconfirmed) {
-			throw new Chat.ErrorMessage(`User '${targetUser.name}' needs to be autoconfirmed to give something away.`);
+			throw new Chat.ErrorMessage(`User '${targetUser.name}' needs to be autoconfirmed ` +
+			`(have won at least one rated battle and been registered for one week or longer) to give something away.`);
 		}
 		if (Giveaway.checkBanned(context.room!, targetUser)) {
 			throw new Chat.ErrorMessage(`User '${targetUser.name}' is giveaway banned.`);

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1236,7 +1236,9 @@ export class CommandContext extends MessageContext {
 		// If the corresponding config option is set, non-AC users cannot send links, except to staff.
 		if (Config.restrictLinks && !user.autoconfirmed) {
 			if (this.checkBannedLinks(message).length && !(targetUser?.can('lock') || room?.settings.isHelp)) {
-				throw new Chat.ErrorMessage("Your account must be autoconfirmed to send links to other users, except for global staff.");
+				throw new Chat.ErrorMessage("Your account must be autoconfirmed " +
+					"(have won at least one rated battle and been registered for one week or longer) " +
+					"to send links to other users, except for global staff.");
 			}
 		}
 

--- a/server/ladders.ts
+++ b/server/ladders.ts
@@ -187,7 +187,8 @@ class Ladder extends LadderStore {
 		if (currentChallenges && currentChallenges.length >= 3 && !user.autoconfirmed) {
 			connection.popup(
 				`This user already has 3 pending challenges.\n` +
-				`You must be autoconfirmed to challenge them.`
+				`You must be autoconfirmed to challenge them.\n` +
+				`(Autoconfirmed users have won at least one rated battle and been registered for one week or longer.)`
 			);
 			return false;
 		}

--- a/server/private-messages/index.ts
+++ b/server/private-messages/index.ts
@@ -102,7 +102,10 @@ export const PrivateMessages = new class {
 		}
 		if (!(options.isLogin ? user.registered : user.autoconfirmed)) {
 			if (options.forceBool) return false;
-			throw new Chat.ErrorMessage("You must be autoconfirmed to use offine messaging.");
+			throw new Chat.ErrorMessage(
+				"You must be autoconfirmed to use offine messaging " +
+				"(autoconfirmed users have won at least one rated battle and been registered for one week or longer)."
+			);
 		}
 		if (!Users.globalAuth.atLeast(user, Config.usesqlitepms)) {
 			if (options.forceBool) return false;


### PR DESCRIPTION
Added descriptions of what it means to be an autoconfirmed user to error messages given to non-autoconfirmed users. 

Based on the smogon suggestion at https://www.smogon.com/forums/threads/improve-the-error-messages-shown-to-non-autoconfirmed-users-trying-to-access-certain-features.3737016/


