### PR TITLE
Randomized format set updates

### DIFF
--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -2050,6 +2050,10 @@
             {
                 "role": "Generalist",
                 "movepool": ["batonpass", "bodyslam", "healbell", "protect", "wish"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["batonpass", "calmmind", "icebeam", "thunderbolt"]
             }
         ]
     },

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -1874,7 +1874,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["bodyslam", "encore", "shadowball", "teeterdance", "toxic"]
+                "movepool": ["encore", "protect", "seismictoss", "shadowball", "substitute", "toxic"]
             },
             {
                 "role": "Bulky Support",

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -82,8 +82,12 @@
         "level": 86,
         "sets": [
             {
+                "role": "Fast Attacker",
+                "movepool": ["doubleedge", "drillpeck", "quickattack", "return", "uturn"]
+            },
+            {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "drillpeck", "pursuit", "quickattack", "return", "uturn"]
+                "movepool": ["doubleedge", "drillpeck", "pursuit", "return", "uturn"]
             }
         ]
     },
@@ -1680,11 +1684,15 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["healbell", "protect", "return", "thunderwave", "wish"]
+                "movepool": ["doubleedge", "protect", "thunderwave", "toxic", "wish"]
             },
             {
                 "role": "Fast Support",
                 "movepool": ["doubleedge", "fakeout", "healbell", "suckerpunch", "thunderwave", "toxic"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["batonpass", "calmmind", "icebeam", "thunderbolt"]
             }
         ]
     },
@@ -3170,10 +3178,6 @@
     "giratina": {
         "level": 69,
         "sets": [
-            {
-                "role": "Fast Support",
-                "movepool": ["dragonpulse", "rest", "roar", "sleeptalk", "willowisp"]
-            },
             {
                 "role": "Bulky Setup",
                 "movepool": ["calmmind", "dragonpulse", "rest", "sleeptalk"]

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -92,8 +92,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "drillpeck", "drillrun", "pursuit", "quickattack", "return", "uturn"],
-                "preferredTypes": ["Normal"]
+                "movepool": ["doubleedge", "drillpeck", "drillrun", "return", "uturn"]
             },
             {
                 "role": "Fast Attacker",
@@ -907,7 +906,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["airslash", "heatwave", "hypervoice", "roost", "toxic", "whirlwind"]
+                "movepool": ["airslash", "heatwave", "hypervoice", "roost", "toxic", "whirlwind"],
+                "preferredTypes": ["Normal"]
             }
         ]
     },

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -642,14 +642,9 @@
         "level": 87,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["closecombat", "earthquake", "stealthrock", "stoneedge", "xscissor"],
-                "preferredTypes": ["Rock"]
-            },
-            {
                 "role": "Fast Attacker",
-                "movepool": ["closecombat", "earthquake", "quickattack", "stoneedge", "swordsdance", "xscissor"],
-                "preferredTypes": ["Ground"]
+                "movepool": ["closecombat", "earthquake", "stealthrock", "stoneedge", "swordsdance", "xscissor"],
+                "preferredTypes": ["Rock"]
             }
         ]
     },
@@ -2297,7 +2292,7 @@
                 "movepool": ["icebeam", "surf", "thunder", "waterspout"]
             },
             {
-                "role": "Bulky Support",
+                "role": "Bulky Setup",
                 "movepool": ["calmmind", "icebeam", "rest", "sleeptalk", "surf", "thunder"]
             }
         ]
@@ -2787,6 +2782,10 @@
             {
                 "role": "Staller",
                 "movepool": ["icebeam", "protect", "scald", "toxic", "uturn"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["hiddenpowergrass", "icebeam", "scald", "toxic"]
             }
         ]
     },
@@ -3536,7 +3535,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "hiddenpowergrass", "hydropump", "icebeam", "nastyplot", "substitute"],
+                "movepool": ["grassknot", "hydropump", "icebeam", "nastyplot", "substitute"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -4158,7 +4157,7 @@
         "level": 79,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Setup Sweeper",
                 "movepool": ["honeclaws", "ironhead", "rockslide", "superpower", "xscissor"],
                 "preferredTypes": ["Fighting"]
             }
@@ -4344,12 +4343,16 @@
         "level": 77,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Setup Sweeper",
                 "movepool": ["calmmind", "hiddenpowerelectric", "hiddenpowerflying", "hydropump", "icywind", "scald", "secretsword"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["calmmind", "scald", "secretsword", "substitute"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["focusblast", "hydropump", "scald", "secretsword"]
             }
         ]
     },

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -4344,7 +4344,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["calmmind", "hiddenpowerelectric", "hiddenpowerflying", "hydropump", "icywind", "scald", "secretsword"]
+                "movepool": ["calmmind", "hiddenpowerelectric", "hiddenpowerflying", "hiddenpowerice", "hydropump", "scald", "secretsword"]
             },
             {
                 "role": "Bulky Setup",

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -1006,7 +1006,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["airslash", "defog", "hypervoice", "roost", "toxic", "whirlwind"]
+                "movepool": ["airslash", "defog", "hypervoice", "roost", "toxic"]
             }
         ]
     },
@@ -1472,11 +1472,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["earthquake", "knockoff", "rapidspin", "stealthrock", "stoneedge", "toxic"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["earthquake", "gunkshot", "iceshard", "knockoff", "rapidspin", "stoneedge"],
-                "preferredTypes": ["Dark"]
             }
         ]
     },
@@ -2372,7 +2367,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["healbell", "knockoff", "psychic", "recover", "taunt", "toxic"]
+                "movepool": ["healbell", "knockoff", "psychic", "recover", "toxic"]
             },
             {
                 "role": "Bulky Setup",
@@ -2865,7 +2860,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "stealthrock", "suckerpunch", "toxic"]
+                "movepool": ["earthquake", "infestation", "protect", "stealthrock", "toxic"]
             }
         ]
     },
@@ -2874,7 +2869,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["flashcannon", "protect", "stealthrock", "suckerpunch", "toxic"]
+                "movepool": ["flashcannon", "infestation", "protect", "stealthrock", "toxic"]
             }
         ]
     },
@@ -3304,10 +3299,6 @@
     "leafeon": {
         "level": 88,
         "sets": [
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["healbell", "knockoff", "leafblade", "synthesis", "toxic"]
-            },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["doubleedge", "knockoff", "leafblade", "swordsdance", "synthesis", "xscissor"],
@@ -3952,7 +3943,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "hydropump", "icebeam", "nastyplot", "substitute"],
+                "movepool": ["grassknot", "hydropump", "icebeam", "nastyplot", "substitute"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -4601,7 +4592,7 @@
         "level": 79,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Setup Sweeper",
                 "movepool": ["honeclaws", "ironhead", "rockslide", "superpower", "xscissor"],
                 "preferredTypes": ["Fighting"]
             }
@@ -4796,12 +4787,16 @@
         "level": 79,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Setup Sweeper",
                 "movepool": ["calmmind", "hiddenpowerelectric", "hiddenpowerflying", "hydropump", "icywind", "scald", "secretsword"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["calmmind", "hydropump", "scald", "secretsword", "substitute"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["focusblast", "hydropump", "scald", "secretsword"]
             }
         ]
     },
@@ -5236,7 +5231,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["avalanche", "earthquake", "rapidspin", "recover", "roar", "toxic"]
+                "movepool": ["avalanche", "curse", "earthquake", "rapidspin", "recover"]
             }
         ]
     },

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -2689,7 +2689,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "firepunch", "icebeam", "knockoff", "psychoboost", "stealthrock", "superpower"],
+                "movepool": ["extremespeed", "icebeam", "knockoff", "psychoboost", "stealthrock", "superpower"],
                 "preferredTypes": ["Fighting"]
             }
         ]
@@ -2699,7 +2699,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "firepunch", "icebeam", "knockoff", "psychoboost", "superpower"],
+                "movepool": ["extremespeed", "icebeam", "knockoff", "psychoboost", "superpower"],
                 "preferredTypes": ["Fighting"]
             }
         ]

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -5295,7 +5295,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "nastyplot", "psyshock", "shadowball", "trick"]
+                "movepool": ["focusblast", "nastyplot", "psychic", "psyshock", "shadowball", "trick"]
             }
         ]
     },

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -134,8 +134,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "drillpeck", "drillrun", "pursuit", "return", "uturn"],
-                "preferredTypes": ["Normal"]
+                "movepool": ["doubleedge", "drillpeck", "drillrun", "return", "uturn"]
             }
         ]
     },

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -1006,7 +1006,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["airslash", "defog", "hypervoice", "roost", "toxic"]
+                "movepool": ["airslash", "defog", "hypervoice", "roost", "toxic"],
+                "preferredTypes": ["Normal"]
             }
         ]
     },

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -29,8 +29,8 @@ const SETUP = [
 // Moves that shouldn't be the only STAB moves:
 const NO_STAB = [
 	'aquajet', 'bulletpunch', 'clearsmog', 'dragontail', 'eruption', 'explosion', 'fakeout', 'flamecharge',
-	'futuresight', 'iceshard', 'icywind', 'incinerate', 'machpunch', 'nuzzle', 'pluck', 'poweruppunch', 'pursuit',
-	'quickattack', 'rapidspin', 'reversal', 'selfdestruct', 'shadowsneak', 'skyattack', 'skydrop', 'snarl',
+	'futuresight', 'iceshard', 'icywind', 'incinerate', 'infestation', 'machpunch', 'nuzzle', 'pluck', 'poweruppunch',
+	'pursuit', 'quickattack', 'rapidspin', 'reversal', 'selfdestruct', 'shadowsneak', 'skyattack', 'skydrop', 'snarl',
 	'suckerpunch', 'uturn', 'watershuriken', 'vacuumwave', 'voltswitch', 'waterspout',
 ];
 // Hazard-setting moves

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -276,7 +276,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 				if (moves.size + movePool.length <= this.maxMoveCount) return;
 			}
 			if (species.baseSpecies === 'Wormadam' && role === 'Staller') {
-				if (movePool.includes('suckerpunch')) this.fastPop(movePool, movePool.indexOf('suckerpunch'));
+				if (movePool.includes('infestation')) this.fastPop(movePool, movePool.indexOf('infestation'));
 				if (moves.size + movePool.length <= this.maxMoveCount) return;
 			}
 		}

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -3079,7 +3079,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bugbuzz", "gigadrain", "hiddenpowerground", "hiddenpowerrock", "energyball", "quiverdance"],
+                "movepool": ["bugbuzz", "energyball", "gigadrain", "hiddenpowerground", "hiddenpowerrock", "quiverdance"],
                 "preferredType": ["Grass"]
             }
         ]

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -1411,8 +1411,11 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["dazzlinggleam", "hypervoice", "nastyplot", "psychic", "psyshock", "substitute", "thunderbolt"],
-                "preferredTypes": ["Psychic"]
+                "movepool": ["dazzlinggleam", "nastyplot", "psychic", "psyshock", "substitute", "thunderbolt"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["hypervoice", "nastyplot", "psyshock", "thunderbolt"]
             }
         ]
     },
