### PR TITLE
Randomized format set updates

### DIFF
--- a/data/random-battles/gen1/data.json
+++ b/data/random-battles/gen1/data.json
@@ -119,8 +119,7 @@
     },
     "sandslash": {
         "level": 76,
-        "moves": ["bodyslam", "earthquake", "rockslide"],
-        "exclusiveMoves": ["slash", "swordsdance", "swordsdance", "swordsdance"]
+        "moves": ["bodyslam", "earthquake", "rockslide", "swordsdance"]
     },
     "nidoranf": {
         "level": 90,

--- a/data/random-battles/gen2/sets.json
+++ b/data/random-battles/gen2/sets.json
@@ -79,7 +79,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["doubleedge", "drillpeck", "hiddenpowerground", "rest", "sleeptalk", "substitute"]
+                "movepool": ["doubleedge", "drillpeck", "hiddenpowerground", "rest", "sleeptalk"]
             }
         ]
     },
@@ -428,7 +428,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["doubleedge", "drillpeck", "hiddenpowerground", "rest", "sleeptalk", "substitute"]
+                "movepool": ["doubleedge", "drillpeck", "hiddenpowerground", "rest", "sleeptalk"]
             }
         ]
     },

--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -566,6 +566,10 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["doubleedge", "earthquake", "rockslide", "swordsdance"]
+            },
+            {
+                "role": "Generalist",
+                "movepool": ["bonemerang", "doubleedge", "rockslide", "swordsdance"]
             }
         ]
     },

--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -1723,12 +1723,8 @@
                 "movepool": ["calmmind", "rest", "sleeptalk", "surf"]
             },
             {
-                "role": "Staller",
-                "movepool": ["protect", "roar", "substitute", "surf", "toxic"]
-            },
-            {
                 "role": "Bulky Attacker",
-                "movepool": ["calmmind", "icebeam", "rest", "substitute", "surf", "toxic"]
+                "movepool": ["calmmind", "icebeam", "rest", "substitute", "surf"]
             }
         ]
     },

--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -517,7 +517,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["batonpass", "firepunch", "protect", "psychic", "wish"]
+                "movepool": ["firepunch", "protect", "psychic", "toxic", "wish"]
             },
             {
                 "role": "Staller",
@@ -2049,7 +2049,7 @@
             },
             {
                 "role": "Generalist",
-                "movepool": ["batonpass", "bodyslam", "healbell", "protect", "wish"]
+                "movepool": ["bodyslam", "healbell", "protect", "wish"]
             },
             {
                 "role": "Setup Sweeper",

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -1553,8 +1553,12 @@
         "level": 82,
         "sets": [
             {
+                "role": "Fast Attacker",
+                "movepool": ["bravebird", "facade", "protect", "uturn"]
+            },
+            {
                 "role": "Wallbreaker",
-                "movepool": ["bravebird", "facade", "protect", "quickattack", "uturn"]
+                "movepool": ["bravebird", "facade", "quickattack", "uturn"]
             }
         ]
     },

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -1603,8 +1603,12 @@
         "level": 83,
         "sets": [
             {
+                "role": "Fast Attacker",
+                "movepool": ["bravebird", "facade", "protect", "uturn"]
+            },
+            {
                 "role": "Wallbreaker",
-                "movepool": ["bravebird", "facade", "protect", "quickattack", "uturn"]
+                "movepool": ["bravebird", "facade", "quickattack", "uturn"]
             }
         ]
     },
@@ -3169,7 +3173,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hiddenpowerfighting", "moonlight", "psyshock", "substitute"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "moonlight", "psyshock", "signalbeam", "substitute"]
             },
             {
                 "role": "Bulky Support",
@@ -3575,8 +3579,9 @@
         "level": 86,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "superpower"]
+                "role": "Bulky Attacker",
+                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "superpower", "toxic"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -260,7 +260,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bugbuzz", "quiverdance", "sleeppowder", "sludgebomb", "substitute"]
+                "movepool": ["bugbuzz", "quiverdance", "sleeppowder", "sludgebomb"]
             }
         ]
     },
@@ -983,10 +983,6 @@
                 "role": "Setup Sweeper",
                 "movepool": ["crunch", "dragondance", "earthquake", "icepunch", "waterfall"],
                 "preferredTypes": ["Ice"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["aquajet", "crunch", "icepunch", "swordsdance", "waterfall"]
             }
         ]
     },
