### PR TITLE
SSB: Add missing QC changes and update descriptions

### DIFF
--- a/data/mods/gen9ssb/abilities.ts
+++ b/data/mods/gen9ssb/abilities.ts
@@ -1609,6 +1609,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	// Merritty
 	endround: {
 		shortDesc: "Clears everything.",
+		desc: "When this Pokemon switches in, all weather, terrains, field conditions, entry hazards, stat stage changes, and volatile status conditions are removed from the field.",
 		name: "End Round",
 		onStart(pokemon) {
 			if (this.suppressingAbility(pokemon)) return;
@@ -1664,7 +1665,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 
 	// Meteordash
 	tatsuglare: {
-		shortDesc: "Fur Coat + All moves hit off of Sp. Atk stat.",
+		shortDesc: "Fur Coat + All of the user's moves use the Special Attack stat.",
 		name: "TatsuGlare",
 		onModifyMove(move, pokemon, target) {
 			if (move.category !== "Status") move.overrideOffensiveStat = 'spa';
@@ -1872,10 +1873,10 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 
 	// Pastor Gigas
 	godsmercy: {
-		shortDesc: "Summons Misty Surge and cures the team's status conditions on switch-in.",
+		shortDesc: "Summons Grassy Terrain and cures the team's status conditions on switch-in.",
 		name: "God's Mercy",
 		onStart(source) {
-			this.field.setTerrain('mistyterrain');
+			this.field.setTerrain('grassyterrain');
 			const allies = [...source.side.pokemon, ...source.side.allySide?.pokemon || []];
 			for (const ally of allies) {
 				if (ally !== source && ally.hasAbility('sapsipper')) {

--- a/data/mods/gen9ssb/moves.ts
+++ b/data/mods/gen9ssb/moves.ts
@@ -105,7 +105,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			this.attrLastMove('[still]');
 		},
 		onHit(pokemon) {
-			// According to bug reports, this also burns the opponent.
 			pokemon.trySetStatus('brn');
 			this.add('-anim', pokemon, 'Shift Gear', pokemon);
 			this.boost({spe: 2, atk: 1});

--- a/data/mods/gen9ssb/moves.ts
+++ b/data/mods/gen9ssb/moves.ts
@@ -105,6 +105,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			this.attrLastMove('[still]');
 		},
 		onHit(pokemon) {
+			// According to bug reports, this also burns the opponent.
 			pokemon.trySetStatus('brn');
 			this.add('-anim', pokemon, 'Shift Gear', pokemon);
 			this.boost({spe: 2, atk: 1});
@@ -916,6 +917,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		basePower: 0,
 		category: "Status",
 		shortDesc: "Protect, hit=-2 Atk/SpA/or Spe, user swap.",
+		desc: "Nearly always moves first. This move can only be used by Mega Sableye. The user is protected from most attacks made by other Pokemon during this turn. If a targeted move is blocked during this effect, the attacker's stats are lowered depending on the move used. If the attacker used a physical attack, their Attack is lowered by 2 stages. If the attacker used a special attack, their Special Attack is lowere dby 2 stages. If the attacker used a status move, their Speed is lowered by 2 stages. If this move successfully decreases a Pokemon's stat stages, this Pokemon's Mega Evolution is removed, and it immediately switches out and is replaced by a selected party member. This move fails if the user moves last, and has an increasing chance to fail when used consecutively.",
 		name: "Shatter and Scatter",
 		pp: 10,
 		priority: 4,
@@ -5240,8 +5242,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 
 	// Spiderz
 	shepherdofthemafiaroom: {
-		accuracy: 100,
-		basePower: 90,
+		accuracy: 90,
+		basePower: 65,
 		category: "Physical",
 		shortDesc: "Sets Sticky Web. 1.3x BP if faster.",
 		name: "Shepherd of the Mafia Room",


### PR DESCRIPTION
-Added descriptions for End Round and Shatter & Scatter
-Adjusted TatsuGlare shortdesc to make more face-value sense
-Applied missing quality control changes (Grassy over Misty terrain on Pastor Gigas, 90 acc/65 BP on the Iron Thorns)