### PR TITLE
Chatlog: Fix broken query

### DIFF
--- a/server/chat-plugins/chatlog.ts
+++ b/server/chat-plugins/chatlog.ts
@@ -827,7 +827,7 @@ export class DatabaseLogSearcher extends Searcher {
 		const results: {[date: string]: {[user: string]: number}} = {};
 		const [monthStart, monthEnd] = LogReader.monthToRange(month);
 		const rows = await Rooms.Roomlogs.table.selectAll()`
-			WHERE ${user ? SQL`userid = ${user} AND` : SQL``}roomid = ${roomid} AND
+			WHERE ${user ? SQL`userid = ${user} AND ` : SQL``}roomid = ${roomid} AND
 			time BETWEEN ${monthStart}::int::timestamp AND ${monthEnd}::int::timestamp AND
 			type = ${'c'}
 		`;


### PR DESCRIPTION
Missing space, seems like a regression from
82ed9b0d2b2e15af54d30de4a1adec20c52be970

Should fix these crashes

<img width="602" alt="image" src="https://github.com/smogon/pokemon-showdown/assets/47090312/c503bcb5-ce67-4351-8c8f-e24f744684fb">
