### PR TITLE
Fix Slow Start duration on switch in

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -4243,6 +4243,11 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			onStart(target) {
 				this.add('-start', target, 'ability: Slow Start');
 			},
+			onResidual(pokemon) {
+				if (!pokemon.activeTurns) {
+					this.effectState.duration += 1;
+				}
+			},
 			onModifyAtkPriority: 5,
 			onModifyAtk(atk, pokemon) {
 				return this.chainModify(0.5);

--- a/test/sim/abilities/slowstart.js
+++ b/test/sim/abilities/slowstart.js
@@ -19,23 +19,14 @@ describe(`Slow Start`, function () {
 		]]);
 		battle.makeChoices('switch 2', 'auto');
 		for (let i = 0; i < 4; i++) { battle.makeChoices(); }
-		const log = battle.getDebugLog();
-		const slowStartEnd = log.indexOf('|-end|p1a: Regigigas|Slow Start');
-		assert(!(slowStartEnd > -1), 'Slow Start should remain in effect after 4 active turns.');
-	});
+		let log = battle.getDebugLog();
+		let slowStartEnd = log.indexOf('|-end|p1a: Regigigas|Slow Start');
+		assert.false(slowStartEnd > -1, 'Slow Start should remain in effect after 4 active turns.');
 
-	it(`condition should be removed after 5 active turns`, function () {
-		battle = common.createBattle([[
-			{species: 'diglett', moves: ['sleeptalk']},
-			{species: 'regigigas', ability: 'slowstart', item: 'normaliumz', moves: ['sleeptalk']},
-		], [
-			{species: 'wynaut', moves: ['sleeptalk']},
-		]]);
-		battle.makeChoices('switch 2', 'auto');
-		for (let i = 0; i < 5; i++) { battle.makeChoices(); }
-		const log = battle.getDebugLog();
-		const slowStartEnd = log.indexOf('|-end|p1a: Regigigas|Slow Start');
-		assert((slowStartEnd > -1), 'Slow Start should not be in effect after 5 active turns.');
+		battle.makeChoices();
+		log = battle.getDebugLog();
+		slowStartEnd = log.indexOf('|-end|p1a: Regigigas|Slow Start');
+		assert(slowStartEnd > -1, 'Slow Start should not be in effect after 5 active turns.');
 	});
 
 	it(`[Gen 7] should halve the user's Special Attack when using a special Z-move`, function () {

--- a/test/sim/abilities/slowstart.js
+++ b/test/sim/abilities/slowstart.js
@@ -10,7 +10,7 @@ describe(`Slow Start`, function () {
 		battle.destroy();
 	});
 
-	it(`should not delay activation on switch-in, unlike Speed Boost`, function () {
+	it(`should delay activation on switch-in, like Speed Boost`, function () {
 		battle = common.createBattle([[
 			{species: 'diglett', moves: ['sleeptalk']},
 			{species: 'regigigas', ability: 'slowstart', item: 'normaliumz', moves: ['sleeptalk']},
@@ -21,7 +21,21 @@ describe(`Slow Start`, function () {
 		for (let i = 0; i < 4; i++) { battle.makeChoices(); }
 		const log = battle.getDebugLog();
 		const slowStartEnd = log.indexOf('|-end|p1a: Regigigas|Slow Start');
-		assert(slowStartEnd > -1, 'Slow Start should end in 5 turns, including the turn it switched in.');
+		assert(!(slowStartEnd > -1), 'Slow Start should remain in effect after 4 active turns.');
+	});
+
+	it(`condition should be removed after 5 active turns`, function () {
+		battle = common.createBattle([[
+			{species: 'diglett', moves: ['sleeptalk']},
+			{species: 'regigigas', ability: 'slowstart', item: 'normaliumz', moves: ['sleeptalk']},
+		], [
+			{species: 'wynaut', moves: ['sleeptalk']},
+		]]);
+		battle.makeChoices('switch 2', 'auto');
+		for (let i = 0; i < 5; i++) { battle.makeChoices(); }
+		const log = battle.getDebugLog();
+		const slowStartEnd = log.indexOf('|-end|p1a: Regigigas|Slow Start');
+		assert((slowStartEnd > -1), 'Slow Start should not be in effect after 5 active turns.');
 	});
 
 	it(`[Gen 7] should halve the user's Special Attack when using a special Z-move`, function () {


### PR DESCRIPTION
Based on the bug report at https://www.smogon.com/forums/threads/slow-start-turn-count-on-switches.3741527/.

Changed slowstart configuration to not decrement duration during an inactive turn, and made new test cases in slowstart to reflect changes.