@@ -3079,8 +3082,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bugbuzz", "energyball", "gigadrain", "hiddenpowerground", "hiddenpowerrock", "quiverdance"],
-                "preferredType": ["Grass"]
+                "movepool": ["bugbuzz", "energyball", "gigadrain", "hiddenpowerground", "hiddenpowerrock", "quiverdance"]
             }
         ]
     },

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -1197,7 +1197,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["defog", "hurricane", "hypervoice", "roost", "toxic", "whirlwind"]
+                "movepool": ["defog", "hurricane", "hypervoice", "roost", "toxic"]
             }
         ]
     },
@@ -1659,11 +1659,6 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["earthquake", "knockoff", "rapidspin", "stealthrock", "stoneedge", "toxic"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["earthquake", "gunkshot", "iceshard", "knockoff", "rapidspin", "stoneedge"],
-                "preferredTypes": ["Dark"]
             }
         ]
     },
@@ -2574,7 +2569,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["defog", "healbell", "knockoff", "psychic", "recover", "taunt", "toxic"]
+                "movepool": ["defog", "healbell", "knockoff", "psychic", "recover", "toxic"]
             },
             {
                 "role": "Bulky Setup",
@@ -3084,7 +3079,8 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bugbuzz", "gigadrain", "hiddenpowerground", "hiddenpowerrock", "leafstorm", "quiverdance"]
+                "movepool": ["bugbuzz", "gigadrain", "hiddenpowerground", "hiddenpowerrock", "energyball", "quiverdance"],
+                "preferredType": ["Grass"]
             }
         ]
     },
@@ -3093,7 +3089,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["earthquake", "protect", "stealthrock", "suckerpunch", "toxic"]
+                "movepool": ["earthquake", "infestation", "protect", "stealthrock", "toxic"]
             }
         ]
     },
@@ -3102,7 +3098,7 @@
         "sets": [
             {
                 "role": "Staller",
-                "movepool": ["flashcannon", "protect", "stealthrock", "suckerpunch", "toxic"]
+                "movepool": ["flashcannon", "infestation", "protect", "stealthrock", "toxic"]
             }
         ]
     },
@@ -3552,10 +3548,6 @@
     "leafeon": {
         "level": 88,
         "sets": [
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["healbell", "knockoff", "leafblade", "synthesis", "toxic"]
-            },
             {
                 "role": "Setup Sweeper",
                 "movepool": ["doubleedge", "knockoff", "leafblade", "swordsdance", "synthesis", "xscissor"],
@@ -4245,7 +4237,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "hydropump", "icebeam", "nastyplot", "substitute"],
+                "movepool": ["grassknot", "hydropump", "icebeam", "nastyplot", "substitute"],
                 "preferredTypes": ["Ice"]
             }
         ]
@@ -4918,7 +4910,7 @@
         "level": 81,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Setup Sweeper",
                 "movepool": ["honeclaws", "ironhead", "rockslide", "superpower", "xscissor"],
                 "preferredTypes": ["Fighting"]
             }
@@ -5152,12 +5144,16 @@
         "level": 80,
         "sets": [
             {
-                "role": "Fast Attacker",
+                "role": "Setup Sweeper",
                 "movepool": ["calmmind", "hiddenpowerelectric", "hiddenpowerflying", "hydropump", "icywind", "scald", "secretsword"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["calmmind", "hydropump", "scald", "secretsword", "substitute"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["focusblast", "hydropump", "scald", "secretsword"]
             }
         ]
     },
@@ -5279,8 +5275,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["darkpulse", "fireblast", "hypervoice", "solarbeam", "sunnyday", "willowisp"],
-                "preferredTypes": ["Normal"]
+                "movepool": ["darkpulse", "fireblast", "hypervoice", "solarbeam", "sunnyday", "willowisp"]
             },
             {
                 "role": "Z-Move user",
@@ -5456,8 +5451,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["darkpulse", "glare", "hypervoice", "surf", "thunderbolt", "voltswitch"],
-                "preferredTypes": ["Normal"]
+                "movepool": ["darkpulse", "glare", "hypervoice", "surf", "thunderbolt", "voltswitch"]
             },
             {
                 "role": "Setup Sweeper",
@@ -5613,7 +5607,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["avalanche", "earthquake", "rapidspin", "recover", "roar", "toxic"]
+                "movepool": ["avalanche", "curse", "earthquake", "rapidspin", "recover"]
             }
         ]
     },
@@ -6352,7 +6346,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["defog", "dracometeor", "fireblast", "glare", "hypervoice", "roost"]
+                "movepool": ["dracometeor", "fireblast", "glare", "hypervoice", "roost"]
             }
         ]
     },

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -162,8 +162,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["doubleedge", "drillpeck", "drillrun", "pursuit", "return", "uturn"],
-                "preferredTypes": ["Normal"]
+                "movepool": ["doubleedge", "drillpeck", "drillrun", "return", "uturn"]
             },
             {
                 "role": "Setup Sweeper",

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -5697,7 +5697,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["focusblast", "nastyplot", "psyshock", "shadowball", "trick"]
+                "movepool": ["focusblast", "nastyplot", "psychic", "psyshock", "shadowball", "trick"]
             }
         ]
     },

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -131,7 +131,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				!counter.get('Ice') || (!moves.has('blizzard') && movePool.includes('freezedry')) ||
 				abilities.has('Refrigerate') && (movePool.includes('return') || movePool.includes('hypervoice'))
 			),
-			Normal: movePool => movePool.includes('boomburst'),
+			Normal: movePool => (movePool.includes('boomburst') || movePool.includes('hypervoice')),
 			Poison: (movePool, moves, abilities, types, counter) => !counter.get('Poison'),
 			Psychic: (movePool, moves, abilities, types, counter) => (
 				!counter.get('Psychic') && (
@@ -395,7 +395,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				if (moves.size + movePool.length <= this.maxMoveCount) return;
 			}
 			if (species.baseSpecies === 'Wormadam' && role === 'Staller') {
-				if (movePool.includes('suckerpunch')) this.fastPop(movePool, movePool.indexOf('suckerpunch'));
+				if (movePool.includes('infestation')) this.fastPop(movePool, movePool.indexOf('infestation'));
 				if (moves.size + movePool.length <= this.maxMoveCount) return;
 			}
 		}

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -343,7 +343,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			[['fierydance', 'firelash', 'lavaplume'], ['fireblast', 'magmastorm']],
 			[['flamethrower', 'flareblitz'], ['fireblast', 'overheat']],
 			['hornleech', 'woodhammer'],
