### PR TITLE
Fix Metronome (item) with calling moves

### DIFF
--- a/data/items.ts
+++ b/data/items.ts
@@ -3652,7 +3652,7 @@ export const Items: {[itemid: string]: ItemData} = {
 					pokemon.removeVolatile('metronome');
 					return;
 				}
-				if (move.flags["calling"]) return;
+				if (move.callsMove) return;
 				if (this.effectState.lastMove === move.id && pokemon.moveLastTurnResult) {
 					this.effectState.numConsecutive++;
 				} else if (pokemon.volatiles['twoturnmove']) {

--- a/data/items.ts
+++ b/data/items.ts
@@ -3652,6 +3652,7 @@ export const Items: {[itemid: string]: ItemData} = {
 					pokemon.removeVolatile('metronome');
 					return;
 				}
+				if (move.flags["calling"]) return;
 				if (this.effectState.lastMove === move.id && pokemon.moveLastTurnResult) {
 					this.effectState.numConsecutive++;
 				} else if (pokemon.volatiles['twoturnmove']) {

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -629,7 +629,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Assist",
 		pp: 20,
 		priority: 0,
-		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1, calling: 1},
+		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1},
 		onHit(target) {
 			const moves = [];
 			for (const pokemon of target.side.pokemon) {
@@ -650,6 +650,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			}
 			this.actions.useMove(randomMove, target);
 		},
+		callsMove: true,
 		secondary: null,
 		target: "self",
 		type: "Normal",
@@ -2937,7 +2938,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Copycat",
 		pp: 20,
 		priority: 0,
-		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1, calling: 1},
+		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1},
 		onHit(pokemon) {
 			let move: Move | ActiveMove | null = this.lastMove;
 			if (!move) return;
@@ -2948,6 +2949,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			}
 			this.actions.useMove(move.id, pokemon);
 		},
+		callsMove: true,
 		secondary: null,
 		target: "self",
 		type: "Normal",
@@ -11923,8 +11925,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {
 			protect: 1, bypasssub: 1,
-			failencore: 1, failmefirst: 1, nosleeptalk: 1, noassist: 1, 
-			failcopycat: 1, failmimic: 1, failinstruct: 1, calling: 1
+			failencore: 1, failmefirst: 1, nosleeptalk: 1, noassist: 1,
+			failcopycat: 1, failmimic: 1, failinstruct: 1,
 		},
 		onTryHit(target, pokemon) {
 			const action = this.queue.willMove(target);
@@ -11945,6 +11947,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				return this.chainModify(1.5);
 			},
 		},
+		callsMove: true,
 		secondary: null,
 		target: "adjacentFoe",
 		type: "Normal",
@@ -12187,7 +12190,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Metronome",
 		pp: 10,
 		priority: 0,
-		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1, calling: 1},
+		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1},
 		onHit(target, source, effect) {
 			const moves = this.dex.moves.all().filter(move => (
 				(![2, 4].includes(this.gen) || !source.moves.includes(move.id)) &&
@@ -12203,6 +12206,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			source.side.lastSelectedMove = this.toID(randomMove);
 			this.actions.useMove(randomMove, target);
 		},
+		callsMove: true,
 		secondary: null,
 		target: "self",
 		type: "Normal",
@@ -12452,7 +12456,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Mirror Move",
 		pp: 20,
 		priority: 0,
-		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1, calling: 1},
+		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1},
 		onTryHit(target, pokemon) {
 			const move = target.lastMove;
 			if (!move?.flags['mirror'] || move.isZ || move.isMax) {
@@ -12461,6 +12465,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			this.actions.useMove(move.id, pokemon, target);
 			return null;
 		},
+		callsMove: true,
 		secondary: null,
 		target: "normal",
 		type: "Flying",
@@ -13032,7 +13037,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Nature Power",
 		pp: 20,
 		priority: 0,
-		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1, calling: 1},
+		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1},
 		onTryHit(target, pokemon) {
 			let move = 'triattack';
 			if (this.field.isTerrain('electricterrain')) {
@@ -13047,6 +13052,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			this.actions.useMove(move, pokemon, target);
 			return null;
 		},
+		callsMove: true,
 		secondary: null,
 		target: "normal",
 		type: "Normal",
@@ -17532,7 +17538,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Sleep Talk",
 		pp: 10,
 		priority: 0,
-		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1, calling: 1},
+		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1},
 		sleepUsable: true,
 		onTry(source) {
 			return source.status === 'slp' || source.hasAbility('comatose');
@@ -17555,6 +17561,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			}
 			this.actions.useMove(randomMove, pokemon);
 		},
+		callsMove: true,
 		secondary: null,
 		target: "self",
 		type: "Normal",
@@ -17776,7 +17783,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Snatch",
 		pp: 10,
 		priority: 4,
