### PR TITLE
Refactor types for Lowercase<string>

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -17,7 +17,7 @@ New sections will be added to the bottom of the specified column.
 The column value will be ignored for repeat sections.
 */
 
-export const Formats: FormatList = [
+export const Formats: import('../sim/dex-formats').FormatList = [
 
 	// S/V Singles
 	///////////////////////////////////////////////////////////////////

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -32,7 +32,7 @@ Ratings and how they work:
 
 */
 
-	export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
+export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	noability: {
 		isNonstandard: "Past",
 		flags: {},

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -32,7 +32,7 @@ Ratings and how they work:
 
 */
 
-export const Abilities: {[abilityid: IDEntry]: AbilityData} = {
+	export const Abilities: import('../sim/dex-abilities').AbilityDataTable = {
 	noability: {
 		isNonstandard: "Past",
 		flags: {},

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -32,7 +32,7 @@ Ratings and how they work:
 
 */
 
-export const Abilities: {[abilityid: string]: AbilityData} = {
+export const Abilities: {[abilityid: IDEntry]: AbilityData} = {
 	noability: {
 		isNonstandard: "Past",
 		flags: {},

--- a/data/aliases.ts
+++ b/data/aliases.ts
@@ -1,4 +1,4 @@
-export const Aliases: {[alias: string]: string} = {
+export const Aliases: {[alias: IDEntry]: string} = {
 	// formats
 	randbats: "[Gen 9] Random Battle",
 	uber: "[Gen 9] Ubers",

--- a/data/aliases.ts
+++ b/data/aliases.ts
@@ -1,4 +1,4 @@
-export const Aliases: {[alias: IDEntry]: string} = {
+export const Aliases: import('../sim/dex').AliasesTable = {
 	// formats
 	randbats: "[Gen 9] Random Battle",
 	uber: "[Gen 9] Ubers",

--- a/data/cg-team-data.ts
+++ b/data/cg-team-data.ts
@@ -11,7 +11,7 @@ export const ABILITY_MOVE_BONUSES: {[abilityID: IDEntry]: {[moveID: IDEntry]: nu
 	contrary: {terablast: 2},
 };
 // Bonuses to move ratings by move type
-export const ABILITY_MOVE_TYPE_BONUSES: {[abilityID: IDEntry]: {[typeID: string]: number}} = {
+export const ABILITY_MOVE_TYPE_BONUSES: {[abilityID: IDEntry]: {[typeName: string]: number}} = {
 	darkaura: {Dark: 1.33},
 	dragonsmaw: {Dragon: 1.5},
 	fairyaura: {Fairy: 1.33},

--- a/data/cg-team-data.ts
+++ b/data/cg-team-data.ts
@@ -1,17 +1,17 @@
 // Data for computer-generated teams
 
-export const MOVE_PAIRINGS: {[moveID: string]: string} = {
+export const MOVE_PAIRINGS: {[moveID: IDEntry]: IDEntry} = {
 	rest: 'sleeptalk',
 	sleeptalk: 'rest',
 };
 
 // Bonuses to move ratings by ability
-export const ABILITY_MOVE_BONUSES: {[abilityID: string]: {[moveID: string]: number}} = {
+export const ABILITY_MOVE_BONUSES: {[abilityID: IDEntry]: {[moveID: IDEntry]: number}} = {
 	drought: {sunnyday: 0.2, solarbeam: 2},
 	contrary: {terablast: 2},
 };
 // Bonuses to move ratings by move type
-export const ABILITY_MOVE_TYPE_BONUSES: {[abilityID: string]: {[typeID: string]: number}} = {
+export const ABILITY_MOVE_TYPE_BONUSES: {[abilityID: IDEntry]: {[typeID: string]: number}} = {
 	darkaura: {Dark: 1.33},
 	dragonsmaw: {Dragon: 1.5},
 	fairyaura: {Fairy: 1.33},
@@ -31,7 +31,7 @@ export const ABILITY_MOVE_TYPE_BONUSES: {[abilityID: string]: {[typeID: string]:
 };
 // For moves whose quality isn't obvious from data
 // USE SPARINGLY!
-export const HARDCODED_MOVE_WEIGHTS: {[moveID: string]: number} = {
+export const HARDCODED_MOVE_WEIGHTS: {[moveID: IDEntry]: number} = {
 	// Fails unless user is asleep
 	snore: 0,
 	// Hard to use

--- a/data/cg-teams.ts
+++ b/data/cg-teams.ts
@@ -149,14 +149,14 @@ export default class TeamGenerator {
 	}
 
 	protected makeSet(species: Species, teamStats: TeamStats): PokemonSet {
-		const abilityPool = Object.values(species.abilities);
+		const abilityPool: string[] = Object.values(species.abilities);
 		const abilityWeights = abilityPool.map(a => this.getAbilityWeight(this.dex.abilities.get(a)));
 		const ability = this.weightedRandomPick(abilityPool, abilityWeights);
 		const level = this.forceLevel || TeamGenerator.getLevel(species);
 
 		const moves: Move[] = [];
 
-		let movePool: string[] = [...this.dex.species.getMovePool(species.id)];
+		let movePool: IDEntry[] = [...this.dex.species.getMovePool(species.id)];
 		if (!movePool.length) throw new Error(`No moves for ${species.id}`);
 
 		// Consider either the top 15 moves or top 30% of moves, whichever is greater.
@@ -173,7 +173,7 @@ export default class TeamGenerator {
 		// this is just a second reference the array because movePool gets set to point to a new array before the old one
 		// gets mutated
 		const movePoolCopy = movePool;
-		let interimMovePool: {move: string, weight: number}[] = [];
+		let interimMovePool: {move: IDEntry, weight: number}[] = [];
 		while (moves.length < 4 && movePool.length) {
 			let weights;
 			if (!movePoolIsTrimmed) {
@@ -514,8 +514,8 @@ export default class TeamGenerator {
 		if (move.category === 'Special' && hasPhysicalSetup) powerEstimate *= 0.7;
 
 		const abilityBonus = (
-			((ABILITY_MOVE_BONUSES[ability] || {})[move.id] || 1) *
-			((ABILITY_MOVE_TYPE_BONUSES[ability] || {})[moveType] || 1)
+			((ABILITY_MOVE_BONUSES[toID(ability)] || {})[move.id] || 1) *
+			((ABILITY_MOVE_TYPE_BONUSES[toID(ability)] || {})[moveType] || 1)
 		);
 
 		let weight = powerEstimate * abilityBonus;

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[id: IDEntry]: ConditionData} = {
+export const Conditions: import('../sim/dex-conditions').ConditionDataTable = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[k: IDEntry]: ConditionData} = {
+export const Conditions: {[id: IDEntry]: ConditionData} = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[k: string]: ConditionData} = {
+export const Conditions: {[k: IDEntry]: ConditionData} = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',

--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: IDEntry]: SpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: SpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: SpeciesFormatsData} = {
+export const FormatsData: import('../sim/dex-species').SpeciesFormatsDataTable = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: SpeciesFormatsData} = {
+export const FormatsData: {[k: IDEntry]: SpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/items.ts
+++ b/data/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[itemid: IDEntry]: ItemData} = {
+export const Items: import('../sim/dex-items').ItemDataTable = {
 	abilityshield: {
 		name: "Ability Shield",
 		spritenum: 746,

--- a/data/items.ts
+++ b/data/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[itemid: string]: ItemData} = {
+export const Items: {[itemid: IDEntry]: ItemData} = {
 	abilityshield: {
 		name: "Ability Shield",
 		spritenum: 746,

--- a/data/learnsets.ts
+++ b/data/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[id: IDEntry]: LearnsetData} = {
+export const Learnsets: import('../sim/dex-species').LearnsetDataTable = {
 	missingno: {
 		learnset: {
 			blizzard: ["3L1"],

--- a/data/learnsets.ts
+++ b/data/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[k: string]: LearnsetData} = {
+export const Learnsets: {[k: IDEntry]: LearnsetData} = {
 	missingno: {
 		learnset: {
 			blizzard: ["3L1"],

--- a/data/learnsets.ts
+++ b/data/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[k: IDEntry]: LearnsetData} = {
+export const Learnsets: {[id: IDEntry]: LearnsetData} = {
 	missingno: {
 		learnset: {
 			blizzard: ["3L1"],

--- a/data/mods/fullpotential/abilities.ts
+++ b/data/mods/fullpotential/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
+export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	unaware: {
 		inherit: true,
 		onAnyModifyBoost(boosts, pokemon) {

--- a/data/mods/fullpotential/abilities.ts
+++ b/data/mods/fullpotential/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
 	unaware: {
 		inherit: true,
 		onAnyModifyBoost(boosts, pokemon) {

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -8,7 +8,7 @@
  * under certain conditions and re-applied under other conditions.
  */
 
-export const Conditions: {[id: string]: ModdedConditionData} = {
+export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',

--- a/data/mods/gen1/conditions.ts
+++ b/data/mods/gen1/conditions.ts
@@ -8,7 +8,7 @@
  * under certain conditions and re-applied under other conditions.
  */
 
-export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
+export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDataTable = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',

--- a/data/mods/gen1/formats-data.ts
+++ b/data/mods/gen1/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen1/formats-data.ts
+++ b/data/mods/gen1/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -3,7 +3,7 @@
  * Some moves have had major changes, such as Bite's typing.
  */
 
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	acid: {
 		inherit: true,
 		secondary: {

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -3,7 +3,7 @@
  * Some moves have had major changes, such as Bite's typing.
  */
 
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	acid: {
 		inherit: true,
 		secondary: {

--- a/data/mods/gen1/pokedex.ts
+++ b/data/mods/gen1/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
 	missingno: {
 		inherit: true,
 		baseStats: {hp: 33, atk: 136, def: 0, spa: 6, spd: 6, spe: 29},

--- a/data/mods/gen1/pokedex.ts
+++ b/data/mods/gen1/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
+export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable = {
 	missingno: {
 		inherit: true,
 		baseStats: {hp: 33, atk: 136, def: 0, spa: 6, spd: 6, spe: 29},

--- a/data/mods/gen1/rulesets.ts
+++ b/data/mods/gen1/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
+export const Rulesets: import('../../../sim/dex-formats').ModdedFormatDataTable = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',

--- a/data/mods/gen1/rulesets.ts
+++ b/data/mods/gen1/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[k: string]: ModdedFormatData} = {
+export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',

--- a/data/mods/gen1/typechart.ts
+++ b/data/mods/gen1/typechart.ts
@@ -6,7 +6,7 @@
  * Psychic was immune to ghost
  */
 
-export const TypeChart: {[id: IDEntry]: ModdedTypeData | null} = {
+export const TypeChart: import('../../../sim/dex-data').ModdedTypeDataTable = {
 	bug: {
 		damageTaken: {
 			Bug: 0,

--- a/data/mods/gen1/typechart.ts
+++ b/data/mods/gen1/typechart.ts
@@ -6,7 +6,7 @@
  * Psychic was immune to ghost
  */
 
-export const TypeChart: {[k: string]: ModdedTypeData | null} = {
+export const TypeChart: {[id: IDEntry]: ModdedTypeData | null} = {
 	bug: {
 		damageTaken: {
 			Bug: 0,

--- a/data/mods/gen1jpn/conditions.ts
+++ b/data/mods/gen1jpn/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
+export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDataTable = {
 	invulnerability: {
 		// Dig/Fly
 		name: 'invulnerability',

--- a/data/mods/gen1jpn/conditions.ts
+++ b/data/mods/gen1jpn/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[k: string]: ModdedConditionData} = {
+export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
 	invulnerability: {
 		// Dig/Fly
 		name: 'invulnerability',

--- a/data/mods/gen1jpn/moves.ts
+++ b/data/mods/gen1jpn/moves.ts
@@ -2,7 +2,7 @@
  * The japanese version of Blizzard in Gen 1 had a 30% chance to freeze
  */
 
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	blizzard: {
 		inherit: true,
 		secondary: {

--- a/data/mods/gen1jpn/moves.ts
+++ b/data/mods/gen1jpn/moves.ts
@@ -2,7 +2,7 @@
  * The japanese version of Blizzard in Gen 1 had a 30% chance to freeze
  */
 
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	blizzard: {
 		inherit: true,
 		secondary: {

--- a/data/mods/gen1jpn/rulesets.ts
+++ b/data/mods/gen1jpn/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
+export const Rulesets: import('../../../sim/dex-formats').ModdedFormatDataTable = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',

--- a/data/mods/gen1jpn/rulesets.ts
+++ b/data/mods/gen1jpn/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[k: string]: ModdedFormatData} = {
+export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',

--- a/data/mods/gen1stadium/conditions.ts
+++ b/data/mods/gen1stadium/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[k: string]: ModdedConditionData} = {
+export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',

--- a/data/mods/gen1stadium/conditions.ts
+++ b/data/mods/gen1stadium/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
+export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDataTable = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',

--- a/data/mods/gen1stadium/formats-data.ts
+++ b/data/mods/gen1stadium/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen1stadium/formats-data.ts
+++ b/data/mods/gen1stadium/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen1stadium/moves.ts
+++ b/data/mods/gen1stadium/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	bide: {
 		inherit: true,
 		priority: 0,

--- a/data/mods/gen1stadium/moves.ts
+++ b/data/mods/gen1stadium/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	bide: {
 		inherit: true,
 		priority: 0,

--- a/data/mods/gen1stadium/rulesets.ts
+++ b/data/mods/gen1stadium/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
+export const Rulesets: import('../../../sim/dex-formats').ModdedFormatDataTable = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',

--- a/data/mods/gen1stadium/rulesets.ts
+++ b/data/mods/gen1stadium/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[k: string]: ModdedFormatData} = {
+export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',

--- a/data/mods/gen2/conditions.ts
+++ b/data/mods/gen2/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[k: string]: ModdedConditionData} = {
+export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',

--- a/data/mods/gen2/conditions.ts
+++ b/data/mods/gen2/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
+export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDataTable = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',

--- a/data/mods/gen2/formats-data.ts
+++ b/data/mods/gen2/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen2/formats-data.ts
+++ b/data/mods/gen2/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen2/items.ts
+++ b/data/mods/gen2/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	berryjuice: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/gen2/items.ts
+++ b/data/mods/gen2/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	berryjuice: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/gen2/learnsets.ts
+++ b/data/mods/gen2/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
+export const Learnsets: import('../../../sim/dex-species').ModdedLearnsetDataTable = {
 	missingno: {
 		learnset: {
 			blizzard: ["1M"],

--- a/data/mods/gen2/learnsets.ts
+++ b/data/mods/gen2/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[k: string]: ModdedLearnsetData} = {
+export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
 	missingno: {
 		learnset: {
 			blizzard: ["1M"],

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -2,7 +2,7 @@
  * Gen 2 moves
  */
 
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	aeroblast: {
 		inherit: true,
 		critRatio: 3,

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -2,7 +2,7 @@
  * Gen 2 moves
  */
 
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	aeroblast: {
 		inherit: true,
 		critRatio: 3,

--- a/data/mods/gen2/pokedex.ts
+++ b/data/mods/gen2/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
 	unown: {
 		inherit: true,
 		cosmeticFormes: ["Unown-B", "Unown-C", "Unown-D", "Unown-E", "Unown-F", "Unown-G", "Unown-H", "Unown-I", "Unown-J", "Unown-K", "Unown-L", "Unown-M", "Unown-N", "Unown-O", "Unown-P", "Unown-Q", "Unown-R", "Unown-S", "Unown-T", "Unown-U", "Unown-V", "Unown-W", "Unown-X", "Unown-Y", "Unown-Z"],

--- a/data/mods/gen2/pokedex.ts
+++ b/data/mods/gen2/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
+export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable = {
 	unown: {
 		inherit: true,
 		cosmeticFormes: ["Unown-B", "Unown-C", "Unown-D", "Unown-E", "Unown-F", "Unown-G", "Unown-H", "Unown-I", "Unown-J", "Unown-K", "Unown-L", "Unown-M", "Unown-N", "Unown-O", "Unown-P", "Unown-Q", "Unown-R", "Unown-S", "Unown-T", "Unown-U", "Unown-V", "Unown-W", "Unown-X", "Unown-Y", "Unown-Z"],

--- a/data/mods/gen2/rulesets.ts
+++ b/data/mods/gen2/rulesets.ts
@@ -1,6 +1,6 @@
 import type {Learnset} from "../../../sim/dex-species";
 
-export const Rulesets: {[k: string]: ModdedFormatData} = {
+export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
 	obtainablemoves: {
 		inherit: true,
 		banlist: [

--- a/data/mods/gen2/rulesets.ts
+++ b/data/mods/gen2/rulesets.ts
@@ -1,6 +1,6 @@
 import type {Learnset} from "../../../sim/dex-species";
 
-export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
+export const Rulesets: import('../../../sim/dex-formats').ModdedFormatDataTable = {
 	obtainablemoves: {
 		inherit: true,
 		banlist: [

--- a/data/mods/gen2/typechart.ts
+++ b/data/mods/gen2/typechart.ts
@@ -1,4 +1,4 @@
-export const TypeChart: {[id: IDEntry]: ModdedTypeData} = {
+export const TypeChart: import('../../../sim/dex-data').ModdedTypeDataTable = {
 	fire: {
 		inherit: true,
 		damageTaken: {

--- a/data/mods/gen2/typechart.ts
+++ b/data/mods/gen2/typechart.ts
@@ -1,4 +1,4 @@
-export const TypeChart: {[k: string]: ModdedTypeData} = {
+export const TypeChart: {[id: IDEntry]: ModdedTypeData} = {
 	fire: {
 		inherit: true,
 		damageTaken: {

--- a/data/mods/gen2stadium2/conditions.ts
+++ b/data/mods/gen2stadium2/conditions.ts
@@ -4,7 +4,7 @@
  * a volatile along with them to keep track of if their respective stat changes should be factored
  * in during stat calculations or not.
  */
-export const Conditions: {[k: string]: ModdedConditionData} = {
+export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',

--- a/data/mods/gen2stadium2/conditions.ts
+++ b/data/mods/gen2stadium2/conditions.ts
@@ -4,7 +4,7 @@
  * a volatile along with them to keep track of if their respective stat changes should be factored
  * in during stat calculations or not.
  */
-export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
+export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDataTable = {
 	brn: {
 		name: 'brn',
 		effectType: 'Status',

--- a/data/mods/gen2stadium2/items.ts
+++ b/data/mods/gen2stadium2/items.ts
@@ -1,5 +1,5 @@
 // Gen 2 Stadium fixes Dragon Fang and Dragon Scale having the wrong effects.
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	dragonfang: {
 		inherit: true,
 		onModifyDamage(damage, source, target, move) {

--- a/data/mods/gen2stadium2/items.ts
+++ b/data/mods/gen2stadium2/items.ts
@@ -1,5 +1,5 @@
 // Gen 2 Stadium fixes Dragon Fang and Dragon Scale having the wrong effects.
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	dragonfang: {
 		inherit: true,
 		onModifyDamage(damage, source, target, move) {

--- a/data/mods/gen2stadium2/moves.ts
+++ b/data/mods/gen2stadium2/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	// Belly Drum no longer boosts attack by 2 stages if under 50% health.
 	bellydrum: {
 		inherit: true,

--- a/data/mods/gen2stadium2/moves.ts
+++ b/data/mods/gen2stadium2/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	// Belly Drum no longer boosts attack by 2 stages if under 50% health.
 	bellydrum: {
 		inherit: true,

--- a/data/mods/gen2stadium2/rulesets.ts
+++ b/data/mods/gen2stadium2/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
+export const Rulesets: import('../../../sim/dex-formats').ModdedFormatDataTable = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',

--- a/data/mods/gen2stadium2/rulesets.ts
+++ b/data/mods/gen2stadium2/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[k: string]: ModdedFormatData} = {
+export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',

--- a/data/mods/gen3/abilities.ts
+++ b/data/mods/gen3/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
+export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	cutecharm: {
 		inherit: true,
 		onDamagingHit(damage, target, source, move) {

--- a/data/mods/gen3/abilities.ts
+++ b/data/mods/gen3/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
 	cutecharm: {
 		inherit: true,
 		onDamagingHit(damage, target, source, move) {

--- a/data/mods/gen3/conditions.ts
+++ b/data/mods/gen3/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
+export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDataTable = {
 	slp: {
 		name: 'slp',
 		effectType: 'Status',

--- a/data/mods/gen3/conditions.ts
+++ b/data/mods/gen3/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[k: string]: ModdedConditionData} = {
+export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
 	slp: {
 		name: 'slp',
 		effectType: 'Status',

--- a/data/mods/gen3/formats-data.ts
+++ b/data/mods/gen3/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen3/formats-data.ts
+++ b/data/mods/gen3/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen3/items.ts
+++ b/data/mods/gen3/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	aguavberry: {
 		inherit: true,
 		onUpdate() {},

--- a/data/mods/gen3/items.ts
+++ b/data/mods/gen3/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	aguavberry: {
 		inherit: true,
 		onUpdate() {},

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -2,7 +2,7 @@
  * Gen 3 moves
  */
 
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	absorb: {
 		inherit: true,
 		pp: 20,

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -2,7 +2,7 @@
  * Gen 3 moves
  */
 
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	absorb: {
 		inherit: true,
 		pp: 20,

--- a/data/mods/gen3/rulesets.ts
+++ b/data/mods/gen3/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
+export const Rulesets: import('../../../sim/dex-formats').ModdedFormatDataTable = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',

--- a/data/mods/gen3/rulesets.ts
+++ b/data/mods/gen3/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[k: string]: ModdedFormatData} = {
+export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',

--- a/data/mods/gen4/abilities.ts
+++ b/data/mods/gen4/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
+export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	airlock: {
 		inherit: true,
 		onSwitchIn() {},

--- a/data/mods/gen4/abilities.ts
+++ b/data/mods/gen4/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
 	airlock: {
 		inherit: true,
 		onSwitchIn() {},

--- a/data/mods/gen4/conditions.ts
+++ b/data/mods/gen4/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[k: string]: ModdedConditionData} = {
+export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
 	brn: {
 		inherit: true,
 		onResidualOrder: 10,

--- a/data/mods/gen4/conditions.ts
+++ b/data/mods/gen4/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
+export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDataTable = {
 	brn: {
 		inherit: true,
 		onResidualOrder: 10,

--- a/data/mods/gen4/formats-data.ts
+++ b/data/mods/gen4/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen4/formats-data.ts
+++ b/data/mods/gen4/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen4/items.ts
+++ b/data/mods/gen4/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	adamantorb: {
 		inherit: true,
 		onBasePower(basePower, user, target, move) {

--- a/data/mods/gen4/items.ts
+++ b/data/mods/gen4/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	adamantorb: {
 		inherit: true,
 		onBasePower(basePower, user, target, move) {

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	acupressure: {
 		inherit: true,
 		flags: {snatch: 1, metronome: 1},

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	acupressure: {
 		inherit: true,
 		flags: {snatch: 1, metronome: 1},

--- a/data/mods/gen4/pokedex.ts
+++ b/data/mods/gen4/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
+export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable = {
 	milotic: {
 		inherit: true,
 		evoType: 'levelExtra',

--- a/data/mods/gen4/pokedex.ts
+++ b/data/mods/gen4/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
 	milotic: {
 		inherit: true,
 		evoType: 'levelExtra',

--- a/data/mods/gen4/rulesets.ts
+++ b/data/mods/gen4/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
+export const Rulesets: import('../../../sim/dex-formats').ModdedFormatDataTable = {
 	standard: {
 		inherit: true,
 		ruleset: ['Obtainable', 'Sleep Clause Mod', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Evasion Items Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],

--- a/data/mods/gen4/rulesets.ts
+++ b/data/mods/gen4/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[k: string]: ModdedFormatData} = {
+export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
 	standard: {
 		inherit: true,
 		ruleset: ['Obtainable', 'Sleep Clause Mod', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Evasion Items Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],

--- a/data/mods/gen4pt/formats-data.ts
+++ b/data/mods/gen4pt/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
 	pichuspikyeared: {
 		isNonstandard: "Future",
 		tier: "Illegal",

--- a/data/mods/gen4pt/formats-data.ts
+++ b/data/mods/gen4pt/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	pichuspikyeared: {
 		isNonstandard: "Future",
 		tier: "Illegal",

--- a/data/mods/gen4pt/learnsets.ts
+++ b/data/mods/gen4pt/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[k: string]: ModdedLearnsetData} = {
+export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
 	bulbasaur: {
 		inherit: true,
 		learnset: {

--- a/data/mods/gen4pt/learnsets.ts
+++ b/data/mods/gen4pt/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
+export const Learnsets: import('../../../sim/dex-species').ModdedLearnsetDataTable = {
 	bulbasaur: {
 		inherit: true,
 		learnset: {

--- a/data/mods/gen5/abilities.ts
+++ b/data/mods/gen5/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
+export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	anticipation: {
 		inherit: true,
 		onStart(pokemon) {

--- a/data/mods/gen5/abilities.ts
+++ b/data/mods/gen5/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
 	anticipation: {
 		inherit: true,
 		onStart(pokemon) {

--- a/data/mods/gen5/conditions.ts
+++ b/data/mods/gen5/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[k: string]: ModdedConditionData} = {
+export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
 	slp: {
 		inherit: true,
 		onSwitchIn(target) {

--- a/data/mods/gen5/conditions.ts
+++ b/data/mods/gen5/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
+export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDataTable = {
 	slp: {
 		inherit: true,
 		onSwitchIn(target) {

--- a/data/mods/gen5/formats-data.ts
+++ b/data/mods/gen5/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen5/formats-data.ts
+++ b/data/mods/gen5/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen5/items.ts
+++ b/data/mods/gen5/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	aguavberry: {
 		inherit: true,
 		naturalGift: {

--- a/data/mods/gen5/items.ts
+++ b/data/mods/gen5/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	aguavberry: {
 		inherit: true,
 		naturalGift: {

--- a/data/mods/gen5/moves.ts
+++ b/data/mods/gen5/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	absorb: {
 		inherit: true,
 		flags: {protect: 1, mirror: 1, metronome: 1},

--- a/data/mods/gen5/moves.ts
+++ b/data/mods/gen5/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	absorb: {
 		inherit: true,
 		flags: {protect: 1, mirror: 1, metronome: 1},

--- a/data/mods/gen5/pokedex.ts
+++ b/data/mods/gen5/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
+export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable = {
 	bulbasaur: {
 		inherit: true,
 		maleOnlyHidden: true,

--- a/data/mods/gen5/pokedex.ts
+++ b/data/mods/gen5/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
 	bulbasaur: {
 		inherit: true,
 		maleOnlyHidden: true,

--- a/data/mods/gen5/rulesets.ts
+++ b/data/mods/gen5/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[k: string]: ModdedFormatData} = {
+export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
 	standard: {
 		inherit: true,
 		ruleset: [

--- a/data/mods/gen5/rulesets.ts
+++ b/data/mods/gen5/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
+export const Rulesets: import('../../../sim/dex-formats').ModdedFormatDataTable = {
 	standard: {
 		inherit: true,
 		ruleset: [

--- a/data/mods/gen5/typechart.ts
+++ b/data/mods/gen5/typechart.ts
@@ -1,4 +1,4 @@
-export const TypeChart: {[id: IDEntry]: ModdedTypeData | null} = {
+export const TypeChart: import('../../../sim/dex-data').ModdedTypeDataTable = {
 	electric: {
 		inherit: true,
 		damageTaken: {

--- a/data/mods/gen5/typechart.ts
+++ b/data/mods/gen5/typechart.ts
@@ -1,4 +1,4 @@
-export const TypeChart: {[k: string]: ModdedTypeData | null} = {
+export const TypeChart: {[id: IDEntry]: ModdedTypeData | null} = {
 	electric: {
 		inherit: true,
 		damageTaken: {

--- a/data/mods/gen5bw1/formats-data.ts
+++ b/data/mods/gen5bw1/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	venusaur: {
 		tier: "OU",
 	},

--- a/data/mods/gen5bw1/formats-data.ts
+++ b/data/mods/gen5bw1/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
 	venusaur: {
 		tier: "OU",
 	},

--- a/data/mods/gen5bw1/items.ts
+++ b/data/mods/gen5bw1/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	apicotberry: {
 		inherit: true,
 		isNonstandard: "Unobtainable",

--- a/data/mods/gen5bw1/items.ts
+++ b/data/mods/gen5bw1/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	apicotberry: {
 		inherit: true,
 		isNonstandard: "Unobtainable",

--- a/data/mods/gen5bw1/learnsets.ts
+++ b/data/mods/gen5bw1/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[k: string]: ModdedLearnsetData} = {
+export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
 	bulbasaur: {
 		inherit: true,
 		learnset: {

--- a/data/mods/gen5bw1/learnsets.ts
+++ b/data/mods/gen5bw1/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
+export const Learnsets: import('../../../sim/dex-species').ModdedLearnsetDataTable = {
 	bulbasaur: {
 		inherit: true,
 		learnset: {

--- a/data/mods/gen5bw1/pokedex.ts
+++ b/data/mods/gen5bw1/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
 	weedle: {
 		inherit: true,
 		unreleasedHidden: true,

--- a/data/mods/gen5bw1/pokedex.ts
+++ b/data/mods/gen5bw1/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
+export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable = {
 	weedle: {
 		inherit: true,
 		unreleasedHidden: true,

--- a/data/mods/gen6/abilities.ts
+++ b/data/mods/gen6/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
 	aerilate: {
 		inherit: true,
 		onBasePower(basePower, pokemon, target, move) {

--- a/data/mods/gen6/abilities.ts
+++ b/data/mods/gen6/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
+export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	aerilate: {
 		inherit: true,
 		onBasePower(basePower, pokemon, target, move) {

--- a/data/mods/gen6/conditions.ts
+++ b/data/mods/gen6/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
+export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDataTable = {
 	brn: {
 		inherit: true,
 		onResidual(pokemon) {

--- a/data/mods/gen6/conditions.ts
+++ b/data/mods/gen6/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[k: string]: ModdedConditionData} = {
+export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
 	brn: {
 		inherit: true,
 		onResidual(pokemon) {

--- a/data/mods/gen6/formats-data.ts
+++ b/data/mods/gen6/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen6/formats-data.ts
+++ b/data/mods/gen6/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen6/items.ts
+++ b/data/mods/gen6/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	aguavberry: {
 		inherit: true,
 		onUpdate(pokemon) {

--- a/data/mods/gen6/items.ts
+++ b/data/mods/gen6/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	aguavberry: {
 		inherit: true,
 		onUpdate(pokemon) {

--- a/data/mods/gen6/learnsets.ts
+++ b/data/mods/gen6/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
+export const Learnsets: import('../../../sim/dex-species').ModdedLearnsetDataTable = {
 	tomohawk: {
 		inherit: true,
 		learnset: {

--- a/data/mods/gen6/learnsets.ts
+++ b/data/mods/gen6/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[k: string]: ModdedLearnsetData} = {
+export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
 	tomohawk: {
 		inherit: true,
 		learnset: {

--- a/data/mods/gen6/moves.ts
+++ b/data/mods/gen6/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	allyswitch: {
 		inherit: true,
 		priority: 1,

--- a/data/mods/gen6/moves.ts
+++ b/data/mods/gen6/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	allyswitch: {
 		inherit: true,
 		priority: 1,

--- a/data/mods/gen6/pokedex.ts
+++ b/data/mods/gen6/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
+export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable = {
 	charizardmegax: {
 		inherit: true,
 		color: "Red",

--- a/data/mods/gen6/pokedex.ts
+++ b/data/mods/gen6/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
 	charizardmegax: {
 		inherit: true,
 		color: "Red",

--- a/data/mods/gen6/typechart.ts
+++ b/data/mods/gen6/typechart.ts
@@ -1,4 +1,4 @@
-export const TypeChart: {[id: IDEntry]: ModdedTypeData} = {
+export const TypeChart: import('../../../sim/dex-data').ModdedTypeDataTable = {
 	dark: {
 		inherit: true,
 		damageTaken: {

--- a/data/mods/gen6/typechart.ts
+++ b/data/mods/gen6/typechart.ts
@@ -1,4 +1,4 @@
-export const TypeChart: {[k: string]: ModdedTypeData} = {
+export const TypeChart: {[id: IDEntry]: ModdedTypeData} = {
 	dark: {
 		inherit: true,
 		damageTaken: {

--- a/data/mods/gen6xy/formats-data.ts
+++ b/data/mods/gen6xy/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	beedrillmega: {
 		isNonstandard: "Future",
 		tier: "Illegal",

--- a/data/mods/gen6xy/formats-data.ts
+++ b/data/mods/gen6xy/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
 	beedrillmega: {
 		isNonstandard: "Future",
 		tier: "Illegal",

--- a/data/mods/gen6xy/items.ts
+++ b/data/mods/gen6xy/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	altarianite: {
 		inherit: true,
 		isNonstandard: "Future",

--- a/data/mods/gen6xy/items.ts
+++ b/data/mods/gen6xy/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	altarianite: {
 		inherit: true,
 		isNonstandard: "Future",

--- a/data/mods/gen6xy/learnsets.ts
+++ b/data/mods/gen6xy/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[k: string]: ModdedLearnsetData} = {
+export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
 	bulbasaur: {
 		inherit: true,
 		learnset: {

--- a/data/mods/gen6xy/learnsets.ts
+++ b/data/mods/gen6xy/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
+export const Learnsets: import('../../../sim/dex-species').ModdedLearnsetDataTable = {
 	bulbasaur: {
 		inherit: true,
 		learnset: {

--- a/data/mods/gen6xy/moves.ts
+++ b/data/mods/gen6xy/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	dragonascent: {
 		inherit: true,
 		isNonstandard: "Future",

--- a/data/mods/gen6xy/moves.ts
+++ b/data/mods/gen6xy/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	dragonascent: {
 		inherit: true,
 		isNonstandard: "Future",

--- a/data/mods/gen6xy/pokedex.ts
+++ b/data/mods/gen6xy/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
 	pikachu: {
 		inherit: true,
 		formeOrder: ["Pikachu"],

--- a/data/mods/gen6xy/pokedex.ts
+++ b/data/mods/gen6xy/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
+export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable = {
 	pikachu: {
 		inherit: true,
 		formeOrder: ["Pikachu"],

--- a/data/mods/gen7/abilities.ts
+++ b/data/mods/gen7/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
 	disguise: {
 		inherit: true,
 		onDamage(damage, target, source, effect) {

--- a/data/mods/gen7/abilities.ts
+++ b/data/mods/gen7/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
+export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	disguise: {
 		inherit: true,
 		onDamage(damage, target, source, effect) {

--- a/data/mods/gen7/formats-data.ts
+++ b/data/mods/gen7/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen7/formats-data.ts
+++ b/data/mods/gen7/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen7/items.ts
+++ b/data/mods/gen7/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	abomasite: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/gen7/items.ts
+++ b/data/mods/gen7/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	abomasite: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	"10000000voltthunderbolt": {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/gen7/moves.ts
+++ b/data/mods/gen7/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	"10000000voltthunderbolt": {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/gen7/pokedex.ts
+++ b/data/mods/gen7/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
+export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable = {
 	pikachuoriginal: {
 		inherit: true,
 		abilities: {0: "Static"},

--- a/data/mods/gen7/pokedex.ts
+++ b/data/mods/gen7/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
 	pikachuoriginal: {
 		inherit: true,
 		abilities: {0: "Static"},

--- a/data/mods/gen7/rulesets.ts
+++ b/data/mods/gen7/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
+export const Rulesets: import('../../../sim/dex-formats').ModdedFormatDataTable = {
 	standard: {
 		inherit: true,
 		ruleset: ['Obtainable', 'Team Preview', 'Sleep Clause Mod', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Moody Clause', 'Evasion Items Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],

--- a/data/mods/gen7/rulesets.ts
+++ b/data/mods/gen7/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[k: string]: ModdedFormatData} = {
+export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
 	standard: {
 		inherit: true,
 		ruleset: ['Obtainable', 'Team Preview', 'Sleep Clause Mod', 'Species Clause', 'Nickname Clause', 'OHKO Clause', 'Moody Clause', 'Evasion Items Clause', 'Evasion Moves Clause', 'Endless Battle Clause', 'HP Percentage Mod', 'Cancel Mod'],

--- a/data/mods/gen7letsgo/formats-data.ts
+++ b/data/mods/gen7letsgo/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen7letsgo/formats-data.ts
+++ b/data/mods/gen7letsgo/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen7letsgo/learnsets.ts
+++ b/data/mods/gen7letsgo/learnsets.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 
-export const Learnsets: {[k: string]: ModdedLearnsetData} = {
+export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
 	bulbasaur: {
 		learnset: {
 			doubleedge: ["7L32"],

--- a/data/mods/gen7letsgo/learnsets.ts
+++ b/data/mods/gen7letsgo/learnsets.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 
-export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
+export const Learnsets: import('../../../sim/dex-species').ModdedLearnsetDataTable = {
 	bulbasaur: {
 		learnset: {
 			doubleedge: ["7L32"],

--- a/data/mods/gen7letsgo/moves.ts
+++ b/data/mods/gen7letsgo/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	absorb: {
 		inherit: true,
 		basePower: 40,

--- a/data/mods/gen7letsgo/moves.ts
+++ b/data/mods/gen7letsgo/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	absorb: {
 		inherit: true,
 		basePower: 40,

--- a/data/mods/gen7letsgo/pokedex.ts
+++ b/data/mods/gen7letsgo/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
 	pichu: {
 		inherit: true,
 		evos: [],

--- a/data/mods/gen7letsgo/pokedex.ts
+++ b/data/mods/gen7letsgo/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
+export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable = {
 	pichu: {
 		inherit: true,
 		evos: [],

--- a/data/mods/gen7pokebilities/abilities.ts
+++ b/data/mods/gen7pokebilities/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
 	mummy: {
 		inherit: true,
 		onDamagingHit(damage, target, source, move) {

--- a/data/mods/gen7pokebilities/abilities.ts
+++ b/data/mods/gen7pokebilities/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
+export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	mummy: {
 		inherit: true,
 		onDamagingHit(damage, target, source, move) {

--- a/data/mods/gen7pokebilities/moves.ts
+++ b/data/mods/gen7pokebilities/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	gastroacid: {
 		inherit: true,
 		condition: {

--- a/data/mods/gen7pokebilities/moves.ts
+++ b/data/mods/gen7pokebilities/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	gastroacid: {
 		inherit: true,
 		condition: {

--- a/data/mods/gen7sm/formats-data.ts
+++ b/data/mods/gen7sm/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
 	pikachupartner: {
 		isNonstandard: "Future",
 		tier: "Illegal",

--- a/data/mods/gen7sm/formats-data.ts
+++ b/data/mods/gen7sm/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	pikachupartner: {
 		isNonstandard: "Future",
 		tier: "Illegal",

--- a/data/mods/gen7sm/items.ts
+++ b/data/mods/gen7sm/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	kommoniumz: {
 		inherit: true,
 		isNonstandard: "Future",

--- a/data/mods/gen7sm/items.ts
+++ b/data/mods/gen7sm/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	kommoniumz: {
 		inherit: true,
 		isNonstandard: "Future",

--- a/data/mods/gen7sm/learnsets.ts
+++ b/data/mods/gen7sm/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[k: string]: ModdedLearnsetData} = {
+export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
 	bulbasaur: {
 		inherit: true,
 		learnset: {

--- a/data/mods/gen7sm/learnsets.ts
+++ b/data/mods/gen7sm/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
+export const Learnsets: import('../../../sim/dex-species').ModdedLearnsetDataTable = {
 	bulbasaur: {
 		inherit: true,
 		learnset: {

--- a/data/mods/gen7sm/moves.ts
+++ b/data/mods/gen7sm/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	mindblown: {
 		inherit: true,
 		isNonstandard: "Future",

--- a/data/mods/gen7sm/moves.ts
+++ b/data/mods/gen7sm/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	mindblown: {
 		inherit: true,
 		isNonstandard: "Future",

--- a/data/mods/gen7sm/pokedex.ts
+++ b/data/mods/gen7sm/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
 	litten: {
 		inherit: true,
 		unreleasedHidden: true,

--- a/data/mods/gen7sm/pokedex.ts
+++ b/data/mods/gen7sm/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
+export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable = {
 	litten: {
 		inherit: true,
 		unreleasedHidden: true,

--- a/data/mods/gen8/abilities.ts
+++ b/data/mods/gen8/abilities.ts
@@ -32,7 +32,7 @@ Ratings and how they work:
 
 */
 
-export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
+export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	noability: {
 		inherit: true,
 		rating: 0.1,

--- a/data/mods/gen8/abilities.ts
+++ b/data/mods/gen8/abilities.ts
@@ -32,7 +32,7 @@ Ratings and how they work:
 
 */
 
-export const Abilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
 	noability: {
 		inherit: true,
 		rating: 0.1,

--- a/data/mods/gen8/formats-data.ts
+++ b/data/mods/gen8/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: SpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen8/formats-data.ts
+++ b/data/mods/gen8/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: SpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: SpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen8/items.ts
+++ b/data/mods/gen8/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	adamantcrystal: {
 		inherit: true,
 		isNonstandard: "Future",

--- a/data/mods/gen8/items.ts
+++ b/data/mods/gen8/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	adamantcrystal: {
 		inherit: true,
 		isNonstandard: "Future",

--- a/data/mods/gen8/learnsets.ts
+++ b/data/mods/gen8/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[k: string]: ModdedLearnsetData} = {
+export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
 	vivillonfancy: {
 		inherit: true,
 		eventOnly: true,

--- a/data/mods/gen8/learnsets.ts
+++ b/data/mods/gen8/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
+export const Learnsets: import('../../../sim/dex-species').ModdedLearnsetDataTable = {
 	vivillonfancy: {
 		inherit: true,
 		eventOnly: true,

--- a/data/mods/gen8/moves.ts
+++ b/data/mods/gen8/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	allyswitch: {
 		inherit: true,
 		// Prevents setting the volatile used to check for Ally Switch failure

--- a/data/mods/gen8/moves.ts
+++ b/data/mods/gen8/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	allyswitch: {
 		inherit: true,
 		// Prevents setting the volatile used to check for Ally Switch failure

--- a/data/mods/gen8/pokedex.ts
+++ b/data/mods/gen8/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
 	growlithehisui: {
 		inherit: true,
 		abilities: {0: "Intimidate", 1: "Flash Fire", H: "Justified"},

--- a/data/mods/gen8/pokedex.ts
+++ b/data/mods/gen8/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
+export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable = {
 	growlithehisui: {
 		inherit: true,
 		abilities: {0: "Intimidate", 1: "Flash Fire", H: "Justified"},

--- a/data/mods/gen8/rulesets.ts
+++ b/data/mods/gen8/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[k: string]: ModdedFormatData} = {
+export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
 	standard: {
 		inherit: true,
 		ruleset: [

--- a/data/mods/gen8/rulesets.ts
+++ b/data/mods/gen8/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
+export const Rulesets: import('../../../sim/dex-formats').ModdedFormatDataTable = {
 	standard: {
 		inherit: true,
 		ruleset: [

--- a/data/mods/gen8/typechart.ts
+++ b/data/mods/gen8/typechart.ts
@@ -1,4 +1,4 @@
-export const TypeChart: {[id: IDEntry]: ModdedTypeData | null} = {
+export const TypeChart: import('../../../sim/dex-data').ModdedTypeDataTable = {
 	stellar: {
 		inherit: true,
 		isNonstandard: 'Future',

--- a/data/mods/gen8/typechart.ts
+++ b/data/mods/gen8/typechart.ts
@@ -1,4 +1,4 @@
-export const TypeChart: {[k: string]: ModdedTypeData | null} = {
+export const TypeChart: {[id: IDEntry]: ModdedTypeData | null} = {
 	stellar: {
 		inherit: true,
 		isNonstandard: 'Future',

--- a/data/mods/gen8bdsp/abilities.ts
+++ b/data/mods/gen8bdsp/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
 	asoneglastrier: {
 		inherit: true,
 		isNonstandard: "Past",

--- a/data/mods/gen8bdsp/abilities.ts
+++ b/data/mods/gen8bdsp/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
+export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	asoneglastrier: {
 		inherit: true,
 		isNonstandard: "Past",

--- a/data/mods/gen8bdsp/formats-data.ts
+++ b/data/mods/gen8bdsp/formats-data.ts
@@ -1,5 +1,5 @@
 // TODO: alphabetize move names. I'm trying to implement this on a low-quality laptop under time pressure, so I haven't bothered doing so.
-export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen8bdsp/formats-data.ts
+++ b/data/mods/gen8bdsp/formats-data.ts
@@ -1,5 +1,5 @@
 // TODO: alphabetize move names. I'm trying to implement this on a low-quality laptop under time pressure, so I haven't bothered doing so.
-export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/gen8bdsp/items.ts
+++ b/data/mods/gen8bdsp/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	absorbbulb: {
 		inherit: true,
 		isNonstandard: "Past",

--- a/data/mods/gen8bdsp/items.ts
+++ b/data/mods/gen8bdsp/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	absorbbulb: {
 		inherit: true,
 		isNonstandard: "Past",

--- a/data/mods/gen8bdsp/learnsets.ts
+++ b/data/mods/gen8bdsp/learnsets.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 
-export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
+export const Learnsets: import('../../../sim/dex-species').ModdedLearnsetDataTable = {
 	bulbasaur: {
 		learnset: {
 			amnesia: ["8E"],

--- a/data/mods/gen8bdsp/learnsets.ts
+++ b/data/mods/gen8bdsp/learnsets.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 
-export const Learnsets: {[k: string]: ModdedLearnsetData} = {
+export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
 	bulbasaur: {
 		learnset: {
 			amnesia: ["8E"],

--- a/data/mods/gen8bdsp/moves.ts
+++ b/data/mods/gen8bdsp/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	accelerock: {
 		inherit: true,
 		isNonstandard: "Past",

--- a/data/mods/gen8bdsp/moves.ts
+++ b/data/mods/gen8bdsp/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	accelerock: {
 		inherit: true,
 		isNonstandard: "Past",

--- a/data/mods/gen8bdsp/pokedex.ts
+++ b/data/mods/gen8bdsp/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
 	eevee: {
 		inherit: true,
 		evos: ["Vaporeon", "Jolteon", "Flareon", "Espeon", "Umbreon", "Leafeon", "Glaceon"],

--- a/data/mods/gen8bdsp/pokedex.ts
+++ b/data/mods/gen8bdsp/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
+export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable = {
 	eevee: {
 		inherit: true,
 		evos: ["Vaporeon", "Jolteon", "Flareon", "Espeon", "Umbreon", "Leafeon", "Glaceon"],

--- a/data/mods/gen8dlc1/abilities.ts
+++ b/data/mods/gen8dlc1/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
+export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	asoneglastrier: {
 		inherit: true,
 		isNonstandard: "Unobtainable",

--- a/data/mods/gen8dlc1/abilities.ts
+++ b/data/mods/gen8dlc1/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
 	asoneglastrier: {
 		inherit: true,
 		isNonstandard: "Unobtainable",

--- a/data/mods/gen8dlc1/formats-data.ts
+++ b/data/mods/gen8dlc1/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
 	pikachuworld: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",

--- a/data/mods/gen8dlc1/formats-data.ts
+++ b/data/mods/gen8dlc1/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	pikachuworld: {
 		isNonstandard: "Unobtainable",
 		tier: "Unreleased",

--- a/data/mods/gen8dlc1/items.ts
+++ b/data/mods/gen8dlc1/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	adamantorb: {
 		inherit: true,
 		isNonstandard: "Unobtainable",

--- a/data/mods/gen8dlc1/items.ts
+++ b/data/mods/gen8dlc1/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	adamantorb: {
 		inherit: true,
 		isNonstandard: "Unobtainable",

--- a/data/mods/gen8dlc1/learnsets.ts
+++ b/data/mods/gen8dlc1/learnsets.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 
-export const Learnsets: {[speciesid: string]: LearnsetData} = {
+export const Learnsets: import('../../../sim/dex-species').ModdedLearnsetDataTable = {
 	bulbasaur: {
 		learnset: {
 			amnesia: ["8M", "7E", "6E", "5E", "4E"],

--- a/data/mods/gen8dlc1/moves.ts
+++ b/data/mods/gen8dlc1/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	aeroblast: {
 		inherit: true,
 		isNonstandard: "Unobtainable",

--- a/data/mods/gen8dlc1/moves.ts
+++ b/data/mods/gen8dlc1/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	aeroblast: {
 		inherit: true,
 		isNonstandard: "Unobtainable",

--- a/data/mods/gen8dlc1/pokedex.ts
+++ b/data/mods/gen8dlc1/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
 	pumpkaboosmall: {
 		inherit: true,
 		unreleasedHidden: true,

--- a/data/mods/gen8dlc1/pokedex.ts
+++ b/data/mods/gen8dlc1/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
+export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable = {
 	pumpkaboosmall: {
 		inherit: true,
 		unreleasedHidden: true,

--- a/data/mods/gen8dlc1/rulesets.ts
+++ b/data/mods/gen8dlc1/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
+export const Rulesets: import('../../../sim/dex-formats').ModdedFormatDataTable = {
 	teampreview: {
 		inherit: true,
 		onBattleStart() {

--- a/data/mods/gen8dlc1/rulesets.ts
+++ b/data/mods/gen8dlc1/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[k: string]: ModdedFormatData} = {
+export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
 	teampreview: {
 		inherit: true,
 		onBattleStart() {

--- a/data/mods/gen8linked/conditions.ts
+++ b/data/mods/gen8linked/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[k: string]: ModdedConditionData} = {
+export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
 	slp: {
 		inherit: true,
 		onBeforeMove(pokemon, target, move) {

--- a/data/mods/gen8linked/conditions.ts
+++ b/data/mods/gen8linked/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
+export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDataTable = {
 	slp: {
 		inherit: true,
 		onBeforeMove(pokemon, target, move) {

--- a/data/mods/gen8linked/items.ts
+++ b/data/mods/gen8linked/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	leppaberry: {
 		inherit: true,
 		onUpdate(pokemon) {

--- a/data/mods/gen8linked/items.ts
+++ b/data/mods/gen8linked/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	leppaberry: {
 		inherit: true,
 		onUpdate(pokemon) {

--- a/data/mods/gen8linked/moves.ts
+++ b/data/mods/gen8linked/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	pursuit: {
 		inherit: true,
 		beforeTurnCallback(pokemon, target) {

--- a/data/mods/gen8linked/moves.ts
+++ b/data/mods/gen8linked/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	pursuit: {
 		inherit: true,
 		beforeTurnCallback(pokemon, target) {

--- a/data/mods/gen9dlc1/abilities.ts
+++ b/data/mods/gen9dlc1/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
+export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	commander: {
 		inherit: true,
 		flags: {failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, notransform: 1},

--- a/data/mods/gen9dlc1/abilities.ts
+++ b/data/mods/gen9dlc1/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
 	commander: {
 		inherit: true,
 		flags: {failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, notransform: 1},

--- a/data/mods/gen9dlc1/formats-data.ts
+++ b/data/mods/gen9dlc1/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: SpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: SpeciesFormatsData} = {
 	bulbasaur: {
 		isNonstandard: "Past",
 		tier: "Illegal",

--- a/data/mods/gen9dlc1/formats-data.ts
+++ b/data/mods/gen9dlc1/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: SpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	bulbasaur: {
 		isNonstandard: "Past",
 		tier: "Illegal",

--- a/data/mods/gen9dlc1/items.ts
+++ b/data/mods/gen9dlc1/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	berrysweet: {
 		inherit: true,
 		isNonstandard: "Past",

--- a/data/mods/gen9dlc1/items.ts
+++ b/data/mods/gen9dlc1/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	berrysweet: {
 		inherit: true,
 		isNonstandard: "Past",

--- a/data/mods/gen9dlc1/learnsets.ts
+++ b/data/mods/gen9dlc1/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[k: string]: LearnsetData} = {
+export const Learnsets: import('../../../sim/dex-species').ModdedLearnsetDataTable = {
 	missingno: {
 		learnset: {
 			blizzard: ["3L1"],

--- a/data/mods/gen9dlc1/moves.ts
+++ b/data/mods/gen9dlc1/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	aeroblast: {
 		inherit: true,
 		flags: {protect: 1, mirror: 1, distance: 1, metronome: 1},

--- a/data/mods/gen9dlc1/moves.ts
+++ b/data/mods/gen9dlc1/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	aeroblast: {
 		inherit: true,
 		flags: {protect: 1, mirror: 1, distance: 1, metronome: 1},

--- a/data/mods/gen9dlc1/pokedex.ts
+++ b/data/mods/gen9dlc1/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
+export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable = {
 	cresceidon: {
 		inherit: true,
 		baseStats: {hp: 80, atk: 32, def: 111, spa: 88, spd: 99, spe: 125},

--- a/data/mods/gen9dlc1/pokedex.ts
+++ b/data/mods/gen9dlc1/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
 	cresceidon: {
 		inherit: true,
 		baseStats: {hp: 80, atk: 32, def: 111, spa: 88, spd: 99, spe: 125},

--- a/data/mods/gen9dlc1/typechart.ts
+++ b/data/mods/gen9dlc1/typechart.ts
@@ -1,4 +1,4 @@
-export const TypeChart: {[id: IDEntry]: ModdedTypeData | null} = {
+export const TypeChart: import('../../../sim/dex-data').ModdedTypeDataTable = {
 	stellar: {
 		inherit: true,
 		isNonstandard: 'Future',

--- a/data/mods/gen9dlc1/typechart.ts
+++ b/data/mods/gen9dlc1/typechart.ts
@@ -1,4 +1,4 @@
-export const TypeChart: {[k: string]: ModdedTypeData | null} = {
+export const TypeChart: {[id: IDEntry]: ModdedTypeData | null} = {
 	stellar: {
 		inherit: true,
 		isNonstandard: 'Future',

--- a/data/mods/gen9predlc/abilities.ts
+++ b/data/mods/gen9predlc/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
 	commander: {
 		inherit: true,
 		flags: {failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, cantsuppress: 1, notransform: 1},

--- a/data/mods/gen9predlc/abilities.ts
+++ b/data/mods/gen9predlc/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
+export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	commander: {
 		inherit: true,
 		flags: {failroleplay: 1, noreceiver: 1, noentrain: 1, notrace: 1, failskillswap: 1, cantsuppress: 1, notransform: 1},

--- a/data/mods/gen9predlc/formats-data.ts
+++ b/data/mods/gen9predlc/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: SpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: SpeciesFormatsData} = {
 	bulbasaur: {
 		isNonstandard: "Past",
 		tier: "Illegal",

--- a/data/mods/gen9predlc/formats-data.ts
+++ b/data/mods/gen9predlc/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: SpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	bulbasaur: {
 		isNonstandard: "Past",
 		tier: "Illegal",

--- a/data/mods/gen9predlc/items.ts
+++ b/data/mods/gen9predlc/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	custapberry: {
 		inherit: true,
 		isNonstandard: "Unobtainable",

--- a/data/mods/gen9predlc/items.ts
+++ b/data/mods/gen9predlc/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	custapberry: {
 		inherit: true,
 		isNonstandard: "Unobtainable",

--- a/data/mods/gen9predlc/learnsets.ts
+++ b/data/mods/gen9predlc/learnsets.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 
-export const Learnsets: {[speciesid: string]: LearnsetData} = {
+export const Learnsets: import('../../../sim/dex-species').ModdedLearnsetDataTable = {
 	bulbasaur: {
 		learnset: {
 			amnesia: ["8M", "7E", "6E", "5E", "4E"],

--- a/data/mods/gen9predlc/moves.ts
+++ b/data/mods/gen9predlc/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	aurawheel: {
 		inherit: true,
 		isNonstandard: "Past",

--- a/data/mods/gen9predlc/moves.ts
+++ b/data/mods/gen9predlc/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	aurawheel: {
 		inherit: true,
 		isNonstandard: "Past",

--- a/data/mods/gen9predlc/pokedex.ts
+++ b/data/mods/gen9predlc/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
 	shiftry: {
 		inherit: true,
 		abilities: {0: "Chlorophyll", 1: "Early Bird", H: "Pickpocket"},

--- a/data/mods/gen9predlc/pokedex.ts
+++ b/data/mods/gen9predlc/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
+export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable = {
 	shiftry: {
 		inherit: true,
 		abilities: {0: "Chlorophyll", 1: "Early Bird", H: "Pickpocket"},

--- a/data/mods/gen9ssb/abilities.ts
+++ b/data/mods/gen9ssb/abilities.ts
@@ -3,7 +3,7 @@ import {changeSet, getName, enemyStaff, PSEUDO_WEATHERS} from "./scripts";
 
 const STRONG_WEATHERS = ['desolateland', 'primordialsea', 'deltastream', 'deserteddunes', 'millenniumcastle'];
 
-export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
+export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	/*
 	// Example
 	abilityid: {

--- a/data/mods/gen9ssb/abilities.ts
+++ b/data/mods/gen9ssb/abilities.ts
@@ -3,7 +3,7 @@ import {changeSet, getName, enemyStaff, PSEUDO_WEATHERS} from "./scripts";
 
 const STRONG_WEATHERS = ['desolateland', 'primordialsea', 'deltastream', 'deserteddunes', 'millenniumcastle'];
 
-export const Abilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
 	/*
 	// Example
 	abilityid: {

--- a/data/mods/gen9ssb/conditions.ts
+++ b/data/mods/gen9ssb/conditions.ts
@@ -1,7 +1,8 @@
 import {ssbSets} from "./random-teams";
 import {changeSet, getName, enemyStaff} from './scripts';
+import {ModdedConditionData} from "../../../sim/dex-conditions";
 
-export const Conditions: {[k: string]: ModdedConditionData & {innateName?: string}} = {
+export const Conditions: {[id: IDEntry]: ModdedConditionData & {innateName?: string}} = {
 	/*
 	// Example:
 	userid: {

--- a/data/mods/gen9ssb/items.ts
+++ b/data/mods/gen9ssb/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	// Archas
 	lilligantiumz: {
 		name: "Lilligantium Z",

--- a/data/mods/gen9ssb/items.ts
+++ b/data/mods/gen9ssb/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	// Archas
 	lilligantiumz: {
 		name: "Lilligantium Z",

--- a/data/mods/gen9ssb/moves.ts
+++ b/data/mods/gen9ssb/moves.ts
@@ -2,7 +2,7 @@ import {ssbSets} from "./random-teams";
 import {PSEUDO_WEATHERS, changeSet, getName} from "./scripts";
 import {Teams} from '../../../sim/teams';
 
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	/*
 	// Example
 	moveid: {

--- a/data/mods/gen9ssb/moves.ts
+++ b/data/mods/gen9ssb/moves.ts
@@ -2,7 +2,7 @@ import {ssbSets} from "./random-teams";
 import {PSEUDO_WEATHERS, changeSet, getName} from "./scripts";
 import {Teams} from '../../../sim/teams';
 
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	/*
 	// Example
 	moveid: {

--- a/data/mods/gen9ssb/pokedex.ts
+++ b/data/mods/gen9ssb/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
 	/*
 	// Example
 	id: {

--- a/data/mods/gen9ssb/pokedex.ts
+++ b/data/mods/gen9ssb/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
+export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable = {
 	/*
 	// Example
 	id: {

--- a/data/mods/gen9ssb/rulesets.ts
+++ b/data/mods/gen9ssb/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[k: string]: ModdedFormatData} = {
+export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
 	sleepclausemod: {
 		inherit: true,
 		onSetStatus(status, target, source) {

--- a/data/mods/gen9ssb/rulesets.ts
+++ b/data/mods/gen9ssb/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
+export const Rulesets: import('../../../sim/dex-formats').ModdedFormatDataTable = {
 	sleepclausemod: {
 		inherit: true,
 		onSetStatus(status, target, source) {

--- a/data/mods/gen9ssb/typechart.ts
+++ b/data/mods/gen9ssb/typechart.ts
@@ -1,4 +1,4 @@
-export const TypeChart: {[id: IDEntry]: ModdedTypeData} = {
+export const TypeChart: import('../../../sim/dex-data').ModdedTypeDataTable = {
 	ground: {
 		inherit: true,
 		damageTaken: {

--- a/data/mods/gen9ssb/typechart.ts
+++ b/data/mods/gen9ssb/typechart.ts
@@ -1,4 +1,4 @@
-export const TypeChart: {[k: string]: ModdedTypeData} = {
+export const TypeChart: {[id: IDEntry]: ModdedTypeData} = {
 	ground: {
 		inherit: true,
 		damageTaken: {

--- a/data/mods/gennext/abilities.ts
+++ b/data/mods/gennext/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
 	swiftswim: {
 		inherit: true,
 		onModifySpe(spe, pokemon) {

--- a/data/mods/gennext/abilities.ts
+++ b/data/mods/gennext/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
+export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	swiftswim: {
 		inherit: true,
 		onModifySpe(spe, pokemon) {

--- a/data/mods/gennext/conditions.ts
+++ b/data/mods/gennext/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
+export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDataTable = {
 	frz: {
 		name: 'frz',
 		effectType: 'Status',

--- a/data/mods/gennext/conditions.ts
+++ b/data/mods/gennext/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[k: string]: ModdedConditionData} = {
+export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
 	frz: {
 		name: 'frz',
 		effectType: 'Status',

--- a/data/mods/gennext/formats-data.ts
+++ b/data/mods/gennext/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
 	aegislash: {
 		inherit: true,
 		tier: "OU",

--- a/data/mods/gennext/formats-data.ts
+++ b/data/mods/gennext/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	aegislash: {
 		inherit: true,
 		tier: "OU",

--- a/data/mods/gennext/items.ts
+++ b/data/mods/gennext/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	burndrive: {
 		inherit: true,
 		onBasePower(basePower, user, target, move) {},

--- a/data/mods/gennext/items.ts
+++ b/data/mods/gennext/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	burndrive: {
 		inherit: true,
 		onBasePower(basePower, user, target, move) {},

--- a/data/mods/gennext/moves.ts
+++ b/data/mods/gennext/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	/******************************************************************
 	Perfect accuracy moves:
 	- base power increased to 90

--- a/data/mods/gennext/moves.ts
+++ b/data/mods/gennext/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	/******************************************************************
 	Perfect accuracy moves:
 	- base power increased to 90

--- a/data/mods/gennext/pokedex.ts
+++ b/data/mods/gennext/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
 	genesectdouse: {
 		inherit: true,
 		types: ["Bug", "Water"],

--- a/data/mods/gennext/pokedex.ts
+++ b/data/mods/gennext/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
+export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable = {
 	genesectdouse: {
 		inherit: true,
 		types: ["Bug", "Water"],

--- a/data/mods/mixandmega/items.ts
+++ b/data/mods/mixandmega/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	abomasite: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/mixandmega/items.ts
+++ b/data/mods/mixandmega/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	abomasite: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/moderngen2/formats-data.ts
+++ b/data/mods/moderngen2/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
+export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/moderngen2/formats-data.ts
+++ b/data/mods/moderngen2/formats-data.ts
@@ -1,4 +1,4 @@
-export const FormatsData: {[id: IDEntry]: ModdedSpeciesFormatsData} = {
+export const FormatsData: import('../../../sim/dex-species').ModdedSpeciesFormatsDataTable = {
 	bulbasaur: {
 		tier: "LC",
 	},

--- a/data/mods/moderngen2/learnsets.ts
+++ b/data/mods/moderngen2/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[k: string]: ModdedLearnsetData} = {
+export const Learnsets: {[k: IDEntry]: ModdedLearnsetData} = {
 	missingno: {
 		learnset: {
 			blizzard: ["2L1"],
@@ -122,12 +122,12 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			worryseed: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 5, level: 1, shiny: 1, ivs: {def: 31}, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 6, level: 5, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 5, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 5, level: 1, shiny: 1, ivs: {def: 31}, pokeball: "pokeball"},
+			{generation: 6, level: 5, pokeball: "cherishball"},
+			{generation: 6, level: 5, isHidden: true, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 5},
@@ -317,7 +317,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			worryseed: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 100, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 100, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	charmander: {
@@ -434,15 +434,15 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 40, gender: "M", nature: "Mild", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 40, gender: "M", nature: "Naive", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 40, gender: "M", nature: "Naughty", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 4, level: 40, gender: "M", nature: "Hardy", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 1, shiny: 1, ivs: {spe: 31}, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 6, level: 5, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 5, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 4, level: 40, gender: "M", nature: "Mild", pokeball: "cherishball"},
+			{generation: 4, level: 40, gender: "M", nature: "Naive", pokeball: "cherishball"},
+			{generation: 4, level: 40, gender: "M", nature: "Naughty", pokeball: "cherishball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 4, level: 40, gender: "M", nature: "Hardy", pokeball: "cherishball"},
+			{generation: 5, level: 1, shiny: 1, ivs: {spe: 31}, pokeball: "pokeball"},
+			{generation: 6, level: 5, pokeball: "cherishball"},
+			{generation: 6, level: 5, isHidden: true, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 5},
@@ -684,18 +684,18 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 6, level: 36, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 36, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 36, shiny: true, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 100, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 36, gender: "M", nature: "Serious", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 40, nature: "Jolly", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 40, gender: "M", nature: "Jolly", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 40, gender: "M", nature: "Adamant", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 7, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 50, gender: "M", nature: "Adamant", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 9, level: 50, nature: "Adamant", ivs: {hp: 20, atk: 31, def: 20, spa: 20, spd: 20, spe: 31}, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 6, level: 36, gender: "M", pokeball: "cherishball"},
+			{generation: 6, level: 36, gender: "M", pokeball: "cherishball"},
+			{generation: 6, level: 36, shiny: true, gender: "M", pokeball: "cherishball"},
+			{generation: 6, level: 100, isHidden: true, pokeball: "cherishball"},
+			{generation: 6, level: 36, gender: "M", nature: "Serious", pokeball: "cherishball"},
+			{generation: 7, level: 40, nature: "Jolly", pokeball: "cherishball"},
+			{generation: 7, level: 40, gender: "M", nature: "Jolly", pokeball: "cherishball"},
+			{generation: 7, level: 40, gender: "M", nature: "Adamant", pokeball: "pokeball"},
+			{generation: 7, level: 50, pokeball: "cherishball"},
+			{generation: 8, level: 50, gender: "M", nature: "Adamant", pokeball: "pokeball"},
+			{generation: 9, level: 50, nature: "Adamant", ivs: {hp: 20, atk: 31, def: 20, spa: 20, spd: 20, spe: 31}, pokeball: "pokeball"},
 		],
 	},
 	squirtle: {
@@ -811,11 +811,11 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 5, level: 1, shiny: 1, ivs: {hp: 31}, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 6, level: 5, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 5, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 5, level: 1, shiny: 1, ivs: {hp: 31}, pokeball: "pokeball"},
+			{generation: 6, level: 5, pokeball: "cherishball"},
+			{generation: 6, level: 5, isHidden: true, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 5},
@@ -1034,8 +1034,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 6, level: 100, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 6, level: 100, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	caterpie: {
@@ -1160,7 +1160,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlwind: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 30, moves: ["2L1"]},
+			{generation: 3, level: 30},
 		],
 		encounters: [
 			{generation: 2, level: 7},
@@ -1283,7 +1283,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 30, moves: ["2L1"]},
+			{generation: 3, level: 30},
 		],
 		encounters: [
 			{generation: 2, level: 7},
@@ -1428,7 +1428,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 30, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 3, level: 30},
 		],
 		encounters: [
 			{generation: 1, level: 9},
@@ -1504,7 +1504,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 61, gender: "M", nature: "Naughty", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 61, gender: "M", nature: "Naughty", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 7, level: 29},
@@ -1753,7 +1753,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 34, moves: ["2L1"]},
+			{generation: 3, level: 34},
 		],
 		encounters: [
 			{generation: 1, level: 15},
@@ -1902,7 +1902,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 20, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 20, perfectIVs: 3, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -1979,7 +1979,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 22, moves: ["2L1"]},
+			{generation: 3, level: 22},
 		],
 		encounters: [
 			{generation: 1, level: 3},
@@ -2163,8 +2163,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wrap: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 14, gender: "F", nature: "Docile", ivs: {hp: 26, atk: 28, def: 6, spa: 14, spd: 30, spe: 11}, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 14, gender: "F", nature: "Docile", ivs: {hp: 26, atk: 28, def: 6, spa: 14, spd: 30, spe: 11}, pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 1, level: 6},
@@ -2275,7 +2275,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wrap: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 33, moves: ["2L1"]},
+			{generation: 3, level: 33},
 		],
 		encounters: [
 			{generation: 2, level: 10},
@@ -2373,13 +2373,13 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball", emeraldEventEgg: true},
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball", emeraldEventEgg: true},
-			{generation: 4, level: 1, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 30, shiny: true, gender: "M", nature: "Jolly", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 9, level: 30, shiny: true, gender: "M", nature: "Jolly", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball", emeraldEventEgg: true},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball", emeraldEventEgg: true},
+			{generation: 4, level: 1, pokeball: "pokeball"},
+			{generation: 4, level: 30, shiny: true, gender: "M", nature: "Jolly", pokeball: "cherishball"},
+			{generation: 9, level: 30, shiny: true, gender: "M", nature: "Jolly", pokeball: "cherishball"},
 		],
 	},
 	pichuspikyeared: {
@@ -2429,7 +2429,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			volttackle: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 30, gender: "F", nature: "Naughty", moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 4, level: 30, gender: "F", nature: "Naughty", pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -2558,62 +2558,62 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 50, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 10, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 10, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 10, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 10, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 10, gender: "F", nature: "Hardy", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 50, gender: "M", nature: "Hardy", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 20, gender: "F", nature: "Bashful", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 20, gender: "M", nature: "Jolly", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 40, gender: "M", nature: "Modest", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 20, gender: "F", nature: "Bashful", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 40, gender: "M", nature: "Mild", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 20, gender: "F", nature: "Bashful", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 30, gender: "M", nature: "Naughty", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 50, gender: "M", nature: "Relaxed", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 20, gender: "M", nature: "Docile", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 50, gender: "M", nature: "Naughty", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 20, gender: "M", nature: "Bashful", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 30, gender: "F", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 100, shiny: 1, gender: "F", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 50, shiny: 1, gender: "F", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 50, gender: "F", nature: "Timid", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 5, level: 100, gender: "M", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 50, gender: "M", nature: "Brave", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 10, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 22, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 10, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 10, gender: "F", moves: ["2L1"], pokeball: "healball"},
-			{generation: 6, level: 36, shiny: true, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 10, gender: "F", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, gender: "M", nature: "Naughty", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 10, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 10, perfectIVs: 2, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 99, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 10, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 10, moves: ["2L1"], pokeball: "healball"},
-			{generation: 7, level: 10, nature: "Jolly", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 10, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 10, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 10, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 40, shiny: 1, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 7, level: 5, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 10, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 5, gender: "M", nature: "Serious", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 21, gender: "M", nature: "Brave", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 25, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 9, level: 5, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 9, level: 100, gender: "M", nature: "Quiet", perfectIVs: 6, isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 9, level: 25, gender: "M", ivs: {hp: 25, atk: 25, def: 25, spa: 25, spd: 25, spe: 25}, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 50, pokeball: "pokeball"},
+			{generation: 3, level: 10, pokeball: "pokeball"},
+			{generation: 3, level: 10, pokeball: "pokeball"},
+			{generation: 3, level: 5, pokeball: "pokeball"},
+			{generation: 3, level: 10, pokeball: "pokeball"},
+			{generation: 3, level: 10, pokeball: "pokeball"},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 4, level: 10, gender: "F", nature: "Hardy", pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 4, level: 50, gender: "M", nature: "Hardy", pokeball: "cherishball"},
+			{generation: 4, level: 20, gender: "F", nature: "Bashful", pokeball: "cherishball"},
+			{generation: 4, level: 20, gender: "M", nature: "Jolly", pokeball: "pokeball"},
+			{generation: 4, level: 40, gender: "M", nature: "Modest", pokeball: "cherishball"},
+			{generation: 4, level: 20, gender: "F", nature: "Bashful", pokeball: "cherishball"},
+			{generation: 4, level: 40, gender: "M", nature: "Mild", pokeball: "cherishball"},
+			{generation: 4, level: 20, gender: "F", nature: "Bashful", pokeball: "cherishball"},
+			{generation: 4, level: 30, gender: "M", nature: "Naughty", pokeball: "cherishball"},
+			{generation: 4, level: 50, gender: "M", nature: "Relaxed", pokeball: "cherishball"},
+			{generation: 4, level: 20, gender: "M", nature: "Docile", pokeball: "cherishball"},
+			{generation: 4, level: 50, gender: "M", nature: "Naughty", pokeball: "cherishball"},
+			{generation: 4, level: 20, gender: "M", nature: "Bashful", pokeball: "cherishball"},
+			{generation: 5, level: 30, gender: "F", isHidden: true, pokeball: "cherishball"},
+			{generation: 5, level: 50, pokeball: "cherishball"},
+			{generation: 5, level: 100, shiny: 1, gender: "F", pokeball: "cherishball"},
+			{generation: 5, level: 50, shiny: 1, gender: "F", pokeball: "cherishball"},
+			{generation: 5, level: 50, gender: "F", nature: "Timid", isHidden: true, pokeball: "cherishball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 5, level: 100, gender: "M", isHidden: true, pokeball: "cherishball"},
+			{generation: 5, level: 50, gender: "M", nature: "Brave", pokeball: "cherishball"},
+			{generation: 6, level: 10, pokeball: "cherishball"},
+			{generation: 6, level: 22, pokeball: "cherishball"},
+			{generation: 6, level: 10, pokeball: "cherishball"},
+			{generation: 6, level: 10, gender: "F", pokeball: "healball"},
+			{generation: 6, level: 36, shiny: true, isHidden: true, pokeball: "cherishball"},
+			{generation: 6, level: 10, gender: "F", pokeball: "cherishball"},
+			{generation: 6, level: 50, gender: "M", nature: "Naughty", pokeball: "cherishball"},
+			{generation: 6, level: 10, shiny: true, pokeball: "cherishball"},
+			{generation: 6, level: 10, perfectIVs: 2, isHidden: true, pokeball: "cherishball"},
+			{generation: 6, level: 99, pokeball: "cherishball"},
+			{generation: 6, level: 10, pokeball: "cherishball"},
+			{generation: 6, level: 10, pokeball: "healball"},
+			{generation: 7, level: 10, nature: "Jolly", pokeball: "cherishball"},
+			{generation: 7, level: 10, pokeball: "cherishball"},
+			{generation: 7, level: 10, pokeball: "cherishball"},
+			{generation: 7, level: 10, pokeball: "cherishball"},
+			{generation: 7, level: 40, shiny: 1, perfectIVs: 3, pokeball: "pokeball"},
+			{generation: 7, level: 5, pokeball: "cherishball"},
+			{generation: 7, level: 10, pokeball: "cherishball"},
+			{generation: 8, level: 5, gender: "M", nature: "Serious", pokeball: "cherishball"},
+			{generation: 8, level: 21, gender: "M", nature: "Brave", pokeball: "cherishball"},
+			{generation: 8, level: 25, isHidden: true, pokeball: "cherishball"},
+			{generation: 9, level: 5, pokeball: "pokeball"},
+			{generation: 9, level: 100, gender: "M", nature: "Quiet", perfectIVs: 6, isHidden: true, pokeball: "pokeball"},
+			{generation: 9, level: 25, gender: "M", ivs: {hp: 25, atk: 25, def: 25, spa: 25, spd: 25, spe: 25}, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 3},
@@ -2679,7 +2679,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wildcharge: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 20, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 6, level: 20, perfectIVs: 3, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -2803,8 +2803,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wish: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 1, nature: "Hardy", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 8, level: 25, nature: "Hardy", isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 1, nature: "Hardy", pokeball: "pokeball"},
+			{generation: 8, level: 25, nature: "Hardy", isHidden: true, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -2898,8 +2898,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wish: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 6, nature: "Hardy", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 8, level: 25, nature: "Hardy", isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 6, nature: "Hardy", pokeball: "pokeball"},
+			{generation: 8, level: 25, nature: "Hardy", isHidden: true, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -2993,8 +2993,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wish: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 10, nature: "Hardy", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 8, level: 25, nature: "Hardy", isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 10, nature: "Hardy", pokeball: "pokeball"},
+			{generation: 8, level: 25, nature: "Hardy", isHidden: true, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -3088,8 +3088,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wish: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 14, nature: "Hardy", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 8, level: 25, nature: "Hardy", isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 14, nature: "Hardy", pokeball: "pokeball"},
+			{generation: 8, level: 25, nature: "Hardy", isHidden: true, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -3183,8 +3183,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wish: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 17, nature: "Hardy", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 8, level: 25, nature: "Hardy", isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 17, nature: "Hardy", pokeball: "pokeball"},
+			{generation: 8, level: 25, nature: "Hardy", isHidden: true, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -3278,8 +3278,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wish: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 20, nature: "Hardy", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 8, level: 25, nature: "Hardy", isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 20, nature: "Hardy", pokeball: "pokeball"},
+			{generation: 8, level: 25, nature: "Hardy", isHidden: true, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -3373,8 +3373,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wish: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 21, shiny: 1, nature: "Hardy", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 8, level: 25, nature: "Hardy", isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 21, shiny: 1, nature: "Hardy", pokeball: "pokeball"},
+			{generation: 8, level: 25, nature: "Hardy", isHidden: true, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -3413,7 +3413,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zippyzap: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 5, perfectIVs: 6, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 5, perfectIVs: 6, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -3490,8 +3490,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wish: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 25, nature: "Hardy", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 8, level: 80, nature: "Hardy", ivs: {hp: 31, atk: 30, def: 30, spa: 31, spd: 30, spe: 31}, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 8, level: 25, nature: "Hardy", pokeball: "pokeball"},
+			{generation: 8, level: 80, nature: "Hardy", ivs: {hp: 31, atk: 30, def: 30, spa: 31, spd: 30, spe: 31}, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -3818,7 +3818,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 12, gender: "M", nature: "Docile", ivs: {hp: 4, atk: 23, def: 8, spa: 31, spd: 1, spe: 25}, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 12, gender: "M", nature: "Docile", ivs: {hp: 4, atk: 23, def: 8, spa: 31, spd: 1, spe: 25}, pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 1, level: 6},
@@ -3919,7 +3919,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 10, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 10, pokeball: "cherishball"},
 		],
 	},
 	sandslash: {
@@ -4436,7 +4436,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 41, perfectIVs: 2, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 41, perfectIVs: 2, pokeball: "cherishball"},
 		],
 	},
 	nidoranm: {
@@ -4747,7 +4747,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 68, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 68, pokeball: "cherishball"},
 		],
 	},
 	cleffa: {
@@ -5017,8 +5017,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 50, gender: "F", shiny: true, nature: "Bold", isHidden: true, ivs: {hp: 31, atk: 0, def: 31, spa: 31, spd: 31, spe: 31}, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 15, gender: "M", nature: "Modest", abilities: ["2L1"], moves: ["2L1"], pokeball: "moonball"},
+			{generation: 8, level: 50, gender: "F", shiny: true, nature: "Bold", isHidden: true, ivs: {hp: 31, atk: 0, def: 31, spa: 31, spd: 31, spe: 31}, pokeball: "cherishball"},
+			{generation: 8, level: 15, gender: "M", nature: "Modest", pokeball: "moonball"},
 		],
 		encounters: [
 			{generation: 1, level: 8},
@@ -5275,8 +5275,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 18, gender: "F", nature: "Quirky", ivs: {hp: 15, atk: 6, def: 3, spa: 25, spd: 13, spe: 22}, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 18, moves: ["2L1"]},
+			{generation: 3, level: 18, gender: "F", nature: "Quirky", ivs: {hp: 15, atk: 6, def: 3, spa: 25, spd: 13, spe: 22}, pokeball: "pokeball"},
+			{generation: 3, level: 18},
 		],
 		encounters: [
 			{generation: 1, level: 18},
@@ -5373,8 +5373,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 10, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 10, gender: "F", nature: "Modest", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 10, pokeball: "cherishball"},
+			{generation: 7, level: 10, gender: "F", nature: "Modest", pokeball: "cherishball"},
 		],
 	},
 	ninetales: {
@@ -5473,7 +5473,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 50, gender: "M", nature: "Bold", ivs: {def: 31}, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 50, gender: "M", nature: "Bold", ivs: {def: 31}, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	ninetalesalola: {
@@ -5670,7 +5670,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball", emeraldEventEgg: true},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball", emeraldEventEgg: true},
 		],
 	},
 	jigglypuff: {
@@ -6255,8 +6255,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 30, gender: "M", nature: "Timid", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 64, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 30, gender: "M", nature: "Timid", pokeball: "cherishball"},
+			{generation: 7, level: 64, gender: "M", pokeball: "cherishball"},
 		],
 	},
 	oddish: {
@@ -6337,8 +6337,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			worryseed: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 26, gender: "M", nature: "Quirky", ivs: {hp: 23, atk: 24, def: 20, spa: 21, spd: 9, spe: 16}, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 26, gender: "M", nature: "Quirky", ivs: {hp: 23, atk: 24, def: 20, spa: 21, spd: 9, spe: 16}, pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 1, level: 12},
@@ -6420,7 +6420,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			worryseed: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 50, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 50, pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 2, level: 14},
@@ -6685,7 +6685,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 28, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 3, level: 28},
 		],
 		encounters: [
 			{generation: 1, level: 8},
@@ -6957,7 +6957,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 32, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 3, level: 32},
 		],
 		encounters: [
 			{generation: 1, level: 30},
@@ -7138,7 +7138,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 10, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 10, pokeball: "cherishball"},
 		],
 	},
 	dugtrio: {
@@ -7230,7 +7230,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 40, moves: ["2L1"]},
+			{generation: 3, level: 40},
 		],
 		encounters: [
 			{generation: 1, level: 15},
@@ -7440,18 +7440,18 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 22, moves: ["2L1"]},
-			{generation: 4, level: 21, gender: "F", nature: "Jolly", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 10, gender: "M", nature: "Jolly", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 15, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 20, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball"},
+			{generation: 3, level: 5, pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 22},
+			{generation: 4, level: 21, gender: "F", nature: "Jolly", pokeball: "cherishball"},
+			{generation: 4, level: 10, gender: "M", nature: "Jolly", pokeball: "cherishball"},
+			{generation: 5, level: 15, gender: "M", pokeball: "cherishball"},
+			{generation: 6, level: 20, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 10},
-			{generation: 3, level: 3, gender: "M", nature: "Naive", ivs: {hp: 4, atk: 5, def: 4, spa: 5, spd: 4, spe: 4}, abilities: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 3, gender: "M", nature: "Naive", ivs: {hp: 4, atk: 5, def: 4, spa: 5, spd: 4, spe: 4}, pokeball: "pokeball"},
 		],
 	},
 	meowthalola: {
@@ -7632,7 +7632,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 15, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 15, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	persian: {
@@ -8062,8 +8062,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 27, gender: "M", nature: "Lax", ivs: {hp: 31, atk: 16, def: 12, spa: 29, spd: 31, spe: 14}, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball", emeraldEventEgg: true},
+			{generation: 3, level: 27, gender: "M", nature: "Lax", ivs: {hp: 31, atk: 16, def: 12, spa: 29, spd: 31, spe: 14}, pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball", emeraldEventEgg: true},
 		],
 		encounters: [
 			{generation: 1, level: 15},
@@ -8195,8 +8195,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 33, moves: ["2L1"]},
-			{generation: 7, level: 50, gender: "M", nature: "Timid", ivs: {hp: 31, atk: 30, def: 31, spa: 31, spd: 31, spe: 31}, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 33},
+			{generation: 7, level: 50, gender: "M", nature: "Timid", ivs: {hp: 31, atk: 30, def: 31, spa: 31, spd: 31, spe: 31}, isHidden: true, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 15},
@@ -8450,7 +8450,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 34, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 3, level: 34},
 		],
 		encounters: [
 			{generation: 2, level: 15},
@@ -8624,9 +8624,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 32, gender: "F", nature: "Quiet", ivs: {hp: 11, atk: 24, def: 28, spa: 1, spd: 20, spe: 2}, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 28, moves: ["2L1"]},
+			{generation: 3, level: 32, gender: "F", nature: "Quiet", ivs: {hp: 11, atk: 24, def: 28, spa: 1, spd: 20, spe: 2}, pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 28},
 		],
 		encounters: [
 			{generation: 1, level: 15},
@@ -8690,7 +8690,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 15, isHidden: true, nature: "Jolly", ivs: {hp: 31, atk: 31, def: 20, spa: 20, spd: 20, spe: 31}, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 9, level: 15, isHidden: true, nature: "Jolly", ivs: {hp: 31, atk: 31, def: 20, spa: 20, spd: 20, spe: 31}, pokeball: "pokeball"},
 		],
 	},
 	arcanine: {
@@ -8787,9 +8787,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 50, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 50, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 9, level: 50, shiny: true, gender: "F", nature: "Adamant", abilities: ["2L1"], ivs: {hp: 31, atk: 31, def: 31, spa: 8, spd: 31, spe: 31}, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 50, pokeball: "cherishball"},
+			{generation: 7, level: 50, pokeball: "cherishball"},
+			{generation: 9, level: 50, shiny: true, gender: "F", nature: "Adamant", ivs: {hp: 31, atk: 31, def: 31, spa: 8, spd: 31, spe: 31}, pokeball: "cherishball"},
 		],
 	},
 	arcaninehisui: {
@@ -8941,7 +8941,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 1, level: 5},
@@ -9046,7 +9046,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			{generation: 3, level: 20},
 			{generation: 4, level: 10},
 			{generation: 7, level: 24},
-			{generation: 7, level: 22, gender: "F", nature: "Naughty", abilities: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 22, gender: "F", nature: "Naughty", pokeball: "pokeball"},
 		],
 	},
 	poliwrath: {
@@ -9168,7 +9168,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 42, moves: ["2L1"]},
+			{generation: 3, level: 42},
 		],
 	},
 	politoed: {
@@ -9265,7 +9265,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 50, gender: "M", nature: "Calm", ivs: {hp: 31, atk: 13, def: 31, spa: 5, spd: 31, spe: 5}, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 50, gender: "M", nature: "Calm", ivs: {hp: 31, atk: 13, def: 31, spa: 5, spd: 31, spe: 5}, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	abra: {
@@ -9596,7 +9596,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 70, pokeball: "pokeball"},
 		],
 	},
 	machop: {
@@ -9796,7 +9796,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 30, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 30, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 2, level: 14},
@@ -9908,10 +9908,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 38, gender: "M", nature: "Quiet", ivs: {hp: 9, atk: 23, def: 25, spa: 20, spd: 15, spe: 10}, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 6, level: 50, shiny: true, gender: "M", nature: "Adamant", ivs: {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31}, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 39, gender: "M", nature: "Hardy", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 34, gender: "F", nature: "Brave", ivs: {atk: 31}, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 38, gender: "M", nature: "Quiet", ivs: {hp: 9, atk: 23, def: 25, spa: 20, spd: 15, spe: 10}, pokeball: "pokeball"},
+			{generation: 6, level: 50, shiny: true, gender: "M", nature: "Adamant", ivs: {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31}, pokeball: "cherishball"},
+			{generation: 6, level: 39, gender: "M", nature: "Hardy", pokeball: "cherishball"},
+			{generation: 7, level: 34, gender: "F", nature: "Brave", ivs: {atk: 31}, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 16},
@@ -10003,8 +10003,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wringout: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 1, level: 12},
@@ -10094,7 +10094,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wringout: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 32, moves: ["2L1"]},
+			{generation: 3, level: 32},
 		],
 		encounters: [
 			{generation: 2, level: 12},
@@ -11063,7 +11063,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 15, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 15, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	rapidash: {
@@ -11147,7 +11147,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 40, moves: ["2L1"]},
+			{generation: 3, level: 40},
 		],
 		encounters: [
 			{generation: 2, level: 14, gender: "M"},
@@ -11331,9 +11331,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 31, gender: "F", nature: "Naive", ivs: {hp: 17, atk: 11, def: 19, spa: 20, spd: 5, spe: 10}, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 30, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 31, gender: "F", nature: "Naive", ivs: {hp: 17, atk: 11, def: 19, spa: 20, spd: 5, spe: 10}, pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 5, level: 30, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 15},
@@ -11560,7 +11560,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 100, nature: "Quiet", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 100, nature: "Quiet", pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 15},
@@ -12100,7 +12100,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 30, moves: ["2L1"]},
+			{generation: 3, level: 30},
 		],
 		encounters: [
 			{generation: 2, level: 5},
@@ -12294,12 +12294,12 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			yawn: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 36, moves: ["2L1"]},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball"},
+			{generation: 3, level: 36},
 		],
 		encounters: [
 			{generation: 1, level: 3},
-			{generation: 3, level: 3, gender: "M", nature: "Adamant", ivs: {hp: 20, atk: 25, def: 21, spa: 24, spd: 15, spe: 20}, abilities: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 3, gender: "M", nature: "Adamant", ivs: {hp: 20, atk: 25, def: 21, spa: 24, spd: 15, spe: 20}, pokeball: "pokeball"},
 		],
 	},
 	farfetchdgalar: {
@@ -12404,7 +12404,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 80, gender: "M", nature: "Brave", abilities: ["2L1"], ivs: {hp: 30, atk: 31, def: 31, spa: 30, spd: 30, spe: 31}, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 8, level: 80, gender: "M", nature: "Brave", ivs: {hp: 30, atk: 31, def: 31, spa: 30, spd: 30, spe: 31}, pokeball: "pokeball"},
 		],
 	},
 	doduo: {
@@ -12577,14 +12577,14 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 34, moves: ["2L1"]},
+			{generation: 3, level: 34},
 		],
 		encounters: [
 			{generation: 1, level: 29},
 			{generation: 2, level: 10, gender: "F"},
 			{generation: 2, level: 30},
 			{generation: 3, level: 29, pokeball: "safariball"},
-			{generation: 4, level: 15, gender: "F", nature: "Impish", ivs: {hp: 20, atk: 20, def: 20, spa: 15, spd: 15, spe: 15}, abilities: ["2L1"], pokeball: "pokeball"},
+			{generation: 4, level: 15, gender: "F", nature: "Impish", ivs: {hp: 20, atk: 20, def: 20, spa: 15, spd: 15, spe: 15}, pokeball: "pokeball"},
 		],
 	},
 	seel: {
@@ -12678,7 +12678,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 23, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 3, level: 23},
 		],
 		encounters: [
 			{generation: 1, level: 22},
@@ -12877,7 +12877,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 23, moves: ["2L1"]},
+			{generation: 3, level: 23},
 		],
 		encounters: [
 			{generation: 1, level: 23},
@@ -12985,7 +12985,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 10, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 10, pokeball: "cherishball"},
 		],
 	},
 	muk: {
@@ -13284,9 +13284,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			withdraw: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 24, gender: "F", nature: "Brave", ivs: {hp: 5, atk: 19, def: 18, spa: 5, spd: 11, spe: 13}, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 10, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 29, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 3, level: 24, gender: "F", nature: "Brave", ivs: {hp: 5, atk: 19, def: 18, spa: 5, spd: 11, spe: 13}, pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 29},
 		],
 		encounters: [
 			{generation: 1, level: 10},
@@ -13384,7 +13384,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			withdraw: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 30, gender: "M", nature: "Naughty", abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 5, level: 30, gender: "M", nature: "Naughty", pokeball: "pokeball"},
 		],
 	},
 	gastly: {
@@ -13592,7 +13592,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 30, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 30, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 20},
@@ -13729,14 +13729,14 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 23, gender: "F", nature: "Hardy", ivs: {hp: 19, atk: 14, def: 0, spa: 14, spd: 17, spe: 27}, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 6, level: 25, nature: "Timid", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 25, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 25, shiny: true, moves: ["2L1"], pokeball: "duskball"},
-			{generation: 6, level: 50, shiny: true, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 80, gender: "M", nature: "Naughty", abilities: ["2L1"], ivs: {hp: 30, atk: 30, def: 30, spa: 31, spd: 31, spe: 31}, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 23, gender: "F", nature: "Hardy", ivs: {hp: 19, atk: 14, def: 0, spa: 14, spd: 17, spe: 27}, pokeball: "pokeball"},
+			{generation: 6, level: 25, nature: "Timid", pokeball: "cherishball"},
+			{generation: 6, level: 25, pokeball: "cherishball"},
+			{generation: 6, level: 50, pokeball: "cherishball"},
+			{generation: 6, level: 25, shiny: true, pokeball: "duskball"},
+			{generation: 6, level: 50, shiny: true, gender: "M", pokeball: "cherishball"},
+			{generation: 6, level: 100, pokeball: "cherishball"},
+			{generation: 8, level: 80, gender: "M", nature: "Naughty", ivs: {hp: 30, atk: 30, def: 30, spa: 31, spd: 31, spe: 31}, pokeball: "pokeball"},
 		],
 	},
 	onix: {
@@ -14055,7 +14055,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 1, level: 9},
@@ -14182,7 +14182,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 34, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 3, level: 34},
 		],
 		encounters: [
 			{generation: 2, level: 16},
@@ -14444,7 +14444,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 19, moves: ["2L1"]},
+			{generation: 3, level: 19},
 		],
 		encounters: [
 			{generation: 1, level: 14},
@@ -14581,7 +14581,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 		encounters: [
 			{generation: 1, level: 3},
 			{generation: 2, level: 23},
-			{generation: 3, level: 3, nature: "Hasty", ivs: {hp: 19, atk: 16, def: 18, spa: 25, spd: 25, spe: 19}, abilities: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 3, nature: "Hasty", ivs: {hp: 19, atk: 16, def: 18, spa: 25, spd: 25, spe: 19}, pokeball: "pokeball"},
 			{generation: 4, level: 23},
 		],
 	},
@@ -14733,7 +14733,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 1, level: 20},
@@ -14856,7 +14856,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 46, moves: ["2L1"]},
+			{generation: 3, level: 46},
 		],
 	},
 	exeggutoralola: {
@@ -14963,7 +14963,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 50, gender: "M", nature: "Modest", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 50, gender: "M", nature: "Modest", isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	cubone: {
@@ -15172,7 +15172,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			watergun: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 44, moves: ["2L1"]},
+			{generation: 3, level: 44},
 		],
 		encounters: [
 			{generation: 1, level: 24},
@@ -15364,7 +15364,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 25, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 25, perfectIVs: 3, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -15542,7 +15542,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 38, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 3, level: 38},
 		],
 		encounters: [
 			{generation: 1, level: 30},
@@ -15653,7 +15653,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 38, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 3, level: 38},
 		],
 		encounters: [
 			{generation: 1, level: 30},
@@ -15749,7 +15749,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 55, gender: "M", nature: "Adamant", abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 5, level: 55, gender: "M", nature: "Adamant"},
 		],
 	},
 	lickitung: {
@@ -15874,8 +15874,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 38, moves: ["2L1"]},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball"},
+			{generation: 3, level: 38},
 		],
 		encounters: [
 			{generation: 1, level: 15},
@@ -16485,7 +16485,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 46, moves: ["2L1"]},
+			{generation: 3, level: 46},
 		],
 		encounters: [
 			{generation: 1, level: 15},
@@ -16846,10 +16846,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 10, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 39, moves: ["2L1"]},
-			{generation: 8, level: 7, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball"},
+			{generation: 3, level: 10, pokeball: "pokeball"},
+			{generation: 3, level: 39},
+			{generation: 8, level: 7, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 7},
@@ -16991,7 +16991,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 10, isHidden: true, moves: ["2L1"]},
+			{generation: 5, level: 10, isHidden: true},
 		],
 	},
 	tangela: {
@@ -17078,7 +17078,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wringout: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 30, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 3, level: 30},
 		],
 		encounters: [
 			{generation: 1, level: 13},
@@ -17171,7 +17171,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wringout: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 50, gender: "M", nature: "Brave", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 50, gender: "M", nature: "Brave", pokeball: "cherishball"},
 		],
 	},
 	kangaskhan: {
@@ -17302,10 +17302,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 10, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 35, abilities: ["2L1"], moves: ["2L1"]},
-			{generation: 6, level: 50, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball"},
+			{generation: 3, level: 10, pokeball: "pokeball"},
+			{generation: 3, level: 35},
+			{generation: 6, level: 50, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 25},
@@ -17387,7 +17387,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 1, shiny: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 5, level: 1, shiny: true, pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 1, level: 5},
@@ -17467,7 +17467,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 45, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 45, pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 1, level: 20},
@@ -17553,8 +17553,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			yawn: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 50, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 50, gender: "M", nature: "Timid", ivs: {hp: 31, atk: 17, def: 8, spa: 31, spd: 11, spe: 31}, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 50, pokeball: "pokeball"},
+			{generation: 5, level: 50, gender: "M", nature: "Timid", ivs: {hp: 31, atk: 17, def: 8, spa: 31, spd: 11, spe: 31}, pokeball: "cherishball"},
 		],
 	},
 	goldeen: {
@@ -17805,8 +17805,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 50, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 18, nature: "Timid", ivs: {hp: 10, atk: 3, def: 22, spa: 24, spd: 3, spe: 18}, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 50, pokeball: "pokeball"},
+			{generation: 3, level: 18, nature: "Timid", ivs: {hp: 10, atk: 3, def: 22, spa: 24, spd: 3, spe: 18}, pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 1, level: 5},
@@ -17909,7 +17909,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 41, moves: ["2L1"]},
+			{generation: 3, level: 41},
 		],
 	},
 	mimejr: {
@@ -18138,7 +18138,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 42, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 3, level: 42},
 		],
 		encounters: [
 			{generation: 1, level: 6},
@@ -18237,7 +18237,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 15, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 15, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	mrrime: {
@@ -18426,9 +18426,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 40, abilities: ["2L1"], moves: ["2L1"]},
-			{generation: 5, level: 30, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 40},
+			{generation: 5, level: 30, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 15},
@@ -18536,14 +18536,14 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 50, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 50, gender: "M", nature: "Adamant", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 100, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 6, level: 50, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 25, nature: "Adamant", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 25, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 50, gender: "M", pokeball: "pokeball"},
+			{generation: 4, level: 50, gender: "M", nature: "Adamant", pokeball: "cherishball"},
+			{generation: 5, level: 100, gender: "M", pokeball: "cherishball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 6, level: 50, gender: "M", pokeball: "cherishball"},
+			{generation: 6, level: 25, nature: "Adamant", pokeball: "cherishball"},
+			{generation: 6, level: 25, pokeball: "cherishball"},
+			{generation: 6, level: 50, pokeball: "cherishball"},
 		],
 	},
 	kleavor: {
@@ -18829,7 +18829,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 		encounters: [
 			{generation: 1, level: 15},
 			{generation: 2, level: 10},
-			{generation: 3, level: 20, nature: "Mild", ivs: {hp: 18, atk: 17, def: 18, spa: 22, spd: 25, spe: 21}, abilities: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 20, nature: "Mild", ivs: {hp: 18, atk: 17, def: 18, spa: 22, spd: 25, spe: 21}, pokeball: "pokeball"},
 			{generation: 4, level: 22},
 			{generation: 7, level: 9},
 		],
@@ -18924,7 +18924,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 20, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 20, pokeball: "pokeball"},
 		],
 	},
 	electabuzz: {
@@ -19027,11 +19027,11 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 43, moves: ["2L1"]},
-			{generation: 4, level: 30, gender: "M", nature: "Naughty", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 30, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 30, gender: "M", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 43},
+			{generation: 4, level: 30, gender: "M", nature: "Naughty", pokeball: "pokeball"},
+			{generation: 5, level: 30, pokeball: "cherishball"},
+			{generation: 6, level: 30, gender: "M", isHidden: true, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 33},
@@ -19137,8 +19137,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wildcharge: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 50, gender: "M", nature: "Adamant", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 50, gender: "M", nature: "Serious", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 50, gender: "M", nature: "Adamant", pokeball: "pokeball"},
+			{generation: 4, level: 50, gender: "M", nature: "Serious", pokeball: "cherishball"},
 		],
 	},
 	magby: {
@@ -19328,11 +19328,11 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 36, moves: ["2L1"]},
-			{generation: 4, level: 30, gender: "M", nature: "Quiet", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 30, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 30, gender: "M", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 36},
+			{generation: 4, level: 30, gender: "M", nature: "Quiet", pokeball: "pokeball"},
+			{generation: 5, level: 30, pokeball: "cherishball"},
+			{generation: 6, level: 30, gender: "M", isHidden: true, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 34},
@@ -19439,8 +19439,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 50, gender: "F", nature: "Modest", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 50, gender: "M", nature: "Hardy", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 50, gender: "F", nature: "Modest", pokeball: "pokeball"},
+			{generation: 4, level: 50, gender: "M", nature: "Hardy", pokeball: "cherishball"},
 		],
 	},
 	pinsir: {
@@ -19532,9 +19532,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 35, abilities: ["2L1"], moves: ["2L1"]},
-			{generation: 6, level: 50, gender: "F", nature: "Adamant", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, nature: "Jolly", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 35},
+			{generation: 6, level: 50, gender: "F", nature: "Adamant", pokeball: "cherishball"},
+			{generation: 6, level: 50, nature: "Jolly", isHidden: true, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 15},
@@ -19641,9 +19641,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 25, nature: "Docile", ivs: {hp: 14, atk: 19, def: 12, spa: 17, spd: 5, spe: 26}, abilities: ["2L1"], moves: ["2L1"], pokeball: "safariball"},
-			{generation: 3, level: 10, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 46, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 3, level: 25, nature: "Docile", ivs: {hp: 14, atk: 19, def: 12, spa: 17, spd: 5, spe: 26}, pokeball: "safariball"},
+			{generation: 3, level: 10, pokeball: "pokeball"},
+			{generation: 3, level: 46},
 		],
 		encounters: [
 			{generation: 1, level: 21},
@@ -19831,14 +19831,14 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			tackle: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 5, gender: "M", nature: "Relaxed", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 6, gender: "F", nature: "Rash", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 7, gender: "F", nature: "Hardy", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 5, gender: "F", nature: "Lonely", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 4, gender: "M", nature: "Modest", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 99, shiny: true, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 1, shiny: 1, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 19, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 5, gender: "M", nature: "Relaxed", pokeball: "pokeball"},
+			{generation: 4, level: 6, gender: "F", nature: "Rash", pokeball: "pokeball"},
+			{generation: 4, level: 7, gender: "F", nature: "Hardy", pokeball: "pokeball"},
+			{generation: 4, level: 5, gender: "F", nature: "Lonely", pokeball: "pokeball"},
+			{generation: 4, level: 4, gender: "M", nature: "Modest", pokeball: "pokeball"},
+			{generation: 5, level: 99, shiny: true, gender: "M", pokeball: "cherishball"},
+			{generation: 6, level: 1, shiny: 1, pokeball: "cherishball"},
+			{generation: 7, level: 19, shiny: true, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 5},
@@ -19949,8 +19949,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 20, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 50, pokeball: "cherishball"},
+			{generation: 6, level: 20, shiny: true, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 15},
@@ -20077,7 +20077,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 44, moves: ["2L1"]},
+			{generation: 3, level: 44},
 		],
 		encounters: [
 			{generation: 1, level: 15},
@@ -20088,7 +20088,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			transform: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 10, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 10, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 12},
@@ -20180,13 +20180,13 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			yawn: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 10, gender: "F", nature: "Lonely", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 50, shiny: true, gender: "M", nature: "Hardy", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 50, gender: "F", nature: "Hardy", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 10, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 15, shiny: true, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 10, nature: "Jolly", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 5, gender: "M", nature: "Docile", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 10, gender: "F", nature: "Lonely", pokeball: "cherishball"},
+			{generation: 4, level: 50, shiny: true, gender: "M", nature: "Hardy", pokeball: "cherishball"},
+			{generation: 5, level: 50, gender: "F", nature: "Hardy", pokeball: "cherishball"},
+			{generation: 6, level: 10, pokeball: "cherishball"},
+			{generation: 6, level: 15, shiny: true, isHidden: true, pokeball: "cherishball"},
+			{generation: 7, level: 10, nature: "Jolly", pokeball: "cherishball"},
+			{generation: 8, level: 5, gender: "M", nature: "Docile", pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 25},
@@ -20227,7 +20227,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			veeveevolley: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 5, perfectIVs: 6, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 5, perfectIVs: 6, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -20333,9 +20333,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			yawn: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 6, level: 10, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 50, gender: "F", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 6, level: 10, pokeball: "cherishball"},
+			{generation: 7, level: 50, gender: "F", isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	jolteon: {
@@ -20440,9 +20440,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 6, level: 10, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 50, gender: "F", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 6, level: 10, pokeball: "cherishball"},
+			{generation: 7, level: 50, gender: "F", pokeball: "cherishball"},
 		],
 	},
 	flareon: {
@@ -20544,9 +20544,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 6, level: 10, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 50, gender: "F", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 6, level: 10, pokeball: "cherishball"},
+			{generation: 7, level: 50, gender: "F", isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	espeon: {
@@ -20655,10 +20655,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 6, level: 10, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 50, gender: "F", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 6, level: 10, pokeball: "cherishball"},
+			{generation: 7, level: 50, gender: "F", isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	umbreon: {
@@ -20764,10 +20764,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 6, level: 10, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 50, gender: "F", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 6, level: 10, pokeball: "cherishball"},
+			{generation: 7, level: 50, gender: "F", pokeball: "cherishball"},
 		],
 	},
 	leafeon: {
@@ -20863,9 +20863,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 6, level: 10, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 50, gender: "F", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 6, level: 10, pokeball: "cherishball"},
+			{generation: 7, level: 50, gender: "F", isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	glaceon: {
@@ -20959,9 +20959,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 6, level: 10, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 50, gender: "F", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 6, level: 10, pokeball: "cherishball"},
+			{generation: 7, level: 50, gender: "F", pokeball: "cherishball"},
 		],
 	},
 	porygon: {
@@ -21055,8 +21055,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 10, isHidden: true, moves: ["2L1"]},
-			{generation: 8, level: 25, isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 5, level: 10, isHidden: true},
+			{generation: 8, level: 25, isHidden: true, pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 1, level: 18},
@@ -21144,7 +21144,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 50, nature: "Sassy", abilities: ["2L1"], ivs: {hp: 31, atk: 0, spe: 0}, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 50, nature: "Sassy", ivs: {hp: 31, atk: 0, spe: 0}, pokeball: "cherishball"},
 		],
 	},
 	porygonz: {
@@ -21314,7 +21314,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wringout: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 15, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 15, gender: "M", pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 30},
@@ -21497,7 +21497,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wringout: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 15, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 15, gender: "M", pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 30},
@@ -21713,8 +21713,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wingattack: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 15, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 50, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 15, gender: "M", pokeball: "cherishball"},
+			{generation: 7, level: 50, isHidden: true, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 30},
@@ -21830,10 +21830,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 5, moves: ["2L1"]},
-			{generation: 4, level: 5, gender: "F", nature: "Relaxed", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 5, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 9, level: 1, shiny: true, gender: "M", isHidden: true, nature: "Impish", moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 4, level: 5},
+			{generation: 4, level: 5, gender: "F", nature: "Relaxed", pokeball: "cherishball"},
+			{generation: 7, level: 5, pokeball: "cherishball"},
+			{generation: 9, level: 1, shiny: true, gender: "M", isHidden: true, nature: "Impish", pokeball: "pokeball"},
 		],
 	},
 	snorlax: {
@@ -21978,8 +21978,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 43, moves: ["2L1"]},
-			{generation: 7, level: 30, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 43},
+			{generation: 7, level: 30, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 1, level: 30},
@@ -22079,15 +22079,15 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlwind: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 50, moves: ["2L1"]},
-			{generation: 4, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 70, moves: ["2L1"]},
-			{generation: 6, level: 70, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 3, level: 50, shiny: 1},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 3, level: 50},
+			{generation: 4, level: 60, shiny: 1},
+			{generation: 4, level: 50, shiny: 1},
+			{generation: 6, level: 70},
+			{generation: 6, level: 70, isHidden: true, pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		encounters: [
 			{generation: 1, level: 50},
@@ -22156,8 +22156,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			uturn: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 70, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 70},
+			{generation: 8, level: 70, shiny: true, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -22253,15 +22253,15 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 50, moves: ["2L1"]},
-			{generation: 4, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 70, moves: ["2L1"]},
-			{generation: 6, level: 70, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 3, level: 50, shiny: 1},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 3, level: 50},
+			{generation: 4, level: 60, shiny: 1},
+			{generation: 4, level: 50, shiny: 1},
+			{generation: 6, level: 70},
+			{generation: 6, level: 70, isHidden: true, pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		encounters: [
 			{generation: 1, level: 50},
@@ -22334,8 +22334,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			uturn: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 70, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 70},
+			{generation: 8, level: 70, shiny: true, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -22427,15 +22427,15 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wingattack: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 50, moves: ["2L1"]},
-			{generation: 4, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 70, moves: ["2L1"]},
-			{generation: 6, level: 70, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 3, level: 50, shiny: 1},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 3, level: 50},
+			{generation: 4, level: 60, shiny: 1},
+			{generation: 4, level: 50, shiny: 1},
+			{generation: 6, level: 70},
+			{generation: 6, level: 70, isHidden: true, pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		encounters: [
 			{generation: 1, level: 50},
@@ -22500,8 +22500,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wingattack: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 70, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 70},
+			{generation: 8, level: 70, shiny: true, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -22836,16 +22836,16 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 55, moves: ["2L1"]},
-			{generation: 4, level: 50, gender: "M", nature: "Mild", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 100, gender: "M", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 55, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 5, level: 55, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 5, level: 50, gender: "M", nature: "Brave", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 55, gender: "M", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 62, gender: "M", ivs: {hp: 31, def: 31, spa: 31, spd: 31}, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 80, gender: "F", nature: "Jolly", abilities: ["2L1"], ivs: {hp: 30, atk: 31, def: 30, spa: 30, spd: 31, spe: 31}, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 3, level: 55},
+			{generation: 4, level: 50, gender: "M", nature: "Mild", pokeball: "cherishball"},
+			{generation: 5, level: 100, gender: "M", isHidden: true, pokeball: "cherishball"},
+			{generation: 5, level: 55, gender: "M", isHidden: true},
+			{generation: 5, level: 55, gender: "M", isHidden: true},
+			{generation: 5, level: 50, gender: "M", nature: "Brave", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, pokeball: "cherishball"},
+			{generation: 6, level: 55, gender: "M", isHidden: true, pokeball: "cherishball"},
+			{generation: 6, level: 62, gender: "M", ivs: {hp: 31, def: 31, spa: 31, spd: 31}, pokeball: "cherishball"},
+			{generation: 8, level: 80, gender: "F", nature: "Jolly", ivs: {hp: 30, atk: 31, def: 30, spa: 30, spd: 31, spe: 31}, pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 5, level: 50},
@@ -23024,15 +23024,15 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 70, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 100, nature: "Timid", ivs: {spa: 31, spe: 31}, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 70, moves: ["2L1"]},
-			{generation: 6, level: 100, shiny: true, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 9, level: 100, nature: "Modest", perfectIVs: 6, isHidden: true, moves: ["2L1"]},
+			{generation: 3, level: 70, shiny: 1},
+			{generation: 4, level: 70, shiny: 1},
+			{generation: 5, level: 70, pokeball: "cherishball"},
+			{generation: 5, level: 100, nature: "Timid", ivs: {spa: 31, spe: 31}, isHidden: true, pokeball: "cherishball"},
+			{generation: 6, level: 70},
+			{generation: 6, level: 100, shiny: true, isHidden: true, pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
+			{generation: 9, level: 100, nature: "Modest", perfectIVs: 6, isHidden: true},
 		],
 		encounters: [
 			{generation: 1, level: 70},
@@ -23418,33 +23418,33 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 30, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 10, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 30, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 10, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 30, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 10, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 30, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 10, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 30, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 10, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 30, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 10, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 30, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 10, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 5, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 5, perfectIVs: 5, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 7, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 1, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 9, level: 5, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 30, shiny: 1},
+			{generation: 3, level: 10, pokeball: "pokeball"},
+			{generation: 3, level: 30, shiny: 1},
+			{generation: 3, level: 10, pokeball: "pokeball"},
+			{generation: 3, level: 30, shiny: 1},
+			{generation: 3, level: 10, pokeball: "pokeball"},
+			{generation: 3, level: 30, shiny: 1},
+			{generation: 3, level: 10, pokeball: "pokeball"},
+			{generation: 3, level: 30, shiny: 1},
+			{generation: 3, level: 10, pokeball: "pokeball"},
+			{generation: 3, level: 30, shiny: 1},
+			{generation: 3, level: 10, pokeball: "pokeball"},
+			{generation: 3, level: 30, shiny: 1},
+			{generation: 3, level: 10, pokeball: "pokeball"},
+			{generation: 4, level: 50, pokeball: "cherishball"},
+			{generation: 4, level: 50, pokeball: "cherishball"},
+			{generation: 4, level: 50, pokeball: "cherishball"},
+			{generation: 4, level: 50, pokeball: "cherishball"},
+			{generation: 4, level: 50, pokeball: "cherishball"},
+			{generation: 4, level: 50, pokeball: "cherishball"},
+			{generation: 4, level: 50, pokeball: "cherishball"},
+			{generation: 4, level: 5, pokeball: "cherishball"},
+			{generation: 6, level: 100, pokeball: "cherishball"},
+			{generation: 7, level: 5, perfectIVs: 5, pokeball: "pokeball"},
+			{generation: 7, level: 50, pokeball: "cherishball"},
+			{generation: 8, level: 1, pokeball: "pokeball"},
+			{generation: 9, level: 5, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -23529,9 +23529,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wringout: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 6, level: 5, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 5, pokeball: "pokeball"},
+			{generation: 6, level: 5, pokeball: "cherishball"},
 		],
 	},
 	bayleef: {
@@ -23704,7 +23704,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 50, isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 6, level: 50, isHidden: true, pokeball: "pokeball"},
 		],
 	},
 	cyndaquil: {
@@ -23789,9 +23789,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 6, level: 5, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 5, pokeball: "pokeball"},
+			{generation: 6, level: 5, pokeball: "cherishball"},
 		],
 	},
 	quilava: {
@@ -23978,8 +23978,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 6, level: 50, isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 6, level: 50, isHidden: true, pokeball: "pokeball"},
 		],
 	},
 	typhlosionhisui: {
@@ -24158,9 +24158,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 6, level: 5, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 5, pokeball: "pokeball"},
+			{generation: 6, level: 5, pokeball: "cherishball"},
 		],
 	},
 	croconaw: {
@@ -24384,7 +24384,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 50, isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 6, level: 50, isHidden: true, pokeball: "pokeball"},
 		],
 	},
 	sentret: {
@@ -24697,7 +24697,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 2, level: 2},
@@ -24883,7 +24883,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			uturn: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, moves: ["2L1"]},
+			{generation: 3, level: 10},
 		],
 		encounters: [
 			{generation: 2, level: 3},
@@ -25055,7 +25055,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 14, moves: ["2L1"]},
+			{generation: 3, level: 14},
 		],
 		encounters: [
 			{generation: 2, level: 3},
@@ -25146,7 +25146,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 65, gender: "M", nature: "Hardy", abilities: ["2L1"], ivs: {hp: 20, atk: 20, def: 20, spa: 20, spd: 20, spe: 20}, moves: ["2L1"]},
+			{generation: 9, level: 65, gender: "M", nature: "Hardy", ivs: {hp: 20, atk: 20, def: 20, spa: 20, spd: 20, spe: 20}},
 		],
 		encounters: [
 			{generation: 2, level: 7},
@@ -25431,8 +25431,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 20, gender: "F", abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 25, moves: ["2L1"]},
+			{generation: 3, level: 20, gender: "F", pokeball: "pokeball"},
+			{generation: 3, level: 25},
 		],
 	},
 	togetic: {
@@ -25672,7 +25672,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
 		],
 	},
 	natu: {
@@ -25772,7 +25772,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 22, moves: ["2L1"]},
+			{generation: 3, level: 22},
 		],
 	},
 	xatu: {
@@ -25871,7 +25871,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 		},
 		encounters: [
 			{generation: 2, level: 15},
-			{generation: 4, level: 16, gender: "M", nature: "Modest", ivs: {hp: 15, atk: 20, def: 15, spa: 20, spd: 20, spe: 20}, abilities: ["2L1"], pokeball: "pokeball"},
+			{generation: 4, level: 16, gender: "M", nature: "Modest", ivs: {hp: 15, atk: 20, def: 15, spa: 20, spd: 20, spe: 20}, pokeball: "pokeball"},
 			{generation: 6, level: 24, maxEggMoves: 1},
 			{generation: 7, level: 21},
 		],
@@ -25952,10 +25952,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 37, gender: "F", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 17, moves: ["2L1"]},
-			{generation: 6, level: 10, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 37, gender: "F", pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 17},
+			{generation: 6, level: 10, pokeball: "cherishball"},
 		],
 	},
 	flaaffy: {
@@ -26887,7 +26887,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			worryseed: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 27, gender: "M", isHidden: true, moves: ["2L1"]},
+			{generation: 5, level: 27, gender: "M", isHidden: true},
 		],
 	},
 	aipom: {
@@ -27007,7 +27007,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 	},
 	ambipom: {
@@ -27178,7 +27178,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			worryseed: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 	},
 	sunflora: {
@@ -27844,7 +27844,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wingattack: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 	},
 	honchkrow: {
@@ -27937,7 +27937,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wingattack: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 65, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 65, gender: "M", pokeball: "cherishball"},
 		],
 	},
 	misdreavus: {
@@ -28051,7 +28051,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 	},
 	mismagius: {
@@ -28178,7 +28178,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			tickle: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball", emeraldEventEgg: true},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball", emeraldEventEgg: true},
 		],
 	},
 	wobbuffet: {
@@ -28193,10 +28193,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			splash: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 6, level: 10, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 15, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 5, pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 6, level: 10, gender: "M", pokeball: "cherishball"},
+			{generation: 6, level: 15, gender: "M", pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 2, level: 5},
@@ -28401,8 +28401,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			venoshock: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 20, moves: ["2L1"]},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 20},
 		],
 	},
 	forretress: {
@@ -28834,7 +28834,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 	},
 	gliscor: {
@@ -29058,7 +29058,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 	},
 	granbull: {
@@ -29288,7 +29288,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 	},
 	qwilfishhisui: {
@@ -29516,8 +29516,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wrap: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 20, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 20, pokeball: "pokeball"},
 		],
 	},
 	heracross: {
@@ -29622,8 +29622,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 50, gender: "F", nature: "Adamant", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, nature: "Adamant", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 50, gender: "F", nature: "Adamant", pokeball: "cherishball"},
+			{generation: 6, level: 50, nature: "Adamant", pokeball: "cherishball"},
 		],
 	},
 	sneasel: {
@@ -29747,7 +29747,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 	},
 	sneaselhisui: {
@@ -29932,8 +29932,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 30, gender: "M", nature: "Jolly", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 48, gender: "M", perfectIVs: 2, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 30, gender: "M", nature: "Jolly", pokeball: "cherishball"},
+			{generation: 6, level: 48, gender: "M", perfectIVs: 2, pokeball: "cherishball"},
 		],
 	},
 	sneasler: {
@@ -30111,8 +30111,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 11, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 11},
 		],
 		encounters: [
 			{generation: 2, level: 2},
@@ -30390,7 +30390,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			yawn: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 70, nature: "Hardy", perfectIVs: 3, moves: ["2L1"]},
+			{generation: 9, level: 70, nature: "Hardy", perfectIVs: 3},
 		],
 		eventOnly: false,
 	},
@@ -30567,7 +30567,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			yawn: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 38, moves: ["2L1"]},
+			{generation: 3, level: 38},
 		],
 		encounters: [
 			{generation: 3, level: 25},
@@ -30656,7 +30656,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			trailblaze: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 22, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 3, level: 22},
 		],
 	},
 	piloswine: {
@@ -30839,8 +30839,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			trailblaze: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 34, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 6, level: 50, shiny: true, gender: "M", nature: "Adamant", isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 5, level: 34, gender: "M", isHidden: true},
+			{generation: 6, level: 50, shiny: true, gender: "M", nature: "Adamant", isHidden: true, pokeball: "pokeball"},
 		],
 	},
 	corsola: {
@@ -30942,8 +30942,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball", emeraldEventEgg: true},
-			{generation: 7, level: 50, gender: "F", nature: "Serious", abilities: ["2L1"], moves: ["2L1"], pokeball: "ultraball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball", emeraldEventEgg: true},
+			{generation: 7, level: 50, gender: "F", nature: "Serious", pokeball: "ultraball"},
 		],
 	},
 	corsolagalar: {
@@ -31017,7 +31017,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 15, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 15, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	cursola: {
@@ -31252,7 +31252,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wringout: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 50, gender: "F", nature: "Serious", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 50, gender: "F", nature: "Serious", pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 4, level: 19},
@@ -31365,8 +31365,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			weatherball: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 6, level: 10, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 6, level: 10, pokeball: "cherishball"},
 		],
 	},
 	mantyke: {
@@ -31528,7 +31528,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wingattack: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 	},
 	skarmory: {
@@ -31724,8 +31724,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 17, moves: ["2L1"]},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 17},
 		],
 	},
 	houndoom: {
@@ -31827,7 +31827,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 50, nature: "Timid", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 50, nature: "Timid", pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 4, level: 20},
@@ -32122,7 +32122,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 	},
 	wyrdeer: {
@@ -32209,9 +32209,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			spore: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 50, gender: "F", nature: "Jolly", ivs: {atk: 31, spe: 31}, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 40, gender: "M", nature: "Jolly", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 5, level: 50, gender: "F", nature: "Jolly", ivs: {atk: 31, spe: 31}, pokeball: "cherishball"},
+			{generation: 6, level: 40, gender: "M", nature: "Jolly", pokeball: "cherishball"},
 		],
 	},
 	miltank: {
@@ -32317,7 +32317,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 20, perfectIVs: 3, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 20, perfectIVs: 3, pokeball: "cherishball"},
 		],
 	},
 	raikou: {
@@ -32410,15 +32410,15 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 40, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 30, shiny: true, nature: "Rash", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 3, level: 50, shiny: 1},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 4, level: 40, shiny: 1},
+			{generation: 4, level: 30, shiny: true, nature: "Rash", pokeball: "cherishball"},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 7, level: 60, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		encounters: [
 			{generation: 2, level: 40},
@@ -32513,15 +32513,15 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 40, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 30, shiny: true, nature: "Adamant", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 3, level: 50, shiny: 1},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 4, level: 40, shiny: 1},
+			{generation: 4, level: 30, shiny: true, nature: "Adamant", pokeball: "cherishball"},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 7, level: 60, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		encounters: [
 			{generation: 2, level: 40},
@@ -32618,13 +32618,13 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 40, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 30, shiny: true, nature: "Relaxed", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 3, level: 50, shiny: 1},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 4, level: 40, shiny: 1},
+			{generation: 4, level: 30, shiny: true, nature: "Relaxed", pokeball: "cherishball"},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		encounters: [
 			{generation: 2, level: 40},
@@ -32716,8 +32716,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			uproar: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 20, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 5, shiny: true, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 20, pokeball: "pokeball"},
+			{generation: 5, level: 5, shiny: true, gender: "M", pokeball: "cherishball"},
 		],
 	},
 	pupitar: {
@@ -32943,13 +32943,13 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 100, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 55, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 6, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, nature: "Jolly", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 55, shiny: true, nature: "Adamant", ivs: {hp: 31, atk: 31, def: 31, spa: 14, spd: 31, spe: 0}, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 100, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 5, level: 100, gender: "M", pokeball: "cherishball"},
+			{generation: 5, level: 55, gender: "M", isHidden: true},
+			{generation: 6, level: 50, pokeball: "cherishball"},
+			{generation: 6, level: 50, nature: "Jolly", pokeball: "cherishball"},
+			{generation: 6, level: 55, shiny: true, nature: "Adamant", ivs: {hp: 31, atk: 31, def: 31, spa: 14, spd: 31, spe: 0}, pokeball: "cherishball"},
+			{generation: 6, level: 100, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 5, level: 50},
@@ -33078,18 +33078,18 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 50, moves: ["2L1"]},
-			{generation: 4, level: 45, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 5, isHidden: true, moves: ["2L1"], pokeball: "dreamball"},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 50, nature: "Timid", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 100, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 3, level: 70, shiny: 1},
+			{generation: 3, level: 50},
+			{generation: 4, level: 45, shiny: 1},
+			{generation: 4, level: 70, shiny: 1},
+			{generation: 5, level: 5, isHidden: true, pokeball: "dreamball"},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 6, level: 50, nature: "Timid", pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 7, level: 100, isHidden: true, pokeball: "cherishball"},
+			{generation: 7, level: 60, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		encounters: [
 			{generation: 2, level: 40},
@@ -33203,17 +33203,17 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 45, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 5, isHidden: true, moves: ["2L1"], pokeball: "dreamball"},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 50, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 3, level: 70, shiny: 1},
+			{generation: 4, level: 45, shiny: 1},
+			{generation: 4, level: 70, shiny: 1},
+			{generation: 5, level: 5, isHidden: true, pokeball: "dreamball"},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 6, level: 50, shiny: true, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 7, level: 60, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		encounters: [
 			{generation: 2, level: 40},
@@ -33329,15 +33329,15 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 10, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 30, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 10, moves: ["2L1"], pokeball: "luxuryball"},
-			{generation: 6, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 30, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 60, shiny: true, nature: "Quirky", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 10, pokeball: "pokeball"},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 3, level: 10, pokeball: "pokeball"},
+			{generation: 3, level: 30, pokeball: "pokeball"},
+			{generation: 4, level: 50, pokeball: "cherishball"},
+			{generation: 6, level: 10, pokeball: "luxuryball"},
+			{generation: 6, level: 100, pokeball: "cherishball"},
+			{generation: 7, level: 30, pokeball: "cherishball"},
+			{generation: 8, level: 60, shiny: true, nature: "Quirky", pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 2, level: 30},
@@ -33446,8 +33446,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			worryseed: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
 		],
 	},
 	grovyle: {
@@ -33670,7 +33670,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 50, shiny: 1, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 50, shiny: 1, pokeball: "cherishball"},
 		],
 	},
 	torchic: {
@@ -33759,9 +33759,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 6, level: 10, gender: "M", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 6, level: 10, gender: "M", isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	combusken: {
@@ -33989,8 +33989,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 50, shiny: 1, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 5, level: 50, shiny: 1, pokeball: "cherishball"},
 		],
 	},
 	mudkip: {
@@ -34082,8 +34082,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			yawn: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
 		],
 	},
 	marshtomp: {
@@ -34294,7 +34294,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 50, shiny: 1, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 50, shiny: 1, pokeball: "cherishball"},
 		],
 	},
 	poochyena: {
@@ -34378,7 +34378,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			yawn: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 3, level: 10},
 		],
 		encounters: [
 			{generation: 3, level: 2},
@@ -34466,7 +34466,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			yawn: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 64, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 64, gender: "M", pokeball: "cherishball"},
 		],
 	},
 	zigzagoon: {
@@ -34554,8 +34554,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: true, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, shiny: 1, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball", emeraldEventEgg: true},
+			{generation: 3, level: 5, shiny: true, pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball", emeraldEventEgg: true},
 		],
 		encounters: [
 			{generation: 3, level: 2},
@@ -34714,7 +34714,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 50, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 50, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 4, level: 3},
@@ -35118,7 +35118,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 3, level: 3},
@@ -35329,8 +35329,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 50, shiny: 1, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 30, gender: "M", nature: "Calm", abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 5, level: 50, shiny: 1, pokeball: "cherishball"},
+			{generation: 5, level: 30, gender: "M", nature: "Calm", pokeball: "pokeball"},
 		],
 	},
 	seedot: {
@@ -35412,8 +35412,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			worryseed: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 17, moves: ["2L1"]},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 17},
 		],
 		encounters: [
 			{generation: 3, level: 3},
@@ -35734,7 +35734,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball", emeraldEventEgg: true},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball", emeraldEventEgg: true},
 		],
 		encounters: [
 			{generation: 3, level: 4},
@@ -35801,7 +35801,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 43, moves: ["2L1"]},
+			{generation: 3, level: 43},
 		],
 		encounters: [
 			{generation: 4, level: 20},
@@ -36096,10 +36096,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 20, moves: ["2L1"]},
-			{generation: 6, level: 1, isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball"},
+			{generation: 3, level: 20},
+			{generation: 6, level: 1, isHidden: true, pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 3, level: 4},
@@ -36328,8 +36328,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 50, shiny: 1, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, shiny: true, gender: "F", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 50, shiny: 1, pokeball: "cherishball"},
+			{generation: 6, level: 50, shiny: true, gender: "F", pokeball: "cherishball"},
 		],
 	},
 	gallade: {
@@ -36561,8 +36561,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			watersport: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball", emeraldEventEgg: true},
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball", emeraldEventEgg: true},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 3, level: 3},
@@ -36731,7 +36731,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 15, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 3, level: 15},
 		],
 	},
 	breloom: {
@@ -37183,7 +37183,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 50, gender: "M", nature: "Adamant", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 50, gender: "M", nature: "Adamant", pokeball: "cherishball"},
 		],
 	},
 	nincada: {
@@ -37391,7 +37391,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 50, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 50, pokeball: "pokeball"},
 		],
 	},
 	whismur: {
@@ -37471,7 +37471,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball", emeraldEventEgg: true},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball", emeraldEventEgg: true},
 		],
 	},
 	loudred: {
@@ -37658,8 +37658,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 100, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 50, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 100, pokeball: "pokeball"},
+			{generation: 3, level: 50, pokeball: "pokeball"},
 		],
 	},
 	makuhita: {
@@ -37766,7 +37766,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 18, moves: ["2L1"]},
+			{generation: 3, level: 18},
 		],
 	},
 	hariyama: {
@@ -37965,7 +37965,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 26, moves: ["2L1"]},
+			{generation: 3, level: 26},
 		],
 	},
 	probopass: {
@@ -38146,12 +38146,12 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball", emeraldEventEgg: true},
-			{generation: 3, level: 5, shiny: 1, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball", emeraldEventEgg: true},
-			{generation: 3, level: 10, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball", emeraldEventEgg: true},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball", emeraldEventEgg: true},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 		encounters: [
-			{generation: 3, level: 3, gender: "F", ivs: {hp: 5, atk: 4, def: 4, spa: 5, spd: 4, spe: 4}, abilities: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 3, gender: "F", ivs: {hp: 5, atk: 4, def: 4, spa: 5, spd: 4, spe: 4}, pokeball: "pokeball"},
 		],
 	},
 	delcatty: {
@@ -38230,7 +38230,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 18, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 3, level: 18},
 		],
 	},
 	sableye: {
@@ -38374,11 +38374,11 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 33, abilities: ["2L1"], moves: ["2L1"]},
-			{generation: 5, level: 50, gender: "M", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, nature: "Relaxed", ivs: {hp: 31, spa: 31}, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 100, nature: "Bold", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 33},
+			{generation: 5, level: 50, gender: "M", isHidden: true, pokeball: "cherishball"},
+			{generation: 6, level: 50, nature: "Relaxed", ivs: {hp: 31, spa: 31}, isHidden: true, pokeball: "cherishball"},
+			{generation: 6, level: 100, nature: "Bold", isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	mawile: {
@@ -38494,10 +38494,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			visegrip: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 22, moves: ["2L1"]},
-			{generation: 6, level: 50, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 100, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 22},
+			{generation: 6, level: 50, pokeball: "cherishball"},
+			{generation: 6, level: 100, pokeball: "cherishball"},
 		],
 	},
 	aron: {
@@ -38781,9 +38781,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 100, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 50, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 6, level: 50, nature: "Brave", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 100, pokeball: "pokeball"},
+			{generation: 3, level: 50, pokeball: "pokeball"},
+			{generation: 6, level: 50, nature: "Brave", pokeball: "cherishball"},
 		],
 	},
 	meditite: {
@@ -38899,8 +38899,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 20, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 20, pokeball: "pokeball"},
 		],
 	},
 	medicham: {
@@ -39162,8 +39162,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wildcharge: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 44, moves: ["2L1"]},
-			{generation: 6, level: 50, nature: "Timid", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 44},
+			{generation: 6, level: 50, nature: "Timid", pokeball: "cherishball"},
 		],
 	},
 	plusle: {
@@ -39258,8 +39258,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wish: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball", emeraldEventEgg: true},
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball", emeraldEventEgg: true},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 	},
 	minun: {
@@ -39352,8 +39352,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wish: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball", emeraldEventEgg: true},
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball", emeraldEventEgg: true},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 	},
 	volbeat: {
@@ -39689,8 +39689,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			worryseed: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 22, moves: ["2L1"]},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 22},
 		],
 	},
 	roserade: {
@@ -39856,7 +39856,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			yawn: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 17, moves: ["2L1"]},
+			{generation: 3, level: 17},
 		],
 	},
 	swalot: {
@@ -40027,8 +40027,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 15, moves: ["2L1"]},
-			{generation: 6, level: 1, isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 15},
+			{generation: 6, level: 1, isHidden: true, pokeball: "pokeball"},
 		],
 	},
 	sharpedo: {
@@ -40118,8 +40118,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 50, nature: "Adamant", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 43, gender: "M", perfectIVs: 2, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 50, nature: "Adamant", isHidden: true, pokeball: "cherishball"},
+			{generation: 6, level: 43, gender: "M", perfectIVs: 2, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 7, level: 10},
@@ -40269,8 +40269,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 100, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 50, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 100, pokeball: "pokeball"},
+			{generation: 3, level: 50, pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 3, level: 25},
@@ -40372,8 +40372,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 14, abilities: ["2L1"], moves: ["2L1"]},
-			{generation: 6, level: 1, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 14},
+			{generation: 6, level: 1, pokeball: "pokeball"},
 		],
 	},
 	camerupt: {
@@ -40470,7 +40470,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 43, gender: "M", perfectIVs: 2, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 43, gender: "M", perfectIVs: 2, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 6, level: 30},
@@ -40568,7 +40568,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 50, gender: "M", nature: "Bold", abilities: ["2L1"], ivs: {hp: 31, atk: 12, def: 31, spa: 31, spd: 31, spe: 0}, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 50, gender: "M", nature: "Bold", ivs: {hp: 31, atk: 12, def: 31, spa: 31, spd: 31, spe: 0}, pokeball: "cherishball"},
 		],
 	},
 	spoink: {
@@ -40667,7 +40667,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball", emeraldEventEgg: true},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball", emeraldEventEgg: true},
 		],
 	},
 	grumpig: {
@@ -40903,7 +40903,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball", emeraldEventEgg: true},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball", emeraldEventEgg: true},
 		],
 	},
 	trapinch: {
@@ -40973,7 +40973,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			toxic: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 1, shiny: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 5, level: 1, shiny: true, pokeball: "pokeball"},
 		],
 	},
 	vibrava: {
@@ -41182,8 +41182,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			vacuumwave: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 45, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 50, gender: "M", nature: "Naive", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 45, pokeball: "pokeball"},
+			{generation: 4, level: 50, gender: "M", nature: "Naive", pokeball: "cherishball"},
 		],
 	},
 	cacnea: {
@@ -41293,7 +41293,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			worryseed: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball", emeraldEventEgg: true},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball", emeraldEventEgg: true},
 		],
 	},
 	cacturne: {
@@ -41411,7 +41411,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 45, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 45, pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 6, level: 30},
@@ -41504,9 +41504,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			uproar: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball", emeraldEventEgg: true},
-			{generation: 5, level: 1, shiny: true, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 6, level: 1, isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball", emeraldEventEgg: true},
+			{generation: 5, level: 1, shiny: true, pokeball: "pokeball"},
+			{generation: 6, level: 1, isHidden: true, pokeball: "pokeball"},
 		],
 	},
 	altaria: {
@@ -41613,10 +41613,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wonderroom: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 45, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 36, moves: ["2L1"]},
-			{generation: 5, level: 35, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 6, level: 100, nature: "Modest", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 45, pokeball: "pokeball"},
+			{generation: 3, level: 36},
+			{generation: 5, level: 35, gender: "M", isHidden: true},
+			{generation: 6, level: 100, nature: "Modest", isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	zangoose: {
@@ -41747,9 +41747,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 18, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 28, moves: ["2L1"]},
+			{generation: 3, level: 18, pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
+			{generation: 3, level: 28},
 		],
 	},
 	seviper: {
@@ -41860,9 +41860,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 18, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 30, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 18, pokeball: "pokeball"},
+			{generation: 3, level: 30, pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 	},
 	lunatone: {
@@ -41963,9 +41963,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 25, moves: ["2L1"]},
-			{generation: 7, level: 30, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 10, pokeball: "pokeball"},
+			{generation: 3, level: 25},
+			{generation: 7, level: 30, pokeball: "cherishball"},
 		],
 	},
 	solrock: {
@@ -42070,9 +42070,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 41, moves: ["2L1"]},
-			{generation: 7, level: 30, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 10, pokeball: "pokeball"},
+			{generation: 3, level: 41},
+			{generation: 7, level: 30, pokeball: "cherishball"},
 		],
 	},
 	barboach: {
@@ -42234,7 +42234,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 51, gender: "F", nature: "Gentle", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 51, gender: "F", nature: "Gentle", pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 4, level: 10},
@@ -42331,7 +42331,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball", emeraldEventEgg: true},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball", emeraldEventEgg: true},
 		],
 	},
 	crawdaunt: {
@@ -42433,8 +42433,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 100, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 50, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 100, pokeball: "pokeball"},
+			{generation: 3, level: 50, pokeball: "pokeball"},
 		],
 		encounters: [
 			{generation: 7, level: 10},
@@ -42528,7 +42528,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 17, moves: ["2L1"]},
+			{generation: 3, level: 17},
 		],
 	},
 	claydol: {
@@ -42703,7 +42703,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wringout: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 15, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 15, gender: "M", pokeball: "cherishball"},
 		],
 	},
 	cradily: {
@@ -42859,7 +42859,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 15, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 15, gender: "M", pokeball: "cherishball"},
 		],
 	},
 	armaldo: {
@@ -43002,7 +43002,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 5, gender: "F", nature: "Calm", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 5, gender: "F", nature: "Calm", pokeball: "cherishball"},
 		],
 	},
 	milotic: {
@@ -43095,11 +43095,11 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wrap: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 35, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 50, gender: "F", nature: "Bold", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 50, shiny: true, gender: "M", nature: "Timid", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 50, shiny: 1, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 58, gender: "M", nature: "Lax", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 35, pokeball: "pokeball"},
+			{generation: 4, level: 50, gender: "F", nature: "Bold", pokeball: "cherishball"},
+			{generation: 4, level: 50, shiny: true, gender: "M", nature: "Timid", pokeball: "cherishball"},
+			{generation: 5, level: 50, shiny: 1, pokeball: "cherishball"},
+			{generation: 5, level: 58, gender: "M", nature: "Lax", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, pokeball: "cherishball"},
 		],
 	},
 	castform: {
@@ -43383,7 +43383,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 45, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 45, pokeball: "pokeball"},
 		],
 	},
 	banette: {
@@ -43484,8 +43484,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 37, abilities: ["2L1"], moves: ["2L1"]},
-			{generation: 5, level: 37, gender: "F", isHidden: true, moves: ["2L1"]},
+			{generation: 3, level: 37},
+			{generation: 5, level: 37, gender: "F", isHidden: true},
 		],
 		encounters: [
 			{generation: 5, level: 32},
@@ -43577,8 +43577,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wonderroom: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 45, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 19, moves: ["2L1"]},
+			{generation: 3, level: 45, pokeball: "pokeball"},
+			{generation: 3, level: 19},
 		],
 	},
 	dusclops: {
@@ -43895,7 +43895,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 53, gender: "F", nature: "Jolly", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 53, gender: "F", nature: "Jolly", pokeball: "cherishball"},
 		],
 	},
 	chingling: {
@@ -44085,7 +44085,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 10, gender: "M", moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 10, gender: "M", pokeball: "pokeball"},
 		],
 	},
 	absol: {
@@ -44205,10 +44205,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, shiny: 1, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 35, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 70, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball"},
+			{generation: 3, level: 35, pokeball: "pokeball"},
+			{generation: 3, level: 70, pokeball: "pokeball"},
 		],
 	},
 	snorunt: {
@@ -44277,7 +44277,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			weatherball: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 20, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 3, level: 20},
 		],
 	},
 	glalie: {
@@ -44532,7 +44532,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			yawn: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 17, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 3, level: 17},
 		],
 	},
 	sealeo: {
@@ -44679,7 +44679,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 50, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 50, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 5, level: 30},
@@ -45080,10 +45080,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, shiny: 1, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 1, shiny: true, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 6, level: 1, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: 1, pokeball: "pokeball"},
+			{generation: 5, level: 1, shiny: true, pokeball: "pokeball"},
+			{generation: 6, level: 1, pokeball: "pokeball"},
 		],
 	},
 	shelgon: {
@@ -45261,10 +45261,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 50, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 50, moves: ["2L1"]},
-			{generation: 4, level: 50, gender: "M", nature: "Naughty", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 50, shiny: 1, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 50, pokeball: "pokeball"},
+			{generation: 3, level: 50},
+			{generation: 4, level: 50, gender: "M", nature: "Naughty", pokeball: "cherishball"},
+			{generation: 5, level: 50, shiny: 1, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 7, level: 9},
@@ -45283,7 +45283,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 5, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 5, shiny: true, pokeball: "cherishball"},
 		],
 	},
 	metang: {
@@ -45384,7 +45384,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 30, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 3, level: 30, pokeball: "pokeball"},
 		],
 	},
 	metagross: {
@@ -45494,14 +45494,14 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 62, nature: "Brave", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 50, shiny: 1, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 45, shiny: true, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 45, isHidden: true, moves: ["2L1"]},
-			{generation: 5, level: 45, isHidden: true, moves: ["2L1"]},
-			{generation: 5, level: 58, nature: "Serious", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 50, nature: "Jolly", ivs: {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31}, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 62, nature: "Brave", pokeball: "cherishball"},
+			{generation: 5, level: 50, shiny: 1, pokeball: "cherishball"},
+			{generation: 5, level: 100, pokeball: "cherishball"},
+			{generation: 5, level: 45, shiny: true, pokeball: "pokeball"},
+			{generation: 5, level: 45, isHidden: true},
+			{generation: 5, level: 45, isHidden: true},
+			{generation: 5, level: 58, nature: "Serious", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, pokeball: "cherishball"},
+			{generation: 7, level: 50, nature: "Jolly", ivs: {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31}, pokeball: "cherishball"},
 		],
 	},
 	regirock: {
@@ -45595,14 +45595,14 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 40, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 40, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 30, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 65, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 40, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 50, isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 3, level: 40, shiny: 1},
+			{generation: 3, level: 40, pokeball: "pokeball"},
+			{generation: 4, level: 30, shiny: 1},
+			{generation: 5, level: 65, shiny: 1},
+			{generation: 6, level: 40, shiny: 1},
+			{generation: 6, level: 50, isHidden: true, pokeball: "pokeball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -45693,14 +45693,14 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 40, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 40, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 30, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 65, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 40, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 50, isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 3, level: 40, shiny: 1},
+			{generation: 3, level: 40, pokeball: "pokeball"},
+			{generation: 4, level: 30, shiny: 1},
+			{generation: 5, level: 65, shiny: 1},
+			{generation: 6, level: 40, shiny: 1},
+			{generation: 6, level: 50, isHidden: true, pokeball: "pokeball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -45797,14 +45797,14 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 40, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 40, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 30, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 65, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 40, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 50, isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 3, level: 40, shiny: 1},
+			{generation: 3, level: 40, pokeball: "pokeball"},
+			{generation: 4, level: 30, shiny: 1},
+			{generation: 5, level: 65, shiny: 1},
+			{generation: 6, level: 40, shiny: 1},
+			{generation: 6, level: 50, isHidden: true, pokeball: "pokeball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -45935,18 +45935,18 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 40, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 35, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 40, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 68, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 30, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, nature: "Bashful", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 40, shiny: 1},
+			{generation: 3, level: 50, shiny: 1},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 4, level: 35, shiny: 1},
+			{generation: 4, level: 40, shiny: 1},
+			{generation: 5, level: 68, shiny: 1},
+			{generation: 6, level: 30, shiny: 1},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 7, level: 60, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
+			{generation: 8, level: 70, nature: "Bashful", pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -46070,18 +46070,18 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 40, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 35, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 40, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 68, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 30, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 50, nature: "Modest", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 3, level: 40, shiny: 1},
+			{generation: 3, level: 50, shiny: 1},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 4, level: 35, shiny: 1},
+			{generation: 4, level: 40, shiny: 1},
+			{generation: 5, level: 68, shiny: 1},
+			{generation: 6, level: 30, shiny: 1},
+			{generation: 6, level: 50, nature: "Modest", pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 7, level: 60, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -46162,18 +46162,18 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 45, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 80, shiny: 1, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 45, moves: ["2L1"]},
-			{generation: 6, level: 100, nature: "Timid", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 3, level: 45, shiny: 1},
+			{generation: 3, level: 70, shiny: 1},
+			{generation: 4, level: 50, shiny: 1},
+			{generation: 5, level: 80, shiny: 1, pokeball: "cherishball"},
+			{generation: 5, level: 100, pokeball: "cherishball"},
+			{generation: 6, level: 45},
+			{generation: 6, level: 100, nature: "Timid", pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 7, level: 60, shiny: true, pokeball: "cherishball"},
+			{generation: 7, level: 60, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -46289,18 +46289,18 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 45, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 80, shiny: 1, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 45, moves: ["2L1"]},
-			{generation: 6, level: 100, nature: "Adamant", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 3, level: 45, shiny: 1},
+			{generation: 3, level: 70, shiny: 1},
+			{generation: 4, level: 50, shiny: 1},
+			{generation: 5, level: 80, shiny: 1, pokeball: "cherishball"},
+			{generation: 5, level: 100, pokeball: "cherishball"},
+			{generation: 6, level: 45},
+			{generation: 6, level: 100, nature: "Adamant", pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 7, level: 60, shiny: true, pokeball: "cherishball"},
+			{generation: 7, level: 60, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -46415,16 +46415,16 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wildcharge: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 70, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 70, moves: ["2L1"]},
-			{generation: 6, level: 70, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 70, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 100, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 3, level: 70, shiny: 1},
+			{generation: 4, level: 50, shiny: 1},
+			{generation: 5, level: 70, shiny: true, pokeball: "cherishball"},
+			{generation: 5, level: 100, pokeball: "cherishball"},
+			{generation: 6, level: 70},
+			{generation: 6, level: 70, shiny: true, pokeball: "cherishball"},
+			{generation: 6, level: 70, shiny: true, pokeball: "cherishball"},
+			{generation: 6, level: 100, shiny: true, pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -46545,30 +46545,30 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 5, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, shiny: true, nature: "Bashful", ivs: {hp: 24, atk: 3, def: 30, spa: 12, spd: 16, spe: 11}, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, shiny: true, nature: "Careful", ivs: {hp: 10, atk: 0, def: 10, spa: 10, spd: 26, spe: 12}, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, shiny: true, nature: "Docile", ivs: {hp: 19, atk: 7, def: 10, spa: 19, spd: 10, spe: 16}, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, shiny: true, nature: "Hasty", ivs: {hp: 3, atk: 12, def: 12, spa: 7, spd: 11, spe: 9}, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, shiny: true, nature: "Jolly", ivs: {hp: 11, atk: 8, def: 6, spa: 14, spd: 5, spe: 20}, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, shiny: true, nature: "Lonely", ivs: {hp: 31, atk: 23, def: 26, spa: 29, spd: 18, spe: 5}, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, shiny: true, nature: "Naughty", ivs: {hp: 21, atk: 31, def: 31, spa: 18, spd: 24, spe: 19}, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, shiny: true, nature: "Serious", ivs: {hp: 29, atk: 10, def: 31, spa: 25, spd: 23, spe: 21}, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 5, shiny: true, nature: "Timid", ivs: {hp: 15, atk: 28, def: 29, spa: 3, spd: 0, spe: 7}, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 3, level: 30, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 5, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 5, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 10, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 15, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 25, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 15, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, nature: "Timid", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 3, level: 5, pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: true, nature: "Bashful", ivs: {hp: 24, atk: 3, def: 30, spa: 12, spd: 16, spe: 11}, pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: true, nature: "Careful", ivs: {hp: 10, atk: 0, def: 10, spa: 10, spd: 26, spe: 12}, pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: true, nature: "Docile", ivs: {hp: 19, atk: 7, def: 10, spa: 19, spd: 10, spe: 16}, pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: true, nature: "Hasty", ivs: {hp: 3, atk: 12, def: 12, spa: 7, spd: 11, spe: 9}, pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: true, nature: "Jolly", ivs: {hp: 11, atk: 8, def: 6, spa: 14, spd: 5, spe: 20}, pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: true, nature: "Lonely", ivs: {hp: 31, atk: 23, def: 26, spa: 29, spd: 18, spe: 5}, pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: true, nature: "Naughty", ivs: {hp: 21, atk: 31, def: 31, spa: 18, spd: 24, spe: 19}, pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: true, nature: "Serious", ivs: {hp: 29, atk: 10, def: 31, spa: 25, spd: 23, spe: 21}, pokeball: "pokeball"},
+			{generation: 3, level: 5, shiny: true, nature: "Timid", ivs: {hp: 15, atk: 28, def: 29, spa: 3, spd: 0, spe: 7}, pokeball: "pokeball"},
+			{generation: 3, level: 30, pokeball: "pokeball"},
+			{generation: 4, level: 5, pokeball: "cherishball"},
+			{generation: 4, level: 5, pokeball: "cherishball"},
+			{generation: 5, level: 50, pokeball: "cherishball"},
+			{generation: 5, level: 50, pokeball: "cherishball"},
+			{generation: 5, level: 50, pokeball: "cherishball"},
+			{generation: 5, level: 50, pokeball: "cherishball"},
+			{generation: 6, level: 10, shiny: true, pokeball: "cherishball"},
+			{generation: 6, level: 15, shiny: true, pokeball: "cherishball"},
+			{generation: 6, level: 100, pokeball: "cherishball"},
+			{generation: 6, level: 25, shiny: true, pokeball: "cherishball"},
+			{generation: 6, level: 100, pokeball: "cherishball"},
+			{generation: 7, level: 15, pokeball: "cherishball"},
+			{generation: 8, level: 70, nature: "Timid", pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -46705,17 +46705,17 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 3, level: 30, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 30, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 30, shiny: 1, moves: ["2L1"]},
-			{generation: 3, level: 70, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 50, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 50, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 50, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 50, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 100, moves: ["2L1"], pokeball: "duskball"},
-			{generation: 6, level: 80, moves: ["2L1"]},
+			{generation: 3, level: 30, shiny: 1},
+			{generation: 3, level: 30, shiny: 1},
+			{generation: 3, level: 30, shiny: 1},
+			{generation: 3, level: 70, pokeball: "pokeball"},
+			{generation: 4, level: 50, pokeball: "cherishball"},
+			{generation: 4, level: 50, pokeball: "pokeball"},
+			{generation: 4, level: 50, pokeball: "pokeball"},
+			{generation: 4, level: 50, pokeball: "pokeball"},
+			{generation: 4, level: 50, pokeball: "pokeball"},
+			{generation: 5, level: 100, pokeball: "duskball"},
+			{generation: 6, level: 80},
 		],
 		eventOnly: false,
 	},
@@ -46813,9 +46813,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 9, level: 1, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 9, level: 1, pokeball: "pokeball"},
 		],
 	},
 	grotle: {
@@ -46994,7 +46994,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 100, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 100, gender: "M", pokeball: "cherishball"},
 		],
 	},
 	chimchar: {
@@ -47100,11 +47100,11 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 40, gender: "M", nature: "Mild", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 4, level: 40, gender: "M", nature: "Hardy", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 9, level: 1, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 4, level: 40, gender: "M", nature: "Mild", pokeball: "cherishball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 4, level: 40, gender: "M", nature: "Hardy", pokeball: "cherishball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 9, level: 1, pokeball: "pokeball"},
 		],
 	},
 	monferno: {
@@ -47335,8 +47335,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 100, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 88, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 100, gender: "M", pokeball: "cherishball"},
+			{generation: 6, level: 88, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	piplup: {
@@ -47429,13 +47429,13 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			yawn: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 5, level: 15, shiny: 1, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 15, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 6, level: 7, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 30, gender: "M", nature: "Hardy", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 9, level: 1, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 5, level: 15, shiny: 1, pokeball: "cherishball"},
+			{generation: 5, level: 15, gender: "M", pokeball: "cherishball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 6, level: 7, pokeball: "cherishball"},
+			{generation: 7, level: 30, gender: "M", nature: "Hardy", pokeball: "pokeball"},
+			{generation: 9, level: 1, pokeball: "pokeball"},
 		],
 	},
 	prinplup: {
@@ -47642,7 +47642,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 100, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 100, gender: "M", pokeball: "cherishball"},
 		],
 	},
 	starly: {
@@ -47714,7 +47714,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 1, gender: "M", nature: "Mild", moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 4, level: 1, gender: "M", nature: "Mild", pokeball: "pokeball"},
 		],
 	},
 	staravia: {
@@ -47924,7 +47924,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			yawn: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 1, gender: "M", nature: "Lonely", abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 4, level: 1, gender: "M", nature: "Lonely", pokeball: "pokeball"},
 		],
 	},
 	bibarel: {
@@ -48423,7 +48423,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 15, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 15, gender: "M", pokeball: "cherishball"},
 		],
 	},
 	rampardos: {
@@ -48610,7 +48610,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wideguard: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 15, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 15, gender: "M", pokeball: "cherishball"},
 		],
 	},
 	bastiodon: {
@@ -49183,7 +49183,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wildcharge: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 50, nature: "Impish", ivs: {hp: 31, atk: 31, def: 31, spa: 14, spd: 31, spe: 31}, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 50, nature: "Impish", ivs: {hp: 31, atk: 31, def: 31, spa: 14, spd: 31, spe: 31}, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	buizel: {
@@ -49654,7 +49654,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 50, gender: "F", nature: "Modest", abilities: ["2L1"], ivs: {hp: 31, atk: 0, def: 31, spa: 31, spd: 31, spe: 31}, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 50, gender: "F", nature: "Modest", ivs: {hp: 31, atk: 0, def: 31, spa: 31, spd: 31, spe: 31}, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 4, level: 20},
@@ -49670,10 +49670,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			yawn: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 50, gender: "F", nature: "Quiet", abilities: ["2L1"], ivs: {hp: 31, atk: 2, def: 31, spa: 31, spd: 31, spe: 0}, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 50, gender: "F", nature: "Sassy", abilities: ["2L1"], ivs: {hp: 31, atk: 0, def: 31, spa: 31, spd: 31, spe: 0}, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 9, level: 50, gender: "M", nature: "Bold", abilities: ["2L1"], ivs: {hp: 31, atk: 0, def: 31, spa: 31, spd: 31, spe: 8}, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 9, level: 50, gender: "F", nature: "Calm", abilities: ["2L1"], ivs: {hp: 31, atk: 0, def: 31, spa: 31, spd: 31, spe: 8}, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 50, gender: "F", nature: "Quiet", ivs: {hp: 31, atk: 2, def: 31, spa: 31, spd: 31, spe: 0}, pokeball: "cherishball"},
+			{generation: 8, level: 50, gender: "F", nature: "Sassy", ivs: {hp: 31, atk: 0, def: 31, spa: 31, spd: 31, spe: 0}, pokeball: "cherishball"},
+			{generation: 9, level: 50, gender: "M", nature: "Bold", ivs: {hp: 31, atk: 0, def: 31, spa: 31, spd: 31, spe: 8}, pokeball: "cherishball"},
+			{generation: 9, level: 50, gender: "F", nature: "Calm", ivs: {hp: 31, atk: 0, def: 31, spa: 31, spd: 31, spe: 8}, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 4, level: 20},
@@ -50621,8 +50621,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 50, nature: "Relaxed", ivs: {hp: 31, atk: 31, def: 31, spa: 22, spd: 31, spe: 0}, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 9, level: 50, nature: "Modest", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 9, level: 50, nature: "Relaxed", ivs: {hp: 31, atk: 31, def: 31, spa: 22, spd: 31, spe: 0}, pokeball: "cherishball"},
+			{generation: 9, level: 50, nature: "Modest", pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 6, level: 30},
@@ -50691,7 +50691,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 25, gender: "M", nature: "Jolly", abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 4, level: 25, gender: "M", nature: "Jolly"},
 		],
 	},
 	spiritomb: {
@@ -50783,7 +50783,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wonderroom: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 61, gender: "F", nature: "Quiet", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 61, gender: "F", nature: "Quiet", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, pokeball: "cherishball"},
 		],
 	},
 	gible: {
@@ -51049,11 +51049,11 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 100, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 48, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 6, level: 48, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 66, gender: "F", perfectIVs: 3, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 100, gender: "M", pokeball: "cherishball"},
+			{generation: 5, level: 48, gender: "M", isHidden: true},
+			{generation: 6, level: 48, gender: "M", pokeball: "cherishball"},
+			{generation: 6, level: 50, gender: "M", pokeball: "cherishball"},
+			{generation: 6, level: 66, gender: "F", perfectIVs: 3, pokeball: "cherishball"},
 		],
 	},
 	riolu: {
@@ -51157,7 +51157,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 30, gender: "M", nature: "Serious", abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 4, level: 30, gender: "M", nature: "Serious", pokeball: "pokeball"},
 		],
 	},
 	lucario: {
@@ -51278,14 +51278,14 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 50, gender: "M", nature: "Modest", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 30, gender: "M", nature: "Adamant", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 5, level: 50, gender: "M", nature: "Naughty", ivs: {atk: 31}, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 100, nature: "Jolly", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 40, gender: "M", nature: "Serious", abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 8, level: 80, gender: "M", nature: "Serious", abilities: ["2L1"], ivs: {hp: 31, atk: 30, def: 30, spa: 31, spd: 30, spe: 31}, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 9, level: 75, shiny: true, gender: "M", nature: "Naive", abilities: ["2L1"], ivs: {hp: 31, atk: 31, def: 20, spa: 31, spd: 20, spe: 31}, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 50, gender: "M", nature: "Modest", pokeball: "cherishball"},
+			{generation: 4, level: 30, gender: "M", nature: "Adamant", pokeball: "cherishball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 5, level: 50, gender: "M", nature: "Naughty", ivs: {atk: 31}, isHidden: true, pokeball: "cherishball"},
+			{generation: 6, level: 100, nature: "Jolly", pokeball: "cherishball"},
+			{generation: 7, level: 40, gender: "M", nature: "Serious", pokeball: "pokeball"},
+			{generation: 8, level: 80, gender: "M", nature: "Serious", ivs: {hp: 31, atk: 30, def: 30, spa: 31, spd: 30, spe: 31}, pokeball: "pokeball"},
+			{generation: 9, level: 75, shiny: true, gender: "M", nature: "Naive", ivs: {hp: 31, atk: 31, def: 20, spa: 31, spd: 20, spe: 31}, pokeball: "cherishball"},
 		],
 	},
 	hippopotas: {
@@ -51725,8 +51725,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
 		],
 	},
 	toxicroak: {
@@ -52319,9 +52319,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 10, nature: "Naughty", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 10, nature: "Quirky", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 10, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 10, nature: "Naughty", pokeball: "cherishball"},
+			{generation: 6, level: 10, nature: "Quirky", pokeball: "cherishball"},
+			{generation: 7, level: 10, pokeball: "cherishball"},
 		],
 	},
 	rotomheat: {
@@ -52450,12 +52450,12 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 65, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 4, level: 50, shiny: 1},
+			{generation: 4, level: 50, shiny: 1},
+			{generation: 5, level: 65, shiny: 1},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -52560,12 +52560,12 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 4, level: 50, shiny: 1},
+			{generation: 4, level: 50, shiny: 1},
+			{generation: 5, level: 50, shiny: 1},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -52673,12 +52673,12 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 4, level: 50, shiny: 1},
+			{generation: 4, level: 50, shiny: 1},
+			{generation: 5, level: 50, shiny: 1},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -52778,20 +52778,20 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			twister: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 47, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 1, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 5, isHidden: true, moves: ["2L1"], pokeball: "dreamball"},
-			{generation: 5, level: 100, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 100, nature: "Modest", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, nature: "Bold", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 9, level: 75, nature: "Quiet", isHidden: true, perfectIVs: 4, moves: ["2L1"]},
+			{generation: 4, level: 47, shiny: 1},
+			{generation: 4, level: 70, shiny: 1},
+			{generation: 4, level: 1, shiny: 1},
+			{generation: 5, level: 5, isHidden: true, pokeball: "dreamball"},
+			{generation: 5, level: 100, shiny: true, pokeball: "cherishball"},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 6, level: 100, nature: "Modest", isHidden: true, pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 7, level: 60, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
+			{generation: 7, level: 50, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
+			{generation: 8, level: 70, nature: "Bold", isHidden: true, pokeball: "cherishball"},
+			{generation: 9, level: 75, nature: "Quiet", isHidden: true, perfectIVs: 4},
 		],
 		eventOnly: false,
 	},
@@ -52900,20 +52900,20 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 47, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 1, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 5, isHidden: true, moves: ["2L1"], pokeball: "dreamball"},
-			{generation: 5, level: 100, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 100, nature: "Timid", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, nature: "Hasty", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 9, level: 75, nature: "Modest", isHidden: true, perfectIVs: 4, moves: ["2L1"]},
+			{generation: 4, level: 47, shiny: 1},
+			{generation: 4, level: 70, shiny: 1},
+			{generation: 4, level: 1, shiny: 1},
+			{generation: 5, level: 5, isHidden: true, pokeball: "dreamball"},
+			{generation: 5, level: 100, shiny: true, pokeball: "cherishball"},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 6, level: 100, nature: "Timid", isHidden: true, pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 7, level: 60, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
+			{generation: 7, level: 50, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
+			{generation: 8, level: 70, nature: "Hasty", isHidden: true, pokeball: "cherishball"},
+			{generation: 9, level: 75, nature: "Modest", isHidden: true, perfectIVs: 4},
 		],
 		eventOnly: false,
 	},
@@ -53010,15 +53010,15 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 50, gender: "M", nature: "Quiet", moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 68, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 4, level: 70, shiny: 1},
+			{generation: 4, level: 50, shiny: 1},
+			{generation: 4, level: 50, gender: "M", nature: "Quiet", pokeball: "pokeball"},
+			{generation: 5, level: 68, shiny: 1},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 7, level: 60, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -53110,15 +53110,15 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 1, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 68, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 100, shiny: 1, moves: ["2L1"]},
+			{generation: 4, level: 70, shiny: 1},
+			{generation: 4, level: 1, shiny: 1},
+			{generation: 4, level: 100, pokeball: "cherishball"},
+			{generation: 5, level: 68, shiny: 1},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 7, level: 60, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
+			{generation: 8, level: 100, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -53223,15 +53223,15 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 47, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 1, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 5, isHidden: true, moves: ["2L1"], pokeball: "dreamball"},
-			{generation: 5, level: 100, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 100, nature: "Brave", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 4, level: 70, shiny: 1},
+			{generation: 4, level: 47, shiny: 1},
+			{generation: 4, level: 1, shiny: 1},
+			{generation: 5, level: 5, isHidden: true, pokeball: "dreamball"},
+			{generation: 5, level: 100, shiny: true, pokeball: "cherishball"},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 6, level: 100, nature: "Brave", isHidden: true, pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -53322,12 +53322,12 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 68, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 68, nature: "Modest", moves: ["2L1"]},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 4, level: 50, shiny: 1},
+			{generation: 5, level: 68, shiny: 1},
+			{generation: 5, level: 68, nature: "Modest"},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -53401,7 +53401,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 50, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 50, pokeball: "cherishball"},
 		],
 	},
 	manaphy: {
@@ -53489,13 +53489,13 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 5, moves: ["2L1"]},
-			{generation: 4, level: 1, shiny: 1, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 50, nature: "Impish", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 1, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 15, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 5},
+			{generation: 4, level: 1, shiny: 1, pokeball: "pokeball"},
+			{generation: 4, level: 50, pokeball: "cherishball"},
+			{generation: 4, level: 50, nature: "Impish", pokeball: "cherishball"},
+			{generation: 6, level: 1, pokeball: "cherishball"},
+			{generation: 6, level: 100, pokeball: "cherishball"},
+			{generation: 7, level: 15, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -53599,15 +53599,15 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 40, shiny: 1, moves: ["2L1"]},
-			{generation: 4, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 50, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 4, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 9, level: 50, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 40, shiny: 1},
+			{generation: 4, level: 50, pokeball: "cherishball"},
+			{generation: 4, level: 50, pokeball: "pokeball"},
+			{generation: 4, level: 50, shiny: 1},
+			{generation: 5, level: 50, pokeball: "cherishball"},
+			{generation: 6, level: 50, pokeball: "cherishball"},
+			{generation: 6, level: 100, pokeball: "cherishball"},
+			{generation: 7, level: 50, pokeball: "cherishball"},
+			{generation: 9, level: 50, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -53687,12 +53687,12 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 4, level: 30, shiny: 1, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 15, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 20, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 50, pokeball: "cherishball"},
+			{generation: 4, level: 30, shiny: 1, pokeball: "pokeball"},
+			{generation: 5, level: 50, pokeball: "cherishball"},
+			{generation: 6, level: 15, pokeball: "cherishball"},
+			{generation: 6, level: 100, pokeball: "cherishball"},
+			{generation: 7, level: 20, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -53878,11 +53878,11 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 4, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 100, moves: ["2L1"]},
-			{generation: 6, level: 100, shiny: 1, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 4, level: 100, pokeball: "cherishball"},
+			{generation: 5, level: 100},
+			{generation: 6, level: 100, shiny: 1, pokeball: "cherishball"},
+			{generation: 6, level: 100, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -54041,14 +54041,14 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 15, moves: ["2L1"]},
-			{generation: 5, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 15, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 15, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 15, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 50, nature: "Brave", perfectIVs: 6, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 15},
+			{generation: 5, level: 50, pokeball: "cherishball"},
+			{generation: 5, level: 100, pokeball: "cherishball"},
+			{generation: 6, level: 15, pokeball: "cherishball"},
+			{generation: 6, level: 100, pokeball: "cherishball"},
+			{generation: 6, level: 15, pokeball: "cherishball"},
+			{generation: 7, level: 15, pokeball: "cherishball"},
+			{generation: 8, level: 50, nature: "Brave", perfectIVs: 6, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -54134,7 +54134,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wringout: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 5, gender: "M", nature: "Hardy", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 5, gender: "M", nature: "Hardy", pokeball: "cherishball"},
 		],
 	},
 	servine: {
@@ -54297,8 +54297,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wringout: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 100, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 100, gender: "M", pokeball: "cherishball"},
+			{generation: 6, level: 50, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	tepig: {
@@ -54573,8 +54573,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 100, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 100, gender: "M", pokeball: "cherishball"},
+			{generation: 6, level: 50, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	oshawott: {
@@ -54822,8 +54822,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 100, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 100, gender: "M", pokeball: "cherishball"},
+			{generation: 6, level: 50, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	samurotthisui: {
@@ -55397,7 +55397,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			uturn: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 20, gender: "F", nature: "Jolly", isHidden: true, moves: ["2L1"]},
+			{generation: 5, level: 20, gender: "F", nature: "Jolly", isHidden: true},
 		],
 	},
 	pansage: {
@@ -55476,9 +55476,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			worryseed: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 1, shiny: 1, gender: "M", nature: "Brave", ivs: {spa: 31}, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 5, level: 30, gender: "M", nature: "Serious", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 1, shiny: 1, gender: "M", nature: "Brave", ivs: {spa: 31}, pokeball: "pokeball"},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
+			{generation: 5, level: 30, gender: "M", nature: "Serious", pokeball: "cherishball"},
 		],
 	},
 	simisage: {
@@ -55625,7 +55625,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			yawn: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
 		],
 	},
 	simisear: {
@@ -55698,7 +55698,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 5, perfectIVs: 2, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 5, perfectIVs: 2, pokeball: "cherishball"},
 		],
 	},
 	panpour: {
@@ -55779,7 +55779,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 10, gender: "M", isHidden: true, moves: ["2L1"]},
+			{generation: 5, level: 10, gender: "M", isHidden: true},
 		],
 	},
 	simipour: {
@@ -55932,7 +55932,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 39, nature: "Mild", isHidden: true, moves: ["2L1"], pokeball: "dreamball"},
+			{generation: 7, level: 39, nature: "Mild", isHidden: true, pokeball: "dreamball"},
 		],
 	},
 	musharna: {
@@ -56010,7 +56010,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 50, isHidden: true, moves: ["2L1"]},
+			{generation: 5, level: 50, isHidden: true},
 		],
 	},
 	pidove: {
@@ -56069,7 +56069,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 1, shiny: 1, gender: "F", nature: "Hardy", ivs: {atk: 31}, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 5, level: 1, shiny: 1, gender: "F", nature: "Hardy", ivs: {atk: 31}, pokeball: "pokeball"},
 		],
 	},
 	tranquill: {
@@ -56939,10 +56939,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 30, gender: "F", nature: "Calm", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 30, gender: "F", nature: "Serious", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 30, gender: "F", nature: "Jolly", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 100, nature: "Relaxed", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 30, gender: "F", nature: "Calm", pokeball: "cherishball"},
+			{generation: 5, level: 30, gender: "F", nature: "Serious", pokeball: "cherishball"},
+			{generation: 5, level: 30, gender: "F", nature: "Jolly", pokeball: "cherishball"},
+			{generation: 6, level: 100, nature: "Relaxed", pokeball: "cherishball"},
 		],
 	},
 	timburr: {
@@ -58078,7 +58078,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			worryseed: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 50, gender: "F", nature: "Timid", ivs: {spe: 31}, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 50, gender: "F", nature: "Timid", ivs: {spe: 31}, pokeball: "cherishball"},
 		],
 	},
 	petilil: {
@@ -59046,8 +59046,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 35, isHidden: true, moves: ["2L1"]},
-			{generation: 6, level: 35, gender: "M", nature: "Calm", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 35, isHidden: true},
+			{generation: 6, level: 35, gender: "M", nature: "Calm", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, isHidden: true, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 6, level: 32, maxEggMoves: 1},
@@ -59432,7 +59432,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 1, gender: "M", nature: "Adamant", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 1, gender: "M", nature: "Adamant", pokeball: "cherishball"},
 		],
 	},
 	scrafty: {
@@ -59543,7 +59543,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 50, gender: "M", nature: "Brave", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 50, gender: "M", nature: "Brave", pokeball: "cherishball"},
 		],
 	},
 	sigilyph: {
@@ -59842,7 +59842,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 66, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 66, gender: "M", pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 6, level: 32, maxEggMoves: 1},
@@ -59992,7 +59992,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 15, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 15, gender: "M", pokeball: "cherishball"},
 		],
 	},
 	carracosta: {
@@ -60151,7 +60151,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 15, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 15, gender: "M", pokeball: "cherishball"},
 		],
 	},
 	archeops: {
@@ -60620,9 +60620,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			uturn: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 50, gender: "M", nature: "Quirky", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, moves: ["2L1"], pokeball: "ultraball"},
-			{generation: 6, level: 45, gender: "M", nature: "Naughty", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 50, gender: "M", nature: "Quirky", pokeball: "cherishball"},
+			{generation: 6, level: 50, pokeball: "ultraball"},
+			{generation: 6, level: 45, gender: "M", nature: "Naughty", pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 5, level: 25},
@@ -60701,7 +60701,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 50, perfectIVs: 3, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 9, level: 50, perfectIVs: 3, pokeball: "cherishball"},
 		],
 	},
 	minccino: {
@@ -61042,8 +61042,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 32, gender: "M", isHidden: true, moves: ["2L1"]},
-			{generation: 5, level: 32, gender: "M", isHidden: true, moves: ["2L1"]},
+			{generation: 5, level: 32, gender: "M", isHidden: true},
+			{generation: 5, level: 32, gender: "M", isHidden: true},
 		],
 		encounters: [
 			{generation: 5, level: 31},
@@ -61792,7 +61792,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 30, gender: "F", isHidden: true, moves: ["2L1"]},
+			{generation: 5, level: 30, gender: "F", isHidden: true},
 		],
 	},
 	sawsbuck: {
@@ -62010,8 +62010,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 30, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 50, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 30, pokeball: "cherishball"},
+			{generation: 5, level: 50, pokeball: "cherishball"},
 		],
 	},
 	escavalier: {
@@ -62207,7 +62207,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			worryseed: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 50, shiny: true, gender: "F", nature: "Sassy", ivs: {hp: 31, atk: 0, def: 31, spa: 31, spd: 31, spe: 0}, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 50, shiny: true, gender: "F", nature: "Sassy", ivs: {hp: 31, atk: 0, def: 31, spa: 31, spd: 31, spe: 0}, isHidden: true, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 5, level: 37},
@@ -62363,7 +62363,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wringout: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 40, isHidden: true, moves: ["2L1"]},
+			{generation: 5, level: 40, isHidden: true},
 		],
 		encounters: [
 			{generation: 5, level: 5},
@@ -63500,7 +63500,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 50, gender: "F", nature: "Modest", ivs: {spa: 31}, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 50, gender: "F", nature: "Modest", ivs: {spa: 31}, pokeball: "cherishball"},
 		],
 	},
 	axew: {
@@ -63587,9 +63587,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 1, shiny: 1, gender: "M", nature: "Naive", ivs: {spe: 31}, abilities: ["2L1"], moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 5, level: 10, gender: "F", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 30, gender: "M", nature: "Naive", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 1, shiny: 1, gender: "M", nature: "Naive", ivs: {spe: 31}, pokeball: "pokeball"},
+			{generation: 5, level: 10, gender: "F", pokeball: "cherishball"},
+			{generation: 5, level: 30, gender: "M", nature: "Naive", pokeball: "cherishball"},
 		],
 	},
 	fraxure: {
@@ -63765,7 +63765,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 59, gender: "F", nature: "Naive", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 59, gender: "F", nature: "Naive", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, pokeball: "cherishball"},
 		],
 	},
 	cubchoo: {
@@ -63855,7 +63855,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			yawn: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 15, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 15, pokeball: "cherishball"},
 		],
 	},
 	beartic: {
@@ -64091,8 +64091,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			yawn: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 30, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 50, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 30, pokeball: "cherishball"},
+			{generation: 5, level: 50, pokeball: "cherishball"},
 		],
 	},
 	accelgor: {
@@ -64481,7 +64481,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 65, gender: "M", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 65, gender: "M", pokeball: "cherishball"},
 		],
 	},
 	druddigon: {
@@ -64579,7 +64579,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			toxic: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 1, shiny: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 5, level: 1, shiny: true, pokeball: "pokeball"},
 		],
 	},
 	golett: {
@@ -64784,7 +64784,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 70, shiny: true, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 70, shiny: true, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 6, level: 30},
@@ -65109,7 +65109,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 50, nature: "Adamant", ivs: {hp: 31, atk: 31}, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 50, nature: "Adamant", ivs: {hp: 31, atk: 31}, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	rufflet: {
@@ -65259,7 +65259,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 25, gender: "M", isHidden: true, moves: ["2L1"]},
+			{generation: 5, level: 25, gender: "M", isHidden: true},
 		],
 		encounters: [
 			{generation: 6, level: 45},
@@ -65497,7 +65497,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlwind: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 25, gender: "F", isHidden: true, moves: ["2L1"]},
+			{generation: 5, level: 25, gender: "F", isHidden: true},
 		],
 	},
 	heatmor: {
@@ -65724,7 +65724,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 1, shiny: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 5, level: 1, shiny: true, pokeball: "pokeball"},
 		],
 	},
 	zweilous: {
@@ -65910,8 +65910,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 70, shiny: true, gender: "M", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 52, gender: "M", perfectIVs: 2, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 70, shiny: true, gender: "M", pokeball: "cherishball"},
+			{generation: 6, level: 52, gender: "M", perfectIVs: 2, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 6, level: 59},
@@ -66064,8 +66064,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 35, moves: ["2L1"]},
-			{generation: 5, level: 77, gender: "M", nature: "Calm", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 35},
+			{generation: 5, level: 77, gender: "M", nature: "Calm", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 7, level: 41},
@@ -66157,12 +66157,12 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 42, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 45, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 65, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 5, level: 42, shiny: 1},
+			{generation: 5, level: 45, shiny: 1},
+			{generation: 5, level: 65, shiny: 1},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -66245,12 +66245,12 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 42, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 45, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 65, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 5, level: 42, shiny: 1},
+			{generation: 5, level: 45, shiny: 1},
+			{generation: 5, level: 65, shiny: 1},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -66339,12 +66339,12 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 42, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 45, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 65, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 5, level: 42, shiny: 1},
+			{generation: 5, level: 45, shiny: 1},
+			{generation: 5, level: 65, shiny: 1},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -66434,14 +66434,14 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			weatherball: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 40, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 5, isHidden: true, moves: ["2L1"], pokeball: "dreamball"},
-			{generation: 5, level: 70, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 5, level: 40, shiny: 1},
+			{generation: 5, level: 5, isHidden: true, pokeball: "dreamball"},
+			{generation: 5, level: 70, pokeball: "cherishball"},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 7, level: 60, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -66542,14 +66542,14 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 40, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 5, isHidden: true, moves: ["2L1"], pokeball: "dreamball"},
-			{generation: 5, level: 70, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 5, level: 40, shiny: 1},
+			{generation: 5, level: 5, isHidden: true, pokeball: "dreamball"},
+			{generation: 5, level: 70, pokeball: "cherishball"},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 7, level: 60, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -66652,14 +66652,14 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 50, moves: ["2L1"]},
-			{generation: 5, level: 70, moves: ["2L1"]},
-			{generation: 5, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 5, level: 50},
+			{generation: 5, level: 70},
+			{generation: 5, level: 100, pokeball: "cherishball"},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 7, level: 60, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -66765,14 +66765,14 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 50, moves: ["2L1"]},
-			{generation: 5, level: 70, moves: ["2L1"]},
-			{generation: 5, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 5, level: 50},
+			{generation: 5, level: 70},
+			{generation: 5, level: 100, pokeball: "cherishball"},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 7, level: 60, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -66859,12 +66859,12 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			weatherball: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 5, isHidden: true, moves: ["2L1"], pokeball: "dreamball"},
-			{generation: 6, level: 65, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 50, nature: "Adamant", ivs: {hp: 31, atk: 31, def: 31, spa: 1, spd: 31, spe: 24}, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 5, level: 70, shiny: 1},
+			{generation: 5, level: 5, isHidden: true, pokeball: "dreamball"},
+			{generation: 6, level: 65, shiny: 1},
+			{generation: 6, level: 50, nature: "Adamant", ivs: {hp: 31, atk: 31, def: 31, spa: 1, spd: 31, spe: 24}, pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -66961,12 +66961,12 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 75, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 5, level: 75, shiny: 1},
+			{generation: 5, level: 70, shiny: 1},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 6, level: 100, pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -67061,12 +67061,12 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 75, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 5, level: 75, shiny: 1},
+			{generation: 5, level: 70, shiny: 1},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 6, level: 100, pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -67161,12 +67161,12 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 75, shiny: 1, moves: ["2L1"]},
-			{generation: 5, level: 70, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 50, shiny: 1, moves: ["2L1"]},
-			{generation: 6, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 5, level: 75, shiny: 1},
+			{generation: 5, level: 70, shiny: 1},
+			{generation: 6, level: 50, shiny: 1},
+			{generation: 6, level: 100, pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -67255,11 +67255,11 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 15, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 15, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 65, moves: ["2L1"]},
+			{generation: 5, level: 15, pokeball: "cherishball"},
+			{generation: 5, level: 50, pokeball: "cherishball"},
+			{generation: 6, level: 15, pokeball: "cherishball"},
+			{generation: 6, level: 100, pokeball: "cherishball"},
+			{generation: 8, level: 65},
 		],
 		eventOnly: false,
 	},
@@ -67376,10 +67376,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 15, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 15, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 50, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 15, pokeball: "cherishball"},
+			{generation: 5, level: 50, pokeball: "cherishball"},
+			{generation: 7, level: 15, pokeball: "cherishball"},
+			{generation: 7, level: 50, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -67469,11 +67469,11 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 5, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 15, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 5, level: 100, shiny: true, nature: "Hasty", ivs: {atk: 31, spe: 31}, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 60, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 5, level: 50, pokeball: "cherishball"},
+			{generation: 5, level: 15, pokeball: "cherishball"},
+			{generation: 5, level: 100, shiny: true, nature: "Hasty", ivs: {atk: 31, spe: 31}, pokeball: "cherishball"},
+			{generation: 6, level: 100, pokeball: "cherishball"},
+			{generation: 8, level: 60, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -67884,7 +67884,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 15, gender: "F", nature: "Hardy", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 15, gender: "F", nature: "Hardy", pokeball: "cherishball"},
 		],
 	},
 	braixen: {
@@ -68161,7 +68161,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 7, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 7, pokeball: "cherishball"},
 		],
 	},
 	frogadier: {
@@ -68337,8 +68337,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 36, ivs: {spe: 31}, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 100, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 36, ivs: {spe: 31}, isHidden: true, pokeball: "cherishball"},
+			{generation: 6, level: 100, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	greninjabond: {
@@ -68432,7 +68432,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 36, ivs: {hp: 20, atk: 31, def: 20, spa: 31, spd: 20, spe: 31}, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 36, ivs: {hp: 20, atk: 31, def: 20, spa: 31, spd: 20, spe: 31}, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -68968,7 +68968,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			uturn: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 12, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 12, pokeball: "cherishball"},
 		],
 	},
 	vivillonpokeball: {
@@ -69040,7 +69040,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			uturn: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 12, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 6, level: 12, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -69189,7 +69189,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 49, gender: "M", perfectIVs: 2, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 49, gender: "M", perfectIVs: 2, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 6, level: 30},
@@ -69722,7 +69722,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 30, gender: "M", nature: "Adamant", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 30, gender: "M", nature: "Adamant", pokeball: "cherishball"},
 		],
 	},
 	pangoro: {
@@ -70360,7 +70360,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wideguard: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 50, gender: "F", nature: "Quiet", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 50, gender: "F", nature: "Quiet", pokeball: "cherishball"},
 		],
 	},
 	spritzee: {
@@ -70502,7 +70502,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			trickroom: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 50, nature: "Relaxed", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 50, nature: "Relaxed", isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	swirlix: {
@@ -70721,7 +70721,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wrap: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 10, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 10, pokeball: "cherishball"},
 		],
 	},
 	malamar: {
@@ -70816,7 +70816,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wrap: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 50, nature: "Adamant", ivs: {hp: 31, atk: 31}, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 50, nature: "Adamant", ivs: {hp: 31, atk: 31}, pokeball: "cherishball"},
 		],
 	},
 	binacle: {
@@ -71544,7 +71544,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 10, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 10, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	tyrantrum: {
@@ -71711,7 +71711,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 10, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 10, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	aurorus: {
@@ -71881,9 +71881,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 10, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 10, gender: "F", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 50, gender: "F", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 10, pokeball: "cherishball"},
+			{generation: 6, level: 10, gender: "F", pokeball: "cherishball"},
+			{generation: 7, level: 50, gender: "F", isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	hawlucha: {
@@ -72214,7 +72214,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			waterpulse: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 1, shiny: 1, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 1, shiny: 1, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	sliggoo: {
@@ -72826,7 +72826,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			trickortreat: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 50, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 50, pokeball: "cherishball"},
 		],
 	},
 	gourgeist: {
@@ -73348,12 +73348,12 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 50, moves: ["2L1"]},
-			{generation: 6, level: 100, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 6, level: 50},
+			{generation: 6, level: 100, shiny: true, pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 7, level: 60, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -73427,12 +73427,12 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 50, moves: ["2L1"]},
-			{generation: 6, level: 100, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 7, level: 60, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 6, level: 50},
+			{generation: 6, level: 100, shiny: true, pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 7, level: 60, pokeball: "cherishball"},
+			{generation: 7, level: 100, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -73510,16 +73510,16 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 70, moves: ["2L1"]},
-			{generation: 6, level: 100, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 30, moves: ["2L1"]},
-			{generation: 7, level: 50, moves: ["2L1"]},
-			{generation: 7, level: 50, isHidden: true, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: true, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, shiny: true, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, isHidden: true, moves: ["2L1"]},
+			{generation: 6, level: 70},
+			{generation: 6, level: 100, pokeball: "cherishball"},
+			{generation: 7, level: 30},
+			{generation: 7, level: 50},
+			{generation: 7, level: 50, isHidden: true},
+			{generation: 7, level: 60, shiny: true, pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: true, isHidden: true, pokeball: "cherishball"},
+			{generation: 7, level: 100, shiny: true, pokeball: "cherishball"},
+			{generation: 7, level: 100, shiny: true, isHidden: true, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1, isHidden: true},
 		],
 		eventOnly: false,
 	},
@@ -73540,12 +73540,12 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			thousandarrows: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 30, moves: ["2L1"]},
-			{generation: 7, level: 50, isHidden: true, moves: ["2L1"]},
-			{generation: 7, level: 50, isHidden: true, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: true, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 100, shiny: true, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, isHidden: true, moves: ["2L1"]},
+			{generation: 7, level: 30},
+			{generation: 7, level: 50, isHidden: true},
+			{generation: 7, level: 50, isHidden: true},
+			{generation: 7, level: 60, shiny: true, isHidden: true, pokeball: "cherishball"},
+			{generation: 7, level: 100, shiny: true, isHidden: true, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1, isHidden: true},
 		],
 		eventOnly: false,
 	},
@@ -73643,8 +73643,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wonderroom: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 50, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 50, pokeball: "cherishball"},
+			{generation: 6, level: 50, shiny: true, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -73749,8 +73749,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 15, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 50, pokeball: "cherishball"},
+			{generation: 7, level: 15, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -73843,9 +73843,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 70, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 6, level: 70, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 60, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 70, pokeball: "cherishball"},
+			{generation: 6, level: 70, pokeball: "cherishball"},
+			{generation: 8, level: 60, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -74107,7 +74107,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			worryseed: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 50, isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 50, isHidden: true, pokeball: "pokeball"},
 		],
 	},
 	decidueyehisui: {
@@ -74427,7 +74427,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 50, isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 50, isHidden: true, pokeball: "pokeball"},
 		],
 	},
 	popplio: {
@@ -74659,7 +74659,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 50, isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 50, isHidden: true, pokeball: "pokeball"},
 		],
 	},
 	pikipek: {
@@ -75080,7 +75080,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 20, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 20, perfectIVs: 3, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -75333,7 +75333,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 35, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 35, perfectIVs: 3, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -75803,7 +75803,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wonderroom: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 50, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 50, perfectIVs: 3, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -75944,8 +75944,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 10, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 10, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 10, pokeball: "cherishball"},
+			{generation: 7, level: 10, pokeball: "cherishball"},
 		],
 	},
 	lycanroc: {
@@ -76121,7 +76121,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 50, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 50, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	lycanrocdusk: {
@@ -76334,7 +76334,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wideguard: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 1, shiny: 1, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 1, shiny: 1, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	toxapex: {
@@ -76735,7 +76735,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 25, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 25, perfectIVs: 3, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -76935,7 +76935,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 30, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 30, perfectIVs: 3, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -77239,7 +77239,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 50, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 50, pokeball: "cherishball"},
 		],
 		encounters: [
 			{generation: 7, level: 16},
@@ -77306,7 +77306,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 30, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 30, perfectIVs: 3, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -77450,7 +77450,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 50, gender: "F", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 50, gender: "F", isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	bounsweet: {
@@ -77583,7 +77583,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 20, nature: "Naive", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 20, nature: "Naive", pokeball: "cherishball"},
 		],
 	},
 	tsareena: {
@@ -77754,7 +77754,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wrap: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 10, nature: "Jolly", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 10, nature: "Jolly", pokeball: "cherishball"},
 		],
 	},
 	oranguru: {
@@ -77852,8 +77852,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 1, shiny: 1, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 50, isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 1, shiny: 1, pokeball: "cherishball"},
+			{generation: 7, level: 50, isHidden: true, pokeball: "pokeball"},
 		],
 	},
 	passimian: {
@@ -77951,8 +77951,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 1, shiny: 1, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 50, isHidden: true, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 1, shiny: 1, pokeball: "cherishball"},
+			{generation: 7, level: 50, isHidden: true, pokeball: "pokeball"},
 		],
 	},
 	wimpod: {
@@ -78339,9 +78339,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 40, shiny: 1, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 7, level: 60, shiny: 1, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 8, level: 50, shiny: 1, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 40, shiny: 1, perfectIVs: 3, pokeball: "pokeball"},
+			{generation: 7, level: 60, shiny: 1, perfectIVs: 3, pokeball: "pokeball"},
+			{generation: 8, level: 50, shiny: 1, perfectIVs: 3, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -78435,7 +78435,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 100, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 100, shiny: true, pokeball: "cherishball"},
 		],
 	},
 	minior: {
@@ -78667,8 +78667,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 1, shiny: 1, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 30, gender: "M", nature: "Brave", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 1, shiny: 1, pokeball: "cherishball"},
+			{generation: 7, level: 30, gender: "M", nature: "Brave", pokeball: "cherishball"},
 		],
 	},
 	togedemaru: {
@@ -78816,7 +78816,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zingzap: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 30, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 30, perfectIVs: 3, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -78911,10 +78911,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 10, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 10, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 50, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 9, level: 25, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 10, pokeball: "cherishball"},
+			{generation: 7, level: 10, shiny: true, pokeball: "cherishball"},
+			{generation: 7, level: 50, shiny: true, pokeball: "cherishball"},
+			{generation: 9, level: 25, pokeball: "cherishball"},
 		],
 	},
 	mimikyutotem: {
@@ -78987,7 +78987,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 40, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 40, perfectIVs: 3, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -79171,7 +79171,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 1, shiny: 1, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 1, shiny: 1, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	dhelmise: {
@@ -79602,7 +79602,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 50, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 50, perfectIVs: 3, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -79684,10 +79684,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 60, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: true, nature: "Timid", moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 7, level: 60, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 7, level: 60},
+			{generation: 7, level: 60, shiny: true, nature: "Timid", pokeball: "cherishball"},
+			{generation: 7, level: 60, shiny: true, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -79766,9 +79766,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wonderroom: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 60, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 7, level: 60},
+			{generation: 7, level: 60, shiny: true, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -79857,9 +79857,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 60, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 7, level: 60},
+			{generation: 7, level: 60, shiny: true, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -79938,9 +79938,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wonderroom: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 60, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 7, level: 60},
+			{generation: 7, level: 60, shiny: true, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -79950,8 +79950,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			teleport: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 5, moves: ["2L1"]},
-			{generation: 8, level: 5, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 7, level: 5},
+			{generation: 8, level: 5, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -80052,10 +80052,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 55, moves: ["2L1"]},
-			{generation: 7, level: 60, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 7, level: 55},
+			{generation: 7, level: 60},
+			{generation: 7, level: 60, shiny: true, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 	},
 	lunala: {
@@ -80147,10 +80147,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 55, moves: ["2L1"]},
-			{generation: 7, level: 60, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 7, level: 55},
+			{generation: 7, level: 60},
+			{generation: 7, level: 60, shiny: true, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 	},
 	nihilego: {
@@ -80229,9 +80229,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 55, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 7, level: 55},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -80304,9 +80304,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 65, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 7, level: 65},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -80380,9 +80380,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			uturn: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 60, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 7, level: 60},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -80448,9 +80448,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 65, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 7, level: 65},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -80523,9 +80523,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 65, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 7, level: 65},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -80578,9 +80578,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 60, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 7, level: 60},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -80664,9 +80664,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wringout: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 70, moves: ["2L1"]},
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 7, level: 70},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -80764,10 +80764,10 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 75, moves: ["2L1"]},
-			{generation: 7, level: 65, moves: ["2L1"]},
-			{generation: 7, level: 75, shiny: true, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 7, level: 75},
+			{generation: 7, level: 65},
+			{generation: 7, level: 75, shiny: true, pokeball: "cherishball"},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -80897,7 +80897,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 50, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 50, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -80988,7 +80988,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 50, nature: "Mild", ivs: {hp: 31, atk: 30, def: 30, spa: 31, spd: 31, spe: 0}, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 50, nature: "Mild", ivs: {hp: 31, atk: 30, def: 30, spa: 31, spd: 31, spe: 0}, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -81080,8 +81080,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 60, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 50, pokeball: "cherishball"},
+			{generation: 8, level: 60, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -81126,9 +81126,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			venoshock: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 40, shiny: 1, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 7, level: 40, shiny: true, nature: "Modest", perfectIVs: 3, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 20, moves: ["2L1"], pokeball: "beastball"},
+			{generation: 7, level: 40, shiny: 1, perfectIVs: 3, pokeball: "pokeball"},
+			{generation: 7, level: 40, shiny: true, nature: "Modest", perfectIVs: 3, pokeball: "cherishball"},
+			{generation: 8, level: 20, pokeball: "beastball"},
 		],
 		eventOnly: false,
 	},
@@ -81283,8 +81283,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -81358,8 +81358,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 60, shiny: 1, moves: ["2L1"]},
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 7, level: 60, shiny: 1},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -81450,8 +81450,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 50, moves: ["2L1"], pokeball: "cherishball"},
-			{generation: 8, level: 100, shiny: true, nature: "Hasty", ivs: {hp: 31, atk: 31, def: 30, spa: 31, spd: 31, spe: 31}, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 50, pokeball: "cherishball"},
+			{generation: 8, level: 100, shiny: true, nature: "Hasty", ivs: {hp: 31, atk: 31, def: 30, spa: 31, spd: 31, spe: 31}, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -81530,7 +81530,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			toxic: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 100, nature: "Brave", ivs: {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 0}, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 100, nature: "Brave", ivs: {hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 0}, pokeball: "cherishball"},
 		],
 	},
 	grookey: {
@@ -83558,7 +83558,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			terablast: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 1, isHidden: true, moves: ["2L1"], pokeball: "luxuryball"},
+			{generation: 8, level: 1, isHidden: true, pokeball: "luxuryball"},
 		],
 	},
 	toxtricity: {
@@ -83645,7 +83645,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wildcharge: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 50, shiny: true, nature: "Rash", abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 50, shiny: true, nature: "Rash", pokeball: "cherishball"},
 		],
 	},
 	toxtricitylowkey: {
@@ -84021,7 +84021,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			withdraw: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 50, isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 50, isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	polteageist: {
@@ -84449,7 +84449,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wonderroom: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 50, nature: "Calm", shiny: true, abilities: ["2L1"], ivs: {hp: 31, atk: 0, def: 31, spa: 31, spd: 31, spe: 31}, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 9, level: 50, nature: "Calm", shiny: true, ivs: {hp: 31, atk: 0, def: 31, spa: 31, spd: 31, spe: 31}, pokeball: "cherishball"},
 		],
 	},
 	milcery: {
@@ -84484,7 +84484,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			terablast: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 5, nature: "Hardy", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 5, nature: "Hardy", isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	alcremie: {
@@ -84994,7 +84994,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 75, shiny: 1, perfectIVs: 4, moves: ["2L1"]},
+			{generation: 9, level: 75, shiny: 1, perfectIVs: 4},
 		],
 	},
 	morpeko: {
@@ -85266,7 +85266,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wildcharge: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 10, shiny: 1, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 8, level: 10, shiny: 1, perfectIVs: 3, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -85328,7 +85328,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wildcharge: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 10, shiny: 1, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 8, level: 10, shiny: 1, perfectIVs: 3, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -85386,8 +85386,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 10, shiny: 1, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 8, level: 80, nature: "Naive", abilities: ["2L1"], ivs: {hp: 30, atk: 31, def: 31, spa: 30, spd: 30, spe: 31}, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 8, level: 10, shiny: 1, perfectIVs: 3, pokeball: "pokeball"},
+			{generation: 8, level: 80, nature: "Naive", ivs: {hp: 30, atk: 31, def: 31, spa: 30, spd: 30, spe: 31}, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -85440,7 +85440,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 10, shiny: 1, perfectIVs: 3, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 8, level: 10, shiny: 1, perfectIVs: 3, pokeball: "pokeball"},
 		],
 		eventOnly: false,
 	},
@@ -85676,7 +85676,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 50, gender: "M", nature: "Jolly", perfectIVs: 6, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 9, level: 50, gender: "M", nature: "Jolly", perfectIVs: 6, pokeball: "cherishball"},
 		],
 	},
 	zacian: {
@@ -85746,8 +85746,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 70, perfectIVs: 3, moves: ["2L1"]},
-			{generation: 8, level: 100, shiny: true, nature: "Adamant", ivs: {hp: 31, atk: 31, def: 31, spa: 30, spd: 31, spe: 31}, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 70, perfectIVs: 3},
+			{generation: 8, level: 100, shiny: true, nature: "Adamant", ivs: {hp: 31, atk: 31, def: 31, spa: 30, spd: 31, spe: 31}, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -85829,8 +85829,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 70, perfectIVs: 3, moves: ["2L1"]},
-			{generation: 8, level: 100, shiny: true, nature: "Adamant", ivs: {hp: 31, atk: 31, def: 31, spa: 30, spd: 31, spe: 31}, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 70, perfectIVs: 3},
+			{generation: 8, level: 100, shiny: true, nature: "Adamant", ivs: {hp: 31, atk: 31, def: 31, spa: 30, spd: 31, spe: 31}, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -85897,8 +85897,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			venoshock: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 60, perfectIVs: 3, moves: ["2L1"]},
-			{generation: 8, level: 100, shiny: true, nature: "Timid", perfectIVs: 6, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 60, perfectIVs: 3},
+			{generation: 8, level: 100, shiny: true, nature: "Timid", perfectIVs: 6, pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -85954,7 +85954,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 10, perfectIVs: 3, moves: ["2L1"]},
+			{generation: 8, level: 10, perfectIVs: 3},
 		],
 		eventOnly: false,
 	},
@@ -86199,7 +86199,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			vinewhip: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 60, nature: "Sassy", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 60, nature: "Sassy", pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -86289,7 +86289,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			vinewhip: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 70, nature: "Adamant", moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 70, nature: "Adamant", pokeball: "cherishball"},
 		],
 		eventOnly: false,
 	},
@@ -86344,7 +86344,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -86395,7 +86395,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			visegrip: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 70, shiny: 1, moves: ["2L1"]},
+			{generation: 8, level: 70, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -86458,7 +86458,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 75, moves: ["2L1"]},
+			{generation: 8, level: 75},
 		],
 		eventOnly: false,
 	},
@@ -86516,7 +86516,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 75, moves: ["2L1"]},
+			{generation: 8, level: 75},
 		],
 		eventOnly: false,
 	},
@@ -86593,7 +86593,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 80, moves: ["2L1"]},
+			{generation: 8, level: 80},
 		],
 		eventOnly: false,
 	},
@@ -86709,7 +86709,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 80, moves: ["2L1"]},
+			{generation: 8, level: 80},
 		],
 		eventOnly: false,
 	},
@@ -86815,7 +86815,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 80, moves: ["2L1"]},
+			{generation: 8, level: 80},
 		],
 		eventOnly: false,
 	},
@@ -87475,7 +87475,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 15, gender: "M", isHidden: true, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 9, level: 15, gender: "M", isHidden: true, pokeball: "cherishball"},
 		],
 	},
 	oinkologne: {
@@ -88492,7 +88492,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 50, gender: "F", nature: "Adamant", ivs: {hp: 31, atk: 31, def: 31, spa: 17, spd: 31, spe: 31}, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 9, level: 50, gender: "F", nature: "Adamant", ivs: {hp: 31, atk: 31, def: 31, spa: 17, spd: 31, spe: 31}, pokeball: "cherishball"},
 		],
 	},
 	smoliv: {
@@ -88920,7 +88920,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 50, gender: "F", nature: "Naughty", abilities: ["2L1"], ivs: {hp: 20, atk: 31, def: 20, spa: 20, spd: 20, spe: 20}, moves: ["2L1"], pokeball: "healball"},
+			{generation: 9, level: 50, gender: "F", nature: "Naughty", ivs: {hp: 20, atk: 31, def: 20, spa: 20, spd: 20, spe: 20}, pokeball: "healball"},
 		],
 	},
 	orthworm: {
@@ -88972,7 +88972,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wrap: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 29, gender: "M", nature: "Quirky", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, moves: ["2L1"]},
+			{generation: 9, level: 29, gender: "M", nature: "Quirky", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}},
 		],
 	},
 	tandemaus: {
@@ -89184,7 +89184,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			waterpulse: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, moves: ["2L1"]},
+			{generation: 9},
 		],
 	},
 	frigibax: {
@@ -89363,7 +89363,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 57, gender: "M", nature: "Quiet", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, moves: ["2L1"]},
+			{generation: 9, level: 57, gender: "M", nature: "Quiet", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}},
 		],
 	},
 	tatsugiristretchy: {
@@ -89374,7 +89374,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			muddywater: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 50, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 9, level: 50, pokeball: "cherishball"},
 		],
 	},
 	cyclizar: {
@@ -89491,7 +89491,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wish: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 5, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 9, level: 5, pokeball: "cherishball"},
 		],
 	},
 	pawmo: {
@@ -89792,7 +89792,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wingattack: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 20, gender: "F", nature: "Jolly", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, isHidden: true, moves: ["2L1"]},
+			{generation: 9, level: 20, gender: "F", nature: "Jolly", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, isHidden: true},
 		],
 	},
 	squawkabilly: {
@@ -89963,7 +89963,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 16, gender: "F", nature: "Gentle", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, abilities: ["2L1"], moves: ["2L1"]},
+			{generation: 9, level: 16, gender: "F", nature: "Gentle", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}},
 		],
 	},
 	nacli: {
@@ -90116,7 +90116,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 50, gender: "M", nature: "Careful", ivs: {hp: 31, atk: 31, def: 31, spa: 22, spd: 31, spe: 31}, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 9, level: 50, gender: "M", nature: "Careful", ivs: {hp: 31, atk: 31, def: 31, spa: 22, spd: 31, spe: 31}, pokeball: "cherishball"},
 		],
 	},
 	glimmet: {
@@ -90384,7 +90384,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			yawn: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 5, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 9, level: 5, pokeball: "cherishball"},
 		],
 	},
 	dachsbun: {
@@ -90656,9 +90656,9 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			thief: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 5, moves: ["2L1"]},
-			{generation: 9, level: 75, shiny: 1, perfectIVs: 4, moves: ["2L1"]},
-			{generation: 9, level: 5, nature: "Timid", ivs: {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 31}, moves: ["2L1"]},
+			{generation: 9, level: 5},
+			{generation: 9, level: 75, shiny: 1, perfectIVs: 4},
+			{generation: 9, level: 5, nature: "Timid", ivs: {hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 31}},
 		],
 		eventOnly: false,
 	},
@@ -90773,8 +90773,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 45, nature: "Naughty", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, moves: ["2L1"]},
-			{generation: 9, level: 57, shiny: 1, moves: ["2L1"]},
+			{generation: 9, level: 45, nature: "Naughty", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}},
+			{generation: 9, level: 57, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -90833,7 +90833,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 52, shiny: 1, moves: ["2L1"]},
+			{generation: 9, level: 52, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -90895,7 +90895,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 52, shiny: 1, moves: ["2L1"]},
+			{generation: 9, level: 52, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -90983,7 +90983,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 52, shiny: 1, moves: ["2L1"]},
+			{generation: 9, level: 52, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -91040,7 +91040,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wish: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 52, shiny: 1, moves: ["2L1"]},
+			{generation: 9, level: 52, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -91105,7 +91105,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 52, shiny: 1, moves: ["2L1"]},
+			{generation: 9, level: 52, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -91181,7 +91181,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 52, shiny: 1, moves: ["2L1"]},
+			{generation: 9, level: 52, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -91241,8 +91241,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 45, nature: "Naughty", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}, moves: ["2L1"]},
-			{generation: 9, level: 57, shiny: 1, moves: ["2L1"]},
+			{generation: 9, level: 45, nature: "Naughty", ivs: {hp: 30, atk: 30, def: 30, spa: 30, spd: 30, spe: 30}},
+			{generation: 9, level: 57, shiny: 1},
 		],
 	},
 	ironmoth: {
@@ -91301,7 +91301,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlwind: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 52, shiny: 1, moves: ["2L1"]},
+			{generation: 9, level: 52, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -91365,7 +91365,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wildcharge: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 52, shiny: 1, moves: ["2L1"]},
+			{generation: 9, level: 52, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -91429,7 +91429,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 52, shiny: 1, moves: ["2L1"]},
+			{generation: 9, level: 52, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -91513,7 +91513,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wildcharge: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 52, shiny: 1, moves: ["2L1"]},
+			{generation: 9, level: 52, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -91562,7 +91562,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 52, shiny: 1, moves: ["2L1"]},
+			{generation: 9, level: 52, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -91650,7 +91650,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 52, shiny: 1, moves: ["2L1"]},
+			{generation: 9, level: 52, shiny: 1},
 		],
 		eventOnly: false,
 	},
@@ -91704,7 +91704,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 60, moves: ["2L1"]},
+			{generation: 9, level: 60},
 		],
 		eventOnly: false,
 	},
@@ -91757,7 +91757,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			throatchop: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 60, moves: ["2L1"]},
+			{generation: 9, level: 60},
 		],
 		eventOnly: false,
 	},
@@ -91817,7 +91817,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 60, moves: ["2L1"]},
+			{generation: 9, level: 60},
 		],
 		eventOnly: false,
 	},
@@ -91871,7 +91871,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 60, moves: ["2L1"]},
+			{generation: 9, level: 60},
 		],
 		eventOnly: false,
 	},
@@ -91951,8 +91951,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 68, nature: "Quirky", ivs: {hp: 31, atk: 31, def: 28, spa: 31, spd: 28, spe: 31}, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 9, level: 72, nature: "Adamant", ivs: {hp: 25, atk: 31, def: 25, spa: 31, spd: 25, spe: 31}, moves: ["2L1"]},
+			{generation: 9, level: 68, nature: "Quirky", ivs: {hp: 31, atk: 31, def: 28, spa: 31, spd: 28, spe: 31}, pokeball: "pokeball"},
+			{generation: 9, level: 72, nature: "Adamant", ivs: {hp: 25, atk: 31, def: 25, spa: 31, spd: 25, spe: 31}},
 		],
 		eventOnly: false,
 	},
@@ -92016,8 +92016,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 68, nature: "Quirky", ivs: {hp: 31, atk: 31, def: 28, spa: 31, spd: 28, spe: 31}, moves: ["2L1"], pokeball: "pokeball"},
-			{generation: 9, level: 72, nature: "Modest", ivs: {hp: 25, atk: 31, def: 25, spa: 31, spd: 25, spe: 31}, moves: ["2L1"]},
+			{generation: 9, level: 68, nature: "Quirky", ivs: {hp: 31, atk: 31, def: 28, spa: 31, spd: 28, spe: 31}, pokeball: "pokeball"},
+			{generation: 9, level: 72, nature: "Modest", ivs: {hp: 25, atk: 31, def: 25, spa: 31, spd: 25, spe: 31}},
 		],
 		eventOnly: false,
 	},
@@ -92206,7 +92206,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			willowisp: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 5, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 9, level: 5, pokeball: "cherishball"},
 		],
 	},
 	armarouge: {
@@ -92512,7 +92512,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			whirlpool: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 75, perfectIVs: 3, moves: ["2L1"]},
+			{generation: 9, level: 75, perfectIVs: 3},
 		],
 		eventOnly: false,
 	},
@@ -92577,7 +92577,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 75, perfectIVs: 3, moves: ["2L1"]},
+			{generation: 9, level: 75, perfectIVs: 3},
 		],
 		eventOnly: false,
 	},
@@ -92866,7 +92866,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			uproar: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 70, moves: ["2L1"]},
+			{generation: 9, level: 70},
 		],
 		eventOnly: false,
 	},
@@ -92930,7 +92930,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			venoshock: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 70, moves: ["2L1"]},
+			{generation: 9, level: 70},
 		],
 		eventOnly: false,
 	},
@@ -93001,7 +93001,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wingattack: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 70, moves: ["2L1"]},
+			{generation: 9, level: 70},
 		],
 		eventOnly: false,
 	},
@@ -93071,8 +93071,8 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zenheadbutt: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 20, nature: "Lonely", ivs: {hp: 31, atk: 31, def: 20, spa: 20, spd: 20, spe: 31}, moves: ["2L1"]},
-			{generation: 9, level: 70, nature: "Lonely", ivs: {hp: 31, atk: 31, def: 20, spa: 20, spd: 20, spe: 31}, moves: ["2L1"]},
+			{generation: 9, level: 20, nature: "Lonely", ivs: {hp: 31, atk: 31, def: 20, spa: 20, spd: 20, spe: 31}},
+			{generation: 9, level: 70, nature: "Lonely", ivs: {hp: 31, atk: 31, def: 20, spa: 20, spd: 20, spe: 31}},
 		],
 		eventOnly: false,
 	},
@@ -95515,7 +95515,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wildcharge: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 50, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 9, level: 50, pokeball: "pokeball"},
 		],
 	},
 	voodoll: {
@@ -97470,7 +97470,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			yawn: ["2L1"],
 		},
 		eventData: [
-			{generation: 6, level: 16, abilities: ["2L1"], moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 6, level: 16, pokeball: "cherishball"},
 		],
 	},
 	pajantom: {
@@ -97951,7 +97951,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			zapcannon: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 50, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 50, pokeball: "cherishball"},
 		],
 	},
 	smogecko: {
@@ -98195,7 +98195,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 50, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 50, pokeball: "cherishball"},
 		],
 	},
 	swirlpool: {
@@ -98462,7 +98462,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			xscissor: ["2L1"],
 		},
 		eventData: [
-			{generation: 7, level: 50, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 7, level: 50, pokeball: "cherishball"},
 		],
 	},
 	justyke: {
@@ -98600,7 +98600,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			workup: ["2L1"],
 		},
 		eventData: [
-			{generation: 9, level: 50, moves: ["2L1"], pokeball: "pokeball"},
+			{generation: 9, level: 50, pokeball: "pokeball"},
 		],
 	},
 	solotl: {
@@ -98959,7 +98959,7 @@ export const Learnsets: {[k: string]: ModdedLearnsetData} = {
 			wideguard: ["2L1"],
 		},
 		eventData: [
-			{generation: 8, level: 50, moves: ["2L1"], pokeball: "cherishball"},
+			{generation: 8, level: 50, pokeball: "cherishball"},
 		],
 	},
 	venomicon: {

--- a/data/mods/moderngen2/learnsets.ts
+++ b/data/mods/moderngen2/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
+export const Learnsets: import('../../../sim/dex-species').ModdedLearnsetDataTable = {
 	missingno: {
 		learnset: {
 			blizzard: ["2L1"],

--- a/data/mods/moderngen2/learnsets.ts
+++ b/data/mods/moderngen2/learnsets.ts
@@ -1,4 +1,4 @@
-export const Learnsets: {[k: IDEntry]: ModdedLearnsetData} = {
+export const Learnsets: {[id: IDEntry]: ModdedLearnsetData} = {
 	missingno: {
 		learnset: {
 			blizzard: ["2L1"],

--- a/data/mods/moderngen2/pokedex.ts
+++ b/data/mods/moderngen2/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
+export const Pokedex: import('../../../sim/dex-species').ModdedSpeciesDataTable = {
 	treecko: {
 		inherit: true,
 		gen: 2,

--- a/data/mods/moderngen2/pokedex.ts
+++ b/data/mods/moderngen2/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[k: string]: ModdedSpeciesData} = {
+export const Pokedex: {[id: IDEntry]: ModdedSpeciesData} = {
 	treecko: {
 		inherit: true,
 		gen: 2,

--- a/data/mods/moderngen2/rulesets.ts
+++ b/data/mods/moderngen2/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
+export const Rulesets: import('../../../sim/dex-formats').ModdedFormatDataTable = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',

--- a/data/mods/moderngen2/rulesets.ts
+++ b/data/mods/moderngen2/rulesets.ts
@@ -1,4 +1,4 @@
-export const Rulesets: {[k: string]: ModdedFormatData} = {
+export const Rulesets: {[id: IDEntry]: ModdedFormatData} = {
 	standard: {
 		effectType: 'ValidatorRule',
 		name: 'Standard',

--- a/data/mods/partnersincrime/abilities.ts
+++ b/data/mods/partnersincrime/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
+export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	neutralizinggas: {
 		inherit: true,
 		// Ability suppression implemented in sim/pokemon.ts:Pokemon#ignoringAbility

--- a/data/mods/partnersincrime/abilities.ts
+++ b/data/mods/partnersincrime/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
 	neutralizinggas: {
 		inherit: true,
 		// Ability suppression implemented in sim/pokemon.ts:Pokemon#ignoringAbility

--- a/data/mods/partnersincrime/items.ts
+++ b/data/mods/partnersincrime/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	leppaberry: {
 		inherit: true,
 		onEat(pokemon) {

--- a/data/mods/partnersincrime/items.ts
+++ b/data/mods/partnersincrime/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	leppaberry: {
 		inherit: true,
 		onEat(pokemon) {

--- a/data/mods/partnersincrime/moves.ts
+++ b/data/mods/partnersincrime/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	gastroacid: {
 		inherit: true,
 		condition: {

--- a/data/mods/partnersincrime/moves.ts
+++ b/data/mods/partnersincrime/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	gastroacid: {
 		inherit: true,
 		condition: {

--- a/data/mods/pokebilities/abilities.ts
+++ b/data/mods/pokebilities/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
 	mummy: {
 		inherit: true,
 		onDamagingHit(damage, target, source, move) {

--- a/data/mods/pokebilities/abilities.ts
+++ b/data/mods/pokebilities/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
+export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	mummy: {
 		inherit: true,
 		onDamagingHit(damage, target, source, move) {

--- a/data/mods/pokebilities/moves.ts
+++ b/data/mods/pokebilities/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	gastroacid: {
 		inherit: true,
 		condition: {

--- a/data/mods/pokebilities/moves.ts
+++ b/data/mods/pokebilities/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	gastroacid: {
 		inherit: true,
 		condition: {

--- a/data/mods/sharedpower/abilities.ts
+++ b/data/mods/sharedpower/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
+export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	neutralizinggas: {
 		inherit: true,
 		// Ability suppression implemented in sim/pokemon.ts:Pokemon#ignoringAbility

--- a/data/mods/sharedpower/abilities.ts
+++ b/data/mods/sharedpower/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
 	neutralizinggas: {
 		inherit: true,
 		// Ability suppression implemented in sim/pokemon.ts:Pokemon#ignoringAbility

--- a/data/mods/sharedpower/moves.ts
+++ b/data/mods/sharedpower/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	gastroacid: {
 		inherit: true,
 		condition: {

--- a/data/mods/sharedpower/moves.ts
+++ b/data/mods/sharedpower/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	gastroacid: {
 		inherit: true,
 		condition: {

--- a/data/mods/sharingiscaring/conditions.ts
+++ b/data/mods/sharingiscaring/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[k: string]: ModdedConditionData} = {
+export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
 	choicelock: {
 		inherit: true,
 		onBeforeMove(pokemon, target, move) {

--- a/data/mods/sharingiscaring/conditions.ts
+++ b/data/mods/sharingiscaring/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
+export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDataTable = {
 	choicelock: {
 		inherit: true,
 		onBeforeMove(pokemon, target, move) {

--- a/data/mods/sharingiscaring/items.ts
+++ b/data/mods/sharingiscaring/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	airballoon: {
 		inherit: true,
 		// airborneness implemented in sim/pokemon.js:Pokemon#isGrounded

--- a/data/mods/sharingiscaring/items.ts
+++ b/data/mods/sharingiscaring/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	airballoon: {
 		inherit: true,
 		// airborneness implemented in sim/pokemon.js:Pokemon#isGrounded

--- a/data/mods/sharingiscaring/moves.ts
+++ b/data/mods/sharingiscaring/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	poltergeist: {
 		inherit: true,
 		onTry(source, target) {

--- a/data/mods/sharingiscaring/moves.ts
+++ b/data/mods/sharingiscaring/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	poltergeist: {
 		inherit: true,
 		onTry(source, target) {

--- a/data/mods/thecardgame/abilities.ts
+++ b/data/mods/thecardgame/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[k: string]: ModdedAbilityData} = {
+export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
 	aerilate: {
 		inherit: true,
 		onModifyType(move, pokemon) {

--- a/data/mods/thecardgame/abilities.ts
+++ b/data/mods/thecardgame/abilities.ts
@@ -1,4 +1,4 @@
-export const Abilities: {[id: IDEntry]: ModdedAbilityData} = {
+export const Abilities: import('../../../sim/dex-abilities').ModdedAbilityDataTable = {
 	aerilate: {
 		inherit: true,
 		onModifyType(move, pokemon) {

--- a/data/mods/thecardgame/conditions.ts
+++ b/data/mods/thecardgame/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[k: string]: ModdedConditionData} = {
+export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
 	deltastream: {
 		inherit: true,
 		onEffectiveness(typeMod, target, type, move) {

--- a/data/mods/thecardgame/conditions.ts
+++ b/data/mods/thecardgame/conditions.ts
@@ -1,4 +1,4 @@
-export const Conditions: {[id: IDEntry]: ModdedConditionData} = {
+export const Conditions: import('../../../sim/dex-conditions').ModdedConditionDataTable = {
 	deltastream: {
 		inherit: true,
 		onEffectiveness(typeMod, target, type, move) {

--- a/data/mods/thecardgame/items.ts
+++ b/data/mods/thecardgame/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[k: string]: ModdedItemData} = {
+export const Items: {[id: IDEntry]: ModdedItemData} = {
 	buggem: {
 		inherit: true,
 		onSourceTryPrimaryHit(target, source, move) {

--- a/data/mods/thecardgame/items.ts
+++ b/data/mods/thecardgame/items.ts
@@ -1,4 +1,4 @@
-export const Items: {[id: IDEntry]: ModdedItemData} = {
+export const Items: import('../../../sim/dex-items').ModdedItemDataTable = {
 	buggem: {
 		inherit: true,
 		onSourceTryPrimaryHit(target, source, move) {

--- a/data/mods/thecardgame/moves.ts
+++ b/data/mods/thecardgame/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[id: IDEntry]: ModdedMoveData} = {
+export const Moves: import('../../../sim/dex-moves').ModdedMoveDataTable = {
 	camouflage: {
 		inherit: true,
 		onHit(target) {

--- a/data/mods/thecardgame/moves.ts
+++ b/data/mods/thecardgame/moves.ts
@@ -1,4 +1,4 @@
-export const Moves: {[k: string]: ModdedMoveData} = {
+export const Moves: {[id: IDEntry]: ModdedMoveData} = {
 	camouflage: {
 		inherit: true,
 		onHit(target) {

--- a/data/mods/thecardgame/typechart.ts
+++ b/data/mods/thecardgame/typechart.ts
@@ -1,4 +1,4 @@
-export const TypeChart: {[id: IDEntry]: ModdedTypeData} = {
+export const TypeChart: import('../../../sim/dex-data').ModdedTypeDataTable = {
 	dark: {
 		inherit: true,
 		damageTaken: {

--- a/data/mods/thecardgame/typechart.ts
+++ b/data/mods/thecardgame/typechart.ts
@@ -1,4 +1,4 @@
-export const TypeChart: {[k: string]: ModdedTypeData} = {
+export const TypeChart: {[id: IDEntry]: ModdedTypeData} = {
 	dark: {
 		inherit: true,
 		damageTaken: {

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -1,6 +1,6 @@
 // List of flags and their descriptions can be found in sim/dex-moves.ts
 
-export const Moves: {[moveid: string]: MoveData} = {
+export const Moves: {[moveid: IDEntry]: MoveData} = {
 	"10000000voltthunderbolt": {
 		num: 719,
 		accuracy: true,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -1,6 +1,6 @@
 // List of flags and their descriptions can be found in sim/dex-moves.ts
 
-export const Moves: {[moveid: IDEntry]: MoveData} = {
+export const Moves: import('../sim/dex-moves').MoveDataTable = {
 	"10000000voltthunderbolt": {
 		num: 719,
 		accuracy: true,

--- a/data/natures.ts
+++ b/data/natures.ts
@@ -1,4 +1,4 @@
-export const Natures: {[k: IDEntry]: NatureData} = {
+export const Natures: {[id: IDEntry]: NatureData} = {
 	adamant: {
 		name: "Adamant",
 		plus: 'atk',

--- a/data/natures.ts
+++ b/data/natures.ts
@@ -1,4 +1,4 @@
-export const Natures: {[k: string]: NatureData} = {
+export const Natures: {[k: IDEntry]: NatureData} = {
 	adamant: {
 		name: "Adamant",
 		plus: 'atk',

--- a/data/natures.ts
+++ b/data/natures.ts
@@ -1,4 +1,4 @@
-export const Natures: {[id: IDEntry]: NatureData} = {
+export const Natures: import('../sim/dex-data').NatureDataTable = {
 	adamant: {
 		name: "Adamant",
 		plus: 'atk',

--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[speciesid: string]: SpeciesData} = {
+export const Pokedex: {[speciesid: IDEntry]: SpeciesData} = {
 	bulbasaur: {
 		num: 1,
 		name: "Bulbasaur",

--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -1,4 +1,4 @@
-export const Pokedex: {[speciesid: IDEntry]: SpeciesData} = {
+export const Pokedex: import('../sim/dex-species').SpeciesDataTable = {
 	bulbasaur: {
 		num: 1,
 		name: "Bulbasaur",

--- a/data/pokemongo.ts
+++ b/data/pokemongo.ts
@@ -26,7 +26,7 @@
  * - Shadow Pokemon: most can also be obtained from the wild, and those that can't are from defeating Giovanni, which
  *   is handled as as its own encounter
  */
-export const PokemonGoData: {[source: IDEntry]: PokemonGoData} = {
+export const PokemonGoData: import('../sim/dex-species').PokemonGoDataTable = {
 	bulbasaur: {encounters: ['wild']},
 	ivysaur: {encounters: ['wild']},
 	venusaur: {encounters: ['wild']},

--- a/data/pokemongo.ts
+++ b/data/pokemongo.ts
@@ -26,7 +26,7 @@
  * - Shadow Pokemon: most can also be obtained from the wild, and those that can't are from defeating Giovanni, which
  *   is handled as as its own encounter
  */
-export const PokemonGoData: {[source: string]: PokemonGoData} = {
+export const PokemonGoData: {[source: IDEntry]: PokemonGoData} = {
 	bulbasaur: {encounters: ['wild']},
 	ivysaur: {encounters: ['wild']},
 	venusaur: {encounters: ['wild']},

--- a/data/random-battles/gen1/teams.ts
+++ b/data/random-battles/gen1/teams.ts
@@ -15,7 +15,7 @@ interface Gen1RandomBattleSpecies {
 }
 
 export class RandomGen1Teams extends RandomGen2Teams {
-	randomData: {[species: string]: Gen1RandomBattleSpecies} = require('./data.json');
+	randomData: {[species: IDEntry]: Gen1RandomBattleSpecies} = require('./data.json');
 
 	// Challenge Cup or CC teams are basically fully random teams.
 	randomCCTeam() {

--- a/data/random-battles/gen2/teams.ts
+++ b/data/random-battles/gen2/teams.ts
@@ -26,7 +26,7 @@ const MOVE_PAIRS = [
 ];
 
 export class RandomGen2Teams extends RandomGen3Teams {
-	randomSets: {[species: string]: RandomTeamsTypes.RandomSpeciesData} = require('./sets.json');
+	randomSets: {[species: IDEntry]: RandomTeamsTypes.RandomSpeciesData} = require('./sets.json');
 
 	constructor(format: string | Format, prng: PRNG | PRNGSeed | null) {
 		super(format, prng);

--- a/data/random-battles/gen8/teams.ts
+++ b/data/random-battles/gen8/teams.ts
@@ -571,8 +571,8 @@ export class RandomGen8Teams {
 						let tagBlacklisted = false;
 						for (const ruleid of ruleTable.tagRules) {
 							if (ruleid.startsWith('*')) continue;
-							const tagid = ruleid.slice(12);
-							const tag = Tags[tagid as ID];
+							const tagid = ruleid.slice(12) as ID;
+							const tag = Tags[tagid];
 							if ((tag.speciesFilter || tag.genericFilter)!(species)) {
 								const existenceTag = EXISTENCE_TAG.includes(tagid);
 								if (ruleid.startsWith('+')) {

--- a/data/random-battles/gen8/teams.ts
+++ b/data/random-battles/gen8/teams.ts
@@ -572,7 +572,7 @@ export class RandomGen8Teams {
 						for (const ruleid of ruleTable.tagRules) {
 							if (ruleid.startsWith('*')) continue;
 							const tagid = ruleid.slice(12);
-							const tag = Tags[tagid];
+							const tag = Tags[tagid as ID];
 							if ((tag.speciesFilter || tag.genericFilter)!(species)) {
 								const existenceTag = EXISTENCE_TAG.includes(tagid);
 								if (ruleid.startsWith('+')) {

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -2179,7 +2179,7 @@ export class RandomTeams {
 						for (const ruleid of ruleTable.tagRules) {
 							if (ruleid.startsWith('*')) continue;
 							const tagid = ruleid.slice(12);
-							const tag = Tags[tagid];
+							const tag = Tags[tagid as ID];
 							if ((tag.speciesFilter || tag.genericFilter)!(species)) {
 								const existenceTag = EXISTENCE_TAG.includes(tagid);
 								if (ruleid.startsWith('+')) {

--- a/data/random-battles/gen9/teams.ts
+++ b/data/random-battles/gen9/teams.ts
@@ -2178,8 +2178,8 @@ export class RandomTeams {
 						let tagBlacklisted = false;
 						for (const ruleid of ruleTable.tagRules) {
 							if (ruleid.startsWith('*')) continue;
-							const tagid = ruleid.slice(12);
-							const tag = Tags[tagid as ID];
+							const tagid = ruleid.slice(12) as ID;
+							const tag = Tags[tagid];
 							if ((tag.speciesFilter || tag.genericFilter)!(species)) {
 								const existenceTag = EXISTENCE_TAG.includes(tagid);
 								if (ruleid.startsWith('+')) {

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -3,7 +3,7 @@
 import type {Learnset} from "../sim/dex-species";
 
 // The list of formats is stored in config/formats.js
-export const Rulesets: {[k: IDEntry]: FormatData} = {
+export const Rulesets: {[id: IDEntry]: FormatData} = {
 
 	// Rulesets
 	///////////////////////////////////////////////////////////////////

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -3,7 +3,7 @@
 import type {Learnset} from "../sim/dex-species";
 
 // The list of formats is stored in config/formats.js
-export const Rulesets: {[k: IDEntry]: FormatData} = {
+export const Rulesets: import('../sim/dex-formats').FormatDataTable = {
 
 	// Rulesets
 	///////////////////////////////////////////////////////////////////

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -3,7 +3,7 @@
 import type {Learnset} from "../sim/dex-species";
 
 // The list of formats is stored in config/formats.js
-export const Rulesets: {[id: IDEntry]: FormatData} = {
+export const Rulesets: {[k: IDEntry]: FormatData} = {
 
 	// Rulesets
 	///////////////////////////////////////////////////////////////////

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -3,7 +3,7 @@
 import type {Learnset} from "../sim/dex-species";
 
 // The list of formats is stored in config/formats.js
-export const Rulesets: {[k: string]: FormatData} = {
+export const Rulesets: {[k: IDEntry]: FormatData} = {
 
 	// Rulesets
 	///////////////////////////////////////////////////////////////////

--- a/data/tags.ts
+++ b/data/tags.ts
@@ -9,7 +9,7 @@ interface TagData {
 	genericNumCol?: (thing: Species | Move | Item | Ability) => number;
 }
 
-export const Tags: {[id: string]: TagData} = {
+export const Tags: {[id: IDEntry]: TagData} = {
 	// Categories
 	// ----------
 	physical: {

--- a/data/text/abilities.ts
+++ b/data/text/abilities.ts
@@ -1,4 +1,4 @@
-export const AbilitiesText: {[k: string]: AbilityText} = {
+export const AbilitiesText: {[id: IDEntry]: AbilityText} = {
 	noability: {
 		name: "No Ability",
 		shortDesc: "Does nothing.",

--- a/data/text/default.ts
+++ b/data/text/default.ts
@@ -1,4 +1,4 @@
-export const DefaultText: {[k: string]: DefaultText} = {
+export const DefaultText: {[id: IDEntry]: DefaultText} = {
 	default: {
 		startBattle: "Battle started between [TRAINER] and [TRAINER]!",
 		winBattle: "**[TRAINER]** won the battle!",

--- a/data/text/items.ts
+++ b/data/text/items.ts
@@ -1,4 +1,4 @@
-export const ItemsText: {[k: string]: ItemText} = {
+export const ItemsText: {[id: IDEntry]: ItemText} = {
 	abilityshield: {
 		name: "Ability Shield",
 		desc: "Holder's Ability cannot be changed by any effect.",

--- a/data/text/moves.ts
+++ b/data/text/moves.ts
@@ -1,4 +1,4 @@
-export const MovesText: {[k: string]: MoveText} = {
+export const MovesText: {[id: IDEntry]: MoveText} = {
 	"10000000voltthunderbolt": {
 		name: "10,000,000 Volt Thunderbolt",
 		desc: "Has a very high chance for a critical hit.",

--- a/data/text/pokedex.ts
+++ b/data/text/pokedex.ts
@@ -1,4 +1,4 @@
-export const PokedexText: {[k: string]: PokedexText} = {
+export const PokedexText: {[id: IDEntry]: PokedexText} = {
 	bulbasaur: {
 		name: "Bulbasaur",
 	},

--- a/data/typechart.ts
+++ b/data/typechart.ts
@@ -1,4 +1,4 @@
-export const TypeChart: {[k: IDEntry]: TypeData} = {
+export const TypeChart: {[id: IDEntry]: TypeData} = {
 	bug: {
 		damageTaken: {
 			Bug: 0,

--- a/data/typechart.ts
+++ b/data/typechart.ts
@@ -1,4 +1,4 @@
-export const TypeChart: {[k: string]: TypeData} = {
+export const TypeChart: {[k: IDEntry]: TypeData} = {
 	bug: {
 		damageTaken: {
 			Bug: 0,

--- a/data/typechart.ts
+++ b/data/typechart.ts
@@ -1,4 +1,4 @@
-export const TypeChart: {[id: IDEntry]: TypeData} = {
+export const TypeChart: import('../sim/dex-data').TypeDataTable = {
 	bug: {
 		damageTaken: {
 			Bug: 0,

--- a/server/global-types.ts
+++ b/server/global-types.ts
@@ -37,7 +37,7 @@ type RoomGame = Rooms.RoomGame;
 type MinorActivity = Rooms.MinorActivity;
 type RoomBattle = Rooms.RoomBattle;
 type Room = Rooms.Room;
-type RoomID = "" | "lobby" | "staff" | "upperstaff" | "development" | string & {__isRoomID: true};
+type RoomID = "" | "lobby" | "staff" | "upperstaff" | "development" | Lowercase<string> & {__isRoomID: true};
 namespace Rooms {
 	export type GlobalRoomState = import('./rooms').GlobalRoomState;
 	export type ChatRoom = import('./rooms').ChatRoom;

--- a/server/room-battle.ts
+++ b/server/room-battle.ts
@@ -18,6 +18,7 @@ import {RoomGamePlayer, RoomGame} from "./room-game";
 import type {Tournament} from './tournaments/index';
 import type {RoomSettings} from './rooms';
 import type {BestOfGame} from './room-battle-bestof';
+import type {GameTimerSettings} from '../sim/dex-formats';
 
 type ChannelIndex = 0 | 1 | 2 | 3 | 4;
 export type PlayerIndex = 1 | 2 | 3 | 4;

--- a/sim/battle-actions.ts
+++ b/sim/battle-actions.ts
@@ -790,7 +790,7 @@ export class BattleActions {
 					boosts[statName2] = 0;
 				}
 				target.setBoost(boosts);
-				if (move.id === "Spectral Thief") {
+				if (move.id === "spectralthief") {
 					this.battle.addMove('-anim', pokemon, "Spectral Thief", target);
 				}
 			}

--- a/sim/dex-abilities.ts
+++ b/sim/dex-abilities.ts
@@ -25,6 +25,8 @@ export interface AbilityData extends Partial<Ability>, AbilityEventMethods, Poke
 }
 
 export type ModdedAbilityData = AbilityData | Partial<AbilityData> & {inherit: true};
+export type AbilityDataTable = {[abilityid: IDEntry]: AbilityData}
+export type ModdedAbilityDataTable = {[abilityid: IDEntry]: ModdedAbilityData}
 
 export class Ability extends BasicEffect implements Readonly<BasicEffect> {
 	declare readonly effectType: 'Ability';

--- a/sim/dex-abilities.ts
+++ b/sim/dex-abilities.ts
@@ -25,8 +25,8 @@ export interface AbilityData extends Partial<Ability>, AbilityEventMethods, Poke
 }
 
 export type ModdedAbilityData = AbilityData | Partial<AbilityData> & {inherit: true};
-export type AbilityDataTable = {[abilityid: IDEntry]: AbilityData}
-export type ModdedAbilityDataTable = {[abilityid: IDEntry]: ModdedAbilityData}
+export interface AbilityDataTable {[abilityid: IDEntry]: AbilityData}
+export interface ModdedAbilityDataTable {[abilityid: IDEntry]: ModdedAbilityData}
 
 export class Ability extends BasicEffect implements Readonly<BasicEffect> {
 	declare readonly effectType: 'Ability';

--- a/sim/dex-abilities.ts
+++ b/sim/dex-abilities.ts
@@ -1,4 +1,4 @@
-import {PokemonEventMethods} from './dex-conditions';
+import type {PokemonEventMethods, ConditionData} from './dex-conditions';
 import {BasicEffect, toID} from './dex-data';
 
 interface AbilityEventMethods {

--- a/sim/dex-conditions.ts
+++ b/sim/dex-conditions.ts
@@ -607,6 +607,8 @@ export interface FieldConditionData extends
 export type ConditionData = PokemonConditionData | SideConditionData | FieldConditionData;
 
 export type ModdedConditionData = ConditionData & {inherit?: true};
+export interface ConditionDataTable {[id: IDEntry]: ConditionData}
+export interface ModdedConditionDataTable {[id: IDEntry]: ModdedConditionData}
 
 export class Condition extends BasicEffect implements
 	Readonly<BasicEffect & SideConditionData & FieldConditionData & PokemonConditionData> {

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -153,7 +153,7 @@ export interface NatureData {
 
 export type ModdedNatureData = NatureData | Partial<Omit<NatureData, 'name'>> & {inherit: true};
 
-export interface NatureDataTable {[abilityid: IDEntry]: NatureData}
+export interface NatureDataTable {[natureid: IDEntry]: NatureData}
 
 
 export class DexNatures {

--- a/sim/dex-data.ts
+++ b/sim/dex-data.ts
@@ -145,6 +145,17 @@ export class Nature extends BasicEffect implements Readonly<BasicEffect & Nature
 	}
 }
 
+export interface NatureData {
+	name: string;
+	plus?: StatIDExceptHP;
+	minus?: StatIDExceptHP;
+}
+
+export type ModdedNatureData = NatureData | Partial<Omit<NatureData, 'name'>> & {inherit: true};
+
+export interface NatureDataTable {[abilityid: IDEntry]: NatureData}
+
+
 export class DexNatures {
 	readonly dex: ModdedDex;
 	readonly natureCache = new Map<ID, Nature>();
@@ -192,6 +203,17 @@ export class DexNatures {
 		return this.allCache;
 	}
 }
+
+export interface TypeData {
+	damageTaken: {[attackingTypeNameOrEffectid: string]: number};
+	HPdvs?: SparseStatsTable;
+	HPivs?: SparseStatsTable;
+	isNonstandard?: Nonstandard | null;
+}
+
+export type ModdedTypeData = TypeData | Partial<Omit<TypeData, 'name'>> & {inherit: true};
+export interface TypeDataTable {[typeid: IDEntry]: TypeData}
+export interface ModdedTypeDataTable {[typeid: IDEntry]: ModdedTypeData}
 
 type TypeInfoEffectType = 'Type' | 'EffectType';
 
@@ -308,7 +330,7 @@ export class DexTypes {
 }
 
 const idsCache: readonly StatID[] = ['hp', 'atk', 'def', 'spa', 'spd', 'spe'];
-const reverseCache: {readonly [k: string]: StatID} = {
+const reverseCache: {readonly [k: IDEntry]: StatID} = {
 	__proto: null as any,
 	"hitpoints": 'hp',
 	"attack": 'atk',

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -18,6 +18,18 @@ type FormatEffectType = 'Format' | 'Ruleset' | 'Rule' | 'ValidatorRule';
 export type ComplexBan = [string, string, number, string[]];
 export type ComplexTeamBan = ComplexBan;
 
+export interface GameTimerSettings {
+	dcTimer: boolean;
+	dcTimerBank: boolean;
+	starting: number;
+	grace: number;
+	addPerTurn: number;
+	maxPerTurn: number;
+	maxFirstTurn: number;
+	timeoutAutoChoose: boolean;
+	accelerate: boolean;
+}
+
 /**
  * A RuleTable keeps track of the rules that a format has. The key can be:
  * - '[ruleid]' the ID of a rule in effect

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -11,6 +11,8 @@ export interface FormatData extends Partial<Format>, EventMethods {
 
 export type FormatList = (FormatData | {section: string, column?: number})[];
 export type ModdedFormatData = FormatData | Omit<FormatData, 'name'> & {inherit: true};
+export interface FormatDataTable {[id: IDEntry]: FormatData}
+export interface ModdedFormatDataTable {[id: IDEntry]: ModdedFormatData}
 
 type FormatEffectType = 'Format' | 'Ruleset' | 'Rule' | 'ValidatorRule';
 

--- a/sim/dex-formats.ts
+++ b/sim/dex-formats.ts
@@ -69,13 +69,13 @@ export class RuleTable extends Map<string, string> {
 		if (this.has(`+basepokemon:${toID(species.baseSpecies)}`)) return false;
 		if (this.has(`-basepokemon:${toID(species.baseSpecies)}`)) return true;
 		for (const tagid in Tags) {
-			const tag = Tags[tagid];
+			const tag = Tags[tagid as ID];
 			if (this.has(`-pokemontag:${tagid}`)) {
 				if ((tag.speciesFilter || tag.genericFilter)!(species)) return true;
 			}
 		}
 		for (const tagid in Tags) {
-			const tag = Tags[tagid];
+			const tag = Tags[tagid as ID];
 			if (this.has(`+pokemontag:${tagid}`)) {
 				if ((tag.speciesFilter || tag.genericFilter)!(species)) return false;
 			}
@@ -94,13 +94,13 @@ export class RuleTable extends Map<string, string> {
 		if (this.has(`+basepokemon:${toID(species.baseSpecies)}`)) return false;
 		if (this.has(`*basepokemon:${toID(species.baseSpecies)}`)) return true;
 		for (const tagid in Tags) {
-			const tag = Tags[tagid];
+			const tag = Tags[tagid as ID];
 			if (this.has(`*pokemontag:${tagid}`)) {
 				if ((tag.speciesFilter || tag.genericFilter)!(species)) return true;
 			}
 		}
 		for (const tagid in Tags) {
-			const tag = Tags[tagid];
+			const tag = Tags[tagid as ID];
 			if (this.has(`+pokemontag:${tagid}`)) {
 				if ((tag.speciesFilter || tag.genericFilter)!(species)) return false;
 			}

--- a/sim/dex-items.ts
+++ b/sim/dex-items.ts
@@ -1,4 +1,4 @@
-import {PokemonEventMethods} from './dex-conditions';
+import type {PokemonEventMethods, ConditionData} from './dex-conditions';
 import {BasicEffect, toID} from './dex-data';
 
 interface FlingData {
@@ -17,8 +17,8 @@ export type ModdedItemData = ItemData | Partial<Omit<ItemData, 'name'>> & {
 	onCustap?: (this: Battle, pokemon: Pokemon) => void,
 };
 
-export interface ItemDataTable {[abilityid: IDEntry]: ItemData}
-export interface ModdedItemDataTable {[abilityid: IDEntry]: ModdedItemData}
+export interface ItemDataTable {[itemid: IDEntry]: ItemData}
+export interface ModdedItemDataTable {[itemid: IDEntry]: ModdedItemData}
 
 export class Item extends BasicEffect implements Readonly<BasicEffect> {
 	declare readonly effectType: 'Item';

--- a/sim/dex-items.ts
+++ b/sim/dex-items.ts
@@ -17,6 +17,9 @@ export type ModdedItemData = ItemData | Partial<Omit<ItemData, 'name'>> & {
 	onCustap?: (this: Battle, pokemon: Pokemon) => void,
 };
 
+export interface ItemDataTable {[abilityid: IDEntry]: ItemData}
+export interface ModdedItemDataTable {[abilityid: IDEntry]: ModdedItemData}
+
 export class Item extends BasicEffect implements Readonly<BasicEffect> {
 	declare readonly effectType: 'Item';
 

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -439,7 +439,7 @@ export class DataMove extends BasicEffect implements Readonly<BasicEffect & Move
 		effect?: IDEntry,
 		boost?: SparseBoostsTable,
 	};
-	/** Is this move a Max move? */
+	/** Is this move a Max move? string = Gigantamax species name */
 	readonly isMax: boolean | string;
 	/** Max/G-Max move fields */
 	declare readonly maxMove?: {

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -286,6 +286,9 @@ export type ModdedMoveData = MoveData | Partial<Omit<MoveData, 'name'>> & {
 	gen?: number,
 };
 
+export interface MoveDataTable {[abilityid: IDEntry]: MoveData}
+export interface ModdedMoveDataTable {[abilityid: IDEntry]: ModdedMoveData}
+
 export interface Move extends Readonly<BasicEffect & MoveData> {
 	readonly effectType: 'Move';
 }
@@ -305,8 +308,7 @@ interface MoveHitData {
 }
 
 type MutableMove = BasicEffect & MoveData;
-type RuinableMove = {[k in `ruined${'Atk' | 'Def' | 'SpA' | 'SpD'}`]?: Pokemon;};
-export interface ActiveMove extends MutableMove, RuinableMove {
+export interface ActiveMove extends MutableMove {
 	readonly name: string;
 	readonly effectType: 'Move';
 	readonly id: ID;
@@ -339,6 +341,10 @@ export interface ActiveMove extends MutableMove, RuinableMove {
 	typeChangerBoosted?: Effect;
 	willChangeForme?: boolean;
 	infiltrates?: boolean;
+	ruinedAtk?: Pokemon;
+	ruinedDef?: Pokemon;
+	ruinedSpA?: Pokemon;
+	ruinedSpD?: Pokemon;
 
 	/**
 	 * Has this move been boosted by a Z-crystal or used by a Dynamax Pokemon? Usually the same as

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -1,4 +1,5 @@
 import {Utils} from '../lib';
+import type {ConditionData} from './dex-conditions';
 import {BasicEffect, toID} from './dex-data';
 
 /**
@@ -286,8 +287,8 @@ export type ModdedMoveData = MoveData | Partial<Omit<MoveData, 'name'>> & {
 	gen?: number,
 };
 
-export interface MoveDataTable {[abilityid: IDEntry]: MoveData}
-export interface ModdedMoveDataTable {[abilityid: IDEntry]: ModdedMoveData}
+export interface MoveDataTable {[moveid: IDEntry]: MoveData}
+export interface ModdedMoveDataTable {[moveid: IDEntry]: ModdedMoveData}
 
 export interface Move extends Readonly<BasicEffect & MoveData> {
 	readonly effectType: 'Move';

--- a/sim/dex-moves.ts
+++ b/sim/dex-moves.ts
@@ -171,10 +171,10 @@ export interface MoveData extends EffectData, MoveEventMethods, HitEffect {
 	 * ID of the Z-Crystal that calls the move.
 	 * `true` for Z-Powered status moves like Z-Encore.
 	 */
-	isZ?: boolean | string;
+	isZ?: boolean | IDEntry;
 	zMove?: {
 		basePower?: number,
-		effect?: string,
+		effect?: IDEntry,
 		boost?: SparseBoostsTable,
 	};
 
@@ -182,7 +182,7 @@ export interface MoveData extends EffectData, MoveEventMethods, HitEffect {
 	// -------------
 	/**
 	 * `true` for Max moves like Max Airstream. If its a G-Max moves, this is
-	 * the species ID of the Gigantamax Pokemon that can use this G-Max move.
+	 * the species name of the Gigantamax Pokemon that can use this G-Max move.
 	 */
 	isMax?: boolean | string;
 	maxMove?: {
@@ -191,7 +191,7 @@ export interface MoveData extends EffectData, MoveEventMethods, HitEffect {
 
 	// Hit effects
 	// -----------
-	ohko?: boolean | string;
+	ohko?: boolean | 'Ice';
 	thawsTarget?: boolean;
 	heal?: number[] | null;
 	forceSwitch?: boolean;
@@ -243,17 +243,17 @@ export interface MoveData extends EffectData, MoveEventMethods, HitEffect {
 	ignoreAccuracy?: boolean;
 	ignoreDefensive?: boolean;
 	ignoreEvasion?: boolean;
-	ignoreImmunity?: boolean | {[k: string]: boolean};
+	ignoreImmunity?: boolean | {[typeName: string]: boolean};
 	ignoreNegativeOffensive?: boolean;
 	ignoreOffensive?: boolean;
 	ignorePositiveDefensive?: boolean;
 	ignorePositiveEvasion?: boolean;
 	multiaccuracy?: boolean;
 	multihit?: number | number[];
-	multihitType?: string;
+	multihitType?: 'parentalbond';
 	noDamageVariance?: boolean;
-	nonGhostTarget?: string;
-	pressureTarget?: string;
+	nonGhostTarget?: MoveTarget;
+	pressureTarget?: MoveTarget;
 	spreadModifier?: number;
 	sleepUsable?: boolean;
 	/**
@@ -274,7 +274,7 @@ export interface MoveData extends EffectData, MoveEventMethods, HitEffect {
 	isConfusionSelfHit?: boolean;
 	noSketch?: boolean;
 	stallingMove?: boolean;
-	baseMove?: string;
+	baseMove?: ID;
 }
 
 export type ModdedMoveData = MoveData | Partial<Omit<MoveData, 'name'>> & {
@@ -364,7 +364,7 @@ export class DataMove extends BasicEffect implements Readonly<BasicEffect & Move
 	/** Will this move always or never be a critical hit? */
 	declare readonly willCrit?: boolean;
 	/** Can this move OHKO foes? */
-	declare readonly ohko?: boolean | string;
+	declare readonly ohko?: boolean | 'Ice';
 	/**
 	 * Base move type. This is the move type as specified by the games,
 	 * tracked because it often differs from the real move type.
@@ -420,8 +420,11 @@ export class DataMove extends BasicEffect implements Readonly<BasicEffect & Move
 	/**
 	 * Whether or not this move ignores type immunities. Defaults to
 	 * true for Status moves and false for Physical/Special moves.
+	 *
+	 * If an Object, its keys represent the types whose immunities are
+	 * ignored, and its values should only be true.
 	 */
-	readonly ignoreImmunity: AnyObject | boolean;
+	readonly ignoreImmunity: {[typeName: string]: boolean} | boolean;
 	/** Base move PP. */
 	readonly pp: number;
 	/** Whether or not this move can receive PP boosts. */
@@ -429,11 +432,11 @@ export class DataMove extends BasicEffect implements Readonly<BasicEffect & Move
 	/** How many times does this move hit? */
 	declare readonly multihit?: number | number[];
 	/** Is this move a Z-Move? */
-	readonly isZ: boolean | string;
+	readonly isZ: boolean | IDEntry;
 	/* Z-Move fields */
 	declare readonly zMove?: {
 		basePower?: number,
-		effect?: string,
+		effect?: IDEntry,
 		boost?: SparseBoostsTable,
 	};
 	/** Is this move a Max move? */
@@ -446,9 +449,9 @@ export class DataMove extends BasicEffect implements Readonly<BasicEffect & Move
 	/** Whether or not the user must switch after using this move. */
 	readonly selfSwitch?: 'copyvolatile' | 'shedtail' | boolean;
 	/** Move target only used by Pressure. */
-	readonly pressureTarget: string;
+	readonly pressureTarget: MoveTarget;
 	/** Move target used if the user is not a Ghost type (for Curse). */
-	readonly nonGhostTarget: string;
+	readonly nonGhostTarget: MoveTarget;
 	/** Whether or not the move ignores abilities. */
 	readonly ignoreAbility: boolean;
 	/**

--- a/sim/dex-species.ts
+++ b/sim/dex-species.ts
@@ -40,6 +40,22 @@ export interface LearnsetData {
 	encounters?: EventInfo[];
 	exists?: boolean;
 }
+
+export type ModdedLearnsetData = LearnsetData & {inherit?: true};
+
+export interface PokemonGoData {
+	encounters?: string[];
+	LGPERestrictiveMoves?: {[moveid: string]: number | null};
+}
+
+export interface SpeciesDataTable {[speciesid: IDEntry]: SpeciesData}
+export interface ModdedSpeciesDataTable {[speciesid: IDEntry]: ModdedSpeciesData}
+export interface SpeciesFormatsDataTable {[speciesid: IDEntry]: SpeciesFormatsData}
+export interface ModdedSpeciesFormatsDataTable {[speciesid: IDEntry]: ModdedSpeciesFormatsData}
+export interface LearnsetDataTable {[speciesid: IDEntry]: LearnsetData}
+export interface ModdedLearnsetDataTable {[speciesid: IDEntry]: ModdedLearnsetData}
+export interface PokemonGoDataTable {[speciesid: IDEntry]: PokemonGoData}
+
 /**
  * Describes a possible way to get a move onto a pokemon.
  *
@@ -67,13 +83,6 @@ export type MoveSource = `${
 }${
 	'M' | 'T' | 'L' | 'R' | 'E' | 'D' | 'S' | 'V' | 'C'
 }${string}`;
-
-export type ModdedLearnsetData = LearnsetData & {inherit?: true};
-
-export interface PokemonGoData {
-	encounters?: string[];
-	LGPERestrictiveMoves?: {[moveid: string]: number | null};
-}
 
 export class Species extends BasicEffect implements Readonly<BasicEffect & SpeciesFormatsData> {
 	declare readonly effectType: 'Pokemon';
@@ -434,7 +443,7 @@ export class DexSpecies {
 
 		if (!this.dex.data.Pokedex.hasOwnProperty(id)) {
 			let aliasTo = '';
-			const formeNames: {[k: string]: string[]} = {
+			const formeNames: {[k: IDEntry]: IDEntry[]} = {
 				alola: ['a', 'alola', 'alolan'],
 				galar: ['g', 'galar', 'galarian'],
 				hisui: ['h', 'hisui', 'hisuian'],
@@ -444,7 +453,7 @@ export class DexSpecies {
 			};
 			for (const forme in formeNames) {
 				let pokeName = '';
-				for (const i of formeNames[forme]) {
+				for (const i of formeNames[forme as ID]) {
 					if (id.startsWith(i)) {
 						pokeName = id.slice(i.length);
 					} else if (id.endsWith(i)) {

--- a/sim/dex-species.ts
+++ b/sim/dex-species.ts
@@ -485,9 +485,10 @@ export class DexSpecies {
 			// Inherit any statuses from the base species (Arceus, Silvally).
 			const baseSpeciesStatuses = this.dex.data.Conditions[toID(species.baseSpecies)];
 			if (baseSpeciesStatuses !== undefined) {
-				let key: keyof EffectData;
-				for (key in baseSpeciesStatuses) {
-					if (!(key in species)) (species as any)[key] = baseSpeciesStatuses[key];
+				for (const key in baseSpeciesStatuses) {
+					if (!(key in species)) {
+						(species as any)[key] = (baseSpeciesStatuses as any)[key];
+					}
 				}
 			}
 			if (!species.tier && !species.doublesTier && !species.natDexTier && species.baseSpecies !== species.name) {

--- a/sim/dex-species.ts
+++ b/sim/dex-species.ts
@@ -40,6 +40,33 @@ export interface LearnsetData {
 	encounters?: EventInfo[];
 	exists?: boolean;
 }
+/**
+ * Describes a possible way to get a move onto a pokemon.
+ *
+ * First character is a generation number, 1-9.
+ * Second character is a source ID, one of:
+ *
+ * - M = TM/HM
+ * - T = tutor
+ * - L = start or level-up, 3rd char+ is the level
+ * - R = restricted (special moves like Rotom moves)
+ * - E = egg
+ * - D = Dream World, only 5D is valid
+ * - S = event, 3rd char+ is the index in .eventData
+ * - V = Virtual Console or Let's Go transfer, only 7V/8V is valid
+ * - C = NOT A REAL SOURCE, see note, only 3C/4C is valid
+ *
+ * C marks certain moves learned by a pokemon's prevo. It's used to
+ * work around the chainbreeding checker's shortcuts for performance;
+ * it lets the pokemon be a valid father for teaching the move, but
+ * is otherwise ignored by the learnset checker (which will actually
+ * check prevos for compatibility).
+ */
+export type MoveSource = `${
+	1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
+}${
+	'M' | 'T' | 'L' | 'R' | 'E' | 'D' | 'S' | 'V' | 'C'
+}${string}`;
 
 export type ModdedLearnsetData = LearnsetData & {inherit?: true};
 

--- a/sim/dex-species.ts
+++ b/sim/dex-species.ts
@@ -34,7 +34,7 @@ export interface SpeciesFormatsData {
 export type ModdedSpeciesFormatsData = SpeciesFormatsData & {inherit?: true};
 
 export interface LearnsetData {
-	learnset?: {[moveid: string]: MoveSource[]};
+	learnset?: {[moveid: IDEntry]: MoveSource[]};
 	eventData?: EventInfo[];
 	eventOnly?: boolean;
 	encounters?: EventInfo[];

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -79,13 +79,13 @@ interface DexTableData {
 	Items: DexTable<ItemData>;
 	Learnsets: DexTable<import('./dex-species').LearnsetData>;
 	Moves: DexTable<MoveData>;
-	Natures: DexTable<NatureData>;
+	Natures: DexTable<import('./dex-data').NatureData>;
 	Pokedex: DexTable<import('./dex-species').SpeciesData>;
 	FormatsData: DexTable<import('./dex-species').SpeciesFormatsData>;
 	PokemonGoData: DexTable<import('./dex-species').PokemonGoData>;
 	Scripts: DexTable<AnyObject>;
-	Conditions: DexTable<EffectData>;
-	TypeChart: DexTable<TypeData>;
+	Conditions: DexTable<import('./dex-conditions').ConditionData>;
+	TypeChart: DexTable<import('./dex-data').TypeData>;
 }
 interface TextTableData {
 	Abilities: DexTable<AbilityText>;

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -68,21 +68,21 @@ const DATA_FILES = {
 	TypeChart: 'typechart',
 };
 
-interface DexTable<T> {
-	[key: string]: T;
-}
+/** Unfortunately we do for..in too much to want to deal with the casts */
+export interface DexTable<T> {[id: string]: T}
+export interface AliasesTable {[id: IDEntry]: string}
 
 interface DexTableData {
-	Abilities: DexTable<AbilityData>;
-	Aliases: {[id: string]: string};
+	Abilities: DexTable<import('./dex-abilities').AbilityData>;
+	Aliases: DexTable<string>;
 	Rulesets: DexTable<FormatData>;
-	FormatsData: DexTable<import('./dex-species').ModdedSpeciesFormatsData>;
 	Items: DexTable<ItemData>;
-	Learnsets: DexTable<LearnsetData>;
+	Learnsets: DexTable<import('./dex-species').LearnsetData>;
 	Moves: DexTable<MoveData>;
 	Natures: DexTable<NatureData>;
-	Pokedex: DexTable<SpeciesData>;
-	PokemonGoData: DexTable<PokemonGoData>;
+	Pokedex: DexTable<import('./dex-species').SpeciesData>;
+	FormatsData: DexTable<import('./dex-species').SpeciesFormatsData>;
+	PokemonGoData: DexTable<import('./dex-species').PokemonGoData>;
 	Scripts: DexTable<AnyObject>;
 	Conditions: DexTable<EffectData>;
 	TypeChart: DexTable<TypeData>;
@@ -317,7 +317,7 @@ export class ModdedDex {
 		return moveCopy;
 	}
 
-	getHiddenPower(ivs: AnyObject) {
+	getHiddenPower(ivs: StatsTable) {
 		const hpTypes = [
 			'Fighting', 'Flying', 'Poison', 'Ground', 'Rock', 'Bug', 'Ghost', 'Steel',
 			'Fire', 'Water', 'Grass', 'Electric', 'Psychic', 'Ice', 'Dragon', 'Dark',
@@ -342,8 +342,8 @@ export class ModdedDex {
 			let hpPowerX = 0;
 			let i = 1;
 			for (const s in stats) {
-				hpTypeX += i * (ivs[s] % 2);
-				hpPowerX += i * (tr(ivs[s] / 2) % 2);
+				hpTypeX += i * (ivs[s as StatID] % 2);
+				hpPowerX += i * (tr(ivs[s as StatID] / 2) % 2);
 				i *= 2;
 			}
 			return {
@@ -378,7 +378,7 @@ export class ModdedDex {
 		} as const;
 		let searchResults: AnyObject[] | null = [];
 		for (const table of searchIn) {
-			const res: AnyObject = this[searchObjects[table]].get(target);
+			const res = this[searchObjects[table]].get(target);
 			if (res.exists && res.gen <= this.gen) {
 				searchResults.push({
 					isInexact,
@@ -400,14 +400,14 @@ export class ModdedDex {
 			maxLd = 2;
 		}
 		searchResults = null;
-		for (const table of [...searchIn, 'Aliases'] as DataType[]) {
-			const searchObj = this.data[table];
+		for (const table of [...searchIn, 'Aliases'] as const) {
+			const searchObj = this.data[table] as DexTable<any>;
 			if (!searchObj) continue;
 
 			for (const j in searchObj) {
 				const ld = Utils.levenshtein(cmpTarget, j, maxLd);
 				if (ld <= maxLd) {
-					const word = (searchObj[j] as DexTable<any>).name || (searchObj[j] as DexTable<any>).species || j;
+					const word = searchObj[j].name || j;
 					const results = this.dataSearch(word, searchIn, word);
 					if (results) {
 						searchResults = results;

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -75,10 +75,10 @@ export interface AliasesTable {[id: IDEntry]: string}
 interface DexTableData {
 	Abilities: DexTable<import('./dex-abilities').AbilityData>;
 	Aliases: DexTable<string>;
-	Rulesets: DexTable<FormatData>;
-	Items: DexTable<ItemData>;
+	Rulesets: DexTable<import('./dex-formats').FormatData>;
+	Items: DexTable<import('./dex-items').ItemData>;
 	Learnsets: DexTable<import('./dex-species').LearnsetData>;
-	Moves: DexTable<MoveData>;
+	Moves: DexTable<import('./dex-moves').MoveData>;
 	Natures: DexTable<import('./dex-data').NatureData>;
 	Pokedex: DexTable<import('./dex-species').SpeciesData>;
 	FormatsData: DexTable<import('./dex-species').SpeciesFormatsData>;

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -137,8 +137,6 @@ type ItemData = import('./dex-items').ItemData;
 type ModdedItemData = import('./dex-items').ModdedItemData;
 type Item = import('./dex-items').Item;
 
-type AbilityData = import('./dex-abilities').AbilityData;
-type ModdedAbilityData = import('./dex-abilities').ModdedAbilityData;
 type Ability = import('./dex-abilities').Ability;
 
 type SpeciesData = import('./dex-species').SpeciesData;

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -146,14 +146,6 @@ type FormatList = import('./dex-formats').FormatList;
 type ModdedFormatData = import('./dex-formats').ModdedFormatData;
 type Format = import('./dex-formats').Format;
 
-interface NatureData {
-	name: string;
-	plus?: StatIDExceptHP;
-	minus?: StatIDExceptHP;
-}
-
-type ModdedNatureData = NatureData | Partial<Omit<NatureData, 'name'>> & {inherit: true};
-
 type Nature = import('./dex-data').Nature;
 
 type GameType = 'singles' | 'doubles' | 'triples' | 'rotation' | 'multi' | 'freeforall';
@@ -378,15 +370,6 @@ interface ModdedBattleScriptsData extends Partial<BattleScriptsData> {
 	) => boolean;
 	checkWin?: (this: Battle, faintQueue?: Battle['faintQueue'][0]) => true | undefined;
 }
-
-interface TypeData {
-	damageTaken: {[attackingTypeNameOrEffectid: string]: number};
-	HPdvs?: SparseStatsTable;
-	HPivs?: SparseStatsTable;
-	isNonstandard?: Nonstandard | null;
-}
-
-type ModdedTypeData = TypeData | Partial<Omit<TypeData, 'name'>> & {inherit: true};
 
 type TypeInfo = import('./dex-data').TypeInfo;
 

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -127,14 +127,10 @@ type ConditionData = import('./dex-conditions').ConditionData;
 type ModdedConditionData = import('./dex-conditions').ModdedConditionData;
 type Condition = import('./dex-conditions').Condition;
 
-type MoveData = import('./dex-moves').MoveData;
-type ModdedMoveData = import('./dex-moves').ModdedMoveData;
 type ActiveMove = import('./dex-moves').ActiveMove;
 type Move = import('./dex-moves').Move;
 type MoveTarget = import('./dex-moves').MoveTarget;
 
-type ItemData = import('./dex-items').ItemData;
-type ModdedItemData = import('./dex-items').ModdedItemData;
 type Item = import('./dex-items').Item;
 
 type Ability = import('./dex-abilities').Ability;

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -38,35 +38,6 @@ type Nonstandard = 'Past' | 'Future' | 'Unobtainable' | 'CAP' | 'LGPE' | 'Custom
 
 type PokemonSet = import('./teams').PokemonSet;
 
-/**
- * Describes a possible way to get a move onto a pokemon.
- *
- * First character is a generation number, 1-9.
- * Second character is a source ID, one of:
- *
- * - M = TM/HM
- * - T = tutor
- * - L = start or level-up, 3rd char+ is the level
- * - R = restricted (special moves like Rotom moves)
- * - E = egg
- * - D = Dream World, only 5D is valid
- * - S = event, 3rd char+ is the index in .eventData
- * - V = Virtual Console or Let's Go transfer, only 7V/8V is valid
- * - C = NOT A REAL SOURCE, see note, only 3C/4C is valid
- *
- * C marks certain moves learned by a pokemon's prevo. It's used to
- * work around the chainbreeding checker's shortcuts for performance;
- * it lets the pokemon be a valid father for teaching the move, but
- * is otherwise ignored by the learnset checker (which will actually
- * check prevos for compatibility).
- */
-type MoveSource = string;
-// type MoveSource = `${
-// 	1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
-// }${
-// 	'M' | 'T' | 'L' | 'R' | 'E' | 'D' | 'S' | 'V' | 'C'
-// }${string}`;
-
 namespace TierTypes {
 	export type Singles = "AG" | "Uber" | "(Uber)" | "OU" | "(OU)" | "UUBL" | "UU" | "RUBL" | "RU" | "NUBL" | "NU" |
 	"(NU)" | "PUBL" | "PU" | "(PU)" | "ZUBL" | "ZU" | "NFE" | "LC";
@@ -196,18 +167,6 @@ type Nature = import('./dex-data').Nature;
 
 type GameType = 'singles' | 'doubles' | 'triples' | 'rotation' | 'multi' | 'freeforall';
 type SideID = 'p1' | 'p2' | 'p3' | 'p4';
-
-interface GameTimerSettings {
-	dcTimer: boolean;
-	dcTimerBank: boolean;
-	starting: number;
-	grace: number;
-	addPerTurn: number;
-	maxPerTurn: number;
-	maxFirstTurn: number;
-	timeoutAutoChoose: boolean;
-	accelerate: boolean;
-}
 
 type SpreadMoveTargets = (Pokemon | false | null)[];
 type SpreadMoveDamage = (number | boolean | undefined)[];

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -135,7 +135,6 @@ type Ability = import('./dex-abilities').Ability;
 
 type Species = import('./dex-species').Species;
 
-type FormatList = import('./dex-formats').FormatList;
 type Format = import('./dex-formats').Format;
 
 type Nature = import('./dex-data').Nature;

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -123,8 +123,6 @@ interface BasicEffect extends EffectData {
 	toString: () => string;
 }
 
-type ConditionData = import('./dex-conditions').ConditionData;
-type ModdedConditionData = import('./dex-conditions').ModdedConditionData;
 type Condition = import('./dex-conditions').Condition;
 
 type ActiveMove = import('./dex-moves').ActiveMove;

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -19,8 +19,10 @@ type TeamValidator = import('./team-validator').TeamValidator;
 type PokemonSources = import('./team-validator').PokemonSources;
 
 /** An ID must be lowercase alphanumeric. */
-type ID = '' | string & {__isID: true};
-type PokemonSlot = '' | string & {__isSlot: true};
+type ID = '' | Lowercase<string> & {__isID: true};
+/** Like ID, but doesn't require you to type `as ID`. For data files */
+type IDEntry = Lowercase<string>;
+type PokemonSlot = '' | IDEntry & {__isSlot: true};
 interface AnyObject {[k: string]: any}
 
 type GenderName = 'M' | 'F' | 'N' | '';
@@ -39,7 +41,7 @@ type PokemonSet = import('./teams').PokemonSet;
 /**
  * Describes a possible way to get a move onto a pokemon.
  *
- * First character is a generation number, 1-7.
+ * First character is a generation number, 1-9.
  * Second character is a source ID, one of:
  *
  * - M = TM/HM
@@ -59,6 +61,11 @@ type PokemonSet = import('./teams').PokemonSet;
  * check prevos for compatibility).
  */
 type MoveSource = string;
+// type MoveSource = `${
+// 	1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
+// }${
+// 	'M' | 'T' | 'L' | 'R' | 'E' | 'D' | 'S' | 'V' | 'C'
+// }${string}`;
 
 namespace TierTypes {
 	export type Singles = "AG" | "Uber" | "(Uber)" | "OU" | "(OU)" | "UUBL" | "UU" | "RUBL" | "RU" | "NUBL" | "NU" |
@@ -78,10 +85,10 @@ interface EventInfo {
 	perfectIVs?: number;
 	/** true: has hidden ability, false | undefined: never has hidden ability */
 	isHidden?: boolean;
-	abilities?: string[];
+	abilities?: IDEntry[];
 	maxEggMoves?: number;
-	moves?: string[];
-	pokeball?: string;
+	moves?: IDEntry[];
+	pokeball?: IDEntry;
 	from?: string;
 	/** Japan-only events can't be transferred to international games in Gen 1 */
 	japan?: boolean;

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -373,11 +373,11 @@ interface PlayerOptions {
 	seed?: PRNGSeed;
 }
 
-interface TextObject {
+interface BasicTextData {
 	desc?: string;
 	shortDesc?: string;
 }
-interface Plines {
+interface ConditionTextData extends BasicTextData {
 	activate?: string;
 	addItem?: string;
 	block?: string;
@@ -392,19 +392,7 @@ interface Plines {
 	transform?: string;
 }
 
-interface TextFile extends TextObject {
-	name: string;
-	gen1?: ModdedTextObject;
-	gen2?: ModdedTextObject;
-	gen3?: ModdedTextObject;
-	gen4?: ModdedTextObject;
-	gen5?: ModdedTextObject;
-	gen6?: ModdedTextObject;
-	gen7?: ModdedTextObject;
-	gen8?: ModdedTextObject;
-}
-
-interface MovePlines extends Plines {
+interface MoveTextData extends ConditionTextData {
 	alreadyStarted?: string;
 	blockSelf?: string;
 	clearBoost?: string;
@@ -424,24 +412,28 @@ interface MovePlines extends Plines {
 	upkeep?: string;
 }
 
-interface AbilityText extends TextFile, Plines {
-	activateFromItem?: string;
-	activateNoTarget?: string;
-	copyBoost?: string;
-	transformEnd?: string;
-}
+type TextFile<T> = T & {
+	name: string,
+	gen1?: T,
+	gen2?: T,
+	gen3?: T,
+	gen4?: T,
+	gen5?: T,
+	gen6?: T,
+	gen7?: T,
+	gen8?: T,
+};
 
-/* eslint-disable @typescript-eslint/no-empty-interface */
-interface MoveText extends TextFile, MovePlines {}
-
-interface ItemText extends TextFile, Plines {}
-
-interface PokedexText extends TextFile {}
-
-interface DefaultText extends AnyObject {}
-
-interface ModdedTextObject extends TextObject, Plines {}
-/* eslint-enable @typescript-eslint/no-empty-interface */
+type AbilityText = TextFile<ConditionTextData & {
+	activateFromItem?: string,
+	activateNoTarget?: string,
+	copyBoost?: string,
+	transformEnd?: string,
+}>;
+type MoveText = TextFile<MoveTextData>;
+type ItemText = TextFile<ConditionTextData>;
+type PokedexText = TextFile<BasicTextData>;
+type DefaultText = AnyObject;
 
 namespace RandomTeamsTypes {
 	export interface TeamDetails {

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -135,9 +135,7 @@ type Ability = import('./dex-abilities').Ability;
 
 type Species = import('./dex-species').Species;
 
-type FormatData = import('./dex-formats').FormatData;
 type FormatList = import('./dex-formats').FormatList;
-type ModdedFormatData = import('./dex-formats').ModdedFormatData;
 type Format = import('./dex-formats').Format;
 
 type Nature = import('./dex-data').Nature;

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -20,7 +20,7 @@ type PokemonSources = import('./team-validator').PokemonSources;
 
 /** An ID must be lowercase alphanumeric. */
 type ID = '' | Lowercase<string> & {__isID: true};
-/** Like ID, but doesn't require you to type `as ID`. For data files */
+/** Like ID, but doesn't require you to type `as ID` to define it. For data files and object keys. */
 type IDEntry = Lowercase<string>;
 type PokemonSlot = '' | IDEntry & {__isSlot: true};
 interface AnyObject {[k: string]: any}
@@ -139,14 +139,7 @@ type Item = import('./dex-items').Item;
 
 type Ability = import('./dex-abilities').Ability;
 
-type SpeciesData = import('./dex-species').SpeciesData;
-type ModdedSpeciesData = import('./dex-species').ModdedSpeciesData;
-type SpeciesFormatsData = import('./dex-species').SpeciesFormatsData;
-type ModdedSpeciesFormatsData = import('./dex-species').ModdedSpeciesFormatsData;
-type LearnsetData = import('./dex-species').LearnsetData;
-type ModdedLearnsetData = import('./dex-species').ModdedLearnsetData;
 type Species = import('./dex-species').Species;
-type PokemonGoData = import('./dex-species').PokemonGoData;
 
 type FormatData = import('./dex-formats').FormatData;
 type FormatList = import('./dex-formats').FormatList;

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -8,6 +8,7 @@
  */
 
 import {Dex, toID} from './dex';
+import type {MoveSource} from './dex-species';
 import {Utils} from '../lib';
 import {Tags} from '../data/tags';
 import {Teams} from './teams';
@@ -2536,7 +2537,7 @@ export class TeamValidator {
 						// falls through to LMT check below
 					} else if (level >= 5 && learnedGen === 3 && species.canHatch) {
 						// Pomeg Glitch
-						learned = learnedGen + 'Epomeg';
+						learned = learnedGen + 'Epomeg' as MoveSource;
 					} else if (species.gender !== 'N' &&
 						learnedGen >= 2 && species.canHatch && !setSources.isFromPokemonGo) {
 						// available as egg move
@@ -2545,7 +2546,7 @@ export class TeamValidator {
 							cantLearnReason = `is learned at level ${parseInt(learned.substr(2))}.`;
 							continue;
 						}
-						learned = learnedGen + 'Eany';
+						learned = learnedGen + 'Eany' as MoveSource;
 						// falls through to E check below
 					} else {
 						// this move is unavailable, skip it
@@ -2595,7 +2596,7 @@ export class TeamValidator {
 					} else if (learnedGen < 6 || (species.mother && !this.motherCanLearn(toID(species.mother), moveid))) {
 						limitedEggMove = move.id;
 					}
-					learned = learnedGen + 'E' + (species.prevo ? species.id : '');
+					learned = learnedGen + 'E' + (species.prevo ? species.id : '') as MoveSource;
 					if (tradebackEligible && learnedGen === 2 && move.gen <= 1) {
 						// can tradeback
 						moveSources.add('1ET' + learned.slice(2), limitedEggMove);

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -1746,7 +1746,7 @@ export class TeamValidator {
 
 		for (const ruleid of ruleTable.tagRules) {
 			if (ruleid.startsWith('*')) continue;
-			const tagid = ruleid.slice(12);
+			const tagid = ruleid.slice(12) as ID;
 			const tag = Tags[tagid];
 			if ((tag.speciesFilter || tag.genericFilter)!(tierSpecies)) {
 				const existenceTag = EXISTENCE_TAG.includes(tagid);

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -2065,7 +2065,7 @@ export class TeamValidator {
 			if (canBottleCap) {
 				// IVs can be overridden but Hidden Power type can't
 				if (Object.keys(eventData.ivs).length >= 6) {
-					const requiredHpType = dex.getHiddenPower(eventData.ivs).type;
+					const requiredHpType = dex.getHiddenPower(eventData.ivs as StatsTable).type;
 					if (set.hpType && set.hpType !== requiredHpType) {
 						if (fastReturn) return true;
 						problems.push(`${name} can only have Hidden Power ${requiredHpType}${etc}.`);


### PR DESCRIPTION
TypeScript 4.8+ supports Lowercase<string> for lowercase strings, which isn't exactly what ID is, but can be used to type IDs in object keys and data entries that previously required `string`. I'm calling it `IDEntry` in places where it _should_ be an ID but TypeScript doesn't support that.

Very conveniently, no additional casts will be needed when using `ID` where `IDEntry` is expected.

It's caught at least a few bugs, which is also why I'm PRing: I didn't write the code for the bugs it found, and don't know if it's the right way to fix them.

This ballooned into several other type refactors.