### PR TITLE
Baby Random Battle: Set updates and bug fixes

### DIFF
--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -224,8 +224,13 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Crunch", "Giga Drain", "Growth", "Leaf Storm", "Stomping Tantrum"],
+                "movepool": ["Bullet Seed", "Crunch", "Leaf Storm", "Stomping Tantrum"],
                 "teraTypes": ["Dark", "Ground"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Leaf Storm", "Giga Drain", "Stomping Tantrum", "Super Fang", "Thief"],
+                "teraTypes": ["Poison", "Water"]
             }
         ]
     },

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -2881,11 +2881,6 @@
                 "role": "Wallbreaker",
                 "movepool": ["Aqua Jet", "Ice Beam", "Liquidation", "Stomping Tantrum", "Throat Chop"],
                 "teraTypes": ["Dark", "Ground", "Water"]
-            },
-            {
-                "role": "Fast Support",
-                "movepool": ["Liquidation", "Pain Split", "Substitute", "Throat Chop"],
-                "teraTypes": ["Poison", "Steel"]
             }
         ]
     },

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -2614,7 +2614,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Crunch", "Double-Edge", "Encore", "Low Sweep", "Play Rough", "Thief", "Thunder Wave", "U-turn"],
+                "movepool": ["Crunch", "Double-Edge", "Encore", "Low Sweep", "Switcheroo", "Thunder Wave", "U-turn"],
                 "teraTypes": ["Ghost"]
             }
         ]

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -1544,17 +1544,17 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Close Combat", "Knock Off", "Poison Jab", "Stone Edge", "Swords Dance"],
+                "movepool": ["High Jump Kick", "Knock Off", "Poison Jab", "Stone Edge", "Swords Dance"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             },
             {
                 "role": "Fast Support",
-                "movepool": ["Close Combat", "Fake Out", "Knock Off", "U-turn"],
+                "movepool": ["High Jump Kick", "Fake Out", "Knock Off", "U-turn"],
                 "teraTypes": ["Dark", "Steel"]
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Knock Off", "Poison Jab", "Stone Edge", "Swords Dance", "U-turn"],
+                "movepool": ["High Jump Kick", "Knock Off", "Poison Jab", "Stone Edge", "Swords Dance", "U-turn"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             }
         ]
@@ -1573,7 +1573,7 @@
         "level": 6,
         "sets": [
             {
-                "role": "Setup Sweeper",
+                "role": "Bulky Setup",
                 "movepool": ["Bullet Seed", "Knock Off", "Tail Slap", "Tidy Up", "Triple Axel"],
                 "teraTypes": ["Grass", "Ice", "Normal"]
             }

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -104,7 +104,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Sludge Bomb", "Solar Beam", "Sunny Day", "Weather Ball"],
+                "movepool": ["Power Whip", "Sludge Bomb", "Sunny Day", "Weather Ball"],
                 "teraTypes": ["Fire"]
             }
         ]
@@ -504,7 +504,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Belch", "Crunch", "Outrage", "Thunder Wave", "Work Up"],
+                "movepool": ["Crunch", "Outrage", "Roar", "Thunder Wave", "Work Up"],
                 "teraTypes": ["Poison"]
             }
         ]
@@ -644,8 +644,8 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Body Press", "Draco Meteor", "Flash Cannon", "Focus Energy", "Thunderbolt"],
-                "teraTypes": ["Electric", "Fighting"]
+                "movepool": ["Body Press", "Draco Meteor", "Flash Cannon", "Thunderbolt"],
+                "teraTypes": ["Dragon", "Electric", "Fighting", "Steel"]
             },
             {
                 "role": "Bulky Attacker",
@@ -690,7 +690,7 @@
             {
                 "role": "Bulky Setup",
                 "movepool": ["Coil", "Earthquake", "Gunk Shot", "Trailblaze"],
-                "teraTypes": ["Dark", "Ground"]
+                "teraTypes": ["Dark", "Grass", "Ground"]
             }
         ]
     },
@@ -925,7 +925,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Dragon Claw", "Earthquake", "Iron Head", "Outrage", "Stealth Rock", "Stone Edge"],
-                "teraTypes": ["Stellar"]
+                "teraTypes": ["Dragon", "Ground", "Steel"]
             }
         ]
     },