-		flags: {bypasssub: 1, mustpressure: 1, noassist: 1, failcopycat: 1, calling: 1},
+		flags: {bypasssub: 1, mustpressure: 1, noassist: 1, failcopycat: 1},
 		volatileStatus: 'snatch',
 		condition: {
 			duration: 1,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -629,7 +629,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Assist",
 		pp: 20,
 		priority: 0,
-		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1},
+		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1, calling: 1},
 		onHit(target) {
 			const moves = [];
 			for (const pokemon of target.side.pokemon) {
@@ -2937,7 +2937,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Copycat",
 		pp: 20,
 		priority: 0,
-		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1},
+		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1, calling: 1},
 		onHit(pokemon) {
 			let move: Move | ActiveMove | null = this.lastMove;
 			if (!move) return;
@@ -11923,7 +11923,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {
 			protect: 1, bypasssub: 1,
-			failencore: 1, failmefirst: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1,
+			failencore: 1, failmefirst: 1, nosleeptalk: 1, noassist: 1, 
+			failcopycat: 1, failmimic: 1, failinstruct: 1, calling: 1
 		},
 		onTryHit(target, pokemon) {
 			const action = this.queue.willMove(target);
@@ -12186,7 +12187,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Metronome",
 		pp: 10,
 		priority: 0,
-		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1},
+		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1, calling: 1},
 		onHit(target, source, effect) {
 			const moves = this.dex.moves.all().filter(move => (
 				(![2, 4].includes(this.gen) || !source.moves.includes(move.id)) &&
@@ -12451,7 +12452,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Mirror Move",
 		pp: 20,
 		priority: 0,
-		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1},
+		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1, calling: 1},
 		onTryHit(target, pokemon) {
 			const move = target.lastMove;
 			if (!move?.flags['mirror'] || move.isZ || move.isMax) {
@@ -13031,7 +13032,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Nature Power",
 		pp: 20,
 		priority: 0,
-		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1},
+		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1, calling: 1},
 		onTryHit(target, pokemon) {
 			let move = 'triattack';
 			if (this.field.isTerrain('electricterrain')) {
@@ -17531,7 +17532,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Sleep Talk",
 		pp: 10,
 		priority: 0,
-		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1},
+		flags: {failencore: 1, nosleeptalk: 1, noassist: 1, failcopycat: 1, failmimic: 1, failinstruct: 1, calling: 1},
 		sleepUsable: true,
 		onTry(source) {
 			return source.status === 'slp' || source.hasAbility('comatose');
@@ -17775,7 +17776,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Snatch",
 		pp: 10,
 		priority: 4,
-		flags: {bypasssub: 1, mustpressure: 1, noassist: 1, failcopycat: 1},
+		flags: {bypasssub: 1, mustpressure: 1, noassist: 1, failcopycat: 1, calling: 1},
 		volatileStatus: 'snatch',
 		condition: {
 			duration: 1,

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -61,6 +61,7 @@ interface MoveFlags {
 	snatch?: 1; // Can be stolen from the original user and instead used by another Pokemon using Snatch.
 	sound?: 1; // Has no effect on Pokemon with the Ability Soundproof.
 	wind?: 1; // Activates the Wind Power and Wind Rider Abilities.
+	calling?: 1; // Calls another move.
 }
 
 export interface HitEffect {

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -61,7 +61,6 @@ interface MoveFlags {
 	snatch?: 1; // Can be stolen from the original user and instead used by another Pokemon using Snatch.
 	sound?: 1; // Has no effect on Pokemon with the Ability Soundproof.
 	wind?: 1; // Activates the Wind Power and Wind Rider Abilities.
-	calling?: 1; // Calls another move.
 }
 
 export interface HitEffect {
@@ -267,6 +266,7 @@ export interface MoveData extends EffectData, MoveEventMethods, HitEffect {
 	 */
 	tracksTarget?: boolean;
 	willCrit?: boolean;
+	callsMove?: boolean;
 
 	// Mechanics flags
 	// ---------------

--- a/test/sim/items/metronome.js
+++ b/test/sim/items/metronome.js
@@ -97,7 +97,7 @@ describe('Metronome (item)', function () {
 		assert.bounded(damage, [80, 95], `Solar Beam should be Metronome 1 boosted`);
 	});
 
-	it.skip(`should use called moves to determine the Metronome multiplier`, function () {
+	it(`should use called moves to determine the Metronome multiplier`, function () {
 		battle = common.createBattle([[
 			{species: 'goomy', item: 'metronome', moves: ['copycat', 'surf']},
 		], [


### PR DESCRIPTION
https://www.smogon.com/forums/threads/metronome-item-and-called-moves.3745535/

This determines Metronome bonus using the called move only, as in Bulbapedia. List of moves that call other moves from here: https://bulbapedia.bulbagarden.net/wiki/Category:Moves_that_call_other_moves

This does not fix the Magic Bounce interaction.