### PR TITLE
Endless Battle Clause: Skill Swap should remove the user's staleness

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -17247,6 +17247,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			target.ability = sourceAbility.id;
 			source.abilityState = {id: this.toID(source.ability), target: source};
 			target.abilityState = {id: this.toID(target.ability), target: target};
+			source.volatileStaleness = undefined;
 			if (!target.isAlly(source)) target.volatileStaleness = 'external';
 			this.singleEvent('Start', targetAbility, source.abilityState, source);
 			this.singleEvent('Start', sourceAbility, target.abilityState, target);

--- a/test/sim/misc/endlessbattleclause.js
+++ b/test/sim/misc/endlessbattleclause.js
@@ -190,6 +190,17 @@ describe('Endless Battle Clause (slow)', () => {
 		battle.makeChoices('switch 2', 'switch 2');
 		assert(battle.ended);
 	});
+
+	it('Skill Swap should remove the user\'s staleness', () => {
+		battle = common.createBattle({endlessBattleClause: true}, [[
+			{species: "Furret", moves: ['skillswap']},
+		], [
+			{species: "Ampharos", moves: ['skillswap']},
+		]]);
+		skipTurns(battle, 100);
+		for (let i = 0; i < 8; i++) battle.makeChoices();
+		assert.false(battle.ended);
+	});
 });
 
 // Endless Battle Clause doesn't take effect for 100 turns, so we artificially skip turns


### PR DESCRIPTION
As defined, a Pokemon is only stale if affected by the *opponent's* Skill Swap. Using Skill Swap yourself means you changed your ability of your own volition and shouldn't be considered stale anymore.

Thanks to Geneku2 who came across this in a battle (unfortunately in his opponent's favor) and reported it https://replay.pokemonshowdown.com/gen9balancedhackmons-2125311602-f9fdiydceby4d10qylt0bu0itj0zuo2pw