### PR TITLE
Fix interaction of As One and Transform

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -260,6 +260,12 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			this.add('-ability', pokemon, 'Unnerve');
 			this.effectState.unnerved = true;
 		},
+		onStart(pokemon) {
+			if (this.effectState.unnerved) return;
+			this.add('-ability', pokemon, 'As One');
+			this.add('-ability', pokemon, 'Unnerve');
+			this.effectState.unnerved = true;
+		},
 		onEnd() {
 			this.effectState.unnerved = false;
 		},
@@ -278,6 +284,12 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	},
 	asonespectrier: {
 		onPreStart(pokemon) {
+			this.add('-ability', pokemon, 'As One');
+			this.add('-ability', pokemon, 'Unnerve');
+			this.effectState.unnerved = true;
+		},
+		onStart(pokemon) {
+			if (this.effectState.unnerved) return;
 			this.add('-ability', pokemon, 'As One');
 			this.add('-ability', pokemon, 'Unnerve');
 			this.effectState.unnerved = true;

--- a/test/sim/abilities/asone.js
+++ b/test/sim/abilities/asone.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const assert = require('./../../assert');
+const common = require('./../../common');
+
+let battle;
+
+describe(`As One`, function () {
+	afterEach(function () {
+		battle.destroy();
+	});
+
+	it(`should work if the user is Transformed`, function () {
+		battle = common.createBattle([[
+			{species: 'ditto', ability: 'imposter', moves: ['transform']},
+		], [
+			{species: 'calyrexshadow', ability: 'asonespectrier', item: 'cheriberry', moves: ['glare', 'sleeptalk', 'astralbarrage']},
+			{species: 'wynaut', moves: ['sleeptalk']},
+		]]);
+
+		const ditto = battle.p1.active[0];
+		const calyrex = battle.p2.active[0];
+		battle.makeChoices('move glare', 'move sleeptalk');
+		assert.equal(calyrex.status, 'par', `Calyrex should not have eaten its Berry, being affected by Ditto-Calyrex's Unnerve`);
+
+		battle.makeChoices('move astralbarrage', 'move sleeptalk');
+		assert.statStage(ditto, 'spa', 1);
+	});
+});


### PR DESCRIPTION
Fixes https://www.smogon.com/forums/threads/transformed-as-one-not-applying-unnerve.3744177/

The issue is that ``onPreStart`` correctly runs before ``onStart``, and Transform correctly only triggers Abilities that happen at ``onStart`` timing, so As One misses the timing. We have a similar implementation for Unnerve itself.