-			[['gigadrain', 'leafstorm'], ['leafstorm', 'petaldance', 'powerwhip']],
+			[['gigadrain', 'leafstorm'], ['energyball', 'leafstorm', 'petaldance', 'powerwhip']],
 			['wildcharge', 'thunderbolt'],
 			['gunkshot', 'poisonjab'],
 			[['drainpunch', 'focusblast'], ['closecombat', 'highjumpkick', 'superpower']],

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -62,9 +62,9 @@ const SETUP = [
 // Moves that shouldn't be the only STAB moves:
 const NO_STAB = [
 	'accelerock', 'aquajet', 'bulletpunch', 'clearsmog', 'dragontail', 'eruption', 'explosion',
-	'fakeout', 'firstimpression', 'flamecharge', 'futuresight', 'iceshard', 'icywind', 'incinerate', 'machpunch', 'nuzzle',
-	'pluck', 'poweruppunch', 'pursuit', 'quickattack', 'rapidspin', 'reversal', 'selfdestruct', 'shadowsneak', 'skyattack',
-	'skydrop', 'snarl', 'suckerpunch', 'uturn', 'watershuriken', 'vacuumwave', 'voltswitch', 'waterspout',
+	'fakeout', 'firstimpression', 'flamecharge', 'futuresight', 'iceshard', 'icywind', 'incinerate', 'infestation', 'machpunch',
+	'nuzzle', 'pluck', 'poweruppunch', 'pursuit', 'quickattack', 'rapidspin', 'reversal', 'selfdestruct', 'shadowsneak',
+	'skyattack', 'skydrop', 'snarl', 'suckerpunch', 'uturn', 'watershuriken', 'vacuumwave', 'voltswitch', 'waterspout',
 ];
 // Hazard-setting moves
 const HAZARDS = [

--- a/data/random-battles/gen8/data.json
+++ b/data/random-battles/gen8/data.json
@@ -215,7 +215,7 @@
     },
     "cloyster": {
         "level": 80,
-        "moves": ["explosion", "hydropump", "iciclespear", "rockblast", "shellsmash"],
+        "moves": ["hydropump", "iciclespear", "rockblast", "shellsmash"],
         "doublesLevel": 84,
         "doublesMoves": ["hydropump", "iciclespear", "protect", "rockblast", "shellsmash"],
         "noDynamaxMoves": ["hydropump", "iciclespear", "rockblast", "shellsmash"]
@@ -880,7 +880,7 @@
     },
     "glalie": {
         "level": 94,
-        "moves": ["earthquake", "explosion", "freezedry", "spikes", "superfang", "taunt"],
+        "moves": ["earthquake", "freezedry", "spikes", "superfang", "taunt"],
         "doublesLevel": 94,
         "doublesMoves": ["disable", "foulplay", "freezedry", "helpinghand", "icywind", "protect"]
     },
@@ -1588,7 +1588,7 @@
     },
     "mandibuzz": {
         "level": 82,
-        "moves": ["bravebird", "defog", "foulplay", "roost", "toxic"],
+        "moves": ["bravebird", "defog", "foulplay", "roost", "toxic", "uturn"],
         "doublesLevel": 88,
         "doublesMoves": ["foulplay", "roost", "snarl", "tailwind", "taunt"]
     },

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -2935,7 +2935,7 @@
             {
                 "role": "Tera Blast user",
                 "movepool": ["Glare", "Leaf Storm", "Protect", "Tera Blast"],
-                "teraTypes": ["Stellar"]
+                "teraTypes": ["Fire", "Rock"]
             }
         ]
     },

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -325,7 +325,7 @@
             {
                 "role": "Doubles Wallbreaker",
                 "movepool": ["Fire Punch", "High Horsepower", "Rock Slide", "Stone Edge"],
-                "teraTypes": ["Fire", "Grass"]
+                "teraTypes": ["Grass"]
             }
         ]
     },
@@ -1019,7 +1019,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Helping Hand", "High Horsepower", "Icy Wind", "Liquidation", "Stealth Rock", "Yawn"],
+                "movepool": ["Helping Hand", "High Horsepower", "Icy Wind", "Liquidation", "Recover", "Yawn"],
                 "teraTypes": ["Fire", "Poison", "Steel"]
             }
         ]
@@ -1704,7 +1704,7 @@
         "sets": [
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Helping Hand", "High Horsepower", "Icy Wind", "Muddy Water", "Stealth Rock"],
+                "movepool": ["Helping Hand", "High Horsepower", "Icy Wind", "Muddy Water", "Protect"],
                 "teraTypes": ["Fire", "Steel"]
             }
         ]
@@ -1954,7 +1954,7 @@
         "sets": [
             {
                 "role": "Doubles Support",
-                "movepool": ["Icy Wind", "Knock Off", "Night Shade", "Teleport", "Thunder Wave"],
+                "movepool": ["Icy Wind", "Knock Off", "Night Shade", "Spikes", "Thunder Wave"],
                 "teraTypes": ["Fairy", "Steel"]
             }
         ]

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -250,7 +250,7 @@
             {
                 "role": "Tera Blast user",
                 "movepool": ["Dark Pulse", "Hypnosis", "Nasty Plot", "Tera Blast"],
-                "teraTypes": ["Fairy", "Fire", "Poison"]
+                "teraTypes": ["Fairy", "Poison"]
             }
         ]
     },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -26,11 +26,6 @@
                 "role": "Setup Sweeper",
                 "movepool": ["Dragon Dance", "Earthquake", "Flare Blitz", "Outrage", "Swords Dance"],
                 "teraTypes": ["Dragon", "Ground"]
-            },
-            {
-                "role": "Fast Attacker",
-                "movepool": ["Air Slash", "Fire Blast", "Solar Beam", "Sunny Day"],
-                "teraTypes": ["Fire", "Grass"]
             }
         ]
     },
@@ -138,9 +133,9 @@
                 "teraTypes": ["Poison", "Steel"]
             },
             {
-                "role": "Setup Sweeper",
+                "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Fire Blast", "Moonblast", "Moonlight"],
-                "teraTypes": ["Fire"]
+                "teraTypes": ["Fire", "Steel"]
             }
         ]
     },
@@ -199,7 +194,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Bug Buzz", "Quiver Dance", "Sleep Powder", "Sludge Wave", "Substitute"],
+                "movepool": ["Bug Buzz", "Quiver Dance", "Sleep Powder", "Sludge Wave"],
                 "teraTypes": ["Bug", "Poison", "Steel", "Water"]
             }
         ]
@@ -251,6 +246,11 @@
                 "role": "Fast Bulky Setup",
                 "movepool": ["Dark Pulse", "Hypnosis", "Nasty Plot", "Power Gem", "Thunderbolt"],
                 "teraTypes": ["Dark", "Electric"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Dark Pulse", "Hypnosis", "Nasty Plot", "Tera Blast"],
+                "teraTypes": ["Fairy", "Fire", "Poison"]
             }
         ]
     },
@@ -826,6 +826,11 @@
                 "role": "Fast Bulky Setup",
                 "movepool": ["Calm Mind", "Freezing Glare", "Hurricane", "Recover"],
                 "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Future Sight", "Hurricane", "Recover", "U-turn"],
+                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -914,8 +919,8 @@
             },
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Alluring Voice", "Aura Sphere", "Dark Pulse", "Earth Power", "Fire Blast", "Hydro Pump", "Nasty Plot", "Psychic", "Psyshock"],
-                "teraTypes": ["Dark", "Fairy", "Fighting", "Fire", "Ground", "Psychic", "Water"]
+                "movepool": ["Aura Sphere", "Bug Buzz", "Dark Pulse", "Earth Power", "Fire Blast", "Hydro Pump", "Nasty Plot", "Psychic", "Psyshock"],
+                "teraTypes": ["Dark", "Fighting", "Fire", "Ground", "Psychic", "Water"]
             }
         ]
     },
@@ -963,8 +968,8 @@
         "level": 80,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["Aqua Jet", "Crunch", "Ice Punch", "Liquidation", "Swords Dance"],
+                "role": "Fast Bulky Setup",
+                "movepool": ["Crunch", "Dragon Dance", "Ice Punch", "Liquidation"],
                 "teraTypes": ["Dark", "Dragon", "Steel", "Water"]
             },
             {
@@ -1076,6 +1081,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Head Smash", "Stealth Rock", "Sucker Punch", "Wood Hammer"],
                 "teraTypes": ["Grass", "Rock"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Earthquake", "Head Smash", "Rock Polish", "Wood Hammer"],
+                "teraTypes": ["Grass", "Rock"]
             }
         ]
     },
@@ -1134,7 +1144,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Curse", "Earthquake", "Gunk Shot", "Recover"],
+                "movepool": ["Curse", "Earthquake", "Gunk Shot", "Poison Jab", "Recover"],
                 "teraTypes": ["Flying", "Steel"]
             },
             {
@@ -1268,8 +1278,13 @@
         "level": 86,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Bulky Support",
                 "movepool": ["Destiny Bond", "Gunk Shot", "Spikes", "Taunt", "Thunder Wave", "Toxic Spikes", "Waterfall"],
+                "teraTypes": ["Dark", "Grass"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Flip Turn", "Gunk Shot", "Pain Split", "Thunder Wave", "Toxic", "Toxic Spikes"],
                 "teraTypes": ["Dark", "Grass"]
             }
         ]
@@ -1625,6 +1640,11 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Crunch", "Play Rough", "Poison Fang", "Sucker Punch", "Taunt", "Throat Chop"],
+                "teraTypes": ["Fairy", "Poison"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Crunch", "Play Rough", "Poison Fang", "Sucker Punch", "Super Fang", "Throat Chop"],
                 "teraTypes": ["Fairy", "Poison"]
             }
         ]
