### PR TITLE
Reveal Greninja-Ash in Team Preview

### DIFF
--- a/data/mods/gen4/rulesets.ts
+++ b/data/mods/gen4/rulesets.ts
@@ -13,8 +13,9 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 			this.add('clearpoke');
 			for (const pokemon of this.getAllPokemon()) {
 				const details = pokemon.details.replace(', shiny', '')
-					.replace(/(Arceus|Genesect|Greninja|Gourgeist|Pumpkaboo|Xerneas|Silvally|Urshifu|Dudunsparce)(-[a-zA-Z?-]+)?/g, '$1-*')
-					.replace(/(Zacian|Zamazenta)(?!-Crowned)/g, '$1-*'); // Hacked-in Crowned formes will be revealed
+					.replace(/(Arceus|Genesect|Gourgeist|Pumpkaboo|Xerneas|Silvally|Urshifu|Dudunsparce)(-[a-zA-Z?-]+)?/g, '$1-*')
+					.replace(/(Zacian|Zamazenta)(?!-Crowned)/g, '$1-*') // Hacked-in Crowned formes will be revealed
+					.replace(/(Greninja)(?!-Ash)/g, '$1-*'); // Hacked-in Greninja-Ash will be revealed
 				this.add('poke', pokemon.side.id, details, pokemon.item ? 'item' : '');
 			}
 			this.makeRequest('teampreview');

--- a/data/mods/gen5/rulesets.ts
+++ b/data/mods/gen5/rulesets.ts
@@ -19,8 +19,9 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 			this.add('clearpoke');
 			for (const pokemon of this.getAllPokemon()) {
 				const details = pokemon.details.replace(', shiny', '')
-					.replace(/(Arceus|Genesect|Greninja|Gourgeist|Pumpkaboo|Xerneas|Silvally|Urshifu|Dudunsparce)(-[a-zA-Z?-]+)?/g, '$1-*')
-					.replace(/(Zacian|Zamazenta)(?!-Crowned)/g, '$1-*'); // Hacked-in Crowned formes will be revealed
+					.replace(/(Arceus|Genesect|Gourgeist|Pumpkaboo|Xerneas|Silvally|Urshifu|Dudunsparce)(-[a-zA-Z?-]+)?/g, '$1-*')
+					.replace(/(Zacian|Zamazenta)(?!-Crowned)/g, '$1-*') // Hacked-in Crowned formes will be revealed
+					.replace(/(Greninja)(?!-Ash)/g, '$1-*'); // Hacked-in Greninja-Ash will be revealed
 				const item = pokemon.item.includes('mail') ? 'mail' : pokemon.item ? 'item' : '';
 				this.add('poke', pokemon.side.id, details, item);
 			}

--- a/data/mods/gen7/rulesets.ts
+++ b/data/mods/gen7/rulesets.ts
@@ -36,8 +36,9 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 			this.add('clearpoke');
 			for (const pokemon of this.getAllPokemon()) {
 				const details = pokemon.details.replace(', shiny', '')
-					.replace(/(Arceus|Genesect|Greninja|Gourgeist|Pumpkaboo|Xerneas|Silvally|Urshifu|Dudunsparce)(-[a-zA-Z?-]+)?/g, '$1-*')
-					.replace(/(Zacian|Zamazenta)(?!-Crowned)/g, '$1-*'); // Hacked-in Crowned formes will be revealed
+					.replace(/(Arceus|Genesect|Gourgeist|Pumpkaboo|Xerneas|Silvally|Urshifu|Dudunsparce)(-[a-zA-Z?-]+)?/g, '$1-*')
+					.replace(/(Zacian|Zamazenta)(?!-Crowned)/g, '$1-*') // Hacked-in Crowned formes will be revealed
+					.replace(/(Greninja)(?!-Ash)/g, '$1-*'); // Hacked-in Greninja-Ash will be revealed
 				this.add('poke', pokemon.side.id, details, pokemon.item ? 'item' : '');
 			}
 			this.makeRequest('teampreview');


### PR DESCRIPTION
Currently in Gen 7 Hackmons, if a player is using a directly hacked Greninja-Ash, it would not appear at Team Preview. We need to hide the Greninja form in non-hackmons metagames to not leak if the Greninja is Greninja-Bond or not, so I mirrored the way Karthik did it for Zacian/Zamazenta. Not sure if the regex would be better combined or separated like I did it.