### PR TITLE
Randomized format set updates

### DIFF
--- a/data/mods/gen2/random-sets.json
+++ b/data/mods/gen2/random-sets.json
@@ -166,7 +166,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["bodyslam", "encore", "fireblast", "flamethrower", "moonlight", "return", "thunderwave"]
+                "movepool": ["fireblast", "flamethrower", "moonlight", "return", "thunderwave"]
             },
             {
                 "role": "Setup Sweeper",
@@ -575,7 +575,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["curse", "hiddenpowerghost", "hiddenpowerrock", "highjumpkick", "machpunch", "rest"]
+                "movepool": ["curse", "hiddenpowerghost", "hiddenpowerrock", "highjumpkick", "machpunch"]
             },
             {
                 "role": "Bulky Setup",
@@ -782,7 +782,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["doubleedge", "hiddenpowerflying", "hydropump", "rest", "sleeptalk"]
+                "movepool": ["doubleedge", "hiddenpowerflying", "hydropump", "rest", "sleeptalk", "surf"]
             },
             {
                 "role": "Bulky Setup",
@@ -1007,7 +1007,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["curse", "irontail", "quickattack", "rest", "return"]
+                "movepool": ["curse", "irontail", "quickattack", "return"]
             }
         ]
     },
@@ -1442,7 +1442,7 @@
         "sets": [
             {
                 "role": "Generalist",
-                "movepool": ["irontail", "moonlight", "return", "toxic"]
+                "movepool": ["hiddenpowerground", "moonlight", "return", "toxic"]
             },
             {
                 "role": "Bulky Attacker",
@@ -1450,7 +1450,7 @@
             },
             {
                 "role": "Thief user",
-                "movepool": ["dynamicpunch", "return", "shadowball", "thief"]
+                "movepool": ["dynamicpunch", "moonlight", "return", "thief"]
             }
         ]
     },
@@ -1600,7 +1600,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["curse", "hiddenpowerghost", "hiddenpowerrock", "highjumpkick", "machpunch", "rest"]
+                "movepool": ["curse", "hiddenpowerghost", "hiddenpowerrock", "highjumpkick", "machpunch"]
             },
             {
                 "role": "Bulky Setup",

--- a/data/mods/gen2/random-sets.json
+++ b/data/mods/gen2/random-sets.json
@@ -166,7 +166,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["fireblast", "flamethrower", "moonlight", "return", "thunderwave"]
+                "movepool": ["bodyslam", "encore", "fireblast", "flamethrower", "moonlight"]
             },
             {
                 "role": "Setup Sweeper",
@@ -707,10 +707,6 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["batonpass", "doubleedge", "hiddenpowerground", "swordsdance"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["doubleedge", "hiddenpowerground", "swordsdance", "wingattack"]
             }
         ]
     },
@@ -1398,7 +1394,7 @@
         "sets": [
             {
                 "role": "Generalist",
-                "movepool": ["curse", "haze", "hydropump", "sludgebomb", "spikes"]
+                "movepool": ["curse", "haze", "hiddenpowerground", "hydropump", "sludgebomb", "spikes"]
             }
         ]
     },

--- a/data/mods/gen2/random-sets.json
+++ b/data/mods/gen2/random-sets.json
@@ -448,11 +448,8 @@
         "sets": [
             {
                 "role": "Generalist",
-                "movepool": ["explosion", "fireblast", "hiddenpowerground", "sludgebomb"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["curse", "explosion", "hiddenpowerground", "sludgebomb"]
+                "movepool": ["curse", "explosion", "fireblast", "hiddenpowerground", "sludgebomb"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },

--- a/data/mods/gen3/random-sets.json
+++ b/data/mods/gen3/random-sets.json
@@ -491,6 +491,10 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["explosion", "icebeam", "rapidspin", "spikes", "surf", "toxic"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["explosion", "rapidspin", "spikes", "surf", "toxic"]
             }
         ]
     },
@@ -997,7 +1001,8 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "hiddenpowerflying", "hydropump", "rockslide", "swordsdance"]
+                "movepool": ["earthquake", "hiddenpowerflying", "hydropump", "rockslide", "swordsdance"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -1091,7 +1096,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "gigadrain", "hiddenpowerfire", "psychic"],
+                "movepool": ["batonpass", "calmmind", "hiddenpowerfire", "psychic", "rest"],
                 "preferredTypes": ["Fire"]
             },
             {
@@ -1332,7 +1337,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "calmmind", "crunch", "protect", "psychic", "substitute", "thunderbolt", "wish"]
+                "movepool": ["batonpass", "calmmind", "crunch", "psychic", "rest", "substitute", "thunderbolt"]
             },
             {
                 "role": "Wallbreaker",
@@ -2236,7 +2241,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["explosion", "fireblast", "flamethrower", "hiddenpowergrass", "rest", "toxic", "yawn"]
+                "movepool": ["explosion", "fireblast", "flamethrower", "hiddenpowergrass", "rest", "toxic"]
             }
         ]
     },
@@ -2425,7 +2430,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["flamethrower", "icebeam", "return", "thunderbolt", "thunderwave"]
+                "movepool": ["fireblast", "icebeam", "return", "thunderbolt", "thunderwave"]
             }
         ]
     },
@@ -2585,6 +2590,11 @@
         "sets": [
             {
                 "role": "Wallbreaker",
+                "movepool": ["earthquake", "explosion", "meteormash", "rockslide"],
+                "preferredTypes": ["Ground"]
+            },
+            {
+                "role": "Setup Sweeper",
                 "movepool": ["agility", "earthquake", "explosion", "meteormash", "psychic", "rockslide"],
                 "preferredTypes": ["Ground"]
             }

--- a/data/mods/gen3/random-sets.json
+++ b/data/mods/gen3/random-sets.json
@@ -1096,8 +1096,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "hiddenpowerfire", "psychic", "rest"],
-                "preferredTypes": ["Fire"]
+                "movepool": ["batonpass", "calmmind", "hiddenpowerfire", "psychic", "rest"]
             },
             {
                 "role": "Bulky Attacker",
@@ -2590,8 +2589,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["earthquake", "explosion", "meteormash", "rockslide"],
-                "preferredTypes": ["Ground"]
+                "movepool": ["earthquake", "explosion", "meteormash", "rockslide"]
             },
             {
                 "role": "Setup Sweeper",

--- a/data/mods/gen3/random-sets.json
+++ b/data/mods/gen3/random-sets.json
@@ -599,7 +599,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["bodyslam", "flamethrower", "protect", "wish"]
+                "movepool": ["bodyslam", "earthquake", "protect", "wish"]
             },
             {
                 "role": "Bulky Support",

--- a/data/mods/gen3/random-teams.ts
+++ b/data/mods/gen3/random-teams.ts
@@ -437,6 +437,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 
 		// Hard-code abilities here
 		if (species.id === 'yanma' && counter.get('inaccurate')) return 'Compound Eyes';
+		if (moves.has('rest') && abilities.has('Early Bird')) return 'Early Bird';
 		if (species.id === 'arcanine') return 'Intimidate';
 		if (species.id === 'blissey') return 'Natural Cure';
 		if (species.id === 'heracross' && role === 'Berry Sweeper') return 'Swarm';

--- a/data/mods/gen4/random-sets.json
+++ b/data/mods/gen4/random-sets.json
@@ -794,7 +794,8 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "firepunch", "outrage", "roost"]
+                "movepool": ["dragondance", "earthquake", "firepunch", "outrage", "roost"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },

--- a/data/mods/gen4/random-sets.json
+++ b/data/mods/gen4/random-sets.json
@@ -789,12 +789,12 @@
         "level": 77,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["dragondance", "earthquake", "extremespeed", "firepunch", "outrage"]
+                "role": "Wallbreaker",
+                "movepool": ["earthquake", "extremespeed", "outrage", "superpower"]
             },
             {
-                "role": "Bulky Setup",
-                "movepool": ["dragonclaw", "dragondance", "earthquake", "firepunch", "roost"]
+                "role": "Setup Sweeper",
+                "movepool": ["dragondance", "earthquake", "firepunch", "outrage", "roost"]
             }
         ]
     },
@@ -2072,9 +2072,13 @@
         "level": 85,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["nightslash", "psychocut", "pursuit", "suckerpunch", "superpower", "swordsdance"],
+                "role": "Bulky Attacker",
+                "movepool": ["nightslash", "psychocut", "pursuit", "suckerpunch", "superpower"],
                 "preferredTypes": ["Fighting"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["nightslash", "suckerpunch", "superpower", "swordsdance"]
             }
         ]
     },

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -2704,7 +2704,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["darkpulse", "painsplit", "pursuit", "suckerpunch", "willowisp"]
+                "movepool": ["foulplay", "painsplit", "pursuit", "suckerpunch", "willowisp"]
             }
         ]
     },

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -2120,7 +2120,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["nightslash", "psychocut", "pursuit", "suckerpunch", "superpower"],
+                "movepool": ["nightslash", "pursuit", "suckerpunch", "superpower", "zenheadbutt"],
                 "preferredTypes": ["Fighting"]
             },
             {

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -3819,7 +3819,7 @@
         "level": 82,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["darkpulse", "flamethrower", "focusblast", "nastyplot", "trick", "uturn"]
             }
         ]

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -838,12 +838,12 @@
         "level": 75,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["dragondance", "earthquake", "extremespeed", "firepunch", "outrage"]
+                "role": "Wallbreaker",
+                "movepool": ["earthquake", "extremespeed", "outrage", "superpower"]
             },
             {
-                "role": "Bulky Setup",
-                "movepool": ["dragonclaw", "dragondance", "earthquake", "firepunch", "roost"]
+                "role": "Setup Sweeper",
+                "movepool": ["dragondance", "earthquake", "firepunch", "outrage", "roost"]
             }
         ]
     },
