### PR TITLE
Randomized format updates

### DIFF
--- a/data/random-battles/gen2/sets.json
+++ b/data/random-battles/gen2/sets.json
@@ -524,7 +524,7 @@
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["explosion", "hiddenpowerice", "lightscreen", "reflect", "thunder"]
+                "movepool": ["explosion", "hiddenpowerice", "lightscreen", "reflect", "thunder", "thunderbolt"]
             }
         ]
     },
@@ -1160,10 +1160,6 @@
             {
                 "role": "Generalist",
                 "movepool": ["encore", "hiddenpowerflying", "leechseed", "stunspore"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["encore", "reflect", "stunspore", "synthesis"]
             }
         ]
     },

--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -1387,8 +1387,8 @@
                 "movepool": ["doubleedge", "earthquake", "explosion", "hiddenpowerrock", "irontail", "rest", "roar", "toxic"]
             },
             {
-                "role": "Bulky Support",
-                "movepool": ["doubleedge", "earthquake", "hiddenpowerrock", "rest", "sleeptalk"]
+                "role": "Staller",
+                "movepool": ["doubleedge", "earthquake", "hiddenpowerrock", "protect", "toxic"]
             }
         ]
     },
@@ -1976,10 +1976,6 @@
     "slaking": {
         "level": 79,
         "sets": [
-            {
-                "role": "Wallbreaker",
-                "movepool": ["doubleedge", "earthquake", "focuspunch", "return", "shadowball"]
-            },
             {
                 "role": "Fast Attacker",
                 "movepool": ["doubleedge", "earthquake", "hyperbeam", "return", "shadowball"]

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -195,7 +195,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowerfire", "sludgebomb", "solarbeam", "sunnyday", "synthesis"]
+                "movepool": ["hiddenpowerfire", "sludgebomb", "solarbeam", "sunnyday"]
             }
         ]
     },
@@ -944,7 +944,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["energyball", "hiddenpowerfire", "hiddenpowerrock", "leafstorm", "sleeppowder", "stunspore", "synthesis"]
+                "movepool": ["energyball", "hiddenpowerfire", "hiddenpowerrock", "leafstorm", "leechseed", "sleeppowder", "stunspore", "synthesis"]
             }
         ]
     },
@@ -1020,11 +1020,11 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "hiddenpowerfire", "morningsun", "psychic", "signalbeam", "trick"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "morningsun", "psychic", "signalbeam", "trick"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["batonpass", "calmmind", "hiddenpowerfire", "morningsun", "psychic", "substitute"]
+                "movepool": ["batonpass", "calmmind", "hiddenpowerfighting", "morningsun", "psychic", "substitute"]
             }
         ]
     },
@@ -1112,6 +1112,10 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["earthquake", "explosion", "ironhead", "roar", "stealthrock", "stoneedge", "toxic"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["earthquake", "ironhead", "protect", "toxic"]
             }
         ]
     },
@@ -1150,8 +1154,8 @@
         "level": 93,
         "sets": [
             {
-                "role": "Staller",
-                "movepool": ["encore", "knockoff", "rest", "stealthrock", "toxic"]
+                "role": "Bulky Support",
+                "movepool": ["encore", "knockoff", "protect", "stealthrock", "toxic"]
             }
         ]
     },
@@ -1218,7 +1222,11 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["hiddenpowerflying", "rest", "sleeptalk", "surf", "toxic"]
+                "movepool": ["rest", "sleeptalk", "surf", "toxic"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["hiddenpowerflying", "protect", "surf", "toxic"]
             }
         ]
     },
@@ -1736,6 +1744,10 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["batonpass", "encore", "hiddenpowerice", "nastyplot", "thunderbolt"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"]
             }
         ]
     },
@@ -1745,6 +1757,10 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["batonpass", "encore", "hiddenpowerice", "nastyplot", "thunderbolt"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"]
             }
         ]
     },
@@ -2226,7 +2242,7 @@
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "seismictoss", "stealthrock", "toxic"]
+                "movepool": ["protect", "seismictoss", "stealthrock", "thunderwave", "toxic"]
             }
         ]
     },
@@ -2493,7 +2509,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["flashcannon", "protect", "stealthrock", "toxic"]
+                "movepool": ["flashcannon", "protect", "stealthrock", "suckerpunch", "toxic"]
             }
         ]
     },
@@ -2619,7 +2635,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fakeout", "return", "shadowclaw", "taunt", "uturn"]
+                "movepool": ["fakeout", "irontail", "return", "shadowclaw", "uturn"]
             }
         ]
     },
@@ -2693,7 +2709,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "crunch", "extremespeed", "icepunch", "swordsdance"],
+                "movepool": ["closecombat", "crunch", "extremespeed", "stoneedge", "swordsdance"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -2950,8 +2966,12 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "icepunch", "painsplit", "shadowsneak", "trick", "willowisp"],
+                "movepool": ["earthquake", "icepunch", "painsplit", "shadowsneak", "toxic", "trick", "willowisp"],
                 "preferredTypes": ["Ground"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["earthquake", "protect", "shadowsneak", "toxic"]
             },
             {
                 "role": "Bulky Attacker",
@@ -2984,6 +3004,10 @@
                 "role": "Bulky Attacker",
                 "movepool": ["overheat", "painsplit", "shadowball", "thunderbolt", "trick", "willowisp"],
                 "preferredTypes": ["Fire"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["rest", "shadowball", "sleeptalk", "thunderbolt"]
             }
         ]
     },