@@ -1782,7 +1778,11 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["bravebird", "facade", "protect", "quickattack", "uturn"]
+                "movepool": ["bravebird", "facade", "protect", "uturn"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["bravebird", "facade", "quickattack", "uturn"]
             }
         ]
     },
@@ -2018,10 +2018,6 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["encore", "hiddenpowerice", "nuzzle", "thunderbolt", "toxic", "voltswitch"]
             }
         ]
     },
@@ -2036,10 +2032,6 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["grassknot", "hiddenpowerice", "nastyplot", "thunderbolt"]
-            },
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["encore", "hiddenpowerice", "nuzzle", "thunderbolt", "toxic", "voltswitch"]
             }
         ]
     },
@@ -3983,8 +3975,9 @@
         "level": 83,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "superpower"]
+                "role": "Bulky Attacker",
+                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "superpower", "toxic"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -3992,7 +3985,7 @@
         "level": 86,
         "sets": [
             {
-                "role": "Bulky Setup",
+                "role": "Bulky Attacker",
                 "movepool": ["calmmind", "heatwave", "roost", "storedpower"]
             },
             {
@@ -4228,7 +4221,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquajet", "earthquake", "shellsmash", "stoneedge", "waterfall"]
+                "movepool": ["aquajet", "earthquake", "icebeam", "shellsmash", "stoneedge", "waterfall"]
             }
         ]
     },
@@ -4420,7 +4413,7 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["flamethrower", "gigadrain", "hiddenpowerice", "knockoff", "superpower", "thunderbolt", "uturn"]
+                "movepool": ["discharge", "flamethrower", "gigadrain", "hiddenpowerice", "knockoff", "superpower", "uturn"]
             }
         ]
     },
@@ -4792,7 +4785,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hydropump", "scald", "secretsword", "substitute"]
+                "movepool": ["calmmind", "scald", "secretsword", "substitute"]
             },
             {
                 "role": "Fast Attacker",
@@ -4908,7 +4901,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["darkpulse", "fireblast", "hypervoice", "solarbeam", "sunnyday", "willowisp"],
+                "movepool": ["darkpulse", "fireblast", "hypervoice", "solarbeam", "sunnyday", "willowisp", "workup"],
                 "preferredTypes": ["Normal"]
             }
         ]
@@ -5249,7 +5242,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "geomancy", "hiddenpowerfire", "moonblast", "psyshock", "thunder"]
+                "movepool": ["focusblast", "geomancy", "moonblast", "psyshock"]
             }
         ]
     },

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -620,7 +620,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		case 'Torrent':
 			return (!counter.get('Water') || !!species.isMega);
 		case 'Unaware':
-			return (role !== 'Bulky Support' && role !== 'Staller');
+			return (!['Bulky Setup', 'Bulky Support', 'Staller'].includes(role));
 		case 'Unburden':
 			return (!!species.isMega || !counter.get('setup') && !moves.has('acrobatics'));
 		case 'Water Absorb':
@@ -776,9 +776,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 		if ((ability === 'Guts' || moves.has('facade')) && !moves.has('sleeptalk')) {
 			return species.name === 'Conkeldurr' ? 'Flame Orb' : 'Toxic Orb';
 		}
-		if (ability === 'Magic Guard' && role !== 'Bulky Support') {
-			return moves.has('counter') ? 'Focus Sash' : 'Life Orb';
-		}
+		if (ability === 'Magic Guard') return moves.has('counter') ? 'Focus Sash' : 'Life Orb';
 		if (species.id === 'rampardos' && role === 'Fast Attacker') return 'Choice Scarf';
 		if (ability === 'Sheer Force' && counter.get('sheerforce')) return 'Life Orb';
 		if (ability === 'Unburden') return (species.id === 'hitmonlee') ? 'White Herb' : 'Sitrus Berry';

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -293,7 +293,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["auroraveil", "blizzard", "freezedry", "hiddenpowerground", "moonblast", "nastyplot"]
+                "movepool": ["auroraveil", "blizzard", "encore", "freezedry", "hiddenpowerground", "moonblast", "nastyplot"]
             }
         ]
     },

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -330,7 +330,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["bugbuzz", "quiverdance", "sleeppowder", "sludgebomb", "substitute"]
+                "movepool": ["bugbuzz", "quiverdance", "sleeppowder", "sludgebomb"]
             },
             {
                 "role": "Z-Move user",
@@ -1170,10 +1170,6 @@
                 "role": "Setup Sweeper",
                 "movepool": ["crunch", "dragondance", "earthquake", "icepunch", "liquidation"],
                 "preferredTypes": ["Ice"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["aquajet", "crunch", "icepunch", "liquidation", "swordsdance"]
             }
         ]
     },