@@ -2118,8 +2118,8 @@
         "level": 87,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["fireblast", "nightslash", "psychocut", "pursuit", "suckerpunch", "superpower"],
+                "role": "Bulky Attacker",
+                "movepool": ["nightslash", "psychocut", "pursuit", "suckerpunch", "superpower"],
                 "preferredTypes": ["Fighting"]
             },
             {
@@ -2543,7 +2543,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["airslash", "roost", "toxic", "uturn"]
+                "movepool": ["acrobatics", "roost", "toxic", "uturn"]
             }
         ]
     },

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -2703,7 +2703,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["foulplay", "painsplit", "pursuit", "shadowsneak", "suckerpunch", "willowisp"]
+                "movepool": ["darkpulse", "painsplit", "pursuit", "suckerpunch", "willowisp"]
             }
         ]
     },
@@ -4038,7 +4038,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["bugbuzz", "encore", "focusblast", "gigadrain", "hiddenpowerground", "hiddenpowerrock", "spikes", "yawn"]
+                "movepool": ["bugbuzz", "encore", "focusblast", "hiddenpowerground", "hiddenpowerrock", "spikes", "uturn"]
             }
         ]
     },

--- a/data/mods/gen5/random-sets.json
+++ b/data/mods/gen5/random-sets.json
@@ -843,7 +843,8 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dragondance", "earthquake", "firepunch", "outrage", "roost"]
+                "movepool": ["dragondance", "earthquake", "firepunch", "outrage", "roost"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },

--- a/data/mods/gen5/random-teams.ts
+++ b/data/mods/gen5/random-teams.ts
@@ -602,7 +602,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		if (species.id === 'beheeyem') return 'Analytic';
 		if (species.id === 'ninetales') return 'Drought';
 		if (species.id === 'gligar') return 'Immunity';
-		if (species.id === 'arcanine') return 'Intimidate';
+		if (species.id === 'arcanine' || species.id === 'stantler') return 'Intimidate';
 		if (species.id === 'altaria') return 'Natural Cure';
 		if (species.id === 'mandibuzz') return 'Overcoat';
 		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -3055,7 +3055,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["darkpulse", "painsplit", "pursuit", "suckerpunch", "willowisp"]
+                "movepool": ["foulplay", "painsplit", "pursuit", "suckerpunch", "willowisp"]
             }
         ]
     },

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -1723,8 +1723,9 @@
         "level": 91,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["crunch", "irontail", "playrough", "suckerpunch"]
+                "role": "Wallbreaker",
+                "movepool": ["crunch", "irontail", "playrough", "suckerpunch", "toxic"],
+                "preferredTypes": ["Fairy"]
             }
         ]
     },

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -482,8 +482,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["curse", "firepunch", "gunkshot", "haze", "icepunch", "poisonjab", "shadowsneak"],
-                "preferredTypes": ["Fire"]
+                "movepool": ["brickbreak", "curse", "gunkshot", "haze", "icepunch", "poisonjab", "shadowsneak"],
+                "preferredTypes": ["Fighting"]
             }
         ]
     },
@@ -914,7 +914,11 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dragondance", "earthquake", "extremespeed", "firepunch", "outrage"]
+                "movepool": ["dragondance", "earthquake", "outrage", "roost"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["dragondance", "earthquake", "ironhead", "outrage"]
             }
         ]
     },
@@ -1750,7 +1754,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bugbuzz", "quiverdance", "roost", "sludgebomb"]
+                "movepool": ["bugbuzz", "hiddenpowerground", "quiverdance", "roost", "sludgebomb"]
             },
             {
                 "role": "Bulky Support",
@@ -3051,7 +3055,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["foulplay", "painsplit", "pursuit", "shadowsneak", "suckerpunch", "willowisp"]
+                "movepool": ["darkpulse", "painsplit", "pursuit", "suckerpunch", "willowisp"]
             }
         ]
     },
@@ -3233,7 +3237,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "hiddenpowerfire", "knockoff", "leafstorm", "leechseed", "powerwhip", "rockslide", "sleeppowder", "synthesis"]
+                "movepool": ["earthquake", "knockoff", "leafstorm", "leechseed", "powerwhip", "rockslide", "sleeppowder", "sludgebomb", "synthesis"]
             },
             {
                 "role": "AV Pivot",
@@ -4096,7 +4100,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "megahorn", "poisonjab", "protect", "spikes", "toxicspikes"]
+                "movepool": ["earthquake", "megahorn", "poisonjab", "spikes", "toxicspikes"]
             },
             {
                 "role": "Setup Sweeper",
@@ -4385,7 +4389,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["bugbuzz", "gigadrain", "hiddenpowerice", "stickyweb", "thunder", "voltswitch"],
+                "movepool": ["bugbuzz", "gigadrain", "stickyweb", "thunder", "voltswitch"],
                 "preferredTypes": ["Bug"]
             }
         ]
@@ -4477,7 +4481,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["bugbuzz", "encore", "energyball", "focusblast", "hiddenpowerground", "hiddenpowerrock", "spikes", "yawn"]
+                "movepool": ["bugbuzz", "encore", "focusblast", "hiddenpowerground", "hiddenpowerrock", "spikes", "uturn"]
             }
         ]
     },
@@ -4957,7 +4961,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["rest", "return", "suckerpunch", "thunderwave", "toxic", "uturn"]
+                "movepool": ["darkpulse", "rest", "return", "thunderwave", "toxic", "uturn"]
             },
             {
                 "role": "Staller",
@@ -4992,7 +4996,7 @@
             },
             {
                 "role": "Staller",
-                "movepool": ["ironhead", "sacredsword", "shadowclaw", "shadowsneak", "toxic"]
+                "movepool": ["ironhead", "sacredsword", "shadowclaw", "shadowsneak"]
             }
         ]
     },
@@ -5081,7 +5085,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["darkpulse", "glare", "hiddenpowerice", "hypervoice", "surf", "thunderbolt", "voltswitch"],
+                "movepool": ["darkpulse", "glare", "hypervoice", "surf", "thunderbolt", "voltswitch"],
                 "preferredTypes": ["Normal"]
             },
             {
@@ -5260,7 +5264,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["foulplay", "knockoff", "oblivionwing", "roost", "suckerpunch", "taunt", "toxic", "uturn"]
+                "movepool": ["knockoff", "oblivionwing", "roost", "suckerpunch", "taunt", "toxic", "uturn"]
             }
         ]
     },
@@ -5321,7 +5325,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthpower", "fireblast", "sludgebomb", "steameruption", "substitute", "superpower"]
+                "movepool": ["earthpower", "fireblast", "sludgebomb", "steameruption", "superpower", "toxic"]
             }
         ]
     }

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -4260,7 +4260,7 @@
         "level": 84,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["darkpulse", "flamethrower", "focusblast", "nastyplot", "sludgebomb", "trick", "uturn"],
                 "preferredTypes": ["Poison"]
             }

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -4993,10 +4993,6 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["ironhead", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["ironhead", "sacredsword", "shadowclaw", "shadowsneak"]
             }
         ]
     },

--- a/data/mods/gen6/random-sets.json
+++ b/data/mods/gen6/random-sets.json
@@ -913,12 +913,9 @@
         "level": 75,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["dragondance", "earthquake", "outrage", "roost"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["dragondance", "earthquake", "ironhead", "outrage"]
+                "role": "Setup Sweeper",
+                "movepool": ["dragondance", "earthquake", "ironhead", "outrage", "roost"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -4631,8 +4628,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["closecombat", "ironhead", "stealthrock", "stoneedge", "swordsdance"],
-                "preferredTypes": ["Steel"]
+                "movepool": ["closecombat", "ironhead", "stealthrock", "stoneedge", "swordsdance"]
             }
         ]
     },
@@ -5002,15 +4998,11 @@
             {
                 "role": "Staller",
                 "movepool": ["ironhead", "kingsshield", "shadowball", "substitute", "toxic"]
-            }
-        ]
-    },
-    "aegislashblade": {
-        "level": 79,
-        "sets": [
+            },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["ironhead", "kingsshield", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"]
+                "movepool": ["ironhead", "kingsshield", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"],
+                "preferredTypes": ["Steel"]
             }
         ]
     },

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -651,9 +651,10 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (species.baseSpecies === 'Gourgeist') return 'Frisk';
 		if (species.id === 'pinsirmega') return 'Hyper Cutter';
 		if (species.id === 'ninjask' || species.id === 'seviper') return 'Infiltrator';
-		if (species.id === 'lucariomega') return 'Justified';
 		if (species.id === 'gligar') return 'Immunity';
 		if (species.id === 'arcanine' || species.id === 'stantler') return 'Intimidate';
+		if (species.id === 'lucariomega') return 'Justified';
+		if (species.id === 'persian' && !counter.get('technician')) return 'Limber';
 		if (species.baseSpecies === 'Altaria') return 'Natural Cure';
 		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it
 		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -648,11 +648,12 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if (species.id === 'starmie') return role === 'Wallbreaker' ? 'Analytic' : 'Natural Cure';
 		if (species.id === 'beheeyem') return 'Analytic';
 		if (species.id === 'ninetales') return 'Drought';
+		if (species.baseSpecies === 'Gourgeist') return 'Frisk';
 		if (species.id === 'pinsirmega') return 'Hyper Cutter';
 		if (species.id === 'ninjask' || species.id === 'seviper') return 'Infiltrator';
 		if (species.id === 'lucariomega') return 'Justified';
 		if (species.id === 'gligar') return 'Immunity';