@@ -2994,6 +3018,10 @@
                 "role": "Bulky Attacker",
                 "movepool": ["hydropump", "painsplit", "shadowball", "thunderbolt", "trick", "willowisp"],
                 "preferredTypes": ["Water"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["rest", "shadowball", "sleeptalk", "thunderbolt"]
             }
         ]
     },
@@ -3031,6 +3059,10 @@
                 "role": "Bulky Attacker",
                 "movepool": ["leafstorm", "painsplit", "shadowball", "thunderbolt", "trick", "willowisp"],
                 "preferredTypes": ["Grass"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["rest", "shadowball", "sleeptalk", "thunderbolt"]
             }
         ]
     },
@@ -3048,11 +3080,11 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "healingwish", "hiddenpowerfire", "icebeam", "psychic", "thunderbolt", "trick", "uturn"]
+                "movepool": ["calmmind", "healingwish", "hiddenpowerfighting", "icebeam", "psychic", "thunderbolt", "trick", "uturn"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["hiddenpowerfire", "psychic", "stealthrock", "thunderwave", "toxic", "uturn"]
+                "movepool": ["hiddenpowerfighting", "psychic", "stealthrock", "thunderwave", "toxic", "uturn"]
             }
         ]
     },
@@ -3351,11 +3383,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "earthpower", "fireblast", "recover", "sludgebomb"]
+                "movepool": ["calmmind", "earthpower", "fireblast", "recover", "sludgebomb"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "fireblast", "icebeam", "recover", "sludgebomb", "stealthrock", "willowisp"]
+                "movepool": ["earthquake", "fireblast", "icebeam", "recover", "sludgebomb", "stealthrock", "willowisp"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -567,11 +567,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["seismictoss", "softboiled", "toxic", "wish"]
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic", "wish"]
             }
         ]
     },
@@ -1068,7 +1064,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "hiddenpowerfire", "morningsun", "psychic", "psyshock", "signalbeam", "trick"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "morningsun", "psychic", "psyshock", "signalbeam", "trick"]
             }
         ]
     },
@@ -1220,11 +1216,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["encore", "knockoff", "stealthrock", "toxic"]
-            },
-            {
-                "role": "Staller",
-                "movepool": ["encore", "protect", "stealthrock", "toxic"]
+                "movepool": ["encore", "knockoff", "protect", "stealthrock", "toxic"]
             }
         ]
     },
@@ -1805,6 +1797,10 @@
                 "role": "Bulky Setup",
                 "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
                 "preferredTypes": ["Ice"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"]
             }
         ]
     },
@@ -1815,6 +1811,10 @@
                 "role": "Bulky Setup",
                 "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
                 "preferredTypes": ["Ice"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"]
             }
         ]
     },
@@ -2245,7 +2245,8 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["icebeam", "rest", "sleeptalk", "thunderbolt"]
+                "movepool": ["focusblast", "icebeam", "rest", "sleeptalk", "thunderbolt", "thunderwave"],
+                "preferredTypes": ["Electric"]
             },
             {
                 "role": "Setup Sweeper",
@@ -2266,7 +2267,7 @@
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "seismictoss", "stealthrock", "toxic"]
+                "movepool": ["protect", "seismictoss", "stealthrock", "thunderwave", "toxic"]
             }
         ]
     },
@@ -2517,7 +2518,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "protect", "stealthrock", "suckerpunch", "toxic"]
             }
         ]
     },
@@ -2526,7 +2527,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["flashcannon", "protect", "stealthrock", "toxic"]
+                "movepool": ["flashcannon", "protect", "stealthrock", "suckerpunch", "toxic"]
             }
         ]
     },
@@ -2726,7 +2727,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "crunch", "extremespeed", "icepunch", "swordsdance"],
+                "movepool": ["closecombat", "crunch", "extremespeed", "stoneedge", "swordsdance"],
                 "preferredTypes": ["Normal"]
             },
             {
@@ -2987,8 +2988,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "icepunch", "painsplit", "shadowsneak", "trick", "willowisp"],
+                "movepool": ["earthquake", "icepunch", "painsplit", "shadowsneak", "toxic", "trick", "willowisp"],
                 "preferredTypes": ["Ground"]
+            },
+            {
+                "role": "Staller",
+                "movepool": ["earthquake", "protect", "shadowsneak", "toxic"]
             }
         ]
     },
@@ -3069,11 +3074,11 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["calmmind", "healingwish", "hiddenpowerfire", "icebeam", "psychic", "psyshock", "signalbeam", "thunderbolt", "trick", "uturn"]
+                "movepool": ["calmmind", "healingwish", "hiddenpowerfighting", "icebeam", "psychic", "psyshock", "signalbeam", "thunderbolt", "trick", "uturn"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["hiddenpowerfire", "psychic", "stealthrock", "thunderwave", "toxic", "uturn"]
+                "movepool": ["hiddenpowerfighting", "psychic", "stealthrock", "thunderwave", "toxic", "uturn"]
             }
         ]
     },
