### PR TITLE
/bssfactory: Fix ability display

### DIFF
--- a/server/chat-plugins/randombattles/index.ts
+++ b/server/chat-plugins/randombattles/index.ts
@@ -329,7 +329,7 @@ function battleFactorySets(species: string | Species, tier: string | null, gen =
 				buf += `<details><summary>Set ${i + 1} (${set.weight}%)</summary>`;
 				buf += `<ul style="list-style-type:none;padding-left:0;">`;
 				buf += `<li>${Dex.forFormat(format).species.get(set.species).name} @ ${set.item.map(formatItem).join(" / ")}</li>`;
-				buf += `<li>Ability: ${formatAbility(set.ability)}</li>`;
+				buf += `<li>Ability: ${set.ability.map(formatAbility).join(" / ")}</li>`;
 				buf += `<li>Level: 50</li>`;
 				buf += `<li>Tera Type: ${set.teraType.map(formatType).join(' / ')}</li>`;
 				if (set.evs) {


### PR DESCRIPTION
set.ability is an array, formatAbility expects a string.

Before: 
![image](https://github.com/smogon/pokemon-showdown/assets/18681232/5d6a37f7-17d3-40d2-a869-af110c99c933)
After:
![image](https://github.com/smogon/pokemon-showdown/assets/18681232/0caa0713-d8c0-485e-bdeb-7f80288de166)
