### PR TITLE
Correctly Implementing Generation 1 Sleep Mechanics

### DIFF
--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -60,7 +60,15 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 				this.add('-status', target, 'slp');
 			}
 			// 1-7 turns
-			this.effectState.startTime = this.random(1, 8);
+			// Since RBY gets the number of sleep turns by taking the 3 lowest bits
+			// of the current rng value (current rng value mod 8), and then if those are not
+			// all zero, it sets that as the number of sleep turns, otherwise it re-rolls the rng
+			// and does the same thing. But because rby's link battles rng formula is (in pseudocode):
+			// next_rng_val = (current_rng_val * 5 + 1 ) % 256
+			// this means that if the current rng value mod 8 is 0, then the next rng value mod 8 will always be 1
+			// making it a 1/4 chance for 1 turn sleep and 1/8'th chance for 2-7 turns of sleep.
+
+			this.effectState.startTime = this.clampIntRange(this.random(0, 8), 1, 7);
 			this.effectState.time = this.effectState.startTime;
 
 			if (target.removeVolatile('nightmare')) {

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -59,7 +59,7 @@ export const Conditions: {[id: string]: ModdedConditionData} = {
 			} else {
 				this.add('-status', target, 'slp');
 			}
-			// 1-7 turns
+			// Pokemon are put to sleep for 1-7 turns.
 			// Since RBY gets the number of sleep turns by taking the 3 lowest bits
 			// of the current rng value (current rng value mod 8), and then if those are not
 			// all zero, it sets that as the number of sleep turns, otherwise it re-rolls the rng


### PR DESCRIPTION
Currently Showdown determines how many turns a Pokemon should be put to sleep in Generation 1 by generating a random number between 1 and 7, with a uniform distribution. However, this is incorrect, it should be a 25% chance to put the opposing Pokemon to sleep for 1 turn and a 12.5% chance for all other RNG rolls.

Further information and an explanation of why can be found in this thread:
https://www.smogon.com/forums/threads/new-rby-sleep-mechanics-discovery.3745689/