@@ -4278,8 +4274,9 @@
         "level": 83,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "superpower"]
+                "role": "Bulky Attacker",
+                "movepool": ["earthquake", "explosion", "stealthrock", "stoneedge", "superpower", "toxic"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -4287,7 +4284,7 @@
         "level": 87,
         "sets": [
             {
-                "role": "Bulky Setup",
+                "role": "Bulky Attacker",
                 "movepool": ["calmmind", "heatwave", "roost", "storedpower"]
             },
             {
@@ -4528,7 +4525,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["aquajet", "earthquake", "liquidation", "shellsmash", "stoneedge"]
+                "movepool": ["aquajet", "earthquake", "icebeam", "liquidation", "shellsmash", "stoneedge"]
             }
         ]
     },
@@ -4730,7 +4727,7 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["flamethrower", "gigadrain", "hiddenpowerice", "knockoff", "superpower", "thunderbolt", "uturn"]
+                "movepool": ["discharge", "flamethrower", "gigadrain", "hiddenpowerice", "knockoff", "superpower", "uturn"]
             }
         ]
     },
@@ -5150,7 +5147,7 @@
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hydropump", "scald", "secretsword", "substitute"]
+                "movepool": ["calmmind", "scald", "secretsword", "substitute"]
             },
             {
                 "role": "Fast Attacker",
@@ -5276,7 +5273,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["darkpulse", "fireblast", "hypervoice", "solarbeam", "sunnyday", "willowisp"]
+                "movepool": ["darkpulse", "fireblast", "hypervoice", "solarbeam", "sunnyday", "willowisp", "workup"]
             },
             {
                 "role": "Z-Move user",
@@ -5630,7 +5627,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["focusblast", "geomancy", "hiddenpowerfire", "moonblast", "psyshock", "thunder"]
+                "movepool": ["focusblast", "geomancy", "moonblast", "psyshock"]
             }
         ]
     },

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -516,8 +516,8 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				movePool, preferredType, role);
 		}
 
-		// Enforce Blizzard, Seismic Toss, Spore, and Sticky Web
-		for (const moveid of ['blizzard', 'seismictoss', 'spore', 'stickyweb']) {
+		// Enforce Aurora Veil, Blizzard, Seismic Toss, Spore, and Sticky Web
+		for (const moveid of ['auroraveil', 'blizzard', 'seismictoss', 'spore', 'stickyweb']) {
 			if (movePool.includes(moveid)) {
 				counter = this.addMove(moveid, moves, types, abilities, teamDetails, species, isLead,
 					movePool, preferredType, role);

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -829,7 +829,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		case 'Torrent':
 			return (!counter.get('Water') || !!species.isMega);
 		case 'Unaware':
-			return (role !== 'Bulky Support' && role !== 'Staller');
+			return (!['Bulky Setup', 'Bulky Support', 'Staller'].includes(role));
 		case 'Unburden':
 			return (!!species.isMega || !counter.get('setup') && !moves.has('acrobatics'));
 		case 'Water Absorb':
@@ -1023,9 +1023,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 		if ((ability === 'Guts' || moves.has('facade')) && !moves.has('sleeptalk')) {
 			return (types.includes('Fire') || ability === 'Quick Feet' || ability === 'Toxic Boost') ? 'Toxic Orb' : 'Flame Orb';
 		}
-		if (ability === 'Magic Guard' && role !== 'Bulky Support') {
-			return moves.has('counter') ? 'Focus Sash' : 'Life Orb';
-		}
+		if (ability === 'Magic Guard') return moves.has('counter') ? 'Focus Sash' : 'Life Orb';
 		if (species.id === 'rampardos' && role === 'Fast Attacker') return 'Choice Scarf';
 		if (ability === 'Sheer Force' && counter.get('sheerforce')) return 'Life Orb';
 		if (ability === 'Unburden') return moves.has('closecombat') ? 'White Herb' : 'Sitrus Berry';

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -2358,9 +2358,9 @@
                 "teraTypes": ["Ghost", "Ice"]
             },
             {
-                "role": "Tera Blast user",
-                "movepool": ["Blizzard", "Calm Mind", "Freeze-Dry", "Tera Blast"],
-                "teraTypes": ["Fire", "Ground"]
+                "role": "Doubles Wallbreaker",
+                "movepool": ["Blizzard", "Calm Mind", "Freeze-Dry", "Mud Shot"],
+                "teraTypes": ["Ground"]
             }
         ]
     },

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -1338,7 +1338,7 @@
                 "teraTypes": ["Dragon", "Grass"]
             },
             {
-                "role": "Doubles Support",
+                "role": "Bulky Protect",
                 "movepool": ["Calm Mind", "Ice Beam", "Protect", "Scald"],
                 "teraTypes": ["Dragon", "Grass"]
             }

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -1096,6 +1096,11 @@
                 "role": "Choice Item user",
                 "movepool": ["Body Press", "Explosion", "Iron Head", "Lunge"],
                 "teraTypes": ["Fighting", "Fire"]
