### PR TITLE
Baby Random Battle: First set patch

### DIFF
--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -224,8 +224,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Crunch", "Giga Drain", "Growth", "Leaf Storm", "Stomping Tantrum"],
+                "movepool": ["Bullet Seed", "Crunch", "Leaf Storm", "Stomping Tantrum"],
                 "teraTypes": ["Dark", "Ground"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Leaf Storm", "Giga Drain", "Stomping Tantrum", "Super Fang", "Thief"],
+                "teraTypes": ["Poison", "Water"]
             }
         ]
     },

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -2881,11 +2881,6 @@
                 "role": "Wallbreaker",
                 "movepool": ["Aqua Jet", "Ice Beam", "Liquidation", "Stomping Tantrum", "Throat Chop"],
                 "teraTypes": ["Dark", "Ground", "Water"]
-            },
-            {
-                "role": "Fast Support",
-                "movepool": ["Liquidation", "Pain Split", "Substitute", "Throat Chop"],
-                "teraTypes": ["Poison", "Steel"]
             }
         ]
     },

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -2614,7 +2614,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Crunch", "Double-Edge", "Encore", "Low Sweep", "Play Rough", "Thief", "Thunder Wave", "U-turn"],
+                "movepool": ["Crunch", "Double-Edge", "Encore", "Low Sweep", "Switcheroo", "Thunder Wave", "U-turn"],
                 "teraTypes": ["Ghost"]
             }
         ]

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -1544,17 +1544,17 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Close Combat", "Knock Off", "Poison Jab", "Stone Edge", "Swords Dance"],
+                "movepool": ["High Jump Kick", "Knock Off", "Poison Jab", "Stone Edge", "Swords Dance"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["Close Combat", "Fake Out", "Knock Off", "U-turn"],
+                "movepool": ["High Jump Kick", "Fake Out", "Knock Off", "U-turn"],
                 "teraTypes": ["Dark", "Steel"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Knock Off", "Poison Jab", "Stone Edge", "Swords Dance", "U-turn"],
+                "movepool": ["High Jump Kick", "Knock Off", "Poison Jab", "Stone Edge", "Swords Dance", "U-turn"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             }
         ]
@@ -1573,7 +1573,7 @@
         "level": 6,
         "sets": [
             {
-                "role": "Setup Sweeper",
+                "role": "Bulky Setup",
                 "movepool": ["Bullet Seed", "Knock Off", "Tail Slap", "Tidy Up", "Triple Axel"],
                 "teraTypes": ["Grass", "Ice", "Normal"]
             }

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -1645,7 +1645,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Curse", "Earthquake", "Recover", "Stealth Rock", "Stone Edge"],
-                "teraTypes": ["Dragon", "Fairy", "Ghost"]
+                "teraTypes": ["Dragon", "Fairy"]
             }
         ]
     },
@@ -2390,7 +2390,7 @@
             {
                 "role": "Tera Blast user",
                 "movepool": ["Glare", "Knock Off", "Leaf Storm", "Substitute", "Synthesis", "Tera Blast"],
-                "teraTypes": ["Stellar"]
+                "teraTypes": ["Fire", "Rock"]
             }
         ]
     },

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -650,27 +650,30 @@ export class RandomBabyTeams extends RandomTeams {
 		// Get level
 		const level = this.getLevel(species);
 
-		// Prepare optimal HP for Life Orb mons with HP close to the X9 threshold
-		if (item === "Life Orb") {
-			let hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
-			const minimumHP = Math.floor(Math.floor(2 * species.baseStats.hp + 100) * level / 100 + 10);
-			const targetHP = Math.floor(hp / 10) * 10 - 1;
 
-			// Don't subtract more than 3, that's not worth it
-			if (hp - targetHP <= 3 && minimumHP <= targetHP) {
-				// If setting evs to 0 is sufficient, decrement evs, otherwise decrement ivs with evs set to 0
-				if (Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + 100) * level / 100 + 10) >= targetHP) {
-					evs.hp = 0;
+		// Prepare optimal HP for Belly Drum and Life Orb
+		let hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
+		let targetHP = Math.floor(hp / 10) * 10 - 1;
+		const minimumHP = Math.floor(Math.floor(2 * species.baseStats.hp + 100) * level / 100 + 10);
+		if (item === "Life Orb") {
+			targetHP = Math.floor(hp / 10) * 10 - 1;
+		} else if (moves.has("bellydrum")) {
+			targetHP = Math.floor(hp / 2) * 2;
+		}
+		// If the difference is too extreme, don't adjust HP
+		if (hp > targetHP && hp - targetHP <= 3 && targetHP >= minimumHP) {
+			// If setting evs to 0 is sufficient, decrement evs, otherwise decrement ivs with evs set to 0
+			if (Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + 100) * level / 100 + 10) >= targetHP) {
+				evs.hp = 0;
+				hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
+				while (hp > targetHP) {
+					ivs.hp -= 1;
 					hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
-					while (hp > targetHP) {
-						ivs.hp -= 1;
-						hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
-					}
-				} else {
-					while (hp > targetHP) {
-						evs.hp -= 4;
-						hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
-					}
+				}
+			} else {
+				while (hp > targetHP) {
+					evs.hp -= 4;
+					hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
 				}
 			}
 		}

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -441,6 +441,7 @@ export class RandomBabyTeams extends RandomTeams {
 		if (species.id === 'chinchou') return 'Volt Absorb';
 		if (species.id === 'deerling') return 'Serene Grace';
 		if (species.id === 'geodudealola') return 'Galvanize';
+		if (species.id === 'growlithehisui') return 'Rock Head';
 		if (species.id === 'gligar') return 'Immunity';
 		if (species.id === 'minccino') return 'Skill Link';
 		if (species.id === 'rellor') return 'Shed Skin';

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -442,6 +442,7 @@ export class RandomBabyTeams extends RandomTeams {
 		if (species.id === 'deerling') return 'Serene Grace';
 		if (species.id === 'geodudealola') return 'Galvanize';
 		if (species.id === 'gligar') return 'Immunity';
+		if (species.id === 'minccino') return 'Skill Link';
 		if (species.id === 'rellor') return 'Shed Skin';
 		if (species.id === 'riolu') return 'Inner Focus';
 		if (species.id === 'shroomish') return 'Effect Spore';
@@ -531,7 +532,6 @@ export class RandomBabyTeams extends RandomTeams {
 			return this.sample(species.requiredItems);
 		}
 
-		if (species.id === 'minccino') return 'Loaded Dice';
 		if (species.id === 'nymble') return 'Silver Powder';
 
 		if (moves.has('focusenergy')) return 'Scope Lens';

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -156,7 +156,7 @@ export class RandomBabyTeams extends RandomTeams {
 			['rockblast', 'stoneedge'],
 			['bodyslam', 'doubleedge'],
 			['gunkshot', 'poisonjab'],
-			['liquidation', 'surf'],
+			[['hydropump', 'liquidation'], 'surf'],
 		];
 
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);


### PR DESCRIPTION
Removes some undesirable/bugged sets found now that a lot of people are playing. Also slightly refactors the HP ev/iv thing for optimal HP, given that there's now multiple scenarios where that's applicable (belly drum and life orb).