@@ -2463,8 +2483,13 @@
         "level": 86,
         "sets": [
             {
-                "role": "Wallbreaker",
+                "role": "Fast Attacker",
                 "movepool": ["Brave Bird", "Heat Wave", "Sucker Punch", "U-turn"],
+                "teraTypes": ["Dark", "Flying"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Brave Bird", "Heat Wave", "Lash Out", "Sucker Punch", "Thunder Wave"],
                 "teraTypes": ["Dark", "Flying"]
             }
         ]
@@ -2608,9 +2633,19 @@
         "level": 85,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["Body Press", "Flash Cannon", "Mirror Coat", "Thunderbolt", "Volt Switch"],
-                "teraTypes": ["Electric", "Flying", "Water"]
+                "role": "Fast Attacker",
+                "movepool": ["Body Press", "Flash Cannon", "Thunderbolt", "Volt Switch"],
+                "teraTypes": ["Electric", "Fighting", "Flying", "Water"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Flash Cannon", "Mirror Coat", "Thunderbolt", "Volt Switch"],
+                "teraTypes": ["Flying", "Water"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Press", "Flash Cannon", "Iron Defense", "Thunderbolt"],
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -2729,7 +2764,7 @@
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["Ice Beam", "Nasty Plot", "Shadow Ball", "Thunderbolt", "Tri Attack"],
+                "movepool": ["Ice Beam", "Nasty Plot", "Shadow Ball", "Thunderbolt", "Tri Attack", "Trick"],
                 "teraTypes": ["Electric", "Ghost"]
             }
         ]
@@ -2864,8 +2899,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Dazzling Gleam", "Energy Ball", "Healing Wish", "Ice Beam", "Nasty Plot", "Psychic", "Thunderbolt", "U-turn"],
-                "teraTypes": ["Electric", "Fairy", "Psychic"]
+                "movepool": ["Dazzling Gleam", "Healing Wish", "Ice Beam", "Nasty Plot", "Psychic", "Shadow Ball", "Thunderbolt", "U-turn"],
+                "teraTypes": ["Electric", "Fairy"]
             },
             {
                 "role": "Bulky Support",
@@ -2899,8 +2934,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Draco Meteor", "Fire Blast", "Heavy Slam", "Stealth Rock", "Thunder Wave", "Thunderbolt"],
-                "teraTypes": ["Dragon", "Fire", "Flying", "Steel"]
+                "movepool": ["Draco Meteor", "Fire Blast", "Heavy Slam", "Stealth Rock", "Thunder Wave"],
+                "teraTypes": ["Dragon", "Flying", "Steel"]
+            },
+            {
+                "role": "AV Pivot",
+                "movepool": ["Draco Meteor", "Dragon Tail", "Fire Blast", "Heavy Slam"],
+                "teraTypes": ["Dragon", "Flying", "Steel"]
             }
         ]
     },
@@ -2909,13 +2949,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Draco Meteor", "Fire Blast", "Flash Cannon", "Stealth Rock", "Thunder Wave"],
-                "teraTypes": ["Dragon", "Fire", "Steel"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["Draco Meteor", "Fire Blast", "Heavy Slam", "Stealth Rock", "Thunder Wave"],
-                "teraTypes": ["Dragon", "Fire", "Steel"]
+                "movepool": ["Draco Meteor", "Fire Blast", "Flash Cannon", "Heavy Slam", "Stealth Rock", "Thunder Wave"],
+                "teraTypes": ["Dragon", "Fire", "Flying", "Steel"]
             }
         ]
     },
@@ -2949,7 +2984,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Earth Power", "Flash Cannon", "Lava Plume", "Magma Storm", "Stealth Rock"],
+                "movepool": ["Earth Power", "Flash Cannon", "Heavy Slam", "Lava Plume", "Magma Storm", "Stealth Rock"],
                 "teraTypes": ["Flying", "Grass", "Steel"]
             }
         ]
@@ -2975,17 +3010,17 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Dragon Tail", "Rest", "Shadow Ball", "Sleep Talk", "Will-O-Wisp"],
-                "teraTypes": ["Fairy", "Ghost"]
+                "teraTypes": ["Fairy"]
             },
             {
                 "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Dragon Pulse", "Rest", "Sleep Talk"],
-                "teraTypes": ["Dragon", "Fairy"]
+                "teraTypes": ["Fairy"]
             },
             {
                 "role": "Bulky Support",
                 "movepool": ["Defog", "Dragon Tail", "Rest", "Shadow Ball", "Will-O-Wisp"],
-                "teraTypes": ["Fairy", "Ghost"]
+                "teraTypes": ["Fairy"]
             }
         ]
     },
@@ -2994,7 +3029,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Defog", "Draco Meteor", "Dragon Tail", "Earthquake", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
+                "movepool": ["Defog", "Draco Meteor", "Dragon Tail", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
                 "teraTypes": ["Dragon", "Fairy", "Ghost", "Steel"]
             }
         ]
@@ -3153,9 +3188,14 @@
         "level": 69,
         "sets": [
             {
-                "role": "Bulky Setup",
+                "role": "Fast Bulky Setup",
                 "movepool": ["Body Press", "Cosmic Power", "Recover", "Stored Power"],
                 "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Body Press", "Iron Defense", "Recover", "Shadow Ball"],
+                "teraTypes": ["Ghost", "Steel"]
             }
         ]
     },
@@ -3319,8 +3359,8 @@
         "sets": [
             {
                 "role": "Tera Blast user",
-                "movepool": ["Glare", "Knock Off", "Leaf Storm", "Leech Seed", "Substitute", "Synthesis", "Tera Blast"],
-                "teraTypes": ["Stellar"]
+                "movepool": ["Glare", "Leaf Storm", "Leech Seed", "Substitute", "Synthesis", "Tera Blast"],
+                "teraTypes": ["Fire", "Rock"]
             },
             {
                 "role": "Fast Attacker",
@@ -3368,8 +3408,13 @@
         "level": 77,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["Ceaseless Edge", "Flip Turn", "Razor Shell", "Sacred Sword", "Sucker Punch", "Swords Dance"],
+                "role": "Setup Sweeper",
+                "movepool": ["Ceaseless Edge", "Razor Shell", "Sucker Punch", "Swords Dance"],
+                "teraTypes": ["Dark", "Water"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Aqua Jet", "Ceaseless Edge", "Flip Turn", "Razor Shell"],
                 "teraTypes": ["Dark", "Water"]
             }
         ]
@@ -3545,11 +3590,6 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Bitter Malice", "Flamethrower", "Focus Blast", "Hyper Voice", "Nasty Plot", "Trick", "U-turn"],
-                "teraTypes": ["Fighting", "Normal"]
-            },
-            {
-                "role": "Fast Attacker",
-                "movepool": ["Focus Blast", "Hyper Voice", "Poltergeist", "Will-O-Wisp"],
                 "teraTypes": ["Fighting", "Normal"]
             }
         ]
@@ -3755,7 +3795,7 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Brave Bird", "Bulk Up", "Close Combat", "Roost"],
-                "teraTypes": ["Fighting", "Flying"]
+                "teraTypes": ["Fighting", "Steel"]
             }
         ]
     },
@@ -3779,12 +3819,12 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Defog", "Foul Play", "Knock Off", "Roost", "Toxic", "U-turn"],
+                "movepool": ["Defog", "Foul Play", "Roost", "Toxic", "U-turn"],
                 "teraTypes": ["Steel"]
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Brave Bird", "Defog", "Knock Off", "Roost", "Toxic"],
+                "movepool": ["Brave Bird", "Defog", "Foul Play", "Knock Off", "Roost", "Toxic"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -3924,7 +3964,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Blue Flare", "Draco Meteor", "Earth Power", "Roar", "Will-O-Wisp"],
+                "movepool": ["Blue Flare", "Draco Meteor", "Dragon Tail", "Earth Power", "Will-O-Wisp"],
                 "teraTypes": ["Fire", "Ground"]
             },
             {
@@ -4189,8 +4229,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Draco Meteor", "Flip Turn", "Focus Blast", "Hydro Pump", "Sludge Wave", "Toxic", "Toxic Spikes"],
-                "teraTypes": ["Water"]
+                "movepool": ["Draco Meteor", "Flip Turn", "Focus Blast", "Sludge Wave", "Toxic", "Toxic Spikes"],
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -4265,7 +4305,7 @@
             {
                 "role": "AV Pivot",
                 "movepool": ["Draco Meteor", "Dragon Tail", "Earthquake", "Fire Blast", "Heavy Slam", "Hydro Pump", "Knock Off", "Thunderbolt"],
-                "teraTypes": ["Electric", "Fire", "Ground", "Water"]
+                "teraTypes": ["Dragon", "Flying", "Ground", "Water"]
             }
         ]
     },
@@ -5104,7 +5144,7 @@
         "sets": [
             {
                 "role": "Tera Blast user",
-                "movepool": ["Bug Buzz", "Giga Drain", "Hurricane", "Ice Beam", "Quiver Dance", "Tera Blast"],
+                "movepool": ["Bug Buzz", "Giga Drain", "Ice Beam", "Quiver Dance", "Tera Blast"],
                 "teraTypes": ["Ground"]
             },
             {
@@ -5453,9 +5493,9 @@
         "level": 79,
         "sets": [
             {
-                "role": "Tera Blast user",
-                "movepool": ["Moonblast", "Play Rough", "Superpower", "Tera Blast"],
-                "teraTypes": ["Stellar"]
+                "role": "Setup Sweeper",
+                "movepool": ["Play Rough", "Substitute", "Superpower", "Taunt", "Zen Headbutt"],
+                "teraTypes": ["Fighting"]
             },
             {
                 "role": "Fast Bulky Setup",
@@ -5604,8 +5644,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Dazzling Gleam", "Earth Power", "Energy Ball", "Hyper Voice", "Strength Sap"],
-                "teraTypes": ["Fairy", "Grass", "Ground"]
+                "movepool": ["Earth Power", "Energy Ball", "Hyper Voice", "Strength Sap"],
+                "teraTypes": ["Grass", "Ground", "Poison"]
             },
             {
                 "role": "Bulky Support",
@@ -5908,9 +5948,9 @@
                 "teraTypes": ["Electric", "Fighting"]
             },
             {
-                "role": "Bulky Support",
-                "movepool": ["Body Press", "Iron Head", "Rest", "Shed Tail", "Spikes", "Stealth Rock"],
-                "teraTypes": ["Electric", "Ghost", "Poison"]
+                "role": "Bulky Attacker",
+                "movepool": ["Body Press", "Heavy Slam", "Rest", "Shed Tail", "Spikes", "Stealth Rock"],
+                "teraTypes": ["Electric", "Fighting", "Ghost", "Poison"]
             }
         ]
     },
@@ -5921,6 +5961,11 @@
                 "role": "Fast Support",
                 "movepool": ["Earth Power", "Mortal Spin", "Power Gem", "Sludge Wave", "Spikes", "Stealth Rock"],
                 "teraTypes": ["Ground"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Earth Power", "Energy Ball", "Meteor Beam", "Sludge Wave"],
+                "teraTypes": ["Grass"]
             }
         ]
     },