-		if (species.id === 'arcanine') return 'Intimidate';
+		if (species.id === 'arcanine' || species.id === 'stantler') return 'Intimidate';
 		if (species.baseSpecies === 'Altaria') return 'Natural Cure';
 		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it
 		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';

--- a/data/mods/gen6/random-teams.ts
+++ b/data/mods/gen6/random-teams.ts
@@ -59,7 +59,7 @@ const MOVE_PAIRS = [
 
 /** Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type */
 const PRIORITY_POKEMON = [
-	'aegislashblade', 'banette', 'breloom', 'cacturne', 'doublade', 'dusknoir', 'honchkrow', 'scizor', 'scizormega', 'shedinja',
+	'aegislash', 'banette', 'breloom', 'cacturne', 'doublade', 'dusknoir', 'honchkrow', 'scizor', 'scizormega', 'shedinja',
 ];
 
 export class RandomGen6Teams extends RandomGen7Teams {

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -1897,8 +1897,9 @@
         "level": 94,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["crunch", "irontail", "playrough", "suckerpunch"]
+                "role": "Wallbreaker",
+                "movepool": ["crunch", "irontail", "playrough", "suckerpunch", "toxic"],
+                "preferredTypes": ["Fairy"]
             }
         ]
     },

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -4540,7 +4540,7 @@
         "level": 84,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["darkpulse", "flamethrower", "focusblast", "nastyplot", "sludgebomb", "trick", "uturn"],
                 "preferredTypes": ["Poison"]
             }

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -85,6 +85,11 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["airslash", "bugbuzz", "energyball", "quiverdance", "sleeppowder"]
+            },
+            {
+                "role": "Z-Move user",
+                "movepool": ["airslash", "bugbuzz", "quiverdance", "sleeppowder"],
+                "preferredTypes": ["Bug"]
             }
         ]
     },
@@ -600,8 +605,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["curse", "firepunch", "gunkshot", "haze", "icepunch", "poisonjab", "shadowsneak"],
-                "preferredTypes": ["Fire"]
+                "movepool": ["brickbreak", "curse", "gunkshot", "haze", "icepunch", "poisonjab", "shadowsneak"],
+                "preferredTypes": ["Fighting"]
             }
         ]
     },
@@ -1086,7 +1091,11 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["dragondance", "earthquake", "extremespeed", "firepunch", "outrage"]
+                "movepool": ["dragondance", "earthquake", "outrage", "roost"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["dragondance", "earthquake", "ironhead", "outrage"]
             }
         ]
     },
@@ -1919,7 +1928,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bugbuzz", "quiverdance", "roost", "sludgebomb"]
+                "movepool": ["bugbuzz", "hiddenpowerground", "quiverdance", "roost", "sludgebomb"]
             },
             {
                 "role": "Bulky Support",
@@ -3082,6 +3091,11 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["airslash", "bugbuzz", "energyball", "quiverdance"]
+            },
+            {
+                "role": "Z-Move user",
+                "movepool": ["airslash", "bugbuzz", "energyball", "quiverdance"],
+                "preferredTypes": ["Bug"]
             }
         ]
     },
@@ -3174,6 +3188,11 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["brutalswing", "healingwish", "highjumpkick", "return", "switcheroo"]
+            },
+            {
+                "role": "Z-Move user",
+                "movepool": ["brutalswing", "highjumpkick", "return", "splash"],
+                "preferredTypes": ["Normal"]
             }
         ]
     },
@@ -3262,7 +3281,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["foulplay", "painsplit", "pursuit", "shadowsneak", "suckerpunch", "willowisp"]
+                "movepool": ["darkpulse", "painsplit", "pursuit", "suckerpunch", "willowisp"]
             }
         ]
     },
@@ -3449,7 +3468,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "hiddenpowerfire", "knockoff", "leafstorm", "leechseed", "powerwhip", "rockslide", "sleeppowder", "synthesis"]
+                "movepool": ["earthquake", "knockoff", "leafstorm", "leechseed", "powerwhip", "rockslide", "sleeppowder", "sludgebomb", "synthesis"]
             },
             {
                 "role": "AV Pivot",
@@ -3531,6 +3550,11 @@
             {
                 "role": "Staller",
                 "movepool": ["icebeam", "protect", "toxic", "wish"]
+            },
+            {
+                "role": "Z-Move user",
+                "movepool": ["celebrate", "hiddenpowerground", "icebeam", "storedpower"],
+                "preferredTypes": ["Normal"]
             }
         ]
     },
@@ -4360,7 +4384,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["earthquake", "megahorn", "poisonjab", "protect", "spikes", "toxicspikes"]
+                "movepool": ["earthquake", "megahorn", "poisonjab", "spikes", "toxicspikes"]
             },
             {
                 "role": "Setup Sweeper",
@@ -4650,7 +4674,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["bugbuzz", "gigadrain", "hiddenpowerice", "stickyweb", "thunder", "voltswitch"],
+                "movepool": ["bugbuzz", "gigadrain", "stickyweb", "thunder", "voltswitch"],
                 "preferredTypes": ["Bug"]
             }
         ]
@@ -4752,7 +4776,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["bugbuzz", "encore", "energyball", "focusblast", "hiddenpowerground", "hiddenpowerrock", "spikes", "toxicspikes", "yawn"]
+                "movepool": ["bugbuzz", "encore", "focusblast", "hiddenpowerground", "hiddenpowerrock", "spikes", "toxicspikes", "uturn"]
             }
         ]
     },
@@ -5290,7 +5314,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["rest", "return", "suckerpunch", "thunderwave", "toxic", "uturn"]
+                "movepool": ["darkpulse", "rest", "return", "thunderwave", "toxic", "uturn"]
             },
             {
                 "role": "Staller",
@@ -5325,7 +5349,7 @@
             },
             {
                 "role": "Staller",
-                "movepool": ["ironhead", "sacredsword", "shadowclaw", "shadowsneak", "toxic"]
+                "movepool": ["ironhead", "sacredsword", "shadowclaw", "shadowsneak"]
             }
         ]
     },
@@ -5415,7 +5439,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["darkpulse", "glare", "hiddenpowerice", "hypervoice", "surf", "thunderbolt", "voltswitch"],
+                "movepool": ["darkpulse", "glare", "hypervoice", "surf", "thunderbolt", "voltswitch"],
                 "preferredTypes": ["Normal"]
             },
             {
@@ -5603,7 +5627,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["foulplay", "knockoff", "oblivionwing", "roost", "suckerpunch", "taunt", "toxic", "uturn"]
+                "movepool": ["knockoff", "oblivionwing", "roost", "suckerpunch", "taunt", "toxic", "uturn"]
             }
         ]
     },
@@ -5681,7 +5705,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "earthpower", "fireblast", "sludgebomb", "steameruption", "substitute", "superpower"]
+                "movepool": ["defog", "earthpower", "fireblast", "sludgebomb", "steameruption", "superpower", "toxic"]
             }
         ]
     },
@@ -5743,7 +5767,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["agility", "bugbuzz", "energyball", "hiddenpowerice", "thunderbolt", "voltswitch"],
+                "movepool": ["agility", "bugbuzz", "energyball", "thunderbolt", "voltswitch"],
                 "preferredTypes": ["Bug"]
             },
             {

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -1090,12 +1090,9 @@
                 "preferredTypes": ["Flying"]
             },
             {
-                "role": "Bulky Attacker",
-                "movepool": ["dragondance", "earthquake", "outrage", "roost"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["dragondance", "earthquake", "ironhead", "outrage"]
+                "role": "Setup Sweeper",
+                "movepool": ["dragondance", "earthquake", "ironhead", "outrage", "roost"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -4935,8 +4932,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["closecombat", "ironhead", "stealthrock", "stoneedge", "swordsdance"],
-                "preferredTypes": ["Steel"]
+                "movepool": ["closecombat", "ironhead", "stealthrock", "stoneedge", "swordsdance"]
             },
             {
                 "role": "Z-Move user",
@@ -5355,15 +5351,11 @@
             {
                 "role": "Staller",
                 "movepool": ["ironhead", "kingsshield", "shadowball", "substitute", "toxic"]
-            }
-        ]
-    },
-    "aegislashblade": {
-        "level": 78,
-        "sets": [
+            },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["ironhead", "kingsshield", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"]
+                "movepool": ["ironhead", "kingsshield", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"],
+                "preferredTypes": ["Steel"]
             }
         ]
     },
@@ -5763,8 +5755,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["agility", "bugbuzz", "energyball", "thunderbolt", "voltswitch"],
-                "preferredTypes": ["Bug"]
+                "movepool": ["agility", "bugbuzz", "energyball", "thunderbolt", "voltswitch"]
             },
             {
                 "role": "Bulky Attacker",

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -5637,11 +5637,15 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
+                "movepool": ["extremespeed", "irontail", "outrage", "thousandarrows"]
+            },
+            {
+                "role": "Setup Sweeper",
                 "movepool": ["coil", "extremespeed", "irontail", "outrage", "thousandarrows"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["coil", "extremespeed", "outrage", "thousandarrows"],
+                "movepool": ["coil", "extremespeed", "irontail", "outrage", "thousandarrows"],
                 "preferredTypes": ["Dragon"]
             }
         ]
@@ -6479,7 +6483,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["airslash", "autotomize", "earthquake", "fireblast", "flashcannon"]
+                "movepool": ["airslash", "autotomize", "earthquake", "fireblast", "heavyslam"]
             }
         ]
     },

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -5346,10 +5346,6 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["ironhead", "sacredsword", "shadowclaw", "shadowsneak", "swordsdance"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["ironhead", "sacredsword", "shadowclaw", "shadowsneak"]
             }
         ]
     },
