### PR TITLE
ADV Doubles OU: Ban Quick Claw

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3326,7 +3326,7 @@ export const Formats: FormatList = [
 		gameType: 'doubles',
 		searchShow: false,
 		ruleset: ['Standard', '!Switch Priority Clause Mod'],
-		banlist: ['Uber', 'Soul Dew', 'Swagger'],
+		banlist: ['Uber', 'Quick Claw', 'Soul Dew', 'Swagger'],
 		unbanlist: ['Wobbuffet', 'Wynaut'],
 	},
 


### PR DESCRIPTION
https://www.smogon.com/forums/threads/adv-doubles-quick-claw-banned.3666831/page-3#post-10114012