### PR TITLE
Randomized format set updates

### DIFF
--- a/data/random-battles/gen2/teams.ts
+++ b/data/random-battles/gen2/teams.ts
@@ -112,7 +112,7 @@ export class RandomGen2Teams extends RandomGen3Teams {
 			if (movePool.includes('rapidspin')) this.fastPop(movePool, movePool.indexOf('rapidspin'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
-		if (teamDetails.cleric) {
+		if (teamDetails.statusCure) {
 			if (movePool.includes('healbell')) this.fastPop(movePool, movePool.indexOf('healbell'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}

--- a/data/random-battles/gen2/teams.ts
+++ b/data/random-battles/gen2/teams.ts
@@ -112,6 +112,10 @@ export class RandomGen2Teams extends RandomGen3Teams {
 			if (movePool.includes('rapidspin')) this.fastPop(movePool, movePool.indexOf('rapidspin'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
+		if (teamDetails.cleric) {
+			if (movePool.includes('healbell')) this.fastPop(movePool, movePool.indexOf('healbell'));
+			if (moves.size + movePool.length <= this.maxMoveCount) return;
+		}
 
 		// General incompatibilities
 		const incompatiblePairs = [

--- a/data/random-battles/gen3/sets.json
+++ b/data/random-battles/gen3/sets.json
@@ -513,7 +513,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["batonpass", "calmmind", "firepunch", "protect", "psychic", "wish"]
+                "movepool": ["batonpass", "calmmind", "firepunch", "psychic"]
             },
             {
                 "role": "Bulky Support",

--- a/data/random-battles/gen3/teams.ts
+++ b/data/random-battles/gen3/teams.ts
@@ -122,7 +122,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			if (movePool.includes('rapidspin')) this.fastPop(movePool, movePool.indexOf('rapidspin'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
-		if (teamDetails.cleric) {
+		if (teamDetails.statusCure) {
 			if (movePool.includes('aromatherapy')) this.fastPop(movePool, movePool.indexOf('aromatherapy'));
 			if (movePool.includes('healbell')) this.fastPop(movePool, movePool.indexOf('healbell'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
@@ -777,7 +777,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			if (set.ability === 'Drizzle' || set.moves.includes('raindance')) teamDetails.rain = 1;
 			if (set.ability === 'Drought' || set.moves.includes('sunnyday')) teamDetails.sun = 1;
 			if (set.ability === 'Sand Stream') teamDetails.sand = 1;
-			if (set.moves.includes('aromatherapy') || set.moves.includes('healbell')) teamDetails.cleric = 1;
+			if (set.moves.includes('aromatherapy') || set.moves.includes('healbell')) teamDetails.statusCure = 1;
 			if (set.moves.includes('spikes')) teamDetails.spikes = 1;
 			if (set.moves.includes('rapidspin')) teamDetails.rapidSpin = 1;
 

--- a/data/random-battles/gen3/teams.ts
+++ b/data/random-battles/gen3/teams.ts
@@ -122,6 +122,11 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			if (movePool.includes('rapidspin')) this.fastPop(movePool, movePool.indexOf('rapidspin'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
+		if (teamDetails.cleric) {
+			if (movePool.includes('aromatherapy')) this.fastPop(movePool, movePool.indexOf('aromatherapy'));
+			if (movePool.includes('healbell')) this.fastPop(movePool, movePool.indexOf('healbell'));
+			if (moves.size + movePool.length <= this.maxMoveCount) return;
+		}
 
 		// Develop additional move lists
 		const badWithSetup = ['knockoff', 'rapidspin', 'toxic'];
@@ -772,6 +777,7 @@ export class RandomGen3Teams extends RandomGen4Teams {
 			if (set.ability === 'Drizzle' || set.moves.includes('raindance')) teamDetails.rain = 1;
 			if (set.ability === 'Drought' || set.moves.includes('sunnyday')) teamDetails.sun = 1;
 			if (set.ability === 'Sand Stream') teamDetails.sand = 1;
+			if (set.moves.includes('aromatherapy') || set.moves.includes('healbell')) teamDetails.cleric = 1;
 			if (set.moves.includes('spikes')) teamDetails.spikes = 1;
 			if (set.moves.includes('rapidspin')) teamDetails.rapidSpin = 1;
 

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -3200,7 +3200,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hiddenpowerfighting", "moonlight", "psychic"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "moonlight", "psychic", "signalbeam"]
             },
             {
                 "role": "Bulky Support",

--- a/data/random-battles/gen4/sets.json
+++ b/data/random-battles/gen4/sets.json
@@ -957,7 +957,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["aquajet", "doubleedge", "icepunch", "superpower", "waterfall"]
+                "movepool": ["aquajet", "doubleedge", "icepunch", "superpower", "waterfall"],
+                "preferredTypes": ["Ice"]
             },
             {
                 "role": "Bulky Setup",
@@ -1431,7 +1432,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthpower", "energyball", "hiddenpowerfire", "leafstorm", "nastyplot", "psychic", "uturn"],
+                "movepool": ["earthpower", "energyball", "leafstorm", "nastyplot", "psychic", "uturn"],
                 "preferredTypes": ["Psychic"]
             },
             {
@@ -2339,8 +2340,11 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "icebeam", "psychoboost", "shadowball", "stealthrock", "superpower"],
-                "preferredTypes": ["Fighting"]
+                "movepool": ["extremespeed", "psychoboost", "shadowball", "superpower"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["icebeam", "psychoboost", "shadowball", "superpower"]
             }
         ]
     },
@@ -2349,8 +2353,11 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "icebeam", "psychoboost", "shadowball", "superpower"],
-                "preferredTypes": ["Fighting"]
+                "movepool": ["extremespeed", "psychoboost", "shadowball", "superpower"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["icebeam", "psychoboost", "shadowball", "superpower"]
             }
         ]
     },
@@ -3175,7 +3182,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dracometeor", "earthquake", "hiddenpowerfire", "outrage", "shadowball", "shadowsneak", "willowisp"]
+                "movepool": ["dracometeor", "earthquake", "outrage", "shadowball", "shadowsneak", "willowisp"]
             }
         ]
     },
@@ -3191,10 +3198,6 @@
     "cresselia": {
         "level": 79,
         "sets": [
-            {
-                "role": "Bulky Attacker",
-                "movepool": ["calmmind", "hiddenpowerfighting", "psychic", "substitute"]
-            },
             {
                 "role": "Bulky Setup",
                 "movepool": ["calmmind", "hiddenpowerfighting", "moonlight", "psychic"]

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -157,6 +157,11 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			if (movePool.includes('spikes')) this.fastPop(movePool, movePool.indexOf('spikes'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
+		if (teamDetails.cleric) {
+			if (movePool.includes('aromatherapy')) this.fastPop(movePool, movePool.indexOf('aromatherapy'));
+			if (movePool.includes('healbell')) this.fastPop(movePool, movePool.indexOf('healbell'));
+			if (moves.size + movePool.length <= this.maxMoveCount) return;
+		}
 
 		// Develop additional move lists
 		const badWithSetup = ['healbell', 'pursuit', 'toxic'];

--- a/data/random-battles/gen4/teams.ts
+++ b/data/random-battles/gen4/teams.ts
@@ -157,7 +157,7 @@ export class RandomGen4Teams extends RandomGen5Teams {
 			if (movePool.includes('spikes')) this.fastPop(movePool, movePool.indexOf('spikes'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
-		if (teamDetails.cleric) {
+		if (teamDetails.statusCure) {
 			if (movePool.includes('aromatherapy')) this.fastPop(movePool, movePool.indexOf('aromatherapy'));
 			if (movePool.includes('healbell')) this.fastPop(movePool, movePool.indexOf('healbell'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -987,7 +987,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["aquajet", "doubleedge", "icepunch", "superpower", "waterfall"]
+                "movepool": ["aquajet", "doubleedge", "icepunch", "superpower", "waterfall"],
+                "preferredTypes": ["Ice"]
             },
             {
                 "role": "Bulky Setup",
@@ -1480,7 +1481,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthpower", "gigadrain", "hiddenpowerfire", "leafstorm", "nastyplot", "psychic", "uturn"],
+                "movepool": ["earthpower", "gigadrain", "leafstorm", "nastyplot", "psychic", "uturn"],
                 "preferredTypes": ["Psychic"]
             },
             {
@@ -2346,8 +2347,11 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["darkpulse", "extremespeed", "icebeam", "psychoboost", "stealthrock", "superpower"],
-                "preferredTypes": ["Fighting"]
+                "movepool": ["darkpulse", "extremespeed", "psychoboost", "superpower"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["darkpulse", "icebeam", "psychoboost", "superpower"]
             }
         ]
     },
@@ -2356,8 +2360,11 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["darkpulse", "extremespeed", "icebeam", "psychoboost", "superpower"],
-                "preferredTypes": ["Fighting"]
+                "movepool": ["darkpulse", "extremespeed", "psychoboost", "superpower"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["darkpulse", "icebeam", "psychoboost", "superpower"]
             }
         ]
     },
@@ -3164,7 +3171,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dracometeor", "earthquake", "hiddenpowerfire", "outrage", "shadowball", "shadowsneak", "willowisp"]
+                "movepool": ["dracometeor", "earthquake", "outrage", "shadowball", "shadowsneak", "willowisp"]
             }
         ]
     },
@@ -3173,7 +3180,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "hiddenpowerfighting", "moonlight", "psyshock", "signalbeam", "substitute"]
+                "movepool": ["calmmind", "hiddenpowerfighting", "moonlight", "psyshock", "signalbeam"]
             },
             {
                 "role": "Bulky Support",

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -2711,7 +2711,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["foulplay", "painsplit", "pursuit", "suckerpunch", "willowisp"]
+                "movepool": ["darkpulse", "painsplit", "pursuit", "suckerpunch", "willowisp"]
             }
         ]
     },

--- a/data/random-battles/gen5/sets.json
+++ b/data/random-battles/gen5/sets.json
@@ -1756,8 +1756,13 @@
         "level": 95,
         "sets": [
             {
+                "role": "Bulky Setup",
+                "movepool": ["firefang", "ironhead", "suckerpunch", "swordsdance", "thunderpunch"],
+                "preferredTypes": ["Fire"]
+            },
+            {
                 "role": "Bulky Attacker",
-                "movepool": ["firefang", "ironhead", "stealthrock", "suckerpunch", "swordsdance", "thunderpunch"],
+                "movepool": ["fireblast", "ironhead", "stealthrock", "suckerpunch", "thunderpunch"],
                 "preferredTypes": ["Fire"]
             }
         ]

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -716,9 +716,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 		if (moves.has('waterspout')) return 'Choice Scarf';
 		if (moves.has('shellsmash')) return 'White Herb';
 		if (moves.has('psychoshift')) return 'Flame Orb';
-		if (ability === 'Magic Guard' && role !== 'Bulky Support') {
-			return moves.has('counter') ? 'Focus Sash' : 'Life Orb';
-		}
+		if (ability === 'Magic Guard') return moves.has('counter') ? 'Focus Sash' : 'Life Orb';
 		if (species.id === 'rampardos' && role === 'Fast Attacker') return 'Choice Scarf';
 		if (ability === 'Sheer Force' && counter.get('sheerforce')) return 'Life Orb';
 		if (moves.has('acrobatics')) return 'Flying Gem';

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -172,6 +172,11 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			if (movePool.includes('spikes')) this.fastPop(movePool, movePool.indexOf('spikes'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
+		if (teamDetails.cleric) {
+			if (movePool.includes('aromatherapy')) this.fastPop(movePool, movePool.indexOf('aromatherapy'));
+			if (movePool.includes('healbell')) this.fastPop(movePool, movePool.indexOf('healbell'));
+			if (moves.size + movePool.length <= this.maxMoveCount) return;
+		}
 
 		// Develop additional move lists
 		const badWithSetup = ['healbell', 'pursuit', 'toxic'];
@@ -1066,6 +1071,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			if (set.ability === 'Drizzle' || set.moves.includes('raindance')) teamDetails.rain = 1;
 			if (set.ability === 'Sand Stream') teamDetails.sand = 1;
 			if (set.ability === 'Drought' || set.moves.includes('sunnyday')) teamDetails.sun = 1;
+			if (set.moves.includes('aromatherapy') || set.moves.includes('healbell')) teamDetails.cleric = 1;
 			if (set.moves.includes('spikes')) teamDetails.spikes = (teamDetails.spikes || 0) + 1;
 			if (set.moves.includes('stealthrock')) teamDetails.stealthRock = 1;
 			if (set.moves.includes('toxicspikes')) teamDetails.toxicSpikes = 1;

--- a/data/random-battles/gen5/teams.ts
+++ b/data/random-battles/gen5/teams.ts
@@ -172,7 +172,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			if (movePool.includes('spikes')) this.fastPop(movePool, movePool.indexOf('spikes'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
-		if (teamDetails.cleric) {
+		if (teamDetails.statusCure) {
 			if (movePool.includes('aromatherapy')) this.fastPop(movePool, movePool.indexOf('aromatherapy'));
 			if (movePool.includes('healbell')) this.fastPop(movePool, movePool.indexOf('healbell'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
@@ -1071,7 +1071,7 @@ export class RandomGen5Teams extends RandomGen6Teams {
 			if (set.ability === 'Drizzle' || set.moves.includes('raindance')) teamDetails.rain = 1;
 			if (set.ability === 'Sand Stream') teamDetails.sand = 1;
 			if (set.ability === 'Drought' || set.moves.includes('sunnyday')) teamDetails.sun = 1;
-			if (set.moves.includes('aromatherapy') || set.moves.includes('healbell')) teamDetails.cleric = 1;
+			if (set.moves.includes('aromatherapy') || set.moves.includes('healbell')) teamDetails.statusCure = 1;
 			if (set.moves.includes('spikes')) teamDetails.spikes = (teamDetails.spikes || 0) + 1;
 			if (set.moves.includes('stealthrock')) teamDetails.stealthRock = 1;
 			if (set.moves.includes('toxicspikes')) teamDetails.toxicSpikes = 1;

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -2526,6 +2526,10 @@
         "level": 87,
         "sets": [
             {
+                "role": "Staller",
+                "movepool": ["icebeam", "protect", "thunderbolt", "toxic"]
+            },
+            {
                 "role": "Bulky Attacker",
                 "movepool": ["focusblast", "icebeam", "rest", "sleeptalk", "thunderbolt", "thunderwave"],
                 "preferredTypes": ["Electric"]

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -4085,10 +4085,6 @@
         "level": 88,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["knockoff", "leafblade", "swordsdance", "xscissor"]
-            },
-            {
                 "role": "Fast Support",
                 "movepool": ["knockoff", "leafblade", "stickyweb", "toxic", "xscissor"]
             }

--- a/data/random-battles/gen6/sets.json
+++ b/data/random-battles/gen6/sets.json
@@ -79,7 +79,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["bugbuzz", "energyball", "psychic", "quiverdance", "sleeppowder"]
+                "movepool": ["bugbuzz", "psychic", "quiverdance", "sleeppowder"]
             }
         ]
     },
@@ -283,7 +283,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowerfighting", "hiddenpowerfire", "hypervoice", "nastyplot", "shadowball", "waterpulse"]
+                "movepool": ["hiddenpowerfighting", "hypervoice", "nastyplot", "shadowball"]
             }
         ]
     },
@@ -1623,7 +1623,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthpower", "gigadrain", "hiddenpowerfire", "leafstorm", "nastyplot", "psychic", "uturn"],
+                "movepool": ["earthpower", "gigadrain", "leafstorm", "nastyplot", "psychic", "uturn"],
                 "preferredTypes": ["Psychic"]
             },
             {
@@ -1654,7 +1654,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dragonpulse", "earthquake", "focusblast", "gigadrain", "hiddenpowerfire", "leafstorm", "substitute"]
+                "movepool": ["dragonpulse", "earthquake", "focusblast", "gigadrain", "leafstorm", "substitute"]
             },
             {
                 "role": "Setup Sweeper",
@@ -1830,7 +1830,7 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["airslash", "bugbuzz", "hydropump", "icebeam", "roost", "stickyweb", "stunspore", "uturn"]
+                "movepool": ["airslash", "bugbuzz", "roost", "scald", "stickyweb", "stunspore", "uturn"]
             }
         ]
     },
@@ -2526,12 +2526,9 @@
         "level": 87,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["icebeam", "rest", "sleeptalk", "thunderwave", "toxic"]
-            },
-            {
                 "role": "Bulky Attacker",
-                "movepool": ["icebeam", "rest", "sleeptalk", "thunderbolt"]
+                "movepool": ["focusblast", "icebeam", "rest", "sleeptalk", "thunderbolt", "thunderwave"],
+                "preferredTypes": ["Electric"]
             },
             {
                 "role": "Bulky Setup",
@@ -2681,8 +2678,11 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "icebeam", "knockoff", "psychoboost", "stealthrock", "superpower"],
-                "preferredTypes": ["Fighting"]
+                "movepool": ["extremespeed", "knockoff", "psychoboost", "superpower"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["icebeam", "knockoff", "psychoboost", "superpower"]
             }
         ]
     },
@@ -2691,8 +2691,11 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "icebeam", "knockoff", "psychoboost", "superpower"],
-                "preferredTypes": ["Fighting"]
+                "movepool": ["extremespeed", "knockoff", "psychoboost", "superpower"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["icebeam", "knockoff", "psychoboost", "superpower"]
             }
         ]
     },
@@ -3048,7 +3051,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["foulplay", "painsplit", "pursuit", "suckerpunch", "willowisp"]
+                "movepool": ["darkpulse", "painsplit", "pursuit", "suckerpunch", "willowisp"]
             }
         ]
     },
@@ -3564,7 +3567,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "moonblast", "moonlight", "psyshock", "substitute"]
+                "movepool": ["calmmind", "moonblast", "moonlight", "psyshock"]
             },
             {
                 "role": "Bulky Support",
@@ -5096,11 +5099,13 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["ancientpower", "blizzard", "earthpower", "freezedry", "stealthrock"]
+                "movepool": ["ancientpower", "blizzard", "earthpower", "freezedry", "haze", "stealthrock", "thunderwave"],
+                "preferredTypes": ["Ground"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["earthpower", "freezedry", "haze", "hypervoice", "stealthrock", "thunderwave"]
+                "movepool": ["ancientpower", "earthpower", "freezedry", "haze", "hypervoice", "stealthrock", "thunderwave"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -193,7 +193,7 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			if (movePool.includes('spikes')) this.fastPop(movePool, movePool.indexOf('spikes'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
-		if (teamDetails.cleric) {
+		if (teamDetails.statusCure) {
 			if (movePool.includes('aromatherapy')) this.fastPop(movePool, movePool.indexOf('aromatherapy'));
 			if (movePool.includes('healbell')) this.fastPop(movePool, movePool.indexOf('healbell'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;

--- a/data/random-battles/gen6/teams.ts
+++ b/data/random-battles/gen6/teams.ts
@@ -193,6 +193,11 @@ export class RandomGen6Teams extends RandomGen7Teams {
 			if (movePool.includes('spikes')) this.fastPop(movePool, movePool.indexOf('spikes'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
+		if (teamDetails.cleric) {
+			if (movePool.includes('aromatherapy')) this.fastPop(movePool, movePool.indexOf('aromatherapy'));
+			if (movePool.includes('healbell')) this.fastPop(movePool, movePool.indexOf('healbell'));
+			if (moves.size + movePool.length <= this.maxMoveCount) return;
+		}
 
 		// Develop additional move lists
 		const badWithSetup = ['defog', 'dragontail', 'haze', 'healbell', 'nuzzle', 'pursuit', 'rapidspin', 'toxic'];

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -6331,7 +6331,8 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["aquajet", "crunch", "icefang", "liquidation", "psychicfangs", "swordsdance"]
+                "movepool": ["aquajet", "crunch", "icefang", "liquidation", "psychicfangs", "swordsdance"],
+                "preferredTypes": ["Dark"]
             }
         ]
     },

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -2743,6 +2743,10 @@
         "level": 87,
         "sets": [
             {
+                "role": "Staller",
+                "movepool": ["icebeam", "protect", "thunderbolt", "toxic"]
+            },
+            {
                 "role": "Bulky Attacker",
                 "movepool": ["focusblast", "icebeam", "rest", "sleeptalk", "thunderbolt", "thunderwave"],
                 "preferredTypes": ["Electric"]

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -5921,7 +5921,7 @@
         "level": 84,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["closecombat", "earthquake", "heavyslam", "rockslide", "stealthrock", "toxic"],
                 "preferredTypes": ["Rock"]
             }

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -4389,10 +4389,6 @@
         "level": 88,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["knockoff", "leafblade", "swordsdance", "xscissor"]
-            },
-            {
                 "role": "Fast Support",
                 "movepool": ["knockoff", "leafblade", "stickyweb", "toxic", "xscissor"]
             }

--- a/data/random-battles/gen7/sets.json
+++ b/data/random-battles/gen7/sets.json
@@ -84,7 +84,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["airslash", "bugbuzz", "energyball", "quiverdance", "sleeppowder"]
+                "movepool": ["airslash", "bugbuzz", "quiverdance", "sleeppowder"]
             },
             {
                 "role": "Z-Move user",
@@ -367,7 +367,7 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["hiddenpowerfighting", "hiddenpowerfire", "hypervoice", "nastyplot", "shadowball", "waterpulse"]
+                "movepool": ["hiddenpowerfighting", "hypervoice", "nastyplot", "shadowball"]
             }
         ]
     },
@@ -1812,7 +1812,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["earthpower", "gigadrain", "hiddenpowerfire", "leafstorm", "nastyplot", "psychic", "uturn"],
+                "movepool": ["earthpower", "gigadrain", "leafstorm", "nastyplot", "psychic", "uturn"],
                 "preferredTypes": ["Psychic"]
             },
             {
@@ -1844,7 +1844,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["dragonpulse", "earthquake", "focusblast", "gigadrain", "hiddenpowerfire", "leafstorm", "substitute"]
+                "movepool": ["dragonpulse", "earthquake", "focusblast", "gigadrain", "leafstorm", "substitute"]
             },
             {
                 "role": "Setup Sweeper",
@@ -2020,7 +2020,7 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["airslash", "bugbuzz", "hydropump", "icebeam", "roost", "stickyweb", "stunspore", "uturn"]
+                "movepool": ["airslash", "bugbuzz", "roost", "scald", "stickyweb", "stunspore", "uturn"]
             }
         ]
     },
@@ -2743,12 +2743,9 @@
         "level": 87,
         "sets": [
             {
-                "role": "Bulky Support",
-                "movepool": ["icebeam", "rest", "sleeptalk", "thunderwave", "toxic"]
-            },
-            {
                 "role": "Bulky Attacker",
-                "movepool": ["icebeam", "rest", "sleeptalk", "thunderbolt"]
+                "movepool": ["focusblast", "icebeam", "rest", "sleeptalk", "thunderbolt", "thunderwave"],
+                "preferredTypes": ["Electric"]
             },
             {
                 "role": "Bulky Setup",
@@ -2914,8 +2911,11 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "icebeam", "knockoff", "psychoboost", "stealthrock", "superpower"],
-                "preferredTypes": ["Fighting"]
+                "movepool": ["extremespeed", "knockoff", "psychoboost", "superpower"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["icebeam", "knockoff", "psychoboost", "superpower"]
             }
         ]
     },
@@ -2924,8 +2924,11 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["extremespeed", "icebeam", "knockoff", "psychoboost", "superpower"],
-                "preferredTypes": ["Fighting"]
+                "movepool": ["extremespeed", "knockoff", "psychoboost", "superpower"]
+            },
+            {
+                "role": "Fast Attacker",
+                "movepool": ["icebeam", "knockoff", "psychoboost", "superpower"]
             }
         ]
     },