@@ -6136,8 +6132,8 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["flamecharge", "ironhead", "multiattack", "shadowclaw", "swordsdance"],
-                "preferredTypes": ["Ghost"]
+                "movepool": ["crunch", "flamecharge", "ironhead", "multiattack", "rockslide", "swordsdance"],
+                "preferredTypes": ["Dark"]
             }
         ]
     },

--- a/data/mods/gen7/random-sets.json
+++ b/data/mods/gen7/random-sets.json
@@ -3281,7 +3281,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["darkpulse", "painsplit", "pursuit", "suckerpunch", "willowisp"]
+                "movepool": ["foulplay", "painsplit", "pursuit", "suckerpunch", "willowisp"]
             }
         ]
     },

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -92,7 +92,7 @@ const MOVE_PAIRS = [
 
 /** Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type */
 const PRIORITY_POKEMON = [
-	'aegislashblade', 'banette', 'breloom', 'cacturne', 'doublade', 'dusknoir', 'golisopod', 'honchkrow', 'mimikyu', 'scizor', 'scizormega', 'shedinja',
+	'aegislash', 'banette', 'breloom', 'cacturne', 'doublade', 'dusknoir', 'golisopod', 'honchkrow', 'mimikyu', 'scizor', 'scizormega', 'shedinja',
 ];
 function sereneGraceBenefits(move: Move) {
 	return move.secondary?.chance && move.secondary.chance >= 20 && move.secondary.chance < 100;

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -338,7 +338,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 
 			// These attacks are redundant with each other
 			['psychic', 'psyshock'],
-			['scald', ['hydropump', 'originpulse', 'waterpulse']],
+			[['scald', 'surf'], ['hydropump', 'originpulse', 'waterpulse']],
 			['return', ['bodyslam', 'doubleedge', 'headbutt']],
 			[['fierydance', 'firelash', 'lavaplume'], ['fireblast', 'magmastorm']],
 			[['flamethrower', 'flareblitz'], ['fireblast', 'overheat']],
@@ -858,11 +858,12 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (species.id === 'beheeyem') return 'Analytic';
 		if (species.id === 'drampa' && moves.has('roost')) return 'Berserk';
 		if (species.id === 'ninetales') return 'Drought';
+		if (species.baseSpecies === 'Gourgeist') return 'Frisk';
 		if (species.id === 'talonflame' && role === 'Z-Move user') return 'Gale Wings';
 		if (species.id === 'golemalola' && moves.has('return')) return 'Galvanize';
 		if (species.id === 'raticatealola') return 'Hustle';
 		if (species.id === 'ninjask' || species.id === 'seviper') return 'Infiltrator';
-		if (species.id === 'arcanine') return 'Intimidate';
+		if (species.id === 'arcanine' || species.id === 'stantler') return 'Intimidate';
 		if (species.id === 'lucariomega') return 'Justified';
 		if (species.id === 'toucannon' && !counter.get('sheerforce') && !counter.get('skilllink')) return 'Keen Eye';
 		if (species.baseSpecies === 'Altaria') return 'Natural Cure';

--- a/data/mods/gen7/random-teams.ts
+++ b/data/mods/gen7/random-teams.ts
@@ -866,6 +866,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (species.id === 'arcanine' || species.id === 'stantler') return 'Intimidate';
 		if (species.id === 'lucariomega') return 'Justified';
 		if (species.id === 'toucannon' && !counter.get('sheerforce') && !counter.get('skilllink')) return 'Keen Eye';
+		if (species.id === 'persian' && !counter.get('technician')) return 'Limber';
 		if (species.baseSpecies === 'Altaria') return 'Natural Cure';
 		// If Ambipom doesn't qualify for Technician, Skill Link is useless on it
 		if (species.id === 'ambipom' && !counter.get('technician')) return 'Pickup';

--- a/data/mods/gen8/random-data.json
+++ b/data/mods/gen8/random-data.json
@@ -1443,7 +1443,7 @@
     },
     "gothitelle": {
         "level": 87,
-        "moves": ["nastyplot", "psychic", "shadowball", "thunderbolt", "trick"],
+        "moves": ["darkpulse", "nastyplot", "psychic", "thunderbolt", "trick"],
         "doublesLevel": 83,
         "doublesMoves": ["fakeout", "healpulse", "helpinghand", "hypnosis", "protect", "psychic", "trickroom"]
     },
@@ -1503,7 +1503,7 @@
     },
     "beheeyem": {
         "level": 87,
-        "moves": ["psychic", "shadowball", "thunderbolt", "trick", "trickroom"],
+        "moves": ["darkpulse", "psychic", "thunderbolt", "trick", "trickroom"],
         "doublesLevel": 88,
         "doublesMoves": ["protect", "psychic", "shadowball", "thunderbolt", "trickroom"]
     },
@@ -1744,7 +1744,7 @@
     },
     "meowsticf": {
         "level": 86,
-        "moves": ["energyball", "nastyplot", "psychic", "shadowball", "thunderbolt"],
+        "moves": ["darkpulse", "energyball", "nastyplot", "psychic", "thunderbolt"],
         "doublesLevel": 88,
         "doublesMoves": ["fakeout", "nastyplot", "psychic", "shadowball", "thunderbolt"]
     },
@@ -2584,7 +2584,7 @@
     },
     "falinks": {
         "level": 84,
-        "moves": ["closecombat", "noretreat", "poisonjab", "rockslide", "throatchop"],
+        "moves": ["closecombat", "ironhead", "noretreat", "rockslide", "throatchop"],
         "doublesLevel": 86,
         "doublesMoves": ["closecombat", "noretreat", "poisonjab", "rockslide", "throatchop"]
     },

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -15,7 +15,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Heat Wave", "Hurricane", "Protect", "Scorching Sands", "Will-O-Wisp"],
-                "teraTypes": ["Fire", "Ground"]
+                "teraTypes": ["Fire", "Grass", "Ground"]
             }
         ]
     },
@@ -229,7 +229,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Fake Out", "Foul Play", "Helping Hand", "Knock Off", "Parting Shot", "Quash", "Snarl", "Taunt", "Thunder Wave"],
+                "movepool": ["Fake Out", "Foul Play", "Helping Hand", "Icy Wind", "Knock Off", "Parting Shot", "Snarl", "Taunt", "Thunder Wave"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -409,7 +409,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Drain Punch", "Gunk Shot", "Helping Hand", "Ice Punch", "Knock Off", "Poison Jab", "Protect", "Rock Tomb", "Snarl"],
+                "movepool": ["Drain Punch", "Gunk Shot", "Helping Hand", "Ice Punch", "Knock Off", "Poison Jab", "Protect", "Snarl"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -729,7 +729,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Brave Bird", "Freeze-Dry", "Ice Beam", "Protect", "Roost", "Tailwind"],
+                "movepool": ["Brave Bird", "Freeze-Dry", "Ice Beam", "Icy Wind", "Protect", "Roost", "Tailwind"],
                 "teraTypes": ["Ground", "Steel"]
             }
         ]
@@ -1014,7 +1014,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Helping Hand", "High Horsepower", "Liquidation", "Stealth Rock", "Yawn"],
+                "movepool": ["Helping Hand", "High Horsepower", "Icy Wind", "Liquidation", "Stealth Rock", "Yawn"],
                 "teraTypes": ["Fire", "Poison", "Steel"]
             }
         ]
@@ -1210,7 +1210,7 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Dark Pulse", "Heat Wave", "Nasty Plot", "Protect", "Sucker Punch"],
-                "teraTypes": ["Dark", "Fire", "Ghost", "Water"]
+                "teraTypes": ["Dark", "Fire", "Ghost", "Grass"]
             }
         ]
     },
@@ -1280,7 +1280,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Close Combat", "Coaching", "Fake Out", "Helping Hand", "Sucker Punch", "Triple Axel", "Wide Guard"],
-                "teraTypes": ["Dark", "Steel"]
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -1304,7 +1304,7 @@
             },
             {
                 "role": "Bulky Protect",
-                "movepool": ["Protect", "Scald", "Snarl", "Thunder Wave", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Electroweb", "Protect", "Scald", "Snarl", "Thunder Wave", "Thunderbolt", "Volt Switch"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -1344,7 +1344,7 @@
             },
             {
                 "role": "Doubles Support",
-                "movepool": ["Fire Blast", "High Horsepower", "Icy Wind", "Knock Off", "Protect", "Rock Slide", "Stone Edge"],
+                "movepool": ["Fire Blast", "High Horsepower", "Icy Wind", "Knock Off", "Protect", "Rock Slide", "Stone Edge", "Thunder Wave"],
                 "teraTypes": ["Flying", "Steel"]
             }
         ]
@@ -1479,7 +1479,7 @@
             },
             {
                 "role": "Doubles Support",
-                "movepool": ["Bug Buzz", "Hurricane", "Sticky Web", "Tailwind"],
+                "movepool": ["Bug Buzz", "Hurricane", "Protect", "Tailwind"],
                 "teraTypes": ["Ground"]
             }
         ]
@@ -1754,7 +1754,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Encore", "Heal Pulse", "Helping Hand", "Icy Wind", "Protect", "Psychic", "Snarl"],
+                "movepool": ["Encore", "Heal Pulse", "Helping Hand", "Icy Wind", "Protect", "Psychic", "Snarl", "Thunder Wave"],
                 "teraTypes": ["Dark", "Steel"]
             }
         ]