@@ -3359,11 +3364,13 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "earthpower", "fireblast", "recover", "sludgebomb"]
+                "movepool": ["calmmind", "earthpower", "fireblast", "recover", "sludgebomb"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["earthquake", "fireblast", "icebeam", "recover", "sludgebomb", "stealthrock", "willowisp"]
+                "movepool": ["earthquake", "fireblast", "icebeam", "recover", "sludgebomb", "stealthrock", "willowisp"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -4239,7 +4246,7 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["focusblast", "hiddenpowerflying", "hiddenpowerice", "taunt", "thunderbolt", "thunderwave"]
+                "movepool": ["hiddenpowerflying", "hiddenpowerice", "superpower", "taunt", "thunderbolt", "thunderwave"]
             }
         ]
     },

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -219,6 +219,8 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			['switcheroo', 'suckerpunch'],
 			// Jirachi
 			['bodyslam', 'healingwish'],
+			// Shuckle
+			['knockoff', 'protect'],
 		];
 
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);
@@ -231,6 +233,18 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		}
 
 		if (abilities.has('Guts')) this.incompatibleMoves(moves, movePool, 'protect', 'swordsdance');
+
+		// Cull filler moves for otherwise fixed set Stealth Rock users
+		if (!teamDetails.stealthRock) {
+			if (species.id === 'registeel' && role === 'Staller') {
+				if (movePool.includes('thunderwave')) this.fastPop(movePool, movePool.indexOf('thunderwave'));
+				if (moves.size + movePool.length <= this.maxMoveCount) return;
+			}
+			if (species.baseSpecies === 'Wormadam' && role === 'Staller') {
+				if (movePool.includes('suckerpunch')) this.fastPop(movePool, movePool.indexOf('suckerpunch'));
+				if (moves.size + movePool.length <= this.maxMoveCount) return;
+			}
+		}
 	}
 
 	// Generate random moveset for a given species, role, preferred type.
@@ -392,7 +406,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 
 		// Enforce Staller moves
 		if (role === 'Staller') {
-			const enforcedMoves = ['protect', 'toxic', 'wish'];
+			const enforcedMoves = ['protect', 'toxic'];
 			for (const move of enforcedMoves) {
 				if (movePool.includes(move)) {
 					counter = this.addMove(move, moves, types, abilities, teamDetails, species, isLead,
@@ -504,7 +518,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			return !counter.get(toID(ability));
 		case 'Defiant': case 'Justified':
 			return !counter.get('Physical');
-		case 'Guts':
+		case 'Guts': case 'Quick Feet':
 			return (!moves.has('facade') && !moves.has('sleeptalk'));
 		case 'Hustle':
 			return (counter.get('Physical') < 2 || species.id === 'delibird');
@@ -771,8 +785,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		}
 		if (
 			role === 'Fast Support' && isLead && defensiveStatTotal < 255 && !counter.get('recovery') &&
-			(!counter.get('recoil') || ability === 'Rock Head') &&
-			(counter.get('hazards') || !(moves.has('uturn') || moves.has('voltswitch')))
+			(counter.get('hazards') || counter.get('setup')) && (!counter.get('recoil') || ability === 'Rock Head')
 		) return 'Focus Sash';
 
 		// Default Items
@@ -883,9 +896,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 
 		// Prepare optimal HP
 		const srImmunity = ability === 'Magic Guard';
-		let srWeakness = srImmunity ? 0 : this.dex.getEffectiveness('Rock', species);
-		// Crash damage move users want an odd HP to survive two misses
-		if (['highjumpkick', 'jumpkick'].some(m => moves.has(m))) srWeakness = 2;
+		const srWeakness = srImmunity ? 0 : this.dex.getEffectiveness('Rock', species);
 		while (evs.hp > 1) {
 			const hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
 			if (moves.has('substitute') && !['Black Sludge', 'Leftovers'].includes(item)) {
@@ -899,9 +910,13 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			} else if (moves.has('bellydrum') && item === 'Sitrus Berry') {
 				// Belly Drum should activate Sitrus Berry
 				if (hp % 2 === 0) break;
+			} else if (['highjumpkick', 'jumpkick'].some(m => moves.has(m))) {
+				// Crash damage move users want an odd HP to survive two misses
+				if (hp % 2 > 0) break;
 			} else {
 				// Maximize number of Stealth Rock switch-ins
-				if (srWeakness <= 0 || ability === 'Regenerator' || ['Black Sludge', 'Leftovers', 'Life Orb'].includes(item)) break;
+				if (srWeakness <= 0 || ability === 'Regenerator') break;
+				if (srWeakness === 1 && ['Black Sludge', 'Leftovers', 'Life Orb'].includes(item)) break;
 				if (item !== 'Sitrus Berry' && hp % (4 / srWeakness) > 0) break;
 				// Minimise number of Stealth Rock switch-ins to activate Sitrus Berry
 				if (item === 'Sitrus Berry' && hp % (4 / srWeakness) === 0) break;

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -621,11 +621,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["seismictoss", "softboiled", "toxic", "wish"]
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic", "wish"]
             }
         ]
     },
@@ -968,7 +964,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "dragontail", "earthquake", "gigadrain", "leechseed", "synthesis", "toxic"]
+                "movepool": ["aromatherapy", "dragontail", "earthquake", "energyball", "leechseed", "synthesis", "toxic"]
             }
         ]
     },
