### PR TITLE
Add min source gen for event-only Pokemon

### DIFF
--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -102,6 +102,10 @@ export class PokemonSources {
 	 */
 	pomegEventEgg?: string | null;
 	/**
+	 * For event-only Pokemon that do not have a minimum source gen identified by its moves
+	 */
+	eventOnlyMinSourceGen?: number;
+	/**
 	 * Some Pokemon evolve by having a move in their learnset (like Piloswine
 	 * with Ancient Power). These can only carry three other moves from their
 	 * prevo, because the fourth move must be the evo move. This restriction
@@ -151,6 +155,7 @@ export class PokemonSources {
 		this.limitedEggMoves = null;
 	}
 	minSourceGen() {
+		if (this.eventOnlyMinSourceGen) return this.eventOnlyMinSourceGen;
 		if (this.sourcesBefore) return this.sourcesAfter || 1;
 		let min = 10;
 		for (const source of this.sources) {
@@ -877,6 +882,7 @@ export class TeamValidator {
 			let legal = false;
 			for (const event of eventData) {
 				if (this.validateEvent(set, setSources, event, eventSpecies)) continue;
+				setSources.eventOnlyMinSourceGen = event.generation;
 				legal = true;
 				break;
 			}

--- a/test/sim/team-validator/events.js
+++ b/test/sim/team-validator/events.js
@@ -150,6 +150,18 @@ describe('Team Validator', function () {
 		assert.false.legalTeam(team, 'gen7anythinggoes');
 	});
 
+	it('should identify the minimum source gen of event-only Pokemon which haven\'t already been identified by its moves', function () {
+		let team = [
+			{species: 'jirachi', ability: 'serenegrace', shiny: true, moves: ['aurasphere'], evs: {hp: 1}, ivs: {hp: 31, atk: 0, def: 31, spa: 31, spd: 31, spe: 31}},
+		];
+		assert.legalTeam(team, 'gen9ou');
+
+		team = [
+			{species: 'jirachi', ability: 'serenegrace', shiny: true, moves: ['hiddenpowerfighting'], nature: 'serious', evs: {hp: 1}, ivs: {hp: 31, atk: 0, def: 31, spa: 31, spd: 31, spe: 31}},
+		];
+		assert.false.legalTeam(team, 'gen7ou');
+	});
+
 	it.skip('should allow evolved Pokemon obtainable from events at lower levels than they could otherwise be obtained', function () {
 		const team = [
 			{species: 'dragonite', ability: 'innerfocus', moves: ['dracometeor'], evs: {hp: 1}, level: 50},


### PR DESCRIPTION
https://www.smogon.com/forums/threads/shiny-jirachi-validation.3733786/ The validator assumes that the Jirachi is from an event that actually does have HP Fighting; while this assumption isn't wrong, what's wrong is that the validator thinks the Jirachi is from Gen 9 due to move sources having to be from Gen 9. This change makes it so that the minimum source gen of an event-only Pokemon is separately identified when needed.

This also causes a different set to be illegal (https://pokepast.es/2a73208c20ed5503 in Gen 7 OU), which from my understanding should be the intended behavior.