@@ -1810,6 +1810,11 @@
             {
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Body Press", "Curse", "Iron Defense", "Rest", "Rock Slide", "Stone Edge"],
+                "teraTypes": ["Fighting"]
+            },
+            {
+                "role": "Doubles Bulky Attacker",
+                "movepool": ["Body Press", "Iron Defense", "Rock Slide", "Stone Edge", "Thunder Wave"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2244,7 +2249,7 @@
         "sets": [
             {
                 "role": "Doubles Wallbreaker",
-                "movepool": ["Fake Out", "Ice Shard", "Ice Spinner", "Knock Off", "Low Kick", "Protect"],
+                "movepool": ["Fake Out", "Ice Shard", "Knock Off", "Low Kick", "Protect", "Triple Axel"],
                 "teraTypes": ["Dark", "Fighting", "Ghost", "Ice"]
             }
         ]
@@ -2279,7 +2284,7 @@
             },
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Dragon Tail", "Heat Crash", "High Horsepower", "Ice Punch", "Megahorn", "Rock Slide"],
+                "movepool": ["Dragon Tail", "Heat Crash", "High Horsepower", "Ice Punch", "Megahorn", "Protect", "Rock Slide"],
                 "teraTypes": ["Dragon", "Flying", "Water"]
             }
         ]
@@ -2354,7 +2359,7 @@
         "sets": [
             {
                 "role": "Bulky Protect",
-                "movepool": ["Dual Wingbeat", "High Horsepower", "Knock Off", "Protect", "Toxic", "Toxic Spikes"],
+                "movepool": ["Dual Wingbeat", "High Horsepower", "Knock Off", "Protect", "Tailwind", "Toxic", "Toxic Spikes"],
                 "teraTypes": ["Water"]
             },
             {
@@ -2421,6 +2426,11 @@
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Leech Life", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
                 "teraTypes": ["Dark"]
+            },
+            {
+                "role": "Doubles Setup Sweeper",
+                "movepool": ["Leech Life", "Poltergeist", "Protect", "Trick Room"],
+                "teraTypes": ["Dark"]
             }
         ]
     },
@@ -2449,7 +2459,7 @@
         "sets": [
             {
                 "role": "Bulky Protect",
-                "movepool": ["Hydro Pump", "Protect", "Thunderbolt", "Volt Switch", "Will-O-Wisp"],
+                "movepool": ["Electroweb", "Hydro Pump", "Protect", "Thunderbolt", "Volt Switch", "Will-O-Wisp"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -2479,7 +2489,7 @@
         "sets": [
             {
                 "role": "Bulky Protect",
-                "movepool": ["Air Slash", "Protect", "Thunderbolt", "Volt Switch", "Will-O-Wisp"],
+                "movepool": ["Air Slash", "Electroweb", "Protect", "Thunderbolt", "Volt Switch", "Will-O-Wisp"],
                 "teraTypes": ["Electric", "Steel"]
             }
         ]
@@ -2624,7 +2634,7 @@
             },
             {
                 "role": "Doubles Support",
-                "movepool": ["Breaking Swipe", "Icy Wind", "Rest", "Shadow Ball", "Will-O-Wisp"],
+                "movepool": ["Breaking Swipe", "Icy Wind", "Rest", "Shadow Ball", "Thunder Wave", "Will-O-Wisp"],
                 "teraTypes": ["Fairy"]
             }
         ]
@@ -2964,7 +2974,12 @@
         "sets": [
             {
                 "role": "Offensive Protect",
-                "movepool": ["Electroweb", "High Horsepower", "Overheat", "Protect", "Thunderbolt", "Wild Charge"],
+                "movepool": ["High Horsepower", "Overheat", "Protect", "Wild Charge"],
+                "teraTypes": ["Ground"]
+            },
+            {
+                "role": "Doubles Fast Attacker",
+                "movepool": ["High Horsepower", "Overheat", "Protect", "Thunderbolt"],
                 "teraTypes": ["Flying", "Water"]
             }
         ]
@@ -2994,8 +3009,8 @@
             },
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Drain Punch", "Knock Off", "Mach Punch", "Poison Jab"],
-                "teraTypes": ["Dark", "Poison"]
+                "movepool": ["Drain Punch", "Ice Punch", "Knock Off", "Mach Punch"],
+                "teraTypes": ["Dark", "Fighting", "Steel"]
             }
         ]
     },
@@ -3211,6 +3226,11 @@
                 "role": "Doubles Support",
                 "movepool": ["Clear Smog", "Pollen Puff", "Protect", "Rage Powder", "Spore"],
                 "teraTypes": ["Steel", "Water"]
+            },
+            {
+                "role": "Doubles Support",
+                "movepool": ["Pollen Puff", "Rage Powder", "Sludge Bomb", "Spore"],
+                "teraTypes": ["Steel", "Water"]
             }
         ]
     },
@@ -3351,11 +3371,6 @@
                 "role": "Doubles Support",
                 "movepool": ["Foul Play", "Knock Off", "Roost", "Snarl", "Tailwind", "Taunt", "Toxic", "U-turn"],
                 "teraTypes": ["Steel"]
-            },
-            {
-                "role": "Doubles Bulky Attacker",
-                "movepool": ["Defog", "Foul Play", "Knock Off", "Taunt", "Toxic"],
-                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -3466,6 +3481,11 @@
                 "role": "Bulky Protect",
                 "movepool": ["Grass Knot", "Knock Off", "Protect", "Snarl", "Taunt", "Thunder Wave", "Thunderbolt"],
                 "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Offensive Protect",
+                "movepool": ["Acrobatics", "Grass Knot", "Knock Off", "Protect", "Snarl", "Wildbolt Storm"],
+                "teraTypes": ["Electric", "Flying", "Steel"]
             }
         ]
     },
@@ -3988,8 +4008,8 @@
         "level": 83,
         "sets": [
             {
-                "role": "Doubles Bulky Attacker",
-                "movepool": ["Bug Buzz", "Protect", "Sticky Web", "Thunderbolt"],
+                "role": "Bulky Protect",
+                "movepool": ["Bug Buzz", "Electroweb", "Protect", "Sticky Web", "Thunderbolt"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -4049,7 +4069,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Pollen Puff", "Protect", "Sticky Web", "Tailwind", "U-turn"],
+                "movepool": ["Moonblast", "Pollen Puff", "Protect", "Tailwind"],
                 "teraTypes": ["Dark"]
             },
             {
@@ -4214,8 +4234,8 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Double-Edge", "Knock Off", "Play Rough", "Rapid Spin", "Sucker Punch", "Superpower", "U-turn", "Wood Hammer"],
-                "teraTypes": ["Fairy", "Fighting", "Grass"]
+                "movepool": ["Double-Edge", "Knock Off", "Rapid Spin", "Sucker Punch", "Superpower", "U-turn", "Wood Hammer"],
+                "teraTypes": ["Fighting", "Grass"]
             }
         ]
     },
@@ -4389,7 +4409,7 @@
         "sets": [
             {
                 "role": "Choice Item user",
-                "movepool": ["Hydro Pump", "Ice Beam", "Scald", "U-turn"],
+                "movepool": ["Hydro Pump", "Ice Beam", "Muddy Water", "Scald"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -4409,7 +4429,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Brave Bird", "Defog", "Iron Head", "Roost", "Tailwind", "U-turn"],
+                "movepool": ["Brave Bird", "Iron Head", "Roost", "Tailwind", "U-turn"],
                 "teraTypes": ["Dragon"]
             }
         ]
@@ -4673,8 +4693,8 @@
         "level": 88,
         "sets": [
             {
-                "role": "Doubles Support",
-                "movepool": ["Aura Wheel", "Fake Out", "Knock Off", "Protect"],
+                "role": "Bulky Protect",
+                "movepool": ["Aura Wheel", "Electroweb", "Fake Out", "Knock Off", "Protect"],
                 "teraTypes": ["Electric"]
             },
             {
@@ -4884,7 +4904,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Encore", "Helping Hand", "Leaf Storm", "Pollen Puff"],
+                "movepool": ["Encore", "Giga Drain", "Helping Hand", "Leaf Storm", "Leech Seed", "Pollen Puff", "Psychic"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -4916,6 +4936,11 @@
                 "role": "Doubles Bulky Attacker",
                 "movepool": ["Body Slam", "Double-Edge", "Earth Power", "Protect", "Psychic", "Thunder Wave", "Thunderbolt"],
                 "teraTypes": ["Fairy"]
+            },
+            {
+                "role": "Doubles Wallbreaker",
+                "movepool": ["Double-Edge", "Earth Power", "Psychic", "Trick Room"],
+                "teraTypes": ["Fairy", "Ground"]
             }
         ]
     },
@@ -4924,7 +4949,7 @@
         "sets": [
             {
                 "role": "Offensive Protect",
-                "movepool": ["Close Combat", "Protect", "Stone Axe", "U-turn", "X-Scissor"],
+                "movepool": ["Close Combat", "Protect", "Stone Axe", "Tailwind", "U-turn", "X-Scissor"],
                 "teraTypes": ["Bug", "Fighting", "Rock", "Steel"]
             }
         ]
@@ -5025,7 +5050,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Double-Edge", "High Horsepower", "Lash Out", "Play Rough"],
-                "teraTypes": ["Ghost", "Normal"]
+                "teraTypes": ["Fairy", "Ground", "Normal"]
             }
         ]
     },