@@ -3297,7 +3300,7 @@
             },
             {
                 "role": "Bulky Attacker",
-                "movepool": ["foulplay", "painsplit", "pursuit", "suckerpunch", "willowisp"]
+                "movepool": ["darkpulse", "painsplit", "pursuit", "suckerpunch", "willowisp"]
             }
         ]
     },
@@ -3833,7 +3836,7 @@
         "sets": [
             {
                 "role": "Bulky Setup",
-                "movepool": ["calmmind", "moonblast", "moonlight", "psyshock", "substitute"]
+                "movepool": ["calmmind", "moonblast", "moonlight", "psyshock"]
             },
             {
                 "role": "Bulky Support",
@@ -5477,11 +5480,8 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["ancientpower", "blizzard", "earthpower", "freezedry", "stealthrock"]
-            },
-            {
-                "role": "Bulky Support",
-                "movepool": ["earthpower", "freezedry", "haze", "hypervoice", "stealthrock", "thunderwave"]
+                "movepool": ["ancientpower", "blizzard", "earthpower", "freezedry", "stealthrock", "thunderwave"],
+                "preferredTypes": ["Ground"]
             }
         ]
     },
@@ -5922,7 +5922,8 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["closecombat", "earthquake", "heavyslam", "rockslide", "stealthrock"]
+                "movepool": ["closecombat", "earthquake", "heavyslam", "rockslide", "stealthrock", "toxic"],
+                "preferredTypes": ["Rock"]
             }
         ]
     },

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -310,7 +310,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			if (movePool.includes('spikes')) this.fastPop(movePool, movePool.indexOf('spikes'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
-		if (teamDetails.cleric) {
+		if (teamDetails.statusCure) {
 			if (movePool.includes('aromatherapy')) this.fastPop(movePool, movePool.indexOf('aromatherapy'));
 			if (movePool.includes('healbell')) this.fastPop(movePool, movePool.indexOf('healbell'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
@@ -1494,7 +1494,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				if (set.moves.includes('raindance') || set.ability === 'Drizzle' && !item.onPrimal) teamDetails.rain = 1;
 				if (set.ability === 'Sand Stream') teamDetails.sand = 1;
 				if (set.moves.includes('sunnyday') || set.ability === 'Drought' && !item.onPrimal) teamDetails.sun = 1;
-				if (set.moves.includes('aromatherapy') || set.moves.includes('healbell')) teamDetails.cleric = 1;
+				if (set.moves.includes('aromatherapy') || set.moves.includes('healbell')) teamDetails.statusCure = 1;
 				if (set.moves.includes('spikes')) teamDetails.spikes = (teamDetails.spikes || 0) + 1;
 				if (set.moves.includes('stealthrock')) teamDetails.stealthRock = 1;
 				if (set.moves.includes('stickyweb')) teamDetails.stickyWeb = 1;

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -812,9 +812,6 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			return !counter.get('setup');
 		case 'Slush Rush':
 			return !teamDetails.hail;
-		case 'Snow Warning':
-			// Aurorus
-			return moves.has('hypervoice');
 		case 'Solar Power':
 			return (!counter.get('Special') || !teamDetails.sun || !!species.isMega);
 		case 'Sturdy':

--- a/data/random-battles/gen7/teams.ts
+++ b/data/random-battles/gen7/teams.ts
@@ -310,6 +310,11 @@ export class RandomGen7Teams extends RandomGen8Teams {
 			if (movePool.includes('spikes')) this.fastPop(movePool, movePool.indexOf('spikes'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
+		if (teamDetails.cleric) {
+			if (movePool.includes('aromatherapy')) this.fastPop(movePool, movePool.indexOf('aromatherapy'));
+			if (movePool.includes('healbell')) this.fastPop(movePool, movePool.indexOf('healbell'));
+			if (moves.size + movePool.length <= this.maxMoveCount) return;
+		}
 
 		// Develop additional move lists
 		const badWithSetup = ['defog', 'dragontail', 'haze', 'healbell', 'nuzzle', 'pursuit', 'rapidspin', 'toxic'];
@@ -1489,6 +1494,7 @@ export class RandomGen7Teams extends RandomGen8Teams {
 				if (set.moves.includes('raindance') || set.ability === 'Drizzle' && !item.onPrimal) teamDetails.rain = 1;
 				if (set.ability === 'Sand Stream') teamDetails.sand = 1;
 				if (set.moves.includes('sunnyday') || set.ability === 'Drought' && !item.onPrimal) teamDetails.sun = 1;
+				if (set.moves.includes('aromatherapy') || set.moves.includes('healbell')) teamDetails.cleric = 1;
 				if (set.moves.includes('spikes')) teamDetails.spikes = (teamDetails.spikes || 0) + 1;
 				if (set.moves.includes('stealthrock')) teamDetails.stealthRock = 1;
 				if (set.moves.includes('stickyweb')) teamDetails.stickyWeb = 1;

--- a/data/random-battles/gen8/data.json
+++ b/data/random-battles/gen8/data.json
@@ -384,7 +384,7 @@
     },
     "omastar": {
         "level": 82,
-        "moves": ["earthpower", "hydropump", "icebeam", "shellsmash", "spikes", "stealthrock"],
+        "moves": ["earthpower", "hydropump", "icebeam", "shellsmash"],
         "doublesLevel": 86,
         "doublesMoves": ["earthpower", "icebeam", "muddywater", "shellsmash"]
     },
@@ -1114,7 +1114,7 @@
     },
     "leafeon": {
         "level": 87,
-        "moves": ["doubleedge", "knockoff", "leafblade", "swordsdance", "synthesis", "xscissor"],
+        "moves": ["doubleedge", "knockoff", "leafblade", "swordsdance", "synthesis"],
         "doublesLevel": 86,
         "doublesMoves": ["doubleedge", "knockoff", "leafblade", "protect", "swordsdance"]
     },
@@ -1389,7 +1389,7 @@
     },
     "crustle": {
         "level": 83,
-        "moves": ["earthquake", "shellsmash", "spikes", "stealthrock", "stoneedge", "xscissor"],
+        "moves": ["earthquake", "shellsmash", "stoneedge", "xscissor"],
         "doublesLevel": 84,
         "doublesMoves": ["knockoff", "protect", "rockslide", "shellsmash", "xscissor"]
     },
@@ -1898,7 +1898,7 @@
     },
     "xerneas": {
         "level": 67,
-        "moves": ["focusblast", "geomancy", "moonblast", "psyshock", "thunderbolt"],
+        "moves": ["focusblast", "geomancy", "moonblast", "psyshock"],
         "doublesLevel": 70,
         "doublesMoves": ["dazzlinggleam", "focusblast", "geomancy", "moonblast", "thunderbolt"]
     },

--- a/data/random-battles/gen9/bss-factory-sets.json
+++ b/data/random-battles/gen9/bss-factory-sets.json
@@ -1505,7 +1505,7 @@
                   ["Sucker Punch"],
                   ["Tera Blast"]
               ],
-              "item": ["Choice Band", "Choice Scarf"],
+              "item": ["Choice Band"],
               "nature": "Jolly",
               "evs": {"atk": 252, "spd": 4, "spe": 252},
               "teraType": ["Fairy", "Fire", "Ghost", "Steel"],
@@ -1569,7 +1569,7 @@
                   ["Thunderbolt"],
                   ["Flamethrower", "U-turn"]
               ],
-              "item": ["Choice Scarf", "Choice Specs"],
+              "item": ["Choice Specs"],
               "nature": "Timid",
               "evs": {"spa": 252, "spd": 4, "spe": 252},
               "teraType": ["Electric", "Fighting", "Fire", "Ghost"],
@@ -3801,10 +3801,10 @@
       "sets": [
           {
               "species": "Chansey",
-              "weight": 100,
+              "weight": 70,
               "moves": [
                   ["Seismic Toss"],
-                  ["Shadow Ball", "Stealth Rock", "Thunder Wave"],
+                  ["Shadow Ball"],
                   ["Calm Mind"],
                   ["Soft-Boiled"]
               ],
@@ -3814,6 +3814,22 @@
               "ivs": {"atk": 0},
               "teraType": ["Dark", "Ghost"],
               "ability": ["Natural Cure"]
+          },
+          {
+            "species": "Chansey",
+            "weight": 30,
+            "moves": [
+                ["Seismic Toss"],
+                ["Stealth Rock"],
+                ["Thunder Wave"],
+                ["Soft-Boiled"]
+            ],
+            "item": ["Eviolite"],
+            "nature": "Bold",
+            "evs": {"hp": 12, "def": 252, "spd": 244},
+            "ivs": {"atk": 0},
+            "teraType": ["Dark", "Ghost"],
+            "ability": ["Natural Cure"]
           }
       ]
   },

--- a/data/random-battles/gen9/bss-factory-sets.json
+++ b/data/random-battles/gen9/bss-factory-sets.json
@@ -382,18 +382,34 @@
           },
           {
               "species": "Flutter Mane",
-              "weight": 5,
+              "weight": 2,
               "moves": [
                   ["Moonblast"],
                   ["Shadow Ball"],
                   ["Psyshock"],
-                  ["Energy Ball", "Mystical Fire"]
+                  ["Energy Ball"]
               ],
               "item": ["Assault Vest"],
               "nature": "Modest",
               "evs": {"hp": 164, "def": 28, "spa": 196, "spd": 4, "spe": 116},
               "ivs": {"atk": 0},
-              "teraType": ["Fire", "Grass"],
+              "teraType": ["Grass"],
+              "ability": ["Protosynthesis"]
+          },
+          {
+              "species": "Flutter Mane",
+              "weight": 3,
+              "moves": [
+                  ["Moonblast"],
+                  ["Shadow Ball"],
+                  ["Psyshock"],
+                  ["Mystical Fire"]
+              ],
+              "item": ["Assault Vest"],
+              "nature": "Modest",
+              "evs": {"hp": 164, "def": 28, "spa": 196, "spd": 4, "spe": 116},
+              "ivs": {"atk": 0},
+              "teraType": ["Fire"],
               "ability": ["Protosynthesis"]
           }
       ]
@@ -1961,7 +1977,7 @@
       "sets": [
           {
               "species": "Breloom",
-              "weight": 80,
+              "weight": 85,
               "moves": [
                   ["Bullet Seed"],
                   ["Mach Punch"],
@@ -1976,7 +1992,7 @@
           },
           {
               "species": "Breloom",
-              "weight": 10,
+              "weight": 15,
               "moves": [
                   ["Bullet Seed"],
                   ["Mach Punch"],
@@ -1989,23 +2005,6 @@
               "teraType": ["Fire"],
               "wantsTera": true,
               "ability": ["Technician"]
-          },
-          {
-              "species": "Breloom",
-              "weight": 10,
-              "moves": [
-                  ["Substitute"],
-                  ["Leech Seed", "Toxic"],
-                  ["Spore"],
-                  ["Protect"]
-              ],
-              "item": ["Toxic Orb"],
-              "nature": "Bold",
-              "evs": {"hp": 204, "def": 252, "spd": 48, "spe": 4},
-              "ivs": {"atk": 0},
-              "teraType": ["Fire", "Steel"],
-              "wantsTera": true,
-              "ability": ["Poison Heal"]
           }
       ]
   },
@@ -2787,7 +2786,7 @@
           },
           {
               "species": "Iron Moth",
-              "weight": 20,
+              "weight": 10,
               "moves": [
                   ["Toxic Spikes"],
                   ["Fiery Dance"],
@@ -2798,8 +2797,24 @@
               "nature": "Calm",
               "evs": {"hp": 196, "spd": 132, "spe": 180},
               "ivs": {"atk": 0},
-              "teraType": ["Grass", "Poison"],
+              "teraType": ["Poison"],
               "ability": ["Quark Drive"]
+          },
+          {
+            "species": "Iron Moth",
+            "weight": 10,
+            "moves": [
+                ["Toxic Spikes"],
+                ["Fiery Dance"],
+                ["Morning Sun"],
+                ["Whirlwind"]
+            ],
+            "item": ["Heavy-Duty Boots", "Leftovers"],
+            "nature": "Calm",
+            "evs": {"hp": 196, "spd": 132, "spe": 180},
+            "ivs": {"atk": 0},
+            "teraType": ["Grass"],
+            "ability": ["Quark Drive"]
           },
           {
               "species": "Iron Moth",
@@ -3223,7 +3238,7 @@
               "moves": [
                   ["Moonblast"],
                   ["Encore", "Shadow Ball", "Shadow Sneak"],
-                  ["Aura Sphere", "Close Combat", "Shadow Ball"],
+                  ["Aura Sphere", "Close Combat"],
                   ["Destiny Bond"]
               ],
               "item": ["Booster Energy", "Focus Sash"],
@@ -3239,7 +3254,7 @@
                   ["Moonblast"],
                   ["Close Combat"],
                   ["Encore", "Shadow Ball"],
-                  ["Psychic", "Psyshock", "Shadow Ball", "Thunderbolt"]
+                  ["Psychic", "Psyshock", "Thunderbolt"]
               ],
               "item": ["Booster Energy", "Life Orb"],
               "nature": "Naive",
@@ -3669,21 +3684,51 @@
           },
           {
               "species": "Blissey",
-              "weight": 40,
+              "weight": 13,
               "moves": [
                   ["Calm Mind"],
                   ["Soft-Boiled"],
                   ["Shadow Ball"],
-                  ["Flamethrower", "Stealth Rock", "Tera Blast"]
+                  ["Flamethrower"]
               ],
               "item": ["Leftovers"],
               "nature": "Calm",
               "evs": {"hp": 4, "def": 252, "spd": 252},
               "teraType": ["Dark", "Fire", "Ghost"],
-              "wantsTera": true,
               "ability": ["Natural Cure"]
           },
           {
+            "species": "Blissey",
+            "weight": 13,
+            "moves": [
+                ["Calm Mind"],
+                ["Soft-Boiled"],
+                ["Shadow Ball"],
+                ["Stealth Rock"]
+            ],
+            "item": ["Leftovers"],
+            "nature": "Calm",
+            "evs": {"hp": 4, "def": 252, "spd": 252},
+            "teraType": ["Dark", "Ghost"],
+            "ability": ["Natural Cure"]
+            },
+            {
+                "species": "Blissey",
+                "weight": 14,
+                "moves": [
+                    ["Calm Mind"],
+                    ["Soft-Boiled"],
+                    ["Shadow Ball"],
+                    ["Tera Blast"]
+                ],
+                "item": ["Leftovers"],
+                "nature": "Calm",
+                "evs": {"hp": 4, "def": 252, "spd": 252},
+                "teraType": ["Fighting", "Fire"],
+                "wantsTera": true,
+                "ability": ["Natural Cure"]
+            },
+            {
               "species": "Blissey",
               "weight": 50,
               "moves": [
@@ -3692,12 +3737,12 @@
                   ["Flamethrower", "Shadow Ball"],
                   ["Fling"]
               ],
-              "item": ["Flame Orb", "Light Ball", "Poison Barb"],
+              "item": ["Flame Orb", "Poison Barb"],
               "nature": "Calm",
               "evs": {"hp": 4, "def": 252, "spd": 252},
               "teraType": ["Dark", "Fire"],
               "ability": ["Natural Cure"]
-          }
+            }
       ]
   },
   "ceruledge": {
@@ -4000,7 +4045,7 @@
       "sets": [
           {
               "species": "Kleavor",
-              "weight": 55,
+              "weight": 28,
               "moves": [
                   ["Stone Axe"],
                   ["Night Slash"],
@@ -4010,12 +4055,27 @@
               "item": ["Focus Sash"],
               "nature": "Jolly",
               "evs": {"atk": 252, "spd": 4, "spe": 252},
-              "teraType": ["Bug", "Grass", "Water"],
+              "teraType": ["Grass", "Water"],
               "ability": ["Sharpness"]
           },
           {
+            "species": "Kleavor",
+            "weight": 27,
+            "moves": [
+                ["Stone Axe"],
+                ["Night Slash"],
+                ["Feint", "Trailblaze"],
+                ["U-turn", "X-Scissor"]
+            ],
+            "item": ["Focus Sash"],
+            "nature": "Jolly",
+            "evs": {"atk": 252, "spd": 4, "spe": 252},
+            "teraType": ["Bug", "Grass", "Water"],
+            "ability": ["Sharpness"]
+          },
+          {
               "species": "Kleavor",
-              "weight": 10,
+              "weight": 5,
               "moves": [
                   ["Stone Axe"],
                   ["Night Slash"],
@@ -4025,12 +4085,27 @@
               "item": ["Assault Vest"],
               "nature": "Adamant",
               "evs": {"hp": 140, "atk": 52, "def": 4, "spd": 244, "spe": 68},
-              "teraType": ["Bug", "Grass", "Water"],
+              "teraType": ["Grass", "Water"],
               "ability": ["Sharpness"]
           },
           {
+            "species": "Kleavor",
+            "weight": 5,
+            "moves": [
+                ["Stone Axe"],
+                ["Night Slash"],
+                ["Feint", "Trailblaze"],
+                ["U-turn", "X-Scissor"]
+            ],
+            "item": ["Assault Vest"],
+            "nature": "Adamant",
+            "evs": {"hp": 140, "atk": 52, "def": 4, "spd": 244, "spe": 68},
+            "teraType": ["Bug", "Grass", "Water"],
+            "ability": ["Sharpness"]
+          },
+          {
               "species": "Kleavor",
-              "weight": 35,
+              "weight": 18,
               "moves": [
                   ["Stone Axe"],
                   ["U-turn"],
@@ -4040,8 +4115,23 @@
               "item": ["Choice Scarf"],
               "nature": "Jolly",
               "evs": {"atk": 252, "spd": 4, "spe": 252},
-              "teraType": ["Bug", "Grass"],
+              "teraType": ["Grass"],
               "ability": ["Sharpness"]
+          },
+          {
+            "species": "Kleavor",
+            "weight": 17,
+            "moves": [
+                ["Stone Axe"],
+                ["U-turn"],
+                ["Night Slash"],
+                ["X-Scissor"]
+            ],
+            "item": ["Choice Scarf"],
+            "nature": "Jolly",
+            "evs": {"atk": 252, "spd": 4, "spe": 252},
+            "teraType": ["Bug", "Grass"],
+            "ability": ["Sharpness"]
           }
       ]
   },
@@ -4151,17 +4241,32 @@
       "sets": [
           {
               "species": "Okidogi",
-              "weight": 40,
+              "weight": 15,
+              "moves": [
+                  ["Bulk Up"],
+                  ["Drain Punch"],
+                  ["Knock Off"],
+                  ["Poison Jab"]
+              ],
+              "item": ["Black Sludge", "Rocky Helmet"],
+              "nature": "Adamant",
+              "evs": {"hp": 252, "atk": 156, "spe": 100},
+              "teraType": ["Poison"],
+              "ability": ["Toxic Chain"]
+          },
+          {
+              "species": "Okidogi",
+              "weight": 25,
               "moves": [
                   ["Bulk Up"],
                   ["Drain Punch"],
                   ["Knock Off"],
                   ["Ice Punch", "Poison Jab", "Substitute", "Taunt"]
               ],
-              "item": ["Black Sludge", "Leftovers", "Rocky Helmet"],
+              "item": ["Leftovers", "Rocky Helmet"],
               "nature": "Adamant",
               "evs": {"hp": 252, "atk": 156, "spe": 100},
-              "teraType": ["Flying", "Poison", "Water"],
+              "teraType": ["Flying", "Water"],
               "ability": ["Toxic Chain"]
           },
           {

--- a/data/random-battles/gen9/doubles-sets.json
+++ b/data/random-battles/gen9/doubles-sets.json
@@ -671,6 +671,11 @@
                 "role": "Choice Item user",
                 "movepool": ["Transform"],
                 "teraTypes": ["Bug", "Dark", "Dragon", "Electric", "Fairy", "Fighting", "Fire", "Flying", "Ghost", "Grass", "Ground", "Ice", "Normal", "Poison", "Psychic", "Rock", "Steel", "Water"]
+            },
+            {
+                "role": "Doubles Bulky Attacker",
+                "movepool": ["Transform"],
+                "teraTypes": ["Bug", "Dark", "Dragon", "Electric", "Fairy", "Fighting", "Fire", "Flying", "Ghost", "Grass", "Ground", "Ice", "Normal", "Poison", "Psychic", "Rock", "Steel", "Water"]
             }
         ]
     },
@@ -2658,9 +2663,9 @@
         "level": 76,
         "sets": [
             {
-                "role": "Doubles Bulky Attacker",
-                "movepool": ["Aura Sphere", "Draco Meteor", "Poltergeist", "Shadow Force", "Will-O-Wisp"],
-                "teraTypes": ["Dragon", "Fairy", "Ghost", "Poison"]
+                "role": "Doubles Fast Attacker",
+                "movepool": ["Draco Meteor", "Poltergeist", "Shadow Force", "Shadow Sneak", "Will-O-Wisp"],
+                "teraTypes": ["Dragon", "Fairy", "Ghost", "Poison", "Steel"]
             }
         ]
     },

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -5690,7 +5690,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Brave Bird", "Double-Edge", "Foul Play", "Parting Shot", "Quick Attack"],
-                "teraTypes": ["Dark", "Flying", "Normal"]
+                "teraTypes": ["Flying", "Normal"]
             }
         ]
     },