@@ -6035,7 +6080,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Boomburst", "Calm Mind", "Earth Power", "Roost"],
-                "teraTypes": ["Ghost"]
+                "teraTypes": ["Fairy", "Ghost"]
             },
             {
                 "role": "Bulky Setup",
@@ -6293,13 +6338,13 @@
         "level": 77,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["Focus Blast", "Make It Rain", "Nasty Plot", "Recover", "Shadow Ball", "Trick"],
-                "teraTypes": ["Ghost", "Steel"]
+                "role": "Bulky Attacker",
+                "movepool": ["Focus Blast", "Make It Rain", "Nasty Plot", "Shadow Ball", "Trick"],
+                "teraTypes": ["Fighting", "Ghost", "Steel"]
             },
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Make It Rain", "Recover", "Shadow Ball", "Thunder Wave"],
+                "role": "Bulky Support",
+                "movepool": ["Make It Rain", "Nasty Plot", "Recover", "Shadow Ball", "Thunder Wave"],
                 "teraTypes": ["Dark", "Steel", "Water"]
             }
         ]
@@ -6601,11 +6646,6 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Calm Mind", "Focus Blast", "Psyshock", "Tachyon Cutter", "Volt Switch"],
                 "teraTypes": ["Fighting", "Steel"]
-            },
-            {
-                "role": "AV Pivot",
-                "movepool": ["Focus Blast", "Future Sight", "Psychic Noise", "Psyshock", "Tachyon Cutter", "Volt Switch"],
-                "teraTypes": ["Steel"]
             }
         ]
     },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -249,7 +249,7 @@
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Dark Pulse", "Hypnosis", "Nasty Plot", "Tera Blast"],
+                "movepool": ["Dark Pulse", "Thunderbolt", "Nasty Plot", "Tera Blast"],
                 "teraTypes": ["Fairy", "Poison"]
             }
         ]
@@ -2950,6 +2950,11 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Draco Meteor", "Fire Blast", "Flash Cannon", "Heavy Slam", "Stealth Rock", "Thunder Wave"],
+                "teraTypes": ["Dragon", "Fire", "Flying", "Steel"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Draco Meteor", "Dragon Tail", "Fire Blast", "Flash Cannon", "Heavy Slam", "Stealth Rock"],
                 "teraTypes": ["Dragon", "Fire", "Flying", "Steel"]
             }
         ]

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -1469,7 +1469,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Close Combat", "Earthquake", "Rapid Spin", "Stone Edge", "Sucker Punch"],
+                "movepool": ["Close Combat", "Earthquake", "Rapid Spin", "Sucker Punch", "Triple Axel"],
                 "teraTypes": ["Steel"]
             },
             {

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -249,7 +249,7 @@
             },
             {
                 "role": "Tera Blast user",
-                "movepool": ["Dark Pulse", "Thunderbolt", "Nasty Plot", "Tera Blast"],
+                "movepool": ["Dark Pulse", "Nasty Plot", "Tera Blast", "Thunderbolt"],
                 "teraTypes": ["Fairy", "Poison"]
             }
         ]

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -3200,7 +3200,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Body Press", "Iron Defense", "Recover", "Shadow Ball"],
-                "teraTypes": ["Ghost", "Steel"]
+                "teraTypes": ["Steel"]
             }
         ]
     },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -1143,13 +1143,8 @@
         "level": 81,
         "sets": [
             {
-                "role": "Bulky Setup",
-                "movepool": ["Curse", "Earthquake", "Gunk Shot", "Poison Jab", "Recover"],
-                "teraTypes": ["Flying", "Steel"]
-            },
-            {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Gunk Shot", "Poison Jab", "Recover", "Stealth Rock", "Toxic", "Toxic Spikes"],
+                "movepool": ["Curse", "Earthquake", "Gunk Shot", "Poison Jab", "Recover", "Stealth Rock", "Toxic", "Toxic Spikes"],
                 "teraTypes": ["Flying", "Steel"]
             }
         ]