@@ -1692,7 +1688,7 @@
         "level": 74,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Setup Sweeper",
                 "movepool": ["flareblitz", "highjumpkick", "knockoff", "protect", "stoneedge", "swordsdance"]
             }
         ]
@@ -2025,6 +2021,10 @@
                 "preferredTypes": ["Ice"]
             },
             {
+                "role": "Setup Sweeper",
+                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"]
+            },
+            {
                 "role": "Bulky Attacker",
                 "movepool": ["encore", "hiddenpowerice", "nuzzle", "thunderbolt", "toxic", "voltswitch"]
             }
@@ -2037,6 +2037,10 @@
                 "role": "Bulky Setup",
                 "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
                 "preferredTypes": ["Ice"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"]
             },
             {
                 "role": "Bulky Attacker",
@@ -2513,7 +2517,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["agility", "earthquake", "hammerarm", "icepunch", "meteormash", "zenheadbutt"]
+                "movepool": ["agility", "earthquake", "hammerarm", "meteormash", "zenheadbutt"],
+                "preferredTypes": ["Psychic"]
             }
         ]
     },
@@ -2560,7 +2565,7 @@
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "seismictoss", "stealthrock", "toxic"]
+                "movepool": ["protect", "seismictoss", "stealthrock", "thunderwave", "toxic"]
             }
         ]
     },
@@ -2860,7 +2865,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "protect", "stealthrock", "suckerpunch", "toxic"]
             }
         ]
     },
@@ -2869,7 +2874,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["flashcannon", "protect", "stealthrock", "toxic"]
+                "movepool": ["flashcannon", "protect", "stealthrock", "suckerpunch", "toxic"]
             }
         ]
     },
@@ -3005,7 +3010,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["fakeout", "knockoff", "return", "uturn"]
+                "movepool": ["fakeout", "knockoff", "return", "uturn", "wakeupslap"],
+                "preferredTypes": ["Dark"]
             }
         ]
     },
@@ -3023,11 +3029,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "ironhead", "psychic", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "ironhead", "psychic", "stealthrock", "toxic"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "ironhead", "protect", "psychic", "toxic"]
+                "movepool": ["earthquake", "ironhead", "protect", "psychic", "toxic"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -3102,7 +3110,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bulletpunch", "closecombat", "icepunch", "swordsdance"]
+                "movepool": ["bulletpunch", "closecombat", "irontail", "swordsdance"]
             },
             {
                 "role": "Setup Sweeper",
@@ -3708,8 +3716,8 @@
         "level": 71,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["calmmind", "earthpower", "icebeam", "judgment", "recover", "thunderbolt"]
+                "role": "Bulky Setup",
+                "movepool": ["calmmind", "earthpower", "energyball", "judgment", "recover"]
             }
         ]
     },
@@ -3780,11 +3788,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "earthquake", "fireblast", "icebeam", "recover", "sludgebomb"]
+                "movepool": ["defog", "earthquake", "icebeam", "recover", "sludgebomb"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "earthpower", "fireblast", "icebeam", "recover", "sludgebomb"]
+                "movepool": ["calmmind", "earthpower", "icebeam", "recover", "sludgebomb"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -4684,7 +4694,7 @@
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "hiddenpowerflying", "hiddenpowerice", "knockoff", "taunt", "thunderbolt", "thunderwave"]
+                "movepool": ["hiddenpowerflying", "hiddenpowerice", "knockoff", "superpower", "taunt", "thunderbolt", "thunderwave"]
             }
         ]
     },
@@ -4831,7 +4841,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["drainpunch", "leechseed", "spikes", "synthesis", "woodhammer"]
+                "movepool": ["bulkup", "drainpunch", "spikes", "synthesis", "toxic", "woodhammer"]
             },
             {
                 "role": "Staller",

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -149,6 +149,11 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["doubleedge", "knockoff", "pursuit", "return", "suckerpunch", "swordsdance"]
+            },
+            {
+                "role": "Z-Move user",
+                "movepool": ["doubleedge", "knockoff", "suckerpunch", "swordsdance"],
+                "preferredTypes": ["Normal"]
             }
         ]
     },
@@ -710,6 +715,10 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["dracometeor", "flamethrower", "gigadrain", "leafstorm"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["dracometeor", "flamethrower", "gigadrain", "knockoff"]
             }
         ]
     },
@@ -779,11 +788,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["seismictoss", "softboiled", "toxic", "wish"]
+                "movepool": ["aromatherapy", "seismictoss", "softboiled", "stealthrock", "thunderwave", "toxic", "wish"]
             }
         ]
     },
