### PR TITLE
[Gen 5] BW1 OU: Unban Acupressure and Assist

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3172,7 +3172,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 
 		mod: 'gen5bw1',
 		ruleset: ['Standard', 'Sleep Clause Mod', 'Swagger Clause', 'Baton Pass Stat Clause'],
-		banlist: ['Uber', 'Drizzle ++ Swift Swim', 'Soul Dew', 'Acupressure', 'Assist'],
+		banlist: ['Uber', 'Drizzle ++ Swift Swim', 'Soul Dew'],
 	},
 	{
 		name: "[Gen 1] ZU",


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bw1-ou-open-signups.3745159/

Acupressure and Assist were never banned in BW1 OU.

<details>
  <summary>Relevant screenshots</summary>
  
  
![Screenshot_20240703_113301_Discord](https://github.com/smogon/pokemon-showdown/assets/30420527/82f27dcf-6606-45bc-9d28-aabb928b6ede)
![Screenshot_20240703_113314_Discord](https://github.com/smogon/pokemon-showdown/assets/30420527/4d375864-9a67-4798-bf08-14e83cefeee8)
![Screenshot_20240703_113325_Discord](https://github.com/smogon/pokemon-showdown/assets/30420527/1a11f99c-b1d6-41fe-ba4a-2128b60e2330)

  
</details>