@@ -3415,12 +3410,12 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Ceaseless Edge", "Razor Shell", "Sucker Punch", "Swords Dance"],
-                "teraTypes": ["Dark", "Water"]
+                "teraTypes": ["Dark", "Poison", "Water"]
             },
             {
                 "role": "Wallbreaker",
                 "movepool": ["Aqua Jet", "Ceaseless Edge", "Flip Turn", "Razor Shell"],
-                "teraTypes": ["Dark", "Water"]
+                "teraTypes": ["Dark", "Poison", "Water"]
             }
         ]
     },

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1050,7 +1050,6 @@ export class RandomTeams {
 		case 'Intimidate':
 			if (abilities.has('Hustle')) return true;
 			if (abilities.has('Sheer Force') && !!counter.get('sheerforce')) return true;
-			if (species.id === 'hitmontop' && role === 'Bulky Setup') return true;
 			return (abilities.has('Stakeout'));
 		case 'Iron Fist':
 			return !counter.ironFist || moves.has('dynamicpunch');
@@ -1181,6 +1180,7 @@ export class RandomTeams {
 		// singles
 		if (!isDoubles) {
 			if (species.id === 'hypno') return 'Insomnia';
+			if (species.id === 'hitmontop') return (role === 'Bulky Setup') ? 'Technician' : 'Intimidate';
 			if (species.id === 'staraptor') return 'Reckless';
 			if (species.id === 'arcaninehisui') return 'Rock Head';
 			if (['raikou', 'suicune', 'vespiquen'].includes(species.id)) return 'Pressure';

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -117,7 +117,7 @@ const MOVE_PAIRS = [
 
 /** Pokemon who always want priority STAB, and are fine with it as its only STAB move of that type */
 const PRIORITY_POKEMON = [
-	'breloom', 'brutebonnet', 'honchkrow', 'mimikyu', 'ragingbolt', 'scizor',
+	'breloom', 'brutebonnet', 'cacturne', 'honchkrow', 'mimikyu', 'ragingbolt', 'scizor',
 ];
 
 /** Pokemon who should never be in the lead slot */
@@ -129,7 +129,7 @@ const DOUBLES_NO_LEAD_POKEMON = [
 ];
 
 const DEFENSIVE_TERA_BLAST_USERS = [
-	'alcremie', 'bellossom', 'comfey', 'florges',
+	'alcremie', 'bellossom', 'comfey', 'fezandipiti', 'florges', 'persianalola',
 ];
 
 function sereneGraceBenefits(move: Move) {
@@ -182,7 +182,14 @@ export class RandomTeams {
 				movePool.includes('megahorn') || movePool.includes('xscissor') ||
 				(!counter.get('Bug') && types.includes('Electric'))
 			),
-			Dark: (movePool, moves, abilities, types, counter) => !counter.get('Dark'),
+			Dark: (
+				movePool, moves, abilities, types, counter, species, teamDetails, isLead, isDoubles, teraType, role
+			) => {
+				if (
+					counter.get('Dark') < 2 && PRIORITY_POKEMON.includes(species.id) && role === 'Wallbreaker'
+				) return true;
+				return !counter.get('Dark');
+			},
 			Dragon: (movePool, moves, abilities, types, counter) => !counter.get('Dragon'),
 			Electric: (movePool, moves, abilities, types, counter) => !counter.get('Electric'),
 			Fairy: (movePool, moves, abilities, types, counter) => !counter.get('Fairy'),
@@ -553,6 +560,7 @@ export class RandomTeams {
 			['closecombat', 'drainpunch'],
 			['bugbite', 'pounce'],
 			[['dragonpulse', 'spacialrend'], 'dracometeor'],
+			['heavyslam', 'flashcannon'],
 			['alluringvoice', 'dazzlinggleam'],
 
 			// These status moves are redundant with each other
@@ -567,8 +575,6 @@ export class RandomTeams {
 			['switcheroo', 'fakeout'],
 			// Beartic
 			['snowscape', 'swordsdance'],
-			// Magnezone
-			['bodypress', 'mirrorcoat'],
 			// Amoonguss, though this can work well as a general rule later
 			['toxic', 'clearsmog'],
 			// Chansey and Blissey
@@ -1044,7 +1050,7 @@ export class RandomTeams {
 		case 'Intimidate':
 			if (abilities.has('Hustle')) return true;
 			if (abilities.has('Sheer Force') && !!counter.get('sheerforce')) return true;
-			if (species.id === 'hitmontop' && moves.has('tripleaxel')) return true;
+			if (species.id === 'hitmontop' && role === 'Bulky Setup') return true;
 			return (abilities.has('Stakeout'));
 		case 'Iron Fist':
 			return !counter.ironFist || moves.has('dynamicpunch');
@@ -1057,7 +1063,8 @@ export class RandomTeams {
 		case 'Mold Breaker':
 			return (['Sharpness', 'Sheer Force', 'Unburden'].some(m => abilities.has(m)));
 		case 'Moxie':
-			return (!counter.get('Physical') || moves.has('stealthrock'));
+			// AV Pivot part is currently only for Mightyena)
+			return (!counter.get('Physical') || moves.has('stealthrock') || role === 'AV Pivot');
 		case 'Natural Cure':
 			return species.id === 'pawmot';
 		case 'Neutralizing Gas':
@@ -1112,8 +1119,6 @@ export class RandomTeams {
 			const hbraviaryCase = (species.id === 'braviaryhisui' && (role === 'Setup Sweeper' || role === 'Doubles Wallbreaker'));
 			const yanmegaCase = (species.id === 'yanmega' && moves.has('protect'));
 			return (yanmegaCase || hbraviaryCase || species.id === 'illumise');
-		case 'Unaware':
-			return (species.id === 'clefable' && role !== 'Bulky Support');
 		case 'Unburden':
 			return (abilities.has('Prankster') || !counter.get('setup') || species.id === 'sceptile');
 		case 'Vital Spirit':
@@ -1317,8 +1322,7 @@ export class RandomTeams {
 		) return 'Weakness Policy';
 		if (['dragonenergy', 'lastrespects', 'waterspout'].some(m => moves.has(m))) return 'Choice Scarf';
 		if (
-			ability === 'Imposter' ||
-			(species.id === 'magnezone' && moves.has('bodypress') && !isDoubles)
+			ability === 'Imposter' || (species.id === 'magnezone' && role === 'Fast Attacker')
 		) return 'Choice Scarf';
 		if (species.id === 'rampardos' && (role === 'Fast Attacker' || isDoubles)) return 'Choice Scarf';
 		if (species.id === 'palkia' && counter.get('Special') < 4) return 'Lustrous Orb';
@@ -1350,7 +1354,7 @@ export class RandomTeams {
 		if ((ability === 'Guts' || moves.has('facade')) && !moves.has('sleeptalk')) {
 			return (types.includes('Fire') || ability === 'Toxic Boost') ? 'Toxic Orb' : 'Flame Orb';
 		}
-		if (species.id === 'reuniclus' || (ability === 'Sheer Force' && counter.get('sheerforce'))) return 'Life Orb';
+		if (ability === 'Magic Guard' || (ability === 'Sheer Force' && counter.get('sheerforce'))) return 'Life Orb';
 		if (ability === 'Anger Shell') return this.sample(['Rindo Berry', 'Passho Berry', 'Scope Lens', 'Sitrus Berry']);
 		if (moves.has('dragondance') && isDoubles) return 'Clear Amulet';
 		if (counter.get('skilllink') && ability !== 'Skill Link' && species.id !== 'breloom') return 'Loaded Dice';
@@ -1427,6 +1431,7 @@ export class RandomTeams {
 			species.id === 'eternatus' || species.id === 'regigigas'
 		) return 'Leftovers';
 		if (species.id === 'sylveon') return 'Pixie Plate';
+		if (ability === 'Intimidate' && this.dex.getEffectiveness('Rock', species) >= 1) return 'Heavy-Duty Boots';
 		if (
 			(offensiveRole || (role === 'Tera Blast user' && (species.baseStats.spe >= 80 || moves.has('trickroom')))) &&
 			(!moves.has('fakeout') || species.id === 'ambipom') && !moves.has('incinerate') &&
@@ -1518,7 +1523,7 @@ export class RandomTeams {
 				(species.baseStats.hp + species.baseStats.def) > 200 && this.randomChance(1, 2)
 			)
 		) return 'Rocky Helmet';
-		if (moves.has('outrage') && this.randomChance(1, 2)) return 'Lum Berry';
+		if (moves.has('outrage')) return 'Lum Berry';
 		if (moves.has('protect') && ability !== 'Speed Boost') return 'Leftovers';
 		if (
 			role === 'Fast Support' && isLead &&

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -129,7 +129,7 @@ const DOUBLES_NO_LEAD_POKEMON = [
 ];
 
 const DEFENSIVE_TERA_BLAST_USERS = [
-	'alcremie', 'bellossom', 'comfey', 'fezandipiti', 'florges', 'persianalola',
+	'alcremie', 'bellossom', 'comfey', 'fezandipiti', 'florges',
 ];
 
 function sereneGraceBenefits(move: Move) {

--- a/test/random-battles/gen2.js
+++ b/test/random-battles/gen2.js
@@ -66,7 +66,7 @@ describe('[Gen 2] Random Battle (slow)', () => {
 			if (species.unreleasedHidden) abilities.delete(species.abilities.H);
 			for (const set of sets) {
 				const role = set.role;
-				const moves = new Set(set.movepool.map(m => dex.moves.get(m).id));
+				const moves = new Set(set.movepool.map(Array.from(set.movepool)));
 				const preferredTypes = set.preferredTypes;
 				let teamDetails = {};
 				// Go through all possible teamDetails combinations, if necessary
@@ -78,7 +78,7 @@ describe('[Gen 2] Random Battle (slow)', () => {
 						const spikes = Math.floor(i / 2) % 2;
 						teamDetails = {rapidSpin, spikes};
 						// randomMoveset() deletes moves from the movepool, so recreate it every time
-						const movePool = set.movepool.map(m => dex.moves.get(m).id);
+						const movePool = set.movepool.map(Array.from(set.movepool));
 						const moveSet = generator.randomMoveset(types, abilities, teamDetails, species, false, movePool, preferredType, role);
 						for (const move of moveSet) moves.delete(move);
 						if (!moves.size) break;

--- a/test/random-battles/gen2.js
+++ b/test/random-battles/gen2.js
@@ -66,7 +66,7 @@ describe('[Gen 2] Random Battle (slow)', () => {
 			if (species.unreleasedHidden) abilities.delete(species.abilities.H);
 			for (const set of sets) {
 				const role = set.role;
-				const moves = new Set(set.movepool.map(Array.from(set.movepool)));
+				const moves = new Set(Array.from(set.movepool));
 				const preferredTypes = set.preferredTypes;
 				let teamDetails = {};
 				// Go through all possible teamDetails combinations, if necessary
@@ -78,7 +78,7 @@ describe('[Gen 2] Random Battle (slow)', () => {
 						const spikes = Math.floor(i / 2) % 2;
 						teamDetails = {rapidSpin, spikes};
 						// randomMoveset() deletes moves from the movepool, so recreate it every time
-						const movePool = set.movepool.map(Array.from(set.movepool));
+						const movePool = Array.from(set.movepool);
 						const moveSet = generator.randomMoveset(types, abilities, teamDetails, species, false, movePool, preferredType, role);
 						for (const move of moveSet) moves.delete(move);
 						if (!moves.size) break;

--- a/test/random-battles/gen3.js
+++ b/test/random-battles/gen3.js
@@ -67,14 +67,14 @@ describe('[Gen 3] Random Battle (slow)', () => {
 			if (species.unreleasedHidden) abilities.delete(species.abilities.H);
 			for (const set of sets) {
 				const role = set.role;
-				const moves = new Set(set.movepool.map(m => dex.moves.get(m).id));
+				const moves = new Set(set.movepool.map(Array.from(set.movepool)));
 				const preferredTypes = set.preferredTypes;
 				// Go through all possible teamDetails combinations, if necessary
 				for (let j = 0; j < rounds; j++) {
 					// Generate a moveset
 					// randomMoveset() deletes moves from the movepool, so recreate it every time
 					const preferredType = preferredTypes ? preferredTypes.join() : '';
-					const movePool = set.movepool.map(m => dex.moves.get(m).id);
+					const movePool = set.movepool.map(Array.from(set.movepool));
 					const moveSet = generator.randomMoveset(types, abilities, {}, species, false, movePool, preferredType, role);
 					for (const move of moveSet) moves.delete(move);
 					if (!moves.size) break;

--- a/test/random-battles/gen3.js
+++ b/test/random-battles/gen3.js
@@ -67,14 +67,14 @@ describe('[Gen 3] Random Battle (slow)', () => {
 			if (species.unreleasedHidden) abilities.delete(species.abilities.H);
 			for (const set of sets) {
 				const role = set.role;
-				const moves = new Set(set.movepool.map(Array.from(set.movepool)));
+				const moves = new Set(Array.from(set.movepool));
 				const preferredTypes = set.preferredTypes;
 				// Go through all possible teamDetails combinations, if necessary
 				for (let j = 0; j < rounds; j++) {
 					// Generate a moveset
 					// randomMoveset() deletes moves from the movepool, so recreate it every time
 					const preferredType = preferredTypes ? preferredTypes.join() : '';
-					const movePool = set.movepool.map(Array.from(set.movepool));
+					const movePool = Array.from(set.movepool);
 					const moveSet = generator.randomMoveset(types, abilities, {}, species, false, movePool, preferredType, role);
 					for (const move of moveSet) moves.delete(move);
 					if (!moves.size) break;

--- a/test/random-battles/gen4.js
+++ b/test/random-battles/gen4.js
@@ -67,14 +67,14 @@ describe('[Gen 4] Random Battle (slow)', () => {
 			if (species.unreleasedHidden) abilities.delete(species.abilities.H);
 			for (const set of sets) {
 				const role = set.role;
-				const moves = new Set(set.movepool.map(m => dex.moves.get(m).id));
+				const moves = new Set(set.movepool.map(Array.from(set.movepool)));
 				const preferredTypes = set.preferredTypes;
 				let teamDetails = {};
 				// Go through all possible teamDetails combinations, if necessary
 				for (let j = 0; j < rounds; j++) {
 					// Generate a moveset as the lead, teamDetails is always empty for this
 					const preferredType = preferredTypes ? preferredTypes[j % preferredTypes.length] : '';
-					const movePool = set.movepool.map(m => dex.moves.get(m).id);
+					const movePool = set.movepool.map(Array.from(set.movepool));
 					const moveSet = generator.randomMoveset(types, abilities, {}, species, true, movePool, preferredType, role);
 					for (const move of moveSet) moves.delete(move);
 					if (!moves.size) break;
@@ -84,7 +84,7 @@ describe('[Gen 4] Random Battle (slow)', () => {
 						const stealthRock = Math.floor(i / 2) % 2;
 						teamDetails = {rapidSpin, stealthRock};
 						// randomMoveset() deletes moves from the movepool, so recreate it every time
-						const movePool = set.movepool.map(m => dex.moves.get(m).id);
+						const movePool = set.movepool.map(Array.from(set.movepool));
 						const moveSet = generator.randomMoveset(types, abilities, teamDetails, species, false, movePool, preferredType, role);
 						for (const move of moveSet) moves.delete(move);
 						if (!moves.size) break;

--- a/test/random-battles/gen4.js
+++ b/test/random-battles/gen4.js
@@ -67,14 +67,14 @@ describe('[Gen 4] Random Battle (slow)', () => {
 			if (species.unreleasedHidden) abilities.delete(species.abilities.H);
 			for (const set of sets) {
 				const role = set.role;
-				const moves = new Set(set.movepool.map(Array.from(set.movepool)));
+				const moves = new Set(Array.from(set.movepool));
 				const preferredTypes = set.preferredTypes;
 				let teamDetails = {};
 				// Go through all possible teamDetails combinations, if necessary
 				for (let j = 0; j < rounds; j++) {
 					// Generate a moveset as the lead, teamDetails is always empty for this
 					const preferredType = preferredTypes ? preferredTypes[j % preferredTypes.length] : '';
-					const movePool = set.movepool.map(Array.from(set.movepool));
+					const movePool = Array.from(set.movepool);
 					const moveSet = generator.randomMoveset(types, abilities, {}, species, true, movePool, preferredType, role);
 					for (const move of moveSet) moves.delete(move);
 					if (!moves.size) break;
@@ -84,7 +84,7 @@ describe('[Gen 4] Random Battle (slow)', () => {
 						const stealthRock = Math.floor(i / 2) % 2;
 						teamDetails = {rapidSpin, stealthRock};
 						// randomMoveset() deletes moves from the movepool, so recreate it every time
-						const movePool = set.movepool.map(Array.from(set.movepool));
+						const movePool = Array.from(set.movepool);
 						const moveSet = generator.randomMoveset(types, abilities, teamDetails, species, false, movePool, preferredType, role);
 						for (const move of moveSet) moves.delete(move);
 						if (!moves.size) break;

--- a/test/random-battles/gen5.js
+++ b/test/random-battles/gen5.js
@@ -67,14 +67,14 @@ describe('[Gen 5] Random Battle (slow)', () => {
 			if (species.unreleasedHidden) abilities.delete(species.abilities.H);
 			for (const set of sets) {
 				const role = set.role;
-				const moves = new Set(set.movepool.map(Array.from(set.movepool)));
+				const moves = new Set(Array.from(set.movepool));
 				const preferredTypes = set.preferredTypes;
 				let teamDetails = {};
 				// Go through all possible teamDetails combinations, if necessary
 				for (let j = 0; j < rounds; j++) {
 					// Generate a moveset as the lead, teamDetails is always empty for this
 					const preferredType = preferredTypes ? preferredTypes[j % preferredTypes.length] : '';
-					const movePool = set.movepool.map(Array.from(set.movepool));
+					const movePool = Array.from(set.movepool);
 					const moveSet = generator.randomMoveset(types, abilities, {}, species, true, movePool, preferredType, role);
 					for (const move of moveSet) moves.delete(move);
 					if (!moves.size) break;
@@ -84,7 +84,7 @@ describe('[Gen 5] Random Battle (slow)', () => {
 						const stealthRock = Math.floor(i / 2) % 2;
 						teamDetails = {rapidSpin, stealthRock};
 						// randomMoveset() deletes moves from the movepool, so recreate it every time
-						const movePool = set.movepool.map(Array.from(set.movepool));
+						const movePool = Array.from(set.movepool);
 						const moveSet = generator.randomMoveset(types, abilities, teamDetails, species, false, movePool, preferredType, role);
 						for (const move of moveSet) moves.delete(move);
 						if (!moves.size) break;

--- a/test/random-battles/gen5.js
+++ b/test/random-battles/gen5.js
@@ -67,14 +67,14 @@ describe('[Gen 5] Random Battle (slow)', () => {
 			if (species.unreleasedHidden) abilities.delete(species.abilities.H);
 			for (const set of sets) {
 				const role = set.role;
-				const moves = new Set(set.movepool.map(m => dex.moves.get(m).id));
+				const moves = new Set(set.movepool.map(Array.from(set.movepool)));
 				const preferredTypes = set.preferredTypes;
 				let teamDetails = {};
 				// Go through all possible teamDetails combinations, if necessary
 				for (let j = 0; j < rounds; j++) {
 					// Generate a moveset as the lead, teamDetails is always empty for this
 					const preferredType = preferredTypes ? preferredTypes[j % preferredTypes.length] : '';
-					const movePool = set.movepool.map(m => dex.moves.get(m).id);
+					const movePool = set.movepool.map(Array.from(set.movepool));
 					const moveSet = generator.randomMoveset(types, abilities, {}, species, true, movePool, preferredType, role);
 					for (const move of moveSet) moves.delete(move);
 					if (!moves.size) break;
@@ -84,7 +84,7 @@ describe('[Gen 5] Random Battle (slow)', () => {
 						const stealthRock = Math.floor(i / 2) % 2;
 						teamDetails = {rapidSpin, stealthRock};
 						// randomMoveset() deletes moves from the movepool, so recreate it every time
-						const movePool = set.movepool.map(m => dex.moves.get(m).id);
+						const movePool = set.movepool.map(Array.from(set.movepool));
 						const moveSet = generator.randomMoveset(types, abilities, teamDetails, species, false, movePool, preferredType, role);
 						for (const move of moveSet) moves.delete(move);
 						if (!moves.size) break;

--- a/test/random-battles/gen6.js
+++ b/test/random-battles/gen6.js
@@ -67,14 +67,14 @@ describe('[Gen 6] Random Battle (slow)', () => {
 			if (species.unreleasedHidden) abilities.delete(species.abilities.H);
 			for (const set of sets) {
 				const role = set.role;
-				const moves = new Set(set.movepool.map(Array.from(set.movepool)));
+				const moves = new Set(Array.from(set.movepool));
 				const preferredTypes = set.preferredTypes;
 				let teamDetails = {};
 				// Go through all possible teamDetails combinations, if necessary
 				for (let j = 0; j < rounds; j++) {
 					// Generate a moveset as the lead, teamDetails is always empty for this
 					const preferredType = preferredTypes ? preferredTypes[j % preferredTypes.length] : '';
-					const movePool = set.movepool.map(Array.from(set.movepool));
+					const movePool = Array.from(set.movepool);
 					const moveSet = generator.randomMoveset(types, abilities, {}, species, true, movePool, preferredType, role);
 					for (const move of moveSet) moves.delete(move);
 					if (!moves.size) break;
@@ -85,7 +85,7 @@ describe('[Gen 6] Random Battle (slow)', () => {
 						const stickyWeb = Math.floor(i / 4) % 2;
 						teamDetails = {defog, stealthRock, stickyWeb};
 						// randomMoveset() deletes moves from the movepool, so recreate it every time
-						const movePool = set.movepool.map(Array.from(set.movepool));
+						const movePool = Array.from(set.movepool);
 						const moveSet = generator.randomMoveset(types, abilities, teamDetails, species, false, movePool, preferredType, role);
 						for (const move of moveSet) moves.delete(move);
 						if (!moves.size) break;

--- a/test/random-battles/gen6.js
+++ b/test/random-battles/gen6.js
@@ -67,14 +67,14 @@ describe('[Gen 6] Random Battle (slow)', () => {
 			if (species.unreleasedHidden) abilities.delete(species.abilities.H);
 			for (const set of sets) {
 				const role = set.role;
-				const moves = new Set(set.movepool.map(m => dex.moves.get(m).id));
+				const moves = new Set(set.movepool.map(Array.from(set.movepool)));
 				const preferredTypes = set.preferredTypes;
 				let teamDetails = {};
 				// Go through all possible teamDetails combinations, if necessary
 				for (let j = 0; j < rounds; j++) {
 					// Generate a moveset as the lead, teamDetails is always empty for this
 					const preferredType = preferredTypes ? preferredTypes[j % preferredTypes.length] : '';
-					const movePool = set.movepool.map(m => dex.moves.get(m).id);
+					const movePool = set.movepool.map(Array.from(set.movepool));
 					const moveSet = generator.randomMoveset(types, abilities, {}, species, true, movePool, preferredType, role);
 					for (const move of moveSet) moves.delete(move);
 					if (!moves.size) break;
@@ -85,7 +85,7 @@ describe('[Gen 6] Random Battle (slow)', () => {
 						const stickyWeb = Math.floor(i / 4) % 2;
 						teamDetails = {defog, stealthRock, stickyWeb};
 						// randomMoveset() deletes moves from the movepool, so recreate it every time
-						const movePool = set.movepool.map(m => dex.moves.get(m).id);
+						const movePool = set.movepool.map(Array.from(set.movepool));
 						const moveSet = generator.randomMoveset(types, abilities, teamDetails, species, false, movePool, preferredType, role);
 						for (const move of moveSet) moves.delete(move);
 						if (!moves.size) break;

--- a/test/random-battles/gen7.js
+++ b/test/random-battles/gen7.js
@@ -92,7 +92,6 @@ describe('[Gen 7] Random Battle (slow)', () => {
 					}
 					if (!moves.size) break;
 				}
-				if (moves.size) console.log(moves, species);
 				assert(!moves.size, species);
 			}
 		}

--- a/test/random-battles/gen7.js
+++ b/test/random-battles/gen7.js
@@ -67,14 +67,14 @@ describe('[Gen 7] Random Battle (slow)', () => {
 			if (species.unreleasedHidden) abilities.delete(species.abilities.H);
 			for (const set of sets) {
 				const role = set.role;
-				const moves = new Set(set.movepool.map(m => dex.moves.get(m).id));
+				const moves = new Set(Array.from(set.movepool));
 				const preferredTypes = set.preferredTypes;
 				let teamDetails = {};
 				// Go through all possible teamDetails combinations, if necessary
 				for (let j = 0; j < rounds; j++) {
 					// Generate a moveset as the lead, teamDetails is always empty for this
 					const preferredType = preferredTypes ? preferredTypes[j % preferredTypes.length] : '';
-					const movePool = set.movepool.map(m => dex.moves.get(m).id);
+					const movePool = Array.from(set.movepool);
 					const moveSet = generator.randomMoveset(types, abilities, {}, species, true, movePool, preferredType, role);
 					for (const move of moveSet) moves.delete(move);
 					if (!moves.size) break;
@@ -85,7 +85,7 @@ describe('[Gen 7] Random Battle (slow)', () => {
 						const stickyWeb = Math.floor(i / 4) % 2;
 						teamDetails = {defog, stealthRock, stickyWeb};
 						// randomMoveset() deletes moves from the movepool, so recreate it every time
-						const movePool = set.movepool.map(m => dex.moves.get(m).id);
+						const movePool = Array.from(set.movepool);
 						const moveSet = generator.randomMoveset(types, abilities, teamDetails, species, false, movePool, preferredType, role);
 						for (const move of moveSet) moves.delete(move);
 						if (!moves.size) break;


### PR DESCRIPTION
Please have live by end of month, if possible.

**Gen 9 Random Battle:**
Major set changes:
-Contrary Enamorus's role has been changed to Setup Sweeper. It now runs Tera Fighting with Play Rough, Superpower, and any two of Substitute, Zen Headbutt, and Taunt. Leftovers with Substitute, Boots without Substitute.
-Alolan Persian now has an additional set of Tera Blast user. It runs Thunderbolt, Nasty Plot, Dark Pulse, and Tera Blast with Tera Poison/Fairy and a Life Orb.
-Clefable now can have either Unaware or Magic Guard on any of its sets. If it has Unaware, it will have Leftovers. If it has Magic Guard, it will have Life Orb. The Calm Mind set now can get Tera Steel sometimes, instead of just being Tera Fire.
-Gholdengo's sets have been reorganized. It now runs Leftovers instead of Life Orb, and it no longer has Recover + 3 attacks as a possibility.
-Mightyena now has an additional set of AV Pivot with Crunch/Throat Chop, and any 3 of Super Fang, Sucker Punch, Poison Fang, and Play Rough, with Intimidate and Tera Poison/Fairy.
-Qwilfish now has an additional set of Fast Support with Flip Turn, Gunk Shot, Pain Split, and Thunder Wave/Toxic/Toxic Spikes with Heavy-Duty Boots. The other Qwilfish set's role is now Bulky Support, and it can no longer get Focus Sash.
-Magnezone's sets have been split so that Choice Scarf can run Tera Fighting sometimes, and it now has a third set of Bulky Setup with Iron Defense that is always Tera Fighting.
-Glimmora now runs an additional set of Setup Sweeper with Power Herb Meteor Beam with Tera Grass Energy Ball.
-Sudowoodo now runs an additional set of Setup Sweeper with Life Orb Rock Polish.
-Honchkrow now runs an additional set of Wallbreaker with Brave Bird, Lash Out, Sucker Punch, and Thunder Wave or Heat Wave.
-Arceus-Fighting now has an additional set of Iron Defense, Body Press, Recover, and Shadow Ball with Tera Steel.
-Dialga no longer runs Thunderbolt or Tera Fire, and it now runs a second set of AV Pivot with Dragon Tail.
-Dialga-Origin's second set is Dragon Tail instead of Thunder Wave, and both Dialga-Origin sets can roll either steel move.
-Hisuian Samurott no longer runs Sacred Sword or Choice Scarf, and it now has its sets split between Swords Dance Sucker Punch and Choice Band Aqua Jet + Flip Turn.
-Galarian Articuno now has an additional set of Fast Support with Future Sight, U-turn, Recover, and Hurricane with Tera Steel.
-Swords Dance Feraligatr is now Dragon Dance with Crunch and Ice Punch. Sheer Force Trailblaze Dragon Dance still exists alongside this and is still intentional.
-Tera Blast Fezandipiti now runs Leftovers instead of Life Orb.
-Tera Blast Serperior now runs Tera Fire/Rock instead of Tera Stellar.
-Bulky Support Orthworm's role has been changed to Bulky Attacker. It now always has Body Press, runs Heavy Slam instead of Iron Head, and sometimes runs Tera Fighting.
-Clodsire's sets have been merged. Curse can now run Poison Jab and is less common than before.

Reversions:
-Mandibuzz now runs Foul Play more often than Knock Off again.
-Charizard no longer runs its Sunny Day set.
-Iron Crown no longer runs its Assault Vest set.
-Hisuian Zoroark no longer runs its Poltergeist set.
-Lum Berry users now run Lum Berry again all the times they used to, instead of just like, not running Lum half the time. For example, Life Orb DD Flygon is gone.

Minor changes:
-Heavy Slam and Flash Cannon are now incompatible with each other.
--Heatran: +Heavy Slam (it can also now run Assault Vest if the team has a Stealth Rock user)
--Dialga-Origin (both sets); +Tera Flying.
-Nasty Plot Mew: -Alluring Voice, -Tera Fairy, +Bug Buzz
-Reshiram: -Roar, +Dragon Tail
-Fast Attacker Porygon-Z: +Trick
-Giratina-Origin: -Earthquake
-Fast Attacker Mesprit: -Energy Ball, -Tera Psychic, +Shadow Ball
-Seed Sower Arboliva: -Dazzling Gleam, -Tera Fairy, +Tera Poison
-Tera Blast Frosmoth: -Hurricane
-Dragalge: -Hydro Pump, -Tera Water, +Tera Fighting
-Venomoth: -Substitute
-Support Hitmontop: -Stone Edge, +Triple Axel (will not get Technician, still)
-Goodra-Hisui: -Tera Fire, -Tera Electric, +Tera Flying, +Tera Dragon
-Braviary: -Tera Flying, +Tera Steel
-Giratina: -Tera Ghost/Dragon on all sets. Now only Tera Fairy.
-Earth Power Dudunsparce: +Tera Fairy
-Hisuian Samurott: +Tera Poison (both sets)

Gen 9 Doubles:
-Intimidate users that are weak to Rock will now get Heavy-Duty Boots instead of Life Orb or Sitrus Berry.
-Whiscash: -Stealth Rock, +Protect
-Deoxys-Defense: -Teleport, +Spikes
-Quagsire: -Stealth Rock, +Recover
-Golem: -Tera Fire
-Serperior: -Tera Stellar, +Tera Fire, +Tera Rock

Old Gens:
-In Gen 8, Glalie no longer runs Explosion.
-In Gen 8, Cloyster no longer runs Explosion.
-In Gen 8, Mandibuzz now very rarely runs U-turn.
-In Gens 5-7, Simipour now runs Grass Knot instead of whatever other non-Ice Beam coverage it was running.
-In Gens 5-7, Keldeo's Choice item sets are now Hydro Pump, Scald, Secret Sword, and Focus Blast.
-In Gens 5-7, Durant now always runs Hone Claws.
-In Gens 6-7, Avalugg now always runs Earthquake and will run Curse if the team has hazard removal. It no longer runs Toxic or Roar.
-In Gens 6-7, Wormadam-Sandy and Trash now run Infestation instead of Sucker Punch when the team already has Stealth Rock.
-In Gens 6-7, Hoopa (Confined) can now use Psychic.
-In Gens 6-7, Leafeon's Bulky Attacker set no longer exists, and it will always be Swords Dance.
-In Gens 6-7, Noctowl no longer runs Whirlwind.
-In Gens 6-7, Staller Chimecho no longer runs Taunt.
-In Gens 6-7, Bulky Attacker Donphan no longer exists, and it will always run Rapid Spin unless the team has a hazard remover.
-In Gens 6-5, Noctowl now always runs Hyper Voice.
-In Gen 7, Normal-types with Hyper Voice now always run Hyper Voice.
-In Gen 7, Girafarig now has a set that isn't Hyper Voice.
-In Gen 7, Drampa no longer runs Defog.
-In Gen 7, Wormadam now runs Energy Ball instead of Leaf Storm.
-In Gen 6, Deoxys formes no longer run Fire Punch.
-In Gens 5-4, Fearow now always runs U-turn.
-In Gen 5, Lumineon now runs a third set with Hidden Power Grass.
-In Gen 5, Kyogre will now always be either Choice item or Calm Mind.
-In Gen 5, Pinsir's set has been changed to match its Gen 4 set.
-In Gen 5, Keldeo now runs Hidden Power Ice instead of Icy Wind.
-In Gens 4-3, Delcatty now runs an additional set of Baton Pass, Calm Mind, Thunderbolt, and Ice Beam.
-In Gen 4, Delcatty's Bulky Support set now uses Double-Edge instead of Return and Toxic instead of Heal Bell.
-In Gen 4, Giratina no longer runs its non-Calm Mind set.