@@ -5035,7 +5060,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Double-Edge", "Helping Hand", "Lash Out", "Protect", "Yawn"],
-                "teraTypes": ["Fairy", "Ground", "Normal"]
+                "teraTypes": ["Ghost", "Normal"]
             },
             {
                 "role": "Doubles Wallbreaker",
@@ -5089,8 +5114,8 @@
             },
             {
                 "role": "Doubles Support",
-                "movepool": ["Encore", "Follow Me", "Helping Hand", "Population Bomb", "Protect", "Taunt", "Thunder Wave", "U-turn"],
-                "teraTypes": ["Ghost"]
+                "movepool": ["Encore", "Follow Me", "Population Bomb", "Protect", "Taunt", "Thunder Wave", "U-turn"],
+                "teraTypes": ["Ghost", "Normal"]
             }
         ]
     },
@@ -5679,7 +5704,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["High Horsepower", "Protect", "Rock Slide", "Stealth Rock", "Thunder Punch", "Thunder Wave", "Volt Switch"],
+                "movepool": ["Electroweb", "High Horsepower", "Protect", "Rock Slide", "Stealth Rock", "Thunder Punch", "Thunder Wave", "Volt Switch"],
                 "teraTypes": ["Flying", "Grass"]
             },
             {
@@ -6060,6 +6085,11 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Dark Pulse", "Earth Power", "Tera Starstorm", "Tri Attack"],
+                "teraTypes": ["Stellar"]
+            },
+            {
+                "role": "Doubles Setup Sweeper",
+                "movepool": ["Dark Pulse", "Meteor Beam", "Protect", "Tera Starstorm"],
                 "teraTypes": ["Stellar"]
             }
         ]

--- a/data/random-doubles-sets.json
+++ b/data/random-doubles-sets.json
@@ -15,7 +15,7 @@
             {
                 "role": "Offensive Protect",
                 "movepool": ["Heat Wave", "Hurricane", "Protect", "Scorching Sands", "Will-O-Wisp"],
-                "teraTypes": ["Fire", "Grass", "Ground"]
+                "teraTypes": ["Dragon", "Fire", "Ground"]
             }
         ]
     },
@@ -398,7 +398,7 @@
         "level": 88,
         "sets": [
             {
-                "role": "Doubles Support",
+                "role": "Doubles Bulky Attacker",
                 "movepool": ["Drain Punch", "Gunk Shot", "Haze", "Helping Hand", "Ice Punch", "Knock Off", "Poison Gas", "Poison Jab", "Shadow Sneak"],
                 "teraTypes": ["Dark"]
             }
@@ -596,6 +596,11 @@
                 "role": "Bulky Protect",
                 "movepool": ["Bulk Up", "Protect", "Raging Bull", "Stone Edge"],
                 "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Doubles Wallbreaker",
+                "movepool": ["Close Combat", "High Horsepower", "Iron Head", "Rock Slide", "Stone Edge", "Throat Chop"],
+                "teraTypes": ["Dark", "Fighting", "Steel"]
             }
         ]
     },
@@ -970,7 +975,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Head Smash", "High Horsepower", "Protect", "Sucker Punch", "Wood Hammer"],
-                "teraTypes": ["Grass", "Steel"]
+                "teraTypes": ["Grass"]
             }
         ]
     },
@@ -1185,7 +1190,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Brave Bird", "Fake Out", "Helping Hand", "Icy Wind", "Tailwind"],
-                "teraTypes": ["Steel"]
+                "teraTypes": ["Ground", "Steel"]
             },
             {
                 "role": "Doubles Wallbreaker",
@@ -1744,7 +1749,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Helping Hand", "Hurricane", "Leaf Storm", "Tailwind", "Wide Guard"],
+                "movepool": ["Helping Hand", "Hurricane", "Leaf Storm", "Protect", "Tailwind", "Wide Guard"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -1994,7 +1999,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Flash Cannon", "Hydro Pump", "Ice Beam", "Protect", "Yawn"],
+                "movepool": ["Flash Cannon", "Hydro Pump", "Ice Beam", "Icy Wind", "Protect", "Yawn"],
                 "teraTypes": ["Flying", "Grass"]
             },
             {
@@ -2023,7 +2028,7 @@
         "level": 100,
         "sets": [
             {
-                "role": "Doubles Support",
+                "role": "Doubles Bulky Attacker",
                 "movepool": ["Bug Bite", "Helping Hand", "Knock Off", "Sticky Web", "Taunt"],
                 "teraTypes": ["Bug", "Steel"]
             }
@@ -2063,7 +2068,7 @@
         "level": 100,
         "sets": [
             {
-                "role": "Doubles Support",
+                "role": "Doubles Bulky Attacker",
                 "movepool": ["Helping Hand", "Hurricane", "Pollen Puff", "Roost", "Toxic Spikes"],
                 "teraTypes": ["Steel"]
             }
@@ -4070,7 +4075,7 @@
             {
                 "role": "Doubles Support",
                 "movepool": ["Moonblast", "Pollen Puff", "Protect", "Tailwind"],
-                "teraTypes": ["Dark"]
+                "teraTypes": ["Steel"]
             },
             {
                 "role": "Tera Blast user",
@@ -4645,6 +4650,11 @@
             {
                 "role": "Doubles Fast Attacker",
                 "movepool": ["Heat Crash", "High Horsepower", "Protect", "Rock Polish", "Stone Edge"],
+                "teraTypes": ["Fire", "Rock"]
+            },
+            {
+                "role": "Choice Item user",
+                "movepool": ["Heat Crash", "High Horsepower", "Rock Slide", "Stone Edge"],
                 "teraTypes": ["Fire", "Rock"]
             }
         ]

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2785,7 +2785,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Destiny Bond", "Poltergeist", "Spikes", "Taunt", "Triple Axel", "Will-O-Wisp"],
-                "teraTypes": ["Ghost"]
+                "teraTypes": ["Ghost", "Ice"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -2406,6 +2406,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Clear Smog", "Earthquake", "Ice Beam", "Recover", "Stealth Rock", "Surf"],
                 "teraTypes": ["Poison", "Steel"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Earthquake", "Recover", "Sludge Bomb", "Stealth Rock", "Surf"],
+                "teraTypes": ["Poison"]
             }
         ]
     },

--- a/data/random-sets.json
+++ b/data/random-sets.json
@@ -1699,7 +1699,7 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["Bug Buzz", "Hurricane", "Hydro Pump", "Ice Beam", "Sticky Web", "Stun Spore", "U-turn"],
+                "movepool": ["Bug Buzz", "Hurricane", "Hydro Pump", "Sticky Web", "Stun Spore", "U-turn"],
                 "teraTypes": ["Ground", "Steel", "Water"]
             }
         ]
@@ -1759,7 +1759,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Encore", "Foul Play", "Knock Off", "Recover", "Taunt", "Thunder Wave", "Will-O-Wisp"],
+                "movepool": ["Encore", "Knock Off", "Recover", "Taunt", "Thunder Wave", "Will-O-Wisp"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -2271,11 +2271,6 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Bullet Seed", "Headlong Rush", "Rock Blast", "Shell Smash"],
                 "teraTypes": ["Grass", "Ground", "Rock", "Water"]
-            },
-            {
-                "role": "Fast Bulky Setup",
-                "movepool": ["Headlong Rush", "Shell Smash", "Stone Edge", "Wood Hammer"],
-                "teraTypes": ["Ground", "Rock", "Water"]
             }
         ]
     },
@@ -2300,11 +2295,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Flip Turn", "Ice Beam", "Knock Off", "Roost", "Stealth Rock", "Surf", "Yawn"],
-                "teraTypes": ["Flying", "Grass"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Grass Knot", "Ice Beam", "Roost", "Surf"],
                 "teraTypes": ["Flying", "Grass"]
             }
         ]
@@ -2503,14 +2493,9 @@
         "level": 90,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Foul Play", "Pain Split", "Poltergeist", "Shadow Sneak", "Sucker Punch", "Will-O-Wisp"],
+                "role": "Bulky Support",
+                "movepool": ["Foul Play", "Pain Split", "Poltergeist", "Shadow Sneak", "Sucker Punch", "Toxic", "Will-O-Wisp"],
                 "teraTypes": ["Dark", "Ghost"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Dark Pulse", "Rest", "Sleep Talk"],
-                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -2644,7 +2629,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Earthquake", "Flamethrower", "Ice Punch", "Knock Off", "Volt Switch", "Wild Charge"],
+                "movepool": ["Earthquake", "Flamethrower", "Ice Punch", "Knock Off", "Supercell Slam", "Volt Switch"],
                 "teraTypes": ["Dark", "Electric", "Ground"]
             },
             {
@@ -2778,7 +2763,7 @@
         "level": 88,
         "sets": [
             {
-                "role": "Bulky Attacker",
+                "role": "Wallbreaker",
                 "movepool": ["Earthquake", "Leech Life", "Pain Split", "Poltergeist", "Shadow Sneak", "Trick"],
                 "teraTypes": ["Ghost", "Ground"]
             },
@@ -3556,6 +3541,11 @@
                 "role": "Wallbreaker",
                 "movepool": ["Bitter Malice", "Flamethrower", "Focus Blast", "Hyper Voice", "Nasty Plot", "Trick", "U-turn"],
                 "teraTypes": ["Fighting", "Normal"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["Focus Blast", "Hyper Voice", "Poltergeist", "Will-O-Wisp"],
+                "teraTypes": ["Fighting", "Normal"]
             }
         ]
     },
@@ -3664,7 +3654,7 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["Close Combat", "Flamethrower", "Giga Drain", "Knock Off", "Thunderbolt", "U-turn"],
+                "movepool": ["Close Combat", "Discharge", "Flamethrower", "Giga Drain", "Knock Off", "U-turn"],
                 "teraTypes": ["Poison", "Steel"]
             }
         ]