@@ -5710,7 +5710,7 @@
             {
                 "role": "Wallbreaker",
                 "movepool": ["Brave Bird", "Double-Edge", "Foul Play", "Parting Shot", "Quick Attack"],
-                "teraTypes": ["Dark", "Flying", "Normal"]
+                "teraTypes": ["Flying", "Normal"]
             }
         ]
     },
@@ -6259,12 +6259,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Energy Ball", "Fiery Dance", "Fire Blast", "Sludge Wave", "U-turn"],
-                "teraTypes": ["Fire", "Grass"]
-            },
-            {
-                "role": "Fast Support",
-                "movepool": ["Energy Ball", "Fiery Dance", "Morning Sun", "Sludge Wave", "Toxic Spikes", "U-turn"],
+                "movepool": ["Energy Ball", "Fiery Dance", "Fire Blast", "Morning Sun", "Sludge Wave", "Toxic Spikes", "U-turn"],
                 "teraTypes": ["Fire", "Grass"]
             }
         ]

--- a/data/random-battles/gen9/sets.json
+++ b/data/random-battles/gen9/sets.json
@@ -204,7 +204,7 @@
         "sets": [
             {
                 "role": "Fast Support",
-                "movepool": ["Earthquake", "Stealth Rock", "Stone Edge", "Sucker Punch", "Swords Dance"],
+                "movepool": ["Earthquake", "Stone Edge", "Sucker Punch", "Swords Dance"],
                 "teraTypes": ["Dark", "Fairy", "Flying", "Ghost", "Ground"]
             },
             {
@@ -273,13 +273,8 @@
         "level": 76,
         "sets": [
             {
-                "role": "Fast Bulky Setup",
-                "movepool": ["Bulk Up", "Drain Punch", "Rage Fist", "Rest"],
-                "teraTypes": ["Fairy", "Ghost", "Steel", "Water"]
-            },
-            {
                 "role": "Bulky Setup",
-                "movepool": ["Bulk Up", "Drain Punch", "Gunk Shot", "Rage Fist", "Stone Edge", "Taunt"],
+                "movepool": ["Bulk Up", "Drain Punch", "Gunk Shot", "Rage Fist", "Rest", "Taunt"],
                 "teraTypes": ["Fairy", "Ghost", "Steel", "Water"]
             }
         ]
@@ -494,8 +489,8 @@
             },
             {
                 "role": "Fast Attacker",
-                "movepool": ["Encore", "Focus Blast", "Shadow Ball", "Sludge Wave", "Toxic Spikes", "Will-O-Wisp"],
-                "teraTypes": ["Ghost"]
+                "movepool": ["Destiny Bond", "Encore", "Focus Blast", "Shadow Ball", "Sludge Wave", "Toxic Spikes", "Will-O-Wisp"],
+                "teraTypes": ["Fighting", "Ghost"]
             }
         ]
     },
