### PR TITLE
Scavenger Hunt Bug fix

### DIFF
--- a/server/room-game.ts
+++ b/server/room-game.ts
@@ -62,6 +62,7 @@ export class RoomGamePlayer<GameClass extends RoomGame = SimpleRoomGame> {
 	 * `this.getUser().games`.
 	 */
 	readonly id: ID;
+	completed: boolean;
 	constructor(user: User | string | null, game: GameClass, num = 0) {
 		this.num = num;
 		if (!user) user = num ? `Player ${num}` : `Player`;
@@ -69,6 +70,7 @@ export class RoomGamePlayer<GameClass extends RoomGame = SimpleRoomGame> {
 		this.name = (typeof user === 'string' ? user : user.name);
 		if (typeof user === 'string') user = null;
 		this.id = user ? user.id : '';
+		this.completed = false;
 		if (user && !this.game.isSubGame) {
 			user.games.add(this.game.roomid);
 			user.updateSearch();

--- a/server/room-game.ts
+++ b/server/room-game.ts
@@ -62,7 +62,7 @@ export class RoomGamePlayer<GameClass extends RoomGame = SimpleRoomGame> {
 	 * `this.getUser().games`.
 	 */
 	readonly id: ID;
-	completed: boolean;
+	completed?: boolean;
 	constructor(user: User | string | null, game: GameClass, num = 0) {
 		this.num = num;
 		if (!user) user = num ? `Player ${num}` : `Player`;
@@ -70,7 +70,6 @@ export class RoomGamePlayer<GameClass extends RoomGame = SimpleRoomGame> {
 		this.name = (typeof user === 'string' ? user : user.name);
 		if (typeof user === 'string') user = null;
 		this.id = user ? user.id : '';
-		this.completed = false;
 		if (user && !this.game.isSubGame) {
 			user.games.add(this.game.roomid);
 			user.updateSearch();

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1396,7 +1396,8 @@ export class GlobalRoomState {
 		for (const room of Rooms.rooms.values()) {
 			const player = room.game && !room.game.ended && room.game.playerTable[user.id];
 			if (!player) continue;
-			if (player.completed) continue; //Prevents players from being re-added to games like Scavengers after they've finished
+			//Prevents players from being re-added to games like Scavengers after they've finished
+			if (player.completed) continue; 
 			user.games.add(room.roomid);
 			player.name = user.name;
 			user.joinRoom(room.roomid);

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1396,8 +1396,8 @@ export class GlobalRoomState {
 		for (const room of Rooms.rooms.values()) {
 			const player = room.game && !room.game.ended && room.game.playerTable[user.id];
 			if (!player) continue;
-			//Prevents players from being re-added to games like Scavengers after they've finished
-			if (player.completed) continue; 
+			// prevents players from being re-added to games like Scavengers after they've finished
+			if (player.completed) continue;
 			user.games.add(room.roomid);
 			player.name = user.name;
 			user.joinRoom(room.roomid);

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1396,8 +1396,8 @@ export class GlobalRoomState {
 		for (const room of Rooms.rooms.values()) {
 			const player = room.game && !room.game.ended && room.game.playerTable[user.id];
 			if (!player) continue;
-			if(room.roomid == "scavengers"){
-				if(player.completed) continue;
+			if (room.roomid === "scavengers") {
+				if (player.completed) continue;
 			}
 			user.games.add(room.roomid);
 			player.name = user.name;

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1396,7 +1396,9 @@ export class GlobalRoomState {
 		for (const room of Rooms.rooms.values()) {
 			const player = room.game && !room.game.ended && room.game.playerTable[user.id];
 			if (!player) continue;
-
+			if(room.roomid == "scavengers"){
+				if(player.completed) continue;
+			}
 			user.games.add(room.roomid);
 			player.name = user.name;
 			user.joinRoom(room.roomid);

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1396,7 +1396,7 @@ export class GlobalRoomState {
 		for (const room of Rooms.rooms.values()) {
 			const player = room.game && !room.game.ended && room.game.playerTable[user.id];
 			if (!player) continue;
-			if (player.completed) continue;
+			if (player.completed) continue; //Prevents players from being re-added to games like Scavengers after they've finished
 			user.games.add(room.roomid);
 			player.name = user.name;
 			user.joinRoom(room.roomid);

--- a/server/rooms.ts
+++ b/server/rooms.ts
@@ -1396,9 +1396,7 @@ export class GlobalRoomState {
 		for (const room of Rooms.rooms.values()) {
 			const player = room.game && !room.game.ended && room.game.playerTable[user.id];
 			if (!player) continue;
-			if (room.roomid === "scavengers") {
-				if (player.completed) continue;
-			}
+			if (player.completed) continue;
 			user.games.add(room.roomid);
 			player.name = user.name;
 			user.joinRoom(room.roomid);


### PR DESCRIPTION
Once a user finished a hunt, upon refresh, they would get the scavenger hunt added back to their games list since they're present in the playerTable. Adding a check during RejoinGames to ignore players who're in scavengers and have completed the current game/hunt.

PS. I'm TheAura on Showdown, a driver in scavengers, for clarity.