@@ -3784,12 +3774,12 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Defog", "Foul Play", "Roost", "Toxic", "U-turn"],
+                "movepool": ["Defog", "Foul Play", "Knock Off", "Roost", "Toxic", "U-turn"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Brave Bird", "Defog", "Foul Play", "Knock Off", "Roost", "Toxic"],
+                "movepool": ["Brave Bird", "Defog", "Knock Off", "Roost", "Toxic"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -4359,7 +4349,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Focus Blast", "Nasty Plot", "Psyshock", "Shadow Ball", "Trick"],
+                "movepool": ["Focus Blast", "Nasty Plot", "Psychic", "Psyshock", "Shadow Ball", "Trick"],
                 "teraTypes": ["Fighting", "Ghost", "Psychic"]
             }
         ]
@@ -4478,11 +4468,6 @@
         "level": 84,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["Agility", "Bug Buzz", "Energy Ball", "Thunderbolt", "Volt Switch"],
-                "teraTypes": ["Electric"]
-            },
-            {
                 "role": "Bulky Support",
                 "movepool": ["Bug Buzz", "Energy Ball", "Sticky Web", "Thunderbolt", "Volt Switch"],
                 "teraTypes": ["Electric"]
@@ -4544,7 +4529,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Moonblast", "Psychic Noise", "Sticky Web", "Stun Spore", "U-turn"],
+                "movepool": ["Bug Buzz", "Moonblast", "Sticky Web", "Stun Spore", "U-turn"],
                 "teraTypes": ["Ghost"]
             },
             {
@@ -5338,8 +5323,8 @@
         "level": 77,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Draco Meteor", "Dragon Dance", "Earthquake", "Fire Fang", "Outrage"],
+                "role": "Setup Sweeper",
+                "movepool": ["Draco Meteor", "Dragon Dance", "Earthquake", "Outrage"],
                 "teraTypes": ["Dragon"]
             },
             {
@@ -5669,12 +5654,17 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Earthquake", "Protect", "Recover", "Salt Cure"],
+                "movepool": ["Earthquake", "Protect", "Recover", "Salt Cure", "Stealth Rock"],
                 "teraTypes": ["Dragon", "Ghost"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Body Press", "Iron Defense", "Recover", "Salt Cure", "Stealth Rock"],
+                "movepool": ["Body Press", "Protect", "Recover", "Salt Cure", "Stealth Rock"],
+                "teraTypes": ["Dragon", "Ghost"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Press", "Iron Defense", "Recover", "Salt Cure"],
                 "teraTypes": ["Dragon", "Ghost"]
             }
         ]
@@ -6086,11 +6076,6 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Close Combat", "Crunch", "Seed Bomb", "Spore", "Sucker Punch"],
                 "teraTypes": ["Dark", "Fighting"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["Bullet Seed", "Crunch", "Seed Bomb", "Spore", "Stun Spore", "Sucker Punch", "Synthesis"],
-                "teraTypes": ["Poison"]
             }
         ]
     },