@@ -1020,6 +1025,11 @@
                 "role": "Fast Support",
                 "movepool": ["defog", "doubleedge", "earthquake", "pursuit", "roost", "stealthrock", "stoneedge"],
                 "preferredTypes": ["Ground"]
+            },
+            {
+                "role": "Z-Move user",
+                "movepool": ["earthquake", "honeclaws", "skyattack", "stoneedge"],
+                "preferredTypes": ["Flying"]
             }
         ]
     },
@@ -1141,7 +1151,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["aromatherapy", "dragontail", "earthquake", "gigadrain", "leechseed", "synthesis", "toxic"]
+                "movepool": ["aromatherapy", "dragontail", "earthquake", "energyball", "leechseed", "synthesis", "toxic"]
             }
         ]
     },
@@ -1866,7 +1876,7 @@
         "level": 74,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Setup Sweeper",
                 "movepool": ["flareblitz", "highjumpkick", "knockoff", "protect", "stoneedge", "swordsdance"]
             }
         ]
@@ -2206,6 +2216,10 @@
                 "role": "Bulky Setup",
                 "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
                 "preferredTypes": ["Ice"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"]
             }
         ]
     },
@@ -2216,6 +2230,10 @@
                 "role": "Bulky Setup",
                 "movepool": ["encore", "hiddenpowerice", "nastyplot", "substitute", "thunderbolt"],
                 "preferredTypes": ["Ice"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"]
             }
         ]
     },
@@ -2318,6 +2336,10 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["focusblast", "healbell", "psychic", "thunderwave", "toxic", "whirlwind"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["calmmind", "focusblast", "psychic", "psyshock", "recycle"]
             }
         ]
     },
@@ -2706,7 +2728,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["agility", "earthquake", "hammerarm", "icepunch", "meteormash", "zenheadbutt"]
+                "movepool": ["agility", "earthquake", "hammerarm", "meteormash", "zenheadbutt"],
+                "preferredTypes": ["Psychic"]
             }
         ]
     },
@@ -2753,7 +2776,7 @@
             },
             {
                 "role": "Staller",
-                "movepool": ["protect", "seismictoss", "stealthrock", "toxic"]
+                "movepool": ["protect", "seismictoss", "stealthrock", "thunderwave", "toxic"]
             }
         ]
     },
@@ -2898,7 +2921,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "firepunch", "icebeam", "knockoff", "psychoboost", "stealthrock", "superpower"],
+                "movepool": ["extremespeed", "icebeam", "knockoff", "psychoboost", "stealthrock", "superpower"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -2908,7 +2931,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "firepunch", "icebeam", "knockoff", "psychoboost", "superpower"],
+                "movepool": ["extremespeed", "icebeam", "knockoff", "psychoboost", "superpower"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -3070,7 +3093,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "protect", "stealthrock", "suckerpunch", "toxic"]
             }
         ]
     },
@@ -3079,7 +3102,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["flashcannon", "protect", "stealthrock", "toxic"]
+                "movepool": ["flashcannon", "protect", "stealthrock", "suckerpunch", "toxic"]
             }
         ]
     },
@@ -3249,11 +3272,13 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["earthquake", "ironhead", "psychic", "stealthrock", "toxic"]
+                "movepool": ["earthquake", "ironhead", "psychic", "stealthrock", "toxic"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "ironhead", "protect", "psychic", "toxic"]
+                "movepool": ["earthquake", "ironhead", "protect", "psychic", "toxic"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -3964,12 +3989,12 @@
         "level": 72,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["calmmind", "earthpower", "icebeam", "judgment", "recover", "thunderbolt"]
+                "role": "Bulky Setup",
+                "movepool": ["calmmind", "earthpower", "energyball", "judgment", "recover"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["calmmind", "earthpower", "fireblast", "icebeam", "recover", "thunderbolt"]
+                "movepool": ["calmmind", "earthpower", "energyball", "fireblast", "recover"]
             }
         ]
     },
@@ -4040,15 +4065,18 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "earthquake", "fireblast", "icebeam", "recover", "sludgebomb"]
+                "movepool": ["defog", "earthquake", "icebeam", "recover", "sludgebomb"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "earthpower", "fireblast", "icebeam", "recover", "sludgebomb"]
+                "movepool": ["calmmind", "earthpower", "icebeam", "recover", "sludgebomb"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Z-Move user",
-                "movepool": ["calmmind", "earthpower", "fireblast", "icebeam", "recover", "sludgebomb"]
+                "movepool": ["calmmind", "earthpower", "icebeam", "recover", "sludgebomb"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -5007,7 +5035,7 @@
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "hiddenpowerflying", "hiddenpowerice", "knockoff", "taunt", "thunderbolt", "thunderwave"]
+                "movepool": ["hiddenpowerflying", "hiddenpowerice", "knockoff", "superpower", "taunt", "thunderbolt", "thunderwave"]
             }
         ]
     },
