### PR TITLE
SSBU: Disable weakness counter on forcemonotype

### DIFF
--- a/data/mods/gen9ssb/random-teams.ts
+++ b/data/mods/gen9ssb/random-teams.ts
@@ -1037,8 +1037,8 @@ export class RandomStaffBrosTeams extends RandomTeams {
 		const debug: string[] = []; // Set this to a list of SSB sets to override the normal pool for debugging.
 		const ruleTable = this.dex.formats.getRuleTable(this.format);
 		const monotype = this.forceMonotype ||
-			(ruleTable.has('sametypeclause') ?
-			this.sample([...this.dex.types.names().filter(x => x !== 'Stellar')]) : false);
+						 (ruleTable.has('sametypeclause') ?
+						 this.sample([...this.dex.types.names().filter(x => x !== 'Stellar')]) : false);
 
 		let pool = Object.keys(ssbSets);
 		if (debug.length) {

--- a/data/mods/gen9ssb/random-teams.ts
+++ b/data/mods/gen9ssb/random-teams.ts
@@ -1036,9 +1036,8 @@ export class RandomStaffBrosTeams extends RandomTeams {
 		const team: PokemonSet[] = [];
 		const debug: string[] = []; // Set this to a list of SSB sets to override the normal pool for debugging.
 		const ruleTable = this.dex.formats.getRuleTable(this.format);
-		const monotype = this.forceMonotype ||
-						 (ruleTable.has('sametypeclause') ?
-						 this.sample([...this.dex.types.names().filter(x => x !== 'Stellar')]) : false);
+		const monotype = this.forceMonotype || (ruleTable.has('sametypeclause') ?
+			this.sample([...this.dex.types.names().filter(x => x !== 'Stellar')]) : false);
 
 		let pool = Object.keys(ssbSets);
 		if (debug.length) {

--- a/data/mods/gen9ssb/random-teams.ts
+++ b/data/mods/gen9ssb/random-teams.ts
@@ -1036,8 +1036,9 @@ export class RandomStaffBrosTeams extends RandomTeams {
 		const team: PokemonSet[] = [];
 		const debug: string[] = []; // Set this to a list of SSB sets to override the normal pool for debugging.
 		const ruleTable = this.dex.formats.getRuleTable(this.format);
-		const monotype = ruleTable.has('sametypeclause') ?
-			this.sample([...this.dex.types.names().filter(x => x !== 'Stellar')]) : false;
+		const monotype = this.forceMonotype ||
+			(ruleTable.has('sametypeclause') ?
+			this.sample([...this.dex.types.names().filter(x => x !== 'Stellar')]) : false);
 
 		let pool = Object.keys(ssbSets);
 		if (debug.length) {
@@ -1066,7 +1067,6 @@ export class RandomStaffBrosTeams extends RandomTeams {
 			// Enforce typing limits
 			if (!(debug.length || monotype)) { // Type limits are ignored for debugging, monotype, or memes.
 				const species = this.dex.species.get(ssbSet.species);
-				if (this.forceMonotype && !species.types.includes(this.forceMonotype)) continue;
 
 				const weaknesses = [];
 				for (const type of this.dex.types.names()) {


### PR DESCRIPTION
The weakness limit of 3 was still enforced under forcemonotype. This harmonizes the @@@monotype and @@@forcemonotype=<type> mods.