@@ -6404,7 +6389,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Dragon Pulse", "Dragon Tail", "Giga Drain", "Recover"],
+                "movepool": ["Dragon Pulse", "Dragon Tail", "Giga Drain", "Recover", "Sucker Punch"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -6523,7 +6508,7 @@
         "level": 78,
         "sets": [
             {
-                "role": "Setup Sweeper",
+                "role": "Bulky Setup",
                 "movepool": ["Earthquake", "Iron Head", "Outrage", "Swords Dance"],
                 "teraTypes": ["Ground"]
             },
@@ -6611,6 +6596,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Calm Mind", "Focus Blast", "Psyshock", "Tachyon Cutter", "Volt Switch"],
                 "teraTypes": ["Fighting", "Steel"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Focus Blast", "Future Sight", "Psychic Noise", "Psyshock", "Tachyon Cutter", "Volt Switch"],
+                "teraTypes": ["Steel"]
             }
         ]
     },

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -557,7 +557,7 @@ export class RandomTeams {
 
 			// These status moves are redundant with each other
 			['taunt', 'disable'],
-			['toxic', ['willowisp', 'thunderwave']],
+			[['thunderwave', 'toxic'], ['thunderwave', 'willowisp']],
 			[['thunderwave', 'toxic', 'willowisp'], 'toxicspikes'],
 
 			// This space reserved for assorted hardcodes that otherwise make little sense out of context
@@ -1039,8 +1039,6 @@ export class RandomTeams {
 		case 'Hustle':
 			// some of this is just for Delibird in singles/doubles
 			return (!counter.get('Physical') || moves.has('fakeout') || moves.has('rapidspin'));
-		case 'Infiltrator':
-			return (isDoubles && abilities.has('Clear Body'));
 		case 'Insomnia':
 			return (role === 'Wallbreaker');
 		case 'Intimidate':
@@ -1195,7 +1193,7 @@ export class RandomTeams {
 		if (isDoubles) {
 			if (species.id === 'gumshoos' || species.id === 'porygonz') return 'Adaptability';
 			if (species.id === 'farigiraf') return 'Armor Tail';
-			if (species.id === 'dragapult') return 'Clear Body';
+			if (['carbink', 'dragapult', 'regirock', 'tentacruel'].includes(species.id)) return 'Clear Body';
 			if (species.id === 'altaria') return 'Cloud Nine';
 			if (species.id === 'kilowattrel' || species.id === 'meowsticf') return 'Competitive';
 			if (species.id === 'armarouge' && !moves.has('meteorbeam')) return 'Flash Fire';

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -83,7 +83,7 @@ const SETUP = [
 	'quiverdance', 'rockpolish', 'shellsmash', 'shiftgear', 'swordsdance', 'tailglow', 'tidyup', 'trailblaze', 'workup', 'victorydance',
 ];
 const SPEED_CONTROL = [
-	'electroweb', 'glare', 'icywind', 'lowsweep', 'quash', 'rocktomb', 'stringshot', 'tailwind', 'thunderwave', 'trickroom',
+	'electroweb', 'glare', 'icywind', 'lowsweep', 'quash', 'stringshot', 'tailwind', 'thunderwave', 'trickroom',
 ];
 // Moves that shouldn't be the only STAB moves:
 const NO_STAB = [
@@ -1157,6 +1157,7 @@ export class RandomTeams {
 		if (species.id === 'scovillain') return 'Chlorophyll';
 		if (species.id === 'empoleon') return 'Competitive';
 		if (species.id === 'swampert' && !counter.get('Water') && !moves.has('flipturn')) return 'Damp';
+		if ((species.id === 'thundurus') && moves.has('terablast')) return 'Defiant';
 		if (species.id === 'dodrio') return 'Early Bird';
 		if (species.id === 'chandelure') return 'Flash Fire';
 		if (species.id === 'golemalola' && moves.has('doubleedge')) return 'Galvanize';
@@ -1205,7 +1206,6 @@ export class RandomTeams {
 			if (species.id === 'conkeldurr' && role === 'Doubles Wallbreaker') return 'Guts';
 			if (species.id !== 'arboliva' && abilities.has('Harvest')) return 'Harvest';
 			if (species.id === 'dragonite' || species.id === 'lucario') return 'Inner Focus';
-			if (species.id === 'ariados') return 'Insomnia';
 			if (species.id === 'primarina') return 'Liquid Voice';
 			if (species.id === 'kommoo') return 'Soundproof';
 			if (
@@ -1221,10 +1221,7 @@ export class RandomTeams {
 
 			// just doubles and multi
 			if (this.format.gameType !== 'freeforall') {
-				if (
-					species.id === 'clefairy' ||
-					(species.baseSpecies === 'Maushold' && role === 'Doubles Support')
-				) return 'Friend Guard';
+				if (species.id === 'clefairy') return 'Friend Guard';
 				if (species.id === 'blissey') return 'Healer';
 				if (species.id === 'sinistcha') return 'Hospitality';
 				if (species.id === 'duraludon') return 'Stalwart';
@@ -1517,9 +1514,13 @@ export class RandomTeams {
 			(species.id === 'garchomp' && role === 'Fast Support') || (
 				ability === 'Regenerator' && (role === 'Bulky Support' || role === 'Bulky Attacker') &&
 				(species.baseStats.hp + species.baseStats.def) >= 180 && this.randomChance(1, 2)
+			) || (
+				ability !== 'Regenerator' && !counter.get('setup') && counter.get('recovery') &&
+				this.dex.getEffectiveness('Fighting', species) < 1 &&
+				(species.baseStats.hp + species.baseStats.def) > 200 && this.randomChance(1, 2)
 			)
 		) return 'Rocky Helmet';
-		if (moves.has('outrage')) return 'Lum Berry';
+		if (moves.has('outrage') && this.randomChance(1, 2)) return 'Lum Berry';
 		if (moves.has('protect') && ability !== 'Speed Boost') return 'Leftovers';
 		if (
 			role === 'Fast Support' && isLead &&

--- a/data/random-teams.ts
+++ b/data/random-teams.ts
@@ -1155,7 +1155,7 @@ export class RandomTeams {
 		if (species.id === 'scovillain') return 'Chlorophyll';
 		if (species.id === 'empoleon') return 'Competitive';
 		if (species.id === 'swampert' && !counter.get('Water') && !moves.has('flipturn')) return 'Damp';
-		if ((species.id === 'thundurus') && moves.has('terablast')) return 'Defiant';
+		if (species.id === 'thundurus' && (role === 'Offensive Protect' || moves.has('terablast'))) return 'Defiant';
 		if (species.id === 'dodrio') return 'Early Bird';
 		if (species.id === 'chandelure') return 'Flash Fire';
 		if (species.id === 'golemalola' && moves.has('doubleedge')) return 'Galvanize';


### PR DESCRIPTION
**Gen 9**

-Rocky Helmet now generates 50% of the time on Pokemon that have recovery, have an HP and Defense stat sum of over 200, don't have setup, and aren't weak to fighting, if they don't have a higher priority item. This affects Eternatus, Morning Sun Solgaleo, Hippowdon, non-setup Chesnaught, non-setup Deoxys-Defense, non-setup Pecharunt, Corviknight, and non-setup Skarmory.
-the existing Lum Berry users (Kingdra, Haxorus, Flygon, Roaring Moon, Flapple, Regidrago, and Archaludon) now run Lum Berry 50% less often, and will get Life Orb (or in Archaludon's case, Leftovers) instead. Flapple will continue to have a 50% chance to get Wide Lens with Dragon Dance.

-Non-Sticky Web Vikavolt (i.e. Specs and Agility) no longer exists. Choice Specs will only generate if the team already has a Sticky Web user.
-RestTalk Calm Mind Spiritomb no longer exists. Instead, Spiritomb can now sometimes get Toxic.
-Garganacl's sets have been restructured so that both Protect and Stealth Rock can exist together, as well as allowing either Body Press or Earthquake with either Protect or Stealth Rock.
-Hisuian Zoroark now has a Fast Attacker Life Orb set with Poltergeist, Hyper Voice, Focus Blast, and Will-O-Wisp. Tera Normal/Fighting.
-Gastrodon now has a second set with Tera Poison Sludge Bomb.
-Iron Crown now has an AV Pivot set with Future Sight, Psychic Noise, Psyshock, Tachyon Cutter, Volt Switch, and Focus Blast. Tera Steel only, for technical reasons.
-Bulky Attacker Regidrago is now Setup Sweeper and does not run Fire Fang. Yes, this does mean it now can run Dragon Dance and Draco Meteor at the same time.
-Swords Dance Archaludon is now Bulky Setup role, to give it Leftovers with the new Lum Berry reduction.
-Tera Blast Thundurus-Incarnate now runs Defiant.

-Support Masquerain: -Ice Beam
-Sableye: -Foul Play
-Mandibuzz: -Foul Play on Brave bird set, +Knock Off on non-Brave Bird set
-Support Ribombee: -Psychic Noise, +Bug Buzz
-Hoopa: +Psychic
-AV Eelektross: -Thunderbolt, +Discharge
-Fast Attacker Electivire: -Wild Charge, +Supercell Slam (i'm still sorry)
-Froslass: +Tera Ice

Reversions:
-Dipplin will regain Sucker Punch because its removal was neutral.
-Brute Bonnet's Synthesis set will be removed entirely because Sucker Punch did not increase its winrate.
-Dusknoir will regain Life Orb.
-Empoleon and Torterra will lose their new sets from last update.

**Gen 9 Random Doubles**:

-Terapagos now runs a third set with Meteor Beam.
-Thundurus now runs a third set with itemless Acrobatics.
-Tauros-Paldea-Combat now has an additional Choice Band set.
-Stonjourner now has an additional Choice Scarf/Band set with Rock Slide.
-Dusknoir now runs an additional Trick Room set of Trick Room, Poltergeist, Leech Life, and Protect with Tera Dark.
-Wyrdeer now runs an additional Trick Room set of Trick Room, Double-Edge, Psychic, and Earth Power with Tera Fairy/Ground.
-Zebstrika's sets have been split to guarantee High Horsepower and optimize its tera types depending on its abilities.
-Regirock has gained basically a copy of Registeel's set but with Rock STABs as a set 2.
-Maushold is now always Technician and no longer runs Helping Hand.
-Amoonguss now has a second set with Sludge Bomb instead of Clear Smog.
-Ariados's abilities are no longer hardcoded to be only Insomnia. I do not know with certainty what it runs now.
-Carbink, Regirock, and Tentacruel now always run Clear Body.
-Kricketune now always runs Knock Off.
-Vespiquen now always runs Pollen Puff.

-Vikavolt: +Electroweb (only appears if team has a Sticky Web user), role changed to Bulky Protect
-Morpeko Set 1: +Electroweb, role changed to Bulky Protect
-Weavile has finally caught up to the rest of the format and runs Triple Axel instead of Ice Spinner.
-Persian-Alola: -Quash, +Icy Wind
-Support Ribombee: -Sticky Web, -U-turn, -Tera Dark, +Moonblast, +Tera Steel
-Support Masquerain: -Sticky Web, +Protect
-Corviknight: -Defog
-Mandibuzz: -Defog (Defog no longer exists in Gen 9 Random Doubles)
-Calyrex: +Psychic, +Giga Drain, +Leech Seed
-Inteleon: -U-turn, +Muddy Water
-Komala: -Play Rough, -Tera Fairy
-Tropius: +Protect
-AV Conkeldurr: -Poison Jab, +Ice Punch
-Bulky Rhyperior: +Protect
-Alolan Muk: -Rock Tomb
-Articuno, Quagsire, Support Empoleon: +Icy Wind
-Kleavor, support Gliscor: +Tailwind
-Chimecho, Giratina, Support Tyranitar: +Thunder Wave
-Rotom-Wash, Rotom-Fan, Doubles Bulky Attacker Iron Thorns, Bulky Protect Raikou: +Electroweb
-Oinkolognes: support is now always Ghost/Normal Tera. Wallbreaker is now always Fairy/Normal/Ground Tera.
-Hitmontop: -Tera Dark
-Charizard: +Tera Dragon
-Houndoom: -Tera Water, +Tera Grass
-Sudowoodo: -Tera Steel
-Support Delibird: +Tera Ground

**Old Gens:**

-In Gens 5-7, Stantler is now always Intimidate.
-In Gens 5-7, Accelgor now sometimes runs U-turn and no longer runs Yawn or a Grass-type move.
-In gens 5-7, Zoroark no longer runs Choice Scarf.
-In Gens 6-7, Yveltal no longer runs Foul Play.
-In gens 6-7, Heliolisk and Galvantula no longer run HP Ice.
-In Gens 6-7, Tangrowth now runs Sludge Bomb instead of HP Fire.
-In Gens 6-7, Volcanion now runs Toxic instead of Substitute.
-In Gens 6-7, Furfrou now runs Dark Pulse instead of Sucker Punch.
-In gens 6-7, Dragonite now runs only Dragon Dance sets, and doesn't run Extreme Speed. Roost is included!
-In Gens 6-7, Muk now runs Brick Break instead of Fire Punch.
-In Gens 6-7, Gourgeist now runs Frisk always.
-In gens 6-7, Scolipede now only runs Protect with its setup set.
-In gens 6-7, Setup Dustox now runs HP Ground.
-In gens 6-7, Doublade no longer runs Toxic.
-In gens 6-7, Persian will no longer run Unnerve.
-In gens 6-7, Mightyena now sometimes runs Toxic and can now hold a Life Orb.
-In Gens 5-4, Absol's sets have been optimized to always have Sucker Punch, and Fire Blast has been removed.
-In Gens 5-4, Dragonite now runs a Choice Band set with Superpower and a Dragon Dance set with Outrage, Earthquake, and Fire Punch/Roost, instead of the sets it ran before.
-In Gen 8, Falinks now runs Iron Head instead of Poison Jab.
-In Gen 8, Gothitelle, Beheeyem, and Meowstic-F now run Dark Pulse instead of Shadow Ball.
-In Gen 7, Butterfree and Mothim now have a Buginium Z set.
-In Gen 7, Lopunny now has a Z-Splash set. (+3 Attack)
-In Gen 7, Glaceon now has a Z-Celebrate set with Hidden Power Ground and Stored Power.
-In Gen 7, Tapu Fini will no longer get both Surf and Hydro Pump at the same time.
-In Gen 7, Vikavolt no longer runs HP Ice.
-In Gen 7, Silvally-Fighting now runs Crunch and Rock Slide and no longer runs Shadow Claw.
-In Gen 7, Celesteela now runs Heavy Slam on its Autotomize set instead of Flash Cannon, because it truly is that heavy.
-In gen 7, Zygarde-10% will no longer run Lum Berry Coil if the team does not have a Z-Move user yet, and the Z-Move user set can now run Iron Tail.
-In Gen 5, Vespiquen now runs Flying Gem Acrobatics instead of Air Slash.
-In Gen 3, Calm Mind variants of Girafarig and Xatu can now run Early Bird Rest. CM Xatu no longer runs Giga Drain, and CM Girafarig no longer runs WishTect.
-In Gen 3, Metagross will no longer run Psychic with Choice Band.
-In Gen 3, Castform now runs Fire Blast instead of Flamethrower
-In Gen 3, Feraligatr now always runs Earthquake
-In Gen 3, Cloyster now sometimes does not run Ice Beam.
-In Gen 3, Torkoal now no longer runs Yawn.
-In Gen 3, Lickitung now runs Earthquake instead of Flamethrower on its Bulky Attacker set.
-In Gen 2, Furret, Hitmontop, and Hitmonchan no longer run Mint Berry Rest on their Setup Sweeper sets.
-In Gen 2, Setup Sweeper Scyther no longer exists; it will now always be Baton Pass.
-In Gen 2, Bulky Attacker Gyarados now runs Surf.
-In Gen 2, the Clefable set that has both Return and Thunder Wave now doesn't.
-In Gen 2, Sneasel now runs HP Ground over Iron Tail, and the Thief set now runs Moonlight over Shadow Ball.
-In Gen 2, Qwilfish now runs Hidden Power Ground.