@@ -831,11 +826,6 @@
                 "role": "Fast Bulky Setup",
                 "movepool": ["Calm Mind", "Freezing Glare", "Hurricane", "Recover"],
                 "teraTypes": ["Steel"]
-            },
-            {
-                "role": "Fast Support",
-                "movepool": ["Future Sight", "Hurricane", "Recover", "U-turn"],
-                "teraTypes": ["Steel"]
             }
         ]
     },
@@ -844,7 +834,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Discharge", "Heat Wave", "Hurricane", "Roost", "U-turn"],
+                "movepool": ["Discharge", "Heat Wave", "Hurricane", "Roost", "U-turn", "Volt Switch"],
                 "teraTypes": ["Electric", "Steel"]
             }
         ]
@@ -1915,7 +1905,7 @@
             {
                 "role": "Setup Sweeper",
                 "movepool": ["Drain Punch", "Knock Off", "Seed Bomb", "Sucker Punch", "Swords Dance"],
-                "teraTypes": ["Dark", "Fighting", "Poison"]
+                "teraTypes": ["Dark", "Poison"]
             }
         ]
     },
@@ -2394,7 +2384,7 @@
             },
             {
                 "role": "Fast Support",
-                "movepool": ["Encore", "Super Fang", "Thunderbolt", "U-turn"],
+                "movepool": ["Discharge", "Encore", "Super Fang", "U-turn"],
                 "teraTypes": ["Flying"]
             }
         ]