@@ -5169,7 +5197,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["drainpunch", "leechseed", "spikes", "synthesis", "woodhammer"]
+                "movepool": ["bulkup", "drainpunch", "spikes", "synthesis", "toxic", "woodhammer"]
             },
             {
                 "role": "Staller",
@@ -5992,7 +6020,8 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "drainingkiss", "gigadrain", "hiddenpowerground"]
+                "movepool": ["calmmind", "drainingkiss", "gigadrain", "hiddenpowerground", "synthesis"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -6431,7 +6460,8 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["grassknot", "hiddenpowerfire", "hiddenpowerground", "powergem", "sludgewave", "stealthrock", "thunderbolt", "toxicspikes"]
+                "movepool": ["grassknot", "hiddenpowerfire", "hiddenpowerground", "powergem", "sludgewave", "stealthrock", "thunderbolt", "toxicspikes"],
+                "preferredTypes": ["Rock"]
             }
         ]
     },

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -387,6 +387,18 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if (species.id === 'porygonz') {
 			this.incompatibleMoves(moves, movePool, 'shadowball', 'recover');
 		}
+
+		// Cull filler moves for otherwise fixed set Stealth Rock users
+		if (!teamDetails.stealthRock) {
+			if (species.id === 'registeel' && role === 'Staller') {
+				if (movePool.includes('thunderwave')) this.fastPop(movePool, movePool.indexOf('thunderwave'));
+				if (moves.size + movePool.length <= this.maxMoveCount) return;
+			}
+			if (species.baseSpecies === 'Wormadam' && role === 'Staller') {
+				if (movePool.includes('suckerpunch')) this.fastPop(movePool, movePool.indexOf('suckerpunch'));
+				if (moves.size + movePool.length <= this.maxMoveCount) return;
+			}
+		}
 	}
 
 	// Checks for and removes incompatible moves, starting with the first move in movesA.
@@ -624,7 +636,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 
 		// Enforce Staller moves
 		if (role === 'Staller') {
-			const enforcedMoves = [...PROTECT_MOVES, 'toxic', 'wish'];
+			const enforcedMoves = [...PROTECT_MOVES, 'toxic'];
 			for (const move of enforcedMoves) {
 				if (movePool.includes(move)) {
 					counter = this.addMove(move, moves, types, abilities, teamDetails, species, isLead,
@@ -1089,8 +1101,8 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		}
 		if (
 			(role === 'Fast Support' || moves.has('stickyweb')) && isLead && defensiveStatTotal < 255 &&
-			!counter.get('recovery') && !moves.has('defog') && (!counter.get('recoil') || ability === 'Rock Head') &&
-			ability !== 'Regenerator'
+			!counter.get('recovery') && (counter.get('hazards') || counter.get('setup')) &&
+			(!counter.get('recoil') || ability === 'Rock Head')
 		) return 'Focus Sash';
 
 		// Default Items
@@ -1242,9 +1254,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 
 		// Prepare optimal HP
 		const srImmunity = ability === 'Magic Guard';
-		let srWeakness = srImmunity ? 0 : this.dex.getEffectiveness('Rock', species);
-		// Crash damage move users want an odd HP to survive two misses
-		if (['highjumpkick', 'jumpkick'].some(m => moves.has(m))) srWeakness = 2;
+		const srWeakness = srImmunity ? 0 : this.dex.getEffectiveness('Rock', species);
 		while (evs.hp > 1) {
 			const hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
 			if (moves.has('substitute') && !['Black Sludge', 'Leftovers'].includes(item)) {
@@ -1258,9 +1268,13 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			} else if (moves.has('bellydrum') && (item === 'Sitrus Berry' || ability === 'Gluttony')) {
 				// Belly Drum should activate Sitrus Berry
 				if (hp % 2 === 0) break;
+			} else if (['highjumpkick', 'jumpkick'].some(m => moves.has(m))) {
+				// Crash damage move users want an odd HP to survive two misses
+				if (hp % 2 > 0) break;
 			} else {
 				// Maximize number of Stealth Rock switch-ins
-				if (srWeakness <= 0 || ability === 'Regenerator' || ['Black Sludge', 'Leftovers', 'Life Orb'].includes(item)) break;
+				if (srWeakness <= 0 || ability === 'Regenerator') break;
+				if (srWeakness === 1 && ['Black Sludge', 'Leftovers', 'Life Orb'].includes(item)) break;
 				if (item !== 'Sitrus Berry' && hp % (4 / srWeakness) > 0) break;
 				// Minimise number of Stealth Rock switch-ins to activate Sitrus Berry
 				if (item === 'Sitrus Berry' && hp % (4 / srWeakness) === 0) break;

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -2059,7 +2059,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Setup",
-                "movepool": ["Body Press", "Foul Play", "Iron Defense", "Wide Guard"],
+                "movepool": ["Body Press", "Foul Play", "Iron Defense", "Rest", "Wide Guard"],
                 "teraTypes": ["Fighting", "Flying"]
             }
         ]
@@ -2421,6 +2421,11 @@
                 "role": "Doubles Bulky Setup",
                 "movepool": ["Body Press", "Flash Cannon", "Iron Defense", "Rest", "Thunder Wave"],
                 "teraTypes": ["Fighting"]
+            },
+            {
+                "role": "Doubles Setup Sweeper",
+                "movepool": ["Body Press", "Iron Defense", "Power Gem", "Rest", "Thunder Wave"],
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -2754,8 +2759,8 @@
         "sets": [
             {
                 "role": "Doubles Setup Sweeper",
-                "movepool": ["Aura Sphere", "Calm Mind", "Earth Power", "Fire Blast", "Judgment", "Recover", "Sludge Bomb"],
-                "teraTypes": ["Poison"]
+                "movepool": ["Calm Mind", "Fire Blast", "Judgment", "Recover", "Sludge Bomb"],
+                "teraTypes": ["Fire", "Poison"]
             }
         ]
     },
@@ -4828,8 +4833,8 @@
         "level": 76,
         "sets": [
             {
-                "role": "Doubles Fast Attacker",
-                "movepool": ["Close Combat", "Protect", "Sucker Punch", "Swords Dance", "Wicked Blow"],
+                "role": "Doubles Wallbreaker",
+                "movepool": ["Close Combat", "Poison Jab", "Protect", "Sucker Punch", "Wicked Blow"],
                 "teraTypes": ["Dark", "Poison"]
             }
         ]
@@ -4838,9 +4843,9 @@
         "level": 78,
         "sets": [
             {
-                "role": "Doubles Fast Attacker",
-                "movepool": ["Aqua Jet", "Close Combat", "Protect", "Surging Strikes", "Swords Dance"],
-                "teraTypes": ["Steel", "Water"]
+                "role": "Doubles Wallbreaker",
+                "movepool": ["Aqua Jet", "Close Combat", "Ice Spinner", "Protect", "Surging Strikes", "U-turn"],
+                "teraTypes": ["Water"]
             }
         ]
     },
@@ -5193,8 +5198,8 @@
         "level": 81,
         "sets": [
             {
-                "role": "Doubles Bulky Setup",
-                "movepool": ["Protect", "Recover", "Salt Cure", "Wide Guard"],
+                "role": "Bulky Protect",
+                "movepool": ["Protect", "Recover", "Salt Cure", "Stealth Rock", "Wide Guard"],
                 "teraTypes": ["Ghost"]
             }
         ]
@@ -5679,7 +5684,7 @@
             },
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Acid Spray", "Energy Ball", "Fire Blast", "Heat Wave", "Protect"],
+                "movepool": ["Acid Spray", "Energy Ball", "Heat Wave", "Protect"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -5739,7 +5744,7 @@
         "sets": [
             {
                 "role": "Offensive Protect",
-                "movepool": ["Close Combat", "Dazzling Gleam", "Knock Off", "Moonblast", "Protect", "Taunt"],
+                "movepool": ["Close Combat", "Dazzling Gleam", "Encore", "Knock Off", "Moonblast", "Protect"],
                 "teraTypes": ["Dark", "Fairy", "Fighting"]
             }
         ]
@@ -5789,8 +5794,13 @@
         "sets": [
             {
                 "role": "Offensive Protect",
-                "movepool": ["Icicle Crash", "Lash Out", "Protect", "Sacred Sword", "Sucker Punch", "Throat Chop"],
-                "teraTypes": ["Dark", "Fighting", "Ghost"]
+                "movepool": ["Icicle Crash", "Lash Out", "Protect", "Sucker Punch", "Throat Chop"],
+                "teraTypes": ["Dark", "Ghost"]
+            },
+            {
+                "role": "Doubles Wallbreaker",
+                "movepool": ["Icicle Crash", "Protect", "Sacred Sword", "Sucker Punch"],
+                "teraTypes": ["Fighting", "Ghost"]
             }
         ]
     },