@@ -995,7 +995,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Dazzling Gleam", "Power Gem", "Sludge Wave", "Spikes", "Stealth Rock"],
-                "teraTypes": ["Grass"]
+                "teraTypes": ["Ghost", "Grass"]
             }
         ]
     },
@@ -1063,13 +1063,8 @@
         "level": 6,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Drain Punch", "Grassy Glide", "Knock Off", "Swords Dance", "Wood Hammer"],
-                "teraTypes": ["Dark", "Fighting", "Grass"]
-            },
-            {
                 "role": "Wallbreaker",
-                "movepool": ["Drain Punch", "Grassy Glide", "Knock Off", "U-turn", "Wood Hammer"],
+                "movepool": ["Drain Punch", "Grassy Glide", "Knock Off", "Swords Dance", "U-turn", "Wood Hammer"],
                 "teraTypes": ["Grass"]
             }
         ]
@@ -1114,7 +1109,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Encore", "Fire Punch", "Giga Drain", "Pain Split", "Sludge Bomb", "Thunder Wave", "Toxic", "Toxic Spikes"],
+                "movepool": ["Encore", "Fire Punch", "Giga Drain", "Pain Split", "Sludge Bomb", "Thunder Wave", "Toxic Spikes"],
                 "teraTypes": ["Dark", "Grass"]
             },
             {
@@ -1144,12 +1139,12 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Dazzling Gleam", "Mystical Fire", "Nuzzle", "Psychic"],
+                "movepool": ["Draining Kiss", "Mystical Fire", "Nuzzle", "Psychic"],
                 "teraTypes": ["Electric", "Fairy"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Calm Mind", "Dazzling Gleam", "Draining Kiss", "Mystical Fire", "Psychic"],
+                "movepool": ["Calm Mind", "Draining Kiss", "Mystical Fire", "Psychic"],
                 "teraTypes": ["Fairy", "Steel"]
             }
         ]
@@ -1274,7 +1269,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Bug Buzz", "Giga Drain", "Leech Life", "Lunge", "Thunder", "Thunder Wave", "Volt Switch"],
+                "movepool": ["Giga Drain", "Leech Life", "Thunder", "Thunder Wave", "Volt Switch"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -1434,8 +1429,8 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Bulk Up", "Bullet Punch", "Drain Punch", "Earthquake", "Heavy Slam", "Stone Edge"],
-                "teraTypes": ["Ground", "Steel"]
+                "movepool": ["Bulk Up", "Bullet Punch", "Drain Punch", "Earthquake", "Heavy Slam", "Knock Off", "Stone Edge"],
+                "teraTypes": ["Dark", "Ground", "Steel"]
             }
         ]
     },
@@ -1625,7 +1620,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Body Slam", "Crunch", "Curse", "Earthquake", "Rest", "Sleep Talk"],
-                "teraTypes": ["Fairy", "Ghost", "Ground"]
+                "teraTypes": ["Fairy", "Ground"]
             }
         ]
     },
@@ -1830,7 +1825,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Belly Drum", "Body Slam", "Encore", "Hypnosis", "Waterfall"],
-                "teraTypes": ["Ground", "Normal", "Water"]
+                "teraTypes": ["Dragon", "Normal", "Water"]
             },
             {
                 "role": "Tera Blast user",
@@ -1905,7 +1900,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Brave Bird", "Encore", "Liquidation", "Rapid Spin", "Roost"],
-                "teraTypes": ["Flying", "Steel"]
+                "teraTypes": ["Dragon", "Steel"]
             }
         ]
     },
@@ -1989,7 +1984,7 @@
             }
         ]
     },
