### PR TITLE
Gen 6 Battle Factory: fix suboptimal Probopass set

### DIFF
--- a/data/random-battles/gen6/factory-sets.json
+++ b/data/random-battles/gen6/factory-sets.json
@@ -9487,7 +9487,7 @@
           "item": "Leftovers",
           "ability": "Sturdy",
           "evs": {"hp": 252, "atk": 0, "def": 4, "spa": 0, "spd": 252, "spe": 0},
-          "nature": "Modest",
+          "nature": "Calm",
           "moves": [["Stealth Rock"], ["Flash Cannon"], ["Volt Switch"], ["Earth Power", "Toxic", "Thunder Wave"]]
         }
       ]


### PR DESCRIPTION
Modest Probopass with no Special Attack EVs and max Special Defense EVs is a suboptimal stat spread; this changes its nature to Calm.