### PR TITLE
[Gen 5] BW1 OU: Update bans

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3171,8 +3171,8 @@ export const Formats: FormatList = [
 		],
 
 		mod: 'gen5bw1',
-		ruleset: ['Standard', 'Sleep Clause Mod', 'Swagger Clause'],
-		banlist: ['Uber', 'Drizzle ++ Swift Swim', 'King\'s Rock', 'Razor Fang', 'Soul Dew', 'Acupressure', 'Assist'],
+		ruleset: ['Standard', 'Sleep Clause Mod', 'Swagger Clause', 'Baton Pass Stat Clause'],
+		banlist: ['Uber', 'Drizzle ++ Swift Swim', 'Soul Dew', 'Acupressure', 'Assist'],
 	},
 	{
 		name: "[Gen 1] ZU",


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bw1-overused.3744853/

In the original version of the OP, Baton Pass was completely unrestricted. However, since then, Baton Pass Stat Clause has since been implemented, but was never done on my fork.

King's Rock and Razor Fang have never been banned in BW1 OU.