+            },
+            {
+                "role": "Doubles Bulky Setup",
+                "movepool": ["Body Press", "Iron Defense", "Iron Head", "Rest", "Thunder Wave"],
+                "teraTypes": ["Fighting", "Fire"]
             }
         ]
     },
@@ -5444,7 +5449,7 @@
             },
             {
                 "role": "Doubles Bulky Attacker",
-                "movepool": ["Body Press", "Helping Hand", "Iron Head", "Protect", "Shed Tail", "Stealth Rock"],
+                "movepool": ["Body Press", "Heavy Slam", "Helping Hand", "Protect", "Shed Tail"],
                 "teraTypes": ["Electric", "Poison"]
             }
         ]

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -574,8 +574,8 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["Draco Meteor", "Flamethrower", "Giga Drain", "Knock Off"],
-                "teraTypes": ["Fire", "Steel"]
+                "movepool": ["Draco Meteor", "Dragon Tail", "Flamethrower", "Giga Drain", "Knock Off"],
+                "teraTypes": ["Fire"]
             }
         ]
     },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -4316,11 +4316,6 @@
                 "role": "AV Pivot",
                 "movepool": ["Draco Meteor", "Dragon Tail", "Earthquake", "Fire Blast", "Heavy Slam", "Hydro Pump", "Knock Off", "Thunderbolt"],
                 "teraTypes": ["Dragon", "Flying", "Ground", "Water"]
-            },
-            {
-                "role": "Bulky Setup",
-                "movepool": ["Curse", "Iron Head", "Rest", "Sleep Talk"],
-                "teraTypes": ["Flying"]
             }
         ]
     },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -449,7 +449,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Drain Punch", "Gunk Shot", "Haze", "Ice Punch", "Knock Off", "Poison Jab", "Shadow Sneak", "Toxic", "Toxic Spikes"],
+                "movepool": ["Drain Punch", "Gunk Shot", "Haze", "Ice Punch", "Knock Off", "Poison Jab", "Shadow Sneak", "Toxic Spikes"],
                 "teraTypes": ["Dark"]
             },
             {
@@ -661,6 +661,11 @@
                 "role": "Fast Attacker",
                 "movepool": ["Body Slam", "Close Combat", "Earthquake", "Throat Chop"],
                 "teraTypes": ["Fighting", "Ground", "Normal"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Body Slam", "Close Combat", "Throat Chop", "Zen Headbutt"],
+                "teraTypes": ["Fighting", "Normal", "Psychic"]
             }
         ]
     },
@@ -1081,11 +1086,6 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Earthquake", "Head Smash", "Stealth Rock", "Sucker Punch", "Wood Hammer"],
                 "teraTypes": ["Grass", "Rock"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["Earthquake", "Head Smash", "Rock Polish", "Wood Hammer"],
-                "teraTypes": ["Grass", "Rock"]
             }
         ]
     },