@@ -2534,8 +2524,8 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Earthquake", "Fire Fang", "Scale Shot", "Stone Edge", "Swords Dance"],
-                "teraTypes": ["Dragon", "Fire", "Ground"]
+                "movepool": ["Earthquake", "Fire Fang", "Iron Head", "Scale Shot", "Stone Edge", "Swords Dance"],
+                "teraTypes": ["Dragon", "Fire", "Ground", "Steel"]
             }
         ]
     },
@@ -2549,8 +2539,8 @@
             },
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Aura Sphere", "Dark Pulse", "Flash Cannon", "Focus Blast", "Nasty Plot", "Vacuum Wave"],
-                "teraTypes": ["Fighting"]
+                "movepool": ["Aura Sphere", "Flash Cannon", "Focus Blast", "Nasty Plot", "Shadow Ball", "Vacuum Wave"],
+                "teraTypes": ["Fighting", "Ghost"]
             }
         ]
     },
@@ -2634,12 +2624,12 @@
             },
             {
                 "role": "AV Pivot",
-                "movepool": ["Flash Cannon", "Mirror Coat", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Discharge", "Flash Cannon", "Mirror Coat", "Thunderbolt", "Volt Switch"],
                 "teraTypes": ["Flying", "Water"]
             },
             {
                 "role": "Bulky Setup",
-                "movepool": ["Body Press", "Flash Cannon", "Iron Defense", "Thunderbolt"],
+                "movepool": ["Body Press", "Discharge", "Flash Cannon", "Iron Defense", "Thunderbolt"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2739,7 +2729,7 @@
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Earthquake", "Knock Off", "Protect", "Stealth Rock", "Toxic", "Toxic Spikes", "U-turn"],
+                "movepool": ["Earthquake", "Knock Off", "Protect", "Toxic", "Toxic Spikes", "U-turn"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -2875,7 +2865,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Air Slash", "Nasty Plot", "Thunderbolt", "Volt Switch", "Will-O-Wisp"],
-                "teraTypes": ["Electric"]
+                "teraTypes": ["Electric", "Steel"]
             }
         ]
     },
@@ -3123,9 +3113,14 @@
         "level": 69,
         "sets": [
             {
-                "role": "Setup Sweeper",
+                "role": "Fast Bulky Setup",
                 "movepool": ["Earthquake", "Extreme Speed", "Recover", "Shadow Claw", "Swords Dance"],
-                "teraTypes": ["Ghost", "Normal"]
+                "teraTypes": ["Ghost"]
+            },
+            {
+                "role": "Setup Sweeper",
+                "movepool": ["Earthquake", "Extreme Speed", "Recover", "Swords Dance"],
+                "teraTypes": ["Normal"]
             }
         ]
     },