@@ -5924,7 +5934,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Gunk Shot", "Icy Wind", "Roost", "Taunt"],
+                "movepool": ["Gunk Shot", "Icy Wind", "Play Rough", "Roost"],
                 "teraTypes": ["Dark", "Steel", "Water"]
             },
             {

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1424,7 +1424,7 @@ export class RandomTeams {
 		}
 		if (
 			(role === 'Bulky Protect' && counter.get('setup')) || moves.has('substitute') || moves.has('irondefense') ||
-			species.id === 'eternatus'
+			species.id === 'eternatus' || species.id === 'regigigas'
 		) return 'Leftovers';
 		if (species.id === 'sylveon') return 'Pixie Plate';
 		if (

--- a/test/random-battles/gen7.js
+++ b/test/random-battles/gen7.js
@@ -135,12 +135,6 @@ describe('[Gen 7] Random Battle (slow)', () => {
 
 	it('should prevent double Hidden Power', () => testHiddenPower('thundurustherian', options));
 
-	it('should give Meganium STAB', () => {
-		testSet('meganium', options, set => {
-			assert(set.moves.includes('gigadrain'), `Meganium: got ${set.moves}`);
-		});
-	});
-
 	it('should never give Xerneas Assault Vest', () => {
 		testSet('xerneas', options, set => assert.notEqual(set.item, 'Assault Vest'));
 	});


### PR DESCRIPTION
**Gen 9 Random Doubles Battle:**
-Bastiodon can now run Rest.
-Probopass now has a second setup set, with Power Gem instead of Flash Cannon as its STAB move.
-Arceus-Dragon: -Aura Sphere, -Earth Power, +Tera Fire.
-Both Urshifu formes have been revamped so that they always run their priority move.
-Garganacl now runs Stealth Rock.
-Iron Moth's Acid Spray set no longer runs Fire Blast, and always runs Heat Wave.
-Iron Valiant: -Taunt, +Encore.
-Chien-Pao's sets have been split to ensure that it always runs Sucker Punch.
-Doubles Support Fezandipiti: -Taunt, +Play Rough.
-Regigigas runs Leftovers.

**Old Gens:**
The changes below reduces or eliminates (depending on the generation) the likelihood that teams will have multiple Stealth Rock users.
-In Gens 4-7, Registeel now runs Thunder Wave on its Staller set; hardcoded to only generate if the team already has a rocker.
-In Gens 4-7, Wormadam-Trash now runs Sucker Punch; hardcoded to only generate if the team already has a rocker.
-In Gens 5-7, Wormadam-Sandy now runs Sucker Punch; hardcoded to only generate if the team already has a rocker.
-In Gens 4-5, Shuckle has been revamped so that it always runs Toxic, Encore, Stealth Rock, and one of Knock Off and Protect; when the team already has a rocker, it doesn't run Stealth Rock and runs both Knock Off and Protect.

-In Gens 4-7, lead Focus Sash no longer generates unless the set contains a hazard or setup move.
-In Gen 4-7, Plusle and Minun now run a Life Orb setup set with Nasty Plot, Thunderbolt, HP Ice, and Grass Knot.
-In Gens 4-7, Arceus-Poison always runs a Ground coverage move: Earthquake on non-setup and Earth Power on setup.
-In Gens 5-7, Chansey's sets have been combined for simplicity. To facilitate this, the Staller role no longer enforces Wish.
-In Gens 5-7, non-setup Thundurus now runs Superpower instead of Focus Blast.
-In Gens 6-7, Meganium now runs Energy Ball instead of Giga Drain.
-In Gens 6-7, Blaziken-Mega now always runs Swords Dance.
-In Gens 6-7, Mega Metagross always runs Zen Headbutt, and no longer runs Ice Punch.
-In Gens 6-7, Deoxys and Deoxys-Attack no longer run Fire Punch.
-In Gens 6-7, Bronzong always runs Earthquake.
-In Gens 6-7, Arceus-Fire no longer runs Thunderbolt and Ice Beam, and runs Energy Ball. Its non-Z set always runs Recover.
-In Gens 6-7, Bulky Support (Synthesis) Chesnaught no longer runs Leech Seed, and runs Bulk Up and Toxic.

-In Gen 7, Aerodactyl now runs a Z-Flying set with Sky Attack, Hone Claws, Stone Edge, and Earthquake.
-In Gen 7, Exeggutor-Alola now runs an AV set with Knock Off.
-In Gen 7, Grumpig runs a Gluttony Recycle Calm Mind set with a 50% healing berry.
-In Gen 7, Setup Sweeper Comfey can now run Synthesis, which rolls with Giga Drain.
-In Gen 7, Nihilego always runs Power Gem.

-In Gen 6, Purugly now runs Wake-up-slap to hit Rock and Steel types.
-In Gen 6, Lucario-Mega's physical set runs Adaptability boosted Iron Tail instead of Ice Punch.

-In Gens 4-5, Espeon and Mesprit now run HP Fighting instead of HP Fire.
-In Gens 4-5, physical Lucario now runs Stone Edge instead of Ice Punch.
-In Gens 4-5, Dusknoir now runs a Staller set like in Gens 6-7, with Shadow Sneak, Toxic, Protect, and Earthquake. Toxic has also been added to its Bulky Attacker set.
-In Gen 5, Scolipede is now always Swarm.
-In Gen 5, Regice can now run Thunder Wave and Focus Blast on its Bulky Attacker set.

-In Gen 4, Sunny Day Vileplume always runs HP Fire and no longer runs Synthesis.
-In Gen 4, Bellossom can now run Leech Seed.
-In Gen 4, Steelix now runs a Staller set with Earthquake, Toxic, Protect, and Iron Head.
-In Gen 4, Mantine now runs two sets. Both sets run Surf and Toxic; the first runs RestTalk, and the second HP Flying and Protect.
-In Gen 4, Purugly no longer runs Taunt and runs Iron Tail (enabling Choice Band).
-In Gen 4, every bulky Rotom forme now runs a RestTalk set.

-In Gen 3, Slaking always runs Hyper Beam, and no longer runs Focus Punch.
-In Gen 3, Steelix no longer runs RestTalk; instead, it has a Staller set with Toxic and Protect.

-In Gen 2, Electrode can now run Thunderbolt on its set with screens.
-In Gen 2, Jumpluff no longer has its attackless set. 



-In Gen 7, Raticate-Alola now runs a Z-Normal set with Double-Edge, Swords Dance, Knock Off, and Sucker Punch.

**Technical:**
-In Gens 5-7, High Jump Kick Mienshao will always have odd HP, even when its ability is Regenerator.
-In Gens 4-7, Pokemon 4x weak to Rock will have odd HP even if their item is Life Orb or Leftovers.