@@ -1403,8 +1403,8 @@
         "level": 86,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["Dark Pulse", "Fire Blast", "Nasty Plot", "Sludge Bomb", "Sucker Punch"],
+                "role": "Setup Sweeper",
+                "movepool": ["Dark Pulse", "Fire Blast", "Nasty Plot", "Sludge Bomb", "Sucker Punch", "Will-O-Wisp"],
                 "teraTypes": ["Dark", "Fire", "Poison"]
             }
         ]
@@ -1469,7 +1469,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Close Combat", "Earthquake", "Rapid Spin", "Sucker Punch", "Triple Axel"],
+                "movepool": ["Close Combat", "Earthquake", "Rapid Spin", "Stone Edge", "Sucker Punch"],
                 "teraTypes": ["Steel"]
             },
             {
@@ -2718,9 +2718,14 @@
         "level": 94,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["Calm Mind", "Freeze-Dry", "Protect", "Wish", "Yawn"],
+                "role": "Bulky Setup",
+                "movepool": ["Calm Mind", "Freeze-Dry", "Protect", "Wish"],
                 "teraTypes": ["Water"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Freeze-Dry", "Mud Shot", "Protect", "Wish"],
+                "teraTypes": ["Ground"]
             }
         ]
     },
@@ -2806,6 +2811,11 @@
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Pain Split", "Poltergeist", "Shadow Sneak", "Will-O-Wisp"],
                 "teraTypes": ["Dark", "Fairy"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Focus Punch", "Pain Split", "Poltergeist", "Substitute"],
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -3466,11 +3476,6 @@
                 "role": "Fast Support",
                 "movepool": ["Knock Off", "Leaf Blade", "Lunge", "Sticky Web", "Swords Dance"],
                 "teraTypes": ["Ghost", "Rock"]
-            },
-            {
-                "role": "Setup Sweeper",
-                "movepool": ["Knock Off", "Leaf Blade", "Lunge", "Swords Dance", "Triple Axel"],
-                "teraTypes": ["Dark", "Rock"]
             }
         ]
     },
@@ -3809,7 +3814,12 @@
             },
             {
                 "role": "Wallbreaker",
-                "movepool": ["Calm Mind", "Defog", "Esper Wing", "Heat Wave", "Hurricane", "U-turn"],
+                "movepool": ["Esper Wing", "Hurricane", "U-turn", "Vacuum Wave"],
+                "teraTypes": ["Fairy", "Fighting", "Psychic", "Steel"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Calm Mind", "Defog", "Esper Wing", "Hurricane", "Roost"],
                 "teraTypes": ["Fairy", "Psychic", "Steel"]
             }
         ]
@@ -3980,7 +3990,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Bolt Strike", "Dragon Dance", "Outrage", "Substitute"],
-                "teraTypes": ["Electric"]
+                "teraTypes": ["Electric", "Steel"]
             }
         ]
     },
@@ -4306,6 +4316,11 @@
                 "role": "AV Pivot",
                 "movepool": ["Draco Meteor", "Dragon Tail", "Earthquake", "Fire Blast", "Heavy Slam", "Hydro Pump", "Knock Off", "Thunderbolt"],
                 "teraTypes": ["Dragon", "Flying", "Ground", "Water"]
+            },
+            {
+                "role": "Bulky Setup",
+                "movepool": ["Curse", "Iron Head", "Rest", "Sleep Talk"],
+                "teraTypes": ["Flying"]
             }
         ]
     },
@@ -4666,6 +4681,11 @@
                 "role": "Fast Support",
                 "movepool": ["Flamethrower", "Protect", "Substitute", "Toxic"],
                 "teraTypes": ["Flying", "Grass"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Dragon Pulse", "Fire Blast", "Nasty Plot", "Sludge Wave"],
+                "teraTypes": ["Dragon", "Fire", "Poison"]
             }
         ]
     },
@@ -5540,7 +5560,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Hex", "Slack Off", "Torch Song", "Will-O-Wisp"],
-                "teraTypes": ["Fairy", "Ghost", "Water"]
+                "teraTypes": ["Fairy", "Water"]
             }
         ]
     },