@@ -3418,13 +3413,8 @@
         "level": 77,
         "sets": [
             {
-                "role": "Setup Sweeper",
-                "movepool": ["Ceaseless Edge", "Razor Shell", "Sucker Punch", "Swords Dance"],
-                "teraTypes": ["Dark", "Poison", "Water"]
-            },
-            {
-                "role": "Wallbreaker",
-                "movepool": ["Aqua Jet", "Ceaseless Edge", "Flip Turn", "Razor Shell"],
+                "role": "Fast Attacker",
+                "movepool": ["Ceaseless Edge", "Flip Turn", "Razor Shell", "Sacred Sword", "Sucker Punch", "Swords Dance"],
                 "teraTypes": ["Dark", "Poison", "Water"]
             }
         ]
@@ -3499,7 +3489,7 @@
         "sets": [
             {
                 "role": "Tera Blast user",
-                "movepool": ["Giga Drain", "Pollen Puff", "Quiver Dance", "Sleep Powder", "Tera Blast"],
+                "movepool": ["Giga Drain", "Quiver Dance", "Sleep Powder", "Tera Blast"],
                 "teraTypes": ["Fire", "Rock"]
             },
             {
@@ -3855,7 +3845,7 @@
             {
                 "role": "Fast Bulky Setup",
                 "movepool": ["Bug Buzz", "Fiery Dance", "Fire Blast", "Giga Drain", "Morning Sun", "Quiver Dance"],
-                "teraTypes": ["Fire", "Grass", "Water"]
+                "teraTypes": ["Fire", "Grass"]
             },
             {
                 "role": "Tera Blast user",
@@ -3940,7 +3930,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Focus Blast", "Grass Knot", "Knock Off", "Nasty Plot", "Sludge Wave", "Taunt", "Thunder Wave", "Thunderbolt", "U-turn"],
-                "teraTypes": ["Electric", "Grass"]
+                "teraTypes": ["Electric", "Grass", "Steel"]
             },
             {
                 "role": "Tera Blast user",
@@ -4154,7 +4144,7 @@
         "sets": [
             {
                 "role": "Fast Bulky Setup",
-                "movepool": ["Bug Buzz", "Energy Ball", "Hurricane", "Quiver Dance", "Sleep Powder"],
+                "movepool": ["Bug Buzz", "Hurricane", "Quiver Dance", "Sleep Powder"],
                 "teraTypes": ["Flying"]
             },
             {
@@ -4339,7 +4329,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Drain Punch", "Horn Leech", "Poltergeist", "Rest", "Trick Room", "Wood Hammer"],
+                "movepool": ["Drain Punch", "Horn Leech", "Poltergeist", "Rest", "Trick Room", "Will-O-Wisp", "Wood Hammer"],
                 "teraTypes": ["Fighting"]
             },
             {
@@ -4455,7 +4445,7 @@
             {
                 "role": "Bulky Attacker",
                 "movepool": ["Defog", "Knock Off", "Leaf Blade", "Roost", "Sucker Punch", "Swords Dance", "Triple Arrows", "U-turn"],
-                "teraTypes": ["Steel"]
+                "teraTypes": ["Steel", "Water"]
             }
         ]
     },
@@ -4524,7 +4514,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Bug Buzz", "Energy Ball", "Sticky Web", "Thunderbolt", "Volt Switch"],
+                "movepool": ["Bug Buzz", "Discharge", "Energy Ball", "Sticky Web", "Thunderbolt", "Volt Switch"],
                 "teraTypes": ["Electric"]
             }
         ]
@@ -4534,7 +4524,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Close Combat", "Drain Punch", "Earthquake", "Gunk Shot", "Ice Hammer", "Knock Off"],
+                "movepool": ["Close Combat", "Drain Punch", "Earthquake", "Ice Hammer", "Knock Off"],
                 "teraTypes": ["Fighting", "Ground"]
             }
         ]
@@ -4764,13 +4754,13 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Double-Edge", "Earthquake", "Knock Off", "Sucker Punch", "Superpower", "U-turn", "Wood Hammer"],
-                "teraTypes": ["Dark", "Fighting", "Grass", "Ground"]
+                "movepool": ["Double-Edge", "Earthquake", "Knock Off", "Superpower", "U-turn", "Wood Hammer"],
+                "teraTypes": ["Fighting", "Grass", "Ground"]
             },
             {
                 "role": "Bulky Support",
-                "movepool": ["Body Slam", "Earthquake", "Knock Off", "Rapid Spin", "Sucker Punch", "U-turn"],
-                "teraTypes": ["Dark", "Ghost"]
+                "movepool": ["Body Slam", "Earthquake", "Knock Off", "Rapid Spin", "U-turn"],
+                "teraTypes": ["Ghost"]
             }
         ]
     },
@@ -4918,9 +4908,19 @@
         "level": 77,
         "sets": [
             {
+                "role": "Wallbreaker",
+                "movepool": ["Gunk Shot", "High Jump Kick", "Pyro Ball", "U-turn"],
+                "teraTypes": ["Fire", "Poison"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Court Change", "High Jump Kick", "Pyro Ball", "Sucker Punch"],
+                "teraTypes": ["Fighting", "Fire"]
+            },
+            {
                 "role": "Fast Attacker",
-                "movepool": ["Court Change", "Gunk Shot", "High Jump Kick", "Pyro Ball", "Sucker Punch", "U-turn"],
-                "teraTypes": ["Fighting", "Fire", "Poison"]
+                "movepool": ["Court Change", "Gunk Shot", "High Jump Kick", "Pyro Ball", "U-turn"],
+                "teraTypes": ["Fighting"]
             }
         ]
     },
@@ -5144,7 +5144,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Discharge", "Recover", "Scald", "Spikes", "Toxic Spikes"],
+                "movepool": ["Discharge", "Recover", "Scald", "Spikes", "Thunderbolt", "Toxic Spikes"],
                 "teraTypes": ["Water"]
             },
             {
@@ -5428,9 +5428,14 @@
         "level": 93,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Setup",
                 "movepool": ["Calm Mind", "Encore", "Giga Drain", "Leech Seed", "Psychic", "Psyshock"],
                 "teraTypes": ["Steel"]
+            },
+            {
+                "role": "Bulky Attacker",
+                "movepool": ["Body Press", "Encore", "Giga Drain", "Leech Seed", "Psychic", "Psyshock"],
+                "teraTypes": ["Fighting", "Steel"]
             }
         ]
     },
@@ -5649,7 +5654,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Body Press", "Play Rough", "Protect", "Wish"],
+                "movepool": ["Body Press", "Play Rough", "Protect", "Stomping Tantrum", "Wish"],
                 "teraTypes": ["Steel"]
             }
         ]
@@ -5770,7 +5775,7 @@
             {
                 "role": "Fast Support",
                 "movepool": ["Hurricane", "Roost", "Thunder Wave", "Thunderbolt", "U-turn"],
-                "teraTypes": ["Electric", "Flying"]
+                "teraTypes": ["Electric", "Flying", "Steel", "Water"]
             }
         ]
     },
@@ -5989,7 +5994,7 @@
         "sets": [
             {
                 "role": "Bulky Attacker",
-                "movepool": ["Body Press", "Poltergeist", "Roar", "Shadow Sneak", "Trick", "Will-O-Wisp"],
+                "movepool": ["Body Press", "Play Rough", "Poltergeist", "Roar", "Shadow Sneak", "Trick", "Will-O-Wisp"],
                 "teraTypes": ["Fighting"]
             },
             {
@@ -6040,7 +6045,7 @@
             {
                 "role": "Fast Attacker",
                 "movepool": ["Aqua Cutter", "Aqua Jet", "Flip Turn", "Night Slash", "Psycho Cut"],
-                "teraTypes": ["Water"]
+                "teraTypes": ["Dark", "Water"]
             },
             {
                 "role": "Setup Sweeper",
@@ -6326,6 +6331,11 @@
                 "role": "Fast Attacker",
                 "movepool": ["Calm Mind", "Close Combat", "Moonblast", "Psychic"],
                 "teraTypes": ["Fairy", "Fighting", "Steel"]
+            },
+            {
+                "role": "Wallbreaker",
+                "movepool": ["Close Combat", "Encore", "Knock Off", "Moonblast"],
+                "teraTypes": ["Dark", "Fairy", "Fighting", "Steel"]
             }
         ]
     },
