### PR TITLE
[Gen 5] BW1 OU: Ban King's Rock

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3174,7 +3174,7 @@ export const Formats: import('../sim/dex-formats').FormatList = [
 
 		mod: 'gen5bw1',
 		ruleset: ['Standard', 'Sleep Clause Mod', 'Swagger Clause', 'Baton Pass Stat Clause'],
-		banlist: ['Uber', 'Drizzle ++ Swift Swim', 'Soul Dew'],
+		banlist: ['Uber', 'Drizzle ++ Swift Swim', 'King\'s Rock', 'Soul Dew'],
 	},
 	{
 		name: "[Gen 1] ZU",


### PR DESCRIPTION
https://www.smogon.com/forums/threads/bw1-overused.3744853/#post-10176942

(I don't know why the TL had me unban KR if they knew that this would happen, but oh well)
(Also BPSC was implemented in a prior PR)