@@ -6124,8 +6144,18 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Close Combat", "Crunch", "Seed Bomb", "Spore", "Sucker Punch"],
-                "teraTypes": ["Dark", "Fighting"]
+                "movepool": ["Close Combat", "Seed Bomb", "Spore", "Sucker Punch"],
+                "teraTypes": ["Fighting", "Poison"]
+            },
+            {
+                "role": "Bulky Support",
+                "movepool": ["Crunch", "Seed Bomb", "Spore", "Sucker Punch"],
+                "teraTypes": ["Dark", "Poison"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Close Combat", "Crunch", "Seed Bomb", "Sucker Punch"],
+                "teraTypes": ["Dark", "Fighting", "Poison"]
             }
         ]
     },
@@ -6409,7 +6439,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Collision Course", "Flare Blitz", "Outrage", "U-turn"],
+                "movepool": ["Close Combat", "Flare Blitz", "Outrage", "U-turn"],
                 "teraTypes": ["Fire"]
             },
             {

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -161,11 +161,6 @@
                 "role": "Fast Bulky Setup",
                 "movepool": ["Aurora Veil", "Blizzard", "Moonblast", "Nasty Plot"],
                 "teraTypes": ["Steel", "Water"]
-            },
-            {
-                "role": "Tera Blast user",
-                "movepool": ["Blizzard", "Moonblast", "Nasty Plot", "Tera Blast"],
-                "teraTypes": ["Ground"]
             }
         ]
     },