@@ -6380,7 +6390,7 @@
             {
                 "role": "Bulky Support",
                 "movepool": ["Earthquake", "Spikes", "Stealth Rock", "Throat Chop", "Whirlwind"],
-                "teraTypes": ["Ghost", "Ground", "Poison"]
+                "teraTypes": ["Ghost", "Poison"]
             },
             {
                 "role": "Bulky Attacker",
@@ -6639,7 +6649,7 @@
         "sets": [
             {
                 "role": "AV Pivot",
-                "movepool": ["Draco Meteor", "Thunderbolt", "Thunderclap", "Volt Switch"],
+                "movepool": ["Discharge", "Draco Meteor", "Thunderbolt", "Thunderclap", "Volt Switch"],
                 "teraTypes": ["Electric"]
             },
             {

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -1214,6 +1214,7 @@ export class RandomTeams {
 			if (['dragapult', 'tentacruel'].includes(species.id)) return 'Clear Body';
 			if (species.id === 'altaria') return 'Cloud Nine';
 			if (species.id === 'kilowattrel' || species.id === 'meowsticf') return 'Competitive';
+			if (species.id === 'kingambit') return 'Defiant';
 			if (species.id === 'armarouge' && !moves.has('meteorbeam')) return 'Flash Fire';
 			if (species.id === 'talonflame') return 'Gale Wings';
 			if (
@@ -1232,8 +1233,6 @@ export class RandomTeams {
 			if (species.id === 'clefable' && role === 'Doubles Support') return 'Unaware';
 			if (['drifblim', 'hitmonlee', 'sceptile'].includes(species.id) && !moves.has('shedtail')) return 'Unburden';
 			if (abilities.has('Intimidate')) return 'Intimidate';
-
-			if (this.randomChance(1, 2) && species.id === 'kingambit') return 'Defiant';
 
 			// just doubles and multi
 			if (this.format.gameType !== 'freeforall') {
@@ -1335,7 +1334,7 @@ export class RandomTeams {
 		) return 'Weakness Policy';
 		if (['dragonenergy', 'lastrespects', 'waterspout'].some(m => moves.has(m))) return 'Choice Scarf';
 		if (
-			ability === 'Imposter' || (species.id === 'magnezone' && role === 'Fast Attacker')
+			!isDoubles && (ability === 'Imposter' || (species.id === 'magnezone' && role === 'Fast Attacker'))
 		) return 'Choice Scarf';
 		if (species.id === 'rampardos' && (role === 'Fast Attacker' || isDoubles)) return 'Choice Scarf';
 		if (species.id === 'palkia' && counter.get('Special') < 4) return 'Lustrous Orb';

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -508,6 +508,10 @@ export class RandomTeams {
 			if (movePool.includes('spikes')) this.fastPop(movePool, movePool.indexOf('spikes'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
+		if (teamDetails.cleric) {
+			if (movePool.includes('healbell')) this.fastPop(movePool, movePool.indexOf('healbell'));
+			if (moves.size + movePool.length <= this.maxMoveCount) return;
+		}
 
 		if (isDoubles) {
 			const doublesIncompatiblePairs = [
@@ -1940,6 +1944,7 @@ export class RandomTeams {
 			if (set.ability === 'Snow Warning' || set.moves.includes('snowscape') || set.moves.includes('chillyreception')) {
 				teamDetails.snow = 1;
 			}
+			if (set.moves.includes('healbell')) teamDetails.cleric = 1;
 			if (set.moves.includes('spikes') || set.moves.includes('ceaselessedge')) {
 				teamDetails.spikes = (teamDetails.spikes || 0) + 1;
 			}

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -508,7 +508,7 @@ export class RandomTeams {
 			if (movePool.includes('spikes')) this.fastPop(movePool, movePool.indexOf('spikes'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
-		if (teamDetails.cleric) {
+		if (teamDetails.statusCure) {
 			if (movePool.includes('healbell')) this.fastPop(movePool, movePool.indexOf('healbell'));
 			if (moves.size + movePool.length <= this.maxMoveCount) return;
 		}
@@ -1944,7 +1944,7 @@ export class RandomTeams {
 			if (set.ability === 'Snow Warning' || set.moves.includes('snowscape') || set.moves.includes('chillyreception')) {
 				teamDetails.snow = 1;
 			}
-			if (set.moves.includes('healbell')) teamDetails.cleric = 1;
+			if (set.moves.includes('healbell')) teamDetails.statusCure = 1;
 			if (set.moves.includes('spikes') || set.moves.includes('ceaselessedge')) {
 				teamDetails.spikes = (teamDetails.spikes || 0) + 1;
 			}

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -190,7 +190,7 @@ export class RandomTeams {
 		this.moveEnforcementCheckers = {
 			Bug: (movePool, moves, abilities, types, counter) => (
 				movePool.includes('megahorn') || movePool.includes('xscissor') ||
-				(!counter.get('Bug') && types.includes('Electric'))
+				(!counter.get('Bug') && (types.includes('Electric') || types.includes('Psychic')))
 			),
 			Dark: (
 				movePool, moves, abilities, types, counter, species, teamDetails, isLead, isDoubles, teraType, role
@@ -226,7 +226,7 @@ export class RandomTeams {
 				if (counter.get('Psychic')) return false;
 				if (movePool.includes('calmmind') || abilities.has('Strong Jaw')) return true;
 				if (isDoubles && movePool.includes('psychicfangs')) return true;
-				return abilities.has('Psychic Surge') || ['Electric', 'Fighting', 'Fire', 'Grass', 'Poison'].some(m => types.includes(m));
+				return abilities.has('Psychic Surge') || ['Bug', 'Electric', 'Fighting', 'Fire', 'Grass', 'Poison'].some(m => types.includes(m));
 			},
 			Rock: (movePool, moves, abilities, types, counter, species) => !counter.get('Rock') && species.baseStats.atk >= 80,
 			Steel: (movePool, moves, abilities, types, counter, species, teamDetails, isLead, isDoubles) => (
@@ -565,6 +565,7 @@ export class RandomTeams {
 			['fireblast', ['fierydance', 'flamethrower']],
 			['lavaplume', 'magmastorm'],
 			['thunderpunch', 'wildcharge'],
+			['thunderbolt', 'discharge'],
 			['gunkshot', ['direclaw', 'poisonjab', 'sludgebomb']],
 			['aurasphere', 'focusblast'],
 			['closecombat', 'drainpunch'],
@@ -1538,8 +1539,8 @@ export class RandomTeams {
 		if (moves.has('outrage')) return 'Lum Berry';
 		if (moves.has('protect') && ability !== 'Speed Boost') return 'Leftovers';
 		if (
-			role === 'Fast Support' && isLead &&
-			!counter.get('recovery') && !counter.get('recoil') &&
+			role === 'Fast Support' && isLead && !counter.get('recovery') && !counter.get('recoil') &&
+			(counter.get('hazards') || counter.get('setup')) &&
 			(species.baseStats.hp + species.baseStats.def + species.baseStats.spd) < 258
 		) return 'Focus Sash';
 		if (

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -584,8 +584,6 @@ export class RandomTeams {
 			['nastyplot', ['rockslide', 'knockoff']],
 			// Persian
 			['switcheroo', 'fakeout'],
-			// Beartic
-			['snowscape', 'swordsdance'],
 			// Amoonguss, though this can work well as a general rule later
 			['toxic', 'clearsmog'],
 			// Chansey and Blissey

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -263,11 +263,6 @@
         "level": 7,
         "sets": [
             {
-                "role": "Wallbreaker",
-                "movepool": ["Flamethrower", "Focus Blast", "Sunny Day", "Weather Ball"],
-                "teraTypes": ["Fire"]
-            },
-            {
                 "role": "Setup Sweeper",
                 "movepool": ["Brick Break", "Dragon Dance", "Flare Blitz", "Outrage", "Thunder Punch"],
                 "teraTypes": ["Dragon", "Electric", "Fighting"]
@@ -389,7 +384,7 @@
         "sets": [
             {
                 "role": "Setup Sweeper",
-                "movepool": ["Aqua Jet", "Brick Break", "Crabhammer", "Dragon Dance", "Knock Off", "X-Scissor"],
+                "movepool": ["Aqua Jet", "Crabhammer", "Dragon Dance", "Knock Off"],
                 "teraTypes": ["Water"]
             }
         ]
@@ -834,7 +829,7 @@
         "sets": [
             {
                 "role": "Bulky Support",
-                "movepool": ["Foul Play", "Giga Drain", "Leaf Storm", "Sludge Bomb", "Spore", "Stun Spore"],
+                "movepool": ["Clear Smog", "Foul Play", "Giga Drain", "Leaf Storm", "Sludge Bomb", "Spore", "Stun Spore"],
                 "teraTypes": ["Steel", "Water"]
             },
             {
@@ -848,7 +843,7 @@
         "level": 6,
         "sets": [
             {
-                "role": "Setup Sweeper",
+                "role": "Bulky Setup",
                 "movepool": ["Crunch", "Icicle Spear", "Outrage", "Swords Dance"],
                 "teraTypes": ["Dragon", "Fairy", "Ice"]
             }
@@ -1538,7 +1533,7 @@
         "level": 6,
         "sets": [
             {
-                "role": "Setup Sweeper",
+                "role": "Bulky Setup",
                 "movepool": ["High Jump Kick", "Knock Off", "Poison Jab", "Stone Edge", "Swords Dance"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             },
@@ -2108,8 +2103,13 @@
         "level": 5,
         "sets": [
             {
-                "role": "Bulky Attacker",
-                "movepool": ["Close Combat", "Dual Wingbeat", "Pounce", "Swords Dance", "U-turn"],
+                "role": "Setup Sweeper",
+                "movepool": ["Bug Bite", "Close Combat", "Dual Wingbeat", "Swords Dance"],
+                "teraTypes": ["Fighting"]
+            },
+            {
+                "role": "Fast Support",
+                "movepool": ["Close Combat", "Defog", "Dual Wingbeat", "U-turn"],
                 "teraTypes": ["Fighting"]
             }
         ]
@@ -2493,19 +2493,14 @@
         "level": 6,
         "sets": [
             {
-                "role": "Fast Attacker",
-                "movepool": ["Flip Turn", "Ice Beam", "Surf", "Water Spout"],
-                "teraTypes": ["Water"]
-            },
-            {
                 "role": "Bulky Support",
                 "movepool": ["Flip Turn", "Ice Beam", "Rapid Spin", "Surf", "Yawn"],
                 "teraTypes": ["Poison", "Steel"]
             },
             {
-                "role": "Bulky Setup",
-                "movepool": ["Body Slam", "Ice Beam", "Shell Smash", "Surf"],
-                "teraTypes": ["Ice", "Normal", "Water"]
+                "role": "Tera Blast user",
+                "movepool": ["Ice Beam", "Shell Smash", "Surf", "Tera Blast"],
+                "teraTypes": ["Electric", "Grass"]
             }
         ]
     },
@@ -2683,7 +2678,7 @@
         "level": 6,
         "sets": [
             {
-                "role": "Fast Support",
+                "role": "Bulky Support",
                 "movepool": ["Earth Power", "Giga Drain", "Knock Off", "Leaf Storm", "Rapid Spin", "Spikes", "Spore", "Toxic Spikes"],
                 "teraTypes": ["Water"]
             }

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -1499,7 +1499,7 @@
         "sets": [
             {
                 "role": "Wallbreaker",
-                "movepool": ["Fake Out", "Fury Swipes", "Knock Off", "Play Rough", "Thunder Wave", "U-turn"],
+                "movepool": ["Double-Edge", "Fake Out", "Knock Off", "Play Rough", "Thunder Wave", "U-turn"],
                 "teraTypes": ["Normal"]
             }
         ]
@@ -1733,9 +1733,14 @@
         "level": 7,
         "sets": [
             {
-                "role": "Bulky Support",
+                "role": "Bulky Attacker",
                 "movepool": ["Encore", "Giga Drain", "Leaf Storm", "Pollen Puff", "Sleep Powder", "Stun Spore", "Synthesis"],
                 "teraTypes": ["Poison", "Steel", "Water"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Giga Drain", "Leaf Storm", "Stun Spore", "Synthesis", "Tera Blast"],
+                "teraTypes": ["Fire", "Rock"]
             }
         ]
     },
@@ -2374,7 +2379,7 @@
         "sets": [
             {
                 "role": "Fast Attacker",
-                "movepool": ["Close Combat", "Gunk Shot", "Lash Out", "Swords Dance", "Toxic Spikes"],
+                "movepool": ["Close Combat", "Gunk Shot", "Swords Dance", "Throat Chop", "Toxic Spikes"],
                 "teraTypes": ["Dark", "Fighting", "Poison"]
             }
         ]

--- a/data/random-battles/gen9baby/sets.json
+++ b/data/random-battles/gen9baby/sets.json
@@ -1461,6 +1461,11 @@
                 "role": "Bulky Attacker",
                 "movepool": ["Dazzling Gleam", "Thunder Wave", "Thunderbolt", "Volt Switch"],
                 "teraTypes": ["Fairy"]
+            },
+            {
+                "role": "Tera Blast user",
+                "movepool": ["Agility", "Dazzling Gleam", "Tera Blast", "Thunderbolt"],
+                "teraTypes": ["Ice"]
             }
         ]
     },

--- a/data/random-battles/gen9baby/teams.ts
+++ b/data/random-battles/gen9baby/teams.ts
@@ -439,6 +439,7 @@ export class RandomBabyTeams extends RandomTeams {
 		if (species.id === 'blitzle') return 'Sap Sipper';
 		if (species.id === 'chinchou') return 'Volt Absorb';
 		if (species.id === 'deerling') return 'Serene Grace';
+		if (species.id === 'doduo') return 'Early Bird';
 		if (species.id === 'geodudealola') return 'Galvanize';
 		if (species.id === 'growlithehisui') return 'Rock Head';
 		if (species.id === 'gligar') return 'Immunity';
@@ -541,12 +542,13 @@ export class RandomBabyTeams extends RandomTeams {
 
 		if (moves.has('acrobatics')) return ability === 'Unburden' ? 'Oran Berry' : '';
 		if (moves.has('auroraveil') || moves.has('lightscreen') && moves.has('reflect')) return 'Light Clay';
-		if (moves.has('rest') && moves.has('sleeptalk')) return 'Eviolite';
 
 		if (ability === 'Guts' && moves.has('facade')) return 'Flame Orb';
 		if (ability === 'Quick Feet') return 'Toxic Orb';
 
-		if (this.dex.getEffectiveness('Rock', species) >= 2) return 'Heavy-Duty Boots';
+		if (
+			this.dex.getEffectiveness('Rock', species) >= 2 && this.dex.getEffectiveness('Ground', species) >= 0
+		) return 'Heavy-Duty Boots';
 		if (['Harvest', 'Ripen', 'Unburden'].includes(ability) || moves.has('bellydrum')) return 'Oran Berry';
 	}
 

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -530,6 +530,7 @@ namespace RandomTeamsTypes {
 		illusion?: number;
 		statusCure?: number;
 		teraBlast?: number;
+		cleric?: number;
 	}
 	export interface FactoryTeamDetails {
 		megaCount?: number;

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -530,7 +530,6 @@ namespace RandomTeamsTypes {
 		illusion?: number;
 		statusCure?: number;
 		teraBlast?: number;
-		cleric?: number;
 	}
 	export interface FactoryTeamDetails {
 		megaCount?: number;


### PR DESCRIPTION
Please merge sometime Sunday.

**All Gens**:
There can now only be one Heal Bell/Aromatherapy user per team.

**Gen 9 Random Battle**
-Cinderace has been split into three sets such that it will always get High Jump Kick and Choice Band Sucker Punch no longer exists.
-Iron Valiant now has a third set of Wallbreaker with Close Combat, Moonblast, Knock Off, and Encore with a Life Orb.
-Calyrex has a second set of Bulky Attacker with Body Press. Its old set has been changed to Bulky Setup, enforcing Calm Mind and both STAB attacks.
-Arceus-Normal now has a second set that's just Swords Dance Life Orb EQ + Recover Tera Normal. Its first set is now always Tera Ghost with Shadow Claw and can get Leftovers when it has Recover.
-Iron Moth's sets have been merged together. This does nothing but allow Fire Blast + Toxic Spikes, basically.
-Beartic can now get both Snowscape and Swords Dance together.
-Focus Sash now only generates on Fast Support Pokemon with entry hazards or a setup move.
-Rabsca now always has both STAB attacks.
-Thunderbolt and Discharge now cannot generate together.
-Special Pincurchin, non-Choice Scarf Magnezone, AV Raging Bolt, and Vikavolt now randomly choose between Thunderbolt and Discharge.
-Wallbreaker Trevenant: +Will-O-Wisp
-Setup Sweeper Cacturne: -Tera Fighting (Gets Knock Off more often)
-Vivillon: -Energy Ball (now always gets Sleep Powder)
-Fast Attacker Veluza: +Tera Dark
-Dugtrio: -Stealth Rock
-Zapdos: +Volt Switch
-Crabominable: -Gunk Shot
-Fast Attacker Gengar: +Tera Fighting, +Destiny Bond
-Annihilape: -Stone Edge. Sets merged together.
-Gliscor: -Stealth Rock
-Nasty Plot Lucario: -Dark Pulse, +Shadow Ball, +Tera Ghost
-Dachsbun: +Stomping Tantrum
-Boots Pachirisu: -Thunderbolt, +Discharge
-Bulky Attacker Houndstone: +Play Rough (Appears on Choice Band)
-Komala (both sets): -Sucker Punch, -Tera Dark
-Tera Blast Lilligant: -Pollen Puff
-Setup Sweeper Garchomp: +Tera Steel, +Iron Head
-Hustle Squawkabilly: -Tera Dark
-Hisuian Decidueye: +Tera Water
-Thundurus set 1: +Tera Steel
-Rotom-Fan: +Tera Steel
-Kilowattrel: +Tera Steel, +Tera Water
-Ting-Lu: -Tera Ground
-Non-Tera Blast Volcarona: -Tera Water

Reversions:
-Hisuian Samurott has been changed back to how it was before May. It now gets Choice Scarf and Sacred Sword again.
-Galarian Articuno no longer runs the Future Sight set.

**Doubles:**
-Ditto, of all things, now has a second set with Sitrus Berry instead of Choice Scarf.
-Kingambit will no longer run Supreme Overlord.
-Giratina-Origin now runs Shadow Sneak over Aura Sphere and can run Tera Steel.

**Baby Rands:**
-Larvesta now runs Eviolite.
-Toedscool's role has been changed to Bulky Support, enforcing Rapid Spin.
-Frigibax and Mienfoo's Setup Sweeper roles have been changed to Bulky Setup, giving them Eviolite.
-Petilil now has a Tera Blast Fire/Rock set with Stun Spore. Its other set will now always get two attacks at least.
-Scyther's sets now match its Gen 9 Random Battle sets.
-Sunny Day Charmander no longer exists.
-Choice Scarf Squirtle no longer exists. Shell Smash Squirtle is now Tera Blast Grass/Electric instead of Body Slam.
-Mareep now runs an Eviolite Tera Blast Ice Agility set.
-Doduo now always runs Early Bird.
-Foongus set 1: +Clear Smog
-Corphish: -Brick Break, -X-Scissor
-Hisuian Sneasel: -Lash Out, +Throat Chop
-Meowth: -Fury Swipes, +Double-Edge

**Gen 9 BSS Factory:**
-Blissey no longer runs Light Ball Fling or Tera Blast Ghost or Dark. Blissey can now run Tera Blast Fighting.
-Chansey can no longer runs Calm Mind with no special attacks. Thunder Wave and Stealth Rock now appear together on the same set instead.
-Breloom no longer runs its attackless Poison Heal set.
-Black Sludge will no longer generate on anything that is not Tera Poison.
-Kleavor will now only get Tera Bug when it has U-turn or X-Scissor.
-Mystical Fire an Energy Ball will now always appear with their respective Tera Types on Assault Vest Flutter Mane.
-Iron Valiant can no longer run two instances of Shadow Ball, nor can it run Shadow Ball + Shadow Sneak.
-Dragapult no longer runs Choice Scarf.
-Yes I know the indentation for BSSF sets is wrong i do not have time to fix it right now

**Old Gens**
-In Gen 8, Omastar and Crustle no longer run entry hazards.
-In gen 8, Xerneas no longer runs Choice items or Thunderbolt.
-In Gens 4-7, Celebi no longer runs HP Fire.
-In Gens 4-7, Cresselia no longer runs Substitute.
-In Gens 4-7, Deoxys and Deoxys-Attack now always run Psycho Boost, Superpower, and coverage for Psychic-types, rolling between Ice Beam and Extreme Speed in the last slot.
-In Gens 5-7, Spiritomb now runs Dark Pulse instead of Foul Play.
-In Gens 6-7, Webs Masquerain now runs Scald instead of Hydro Pump and Ice Beam
-In Gens 6-7, Regice's Bulky Support set was removed and its Bulky Attacker set has been changed to match its Gen 5 set.
-In Gens 6-7, Mega Sceptile no longer runs HP Fire.
-In Gens 6-7, Nasty Plot Persian no longer runs HP Fire or Water Pulse.
-In Gens 6-7, Butterfree will always run Sleep Powder now. (by no longer having Energy Ball
-In Gens 6-7, Leavanny will now always run Sticky Web, unless the team already has a Sticky Web user.
-In Gens 6-7, Regice now runs an additional Toxic + Protect Staller set.
-In Gen 7, Mudsdale now always runs Rock Slide and can run Toxic.
-In Gen 7, Bruxish now always runs Crunch.
-In Gen 7, Aurorus no longer runs Refrigerate. Blizzard Aurorus now always runs Earth Power and can run Thunder Wave.
-In Gen 6, Aurorus's sets both now run the same moves aside from their main Ice STAB and both sets always run Earth Power.
-In Gens 4-5, Choice Band Azumarill always runs Ice Punch.
-In Gens 4-5, Giratina-Origin no longer runs HP Fire.
-In Gen 5, Magic Guard Clefable is now always Life Orb.
-In Gen 5, Mawile now runs Fire Blast when it does not have Swords Dance.
-In Gen 4, Cresselia now runs Signal Beam on its Calm Mind + Moonlight set.
-In Gen 3, Calm Mind Hypno no longer runs WishTect.