### PR TITLE
Unban Heat Rock in Nat Dex RU

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -2322,7 +2322,7 @@ export const Formats: FormatList = [
 		mod: 'gen9',
 		searchShow: false,
 		ruleset: ['[Gen 9] National Dex UU'],
-		banlist: ['ND UU', 'ND RUBL', 'Slowbro-Base + Slowbronite', 'Heat Rock'],
+		banlist: ['ND UU', 'ND RUBL', 'Slowbro-Base + Slowbronite'],
 	},
 	{
 		name: "[Gen 9] National Dex LC",


### PR DESCRIPTION
Unbanning Heat Rock in Nat Dex RU.

According to this [thread](https://www.smogon.com/forums/threads/national-dex-ru-metagame-discussion.3713801/page-4), its been unbanned for a while, but never updated on main showdown. 

Shown below is recent confirmation from Tier Leader.

![image](https://github.com/smogon/pokemon-showdown/assets/13453363/e37c2f69-343b-41aa-ad09-ccb889a74ac5)