@@ -4678,9 +4673,9 @@
                 "teraTypes": ["Flying", "Grass"]
             },
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Dragon Pulse", "Fire Blast", "Nasty Plot", "Sludge Wave"],
-                "teraTypes": ["Dragon", "Fire", "Poison"]
+                "role": "Tera Blast user",
+                "movepool": ["Fire Blast", "Nasty Plot", "Sludge Wave", "Tera Blast"],
+                "teraTypes": ["Grass"]
             }
         ]
     },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -153,13 +153,18 @@
         "level": 79,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Bulky Support",
                 "movepool": ["Aurora Veil", "Blizzard", "Encore", "Moonblast"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Aurora Veil", "Blizzard", "Moonblast", "Nasty Plot"],
+                "teraTypes": ["Steel", "Water"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Aurora Veil", "Blizzard", "Freeze-Dry", "Moonblast"],
                 "teraTypes": ["Steel", "Water"]
             }
         ]

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -76,7 +76,7 @@ const PHYSICAL_SETUP = [
 ];
 // Moves which boost Special Attack:
 const SPECIAL_SETUP = [
-	'calmmind', 'chargebeam', 'geomancy', 'nastyplot', 'quiverdance', 'tailglow', 'torchsong',
+	'calmmind', 'chargebeam', 'geomancy', 'nastyplot', 'quiverdance', 'tailglow', 'takeheart', 'torchsong',
 ];
 // Moves that boost Attack AND Special Attack:
 const MIXED_SETUP = [
@@ -88,16 +88,16 @@ const SPEED_SETUP = [
 ];
 // Conglomerate for ease of access
 const SETUP = [
-	'acidarmor', 'agility', 'autotomize', 'bellydrum', 'bulkup', 'calmmind', 'clangoroussoul', 'coil', 'cosmicpower', 'curse',
-	'dragondance', 'flamecharge', 'growth', 'honeclaws', 'howl', 'irondefense', 'meditate', 'nastyplot', 'noretreat', 'poweruppunch',
-	'quiverdance', 'rockpolish', 'shellsmash', 'shiftgear', 'swordsdance', 'tailglow', 'tidyup', 'trailblaze', 'workup', 'victorydance',
+	'acidarmor', 'agility', 'autotomize', 'bellydrum', 'bulkup', 'calmmind', 'clangoroussoul', 'coil', 'cosmicpower', 'curse', 'dragondance',
+	'flamecharge', 'growth', 'honeclaws', 'howl', 'irondefense', 'meditate', 'nastyplot', 'noretreat', 'poweruppunch', 'quiverdance',
+	'rockpolish', 'shellsmash', 'shiftgear', 'swordsdance', 'tailglow', 'takeheart', 'tidyup', 'trailblaze', 'workup', 'victorydance',
 ];
 const SPEED_CONTROL = [
 	'electroweb', 'glare', 'icywind', 'lowsweep', 'quash', 'stringshot', 'tailwind', 'thunderwave', 'trickroom',
 ];
 // Moves that shouldn't be the only STAB moves:
 const NO_STAB = [
-	'accelerock', 'aquajet', 'bounce', 'breakingswipe', 'bulletpunch', 'chatter', 'chloroblast', 'clearsmog', 'covet',
+	'accelerock', 'aquajet', 'bounce', 'breakingswipe', 'bulletpunch', 'chatter', 'chloroblast', 'circlethrow', 'clearsmog', 'covet',
 	'dragontail', 'doomdesire', 'electroweb', 'eruption', 'explosion', 'fakeout', 'feint', 'flamecharge', 'flipturn', 'futuresight',
 	'grassyglide', 'iceshard', 'icywind', 'incinerate', 'infestation', 'machpunch', 'meteorbeam', 'mortalspin', 'nuzzle', 'pluck', 'pursuit',
 	'quickattack', 'rapidspin', 'reversal', 'selfdestruct', 'shadowsneak', 'skydrop', 'snarl', 'strugglebug', 'suckerpunch', 'uturn',
@@ -1099,10 +1099,9 @@ export class RandomTeams {
 		case 'Seed Sower':
 			return role === 'Bulky Support';
 		case 'Sheer Force':
-			const braviaryCase = (species.id === 'braviaryhisui' && (role === 'Wallbreaker' || role === 'Bulky Protect'));
 			const abilitiesCase = (abilities.has('Guts') || abilities.has('Sharpness'));
 			const movesCase = (moves.has('bellydrum') || moves.has('flamecharge'));
-			return (!counter.get('sheerforce') || braviaryCase || abilitiesCase || movesCase);
+			return (!counter.get('sheerforce') || abilitiesCase || movesCase);
 		case 'Slush Rush':
 			return !teamDetails.snow;
 		case 'Solar Power':
@@ -1125,9 +1124,8 @@ export class RandomTeams {
 		case 'Technician':
 			return (!counter.get('technician') || abilities.has('Punk Rock') || abilities.has('Fur Coat'));
 		case 'Tinted Lens':
-			const hbraviaryCase = (species.id === 'braviaryhisui' && (role === 'Setup Sweeper' || role === 'Doubles Wallbreaker'));
 			const yanmegaCase = (species.id === 'yanmega' && moves.has('protect'));
-			return (yanmegaCase || hbraviaryCase || species.id === 'illumise');
+			return (yanmegaCase || species.id === 'illumise');
 		case 'Unburden':
 			return (abilities.has('Prankster') || !counter.get('setup') || species.id === 'sceptile');
 		case 'Vital Spirit':
@@ -1167,6 +1165,7 @@ export class RandomTeams {
 		if (species.id === 'florges') return 'Flower Veil';
 		if (species.id === 'bombirdier' && !counter.get('Rock')) return 'Big Pecks';
 		if (species.id === 'scovillain') return 'Chlorophyll';
+		if (species.id === 'regirock' || (species.id === 'carbink' && moves.has('irondefense'))) return 'Clear Body';
 		if (species.id === 'empoleon') return 'Competitive';
 		if (species.id === 'swampert' && !counter.get('Water') && !moves.has('flipturn')) return 'Damp';
 		if (species.id === 'thundurus' && (role === 'Offensive Protect' || moves.has('terablast'))) return 'Defiant';
@@ -1181,6 +1180,9 @@ export class RandomTeams {
 		if (species.id === 'smeargle' && !counter.get('technician')) return 'Own Tempo';
 		if (species.id === 'zebstrika') return moves.has('thunderbolt') ? 'Lightning Rod' : 'Sap Sipper';
 		if (species.id === 'sandaconda' || (species.id === 'scrafty' && moves.has('rest'))) return 'Shed Skin';
+		if (species.id === 'braviaryhisui') {
+			return (role === 'Setup Sweeper' || role === 'Doubles Wallbreaker') ? 'Sheer Force' : 'Tinted Lens';
+		}
 		if (species.id === 'cetitan' && (role === 'Wallbreaker' || isDoubles)) return 'Sheer Force';
 		if (species.id === 'charizard' && moves.has('sunnyday')) return 'Solar Power';
 		if (species.id === 'dipplin') return 'Sticky Hold';
@@ -1208,7 +1210,7 @@ export class RandomTeams {
 		if (isDoubles) {
 			if (species.id === 'gumshoos' || species.id === 'porygonz') return 'Adaptability';
 			if (species.id === 'farigiraf') return 'Armor Tail';
-			if (['carbink', 'dragapult', 'regirock', 'tentacruel'].includes(species.id)) return 'Clear Body';
+			if (['dragapult', 'tentacruel'].includes(species.id)) return 'Clear Body';
 			if (species.id === 'altaria') return 'Cloud Nine';
 			if (species.id === 'kilowattrel' || species.id === 'meowsticf') return 'Competitive';
 			if (species.id === 'armarouge' && !moves.has('meteorbeam')) return 'Flash Fire';


### PR DESCRIPTION
**Gen 9 Random Battle:**
-Bulky Attacker Muk: -Toxic.
-Tauros now runs a second set with Zen Headbutt instead of Earthquake.
-Houndoom: +wisp, changed role to Setup Sweeper.
-Glaceon now runs Mud Shot with Tera Ground instead of Yawn.
-Dusknoir now runs a third set with SubPunch and Tera Fighting.
-Leavanny always runs Sticky Web unless the team already has a setter.
-Braviary-Hisui's Tinted Lens set has been split into Specs with Vacuum Wave and Calm Mind/Defog with Roost.
-Zekrom: +Tera Steel.
-Salazzle now runs a Tera Blast Grass setup set alongside its Toxic stalling set.
-Skeledirge: -Tera Ghost.
-Brute Bonnet has been split into three sets with finetuned tera types. Tera Poison has been added to all sets.
-CB Koraidon: -Collision Course, +Close Combat.
-Regirock and Iron Defense Carbink now run Clear Body instead of Sturdy.
-Reverted Rock Polish Sudowoodo and Triple Axel on Intimidate Hitmontop since they resulted in a significant winrate drop.
-AV Exeggutor-Alola: +Dragon Tail, -Tera Steel. It rolls between Dragon Tail and Knock Off.
-Ninetales-Alola no longer runs its Tera Blast set and always has Aurora Veil; it has been replaced by a set with Freeze-Dry.

**Gen 9 Random Doubles Battle:**
-Phione now runs Leftovers (Take Heart added to the setup moves list).
-Circle Throw is now on the noSTAB list, ensuring that Poliwrath always gets Close Combat.
-Forretress now runs an IronPress set alongside its Choice Band set.
-Orthworm: -Stealth Rock.
-Glaceon now runs Tera Ground Mud Shot instead of Tera Blast.

**Old Gens:**
-In Gen 7, Ninetales-Alola will always run Aurora Veil, and can now roll Encore.
-In Gens 6-7, Venomoth no longer runs Substitute.
-In Gens 6-7, Feraligatr no longer runs Swords Dance and always runs Dragon Dance.
-In Gens 6-7, Carracosta can now obtain Ice Beam.
-In Gens 6-7, AV Eelektross now runs Discharge instead of Thunderbolt.
-In Gens 6-7, SubCM Keldeo no longer runs Hydro Pump and always runs Scald.
-In Gens 6-7, Pyroar now runs Work Up.
-In Gens 6-7, Xerneas always obtains Focus Blast and Psyshock, and no longer runs Hidden Power Fire or Thunder.
-In Gens 6-7, both Clefable sets roll between Magic Guard and Unaware; Magic Guard is always Life Orb, and Unaware is always Leftovers.
-In Gens 5-7, Gigalith can now run Toxic and always gets Earthquake.
-In Gen 6, Plusle and Minun no longer run their support sets and always have Nasty Plot.
-In Gens 4-6, Swellow always has U-Turn.
-In Gen 5, CM Cresselia can now run Signal Beam.
-In Gen 3, Suicune no longer runs its non-Calm Mind sets.
-In Gen 3, WishTect Delcatty and Hypno no longer run Baton Pass. On Hypno, it has been replaced with Toxic.
-In Gen 2, Dodrio and Fearow can no longer obtain sub 3 attacks, and are always RestTalk.
-In Gen 1, Sandslash will always obtain Swords Dance and can no longer obtain Slash.