-    "rookiedee": {
+    "rookidee": {
         "level": 8,
         "sets": [
             {
@@ -2019,7 +2014,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["Brave Bird", "Bulk Up", "Close Combat", "Hone Claws", "Roost"],
+                "movepool": ["Brave Bird", "Close Combat", "Hone Claws", "Roost"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2129,7 +2124,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Bullet Seed", "Defog", "Foul Play", "Sucker Punch", "Synthesis"],
+                "movepool": ["Body Slam", "Bullet Seed", "Defog", "Sucker Punch", "Synthesis"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]
@@ -2434,7 +2429,7 @@
             }
         ]
     },
-    "snubble": {
+    "snubbull": {
         "level": 7,
         "sets": [
             {
@@ -2671,6 +2666,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Bulk Up", "Defog", "Drain Punch", "Knock Off", "Stone Edge"],
                 "teraTypes": ["Dark", "Steel"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Bulk Up", "Defog", "Drain Punch", "Knock Off", "Mach Punch"],
+                "teraTypes": ["Dark", "Steel"]
             }
         ]
     },
@@ -2703,9 +2703,14 @@
                 "teraTypes": ["Dragon", "Fire", "Rock"]
             },
             {
+                "role": "Wallbreaker",
+                "movepool": ["Flare Blitz", "Overheat", "Protect", "Rock Slide"],
+                "teraTypes": ["Dragon", "Fire", "Rock"]
+            },
+            {
                 "role": "Tera Blast user",
-                "movepool": ["Focus Energy", "Overheat", "Protect", "Tera Blast"],
-                "teraTypes": ["Fighting", "Ground"]
+                "movepool": ["Flare Blitz", "Protect", "Swords Dance", "Tera Blast"],
+                "teraTypes": ["Fighting", "Grass", "Ground"]
             }
         ]
     },

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -1645,7 +1645,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Curse", "Earthquake", "Recover", "Stealth Rock", "Stone Edge"],
-                "teraTypes": ["Dragon", "Fairy", "Ghost"]
+                "teraTypes": ["Dragon", "Fairy"]
             }
         ]
     },
