### PR TITLE
Fix Syrup Bomb interactions with source

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -19504,9 +19504,14 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onStart(pokemon) {
 				this.add('-start', pokemon, 'Syrup Bomb');
 			},
+			onUpdate(pokemon) {
+				if (this.effectState.source && !this.effectState.source.isActive) {
+					pokemon.removeVolatile('syrupbomb');
+				}
+			},
 			onResidualOrder: 14,
-			onResidual() {
-				this.boost({spe: -1});
+			onResidual(pokemon) {
+				this.boost({spe: -1}, pokemon, this.effectState.source);
 			},
 			onEnd(pokemon) {
 				this.add('-end', pokemon, 'Syrup Bomb', '[silent]');

--- a/test/sim/moves/syrupbomb.js
+++ b/test/sim/moves/syrupbomb.js
@@ -26,4 +26,29 @@ describe('Syrup Bomb', function () {
 		assert.statStage(applin, 'spe', -3);
 		assert.false(applin.volatiles['syrupbomb'], `Applin should no longer have the Syrup Bomb volatile`);
 	});
+
+	it(`should end if the source leaves the field`, function () {
+		battle = common.createBattle([[
+			{species: 'Dipplin', ability: 'noguard', moves: ['syrupbomb']},
+			{species: 'Furret', moves: ['sleeptalk']},
+		], [
+			{species: 'Applin', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		battle.makeChoices('switch 2', 'auto');
+		assert.statStage(battle.p2.active[0], 'spe', -1);
+	});
+
+	it(`the stat changes should be reflected by Mirror Armor`, function () {
+		battle = common.createBattle([[
+			{species: 'Dipplin', ability: 'noguard', moves: ['syrupbomb']},
+		], [
+			{species: 'Corviknight', ability: 'mirrorarmor', moves: ['sleeptalk']},
+		]]);
+
+		battle.makeChoices();
+		assert.statStage(battle.p1.active[0], 'spe', -1);
+		assert.statStage(battle.p2.active[0], 'spe', 0);
+	});
 });


### PR DESCRIPTION
* Syrup Bomb ends if the source leaves the field https://www.youtube.com/watch?v=QUk_cWJKw4Y
* Mirror Armor reflects the stat boosts from Syrup Bomb https://www.smogon.com/forums/threads/syrup-bomb-mirror-armor.3742869/post-10130871