@@ -2390,7 +2390,7 @@
             {
                 "role": "Tera Blast user",
                 "movepool": ["Glare", "Knock Off", "Leaf Storm", "Substitute", "Synthesis", "Tera Blast"],
-                "teraTypes": ["Stellar"]
+                "teraTypes": ["Fire", "Rock"]
             }
         ]
     },

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -650,27 +650,30 @@ export class RandomBabyTeams extends RandomTeams {
 		// Get level
 		const level = this.getLevel(species);
 
-		// Prepare optimal HP for Life Orb mons with HP close to the X9 threshold
-		if (item === "Life Orb") {
-			let hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
-			const minimumHP = Math.floor(Math.floor(2 * species.baseStats.hp + 100) * level / 100 + 10);
-			const targetHP = Math.floor(hp / 10) * 10 - 1;
 
-			// Don't subtract more than 3, that's not worth it
-			if (hp - targetHP <= 3 && minimumHP <= targetHP) {
-				// If setting evs to 0 is sufficient, decrement evs, otherwise decrement ivs with evs set to 0
-				if (Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + 100) * level / 100 + 10) >= targetHP) {
-					evs.hp = 0;
+		// Prepare optimal HP for Belly Drum and Life Orb
+		let hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
+		let targetHP = Math.floor(hp / 10) * 10 - 1;
+		const minimumHP = Math.floor(Math.floor(2 * species.baseStats.hp + 100) * level / 100 + 10);
+		if (item === "Life Orb") {
+			targetHP = Math.floor(hp / 10) * 10 - 1;
+		} else if (moves.has("bellydrum")) {
+			targetHP = Math.floor(hp / 2) * 2;
+		}
+		// If the difference is too extreme, don't adjust HP
+		if (hp > targetHP && hp - targetHP <= 3 && targetHP >= minimumHP) {
+			// If setting evs to 0 is sufficient, decrement evs, otherwise decrement ivs with evs set to 0
+			if (Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + 100) * level / 100 + 10) >= targetHP) {
+				evs.hp = 0;
+				hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
+				while (hp > targetHP) {
+					ivs.hp -= 1;
 					hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
-					while (hp > targetHP) {
-						ivs.hp -= 1;
-						hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
-					}
-				} else {
-					while (hp > targetHP) {
-						evs.hp -= 4;
-						hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
-					}
+				}
+			} else {
+				while (hp > targetHP) {
+					evs.hp -= 4;
+					hp = Math.floor(Math.floor(2 * species.baseStats.hp + ivs.hp + Math.floor(evs.hp / 4) + 100) * level / 100 + 10);
 				}
 			}
 		}

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -441,6 +441,7 @@ export class RandomBabyTeams extends RandomTeams {
 		if (species.id === 'chinchou') return 'Volt Absorb';
 		if (species.id === 'deerling') return 'Serene Grace';
 		if (species.id === 'geodudealola') return 'Galvanize';
+		if (species.id === 'growlithehisui') return 'Rock Head';
 		if (species.id === 'gligar') return 'Immunity';
 		if (species.id === 'minccino') return 'Skill Link';
 		if (species.id === 'rellor') return 'Shed Skin';

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -442,6 +442,7 @@ export class RandomBabyTeams extends RandomTeams {
 		if (species.id === 'deerling') return 'Serene Grace';
 		if (species.id === 'geodudealola') return 'Galvanize';
 		if (species.id === 'gligar') return 'Immunity';
+		if (species.id === 'minccino') return 'Skill Link';
 		if (species.id === 'rellor') return 'Shed Skin';
 		if (species.id === 'riolu') return 'Inner Focus';
 		if (species.id === 'shroomish') return 'Effect Spore';
@@ -531,7 +532,6 @@ export class RandomBabyTeams extends RandomTeams {
 			return this.sample(species.requiredItems);
 		}
 
-		if (species.id === 'minccino') return 'Loaded Dice';
 		if (species.id === 'nymble') return 'Silver Powder';
 
 		if (moves.has('focusenergy')) return 'Scope Lens';

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -156,7 +156,7 @@ export class RandomBabyTeams extends RandomTeams {
 			['rockblast', 'stoneedge'],
 			['bodyslam', 'doubleedge'],
 			['gunkshot', 'poisonjab'],
-			['liquidation', 'surf'],
+			[['hydropump', 'liquidation'], 'surf'],
 		];
 
 		for (const pair of incompatiblePairs) this.incompatibleMoves(moves, movePool, pair[0], pair[1]);

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -55,8 +55,7 @@ export class RandomBabyTeams extends RandomTeams {
 
 		// Overwrite enforcementcheckers where needed here
 		this.moveEnforcementCheckers['Bug'] = (movePool, moves, abilities, types, counter) => (
-			movePool.includes('megahorn') || movePool.includes('xscissor') ||
-			(!counter.get('Bug') && (types.includes('Electric') || types.includes('Water')))
+			!counter.get('Bug')
 		);
 	}
 
@@ -139,7 +138,7 @@ export class RandomBabyTeams extends RandomTeams {
 			[SETUP, PIVOT_MOVES],
 			[SETUP, HAZARDS],
 			[PHYSICAL_SETUP, PHYSICAL_SETUP],
-			[statusMoves, ['healingwish', 'trick', 'destinybond']],
+			[statusMoves, ['destinybond', 'healingwish', 'switcheroo', 'trick']],
 			['curse', 'rapidspin'],
 
 			// These moves are redundant with each other
@@ -148,7 +147,7 @@ export class RandomBabyTeams extends RandomTeams {
 			    ['alluringvoice', 'dazlinggleam', 'drainingkiss', 'moonblast'],
 			],
 			[['bulletseed', 'gigadrain', 'leafstorm', 'seedbomb'], ['bulletseed', 'gigadrain', 'leafstorm', 'seedbomb']],
-			[['thunderwave', 'toxic', 'willowisp'], ['thunderwave', 'toxic', 'willowisp']],
+			[['hypnosis', 'thunderwave', 'toxic', 'willowisp', 'yawn'], ['hypnosis', 'thunderwave', 'toxic', 'willowisp', 'yawn']],
 			['roar', 'yawn'],
 			['dragonclaw', 'outrage'],
 			['dracometeor', 'dragonpulse'],
@@ -448,6 +447,7 @@ export class RandomBabyTeams extends RandomTeams {
 		if (species.id === 'riolu') return 'Inner Focus';
 		if (species.id === 'shroomish') return 'Effect Spore';
 		if (species.id === 'silicobra') return 'Shed Skin';
+		if (species.id === 'tepig') return 'Blaze';
 		if (species.id === 'timburr') return 'Guts';
 		if (species.id === 'tyrogue') return 'Guts';
 
@@ -537,7 +537,7 @@ export class RandomBabyTeams extends RandomTeams {
 
 		if (moves.has('focusenergy')) return 'Scope Lens';
 		if (moves.has('thief')) return '';
-		if (moves.has('trick')) return 'Choice Scarf';
+		if (moves.has('trick') || moves.has('switcheroo')) return 'Choice Scarf';
 
 		if (moves.has('acrobatics')) return ability === 'Unburden' ? 'Oran Berry' : '';
 		if (moves.has('auroraveil') || moves.has('lightscreen') && moves.has('reflect')) return 'Light Clay';
@@ -547,10 +547,7 @@ export class RandomBabyTeams extends RandomTeams {
 		if (ability === 'Quick Feet') return 'Toxic Orb';
 
 		if (this.dex.getEffectiveness('Rock', species) >= 2) return 'Heavy-Duty Boots';
-		if (
-			['Harvest', 'Ripen', 'Unburden'].includes(ability) ||
-			moves.has('belch') || moves.has('bellydrum')
-		) return 'Oran Berry';
+		if (['Harvest', 'Ripen', 'Unburden'].includes(ability) || moves.has('bellydrum')) return 'Oran Berry';
 	}
 
 	getItem(

--- a/test/random-battles/gen9.js
+++ b/test/random-battles/gen9.js
@@ -20,16 +20,18 @@ describe('[Gen 9] Random Battle (slow)', () => {
 		});
 	});
 
-	it('all moves on all sets should be obtainable', function () {
+	it('all moves on all sets should exist and be obtainable', function () {
 		const generator = Teams.getGenerator(options.format);
 		const rounds = 100;
 		for (const pokemon of Object.keys(setsJSON)) {
 			const species = dex.species.get(pokemon);
+			assert(species.exists, `Pokemon ${species} does not exist`);
 			const sets = setsJSON[pokemon]["sets"];
 			const types = species.types;
 			const abilities = new Set(Object.values(species.abilities));
 			if (species.unreleasedHidden) abilities.delete(species.abilities.H);
 			for (const set of sets) {
+				assert(set.movepool.every(m => dex.moves.get(m).exists), `One of ${set.movepool} does not exist.`);
 				const role = set.role;
 				const moves = new Set(set.movepool.map(m => dex.moves.get(m).id));
 				const teraTypes = set.teraTypes;
@@ -78,16 +80,18 @@ describe('[Gen 9] Baby Random Battle (slow)', () => {
 		});
 	});
 
-	it('all moves on all sets should be obtainable', function () {
+	it('all moves on all sets should exist and be obtainable', function () {
 		const generator = Teams.getGenerator(options.format);
 		const rounds = 100;
 		for (const pokemon of Object.keys(setsJSON)) {
 			const species = dex.species.get(pokemon);
+			assert(species.exists, `Pokemon ${species} does not exist`);
 			const sets = setsJSON[pokemon]["sets"];
 			const types = species.types;
 			const abilities = new Set(Object.values(species.abilities));
 			if (species.unreleasedHidden) abilities.delete(species.abilities.H);
 			for (const set of sets) {
+				assert(set.movepool.every(m => dex.moves.get(m).exists), `One of ${set.movepool} does not exist.`);
 				const role = set.role;
 				const moves = new Set(set.movepool.map(m => dex.moves.get(m).id));
 				const teraTypes = set.teraTypes;
@@ -142,16 +146,18 @@ describe('[Gen 9] Random Doubles Battle (slow)', () => {
 		});
 	});
 
-	it('all moves on all sets should be obtainable', function () {
+	it('all moves on all sets should exist and be obtainable', function () {
 		const generator = Teams.getGenerator(options.format);
 		const rounds = 100;
 		for (const pokemon of Object.keys(setsJSON)) {
 			const species = dex.species.get(pokemon);
+			assert(species.exists, `Pokemon ${species} does not exist`);
 			const sets = setsJSON[pokemon]["sets"];
 			const types = species.types;
 			const abilities = new Set(Object.values(species.abilities));
 			if (species.unreleasedHidden) abilities.delete(species.abilities.H);
 			for (const set of sets) {
+				assert(set.movepool.every(m => dex.moves.get(m).exists), `One of ${set.movepool} does not exist.`);
 				const role = set.role;
 				const moves = new Set(set.movepool.map(m => dex.moves.get(m).id));
 				const teraTypes = set.teraTypes;


### PR DESCRIPTION
Has a bunch of simple set changes.
Apart from that, someone noticed that "rookiedee" had a typo because of which it couldn't appear. I've added a check for mon/move names in the gen9 tests to prevent this in the future, and in doing so found that "snubble" was also incorrect.